### PR TITLE
Update Umpire to v2.0.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ### Deprecated
 
 ### Changed
+- Updated Umpire TPL to v2.0.0, which, natively handles zero byte re-allocations consistently. Workaround
+  for older releases of Umpire is in place for backwards compatibility. 
 - Updated BLT to develop (f0ab9a4) as of Jan 15, 2020
 - Set CUDA_SEPARABLE_COMPILATION globally instead of just in a few components.
 - Reduced verbosity of quest's InOutOctree in cases where query point lies on surface.

--- a/scripts/uberenv/packages/umpire/package.py
+++ b/scripts/uberenv/packages/umpire/package.py
@@ -12,8 +12,9 @@ class Umpire(CMakePackage):
     architectures"""
 
     homepage = 'https://github.com/LLNL/Umpire'
-    url='https://github.com/LLNL/Umpire/releases/download/v1.0.0/umpire-1.0.0.tar.gz'
+    url='https://github.com/LLNL/Umpire/releases/download/v2.0.0/umpire-2.0.0.tar.gz'
 
+    version('2.0.0', '4ba1c960b16552e0a85f28c244a9c383')
     version('1.0.0', '3435e9c9d48f2b05f838eb64fbf66d8e')
     version('0.3.2', '2b4138fb4d4272de8c34c073b4c6e88c')
 

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -198,10 +198,14 @@ inline T* reallocate( T* pointer, std::size_t n ) noexcept
 {
   const std::size_t numbytes = n * sizeof( T );
 
-#ifdef AXOM_USE_UMPIRE
+#if defined(AXOM_USE_UMPIRE) && !defined(UMPIRE_VERSION_MAJOR)
 
   // Workaround for bug in Umpire's handling on reallocate(0)
   // Fixed in Umpire PR #292 (after v1.1.0)
+
+  // NOTE: The UMPIRE_VERSION_MAJOR macro was added in umpire-v2.0.0. If the
+  // macro is not defined, we assume that the Umpire version is less than 2.0.0
+  // and that the workaround is needed.
   if(n==0)
   {
     axom::deallocate<T>(pointer);
@@ -225,6 +229,12 @@ inline T* reallocate( T* pointer, std::size_t n ) noexcept
     }
   }
 
+  pointer = static_cast< T* >( rm.reallocate( pointer, numbytes ) );
+
+#elif defined(AXOM_USE_UMPIRE) && (UMPIRE_VERSION_MAJOR >= 2)
+
+  // Umpire 2.0.0 and above handles reallocate(0) natively
+  umpire::ResourceManager& rm = umpire::ResourceManager::getInstance();
   pointer = static_cast< T* >( rm.reallocate( pointer, numbytes ) );
 
 #else


### PR DESCRIPTION
# Summary

This PR updates Umpire to v2.0.0. In addition, `axom::reallocate()` is updated since umpire-v2.0.0 natively handles zero byte reallocations consistently.  The previously implemented workaround remains in place for backwards compatibility.
