### PR TITLE
Fix minor warnings on windows

### DIFF
--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -745,7 +745,8 @@ inline void Array< T >::dynamicRealloc( IndexType new_num_tuples )
   }
 
   assert( m_resize_ratio >= 1.0 );
-  const IndexType new_capacity = new_num_tuples * m_resize_ratio + 0.5;
+  const IndexType new_capacity =
+      static_cast< IndexType >( new_num_tuples * m_resize_ratio + 0.5 );
 
   if ( m_resize_ratio < 1.0 )
   {

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -61,6 +61,8 @@ inline void setDefaultAllocator( int allocatorID )
   umpire::ResourceManager& rm = umpire::ResourceManager::getInstance();
   umpire::Allocator allocator = rm.getAllocator( allocatorID );
   rm.setDefaultAllocator( allocator );
+#else
+  static_cast< void >( allocatorID ); // silence compiler warnings
 #endif
 }
 
@@ -158,6 +160,7 @@ inline T* allocate( std::size_t n, int allocID ) noexcept
   return static_cast< T* >( allocator.allocate( numbytes ) );
 
 #else
+  static_cast< void >( allocID ); // silence compiler warnings
   return static_cast< T* >( std::malloc( numbytes ) );
 #endif
 

--- a/src/axom/core/numerics/eigen_solve.hpp
+++ b/src/axom/core/numerics/eigen_solve.hpp
@@ -138,9 +138,9 @@ int eigen_solve(Matrix< T >& A, int k, T* u, T* lambdas, int numIterations)
       matrix_vector_multiply(A, vec, temp);
 
       // make ortho to previous (for stability)
-      for (int k = 0 ; k < i ; k++)
+      for (int kk = 0 ; kk < i ; kk++)
       {
-        make_orthogonal< T >(temp, u + k*N, N);
+        make_orthogonal< T >(temp, u + kk*N, N);
       }
 
       res = normalize< T >(temp, N);

--- a/src/axom/core/tests/core_array.cpp
+++ b/src/axom/core/tests/core_array.cpp
@@ -32,7 +32,7 @@ IndexType calc_new_capacity( Array< T > & v, IndexType increase )
   IndexType new_num_tuples = v.size() + increase;
   if ( new_num_tuples > v.capacity() )
   {
-    return new_num_tuples * v.getResizeRatio() + 0.5;
+    return static_cast< IndexType >( new_num_tuples*v.getResizeRatio() + 0.5 );
   }
 
   return v.capacity();
@@ -227,7 +227,7 @@ void check_fill( Array< T >& v )
 template < typename T >
 void check_set( Array< T >& v )
 {
-  constexpr T ZERO = 0;
+  constexpr T ZERO_VAL = 0;
   const IndexType capacity = v.capacity();
   const IndexType size = v.size();
   const IndexType num_components = v.numComponents();
@@ -244,7 +244,7 @@ void check_set( Array< T >& v )
   }
 
   /* Set all the values in the array to zero. */
-  v.fill( ZERO );
+  v.fill( ZERO_VAL );
 
   /* Set the first half of the tuples in the array to the sequential values in
    * buffer. */
@@ -272,7 +272,7 @@ void check_set( Array< T >& v )
   {
     for ( IndexType j = 0 ; j < num_components ; ++j )
     {
-      EXPECT_EQ( v( i, j ), ZERO );
+      EXPECT_EQ( v( i, j ), ZERO_VAL );
     }
   }
 
@@ -878,16 +878,16 @@ void check_external( Array< T >& v )
 //------------------------------------------------------------------------------
 TEST( core_array, checkStorage )
 {
-  constexpr IndexType ZERO = 0;
+  constexpr IndexType ZERO_VAL = 0;
 
   for ( IndexType capacity = 2 ; capacity < 512 ; capacity *= 2 )
   {
     for ( IndexType n_components = 1 ; n_components <= 4 ; n_components++ )
     {
-      Array< int > v_int( ZERO, n_components, capacity );
+      Array< int > v_int( ZERO_VAL, n_components, capacity );
       internal::check_storage( v_int );
 
-      Array< double > v_double( ZERO, n_components, capacity );
+      Array< double > v_double( ZERO_VAL, n_components, capacity );
       internal::check_storage( v_double );
     }
   }
@@ -929,7 +929,7 @@ TEST( core_array, checkSet )
 //------------------------------------------------------------------------------
 TEST( core_array, checkResize )
 {
-  constexpr IndexType ZERO = 0;
+  constexpr IndexType ZERO_VAL = 0;
 
   for ( double ratio = 1.0 ; ratio <= 2.0 ; ratio += 0.5 )
   {
@@ -937,11 +937,11 @@ TEST( core_array, checkResize )
     {
       for ( IndexType n_components = 1 ; n_components <= 4 ; n_components++ )
       {
-        Array< int > v_int( ZERO, n_components, capacity );
+        Array< int > v_int( ZERO_VAL, n_components, capacity );
         v_int.setResizeRatio( ratio );
         internal::check_resize( v_int );
 
-        Array< double > v_double( ZERO, n_components, capacity );
+        Array< double > v_double( ZERO_VAL, n_components, capacity );
         v_double.setResizeRatio( ratio );
         internal::check_resize( v_double );
       }
@@ -961,7 +961,7 @@ TEST( core_array_DeathTest, checkResize )
 //------------------------------------------------------------------------------
 TEST( core_array, checkInsert )
 {
-  constexpr IndexType ZERO = 0;
+  constexpr IndexType ZERO_VAL = 0;
 
   for ( double ratio = 1.0 ; ratio <= 2.0 ; ratio += 0.5 )
   {
@@ -969,11 +969,11 @@ TEST( core_array, checkInsert )
     {
       for ( IndexType n_components = 1 ; n_components <= 3 ; n_components++ )
       {
-        Array< int > v_int( ZERO, n_components, capacity );
+        Array< int > v_int( ZERO_VAL, n_components, capacity );
         v_int.setResizeRatio( ratio );
         internal::check_insert( v_int );
 
-        Array< double > v_double( ZERO, n_components, capacity );
+        Array< double > v_double( ZERO_VAL, n_components, capacity );
         v_double.setResizeRatio( ratio );
         internal::check_insert( v_double );
       }
@@ -984,7 +984,7 @@ TEST( core_array, checkInsert )
 //------------------------------------------------------------------------------
 TEST( core_array, checkEmplace )
 {
-  constexpr IndexType ZERO = 0;
+  constexpr IndexType ZERO_VAL = 0;
 
   for ( double ratio = 1.0 ; ratio <= 2.0 ; ratio += 0.5 )
   {
@@ -992,11 +992,11 @@ TEST( core_array, checkEmplace )
     {
       for ( IndexType n_components = 1 ; n_components <= 3 ; n_components++ )
       {
-        Array< int > v_int( ZERO, n_components, capacity );
+        Array< int > v_int( ZERO_VAL, n_components, capacity );
         v_int.setResizeRatio( ratio );
         internal::check_emplace( v_int );
 
-        Array< double > v_double( ZERO, n_components, capacity );
+        Array< double > v_double( ZERO_VAL, n_components, capacity );
         v_double.setResizeRatio( ratio );
         internal::check_emplace( v_double );
       }

--- a/src/axom/core/tests/core_stack_array.cpp
+++ b/src/axom/core/tests/core_stack_array.cpp
@@ -105,10 +105,16 @@ struct Tensor
 
   bool operator==( const Tensor& other ) const
   {
+#ifndef WIN32
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+
     return x == other.x && y == other.y && z == other.z;
+
+#ifndef WIN32
 #pragma GCC diagnostic pop
+#endif
   }
 };
 

--- a/src/axom/core/tests/utils_utilities.cpp
+++ b/src/axom/core/tests/utils_utilities.cpp
@@ -7,6 +7,36 @@
 
 #include "axom/core/utilities/Utilities.hpp"
 
+// C/C++ includes
+#include <type_traits>
+
+//------------------------------------------------------------------------------
+// HELPER METHODS
+//------------------------------------------------------------------------------
+template < typename T >
+void check_random_real( int offset )
+{
+  AXOM_STATIC_ASSERT( std::is_floating_point< T >::value );
+
+  constexpr T min = 0;
+  constexpr T max = 1;
+
+  const T curr_min = min - static_cast< T >( offset );
+  const T curr_max = max - static_cast< T >( offset );
+
+  constexpr int MAX_ITERS = 100;
+  for ( int i=0; i < MAX_ITERS; ++i )
+  {
+    T val = axom::utilities::random_real( curr_min, curr_max );
+    EXPECT_GE( val, curr_min );
+    EXPECT_LT( val, curr_max );
+  }
+
+}
+
+//------------------------------------------------------------------------------
+// UNIT TESTS
+//------------------------------------------------------------------------------
 TEST(core_Utilities,log2)
 {
   std::cout<<"Testing log2 functions."<< std::endl;
@@ -40,34 +70,21 @@ TEST(core_Utilities,log2)
   }
 }
 
+//------------------------------------------------------------------------------
 TEST(core_Utilities,random_real)
 {
   std::cout<<"Testing random_real functions (non-deterministic)."<< std::endl;
 
-  int min = 0;
-  int max = 1;
   for (int offset = 0 ; offset < 10 ; ++offset)
   {
-    int cur_min = min - offset;
-    int cur_max = max + offset;
-    for (int i = 0 ; i < 100 ; ++i)
-    {
-      float f_val = axom::utilities::random_real<float>(cur_min, cur_max);
-      EXPECT_GE(f_val, cur_min);
-      EXPECT_LT(f_val, cur_max);
-
-      double d_val = axom::utilities::random_real<double>(cur_min, cur_max);
-      EXPECT_GE(d_val, cur_min);
-      EXPECT_LT(d_val, cur_max);
-
-      long double ld_val = axom::utilities::random_real<long double>(cur_min,
-                                                                     cur_max);
-      EXPECT_GE(ld_val, cur_min);
-      EXPECT_LT(ld_val, cur_max);
-    }
+    check_random_real< float >( offset );
+    check_random_real< double >( offset );
+    check_random_real< long double >( offset );
   }
+
 }
 
+//------------------------------------------------------------------------------
 TEST( core_Utilities,random_real_with_seed )
 {
   std::cout<<"Testing random_real functions (deterministic)."<< std::endl;
@@ -94,6 +111,7 @@ TEST( core_Utilities,random_real_with_seed )
 
 }
 
+//------------------------------------------------------------------------------
 TEST(core_Utilities,minmax)
 {
   std::cout<<"Testing min and max functions."<< std::endl;

--- a/src/axom/core/utilities/Utilities.hpp
+++ b/src/axom/core/utilities/Utilities.hpp
@@ -93,7 +93,7 @@ void swap( T& a, T& b )
 template < typename T >
 inline T log2( T& val)
 {
-  return std::log2(val);
+  return static_cast< T >( std::log2(val) );
 }
 
 /*!
@@ -169,7 +169,7 @@ inline T random_real( const T& a, const T& b )
   static std::mt19937_64 mt( rd() );
   static std::uniform_real_distribution< T > dist(0.0, 1.0);
 
-  double temp = dist(mt);
+  T temp = dist(mt);
   return temp * ( b - a ) + a;
 }
 

--- a/src/axom/mint/examples/mint_heat_equation.cpp
+++ b/src/axom/mint/examples/mint_heat_equation.cpp
@@ -192,7 +192,7 @@ public:
 
     int cur_dump = 0;
     double cur_time = 0.0;
-    const int num_cycles = std::ceil( t_max / dt );
+    const int num_cycles = static_cast< int >( std::ceil( t_max / dt ) );
     for (int cycle = 0 ; cycle < num_cycles ; ++cycle )
     {
       if ( cycle == num_cycles - 1 )
@@ -326,10 +326,10 @@ private:
     IndexType Ni, Nj;
 
     const double lx = axom::utilities::abs( upper_bound[0] - lower_bound[0] );
-    Ni = (lx / h) + 1;
+    Ni = static_cast< IndexType >( (lx / h) + 1 );
 
     const double ly = axom::utilities::abs( upper_bound[1] - lower_bound[1] );
-    Nj = (ly / h) + 1;
+    Nj = static_cast< IndexType >( (ly / h) + 1 );
 
     UniformMesh* mesh = new UniformMesh( lower_bound, upper_bound, Ni, Nj );
     mesh->createField< double >( "temperature", mint::NODE_CENTERED );
@@ -474,7 +474,7 @@ void parse_arguments( Arguments& args, int argc, const char** argv )
               std::strcmp( argv[ i ], "-dumpPeriod" ) == 0 )
     {
       SLIC_ERROR_IF( i >= argc - 1, "Not enough arguments." );
-      args.period = atof( argv[ i + 1 ] );
+      args.period = atoi( argv[ i + 1 ] );
       i++;
     }
     else

--- a/src/axom/mint/examples/mint_unstructured_mixed_topology_mesh.cpp
+++ b/src/axom/mint/examples/mint_unstructured_mixed_topology_mesh.cpp
@@ -74,7 +74,7 @@ int main( int AXOM_NOT_USED(argc), char** AXOM_NOT_USED(argv) )
       vy[ node_ID ] = utilities::random_real( LO, HI );
       vz[ node_ID ] = utilities::random_real( LO, HI );
       p_avg[ node_ID ] = 0.0;
-      cells_per_node[ node_ID ] = 0.0;
+      cells_per_node[ node_ID ] = 0;
       node_ID++;
     }
   }

--- a/src/axom/mint/examples/mint_unstructured_single_topology_mesh.cpp
+++ b/src/axom/mint/examples/mint_unstructured_single_topology_mesh.cpp
@@ -68,7 +68,7 @@ int main( int AXOM_NOT_USED(argc), char** AXOM_NOT_USED(argv) )
       vy[ node_ID ] = utilities::random_real( LO, HI );
       vz[ node_ID ] = utilities::random_real( LO, HI );
       p_avg[ node_ID ] = 0.0;
-      cells_per_node[ node_ID ] = 0.0;
+      cells_per_node[ node_ID ] = 0;
       node_ID++;
     }
   }

--- a/src/axom/mint/execution/internal/for_all_cells.hpp
+++ b/src/axom/mint/execution/internal/for_all_cells.hpp
@@ -220,9 +220,9 @@ inline void for_all_cells_impl( xargs::nodeids,
         const IndexType n0 = i + j * nodeJp;
         IndexType cell_connectivity[ 4 ];
 
-        for ( int i = 0; i < 4; ++i )
+        for ( int ii = 0; ii < 4; ++ii )
         {
-          cell_connectivity[ i ] = n0 + offsets[ i ];
+          cell_connectivity[ ii ] = n0 + offsets[ ii ];
         }
 
         kernel( cellID, cell_connectivity, 4 );
@@ -239,9 +239,9 @@ inline void for_all_cells_impl( xargs::nodeids,
         const IndexType n0 = i + j * nodeJp + k * nodeKp;
         IndexType cell_connectivity[ 8 ];
 
-        for ( int i = 0; i < 8; ++i )
+        for ( int ii = 0; ii < 8; ++ii )
         {
-          cell_connectivity[ i ] = n0 + offsets[ i ];
+          cell_connectivity[ ii ] = n0 + offsets[ ii ];
         }
 
         kernel( cellID, cell_connectivity, 8 );

--- a/src/axom/mint/execution/internal/for_all_faces.hpp
+++ b/src/axom/mint/execution/internal/for_all_faces.hpp
@@ -317,12 +317,13 @@ inline void for_all_faces_impl( xargs::nodeids,
                                 KernelType&& kernel )
 {
   const IndexType dimension = m.getDimension();
-  const IndexType numIFaces = m.getTotalNumFaces( I_DIRECTION );
   const IndexType* offsets  = m.getCellNodeOffsetsArray();
   const IndexType cellNodeOffset3 = offsets[ 3 ];
 
   if ( dimension == 2 )
   {
+    const IndexType numIFaces = m.getTotalNumFaces( I_DIRECTION );
+
     helpers::for_all_I_faces< ExecPolicy >( xargs::ij(), m,
       AXOM_LAMBDA( IndexType faceID, IndexType AXOM_NOT_USED(i),
                    IndexType AXOM_NOT_USED(j) )

--- a/src/axom/mint/mesh/internal/MeshHelpers.cpp
+++ b/src/axom/mint/mesh/internal/MeshHelpers.cpp
@@ -114,7 +114,7 @@ bool initFaces(Mesh * mesh,
       // https://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf.
       // This routine selects the face nodes as listed in the registered
       // cell info to make sure that face normals point outward.
-      // 
+      //
       // For every face, sort the node IDs and join them together in a
       // string with '.' delimiters.  This is the key for an associative
       // array whose value is a list of cell IDs.
@@ -155,8 +155,8 @@ bool initFaces(Mesh * mesh,
   for (FaceBuilderType::value_type v : workface)
   {
     FaceTypeCellsNodes theFace = v.second;
-    faceNodeTotal += theFace.facenodes.size();
-    int faceCellCount = theFace.facecells.size();
+    faceNodeTotal += static_cast< IndexType >( theFace.facenodes.size() );
+    int faceCellCount = static_cast< int >( theFace.facecells.size() );
     IndexType * faceCells = theFace.facecells.data();
 
     if (faceCellCount < 1 || faceCellCount > 2)
@@ -199,7 +199,7 @@ bool initFaces(Mesh * mesh,
     std::copy(faceNodes.begin(), faceNodes.end(), f2n + faceNodeOffset);
     f2noffsets[fidx] = faceNodeOffset;
     f2ntypes[fidx] = theFace.facetype;
-    faceNodeOffset += faceNodes.size();
+    faceNodeOffset += static_cast< int >( faceNodes.size() );
   }
   f2noffsets[facecount] = faceNodeOffset;
 
@@ -242,7 +242,7 @@ bool initFaces(Mesh * mesh,
       // *SHOULD* have), copy them in.
       std::vector<IndexType> & theCells = cell_to_face[cellID];
       IndexType * faceIDs = theCells.data();
-      int thisCellFaceCount = theCells.size();
+      int thisCellFaceCount = static_cast< int >( theCells.size() );
 
       // Copy in values
       for (int f = 0; f < thisCellFaceCount; ++f)
@@ -253,7 +253,7 @@ bool initFaces(Mesh * mesh,
 
       // Maintain offset
       cellFaceCount += thisCellFaceCount;
-    }        
+    }
   }
   c2foffsets[cellcount] = cellFaceCount;
 

--- a/src/axom/mint/tests/mint_fem_shape_functions.cpp
+++ b/src/axom/mint/tests/mint_fem_shape_functions.cpp
@@ -181,7 +181,7 @@ void partition_of_unity()
 
     sf.evaluate( nc, phi );
 
-    double sum=0.0;
+    sum=0.0;
     for ( int j=0 ; j < ndofs ; ++j )
     {
       sum += phi[ j ];

--- a/src/axom/mint/tests/mint_mesh_connectivity_array.cpp
+++ b/src/axom/mint/tests/mint_mesh_connectivity_array.cpp
@@ -49,7 +49,7 @@ IndexType calc_ID_capacity( const ConnectivityArray< NO_INDIRECTION >& connec,
   IndexType new_n_IDs = connec.getNumberOfIDs() + increase;
   if ( new_n_IDs > connec.getIDCapacity() )
   {
-    return new_n_IDs * connec.getResizeRatio() + 0.5;
+    return static_cast< IndexType >( new_n_IDs*connec.getResizeRatio() + 0.5 );
   }
 
   return connec.getIDCapacity();
@@ -71,7 +71,8 @@ IndexType calc_ID_capacity( const ConnectivityArray< INDIRECTION >& connec,
   IndexType new_n_IDs = connec.getNumberOfIDs() + increase;
   if ( new_n_IDs > connec.getIDCapacity() )
   {
-    return ((new_n_IDs + 1) * connec.getResizeRatio() + 0.5) - 1;
+    return (
+      static_cast< IndexType >((new_n_IDs+1)*connec.getResizeRatio() + 0.5)-1);
   }
 
   return connec.getIDCapacity();
@@ -91,7 +92,7 @@ IndexType calc_ID_capacity(
   IndexType new_n_IDs = connec.getNumberOfIDs() + increase;
   if ( new_n_IDs > connec.getIDCapacity() )
   {
-    return new_n_IDs * connec.getResizeRatio() + 0.5;
+    return static_cast< IndexType >( new_n_IDs*connec.getResizeRatio()+0.5);
   }
 
   return connec.getIDCapacity();
@@ -127,7 +128,7 @@ IndexType calc_value_capacity( const ConnectivityArray< TYPE >& connec,
   IndexType new_n_values = connec.getNumberOfValues() + increase;
   if ( new_n_values > connec.getValueCapacity() )
   {
-    return new_n_values * connec.getResizeRatio() + 0.5;
+    return static_cast< IndexType >( new_n_values*connec.getResizeRatio()+0.5 );
   }
 
   return connec.getValueCapacity();

--- a/src/axom/mint/tests/mint_mesh_face_relation.cpp
+++ b/src/axom/mint/tests/mint_mesh_face_relation.cpp
@@ -86,7 +86,7 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
       new UnstructuredMesh< SINGLE_SHAPE >(TWO_D, TRIANGLE);
     double    trinodes[] = { 0, 0, 1, 0, 0, 1 } ;
     IndexType tricells[] = { 0, 1, 2 } ;
-  
+
     tri->appendNodes(trinodes, 3);
     tri->appendCells(tricells, 1);
     tests.push_back(new internal::MeshFaceTest
@@ -106,7 +106,7 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
     double    twotrisnodes[] = { 0, 0, 1, 0, 0, 1, 0.8, 1.2 } ;
     IndexType twotriscells[] = { 0, 1, 2,
                                  1, 3, 2 } ;
-  
+
     twotris->appendNodes(twotrisnodes, 4);
     twotris->appendCells(twotriscells, 2);
     tests.push_back(new internal::MeshFaceTest
@@ -173,7 +173,7 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
                                   0, 2, 3,
                                   1, 5, 4,
                                   2, 5, 3 };
-  
+
     fourtris->appendNodes(fourtrisxs, fourtrisys, 6);
     fourtris->appendCells(fourtriscells, 4);
     tests.push_back(new internal::MeshFaceTest
@@ -204,7 +204,7 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
       new UnstructuredMesh< SINGLE_SHAPE >(THREE_D, TRIANGLE);
     double    threeDtrinodes[] = { -1, 0, 0, 0, 1, 0.5, 1.2, -.2, 3 };
     IndexType threeDtricells[] = { 0, 1, 2 };
-  
+
     threeDtri->appendNodes(threeDtrinodes, 3);
     threeDtri->appendCells(threeDtricells, 1);
     tests.push_back(new internal::MeshFaceTest
@@ -264,7 +264,7 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
     double    tettrisys[] = { 0,   0,   1, 1 };
     double    tettriszs[] = { 0, -.1, 0.2, 1 };
     IndexType tettriscells[] = { 0, 2, 1, 0, 1, 3, 1, 2, 3, 2, 0, 3 };
-  
+
     tettris->appendNodes(tettrisxs, tettrisys, tettriszs, 4);
     tettris->appendCells(tettriscells, 4);
     tests.push_back(new internal::MeshFaceTest
@@ -300,7 +300,7 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
                                   2, 3, 7, 6,
                                   3, 0, 4, 7,
                                   4, 5, 6, 7 };
-  
+
     hexquads->appendNodes(hexquadsxs, hexquadsys, hexquadszs, 8);
     hexquads->appendCells(hexquadscells, 6);
     tests.push_back(new internal::MeshFaceTest
@@ -378,7 +378,7 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
                                  1,   1,   1 };
     IndexType b2btriscells[] = { 0, 1, 2,
                                  0, 2, 1 };
-  
+
     b2btris->appendNodes(b2btrisnodes, 3);
     b2btris->appendCells(b2btriscells, 2);
     tests.push_back(new internal::MeshFaceTest
@@ -527,7 +527,7 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
     double    crackedtetys[] = { 0,   0,   1, 1, 0.9 };
     double    crackedtetzs[] = { 0, -.1, 0.2, 1, 1 };
     IndexType crackedtetcells[] = { 0, 2, 1, 0, 1, 4, 1, 2, 3, 2, 0, 3 };
-  
+
     crackedtet->appendNodes(crackedtetxs, crackedtetys, crackedtetzs, 5);
     crackedtet->appendCells(crackedtetcells, 4);
     tests.push_back(new internal::MeshFaceTest
@@ -606,10 +606,10 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
     double    notmanfxs[] = {  -1, 0, 0, 0.2, 1 };
     double    notmanfys[] = {   0, 0, 0, -.6, 0 };
     double    notmanfzs[] = { 0.6, 0, 1, 0.4, 0.4 };
-    IndexType notmanfcells[] = { 0, 1, 2, 
+    IndexType notmanfcells[] = { 0, 1, 2,
                                  3, 1, 2,
                                  4, 1, 2 };
-  
+
     notmanf->appendNodes(notmanfxs, notmanfys, notmanfzs, 5);
     notmanf->appendCells(notmanfcells, 3);
     tests.push_back(new internal::MeshFaceTest
@@ -642,7 +642,7 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
     double    egregys[] = { 0, 0, 1, 1, 0.8, 0, 0, -0.4, -0.9 };
     double    egregzs[] = { 0, 0, 0, 0, 0.4, 1, 1,  1.2,  0.5 };
     IndexType egregcells[] = { 0, 1, 2, 3,
-                               0, 1, 4, 
+                               0, 1, 4,
                                0, 1, 5, 6,
                                0, 1, 7,
                                0, 1, 8 } ;
@@ -689,7 +689,7 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
     double    tetys[] = { 0,   0,   1, 1 };
     double    tetzs[] = { 0, -.1, 0.2, 1 };
     IndexType tetcells[] = { 0, 1, 2, 3 };
-  
+
     tet->appendNodes(tetxs, tetys, tetzs, 4);
     tet->appendCells(tetcells, 1);
     tests.push_back(new internal::MeshFaceTest
@@ -717,7 +717,7 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
     double    hexszs[] = { 0, 0.2, 0, 0,   0, 0, 1,   1, 1, 1, 0.8, 1 };
     IndexType hexscells[] = { 0, 1, 4, 3, 6, 7, 10, 9,
                               1, 2, 5, 4, 7, 8, 11, 10 };
-  
+
     hexs->appendNodes(hexsxs, hexsys, hexszs, 12);
     hexs->appendCells(hexscells, 2);
     tests.push_back(new internal::MeshFaceTest
@@ -755,7 +755,7 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
     IndexType hexs3cells[] = { 0, 3, 10,  7, 1, 4, 11,  8,
                                3, 5, 12, 10, 4, 6, 13, 11,
                                0, 2,  9,  7, 3, 5, 12, 10 };
-  
+
     hexs3->appendNodes(hexs3xs, hexs3ys, hexs3zs, 14);
     hexs3->appendCells(hexs3cells, 3);
     tests.push_back(new internal::MeshFaceTest
@@ -798,7 +798,7 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
     double    mtetzs[] = { 0, -.1, 0.2, 1 };
     IndexType mtetcells[] = { 0, 1, 2, 3,
                               0, 2, 1, 3 };
-  
+
     mtet->appendNodes(mtetxs, mtetys, mtetzs, 4);
     mtet->appendCells(mtetcells, 2);
     tests.push_back(new internal::MeshFaceTest
@@ -830,7 +830,7 @@ std::vector<internal::MeshFaceTest *> generateFaceTestCases()
     IndexType badtetscells[] = { 0, 1, 2, 3,
                                  0, 3, 2, 4,
                                  0, 3, 2, 5 };
-  
+
     badtets->appendNodes(badtetsxs, badtetsys, badtetszs, 6);
     badtets->appendCells(badtetscells, 3);
     tests.push_back(new internal::MeshFaceTest
@@ -954,14 +954,15 @@ bool checkAndReportFaceNodes(std::map< std::string, FaceTypeNodes > & fn,
   bool success = true;
   if (fn.size() > 0)
   {
-    int fcount = fn.size();
+    int fcount = static_cast< int >( fn.size() );
     mesg << fcount << label << std::endl;
     for (auto fit = fn.begin(), fend = fn.end(); fit != fend; ++fit)
     {
       FaceTypeNodes & ftn = fit->second;
       mesg << "Type " << getCellInfo(ftn.facetype).name << " (";
-      mesg << internal::join_ints_into_string(ftn.facenodes.size(),
-                                              ftn.facenodes.data(), ' ');
+      mesg << internal::join_ints_into_string(
+          static_cast< int >( ftn.facenodes.size() ),
+          ftn.facenodes.data(), ' ');
       mesg << ") " << std::endl;
     }
     success = false;
@@ -977,7 +978,7 @@ bool matchRotateList(std::vector<T> &a, std::vector<T> &b)
   if (a.size() != b.size() || a.size() < 1) { return false; }
 
   bool matches = false;
-  int elts = a.size();
+  int elts = static_cast< int >( a.size() );
   for (int offset = 0; offset < elts && !matches; ++offset)
   {
     matches = true;
@@ -1131,7 +1132,7 @@ void runMeshFaceTest(internal::MeshFaceTest * t)
   }
   else if (!initresult && t->initShouldSucceed)
   {
-    FAIL() << "test mesh \"" << t->name << 
+    FAIL() << "test mesh \"" << t->name <<
       "\" call to initFaces() failed but should have succeeded.";
   }
   else if (initresult && !(t->initShouldSucceed))
@@ -1144,7 +1145,7 @@ void runMeshFaceTest(internal::MeshFaceTest * t)
     delete [] f2noffsets;
     delete [] f2ntypes;
 
-    FAIL() << "test mesh \"" << t->name << 
+    FAIL() << "test mesh \"" << t->name <<
       "\" call to initFaces() succeeded but should have failed.";
   }
   else
@@ -1178,8 +1179,9 @@ void runMeshFaceTest(internal::MeshFaceTest * t)
       if (!neighborsMatched)
       {
         errmesg << "Cell " << c << " expected neighbors ";
-        IndexType facecount = t->cellFaceCount[c];
-        for (int i = 0; i < facecount; ++i) 
+
+        facecount = t->cellFaceCount[c];
+        for (IndexType i = 0; i < facecount; ++i)
         {
           errmesg << t->cellNeighbors[c2foffsets[c] + i] << " ";
         }
@@ -1393,7 +1395,7 @@ TEST( mint_mesh_face_relation, tf_faceMatches )
 }
 
 /*! \brief Test driver for the mesh face relation construction.
- * 
+ *
  * This TEST does the following:
  * -# generate mesh test sets, each supplied with correct answers, comprising
  *    -# the mesh itself

--- a/src/axom/mint/tests/mint_mesh_field_variable.cpp
+++ b/src/axom/mint/tests/mint_mesh_field_variable.cpp
@@ -407,7 +407,10 @@ TEST( mint_mesh_field_variable, shrink )
   mint::FieldVariable< double > field( "f", SMALL_NUM_TUPLES, NUM_COMPONENTS );
   EXPECT_EQ( field.getName(), "f" );
 
-  axom::IndexType capacity = SMALL_NUM_TUPLES * field.getResizeRatio() + 0.5;
+  const double ratio = field.getResizeRatio();
+  axom::IndexType capacity =
+      static_cast< axom::IndexType >( SMALL_NUM_TUPLES*ratio + 0.5 );
+
   if ( capacity < axom::Array< axom::IndexType >::MIN_DEFAULT_CAPACITY )
   {
     capacity = axom::Array< axom::IndexType >::MIN_DEFAULT_CAPACITY;

--- a/src/axom/mint/tests/mint_mesh_unstructured_mesh.cpp
+++ b/src/axom/mint/tests/mint_mesh_unstructured_mesh.cpp
@@ -1305,11 +1305,11 @@ void check_append_cells( const UnstructuredMesh< MIXED_SHAPE >* mesh,
   /* Check using the other getCell */
   for ( IndexType i = 0 ; i < n_cells ; ++i )
   {
-    const IndexType* cell = mesh->getCellNodeIDs( i );
+    const IndexType* cellNodeIds = mesh->getCellNodeIDs( i );
     IndexType num_nodes = mesh->getNumberOfCellNodes( i );
     for ( IndexType j = 0 ; j < num_nodes ; ++j )
     {
-      EXPECT_EQ( cell[ j ], connecValue( i, j ) );
+      EXPECT_EQ( cellNodeIds[ j ], connecValue( i, j ) );
     }
   }
 }
@@ -2099,7 +2099,7 @@ void resize_nodes( UnstructuredMesh< TOPO >* mesh )
   /* Append one more, should trigger a resize. */
   append_node_single( mesh, 1 );
   n_nodes++;
-  node_capacity = n_nodes * resize_ratio + 0.5;
+  node_capacity = static_cast< IndexType >( n_nodes * resize_ratio + 0.5 );
   ASSERT_EQ( n_nodes, mesh->getNumberOfNodes() );
   ASSERT_EQ( node_capacity, mesh->getNodeCapacity() );
 
@@ -2114,7 +2114,7 @@ void resize_nodes( UnstructuredMesh< TOPO >* mesh )
   mesh->setNodeResizeRatio( resize_ratio );
   append_node_structs( mesh, 100 );
   n_nodes += 100;
-  node_capacity = resize_ratio * n_nodes + 0.5;
+  node_capacity = static_cast< IndexType >( resize_ratio * n_nodes + 0.5 );
   ASSERT_EQ( n_nodes, mesh->getNumberOfNodes() );
   ASSERT_EQ( node_capacity, mesh->getNodeCapacity() );
 
@@ -2195,7 +2195,7 @@ void resize_cells( UnstructuredMesh< TOPO >* mesh )
   /* Append one more, should trigger a resize. */
   append_cell_single( mesh, 1 );
   n_cells++;
-  cell_capacity = n_cells * resize_ratio + 0.5;
+  cell_capacity = static_cast< IndexType >( n_cells * resize_ratio + 0.5 );
   connec_capacity = mesh->getCellNodesCapacity();
   ASSERT_EQ( n_cells, mesh->getNumberOfCells() );
   ASSERT_EQ( cell_capacity, mesh->getCellCapacity() );
@@ -2212,7 +2212,7 @@ void resize_cells( UnstructuredMesh< TOPO >* mesh )
   mesh->setCellResizeRatio( resize_ratio );
   append_cell_multiple( mesh, 100 );
   n_cells += 100;
-  cell_capacity = resize_ratio * n_cells + 0.5;
+  cell_capacity = static_cast< IndexType >( resize_ratio * n_cells + 0.5 );
   ASSERT_EQ( n_cells, mesh->getNumberOfCells() );
   ASSERT_EQ( cell_capacity, mesh->getCellCapacity() );
 

--- a/src/axom/mint/tests/mint_test_utilities.hpp
+++ b/src/axom/mint/tests/mint_test_utilities.hpp
@@ -65,7 +65,7 @@ template < >
 struct mesh_type< STRUCTURED_RECTILINEAR_MESH, SINGLE_SHAPE >
 {
   using MeshType = RectilinearMesh;
-  static constexpr char* name() { 
+  static constexpr char* name() {
     return (char*)"STRUCTURED_RECTILINEAR_MESH";
   };
 };
@@ -120,7 +120,7 @@ Mesh* create_mesh( const UniformMesh& uniform_mesh )
     lo[ i ] = uniform_mesh.evaluateCoordinate(0,i);
     hi[ i ] = uniform_mesh.evaluateCoordinate( N[i]-1, i );
   }
-  UniformMesh* output_mesh = new UniformMesh( lo, hi, N[0], N[1], 
+  UniformMesh* output_mesh = new UniformMesh( lo, hi, N[0], N[1],
                                                           N[2] );
 
   EXPECT_EQ( output_mesh->getMeshType(), STRUCTURED_UNIFORM_MESH );
@@ -144,7 +144,7 @@ Mesh* create_mesh< STRUCTURED_CURVILINEAR_MESH, SINGLE_SHAPE >(
     node_dims[ i ] = uniform_mesh.getNodeResolution( i );
   }
 
-  CurvilinearMesh* output_mesh = new CurvilinearMesh( 
+  CurvilinearMesh* output_mesh = new CurvilinearMesh(
                                                node_dims[ I_DIRECTION ],
                                                node_dims[ J_DIRECTION ],
                                                node_dims[ K_DIRECTION ] );
@@ -239,13 +239,13 @@ Mesh* create_mesh< STRUCTURED_RECTILINEAR_MESH, SINGLE_SHAPE >(
 
 //------------------------------------------------------------------------------
 template < >
-Mesh* create_mesh< PARTICLE_MESH, SINGLE_SHAPE >( 
+Mesh* create_mesh< PARTICLE_MESH, SINGLE_SHAPE >(
                                         const UniformMesh& uniform_mesh )
 {
   const int dimension            = uniform_mesh.getDimension();
   const IndexType numNodes = uniform_mesh.getNumberOfNodes();
 
-  ParticleMesh* output_mesh = 
+  ParticleMesh* output_mesh =
                                   new ParticleMesh( dimension, numNodes );
 
   for ( IndexType inode=0 ; inode < numNodes ; ++inode )
@@ -273,8 +273,8 @@ Mesh* create_mesh< PARTICLE_MESH, SINGLE_SHAPE >(
 
 //------------------------------------------------------------------------------
 template < >
-Mesh* 
-create_mesh< UNSTRUCTURED_MESH, SINGLE_SHAPE >( 
+Mesh*
+create_mesh< UNSTRUCTURED_MESH, SINGLE_SHAPE >(
                                         const UniformMesh& uniform_mesh )
 {
   const int dimension            = uniform_mesh.getDimension();
@@ -285,7 +285,7 @@ create_mesh< UNSTRUCTURED_MESH, SINGLE_SHAPE >(
   CellType cell_type   = ( dimension==3 ) ? HEX :
                                ( (dimension==2) ? QUAD : SEGMENT );
 
-  UnstructuredMeshType* output_mesh = 
+  UnstructuredMeshType* output_mesh =
           new UnstructuredMeshType( dimension, cell_type, numNodes, numCells );
 
   // append nodes
@@ -317,8 +317,8 @@ create_mesh< UNSTRUCTURED_MESH, SINGLE_SHAPE >(
 
 //------------------------------------------------------------------------------
 template < >
-Mesh* 
-create_mesh< UNSTRUCTURED_MESH, MIXED_SHAPE >( 
+Mesh*
+create_mesh< UNSTRUCTURED_MESH, MIXED_SHAPE >(
                                         const UniformMesh& uniform_mesh )
 {
   const int dimension            = uniform_mesh.getDimension();
@@ -331,12 +331,12 @@ create_mesh< UNSTRUCTURED_MESH, MIXED_SHAPE >(
   using UnstructuredMeshType = UnstructuredMesh< MIXED_SHAPE >;
 
   IndexType node_capacity = numNodes + numCells / 2;
-  IndexType cell_capacity = numCells * 2.5;
+  IndexType cell_capacity = static_cast< IndexType >( numCells * 2.5 );
 
   if ( dimension == 3 )
   {
-    node_capacity = numNodes + numCells / 2.0;
-    cell_capacity = numCells * 3.5;
+    node_capacity = static_cast< IndexType >( numNodes + numCells / 2.0 );
+    cell_capacity = static_cast< IndexType >( numCells * 3.5 );
   }
 
   UnstructuredMeshType* output_mesh = new UnstructuredMeshType( dimension,
@@ -415,38 +415,38 @@ create_mesh< UNSTRUCTURED_MESH, MIXED_SHAPE >(
                                          (k + 0.5) * spacing[ 2 ] };
             output_mesh->appendNodes( centroid );
 
-            pyramid[0] = uniformCell[0]; 
+            pyramid[0] = uniformCell[0];
             pyramid[1] = uniformCell[1];
             pyramid[2] = uniformCell[2];
             pyramid[3] = uniformCell[3];
             pyramid[4] = centerNode;
             output_mesh->appendCell( pyramid, PYRAMID );
 
-            pyramid[0] = uniformCell[4]; 
+            pyramid[0] = uniformCell[4];
             pyramid[1] = uniformCell[7];
             pyramid[2] = uniformCell[6];
             pyramid[3] = uniformCell[5];
             output_mesh->appendCell( pyramid, PYRAMID );
 
-            pyramid[0] = uniformCell[1]; 
+            pyramid[0] = uniformCell[1];
             pyramid[1] = uniformCell[5];
             pyramid[2] = uniformCell[6];
             pyramid[3] = uniformCell[2];
             output_mesh->appendCell( pyramid, PYRAMID );
 
-            pyramid[0] = uniformCell[0]; 
+            pyramid[0] = uniformCell[0];
             pyramid[1] = uniformCell[3];
             pyramid[2] = uniformCell[7];
             pyramid[3] = uniformCell[4];
             output_mesh->appendCell( pyramid, PYRAMID );
 
-            pyramid[0] = uniformCell[0]; 
+            pyramid[0] = uniformCell[0];
             pyramid[1] = uniformCell[4];
             pyramid[2] = uniformCell[5];
             pyramid[3] = uniformCell[1];
             output_mesh->appendCell( pyramid, PYRAMID );
 
-            pyramid[0] = uniformCell[3]; 
+            pyramid[0] = uniformCell[3];
             pyramid[1] = uniformCell[2];
             pyramid[2] = uniformCell[6];
             pyramid[3] = uniformCell[7];

--- a/src/axom/primal/examples/primal_introduction.cpp
+++ b/src/axom/primal/examples/primal_introduction.cpp
@@ -669,7 +669,7 @@ void findTriIntersectionsNaively(
   std::vector< std::pair<int, int> > & clashes
   )
 {
-  int tcount = tris.size();
+  int tcount = static_cast< int >( tris.size() );
 
   for (int i = 0 ; i < tcount ; ++i)
   {

--- a/src/axom/primal/geometry/BezierCurve.hpp
+++ b/src/axom/primal/geometry/BezierCurve.hpp
@@ -150,7 +150,7 @@ public:
   void setOrder( int ord) { m_controlPoints.resize(ord+1); }
 
   /*! Returns the order of the Bezier Curve*/
-  int getOrder() const { return m_controlPoints.size()-1; }
+  int getOrder() const { return static_cast< int>(m_controlPoints.size())-1; }
 
   /*! Clears the list of control points*/
   void clear()
@@ -190,14 +190,15 @@ public:
   /*! Returns an axis-aligned bounding box containing the Bezier curve */
   BoundingBoxType boundingBox() const
   {
-    return BoundingBoxType(m_controlPoints.data(), m_controlPoints.size());
+    return BoundingBoxType(m_controlPoints.data(),
+                           static_cast< int >( m_controlPoints.size() ) );
   }
 
   /*! Returns an oriented bounding box containing the Bezier curve */
   OrientedBoundingBoxType orientedBoundingBox() const
   {
     return OrientedBoundingBoxType(m_controlPoints.data(),
-                                   m_controlPoints.size());
+                                   static_cast< int >(m_controlPoints.size()));
   }
 
   /*!

--- a/src/axom/primal/geometry/OrientedBoundingBox.hpp
+++ b/src/axom/primal/geometry/OrientedBoundingBox.hpp
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#ifndef ORIENTEDBOUNDINGBOX_HPP_
-#define ORIENTEDBOUNDINGBOX_HPP_
+#ifndef PRIMAL_ORIENTEDBOUNDINGBOX_HPP_
+#define PRIMAL_ORIENTEDBOUNDINGBOX_HPP_
 
 #include <vector>
 
@@ -534,7 +534,7 @@ void OrientedBoundingBox< T, NDIMS >::addBox( OrientedBoundingBox< T,
   }
 
   std::vector< Point< T, NDIMS > > res = obb.vertices();
-  int size = res.size();
+  int size = static_cast< int >( res.size() );
 
   for (int i = 0 ; i < size ; i++)
   {
@@ -660,7 +660,7 @@ bool OrientedBoundingBox< T, NDIMS >::contains(
 {
   std::vector< Point< T, NDIMS > > l = otherOBB.vertices();
 
-  int size = l.size();
+  int size = static_cast< int >( l.size() );
 
   for (int i = 0 ; i < size ; i++)
   {

--- a/src/axom/primal/geometry/Point.hpp
+++ b/src/axom/primal/geometry/Point.hpp
@@ -132,10 +132,10 @@ public:
    * \return p[i] the value at the given component index.
    * \pre (i >= 0) && (i < ndims)
    */
-  AXOM_HOST_DEVICE 
+  AXOM_HOST_DEVICE
   const T& operator[](int i) const { return m_components[i]; }
-  
-  AXOM_HOST_DEVICE 
+
+  AXOM_HOST_DEVICE
   T& operator[](int i)             { return m_components[i]; }
 
   ///@}
@@ -154,10 +154,10 @@ public:
   /*!
    * \brief Returns a reference to the underlying NumericArray.
    */
-  AXOM_HOST_DEVICE 
+  AXOM_HOST_DEVICE
   const NumericArray< T,NDIMS >& array() const { return m_components; }
-  
-  AXOM_HOST_DEVICE 
+
+  AXOM_HOST_DEVICE
   NumericArray< T,NDIMS >& array()             { return m_components; }
 
   /*!
@@ -225,7 +225,7 @@ public:
    * \post \f$ P==B\f$ when \f$ \alpha=1.0\f$
    * \post The return point, P, and the user-supplied points A, B are collinear.
    */
-  static Point lerp( const Point& A, const Point& B, double alpha);
+  static Point lerp( const Point& A, const Point& B, T alpha);
 
   /*!
    * \brief Helper function to return a point whose coordinates are all 0
@@ -297,10 +297,10 @@ template < typename T, int NDIMS >
 inline Point< T,NDIMS > Point< T,NDIMS >::lerp(
   const Point< T,NDIMS >& A,
   const Point< T,NDIMS >& B,
-  double alpha)
+  T alpha)
 {
   PointType res;
-  const double beta = 1.-alpha;
+  const T beta = 1.-alpha;
   for ( int i=0 ; i < NDIMS ; ++i )
   {
     res[ i ] = beta*A[ i ] + alpha*B[ i ];

--- a/src/axom/primal/geometry/Polygon.hpp
+++ b/src/axom/primal/geometry/Polygon.hpp
@@ -71,7 +71,7 @@ public:
   }
 
   /*! Return the number of vertices in the polygon */
-  int numVertices() const { return m_vertices.size(); }
+  int numVertices() const { return static_cast< int >( m_vertices.size() ); }
 
   /*! Appends a vertex to the list of vertices */
   void addVertex(const PointType& pt)

--- a/src/axom/primal/tests/primal_bezier_intersect.cpp
+++ b/src/axom/primal/tests/primal_bezier_intersect.cpp
@@ -46,7 +46,7 @@ void checkIntersections(const primal::BezierCurve<CoordType, DIM>& curve1,
   EXPECT_TRUE(std::is_sorted(exp_s.begin(), exp_s.end()));
   EXPECT_TRUE(std::is_sorted(exp_t.begin(), exp_t.end()));
 
-  const int num_exp_intersections = exp_s.size();
+  const int num_exp_intersections = static_cast< int >( exp_s.size() );
   const bool exp_intersect = (num_exp_intersections > 0);
 
   // Intersect the two curves, intersection parameters will be
@@ -57,7 +57,7 @@ void checkIntersections(const primal::BezierCurve<CoordType, DIM>& curve1,
   EXPECT_EQ(s.size(), t.size());
 
   // check that we found the expected number of intersection points
-  const int num_actual_intersections = s.size();
+  const int num_actual_intersections = static_cast< int >( s.size() );
   EXPECT_EQ(num_exp_intersections, num_actual_intersections);
 
   // check that the evaluated intersection points are identical

--- a/src/axom/primal/tests/primal_point.cpp
+++ b/src/axom/primal/tests/primal_point.cpp
@@ -308,11 +308,10 @@ TEST( primal_point, point_midpoint)
 //------------------------------------------------------------------------------
 TEST( primal_point, point_linear_interpolation)
 {
-  static const int DIM = 3;
-  typedef int CoordType;
-  typedef primal::Point< CoordType, DIM > QPoint;
+  constexpr int DIM = 3;
+  using QPoint = primal::Point< double, DIM >;
 
-  QPoint p0(0);
+  QPoint p0;
   QPoint p1(100);
 
   EXPECT_TRUE(QPoint::lerp(p0,p1, 0) == p0);

--- a/src/axom/quest/InOutOctree.hpp
+++ b/src/axom/quest/InOutOctree.hpp
@@ -421,7 +421,7 @@ public:     // Functions related to the associated triangles
   void reserveTriangles(int count) { m_tris.reserve(count); }
 
   /** Find the number of triangles associated with this leaf */
-  int numTriangles() const { return m_tris.size(); }
+  int numTriangles() const { return static_cast< int >( m_tris.size() ); }
 
   /** Associates the surface triangle with the given index with this block */
   void addTriangle(TriangleIndex tInd) { m_tris.push_back(tInd); }
@@ -840,10 +840,12 @@ public:
         }
       }
 
-      m_elementSet = MeshElementSet( m_tv_data.size() / NUM_TRI_VERTS );
+      m_elementSet =
+          MeshElementSet( static_cast<int>(m_tv_data.size()) / NUM_TRI_VERTS );
       m_triangleToVertexRelation =
         TriangleVertexRelation(&m_elementSet, &m_vertexSet);
-      m_triangleToVertexRelation.bindIndices(m_tv_data.size(), &m_tv_data);
+      m_triangleToVertexRelation.bindIndices(
+          static_cast<int>(m_tv_data.size()), &m_tv_data);
 
 
       // Delete old mesh, and NULL its pointer
@@ -1526,7 +1528,7 @@ void InOutOctree<DIM>::insertMeshTriangles ()
         if( dynamicLeafData.hasTriangles())
         {
           // Set the leaf data in the octree
-          blkData.setData( gvRelData.size() );
+          blkData.setData( static_cast< int >( gvRelData.size() ) );
 
           // Add the vertex index to the gray blocks vertex relation
           gvRelData.push_back( dynamicLeafData.vertexIndex() );
@@ -1535,7 +1537,7 @@ void InOutOctree<DIM>::insertMeshTriangles ()
           std::copy( dynamicLeafData.triangles().begin(),
                      dynamicLeafData.triangles().end(),
                      std::back_inserter(geIndRelData));
-          geSizeRelData.push_back( geIndRelData.size());
+          geSizeRelData.push_back( static_cast< int >( geIndRelData.size() ) );
 
           QUEST_OCTREE_DEBUG_LOG_IF(
             DEBUG_BLOCK_1 == blk || DEBUG_BLOCK_2 == blk,
@@ -1612,7 +1614,7 @@ void InOutOctree<DIM>::insertMeshTriangles ()
         // Add all triangles to intersecting children blocks
         DynamicGrayBlockData::TriangleList& parentTriangles =
           dynamicLeafData.triangles();
-        int numTriangles = parentTriangles.size();
+        int numTriangles = static_cast< int >( parentTriangles.size() );
         for(int i=0 ; i< numTriangles ; ++i)
         {
           TriangleIndex tIdx = parentTriangles[i];
@@ -1678,13 +1680,13 @@ void InOutOctree<DIM>::insertMeshTriangles ()
     if(!levelLeafMap.empty() )
     {
       // Create the relations from gray leaves to mesh vertices and elements
-      m_grayLeafsMap[lev] = GrayLeafSet( gvRelData.size() );
+      m_grayLeafsMap[lev] = GrayLeafSet( static_cast< int >(gvRelData.size()) );
 
       m_grayLeafToVertexRelationLevelMap[lev] =
         GrayLeafVertexRelation(&m_grayLeafsMap[lev],
                                &m_meshWrapper.vertexSet());
       m_grayLeafToVertexRelationLevelMap[lev].
-      bindIndices(gvRelData.size(), &gvRelData);
+      bindIndices( static_cast< int >(gvRelData.size()), &gvRelData);
 
       m_grayLeafToElementRelationLevelMap[lev] =
         GrayLeafElementRelation(&m_grayLeafsMap[lev],
@@ -1692,7 +1694,7 @@ void InOutOctree<DIM>::insertMeshTriangles ()
       m_grayLeafToElementRelationLevelMap[lev].
       bindBeginOffsets(m_grayLeafsMap[lev].size(), &geSizeRelData);
       m_grayLeafToElementRelationLevelMap[lev].
-      bindIndices(geIndRelData.size(), &geIndRelData);
+      bindIndices( static_cast< int >(geIndRelData.size()), &geIndRelData);
     }
 
     currentLevelData.clear();
@@ -1742,14 +1744,13 @@ void InOutOctree<DIM>::colorOctreeLeaves()
     // (or their descendants) is gray
     while(!uncoloredBlocks.empty())
     {
-      int prevCount = uncoloredBlocks.size();
+      int prevCount = static_cast< int >(uncoloredBlocks.size());
       AXOM_DEBUG_VAR(prevCount);
 
       GridPtVec prevVec;
       prevVec.swap(uncoloredBlocks);
-      for(typename GridPtVec::iterator it = prevVec.begin(),
-          itEnd = prevVec.end() ;
-          it < itEnd ; ++it)
+      auto end = prevVec.end();
+      for(auto it = prevVec.begin() ; it < end ; ++it)
       {
         BlockIndex leafBlk(*it, lev);
         if(!colorLeafAndNeighbors( leafBlk, (*this)[leafBlk] ) )

--- a/src/axom/quest/MeshTester.cpp
+++ b/src/axom/quest/MeshTester.cpp
@@ -382,7 +382,7 @@ void weldTriMeshVertices(UMesh** surface_mesh,double eps)
         uniqueVertCount++;
         newMesh->appendNodes(vert.data());
       }
-      vertex_remap[i] = res.first->second;
+      vertex_remap[i] = static_cast< int >( res.first->second );
     }
 
     // Next, add triangles into the new mesh using the unique vertex indices

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -380,11 +380,11 @@ inline double SignedDistance< NDIMS >::computeDistance(
   m_bvhTree->find( pt, buckets );
 
   // STEP 1: get candidate surface elements
-  int nbuckets = buckets.size();
+  int nbuckets = static_cast< int >( buckets.size() );
   std::vector< int > candidates;
   this->getCandidateSurfaceElements( pt, &buckets[0], nbuckets, candidates );
 
-  const int nelems = candidates.size();
+  const int nelems = static_cast< int >( candidates.size() );
 
   // STEP 2: process surface elements and compute minimum distance and
   // corresponding closest point.
@@ -596,7 +596,7 @@ void SignedDistance< NDIMS >::getCandidateSurfaceElements(
   int* indx             = new int[ nelems ];
 
   // STEP 1: get flat array of the surface elements and compute distances
-  int icount = 0;
+  int icount( static_cast< int >(0) );
   for ( int ibin=0 ; ibin < nbins ; ++ibin )
   {
 

--- a/src/axom/quest/examples/quest_inout_interface.cpp
+++ b/src/axom/quest/examples/quest_inout_interface.cpp
@@ -247,7 +247,8 @@ int main( int argc, char** argv )
     const double rate =  queryPoints.size() / timer.elapsed();
     SLIC_INFO("  query rate: " <<  rate  << " queries per second.");
 
-    const double intPercent = (100 * numInside) / queryPoints.size();
+    const double intPercent =
+       (100 * numInside) / static_cast< double >( queryPoints.size() );
     SLIC_INFO("  " << numInside << " of " << queryPoints.size()
                    << " (" << intPercent << "%) "
                    << " of the query points were contained in the surface.");

--- a/src/axom/quest/stl/STLReader.cpp
+++ b/src/axom/quest/stl/STLReader.cpp
@@ -131,7 +131,7 @@ int STLReader::readAsciiSTL()
   }
 
   // Set the number of nodes and faces
-  m_num_nodes = m_nodes.size() / 3;
+  m_num_nodes = static_cast< axom::IndexType >( m_nodes.size() ) / 3;
   m_num_faces = m_num_nodes / 3;
 
   ifs.close();

--- a/src/axom/quest/tests/quest_all_nearest_neighbors.cpp
+++ b/src/axom/quest/tests/quest_all_nearest_neighbors.cpp
@@ -242,11 +242,11 @@ TEST(quest_all_nearnbr, cplx_13region_query)
   }
 }
 
-void readPointsFile(char* fname,
+void readPointsFile(char* filename,
                     std::vector<double> &x, std::vector<double> &y,
                     std::vector<double> &z, std::vector<int> &region)
 {
-  std::ifstream infile(fname);
+  std::ifstream infile(filename);
   std::string theline;
   double xi, yi, zi;
   int regioni;
@@ -271,9 +271,9 @@ void readPointsFile(char* fname,
   }
 }
 
-void writeNeigborsFile(char* fname, int* neighbors, int n)
+void writeNeigborsFile(char* filename, int* neighbors, int n)
 {
-  std::ofstream outfile(fname);
+  std::ofstream outfile(filename);
   if (outfile.good())
   {
     for (int i = 0 ; i < n ; ++i)
@@ -298,11 +298,13 @@ TEST(quest_all_nearnbr, file_query)
 
     readPointsFile(fname, x, y, z, region);
 
-    size_t n = region.size();
+    const int n = static_cast< int >( region.size() );
 
     SLIC_INFO("n is " << n);
 
-    if (n > 0 && n == x.size() && n == y.size() && n == z.size())
+    if ( (n > 0) && (n == static_cast< int >(x.size())) &&
+         (n == static_cast< int >(y.size())) &&
+         (n == static_cast< int >(z.size())) )
     {
       double limit = 2.1;
       bfneighbor = new int[n];
@@ -310,7 +312,7 @@ TEST(quest_all_nearnbr, file_query)
       bfsqdst = new double[n];
       idxsqdst = new double[n];
 
-      for (size_t i = 0 ; i < n ; ++i)
+      for ( int i = 0 ; i < n ; ++i)
       {
         bfneighbor[i] = -1;
         idxneighbor[i] = -1;

--- a/src/axom/quest/tests/quest_inout_interface.cpp
+++ b/src/axom/quest/tests/quest_inout_interface.cpp
@@ -47,14 +47,13 @@ protected:
 
 TEST_F(InOutInterfaceTest, initialize_and_finalize)
 {
-  const std::string meshfile = this->meshfile;
-  EXPECT_TRUE(axom::utilities::filesystem::pathExists(meshfile));
+  EXPECT_TRUE(axom::utilities::filesystem::pathExists(this->meshfile));
 
   // InOut begins uninitialized
   EXPECT_FALSE(axom::quest::inout_initialized());
 
   // Initialize the InOut query
-  EXPECT_EQ(0, axom::quest::inout_init(meshfile));
+  EXPECT_EQ(0, axom::quest::inout_init(this->meshfile));
 
   // InOut should now be initialized
   EXPECT_TRUE(axom::quest::inout_initialized());
@@ -94,11 +93,10 @@ TEST_F(InOutInterfaceTest, logger_inited)
 
 TEST_F(InOutInterfaceTest, initialize_from_mesh)
 {
-  const std::string meshfile = this->meshfile;
-  EXPECT_TRUE(axom::utilities::filesystem::pathExists(meshfile));
+  EXPECT_TRUE(axom::utilities::filesystem::pathExists(this->meshfile));
 
   axom::mint::Mesh* mesh = nullptr;
-  int rc = axom::quest::internal::read_mesh(meshfile, mesh);
+  int rc = axom::quest::internal::read_mesh(this->meshfile, mesh);
   EXPECT_EQ(0, rc);
 
   // Initialize the InOut query

--- a/src/axom/quest/tests/quest_test_utilities.hpp
+++ b/src/axom/quest/tests/quest_test_utilities.hpp
@@ -60,8 +60,8 @@ void getSphereSurfaceMesh( mint::UnstructuredMesh< mint::SINGLE_SHAPE >* mesh,
   SLIC_ASSERT( mesh->hasMixedCellTypes()==false );
   SLIC_ASSERT( mesh->getCellType()==mint::TRIANGLE );
 
-  const double totalNodes = THETA_RES * PHI_RES;
-  const double totalCells = (2 * THETA_RES) + (THETA_RES * PHI_RES);
+  const IndexType totalNodes = THETA_RES * PHI_RES;
+  const IndexType totalCells = (2 * THETA_RES) + (THETA_RES * PHI_RES);
   mesh->reserve( totalNodes, totalCells );
 
   const double theta_start = 0;

--- a/src/axom/slam/DynamicSet.hpp
+++ b/src/axom/slam/DynamicSet.hpp
@@ -212,7 +212,7 @@ public:
    */
   PositionType size() const
   {
-    return m_data.size();
+    return static_cast< PositionType >( m_data.size() );
   };
 
 
@@ -285,7 +285,7 @@ public:
    * \brief Insert an entry at the end of the set with value = ( size()-1 )
    */
   IndexType insert(){
-    return insert(m_data.size());
+    return insert( static_cast< IndexType >( m_data.size() ) );
   }
 
   /**
@@ -295,7 +295,7 @@ public:
   IndexType insert(ElementType val)
   {
     m_data.push_back(val);
-    return m_data.size()-1;
+    return static_cast< IndexType >( m_data.size()-1 );
   };
 
   /**

--- a/src/axom/slam/Map.hpp
+++ b/src/axom/slam/Map.hpp
@@ -231,7 +231,7 @@ public:
   /** Set each entry in the map to the given value  */
   void        fill(DataType val = DataType())
   {
-    const SetPosition sz = m_data.size();
+    const SetPosition sz = static_cast< SetPosition >( m_data.size() );
 
     for(SetPosition idx = SetPosition() ; idx < sz ; ++idx)
     {

--- a/src/axom/slam/examples/ShockTube.cpp
+++ b/src/axom/slam/examples/ShockTube.cpp
@@ -310,7 +310,8 @@ void CreateShockTubeMesh(ShockTubeMesh* mesh)
 
   mesh->relationFaceElem = ShockTubeMesh::
                            FaceToElemRelation(&mesh->faces, &mesh->elems);
-  mesh->relationFaceElem.bindIndices(feRelVec.size(), &feRelVec);
+  mesh->relationFaceElem.bindIndices( static_cast< int >( feRelVec.size() ),
+                                      &feRelVec);
   SLIC_ASSERT(mesh->relationFaceElem.isValid( verboseOutput ));
 
 
@@ -330,7 +331,8 @@ void CreateShockTubeMesh(ShockTubeMesh* mesh)
 
   mesh->relationTubeFace =
     ShockTubeMesh::TubeElemToFaceRelation(&mesh->tubeElems, &mesh->faces);
-  mesh->relationTubeFace.bindIndices(efRelVec.size(), &efRelVec);
+  mesh->relationTubeFace.bindIndices( static_cast< int >( efRelVec.size() ),
+                                      &efRelVec);
   SLIC_ASSERT(mesh->relationTubeFace.isValid( verboseOutput ));
 
 }

--- a/src/axom/slam/examples/UserDocs.cpp
+++ b/src/axom/slam/examples/UserDocs.cpp
@@ -170,7 +170,7 @@ struct SimpleQuadMesh
              .fromSet( &elems )
              .toSet( &verts )
              .indices(RelationBuilder::IndicesSetBuilder()
-                      .size( evInds.size() )
+                      .size( static_cast< int >(evInds.size()) )
                       .data( evInds.data() ) );
       // _quadmesh_example_construct_bdry_relation_end
     }
@@ -186,7 +186,7 @@ struct SimpleQuadMesh
                         .size( verts.size() )
                         .data( veBegins.data() ) )
                .indices( RelationBuilder::IndicesSetBuilder()
-                         .size( veInds.size() )
+                         .size( static_cast< int >( veInds.size() ) )
                          .data( veInds.data() ) );
       // _quadmesh_example_construct_cobdry_relation_end
     }

--- a/src/axom/slam/policies/IndirectionPolicies.hpp
+++ b/src/axom/slam/policies/IndirectionPolicies.hpp
@@ -294,7 +294,7 @@ bool STLVectorIndirection<PosType,ElemType>::isValid(PosType size,
     // Note: it is valid for the data buffer to have extra space
     PosType firstEltInd = offset;
     PosType lastEltInd = (size - 1) * stride + offset;
-    PosType vecSize = m_vecBuf->size();
+    PosType vecSize = static_cast< PosType >( m_vecBuf->size() );
 
     bool isRangeValid =
       (0 <= firstEltInd) && (firstEltInd < vecSize)

--- a/src/axom/slic/core/LogStream.cpp
+++ b/src/axom/slic/core/LogStream.cpp
@@ -55,6 +55,10 @@ void LogStream::replaceKey( std::string& msg,
 //------------------------------------------------------------------------------
 std::string LogStream::getTimeStamp( )
 {
+#ifdef WIN32
+#pragma warning(disable : 4996) // _CRT_SECURE_NO_WARNINGS
+#endif
+
   std::time_t t;
   std::time( &t );
   std::string timestamp( std::asctime( std::localtime( &t ) ) );

--- a/src/axom/slic/core/Logger.cpp
+++ b/src/axom/slic/core/Logger.cpp
@@ -142,7 +142,7 @@ void Logger::addStreamToAllMsgLevels( LogStream* ls )
 //------------------------------------------------------------------------------
 int Logger::getNumStreamsAtMsgLevel( message::Level level )
 {
-  return m_logStreams[ level ].size( );
+  return static_cast< int >( m_logStreams[ level ].size( ) );
 }
 
 //------------------------------------------------------------------------------
@@ -204,7 +204,7 @@ void Logger::logMessage( message::Level level,
 
   } // END if
 
-  unsigned nstreams = m_logStreams[ level ].size();
+  unsigned nstreams = static_cast< unsigned >( m_logStreams[ level ].size() );
   for ( unsigned istream=0 ; istream < nstreams ; ++istream )
   {
 
@@ -231,7 +231,7 @@ void Logger::flushStreams()
   for ( int level=message::Error ; level < message::Num_Levels ; ++level )
   {
 
-    unsigned nstreams = m_logStreams[ level ].size();
+    unsigned nstreams = static_cast< unsigned >( m_logStreams[ level ].size() );
     for ( unsigned istream=0 ; istream < nstreams ; ++istream )
     {
       m_logStreams[ level ][ istream ]->flush( );
@@ -248,7 +248,7 @@ void Logger::pushStreams()
   for ( int level=message::Error ; level < message::Num_Levels ; ++level )
   {
 
-    unsigned nstreams = m_logStreams[ level ].size();
+    unsigned nstreams = static_cast< unsigned >( m_logStreams[ level ].size() );
     for ( unsigned istream=0 ; istream < nstreams ; ++istream )
     {
       m_logStreams[ level ][ istream ]->push( );

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -7,6 +7,7 @@
 #define AXOM_SLIC_MACROS_HPP_
 
 #include "axom/config.hpp"
+#include "axom/core/Macros.hpp" // for AXOM_HOST_DEVICE macros
 
 /*!
  * \file slic_macros.hpp
@@ -30,9 +31,9 @@
  */
 #define SLIC_ERROR( msg )                                                     \
   do {                                                                        \
-    std::ostringstream oss;                                                   \
-    oss << msg;                                                               \
-    axom::slic::logErrorMessage( oss.str(),__FILE__, __LINE__);               \
+    std::ostringstream __oss;                                                 \
+    __oss << msg;                                                             \
+    axom::slic::logErrorMessage( __oss.str(),__FILE__, __LINE__);             \
   } while ( axom::slic::detail::false_value )
 
 /*!
@@ -52,9 +53,9 @@
 #define SLIC_ERROR_IF( EXP, msg )                                             \
   do {                                                                        \
     if ( EXP ) {                                                              \
-      std::ostringstream oss;                                                 \
-      oss << msg;                                                             \
-      axom::slic::logErrorMessage(oss.str(),__FILE__,__LINE__);               \
+      std::ostringstream __oss;                                               \
+      __oss << msg;                                                           \
+      axom::slic::logErrorMessage(__oss.str(),__FILE__,__LINE__);             \
     }                                                                         \
   } while ( axom::slic::detail::false_value )
 
@@ -77,9 +78,9 @@
  */
 #define SLIC_WARNING( msg )                                                   \
   do {                                                                        \
-    std::ostringstream oss;                                                   \
-    oss << msg;                                                               \
-    axom::slic::logWarningMessage(oss.str(),__FILE__, __LINE__ );             \
+    std::ostringstream __oss;                                                 \
+    __oss << msg;                                                             \
+    axom::slic::logWarningMessage(__oss.str(),__FILE__, __LINE__ );           \
   } while ( axom::slic::detail::false_value )
 
 /*!
@@ -98,9 +99,9 @@
 #define SLIC_WARNING_IF( EXP, msg )                                           \
   do {                                                                        \
     if ( EXP ) {                                                              \
-      std::ostringstream oss;                                                 \
-      oss << msg;                                                             \
-      axom::slic::logWarningMessage(oss.str(),__FILE__,__LINE__ );            \
+      std::ostringstream __oss;                                               \
+      __oss << msg;                                                           \
+      axom::slic::logWarningMessage(__oss.str(),__FILE__,__LINE__ );          \
     }                                                                         \
   } while ( axom::slic::detail::false_value )
 
@@ -130,9 +131,9 @@
 #define SLIC_ASSERT( EXP )                                                    \
   do {                                                                        \
     if ( !(EXP) ) {                                                           \
-      std::ostringstream oss;                                                 \
-      oss << "Failed Assert: " << # EXP << std::ends;                         \
-      axom::slic::logErrorMessage(oss.str(),__FILE__,__LINE__ );              \
+      std::ostringstream __oss;                                               \
+      __oss << "Failed Assert: " << # EXP << std::ends;                       \
+      axom::slic::logErrorMessage(__oss.str(),__FILE__,__LINE__ );            \
     }                                                                         \
   } while ( axom::slic::detail::false_value )
 
@@ -154,9 +155,9 @@
 #define SLIC_ASSERT_MSG( EXP, msg )                                           \
   do {                                                                        \
     if ( !(EXP) ) {                                                           \
-      std::ostringstream oss;                                                 \
-      oss << "Failed Assert: " << # EXP << std::endl << msg << std::ends;     \
-      axom::slic::logErrorMessage(oss.str(),__FILE__,__LINE__ );              \
+      std::ostringstream __oss;                                               \
+      __oss << "Failed Assert: " << # EXP << std::endl << msg << std::ends;   \
+      axom::slic::logErrorMessage(__oss.str(),__FILE__,__LINE__ );            \
     }                                                                         \
   } while ( axom::slic::detail::false_value )
 
@@ -183,13 +184,13 @@
 #define SLIC_CHECK( EXP )                                                     \
   do {                                                                        \
     if ( !(EXP) ) {                                                           \
-      std::ostringstream oss;                                                 \
-      oss << "Failed Check: " << # EXP << std::ends;                          \
+      std::ostringstream __oss;                                               \
+      __oss << "Failed Check: " << # EXP << std::ends;                        \
       if (axom::slic::debug::checksAreErrors) {                               \
-        axom::slic::logErrorMessage( oss.str(),__FILE__, __LINE__);           \
+        axom::slic::logErrorMessage( __oss.str(),__FILE__, __LINE__);         \
       }                                                                       \
       else {                                                                  \
-        axom::slic::logWarningMessage( oss.str(),__FILE__, __LINE__);         \
+        axom::slic::logWarningMessage( __oss.str(),__FILE__, __LINE__);       \
       }                                                                       \
     }                                                                         \
   } while ( axom::slic::detail::false_value )
@@ -211,13 +212,13 @@
 #define SLIC_CHECK_MSG( EXP, msg )                                            \
   do {                                                                        \
     if ( !(EXP) ) {                                                           \
-      std::ostringstream oss;                                                 \
-      oss << "Failed Check: " << # EXP << std::endl << msg <<  std::ends;     \
+      std::ostringstream __oss;                                               \
+      __oss << "Failed Check: " << # EXP << std::endl << msg <<  std::ends;   \
       if (axom::slic::debug::checksAreErrors) {                               \
-        axom::slic::logErrorMessage( oss.str(),__FILE__, __LINE__);           \
+        axom::slic::logErrorMessage( __oss.str(),__FILE__, __LINE__);         \
       }                                                                       \
       else {                                                                  \
-        axom::slic::logWarningMessage( oss.str(),__FILE__, __LINE__);         \
+        axom::slic::logWarningMessage( __oss.str(),__FILE__, __LINE__);       \
       }                                                                       \
     }                                                                         \
   } while ( axom::slic::detail::false_value )
@@ -227,8 +228,8 @@
 // Use assert when on device
 #elif defined(AXOM_DEBUG) && defined(AXOM_DEVICE_CODE)
 
-#define SLIC_ASSERT( EXP )  assert (EXP)                                    
-#define SLIC_ASSERT_MSG( EXP, msg ) assert (EXP) 
+#define SLIC_ASSERT( EXP )  assert (EXP)
+#define SLIC_ASSERT_MSG( EXP, msg ) assert (EXP)
 #define SLIC_CHECK( EXP ) assert (EXP)
 #define SLIC_CHECK_MSG( EXP, msg ) assert (EXP)
 
@@ -255,10 +256,10 @@
  */
 #define SLIC_INFO( msg )                                                      \
   do {                                                                        \
-    std::ostringstream oss;                                                   \
-    oss << msg;                                                               \
+    std::ostringstream __oss;                                                 \
+    __oss << msg;                                                             \
     axom::slic::logMessage(axom::slic::message::Info                          \
-                           , oss.str()                                        \
+                           , __oss.str()                                      \
                            ,__FILE__                                          \
                            , __LINE__ );                                      \
   } while ( axom::slic::detail::false_value )
@@ -277,15 +278,15 @@
  *
  */
 #define SLIC_INFO_IF( EXP, msg )                                           \
-  do {                                                                        \
-    if ( EXP ) {                                                              \
-      std::ostringstream oss;                                                 \
-      oss << msg;                                                             \
-      axom::slic::logMessage(axom::slic::message::Info                        \
-                             , oss.str()                                      \
-                             ,__FILE__                                        \
-                             , __LINE__ );                                    \
-    }                                                                         \
+  do {                                                                     \
+    if ( EXP ) {                                                           \
+      std::ostringstream __oss;                                            \
+      __oss << msg;                                                        \
+      axom::slic::logMessage(axom::slic::message::Info                     \
+                             , __oss.str()                                 \
+                             ,__FILE__                                     \
+                             , __LINE__ );                                 \
+    }                                                                      \
   } while ( axom::slic::detail::false_value )
 
 #ifdef AXOM_DEBUG
@@ -304,10 +305,10 @@
  */
 #define SLIC_DEBUG( msg )                                                     \
   do {                                                                        \
-    std::ostringstream oss;                                                   \
-    oss << msg;                                                               \
+    std::ostringstream __oss;                                                 \
+    __oss << msg;                                                             \
     axom::slic::logMessage(axom::slic::message::Debug                         \
-                           , oss.str()                                        \
+                           , __oss.str()                                      \
                            ,__FILE__                                          \
                            , __LINE__ );                                      \
   } while ( axom::slic::detail::false_value )
@@ -328,10 +329,10 @@
 #define SLIC_DEBUG_IF( EXP, msg )                                             \
   do {                                                                        \
     if ( EXP ) {                                                              \
-      std::ostringstream oss;                                                 \
-      oss << msg;                                                             \
+      std::ostringstream __oss;                                               \
+      __oss << msg;                                                           \
       axom::slic::logMessage(axom::slic::message::Debug                       \
-                             , oss.str()                                      \
+                             , __oss.str()                                    \
                              ,__FILE__                                        \
                              , __LINE__ );                                    \
     }                                                                         \
@@ -361,7 +362,7 @@ struct FalseType
 {
   AXOM_HOST_DEVICE
   FalseType() {}
-  
+
   AXOM_HOST_DEVICE
   inline operator bool() const { return false; }
 };

--- a/src/axom/spin/BVHTree.hpp
+++ b/src/axom/spin/BVHTree.hpp
@@ -584,7 +584,7 @@ void BVHTree< T,NDIMS >::percolateDown( int parent, int rChild, int lChild )
   const BoxType leftBox  = m_tree[ lChild ].Box;
 
   // STEP 1: pre-allocated space for object at the children
-  const int numObjects   = m_tree[ parent ].ObjectArray.size();
+  const int numObjects   = static_cast<int>(m_tree[parent].ObjectArray.size());
   const int estChildSize = static_cast<int>(0.5 * numObjects);
   m_tree[ rChild ].ObjectArray.reserve( estChildSize );
   m_tree[ lChild  ].ObjectArray.reserve( estChildSize );
@@ -684,7 +684,7 @@ template < typename T, int NDIMS >
 bool BVHTree< T,NDIMS >::shouldRefine( int idx, int threshold )
 {
   SLIC_ASSERT( idx >= 0 && idx < static_cast< int >( m_tree.size() ) );
-  const int numObjects = m_tree[ idx ].ObjectArray.size();
+  const int numObjects = static_cast< int >( m_tree[ idx ].ObjectArray.size() );
   const int level      = m_tree[ idx ].Level;
 
   if ( (numObjects > threshold) && (level < m_maxNumLevels-1) )
@@ -811,7 +811,7 @@ inline double BVHTree< T,NDIMS >::getMaxSqDistanceToBucket(
     BoxType::getPoints( m_tree[ bucketIdx ].Box, pnts );
     SLIC_ASSERT( pnts.size()==4 || pnts.size()==8 );
 
-    const int npoints = pnts.size();
+    const int npoints = static_cast< int >( pnts.size() );
     for ( int i=0 ; i < npoints ; ++i )
     {
       dist = std::max( dist, squared_distance( pt, pnts[ i ] ) );
@@ -864,7 +864,7 @@ void BVHTree< T,NDIMS >::find( const PointType& pt,
   // the estLowerBound and estUpperBound
   for ( int level=1 ; level < m_numLevels ; ++level )
   {
-    const int nbuckets = buckets_to_check.size();
+    const int nbuckets = static_cast< int >( buckets_to_check.size() );
     if ( nbuckets==0 )
     {
       /* short-circuit */
@@ -956,7 +956,7 @@ void BVHTree< T,NDIMS >::find( const PointType& pt,
 
   // STEP 4: further filter first_set_candidate buckets into the final set
   // of candidate buckets to pass back to the caller.
-  const int numCandidates = first_set_candidates.size();
+  const int numCandidates = static_cast< int >( first_set_candidates.size() );
   candidate_buckets.clear();
   candidate_buckets.reserve( numCandidates );
   candidate_buckets.push_back( globalClosestBucketIdx );
@@ -997,7 +997,7 @@ int BVHTree< T,NDIMS >::getBucketNumObjects( int bucketIdx ) const
 {
   SLIC_ASSERT( bucketIdx >= 0 &&
                bucketIdx < static_cast< int >(m_tree.size()) );
-  return ( m_tree[ bucketIdx ].ObjectArray.size() );
+  return ( static_cast< int >( m_tree[ bucketIdx ].ObjectArray.size() ) );
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/spin/Brood.hpp
+++ b/src/axom/spin/Brood.hpp
@@ -64,7 +64,10 @@ struct Brood
    */
   static GridPt reconstructGridPt(MortonIndexType morton, int offset)
   {
-    return MortonizerType::demortonize( (morton << DIM) + offset);
+    return
+      static_cast< GridPt >(
+          MortonizerType::demortonize(
+              static_cast< MortonIndexType >( (morton<<DIM)+offset) ) );
   }
 private:
   MortonIndexType m_broodIdx;           /** MortonIndex of the base point of all

--- a/src/axom/spin/DenseOctreeLevel.hpp
+++ b/src/axom/spin/DenseOctreeLevel.hpp
@@ -71,7 +71,7 @@ public:
 
     IteratorHelper(OctreeLevelType* octLevel, bool begin)
       : m_octreeLevel(octLevel),
-      m_endIdx( octLevel->m_broodCapacity),
+      m_endIdx( static_cast< MortonIndexType >(octLevel->m_broodCapacity) ),
       m_offset(0),
       m_isLevelZero( octLevel->level() == 0)
     {

--- a/src/axom/spin/SparseOctreeLevel.hpp
+++ b/src/axom/spin/SparseOctreeLevel.hpp
@@ -376,7 +376,9 @@ public:
   {
     if(empty())
       return 0;
-    return (this->m_level == 0) ? 1 : (m_map.size() * Base::BROOD_SIZE);
+
+    return ( (this->m_level == 0) ?
+                1 : ( static_cast< int >( m_map.size() ) * Base::BROOD_SIZE ) );
   }
 
   /** \brief Returns the number of internal blocks in the level */

--- a/src/axom/spin/UniformGrid.hpp
+++ b/src/axom/spin/UniformGrid.hpp
@@ -355,7 +355,7 @@ bool UniformGrid< T, NDIMS >::isValidIndex(int index) const
 template < typename T, int NDIMS >
 int UniformGrid< T, NDIMS >::getNumBins() const
 {
-  return m_bins.size();
+  return static_cast< int >( m_bins.size() );
 }
 
 template < typename T, int NDIMS >
@@ -452,7 +452,7 @@ void UniformGrid< T, NDIMS >::insert(const BoxType& BB,
 
   const std::vector< int > bidxs = getBinsForBbox(BB);
 
-  const int numBins = bidxs.size();
+  const int numBins = static_cast< int >( bidxs.size() );
   for (int i = 0 ; i < numBins ; ++i)
   {
     addObj(obj, bidxs[i]);

--- a/src/axom/spin/examples/spin_introduction.cpp
+++ b/src/axom/spin/examples/spin_introduction.cpp
@@ -44,8 +44,8 @@
 #include "fmt/fmt.hpp"
 
 // almost all our examples are in 3D
-const int in3D = 3;
-const int in2D = 2;
+constexpr int in3D = 3;
+constexpr int in2D = 2;
 
 // primitives represented by doubles in 3D
 using BoundingBoxType = axom::primal::BoundingBox<double, in3D>;
@@ -231,7 +231,7 @@ void findTriIntersectionsNaively(
   std::vector< std::pair<int, int> > & clashes
   )
 {
-  int tcount = tris.size();
+  int tcount = static_cast< int >( tris.size() );
 
   for (int i = 0 ; i < tcount ; ++i)
   {
@@ -295,7 +295,7 @@ UniformGridType* buildUniformGrid(std::vector<TriangleType> & tris)
   const PointType & minBBPt = allbbox.getMin();
   const PointType & maxBBPt = allbbox.getMax();
 
-  int tcount = tris.size();
+  int tcount = static_cast< int >( tris.size() );
 
   // The number of bins along one side of the UniformGrid.
   // This is a heuristic.
@@ -358,7 +358,7 @@ void findTriIntersectionsAccel(
   UniformGridType* ugrid,
   std::vector< std::pair<int, int> > & clashes)
 {
-  int tcount = tris.size();
+  int tcount = static_cast< int >( tris.size() );
 
   // For each triangle t1,
   for (int i = 0 ; i < tcount ; ++i)
@@ -368,7 +368,7 @@ void findTriIntersectionsAccel(
     findNeighborCandidates(t1, i, ugrid, neighbors);
 
     // Test for intersection between t1 and each of its neighbors.
-    int ncount = neighbors.size();
+    int ncount = static_cast< int >( neighbors.size() );
     for (int n = 0 ; n < ncount ; ++n)
     {
       int j = neighbors[n];
@@ -400,7 +400,7 @@ void showImplicitGrid()
   // establish the domain of the ImplicitGrid.
   IBBox bbox(ISpacePt::zero(), ISpacePt::ones());
   // room for one hundred elements in the index
-  const int numElts = tris.size();
+  const int numElts = static_cast< int >( tris.size() );
   IGridT grid(bbox, &res, numElts);
 
   // load the bounding box of each triangle, along with its index,
@@ -481,7 +481,7 @@ void makeTriangles(std::vector<Triangle2DType> & tris)
 void printPairs(std::string title,
                 std::vector< std::pair<int, int> > & clashes)
 {
-  int ccount = clashes.size();
+  int ccount = static_cast< int >( clashes.size() );
   std::cout << ccount << title << std::endl;
   for (int i = 0 ; i < ccount ; ++i)
   {
@@ -516,7 +516,7 @@ BVHTree2DType* buildBVHTree(std::vector<Triangle2DType> & tris)
   // Initialize BVHTree with the triangles
   const int MaxBinFill = 1;
   const int MaxLevels = 4;
-  int tricount = tris.size();
+  int tricount = static_cast< int >( tris.size() );
   BVHTree2DType* tree  = new BVHTree2DType( tricount, MaxLevels );
 
   for ( int i=0 ; i < tricount ; ++i )
@@ -578,7 +578,7 @@ void findIntersectionsWithCandidates(std::vector<Triangle2DType> & tris,
                                      std::vector<int> & intersections)
 {
   // Test if ppoint lands in any of its neighbor triangles.
-  int csize = candidates.size();
+  int csize = static_cast< int >( candidates.size() );
   for (int i = 0 ; i < csize ; ++i)
   {
     Triangle2DType & t = tris[candidates[i]];

--- a/src/axom/spin/tests/spin_octree.cpp
+++ b/src/axom/spin/tests/spin_octree.cpp
@@ -161,11 +161,11 @@ TEST( spin_octree, octree_coveringLeafBlocks)
 
     // Each child or the root has two valid face neighbors
     int validNeighborCount = 0;
-    for(int i=0 ; i< blk.numFaceNeighbors() ; ++i)
+    for(int j=0 ; j< blk.numFaceNeighbors() ; ++j)
     {
-      BlockIndex neighborBlk = blk.faceNeighbor(i);
+      BlockIndex neighborBlk = blk.faceNeighbor(j);
 
-      SLIC_INFO(" Face neighbor " << i << " is " << neighborBlk );
+      SLIC_INFO(" Face neighbor " << j << " is " << neighborBlk );
 
       if( octree.coveringLeafBlock(neighborBlk) != BlockIndex::invalid_index() )
         validNeighborCount++;
@@ -194,14 +194,14 @@ TEST( spin_octree, octree_coveringLeafBlocks)
       // .. at a coarser level
       EXPECT_GE( blk.level(), coveringBlock.level());
 
-      for(int i=0 ; i< blk.numFaceNeighbors() ; ++i)
+      for(int k=0 ; k< blk.numFaceNeighbors() ; ++k)
       {
-        BlockIndex neighborBlk = blk.faceNeighbor(i);
+        BlockIndex neighborBlk = blk.faceNeighbor(k);
         BlockIndex coveringBlk = octree.coveringLeafBlock(neighborBlk);
 
         SLIC_INFO(
           "\tFace neighbor "
-          << i << " is " << neighborBlk
+          << k << " is " << neighborBlk
           << " -- Covering block is " << coveringBlk
           << (coveringBlk == BlockIndex::invalid_index()
               ? " -- invalid_index" : "")  );

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -32,10 +32,10 @@
 #include "axom/slic/streams/GenericOutputStream.hpp"
 #include "axom/slic/interface/slic.hpp"
 
-// RAJA 
+// RAJA
 #ifdef AXOM_USE_RAJA
   #include "RAJA/RAJA.hpp"
-#endif 
+#endif
 
 // RAJA policies
 #include "axom/mint/execution/internal/structured_exec.hpp"
@@ -78,8 +78,8 @@ using UniformGrid3 = spin::UniformGrid<int, 3>;
 using Vector3 = primal::Vector<double, 3>;
 using Segment3 = primal::Segment<double, 3>;
 
-enum RuntimePolicy { seq = 0, 
-                     raja_seq = 1, 
+enum RuntimePolicy { seq = 0,
+                     raja_seq = 1,
                      raja_omp = 2,
                      raja_cuda = 3};
 
@@ -120,7 +120,7 @@ const std::set<RuntimePolicy> Input::s_validPolicies({
     , raja_seq
     #ifdef AXOM_USE_OPENMP
     , raja_omp
-    #endif  
+    #endif
     #ifdef AXOM_USE_CUDA
     , raja_cuda
     #endif
@@ -143,7 +143,7 @@ void Input::parse(int argc, char** argv, CLI::App& app)
                  "Set to 1 to use the RAJA sequential policy. \n"
     #ifdef AXOM_USE_OPENMP
                  "Set to 2 to use the RAJA OpenMP policy. \n"
-    #endif 
+    #endif
     #ifdef AXOM_USE_CUDA
                  "Set to 3 to use the RAJA CUDA policy."
     #endif
@@ -208,11 +208,11 @@ void Input::fixOutfilePath()
   std::string outFileBase = futil::joinPath(futil::getCWD(),inFileStem);
 
   // set output file name when not provided
-  int sz = vtkOutput.size();
+  int sz = static_cast< int >( vtkOutput.size() );
   if (sz < 1)
   {
     vtkOutput = outFileBase;
-    sz = vtkOutput.size();
+    sz = static_cast< int >( vtkOutput.size() );
   }
 
   // ensure that output file does not end with '.vtk'
@@ -335,7 +335,7 @@ std::vector< std::pair<int, int> > naiveIntersectionAlgorithm(
   std::vector<int> & degenerate)
 {
   SLIC_INFO("Running naive intersection algorithm "
-    << " in execution Space: " 
+    << " in execution Space: "
     << axom::execution_space< ExecSpace >::name());
 
   // Get allocator
@@ -362,14 +362,14 @@ std::vector< std::pair<int, int> > naiveIntersectionAlgorithm(
   RAJA::RangeSegment row_range(0, ncells);
   RAJA::RangeSegment col_range(0, ncells);
 
-  using KERNEL_POL = 
+  using KERNEL_POL =
     typename axom::mint::internal::structured_exec< ExecSpace >::loop2d_policy;
   using REDUCE_POL =
     typename axom::execution_space< ExecSpace >::reduce_policy;
-  using ATOMIC_POL = 
+  using ATOMIC_POL =
     typename axom::execution_space< ExecSpace >::atomic_policy;
- 
-  RAJA::ReduceSum< REDUCE_POL, int > numIntersect(0);  
+
+  RAJA::ReduceSum< REDUCE_POL, int > numIntersect(0);
 
   // Compute the number of intersections
   RAJA::kernel<KERNEL_POL>( RAJA::make_tuple(col_range, row_range),
@@ -387,7 +387,7 @@ std::vector< std::pair<int, int> > naiveIntersectionAlgorithm(
   int * intersections =
     axom::allocate <int> (numIntersect.get() * 2);
   int * counter = axom::allocate <int> (1);
-  
+
   counter[0] = 0;
 
   // RAJA loop to populate with intersections
@@ -410,7 +410,7 @@ std::vector< std::pair<int, int> > naiveIntersectionAlgorithm(
     retval.push_back(std::make_pair(intersections[i], intersections[i + 1]));
   }
 
-  // Deallocate 
+  // Deallocate
   axom::deallocate(tris);
   axom::deallocate(intersections);
   axom::deallocate(counter);
@@ -519,7 +519,7 @@ void initializeLogger()
  * Currently the mesh tester checks for intersecting triangles.  This is
  * implemented in three ways.  First, a naive algorithm tests each triangle
  * against each other triangle.  This is easy to understand and verify,
- * but slow. Second, the same naive algorithm is run using raja. A third 
+ * but slow. Second, the same naive algorithm is run using raja. A third
  * algorithm uses a UniformGrid to index the bounding box of the mesh,
  * and checks each triangle for intersection with the triangles in all the
  * bins the triangle's bounding box falls into.
@@ -598,18 +598,18 @@ int main( int argc, char** argv )
       collisions = naiveIntersectionAlgorithm(surface_mesh, degenerate);
   #ifdef AXOM_USE_RAJA
      case raja_seq:
-        collisions = naiveIntersectionAlgorithm< seq_exec >(surface_mesh, 
+        collisions = naiveIntersectionAlgorithm< seq_exec >(surface_mesh,
                                                           degenerate);
        break;
     #ifdef AXOM_USE_OPENMP
      case raja_omp:
-        collisions = naiveIntersectionAlgorithm< omp_exec >(surface_mesh, 
+        collisions = naiveIntersectionAlgorithm< omp_exec >(surface_mesh,
                                                           degenerate);
        break;
     #endif
     #ifdef AXOM_USE_CUDA
      case raja_cuda:
-        collisions = naiveIntersectionAlgorithm< cuda_exec >(surface_mesh, 
+        collisions = naiveIntersectionAlgorithm< cuda_exec >(surface_mesh,
                                                           degenerate);
        break;
     #endif
@@ -634,7 +634,9 @@ int main( int argc, char** argv )
               << timer.elapsedTimeInSec() << " seconds.");
 
     announceMeshProblems(surface_mesh->getNumberOfCells(),
-                         collisions.size(), degenerate.size());
+                         static_cast< int >( collisions.size() ),
+                         static_cast< int >( degenerate.size() )
+                         );
 
     saveProblemFlagsToMesh(surface_mesh, collisions, degenerate);
 


### PR DESCRIPTION
# Summary

Fix various warnings on Windows due to unused variables
and type conversion from double to integer.

