### PR TITLE
Use CudaKernelFixed and tread_direct policies

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,6 +7,25 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 
 The Axom project release numbers follow [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - Release date yyyy-mm-dd
+
+### Added
+
+### Removed
+
+### Deprecated
+
+### Changed
+
+### Fixed
+- Fixed usage of cuda kernel policies in Mint. Raja v0.11.0 changed the way max threads
+  launch bounds is calculated. Consequently, a large number of threads was being launched
+  leading to max registry count violation when linking. We are now using fixed kernel size
+  of 256 threads (16x16 in 2D and 8x8x4 in 3D).
+
+### Known Bugs
+
+
 ## [Version 0.3.3] - Release date 2020-01-31
 
 ### Added

--- a/src/axom/mint/execution/internal/structured_exec.hpp
+++ b/src/axom/mint/execution/internal/structured_exec.hpp
@@ -97,11 +97,11 @@ struct structured_exec< CUDA_EXEC< BLOCK_SIZE, SYNCHRONOUS > >
   /* *INDENT-OFF* */
 
   using loop2d_policy = RAJA::KernelPolicy<
-    RAJA::statement::CudaKernel<
+    RAJA::statement::CudaKernelFixed< 256,
       RAJA::statement::Tile<1, RAJA::statement::tile_fixed<16>, RAJA::cuda_block_y_loop,
         RAJA::statement::Tile<0, RAJA::statement::tile_fixed<16>, RAJA::cuda_block_x_loop,
-          RAJA::statement::For<1, RAJA::cuda_thread_y_loop,
-            RAJA::statement::For<0, RAJA::cuda_thread_x_loop,
+          RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+            RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
               RAJA::statement::Lambda<0>
             >
           >
@@ -111,13 +111,13 @@ struct structured_exec< CUDA_EXEC< BLOCK_SIZE, SYNCHRONOUS > >
   >;
 
   using loop3d_policy = RAJA::KernelPolicy<
-    RAJA::statement::CudaKernel<
-      RAJA::statement::Tile<2, RAJA::statement::tile_fixed<8>, RAJA::cuda_block_z_loop,
+    RAJA::statement::CudaKernelFixed< 256, 
+      RAJA::statement::Tile<2, RAJA::statement::tile_fixed<4>, RAJA::cuda_block_z_loop,
         RAJA::statement::Tile<1, RAJA::statement::tile_fixed<8>, RAJA::cuda_block_y_loop,
           RAJA::statement::Tile<0, RAJA::statement::tile_fixed<8>, RAJA::cuda_block_x_loop,
-            RAJA::statement::For<2, RAJA::cuda_thread_z_loop,
-              RAJA::statement::For<1, RAJA::cuda_thread_y_loop,
-                RAJA::statement::For<0, RAJA::cuda_thread_x_loop,
+            RAJA::statement::For<2, RAJA::cuda_thread_z_direct,
+              RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
                   RAJA::statement::Lambda<0>
                 >
               >
@@ -138,11 +138,11 @@ struct structured_exec< CUDA_EXEC< BLOCK_SIZE, ASYNC > >
   /* *INDENT-OFF* */
 
   using loop2d_policy = RAJA::KernelPolicy <
-    RAJA::statement::CudaKernelAsync<
+    RAJA::statement::CudaKernelFixedAsync< 256,
       RAJA::statement::Tile<1, RAJA::statement::tile_fixed<16>, RAJA::cuda_block_y_loop,
         RAJA::statement::Tile<0, RAJA::statement::tile_fixed<16>, RAJA::cuda_block_x_loop,
-          RAJA::statement::For<1, RAJA::cuda_thread_y_loop,
-            RAJA::statement::For<0, RAJA::cuda_thread_x_loop,
+          RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+            RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
               RAJA::statement::Lambda<0>
             >
           >
@@ -152,13 +152,13 @@ struct structured_exec< CUDA_EXEC< BLOCK_SIZE, ASYNC > >
   >;
 
   using loop3d_policy = RAJA::KernelPolicy<
-    RAJA::statement::CudaKernelAsync<
-      RAJA::statement::Tile<2, RAJA::statement::tile_fixed<8>, RAJA::cuda_block_z_loop,
+    RAJA::statement::CudaKernelFixedAsync< 256,
+      RAJA::statement::Tile<2, RAJA::statement::tile_fixed<4>, RAJA::cuda_block_z_loop,
         RAJA::statement::Tile<1, RAJA::statement::tile_fixed<8>, RAJA::cuda_block_y_loop,
           RAJA::statement::Tile<0, RAJA::statement::tile_fixed<8>, RAJA::cuda_block_x_loop,
-            RAJA::statement::For<2, RAJA::cuda_thread_z_loop,
-              RAJA::statement::For<1, RAJA::cuda_thread_y_loop,
-                RAJA::statement::For<0, RAJA::cuda_thread_x_loop,
+            RAJA::statement::For<2, RAJA::cuda_thread_z_direct,
+              RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
+                RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
                   RAJA::statement::Lambda<0>
                 >
               >

--- a/src/axom/mint/execution/internal/structured_exec.hpp
+++ b/src/axom/mint/execution/internal/structured_exec.hpp
@@ -88,6 +88,17 @@ struct structured_exec< OMP_EXEC >
 };
 #endif
 
+// CUDA Kernel settings: 
+// 
+// CudaKernel launches 256 threads total
+// - In 2D, the launch configuration is 16 x 16
+// - In 3D, the launch configuration is 8 x 8 x 4
+constexpr int CUDA_KERNEL_FIXED_SIZE = 256;
+constexpr int TILE_SIZE_2D = 16;
+constexpr int TILE_SIZE_X  = 8;
+constexpr int TILE_SIZE_Y  = 8;
+constexpr int TILE_SIZE_Z  = 4;
+
 //--------------------------------------------------------| CUDA_EXEC |---------
 #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
 
@@ -97,9 +108,9 @@ struct structured_exec< CUDA_EXEC< BLOCK_SIZE, SYNCHRONOUS > >
   /* *INDENT-OFF* */
 
   using loop2d_policy = RAJA::KernelPolicy<
-    RAJA::statement::CudaKernelFixed< 256,
-      RAJA::statement::Tile<1, RAJA::statement::tile_fixed<16>, RAJA::cuda_block_y_loop,
-        RAJA::statement::Tile<0, RAJA::statement::tile_fixed<16>, RAJA::cuda_block_x_loop,
+    RAJA::statement::CudaKernelFixed< CUDA_KERNEL_FIXED_SIZE,
+      RAJA::statement::Tile<1, RAJA::statement::tile_fixed< TILE_SIZE_2D >, RAJA::cuda_block_y_loop,
+        RAJA::statement::Tile<0, RAJA::statement::tile_fixed< TILE_SIZE_2D >, RAJA::cuda_block_x_loop,
           RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
             RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
               RAJA::statement::Lambda<0>
@@ -111,10 +122,10 @@ struct structured_exec< CUDA_EXEC< BLOCK_SIZE, SYNCHRONOUS > >
   >;
 
   using loop3d_policy = RAJA::KernelPolicy<
-    RAJA::statement::CudaKernelFixed< 256, 
-      RAJA::statement::Tile<2, RAJA::statement::tile_fixed<4>, RAJA::cuda_block_z_loop,
-        RAJA::statement::Tile<1, RAJA::statement::tile_fixed<8>, RAJA::cuda_block_y_loop,
-          RAJA::statement::Tile<0, RAJA::statement::tile_fixed<8>, RAJA::cuda_block_x_loop,
+    RAJA::statement::CudaKernelFixed< CUDA_KERNEL_FIXED_SIZE, 
+      RAJA::statement::Tile<2, RAJA::statement::tile_fixed< TILE_SIZE_Z >, RAJA::cuda_block_z_loop,
+        RAJA::statement::Tile<1, RAJA::statement::tile_fixed< TILE_SIZE_Y >, RAJA::cuda_block_y_loop,
+          RAJA::statement::Tile<0, RAJA::statement::tile_fixed< TILE_SIZE_X >, RAJA::cuda_block_x_loop,
             RAJA::statement::For<2, RAJA::cuda_thread_z_direct,
               RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
                 RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
@@ -138,9 +149,9 @@ struct structured_exec< CUDA_EXEC< BLOCK_SIZE, ASYNC > >
   /* *INDENT-OFF* */
 
   using loop2d_policy = RAJA::KernelPolicy <
-    RAJA::statement::CudaKernelFixedAsync< 256,
-      RAJA::statement::Tile<1, RAJA::statement::tile_fixed<16>, RAJA::cuda_block_y_loop,
-        RAJA::statement::Tile<0, RAJA::statement::tile_fixed<16>, RAJA::cuda_block_x_loop,
+    RAJA::statement::CudaKernelFixedAsync< CUDA_KERNEL_FIXED_SIZE,
+      RAJA::statement::Tile<1, RAJA::statement::tile_fixed< TILE_SIZE_2D >, RAJA::cuda_block_y_loop,
+        RAJA::statement::Tile<0, RAJA::statement::tile_fixed< TILE_SIZE_2D >, RAJA::cuda_block_x_loop,
           RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
             RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
               RAJA::statement::Lambda<0>
@@ -152,10 +163,10 @@ struct structured_exec< CUDA_EXEC< BLOCK_SIZE, ASYNC > >
   >;
 
   using loop3d_policy = RAJA::KernelPolicy<
-    RAJA::statement::CudaKernelFixedAsync< 256,
-      RAJA::statement::Tile<2, RAJA::statement::tile_fixed<4>, RAJA::cuda_block_z_loop,
-        RAJA::statement::Tile<1, RAJA::statement::tile_fixed<8>, RAJA::cuda_block_y_loop,
-          RAJA::statement::Tile<0, RAJA::statement::tile_fixed<8>, RAJA::cuda_block_x_loop,
+    RAJA::statement::CudaKernelFixedAsync< CUDA_KERNEL_FIXED_SIZE,
+      RAJA::statement::Tile<2, RAJA::statement::tile_fixed< TILE_SIZE_Z >, RAJA::cuda_block_z_loop,
+        RAJA::statement::Tile<1, RAJA::statement::tile_fixed< TILE_SIZE_Y >, RAJA::cuda_block_y_loop,
+          RAJA::statement::Tile<0, RAJA::statement::tile_fixed< TILE_SIZE_X >, RAJA::cuda_block_x_loop,
             RAJA::statement::For<2, RAJA::cuda_thread_z_direct,
               RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
                 RAJA::statement::For<0, RAJA::cuda_thread_x_direct,


### PR DESCRIPTION
# Summary

Raja changed the way cuda kernel launch bounds are calculated, which
was leading to a large number of threads being launched in the way
policies were defined previously. The large number of threads was
bloating the number of registers being used leading to a linking error
due max reg count violation. Fixed that by using Raja CudaKernelFixed
in conjuction with the "thread direct" policies.
