### PR TITLE
clang9 workaround

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -60,6 +60,11 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   ex. `level_error` is now `message_error`.
 
 ### Fixed
+- Fixed issue in Mint that would cause the clang@9.0.0 compiler to segfault. The
+  `mint_cell_types.cpp` test was causing a segfault in the compiler. The main
+  issue triggering this compiler bug was the use of `constexpr` when defining the
+  static `cell_info` array of structs. The code has been modified to use `const`
+  instead.
 - Fixed issue in Quest's Signed Distance query that would prevent consecutive
   calls to Quest when MPI-3 shared memory is enabled due to not properly 
   nullifying internal pointers when finalize is called.

--- a/src/axom/mint/examples/mint_unstructured_single_topology_mesh.cpp
+++ b/src/axom/mint/examples/mint_unstructured_single_topology_mesh.cpp
@@ -28,11 +28,10 @@ int main( int AXOM_NOT_USED(argc), char** AXOM_NOT_USED(argv) )
   constexpr axom::IndexType X_EXTENT = 11;
   constexpr axom::IndexType Y_EXTENT = 11;
   constexpr double SPACING = 1.0;
-  constexpr mint::CellType CELL_TYPE = mint::QUAD;
-  constexpr axom::IndexType NODES_PER_CELL =
-    mint::getCellInfo( CELL_TYPE ).num_nodes;
-  constexpr axom::IndexType NUM_NODES = X_EXTENT * Y_EXTENT;
-  constexpr axom::IndexType NUM_CELLS = (X_EXTENT - 1) * (Y_EXTENT - 1);
+  constexpr mint::CellType CELL_TYPE       = mint::QUAD;
+  constexpr axom::IndexType NODES_PER_CELL = 4;
+  constexpr axom::IndexType NUM_NODES      = X_EXTENT * Y_EXTENT;
+  constexpr axom::IndexType NUM_CELLS      = (X_EXTENT - 1) * (Y_EXTENT - 1);
 
   constexpr double HI  = -10.0;
   constexpr double LO  = 10.0;

--- a/src/axom/mint/mesh/CellTypes.hpp
+++ b/src/axom/mint/mesh/CellTypes.hpp
@@ -72,23 +72,23 @@ constexpr int NUM_CELL_TYPES = static_cast< int >( CellType::NUM_CELL_TYPES );
  * \param FACE_NODES an array; the node offsets specifying each face
  *        (CCW, so normal points out).
  */
-#define REGISTER_CELL_INFO( MINT_CELL_TYPE, MINT_NAME, BP_NAME, VTK_TYPE,   \
+#define REGISTER_CELL_INFO( MINT_CELL_TYPE, MINT_NAME, BP_NAME, VTK_TYPE,    \
                             N_NODES, N_FACES, N_FACE_NODES, FACE_CELL_TYPES, \
-                            FACE_NODES )                                    \
-  namespace internal                                                        \
-  {                                                                         \
-  static constexpr CellInfo MINT_CELL_TYPE ## _INFO =                       \
-  {                                                                         \
-    MINT_CELL_TYPE,                                                         \
-    MINT_NAME,                                                              \
-    BP_NAME,                                                                \
-    VTK_TYPE,                                                               \
-    N_NODES,                                                                \
-    N_FACES,                                                                \
-    N_FACE_NODES,                                                           \
-    FACE_CELL_TYPES,                                                        \
-    FACE_NODES                                                              \
-  };                                                                        \
+                            FACE_NODES )                                     \
+  namespace internal                                                         \
+  {                                                                          \
+  static const CellInfo MINT_CELL_TYPE ## _INFO =                            \
+  {                                                                          \
+    MINT_CELL_TYPE,                                                          \
+    MINT_NAME,                                                               \
+    BP_NAME,                                                                 \
+    VTK_TYPE,                                                                \
+    N_NODES,                                                                 \
+    N_FACES,                                                                 \
+    N_FACE_NODES,                                                            \
+    FACE_CELL_TYPES,                                                         \
+    FACE_NODES                                                               \
+  };                                                                         \
   }
 
 /*!
@@ -219,7 +219,7 @@ REGISTER_CELL_INFO( HEX27, "HEX27", "hex27-no-bp", 29, 27, 6,
  * \note The order at which CellInfo for each type is added has to match
  *  the order of the cell types in the CellTypes enum above.
  */
-static constexpr CellInfo cell_info[ NUM_CELL_TYPES ] = {
+static const CellInfo cell_info[ NUM_CELL_TYPES ] = {
   CELL_INFO( VERTEX ),
   CELL_INFO( SEGMENT ),
   CELL_INFO( TRIANGLE ),

--- a/src/axom/mint/tests/CMakeLists.txt
+++ b/src/axom/mint/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set( mint_tests
 
      ## mesh tests
      mint_mesh.cpp
+     mint_mesh_cell_types.cpp
      mint_mesh_blueprint.cpp
      mint_mesh_connectivity_array.cpp
      mint_mesh_coordinates.cpp
@@ -38,13 +39,6 @@ set( mint_tests
      mint_su2_io.cpp
      mint_util_write_vtk.cpp
    )
-
-if(NOT (("${CMAKE_CXX_COMPILER_VERSION}" VERSION_EQUAL "9.0.0") AND
-   ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))
-    # This test causes a compiler seg fault in clang@9.0.0,
-    # codes are still using mint with that compiler though
-    list(APPEND mint_tests mint_mesh_cell_types.cpp)
-endif()
 
 ## lists all axom depencies used for testing
 set( mint_test_dependencies

--- a/src/axom/mint/tests/mint_mesh_connectivity_array.cpp
+++ b/src/axom/mint/tests/mint_mesh_connectivity_array.cpp
@@ -29,8 +29,8 @@ namespace mint
 
 const char IGNORE_OUTPUT[] = ".*";
 
-constexpr IndexType vertex_stride = getCellInfo( VERTEX ).num_nodes;
-constexpr IndexType hex_stride = getCellInfo( HEX ).num_nodes;
+constexpr IndexType vertex_stride = 1;
+constexpr IndexType hex_stride = 8;
 
 namespace internal
 {


### PR DESCRIPTION
# Summary

The clang@9.0.0 compiler was segfaulting when compiling
the mint_cell_types.cpp unit test. The key issue that
was triggering this is the use of `constexpr` when
defining the static cell_info array in CellTypes.hpp.

This appears to be a bug in the clang@9.0.0 compiler.
    
Although it would be nice to use `constexpr` for the
cell info, Mint does not rely on this. So, to workaround this 
issue, the code has been changed to use `const` instead 
of `constexpr`.
    
In addition, the `mint_cell_types.cpp` unit test is now re-enabled for 
all specs.
    
Resolves #266
