### PR TITLE
Adds mfem to vcpkg uberenv build (Windows)

### DIFF
--- a/config-build.py
+++ b/config-build.py
@@ -32,7 +32,7 @@ def extract_cmake_location(file_path):
         content = file_handle.readlines()
         for line in content:
             if line.lower().startswith(cmake_line_prefix):
-                return line.split(" ")[4].strip()
+                return line.partition(":")[2].strip()
     print("Could not find a cmake entry in host config file.\n"
           "Attempting to find cmake on your path...")
     cmake_path = distutils.spawn.find_executable("cmake")
@@ -220,6 +220,7 @@ def create_cmake_command_line(
     args, unknown_args, buildpath, hostconfigpath, installpath
 ):
     cmakeline = extract_cmake_location(hostconfigpath)
+    cmakeline = os.path.normpath(cmakeline) # Fixes path for Windows
     assert cmakeline != None, ("No cmake executable found on path")
     assert executable_exists(cmakeline), (
         "['%s'] invalid path to cmake executable or file does not have execute permissions"
@@ -242,7 +243,7 @@ def create_cmake_command_line(
         os.chmod(ccmake_file, st.st_mode | stat.S_IEXEC)
 
     # Add cache file option
-    cmakeline += " -C %s" % hostconfigpath
+    cmakeline = '"{0}" -C {1}'.format(cmakeline,hostconfigpath)
     # Add build type (opt or debug)
     cmakeline += " -DCMAKE_BUILD_TYPE=" + args.buildtype
     # Set install dir

--- a/scripts/uberenv/project.json
+++ b/scripts/uberenv/project.json
@@ -6,5 +6,6 @@
 "spack_url": "https://github.com/spack/spack",
 "spack_commit": "d98b433a3c14af5aaba03fd439f6e47cb970bac6",
 "vcpkg_url": "https://github.com/microsoft/vcpkg",
-"vcpkg_commit": "b79f7675aaa82eb6c5a96ae764fb1ce379a9d5d6"
+"vcpkg_commit": "b79f7675aaa82eb6c5a96ae764fb1ce379a9d5d6",
+"vcpkg_triplet": "x64-windows"
 }

--- a/scripts/uberenv/project.json
+++ b/scripts/uberenv/project.json
@@ -4,5 +4,7 @@
 "package_final_phase" : "hostconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack",
-"spack_commit": "d98b433a3c14af5aaba03fd439f6e47cb970bac6"
+"spack_commit": "d98b433a3c14af5aaba03fd439f6e47cb970bac6",
+"vcpkg_url": "https://github.com/microsoft/vcpkg",
+"vcpkg_commit": "b79f7675aaa82eb6c5a96ae764fb1ce379a9d5d6"
 }

--- a/scripts/uberenv/uberenv.py
+++ b/scripts/uberenv/uberenv.py
@@ -106,7 +106,7 @@ def parse_args():
 
     # for vcpkg, what architecture to target
     parser.add_option("--triplet",
-                      dest="triplet",
+                      dest="vcpkg_triplet",
                       default=None,
                       help="vcpkg architecture triplet")
 
@@ -297,9 +297,10 @@ class VcpkgEnv(UberEnv):
         UberEnv.__init__(self,opts,extra_opts)
 
         # setup architecture triplet
-        self.triplet = opts["triplet"]
-        if self.triplet is None:
-           self.triplet = os.getenv("VCPKG_DEFAULT_TRIPLET", "x86-windows")
+        self.vcpkg_triplet = self.set_from_args_or_json("vcpkg_triplet", False)
+        print("triplet: {}".format(self.vcpkg_triplet))
+        if self.vcpkg_triplet is None:
+           self.vcpkg_triplet = os.getenv("VCPKG_DEFAULT_TRIPLET", "x86-windows")
 
     def setup_paths_and_dirs(self):
         # get the current working path, and the glob used to identify the
@@ -384,14 +385,14 @@ class VcpkgEnv(UberEnv):
         
         os.chdir(self.dest_vcpkg)
         install_cmd = "vcpkg.exe "
-        install_cmd += "install {0}:{1}".format(self.pkg_name, self.triplet)
+        install_cmd += "install {0}:{1}".format(self.pkg_name, self.vcpkg_triplet)
 
         res = sexe(install_cmd, echo=True)
 
         # Running the install_cmd eventually generates the host config file,
         # which we copy to the target directory.
-        src_hc = pjoin(self.dest_vcpkg, "installed", self.triplet, "include", self.pkg_name, "hc.cmake")
-        hcfg_fname = pjoin(self.dest_dir, "{0}.{1}.cmake".format(platform.uname()[1], self.triplet))
+        src_hc = pjoin(self.dest_vcpkg, "installed", self.vcpkg_triplet, "include", self.pkg_name, "hc.cmake")
+        hcfg_fname = pjoin(self.dest_dir, "{0}.{1}.cmake".format(platform.uname()[1], self.vcpkg_triplet))
         print("[info: copying host config file to {0}]".format(hcfg_fname))
         shutil.copy(os.path.abspath(src_hc), hcfg_fname)
         print("")

--- a/scripts/uberenv/vcpkg_ports/axom/CONTROL
+++ b/scripts/uberenv/vcpkg_ports/axom/CONTROL
@@ -1,4 +1,9 @@
 Source: axom
 Version: develop
 Description: Host-config generator for Axom TPLs
-Build-Depends: hdf5, conduit
+Build-Depends: hdf5, conduit, mfem
+Default-Features: hdf5, conduit, mfem
+
+Feature: mfem
+Description: Adds basic (serial) mfem support to Axom
+Build-Depends: mfem

--- a/scripts/uberenv/vcpkg_ports/axom/portfile.cmake
+++ b/scripts/uberenv/vcpkg_ports/axom/portfile.cmake
@@ -118,6 +118,7 @@ set(ENABLE_MPI OFF CACHE BOOL "")
 #------------------------------------------------------------------------------
 set(CONDUIT_DIR "@CURRENT_INSTALLED_DIR@/share/conduit" CACHE PATH "")
 set(HDF5_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
+set(MFEM_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
 
 # TODO:
 #  * Add TPLs: mfem, umpire, raja

--- a/scripts/uberenv/vcpkg_ports/axom/portfile.cmake
+++ b/scripts/uberenv/vcpkg_ports/axom/portfile.cmake
@@ -36,45 +36,32 @@ set(_host-config_hdr [=[
 # vcpkg target triplet: @TARGET_TRIPLET@
 # vcpkg target triplet file: @TARGET_TRIPLET_FILE@
 #
-# CMake system name: @CMAKE_SYSTEM_NAME@
-# CMake system version: @CMAKE_SYSTEM_VERSION@
 # CMake executable path: @CMAKE_COMMAND@
 #------------------------------------------------------------------------------
-# Empty/useless variables:
-#   VS path: @VCPKG_VISUAL_STUDIO_PATH@
-#   VC Package root: @VCPKG_ROOT@
-#   Linkage: @VCPKG_CRT_LINKAGE@
-#   Library linkage: @VCPKG_CRT_LINKAGE@
-#   CMake system name: @VCPKG_CMAKE_SYSTEM_NAME@
-#   CMake system version: @VCPKG_CMAKE_SYSTEM_VERSION@
-#------------------------------------------------------------------------------
 # To configure the code using the vcpkg toolchain:
-#   cmake -C @_hc_file@ ../src
+#   cmake -C @_hc_file@ \
+#         -G <generator> \
+#         ../src
 #
+#   For x86 MSVC builds, use "Visual Studio 2017" as the generator
+#   For x64 MSVC builds, use "Visual Studio 2017 Win64" as the genererator
+#------------------------------------------------------------------------------
 # To build the code through the command line:
 #   cmake --build . --target ALL_BUILD --config Debug  [ -- -m:8 [-v:m] ]  
 #
 # To run tests, run either:
 #   cmake --build . --target RUN_TESTS --config Debug
 #   ctest -C Debug [-j8]
+#
+# For release builds, use 'Release' in the configuration instead of 'Debug'
 #------------------------------------------------------------------------------
 
-# On Windows, build shared libraries by default.
-set(BUILD_SHARED_LIBS ON CACHE BOOL "")
-# Static builds require some care and effort to get right.  With a static
-# build, choose one of
-#    - disable Google Test and MSVC static MD to MT (see BLT options
-#      section) or
-#    - disable one of HDF5, conduit (which uses HDF5), or sidre (which
-#      uses conduit).
-
 # Toolchain file
-set(CMAKE_TOOLCHAIN_FILE @VCPKG_ROOT_PATH@/scripts/buildsystems/vcpkg.cmake CACHE FILEPATH "")
-set(VCPKG_TARGET_TRIPLET @TARGET_TRIPLET@ CACHE STRING "")
+set(CMAKE_TOOLCHAIN_FILE "@VCPKG_ROOT_PATH@/scripts/buildsystems/vcpkg.cmake" CACHE FILEPATH "")
+set(VCPKG_TARGET_TRIPLET "@TARGET_TRIPLET@" CACHE STRING "")
 
-# Set TPLs
-set(CONDUIT_DIR @CURRENT_INSTALLED_DIR@/share/conduit CACHE PATH "")
-set(HDF5_DIR @CURRENT_INSTALLED_DIR@ CACHE PATH "")
+# CMake options
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "")
 
 # Axom options
 set(AXOM_ENABLE_TESTS ON CACHE BOOL "")
@@ -84,16 +71,35 @@ set(AXOM_ENABLE_EXAMPLES ON CACHE BOOL "")
 # BLT options
 set(ENABLE_FORTRAN OFF CACHE BOOL "")
 set(ENABLE_FOLDERS ON CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# Static vs. Dynamic builds
+#------------------------------------------------------------------------------
+# Note: Static builds require some care and effort to get right with MSVC.  
+# With a static build, choose one of
+#    - disable Google Test and MSVC static MD to MT (see BLT options
+#      section) or
+#    - disable one of HDF5, conduit (which uses HDF5), or sidre (which
+#      uses conduit).
+#------------------------------------------------------------------------------
+
+# On Windows, build shared libraries by default.
+set(BUILD_SHARED_LIBS ON CACHE BOOL "")
+
 # Toggle the following to disable gtest if you are compiling with static
 # libraries and need HDF5
 set(ENABLE_GTEST ON CACHE BOOL "")
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
 # Toggle the following to disable changing MSVC's /MD to /MT if you are
 # compiling with static libraries and need HDF5
 set(BLT_ENABLE_MSVC_STATIC_MD_TO_MT ON CACHE BOOL "")
 
+#------------------------------------------------------------------------------
 # MPI options
+#------------------------------------------------------------------------------
 set(ENABLE_MPI OFF CACHE BOOL "")
+
 # If MSMPI and no other MPI is installed, turn ENABLE_MPI ON and CMake
 # should automatically detect it.  If CMake doesn't auto-detect MSMPI,
 # or if you need to use another MPI, you will need to specify the MPI
@@ -106,10 +112,12 @@ set(ENABLE_MPI OFF CACHE BOOL "")
 # set(MPI_Fortran_COMPILER "C:/Program Files (x86)/IntelSWTools/compilers_and_libraries_2019.5.281/windows/mpi/intel64/bin/mpifc.bat" CACHE PATH "")
 # set(MPIEXEC "C:/Program Files (x86)/IntelSWTools/compilers_and_libraries_2019.5.281/windows/mpi/intel64/bin/mpiexec.exe" CACHE PATH "")
 # set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
-#
 
-# cmake options
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "")
+#------------------------------------------------------------------------------
+# Set TPLs
+#------------------------------------------------------------------------------
+set(CONDUIT_DIR "@CURRENT_INSTALLED_DIR@/share/conduit" CACHE PATH "")
+set(HDF5_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
 
 # TODO:
 #  * Add TPLs: mfem, umpire, raja

--- a/scripts/uberenv/vcpkg_ports/hdf5/xCONTROL
+++ b/scripts/uberenv/vcpkg_ports/hdf5/xCONTROL
@@ -1,5 +1,0 @@
-Source: hdf5
-Version: 1.10.5-8
-Homepage: https://www.hdfgroup.org/downloads/hdf5/
-Description: HDF5 is a data model, library, and file format for storing and managing data
-Build-Depends: zlib, szip

--- a/scripts/uberenv/vcpkg_ports/mfem/CONTROL
+++ b/scripts/uberenv/vcpkg_ports/mfem/CONTROL
@@ -1,0 +1,4 @@
+Source: mfem
+Version: v4.0
+Homepage: http://mfem.org
+Description: Lightweight, general, scalable C++ library for finite element methods

--- a/scripts/uberenv/vcpkg_ports/mfem/export-extern-vars.patch
+++ b/scripts/uberenv/vcpkg_ports/mfem/export-extern-vars.patch
@@ -1,0 +1,184 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f016de2e2..c30a400c7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -383,6 +383,13 @@ set(MFEM_INSTALL_DIR ${CMAKE_INSTALL_PREFIX} CACHE PATH
+ 
+ # Declaring the library
+ add_library(mfem ${SOURCES} ${HEADERS} ${MASTER_HEADERS})
++
++# Generate export symbols and add to list of header files
++include(GenerateExportHeader)
++set(_export_header ${CMAKE_CURRENT_SOURCE_DIR}/mfem_export.h)
++generate_export_header(mfem EXPORT_FILE_NAME ${_export_header})
++list(APPEND ${HEADERS} ${_export_header})
++
+ # message(STATUS "TPL_LIBRARIES = ${TPL_LIBRARIES}")
+ if (CMAKE_VERSION VERSION_GREATER 2.8.11)
+   target_link_libraries(mfem PUBLIC ${TPL_LIBRARIES})
+@@ -521,7 +528,7 @@ foreach(Header mfem.hpp mfem-performance.hpp)
+   install(FILES ${PROJECT_BINARY_DIR}/InstallHeaders/${Header}
+     DESTINATION ${INSTALL_INCLUDE_DIR})
+ endforeach()
+-install(FILES ${MASTER_HEADERS} DESTINATION ${INSTALL_INCLUDE_DIR}/mfem)
++install(FILES ${MASTER_HEADERS} mfem_export.h DESTINATION ${INSTALL_INCLUDE_DIR}/mfem)
+ 
+ # Install the headers; currently, the miniapps headers are excluded
+ install(DIRECTORY ${MFEM_SOURCE_DIRS}
+diff --git a/fem/fe.hpp b/fem/fe.hpp
+index b7b80c4ce..d8c8f93c4 100644
+--- a/fem/fe.hpp
++++ b/fem/fe.hpp
+@@ -13,6 +13,7 @@
+ #define MFEM_FE
+ 
+ #include "../config/config.hpp"
++#include "../mfem_export.h"
+ #include "../general/array.hpp"
+ #include "../linalg/linalg.hpp"
+ #include "intrules.hpp"
+@@ -1795,7 +1796,7 @@ public:
+    ~Poly_1D();
+ };
+ 
+-extern Poly_1D poly1d;
++MFEM_EXPORT extern Poly_1D poly1d;
+ 
+ class TensorBasisElement
+ {
+diff --git a/fem/geom.hpp b/fem/geom.hpp
+index 819814e04..e92b08043 100644
+--- a/fem/geom.hpp
++++ b/fem/geom.hpp
+@@ -13,6 +13,7 @@
+ #define MFEM_GEOM
+ 
+ #include "../config/config.hpp"
++#include "../mfem_export.h"
+ #include "../linalg/densemat.hpp"
+ #include "intrules.hpp"
+ 
+@@ -116,7 +117,7 @@ template <> struct Geometry::Constants<Geometry::POINT>
+    static const int InvOrient[NumOrient];
+ };
+ 
+-template <> struct Geometry::Constants<Geometry::SEGMENT>
++template <> struct MFEM_EXPORT Geometry::Constants<Geometry::SEGMENT>
+ {
+    static const int Dimension = 1;
+    static const int NumVert = 2;
+@@ -128,7 +129,7 @@ template <> struct Geometry::Constants<Geometry::SEGMENT>
+    static const int InvOrient[NumOrient];
+ };
+ 
+-template <> struct Geometry::Constants<Geometry::TRIANGLE>
++template <> struct MFEM_EXPORT Geometry::Constants<Geometry::TRIANGLE>
+ {
+    static const int Dimension = 2;
+    static const int NumVert = 3;
+@@ -154,7 +155,7 @@ template <> struct Geometry::Constants<Geometry::TRIANGLE>
+    static const int InvOrient[NumOrient];
+ };
+ 
+-template <> struct Geometry::Constants<Geometry::SQUARE>
++template <> struct MFEM_EXPORT Geometry::Constants<Geometry::SQUARE>
+ {
+    static const int Dimension = 2;
+    static const int NumVert = 4;
+@@ -174,7 +175,7 @@ template <> struct Geometry::Constants<Geometry::SQUARE>
+    static const int InvOrient[NumOrient];
+ };
+ 
+-template <> struct Geometry::Constants<Geometry::TETRAHEDRON>
++template <> struct MFEM_EXPORT Geometry::Constants<Geometry::TETRAHEDRON>
+ {
+    static const int Dimension = 3;
+    static const int NumVert = 4;
+@@ -192,7 +193,7 @@ template <> struct Geometry::Constants<Geometry::TETRAHEDRON>
+    };
+ };
+ 
+-template <> struct Geometry::Constants<Geometry::CUBE>
++template <> struct MFEM_EXPORT Geometry::Constants<Geometry::CUBE>
+ {
+    static const int Dimension = 3;
+    static const int NumVert = 8;
+@@ -210,7 +211,7 @@ template <> struct Geometry::Constants<Geometry::CUBE>
+    };
+ };
+ 
+-template <> struct Geometry::Constants<Geometry::PRISM>
++template <> struct MFEM_EXPORT Geometry::Constants<Geometry::PRISM>
+ {
+    static const int Dimension = 3;
+    static const int NumVert = 6;
+@@ -229,7 +230,7 @@ template <> struct Geometry::Constants<Geometry::PRISM>
+ };
+ 
+ // Defined in fe.cpp to ensure construction after 'mfem::WedgeFE'.
+-extern Geometry Geometries;
++MFEM_EXPORT extern Geometry Geometries;
+ 
+ 
+ class RefinedGeometry
+@@ -272,7 +273,7 @@ public:
+    ~GeometryRefiner();
+ };
+ 
+-extern GeometryRefiner GlobGeometryRefiner;
++MFEM_EXPORT extern GeometryRefiner GlobGeometryRefiner;
+ 
+ }
+ 
+diff --git a/fem/intrules.hpp b/fem/intrules.hpp
+index c8bd6dcdc..df759eeb7 100644
+--- a/fem/intrules.hpp
++++ b/fem/intrules.hpp
+@@ -13,6 +13,7 @@
+ #define MFEM_INTRULES
+ 
+ #include "../config/config.hpp"
++#include "../mfem_export.h"
+ #include "../general/array.hpp"
+ 
+ namespace mfem
+@@ -365,10 +366,10 @@ public:
+ };
+ 
+ /// A global object with all integration rules (defined in intrules.cpp)
+-extern IntegrationRules IntRules;
++MFEM_EXPORT extern IntegrationRules IntRules;
+ 
+ /// A global object with all refined integration rules
+-extern IntegrationRules RefinedIntRules;
++MFEM_EXPORT extern IntegrationRules RefinedIntRules;
+ 
+ }
+ 
+diff --git a/general/globals.hpp b/general/globals.hpp
+index 076ab579c..b32c624b3 100644
+--- a/general/globals.hpp
++++ b/general/globals.hpp
+@@ -13,6 +13,7 @@
+ #define MFEM_GLOBALS_HPP
+ 
+ #include "../config/config.hpp"
++#include "../mfem_export.h"
+ #include <iostream>
+ 
+ #ifdef MFEM_USE_MPI
+@@ -61,12 +62,12 @@ public:
+ /** @brief Global stream used by the library for standard output. Initially it
+     uses the same std::streambuf as std::cout, however that can be changed.
+     @sa OutStream. */
+-extern OutStream out;
++extern MFEM_EXPORT OutStream out;
+ /** @brief Global stream used by the library for standard error output.
+     Initially it uses the same std::streambuf as std::cerr, however that can be
+     changed.
+     @sa OutStream. */
+-extern OutStream err;
++extern MFEM_EXPORT OutStream err;
+ 
+ 
+ /** @brief Construct a string of the form "<prefix><myid><suffix>" where the

--- a/scripts/uberenv/vcpkg_ports/mfem/portfile.cmake
+++ b/scripts/uberenv/vcpkg_ports/mfem/portfile.cmake
@@ -1,0 +1,80 @@
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    message(FATAL_ERROR "${PORT} does not currently support UWP")
+endif()
+
+include(vcpkg_common_functions)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mfem/mfem
+    REF v4.0
+    SHA512 c1ef3ba4369a5d2a28c3bcf26f07798f9d4d4903549c884feae88f52ed7ec0bbc1ad23ed325cf2bfed4a8dacb08ecea23ed9702d603526fb9777f3c518fda3a1
+    HEAD_REF master
+    PATCHES
+        "./export-extern-vars.patch"        
+)
+
+set(_is_shared TRUE)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(_is_shared FALSE)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS 
+        -DMFEM_ENABLE_EXAMPLES=OFF
+        -DMFEM_ENABLE_MINIAPPS=OFF
+        -DMFEM_ENABLE_TESTING=OFF
+        -DBUILD_SHARED_LIBS=${_is_shared}
+        -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=${_is_shared}
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake)
+vcpkg_copy_pdbs()
+
+
+## shuffle the output directories to make vcpkg happy
+# Remove extraneous debug header files
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Move CMake config files up a directory
+set(_config_dir "${CURRENT_PACKAGES_DIR}/share/mfem")
+file(GLOB _cmake_files "${_config_dir}/mfem/*.cmake")
+foreach(_f ${_cmake_files})
+    get_filename_component(_name ${_f} NAME)
+    file(RENAME ${_f} ${_config_dir}/${_name})
+endforeach()
+file(REMOVE_RECURSE "${_config_dir}/mfem")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    # Note: Not tested
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+else()
+    # Move dll files from lib to bin directory
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/bin )
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug/bin )
+
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/mfem.dll
+                ${CURRENT_PACKAGES_DIR}/bin/mfem.dll)
+
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/mfem.dll
+                ${CURRENT_PACKAGES_DIR}/debug/bin/mfem.dll)
+
+    # Update paths to dlls in CMake config files
+    foreach(_c  debug release)
+        set(_f ${_config_dir}/MFEMTargets-${_c}.cmake)
+        file(READ ${_f} _fdata)
+        string(REPLACE "lib/mfem.dll" "bin/mfem.dll" _fdata "${_fdata}")
+        file(WRITE  ${_f} "${_fdata}")
+    endforeach()
+endif()
+
+
+# Put the license file where vcpkg expects it
+file(INSTALL     ${SOURCE_PATH}/LICENSE 
+     DESTINATION ${CURRENT_PACKAGES_DIR}/share/mfem 
+     RENAME      copyright)
+
+

--- a/src/axom/CMakeLists.txt
+++ b/src/axom/CMakeLists.txt
@@ -60,3 +60,21 @@ else()
     message(STATUS "AXOM_DATA_DIR: <undefined>")
 endif()
 
+#------------------------------------------------------------------------------
+# Fix FOLDER property for some targets
+#------------------------------------------------------------------------------
+if(TARGET axom)
+    set_target_properties(axom PROPERTIES FOLDER "axom")
+endif()
+
+# If Axom is the main project, set FOLDER property for top-level check targets
+if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
+    set(_code_check_targets "docs" "doxygen_docs"
+                            "check" "style" 
+                            "uncrustify_check" "uncrustify_style" )
+    foreach(_tgt ${_code_check_targets})
+        if(TARGET ${_tgt})
+            set_target_properties(${_tgt} PROPERTIES FOLDER "axom/code_checks")
+        endif()
+    endforeach()
+endif()

--- a/src/axom/quest/tests/CMakeLists.txt
+++ b/src/axom/quest/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ if(MFEM_FOUND)
         SOURCES ${test_name}.cpp
         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
         DEPENDS_ON ${quest_tests_depends} mfem core
+        FOLDER axom/quest/tests
         )
 
     string(STRIP "${AXOM_DISABLE_UNUSED_PARAMETER_WARNINGS}" MFEM_COMPILE_FLAGS)

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -57,6 +57,14 @@ macro(axom_add_code_checks)
         blt_add_code_checks(PREFIX    ${arg_PREFIX}
                             SOURCES   ${_sources}
                             UNCRUSTIFY_CFG_FILE ${PROJECT_SOURCE_DIR}/uncrustify.cfg)
+
+        # Set FOLDER property for code check targets
+        foreach(_suffix uncrustify_check uncrustify_style)
+            set(_tgt ${arg_PREFIX}_${_suffix})
+            if(TARGET ${_tgt}) 
+                set_target_properties(${_tgt} PROPERTIES FOLDER "axom/code_checks")
+            endif()
+        endforeach()
     endif()
 
 endmacro(axom_add_code_checks)

--- a/src/cmake/thirdparty/FindMFEM.cmake
+++ b/src/cmake/thirdparty/FindMFEM.cmake
@@ -15,12 +15,26 @@ if (NOT MFEM_DIR)
   message(FATAL_ERROR "Cannot find MFEM. MFEM_DIR is not defined. ")
 endif()
 
-if(EXISTS "${MFEM_DIR}/MFEMConfig.cmake")
-    include("${MFEM_DIR}/MFEMConfig.cmake")
+# Using the CMake build system on Windows, and make-based system otherwise
+set(_use_mfem_config FALSE)
+if(WIN32)
+    set(_use_mfem_config TRUE)
+endif()
+
+if(_use_mfem_config)
+    # Allow for several different configurations of MFEM
+    find_package(mfem CONFIG 
+        REQUIRED
+        HINTS ${MFEM_DIR}/cmake/mfem 
+              ${MFEM_DIR}/lib/cmake/mfem
+              ${MFEM_DIR}/share/cmake/mfem
+              ${MFEM_DIR}/share/mfem
+              ${MFEM_DIR}/mfem)
+
     if(NOT MEFM_LIBRARY)
        set(MFEM_LIBRARY ${MFEM_LIBRARIES})
     endif()
-    
+
 else()
 
     find_path( MFEM_INCLUDE_DIRS mfem.hpp


### PR DESCRIPTION
# Summary

- This PR improves support for `axom` builds on Windows through `uberenv`
- It adds `mfem` to the windows build. This includes a patch to label some `mfem` variables as `dllimport`/`dllexport`
- It also improves support for our `config-build` script on windows by handling paths to `CMake` that have spaces in them (e.g. ``C:\Program Files\cmake\...``)
