### PR TITLE
uberenv: full_spec not defined in install step

### DIFF
--- a/scripts/uberenv/uberenv.py
+++ b/scripts/uberenv/uberenv.py
@@ -625,6 +625,7 @@ class SpackEnv(UberEnv):
                       return res
         # note: this assumes package extends python when +python
         # this may fail general cases
+        full_spec = self.read_spack_full_spec(self.pkg_name,self.opts["spec"])
         if self.opts["install"] and "+python" in full_spec:
             activate_cmd = "spack/bin/spack activate " + self.pkg_name
             sexe(activate_cmd, echo=True)


### PR DESCRIPTION
# Summary

- This PR is a bugfix for the uberenv script
- It does the following (modify list as needed):
  - Modifies/refactors (class or method) (how?)
  - Fixes (issue number(s))
  - Adds (specific feature) at the request of (project or person)

# Design review (for API changes or additions---delete if unneeded)

On (date), we reviewed this PR.  We discussed the design ideas:

1. First idea or goal
2. Second idea
3. Third idea

This PR implements 1. and 3.  It leaves out 2. for the following reasons

- (impractical)
- (too big)
- (not a good idea anyway)

# Description
When running a command like:
```
python scripts/uberenv/uberenv.py --install --prefix="build" --spec '%gcc@8.1.0 ^mvapich2'
```
I get the following error:
```
Traceback (most recent call last):
  File "scripts/uberenv/uberenv.py", line 855, in <module>
    sys.exit(main())
  File "scripts/uberenv/uberenv.py", line 850, in main
    res = env.install()
  File "scripts/uberenv/uberenv.py", line 628, in install
    if self.opts["install"] and "+python" in full_spec:
UnboundLocalError: local variable 'full_spec' referenced before assignment
```
This PR sets full_spec to fix that problem.