### PR TITLE
Avoid GPU page faults in BVH::find()

### DIFF
--- a/src/axom/spin/BVH.hpp
+++ b/src/axom/spin/BVH.hpp
@@ -6,15 +6,19 @@
 #ifndef AXOM_SPIN_BVH_H_
 #define AXOM_SPIN_BVH_H_
 
+// axom core includes
 #include "axom/config.hpp"                 // for Axom compile-time definitions
 #include "axom/core/Macros.hpp"            // for Axom macros
 #include "axom/core/memory_management.hpp" // for memory functions
 #include "axom/core/Types.hpp"             // for fixed bitwidth types
+
+#include "axom/core/execution/execution_space.hpp" // for execution spaces
+#include "axom/core/execution/for_all.hpp"         // for generic for_all()
+
+// slic includes
 #include "axom/slic/interface/slic.hpp"    // for SLIC macros
 
 // spin includes
-#include "axom/core/execution/execution_space.hpp"
-
 #include "axom/spin/internal/linear_bvh/aabb.hpp"
 #include "axom/spin/internal/linear_bvh/vec.hpp"
 #include "axom/spin/internal/linear_bvh/bvh_vtkio.hpp"
@@ -391,9 +395,7 @@ int BVH< NDIMS, ExecSpace, FloatType >::build()
     const FloatType* myboxes = m_boxes;
 
     // copy first box and add a fake 2nd box
-    using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
-    RAJA::forall< exec_policy >(
-          RAJA::RangeSegment(0,N), AXOM_LAMBDA(IndexType i)
+    for_all< ExecSpace >( N, AXOM_LAMBDA(IndexType i)
     {
       boxesptr[ i ] = ( i < M ) ? myboxes[ i ] : 0.0;
     } );
@@ -476,9 +478,7 @@ void BVH< NDIMS, ExecSpace, FloatType >::find( IndexType* offsets,
   SLIC_ASSERT( inner_nodes != nullptr );
   SLIC_ASSERT( leaf_nodes != nullptr );
 
-  using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0,numPts), AXOM_LAMBDA(IndexType i)
+  for_all< ExecSpace >( numPts, AXOM_LAMBDA(IndexType i)
   {
     int32 count = 0;
     internal::linear_bvh::Vec< FloatType, NDIMS > point;
@@ -547,6 +547,7 @@ void BVH< NDIMS, ExecSpace, FloatType >::find( IndexType* offsets,
 
   } );
 
+  using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
   RAJA::exclusive_scan< exec_policy >(
       counts, counts+numPts, offsets, RAJA::operators::plus<IndexType>{} );
 
@@ -556,8 +557,7 @@ void BVH< NDIMS, ExecSpace, FloatType >::find( IndexType* offsets,
   candidates = axom::allocate< IndexType >( total_candidates);
 
   // STEP 2: fill in candidates for each point
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0, numPts), AXOM_LAMBDA (IndexType i)
+  for_all< ExecSpace >( numPts, AXOM_LAMBDA (IndexType i)
   {
     int32 offset = offsets[ i ];
 
@@ -657,10 +657,8 @@ void BVH< NDIMS, ExecSpace, FloatType >::find( IndexType* offsets,
   SLIC_ASSERT( inner_nodes != nullptr );
   SLIC_ASSERT( leaf_nodes != nullptr );
 
-  using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
   using vec4_t      = internal::linear_bvh::Vec< FloatType, 4 >;
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0, numPts), AXOM_LAMBDA (IndexType i)
+  for_all< ExecSpace >( numPts, AXOM_LAMBDA (IndexType i)
   {
     int32 count = 0;
     internal::linear_bvh::Vec< FloatType, NDIMS > point;
@@ -728,6 +726,7 @@ void BVH< NDIMS, ExecSpace, FloatType >::find( IndexType* offsets,
 
   } );
 
+  using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
   RAJA::exclusive_scan< exec_policy >(
       counts, counts+numPts, offsets, RAJA::operators::plus<IndexType>{} );
 
@@ -737,8 +736,7 @@ void BVH< NDIMS, ExecSpace, FloatType >::find( IndexType* offsets,
   candidates = axom::allocate< IndexType >( total_candidates);
 
   // STEP 2: fill in candidates for each point
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0, numPts), AXOM_LAMBDA (IndexType i)
+  for_all< ExecSpace >( numPts, AXOM_LAMBDA (IndexType i)
   {
     int32 offset = offsets[ i ];
 

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -381,10 +381,10 @@ void custom_sort( ExecSpace, uint32*& mcodes, int32 size, int32* iter )
 #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA) && \
     defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_CUB)
 template < int BLOCK_SIZE >
-void custom_sort( spin::CUDA_EXEC< BLOCK_SIZE >,
+void custom_sort( axom::CUDA_EXEC< BLOCK_SIZE >,
                   uint32*& mcodes, int32 size, int32* iter )
 {
-  using ExecSpace = typename spin::CUDA_EXEC< BLOCK_SIZE >;
+  using ExecSpace = typename axom::CUDA_EXEC< BLOCK_SIZE >;
   array_counting< ExecSpace >(iter, size, 0, 1);
 
   uint32* mcodes_alt_buf = axom::allocate< uint32 >( size );

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -7,6 +7,7 @@
 #define AXOM_SPIN_BUILD_RADIX_TREE_H_
 
 #include "axom/core/execution/execution_space.hpp"
+#include "axom/core/execution/for_all.hpp"
 
 #include "axom/spin/internal/linear_bvh/BVHData.hpp"
 #include "axom/spin/internal/linear_bvh/RadixTree.hpp"
@@ -110,9 +111,7 @@ void transform_boxes( const FloatType *boxes,
   constexpr int NDIMS  = 3;
   constexpr int STRIDE = 2 * NDIMS;
 
-  using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0, size), AXOM_LAMBDA (int32 i)
+  for_all< ExecSpace >( size, AXOM_LAMBDA (int32 i)
   {
     AABB< FloatType, NDIMS > aabb;
     Vec< FloatType, NDIMS > min_point, max_point;
@@ -145,9 +144,7 @@ void transform_boxes( const FloatType *boxes,
   constexpr int NDIMS  = 2;
   constexpr int STRIDE = 2 * NDIMS;
 
-  using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0, size), AXOM_LAMBDA (int32 i)
+  for_all< ExecSpace >( size, AXOM_LAMBDA (int32 i)
   {
     AABB< FloatType, NDIMS > aabb;
     Vec< FloatType, NDIMS > min_point, max_point;
@@ -184,8 +181,7 @@ AABB<FloatType,3> reduce(AABB<FloatType,3> *aabbs, int32 size)
   RAJA::ReduceMax< reduce_policy, FloatType> ymax(neg_infinity32());
   RAJA::ReduceMax< reduce_policy, FloatType> zmax(neg_infinity32());
 
-  using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
-  RAJA::forall< exec_policy >(RAJA::RangeSegment(0,size), AXOM_LAMBDA(int32 i)
+  for_all< ExecSpace >( size, AXOM_LAMBDA(int32 i)
   {
 
     const AABB< FloatType, NDIMS > &aabb = aabbs[i];
@@ -228,10 +224,7 @@ AABB<FloatType,2> reduce(AABB<FloatType,2> *aabbs, int32 size)
   RAJA::ReduceMax< reduce_policy, FloatType> ymax(neg_infinity32());
 
 
-  using exec_policy =
-      typename axom::execution_space< ExecSpace >::loop_policy;
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0, size), AXOM_LAMBDA (int32 i)
+  for_all< ExecSpace >( size, AXOM_LAMBDA (int32 i)
   {
 
     const AABB<FloatType, NDIMS > &aabb = aabbs[ i ];
@@ -276,9 +269,7 @@ void get_mcodes( AABB<FloatType,2> *aabbs,
             0.f : 1.f / extent[i];
   }
 
-  using exec_policy =
-      typename axom::execution_space< ExecSpace >::loop_policy;
-  RAJA::forall< exec_policy >(RAJA::RangeSegment(0,size), AXOM_LAMBDA(int32 i)
+  for_all< ExecSpace >( size, AXOM_LAMBDA(int32 i)
   {
     const AABB<FloatType,NDIMS> &aabb = aabbs[i];
 
@@ -317,9 +308,7 @@ void get_mcodes( AABB<FloatType,3> *aabbs,
           0.f : 1.f / extent[i];
   }
 
-  using exec_policy =
-      typename axom::execution_space< ExecSpace >::loop_policy;
-  RAJA::forall< exec_policy >(RAJA::RangeSegment(0,size), AXOM_LAMBDA(int32 i)
+  for_all< ExecSpace >( size, AXOM_LAMBDA(int32 i)
   {
     const AABB<FloatType,NDIMS> &aabb = aabbs[i];
 
@@ -342,9 +331,7 @@ void array_counting( IntType* iterator,
                      const IntType& start,
                      const IntType& step)
 {
-  using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0, size), AXOM_LAMBDA(int32 i)
+  for_all< ExecSpace >( size, AXOM_LAMBDA(int32 i)
   {
     iterator[ i ] = start + i * step;
   } );
@@ -362,9 +349,7 @@ void reorder(int32 *indices, T *&array, int32 size)
 {
   T* temp = axom::allocate< T >( size );
 
-  using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0, size), AXOM_LAMBDA (int32 i)
+  for_all< ExecSpace >( size, AXOM_LAMBDA (int32 i)
   {
     int32 in_idx = indices[ i ];
     temp[ i ]    = array[ in_idx ];
@@ -426,9 +411,7 @@ void custom_sort( spin::CUDA_EXEC< BLOCK_SIZE >,
   uint32* sorted_keys = d_keys.Current();
   int32*  sorted_vals = d_values.Current();
 
-  using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0,size), AXOM_LAMBDA (int32 i)
+  for_all< ExecSpace >( size, AXOM_LAMBDA (int32 i)
   {
     mcodes[ i ] = sorted_keys[ i ];
     iter[ i ]   = sorted_vals[ i ];
@@ -490,9 +473,7 @@ void build_tree(  RadixTree< FloatType, NDIMS > &data )
   int32 *parent_ptr = data.m_parents;
   const uint32 *mcodes_ptr = data.m_mcodes;
 
-  using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0, inner_size), AXOM_LAMBDA (int32 i)
+  for_all< ExecSpace >( inner_size, AXOM_LAMBDA (int32 i)
   {
     //determine range direction
     int32 d = 0 > (delta(i, i + 1, inner_size, mcodes_ptr) - delta(i, i - 1, inner_size, mcodes_ptr)) ? -1 : 1;
@@ -570,9 +551,7 @@ void build_tree(  RadixTree< FloatType, NDIMS > &data )
 template< typename ExecSpace, typename T>
 static void array_memset(T* array, const int32 size, const T val)
 {
-  using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0, size), AXOM_LAMBDA (int32 i)
+  for_all< ExecSpace >( size, AXOM_LAMBDA (int32 i)
   {
     array[ i ] = val;
   } );
@@ -601,13 +580,10 @@ void propagate_aabbs( RadixTree< FloatType, NDIMS >& data)
 
   array_memset< ExecSpace >(counters_ptr, inner_size, 0);
 
-  using exec_policy   =
-      typename axom::execution_space< ExecSpace >::loop_policy;
   using atomic_policy =
       typename axom::execution_space< ExecSpace >::atomic_policy;
 
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0,leaf_size), AXOM_LAMBDA(int32 i)
+  for_all< ExecSpace >( leaf_size, AXOM_LAMBDA(int32 i)
   {
     int32 current_node = parent_ptr[inner_size + i];
 

--- a/src/axom/spin/internal/linear_bvh/emit_bvh.hpp
+++ b/src/axom/spin/internal/linear_bvh/emit_bvh.hpp
@@ -11,8 +11,8 @@
 #include "axom/core/Types.hpp"               // for fixed bitwidth types
 #include "axom/core/memory_management.hpp"   // for alloc()/free()
 
-// spin includes
 #include "axom/core/execution/execution_space.hpp"
+#include "axom/core/execution/for_all.hpp"
 
 #include "axom/spin/internal/linear_bvh/vec.hpp"
 #include "axom/spin/internal/linear_bvh/aabb.hpp"
@@ -69,9 +69,7 @@ void emit_bvh( RadixTree<FloatType, 3>& data,
 
   Vec<FloatType,4> *flat_ptr = bvh_data.m_inner_nodes;
 
-  using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0, inner_size), AXOM_LAMBDA (int32 node)
+  for_all< ExecSpace >( inner_size, AXOM_LAMBDA (int32 node)
   {
     Vec<FloatType,4> vec1;
     Vec<FloatType,4> vec2;
@@ -135,8 +133,7 @@ void emit_bvh( RadixTree<FloatType, 3>& data,
 
   int32* radix_tree_leafs = data.m_leafs;
   int32* bvh_leafs        = bvh_data.m_leaf_nodes;
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0,size), AXOM_LAMBDA(int32 i)
+  for_all< ExecSpace >( size, AXOM_LAMBDA(int32 i)
   {
     bvh_leafs[ i ] = radix_tree_leafs[ i ];
   } );
@@ -161,9 +158,7 @@ void emit_bvh( RadixTree<FloatType, 2>& data,
 
   Vec<FloatType,4> *flat_ptr = bvh_data.m_inner_nodes;
 
-  using exec_policy = typename axom::execution_space< ExecSpace >::loop_policy;
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0, inner_size), AXOM_LAMBDA (int32 node)
+  for_all< ExecSpace >( inner_size, AXOM_LAMBDA (int32 node)
   {
     Vec<FloatType,4> vec1;
     Vec<FloatType,4> vec2;
@@ -227,8 +222,7 @@ void emit_bvh( RadixTree<FloatType, 2>& data,
 
   int32* radix_tree_leafs = data.m_leafs;
   int32* bvh_leafs        = bvh_data.m_leaf_nodes;
-  RAJA::forall< exec_policy >(
-      RAJA::RangeSegment(0,size), AXOM_LAMBDA(int32 i)
+  for_all< ExecSpace >( size, AXOM_LAMBDA(int32 i)
   {
     bvh_leafs[ i ] = radix_tree_leafs[ i ];
   } );


### PR DESCRIPTION
# Summary

This PR includes changes to the BVH::find() algorithm to use sum reduction variables in order to avoid GPU page faults and implicitly rely and enforce unified memory for storing the supplied `counts` and `offsets` arrays. This allows the calling application to supply device pointers for these arrays.

Resolves #131 

