### PR TITLE
Fixes a 2D triangle intersection case

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ## [Unreleased] - Release date yyyy-mm-dd
 
 ### Added
+- Exposed the tolerance parameter `EPS` that is used to determine intersections between
+  triangles in `primal:intersect()` as an optional final parameter.
 - Added BVH spatial index option to the `mesh_tester` utility for calculating
   triangle-triangle intersection.
 - Added `axom::execution_space< ExecSpace >::onDevice()` to check if execution
@@ -79,6 +81,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   `iomanager_new` is now `IOManager`
 
 ### Fixed
+- Fixed a triangle-triangle intersection case in primal that produced inconsistent results
+  depending on the order of the triangle's vertices.
 - Fixed issue in the parallel construction of the BVH on GPUs, due to incoherent
   L1 cache that could result in some data corruption in the BVH. The code now
   calls ``__threadfence_system()`` after the parent is computed and stored back

--- a/src/axom/primal/operators/detail/intersect_impl.cpp
+++ b/src/axom/primal/operators/detail/intersect_impl.cpp
@@ -330,35 +330,40 @@ inline bool checkVertex(const Point2& p1,
                         bool includeBoundary,
                         double EPS)
 {
-  if (isGpeq(twoDcross(r2, p2, q1), 0.0, includeBoundary, EPS))
+  // The tests `isGpeq(twoDcross(...))` are checking the orientation
+  // of the triangle defined by its three arguments (CCW vs CW)
+  // Note: Comments in this function refer to regions 
+  // in Figure 8 of the paper: https://hal.inria.fr/inria-00072100/document
+
+  if (isGpeq(twoDcross(r2, p2, q1), 0.0, includeBoundary, EPS))                // q1 is in {R_22, R_23, R_24, R_25}
   {
-    if (isGpeq(twoDcross(q2, r2, q1), 0.0, includeBoundary, EPS))
+    if (isGpeq(twoDcross(q2, r2, q1), 0.0, includeBoundary, EPS))                  // q1 is in {R_23, R_24} or possibly R_22
     {
-      if (isGpeq(twoDcross(p1, p2, q1), 0.0, includeBoundary, EPS))
+      if (isGpeq(twoDcross(p1, p2, q1), 0.0, includeBoundary, EPS))                    // q1 in in R_23  or possible R_22
       {
         if (isLpeq(twoDcross(p1, q2, q1), 0.0, includeBoundary, EPS))
         {
-          return true;
+          return true;                                                                       // q1 is in R_23  -- intersect
         }
         else
         {
-          return false;
+          return false;                                                                      // q1 in in R_22 -- no intersection
         }
       }
-      else
+      else                                                                             // q1 is in R_24
       {
         if (isGpeq(twoDcross(p1, p2, r1), 0.0, includeBoundary, EPS) &&
-            isGpeq(twoDcross(r2, p2, r1), 0.0, includeBoundary, EPS))
+            isLpeq(twoDcross(q1, p2, r1), 0.0, includeBoundary, EPS))
         {
-          return true;
+          return true;                                                                     // r1 is in R_23 -- intersect!
         }
         else
         {
-          return false;
+          return false;                                                                    // no intersection 
         }
       }
     }
-    else
+    else                                                                           // q1 is in {R_22, R_25}
     {
       if (isLpeq(twoDcross(p1, q2, q1), 0.0, includeBoundary, EPS) &&
           isGpeq(twoDcross(q2, r2, r1), 0.0, includeBoundary, EPS) &&
@@ -372,7 +377,7 @@ inline bool checkVertex(const Point2& p1,
       }
     }
   }
-  else
+  else                                                                         // q1 is in R_21
   {
     if (isGpeq(twoDcross(r2, p2, r1), 0.0, includeBoundary, EPS))
     {

--- a/src/axom/primal/operators/detail/intersect_impl.cpp
+++ b/src/axom/primal/operators/detail/intersect_impl.cpp
@@ -332,8 +332,10 @@ inline bool checkVertex(const Point2& p1,
 {
   // The tests `isGpeq(twoDcross(...))` are checking the orientation
   // of the triangle defined by its three arguments (CCW vs CW)
-  // Note: Comments in this function refer to regions 
+  // Note: Comments in this function refer to regions
   // in Figure 8 of the paper: https://hal.inria.fr/inria-00072100/document
+
+  /* *INDENT-OFF* */
 
   if (isGpeq(twoDcross(r2, p2, q1), 0.0, includeBoundary, EPS))                // q1 is in {R_22, R_23, R_24, R_25}
   {
@@ -359,7 +361,7 @@ inline bool checkVertex(const Point2& p1,
         }
         else
         {
-          return false;                                                                    // no intersection 
+          return false;                                                                    // no intersection
         }
       }
     }
@@ -410,6 +412,8 @@ inline bool checkVertex(const Point2& p1,
       return false;
     }
   }
+
+  /* *INDENT-ON* */
 }
 
 // -----------------------------------------------------------------------------

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -44,7 +44,7 @@ namespace primal
  * \param [in] t2 The second triangle
  * \param [in] includeBoundary Indicates if boundaries should be considered
  * when detecting intersections (default: false)
- * \param [in] EPS Tolerance threshold for determining intersections (default: 1E-8)
+ * \param [in] EPS Tolerance for determining intersections (default: 1E-8)
  * \return status true iff t1 intersects with t2, otherwise, false.
  *
  * If parameter \a includeBoundary is false (default), this function will
@@ -67,7 +67,7 @@ bool intersect( const Triangle< T, 3 >& t1,
  * \param [in] t2 The second triangle
  * \param [in] includeBoundary Indicates if boundaries should be considered
  * when detecting intersections (default: false)
- * \param [in] EPS Tolerance threshold for determining intersections (default: 1E-8)
+ * \param [in] EPS Tolerance for determining intersections (default: 1E-8)
  * \return status true iff t1 intersects with t2, otherwise, false.
  *
  * If parameter \a includeBoundary is false (default), this function will

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -5,6 +5,8 @@
 
 #include "gtest/gtest.h"
 
+#include "fmt/fmt.hpp"
+
 #include "axom/slic/interface/slic.hpp"
 
 #include "axom/primal/geometry/OrientedBoundingBox.hpp"
@@ -966,18 +968,124 @@ TEST( primal_intersect, 3D_triangle_triangle_intersection_regression )
   {
     // https://github.com/LLNL/axom/issues/152
     std::string msg = "From Axom github issue #152";
-    Triangle3 tri3d_1( Point3::make_point(76.648, 54.6752, 15.0012),
-                       Point3::make_point(76.648, 54.6752, 14.5542),
-                       Point3::make_point(76.582, 54.6752, 14.7879) );
-  
-    Triangle3 tri3d_2( Point3::make_point(76.6252, 54.6752, 14.892),
-                       Point3::make_point(76.582, 54.6752, 14.7879),
-                       Point3::make_point(76.5617,54.6752,14.7929) );
+    Point3 vdata[] = { Point3::make_point(76.648,  54.6752, 15.0012),
+                       Point3::make_point(76.648,  54.6752, 14.5542),
+                       Point3::make_point(76.582,  54.6752, 14.7879),
+                       Point3::make_point(76.6252, 54.6752, 14.892),
+                       Point3::make_point(76.5617, 54.6752, 14.7929) };
+
+    Triangle3 tri3d_1(vdata[0], vdata[1], vdata[2]);
+    Triangle3 tri3d_2(vdata[3], vdata[2], vdata[4]);
+
+    // Output some debugging information about this configuration
+    // (change logging level to Debug to see these messages)
+    SLIC_DEBUG("Triangle 1: " << tri3d_1);
+    SLIC_DEBUG("Triangle 2: " << tri3d_2);
+
+    for(int i=0; i<3; ++i)
+    {
+      SLIC_DEBUG("t1 " << i << "-- distance " << tri3d_1[i] << " to tri2: " 
+          << std::setprecision(17)
+          << sqrt( primal::squared_distance( tri3d_1[i], tri3d_2 ) )
+          << " -- closest point: " << primal::closest_point(tri3d_1[i], tri3d_2));
+    }
+
+    for(int i=0; i<3; ++i)
+    {
+      SLIC_DEBUG("t2 " << i << "-- distance " << tri3d_2[i] << " to tri1: " 
+          << std::setprecision(17)
+          << sqrt( primal::squared_distance( tri3d_2[i], tri3d_1) )
+          << " -- closest point: " << primal::closest_point(tri3d_2[i], tri3d_1));
+    }
+
+    const bool expectIntersect = true;
+    permuteCornersTest(tri3d_1, tri3d_2, msg, false, expectIntersect);
+    permuteCornersTest(tri3d_1, tri3d_2, msg, true, expectIntersect);
+  }
+
+  {
+    // https://github.com/LLNL/axom/issues/152
+    std::string msg = "From Axom github issue #152 (simplified)";
+    Point3 vdata[] = { Point3::make_point( 0.066,  0,  0.2133).
+                       Point3::make_point( 0.066,  0, -0.2337),
+                       Point3::make_point( 0,      0,  0),
+                       Point3::make_point( 0.0432, 0,  0.1041),
+                       Point3::make_point(-0.0203, 0,  0.005) };
+
+    Triangle3 tri3d_1(vdata[0], vdata[1], vdata[2]);
+    Triangle3 tri3d_2(vdata[3], vdata[2], vdata[4]);
 
     permuteCornersTest(tri3d_1, tri3d_2, msg, false, false);
     permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
   }  
 
+
+  {
+    // https://github.com/LLNL/axom/issues/152
+    std::string msg = "From Axom github issue #152 (simplified 2) -- one point inside other triangle";
+    Point3 vdata[] = { Point3::make_point( 1,   0,  0.5 ),
+                       Point3::make_point( 1,   0, -0.5 ),
+                       Point3::make_point( 0,   0,  0  ),
+                       Point3::make_point( 0.5, 0,  0.1),
+                       Point3::make_point(-0.1, 0, -0.2) };
+
+    Triangle3 tri3d_1(vdata[0], vdata[1], vdata[2]);
+    Triangle3 tri3d_2(vdata[3], vdata[2], vdata[4]);
+
+    permuteCornersTest(tri3d_1, tri3d_2, msg, false, true);
+    permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
+  }  
+
+  {
+    // https://github.com/LLNL/axom/issues/152
+    std::string msg = "From Axom github issue #152 (simplified 3) -- one point inside other triangle";
+    Point3 vdata[] = { Point3::make_point( 1,   0,  0.5 ),
+                       Point3::make_point( 1,   0, -0.5 ),
+                       Point3::make_point( 0,   0,  0  ),
+                       Point3::make_point( 0.5, 0,  0.1),
+                       Point3::make_point(-0.1, 0,  0.05) };
+
+    Triangle3 tri3d_1(vdata[0], vdata[1], vdata[2]);
+    Triangle3 tri3d_2(vdata[3], vdata[2], vdata[4]);
+
+    permuteCornersTest(tri3d_1, tri3d_2, msg, false, true);
+    permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
+  }  
+
+
+  {
+    // https://github.com/LLNL/axom/issues/152
+    std::string msg = "From Axom github issue #152 (simplified 4) -- one point inside other triangle";
+    Point3 vdata[] = { Point3::make_point( 1,   0,  0.5 ),
+                       Point3::make_point( 1,   0, -0.5 ),
+                       Point3::make_point( 0,   0,  0  ),
+                       Point3::make_point( 0.5, 0,  0.1),
+                       Point3::make_point(-0.1, 0,  0.06) };
+
+    Triangle3 tri3d_1(vdata[0], vdata[1], vdata[2]);
+    Triangle3 tri3d_2(vdata[3], vdata[2], vdata[4]);
+
+    permuteCornersTest(tri3d_1, tri3d_2, msg, false, true);
+    permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
+  }  
+
+  {
+    // https://github.com/LLNL/axom/issues/152
+    std::string msg = "From Axom github issue #152 (simplified 5) -- one point inside other triangle";
+    Point3 vdata[] = { Point3::make_point( 1,   0,  0.5 ),
+                       Point3::make_point( 1,   0, -0.5 ),
+                       Point3::make_point( 0,   0,  0  ),
+                       Point3::make_point( 0.5, 0,  0.1),
+                       Point3::make_point(-0.1, 0,  0.04) };
+
+    Triangle3 tri3d_1(vdata[0], vdata[1], vdata[2]);
+    Triangle3 tri3d_2(vdata[3], vdata[2], vdata[4]);
+
+    permuteCornersTest(tri3d_1, tri3d_2, msg, false, true);
+    permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
+  }  
+
+  // Revert logging level to Warning
   axom::slic::setLoggingMsgLevel( axom::slic::message::Warning);
 }
 

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -63,7 +63,8 @@ void permuteCornersTest(const primal::Triangle< double, DIM > & a,
                         const primal::Triangle< double, DIM > & b,
                         const std::string & whattest,
                         const bool includeBdry,
-                        const bool testtrue)
+                        const bool testtrue,
+                        double EPS = 1E-8)
 {
   SCOPED_TRACE(whattest + (includeBdry ?
                            " (including boundary)" :
@@ -76,7 +77,9 @@ void permuteCornersTest(const primal::Triangle< double, DIM > & a,
   {
     for (int j = 0 ; j < 3 ; ++j)
     {
-      if(primal::intersect(roll(a, i), roll(b, j),includeBdry) != testtrue)
+      auto t1 = roll(a, i);
+      auto t2 = roll(b, j);
+      if(primal::intersect(t1, t2,includeBdry, EPS) != testtrue)
       {
         ++numFailures;
       }
@@ -90,7 +93,9 @@ void permuteCornersTest(const primal::Triangle< double, DIM > & a,
   {
     for (int j = 0 ; j < 3 ; ++j)
     {
-      if(primal::intersect(roll(ap, i), roll(bp, j),includeBdry) != testtrue)
+      auto t1 = roll(ap, i);
+      auto t2 = roll(bp, j);
+      if(primal::intersect(t1, t2, includeBdry, EPS) != testtrue)
       {
         ++numFailures;
       }
@@ -103,7 +108,9 @@ void permuteCornersTest(const primal::Triangle< double, DIM > & a,
   {
     for (int j = 0 ; j < 3 ; ++j)
     {
-      if(primal::intersect(roll(b, i), roll(a, j),includeBdry) != testtrue)
+      auto t1 = roll(b, i);
+      auto t2 = roll(a, j);
+      if(primal::intersect(t1, t2, includeBdry) != testtrue)
       {
         ++numFailures;
       }
@@ -114,7 +121,9 @@ void permuteCornersTest(const primal::Triangle< double, DIM > & a,
   {
     for (int j = 0 ; j < 3 ; ++j)
     {
-      if(primal::intersect(roll(bp, i), roll(ap, j),includeBdry) != testtrue)
+      auto t1 = roll(bp, i);
+      auto t2 = roll(ap, j);
+      if(primal::intersect(t1, t2, includeBdry) != testtrue)
       {
         ++numFailures;
       }

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -450,7 +450,7 @@ TEST( primal_intersect, 2D_triangle_triangle_intersection_barycentric )
   // Add some barycentric coordinates w.r.t. the input triangle
   for(double x : {-0.2, -0.1, 0.0, 0.1, 0.2})
   {
-    for(int j = -6; j <= 6; j+=3)
+    for(int j = -6; j <= 6; ++j)
     {
       Bary b;
       b[0] = x;

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -450,7 +450,7 @@ TEST( primal_intersect, 2D_triangle_triangle_intersection_barycentric )
   // Add some barycentric coordinates w.r.t. the input triangle
   for(double x : {-0.2, -0.1, 0.0, 0.1, 0.2})
   {
-    for(int j = -6; j <= 6; ++j)
+    for(int j = -6 ; j <= 6 ; ++j)
     {
       Bary b;
       b[0] = x;
@@ -466,17 +466,18 @@ TEST( primal_intersect, 2D_triangle_triangle_intersection_barycentric )
   bool includeBdry = true;
 
   int sz = bary.size();
-  for(int i=0; i< sz-1; ++i)
+  for(int i=0 ; i< sz-1 ; ++i)
   {
-    for(int j=i; j<sz; ++j)
+    for(int j=i ; j<sz ; ++j)
     {
-      Triangle2 triB ( p0, 
-                       triA.baryToPhysical(bary[i]), 
+      Triangle2 triB ( p0,
+                       triA.baryToPhysical(bary[i]),
                        triA.baryToPhysical(bary[j]));
 
       if(!triB.degenerate())
       {
-        std::string str = fmt::format("Tri2D-Tri2D from barycenters. b1:{}, b2:{}", bary[i], bary[j]);
+        std::string str = fmt::format(
+          "Tri2D-Tri2D from barycenters. b1:{}, b2:{}", bary[i], bary[j]);
         permuteCornersTest(triA, triB, str, !includeBdry, expectIntersect);
         permuteCornersTest(triA, triB, str, includeBdry, expectIntersect);
       }
@@ -1045,20 +1046,23 @@ TEST( primal_intersect, 3D_triangle_triangle_intersection_regression )
     SLIC_DEBUG("Triangle 1: " << tri3d_1);
     SLIC_DEBUG("Triangle 2: " << tri3d_2);
 
-    for(int i=0; i<3; ++i)
+    for(int i=0 ; i<3 ; ++i)
     {
-      SLIC_DEBUG("t1 " << i << "-- distance " << tri3d_1[i] << " to tri2: " 
-          << std::setprecision(17)
-          << sqrt( primal::squared_distance( tri3d_1[i], tri3d_2 ) )
-          << " -- closest point: " << primal::closest_point(tri3d_1[i], tri3d_2));
+      SLIC_DEBUG("t1 " << i << "-- distance " << tri3d_1[i] << " to tri2: "
+                       << std::setprecision(17)
+                       << sqrt( primal::squared_distance( tri3d_1[i],
+                                                    tri3d_2 ) )
+                       << " -- closest point: "
+                       << primal::closest_point(tri3d_1[i], tri3d_2));
     }
 
-    for(int i=0; i<3; ++i)
+    for(int i=0 ; i<3 ; ++i)
     {
-      SLIC_DEBUG("t2 " << i << "-- distance " << tri3d_2[i] << " to tri1: " 
-          << std::setprecision(17)
-          << sqrt( primal::squared_distance( tri3d_2[i], tri3d_1) )
-          << " -- closest point: " << primal::closest_point(tri3d_2[i], tri3d_1));
+      SLIC_DEBUG("t2 " << i << "-- distance " << tri3d_2[i] << " to tri1: "
+                       << std::setprecision(17)
+                       << sqrt( primal::squared_distance( tri3d_2[i], tri3d_1) )
+                       << " -- closest point: "
+                       << primal::closest_point(tri3d_2[i], tri3d_1));
     }
 
     const bool expectIntersect = true;
@@ -1080,12 +1084,13 @@ TEST( primal_intersect, 3D_triangle_triangle_intersection_regression )
 
     permuteCornersTest(tri3d_1, tri3d_2, msg, false, false);
     permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
-  }  
+  }
 
 
   {
     // https://github.com/LLNL/axom/issues/152
-    std::string msg = "From Axom github issue #152 (simplified 2) -- one point inside other triangle";
+    std::string msg =
+      "From Axom github issue #152 (simplified 2) -- one point inside other triangle";
     Point3 vdata[] = { Point3::make_point( 1,   0,  0.5 ),
                        Point3::make_point( 1,   0, -0.5 ),
                        Point3::make_point( 0,   0,  0  ),
@@ -1097,11 +1102,12 @@ TEST( primal_intersect, 3D_triangle_triangle_intersection_regression )
 
     permuteCornersTest(tri3d_1, tri3d_2, msg, false, true);
     permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
-  }  
+  }
 
   {
     // https://github.com/LLNL/axom/issues/152
-    std::string msg = "From Axom github issue #152 (simplified 3) -- one point inside other triangle";
+    std::string msg =
+      "From Axom github issue #152 (simplified 3) -- one point inside other triangle";
     Point3 vdata[] = { Point3::make_point( 1,   0,  0.5 ),
                        Point3::make_point( 1,   0, -0.5 ),
                        Point3::make_point( 0,   0,  0  ),
@@ -1113,12 +1119,13 @@ TEST( primal_intersect, 3D_triangle_triangle_intersection_regression )
 
     permuteCornersTest(tri3d_1, tri3d_2, msg, false, true);
     permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
-  }  
+  }
 
 
   {
     // https://github.com/LLNL/axom/issues/152
-    std::string msg = "From Axom github issue #152 (simplified 4) -- one point inside other triangle";
+    std::string msg =
+      "From Axom github issue #152 (simplified 4) -- one point inside other triangle";
     Point3 vdata[] = { Point3::make_point( 1,   0,  0.5 ),
                        Point3::make_point( 1,   0, -0.5 ),
                        Point3::make_point( 0,   0,  0  ),
@@ -1130,11 +1137,12 @@ TEST( primal_intersect, 3D_triangle_triangle_intersection_regression )
 
     permuteCornersTest(tri3d_1, tri3d_2, msg, false, true);
     permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
-  }  
+  }
 
   {
     // https://github.com/LLNL/axom/issues/152
-    std::string msg = "From Axom github issue #152 (simplified 5) -- one point inside other triangle";
+    std::string msg =
+      "From Axom github issue #152 (simplified 5) -- one point inside other triangle";
     Point3 vdata[] = { Point3::make_point( 1,   0,  0.5 ),
                        Point3::make_point( 1,   0, -0.5 ),
                        Point3::make_point( 0,   0,  0  ),
@@ -1146,7 +1154,7 @@ TEST( primal_intersect, 3D_triangle_triangle_intersection_regression )
 
     permuteCornersTest(tri3d_1, tri3d_2, msg, false, true);
     permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
-  }  
+  }
 
   // Revert logging level to Warning
   axom::slic::setLoggingMsgLevel( axom::slic::message::Warning);

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -954,6 +954,21 @@ TEST( primal_intersect, 3D_triangle_triangle_intersection_regression )
     permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
   }
 
+  {
+    // https://github.com/LLNL/axom/issues/152
+    std::string msg = "From Axom github issue #152";
+    Triangle3 tri3d_1( Point3::make_point(76.648, 54.6752, 15.0012),
+                       Point3::make_point(76.648, 54.6752, 14.5542),
+                       Point3::make_point(76.582, 54.6752, 14.7879) );
+  
+    Triangle3 tri3d_2( Point3::make_point(76.6252, 54.6752, 14.892),
+                       Point3::make_point(76.582, 54.6752, 14.7879),
+                       Point3::make_point(76.5617,54.6752,14.7929) );
+
+    permuteCornersTest(tri3d_1, tri3d_2, msg, false, false);
+    permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
+  }  
+
   axom::slic::setLoggingMsgLevel( axom::slic::message::Warning);
 }
 

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -112,7 +112,7 @@ void permuteCornersTest(const primal::Triangle< double, DIM > & a,
     {
       auto t1 = roll(b, i);
       auto t2 = roll(a, j);
-      if(primal::intersect(t1, t2, includeBdry) != testtrue)
+      if(primal::intersect(t1, t2, includeBdry, EPS) != testtrue)
       {
         ++numFailures;
       }
@@ -125,7 +125,7 @@ void permuteCornersTest(const primal::Triangle< double, DIM > & a,
     {
       auto t1 = roll(bp, i);
       auto t2 = roll(ap, j);
-      if(primal::intersect(t1, t2, includeBdry) != testtrue)
+      if(primal::intersect(t1, t2, includeBdry, EPS) != testtrue)
       {
         ++numFailures;
       }
@@ -1048,20 +1048,20 @@ TEST( primal_intersect, 3D_triangle_triangle_intersection_regression )
 
     for(int i=0 ; i<3 ; ++i)
     {
-      SLIC_DEBUG("t1 " << i << "-- distance " << tri3d_1[i] << " to tri2: "
+      SLIC_DEBUG("t1 " << i << "\n\t-- distance " << tri3d_1[i] << " to tri2: "
                        << std::setprecision(17)
                        << sqrt( primal::squared_distance( tri3d_1[i],
                                                     tri3d_2 ) )
-                       << " -- closest point: "
+                       << "\n\t-- closest point: "
                        << primal::closest_point(tri3d_1[i], tri3d_2));
     }
 
     for(int i=0 ; i<3 ; ++i)
     {
-      SLIC_DEBUG("t2 " << i << "-- distance " << tri3d_2[i] << " to tri1: "
+      SLIC_DEBUG("t2 " << i << "\n\t-- distance " << tri3d_2[i] << " to tri1: "
                        << std::setprecision(17)
                        << sqrt( primal::squared_distance( tri3d_2[i], tri3d_1) )
-                       << " -- closest point: "
+                       << "\n\t-- closest point: "
                        << primal::closest_point(tri3d_2[i], tri3d_1));
     }
 
@@ -1073,7 +1073,7 @@ TEST( primal_intersect, 3D_triangle_triangle_intersection_regression )
   {
     // https://github.com/LLNL/axom/issues/152
     std::string msg = "From Axom github issue #152 (simplified)";
-    Point3 vdata[] = { Point3::make_point( 0.066,  0,  0.2133).
+    Point3 vdata[] = { Point3::make_point( 0.066,  0,  0.2133),
                        Point3::make_point( 0.066,  0, -0.2337),
                        Point3::make_point( 0,      0,  0),
                        Point3::make_point( 0.0432, 0,  0.1041),
@@ -1082,8 +1082,10 @@ TEST( primal_intersect, 3D_triangle_triangle_intersection_regression )
     Triangle3 tri3d_1(vdata[0], vdata[1], vdata[2]);
     Triangle3 tri3d_2(vdata[3], vdata[2], vdata[4]);
 
-    permuteCornersTest(tri3d_1, tri3d_2, msg, false, false);
-    permuteCornersTest(tri3d_1, tri3d_2, msg, true, true);
+
+    const bool expectIntersect = true;
+    permuteCornersTest(tri3d_1, tri3d_2, msg, false, expectIntersect);
+    permuteCornersTest(tri3d_1, tri3d_2, msg, true, expectIntersect);
   }
 
 


### PR DESCRIPTION
# Summary

- Fixes #152 
- There was a bug in one of the 2D triangle-triangle intersection cases in the original paper
- I added the test case from #152 and several variations
- I also added a number of 2D triangle-triangle tests where one of the points of the second triangle are known to be inside the first triangle.  It uses points from barycentric coordinates to ensure that we can get exact edge and corner cases where the other points of the triangles are on edges and corners :)
- Minor: I ran uncrustify on primal
