### PR TITLE
Fix build issue with Clang9 and CUDA-10.2 on rzansel

### DIFF
--- a/src/axom/quest/tests/quest_signed_distance_interface.cpp
+++ b/src/axom/quest/tests/quest_signed_distance_interface.cpp
@@ -64,7 +64,9 @@ const char IGNORE_OUTPUT[] = ".*";
 namespace
 {
 
+#if defined( AXOM_USE_MPI ) && defined( AXOM_USE_MPI3 )
 constexpr bool USE_MPI3_SHARED_MEMORY = true;
+#endif
 
 /*!
  * \brief Generate a mesh of 4 triangles along the XY plane.

--- a/src/axom/spin/OctreeLevel.hpp
+++ b/src/axom/spin/OctreeLevel.hpp
@@ -210,7 +210,8 @@ public:
       >
   {
 public:
-    using iter = BlockIterator<OctreeLevel, IterHelper, DataType>;
+    using GridPt = typename OctreeLevel::GridPt; 
+    using iter   = BlockIterator< OctreeLevel, IterHelper, DataType>;
 
     BlockIterator(OctreeLevel* octLevel, bool begin = false)
       : m_octLevel(octLevel)


### PR DESCRIPTION
# Summary

This PR fixes a compilation issue encountered when building Axom-v0.3.3 on rzansel using Clan9 and CUDA-10.2 toolchain. 