### PR TITLE
Fix build errors found with Serac's configuration

### DIFF
--- a/src/axom/inlet/SchemaCreator.hpp
+++ b/src/axom/inlet/SchemaCreator.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 #include "axom/inlet/Field.hpp"
 

--- a/src/thirdparty/tests/CMakeLists.txt
+++ b/src/thirdparty/tests/CMakeLists.txt
@@ -37,11 +37,8 @@ if ( RAJA_FOUND )
   set( raja_smoke_dependencies RAJA gtest )
 
   blt_list_append( TO raja_smoke_dependencies ELEMENTS openmp IF ENABLE_OPENMP)
-
   blt_list_append( TO raja_smoke_dependencies ELEMENTS umpire IF UMPIRE_FOUND)
-
   blt_list_append( TO raja_smoke_dependencies ELEMENTS cuda IF ENABLE_CUDA)
-
   blt_list_append( TO raja_smoke_dependencies ELEMENTS mpi IF ENABLE_MPI)
 
   blt_add_executable( NAME raja_smoke_test
@@ -59,10 +56,15 @@ endif()
 # Smoke test for hdf5 third party library
 #------------------------------------------------------------------------------
 if( HDF5_FOUND)
+
+    set( hdf5_smoke_dependencies hdf5 gtest )
+
+    blt_list_append( TO hdf5_smoke_dependencies ELEMENTS mpi IF ENABLE_MPI)
+
     blt_add_executable(NAME hdf5_smoke_test
                        SOURCES hdf5_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON hdf5 gtest
+                       DEPENDS_ON ${hdf5_smoke_dependencies}
                        FOLDER axom/thirdparty/tests )
 
     blt_add_test(NAME hdf5_smoke


### PR DESCRIPTION
I swear I tested this. I am not sure how the hdf5 ever worked. Serac is the only configuration I know that turns on mpi for hdf5 but I turned it on 25 days ago and there has been multiple TPL builds since then...