### PR TITLE
Fix test failures in non-HDF5 builds

### DIFF
--- a/src/axom/sidre/examples/sidre_array.cpp
+++ b/src/axom/sidre/examples/sidre_array.cpp
@@ -60,7 +60,11 @@ int main ( int argc, char** argv )
 
   // STEP 2: save the array data in to a file
   sidre::IOManager sidre_io( problem_comm );
+#if defined(AXOM_USE_HDF5)
   sidre_io.write( root1, nranks, "sidre_array_mesh", "sidre_hdf5" );
+#else
+  sidre_io.write( root1, nranks, "sidre_array_mesh", "sidre_conduit_json" );
+#endif
 
   // STEP 3: read the data from the file into a new DataStore
   sidre::DataStore* dataStore2 = new sidre::DataStore();

--- a/src/axom/sidre/examples/sidre_createdatastore.cpp
+++ b/src/axom/sidre/examples/sidre_createdatastore.cpp
@@ -577,10 +577,15 @@ void generate_spio_blueprint(DataStore* ds) {
   if (conduit::blueprint::verify(bp_protocol, mesh_node[domain_mesh], info))
   {
 
+#if defined(AXOM_USE_HDF5)
+    std::string protocol = "sidre_hdf5";
+#else
+    std::string protocol = "sidre_json";
+#endif
     std::string bp_rootfile("bpspio.root");
 
     writer.write(ds->getRoot()->getGroup(
-                   domain_location), 1, "bpspio", "sidre_hdf5");
+                   domain_location), 1, "bpspio", protocol);
 
     writer.writeBlueprintIndexToRootFile(ds, domain_mesh, bp_rootfile,
                                          mesh_name);
@@ -621,9 +626,14 @@ void generate_spio_blueprint_to_path(DataStore* ds) {
   {
 
     std::string bp_rootfile("pathbpspio.root");
+#if defined(AXOM_USE_HDF5)
+    std::string protocol = "sidre_hdf5";
+#else
+    std::string protocol = "sidre_json";
+#endif
 
     writer.write(ds->getRoot()->getGroup(
-                   "domain_data"), 1, "pathbpspio", "sidre_hdf5");
+                   "domain_data"), 1, "pathbpspio", protocol);
 
     writer.writeBlueprintIndexToRootFile(ds, domain_mesh, bp_rootfile,
                                          "level/domains/domain/" + mesh_name);
@@ -635,18 +645,26 @@ void generate_spio_blueprint_to_path(DataStore* ds) {
 
 void serial_save_datastore_and_load_copy_lower(DataStore* ds)
 {
+#if defined(AXOM_USE_HDF5)
+    std::string protocol = "sidre_hdf5";
+    std::string filename = "example.hdf5";
+#else
+    std::string protocol = "sidre_json";
+    std::string filename = "example.json";
+#endif
+
   // _serial_io_save_start
-  // Save the data store to a file, using the default sidre_hdf5 protocol,
+  // Save the data store to a file,
   // saving all Views
-  ds->getRoot()->save("example.hdf5");
+  ds->getRoot()->save(filename, protocol);
   // Delete the data hierarchy under the root, then load it from the file
-  ds->getRoot()->load("example.hdf5");
+  ds->getRoot()->load(filename, protocol);
   Group* additional = ds->getRoot()->createGroup("additional");
   additional->createGroup("yetanother");
   // Load another copy of the data store into the "additional" group
   // without first clearing all its contents
   std::string groupname;
-  additional->load("example.hdf5", "sidre_hdf5", true, groupname);
+  additional->load(filename, protocol, true, groupname);
   // _serial_io_save_end
 }
 

--- a/src/axom/sidre/examples/sidre_createdatastore.cpp
+++ b/src/axom/sidre/examples/sidre_createdatastore.cpp
@@ -646,11 +646,11 @@ void generate_spio_blueprint_to_path(DataStore* ds) {
 void serial_save_datastore_and_load_copy_lower(DataStore* ds)
 {
 #if defined(AXOM_USE_HDF5)
-    std::string protocol = "sidre_hdf5";
-    std::string filename = "example.hdf5";
+  std::string protocol = "sidre_hdf5";
+  std::string filename = "example.hdf5";
 #else
-    std::string protocol = "sidre_json";
-    std::string filename = "example.json";
+  std::string protocol = "sidre_json";
+  std::string filename = "example.json";
 #endif
 
   // _serial_io_save_start

--- a/src/axom/sidre/examples/sidre_external_array.cpp
+++ b/src/axom/sidre/examples/sidre_external_array.cpp
@@ -20,6 +20,7 @@
 namespace sidre = axom::sidre;
 namespace slic  = axom::slic;
 
+#if defined(AXOM_USE_HDF5)
 //------------------------------------------------------------------------------
 void sidre_write( MPI_Comm comm,
                   const std::string& file,
@@ -106,11 +107,12 @@ void sidre_read( MPI_Comm comm,
   std::cout << std::endl;
 // DEBUG
 }
-
+#endif
 //------------------------------------------------------------------------------
 int main ( int argc, char** argv )
 {
   MPI_Init( &argc, &argv );
+#if defined(AXOM_USE_HDF5)
   MPI_Comm problem_comm = MPI_COMM_WORLD;
 
   slic::UnitTestLogger logger;
@@ -155,6 +157,7 @@ int main ( int argc, char** argv )
   // STEP 4: deallocate
   axom::deallocate( data );
   axom::deallocate( data2 );
+#endif
 
   MPI_Finalize();
   return 0;

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -2567,10 +2567,18 @@ TEST(sidre_group,import_conduit_lists)
     }
   }
 
-  ds.getRoot()->save("lists.hdf5", "sidre_hdf5");
+#if defined(AXOM_USE_HDF5)
+  std::string lists_file = "lists.hdf5";
+  std::string lists_protocol = "sidre_hdf5";
+#else
+  std::string lists_file = "lists.json";
+  std::string lists_protocol = "sidre_json";
+#endif
+
+  ds.getRoot()->save(lists_file, lists_protocol);
 
   DataStore load_ds;
-  load_ds.getRoot()->load("lists.hdf5", "sidre_hdf5");
+  load_ds.getRoot()->load(lists_file, lists_protocol);
 
   {
     EXPECT_EQ(load_ds.getRoot()->getView(

--- a/src/axom/sidre/tests/spio/F_spio_basicWriteRead.F
+++ b/src/axom/sidre/tests/spio/F_spio_basicWriteRead.F
@@ -31,7 +31,7 @@ program spio_basic_write_read
   character(18) :: root_ext = ".root             "
 #else
   character(18) :: protocol = "sidre_conduit_json"
-  character(18) :: root_ext = ".conduit_json.root"
+  character(18) :: root_ext = ".root"
 #endif  
 
 

--- a/src/axom/sidre/tests/spio/F_spio_externalWriteRead.F
+++ b/src/axom/sidre/tests/spio/F_spio_externalWriteRead.F
@@ -111,6 +111,7 @@ program spio_external_write_read
 
   call mpi_finalize(mpierr)
 #else
+  return_val = 0
   print *, "Loading external data only valid for 'sidre_hdf5' format &
            & and when Axom is configured with hdf5. Skipping test."
 #endif

--- a/src/axom/sidre/tests/spio/F_spio_irregularWriteRead.F
+++ b/src/axom/sidre/tests/spio/F_spio_irregularWriteRead.F
@@ -36,7 +36,7 @@ program spio_irregularWriteRead
   character(18) :: root_ext = ".root             "
 #else
   character(18) :: protocol = "sidre_conduit_json"
-  character(18) :: root_ext = ".conduit_json.root"
+  character(18) :: root_ext = ".root"
 #endif  
 
   call mpi_init(mpierr)

--- a/src/axom/sidre/tests/spio/F_spio_parallelWriteRead.F
+++ b/src/axom/sidre/tests/spio/F_spio_parallelWriteRead.F
@@ -38,7 +38,7 @@ program spio_parallel_write_read
   character(18) :: root_ext = ".root             "
 #else
   character(18) :: protocol = "sidre_conduit_json"
-  character(18) :: root_ext = ".conduit_json.root"
+  character(18) :: root_ext = ".root"
 #endif  
 
   call mpi_init(mpierr)

--- a/src/axom/sidre/tests/spio/F_spio_preserveWriteRead.F
+++ b/src/axom/sidre/tests/spio/F_spio_preserveWriteRead.F
@@ -43,7 +43,7 @@ program spio_preserve_write_read
   character(18) :: root_ext = ".root             "
 #else
   character(18) :: protocol = "sidre_conduit_json"
-  character(18) :: root_ext = ".conduit_json.root"
+  character(18) :: root_ext = ".root"
 #endif  
 
   call mpi_init(mpierr)

--- a/src/axom/sidre/tests/spio/spio_parallel.cpp
+++ b/src/axom/sidre/tests/spio/spio_parallel.cpp
@@ -49,7 +49,7 @@ const std::string ROOT_EXT = ".root";
 // Note: 'sidre_json' does not work for this test
 // since it doesn't preserve bitwidth sizes (e.g. int)
 const std::string PROTOCOL = "sidre_conduit_json";
-const std::string ROOT_EXT = ".conduit_json.root";
+const std::string ROOT_EXT = ".root";
 #endif
 
 /** Returns the number of output files for spio  */


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following (modify list as needed):
  - Makes sure Sidre/SPIO tests don't try to use HDF5 I/O protocols when axom is build without HDF5.
  - Fixes an issue on our old tracker