### PR TITLE
Bugfix/improvement for triangle-triangle intersect

### DIFF
--- a/src/axom/primal/operators/detail/intersect_impl.cpp
+++ b/src/axom/primal/operators/detail/intersect_impl.cpp
@@ -19,78 +19,90 @@ bool intersectOnePermutedTriangle(
   const Point3 &p1, const Point3 &q1, const Point3 &r1,
   const Point3 &p2, const Point3 &q2, const Point3 &r2,
   double dp2, double dq2, double dr2,  Vector3 &normal,
-  bool includeBoundary)
+  bool includeBoundary, double EPS)
 {
   /* Step 4: repeat Step 3, except doing it for triangle 2
      instead of triangle 1 */
-  if (isGt(dp2, 0.0))
+  if (isGt(dp2, 0.0, EPS))
   {
-    if (isGt(dq2, 0.0))
+    if (isGt(dq2, 0.0, EPS))
     {
-      return intersectTwoPermutedTriangles(p1,r1,q1,r2,p2,q2,includeBoundary);
+      return intersectTwoPermutedTriangles(p1,r1,q1,r2,p2,q2,includeBoundary,
+                                           EPS);
     }
-    else if (isGt(dr2, 0.0))
+    else if (isGt(dr2, 0.0, EPS))
     {
-      return intersectTwoPermutedTriangles(p1,r1,q1,q2,r2,p2,includeBoundary);
+      return intersectTwoPermutedTriangles(p1,r1,q1,q2,r2,p2,includeBoundary,
+                                           EPS);
     }
     else
     {
-      return intersectTwoPermutedTriangles(p1,q1,r1,p2,q2,r2,includeBoundary);
+      return intersectTwoPermutedTriangles(p1,q1,r1,p2,q2,r2,includeBoundary,
+                                           EPS);
     }
   }
-  else if (isLt(dp2,  0.0))
+  else if (isLt(dp2,  0.0, EPS))
   {
-    if (isLt(dq2, 0.0))
+    if (isLt(dq2, 0.0, EPS))
     {
-      return intersectTwoPermutedTriangles(p1,q1,r1,r2,p2,q2,includeBoundary);
+      return intersectTwoPermutedTriangles(p1,q1,r1,r2,p2,q2,includeBoundary,
+                                           EPS);
     }
-    else if (isLt(dr2, 0.0))
+    else if (isLt(dr2, 0.0, EPS))
     {
-      return intersectTwoPermutedTriangles(p1,q1,r1,q2,r2,p2,includeBoundary);
+      return intersectTwoPermutedTriangles(p1,q1,r1,q2,r2,p2,includeBoundary,
+                                           EPS);
     }
     else
     {
-      return intersectTwoPermutedTriangles(p1,r1,q1,p2,q2,r2,includeBoundary);
+      return intersectTwoPermutedTriangles(p1,r1,q1,p2,q2,r2,includeBoundary,
+                                           EPS);
     }
   }
   else
   {
-    if (isLt(dq2, 0.0))
+    if (isLt(dq2, 0.0, EPS))
     {
-      if (isGeq(dr2, 0.0))
+      if (isGeq(dr2, 0.0, EPS))
       {
-        return intersectTwoPermutedTriangles(p1,r1,q1,q2,r2,p2,includeBoundary);
+        return intersectTwoPermutedTriangles(p1,r1,q1,q2,r2,p2,includeBoundary,
+                                             EPS);
       }
       else
       {
-        return intersectTwoPermutedTriangles(p1,q1,r1,p2,q2,r2,includeBoundary);
+        return intersectTwoPermutedTriangles(p1,q1,r1,p2,q2,r2,includeBoundary,
+                                             EPS);
       }
     }
-    else if (isGt(dq2, 0.0))
+    else if (isGt(dq2, 0.0, EPS))
     {
-      if (isGt(dr2, 0.0))
+      if (isGt(dr2, 0.0, EPS))
       {
-        return intersectTwoPermutedTriangles(p1,r1,q1,p2,q2,r2,includeBoundary);
+        return intersectTwoPermutedTriangles(p1,r1,q1,p2,q2,r2,includeBoundary,
+                                             EPS);
       }
       else
       {
-        return intersectTwoPermutedTriangles(p1,q1,r1,q2,r2,p2,includeBoundary);
+        return intersectTwoPermutedTriangles(p1,q1,r1,q2,r2,p2,includeBoundary,
+                                             EPS);
       }
     }
     else
     {
-      if (isGt(dr2, 0.0))
+      if (isGt(dr2, 0.0, EPS))
       {
-        return intersectTwoPermutedTriangles(p1,q1,r1,r2,p2,q2,includeBoundary);
+        return intersectTwoPermutedTriangles(p1,q1,r1,r2,p2,q2,includeBoundary,
+                                             EPS);
       }
-      else if (isLt(dr2, 0.0))
+      else if (isLt(dr2, 0.0, EPS))
       {
-        return intersectTwoPermutedTriangles(p1,r1,q1,r2,p2,q2,includeBoundary);
+        return intersectTwoPermutedTriangles(p1,r1,q1,r2,p2,q2,includeBoundary,
+                                             EPS);
       }
       else
       {
         return intersectCoplanar3DTriangles(p1,q1,r1,p2,q2,r2,normal,
-                                            includeBoundary);
+                                            includeBoundary, EPS);
       }
     }
   }
@@ -104,7 +116,8 @@ bool intersectCoplanar3DTriangles(const Point3& p1,
                                   const Point3& q2,
                                   const Point3& r2,
                                   Vector3 normal,
-                                  bool includeBoundary)
+                                  bool includeBoundary,
+                                  double EPS)
 {
   /* Co-planar triangles are projected onto the axis that maximizes their
      area and the 2d intersection used to check if they intersect.
@@ -116,7 +129,7 @@ bool intersectCoplanar3DTriangles(const Point3& p1,
     normal[i] = std::abs(normal[i]);
   }
 
-  if ((isGt(normal[0], normal[2])) && (isGeq(normal[0], normal[1])))
+  if ((isGt(normal[0], normal[2], EPS)) && (isGeq(normal[0], normal[1], EPS)))
   {
     //if x projection area greatest, project on YZ and return 2D checker
 
@@ -128,9 +141,9 @@ bool intersectCoplanar3DTriangles(const Point3& p1,
                                        Point2::make_point(p2[2],p2[1]),
                                        Point2::make_point(r2[2],r2[1]));
 
-    return TriangleIntersection2D(t1_2da, t2_2da, includeBoundary);
+    return TriangleIntersection2D(t1_2da, t2_2da, includeBoundary, EPS);
   }
-  else if (isGt(normal[1],normal[2]) && isGeq(normal[1],normal[0]))
+  else if (isGt(normal[1],normal[2], EPS) && isGeq(normal[1],normal[0], EPS))
   {
     //if y projection area greatest, project on XZ and return 2D checker
     const Triangle2 t1_2da = Triangle2(Point2::make_point(q1[0],q1[2]),
@@ -141,7 +154,7 @@ bool intersectCoplanar3DTriangles(const Point3& p1,
                                        Point2::make_point(p2[0],p2[2]),
                                        Point2::make_point(r2[0],r2[2]));
 
-    return TriangleIntersection2D(t1_2da, t2_2da, includeBoundary);
+    return TriangleIntersection2D(t1_2da, t2_2da, includeBoundary, EPS);
   }
 
   //if z projection area greatest, project on XY and return 2D checker
@@ -153,42 +166,43 @@ bool intersectCoplanar3DTriangles(const Point3& p1,
                                      Point2::make_point(q2[0],q2[1]),
                                      Point2::make_point(r2[0],r2[1]));
 
-  return TriangleIntersection2D(t1_2da, t2_2da, includeBoundary);
+  return TriangleIntersection2D(t1_2da, t2_2da, includeBoundary, EPS);
 }
 
 // -----------------------------------------------------------------------------
 bool TriangleIntersection2D(const Triangle2& t1,
                             const Triangle2& t2,
-                            bool includeBoundary)
+                            bool includeBoundary,
+                            double EPS)
 {
-  if (isLt(twoDcross(t1[0],t1[1],t1[2]),0.0))
+  if (isLt(twoDcross(t1[0],t1[1],t1[2]),0.0, EPS))
   {
-    if ((isLt(twoDcross(t2[0], t2[1], t2[2]),0.0)))
+    if ((isLt(twoDcross(t2[0], t2[1], t2[2]),0.0, EPS)))
     {
       return intersectPermuted2DTriangles(t1[0], t1[2], t1[1],
                                           t2[0], t2[2], t2[1],
-                                          includeBoundary);
+                                          includeBoundary, EPS);
     }
     else
     {
       return intersectPermuted2DTriangles(t1[0], t1[2], t1[1],
                                           t2[0], t2[1], t2[2],
-                                          includeBoundary);
+                                          includeBoundary, EPS);
     }
   }
   else
   {
-    if (isLt(twoDcross(t2[0], t2[1], t2[2]),0.0))
+    if (isLt(twoDcross(t2[0], t2[1], t2[2]),0.0, EPS))
     {
       return intersectPermuted2DTriangles(t1[0], t1[1], t1[2],
                                           t2[0], t2[2], t2[1],
-                                          includeBoundary);
+                                          includeBoundary, EPS);
     }
     else
     {
       return intersectPermuted2DTriangles(t1[0], t1[1], t1[2],
                                           t2[0], t2[1], t2[2],
-                                          includeBoundary);
+                                          includeBoundary, EPS);
     }
   }
 }
@@ -200,7 +214,8 @@ bool intersectPermuted2DTriangles(const Point2& p1,
                                   const Point2& p2,
                                   const Point2& q2,
                                   const Point2& r2,
-                                  bool includeBoundary)
+                                  bool includeBoundary,
+                                  double EPS)
 {
   // Step 2: Orient triangle 2 to be counter clockwise and break the problem
   // into two generic cases (where we test the vertex for intersection or the
@@ -208,49 +223,49 @@ bool intersectPermuted2DTriangles(const Point2& p1,
   //
   // See paper at https://hal.inria.fr/inria-00072100/document for more details
 
-  if (isGpeq(twoDcross(p2,q2,p1), 0.0, includeBoundary))
+  if (isGpeq(twoDcross(p2,q2,p1), 0.0, includeBoundary, EPS))
   {
-    if (isGpeq(twoDcross(q2,r2,p1), 0.0, includeBoundary))
+    if (isGpeq(twoDcross(q2,r2,p1), 0.0, includeBoundary, EPS))
     {
-      if (isGpeq(twoDcross(r2,p2,p1), 0.0, includeBoundary))
+      if (isGpeq(twoDcross(r2,p2,p1), 0.0, includeBoundary, EPS))
       {
         return true;
       }
       else
       {
-        return checkEdge(p1,q1,r1,p2,r2,includeBoundary); //T1 clockwise
+        return checkEdge(p1,q1,r1,p2,r2,includeBoundary, EPS); //T1 clockwise
       }
     }
     else
     {
-      if (isGpeq(twoDcross(r2,p2,p1), 0.0, includeBoundary))
+      if (isGpeq(twoDcross(r2,p2,p1), 0.0, includeBoundary, EPS))
       {
         //5 region decomposition with p1 in the +-- region
-        return checkEdge(p1,q1,r1,r2,q2,includeBoundary);
+        return checkEdge(p1,q1,r1,r2,q2,includeBoundary, EPS);
       }
       else
       {
-        return checkVertex(p1,q1,r1,p2,q2,r2,includeBoundary);
+        return checkVertex(p1,q1,r1,p2,q2,r2,includeBoundary, EPS);
       }
     }
   }
   else
   {
-    if (isGpeq(twoDcross(q2,r2,p1), 0.0, includeBoundary))
+    if (isGpeq(twoDcross(q2,r2,p1), 0.0, includeBoundary, EPS))
     {
-      if (isGpeq(twoDcross(r2,p2,p1), 0.0, includeBoundary))
+      if (isGpeq(twoDcross(r2,p2,p1), 0.0, includeBoundary, EPS))
       {
         //four region decomposition.  ++- region
-        return checkEdge(p1,q1,r1,q2,p2,includeBoundary);
+        return checkEdge(p1,q1,r1,q2,p2,includeBoundary, EPS);
       }
       else
       {
-        return checkVertex(p1,q1,r1,q2,r2,p2,includeBoundary);
+        return checkVertex(p1,q1,r1,q2,r2,p2,includeBoundary, EPS);
       }
     }
     else
     {
-      return checkVertex(p1,q1,r1,r2,p2,q2,includeBoundary);
+      return checkVertex(p1,q1,r1,r2,p2,q2,includeBoundary, EPS);
     }
   }
 }
@@ -261,20 +276,21 @@ bool checkEdge(const Point2& p1,
                const Point2& r1,
                const Point2& p2,
                const Point2& r2,
-               bool includeBoundary)
+               bool includeBoundary,
+               double EPS)
 {
-  if (isGpeq(twoDcross(r2, p2, q1), 0.0, includeBoundary))
+  if (isGpeq(twoDcross(r2, p2, q1), 0.0, includeBoundary, EPS))
   {
-    if (isGpeq(twoDcross(r2, p1, q1), 0.0, includeBoundary))
+    if (isGpeq(twoDcross(r2, p1, q1), 0.0, includeBoundary, EPS))
     {
-      if (isGpeq(twoDcross(p1, p2, q1), 0.0, includeBoundary))
+      if (isGpeq(twoDcross(p1, p2, q1), 0.0, includeBoundary, EPS))
       {
         return true;
       }
       else
       {
-        if (isGpeq(twoDcross(p1, p2, r1), 0.0, includeBoundary) &&
-            isGpeq(twoDcross(q1, r1, p2), 0.0, includeBoundary))
+        if (isGpeq(twoDcross(p1, p2, r1), 0.0, includeBoundary, EPS) &&
+            isGpeq(twoDcross(q1, r1, p2), 0.0, includeBoundary, EPS))
         {
           return true;
         }
@@ -291,9 +307,9 @@ bool checkEdge(const Point2& p1,
   }
   else
   {
-    if (isGpeq(twoDcross(r2, p2, r1), 0.0, includeBoundary) &&
-        isGpeq(twoDcross(q1, r1, r2), 0.0, includeBoundary) &&
-        isGpeq(twoDcross(p1, p2, r1), 0.0, includeBoundary))
+    if (isGpeq(twoDcross(r2, p2, r1), 0.0, includeBoundary, EPS) &&
+        isGpeq(twoDcross(q1, r1, r2), 0.0, includeBoundary, EPS) &&
+        isGpeq(twoDcross(p1, p2, r1), 0.0, includeBoundary, EPS))
     {
       return true;
     }
@@ -311,15 +327,16 @@ inline bool checkVertex(const Point2& p1,
                         const Point2& p2,
                         const Point2& q2,
                         const Point2& r2,
-                        bool includeBoundary)
+                        bool includeBoundary,
+                        double EPS)
 {
-  if (isGpeq(twoDcross(r2, p2, q1), 0.0, includeBoundary))
+  if (isGpeq(twoDcross(r2, p2, q1), 0.0, includeBoundary, EPS))
   {
-    if (isGpeq(twoDcross(q2, r2, q1), 0.0, includeBoundary))
+    if (isGpeq(twoDcross(q2, r2, q1), 0.0, includeBoundary, EPS))
     {
-      if (isGpeq(twoDcross(p1, p2, q1), 0.0, includeBoundary))
+      if (isGpeq(twoDcross(p1, p2, q1), 0.0, includeBoundary, EPS))
       {
-        if (isLpeq(twoDcross(p1, q2, q1), 0.0, includeBoundary))
+        if (isLpeq(twoDcross(p1, q2, q1), 0.0, includeBoundary, EPS))
         {
           return true;
         }
@@ -330,8 +347,8 @@ inline bool checkVertex(const Point2& p1,
       }
       else
       {
-        if (isGpeq(twoDcross(p1, p2, r1), 0.0, includeBoundary) &&
-            isGpeq(twoDcross(r2, p2, r1), 0.0, includeBoundary))
+        if (isGpeq(twoDcross(p1, p2, r1), 0.0, includeBoundary, EPS) &&
+            isGpeq(twoDcross(r2, p2, r1), 0.0, includeBoundary, EPS))
         {
           return true;
         }
@@ -343,9 +360,9 @@ inline bool checkVertex(const Point2& p1,
     }
     else
     {
-      if (isLpeq(twoDcross(p1, q2, q1), 0.0, includeBoundary) &&
-          isGpeq(twoDcross(q2, r2, r1), 0.0, includeBoundary) &&
-          isGpeq(twoDcross(q1, r1, q2), 0.0, includeBoundary))
+      if (isLpeq(twoDcross(p1, q2, q1), 0.0, includeBoundary, EPS) &&
+          isGpeq(twoDcross(q2, r2, r1), 0.0, includeBoundary, EPS) &&
+          isGpeq(twoDcross(q1, r1, q2), 0.0, includeBoundary, EPS))
       {
         return true;
       }
@@ -357,11 +374,11 @@ inline bool checkVertex(const Point2& p1,
   }
   else
   {
-    if (isGpeq(twoDcross(r2, p2, r1), 0.0, includeBoundary))
+    if (isGpeq(twoDcross(r2, p2, r1), 0.0, includeBoundary, EPS))
     {
-      if (isGpeq(twoDcross(q1, r1, r2), 0.0, includeBoundary))
+      if (isGpeq(twoDcross(q1, r1, r2), 0.0, includeBoundary, EPS))
       {
-        if (isGpeq(twoDcross(r1, p1, p2), 0.0, includeBoundary))
+        if (isGpeq(twoDcross(r1, p1, p2), 0.0, includeBoundary, EPS))
         {
           return true;
         }
@@ -372,8 +389,8 @@ inline bool checkVertex(const Point2& p1,
       }
       else
       {
-        if (isGpeq(twoDcross(q1, r1, q2), 0.0, includeBoundary) &&
-            isGpeq(twoDcross(q2, r2, r1), 0.0, includeBoundary))
+        if (isGpeq(twoDcross(q1, r1, q2), 0.0, includeBoundary, EPS) &&
+            isGpeq(twoDcross(q2, r2, r1), 0.0, includeBoundary, EPS))
         {
           return true;
         }

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -387,16 +387,12 @@ inline bool intersectTwoPermutedTriangles(const Point3& p1,
      if intersecting, have a line that intersects segments p1r1, p1q1,
      p2q2, and p2r2.  We check if these two intervals overlap:
    */
-
-  if (!isLpeq(Vector3(q1, q2).dot(Triangle3(q1, p2, p1).normal()), 0.0,
-              includeBoundary) ||
-      !isLpeq(Vector3(p1, r2).dot(Triangle3(p1, p2, r1).normal()), 0.0,
-              includeBoundary))
-  {
-    return false;
-  }
-
-  return true;
+  const bool bdr = includeBoundary;
+  const double local_eps = 1e-8;
+  /* *INDENT-OFF* */
+  return isLpeq(Vector3(q1, q2).dot(Triangle3(q1, p2, p1).normal()), 0.0, bdr, local_eps)
+      && isLpeq(Vector3(p1, r2).dot(Triangle3(p1, p2, r1).normal()), 0.0, bdr, local_eps);
+  /* *INDENT-ON* */
 }
 
 /*!

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -45,6 +45,7 @@ bool isGt(double x, double y, double EPS=1E-12);
 AXOM_HOST_DEVICE
 bool isLt(double x, double y, double EPS=1E-12);
 
+AXOM_HOST_DEVICE
 bool isLeq(double x, double y, double EPS=1E-12);
 
 AXOM_HOST_DEVICE

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -33,78 +33,81 @@ namespace detail
 
 //---------------------------- FUNCTION DECLARATIONS ---------------------------
 
-typedef primal::Vector< double, 3 > Vector3;
-typedef primal::Point< double, 3 > Point3;
-typedef primal::Triangle< double, 3 > Triangle3;
-typedef primal::Triangle< double, 2 > Triangle2;
-typedef primal::Point< double, 2 > Point2;
+using Vector3 = primal::Vector< double, 3 >;
+using Point3 = primal::Point< double, 3 >;
+using Triangle3 = primal::Triangle< double, 3 >;
+using Triangle2 = primal::Triangle< double, 2 >;
+using Point2 = primal::Point< double, 2 >;
 
 AXOM_HOST_DEVICE
-bool isGt(double x, double y, double EPS=1.0e-12);
-
-AXOM_HOST_DEVICE 
-bool isLt(double x, double y, double EPS=1.0e-12);
-
-bool isLeq(double x, double y, double EPS=1.0e-12);
+bool isGt(double x, double y, double EPS=1E-12);
 
 AXOM_HOST_DEVICE
-bool isLpeq(double x, double y, bool includeEqual = false,
-            double EPS=1.0e-12);
+bool isLt(double x, double y, double EPS=1E-12);
+
+bool isLeq(double x, double y, double EPS=1E-12);
 
 AXOM_HOST_DEVICE
-bool isGeq(double x, double y, double EPS=1.0e-12);
+bool isLpeq(double x, double y, bool includeEqual = false, double EPS=1E-12);
 
 AXOM_HOST_DEVICE
-bool isGpeq(double x, double y, bool includeEqual = false,
-            double EPS=1.0e-12);
+bool isGeq(double x, double y, double EPS=1E-12);
 
 AXOM_HOST_DEVICE
-bool nonzeroSignMatch(double x, double y, double z, double EPS=1.0e-12);
+bool isGpeq(double x, double y, bool includeEqual = false, double EPS=1E-12);
 
 AXOM_HOST_DEVICE
-bool twoZeros(double x, double y, double z, double EPS=1.0e-12);
+bool nonzeroSignMatch(double x, double y, double z, double EPS=1E-12);
 
 AXOM_HOST_DEVICE
-bool oneZeroOthersMatch(double x, double y, double z, double EPS=1.0e-12);
+bool twoZeros(double x, double y, double z, double EPS=1E-12);
 
 AXOM_HOST_DEVICE
-int  countZeros(double x, double y, double z, double EPS=1.0e-12);
+bool oneZeroOthersMatch(double x, double y, double z, double EPS=1E-12);
+
+AXOM_HOST_DEVICE
+int  countZeros(double x, double y, double z, double EPS=1E-12);
 
 AXOM_HOST_DEVICE
 double twoDcross(const Point2& A, const Point2& B, const Point2& C);
 
+/*!
+ * This function finds where p1 lies in relation to the vertices of t2
+ * and calls either checkEdge() or checkVertex().
+ * \return status true iff triangle p1 q1 r1 intersects triangle p2 q2 r2.
+ */
 AXOM_HOST_DEVICE
-bool checkEdge(const Point2& p1,
-               const Point2& q1,
-               const Point2& r1,
-               const Point2& p2,
-               const Point2& r2,
-               bool includeBoundary);
-
-AXOM_HOST_DEVICE
-bool checkVertex(const Point2& p1,
-                 const Point2& q1,
-                 const Point2& r1,
-                 const Point2& p2,
-                 const Point2& q2,
-                 const Point2& r2,
-                 bool includeBoundary);
-
-AXOM_HOST_DEVICE 
 bool intersectPermuted2DTriangles(const Point2& p1,
                                   const Point2& q1,
                                   const Point2& r1,
                                   const Point2& p2,
                                   const Point2& q2,
                                   const Point2& r2,
-                                  bool includeBoundary);
+                                  bool includeBoundary,
+                                  double EPS);
 
+/*!
+ * Triangle 1 vertices have been permuted to CCW: permute t2 to CCW
+ * and call worker function to test for intersection.
+ *
+ * q1 and r1 both lie in the negative half-space defined by t2; p1 lies in
+ * t2's plane or in its positive half-space.
+ * The sign of dp2, dq2, and dr2 indicates whether the associated vertex
+ * of t2 lies in the positive or negative half-space defined by t1.
+ */
 AXOM_HOST_DEVICE
-bool intersectOnePermutedTriangle(
-  const Point3 &p1, const Point3 &q1, const Point3 &r1,
-  const Point3 &p2, const Point3 &q2, const Point3 &r2,
-  double dp2, double dq2, double dr2,  Vector3 &normal,
-  bool includeBoundary);
+bool intersectOnePermutedTriangle(const Point3 &p1,
+                                  const Point3 &q1,
+                                  const Point3 &r1,
+                                  const Point3 &p2,
+                                  const Point3 &q2,
+                                  const Point3 &r2,
+                                  double dp2,
+                                  double dq2,
+                                  double dr2,
+                                  Vector3 &normal,
+                                  bool includeBoundary,
+                                  double EPS);
 
 AXOM_HOST_DEVICE
 bool intersectTwoPermutedTriangles(const Point3& p1,
@@ -113,8 +116,13 @@ bool intersectTwoPermutedTriangles(const Point3& p1,
                                    const Point3& p2,
                                    const Point3& q2,
                                    const Point3& r2,
-                                   bool includeBoundary);
+                                   bool includeBoundary,
+                                   double EPS);
 
+/*!
+ * Project (nearly) coplanar triangles 1 and 2 on an axis; call 2D worker
+ * function to test for intersection.
+ */
 AXOM_HOST_DEVICE
 bool intersectCoplanar3DTriangles(const Point3& p1,
                                   const Point3& q1,
@@ -123,12 +131,21 @@ bool intersectCoplanar3DTriangles(const Point3& p1,
                                   const Point3& q2,
                                   const Point3& r2,
                                   Vector3 normal,
-                                  bool includeBoundary);
+                                  bool includeBoundary,
+                                  double EPS);
 
+/*!
+ * \brief Orients triangle vertices so both triangles are CCW; calls worker.
+ * \return status true iff t1 and t2 intersect
+ *
+ * Determine triangle orientation, then call the worker function with
+ * vertices from t1 and t2 permuted to ensure CCW orientation.
+ */
 AXOM_HOST_DEVICE
 bool TriangleIntersection2D(const Triangle2& t1,
                             const Triangle2& t2,
-                            bool includeBoundary = false);
+                            bool includeBoundary,
+                            double EPS);
 
 //------------------------------ IMPLEMENTATIONS ------------------------------
 
@@ -155,7 +172,8 @@ template < typename T >
 AXOM_HOST_DEVICE
 bool intersect_tri3D_tri3D( const Triangle< T, 3 >& t1,
                             const Triangle< T, 3 >& t2,
-                            bool includeBoundary = false)
+                            bool includeBoundary,
+                            double EPS)
 {
   typedef primal::Vector< T, 3 > Vector3;
 
@@ -176,14 +194,14 @@ bool intersect_tri3D_tri3D( const Triangle< T, 3 >& t1,
   double dq1 = (Vector3(t2[2],t1[1])).dot(t2Normal);
   double dr1 = (Vector3(t2[2],t1[2])).dot(t2Normal);
 
-  if (nonzeroSignMatch(dp1, dq1, dr1))
+  if (nonzeroSignMatch(dp1, dq1, dr1, EPS))
   {
     return false;
   }
 
   if (!includeBoundary &&
-      (twoZeros(dp1, dq1, dr1) ||
-       oneZeroOthersMatch(dp1, dq1, dr1)))
+      (twoZeros(dp1, dq1, dr1, EPS) ||
+       oneZeroOthersMatch(dp1, dq1, dr1, EPS)))
   {
     return false;
   }
@@ -198,14 +216,14 @@ bool intersect_tri3D_tri3D( const Triangle< T, 3 >& t1,
   double dq2 = (Vector3(t1[2],t2[1])).dot(t1Normal);
   double dr2 = (Vector3(t1[2],t2[2])).dot(t1Normal);
 
-  if (nonzeroSignMatch(dp2, dq2, dr2))
+  if (nonzeroSignMatch(dp2, dq2, dr2, EPS))
   {
     return false;
   }
 
   if (!includeBoundary &&
-      (twoZeros(dp2, dq2, dr2) ||
-       oneZeroOthersMatch(dp2, dq2, dr2)))
+      (twoZeros(dp2, dq2, dr2, EPS) ||
+       oneZeroOthersMatch(dp2, dq2, dr2, EPS)))
   {
     return false;
   }
@@ -228,130 +246,116 @@ bool intersect_tri3D_tri3D( const Triangle< T, 3 >& t1,
   // compare the signs to create a convenient permutation of the vertices
   // of triangle 1
 
-  if (isGt(dp1, 0.0))
+  if (isGt(dp1, 0.0, EPS))
   {
-    if (isGt(dq1, 0.0))
+    if (isGt(dq1, 0.0, EPS))
     {
       return intersectOnePermutedTriangle(t1[2], t1[0], t1[1],
                                           t2[0], t2[2], t2[1],
                                           dp2, dr2, dq2, t1Normal,
-                                          includeBoundary);
+                                          includeBoundary, EPS);
     }
-    else if (isGt(dr1, 0.0))
+    else if (isGt(dr1, 0.0, EPS))
     {
       return intersectOnePermutedTriangle(t1[1], t1[2], t1[0],
                                           t2[0], t2[2], t2[1],
                                           dp2, dr2, dq2, t1Normal,
-                                          includeBoundary);
+                                          includeBoundary, EPS);
     }
     else
     {
       return intersectOnePermutedTriangle(t1[0], t1[1], t1[2],
                                           t2[0], t2[1], t2[2],
                                           dp2, dq2, dr2, t1Normal,
-                                          includeBoundary);
+                                          includeBoundary, EPS);
     }
   }
-  else if (isLt(dp1, 0.0))
+  else if (isLt(dp1, 0.0, EPS))
   {
-    if (isLt(dq1, 0.0))
+    if (isLt(dq1, 0.0, EPS))
     {
       return intersectOnePermutedTriangle(t1[2], t1[0], t1[1],
                                           t2[0], t2[1], t2[2],
                                           dp2, dq2, dr2, t1Normal,
-                                          includeBoundary);
+                                          includeBoundary, EPS);
     }
-    else if (isLt(dr1, 0.0f))
+    else if (isLt(dr1, 0.0, EPS))
     {
       return intersectOnePermutedTriangle(t1[1], t1[2], t1[0],
                                           t2[0], t2[1], t2[2],
                                           dp2, dq2, dr2, t1Normal,
-                                          includeBoundary);
+                                          includeBoundary, EPS);
     }
     else
     {
       return intersectOnePermutedTriangle(t1[0], t1[1], t1[2],
                                           t2[0], t2[2], t2[1],
                                           dp2, dr2, dq2, t1Normal,
-                                          includeBoundary);
+                                          includeBoundary, EPS);
     }
   }
   else   //dp1 ~= 0
   {
-    if (isLt(dq1, 0.0))
+    if (isLt(dq1, 0.0, EPS))
     {
-      if (isGeq(dr1, 0.0))
+      if (isGeq(dr1, 0.0, EPS))
       {
         return intersectOnePermutedTriangle(t1[1], t1[2], t1[0],
                                             t2[0], t2[2], t2[1],
                                             dp2, dr2, dq2, t1Normal,
-                                            includeBoundary);
+                                            includeBoundary, EPS);
       }
       else
       {
         return intersectOnePermutedTriangle(t1[0], t1[1], t1[2],
                                             t2[0], t2[1], t2[2],
                                             dp2, dq2, dr2, t1Normal,
-                                            includeBoundary);
+                                            includeBoundary, EPS);
       }
     }
-    else if (isGt(dq1, 0.0))
+    else if (isGt(dq1, 0.0, EPS))
     {
-      if (isGt(dr1, 0.0))
+      if (isGt(dr1, 0.0, EPS))
       {
         return intersectOnePermutedTriangle(t1[0], t1[1], t1[2],
                                             t2[0], t2[2], t2[1],
                                             dp2, dr2, dq2, t1Normal,
-                                            includeBoundary);
+                                            includeBoundary, EPS);
       }
       else
       {
         return intersectOnePermutedTriangle(t1[1], t1[2], t1[0],
                                             t2[0], t2[1], t2[2],
                                             dp2, dq2, dr2, t1Normal,
-                                            includeBoundary);
+                                            includeBoundary, EPS);
       }
     }
     else
     {
-      if (isGt(dr1, 0.0))
+      if (isGt(dr1, 0.0, EPS))
       {
         return intersectOnePermutedTriangle(t1[2], t1[0], t1[1],
                                             t2[0], t2[1], t2[2],
                                             dp2, dq2, dr2, t1Normal,
-                                            includeBoundary);
+                                            includeBoundary, EPS);
       }
-      else if (isLt(dr1, 0.0))
+      else if (isLt(dr1, 0.0, EPS))
       {
         return intersectOnePermutedTriangle(t1[2], t1[0], t1[1],
                                             t2[0], t2[2], t2[1],
                                             dp2, dr2, dq2, t1Normal,
-                                            includeBoundary);
+                                            includeBoundary, EPS);
       }
       else
       {
         return intersectCoplanar3DTriangles(t1[0], t1[1], t1[2],
                                             t2[0], t2[1], t2[2], t1Normal,
-                                            includeBoundary);
+                                            includeBoundary, EPS);
       }
     }
   }
 }
 
-/*!
- * Triangle 1 vertices have been permuted to CCW: permute t2 to CCW
- * and call worker function to test for intersection.
- *
- * q1 and r1 both lie in the negative half-space defined by t2; p1 lies in
- * t2's plane or in its positive half-space.
- * The sign of dp2, dq2, and dr2 indicates whether the associated vertex
- * of t2 lies in the positive or negative half-space defined by t1.
- */
-bool intersectOnePermutedTriangle(
-  const Point3 &p1, const Point3 &q1, const Point3 &r1,
-  const Point3 &p2, const Point3 &q2, const Point3 &r2,
-  double dp2, double dq2, double dr2,  Vector3 &normal,
-  bool includeBoundary);
 
 /*!
  * \brief Tests for general 3D triangle-triangle intersection.
@@ -381,32 +385,20 @@ inline bool intersectTwoPermutedTriangles(const Point3& p1,
                                           const Point3& p2,
                                           const Point3& q2,
                                           const Point3& r2,
-                                          bool includeBoundary)
+                                          bool includeBoundary,
+                                          double EPS)
 {
   /* Step 5: From step's 1 through 4, we now have two triangles that,
      if intersecting, have a line that intersects segments p1r1, p1q1,
      p2q2, and p2r2.  We check if these two intervals overlap:
    */
   const bool bdr = includeBoundary;
-  const double local_eps = 1e-8;
   /* *INDENT-OFF* */
-  return isLpeq(Vector3(q1, q2).dot(Triangle3(q1, p2, p1).normal()), 0.0, bdr, local_eps)
-      && isLpeq(Vector3(p1, r2).dot(Triangle3(p1, p2, r1).normal()), 0.0, bdr, local_eps);
+  return isLpeq(Vector3(q1, q2).dot(Triangle3(q1, p2, p1).normal()), 0.0, bdr, EPS)
+      && isLpeq(Vector3(p1, r2).dot(Triangle3(p1, p2, r1).normal()), 0.0, bdr, EPS);
   /* *INDENT-ON* */
 }
 
-/*!
- * Project (nearly) coplanar triangles 1 and 2 on an axis; call 2D worker
- * function to test for intersection.
- */
-bool intersectCoplanar3DTriangles(const Point3& p1,
-                                  const Point3& q1,
-                                  const Point3& r1,
-                                  const Point3& p2,
-                                  const Point3& q2,
-                                  const Point3& r2,
-                                  Vector3 normal,
-                                  bool includeBoundary);
 /*! @} */
 
 /*! @{ @name 2D triangle-triangle intersection */
@@ -421,7 +413,8 @@ bool intersectCoplanar3DTriangles(const Point3& p1,
 template < typename T >
 bool intersect_tri2D_tri2D(const primal::Triangle< T, 2 >& t1,
                            const primal::Triangle< T, 2 >& t2,
-                           bool includeBoundary = false)
+                           bool includeBoundary,
+                           double EPS)
 {
   SLIC_CHECK_MSG(
     !t1.degenerate(),
@@ -430,55 +423,35 @@ bool intersect_tri2D_tri2D(const primal::Triangle< T, 2 >& t1,
     !t2.degenerate(),
     "\n\n WARNING \n\n Triangle " << t2 <<" is degenerate");
 
-  return TriangleIntersection2D(t1, t2, includeBoundary);
+  return TriangleIntersection2D(t1, t2, includeBoundary, EPS);
 }
-
-/*!
- * \brief Orients triangle vertices so both triangles are CCW; calls worker.
- * \return status true iff t1 and t2 intersect
- *
- * Determine triangle orientation, then call the worker function with
- * vertices from t1 and t2 permuted to ensure CCW orientation.
- */
-bool TriangleIntersection2D(const Triangle2& t1,
-                            const Triangle2& t2,
-                            bool includeBoundary);
-
-/*!
- * This function finds where p1 lies in relation to the vertices of t2
- * and calls either checkEdge() or checkVertex().
- * \return status true iff triangle p1 q1 r1 intersects triangle p2 q2 r2.
- */
-bool intersectPermuted2DTriangles(const Point2& p1,
-                                  const Point2& q1,
-                                  const Point2& r1,
-                                  const Point2& p2,
-                                  const Point2& q2,
-                                  const Point2& r2,
-                                  bool includeBoundary);
 
 /*!
  * \brief Check for 2D triangle-edge intersection, given p1 close to r2p2.
  * \return status true iff coplanar CCW triangles 1 and 2 intersect.
  */
-bool checkEdge(const Point2& p1,
-               const Point2& q1,
-               const Point2& r1,
-               const Point2& p2,
-               const Point2& r2,
-               bool includeBoundary);
+AXOM_HOST_DEVICE
+inline bool checkEdge(const Point2& p1,
+                      const Point2& q1,
+                      const Point2& r1,
+                      const Point2& p2,
+                      const Point2& r2,
+                      bool includeBoundary,
+                      double EPS);
 
 /*!
  * \brief Check for 2D triangle-edge intersection, given p1 close to r2.
  * \return status true iff coplanar CCW triangles 1 and 2 intersect.
  */
+AXOM_HOST_DEVICE
 inline bool checkVertex(const Point2& p1,
                         const Point2& q1,
                         const Point2& r1,
                         const Point2& p2,
                         const Point2& q2,
                         const Point2& r2,
-                        bool includeBoundary);
+                        bool includeBoundary,
+                        double EPS);
 
 /*!
  * \brief Compute cross product of two 2D vectors as if they were 3D.

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -39,11 +39,17 @@ namespace primal
 
 /*!
  * \brief Tests if 3D Triangles t1 and t2 intersect.
+ *
+ * \param [in] t1 The first triangle
+ * \param [in] t2 The second triangle
+ * \param [in] includeBoundary Indicates if boundaries should be considered
+ * when detecting intersections (default: false)
+ * \param [in] EPS Tolerance threshold for determining intersections (default: 1E-8)
  * \return status true iff t1 intersects with t2, otherwise, false.
  *
- * If parameter includeBoundary is false (default), this function will
+ * If parameter \a includeBoundary is false (default), this function will
  * return true if the interior of t1 intersects the interior of t2.  To include
- * triangle boundaries in intersections, specify includeBoundary as true.
+ * triangle boundaries in intersections, specify \a includeBoundary as true.
  */
 template < typename T >
 AXOM_HOST_DEVICE
@@ -57,11 +63,16 @@ bool intersect( const Triangle< T, 3 >& t1,
 
 /*!
  * \brief Tests if 2D Triangles t1 and t2 intersect.
+ * \param [in] t1 The first triangle
+ * \param [in] t2 The second triangle
+ * \param [in] includeBoundary Indicates if boundaries should be considered
+ * when detecting intersections (default: false)
+ * \param [in] EPS Tolerance threshold for determining intersections (default: 1E-8)
  * \return status true iff t1 intersects with t2, otherwise, false.
  *
- * If parameter includeBoundary is false (default), this function will
+ * If parameter \a includeBoundary is false (default), this function will
  * return true if the interior of t1 intersects the interior of t2.  To include
- * triangle boundaries in intersections, specify includeBoundary as true.
+ * triangle boundaries in intersections, specify \a includeBoundary as true.
  */
 template < typename T >
 bool intersect( const Triangle< T, 2 >& t1,

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -49,9 +49,10 @@ template < typename T >
 AXOM_HOST_DEVICE
 bool intersect( const Triangle< T, 3 >& t1,
                 const Triangle< T, 3 >& t2,
-                const bool includeBoundary = false)
+                bool includeBoundary = false,
+                double EPS = 1E-08)
 {
-  return detail::intersect_tri3D_tri3D< T >(t1, t2, includeBoundary);
+  return detail::intersect_tri3D_tri3D< T >(t1, t2, includeBoundary, EPS);
 }
 
 /*!
@@ -65,9 +66,10 @@ bool intersect( const Triangle< T, 3 >& t1,
 template < typename T >
 bool intersect( const Triangle< T, 2 >& t1,
                 const Triangle< T, 2 >& t2,
-                const bool includeBoundary = false)
+                bool includeBoundary = false,
+                double EPS = 1E-08)
 {
-  return detail::intersect_tri2D_tri2D< T >(t1, t2, includeBoundary);
+  return detail::intersect_tri2D_tri2D< T >(t1, t2, includeBoundary, EPS);
 }
 
 /*!

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -922,6 +922,38 @@ TEST( primal_intersect, 3D_triangle_triangle_intersection_regression )
     permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
   }
 
+  {
+    std::string msg = "Vertex-adjacent triangles";
+    /* *INDENT-OFF* */
+    Point3 vdata[] = { Point3::make_point(-138.02488708496094,    -14398.0908203125, 111881.2421875),
+                       Point3::make_point(   0.067092768847942352,-14407.21875,      111891.078125),
+                       Point3::make_point(-136.77900695800781,    -14416.4912109375, 111891.078125),
+                       Point3::make_point(   1.1611454486846924,  -14423.3466796875, 111904.359375),
+                       Point3::make_point( 136.91319274902344,    -14397.947265625,  111891.078125)};
+    /* *INDENT-ON* */
+
+    Triangle3 tri3d_1(vdata[0], vdata[1], vdata[2]);
+    Triangle3 tri3d_2(vdata[3], vdata[1], vdata[4]);
+
+    permuteCornersTest(tri3d_1, tri3d_2, msg, false, false);
+    permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
+  }
+
+  {
+    std::string msg = "Vertex-adjacent triangles (simplified)";
+    Point3 vdata[] = { Point3::make_point(-1,-1,-1),
+                       Point3::make_point( 0, 0, -0.005),
+                       Point3::make_point(-1, 0, 0),
+                       Point3::make_point( 0, 1,-1),
+                       Point3::make_point( 1, 0, 0)};
+
+    Triangle3 tri3d_1(vdata[0], vdata[1], vdata[2]);
+    Triangle3 tri3d_2(vdata[3], vdata[1], vdata[4]);
+
+    permuteCornersTest(tri3d_1, tri3d_2, msg, false, false);
+    permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
+  }
+
   axom::slic::setLoggingMsgLevel( axom::slic::message::Warning);
 }
 

--- a/src/axom/quest/MeshTester.cpp
+++ b/src/axom/quest/MeshTester.cpp
@@ -112,10 +112,11 @@ void findTriMeshIntersections(
   UMesh* surface_mesh,
   std::vector<std::pair<int, int> > & intersections,
   std::vector<int> & degenerateIndices,
-  int spatialIndexResolution)
+  int spatialIndexResolution,
+  double intersectionThreshold)
 {
-  Triangle3 t1 = Triangle3();
-  Triangle3 t2 = Triangle3();
+  Triangle3 t1{};
+  Triangle3 t2{};
   SLIC_INFO("Running mesh_tester with UniformGrid index");
 
   // Create a bounding box around mesh to find the minimum point
@@ -198,7 +199,7 @@ void findTriMeshIntersections(
     while (nit != nend)
     {
       t2 = getMeshTriangle(*nit, surface_mesh);
-      if (primal::intersect(t1, t2))
+      if (primal::intersect(t1, t2, false, intersectionThreshold))
       {
         intersections.push_back(std::make_pair(*idx, *nit));
       }

--- a/src/axom/quest/MeshTester.hpp
+++ b/src/axom/quest/MeshTester.hpp
@@ -45,6 +45,8 @@ enum class WatertightStatus : signed char
  * \param [out] degenerateIndices indices of degenerate mesh triangles
  * \param [in] spatialIndexResolution The grid resolution for the index
  * structure (default: 0)
+ * \param [in] intersectionThreshold Tolerance threshold for triangle 
+ * intersection tests (default: 1E-8)
  *
  * After running this function over a surface mesh, intersection will be filled
  * with pairs of indices of intersecting triangles and degenerateIndices will

--- a/src/axom/quest/MeshTester.hpp
+++ b/src/axom/quest/MeshTester.hpp
@@ -62,7 +62,8 @@ void findTriMeshIntersections(
   mint::UnstructuredMesh< mint::SINGLE_SHAPE >* surface_mesh,
   std::vector<std::pair<int, int> > & intersections,
   std::vector<int> & degenerateIndices,
-  int spatialIndexResolution = 0);
+  int spatialIndexResolution = 0,
+  double intersectionThreshold = 1E-8);
 
 
 /*!

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -64,6 +64,7 @@
 #include <iostream>
 #include <utility>
 #include <vector>
+#include <iomanip>
 
 // _read_stl_typedefs_start
 using namespace axom;
@@ -94,6 +95,7 @@ struct Input
   int resolution;
   double weldThreshold;
   bool skipWeld;
+  bool verboseOutput;
 
   Input()
     : stlInput("")
@@ -102,6 +104,7 @@ struct Input
     , resolution(0)
     , weldThreshold(1e-6)
     , skipWeld(false)
+    , verboseOutput(false)
   { };
 
   void parse(int argc, char** argv, CLI::App& app);
@@ -168,6 +171,10 @@ void Input::parse(int argc, char** argv, CLI::App& app)
 
   app.add_flag("--skipWeld", skipWeld,
                "Don't weld vertices (useful for testing, not helpful otherwise).");
+
+  app.add_flag("-v,--verbose", verboseOutput,
+               "Increase logging verbosity.")
+  ->capture_default_str();
 
   app.get_formatter()->column_width(35);
 
@@ -649,6 +656,24 @@ int main( int argc, char** argv )
     {
       SLIC_ERROR("Couldn't write results to "<< params.collisionsTextName());
     }
+
+    if( params.verboseOutput && !collisions.empty() )
+    {
+      SLIC_INFO("Intersecting triangle pairs:");
+      // Initialize pairs of clashes
+      for (auto i : collisions)
+      {
+        auto t1 = getMeshTriangle(i.first, surface_mesh);
+        auto t2 = getMeshTriangle(i.second, surface_mesh);
+
+        SLIC_INFO( "  Triangle " << i.first << " -- "
+            << std::setprecision(17) << t1);
+        SLIC_INFO( "  Triangle " << i.second << " -- "
+            << std::setprecision(17) << t2 << "\n");
+        SLIC_INFO( "  ");
+      }
+    }
+
   }
 
   // Look for holes---must be welded

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -195,6 +195,7 @@ void Input::parse(int argc, char** argv, CLI::App& app)
     << (resolution == 1 && policy == raja_cuda ? " (use RAJA CUDA policy)" : "")
     <<"\n  weld threshold = " <<  weldThreshold
     <<"\n  " << (skipWeld ? "" : "not ") << "skipping weld"
+    <<"\n  intersection tolerance = " <<  intersectionThreshold
     <<"\n  infile = " << stlInput
     <<"\n  collisions outfile = " << collisionsMeshName()
     <<"\n  weld outfile = " << weldMeshName()  );

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -88,24 +88,16 @@ struct Input
 {
   static const std::set<RuntimePolicy> s_validPolicies;
 
-  std::string stlInput;
-  std::string vtkOutput;
-  RuntimePolicy policy;
+  std::string stlInput {""};
+  std::string vtkOutput {""};
+  RuntimePolicy policy {seq};
 
-  int resolution;
-  double weldThreshold;
-  bool skipWeld;
-  bool verboseOutput;
+  int resolution {0};
+  double weldThreshold {1e-6};
+  bool skipWeld {false};
+  bool verboseOutput {false};
 
-  Input()
-    : stlInput("")
-    , vtkOutput("")
-    , policy(seq)
-    , resolution(0)
-    , weldThreshold(1e-6)
-    , skipWeld(false)
-    , verboseOutput(false)
-  { };
+  Input() = default;
 
   void parse(int argc, char** argv, CLI::App& app);
 


### PR DESCRIPTION
# Summary

- Fixes #261 
- It exposes the tolerance threshold `EPS` for determining triangle intersections to the user.
- It sets the default tolerance for triangle intersection to `1E-8`. Previously, the intersections were getting a default of `1E-12` in the fuzzy comparison tests.
- This tolerance option is also exposed to users in the `mesh_tester` app
- I've also added a regression test derived from the mesh in #261

