### PR TITLE
Feature/capps2/sidre group save

### DIFF
--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -1249,10 +1249,14 @@ void Group::copyToConduitNode(Node& n) const
  *
  *************************************************************************
  */
-bool Group::isEquivalentTo(const Group* other) const
+bool Group::isEquivalentTo(const Group* other, bool checkName) const
 {
   // Equality of names
-  bool is_equiv = (m_name == other->m_name);
+  bool is_equiv = true;
+  if (checkName)
+  {
+    is_equiv = (m_name == other->m_name);
+  }
 
   // Sizes of collections of child items must be equal
   if (is_equiv)

--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -1906,34 +1906,24 @@ bool Group::exportTo(conduit::Node& result,
     {
       result.remove("views");
     }
-
   }
 
+  bool hasSavedGroups = false;
   if (getNumGroups() > 0)
   {
-    bool hasSavedGroups = false;
     Node & gnode = result["groups"];
     IndexType gidx = getFirstValidGroupIndex();
     while ( indexIsValid(gidx) )
     {
       const Group* group = getGroup(gidx);
       Node& n_group = gnode.fetch(group->getName());
-      if ( group->exportTo(n_group, attr, buffer_indices) )
-      {
-        hasSavedGroups = true;
-      }
-      else
-      {
-        gnode.remove(group->getName());
-      }
+      bool hsv = group->exportTo(n_group, attr, buffer_indices);
+      hasSavedViews = hasSavedViews || hsv;
+      hasSavedGroups = true;
 
       gidx = getNextValidGroupIndex(gidx);
     }
-    if (hasSavedGroups)
-    {
-      hasSavedViews = true;
-    }
-    else
+    if (!hasSavedGroups)
     {
       result.remove("groups");
     }

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -1118,6 +1118,10 @@ public:
    * Group hierarchy structures with the same names for all Views and
    * Groups in the hierarchy, and the Views are also equivalent.
    *
+   * \param other     The group to compare with
+   * \param checkName If true (default), groups must have the same name
+   *                  to be equivalent.  If false, disregard the name.
+   *
    * \sa View::isEquivalentTo()
    */
   bool isEquivalentTo(const Group* other, bool checkName = true) const;

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -1120,7 +1120,7 @@ public:
    *
    * \sa View::isEquivalentTo()
    */
-  bool isEquivalentTo(const Group* other) const;
+  bool isEquivalentTo(const Group* other, bool checkName = true) const;
 
 
 //@{

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -1220,6 +1220,7 @@ TEST(sidre_group,save_root_restore_as_child)
       cg->load(file_path, protocols[i]);
 
       EXPECT_TRUE(cg->isEquivalentTo(root, false));
+      EXPECT_TRUE(root->isEquivalentTo(cg, false));
     }
     else
     {


### PR DESCRIPTION
# Summary

- This PR fixes a design bug and adds a feature, both in `sidre::Group`
- It does the following:
  - Allows `Group::isEquivalentTo()` to optionally ignore the name of the group (issue #103 )
  - Causes `Group::save()` to not prune empty Groups (issue #102)

# Design review

On Sep 16 2019, the Axom group discussed several related issues with the Group class, saving, and loading.  The issues this PR addresses were covered in that discussion.