### PR TITLE
SU2 I/O support in Mint

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ## [Unreleased] - Release date yyyy-mm-dd
 
 ### Added
+- Added support in Mint for reading and writing an unstructured mesh in the [SU2 Mesh file format].
+  This includes support for both single and mixed cell type topology unstructured mesh types.   
 
 ### Removed
 
@@ -248,3 +250,5 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 [Version 0.2.9]: https://github.com/LLNL/axom/compare/v0.2.8...v0.2.9
 
 [Scalable Checkpoint Restart (SCR)]: https://computation.llnl.gov/projects/scalable-checkpoint-restart-for-mpi
+[SU2 Mesh file format]: https://su2code.github.io/docs/Mesh-File/
+

--- a/src/axom/mint/CMakeLists.txt
+++ b/src/axom/mint/CMakeLists.txt
@@ -79,6 +79,7 @@ set( mint_headers
 
     ## utils
     utils/vtk_utils.hpp
+    utils/su2_utils.hpp
    )
 
 set( mint_sources
@@ -102,6 +103,7 @@ set( mint_sources
 
     ## utils
     utils/vtk_utils.cpp
+    utils/su2_utils.cpp
    )
 
 ################################

--- a/src/axom/mint/examples/CMakeLists.txt
+++ b/src/axom/mint/examples/CMakeLists.txt
@@ -9,9 +9,10 @@ set( mint_examples
      mint_nbody_solver.cpp
      mint_particle_mesh.cpp
      mint_rectilinear_mesh.cpp
+     mint_su2_mesh.cpp
      mint_unstructured_mixed_topology_mesh.cpp
      mint_unstructured_single_topology_mesh.cpp
-     
+
      user_guide/mint_tutorial.cpp
      user_guide/mint_getting_started.cpp
    )
@@ -22,10 +23,17 @@ set( mint_example_dependencies
      slic
    )
 
-blt_list_append( TO mint_example_dependencies ELEMENTS sidre conduit IF AXOM_MINT_USE_SIDRE )
-blt_list_append( TO mint_example_dependencies ELEMENTS raja IF RAJA_FOUND )
-blt_list_append( TO mint_example_dependencies ELEMENTS openmp IF ENABLE_OPENMP )
-blt_list_append( TO mint_example_dependencies ELEMENTS cuda IF ENABLE_CUDA )
+blt_list_append( TO mint_example_dependencies ELEMENTS sidre conduit
+                 IF ${AXOM_MINT_USE_SIDRE} )
+
+blt_list_append( TO mint_example_dependencies ELEMENTS raja
+                 IF ${RAJA_FOUND} )
+
+blt_list_append( TO mint_example_dependencies ELEMENTS openmp
+                 IF ${ENABLE_OPENMP} )
+
+blt_list_append( TO mint_example_dependencies ELEMENTS cuda
+                 IF ${ENABLE_CUDA} )
 
 foreach( example ${mint_examples} )
 

--- a/src/axom/mint/examples/mint_su2_mesh.cpp
+++ b/src/axom/mint/examples/mint_su2_mesh.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+// Mint includes
+#include "axom/mint/mesh/Mesh.hpp"                   /* for mesh base class  */
+#include "axom/mint/utils/su2_utils.hpp"             /* for su2 i/o routines */
+#include "axom/mint/utils/vtk_utils.hpp"             /* for vtk i/o routines */
+
+// Slic includes
+#include "axom/slic/interface/slic.hpp"              /* for slic macros     */
+#include "axom/slic/streams/GenericOutputStream.hpp" /* logging to terminal */
+
+// C/C++ includes
+#include <string>   /* for C++ string */
+#include <cstring>  /* for strcmp() */
+
+/*!
+ * \file
+ *
+ * \brief A simple example that illustrates how to read in an su2 mesh.
+ */
+
+//------------------------------------------------------------------------------
+// GLOBALS
+//------------------------------------------------------------------------------
+static struct
+{
+  bool dumpVtk;
+  std::string file;
+} Parameters;
+
+namespace slic = axom::slic;
+namespace mint = axom::mint;
+
+//------------------------------------------------------------------------------
+// FUNCTION PROTOTYPES
+//------------------------------------------------------------------------------
+void parse_args( int argc, char** argv );
+
+int main ( int argc, char** argv )
+{
+  // STEP 0: initialize the slic logging environment
+  slic::initialize();
+  slic::setLoggingMsgLevel( slic::message::Debug );
+  slic::addStreamToAllMsgLevels(
+      new slic::GenericOutputStream( &std::cout, "[<LEVEL>]: <MESSAGE>\n" ) );
+
+  // STEP 1: parse command line arguemnts
+  parse_args( argc, argv );
+
+  // STEP 2: read SU2 mesh
+  SLIC_INFO( "reading file [" << Parameters.file << "]\n" );
+
+  mint::Mesh* mesh = nullptr;
+  int rc = mint::read_su2( Parameters.file, mesh );
+  SLIC_ERROR_IF( (rc != 0), "Failed to read SU2 file!" );
+  SLIC_ASSERT( mesh != nullptr );
+
+  // STEP 3: print some mesh information
+  SLIC_INFO( "MESH DIMENSION:  " << mesh->getDimension() );
+  SLIC_INFO( "NUMBER OF NODES: " << mesh->getNumberOfNodes() );
+  SLIC_INFO( "NUMBER OF CELLS: " << mesh->getNumberOfCells() );
+  if ( mesh->hasMixedCellTypes() )
+  {
+    SLIC_INFO( "MIXED_CELL_TOPOLOGY" );
+  }
+  else
+  {
+    SLIC_INFO( "SINGLE_CELL_TOPOLOGY" );
+  }
+
+  // STEP 4: dump a corresponding VTK file
+  if ( Parameters.dumpVtk )
+  {
+    std::string vtkFile = Parameters.file + ".vtk";
+    SLIC_INFO( "generating vtk file [" << vtkFile << "]" );
+
+    mint::write_vtk( mesh, vtkFile );
+  }
+
+  // STEP 4: finalize
+  delete mesh;
+  slic::flushStreams();
+  slic::finalize();
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+// FUNCTION PROTOTYPE IMPLEMENTATION
+//------------------------------------------------------------------------------
+void parse_args( int argc, char** argv )
+{
+  Parameters.file    = "";
+  Parameters.dumpVtk = false;
+
+  for ( int i=1; i < argc; ++i )
+  {
+    if ( strcmp( argv[i], "--file" )==0 )
+    {
+      Parameters.file = std::string( argv[ ++i ] );
+    }
+    else if ( strcmp(argv[i], "--vtk" )==0 )
+    {
+      Parameters.dumpVtk = true;
+    }
+
+  }
+
+  SLIC_ERROR_IF( Parameters.file.length() == 0,
+                 "must specify a valid SU2 file." );
+
+}
+
+

--- a/src/axom/mint/tests/CMakeLists.txt
+++ b/src/axom/mint/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set( mint_tests
      mint_fem_single_fe.cpp
 
      ## util tests
+     mint_su2_io.cpp
      mint_util_write_vtk.cpp
    )
 

--- a/src/axom/mint/tests/mint_su2_io.cpp
+++ b/src/axom/mint/tests/mint_su2_io.cpp
@@ -1,0 +1,239 @@
+// Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+// Mint includes
+#include "axom/mint/mesh/UniformMesh.hpp"         /* for UniformMesh */
+#include "axom/mint/mesh/UnstructuredMesh.hpp"    /* for UnstructuredMesh */
+#include "axom/mint/utils/su2_utils.hpp"          /* for su2 i/o */
+
+// Slic includes
+#include "axom/slic/interface/slic.hpp"           /* for slic macros */
+#include "axom/slic/core/UnitTestLogger.hpp"      /* for UnitTestLogger */
+
+// gtest includes
+#include "gtest/gtest.h"                          /* for gtest macros */
+
+// C/C++ includes
+#include <cstdio>    /* for std::remove() */
+
+namespace mint = axom::mint;
+
+//------------------------------------------------------------------------------
+// HELPER FUNCTIONS
+//------------------------------------------------------------------------------
+namespace
+{
+
+void check_cell_connectivity( mint::Mesh* m1, mint::Mesh* m2 )
+{
+  EXPECT_TRUE( m1 != nullptr );
+  EXPECT_TRUE( m2 != nullptr );
+
+  const axom::IndexType ncells = m1->getNumberOfCells();
+  EXPECT_EQ( ncells, m2->getNumberOfCells() );
+
+  axom::IndexType c1[ mint::MAX_CELL_NODES ];
+  axom::IndexType c2[ mint::MAX_CELL_NODES ];
+
+  for ( axom::IndexType icell=0; icell < ncells; ++icell )
+  {
+    EXPECT_TRUE( m1->getCellType( icell ) == m2->getCellType( icell ) );
+
+    axom::IndexType nnodes = m1->getNumberOfCellNodes( icell );
+    EXPECT_EQ( nnodes, m2->getNumberOfCellNodes( icell ) );
+
+    m1->getCellNodeIDs( icell, c1 );
+    m2->getCellNodeIDs( icell, c2 );
+
+    for ( axom::IndexType inode=0; inode < nnodes; ++inode )
+    {
+      EXPECT_EQ( c1[ inode ], c2[ inode ] );
+    } // END for all cell nodes
+
+  } // END for all cells
+
+}
+
+//------------------------------------------------------------------------------
+void check_nodes( mint::Mesh* m1, mint::Mesh* m2 )
+{
+  EXPECT_TRUE( m1 != nullptr );
+  EXPECT_TRUE( m2 != nullptr );
+
+  constexpr int NDIMS = 2;
+  EXPECT_EQ( m1->getDimension(), NDIMS );
+  EXPECT_EQ( m2->getDimension(), NDIMS );
+
+  const axom::IndexType nnodes = m1->getNumberOfNodes();
+  EXPECT_EQ( nnodes, m2->getNumberOfNodes() );
+
+  double n1[ NDIMS ];
+  double n2[ NDIMS ];
+
+  for ( axom::IndexType inode=0; inode < nnodes; ++inode )
+  {
+    m1->getNode( inode, n1 );
+    m2->getNode( inode, n2 );
+
+    for ( int idim=0; idim < NDIMS; ++idim )
+    {
+      EXPECT_DOUBLE_EQ( n1[ idim ], n2[ idim ] );
+    } // END for each dimension
+
+  } // END for all nodes
+
+}
+
+} /* end anonymous namespace */
+
+//------------------------------------------------------------------------------
+// UNIT TESTS
+//------------------------------------------------------------------------------
+TEST( mint_su2_io, invalid_write_with_structured_mesh )
+{
+  const double lo[] = { 0.0, 0.0, 0.0 };
+  const double hi[] = { 2.0, 2.0, 2.0 };
+  constexpr axom::IndexType N = 5;
+
+  mint::UniformMesh mesh( lo, hi, N, N, N );
+  int rc = mint::write_su2( &mesh, "test.su2" );
+  EXPECT_TRUE( rc != 0 );
+}
+
+//------------------------------------------------------------------------------
+TEST( mint_su2_io, read_invalid_file )
+{
+  mint::Mesh* mesh = nullptr;
+  int rc = mint::read_su2( "some/invalid/file.su2", mesh );
+  EXPECT_TRUE( rc != 0 );
+  EXPECT_TRUE( mesh == nullptr );
+}
+
+//------------------------------------------------------------------------------
+TEST( mint_su2_io, write_read_mixed_cell_topology_mesh )
+{
+  constexpr int DIMENSION = 2;
+
+  // Construct the mesh object
+  mint::UnstructuredMesh< mint::MIXED_SHAPE > mesh( DIMENSION );
+
+  // Append the mesh nodes
+  const axom::IndexType n0 = mesh.appendNode( 0.0, 0.0 );
+  const axom::IndexType n1 = mesh.appendNode( 2.0, 0.0 );
+  const axom::IndexType n2 = mesh.appendNode( 1.0, 1.0 );
+  const axom::IndexType n3 = mesh.appendNode( 3.5, 1.0 );
+  const axom::IndexType n4 = mesh.appendNode( 2.5, 2.0 );
+  const axom::IndexType n5 = mesh.appendNode( 5.0, 0.0 );
+
+  // Append mesh cells
+  const axom::IndexType c0[ ] = { n0, n1, n2 };
+  const axom::IndexType c1[ ] = { n1, n5, n3, n2 };
+  const axom::IndexType c2[ ] = { n3, n4, n2 };
+
+  mesh.appendCell( c0, mint::TRIANGLE );
+  mesh.appendCell( c1, mint::QUAD );
+  mesh.appendCell( c2, mint::TRIANGLE );
+
+  // write an SU2 file
+  const std::string su2File = "mixed_cell_mesh.su2";
+  int rc = mint::write_su2( &mesh, su2File );
+  EXPECT_EQ( rc, 0 );
+
+  // read it on a new mesh instance
+  mint::Mesh* test_mesh = nullptr;
+  rc = mint::read_su2( su2File, test_mesh );
+  EXPECT_EQ( rc, 0 );
+  EXPECT_TRUE( test_mesh != nullptr );
+  EXPECT_TRUE( test_mesh->isUnstructured() );
+
+  // test the mesh
+  EXPECT_EQ( test_mesh->getDimension(), DIMENSION );
+  EXPECT_EQ( test_mesh->getNumberOfNodes(), mesh.getNumberOfNodes() );
+  EXPECT_EQ( test_mesh->getNumberOfCells(), mesh.getNumberOfCells() );
+  EXPECT_EQ( test_mesh->hasMixedCellTypes(), mesh.hasMixedCellTypes() );
+
+  // test mesh nodes
+  check_nodes( &mesh, test_mesh );
+
+  // test mesh connectivity
+  check_cell_connectivity( &mesh, test_mesh );
+
+  // cleanup
+  delete test_mesh;
+  std::remove( su2File.c_str() );
+}
+
+//------------------------------------------------------------------------------
+TEST( mint_su2_io, write_read_single_cell_topology_mesh )
+{
+  constexpr int DIMENSION            = 2;
+  constexpr mint::CellType CELL_TYPE = mint::TRIANGLE;
+
+  // Construct the mesh object
+  mint::UnstructuredMesh< mint::SINGLE_SHAPE > mesh( DIMENSION, CELL_TYPE );
+
+  // Append the mesh nodes
+  const axom::IndexType n0 = mesh.appendNode( 0.0, 0.0 );
+  const axom::IndexType n1 = mesh.appendNode( 2.0, 0.0 );
+  const axom::IndexType n2 = mesh.appendNode( 1.0, 1.0 );
+  const axom::IndexType n3 = mesh.appendNode( 3.5, 1.0 );
+  const axom::IndexType n4 = mesh.appendNode( 2.5, 2.0 );
+  const axom::IndexType n5 = mesh.appendNode( 5.0, 0.0 );
+
+  // Append mesh cells
+  const axom::IndexType c0[ ] = { n1, n3, n2 };
+  const axom::IndexType c1[ ] = { n2, n0, n1 };
+  const axom::IndexType c2[ ] = { n3, n4, n2 };
+  const axom::IndexType c3[ ] = { n1, n5, n3 };
+
+  mesh.appendCell( c0 );
+  mesh.appendCell( c1 );
+  mesh.appendCell( c2 );
+  mesh.appendCell( c3 );
+
+  // write an SU2 file
+  const std::string su2File = "simple_mesh.su2";
+  int rc = mint::write_su2( &mesh, su2File );
+  EXPECT_EQ( rc, 0 );
+
+  // read it on a new mesh instance
+  mint::Mesh* test_mesh = nullptr;
+  rc = mint::read_su2( su2File, test_mesh );
+  EXPECT_EQ( rc, 0 );
+  EXPECT_TRUE( test_mesh != nullptr );
+  EXPECT_TRUE( test_mesh->isUnstructured() );
+
+  // test the mesh
+  EXPECT_EQ( test_mesh->getDimension(), DIMENSION );
+  EXPECT_EQ( test_mesh->getNumberOfNodes(), mesh.getNumberOfNodes() );
+  EXPECT_EQ( test_mesh->getNumberOfCells(), mesh.getNumberOfCells() );
+  EXPECT_EQ( test_mesh->hasMixedCellTypes(), mesh.hasMixedCellTypes() );
+
+  // test mesh nodes
+  check_nodes( &mesh, test_mesh );
+
+  // test mesh connectivity
+  check_cell_connectivity( &mesh, test_mesh );
+
+  // cleanup
+  delete test_mesh;
+  std::remove( su2File.c_str() );
+}
+
+//------------------------------------------------------------------------------
+using axom::slic::UnitTestLogger;
+
+int main( int argc, char* argv[] )
+{
+  int result = 0;
+  ::testing::InitGoogleTest( &argc, argv );
+  UnitTestLogger logger;
+  result = RUN_ALL_TESTS();
+  return result;
+}
+
+
+
+

--- a/src/axom/mint/utils/su2_utils.cpp
+++ b/src/axom/mint/utils/su2_utils.cpp
@@ -1,0 +1,375 @@
+// Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/mint/utils/su2_utils.hpp"
+
+#include "axom/mint/mesh/Mesh.hpp"               /* for Mesh base class */
+#include "axom/mint/mesh/UnstructuredMesh.hpp"   /* for UnstructuredMesh */
+#include "axom/mint/mesh/CellTypes.hpp"
+
+// C/C++ includes
+#include <fstream> // for std::ifstream
+
+namespace axom
+{
+namespace mint
+{
+
+//------------------------------------------------------------------------------
+// INTERNAL HELPER METHODS
+//------------------------------------------------------------------------------
+namespace
+{
+
+constexpr int SU2_LINE     = 3;
+constexpr int SU2_TRIANGLE = 5;
+constexpr int SU2_QUAD     = 9;
+constexpr int SU2_TET      = 10;
+constexpr int SU2_HEX      = 12;
+constexpr int SU2_PRISM    = 13;
+constexpr int SU2_PYRAMID  = 14;
+
+//------------------------------------------------------------------------------
+mint::CellType getMintCellType( int su2CellType )
+{
+  mint::CellType c = mint::UNDEFINED_CELL;
+
+  switch ( su2CellType )
+  {
+  case SU2_LINE:
+    c = mint::SEGMENT;
+    break;
+  case SU2_TRIANGLE:
+    c = mint::TRIANGLE;
+    break;
+  case SU2_QUAD:
+    c = mint::QUAD;
+    break;
+  case SU2_TET:
+    c = mint::TET;
+    break;
+  case SU2_HEX:
+    c = mint::HEX;
+    break;
+  case SU2_PRISM:
+    c = mint::PRISM;
+    break;
+  case SU2_PYRAMID:
+    c = mint::PYRAMID;
+    break;
+  default:
+    c = mint::UNDEFINED_CELL;
+  } // END switch
+
+  return ( c );
+}
+
+//------------------------------------------------------------------------------
+int getSU2CellType( mint::CellType mint_type )
+{
+  int su2type = mint::cellTypeToInt( mint::UNDEFINED_CELL );
+
+  switch ( mint_type )
+  {
+  case mint::SEGMENT:
+    su2type = SU2_LINE;
+    break;
+  case mint::TRIANGLE:
+    su2type = SU2_TRIANGLE;
+    break;
+  case mint::QUAD:
+    su2type = SU2_QUAD;
+    break;
+  case mint::TET:
+    su2type = SU2_TET;
+    break;
+  case mint::HEX:
+    su2type = SU2_HEX;
+    break;
+  case mint::PRISM:
+    su2type = SU2_PRISM;
+    break;
+  case mint::PYRAMID:
+    su2type = SU2_PYRAMID;
+    break;
+  default:
+    su2type = mint::cellTypeToInt( mint::UNDEFINED_CELL );
+  } // END switch
+
+  return ( su2type );
+}
+
+//------------------------------------------------------------------------------
+void read_points( double* points, int npoin, int ndime, std::ifstream& ifs )
+{
+  SLIC_ASSERT( points != nullptr );
+
+  if ( npoin <= 0 )
+  {
+    return;
+  }
+
+  std::string line = "";
+  for ( int ipoint=0; ipoint < npoin; ++ipoint )
+  {
+    const int offset = ipoint*ndime;
+    for ( int idim=0; idim < ndime; ++idim )
+    {
+      ifs >> points[ offset + idim ];
+    }
+
+    std::getline( ifs, line );
+
+  } // END for all points
+
+}
+
+//------------------------------------------------------------------------------
+void read_connectivity( axom::IndexType* connectivity,
+                        mint::CellType* cellTypes,
+                        int nelem, bool& isMixed, std::ifstream& ifs )
+{
+  SLIC_ASSERT( cellTypes != nullptr );
+  SLIC_ASSERT( connectivity != nullptr );
+
+  if ( nelem <= 0 )
+  {
+    return;
+  }
+
+  std::string line = "";
+  int ctype;
+  for ( int icell=0; icell < nelem; ++icell )
+  {
+    ifs >> ctype;
+    mint::CellType c = getMintCellType( ctype );
+    SLIC_ASSERT( c != mint::UNDEFINED_CELL );
+    cellTypes[ icell ] = c;
+
+    if ( !isMixed )
+    {
+      isMixed = ( (icell > 0) && ( cellTypes[ icell-1 ] != c ) ) ?  true:false;
+    }
+
+    const int offset   = icell * mint::MAX_CELL_NODES;
+    const int numNodes = mint::getCellInfo( c ).num_nodes;
+    for ( int inode=0; inode < numNodes; ++inode )
+    {
+      ifs >> connectivity[ offset + inode ];
+    }
+
+    std::getline( ifs, line );
+
+  } // END for all cells
+
+}
+
+//------------------------------------------------------------------------------
+void read_data( std::ifstream& ifs, int& ndime, int& nelem, int& npoin,
+                bool& isMixed,
+                double*& points,
+                axom::IndexType*& connectivity,
+                mint::CellType*& cellTypes )
+{
+  // sanity checks
+  SLIC_ASSERT( points == nullptr );
+  SLIC_ASSERT( connectivity == nullptr );
+  SLIC_ASSERT( cellTypes == nullptr );
+
+  std::string line = "";
+  while ( std::getline(ifs, line) )
+  {
+
+    if ( line.substr(0,1) == "%" || line.length()==0 )
+    {
+      // skip empty lines and comments
+      continue;
+    }
+
+    if ( line.substr(0,6) == "NDIME=" )
+    {
+      ndime = std::stoi( line.substr(6,line.length() ) );
+      SLIC_ERROR_IF( (ndime < 2) || (ndime > 3),
+                     "mesh dimension must be 2 or 3!" );
+    }
+    else if ( line.substr(0,6) == "NPOIN=" )
+    {
+      SLIC_ERROR_IF( ndime==-1,
+                     "dimension must be set prior to parsing the mesh points!");
+
+      npoin  = std::stoi( line.substr(6,line.length() ) );
+      points = axom::allocate< double >( npoin*ndime );
+      read_points( points, npoin, ndime, ifs );
+    }
+    else if ( line.substr(0,6) == "NELEM=" )
+    {
+      SLIC_ERROR_IF( ndime==-1,
+                 "dimension must be set prior to parsing mesh connectivity!" );
+
+      nelem = std::stoi( line.substr(6,line.length() ) );
+      connectivity =
+          axom::allocate< axom::IndexType >( nelem * mint::MAX_CELL_NODES );
+      cellTypes = axom::allocate< mint::CellType >( nelem );
+      read_connectivity( connectivity, cellTypes, nelem, isMixed, ifs );
+
+    }
+
+  } // END while
+
+  // sanity checks
+  SLIC_ASSERT( points != nullptr );
+  SLIC_ASSERT( connectivity != nullptr );
+  SLIC_ASSERT( cellTypes != nullptr );
+}
+
+} /* end anonymous namespace */
+
+//------------------------------------------------------------------------------
+int read_su2( const std::string& file, Mesh*& mesh )
+{
+  SLIC_ERROR_IF( file.length() <= 0, "No SU2 file was supplied!" );
+  SLIC_ERROR_IF( mesh != nullptr, "supplied mesh pointer should be a nullptr" );
+
+
+  std::ifstream ifs( file.c_str() );
+  if ( !ifs.is_open() )
+  {
+    SLIC_WARNING( "cannot read from file [" << file << "]" );
+    return -1;
+  }
+
+  // STEP 0: read the raw data
+  int ndime = -1;
+  int nelem = -1;
+  int npoin = -1;
+
+  double* points                = nullptr;
+  axom::IndexType* connectivity = nullptr;
+  mint::CellType* cellTypes     = nullptr;
+  bool isMixed                  = false;
+
+  read_data( ifs,ndime,nelem,npoin,isMixed,points,connectivity,cellTypes );
+  SLIC_ERROR_IF( ndime < 2 || ndime > 3, "mesh dimension must be 2 or 3!" );
+  SLIC_ERROR_IF( nelem <= 0, "mesh has zero cells!" );
+  SLIC_ERROR_IF( npoin <= 0, "mesh has zero nodes!" );
+
+  SLIC_ASSERT( points != nullptr );
+  SLIC_ASSERT( connectivity != nullptr );
+  SLIC_ASSERT( cellTypes != nullptr );
+
+  ifs.close( );
+
+  // STEP 1: construct a mint mesh object
+  if ( isMixed )
+  {
+    using MeshType = mint::UnstructuredMesh< mint::MIXED_SHAPE >;
+    MeshType* m = new MeshType( ndime, npoin, nelem );
+
+    for ( int i=0; i < npoin; ++i )
+    {
+      m->appendNodes( &points[i*ndime], 1 );
+    }
+
+    for ( int i=0; i < nelem; ++i )
+    {
+      m->appendCell( &connectivity[i*mint::MAX_CELL_NODES], cellTypes[ i ] );
+    }
+
+    mesh = m;
+  }
+  else
+  {
+    using MeshType = mint::UnstructuredMesh< mint::SINGLE_SHAPE >;
+    MeshType* m = new MeshType( ndime, cellTypes[ 0 ], npoin, nelem );
+
+    for ( int i=0; i < npoin; ++i )
+    {
+      m->appendNodes( &points[i*ndime], 1 );
+    }
+
+    for ( int i=0; i < nelem; ++i )
+    {
+      m->appendCell( &connectivity[i*mint::MAX_CELL_NODES] );
+    }
+
+    mesh = m;
+  }
+
+  axom::deallocate( points );
+  axom::deallocate( connectivity );
+  axom::deallocate( cellTypes );
+
+  SLIC_ASSERT( mesh != nullptr );
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+int write_su2( const mint::Mesh* mesh, const std::string& file )
+{
+  SLIC_ERROR_IF( mesh==nullptr, "mesh pointer is null!" );
+  SLIC_ERROR_IF( file.length() <= 0, "SU2 filename is empty!" );
+
+  if ( mesh->isStructured() )
+  {
+    SLIC_WARNING( "SU2 format is supported only for unstructured meshes!" );
+    return -1;
+  }
+
+  std::ofstream ofs( file.c_str() );
+  if ( !ofs.is_open() )
+  {
+    SLIC_WARNING( "cannot write to file [" << file << "]" );
+    return -1;
+  }
+
+  const int ndims              = mesh->getDimension();
+  const axom::IndexType nnodes = mesh->getNumberOfNodes();
+  const axom::IndexType ncells = mesh->getNumberOfCells();
+
+  ofs << "NDIME= " << ndims << std::endl << std::endl;
+  ofs << "NPOIN= " << nnodes << std::endl;
+
+  double coords[ 3 ];
+  for ( axom::IndexType inode=0; inode < nnodes; ++inode )
+  {
+    mesh->getNode( inode, coords );
+
+    for ( int idim=0; idim < ndims; ++idim )
+    {
+      ofs << coords[ idim ] << " ";
+    } // END for all dimensions
+    ofs << std::endl;
+
+  } // END for all nodes
+  ofs << std::endl;
+
+  ofs << "NELEM= " << ncells << std::endl;
+  axom::IndexType cell[ mint::MAX_CELL_NODES ];
+  for ( axom::IndexType icell=0; icell < ncells; ++icell )
+  {
+    const int ctype = getSU2CellType( mesh->getCellType(icell) );
+    ofs << ctype << " ";
+
+    const axom::IndexType ncnodes = mesh->getNumberOfCellNodes( icell );
+
+    mesh->getCellNodeIDs( icell, cell );
+    for ( axom::IndexType inode=0; inode < ncnodes; ++inode )
+    {
+      ofs << cell[ inode ] << " ";
+    } // END for all cell nodes
+    ofs << std::endl;
+
+  } // END for all cells
+  ofs << std::endl;
+
+  ofs.close();
+  return 0;
+}
+
+} /* namespace mint */
+
+} /* namespace axom */
+
+

--- a/src/axom/mint/utils/su2_utils.hpp
+++ b/src/axom/mint/utils/su2_utils.hpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef MINT_UTILS_SU2_UTILS_HPP_
+#define MINT_UTILS_SU2_UTILS_HPP_
+
+#include <string> // for std::string
+
+namespace axom
+{
+namespace mint
+{
+
+// Forward Declarations
+class Mesh;
+
+/*!
+ * \brief Reads an unstructured mesh from an SU2 Mesh file.
+ *
+ * \param [in] file path corresponding to su2 mesh file.
+ * \param [out] mesh pointer to a mesh object where the mesh will be loaded.
+ *
+ * \return status error code, zero on success
+ *
+ * \note The SU2 Mesh file format is documented here:
+ *  https://su2code.github.io/docs/Mesh-File/
+ *
+ * \note The current implementation ignores the boundary markers.
+ *
+ * \note Ownership of the mesh object is passed to the caller. Consequently,
+ *  the caller is responsible for properly deallocating the mesh object that
+ *  the return mesh pointer points to.
+ *
+ * \pre file.length() > 0
+ * \pre mesh == nullptr
+ * \post mesh->isUnstructured()==true
+ */
+int read_su2( const std::string& file, Mesh*& mesh );
+
+/*!
+ * \brief Writes an unstructured mesh to the specified file according to the
+ *  SU2 Mesh file format.
+ *
+ * \param [in] mesh pointer to the mesh to write.
+ * \param [in] file path to the file where to write the mesh.
+ *
+ * \return status error code, zero on success
+ *
+ * \note The SU2 Mesh file format is documented here:
+ *  https://su2code.github.io/docs/Mesh-File/
+ *
+ * \note The current implementation ignores the boundary markers.
+ *
+ * \pre mesh != nullptr
+ * \pre mesh->isUnstructured()==true
+ * \pre file.lenght() > 0
+ */
+int write_su2( const mint::Mesh* mesh, const std::string& file );
+
+} /* namespace mint */
+
+} /* namespace axom */
+
+
+
+#endif /* MINT_UTILS_SU2_UTILS_HPP_ */


### PR DESCRIPTION
# Summary

- This PR adds support for the [SU2 mesh file format](https://su2code.github.io/docs/Mesh-File/) in Mint. Both single cell topology and mixed cell topology unstructured mesh types are supported.