### PR TITLE
Feature/elliott/reduce ranks

### DIFF
--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -1427,7 +1427,10 @@ void Group::load(const std::string& path,
     SLIC_ERROR("Invalid protocol " << protocol << " for file load.");
   }
 
-  renameOrWarn(new_name);
+  if (!new_name.empty())
+  {
+    renameOrWarn(new_name);
+  }
 }
 
 /*
@@ -1587,7 +1590,10 @@ void Group::load(const hid_t& h5_id,
     SLIC_ERROR("Invalid protocol " << protocol << " for file load.");
   }
 
-  renameOrWarn(new_name);
+  if (!new_name.empty())
+  {
+    renameOrWarn(new_name);
+  }
 }
 
 /*

--- a/src/axom/sidre/docs/sphinx/parallel_io_concepts.rst
+++ b/src/axom/sidre/docs/sphinx/parallel_io_concepts.rst
@@ -46,17 +46,29 @@ management (such as using burst buffers if available).
 
 In typical usage, a run that calls ``read()`` on a certain set of files
 should be executed on the same number of MPI ranks as the run that created
-those files with a ``write()`` call.  Still a ``read()`` call, if using
-the "sidre_hdf5" protocol, can work when called from a greater number of
-processors.  If ``write()`` was executed on N ranks and ``read()`` is called
-while running on M ranks (M > N), then data will be read into ranks 0 to N-1,
-and all ranks higher than N-1 will receive no data.
+those files with a ``write()`` call.  However, if using the "sidre_hdf5"
+protocol, there are some usage patterns that do not have this limitation.
+
+A ``read()`` call using "sidre_hdf5" will work when called from a greater
+number of processors.  If ``write()`` was executed on N ranks and ``read()``
+is called while running on M ranks (M > N), then data will be read into ranks
+0 to N-1, and all ranks higher than N-1 will receive no data.
+
+If ``read()`` is called using "sidre_hdf5" to read data that was created on
+a larger number of processors, this will work only in the case that the data
+was written in a file-per-processor mode (M ranks to M files).  In this case
+the data in the Group being filled with file input will look a bit different
+than in other usage patterns, since a Group on one rank will end up with data
+from multiple ranks.  An integer scalar View named ``reduced_input_ranks``
+will be added to the Group with the value being the number of ranks that
+wrote the files.  The data from each output rank will be read into subgroups
+located at ``rank_*******/sidre_input`` in the input Group's data hierarchy.
 
 .. warning::
-   If ``read()`` is called in an attempt to read data that was created on a
-   larger number of processors than the current run, an error will occur.
-   Support for this type of usage is intended to be added in future
-   releases.
+   If ``read()`` is called to read data that was created on a larger
+   number of processors than the current run with files produced in M-to-N
+   mode (M > N), an error will occur.  Support for this type of usage is
+   intended to be added in future releases.
 
 In the following example, an IOManager is created and used to write the contents
 of the Group "root" in parallel.

--- a/src/axom/sidre/docs/sphinx/parallel_io_concepts.rst
+++ b/src/axom/sidre/docs/sphinx/parallel_io_concepts.rst
@@ -62,7 +62,7 @@ than in other usage patterns, since a Group on one rank will end up with data
 from multiple ranks.  An integer scalar View named ``reduced_input_ranks``
 will be added to the Group with the value being the number of ranks that
 wrote the files.  The data from each output rank will be read into subgroups
-located at ``rank_*******/sidre_input`` in the input Group's data hierarchy.
+located at ``rank_{%07d}/sidre_input`` in the input Group's data hierarchy.
 
 .. warning::
    If ``read()`` is called to read data that was created on a larger

--- a/src/axom/sidre/spio/IOBaton.cpp
+++ b/src/axom/sidre/spio/IOBaton.cpp
@@ -38,47 +38,48 @@ IOBaton::IOBaton(MPI_Comm comm,
   MPI_Comm_rank(comm, &m_my_rank);
   m_num_files = num_files;
   m_num_groups = num_groups;
+
   int active_comm_size = m_comm_size;
   if (m_comm_size > m_num_groups)
   {
     active_comm_size = m_num_groups;
   }
-  m_num_larger_groups = active_comm_size % num_files;
+  m_num_larger_sets = active_comm_size % num_files;
   if (m_my_rank < active_comm_size)
   {
-    m_group_size = active_comm_size / m_num_files; // ?
+    m_set_size = active_comm_size / m_num_files;
   }
   else
   {
-    m_group_size = 1;
+    m_set_size = 1;
   }
-  m_first_regular_group_rank = (m_group_size + 1) * m_num_larger_groups;
-  if (m_my_rank < m_first_regular_group_rank)
+  m_first_regular_set_rank = (m_set_size + 1) * m_num_larger_sets;
+  if (m_my_rank < m_first_regular_set_rank)
   {
-    m_group_id = m_my_rank / (m_group_size + 1);
-    m_rank_within_group = m_my_rank % (m_group_size + 1);
-    if (m_rank_within_group < m_group_size)
+    m_set_id = m_my_rank / (m_set_size + 1);
+    m_rank_within_set = m_my_rank % (m_set_size + 1);
+    if (m_rank_within_set < m_set_size)
     {
       m_rank_after_me = m_my_rank + 1;
     }
   }
   else if (m_my_rank < active_comm_size)
   {
-    m_group_id = m_num_larger_groups +
-                 (m_my_rank - m_first_regular_group_rank) / m_group_size;
-    m_rank_within_group = (m_my_rank - m_first_regular_group_rank) %
-                          m_group_size;
-    if (m_rank_within_group < m_group_size - 1)
+    m_set_id = m_num_larger_sets +
+                 (m_my_rank - m_first_regular_set_rank) / m_set_size;
+    m_rank_within_set = (m_my_rank - m_first_regular_set_rank) %
+                          m_set_size;
+    if (m_rank_within_set < m_set_size - 1)
     {
       m_rank_after_me = m_my_rank + 1;
     }
   }
   else
   {
-    m_group_id = m_my_rank;
-    m_rank_within_group = 0;
+    m_set_id = m_my_rank;
+    m_rank_within_set = 0;
   }
-  if (m_rank_within_group > 0)
+  if (m_rank_within_set > 0)
   {
     m_rank_before_me = m_my_rank - 1;
   }
@@ -107,12 +108,12 @@ int IOBaton::wait()
                            m_mpi_tag, m_mpi_comm, &mpi_stat);
     if (mpi_err == MPI_SUCCESS)
     {
-      return_val = m_group_id;
+      return_val = m_set_id;
     }
   }
   else
   {
-    return_val = m_group_id;
+    return_val = m_set_id;
   }
   return return_val;
 }
@@ -132,8 +133,6 @@ int IOBaton::pass()
   }
   return return_val;
 }
-
-
 
 
 } /* end namespace sidre */

--- a/src/axom/sidre/spio/IOBaton.cpp
+++ b/src/axom/sidre/spio/IOBaton.cpp
@@ -66,9 +66,9 @@ IOBaton::IOBaton(MPI_Comm comm,
   else if (m_my_rank < active_comm_size)
   {
     m_set_id = m_num_larger_sets +
-                 (m_my_rank - m_first_regular_set_rank) / m_set_size;
+               (m_my_rank - m_first_regular_set_rank) / m_set_size;
     m_rank_within_set = (m_my_rank - m_first_regular_set_rank) %
-                          m_set_size;
+                        m_set_size;
     if (m_rank_within_set < m_set_size - 1)
     {
       m_rank_after_me = m_my_rank + 1;

--- a/src/axom/sidre/spio/IOBaton.hpp
+++ b/src/axom/sidre/spio/IOBaton.hpp
@@ -35,10 +35,10 @@ namespace sidre
  * \brief IOBaton ensures that during I/O operations, only one rank will
  * interact with a particular file at one time.
  *
- * Each rank is placed into a group of ranks, with the number of groups being
+ * Each rank is placed into a set of ranks, with the number of sets being
  * equal to the number of I/O files, and then the ranks use the wait and
  * pass methods to pass control of I/O operations from one rank to the next
- * within the group.
+ * within the set.
  */
 class IOBaton
 {
@@ -64,7 +64,7 @@ public:
   /*!
    * \brief Wait for previous rank to pass control to the local rank.
    *
-   * \return An integer id for the group of which this rank is a member.
+   * \return An integer id for the set of which this rank is a member.
    */
   int wait();
 
@@ -76,26 +76,26 @@ public:
   int pass();
 
   /*!
-   * \brief Size of local rank's group.
+   * \brief Size of local rank's set.
    *
-   * \return Number of ranks in the group.
+   * \return Number of ranks in the set.
    */
-  int groupSize() const
+  int setSize() const
   {
     return m_my_rank <
-           m_first_regular_group_rank ? m_group_size + 1 : m_group_size;
+           m_first_regular_set_rank ? m_set_size + 1 : m_set_size;
   }
 
   /*!
-   * \brief Tells if the local rank is the first (lowest) in its group.
+   * \brief Tells if the local rank is the first (lowest) in its set.
    */
   bool isFirstInGroup() const
   {
-    return (m_rank_within_group == 0);
+    return (m_rank_within_set == 0);
   }
 
   /*!
-   * \brief Tells if the local rank is the last (highest) in its group.
+   * \brief Tells if the local rank is the last (highest) in its set.
    */
   bool isLastInGroup() const
   {
@@ -114,6 +114,8 @@ private:
 
   DISABLE_COPY_AND_ASSIGNMENT( IOBaton );
 
+  void setupReducedRanks();
+
   static const int s_invalid_rank_id;
 
   MPI_Comm m_mpi_comm;
@@ -121,13 +123,13 @@ private:
   int m_comm_size;  // num procs in the MPI communicator
   int m_my_rank;    // rank of this proc
   int m_num_files; // number of files
-  int m_num_groups; // number of groups (ranks)
-  int m_num_larger_groups;  // some group have one extra
-  int m_group_size; // regular group size (m_comm_size / m_num_files) w/o
+  int m_num_groups; // number of groups (input ranks)
+  int m_num_larger_sets;  // some sets have one extra
+  int m_set_size; // regular set size (m_comm_size / m_num_files) w/o
                     // remainder
-  int m_group_id;
-  int m_first_regular_group_rank;
-  int m_rank_within_group;
+  int m_set_id;
+  int m_first_regular_set_rank;
+  int m_rank_within_set;
   int m_rank_before_me;
   int m_rank_after_me;
 

--- a/src/axom/sidre/spio/IOBaton.hpp
+++ b/src/axom/sidre/spio/IOBaton.hpp
@@ -126,7 +126,7 @@ private:
   int m_num_groups; // number of groups (input ranks)
   int m_num_larger_sets;  // some sets have one extra
   int m_set_size; // regular set size (m_comm_size / m_num_files) w/o
-                    // remainder
+                  // remainder
   int m_set_id;
   int m_first_regular_set_rank;
   int m_rank_within_set;

--- a/src/axom/sidre/spio/IOManager.cpp
+++ b/src/axom/sidre/spio/IOManager.cpp
@@ -744,8 +744,10 @@ void IOManager::readSidreHDF5(sidre::Group* datagroup,
   int num_files = getNumFilesFromRoot(root_file);
   int num_groups = getNumGroupsFromRoot(root_file);
   SLIC_ASSERT(num_files > 0);
-//  SLIC_ERROR_IF(num_groups > m_comm_size,
-//                "IOManager cannot read from files written by more ranks than are being used in the current run.");
+  SLIC_ERROR_IF(num_groups > m_comm_size && num_groups != num_files,
+        "IOManager attempted to read using a smaller number of processors "
+     << "than were used to produce the I/O files.  This only can work if "
+     << "those files were created in file-per-processor mode.");
 
   if (m_baton)
   {

--- a/src/axom/sidre/spio/IOManager.cpp
+++ b/src/axom/sidre/spio/IOManager.cpp
@@ -434,7 +434,8 @@ void IOManager::loadExternalData(sidre::Group* datagroup,
 
   int set_id = m_baton->wait();
 
-  if (num_groups <= m_comm_size) {
+  if (num_groups <= m_comm_size)
+  {
     if (m_my_rank < num_groups)
     {
       herr_t errv;
@@ -461,7 +462,9 @@ void IOManager::loadExternalData(sidre::Group* datagroup,
   }
   else
   {
-    for (int input_rank = m_my_rank; input_rank < num_groups; input_rank += m_comm_size) {
+    for (int input_rank = m_my_rank ; input_rank < num_groups ;
+         input_rank += m_comm_size)
+    {
 
       herr_t errv;
       AXOM_DEBUG_VAR(errv);
@@ -476,8 +479,9 @@ void IOManager::loadExternalData(sidre::Group* datagroup,
       hid_t h5_group_id = H5Gopen(h5_file_id, group_name.c_str(), 0);
       SLIC_ASSERT(h5_group_id >= 0);
 
-      std::string input_name = fmt::sprintf("rank_%07d/sidre_input", input_rank);
-      Group * one_rank_input = datagroup->getGroup(input_name);
+      std::string input_name =
+        fmt::sprintf("rank_%07d/sidre_input", input_rank);
+      Group* one_rank_input = datagroup->getGroup(input_name);
 
       one_rank_input->loadExternalData(h5_group_id);
 
@@ -493,7 +497,7 @@ void IOManager::loadExternalData(sidre::Group* datagroup,
 #else
   AXOM_DEBUG_VAR(datagroup);
   SLIC_WARNING("Loading external data only only available "
-                   << "when Axom is configured with hdf5");
+               << "when Axom is configured with hdf5");
 #endif /* AXOM_USE_HDF5 */
 
   (void)m_baton->pass();
@@ -745,9 +749,9 @@ void IOManager::readSidreHDF5(sidre::Group* datagroup,
   int num_groups = getNumGroupsFromRoot(root_file);
   SLIC_ASSERT(num_files > 0);
   SLIC_ERROR_IF(num_groups > m_comm_size && num_groups != num_files,
-        "IOManager attempted to read using a smaller number of processors "
-     << "than were used to produce the I/O files.  This only can work if "
-     << "those files were created in file-per-processor mode.");
+                "IOManager attempted to read using a smaller number of processors "
+                << "than were used to produce the I/O files.  This only can work if "
+                << "those files were created in file-per-processor mode.");
 
   if (m_baton)
   {
@@ -766,7 +770,8 @@ void IOManager::readSidreHDF5(sidre::Group* datagroup,
   std::string file_pattern = getHDF5FilePattern(root_file);
 
   int set_id = m_baton->wait();
-  if (num_groups <= m_comm_size) {
+  if (num_groups <= m_comm_size)
+  {
     if (m_my_rank < num_groups)
     {
 
@@ -791,11 +796,16 @@ void IOManager::readSidreHDF5(sidre::Group* datagroup,
       errv = H5Fclose(h5_file_id);
       SLIC_ASSERT(errv >= 0);
     }
-  } else {
+  }
+  else
+  {
 
-    View * reduced = datagroup->createViewScalar("reduced_input_ranks", num_groups);
+    View* reduced = datagroup->createViewScalar("reduced_input_ranks",
+                                                num_groups);
 
-    for (int input_rank = m_my_rank; input_rank < num_groups; input_rank += m_comm_size) {
+    for (int input_rank = m_my_rank ; input_rank < num_groups ;
+         input_rank += m_comm_size)
+    {
 
       herr_t errv;
       AXOM_DEBUG_VAR(errv);
@@ -810,8 +820,9 @@ void IOManager::readSidreHDF5(sidre::Group* datagroup,
       hid_t h5_group_id = H5Gopen(h5_file_id, group_name.c_str(), 0);
       SLIC_ASSERT(h5_group_id >= 0);
 
-      std::string input_name = fmt::sprintf("rank_%07d/sidre_input", input_rank);
-      Group * one_rank_input = datagroup->createGroup(input_name);
+      std::string input_name =
+        fmt::sprintf("rank_%07d/sidre_input", input_rank);
+      Group* one_rank_input = datagroup->createGroup(input_name);
 
       one_rank_input->load(h5_group_id, "sidre_hdf5", preserve_contents);
 

--- a/src/axom/sidre/tests/spio/spio_basic.cpp
+++ b/src/axom/sidre/tests/spio/spio_basic.cpp
@@ -92,7 +92,7 @@ void checkBaton(int numFiles, int numRanks, int myRank)
 
   // Num files and groups
   EXPECT_EQ(numFiles, baton.getNumFiles());
-  EXPECT_EQ(myGroup.m_size, baton.groupSize());
+  EXPECT_EQ(myGroup.m_size, baton.setSize());
 
   // First and last index in the group
   const bool expFirst = (myRank == myGroup.m_firstIdx);

--- a/src/axom/sidre/tests/spio/spio_parallel.cpp
+++ b/src/axom/sidre/tests/spio/spio_parallel.cpp
@@ -806,6 +806,8 @@ TEST(spio_parallel, parallel_increase_procs)
   delete ds2;
   delete ds;
 
+  MPI_Comm_free(&split_comm);
+
 #endif
 
 }
@@ -944,6 +946,8 @@ TEST(spio_parallel, parallel_decrease_procs)
 
   delete ds2;
   delete ds;
+
+  MPI_Comm_free(&split_comm);
 
 #endif
 

--- a/src/axom/sidre/tests/spio/spio_parallel.cpp
+++ b/src/axom/sidre/tests/spio/spio_parallel.cpp
@@ -893,32 +893,35 @@ TEST(spio_parallel, parallel_decrease_procs)
     int num_output_ranks = 1;
     if (num_ranks > 1)
     {
-       EXPECT_TRUE(ds2_root->hasView("reduced_input_ranks"));
+      EXPECT_TRUE(ds2_root->hasView("reduced_input_ranks"));
     }
 
     if (ds2->getRoot()->hasView("reduced_input_ranks"))
     {
-       num_output_ranks = ds2_root->getView("reduced_input_ranks")->getData();
+      num_output_ranks = ds2_root->getView("reduced_input_ranks")->getData();
     }
 
-    for (int output_rank = my_rank; output_rank < num_output_ranks;
+    for (int output_rank = my_rank ; output_rank < num_output_ranks ;
          output_rank += (top_input_rank+1))
     {
       /*
        * Verify that the contents of ds2 on rank 0 match those written from ds.
        */
-      std::string output_name = fmt::sprintf("rank_%07d/sidre_input", output_rank);
+      std::string output_name = fmt::sprintf("rank_%07d/sidre_input",
+                                             output_rank);
 
       int testvalue = 101*output_rank;
       int testvalue2 =
-        ds2_root->getGroup(output_name)->getGroup("fields")->getGroup("a")->getView("i0")->getData();
+        ds2_root->getGroup(output_name)->getGroup("fields")->getGroup("a")->
+        getView("i0")->getData();
 
       EXPECT_EQ(testvalue, testvalue2);
 
       View* view_i1_orig =
         ds->getRoot()->getGroup("fields2")->getGroup("b")->getView("i1");
       View* view_i1_restored =
-        ds2_root->getGroup(output_name)->getGroup("fields2")->getGroup("b")->getView("i1");
+        ds2_root->getGroup(output_name)->getGroup("fields2")->getGroup("b")->
+        getView("i1");
 
       int num_elems = view_i1_orig->getNumElements();
       EXPECT_EQ(view_i1_restored->getNumElements(), num_elems);


### PR DESCRIPTION
This enables SPIO reads when running on a smaller number of processors.  It has a restriction that the original files must have been produced in a file-per-processor mode.  Removing this restriction will require some further development.