### PR TITLE
Bugfix for primal::intersect(Segment, BoundingBox)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -55,9 +55,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   candidate BVH bins that intersect each bounding box.
 - Added an `axom-config.cmake` file to axom's installation to streamline incorporating axom
   into user applications. See `<axom-install>/examples/axom` for example usages.
-- Added a new built-in TPL, Sol (https://github.com/ThePhD/sol2), for fast and 
-  simple C++ and Lua Binding (automatically enabled when LUA_DIR is found). 
-  The version of Sol used in this release is v2.20.6, which requires C++14. 
+- Added [Sol] as a built-in TPL for fast and simple `C++` and `Lua` binding.
+  Sol is automatically enabled when `LUA_DIR` is found. 
+  The version of Sol used in this release is `v2.20.6`, which requires `C++14`.
 
 ### Removed
 
@@ -86,6 +86,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   `iomanager_new` is now `IOManager`
 
 ### Fixed
+- Fixed a bug in `primal::intersect(Segment, BoundingBox)` and added regression tests.
 - Spin's octrees can now be used with 64-bit indexes. This allows octrees 
   with up to 64 levels of resolution when using a 64-bit index type.
 - Resolved issue with `AXOM_USE_64BIT_INDEXTYPE` configurations. Axom can once again
@@ -406,3 +407,4 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 [SU2 Mesh file format]: https://su2code.github.io/docs/Mesh-File/
 [Umpire]: https://github.com/LLNL/Umpire
 [clang-format]: https://releases.llvm.org/10.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+[Sol]: https://github.com/ThePhD/sol2

--- a/src/axom/core/examples/core_containers.cpp
+++ b/src/axom/core/examples/core_containers.cpp
@@ -137,7 +137,7 @@ void demoArrayBasic()
 }
 
 int main()
-{ 
+{
   demoArrayBasic();
   return 0;
 }

--- a/src/axom/inlet/LuaReader.hpp
+++ b/src/axom/inlet/LuaReader.hpp
@@ -202,7 +202,7 @@ private:
   bool getMap(const std::string& id,
               std::unordered_map<int, T>& values,
               sol::type type);
-  
+
   sol::state m_lua;
 };
 

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -685,15 +685,13 @@ bool intersect_seg_bbox(const primal::Segment<T, DIM>& S,
                         const primal::BoundingBox<T, DIM>& bb,
                         primal::Point<T, DIM>& ip)
 {
-  T tmin = std::numeric_limits<T>::min();
   primal::Vector<T, DIM> direction(S.source(), S.target());
-  T tmax = direction.norm();
   primal::Ray<T, DIM> R(S.source(), direction);
 
   // These operations constrain the parameter specifying ray-slab intersection
   // points to exclude points not within the segment.
-  tmin = static_cast<T>(0);
-  tmax = static_cast<T>(1);
+  T tmin = static_cast<T>(0);
+  T tmax = static_cast<T>(direction.norm());
 
   for(int i = 0; i < DIM; i++)
   {

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -269,13 +269,16 @@ bool intersect(const Ray<T, DIM>& R,
 /// @{
 
 /*!
- * \brief Computes the intersection of the given segment, S, with the Box, bb.
- *     ip the point of intersection on S.
- * \return status true iff bb intersects with S, otherwise, false.
+ * \brief Computes the intersection of the given segment, \a S, with the Box, \a bb.
+ *     If an intersection is found, output parameter \a ip contains an intersection point
+ * \return status true iff \a bb intersects with \a S, otherwise, false.
  *
- * Computes Segment Box intersection using the slab method from pg 180 of
+ * \note The intersection between segment \a S and box \a bb intersect, will, in general,
+ * be a along a (1D) subset of segment \a S. This function returns a single point of 
+ * the intersection of \a S and \a bb found while determining if there is a valid intersection.
+ * 
+ * Computes Segment-Box intersection using the slab method from pg 180 of
  * Real Time Collision Detection by Christer Ericson.
- * WIP: More test cases for this
  */
 template <typename T, int DIM>
 bool intersect(const Segment<T, DIM>& S,

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -1430,6 +1430,145 @@ void testTriSegBothEnds(const primal::Triangle<double, DIM>& tri,
   }
 }
 
+TEST(primal_intersect, segment_aabb_2d_intersection)
+{
+  constexpr int DIM = 2;
+  using PointType = primal::Point<double, DIM>;
+  using SegmentType = primal::Segment<double, DIM>;
+  using BoxType = primal::BoundingBox<double, DIM>;
+
+  // Helper lambda for printing out intersection details
+  auto print_details = AXOM_LAMBDA(bool expected,
+                                   const BoxType& b,
+                                   const SegmentType& s,
+                                   const PointType& p)
+  {
+    if(expected)
+    {
+      SLIC_INFO("Found intersection between box " << b << " and line segment "
+                                                  << s << " at point " << p);
+    }
+    else
+    {
+      SLIC_INFO("No expected intersection between box "
+                << b << " and line segment " << s);
+    }
+  };
+
+  // Simple intersection
+  {
+    BoxType box(PointType::make_point(3, 3), PointType::make_point(5, 5));
+    SegmentType seg(PointType::make_point(3.25, 0),
+                    PointType::make_point(4.75, 6));
+    PointType ipt;
+
+    EXPECT_TRUE(primal::intersect(seg, box, ipt));
+    print_details(true, box, seg, ipt);
+  }
+
+  // Reverse of first case
+  {
+    BoxType box(PointType::make_point(3, 3), PointType::make_point(5, 5));
+    SegmentType seg(PointType::make_point(4.75, 6),
+                    PointType::make_point(3.25, 0));
+    PointType ipt;
+
+    EXPECT_TRUE(primal::intersect(seg, box, ipt));
+    print_details(true, box, seg, ipt);
+  }
+
+  // No intersection
+  {
+    BoxType box(PointType::make_point(3, 3), PointType::make_point(5, 5));
+    SegmentType seg(PointType::make_point(-3.25, 0),
+                    PointType::make_point(-4.75, 6));
+    PointType ipt;
+
+    EXPECT_FALSE(primal::intersect(seg, box, ipt));
+    print_details(false, box, seg, ipt);
+  }
+
+  // Grazing intersection
+  {
+    BoxType box(PointType::make_point(3, 3), PointType::make_point(5, 5));
+    SegmentType seg(PointType::make_point(3, 4), PointType::make_point(3, 6));
+    PointType ipt;
+
+    EXPECT_TRUE(primal::intersect(seg, box, ipt));
+    print_details(true, box, seg, ipt);
+  }
+}
+
+TEST(primal_intersect, segment_aabb_3d_intersection)
+{
+  constexpr int DIM = 3;
+  using PointType = primal::Point<double, DIM>;
+  using SegmentType = primal::Segment<double, DIM>;
+  using BoxType = primal::BoundingBox<double, DIM>;
+
+  // Helper lambda for printing out intersection details
+  auto print_details = AXOM_LAMBDA(bool expected,
+                                   const BoxType& b,
+                                   const SegmentType& s,
+                                   const PointType& p)
+  {
+    if(expected)
+    {
+      SLIC_INFO("Found intersection between box " << b << " and line segment "
+                                                  << s << " at point " << p);
+    }
+    else
+    {
+      SLIC_INFO("No expected intersection between box "
+                << b << " and line segment " << s);
+    }
+  };
+
+  // Simple intersection
+  {
+    BoxType box(PointType::make_point(3, 3, 3), PointType::make_point(5, 5, 5));
+    SegmentType seg(PointType::make_point(3.25, 0, 4),
+                    PointType::make_point(4.75, 6, 4));
+    PointType ipt;
+
+    EXPECT_TRUE(primal::intersect(seg, box, ipt));
+    print_details(true, box, seg, ipt);
+  }
+
+  // Reverse of first case
+  {
+    BoxType box(PointType::make_point(3, 3, 3), PointType::make_point(5, 5, 5));
+    SegmentType seg(PointType::make_point(4.75, 6, 4),
+                    PointType::make_point(3.25, 0, 4));
+    PointType ipt;
+
+    EXPECT_TRUE(primal::intersect(seg, box, ipt));
+    print_details(true, box, seg, ipt);
+  }
+
+  // No intersection
+  {
+    BoxType box(PointType::make_point(3, 3, 3), PointType::make_point(5, 5, 5));
+    SegmentType seg(PointType::make_point(-3.25, 0, 2),
+                    PointType::make_point(-4.75, 6, -2));
+    PointType ipt;
+
+    EXPECT_FALSE(primal::intersect(seg, box, ipt));
+    print_details(false, box, seg, ipt);
+  }
+
+  // Grazing intersection
+  {
+    BoxType box(PointType::make_point(3, 3, 3), PointType::make_point(5, 5, 5));
+    SegmentType seg(PointType::make_point(3, 4, 3),
+                    PointType::make_point(3, 6, 3));
+    PointType ipt;
+
+    EXPECT_TRUE(primal::intersect(seg, box, ipt));
+    print_details(true, box, seg, ipt);
+  }
+}
+
 TEST(primal_intersect, triangle_segment_intersection)
 {
   const int DIM = 3;

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -1438,11 +1438,10 @@ TEST(primal_intersect, segment_aabb_2d_intersection)
   using BoxType = primal::BoundingBox<double, DIM>;
 
   // Helper lambda for printing out intersection details
-  auto print_details = AXOM_LAMBDA(bool expected,
-                                   const BoxType& b,
-                                   const SegmentType& s,
-                                   const PointType& p)
-  {
+  auto print_details = [=](bool expected,
+                           const BoxType& b,
+                           const SegmentType& s,
+                           const PointType& p) {
     if(expected)
     {
       SLIC_INFO("Found intersection between box " << b << " and line segment "
@@ -1507,11 +1506,10 @@ TEST(primal_intersect, segment_aabb_3d_intersection)
   using BoxType = primal::BoundingBox<double, DIM>;
 
   // Helper lambda for printing out intersection details
-  auto print_details = AXOM_LAMBDA(bool expected,
-                                   const BoxType& b,
-                                   const SegmentType& s,
-                                   const PointType& p)
-  {
+  auto print_details = [=](bool expected,
+                           const BoxType& b,
+                           const SegmentType& s,
+                           const PointType& p) {
     if(expected)
     {
       SLIC_INFO("Found intersection between box " << b << " and line segment "


### PR DESCRIPTION
# Summary

- This PR is a bugfix for `primal::intersect(Segment, BoundingBox)`
- It fixes the initial bounds calculations for determining if the segment intersect bounding box
- Closes #342 
