### PR TITLE
Fix for adding Inlet Fields via Table

### DIFF
--- a/src/axom/inlet/Table.cpp
+++ b/src/axom/inlet/Table.cpp
@@ -85,7 +85,7 @@ std::shared_ptr<Field> Table::addDouble(const std::string& name,
   }
   
   double value;
-  if(m_reader->getDouble(name, value))
+  if(m_reader->getDouble(fullName, value))
   {
     sidreGroup->createViewScalar("value", value);
   }
@@ -104,7 +104,7 @@ std::shared_ptr<Field> Table::addInt(const std::string& name,
   }
   
   int value;
-  if(m_reader->getInt(name, value))
+  if(m_reader->getInt(fullName, value))
   {
     sidreGroup->createViewScalar("value", value);
   }
@@ -123,7 +123,7 @@ std::shared_ptr<Field> Table::addString(const std::string& name,
   }
   
   std::string value;
-  if(m_reader->getString(name, value))
+  if(m_reader->getString(fullName, value))
   {
     sidreGroup->createViewString("value", value);
   }

--- a/src/axom/inlet/tests/inlet_Inlet.cpp
+++ b/src/axom/inlet/tests/inlet_Inlet.cpp
@@ -398,6 +398,60 @@ TEST(inlet_Inlet_basic, getNestedStrings)
   EXPECT_EQ(value, "1000");
 }
 
+TEST(inlet_Inlet_basic, getNestedValuesAddedUsingTable)
+{
+  std::string strVal = "";
+  int intVal = 0;
+  double doubleVal = 0;
+  bool boolVal = false;
+  bool found = false;
+
+  std::string testString = "foo = { bar = 'yet another string'; so = 3.5; re = 9; mi = true }";
+  DataStore ds;
+  auto inlet = createBasicInlet(&ds, testString);
+
+  std::shared_ptr<axom::inlet::Field> currField;
+
+  // Check for existing fields
+  auto table = inlet->addTable("foo", "A table called foo");
+  table->required(true);
+
+  currField = table->addString("bar", "bar's description");
+  // currField = inlet->addString("foo/bar", "bar's description");
+  EXPECT_TRUE(currField);
+  currField->required(true);
+
+  currField = table->addDouble("so", "so's description");
+  EXPECT_TRUE(currField);
+
+  currField = table->addInt("re", "re's description");
+  EXPECT_TRUE(currField);
+
+  currField = table->addBool("mi", "mi's description");
+  EXPECT_TRUE(currField);
+
+  //
+  // Check stored values from get
+  //
+
+  found = inlet->get("foo/bar", strVal);
+  EXPECT_TRUE(found);
+  EXPECT_EQ(strVal, "yet another string");
+
+  found = inlet->get("foo/mi", boolVal);
+  EXPECT_TRUE(found);
+  EXPECT_EQ(boolVal, true);
+
+  found = inlet->get("foo/so", doubleVal);
+  EXPECT_TRUE(found);
+  EXPECT_EQ(doubleVal, 3.5);
+
+  found = inlet->get("foo/re", intVal);
+  EXPECT_TRUE(found);
+  EXPECT_EQ(intVal, 9);
+
+}
+
 //------------------------------------------------------------------------------
 #include "axom/slic/core/UnitTestLogger.hpp"
 using axom::slic::UnitTestLogger;

--- a/src/axom/inlet/tests/inlet_Inlet.cpp
+++ b/src/axom/inlet/tests/inlet_Inlet.cpp
@@ -417,7 +417,6 @@ TEST(inlet_Inlet_basic, getNestedValuesAddedUsingTable)
   table->required(true);
 
   currField = table->addString("bar", "bar's description");
-  // currField = inlet->addString("foo/bar", "bar's description");
   EXPECT_TRUE(currField);
   currField->required(true);
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Modifies Table.cpp to utilize the full path of a Field when adding it to the Inlet