### PR TITLE
Fix bug related to obtuse bug regarding the lua stack index

### DIFF
--- a/src/axom/inlet/LuaReader.cpp
+++ b/src/axom/inlet/LuaReader.cpp
@@ -108,6 +108,8 @@ bool LuaReader::findVariable(const std::string& id)
   std::vector<std::string> tokens;
   axom::utilities::string::split(tokens, temp_id, SCOPE_DELIMITER);
 
+  // Clear the lua stack because we always call with fully qualified names
+  lua_settop(m_luaState, 0);
   for (std::string token : tokens)
   {
     if(atGlobalScope)

--- a/src/axom/inlet/tests/inlet_Inlet.cpp
+++ b/src/axom/inlet/tests/inlet_Inlet.cpp
@@ -460,8 +460,8 @@ TEST(inlet_Inlet, mixLevelTables)
   auto luaReader = std::make_shared<axom::inlet::LuaReader>();
   luaReader->parseString(
     "thermal_solver={"
-    "   u0 = { type = \"function\", func = \"BoundaryTemperature\"},"
-    "   kappa = { type = \"constant\", constant = 0.5},"
+    "   u0 = { type = 'function', func = 'BoundaryTemperature'},"
+    "   kappa = { type = 'constant', constant = 0.5},"
     "   solver = {"
     "     rel_tol = 1.e-6,"
     "     abs_tol = 1.e-12,"
@@ -478,13 +478,14 @@ TEST(inlet_Inlet, mixLevelTables)
   // Define input deck schema
   //
 
+  // fields that are expected to not be present in above string
   inlet->addString("thermal_solver/mesh/filename", "filename");
   inlet->addInt("thermal_solver/mesh/serial", "serial");
   inlet->addInt("thermal_solver/mesh/parallel", "parallel");
-
   inlet->addInt("thermal_solver/order", "order");
   inlet->addString("thermal_solver/timestepper", "timestepper");
 
+  // Rest of the fields are present
   inlet->addString("thermal_solver/u0/type", "type");
   inlet->addString("thermal_solver/u0/func", "func");
 

--- a/src/axom/inlet/tests/inlet_LuaReader.cpp
+++ b/src/axom/inlet/tests/inlet_LuaReader.cpp
@@ -88,6 +88,33 @@ TEST(inlet_LuaReader_getString, getInsideStrings)
   EXPECT_EQ(value, "TesT StrInG");
 }
 
+
+TEST(inlet_LuaReader, mixLevelTables)
+{
+  axom::inlet::LuaReader lr;
+  lr.parseString(
+    "t = { innerT = { foo = 1 }, anotherInnerT = {baz = 3}}");
+
+  bool retValue;
+  int value;
+
+  value = 0;
+  retValue = lr.getInt("t/innerT/foo", value);
+  EXPECT_EQ(retValue, true);
+  EXPECT_EQ(value, 1);
+
+  value = 0;
+  retValue = lr.getInt("t/doesntexist", value);
+  EXPECT_EQ(retValue, false);
+  EXPECT_EQ(value, 0);
+
+  value = 0;
+  retValue = lr.getInt("t/anotherInnerT/baz", value);
+  EXPECT_EQ(retValue, true);
+  EXPECT_EQ(value, 3);
+}
+
+
 //------------------------------------------------------------------------------
 #include "axom/slic/core/UnitTestLogger.hpp"
 using axom::slic::UnitTestLogger;


### PR DESCRIPTION
Fix a seg fault in LuaReader that was caused by some combination of existant/non-existant reading of multi-nested tables
Added regression test that seg faulted prior to fix

... This was very annoying to find and I am still not entirely sure I understand what triggers this behavior but this does make it go away.

