### PR TITLE
Update BLT to 0.3.0 and fix gtest warnings

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,7 +22,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ### Deprecated
 
 ### Changed
-- Updated BLT to develop (30ccea5) as of Nov 21, 2019
+- Updated BLT to develop (f0ab9a4) as of Jan 15, 2020
 - Set CUDA_SEPARABLE_COMPILATION globally instead of just in a few components.
 - Reduced verbosity of quest's InOutOctree in cases where query point lies on surface.
 - Changed semantics of ``axom::reallocate(_, 0)`` to always return a valid pointer.

--- a/src/axom/core/tests/core_memory_management.cpp
+++ b/src/axom/core/tests/core_memory_management.cpp
@@ -430,7 +430,7 @@ const std::string copy_locations[] = {
 };
 
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   core_memory_management,
   CopyTest,
   ::testing::Combine(

--- a/src/axom/sidre/tests/sidre_buffer.cpp
+++ b/src/axom/sidre/tests/sidre_buffer.cpp
@@ -549,7 +549,7 @@ const int allocators[] = {
 #endif
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   sidre_buffer,
   UmpireTest,
   ::testing::ValuesIn(allocators)

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -2479,7 +2479,7 @@ const int allocators[] = {
 #endif
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   sidre_group,
   UmpireTest,
   ::testing::ValuesIn(allocators)

--- a/src/axom/sidre/tests/sidre_view.cpp
+++ b/src/axom/sidre/tests/sidre_view.cpp
@@ -1832,7 +1832,7 @@ const int allocators[] = {
 #endif
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   sidre_view,
   UmpireTest,
   ::testing::ValuesIn(allocators)
@@ -2070,7 +2070,7 @@ const std::string copy_locations[] = {
 
 const int offsets[] = {0, 29};
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   sidre_view,
   UpdateTest,
   ::testing::Combine(

--- a/src/axom/slam/tests/slam_set_BitSet.cpp
+++ b/src/axom/slam/tests/slam_set_BitSet.cpp
@@ -365,7 +365,7 @@ TEST_P(SlamBitSet, differenceOperator)
   EXPECT_TRUE(bitset1.isValid());
 }
 
-INSTANTIATE_TEST_CASE_P(SlamBitSetParam,
+INSTANTIATE_TEST_SUITE_P(SlamBitSetParam,
                         SlamBitSet,
                         ::testing::ValuesIn( testSizes() ));
 

--- a/src/axom/slam/tests/slam_set_IndirectionSet.cpp
+++ b/src/axom/slam/tests/slam_set_IndirectionSet.cpp
@@ -130,7 +130,7 @@ using MyTypes = ::testing::Types<
         slam::VectorIndirectionSet< axom::int32, axom::int64 >
         >;
 
-TYPED_TEST_CASE(IndirectionSetTester, MyTypes);
+TYPED_TEST_SUITE(IndirectionSetTester, MyTypes);
 
 
 TYPED_TEST(IndirectionSetTester, constuct)

--- a/src/axom/slam/tests/slam_set_Iterator.cpp
+++ b/src/axom/slam/tests/slam_set_Iterator.cpp
@@ -127,7 +127,7 @@ using MyTypes = ::testing::Types<
         VectorSet,
         ArraySet
         >;
-TYPED_TEST_CASE(OrderedSetIteratorTester, MyTypes);
+TYPED_TEST_SUITE(OrderedSetIteratorTester, MyTypes);
 
 
 TYPED_TEST(OrderedSetIteratorTester,basic_operations)

--- a/src/axom/spin/tests/spin_implicit_grid.cpp
+++ b/src/axom/spin/tests/spin_implicit_grid.cpp
@@ -44,7 +44,7 @@ using MyTypes = ::testing::Types <
         axom::spin::ImplicitGrid<2>,
         axom::spin::ImplicitGrid<3> >;
 
-TYPED_TEST_CASE( ImplicitGridTest, MyTypes );
+TYPED_TEST_SUITE( ImplicitGridTest, MyTypes );
 
 
 TYPED_TEST( ImplicitGridTest, initialization)


### PR DESCRIPTION
Update BLT and fix new gtest warnings due to deprecated features.

#147 
