### PR TITLE
Host doxygen on ReadtheDocs

### DIFF
--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -58,6 +58,7 @@ set(UMPIRE_DIR "${TPL_ROOT}/umpire-1.0.0/share/umpire/cmake" CACHE PATH "")
 # python not built by uberenv
 
 set(ENABLE_DOCS OFF CACHE BOOL "")
+set(SPHINX_EXECUTABLE /collab/usr/gapps/python/build/spack-toss3.2/opt/spack/linux-rhel7-x86_64/gcc-4.9.3/python-2.7.14-7rci3jkmuht2uiwp433afigveuf4ocnu/bin/sphinx-build CACHE PATH "")
 
 # shroud not built by uberenv
 

--- a/src/axom/lumberjack/README.md
+++ b/src/axom/lumberjack/README.md
@@ -3,5 +3,5 @@ Lumberjack: Log filtering and aggregation {#lumberjacktop}
 
 [Lumberjack](@ref axom::lumberjack) provides functionality to filter log events based on priority, rate, and volume.  It coordinates with but does not require the [SLIC](@ref slictop) component.
 
-The [introduction to Lumberjack](../../../sphinx/axom_docs/html/axom/lumberjack/docs/sphinx/index.html)
+The [introduction to Lumberjack](https://axom.readthedocs.io/en/develop/axom/lumberjack/docs/sphinx/index.html)
 covers these concepts in more detail.

--- a/src/axom/lumberjack/README.md
+++ b/src/axom/lumberjack/README.md
@@ -2,6 +2,3 @@ Lumberjack: Log filtering and aggregation {#lumberjacktop}
 ========
 
 [Lumberjack](@ref axom::lumberjack) provides functionality to filter log events based on priority, rate, and volume.  It coordinates with but does not require the [SLIC](@ref slictop) component.
-
-The [introduction to Lumberjack](https://axom.readthedocs.io/en/develop/axom/lumberjack/docs/sphinx/index.html)
-covers these concepts in more detail.

--- a/src/axom/mainpage.md
+++ b/src/axom/mainpage.md
@@ -31,10 +31,10 @@ indicate hard dependencies; dashed links indicate optional dependencies.
 
 # Further documentation
 
-- [User manual](../../../sphinx/axom_docs/html/docs/index.html)
-- [Quick start guide](../../../sphinx/axom_docs/html/docs/sphinx/quickstart_guide/index.html)
-- [Development guide](../../../sphinx/axom_docs/html/docs/sphinx/dev_guide/index.html) (intended for Axom contributors)
-- Coding [style guide](../../../sphinx/axom_docs/html/docs/sphinx/coding_guide/index.html) (intended for Axom contributors)
-- Please see our [license](../../../sphinx/axom_docs/html/docs/licenses.html).
+- [User manual](../../index.html)
+- [Quick start guide](../../docs/sphinx/quickstart_guide/index.html)
+- [Development guide](../../docs/sphinx/dev_guide/index.html) (intended for Axom contributors)
+- Coding [style guide](../../docs/sphinx/coding_guide/index.html) (intended for Axom contributors)
+- Please see our [license](../../docs/licenses.html).
 
 Each component contains a `test` subdirectory containing numerous code unit tests and an `example` subdirectory with more extensive demonstrations of the Axom library.  The Sidre, Mint, and Slam examples include several versions of the `lulesh` mini-app,  an implementation of the heat equation and a 1-D shock tube simulation.

--- a/src/axom/mint/README.md
+++ b/src/axom/mint/README.md
@@ -12,6 +12,3 @@ Mint: Mesh Data Model {#minttop}
 Mint serves as as fundmental building block that underpins the development of
 computational tools and numerical discretization methods, enabling implementations 
 that are born *parallel* and *portable* to new and emerging architectures.
-
-The [Mint User Guide](https://axom.readthedocs.io/en/develop/axom/mint/docs/sphinx/index.html)
-introduces these concepts in more detail.

--- a/src/axom/mint/docs/sphinx/index.rst
+++ b/src/axom/mint/docs/sphinx/index.rst
@@ -25,5 +25,3 @@ Mint User Guide
    sections/examples.rst
    sections/faq.rst
    sections/appendix.rst
-
-.. include:: sections/citations.rst

--- a/src/axom/mint/docs/sphinx/sections/citations.rst
+++ b/src/axom/mint/docs/sphinx/sections/citations.rst
@@ -7,12 +7,12 @@
 .. _LLNL: https://www.llnl.gov/
 .. _Umpire: https://umpire.readthedocs.io/en/develop/
 .. _Mint Doxygen API Documentation: ../../../../../doxygen/html/minttop.html
-.. _Axom Quick Start Guide: https://axom.readthedocs.io/en/develop/docs/sphinx/quickstart_guide/index.html
+.. _Axom Quick Start Guide: ../../../../../docs/sphinx/quickstart_guide/index.html
 .. _Conduit: https://llnl-conduit.readthedocs.io/en/latest/index.html
 .. _Blueprint: https://llnl-conduit.readthedocs.io/en/latest/blueprint.html
 .. _RAJA: https://raja.readthedocs.io/en/master/index.html
-.. _Axom Toolkit: https://axom.readthedocs.io/en/develop/
-.. _Sidre: https://axom.readthedocs.io/en/develop/axom/sidre/docs/sphinx/index.html
+.. _Axom Toolkit: ../../../../../index.html
+.. _Sidre: ../../../../sidre/docs/sphinx/index.html
 .. _WCI: https://wci.llnl.gov/
 .. _WSC: https://wci.llnl.gov/about-us/weapon-simulation-and-computing
 .. _CGNS Numbering Conventions: https://cgns.github.io/CGNS_docs_current/sids/conv.html#unstructgrid.

--- a/src/axom/mint/docs/sphinx/sections/citations.rst
+++ b/src/axom/mint/docs/sphinx/sections/citations.rst
@@ -6,7 +6,7 @@
 
 .. _LLNL: https://www.llnl.gov/
 .. _Umpire: https://umpire.readthedocs.io/en/develop/
-.. _Mint Doxygen API Documentation: https://lc.llnl.gov/axom/docs/doxygen/axom_doxygen/html/classaxom_1_1mint_1_1Mesh.html
+.. _Mint Doxygen API Documentation: ../../../../../doxygen/html/minttop.html
 .. _Axom Quick Start Guide: https://axom.readthedocs.io/en/develop/docs/sphinx/quickstart_guide/index.html
 .. _Conduit: https://llnl-conduit.readthedocs.io/en/latest/index.html
 .. _Blueprint: https://llnl-conduit.readthedocs.io/en/latest/blueprint.html

--- a/src/axom/mint/docs/sphinx/sections/synopsis.rst
+++ b/src/axom/mint/docs/sphinx/sections/synopsis.rst
@@ -26,7 +26,7 @@ architectures.
 * Basic support for :ref:`sections/fem`, consisting of
   commonly employed *shape functions* and *quadratures*.
 
-* A Mesh-Aware :ref:`sections/execution_model`, based on the `RAJA`_ programming
+* A Mesh-Aware :ref:`sections/execution_model`, based on the `RAJA <https://raja.readthedocs.io/en/master/index.html>`_ programming
   model abstraction layer that supports on-node parallelism for mesh-traversals,
   enabling the implementation of computational kernels that are born parallel
   and portable across different processor architectures.
@@ -38,11 +38,11 @@ The only requirement for using Mint is a C++11 compliant compiler.
 However, to realize the full spectrum of capabilities, support for
 the following third-party libraries is provided:
 
-* `RAJA`_, used for the parallel execution and portability layer.
+* `RAJA <https://raja.readthedocs.io/en/master/index.html>`_, used for the parallel execution and portability layer.
 
-* `Conduit`_ , for using `Sidre <../../../sidre/docs/sphinx/index.html>`_ as the :ref:`MeshStorageManagement` system.
+* `Conduit <https://llnl-conduit.readthedocs.io/en/latest/index.html>`_ , for using `Sidre <../../../sidre/docs/sphinx/index.html>`_ as the :ref:`MeshStorageManagement` system.
 
-* `Umpire`_, for memory management on next-generation architectures.
+* `Umpire <https://umpire.readthedocs.io/en/develop/>`_, for memory management on next-generation architectures.
 
 For further information on how to build the `Axom Toolkit <../../../../index.html>`_ using these
 third-party libraries, consult the `Axom Quick Start Guide <../../../../docs/sphinx/quickstart_guide/index.html>`_.

--- a/src/axom/mint/docs/sphinx/sections/synopsis.rst
+++ b/src/axom/mint/docs/sphinx/sections/synopsis.rst
@@ -20,7 +20,7 @@ architectures.
 * Native support for a variety of commonly employed :ref:`CellTypes`.
 
 * A flexible :ref:`MeshStorageManagement` system, which can optionally
-  inter-operate with `Sidre`_ as the underlying, in-memory, hierarchical
+  inter-operate with `Sidre <../../../sidre/docs/sphinx/index.html>`_ as the underlying, in-memory, hierarchical
   datastore, facilitating the integration across packages.
 
 * Basic support for :ref:`sections/fem`, consisting of
@@ -40,12 +40,12 @@ the following third-party libraries is provided:
 
 * `RAJA`_, used for the parallel execution and portability layer.
 
-* `Conduit`_ , for using `Sidre`_ as the :ref:`MeshStorageManagement` system.
+* `Conduit`_ , for using `Sidre <../../../sidre/docs/sphinx/index.html>`_ as the :ref:`MeshStorageManagement` system.
 
 * `Umpire`_, for memory management on next-generation architectures.
 
-For further information on how to build the `Axom Toolkit`_ using these
-third-party libraries, consult the `Axom Quick Start Guide`_.
+For further information on how to build the `Axom Toolkit <../../../../index.html>`_ using these
+third-party libraries, consult the `Axom Quick Start Guide <../../../../docs/sphinx/quickstart_guide/index.html>`_.
 
 **About this Guide**
 
@@ -59,7 +59,7 @@ This guide discusses the basic concepts and architecture of Mint.
   demonstrate specific topics in a structured and simple format.
 
 * For complete documentation of the interfaces of the various classes and
-  functions in Mint consult the `Mint Doxygen API Documentation`_.
+  functions in Mint consult the `Mint Doxygen API Documentation <../../../../doxygen/html/minttop.html>`_.
 
 * Complete examples and code walk-throughs of mini-apps using Mint are
   provided in the :ref:`sections/examples` section.

--- a/src/axom/primal/README.md
+++ b/src/axom/primal/README.md
@@ -4,6 +4,3 @@ Primal: Geometric primitives and associated computational geometry tests {#prima
 [Primal](@ref axom::primal) provides classes representing geometric primitives (such as [points](@ref axom::primal::Point), [bounding boxes](@ref axom::primal::BoundingBox), and [triangles](@ref axom::primal::BoundingBox)) and functions implementing computational geometry tests (such as intersect(), squared_distance(), orientation()).
 
 It also provides spatial acceleration data structures over collections of spatial objects, including the [bounding volume hierarchy](@ref axom::primal::BVHTree) tree and the [uniform grid](@ref axom::primal::UniformGrid) (also known as cell list).
-
-The [introduction to Primal](https://axom.readthedocs.io/en/develop/axom/primal/docs/sphinx/index.html)
-covers these concepts in more detail.

--- a/src/axom/primal/README.md
+++ b/src/axom/primal/README.md
@@ -5,5 +5,5 @@ Primal: Geometric primitives and associated computational geometry tests {#prima
 
 It also provides spatial acceleration data structures over collections of spatial objects, including the [bounding volume hierarchy](@ref axom::primal::BVHTree) tree and the [uniform grid](@ref axom::primal::UniformGrid) (also known as cell list).
 
-The [introduction to Primal](../../../sphinx/axom_docs/html/axom/primal/docs/sphinx/index.html)
+The [introduction to Primal](https://axom.readthedocs.io/en/develop/axom/primal/docs/sphinx/index.html)
 covers these concepts in more detail.

--- a/src/axom/primal/docs/sphinx/index.rst
+++ b/src/axom/primal/docs/sphinx/index.rst
@@ -13,7 +13,7 @@ This tutorial contains a collection of brief examples demonstrating
 Primal primitives and operators.  The examples instantiate geometric primitives
 as needed and demonstrate geometric operators.  These examples also show
 representative overloads of each of the Primal operators (see the
-`API documentation <../../../doxygen/axom_doxygen/html/primaltop.html>`_ 
+`API documentation <../../../../doxygen/html/primaltop.html>`_ 
 for more details).
 
 .. toctree::

--- a/src/axom/quest/README.md
+++ b/src/axom/quest/README.md
@@ -13,5 +13,5 @@ Quest: Query points in meshes {#questtop}
 - A [function](@ref all_nearest_neighbors()) to find the nearest neighbor for each
   of a set of points
 
-The [Quest user guide](../../../sphinx/axom_docs/html/axom/quest/docs/sphinx/index.html)
+The [Quest user guide](https://axom.readthedocs.io/en/develop/axom/quest/docs/sphinx/index.html)
 also discusses these concepts.

--- a/src/axom/quest/README.md
+++ b/src/axom/quest/README.md
@@ -12,6 +12,3 @@ Quest: Query points in meshes {#questtop}
   of a high-order mesh
 - A [function](@ref all_nearest_neighbors()) to find the nearest neighbor for each
   of a set of points
-
-The [Quest user guide](https://axom.readthedocs.io/en/develop/axom/quest/docs/sphinx/index.html)
-also discusses these concepts.

--- a/src/axom/sidre/README.md
+++ b/src/axom/sidre/README.md
@@ -25,6 +25,3 @@ Typically, an application code will
   - Save a subset of data in a group hierarchy; e.g., only the views with a specific attribute set
 - Delete the data store when done
   - This will also clean up data allocated via Sidre mechanisms; external data must be deallocated by user code
-
-The [Sidre guide](https://axom.readthedocs.io/en/develop/axom/sidre/docs/sphinx/index.html)
-introduces these concepts in more detail.

--- a/src/axom/sidre/README.md
+++ b/src/axom/sidre/README.md
@@ -26,5 +26,5 @@ Typically, an application code will
 - Delete the data store when done
   - This will also clean up data allocated via Sidre mechanisms; external data must be deallocated by user code
 
-The [Sidre guide](../../../sphinx/axom_docs/html/axom/sidre/docs/sphinx/index.html)
+The [Sidre guide](https://axom.readthedocs.io/en/develop/axom/sidre/docs/sphinx/index.html)
 introduces these concepts in more detail.

--- a/src/axom/slam/README.md
+++ b/src/axom/slam/README.md
@@ -7,8 +7,6 @@ Axom's [Slam](@ref axom::slam) component provides a collection of high performan
 * Relations among pairs of sets (e.g. incidence, adjacency and containment relations)
 * Maps defining fields and attributes on the elements of a given set
 
-The [Slam guide](https://axom.readthedocs.io/en/develop/axom/slam/docs/sphinx/index.html)
-discusses these concepts at length.
 
 <!--    (see ['components' section](@ref #components) for more detail) -->
 

--- a/src/axom/slam/README.md
+++ b/src/axom/slam/README.md
@@ -7,7 +7,7 @@ Axom's [Slam](@ref axom::slam) component provides a collection of high performan
 * Relations among pairs of sets (e.g. incidence, adjacency and containment relations)
 * Maps defining fields and attributes on the elements of a given set
 
-The [Slam guide](../../../sphinx/axom_docs/html/axom/slam/docs/sphinx/index.html)
+The [Slam guide](https://axom.readthedocs.io/en/develop/axom/slam/docs/sphinx/index.html)
 discusses these concepts at length.
 
 <!--    (see ['components' section](@ref #components) for more detail) -->

--- a/src/axom/slam/docs/sphinx/index.rst
+++ b/src/axom/slam/docs/sphinx/index.rst
@@ -107,4 +107,4 @@ See :ref:`policy-label` for more details.
 
 
 * `API documentation <../../../../doxygen/html/slamtop.html>`_
-* `Axom main docs <../../web_main_docs/html/index.html>`_
+* `Axom main docs <../../../../index.html>`_

--- a/src/axom/slam/docs/sphinx/index.rst
+++ b/src/axom/slam/docs/sphinx/index.rst
@@ -106,5 +106,5 @@ See :ref:`policy-label` for more details.
     <h3>Additional links</h3>
 
 
-* `API documentation <../../../doxygen/axom_doxygen/html/slamtop.html>`_
+* `API documentation <../../../../doxygen/html/slamtop.html>`_
 * `Axom main docs <../../web_main_docs/html/index.html>`_

--- a/src/axom/slic/README.md
+++ b/src/axom/slic/README.md
@@ -3,5 +3,3 @@ Slic: Simple Logging Interface Code {#slictop}
 
 [Slic](@ref axom::slic) provides a *light-wieght*, *modular* and *extensible* 
 logging infrastructure that simplifies logging application messages.
-
-Also see the [Slic user guide](https://axom.readthedocs.io/en/develop/axom/slic/docs/sphinx/index.html#).

--- a/src/axom/slic/docs/sphinx/index.rst
+++ b/src/axom/slic/docs/sphinx/index.rst
@@ -17,5 +17,3 @@ Slic User Guide
    sections/architecture.rst
    sections/wrapping_slic_in_macros.rst
    sections/appendix.rst
-
-.. include:: sections/citations.rst

--- a/src/axom/slic/docs/sphinx/sections/citations.rst
+++ b/src/axom/slic/docs/sphinx/sections/citations.rst
@@ -5,9 +5,9 @@
 
 .. _LLNL: https://www.llnl.gov/
 .. _Shroud: https://shroud.readthedocs.io/en/develop/
-.. _Lumberjack: ../../../lumberjack/docs/sphinx/index.html
-.. _Axom Quick Start Guide: https://axom.readthedocs.io/en/develop/docs/sphinx/quickstart_guide/index.html
-.. _Axom Toolkit: https://axom.readthedocs.io/en/develop/
+.. _Lumberjack: ../../../../lumberjack/docs/sphinx/index.html
+.. _Axom Quick Start Guide: ../../../../../docs/sphinx/quickstart_guide/index.html
+.. _Axom Toolkit: ../../../../../index.html
 .. _WCI: https://wci.llnl.gov/
 .. _WSC: https://wci.llnl.gov/about-us/weapon-simulation-and-computing
 .. _Slic Doxygen API Documentation: ../../../../../doxygen/html/slictop.html

--- a/src/axom/slic/docs/sphinx/sections/citations.rst
+++ b/src/axom/slic/docs/sphinx/sections/citations.rst
@@ -5,10 +5,10 @@
 
 .. _LLNL: https://www.llnl.gov/
 .. _Shroud: https://shroud.readthedocs.io/en/develop/
-.. _Lumberjack: https://lc.llnl.gov/axom/docs/sphinx/lumberjack_docs/html/index.html
+.. _Lumberjack: ../../../lumberjack/docs/sphinx/index.html
 .. _Axom Quick Start Guide: https://axom.readthedocs.io/en/develop/docs/sphinx/quickstart_guide/index.html
 .. _Axom Toolkit: https://axom.readthedocs.io/en/develop/
 .. _WCI: https://wci.llnl.gov/
 .. _WSC: https://wci.llnl.gov/about-us/weapon-simulation-and-computing
-.. _Slic Doxygen API Documentation: https://lc.llnl.gov/axom/docs/doxygen/axom_doxygen/html/slictop.html
+.. _Slic Doxygen API Documentation: ../../../../../doxygen/html/slictop.html
 

--- a/src/axom/slic/docs/sphinx/sections/synopsis.rst
+++ b/src/axom/slic/docs/sphinx/sections/synopsis.rst
@@ -21,7 +21,7 @@ infrastructure that simplifies logging application messages.
 * :ref:`BuiltInLogStreams` to support common logging use cases, e.g., log to
   a file or console.
 
-* Native integration with `Lumberjack`_ for logging and filtering of messages
+* Native integration with `Lumberjack <../../../lumberjack/docs/sphinx/index.html>`_ for logging and filtering of messages
   at scale.
 
 * Fortran bindings that provide an idiomatic API for Fortran applications.
@@ -31,10 +31,10 @@ infrastructure that simplifies logging application messages.
 Slic is designed to be *light-weight* and *self-contained*. The only requirement
 for using Slic is a C++11 compliant compiler. However, to use Slic in the
 context of a distributed parallel application and in conjunction with
-`Lumberjack`_, support for building with MPI is provided.
+`Lumberjack <../../../lumberjack/docs/sphinx/index.html>`_, support for building with MPI is provided.
 
-For further information on how to build the `Axom Toolkit`_,
-consult the `Axom Quick Start Guide`_.
+For further information on how to build the `Axom Toolkit <../../../../index.html>`_,
+consult the `Axom Quick Start Guide <../../../../docs/sphinx/quickstart_guide/index.html>`_.
 
 **About this Guide**
 

--- a/src/axom/slic/docs/sphinx/sections/synopsis.rst
+++ b/src/axom/slic/docs/sphinx/sections/synopsis.rst
@@ -43,7 +43,7 @@ principles of Slic's :ref:`sections/architecture`. To get started with
 using Slic quickly within an application, see the
 :ref:`sections/getting_started` section. For more detailed information on
 the interfaces of the various classes and functions in Slic, developers
-are advised to consult the `Slic Doxygen API Documentation`_.
+are advised to consult the `Slic Doxygen API <../../../../doxygen/html/slictop.html>`_.
 
 Additional questions, feature requests or bug reports on Slic can be submitted
 by `creating a new issue on Github <https://github.com/LLNL/axom/issues>`_

--- a/src/axom/spin/README.md
+++ b/src/axom/spin/README.md
@@ -16,5 +16,5 @@ associated support classes.
   - [RectangularLattice](@ref axom::spin::RectangularLattice) supports
     computation of coordinates for spatial bins.
 
-The [Spin user documentation](../../../sphinx/axom_docs/html/axom/spin/docs/sphinx/index.html)
+The [Spin user documentation](https://axom.readthedocs.io/en/develop/axom/spin/docs/sphinx/index.html)
 describes these classes and their use.

--- a/src/axom/spin/README.md
+++ b/src/axom/spin/README.md
@@ -15,6 +15,3 @@ associated support classes.
     each axis, assigning every object to the range of bins it falls into
   - [RectangularLattice](@ref axom::spin::RectangularLattice) supports
     computation of coordinates for spatial bins.
-
-The [Spin user documentation](https://axom.readthedocs.io/en/develop/axom/spin/docs/sphinx/index.html)
-describes these classes and their use.

--- a/src/conf.py
+++ b/src/conf.py
@@ -16,6 +16,33 @@ import sys
 import os
 import shlex
 
+# Call doxygen in ReadtheDocs
+read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
+if read_the_docs_build:
+
+    # Makes sure directory exists for doxygen output
+    cwd=os.getcwd()
+    buildpath=os.path.join(cwd,"_build")
+    if (os.path.isdir(buildpath) == 0):
+        os.mkdir(buildpath)
+    htmlpath=os.path.join(buildpath,"html")
+    if (os.path.isdir(htmlpath) == 0):
+        os.mkdir(htmlpath)
+
+    # Modify Doxyfile for ReadTheDocs compatibility
+    with open('./docs/doxygen/Doxyfile.in', 'r') as f:
+        fdata = f.read()
+    fdata = fdata.replace('@PROJECT_SOURCE_DIR@', '.')
+    with open('./docs/doxygen/Doxyfile.in', 'w') as f:
+        f.write(fdata)
+    with open('./docs/doxygen/Doxyfile.in', 'a') as f:
+        f.write("\nOUTPUT_DIRECTORY=./_build/html/doxygen")
+
+    # Call doxygen
+    from subprocess import call
+    call(['doxygen', "./docs/doxygen/Doxyfile.in"])
+
+
 # Get current directory
 conf_directory = os.path.dirname(os.path.realpath(__file__))
 

--- a/src/docs/doxygen/CMakeLists.txt
+++ b/src/docs/doxygen/CMakeLists.txt
@@ -16,3 +16,4 @@ add_custom_target( build_doxygen_output_dir
                  ) 
 
 add_dependencies( axom_doxygen build_doxygen_output_dir )
+

--- a/src/docs/doxygen/CMakeLists.txt
+++ b/src/docs/doxygen/CMakeLists.txt
@@ -9,5 +9,10 @@
 
 blt_add_doxygen_target( axom_doxygen )
 
+# Required directory for doxygen to generate output to 
+add_custom_target( build_doxygen_output_dir 
+                   ALL 
+                   COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/html 
+                 ) 
 
-
+add_dependencies( axom_doxygen build_doxygen_output_dir )

--- a/src/docs/doxygen/Doxyfile.in
+++ b/src/docs/doxygen/Doxyfile.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       =
+OUTPUT_DIRECTORY       = ../../html/doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/src/docs/doxygen/Doxyfile.in
+++ b/src/docs/doxygen/Doxyfile.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ../../html/doxygen
+OUTPUT_DIRECTORY       = @PROJECT_BINARY_DIR@/html/doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -1071,7 +1071,7 @@ VERBATIM_HEADERS       = NO
 # classes, structs, unions or interfaces.
 # The default value is: YES.
 
-ALPHABETICAL_INDEX     = NO
+ALPHABETICAL_INDEX     = YES
 
 # The COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns in
 # which the alphabetical index list will be split.

--- a/src/docs/sphinx/coding_guide/references.rst
+++ b/src/docs/sphinx/coding_guide/references.rst
@@ -13,15 +13,15 @@ Most of the guidelines here were gathered from the following list sources.
 The list contains a variety of useful resources for programming in C++
 beyond what is presented in these guidelines.
 
-#. *The Chromium Projects: C++ Dos and Don'ts*. https://www.chromium.org/developers/coding-style/cpp-dos-and-donts
+#. *The Chromium Projects: C++ Dos and Don'ts*. https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++-dos-and-donts.md
 
 #. Dewhurst, S., *C++ Gotchas: Avoiding Common Problems in Coding and Design*, Addison-Wesley, 2003.
 
 #. Dewhurst S., *C++ Common Knowledge: Essential Intermediate Programming*, Addison-Wesley, 2005.
 
-#. *Doxygen manual*, http://www.stack.nl/~dimitri/doxygen/manual/index.html
+#. *Doxygen manual*, http://www.doxygen.nl/manual/
 
-#. *Google C++ Style Guide*, https://google-styleguide.googlecode.com/svn/trunk/cppguide.html
+#. *Google C++ Style Guide*, https://google.github.io/styleguide/cppguide.html
 
 #. *ISO/IEC 14882:2011 C++ Programming Language Standard*.
 

--- a/src/docs/sphinx/coding_guide/sec07_documentation.rst
+++ b/src/docs/sphinx/coding_guide/sec07_documentation.rst
@@ -561,7 +561,7 @@ Summary of common Doxygen commands
 --------------------------------------------------------------------
 
 This Section provides an overview of commonly used Doxygen commands.
-Please see the `Doxygen guide <http://www.stack.nl/~dimitri/doxygen/manual/index.html>`_ for more details and information about other commands.
+Please see the `Doxygen guide <http://www.doxygen.nl/manual/>`_ for more details and information about other commands.
 
 Note that to be processed properly, Doxygen commands **must** be preceded with 
 either "\\" or "\@" character. For brevity, we use "\\" for all commands 

--- a/src/docs/sphinx/dev_guide/component_org.rst
+++ b/src/docs/sphinx/dev_guide/component_org.rst
@@ -20,7 +20,7 @@ tasks to be done when adding a new software component to Axom. These include:
   * Writing tests
 
 .. note:: The discussion here does not contain coding guidelines. Please see
-          `Axom Coding Guide <../../coding_guide_docs/html/index.html>`_ 
+          `Axom Coding Guide <../coding_guide/index.html>`_ 
           for that information.
 
 ====================================
@@ -392,8 +392,8 @@ reference document of your software interfaces and implementations for
 users who need to understand details of your code.
 
 We have a useful discussion of our Doxygen usage conventions in the 
-`Documentation Section of the Axom Coding Guide <../../coding_guide_docs/html/sec07_documentation.html>`_. 
-The `Doxygen Manual <http://www.stack.nl/~dimitri/doxygen/>`_ contains
+`Documentation Section of the Axom Coding Guide <../coding_guide/sec07_documentation.html>`_. 
+The `Doxygen Manual <http://www.doxygen.nl/manual/>`_ contains
 a lot more details.
 
 **Fill in more details when we have a better handle on how we want to organize 

--- a/src/docs/sphinx/dev_guide/index.rst
+++ b/src/docs/sphinx/dev_guide/index.rst
@@ -31,8 +31,8 @@ changes are made, this guide should be updated accordingly.
 .. note:: This document does not describe how to configure and build the
           Axom code, or discuss Axom coding guidelines. For information
           on those topics please refer to the following documents:
-          `Axom Quickstart Guide <../../quickstart_guide_docs/html/index.html>`_,
-          `Axom Coding Guide <../../coding_guide_docs/html/index.html>`_.
+          `Axom Quickstart Guide <../quickstart_guide/index.html>`_,
+          `Axom Coding Guide <../coding_guide/index.html>`_.
 
 
 **Contents:**

--- a/src/docs/sphinx/dev_guide/pull_requests.rst
+++ b/src/docs/sphinx/dev_guide/pull_requests.rst
@@ -70,7 +70,7 @@ Beyond build and test correctness, we also want to ensure that code follows
 common conventions before acceptance. The following list is a high-level 
 summary of the types of concerns we want to identify during pull request 
 reviews and resolve before a pull request is merged. Please see the 
-`Axom Coding Guide <../../coding_guide_docs/html/index.html>`_ for details
+`Axom Coding Guide <../coding_guide/index.html>`_ for details
 on items in this list.
 
  #. A new file or directory must be placed in its proper location; e.g.,

--- a/src/docs/sphinx/dev_guide/release.rst
+++ b/src/docs/sphinx/dev_guide/release.rst
@@ -117,8 +117,8 @@ approved. At this point, the release candidate branch can be deleted.
   script. This will generate a tarball of the form ``Axom-v0.3.1.tar.gz``
 
 * Upload the tarball for the corresponding release, by going to the
- `Github Releases section <https://github.com/LLNL/axom/releases>`_ and ``Edit``
- the release created earlier.
+  `Github Releases section <https://github.com/LLNL/axom/releases>`_ and ``Edit``
+  the release created earlier.
 
 * Attach the tarball to the release.
 

--- a/src/docs/sphinx/quickstart_guide/config_build.rst
+++ b/src/docs/sphinx/quickstart_guide/config_build.rst
@@ -320,7 +320,7 @@ Here are the key build system options in Axom.
 If ``AXOM_ENABLE_ALL_COMPONENTS`` is OFF, you must explicitly enable the desired
 components (other than 'common', which is always enabled).
 
-See `Axom software documentation <../../web_main_docs/html/index.html#axom-software-documentation>`_
+See `Axom software documentation <../../../index.html>`_
 for a list of Axom's components and their dependencies.
 
 .. note :: To configure the version of the C++ standard, you can supply one of the

--- a/src/index.rst
+++ b/src/index.rst
@@ -67,16 +67,16 @@ for Axom software components:
 Source Code Documentation
 --------------------------
 
-  *  `Axom <../../../doxygen/axom_doxygen/html/index.html>`_
-  *  `Core <../../../doxygen/axom_doxygen/html/coretop.html>`_
-  *  `Lumberjack <../../../doxygen/axom_doxygen/html/lumberjacktop.html>`_
-  *  `Mint <../../../doxygen/axom_doxygen/html/minttop.html>`_
-  *  `Primal <../../../doxygen/axom_doxygen/html/primaltop.html>`_
-  *  `Quest <../../../doxygen/axom_doxygen/html/questtop.html>`_
-  *  `Sidre <../../../doxygen/axom_doxygen/html/sidretop.html>`_
-  *  `Spin <../../../doxygen/axom_doxygen/html/spintop.html>`_
-  *  `Slic <../../../doxygen/axom_doxygen/html/slictop.html>`_
-  *  `Slam <../../../doxygen/axom_doxygen/html/slamtop.html>`_
+  *  `Axom <doxygen/html/index.html>`_
+  *  `Core <doxygen/html/coretop.html>`_
+  *  `Lumberjack <doxygen/html/lumberjacktop.html>`_
+  *  `Mint <doxygen/html/minttop.html>`_
+  *  `Primal <doxygen/html/primaltop.html>`_
+  *  `Quest <doxygen/html/questtop.html>`_
+  *  `Sidre <doxygen/html/sidretop.html>`_
+  *  `Spin <doxygen/html/spintop.html>`_
+  *  `Slic <doxygen/html/slictop.html>`_
+  *  `Slam <doxygen/html/slamtop.html>`_
 
 Look for documentation to appear for new components as they are developed.
 


### PR DESCRIPTION
- This PR gets ReadtheDocs to host doxygen documentation. 
You can view the doxygen by going to this branch's [ReadTheDocs](https://axom.readthedocs.io/en/docs-han12-doxygenonreadthedocs/) and clicking on one of the links under "Source Code Documentation" on the first page.
 
- I did a pass through and fixed any broken links I found in reStructuredText and README.md files (README's get pulled into the doxygen documentation).  There were a lot, so I probably did miss some… I also updated links in "References and Useful Resources": https://axom.readthedocs.io/en/docs-han12-doxygenonreadthedocs/docs/sphinx/coding_guide/references.html
so please let me know if they do not link to where they are supposed to.
 
- Added a path to sphinx-build (SPHINX_EXECUTABLE) in rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake .  Motivation being I got an error when trying to generate sphinx documentation with the version at /usr/bin/sphinx-build (version 1.1.3)

