### PR TITLE
Fix issue when no fortran is defined

### DIFF
--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@10.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@10.0.0.cmake
@@ -30,7 +30,7 @@ set(BLT_EXE_LINKER_FLAGS " -Wl,-rpath,/usr/tce/packages/clang/clang-10.0.0/lib" 
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_16_18_15_18/clang-10.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_19_12_14_54/clang-10.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@9.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@9.0.0.cmake
@@ -30,7 +30,7 @@ set(BLT_EXE_LINKER_FLAGS " -Wl,-rpath,/usr/tce/packages/clang/clang-9.0.0/lib" C
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_16_18_15_18/clang-9.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_19_12_14_54/clang-9.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran" CACHE 
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_16_18_15_18/gcc-8.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_19_12_14_54/gcc-8.1.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0_no_fortran.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0_no_fortran.cmake
@@ -1,0 +1,84 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# SYS_TYPE: toss_3_x86_64_ib
+# Compiler Spec: gcc@8.1.0_no_fortran
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc" CACHE PATH "")
+
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/g++" CACHE PATH "")
+
+set(ENABLE_FORTRAN OFF CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_18_22_06_39/gcc-8.1.0_no_fortran" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+# SCR not built
+
+set(RAJA_DIR "${TPL_ROOT}/raja-0.11.0" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2.1.0" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0/bin/mpicxx" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# Root directory for generated developer tools
+set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_05_04_17_39_29/gcc-8.1.0" CACHE PATH "")
+
+set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
+
+set(ENABLE_DOCS ON CACHE BOOL "")
+
+set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.14/bin/doxygen" CACHE PATH "")
+
+set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/sphinx-build" CACHE PATH "")
+
+set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/shroud" CACHE PATH "")
+
+set(UNCRUSTIFY_EXECUTABLE "${DEVTOOLS_ROOT}/uncrustify-0.61/bin/uncrustify" CACHE PATH "")
+
+set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@no_fortran.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@no_fortran.cmake
@@ -2,7 +2,7 @@
 # !!!! This is a generated file, edit at own risk !!!!
 #------------------------------------------------------------------------------
 # SYS_TYPE: toss_3_x86_64_ib
-# Compiler Spec: gcc@8.1.0_no_fortran
+# Compiler Spec: gcc@no_fortran
 #------------------------------------------------------------------------------
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
 #------------------------------------------------------------------------------
@@ -22,7 +22,7 @@ set(ENABLE_FORTRAN OFF CACHE BOOL "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_18_22_06_39/gcc-8.1.0_no_fortran" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_19_12_14_54/gcc-no_fortran" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@18.0.2.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@18.0.2.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-18.0.2/bin/ifort" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_16_18_15_18/intel-18.0.2" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_19_12_14_54/intel-18.0.2" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.4.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.4.cmake
@@ -30,7 +30,7 @@ set(CMAKE_Fortran_FLAGS "-gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_16_18_15_18/intel-19.0.4" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_19_12_14_54/intel-19.0.4" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 

--- a/scripts/uberenv/packages/axom/package.py
+++ b/scripts/uberenv/packages/axom/package.py
@@ -231,7 +231,9 @@ class Axom(CMakePackage, CudaPackage):
         if fflags:
             cfg.write(cmake_cache_entry("CMAKE_Fortran_FLAGS", fflags))
 
-        if ("gfortran" in f_compiler) and ("clang" in cpp_compiler):
+        if ((f_compiler is not None)
+           and ("gfortran" in f_compiler)
+           and ("clang" in cpp_compiler)):
             libdir = pjoin(os.path.dirname(
                            os.path.dirname(cpp_compiler)), "lib")
             flags = ""

--- a/scripts/uberenv/packages/axom/package.py
+++ b/scripts/uberenv/packages/axom/package.py
@@ -446,7 +446,7 @@ class Axom(CMakePackage, CudaPackage):
 
         # Override XL compiler family
         familymsg = ("Override to proper compiler family for XL")
-        if "xlf" in f_compiler:
+        if (f_compiler is not None) and ("xlf" in f_compiler):
             cfg.write(cmake_cache_entry("CMAKE_Fortran_COMPILER_ID", "XL",
                                         familymsg))
         if "xlc" in c_compiler:
@@ -457,7 +457,7 @@ class Axom(CMakePackage, CudaPackage):
                                         familymsg))
 
         if spec.satisfies('target=ppc64le:'):
-            if "xlf" in f_compiler:
+            if (f_compiler is not None) and ("xlf" in f_compiler):
                 description = ("Converts C-style comments to Fortran style "
                                "in preprocessed files")
                 cfg.write(cmake_cache_entry("BLT_FORTRAN_FLAGS",

--- a/scripts/uberenv/packages/conduit/package.py
+++ b/scripts/uberenv/packages/conduit/package.py
@@ -371,7 +371,9 @@ class Conduit(Package):
         if fflags:
             cfg.write(cmake_cache_entry("CMAKE_Fortran_FLAGS", fflags))
 
-        if ("gfortran" in f_compiler) and ("clang" in cpp_compiler):
+        if ((f_compiler is not None)
+           and ("gfortran" in f_compiler)
+           and ("clang" in cpp_compiler)):
             libdir = os.path.join(os.path.dirname(
                                   os.path.dirname(f_compiler)), "lib")
             flags = ""

--- a/scripts/uberenv/spack_configs/toss_3_x86_64_ib/compilers.yaml
+++ b/scripts/uberenv/spack_configs/toss_3_x86_64_ib/compilers.yaml
@@ -51,6 +51,17 @@ compilers:
     modules: []
     operating_system: rhel7
     paths:
+      cc:  /usr/tce/packages/gcc/gcc-8.1.0/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-8.1.0/bin/g++
+    spec: gcc@8.1.0_no_fortran
+    target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: rhel7
+    paths:
       cc:  /usr/tce/packages/intel/intel-18.0.2/bin/icc
       cxx: /usr/tce/packages/intel/intel-18.0.2/bin/icpc
       f77: /usr/tce/packages/intel/intel-18.0.2/bin/ifort

--- a/scripts/uberenv/spack_configs/toss_3_x86_64_ib/compilers.yaml
+++ b/scripts/uberenv/spack_configs/toss_3_x86_64_ib/compilers.yaml
@@ -55,7 +55,7 @@ compilers:
       cxx: /usr/tce/packages/gcc/gcc-8.1.0/bin/g++
       f77:
       fc:
-    spec: gcc@8.1.0_no_fortran
+    spec: gcc@no_fortran
     target: x86_64
 - compiler:
     environment: {}

--- a/scripts/uberenv/spack_configs/toss_3_x86_64_ib/compilers.yaml
+++ b/scripts/uberenv/spack_configs/toss_3_x86_64_ib/compilers.yaml
@@ -53,6 +53,8 @@ compilers:
     paths:
       cc:  /usr/tce/packages/gcc/gcc-8.1.0/bin/gcc
       cxx: /usr/tce/packages/gcc/gcc-8.1.0/bin/g++
+      f77:
+      fc:
     spec: gcc@8.1.0_no_fortran
     target: x86_64
 - compiler:

--- a/scripts/uberenv/spack_configs/toss_3_x86_64_ib/packages.yaml
+++ b/scripts/uberenv/spack_configs/toss_3_x86_64_ib/packages.yaml
@@ -37,6 +37,7 @@ packages:
       mvapich2@2.3%clang@9.0.0 process_managers=slurm arch=linux-rhel7-ivybridge: /usr/tce/packages/mvapich2/mvapich2-2.3-clang-9.0.0
       mvapich2@2.3%clang@10.0.0 process_managers=slurm arch=linux-rhel7-ivybridge: /usr/tce/packages/mvapich2/mvapich2-2.3-clang-10.0.0
       mvapich2@2.3%gcc@8.1.0 process_managers=slurm arch=linux-rhel7-ivybridge: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0
+      mvapich2@2.3%gcc@8.1.0_no_fortran process_managers=slurm arch=linux-rhel7-ivybridge: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0
       mvapich2@2.3%intel@18.0.2 process_managers=slurm arch=linux-rhel7-ivybridge: /usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.2
       mvapich2@2.3%intel@19.0.4 process_managers=slurm arch=linux-rhel7-ivybridge: /usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.0
     buildable: False

--- a/scripts/uberenv/specs.json
+++ b/scripts/uberenv/specs.json
@@ -17,6 +17,7 @@
     [ "clang@9.0.0+devtools+mfem",
       "clang@10.0.0+devtools+mfem",
       "gcc@8.1.0+devtools+mfem",
+      "gcc@8.1.0_no_fortran~fortran+devtools+mfem",
       "intel@18.0.2+devtools+mfem",
       "intel@19.0.4+devtools+mfem" ],
 

--- a/scripts/uberenv/specs.json
+++ b/scripts/uberenv/specs.json
@@ -17,7 +17,7 @@
     [ "clang@9.0.0+devtools+mfem",
       "clang@10.0.0+devtools+mfem",
       "gcc@8.1.0+devtools+mfem",
-      "gcc@8.1.0_no_fortran~fortran+devtools+mfem",
+      "gcc@no_fortran~fortran+devtools+mfem",
       "intel@18.0.2+devtools+mfem",
       "intel@19.0.4+devtools+mfem" ],
 


### PR DESCRIPTION
I added "no fortran" spec so this doesn't happen again

This issue was brought up by a Spack user. This is probably the second or third time not testing against a spec that didn't have fortran has come up.