### PR TITLE
Split HEADERS from SOURCES on blt_add_executable

### DIFF
--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -55,7 +55,8 @@ if (NOT ENABLE_MPI)
 endif()
 
 blt_add_executable( NAME       core_serial_tests
-                    SOURCES    core_serial_main.cpp ${gtest_utils_tests}
+                    SOURCES    core_serial_main.cpp
+                    HEADERS    ${gtest_utils_tests}
                     OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                     DEPENDS_ON ${utils_tests_depends}
                     FOLDER     axom/core/tests )
@@ -75,7 +76,8 @@ if (ENABLE_MPI)
        )
 
   blt_add_executable( NAME       core_mpi_tests
-                      SOURCES    core_mpi_main.cpp ${core_mpi_tests}
+                      SOURCES    core_mpi_main.cpp
+                      HEADERS    ${core_mpi_tests}
                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                       DEPENDS_ON ${utils_tests_depends} mpi
                       FOLDER     axom/core/tests )

--- a/src/axom/lumberjack/tests/CMakeLists.txt
+++ b/src/axom/lumberjack/tests/CMakeLists.txt
@@ -15,7 +15,8 @@ set(lumberjack_serial_tests
     lumberjack_TextEqualityCombiner.hpp )
 
 blt_add_executable(NAME       lumberjack_serial_tests
-                   SOURCES    lumberjack_serial_main.cpp ${lumberjack_serial_tests}
+                   SOURCES    lumberjack_serial_main.cpp
+                   HEADERS    ${lumberjack_serial_tests}
                    OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                    DEPENDS_ON lumberjack gtest 
                    FOLDER     axom/lumberjack/tests )
@@ -35,7 +36,8 @@ set(lumberjack_mpi_tests
     lumberjack_RootCommunicator.hpp )
 
 blt_add_executable(NAME       lumberjack_mpi_tests
-                   SOURCES    lumberjack_mpi_main.cpp ${lumberjack_mpi_tests}
+                   SOURCES    lumberjack_mpi_main.cpp
+                   HEADERS    ${lumberjack_mpi_tests}
                    OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                    DEPENDS_ON lumberjack mpi gtest 
                    FOLDER     axom/lumberjack/tests )

--- a/src/axom/sidre/examples/lulesh2/CMakeLists.txt
+++ b/src/axom/sidre/examples/lulesh2/CMakeLists.txt
@@ -29,7 +29,8 @@ blt_list_append( TO lulesh_depends ELEMENTS openmp IF ENABLE_OPENMP )
 
 blt_add_executable(
     NAME sidre_lulesh2_ex
-    SOURCES ${lulesh_sources} ${lulesh_headers}
+    SOURCES ${lulesh_sources}
+    HEADERS ${lulesh_headers}
     OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
     DEPENDS_ON ${lulesh_depends}
     FOLDER axom/sidre/examples )

--- a/src/axom/sidre/tests/spio/CMakeLists.txt
+++ b/src/axom/sidre/tests/spio/CMakeLists.txt
@@ -36,7 +36,8 @@ endif()
 # Add gtest C++ tests
 #------------------------------------------------------------------------------
 blt_add_executable( NAME       spio_tests
-                    SOURCES    spio_main.cpp ${gtest_spio_parallel_tests} ${gtest_spio_serial_tests}
+                    SOURCES    spio_main.cpp
+                    HEADERS    ${gtest_spio_parallel_tests} ${gtest_spio_serial_tests}
                     OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                     DEPENDS_ON ${spio_test_depends} gtest
                     FOLDER     axom/sidre/tests

--- a/src/axom/slam/examples/lulesh2.0.3_orig/CMakeLists.txt
+++ b/src/axom/slam/examples/lulesh2.0.3_orig/CMakeLists.txt
@@ -39,14 +39,16 @@ set_source_files_properties(${lulesh_sources} ${lulesh_headers}
 if ( lulesh_depends_on )
     blt_add_executable(
         NAME        slam_lulesh_orig_ex
-        SOURCES     ${lulesh_sources} ${lulesh_headers}
+        SOURCES     ${lulesh_sources}
+        HEADERS     ${lulesh_headers}
         OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
         DEPENDS_ON  ${lulesh_depends_on}
         FOLDER      axom/slam/examples )
 else()
     blt_add_executable(
         NAME        slam_lulesh_orig_ex
-        SOURCES     ${lulesh_sources} ${lulesh_headers}
+        SOURCES     ${lulesh_sources}
+        HEADERS     ${lulesh_headers}
         OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
         FOLDER      axom/slam/examples )
 endif()


### PR DESCRIPTION
This updates BLT to include the fix i just put in to split HEADERS from SOURCES on blt_add_executable.  This is important for file level dependency checking during the build system run (ie makefiles) as well as IDE folder support.

Surprisingly enough CMake is not smart enough not to compile a header when you flag it for separable compilation, it has logic everywhere else not to compile a header by itself based on file extension.  My guess this is in the old CUDA support and will go away when we switch to the new CMake CUDA support.