### PR TITLE
Bugfix for 64 bit indexing in slam, spin and quest

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -81,6 +81,10 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   `iomanager_new` is now `IOManager`
 
 ### Fixed
+- Spin's octrees can now be used with 64-bit indexes. This allows octrees 
+  with up to 64 levels of resolution when using a 64-bit index type.
+- Resolved issue with `AXOM_USE_64BIT_INDEXTYPE` configurations. Axom can once again
+  be configured with 64-bit index types.
 - Fixed a triangle-triangle intersection case in primal that produced inconsistent results
   depending on the order of the triangle's vertices.
 - Fixed issue in the parallel construction of the BVH on GPUs, due to incoherent

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,13 @@ strategy:
       COMPILER: 'g++'
       TEST_TARGET: 'linux_gcc8'
       HOST_CONFIG: 'docker-linux-ubuntu16.04-x86_64-gcc@8.1.0'
+    linux_gcc8_64bit:
+      VM_ImageName: 'ubuntu-16.04'
+      Compiler_ImageName: 'axom/tpls:gcc-8'
+      CMAKE_EXTRA_FLAGS: '-DAXOM_USE_64BIT_INDEXTYPE:BOOL=ON'
+      COMPILER: 'g++'
+      TEST_TARGET: 'linux_gcc8_64bit'
+      HOST_CONFIG: 'docker-linux-ubuntu16.04-x86_64-gcc@8.1.0'
     linux_clang4:
        VM_ImageName: 'ubuntu-16.04'
        Compiler_ImageName: 'axom/tpls:clang-4'

--- a/src/axom/quest/InOutOctree.hpp
+++ b/src/axom/quest/InOutOctree.hpp
@@ -2315,8 +2315,8 @@ public:
   using SpaceTriangle = typename InOutOctreeType::SpaceTriangle;
 
   using LeafVertMap = slam::Map<slam::Set<VertexIndex>, VertexIndex>;
-  using LeafIntMap = slam::Map<slam::Set<int>, int>;
-  using LeafGridPtMap = slam::Map<slam::Set<int>, GridPt>;
+  using LeafIntMap = slam::Map<slam::Set<axom::IndexType>, axom::IndexType>;
+  using LeafGridPtMap = slam::Map<slam::Set<axom::IndexType>, GridPt>;
 
   using DebugMesh = mint::UnstructuredMesh< mint::MIXED_SHAPE>;
 
@@ -2634,10 +2634,10 @@ private:
 
 
     // Add the fields to the mint mesh
-    VertexIndex* vertID = addIntField(debugMesh, "vertID" );
-    VertexIndex* lLevel = addIntField(debugMesh, "level" );
+    auto* vertID = addIntField(debugMesh, "vertID" );
+    auto* lLevel = addIntField(debugMesh, "level" );
 
-    int* blockCoord[3];
+    axom::IndexType* blockCoord[3];
     blockCoord[0] = addIntField(debugMesh, "block_x" );
     blockCoord[1] = addIntField(debugMesh, "block_y" );
     blockCoord[2] = addIntField(debugMesh, "block_z" );
@@ -2654,8 +2654,8 @@ private:
 
     if(hasTriangles)
     {
-      VertexIndex* uniqVertID = addIntField(debugMesh, "uniqVertID" );
-      int* triCount = addIntField(debugMesh, "triCount" );
+      auto* uniqVertID = addIntField(debugMesh, "uniqVertID" );
+      auto* triCount = addIntField(debugMesh, "triCount" );
 
       for ( int i=0 ; i < leafSet.size() ; ++i )
       {
@@ -2666,7 +2666,7 @@ private:
 
     if(hasColors)
     {
-      int* colors = addIntField(debugMesh, "colors" );
+      auto* colors = addIntField(debugMesh, "colors" );
       for ( int i=0 ; i < leafSet.size() ; ++i )
         colors[i] = leafColors[i];
     }
@@ -2697,10 +2697,10 @@ private:
     int numTris = tris.size();
 
     // Index of each triangle within the mesh
-    int* triIdx = addIntField(debugMesh, "triangle_index" );
+    auto* triIdx = addIntField(debugMesh, "triangle_index" );
 
     // Indices of the three boundary vertices of this triangle
-    int* vertIdx[3];
+    axom::IndexType* vertIdx[3];
     vertIdx[0] = addIntField(debugMesh, "vertex_index_0" );
     vertIdx[1] = addIntField(debugMesh, "vertex_index_1" );
     vertIdx[2] = addIntField(debugMesh, "vertex_index_2" );
@@ -2728,9 +2728,9 @@ private:
 
 private:
 
-  int* addIntField(DebugMesh* mesh, const std::string& name ) const
+  axom::IndexType* addIntField(DebugMesh* mesh, const std::string& name ) const
   {
-    int* fld = mesh->createField< int >( name, mint::CELL_CENTERED );
+    axom::IndexType* fld = mesh->createField< axom::IndexType >( name, mint::CELL_CENTERED );
     SLIC_ASSERT( fld != nullptr );
     return fld;
   }

--- a/src/axom/quest/InOutOctree.hpp
+++ b/src/axom/quest/InOutOctree.hpp
@@ -2634,8 +2634,8 @@ private:
 
 
     // Add the fields to the mint mesh
-    auto* vertID = addIntField(debugMesh, "vertID" );
-    auto* lLevel = addIntField(debugMesh, "level" );
+    axom::IndexType* vertID = addIntField(debugMesh, "vertID" );
+    axom::IndexType* lLevel = addIntField(debugMesh, "level" );
 
     axom::IndexType* blockCoord[3];
     blockCoord[0] = addIntField(debugMesh, "block_x" );
@@ -2654,8 +2654,8 @@ private:
 
     if(hasTriangles)
     {
-      auto* uniqVertID = addIntField(debugMesh, "uniqVertID" );
-      auto* triCount = addIntField(debugMesh, "triCount" );
+      axom::IndexType* uniqVertID = addIntField(debugMesh, "uniqVertID" );
+      axom::IndexType* triCount = addIntField(debugMesh, "triCount" );
 
       for ( int i=0 ; i < leafSet.size() ; ++i )
       {
@@ -2666,7 +2666,7 @@ private:
 
     if(hasColors)
     {
-      auto* colors = addIntField(debugMesh, "colors" );
+      axom::IndexType* colors = addIntField(debugMesh, "colors" );
       for ( int i=0 ; i < leafSet.size() ; ++i )
         colors[i] = leafColors[i];
     }
@@ -2697,7 +2697,7 @@ private:
     int numTris = tris.size();
 
     // Index of each triangle within the mesh
-    auto* triIdx = addIntField(debugMesh, "triangle_index" );
+    axom::IndexType* triIdx = addIntField(debugMesh, "triangle_index" );
 
     // Indices of the three boundary vertices of this triangle
     axom::IndexType* vertIdx[3];

--- a/src/axom/quest/examples/quest_signed_distance_interface.cpp
+++ b/src/axom/quest/examples/quest_signed_distance_interface.cpp
@@ -293,7 +293,7 @@ void generate_uniform_box_mesh( mint::UniformMesh*& mesh, Arguments& args)
     auto bbox = primal::BoundingBox<double,3>(lowerPoint, upperPoint);
     SLIC_INFO( "bounding box " << bbox );
     
-    const primal::Point<int,3> bdims(args.box_dims.data(), 3);
+    const primal::Point<axom::IndexType,3> bdims(args.box_dims.data(), 3);
     SLIC_INFO( "constructing Uniform Mesh of resolution " << bdims );
   }
 

--- a/src/axom/slam/BivariateMap.hpp
+++ b/src/axom/slam/BivariateMap.hpp
@@ -81,7 +81,7 @@ template<
   typename DataType,
   typename StridePolicy = policies::StrideOne<typename SetType::PositionType>
   >
-class BivariateMap : public MapBase, public StridePolicy
+class BivariateMap : public MapBase<typename SetType::PositionType>, public StridePolicy
 {
 public:
   using SetPosition = typename SetType::PositionType;

--- a/src/axom/slam/Map.hpp
+++ b/src/axom/slam/Map.hpp
@@ -62,7 +62,7 @@ template<
   typename DataType,
   typename StridePolicy = policies::StrideOne<typename SetType::PositionType>
   >
-class Map : public MapBase, public StridePolicy
+class Map : public MapBase<typename SetType::PositionType>, public StridePolicy
 {
 public:
 
@@ -214,7 +214,7 @@ public:
   SetPosition size() const { return SetPosition(m_set->size()); }
 
   /*
-   * \brief  Gets the number of component values associalted with each element.
+   * \brief  Gets the number of component values associated with each element.
    *         Equivalent to stride().
    */
   SetPosition numComp() const { return StridePolicyType::stride(); }

--- a/src/axom/slam/MapBase.hpp
+++ b/src/axom/slam/MapBase.hpp
@@ -33,10 +33,11 @@ namespace slam
  *
  */
 
+template<typename SetPositionType = slam::DefaultPositionType>
 class MapBase
 {
 public:
-  using SetPosition = slam::DefaultPositionType;
+  using SetPosition = SetPositionType;
 
 public:
   virtual ~MapBase() {};

--- a/src/axom/slam/SubMap.hpp
+++ b/src/axom/slam/SubMap.hpp
@@ -53,7 +53,7 @@ template<
   typename SuperMapType,
   typename StridePolicy = policies::StrideOne<typename SetType::PositionType>
   >
-class SubMap : public MapBase, public StridePolicy
+class SubMap : public MapBase<typename SetType::PositionType>, public StridePolicy
 {
 private:
   using SetPosition = typename SetType::PositionType;
@@ -279,7 +279,7 @@ public:
     }
     else
     {
-      int map_size = ((const MapBase*)m_superMap_constptr)->size();
+      int map_size = ((const MapBase<SetPosition>*)m_superMap_constptr)->size();
       //Check all indices is inside the SuperMap range
       for (int i = 0 ; i < m_subsetIdx.size() ; i++)
       {

--- a/src/axom/slam/examples/ShockTube.cpp
+++ b/src/axom/slam/examples/ShockTube.cpp
@@ -156,7 +156,7 @@ public:
 
 
 // Define explicit instances of local (key/value) datastore for int and double
-using IntsRegistry = slam::FieldRegistry<BaseSet, int>;
+using IntsRegistry = slam::FieldRegistry<BaseSet, BaseSet::ElementType>;
 using RealsRegistry = slam::FieldRegistry<BaseSet, double>;
 using IntField = IntsRegistry::MapType;
 using RealField = RealsRegistry::MapType;
@@ -658,7 +658,7 @@ int main(void)
   int dumpInterval   = intsRegistry.getScalar("numCyclesPerDump");
 
   // use the & operation when you want to update the param directly
-  int& currCycle = intsRegistry.getScalar("cycle");
+  auto& currCycle = intsRegistry.getScalar("cycle");
   for (currCycle = 0 ; currCycle<numTotalCycles ; ++currCycle)
   {
     if( currCycle % dumpInterval == 0)

--- a/src/axom/slam/examples/UnstructMeshField.cpp
+++ b/src/axom/slam/examples/UnstructMeshField.cpp
@@ -190,9 +190,9 @@ struct Repository
   // Define the explicit instances of our local (key/value) datastore
   // for int and double
   using SetType = axom::slam::Set<>;
-  using IntsRegistry = slam::FieldRegistry<SetType, int>;
+  using IntsRegistry = slam::FieldRegistry<SetType, SetType::ElementType>;
   using RealsRegistry = slam::FieldRegistry<SetType, double>;
-  using IntField = slam::Map<SetType, int>;
+  using IntField = slam::Map<SetType, SetType::ElementType>;
   using RealField = slam::Map<SetType, double>;
 
   static IntsRegistry intsRegistry;

--- a/src/axom/slam/examples/lulesh2.0.3/lulesh-init.cpp
+++ b/src/axom/slam/examples/lulesh2.0.3/lulesh-init.cpp
@@ -27,7 +27,7 @@ namespace slamLulesh {
 /////////////////////////////////////////////////////////////////////
   Domain::Domain(Int_t numRanks, Index_t colLoc,
       Index_t rowLoc, Index_t planeLoc,
-      Index_t nx, int tp, int nr, int balance, Int_t cost)
+      Index_t nx, Int_t tp, Int_t nr, Int_t balance, Int_t cost)
       : m_e_cut(Real_t(1.0e-7)),
         m_p_cut(Real_t(1.0e-7)),
         m_q_cut(Real_t(1.0e-7)),
@@ -394,7 +394,7 @@ namespace slamLulesh {
     using RegionToElemDynamicRelation = axom::slam::DynamicVariableRelation<PositionType, ElementType>;
 
 #ifdef AXOM_USE_MPI
-    Index_t myRank;
+    int myRank;
     MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
     srand(myRank);
 #else

--- a/src/axom/slam/examples/lulesh2.0.3/lulesh-util.cpp
+++ b/src/axom/slam/examples/lulesh2.0.3/lulesh-util.cpp
@@ -21,7 +21,7 @@
 namespace slamLulesh {
 
 /* Helper function for converting strings to ints, with error checking */
-  int StrToInt(const char *token, int *retVal)
+  int StrToInt(const char *token, Int_t *retVal)
   {
     const char *c;
     char *endptr;

--- a/src/axom/slam/examples/lulesh2.0.3/lulesh.cpp
+++ b/src/axom/slam/examples/lulesh2.0.3/lulesh.cpp
@@ -2852,8 +2852,8 @@ int main(int argc, char *argv[])
   using namespace slamLulesh;
 
   Domain *locDom;
-  Int_t numRanks;
-  Int_t myRank;
+  int numRanks;
+  int myRank;
   struct cmdLineOpts opts;
 
 #ifdef AXOM_USE_MPI

--- a/src/axom/slam/examples/lulesh2.0.3/lulesh.hpp
+++ b/src/axom/slam/examples/lulesh2.0.3/lulesh.hpp
@@ -37,9 +37,9 @@ namespace slamLulesh {
   typedef double      real8;
   typedef long double real10;  // 10 bytes on x86
 
-  typedef int         Index_t; // array subscript and loop index
-  typedef real8       Real_t; // floating point representation
-  typedef int         Int_t; // integer representation
+  typedef axom::IndexType  Index_t; // array subscript and loop index
+  typedef real8            Real_t; // floating point representation
+  typedef axom::IndexType  Int_t; // integer representation
 
   enum { VolumeError = -1, QStopError = -2 };
 
@@ -690,7 +690,7 @@ namespace slamLulesh {
 
 // lulesh-util
   void  ParseCommandLineOptions(int argc, char *argv[],
-      Int_t myRank, struct cmdLineOpts *opts);
+      int myRank, struct cmdLineOpts *opts);
   void  VerifyAndWriteFinalOutput(Real_t elapsed_time,
       Domain& locDom,
       Int_t nx,
@@ -700,9 +700,9 @@ namespace slamLulesh {
   void  DumpToVisit(Domain& domain, int numFiles, int myRank, int numRanks);
 
 // lulesh-comm
-  void  CommRecv(Domain& domain, Int_t msgType, Index_t xferFields, Index_t dx, Index_t dy, Index_t dz, bool doRecv, bool planeOnly);
-  void  CommSend(Domain& domain, Int_t msgType, Index_t xferFields, Domain_member *fieldData, Index_t dx, Index_t dy, Index_t dz, bool doSend, bool planeOnly);
-  void  CommSBN(Domain& domain, Int_t xferFields, Domain_member *fieldData);
+  void  CommRecv(Domain& domain, int msgType, Index_t xferFields, Index_t dx, Index_t dy, Index_t dz, bool doRecv, bool planeOnly);
+  void  CommSend(Domain& domain, int msgType, Index_t xferFields, Domain_member *fieldData, Index_t dx, Index_t dy, Index_t dz, bool doSend, bool planeOnly);
+  void  CommSBN(Domain& domain, int xferFields, Domain_member *fieldData);
   void  CommSyncPosVel(Domain& domain);
   void  CommMonoQ(Domain& domain);
 

--- a/src/axom/slam/tests/slam_set_IndirectionSet.cpp
+++ b/src/axom/slam/tests/slam_set_IndirectionSet.cpp
@@ -466,7 +466,7 @@ TEST(slam_set_indirectionset,negative_stride)
                                   SizePol,OffPol,StridePol, ArrIndPol>;
 
   // Set up data -- an array of incrementing integers
-  std::vector<int> intVec(MAX_SET_SIZE);
+  std::vector<SetElement> intVec(MAX_SET_SIZE);
   for(auto i: slam::PositionSet<>(MAX_SET_SIZE) )
   {
     intVec[i] = i;

--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -70,7 +70,7 @@ public:
 
 
   using BitsetType = slam::BitSet;
-  using BinBitMap = slam::Map<slam::Set<>, BitsetType>;
+  using BinBitMap = slam::Map<slam::Set<IndexType,IndexType>, BitsetType>;
 
   /*!
    * \brief Default constructor for an ImplicitGrid
@@ -178,7 +178,7 @@ public:
     // ensure that resolution in each dimension is at least one
     for(int i=0 ; i< NDIMS ; ++i)
     {
-      m_gridRes[i] = axom::utilities::max( m_gridRes[i], 1);
+      m_gridRes[i] = axom::utilities::max( m_gridRes[i], IndexType(1));
     }
 
     // Setup lattice
@@ -190,7 +190,7 @@ public:
     for(int i=0 ; i<NDIMS ; ++i)
     {
       m_bins[i] = BinSet(m_gridRes[i]);
-      m_binData[i] = BinBitMap(&m_bins[i], BitsetType(m_elementSet.size()));
+      m_binData[i] = BinBitMap(&m_bins[i], BitsetType(numElts));
     }
 
     // Set the expansion factor for each element to a small fraction of the

--- a/src/axom/spin/OctreeBase.hpp
+++ b/src/axom/spin/OctreeBase.hpp
@@ -259,7 +259,7 @@ public:
       for(int dim =0 ; dim< DIM ; ++dim)
       {
         cPoint[dim] = (m_pt[dim] << 1)
-                      + (childIndex & (1 << dim) ? 1 : 0);
+                      + (childIndex & (CoordType(1) << dim) ? 1 : 0);
       }
 
       return cPoint;
@@ -372,7 +372,7 @@ public:
      */
     bool inBounds() const
     {
-      const CoordType maxVal = (1<<m_lev)-1;
+      const CoordType maxVal = (CoordType(1)<<m_lev)-CoordType(1);
       for(int i = 0 ; i < DIM ; ++i)
         if( (m_pt[i] < 0) || (m_pt[i] > maxVal) )
           return false;
@@ -557,7 +557,7 @@ public:
    */
   static CoordType maxCoordAtLevel(int level)
   {
-    return (1<< level)-1;
+    return (CoordType(1)<< level)-CoordType(1);
   }
 
   /**

--- a/src/axom/spin/OctreeLevel.hpp
+++ b/src/axom/spin/OctreeLevel.hpp
@@ -158,7 +158,7 @@ public:
    */
   CoordType maxCoord() const
   {
-    return (1<< m_level) -1;
+    return (CoordType(1)<< m_level) -CoordType(1);
   }
 
   /**

--- a/src/axom/spin/SparseOctreeLevel.hpp
+++ b/src/axom/spin/SparseOctreeLevel.hpp
@@ -96,7 +96,7 @@ struct BroodRepresentationTraits<CoordType, DIM, BroodDataType,
                                  primal::Point<CoordType,DIM> >
 {
   using GridPt = primal::Point<CoordType,DIM>;
-  using PointRepresenationType = GridPt;
+  using PointRepresentationType = GridPt;
   using PointHashType = PointHash<CoordType>;
 
   AXOM_STATIC_ASSERT_MSG( std::is_integral<CoordType>::value,
@@ -114,7 +114,7 @@ struct BroodRepresentationTraits<CoordType, DIM, BroodDataType,
    *  \note This is a pass through function
    *        since the representation and grid point types are the same
    */
-  static const PointRepresenationType& convertPoint(const GridPt& pt)
+  static const PointRepresentationType& convertPoint(const GridPt& pt)
   {
     return pt;          // simple pass through function
   }

--- a/src/axom/spin/SpatialOctree.hpp
+++ b/src/axom/spin/SpatialOctree.hpp
@@ -57,7 +57,7 @@ public:
     const SpaceVector bbRange = m_boundingBox.range();
     for(int lev = 0 ; lev < this->m_levels.size() ; ++lev)
     {
-      m_deltaLevelMap[lev] = bbRange / static_cast<double>(1<<lev);
+      m_deltaLevelMap[lev] = bbRange / static_cast<double>(CoordType(1)<<lev);
 
       for(int dim=0 ; dim < DIM ; ++dim)
         m_invDeltaLevelMap[lev][dim] = 1./m_deltaLevelMap[lev][dim];
@@ -134,9 +134,9 @@ public:
 
     // Perform binary search on levels to find the leaf block containing the
     // point
-    int minLev = 0;
-    int maxLev = this->maxLeafLevel();
-    int lev = (startingLevel == -1) ? maxLev >> 1 : startingLevel;
+    CoordType minLev = 0;
+    CoordType maxLev = this->maxLeafLevel();
+    CoordType lev = (startingLevel == -1) ? maxLev >> 1 : startingLevel;
 
     while(minLev <= maxLev)
     {

--- a/src/axom/spin/UniformGrid.hpp
+++ b/src/axom/spin/UniformGrid.hpp
@@ -281,7 +281,7 @@ UniformGrid< T, NDIMS >::UniformGrid(const double* lower_bound,
 
   // set up the lattice for point conversions
   m_lattice = rectangular_lattice_from_bounding_box(
-    m_boundingBox, primal::NumericArray< T,NDIMS >(m_resolution));
+    m_boundingBox, primal::NumericArray< int,NDIMS >(m_resolution));
 }
 
 template < typename T, int NDIMS >
@@ -295,7 +295,7 @@ UniformGrid< T, NDIMS >::UniformGrid(const BoxType & bbox, const int* res)
 
   // set up the bounding box and lattice for point conversions
   m_lattice = rectangular_lattice_from_bounding_box(
-    m_boundingBox, primal::NumericArray< T,NDIMS >(m_resolution));
+    m_boundingBox, primal::NumericArray< int,NDIMS >(m_resolution));
 }
 
 template < typename T, int NDIMS >

--- a/src/axom/spin/tests/spin_spatial_octree.cpp
+++ b/src/axom/spin/tests/spin_spatial_octree.cpp
@@ -51,7 +51,10 @@ TEST( spin_spatial_octree, spatial_octree_point_location)
 
   for(int i=0 ; i< octree.maxInternalLevel() ; ++i)
   {
+    EXPECT_EQ(0, octree.getOctreeLevel(i+1).numLeafBlocks());
     octree.refineLeaf( leafBlock );
+    EXPECT_EQ(1<<DIM, octree.getOctreeLevel(i+1).numLeafBlocks());
+
     leafBlock = octree.findLeafBlock(queryPt);
     EXPECT_TRUE( octree.isLeaf(leafBlock));
 
@@ -60,7 +63,7 @@ TEST( spin_spatial_octree, spatial_octree_point_location)
     EXPECT_TRUE( bb.contains(leafBB));
 
     SLIC_INFO(
-      "Query pt: "
+      "Level " << i << " -- Query pt: "
       << queryPt
       <<"\n\t" << ( leafBB.contains(queryPt) ? " was" : " was not")
       <<" contained in bounding box " << leafBB


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- Resolves #296 -- Axom can once again be configured with `AXOM_USE_64BIT_INDEXTYPE`
- Resolves #295 -- Quest's `InOutOctree` can use up to 64 levels when axom is configured with `AXOM_USE_64BIT_INDEXTYPE`

A future PR will consider extentions to the `Octree` and `InOutOctree` classes to allow more than 32 levels of resolution, regardless of the value of `axom::IndexType`. This might take the form of an extra template parameter that defaults to `axom::IndexType`.


### TODO:
- [x] Add a CI configuration that uses 64 bit indexing
- [x] Look into warning about octree coloring from user-supplied mesh for #295 
