### PR TITLE
Sets CUDA_SEPARABLE_COMPILATION flag in blueos9 host-config

### DIFF
--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@8.0.0_nvcc_xlf.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@8.0.0_nvcc_xlf.cmake
@@ -110,6 +110,7 @@ set(AXOM_CUDA_ARCH "sm_70" CACHE PATH "")
 
 set(CMAKE_CUDA_FLAGS "-restrict -arch ${AXOM_CUDA_ARCH} -std=c++11 --expt-extended-lambda -G" CACHE PATH "")
 
+set(CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "" )
 set(CMAKE_CUDA_HOST_COMPILER "${MPI_CXX_COMPILER}" CACHE PATH "")
 
 # nvcc does not like gtest's 'pthreads' flag

--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -76,10 +76,6 @@ blt_add_library(
     OBJECT                TRUE
     )
 
-if (ENABLE_CUDA)
-  set_target_properties(primal PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-endif()
-
 axom_write_unified_header(NAME    primal
                           HEADERS ${primal_headers})
 

--- a/src/axom/spin/examples/CMakeLists.txt
+++ b/src/axom/spin/examples/CMakeLists.txt
@@ -33,6 +33,3 @@ blt_add_executable(
     FOLDER      axom/spin/examples
     )
 
-if (ENABLE_CUDA)
-  set_target_properties(naive_intersect_raja_ex PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-endif()


### PR DESCRIPTION
# Summary 

It seems that there was a conflict with setting the ``CUDA_SEPARABLE_COMPILATION``
flag on one of axom's libraries (primal) and compiling axom's libraries as object libraries.

This fixes the weird compiler bug that @bmhan12 reported:
```
ptxas /var/tmp/han12/tmpxft_00002929_00000000-5_intersect_impl.ptx, line 435; error   : Illegal operand type to instruction 'ld'
ptxas /var/tmp/han12/tmpxft_00002929_00000000-5_intersect_impl.ptx, line 435; error   : Unknown symbol '_param_0'
ptxas /var/tmp/han12/tmpxft_00002929_00000000-5_intersect_impl.ptx, line 531; error   : Illegal operand type to instruction 'ld'
ptxas /var/tmp/han12/tmpxft_00002929_00000000-5_intersect_impl.ptx, line 531; error   : Unknown symbol '_param_0'
ptxas fatal   : Ptx assembly aborted due to errors
```
Specifically, I was able to compile your branch and pass all tests using the ``rzansel-blueos_3_ppc64le_ib_p9-clang@8.0.0_nvcc_xlf.cmake `` host-config.

Note: This PR is into @bmhan12's feature branch, not into develop.
I am adding others to this PR in case they see a better solution and/or object to setting this flag in our main GPU host-config for blueos9.