### PR TITLE
simplify the packages.yaml mpi buildable logic

### DIFF
--- a/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib/devtools/packages.yaml
+++ b/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib/devtools/packages.yaml
@@ -22,37 +22,17 @@ packages:
       mpi: [spectrum-mpi]
   cuda:
     buildable: false
-  mvapich2:
-    buildable: false
-  openmpi:
-    buildable: false
-  mpich:
-    buildable: false
-  spectrum-mpi:
-    buildable: false
-  charmpp:
-    buildable: false
-  charm:
-    buildable: false
-  intel-mpi:
-    buildable: false
-  intel-parallel-studio:
-    buildable: false
-  fujitsu-mpi:
-    buildable: false
-  mpilander:
-    buildable: false
-  mpt:
+  mpi:
     buildable: false
 
   # blas is a bit more complicated because its a virtual package so fake it with
   # the following per spack docs
   netlib-lapack:
     buildable: false
-
     externals:
     - spec: netlib-lapack@3.6.1
       prefix: /usr
+
 # System level packages to not build
   autoconf:
     buildable: false
@@ -96,10 +76,10 @@ packages:
       prefix: /usr
   tar:
     buildable: false
-
     externals:
     - spec: tar
       prefix: /usr
+
 # Globally lock in version of CMake
   cmake:
     version: [3.14.5]

--- a/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib/packages.yaml
+++ b/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib/packages.yaml
@@ -29,6 +29,8 @@ packages:
       prefix: /usr/tce/packages/cuda/cuda-10.1.243
 
 # LLNL blueos mpi
+  mpi:
+    buildable: false
   spectrum-mpi:
     buildable: false
     externals:
@@ -42,36 +44,15 @@ packages:
       prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/
     - spec: spectrum-mpi@release%xl@16.1.1_nvcc
       prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/
-# Spack may grab for mpi & we don't want to use them
-  mvapich2:
-    buildable: false
-  openmpi:
-    buildable: false
-  mpich:
-    buildable: false
-  charmpp:
-    buildable: false
-  charm:
-    buildable: false
-  intel-mpi:
-    buildable: false
-  intel-parallel-studio:
-    buildable: false
-  fujitsu-mpi:
-    buildable: false
-  mpilander:
-    buildable: false
-  mpt:
-    buildable: false
 
   # blas is a bit more complicated because its a virtual package so fake it with
   # the following per spack docs
   netlib-lapack:
     buildable: false
-
     externals:
     - spec: netlib-lapack@3.6.1
       prefix: /usr
+
 # System level packages to not build
   autoconf:
     buildable: false

--- a/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/devtools/packages.yaml
+++ b/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/devtools/packages.yaml
@@ -22,37 +22,17 @@ packages:
       mpi: [spectrum-mpi]
   cuda:
     buildable: false
-  mvapich2:
-    buildable: false
-  openmpi:
-    buildable: false
-  mpich:
-    buildable: false
-  spectrum-mpi:
-    buildable: false
-  charmpp:
-    buildable: false
-  charm:
-    buildable: false
-  intel-mpi:
-    buildable: false
-  intel-parallel-studio:
-    buildable: false
-  fujitsu-mpi:
-    buildable: false
-  mpilander:
-    buildable: false
-  mpt:
+  mpi:
     buildable: false
 
   # blas is a bit more complicated because its a virtual package so fake it with
   # the following per spack docs
   netlib-lapack:
     buildable: false
-
     externals:
     - spec: netlib-lapack@3.6.1
       prefix: /usr
+
 # System level packages to not build
   autoconf:
     buildable: false
@@ -96,10 +76,10 @@ packages:
       prefix: /usr
   tar:
     buildable: false
-
     externals:
     - spec: tar
       prefix: /usr
+
 # Globally lock in version of CMake
   cmake:
     version: [3.14.5]

--- a/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/packages.yaml
+++ b/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/packages.yaml
@@ -29,6 +29,8 @@ packages:
       prefix: /usr/tce/packages/cuda/cuda-10.1.243
 
 # LLNL blueos mpi
+  mpi:
+    buildable: false
   spectrum-mpi:
     buildable: false
     externals:
@@ -42,36 +44,15 @@ packages:
       prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/
     - spec: spectrum-mpi@release%xl@16.1.1_nvcc
       prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/
-# Spack may grab for mpi & we don't want to use them
-  mvapich2:
-    buildable: false
-  openmpi:
-    buildable: false
-  mpich:
-    buildable: false
-  charmpp:
-    buildable: false
-  charm:
-    buildable: false
-  intel-mpi:
-    buildable: false
-  intel-parallel-studio:
-    buildable: false
-  fujitsu-mpi:
-    buildable: false
-  mpilander:
-    buildable: false
-  mpt:
-    buildable: false
 
   # blas is a bit more complicated because its a virtual package so fake it with
   # the following per spack docs
   netlib-lapack:
     buildable: false
-
     externals:
     - spec: netlib-lapack@3.6.1
       prefix: /usr
+
 # System level packages to not build
   autoconf:
     buildable: false

--- a/scripts/uberenv/spack_configs/docker/packages.yaml
+++ b/scripts/uberenv/spack_configs/docker/packages.yaml
@@ -35,11 +35,15 @@ packages:
       szip: [libszip, libaec]
       tbb: [intel-tbb]
       jpeg: [libjpeg-turbo, libjpeg]
-# Spack may grab for mpi & we don't want to use them
-  charm:
+
+  # Spack may grab for mpi & we don't want to use them
+  mpi:
     buildable: false
-  mpilander:
-    buildable: false
+  mpich:
+    externals:
+    - spec: mpich@3.3
+      prefix: /usr
+
 # System level packages to not build
   autotools:
     buildable: false

--- a/scripts/uberenv/spack_configs/toss_3_x86_64_ib/devtools/packages.yaml
+++ b/scripts/uberenv/spack_configs/toss_3_x86_64_ib/devtools/packages.yaml
@@ -25,37 +25,17 @@ packages:
       mpi: [mvapich2]
   cuda:
     buildable: false
-  mvapich2:
-    buildable: false
-  openmpi:
-    buildable: false
-  mpich:
-    buildable: false
-  spectrum-mpi:
-    buildable: false
-  charmpp:
-    buildable: false
-  charm:
-    buildable: false
-  intel-mpi:
-    buildable: false
-  intel-parallel-studio:
-    buildable: false
-  fujitsu-mpi:
-    buildable: false
-  mpilander:
-    buildable: false
-  mpt:
+  mpi:
     buildable: false
 
   # blas is a bit more complicated because its a virtual package so fake it with
   # the following per spack docs
   netlib-lapack:
     buildable: false
-
     externals:
     - spec: netlib-lapack@3.6.1
       prefix: /usr
+
 # System level packages to not build
   autoconf:
     buildable: false
@@ -99,10 +79,10 @@ packages:
       prefix: /usr
   tar:
     buildable: false
-
     externals:
     - spec: tar
       prefix: /usr
+
 # Globally lock in version of CMake
   cmake:
     version: [3.14.5]

--- a/scripts/uberenv/spack_configs/toss_3_x86_64_ib/packages.yaml
+++ b/scripts/uberenv/spack_configs/toss_3_x86_64_ib/packages.yaml
@@ -23,14 +23,17 @@ packages:
       blas: [netlib-lapack]
       lapack: [netlib-lapack]
       mpi: [mvapich2]
+
 # LLNL toss3 CUDA 
   cuda:
     buildable: false
-
     externals:
     - spec: cuda@10.2
       prefix: /opt/cudatoolkit/10.2
+
 # Lock down which MPI we are using
+  mpi:
+    buildable: false
   mvapich2:
     buildable: false
     externals:
@@ -46,27 +49,6 @@ packages:
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.2
     - spec: mvapich2@2.3%intel@19.0.4 process_managers=slurm arch=linux-rhel7-ivybridge
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.0
-# Spack may grab for mpi & we don't want to use them
-  openmpi:
-    buildable: false
-  mpich:
-    buildable: false
-  spectrum-mpi:
-    buildable: false
-  charmpp:
-    buildable: false
-  charm:
-    buildable: false
-  intel-mpi:
-    buildable: false
-  intel-parallel-studio:
-    buildable: false
-  fujitsu-mpi:
-    buildable: false
-  mpilander:
-    buildable: false
-  mpt:
-    buildable: false
 
   # blas is a bit more complicated because its a virtual package so fake it with
   # the following per spack docs


### PR DESCRIPTION
Forgot to add the new packages.yaml support for the general `mpi` target when i updated spack.