### PR TITLE
Print Axom version in the mesh_tester executable

### DIFF
--- a/src/axom/core/tests/utils_about.cpp
+++ b/src/axom/core/tests/utils_about.cpp
@@ -5,9 +5,24 @@
 
 #include "gtest/gtest.h"
 
+#include "axom/config.hpp" 
 #include "axom/core/utilities/About.hpp"
+
+// C/C++ includes
+#include <sstream> // for std::ostringstream
 
 TEST(core_about,print_about)
 {
   axom::about();
+}
+
+//-----------------------------------------------------------------------------
+TEST(core_about,get_version)
+{
+  std::ostringstream EXPECTED_VERSION_STRING;
+  EXPECTED_VERSION_STRING << AXOM_VERSION_FULL << "-";
+  EXPECTED_VERSION_STRING << AXOM_VERSION_EXTRA;
+
+  std::string axom_version = axom::getVersion();
+  EXPECT_EQ( EXPECTED_VERSION_STRING.str(), axom_version );
 }

--- a/src/axom/core/utilities/About.cpp
+++ b/src/axom/core/utilities/About.cpp
@@ -135,5 +135,12 @@ void about(std::ostream &oss)
   oss << " { " << sstr.str() << "}" << std::endl;
 }
 
+//-----------------------------------------------------------------------------
+std::string getVersion()
+{
+  std::ostringstream oss;
+  oss << AXOM_VERSION_FULL << "-" << AXOM_VERSION_EXTRA;
+  return oss.str();
+}
 
 } // end namespace axom

--- a/src/axom/core/utilities/About.hpp
+++ b/src/axom/core/utilities/About.hpp
@@ -6,7 +6,8 @@
 #ifndef AXOM_UTILS_ABOUT_H_
 #define AXOM_UTILS_ABOUT_H_
 
-#include <ostream>
+#include <ostream> // for std::ostream
+#include <string>  // for std::string
 
 namespace axom
 {
@@ -19,8 +20,17 @@ void about();
 /*!
  * \brief Prints info about how Axom was configured and built to a stream
  *
+ * \param [in,out] oss the target stream where to append the Axom info
  */
 void about(std::ostream &oss);
+
+/*!
+ * \brief Returns a string consisting of the Axom version.
+ *
+ * \return str string corresponding to the Axom version
+ * \post str != ""
+ */
+std::string getVersion();
 
 } // end namespace axom
 

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -5,6 +5,7 @@
 
 // Axom includes
 #include "axom/core/Macros.hpp"
+#include "axom/core/utilities/About.hpp"
 #include "axom/core/utilities/FileUtilities.hpp"
 #include "axom/core/utilities/Timer.hpp"
 
@@ -538,6 +539,8 @@ void initializeLogger()
 int main( int argc, char** argv )
 {
   initializeLogger();
+
+  SLIC_INFO( "Axom Version:" << " [" << axom::getVersion() << "]" );
 
   // Parse the command line arguments
   Input params;


### PR DESCRIPTION
# Summary

Prints the Axom version in the mesh_tester executable. Given that a number of users have gotten their hand on this executable, printing the corresponding Axom version will allow us to tell what was the corresponding Axom version used to produce the given executable.

