### PR TITLE
Fix dispatch when using asynchronous CUDA execution policies with the BVH

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -51,6 +51,10 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   ex. `level_error` is now `message_error`.
 
 ### Fixed
+- Fixed issue where the BVH would dispatch to the CPU sort() routine when the
+  specified execution policy was CUDA_EXEC async. Now, when the execution policy
+  is CUDA_EXEC the code would correctly dispatch to the GPU sort, using CUB
+  (when CUB is enabled), regardless of whether it's synchronous or asynchronous.
 - Fixed issue with missing the bvh_traverse.hpp from the install prefix, which was preventing
   applications from using the BVH when pointing to an Axom install prefix.
 - Fixed usage of cuda kernel policies in Mint. Raja v0.11.0 changed the way max threads

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -403,13 +403,13 @@ void custom_sort( ExecSpace, uint32*& mcodes, int32 size, int32* iter )
 //------------------------------------------------------------------------------
 #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA) && \
   defined(RAJA_ENABLE_CUDA) && defined(AXOM_USE_CUB)
-template < int BLOCK_SIZE >
-void custom_sort( axom::CUDA_EXEC< BLOCK_SIZE >,
+template < int BLOCK_SIZE, axom::ExecutionMode EXEC_MODE >
+void custom_sort( axom::CUDA_EXEC< BLOCK_SIZE, EXEC_MODE >,
                   uint32*& mcodes, int32 size, int32* iter )
 {
   AXOM_PERF_MARK_FUNCTION( "custom_sort" );
 
-  using ExecSpace = typename axom::CUDA_EXEC< BLOCK_SIZE >;
+  using ExecSpace = typename axom::CUDA_EXEC< BLOCK_SIZE, EXEC_MODE >;
   array_counting< ExecSpace >(iter, size, 0, 1);
 
   AXOM_PERF_MARK_SECTION( "gpu_cub_sort",


### PR DESCRIPTION
# Summary

This commit fixes an issue with the template specialization of the `custom_sort()` routine, used internally by the BVH to sort the AABBs, which would dispatch to the CPU sort(), when a CUDA async execution policy is used, i.e., `axom::CUDA_EXEC< BLOCKSIZE, axom::ASYNC >`. Now, the code will correctly dispatch to the GPU sort when a CUDA execution policy is specified irrespective of whether it is synchronous or asynchronous.

Resolves #230 
