### PR TITLE
Modify semantics for zero-sized allocations in  `axom::reallocate()`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,9 +25,13 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Updated BLT to develop (30ccea5) as of Nov 21, 2019
 - Set CUDA_SEPARABLE_COMPILATION globally instead of just in a few components.
 - Reduced verbosity of quest's InOutOctree in cases where query point lies on surface.
+- Changed semantics of ``axom::reallocate(_, 0)`` to always return a valid pointer.
+  This matches the semantics of Umpire's ``reallocate(_, 0)``.
+  Note: Umpire's PR-292 fixed a bug in its handling of this case and Axom
+  includes a workaround to get the new behavior until we upgrade to Umpire v2.0+.
 
 ### Fixed
-- Fixed a bug in ``convert_sidre_protocol`` example. Data tructation functionality now
+- Fixed a bug in ``convert_sidre_protocol`` example. Data truncation functionality now
   works properly when multiple Views point to the same data.
 
 ### Known Bugs

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -205,6 +205,12 @@ inline T* reallocate( T* pointer, std::size_t n ) noexcept
 
   pointer = static_cast< T* >( std::realloc( pointer, numbytes ) );
 
+  // Consistently handle realloc(0) for std::realloc to match umpire's behavior
+  if(n==0 && pointer == nullptr)
+  {
+    pointer = axom::allocate<T>(0);
+  }
+
 #endif
 
   return pointer;

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -154,9 +154,6 @@ inline void copy( void* dst, void* src, std::size_t numbytes ) noexcept;
 template < typename T >
 inline T* allocate( std::size_t n, umpire::Allocator allocator ) noexcept
 {
-  if ( n == 0 )
-    return nullptr;
-
   const std::size_t numbytes = n * sizeof( T );
   return static_cast< T* >( allocator.allocate( numbytes )  );
 }
@@ -166,9 +163,6 @@ inline T* allocate( std::size_t n, umpire::Allocator allocator ) noexcept
 template < typename T >
 inline T* allocate( std::size_t n ) noexcept
 {
-  if ( n == 0 )
-    return nullptr;
-
   const std::size_t numbytes = n * sizeof( T );
   return static_cast< T* >( std::malloc( numbytes )  );
 }
@@ -200,12 +194,6 @@ inline void deallocate( T*& pointer ) noexcept
 template < typename T >
 inline T* reallocate( T* pointer, std::size_t n ) noexcept
 {
-  if ( n == 0 )
-  {
-    axom::deallocate( pointer );
-    return nullptr;
-  }
-
   const std::size_t numbytes = n * sizeof( T );
 
 #ifdef AXOM_USE_UMPIRE

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -83,7 +83,7 @@ inline umpire::Allocator getDefaultAllocator()
  * \brief Allocates a chunk of memory of type T.
  *
  * \param [in] n the number of elements to allocate.
- * \param [in] spaceId the memory space where memory will be allocated
+ * \param [in] allocator the Umpire allocator to use
  *(optional)
  *
  * \tparam T the type of pointer returned.
@@ -94,8 +94,6 @@ inline umpire::Allocator getDefaultAllocator()
  *  axom::setDefaultAllocator().
  *
  * \return p pointer to the new allocation or a nullptr if allocation failed.
- *
- * \pre spaceId >= 0 && spaceId < NUM_MEMORY_SPACES
  */
 template < typename T >
 #ifdef AXOM_USE_UMPIRE
@@ -125,6 +123,10 @@ inline void deallocate( T*& p ) noexcept;
  * \tparam T the type pointer p points to.
  *
  * \return p pointer to the new allocation or a nullptr if allocation failed.
+ * 
+ * \note When n == 0, this function returns a valid pointer (of size 0) in the
+ * current allocator's memory space. This follows the semantics of 
+ * Umpire's reallocate function.
  */
 template < typename T >
 inline T* reallocate( T* p, std::size_t n ) noexcept;
@@ -209,7 +211,7 @@ inline T* reallocate( T* pointer, std::size_t n ) noexcept
 
   umpire::ResourceManager& rm = umpire::ResourceManager::getInstance();
 
-  // Workaround for bug in Umpire's handling of reallocate 
+  // Workaround for bug in Umpire's handling of reallocate
   // called on a zero-sized allocation
   // Fixed in Umpire PR #292 (after v1.1.0)
   if(pointer != nullptr)
@@ -229,7 +231,7 @@ inline T* reallocate( T* pointer, std::size_t n ) noexcept
 
   pointer = static_cast< T* >( std::realloc( pointer, numbytes ) );
 
-  // Consistently handle realloc(0) for std::realloc to match umpire's behavior
+  // Consistently handle realloc(0) for std::realloc to match Umpire's behavior
   if(n==0 && pointer == nullptr)
   {
     pointer = axom::allocate<T>(0);

--- a/src/axom/core/tests/core_execution_space.cpp
+++ b/src/axom/core/tests/core_execution_space.cpp
@@ -116,8 +116,12 @@ TEST( core_execution_space, check_invalid )
   check_invalid< InvalidSpace >( );
 }
 
-//------------------------------------------------------------------------------
-#ifdef AXOM_USE_RAJA
+
+//==============================================================================
+// The following tests require RAJA and UMPIRE
+//==============================================================================
+#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_RAJA)
+
 TEST( core_execution_space, check_seq_exec )
 {
   check_valid< axom::SEQ_EXEC >( );
@@ -133,10 +137,9 @@ TEST( core_execution_space, check_seq_exec )
                             void >( allocator_id, IS_ASYNC );
 
 }
-#endif
 
 //------------------------------------------------------------------------------
-#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
+#if defined(AXOM_USE_OPENMP)
 TEST( core_execution_space, check_omp_exec )
 {
 
@@ -152,10 +155,10 @@ TEST( core_execution_space, check_omp_exec )
                             RAJA::omp_synchronize >( allocator_id, IS_ASYNC );
 
 }
-#endif
+#endif // defined(AXOM_USE_OPENMP)
 
 //------------------------------------------------------------------------------
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_CUDA)
 
 TEST( core_execution_space, check_cuda_exec )
 {
@@ -191,7 +194,9 @@ TEST( core_execution_space, check_cuda_exec_async )
                             RAJA::cuda_synchronize >( allocator_id, IS_ASYNC );
 
 }
-#endif
+#endif // defined(AXOM_USE_CUDA)
+
+#endif // defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_RAJA)
 
 //------------------------------------------------------------------------------
 int main(int argc, char* argv[])

--- a/src/axom/core/tests/core_memory_management.cpp
+++ b/src/axom/core/tests/core_memory_management.cpp
@@ -438,6 +438,46 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::ValuesIn(copy_locations)
     ));
 
+
+//------------------------------------------------------------------------------
+TEST( core_memory_management, basic_alloc_realloc_dealloc )
+{
+  // A basic test for axom's allocate, reallocate and deallocate functionality
+  // for the default memory allocator
+
+  constexpr std::size_t N = 5;
+
+  int* buf = nullptr;
+  
+  // allocate an array of size N
+  buf = axom::allocate<int>(N);
+  EXPECT_NE(buf, nullptr);
+
+  // free the array
+  axom::deallocate<int>(buf);
+  EXPECT_EQ(buf, nullptr);
+
+  // reallocate array to size 0
+  buf = axom::reallocate<int>(buf, 0);
+  EXPECT_NE(buf, nullptr);
+
+  // reallocate array to size N
+  buf = axom::reallocate<int>(buf, N);
+  EXPECT_NE(buf, nullptr);
+
+  // reallocate array to size 0
+  buf = axom::reallocate<int>(buf, 0);
+  EXPECT_NE(buf, nullptr);
+
+  // reallocate array to size 0, again
+  buf = axom::reallocate<int>(buf, 0);
+  EXPECT_NE(buf, nullptr);
+
+  // Finally, free the array
+  axom::deallocate<int>(buf);
+  EXPECT_EQ(buf, nullptr);
+}
+
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {

--- a/src/axom/sidre/core/Buffer.hpp
+++ b/src/axom/sidre/core/Buffer.hpp
@@ -165,8 +165,7 @@ public:
   }
 
   /*!
-   * \brief Return true if data description exists.  It may/may not have been
-   * applied to the data yet.  ( Check isApplied() for that. )
+   * \brief Return true if data description exists.
    */
   bool isDescribed() const
   {

--- a/src/axom/sidre/examples/lulesh2/CMakeLists.txt
+++ b/src/axom/sidre/examples/lulesh2/CMakeLists.txt
@@ -38,7 +38,7 @@ if(AXOM_ENABLE_TESTS)
     if(ENABLE_MPI)
         blt_add_test(NAME sidre_lulesh2
                      COMMAND sidre_lulesh2_ex -s 5
-                     NUM_MPI_TASKS 1
+                     NUM_MPI_TASKS 8
                      NUM_OMP_THREADS 2 )
     else()
         blt_add_test(NAME sidre_lulesh2

--- a/src/axom/sidre/tests/sidre_buffer_unit.cpp
+++ b/src/axom/sidre/tests/sidre_buffer_unit.cpp
@@ -84,11 +84,8 @@ void verifyAllocatedBuffer(Buffer* buf, DataTypeId tid, int eltsize,
   EXPECT_EQ(eltsize * eltcount, buf->getTotalBytes());
   EXPECT_EQ(eltcount, buf->getNumElements());
 
-  if (eltcount > 0)
-  {
-    EXPECT_TRUE(buf->isAllocated());
-    EXPECT_NE(static_cast<void*>(nullptr), buf->getVoidPtr());
-  }
+  EXPECT_TRUE(buf->isAllocated());
+  EXPECT_NE(static_cast<void*>(nullptr), buf->getVoidPtr());
 }
 
 // Test describe methods
@@ -272,6 +269,7 @@ TEST(sidre_buffer,buffer_allocate)
   {
     SCOPED_TRACE("Reallocate a described zero-element buffer");
     buf4a->reallocate(eltcount);
+    verifyAllocatedBuffer(buf4a, tid, eltsize, eltcount);
     eltcount = 0;
     buf4a->reallocate(eltcount);
     verifyAllocatedBuffer(buf4a, tid, eltsize, eltcount);
@@ -312,12 +310,12 @@ TEST(sidre_databuffer,buffer_reallocate_zero_elements)
   eltcount = 0;
   buf->reallocate(eltcount);
 
-  EXPECT_FALSE(buf->isAllocated());
+  EXPECT_TRUE(buf->isAllocated());
   EXPECT_TRUE(buf->isDescribed());
   EXPECT_EQ(tid, buf->getTypeID());
   EXPECT_EQ(eltsize * eltcount, buf->getTotalBytes());
   EXPECT_EQ(eltcount, buf->getNumElements());
-  EXPECT_EQ(nullptr, buf->getVoidPtr());
+  EXPECT_NE(nullptr, buf->getVoidPtr());
 
   eltcount = 5;
   buf->reallocate(eltcount);

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -683,6 +683,21 @@ TEST(sidre_group,create_destroy_has_view)
 }
 
 //------------------------------------------------------------------------------
+// createViewAndAllocate() with zero-sized array
+//------------------------------------------------------------------------------
+TEST(sidre_group,create_zero_sized_view)
+{
+  DataStore* ds = new DataStore();
+  Group* root = ds->getRoot();
+
+  View* zeroSizedView = root->createViewAndAllocate("foo", INT_ID, 0);
+  EXPECT_TRUE( zeroSizedView->isDescribed() );
+  EXPECT_TRUE( zeroSizedView->isAllocated() );
+
+  delete ds;
+}
+
+//------------------------------------------------------------------------------
 // createGroup()
 // destroyGroup()
 // hasGroup()

--- a/src/axom/sidre/tests/sidre_view.cpp
+++ b/src/axom/sidre/tests/sidre_view.cpp
@@ -426,9 +426,9 @@ TEST(sidre_view,alloc_zero_items)
     // Allocate with size zero
     dv->allocate(INT_ID, 0);
     expDesc = expAppl = true;
-    expAlloc = false;
+    expAlloc = true;
     EXPECT_TRUE(checkViewValues(dv, BUFFER, expDesc, expAlloc, expAppl, 0));
-    EXPECT_FALSE(dv->getBuffer()->isAllocated());
+    EXPECT_TRUE(dv->getBuffer()->isAllocated());
     EXPECT_EQ(0, dv->getBuffer()->getNumElements());
   }
 
@@ -458,16 +458,17 @@ TEST(sidre_view,alloc_zero_items)
     // Call realloc(0); view and associated buffer are resized
     dv->reallocate(0);
     expDesc = expAppl = true;
-    expAlloc = false;
+    expAlloc = true;
     EXPECT_TRUE(checkViewValues(dv, BUFFER, expDesc, expAlloc, expAppl, 0));
-    EXPECT_FALSE(dv->getBuffer()->isAllocated());
+    EXPECT_TRUE(dv->getBuffer()->isAllocated());
     EXPECT_EQ(0, dv->getBuffer()->getNumElements());
 
     // Deallocate and then allocate() when described with zero items
     dv->deallocate();
-    expDesc = expAppl = true;
-    expAlloc = false;
+    expDesc = true;
+    expAlloc = expAppl = false;
     EXPECT_TRUE(checkViewValues(dv, BUFFER, expDesc, expAlloc, expAppl, 0));
+    expAlloc = expAppl = true;
     dv->allocate();
     EXPECT_TRUE(checkViewValues(dv, BUFFER, expDesc, expAlloc, expAppl, 0));
 
@@ -511,7 +512,7 @@ TEST(sidre_view,alloc_zero_items)
     // reallocate view to have size zero and check that buffer is resized
     dv->reallocate(0);
     expDesc = expAppl = true;
-    expAlloc = false;
+    expAlloc = true;
     EXPECT_TRUE(checkViewValues(dv, BUFFER, expDesc, expAlloc, expAppl, 0));
     EXPECT_EQ(0, dv->getBuffer()->getNumElements());
 
@@ -531,16 +532,16 @@ TEST(sidre_view,alloc_zero_items)
   // Allocate View of size 0 into empty buffer
   {
     bool expDesc = true;
-    bool expAlloc = false;
+    bool expAlloc = true;
     bool expAppl = true;
 
     Buffer* emptyBuf = ds->createBuffer( INT_ID, 0)->allocate();
     View* dv = root->createView("z_emptyBuf_attach_apply");
     dv->attachBuffer(emptyBuf)->allocate()->apply(0);
-    EXPECT_FALSE(dv->getBuffer()->isAllocated());
+    EXPECT_TRUE(dv->getBuffer()->isAllocated());
     EXPECT_TRUE(checkViewValues(dv, BUFFER, expDesc, expAlloc, expAppl, 0));
 
-    // reallocate buffer with non-emtpy size; view should still be zero
+    // reallocate buffer with non-empty size; view should still be zero
     emptyBuf->reallocate(BLEN);
     expDesc = expAlloc = expAppl = true;
     EXPECT_TRUE(checkViewValues(dv, BUFFER, expDesc, expAlloc, expAppl, 0));
@@ -549,17 +550,16 @@ TEST(sidre_view,alloc_zero_items)
 
     // reallocate view to have size zero; view and buffer should be resized
     dv->reallocate(0);
-    expDesc = expAppl = true;
-    expAlloc = false;
+    expDesc = expAlloc = expAppl = true;
     EXPECT_TRUE(checkViewValues(dv, BUFFER, expDesc, expAlloc, expAppl, 0));
-    EXPECT_FALSE(dv->getBuffer()->isAllocated());
+    EXPECT_TRUE(dv->getBuffer()->isAllocated());
     EXPECT_EQ(0, dv->getBuffer()->getNumElements());
 
     // attach a second view with size zero
-    dv = root->createView("z_emptyBuf_described_attach", INT_ID, 0);
-    dv->attachBuffer(emptyBuf);
+    auto* v2 = root->createView("z_emptyBuf_described_attach", INT_ID, 0);
+    v2->attachBuffer(emptyBuf);
     expDesc = true;
-    expAlloc = expAppl = false;
+    expAlloc = expAppl = true;
     EXPECT_TRUE(checkViewValues(dv, BUFFER, expDesc, expAlloc, expAppl, 0));
     EXPECT_EQ(0, dv->getBuffer()->getNumElements());
   }

--- a/src/axom/spin/tests/CMakeLists.txt
+++ b/src/axom/spin/tests/CMakeLists.txt
@@ -47,7 +47,7 @@ foreach ( test ${spin_tests} )
 
 endforeach()
 
-if ( ${RAJA_FOUND} AND ${UMPIRE_FOUND} )
+if ( RAJA_FOUND AND UMPIRE_FOUND )
 
    blt_add_executable(
       NAME       spin_bvh_test

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -394,7 +394,6 @@ void check_find3d( )
   {
     EXPECT_EQ( counts[ i ], 0 );
   }
-  EXPECT_TRUE( candidates == nullptr );
 
   axom::deallocate( offsets );
   axom::deallocate( candidates );
@@ -491,7 +490,6 @@ void check_find2d( )
   {
     EXPECT_EQ( counts[ i ], 0 );
   }
-  EXPECT_TRUE( candidates == nullptr );
 
   axom::deallocate( offsets );
   axom::deallocate( candidates );
@@ -560,13 +558,13 @@ void check_single_box2d( )
   xc[ 0 ] += 10.0; yc[ 0 ] += 10.0;
   bvh.find( offsets, counts, candidates, NUM_BOXES, xc, yc );
   EXPECT_EQ( counts[ 0 ], 0 );
-  EXPECT_TRUE( candidates == nullptr );
 
   axom::deallocate( xc );
   axom::deallocate( yc );
   axom::deallocate( boxes );
   axom::deallocate( offsets );
   axom::deallocate( counts );
+  axom::deallocate( candidates );
   axom::setDefaultAllocator( current_allocator );
 }
 
@@ -629,7 +627,6 @@ void check_single_box3d( )
   xc[ 0 ] += 10.0; yc[ 0 ] += 10.0;
   bvh.find( offsets, counts, candidates, NUM_BOXES, xc, yc, zc );
   EXPECT_EQ( counts[ 0 ], 0 );
-  EXPECT_TRUE( candidates == nullptr );
 
   axom::deallocate( xc );
   axom::deallocate( yc );
@@ -637,6 +634,7 @@ void check_single_box3d( )
   axom::deallocate( boxes );
   axom::deallocate( offsets );
   axom::deallocate( counts );
+  axom::deallocate( candidates );
   axom::setDefaultAllocator( current_allocator );
 }
 


### PR DESCRIPTION
# Summary

- This PR modifies the semantics of ``axom::reallocate(_, 0)`` to always return a valid pointer
- This matches the semantics of ``Umpire``'s ``reallocate(_,0)`` function (after a bugfix in https://github.com/LLNL/Umpire/pull/292)
   - This PR includes a workaround to achieve this new behavior with our existing version of Umpire. We can consider removing this workaround after we upgrade Umpire to a version later than v1.1.
- Also updates sidre's test to verify a ``Buffer`` or ``View`` is allocated after a zero-sized allocation is requested
  - Note that there were no changes necessary to ``sidre``, only to our sidre tests related to zero-sized allocations.
- This change fixes a regression for Visualizing mesh blueprint files in a domain decomposed case where some domains did not have elements for a particular mesh. 
   - For more details, see: https://github.com/visit-dav/visit/issues/4212

# Design review)

- We discussed this on the ``axom-dev`` mailing list and in a team meeting on 1/6/2020.
- This issue was also brought up with several customers during a meeting on 1/8/2020.