### PR TITLE
Improve BVH robustness

### DIFF
--- a/src/axom/spin/BVH.hpp
+++ b/src/axom/spin/BVH.hpp
@@ -198,6 +198,15 @@ public:
   ~BVH();
 
   /*!
+   * \brief Sets the scale factor for scaling the supplied bounding boxes.
+   * \param [in] scale_factor the scale factor
+   *
+   * \note The default scale factor is set to 1.001
+   */
+  void setScaleFactor( FloatType scale_factor )
+  { m_scaleFactor = scale_factor; };
+
+  /*!
    * \brief Generates the BVH
    * \return status set to BVH_BUILD_OK on success.
    */
@@ -267,6 +276,7 @@ private:
 /// \name Private Members
 /// @{
 
+  FloatType m_scaleFactor;
   IndexType m_numItems;
   const FloatType* m_boxes;
   internal::linear_bvh::BVHData< FloatType,NDIMS > m_bvh;
@@ -365,6 +375,7 @@ bool InRight( const internal::linear_bvh::Vec< FloatType, 2>& point,
 template< int NDIMS, typename ExecSpace, typename FloatType >
 BVH< NDIMS, ExecSpace, FloatType >::BVH( const FloatType* boxes,
                                          IndexType numItems ) :
+  m_scaleFactor( 1.001 ),
   m_numItems( numItems ),
   m_boxes( boxes )
 {
@@ -418,7 +429,7 @@ int BVH< NDIMS, ExecSpace, FloatType >::build()
   internal::linear_bvh::RadixTree< FloatType, NDIMS > radix_tree;
   internal::linear_bvh::AABB< FloatType, NDIMS > global_bounds;
   internal::linear_bvh::build_radix_tree< ExecSpace >(
-      boxesptr, numBoxes, global_bounds, radix_tree );
+      boxesptr, numBoxes, global_bounds, radix_tree, m_scaleFactor );
 
   // STEP 3: emit the BVH data-structure from the radix tree
   m_bvh.m_bounds = global_bounds;

--- a/src/axom/spin/BVH.hpp
+++ b/src/axom/spin/BVH.hpp
@@ -281,6 +281,7 @@ private:
   const FloatType* m_boxes;
   internal::linear_bvh::BVHData< FloatType,NDIMS > m_bvh;
 
+  static constexpr FloatType DEFAULT_SCALE_FACTOR = 1.001;
 /// @}
 
   DISABLE_COPY_AND_ASSIGNMENT(BVH);
@@ -375,7 +376,7 @@ bool InRight( const internal::linear_bvh::Vec< FloatType, 2>& point,
 template< int NDIMS, typename ExecSpace, typename FloatType >
 BVH< NDIMS, ExecSpace, FloatType >::BVH( const FloatType* boxes,
                                          IndexType numItems ) :
-  m_scaleFactor( 1.001 ),
+  m_scaleFactor( DEFAULT_SCALE_FACTOR ),
   m_numItems( numItems ),
   m_boxes( boxes )
 {

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -103,7 +103,8 @@ axom::int64 morton64_encode( axom::float32 x,
 template < typename ExecSpace, typename FloatType >
 void transform_boxes( const FloatType *boxes,
                       AABB<FloatType,3> *aabbs,
-                      int32 size)
+                      int32 size,
+                      FloatType scale_factor )
 {
   constexpr int NDIMS  = 3;
   constexpr int STRIDE = 2 * NDIMS;
@@ -126,6 +127,8 @@ void transform_boxes( const FloatType *boxes,
 
     aabb.include(min_point);
     aabb.include(max_point);
+    aabb.scale( scale_factor );
+
     aabbs[i] = aabb;
   } );
 
@@ -135,7 +138,8 @@ void transform_boxes( const FloatType *boxes,
 template < typename ExecSpace, typename FloatType >
 void transform_boxes( const FloatType *boxes,
                       AABB<FloatType,2> *aabbs,
-                      int32 size)
+                      int32 size,
+                      FloatType scale_factor )
 {
   constexpr int NDIMS  = 2;
   constexpr int STRIDE = 2 * NDIMS;
@@ -156,6 +160,8 @@ void transform_boxes( const FloatType *boxes,
 
     aabb.include(min_point);
     aabb.include(max_point);
+    aabb.scale( scale_factor );
+
     aabbs[ i ] = aabb;
   } );
 
@@ -653,7 +659,8 @@ template < typename ExecSpace, typename FloatType, int NDIMS >
 void build_radix_tree( const FloatType* boxes,
                        int size,
                        AABB< FloatType, NDIMS >& bounds,
-                       RadixTree< FloatType, NDIMS >& radix_tree )
+                       RadixTree< FloatType, NDIMS >& radix_tree,
+                       FloatType scale_factor )
 {
   // sanity checks
   SLIC_ASSERT( boxes !=nullptr );
@@ -662,7 +669,8 @@ void build_radix_tree( const FloatType* boxes,
   radix_tree.allocate( size );
 
   // copy so we don't reorder the input
-  transform_boxes< ExecSpace >(boxes, radix_tree.m_leaf_aabbs, size);
+  transform_boxes< ExecSpace >( boxes, radix_tree.m_leaf_aabbs,
+                                size, scale_factor );
 
   // evaluate global bounds
   bounds = reduce< ExecSpace >(radix_tree.m_leaf_aabbs, size);

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -374,12 +374,12 @@ void custom_sort( ExecSpace, uint32*& mcodes, int32 size, int32* iter )
 {
   array_counting< ExecSpace >(iter, size, 0, 1);
 
-  std::sort(iter,
-            iter + size,
-            [=](int32 i1, int32 i2)
-            {
-              return mcodes[i1] < mcodes[i2];
-            } );
+  std::stable_sort( iter,
+                    iter + size,
+                    [=](int32 i1, int32 i2)
+                    {
+                    return mcodes[i1] < mcodes[i2];
+                    } );
 
 
   reorder< ExecSpace >(iter, mcodes, size);


### PR DESCRIPTION
# Summary

This PR improves the robustness of the BVH by:
* Using `std::stable_sort` on the CPU for sorting the BVH bins in a deterministic way
* Scaling the supplied bounding boxes by a scaling factor. The scaling factor can be set by the caller. If a scaling factor is not set, the default is set to `1.001`.


