### PR TITLE
Added std::initializer_list constructors to primal primitives

### DIFF
--- a/src/axom/inlet/Inlet.hpp
+++ b/src/axom/inlet/Inlet.hpp
@@ -364,7 +364,8 @@ public:
    * this Table.
    *****************************************************************************
    */
-  std::unordered_map<std::string, std::shared_ptr<Field>> getChildFields() {
+  std::unordered_map<std::string, std::shared_ptr<Field>> getChildFields()
+  {
     return m_globalTable->getChildFields();
   }
 
@@ -374,7 +375,8 @@ public:
    * this Table.
    *****************************************************************************
    */
-  std::unordered_map<std::string, std::shared_ptr<Table>> getChildTables() {
+  std::unordered_map<std::string, std::shared_ptr<Table>> getChildTables()
+  {
     return m_globalTable->getChildTables();
   }
 
@@ -389,8 +391,9 @@ public:
    *****************************************************************************
    */
   std::shared_ptr<Table> addBoolArray(const std::string& name,
-                                      const std::string& description = "") {
-    return m_globalTable->addBoolArray(name,description);                                        
+                                      const std::string& description = "")
+  {
+    return m_globalTable->addBoolArray(name, description);
   }
 
   /*!
@@ -404,8 +407,9 @@ public:
    *****************************************************************************
    */
   std::shared_ptr<Table> addIntArray(const std::string& name,
-                                     const std::string& description = "") {
-    return m_globalTable->addIntArray(name,description);  
+                                     const std::string& description = "")
+  {
+    return m_globalTable->addIntArray(name, description);
   }
 
   /*!
@@ -419,8 +423,9 @@ public:
    *****************************************************************************
    */
   std::shared_ptr<Table> addDoubleArray(const std::string& name,
-                                        const std::string& description = "") {
-    return m_globalTable->addDoubleArray(name,description);                                     
+                                        const std::string& description = "")
+  {
+    return m_globalTable->addDoubleArray(name, description);
   }
 
   /*!
@@ -434,8 +439,9 @@ public:
    *****************************************************************************
    */
   std::shared_ptr<Table> addStringArray(const std::string& name,
-                                        const std::string& description = "") {
-    return m_globalTable->addStringArray(name,description);                                    
+                                        const std::string& description = "")
+  {
+    return m_globalTable->addStringArray(name, description);
   }
 
   /*!
@@ -447,7 +453,8 @@ public:
    * \return Whether or not the array was found
    *****************************************************************************
    */
-  bool getBoolArray(std::unordered_map<int, bool>& map) {
+  bool getBoolArray(std::unordered_map<int, bool>& map)
+  {
     return m_globalTable->getBoolArray(map);
   }
 
@@ -460,7 +467,8 @@ public:
    * \return Whether or not the array was found
    *****************************************************************************
    */
-  bool getIntArray(std::unordered_map<int, int>& map) {
+  bool getIntArray(std::unordered_map<int, int>& map)
+  {
     return m_globalTable->getIntArray(map);
   }
 
@@ -473,7 +481,8 @@ public:
    * \return Whether or not the array was found
    *****************************************************************************
    */
-  bool getDoubleArray(std::unordered_map<int, double>& map) {
+  bool getDoubleArray(std::unordered_map<int, double>& map)
+  {
     return m_globalTable->getDoubleArray(map);
   }
 
@@ -486,7 +495,8 @@ public:
    * \return Whether or not the array was found
    *****************************************************************************
    */
-  bool getStringArray(std::unordered_map<int, std::string>& map) {
+  bool getStringArray(std::unordered_map<int, std::string>& map)
+  {
     return m_globalTable->getStringArray(map);
   }
 

--- a/src/axom/inlet/LuaReader.hpp
+++ b/src/axom/inlet/LuaReader.hpp
@@ -39,11 +39,7 @@ namespace inlet
 class LuaReader : public Reader
 {
 public:
-
-  LuaReader() 
-  {
-    m_lua.open_libraries(sol::lib::base);
-  }
+  LuaReader() { m_lua.open_libraries(sol::lib::base); }
 
   /*!
    *****************************************************************************
@@ -198,7 +194,6 @@ public:
   bool getStringMap(const std::string& id,
                     std::unordered_map<int, std::string>& values);
 
-
   /*!
    *****************************************************************************
    * \brief Returns the Sol Lua state
@@ -208,9 +203,7 @@ public:
    * \return Reference to the Sol Lua state
    *****************************************************************************
    */
-  sol::state& solState() {
-    return m_lua;
-  }
+  sol::state& solState() { return m_lua; }
 
 private:
   // Expect this to be called for only Inlet-supported types.

--- a/src/axom/inlet/SchemaCreator.hpp
+++ b/src/axom/inlet/SchemaCreator.hpp
@@ -60,7 +60,7 @@ public:
    *****************************************************************************
    */
   virtual std::shared_ptr<Table> addTable(const std::string& name,
-                                  const std::string& description) = 0;
+                                          const std::string& description) = 0;
 
   /*!
    *****************************************************************************
@@ -78,7 +78,7 @@ public:
    *****************************************************************************
    */
   virtual std::shared_ptr<Field> addBool(const std::string& name,
-                                 const std::string& description) = 0;
+                                         const std::string& description) = 0;
 
   /*!
    *****************************************************************************
@@ -96,7 +96,7 @@ public:
    *****************************************************************************
    */
   virtual std::shared_ptr<Field> addDouble(const std::string& name,
-                                   const std::string& description) = 0;
+                                           const std::string& description) = 0;
 
   /*!
    *****************************************************************************
@@ -114,7 +114,7 @@ public:
    *****************************************************************************
    */
   virtual std::shared_ptr<Field> addInt(const std::string& name,
-                                const std::string& description) = 0;
+                                        const std::string& description) = 0;
 
   /*!
    *****************************************************************************
@@ -132,7 +132,7 @@ public:
    *****************************************************************************
    */
   virtual std::shared_ptr<Field> addString(const std::string& name,
-                                   const std::string& description) = 0;
+                                           const std::string& description) = 0;
   /*!
    *****************************************************************************
    * \brief Return whether a Table with the given name is present in this Table's subtree.
@@ -202,8 +202,9 @@ public:
    * \return Shared pointer to the created Field
    *****************************************************************************
    */
-  virtual std::shared_ptr<Table> addBoolArray(const std::string& name,
-                                      const std::string& description = "") = 0;
+  virtual std::shared_ptr<Table> addBoolArray(
+    const std::string& name,
+    const std::string& description = "") = 0;
 
   /*!
    *****************************************************************************
@@ -215,8 +216,9 @@ public:
    * \return Shared pointer to the created Field
    *****************************************************************************
    */
-  virtual std::shared_ptr<Table> addIntArray(const std::string& name,
-                                     const std::string& description = "") = 0;
+  virtual std::shared_ptr<Table> addIntArray(
+    const std::string& name,
+    const std::string& description = "") = 0;
 
   /*!
    *****************************************************************************
@@ -228,8 +230,9 @@ public:
    * \return Shared pointer to the created Field
    *****************************************************************************
    */
-  virtual std::shared_ptr<Table> addDoubleArray(const std::string& name,
-                                        const std::string& description = "") = 0;
+  virtual std::shared_ptr<Table> addDoubleArray(
+    const std::string& name,
+    const std::string& description = "") = 0;
 
   /*!
    *****************************************************************************
@@ -241,8 +244,9 @@ public:
    * \return Shared pointer to the created Field
    *****************************************************************************
    */
-  virtual std::shared_ptr<Table> addStringArray(const std::string& name,
-                                        const std::string& description = "") = 0;
+  virtual std::shared_ptr<Table> addStringArray(
+    const std::string& name,
+    const std::string& description = "") = 0;
 
   /*!
    *****************************************************************************

--- a/src/axom/inlet/tests/inlet_LuaReader.cpp
+++ b/src/axom/inlet/tests/inlet_LuaReader.cpp
@@ -109,7 +109,6 @@ TEST(inlet_LuaReader, mixLevelTables)
   EXPECT_EQ(value, 3);
 }
 
-
 // Checks that LuaReader parses array information as expected
 TEST(inlet_LuaReader, getMap)
 {
@@ -147,7 +146,6 @@ TEST(inlet_LuaReader, getMap)
                                                      {200, "bye"}};
   EXPECT_EQ(expectedStrs, strs);
 }
-
 
 //------------------------------------------------------------------------------
 #include "axom/slic/core/UnitTestLogger.hpp"

--- a/src/axom/primal/geometry/NumericArray.hpp
+++ b/src/axom/primal/geometry/NumericArray.hpp
@@ -14,6 +14,7 @@
 #include <cstring>    // For memcpy()
 #include <algorithm>  // For std:: copy and fill
 #include <ostream>    // For print() and operator <<
+#include <initializer_list>
 
 namespace axom
 {
@@ -205,7 +206,17 @@ public:
    */
   AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE
-  NumericArray(const T* vals, int sz = SIZE);
+  explicit NumericArray(const T* vals, int sz = SIZE);
+
+  /*!
+   * \brief Creates a numeric array from an initializer list
+   * \param [in] values an initializer list containing the values of the
+   * array. If the size is not the same as the size of this array, this
+   * behaves the same way as the constructor which takes a pointer and size.
+   */
+  NumericArray(std::initializer_list<T> values)
+    : NumericArray {values.begin(), static_cast<int>(values.size())}
+  { }
 
   /*!
    * \brief Copy constructor.

--- a/src/axom/primal/geometry/Point.hpp
+++ b/src/axom/primal/geometry/Point.hpp
@@ -95,6 +95,16 @@ public:
   Point(const T* vals, int sz = NDIMS) : m_components(vals, sz) { }
 
   /*!
+   * \brief Creates a point from an initializer list
+   * \param [in] values an initializer list containing the values of the
+   * point. If the size is not the same as the size of this point, this
+   * behaves the same way as the constructor which takes a pointer and size.
+   */
+  Point(std::initializer_list<T> values)
+    : Point {values.begin(), static_cast<int>(values.size())}
+  { }
+
+  /*!
    * \brief Copy constructor.
    * \param [in] other The point to copy
    */

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -168,6 +168,16 @@ public:
   { }
 
   /*!
+   * \brief Creates a vector from an initializer list
+   * \param [in] values an initializer list containing the values of the
+   * vector. If the size is not the same as the size of this vector, this
+   * behaves the same way as the constructor which takes a pointer and size.
+   */
+  Vector(std::initializer_list<T> values)
+    : Vector {values.begin(), static_cast<int>(values.size())}
+  { }
+
+  /*!
    * \brief Destructor.
    */
   AXOM_HOST_DEVICE

--- a/src/axom/primal/tests/primal_numeric_array.cpp
+++ b/src/axom/primal/tests/primal_numeric_array.cpp
@@ -57,6 +57,28 @@ TEST(primal_numeric_array, constructors)
     CoordType expVal = i < halfPt ? valsArr[i] : CoordType();
     EXPECT_EQ(arrHalfVec[i], expVal);
   }
+
+  primal::NumericArray<int, 3> fromInitializerListRightSize = {10, 20, 30};
+  for(int i = 0; i < 3; ++i)
+  {
+    EXPECT_EQ(10 * (i + 1), fromInitializerListRightSize[i]);
+  }
+
+  primal::NumericArray<int, 3> fromInitializerListTooLong = {10, 20, 30, 40};
+  for(int i = 0; i < 3; ++i)
+  {
+    EXPECT_EQ(10 * (i + 1), fromInitializerListTooLong[i]);
+  }
+
+  primal::NumericArray<int, 5> fromInitializerListTooShort = {10, 20};
+  for(int i = 0; i < 2; ++i)
+  {
+    EXPECT_EQ(10 * (i + 1), fromInitializerListTooShort[i]);
+  }
+  for(int i = 2; i < 5; ++i)
+  {
+    EXPECT_EQ(0, fromInitializerListTooShort[i]);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_numeric_array.cpp
+++ b/src/axom/primal/tests/primal_numeric_array.cpp
@@ -79,6 +79,12 @@ TEST(primal_numeric_array, constructors)
   {
     EXPECT_EQ(0, fromInitializerListTooShort[i]);
   }
+
+  primal::NumericArray<int, 3> fromInitializerNoEquaslSign{10, 20, 30};
+  for(int i = 0; i < 3; ++i)
+  {
+    EXPECT_EQ(10 * (i + 1), fromInitializerNoEquaslSign[i]);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_point.cpp
+++ b/src/axom/primal/tests/primal_point.cpp
@@ -167,6 +167,17 @@ TEST(primal_point, point_numericArray_constructor)
 }
 
 //------------------------------------------------------------------------------
+TEST(primal_point, point_initializerList_constructor)
+{
+  // Should work because of the implicit constructor from a NumericArray.
+  primal::Point<int, 3> fromInitializerList = {10, 20, 30};
+  for(int i = 0; i < 3; ++i)
+  {
+    EXPECT_EQ(10 * (i + 1), fromInitializerList[i]);
+  }
+}
+
+//------------------------------------------------------------------------------
 TEST(primal_point, point_copy_and_assignment)
 {
   static const int DIM = 5;

--- a/src/axom/primal/tests/primal_point.cpp
+++ b/src/axom/primal/tests/primal_point.cpp
@@ -169,11 +169,32 @@ TEST(primal_point, point_numericArray_constructor)
 //------------------------------------------------------------------------------
 TEST(primal_point, point_initializerList_constructor)
 {
-  // Should work because of the implicit constructor from a NumericArray.
   primal::Point<int, 3> fromInitializerList = {10, 20, 30};
   for(int i = 0; i < 3; ++i)
   {
     EXPECT_EQ(10 * (i + 1), fromInitializerList[i]);
+  }
+
+  primal::Point<int, 4> listTooShort = {10, 20};
+  for(int i = 0; i < 2; ++i)
+  {
+    EXPECT_EQ(10 * (i + 1), listTooShort[i]);
+  }
+  for(int i = 2; i < 4; ++i)
+  {
+    EXPECT_EQ(0, listTooShort[i]);
+  }
+
+  primal::Point<int, 3> listTooLong = {10, 20, 30, 40};
+  for(int i = 0; i < 3; ++i)
+  {
+    EXPECT_EQ(10 * (i + 1), listTooLong[i]);
+  }
+
+  primal::Point<int, 3> noEqualsSign{10, 20, 30};
+  for(int i = 0; i < 3; ++i)
+  {
+    EXPECT_EQ(10 * (i + 1), noEqualsSign[i]);
   }
 }
 

--- a/src/axom/primal/tests/primal_vector.cpp
+++ b/src/axom/primal/tests/primal_vector.cpp
@@ -64,11 +64,33 @@ TEST(primal_vector, vector_constructors)
     EXPECT_EQ(vFromNA[i], valsArr[i]);
   }
 
-  // Should work because of the implicit constructor from a NumericArray.
-  primal::Vector<int, 3> fromInitializerList = {10, 20, 30};
+  // Initializer list constructor
+  primal::Vector<int, 3> fromInitializerListRightSize = {10, 20, 30};
   for(int i = 0; i < 3; ++i)
   {
-    EXPECT_EQ(10 * (i + 1), fromInitializerList[i]);
+    EXPECT_EQ(10 * (i + 1), fromInitializerListRightSize[i]);
+  }
+
+  primal::Vector<int, 3> fromInitializerListTooLong = {10, 20, 30, 40};
+  for(int i = 0; i < 3; ++i)
+  {
+    EXPECT_EQ(10 * (i + 1), fromInitializerListTooLong[i]);
+  }
+
+  primal::Vector<int, 5> fromInitializerListTooShort = {10, 20};
+  for(int i = 0; i < 2; ++i)
+  {
+    EXPECT_EQ(10 * (i + 1), fromInitializerListTooShort[i]);
+  }
+  for(int i = 2; i < 5; ++i)
+  {
+    EXPECT_EQ(0, fromInitializerListTooShort[i]);
+  }
+
+  primal::Vector<int, 3> fromInitializerNoEquaslSign{10, 20, 30};
+  for(int i = 0; i < 3; ++i)
+  {
+    EXPECT_EQ(10 * (i + 1), fromInitializerNoEquaslSign[i]);
   }
 }
 

--- a/src/axom/primal/tests/primal_vector.cpp
+++ b/src/axom/primal/tests/primal_vector.cpp
@@ -63,6 +63,13 @@ TEST(primal_vector, vector_constructors)
   {
     EXPECT_EQ(vFromNA[i], valsArr[i]);
   }
+
+  // Should work because of the implicit constructor from a NumericArray.
+  primal::Vector<int, 3> fromInitializerList = {10, 20, 30};
+  for(int i = 0; i < 3; ++i)
+  {
+    EXPECT_EQ(10 * (i + 1), fromInitializerList[i]);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/sidre/core/DataStore.cpp
+++ b/src/axom/sidre/core/DataStore.cpp
@@ -140,9 +140,9 @@ void DataStore::setConduitSLICMessageHandlers()
 {
   // Provide SLIC message handler functions to Conduit to log
   // internal Conduit info, warning, error messages.
-  conduit::utils::set_error_handler( DataStoreConduitErrorHandler );
-  conduit::utils::set_warning_handler( DataStoreConduitWarningHandler );
-  conduit::utils::set_info_handler( DataStoreConduitInfoHandler );
+  conduit::utils::set_error_handler(DataStoreConduitErrorHandler);
+  conduit::utils::set_warning_handler(DataStoreConduitWarningHandler);
+  conduit::utils::set_info_handler(DataStoreConduitInfoHandler);
 }
 
 /*
@@ -159,7 +159,6 @@ void DataStore::setConduitDefaultMessageHandlers()
   conduit::utils::set_warning_handler(conduit::utils::default_warning_handler);
   conduit::utils::set_error_handler(conduit::utils::default_error_handler);
 }
-
 
 /*
  *************************************************************************

--- a/src/axom/sidre/core/DataStore.hpp
+++ b/src/axom/sidre/core/DataStore.hpp
@@ -419,7 +419,6 @@ public:
    */
   static void setConduitDefaultMessageHandlers();
 
-
 private:
   DISABLE_COPY_AND_ASSIGNMENT(DataStore);
   DISABLE_MOVE_AND_ASSIGNMENT(DataStore);

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -2374,7 +2374,6 @@ TEST(sidre_group, save_load_preserve_contents)
 
   // restore conduit default errors
   DataStore::setConduitDefaultMessageHandlers();
-
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/sidre/tests/sidre_view.cpp
+++ b/src/axom/sidre/tests/sidre_view.cpp
@@ -1643,11 +1643,10 @@ TEST(sidre_view, value_from_uninited_view)
   EXPECT_TRUE(dval_ptr == nullptr);
 
   int dval = view->getData();
-  EXPECT_EQ(dval,0);
+  EXPECT_EQ(dval, 0);
 
   // restore conduit default errors
   DataStore::setConduitDefaultMessageHandlers();
-
 }
 
 #ifdef AXOM_USE_UMPIRE


### PR DESCRIPTION
The primal class templates NumericArray, Point, and Vector now have
constructors from initializer lists. As per a conversation with Kenny
and Rich, these are not marked with AXOM_HOST_DEVICE for now.


# Summary

- This PR is a  feature
- It does the following
  - Creates constructors on Vector, Point, and NumericArray to create these classes from instances of std::initializer_list.
