### PR TITLE
Fix Parallel BVH construction on GPUs due to incoherent L1 cache

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -62,6 +62,10 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   ex. `level_error` is now `message_error`.
 
 ### Fixed
+- Fixed issue in the parallel construction of the BVH on GPUs, due to incoherent
+  L1 cache that could result in some data corruption in the BVH. The code now
+  calls ``__threadfence_system()`` after the parent is computed and stored back
+  to global memory to ensure that the *write*  is visible to all threads. 
 - Fixed issue in Mint that would cause the clang@9.0.0 compiler to segfault. The
   `mint_cell_types.cpp` test was causing a segfault in the compiler. The main
   issue triggering this compiler bug was the use of `constexpr` when defining the

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -606,6 +606,22 @@ static void array_memset(T* array, const int32 size, const T val)
   } );
 }
 
+/*!
+ * \def BVH_THREAD_FENCE_SYSTEM
+ *
+ * \brief Macro for __threadfence_system() on NVIDIA GPUs expands
+ *  to nothing on all other platforms.
+ *
+ * \note This is an internal macro use in the propagate_aabbs() method below.
+ */
+#if defined(__CUDA_ARCH__)
+  // on NVIDIA GPUs call __threadfence_system()
+  #define BVH_THREAD_FENCE_SYSTEM __threadfence_system()
+#else
+  // on CPUs do nothing
+  #define BVH_THREAD_FENCE_SYSTEM
+#endif
+
 //------------------------------------------------------------------------------
 template < typename ExecSpace, typename FloatType, int NDIMS >
 void propagate_aabbs( RadixTree< FloatType, NDIMS >& data, int allocatorID )
@@ -673,6 +689,16 @@ void propagate_aabbs( RadixTree< FloatType, NDIMS >& data, int allocatorID )
 
       inner_aabb_ptr[current_node] = aabb;
 
+      // NOTE: this ensures that the write to global memory above 
+      // is observed by all other threads. It provides a workaround
+      // where a thread would write to the L1 cache instead, which 
+      // would not be observed by other threads. 
+      //
+      // See Github issue: https://github.com/LLNL/axom/issues/307 
+      //
+      // This is a workaround for NVIDIA GPUs.
+      BVH_THREAD_FENCE_SYSTEM;
+
       current_node = parent_ptr[current_node];
     }
 
@@ -680,6 +706,8 @@ void propagate_aabbs( RadixTree< FloatType, NDIMS >& data, int allocatorID )
 
   axom::deallocate(counters_ptr);
 }
+
+#undef BVH_THREAD_FENCE_SYSTEM 
 
 
 //------------------------------------------------------------------------------

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -607,7 +607,7 @@ static void array_memset(T* array, const int32 size, const T val)
 }
 
 /*!
- * \def BVH_THREAD_FENCE_SYSTEM
+ * \def SPIN_BVH_THREAD_FENCE_SYSTEM
  *
  * \brief Macro for __threadfence_system() on NVIDIA GPUs expands
  *  to nothing on all other platforms.
@@ -616,10 +616,10 @@ static void array_memset(T* array, const int32 size, const T val)
  */
 #if defined(__CUDA_ARCH__)
   // on NVIDIA GPUs call __threadfence_system()
-  #define BVH_THREAD_FENCE_SYSTEM __threadfence_system()
+  #define SPIN_BVH_THREAD_FENCE_SYSTEM __threadfence_system()
 #else
   // on CPUs do nothing
-  #define BVH_THREAD_FENCE_SYSTEM
+  #define SPIN_BVH_THREAD_FENCE_SYSTEM
 #endif
 
 //------------------------------------------------------------------------------
@@ -697,7 +697,7 @@ void propagate_aabbs( RadixTree< FloatType, NDIMS >& data, int allocatorID )
       // See Github issue: https://github.com/LLNL/axom/issues/307 
       //
       // This is a workaround for NVIDIA GPUs.
-      BVH_THREAD_FENCE_SYSTEM;
+      SPIN_BVH_THREAD_FENCE_SYSTEM;
 
       current_node = parent_ptr[current_node];
     }
@@ -707,7 +707,7 @@ void propagate_aabbs( RadixTree< FloatType, NDIMS >& data, int allocatorID )
   axom::deallocate(counters_ptr);
 }
 
-#undef BVH_THREAD_FENCE_SYSTEM 
+#undef SPIN_BVH_THREAD_FENCE_SYSTEM 
 
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

Adds a call to ``__threadfence_system()`` in the ``propagate_aabbs()`` method which does a bottom-up  parallel construction of the BVH. The memory fence ensures that when a thread computes and stores a parent to global memory, the *write*  is observed by all threads in the system.

This fix currently only applies to NVIDIA GPUs where the bug was observed due to the incoherent L1 cache on NVIDIA GPUs.

Resolves #307 