### PR TITLE
Guard hdf5

### DIFF
--- a/src/axom/sidre/examples/lulesh2/CMakeLists.txt
+++ b/src/axom/sidre/examples/lulesh2/CMakeLists.txt
@@ -21,10 +21,10 @@ set(lulesh_depends
     core
     sidre
     conduit::conduit
-    hdf5
     slic )
 
-blt_list_append( TO lulesh_depends ELEMENTS mpi IF ENABLE_MPI )
+blt_list_append( TO lulesh_depends ELEMENTS hdf5   IF HDF5_FOUND )
+blt_list_append( TO lulesh_depends ELEMENTS mpi    IF ENABLE_MPI )
 blt_list_append( TO lulesh_depends ELEMENTS openmp IF ENABLE_OPENMP )
 
 blt_add_executable(


### PR DESCRIPTION
A user showed that we were guarding hdf5 properly in our lulesh2 example.  I reproduced this by turning off axom's and conduits hdf5 variant then building.  Because hdf5 is not a target in this state CMake blindly puts -lhdf5 on the link line hoping it is on the system (it actually is on rzgenie, unhelpfully?).  But this fix made it go away.

(All the labels for @kennyweiss )