### PR TITLE
Fix missing bvh_traverse.hpp header from install prefix

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -29,6 +29,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   integer ID associated with the allocator.
 
 ### Fixed
+- Fixed issue with missing the bvh_traverse.hpp from the install prefix, which was preventing
+  applications from using the BVH when pointing to an Axom install prefix.
 - Fixed usage of cuda kernel policies in Mint. Raja v0.11.0 changed the way max threads
   launch bounds is calculated. Consequently, a large number of threads was being launched
   leading to max registry count violation when linking. We are now using fixed kernel size

--- a/src/axom/spin/CMakeLists.txt
+++ b/src/axom/spin/CMakeLists.txt
@@ -51,6 +51,7 @@ if ( RAJA_FOUND AND UMPIRE_FOUND )
        internal/linear_bvh/TraversalPredicates.hpp
        internal/linear_bvh/aabb.hpp
        internal/linear_bvh/build_radix_tree.hpp
+       internal/linear_bvh/bvh_traverse.hpp
        internal/linear_bvh/bvh_vtkio.hpp
        internal/linear_bvh/emit_bvh.hpp
        internal/linear_bvh/math.hpp


### PR DESCRIPTION
# Summary

The internal header, bvh_traverse.hpp, was not
listed in CMakeLists and therefore, it was not
being installed in the specified install prefix.
Consequently, an application using
the BVH and pointing to an Axom install
prefix would result in a "cannot open include"
compiler error. Fixed that.
