### PR TITLE
Fixes some compiler warnings on LLNL clusters

### DIFF
--- a/src/axom/core/tests/core_stack_array.cpp
+++ b/src/axom/core/tests/core_stack_array.cpp
@@ -87,9 +87,9 @@ struct Tensor
 {
   double x, y, z;
 
-  Tensor() :
-    x(), y(), z()
-  {}
+  Tensor() = default;
+  Tensor(const Tensor& other) = default;
+
 
   explicit Tensor( double val ) :
     x( 3 * val ), y( 3 * val + 1 ), z( 3 * val + 2 )

--- a/src/axom/slam/OrderedSet.hpp
+++ b/src/axom/slam/OrderedSet.hpp
@@ -114,15 +114,8 @@ public:
     , SubsettingPolicyType(builder.m_parent)
   {}
 
-  OrderedSet(const OrderedSet& oset)
-    : SizePolicyType(oset)
-    , OffsetPolicyType(oset)
-    , StridePolicyType(oset)
-    , IndirectionPolicyType(oset)
-    , SubsettingPolicyType(oset)
-  {}
-
-
+  OrderedSet(const OrderedSet& oset) = default;
+  OrderedSet& operator=(const OrderedSet& other) = default;
 
 public:
 

--- a/src/axom/slam/examples/HandleMesh.cpp
+++ b/src/axom/slam/examples/HandleMesh.cpp
@@ -36,6 +36,8 @@ struct Handle
   Handle() : mID(T()) {}
   explicit Handle(T id) : mID(id) {}
   Handle(const Handle& h) : mID(h.mID) {}
+  Handle& operator=(const Handle& h) = default;
+
   bool operator==(const Handle& h) const { return mID == h.mID; }
 
   static Handle make_handle(T id) { return Handle(id); }

--- a/src/axom/spin/internal/linear_bvh/vec.hpp
+++ b/src/axom/spin/internal/linear_bvh/vec.hpp
@@ -38,8 +38,8 @@ public:
   //
   //  Use only default contructors to keep this a POD type
   //
-  inline AXOM_HOST_DEVICE Vec<T,S>() = default;
-  inline AXOM_HOST_DEVICE Vec<T,S>(const Vec<T,S>& v) = default;
+  inline Vec<T,S>() = default;
+  inline Vec<T,S>(const Vec<T,S>& v) = default;
 
   inline AXOM_HOST_DEVICE bool operator==(const Vec<T,S> &other) const
   {

--- a/src/axom/spin/internal/linear_bvh/vec.hpp
+++ b/src/axom/spin/internal/linear_bvh/vec.hpp
@@ -36,8 +36,10 @@ public:
   T m_data[S];
 
   //
-  //  No contructors so this is a POD type
+  //  Use only default contructors to keep this a POD type
   //
+  inline AXOM_HOST_DEVICE Vec<T,S>() = default;
+  inline AXOM_HOST_DEVICE Vec<T,S>(const Vec<T,S>& v) = default;
 
   inline AXOM_HOST_DEVICE bool operator==(const Vec<T,S> &other) const
   {

--- a/src/docs/sphinx/dev_guide/github.rst
+++ b/src/docs/sphinx/dev_guide/github.rst
@@ -3,7 +3,7 @@
 .. ##
 .. ## SPDX-License-Identifier: (BSD-3-Clause)
 
-.. github-label:
+.. _github-label:
 
 ******************************************************
 Git/Github: Version Control and Branch Development 

--- a/src/examples/using-with-blt/example.cpp
+++ b/src/examples/using-with-blt/example.cpp
@@ -15,7 +15,7 @@
 
 #include <iostream>
 
-int main(int argc, char **argv)
+int main()
 {
    // Using fmt library exported by axom
    std::cout << fmt::format(

--- a/src/examples/using-with-cmake/example.cpp
+++ b/src/examples/using-with-cmake/example.cpp
@@ -15,7 +15,7 @@
 
 #include <iostream>
 
-int main(int argc, char **argv)
+int main()
 {
    // Using fmt library exported by axom
    std::cout << fmt::format(

--- a/src/examples/using-with-make/example.cpp
+++ b/src/examples/using-with-make/example.cpp
@@ -14,7 +14,7 @@
 
 #include "axom/core/utilities/About.hpp"
 
-int main(int argc, char **argv)
+int main()
 {
    axom::about();
 }

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -599,32 +599,33 @@ int main( int argc, char** argv )
     axom::utilities::Timer timer(true);
     if (params.resolution == 1)
     {
-     // Naive method
-     switch (params.policy)
-     {
-     case seq:
-      collisions = naiveIntersectionAlgorithm(surface_mesh, degenerate, params.intersectionThreshold);
-  #ifdef AXOM_USE_RAJA
-     case raja_seq:
+      switch (params.policy)
+      {
+      case seq:
+        collisions = naiveIntersectionAlgorithm(surface_mesh, degenerate, params.intersectionThreshold);
+        break;
+    #ifdef AXOM_USE_RAJA
+      case raja_seq:
         collisions = naiveIntersectionAlgorithm< seq_exec >(surface_mesh,
-                                                          degenerate, params.intersectionThreshold);
-       break;
-    #ifdef AXOM_USE_OPENMP
-     case raja_omp:
+                                                            degenerate, params.intersectionThreshold);
+        break;
+     #ifdef AXOM_USE_OPENMP
+      case raja_omp:
         collisions = naiveIntersectionAlgorithm< omp_exec >(surface_mesh,
-                                                          degenerate, params.intersectionThreshold);
-       break;
-    #endif
-    #ifdef AXOM_USE_CUDA
-     case raja_cuda:
+                                                            degenerate, params.intersectionThreshold);
+        break;
+     #endif
+     #ifdef AXOM_USE_CUDA
+      case raja_cuda:
         collisions = naiveIntersectionAlgorithm< cuda_exec >(surface_mesh,
-                                                          degenerate, params.intersectionThreshold);
-       break;
-    #endif
-  #endif // AXOM_USE_RAJA
+                                                             degenerate, params.intersectionThreshold);
+        break;
+     #endif
+    #endif // AXOM_USE_RAJA
+
      default:
-       SLIC_ERROR("Unhandled runtime policy case " << params.policy );
-       break;
+        SLIC_ERROR("Unhandled runtime policy case " << params.policy );
+        break;
      }
     }
     else


### PR DESCRIPTION
# Summary

- This PR fixes some compiler warnings after a recent upgrade to several `host-configs` on LLNL's `toss3` clusters.

## Notes

- Our clang host-configs still have the following warnings due to what appears to be an MPI build on the default gcc compiler:
`/usr/bin/ld: warning: libgfortran.so.3, needed by /usr/tce/packages/mvapich2/mvapich2-2.3-clang-10.0.0/lib/libmpi.so, may conflict with libgfortran.so.5`
- There are still numerous warnings about incorrect/invalide host/device decoration. I believe @bmhan12 has a forthcoming PR to address this.  (Possibly #249 ?)