### PR TITLE
remove bad fmt include

### DIFF
--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -48,7 +48,7 @@ set(FMT_HEADER_ONLY TRUE PARENT_SCOPE)
 
 install(TARGETS              fmt
         EXPORT               fmt-targets
-        INCLUDES DESTINATION include/fmt)
+        INCLUDES DESTINATION include)
 install(DIRECTORY   ${PROJECT_SOURCE_DIR}/thirdparty/fmt
         DESTINATION include
         )


### PR DESCRIPTION
Having include/fmt on your path caused problems with finding fmt's time.h before the system's <ctime> header.  This is bad so I fixed it.