### PR TITLE
Axom Memory Management API Updates

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -16,6 +16,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ### Deprecated
 
 ### Changed
+- Modified the API of Axom's memory management routines to not leak usage of Umpire. Instead of 
+  passing an `umpire::Allocator` object to specify an allocator, we now use the corresponding
+  integer ID associated with the allocator.
 
 ### Fixed
 - Fixed usage of cuda kernel policies in Mint. Raja v0.11.0 changed the way max threads

--- a/src/axom/core/execution/internal/cuda_exec.hpp
+++ b/src/axom/core/execution/internal/cuda_exec.hpp
@@ -57,7 +57,7 @@ struct execution_space< CUDA_EXEC< BLOCK_SIZE, SYNCHRONOUS > >
   static constexpr bool valid() noexcept { return true; };
   static constexpr char* name() noexcept { return (char*)"[CUDA_EXEC]"; };
   static int allocatorID() noexcept
-  { return axom::getResourceAllocatorID(umpire::resource::Unified); };
+  { return axom::getUmpireResourceAllocatorID(umpire::resource::Unified); };
 
 };
 

--- a/src/axom/core/execution/internal/cuda_exec.hpp
+++ b/src/axom/core/execution/internal/cuda_exec.hpp
@@ -82,7 +82,7 @@ struct execution_space< CUDA_EXEC< BLOCK_SIZE, ASYNC > >
     return (char*)"[CUDA_EXEC] (async)";
   };
   static int allocatorID() noexcept
-  { return axom::getResourceAllocatorID(umpire::resource::Unified); };
+  { return axom::getUmpireResourceAllocatorID(umpire::resource::Unified); };
 
 };
 } /* namespace axom */

--- a/src/axom/core/execution/internal/omp_exec.hpp
+++ b/src/axom/core/execution/internal/omp_exec.hpp
@@ -50,7 +50,7 @@ struct execution_space< OMP_EXEC >
 #ifdef AXOM_USE_UMPIRE
     return axom::getUmpireResourceAllocatorID(umpire::resource::Host);
 #else
-    return 0;
+    return axom::DEFAULT_ALLOCATOR_ID;
 #endif
   };
 

--- a/src/axom/core/execution/internal/omp_exec.hpp
+++ b/src/axom/core/execution/internal/omp_exec.hpp
@@ -48,7 +48,7 @@ struct execution_space< OMP_EXEC >
   static int allocatorID() noexcept
   {
 #ifdef AXOM_USE_UMPIRE
-    return axom::getResourceAllocatorID(umpire::resource::Host);
+    return axom::getUmpireResourceAllocatorID(umpire::resource::Host);
 #else
     return 0;
 #endif

--- a/src/axom/core/execution/internal/seq_exec.hpp
+++ b/src/axom/core/execution/internal/seq_exec.hpp
@@ -58,7 +58,7 @@ struct execution_space< SEQ_EXEC >
 #ifdef AXOM_USE_UMPIRE
     return axom::getUmpireResourceAllocatorID( umpire::resource::Host );
 #else
-    return 0;
+    return axom::DEFAULT_ALLOCATOR_ID;
 #endif
   };
 

--- a/src/axom/core/execution/internal/seq_exec.hpp
+++ b/src/axom/core/execution/internal/seq_exec.hpp
@@ -56,7 +56,7 @@ struct execution_space< SEQ_EXEC >
   static int allocatorID() noexcept
   {
 #ifdef AXOM_USE_UMPIRE
-    return axom::getResourceAllocatorID( umpire::resource::Host );
+    return axom::getUmpireResourceAllocatorID( umpire::resource::Host );
 #else
     return 0;
 #endif

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -66,13 +66,17 @@ inline void setDefaultAllocator( int allocatorID )
 
 /*!
  * \brief Returns the current default memory space used.
+ * \note If Umpire is used, the corresponding umpire allocator can be retrieved by:
+ *  <code>
+ *    umpire::Allocator alloc = umpire::ResourceManager::getInstance().getAllocator( allocID );
+ *  </code>
  */
 inline int getDefaultAllocatorID()
 {
 #ifdef AXOM_USE_UMPIRE
   return umpire::ResourceManager::getInstance().getDefaultAllocator().getId();
 #else
-  return DEFAULT_ALLOCATOR_ID;
+  return axom::DEFAULT_ALLOCATOR_ID;
 #endif
 }
 

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -22,6 +22,13 @@
 namespace axom
 {
 
+#ifdef AXOM_USE_UMPIRE
+const int DEFAULT_ALLOCATOR_ID =
+  umpire::ResourceManager::getInstance().getAllocator("HOST").getId();
+#else
+constexpr int DEFAULT_ALLOCATOR_ID = 0;
+#endif
+
 constexpr int INVALID_ALLOCATOR_ID = -1;
 
 /// \name Memory Management Routines
@@ -34,7 +41,7 @@ constexpr int INVALID_ALLOCATOR_ID = -1;
  * \param [in] resource_type the Umpire resource type
  * \return ID the id of the predefined umpire allocator.
  */
-inline int getResourceAllocatorID(
+inline int getUmpireResourceAllocatorID(
   umpire::resource::MemoryResourceType resource_type )
 {
   umpire::ResourceManager& rm = umpire::ResourceManager::getInstance();
@@ -42,42 +49,32 @@ inline int getResourceAllocatorID(
   return alloc.getId();
 }
 
-/*!
- * \brief Returns the umpire allocator associated with the given ID.
- * \param [in] allocatorID the ID of the allocator to get.
- */
-inline umpire::Allocator getAllocator( int allocatorID )
-{
-  return umpire::ResourceManager::getInstance().getAllocator( allocatorID );
-}
+#endif
 
 /*!
  * \brief Sets the default memory space to use. Default is set to HOST
- * \param [in] allocator the umpire::Allocator to make default.
- */
-inline void setDefaultAllocator( umpire::Allocator allocator )
-{
-  umpire::ResourceManager::getInstance().setDefaultAllocator( allocator );
-}
-
-/*!
- * \brief Sets the default memory space to use. Default is set to HOST
- * \param [in] allocatorID ID of the umpire::Allocator to use.
+ * \param [in] allocatorID ID of the allocator to use.
  */
 inline void setDefaultAllocator( int allocatorID )
 {
-  setDefaultAllocator( getAllocator( allocatorID ) );
+#ifdef AXOM_USE_UMPIRE
+  umpire::ResourceManager& rm = umpire::ResourceManager::getInstance();
+  umpire::Allocator allocator = rm.getAllocator( allocatorID );
+  rm.setDefaultAllocator( allocator );
+#endif
 }
 
 /*!
  * \brief Returns the current default memory space used.
  */
-inline umpire::Allocator getDefaultAllocator()
+inline int getDefaultAllocatorID()
 {
-  return umpire::ResourceManager::getInstance().getDefaultAllocator();
-}
-
+#ifdef AXOM_USE_UMPIRE
+  return umpire::ResourceManager::getInstance().getDefaultAllocator().getId();
+#else
+  return DEFAULT_ALLOCATOR_ID;
 #endif
+}
 
 /*!
  * \brief Allocates a chunk of memory of type T.
@@ -96,13 +93,8 @@ inline umpire::Allocator getDefaultAllocator()
  * \return p pointer to the new allocation or a nullptr if allocation failed.
  */
 template < typename T >
-#ifdef AXOM_USE_UMPIRE
-inline T* allocate( std::size_t n,
-                    umpire::Allocator allocator=
-                      getDefaultAllocator() ) noexcept;
-#else
-inline T* allocate( std::size_t n ) noexcept;
-#endif
+inline T* allocate(std::size_t n, int allocID=getDefaultAllocatorID() )noexcept;
+
 
 /*!
  * \brief Frees the chunk of memory pointed to by the supplied pointer, p.
@@ -150,27 +142,22 @@ inline void copy( void* dst, void* src, std::size_t numbytes ) noexcept;
 //                        IMPLEMENTATION
 //------------------------------------------------------------------------------
 
-//------------------------------------------------------------------------------
+template < typename T >
+inline T* allocate( std::size_t n, int allocID ) noexcept
+{
+  const std::size_t numbytes = n * sizeof( T );
+
 #ifdef AXOM_USE_UMPIRE
 
-template < typename T >
-inline T* allocate( std::size_t n, umpire::Allocator allocator ) noexcept
-{
-  const std::size_t numbytes = n * sizeof( T );
-  return static_cast< T* >( allocator.allocate( numbytes )  );
-}
+  umpire::ResourceManager& rm = umpire::ResourceManager::getInstance();
+  umpire::Allocator allocator = rm.getAllocator( allocID );
+  return static_cast< T* >( allocator.allocate( numbytes ) );
 
 #else
-
-template < typename T >
-inline T* allocate( std::size_t n ) noexcept
-{
-  const std::size_t numbytes = n * sizeof( T );
-  return static_cast< T* >( std::malloc( numbytes )  );
-}
-
+  return static_cast< T* >( std::malloc( numbytes ) );
 #endif
 
+}
 //------------------------------------------------------------------------------
 template < typename T >
 inline void deallocate( T*& pointer ) noexcept

--- a/src/axom/core/tests/core_execution_for_all.cpp
+++ b/src/axom/core/tests/core_execution_for_all.cpp
@@ -34,10 +34,8 @@ void check_for_all( )
   constexpr int N       = 256;
 
   // STEP 1: set default allocator for the execution space
-#ifdef AXOM_USE_UMPIRE
-  umpire::Allocator current_allocator = axom::getDefaultAllocator();
+  const int currentAllocatorID = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator( axom::execution_space<ExecSpace>::allocatorID() );
-#endif
 
   // STEP 0: allocate buffer
   int* a = axom::allocate< int >( N );
@@ -80,9 +78,8 @@ void check_for_all( )
   // STEP 5: cleanup
   axom::deallocate( a );
 
-#ifdef AXOM_USE_UMPIRE
-  axom::setDefaultAllocator( current_allocator );
-#endif
+
+  axom::setDefaultAllocator( currentAllocatorID );
 }
 
 } /* end anonymous namespace */

--- a/src/axom/core/tests/core_execution_space.cpp
+++ b/src/axom/core/tests/core_execution_space.cpp
@@ -129,7 +129,7 @@ TEST( core_execution_space, check_seq_exec )
   constexpr bool IS_ASYNC = false;
 
 
-  int allocator_id = axom::getResourceAllocatorID( umpire::resource::Host );
+  int allocator_id = axom::getUmpireResourceAllocatorID(umpire::resource::Host);
   check_execution_mappings< axom::SEQ_EXEC,
                             RAJA::loop_exec,
                             RAJA::loop_reduce,
@@ -147,7 +147,7 @@ TEST( core_execution_space, check_omp_exec )
 
   constexpr bool IS_ASYNC = false;
 
-  int allocator_id = axom::getResourceAllocatorID( umpire::resource::Host );
+  int allocator_id = axom::getUmpireResourceAllocatorID(umpire::resource::Host);
   check_execution_mappings< axom::OMP_EXEC,
                             RAJA::omp_parallel_for_exec,
                             RAJA::omp_reduce,
@@ -168,7 +168,8 @@ TEST( core_execution_space, check_cuda_exec )
 
   constexpr bool IS_ASYNC = false;
 
-  int allocator_id = axom::getResourceAllocatorID( umpire::resource::Unified );
+  int allocator_id =
+      axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
   check_execution_mappings< axom::CUDA_EXEC< BLOCK_SIZE >,
                             RAJA::cuda_exec< BLOCK_SIZE >,
                             RAJA::cuda_reduce,
@@ -186,7 +187,8 @@ TEST( core_execution_space, check_cuda_exec_async )
 
   constexpr bool IS_ASYNC = true;
 
-  int allocator_id = axom::getResourceAllocatorID( umpire::resource::Unified );
+  int allocator_id =
+      axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
   check_execution_mappings< axom::CUDA_EXEC< BLOCK_SIZE, axom::ASYNC >,
                             RAJA::cuda_exec_async< BLOCK_SIZE >,
                             RAJA::cuda_reduce,

--- a/src/axom/core/tests/core_memory_management.cpp
+++ b/src/axom/core/tests/core_memory_management.cpp
@@ -325,25 +325,25 @@ TEST( core_memory_management, alloc_free )
 
 #ifdef UMPIRE_ENABLE_PINNED
   const int PinnedAllocatorID =
-    axom::getResourceAllocatorID( umpire::resource::Pinned );
+    axom::getUmpireResourceAllocatorID( umpire::resource::Pinned );
   check_alloc_and_free( PinnedAllocatorID, HOST_ACCESSIBLE );
 #endif
 
 #ifdef UMPIRE_ENABLE_DEVICE
   const int DeviceAllocatorID =
-    axom::getResourceAllocatorID( umpire::resource::Device );
+    axom::getUmpireResourceAllocatorID( umpire::resource::Device );
   check_alloc_and_free( DeviceAllocatorID, NOT_HOST_ACCESSIBLE );
 #endif
 
 #ifdef UMPIRE_ENABLE_CONST
   const int ConstantAllocatorID =
-    axom::getResourceAllocatorID( umpire::resource::Constant );
+    axom::getUmpireResourceAllocatorID( umpire::resource::Constant );
   check_alloc_and_free( ConstantAllocatorID, NOT_HOST_ACCESSIBLE );
 #endif
 
 #ifdef UMPIRE_ENABLE_UM
   const int UnifiedAllocatorID =
-    axom::getResourceAllocatorID( umpire::resource::Unified );
+    axom::getUmpireResourceAllocatorID( umpire::resource::Unified );
   check_alloc_and_free( UnifiedAllocatorID, HOST_ACCESSIBLE );
 #endif
 

--- a/src/axom/core/tests/core_memory_management.cpp
+++ b/src/axom/core/tests/core_memory_management.cpp
@@ -17,10 +17,6 @@
 // HELPER METHODS
 //------------------------------------------------------------------------------
 
-#ifdef AXOM_USE_UMPIRE
-#else
-#endif
-
 // This value is such that the 64Kb limit on device constant memory is not hit
 // in check_alloc_realloc_free when reallocating to 3 * SIZE.
 constexpr int SIZE = 5345;

--- a/src/axom/core/tests/core_memory_management.cpp
+++ b/src/axom/core/tests/core_memory_management.cpp
@@ -17,6 +17,10 @@
 // HELPER METHODS
 //------------------------------------------------------------------------------
 
+#ifdef AXOM_USE_UMPIRE
+#else
+#endif
+
 // This value is such that the 64Kb limit on device constant memory is not hit
 // in check_alloc_realloc_free when reallocating to 3 * SIZE.
 constexpr int SIZE = 5345;
@@ -127,10 +131,8 @@ private:
 };
 
 #ifdef AXOM_USE_UMPIRE
-void check_alloc_and_free(
-  umpire::Allocator allocator=
-    axom::getAllocator(axom::getResourceAllocatorID(umpire::resource::Host)),
-  bool hostAccessible=true  )
+void check_alloc_and_free( int allocatorID=axom::DEFAULT_ALLOCATOR_ID,
+                           bool hostAccessible=true  )
 #else
 void check_alloc_and_free( bool hostAccessible=true)
 #endif
@@ -138,12 +140,12 @@ void check_alloc_and_free( bool hostAccessible=true)
   for ( int size = 0 ; size <= SIZE ; size = size * 2 + 1 )
   {
 #ifdef AXOM_USE_UMPIRE
-    int* buffer = axom::allocate< int >( size, allocator );
+    int* buffer = axom::allocate< int >( size, allocatorID );
 
     if (size > 0)
     {
       umpire::ResourceManager& rm = umpire::ResourceManager::getInstance();
-      EXPECT_EQ( allocator.getId(), rm.getAllocator( buffer ).getId() );
+      EXPECT_EQ( allocatorID, rm.getAllocator( buffer ).getId() );
     }
 #else
     int* buffer = axom::allocate< int >( size );
@@ -168,10 +170,8 @@ void check_alloc_and_free( bool hostAccessible=true)
 }
 
 #ifdef AXOM_USE_UMPIRE
-void check_alloc_realloc_free(
-  umpire::Allocator allocator=
-    axom::getAllocator(axom::getResourceAllocatorID(umpire::resource::Host)),
-  bool hostAccessible=true )
+void check_alloc_realloc_free( int allocatorID=axom::DEFAULT_ALLOCATOR_ID,
+                               bool hostAccessible=true )
 #else
 void check_alloc_realloc_free( bool hostAccessible=true )
 #endif
@@ -181,12 +181,12 @@ void check_alloc_realloc_free( bool hostAccessible=true )
     int buffer_size = size;
 
 #ifdef AXOM_USE_UMPIRE
-    int* buffer = axom::allocate< int >( buffer_size, allocator );
+    int* buffer = axom::allocate< int >( buffer_size, allocatorID );
 
     umpire::ResourceManager & rm = umpire::ResourceManager::getInstance();
     if (buffer_size > 0)
     {
-      ASSERT_EQ(allocator.getId(), rm.getAllocator(buffer).getId());
+      ASSERT_EQ( allocatorID, rm.getAllocator(buffer).getId() );
     }
 #else
     int* buffer = axom::allocate< int >( buffer_size );
@@ -213,7 +213,7 @@ void check_alloc_realloc_free( bool hostAccessible=true )
 #ifdef AXOM_USE_UMPIRE
     if (buffer_size > 0)
     {
-      ASSERT_EQ(allocator.getId(), rm.getAllocator(buffer).getId());
+      ASSERT_EQ( allocatorID, rm.getAllocator(buffer).getId() );
     }
 #endif
 
@@ -238,7 +238,7 @@ void check_alloc_realloc_free( bool hostAccessible=true )
 #ifdef AXOM_USE_UMPIRE
     if (buffer_size > 0)
     {
-      ASSERT_EQ(allocator.getId(), rm.getAllocator(buffer).getId());
+      ASSERT_EQ( allocatorID, rm.getAllocator(buffer).getId() );
     }
 #endif
 
@@ -266,45 +266,45 @@ void check_alloc_realloc_free( bool hostAccessible=true )
 TEST( core_memory_management, set_get_default_memory_space )
 {
   const int HostAllocatorID =
-    axom::getResourceAllocatorID( umpire::resource::Host );
-  EXPECT_EQ( HostAllocatorID, axom::getDefaultAllocator().getId() );
+    axom::getUmpireResourceAllocatorID( umpire::resource::Host );
+  EXPECT_EQ( HostAllocatorID, axom::getDefaultAllocatorID() );
 
 #ifdef AXOM_USE_CUDA
 
 #ifdef UMPIRE_ENABLE_PINNED
   const int PinnedAllocatorID =
-    axom::getResourceAllocatorID( umpire::resource::Pinned );
+    axom::getUmpireResourceAllocatorID( umpire::resource::Pinned );
 
-  axom::setDefaultAllocator( axom::getAllocator( PinnedAllocatorID ) );
-  EXPECT_EQ( PinnedAllocatorID, axom::getDefaultAllocator().getId() );
+  axom::setDefaultAllocator( PinnedAllocatorID );
+  EXPECT_EQ( PinnedAllocatorID, axom::getDefaultAllocatorID() );
 #endif
 
 #ifdef UMPIRE_ENABLE_DEVICE
   const int DeviceAllocatorID =
-    axom::getResourceAllocatorID( umpire::resource::Device );
-  axom::setDefaultAllocator( axom::getAllocator( DeviceAllocatorID ) );
-  EXPECT_EQ( DeviceAllocatorID, axom::getDefaultAllocator().getId() );
+    axom::getUmpireResourceAllocatorID( umpire::resource::Device );
+  axom::setDefaultAllocator( DeviceAllocatorID );
+  EXPECT_EQ( DeviceAllocatorID, axom::getDefaultAllocatorID() );
 #endif
 
 #ifdef UMPIRE_ENABLE_CONST
   const int ConstantAllocatorID =
-    axom::getResourceAllocatorID( umpire::resource::Constant );
-  axom::setDefaultAllocator( axom::getAllocator( ConstantAllocatorID ) );
-  EXPECT_EQ( ConstantAllocatorID, axom::getDefaultAllocator().getId() );
+    axom::getUmpireResourceAllocatorID( umpire::resource::Constant );
+  axom::setDefaultAllocator( ConstantAllocatorID  );
+  EXPECT_EQ( ConstantAllocatorID, axom::getDefaultAllocatorID() );
 #endif
 
 #ifdef UMPIRE_ENABLE_UM
   const int UnifiedAllocatorID =
-    axom::getResourceAllocatorID( umpire::resource::Unified );
-  axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-  EXPECT_EQ( UnifiedAllocatorID, axom::getDefaultAllocator().getId() );
+    axom::getUmpireResourceAllocatorID( umpire::resource::Unified );
+  axom::setDefaultAllocator( UnifiedAllocatorID );
+  EXPECT_EQ( UnifiedAllocatorID, axom::getDefaultAllocatorID() );
 #endif
 
 #endif // AXOM_USE_CUDA
 
 
-  axom::setDefaultAllocator( axom::getAllocator( HostAllocatorID ) );
-  EXPECT_EQ( HostAllocatorID, axom::getDefaultAllocator().getId() );
+  axom::setDefaultAllocator( HostAllocatorID );
+  EXPECT_EQ( HostAllocatorID, axom::getDefaultAllocatorID() );
 }
 #endif /* AXOM_USE_UMPIRE */
 
@@ -316,10 +316,8 @@ TEST( core_memory_management, alloc_free )
   constexpr bool HOST_ACCESSIBLE = true;
 
   const int HostAllocatorID =
-    axom::getResourceAllocatorID( umpire::resource::Host );
-  check_alloc_and_free( axom::getAllocator( HostAllocatorID ),
-                        HOST_ACCESSIBLE
-                        );
+      axom::getUmpireResourceAllocatorID( umpire::resource::Host );
+  check_alloc_and_free( HostAllocatorID, HOST_ACCESSIBLE );
 
 #ifdef AXOM_USE_CUDA
 
@@ -328,33 +326,25 @@ TEST( core_memory_management, alloc_free )
 #ifdef UMPIRE_ENABLE_PINNED
   const int PinnedAllocatorID =
     axom::getResourceAllocatorID( umpire::resource::Pinned );
-  check_alloc_and_free( axom::getAllocator( PinnedAllocatorID ),
-                        HOST_ACCESSIBLE
-                        );
+  check_alloc_and_free( PinnedAllocatorID, HOST_ACCESSIBLE );
 #endif
 
 #ifdef UMPIRE_ENABLE_DEVICE
   const int DeviceAllocatorID =
     axom::getResourceAllocatorID( umpire::resource::Device );
-  check_alloc_and_free( axom::getAllocator( DeviceAllocatorID ),
-                        NOT_HOST_ACCESSIBLE
-                        );
+  check_alloc_and_free( DeviceAllocatorID, NOT_HOST_ACCESSIBLE );
 #endif
 
 #ifdef UMPIRE_ENABLE_CONST
   const int ConstantAllocatorID =
     axom::getResourceAllocatorID( umpire::resource::Constant );
-  check_alloc_and_free( axom::getAllocator( ConstantAllocatorID ),
-                        NOT_HOST_ACCESSIBLE
-                        );
+  check_alloc_and_free( ConstantAllocatorID, NOT_HOST_ACCESSIBLE );
 #endif
 
 #ifdef UMPIRE_ENABLE_UM
   const int UnifiedAllocatorID =
     axom::getResourceAllocatorID( umpire::resource::Unified );
-  check_alloc_and_free( axom::getAllocator( UnifiedAllocatorID ),
-                        HOST_ACCESSIBLE
-                        );
+  check_alloc_and_free( UnifiedAllocatorID, HOST_ACCESSIBLE );
 #endif
 
 #endif // AXOM_USE_CUDA
@@ -371,9 +361,9 @@ TEST( core_memory_management, alloc_realloc_free )
 
   constexpr bool HOST_ACCESSIBLE = true;
 
-  check_alloc_realloc_free( axom::getAllocator( umpire::resource::Host ),
-                            HOST_ACCESSIBLE
-                            );
+  const int HostAllocatorID =
+        axom::getUmpireResourceAllocatorID( umpire::resource::Host );
+  check_alloc_realloc_free( HostAllocatorID, HOST_ACCESSIBLE );
 
 #ifdef AXOM_USE_CUDA
 
@@ -381,18 +371,14 @@ TEST( core_memory_management, alloc_realloc_free )
 
 #ifdef UMPIRE_ENABLE_PINNED
   const int PinnedAllocatorID =
-    axom::getResourceAllocatorID( umpire::resource::Pinned );
-  check_alloc_realloc_free( axom::getAllocator( PinnedAllocatorID ),
-                            HOST_ACCESSIBLE
-                            );
+    axom::getUmpireResourceAllocatorID( umpire::resource::Pinned );
+  check_alloc_realloc_free( PinnedAllocatorID, HOST_ACCESSIBLE );
 #endif
 
 #ifdef UMPIRE_ENABLE_DEVICE
   const int DeviceAllocatorID =
-    axom::getResourceAllocatorID( umpire::resource::Device );
-  check_alloc_realloc_free( axom::getAllocator( DeviceAllocatorID ),
-                            NOT_HOST_ACCESSIBLE
-                            );
+    axom::getUmpireResourceAllocatorID( umpire::resource::Device );
+  check_alloc_realloc_free( DeviceAllocatorID, NOT_HOST_ACCESSIBLE );
 #endif
 
   // Umpire doesn't allow reallocation of Constant memory.
@@ -403,10 +389,8 @@ TEST( core_memory_management, alloc_realloc_free )
 #ifdef UMPIRE_ENABLE_UM
 
   const int UnifiedAllocatorID =
-    axom::getResourceAllocatorID( umpire::resource::Unified );
-  check_alloc_realloc_free( axom::getAllocator( UnifiedAllocatorID ),
-                            HOST_ACCESSIBLE
-                            );
+    axom::getUmpireResourceAllocatorID( umpire::resource::Unified );
+  check_alloc_realloc_free( UnifiedAllocatorID, HOST_ACCESSIBLE );
 
 #endif
 

--- a/src/axom/mint/examples/user_guide/mint_getting_started.cpp
+++ b/src/axom/mint/examples/user_guide/mint_getting_started.cpp
@@ -67,10 +67,8 @@ int main ( int argc, char** argv )
 
 // sphinx_tutorial_walkthrough_set_memory_start
   // NOTE: use unified memory if we are using CUDA
-#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA)
-  const int allocID = axom::getResourceAllocatorID( umpire::resource::Unified );
-  axom::setDefaultAllocator( axom::getAllocator( allocID) );
-#endif
+  const int allocID = axom::execution_space< ExecPolicy >::allocatorID();
+  axom::setDefaultAllocator( allocID );
 // sphinx_tutorial_walkthrough_set_memory_end
 
 // sphinx_tutorial_walkthrough_construct_mesh_start

--- a/src/axom/mint/tests/mint_execution_cell_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_cell_traversals.cpp
@@ -379,12 +379,12 @@ AXOM_CUDA_TEST( mint_execution_cell_traversals, for_all_cells_nodeids )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
     defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-    const int UnifiedAllocatorID =
-        axom::getResourceAllocatorID( umpire::resource::Unified );
-    const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-    axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
     using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+    const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+    const int prev_allocator = axom::getDefaultAllocatorID();
+    axom::setDefaultAllocator( exec_space_id );
+
     check_for_all_cell_nodes< cuda_exec, STRUCTURED_UNIFORM_MESH >(i);
     check_for_all_cell_nodes< cuda_exec, STRUCTURED_CURVILINEAR_MESH >(i);
     check_for_all_cell_nodes< cuda_exec, STRUCTURED_RECTILINEAR_MESH >(i);
@@ -425,12 +425,12 @@ AXOM_CUDA_TEST( mint_execution_cell_traversals, for_all_cells_coords )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
     defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-    const int UnifiedAllocatorID =
-        axom::getResourceAllocatorID( umpire::resource::Unified );
-    const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-    axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
     using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+    const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+    const int prev_allocator = axom::getDefaultAllocatorID();
+    axom::setDefaultAllocator( exec_space_id );
+
     check_for_all_cell_coords< cuda_exec, STRUCTURED_UNIFORM_MESH >(i);
     check_for_all_cell_coords< cuda_exec, STRUCTURED_CURVILINEAR_MESH >(i);
     check_for_all_cell_coords< cuda_exec, STRUCTURED_RECTILINEAR_MESH >(i);
@@ -471,12 +471,12 @@ AXOM_CUDA_TEST( mint_execution_cell_traversals, for_all_cells_faceids )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
     defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-    const int UnifiedAllocatorID =
-        axom::getResourceAllocatorID( umpire::resource::Unified );
-    const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-    axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
     using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+    const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+    const int prev_allocator = axom::getDefaultAllocatorID();
+    axom::setDefaultAllocator( exec_space_id );
+
     check_for_all_cell_faces< cuda_exec, STRUCTURED_UNIFORM_MESH >(i);
     check_for_all_cell_faces< cuda_exec, STRUCTURED_CURVILINEAR_MESH >(i);
     check_for_all_cell_faces< cuda_exec, STRUCTURED_RECTILINEAR_MESH >(i);
@@ -510,12 +510,12 @@ AXOM_CUDA_TEST( mint_execution_cell_traversals, for_all_cells_ij )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
   defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-  const int UnifiedAllocatorID =
-      axom::getResourceAllocatorID( umpire::resource::Unified );
-  const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-  axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
   using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+  const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+  const int prev_allocator = axom::getDefaultAllocatorID();
+  axom::setDefaultAllocator( exec_space_id );
+
   check_for_all_cells_ij< cuda_exec, STRUCTURED_UNIFORM_MESH >();
   check_for_all_cells_ij< cuda_exec, STRUCTURED_CURVILINEAR_MESH >();
   check_for_all_cells_ij< cuda_exec, STRUCTURED_RECTILINEAR_MESH >();
@@ -546,13 +546,12 @@ AXOM_CUDA_TEST( mint_execution_cell_traversals, for_all_cells_ijk )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
   defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-  const int UnifiedAllocatorID =
-      axom::getResourceAllocatorID( umpire::resource::Unified );
-  const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-  axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
-
   using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+  const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+  const int prev_allocator = axom::getDefaultAllocatorID();
+  axom::setDefaultAllocator( exec_space_id );
+
   check_for_all_cells_ijk< cuda_exec, STRUCTURED_UNIFORM_MESH >();
   check_for_all_cells_ijk< cuda_exec, STRUCTURED_CURVILINEAR_MESH >();
   check_for_all_cells_ijk< cuda_exec, STRUCTURED_RECTILINEAR_MESH >();
@@ -591,12 +590,12 @@ AXOM_CUDA_TEST( mint_execution_cell_traversals, for_all_cells_index )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
     defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-    const int UnifiedAllocatorID =
-        axom::getResourceAllocatorID( umpire::resource::Unified );
-    const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-    axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
     using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+    const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+    const int prev_allocator = axom::getDefaultAllocatorID();
+    axom::setDefaultAllocator( exec_space_id );
+
     check_for_all_cells_idx< cuda_exec, STRUCTURED_UNIFORM_MESH >(i);
     check_for_all_cells_idx< cuda_exec, STRUCTURED_CURVILINEAR_MESH >(i);
     check_for_all_cells_idx< cuda_exec, STRUCTURED_RECTILINEAR_MESH >(i);

--- a/src/axom/mint/tests/mint_execution_face_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_face_traversals.cpp
@@ -274,12 +274,12 @@ AXOM_CUDA_TEST( mint_execution_face_traversals, for_all_face_nodeids )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
     defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-    const int UnifiedAllocatorID =
-        axom::getResourceAllocatorID( umpire::resource::Unified );
-    const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-    axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
     using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+    const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+    const int prev_allocator = axom::getDefaultAllocatorID();
+    axom::setDefaultAllocator( exec_space_id );
+
     check_for_all_face_nodes< cuda_exec, STRUCTURED_UNIFORM_MESH >( dim );
     check_for_all_face_nodes< cuda_exec, STRUCTURED_CURVILINEAR_MESH >( dim );
     check_for_all_face_nodes< cuda_exec, STRUCTURED_RECTILINEAR_MESH >( dim );
@@ -319,12 +319,12 @@ AXOM_CUDA_TEST( mint_execution_face_traversals, for_all_face_coords )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
     defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-    const int UnifiedAllocatorID =
-        axom::getResourceAllocatorID( umpire::resource::Unified );
-    const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-    axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
     using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+    const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+    const int prev_allocator = axom::getDefaultAllocatorID();
+    axom::setDefaultAllocator( exec_space_id );
+
     check_for_all_face_coords< cuda_exec, STRUCTURED_UNIFORM_MESH >( dim );
     check_for_all_face_coords< cuda_exec, STRUCTURED_CURVILINEAR_MESH >( dim );
     check_for_all_face_coords< cuda_exec, STRUCTURED_RECTILINEAR_MESH >( dim );
@@ -364,12 +364,12 @@ AXOM_CUDA_TEST( mint_execution_face_traversals, for_all_face_cellids )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
     defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-    const int UnifiedAllocatorID =
-        axom::getResourceAllocatorID( umpire::resource::Unified );
-    const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-    axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
     using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+    const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+    const int prev_allocator = axom::getDefaultAllocatorID();
+    axom::setDefaultAllocator( exec_space_id );
+
     check_for_all_face_cells< cuda_exec, STRUCTURED_UNIFORM_MESH >( dim );
     check_for_all_face_cells< cuda_exec, STRUCTURED_CURVILINEAR_MESH >( dim );
     check_for_all_face_cells< cuda_exec, STRUCTURED_RECTILINEAR_MESH >( dim );
@@ -411,12 +411,12 @@ AXOM_CUDA_TEST( mint_execution_face_traversals, for_all_faces_index )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
     defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-    const int UnifiedAllocatorID =
-        axom::getResourceAllocatorID( umpire::resource::Unified );
-    const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-    axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
     using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+    const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+    const int prev_allocator = axom::getDefaultAllocatorID();
+    axom::setDefaultAllocator( exec_space_id );
+
     check_for_all_faces< cuda_exec, STRUCTURED_UNIFORM_MESH >( dim );
     check_for_all_faces< cuda_exec, STRUCTURED_CURVILINEAR_MESH >( dim );
     check_for_all_faces< cuda_exec, STRUCTURED_RECTILINEAR_MESH >( dim );

--- a/src/axom/mint/tests/mint_execution_node_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_node_traversals.cpp
@@ -362,12 +362,12 @@ AXOM_CUDA_TEST( mint_execution_node_traversals, for_all_nodes_xyz )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
   defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-  const int UnifiedAllocatorID =
-      axom::getResourceAllocatorID( umpire::resource::Unified );
-  const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-  axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
   using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+  const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+  const int prev_allocator = axom::getDefaultAllocatorID();
+  axom::setDefaultAllocator( exec_space_id );
+
   check_for_all_nodes_xyz< cuda_exec, STRUCTURED_UNIFORM_MESH >();
   check_for_all_nodes_xyz< cuda_exec, STRUCTURED_CURVILINEAR_MESH >();
   check_for_all_nodes_xyz< cuda_exec, STRUCTURED_RECTILINEAR_MESH >();
@@ -406,12 +406,12 @@ AXOM_CUDA_TEST( mint_execution_node_traversals, for_all_nodes_xy )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
   defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-  const int UnifiedAllocatorID =
-      axom::getResourceAllocatorID( umpire::resource::Unified );
-  const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-  axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
   using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+  const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+  const int prev_allocator = axom::getDefaultAllocatorID();
+  axom::setDefaultAllocator( exec_space_id );
+
   check_for_all_nodes_xy< cuda_exec, STRUCTURED_UNIFORM_MESH >();
   check_for_all_nodes_xy< cuda_exec, STRUCTURED_CURVILINEAR_MESH >();
   check_for_all_nodes_xy< cuda_exec, STRUCTURED_RECTILINEAR_MESH >();
@@ -450,12 +450,12 @@ AXOM_CUDA_TEST( mint_execution_node_traversals, for_all_nodes_x )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
   defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-  const int UnifiedAllocatorID =
-      axom::getResourceAllocatorID( umpire::resource::Unified );
-  const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-  axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
   using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+  const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+  const int prev_allocator = axom::getDefaultAllocatorID();
+  axom::setDefaultAllocator( exec_space_id );
+
   check_for_all_nodes_x< cuda_exec, STRUCTURED_UNIFORM_MESH >();
   check_for_all_nodes_x< cuda_exec, STRUCTURED_CURVILINEAR_MESH >();
   check_for_all_nodes_x< cuda_exec, STRUCTURED_RECTILINEAR_MESH >();
@@ -489,12 +489,12 @@ AXOM_CUDA_TEST( mint_execution_node_traversals, for_all_nodes_ijk )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
   defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-  const int UnifiedAllocatorID =
-      axom::getResourceAllocatorID( umpire::resource::Unified );
-  const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-  axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
   using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+  const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+  const int prev_allocator = axom::getDefaultAllocatorID();
+  axom::setDefaultAllocator( exec_space_id );
+
   check_for_all_nodes_ijk< cuda_exec, STRUCTURED_UNIFORM_MESH >();
   check_for_all_nodes_ijk< cuda_exec, STRUCTURED_CURVILINEAR_MESH >();
   check_for_all_nodes_ijk< cuda_exec, STRUCTURED_RECTILINEAR_MESH >();
@@ -524,12 +524,12 @@ AXOM_CUDA_TEST( mint_execution_node_traversals, for_all_nodes_ij )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
   defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-  const int UnifiedAllocatorID =
-      axom::getResourceAllocatorID( umpire::resource::Unified );
-  const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-  axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
   using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+  const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+  const int prev_allocator = axom::getDefaultAllocatorID();
+  axom::setDefaultAllocator( exec_space_id );
+
   check_for_all_nodes_ij< cuda_exec, STRUCTURED_UNIFORM_MESH >();
   check_for_all_nodes_ij< cuda_exec, STRUCTURED_CURVILINEAR_MESH >();
   check_for_all_nodes_ij< cuda_exec, STRUCTURED_RECTILINEAR_MESH >();
@@ -569,12 +569,12 @@ AXOM_CUDA_TEST( mint_execution_node_traversals, for_all_nodes_index )
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
     defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
 
-    const int UnifiedAllocatorID =
-        axom::getResourceAllocatorID( umpire::resource::Unified );
-    const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
-    axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
-
     using cuda_exec = axom::CUDA_EXEC< 512 >;
+
+    const int exec_space_id  = axom::execution_space<cuda_exec>::allocatorID();
+    const int prev_allocator = axom::getDefaultAllocatorID();
+    axom::setDefaultAllocator( exec_space_id );
+
     check_for_all_nodes_idx< cuda_exec, STRUCTURED_UNIFORM_MESH >(i);
     check_for_all_nodes_idx< cuda_exec, STRUCTURED_CURVILINEAR_MESH >(i);
     check_for_all_nodes_idx< cuda_exec, STRUCTURED_RECTILINEAR_MESH >(i);

--- a/src/axom/sidre/core/Buffer.cpp
+++ b/src/axom/sidre/core/Buffer.cpp
@@ -29,7 +29,7 @@ int getValidAllocatorID( int allocID )
 #ifdef AXOM_USE_UMPIRE
   if ( allocID == INVALID_ALLOCATOR_ID )
   {
-    allocID = getDefaultAllocator().getId();
+    allocID = getDefaultAllocatorID();
   }
 #endif
 
@@ -423,7 +423,7 @@ void* Buffer::allocateBytes(IndexType num_bytes, int allocID)
 {
   allocID = getValidAllocatorID(allocID);
 #ifdef AXOM_USE_UMPIRE
-  return axom::allocate<axom::int8>(num_bytes, getAllocator(allocID));
+  return axom::allocate<axom::int8>(num_bytes, allocID );
 #else
   return axom::allocate<axom::int8>(num_bytes);
 #endif

--- a/src/axom/sidre/core/Buffer.cpp
+++ b/src/axom/sidre/core/Buffer.cpp
@@ -26,13 +26,10 @@ namespace sidre
  */
 int getValidAllocatorID( int allocID )
 {
-#ifdef AXOM_USE_UMPIRE
   if ( allocID == INVALID_ALLOCATOR_ID )
   {
     allocID = getDefaultAllocatorID();
   }
-#endif
-
   return allocID;
 }
 
@@ -422,11 +419,7 @@ void Buffer::detachFromAllViews()
 void* Buffer::allocateBytes(IndexType num_bytes, int allocID)
 {
   allocID = getValidAllocatorID(allocID);
-#ifdef AXOM_USE_UMPIRE
   return axom::allocate<axom::int8>(num_bytes, allocID );
-#else
-  return axom::allocate<axom::int8>(num_bytes);
-#endif
 }
 
 /*

--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -1677,7 +1677,7 @@ Group::Group(const std::string& name,
   , m_view_coll(new ViewCollection())
   , m_group_coll(new GroupCollection())
 #ifdef AXOM_USE_UMPIRE
-  , m_default_allocator_id(axom::getDefaultAllocator().getId())
+  , m_default_allocator_id(axom::getDefaultAllocatorID())
 #endif
 {}
 

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -264,7 +264,8 @@ public:
    */
   umpire::Allocator getDefaultAllocator() const
   {
-    return getAllocator(m_default_allocator_id);
+    umpire::ResourceManager& rm = umpire::ResourceManager::getInstance();
+    return rm.getAllocator( m_default_allocator_id );
   }
 
   /*!

--- a/src/axom/sidre/tests/sidre_buffer.cpp
+++ b/src/axom/sidre/tests/sidre_buffer.cpp
@@ -378,7 +378,7 @@ public:
 
   void TearDown() override
   {
-    int allocID = axom::getResourceAllocatorID( umpire::resource::Host );
+    int allocID = axom::getUmpireResourceAllocatorID( umpire::resource::Host );
     axom::setDefaultAllocator( allocID );
   }
 
@@ -455,7 +455,7 @@ TEST_P(UmpireTest, reallocate)
   constexpr int SIZE = 100;
 
 #if defined(AXOM_USE_CUDA) && defined(UMPIRE_ENABLE_CONST)
-  if (allocID == axom::getResourceAllocatorID( umpire::resource::Constant ) )
+  if (allocID == axom::getUmpireResourceAllocatorID(umpire::resource::Constant))
   {
     return;
   }
@@ -497,7 +497,7 @@ TEST_P(UmpireTest, reallocate_zero)
 
 
 #if defined(AXOM_USE_CUDA) && defined(UMPIRE_ENABLE_CONST)
-  if (allocID == axom::getResourceAllocatorID( umpire::resource::Constant ) )
+  if (allocID == axom::getUmpireResourceAllocatorID(umpire::resource::Constant))
   {
     return;
   }
@@ -513,7 +513,7 @@ TEST_P(UmpireTest, reallocate_zero)
     buff->reallocate(0);
     buff->reallocate(SIZE);
 
-    ASSERT_EQ(axom::getDefaultAllocator().getId(),
+    ASSERT_EQ(axom::getDefaultAllocatorID(),
               rm.getAllocator(buff->getVoidPtr()).getId());
 
     buff->deallocate();
@@ -525,7 +525,7 @@ TEST_P(UmpireTest, reallocate_zero)
     buff->reallocate(0);
     buff->reallocate(SIZE);
 
-    ASSERT_EQ(axom::getDefaultAllocator().getId(),
+    ASSERT_EQ(axom::getDefaultAllocatorID(),
               rm.getAllocator(buff->getVoidPtr()).getId());
     buff->deallocate();
   }
@@ -536,30 +536,30 @@ TEST_P(UmpireTest, reallocate_zero)
     buff->reallocate(0);
     buff->reallocate(SIZE);
 
-    ASSERT_EQ(axom::getDefaultAllocator().getId(),
+    ASSERT_EQ(axom::getDefaultAllocatorID(),
               rm.getAllocator(buff->getVoidPtr()).getId());
     buff->deallocate();
   }
 }
 
 const int allocators[] = {
-  axom::getResourceAllocatorID( umpire::resource::Host )
+  axom::getUmpireResourceAllocatorID( umpire::resource::Host )
 #ifdef AXOM_USE_CUDA
 
 #ifdef UMPIRE_ENABLE_PINNED
-  , axom::getResourceAllocatorID( umpire::resource::Pinned )
+  , axom::getUmpireResourceAllocatorID( umpire::resource::Pinned )
 #endif
 
 #ifdef UMPIRE_ENABLE_DEVICE
-  , axom::getResourceAllocatorID( umpire::resource::Device )
+  , axom::getUmpireResourceAllocatorID( umpire::resource::Device )
 #endif
 
 #ifdef UMPIRE_ENABLE_CONST
-  , axom::getResourceAllocatorID( umpire::resource::Constant )
+  , axom::getUmpireResourceAllocatorID( umpire::resource::Constant )
 #endif
 
 #ifdef UMPIRE_ENABLE_UM
-  , axom::getResourceAllocatorID( umpire::resource::Unified )
+  , axom::getUmpireResourceAllocatorID( umpire::resource::Unified )
 #endif
 
 #endif /* AXOM_USE_CUDA */

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -2396,17 +2396,15 @@ TEST_P(UmpireTest, root_default_allocator)
 
 TEST_P(UmpireTest, get_set_allocator)
 {
-  int defaultAllocatorID = axom::getDefaultAllocator().getId();
+  int defaultAllocatorID = axom::getDefaultAllocatorID();
   ASSERT_EQ(root->getDefaultAllocator().getId(), defaultAllocatorID);
   ASSERT_EQ(root->getDefaultAllocatorID(), defaultAllocatorID);
 
   root->setDefaultAllocator(allocID);
-  defaultAllocatorID = axom::getDefaultAllocator().getId();
-  ASSERT_EQ(root->getDefaultAllocator().getId(), axom::getAllocator(
-              allocID).getId());
-  ASSERT_EQ(root->getDefaultAllocatorID(), allocID);
+  defaultAllocatorID = axom::getDefaultAllocatorID();
+  ASSERT_EQ(root->getDefaultAllocatorID(), defaultAllocatorID );
 
-  root->setDefaultAllocator(axom::getDefaultAllocator());
+  root->setDefaultAllocator(rm.getInstance().getAllocator(defaultAllocatorID));
   ASSERT_EQ(root->getDefaultAllocator().getId(), defaultAllocatorID);
   ASSERT_EQ(root->getDefaultAllocatorID(), defaultAllocatorID);
 }
@@ -2470,12 +2468,12 @@ TEST_P(UmpireTest, allocate_default)
 }
 
 const int allocators[] = {
-  axom::getResourceAllocatorID(umpire::resource::Host)
+  axom::getUmpireResourceAllocatorID(umpire::resource::Host)
 #ifdef AXOM_USE_CUDA
-  , axom::getResourceAllocatorID(umpire::resource::Pinned)
-  , axom::getResourceAllocatorID(umpire::resource::Device)
-  , axom::getResourceAllocatorID(umpire::resource::Constant)
-  , axom::getResourceAllocatorID(umpire::resource::Unified)
+  , axom::getUmpireResourceAllocatorID(umpire::resource::Pinned)
+  , axom::getUmpireResourceAllocatorID(umpire::resource::Device)
+  , axom::getUmpireResourceAllocatorID(umpire::resource::Constant)
+  , axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
 #endif
 };
 

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -2402,7 +2402,7 @@ TEST_P(UmpireTest, get_set_allocator)
 
   root->setDefaultAllocator(allocID);
   defaultAllocatorID = axom::getDefaultAllocatorID();
-  ASSERT_EQ(root->getDefaultAllocatorID(), defaultAllocatorID );
+  ASSERT_EQ(root->getDefaultAllocatorID(), allocID );
 
   root->setDefaultAllocator(rm.getInstance().getAllocator(defaultAllocatorID));
   ASSERT_EQ(root->getDefaultAllocator().getId(), defaultAllocatorID);

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -2470,11 +2470,24 @@ TEST_P(UmpireTest, allocate_default)
 const int allocators[] = {
   axom::getUmpireResourceAllocatorID(umpire::resource::Host)
 #ifdef AXOM_USE_CUDA
+
+#ifdef UMPIRE_ENABLE_PINNED
   , axom::getUmpireResourceAllocatorID(umpire::resource::Pinned)
+#endif
+
+#ifdef UMPIRE_ENABLE_DEVICE
   , axom::getUmpireResourceAllocatorID(umpire::resource::Device)
+#endif
+
+#ifdef UMPIRE_ENABLE_CONST
   , axom::getUmpireResourceAllocatorID(umpire::resource::Constant)
+#endif
+
+#ifdef UMPIRE_ENABLE_UM
   , axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
 #endif
+
+#endif /* AXOM_USE_CUDA */
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/axom/sidre/tests/sidre_view.cpp
+++ b/src/axom/sidre/tests/sidre_view.cpp
@@ -1758,7 +1758,7 @@ TEST_P(UmpireTest, reallocate)
 {
 
 #if defined(AXOM_USE_CUDA) && defined(UMPIRE_ENABLE_CONST)
-  if (allocID == axom::getResourceAllocatorID( umpire::resource::Constant ) )
+  if (allocID == axom::getUmpireResourceAllocatorID(umpire::resource::Constant))
   {
     return;
   }
@@ -1826,24 +1826,24 @@ TEST_P(UmpireTest, reallocate_zero)
 }
 
 const int allocators[] = {
-  axom::getUmpireResourceAllocatorID( umpire::resource::Host )
+  axom::getUmpireResourceAllocatorID(umpire::resource::Host)
 
 #ifdef AXOM_USE_CUDA
 
 #ifdef UMPIRE_ENABLE_PINNED
-  , axom::getUmpireResourceAllocatorID( umpire::resource::Pinned )
+  , axom::getUmpireResourceAllocatorID(umpire::resource::Pinned)
 #endif
 
 #ifdef UMPIRE_ENABLE_DEVICE
-  , axom::getUmpireResourceAllocatorID( umpire::resource::Device )
+  , axom::getUmpireResourceAllocatorID(umpire::resource::Device)
 #endif
 
 #ifdef UMPIRE_ENABLE_CONST
-  , axom::getResourceUmpireAllocatorID( umpire::resource::Constant )
+  , axom::getUmpireResourceAllocatorID(umpire::resource::Constant)
 #endif
 
 #ifdef UMPIRE_ENABLE_UM
-  , axom::getUmpireResourceAllocatorID( umpire::resource::Unified )
+  , axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
 #endif
 
 #endif /* AXOM_USE_CUDA */

--- a/src/axom/sidre/tests/sidre_view.cpp
+++ b/src/axom/sidre/tests/sidre_view.cpp
@@ -1695,7 +1695,8 @@ public:
 
   void TearDown() override
   {
-    const int allocID = axom::getResourceAllocatorID( umpire::resource::Host );
+    const int allocID =
+        axom::getUmpireResourceAllocatorID( umpire::resource::Host );
     axom::setDefaultAllocator( allocID );
   }
 
@@ -1789,7 +1790,7 @@ TEST_P(UmpireTest, reallocate_zero)
 {
 
 #if defined(AXOM_USE_CUDA) && defined(UMPIRE_ENABLE_CONST)
-  if (allocID == axom::getResourceAllocatorID( umpire::resource::Constant ) )
+  if (allocID == axom::getUmpireResourceAllocatorID(umpire::resource::Constant))
   {
     return;
   }
@@ -1803,7 +1804,7 @@ TEST_P(UmpireTest, reallocate_zero)
     view->reallocate(0);
     view->reallocate(SIZE);
 
-    ASSERT_EQ(axom::getDefaultAllocator().getId(),
+    ASSERT_EQ(axom::getDefaultAllocatorID(),
               rm.getAllocator(view->getVoidPtr()).getId());
 
     root->destroyViewAndData("v");
@@ -1817,7 +1818,7 @@ TEST_P(UmpireTest, reallocate_zero)
     view->reallocate(0);
     view->reallocate(SIZE);
 
-    ASSERT_EQ(axom::getDefaultAllocator().getId(),
+    ASSERT_EQ(axom::getDefaultAllocatorID(),
               rm.getAllocator(view->getVoidPtr()).getId());
 
     root->destroyViewAndData("v");
@@ -1825,24 +1826,24 @@ TEST_P(UmpireTest, reallocate_zero)
 }
 
 const int allocators[] = {
-  axom::getResourceAllocatorID( umpire::resource::Host )
+  axom::getUmpireResourceAllocatorID( umpire::resource::Host )
 
 #ifdef AXOM_USE_CUDA
 
-#ifdef UMPIRE_ENABLE_PINNED 
-  , axom::getResourceAllocatorID( umpire::resource::Pinned )
+#ifdef UMPIRE_ENABLE_PINNED
+  , axom::getUmpireResourceAllocatorID( umpire::resource::Pinned )
 #endif
 
 #ifdef UMPIRE_ENABLE_DEVICE
-  , axom::getResourceAllocatorID( umpire::resource::Device )
+  , axom::getUmpireResourceAllocatorID( umpire::resource::Device )
 #endif
 
 #ifdef UMPIRE_ENABLE_CONST
-  , axom::getResourceAllocatorID( umpire::resource::Constant )
+  , axom::getResourceUmpireAllocatorID( umpire::resource::Constant )
 #endif
 
 #ifdef UMPIRE_ENABLE_UM
-  , axom::getResourceAllocatorID( umpire::resource::Unified )
+  , axom::getUmpireResourceAllocatorID( umpire::resource::Unified )
 #endif
 
 #endif /* AXOM_USE_CUDA */

--- a/src/axom/spin/BVH.hpp
+++ b/src/axom/spin/BVH.hpp
@@ -378,7 +378,7 @@ template< int NDIMS, typename ExecSpace, typename FloatType >
 int BVH< NDIMS, ExecSpace, FloatType >::build()
 {
   // STEP 0: set the default memory allocator to use for the execution space.
-  umpire::Allocator current_allocator = axom::getDefaultAllocator();
+  const int currentAllocatorID = axom::getDefaultAllocatorID();
   const int allocatorID = axom::execution_space< ExecSpace >::allocatorID();
   axom::setDefaultAllocator( allocatorID );
 
@@ -430,7 +430,7 @@ int BVH< NDIMS, ExecSpace, FloatType >::build()
   }
 
   // STEP 6: restore default allocator
-  axom::setDefaultAllocator( current_allocator );
+  axom::setDefaultAllocator( currentAllocatorID );
   return BVH_BUILD_OK;
 }
 
@@ -466,7 +466,7 @@ void BVH< NDIMS, ExecSpace, FloatType >::find( IndexType* offsets,
   SLIC_ASSERT( z != nullptr );
 
   // STEP 0: set the default memory allocator to use for the execution space.
-  umpire::Allocator current_allocator = axom::getDefaultAllocator();
+  const int currentAllocatorID = axom::getDefaultAllocatorID();
   const int allocatorID = axom::execution_space< ExecSpace >::allocatorID();
   axom::setDefaultAllocator( allocatorID );
 
@@ -628,7 +628,7 @@ void BVH< NDIMS, ExecSpace, FloatType >::find( IndexType* offsets,
   } );
 
   // STEP 3: restore default allocator
-  axom::setDefaultAllocator( current_allocator );
+  axom::setDefaultAllocator( currentAllocatorID );
 }
 
 //------------------------------------------------------------------------------
@@ -650,7 +650,7 @@ void BVH< NDIMS, ExecSpace, FloatType >::find( IndexType* offsets,
   SLIC_ASSERT( y != nullptr );
 
   // STEP 0: set the default memory allocator to use for the execution space.
-  umpire::Allocator current_allocator = axom::getDefaultAllocator();
+  const int currentAllocatorID = axom::getDefaultAllocatorID();
   const int allocatorID = axom::execution_space< ExecSpace >::allocatorID();
   axom::setDefaultAllocator( allocatorID );
 
@@ -811,7 +811,7 @@ void BVH< NDIMS, ExecSpace, FloatType >::find( IndexType* offsets,
   } );
 
   // STEP 3: restore default allocator
-  axom::setDefaultAllocator( current_allocator );
+  axom::setDefaultAllocator( currentAllocatorID );
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -227,7 +227,7 @@ void check_build_bvh2d( )
   constexpr int NUM_BOXES = 2;
   constexpr int NDIMS     = 2;
 
-  umpire::Allocator current_allocator = axom::getDefaultAllocator();
+  const int current_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator( axom::execution_space<ExecSpace>::allocatorID());
 
   FloatType* boxes = axom::allocate< FloatType >( 8 );
@@ -266,7 +266,7 @@ void check_build_bvh3d( )
   constexpr int NUM_BOXES = 2;
   constexpr int NDIMS     = 3;
 
-  umpire::Allocator current_allocator = axom::getDefaultAllocator();
+  const int current_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator( axom::execution_space<ExecSpace>::allocatorID());
 
   FloatType* boxes = axom::allocate< FloatType >( 12 );
@@ -315,7 +315,7 @@ void check_find3d( )
   constexpr int NDIMS   = 3;
   constexpr IndexType N = 4;
 
-  umpire::Allocator current_allocator = axom::getDefaultAllocator();
+  const int current_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator( axom::execution_space<ExecSpace>::allocatorID());
 
   using PointType = primal::Point< double, NDIMS >;
@@ -413,7 +413,7 @@ void check_find2d( )
   constexpr int NDIMS   = 2;
   constexpr IndexType N = 4;
 
-  umpire::Allocator current_allocator = axom::getDefaultAllocator();
+  const int current_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator( axom::execution_space<ExecSpace>::allocatorID());
 
   using PointType = primal::Point< double, NDIMS >;
@@ -502,7 +502,7 @@ void check_single_box2d( )
   constexpr int NUM_BOXES = 1;
   constexpr int NDIMS     = 2;
 
-  umpire::Allocator current_allocator = axom::getDefaultAllocator();
+  const int current_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator( axom::execution_space<ExecSpace>::allocatorID());
 
   // single bounding box in [0,1] x [0,1]
@@ -570,7 +570,7 @@ void check_single_box3d( )
   constexpr int NUM_BOXES = 1;
   constexpr int NDIMS     = 3;
 
-  umpire::Allocator current_allocator = axom::getDefaultAllocator();
+  const int current_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator( axom::execution_space<ExecSpace>::allocatorID());
 
   // single bounding box in [0,1] x [0,1] x [0,1]

--- a/src/thirdparty/tests/raja_smoke.cpp
+++ b/src/thirdparty/tests/raja_smoke.cpp
@@ -71,10 +71,10 @@ AXOM_CUDA_TEST( raja_smoke, basic_use )
 #endif
 
 #if defined(AXOM_USE_CUDA) && defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_UMPIRE)
-  const umpire::Allocator prev_allocator = axom::getDefaultAllocator();
+  const int prev_allocator = axom::getDefaultAllocatorID();
   const int UnifiedAllocatorID =
-          axom::getResourceAllocatorID( umpire::resource::Unified );
-  axom::setDefaultAllocator( axom::getAllocator( UnifiedAllocatorID ) );
+          axom::getUmpireResourceAllocatorID( umpire::resource::Unified );
+  axom::setDefaultAllocator( UnifiedAllocatorID );
 
   std::cout << "Testing RAJA CUDA execution" << std::endl;
   constexpr int BLOCKSIZE = 256;


### PR DESCRIPTION
# Summary

This PR changes the API of Axom's memory management routines to prevent leaking the use of `umpire::Allocator` objects in the public API. Instead, we use the corresponding integer IDs with the umpire allocators to specify an allocator. This streamlines the use of these routines in application code.

This PR resolves #175.