### PR TITLE
Removes integer suffix from "datagroup" label in SPIO output

### DIFF
--- a/src/axom/sidre/spio/IOManager.cpp
+++ b/src/axom/sidre/spio/IOManager.cpp
@@ -217,7 +217,7 @@ void IOManager::write(sidre::Group* datagroup,
     SLIC_ASSERT(h5_file_id >= 0);
 
     std::string group_name;
-    if (m_comm_size == num_files)
+    if(m_comm_size == num_files)
     {
       group_name = "datagroup";
     }
@@ -449,11 +449,11 @@ void IOManager::loadExternalData(sidre::Group* datagroup,
       SLIC_ASSERT(h5_file_id >= 0);
 
       std::string group_name = "datagroup";
-      if (H5Lexists(h5_file_id, group_name.c_str(), 0) <= 0)
+      if(H5Lexists(h5_file_id, group_name.c_str(), 0) <= 0)
       {
         group_name = fmt::sprintf("datagroup_%07d", m_my_rank);
       }
- 
+
       hid_t h5_group_id = H5Gopen(h5_file_id, group_name.c_str(), 0);
       SLIC_ASSERT(h5_group_id >= 0);
 
@@ -481,7 +481,7 @@ void IOManager::loadExternalData(sidre::Group* datagroup,
       SLIC_ASSERT(h5_file_id >= 0);
 
       std::string group_name = "datagroup";
-      if (H5Lexists(h5_file_id, group_name.c_str(), 0) <= 0)
+      if(H5Lexists(h5_file_id, group_name.c_str(), 0) <= 0)
       {
         group_name = fmt::sprintf("datagroup_%07d", input_rank);
       }
@@ -787,7 +787,7 @@ void IOManager::readSidreHDF5(sidre::Group* datagroup,
       SLIC_ASSERT(h5_file_id >= 0);
 
       std::string group_name = "datagroup";
-      if (H5Lexists(h5_file_id, group_name.c_str(), 0) <= 0)
+      if(H5Lexists(h5_file_id, group_name.c_str(), 0) <= 0)
       {
         group_name = fmt::sprintf("datagroup_%07d", m_my_rank);
       }
@@ -820,7 +820,7 @@ void IOManager::readSidreHDF5(sidre::Group* datagroup,
       SLIC_ASSERT(h5_file_id >= 0);
 
       std::string group_name = "datagroup";
-      if (H5Lexists(h5_file_id, group_name.c_str(), 0) <= 0)
+      if(H5Lexists(h5_file_id, group_name.c_str(), 0) <= 0)
       {
         group_name = fmt::sprintf("datagroup_%07d", m_my_rank);
       }

--- a/src/axom/sidre/spio/IOManager.cpp
+++ b/src/axom/sidre/spio/IOManager.cpp
@@ -216,12 +216,8 @@ void IOManager::write(sidre::Group* datagroup,
     }
     SLIC_ASSERT(h5_file_id >= 0);
 
-    std::string group_name;
-    if(m_comm_size == num_files)
-    {
-      group_name = "datagroup";
-    }
-    else
+    std::string group_name = "datagroup";
+    if(m_comm_size != num_files)
     {
       group_name = fmt::sprintf("datagroup_%07d", m_my_rank);
     }

--- a/src/axom/sidre/spio/IOManager.cpp
+++ b/src/axom/sidre/spio/IOManager.cpp
@@ -216,7 +216,15 @@ void IOManager::write(sidre::Group* datagroup,
     }
     SLIC_ASSERT(h5_file_id >= 0);
 
-    std::string group_name = fmt::sprintf("datagroup_%07d", m_my_rank);
+    std::string group_name;
+    if (m_comm_size == num_files)
+    {
+      group_name = "datagroup";
+    }
+    else
+    {
+      group_name = fmt::sprintf("datagroup_%07d", m_my_rank);
+    }
     h5_group_id = H5Gcreate(h5_file_id,
                             group_name.c_str(),
                             H5P_DEFAULT,
@@ -440,7 +448,12 @@ void IOManager::loadExternalData(sidre::Group* datagroup,
       hid_t h5_file_id = conduit::relay::io::hdf5_open_file_for_read(hdf5_name);
       SLIC_ASSERT(h5_file_id >= 0);
 
-      std::string group_name = fmt::sprintf("datagroup_%07d", m_my_rank);
+      std::string group_name = "datagroup";
+      if (H5Lexists(h5_file_id, group_name.c_str(), 0) <= 0)
+      {
+        group_name = fmt::sprintf("datagroup_%07d", m_my_rank);
+      }
+ 
       hid_t h5_group_id = H5Gopen(h5_file_id, group_name.c_str(), 0);
       SLIC_ASSERT(h5_group_id >= 0);
 
@@ -467,7 +480,12 @@ void IOManager::loadExternalData(sidre::Group* datagroup,
       hid_t h5_file_id = conduit::relay::io::hdf5_open_file_for_read(hdf5_name);
       SLIC_ASSERT(h5_file_id >= 0);
 
-      std::string group_name = fmt::sprintf("datagroup_%07d", input_rank);
+      std::string group_name = "datagroup";
+      if (H5Lexists(h5_file_id, group_name.c_str(), 0) <= 0)
+      {
+        group_name = fmt::sprintf("datagroup_%07d", input_rank);
+      }
+
       hid_t h5_group_id = H5Gopen(h5_file_id, group_name.c_str(), 0);
       SLIC_ASSERT(h5_group_id >= 0);
 
@@ -768,7 +786,11 @@ void IOManager::readSidreHDF5(sidre::Group* datagroup,
       hid_t h5_file_id = conduit::relay::io::hdf5_open_file_for_read(hdf5_name);
       SLIC_ASSERT(h5_file_id >= 0);
 
-      std::string group_name = fmt::sprintf("datagroup_%07d", m_my_rank);
+      std::string group_name = "datagroup";
+      if (H5Lexists(h5_file_id, group_name.c_str(), 0) <= 0)
+      {
+        group_name = fmt::sprintf("datagroup_%07d", m_my_rank);
+      }
       hid_t h5_group_id = H5Gopen(h5_file_id, group_name.c_str(), 0);
       SLIC_ASSERT(h5_group_id >= 0);
 
@@ -797,7 +819,11 @@ void IOManager::readSidreHDF5(sidre::Group* datagroup,
       hid_t h5_file_id = conduit::relay::io::hdf5_open_file_for_read(hdf5_name);
       SLIC_ASSERT(h5_file_id >= 0);
 
-      std::string group_name = fmt::sprintf("datagroup_%07d", input_rank);
+      std::string group_name = "datagroup";
+      if (H5Lexists(h5_file_id, group_name.c_str(), 0) <= 0)
+      {
+        group_name = fmt::sprintf("datagroup_%07d", m_my_rank);
+      }
       hid_t h5_group_id = H5Gopen(h5_file_id, group_name.c_str(), 0);
       SLIC_ASSERT(h5_group_id >= 0);
 

--- a/src/axom/sidre/spio/IOManager.hpp
+++ b/src/axom/sidre/spio/IOManager.hpp
@@ -93,7 +93,7 @@ public:
              int num_files,
              const std::string& file_string,
              const std::string& protocol,
-             const std::string& tree_pattern = "datagroup_%07d");
+             const std::string& tree_pattern = "datagroup");
 
   /*!
    * \brief write additional group to existing root file


### PR DESCRIPTION
# Summary

- This PR is an enhancement.
- It does the following:
  - Removes the "_%07d" suffix from the outer "datagroup" in output files when using M->M file per processor output.
  - Addresses https://github.com/LLNL/axom/issues/386
  - This will make future enhancements to automatic blueprint index generation easier, and this limited change doesn't break current usage in applications.
