### PR TITLE
Lumberjack tweaks

### DIFF
--- a/src/axom/lumberjack/MPIUtility.cpp
+++ b/src/axom/lumberjack/MPIUtility.cpp
@@ -22,7 +22,7 @@ namespace axom
 namespace lumberjack
 {
 
-const int LJ_TAG = 55432;
+constexpr int LJ_TAG = 55432;
 
 const char* mpiBlockingReceiveMessages(MPI_Comm comm)
 {

--- a/src/axom/lumberjack/MPIUtility.cpp
+++ b/src/axom/lumberjack/MPIUtility.cpp
@@ -22,6 +22,8 @@ namespace axom
 namespace lumberjack
 {
 
+const int LJ_TAG = 55432;
+
 const char* mpiBlockingReceiveMessages(MPI_Comm comm)
 {
   char* charArray = nullptr;
@@ -29,7 +31,7 @@ const char* mpiBlockingReceiveMessages(MPI_Comm comm)
   MPI_Status mpiStatus;
 
   // Get size and source of MPI message
-  MPI_Probe(MPI_ANY_SOURCE, 0, comm, &mpiStatus);
+  MPI_Probe(MPI_ANY_SOURCE, LJ_TAG, comm, &mpiStatus);
   MPI_Get_count(&mpiStatus, MPI_CHAR, &messageSize);
 
   // Setup where to receive the char array
@@ -37,8 +39,8 @@ const char* mpiBlockingReceiveMessages(MPI_Comm comm)
   charArray[messageSize] = '\0';
 
   // Receive packed Message
-  MPI_Recv(charArray, messageSize, MPI_CHAR, mpiStatus.MPI_SOURCE, 0, comm,
-           &mpiStatus);
+  MPI_Recv(charArray, messageSize, MPI_CHAR, mpiStatus.MPI_SOURCE,
+           LJ_TAG, comm, &mpiStatus);
 
   return charArray;
 }
@@ -49,7 +51,8 @@ void mpiNonBlockingSendMessages(MPI_Comm comm, int destinationRank,
   MPI_Request mpiRequest;
   MPI_Isend(const_cast<char*>(packedMessagesToBeSent),
             strlen(packedMessagesToBeSent), MPI_CHAR,
-            destinationRank, 0, comm, &mpiRequest);
+            destinationRank, LJ_TAG, comm, &mpiRequest);
+  MPI_Request_free(&mpiRequest);
 }
 
 } // end namespace lumberjack

--- a/src/axom/lumberjack/Message.cpp
+++ b/src/axom/lumberjack/Message.cpp
@@ -36,9 +36,9 @@ std::vector<int> Message::ranks() const
   return m_ranks;
 }
 
-int Message::ranksCount() const
+int Message::count() const
 {
-  return m_ranksCount;
+  return m_count;
 }
 
 std::string Message::fileName() const
@@ -72,6 +72,12 @@ std::string Message::stringOfRanks(std::string delimiter) const
     {
       returnString += delimiter;
     }
+  }
+
+  // Indicate we might have more ranks we aren't individually tracking
+  if (m_ranksLimitReached)
+  {
+    returnString += "...";
   }
   return returnString;
 }
@@ -116,11 +122,18 @@ void Message::addRank(int newRank, int ranksLimit)
       m_ranks.push_back(newRank);
     }
   }
-  // Always increment rank count
-  m_ranksCount++;
+  
+  if (!m_ranksLimitReached &&
+      (m_ranks.size() == (std::vector<int>::size_type)ranksLimit))
+  {
+    m_ranksLimitReached = true;
+  }
+
+  // Always increment message count
+  m_count++;
 }
 
-void Message::addRanks(const std::vector<int>& newRanks, int ranksCount,
+void Message::addRanks(const std::vector<int>& newRanks, int count,
                        int ranksLimit)
 {
   int newRanksSize = newRanks.size();
@@ -139,8 +152,15 @@ void Message::addRanks(const std::vector<int>& newRanks, int ranksCount,
       m_ranks.push_back(newRanks[i]);
     }
   }
-  // Always increment ranks count
-  m_ranksCount += ranksCount;
+
+  if (!m_ranksLimitReached &&
+      (m_ranks.size() == (std::vector<int>::size_type)ranksLimit))
+  {
+    m_ranksLimitReached = true;
+  }
+
+  // Always increment message count
+  m_count += count;
 }
 
 // Utilities
@@ -160,7 +180,7 @@ std::string Message::pack()
   }
   packedMessage += memberDelimiter;
 
-  packedMessage += std::to_string(m_ranksCount) + memberDelimiter;
+  packedMessage += std::to_string(m_count) + memberDelimiter;
 
   packedMessage += m_fileName + memberDelimiter;
 
@@ -196,7 +216,7 @@ void Message::unpack(const std::string& packedMessage, int ranksLimit)
   unpackRanks(packedMessage.substr(0, end), ranksLimit);
   start = end + 1;
 
-  //Grab rank count since it can differ from list that is sent
+  //Grab message count since it can differ from list that is sent
   end = packedMessage.find(memberDelimiter, start);
   if (end == std::string::npos)
   {
@@ -205,7 +225,7 @@ void Message::unpack(const std::string& packedMessage, int ranksLimit)
               << std::endl;
     std::cerr << packedMessage << std::endl;
   }
-  m_ranksCount = std::stoi(packedMessage.substr(start, end-start));
+  m_count = std::stoi(packedMessage.substr(start, end-start));
   start = end + 1;
 
   //Grab file name
@@ -260,7 +280,7 @@ void Message::unpack(const std::string& packedMessage, int ranksLimit)
   start = end + 1;
 
   //Grab message
-  m_text = packedMessage.substr(end+1);
+  m_text = packedMessage.substr(start);
 }
 
 void Message::unpackRanks(const std::string& ranksString, int ranksLimit)

--- a/src/axom/lumberjack/Message.hpp
+++ b/src/axom/lumberjack/Message.hpp
@@ -69,7 +69,8 @@ public:
   Message()
     : m_text("")
     , m_ranks()
-    , m_ranksCount(0)
+    , m_ranksLimitReached(false)
+    , m_count(0)
     , m_fileName("")
     , m_lineNumber(0)
     , m_level(0)
@@ -93,7 +94,8 @@ public:
           int level, const std::string& tag)
     : m_text(text)
     , m_ranks(1, rank)
-    , m_ranksCount(1)
+    , m_ranksLimitReached(false)
+    , m_count(1)
     , m_fileName(fileName)
     , m_lineNumber(lineNumber)
     , m_level(level)
@@ -106,8 +108,7 @@ public:
    *
    * \param [in] text Actual text of the Message.
    * \param [in] ranks The rank where the Message originated.
-   * \param [in] ranksCount Total amount of ranks where this Message has
-   *  originated from.
+   * \param [in] count Total number of instances of this Message.
    * \param [in] ranksLimit Limit on how many ranks are individually tracked per
    *  Message.
    * \param [in] fileName The file name where the Message originated.
@@ -117,18 +118,19 @@ public:
    *****************************************************************************
    */
   Message(const std::string& text, const std::vector<int>& ranks,
-          int ranksCount, int ranksLimit,
+          int count, int ranksLimit,
           const std::string& fileName, int lineNumber,
           int level, const std::string& tag)
     : m_text(text)
     , m_ranks()
-    , m_ranksCount(0)
+    , m_ranksLimitReached(false)
+    , m_count(0)
     , m_fileName(fileName)
     , m_lineNumber(lineNumber)
     , m_level(level)
     , m_tag(tag)
   {
-    addRanks(ranks, ranksCount, ranksLimit);
+    addRanks(ranks, count, ranksLimit);
   }
 
   // Getters
@@ -148,10 +150,10 @@ public:
 
   /*!
    *****************************************************************************
-   * \brief Returns the total count of ranks where this Message originated.
+   * \brief Returns the total count of this Message.
    *****************************************************************************
    */
-  int ranksCount() const;
+  int count() const;
 
   /*!
    *****************************************************************************
@@ -251,15 +253,15 @@ public:
 
   /*!
    *****************************************************************************
-   * \brief Adds multiple ranks to this Message.  ranksCount is used to
-   * increment since duplicates are removed from Message::ranks.
+   * \brief Adds multiple ranks to this Message.  count tracks how many times
+   * this message has occurred since duplicates are being filtered.
    *
    * \param [in] newRanks The new ranks to be added.
-   * \param [in] ranksCount Count to add to Message::ranksCount
+   * \param [in] count Count to add to Message::count
    * \param [in] ranksLimit Limits how many ranks are tracked per Message.
    *****************************************************************************
    */
-  void addRanks(const std::vector<int>& newRanks, int ranksCount,
+  void addRanks(const std::vector<int>& newRanks, int count,
                 int ranksLimit);
 
   // utilities
@@ -295,7 +297,8 @@ private:
 
   std::string m_text;
   std::vector<int> m_ranks;
-  int m_ranksCount;
+  bool m_ranksLimitReached;
+  int m_count;
   std::string m_fileName;
   int m_lineNumber;
   int m_level;

--- a/src/axom/lumberjack/TextEqualityCombiner.hpp
+++ b/src/axom/lumberjack/TextEqualityCombiner.hpp
@@ -91,7 +91,7 @@ public:
    */
   void combine(Message& combined, const Message& combinee, const int ranksLimit)
   {
-    combined.addRanks(combinee.ranks(), combinee.ranksCount(), ranksLimit);
+    combined.addRanks(combinee.ranks(), combinee.count(), ranksLimit);
   }
 private:
   std::string m_id;

--- a/src/axom/lumberjack/docs/sphinx/combiner_class.rst
+++ b/src/axom/lumberjack/docs/sphinx/combiner_class.rst
@@ -32,5 +32,5 @@ TextEqualityCombiner
 
 This Combiner combines the two given Messages if the Message text strings are equal.
 It does so by adding the second Message's ranks to the first Message (if not past
-the ranksLimit) and incrementing the Message's rankCount as well.  This is handled by
+the ranksLimit) and incrementing the Message's count as well.  This is handled by
 Message.addRanks().

--- a/src/axom/lumberjack/docs/sphinx/core_concepts.rst
+++ b/src/axom/lumberjack/docs/sphinx/core_concepts.rst
@@ -28,9 +28,9 @@ if the Text strings are exactly equal, it signals they should be combined.
 
 The function combine, takes two Messages and combines them in the way that is specific
 to that Combiner class.  For example in the TextEqualityCombiner, the only thing
-that happens is the second Message's ranks gets added to the first.  This is because
-the text strings were equal.  This may not be the case for all Combiners that you write
-yourself.
+that happens is the second Message's ranks gets added to the first and the message count
+is increased.  This is because the text strings were equal.  This may not be the case
+for all Combiners that you write yourself.
 
 
 .. _communication_label:

--- a/src/axom/lumberjack/docs/sphinx/message_class.rst
+++ b/src/axom/lumberjack/docs/sphinx/message_class.rst
@@ -17,7 +17,7 @@ Name        Description
 =========== ===================
 text        Contents of the message
 ranks       Truncated list of where the message originated
-ranksCount  Total count of how many ranks generated the message
+count       Total count of how many individual messages occurred
 fileName    File name that generated the message
 lineNumber  Line number that generated the message
 level       Message severity (error, warning, debug, etc.)

--- a/src/axom/lumberjack/docs/sphinx/quick_start.rst
+++ b/src/axom/lumberjack/docs/sphinx/quick_start.rst
@@ -107,7 +107,7 @@ Once you are ready to retrieve your messages, do so by the following:
         std::vector<axom::lumberjack::Message*> messages = lj.getMessages();
         for(int i=0; i<(int)(messages.size()); ++i){
             // Output a single Message at a time to screen
-            std::cout << "(" << messages[i]->stringOfRanks() << ") " << messages[i]->ranksCount() <<
+            std::cout << "(" << messages[i]->stringOfRanks() << ") " << messages[i]->count() <<
                          " '" << messages[i]->text() << "'" << std::endl;
         }
         // Clear already outputted Messages from Lumberjack

--- a/src/axom/lumberjack/examples/basicExample.cpp
+++ b/src/axom/lumberjack/examples/basicExample.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
     {
       // Output a single Message at a time to screen
       std::cout << "(" << messages[i]->stringOfRanks() << ") "
-                << messages[i]->ranksCount() << " '"
+                << messages[i]->count() << " '"
                 << messages[i]->text() << "'" << std::endl;
     }
     // Clear already outputted Messages from Lumberjack

--- a/src/axom/lumberjack/tests/lumberjack_Lumberjack.cpp
+++ b/src/axom/lumberjack/tests/lumberjack_Lumberjack.cpp
@@ -88,7 +88,7 @@ TEST(lumberjack_Lumberjack, combineMessagesPushOnce01)
 
   EXPECT_EQ((int)messages.size(), 1);
   EXPECT_EQ(messages[0]->text(), "Should be combined.");
-  EXPECT_EQ(messages[0]->ranksCount(), 6);
+  EXPECT_EQ(messages[0]->count(), 6);
 
   lumberjack.finalize();
   communicator.finalize();
@@ -115,9 +115,9 @@ TEST(lumberjack_Lumberjack, combineMessagesPushOnce02)
 
   EXPECT_EQ((int)messages.size(), 2);
   EXPECT_EQ(messages[0]->text(), "");
-  EXPECT_EQ(messages[0]->ranksCount(), 1);
+  EXPECT_EQ(messages[0]->count(), 1);
   EXPECT_EQ(messages[1]->text(), "Should be combined.");
-  EXPECT_EQ(messages[1]->ranksCount(), 5);
+  EXPECT_EQ(messages[1]->count(), 5);
 
   lumberjack.finalize();
   communicator.finalize();
@@ -139,7 +139,7 @@ TEST(lumberjack_Lumberjack, combineMessagesPushOnceEmpty)
 
   EXPECT_EQ((int)messages.size(), 1);
   EXPECT_EQ(messages[0]->text(), "");
-  EXPECT_EQ(messages[0]->ranksCount(), 1);
+  EXPECT_EQ(messages[0]->count(), 1);
 
   lumberjack.finalize();
   communicator.finalize();
@@ -206,7 +206,7 @@ TEST(lumberjack_Lumberjack, combineMessages01)
 
   EXPECT_EQ((int)messages.size(), 1);
   EXPECT_EQ(messages[0]->text(), "Should be combined.");
-  EXPECT_EQ(messages[0]->ranksCount(), 6);
+  EXPECT_EQ(messages[0]->count(), 6);
 
   lumberjack.finalize();
   communicator.finalize();
@@ -233,9 +233,9 @@ TEST(lumberjack_Lumberjack, combineMessages02)
 
   EXPECT_EQ((int)messages.size(), 2);
   EXPECT_EQ(messages[0]->text(), "Should be combined 1.");
-  EXPECT_EQ(messages[0]->ranksCount(), 3);
+  EXPECT_EQ(messages[0]->count(), 3);
   EXPECT_EQ(messages[1]->text(), "Should be combined 2.");
-  EXPECT_EQ(messages[1]->ranksCount(), 3);
+  EXPECT_EQ(messages[1]->count(), 3);
 
   lumberjack.finalize();
   communicator.finalize();
@@ -266,7 +266,7 @@ TEST(lumberjack_Lumberjack, combineMessages03)
     std::string s = "Should not be combined " +
                     std::to_string(i+1) + ".";
     EXPECT_EQ(messages[i]->text(), s);
-    EXPECT_EQ(messages[i]->ranksCount(), 1);
+    EXPECT_EQ(messages[i]->count(), 1);
   }
 
   lumberjack.finalize();
@@ -299,14 +299,14 @@ TEST(lumberjack_Lumberjack, combineMixedMessages01)
     std::string s = "Should not be combined " +
                     std::to_string(i+1) + ".";
     EXPECT_EQ(messages[i]->text(), s);
-    EXPECT_EQ(messages[i]->ranksCount(), 1);
+    EXPECT_EQ(messages[i]->count(), 1);
   }
 
   EXPECT_EQ(messages[2]->text(), "");
-  EXPECT_EQ(messages[2]->ranksCount(), 1);
+  EXPECT_EQ(messages[2]->count(), 1);
 
   EXPECT_EQ(messages[3]->text(), "Should be combined.");
-  EXPECT_EQ(messages[3]->ranksCount(), 3);
+  EXPECT_EQ(messages[3]->count(), 3);
 
   lumberjack.finalize();
   communicator.finalize();
@@ -338,14 +338,14 @@ TEST(lumberjack_Lumberjack, combineMixedMessages02)
     std::string s = "Should not be combined " +
                     std::to_string(i+1) + ".";
     EXPECT_EQ(messages[i]->text(), s);
-    EXPECT_EQ(messages[i]->ranksCount(), 1);
+    EXPECT_EQ(messages[i]->count(), 1);
   }
 
   EXPECT_EQ(messages[2]->text(), "Should be combined.");
-  EXPECT_EQ(messages[2]->ranksCount(), 3);
+  EXPECT_EQ(messages[2]->count(), 3);
 
   EXPECT_EQ(messages[3]->text(), "");
-  EXPECT_EQ(messages[3]->ranksCount(), 1);
+  EXPECT_EQ(messages[3]->count(), 1);
 
   lumberjack.finalize();
   communicator.finalize();
@@ -374,18 +374,18 @@ TEST(lumberjack_Lumberjack, combineMixedMessages03)
   EXPECT_EQ((int)messages.size(), 4);
 
   EXPECT_EQ(messages[0]->text(), "");
-  EXPECT_EQ(messages[0]->ranksCount(), 1);
+  EXPECT_EQ(messages[0]->count(), 1);
 
   for(int i=1 ; i<3 ; ++i)
   {
     std::string s = "Should not be combined " +
                     std::to_string(i+1) + ".";
     EXPECT_EQ(messages[i]->text(), s);
-    EXPECT_EQ(messages[i]->ranksCount(), 1);
+    EXPECT_EQ(messages[i]->count(), 1);
   }
 
   EXPECT_EQ(messages[3]->text(), "Should be combined.");
-  EXPECT_EQ(messages[3]->ranksCount(), 3);
+  EXPECT_EQ(messages[3]->count(), 3);
 
   lumberjack.finalize();
   communicator.finalize();
@@ -418,7 +418,7 @@ TEST(lumberjack_Lumberjack, combineMessagesManyMessages)
     std::string s = "Should not be combined " +
                     std::to_string(i) + ".";
     EXPECT_EQ(messages[i]->text(), s);
-    EXPECT_EQ(messages[i]->ranksCount(), 1);
+    EXPECT_EQ(messages[i]->count(), 1);
   }
 
   lumberjack.finalize();
@@ -456,7 +456,7 @@ TEST(lumberjack_Lumberjack, combineMessagesLargeMessages)
   {
     std::string s = std::to_string(i) + ":" + padding;
     EXPECT_EQ(messages[i]->text(), s);
-    EXPECT_EQ(messages[i]->ranksCount(), 1);
+    EXPECT_EQ(messages[i]->count(), 1);
   }
 
   lumberjack.finalize();

--- a/src/axom/lumberjack/tests/lumberjack_Message.cpp
+++ b/src/axom/lumberjack/tests/lumberjack_Message.cpp
@@ -85,7 +85,7 @@ TEST(lumberjack_Message, getSet)
 
     EXPECT_EQ(m->text(), td.text);
     EXPECT_EQ(m->ranks().size(), (std::vector<int>::size_type) 1);
-    EXPECT_EQ(m->ranksCount(), 1);
+    EXPECT_EQ(m->count(), 1);
     EXPECT_EQ(m->ranks()[0], td.rank);
     EXPECT_EQ(m->level(), td.level);
     EXPECT_EQ(m->tag(), td.tag);
@@ -108,7 +108,7 @@ TEST(lumberjack_Message, getSetCaseConstCharToString)
 
   EXPECT_EQ(m.text(), textString);
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type) 1);
-  EXPECT_EQ(m.ranksCount(), 1);
+  EXPECT_EQ(m.count(), 1);
   EXPECT_EQ(m.ranks()[0], 14);
 }
 
@@ -125,7 +125,7 @@ TEST(lumberjack_Message, getSetFillRankLimit)
 
   EXPECT_EQ(m.text(), "Testing filling rank to rank limit.");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type)ranksLimit);
-  EXPECT_EQ(m.ranksCount(), ranksLimit);
+  EXPECT_EQ(m.count(), ranksLimit);
   for(int i=0 ; i<(int)ranksLimit ; ++i)
   {
     EXPECT_EQ(m.ranks()[i], i+1);
@@ -145,7 +145,7 @@ TEST(lumberjack_Message, getSetFillPastRankLimit)
 
   EXPECT_EQ(m.text(), "Test filling past rank limit.");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type)ranksLimit);
-  EXPECT_EQ(m.ranksCount(), (int)ranksLimit*2);
+  EXPECT_EQ(m.count(), (int)ranksLimit*2);
   for(int i=0 ; i<(int)ranksLimit ; ++i)
   {
     EXPECT_EQ(m.ranks()[i], i+1);
@@ -165,7 +165,7 @@ TEST(lumberjack_Message, getSetTestAddingVectorOfOneRank)
 
   EXPECT_EQ(m.text(), "Test adding vector of 1 rank.");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type) 1);
-  EXPECT_EQ(m.ranksCount(), 1);
+  EXPECT_EQ(m.count(), 1);
   EXPECT_EQ(m.ranks()[0], 123);
 }
 
@@ -186,7 +186,7 @@ TEST(lumberjack_Message, getSetTestAddingVectorOfManyRanks)
 
   EXPECT_EQ(m.text(), "Test adding vector of many ranks over limit.");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type)ranksLimit);
-  EXPECT_EQ(m.ranksCount(), ranksAdded);
+  EXPECT_EQ(m.count(), ranksAdded);
   for(int i=0 ; i<(int)ranksLimit ; ++i)
   {
     EXPECT_EQ(m.ranks()[i], i);
@@ -210,7 +210,7 @@ TEST(lumberjack_Message, getSetTestAddingExactNumberOfRanksLimit)
 
   EXPECT_EQ(m.text(), "Test adding vector of exactly ranksLimit of ranks.");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type)ranksLimit);
-  EXPECT_EQ(m.ranksCount(), ranksLimit);
+  EXPECT_EQ(m.count(), ranksLimit);
   for(int i=0 ; i<(int)ranksLimit ; ++i)
   {
     EXPECT_EQ(m.ranks()[i], i+1);
@@ -232,7 +232,7 @@ TEST(lumberjack_Message, getSetAddSameRankMultipleTimes)
 
   EXPECT_EQ(m.text(), "Test adding same rank over and over.");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type) 1);
-  EXPECT_EQ(m.ranksCount(), (int)ranksLimit*3);
+  EXPECT_EQ(m.count(), (int)ranksLimit*3);
   EXPECT_EQ(m.ranks()[0], 1);
 }
 
@@ -253,7 +253,7 @@ TEST(lumberjack_Message, getSetAddRanksWithOverRankLimit)
 
   EXPECT_EQ(m.text(), "This message is unimportant.");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type) 1);
-  EXPECT_EQ(m.ranksCount(), (int)ranksLimit*3);
+  EXPECT_EQ(m.count(), (int)ranksLimit*3);
   EXPECT_EQ(m.ranks()[0], 1);
 }
 
@@ -269,7 +269,7 @@ TEST(lumberjack_Message, testConstructor01)
   EXPECT_EQ(m.level(), 1);
   EXPECT_EQ(m.tag(), "tag1");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type) 1);
-  EXPECT_EQ(m.ranksCount(), 1);
+  EXPECT_EQ(m.count(), 1);
   EXPECT_EQ(m.ranks()[0], 122);
 }
 
@@ -293,7 +293,7 @@ TEST(lumberjack_Message, testConstructor02)
   EXPECT_EQ(m.level(), 2);
   EXPECT_EQ(m.tag(), "mytag");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type)ranksLimit);
-  EXPECT_EQ(m.ranksCount(), ranksLimit);
+  EXPECT_EQ(m.count(), ranksLimit);
   for(int i=0 ; i<(int)ranksLimit ; ++i)
   {
     EXPECT_EQ(m.ranks()[i], i+1);
@@ -313,7 +313,7 @@ TEST(lumberjack_Message, stringOfRanks01)
   EXPECT_EQ(m.level(), 0);
   EXPECT_EQ(m.tag(), "");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type) 1);
-  EXPECT_EQ(m.ranksCount(), 1);
+  EXPECT_EQ(m.count(), 1);
   EXPECT_EQ(m.ranks()[0], 400);
   EXPECT_EQ(m.stringOfRanks(), "400");
 }
@@ -335,12 +335,12 @@ TEST(lumberjack_Message, stringOfRanks02)
   EXPECT_EQ(m.fileName(), "");
   EXPECT_EQ(m.lineNumber(), 0);
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type)ranksLimit);
-  EXPECT_EQ(m.ranksCount(), ranksLimit);
+  EXPECT_EQ(m.count(), ranksLimit);
   for(int i=0 ; i<(int)ranksLimit ; ++i)
   {
     EXPECT_EQ(m.ranks()[i], i+1);
   }
-  EXPECT_EQ(m.stringOfRanks(), "1,2,3,4,5");
+  EXPECT_EQ(m.stringOfRanks(), "1,2,3,4,5...");
 }
 
 TEST(lumberjack_Message, stringOfRanks03)
@@ -361,12 +361,12 @@ TEST(lumberjack_Message, stringOfRanks03)
   EXPECT_EQ(m.fileName(), "test/foo.cpp");
   EXPECT_EQ(m.lineNumber(), 987654321);
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type)ranksLimit);
-  EXPECT_EQ(m.ranksCount(), ranksLimit);
+  EXPECT_EQ(m.count(), ranksLimit);
   for(int i=0 ; i<(int)ranksLimit ; ++i)
   {
     EXPECT_EQ(m.ranks()[i], i*2);
   }
-  EXPECT_EQ(m.stringOfRanks(), "0,2,4,6,8");
+  EXPECT_EQ(m.stringOfRanks(), "0,2,4,6,8...");
 }
 
 TEST(lumberjack_Message, pack01)
@@ -387,7 +387,7 @@ TEST(lumberjack_Message, pack01)
   EXPECT_EQ(m.fileName(), "test/foo.cpp");
   EXPECT_EQ(m.lineNumber(), 987654321);
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type)ranksLimit);
-  EXPECT_EQ(m.ranksCount(), ranksLimit);
+  EXPECT_EQ(m.count(), ranksLimit);
   for(int i=0 ; i<(int)ranksLimit ; ++i)
   {
     EXPECT_EQ(m.ranks()[i], i*2);
@@ -413,7 +413,7 @@ TEST(lumberjack_Message, unpack01)
   EXPECT_EQ(m.level(), 1);
   EXPECT_EQ(m.tag(), "gtest");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type)ranksLimit);
-  EXPECT_EQ(m.ranksCount(), 15);
+  EXPECT_EQ(m.count(), 15);
   for(int i=0 ; i<(int)ranksLimit ; ++i)
   {
     EXPECT_EQ(m.ranks()[i], i*2);
@@ -435,7 +435,7 @@ TEST(lumberjack_Message, unpack02)
   EXPECT_EQ(m.level(), 0);
   EXPECT_EQ(m.tag(), "");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type)ranksLimit);
-  EXPECT_EQ(m.ranksCount(), 15);
+  EXPECT_EQ(m.count(), 15);
   for(int i=0 ; i<(int)ranksLimit ; ++i)
   {
     EXPECT_EQ(m.ranks()[i], i*2);
@@ -485,7 +485,7 @@ TEST(lumberjack_Message, unpackEmptyMessage)
   EXPECT_EQ(m.level(), 0);
   EXPECT_EQ(m.tag(), "tag");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type)ranksLimit);
-  EXPECT_EQ(m.ranksCount(), 15);
+  EXPECT_EQ(m.count(), 15);
   for(int i=0 ; i<(int)ranksLimit ; ++i)
   {
     EXPECT_EQ(m.ranks()[i], i*2);
@@ -507,7 +507,7 @@ TEST(lumberjack_Message, unpackEmptyTag)
   EXPECT_EQ(m.level(), 0);
   EXPECT_EQ(m.tag(), "");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type)ranksLimit);
-  EXPECT_EQ(m.ranksCount(), 15);
+  EXPECT_EQ(m.count(), 15);
   for(int i=0 ; i<(int)ranksLimit ; ++i)
   {
     EXPECT_EQ(m.ranks()[i], i*2);
@@ -529,7 +529,7 @@ TEST(lumberjack_Message, unpackEmptyTagAndMessage)
   EXPECT_EQ(m.level(), 0);
   EXPECT_EQ(m.tag(), "");
   EXPECT_EQ(m.ranks().size(), (std::vector<int>::size_type)ranksLimit);
-  EXPECT_EQ(m.ranksCount(), 15);
+  EXPECT_EQ(m.count(), 15);
   for(int i=0 ; i<(int)ranksLimit ; ++i)
   {
     EXPECT_EQ(m.ranks()[i], i*2);

--- a/src/axom/lumberjack/tests/lumberjack_TextEqualityCombiner.cpp
+++ b/src/axom/lumberjack/tests/lumberjack_TextEqualityCombiner.cpp
@@ -31,7 +31,7 @@ TEST(lumberjack_TextEqualityCombiner, case01)
 
   EXPECT_EQ(shouldMessagesBeCombined, true);
   EXPECT_EQ(m1.text().compare(text), 0);
-  EXPECT_EQ(m1.ranksCount(), 2);
+  EXPECT_EQ(m1.count(), 2);
   EXPECT_EQ(m1.ranks()[0], 13);
   EXPECT_EQ(m1.ranks()[1], 14);
 }
@@ -59,10 +59,10 @@ TEST(lumberjack_TextEqualityCombiner, case02)
 
   EXPECT_EQ(shouldMessagesBeCombined, false);
   EXPECT_EQ(m1.text().compare(text1), 0);
-  EXPECT_EQ(m1.ranksCount(), 1);
+  EXPECT_EQ(m1.count(), 1);
   EXPECT_EQ(m1.ranks()[0], 13);
 
   EXPECT_EQ(m2.text().compare(text2), 0);
-  EXPECT_EQ(m2.ranksCount(), 1);
+  EXPECT_EQ(m2.count(), 1);
   EXPECT_EQ(m2.ranks()[0], 14);
 }

--- a/src/axom/slic/streams/LumberjackStream.cpp
+++ b/src/axom/slic/streams/LumberjackStream.cpp
@@ -121,20 +121,21 @@ void LumberjackStream::write()
 
   if ( m_lj->isOutputNode() )
   {
-
     std::vector< axom::lumberjack::Message* > messages =
       m_lj->getMessages();
 
     const int nmessages = static_cast< int >( messages.size() );
+    std::string rankString;
     for ( int i=0 ; i < nmessages ; ++i)
     {
-
+      rankString = std::to_string(messages[i]->count())
+                   + ": " + messages[i]->stringOfRanks();
       (*m_stream) << this->getFormatedMessage( message::getLevelAsString(
                                                  static_cast< message::Level >(
                                                    messages[i]->level()) ),
                                                messages[i]->text(),
                                                messages[i]->tag(),
-                                               messages[i]->stringOfRanks(),
+                                               rankString,
                                                messages[i]->fileName(),
                                                messages[i]->lineNumber() );
     }

--- a/src/axom/slic/streams/LumberjackStream.hpp
+++ b/src/axom/slic/streams/LumberjackStream.hpp
@@ -42,7 +42,7 @@ namespace slic
  * \class LumberjackStream
  *
  * \brief A concrete instance of LogStream that utilizes Lumberjack to
- *  filter and pass messagse between MPI nodes.
+ *  filter and pass messages between MPI nodes.
  *
  */
 class LumberjackStream : public LogStream

--- a/src/axom/slic/streams/LumberjackStream.hpp
+++ b/src/axom/slic/streams/LumberjackStream.hpp
@@ -41,17 +41,9 @@ namespace slic
 /*!
  * \class LumberjackStream
  *
- * \brief A concrete instance of LogStream that dumps messages to a C++
- *  std::ostream object.
+ * \brief A concrete instance of LogStream that utilizes Lumberjack to
+ *  filter and pass messagse between MPI nodes.
  *
- * \note The intent of this class is to illustrate how to using the Logging
- *  facility within an MPI distributed environment and provide a utility that
- *  could be useful for debugging problems at small scales.
- *
- * \warning Do not use this for large-scale production runs.
- * \warning The intent of this class is to be used primarily with std::cout,
- *  std::cerr, etc. It is suggested that applications do not use this class
- *  with an std::ofstream object.
  */
 class LumberjackStream : public LogStream
 {


### PR DESCRIPTION
* Fixes memory leak in lumberjack's MPI communication
* Clarifies message count is not just rank count
* Increases information out of LumberjackStream in regards to rank and message count