### PR TITLE
Link hdf5 when using Sidre with Mint

### DIFF
--- a/src/axom/mint/CMakeLists.txt
+++ b/src/axom/mint/CMakeLists.txt
@@ -117,9 +117,10 @@ set( mint_dependencies
      slic
      )
 
-blt_list_append( TO mint_dependencies
-                 ELEMENTS sidre conduit::conduit hdf5
-                 IF AXOM_MINT_USE_SIDRE )
+if (AXOM_MINT_USE_SIDRE)
+   list( APPEND mint_dependencies sidre conduit::conduit )
+   blt_list_append( TO mint_dependencies ELEMENTS hdf5 IF HDF5_FOUND )
+endif()
 
 blt_list_append( TO mint_dependencies ELEMENTS RAJA IF RAJA_FOUND )
 

--- a/src/axom/mint/CMakeLists.txt
+++ b/src/axom/mint/CMakeLists.txt
@@ -118,7 +118,7 @@ set( mint_dependencies
      )
 
 blt_list_append( TO mint_dependencies
-                 ELEMENTS sidre conduit::conduit
+                 ELEMENTS sidre conduit::conduit hdf5
                  IF AXOM_MINT_USE_SIDRE )
 
 blt_list_append( TO mint_dependencies ELEMENTS RAJA IF RAJA_FOUND )


### PR DESCRIPTION
# Summary

In some instances the code was failing to compile b/c
the compiler was not able to resolve the hdf5 header include
in one of the Sidre header. To handle this more robustly, hdf5
needs to be specified explicitely for mint when using Sidre.
Fixed that.

