### PR TITLE
Fix build error when AXOM_VERSION_EXTRA is not defined

### DIFF
--- a/src/axom/core/utilities/About.cpp
+++ b/src/axom/core/utilities/About.cpp
@@ -144,7 +144,10 @@ void about(std::ostream &oss)
 std::string getVersion()
 {
   std::ostringstream oss;
-  oss << AXOM_VERSION_FULL << "-" << AXOM_VERSION_EXTRA;
+  oss << AXOM_VERSION_FULL;
+#ifdef AXOM_VERSION_EXTRA
+  oss << "-" << AXOM_VERSION_EXTRA;
+#endif
   return oss.str();
 }
 


### PR DESCRIPTION
This is fixes a build error when not in a git repository.

... i just want to use a new Axom in Serac....