### PR TITLE
Add MPI barriers and some documentation clarification in IOManager

### DIFF
--- a/src/axom/sidre/examples/sidre_array.cpp
+++ b/src/axom/sidre/examples/sidre_array.cpp
@@ -60,13 +60,12 @@ int main ( int argc, char** argv )
 
   // STEP 2: save the array data in to a file
   sidre::IOManager sidre_io( problem_comm );
-  sidre_io.write( root1, nranks, "mesh", "sidre_hdf5" );
+  sidre_io.write( root1, nranks, "sidre_array_mesh", "sidre_hdf5" );
 
   // STEP 3: read the data from the file into a new DataStore
   sidre::DataStore* dataStore2 = new sidre::DataStore();
   sidre::Group* root2 = dataStore2->getRoot();
-  sidre_io.read( root2, "mesh.root");
-  MPI_Barrier(problem_comm);
+  sidre_io.read( root2, "sidre_array_mesh.root");
 
 // DEBUG
     SLIC_INFO( "Here is the array data in DataStore_2:\n" );

--- a/src/axom/sidre/examples/sidre_array.cpp
+++ b/src/axom/sidre/examples/sidre_array.cpp
@@ -66,6 +66,7 @@ int main ( int argc, char** argv )
   sidre::DataStore* dataStore2 = new sidre::DataStore();
   sidre::Group* root2 = dataStore2->getRoot();
   sidre_io.read( root2, "mesh.root");
+  MPI_Barrier(problem_comm);
 
 // DEBUG
     SLIC_INFO( "Here is the array data in DataStore_2:\n" );

--- a/src/axom/sidre/examples/sidre_array.cpp
+++ b/src/axom/sidre/examples/sidre_array.cpp
@@ -61,13 +61,11 @@ int main ( int argc, char** argv )
   // STEP 2: save the array data in to a file
   sidre::IOManager sidre_io( problem_comm );
   sidre_io.write( root1, nranks, "mesh", "sidre_hdf5" );
-  MPI_Barrier( problem_comm );
 
   // STEP 3: read the data from the file into a new DataStore
   sidre::DataStore* dataStore2 = new sidre::DataStore();
   sidre::Group* root2 = dataStore2->getRoot();
   sidre_io.read( root2, "mesh.root");
-  MPI_Barrier( problem_comm );
 
 // DEBUG
     SLIC_INFO( "Here is the array data in DataStore_2:\n" );

--- a/src/axom/sidre/examples/sidre_external_array.cpp
+++ b/src/axom/sidre/examples/sidre_external_array.cpp
@@ -54,7 +54,6 @@ void sidre_write( MPI_Comm comm,
   // STEP 2: save the array data in to a file
   sidre::IOManager sidre_io( comm );
   sidre_io.write( root, nranks, file, "sidre_hdf5" );
-  MPI_Barrier( comm );
 }
 
 //------------------------------------------------------------------------------
@@ -76,7 +75,6 @@ void sidre_read( MPI_Comm comm,
 
   sidre::IOManager sidre_io( comm );
   sidre_io.read( root, file );
-  MPI_Barrier( comm );
 
   SLIC_ASSERT( root->hasChildView("data") );
   sidre::View* view = root->getView( "data" );
@@ -101,7 +99,6 @@ void sidre_read( MPI_Comm comm,
 
   // load the external data
   sidre_io.loadExternalData(root,file);
-  MPI_Barrier( comm );
 
 // DEBUG
   SLIC_INFO( "Here is the data that was read back:" );

--- a/src/axom/sidre/examples/sidre_external_array.cpp
+++ b/src/axom/sidre/examples/sidre_external_array.cpp
@@ -130,7 +130,7 @@ int main ( int argc, char** argv )
 
   // STEP 1: dump the data to a file using sidre
   SLIC_INFO( "Writting data..." );
-  sidre_write( problem_comm, "mesh", data, NUM_NODES, DIMENSION );
+  sidre_write( problem_comm, "sidre_external_array_mesh", data, NUM_NODES, DIMENSION );
   SLIC_INFO( "[DONE]" );
 
   // STEP 2: read the data from a file using sidre
@@ -139,7 +139,7 @@ int main ( int argc, char** argv )
   axom::IndexType ncomp   = -1;
 
   SLIC_INFO( "Reading data..." );
-  sidre_read( problem_comm, "mesh.root", data2, ntuples, ncomp );
+  sidre_read( problem_comm, "sidre_external_array_mesh.root", data2, ntuples, ncomp );
   SLIC_INFO( "[DONE]" );
 
   // STEP 3: check the data

--- a/src/axom/sidre/spio/IOManager.cpp
+++ b/src/axom/sidre/spio/IOManager.cpp
@@ -257,10 +257,10 @@ void IOManager::write(sidre::Group* datagroup, int num_files,
   }
   (void)m_baton->pass();
 
+  MPI_Barrier(m_mpi_comm);
 #ifdef AXOM_USE_SCR
   if (m_use_scr)
   {
-    MPI_Barrier(m_mpi_comm);
     int valid = 1;
     SCR_Complete_checkpoint(valid);
   }
@@ -280,6 +280,8 @@ void IOManager::read(
   const std::string& protocol,
   bool preserve_contents)
 {
+  MPI_Barrier(m_mpi_comm);
+
   if (protocol == "sidre_hdf5")
   {
 #ifdef AXOM_USE_HDF5
@@ -331,6 +333,7 @@ void IOManager::read(sidre::Group* datagroup,
                      bool preserve_contents,
                      bool read_with_scr)
 {
+  MPI_Barrier(m_mpi_comm);
 
   if (!read_with_scr)
   {

--- a/src/axom/sidre/spio/IOManager.hpp
+++ b/src/axom/sidre/spio/IOManager.hpp
@@ -68,6 +68,8 @@ public:
    * The Group, including all of its child groups and views, is written
    * to files according to the given protocol.
    *
+   * This is an MPI collective call.
+   *
    * valid protocols:
    *
    *    sidre_hdf5
@@ -224,7 +226,11 @@ public:
                                      const std::string& mesh_path);
 
   /*!
-   * \brief read from input files
+   * \brief read from input file
+   *
+   * This is an MPI collective call.  Calling code may also need to add
+   * an MPI barrier after this call if invoking subsequent operations that
+   * may change the inpt files.
    *
    * \param group         Group to fill with input data
    * \param file_string   base name of input files
@@ -238,6 +244,10 @@ public:
 
   /*!
    * \brief read from a root file
+   *
+   * This is an MPI collective call.  Calling code may also need to add
+   * an MPI barrier after this call if invoking subsequent operations that
+   * may change the inpt files.
    *
    * \param group      Group to fill with input data
    * \param root_file  root file containing input data


### PR DESCRIPTION
# Summary

- This PR is a small bugfix.
- It does the following:
  - Fixes #203
  - Adds MPI Barrier at the end of IOManager::write() to make sure all output files are complete before any further operation.
  - Adds MPI Barrier at the beginning of IOManager::read() to make sure any previous operations that may be operating on the input files are complete before starting to read them.
