### PR TITLE
Add option to Enable/Disable CUB when building with CUDA

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,6 +12,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ### Added
 - Added support in Mint for reading and writing an unstructured mesh in the [SU2 Mesh file format].
   This includes support for both single and mixed cell type topology unstructured mesh types.   
+- Added a new option to enable/disable use of CUB, AXOM_USE_CUB, which is disabled by default. This
+  allows to disable CUB to circumvent issues encountered with the device linker.
 
 ### Removed
 

--- a/src/axom/config.hpp.in
+++ b/src/axom/config.hpp.in
@@ -52,6 +52,7 @@
  */
 #cmakedefine AXOM_USE_CONDUIT
 #cmakedefine AXOM_USE_CUDA
+#cmakedefine AXOM_USE_CUB
 #cmakedefine AXOM_USE_FMT
 #cmakedefine AXOM_USE_HDF5
 #cmakedefine AXOM_USE_MFEM

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -393,7 +393,7 @@ void custom_sort( ExecSpace, uint32*& mcodes, int32 size, int32* iter )
 
 //------------------------------------------------------------------------------
 #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA) && \
-    defined(RAJA_ENABLE_CUDA)
+    defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_CUB)
 template < int BLOCK_SIZE >
 void custom_sort( spin::CUDA_EXEC< BLOCK_SIZE >,
                   uint32*& mcodes, int32 size, int32* iter )

--- a/src/cmake/AxomOptions.cmake
+++ b/src/cmake/AxomOptions.cmake
@@ -19,5 +19,7 @@ cmake_dependent_option(AXOM_ENABLE_TESTS "Enables Axom Tests" ON "ENABLE_TESTS" 
 cmake_dependent_option(AXOM_ENABLE_DOCS "Enables Axom Docs" ON "ENABLE_DOCS" OFF)
 cmake_dependent_option(AXOM_ENABLE_EXAMPLES "Enables Axom Examples" ON "ENABLE_EXAMPLES" OFF)
 
+cmake_dependent_option(AXOM_USE_CUB "Enables use of CUB" OFF "ENABLE_CUDA" OFF)
+
 cmake_dependent_option(AXOM_USE_MPI3 "Enables use of MPI-3 features" OFF "ENABLE_MPI" OFF)
 mark_as_advanced(AXOM_USE_MPI3)


### PR DESCRIPTION
# Summary

Allows to toggle use of CUB when Axom is compiled with CUDA.
By default CUB is disabled, but, it can be turned ON by setting
AXOM_USE_CUB, a CMake dependent option that is available when 
Axom is configured  with CUDA (i.e., ENABLE_CUDA=ON). 

This allows to disable CUB to circumvent issues encountered with
the device linker.

This PR resolves issue #88 