### PR TITLE
BUGFIX: add ItemCollection.hpp to header list

### DIFF
--- a/src/axom/sidre/CMakeLists.txt
+++ b/src/axom/sidre/CMakeLists.txt
@@ -26,6 +26,7 @@ set(sidre_headers
     core/View.hpp
     core/Attribute.hpp
     core/AttrValues.hpp
+    core/ItemCollection.hpp
     core/Iterator.hpp
     core/ListCollection.hpp
     core/MapCollection.hpp


### PR DESCRIPTION
# Summary

Add ItemCollection.hpp to the list of headers so that
it gets installed to the install prefix.

