### PR TITLE
Updates macOS host image on Azure from High Sierra to Mojave

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ strategy:
        TEST_TARGET: 'linux_clang6'
        HOST_CONFIG: 'docker-linux-ubuntu16.04-x86_64-clang@6.0.0'
     osx_gcc:
-      VM_ImageName: 'macos-10.13'
+      VM_ImageName: 'macos-10.14'
       CMAKE_EXTRA_FLAGS: '-DAXOM_ENABLE_SIDRE=Off'
       TEST_TARGET: 'osx_gcc'
     windows:


### PR DESCRIPTION
# Summary
- This PR updates the ``macOS`` image in our Azure pipelines due to a recent error message
- This problem appears to be blocking #180 
- Resolves https://github.com/LLNL/axom/issues/181