### PR TITLE
Adds batched option to quest's InOutOctree containment example

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,6 +14,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   class was adapted from MFEM's SidreDataCollection and is enabled when Axom is built with MFEM
   *and* the `AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION` CMake option is enabled.
 - Added `slic::setAbortFunction` to configure a custom callback when SLIC aborts.
+- Added a `batched` option to quest's InOutOctree containment query example application.
+  This uses a kernel to test for containment on an array of points.
+  The query uses OpenMP threading, when available.
 
 ### Changed
 - The Sidre Datastore no longer rewires Conduit's error handlers to SLIC by default. 

--- a/src/axom/primal/tests/primal_numeric_array.cpp
+++ b/src/axom/primal/tests/primal_numeric_array.cpp
@@ -80,10 +80,10 @@ TEST(primal_numeric_array, constructors)
     EXPECT_EQ(0, fromInitializerListTooShort[i]);
   }
 
-  primal::NumericArray<int, 3> fromInitializerNoEquaslSign {10, 20, 30};
+  primal::NumericArray<int, 3> fromInitializerNoEqualsSign {10, 20, 30};
   for(int i = 0; i < 3; ++i)
   {
-    EXPECT_EQ(10 * (i + 1), fromInitializerNoEquaslSign[i]);
+    EXPECT_EQ(10 * (i + 1), fromInitializerNoEqualsSign[i]);
   }
 }
 

--- a/src/axom/primal/tests/primal_numeric_array.cpp
+++ b/src/axom/primal/tests/primal_numeric_array.cpp
@@ -80,7 +80,7 @@ TEST(primal_numeric_array, constructors)
     EXPECT_EQ(0, fromInitializerListTooShort[i]);
   }
 
-  primal::NumericArray<int, 3> fromInitializerNoEquaslSign{10, 20, 30};
+  primal::NumericArray<int, 3> fromInitializerNoEquaslSign {10, 20, 30};
   for(int i = 0; i < 3; ++i)
   {
     EXPECT_EQ(10 * (i + 1), fromInitializerNoEquaslSign[i]);

--- a/src/axom/primal/tests/primal_point.cpp
+++ b/src/axom/primal/tests/primal_point.cpp
@@ -191,7 +191,7 @@ TEST(primal_point, point_initializerList_constructor)
     EXPECT_EQ(10 * (i + 1), listTooLong[i]);
   }
 
-  primal::Point<int, 3> noEqualsSign{10, 20, 30};
+  primal::Point<int, 3> noEqualsSign {10, 20, 30};
   for(int i = 0; i < 3; ++i)
   {
     EXPECT_EQ(10 * (i + 1), noEqualsSign[i]);

--- a/src/axom/primal/tests/primal_vector.cpp
+++ b/src/axom/primal/tests/primal_vector.cpp
@@ -87,10 +87,10 @@ TEST(primal_vector, vector_constructors)
     EXPECT_EQ(0, fromInitializerListTooShort[i]);
   }
 
-  primal::Vector<int, 3> fromInitializerNoEquaslSign {10, 20, 30};
+  primal::Vector<int, 3> fromInitializerNoEqualsSign {10, 20, 30};
   for(int i = 0; i < 3; ++i)
   {
-    EXPECT_EQ(10 * (i + 1), fromInitializerNoEquaslSign[i]);
+    EXPECT_EQ(10 * (i + 1), fromInitializerNoEqualsSign[i]);
   }
 }
 

--- a/src/axom/primal/tests/primal_vector.cpp
+++ b/src/axom/primal/tests/primal_vector.cpp
@@ -87,7 +87,7 @@ TEST(primal_vector, vector_constructors)
     EXPECT_EQ(0, fromInitializerListTooShort[i]);
   }
 
-  primal::Vector<int, 3> fromInitializerNoEquaslSign{10, 20, 30};
+  primal::Vector<int, 3> fromInitializerNoEquaslSign {10, 20, 30};
   for(int i = 0; i < 3; ++i)
   {
     EXPECT_EQ(10 * (i + 1), fromInitializerNoEquaslSign[i]);

--- a/src/axom/quest/examples/containment_driver.cpp
+++ b/src/axom/quest/examples/containment_driver.cpp
@@ -73,7 +73,8 @@ GeometricBoundingBox compute_bounds(mint::Mesh* mesh)
  */
 void testContainmentOnRegularGrid(const Octree3D& inOutOctree,
                                   const GeometricBoundingBox& queryBounds,
-                                  const GridPt& gridRes)
+                                  const GridPt& gridRes,
+                                  bool isBatched)
 {
   const double* low = queryBounds.getMin().data();
   const double* high = queryBounds.getMax().data();
@@ -85,15 +86,59 @@ void testContainmentOnRegularGrid(const Octree3D& inOutOctree,
 
   SLIC_ASSERT(containment != nullptr);
 
-  axom::utilities::Timer timer(true);
-  for(int inode = 0; inode < nnodes; ++inode)
+  axom::utilities::Timer timer;
+  if(!isBatched)
   {
-    primal::Point<double, 3> pt;
-    umesh->getNode(inode, pt.data());
+    timer.start();
+    for(int inode = 0; inode < nnodes; ++inode)
+    {
+      primal::Point<double, 3> pt;
+      umesh->getNode(inode, pt.data());
 
-    containment[inode] = inOutOctree.within(pt) ? 1 : 0;
+      containment[inode] = inOutOctree.within(pt) ? 1 : 0;
+    }
+    timer.stop();
   }
-  timer.stop();
+  else
+  {
+    timer.start();
+
+    // Allocate space for the coordinate arrays
+    double* x = axom::allocate<double>(nnodes);
+    double* y = axom::allocate<double>(nnodes);
+    double* z = axom::allocate<double>(nnodes);
+
+// Determine an appropriate execution policy
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP) && \
+  defined(RAJA_ENABLE_OPENMP)
+    using ExecPolicy = axom::OMP_EXEC;
+#else
+    using ExecPolicy = axom::SEQ_EXEC;
+#endif
+
+    // Fill the coordinate arrays
+    mint::for_all_nodes<ExecPolicy, mint::xargs::xyz>(
+      umesh,
+      AXOM_LAMBDA(axom::IndexType idx, double xx, double yy, double zz) {
+        x[idx] = xx;
+        y[idx] = yy;
+        z[idx] = zz;
+      });
+
+    // Loop through the points using ExecPolicy
+    axom::for_all<ExecPolicy>(0, nnodes, [&](axom::IndexType idx) {
+      const bool inside = inOutOctree.within(SpacePt {x[idx], y[idx], z[idx]});
+      containment[idx] = inside ? 1 : 0;
+    });
+
+    // Deallocate the coordinate arrays
+    axom::deallocate(x);
+    axom::deallocate(y);
+    axom::deallocate(z);
+
+    timer.stop();
+  }
+
   SLIC_INFO(
     fmt::format("\tQuerying {}^3 containment field "
                 "took {} seconds (@ {} queries per second)",
@@ -314,20 +359,17 @@ struct Input
 {
 public:
   std::string stlFile;
-  int maxQueryLevel;
+  int maxQueryLevel {7};
   std::vector<double> queryBoxMins;
   std::vector<double> queryBoxMaxs;
 
 private:
-  bool m_verboseOutput;
-  bool m_hasUserQueryBox;
+  bool m_verboseOutput {false};
+  bool m_hasUserQueryBox {false};
+  bool m_use_batched_query {false};
 
 public:
   Input()
-    : stlFile("")
-    , maxQueryLevel(7)
-    , m_verboseOutput(false)
-    , m_hasUserQueryBox(false)
   {
 // set default stl file, when the 'data' submodule is available
 #ifdef AXOM_DATA_DIR
@@ -345,6 +387,8 @@ public:
   }
 
   bool isVerbose() const { return m_verboseOutput; }
+
+  bool useBatchedQuery() const { return m_use_batched_query; }
 
   bool hasUserQueryBox() const { return m_hasUserQueryBox; }
 
@@ -374,6 +418,13 @@ public:
         ->expected(3);
     minbb->needs(maxbb);
     maxbb->needs(minbb);
+
+    app
+      .add_flag("--batched",
+                m_use_batched_query,
+                "uses a single batched query on all points instead of many "
+                "individual queries")
+      ->capture_default_str();
 
     app.get_formatter()->column_width(35);
 
@@ -462,7 +513,8 @@ int main(int argc, char** argv)
     int res = 1 << i;
     testContainmentOnRegularGrid(octree,
                                  queryBB,
-                                 GridPt::make_point(res, res, res));
+                                 GridPt::make_point(res, res, res),
+                                 params.useBatchedQuery());
   }
 
   if(!params.isVerbose())


### PR DESCRIPTION
# Summary

- This PR is a feature
- It adds a ``--batched`` flag to the quest::InOutOctree point containment example
- When this is set and the code is built using RAJA and OpenMP, it will run the containment query
over an array of points using the RAJA OMP execution policy.
