### PR TITLE
Allow user to specify an abort callback for slic abort

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,11 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ## Unreleased
 
+### Added
+- Added the MFEMSidreDataCollection class for HDF5-format simulation data collection.  This
+  class was adapted from MFEM's SidreDataCollection and is enabled when Axom is built with MFEM
+  *and* the `AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION` CMake option is enabled.
+- Added `slic::setAbortFunction` to configure a custom callback when SLIC aborts.
 
 ### Changed
 - The Sidre Datastore no longer rewires Conduit's error handlers to SLIC by default. 
@@ -70,9 +75,6 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Added [Sol] as a built-in TPL for fast and simple `C++` and `Lua` binding.
   Sol is automatically enabled when `LUA_DIR` is found. 
   The version of Sol used in this release is `v2.20.6`, which requires `C++14`.
-- Added the MFEMSidreDataCollection class for HDF5-format simulation data collection.  This
-  class was adapted from MFEM's SidreDataCollection and is enabled when Axom is built with MFEM
-  *and* the `AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION` CMake option is enabled.
 
 ### Removed
 - Removed the `AXOM_ENABLE_CUB` option, since `CUB` is no lonher used directly in

--- a/src/axom/slic/core/Logger.cpp
+++ b/src/axom/slic/core/Logger.cpp
@@ -20,7 +20,10 @@ Logger* Logger::s_Logger = nullptr;
 std::map<std::string, Logger*> Logger::s_loggers;
 
 //------------------------------------------------------------------------------
-Logger::Logger() : m_abortOnError(true), m_abortOnWarning(false), m_abortFunction(axom::utilities::processAbort)
+Logger::Logger()
+  : m_abortOnError(true)
+  , m_abortOnWarning(false)
+  , m_abortFunction(axom::utilities::processAbort)
 {
   // by default, all message streams are disabled
   for(int i = 0; i < message::Num_Levels; ++i)

--- a/src/axom/slic/core/Logger.cpp
+++ b/src/axom/slic/core/Logger.cpp
@@ -20,7 +20,7 @@ Logger* Logger::s_Logger = nullptr;
 std::map<std::string, Logger*> Logger::s_loggers;
 
 //------------------------------------------------------------------------------
-Logger::Logger() : m_abortOnError(true), m_abortOnWarning(false)
+Logger::Logger() : m_abortOnError(true), m_abortOnWarning(false), m_abortFunction(axom::utilities::processAbort)
 {
   // by default, all message streams are disabled
   for(int i = 0; i < message::Num_Levels; ++i)
@@ -34,6 +34,7 @@ Logger::Logger(const std::string& name)
   : m_name(name)
   , m_abortOnError(true)
   , m_abortOnWarning(false)
+  , m_abortFunction(axom::utilities::processAbort)
 {
   // by default, all message streams are disabled
   for(int i = 0; i < message::Num_Levels; ++i)
@@ -56,6 +57,18 @@ Logger::~Logger()
     m_logStreams[level].clear();
 
   }  // END for all levels
+}
+
+//------------------------------------------------------------------------------
+void Logger::setAbortFunction(void (*abort_func)(void))
+{
+  if(abort_func == nullptr)
+  {
+    std::cerr << "WARNING: supplied abort function is NULL!\n";
+    return;
+  }
+
+  m_abortFunction = abort_func;
 }
 
 //------------------------------------------------------------------------------
@@ -202,7 +215,7 @@ void Logger::logMessage(message::Level level,
      (m_abortOnWarning && (level == message::Warning)))
   {
     this->flushStreams();
-    axom::utilities::processAbort();
+    m_abortFunction();
 
   }  // END if
 }

--- a/src/axom/slic/core/Logger.cpp
+++ b/src/axom/slic/core/Logger.cpp
@@ -63,11 +63,12 @@ Logger::~Logger()
 }
 
 //------------------------------------------------------------------------------
-void Logger::setAbortFunction(void (*abort_func)(void))
+void Logger::setAbortFunction(AbortFunctionPtr abort_func)
 {
   if(abort_func == nullptr)
   {
-    std::cerr << "WARNING: supplied abort function is NULL!\n";
+    std::cerr << "WARNING: slic::Logger::setAbortFunction() -- supplied abort "
+                 "function is invalid!\n";
     return;
   }
 

--- a/src/axom/slic/core/Logger.hpp
+++ b/src/axom/slic/core/Logger.hpp
@@ -26,6 +26,9 @@ namespace slic
 // Forward declarations
 class LogStream;
 
+// Type alias for readability
+using AbortFunctionPtr = void (*)();
+
 /*!
  * \class Logger
  *
@@ -114,7 +117,7 @@ public:
    * \brief Sets the function to call when program abort is requested
    * \param [in] abort_func The user-specified function to call
    */
-  void setAbortFunction(void (*abort_func)(void));
+  void setAbortFunction(AbortFunctionPtr abort_func);
 
   /*!
    * \brief Returns the name of this logger instance.

--- a/src/axom/slic/core/Logger.hpp
+++ b/src/axom/slic/core/Logger.hpp
@@ -111,6 +111,12 @@ public:
   bool isAbortOnWarningsEnabled() const { return m_abortOnWarning; };
 
   /*!
+   * \brief Sets the function to call when program abort is requested
+   * \param [in] abort_func The user-specified function to call
+   */
+  void setAbortFunction(void (*abort_func)(void));
+
+  /*!
    * \brief Returns the name of this logger instance.
    * \return s a string corresponding to the name of this logger instance.
    * \post s.length() > 0
@@ -315,6 +321,7 @@ private:
   std::string m_name;
   bool m_abortOnError;
   bool m_abortOnWarning;
+  void (*m_abortFunction)(void);
 
   bool m_isEnabled[message::Num_Levels];
   std::map<LogStream*, LogStream*> m_streamObjectsManager;

--- a/src/axom/slic/docs/sphinx/sections/getting_started.rst
+++ b/src/axom/slic/docs/sphinx/sections/getting_started.rst
@@ -173,7 +173,8 @@ below.
    By default, ``SLIC_ERROR()`` will print the specified message and a stacktrace
    to the corresponding output destination and call :ref:`axomProcessAbort` to
    gracefully abort the application. This behavior can be toggled by calling
-   ``slic::disableAbortOnError()``. See the `Slic Doxygen API Documentation`_
+   ``slic::disableAbortOnError()``. Additionally, a custom abort function can be
+   registered with ``slic::setAbortFunction()``. See the `Slic Doxygen API Documentation`_
    for more details.
 
 Step 6: Finalize Slic

--- a/src/axom/slic/examples/CMakeLists.txt
+++ b/src/axom/slic/examples/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 set(example_sources
     basic/cpplogger.cpp
+    basic/custom_abort_logger.cpp
     basic/logging.cpp
     multicode/driver.cpp
     )
@@ -52,4 +53,3 @@ if ( ENABLE_MPI )
         endif()
     endforeach()
 endif()
-

--- a/src/axom/slic/examples/basic/custom_abort_logger.cpp
+++ b/src/axom/slic/examples/basic/custom_abort_logger.cpp
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 // C/C++ includes
-#include <iostream> // For std::cerr
+#include <iostream>  // For std::cerr
 
 // Logging includes
 #include "axom/slic/interface/slic.hpp"
@@ -15,7 +15,7 @@ using namespace axom;
 void customAbortFunction()
 {
   // finalize logging if needed
-  if (slic::isInitialized())
+  if(slic::isInitialized())
   {
     slic::finalize();
   }

--- a/src/axom/slic/examples/basic/custom_abort_logger.cpp
+++ b/src/axom/slic/examples/basic/custom_abort_logger.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2017-2020, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+// C/C++ includes
+#include <iostream> // For std::cerr
+
+// Logging includes
+#include "axom/slic/interface/slic.hpp"
+#include "axom/slic/streams/GenericOutputStream.hpp"
+
+using namespace axom;
+
+void customAbortFunction()
+{
+  // finalize logging if needed
+  if (slic::isInitialized())
+  {
+    slic::finalize();
+  }
+  std::cerr << "Custom abort function called!\n";
+}
+
+//------------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  static_cast<void>(argc);
+  static_cast<void>(argv);
+
+  //----------------------------------------------------------------------------
+  // STEP 0: Initialize logger
+  //----------------------------------------------------------------------------
+  slic::initialize();
+  slic::setLoggingMsgLevel(slic::message::Debug);
+
+  //----------------------------------------------------------------------------
+  // STEP 1: Create log streams
+  //----------------------------------------------------------------------------
+
+  // setup log stream for ALL messages, including FATAL, ERROR and WARNING
+  std::string console_format = std::string("[<LEVEL>]: <MESSAGE>\n");
+  slic::LogStream* console =
+    new slic::GenericOutputStream(&std::cerr, console_format);
+
+  //----------------------------------------------------------------------------
+  // STEP 2: add streams to logger
+  //----------------------------------------------------------------------------
+
+  slic::addStreamToAllMsgLevels(console);
+
+  //----------------------------------------------------------------------------
+  // STEP 3: Register a custom abort function
+  //----------------------------------------------------------------------------
+  slic::setAbortFunction(customAbortFunction);
+
+  //----------------------------------------------------------------------------
+  // STEP 4: Trigger the abort function by raising an error
+  //----------------------------------------------------------------------------
+  SLIC_ERROR("Here is an error message!");
+
+  return 0;
+}

--- a/src/axom/slic/interface/slic.cpp
+++ b/src/axom/slic/interface/slic.cpp
@@ -148,6 +148,19 @@ bool isAbortOnWarningsEnabled()
 }
 
 //------------------------------------------------------------------------------
+void setAbortFunction(void (*abort_func)(void))
+{
+  if(!isInitialized())
+  {
+    std::cerr << "[ERROR]: slic::initialize() must be called first "
+              << "before making any other calls to SLIC.";
+    return;
+  }
+
+  Logger::getActiveLogger()->setAbortFunction(abort_func);
+}
+
+//------------------------------------------------------------------------------
 void addStreamToMsgLevel(LogStream* ls, message::Level level)
 {
   if(!isInitialized())

--- a/src/axom/slic/interface/slic.cpp
+++ b/src/axom/slic/interface/slic.cpp
@@ -28,7 +28,7 @@ void createLogger(const std::string& name, char imask)
 {
   if(!isInitialized())
   {
-    std::cerr << "[ERROR]: slic::initialize() must be called first "
+    std::cerr << "[ERROR]: slic::initialize() must be called "
               << "before making any other calls to SLIC.";
     return;
   }
@@ -40,7 +40,7 @@ bool activateLogger(const std::string& name)
 {
   if(!isInitialized())
   {
-    std::cerr << "[ERROR]: slic::initialize() must be called first "
+    std::cerr << "[ERROR]: slic::initialize() must be called "
               << "before making any other calls to SLIC.";
     return false;
   }
@@ -52,7 +52,7 @@ std::string getActiveLoggerName()
 {
   if(!isInitialized())
   {
-    std::cerr << "[ERROR]: slic::initialize() must be called first "
+    std::cerr << "[ERROR]: slic::initialize() must be called "
               << "before making any other calls to SLIC.";
     return "";
   }
@@ -64,7 +64,7 @@ message::Level getLoggingMsgLevel()
 {
   if(!isInitialized())
   {
-    std::cerr << "[ERROR]: slic::initialize() must be called first "
+    std::cerr << "[ERROR]: slic::initialize() must be called "
               << "before making any other calls to SLIC.";
     return message::Num_Levels;
   }
@@ -76,7 +76,7 @@ void setLoggingMsgLevel(message::Level level)
 {
   if(!isInitialized())
   {
-    std::cerr << "[ERROR]: slic::initialize() must be called first "
+    std::cerr << "[ERROR]: slic::initialize() must be called "
               << "before making any other calls to SLIC.";
     return;
   }
@@ -88,7 +88,7 @@ void setAbortOnError(bool status)
 {
   if(!isInitialized())
   {
-    std::cerr << "[ERROR]: slic::initialize() must be called first "
+    std::cerr << "[ERROR]: slic::initialize() must be called "
               << "before making any other calls to SLIC.";
     return;
   }
@@ -107,7 +107,7 @@ bool isAbortOnErrorsEnabled()
 {
   if(!isInitialized())
   {
-    std::cerr << "[ERROR]: slic::initialize() must be called first "
+    std::cerr << "[ERROR]: slic::initialize() must be called "
               << "before making any other calls to SLIC.";
     return false;
   }
@@ -120,7 +120,7 @@ void setAbortOnWarning(bool status)
 {
   if(!isInitialized())
   {
-    std::cerr << "[ERROR]: slic::initialize() must be called first "
+    std::cerr << "[ERROR]: slic::initialize() must be called "
               << "before making any other calls to SLIC.";
     return;
   }
@@ -139,7 +139,7 @@ bool isAbortOnWarningsEnabled()
 {
   if(!isInitialized())
   {
-    std::cerr << "[ERROR]: slic::initialize() must be called first "
+    std::cerr << "[ERROR]: slic::initialize() must be called "
               << "before making any other calls to SLIC.";
     return false;
   }
@@ -148,11 +148,11 @@ bool isAbortOnWarningsEnabled()
 }
 
 //------------------------------------------------------------------------------
-void setAbortFunction(void (*abort_func)(void))
+void setAbortFunction(AbortFunctionPtr abort_func)
 {
   if(!isInitialized())
   {
-    std::cerr << "[ERROR]: slic::initialize() must be called first "
+    std::cerr << "[ERROR]: slic::initialize() must be called "
               << "before making any other calls to SLIC.";
     return;
   }
@@ -165,7 +165,7 @@ void addStreamToMsgLevel(LogStream* ls, message::Level level)
 {
   if(!isInitialized())
   {
-    std::cerr << "[ERROR]: slic::initialize() must be called first "
+    std::cerr << "[ERROR]: slic::initialize() must be called "
               << "before making any other calls to SLIC.";
     return;
   }
@@ -261,7 +261,7 @@ void flushStreams()
 {
   if(!isInitialized())
   {
-    std::cerr << "[ERROR]: slic::initialize() must be called first "
+    std::cerr << "[ERROR]: slic::initialize() must be called "
               << "before making any other calls to SLIC.";
     return;
   }
@@ -273,7 +273,7 @@ void pushStreams()
 {
   if(!isInitialized())
   {
-    std::cerr << "[ERROR]: slic::initialize() must be called first "
+    std::cerr << "[ERROR]: slic::initialize() must be called "
               << "before making any other calls to SLIC.";
     return;
   }

--- a/src/axom/slic/interface/slic.hpp
+++ b/src/axom/slic/interface/slic.hpp
@@ -130,6 +130,13 @@ void disableAbortOnWarning();
 bool isAbortOnWarningsEnabled();
 
 /*!
+ * \brief Sets the function to call when program abort is requested
+ * \param [in] abort_func The user-specified function to call
+ * \pre slic::isInitialized() == true.
+ */
+void setAbortFunction(void (*abort_func)(void));
+
+/*!
  * \brief Adds the given stream to the the given level.
  * \param [in] ls pointer to the log stream.
  * \param [in] level the level to log.

--- a/src/axom/slic/interface/slic.hpp
+++ b/src/axom/slic/interface/slic.hpp
@@ -134,7 +134,7 @@ bool isAbortOnWarningsEnabled();
  * \param [in] abort_func The user-specified function to call
  * \pre slic::isInitialized() == true.
  */
-void setAbortFunction(void (*abort_func)(void));
+void setAbortFunction(AbortFunctionPtr abort_func);
 
 /*!
  * \brief Adds the given stream to the the given level.


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following:
  - Adds the ability for the user to specify a custom abort function - `axom::utilities::processAbort` remains the default

`std::function` could be used in place of raw function pointers.

An example usage was also added.