### PR TITLE
BUGFIX: Using proper variables in ImplicitGrid Constructor

### DIFF
--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -127,20 +127,13 @@ public:
    
     GridCell res;
     if(gridRes != nullptr){
-        if(NDIMS == 2){
-            res = GridCell::make_point(gridRes[0], gridRes[1]);
-        }
-        else if(NDIMS == 3){
-            res = GridCell::make_point(gridRes[0], gridRes[1], gridRes[2]);
-        }
+            res = GridCell(gridRes, NDIMS);
     }
-    
-    const GridCell* pRes =
-      (gridRes != nullptr) ? &res : nullptr;
 
     initialize(
       SpatialBoundingBox( SpacePoint(bbMin), SpacePoint(bbMax) ),
-      pRes, numElts);
+      (gridRes != nullptr) ? &res : nullptr, 
+      numElts);
   }
 
   /*! Predicate to check if the ImplicitGrid has been initialized */

--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -127,7 +127,7 @@ public:
    
     GridCell res;
     if(gridRes != nullptr){
-            res = GridCell(gridRes, NDIMS);
+      res = GridCell(gridRes, NDIMS);
     }
 
     initialize(

--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -124,8 +124,19 @@ public:
 
     // Set up the grid resolution from the gridRes array
     //   if NULL, GridCell parameter to initialize should also be NULL
+   
+    GridCell res;
+    if(gridRes != nullptr){
+        if(NDIMS == 2){
+            res = GridCell::make_point(gridRes[0], gridRes[1]);
+        }
+        else if(NDIMS == 3){
+            res = GridCell::make_point(gridRes[0], gridRes[1], gridRes[2]);
+        }
+    }
+    
     const GridCell* pRes =
-      (gridRes != nullptr) ? &m_gridRes : nullptr;
+      (gridRes != nullptr) ? &res : nullptr;
 
     initialize(
       SpatialBoundingBox( SpacePoint(bbMin), SpacePoint(bbMax) ),

--- a/src/axom/spin/tests/spin_implicit_grid.cpp
+++ b/src/axom/spin/tests/spin_implicit_grid.cpp
@@ -67,17 +67,20 @@ TYPED_TEST( ImplicitGridTest, initialization)
 
   grid1.initialize(bbox, &res, numElts);
   EXPECT_TRUE( grid1.isInitialized() );
-
-
+  EXPECT_EQ(grid1.gridResolution()[0], res[0]);
+  EXPECT_EQ(grid1.numIndexElements(), numElts); 
+ 
   // Tests initializing constructor
   GridT grid2( bbox, &res, numElts);
   EXPECT_TRUE( grid2.isInitialized() );
-
+  EXPECT_EQ(grid2.gridResolution()[0], res[0]); 
+  EXPECT_EQ(grid2.numIndexElements(), numElts); 
 
   // Tests initializing from primitive types
   GridT grid3( bbox.getMin().data(), bbox.getMax().data(), res.data(), numElts);
   EXPECT_TRUE( grid3.isInitialized() );
-
+  EXPECT_EQ(grid3.gridResolution()[0], res.data()[0]); 
+  EXPECT_EQ(grid3.numIndexElements(), numElts); 
 }
 
 

--- a/src/axom/spin/tests/spin_implicit_grid.cpp
+++ b/src/axom/spin/tests/spin_implicit_grid.cpp
@@ -67,19 +67,19 @@ TYPED_TEST( ImplicitGridTest, initialization)
 
   grid1.initialize(bbox, &res, numElts);
   EXPECT_TRUE( grid1.isInitialized() );
-  EXPECT_EQ(grid1.gridResolution()[0], res[0]);
+  EXPECT_EQ(grid1.gridResolution(), res);
   EXPECT_EQ(grid1.numIndexElements(), numElts); 
  
   // Tests initializing constructor
   GridT grid2( bbox, &res, numElts);
   EXPECT_TRUE( grid2.isInitialized() );
-  EXPECT_EQ(grid2.gridResolution()[0], res[0]); 
+  EXPECT_EQ(grid2.gridResolution(), res); 
   EXPECT_EQ(grid2.numIndexElements(), numElts); 
 
   // Tests initializing from primitive types
   GridT grid3( bbox.getMin().data(), bbox.getMax().data(), res.data(), numElts);
   EXPECT_TRUE( grid3.isInitialized() );
-  EXPECT_EQ(grid3.gridResolution()[0], res.data()[0]); 
+  EXPECT_EQ(grid3.gridResolution(), res.data()); 
   EXPECT_EQ(grid3.numIndexElements(), numElts); 
 }
 

--- a/src/axom/spin/tests/spin_implicit_grid.cpp
+++ b/src/axom/spin/tests/spin_implicit_grid.cpp
@@ -79,7 +79,7 @@ TYPED_TEST( ImplicitGridTest, initialization)
   // Tests initializing from primitive types
   GridT grid3( bbox.getMin().data(), bbox.getMax().data(), res.data(), numElts);
   EXPECT_TRUE( grid3.isInitialized() );
-  EXPECT_EQ(grid3.gridResolution(), res.data()); 
+  EXPECT_EQ(grid3.gridResolution(), res); 
   EXPECT_EQ(grid3.numIndexElements(), numElts); 
 }
 


### PR DESCRIPTION
# Summary

This PR is a bugfix for ImplicitGrid in Spin. It ensures that the constructor for an ImplicitGrid from raw doubles and integers utilizes the integer argument for resolution of the grid. Previously, it would always take the values 0 for the resolution in all dimensions, due to pulling from an internal data structure. It does so by allocating a Point using the supplied values, then using that for further initialization, thus maintaining the data types used for the rest of the code. 

Also included is an expansion of the existing unit test for the initialization of ImplicitGrid, ensuring that values are being properly used.