### PR TITLE
Don't change a group's name when loading.

### DIFF
--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -1374,9 +1374,17 @@ void Group::save(const std::string& path,
  *************************************************************************
  */
 void Group::load(const std::string& path,
-                 std::string & new_name,
                  const std::string& protocol,
                  bool preserve_contents)
+{
+  std::string new_name;
+  load(path, protocol, preserve_contents, new_name);
+}
+
+void Group::load(const std::string& path,
+                 const std::string& protocol,
+                 bool preserve_contents,
+                 std::string & name_from_file)
 {
   if (protocol == "sidre_hdf5")
   {
@@ -1388,7 +1396,7 @@ void Group::load(const std::string& path,
     importFrom(n["sidre"], preserve_contents);
     if (n.has_path("sidre_group_name"))
     {
-      new_name = n["sidre_group_name"].as_string();
+      name_from_file = n["sidre_group_name"].as_string();
     }
   }
   else if (protocol == "sidre_conduit_json")
@@ -1401,7 +1409,7 @@ void Group::load(const std::string& path,
     importFrom(n["sidre"], preserve_contents);
     if (n.has_path("sidre_group_name"))
     {
-      new_name = n["sidre_group_name"].as_string();
+      name_from_file = n["sidre_group_name"].as_string();
     }
   }
   else if (protocol == "sidre_json")
@@ -1414,7 +1422,7 @@ void Group::load(const std::string& path,
     importFrom(n["sidre"], preserve_contents);
     if (n.has_path("sidre_group_name"))
     {
-      new_name = n["sidre_group_name"].as_string();
+      name_from_file = n["sidre_group_name"].as_string();
     }
   }
   else if (protocol == "conduit_hdf5")
@@ -1424,7 +1432,7 @@ void Group::load(const std::string& path,
     importConduitTree(n, preserve_contents);
     if (n.has_path("sidre_group_name"))
     {
-      new_name = n["sidre_group_name"].as_string();
+      name_from_file = n["sidre_group_name"].as_string();
     }
   }
   else if (protocol == "conduit_bin"  ||
@@ -1436,7 +1444,7 @@ void Group::load(const std::string& path,
     importConduitTree(n, preserve_contents);
     if (n.has_path("sidre_group_name"))
     {
-      new_name = n["sidre_group_name"].as_string();
+      name_from_file = n["sidre_group_name"].as_string();
     }
   }
   else
@@ -1452,21 +1460,20 @@ void Group::load(const std::string& path,
  *
  *************************************************************************
  */
-Group* Group::loadChild(const std::string& path,
-                        std::string & new_name,
-                        const std::string& protocol,
-                        bool preserve_contents)
+Group* Group::createAndLoad(std::string & group_name,
+                            const std::string& path,
+                            const std::string& protocol,
+                            bool & load_success)
 {
-  std::string tempname = getUniqueGroupName(new_name);
-  Group * child = createGroup(tempname);
-  child->load(path, new_name, protocol, preserve_contents);
-
-  if (!new_name.empty())
+  load_success = false;
+  Group * child = createGroup(group_name);
+  if (child != nullptr)
   {
-    tempname = getUniqueGroupName(new_name);
-    child->rename(tempname);
+    // In a forthcoming PR, load() will return a bool for success/failure
+    load_success = true;
+    child->load(path, protocol, false, group_name);
   }
-
+  
   return child;
 }
 
@@ -1565,9 +1572,17 @@ void Group::save(const hid_t& h5_id,
  *************************************************************************
  */
 void Group::load(const hid_t& h5_id,
-                 std::string & new_name,
                  const std::string &protocol,
                  bool preserve_contents)
+{
+  std::string name_from_file;
+  load(h5_id, protocol, preserve_contents, name_from_file);
+}
+
+void Group::load(const hid_t& h5_id,
+                 const std::string &protocol,
+                 bool preserve_contents,
+                 std::string & name_from_file)
 {
   // supported here:
   // "sidre_hdf5"
@@ -1582,7 +1597,7 @@ void Group::load(const hid_t& h5_id,
     importFrom(n["sidre"], preserve_contents);
     if (n.has_path("sidre_group_name"))
     {
-      new_name = n["sidre_group_name"].as_string();
+      name_from_file = n["sidre_group_name"].as_string();
     }
   }
   else if( protocol == "conduit_hdf5")
@@ -1593,7 +1608,7 @@ void Group::load(const hid_t& h5_id,
     importConduitTree(n, preserve_contents);
     if (n.has_path("sidre_group_name"))
     {
-      new_name = n["sidre_group_name"].as_string();
+      name_from_file = n["sidre_group_name"].as_string();
     }
   }
   else

--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -1460,10 +1460,10 @@ void Group::load(const std::string& path,
  *
  *************************************************************************
  */
-Group* Group::createAndLoad(std::string & group_name,
-                            const std::string& path,
-                            const std::string& protocol,
-                            bool & load_success)
+Group* Group::createGroupAndLoad(std::string & group_name,
+                                 const std::string& path,
+                                 const std::string& protocol,
+                                 bool & load_success)
 {
   load_success = false;
   Group * child = createGroup(group_name);

--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -1481,27 +1481,6 @@ Group* Group::createAndLoad(std::string & group_name,
 /*
  *************************************************************************
  *
- * Find a valid (unique) name for a new group
- *
- *************************************************************************
- */
-std::string Group::getUniqueGroupName(const std::string & basename) const
-{
-  int counter = 0;
-  std::string name = basename;
-  while (hasGroup(name))
-  {
-    name = basename + std::to_string(counter);
-    counter += 1;
-  }
-
-  return name;
-}
-
-
-/*
- *************************************************************************
- *
  * Load External Data from a file
  *
  *************************************************************************

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -1209,7 +1209,7 @@ public:
    * - create a group with name or path group_name
    * - load a Group hierarchy from a file into the newly-created Group
    * - return the newly created Group, or nullptr if creation failed
-   * - in out-parameters, return
+   * - out-parameters return:
    *   - the group name from the file
    *   - a flag indicating success reading the file
    *

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -1179,6 +1179,10 @@ public:
   /*!
    * \brief Load a Group hierarchy from a file into this Group
    *
+   * This method instantiates the Group hierarchy and its Views stored
+   * in the file under this Group.  The name of this Group is not
+   * changed.
+   *
    * \param path     file path
    * \param protocol I/O protocol
    * \param preserve_contents   Preserve existing contents of group if true
@@ -1190,6 +1194,11 @@ public:
   /*!
    * \brief Load a Group hierarchy from a file into this Group, reporting
    *        the Group name stored in the file
+   *
+   * This method instantiates the Group hierarchy and its Views stored
+   * in the file under this Group.  The name of this Group is not
+   * changed.  The calling code may optionally rename this Group with
+   * the string returned in group_name.
    *
    * \param [in]  path     file path to load
    * \param [in]  protocol I/O protocol to use
@@ -1551,12 +1560,6 @@ private:
    *  it. Otherwise return the ID of the default allocator of the owning group.
    */
   int getValidAllocatorID( int allocatorID );
-
-  /*!
-   * \brief Const private method that returns a string that would be valid
-   * to use for a new group name.  Adds a suffix to basename if necessary.
-   */
-  std::string getUniqueGroupName(const std::string & basename) const;
 
   /// Name of this Group object.
   std::string m_name;

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -1179,13 +1179,38 @@ public:
   /*!
    * \brief Load the Group from a file.
    *
-   * \param path      file path
-   * \param protocol  I/O protocol
+   * \param path     file path
+   * \param new_name the group name stored in the file
+   * \param protocol I/O protocol
    * \param preserve_contents   Preserve existing contents of group if true
    */
   void load(const std::string& path,
+            std::string & new_name,
             const std::string& protocol = SIDRE_DEFAULT_PROTOCOL,
             bool preserve_contents = false);
+
+  /*!
+   * \brief Load a file into a new child group.
+   *
+   * This is a convenience routine for the following sequence:
+   * - create a group
+   * - load a file into the newly-created group
+   * - rename the group with the name stored in the file (or if blank,
+   *   the contents of new_name).  If necessary, ensure new name is unique
+   *   by adding a suffix.
+   * - return the group name from the file in parameter new_name
+   *
+   * \param path     file path
+   * \param new_name In: name for the new group if the file's stored group
+   *                 name is the empty string.
+   *                 Out: the group name stored in the file
+   * \param protocol I/O protocol
+   * \param preserve_contents   Preserve existing contents of group if true
+   */
+  Group* loadChild(const std::string& path,
+                   std::string & new_name,
+                   const std::string& protocol = SIDRE_DEFAULT_PROTOCOL,
+                   bool preserve_contents = false);
 
   /*!
    * \brief Load data into the Group's external views from a file.
@@ -1217,10 +1242,12 @@ public:
   /*!
    * \brief Load the Group from an hdf5 handle.
    * \param h5_id      hdf5 handle
+   * \param new_name   the group name stored in the file
    * \param protocol   I/O protocol sidre_hdf5 or conduit_hdf5
    * \param preserve_contents   Preserve existing contents of group if true
    */
   void load( const hid_t& h5_id,
+             std::string & new_name,
              const std::string &protocol = SIDRE_DEFAULT_PROTOCOL,
              bool preserve_contents = false);
 
@@ -1487,20 +1514,16 @@ private:
   const Group* walkPath(std::string& path ) const;
 
   /*!
-   * \brief Private method to rename this Group if possible, give warning if
-   * not.
-   *
-   * If the parent group already holds a Group or View with the new name,
-   * a warning will be given and the name will not be changed.  Otherwise
-   * the name will be changed to the new name.
-   */
-  void renameOrWarn(const std::string& new_name);
-
-  /*!
    * \brief Private method. If allocatorID is a valid allocator ID then return
    *  it. Otherwise return the ID of the default allocator of the owning group.
    */
   int getValidAllocatorID( int allocatorID );
+
+  /*!
+   * \brief Const private method that returns a string that would be valid
+   * to use for a new group name.  Adds a suffix to basename if necessary.
+   */
+  std::string getUniqueGroupName(const std::string & basename) const;
 
   /// Name of this Group object.
   std::string m_name;

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -1183,9 +1183,16 @@ public:
    * in the file under this Group.  The name of this Group is not
    * changed.
    *
+   * If preserve_contents is true, then the names of the children held by the
+   * Node cannot be the same as the names of the children already held by this
+   * Group.  If there is a naming conflict, an error will occur.
+   *
    * \param path     file path
    * \param protocol I/O protocol
-   * \param preserve_contents   Preserve existing contents of group if true
+   * \param preserve_contents  If true, any child Groups and Views held by
+   *                           this Group remain in place.  If false, all
+   *                           child Groups and Views are destroyed before
+   *                           loading data from the file.
    */
   void load(const std::string& path,
             const std::string& protocol = SIDRE_DEFAULT_PROTOCOL,
@@ -1197,12 +1204,20 @@ public:
    *
    * This method instantiates the Group hierarchy and its Views stored
    * in the file under this Group.  The name of this Group is not
-   * changed.  The calling code may optionally rename this Group with
-   * the string returned in group_name.
+   * changed.  The name of the group stored in the file is returned in
+   * the output parameter name_from_file.  This can be used to rename the
+   * group in a subsequent call.
+   *
+   * If preserve_contents is true, then the names of the children held by the
+   * Node cannot be the same as the names of the children already held by this
+   * Group.  If there is a naming conflict, an error will occur.
    *
    * \param [in]  path     file path to load
    * \param [in]  protocol I/O protocol to use
-   * \param [in]  preserve_contents Preserve existing contents of group if true
+   * \param [in]  preserve_contents  If true, any child Groups and Views
+   *                           held by this Group remain in place.
+   *                           If false, all child Groups and Views are
+   *                           destroyed before loading data from the file.
    * \param [out] name_from_file    Group name stored in the file
    */
   void load(const std::string& path,
@@ -1226,7 +1241,7 @@ public:
    * already exists a child Group with that name or path, the child Group
    * will not be created and this method will return nullptr.
    *
-   * As with the load() method, after calling createAndLoad() a host
+   * As with the load() method, after calling createGroupAndLoad() a host
    * code may choose to rename the newly-created Group with the string
    * returned in group_name.
    *
@@ -1234,15 +1249,15 @@ public:
    *                               Out: the group name stored in the file.
    * \param [in]     path          file path
    * \param [in]     protocol      I/O protocol
-   * \param [out]    load_success  Preserve existing contents of group if true
+   * \param [out]    load_success  Report success of the load operation
    *
    * \return pointer to created Group object or nullptr if new
    *         Group is not created.
    */
-  Group* createAndLoad(std::string & group_name,
-                       const std::string& path,
-                       const std::string& protocol,
-                       bool & load_success);
+  Group* createGroupAndLoad(std::string & group_name,
+                            const std::string& path,
+                            const std::string& protocol,
+                            bool & load_success);
 
   /*!
    * \brief Load data into the Group's external views from a file.
@@ -1273,9 +1288,17 @@ public:
 
   /*!
    * \brief Load the Group from an hdf5 handle.
+   *
+   * If preserve_contents is true, then the names of the children held by the
+   * Node cannot be the same as the names of the children already held by this
+   * Group.  If there is a naming conflict, an error will occur.
+   *
    * \param h5_id      hdf5 handle
    * \param protocol   I/O protocol sidre_hdf5 or conduit_hdf5
-   * \param preserve_contents   Preserve existing contents of group if true
+   * \param preserve_contents  If true, any child Groups and Views held by
+   *                           this Group remain in place.  If false, all
+   *                           child Groups and Views are destroyed before
+   *                           loading data from the file.
    */
   void load( const hid_t& h5_id,
              const std::string &protocol = SIDRE_DEFAULT_PROTOCOL,
@@ -1283,9 +1306,17 @@ public:
 
   /*!
    * \brief Load the Group from an hdf5 handle.
+   *
+   * If preserve_contents is true, then the names of the children held by the
+   * Node cannot be the same as the names of the children already held by this
+   * Group.  If there is a naming conflict, an error will occur.
+   *
    * \param [in]  h5_id      hdf5 handle
    * \param [in]  protocol   I/O protocol sidre_hdf5 or conduit_hdf5
-   * \param [in]  preserve_contents Preserve existing contents of group if true
+   * \param [in]  preserve_contents  If true, any child Groups and Views held by
+   *                           this Group remain in place.  If false, all
+   *                           child Groups and Views are destroyed before
+   *                           loading data from the file.
    * \param [out] name_from_file    Group name stored in the file
    */
   void load( const hid_t& h5_id,

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -1177,40 +1177,63 @@ public:
              const Attribute* attr = nullptr) const;
 
   /*!
-   * \brief Load the Group from a file.
+   * \brief Load a Group hierarchy from a file into this Group
    *
    * \param path     file path
-   * \param new_name the group name stored in the file
    * \param protocol I/O protocol
    * \param preserve_contents   Preserve existing contents of group if true
    */
   void load(const std::string& path,
-            std::string & new_name,
             const std::string& protocol = SIDRE_DEFAULT_PROTOCOL,
             bool preserve_contents = false);
 
   /*!
-   * \brief Load a file into a new child group.
+   * \brief Load a Group hierarchy from a file into this Group, reporting
+   *        the Group name stored in the file
+   *
+   * \param [in]  path     file path to load
+   * \param [in]  protocol I/O protocol to use
+   * \param [in]  preserve_contents Preserve existing contents of group if true
+   * \param [out] name_from_file    Group name stored in the file
+   */
+  void load(const std::string& path,
+            const std::string& protocol,  
+            bool preserve_contents,
+            std::string & name_from_file);
+
+  /*!
+   * \brief Create a child Group and load a Group hierarchy from file
+   *        into the new Group.
    *
    * This is a convenience routine for the following sequence:
-   * - create a group
-   * - load a file into the newly-created group
-   * - rename the group with the name stored in the file (or if blank,
-   *   the contents of new_name).  If necessary, ensure new name is unique
-   *   by adding a suffix.
-   * - return the group name from the file in parameter new_name
+   * - create a group with name or path group_name
+   * - load a Group hierarchy from a file into the newly-created Group
+   * - return the newly created Group, or nullptr if creation failed
+   * - in out-parameters, return
+   *   - the group name from the file
+   *   - a flag indicating success reading the file
    *
-   * \param path     file path
-   * \param new_name In: name for the new group if the file's stored group
-   *                 name is the empty string.
-   *                 Out: the group name stored in the file
-   * \param protocol I/O protocol
-   * \param preserve_contents   Preserve existing contents of group if true
+   * As with the createGroup() method, if group_name is empty or there
+   * already exists a child Group with that name or path, the child Group
+   * will not be created and this method will return nullptr.
+   *
+   * As with the load() method, after calling createAndLoad() a host
+   * code may choose to rename the newly-created Group with the string
+   * returned in group_name.
+   *
+   * \param [in,out] group_name    In: name for the new group.
+   *                               Out: the group name stored in the file.
+   * \param [in]     path          file path
+   * \param [in]     protocol      I/O protocol
+   * \param [out]    load_success  Preserve existing contents of group if true
+   *
+   * \return pointer to created Group object or nullptr if new
+   *         Group is not created.
    */
-  Group* loadChild(const std::string& path,
-                   std::string & new_name,
-                   const std::string& protocol = SIDRE_DEFAULT_PROTOCOL,
-                   bool preserve_contents = false);
+  Group* createAndLoad(std::string & group_name,
+                       const std::string& path,
+                       const std::string& protocol,
+                       bool & load_success);
 
   /*!
    * \brief Load data into the Group's external views from a file.
@@ -1242,14 +1265,24 @@ public:
   /*!
    * \brief Load the Group from an hdf5 handle.
    * \param h5_id      hdf5 handle
-   * \param new_name   the group name stored in the file
    * \param protocol   I/O protocol sidre_hdf5 or conduit_hdf5
    * \param preserve_contents   Preserve existing contents of group if true
    */
   void load( const hid_t& h5_id,
-             std::string & new_name,
              const std::string &protocol = SIDRE_DEFAULT_PROTOCOL,
              bool preserve_contents = false);
+
+  /*!
+   * \brief Load the Group from an hdf5 handle.
+   * \param [in]  h5_id      hdf5 handle
+   * \param [in]  protocol   I/O protocol sidre_hdf5 or conduit_hdf5
+   * \param [in]  preserve_contents Preserve existing contents of group if true
+   * \param [out] name_from_file    Group name stored in the file
+   */
+  void load( const hid_t& h5_id,
+             const std::string &protocol,
+             bool preserve_contents,
+             std::string & name_from_file );
 
   /*!
    * \brief Load data into the Group's external views from a hdf5 handle.

--- a/src/axom/sidre/examples/sidre_createdatastore.cpp
+++ b/src/axom/sidre/examples/sidre_createdatastore.cpp
@@ -640,12 +640,13 @@ void serial_save_datastore_and_load_copy_lower(DataStore* ds)
   // saving all Views
   ds->getRoot()->save("example.hdf5");
   // Delete the data hierarchy under the root, then load it from the file
-  ds->getRoot()->load("example.hdf5");
+  std::string groupname;
+  ds->getRoot()->load("example.hdf5", groupname);
   Group* additional = ds->getRoot()->createGroup("additional");
   additional->createGroup("yetanother");
   // Load another copy of the data store into the "additional" group
   // without first clearing all its contents
-  additional->load("example.hdf5", "sidre_hdf5", true);
+  additional->load("example.hdf5", groupname, "sidre_hdf5", true);
   // _serial_io_save_end
 }
 

--- a/src/axom/sidre/examples/sidre_createdatastore.cpp
+++ b/src/axom/sidre/examples/sidre_createdatastore.cpp
@@ -640,13 +640,13 @@ void serial_save_datastore_and_load_copy_lower(DataStore* ds)
   // saving all Views
   ds->getRoot()->save("example.hdf5");
   // Delete the data hierarchy under the root, then load it from the file
-  std::string groupname;
-  ds->getRoot()->load("example.hdf5", groupname);
+  ds->getRoot()->load("example.hdf5");
   Group* additional = ds->getRoot()->createGroup("additional");
   additional->createGroup("yetanother");
   // Load another copy of the data store into the "additional" group
   // without first clearing all its contents
-  additional->load("example.hdf5", groupname, "sidre_hdf5", true);
+  std::string groupname;
+  additional->load("example.hdf5", "sidre_hdf5", true, groupname);
   // _serial_io_save_end
 }
 

--- a/src/axom/sidre/tests/sidre_attribute.cpp
+++ b/src/axom/sidre/tests/sidre_attribute.cpp
@@ -723,7 +723,6 @@ TEST(sidre_attribute,save_attributes)
   delete ds1;
 
   //----------------------------------------
-  std::string groupname;
   for (int i = 0 ; i < g_nprotocols ; ++i)
   {
     // Only restore sidre_hdf5 protocol
@@ -737,7 +736,7 @@ TEST(sidre_attribute,save_attributes)
     DataStore* ds2 = new DataStore();
     Group* root2 = ds2->getRoot();
 
-    root2->load(file_path, groupname, g_protocols[i]);
+    root2->load(file_path, g_protocols[i]);
     EXPECT_EQ(3, ds2->getNumAttributes());
 
     // Check available attributes
@@ -852,7 +851,6 @@ TEST(sidre_attribute,save_by_attribute)
   delete ds1;
 
   //----------------------------------------
-  std::string groupname;
   for (int i = 0 ; i < g_nprotocols ; ++i)
   {
     // Only restore sidre_hdf5 protocol
@@ -866,7 +864,7 @@ TEST(sidre_attribute,save_by_attribute)
     DataStore* ds2 = new DataStore();
     Group* root2 = ds2->getRoot();
 
-    root2->load(file_path, groupname, g_protocols[i]);
+    root2->load(file_path, g_protocols[i]);
 
     // Only views with the dump attribute should exist.
 

--- a/src/axom/sidre/tests/sidre_attribute.cpp
+++ b/src/axom/sidre/tests/sidre_attribute.cpp
@@ -723,6 +723,7 @@ TEST(sidre_attribute,save_attributes)
   delete ds1;
 
   //----------------------------------------
+  std::string groupname;
   for (int i = 0 ; i < g_nprotocols ; ++i)
   {
     // Only restore sidre_hdf5 protocol
@@ -736,7 +737,7 @@ TEST(sidre_attribute,save_attributes)
     DataStore* ds2 = new DataStore();
     Group* root2 = ds2->getRoot();
 
-    root2->load(file_path, g_protocols[i]);
+    root2->load(file_path, groupname, g_protocols[i]);
     EXPECT_EQ(3, ds2->getNumAttributes());
 
     // Check available attributes
@@ -851,6 +852,7 @@ TEST(sidre_attribute,save_by_attribute)
   delete ds1;
 
   //----------------------------------------
+  std::string groupname;
   for (int i = 0 ; i < g_nprotocols ; ++i)
   {
     // Only restore sidre_hdf5 protocol
@@ -864,7 +866,7 @@ TEST(sidre_attribute,save_by_attribute)
     DataStore* ds2 = new DataStore();
     Group* root2 = ds2->getRoot();
 
-    root2->load(file_path, g_protocols[i]);
+    root2->load(file_path, groupname, g_protocols[i]);
 
     // Only views with the dump attribute should exist.
 

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -1383,7 +1383,8 @@ TEST(sidre_group,save_restore_api)
   std::string groupname = newgroupname;
   bool loadSuccess = false;
   Group * load3 =
-    load2->createAndLoad(groupname, "sidre_save_subtree_sidre_json", "sidre_json", loadSuccess);
+    load2->createGroupAndLoad(groupname, "sidre_save_subtree_sidre_json",
+                              "sidre_json", loadSuccess);
 
   EXPECT_NE(load3, (Group*)nullptr);
   EXPECT_TRUE(loadSuccess);
@@ -1398,7 +1399,8 @@ TEST(sidre_group,save_restore_api)
   groupname = anothergroupname;
   loadSuccess = false;
   Group * load4 =
-    load2->createAndLoad(groupname, "sidre_save_subtree_sidre_json", "sidre_json", loadSuccess);
+    load2->createGroupAndLoad(groupname, "sidre_save_subtree_sidre_json",
+                              "sidre_json", loadSuccess);
 
   EXPECT_NE(load4, (Group*)nullptr);
   EXPECT_TRUE(loadSuccess);
@@ -1411,7 +1413,8 @@ TEST(sidre_group,save_restore_api)
   groupname = anothergroupname;
   loadSuccess = false;
   Group * load5 =
-    load2->createAndLoad(groupname, "sidre_save_subtree_sidre_json", "sidre_json", loadSuccess);
+    load2->createGroupAndLoad(groupname, "sidre_save_subtree_sidre_json",
+                              "sidre_json", loadSuccess);
   EXPECT_EQ(load5, (Group*)nullptr);
   EXPECT_FALSE(loadSuccess);
 

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -1096,8 +1096,8 @@ TEST(sidre_group,save_restore_empty_datastore)
 
     DataStore* ds2 = new DataStore();
     Group* root2 = ds2->getRoot();
-
-    root2->load(file_path, protocols[i]);
+    std::string groupname;
+    root2->load(file_path, groupname, protocols[i]);
 
     EXPECT_TRUE(ds2->getNumBuffers() == 0 );
     EXPECT_TRUE(root2->getNumGroups() == 0 );
@@ -1131,8 +1131,9 @@ TEST(sidre_group,save_load_via_hdf5_ids)
 
   // load via path based
   DataStore ds_load_generic;
-  ds_load_generic.getRoot()->load("out_save_load_via_hdf5_ids.sidre_hdf5",
-                                  "sidre_hdf5");
+  std::string groupname;
+  ds_load_generic.getRoot()->load("out_save_load_via_hdf5_ids.sidre_hdf5", 
+                                  groupname, "sidre_hdf5");
 
   // load via hdf5 id
   DataStore ds_load_hdf5;
@@ -1143,7 +1144,7 @@ TEST(sidre_group,save_load_via_hdf5_ids)
   EXPECT_TRUE(h5_id >= 0);
 
   // this implies protocol == "sidre_hdf5"
-  ds_load_hdf5.getRoot()->load(h5_id);
+  ds_load_hdf5.getRoot()->load(h5_id, groupname);
 
   // ? Does isEquivalentTo check values?
   // check path based with source
@@ -1198,6 +1199,7 @@ TEST(sidre_group,save_root_restore_as_child)
   }
 
   // Restore the original DataStore into a child group
+  std::string groupname;
   for (int i = 0; i < nprotocols; ++i)
   {
     // Only restore sidre_hdf5 protocol
@@ -1217,7 +1219,7 @@ TEST(sidre_group,save_root_restore_as_child)
     if (axom::utilities::filesystem::pathExists(file_path))
     {
       std::cout << "loading " << file_path << std::endl;
-      cg->load(file_path, protocols[i]);
+      cg->load(file_path, groupname, protocols[i]);
 
       EXPECT_TRUE(cg->isEquivalentTo(root, false));
       EXPECT_TRUE(root->isEquivalentTo(cg, false));
@@ -1283,6 +1285,7 @@ TEST(sidre_group,save_child_restore_as_root)
   }
 
   // Restore the saved child1 into a root group
+  std::string groupname;
   for (int i = 0; i < nprotocols; ++i)
   {
     // Only restore sidre_hdf5 protocol
@@ -1295,7 +1298,7 @@ TEST(sidre_group,save_child_restore_as_root)
     const std::string file_path = file_path_base + protocols[i];
     if (axom::utilities::filesystem::pathExists(file_path))
     {
-      dscopy->getRoot()->load(file_path, protocols[i]);
+      dscopy->getRoot()->load(file_path, groupname, protocols[i]);
 
       EXPECT_TRUE(dscopy->getRoot()->isEquivalentTo(child1, false));
       EXPECT_TRUE(child1->isEquivalentTo(dscopy->getRoot(), false));
@@ -1318,6 +1321,7 @@ TEST(sidre_group,save_restore_api)
   const std::string file_path_base("sidre_save_subtree_");
   DataStore* ds1 = new DataStore();
   Group* root1 = ds1->getRoot();
+  std::string groupname;
 
   root1->createViewScalar<int>("i0", 1);
 
@@ -1339,13 +1343,13 @@ TEST(sidre_group,save_restore_api)
 #if 0
   DataStore* ds2 = new DataStore();
   Group* root2 = ds2->getRoot();
-  root2->load("sidre_save_fulltree_conduit", "json");
+  root2->load("sidre_save_fulltree_conduit", groupname, "json");
   EXPECT_TRUE( ds2->getRoot()->isEquivalentTo(root1) );
   delete ds2;
 
   DataStore* ds3 = new DataStore();
   Group* root3 = ds3->getRoot();
-  root3->load("sidre_save_subtree_sidre_json", "sidre_json");
+  root3->load("sidre_save_subtree_sidre_json", groupname, "sidre_json");
   EXPECT_TRUE( ds3->getRoot()->isEquivalentTo(root1) );
   delete ds3;
 #endif
@@ -1353,7 +1357,7 @@ TEST(sidre_group,save_restore_api)
 #ifdef AXOM_USE_HDF5
   DataStore* ds4 = new DataStore();
   Group* root4 = ds4->getRoot();
-  root4->load("sidre_save_subtree_sidre_hdf5", "sidre_hdf5");
+  root4->load("sidre_save_subtree_sidre_hdf5", groupname, "sidre_hdf5");
   EXPECT_TRUE( ds4->getRoot()->isEquivalentTo(root1) );
   delete ds4;
 #endif
@@ -1361,7 +1365,7 @@ TEST(sidre_group,save_restore_api)
 #if 0
   DataStore* ds5 = new DataStore();
   Group* root5 = ds5->getRoot();
-  root5->load("sidre_save_subtree_json", "json");
+  root5->load("sidre_save_subtree_json", groupname, "json");
   EXPECT_TRUE( ds5->getRoot()->isEquivalentTo(root1) );
   delete ds5;
 #endif
@@ -1375,10 +1379,32 @@ TEST(sidre_group,save_restore_api)
   Group* load1 = tree1->createGroup("subtree");
   Group* load2 = tree2->createGroup("subtree");
 
-  load1->load("sidre_save_subtree_sidre_json", "sidre_json");
-  load2->load("sidre_save_subtree_sidre_json", "sidre_json");
+  load1->load("sidre_save_subtree_sidre_json", groupname, "sidre_json");
+  load2->load("sidre_save_subtree_sidre_json", groupname, "sidre_json");
 
   EXPECT_TRUE( load1->isEquivalentTo( load2) );
+
+  std::string newgroupname = "in case of blank";
+  groupname = newgroupname;
+  Group * load3 =
+    load2->loadChild("sidre_save_subtree_sidre_json", groupname, "sidre_json");
+
+  EXPECT_EQ(newgroupname, load3->getName());
+  EXPECT_EQ(groupname, "");
+  EXPECT_TRUE( load1->isEquivalentTo( load3, false ) );
+
+  groupname = newgroupname;
+  Group * load4 =
+    load2->loadChild("sidre_save_subtree_sidre_json", groupname, "sidre_json");
+
+  EXPECT_TRUE( load3->isEquivalentTo( load4, false ) );
+  // the name of load3 name should be a prefix of the name of load4.
+  std::string load3name = load3->getName();
+  std::string load4name = load4->getName();
+  auto res =
+    std::mismatch(load3name.begin(), load3name.end(), load4name.begin());
+  bool nameIsPrefix = (res.first == load3name.end());
+  EXPECT_TRUE(nameIsPrefix);
 
   delete ds_new;
 }
@@ -1403,6 +1429,7 @@ TEST(sidre_group,save_restore_scalars_and_strings)
     root1->save(file_path, protocols[i]);
   }
 
+  std::string groupname;
   for (int i = 0 ; i < nprotocols ; ++i)
   {
     // Only restore sidre_hdf5 protocol
@@ -1416,7 +1443,7 @@ TEST(sidre_group,save_restore_scalars_and_strings)
     DataStore* ds2 = new DataStore();
     Group* root2 = ds2->getRoot();
 
-    root2->load(file_path, protocols[i]);
+    root2->load(file_path, groupname, protocols[i]);
 
     EXPECT_TRUE( root1->isEquivalentTo( root2 ));
 
@@ -1501,7 +1528,7 @@ TEST(sidre_group,save_restore_name_change)
     child1->save(file_path, protocols[i]);
   }
 
-
+  std::string groupname;
   for (int i = 0 ; i < nprotocols ; ++i)
   {
     // Only restore sidre_hdf5 protocol
@@ -1518,9 +1545,11 @@ TEST(sidre_group,save_restore_name_change)
 
     EXPECT_EQ( child2->getName(), "child2" );
 
-    child2->load(file_path, protocols[i]);
+    child2->load(file_path, groupname, protocols[i]);
 
-    EXPECT_EQ( child2->getName(), "child1" );
+    EXPECT_EQ( child2->getName(), "child2" );
+
+    child2->rename(groupname);
 
     EXPECT_TRUE( root1->isEquivalentTo( root2 ) );
 
@@ -1578,6 +1607,7 @@ TEST(sidre_group,save_restore_external_data)
   delete ds1;
 
   // Now load back in.
+  std::string groupname;
   for (int i = 0 ; i < nprotocols ; ++i)
   {
     // Only restore sidre_hdf5 protocol
@@ -1593,7 +1623,7 @@ TEST(sidre_group,save_restore_external_data)
     DataStore* ds2 = new DataStore();
     Group* root2 = ds2->getRoot();
 
-    root2->load(file_path, protocols[i]);
+    root2->load(file_path, groupname, protocols[i]);
 
     // load has set the type and size of the view.
     // Now set the external address before calling loadExternal.
@@ -1791,6 +1821,7 @@ TEST(sidre_group,save_restore_buffer)
   }
 
   // Now load back in.
+  std::string groupname;
   for (int i = 0 ; i < nprotocols ; ++i)
   {
     // Only restore sidre_hdf5 protocol
@@ -1804,7 +1835,7 @@ TEST(sidre_group,save_restore_buffer)
     DataStore* ds2 = new DataStore();
     Group* root2 = ds2->getRoot();
 
-    root2->load(file_path, protocols[i]);
+    root2->load(file_path, groupname, protocols[i]);
 
     bool isequivalent = root1->isEquivalentTo(root2);
     EXPECT_TRUE( isequivalent );
@@ -1854,6 +1885,7 @@ TEST(sidre_group,save_restore_other)
   delete ds1;
 
   // Now load back in.
+  std::string groupname;
   for (int i = 0 ; i < nprotocols ; ++i)
   {
     // Only restore sidre_hdf5 protocol
@@ -1869,7 +1901,7 @@ TEST(sidre_group,save_restore_other)
     DataStore* ds2 = new DataStore();
     Group* root2 = ds2->getRoot();
 
-    root2->load(file_path, protocols[i]);
+    root2->load(file_path, groupname, protocols[i]);
 
     View* view1 = root2->getView("empty_view");
     EXPECT_TRUE(view1->isEmpty());
@@ -1936,6 +1968,7 @@ TEST(sidre_group,save_restore_complex)
     ds1->getRoot()->save(file_path, protocols[i]);
   }
 
+  std::string groupname;
   for (int i = 0 ; i < nprotocols ; ++i)
   {
     // Only restore sidre_hdf5 protocol
@@ -1948,7 +1981,8 @@ TEST(sidre_group,save_restore_complex)
 
     DataStore* ds2 = new DataStore();
 
-    ds2->getRoot()->load(file_path, protocols[i]);
+    std::string groupname;
+    ds2->getRoot()->load(file_path, groupname, protocols[i]);
 
     EXPECT_TRUE( ds1->getRoot()->isEquivalentTo(ds2->getRoot()) );
 
@@ -2071,6 +2105,7 @@ TEST(sidre_group,save_load_all_protocols)
   // test all protocols
   //
   std::vector<std::string> protocols = getAvailableSidreProtocols();
+  std::string groupname;
   for (size_t i = 0 ; i < protocols.size() ; ++i)
   {
     SLIC_INFO("Testing protocol: " << protocols[i]);
@@ -2079,7 +2114,8 @@ TEST(sidre_group,save_load_all_protocols)
     ds.getRoot()->save(file_path, protocols[i]);
 
     DataStore ds_load;
-    ds_load.getRoot()->load(file_path, protocols[i]);
+    std::string groupname;
+    ds_load.getRoot()->load(file_path, groupname, protocols[i]);
 
     SLIC_INFO("Tree from protocol: " <<  protocols[i]);
     // show the result
@@ -2138,6 +2174,7 @@ TEST(sidre_group,save_load_preserve_contents)
   }
 
   std::vector<std::string> protocols = getAvailableSidreProtocols();
+  std::string groupname;
   for(size_t i = 0 ; i < protocols.size() ; ++i)
   {
     std::string& protocol = protocols[i];
@@ -2170,8 +2207,9 @@ TEST(sidre_group,save_load_preserve_contents)
 
     DataStore ds_load;
     Group* loadtree0 = ds_load.getRoot()->createGroup("tree0");
-    loadtree0->load(file_path0, protocol);
-    loadtree0->load(file_path1, protocol, true);
+    loadtree0->load(file_path0, groupname, protocol);
+    loadtree0->load(file_path1, groupname, protocol, true);
+    loadtree0->rename(groupname);
 
     SLIC_INFO("Tree from protocol: " << protocol);
     // show the result


### PR DESCRIPTION
# Summary

- This PR changes the design of Group, such that load() no longer changes the group name, but instead returns the group name stored in the loaded file using an out-parameter.
- It also adds a convenience function loadChild() to load create a child Group, load it from the specified file, and name it the name stored in the file. 
- This PR comes from issues discussed at the Axom group meeting on 16 September 2019
- This PR addresses issue #99 
