### PR TITLE
Feature/white238/buildstuffpart1

### DIFF
--- a/host-configs/docker/docker-linux-ubuntu16.04-x86_64-gcc@8.1.0.cmake
+++ b/host-configs/docker/docker-linux-ubuntu16.04-x86_64-gcc@8.1.0.cmake
@@ -41,8 +41,7 @@ set(TPL_ROOT "/home/axom/axom_tpls/gcc-8.1.0" CACHE PATH "")
 # conduit from uberenv
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
 
-# mfem from uberenv
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")
+# mfem not built by uberenv
 
 # hdf5 from uberenv
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@8.0.1_nvcc_xlf.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@8.0.1_nvcc_xlf.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_06_16_18_16_44/clang-8.0.1_nvcc_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_08_11_23_54_55/clang-8.0.1_nvcc_xlf" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -63,7 +63,7 @@ set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/blueos_3_ppc64le_ib_p9/2020_05_04_17_40_12/gcc-8.3.1" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/2020_08_03_17_07_42/gcc-8.3.1" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 
@@ -92,6 +92,8 @@ set(CMAKE_Fortran_COMPILER_ID "XL" CACHE PATH "Override to proper compiler famil
 set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
 
 set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
 
 #------------------------------------------------------------------------------
 # Cuda

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@upstream_xlf.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@upstream_xlf.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_06_16_18_16_44/clang-upstream_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_08_11_23_54_55/clang-upstream_xlf" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -63,7 +63,7 @@ set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/blueos_3_ppc64le_ib_p9/2020_05_04_17_40_12/gcc-8.3.1" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/2020_08_03_17_07_42/gcc-8.3.1" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 
@@ -92,5 +92,7 @@ set(CMAKE_Fortran_COMPILER_ID "XL" CACHE PATH "Override to proper compiler famil
 set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
 
 set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
 
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@7.3.1.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@7.3.1.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-7.3.1/bin/gfortran" CACHE 
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_06_16_18_16_44/gcc-7.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_08_11_23_54_55/gcc-7.3.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -63,7 +63,7 @@ set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/blueos_3_ppc64le_ib_p9/2020_05_04_17_40_12/gcc-8.3.1" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/2020_08_03_17_07_42/gcc-8.3.1" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@coral.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@coral.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_06_16_18_16_44/xl-coral" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_08_11_23_54_55/xl-coral" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -63,7 +63,7 @@ set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/blueos_3_ppc64le_ib_p9/2020_05_04_17_40_12/gcc-8.3.1" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/2020_08_03_17_07_42/gcc-8.3.1" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 
@@ -96,5 +96,7 @@ set(CMAKE_CXX_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family fo
 set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
 
 set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
 
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@nvcc.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@nvcc.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.08.20/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_06_16_18_16_44/xl-nvcc" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_08_11_23_54_55/xl-nvcc" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -63,7 +63,7 @@ set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/blueos_3_ppc64le_ib_p9/2020_05_04_17_40_12/gcc-8.3.1" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/2020_08_03_17_07_42/gcc-8.3.1" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 
@@ -96,6 +96,8 @@ set(CMAKE_CXX_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family fo
 set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
 
 set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
 
 #------------------------------------------------------------------------------
 # Cuda

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@10.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@10.0.0.cmake
@@ -30,7 +30,7 @@ set(BLT_EXE_LINKER_FLAGS " -Wl,-rpath,/usr/tce/packages/clang/clang-10.0.0/lib" 
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_19_12_14_54/clang-10.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_08_11_23_56_00/clang-10.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -67,7 +67,7 @@ set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_05_04_17_39_29/gcc-8.1.0" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/2020_08_03_16_59_10/gcc-8.1.0" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@9.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@9.0.0.cmake
@@ -30,7 +30,7 @@ set(BLT_EXE_LINKER_FLAGS " -Wl,-rpath,/usr/tce/packages/clang/clang-9.0.0/lib" C
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_19_12_14_54/clang-9.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_08_11_23_56_00/clang-9.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -67,7 +67,7 @@ set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_05_04_17_39_29/gcc-8.1.0" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/2020_08_03_16_59_10/gcc-8.1.0" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran" CACHE 
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_19_12_14_54/gcc-8.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_08_11_23_56_00/gcc-8.1.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -61,7 +61,7 @@ set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_05_04_17_39_29/gcc-8.1.0" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/2020_08_03_16_59_10/gcc-8.1.0" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@no_fortran.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@no_fortran.cmake
@@ -22,7 +22,7 @@ set(ENABLE_FORTRAN OFF CACHE BOOL "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_19_12_14_54/gcc-no_fortran" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_08_11_23_56_00/gcc-no_fortran" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -57,7 +57,7 @@ set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_05_04_17_39_29/gcc-8.1.0" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/2020_08_03_16_59_10/gcc-8.1.0" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@18.0.2.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@18.0.2.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-18.0.2/bin/ifort" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_19_12_14_54/intel-18.0.2" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_08_11_23_56_00/intel-18.0.2" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -61,7 +61,7 @@ set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_05_04_17_39_29/gcc-8.1.0" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/2020_08_03_16_59_10/gcc-8.1.0" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.4.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.4.cmake
@@ -30,7 +30,7 @@ set(CMAKE_Fortran_FLAGS "-gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_06_19_12_14_54/intel-19.0.4" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_08_11_23_56_00/intel-19.0.4" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
@@ -67,7 +67,7 @@ set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/toss_3_x86_64_ib/2020_05_04_17_39_29/gcc-8.1.0" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/2020_08_03_16_59_10/gcc-8.1.0" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@8.0.1_nvcc_xlf.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@8.0.1_nvcc_xlf.cmake
@@ -24,15 +24,15 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_05_04_19_01_41/clang-8.0.1_nvcc_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_08_11_23_52_35/clang-8.0.1_nvcc_xlf" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
 
-# Lua not built
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
 
 # SCR not built
 
@@ -63,7 +63,7 @@ set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/blueos_3_ppc64le_ib/2020_05_04_17_39_54/gcc-8.3.1" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib/2020_08_03_17_57_41/gcc-8.3.1" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 
@@ -91,7 +91,9 @@ set(CMAKE_Fortran_COMPILER_ID "XL" CACHE PATH "Override to proper compiler famil
 
 set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
 
-set(BLT_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
 
 #------------------------------------------------------------------------------
 # Cuda

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@upstream_xlf.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@upstream_xlf.cmake
@@ -24,15 +24,15 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_05_04_19_01_41/clang-upstream_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_08_11_23_52_35/clang-upstream_xlf" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
 
-# Lua not built
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
 
 # SCR not built
 
@@ -63,7 +63,7 @@ set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/blueos_3_ppc64le_ib/2020_05_04_17_39_54/gcc-8.3.1" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib/2020_08_03_17_57_41/gcc-8.3.1" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 
@@ -91,6 +91,8 @@ set(CMAKE_Fortran_COMPILER_ID "XL" CACHE PATH "Override to proper compiler famil
 
 set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
 
-set(BLT_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
 
 

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-gcc@7.3.1.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-gcc@7.3.1.cmake
@@ -24,15 +24,15 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-7.3.1/bin/gfortran" CACHE 
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_05_04_19_01_41/gcc-7.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_08_11_23_52_35/gcc-7.3.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
 
-# Lua not built
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
 
 # SCR not built
 
@@ -63,7 +63,7 @@ set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/blueos_3_ppc64le_ib/2020_05_04_17_39_54/gcc-8.3.1" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib/2020_08_03_17_57_41/gcc-8.3.1" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-xl@coral.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-xl@coral.cmake
@@ -24,15 +24,15 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_05_04_19_01_41/xl-coral" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_08_11_23_52_35/xl-coral" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
 
-# Lua not built
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
 
 # SCR not built
 
@@ -63,7 +63,7 @@ set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/blueos_3_ppc64le_ib/2020_05_04_17_39_54/gcc-8.3.1" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib/2020_08_03_17_57_41/gcc-8.3.1" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 
@@ -95,6 +95,8 @@ set(CMAKE_CXX_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family fo
 
 set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
 
-set(BLT_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
 
 

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-xl@nvcc.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-xl@nvcc.cmake
@@ -24,15 +24,15 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.08.20/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_05_04_19_01_41/xl-nvcc" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_08_11_23_52_35/xl-nvcc" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.0" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
 
-# Lua not built
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
 
 # SCR not built
 
@@ -63,7 +63,7 @@ set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated developer tools
-set(DEVTOOLS_ROOT "/usr/WS1/axom/devtools/blueos_3_ppc64le_ib/2020_05_04_17_39_54/gcc-8.3.1" CACHE PATH "")
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib/2020_08_03_17_57_41/gcc-8.3.1" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
 
@@ -95,7 +95,9 @@ set(CMAKE_CXX_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family fo
 
 set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
 
-set(BLT_EXE_LINKER_FLAGS "-Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
 
 #------------------------------------------------------------------------------
 # Cuda

--- a/scripts/llnl_scripts/build_devtools.py
+++ b/scripts/llnl_scripts/build_devtools.py
@@ -18,6 +18,7 @@ from llnl_lc_build_tools import *
 
 from optparse import OptionParser
 
+import getpass
 import os
 
 
@@ -54,6 +55,9 @@ def main():
         if not os.path.exists(build_dir):
             os.makedirs(build_dir)
     else:
+        if getpass.getuser() != "atk":
+            print "ERROR: Only shared user 'atk' can install into shared directory. Use -d option."
+            return 1
         build_dir = get_shared_devtool_dir()
     build_dir = os.path.abspath(build_dir)
 

--- a/scripts/llnl_scripts/llnl_lc_build_tools.py
+++ b/scripts/llnl_scripts/llnl_lc_build_tools.py
@@ -531,7 +531,6 @@ def set_axom_group_and_perms(directory):
 
     if skip:
         print "[Skipping update of group and access permissions. Provided directory was not a known shared location: {0}]".format(directory)
-        return 0
     else:
         print "[changing group and access perms of: %s]" % directory
         # change group to axomdev
@@ -544,7 +543,7 @@ def set_axom_group_and_perms(directory):
         print "[changing perms for all users to rX]"
         sexe("chmod -f -R a+rX %s" % (directory),echo=True,error_prefix="WARNING:")
         print "[done setting perms for: %s]" % directory
-        return 0
+    return 0
 
 
 def full_build_and_test_of_tpls(builds_dir, job_name, timestamp, spec):

--- a/scripts/llnl_scripts/llnl_lc_build_tools.py
+++ b/scripts/llnl_scripts/llnl_lc_build_tools.py
@@ -521,18 +521,30 @@ def set_axom_group_and_perms(directory):
     Sets the proper group and access permissions of given input
     directory. 
     """
-    print "[changing group and access perms of: %s]" % directory
-    # change group to axomdev
-    print "[changing group to axomdev]"
-    sexe("chgrp -f -R axomdev %s" % (directory),echo=True,error_prefix="WARNING:")
-    # change group perms to rwX
-    print "[changing perms for axomdev members to rwX]"
-    sexe("chmod -f -R g+rwX %s" % (directory),echo=True,error_prefix="WARNING:")
-    # change perms for all to rX
-    print "[changing perms for all users to rX]"
-    sexe("chmod -f -R a+rX %s" % (directory),echo=True,error_prefix="WARNING:")
-    print "[done setting perms for: %s]" % directory
-    return 0
+
+    skip = True
+    shared_dirs = [get_shared_base_dir(), get_shared_collab_dir(), get_archive_base_dir()]
+    for shared_dir in shared_dirs:
+        if directory.startswith(shared_dir):
+            skip = False
+            break
+
+    if skip:
+        print "[Skipping update of group and access permissions. Provided directory was not a known shared location: {0}]".format(directory)
+        return 0
+    else:
+        print "[changing group and access perms of: %s]" % directory
+        # change group to axomdev
+        print "[changing group to axomdev]"
+        sexe("chgrp -f -R axomdev %s" % (directory),echo=True,error_prefix="WARNING:")
+        # change group perms to rwX
+        print "[changing perms for axomdev members to rwX]"
+        sexe("chmod -f -R g+rwX %s" % (directory),echo=True,error_prefix="WARNING:")
+        # change perms for all to rX
+        print "[changing perms for all users to rX]"
+        sexe("chmod -f -R a+rX %s" % (directory),echo=True,error_prefix="WARNING:")
+        print "[done setting perms for: %s]" % directory
+        return 0
 
 
 def full_build_and_test_of_tpls(builds_dir, job_name, timestamp, spec):
@@ -725,6 +737,10 @@ def get_shared_base_dir():
     return "/usr/WS1/axom"
 
 
+def get_shared_collab_dir():
+    return "/collab/usr/gapps/axom"
+
+
 def get_shared_mirror_dir():
     return pjoin(get_shared_base_dir(), "mirror")
 
@@ -734,7 +750,7 @@ def get_shared_libs_dir():
 
 
 def get_shared_devtool_dir():
-    return pjoin(get_shared_base_dir(), "devtools")
+    return pjoin(get_shared_collab_dir(), "devtools")
 
 
 def get_specs_for_current_machine():
@@ -779,6 +795,7 @@ def on_rz():
         return True
     return False
 
+
 def get_compiler_from_spec(spec):
     compiler = spec
     for c in ['~', '+']:
@@ -792,4 +809,3 @@ def convertSecondsToReadableTime(seconds):
     m, s = divmod(seconds, 60)
     h, m = divmod(m, 60)
     return "%d:%02d:%02d" % (h, m, s)
-

--- a/scripts/uberenv/packages/axom/package.py
+++ b/scripts/uberenv/packages/axom/package.py
@@ -65,6 +65,8 @@ class Axom(CMakePackage, CudaPackage):
     # -----------------------------------------------------------------------
     # Variants
     # -----------------------------------------------------------------------
+    variant('shared',   default=True,
+            description='Enable build of shared libraries')
     variant('debug',    default=False,
             description='Build debug instead of optimized version')
 
@@ -96,12 +98,10 @@ class Axom(CMakePackage, CudaPackage):
     depends_on("mpi", when="+mpi")
 
     # Libraries
-    depends_on("conduit~shared+python", when="+python")
-    depends_on("conduit~shared~python", when="~python")
-    depends_on("conduit~shared+python+hdf5", when="+hdf5+python")
-    depends_on("conduit~shared+python~hdf5", when="~hdf5+python")
-    depends_on("conduit~shared~python+hdf5", when="+hdf5~python")
-    depends_on("conduit~shared~python~hdf5", when="~hdf5~python")
+    depends_on("conduit+python", when="+python")
+    depends_on("conduit~python", when="~python")
+    depends_on("conduit+hdf5", when="+hdf5")
+    depends_on("conduit~hdf5", when="~hdf5")
 
     # HDF5 needs to be the same as Conduit's
     depends_on("hdf5@1.8.19:1.8.999~mpi~cxx~shared~fortran", when="+hdf5")
@@ -124,7 +124,8 @@ class Axom(CMakePackage, CudaPackage):
         depends_on('umpire cuda_arch={0}'.format(sm_),
                    when='+umpire cuda_arch={0}'.format(sm_))
 
-    depends_on("mfem~mpi~hypre~metis~zlib", when="+mfem")
+    depends_on("mfem", when="+mfem")
+    depends_on("mfem~mpi", when="+mfem~mpi")
 
     depends_on("python", when="+python")
 
@@ -471,6 +472,11 @@ class Axom(CMakePackage, CudaPackage):
                 linker_flags = "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath," + libdir
                 cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS",
                                             linker_flags, description))
+                if "+shared" in spec:
+                    linker_flags = "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath," \
+                                   + libdir
+                    cfg.write(cmake_cache_entry("CMAKE_SHARED_LINKER_FLAGS",
+                                                linker_flags, description))
 
             if "+cuda" in spec:
                 cfg.write("#------------------{0}\n".format("-" * 60))
@@ -530,10 +536,17 @@ class Axom(CMakePackage, CudaPackage):
 
         options = []
         options.extend(['-C', host_config_path])
+
         if self.run_tests is False:
             options.append('-DENABLE_TESTS=OFF')
         else:
             options.append('-DENABLE_TESTS=ON')
+
+        if "+shared" in spec:
+            options.append('-DBUILD_SHARED_LIBS=ON')
+        else:
+            options.append('-DBUILD_SHARED_LIBS=OFF')
+
         return options
 
     @run_after('install')

--- a/scripts/uberenv/packages/conduit/package.py
+++ b/scripts/uberenv/packages/conduit/package.py
@@ -54,10 +54,10 @@ class Conduit(Package):
     ###########################################################################
 
     variant("shared", default=True, description="Build Conduit as shared libs")
-    variant('test', default=True, description='Enable Conduit unit tests')
+    variant("test", default=True, description='Enable Conduit unit tests')
 
     # variants for python support
-    variant("python", default=True, description="Build Conduit Python support")
+    variant("python", default=False, description="Build Conduit Python support")
     variant("fortran", default=True, description="Build Conduit Fortran support")
 
     # variants for comm and i/o
@@ -93,6 +93,7 @@ class Conduit(Package):
     depends_on("python", when="+python")
     extends("python", when="+python")
     depends_on("py-numpy", when="+python", type=('build', 'run'))
+    depends_on("py-mpi4py", when="+python+mpi", type=('build', 'run'))
 
     #######################
     # I/O Packages
@@ -407,7 +408,7 @@ class Conduit(Package):
                     cfg.write(cmake_cache_entry("CMAKE_Fortran_COMPILER_ID",
                                                 "XL"))
 
-                if 'xl@coral' in os.getenv('SPACK_COMPILER_SPEC', ""):
+                if (f_compiler is not None) and ("xlf" in f_compiler):
                     # Fix missing std linker flag in xlc compiler
                     flags = "-WF,-C! -qxlf2003=polymorphic"
                     cfg.write(cmake_cache_entry("BLT_FORTRAN_FLAGS",
@@ -415,10 +416,15 @@ class Conduit(Package):
                     # Grab lib directory for the current fortran compiler
                     libdir = os.path.join(os.path.dirname(
                                           os.path.dirname(f_compiler)), "lib")
-                    flags  = "${BLT_EXE_LINKER_FLAGS} -lstdc++ "
-                    flags += "-Wl,-rpath,{0} -Wl,-rpath,{0}64".format(libdir)
+                    rpaths = "-Wl,-rpath,{0} -Wl,-rpath,{0}64".format(libdir)
+
+                    flags  = "${BLT_EXE_LINKER_FLAGS} -lstdc++ " + rpaths
                     cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS",
                                                 flags))
+                    if "+shared" in spec:
+                        flags = "${CMAKE_SHARED_LINKER_FLAGS} " + rpaths
+                        cfg.write(cmake_cache_entry(
+                                  "CMAKE_SHARED_LINKER_FLAGS", flags))
 
         #######################
         # Python
@@ -469,7 +475,7 @@ class Conduit(Package):
             # use those for mpi wrappers, b/c  spec['mpi'].mpicxx
             # etc make return the spack compiler wrappers
             # which can trip up mpi detection in CMake 3.14
-            if cpp_compiler == "CC":
+            if spec['mpi'].mpicc == spack_cc:
                 mpicc_path = "cc"
                 mpicxx_path = "CC"
                 mpifc_path = "ftn"

--- a/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib/packages.yaml
+++ b/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib/packages.yaml
@@ -112,40 +112,43 @@ packages:
 # Globally lock version of third party libraries
   conduit:
     version: [0.5.1]
+    variants: ~shared
+  mfem:
+    variants: ~mpi~metis~zlib
 
 # Globally lock in versions of Devtools
   cppcheck:
     version: [1.87]
     paths:
-      cppcheck: /usr/WS1/axom/devtools/blueos_3_ppc64le_ib/latest/cppcheck-1.87
+      cppcheck: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib/latest/cppcheck-1.87
     buildable: False
   doxygen:
     version: [1.8.14]
     paths:
-      doxygen: /usr/WS1/axom/devtools/blueos_3_ppc64le_ib/latest/doxygen-1.8.14
+      doxygen: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib/latest/doxygen-1.8.14
     buildable: False
   graphviz:
     version: [2.42.2]
     paths:
-      graphviz: /usr/WS1/axom/devtools/blueos_3_ppc64le_ib/latest/graphviz-2.42.2
+      graphviz: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib/latest/graphviz-2.42.2
     buildable: False
   python:
     version: [3.7.7]
     paths:
-      python: /usr/WS1/axom/devtools/blueos_3_ppc64le_ib/latest/python-3.7.7
+      python: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib/latest/python-3.7.7
     buildable: False
   py-shroud:
     version: [0.11.0]
     paths:
-      py-shroud: /usr/WS1/axom/devtools/blueos_3_ppc64le_ib/latest/python-3.7.7
+      py-shroud: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib/latest/python-3.7.7
     buildable: False
   py-sphinx:
     version: [2.2.0]
     paths:
-      py-sphinx: /usr/WS1/axom/devtools/blueos_3_ppc64le_ib/latest/python-3.7.7
+      py-sphinx: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib/latest/python-3.7.7
     buildable: False
   uncrustify:
     version: [0.61]
     paths:
-      uncrustify: /usr/WS1/axom/devtools/blueos_3_ppc64le_ib/latest/uncrustify-0.61
+      uncrustify: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib/latest/uncrustify-0.61
     buildable: False

--- a/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/packages.yaml
+++ b/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/packages.yaml
@@ -112,40 +112,43 @@ packages:
 # Globally lock version of third party libraries
   conduit:
     version: [0.5.1]
+    variants: ~shared
+  mfem:
+    variants: ~mpi~metis~zlib
 
 # Globally lock in versions of Devtools
   cppcheck:
     version: [1.87]
     paths:
-      cppcheck: /usr/WS1/axom/devtools/blueos_3_ppc64le_ib_p9/latest/cppcheck-1.87
+      cppcheck: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/latest/cppcheck-1.87
     buildable: False
   doxygen:
     version: [1.8.14]
     paths:
-      doxygen: /usr/WS1/axom/devtools/blueos_3_ppc64le_ib_p9/latest/doxygen-1.8.14
+      doxygen: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/latest/doxygen-1.8.14
     buildable: False
   graphviz:
     version: [2.42.2]
     paths:
-      graphviz: /usr/WS1/axom/devtools/blueos_3_ppc64le_ib_p9/latest/graphviz-2.42.2
+      graphviz: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/latest/graphviz-2.42.2
     buildable: False
   python:
     version: [3.7.7]
     paths:
-      python: /usr/WS1/axom/devtools/blueos_3_ppc64le_ib_p9/latest/python-3.7.7
+      python: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/latest/python-3.7.7
     buildable: False
   py-shroud:
     version: [0.11.0]
     paths:
-      py-shroud: /usr/WS1/axom/devtools/blueos_3_ppc64le_ib_p9/latest/python-3.7.7
+      py-shroud: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/latest/python-3.7.7
     buildable: False
   py-sphinx:
     version: [2.2.0]
     paths:
-      py-sphinx: /usr/WS1/axom/devtools/blueos_3_ppc64le_ib_p9/latest/python-3.7.7
+      py-sphinx: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/latest/python-3.7.7
     buildable: False
   uncrustify:
     version: [0.61]
     paths:
-      uncrustify: /usr/WS1/axom/devtools/blueos_3_ppc64le_ib_p9/latest/uncrustify-0.61
+      uncrustify: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/latest/uncrustify-0.61
     buildable: False

--- a/scripts/uberenv/spack_configs/darwin/packages.yaml
+++ b/scripts/uberenv/spack_configs/darwin/packages.yaml
@@ -69,3 +69,9 @@ packages:
   cmake:
     version: [3.9.6]
 
+# Globally lock version of third party libraries
+  conduit:
+    version: [0.5.1]
+    variants: ~shared
+  mfem:
+    variants: ~mpi~metis~zlib

--- a/scripts/uberenv/spack_configs/docker/packages.yaml
+++ b/scripts/uberenv/spack_configs/docker/packages.yaml
@@ -77,3 +77,10 @@ packages:
 # Globally lock in version of CMake
   cmake:
     version: [3.10.1]
+
+# Globally lock version of third party libraries
+  conduit:
+    version: [0.5.1]
+    variants: ~shared
+  mfem:
+    variants: ~mpi~metis~zlib

--- a/scripts/uberenv/spack_configs/toss_3_x86_64_ib/packages.yaml
+++ b/scripts/uberenv/spack_configs/toss_3_x86_64_ib/packages.yaml
@@ -116,40 +116,43 @@ packages:
 # Globally lock version of third party libraries
   conduit:
     version: [0.5.1]
+    variants: ~shared
+  mfem:
+    variants: ~mpi~metis~zlib
 
 # Globally lock in versions of Devtools
   cppcheck:
     version: [1.87]
     paths:
-      cppcheck: /usr/WS1/axom/devtools/toss_3_x86_64_ib/latest/cppcheck-1.87
+      cppcheck: /collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/latest/cppcheck-1.87
     buildable: False
   doxygen:
     version: [1.8.14]
     paths:
-      doxygen: /usr/WS1/axom/devtools/toss_3_x86_64_ib/latest/doxygen-1.8.14
+      doxygen: /collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/latest/doxygen-1.8.14
     buildable: False
   graphviz:
     version: [2.42.2]
     paths:
-      graphviz: /usr/WS1/axom/devtools/toss_3_x86_64_ib/latest/graphviz-2.42.2
+      graphviz: /collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/latest/graphviz-2.42.2
     buildable: False
   python:
     version: [3.7.7]
     paths:
-      python: /usr/WS1/axom/devtools/toss_3_x86_64_ib/latest/python-3.7.7
+      python: /collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/latest/python-3.7.7
     buildable: False
   py-shroud:
     version: [0.11.0]
     paths:
-      py-shroud: /usr/WS1/axom/devtools/toss_3_x86_64_ib/latest/python-3.7.7
+      py-shroud: /collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/latest/python-3.7.7
     buildable: False
   py-sphinx:
     version: [2.2.0]
     paths:
-      py-sphinx: /usr/WS1/axom/devtools/toss_3_x86_64_ib/latest/python-3.7.7
+      py-sphinx: /collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/latest/python-3.7.7
     buildable: False
   uncrustify:
     version: [0.61]
     paths:
-      uncrustify: /usr/WS1/axom/devtools/toss_3_x86_64_ib/latest/uncrustify-0.61
+      uncrustify: /collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/latest/uncrustify-0.61
     buildable: False

--- a/src/cmake/thirdparty/FindMFEM.cmake
+++ b/src/cmake/thirdparty/FindMFEM.cmake
@@ -8,7 +8,7 @@
 # This file defines:
 #  MFEM_FOUND        - If mfem was found
 #  MFEM_INCLUDE_DIRS - The mfem include directories
-#  MFEM_LIBRARY      - The mfem library
+#  MFEM_LIBRARIES    - The mfem libraries
 #------------------------------------------------------------------------------
 
 if (NOT MFEM_DIR)
@@ -31,36 +31,97 @@ if(_use_mfem_config)
               ${MFEM_DIR}/share/mfem
               ${MFEM_DIR}/mfem)
 
-    if(NOT MEFM_LIBRARY)
-       set(MFEM_LIBRARY ${MFEM_LIBRARIES})
-    endif()
-
 else()
 
-    find_path( MFEM_INCLUDE_DIRS mfem.hpp
-               PATHS 
-                ${MFEM_DIR}/include/
-                ${MFEM_DIR}
-               NO_DEFAULT_PATH
-               NO_CMAKE_ENVIRONMENT_PATH
-               NO_CMAKE_PATH
-               NO_SYSTEM_ENVIRONMENT_PATH
-               NO_CMAKE_SYSTEM_PATH
-               )
+    find_path(
+        MFEM_INCLUDE_DIRS mfem.hpp
+        PATHS ${MFEM_DIR}/include
+        NO_DEFAULT_PATH
+        NO_CMAKE_ENVIRONMENT_PATH
+        NO_CMAKE_PATH
+        NO_SYSTEM_ENVIRONMENT_PATH
+        NO_CMAKE_SYSTEM_PATH
+    )
 
-    find_library( MFEM_LIBRARY NAMES mfem
-                  PATHS 
-                    ${MFEM_DIR}/lib
-                    ${MFEM_DIR}
-                  NO_DEFAULT_PATH
-                  NO_CMAKE_ENVIRONMENT_PATH
-                  NO_CMAKE_PATH
-                  NO_SYSTEM_ENVIRONMENT_PATH
-                  NO_CMAKE_SYSTEM_PATH
-                  )
+    find_library(
+        MFEM_LIBRARIES NAMES mfem
+        PATHS ${MFEM_DIR}/lib
+        NO_DEFAULT_PATH
+        NO_CMAKE_ENVIRONMENT_PATH
+        NO_CMAKE_PATH
+        NO_SYSTEM_ENVIRONMENT_PATH
+        NO_CMAKE_SYSTEM_PATH )
+
+
+    # when MFEM is built w/o cmake, we can get the details
+    # of deps from its config.mk file
+    find_path(
+        MFEM_CFG_DIR config.mk
+        PATHS ${MFEM_DIR}/share/mfem/
+        NO_DEFAULT_PATH
+        NO_CMAKE_ENVIRONMENT_PATH
+        NO_CMAKE_PATH
+        NO_SYSTEM_ENVIRONMENT_PATH
+        NO_CMAKE_SYSTEM_PATH
+    )
+
+    if(NOT MFEM_CFG_DIR)
+        message(FATAL_ERROR "Failed to find any MFEM build configuration files in ${MFEM_DIR}")
+    else()
+        message(STATUS "Using MFEM's GNU Make config file: ${MFEM_CFG_DIR}/config.mk")
+    endif()
+
+    # read config.mk file
+    file(READ "${MFEM_CFG_DIR}/config.mk" mfem_cfg_file_txt)
+
+    # parse include flags
+    string(REGEX MATCHALL "MFEM_TPLFLAGS [^\n]+\n" mfem_tpl_inc_flags ${mfem_cfg_file_txt})
+    if(${CMAKE_VERSION} VERSION_GREATER 3.15.0)
+        message(VERBOSE "Content of variable mfem_tpl_inc_flags: ${mfem_tpl_inc_flags}")
+    endif()
+    string(REGEX REPLACE  "MFEM_TPLFLAGS +=" "" mfem_tpl_inc_flags ${mfem_tpl_inc_flags})
+    string(FIND  "${mfem_tpl_inc_flags}" "\n" mfem_tpl_inc_flags_end_pos)
+    string(SUBSTRING "${mfem_tpl_inc_flags}" 0 ${mfem_tpl_inc_flags_end_pos} mfem_tpl_inc_flags)
+    string(STRIP "${mfem_tpl_inc_flags}" mfem_tpl_inc_flags)
+
+    # remove the " -I" and add them to the include dir list
+    separate_arguments(mfem_tpl_inc_flags)
+    foreach(_include_flag ${mfem_tpl_inc_flags})
+        string(FIND "${_include_flag}" "-I" _pos)
+        if(_pos EQUAL 0)
+            string(SUBSTRING "${_include_flag}" 2 -1 _include_dir)
+            list(APPEND MFEM_INCLUDE_DIRS ${_include_dir})
+        endif()
+    endforeach()
+
+    # parse link flags
+    string(REGEX MATCHALL "MFEM_EXT_LIBS [^\n]+\n" mfem_tpl_lnk_flags ${mfem_cfg_file_txt})
+    if(${CMAKE_VERSION} VERSION_GREATER 3.15.0)
+        message(VERBOSE "Content of variable mfem_tpl_lnk_flags: ${mfem_tpl_lnk_flags}")
+    endif()
+    if(NOT mfem_tpl_lnk_flags EQUAL "")
+        string(REGEX REPLACE  "MFEM_EXT_LIBS +=" "" mfem_tpl_lnk_flags ${mfem_tpl_lnk_flags})
+        string(FIND  "${mfem_tpl_lnk_flags}" "\n" mfem_tpl_lnl_flags_end_pos )
+        string(SUBSTRING "${mfem_tpl_lnk_flags}" 0 ${mfem_tpl_lnl_flags_end_pos} mfem_tpl_lnk_flags)
+        string(STRIP "${mfem_tpl_lnk_flags}" mfem_tpl_lnk_flags)
+    else()
+        message(WARNING "No third party library flags found in ${MFEM_CFG_DIR}/config.mk")
+    endif()
+
+    list(APPEND MFEM_LIBRARIES ${mfem_tpl_lnk_flags})
+
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(MFEM  DEFAULT_MSG
-                                  MFEM_INCLUDE_DIRS
-                                  MFEM_LIBRARY )
+# handle the QUIETLY and REQUIRED arguments and set MFEM_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(MFEM DEFAULT_MSG
+                                  MFEM_LIBRARIES
+                                  MFEM_INCLUDE_DIRS )
+
+if(NOT MFEM_FOUND)
+    message(FATAL_ERROR "MFEM_DIR is not a path to a valid MFEM install")
+endif()
+
+message(STATUS "MFEM Includes: ${MFEM_INCLUDE_DIRS}")
+message(STATUS "MFEM Libraries: ${MFEM_LIBRARIES}")

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -107,9 +107,12 @@ endif()
 #------------------------------------------------------------------------------
 if (MFEM_DIR)
     include(cmake/thirdparty/FindMFEM.cmake)
+
+    blt_list_append(TO MFEM_LIBRARIES ELEMENTS mpi IF ENABLE_MPI)
+
     blt_register_library( NAME      mfem
                           INCLUDES  ${MFEM_INCLUDE_DIRS}
-                          LIBRARIES ${MFEM_LIBRARY}
+                          LIBRARIES ${MFEM_LIBRARIES}
                           TREAT_INCLUDES_AS_SYSTEM ON)
 else()
     message(STATUS "MFEM support is OFF")

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -107,9 +107,6 @@ endif()
 #------------------------------------------------------------------------------
 if (MFEM_DIR)
     include(cmake/thirdparty/FindMFEM.cmake)
-
-    blt_list_append(TO MFEM_LIBRARIES ELEMENTS mpi IF ENABLE_MPI)
-
     blt_register_library( NAME      mfem
                           INCLUDES  ${MFEM_INCLUDE_DIRS}
                           LIBRARIES ${MFEM_LIBRARIES}


### PR DESCRIPTION
This is the safe part of my previous PR.  It does not attempt to build MFEM w/ MPI support.  It does the following:

* Updates BLT to the newest develop (v0.3.6)
* Removes the non-existant MFEM from a docker host-config (it's missing from one of them)
* Moves devtools to /collab/usr/gapps
* Skips fixing permissions and groups on files that aren't in a shared space
* Removes Axom's hardcoded dependency variants for Conduit and MFEM