### PR TITLE
Set boolean option so job fails when tests fail

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,3 +102,4 @@ steps:
     testResultsFormat: 'cTest'
     testResultsFiles: '**/Test.xml'
     testRunTitle: '$(TEST_TARGET) Tests'
+    failTaskOnFailedTests: true


### PR DESCRIPTION
Setting the option 'failTaskOnFailedTests' of the PublishTestResults task to true will cause that task to be marked as failed when any tests fail.  This addresses the confusion caused when all the Azure build and test tasks succeed (and show as green) even when one or more tests has failed.


- This PR is a bugfix
- It does the following:
  - Fails the PublishTestResults task when test failures are detected (issue 162)
