### PR TITLE
Update Conduit to master

### DIFF
--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@8.0.0_nvcc_xlf.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@8.0.0_nvcc_xlf.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: clang@8.0.0_nvcc_xlf
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_27_14_07_53/clang-8.0.0_nvcc_xlf/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_32/clang-8.0.0_nvcc_xlf/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -26,20 +26,23 @@ set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-8.0.0/bin/clang" CACHE PATH 
 # C++ compiler used by spack
 set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-8.0.0/bin/clang++" CACHE PATH "")
 
+# NOTE: The MPI Fortran wrapper is currently pointing at a non-existant compiler.
+#   So until this is fixed Fortran is turned off on this host-config.
+
 # Fortran compiler used by spack
 set(ENABLE_FORTRAN OFF CACHE BOOL "")
 
-set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.06.12/bin/xlf2003" CACHE PATH "")
+#set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.06.12/bin/xlf2003" CACHE PATH "")
 
 ##############
 # TPLs
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_27_14_07_53/clang-8.0.0_nvcc_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_32/clang-8.0.0_nvcc_xlf" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")
@@ -77,7 +80,7 @@ set(MPI_C_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-
 
 set(MPI_CXX_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-8.0.0/bin/mpicxx" CACHE PATH "")
 
-set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-8.0.0/bin/mpif90" CACHE PATH "")
+#set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-8.0.0/bin/mpif90" CACHE PATH "")
 
 set(MPIEXEC "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-8.0.0/bin/mpirun" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@upstream_xlf.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@upstream_xlf.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: clang@upstream_xlf
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_27_14_07_53/clang-upstream_xlf/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_32/clang-upstream_xlf/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -36,10 +36,10 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.06.12/bin/xlf2003" CACH
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_27_14_07_53/clang-upstream_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_32/clang-upstream_xlf" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@7.3.1.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@7.3.1.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: gcc@7.3.1
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_27_14_07_53/gcc-7.3.1/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_32/gcc-7.3.1/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -36,10 +36,10 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-7.3.1/bin/gfortran" CACHE 
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_27_14_07_53/gcc-7.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_32/gcc-7.3.1" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@coral.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@coral.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: xl@coral
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_27_14_07_53/xl-coral/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_32/xl-coral/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -36,10 +36,10 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.06.12/bin/xlf2003" CACH
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_27_14_07_53/xl-coral" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_32/xl-coral" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@4.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@4.0.0.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: clang@4.0.0
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_23_21_31_06/clang-4.0.0/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_57_11/clang-4.0.0/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -36,10 +36,10 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE 
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_23_21_31_06/clang-4.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_57_11/clang-4.0.0" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@6.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@6.0.0.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: clang@6.0.0
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_23_21_31_06/clang-6.0.0/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_57_11/clang-6.0.0/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -36,10 +36,10 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE 
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_23_21_31_06/clang-6.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_57_11/clang-6.0.0" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@6.1.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@6.1.0.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: gcc@6.1.0
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_23_21_31_06/gcc-6.1.0/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_57_11/gcc-6.1.0/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -36,10 +36,10 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-6.1.0/bin/gfortran" CACHE 
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_23_21_31_06/gcc-6.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_57_11/gcc-6.1.0" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@7.3.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@7.3.0.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: gcc@7.3.0
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_23_21_31_06/gcc-7.3.0/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_57_11/gcc-7.3.0/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -36,10 +36,10 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-7.3.0/bin/gfortran" CACHE 
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_23_21_31_06/gcc-7.3.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_57_11/gcc-7.3.0" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: gcc@8.1.0
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_23_21_31_06/gcc-8.1.0/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_57_11/gcc-8.1.0/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -36,10 +36,10 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran" CACHE 
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_23_21_31_06/gcc-8.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_57_11/gcc-8.1.0" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@18.0.2.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@18.0.2.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: intel@18.0.2
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_23_21_31_06/intel-18.0.2/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_57_11/intel-18.0.2/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -36,10 +36,10 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-18.0.2/bin/ifort" CACH
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_23_21_31_06/intel-18.0.2" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_57_11/intel-18.0.2" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.0.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: intel@19.0.0
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_23_21_31_06/intel-19.0.0/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_57_11/intel-19.0.0/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -36,10 +36,10 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-19.0.0/bin/ifort" CACH
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_23_21_31_06/intel-19.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_57_11/intel-19.0.0" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@upstream_nvcc_xlf.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@upstream_nvcc_xlf.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: clang@upstream_nvcc_xlf
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_27_13_46_00/clang-upstream_nvcc_xlf/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_43/clang-upstream_nvcc_xlf/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -36,10 +36,10 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2018.11.26/bin/xlf2003" CACH
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_27_13_46_00/clang-upstream_nvcc_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_43/clang-upstream_nvcc_xlf" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@upstream_xlf.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@upstream_xlf.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: clang@upstream_xlf
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_27_13_46_00/clang-upstream_xlf/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_43/clang-upstream_xlf/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -36,10 +36,10 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2018.11.26/bin/xlf2003" CACH
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_27_13_46_00/clang-upstream_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_43/clang-upstream_xlf" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-gcc@4.9.3.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-gcc@4.9.3.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: gcc@4.9.3
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_27_13_46_00/gcc-4.9.3/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_43/gcc-4.9.3/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -36,10 +36,10 @@ set(CMAKE_Fortran_COMPILER "/usr/tcetmp/packages/gcc/gcc-4.9.3/bin/gfortran" CAC
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_27_13_46_00/gcc-4.9.3" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_43/gcc-4.9.3" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-xl@coral.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-xl@coral.cmake
@@ -14,7 +14,7 @@
 # Compiler Spec: xl@coral
 ##################################
 
-# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_27_13_46_00/xl-coral/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_43/xl-coral/cmake-3.9.6/bin/cmake
 
 ##############
 # Compilers
@@ -36,10 +36,10 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2018.11.26/bin/xlf2003" CACH
 ##############
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_27_13_46_00/xl-coral" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/thirdparty_libs/builds/2019_08_29_16_56_43/xl-coral" CACHE PATH "")
 
 # conduit from uberenv
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.4.0" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
 # mfem from uberenv
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")

--- a/scripts/uberenv/packages/conduit/package.py
+++ b/scripts/uberenv/packages/conduit/package.py
@@ -46,13 +46,13 @@ class Conduit(Package):
     coupling between packages in-core, serialization, and I/O tasks."""
 
     homepage = "http://software.llnl.gov/conduit"
-    url = "https://github.com/LLNL/conduit/releases/download/v0.3.0/conduit-v0.3.0-src-with-blt.tar.gz"
+    url = "https://github.com/LLNL/conduit/releases/download/v0.4.0/conduit-v0.4.0-src-with-blt.tar.gz"
 
     version('master', branch='master', submodules=True,
-            git='https://github.com/LLNL/conduit.git')
-    version('0.4.0', 
-            sha256='c228e6f0ce5a9c0ffb98e0b3d886f2758ace1a4b40d00f3f118542c0747c1f52', 
+            git='https://github.com/LLNL/conduit.git',
             preferred=True)
+    version('0.4.0', 
+            sha256='c228e6f0ce5a9c0ffb98e0b3d886f2758ace1a4b40d00f3f118542c0747c1f52')
     version('0.3.1', 'b98d1476199a46bde197220cd9cde042')
     version('0.3.0', '6396f1d1ca16594d7c66d4535d4f898e')
     # note: checksums on github automatic release source tars changed ~9/17

--- a/scripts/uberenv/specs.json
+++ b/scripts/uberenv/specs.json
@@ -39,5 +39,5 @@
       "clang@4.0.0_xlf~openmp~umpire ^zlib~shared" ],
 
     "darwin-x86_64":
-    [ "clang@9.0.0 ^conduit@master" ]
+    [ "clang@9.0.0" ]
 }

--- a/src/axom/mint/CMakeLists.txt
+++ b/src/axom/mint/CMakeLists.txt
@@ -114,7 +114,9 @@ set( mint_dependencies
      slic
      )
 
-blt_list_append( TO mint_dependencies ELEMENTS sidre conduit IF AXOM_MINT_USE_SIDRE )
+blt_list_append( TO mint_dependencies
+                 ELEMENTS sidre conduit::conduit
+                 IF AXOM_MINT_USE_SIDRE )
 
 blt_list_append( TO mint_dependencies ELEMENTS raja IF RAJA_FOUND )
 

--- a/src/axom/mint/examples/CMakeLists.txt
+++ b/src/axom/mint/examples/CMakeLists.txt
@@ -23,7 +23,7 @@ set( mint_example_dependencies
      slic
    )
 
-blt_list_append( TO mint_example_dependencies ELEMENTS sidre conduit
+blt_list_append( TO mint_example_dependencies ELEMENTS sidre conduit::conduit
                  IF ${AXOM_MINT_USE_SIDRE} )
 
 blt_list_append( TO mint_example_dependencies ELEMENTS raja

--- a/src/axom/mint/tests/CMakeLists.txt
+++ b/src/axom/mint/tests/CMakeLists.txt
@@ -46,7 +46,9 @@ set( mint_test_dependencies
      mint
      )
 
-blt_list_append( TO mint_test_dependencies ELEMENTS sidre conduit IF AXOM_MINT_USE_SIDRE )
+blt_list_append( TO mint_test_dependencies
+                 ELEMENTS sidre conduit::conduit
+                 IF AXOM_MINT_USE_SIDRE )
 blt_list_append( TO mint_test_dependencies ELEMENTS raja IF RAJA_FOUND )
 blt_list_append( TO mint_test_dependencies ELEMENTS openmp IF ENABLE_OPENMP )
 blt_list_append( TO mint_test_dependencies ELEMENTS cuda IF ENABLE_CUDA )

--- a/src/axom/quest/tests/CMakeLists.txt
+++ b/src/axom/quest/tests/CMakeLists.txt
@@ -143,7 +143,7 @@ if (ENABLE_MPI AND AXOM_ENABLE_SIDRE)
 
     set(quest_regression_depends
         ${quest_tests_depends}
-        conduit
+        conduit::conduit
         sidre
         )
 

--- a/src/axom/sidre/CMakeLists.txt
+++ b/src/axom/sidre/CMakeLists.txt
@@ -96,7 +96,7 @@ endif()
 ################################
 set(sidre_depends
     core
-    conduit
+    conduit::conduit
     slic)
 
 if(HDF5_FOUND)

--- a/src/axom/sidre/CMakeLists.txt
+++ b/src/axom/sidre/CMakeLists.txt
@@ -97,8 +97,6 @@ endif()
 set(sidre_depends
     core
     conduit
-    conduit_blueprint
-    conduit_relay
     slic)
 
 if(HDF5_FOUND)

--- a/src/axom/sidre/examples/CMakeLists.txt
+++ b/src/axom/sidre/examples/CMakeLists.txt
@@ -32,10 +32,8 @@ endif()
 
 set(sidre_example_depends
     core
-    sidre 
-    conduit 
-    conduit_blueprint 
-    conduit_relay 
+    sidre
+    conduit::conduit
     slic
     )
 

--- a/src/axom/sidre/examples/lulesh2/CMakeLists.txt
+++ b/src/axom/sidre/examples/lulesh2/CMakeLists.txt
@@ -24,7 +24,7 @@ blt_add_executable(
     NAME sidre_lulesh2_ex
     SOURCES ${lulesh_sources} ${lulesh_headers}
     OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-    DEPENDS_ON core sidre conduit conduit_relay hdf5 slic
+    DEPENDS_ON core sidre conduit::conduit hdf5 slic
     FOLDER axom/sidre/examples
     )
 

--- a/src/axom/sidre/examples/spio/CMakeLists.txt
+++ b/src/axom/sidre/examples/spio/CMakeLists.txt
@@ -16,7 +16,7 @@ if (SCR_FOUND)
     list(APPEND example_sources IOSCRWrite.cpp)
 endif() 
 
-set(spio_example_depends sidre conduit conduit_relay slic ${EXTRA_LIBS})
+set(spio_example_depends sidre conduit::conduit slic ${EXTRA_LIBS})
 
 if (HDF5_FOUND)
     list(APPEND spio_example_depends hdf5)

--- a/src/axom/sidre/tests/CMakeLists.txt
+++ b/src/axom/sidre/tests/CMakeLists.txt
@@ -46,10 +46,9 @@ set(fruit_sidre_tests
 
 
 set(sidre_test_depends 
-    sidre 
-    conduit 
-    conduit_relay 
-    slic 
+    sidre
+    conduit::conduit
+    slic
     )
     
 if(HDF5_FOUND)

--- a/src/axom/sidre/tests/spio/CMakeLists.txt
+++ b/src/axom/sidre/tests/spio/CMakeLists.txt
@@ -18,7 +18,7 @@ set(gtest_spio_parallel_tests
 
 set(spio_test_depends
     sidre
-    conduit
+    conduit::conduit
     mpi
     )
 

--- a/src/cmake/thirdparty/FindConduit.cmake
+++ b/src/cmake/thirdparty/FindConduit.cmake
@@ -20,13 +20,14 @@ if(NOT CONDUIT_DIR)
     MESSAGE(FATAL_ERROR "Could not find Conduit. Conduit requires explicit CONDUIT_DIR.")
 endif()
 
-if(NOT EXISTS ${CONDUIT_DIR}/lib/cmake/conduit.cmake)
-    MESSAGE(FATAL_ERROR "Could not find Conduit cmake include file (${CONDUIT_DIR}/lib/cmake/conduit.cmake)")
+set(_conduit_config "${CONDUIT_DIR}/lib/cmake/ConduitConfig.cmake")
+if(NOT EXISTS ${_conduit_config})
+    MESSAGE(FATAL_ERROR "Could not find Conduit cmake include file ${_conduit_config}")
 endif()
 
-include(${CONDUIT_DIR}/lib/cmake/conduit.cmake)
-
-set(CONDUIT_INCLUDE_DIRS ${CONDUIT_DIR}/include/conduit)
+find_package(Conduit REQUIRED
+             NO_DEFAULT_PATH
+             PATHS ${CONDUIT_DIR}/lib/cmake)
 
 # handle the QUIETLY and REQUIRED arguments and set CONDUIT_FOUND to TRUE
 # if all listed variables are TRUE

--- a/src/cmake/thirdparty/FindConduit.cmake
+++ b/src/cmake/thirdparty/FindConduit.cmake
@@ -9,9 +9,8 @@
 #
 # This file defines:
 #  CONDUIT_FOUND - If Conduit was found
-#  CONDUIT_INCLUDE_DIRS - The Conduit include directories
 #  
-#  If found, the conduit CMake targets will also be imported
+#  If found, the Conduit CMake targets will also be imported
 #------------------------------------------------------------------------------
 
 # first Check for CONDUIT_DIR
@@ -28,14 +27,3 @@ endif()
 find_package(Conduit REQUIRED
              NO_DEFAULT_PATH
              PATHS ${CONDUIT_DIR}/lib/cmake)
-
-# handle the QUIETLY and REQUIRED arguments and set CONDUIT_FOUND to TRUE
-# if all listed variables are TRUE
-find_package_handle_standard_args(CONDUIT  DEFAULT_MSG
-                                  CONDUIT_INCLUDE_DIRS
-                                  )
-
-
-
-
-

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -11,40 +11,38 @@
 # UMPIRE
 ################################
 if (UMPIRE_DIR)
-  include(cmake/thirdparty/FindUmpire.cmake)
-  blt_register_library( NAME umpire
-                        INCLUDES ${UMPIRE_INCLUDE_DIRS}
-                        TREAT_INCLUDES_AS_SYSTEM ON
-                        LIBRARIES umpire )
+    include(cmake/thirdparty/FindUmpire.cmake)
+    blt_register_library( NAME      umpire
+                          INCLUDES  ${UMPIRE_INCLUDE_DIRS}
+                          LIBRARIES umpire
+                          TREAT_INCLUDES_AS_SYSTEM ON)
 else()
-  message(STATUS "Umpire support is OFF")
+    message(STATUS "Umpire support is OFF")
 endif()
+
 
 ################################
 # RAJA
 ################################
 if (RAJA_DIR)
-  include(cmake/thirdparty/FindRAJA.cmake)
-  blt_register_library( NAME raja
-                        INCLUDES ${RAJA_INCLUDE_DIR}
-                        TREAT_INCLUDES_AS_SYSTEM ON
-                        LIBRARIES ${RAJA_LIB_DIR}/libRAJA.a )
+    include(cmake/thirdparty/FindRAJA.cmake)
+    blt_register_library( NAME      raja
+                          INCLUDES  ${RAJA_INCLUDE_DIR}
+                          LIBRARIES ${RAJA_LIB_DIR}/libRAJA.a
+                          TREAT_INCLUDES_AS_SYSTEM ON)
 else()
-  message(STATUS "RAJA support is OFF" )
+    message(STATUS "RAJA support is OFF" )
 endif()
+
 
 ################################
 # Conduit
 ################################
 if (CONDUIT_DIR)
     include(cmake/thirdparty/FindConduit.cmake)
-    blt_register_library( NAME conduit
-                          INCLUDES ${CONDUIT_INCLUDE_DIRS}
-                          LIBRARIES conduit
-                          TREAT_INCLUDES_AS_SYSTEM ON)
-    blt_register_library( NAME conduit_relay
-                          INCLUDES ${CONDUIT_INCLUDE_DIRS}
-                          LIBRARIES conduit_relay
+    blt_register_library( NAME      conduit
+                          INCLUDES  ${CONDUIT_INCLUDE_DIRS}
+                          LIBRARIES conduit::conduit
                           TREAT_INCLUDES_AS_SYSTEM ON)
 else()
     message(STATUS "Conduit support is OFF")
@@ -56,8 +54,8 @@ endif()
 ################################
 if (HDF5_DIR)
     include(cmake/thirdparty/SetupHDF5.cmake)
-    blt_register_library( NAME hdf5
-                          INCLUDES ${HDF5_INCLUDE_DIRS}
+    blt_register_library( NAME      hdf5
+                          INCLUDES  ${HDF5_INCLUDE_DIRS}
                           LIBRARIES ${HDF5_LIBRARIES}
                           TREAT_INCLUDES_AS_SYSTEM ON)
 else()
@@ -70,8 +68,8 @@ endif()
 ################################
 if (MFEM_DIR)
     include(cmake/thirdparty/FindMFEM.cmake)
-    blt_register_library( NAME mfem
-                          INCLUDES ${MFEM_INCLUDE_DIRS}
+    blt_register_library( NAME      mfem
+                          INCLUDES  ${MFEM_INCLUDE_DIRS}
                           LIBRARIES ${MFEM_LIBRARY}
                           TREAT_INCLUDES_AS_SYSTEM ON)
 else()
@@ -91,7 +89,7 @@ if(EXISTS ${SHROUD_EXECUTABLE})
                     ERROR_VARIABLE SHROUD_cmake_error
                     OUTPUT_STRIP_TRAILING_WHITESPACE )
     if(${SHROUD_cmake_error})
-       message(FATAL_ERROR "Error from Shroud: ${SHROUD_cmake_error}")
+        message(FATAL_ERROR "Error from Shroud: ${SHROUD_cmake_error}")
     endif()
     include(${CMAKE_CURRENT_BINARY_DIR}/SetupShroud.cmake)
 else()
@@ -104,8 +102,8 @@ endif()
 ################################
 if (SCR_DIR)
     include(cmake/thirdparty/FindSCR.cmake)
-    blt_register_library( NAME scr
-                          INCLUDES ${SCR_INCLUDE_DIRS}
+    blt_register_library( NAME      scr
+                          INCLUDES  ${SCR_INCLUDE_DIRS}
                           LIBRARIES ${SCR_LIBRARY}
                           TREAT_INCLUDES_AS_SYSTEM ON)
 else()

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -40,6 +40,15 @@ endif()
 ################################
 if (CONDUIT_DIR)
     include(cmake/thirdparty/FindConduit.cmake)
+
+    # Manually set includes as system includes
+    set_property(TARGET conduit::conduit 
+                 APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                 "${CONDUIT_INSTALL_PREFIX}/include/")
+
+    set_property(TARGET conduit::conduit 
+                 APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                 "${CONDUIT_INSTALL_PREFIX}/include/conduit/")
 else()
     message(STATUS "Conduit support is OFF")
 endif()

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -40,10 +40,6 @@ endif()
 ################################
 if (CONDUIT_DIR)
     include(cmake/thirdparty/FindConduit.cmake)
-    blt_register_library( NAME      conduit
-                          INCLUDES  ${CONDUIT_INCLUDE_DIRS}
-                          LIBRARIES conduit::conduit
-                          TREAT_INCLUDES_AS_SYSTEM ON)
 else()
     message(STATUS "Conduit support is OFF")
 endif()

--- a/src/thirdparty/tests/CMakeLists.txt
+++ b/src/thirdparty/tests/CMakeLists.txt
@@ -70,20 +70,20 @@ endif()
 # Smoke test for conduit thirdparty library
 ###########################################
 if (CONDUIT_FOUND)
-    blt_add_executable(NAME conduit_smoke_test
-                       SOURCES conduit_smoke.cpp
+    blt_add_executable(NAME       conduit_smoke_test
+                       SOURCES    conduit_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON conduit gtest
-                       FOLDER axom/thirdparty/tests )
+                       DEPENDS_ON conduit::conduit gtest
+                       FOLDER     axom/thirdparty/tests )
     blt_add_test(NAME conduit_smoke
                  COMMAND conduit_smoke_test)
 
     if (ENABLE_FORTRAN)
-        blt_add_executable(NAME conduit_smoke_F_test
-                           SOURCES f_conduit_smoke.f
+        blt_add_executable(NAME       conduit_smoke_F_test
+                           SOURCES    f_conduit_smoke.f
                            OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON conduit fruit
-                           FOLDER axom/thirdparty/tests )
+                           DEPENDS_ON conduit::conduit fruit
+                           FOLDER     axom/thirdparty/tests )
         blt_add_test(NAME conduit_smoke_F
                      COMMAND conduit_smoke_F_test)
   endif()

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -20,7 +20,7 @@ if( AXOM_ENABLE_SLAM AND AXOM_ENABLE_SIDRE AND ENABLE_MPI AND HDF5_FOUND )
         convert_sidre_protocol.cpp
     )
     set(datastore_converter_depends 
-        sidre conduit conduit_relay hdf5
+        sidre conduit::conduit hdf5
         slic fmt 
         slam 
         mpi


### PR DESCRIPTION
Updates Conduit to the master branch for all specs and platforms.  This is required for any codes that rely on Sidre and use Conduit's find_package logic. Basically hdf5 and silo were backwards on the link line.

Host-config's incoming next week....

- [ Check-in new built host-configs]