### PR TITLE
Support for CI Testing using Azure Pipelines/Docker

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,38 +13,54 @@ strategy:
   matrix:
     linux_gcc6:
       VM_ImageName: 'ubuntu-16.04'
-      Compiler_ImageName: 'axom/compilers:gcc-6'
-      CMAKE_EXTRA_FLAGS: '-DAXOM_ENABLE_SIDRE=Off'
+      Compiler_ImageName: 'axom/tpls:gcc-6'
+      CMAKE_EXTRA_FLAGS: ''
       COMPILER: 'g++'
       TEST_TARGET: 'linux_gcc6'
-    linux_gcc7:
-      VM_ImageName: 'ubuntu-16.04'
-      Compiler_ImageName: 'axom/compilers:gcc-7'
-      CMAKE_EXTRA_FLAGS: '-DAXOM_ENABLE_SIDRE=Off'
-      COMPILER: 'g++'
-      TEST_TARGET: 'linux_gcc7'
+      HOST_CONFIG: 'docker-linux-ubuntu16.04-x86_64-gcc@6.1.0'
     linux_gcc8:
       VM_ImageName: 'ubuntu-16.04'
-      Compiler_ImageName: 'axom/compilers:gcc-8'
-      CMAKE_EXTRA_FLAGS: '-DAXOM_ENABLE_SIDRE=Off'
+      Compiler_ImageName: 'axom/tpls:gcc-8'
+      CMAKE_EXTRA_FLAGS: ''
       COMPILER: 'g++'
       TEST_TARGET: 'linux_gcc8'
+      HOST_CONFIG: 'docker-linux-ubuntu16.04-x86_64-gcc@8.1.0'
+    linux_gcc7:
+      VM_ImageName: 'ubuntu-16.04'
+      Compiler_ImageName: 'axom/tpls:gcc-7'
+      CMAKE_EXTRA_FLAGS: ''
+      COMPILER: 'g++'
+      TEST_TARGET: 'linux_gcc7'
+      HOST_CONFIG: 'docker-linux-ubuntu16.04-x86_64-gcc@7.3.0'
     linux_clang4:
-      VM_ImageName: 'ubuntu-16.04'
-      Compiler_ImageName: 'axom/compilers:clang-4'
-      CMAKE_EXTRA_FLAGS: '-DAXOM_ENABLE_SIDRE=Off'
-      COMPILER: 'clang++'
-      TEST_TARGET: 'linux_clang4'
+       VM_ImageName: 'ubuntu-16.04'
+       Compiler_ImageName: 'axom/tpls:clang-4'
+       CMAKE_EXTRA_FLAGS: ''
+       COMPILER: 'clang++'
+       TEST_TARGET: 'linux_clang4'
+       HOST_CONFIG: 'docker-linux-ubuntu16.04-x86_64-clang@4.0.0'
+    linux_clang5:
+       VM_ImageName: 'ubuntu-16.04'
+       Compiler_ImageName: 'axom/tpls:clang-5'
+       CMAKE_EXTRA_FLAGS: ''
+       COMPILER: 'clang++'
+       TEST_TARGET: 'linux_clang5'
+       HOST_CONFIG: 'docker-linux-ubuntu16.04-x86_64-clang@5.0.0'
     linux_clang6:
-      VM_ImageName: 'ubuntu-16.04'
-      Compiler_ImageName: 'axom/compilers:clang-6'
-      CMAKE_EXTRA_FLAGS: '-DAXOM_ENABLE_SIDRE=Off'
-      COMPILER: 'clang++'
-      TEST_TARGET: 'linux_clang6'
+       VM_ImageName: 'ubuntu-16.04'
+       Compiler_ImageName: 'axom/tpls:clang-6'
+       CMAKE_EXTRA_FLAGS: ''
+       COMPILER: 'clang++'
+       TEST_TARGET: 'linux_clang6'
+       HOST_CONFIG: 'docker-linux-ubuntu16.04-x86_64-clang@6.0.0'
     osx_gcc:
       VM_ImageName: 'macos-10.13'
       CMAKE_EXTRA_FLAGS: '-DAXOM_ENABLE_SIDRE=Off'
       TEST_TARGET: 'osx_gcc'
+    windows:
+      VM_ImageName: 'windows-2019'
+      CMAKE_EXTRA_FLAGS: '-DAXOM_ENABLE_SIDRE=Off'
+      TEST_TARGET: 'win_vs'
 
 pool:
   vmImage: $(VM_ImageName)
@@ -57,7 +73,13 @@ steps:
   inputs:
     workingDir: 'build'
     cmakeArgs: '$(CMAKE_EXTRA_FLAGS) ../src'
-  condition: eq( variables['Agent.OS'], 'Darwin')
+  condition: or( eq( variables['Agent.OS'], 'Windows_NT'), eq( variables['Agent.OS'], 'Darwin'))
+- task: VSBuild@1
+  inputs:
+    solution: 'build/*.sln'
+    vsVersion: 'latest'
+  condition: eq( variables['Agent.OS'], 'Windows_NT')
+  displayName: 'Visual Studio Build'
 - script: |
     cd build
     make
@@ -69,8 +91,10 @@ steps:
   displayName: '$(TEST_TARGET) Test'
   condition: eq( variables['Agent.OS'], 'Darwin')
 - script:  |
-    docker run --rm --user='root' -v `pwd`:/home/axom $(Compiler_ImageName) chown -R axom /home/axom
-    docker run --rm  -v `pwd`:/home/axom -e TEST_TARGET -e COMPILER -e DO_BUILD -e DO_TEST -e CMAKE_EXTRA_FLAGS $(Compiler_ImageName) ./scripts/azure-pipelines/linux-build_and_test.sh
+    echo " -e $TEST_TARGET -e $COMPILER -e $DO_BUILD -e $DO_TEST -e $CMAKE_EXTRA_FLAGS $(Compiler_ImageName) ./scripts/azure-pipelines/linux-build_and_test.sh"
+    docker run --rm --user='root' -v `pwd`:/home/axom/axom $(Compiler_ImageName) chown -R axom /home/axom
+    docker run --rm -v `pwd`:/home/axom/axom -e TEST_TARGET -e COMPILER -e DO_BUILD -e DO_TEST -e HOST_CONFIG -e CMAKE_EXTRA_FLAGS $(Compiler_ImageName) ./axom/scripts/azure-pipelines/linux-build_and_test.sh
+
   condition: eq( variables['Agent.OS'], 'Linux')
   displayName: '$(TEST_TARGET) Build & Test'
 - task: PublishTestResults@2

--- a/host-configs/docker/docker-linux-ubuntu16.04-x86_64-clang@4.0.0.cmake
+++ b/host-configs/docker/docker-linux-ubuntu16.04-x86_64-clang@4.0.0.cmake
@@ -1,0 +1,90 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# Copyright (c) 2017-2020, Lawrence Livermore National Security, LLC and
+# other Axom Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+#------------------------------------------------------------------------------
+# SYS_TYPE: linux-ubuntu16.04-x86_64
+# Compiler Spec: clang@4.0.0
+#------------------------------------------------------------------------------
+# CMake executable path: /home/axom/axom_tpls/clang-4.0.0/cmake-3.10.1/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+# C compiler used by spack
+set(CMAKE_C_COMPILER "/usr/bin/clang" CACHE PATH "")
+
+# C++ compiler used by spack
+set(CMAKE_CXX_COMPILER "/usr/bin/clang++" CACHE PATH "")
+
+# Fortran compiler used by spack
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/bin/gfortran" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/home/axom/axom_tpls/clang-4.0.0" CACHE PATH "")
+
+# conduit from uberenv
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
+
+# mfem from uberenv
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")
+
+# hdf5 from uberenv
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.19" CACHE PATH "")
+
+# scr not built by uberenv
+
+# raja from uberenv
+set(RAJA_DIR "/usr/local/share/raja/cmake/share/raja/cmake" CACHE PATH "")
+
+# umpire from uberenv
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-1.0.0/share/umpire/cmake" CACHE PATH "")
+
+# python not built by uberenv
+
+set(ENABLE_DOCS OFF CACHE BOOL "")
+
+# shroud not built by uberenv
+
+# uncrustify not built by uberenv
+
+# lcov and genhtml not built by uberenv
+
+# cppcheck not built by uberenv
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/home/axom/axom_tpls/clang-4.0.0/mpich-3.0.4/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/home/axom/axom_tpls/clang-4.0.0/mpich-3.0.4/bin/mpic++" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/home/axom/axom_tpls/clang-4.0.0/mpich-3.0.4/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/home/axom/axom_tpls/clang-4.0.0/mpich-3.0.4/bin/mpiexec" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+

--- a/host-configs/docker/docker-linux-ubuntu16.04-x86_64-clang@5.0.0.cmake
+++ b/host-configs/docker/docker-linux-ubuntu16.04-x86_64-clang@5.0.0.cmake
@@ -1,0 +1,90 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# Copyright (c) 2017-2020, Lawrence Livermore National Security, LLC and
+# other Axom Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+#------------------------------------------------------------------------------
+# SYS_TYPE: linux-ubuntu16.04-x86_64
+# Compiler Spec: clang@5.0.0
+#------------------------------------------------------------------------------
+# CMake executable path: /home/axom/axom_tpls/clang-5.0.0/cmake-3.10.1/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+# C compiler used by spack
+set(CMAKE_C_COMPILER "/usr/bin/clang" CACHE PATH "")
+
+# C++ compiler used by spack
+set(CMAKE_CXX_COMPILER "/usr/bin/clang++" CACHE PATH "")
+
+# Fortran compiler used by spack
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/bin/gfortran" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/home/axom/axom_tpls/clang-5.0.0" CACHE PATH "")
+
+# conduit from uberenv
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
+
+# mfem from uberenv
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")
+
+# hdf5 from uberenv
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.19" CACHE PATH "")
+
+# scr not built by uberenv
+
+# raja from uberenv
+set(RAJA_DIR "/usr/local/share/raja/cmake/share/raja/cmake" CACHE PATH "")
+
+# umpire from uberenv
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-1.0.0/share/umpire/cmake" CACHE PATH "")
+
+# python not built by uberenv
+
+set(ENABLE_DOCS OFF CACHE BOOL "")
+
+# shroud not built by uberenv
+
+# uncrustify not built by uberenv
+
+# lcov and genhtml not built by uberenv
+
+# cppcheck not built by uberenv
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/home/axom/axom_tpls/clang-5.0.0/mpich-3.0.4/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/home/axom/axom_tpls/clang-5.0.0/mpich-3.0.4/bin/mpic++" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/home/axom/axom_tpls/clang-5.0.0/mpich-3.0.4/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/home/axom/axom_tpls/clang-5.0.0/mpich-3.0.4/bin/mpiexec" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+

--- a/host-configs/docker/docker-linux-ubuntu16.04-x86_64-clang@6.0.0.cmake
+++ b/host-configs/docker/docker-linux-ubuntu16.04-x86_64-clang@6.0.0.cmake
@@ -1,0 +1,90 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# Copyright (c) 2017-2020, Lawrence Livermore National Security, LLC and
+# other Axom Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+#------------------------------------------------------------------------------
+# SYS_TYPE: linux-ubuntu16.04-x86_64
+# Compiler Spec: clang@6.0.0
+#------------------------------------------------------------------------------
+# CMake executable path: /home/axom/axom_tpls/clang-6.0.0/cmake-3.10.1/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+# C compiler used by spack
+set(CMAKE_C_COMPILER "/usr/bin/clang" CACHE PATH "")
+
+# C++ compiler used by spack
+set(CMAKE_CXX_COMPILER "/usr/bin/clang++" CACHE PATH "")
+
+# Fortran compiler used by spack
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/bin/gfortran" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/home/axom/axom_tpls/clang-6.0.0" CACHE PATH "")
+
+# conduit from uberenv
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
+
+# mfem from uberenv
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")
+
+# hdf5 from uberenv
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.19" CACHE PATH "")
+
+# scr not built by uberenv
+
+# raja from uberenv
+set(RAJA_DIR "/usr/local/share/raja/cmake/share/raja/cmake" CACHE PATH "")
+
+# umpire from uberenv
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-1.0.0/share/umpire/cmake" CACHE PATH "")
+
+# python not built by uberenv
+
+set(ENABLE_DOCS OFF CACHE BOOL "")
+
+# shroud not built by uberenv
+
+# uncrustify not built by uberenv
+
+# lcov and genhtml not built by uberenv
+
+# cppcheck not built by uberenv
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/home/axom/axom_tpls/clang-6.0.0/mpich-3.0.4/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/home/axom/axom_tpls/clang-6.0.0/mpich-3.0.4/bin/mpic++" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/home/axom/axom_tpls/clang-6.0.0/mpich-3.0.4/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/home/axom/axom_tpls/clang-6.0.0/mpich-3.0.4/bin/mpiexec" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+

--- a/host-configs/docker/docker-linux-ubuntu16.04-x86_64-gcc@6.1.0.cmake
+++ b/host-configs/docker/docker-linux-ubuntu16.04-x86_64-gcc@6.1.0.cmake
@@ -1,0 +1,94 @@
+##################################
+# !!!! This is a generated file, edit at own risk !!!!
+##################################
+
+# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+# other Axom Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+##################################
+
+##################################
+
+# SYS_TYPE: linux-ubuntu16.04-x86_64
+# Compiler Spec: gcc@6.1.0
+##################################
+
+# CMake executable path: /home/axom/axom_tpls/gcc-6.1.0/cmake-3.9.6/bin/cmake
+
+##############
+# Compilers
+##############
+
+# C compiler used by spack
+set(CMAKE_C_COMPILER "/usr/bin/gcc" CACHE PATH "")
+
+# C++ compiler used by spack
+set(CMAKE_CXX_COMPILER "/usr/bin/g++" CACHE PATH "")
+
+# Fortran compiler used by spack
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/bin/gfortran" CACHE PATH "")
+
+##############
+# TPLs
+##############
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/home/axom/axom_tpls/gcc-6.1.0" CACHE PATH "")
+
+# conduit from uberenv
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
+
+# mfem from uberenv
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")
+
+# hdf5 from uberenv
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.19" CACHE PATH "")
+
+# scr not built by uberenv
+
+# raja from uberenv
+set(RAJA_DIR "/usr/local/share/raja/cmake" CACHE PATH "")
+
+# umpire from uberenv
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-1.0.0/share/umpire/cmake" CACHE PATH "")
+
+# python not built by uberenv
+
+set(ENABLE_DOCS OFF CACHE BOOL "")
+
+# shroud not built by uberenv
+
+# uncrustify not built by uberenv
+
+# lcov and genhtml not built by uberenv
+
+# cppcheck not built by uberenv
+
+##############
+# MPI
+##############
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/home/axom/axom_tpls/gcc-6.1.0/mpich-3.2.1/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/home/axom/axom_tpls/gcc-6.1.0/mpich-3.2.1/bin/mpic++" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/home/axom/axom_tpls/gcc-6.1.0/mpich-3.2.1/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC "/home/axom/axom_tpls/gcc-6.1.0/mpich-3.2.1/bin/mpiexec" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
+
+##############
+# Other machine specifics
+##############
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+

--- a/host-configs/docker/docker-linux-ubuntu16.04-x86_64-gcc@7.3.0.cmake
+++ b/host-configs/docker/docker-linux-ubuntu16.04-x86_64-gcc@7.3.0.cmake
@@ -1,0 +1,94 @@
+##################################
+# !!!! This is a generated file, edit at own risk !!!!
+##################################
+
+# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+# other Axom Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+##################################
+
+##################################
+
+# SYS_TYPE: linux-ubuntu16.04-x86_64
+# Compiler Spec: gcc@7.3.0
+##################################
+
+# CMake executable path: /home/axom/axom_tpls/gcc-7.3.0/cmake-3.9.6/bin/cmake
+
+##############
+# Compilers
+##############
+
+# C compiler used by spack
+set(CMAKE_C_COMPILER "/usr/bin/gcc" CACHE PATH "")
+
+# C++ compiler used by spack
+set(CMAKE_CXX_COMPILER "/usr/bin/g++" CACHE PATH "")
+
+# Fortran compiler used by spack
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/bin/gfortran" CACHE PATH "")
+
+##############
+# TPLs
+##############
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/home/axom/axom_tpls/gcc-7.3.0" CACHE PATH "")
+
+# conduit from uberenv
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
+
+# mfem from uberenv
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")
+
+# hdf5 from uberenv
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.19" CACHE PATH "")
+
+# scr not built by uberenv
+
+# raja from uberenv
+set(RAJA_DIR "/usr/local/share/raja/cmake" CACHE PATH "")
+
+# umpire from uberenv
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-1.0.0/share/umpire/cmake" CACHE PATH "")
+
+# python not built by uberenv
+
+set(ENABLE_DOCS OFF CACHE BOOL "")
+
+# shroud not built by uberenv
+
+# uncrustify not built by uberenv
+
+# lcov and genhtml not built by uberenv
+
+# cppcheck not built by uberenv
+
+##############
+# MPI
+##############
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/home/axom/axom_tpls/gcc-7.3.0/mpich-3.2.1/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/home/axom/axom_tpls/gcc-7.3.0/mpich-3.2.1/bin/mpic++" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/home/axom/axom_tpls/gcc-7.3.0/mpich-3.2.1/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC "/home/axom/axom_tpls/gcc-7.3.0/mpich-3.2.1/bin/mpiexec" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
+
+##############
+# Other machine specifics
+##############
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+

--- a/host-configs/docker/docker-linux-ubuntu16.04-x86_64-gcc@8.1.0.cmake
+++ b/host-configs/docker/docker-linux-ubuntu16.04-x86_64-gcc@8.1.0.cmake
@@ -1,0 +1,94 @@
+##################################
+# !!!! This is a generated file, edit at own risk !!!!
+##################################
+
+# Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+# other Axom Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+##################################
+
+##################################
+
+# SYS_TYPE: linux-ubuntu16.04-x86_64
+# Compiler Spec: gcc@8.1.0
+##################################
+
+# CMake executable path: /home/axom/axom_tpls/gcc-8.1.0/cmake-3.9.6/bin/cmake
+
+##############
+# Compilers
+##############
+
+# C compiler used by spack
+set(CMAKE_C_COMPILER "/usr/bin/gcc" CACHE PATH "")
+
+# C++ compiler used by spack
+set(CMAKE_CXX_COMPILER "/usr/bin/g++" CACHE PATH "")
+
+# Fortran compiler used by spack
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/bin/gfortran" CACHE PATH "")
+
+##############
+# TPLs
+##############
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/home/axom/axom_tpls/gcc-8.1.0" CACHE PATH "")
+
+# conduit from uberenv
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
+
+# mfem from uberenv
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")
+
+# hdf5 from uberenv
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.19" CACHE PATH "")
+
+# scr not built by uberenv
+
+# raja from uberenv
+set(RAJA_DIR "/usr/local/share/raja/cmake" CACHE PATH "")
+
+# umpire from uberenv
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-1.0.0/share/umpire/cmake" CACHE PATH "")
+
+# python not built by uberenv
+
+set(ENABLE_DOCS OFF CACHE BOOL "")
+
+# shroud not built by uberenv
+
+# uncrustify not built by uberenv
+
+# lcov and genhtml not built by uberenv
+
+# cppcheck not built by uberenv
+
+##############
+# MPI
+##############
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/home/axom/axom_tpls/gcc-8.1.0/mpich-3.2.1/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/home/axom/axom_tpls/gcc-8.1.0/mpich-3.2.1/bin/mpic++" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/home/axom/axom_tpls/gcc-8.1.0/mpich-3.2.1/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC "/home/axom/axom_tpls/gcc-8.1.0/mpich-3.2.1/bin/mpiexec" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
+
+##############
+# Other machine specifics
+##############
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+

--- a/scripts/azure-pipelines/linux-build_and_test.sh
+++ b/scripts/azure-pipelines/linux-build_and_test.sh
@@ -6,7 +6,8 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ##############################################################################
 
-env
+set -x
+
 function or_die () {
     "$@"
     local status=$?
@@ -16,21 +17,30 @@ function or_die () {
     fi
 }
 
-or_die mkdir azure-${TEST_TARGET}-build
-cd azure-${TEST_TARGET}-build
+or_die cd axom
+git submodule init 
+git submodule update 
+
+echo HOST_CONFIG
+echo $HOST_CONFIG
+
 if [[ "$DO_BUILD" == "yes" ]] ; then
-    or_die cmake -DCMAKE_CXX_COMPILER="${COMPILER}" ${CMAKE_EXTRA_FLAGS} ../src
+    or_die ./config-build.py -hc /home/axom/axom/host-configs/docker/${HOST_CONFIG}.cmake -DENABLE_GTEST_DEATH_TESTS=ON
+    or_die cd build-$HOST_CONFIG-debug
     if [[ ${CMAKE_EXTRA_FLAGS} == *COVERAGE* ]] ; then
-      or_die make -j 3
+        or_die make -j 10
     else
-      or_die make -j 3 VERBOSE=1
+        or_die make -j 10 VERBOSE=1
     fi
     if [[ "${DO_TEST}" == "yes" ]] ; then
-      or_die ctest -T test --output-on-failure -V
+        make CTEST_OUTPUT_ON_FAILURE=1 test ARGS='-T Test -VV -j8'
     fi
     if [[ "${DO_MEMCHECK}" == "yes" ]] ; then
       or_die ctest -T memcheck
     fi
 fi
+
+find ./axom/sidre -type d -exec chmod 755 {} \;
+find ./axom/sidre -type f -exec chmod 644 {} \;
 
 exit 0

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -1,0 +1,89 @@
+**WHAT IS A DOCKERFILE?**
+Dockerfiles are used to create Docker images.  Docker images are the 'recipes' used to build virtual environments called containers. These dockerfiles all use a base Linux image that has a particular compiler installed.  These base images were created by David Beckinsale and are located on Docker Hub at this location:
+https://hub.docker.com/r/axom/compilers/tags
+
+**EXPLANATION OF DOCKERFILE CONTENTS**
+The base images are accessed in these dockerfiles by the use of the 'FROM' command:
+>FROM axom/compilers:&lt;compiler&gt;
+
+The remaining dockerfile commands attempt to build the Axom third party libraries using the specified compiler. The following commands update the compiler and add Fortran compiler support:
+
+>RUN sudo apt-get update -y
+
+>RUN sudo apt-get install curl -fy
+RUN sudo apt-get -qq install -y --no-install-recommends gfortran-7 && sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-7 100
+
+>#(For Clang Builds - Need to restore stdc++ lib)
+
+>RUN sudo apt-get install libstdc++-7-dev
+
+Then the Axom and RAJA source is retrieved and RAJA is built and installed: (WORKDIR functions as a 'cd' command)
+>RUN git clone --recursive https://github.com/LLNL/axom.git
+
+>RUN git clone --recursive https://github.com/LLNL/RAJA.git
+
+>WORKDIR "/home/axom/RAJA"
+
+>RUN mkdir build
+
+>WORKDIR "/home/axom/RAJA/build"
+
+>RUN cmake ../. -DENABLE_TESTS=OFF
+
+>RUN make 
+
+>RUN sudo make install
+
+Finally, the uberenv script is invoked to build the libraries and store them in the axom_tpls directory.  (The host config files produced during this process had been added to the Axom repo under "axom/host-configs/docker")
+
+>sudo apt-get update -y
+
+>WORKDIR "/home/axom/axom"
+
+>RUN ./scripts/uberenv/uberenv.py --spack-config-dir=./scripts/uberenv/spack_configs/docker --spec=%&lt;compiler&gt;^mpich@3.0.4 --prefix=/home/axom/axom_tpls -k
+
+Note: The mpich specification (^mpich@3.0.4) is necessary for clang builds.  Not specifying it currently results in the system attempting to use and patch version 3.2.1 of mpich, which fails. See https://github.com/spack/spack/pull/8320 and https://github.com/spack/spack/issues/8432
+Also, mpich itself is used because openmpi's mpiexec will not run for the root user and causes multiple test failures.
+
+Once completed, this container can be used to build and test the Axom application on a Docker-using CI web tool such as Azure Pipelines.
+
+Already built Docker images containing these third party libraries can be accessed on Docker Hub at this location:
+https://hub.docker.com/r/axom/tpls/tags
+
+**BUILDING THE IMAGE**
+Using a dockerfile to create an image requires a Docker client called Docker Desktop that provides a command line interface for Docker commands.  Once this client has been installed the image can be built in two ways.
+
+1. BUILD INTERACTIVELY
+
+   The first way is to run an interactive session of the base image followed by running the individual commands at the session prompt.
+
+   Running the interactive session is accomplished with the "docker run -it <base image>" command. For example:
+
+   >docker run -it axom/compilers:&lt;compiler&gt;
+
+   This should start a container that provides a linux prompt.  The remaining commands can be entered in order (without the Docker 'RUN' command):
+
+   >sudo apt-get update -y
+
+   >sudo apt-get install curl -fy
+
+   etc...
+
+   Once all the commands have been completed the container can be exited and then converted into an image using the "docker commit" command.
+
+   >docker commit &lt;container id&gt; &lt;image repository:tag&gt;
+
+   The container id can be found with "docker container ls -a".
+   The &lt;image repository:tag&gt; is chosen by the user to identify this image.
+
+2. BUILD WITH DOCKERFILE
+
+   The second way is to have the Docker engine build the image directly from the dockerfile.  This is done by placing the dockerfile in an empty directory and using the "docker build" command.
+
+   >docker build -t &lt;image repository:tag&gt; &lt;dir with dockerfile&gt;
+
+   The -t &lt;image repositag&gt; opt sets the repository:tag identifier of the image.
+
+**PUSHING THE IMAGE TO DOCKER HUB**
+Once created the image can be uploaded to Docker Hub with the "docker push" command.
+>docker push &lt;image repository:tag&gt;

--- a/scripts/docker/dockerfile_clang-4
+++ b/scripts/docker/dockerfile_clang-4
@@ -1,0 +1,30 @@
+FROM axom/compilers:clang-4
+
+RUN sudo apt-get update -y
+RUN sudo apt-get install curl -fy
+
+RUN sudo apt-get -qq install -y --no-install-recommends gfortran-7 && sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-7 100
+ 
+#(For Clang Builds - Need to restore stdc++ lib)
+RUN sudo apt-get install libstdc++-7-dev
+
+RUN git clone --recursive https://github.com/LLNL/axom.git
+
+RUN git clone --recursive https://github.com/LLNL/RAJA.git
+
+WORKDIR "/home/axom/RAJA"
+RUN mkdir build
+
+WORKDIR "/home/axom/RAJA/build"
+
+RUN cmake ../. -DENABLE_TESTS=OFF
+RUN make 
+RUN sudo make install
+
+WORKDIR "/home/axom/axom"
+
+RUN ./scripts/uberenv/uberenv.py --spack-config-dir=./scripts/uberenv/spack_configs/docker --spec=%clang@4.0.0^mpich@3.0.4 --prefix=/home/axom/axom_tpls -k
+
+WORKDIR "/home/axom"
+
+RUN rm -rf axom

--- a/scripts/docker/dockerfile_clang-5
+++ b/scripts/docker/dockerfile_clang-5
@@ -1,0 +1,28 @@
+FROM axom/compilers:clang-5
+
+RUN sudo apt-get update -y
+RUN sudo apt-get install curl -fy
+
+RUN sudo apt-get -qq install -y --no-install-recommends gfortran-7 && sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-7 100
+ 
+#(For Clang Builds - Need to restore stdc++ lib)
+RUN sudo apt-get install libstdc++-7-dev
+
+RUN git clone --recursive https://github.com/LLNL/axom.git
+
+RUN git clone --recursive https://github.com/LLNL/RAJA.git
+
+WORKDIR "/home/axom/RAJA"
+RUN mkdir build
+
+WORKDIR "/home/axom/RAJA/build"
+RUN cmake ../. -DENABLE_TESTS=OFF
+RUN make 
+RUN sudo make install
+
+WORKDIR "/home/axom/axom"
+RUN ./scripts/uberenv/uberenv.py --spack-config-dir=./scripts/uberenv/spack_configs/docker --spec=%clang@5.0.0^mpich@3.0.4 --prefix=/home/axom/axom_tpls -k
+
+WORKDIR "/home/axom"
+
+RUN rm -rf axom

--- a/scripts/docker/dockerfile_clang-6
+++ b/scripts/docker/dockerfile_clang-6
@@ -1,0 +1,28 @@
+FROM axom/compilers:clang-6
+RUN sudo apt-get update -y
+RUN sudo apt-get install curl -fy
+
+RUN sudo apt-get -qq install -y --no-install-recommends gfortran-7 && sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-7 100
+ 
+#(For Clang Builds - Need to restore stdc++ lib)
+RUN sudo apt-get install libstdc++-7-dev
+
+RUN git clone --recursive https://github.com/LLNL/axom.git
+
+RUN git clone --recursive https://github.com/LLNL/RAJA.git
+
+WORKDIR "/home/axom/RAJA"
+RUN mkdir build
+
+WORKDIR "/home/axom/RAJA/build"
+RUN cmake ../. -DENABLE_TESTS=OFF
+RUN make 
+RUN sudo make install
+
+WORKDIR "/home/axom/axom"
+
+RUN ./scripts/uberenv/uberenv.py --spack-config-dir=./scripts/uberenv/spack_configs/docker --spec=%clang@6.0.0^mpich@3.0.4 --prefix=/home/axom/axom_tpls -k
+
+WORKDIR "/home/axom"
+
+RUN rm -rf axom

--- a/scripts/docker/dockerfile_gcc-6
+++ b/scripts/docker/dockerfile_gcc-6
@@ -1,0 +1,24 @@
+FROM axom/compilers:gcc-6
+
+RUN sudo apt-get update -y
+RUN sudo apt-get install curl -fy
+
+RUN sudo apt-get -qq install -y --no-install-recommends gfortran-7 && sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-7 100
+
+RUN git clone --recursive https://github.com/LLNL/axom.git
+
+RUN git clone --recursive https://github.com/LLNL/RAJA.git
+
+WORKDIR "/home/axom/RAJA"
+RUN mkdir build
+
+WORKDIR "/home/axom/RAJA/build"
+RUN cmake ../. -DENABLE_TESTS=OFF
+RUN make 
+RUN sudo make install
+
+WORKDIR "/home/axom/axom"
+RUN ./scripts/uberenv/uberenv.py --spack-config-dir=./scripts/uberenv/spack_configs/docker --spec=%gcc@6.1.0 --prefix=/home/axom/axom_tpls -k
+
+WORKDIR "/home/axom"
+RUN rm -rf axom

--- a/scripts/docker/dockerfile_gcc-7
+++ b/scripts/docker/dockerfile_gcc-7
@@ -1,0 +1,26 @@
+FROM axom/compilers:gcc-7
+
+RUN sudo apt-get update -y
+RUN sudo apt-get install curl -fy
+
+RUN sudo apt-get -qq install -y --no-install-recommends gfortran-7 && sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-7 100
+
+RUN git clone --recursive https://github.com/LLNL/axom.git
+
+RUN git clone --recursive https://github.com/LLNL/RAJA.git
+
+WORKDIR "/home/axom/RAJA"
+RUN mkdir build
+
+WORKDIR "/home/axom/RAJA/build"
+RUN cmake ../. -DENABLE_TESTS=OFF
+RUN make 
+RUN sudo make install
+
+WORKDIR "/home/axom/axom"
+
+RUN ./scripts/uberenv/uberenv.py --spack-config-dir=./scripts/uberenv/spack_configs/docker --spec=%gcc@7.3.0 --prefix=/home/axom/axom_tpls -k
+
+WORKDIR "/home/axom"
+
+RUN rm -rf axom

--- a/scripts/docker/dockerfile_gcc-8
+++ b/scripts/docker/dockerfile_gcc-8
@@ -1,0 +1,25 @@
+FROM axom/compilers:gcc-8
+
+RUN sudo apt-get update -y
+RUN sudo apt-get install curl -fy
+
+RUN sudo apt-get -qq install -y --no-install-recommends gfortran-7 && sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-7 100
+
+RUN git clone --recursive https://github.com/LLNL/axom.git
+
+RUN git clone --recursive https://github.com/LLNL/RAJA.git
+
+WORKDIR "/home/axom/RAJA"
+RUN mkdir build
+
+WORKDIR "/home/axom/RAJA/build"
+RUN cmake ../. -DENABLE_TESTS=OFF
+RUN make 
+RUN sudo make install
+
+WORKDIR "/home/axom/axom"
+RUN ./scripts/uberenv/uberenv.py --spack-config-dir=./scripts/uberenv/spack_configs/docker --spec=%gcc@8.1.0 --prefix=/home/axom/axom_tpls -k
+
+WORKDIR "/home/axom"
+
+RUN rm -rf axom

--- a/scripts/uberenv/spack_configs/docker/compilers.yaml
+++ b/scripts/uberenv/spack_configs/docker/compilers.yaml
@@ -1,0 +1,80 @@
+compilers:
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: ubuntu16.04
+    paths:
+      cc:  /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc:  /usr/bin/gfortran
+    spec: gcc@6.1.0
+    target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: ubuntu16.04
+    paths:
+      cc:  /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc:  /usr/bin/gfortran
+    spec: gcc@7.3.0
+    target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: ubuntu16.04
+    paths:
+      cc:  /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc:  /usr/bin/gfortran
+    spec: gcc@8.1.0
+    target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: 
+      cxxflags: -stdlib=libc++
+    modules: []
+    operating_system: ubuntu16.04
+    paths:
+      cc:  /usr/bin/clang
+      cxx: /usr/bin/clang++
+      f77: /usr/bin/gfortran
+      fc:  /usr/bin/gfortran
+    spec: clang@6.0.0
+    target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: ubuntu16.04
+    paths:
+      cc:  /usr/bin/clang
+      cxx: /usr/bin/clang++
+      f77: /usr/bin/gfortran
+      fc:  /usr/bin/gfortran
+    spec: clang@5.0.0
+    target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: ubuntu16.04
+    paths:
+      cc:  /usr/bin/clang
+      cxx: /usr/bin/clang++
+      f77: /usr/bin/gfortran
+      fc:  /usr/bin/gfortran
+    spec: clang@4.0.0
+    target: x86_64

--- a/scripts/uberenv/spack_configs/docker/packages.yaml
+++ b/scripts/uberenv/spack_configs/docker/packages.yaml
@@ -1,0 +1,79 @@
+
+# -------------------------------------------------------------------------
+# This file controls default concretization preferences for Spack.
+#
+# Settings here are versioned with Spack and are intended to provide
+# sensible defaults out of the box. Spack maintainers should edit this
+# file to keep it current.
+#
+# Users can override these settings by editing the following files.
+#
+# Per-spack-instance settings (overrides defaults):
+#   $SPACK_ROOT/etc/spack/packages.yaml
+#
+# Per-user settings (overrides default and site settings):
+#   ~/.spack/packages.yaml
+# -------------------------------------------------------------------------
+packages:
+  all:
+    compiler: [gcc, intel, pgi, clang, xl, nag]
+    providers:
+      awk: [gawk]
+      blas: [openblas]
+      daal: [intel-daal]
+      elf: [elfutils]
+      golang: [gcc]
+      ipp: [intel-ipp]
+      java: [jdk]
+      lapack: [openblas]
+      mkl: [intel-mkl]
+      mpe: [mpe2]
+      mpi: [mpich]
+      opencl: [pocl]
+      openfoam: [openfoam-com, openfoam-org, foam-extend]
+      pil: [py-pillow]
+      scalapack: [netlib-scalapack]
+      szip: [libszip, libaec]
+      tbb: [intel-tbb]
+      jpeg: [libjpeg-turbo, libjpeg]
+# Spack may grab for mpi & we don't want to use them
+  charm:
+    buildable: False
+  mpilander:
+    buildable: False  
+# System level packages to not build
+  autotools:
+    paths:
+      autotools: /usr/bin/
+    buildable: False 
+  bzip2:
+   paths:
+      bzip2: /usr/bin/
+   buildable: False
+  gettext:
+   paths:
+      gettext: /usr/bin/
+   buildable: False
+  m4:
+   paths:
+      m4: /usr/bin/
+   buildable: False
+  pkg-config:
+    paths:
+      pkg-config: /usr/bin/
+    buildable: False 
+  tar:
+   paths:
+      tar: /usr/bin/
+   buildable: False
+  graphviz:
+    paths:
+      graphviz: /usr/bin/
+    buildable: False
+  raja:
+    paths:
+      raja: /usr/local/share/raja/cmake
+    buildable: False
+# Globally lock in version of CMake
+  cmake:
+    version: [3.10.1]


### PR DESCRIPTION
# Summary

- This PR is a feature
- It adds support for CI testing of Axom using Azure Pipelines/Docker.
- Currently enables testing on Linux, Windows, and Mac.
- Linux testing uses following compilers: Clang 4,5,6 and GCC 6,7,8
- Dockerfiles located in axom/scripts/docker were used to generate docker images stored on Docker Hub.  See README.
