### PR TITLE
Attempt to fix CI tests of sidre_lulesh by changing number of ctest threads

### DIFF
--- a/scripts/azure-pipelines/linux-build_and_test.sh
+++ b/scripts/azure-pipelines/linux-build_and_test.sh
@@ -33,7 +33,7 @@ if [[ "$DO_BUILD" == "yes" ]] ; then
         or_die make -j 10 VERBOSE=1
     fi
     if [[ "${DO_TEST}" == "yes" ]] ; then
-        ctest -j8 -T test --output-on-failure -V
+        make CTEST_OUTPUT_ON_FAILURE=1 test ARGS='-T Test -VV -j8'
     fi
     if [[ "${DO_MEMCHECK}" == "yes" ]] ; then
       or_die ctest -T memcheck

--- a/scripts/azure-pipelines/linux-build_and_test.sh
+++ b/scripts/azure-pipelines/linux-build_and_test.sh
@@ -33,7 +33,7 @@ if [[ "$DO_BUILD" == "yes" ]] ; then
         or_die make -j 10 VERBOSE=1
     fi
     if [[ "${DO_TEST}" == "yes" ]] ; then
-        make CTEST_OUTPUT_ON_FAILURE=1 test ARGS='-T Test -VV -j4'
+        make -j4 CTEST_OUTPUT_ON_FAILURE=1 test ARGS='-T Test -VV'
     fi
     if [[ "${DO_MEMCHECK}" == "yes" ]] ; then
       or_die ctest -T memcheck

--- a/scripts/azure-pipelines/linux-build_and_test.sh
+++ b/scripts/azure-pipelines/linux-build_and_test.sh
@@ -33,7 +33,7 @@ if [[ "$DO_BUILD" == "yes" ]] ; then
         or_die make -j 10 VERBOSE=1
     fi
     if [[ "${DO_TEST}" == "yes" ]] ; then
-        make CTEST_OUTPUT_ON_FAILURE=1 test ARGS='-T Test -VV'
+        make CTEST_OUTPUT_ON_FAILURE=1 test ARGS='-T Test -VV -j8'
     fi
     if [[ "${DO_MEMCHECK}" == "yes" ]] ; then
       or_die ctest -T memcheck

--- a/scripts/azure-pipelines/linux-build_and_test.sh
+++ b/scripts/azure-pipelines/linux-build_and_test.sh
@@ -33,7 +33,7 @@ if [[ "$DO_BUILD" == "yes" ]] ; then
         or_die make -j 10 VERBOSE=1
     fi
     if [[ "${DO_TEST}" == "yes" ]] ; then
-        make -j4 CTEST_OUTPUT_ON_FAILURE=1 test ARGS='-T Test -VV'
+        make CTEST_OUTPUT_ON_FAILURE=1 test ARGS='-T Test -VV'
     fi
     if [[ "${DO_MEMCHECK}" == "yes" ]] ; then
       or_die ctest -T memcheck

--- a/scripts/azure-pipelines/linux-build_and_test.sh
+++ b/scripts/azure-pipelines/linux-build_and_test.sh
@@ -33,7 +33,7 @@ if [[ "$DO_BUILD" == "yes" ]] ; then
         or_die make -j 10 VERBOSE=1
     fi
     if [[ "${DO_TEST}" == "yes" ]] ; then
-        make CTEST_OUTPUT_ON_FAILURE=1 test ARGS='-T Test -VV -j8'
+        make CTEST_OUTPUT_ON_FAILURE=1 test ARGS='-T Test -VV -j4'
     fi
     if [[ "${DO_MEMCHECK}" == "yes" ]] ; then
       or_die ctest -T memcheck

--- a/scripts/azure-pipelines/linux-build_and_test.sh
+++ b/scripts/azure-pipelines/linux-build_and_test.sh
@@ -33,7 +33,7 @@ if [[ "$DO_BUILD" == "yes" ]] ; then
         or_die make -j 10 VERBOSE=1
     fi
     if [[ "${DO_TEST}" == "yes" ]] ; then
-        make -j8 CTEST_OUTPUT_ON_FAILURE=1 test ARGS='-T Test -VV'
+        ctest -j8 -T test --output-on-failure -V
     fi
     if [[ "${DO_MEMCHECK}" == "yes" ]] ; then
       or_die ctest -T memcheck

--- a/scripts/azure-pipelines/linux-build_and_test.sh
+++ b/scripts/azure-pipelines/linux-build_and_test.sh
@@ -33,7 +33,7 @@ if [[ "$DO_BUILD" == "yes" ]] ; then
         or_die make -j 10 VERBOSE=1
     fi
     if [[ "${DO_TEST}" == "yes" ]] ; then
-        make CTEST_OUTPUT_ON_FAILURE=1 test ARGS='-T Test -VV -j8'
+        make -j8 CTEST_OUTPUT_ON_FAILURE=1 test ARGS='-T Test -VV'
     fi
     if [[ "${DO_MEMCHECK}" == "yes" ]] ; then
       or_die ctest -T memcheck

--- a/src/axom/sidre/examples/lulesh2/CMakeLists.txt
+++ b/src/axom/sidre/examples/lulesh2/CMakeLists.txt
@@ -39,10 +39,10 @@ if(AXOM_ENABLE_TESTS)
         blt_add_test(NAME sidre_lulesh2
                      COMMAND sidre_lulesh2_ex
                      NUM_MPI_TASKS 8
-                     NUM_OMP_THREADS 4 )
+                     NUM_OMP_THREADS 2 )
     else()
         blt_add_test(NAME sidre_lulesh2
                      COMMAND sidre_lulesh2_ex
-                     NUM_OMP_THREADS 4 )
+                     NUM_OMP_THREADS 2 )
     endif()
 endif()

--- a/src/axom/sidre/examples/lulesh2/CMakeLists.txt
+++ b/src/axom/sidre/examples/lulesh2/CMakeLists.txt
@@ -37,12 +37,12 @@ blt_add_executable(
 if(AXOM_ENABLE_TESTS)
     if(ENABLE_MPI)
         blt_add_test(NAME sidre_lulesh2
-                     COMMAND sidre_lulesh2_ex -s 5
+                     COMMAND sidre_lulesh2_ex
                      NUM_MPI_TASKS 8
-                     NUM_OMP_THREADS 2 )
+                     NUM_OMP_THREADS 4 )
     else()
         blt_add_test(NAME sidre_lulesh2
-                     COMMAND sidre_lulesh2_ex -s 5
-                     NUM_OMP_THREADS 2 )
+                     COMMAND sidre_lulesh2_ex
+                     NUM_OMP_THREADS 4 )
     endif()
 endif()

--- a/src/axom/sidre/examples/lulesh2/CMakeLists.txt
+++ b/src/axom/sidre/examples/lulesh2/CMakeLists.txt
@@ -38,11 +38,11 @@ if(AXOM_ENABLE_TESTS)
     if(ENABLE_MPI)
         blt_add_test(NAME sidre_lulesh2
                      COMMAND sidre_lulesh2_ex
-                     NUM_MPI_TASKS 8
-                     NUM_OMP_THREADS 1 )
+                     NUM_MPI_TASKS 1
+                     NUM_OMP_THREADS 2 )
     else()
         blt_add_test(NAME sidre_lulesh2
                      COMMAND sidre_lulesh2_ex
-                     NUM_OMP_THREADS 1 )
+                     NUM_OMP_THREADS 2 )
     endif()
 endif()

--- a/src/axom/sidre/examples/lulesh2/CMakeLists.txt
+++ b/src/axom/sidre/examples/lulesh2/CMakeLists.txt
@@ -39,10 +39,10 @@ if(AXOM_ENABLE_TESTS)
         blt_add_test(NAME sidre_lulesh2
                      COMMAND sidre_lulesh2_ex
                      NUM_MPI_TASKS 8
-                     NUM_OMP_THREADS 2 )
+                     NUM_OMP_THREADS 1 )
     else()
         blt_add_test(NAME sidre_lulesh2
                      COMMAND sidre_lulesh2_ex
-                     NUM_OMP_THREADS 2 )
+                     NUM_OMP_THREADS 1 )
     endif()
 endif()


### PR DESCRIPTION
# Summary

Our azure job is failing the ``sidre_lulesh`` tests for ``gcc`` configurations.
Those tests use ``MPI`` and ``OpenMP``.

This is an attempt to fix it by reducing the number of threads.
