### PR TITLE
Fix TPL build on LC TOSS machines

### DIFF
--- a/scripts/uberenv/packages/uberenv-axom/package.py
+++ b/scripts/uberenv/packages/uberenv-axom/package.py
@@ -337,14 +337,14 @@ class UberenvAxom(Package):
                     # blueos_p9
                     spectrum_prefix = "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release"
                     if spec['mpi'].mpifc == spectrum_prefix + "-clang-8.0.0/bin/mpif90":
-                        cfg.write(cmake_cache_entry("MPI_Fortran_COMPILER", 
+                        cfg.write(cmake_cache_entry("MPI_Fortran_COMPILER",
                                                     spectrum_prefix + "-xl-2019.06.12/bin/mpif90"))
                     elif spec['mpi'].mpifc == spectrum_prefix + "-clang-upstream-2019.03.26/bin/mpif90":
-                        cfg.write(cmake_cache_entry("MPI_Fortran_COMPILER", 
+                        cfg.write(cmake_cache_entry("MPI_Fortran_COMPILER",
                                                     spectrum_prefix + "-xl-2019.06.12/bin/mpif90"))
                     # blueos
                     elif spec['mpi'].mpifc == spectrum_prefix + "-clang-upstream-2018.11.09/bin/mpif90":
-                        cfg.write(cmake_cache_entry("MPI_Fortran_COMPILER", 
+                        cfg.write(cmake_cache_entry("MPI_Fortran_COMPILER",
                                                     spectrum_prefix + "-xl-2018.11.26/bin/mpif90"))
                     else:
                         cfg.write(cmake_cache_entry("MPI_Fortran_COMPILER", spec['mpi'].mpifc))
@@ -455,6 +455,11 @@ class UberenvAxom(Package):
             if "gcc@4.9.3" == str(spec.compiler):
                 cfg.write(cmake_cache_entry("SCR_DIR",
                     "/usr/gapps/axom/thirdparty_libs/scr-1.2.1/toss_3_x86_64_ib/gcc-4.9.3"))
+
+            if ("gfortran" in f_compiler) and ("clang" in cpp_compiler):
+                cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS",
+                    "-Wl,-rpath,/usr/tce/packages/clang/clang-6.0.0/lib",
+                    "Adds a missing rpath for libraries associated with the fortran compiler"))
 
         if "+openmp" in spec:
             cfg.write(cmake_cache_option("ENABLE_OPENMP", True))

--- a/src/axom/mint/tests/CMakeLists.txt
+++ b/src/axom/mint/tests/CMakeLists.txt
@@ -47,9 +47,9 @@ set( mint_test_dependencies
 blt_list_append( TO mint_test_dependencies
                  ELEMENTS sidre conduit::conduit
                  IF AXOM_MINT_USE_SIDRE )
-blt_list_append( TO mint_test_dependencies ELEMENTS raja IF RAJA_FOUND )
-blt_list_append( TO mint_test_dependencies ELEMENTS openmp IF ENABLE_OPENMP )
-blt_list_append( TO mint_test_dependencies ELEMENTS cuda IF ENABLE_CUDA )
+blt_list_append( TO mint_test_dependencies ELEMENTS raja IF ${RAJA_FOUND} )
+blt_list_append( TO mint_test_dependencies ELEMENTS openmp IF ${ENABLE_OPENMP} )
+blt_list_append( TO mint_test_dependencies ELEMENTS cuda IF ${ENABLE_CUDA} )
 
 foreach( test ${mint_tests} )
 
@@ -65,6 +65,7 @@ foreach( test ${mint_tests} )
 
    blt_add_test( NAME    ${test_name}
                  COMMAND ${test_name}_test
+                 NUM_OMP_THREADS 4
                )
 
 endforeach()

--- a/src/axom/sidre/examples/lulesh2/CMakeLists.txt
+++ b/src/axom/sidre/examples/lulesh2/CMakeLists.txt
@@ -43,11 +43,13 @@ if(AXOM_ENABLE_TESTS)
     if(ENABLE_MPI)
         blt_add_test(NAME sidre_lulesh2
                      COMMAND sidre_lulesh2_ex -s 3
-                     NUM_MPI_TASKS 1 
+                     NUM_MPI_TASKS 1
+                     NUM_OMP_THREADS 2
                     )
     else()
         blt_add_test(NAME sidre_lulesh2
                      COMMAND sidre_lulesh2_ex -s 3
+                     NUM_OMP_THREADS 2
                     )
     endif()
 endif()

--- a/src/axom/sidre/examples/lulesh2/CMakeLists.txt
+++ b/src/axom/sidre/examples/lulesh2/CMakeLists.txt
@@ -20,23 +20,34 @@ set(lulesh_sources
     lulesh-viz.cc
     )
 
+set(lulesh_depends
+    core
+    sidre
+    conduit::conduit
+    hdf5
+    slic
+    )
+
+blt_list_append( TO lulesh_depends ELEMENTS mpi IF ${ENABLE_MPI} )
+blt_list_append( TO lulesh_depends ELEMENTS openmp IF ${ENABLE_OPENMP} )
+
 blt_add_executable(
     NAME sidre_lulesh2_ex
     SOURCES ${lulesh_sources} ${lulesh_headers}
     OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-    DEPENDS_ON core sidre conduit::conduit hdf5 slic
+    DEPENDS_ON ${lulesh_depends}
     FOLDER axom/sidre/examples
     )
 
 if(AXOM_ENABLE_TESTS)
     if(ENABLE_MPI)
         blt_add_test(NAME sidre_lulesh2
-                     COMMAND sidre_lulesh2_ex -s 5
-                     NUM_MPI_TASKS 8
+                     COMMAND sidre_lulesh2_ex -s 3
+                     NUM_MPI_TASKS 8 
                     )
     else()
         blt_add_test(NAME sidre_lulesh2
-                     COMMAND sidre_lulesh2_ex -s 5
+                     COMMAND sidre_lulesh2_ex -s 3
                     )
     endif()
 endif()

--- a/src/axom/sidre/examples/lulesh2/CMakeLists.txt
+++ b/src/axom/sidre/examples/lulesh2/CMakeLists.txt
@@ -43,7 +43,7 @@ if(AXOM_ENABLE_TESTS)
     if(ENABLE_MPI)
         blt_add_test(NAME sidre_lulesh2
                      COMMAND sidre_lulesh2_ex -s 3
-                     NUM_MPI_TASKS 8 
+                     NUM_MPI_TASKS 1 
                     )
     else()
         blt_add_test(NAME sidre_lulesh2

--- a/src/axom/sidre/examples/lulesh2/lulesh-init.cc
+++ b/src/axom/sidre/examples/lulesh2/lulesh-init.cc
@@ -7,7 +7,7 @@
 #ifdef AXOM_USE_MPI
 # include <mpi.h>
 #endif
-#if _OPENMP
+#ifdef _OPENMP
 #include <omp.h>
 #endif
 #include <stdio.h>
@@ -110,7 +110,7 @@ Domain::Domain(Int_t numRanks, Index_t colLoc,
 
    BuildMesh(nx, edgeNodes, edgeElems);
 
-#if _OPENMP
+#ifdef _OPENMP
    SetupThreadSupportStructures();
 #else
    // These arrays are not used if we're not threaded
@@ -251,7 +251,7 @@ Domain::BuildMesh(Int_t nx, Int_t edgeNodes, Int_t edgeElems)
 void
 Domain::SetupThreadSupportStructures()
 {
-#if _OPENMP
+#ifdef _OPENMP
    Index_t numthreads = omp_get_max_threads();
 #else
    Index_t numthreads = 1;

--- a/src/axom/sidre/examples/lulesh2/lulesh.cc
+++ b/src/axom/sidre/examples/lulesh2/lulesh.cc
@@ -2809,6 +2809,7 @@ int main(int argc, char *argv[])
       printf("Running problem size %d^3 per domain until completion\n", opts.nx);
       printf("Num processors: %d\n", numRanks);
 #ifdef _OPENMP
+      omp_set_num_threads( 2 );
       printf("Num threads: %d\n", omp_get_max_threads());
 #endif
       printf("Total number of elements: %lld\n\n", (long long int)(numRanks*opts.nx*opts.nx*opts.nx));

--- a/src/axom/sidre/examples/lulesh2/lulesh.cc
+++ b/src/axom/sidre/examples/lulesh2/lulesh.cc
@@ -156,7 +156,7 @@ Additional BSD Notice
 #include <iostream>
 #include <unistd.h>
 
-#if _OPENMP
+#ifdef _OPENMP
 # include <omp.h>
 #endif
 
@@ -526,7 +526,7 @@ void IntegrateStressForElems( Domain &domain,
                               Real_t *sigxx, Real_t *sigyy, Real_t *sigzz,
                               Real_t *determ, Index_t numElem, Index_t numNode)
 {
-#if _OPENMP
+#ifdef _OPENMP
    Index_t numthreads = omp_get_max_threads();
 #else
    Index_t numthreads = 1;
@@ -751,7 +751,7 @@ void CalcFBHourglassForceForElems( Domain &domain,
                                    Index_t numNode)
 {
 
-#if _OPENMP
+#ifdef _OPENMP
    Index_t numthreads = omp_get_max_threads();
 #else
    Index_t numthreads = 1;
@@ -2555,7 +2555,7 @@ void CalcCourantConstraintForElems(Domain &domain, Index_t length,
                                    Index_t *regElemlist,
                                    Real_t qqc, Real_t& dtcourant)
 {
-#if _OPENMP   
+#ifdef _OPENMP   
    Index_t threads = omp_get_max_threads();
    static Index_t *courant_elem_per_thread;
    static Real_t *dtcourant_per_thread;
@@ -2580,7 +2580,7 @@ void CalcCourantConstraintForElems(Domain &domain, Index_t length,
       Real_t   dtcourant_tmp = dtcourant;
       Index_t  courant_elem  = -1 ;
 
-#if _OPENMP
+#ifdef _OPENMP
       Index_t thread_num = omp_get_thread_num();
 #else
       Index_t thread_num = 0;
@@ -2808,7 +2808,7 @@ int main(int argc, char *argv[])
    if ((myRank == 0) && (opts.quiet == 0)) {
       printf("Running problem size %d^3 per domain until completion\n", opts.nx);
       printf("Num processors: %d\n", numRanks);
-#if _OPENMP
+#ifdef _OPENMP
       printf("Num threads: %d\n", omp_get_max_threads());
 #endif
       printf("Total number of elements: %lld\n\n", (long long int)(numRanks*opts.nx*opts.nx*opts.nx));

--- a/src/axom/sidre/examples/lulesh2/lulesh.cc
+++ b/src/axom/sidre/examples/lulesh2/lulesh.cc
@@ -15,9 +15,9 @@ DIFFERENCES BETWEEN THIS VERSION (2.x) AND EARLIER VERSIONS:
 * Addition of regions to make work more representative of multi-material codes
 * Default size of each domain is 30^3 (27000 elem) instead of 45^3. This is
   more representative of our actual working set sizes
-* Single source distribution supports pure serial, pure OpenMP, MPI-only, 
+* Single source distribution supports pure serial, pure OpenMP, MPI-only,
   and MPI+OpenMP
-* Addition of ability to visualize the mesh using VisIt 
+* Addition of ability to visualize the mesh using VisIt
   https://wci.llnl.gov/codes/visit/download.html
 * Various command line options (see ./lulesh2.0 -h)
  -q              : quiet mode - suppress stdout
@@ -61,7 +61,7 @@ lulesh-util.cc - Non-timed functions
 *   Four of the LULESH routines are now performed on a region-by-region basis,
 *     making the memory access patterns non-unit stride
 *   Artificial load imbalances can be easily introduced that could impact
-*     parallelization strategies.  
+*     parallelization strategies.
 * The load balance flag changes region assignment.  Region number is raised to
 *   the power entered for assignment probability.  Most likely regions changes
 *   with MPI process id.
@@ -210,14 +210,14 @@ void TimeIncrement(Domain& domain)
          gnewdt = domain.dthydro() * Real_t(2.0) / Real_t(3.0) ;
       }
 
-#ifdef AXOM_USE_MPI      
+#ifdef AXOM_USE_MPI
       MPI_Allreduce(&gnewdt, &newdt, 1,
                     ((sizeof(Real_t) == 4) ? MPI_FLOAT : MPI_DOUBLE),
                     MPI_MIN, MPI_COMM_WORLD) ;
 #else
       newdt = gnewdt;
 #endif
-      
+
       ratio = newdt / olddt ;
       if (ratio >= Real_t(1.0)) {
          if (ratio < domain.deltatimemultlb()) {
@@ -762,12 +762,12 @@ void CalcFBHourglassForceForElems( Domain &domain,
     *               force.
     *
     *************************************************/
-  
+
    Index_t numElem8 = numElem * 8 ;
 
-   Real_t *fx_elem; 
-   Real_t *fy_elem; 
-   Real_t *fz_elem; 
+   Real_t *fx_elem;
+   Real_t *fy_elem;
+   Real_t *fz_elem;
 
    if(numthreads > 1) {
       fx_elem = Allocate<Real_t>(numElem8) ;
@@ -1073,7 +1073,7 @@ void CalcHourglassControlForElems(Domain& domain,
 
       /* Do a check for negative volumes */
       if ( domain.v(i) <= Real_t(0.0) ) {
-#ifdef AXOM_USE_MPI         
+#ifdef AXOM_USE_MPI
          MPI_Abort(MPI_COMM_WORLD, VolumeError) ;
 #else
          exit(VolumeError);
@@ -1125,7 +1125,7 @@ void CalcVolumeForceForElems(Domain& domain)
 #endif
       for ( Index_t k=0 ; k<numElem ; ++k ) {
          if (determ[k] <= Real_t(0.0)) {
-#ifdef AXOM_USE_MPI            
+#ifdef AXOM_USE_MPI
             MPI_Abort(MPI_COMM_WORLD, VolumeError) ;
 #else
             exit(VolumeError);
@@ -1148,11 +1148,11 @@ static inline void CalcForceForNodes(Domain& domain)
 {
   Index_t numNode = domain.numNode() ;
 
-#ifdef AXOM_USE_MPI  
+#ifdef AXOM_USE_MPI
   CommRecv(domain, MSG_COMM_SBN, 3,
            domain.sizeX() + 1, domain.sizeY() + 1, domain.sizeZ() + 1,
            true, false) ;
-#endif  
+#endif
 
 #ifdef _OPENMP
 #pragma omp parallel for firstprivate(numNode)
@@ -1166,17 +1166,17 @@ static inline void CalcForceForNodes(Domain& domain)
   /* Calcforce calls partial, force, hourq */
   CalcVolumeForceForElems(domain) ;
 
-#ifdef AXOM_USE_MPI  
+#ifdef AXOM_USE_MPI
   Domain_member fieldData[3] ;
   fieldData[0] = &Domain::fx ;
   fieldData[1] = &Domain::fy ;
   fieldData[2] = &Domain::fz ;
-  
+
   CommSend(domain, MSG_COMM_SBN, 3, fieldData,
            domain.sizeX() + 1, domain.sizeY() + 1, domain.sizeZ() +  1,
            true, false) ;
   CommSBN(domain, 3, fieldData) ;
-#endif  
+#endif
 }
 
 /******************************************/
@@ -1184,7 +1184,7 @@ static inline void CalcForceForNodes(Domain& domain)
 static inline
 void CalcAccelerationForNodes(Domain &domain, Index_t numNode)
 {
-   
+
 #ifdef _OPENMP
 #pragma omp parallel for firstprivate(numNode)
 #endif
@@ -1293,16 +1293,16 @@ void LagrangeNodal(Domain& domain)
    * acceleration boundary conditions. */
   CalcForceForNodes(domain);
 
-#ifdef AXOM_USE_MPI  
+#ifdef AXOM_USE_MPI
 #ifdef SEDOV_SYNC_POS_VEL_EARLY
    CommRecv(domain, MSG_SYNC_POS_VEL, 6,
             domain.sizeX() + 1, domain.sizeY() + 1, domain.sizeZ() + 1,
             false, false) ;
 #endif
 #endif
-   
+
    CalcAccelerationForNodes(domain, domain.numNode());
-   
+
    ApplyAccelerationBoundaryConditionsForNodes(domain);
 
    CalcVelocityForNodes( domain, delt, u_cut, domain.numNode()) ;
@@ -1323,7 +1323,7 @@ void LagrangeNodal(Domain& domain)
    CommSyncPosVel(domain) ;
 #endif
 #endif
-   
+
   return;
 }
 
@@ -1561,7 +1561,7 @@ void CalcElemVelocityGradient( const Real_t* const xvel,
 /******************************************/
 
 //static inline
-void CalcKinematicsForElems( Domain &domain, Real_t *vnew, 
+void CalcKinematicsForElems( Domain &domain, Real_t *vnew,
                              Real_t deltaTime, Index_t numElem )
 {
 
@@ -1660,7 +1660,7 @@ void CalcLagrangeElements(Domain& domain, Real_t* vnew)
         // See if any volumes are negative, and take appropriate action.
          if (vnew[k] <= Real_t(0.0))
         {
-#ifdef AXOM_USE_MPI           
+#ifdef AXOM_USE_MPI
            MPI_Abort(MPI_COMM_WORLD, VolumeError) ;
 #else
            exit(VolumeError);
@@ -1991,10 +1991,10 @@ void CalcMonotonicQRegionForElems(Domain &domain, Int_t r,
 
 static inline
 void CalcMonotonicQForElems(Domain& domain, Real_t vnew[])
-{  
+{
    //
    // initialize parameters
-   // 
+   //
    const Real_t ptiny = Real_t(1.e-36) ;
 
    //
@@ -2027,18 +2027,18 @@ void CalcQForElems(Domain& domain, Real_t vnew[])
 
       domain.AllocateGradients(numElem, allElem);
 
-#ifdef AXOM_USE_MPI      
+#ifdef AXOM_USE_MPI
       CommRecv(domain, MSG_MONOQ, 3,
                domain.sizeX(), domain.sizeY(), domain.sizeZ(),
                true, true) ;
-#endif      
+#endif
 
       /* Calculate velocity gradients */
       CalcMonotonicQGradientsForElems(domain, vnew);
 
-#ifdef AXOM_USE_MPI      
+#ifdef AXOM_USE_MPI
       Domain_member fieldData[3] ;
-      
+
       /* Transfer veloctiy gradients in the first order elements */
       /* problem->commElements->Transfer(CommElements::monoQ) ; */
 
@@ -2051,7 +2051,7 @@ void CalcQForElems(Domain& domain, Real_t vnew[])
                true, true) ;
 
       CommMonoQ(domain) ;
-#endif      
+#endif
 
       CalcMonotonicQForElems(domain, vnew) ;
 
@@ -2059,7 +2059,7 @@ void CalcQForElems(Domain& domain, Real_t vnew[])
       domain.DeallocateGradients();
 
       /* Don't allow excessive artificial viscosity */
-      Index_t idx = -1; 
+      Index_t idx = -1;
       for (Index_t i=0; i<numElem; ++i) {
          if ( domain.q(i) > domain.qstop() ) {
             idx = i ;
@@ -2068,7 +2068,7 @@ void CalcQForElems(Domain& domain, Real_t vnew[])
       }
 
       if(idx >= 0) {
-#ifdef AXOM_USE_MPI         
+#ifdef AXOM_USE_MPI
          MPI_Abort(MPI_COMM_WORLD, QStopError) ;
 #else
          exit(QStopError);
@@ -2101,7 +2101,7 @@ void CalcPressureForElems(Real_t* p_new, Real_t* bvc,
 #endif
    for (Index_t i = 0 ; i < length ; ++i){
       Index_t elem = regElemList[i];
-      
+
       p_new[i] = bvc[i] * e_old[i] ;
 
       if    (FABS(p_new[i]) <  p_cut   )
@@ -2301,7 +2301,7 @@ void EvalEOSForElems(Domain& domain, Real_t *vnewc,
    Real_t emin    = domain.emin() ;
    Real_t rho0    = domain.refdens() ;
 
-   // These temporaries will be of different size for 
+   // These temporaries will be of different size for
    // each call (due to different sized region element
    // lists)
    Real_t *e_old = Allocate<Real_t>(numElemReg) ;
@@ -2318,8 +2318,8 @@ void EvalEOSForElems(Domain& domain, Real_t *vnewc,
    Real_t *q_new = Allocate<Real_t>(numElemReg) ;
    Real_t *bvc = Allocate<Real_t>(numElemReg) ;
    Real_t *pbvc = Allocate<Real_t>(numElemReg) ;
- 
-   //loop to add load imbalance based on region number 
+
+   //loop to add load imbalance based on region number
    for(Int_t j = 0; j < rep; j++) {
       /* compress data, minimal set */
 #ifdef _OPENMP
@@ -2380,7 +2380,7 @@ void EvalEOSForElems(Domain& domain, Real_t *vnewc,
 #pragma omp for nowait firstprivate(numElemReg)
 #endif
          for (Index_t i = 0 ; i < numElemReg ; ++i) {
-            work[i] = Real_t(0.) ; 
+            work[i] = Real_t(0.) ;
          }
       }
       CalcEnergyForElems(p_new, e_new, q_new, bvc, pbvc,
@@ -2476,7 +2476,7 @@ void ApplyMaterialPropertiesForElems(Domain& domain, Real_t vnew[])
                 vc = eosvmax ;
           }
           if (vc <= 0.) {
-#ifdef AXOM_USE_MPI             
+#ifdef AXOM_USE_MPI
              MPI_Abort(MPI_COMM_WORLD, VolumeError) ;
 #else
              exit(VolumeError);
@@ -2555,7 +2555,7 @@ void CalcCourantConstraintForElems(Domain &domain, Index_t length,
                                    Index_t *regElemlist,
                                    Real_t qqc, Real_t& dtcourant)
 {
-#ifdef _OPENMP   
+#ifdef _OPENMP
    Index_t threads = omp_get_max_threads();
    static Index_t *courant_elem_per_thread;
    static Real_t *dtcourant_per_thread;
@@ -2584,10 +2584,10 @@ void CalcCourantConstraintForElems(Domain &domain, Index_t length,
       Index_t thread_num = omp_get_thread_num();
 #else
       Index_t thread_num = 0;
-#endif      
+#endif
 
 #ifdef _OPENMP
-#pragma omp for 
+#pragma omp for
 #endif
       for (Index_t i = 0 ; i < length ; ++i) {
          Index_t indx = regElemlist[i] ;
@@ -2635,7 +2635,7 @@ static inline
 void CalcHydroConstraintForElems(Domain &domain, Index_t length,
                                  Index_t *regElemlist, Real_t dvovmax, Real_t& dthydro)
 {
-#if _OPENMP   
+#if _OPENMP
    Index_t threads = omp_get_max_threads();
    static Index_t *hydro_elem_per_thread;
    static Real_t *dthydro_per_thread;
@@ -2658,11 +2658,11 @@ void CalcHydroConstraintForElems(Domain &domain, Index_t length,
       Real_t dthydro_tmp = dthydro ;
       Index_t hydro_elem = -1 ;
 
-#ifdef _OPENMP      
+#ifdef _OPENMP
       Index_t thread_num = omp_get_thread_num();
-#else      
+#else
       Index_t thread_num = 0;
-#endif      
+#endif
 
 #ifdef _OPENMP
 #pragma omp for
@@ -2743,7 +2743,7 @@ void LagrangeLeapFrog(Domain& domain)
     * material states */
    LagrangeElements(domain, domain.numElem());
 
-#ifdef AXOM_USE_MPI   
+#ifdef AXOM_USE_MPI
 #ifdef SEDOV_SYNC_POS_VEL_LATE
    CommRecv(domain, MSG_SYNC_POS_VEL, 6,
             domain.sizeX() + 1, domain.sizeY() + 1, domain.sizeZ() + 1,
@@ -2755,20 +2755,20 @@ void LagrangeLeapFrog(Domain& domain)
    fieldData[3] = &Domain::xd ;
    fieldData[4] = &Domain::yd ;
    fieldData[5] = &Domain::zd ;
-   
+
    CommSend(domain, MSG_SYNC_POS_VEL, 6, fieldData,
             domain.sizeX() + 1, domain.sizeY() + 1, domain.sizeZ() + 1,
             false, false) ;
 #endif
-#endif   
+#endif
 
    CalcTimeConstraintsForElems(domain);
 
-#ifdef AXOM_USE_MPI   
+#ifdef AXOM_USE_MPI
 #ifdef SEDOV_SYNC_POS_VEL_LATE
    CommSyncPosVel(domain) ;
 #endif
-#endif   
+#endif
 }
 
 
@@ -2781,7 +2781,7 @@ int main(int argc, char *argv[])
    Int_t myRank ;
    struct cmdLineOpts opts;
 
-#ifdef AXOM_USE_MPI   
+#ifdef AXOM_USE_MPI
    Domain_member fieldData ;
 
    MPI_Init(&argc, &argv) ;
@@ -2790,7 +2790,7 @@ int main(int argc, char *argv[])
 #else
    numRanks = 1;
    myRank = 0;
-#endif   
+#endif
 
    /* Set defaults that can be overridden by command line opts */
    opts.its = 9999999;
@@ -2809,7 +2809,6 @@ int main(int argc, char *argv[])
       printf("Running problem size %d^3 per domain until completion\n", opts.nx);
       printf("Num processors: %d\n", numRanks);
 #ifdef _OPENMP
-      omp_set_num_threads( 2 );
       printf("Num threads: %d\n", omp_get_max_threads());
 #endif
       printf("Total number of elements: %lld\n\n", (long long int)(numRanks*opts.nx*opts.nx*opts.nx));
@@ -2833,10 +2832,10 @@ int main(int argc, char *argv[])
                        side, opts.numReg, opts.balance, opts.cost) ;
 
 
-#ifdef AXOM_USE_MPI   
+#ifdef AXOM_USE_MPI
    fieldData = &Domain::nodalMass ;
 
-   // Initial domain boundary communication 
+   // Initial domain boundary communication
    CommRecv(*locDom, MSG_COMM_SBN, 1,
             locDom->sizeX() + 1, locDom->sizeY() + 1, locDom->sizeZ() + 1,
             true, false) ;
@@ -2847,10 +2846,10 @@ int main(int argc, char *argv[])
 
    // End initialization
    MPI_Barrier(MPI_COMM_WORLD);
-#endif   
-   
+#endif
+
    // BEGIN timestep to solution */
-#ifdef AXOM_USE_MPI   
+#ifdef AXOM_USE_MPI
    double start = MPI_Wtime();
 #else
    timeval start;
@@ -2872,7 +2871,7 @@ int main(int argc, char *argv[])
 
    // Use reduced max elapsed time
    double elapsed_time;
-#ifdef AXOM_USE_MPI   
+#ifdef AXOM_USE_MPI
    elapsed_time = MPI_Wtime() - start;
 #else
    timeval end;
@@ -2880,7 +2879,7 @@ int main(int argc, char *argv[])
    elapsed_time = (double)(end.tv_sec - start.tv_sec) + ((double)(end.tv_usec - start.tv_usec))/1000000 ;
 #endif
    double elapsed_timeG;
-#ifdef AXOM_USE_MPI   
+#ifdef AXOM_USE_MPI
    MPI_Reduce(&elapsed_time, &elapsed_timeG, 1, MPI_DOUBLE,
               MPI_MAX, 0, MPI_COMM_WORLD);
 #else
@@ -2891,7 +2890,7 @@ int main(int argc, char *argv[])
    if (opts.viz) {
       DumpToVisit(*locDom, opts.numFiles, myRank, numRanks) ;
    }
-   
+
    if ((myRank == 0) && (opts.quiet == 0)) {
       VerifyAndWriteFinalOutput(elapsed_timeG, *locDom, opts.nx, numRanks);
    }

--- a/src/axom/sidre/tests/CMakeLists.txt
+++ b/src/axom/sidre/tests/CMakeLists.txt
@@ -45,15 +45,13 @@ set(fruit_sidre_tests
 )
 
 
-set(sidre_test_depends 
+set(sidre_test_depends
     sidre
     conduit::conduit
     slic
     )
-    
-if(HDF5_FOUND)
-    list(APPEND sidre_test_depends hdf5)
-endif()    
+
+blt_list_append(TO sidre_test_depends ELEMENTS hdf5 IF ${HDF5_FOUND})
 
 #
 # Add gtest C++ based tests
@@ -67,7 +65,7 @@ foreach(test ${gtest_sidre_tests})
                         FOLDER axom/sidre/tests
                         )
 
-    blt_add_test( NAME ${test_name} 
+    blt_add_test( NAME ${test_name}
                   COMMAND ${test_name}_test
                   )
 endforeach()
@@ -84,7 +82,7 @@ if (ENABLE_FORTRAN)
                             DEPENDS_ON ${sidre_test_depends} gtest
                             FOLDER axom/sidre/tests
                             )
-        blt_add_test( NAME ${test_name} 
+        blt_add_test( NAME ${test_name}
                       COMMAND ${test_name}_test
                       )
     endforeach()
@@ -102,7 +100,7 @@ if (ENABLE_FORTRAN)
                             DEPENDS_ON ${sidre_test_depends} fruit
                             FOLDER axom/sidre/tests
                             )
-        blt_add_test( NAME ${test_name} 
+        blt_add_test( NAME ${test_name}
                       COMMAND ${test_name}_test
                       )
     endforeach()

--- a/src/axom/slam/examples/lulesh2.0.3/CMakeLists.txt
+++ b/src/axom/slam/examples/lulesh2.0.3/CMakeLists.txt
@@ -29,13 +29,8 @@ endif()
 
 set(slam_tests_depends_on core slic slam)
 
-if (ENABLE_OPENMP)
-    list(APPEND slam_tests_depends_on openmp)
-endif()
-
-if (ENABLE_MPI)
-    list(APPEND slam_tests_depends_on mpi)
-endif()
+blt_list_append( TO slam_tests_depends_on ELEMENTS mpi IF ${ENABLE_MPI} )
+blt_list_append( TO slam_tests_depends_on ELEMENTS openmp IF ${ENABLE_OPENMP} )
 
 blt_add_executable(
     NAME        slam_lulesh_ex
@@ -48,10 +43,12 @@ if(AXOM_ENABLE_TESTS)
     if(ENABLE_MPI)
         blt_add_test(NAME        slam_lulesh
                      COMMAND     slam_lulesh_ex
-                     NUM_MPI_TASKS   8 )
+                     NUM_MPI_TASKS   8
+                     NUM_OMP_THREADS 4 )
     else()
         blt_add_test(NAME        slam_lulesh
-                     COMMAND     slam_lulesh_ex )
+                     COMMAND     slam_lulesh_ex
+                     NUM_OMP_THREADS 4 )
     endif()
 endif()
 

--- a/src/axom/slam/examples/lulesh2.0.3/lulesh.cpp
+++ b/src/axom/slam/examples/lulesh2.0.3/lulesh.cpp
@@ -2867,10 +2867,6 @@ int main(int argc, char *argv[])
   myRank = 0;
 #endif
 
-#ifdef AXOM_USE_OPENMP
-  omp_set_num_threads(4);
-#endif
-
   { // initialize logger
     axom::slic::initialize();
 

--- a/src/axom/spin/tests/CMakeLists.txt
+++ b/src/axom/spin/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ if ( ${RAJA_FOUND} AND ${UMPIRE_FOUND} )
    blt_add_test(
       NAME    spin_bvh
       COMMAND spin_bvh_test
+      NUM_OMP_THREADS 4
      )
 
 endif()


### PR DESCRIPTION
# Summary

Adds a missing rpath needed for openmp when compiling with
clang + gfortran.

Resolves #141 
