### PR TITLE
Fix failing Mint test with intel18 release build

### DIFF
--- a/src/axom/core/numerics/Matrix.hpp
+++ b/src/axom/core/numerics/Matrix.hpp
@@ -742,7 +742,9 @@ void Matrix< T >::swapColumns( IndexType icol, IndexType jcol )
   T* jcol_data = this->getColumn( jcol );
   for ( IndexType i=0 ; i < m_rows ; ++i )
   {
-    utilities::swap( icol_data[ i ], jcol_data[ i ] );
+    const T temp   = icol_data[ i ];
+    icol_data[ i ] = jcol_data[ i ];
+    jcol_data[ i ] = temp;
   }
 
 }

--- a/src/axom/mint/tests/mint_fem_single_fe.cpp
+++ b/src/axom/mint/tests/mint_fem_single_fe.cpp
@@ -819,7 +819,7 @@ void check_interp( double TOL=1.e-9 )
 //------------------------------------------------------------------------------
 TEST( mint_single_fe, check_override_max_newton )
 {
-  const int MAX_NEWTON = 42; // test value to override max newton
+  constexpr int MAX_NEWTON = 42; // test value to override max newton
 
   // STEP 0: construct a mesh with a single element
   mint::FiniteElement* fe = nullptr;
@@ -839,9 +839,9 @@ TEST( mint_single_fe, check_override_max_newton )
 TEST( mint_fem_single_fe, matrix_constructor_deepcopy )
 {
   // STEP 0: constants used in the test
-  const int NROWS = 2;
-  const int NCOLS = 3;
-  const int NSIZE = NROWS * NCOLS;
+  constexpr int NROWS = 2;
+  constexpr int NCOLS = 3;
+  constexpr int NSIZE = NROWS * NCOLS;
 
   // STEP 1: setup element coordinates matrix
   numerics::Matrix< double > M( NROWS, NCOLS );
@@ -880,9 +880,9 @@ TEST( mint_fem_single_fe, matrix_constructor_deepcopy )
 TEST( mint_fem_single_fe, matrix_constructor_shallowcopy)
 {
   // STEP 0: constants used in the test
-  const int NROWS = 2;
-  const int NCOLS = 3;
-  const int NSIZE = NROWS * NCOLS;
+  constexpr int NROWS = 2;
+  constexpr int NCOLS = 3;
+  constexpr int NSIZE = NROWS * NCOLS;
 
   // STEP 1: setup element coordinates matrix
   numerics::Matrix< double > M( 2, 3 );

--- a/src/axom/mint/tests/mint_fem_single_fe.cpp
+++ b/src/axom/mint/tests/mint_fem_single_fe.cpp
@@ -110,8 +110,8 @@ void get_single_fe( mint::FiniteElement*& fe )
 {
   EXPECT_TRUE( fe==nullptr );
 
-  typedef typename mint::FEBasis< BasisType,CELLTYPE > FEMType;
-  typedef typename FEMType::ShapeFunctionType ShapeFunctionType;
+  using FEMType           = typename mint::FEBasis< BasisType,CELLTYPE >;
+  using ShapeFunctionType = typename FEMType::ShapeFunctionType;
 
   const bool zero_copy = true;
   const double SCALE   = 10.0;
@@ -418,8 +418,8 @@ void check_shape( )
   SLIC_INFO( "checking " << mint::basis_name[ BasisType ] << " / "
                          << mint::getCellInfo( CELLTYPE ).name );
 
-  typedef typename mint::FEBasis< BasisType, CELLTYPE > FEMType;
-  typedef typename FEMType::ShapeFunctionType ShapeFunctionType;
+  using FEMType           = typename mint::FEBasis< BasisType, CELLTYPE >;
+  using ShapeFunctionType = typename FEMType::ShapeFunctionType;
 
   // STEP 0: construct finite element mesh
   mint::FiniteElement* fe = nullptr;


### PR DESCRIPTION
# Summary

This PR fixes a failing Mint test, `mint_fem_single_fe`. The test was failing due to a compiler bug, which is circumvented by the changes introduced in this PR. In addition, this PR introduces some minor stylistic changes to modernize some of the code in `mint_fem_single_fe` test to C++11.

This PR resolves #90 