### PR TITLE
Fixes slam warnings on the intel compiler

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,6 +1,6 @@
 *******************************************************************************
 
-Axom: ................................, version 0.3.0
+Axom: ................................, version 0.3.1
 
 Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC. 
 Produced at the Lawrence Livermore National Laboratory.

--- a/src/axom/slam/OrderedSet.hpp
+++ b/src/axom/slam/OrderedSet.hpp
@@ -305,9 +305,10 @@ public:
     /// \{
 
     /// Convert from iterator type to const_iterator type
-    operator OrderedSetIterator<T, true>() const
+    template<typename U>
+    operator OrderedSetIterator<U, true>() const
     {
-      return OrderedSetIterator<T, true>(this->m_pos, this->m_orderedSet);
+      return OrderedSetIterator<U, true>(this->m_pos, this->m_orderedSet);
     }
     /// \}
 

--- a/src/axom/slam/examples/HandleMesh.cpp
+++ b/src/axom/slam/examples/HandleMesh.cpp
@@ -36,7 +36,7 @@ struct Handle
   Handle() : mID(T()) {}
   explicit Handle(T id) : mID(id) {}
   Handle(const Handle& h) : mID(h.mID) {}
-  bool operator==(const Handle& h) { return mID == h.mID; }
+  bool operator==(const Handle& h) const { return mID == h.mID; }
 
   static Handle make_handle(T id) { return Handle(id); }
 
@@ -94,6 +94,11 @@ int main(int, char**)
       "  " << i << ": " << hSet[i]
            << " -- double of index is: " << it->twiceIndex() );
   }
+
+  // Check equality
+  SLIC_INFO( "Checking equality of Handle elements: " );
+  SLIC_INFO("  hSet[0] == hSet[0] ? " << (hSet[0] == hSet[0] ? "yes" : "no"));
+  SLIC_INFO("  hSet[0] == hSet[1] ? " << (hSet[0] == hSet[1] ? "yes" : "no"));
 
   return 0;
 }


### PR DESCRIPTION
# Summary

This PR is a bugfix for some warnings on the intel compiler in the slam component.
It also updates Axom's version number in the ``RELEASE`` file, which was unintentionally not updated during the last release.

Thanks @white238 for bringing them to my attention!

