### PR TITLE
Don't use gcc's non-standandard abi::__cxa_demangle with clang's libc++

### DIFF
--- a/src/axom/slic/internal/stacktrace.cpp
+++ b/src/axom/slic/internal/stacktrace.cpp
@@ -13,7 +13,10 @@
   #include <DbgHelp.h>
 #else
   #include <execinfo.h> // for backtrace()
-  #include <cxxabi.h>   // for abi::__cxa_demangle
+  #include <ciso646>
+  #if !defined(_LIBCPP_VERSION)
+     #include <cxxabi.h>   // for abi::__cxa_demangle
+  #endif
 #endif
 
 constexpr int MAX_FRAMES = 25;
@@ -122,9 +125,13 @@ std::string demangle( char* backtraceString, int frame )
     *returnOffset = 0;
     ++returnOffset;
 
-    int status;
+    int status = false;
+#if !defined(_LIBCPP_VERSION)
     char* realName = abi::__cxa_demangle( mangledName, nullptr, nullptr,
                                           &status );
+#else
+    char* realName = mangledName;
+#endif
 
     // if demangling is successful, output the demangled function name
     if (status == 0)

--- a/src/axom/slic/internal/stacktrace.cpp
+++ b/src/axom/slic/internal/stacktrace.cpp
@@ -144,7 +144,9 @@ std::string demangle( char* backtraceString, int frame )
       oss << "Frame " << frame << ": " << mangledName << std::endl;
     }
 
+#if !defined(_LIBCPP_VERSION)
     free(realName);
+#endif
   }
   // otherwise, print the whole line
   else


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It enables building with a pure clang compile using ``libc++``
  - The calls to the ``gcc``'s nonstandard ``abi::__cxa_demangle`` have been protected against.
  - Fixes #179 

