### PR TITLE
Small build system changes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,10 +43,16 @@ else()
     endif()
 endif()
 
-if (NOT BLT_CXX_STD)
-    set(BLT_CXX_STD "c++11" CACHE STRING "")
+if (“${PROJECT_SOURCE_DIR}” STREQUAL “${CMAKE_SOURCE_DIR}”)
+    # Set some default BLT options before loading BLT only if not included in
+    # another project
+    if (NOT BLT_CXX_STD)
+        set(BLT_CXX_STD "c++11" CACHE STRING "")
+    endif()
+
+    set(ENABLE_ASTYLE      OFF CACHE BOOL "")
+    set(ENABLE_CLANGFORMAT OFF CACHE BOOL "")
 endif()
-set(ENABLE_ASTYLE OFF CACHE BOOL "")
 
 include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
 

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -28,7 +28,7 @@ macro(axom_add_code_checks)
 
     # Only do code checks if building Axom by itself and not included in
     # another project
-    if (“${PROJECT_SOURCE_DIR}” STREQUAL “${CMAKE_SOURCE_DIR}”)
+    if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
         set(_all_sources)
         file(GLOB_RECURSE _all_sources
              "*.cpp" "*.hpp" "*.cxx" "*.hxx" "*.cc" "*.c" "*.h" "*.hh"

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -26,34 +26,38 @@ macro(axom_add_code_checks)
     cmake_parse_arguments(arg
          "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    set(_all_sources)
-    file(GLOB_RECURSE _all_sources
-         "*.cpp" "*.hpp" "*.cxx" "*.hxx" "*.cc" "*.c" "*.h" "*.hh"
-         "*.F" "*.f" "*.f90" "*.F90")
+    # Only do code checks if building Axom by itself and not included in
+    # another project
+    if (“${PROJECT_SOURCE_DIR}” STREQUAL “${CMAKE_SOURCE_DIR}”)
+        set(_all_sources)
+        file(GLOB_RECURSE _all_sources
+             "*.cpp" "*.hpp" "*.cxx" "*.hxx" "*.cc" "*.c" "*.h" "*.hh"
+             "*.F" "*.f" "*.f90" "*.F90")
 
-    # Check for excludes
-    if (NOT DEFINED arg_EXCLUDES)
-        set(_sources ${_all_sources})
-    else()
-        set(_sources)
-        foreach(_source ${_all_sources})
-            set(_to_be_excluded FALSE)
-            foreach(_exclude ${arg_EXCLUDES})
-                if (${_source} MATCHES ${_exclude})
-                    set(_to_be_excluded TRUE)
-                    break()
+        # Check for excludes
+        if (NOT DEFINED arg_EXCLUDES)
+            set(_sources ${_all_sources})
+        else()
+            set(_sources)
+            foreach(_source ${_all_sources})
+                set(_to_be_excluded FALSE)
+                foreach(_exclude ${arg_EXCLUDES})
+                    if (${_source} MATCHES ${_exclude})
+                        set(_to_be_excluded TRUE)
+                        break()
+                    endif()
+                endforeach()
+
+                if (NOT ${_to_be_excluded})
+                    list(APPEND _sources ${_source})
                 endif()
             endforeach()
+        endif()
 
-            if (NOT ${_to_be_excluded})
-                list(APPEND _sources ${_source})
-            endif()
-        endforeach()
+        blt_add_code_checks(PREFIX    ${arg_PREFIX}
+                            SOURCES   ${_sources}
+                            UNCRUSTIFY_CFG_FILE ${PROJECT_SOURCE_DIR}/uncrustify.cfg)
     endif()
-
-    blt_add_code_checks(PREFIX    ${arg_PREFIX}
-                        SOURCES   ${_sources}
-                        UNCRUSTIFY_CFG_FILE ${PROJECT_SOURCE_DIR}/uncrustify.cfg)
 
 endmacro(axom_add_code_checks)
 

--- a/src/docs/sphinx/dev_guide/component_org.rst
+++ b/src/docs/sphinx/dev_guide/component_org.rst
@@ -210,8 +210,6 @@ add *sidre* as a library is::
                        "${sidre_fortran_sources}"
                    HEADERS
                        "${sidre_headers}"
-                   HEADERS_OUTPUT_SUBDIR
-                       sidre
                    DEPENDS_ON
                        ${sidre_depends}
                    )

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -13,8 +13,7 @@
 #------------------------------------------------------------------------------
 
 blt_add_library(NAME cli11
-                HEADERS CLI11/CLI11.hpp
-                HEADERS_OUTPUT_SUBDIR CLI11)
+                HEADERS CLI11/CLI11.hpp)
 
 target_include_directories(cli11 SYSTEM INTERFACE
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/thirdparty>)
@@ -57,8 +56,7 @@ set(fmt_headers_sources
     )
 
 blt_add_library(NAME fmt
-                HEADERS ${fmt_headers}
-                HEADERS_OUTPUT_SUBDIR fmt)
+                HEADERS ${fmt_headers})
 
 target_include_directories(fmt SYSTEM INTERFACE
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/thirdparty>)
@@ -140,8 +138,7 @@ if (AXOM_ENABLE_SPARSEHASH)
      )
      
     blt_add_library(NAME sparsehash
-            HEADERS ${sparsehash_headers}
-            HEADERS_OUTPUT_SUBDIR sparsehash)
+            HEADERS ${sparsehash_headers})
      
     target_include_directories(sparsehash SYSTEM INTERFACE
                 $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/thirdparty>)


### PR DESCRIPTION
* Update to develop BLT
* Guard code checks and global options against including Axom as a subdirectory from another project

This is mainly because I want to play with clang-format (which i just added to BLT) in a few projects.