### PR TITLE
RAJA implementation of naive triangle intersection algorithm 

### DIFF
--- a/src/axom/core/Macros.hpp
+++ b/src/axom/core/Macros.hpp
@@ -70,6 +70,15 @@
 #endif
 
 /*!
+ * \def AXOM_DEVICE_CODE
+ *
+ * \brief Convenience macro used for kernel code
+ */
+#if defined (__CUDA_ARCH__)
+#define AXOM_DEVICE_CODE
+#endif
+
+/*!
  *
  * \def AXOM_NOT_USED(x)
  * \brief Macro used to silence compiler warnings in methods with unused

--- a/src/axom/core/numerics/Determinants.hpp
+++ b/src/axom/core/numerics/Determinants.hpp
@@ -9,6 +9,7 @@
 #include "axom/core/numerics/LU.hpp"     // for lu_decompose()
 #include "axom/core/numerics/Matrix.hpp" // for Matrix
 
+#include "axom/core/Macros.hpp"
 
 namespace axom
 {
@@ -27,7 +28,8 @@ namespace numerics
  * \return det the determinant of the 2X2 matrix
  */
 template < typename real >
-inline real determinant( const real& a00, const real& a01,
+inline AXOM_HOST_DEVICE 
+real determinant( const real& a00, const real& a01,
                          const real& a10, const real& a11 )
 {
   const real det = a00*a11 - a10*a01;

--- a/src/axom/core/numerics/Determinants.hpp
+++ b/src/axom/core/numerics/Determinants.hpp
@@ -30,7 +30,7 @@ namespace numerics
 template < typename real >
 inline AXOM_HOST_DEVICE 
 real determinant( const real& a00, const real& a01,
-                         const real& a10, const real& a11 )
+                  const real& a10, const real& a11 )
 {
   const real det = a00*a11 - a10*a01;
   return det;

--- a/src/axom/core/numerics/Matrix.hpp
+++ b/src/axom/core/numerics/Matrix.hpp
@@ -606,7 +606,7 @@ AXOM_HOST_DEVICE Matrix< T >::Matrix( int rows, int cols, T* data,
   }
   else
   {
-#if defined(__CUDA_ARCH__)
+#if defined(AXOM_DEVICE_CODE)
     assert(false);
 #else
     const int nitems = m_rows * m_cols;
@@ -923,7 +923,7 @@ void Matrix< T >::copy( const Matrix< T >& rhs )
 template < typename T >
 AXOM_HOST_DEVICE void Matrix< T >::clear( )
 {
-#if defined(__CUDA_ARCH__)
+#if defined(AXOM_DEVICE_CODE)
   assert(m_usingExternal);
 #else
   if ( !m_usingExternal )

--- a/src/axom/core/numerics/matvecops.hpp
+++ b/src/axom/core/numerics/matvecops.hpp
@@ -575,9 +575,9 @@ inline bool linspace( const T& x0, const T& x1, T* v, int N )
 template < typename T >
 inline void cross_product( const T* u, const T* v, T* w )
 {
-    assert( "pre: u pointer is null" && (u != nullptr) );
-    assert( "pre: v pointer is null" && (v != nullptr) );
-    assert( "pre: w pointer is null" && (w != nullptr) );
+  assert( "pre: u pointer is null" && (u != nullptr) );
+  assert( "pre: v pointer is null" && (v != nullptr) );
+  assert( "pre: w pointer is null" && (w != nullptr) );
 
   w[ 0 ] = numerics::determinant( u[1], u[2], v[1], v[2] );
 
@@ -590,9 +590,9 @@ inline void cross_product( const T* u, const T* v, T* w )
 template < typename T >
 inline T dot_product( const T* u, const T* v, int dim)
 {
-    assert("pre: u pointer is null" && (u != nullptr));
-    assert("pre: v pointer is null" && (v != nullptr));
-    assert("pre: dim >= 1" && (dim >= 1));
+  assert("pre: u pointer is null" && (u != nullptr));
+  assert("pre: v pointer is null" && (v != nullptr));
+  assert("pre: dim >= 1" && (dim >= 1));
 
   T res = u[0]*v[0];
   for (int i = 1 ; i < dim ; ++i)

--- a/src/axom/core/numerics/matvecops.hpp
+++ b/src/axom/core/numerics/matvecops.hpp
@@ -575,11 +575,9 @@ inline bool linspace( const T& x0, const T& x1, T* v, int N )
 template < typename T >
 inline void cross_product( const T* u, const T* v, T* w )
 {
-  #ifndef AXOM_USE_RAJA
     assert( "pre: u pointer is null" && (u != nullptr) );
     assert( "pre: v pointer is null" && (v != nullptr) );
     assert( "pre: w pointer is null" && (w != nullptr) );
-  #endif
 
   w[ 0 ] = numerics::determinant( u[1], u[2], v[1], v[2] );
 
@@ -592,11 +590,9 @@ inline void cross_product( const T* u, const T* v, T* w )
 template < typename T >
 inline T dot_product( const T* u, const T* v, int dim)
 {
-  #ifndef AXOM_USE_RAJA
     assert("pre: u pointer is null" && (u != nullptr));
     assert("pre: v pointer is null" && (v != nullptr));
     assert("pre: dim >= 1" && (dim >= 1));
-  #endif
 
   T res = u[0]*v[0];
   for (int i = 1 ; i < dim ; ++i)

--- a/src/axom/core/numerics/matvecops.hpp
+++ b/src/axom/core/numerics/matvecops.hpp
@@ -24,6 +24,8 @@
 #include <cassert> // for assert()
 #include <cmath>   // for sqrt()
 
+#include "axom/core/Macros.hpp"
+
 namespace axom
 {
 namespace numerics
@@ -85,7 +87,8 @@ inline bool linspace( const T& x0, const T& x1, T* v, int N );
  *
  */
 template < typename T >
-inline void cross_product( const T* u, const T* v, T* w );
+inline AXOM_HOST_DEVICE
+void cross_product( const T* u, const T* v, T* w );
 
 /*!
  * \brief Computes the dot product of the arrays u and v.
@@ -103,7 +106,8 @@ inline void cross_product( const T* u, const T* v, T* w );
  * \pre v has at least dim entries
  */
 template < typename T >
-inline T dot_product( const T* u, const T* v, int dim);
+inline AXOM_HOST_DEVICE
+T dot_product( const T* u, const T* v, int dim);
 
 /*!
  * \brief Makes u orthogonal to v.
@@ -571,9 +575,11 @@ inline bool linspace( const T& x0, const T& x1, T* v, int N )
 template < typename T >
 inline void cross_product( const T* u, const T* v, T* w )
 {
-  assert( "pre: u pointer is null" && (u != nullptr) );
-  assert( "pre: v pointer is null" && (v != nullptr) );
-  assert( "pre: w pointer is null" && (w != nullptr) );
+  #ifndef AXOM_USE_RAJA
+    assert( "pre: u pointer is null" && (u != nullptr) );
+    assert( "pre: v pointer is null" && (v != nullptr) );
+    assert( "pre: w pointer is null" && (w != nullptr) );
+  #endif
 
   w[ 0 ] = numerics::determinant( u[1], u[2], v[1], v[2] );
 
@@ -586,9 +592,11 @@ inline void cross_product( const T* u, const T* v, T* w )
 template < typename T >
 inline T dot_product( const T* u, const T* v, int dim)
 {
-  assert("pre: u pointer is null" && (u != nullptr));
-  assert("pre: v pointer is null" && (v != nullptr));
-  assert("pre: dim >= 1" && (dim >= 1));
+  #ifndef AXOM_USE_RAJA
+    assert("pre: u pointer is null" && (u != nullptr));
+    assert("pre: v pointer is null" && (v != nullptr));
+    assert("pre: dim >= 1" && (dim >= 1));
+  #endif
 
   T res = u[0]*v[0];
   for (int i = 1 ; i < dim ; ++i)

--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -72,10 +72,6 @@ blt_add_library(
     OBJECT                TRUE
     )
 
-if (ENABLE_CUDA)
-  set_target_properties(primal PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-endif()
-
 axom_write_unified_header(NAME    primal
                           HEADERS ${primal_headers})
 

--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -61,7 +61,7 @@ set( primal_dependencies
      slic
      )
      
-blt_list_append( TO primal_dependencies ELEMENTS cuda IF ${ENABLE_CUDA} )
+blt_list_append( TO primal_dependencies ELEMENTS cuda IF ENABLE_CUDA )
 
 blt_add_library(
     NAME                  primal

--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -60,6 +60,8 @@ set( primal_dependencies
      core
      slic
      )
+     
+blt_list_append( TO primal_dependencies ELEMENTS cuda IF ${ENABLE_CUDA} )
 
 blt_add_library(
     NAME                  primal
@@ -69,6 +71,10 @@ blt_add_library(
     DEPENDS_ON            ${primal_dependencies}
     OBJECT                TRUE
     )
+
+if (ENABLE_CUDA)
+  set_target_properties(primal PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+endif()
 
 axom_write_unified_header(NAME    primal
                           HEADERS ${primal_headers})

--- a/src/axom/primal/geometry/NumericArray.hpp
+++ b/src/axom/primal/geometry/NumericArray.hpp
@@ -12,6 +12,8 @@
 
 #include "axom/slic/interface/slic.hpp"
 
+#include "axom/core/Macros.hpp"
+
 // C/C++ includes
 #include <cstring>    // For memcpy()
 #include <algorithm>  // For std:: copy and fill
@@ -66,6 +68,7 @@ NumericArray< T,SIZE > operator+( const NumericArray< T,SIZE >& lhs,
  * \result C resulting numeric array from component-wise subtraction.
  */
 template < typename T,int SIZE >
+AXOM_HOST_DEVICE
 NumericArray< T,SIZE > operator-( const NumericArray< T,SIZE >& lhs,
                                   const NumericArray< T,SIZE >& rhs  );
 
@@ -201,6 +204,7 @@ public:
    * The rest will be set to zero.  Defaults is SIZE.
    * If sz is greater than SIZE, we set all coordinates to val
    */
+  AXOM_HOST_DEVICE
   explicit NumericArray( T val = T(), int sz = SIZE);
 
   /*!
@@ -209,17 +213,20 @@ public:
    * \param [in] sz number of coordinates. Defaults to SIZE.
    * \note If sz is greater than SIZE, we only take the first SIZE values.
    */
+  AXOM_HOST_DEVICE
   NumericArray(const T* vals, int sz = SIZE);
 
   /*!
    * \brief Copy constructor.
    * \param [in] other The numeric array to copy
    */
+  AXOM_HOST_DEVICE
   NumericArray( const NumericArray& other ) { *this = other; };
 
   /*!
    * \brief Destructor.
    */
+  AXOM_HOST_DEVICE
   ~NumericArray() { }
 
   /*!
@@ -233,6 +240,7 @@ public:
    * \brief Assignment operator.
    * \param [in] rhs a numeric array instance on the right hand side.
    */
+  AXOM_HOST_DEVICE
   NumericArray& operator=(const NumericArray& rhs);
 
   /*!
@@ -241,14 +249,14 @@ public:
    * \return \f$ p_i \f$ the value at the given component index.
    * \pre \f$  0 \le i < SIZE \f$
    */
-  const T& operator[](int i) const;
-  T& operator[](int i);
+  AXOM_HOST_DEVICE const T& operator[](int i) const;
+  AXOM_HOST_DEVICE T& operator[](int i);
 
   /*!
    * \brief Returns a pointer to the underlying data.
    */
-  const T* data() const;
-  T* data();
+  AXOM_HOST_DEVICE const T* data() const;
+  AXOM_HOST_DEVICE T* data();
 
   /*!
    *
@@ -280,6 +288,7 @@ public:
    * Subtracts the numeric array arr from this instance (component-wise).
    * \return A reference to the NumericArray instance after subtraction.
    */
+  AXOM_HOST_DEVICE
   NumericArray< T,SIZE >& operator-=( const NumericArray< T,SIZE >& arr );
 
   /*!
@@ -289,6 +298,7 @@ public:
    * \return A reference to the NumericArray instance after scalar
    * multiplication.
    */
+  AXOM_HOST_DEVICE
   NumericArray< T,SIZE >& operator*=(double scalar);
 
   /*!
@@ -298,6 +308,7 @@ public:
    * Each element of the numeric array is divided by scalar
    * \return A reference to the NumericArray instance after scalar division.
    */
+  AXOM_HOST_DEVICE
   NumericArray< T,SIZE >& operator/=(double scalar);
 
   /*!
@@ -307,6 +318,7 @@ public:
    * \return A reference to the NumericArray instance after cwise
    * multiplication.
    */
+  AXOM_HOST_DEVICE
   NumericArray< T,SIZE >& operator*=( const NumericArray< T,SIZE >& arr );
 
   /*!
@@ -379,6 +391,7 @@ public:
   int argMin() const;
 
 private:
+  AXOM_HOST_DEVICE
   void verifyIndex(int AXOM_DEBUG_PARAM(idx)) const
   {
     SLIC_ASSERT(idx >= 0 && idx < SIZE);
@@ -410,12 +423,13 @@ NumericArray< T,SIZE >::NumericArray(T val, int sz)
 
   // Fill first nvals coordinates with val ( 0 <= nvals <= SIZE )
   const int nvals = axom::utilities::clampVal(sz, 0, SIZE);
-  std::fill( m_components, m_components+nvals, val );
+  for (int i = 0; i < nvals; i++) {
+    m_components[i] = val;    
+  }
 
   // Fill any remaining coordinates with zero
-  if ( nvals < SIZE )
-  {
-    std::fill( m_components+nvals, m_components+SIZE, T() );
+  for (int j = nvals; j < SIZE; j++) {
+    m_components[j] = T();    
   }
 }
 
@@ -428,19 +442,19 @@ NumericArray< T, SIZE >::NumericArray(const T* vals, int sz)
   const int nvals = axom::utilities::clampVal(sz, 0, SIZE);
 
   // Copy first nvals coordinates from vals array ( 0 <= nvals <= SIZE )
-  std::copy( vals, vals+nvals, m_components);
-
-  // Fill any remaining coordinates with zero
-  if ( nvals < SIZE)
-  {
-    std::fill( m_components+nvals, m_components+SIZE, T());
+  for (int i = 0; i < nvals; i++) {
+    m_components[i] = vals[i];    
   }
 
+  // Fill any remaining coordinates with zero
+  for (int j = nvals; j < SIZE; j++) {
+    m_components[j] = T();    
+  }
 }
 
 //------------------------------------------------------------------------------
 template < typename T,int SIZE >
-inline NumericArray< T,SIZE >&
+inline  AXOM_HOST_DEVICE NumericArray< T,SIZE >&
 NumericArray< T,SIZE >::operator=( const NumericArray< T,SIZE >& rhs )
 {
 

--- a/src/axom/primal/geometry/NumericArray.hpp
+++ b/src/axom/primal/geometry/NumericArray.hpp
@@ -7,12 +7,8 @@
 #define NUMERIC_ARRAY_HPP_
 
 #include "axom/core/Macros.hpp"
-
 #include "axom/core/utilities/Utilities.hpp"
-
 #include "axom/slic/interface/slic.hpp"
-
-#include "axom/core/Macros.hpp"
 
 // C/C++ includes
 #include <cstring>    // For memcpy()
@@ -423,12 +419,14 @@ NumericArray< T,SIZE >::NumericArray(T val, int sz)
 
   // Fill first nvals coordinates with val ( 0 <= nvals <= SIZE )
   const int nvals = axom::utilities::clampVal(sz, 0, SIZE);
-  for (int i = 0; i < nvals; i++) {
+  for (auto i = 0; i < nvals; i++)
+  {
     m_components[i] = val;    
   }
 
   // Fill any remaining coordinates with zero
-  for (int j = nvals; j < SIZE; j++) {
+  for (auto j = nvals; j < SIZE; j++)
+  {
     m_components[j] = T();    
   }
 }
@@ -442,19 +440,22 @@ NumericArray< T, SIZE >::NumericArray(const T* vals, int sz)
   const int nvals = axom::utilities::clampVal(sz, 0, SIZE);
 
   // Copy first nvals coordinates from vals array ( 0 <= nvals <= SIZE )
-  for (int i = 0; i < nvals; i++) {
+  for (auto i = 0; i < nvals; i++)
+  {
     m_components[i] = vals[i];    
   }
 
   // Fill any remaining coordinates with zero
-  for (int j = nvals; j < SIZE; j++) {
+  for (auto j = nvals; j < SIZE; j++) 
+  {
     m_components[j] = T();    
   }
 }
 
 //------------------------------------------------------------------------------
 template < typename T,int SIZE >
-inline  AXOM_HOST_DEVICE NumericArray< T,SIZE >&
+inline  AXOM_HOST_DEVICE 
+NumericArray< T,SIZE >&
 NumericArray< T,SIZE >::operator=( const NumericArray< T,SIZE >& rhs )
 {
 

--- a/src/axom/primal/geometry/NumericArray.hpp
+++ b/src/axom/primal/geometry/NumericArray.hpp
@@ -245,14 +245,20 @@ public:
    * \return \f$ p_i \f$ the value at the given component index.
    * \pre \f$  0 \le i < SIZE \f$
    */
-  AXOM_HOST_DEVICE const T& operator[](int i) const;
-  AXOM_HOST_DEVICE T& operator[](int i);
+  AXOM_HOST_DEVICE 
+  const T& operator[](int i) const;
+  
+  AXOM_HOST_DEVICE 
+  T& operator[](int i);
 
   /*!
    * \brief Returns a pointer to the underlying data.
    */
-  AXOM_HOST_DEVICE const T* data() const;
-  AXOM_HOST_DEVICE T* data();
+  AXOM_HOST_DEVICE 
+  const T* data() const;
+  
+  AXOM_HOST_DEVICE 
+  T* data();
 
   /*!
    *
@@ -419,13 +425,13 @@ NumericArray< T,SIZE >::NumericArray(T val, int sz)
 
   // Fill first nvals coordinates with val ( 0 <= nvals <= SIZE )
   const int nvals = axom::utilities::clampVal(sz, 0, SIZE);
-  for (auto i = 0; i < nvals; i++)
+  for (int i = 0; i < nvals; i++)
   {
     m_components[i] = val;    
   }
 
   // Fill any remaining coordinates with zero
-  for (auto j = nvals; j < SIZE; j++)
+  for (int j = nvals; j < SIZE; j++)
   {
     m_components[j] = T();    
   }
@@ -440,13 +446,13 @@ NumericArray< T, SIZE >::NumericArray(const T* vals, int sz)
   const int nvals = axom::utilities::clampVal(sz, 0, SIZE);
 
   // Copy first nvals coordinates from vals array ( 0 <= nvals <= SIZE )
-  for (auto i = 0; i < nvals; i++)
+  for (int i = 0; i < nvals; i++)
   {
     m_components[i] = vals[i];    
   }
 
   // Fill any remaining coordinates with zero
-  for (auto j = nvals; j < SIZE; j++) 
+  for (int j = nvals; j < SIZE; j++) 
   {
     m_components[j] = T();    
   }

--- a/src/axom/primal/geometry/Point.hpp
+++ b/src/axom/primal/geometry/Point.hpp
@@ -6,11 +6,9 @@
 #ifndef POINT_HXX_
 #define POINT_HXX_
 
-#include "axom/slic/interface/slic.hpp"
-
-#include "axom/primal/geometry/NumericArray.hpp"
-
 #include "axom/core/Macros.hpp"
+#include "axom/slic/interface/slic.hpp"
+#include "axom/primal/geometry/NumericArray.hpp"
 
 // C/C++ includes
 #include <cstring> // For memcpy()

--- a/src/axom/primal/geometry/Point.hpp
+++ b/src/axom/primal/geometry/Point.hpp
@@ -132,8 +132,11 @@ public:
    * \return p[i] the value at the given component index.
    * \pre (i >= 0) && (i < ndims)
    */
-  AXOM_HOST_DEVICE const T& operator[](int i) const { return m_components[i]; }
-  AXOM_HOST_DEVICE T& operator[](int i)             { return m_components[i]; }
+  AXOM_HOST_DEVICE 
+  const T& operator[](int i) const { return m_components[i]; }
+  
+  AXOM_HOST_DEVICE 
+  T& operator[](int i)             { return m_components[i]; }
 
   ///@}
 
@@ -151,8 +154,11 @@ public:
   /*!
    * \brief Returns a reference to the underlying NumericArray.
    */
-  AXOM_HOST_DEVICE const NumericArray< T,NDIMS >& array() const { return m_components; }
-  AXOM_HOST_DEVICE NumericArray< T,NDIMS >& array()              { return m_components; }
+  AXOM_HOST_DEVICE 
+  const NumericArray< T,NDIMS >& array() const { return m_components; }
+  
+  AXOM_HOST_DEVICE 
+  NumericArray< T,NDIMS >& array()             { return m_components; }
 
   /*!
    * \brief Output the point's coordinates to the array

--- a/src/axom/primal/geometry/Point.hpp
+++ b/src/axom/primal/geometry/Point.hpp
@@ -10,6 +10,8 @@
 
 #include "axom/primal/geometry/NumericArray.hpp"
 
+#include "axom/core/Macros.hpp"
+
 // C/C++ includes
 #include <cstring> // For memcpy()
 #include <ostream> // For print() and operator <<
@@ -77,12 +79,14 @@ public:
    * The rest will be set to zero.  Defaults is NDIMS.
    * If sz is greater than NDIMS, we set all coordinates to val
    */
+  AXOM_HOST_DEVICE
   explicit Point(T val = T(), int sz = NDIMS) : m_components(val,sz) { }
 
   /*!
    * \brief Constructor from a numeric array
    * \param [in] arr The numeric array to copy from
    */
+  AXOM_HOST_DEVICE
   Point(const NumericArray< T,NDIMS >& arr) : m_components(arr) { }
 
   /*!
@@ -91,17 +95,20 @@ public:
    * \param [in] sz num values to copy from the vals array. Defaults to NDIMS.
    * \note If sz is greater than NDIMS, we only take the first NDIMS values.
    */
+  AXOM_HOST_DEVICE
   Point(const T* vals, int sz = NDIMS) : m_components(vals,sz) { }
 
   /*!
    * \brief Copy constructor.
    * \param [in] other The point to copy
    */
+  AXOM_HOST_DEVICE
   Point( const Point& other) : m_components( other.m_components) { }
 
   /*!
    * \brief Destructor.
    */
+  AXOM_HOST_DEVICE
   ~Point() { }
 
   /*!
@@ -127,8 +134,8 @@ public:
    * \return p[i] the value at the given component index.
    * \pre (i >= 0) && (i < ndims)
    */
-  const T& operator[](int i) const { return m_components[i]; }
-  T& operator[](int i)             { return m_components[i]; }
+  AXOM_HOST_DEVICE const T& operator[](int i) const { return m_components[i]; }
+  AXOM_HOST_DEVICE T& operator[](int i)             { return m_components[i]; }
 
   ///@}
 
@@ -146,8 +153,8 @@ public:
   /*!
    * \brief Returns a reference to the underlying NumericArray.
    */
-  const NumericArray< T,NDIMS >& array() const { return m_components; }
-  NumericArray< T,NDIMS >& array()              { return m_components; }
+  AXOM_HOST_DEVICE const NumericArray< T,NDIMS >& array() const { return m_components; }
+  AXOM_HOST_DEVICE NumericArray< T,NDIMS >& array()              { return m_components; }
 
   /*!
    * \brief Output the point's coordinates to the array
@@ -183,6 +190,7 @@ public:
    * \param [in] z the z--coordinate of the point. Default is 0.0.
    * \return p a Point instance with the given coordinates.
    */
+  AXOM_HOST_DEVICE
   static Point make_point( const T& x, const T& y, const T& z=0.0 );
 
   /*!

--- a/src/axom/primal/geometry/Triangle.hpp
+++ b/src/axom/primal/geometry/Triangle.hpp
@@ -14,6 +14,8 @@
 
 #include "axom/slic/interface/slic.hpp"
 
+#include "axom/core/Macros.hpp"
+
 #include <cmath>   // for acos()
 #include <ostream> // for std::ostream
 
@@ -56,6 +58,7 @@ public:
   /*!
    * \brief Default constructor. Creates a degenerate triangle.
    */
+  AXOM_HOST_DEVICE
   Triangle() { }
 
   /*!
@@ -64,6 +67,7 @@ public:
    * \param [in] B point instance corresponding to vertex B of the triangle.
    * \param [in] C point instance corresponding to vertex C of the triangle.
    */
+  AXOM_HOST_DEVICE
   Triangle( const PointType& A,
             const PointType& B,
             const PointType& C );
@@ -71,6 +75,7 @@ public:
   /*!
    * \brief Destructor
    */
+  AXOM_HOST_DEVICE
   ~Triangle() { }
 
   /*!
@@ -78,6 +83,7 @@ public:
    * \param idx The index of the desired vertex
    * \pre idx is 0, 1 or 2
    */
+  AXOM_HOST_DEVICE
   PointType& operator[](int idx)
   {
     SLIC_ASSERT(idx >=0 && idx < NUM_TRI_VERTS);
@@ -89,6 +95,7 @@ public:
    * \param idx The index of the desired vertex
    * \pre idx is 0, 1 or 2
    */
+  AXOM_HOST_DEVICE
   const PointType& operator[](int idx) const
   {
     SLIC_ASSERT(idx >=0 && idx < NUM_TRI_VERTS);
@@ -100,6 +107,7 @@ public:
    * \pre This function is only valid when NDIMS = 3
    * \return n triangle normal when NDIMS=3, zero vector otherwise
    */
+  AXOM_HOST_DEVICE
   VectorType normal() const
   {
     SLIC_CHECK_MSG(NDIMS==3, "Triangle::normal() is only valid in 3D.");
@@ -114,6 +122,7 @@ public:
    * \brief Returns the area of the triangle
    * \pre Only defined when dimension NDIMS is 2 or 3
    */
+  AXOM_HOST_DEVICE
   double area() const
   {
     SLIC_CHECK_MSG( NDIMS == 2 || NDIMS == 3,
@@ -241,6 +250,7 @@ public:
    * \return true iff the triangle is degenerate (0 area)
    * \see primal::Point
    */
+  AXOM_HOST_DEVICE
   bool degenerate(double eps = 1.0e-12) const
   {
     return axom::utilities::isNearlyEqual(area(),  0.0, eps);
@@ -305,12 +315,9 @@ namespace primal
 template < typename T, int NDIMS >
 Triangle< T,NDIMS >::Triangle( const PointType& A,
                                const PointType& B,
-                               const PointType& C  )
-{
-  m_points[0] = A;
-  m_points[1] = B;
-  m_points[2] = C;
-}
+                               const PointType& C  ):
+  m_points{A,B,C}
+{}
 
 //------------------------------------------------------------------------------
 template < typename T, int NDIMS >

--- a/src/axom/primal/geometry/Triangle.hpp
+++ b/src/axom/primal/geometry/Triangle.hpp
@@ -6,15 +6,15 @@
 #ifndef TRIANGLE_HPP_
 #define TRIANGLE_HPP_
 
-#include "axom/core/numerics/Determinants.hpp" // For numerics::determinant()
+#include "axom/core/Macros.hpp"
+#include "axom/core/numerics/Determinants.hpp"
 #include "axom/core/utilities/Utilities.hpp"
+
+#include "axom/slic/interface/slic.hpp"
 
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
 
-#include "axom/slic/interface/slic.hpp"
-
-#include "axom/core/Macros.hpp"
 
 #include <cmath>   // for acos()
 #include <ostream> // for std::ostream
@@ -315,8 +315,8 @@ namespace primal
 template < typename T, int NDIMS >
 Triangle< T,NDIMS >::Triangle( const PointType& A,
                                const PointType& B,
-                               const PointType& C  ):
-  m_points{A,B,C}
+                               const PointType& C)
+   : m_points{A,B,C} 
 {}
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -182,6 +182,7 @@ public:
    * \return d the dimension (size) of the vector
    * \post d >= 1.
    */
+  AXOM_HOST_DEVICE
   int dimension() const { return NDIMS; };
 
   /*!

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -7,14 +7,13 @@
 #define VECTOR_HPP_
 
 // axom_utils includes
-#include "axom/core/numerics/Determinants.hpp"  // for numerics::determinant()
-#include "axom/core/numerics/matvecops.hpp"     // dot_product()/cross_product()
+#include "axom/core/Macros.hpp"
+#include "axom/core/numerics/Determinants.hpp"
+#include "axom/core/numerics/matvecops.hpp"
 
 // Primal includes
 #include "axom/primal/geometry/NumericArray.hpp"
 #include "axom/primal/geometry/Point.hpp"
-
-#include "axom/core/Macros.hpp"
 
 // C/C++ includes
 #include <cmath> // for sqrt()

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -190,20 +190,29 @@ public:
    * \return p[i] the value at the given component index.
    * \pre (i >= 0) && (i < ndims)
    */
-  AXOM_HOST_DEVICE const T& operator[](int i) const { return m_components[i]; }
-  AXOM_HOST_DEVICE T& operator[](int i)             { return m_components[i]; }
+  AXOM_HOST_DEVICE
+  const T& operator[](int i) const { return m_components[i]; }
+  
+  AXOM_HOST_DEVICE
+  T& operator[](int i)             { return m_components[i]; }
 
   /*!
    * \brief Returns a reference to the underlying NumericArray.
    */
-  AXOM_HOST_DEVICE const NumericArray< T,NDIMS > & array() const { return m_components; }
-  AXOM_HOST_DEVICE NumericArray< T,NDIMS >& array()               { return m_components; }
+  AXOM_HOST_DEVICE 
+  const NumericArray< T,NDIMS > & array() const { return m_components; }
+  
+  AXOM_HOST_DEVICE 
+  NumericArray< T,NDIMS >& array()              { return m_components; }
 
   /*!
    * \brief Returns a pointer to the underlying data.
    */
-  AXOM_HOST_DEVICE const T* data() const { return m_components.data(); }
-  AXOM_HOST_DEVICE T* data()             { return m_components.data(); }
+  AXOM_HOST_DEVICE
+  const T* data() const { return m_components.data(); }
+  
+  AXOM_HOST_DEVICE
+  T* data()             { return m_components.data(); }
 
   /*!
    * \brief Equality comparison operator for vectors.

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -14,6 +14,8 @@
 #include "axom/primal/geometry/NumericArray.hpp"
 #include "axom/primal/geometry/Point.hpp"
 
+#include "axom/core/Macros.hpp"
+
 // C/C++ includes
 #include <cmath> // for sqrt()
 
@@ -123,12 +125,14 @@ public:
    * \param [in] sz The number of coordinates to set to val.
    * The rest will be set to zero.  Defaults is NDIMS.
    */
+  AXOM_HOST_DEVICE
   explicit Vector( T val = T(), int sz = NDIMS) : m_components(val, sz) { }
 
   /*!
    * \brief Constructor from a numeric array
    * \param [in] arr The numeric array to copy from
    */
+  AXOM_HOST_DEVICE
   Vector( const NumericArray< T,NDIMS >& arr) : m_components(arr) { }
 
   /*!
@@ -138,6 +142,7 @@ public:
    * to NDIMS.
    * If sz is greater than NDIMS, we only take the first NDIMS values.
    */
+  AXOM_HOST_DEVICE
   Vector(const T* vals, int sz = NDIMS) : m_components(vals, sz) {}
 
   /*!
@@ -145,12 +150,14 @@ public:
    * \param [in] pt The point containing the vector's coordinates.
    * \note Equivalent to Vector( Point::zero(), pt)
    */
+  AXOM_HOST_DEVICE
   Vector(const Point< T,NDIMS > & pt) : m_components( pt.array() ) {}
 
   /*!
    * \brief Copy constructor
    * \param [in] other The vector to copy
    */
+  AXOM_HOST_DEVICE
   Vector(const Vector< T,NDIMS > & other) : m_components( other.array() ) {}
 
   /*!
@@ -160,12 +167,14 @@ public:
    * \pre A.dimension() == B.dimension()
    * \pre A.dimension() == ndims
    */
+  AXOM_HOST_DEVICE
   Vector( const Point< T,NDIMS >& A, const Point< T,NDIMS >& B ) :
     m_components(B.array() - A.array()) {}
 
   /*!
    * \brief Destructor.
    */
+  AXOM_HOST_DEVICE
   ~Vector() {}
 
   /*!
@@ -181,20 +190,20 @@ public:
    * \return p[i] the value at the given component index.
    * \pre (i >= 0) && (i < ndims)
    */
-  const T& operator[](int i) const { return m_components[i]; }
-  T& operator[](int i)             { return m_components[i]; }
+  AXOM_HOST_DEVICE const T& operator[](int i) const { return m_components[i]; }
+  AXOM_HOST_DEVICE T& operator[](int i)             { return m_components[i]; }
 
   /*!
    * \brief Returns a reference to the underlying NumericArray.
    */
-  const NumericArray< T,NDIMS > & array() const { return m_components; }
-  NumericArray< T,NDIMS >& array()               { return m_components; }
+  AXOM_HOST_DEVICE const NumericArray< T,NDIMS > & array() const { return m_components; }
+  AXOM_HOST_DEVICE NumericArray< T,NDIMS >& array()               { return m_components; }
 
   /*!
    * \brief Returns a pointer to the underlying data.
    */
-  const T* data() const { return m_components.data(); }
-  T* data()             { return m_components.data(); }
+  AXOM_HOST_DEVICE const T* data() const { return m_components.data(); }
+  AXOM_HOST_DEVICE T* data()             { return m_components.data(); }
 
   /*!
    * \brief Equality comparison operator for vectors.
@@ -235,6 +244,7 @@ public:
    * \pre scalar != 0
    * \return A reference to the vector instance after scalar division.
    */
+  AXOM_HOST_DEVICE
   Vector< T,NDIMS >& operator/=(T scalar);
 
   /*!
@@ -242,6 +252,7 @@ public:
    * \param [in] v the other vector in the dot product
    * \return The dot product of the two vectors.
    */
+  AXOM_HOST_DEVICE
   T dot(const Vector< T,NDIMS >& v ) const;
 
   /*!
@@ -249,12 +260,14 @@ public:
    * \return n the squared norm.
    * \see Vector::norm()
    */
+  AXOM_HOST_DEVICE
   double squared_norm() const;
 
   /*!
    * \brief Computes the \f$ l^2 \f$ norm of this vector instance.
    * \return n the norm of the vector, a.k.a., magnitude or length.
    */
+  AXOM_HOST_DEVICE
   double norm() const;
 
   /*!
@@ -267,6 +280,7 @@ public:
    * \note The unit vector of the zero vector is (1,0,0,...) when normalized.
    * \post this->norm() == 1.0f
    */
+  AXOM_HOST_DEVICE
   Vector unitVector() const;
 
   /*!
@@ -283,6 +297,7 @@ public:
    * \return dotprod the computed dot product.
    * \pre u.dimension() == v.dimension().
    */
+  AXOM_HOST_DEVICE
   static T dot_product( const Vector< T,NDIMS >& u,
                         const Vector< T,NDIMS >& v );
 
@@ -301,6 +316,7 @@ public:
    * \param [in] v the vector on the left-hand side.
    * \return C the resulting vector from A x B.
    */
+  AXOM_HOST_DEVICE
   static Vector< T,3 > cross_product( const Vector< T,3 >& u,
                                       const Vector< T,3 >& v );
 
@@ -389,7 +405,7 @@ inline double Vector< T, NDIMS >::norm() const
 template < typename T, int NDIMS >
 inline Vector< T, NDIMS > Vector< T, NDIMS >::unitVector() const
 {
-  static const double EPS = 1.0e-50;
+  constexpr double EPS = 1.0e-50;
 
   Vector v( *this);
 

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -13,6 +13,7 @@
 #ifndef PRIMAL_INTERSECT_IMPL_HPP_
 #define PRIMAL_INTERSECT_IMPL_HPP_
 
+#include "axom/core/Macros.hpp"
 #include "axom/core/numerics/Determinants.hpp"
 #include "axom/core/utilities/Utilities.hpp"
 
@@ -22,8 +23,6 @@
 #include "axom/primal/geometry/Ray.hpp"
 #include "axom/primal/geometry/Segment.hpp"
 #include "axom/primal/geometry/Triangle.hpp"
-
-#include "axom/core/Macros.hpp"
 
 namespace axom
 {
@@ -54,13 +53,16 @@ AXOM_HOST_DEVICE bool oneZeroOthersMatch(double x, double y, double z, double EP
 AXOM_HOST_DEVICE int  countZeros(double x, double y, double z, double EPS=1.0e-12);
 AXOM_HOST_DEVICE double twoDcross(const Point2& A, const Point2& B, const Point2& C);
 
-AXOM_HOST_DEVICE bool checkEdge(const Point2& p1,
+AXOM_HOST_DEVICE
+bool checkEdge(const Point2& p1,
                const Point2& q1,
                const Point2& r1,
                const Point2& p2,
                const Point2& r2,
                bool includeBoundary);
-AXOM_HOST_DEVICE bool checkVertex(const Point2& p1,
+
+AXOM_HOST_DEVICE
+bool checkVertex(const Point2& p1,
                  const Point2& q1,
                  const Point2& r1,
                  const Point2& p2,
@@ -68,7 +70,8 @@ AXOM_HOST_DEVICE bool checkVertex(const Point2& p1,
                  const Point2& r2,
                  bool includeBoundary);
 
-AXOM_HOST_DEVICE bool intersectPermuted2DTriangles(const Point2& p1,
+AXOM_HOST_DEVICE 
+bool intersectPermuted2DTriangles(const Point2& p1,
                                   const Point2& q1,
                                   const Point2& r1,
                                   const Point2& p2,
@@ -76,13 +79,15 @@ AXOM_HOST_DEVICE bool intersectPermuted2DTriangles(const Point2& p1,
                                   const Point2& r2,
                                   bool includeBoundary);
 
-AXOM_HOST_DEVICE bool intersectOnePermutedTriangle(
+AXOM_HOST_DEVICE
+bool intersectOnePermutedTriangle(
   const Point3 &p1, const Point3 &q1, const Point3 &r1,
   const Point3 &p2, const Point3 &q2, const Point3 &r2,
   double dp2, double dq2, double dr2,  Vector3 &normal,
   bool includeBoundary);
 
-AXOM_HOST_DEVICE bool intersectTwoPermutedTriangles(const Point3& p1,
+AXOM_HOST_DEVICE
+bool intersectTwoPermutedTriangles(const Point3& p1,
                                    const Point3& q1,
                                    const Point3& r1,
                                    const Point3& p2,
@@ -90,7 +95,8 @@ AXOM_HOST_DEVICE bool intersectTwoPermutedTriangles(const Point3& p1,
                                    const Point3& r2,
                                    bool includeBoundary);
 
-AXOM_HOST_DEVICE bool intersectCoplanar3DTriangles(const Point3& p1,
+AXOM_HOST_DEVICE
+bool intersectCoplanar3DTriangles(const Point3& p1,
                                   const Point3& q1,
                                   const Point3& r1,
                                   const Point3& p2,
@@ -99,7 +105,8 @@ AXOM_HOST_DEVICE bool intersectCoplanar3DTriangles(const Point3& p1,
                                   Vector3 normal,
                                   bool includeBoundary);
 
-AXOM_HOST_DEVICE bool TriangleIntersection2D(const Triangle2& t1,
+AXOM_HOST_DEVICE
+bool TriangleIntersection2D(const Triangle2& t1,
                             const Triangle2& t2,
                             bool includeBoundary = false);
 

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -39,19 +39,39 @@ typedef primal::Triangle< double, 3 > Triangle3;
 typedef primal::Triangle< double, 2 > Triangle2;
 typedef primal::Point< double, 2 > Point2;
 
-AXOM_HOST_DEVICE bool isGt(double x, double y, double EPS=1.0e-12);
-AXOM_HOST_DEVICE bool isLt(double x, double y, double EPS=1.0e-12);
+AXOM_HOST_DEVICE
+bool isGt(double x, double y, double EPS=1.0e-12);
+
+AXOM_HOST_DEVICE 
+bool isLt(double x, double y, double EPS=1.0e-12);
+
 bool isLeq(double x, double y, double EPS=1.0e-12);
-AXOM_HOST_DEVICE bool isLpeq(double x, double y, bool includeEqual = false,
+
+AXOM_HOST_DEVICE
+bool isLpeq(double x, double y, bool includeEqual = false,
             double EPS=1.0e-12);
-AXOM_HOST_DEVICE bool isGeq(double x, double y, double EPS=1.0e-12);
-AXOM_HOST_DEVICE bool isGpeq(double x, double y, bool includeEqual = false,
+
+AXOM_HOST_DEVICE
+bool isGeq(double x, double y, double EPS=1.0e-12);
+
+AXOM_HOST_DEVICE
+bool isGpeq(double x, double y, bool includeEqual = false,
             double EPS=1.0e-12);
-AXOM_HOST_DEVICE bool nonzeroSignMatch(double x, double y, double z, double EPS=1.0e-12);
-AXOM_HOST_DEVICE bool twoZeros(double x, double y, double z, double EPS=1.0e-12);
-AXOM_HOST_DEVICE bool oneZeroOthersMatch(double x, double y, double z, double EPS=1.0e-12);
-AXOM_HOST_DEVICE int  countZeros(double x, double y, double z, double EPS=1.0e-12);
-AXOM_HOST_DEVICE double twoDcross(const Point2& A, const Point2& B, const Point2& C);
+
+AXOM_HOST_DEVICE
+bool nonzeroSignMatch(double x, double y, double z, double EPS=1.0e-12);
+
+AXOM_HOST_DEVICE
+bool twoZeros(double x, double y, double z, double EPS=1.0e-12);
+
+AXOM_HOST_DEVICE
+bool oneZeroOthersMatch(double x, double y, double z, double EPS=1.0e-12);
+
+AXOM_HOST_DEVICE
+int  countZeros(double x, double y, double z, double EPS=1.0e-12);
+
+AXOM_HOST_DEVICE
+double twoDcross(const Point2& A, const Point2& B, const Point2& C);
 
 AXOM_HOST_DEVICE
 bool checkEdge(const Point2& p1,

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -23,6 +23,8 @@
 #include "axom/primal/geometry/Segment.hpp"
 #include "axom/primal/geometry/Triangle.hpp"
 
+#include "axom/core/Macros.hpp"
+
 namespace axom
 {
 namespace primal
@@ -38,27 +40,27 @@ typedef primal::Triangle< double, 3 > Triangle3;
 typedef primal::Triangle< double, 2 > Triangle2;
 typedef primal::Point< double, 2 > Point2;
 
-bool isGt(double x, double y, double EPS=1.0e-12);
-bool isLt(double x, double y, double EPS=1.0e-12);
+AXOM_HOST_DEVICE bool isGt(double x, double y, double EPS=1.0e-12);
+AXOM_HOST_DEVICE bool isLt(double x, double y, double EPS=1.0e-12);
 bool isLeq(double x, double y, double EPS=1.0e-12);
-bool isLpeq(double x, double y, bool includeEqual = false,
+AXOM_HOST_DEVICE bool isLpeq(double x, double y, bool includeEqual = false,
             double EPS=1.0e-12);
-bool isGeq(double x, double y, double EPS=1.0e-12);
-bool isGpeq(double x, double y, bool includeEqual = false,
+AXOM_HOST_DEVICE bool isGeq(double x, double y, double EPS=1.0e-12);
+AXOM_HOST_DEVICE bool isGpeq(double x, double y, bool includeEqual = false,
             double EPS=1.0e-12);
-bool nonzeroSignMatch(double x, double y, double z, double EPS=1.0e-12);
-bool twoZeros(double x, double y, double z, double EPS=1.0e-12);
-bool oneZeroOthersMatch(double x, double y, double z, double EPS=1.0e-12);
-int  countZeros(double x, double y, double z, double EPS=1.0e-12);
-double twoDcross(const Point2& A, const Point2& B, const Point2& C);
+AXOM_HOST_DEVICE bool nonzeroSignMatch(double x, double y, double z, double EPS=1.0e-12);
+AXOM_HOST_DEVICE bool twoZeros(double x, double y, double z, double EPS=1.0e-12);
+AXOM_HOST_DEVICE bool oneZeroOthersMatch(double x, double y, double z, double EPS=1.0e-12);
+AXOM_HOST_DEVICE int  countZeros(double x, double y, double z, double EPS=1.0e-12);
+AXOM_HOST_DEVICE double twoDcross(const Point2& A, const Point2& B, const Point2& C);
 
-bool checkEdge(const Point2& p1,
+AXOM_HOST_DEVICE bool checkEdge(const Point2& p1,
                const Point2& q1,
                const Point2& r1,
                const Point2& p2,
                const Point2& r2,
                bool includeBoundary);
-bool checkVertex(const Point2& p1,
+AXOM_HOST_DEVICE bool checkVertex(const Point2& p1,
                  const Point2& q1,
                  const Point2& r1,
                  const Point2& p2,
@@ -66,7 +68,7 @@ bool checkVertex(const Point2& p1,
                  const Point2& r2,
                  bool includeBoundary);
 
-bool intersectPermuted2DTriangles(const Point2& p1,
+AXOM_HOST_DEVICE bool intersectPermuted2DTriangles(const Point2& p1,
                                   const Point2& q1,
                                   const Point2& r1,
                                   const Point2& p2,
@@ -74,13 +76,13 @@ bool intersectPermuted2DTriangles(const Point2& p1,
                                   const Point2& r2,
                                   bool includeBoundary);
 
-bool intersectOnePermutedTriangle(
+AXOM_HOST_DEVICE bool intersectOnePermutedTriangle(
   const Point3 &p1, const Point3 &q1, const Point3 &r1,
   const Point3 &p2, const Point3 &q2, const Point3 &r2,
   double dp2, double dq2, double dr2,  Vector3 &normal,
   bool includeBoundary);
 
-bool intersectTwoPermutedTriangles(const Point3& p1,
+AXOM_HOST_DEVICE bool intersectTwoPermutedTriangles(const Point3& p1,
                                    const Point3& q1,
                                    const Point3& r1,
                                    const Point3& p2,
@@ -88,7 +90,7 @@ bool intersectTwoPermutedTriangles(const Point3& p1,
                                    const Point3& r2,
                                    bool includeBoundary);
 
-bool intersectCoplanar3DTriangles(const Point3& p1,
+AXOM_HOST_DEVICE bool intersectCoplanar3DTriangles(const Point3& p1,
                                   const Point3& q1,
                                   const Point3& r1,
                                   const Point3& p2,
@@ -97,7 +99,7 @@ bool intersectCoplanar3DTriangles(const Point3& p1,
                                   Vector3 normal,
                                   bool includeBoundary);
 
-bool TriangleIntersection2D(const Triangle2& t1,
+AXOM_HOST_DEVICE bool TriangleIntersection2D(const Triangle2& t1,
                             const Triangle2& t2,
                             bool includeBoundary = false);
 
@@ -123,6 +125,7 @@ bool TriangleIntersection2D(const Triangle2& t1,
  * Tests, RR-4488, INRIA (2002).  https://hal.inria.fr/inria-00072100/
  */
 template < typename T >
+AXOM_HOST_DEVICE
 bool intersect_tri3D_tri3D( const Triangle< T, 3 >& t1,
                             const Triangle< T, 3 >& t2,
                             bool includeBoundary = false)

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -12,6 +12,7 @@
 #ifndef PRIMAL_INTERSECT_HPP_
 #define PRIMAL_INTERSECT_HPP_
 
+#include "axom/core/Macros.hpp"
 #include "axom/core/utilities/Utilities.hpp"
 
 #include "axom/primal/geometry/BoundingBox.hpp"
@@ -25,8 +26,6 @@
 
 #include "axom/primal/operators/detail/intersect_impl.hpp"
 #include "axom/primal/operators/detail/intersect_bezier_impl.hpp"
-
-#include "axom/core/Macros.hpp"
 
 namespace axom
 {

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -26,6 +26,8 @@
 #include "axom/primal/operators/detail/intersect_impl.hpp"
 #include "axom/primal/operators/detail/intersect_bezier_impl.hpp"
 
+#include "axom/core/Macros.hpp"
+
 namespace axom
 {
 namespace primal
@@ -40,6 +42,7 @@ namespace primal
  * triangle boundaries in intersections, specify includeBoundary as true.
  */
 template < typename T >
+AXOM_HOST_DEVICE
 bool intersect( const Triangle< T, 3 >& t1,
                 const Triangle< T, 3 >& t2,
                 const bool includeBoundary = false)

--- a/src/axom/sidre/examples/lulesh2/CMakeLists.txt
+++ b/src/axom/sidre/examples/lulesh2/CMakeLists.txt
@@ -37,11 +37,11 @@ blt_add_executable(
 if(AXOM_ENABLE_TESTS)
     if(ENABLE_MPI)
         blt_add_test(NAME sidre_lulesh2
-                     COMMAND sidre_lulesh2_ex
+                     COMMAND sidre_lulesh2_ex -s 5
                      NUM_MPI_TASKS 1
                      NUM_OMP_THREADS 2 )
     else()
-        blt_add_test(NAME sidre_lulesh2
+        blt_add_test(NAME sidre_lulesh2 -s 5
                      COMMAND sidre_lulesh2_ex
                      NUM_OMP_THREADS 2 )
     endif()

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -359,8 +359,11 @@ namespace detail
  */
 struct FalseType
 {
-  AXOM_HOST_DEVICE FalseType() {}
-  AXOM_HOST_DEVICE inline operator bool() const { return false; }
+  AXOM_HOST_DEVICE
+  FalseType() {}
+  
+  AXOM_HOST_DEVICE
+  inline operator bool() const { return false; }
 };
 
 static const FalseType false_value;

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -106,7 +106,8 @@
 
 /// @}
 
-#ifdef AXOM_DEBUG
+// Use complete debug macros when not on device
+#if defined(AXOM_DEBUG) && !defined(AXOM_DEVICE_CODE)
 
 //-----------------------------------------------------------------------------
 /// \name ASSERT MACROS
@@ -222,6 +223,14 @@
   } while ( axom::slic::detail::false_value )
 
 /// @}
+
+// Use assert when on device
+#elif defined(AXOM_DEBUG) && defined(AXOM_DEVICE_CODE)
+
+#define SLIC_ASSERT( EXP )  assert (EXP)                                    
+#define SLIC_ASSERT_MSG( EXP, msg ) assert (EXP) 
+#define SLIC_CHECK( EXP ) assert (EXP)
+#define SLIC_CHECK_MSG( EXP, msg ) assert (EXP)
 
 #else // turn off debug macros and asserts
 
@@ -350,8 +359,8 @@ namespace detail
  */
 struct FalseType
 {
-  FalseType() {}
-  inline operator bool() const { return false; }
+  AXOM_HOST_DEVICE FalseType() {}
+  AXOM_HOST_DEVICE inline operator bool() const { return false; }
 };
 
 static const FalseType false_value;

--- a/src/axom/slic/tests/slic_macros.cpp
+++ b/src/axom/slic/tests/slic_macros.cpp
@@ -224,7 +224,7 @@ TEST( slic_macros, test_assert_macros )
 
   constexpr int val = 42;
   SLIC_ASSERT(  val < 0 );
-#ifdef AXOM_DEBUG
+#if defined(AXOM_DEBUG) && !defined(AXOM_DEVICE_CODE)
   EXPECT_FALSE( slic::internal::is_stream_empty() );
   check_level( slic::internal::test_stream.str(), "ERROR" );
   check_msg( slic::internal::test_stream.str(), "Failed Assert: val < 0" );
@@ -241,7 +241,7 @@ TEST( slic_macros, test_assert_macros )
   EXPECT_TRUE( slic::internal::is_stream_empty() );
 
   SLIC_ASSERT_MSG( val < 0, "val should be negative!" );
-#ifdef AXOM_DEBUG
+#if defined(AXOM_DEBUG) && !defined(AXOM_DEVICE_CODE)
   EXPECT_FALSE( slic::internal::is_stream_empty() );
   check_level( slic::internal::test_stream.str(), "ERROR" );
   check_msg( slic::internal::test_stream.str(),
@@ -264,7 +264,7 @@ TEST( slic_macros, test_check_macros )
 
   constexpr int val = 42;
   SLIC_CHECK(  val < 0 );
-#ifdef AXOM_DEBUG
+#if defined(AXOM_DEBUG) && !defined(AXOM_DEVICE_CODE)
   EXPECT_FALSE( slic::internal::is_stream_empty() );
   check_level( slic::internal::test_stream.str(), "WARNING" );
   check_msg( slic::internal::test_stream.str(), "Failed Check: val < 0" );
@@ -281,7 +281,7 @@ TEST( slic_macros, test_check_macros )
   EXPECT_TRUE( slic::internal::is_stream_empty() );
 
   SLIC_CHECK_MSG( val < 0, "val should be negative!" );
-#ifdef AXOM_DEBUG
+#if defined(AXOM_DEBUG) && !defined(AXOM_DEVICE_CODE)
   EXPECT_FALSE( slic::internal::is_stream_empty() );
   check_level( slic::internal::test_stream.str(), "WARNING" );
   check_msg( slic::internal::test_stream.str(),

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -57,7 +57,7 @@ blt_list_append( TO mesh_tester_depends ELEMENTS umpire IF ${UMPIRE_FOUND} )
 blt_list_append( TO mesh_tester_depends ELEMENTS openmp  IF ${ENABLE_OPENMP} )
 blt_list_append( TO mesh_tester_depends ELEMENTS cuda IF ${ENABLE_CUDA} )
 
-if(AXOM_ENABLE_QUEST AND RAJA_FOUND)
+if(AXOM_ENABLE_QUEST)
     blt_add_executable(
         NAME        mesh_tester
         SOURCES     ${mesh_tester_sources}

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -53,8 +53,11 @@ set(mesh_tester_depends
 
 blt_list_append(TO mesh_tester_depends ELEMENTS lumberjack mpi IF AXOM_ENABLE_LUMBERJACK)
 blt_list_append(TO mesh_tester_depends ELEMENTS openmp IF ENABLE_OPENMP)
+blt_list_append( TO mesh_tester_depends ELEMENTS umpire IF ${UMPIRE_FOUND} )
+blt_list_append( TO mesh_tester_depends ELEMENTS openmp  IF ${ENABLE_OPENMP} )
+blt_list_append( TO mesh_tester_depends ELEMENTS cuda IF ${ENABLE_CUDA} )
 
-if(AXOM_ENABLE_QUEST)
+if(AXOM_ENABLE_QUEST AND RAJA_FOUND)
     blt_add_executable(
         NAME        mesh_tester
         SOURCES     ${mesh_tester_sources}

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -53,9 +53,9 @@ set(mesh_tester_depends
 
 blt_list_append(TO mesh_tester_depends ELEMENTS lumberjack mpi IF AXOM_ENABLE_LUMBERJACK)
 blt_list_append(TO mesh_tester_depends ELEMENTS openmp IF ENABLE_OPENMP)
-blt_list_append( TO mesh_tester_depends ELEMENTS umpire IF ${UMPIRE_FOUND} )
-blt_list_append( TO mesh_tester_depends ELEMENTS openmp  IF ${ENABLE_OPENMP} )
-blt_list_append( TO mesh_tester_depends ELEMENTS cuda IF ${ENABLE_CUDA} )
+blt_list_append(TO mesh_tester_depends ELEMENTS umpire IF UMPIRE_FOUND)
+blt_list_append(TO mesh_tester_depends ELEMENTS RAJA IF RAJA_FOUND)
+blt_list_append(TO mesh_tester_depends ELEMENTS cuda IF ENABLE_CUDA)
 
 if(AXOM_ENABLE_QUEST)
     blt_add_executable(

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -339,21 +339,15 @@ std::vector< std::pair<int, int> > naiveIntersectionAlgorithm(
     << axom::execution_space< ExecSpace >::name());
 
   // Get allocator
-  #ifdef AXOM_USE_UMPIRE
-    int allocatorID = axom::execution_space< ExecSpace >::allocatorID();
-    umpire::Allocator allocator = axom::getAllocator(allocatorID);
-  #endif
+  int allocatorID = axom::execution_space< ExecSpace >::allocatorID();
+  axom::setDefaultAllocator( allocatorID );
 
   std::vector< std::pair<int, int> > retval;
 
   const int ncells = surface_mesh->getNumberOfCells();
   SLIC_INFO("Checking mesh with a total of "<< ncells<< " cells.");
 
-  #ifdef AXOM_USE_UMPIRE
-    Triangle3 * tris = axom::allocate <Triangle3> (ncells, allocator);
-  #else
-    Triangle3 * tris = axom::allocate <Triangle3> (ncells);
-  #endif
+  Triangle3 * tris = axom::allocate <Triangle3> (ncells);
 
   // Get each triangle in the mesh and check for degeneracies
   for (int i = 0; i < ncells ; i++)
@@ -390,15 +384,9 @@ std::vector< std::pair<int, int> > naiveIntersectionAlgorithm(
   });
 
   // Allocation to hold intersection pairs and counter to know where to store
-  #ifdef AXOM_USE_UMPIRE
-    int * intersections =
-      axom::allocate <int> (numIntersect.get() * 2, allocator);
-    int * counter = axom::allocate <int> (1, allocator);
-  #else
-    int * intersections =
-      axom::allocate <int> (numIntersect.get() * 2);
-    int * counter = axom::allocate <int> (1);
-  #endif
+  int * intersections =
+    axom::allocate <int> (numIntersect.get() * 2);
+  int * counter = axom::allocate <int> (1);
   
   counter[0] = 0;
 


### PR DESCRIPTION
This PR adds a RAJA implementation of the naiveIntersectionAlgorithm in `mesh_tester.cpp`.
The naive algorithm tests each 3D triangle against each other triangle in a triangle mesh for intersection.
 
- `__host__ __device__` decorates (`AXOM_HOST_DEVICE`) the necessary functions to call `intersect_tri3D_tri3D` from the naïve algorithm.
- Disables the SLIC Check and Assert macros globally when using RAJA.