### PR TITLE
Make rank 0 find protocol string in root file, broadcast to all ranks

### DIFF
--- a/src/axom/sidre/spio/IOManager.cpp
+++ b/src/axom/sidre/spio/IOManager.cpp
@@ -639,7 +639,7 @@ std::string IOManager::getProtocol(
     H5E_auto2_t herr_func;
     void* old_client_data;
     H5Eget_auto(H5E_DEFAULT, &herr_func, &old_client_data);
-    H5Eset_auto(H5E_DEFAULT, NULL, NULL);
+    H5Eset_auto(H5E_DEFAULT, nullptr, nullptr);
 
     hid_t file_id = H5Fopen(root_name.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
     if (file_id > 0)

--- a/src/axom/sidre/spio/IOManager.cpp
+++ b/src/axom/sidre/spio/IOManager.cpp
@@ -626,33 +626,35 @@ std::string IOManager::getProtocol(
                  "The root file name should always end in 'root'."
                  << " File name was '"<< root_name <<"'");
 
-  std::string relay_protocol = "json";
-#ifdef AXOM_USE_HDF5
-  // Attempt to open the root file using HDF5.  If it succeeds, set
-  // relay_protocol to "hdf5", otherwise we assume a json protocol.
-  //
-  // Suppress error output for H5Fopen, since failure is acceptable here.
-  H5E_auto2_t herr_func;
-  void* old_client_data;
-  H5Eget_auto(H5E_DEFAULT, &herr_func, &old_client_data);
-  H5Eset_auto(H5E_DEFAULT, NULL, NULL);
-
-  hid_t file_id = H5Fopen(root_name.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
-  if (file_id > 0)
-  {
-    relay_protocol = "hdf5";
-    herr_t errv = H5Fclose(file_id);
-    AXOM_DEBUG_VAR(errv);
-    SLIC_ASSERT(errv >= 0);
-  }
-
-  // Restore error output
-  H5Eset_auto(H5E_DEFAULT, herr_func, old_client_data);
-#endif
-
-  std::string protocol;
+  std::string protocol; 
   if (m_my_rank == 0)
   {
+    std::string relay_protocol = "json";
+#ifdef AXOM_USE_HDF5
+    // Attempt to open the root file using HDF5.  If it succeeds, set
+    // relay_protocol to "hdf5", otherwise we assume a json protocol.
+    //
+    // Suppress error output for H5Fopen, since failure is acceptable here.
+
+    H5E_auto2_t herr_func;
+    void* old_client_data;
+    H5Eget_auto(H5E_DEFAULT, &herr_func, &old_client_data);
+    H5Eset_auto(H5E_DEFAULT, NULL, NULL);
+
+    hid_t file_id = H5Fopen(root_name.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+    if (file_id > 0)
+    {
+      relay_protocol = "hdf5";
+      herr_t errv = H5Fclose(file_id);
+      AXOM_DEBUG_VAR(errv);
+      SLIC_ASSERT(errv >= 0);
+    }
+
+    // Restore error output
+    H5Eset_auto(H5E_DEFAULT, herr_func, old_client_data);
+ 
+#endif
+
     conduit::Node n;
     conduit::relay::io::load(root_name, relay_protocol, n);
 


### PR DESCRIPTION
# Summary

- This PR is a small refactoring, possible bugfix.
- It does the following (modify list as needed):
  - Modifies IOManager's reading of I/O protocol string from the root file to only occur on rank 0 and then broadcast it to all ranks.  This is motivated by discussions with SCR team who pointed out that for best use of SCR features, the restarts need to have the rank that wrote a file be the one to read it.  Since rank 0 writes the root file, it needs to be the rank that reads it as well, and then any information needed by other ranks can be sent through MPI calls.

Most of the root file parsing in IO Manager already operates in this way, so this gets this operation in line with the rest of the class and is a cleaner way to do this, with or without SCR.