### PR TITLE
Fix issue with making consecutive calls to Quest's Signed Distance query when MPI-3 shared memory is employed

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -60,6 +60,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   ex. `level_error` is now `message_error`.
 
 ### Fixed
+- Fixed issue in Quest's Signed Distance query that would prevent consecutive
+  calls to Quest when MPI-3 shared memory is enabled due to not properly 
+  nullifying internal pointers when finalize is called.
 - Fixed issue where the BVH would dispatch to the CPU sort() routine when the
   specified execution policy was CUDA_EXEC async. Now, when the execution policy
   is CUDA_EXEC the code would correctly dispatch to the GPU sort, using CUB

--- a/src/axom/quest/interface/signed_distance.cpp
+++ b/src/axom/quest/interface/signed_distance.cpp
@@ -314,6 +314,7 @@ void signed_distance_finalize( )
 #if defined(AXOM_USE_MPI) && defined(AXOM_USE_MPI3)
   internal::mpi_comm_free( &s_intra_node_comm );
   internal::mpi_win_free( &s_window );
+  s_shared_mesh_buffer = nullptr;
 #endif
 
 }

--- a/src/axom/quest/tests/quest_signed_distance.cpp
+++ b/src/axom/quest/tests/quest_signed_distance.cpp
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+#include "axom/config.hpp"
 #include "axom/slic/interface/slic.hpp"
 #include "axom/slic/core/UnitTestLogger.hpp"
 using axom::slic::UnitTestLogger;

--- a/src/axom/quest/tests/quest_signed_distance_interface.cpp
+++ b/src/axom/quest/tests/quest_signed_distance_interface.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 // Axom utils
+#include "axom/config.hpp"                      // axom compile-time definitions
 #include "axom/core/utilities/Utilities.hpp"
 
 // Mint includes
@@ -429,6 +430,15 @@ TEST( quest_signed_distance_interface, analytic_plane )
   check_analytic_plane( true );
 #endif
 }
+
+//------------------------------------------------------------------------------
+#if defined( AXOM_USE_MPI ) && defined ( AXOM_USE_MPI3 )
+TEST( quest_signed_distance_interface, call_twice_using_shared_memory )
+{
+  check_analytic_plane( true );
+  check_analytic_plane( true );
+}
+#endif
 
 //------------------------------------------------------------------------------
 TEST( quest_signed_distance_interface, analytic_sphere )

--- a/src/axom/quest/tests/quest_signed_distance_interface.cpp
+++ b/src/axom/quest/tests/quest_signed_distance_interface.cpp
@@ -64,6 +64,8 @@ const char IGNORE_OUTPUT[] = ".*";
 namespace
 {
 
+constexpr bool USE_MPI3_SHARED_MEMORY = true;
+
 /*!
  * \brief Generate a mesh of 4 triangles along the XY plane.
  *
@@ -427,7 +429,7 @@ TEST( quest_signed_distance_interface, analytic_plane )
   check_analytic_plane( );
 
 #if defined( AXOM_USE_MPI ) && defined( AXOM_USE_MPI3 )
-  check_analytic_plane( true );
+  check_analytic_plane( USE_MPI3_SHARED_MEMORY );
 #endif
 }
 
@@ -435,8 +437,8 @@ TEST( quest_signed_distance_interface, analytic_plane )
 #if defined( AXOM_USE_MPI ) && defined ( AXOM_USE_MPI3 )
 TEST( quest_signed_distance_interface, call_twice_using_shared_memory )
 {
-  check_analytic_plane( true );
-  check_analytic_plane( true );
+  check_analytic_plane( USE_MPI3_SHARED_MEMORY );
+  check_analytic_plane( USE_MPI3_SHARED_MEMORY );
 }
 #endif
 


### PR DESCRIPTION
# Summary

Fixes an issue that prevents consecutive calls to Quest's Signed Distance query, when MPI-3 Shared memory is employed , due to not properly nullifying internal pointers when finalize() is
called.

This resolves #220 