### PR TITLE
bugfix/zagaris2/fix-bqq-build

### DIFF
--- a/src/axom/spin/CMakeLists.txt
+++ b/src/axom/spin/CMakeLists.txt
@@ -39,6 +39,7 @@ if ( RAJA_FOUND AND UMPIRE_FOUND )
   set( spin_headers
        ${spin_headers}
        BVH.hpp
+       execution_space.hpp
 
        ## internal
        internal/linear_bvh/aabb.hpp

--- a/src/axom/spin/CMakeLists.txt
+++ b/src/axom/spin/CMakeLists.txt
@@ -34,7 +34,7 @@ set( spin_sources
 ################################################################
 # Specify Spin headers/sources that depend on RAJA and Umpire
 ################################################################
-if ( ${RAJA_FOUND} AND ${UMPIRE_FOUND} )
+if ( RAJA_FOUND AND UMPIRE_FOUND )
 
   set( spin_headers
        ${spin_headers}

--- a/src/axom/spin/tests/CMakeLists.txt
+++ b/src/axom/spin/tests/CMakeLists.txt
@@ -47,7 +47,7 @@ foreach ( test ${spin_tests} )
 
 endforeach()
 
-if ( ${RAJA_FOUND} AND ${UMPIRE_FOUND} )
+if ( RAJA_FOUND AND UMPIRE_FOUND )
 
   blt_add_executable(
       NAME       spin_execution_space_test


### PR DESCRIPTION
The BG/Q build was failing when CMake was trying to configure
due to using undefined variables in conditional logic.

Specifically, checks of the form:
```
if ( ${RAJA_FOUND} AND ${UMPIRE_FOUND} )
    ...
endif()
```

Would cause CMake to fail when ${RAJA_FOUND} and/or ${UMPIRE_FOUND}
were not defined. These variables are set when calling
```
find_package_handle_standard_args()
```

However, when RAJA_DIR or UMPIRE_DIR are not specified, the code
will not set those variables. Consequently, downstream CMake code that
relies on checking for those variables would fail to configure.

This commit fixes the issue encountered on BG/Q where we don't
specify `UMPIRE_DIR`.