### PR TITLE
Remove shared_ptr from Inlet

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -29,6 +29,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   from the `LuaReader` class
 - Inlet: Switched accessor interface to match that of the STL with operator[] and
   T get<T>()
+- Inlet: `std::shared_ptr<T>` has been replaced with `T&` in non-owning contexts
+  and `std::unique_ptr<T>` in owning contexts 
 
 
 ## [Version 0.4.0] - Release date 2020-09-22

--- a/src/axom/inlet/Field.cpp
+++ b/src/axom/inlet/Field.cpp
@@ -14,7 +14,7 @@ namespace axom
 {
 namespace inlet
 {
-std::shared_ptr<VerifiableScalar> Field::required(bool isRequired)
+VerifiableScalar& Field::required(bool isRequired)
 {
   SLIC_ASSERT_MSG(m_sidreGroup != nullptr,
                   "[Inlet] Field specific Sidre Datastore Group not set");
@@ -27,7 +27,7 @@ std::shared_ptr<VerifiableScalar> Field::required(bool isRequired)
       m_sidreGroup->getPathName());
     SLIC_WARNING(msg);
     setWarningFlag(m_sidreRootGroup);
-    return shared_from_this();
+    return *this;
   }
 
   if(isRequired)
@@ -39,7 +39,7 @@ std::shared_ptr<VerifiableScalar> Field::required(bool isRequired)
     m_sidreGroup->createViewScalar("required", (int8)0);
   }
 
-  return shared_from_this();
+  return *this;
 }
 
 bool Field::isRequired() const
@@ -121,7 +121,7 @@ void Field::setDefaultValue<std::string>(std::string value)
   }
 }
 
-std::shared_ptr<VerifiableScalar> Field::defaultValue(const char* value)
+VerifiableScalar& Field::defaultValue(const char* value)
 {
   std::string str = "";
   if(value)
@@ -129,10 +129,10 @@ std::shared_ptr<VerifiableScalar> Field::defaultValue(const char* value)
     str = value;
   }
   setDefaultValue(std::string(value));
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> Field::defaultValue(const std::string& value)
+VerifiableScalar& Field::defaultValue(const std::string& value)
 {
   if(m_type != axom::sidre::DataTypeId::CHAR8_STR_ID)
   {
@@ -140,10 +140,10 @@ std::shared_ptr<VerifiableScalar> Field::defaultValue(const std::string& value)
     setWarningFlag(m_sidreRootGroup);
   }
   setDefaultValue(value);
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> Field::defaultValue(bool value)
+VerifiableScalar& Field::defaultValue(bool value)
 {
   if(m_type != axom::sidre::DataTypeId::INT8_ID)
   {
@@ -151,10 +151,10 @@ std::shared_ptr<VerifiableScalar> Field::defaultValue(bool value)
     setWarningFlag(m_sidreRootGroup);
   }
   setDefaultValue((int8)value);
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> Field::defaultValue(int value)
+VerifiableScalar& Field::defaultValue(int value)
 {
   switch(m_type)
   {
@@ -169,10 +169,10 @@ std::shared_ptr<VerifiableScalar> Field::defaultValue(int value)
     setWarningFlag(m_sidreRootGroup);
     break;
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> Field::defaultValue(double value)
+VerifiableScalar& Field::defaultValue(double value)
 {
   if(m_type != axom::sidre::DataTypeId::DOUBLE_ID)
   {
@@ -180,7 +180,7 @@ std::shared_ptr<VerifiableScalar> Field::defaultValue(double value)
     setWarningFlag(m_sidreRootGroup);
   }
   setDefaultValue(value);
-  return shared_from_this();
+  return *this;
 }
 
 template <typename T>
@@ -213,7 +213,7 @@ void Field::setRange(T startVal, T endVal)
   }
 }
 
-std::shared_ptr<VerifiableScalar> Field::range(int startVal, int endVal)
+VerifiableScalar& Field::range(int startVal, int endVal)
 {
   switch(m_type)
   {
@@ -228,10 +228,10 @@ std::shared_ptr<VerifiableScalar> Field::range(int startVal, int endVal)
     setWarningFlag(m_sidreRootGroup);
     break;
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> Field::range(double startVal, double endVal)
+VerifiableScalar& Field::range(double startVal, double endVal)
 {
   switch(m_type)
   {
@@ -243,7 +243,7 @@ std::shared_ptr<VerifiableScalar> Field::range(double startVal, double endVal)
     setWarningFlag(m_sidreRootGroup);
     break;
   }
-  return shared_from_this();
+  return *this;
 }
 
 template <>
@@ -370,7 +370,7 @@ void Field::setScalarValidValues(std::vector<T> set)
   }
 }
 
-std::shared_ptr<VerifiableScalar> Field::validValues(const std::vector<int>& set)
+VerifiableScalar& Field::validValues(const std::vector<int>& set)
 {
   switch(m_type)
   {
@@ -385,10 +385,10 @@ std::shared_ptr<VerifiableScalar> Field::validValues(const std::vector<int>& set
     setWarningFlag(m_sidreRootGroup);
     break;
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> Field::validValues(const std::vector<double>& set)
+VerifiableScalar& Field::validValues(const std::vector<double>& set)
 {
   switch(m_type)
   {
@@ -400,11 +400,10 @@ std::shared_ptr<VerifiableScalar> Field::validValues(const std::vector<double>& 
     setWarningFlag(m_sidreRootGroup);
     break;
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> Field::validValues(
-  const std::vector<std::string>& set)
+VerifiableScalar& Field::validValues(const std::vector<std::string>& set)
 {
   if(m_type != axom::sidre::DataTypeId::CHAR8_STR_ID)
   {
@@ -438,36 +437,32 @@ std::shared_ptr<VerifiableScalar> Field::validValues(
       group->createViewString("", str);
     }
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> Field::validValues(
-  const std::initializer_list<const char*>& set)
+VerifiableScalar& Field::validValues(const std::initializer_list<const char*>& set)
 {
   return validValues(std::vector<std::string>(set.begin(), set.end()));
 }
 
-std::shared_ptr<VerifiableScalar> Field::validValues(
-  const std::initializer_list<int>& set)
+VerifiableScalar& Field::validValues(const std::initializer_list<int>& set)
 {
   return validValues(std::vector<int>(set));
 }
 
-std::shared_ptr<VerifiableScalar> Field::validValues(
-  const std::initializer_list<double>& set)
+VerifiableScalar& Field::validValues(const std::initializer_list<double>& set)
 {
   return validValues(std::vector<double>(set));
 }
 
-std::shared_ptr<VerifiableScalar> Field::registerVerifier(
-  std::function<bool(const Field&)> lambda)
+VerifiableScalar& Field::registerVerifier(std::function<bool(const Field&)> lambda)
 {
   SLIC_WARNING_IF(m_verifier,
                   fmt::format("[Inlet] Verifier for Field "
                               "already set: {0}",
                               m_sidreGroup->getPathName()));
   m_verifier = lambda;
-  return shared_from_this();
+  return *this;
 }
 
 bool Field::verify() const
@@ -597,167 +592,156 @@ std::string Field::name() const
 
 bool AggregateField::verify() const
 {
-  return std::all_of(m_fields.begin(),
-                     m_fields.end(),
-                     [](const std::shared_ptr<VerifiableScalar>& field) {
-                       return field->verify();
-                     });
+  return std::all_of(
+    m_fields.begin(),
+    m_fields.end(),
+    [](const VerifiableScalar& field) { return field.verify(); });
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::required(bool isRequired)
+VerifiableScalar& AggregateField::required(bool isRequired)
 {
   for(auto& field : m_fields)
   {
-    field->required(isRequired);
+    field.get().required(isRequired);
   }
-  return shared_from_this();
+  return *this;
 }
 
 bool AggregateField::isRequired() const
 {
-  for(auto& field : m_fields)
-  {
-    if(field->isRequired())
-    {
-      return true;
-    }
-  }
-  return false;
+  return std::any_of(
+    m_fields.begin(),
+    m_fields.end(),
+    [](const VerifiableScalar& field) { return field.isRequired(); });
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::defaultValue(
-  const std::string& value)
+VerifiableScalar& AggregateField::defaultValue(const std::string& value)
 {
   for(auto& field : m_fields)
   {
-    field->defaultValue(value);
+    field.get().defaultValue(value);
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::defaultValue(const char* value)
+VerifiableScalar& AggregateField::defaultValue(const char* value)
 {
   for(auto& field : m_fields)
   {
-    field->defaultValue(value);
+    field.get().defaultValue(value);
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::defaultValue(bool value)
+VerifiableScalar& AggregateField::defaultValue(bool value)
 {
   for(auto& field : m_fields)
   {
-    field->defaultValue(value);
+    field.get().defaultValue(value);
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::defaultValue(int value)
+VerifiableScalar& AggregateField::defaultValue(int value)
 {
   for(auto& field : m_fields)
   {
-    field->defaultValue(value);
+    field.get().defaultValue(value);
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::defaultValue(double value)
+VerifiableScalar& AggregateField::defaultValue(double value)
 {
   for(auto& field : m_fields)
   {
-    field->defaultValue(value);
+    field.get().defaultValue(value);
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::range(double startVal,
-                                                        double endVal)
+VerifiableScalar& AggregateField::range(double startVal, double endVal)
 {
   for(auto& field : m_fields)
   {
-    field->range(startVal, endVal);
+    field.get().range(startVal, endVal);
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::range(int startVal, int endVal)
+VerifiableScalar& AggregateField::range(int startVal, int endVal)
 {
   for(auto& field : m_fields)
   {
-    field->range(startVal, endVal);
+    field.get().range(startVal, endVal);
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::validValues(
-  const std::vector<int>& set)
+VerifiableScalar& AggregateField::validValues(const std::vector<int>& set)
 {
   for(auto& field : m_fields)
   {
-    field->validValues(set);
+    field.get().validValues(set);
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::validValues(
-  const std::vector<double>& set)
+VerifiableScalar& AggregateField::validValues(const std::vector<double>& set)
 {
   for(auto& field : m_fields)
   {
-    field->validValues(set);
+    field.get().validValues(set);
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::validValues(
-  const std::vector<std::string>& set)
+VerifiableScalar& AggregateField::validValues(const std::vector<std::string>& set)
 {
   for(auto& field : m_fields)
   {
-    field->validValues(set);
+    field.get().validValues(set);
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::validValues(
+VerifiableScalar& AggregateField::validValues(
   const std::initializer_list<const char*>& set)
 {
   for(auto& field : m_fields)
   {
-    field->validValues(set);
+    field.get().validValues(set);
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::validValues(
-  const std::initializer_list<int>& set)
+VerifiableScalar& AggregateField::validValues(const std::initializer_list<int>& set)
 {
   for(auto& field : m_fields)
   {
-    field->validValues(set);
+    field.get().validValues(set);
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::validValues(
+VerifiableScalar& AggregateField::validValues(
   const std::initializer_list<double>& set)
 {
   for(auto& field : m_fields)
   {
-    field->validValues(set);
+    field.get().validValues(set);
   }
-  return shared_from_this();
+  return *this;
 }
 
-std::shared_ptr<VerifiableScalar> AggregateField::registerVerifier(
+VerifiableScalar& AggregateField::registerVerifier(
   std::function<bool(const Field&)> lambda)
 {
   for(auto& field : m_fields)
   {
-    field->registerVerifier(lambda);
+    field.get().registerVerifier(lambda);
   }
-  return shared_from_this();
+  return *this;
 }
 
 }  // end namespace inlet

--- a/src/axom/inlet/Field.cpp
+++ b/src/axom/inlet/Field.cpp
@@ -14,7 +14,7 @@ namespace axom
 {
 namespace inlet
 {
-VerifiableScalar& Field::required(bool isRequired)
+Field& Field::required(bool isRequired)
 {
   SLIC_ASSERT_MSG(m_sidreGroup != nullptr,
                   "[Inlet] Field specific Sidre Datastore Group not set");
@@ -121,7 +121,7 @@ void Field::setDefaultValue<std::string>(std::string value)
   }
 }
 
-VerifiableScalar& Field::defaultValue(const char* value)
+Field& Field::defaultValue(const char* value)
 {
   std::string str = "";
   if(value)
@@ -132,7 +132,7 @@ VerifiableScalar& Field::defaultValue(const char* value)
   return *this;
 }
 
-VerifiableScalar& Field::defaultValue(const std::string& value)
+Field& Field::defaultValue(const std::string& value)
 {
   if(m_type != axom::sidre::DataTypeId::CHAR8_STR_ID)
   {
@@ -143,7 +143,7 @@ VerifiableScalar& Field::defaultValue(const std::string& value)
   return *this;
 }
 
-VerifiableScalar& Field::defaultValue(bool value)
+Field& Field::defaultValue(bool value)
 {
   if(m_type != axom::sidre::DataTypeId::INT8_ID)
   {
@@ -154,7 +154,7 @@ VerifiableScalar& Field::defaultValue(bool value)
   return *this;
 }
 
-VerifiableScalar& Field::defaultValue(int value)
+Field& Field::defaultValue(int value)
 {
   switch(m_type)
   {
@@ -172,7 +172,7 @@ VerifiableScalar& Field::defaultValue(int value)
   return *this;
 }
 
-VerifiableScalar& Field::defaultValue(double value)
+Field& Field::defaultValue(double value)
 {
   if(m_type != axom::sidre::DataTypeId::DOUBLE_ID)
   {
@@ -213,7 +213,7 @@ void Field::setRange(T startVal, T endVal)
   }
 }
 
-VerifiableScalar& Field::range(int startVal, int endVal)
+Field& Field::range(int startVal, int endVal)
 {
   switch(m_type)
   {
@@ -231,7 +231,7 @@ VerifiableScalar& Field::range(int startVal, int endVal)
   return *this;
 }
 
-VerifiableScalar& Field::range(double startVal, double endVal)
+Field& Field::range(double startVal, double endVal)
 {
   switch(m_type)
   {
@@ -370,7 +370,7 @@ void Field::setScalarValidValues(std::vector<T> set)
   }
 }
 
-VerifiableScalar& Field::validValues(const std::vector<int>& set)
+Field& Field::validValues(const std::vector<int>& set)
 {
   switch(m_type)
   {
@@ -388,7 +388,7 @@ VerifiableScalar& Field::validValues(const std::vector<int>& set)
   return *this;
 }
 
-VerifiableScalar& Field::validValues(const std::vector<double>& set)
+Field& Field::validValues(const std::vector<double>& set)
 {
   switch(m_type)
   {
@@ -403,7 +403,7 @@ VerifiableScalar& Field::validValues(const std::vector<double>& set)
   return *this;
 }
 
-VerifiableScalar& Field::validValues(const std::vector<std::string>& set)
+Field& Field::validValues(const std::vector<std::string>& set)
 {
   if(m_type != axom::sidre::DataTypeId::CHAR8_STR_ID)
   {
@@ -440,22 +440,22 @@ VerifiableScalar& Field::validValues(const std::vector<std::string>& set)
   return *this;
 }
 
-VerifiableScalar& Field::validValues(const std::initializer_list<const char*>& set)
+Field& Field::validValues(const std::initializer_list<const char*>& set)
 {
   return validValues(std::vector<std::string>(set.begin(), set.end()));
 }
 
-VerifiableScalar& Field::validValues(const std::initializer_list<int>& set)
+Field& Field::validValues(const std::initializer_list<int>& set)
 {
   return validValues(std::vector<int>(set));
 }
 
-VerifiableScalar& Field::validValues(const std::initializer_list<double>& set)
+Field& Field::validValues(const std::initializer_list<double>& set)
 {
   return validValues(std::vector<double>(set));
 }
 
-VerifiableScalar& Field::registerVerifier(std::function<bool(const Field&)> lambda)
+Field& Field::registerVerifier(std::function<bool(const Field&)> lambda)
 {
   SLIC_WARNING_IF(m_verifier,
                   fmt::format("[Inlet] Verifier for Field "
@@ -598,7 +598,7 @@ bool AggregateField::verify() const
     [](const VerifiableScalar& field) { return field.verify(); });
 }
 
-VerifiableScalar& AggregateField::required(bool isRequired)
+AggregateField& AggregateField::required(bool isRequired)
 {
   for(auto& field : m_fields)
   {
@@ -615,7 +615,7 @@ bool AggregateField::isRequired() const
     [](const VerifiableScalar& field) { return field.isRequired(); });
 }
 
-VerifiableScalar& AggregateField::defaultValue(const std::string& value)
+AggregateField& AggregateField::defaultValue(const std::string& value)
 {
   for(auto& field : m_fields)
   {
@@ -624,7 +624,7 @@ VerifiableScalar& AggregateField::defaultValue(const std::string& value)
   return *this;
 }
 
-VerifiableScalar& AggregateField::defaultValue(const char* value)
+AggregateField& AggregateField::defaultValue(const char* value)
 {
   for(auto& field : m_fields)
   {
@@ -633,7 +633,7 @@ VerifiableScalar& AggregateField::defaultValue(const char* value)
   return *this;
 }
 
-VerifiableScalar& AggregateField::defaultValue(bool value)
+AggregateField& AggregateField::defaultValue(bool value)
 {
   for(auto& field : m_fields)
   {
@@ -642,7 +642,7 @@ VerifiableScalar& AggregateField::defaultValue(bool value)
   return *this;
 }
 
-VerifiableScalar& AggregateField::defaultValue(int value)
+AggregateField& AggregateField::defaultValue(int value)
 {
   for(auto& field : m_fields)
   {
@@ -651,7 +651,7 @@ VerifiableScalar& AggregateField::defaultValue(int value)
   return *this;
 }
 
-VerifiableScalar& AggregateField::defaultValue(double value)
+AggregateField& AggregateField::defaultValue(double value)
 {
   for(auto& field : m_fields)
   {
@@ -660,7 +660,7 @@ VerifiableScalar& AggregateField::defaultValue(double value)
   return *this;
 }
 
-VerifiableScalar& AggregateField::range(double startVal, double endVal)
+AggregateField& AggregateField::range(double startVal, double endVal)
 {
   for(auto& field : m_fields)
   {
@@ -669,7 +669,7 @@ VerifiableScalar& AggregateField::range(double startVal, double endVal)
   return *this;
 }
 
-VerifiableScalar& AggregateField::range(int startVal, int endVal)
+AggregateField& AggregateField::range(int startVal, int endVal)
 {
   for(auto& field : m_fields)
   {
@@ -678,7 +678,7 @@ VerifiableScalar& AggregateField::range(int startVal, int endVal)
   return *this;
 }
 
-VerifiableScalar& AggregateField::validValues(const std::vector<int>& set)
+AggregateField& AggregateField::validValues(const std::vector<int>& set)
 {
   for(auto& field : m_fields)
   {
@@ -687,7 +687,7 @@ VerifiableScalar& AggregateField::validValues(const std::vector<int>& set)
   return *this;
 }
 
-VerifiableScalar& AggregateField::validValues(const std::vector<double>& set)
+AggregateField& AggregateField::validValues(const std::vector<double>& set)
 {
   for(auto& field : m_fields)
   {
@@ -696,7 +696,7 @@ VerifiableScalar& AggregateField::validValues(const std::vector<double>& set)
   return *this;
 }
 
-VerifiableScalar& AggregateField::validValues(const std::vector<std::string>& set)
+AggregateField& AggregateField::validValues(const std::vector<std::string>& set)
 {
   for(auto& field : m_fields)
   {
@@ -705,7 +705,7 @@ VerifiableScalar& AggregateField::validValues(const std::vector<std::string>& se
   return *this;
 }
 
-VerifiableScalar& AggregateField::validValues(
+AggregateField& AggregateField::validValues(
   const std::initializer_list<const char*>& set)
 {
   for(auto& field : m_fields)
@@ -715,7 +715,7 @@ VerifiableScalar& AggregateField::validValues(
   return *this;
 }
 
-VerifiableScalar& AggregateField::validValues(const std::initializer_list<int>& set)
+AggregateField& AggregateField::validValues(const std::initializer_list<int>& set)
 {
   for(auto& field : m_fields)
   {
@@ -724,8 +724,7 @@ VerifiableScalar& AggregateField::validValues(const std::initializer_list<int>& 
   return *this;
 }
 
-VerifiableScalar& AggregateField::validValues(
-  const std::initializer_list<double>& set)
+AggregateField& AggregateField::validValues(const std::initializer_list<double>& set)
 {
   for(auto& field : m_fields)
   {
@@ -734,7 +733,7 @@ VerifiableScalar& AggregateField::validValues(
   return *this;
 }
 
-VerifiableScalar& AggregateField::registerVerifier(
+AggregateField& AggregateField::registerVerifier(
   std::function<bool(const Field&)> lambda)
 {
   for(auto& field : m_fields)

--- a/src/axom/inlet/Field.hpp
+++ b/src/axom/inlet/Field.hpp
@@ -336,8 +336,6 @@ private:
    * \brief Set the valid values for this Field.
    *
    * \param [in] set A vector containing the set of allowed scalar values
-   *
-   * \return Reference to this Field instance
    *****************************************************************************
   */
   template <typename T>
@@ -352,8 +350,6 @@ private:
    * \param [in] startVal The start of the range
    * 
    * \param [in] endVal The end of the range
-   *
-   * \return Reference to this Field instance
    *****************************************************************************
   */
   template <typename T>
@@ -366,8 +362,6 @@ private:
    * Set the default value for the Field in the input file.
    *
    * \param [in] value The default value
-   *
-   * \return Reference to this Field instance
    *****************************************************************************
   */
   template <typename T>
@@ -662,6 +656,8 @@ public:
    * during the verification stage.
    * 
    * \param [in] The function object that will be called by Field::verify().
+   * 
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   AggregateField& registerVerifier(std::function<bool(const Field&)> lambda);

--- a/src/axom/inlet/Field.hpp
+++ b/src/axom/inlet/Field.hpp
@@ -109,7 +109,7 @@ public:
    * \return Shared pointer to this instance of this class
    *****************************************************************************
    */
-  std::shared_ptr<VerifiableScalar> required(bool isRequired = true);
+  VerifiableScalar& required(bool isRequired = true);
 
   /*!
    *****************************************************************************
@@ -134,7 +134,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> defaultValue(const std::string& value);
+  VerifiableScalar& defaultValue(const std::string& value);
 
   /*!
    *****************************************************************************
@@ -147,7 +147,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> defaultValue(const char* value);
+  VerifiableScalar& defaultValue(const char* value);
 
   /*!
    *****************************************************************************
@@ -160,7 +160,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> defaultValue(bool value);
+  VerifiableScalar& defaultValue(bool value);
 
   /*!
    *****************************************************************************
@@ -173,7 +173,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> defaultValue(int value);
+  VerifiableScalar& defaultValue(int value);
 
   /*!
    *****************************************************************************
@@ -186,7 +186,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> defaultValue(double value);
+  VerifiableScalar& defaultValue(double value);
 
   /*!
    *****************************************************************************
@@ -201,7 +201,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> range(double startVal, double endVal);
+  VerifiableScalar& range(double startVal, double endVal);
 
   /*!
    *****************************************************************************
@@ -216,7 +216,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> range(int startVal, int endVal);
+  VerifiableScalar& range(int startVal, int endVal);
 
   /*!
    *****************************************************************************
@@ -227,7 +227,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> validValues(const std::vector<int>& set);
+  VerifiableScalar& validValues(const std::vector<int>& set);
 
   /*!
    *****************************************************************************
@@ -238,7 +238,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> validValues(const std::vector<double>& set);
+  VerifiableScalar& validValues(const std::vector<double>& set);
 
   /*!
    *****************************************************************************
@@ -249,7 +249,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> validValues(const std::vector<std::string>& set);
+  VerifiableScalar& validValues(const std::vector<std::string>& set);
 
   /*!
    *****************************************************************************
@@ -261,8 +261,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> validValues(
-    const std::initializer_list<const char*>& set);
+  VerifiableScalar& validValues(const std::initializer_list<const char*>& set);
 
   /*!
    *****************************************************************************
@@ -273,8 +272,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> validValues(
-    const std::initializer_list<int>& set);
+  VerifiableScalar& validValues(const std::initializer_list<int>& set);
 
   /*!
    *****************************************************************************
@@ -285,8 +283,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> validValues(
-    const std::initializer_list<double>& set);
+  VerifiableScalar& validValues(const std::initializer_list<double>& set);
 
   /*!
    *****************************************************************************
@@ -296,8 +293,7 @@ public:
    * \param [in] The function object that will be called by Field::verify().
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> registerVerifier(
-    std::function<bool(const Field&)> lambda);
+  VerifiableScalar& registerVerifier(std::function<bool(const Field&)> lambda);
 
   /*!
    *****************************************************************************
@@ -461,7 +457,7 @@ class AggregateField : public std::enable_shared_from_this<AggregateField>,
                        public VerifiableScalar
 {
 public:
-  AggregateField(std::vector<std::shared_ptr<VerifiableScalar>>&& fields)
+  AggregateField(std::vector<std::reference_wrapper<VerifiableScalar>>&& fields)
     : m_fields(std::move(fields))
   { }
 
@@ -486,7 +482,7 @@ public:
    * \return Shared pointer to this instance of this class
    *****************************************************************************
    */
-  std::shared_ptr<VerifiableScalar> required(bool isRequired);
+  VerifiableScalar& required(bool isRequired);
 
   /*!
    *****************************************************************************
@@ -511,7 +507,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> defaultValue(const std::string& value);
+  VerifiableScalar& defaultValue(const std::string& value);
 
   /*!
    *****************************************************************************
@@ -524,7 +520,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> defaultValue(const char* value);
+  VerifiableScalar& defaultValue(const char* value);
 
   /*!
    *****************************************************************************
@@ -537,7 +533,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> defaultValue(bool value);
+  VerifiableScalar& defaultValue(bool value);
 
   /*!
    *****************************************************************************
@@ -550,7 +546,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> defaultValue(int value);
+  VerifiableScalar& defaultValue(int value);
 
   /*!
    *****************************************************************************
@@ -563,7 +559,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> defaultValue(double value);
+  VerifiableScalar& defaultValue(double value);
 
   /*!
    *****************************************************************************
@@ -578,7 +574,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> range(double startVal, double endVal);
+  VerifiableScalar& range(double startVal, double endVal);
 
   /*!
    *****************************************************************************
@@ -593,7 +589,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> range(int startVal, int endVal);
+  VerifiableScalar& range(int startVal, int endVal);
 
   /*!
    *****************************************************************************
@@ -604,7 +600,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> validValues(const std::vector<int>& set);
+  VerifiableScalar& validValues(const std::vector<int>& set);
 
   /*!
    *****************************************************************************
@@ -615,7 +611,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> validValues(const std::vector<double>& set);
+  VerifiableScalar& validValues(const std::vector<double>& set);
 
   /*!
    *****************************************************************************
@@ -626,7 +622,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> validValues(const std::vector<std::string>& set);
+  VerifiableScalar& validValues(const std::vector<std::string>& set);
 
   /*!
    *****************************************************************************
@@ -638,8 +634,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> validValues(
-    const std::initializer_list<const char*>& set);
+  VerifiableScalar& validValues(const std::initializer_list<const char*>& set);
 
   /*!
    *****************************************************************************
@@ -650,8 +645,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> validValues(
-    const std::initializer_list<int>& set);
+  VerifiableScalar& validValues(const std::initializer_list<int>& set);
 
   /*!
    *****************************************************************************
@@ -662,8 +656,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> validValues(
-    const std::initializer_list<double>& set);
+  VerifiableScalar& validValues(const std::initializer_list<double>& set);
   /*!
    *****************************************************************************
    * \brief Registers the function object that will verify this Field's contents
@@ -672,11 +665,10 @@ public:
    * \param [in] The function object that will be called by Field::verify().
    *****************************************************************************
   */
-  std::shared_ptr<VerifiableScalar> registerVerifier(
-    std::function<bool(const Field&)> lambda);
+  VerifiableScalar& registerVerifier(std::function<bool(const Field&)> lambda);
 
 private:
-  std::vector<std::shared_ptr<VerifiableScalar>> m_fields;
+  std::vector<std::reference_wrapper<VerifiableScalar>> m_fields;
 };
 
 }  // end namespace inlet

--- a/src/axom/inlet/Field.hpp
+++ b/src/axom/inlet/Field.hpp
@@ -106,7 +106,7 @@ public:
    *
    * \param [in] isRequired Boolean value of whether Field is required
    *
-   * \return Shared pointer to this instance of this class
+   * \return Reference to this instance of this class
    *****************************************************************************
    */
   Field& required(bool isRequired = true);
@@ -131,7 +131,7 @@ public:
    *
    * \param [in] value The default string value
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   Field& defaultValue(const std::string& value);
@@ -144,7 +144,7 @@ public:
    *
    * \param [in] value The default string value
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   Field& defaultValue(const char* value);
@@ -157,7 +157,7 @@ public:
    *
    * \param [in] value The default boolean value
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   Field& defaultValue(bool value);
@@ -170,7 +170,7 @@ public:
    *
    * \param [in] value The default integer value
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   Field& defaultValue(int value);
@@ -183,7 +183,7 @@ public:
    *
    * \param [in] value The default double value
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   Field& defaultValue(double value);
@@ -198,7 +198,7 @@ public:
    * 
    * \param [in] endVal The end of the range
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   Field& range(double startVal, double endVal);
@@ -213,7 +213,7 @@ public:
    * 
    * \param [in] endVal The end of the range
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   Field& range(int startVal, int endVal);
@@ -224,7 +224,7 @@ public:
    *
    * \param [in] set An vector containing the set of allowed integer values
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   Field& validValues(const std::vector<int>& set);
@@ -235,7 +235,7 @@ public:
    *
    * \param [in] set An vector containing the set of allowed double values
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   Field& validValues(const std::vector<double>& set);
@@ -246,7 +246,7 @@ public:
    *
    * \param [in] set A vector containing the set of allowed string values
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   Field& validValues(const std::vector<std::string>& set);
@@ -258,7 +258,7 @@ public:
    * \param [in] set An initializer list containing the set of allowed C-string 
    * values
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   Field& validValues(const std::initializer_list<const char*>& set);
@@ -269,7 +269,7 @@ public:
    *
    * \param [in] set An initializer list containing the valid integer values
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   Field& validValues(const std::initializer_list<int>& set);
@@ -280,7 +280,7 @@ public:
    *
    * \param [in] set An initializer list containing the valid double values
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   Field& validValues(const std::initializer_list<double>& set);
@@ -337,7 +337,7 @@ private:
    *
    * \param [in] set A vector containing the set of allowed scalar values
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   template <typename T>
@@ -353,7 +353,7 @@ private:
    * 
    * \param [in] endVal The end of the range
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   template <typename T>
@@ -367,7 +367,7 @@ private:
    *
    * \param [in] value The default value
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   template <typename T>
@@ -478,7 +478,7 @@ public:
    *
    * \param [in] isRequired Boolean value of whether Field is required
    *
-   * \return Shared pointer to this instance of this class
+   * \return Reference to this instance of this class
    *****************************************************************************
    */
   AggregateField& required(bool isRequired);
@@ -503,7 +503,7 @@ public:
    *
    * \param [in] value The default string value
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   AggregateField& defaultValue(const std::string& value);
@@ -516,7 +516,7 @@ public:
    *
    * \param [in] value The default string value
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   AggregateField& defaultValue(const char* value);
@@ -529,7 +529,7 @@ public:
    *
    * \param [in] value The default boolean value
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   AggregateField& defaultValue(bool value);
@@ -542,7 +542,7 @@ public:
    *
    * \param [in] value The default integer value
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   AggregateField& defaultValue(int value);
@@ -555,7 +555,7 @@ public:
    *
    * \param [in] value The default double value
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   AggregateField& defaultValue(double value);
@@ -570,7 +570,7 @@ public:
    * 
    * \param [in] endVal The end of the range
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   AggregateField& range(double startVal, double endVal);
@@ -585,7 +585,7 @@ public:
    * 
    * \param [in] endVal The end of the range
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   AggregateField& range(int startVal, int endVal);
@@ -596,7 +596,7 @@ public:
    *
    * \param [in] set An vector containing the set of allowed integer values
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   AggregateField& validValues(const std::vector<int>& set);
@@ -607,7 +607,7 @@ public:
    *
    * \param [in] set An vector containing the set of allowed double values
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   AggregateField& validValues(const std::vector<double>& set);
@@ -618,7 +618,7 @@ public:
    *
    * \param [in] set A vector containing the set of allowed string values
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   AggregateField& validValues(const std::vector<std::string>& set);
@@ -630,7 +630,7 @@ public:
    * \param [in] set An initializer list containing the set of allowed C-string 
    * values
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   AggregateField& validValues(const std::initializer_list<const char*>& set);
@@ -641,7 +641,7 @@ public:
    *
    * \param [in] set An initializer list containing the valid integer values
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   AggregateField& validValues(const std::initializer_list<int>& set);
@@ -652,7 +652,7 @@ public:
    *
    * \param [in] set An initializer list containing the valid double values
    *
-   * \return Shared pointer to this Field instance
+   * \return Reference to this Field instance
    *****************************************************************************
   */
   AggregateField& validValues(const std::initializer_list<double>& set);

--- a/src/axom/inlet/Field.hpp
+++ b/src/axom/inlet/Field.hpp
@@ -55,7 +55,7 @@ enum class InletType
  * \see Inlet Table
  *******************************************************************************
  */
-class Field : public std::enable_shared_from_this<Field>, public VerifiableScalar
+class Field : public VerifiableScalar
 {
 public:
   /*!
@@ -109,7 +109,7 @@ public:
    * \return Shared pointer to this instance of this class
    *****************************************************************************
    */
-  VerifiableScalar& required(bool isRequired = true);
+  Field& required(bool isRequired = true);
 
   /*!
    *****************************************************************************
@@ -134,7 +134,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& defaultValue(const std::string& value);
+  Field& defaultValue(const std::string& value);
 
   /*!
    *****************************************************************************
@@ -147,7 +147,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& defaultValue(const char* value);
+  Field& defaultValue(const char* value);
 
   /*!
    *****************************************************************************
@@ -160,7 +160,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& defaultValue(bool value);
+  Field& defaultValue(bool value);
 
   /*!
    *****************************************************************************
@@ -173,7 +173,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& defaultValue(int value);
+  Field& defaultValue(int value);
 
   /*!
    *****************************************************************************
@@ -186,7 +186,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& defaultValue(double value);
+  Field& defaultValue(double value);
 
   /*!
    *****************************************************************************
@@ -201,7 +201,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& range(double startVal, double endVal);
+  Field& range(double startVal, double endVal);
 
   /*!
    *****************************************************************************
@@ -216,7 +216,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& range(int startVal, int endVal);
+  Field& range(int startVal, int endVal);
 
   /*!
    *****************************************************************************
@@ -227,7 +227,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& validValues(const std::vector<int>& set);
+  Field& validValues(const std::vector<int>& set);
 
   /*!
    *****************************************************************************
@@ -238,7 +238,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& validValues(const std::vector<double>& set);
+  Field& validValues(const std::vector<double>& set);
 
   /*!
    *****************************************************************************
@@ -249,7 +249,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& validValues(const std::vector<std::string>& set);
+  Field& validValues(const std::vector<std::string>& set);
 
   /*!
    *****************************************************************************
@@ -261,7 +261,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& validValues(const std::initializer_list<const char*>& set);
+  Field& validValues(const std::initializer_list<const char*>& set);
 
   /*!
    *****************************************************************************
@@ -272,7 +272,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& validValues(const std::initializer_list<int>& set);
+  Field& validValues(const std::initializer_list<int>& set);
 
   /*!
    *****************************************************************************
@@ -283,7 +283,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& validValues(const std::initializer_list<double>& set);
+  Field& validValues(const std::initializer_list<double>& set);
 
   /*!
    *****************************************************************************
@@ -293,7 +293,7 @@ public:
    * \param [in] The function object that will be called by Field::verify().
    *****************************************************************************
   */
-  VerifiableScalar& registerVerifier(std::function<bool(const Field&)> lambda);
+  Field& registerVerifier(std::function<bool(const Field&)> lambda);
 
   /*!
    *****************************************************************************
@@ -453,8 +453,7 @@ inline bool Field::searchValidValues<std::string>(const axom::sidre::View& view)
    * \brief A wrapper class that enables constraints on groups of Fields
    *****************************************************************************
   */
-class AggregateField : public std::enable_shared_from_this<AggregateField>,
-                       public VerifiableScalar
+class AggregateField : public VerifiableScalar
 {
 public:
   AggregateField(std::vector<std::reference_wrapper<VerifiableScalar>>&& fields)
@@ -482,7 +481,7 @@ public:
    * \return Shared pointer to this instance of this class
    *****************************************************************************
    */
-  VerifiableScalar& required(bool isRequired);
+  AggregateField& required(bool isRequired);
 
   /*!
    *****************************************************************************
@@ -507,7 +506,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& defaultValue(const std::string& value);
+  AggregateField& defaultValue(const std::string& value);
 
   /*!
    *****************************************************************************
@@ -520,7 +519,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& defaultValue(const char* value);
+  AggregateField& defaultValue(const char* value);
 
   /*!
    *****************************************************************************
@@ -533,7 +532,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& defaultValue(bool value);
+  AggregateField& defaultValue(bool value);
 
   /*!
    *****************************************************************************
@@ -546,7 +545,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& defaultValue(int value);
+  AggregateField& defaultValue(int value);
 
   /*!
    *****************************************************************************
@@ -559,7 +558,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& defaultValue(double value);
+  AggregateField& defaultValue(double value);
 
   /*!
    *****************************************************************************
@@ -574,7 +573,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& range(double startVal, double endVal);
+  AggregateField& range(double startVal, double endVal);
 
   /*!
    *****************************************************************************
@@ -589,7 +588,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& range(int startVal, int endVal);
+  AggregateField& range(int startVal, int endVal);
 
   /*!
    *****************************************************************************
@@ -600,7 +599,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& validValues(const std::vector<int>& set);
+  AggregateField& validValues(const std::vector<int>& set);
 
   /*!
    *****************************************************************************
@@ -611,7 +610,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& validValues(const std::vector<double>& set);
+  AggregateField& validValues(const std::vector<double>& set);
 
   /*!
    *****************************************************************************
@@ -622,7 +621,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& validValues(const std::vector<std::string>& set);
+  AggregateField& validValues(const std::vector<std::string>& set);
 
   /*!
    *****************************************************************************
@@ -634,7 +633,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& validValues(const std::initializer_list<const char*>& set);
+  AggregateField& validValues(const std::initializer_list<const char*>& set);
 
   /*!
    *****************************************************************************
@@ -645,7 +644,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& validValues(const std::initializer_list<int>& set);
+  AggregateField& validValues(const std::initializer_list<int>& set);
 
   /*!
    *****************************************************************************
@@ -656,7 +655,7 @@ public:
    * \return Shared pointer to this Field instance
    *****************************************************************************
   */
-  VerifiableScalar& validValues(const std::initializer_list<double>& set);
+  AggregateField& validValues(const std::initializer_list<double>& set);
   /*!
    *****************************************************************************
    * \brief Registers the function object that will verify this Field's contents
@@ -665,7 +664,7 @@ public:
    * \param [in] The function object that will be called by Field::verify().
    *****************************************************************************
   */
-  VerifiableScalar& registerVerifier(std::function<bool(const Field&)> lambda);
+  AggregateField& registerVerifier(std::function<bool(const Field&)> lambda);
 
 private:
   std::vector<std::reference_wrapper<VerifiableScalar>> m_fields;

--- a/src/axom/inlet/Inlet.cpp
+++ b/src/axom/inlet/Inlet.cpp
@@ -52,9 +52,9 @@ VerifiableScalar& Inlet::addString(const std::string& name,
   return m_globalTable.addString(name, description);
 }
 
-void Inlet::registerDocWriter(std::shared_ptr<DocWriter> writer)
+void Inlet::registerDocWriter(std::unique_ptr<DocWriter> writer)
 {
-  m_docWriter = writer;
+  m_docWriter = std::move(writer);
 }
 
 void Inlet::writeDoc()

--- a/src/axom/inlet/Inlet.cpp
+++ b/src/axom/inlet/Inlet.cpp
@@ -23,34 +23,33 @@ namespace axom
 {
 namespace inlet
 {
-std::shared_ptr<Table> Inlet::addTable(const std::string& name,
-                                       const std::string& description)
+Table& Inlet::addTable(const std::string& name, const std::string& description)
 {
-  return m_globalTable->addTable(name, description);
+  return m_globalTable.addTable(name, description);
 }
 
-std::shared_ptr<VerifiableScalar> Inlet::addBool(const std::string& name,
-                                                 const std::string& description)
+VerifiableScalar& Inlet::addBool(const std::string& name,
+                                 const std::string& description)
 {
-  return m_globalTable->addBool(name, description);
+  return m_globalTable.addBool(name, description);
 }
 
-std::shared_ptr<VerifiableScalar> Inlet::addDouble(const std::string& name,
-                                                   const std::string& description)
+VerifiableScalar& Inlet::addDouble(const std::string& name,
+                                   const std::string& description)
 {
-  return m_globalTable->addDouble(name, description);
+  return m_globalTable.addDouble(name, description);
 }
 
-std::shared_ptr<VerifiableScalar> Inlet::addInt(const std::string& name,
-                                                const std::string& description)
+VerifiableScalar& Inlet::addInt(const std::string& name,
+                                const std::string& description)
 {
-  return m_globalTable->addInt(name, description);
+  return m_globalTable.addInt(name, description);
 }
 
-std::shared_ptr<VerifiableScalar> Inlet::addString(const std::string& name,
-                                                   const std::string& description)
+VerifiableScalar& Inlet::addString(const std::string& name,
+                                   const std::string& description)
 {
-  return m_globalTable->addString(name, description);
+  return m_globalTable.addString(name, description);
 }
 
 void Inlet::registerDocWriter(std::shared_ptr<DocWriter> writer)
@@ -66,7 +65,7 @@ void Inlet::writeDoc()
   }
 }
 
-bool Inlet::verify() { return m_globalTable->verify(); }
+bool Inlet::verify() const { return m_globalTable.verify(); }
 
 }  // end namespace inlet
 }  // end namespace axom

--- a/src/axom/inlet/Inlet.hpp
+++ b/src/axom/inlet/Inlet.hpp
@@ -54,7 +54,7 @@ public:
    * Creates an Inlet class that can then be used with the given Reader and will
    * store data under the given Sidre Group.
    *
-   * \param [in] reader Reference to the input file Reader class.
+   * \param [in] reader Unique (owning) pointer to the input file Reader class.
    * \param [in] sidreRootGroup Pointer to the already created Sidre Group.
    * \param [in] docEnabled Boolean indicating whether documentation generation
    * is enabled. This also toggles the storing of documentation-specific information.
@@ -248,7 +248,7 @@ public:
    * Sets the associated DocWriter. If the DocWriter is already set, it will be
    * replaced by the one that was most recently set.
    *
-   * \param [in] writer A pointer to a DocWriter object
+   * \param [in] writer An owning pointer to a DocWriter object
    *
    *****************************************************************************
    */

--- a/src/axom/inlet/Inlet.hpp
+++ b/src/axom/inlet/Inlet.hpp
@@ -54,18 +54,18 @@ public:
    * Creates an Inlet class that can then be used with the given Reader and will
    * store data under the given Sidre Group.
    *
-   * \param [in] reader Shared pointer to the input file Reader class.
+   * \param [in] reader Reference to the input file Reader class.
    * \param [in] sidreRootGroup Pointer to the already created Sidre Group.
    * \param [in] docEnabled Boolean indicating whether documentation generation
    * is enabled. This also toggles the storing of documentation-specific information.
    *****************************************************************************
    */
-  Inlet(std::shared_ptr<Reader> reader,
+  Inlet(std::unique_ptr<Reader> reader,
         axom::sidre::Group* sidreRootGroup,
         bool docEnabled = true)
-    : m_reader(reader)
+    : m_reader(std::move(reader))
     , m_sidreRootGroup(sidreRootGroup)
-    , m_globalTable("", "", m_reader, m_sidreRootGroup, docEnabled)
+    , m_globalTable("", "", *m_reader, m_sidreRootGroup, docEnabled)
     , m_docEnabled(docEnabled)
   { }
 
@@ -77,14 +77,14 @@ public:
 
   /*!
    *****************************************************************************
-   * \brief Returns the shared pointer to the Reader class.
+   * \brief Returns the reference to the Reader class.
    *
    * Provides access to the Reader class that is used to access the input file.
    *
-   * \return Shared pointer to this instances' Reader class
+   * \return Reference to this instances' Reader class
    *****************************************************************************
    */
-  std::shared_ptr<Reader> reader() { return m_reader; };
+  Reader& reader() { return *m_reader; };
 
   /*!
    *****************************************************************************
@@ -114,7 +114,7 @@ public:
    * \param [in] name Name of the Table expected in the input file
    * \param [in] description Description of the Table
    *
-   * \return Shared pointer to the created Table
+   * \return Reference to the created Table
    *****************************************************************************
    */
   Table& addTable(const std::string& name, const std::string& description = "");
@@ -131,7 +131,7 @@ public:
    * \param [in] name Name of the Field expected in the input file
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   VerifiableScalar& addBool(const std::string& name,
@@ -149,7 +149,7 @@ public:
    * \param [in] name Name of the Field expected in the input file
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   VerifiableScalar& addDouble(const std::string& name,
@@ -167,7 +167,7 @@ public:
    * \param [in] name Name of the Field expected in the input file
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   VerifiableScalar& addInt(const std::string& name,
@@ -185,7 +185,7 @@ public:
    * \param [in] name Name of the Table expected in the input file
    * \param [in] description Description of the Table
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   VerifiableScalar& addString(const std::string& name,
@@ -252,7 +252,7 @@ public:
    *
    *****************************************************************************
    */
-  void registerDocWriter(std::shared_ptr<DocWriter> writer);
+  void registerDocWriter(std::unique_ptr<DocWriter> writer);
 
   /*!
    *****************************************************************************
@@ -371,7 +371,7 @@ public:
    * \param [in] name Name of the array
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   Verifiable& addBoolArray(const std::string& name,
@@ -387,7 +387,7 @@ public:
    * \param [in] name Name of the array
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   Verifiable& addIntArray(const std::string& name,
@@ -403,7 +403,7 @@ public:
    * \param [in] name Name of the array
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   Verifiable& addDoubleArray(const std::string& name,
@@ -419,7 +419,7 @@ public:
    * \param [in] name Name of the array
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   Verifiable& addStringArray(const std::string& name,
@@ -435,7 +435,7 @@ public:
    * \param [in] name Name of the array
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   Table& addGenericArray(const std::string& name,
@@ -502,10 +502,10 @@ public:
 
   // TODO add update value functions
 private:
-  std::shared_ptr<Reader> m_reader;
+  std::unique_ptr<Reader> m_reader;
   axom::sidre::Group* m_sidreRootGroup = nullptr;
   Table m_globalTable;
-  std::shared_ptr<DocWriter> m_docWriter;
+  std::unique_ptr<DocWriter> m_docWriter;
   bool m_docEnabled;
 };
 

--- a/src/axom/inlet/Table.cpp
+++ b/src/axom/inlet/Table.cpp
@@ -34,11 +34,11 @@ Table& Table::addTable(const std::string& name, const std::string& description)
       // or do we need std::piecewise_construct/std::forward_as_tuple?
       const auto& emplace_result = currTable->m_tableChildren.emplace(
         currTableName,
-        std::make_unique<Table>(currTableName,
-                                "",
-                                m_reader,
-                                m_sidreRootGroup,
-                                m_docEnabled));
+        cpp11_compat::make_unique<Table>(currTableName,
+                                         "",
+                                         m_reader,
+                                         m_sidreRootGroup,
+                                         m_docEnabled));
       // emplace_result is a pair whose first element is an iterator to the inserted element
       currTable = emplace_result.first->second.get();
     }
@@ -57,11 +57,11 @@ Table& Table::addTable(const std::string& name, const std::string& description)
   {
     const auto& emplace_result = currTable->m_tableChildren.emplace(
       currTableName,
-      std::make_unique<Table>(currTableName,
-                              description,
-                              m_reader,
-                              m_sidreRootGroup,
-                              m_docEnabled));
+      cpp11_compat::make_unique<Table>(currTableName,
+                                       description,
+                                       m_reader,
+                                       m_sidreRootGroup,
+                                       m_docEnabled));
     currTable = emplace_result.first->second.get();
   }
   else
@@ -199,7 +199,10 @@ Field& Table::addField(axom::sidre::Group* sidreGroup,
   }
   const auto& emplace_result = currTable->m_fieldChildren.emplace(
     fullName,
-    std::make_unique<Field>(sidreGroup, m_sidreRootGroup, type, m_docEnabled));
+    cpp11_compat::make_unique<Field>(sidreGroup,
+                                     m_sidreRootGroup,
+                                     type,
+                                     m_docEnabled));
   // emplace_result is a pair whose first element is an iterator to the inserted element
   return *(emplace_result.first->second);
 }

--- a/src/axom/inlet/Table.cpp
+++ b/src/axom/inlet/Table.cpp
@@ -215,13 +215,13 @@ std::shared_ptr<VerifiableScalar> Table::addPrimitive(
     // If it has indices, we're adding a primitive field to an array
     // of structs, so we need to iterate over the subtables
     // corresponding to elements of the array
-    std::vector<std::shared_ptr<VerifiableScalar>> fields;
+    std::vector<std::reference_wrapper<VerifiableScalar>> fields;
     for(const auto& indexPath : arrayIndicesWithPaths(name))
     {
       // Add a primitive to an array element (which is a struct)
-      fields.push_back(
+      fields.push_back(*(
         getTable(indexPath.first)
-          ->addPrimitive<T>(name, description, forArray, val, indexPath.second));
+          ->addPrimitive<T>(name, description, forArray, val, indexPath.second)));
     }
     // Create an aggregate field so requirements can be collectively imposed
     // on all elements of the array

--- a/src/axom/inlet/Table.cpp
+++ b/src/axom/inlet/Table.cpp
@@ -731,14 +731,9 @@ AggregateTable& AggregateTable::required(bool isRequired)
 
 bool AggregateTable::isRequired() const
 {
-  for(auto& table : m_tables)
-  {
-    if(table.get().isRequired())
-    {
-      return true;
-    }
-  }
-  return false;
+  return std::any_of(m_tables.begin(),
+                     m_tables.end(),
+                     [](const Verifiable& table) { return table.isRequired(); });
 }
 
 AggregateTable& AggregateTable::registerVerifier(

--- a/src/axom/inlet/Table.cpp
+++ b/src/axom/inlet/Table.cpp
@@ -137,7 +137,7 @@ Table& Table::addGenericArray(const std::string& name,
   auto& table = addTable(appendPrefix(name, ARRAY_GROUP_NAME), description);
   std::vector<int> indices;
   const std::string& fullName = appendPrefix(m_name, name);
-  if(m_reader->getArrayIndices(fullName, indices))
+  if(m_reader.getArrayIndices(fullName, indices))
   {
     // This is how an array of user-defined type is differentiated
     // from an array of primitives - the tables have to be allocated
@@ -164,7 +164,6 @@ Table& Table::addGenericArray(const std::string& name,
 axom::sidre::Group* Table::createSidreGroup(const std::string& name,
                                             const std::string& description)
 {
-  SLIC_ASSERT_MSG(m_reader != nullptr, "[Inlet] Reader class not set");
   SLIC_ASSERT_MSG(m_sidreRootGroup != nullptr,
                   "[Inlet] Sidre Datastore Group not set");
 
@@ -198,11 +197,6 @@ Field& Table::addField(axom::sidre::Group* sidreGroup,
     // This will add any intermediate Tables (if not present) before adding the field
     currTable = &addTable(name.substr(0, found));
   }
-  // auto field = std::make_shared<axom::inlet::Field>(sidreGroup,
-  //                                                   m_sidreRootGroup,
-  //                                                   type,
-  //                                                   m_docEnabled);
-  // currTable->m_fieldChildren[fullName] = field;
   const auto& emplace_result = currTable->m_fieldChildren.emplace(
     fullName,
     std::make_unique<Field>(sidreGroup, m_sidreRootGroup, type, m_docEnabled));
@@ -289,7 +283,7 @@ axom::sidre::DataTypeId Table::addPrimitiveHelper<bool>(
   bool forArray,
   bool val)
 {
-  if(forArray || m_reader->getBool(lookupPath, val))
+  if(forArray || m_reader.getBool(lookupPath, val))
   {
     sidreGroup->createViewScalar("value", val ? int8(1) : int8(0));
   }
@@ -303,7 +297,7 @@ axom::sidre::DataTypeId Table::addPrimitiveHelper<int>(
   bool forArray,
   int val)
 {
-  if(forArray || m_reader->getInt(lookupPath, val))
+  if(forArray || m_reader.getInt(lookupPath, val))
   {
     sidreGroup->createViewScalar("value", val);
   }
@@ -317,7 +311,7 @@ axom::sidre::DataTypeId Table::addPrimitiveHelper<double>(
   bool forArray,
   double val)
 {
-  if(forArray || m_reader->getDouble(lookupPath, val))
+  if(forArray || m_reader.getDouble(lookupPath, val))
   {
     sidreGroup->createViewScalar("value", val);
   }
@@ -331,7 +325,7 @@ axom::sidre::DataTypeId Table::addPrimitiveHelper<std::string>(
   bool forArray,
   std::string val)
 {
-  if(forArray || m_reader->getString(lookupPath, val))
+  if(forArray || m_reader.getString(lookupPath, val))
   {
     sidreGroup->createViewString("value", val);
   }
@@ -396,7 +390,7 @@ void Table::addPrimitiveArrayHelper<bool>(Table& table,
                                           const std::string& lookupPath)
 {
   std::unordered_map<int, bool> map;
-  if(m_reader->getBoolMap(lookupPath, map))
+  if(m_reader.getBoolMap(lookupPath, map))
   {
     for(const auto& p : map)
     {
@@ -414,7 +408,7 @@ void Table::addPrimitiveArrayHelper<int>(Table& table,
                                          const std::string& lookupPath)
 {
   std::unordered_map<int, int> map;
-  if(m_reader->getIntMap(lookupPath, map))
+  if(m_reader.getIntMap(lookupPath, map))
   {
     for(const auto& p : map)
     {
@@ -432,7 +426,7 @@ void Table::addPrimitiveArrayHelper<double>(Table& table,
                                             const std::string& lookupPath)
 {
   std::unordered_map<int, double> map;
-  if(m_reader->getDoubleMap(lookupPath, map))
+  if(m_reader.getDoubleMap(lookupPath, map))
   {
     for(const auto& p : map)
     {
@@ -450,7 +444,7 @@ void Table::addPrimitiveArrayHelper<std::string>(Table& table,
                                                  const std::string& lookupPath)
 {
   std::unordered_map<int, std::string> map;
-  if(m_reader->getStringMap(lookupPath, map))
+  if(m_reader.getStringMap(lookupPath, map))
   {
     for(const auto& p : map)
     {

--- a/src/axom/inlet/Table.hpp
+++ b/src/axom/inlet/Table.hpp
@@ -164,7 +164,7 @@ public:
    *
    * \param [in] isRequired Boolean value of whether Table is required
    *
-   * \return Shared pointer to this instance of Table
+   * \return Reference to this instance of Table
    *****************************************************************************
    */
   AggregateTable& required(bool isRequired = true);
@@ -219,7 +219,7 @@ public:
    *
    * \param [in] name Name of the Table expected in the input file
    * \param [in] description Description of the Table
-   * \param [in] reader Shared pointer to the input file Reader class.
+   * \param [in] reader Reference to the input file Reader class.
    * \param [in] sidreRootGroup Pointer to the already created Sidre Group.
    * \param [in] docEnabled Boolean indicating whether or not documentation
    * generation is enabled for input feck this Table instance belongs to.
@@ -227,7 +227,7 @@ public:
    */
   Table(const std::string& name,
         const std::string& description,
-        std::shared_ptr<Reader> reader,
+        Reader& reader,
         axom::sidre::Group* sidreRootGroup,
         bool docEnabled = true)
     : m_name(name)
@@ -235,7 +235,6 @@ public:
     , m_sidreRootGroup(sidreRootGroup)
     , m_docEnabled(docEnabled)
   {
-    SLIC_ASSERT_MSG(m_reader, "Inlet's Reader class not valid");
     SLIC_ASSERT_MSG(m_sidreRootGroup != nullptr,
                     "Inlet's Sidre Datastore class not set");
 
@@ -301,7 +300,7 @@ public:
    * \param [in] name Name of the Table expected in the input file
    * \param [in] description Description of the Table
    *
-   * \return Shared pointer to the created Table
+   * \return Reference to the created Table
    *****************************************************************************
    */
   Table& addTable(const std::string& name, const std::string& description = "");
@@ -313,7 +312,7 @@ public:
    * \param [in] name Name of the array
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   Verifiable& addBoolArray(const std::string& name,
@@ -326,7 +325,7 @@ public:
    * \param [in] name Name of the array
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   Verifiable& addIntArray(const std::string& name,
@@ -339,7 +338,7 @@ public:
    * \param [in] name Name of the array
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   Verifiable& addDoubleArray(const std::string& name,
@@ -352,7 +351,7 @@ public:
    * \param [in] name Name of the array
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   Verifiable& addStringArray(const std::string& name,
@@ -365,7 +364,7 @@ public:
    * \param [in] name Name of the array
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   Table& addGenericArray(const std::string& name,
@@ -443,7 +442,7 @@ public:
    * \param [in] name Name of the Field expected in the input file
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   VerifiableScalar& addBool(const std::string& name,
@@ -464,7 +463,7 @@ public:
    * \param [in] name Name of the Field expected in the input file
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   VerifiableScalar& addDouble(const std::string& name,
@@ -485,7 +484,7 @@ public:
    * \param [in] name Name of the Field expected in the input file
    * \param [in] description Description of the Field
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   VerifiableScalar& addInt(const std::string& name,
@@ -505,7 +504,7 @@ public:
    * \param [in] name Name of the Table expected in the input file
    * \param [in] description Description of the Table
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   VerifiableScalar& addString(const std::string& name,
@@ -533,7 +532,7 @@ public:
    * \param [in] pathOverride The path within the input file to read from, if
    * different than the structure of the Sidre datastore
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   template <typename T,
@@ -554,7 +553,7 @@ public:
    * \param [in] pathOverride The path within the input file to read from, if
    * different than the structure of the Sidre datastore
    *
-   * \return Shared pointer to the created Field
+   * \return Reference to the created Field
    *****************************************************************************
    */
   template <typename T,
@@ -680,7 +679,7 @@ public:
    *
    * \param [in] isRequired Boolean value of whether Table is required
    *
-   * \return Shared pointer to this instance of Table
+   * \return Reference to this instance of Table
    *****************************************************************************
    */
   Table& required(bool isRequired = true);
@@ -927,7 +926,7 @@ private:
     const std::string& name) const;
 
   std::string m_name;
-  std::shared_ptr<Reader> m_reader;
+  Reader& m_reader;
   // Inlet's Root Sidre Group
   axom::sidre::Group* m_sidreRootGroup;
   // This Table's Sidre Group

--- a/src/axom/inlet/Table.hpp
+++ b/src/axom/inlet/Table.hpp
@@ -139,8 +139,7 @@ class Proxy;
    * \brief A wrapper class that enables constraints on groups of Tables
    *****************************************************************************
   */
-class AggregateTable : public std::enable_shared_from_this<AggregateTable>,
-                       public Verifiable
+class AggregateTable : public Verifiable
 {
 public:
   AggregateTable(std::vector<std::reference_wrapper<Verifiable>>&& tables)
@@ -206,7 +205,7 @@ private:
  * \see Inlet Field
  *******************************************************************************
  */
-class Table : public std::enable_shared_from_this<Table>, public Verifiable
+class Table : public Verifiable
 {
 public:
   /*!

--- a/src/axom/inlet/Verifiable.hpp
+++ b/src/axom/inlet/Verifiable.hpp
@@ -14,7 +14,6 @@
 #ifndef INLET_VERIFIABLE_HPP
 #define INLET_VERIFIABLE_HPP
 
-#include <memory>
 #include <functional>
 
 namespace axom
@@ -39,6 +38,8 @@ class Table;
 class Verifiable
 {
 public:
+  // Should not be reassignable
+  Verifiable& operator=(const Verifiable&) = delete;
   /*!
    *****************************************************************************
    * \brief Set the required status of this object.
@@ -51,7 +52,7 @@ public:
    * \return Shared pointer to calling object, for chaining
    *****************************************************************************
    */
-  virtual std::shared_ptr<Verifiable> required(bool isRequired = true) = 0;
+  virtual Verifiable& required(bool isRequired = true) = 0;
 
   /*!
    *****************************************************************************
@@ -73,7 +74,7 @@ public:
    * \param [in] The function object.
    *****************************************************************************
   */
-  virtual std::shared_ptr<Verifiable> registerVerifier(
+  virtual Verifiable& registerVerifier(
     std::function<bool(const axom::inlet::Table&)> lambda) = 0;
 
   /*!

--- a/src/axom/inlet/Verifiable.hpp
+++ b/src/axom/inlet/Verifiable.hpp
@@ -49,7 +49,7 @@ public:
    *
    * \param [in] isRequired Boolean value of whether object is required
    *
-   * \return Shared pointer to calling object, for chaining
+   * \return Reference to calling object, for chaining
    *****************************************************************************
    */
   virtual Verifiable& required(bool isRequired = true) = 0;

--- a/src/axom/inlet/VerifiableScalar.hpp
+++ b/src/axom/inlet/VerifiableScalar.hpp
@@ -55,7 +55,7 @@ public:
    * \return Shared pointer to calling object, for chaining
    *****************************************************************************
    */
-  virtual std::shared_ptr<VerifiableScalar> required(bool isRequired = true) = 0;
+  virtual VerifiableScalar& required(bool isRequired = true) = 0;
 
   /*!
    *****************************************************************************
@@ -77,7 +77,7 @@ public:
    * \param [in] The function object.
    *****************************************************************************
   */
-  virtual std::shared_ptr<VerifiableScalar> registerVerifier(
+  virtual VerifiableScalar& registerVerifier(
     std::function<bool(const axom::inlet::Field&)> lambda) = 0;
 
   /*!
@@ -91,8 +91,7 @@ public:
    * \return Shared pointer to calling object for chaining
    *****************************************************************************
   */
-  virtual std::shared_ptr<VerifiableScalar> defaultValue(
-    const std::string& value) = 0;
+  virtual VerifiableScalar& defaultValue(const std::string& value) = 0;
   /*!
    *****************************************************************************
    * \brief Set the default value of this object.
@@ -104,7 +103,7 @@ public:
    * \return Shared pointer to calling object for chaining
    *****************************************************************************
   */
-  virtual std::shared_ptr<VerifiableScalar> defaultValue(const char* value) = 0;
+  virtual VerifiableScalar& defaultValue(const char* value) = 0;
 
   /*!
    *****************************************************************************
@@ -117,7 +116,7 @@ public:
    * \return Shared pointer to calling object for chaining
    *****************************************************************************
   */
-  virtual std::shared_ptr<VerifiableScalar> defaultValue(bool value) = 0;
+  virtual VerifiableScalar& defaultValue(bool value) = 0;
 
   /*!
    *****************************************************************************
@@ -130,7 +129,7 @@ public:
    * \return Shared pointer to calling object for chaining
    *****************************************************************************
   */
-  virtual std::shared_ptr<VerifiableScalar> defaultValue(int value) = 0;
+  virtual VerifiableScalar& defaultValue(int value) = 0;
 
   /*!
    *****************************************************************************
@@ -143,7 +142,7 @@ public:
    * \return Shared pointer to calling object for chaining
    *****************************************************************************
   */
-  virtual std::shared_ptr<VerifiableScalar> defaultValue(double value) = 0;
+  virtual VerifiableScalar& defaultValue(double value) = 0;
 
   /*!
    *****************************************************************************
@@ -158,8 +157,7 @@ public:
    * \return Shared pointer to calling object for chaining
    *****************************************************************************
   */
-  virtual std::shared_ptr<VerifiableScalar> range(double startVal,
-                                                  double endVal) = 0;
+  virtual VerifiableScalar& range(double startVal, double endVal) = 0;
 
   /*!
    *****************************************************************************
@@ -174,7 +172,7 @@ public:
    * \return Shared pointer to calling object for chaining
    *****************************************************************************
   */
-  virtual std::shared_ptr<VerifiableScalar> range(int startVal, int endVal) = 0;
+  virtual VerifiableScalar& range(int startVal, int endVal) = 0;
 
   /*!
    *****************************************************************************
@@ -185,8 +183,7 @@ public:
    * \return Shared pointer to calling object for chaining
    *****************************************************************************
   */
-  virtual std::shared_ptr<VerifiableScalar> validValues(
-    const std::vector<int>& set) = 0;
+  virtual VerifiableScalar& validValues(const std::vector<int>& set) = 0;
 
   /*!
    *****************************************************************************
@@ -197,8 +194,7 @@ public:
    * \return Shared pointer to calling object for chaining
    *****************************************************************************
   */
-  virtual std::shared_ptr<VerifiableScalar> validValues(
-    const std::vector<double>& set) = 0;
+  virtual VerifiableScalar& validValues(const std::vector<double>& set) = 0;
 
   /*!
    *****************************************************************************
@@ -209,8 +205,7 @@ public:
    * \return Shared pointer to calling object for chaining
    *****************************************************************************
   */
-  virtual std::shared_ptr<VerifiableScalar> validValues(
-    const std::vector<std::string>& set) = 0;
+  virtual VerifiableScalar& validValues(const std::vector<std::string>& set) = 0;
 
   /*!
    *****************************************************************************
@@ -222,7 +217,7 @@ public:
    * \return Shared pointer to calling object for chaining
    *****************************************************************************
   */
-  virtual std::shared_ptr<VerifiableScalar> validValues(
+  virtual VerifiableScalar& validValues(
     const std::initializer_list<const char*>& set) = 0;
 
   /*!
@@ -234,8 +229,7 @@ public:
    * \return Shared pointer to calling object for chaining
    *****************************************************************************
   */
-  virtual std::shared_ptr<VerifiableScalar> validValues(
-    const std::initializer_list<int>& set) = 0;
+  virtual VerifiableScalar& validValues(const std::initializer_list<int>& set) = 0;
 
   /*!
    *****************************************************************************
@@ -246,8 +240,7 @@ public:
    * \return Shared pointer to calling object for chaining
    *****************************************************************************
   */
-  virtual std::shared_ptr<VerifiableScalar> validValues(
-    const std::initializer_list<double>& set) = 0;
+  virtual VerifiableScalar& validValues(const std::initializer_list<double>& set) = 0;
 
   /*!
    *****************************************************************************

--- a/src/axom/inlet/VerifiableScalar.hpp
+++ b/src/axom/inlet/VerifiableScalar.hpp
@@ -43,6 +43,8 @@ class Field;
 class VerifiableScalar
 {
 public:
+  // Should not be reassignable
+  VerifiableScalar& operator=(const VerifiableScalar&) = delete;
   /*!
    *****************************************************************************
    * \brief Set the required status of this object.

--- a/src/axom/inlet/VerifiableScalar.hpp
+++ b/src/axom/inlet/VerifiableScalar.hpp
@@ -54,7 +54,7 @@ public:
    *
    * \param [in] isRequired Boolean value of whether object is required
    *
-   * \return Shared pointer to calling object, for chaining
+   * \return Reference to calling object, for chaining
    *****************************************************************************
    */
   virtual VerifiableScalar& required(bool isRequired = true) = 0;
@@ -90,7 +90,7 @@ public:
    *
    * \param [in] value The default string value
    *
-   * \return Shared pointer to calling object for chaining
+   * \return Reference to calling object for chaining
    *****************************************************************************
   */
   virtual VerifiableScalar& defaultValue(const std::string& value) = 0;
@@ -102,7 +102,7 @@ public:
    *
    * \param [in] value The default string value
    *
-   * \return Shared pointer to calling object for chaining
+   * \return Reference to calling object for chaining
    *****************************************************************************
   */
   virtual VerifiableScalar& defaultValue(const char* value) = 0;
@@ -115,7 +115,7 @@ public:
    *
    * \param [in] value The default boolean value
    *
-   * \return Shared pointer to calling object for chaining
+   * \return Reference to calling object for chaining
    *****************************************************************************
   */
   virtual VerifiableScalar& defaultValue(bool value) = 0;
@@ -128,7 +128,7 @@ public:
    *
    * \param [in] value The default integer value
    *
-   * \return Shared pointer to calling object for chaining
+   * \return Reference to calling object for chaining
    *****************************************************************************
   */
   virtual VerifiableScalar& defaultValue(int value) = 0;
@@ -141,7 +141,7 @@ public:
    *
    * \param [in] value The default double value
    *
-   * \return Shared pointer to calling object for chaining
+   * \return Reference to calling object for chaining
    *****************************************************************************
   */
   virtual VerifiableScalar& defaultValue(double value) = 0;
@@ -156,7 +156,7 @@ public:
    * 
    * \param [in] endVal The end of the range
    *
-   * \return Shared pointer to calling object for chaining
+   * \return Reference to calling object for chaining
    *****************************************************************************
   */
   virtual VerifiableScalar& range(double startVal, double endVal) = 0;
@@ -171,7 +171,7 @@ public:
    * 
    * \param [in] endVal The end of the range
    *
-   * \return Shared pointer to calling object for chaining
+   * \return Reference to calling object for chaining
    *****************************************************************************
   */
   virtual VerifiableScalar& range(int startVal, int endVal) = 0;
@@ -182,7 +182,7 @@ public:
    *
    * \param [in] set An vector containing the set of allowed integer values
    *
-   * \return Shared pointer to calling object for chaining
+   * \return Reference to calling object for chaining
    *****************************************************************************
   */
   virtual VerifiableScalar& validValues(const std::vector<int>& set) = 0;
@@ -193,7 +193,7 @@ public:
    *
    * \param [in] set An vector containing the set of allowed double values
    *
-   * \return Shared pointer to calling object for chaining
+   * \return Reference to calling object for chaining
    *****************************************************************************
   */
   virtual VerifiableScalar& validValues(const std::vector<double>& set) = 0;
@@ -204,7 +204,7 @@ public:
    *
    * \param [in] set A vector containing the set of allowed string values
    *
-   * \return Shared pointer to calling object for chaining
+   * \return Reference to calling object for chaining
    *****************************************************************************
   */
   virtual VerifiableScalar& validValues(const std::vector<std::string>& set) = 0;
@@ -216,7 +216,7 @@ public:
    * \param [in] set An initializer list containing the set of allowed C-string 
    * values
    *
-   * \return Shared pointer to calling object for chaining
+   * \return Reference to calling object for chaining
    *****************************************************************************
   */
   virtual VerifiableScalar& validValues(
@@ -228,7 +228,7 @@ public:
    *
    * \param [in] set An initializer list containing the valid integer values
    *
-   * \return Shared pointer to calling object for chaining
+   * \return Reference to calling object for chaining
    *****************************************************************************
   */
   virtual VerifiableScalar& validValues(const std::initializer_list<int>& set) = 0;
@@ -239,7 +239,7 @@ public:
    *
    * \param [in] set An initializer list containing the valid double values
    *
-   * \return Shared pointer to calling object for chaining
+   * \return Reference to calling object for chaining
    *****************************************************************************
   */
   virtual VerifiableScalar& validValues(const std::initializer_list<double>& set) = 0;

--- a/src/axom/inlet/examples/arrays.cpp
+++ b/src/axom/inlet/examples/arrays.cpp
@@ -18,11 +18,11 @@ int main()
   axom::sidre::DataStore ds;
 
   // Initialize Inlet
-  auto inlet = std::make_shared<axom::inlet::Inlet>(lr, ds.getRoot());
+  axom::inlet::Inlet inlet(lr, ds.getRoot());
 
   // Register the verifier, which will verify the array values
-  auto vals = inlet->getGlobalTable()->addStringArray("values");
-  vals->registerVerifier([](axom::inlet::Table& table) -> bool {
+  auto& vals = inlet.getGlobalTable().addStringArray("values");
+  vals.registerVerifier([](const axom::inlet::Table& table) -> bool {
     auto map = table.get<std::unordered_map<int, std::string>>();
     bool startFound = false;
     bool stopFound = false;
@@ -43,11 +43,11 @@ int main()
   });
 
   // We expect verfication to pass since values array has 3 elements
-  inlet->verify() ? std::cout << "Verification passed\n"
-                  : std::cout << "Verification failed\n";
+  inlet.verify() ? std::cout << "Verification passed\n"
+                 : std::cout << "Verification failed\n";
 
   // Print contents of map
-  std::unordered_map<int, std::string> map = (*inlet)["values"];
+  std::unordered_map<int, std::string> map = inlet["values"];
   std::cout << "\nMap Contents:\n";
   for(auto p : map)
   {

--- a/src/axom/inlet/examples/arrays.cpp
+++ b/src/axom/inlet/examples/arrays.cpp
@@ -10,7 +10,7 @@
 
 int main()
 {
-  auto lr = axom::inlet::cpp11_compat::make_unique<axom::inlet::LuaReader>();
+  auto lr = std::make_unique<axom::inlet::LuaReader>();
 
   // Parse example input file
   lr->parseString("values = { [1] = 'start', [2] = 'stop', [3] = 'pause' }");

--- a/src/axom/inlet/examples/arrays.cpp
+++ b/src/axom/inlet/examples/arrays.cpp
@@ -10,7 +10,7 @@
 
 int main()
 {
-  auto lr = std::make_unique<axom::inlet::LuaReader>();
+  auto lr = axom::inlet::cpp11_compat::make_unique<axom::inlet::LuaReader>();
 
   // Parse example input file
   lr->parseString("values = { [1] = 'start', [2] = 'stop', [3] = 'pause' }");

--- a/src/axom/inlet/examples/arrays.cpp
+++ b/src/axom/inlet/examples/arrays.cpp
@@ -10,7 +10,7 @@
 
 int main()
 {
-  auto lr = std::make_shared<axom::inlet::LuaReader>();
+  auto lr = std::make_unique<axom::inlet::LuaReader>();
 
   // Parse example input file
   lr->parseString("values = { [1] = 'start', [2] = 'stop', [3] = 'pause' }");
@@ -18,7 +18,7 @@ int main()
   axom::sidre::DataStore ds;
 
   // Initialize Inlet
-  axom::inlet::Inlet inlet(lr, ds.getRoot());
+  axom::inlet::Inlet inlet(std::move(lr), ds.getRoot());
 
   // Register the verifier, which will verify the array values
   auto& vals = inlet.getGlobalTable().addStringArray("values");

--- a/src/axom/inlet/examples/documentation_generation.cpp
+++ b/src/axom/inlet/examples/documentation_generation.cpp
@@ -10,15 +10,16 @@
 
 #include "CLI11/CLI11.hpp"
 #include <iostream>
+#include <limits>
 
 using axom::inlet::Inlet;
 using axom::inlet::LuaReader;
 using axom::inlet::SphinxDocWriter;
 using axom::sidre::DataStore;
 
-void findStr(std::string path, std::shared_ptr<Inlet> inlet)
+void findStr(std::string path, const Inlet& inlet)
 {
-  auto proxy = (*inlet)[path];
+  auto proxy = inlet[path];
   if(proxy.type() == axom::inlet::InletType::String)
   {
     std::cout << "found " << proxy.get<std::string>();
@@ -30,9 +31,9 @@ void findStr(std::string path, std::shared_ptr<Inlet> inlet)
   std::cout << std::endl;
 }
 
-void findInt(std::string path, std::shared_ptr<Inlet> inlet)
+void findInt(std::string path, const Inlet& inlet)
 {
-  auto proxy = (*inlet)[path];
+  auto proxy = inlet[path];
   if(proxy.type() == axom::inlet::InletType::Integer)
   {
     std::cout << "found " << proxy.get<int>();
@@ -44,9 +45,9 @@ void findInt(std::string path, std::shared_ptr<Inlet> inlet)
   std::cout << std::endl;
 }
 
-void findDouble(std::string path, std::shared_ptr<Inlet> inlet)
+void findDouble(std::string path, const Inlet& inlet)
 {
-  auto proxy = (*inlet)[path];
+  auto proxy = inlet[path];
   if(proxy.type() == axom::inlet::InletType::Double)
   {
     std::cout << "found " << proxy.get<double>();
@@ -58,91 +59,90 @@ void findDouble(std::string path, std::shared_ptr<Inlet> inlet)
   std::cout << std::endl;
 }
 
-void defineSchema(std::shared_ptr<Inlet> inlet)
+void defineSchema(Inlet& inlet)
 {
   // Add the description to the thermal_solver/mesh/filename Field
-  auto currVerifiable =
-    inlet->addString("thermal_solver/mesh/filename", "file for thermal solver");
+  auto& filename_field =
+    inlet.addString("thermal_solver/mesh/filename", "file for thermal solver");
   // Set the field's required property to true
-  currVerifiable->required(true);
+  filename_field.required();
 
-  currVerifiable = inlet->addInt("thermal_solver/mesh/serial", "serial value");
-  currVerifiable->range(0, INT_MAX);
-  currVerifiable->defaultValue(1);
+  inlet.addInt("thermal_solver/mesh/serial", "serial value")
+    .range(0, std::numeric_limits<int>::max())
+    .defaultValue(1);
 
   // The description for thermal_solver/mesh/parallel is left unspecified
-  currVerifiable = inlet->addInt("thermal_solver/mesh/parallel");
-  currVerifiable->range(1, INT_MAX);
-  currVerifiable->defaultValue(1);
+  inlet.addInt("thermal_solver/mesh/parallel")
+    .range(1, std::numeric_limits<int>::max())
+    .defaultValue(1);
 
-  currVerifiable = inlet->addInt("thermal_solver/order", "thermal solver order");
-  currVerifiable->required(true);
-  currVerifiable->range(1, INT_MAX);
+  inlet.addInt("thermal_solver/order", "thermal solver order")
+    .required()
+    .range(1, std::numeric_limits<int>::max());
 
-  currVerifiable =
-    inlet->addString("thermal_solver/timestepper", "thermal solver timestepper");
-  currVerifiable->defaultValue("quasistatic");
-  currVerifiable->validValues({"quasistatic", "forwardeuler", "backwardeuler"});
+  auto& timestep_field =
+    inlet.addString("thermal_solver/timestepper", "thermal solver timestepper");
+  timestep_field.defaultValue("quasistatic")
+    .validValues({"quasistatic", "forwardeuler", "backwardeuler"});
 
-  currVerifiable =
-    inlet->addString("thermal_solver/u0/type", "description for u0 type");
-  currVerifiable->defaultValue("constant");
-  currVerifiable->validValues({"constant", "function"});
+  auto& coef_type_field =
+    inlet.addString("thermal_solver/u0/type", "description for u0 type");
+  coef_type_field.defaultValue("constant").validValues({"constant", "function"});
 
-  currVerifiable =
-    inlet->addString("thermal_solver/u0/func", "description for u0 func");
-  currVerifiable->required(true);
+  inlet.addString("thermal_solver/u0/func", "description for u0 func").required();
 
-  currVerifiable =
-    inlet->addString("thermal_solver/kappa/type", "description for kappa type");
-  currVerifiable->required(true);
-  currVerifiable->validValues({"constant", "function"});
+  inlet.addString("thermal_solver/kappa/type", "description for kappa type")
+    .required()
+    .validValues({"constant", "function"});
 
-  currVerifiable = inlet->addDouble("thermal_solver/kappa/constant",
-                                    "description for kappa constant");
-  currVerifiable->required(true);
+  inlet
+    .addDouble("thermal_solver/kappa/constant", "description for kappa constant")
+    .required();
 
   // Add description to solver table by using the addTable function
-  auto table =
-    inlet->addTable("thermal_solver/solver",
-                    "This is the solver sub-table in the thermal_solver table");
+  auto& table =
+    inlet.addTable("thermal_solver/solver",
+                   "This is the solver sub-table in the thermal_solver table");
 
   // You can also add fields through a table
 
-  currVerifiable = table->addDouble("rel_tol", "description for solver rel tol");
-  currVerifiable->required(false);
-  currVerifiable->defaultValue(1.e-6);
-  currVerifiable->range(0.0, __DBL_MAX__);
+  auto& rel_tol_field =
+    table.addDouble("rel_tol", "description for solver rel tol");
+  rel_tol_field.required(false);
+  rel_tol_field.defaultValue(1.e-6);
+  rel_tol_field.range(0.0, std::numeric_limits<double>::max());
 
-  currVerifiable = table->addDouble("abs_tol", "description for solver abs tol");
-  currVerifiable->required(true);
-  currVerifiable->defaultValue(1.e-12);
-  currVerifiable->range(0.0, __DBL_MAX__);
+  auto& abs_tol_field =
+    table.addDouble("abs_tol", "description for solver abs tol");
+  abs_tol_field.required(true);
+  abs_tol_field.defaultValue(1.e-12);
+  abs_tol_field.range(0.0, std::numeric_limits<double>::max());
 
-  currVerifiable =
-    table->addInt("print_level", "description for solver print level");
-  currVerifiable->required(true);
-  currVerifiable->defaultValue(0);
-  currVerifiable->range(0, 3);
+  auto& print_level_field =
+    table.addInt("print_level", "description for solver print level");
+  print_level_field.required(true);
+  print_level_field.defaultValue(0);
+  print_level_field.range(0, 3);
 
-  currVerifiable = table->addInt("max_iter", "description for solver max iter");
-  currVerifiable->required(false);
-  currVerifiable->defaultValue(100);
-  currVerifiable->range(1, INT_MAX);
+  auto& max_iter_field =
+    table.addInt("max_iter", "description for solver max iter");
+  max_iter_field.required(false);
+  max_iter_field.defaultValue(100);
+  max_iter_field.range(1, std::numeric_limits<int>::max());
 
-  currVerifiable = table->addDouble("dt", "description for solver dt");
-  currVerifiable->required(true);
-  currVerifiable->defaultValue(1);
-  currVerifiable->range(0.0, __DBL_MAX__);
+  auto& dt_field = table.addDouble("dt", "description for solver dt");
+  dt_field.required(true);
+  dt_field.defaultValue(1);
+  dt_field.range(0.0, std::numeric_limits<double>::max());
 
-  currVerifiable = table->addInt("steps", "description for solver steps");
-  currVerifiable->required(true);
-  currVerifiable->defaultValue(1);
-  currVerifiable->range(1, INT_MAX);
+  auto& steps_field = table.addInt("steps", "description for solver steps");
+  steps_field.required(true);
+  steps_field.defaultValue(1);
+  steps_field.range(1, std::numeric_limits<int>::max());
 }
 
 // Checking the contents of the passed inlet
-void checkValues(std::shared_ptr<Inlet> inlet)
+void checkValues(const Inlet& inlet)
 {
   findStr("thermal_solver/mesh/filename", inlet);
   findStr("thermal_solver/timestepper", inlet);
@@ -163,7 +163,7 @@ void checkValues(std::shared_ptr<Inlet> inlet)
   findDouble("thermal_solver/kappa/constant", inlet);
 
   // Verify that contents of Inlet meet the requirements of the specified schema
-  if(inlet->verify())
+  if(inlet.verify())
   {
     SLIC_INFO("Inlet verify successful.");
   }
@@ -194,19 +194,19 @@ int main(int argc, char** argv)
   DataStore ds;
   auto lr = std::make_shared<LuaReader>();
   lr->parseFile(inputFileName);
-  auto inlet = std::make_shared<Inlet>(lr, ds.getRoot(), docsEnabled);
+  Inlet inlet(lr, ds.getRoot(), docsEnabled);
 
   // _inlet_documentation_generation_start
   auto docWriter =
-    std::make_shared<SphinxDocWriter>("example_doc.rst", inlet->sidreGroup());
-  inlet->registerDocWriter(docWriter);
+    std::make_shared<SphinxDocWriter>("example_doc.rst", inlet.sidreGroup());
+  inlet.registerDocWriter(docWriter);
   // _inlet_documentation_generation_end
 
   defineSchema(inlet);
   checkValues(inlet);
 
   // Generate the documentation
-  inlet->writeDoc();
+  inlet.writeDoc();
 
   if(docsEnabled)
   {

--- a/src/axom/inlet/examples/documentation_generation.cpp
+++ b/src/axom/inlet/examples/documentation_generation.cpp
@@ -192,14 +192,14 @@ int main(int argc, char** argv)
   // Create inlet and parse input file data into the inlet
 
   DataStore ds;
-  auto lr = std::make_shared<LuaReader>();
+  auto lr = std::make_unique<LuaReader>();
   lr->parseFile(inputFileName);
-  Inlet inlet(lr, ds.getRoot(), docsEnabled);
+  Inlet inlet(std::move(lr), ds.getRoot(), docsEnabled);
 
   // _inlet_documentation_generation_start
   auto docWriter =
-    std::make_shared<SphinxDocWriter>("example_doc.rst", inlet.sidreGroup());
-  inlet.registerDocWriter(docWriter);
+    std::make_unique<SphinxDocWriter>("example_doc.rst", inlet.sidreGroup());
+  inlet.registerDocWriter(std::move(docWriter));
   // _inlet_documentation_generation_end
 
   defineSchema(inlet);

--- a/src/axom/inlet/examples/documentation_generation.cpp
+++ b/src/axom/inlet/examples/documentation_generation.cpp
@@ -192,14 +192,13 @@ int main(int argc, char** argv)
   // Create inlet and parse input file data into the inlet
 
   DataStore ds;
-  auto lr = axom::inlet::cpp11_compat::make_unique<LuaReader>();
+  auto lr = std::make_unique<LuaReader>();
   lr->parseFile(inputFileName);
   Inlet inlet(std::move(lr), ds.getRoot(), docsEnabled);
 
   // _inlet_documentation_generation_start
   auto docWriter =
-    axom::inlet::cpp11_compat::make_unique<SphinxDocWriter>("example_doc.rst",
-                                                            inlet.sidreGroup());
+    std::make_unique<SphinxDocWriter>("example_doc.rst", inlet.sidreGroup());
   inlet.registerDocWriter(std::move(docWriter));
   // _inlet_documentation_generation_end
 

--- a/src/axom/inlet/examples/documentation_generation.cpp
+++ b/src/axom/inlet/examples/documentation_generation.cpp
@@ -192,13 +192,14 @@ int main(int argc, char** argv)
   // Create inlet and parse input file data into the inlet
 
   DataStore ds;
-  auto lr = std::make_unique<LuaReader>();
+  auto lr = axom::inlet::cpp11_compat::make_unique<LuaReader>();
   lr->parseFile(inputFileName);
   Inlet inlet(std::move(lr), ds.getRoot(), docsEnabled);
 
   // _inlet_documentation_generation_start
   auto docWriter =
-    std::make_unique<SphinxDocWriter>("example_doc.rst", inlet.sidreGroup());
+    axom::inlet::cpp11_compat::make_unique<SphinxDocWriter>("example_doc.rst",
+                                                            inlet.sidreGroup());
   inlet.registerDocWriter(std::move(docWriter));
   // _inlet_documentation_generation_end
 

--- a/src/axom/inlet/examples/user_defined_type.cpp
+++ b/src/axom/inlet/examples/user_defined_type.cpp
@@ -208,9 +208,9 @@ int main(int argc, char** argv)
   CLI11_PARSE(app, argc, argv);
 
   DataStore ds;
-  auto lr = std::make_shared<LuaReader>();
+  auto lr = std::make_unique<LuaReader>();
   lr->parseFile(inputFileName);
-  Inlet inlet(lr, ds.getRoot());
+  Inlet inlet(std::move(lr), ds.getRoot());
 
   // Create a table off the global table for the thermal_solver object
   // then define its schema

--- a/src/axom/inlet/examples/user_defined_type.cpp
+++ b/src/axom/inlet/examples/user_defined_type.cpp
@@ -208,7 +208,7 @@ int main(int argc, char** argv)
   CLI11_PARSE(app, argc, argv);
 
   DataStore ds;
-  auto lr = axom::inlet::cpp11_compat::make_unique<LuaReader>();
+  auto lr = std::make_unique<LuaReader>();
   lr->parseFile(inputFileName);
   Inlet inlet(std::move(lr), ds.getRoot());
 

--- a/src/axom/inlet/examples/user_defined_type.cpp
+++ b/src/axom/inlet/examples/user_defined_type.cpp
@@ -146,17 +146,18 @@ struct ThermalSolver
   // subobject defineSchema implementations
   static void defineSchema(inlet::Table& schema)
   {
-    auto mesh_table = schema.addTable("mesh", "Information about the mesh");
-    Mesh::defineSchema(*mesh_table);
-    auto solver_table =
+    auto& mesh_table = schema.addTable("mesh", "Information about the mesh");
+    Mesh::defineSchema(mesh_table);
+    auto& solver_table =
       schema.addTable("solver",
                       "Information about the iterative solver used for Ku = f");
-    LinearSolver::defineSchema(*solver_table);
+    LinearSolver::defineSchema(solver_table);
 
     // Schema only needs to be defined once, will propagate through to each
     // element of the array, namely, the subtable at each found index in the input file
-    auto bc_table = schema.addGenericArray("bcs", "List of boundary conditions");
-    BoundaryCondition::defineSchema(*bc_table);
+    auto& bc_table =
+      schema.addGenericArray("bcs", "List of boundary conditions");
+    BoundaryCondition::defineSchema(bc_table);
   }
 };
 
@@ -209,20 +210,20 @@ int main(int argc, char** argv)
   DataStore ds;
   auto lr = std::make_shared<LuaReader>();
   lr->parseFile(inputFileName);
-  auto inlet = std::make_shared<Inlet>(lr, ds.getRoot());
+  Inlet inlet(lr, ds.getRoot());
 
   // Create a table off the global table for the thermal_solver object
   // then define its schema
-  auto thermal_solver_table =
-    inlet->addTable("thermal_solver",
-                    "Configuration for a thermal conduction module");
-  ThermalSolver::defineSchema(*thermal_solver_table);
+  auto& thermal_solver_table =
+    inlet.addTable("thermal_solver",
+                   "Configuration for a thermal conduction module");
+  ThermalSolver::defineSchema(thermal_solver_table);
 
-  if(!inlet->verify())
+  if(!inlet.verify())
   {
     SLIC_ERROR("Inlet failed to verify against provided schema");
   }
 
   // Read all the data into a thermal solver object
-  auto thermal_solver = (*inlet)["thermal_solver"].get<ThermalSolver>();
+  auto thermal_solver = inlet["thermal_solver"].get<ThermalSolver>();
 }

--- a/src/axom/inlet/examples/user_defined_type.cpp
+++ b/src/axom/inlet/examples/user_defined_type.cpp
@@ -208,7 +208,7 @@ int main(int argc, char** argv)
   CLI11_PARSE(app, argc, argv);
 
   DataStore ds;
-  auto lr = std::make_unique<LuaReader>();
+  auto lr = axom::inlet::cpp11_compat::make_unique<LuaReader>();
   lr->parseFile(inputFileName);
   Inlet inlet(std::move(lr), ds.getRoot());
 

--- a/src/axom/inlet/examples/verification.cpp
+++ b/src/axom/inlet/examples/verification.cpp
@@ -14,10 +14,10 @@ int main()
   axom::slic::UnitTestLogger logger;
 
   // Initialize Inlet
-  auto lr = std::make_shared<axom::inlet::LuaReader>();
+  auto lr = std::make_unique<axom::inlet::LuaReader>();
   lr->parseString("dimensions = 2; vector = { x = 1.0; y = 2.0; z = 3.0; }");
   axom::sidre::DataStore ds;
-  axom::inlet::Inlet myInlet(lr, ds.getRoot());
+  axom::inlet::Inlet myInlet(std::move(lr), ds.getRoot());
 
   // _inlet_workflow_defining_schema_start
   // defines a required global field named "dimensions" with a default value of 2

--- a/src/axom/inlet/examples/verification.cpp
+++ b/src/axom/inlet/examples/verification.cpp
@@ -14,7 +14,7 @@ int main()
   axom::slic::UnitTestLogger logger;
 
   // Initialize Inlet
-  auto lr = axom::inlet::cpp11_compat::make_unique<axom::inlet::LuaReader>();
+  auto lr = std::make_unique<axom::inlet::LuaReader>();
   lr->parseString("dimensions = 2; vector = { x = 1.0; y = 2.0; z = 3.0; }");
   axom::sidre::DataStore ds;
   axom::inlet::Inlet myInlet(std::move(lr), ds.getRoot());

--- a/src/axom/inlet/examples/verification.cpp
+++ b/src/axom/inlet/examples/verification.cpp
@@ -17,21 +17,20 @@ int main()
   auto lr = std::make_shared<axom::inlet::LuaReader>();
   lr->parseString("dimensions = 2; vector = { x = 1.0; y = 2.0; z = 3.0; }");
   axom::sidre::DataStore ds;
-  auto myInlet = std::make_shared<axom::inlet::Inlet>(lr, ds.getRoot());
+  axom::inlet::Inlet myInlet(lr, ds.getRoot());
 
   // _inlet_workflow_defining_schema_start
   // defines a required global field named "dimensions" with a default value of 2
-  auto dimField = myInlet->addInt("dimensions")->required(true)->defaultValue(2);
+  myInlet.addInt("dimensions").required(true).defaultValue(2);
 
   // defines a required table named vector with an internal field named 'x'
-  auto v = myInlet->addTable("vector");
-  v->required(true);
-  v->addDouble("x");
+  auto& v = myInlet.addTable("vector").required(true);
+  v.addDouble("x");
   // _inlet_workflow_defining_schema_end
 
   // _inlet_workflow_verification_start
-  v->registerVerifier([&myInlet](axom::inlet::Table& table) -> bool {
-    int dim = (*myInlet)["dimensions"];
+  v.registerVerifier([&myInlet](const axom::inlet::Table& table) -> bool {
+    int dim = myInlet["dimensions"];
     bool x_present = table.contains("x") &&
       (table["x"].type() == axom::inlet::InletType::Double);
     bool y_present = table.contains("y") &&
@@ -57,25 +56,25 @@ int main()
   // We expect verification to be unsuccessful since the only Field
   // in vector is x but 2 dimensions are expected
   SLIC_INFO("This should fail due to a missing dimension:");
-  myInlet->verify() ? msg = "Verification was successful\n"
-                    : msg = "Verification was unsuccessful\n";
+  myInlet.verify() ? msg = "Verification was successful\n"
+                   : msg = "Verification was unsuccessful\n";
   SLIC_INFO(msg);
 
   // Add required dimension to schema
-  v->addDouble("y");
+  v.addDouble("y");
 
   // We expect the verification to succeed because vector now contains
   // both x and y to match the 2 dimensions
   SLIC_INFO("After adding the required dimension:");
-  myInlet->verify() ? msg = "Verification was successful\n"
-                    : msg = "Verification was unsuccessful\n";
+  myInlet.verify() ? msg = "Verification was successful\n"
+                   : msg = "Verification was unsuccessful\n";
   SLIC_INFO(msg);
   // _inlet_workflow_verification_end
 
   // _inlet_workflow_accessing_data_start
 
   // Get dimensions if it was present in input file
-  auto proxy = (*myInlet)["dimensions"];
+  auto proxy = myInlet["dimensions"];
   if(proxy.type() == axom::inlet::InletType::Integer)
   {
     msg = "Dimensions = " + std::to_string(proxy.get<int>()) + "\n";
@@ -83,12 +82,12 @@ int main()
   }
 
   // Get vector information if it was present in input file
-  bool x_found = (*myInlet)["vector/x"].type() == axom::inlet::InletType::Double;
-  bool y_found = (*myInlet)["vector/y"].type() == axom::inlet::InletType::Double;
+  bool x_found = myInlet["vector/x"].type() == axom::inlet::InletType::Double;
+  bool y_found = myInlet["vector/y"].type() == axom::inlet::InletType::Double;
   if(x_found && y_found)
   {
-    msg = "Vector = " + std::to_string((*myInlet)["vector/x"].get<double>()) +
-      "," + std::to_string((*myInlet)["vector/y"].get<double>()) + "\n";
+    msg = "Vector = " + std::to_string(myInlet["vector/x"].get<double>()) +
+      "," + std::to_string(myInlet["vector/y"].get<double>()) + "\n";
     SLIC_INFO(msg);
   }
   // _inlet_workflow_accessing_data_end

--- a/src/axom/inlet/examples/verification.cpp
+++ b/src/axom/inlet/examples/verification.cpp
@@ -14,7 +14,7 @@ int main()
   axom::slic::UnitTestLogger logger;
 
   // Initialize Inlet
-  auto lr = std::make_unique<axom::inlet::LuaReader>();
+  auto lr = axom::inlet::cpp11_compat::make_unique<axom::inlet::LuaReader>();
   lr->parseString("dimensions = 2; vector = { x = 1.0; y = 2.0; z = 3.0; }");
   axom::sidre::DataStore ds;
   axom::inlet::Inlet myInlet(std::move(lr), ds.getRoot());

--- a/src/axom/inlet/inlet_utils.hpp
+++ b/src/axom/inlet/inlet_utils.hpp
@@ -3,6 +3,9 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+#include <memory>
+#include <utility>
+
 #include "axom/sidre.hpp"
 #include "fmt/fmt.hpp"
 #include "axom/core/utilities/StringUtilities.hpp"
@@ -48,6 +51,16 @@ std::string appendPrefix(const std::string& prefix, const std::string& name);
 *****************************************************************************
 */
 std::string removePrefix(const std::string& prefix, const std::string& name);
+
+namespace cpp11_compat
+{
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+}  // namespace cpp11_compat
 
 }  // namespace inlet
 }  // namespace axom

--- a/src/axom/inlet/inlet_utils.hpp
+++ b/src/axom/inlet/inlet_utils.hpp
@@ -54,7 +54,6 @@ std::string removePrefix(const std::string& prefix, const std::string& name);
 
 namespace cpp11_compat
 {
-
 /*!
 *****************************************************************************
 * \brief This function provides backwards compatibility for std::make_unique,

--- a/src/axom/inlet/inlet_utils.hpp
+++ b/src/axom/inlet/inlet_utils.hpp
@@ -54,6 +54,19 @@ std::string removePrefix(const std::string& prefix, const std::string& name);
 
 namespace cpp11_compat
 {
+
+/*!
+*****************************************************************************
+* \brief This function provides backwards compatibility for std::make_unique,
+* which is not implemented until C++14.  It should be removed when either
+* Axom or the Inlet component is no longer required to support C++11
+*
+* \tparam T The type to construct
+* \tparam Args The variadic argument list to forward to T's constructor
+*
+* \return A unique ptr constructed with the given arguments
+*****************************************************************************
+*/
 template <typename T, typename... Args>
 std::unique_ptr<T> make_unique(Args&&... args)
 {

--- a/src/axom/inlet/tests/inlet_Inlet.cpp
+++ b/src/axom/inlet/tests/inlet_Inlet.cpp
@@ -24,14 +24,14 @@ using axom::inlet::Proxy;
 using axom::inlet::Table;
 using axom::sidre::DataStore;
 
-std::shared_ptr<Inlet> createBasicInlet(DataStore* ds,
-                                        const std::string& luaString,
-                                        bool enableDocs = true)
+Inlet createBasicInlet(DataStore* ds,
+                       const std::string& luaString,
+                       bool enableDocs = true)
 {
   auto lr = std::make_shared<LuaReader>();
   lr->parseString(luaString);
 
-  return std::make_shared<Inlet>(lr, ds->getRoot(), enableDocs);
+  return Inlet(lr, ds->getRoot(), enableDocs);
 }
 
 TEST(inlet_Inlet_basic, getTopLevelBools)
@@ -45,15 +45,11 @@ TEST(inlet_Inlet_basic, getTopLevelBools)
   //
 
   // Check for existing fields
-  auto currVerifiable = inlet->addBool("foo", "foo's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable = inlet->addBool("bar", "bar's description");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addBool("foo", "foo's description");
+  inlet.addBool("bar", "bar's description");
 
   // Check one that doesn't exist and doesn't have a default value
-  currVerifiable = inlet->addBool("non/existant", "nothing");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addBool("non/existant", "nothing");
 
   //
   // Check stored values from get
@@ -62,20 +58,20 @@ TEST(inlet_Inlet_basic, getTopLevelBools)
   bool value = false;
 
   // Check for existing fields
-  value = (*inlet)["foo"];
+  value = inlet["foo"];
   EXPECT_TRUE(value);
 
-  value = inlet->get<bool>("foo");
+  value = inlet.get<bool>("foo");
   EXPECT_TRUE(value);
 
-  value = (*inlet)["bar"];
+  value = inlet["bar"];
   EXPECT_FALSE(value);
 
-  value = inlet->get<bool>("bar");
+  value = inlet.get<bool>("bar");
   EXPECT_FALSE(value);
 
   // Check one that doesn't exist and doesn't have a default value
-  auto table = (*inlet)["non/existant"];
+  auto table = inlet["non/existant"];
   EXPECT_EQ(table.type(), InletType::Nothing);
 }
 
@@ -90,15 +86,11 @@ TEST(inlet_Inlet_basic, getNestedBools)
   //
 
   // Check for existing fields
-  auto currVerifiable = inlet->addBool("foo/bar", "bar's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable = inlet->addBool("foo/baz", "baz's description");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addBool("foo/bar", "bar's description");
+  inlet.addBool("foo/baz", "baz's description");
 
   // Check one that doesn't exist and doesn't have a default value
-  currVerifiable = inlet->addBool("foo/nonexistant", "nothing");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addBool("foo/nonexistant", "nothing");
 
   //
   // Check stored values from get
@@ -107,14 +99,14 @@ TEST(inlet_Inlet_basic, getNestedBools)
   bool value = false;
 
   // Check for existing fields
-  value = (*inlet)["foo/bar"];
+  value = inlet["foo/bar"];
   EXPECT_TRUE(value);
 
-  value = (*inlet)["foo/baz"];
+  value = inlet["foo/baz"];
   EXPECT_FALSE(value);
 
   // Check one that doesn't exist and doesn't have a default value
-  auto table = (*inlet)["foo/nonexistant"];
+  auto table = inlet["foo/nonexistant"];
   EXPECT_EQ(table.type(), InletType::Nothing);
 }
 
@@ -129,15 +121,11 @@ TEST(inlet_Inlet_basic, getDoublyNestedBools)
   //
 
   // Check for existing fields
-  auto currVerifiable = inlet->addBool("foo/quux/bar", "bar's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable = inlet->addBool("foo/quux/baz", "baz's description");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addBool("foo/quux/bar", "bar's description");
+  inlet.addBool("foo/quux/baz", "baz's description");
 
   // Check one that doesn't exist and doesn't have a default value
-  currVerifiable = inlet->addBool("foo/quux/nonexistant", "nothing");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addBool("foo/quux/nonexistant", "nothing");
 
   //
   // Check stored values from get
@@ -146,14 +134,14 @@ TEST(inlet_Inlet_basic, getDoublyNestedBools)
   bool value = false;
 
   // Check for existing fields
-  value = (*inlet)["foo/quux/bar"];
+  value = inlet["foo/quux/bar"];
   EXPECT_TRUE(value);
 
-  value = (*inlet)["foo/quux/baz"];
+  value = inlet["foo/quux/baz"];
   EXPECT_FALSE(value);
 
   // Check one that doesn't exist and doesn't have a default value
-  auto table = (*inlet)["foo/quux/nonexistant"];
+  auto table = inlet["foo/quux/nonexistant"];
   EXPECT_EQ(table.type(), InletType::Nothing);
 }
 
@@ -170,18 +158,11 @@ TEST(inlet_Inlet_basic, getDeeplyNestedBools)
   //
 
   // Check for existing fields
-  auto currVerifiable =
-    inlet->addBool("foo/quux/corge/quuz/grault/bar", "bar's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable =
-    inlet->addBool("foo/quux/corge/quuz/grault/baz", "baz's description");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addBool("foo/quux/corge/quuz/grault/bar", "bar's description");
+  inlet.addBool("foo/quux/corge/quuz/grault/baz", "baz's description");
 
   // Check one that doesn't exist and doesn't have a default value
-  currVerifiable =
-    inlet->addBool("foo/quux/corge/quuz/grault/nonexistant", "nothing");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addBool("foo/quux/corge/quuz/grault/nonexistant", "nothing");
 
   //
   // Check stored values from get
@@ -190,14 +171,14 @@ TEST(inlet_Inlet_basic, getDeeplyNestedBools)
   bool value = false;
 
   // Check for existing fields
-  value = (*inlet)["foo/quux/corge/quuz/grault/bar"];
+  value = inlet["foo/quux/corge/quuz/grault/bar"];
   EXPECT_TRUE(value);
 
-  value = (*inlet)["foo/quux/corge/quuz/grault/baz"];
+  value = inlet["foo/quux/corge/quuz/grault/baz"];
   EXPECT_FALSE(value);
 
   // Check one that doesn't exist and doesn't have a default value
-  auto table = (*inlet)["foo/quux/corge/quuz/grault/nonexistant"];
+  auto table = inlet["foo/quux/corge/quuz/grault/nonexistant"];
   EXPECT_EQ(table.type(), InletType::Nothing);
 }
 
@@ -212,15 +193,11 @@ TEST(inlet_Inlet_basic, getNestedBoolsThroughTable)
   //
 
   // Check for existing fields
-  auto currVerifiable = inlet->addBool("foo/bar", "bar's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable = inlet->addBool("foo/baz", "baz's description");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addBool("foo/bar", "bar's description");
+  inlet.addBool("foo/baz", "baz's description");
 
   // Check one that doesn't exist and doesn't have a default value
-  currVerifiable = inlet->addBool("foo/nonexistant", "nothing");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addBool("foo/nonexistant", "nothing");
 
   //
   // Check stored values from get
@@ -229,17 +206,17 @@ TEST(inlet_Inlet_basic, getNestedBoolsThroughTable)
   bool value = false;
 
   // Grab the subtable
-  auto table = inlet->getTable("foo");
+  Table& table = inlet.getTable("foo");
 
   // Check for existing fields
-  value = (*table)["bar"];
+  value = table["bar"];
   EXPECT_TRUE(value);
 
-  value = (*table)["baz"];
+  value = table["baz"];
   EXPECT_FALSE(value);
 
   // Check one that doesn't exist and doesn't have a default value
-  auto proxy = (*table)["nonexistant"];
+  auto proxy = table["nonexistant"];
   EXPECT_EQ(proxy.type(), InletType::Nothing);
 }
 
@@ -256,18 +233,11 @@ TEST(inlet_Inlet_basic, getDeeplyNestedBoolsThroughTable)
   //
 
   // Check for existing fields
-  auto currVerifiable =
-    inlet->addBool("foo/quux/corge/quuz/grault/bar", "bar's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable =
-    inlet->addBool("foo/quux/corge/quuz/grault/baz", "baz's description");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addBool("foo/quux/corge/quuz/grault/bar", "bar's description");
+  inlet.addBool("foo/quux/corge/quuz/grault/baz", "baz's description");
 
   // Check one that doesn't exist and doesn't have a default value
-  currVerifiable =
-    inlet->addBool("foo/quux/corge/quuz/grault/nonexistant", "nothing");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addBool("foo/quux/corge/quuz/grault/nonexistant", "nothing");
 
   //
   // Check stored values from get
@@ -275,17 +245,17 @@ TEST(inlet_Inlet_basic, getDeeplyNestedBoolsThroughTable)
 
   bool value = false;
 
-  auto table = inlet->getTable("foo/quux/corge");
+  Table& table = inlet.getTable("foo/quux/corge");
 
   // Check for existing fields
-  value = (*table)["quuz/grault/bar"];
+  value = table["quuz/grault/bar"];
   EXPECT_TRUE(value);
 
-  value = (*table)["quuz/grault/baz"];
+  value = table["quuz/grault/baz"];
   EXPECT_FALSE(value);
 
   // Check one that doesn't exist and doesn't have a default value
-  auto proxy = (*table)["quuz/grault/nonexistant"];
+  auto proxy = table["quuz/grault/nonexistant"];
   EXPECT_EQ(proxy.type(), InletType::Nothing);
 }
 
@@ -302,18 +272,11 @@ TEST(inlet_Inlet_basic, getDeeplyNestedBoolsThroughField)
   //
 
   // Check for existing fields
-  auto currVerifiable =
-    inlet->addBool("foo/quux/corge/quuz/grault/bar", "bar's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable =
-    inlet->addBool("foo/quux/corge/quuz/grault/baz", "baz's description");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addBool("foo/quux/corge/quuz/grault/bar", "bar's description");
+  inlet.addBool("foo/quux/corge/quuz/grault/baz", "baz's description");
 
   // Check one that doesn't exist and doesn't have a default value
-  currVerifiable =
-    inlet->addBool("foo/quux/corge/quuz/grault/nonexistant", "nothing");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addBool("foo/quux/corge/quuz/grault/nonexistant", "nothing");
 
   //
   // Check stored values from get
@@ -321,17 +284,17 @@ TEST(inlet_Inlet_basic, getDeeplyNestedBoolsThroughField)
 
   bool value = false;
 
-  auto table = inlet->getTable("foo/quux/corge");
+  Table& table = inlet.getTable("foo/quux/corge");
 
   // Check for existing fields
-  value = (*table)["quuz/grault/bar"];
+  value = table["quuz/grault/bar"];
   EXPECT_TRUE(value);
 
-  value = (*table)["quuz/grault/baz"];
+  value = table["quuz/grault/baz"];
   EXPECT_FALSE(value);
 
   // Check one that doesn't exist and doesn't have a default value
-  auto nonexistant_field = (*table)["quuz/grault/nonexistant"];
+  auto nonexistant_field = table["quuz/grault/nonexistant"];
   EXPECT_EQ(nonexistant_field.type(), InletType::Nothing);
 }
 
@@ -346,15 +309,11 @@ TEST(inlet_Inlet_basic, getTopLevelDoubles)
   //
 
   // Check for existing fields
-  auto currVerifiable = inlet->addDouble("foo", "foo's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable = inlet->addDouble("bar", "bar's description");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addDouble("foo", "foo's description");
+  inlet.addDouble("bar", "bar's description");
 
   // Check one that doesn't exist and doesn't have a default value
-  currVerifiable = inlet->addDouble("nonexistant", "nothing");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addDouble("nonexistant", "nothing");
 
   //
   // Check stored values from get
@@ -363,14 +322,14 @@ TEST(inlet_Inlet_basic, getTopLevelDoubles)
   double value = -1;
 
   // Check for existing fields
-  value = (*inlet)["foo"];
+  value = inlet["foo"];
   EXPECT_EQ(value, 5.05);
 
-  value = (*inlet)["bar"];
+  value = inlet["bar"];
   EXPECT_EQ(value, 15.1);
 
   // Check one that doesn't exist and doesn't have a default value
-  auto proxy = (*inlet)["nonexistant"];
+  auto proxy = inlet["nonexistant"];
   EXPECT_EQ(proxy.type(), InletType::Nothing);
 }
 
@@ -385,15 +344,11 @@ TEST(inlet_Inlet_basic, getNestedDoubles)
   //
 
   // Check for existing fields
-  auto currVerifiable = inlet->addDouble("foo/bar", "bar's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable = inlet->addDouble("foo/baz", "baz's description");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addDouble("foo/bar", "bar's description");
+  inlet.addDouble("foo/baz", "baz's description");
 
   // Check one that doesn't exist and doesn't have a default value
-  currVerifiable = inlet->addDouble("foo/nonexistant", "nothing");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addDouble("foo/nonexistant", "nothing");
 
   //
   // Check stored values from get
@@ -402,14 +357,14 @@ TEST(inlet_Inlet_basic, getNestedDoubles)
   double value = -1;
 
   // Check for existing fields
-  value = (*inlet)["foo/bar"];
+  value = inlet["foo/bar"];
   EXPECT_EQ(value, 200.5);
 
-  value = (*inlet)["foo/baz"];
+  value = inlet["foo/baz"];
   EXPECT_EQ(value, 100.987654321);
 
   // Check one that doesn't exist and doesn't have a default value
-  auto proxy = (*inlet)["foo/nonexistant"];
+  auto proxy = inlet["foo/nonexistant"];
   EXPECT_EQ(proxy.type(), InletType::Nothing);
 }
 
@@ -424,15 +379,11 @@ TEST(inlet_Inlet_basic, getTopLevelInts)
   //
 
   // Check for existing fields
-  auto currVerifiable = inlet->addInt("foo", "foo's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable = inlet->addInt("bar", "bar's description");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addInt("foo", "foo's description");
+  inlet.addInt("bar", "bar's description");
 
   // Check one that doesn't exist and doesn't have a default value
-  currVerifiable = inlet->addInt("nonexistant", "nothing");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addInt("nonexistant", "nothing");
 
   //
   // Check stored values from get
@@ -441,14 +392,14 @@ TEST(inlet_Inlet_basic, getTopLevelInts)
   int value = -1;
 
   // Check for existing fields
-  value = (*inlet)["foo"];
+  value = inlet["foo"];
   EXPECT_EQ(value, 5);
 
-  value = (*inlet)["bar"];
+  value = inlet["bar"];
   EXPECT_EQ(value, 15);
 
   // Check one that doesn't exist and doesn't have a default value
-  auto proxy = (*inlet)["nonexistant"];
+  auto proxy = inlet["nonexistant"];
   EXPECT_EQ(proxy.type(), InletType::Nothing);
 }
 
@@ -463,15 +414,11 @@ TEST(inlet_Inlet_basic, getNestedInts)
   //
 
   // Check for existing fields
-  auto currVerifiable = inlet->addInt("foo/bar", "bar's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable = inlet->addInt("foo/baz", "baz's description");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addInt("foo/bar", "bar's description");
+  inlet.addInt("foo/baz", "baz's description");
 
   // Check one that doesn't exist and doesn't have a default value
-  currVerifiable = inlet->addInt("foo/nonexistant", "nothing");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addInt("foo/nonexistant", "nothing");
 
   //
   // Check stored values from get
@@ -480,14 +427,14 @@ TEST(inlet_Inlet_basic, getNestedInts)
   int value = -1;
 
   // Check for existing fields
-  value = (*inlet)["foo/bar"];
+  value = inlet["foo/bar"];
   EXPECT_EQ(value, 200);
 
-  value = (*inlet)["foo/baz"];
+  value = inlet["foo/baz"];
   EXPECT_EQ(value, 100);
 
   // Check one that doesn't exist and doesn't have a default value
-  auto proxy = (*inlet)["foo/nonexistant"];
+  auto proxy = inlet["foo/nonexistant"];
   EXPECT_EQ(proxy.type(), InletType::Nothing);
 }
 
@@ -502,15 +449,11 @@ TEST(inlet_Inlet_basic, getTopLevelStrings)
   //
 
   // Check for existing fields
-  auto currVerifiable = inlet->addString("foo", "foo's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable = inlet->addString("bar", "bar's description");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addString("foo", "foo's description");
+  inlet.addString("bar", "bar's description");
 
   // Check one that doesn't exist and doesn't have a default value
-  currVerifiable = inlet->addString("nonexistant", "nothing");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addString("nonexistant", "nothing");
 
   //
   // Check stored values from get
@@ -519,14 +462,14 @@ TEST(inlet_Inlet_basic, getTopLevelStrings)
   std::string value = "";
 
   // Check for existing fields
-  value = (*inlet)["foo"].get<std::string>();
+  value = inlet["foo"].get<std::string>();
   EXPECT_EQ(value, "test string");
 
-  value = (*inlet)["bar"].get<std::string>();
+  value = inlet["bar"].get<std::string>();
   EXPECT_EQ(value, "15");
 
   // Check one that doesn't exist and doesn't have a default value
-  auto proxy = (*inlet)["nonexistant"];
+  auto proxy = inlet["nonexistant"];
   EXPECT_EQ(proxy.type(), InletType::Nothing);
 }
 
@@ -541,15 +484,11 @@ TEST(inlet_Inlet_basic, getNestedStrings)
   //
 
   // Check for existing fields
-  auto currVerifiable = inlet->addString("foo/bar", "bar's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable = inlet->addString("foo/baz", "baz's description");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addString("foo/bar", "bar's description");
+  inlet.addString("foo/baz", "baz's description");
 
   // Check one that doesn't exist and doesn't have a default value
-  currVerifiable = inlet->addString("foo/nonexistant", "nothing");
-  EXPECT_TRUE(currVerifiable);
+  inlet.addString("foo/nonexistant", "nothing");
 
   //
   // Check stored values from get
@@ -558,14 +497,14 @@ TEST(inlet_Inlet_basic, getNestedStrings)
   std::string value = "";
 
   // Check for existing fields
-  value = (*inlet)["foo/bar"].get<std::string>();
+  value = inlet["foo/bar"].get<std::string>();
   EXPECT_EQ(value, "yet another string");
 
-  value = (*inlet)["foo/baz"].get<std::string>();
+  value = inlet["foo/baz"].get<std::string>();
   EXPECT_EQ(value, "");
 
   // Check one that doesn't exist and doesn't have a default value
-  auto proxy = (*inlet)["foo/nonexistant"];
+  auto proxy = inlet["foo/nonexistant"];
   EXPECT_EQ(proxy.type(), InletType::Nothing);
 }
 
@@ -582,36 +521,29 @@ TEST(inlet_Inlet_basic, getNestedValuesAddedUsingTable)
   auto inlet = createBasicInlet(&ds, testString);
 
   // Check for existing fields
-  auto table = inlet->addTable("foo", "A table called foo");
-  table->required(true);
+  Table& table = inlet.addTable("foo", "A table called foo");
+  table.required(true);
 
-  auto currVerifiable = table->addString("bar", "bar's description");
-  EXPECT_TRUE(currVerifiable);
-  currVerifiable->required(true);
+  table.addString("bar", "bar's description").required(true);
 
-  currVerifiable = table->addDouble("so", "so's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable = table->addInt("re", "re's description");
-  EXPECT_TRUE(currVerifiable);
-
-  currVerifiable = table->addBool("mi", "mi's description");
-  EXPECT_TRUE(currVerifiable);
+  table.addDouble("so", "so's description");
+  table.addInt("re", "re's description");
+  table.addBool("mi", "mi's description");
 
   //
   // Check stored values from get
   //
 
-  strVal = (*inlet)["foo/bar"].get<std::string>();
+  strVal = inlet["foo/bar"].get<std::string>();
   EXPECT_EQ(strVal, "yet another string");
 
-  boolVal = (*inlet)["foo/mi"];
+  boolVal = inlet["foo/mi"];
   EXPECT_EQ(boolVal, true);
 
-  doubleVal = (*inlet)["foo/so"];
+  doubleVal = inlet["foo/so"];
   EXPECT_EQ(doubleVal, 3.5);
 
-  intVal = (*inlet)["foo/re"];
+  intVal = inlet["foo/re"];
   EXPECT_EQ(intVal, 9);
 }
 
@@ -621,24 +553,18 @@ TEST(inlet_Inlet_views, NestedTableViewCheck1)
     "field1 = true; field2 = 5632; NewTable = { str = 'hello'; integer = 32 }";
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
-  auto currVerifiable =
-    inlet->addBool("field1", "this is field #1, a boolean value");
-  currVerifiable->required(true);
-  currVerifiable = inlet->addInt("field2", "this is field #2, an integer");
-  currVerifiable->required(false);
-  auto t = inlet->addTable("NewTable", "It's blue");
-  t->required(false);
-  currVerifiable = t->addString("str", "str's description");
-  currVerifiable->required(true);
-  currVerifiable = t->addInt("integer", "a whole number");
-  currVerifiable->required(false);
+  inlet.addBool("field1", "this is field #1, a boolean value").required(true);
+  inlet.addInt("field2", "this is field #2, an integer").required(false);
+  Table& t = inlet.addTable("NewTable", "It's blue").required(false);
+  t.addString("str", "str's description").required(true);
+  t.addInt("integer", "a whole number").required(false);
 
-  axom::sidre::Group* sidreGroup = inlet->sidreGroup();
+  axom::sidre::Group* sidreGroup = inlet.sidreGroup();
 
-  EXPECT_EQ((*inlet)["field1"].type(), InletType::Bool);
-  EXPECT_EQ((*inlet)["field2"].type(), InletType::Integer);
-  EXPECT_EQ((*inlet)["NewTable/str"].type(), InletType::String);
-  EXPECT_EQ((*inlet)["NewTable/integer"].type(), InletType::Integer);
+  EXPECT_EQ(inlet["field1"].type(), InletType::Bool);
+  EXPECT_EQ(inlet["field2"].type(), InletType::Integer);
+  EXPECT_EQ(inlet["NewTable/str"].type(), InletType::String);
+  EXPECT_EQ(inlet["NewTable/integer"].type(), InletType::Integer);
 
   EXPECT_TRUE(sidreGroup->hasView("field1/required"));
   EXPECT_TRUE(sidreGroup->hasView("field2/required"));
@@ -658,25 +584,20 @@ TEST(inlet_Inlet_views, NestedTableViewCheck2)
     "{ x = 4 } } }";
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
-  auto currVerifiable = inlet->addBool("foo", "foo's description");
-  currVerifiable->required(true);
-  currVerifiable = inlet->addBool("bar", "bar's description");
-  currVerifiable->required(false);
+  inlet.addBool("foo", "foo's description").required(true);
+  inlet.addBool("bar", "bar's description").required(false);
 
-  auto t = inlet->addTable("Table1", "The first table");
-  t->required(false);
-  currVerifiable =
-    t->addDouble("float1", "floating point number within table 1");
-  currVerifiable->required(true);
-  t = t->addTable("Table11", "Table within Table 1");
-  t = t->addTable("Table111", "Table within Table 11");
-  t->addInt("x", "A variable");
+  auto& t = inlet.addTable("Table1", "The first table").required(false);
+  t.addDouble("float1", "floating point number within table 1").required(true);
+  auto& t2 = t.addTable("Table11", "Table within Table 1");
+  auto& t3 = t2.addTable("Table111", "Table within Table 11");
+  t3.addInt("x", "A variable");
 
-  axom::sidre::Group* sidreGroup = inlet->sidreGroup();
+  axom::sidre::Group* sidreGroup = inlet.sidreGroup();
 
-  EXPECT_EQ((*inlet)["foo"].type(), InletType::Bool);
-  EXPECT_EQ((*inlet)["bar"].type(), InletType::Bool);
-  EXPECT_EQ((*inlet)["Table1/float1"].type(), InletType::Double);
+  EXPECT_EQ(inlet["foo"].type(), InletType::Bool);
+  EXPECT_EQ(inlet["bar"].type(), InletType::Bool);
+  EXPECT_EQ(inlet["Table1/float1"].type(), InletType::Double);
 
   EXPECT_TRUE(sidreGroup->hasView("foo/required"));
   EXPECT_TRUE(sidreGroup->hasView("bar/required"));
@@ -696,18 +617,18 @@ TEST(inlet_Inlet_views, NestedTableViewCheck3)
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
 
-  auto t = inlet->addTable("Table1", "The first table");
-  t->addDouble("float1", " A floating point number in Table 1");
-  t = inlet->addTable("Table2", "The second table");
-  t->addInt("int1", "An integer in Table 2");
-  t = inlet->addTable("Table3", "The third table");
-  t->addBool("bool1", "A boolean value in Table 3");
+  auto& t = inlet.addTable("Table1", "The first table");
+  t.addDouble("float1", " A floating point number in Table 1");
+  auto& t2 = inlet.addTable("Table2", "The second table");
+  t2.addInt("int1", "An integer in Table 2");
+  auto& t3 = inlet.addTable("Table3", "The third table");
+  t3.addBool("bool1", "A boolean value in Table 3");
 
-  axom::sidre::Group* sidreGroup = inlet->sidreGroup();
+  axom::sidre::Group* sidreGroup = inlet.sidreGroup();
 
-  EXPECT_EQ((*inlet)["Table1/float1"].type(), InletType::Double);
-  EXPECT_EQ((*inlet)["Table2/int1"].type(), InletType::Integer);
-  EXPECT_EQ((*inlet)["Table3/bool1"].type(), InletType::Bool);
+  EXPECT_EQ(inlet["Table1/float1"].type(), InletType::Double);
+  EXPECT_EQ(inlet["Table2/int1"].type(), InletType::Integer);
+  EXPECT_EQ(inlet["Table3/bool1"].type(), InletType::Bool);
 
   EXPECT_TRUE(sidreGroup->hasView("Table1/float1/description"));
   EXPECT_TRUE(sidreGroup->hasView("Table2/int1/description"));
@@ -741,25 +662,25 @@ TEST(inlet_Inlet, mixLevelTables)
   //
 
   // fields that are expected to not be present in above string
-  inlet->addString("thermal_solver/mesh/filename", "filename");
-  inlet->addInt("thermal_solver/mesh/serial", "serial");
-  inlet->addInt("thermal_solver/mesh/parallel", "parallel");
-  inlet->addInt("thermal_solver/order", "order");
-  inlet->addString("thermal_solver/timestepper", "timestepper");
+  inlet.addString("thermal_solver/mesh/filename", "filename");
+  inlet.addInt("thermal_solver/mesh/serial", "serial");
+  inlet.addInt("thermal_solver/mesh/parallel", "parallel");
+  inlet.addInt("thermal_solver/order", "order");
+  inlet.addString("thermal_solver/timestepper", "timestepper");
 
   // Rest of the fields are present
-  inlet->addString("thermal_solver/u0/type", "type");
-  inlet->addString("thermal_solver/u0/func", "func");
+  inlet.addString("thermal_solver/u0/type", "type");
+  inlet.addString("thermal_solver/u0/func", "func");
 
-  inlet->addString("thermal_solver/kappa/type", "type");
-  inlet->addDouble("thermal_solver/kappa/constant", "constant");
+  inlet.addString("thermal_solver/kappa/type", "type");
+  inlet.addDouble("thermal_solver/kappa/constant", "constant");
 
-  inlet->addDouble("thermal_solver/solver/rel_tol", "rel_tol");
-  inlet->addDouble("thermal_solver/solver/abs_tol", "abs_tol");
-  inlet->addInt("thermal_solver/solver/print_level", "print_level");
-  inlet->addInt("thermal_solver/solver/max_iter", "max_iter");
-  inlet->addDouble("thermal_solver/solver/dt", "dt");
-  inlet->addInt("thermal_solver/solver/steps", "steps");
+  inlet.addDouble("thermal_solver/solver/rel_tol", "rel_tol");
+  inlet.addDouble("thermal_solver/solver/abs_tol", "abs_tol");
+  inlet.addInt("thermal_solver/solver/print_level", "print_level");
+  inlet.addInt("thermal_solver/solver/max_iter", "max_iter");
+  inlet.addDouble("thermal_solver/solver/dt", "dt");
+  inlet.addInt("thermal_solver/solver/steps", "steps");
 
   //
   //  Verify values found in input file
@@ -769,36 +690,36 @@ TEST(inlet_Inlet, mixLevelTables)
   double doubleVal;
 
   // u0
-  strVal = (*inlet)["thermal_solver/u0/type"].get<std::string>();
+  strVal = inlet["thermal_solver/u0/type"].get<std::string>();
   EXPECT_EQ(strVal, "function");
 
-  strVal = (*inlet)["thermal_solver/u0/func"].get<std::string>();
+  strVal = inlet["thermal_solver/u0/func"].get<std::string>();
   EXPECT_EQ(strVal, "BoundaryTemperature");
 
   // kappa
-  strVal = (*inlet)["thermal_solver/kappa/type"].get<std::string>();
+  strVal = inlet["thermal_solver/kappa/type"].get<std::string>();
   EXPECT_EQ(strVal, "constant");
 
-  doubleVal = (*inlet)["thermal_solver/kappa/constant"];
+  doubleVal = inlet["thermal_solver/kappa/constant"];
   EXPECT_EQ(doubleVal, 0.5);
 
   // solver
-  doubleVal = (*inlet)["thermal_solver/solver/rel_tol"];
+  doubleVal = inlet["thermal_solver/solver/rel_tol"];
   EXPECT_EQ(doubleVal, 1.e-6);
 
-  doubleVal = (*inlet)["thermal_solver/solver/abs_tol"];
+  doubleVal = inlet["thermal_solver/solver/abs_tol"];
   EXPECT_EQ(doubleVal, 1.e-12);
 
-  intVal = (*inlet)["thermal_solver/solver/print_level"];
+  intVal = inlet["thermal_solver/solver/print_level"];
   EXPECT_EQ(intVal, 0);
 
-  intVal = (*inlet)["thermal_solver/solver/max_iter"];
+  intVal = inlet["thermal_solver/solver/max_iter"];
   EXPECT_EQ(intVal, 100);
 
-  doubleVal = (*inlet)["thermal_solver/solver/dt"];
+  doubleVal = inlet["thermal_solver/solver/dt"];
   EXPECT_EQ(doubleVal, 1.0);
 
-  intVal = (*inlet)["thermal_solver/solver/steps"];
+  intVal = inlet["thermal_solver/solver/steps"];
   EXPECT_EQ(intVal, 1);
 }
 
@@ -812,20 +733,19 @@ TEST(inlet_Field, defaultValuesDocsEnabled)
   auto inlet = createBasicInlet(&ds, testString, true);
 
   // new fields
-  inlet->addDouble("field1")->defaultValue(
-    2);  // int argument will get casted to double
-  inlet->addInt("Table1/Table2/field2")->defaultValue(5);
-  inlet->addBool("Table1/field3")->defaultValue(true);
-  inlet->addString("Table3/field4")->defaultValue("default for new string");
+  inlet.addDouble("field1").defaultValue(2);  // int argument will get casted to double
+  inlet.addInt("Table1/Table2/field2").defaultValue(5);
+  inlet.addBool("Table1/field3").defaultValue(true);
+  inlet.addString("Table3/field4").defaultValue("default for new string");
 
   // existing fields
-  inlet->addInt("Table1/Table2/int1")->defaultValue(100);
-  inlet->addBool("Table3/bool1")->defaultValue(false);
-  inlet->addDouble("Table1/float1")->defaultValue(3.14);
-  inlet->addString("Table1/Table2/Table4/str1")
-    ->defaultValue("default for old string");
+  inlet.addInt("Table1/Table2/int1").defaultValue(100);
+  inlet.addBool("Table3/bool1").defaultValue(false);
+  inlet.addDouble("Table1/float1").defaultValue(3.14);
+  inlet.addString("Table1/Table2/Table4/str1")
+    .defaultValue("default for old string");
 
-  axom::sidre::Group* sidreGroup = inlet->sidreGroup();
+  axom::sidre::Group* sidreGroup = inlet.sidreGroup();
 
   EXPECT_TRUE(sidreGroup->hasView("field1/defaultValue"));
   double doubleVal = sidreGroup->getView("field1/defaultValue")->getScalar();
@@ -897,19 +817,19 @@ TEST(inlet_Field, defaultValuesDocsDisabled)
   auto inlet = createBasicInlet(&ds, testString, false);
 
   // new fields
-  inlet->addDouble("field1")->defaultValue(2.0);
-  inlet->addInt("Table1/Table2/field2")->defaultValue(5);
-  inlet->addBool("Table1/field3")->defaultValue(true);
-  inlet->addString("Table3/field4")->defaultValue("default for new string");
+  inlet.addDouble("field1").defaultValue(2.0);
+  inlet.addInt("Table1/Table2/field2").defaultValue(5);
+  inlet.addBool("Table1/field3").defaultValue(true);
+  inlet.addString("Table3/field4").defaultValue("default for new string");
 
   // existing fields
-  inlet->addInt("Table1/Table2/int1")->defaultValue(100);
-  inlet->addBool("Table3/bool1")->defaultValue(false);
-  inlet->addDouble("Table1/float1")->defaultValue(3.14);
-  inlet->addString("Table1/Table2/Table4/str1")
-    ->defaultValue("default for old string");
+  inlet.addInt("Table1/Table2/int1").defaultValue(100);
+  inlet.addBool("Table3/bool1").defaultValue(false);
+  inlet.addDouble("Table1/float1").defaultValue(3.14);
+  inlet.addString("Table1/Table2/Table4/str1")
+    .defaultValue("default for old string");
 
-  axom::sidre::Group* sidreGroup = inlet->sidreGroup();
+  axom::sidre::Group* sidreGroup = inlet.sidreGroup();
 
   EXPECT_FALSE(sidreGroup->hasView("field1/defaultValue"));
   EXPECT_FALSE(sidreGroup->hasView("Table1/Table2/field2/defaultValue"));
@@ -953,9 +873,9 @@ TEST(inlet_Field, ranges)
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
 
-  axom::sidre::Group* sidreGroup = inlet->sidreGroup();
+  axom::sidre::Group* sidreGroup = inlet.sidreGroup();
 
-  inlet->addInt("Table1/set")->validValues({2, 4, 6});
+  inlet.addInt("Table1/set").validValues({2, 4, 6});
   EXPECT_TRUE(sidreGroup->hasView("Table1/set/validValues"));
   int* bufferArr1 = sidreGroup->getView("Table1/set/validValues")->getArray();
   EXPECT_TRUE(bufferArr1);
@@ -966,7 +886,7 @@ TEST(inlet_Field, ranges)
   EXPECT_EQ(bufferArr1[1], 4);
   EXPECT_EQ(bufferArr1[2], 6);
 
-  inlet->addDouble("Table1/Table2/Table4/double1")->range(2.0, 5.0);
+  inlet.addDouble("Table1/Table2/Table4/double1").range(2.0, 5.0);
   EXPECT_TRUE(sidreGroup->hasView("Table1/Table2/Table4/double1/range"));
   double* bufferArr2 =
     sidreGroup->getView("Table1/Table2/Table4/double1/range")->getArray();
@@ -978,7 +898,7 @@ TEST(inlet_Field, ranges)
   EXPECT_EQ(bufferArr2[0], 2.0);
   EXPECT_EQ(bufferArr2[1], 5.0);
 
-  inlet->addInt("Table1/Table2/int1")->range(1, 50);
+  inlet.addInt("Table1/Table2/int1").range(1, 50);
   EXPECT_TRUE(sidreGroup->hasView("Table1/Table2/int1/range"));
   int* bufferArr3 = sidreGroup->getView("Table1/Table2/int1/range")->getArray();
   EXPECT_TRUE(bufferArr3);
@@ -996,15 +916,15 @@ TEST(inlet_Inlet_verify, verifyRequired)
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
 
-  inlet->addString("NewTable/str")->required(true);
-  inlet->addInt("NewTable/int")->required(false);
-  inlet->addBool("field1")->required(true);
-  inlet->addInt("field2")->required(true);
-  EXPECT_TRUE(inlet->verify());
+  inlet.addString("NewTable/str").required(true);
+  inlet.addInt("NewTable/int").required(false);
+  inlet.addBool("field1").required(true);
+  inlet.addInt("field2").required(true);
+  EXPECT_TRUE(inlet.verify());
 
-  inlet->addBool("NewTable/field3")->required(true);
-  inlet->addTable("NewTable/LastTable")->addDouble("field4")->required(true);
-  EXPECT_FALSE(inlet->verify());
+  inlet.addBool("NewTable/field3").required(true);
+  inlet.addTable("NewTable/LastTable").addDouble("field4").required(true);
+  EXPECT_FALSE(inlet.verify());
 }
 
 TEST(inlet_Inlet_verify, verifyDoubleRange)
@@ -1016,17 +936,14 @@ TEST(inlet_Inlet_verify, verifyDoubleRange)
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
 
-  auto field = inlet->addDouble("field2");
-  field->range(1.0, 57.2);
-  EXPECT_TRUE(inlet->verify());
+  inlet.addDouble("field2").range(1.0, 57.2);
+  EXPECT_TRUE(inlet.verify());
 
-  field = inlet->addDouble("field3");
-  field->range(-10.5, 13.23);
-  EXPECT_TRUE(inlet->verify());
+  inlet.addDouble("field3").range(-10.5, 13.23);
+  EXPECT_TRUE(inlet.verify());
 
-  field = inlet->addDouble("NewTable/field4");
-  field->range(1.0, 22.0);
-  EXPECT_FALSE(inlet->verify());
+  inlet.addDouble("NewTable/field4").range(1.0, 22.0);
+  EXPECT_FALSE(inlet.verify());
 
   // For checking default values
   std::string testString1 =
@@ -1035,13 +952,13 @@ TEST(inlet_Inlet_verify, verifyDoubleRange)
   DataStore ds1;
   auto inlet1 = createBasicInlet(&ds1, testString1);
 
-  auto field1 = inlet1->addDouble("field2");
-  field1->defaultValue(5).range(0, 60);  // ints will get casted to double
-  EXPECT_TRUE(inlet1->verify());
+  inlet1.addDouble("field2").defaultValue(5).range(
+    0,
+    60);  // ints will get casted to double
+  EXPECT_TRUE(inlet1.verify());
 
-  field1 = inlet1->addDouble("field3");
-  field1->defaultValue(-12).range(-10.5, 13.23);
-  EXPECT_FALSE(inlet1->verify());
+  inlet1.addDouble("field3").defaultValue(-12).range(-10.5, 13.23);
+  EXPECT_FALSE(inlet1.verify());
 }
 
 TEST(inlet_Inlet_verify, verifyIntRange)
@@ -1052,38 +969,31 @@ TEST(inlet_Inlet_verify, verifyIntRange)
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
 
-  auto field = inlet->addInt("field2");
-  field->range(0, 56);
-  EXPECT_TRUE(inlet->verify());
+  inlet.addInt("field2").range(0, 56);
+  EXPECT_TRUE(inlet.verify());
 
-  field = inlet->addInt("field3");
-  field->range(-12, 13);
-  EXPECT_TRUE(inlet->verify());
+  inlet.addInt("field3").range(-12, 13);
+  EXPECT_TRUE(inlet.verify());
 
-  field = inlet->addInt("NewTable/field4");
-  field->range(1, 23);
-  EXPECT_TRUE(inlet->verify());
+  inlet.addInt("NewTable/field4").range(1, 23);
+  EXPECT_TRUE(inlet.verify());
 
-  field = inlet->addInt("NewTable/field5");
-  field->range(1, 7);
-  EXPECT_FALSE(inlet->verify());
+  inlet.addInt("NewTable/field5").range(1, 7);
+  EXPECT_FALSE(inlet.verify());
 
   // For checking default values
   std::string testString1 =
     "field1 = true; field2 = 56; NewTable = { field4 = 22; field5 = 48 }";
   DataStore ds1;
   auto inlet1 = createBasicInlet(&ds1, testString1);
-  field = inlet1->addInt("field2");
-  field->range(0, 56).defaultValue(32);
-  EXPECT_TRUE(inlet1->verify());
+  inlet1.addInt("field2").range(0, 56).defaultValue(32);
+  EXPECT_TRUE(inlet1.verify());
 
-  field = inlet1->addInt("field3");
-  field->range(-12, 13).defaultValue(-3);
-  EXPECT_TRUE(inlet1->verify());
+  inlet1.addInt("field3").range(-12, 13).defaultValue(-3);
+  EXPECT_TRUE(inlet1.verify());
 
-  field = inlet1->addInt("NewTable/field4");
-  field->range(1, 23).defaultValue(24);
-  EXPECT_FALSE(inlet1->verify());
+  inlet1.addInt("NewTable/field4").range(1, 23).defaultValue(24);
+  EXPECT_FALSE(inlet1.verify());
 }
 
 TEST(inlet_Inlet_verify, verifyValidIntValues)
@@ -1094,23 +1004,19 @@ TEST(inlet_Inlet_verify, verifyValidIntValues)
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
 
-  auto field = inlet->addInt("field2");
-  field->validValues({1, 2, 3, 56, 57, 58});
-  EXPECT_TRUE(inlet->verify());
+  inlet.addInt("field2").validValues({1, 2, 3, 56, 57, 58});
+  EXPECT_TRUE(inlet.verify());
 
   std::vector<int> nums = {-1, -2, -6, -18, 21};
 
-  field = inlet->addInt("field3");
-  field->validValues(nums);
-  EXPECT_TRUE(inlet->verify());
+  inlet.addInt("field3").validValues(nums);
+  EXPECT_TRUE(inlet.verify());
 
-  field = inlet->addInt("NewTable/field4");
-  field->validValues({44, 40, 48, 22});
-  EXPECT_TRUE(inlet->verify());
+  inlet.addInt("NewTable/field4").validValues({44, 40, 48, 22});
+  EXPECT_TRUE(inlet.verify());
 
-  field = inlet->addInt("NewTable/field5");
-  field->validValues(nums);
-  EXPECT_FALSE(inlet->verify());
+  inlet.addInt("NewTable/field5").validValues(nums);
+  EXPECT_FALSE(inlet.verify());
 
   // check default values
   std::string testString1 =
@@ -1118,21 +1024,17 @@ TEST(inlet_Inlet_verify, verifyValidIntValues)
   DataStore ds1;
   auto inlet1 = createBasicInlet(&ds1, testString1);
 
-  field = inlet1->addInt("field2");
-  field->validValues({1, 2, 3, 56, 57, 58}).defaultValue(2);
-  EXPECT_TRUE(inlet1->verify());
+  inlet1.addInt("field2").validValues({1, 2, 3, 56, 57, 58}).defaultValue(2);
+  EXPECT_TRUE(inlet1.verify());
 
-  field = inlet1->addInt("field3");
-  field->validValues(nums).defaultValue(21);
-  EXPECT_TRUE(inlet1->verify());
+  inlet1.addInt("field3").validValues(nums).defaultValue(21);
+  EXPECT_TRUE(inlet1.verify());
 
-  field = inlet1->addInt("NewTable/field4");
-  field->validValues({44, 40, 48, 22}).defaultValue(48);
-  EXPECT_TRUE(inlet1->verify());
+  inlet1.addInt("NewTable/field4").validValues({44, 40, 48, 22}).defaultValue(48);
+  EXPECT_TRUE(inlet1.verify());
 
-  field = inlet1->addInt("NewTable/field5");
-  field->validValues(nums).defaultValue(90);
-  EXPECT_FALSE(inlet1->verify());
+  inlet1.addInt("NewTable/field5").validValues(nums).defaultValue(90);
+  EXPECT_FALSE(inlet1.verify());
 }
 
 TEST(inlet_Inlet_verify, verifyValidDoubleValues)
@@ -1144,23 +1046,19 @@ TEST(inlet_Inlet_verify, verifyValidDoubleValues)
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
 
-  auto field = inlet->addDouble("field2");
-  field->validValues({1, 2, 3, 56, 57, 58});
-  EXPECT_TRUE(inlet->verify());
+  inlet.addDouble("field2").validValues({1, 2, 3, 56, 57, 58});
+  EXPECT_TRUE(inlet.verify());
 
   std::vector<int> nums = {-1, -2, -6, -18, 21};
 
-  field = inlet->addDouble("field3");
-  field->validValues(nums);
-  EXPECT_TRUE(inlet->verify());
+  inlet.addDouble("field3").validValues(nums);
+  EXPECT_TRUE(inlet.verify());
 
-  field = inlet->addDouble("NewTable/field4");
-  field->validValues({44.1, 40., 48., 22.});
-  EXPECT_TRUE(inlet->verify());
+  inlet.addDouble("NewTable/field4").validValues({44.1, 40., 48., 22.});
+  EXPECT_TRUE(inlet.verify());
 
-  field = inlet->addDouble("NewTable/field5");
-  field->validValues(nums);
-  EXPECT_FALSE(inlet->verify());
+  inlet.addDouble("NewTable/field5").validValues(nums);
+  EXPECT_FALSE(inlet.verify());
 
   // check default values
   std::string testString1 =
@@ -1169,21 +1067,19 @@ TEST(inlet_Inlet_verify, verifyValidDoubleValues)
   DataStore ds1;
   auto inlet1 = createBasicInlet(&ds1, testString1);
 
-  field = inlet1->addDouble("field2");
-  field->validValues({1, 2, 3, 56, 57, 58}).defaultValue(2.);
-  EXPECT_TRUE(inlet1->verify());
+  inlet1.addDouble("field2").validValues({1, 2, 3, 56, 57, 58}).defaultValue(2.);
+  EXPECT_TRUE(inlet1.verify());
 
-  field = inlet1->addDouble("field3");
-  field->validValues(nums).defaultValue(21);
-  EXPECT_TRUE(inlet1->verify());
+  inlet1.addDouble("field3").validValues(nums).defaultValue(21);
+  EXPECT_TRUE(inlet1.verify());
 
-  field = inlet1->addDouble("NewTable/field4");
-  field->validValues({44.05, 40.13, 48.28, 22.}).defaultValue(48.28);
-  EXPECT_TRUE(inlet1->verify());
+  inlet1.addDouble("NewTable/field4")
+    .validValues({44.05, 40.13, 48.28, 22.})
+    .defaultValue(48.28);
+  EXPECT_TRUE(inlet1.verify());
 
-  field = inlet1->addDouble("NewTable/field5");
-  field->validValues(nums).defaultValue(90.1);
-  EXPECT_FALSE(inlet1->verify());
+  inlet1.addDouble("NewTable/field5").validValues(nums).defaultValue(90.1);
+  EXPECT_FALSE(inlet1.verify());
 }
 
 TEST(inlet_Inlet_verify, verifyValidStringValues)
@@ -1195,44 +1091,38 @@ TEST(inlet_Inlet_verify, verifyValidStringValues)
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
 
-  auto field = inlet->addString("field2");
-  field->validValues({"abc", "defg", "hijk", "lm"});
-  EXPECT_TRUE(inlet->verify());
+  inlet.addString("field2").validValues({"abc", "defg", "hijk", "lm"});
+  EXPECT_TRUE(inlet.verify());
 
   std::vector<std::string> strs = {"nop", "qrstuv", "xyz", "wx"};
 
-  field = inlet->addString("NewTable/field3");
-  field->validValues(strs);
-  EXPECT_TRUE(inlet->verify());
+  inlet.addString("NewTable/field3").validValues(strs);
+  EXPECT_TRUE(inlet.verify());
 
-  field = inlet->addString("Table1/field5");
-  field->validValues(strs);
-  EXPECT_TRUE(inlet->verify());
+  inlet.addString("Table1/field5").validValues(strs);
+  EXPECT_TRUE(inlet.verify());
 
-  field = inlet->addString("NewTable/field4");
-  field->validValues(strs);
-  EXPECT_FALSE(inlet->verify());
+  inlet.addString("NewTable/field4").validValues(strs);
+  EXPECT_FALSE(inlet.verify());
 
   // check default values
   std::string testString1 = "field1 = true; NewTable = { field5 = 'nop' }";
   DataStore ds1;
   auto inlet1 = createBasicInlet(&ds1, testString1);
 
-  field = inlet1->addString("field2");
-  field->validValues({"abc", "defg", "hijk", "lm"}).defaultValue("defg");
-  EXPECT_TRUE(inlet1->verify());
+  inlet1.addString("field2")
+    .validValues({"abc", "defg", "hijk", "lm"})
+    .defaultValue("defg");
+  EXPECT_TRUE(inlet1.verify());
 
-  field = inlet1->addString("field3");
-  field->validValues(strs).defaultValue("wx");
-  EXPECT_TRUE(inlet1->verify());
+  inlet1.addString("field3").validValues(strs).defaultValue("wx");
+  EXPECT_TRUE(inlet1.verify());
 
-  field = inlet1->addString("NewTable/field4");
-  field->validValues(strs);
-  EXPECT_TRUE(inlet1->verify());
+  inlet1.addString("NewTable/field4").validValues(strs);
+  EXPECT_TRUE(inlet1.verify());
 
-  field = inlet1->addString("NewTable/field5");
-  field->validValues(strs).defaultValue("zyx");
-  EXPECT_FALSE(inlet1->verify());
+  inlet1.addString("NewTable/field5").validValues(strs).defaultValue("zyx");
+  EXPECT_FALSE(inlet1.verify());
 }
 
 TEST(inlet_verify, verifyFieldLambda)
@@ -1243,21 +1133,21 @@ TEST(inlet_verify, verifyFieldLambda)
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
 
-  auto field1 = inlet->addBool("field1");
-  auto field2 = inlet->addString("field2");
-  auto field3 = inlet->addString("NewTable/field3");
+  inlet.addBool("field1");
+  auto& field2 = inlet.addString("field2");
+  auto& field3 = inlet.addString("NewTable/field3");
 
-  field2->registerVerifier([](const Field& field) -> bool {
+  field2.registerVerifier([](const Field& field) {
     auto str = field.get<std::string>();
     return (str.size() >= 1 && str[0] == 'a');
   });
-  EXPECT_TRUE(inlet->verify());
+  EXPECT_TRUE(inlet.verify());
 
-  field3->registerVerifier([](const Field& field) -> bool {
+  field3.registerVerifier([](const Field& field) {
     auto str = field.get<std::string>();
     return (str.size() >= 1 && str[0] == 'a');
   });
-  EXPECT_FALSE(inlet->verify());
+  EXPECT_FALSE(inlet.verify());
 }
 
 TEST(inlet_verify, verifyTableLambda1)
@@ -1268,32 +1158,32 @@ TEST(inlet_verify, verifyTableLambda1)
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
 
-  auto field1 = inlet->addBool("field1");
-  auto field2 = inlet->addString("field2");
-  auto table1 = inlet->addTable("NewTable");
-  auto field3 = table1->addString("field3");
+  inlet.addBool("field1");
+  auto& field2 = inlet.addString("field2");
+  Table& table1 = inlet.addTable("NewTable");
+  auto& field3 = table1.addString("field3");
 
-  field2->registerVerifier([](const Field& field) -> bool {
+  field2.registerVerifier([](const Field& field) {
     auto str = field.get<std::string>();
     return (str.size() >= 1 && str[0] == 'a');
   });
-  EXPECT_TRUE(inlet->verify());
+  EXPECT_TRUE(inlet.verify());
 
-  field3->registerVerifier([](const Field& field) -> bool {
+  field3.registerVerifier([](const Field& field) {
     auto str = field.get<std::string>();
     return (str.size() >= 1 && str[0] == 'x');
   });
-  EXPECT_TRUE(inlet->verify());
+  EXPECT_TRUE(inlet.verify());
 
-  EXPECT_TRUE(table1->hasField("field3"));
+  EXPECT_TRUE(table1.hasField("field3"));
 
-  table1->registerVerifier(
-    [](const Table& table) -> bool { return table.contains("field3"); });
-  EXPECT_TRUE(inlet->verify());
+  table1.registerVerifier(
+    [](const Table& table) { return table.contains("field3"); });
+  EXPECT_TRUE(inlet.verify());
 
-  table1->registerVerifier(
-    [](const Table& table) -> bool { return table.contains("field22"); });
-  EXPECT_FALSE(inlet->verify());
+  table1.registerVerifier(
+    [](const Table& table) { return table.contains("field22"); });
+  EXPECT_FALSE(inlet.verify());
 }
 
 TEST(inlet_verify, verifyTableLambda2)
@@ -1311,15 +1201,15 @@ TEST(inlet_verify, verifyTableLambda2)
     "material.solidview = 'hyperelastic'";
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
-  auto thermalOrder = inlet->addInt("thermal_solver/order");
-  auto thermalTimeStep = inlet->addString("thermal_solver/timestepper");
-  auto solidOrder = inlet->addInt("solid_solver/order");
-  auto soldTimestep = inlet->addString("solid_solver/timestepper");
-  auto attrib = inlet->addInt("material/attribute");
-  auto globalTable = inlet->getGlobalTable();
-  auto material = globalTable->getTable("material");
+  inlet.addInt("thermal_solver/order");
+  inlet.addString("thermal_solver/timestepper");
+  inlet.addInt("solid_solver/order");
+  inlet.addString("solid_solver/timestepper");
+  inlet.addInt("material/attribute");
+  auto& globalTable = inlet.getGlobalTable();
+  Table& material = globalTable.getTable("material");
 
-  globalTable->registerVerifier([](const Table& table) -> bool {
+  globalTable.registerVerifier([](const Table& table) {
     bool verifySuccess = true;
     if(table.contains("thermal_solver") &&
        !table["material"].contains("thermalview"))
@@ -1333,23 +1223,23 @@ TEST(inlet_verify, verifyTableLambda2)
     return verifySuccess;
   });
 
-  EXPECT_FALSE(inlet->verify());
+  EXPECT_FALSE(inlet.verify());
 
-  auto thermalView = inlet->addString("material/thermalview");
-  auto solidView = inlet->addString("material/solidview");
+  inlet.addString("material/thermalview");
+  inlet.addString("material/solidview");
 
-  EXPECT_TRUE(material->hasField("solidview"));
-  EXPECT_TRUE(material->hasField("thermalview"));
+  EXPECT_TRUE(material.hasField("solidview"));
+  EXPECT_TRUE(material.hasField("thermalview"));
 
-  EXPECT_TRUE(inlet->verify());
+  EXPECT_TRUE(inlet.verify());
 
-  auto thing = inlet->addTable("test");
-  auto thing2 = thing->addTable("test2");
-  auto thing5 = thing2->addTable("test3/test4/test5");
+  auto& thing = inlet.addTable("test");
+  auto& thing2 = thing.addTable("test2");
+  thing2.addTable("test3/test4/test5");
 
-  EXPECT_EQ(globalTable->getTable("test")->name(), "test");
-  EXPECT_EQ(thing->getTable("test2")->name(), "test/test2");
-  EXPECT_EQ(thing2->getTable("test3/test4/test5")->name(),
+  EXPECT_EQ(globalTable.getTable("test").name(), "test");
+  EXPECT_EQ(thing.getTable("test2").name(), "test/test2");
+  EXPECT_EQ(thing2.getTable("test3/test4/test5").name(),
             "test/test2/test3/test4/test5");
 }
 
@@ -1368,18 +1258,18 @@ TEST(inlet_verify, requiredTable)
     "material.solidview = 'hyperelastic'";
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
-  auto material = inlet->addTable("material");
-  material->required(true);
+  auto& material = inlet.addTable("material");
+  material.required(true);
 
-  EXPECT_FALSE(inlet->verify());
+  EXPECT_FALSE(inlet.verify());
 
-  auto thermalView = inlet->addString("material/thermalview");
-  auto solidView = inlet->addString("material/solidview");
+  inlet.addString("material/thermalview");
+  inlet.addString("material/solidview");
 
-  EXPECT_TRUE(inlet->hasField("material/thermalview"));
-  EXPECT_TRUE(inlet->hasField("material/solidview"));
+  EXPECT_TRUE(inlet.hasField("material/thermalview"));
+  EXPECT_TRUE(inlet.hasField("material/solidview"));
 
-  EXPECT_TRUE(inlet->verify());
+  EXPECT_TRUE(inlet.verify());
 }
 
 TEST(inlet_verify, verifyTableLambda3)
@@ -1387,13 +1277,12 @@ TEST(inlet_verify, verifyTableLambda3)
   std::string testString = "dimensions = 2; vector = { x = 1; y = 2; z = 3; }";
   DataStore ds;
   auto myInlet = createBasicInlet(&ds, testString);
-  myInlet->addInt("dimensions")->required(true);
-  auto v = myInlet->addTable("vector");
-  v->required(true);
-  v->addInt("x");
+  myInlet.addInt("dimensions").required(true);
+  auto& v = myInlet.addTable("vector").required(true);
+  v.addInt("x");
 
-  v->registerVerifier([&myInlet](const Table& table) -> bool {
-    int dim = (*myInlet)["dimensions"];
+  v.registerVerifier([&myInlet](const Table& table) {
+    int dim = myInlet["dimensions"];
     bool x_present =
       table.contains("x") && (table["x"].type() == InletType::Integer);
     bool y_present =
@@ -1415,12 +1304,12 @@ TEST(inlet_verify, verifyTableLambda3)
     return false;
   });
 
-  EXPECT_FALSE(myInlet->verify());
+  EXPECT_FALSE(myInlet.verify());
 
-  v->addInt("y");
-  v->addInt("z");
+  v.addInt("y");
+  v.addInt("z");
 
-  EXPECT_TRUE(myInlet->verify());
+  EXPECT_TRUE(myInlet.verify());
 }
 
 // Checks all of the Table::getArray functions
@@ -1434,20 +1323,20 @@ TEST(inletArrays, getArray)
     "              arr4 = { [12] = 2.4 } }";
   auto inlet = createBasicInlet(&ds, testString);
 
-  auto arr1 = inlet->getGlobalTable()->addIntArray("luaArrays/arr1");
-  auto arr2 = inlet->getGlobalTable()->addBoolArray("luaArrays/arr2");
-  auto arr3 = inlet->getGlobalTable()->addStringArray("luaArrays/arr3");
-  auto arr4 = inlet->getGlobalTable()->addDoubleArray("luaArrays/arr4");
+  inlet.getGlobalTable().addIntArray("luaArrays/arr1");
+  inlet.getGlobalTable().addBoolArray("luaArrays/arr2");
+  inlet.getGlobalTable().addStringArray("luaArrays/arr3");
+  inlet.getGlobalTable().addDoubleArray("luaArrays/arr4");
 
   std::unordered_map<int, int> expectedInts {{1, 4}};
   std::unordered_map<int, bool> expectedBools {{4, true}, {8, false}};
   std::unordered_map<int, double> expectedDoubles {{12, 2.4}};
   std::unordered_map<int, std::string> expectedStrs {{33, "hello"}, {2, "bye"}};
 
-  std::unordered_map<int, int> intMap = (*inlet)["luaArrays/arr1"];
-  std::unordered_map<int, bool> boolMap = (*inlet)["luaArrays/arr2"];
-  std::unordered_map<int, std::string> strMap = (*inlet)["luaArrays/arr3"];
-  std::unordered_map<int, double> doubleMap = (*inlet)["luaArrays/arr4"];
+  std::unordered_map<int, int> intMap = inlet["luaArrays/arr1"];
+  std::unordered_map<int, bool> boolMap = inlet["luaArrays/arr2"];
+  std::unordered_map<int, std::string> strMap = inlet["luaArrays/arr3"];
+  std::unordered_map<int, double> doubleMap = inlet["luaArrays/arr4"];
 
   EXPECT_EQ(intMap, expectedInts);
 
@@ -1469,9 +1358,9 @@ TEST(inletArrays, inletArraysInSidre)
     "              arr4 = { [12] = 2.4 } }";
   auto inlet = createBasicInlet(&ds, testString);
 
-  inlet->addIntArray("luaArrays/arr1");
+  inlet.addIntArray("luaArrays/arr1");
 
-  auto group = inlet->getGlobalTable()->sidreGroup()->getGroup(
+  auto group = inlet.getGlobalTable().sidreGroup()->getGroup(
     "luaArrays/arr1/_inlet_array");
   auto idx = group->getGroup("1");
   EXPECT_TRUE(idx);
@@ -1493,8 +1382,8 @@ TEST(inletArrays, inletArraysInSidre)
   val = idx->getView("value")->getScalar();
   EXPECT_EQ(val, 6);
 
-  inlet->getGlobalTable()->addBoolArray("luaArrays/arr2");
-  group = inlet->getTable("luaArrays/arr2/_inlet_array")->sidreGroup();
+  inlet.getGlobalTable().addBoolArray("luaArrays/arr2");
+  group = inlet.getTable("luaArrays/arr2/_inlet_array").sidreGroup();
 
   idx = group->getGroup("4");
   EXPECT_TRUE(idx);
@@ -1506,8 +1395,8 @@ TEST(inletArrays, inletArraysInSidre)
   boolVal = idx->getView("value")->getScalar();
   EXPECT_EQ(boolVal, 0);
 
-  inlet->getGlobalTable()->addStringArray("luaArrays/arr3");
-  group = inlet->getTable("luaArrays/arr3/_inlet_array")->sidreGroup();
+  inlet.getGlobalTable().addStringArray("luaArrays/arr3");
+  group = inlet.getTable("luaArrays/arr3/_inlet_array").sidreGroup();
 
   idx = group->getGroup("33");
   EXPECT_TRUE(idx);
@@ -1519,8 +1408,8 @@ TEST(inletArrays, inletArraysInSidre)
   str = idx->getView("value")->getString();
   EXPECT_EQ(str, "bye");
 
-  inlet->getGlobalTable()->addDoubleArray("luaArrays/arr4");
-  group = inlet->getTable("luaArrays/arr4/_inlet_array")->sidreGroup();
+  inlet.getGlobalTable().addDoubleArray("luaArrays/arr4");
+  group = inlet.getTable("luaArrays/arr4/_inlet_array").sidreGroup();
 
   idx = group->getGroup("12");
   EXPECT_TRUE(idx);

--- a/src/axom/inlet/tests/inlet_Inlet.cpp
+++ b/src/axom/inlet/tests/inlet_Inlet.cpp
@@ -28,7 +28,7 @@ Inlet createBasicInlet(DataStore* ds,
                        const std::string& luaString,
                        bool enableDocs = true)
 {
-  auto lr = std::make_unique<LuaReader>();
+  auto lr = axom::inlet::cpp11_compat::make_unique<LuaReader>();
   lr->parseString(luaString);
 
   return Inlet(std::move(lr), ds->getRoot(), enableDocs);

--- a/src/axom/inlet/tests/inlet_Inlet.cpp
+++ b/src/axom/inlet/tests/inlet_Inlet.cpp
@@ -28,10 +28,10 @@ Inlet createBasicInlet(DataStore* ds,
                        const std::string& luaString,
                        bool enableDocs = true)
 {
-  auto lr = std::make_shared<LuaReader>();
+  auto lr = std::make_unique<LuaReader>();
   lr->parseString(luaString);
 
-  return Inlet(lr, ds->getRoot(), enableDocs);
+  return Inlet(std::move(lr), ds->getRoot(), enableDocs);
 }
 
 TEST(inlet_Inlet_basic, getTopLevelBools)

--- a/src/axom/inlet/tests/inlet_Inlet.cpp
+++ b/src/axom/inlet/tests/inlet_Inlet.cpp
@@ -1036,11 +1036,11 @@ TEST(inlet_Inlet_verify, verifyDoubleRange)
   auto inlet1 = createBasicInlet(&ds1, testString1);
 
   auto field1 = inlet1->addDouble("field2");
-  field1->defaultValue(5)->range(0, 60);  // ints will get casted to double
+  field1->defaultValue(5).range(0, 60);  // ints will get casted to double
   EXPECT_TRUE(inlet1->verify());
 
   field1 = inlet1->addDouble("field3");
-  field1->defaultValue(-12)->range(-10.5, 13.23);
+  field1->defaultValue(-12).range(-10.5, 13.23);
   EXPECT_FALSE(inlet1->verify());
 }
 
@@ -1074,15 +1074,15 @@ TEST(inlet_Inlet_verify, verifyIntRange)
   DataStore ds1;
   auto inlet1 = createBasicInlet(&ds1, testString1);
   field = inlet1->addInt("field2");
-  field->range(0, 56)->defaultValue(32);
+  field->range(0, 56).defaultValue(32);
   EXPECT_TRUE(inlet1->verify());
 
   field = inlet1->addInt("field3");
-  field->range(-12, 13)->defaultValue(-3);
+  field->range(-12, 13).defaultValue(-3);
   EXPECT_TRUE(inlet1->verify());
 
   field = inlet1->addInt("NewTable/field4");
-  field->range(1, 23)->defaultValue(24);
+  field->range(1, 23).defaultValue(24);
   EXPECT_FALSE(inlet1->verify());
 }
 
@@ -1119,19 +1119,19 @@ TEST(inlet_Inlet_verify, verifyValidIntValues)
   auto inlet1 = createBasicInlet(&ds1, testString1);
 
   field = inlet1->addInt("field2");
-  field->validValues({1, 2, 3, 56, 57, 58})->defaultValue(2);
+  field->validValues({1, 2, 3, 56, 57, 58}).defaultValue(2);
   EXPECT_TRUE(inlet1->verify());
 
   field = inlet1->addInt("field3");
-  field->validValues(nums)->defaultValue(21);
+  field->validValues(nums).defaultValue(21);
   EXPECT_TRUE(inlet1->verify());
 
   field = inlet1->addInt("NewTable/field4");
-  field->validValues({44, 40, 48, 22})->defaultValue(48);
+  field->validValues({44, 40, 48, 22}).defaultValue(48);
   EXPECT_TRUE(inlet1->verify());
 
   field = inlet1->addInt("NewTable/field5");
-  field->validValues(nums)->defaultValue(90);
+  field->validValues(nums).defaultValue(90);
   EXPECT_FALSE(inlet1->verify());
 }
 
@@ -1170,19 +1170,19 @@ TEST(inlet_Inlet_verify, verifyValidDoubleValues)
   auto inlet1 = createBasicInlet(&ds1, testString1);
 
   field = inlet1->addDouble("field2");
-  field->validValues({1, 2, 3, 56, 57, 58})->defaultValue(2.);
+  field->validValues({1, 2, 3, 56, 57, 58}).defaultValue(2.);
   EXPECT_TRUE(inlet1->verify());
 
   field = inlet1->addDouble("field3");
-  field->validValues(nums)->defaultValue(21);
+  field->validValues(nums).defaultValue(21);
   EXPECT_TRUE(inlet1->verify());
 
   field = inlet1->addDouble("NewTable/field4");
-  field->validValues({44.05, 40.13, 48.28, 22.})->defaultValue(48.28);
+  field->validValues({44.05, 40.13, 48.28, 22.}).defaultValue(48.28);
   EXPECT_TRUE(inlet1->verify());
 
   field = inlet1->addDouble("NewTable/field5");
-  field->validValues(nums)->defaultValue(90.1);
+  field->validValues(nums).defaultValue(90.1);
   EXPECT_FALSE(inlet1->verify());
 }
 
@@ -1219,11 +1219,11 @@ TEST(inlet_Inlet_verify, verifyValidStringValues)
   auto inlet1 = createBasicInlet(&ds1, testString1);
 
   field = inlet1->addString("field2");
-  field->validValues({"abc", "defg", "hijk", "lm"})->defaultValue("defg");
+  field->validValues({"abc", "defg", "hijk", "lm"}).defaultValue("defg");
   EXPECT_TRUE(inlet1->verify());
 
   field = inlet1->addString("field3");
-  field->validValues(strs)->defaultValue("wx");
+  field->validValues(strs).defaultValue("wx");
   EXPECT_TRUE(inlet1->verify());
 
   field = inlet1->addString("NewTable/field4");
@@ -1231,7 +1231,7 @@ TEST(inlet_Inlet_verify, verifyValidStringValues)
   EXPECT_TRUE(inlet1->verify());
 
   field = inlet1->addString("NewTable/field5");
-  field->validValues(strs)->defaultValue("zyx");
+  field->validValues(strs).defaultValue("zyx");
   EXPECT_FALSE(inlet1->verify());
 }
 
@@ -1247,13 +1247,13 @@ TEST(inlet_verify, verifyFieldLambda)
   auto field2 = inlet->addString("field2");
   auto field3 = inlet->addString("NewTable/field3");
 
-  field2->registerVerifier([](Field& field) -> bool {
+  field2->registerVerifier([](const Field& field) -> bool {
     auto str = field.get<std::string>();
     return (str.size() >= 1 && str[0] == 'a');
   });
   EXPECT_TRUE(inlet->verify());
 
-  field3->registerVerifier([](Field& field) -> bool {
+  field3->registerVerifier([](const Field& field) -> bool {
     auto str = field.get<std::string>();
     return (str.size() >= 1 && str[0] == 'a');
   });
@@ -1273,13 +1273,13 @@ TEST(inlet_verify, verifyTableLambda1)
   auto table1 = inlet->addTable("NewTable");
   auto field3 = table1->addString("field3");
 
-  field2->registerVerifier([](Field& field) -> bool {
+  field2->registerVerifier([](const Field& field) -> bool {
     auto str = field.get<std::string>();
     return (str.size() >= 1 && str[0] == 'a');
   });
   EXPECT_TRUE(inlet->verify());
 
-  field3->registerVerifier([](Field& field) -> bool {
+  field3->registerVerifier([](const Field& field) -> bool {
     auto str = field.get<std::string>();
     return (str.size() >= 1 && str[0] == 'x');
   });
@@ -1288,11 +1288,11 @@ TEST(inlet_verify, verifyTableLambda1)
   EXPECT_TRUE(table1->hasField("field3"));
 
   table1->registerVerifier(
-    [](Table& table) -> bool { return table.contains("field3"); });
+    [](const Table& table) -> bool { return table.contains("field3"); });
   EXPECT_TRUE(inlet->verify());
 
   table1->registerVerifier(
-    [](Table& table) -> bool { return table.contains("field22"); });
+    [](const Table& table) -> bool { return table.contains("field22"); });
   EXPECT_FALSE(inlet->verify());
 }
 
@@ -1319,7 +1319,7 @@ TEST(inlet_verify, verifyTableLambda2)
   auto globalTable = inlet->getGlobalTable();
   auto material = globalTable->getTable("material");
 
-  globalTable->registerVerifier([](Table& table) -> bool {
+  globalTable->registerVerifier([](const Table& table) -> bool {
     bool verifySuccess = true;
     if(table.contains("thermal_solver") &&
        !table["material"].contains("thermalview"))
@@ -1392,7 +1392,7 @@ TEST(inlet_verify, verifyTableLambda3)
   v->required(true);
   v->addInt("x");
 
-  v->registerVerifier([&myInlet](Table& table) -> bool {
+  v->registerVerifier([&myInlet](const Table& table) -> bool {
     int dim = (*myInlet)["dimensions"];
     bool x_present =
       table.contains("x") && (table["x"].type() == InletType::Integer);

--- a/src/axom/inlet/tests/inlet_Inlet.cpp
+++ b/src/axom/inlet/tests/inlet_Inlet.cpp
@@ -28,7 +28,7 @@ Inlet createBasicInlet(DataStore* ds,
                        const std::string& luaString,
                        bool enableDocs = true)
 {
-  auto lr = axom::inlet::cpp11_compat::make_unique<LuaReader>();
+  auto lr = std::make_unique<LuaReader>();
   lr->parseString(luaString);
 
   return Inlet(std::move(lr), ds->getRoot(), enableDocs);

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -26,10 +26,10 @@ Inlet createBasicInlet(DataStore* ds,
                        const std::string& luaString,
                        bool enableDocs = true)
 {
-  auto lr = std::make_shared<LuaReader>();
+  auto lr = std::make_unique<LuaReader>();
   lr->parseString(luaString);
 
-  return Inlet(lr, ds->getRoot(), enableDocs);
+  return Inlet(std::move(lr), ds->getRoot(), enableDocs);
 }
 
 struct Foo

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -26,7 +26,7 @@ Inlet createBasicInlet(DataStore* ds,
                        const std::string& luaString,
                        bool enableDocs = true)
 {
-  auto lr = std::make_unique<LuaReader>();
+  auto lr = axom::inlet::cpp11_compat::make_unique<LuaReader>();
   lr->parseString(luaString);
 
   return Inlet(std::move(lr), ds->getRoot(), enableDocs);

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -26,7 +26,7 @@ Inlet createBasicInlet(DataStore* ds,
                        const std::string& luaString,
                        bool enableDocs = true)
 {
-  auto lr = axom::inlet::cpp11_compat::make_unique<LuaReader>();
+  auto lr = std::make_unique<LuaReader>();
   lr->parseString(luaString);
 
   return Inlet(std::move(lr), ds->getRoot(), enableDocs);


### PR DESCRIPTION
# Summary

- This PR is a refactoring
- It does the following:
  - Removes all `shared_ptr`s from the Inlet component as shared ownership is not necessary from what I can tell


Unfortunately this PR is somewhat large, but the changes are fairly boring.  

In general, functions that returned `shared_ptr`s to `Field`s or `Table`s now return references as ownership is managed by the parent `Table` object.  Functions that previously returned `shared_ptr`s to the calling object now return references to the calling object.

`unique_ptr`s were used for the `Reader` and `DocWriter` classes (where instances are moved into the `Inlet` object, as I could not think of a use case where unique ownership is insufficient.  `Table`s store references to the `Reader` object as ownership is managed by the parent `Inlet`.  This required the re implementation of `std::make_unique` for c++11 compatibility, which I've placed in a `axom::inlet::cpp11_compat` namespace.  This is also provided by umpire but I was hesitant to make Inlet dependent on umpire just for a one-line function.

The use of references allows for more flexibility with respect to covariant return types.  After arrays of structs were added, 
functions like `Table::required(bool)` **had** to return `std::shared_ptr<Verifiable>` instead of `std::shared_ptr<Table>`, meaning that the following was no longer possible:
```cpp
auto v = inlet->addTable("vector")->required(true);
v->addInt("x"); // Error: No match for function Verifiable::addInt
// Instead, has to be like this, perhaps less obvious that the table is required
auto v = inlet->addTable("vector");
v->required(true);
v->addInt("x");
```

Now, `Table::required` can return `Table&`, allowing for the following:
```cpp
auto& v = myInlet.addTable("vector").required(true);
v.addInt("x");
```

Note that the `auto` required a reference qualifier to not make a copy.  To avoid bugs and memory safety issues related to the use of the implicit shallow copy constructor, the copy constructors and copy assignment operators have been explicitly deleted from the `Table` and `Verifiable/VerifiableScalar` types, respectively.

Removal of `shared_ptr` also makes `operator[]` nicer to use:
```cpp
(*inlet)["path"];
```
can be replaced with
```cpp
inlet["path"];
```
which looks a bit nicer in my opinion.
