### PR TITLE
Fix uberenv, Lower Spack's architecture optimization from AVX2 to AVX

### DIFF
--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@4.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@4.0.0.cmake
@@ -29,7 +29,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE 
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_02_18_10_11_15/clang-4.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_03_20_22_04_40/clang-4.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -64,7 +64,7 @@ set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_02_13_10_02_04/gcc-8.1.0" CACHE PATH "")
+set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_03_20_16_52_14/gcc-8.1.0" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.4/bin/python" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@6.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@6.0.0.cmake
@@ -29,7 +29,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-4.9.3/bin/gfortran" CACHE 
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_02_18_10_11_15/clang-6.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_03_20_22_04_40/clang-6.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -64,7 +64,7 @@ set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_02_13_10_02_04/gcc-8.1.0" CACHE PATH "")
+set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_03_20_16_52_14/gcc-8.1.0" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.4/bin/python" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@6.1.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@6.1.0.cmake
@@ -29,7 +29,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-6.1.0/bin/gfortran" CACHE 
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_02_18_10_11_15/gcc-6.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_03_20_22_04_40/gcc-6.1.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -64,7 +64,7 @@ set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_02_13_10_02_04/gcc-8.1.0" CACHE PATH "")
+set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_03_20_16_52_14/gcc-8.1.0" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.4/bin/python" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@7.3.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@7.3.0.cmake
@@ -29,7 +29,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-7.3.0/bin/gfortran" CACHE 
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_02_18_10_11_15/gcc-7.3.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_03_20_22_04_40/gcc-7.3.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -64,7 +64,7 @@ set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_02_13_10_02_04/gcc-8.1.0" CACHE PATH "")
+set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_03_20_16_52_14/gcc-8.1.0" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.4/bin/python" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -29,7 +29,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran" CACHE 
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_02_18_10_11_15/gcc-8.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_03_20_22_04_40/gcc-8.1.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -64,7 +64,7 @@ set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_02_13_10_02_04/gcc-8.1.0" CACHE PATH "")
+set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_03_20_16_52_14/gcc-8.1.0" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.4/bin/python" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@18.0.2.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@18.0.2.cmake
@@ -29,7 +29,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-18.0.2/bin/ifort" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_02_18_10_11_15/intel-18.0.2" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_03_20_22_04_40/intel-18.0.2" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -64,7 +64,7 @@ set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_02_13_10_02_04/gcc-8.1.0" CACHE PATH "")
+set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_03_20_16_52_14/gcc-8.1.0" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.4/bin/python" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.0.cmake
@@ -29,7 +29,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-19.0.0/bin/ifort" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_02_18_10_11_15/intel-19.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_03_20_22_04_40/intel-19.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -64,7 +64,7 @@ set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_02_13_10_02_04/gcc-8.1.0" CACHE PATH "")
+set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_03_20_16_52_14/gcc-8.1.0" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.4/bin/python" CACHE PATH "")
 

--- a/scripts/llnl_scripts/llnl_lc_build_tools.py
+++ b/scripts/llnl_scripts/llnl_lc_build_tools.py
@@ -105,6 +105,7 @@ def log_success(prefix, msg, timestamp=""):
         info["timestamp"] = timestamp
     json.dump(info,open(pjoin(prefix,"success.json"),"w"),indent=2)
 
+
 def log_failure(prefix, msg, timestamp=""):
     """
     Called when the process failed.
@@ -256,7 +257,12 @@ def uberenv_create_mirror(prefix, project_file, mirror_path):
     cmd  = "python scripts/uberenv/uberenv.py --create-mirror"
     cmd += " --prefix=\"{0}\" --mirror=\"{1}\"".format(prefix, mirror_path)
     cmd += " --project-json=\"{0}\" ".format(project_file)
-    return sexe(cmd,echo=True,error_prefix="WARNING:")
+    res = sexe(cmd, echo=True, error_prefix="WARNING:")
+    print "[~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~]"
+    print "[The above behavior of 'spack --create-mirror' is normal to throw many warnings]"
+    print "[~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~]"
+    set_axom_group_and_perms(mirror_path)
+    return res
 
 
 def uberenv_build(prefix, spec, project_file, config_dir, mirror_path):

--- a/scripts/llnl_scripts/llnl_lc_build_tools.py
+++ b/scripts/llnl_scripts/llnl_lc_build_tools.py
@@ -259,7 +259,7 @@ def uberenv_create_mirror(prefix, project_file, mirror_path):
     cmd += " --project-json=\"{0}\" ".format(project_file)
     res = sexe(cmd, echo=True, error_prefix="WARNING:")
     print "[~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~]"
-    print "[The above behavior of 'spack --create-mirror' is normal to throw many warnings]"
+    print "[ It is expected for 'spack --create-mirror' to throw warnings.                ]"
     print "[~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~]"
     set_axom_group_and_perms(mirror_path)
     return res

--- a/scripts/uberenv/spack_configs/toss_3_x86_64_ib/devtools/packages.yaml
+++ b/scripts/uberenv/spack_configs/toss_3_x86_64_ib/devtools/packages.yaml
@@ -16,6 +16,9 @@
 # -------------------------------------------------------------------------
 packages:
   all:
+    # This defaults us to machine specific flags of ivybridge which is allows
+    # us to run on broadwell as well
+    target: [ivybridge]
     compiler: [gcc, intel, pgi, clang, xl, nag]
     providers:
       blas: [netlib-lapack]

--- a/scripts/uberenv/spack_configs/toss_3_x86_64_ib/devtools/packages.yaml
+++ b/scripts/uberenv/spack_configs/toss_3_x86_64_ib/devtools/packages.yaml
@@ -16,7 +16,7 @@
 # -------------------------------------------------------------------------
 packages:
   all:
-    # This defaults us to machine specific flags of ivybridge which is allows
+    # This defaults us to machine specific flags of ivybridge which allows
     # us to run on broadwell as well
     target: [ivybridge]
     compiler: [gcc, intel, pgi, clang, xl, nag]

--- a/scripts/uberenv/spack_configs/toss_3_x86_64_ib/packages.yaml
+++ b/scripts/uberenv/spack_configs/toss_3_x86_64_ib/packages.yaml
@@ -16,6 +16,9 @@
 # -------------------------------------------------------------------------
 packages:
   all:
+    # This defaults us to machine specific flags of ivybridge which is allows
+    # us to run on broadwell as well
+    target: [ivybridge]
     compiler: [gcc, intel, pgi, clang, xl, nag]
     providers:
       blas: [netlib-lapack]
@@ -31,13 +34,13 @@ packages:
 # Lock down which MPI we are using
   mvapich2:
     paths:
-      mvapich2@2.3%gcc@6.1.0 arch=linux-rhel7-broadwell: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-6.1.0
-      mvapich2@2.3%gcc@7.3.0 arch=linux-rhel7-broadwell: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-7.3.0
-      mvapich2@2.3%gcc@8.1.0 arch=linux-rhel7-broadwell: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0
-      mvapich2@2.3%intel@18.0.2 arch=linux-rhel7-broadwell: /usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.2
-      mvapich2@2.3%intel@19.0.0 arch=linux-rhel7-broadwell: /usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.0
-      mvapich2@2.3%clang@4.0.0 arch=linux-rhel7-broadwell: /usr/tce/packages/mvapich2/mvapich2-2.3-clang-4.0.0
-      mvapich2@2.3%clang@6.0.0 arch=linux-rhel7-broadwell: /usr/tce/packages/mvapich2/mvapich2-2.3-clang-6.0.0
+      mvapich2@2.3%gcc@6.1.0 arch=linux-rhel7-ivybridge: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-6.1.0
+      mvapich2@2.3%gcc@7.3.0 arch=linux-rhel7-ivybridge: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-7.3.0
+      mvapich2@2.3%gcc@8.1.0 arch=linux-rhel7-ivybridge: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0
+      mvapich2@2.3%intel@18.0.2 arch=linux-rhel7-ivybridge: /usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.2
+      mvapich2@2.3%intel@19.0.0 arch=linux-rhel7-ivybridge: /usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.0
+      mvapich2@2.3%clang@4.0.0 arch=linux-rhel7-ivybridge: /usr/tce/packages/mvapich2/mvapich2-2.3-clang-4.0.0
+      mvapich2@2.3%clang@6.0.0 arch=linux-rhel7-ivybridge: /usr/tce/packages/mvapich2/mvapich2-2.3-clang-6.0.0
     buildable: False
 # Spack may grab for mpi & we don't want to use them
   openmpi:

--- a/scripts/uberenv/spack_configs/toss_3_x86_64_ib/packages.yaml
+++ b/scripts/uberenv/spack_configs/toss_3_x86_64_ib/packages.yaml
@@ -16,7 +16,7 @@
 # -------------------------------------------------------------------------
 packages:
   all:
-    # This defaults us to machine specific flags of ivybridge which is allows
+    # This defaults us to machine specific flags of ivybridge which allows
     # us to run on broadwell as well
     target: [ivybridge]
     compiler: [gcc, intel, pgi, clang, xl, nag]

--- a/scripts/uberenv/uberenv.py
+++ b/scripts/uberenv/uberenv.py
@@ -500,7 +500,7 @@ class SpackEnv(UberEnv):
                 os.chdir(pjoin(self.dest_dir,"spack"))
                 sexe("git checkout {0}".format(sha1),echo=True)
 
-        if self.opts["spack_pull"]:
+        if self.opts["repo_pull"]:
             # do a pull to make sure we have the latest
             os.chdir(pjoin(self.dest_dir,"spack"))
             sexe("git stash", echo=True)


### PR DESCRIPTION
* Uberenv had a python dictionary key error on the linux side of things
* Newer Spacks now add architecture optimization flags behind the scenes.. AVX2 is not compatible on all TOSS3 machines but AVX seems to be.