### PR TITLE
Const correctness in Inlet

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -17,6 +17,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Added a `batched` option to quest's InOutOctree containment query example application.
   This uses a kernel to test for containment on an array of points.
   The query uses OpenMP threading, when available.
+- Inlet: Added support for user-defined conversions from Inlet tables to user-defined
+  types, and support for arrays of user-defined types
 
 ### Changed
 - The Sidre Datastore no longer rewires Conduit's error handlers to SLIC by default. 
@@ -25,6 +27,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Inlet: Fixed `SchemaCreator` to an abstract class and added missing functions
 - Inlet: Added ability to access the `Reader` class from `Inlet` and Sol Lua state
   from the `LuaReader` class
+- Inlet: Switched accessor interface to match that of the STL with operator[] and
+  T get<T>()
 
 
 ## [Version 0.4.0] - Release date 2020-09-22

--- a/src/axom/inlet/Field.cpp
+++ b/src/axom/inlet/Field.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<VerifiableScalar> Field::required(bool isRequired)
 
   if(m_sidreGroup->hasView("required"))
   {
-    std::string msg = fmt::format(
+    const std::string msg = fmt::format(
       "[Inlet] Field has already defined "
       "required value: {0}",
       m_sidreGroup->getPathName());
@@ -59,7 +59,7 @@ bool Field::isRequired() const
   int8 intValue = valueView->getScalar();
   if(intValue < 0 || intValue > 1)
   {
-    std::string msg = fmt::format(
+    const std::string msg = fmt::format(
       "[Inlet] Invalid integer value stored in "
       "boolean value named {0}",
       m_sidreGroup->getPathName());
@@ -76,7 +76,7 @@ void Field::setDefaultValue(T value)
 {
   if(m_sidreGroup->hasView("defaultValue"))
   {
-    std::string msg = fmt::format(
+    const std::string msg = fmt::format(
       "[Inlet] Field has already defined "
       "default value: {0}",
       m_sidreGroup->getPathName());
@@ -101,7 +101,7 @@ void Field::setDefaultValue<std::string>(std::string value)
 {
   if(m_sidreGroup->hasView("defaultValue"))
   {
-    std::string msg = fmt::format(
+    const std::string msg = fmt::format(
       "[Inlet] Field has already defined "
       "default value: {0}",
       m_sidreGroup->getPathName());
@@ -188,7 +188,7 @@ void Field::setRange(T startVal, T endVal)
 {
   if(m_sidreGroup->hasView("range"))
   {
-    std::string msg =
+    const std::string msg =
       fmt::format("[Inlet] Inlet Field has already defined range: {0}",
                   m_sidreGroup->getPathName());
     SLIC_WARNING(msg);
@@ -197,7 +197,7 @@ void Field::setRange(T startVal, T endVal)
   else if(m_sidreGroup->hasView("validValues") ||
           m_sidreGroup->hasView("validStringValues"))
   {
-    std::string msg = fmt::format(
+    const std::string msg = fmt::format(
       "[Inlet] Cannot set range for Inlet Field "
       "after setting valid values: {0}",
       m_sidreGroup->getPathName());
@@ -249,12 +249,12 @@ std::shared_ptr<VerifiableScalar> Field::range(double startVal, double endVal)
 template <>
 bool Field::get<bool>() const
 {
-  auto valueView = checkExistenceAndType(axom::sidre::INT8_ID);
+  const auto valueView = checkExistenceAndType(axom::sidre::INT8_ID);
   // There is no boolean type in conduit/sidre so we use int8
-  int8 intValue = valueView->getScalar();
+  const int8 intValue = valueView->getScalar();
   if(intValue < 0 || intValue > 1)
   {
-    std::string msg = fmt::format(
+    const std::string msg = fmt::format(
       "[Inlet] Invalid integer value stored in "
       " boolean value named {0}",
       name());
@@ -267,30 +267,30 @@ bool Field::get<bool>() const
 template <>
 double Field::get<double>() const
 {
-  auto valueView = checkExistenceAndType(axom::sidre::DOUBLE_ID);
+  const auto valueView = checkExistenceAndType(axom::sidre::DOUBLE_ID);
   return valueView->getScalar();
 }
 
 template <>
 int Field::get<int>() const
 {
-  auto valueView = checkExistenceAndType(axom::sidre::INT_ID);
+  const auto valueView = checkExistenceAndType(axom::sidre::INT_ID);
   return valueView->getScalar();
 }
 
 template <>
 std::string Field::get<std::string>() const
 {
-  auto valueView = checkExistenceAndType(axom::sidre::CHAR8_STR_ID);
+  const auto valueView = checkExistenceAndType(axom::sidre::CHAR8_STR_ID);
 
   const char* valueStr = valueView->getString();
   return (valueStr == nullptr) ? "" : valueStr;
 }
 
-axom::sidre::View* Field::checkExistenceAndType(
+const axom::sidre::View* Field::checkExistenceAndType(
   const axom::sidre::DataTypeId expected) const
 {
-  axom::sidre::View* valueView = m_sidreGroup->getView("value");
+  const axom::sidre::View* valueView = m_sidreGroup->getView("value");
 
   if(valueView == nullptr)
   {
@@ -299,7 +299,7 @@ axom::sidre::View* Field::checkExistenceAndType(
 
   if(valueView->getTypeID() != expected)
   {
-    std::string msg = fmt::format(
+    const std::string msg = fmt::format(
       "[Inlet] Field with name '{0}' was expected to be of type {1}"
       " but was actually of type {2}",
       name(),
@@ -521,9 +521,9 @@ bool Field::verify() const
   return true;
 }
 
-bool Field::verifyValue(axom::sidre::View& view) const
+bool Field::verifyValue(const axom::sidre::View& view) const
 {
-  auto type = view.getTypeID();
+  const auto type = view.getTypeID();
   if(m_sidreGroup->hasView("validValues"))
   {
     if(type == axom::sidre::INT_ID)
@@ -554,29 +554,29 @@ bool Field::verifyValue(axom::sidre::View& view) const
 }
 
 template <typename T>
-bool Field::checkRange(axom::sidre::View& view) const
+bool Field::checkRange(const axom::sidre::View& view) const
 {
-  T val = view.getScalar();
-  T* range = m_sidreGroup->getView("range")->getArray();
+  const T val = view.getScalar();
+  const T* range = m_sidreGroup->getView("range")->getArray();
   return range[0] <= val && val <= range[1];
 }
 
 template <typename T>
-bool Field::searchValidValues(axom::sidre::View& view) const
+bool Field::searchValidValues(const axom::sidre::View& view) const
 {
-  T target = view.getScalar();
-  auto valid_vals = m_sidreGroup->getView("validValues");
-  T* valuesArray = valid_vals->getArray();
-  size_t size = valid_vals->getBuffer()->getNumElements();
-  T* result = std::find(valuesArray, valuesArray + size, target);
+  const T target = view.getScalar();
+  const auto valid_vals = m_sidreGroup->getView("validValues");
+  const T* valuesArray = valid_vals->getArray();
+  const size_t size = valid_vals->getBuffer()->getNumElements();
+  const T* result = std::find(valuesArray, valuesArray + size, target);
   return result != valuesArray + size;
 }
 
 template <>
-bool Field::searchValidValues<std::string>(axom::sidre::View& view) const
+bool Field::searchValidValues<std::string>(const axom::sidre::View& view) const
 {
-  auto string_group = m_sidreGroup->getGroup("validStringValues");
-  std::string value = view.getString();
+  const auto string_group = m_sidreGroup->getGroup("validStringValues");
+  const std::string value = view.getString();
   auto idx = string_group->getFirstValidViewIndex();
   while(axom::sidre::indexIsValid(idx))
   {

--- a/src/axom/inlet/Field.hpp
+++ b/src/axom/inlet/Field.hpp
@@ -109,7 +109,7 @@ public:
    * \return Shared pointer to this instance of this class
    *****************************************************************************
    */
-  std::shared_ptr<VerifiableScalar> required(bool isRequired);
+  std::shared_ptr<VerifiableScalar> required(bool isRequired = true);
 
   /*!
    *****************************************************************************
@@ -121,7 +121,7 @@ public:
    * \return Boolean value of whether this Field is required
    *****************************************************************************
    */
-  bool isRequired();
+  bool isRequired() const;
 
   /*!
    *****************************************************************************
@@ -297,21 +297,21 @@ public:
    *****************************************************************************
   */
   std::shared_ptr<VerifiableScalar> registerVerifier(
-    std::function<bool(Field&)> lambda);
+    std::function<bool(const Field&)> lambda);
 
   /*!
    *****************************************************************************
    * \brief Called by Inlet::verify to verify the contents of this Field.
    *****************************************************************************
   */
-  bool verify();
+  bool verify() const;
 
   /*!
    *****************************************************************************
    * \return The full name for this Field.
    *****************************************************************************
   */
-  std::string name();
+  std::string name() const;
 
   /*!
    *****************************************************************************
@@ -322,7 +322,7 @@ public:
    *****************************************************************************
    */
   template <typename T>
-  T get();
+  T get() const;
 
   /*!
    *****************************************************************************
@@ -386,7 +386,7 @@ private:
    * \return Whether the value satisfied all constraints
    *****************************************************************************
   */
-  bool verifyValue(axom::sidre::View& view);
+  bool verifyValue(axom::sidre::View& view) const;
 
   /*!
    *****************************************************************************
@@ -399,7 +399,7 @@ private:
    *****************************************************************************
    */
   template <typename T>
-  bool checkRange(axom::sidre::View& view);
+  bool checkRange(axom::sidre::View& view) const;
 
   /*!
    *****************************************************************************
@@ -412,7 +412,7 @@ private:
    *****************************************************************************
    */
   template <typename T>
-  bool searchValidValues(axom::sidre::View& view);
+  bool searchValidValues(axom::sidre::View& view) const;
 
   /*!
    *****************************************************************************
@@ -425,31 +425,32 @@ private:
    * emit a SLIC_ERROR accordingly
    *****************************************************************************
   */
-  axom::sidre::View* checkExistenceAndType(const axom::sidre::DataTypeId expected);
+  axom::sidre::View* checkExistenceAndType(
+    const axom::sidre::DataTypeId expected) const;
 
   // This Field's sidre group
   axom::sidre::Group* m_sidreGroup = nullptr;
   axom::sidre::Group* m_sidreRootGroup = nullptr;
   axom::sidre::DataTypeId m_type = axom::sidre::DataTypeId::NO_TYPE_ID;
   bool m_docEnabled;
-  std::function<bool(Field&)> m_verifier;
+  std::function<bool(const Field&)> m_verifier;
 };
 
 // Prototypes for template specializations
 template <>
-bool Field::get<bool>();
+bool Field::get<bool>() const;
 
 template <>
-int Field::get<int>();
+int Field::get<int>() const;
 
 template <>
-double Field::get<double>();
+double Field::get<double>() const;
 
 template <>
-std::string Field::get<std::string>();
+std::string Field::get<std::string>() const;
 
 template <>
-inline bool Field::searchValidValues<std::string>(axom::sidre::View& view);
+inline bool Field::searchValidValues<std::string>(axom::sidre::View& view) const;
 
 /*!
    *****************************************************************************
@@ -471,7 +472,7 @@ public:
    * \brief Called by Inlet::verify to verify the contents of this Field.
    *****************************************************************************
   */
-  bool verify();
+  bool verify() const;
 
   /*!
    *****************************************************************************
@@ -497,7 +498,7 @@ public:
    * \return Boolean value of whether this Field is required
    *****************************************************************************
    */
-  bool isRequired();
+  bool isRequired() const;
 
   /*!
    *****************************************************************************
@@ -672,7 +673,7 @@ public:
    *****************************************************************************
   */
   std::shared_ptr<VerifiableScalar> registerVerifier(
-    std::function<bool(Field&)> lambda);
+    std::function<bool(const Field&)> lambda);
 
 private:
   std::vector<std::shared_ptr<VerifiableScalar>> m_fields;

--- a/src/axom/inlet/Field.hpp
+++ b/src/axom/inlet/Field.hpp
@@ -386,7 +386,7 @@ private:
    * \return Whether the value satisfied all constraints
    *****************************************************************************
   */
-  bool verifyValue(axom::sidre::View& view) const;
+  bool verifyValue(const axom::sidre::View& view) const;
 
   /*!
    *****************************************************************************
@@ -399,7 +399,7 @@ private:
    *****************************************************************************
    */
   template <typename T>
-  bool checkRange(axom::sidre::View& view) const;
+  bool checkRange(const axom::sidre::View& view) const;
 
   /*!
    *****************************************************************************
@@ -412,7 +412,7 @@ private:
    *****************************************************************************
    */
   template <typename T>
-  bool searchValidValues(axom::sidre::View& view) const;
+  bool searchValidValues(const axom::sidre::View& view) const;
 
   /*!
    *****************************************************************************
@@ -425,7 +425,7 @@ private:
    * emit a SLIC_ERROR accordingly
    *****************************************************************************
   */
-  axom::sidre::View* checkExistenceAndType(
+  const axom::sidre::View* checkExistenceAndType(
     const axom::sidre::DataTypeId expected) const;
 
   // This Field's sidre group
@@ -450,7 +450,7 @@ template <>
 std::string Field::get<std::string>() const;
 
 template <>
-inline bool Field::searchValidValues<std::string>(axom::sidre::View& view) const;
+inline bool Field::searchValidValues<std::string>(const axom::sidre::View& view) const;
 
 /*!
    *****************************************************************************

--- a/src/axom/inlet/Proxy.cpp
+++ b/src/axom/inlet/Proxy.cpp
@@ -29,7 +29,7 @@ InletType Proxy::type() const
   return m_field->type();
 }
 
-bool Proxy::contains(const std::string& name)
+bool Proxy::contains(const std::string& name) const
 {
   if(m_table == nullptr)
   {
@@ -38,7 +38,7 @@ bool Proxy::contains(const std::string& name)
   return m_table->contains(name);
 }
 
-Proxy Proxy::operator[](const std::string& name)
+Proxy Proxy::operator[](const std::string& name) const
 {
   if(m_table == nullptr)
   {

--- a/src/axom/inlet/Proxy.hpp
+++ b/src/axom/inlet/Proxy.hpp
@@ -71,7 +71,7 @@ public:
             typename SFINAE =
               typename std::enable_if<detail::is_inlet_primitive<T>::value ||
                                       detail::is_inlet_primitive_array<T>::value>::type>
-  operator T()
+  operator T() const
   {
     return get<T>();
   }
@@ -85,7 +85,7 @@ public:
    * Field or Table with the given name.
    *****************************************************************************
    */
-  bool contains(const std::string& name);
+  bool contains(const std::string& name) const;
 
   /*!
    *****************************************************************************
@@ -109,7 +109,7 @@ public:
    * \return A view onto the subobject
    *******************************************************************************
    */
-  Proxy operator[](const std::string& name);
+  Proxy operator[](const std::string& name) const;
 
   /*!
    *******************************************************************************
@@ -121,7 +121,7 @@ public:
    *******************************************************************************
    */
   template <typename T>
-  typename std::enable_if<!detail::is_inlet_primitive<T>::value, T>::type get()
+  typename std::enable_if<!detail::is_inlet_primitive<T>::value, T>::type get() const
   {
     SLIC_ASSERT_MSG(m_table != nullptr,
                     "[Inlet] Tried to read a user-defined type from a Proxy "
@@ -139,7 +139,7 @@ public:
    *******************************************************************************
    */
   template <typename T>
-  typename std::enable_if<detail::is_inlet_primitive<T>::value, T>::type get()
+  typename std::enable_if<detail::is_inlet_primitive<T>::value, T>::type get() const
   {
     SLIC_ASSERT_MSG(
       m_field != nullptr,

--- a/src/axom/inlet/Table.hpp
+++ b/src/axom/inlet/Table.hpp
@@ -324,7 +324,7 @@ public:
   getArray(std::unordered_map<int, T>& map) const
   {
     map.clear();
-    if(!axom::utilities::string::endsWith(m_name, INTERNAL_ARRAY_GROUP))
+    if(!axom::utilities::string::endsWith(m_name, ARRAY_GROUP_NAME))
     {
       return false;
     }
@@ -583,7 +583,7 @@ public:
     T result;
     // This needs to work transparently for both references to the underlying
     // internal table and references using the same path as the data file
-    if(axom::utilities::string::endsWith(m_name, INTERNAL_ARRAY_GROUP))
+    if(axom::utilities::string::endsWith(m_name, ARRAY_GROUP_NAME))
     {
       if(!getArray(result))
       {
@@ -591,7 +591,7 @@ public:
           "[Inlet] Table does not contain a valid array of requested type");
       }
     }
-    else if(!getTable(INTERNAL_ARRAY_GROUP)->getArray(result))
+    else if(!getTable(ARRAY_GROUP_NAME)->getArray(result))
     {
       SLIC_ERROR(
         "[Inlet] Table does not contain a valid array of requested type");
@@ -880,8 +880,8 @@ private:
   std::unordered_map<std::string, std::shared_ptr<Field>> m_fieldChildren;
   std::function<bool(const Table&)> m_verifier;
 
-  static const std::string INTERNAL_ARRAY_GROUP;
-  static const std::string INTERNAL_ARRAY_INDEX_VIEW;
+  static const std::string ARRAY_GROUP_NAME;
+  static const std::string ARRAY_INDICIES_VIEW_NAME;
 };
 
 // To-be-defined template specializations

--- a/src/axom/inlet/Table.hpp
+++ b/src/axom/inlet/Table.hpp
@@ -324,7 +324,7 @@ public:
   getArray(std::unordered_map<int, T>& map) const
   {
     map.clear();
-    if(!axom::utilities::string::endsWith(m_name, "_inlet_array"))
+    if(!axom::utilities::string::endsWith(m_name, INTERNAL_ARRAY_GROUP))
     {
       return false;
     }
@@ -583,7 +583,7 @@ public:
     T result;
     // This needs to work transparently for both references to the underlying
     // internal table and references using the same path as the data file
-    if(axom::utilities::string::endsWith(m_name, "_inlet_array"))
+    if(axom::utilities::string::endsWith(m_name, INTERNAL_ARRAY_GROUP))
     {
       if(!getArray(result))
       {
@@ -591,7 +591,7 @@ public:
           "[Inlet] Table does not contain a valid array of requested type");
       }
     }
-    else if(!getTable("_inlet_array")->getArray(result))
+    else if(!getTable(INTERNAL_ARRAY_GROUP)->getArray(result))
     {
       SLIC_ERROR(
         "[Inlet] Table does not contain a valid array of requested type");
@@ -879,6 +879,9 @@ private:
   std::unordered_map<std::string, std::shared_ptr<Table>> m_tableChildren;
   std::unordered_map<std::string, std::shared_ptr<Field>> m_fieldChildren;
   std::function<bool(const Table&)> m_verifier;
+
+  static const std::string INTERNAL_ARRAY_GROUP;
+  static const std::string INTERNAL_ARRAY_INDEX_VIEW;
 };
 
 // To-be-defined template specializations

--- a/src/axom/inlet/Table.hpp
+++ b/src/axom/inlet/Table.hpp
@@ -124,8 +124,9 @@ struct has_FromInlet_specialization : std::false_type
 template <typename T>
 struct has_FromInlet_specialization<
   T,
-  typename std::enable_if<
-    std::is_same<T, decltype(std::declval<FromInlet<T>&>()(std::declval<Table&>()))>::value>::type>
+  typename std::enable_if<std::is_same<T,
+                                       decltype(std::declval<FromInlet<T>&>()(
+                                         std::declval<const Table&>()))>::value>::type>
   : std::true_type
 { };
 
@@ -320,7 +321,7 @@ public:
    */
   template <typename T>
   typename std::enable_if<detail::is_inlet_primitive<T>::value, bool>::type
-  getArray(std::unordered_map<int, T>& map)
+  getArray(std::unordered_map<int, T>& map) const
   {
     map.clear();
     if(!axom::utilities::string::endsWith(m_name, "_inlet_array"))
@@ -348,7 +349,7 @@ public:
    */
   template <typename T>
   typename std::enable_if<!detail::is_inlet_primitive<T>::value, bool>::type
-  getArray(std::unordered_map<int, T>& map)
+  getArray(std::unordered_map<int, T>& map) const
   {
     if(m_sidreGroup->hasView("_inlet_array_indices"))
     {
@@ -517,7 +518,7 @@ public:
    */
   template <typename T>
   typename std::enable_if<detail::is_inlet_primitive<T>::value, T>::type get(
-    const std::string& name)
+    const std::string& name) const
   {
     if(!hasField(name))
     {
@@ -546,7 +547,7 @@ public:
   typename std::enable_if<!detail::is_inlet_primitive<T>::value &&
                             !detail::is_inlet_array<T>::value,
                           T>::type
-  get(const std::string& name = "")
+  get(const std::string& name = "") const
   {
     static_assert(detail::has_FromInlet_specialization<T>::value,
                   "To read a user-defined type, specialize FromInlet<T>");
@@ -577,7 +578,7 @@ public:
    *******************************************************************************
    */
   template <typename T>
-  typename std::enable_if<detail::is_inlet_array<T>::value, T>::type get()
+  typename std::enable_if<detail::is_inlet_array<T>::value, T>::type get() const
   {
     T result;
     // This needs to work transparently for both references to the underlying
@@ -610,7 +611,7 @@ public:
    * \return The retrieved array
    *******************************************************************************
    */
-  Proxy operator[](const std::string& name);
+  Proxy operator[](const std::string& name) const;
 
   /*!
    *****************************************************************************
@@ -624,7 +625,7 @@ public:
    * \return Shared pointer to this instance of Table
    *****************************************************************************
    */
-  std::shared_ptr<Verifiable> required(bool isRequired);
+  std::shared_ptr<Verifiable> required(bool isRequired = true);
 
   /*!
    *****************************************************************************
@@ -636,7 +637,7 @@ public:
    * \return Boolean value of whether this Table is required
    *****************************************************************************
    */
-  bool isRequired();
+  bool isRequired() const;
 
   /*!
    *****************************************************************************
@@ -646,7 +647,8 @@ public:
    * \param [in] The function object that will be called by Table::verify().
    *****************************************************************************
   */
-  std::shared_ptr<Verifiable> registerVerifier(std::function<bool(Table&)> lambda);
+  std::shared_ptr<Verifiable> registerVerifier(
+    std::function<bool(const Table&)> lambda);
 
   /*!
    *****************************************************************************
@@ -654,7 +656,7 @@ public:
    *  Table and all child Tables/Fields of this Table.
    *****************************************************************************
   */
-  bool verify();
+  bool verify() const;
 
   /*!
    *****************************************************************************
@@ -663,7 +665,7 @@ public:
    * \return Boolean value indicating whether this Table's subtree contains this Table.
    *****************************************************************************
    */
-  bool hasTable(const std::string& tableName);
+  bool hasTable(const std::string& tableName) const;
 
   /*!
    *****************************************************************************
@@ -673,7 +675,7 @@ public:
    * \return Boolean value indicating whether this Table's subtree contains this Field.
    *****************************************************************************
    */
-  bool hasField(const std::string& fieldName);
+  bool hasField(const std::string& fieldName) const;
 
   /*!
    *****************************************************************************
@@ -684,7 +686,7 @@ public:
    * Field or Table with the given name.
    *****************************************************************************
    */
-  bool contains(const std::string& name)
+  bool contains(const std::string& name) const
   {
     return hasTable(name) || hasField(name);
   }
@@ -695,7 +697,7 @@ public:
    * this Table.
    *****************************************************************************
    */
-  std::unordered_map<std::string, std::shared_ptr<Field>> getChildFields();
+  std::unordered_map<std::string, std::shared_ptr<Field>> getChildFields() const;
 
   /*!
    *****************************************************************************
@@ -703,14 +705,14 @@ public:
    * this Table.
    *****************************************************************************
    */
-  std::unordered_map<std::string, std::shared_ptr<Table>> getChildTables();
+  std::unordered_map<std::string, std::shared_ptr<Table>> getChildTables() const;
 
   /*!
    *****************************************************************************
    * \return The full name of this Table.
    *****************************************************************************
    */
-  std::string name();
+  std::string name() const;
 
   /*!
    *****************************************************************************
@@ -722,7 +724,7 @@ public:
    * a nullptr is returned.
    *****************************************************************************
    */
-  std::shared_ptr<Table> getTable(const std::string& tableName);
+  std::shared_ptr<Table> getTable(const std::string& tableName) const;
 
   /*!
    *****************************************************************************
@@ -734,7 +736,7 @@ public:
    * a nullptr is returned.
    *****************************************************************************
    */
-  std::shared_ptr<Field> getField(const std::string& fieldName);
+  std::shared_ptr<Field> getField(const std::string& fieldName) const;
 
 private:
   /*!
@@ -818,7 +820,7 @@ private:
    * a nullptr is returned.
    *****************************************************************************
    */
-  std::shared_ptr<Table> getTableInternal(const std::string& tableName);
+  std::shared_ptr<Table> getTableInternal(const std::string& tableName) const;
 
   /*!
    *****************************************************************************
@@ -830,7 +832,7 @@ private:
    * a nullptr is returned.
    *****************************************************************************
    */
-  std::shared_ptr<Field> getFieldInternal(const std::string& fieldName);
+  std::shared_ptr<Field> getFieldInternal(const std::string& fieldName) const;
 
   /*!
    *****************************************************************************
@@ -840,7 +842,7 @@ private:
    * \return Boolean value of whether this Table has the child Table.
    *****************************************************************************
    */
-  bool hasChildTable(const std::string& tableName);
+  bool hasChildTable(const std::string& tableName) const;
 
   /*!
    *****************************************************************************
@@ -850,9 +852,9 @@ private:
    * \return Boolean value of whether this Table has the child Field.
    *****************************************************************************
    */
-  bool hasChildField(const std::string& fieldName);
+  bool hasChildField(const std::string& fieldName) const;
 
-  axom::sidre::View* baseGet(const std::string& name);
+  axom::sidre::View* baseGet(const std::string& name) const;
 
   /*!
    *****************************************************************************
@@ -865,7 +867,7 @@ private:
    *****************************************************************************
    */
   std::vector<std::pair<std::string, std::string>> arrayIndicesWithPaths(
-    const std::string& name);
+    const std::string& name) const;
 
   std::string m_name;
   std::shared_ptr<Reader> m_reader;
@@ -876,7 +878,7 @@ private:
   bool m_docEnabled;
   std::unordered_map<std::string, std::shared_ptr<Table>> m_tableChildren;
   std::unordered_map<std::string, std::shared_ptr<Field>> m_fieldChildren;
-  std::function<bool(Table&)> m_verifier;
+  std::function<bool(const Table&)> m_verifier;
 };
 
 // To-be-defined template specializations
@@ -943,7 +945,7 @@ public:
    *  Table and all child Tables/Fields of this Table.
    *****************************************************************************
    */
-  bool verify();
+  bool verify() const;
 
   /*!
    *****************************************************************************
@@ -957,7 +959,7 @@ public:
    * \return Shared pointer to this instance of Table
    *****************************************************************************
    */
-  std::shared_ptr<Verifiable> required(bool isRequired);
+  std::shared_ptr<Verifiable> required(bool isRequired = true);
 
   /*!
    *****************************************************************************
@@ -969,7 +971,7 @@ public:
    * \return Boolean value of whether this Table is required
    *****************************************************************************
    */
-  bool isRequired();
+  bool isRequired() const;
 
   /*!
    *****************************************************************************
@@ -979,7 +981,8 @@ public:
    * \param [in] The function object that will be called by Table::verify().
    *****************************************************************************
   */
-  std::shared_ptr<Verifiable> registerVerifier(std::function<bool(Table&)> lambda);
+  std::shared_ptr<Verifiable> registerVerifier(
+    std::function<bool(const Table&)> lambda);
 
 private:
   std::vector<std::shared_ptr<Verifiable>> m_tables;

--- a/src/axom/inlet/Verifiable.hpp
+++ b/src/axom/inlet/Verifiable.hpp
@@ -51,7 +51,7 @@ public:
    * \return Shared pointer to calling object, for chaining
    *****************************************************************************
    */
-  virtual std::shared_ptr<Verifiable> required(bool isRequired) = 0;
+  virtual std::shared_ptr<Verifiable> required(bool isRequired = true) = 0;
 
   /*!
    *****************************************************************************
@@ -63,7 +63,7 @@ public:
    * \return Boolean value of whether this object is required
    *****************************************************************************
    */
-  virtual bool isRequired() = 0;
+  virtual bool isRequired() const = 0;
 
   /*!
    *****************************************************************************
@@ -74,14 +74,14 @@ public:
    *****************************************************************************
   */
   virtual std::shared_ptr<Verifiable> registerVerifier(
-    std::function<bool(axom::inlet::Table&)> lambda) = 0;
+    std::function<bool(const axom::inlet::Table&)> lambda) = 0;
 
   /*!
    *****************************************************************************
    * \brief Verifies the object to make sure it satisfies the imposed requirements
    *****************************************************************************
   */
-  virtual bool verify() = 0;
+  virtual bool verify() const = 0;
 };
 
 }  // namespace inlet

--- a/src/axom/inlet/VerifiableScalar.hpp
+++ b/src/axom/inlet/VerifiableScalar.hpp
@@ -55,7 +55,7 @@ public:
    * \return Shared pointer to calling object, for chaining
    *****************************************************************************
    */
-  virtual std::shared_ptr<VerifiableScalar> required(bool isRequired) = 0;
+  virtual std::shared_ptr<VerifiableScalar> required(bool isRequired = true) = 0;
 
   /*!
    *****************************************************************************
@@ -67,7 +67,7 @@ public:
    * \return Boolean value of whether this object is required
    *****************************************************************************
    */
-  virtual bool isRequired() = 0;
+  virtual bool isRequired() const = 0;
 
   /*!
    *****************************************************************************
@@ -78,7 +78,7 @@ public:
    *****************************************************************************
   */
   virtual std::shared_ptr<VerifiableScalar> registerVerifier(
-    std::function<bool(axom::inlet::Field&)> lambda) = 0;
+    std::function<bool(const axom::inlet::Field&)> lambda) = 0;
 
   /*!
    *****************************************************************************
@@ -254,7 +254,7 @@ public:
    * \brief Verifies the object to make sure it satisfies the imposed requirements
    *****************************************************************************
   */
-  virtual bool verify() = 0;
+  virtual bool verify() const = 0;
 };
 
 }  // namespace inlet

--- a/src/axom/inlet/examples/user_defined_type.cpp
+++ b/src/axom/inlet/examples/user_defined_type.cpp
@@ -47,7 +47,7 @@ struct Mesh
 template <>
 struct FromInlet<Mesh>
 {
-  Mesh operator()(inlet::Table& base)
+  Mesh operator()(const inlet::Table& base)
   {
     return {base["filename"], base["serial"], base["parallel"]};
   }
@@ -88,7 +88,7 @@ struct LinearSolver
 template <>
 struct FromInlet<LinearSolver>
 {
-  LinearSolver operator()(inlet::Table& base)
+  LinearSolver operator()(const inlet::Table& base)
   {
     LinearSolver lin_solve;
     lin_solve.rel_tol = base["rel_tol"];
@@ -127,7 +127,7 @@ struct BoundaryCondition
 template <>
 struct FromInlet<BoundaryCondition>
 {
-  BoundaryCondition operator()(inlet::Table& base)
+  BoundaryCondition operator()(const inlet::Table& base)
   {
     BoundaryCondition bc;
     bc.attrs = base["attrs"];
@@ -186,7 +186,7 @@ struct FromInlet<ThermalSolver>
 {
   // This is also implicitly recursive - will call the FromInlet
   // functions defined for the subobjects
-  ThermalSolver operator()(inlet::Table& base)
+  ThermalSolver operator()(const inlet::Table& base)
   {
     return {base["mesh"].get<Mesh>(),
             base["solver"].get<LinearSolver>(),

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -46,7 +46,7 @@ struct Foo
 template <>
 struct FromInlet<Foo>
 {
-  Foo operator()(axom::inlet::Table& base)
+  Foo operator()(const axom::inlet::Table& base)
   {
     Foo f {base["bar"], base["baz"]};
     return f;
@@ -154,7 +154,7 @@ struct FooWithArray
 template <>
 struct FromInlet<FooWithArray>
 {
-  FooWithArray operator()(axom::inlet::Table& base)
+  FooWithArray operator()(const axom::inlet::Table& base)
   {
     FooWithArray f = {base["arr"]};
     return f;
@@ -192,7 +192,7 @@ struct MoveOnlyFoo
 template <>
 struct FromInlet<MoveOnlyFoo>
 {
-  MoveOnlyFoo operator()(axom::inlet::Table& base)
+  MoveOnlyFoo operator()(const axom::inlet::Table& base)
   {
     MoveOnlyFoo f(base["bar"], base["baz"]);
     return f;


### PR DESCRIPTION
# Summary

- This PR is a refactoring
- It does the following:
  - Adds const to member functions and local variables
  - Adds `true` as the default argument to `Verifiable::required` and `VerifiableScalar::required` (and the implementations of those interfaces)

In the interest of keeping PRs small, other fixes (e.g. removing `shared_ptr` when possible) will be part of future PRs.