### PR TITLE
Resolve out-of-space issue in azure pipelines CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,7 @@ pool:
 
 steps:
 - checkout: self
-  clean: boolean
+  clean: true
   submodules: recursive
 - task: CMake@1
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,3 +103,6 @@ steps:
     testResultsFiles: '**/Test.xml'
     testRunTitle: '$(TEST_TARGET) Tests'
     failTaskOnFailedTests: true
+
+workspace:
+  clean: outputs


### PR DESCRIPTION
# Summary

- Attempt to resolve 'out-of-space' issue in azure pipelines CI (#214)
- Sets 'clean' step to 'true' in azure-pipelines
