### PR TITLE
Change error to warning when trying to import conduit lists into Sidre

### DIFF
--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -2046,8 +2046,9 @@ void Group::importFrom(conduit::Node& node,
  *************************************************************************
  */
 
-void Group::importConduitTree(const conduit::Node &node, bool preserve_contents)
+bool Group::importConduitTree(const conduit::Node &node, bool preserve_contents)
 {
+  bool success = true;
   if (!preserve_contents)
   {
     destroyGroups();
@@ -2069,7 +2070,7 @@ void Group::importConduitTree(const conduit::Node &node, bool preserve_contents)
       {
         // create group
         Group* grp = createGroup(cld_name);
-        grp->importConduitTree(cld_node, preserve_contents);
+        success = grp->importConduitTree(cld_node, preserve_contents);
       }
       else if(cld_dtype.is_empty())
       {
@@ -2125,8 +2126,9 @@ void Group::importConduitTree(const conduit::Node &node, bool preserve_contents)
       }
       else if (cld_dtype.is_list())
       {
-        SLIC_ERROR( "Group " << getPathName() <<
+        SLIC_WARNING( "Group " << getPathName() <<
         " cannot import Conduit list " << cld_name);
+        success = false; 
       }
       else
       {
@@ -2143,10 +2145,13 @@ void Group::importConduitTree(const conduit::Node &node, bool preserve_contents)
     SLIC_ERROR( "Group " << getPathName() <<
                 " cannot import non-object Conduit Node");
   }
+
+  return success;
 }
 
-void Group::importConduitTreeExternal(conduit::Node &node, bool preserve_contents)
+bool Group::importConduitTreeExternal(conduit::Node &node, bool preserve_contents)
 {
+  bool success = true;
   if (!preserve_contents)
   {
     destroyGroups();
@@ -2168,7 +2173,7 @@ void Group::importConduitTreeExternal(conduit::Node &node, bool preserve_content
       {
         // create group
         Group* grp = createGroup(cld_name);
-        grp->importConduitTreeExternal(cld_node, preserve_contents);
+        success = grp->importConduitTreeExternal(cld_node, preserve_contents);
       }
       else if(cld_dtype.is_empty())
       {
@@ -2201,8 +2206,9 @@ void Group::importConduitTreeExternal(conduit::Node &node, bool preserve_content
       }
       else if (cld_dtype.is_list())
       {
-        SLIC_ERROR( "Group " << getPathName() <<
+        SLIC_WARNING( "Group " << getPathName() <<
         " cannot import Conduit list " << cld_name);
+        success = false;
       }
       else
       {
@@ -2220,6 +2226,7 @@ void Group::importConduitTreeExternal(conduit::Node &node, bool preserve_content
                 " cannot import non-object Conduit Node");
   }
 
+  return success;
 }
 
 /*

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -1261,7 +1261,9 @@ public:
    * same tree structure.
    *
    * This does not support conduit's list datatype.  If the Node contains a
-   * list any where in its tree, an error will occur.
+   * list any where in its tree, the list and any child Nodes descending from
+   * the list will not be imported.  A warning will occur and an unsuccessful
+   * return value will be returned.
    *
    * If preserve_contents is true, then the names of the children held by the
    * Node cannot be the same as the names of the children already held by this
@@ -1271,9 +1273,12 @@ public:
    * \param preserve_contents  If true, any child Groups and Views held by
    *                           this Group remain in place.  If false, all
    *                           child Groups and Views are destroyed before
-   *                           importing data from the Node. 
+   *                           importing data from the Node.
+   *
+   * \return                   true for success, false if the full conduit
+   *                           tree is not succesfully imported.
    */
-  void importConduitTree(const conduit::Node& node,
+  bool importConduitTree(const conduit::Node& node,
      bool preserve_contents = false);
 
   /*!
@@ -1287,7 +1292,9 @@ public:
    * same tree structure.
    *
    * This does not support conduit's list datatype.  If the Node contains a
-   * list any where in its tree, an error will occur.
+   * list any where in its tree, the list and any child Nodes descending from
+   * the list will not be imported.  A warning will occur and an unsuccessful
+   * return value will be returned.
    *
    * If preserve_contents is true, then the names of the children held by the
    * Node cannot be the same as the names of the children already held by this
@@ -1297,9 +1304,12 @@ public:
    * \param preserve_contents  If true, any child Groups and Views held by
    *                           this Group remain in place.  If false, all
    *                           child Groups and Views are destroyed before
-   *                           importing data from the Node. 
+   *                           importing data from the Node.
+   *
+   * \return                   true for success, false if the full conduit
+   *                           tree is not succesfully imported.
    */
-  void importConduitTreeExternal(conduit::Node& node,
+  bool importConduitTreeExternal(conduit::Node& node,
      bool preserve_contents = false);
 
 private:

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -2076,7 +2076,7 @@ TEST(sidre_group,import_conduit)
 
   DataStore ds;
 
-  ds.getRoot()->importConduitTree(input);
+  EXPECT_TRUE(ds.getRoot()->importConduitTree(input));
 
   Group* flds = ds.getRoot()->getGroup("fields");
 
@@ -2120,7 +2120,7 @@ TEST(sidre_group,import_conduit_external)
   DataStore ds;
 
   //Zero copy of array data
-  ds.getRoot()->importConduitTreeExternal(input);
+  EXPECT_TRUE(ds.getRoot()->importConduitTreeExternal(input));
 
   Group* flds = ds.getRoot()->getGroup("fields");
 
@@ -2150,7 +2150,7 @@ TEST(sidre_group,import_conduit_external)
     EXPECT_EQ(iarray[j],sidre_data_ptr[j]);
   }
 
-  //Change a value in the original conduit array, test that it's changed
+  //Change a value in the original conduit array, then test that it's changed
   //in the Sidre external view.
   if (ndata > 3)
   {


### PR DESCRIPTION
# Summary

- This PR is a small change
- It does the following (modify list as needed):
  - Changes an error to a warning at the request of @kennyweiss

In the previous pull request #82, an attempt to import a conduit list resulted in a SLIC error, since Sidre Groups do not have an analogous concept.  @kennyweiss requested that this be changed to a warning, but I merged the pull request without addressing the comment.

Here the error is changed to a warning, and the import will still import all other parts of the condiut tree that it can import, while leaving out the lists and anything descending from lists.  A boolean return value is added, true if the full import is successful, false if there was a list that had to be left out.