### PR TITLE
Adds openmp variant to Axom's local umpire spack package

### DIFF
--- a/scripts/uberenv/packages/uberenv-axom/package.py
+++ b/scripts/uberenv/packages/uberenv-axom/package.py
@@ -81,8 +81,10 @@ class UberenvAxom(Package):
     depends_on("raja~openmp+cuda", when="+raja~openmp+cuda")
     depends_on("raja+openmp+cuda", when="+raja+openmp+cuda")
 
-    depends_on("umpire", when="+umpire")
-    depends_on("umpire+cuda", when="+umpire+cuda")
+    depends_on("umpire~openmp", when="+umpire~openmp")
+    depends_on("umpire+openmp", when="+umpire+openmp")
+    depends_on("umpire~openmp+cuda", when="+umpire~openmp+cuda")
+    depends_on("umpire+openmp+cuda", when="+umpire+openmp+cuda")
 
     # builds serial version of mfem that does not depend on Sidre
     depends_on("mfem~hypre~metis~mpi~gzstream",   when="+mfem")

--- a/scripts/uberenv/packages/umpire/package.py
+++ b/scripts/uberenv/packages/umpire/package.py
@@ -18,6 +18,7 @@ class Umpire(CMakePackage):
 
     variant('cuda', default=False, description='Build with CUDA support')
     variant('fortran', default=False, description='Build C/Fortran API')
+    variant('openmp', default=True, description='Build with OpenMP support')
 
     depends_on('cuda', when='+cuda')
     depends_on('cmake@3.3:', type='build')
@@ -43,5 +44,10 @@ class Umpire(CMakePackage):
 
         if '+fortran' in spec:
             options.append('-DENABLE_FORTRAN=On')
+
+        if '+openmp' in spec:
+            options.append('-DENABLE_OPENMP=On')
+        else:
+            options.append('-DENABLE_OPENMP=Off')
 
         return options


### PR DESCRIPTION
Looks like I merged my previous macos uberenv PR (#48) too soon...

This PR allows disabling openmp in our local umpire spack package for compilers that do not support it (e.g. the built-in clang on macos).  Umpire enables openmp by default, so we need to be able to explicitly disable it.

After this PR, I was able to configure uberenv with the default compiler using the following spec
```bash
--spec=%clang~openmp^conduit@master
```

Notes:
* I had to use a newer version of conduit due to an incompatibility between 32-bit and 64-bit int types with the current Axom and conduit version 0.3.1 on mac (#50)
* My laptop's Fortran compiler is currently not working, so my test build set the Fortran compiler to `None` and my spec also disabled mpi, e.g. ``--spec=%clang~openmp~mpi^conduit@master``