### PR TITLE
Fix feature list and dependencies for package axom.

### DIFF
--- a/scripts/uberenv/vcpkg_ports/axom/CONTROL
+++ b/scripts/uberenv/vcpkg_ports/axom/CONTROL
@@ -1,9 +1,12 @@
 Source: axom
 Version: develop
 Description: Host-config generator for Axom TPLs
-Build-Depends: hdf5, conduit, mfem
-Default-Features: hdf5, conduit, mfem
+Default-Features: conduit, mfem
 
 Feature: mfem
 Description: Adds basic (serial) mfem support to Axom
 Build-Depends: mfem
+
+Feature: conduit
+Description: Enables data exchange using Conduit
+Build-Depends: conduit


### PR DESCRIPTION
# Summary

- This PR is a bugfix: see https://github.com/LLNL/axom/issues/288
- It allows Windows TPL and src to build in a freshly-pulled repository.
  This PR does the following:
  - Changes the vcpkg CONTROL file for the axom package so build dependencies and features are properly specified
  - Sets the default for the source build to 64-bits, to match the TPLs

