### PR TITLE
Bugfix/white238/spackpackage

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   types, and support for arrays of user-defined types
 - Added compiler define `NOMINMAX` to `axom/config.hpp.in` to avoid problems with
   the Windows `min` and `max` macros.
+- Added `cpp14` variant to Spack package to allow `Inlet::LuaReader` to be used easier.
 
 ### Changed
 - The Sidre Datastore no longer rewires Conduit's error handlers to SLIC by default. 

--- a/scripts/uberenv/packages/axom/package.py
+++ b/scripts/uberenv/packages/axom/package.py
@@ -422,19 +422,24 @@ class Axom(CMakePackage, CudaPackage):
 
         # Only turn on clangformat support if devtools is on
         if "+devtools" in spec:
-            lc_clangformatpath = "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format"
-            # This works only with Ubuntu + Debian - other distros (Arch/Fedora) use
-            # /usr/bin/clang-format which would require actually running the executable to grab the version
-            apt_clangformatpath = "/usr/bin/clang-format-10"
-            if os.path.exists(lc_clangformatpath):
-                cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE", lc_clangformatpath))
-            elif os.path.exists(apt_clangformatpath):
-                cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE", apt_clangformatpath))
-            else:
+            cf_paths = []
+            lc_clangpath = "/usr/tce/packages/clang/clang-10.0.0"
+            cf_paths.append(pjoin(lc_clangpath, "bin/clang-format"))
+            cf_paths.append("/usr/bin/clang-format-10")
+            cf_paths.append("/usr/bin/clang-format")
+
+            cf_found = False
+            for path in cf_paths:
+                if os.path.exists(path):
+                    cf_found = True
+                    cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE",
+                                                path))
+
+            if not cf_found:
                 cfg.write("# Unable to find clang-format\n\n")
                 cfg.write(cmake_cache_option("ENABLE_CLANGFORMAT", False))
         else:
-            cfg.write("# Devtools disabled\n\n")
+            cfg.write("# ClangFormat disabled due to disabled devtools\n")
             cfg.write(cmake_cache_option("ENABLE_CLANGFORMAT", False))
 
         ##################################

--- a/scripts/uberenv/packages/axom/package.py
+++ b/scripts/uberenv/packages/axom/package.py
@@ -51,14 +51,14 @@ class Axom(CMakePackage, CudaPackage):
     homepage = "https://github.com/LLNL/axom"
     git      = "https://github.com/LLNL/axom.git"
 
-    version('main', branch='main', submodules='True')
-    version('develop', branch='develop', submodules='True')
-    version('0.4.0', tag='v0.4.0', submodules='True')
-    version('0.3.3', tag='v0.3.3', submodules='True')
-    version('0.3.2', tag='v0.3.2', submodules='True')
-    version('0.3.1', tag='v0.3.1', submodules='True')
-    version('0.3.0', tag='v0.3.0', submodules='True')
-    version('0.2.9', tag='v0.2.9', submodules='True')
+    version('main', branch='main', submodules=True)
+    version('develop', branch='develop', submodules=True)
+    version('0.4.0', tag='v0.4.0', submodules=True)
+    version('0.3.3', tag='v0.3.3', submodules=True)
+    version('0.3.2', tag='v0.3.2', submodules=True)
+    version('0.3.1', tag='v0.3.1', submodules=True)
+    version('0.3.0', tag='v0.3.0', submodules=True)
+    version('0.2.9', tag='v0.2.9', submodules=True)
 
     phases = ["hostconfig", "cmake", "build", "install"]
     root_cmakelists_dir = 'src'
@@ -70,6 +70,8 @@ class Axom(CMakePackage, CudaPackage):
             description='Enable build of shared libraries')
     variant('debug',    default=False,
             description='Build debug instead of optimized version')
+
+    variant('cpp14',  default=True, description="Build with C++14 support")
 
     variant('fortran',  default=True, description="Build with Fortran support")
 
@@ -103,7 +105,7 @@ class Axom(CMakePackage, CudaPackage):
     depends_on("conduit~hdf5", when="~hdf5")
 
     # HDF5 needs to be the same as Conduit's
-    depends_on("hdf5@1.8.19:1.8.999~mpi~cxx~shared~fortran", when="+hdf5")
+    depends_on("hdf5@1.8.19:1.8.999~cxx~shared~fortran", when="+hdf5")
 
     depends_on("lua", when="+lua")
 
@@ -243,6 +245,9 @@ class Axom(CMakePackage, CudaPackage):
             if flags:
                 cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS", flags,
                                             description))
+
+        if "+cpp14" in spec:
+            cfg.write(cmake_cache_entry("BLT_CXX_STD", "c++14", ""))
 
         # TPL locations
         cfg.write("#------------------{0}\n".format("-" * 60))

--- a/scripts/uberenv/packages/axom/package.py
+++ b/scripts/uberenv/packages/axom/package.py
@@ -415,16 +415,22 @@ class Axom(CMakePackage, CudaPackage):
             cfg.write(cmake_cache_entry("CPPCHECK_EXECUTABLE",
                                         pjoin(cppcheck_bin_dir, "cppcheck")))
 
-        lc_clangformatpath = "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format"
-        # This works only with Ubuntu + Debian - other distros (Arch/Fedora) use
-        # /usr/bin/clang-format which would require actually running the executable to grab the version
-        apt_clangformatpath = "/usr/bin/clang-format-10"
-        if os.path.exists(lc_clangformatpath):
-            cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE", lc_clangformatpath))
-        elif os.path.exists(apt_clangformatpath):
-            cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE", apt_clangformatpath))
+        # Only turn on clangformat support if devtools is on
+        if "+devtools" in spec:
+            lc_clangformatpath = "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format"
+            # This works only with Ubuntu + Debian - other distros (Arch/Fedora) use
+            # /usr/bin/clang-format which would require actually running the executable to grab the version
+            apt_clangformatpath = "/usr/bin/clang-format-10"
+            if os.path.exists(lc_clangformatpath):
+                cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE", lc_clangformatpath))
+            elif os.path.exists(apt_clangformatpath):
+                cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE", apt_clangformatpath))
+            else:
+                cfg.write("# Unable to find clang-format\n\n")
+                cfg.write(cmake_cache_option("ENABLE_CLANGFORMAT", False))
         else:
-            cfg.write("# Unable to find clang-format\n\n")
+            cfg.write("# Devtools disabled\n\n")
+            cfg.write(cmake_cache_option("ENABLE_CLANGFORMAT", False))
 
         ##################################
         # Other machine specifics

--- a/scripts/uberenv/specs.json
+++ b/scripts/uberenv/specs.json
@@ -14,27 +14,27 @@
     "__comment__":"##############################################################################",
 
     "toss_3_x86_64_ib":
-    [ "clang@9.0.0+devtools+mfem",
-      "clang@10.0.0+devtools+mfem",
-      "gcc@8.1.0+devtools+mfem",
-      "gcc@8.1_no_fortran~fortran+devtools+mfem",
-      "intel@18.0.2+devtools+mfem",
-      "intel@19.0.4+devtools+mfem" ],
+    [ "clang@9.0.0~cpp14+devtools+mfem",
+      "clang@10.0.0~cpp14+devtools+mfem",
+      "gcc@8.1.0~cpp14+devtools+mfem",
+      "gcc@8.1_no_fortran~cpp14~fortran+devtools+mfem",
+      "intel@18.0.2~cpp14+devtools+mfem",
+      "intel@19.0.4~cpp14+devtools+mfem" ],
 
     "blueos_3_ppc64le_ib":
-    [ "clang@9.0.0_upstream_xlf~openmp+devtools+mfem",
-      "clang@8.0.1_nvcc_xlf~openmp+devtools+mfem+cuda cuda_arch=60",
-      "gcc@7.3.1+devtools+mfem",
-      "xl@16.1.1_coral~openmp+devtools+mfem",
-      "xl@16.1.1_nvcc~openmp+devtools+mfem+cuda cuda_arch=60" ],
+    [ "clang@9.0.0_upstream_xlf~cpp14~openmp+devtools+mfem",
+      "clang@8.0.1_nvcc_xlf~cpp14~openmp+devtools+mfem+cuda cuda_arch=60",
+      "gcc@7.3.1~cpp14+devtools+mfem",
+      "xl@16.1.1_coral~cpp14~openmp+devtools+mfem",
+      "xl@16.1.1_nvcc~cpp14~openmp+devtools+mfem+cuda cuda_arch=60" ],
 
     "blueos_3_ppc64le_ib_p9":
-    [ "clang@9.0.0_upstream_xlf~openmp+devtools+mfem",
-      "clang@8.0.1_nvcc_xlf~openmp+devtools+mfem+cuda cuda_arch=70",
-      "gcc@7.3.1+devtools+mfem",
-      "xl@16.1.1_coral~openmp+devtools+mfem",
-      "xl@16.1.1_nvcc~openmp+devtools+mfem+cuda cuda_arch=70" ],
+    [ "clang@9.0.0_upstream_xlf~cpp14~openmp+devtools+mfem",
+      "clang@8.0.1_nvcc_xlf~cpp14~openmp+devtools+mfem+cuda cuda_arch=70",
+      "gcc@7.3.1~cpp14+devtools+mfem",
+      "xl@16.1.1_coral~cpp14~openmp+devtools+mfem",
+      "xl@16.1.1_nvcc~cpp14~openmp+devtools+mfem+cuda cuda_arch=70" ],
 
     "darwin-x86_64":
-    [ "clang@9.0.0+devtools+mfem" ]
+    [ "clang@9.0.0~cpp14+devtools+mfem" ]
 }

--- a/src/axom/sidre/tests/spio/F_spio_blueprintIndex.F
+++ b/src/axom/sidre/tests/spio/F_spio_blueprintIndex.F
@@ -112,6 +112,8 @@ program spio_blueprint_index
 
   call writer%write_blueprint_index_to_root_file(cds, "domain_data/domain/mesh", "fbp.root", "mesh")
 
+  call mpi_finalize(mpierr)
+
   if (return_val .ne. 0) then
      call exit(1)
   endif


### PR DESCRIPTION
The main reason for this was to turn off clang-format explicitly when devtools was not enabled.  This was causing a problem in the version checking regex that will be fixed in BLT soon.

This also unifies a bunch of changes across projects with their own axom/package.py.  This will get upstreamed to spack's repo as well.