### PR TITLE
Fix Sidre Array examples

### DIFF
--- a/src/axom/sidre/examples/sidre_array.cpp
+++ b/src/axom/sidre/examples/sidre_array.cpp
@@ -61,11 +61,13 @@ int main ( int argc, char** argv )
   // STEP 2: save the array data in to a file
   sidre::IOManager sidre_io( problem_comm );
   sidre_io.write( root1, nranks, "mesh", "sidre_hdf5" );
+  MPI_Barrier( problem_comm );
 
   // STEP 3: read the data from the file into a new DataStore
   sidre::DataStore* dataStore2 = new sidre::DataStore();
   sidre::Group* root2 = dataStore2->getRoot();
   sidre_io.read( root2, "mesh.root");
+  MPI_Barrier( problem_comm );
 
 // DEBUG
     SLIC_INFO( "Here is the array data in DataStore_2:\n" );

--- a/src/axom/sidre/examples/sidre_external_array.cpp
+++ b/src/axom/sidre/examples/sidre_external_array.cpp
@@ -54,6 +54,7 @@ void sidre_write( MPI_Comm comm,
   // STEP 2: save the array data in to a file
   sidre::IOManager sidre_io( comm );
   sidre_io.write( root, nranks, file, "sidre_hdf5" );
+  MPI_Barrier( comm );
 }
 
 //------------------------------------------------------------------------------
@@ -75,6 +76,7 @@ void sidre_read( MPI_Comm comm,
 
   sidre::IOManager sidre_io( comm );
   sidre_io.read( root, file );
+  MPI_Barrier( comm );
 
   SLIC_ASSERT( root->hasChildView("data") );
   sidre::View* view = root->getView( "data" );
@@ -99,6 +101,7 @@ void sidre_read( MPI_Comm comm,
 
   // load the external data
   sidre_io.loadExternalData(root,file);
+  MPI_Barrier( comm );
 
 // DEBUG
   SLIC_INFO( "Here is the data that was read back:" );


### PR DESCRIPTION
# Summary

Add MPI barriers to synchronize all ranks after write() and read().
