### PR TITLE
Add YAML reader to Inlet

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,6 +24,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Added `cpp14` variant to Spack package to allow `Inlet::LuaReader` to be used easier.
 - Inlet: Added support for string-keyed associative arrays (dictionaries)
 - Inlet: Added support for defining and retrieving functions from the input file
+- Inlet: Added support for YAML input files
 
 ### Changed
 - The Sidre Datastore no longer rewires Conduit's error handlers to SLIC by default. 

--- a/src/axom/core/utilities/StringUtilities.cpp
+++ b/src/axom/core/utilities/StringUtilities.cpp
@@ -5,6 +5,8 @@
 
 #include "axom/core/utilities/StringUtilities.hpp"
 
+#include <algorithm>
+
 namespace axom
 {
 namespace utilities
@@ -21,6 +23,20 @@ void split(std::vector<std::string>& tokens,
   {
     tokens.push_back(token);
   }
+}
+
+void toLower(std::string& str)
+{
+  std::transform(str.begin(), str.end(), str.begin(), [](const unsigned char c) {
+    return std::tolower(c);
+  });
+}
+
+void toUpper(std::string& str)
+{
+  std::transform(str.begin(), str.end(), str.begin(), [](const unsigned char c) {
+    return std::toupper(c);
+  });
 }
 
 }  // end namespace string

--- a/src/axom/core/utilities/StringUtilities.hpp
+++ b/src/axom/core/utilities/StringUtilities.hpp
@@ -73,6 +73,18 @@ void split(std::vector<std::string>& tokens,
            const std::string& str,
            const char delimiter);
 
+/*!
+ * \brief Converts a string to lowercase
+ * \param [inout] str    string to be converted
+ */
+void toLower(std::string& str);
+
+/*!
+ * \brief Converts a string to uppercase
+ * \param [inout] str    string to be converted
+ */
+void toUpper(std::string& str);
+
 }  // end namespace string
 }  // end namespace utilities
 }  // end namespace axom

--- a/src/axom/inlet/CMakeLists.txt
+++ b/src/axom/inlet/CMakeLists.txt
@@ -26,6 +26,7 @@ set(inlet_headers
     VerifiableScalar.hpp
     DocWriter.hpp
     SphinxDocWriter.hpp
+    YAMLReader.hpp
     inlet_utils.hpp )
 
 set(inlet_sources
@@ -35,6 +36,7 @@ set(inlet_sources
     Table.cpp
     Proxy.cpp
     SphinxDocWriter.cpp
+    YAMLReader.cpp
     inlet_utils.cpp )
 
 blt_list_append(TO inlet_headers ELEMENTS LuaReader.hpp IF SOL_FOUND)

--- a/src/axom/inlet/LuaReader.hpp
+++ b/src/axom/inlet/LuaReader.hpp
@@ -39,7 +39,13 @@ namespace inlet
 class LuaReader : public Reader
 {
 public:
-  LuaReader() { m_lua.open_libraries(sol::lib::base, sol::lib::math, sol::lib::string, sol::lib::package); }
+  LuaReader()
+  {
+    m_lua.open_libraries(sol::lib::base,
+                         sol::lib::math,
+                         sol::lib::string,
+                         sol::lib::package);
+  }
 
   /*!
    *****************************************************************************

--- a/src/axom/inlet/YAMLReader.cpp
+++ b/src/axom/inlet/YAMLReader.cpp
@@ -349,7 +349,6 @@ bool YAMLReader::getArray(const std::string& id,
     if(getValue(node, value))
     {
       values[0] = value;
-      return true;
     }
     else
     {
@@ -367,7 +366,7 @@ bool YAMLReader::getArray(const std::string& id,
       const auto& child = itr.next();
       T value;
       // Inlet allows for heterogenous containers, so a failure here is "normal"
-      if(!getValue(child, value))
+      if(getValue(child, value))
       {
         values[index] = value;
       }

--- a/src/axom/inlet/YAMLReader.cpp
+++ b/src/axom/inlet/YAMLReader.cpp
@@ -152,11 +152,12 @@ bool YAMLReader::getValue(const conduit::Node& node, double& value)
   // Match LuaReader functionality - promote from integer
   if(node.dtype().is_number())
   {
-    value = node.to_float64();
+    value = node.to_double();
     return true;
   }
   return false;
 }
+
 bool YAMLReader::getValue(const conduit::Node& node, bool& value)
 {
   // Boolean literals don't appear to be parsed as such - they are strings
@@ -166,10 +167,7 @@ bool YAMLReader::getValue(const conduit::Node& node, bool& value)
     // YAML 1.2 spec, section 10.3.2
     // FIXME: Converting the string to lowercase is not strictly correct, it
     // allows for things like tRue and falsE
-    std::transform(as_str.begin(),
-                   as_str.end(),
-                   as_str.begin(),
-                   [](const unsigned char c) { return std::tolower(c); });
+    utilities::string::toLower(as_str);
     if(as_str == "true")
     {
       value = true;
@@ -275,11 +273,8 @@ bool YAMLReader::getIndices(const std::string& id,
   {
     return false;
   }
-  // FIXME: Update to range-based for loops when Axom begins using Conduit 0.6.0
-  auto itr = node.children();
-  while(itr.has_next())
+  for(const auto& child : node.children())
   {
-    const auto& child = itr.next();
     indices.push_back(child.name());
   }
   return true;
@@ -304,11 +299,8 @@ bool YAMLReader::getDictionary(const std::string& id,
     return false;
   }
 
-  // FIXME: Update to range-based for loops when Axom begins using Conduit 0.6.0
-  auto itr = node.children();
-  while(itr.has_next())
+  for(const auto& child : node.children())
   {
-    const auto& child = itr.next();
     const auto name = child.name();
 
     T value;
@@ -363,11 +355,8 @@ bool YAMLReader::getArray(const std::string& id,
   else
   {
     conduit::index_t index = 0;
-    // FIXME: Update to range-based for loops when Axom begins using Conduit 0.6.0
-    auto itr = node.children();
-    while(itr.has_next())
+    for(const auto& child : node.children())
     {
-      const auto& child = itr.next();
       T value;
       // Inlet allows for heterogenous containers, so a failure here is "normal"
       if(getValue(child, value))

--- a/src/axom/inlet/YAMLReader.cpp
+++ b/src/axom/inlet/YAMLReader.cpp
@@ -35,8 +35,20 @@ bool YAMLReader::parseFile(const std::string& filePath)
                              filePath));
     return false;
   }
-  m_root.load(filePath, "yaml");
-  return true;
+  bool success = true;
+  // Temporarily enable exceptions for Conduit errors so they can be caught and displayed
+  sidre::DataStore::setConduitDefaultMessageHandlers();
+  try
+  {
+    m_root.load(filePath, "yaml");
+  }
+  catch(const conduit::Error& e)
+  {
+    SLIC_WARNING(fmt::format("[Inlet]: Failed to parse YAML:\n{}", e.message()));
+    success = false;
+  }
+  sidre::DataStore::setConduitSLICMessageHandlers();
+  return success;
 }
 
 bool YAMLReader::parseString(const std::string& YAMLString)
@@ -46,8 +58,19 @@ bool YAMLReader::parseString(const std::string& YAMLString)
     SLIC_WARNING("Inlet: Given an empty YAML string to parse.");
     return false;
   }
-  m_root.parse(YAMLString, "yaml");
-  return true;
+  bool success = true;
+  sidre::DataStore::setConduitDefaultMessageHandlers();
+  try
+  {
+    m_root.parse(YAMLString, "yaml");
+  }
+  catch(const conduit::Error& e)
+  {
+    SLIC_WARNING(fmt::format("[Inlet]: Failed to parse YAML:\n{}", e.message()));
+    success = false;
+  }
+  sidre::DataStore::setConduitSLICMessageHandlers();
+  return success;
 }
 
 namespace detail

--- a/src/axom/inlet/YAMLReader.cpp
+++ b/src/axom/inlet/YAMLReader.cpp
@@ -11,9 +11,9 @@
  *******************************************************************************
  */
 
-#include <fstream>
-
 #include "axom/inlet/YAMLReader.hpp"
+
+#include <fstream>
 
 #include "axom/core/utilities/FileUtilities.hpp"
 #include "axom/core/utilities/StringUtilities.hpp"
@@ -21,8 +21,6 @@
 
 #include "fmt/fmt.hpp"
 #include "axom/slic.hpp"
-
-// #include "conduit_relay.hpp"
 
 namespace axom
 {
@@ -308,11 +306,11 @@ bool YAMLReader::getDictionary(const std::string& id,
   {
     const auto& child = itr.next();
     const auto name = child.name();
-    if(!getValue(child, values[name]))
+
+    T value;
+    if(getValue(child, value))
     {
-      // The current interface allows for overlapping types, but we need to
-      // remove the default-initialized element here if it failed
-      values.erase(name);
+      values[name] = value;
     }
   }
   return true;
@@ -346,9 +344,14 @@ bool YAMLReader::getArray(const std::string& id,
   {
     // Single-element arrays will be just the element itself
     // If it's a single element, we know the index is zero
-    if(!getValue(node, values[0]))
+    T value;
+    if(getValue(node, value))
     {
-      values.erase(0);
+      values[0] = value;
+      return false;
+    }
+    else
+    {
       return false;
     }
   }
@@ -361,11 +364,10 @@ bool YAMLReader::getArray(const std::string& id,
     while(itr.has_next())
     {
       const auto& child = itr.next();
-      if(!getValue(child, values[index]))
+      T value;
+      if(!getValue(child, value))
       {
-        // The current interface allows for overlapping types, but we need to
-        // remove the default-initialized element here if it failed
-        values.erase(index);
+        values[index] = value;
       }
       index++;
     }

--- a/src/axom/inlet/YAMLReader.cpp
+++ b/src/axom/inlet/YAMLReader.cpp
@@ -60,8 +60,12 @@ const static char SCOPE_DELIMITER = '/';
  * \brief Traverses a path starting from a Node
  *
  * \param [in] root The node from which to begin traversal
- * \param [in] id   The path to traverse
+ * \param [in] id   The path to traverse as an Inlet path
  * \note Needed for paths containing integers as a conversion is required
+ * \note Inlet paths differ from Conduit paths in that they can contain integers,
+ * e.g., "/path/to/7/foo" would correspond to node["path"]["to"][7]["foo"].
+ * The traversal prefers the string-valued name but will attempt to convert to
+ * integer if no such child exists.
  *******************************************************************************
  */
 conduit::Node traverseNode(const conduit::Node& root, const std::string& id)

--- a/src/axom/inlet/YAMLReader.cpp
+++ b/src/axom/inlet/YAMLReader.cpp
@@ -1,0 +1,382 @@
+// Copyright (c) 2017-2020, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ *******************************************************************************
+ * \file YAMLReader.cpp
+ *
+ * \brief This file contains the class implementation of the YAMLReader.
+ *******************************************************************************
+ */
+
+#include <fstream>
+
+#include "axom/inlet/YAMLReader.hpp"
+
+#include "axom/core/utilities/FileUtilities.hpp"
+#include "axom/core/utilities/StringUtilities.hpp"
+#include "axom/inlet/inlet_utils.hpp"
+
+#include "fmt/fmt.hpp"
+#include "axom/slic.hpp"
+
+// #include "conduit_relay.hpp"
+
+namespace axom
+{
+namespace inlet
+{
+YAMLReader::YAMLReader() { }
+bool YAMLReader::parseFile(const std::string& filePath)
+{
+  if(!axom::utilities::filesystem::pathExists(filePath))
+  {
+    SLIC_WARNING(fmt::format("Inlet: Given YAML input file does not exist: {0}",
+                             filePath));
+    return false;
+  }
+  m_root.load(filePath, "yaml");
+  return true;
+}
+
+bool YAMLReader::parseString(const std::string& YAMLString)
+{
+  if(YAMLString.empty())
+  {
+    SLIC_WARNING("Inlet: Given an empty YAML string to parse.");
+    return false;
+  }
+  m_root.parse(YAMLString, "yaml");
+  return true;
+}
+
+namespace detail
+{
+// TODO: allow alternate delimiter at sidre level
+const static char SCOPE_DELIMITER = '/';
+
+/*!
+ *******************************************************************************
+ * \brief Traverses a path starting from a Node
+ *
+ * \param [in] root The node from which to begin traversal
+ * \param [in] id   The path to traverse
+ * \note Needed for paths containing integers as a conversion is required
+ *******************************************************************************
+ */
+conduit::Node traverseNode(const conduit::Node& root, const std::string& id)
+{
+  if(root.has_path(id))
+  {
+    return root[id];
+  }
+
+  const conduit::Node* node = &root;
+  std::vector<std::string> tokens;
+  axom::utilities::string::split(tokens, id, SCOPE_DELIMITER);
+  for(const auto& token : tokens)
+  {
+    // Prefer the string name, but if it doesn't exist, try converting to int
+    if(node->has_child(token))
+    {
+      node = &((*node)[token]);
+    }
+    else
+    {
+      auto as_int = checkedConvertToInt(token);
+      if(as_int.second && as_int.first < node->number_of_children())
+      {
+        node = &((*node)[as_int.first]);
+      }
+      else
+      {
+        // Bail out and return an empty node to indicate failure
+        return {};
+      }
+    }
+  }
+  return *node;
+}
+
+/*!
+ *******************************************************************************
+ * \brief Copies a Conduit array into an unordered map, using zero-based array
+ * indices as the keys
+ *
+ * \param [in] array The array to copy from
+ * \param [out] map  The map to copy into
+ * \note Implementing to allow for widening/narrowing conversions
+ *******************************************************************************
+ */
+template <typename ConduitType, typename MapValueType>
+void arrayToMap(const conduit::DataArray<ConduitType>& array,
+                std::unordered_map<int, MapValueType>& map)
+{
+  map.clear();
+  for(conduit::index_t i = 0; i < array.number_of_elements(); i++)
+  {
+    // No begin/end iterators are provided by DataArray
+    map[i] = array[i];
+  }
+}
+
+}  // namespace detail
+
+bool YAMLReader::getValue(const conduit::Node& node, int& value)
+{
+  // Match LuaReader functionality - narrow from floating-point
+  if(node.dtype().is_number())
+  {
+    value = node.to_int();
+    return true;
+  }
+  return false;
+}
+
+bool YAMLReader::getValue(const conduit::Node& node, std::string& value)
+{
+  if(node.dtype().is_string())
+  {
+    value = node.as_string();
+    return true;
+  }
+  return false;
+}
+
+bool YAMLReader::getValue(const conduit::Node& node, double& value)
+{
+  // Match LuaReader functionality - promote from integer
+  if(node.dtype().is_number())
+  {
+    value = node.to_float64();
+    return true;
+  }
+  return false;
+}
+bool YAMLReader::getValue(const conduit::Node& node, bool& value)
+{
+  // Boolean literals don't appear to be parsed as such - they are strings
+  if(node.dtype().is_string())
+  {
+    std::string as_str = node.as_string();
+    // YAML 1.2 spec, section 10.3.2
+    // FIXME: Converting the string to lowercase is not strictly correct, it
+    // allows for things like tRue and falsE
+    std::transform(as_str.begin(),
+                   as_str.end(),
+                   as_str.begin(),
+                   [](const unsigned char c) { return std::tolower(c); });
+    if(as_str == "true")
+    {
+      value = true;
+      return true;
+    }
+    else if(as_str == "false")
+    {
+      value = false;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool YAMLReader::getBool(const std::string& id, bool& value)
+{
+  return getValue(detail::traverseNode(m_root, id), value);
+}
+
+bool YAMLReader::getDouble(const std::string& id, double& value)
+{
+  return getValue(detail::traverseNode(m_root, id), value);
+}
+
+bool YAMLReader::getInt(const std::string& id, int& value)
+{
+  return getValue(detail::traverseNode(m_root, id), value);
+}
+
+bool YAMLReader::getString(const std::string& id, std::string& value)
+{
+  return getValue(detail::traverseNode(m_root, id), value);
+}
+
+bool YAMLReader::getIntMap(const std::string& id,
+                           std::unordered_map<int, int>& values)
+{
+  return getArray(id, values);
+}
+
+bool YAMLReader::getDoubleMap(const std::string& id,
+                              std::unordered_map<int, double>& values)
+{
+  return getArray(id, values);
+}
+
+bool YAMLReader::getBoolMap(const std::string& id,
+                            std::unordered_map<int, bool>& values)
+{
+  return getArray(id, values);
+}
+
+bool YAMLReader::getStringMap(const std::string& id,
+                              std::unordered_map<int, std::string>& values)
+{
+  return getArray(id, values);
+}
+
+bool YAMLReader::getIntMap(const std::string& id,
+                           std::unordered_map<std::string, int>& values)
+{
+  return getDictionary(id, values);
+}
+
+bool YAMLReader::getDoubleMap(const std::string& id,
+                              std::unordered_map<std::string, double>& values)
+{
+  return getDictionary(id, values);
+}
+
+bool YAMLReader::getBoolMap(const std::string& id,
+                            std::unordered_map<std::string, bool>& values)
+{
+  return getDictionary(id, values);
+}
+
+bool YAMLReader::getStringMap(const std::string& id,
+                              std::unordered_map<std::string, std::string>& values)
+{
+  return getDictionary(id, values);
+}
+
+bool YAMLReader::getIndices(const std::string& id, std::vector<int>& indices)
+{
+  indices.clear();
+  const auto node = detail::traverseNode(m_root, id);
+  if(!node.dtype().is_list())
+  {
+    return false;
+  }
+  indices.resize(node.number_of_children());
+  // Arrays in YAML are contiguous so we don't need to query the input file
+  std::iota(indices.begin(), indices.end(), 0);
+  return true;
+}
+
+bool YAMLReader::getIndices(const std::string& id,
+                            std::vector<std::string>& indices)
+{
+  indices.clear();
+  const auto node = detail::traverseNode(m_root, id);
+  if(!node.dtype().is_object())
+  {
+    return false;
+  }
+  // FIXME: Update to range-based for loops when Axom begins using Conduit 0.6.0
+  auto itr = node.children();
+  while(itr.has_next())
+  {
+    const auto& child = itr.next();
+    indices.push_back(child.name());
+  }
+  return true;
+}
+
+FunctionVariant YAMLReader::getFunction(const std::string&,
+                                        const FunctionType,
+                                        const std::vector<FunctionType>&)
+{
+  SLIC_ERROR("[Inlet] YAML does not support functions");
+  return {};
+}
+
+template <typename T>
+bool YAMLReader::getDictionary(const std::string& id,
+                               std::unordered_map<std::string, T>& values)
+{
+  values.clear();
+  const auto node = detail::traverseNode(m_root, id);
+  if(!node.dtype().is_object())
+  {
+    return false;
+  }
+
+  // FIXME: Update to range-based for loops when Axom begins using Conduit 0.6.0
+  auto itr = node.children();
+  while(itr.has_next())
+  {
+    const auto& child = itr.next();
+    const auto name = child.name();
+    if(!getValue(child, values[name]))
+    {
+      // The current interface allows for overlapping types, but we need to
+      // remove the default-initialized element here if it failed
+      values.erase(name);
+    }
+  }
+  return true;
+}
+
+template <typename T>
+bool YAMLReader::getArray(const std::string& id,
+                          std::unordered_map<int, T>& values)
+{
+  values.clear();
+  const auto node = detail::traverseNode(m_root, id);
+  // Truly primitive (i.e., not string) types are contiguous so we grab the array pointer
+  if(node.dtype().number_of_elements() > 1)
+  {
+    // The template parameter is not enough to know the type of the conduit array
+    // as widening/narrowing conversions are supported
+    if(node.dtype().is_floating_point())
+    {
+      detail::arrayToMap(node.as_double_array(), values);
+    }
+    else if(node.dtype().is_integer())
+    {
+      detail::arrayToMap(node.as_long_array(), values);
+    }
+    else
+    {
+      return false;
+    }
+  }
+  else if(!node.dtype().is_list())
+  {
+    // Single-element arrays will be just the element itself
+    // If it's a single element, we know the index is zero
+    if(!getValue(node, values[0]))
+    {
+      values.erase(0);
+      return false;
+    }
+  }
+  // String arrays are not supported natively so the node is directly iterated over
+  else
+  {
+    conduit::index_t index = 0;
+    // FIXME: Update to range-based for loops when Axom begins using Conduit 0.6.0
+    auto itr = node.children();
+    while(itr.has_next())
+    {
+      const auto& child = itr.next();
+      if(!getValue(child, values[index]))
+      {
+        // The current interface allows for overlapping types, but we need to
+        // remove the default-initialized element here if it failed
+        values.erase(index);
+      }
+      index++;
+    }
+    // Check if nothing was inserted
+    if(values.empty())
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // end namespace inlet
+}  // end namespace axom

--- a/src/axom/inlet/YAMLReader.cpp
+++ b/src/axom/inlet/YAMLReader.cpp
@@ -308,6 +308,7 @@ bool YAMLReader::getDictionary(const std::string& id,
     const auto name = child.name();
 
     T value;
+    // Inlet allows for heterogenous containers, so a failure here is "normal"
     if(getValue(child, value))
     {
       values[name] = value;
@@ -348,7 +349,7 @@ bool YAMLReader::getArray(const std::string& id,
     if(getValue(node, value))
     {
       values[0] = value;
-      return false;
+      return true;
     }
     else
     {
@@ -365,6 +366,7 @@ bool YAMLReader::getArray(const std::string& id,
     {
       const auto& child = itr.next();
       T value;
+      // Inlet allows for heterogenous containers, so a failure here is "normal"
       if(!getValue(child, value))
       {
         values[index] = value;

--- a/src/axom/inlet/YAMLReader.hpp
+++ b/src/axom/inlet/YAMLReader.hpp
@@ -36,179 +36,38 @@ class YAMLReader : public Reader
 public:
   YAMLReader();
 
-  /*!
-   *****************************************************************************
-   * \brief Parses the given input file.
-   *
-   * This performs any setup work and parses the given input file.
-   * It is required that this is called before using the Reader and overrides
-   * any YAML state that was previously there.
-   *
-   * \param [in] filePath The Input file to be read
-   *
-   * \return true if the input file was able to be parsed
-   *****************************************************************************
-   */
   bool parseFile(const std::string& filePath) override;
 
-  /*!
-   *****************************************************************************
-   * \brief Parses the given YAML string.
-   *
-   * This performs any setup work and parses the given YAML string.
-   * It is required that this is called before using the Reader and overrides
-   * any YAML state that was previously there.
-   *
-   * \param [in] YAMLString The Input file to be read
-   *
-   * \return true if the string was able to be parsed
-   *****************************************************************************
-   */
   bool parseString(const std::string& YAMLString) override;
 
-  /*!
-   *****************************************************************************
-   * \brief Return a boolean out of the input file
-   *
-   * This performs any necessary retrieval and mapping from the given identifier
-   * to what is in the input file.
-   *
-   * \param [in]  id    The identifier to the bool that will be retrieved
-   * \param [out] value The value of the bool that was retrieved
-   *
-   * \return true if the variable was able to be retrieved from the file
-   *****************************************************************************
-   */
   bool getBool(const std::string& id, bool& value) override;
 
-  /*!
-   *****************************************************************************
-   * \brief Return a double out of the input file
-   *
-   * This performs any necessary retrieval and mapping from the given identifier
-   * to what is in the input file.
-   *
-   * \param [in]  id    The identifier to the double that will be retrieved
-   * \param [out] value The value of the double that was retrieved
-   *
-   * \return true if the variable was able to be retrieved from the file
-   *****************************************************************************
-   */
   bool getDouble(const std::string& id, double& value) override;
 
-  /*!
-   *****************************************************************************
-   * \brief Return a int out of the input file
-   *
-   * This performs any necessary retrieval and mapping from the given identifier
-   * to what is in the input file.
-   *
-   * \param [in]  id    The identifier to the int that will be retrieved from
-   *the file
-   * \param [out] value The value of the int that was retrieved from the file
-   *
-   * \return true if the variable was able to be retrieved from the file
-   *****************************************************************************
-   */
   bool getInt(const std::string& id, int& value) override;
 
-  /*!
-   *****************************************************************************
-   * \brief Return a string out of the input file
-   *
-   * This performs any necessary retrieval and mapping from the given identifier
-   * to what is in the input file.
-   *
-   * \param [in]  id    The identifier to the string that will be retrieved
-   * \param [out] value The value of the string that was retrieved
-   *
-   * \return true if the variable was able to be retrieved from the file
-   *****************************************************************************
-   */
   bool getString(const std::string& id, std::string& value) override;
 
-  /*!
-   *****************************************************************************
-   * \brief Get an index-integer mapping for the given YAML array
-   *
-   * This performs any necessary retrieval and mapping from the given identifier
-   * to what is in the input file.
-   *
-   * \param [in]  id    The identifier to the string that will be retrieved
-   * \param [out] map The values of the ints that were retrieved
-   *
-   * \return true if the array was able to be retrieved from the file
-   *****************************************************************************
-   */
   bool getIntMap(const std::string& id,
                  std::unordered_map<int, int>& values) override;
   bool getIntMap(const std::string& id,
                  std::unordered_map<std::string, int>& values) override;
 
-  /*!
-   *****************************************************************************
-   * \brief Get an index-double mapping for the given YAML array
-   *
-   * This performs any necessary retrieval and mapping from the given identifier
-   * to what is in the input file.
-   *
-   * \param [in]  id    The identifier to the string that will be retrieved
-   * \param [out] map The values of the doubles that were retrieved
-   *
-   * \return true if the array was able to be retrieved from the file
-   *****************************************************************************
-   */
   bool getDoubleMap(const std::string& id,
                     std::unordered_map<int, double>& values) override;
   bool getDoubleMap(const std::string& id,
                     std::unordered_map<std::string, double>& values) override;
 
-  /*!
-   *****************************************************************************
-   * \brief Get an index-bool mapping for the given YAML array
-   *
-   * This performs any necessary retrieval and mapping from the given identifier
-   * to what is in the input file.
-   *
-   * \param [in]  id    The identifier to the string that will be retrieved
-   * \param [out] map The values of the bools that were retrieved
-   *
-   * \return true if the array was able to be retrieved from the file
-   *****************************************************************************
-   */
   bool getBoolMap(const std::string& id,
                   std::unordered_map<int, bool>& values) override;
   bool getBoolMap(const std::string& id,
                   std::unordered_map<std::string, bool>& values) override;
 
-  /*!
-   *****************************************************************************
-   * \brief Get an index-string mapping for the given YAML array
-   *
-   * This performs any necessary retrieval and mapping from the given identifier
-   * to what is in the input file.
-   *
-   * \param [in]  id    The identifier to the string that will be retrieved
-   * \param [out] map The values of the strings that were retrieved
-   *
-   * \return true if the array was able to be retrieved from the file
-   *****************************************************************************
-   */
   bool getStringMap(const std::string& id,
                     std::unordered_map<int, std::string>& values) override;
   bool getStringMap(const std::string& id,
                     std::unordered_map<std::string, std::string>& values) override;
 
-  /*!
-   *****************************************************************************
-   * \brief Get the list of indices for an container
-   *
-   * \param [in]  id    The identifier to the container that will be retrieved
-   * \param [out] map The values of the indices that were retrieved
-   *
-   * \return true if the indices were able to be retrieved from the file
-   *****************************************************************************
-   */
   bool getIndices(const std::string& id, std::vector<int>& indices) override;
   bool getIndices(const std::string& id,
                   std::vector<std::string>& indices) override;

--- a/src/axom/inlet/YAMLReader.hpp
+++ b/src/axom/inlet/YAMLReader.hpp
@@ -49,7 +49,7 @@ public:
    * \return true if the input file was able to be parsed
    *****************************************************************************
    */
-  bool parseFile(const std::string& filePath);
+  bool parseFile(const std::string& filePath) override;
 
   /*!
    *****************************************************************************
@@ -64,7 +64,7 @@ public:
    * \return true if the string was able to be parsed
    *****************************************************************************
    */
-  bool parseString(const std::string& YAMLString);
+  bool parseString(const std::string& YAMLString) override;
 
   /*!
    *****************************************************************************
@@ -79,7 +79,7 @@ public:
    * \return true if the variable was able to be retrieved from the file
    *****************************************************************************
    */
-  bool getBool(const std::string& id, bool& value);
+  bool getBool(const std::string& id, bool& value) override;
 
   /*!
    *****************************************************************************
@@ -94,7 +94,7 @@ public:
    * \return true if the variable was able to be retrieved from the file
    *****************************************************************************
    */
-  bool getDouble(const std::string& id, double& value);
+  bool getDouble(const std::string& id, double& value) override;
 
   /*!
    *****************************************************************************
@@ -110,7 +110,7 @@ public:
    * \return true if the variable was able to be retrieved from the file
    *****************************************************************************
    */
-  bool getInt(const std::string& id, int& value);
+  bool getInt(const std::string& id, int& value) override;
 
   /*!
    *****************************************************************************
@@ -125,7 +125,7 @@ public:
    * \return true if the variable was able to be retrieved from the file
    *****************************************************************************
    */
-  bool getString(const std::string& id, std::string& value);
+  bool getString(const std::string& id, std::string& value) override;
 
   /*!
    *****************************************************************************
@@ -140,9 +140,10 @@ public:
    * \return true if the array was able to be retrieved from the file
    *****************************************************************************
    */
-  bool getIntMap(const std::string& id, std::unordered_map<int, int>& values);
   bool getIntMap(const std::string& id,
-                 std::unordered_map<std::string, int>& values);
+                 std::unordered_map<int, int>& values) override;
+  bool getIntMap(const std::string& id,
+                 std::unordered_map<std::string, int>& values) override;
 
   /*!
    *****************************************************************************
@@ -158,9 +159,9 @@ public:
    *****************************************************************************
    */
   bool getDoubleMap(const std::string& id,
-                    std::unordered_map<int, double>& values);
+                    std::unordered_map<int, double>& values) override;
   bool getDoubleMap(const std::string& id,
-                    std::unordered_map<std::string, double>& values);
+                    std::unordered_map<std::string, double>& values) override;
 
   /*!
    *****************************************************************************
@@ -175,9 +176,10 @@ public:
    * \return true if the array was able to be retrieved from the file
    *****************************************************************************
    */
-  bool getBoolMap(const std::string& id, std::unordered_map<int, bool>& values);
   bool getBoolMap(const std::string& id,
-                  std::unordered_map<std::string, bool>& values);
+                  std::unordered_map<int, bool>& values) override;
+  bool getBoolMap(const std::string& id,
+                  std::unordered_map<std::string, bool>& values) override;
 
   /*!
    *****************************************************************************
@@ -193,9 +195,9 @@ public:
    *****************************************************************************
    */
   bool getStringMap(const std::string& id,
-                    std::unordered_map<int, std::string>& values);
+                    std::unordered_map<int, std::string>& values) override;
   bool getStringMap(const std::string& id,
-                    std::unordered_map<std::string, std::string>& values);
+                    std::unordered_map<std::string, std::string>& values) override;
 
   /*!
    *****************************************************************************
@@ -207,8 +209,9 @@ public:
    * \return true if the indices were able to be retrieved from the file
    *****************************************************************************
    */
-  bool getIndices(const std::string& id, std::vector<int>& indices);
-  bool getIndices(const std::string& id, std::vector<std::string>& indices);
+  bool getIndices(const std::string& id, std::vector<int>& indices) override;
+  bool getIndices(const std::string& id,
+                  std::vector<std::string>& indices) override;
 
   /*!
    *****************************************************************************
@@ -225,11 +228,11 @@ public:
    */
   FunctionVariant getFunction(const std::string& id,
                               const FunctionType ret_type,
-                              const std::vector<FunctionType>& arg_types);
+                              const std::vector<FunctionType>& arg_types) override;
 
   /*!
    *****************************************************************************
-   * \brief The base index for arrays in Lua
+   * \brief The base index for arrays in YAML
    *****************************************************************************
    */
   static const int baseIndex = 0;

--- a/src/axom/inlet/YAMLReader.hpp
+++ b/src/axom/inlet/YAMLReader.hpp
@@ -1,0 +1,255 @@
+// Copyright (c) 2017-2020, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ *******************************************************************************
+ * \file YAMLReader.hpp
+ *
+ * \brief This file contains the class definition of the YAMLReader.
+ *******************************************************************************
+ */
+
+#ifndef INLET_YAMLREADER_HPP
+#define INLET_YAMLREADER_HPP
+
+#include "axom/inlet/Reader.hpp"
+
+#include "conduit.hpp"
+
+namespace axom
+{
+namespace inlet
+{
+/*!
+ *******************************************************************************
+ * \class YAMLReader
+ *
+ * \brief A Reader that is able to read variables from a YAML file.
+ *
+ * \see Reader
+ *******************************************************************************
+ */
+class YAMLReader : public Reader
+{
+public:
+  YAMLReader();
+
+  /*!
+   *****************************************************************************
+   * \brief Parses the given input file.
+   *
+   * This performs any setup work and parses the given input file.
+   * It is required that this is called before using the Reader and overrides
+   * any YAML state that was previously there.
+   *
+   * \param [in] filePath The Input file to be read
+   *
+   * \return true if the input file was able to be parsed
+   *****************************************************************************
+   */
+  bool parseFile(const std::string& filePath);
+
+  /*!
+   *****************************************************************************
+   * \brief Parses the given YAML string.
+   *
+   * This performs any setup work and parses the given YAML string.
+   * It is required that this is called before using the Reader and overrides
+   * any YAML state that was previously there.
+   *
+   * \param [in] YAMLString The Input file to be read
+   *
+   * \return true if the string was able to be parsed
+   *****************************************************************************
+   */
+  bool parseString(const std::string& YAMLString);
+
+  /*!
+   *****************************************************************************
+   * \brief Return a boolean out of the input file
+   *
+   * This performs any necessary retrieval and mapping from the given identifier
+   * to what is in the input file.
+   *
+   * \param [in]  id    The identifier to the bool that will be retrieved
+   * \param [out] value The value of the bool that was retrieved
+   *
+   * \return true if the variable was able to be retrieved from the file
+   *****************************************************************************
+   */
+  bool getBool(const std::string& id, bool& value);
+
+  /*!
+   *****************************************************************************
+   * \brief Return a double out of the input file
+   *
+   * This performs any necessary retrieval and mapping from the given identifier
+   * to what is in the input file.
+   *
+   * \param [in]  id    The identifier to the double that will be retrieved
+   * \param [out] value The value of the double that was retrieved
+   *
+   * \return true if the variable was able to be retrieved from the file
+   *****************************************************************************
+   */
+  bool getDouble(const std::string& id, double& value);
+
+  /*!
+   *****************************************************************************
+   * \brief Return a int out of the input file
+   *
+   * This performs any necessary retrieval and mapping from the given identifier
+   * to what is in the input file.
+   *
+   * \param [in]  id    The identifier to the int that will be retrieved from
+   *the file
+   * \param [out] value The value of the int that was retrieved from the file
+   *
+   * \return true if the variable was able to be retrieved from the file
+   *****************************************************************************
+   */
+  bool getInt(const std::string& id, int& value);
+
+  /*!
+   *****************************************************************************
+   * \brief Return a string out of the input file
+   *
+   * This performs any necessary retrieval and mapping from the given identifier
+   * to what is in the input file.
+   *
+   * \param [in]  id    The identifier to the string that will be retrieved
+   * \param [out] value The value of the string that was retrieved
+   *
+   * \return true if the variable was able to be retrieved from the file
+   *****************************************************************************
+   */
+  bool getString(const std::string& id, std::string& value);
+
+  /*!
+   *****************************************************************************
+   * \brief Get an index-integer mapping for the given YAML array
+   *
+   * This performs any necessary retrieval and mapping from the given identifier
+   * to what is in the input file.
+   *
+   * \param [in]  id    The identifier to the string that will be retrieved
+   * \param [out] map The values of the ints that were retrieved
+   *
+   * \return true if the array was able to be retrieved from the file
+   *****************************************************************************
+   */
+  bool getIntMap(const std::string& id, std::unordered_map<int, int>& values);
+  bool getIntMap(const std::string& id,
+                 std::unordered_map<std::string, int>& values);
+
+  /*!
+   *****************************************************************************
+   * \brief Get an index-double mapping for the given YAML array
+   *
+   * This performs any necessary retrieval and mapping from the given identifier
+   * to what is in the input file.
+   *
+   * \param [in]  id    The identifier to the string that will be retrieved
+   * \param [out] map The values of the doubles that were retrieved
+   *
+   * \return true if the array was able to be retrieved from the file
+   *****************************************************************************
+   */
+  bool getDoubleMap(const std::string& id,
+                    std::unordered_map<int, double>& values);
+  bool getDoubleMap(const std::string& id,
+                    std::unordered_map<std::string, double>& values);
+
+  /*!
+   *****************************************************************************
+   * \brief Get an index-bool mapping for the given YAML array
+   *
+   * This performs any necessary retrieval and mapping from the given identifier
+   * to what is in the input file.
+   *
+   * \param [in]  id    The identifier to the string that will be retrieved
+   * \param [out] map The values of the bools that were retrieved
+   *
+   * \return true if the array was able to be retrieved from the file
+   *****************************************************************************
+   */
+  bool getBoolMap(const std::string& id, std::unordered_map<int, bool>& values);
+  bool getBoolMap(const std::string& id,
+                  std::unordered_map<std::string, bool>& values);
+
+  /*!
+   *****************************************************************************
+   * \brief Get an index-string mapping for the given YAML array
+   *
+   * This performs any necessary retrieval and mapping from the given identifier
+   * to what is in the input file.
+   *
+   * \param [in]  id    The identifier to the string that will be retrieved
+   * \param [out] map The values of the strings that were retrieved
+   *
+   * \return true if the array was able to be retrieved from the file
+   *****************************************************************************
+   */
+  bool getStringMap(const std::string& id,
+                    std::unordered_map<int, std::string>& values);
+  bool getStringMap(const std::string& id,
+                    std::unordered_map<std::string, std::string>& values);
+
+  /*!
+   *****************************************************************************
+   * \brief Get the list of indices for an container
+   *
+   * \param [in]  id    The identifier to the container that will be retrieved
+   * \param [out] map The values of the indices that were retrieved
+   *
+   * \return true if the indices were able to be retrieved from the file
+   *****************************************************************************
+   */
+  bool getIndices(const std::string& id, std::vector<int>& indices);
+  bool getIndices(const std::string& id, std::vector<std::string>& indices);
+
+  /*!
+   *****************************************************************************
+   * \brief Get a function from the input file
+   *
+   * \param [in]  id    The identifier to the function that will be retrieved
+   * \param [in]  ret_type    The return type of the function
+   * \param [in]  arg_types    The argument types of the function
+   *
+   * \return The function, compares false if not found
+   * \note YAML does not support functions - calling this function will result
+   * in a SLIC_ERROR
+   *****************************************************************************
+   */
+  FunctionVariant getFunction(const std::string& id,
+                              const FunctionType ret_type,
+                              const std::vector<FunctionType>& arg_types);
+
+  /*!
+   *****************************************************************************
+   * \brief The base index for arrays in Lua
+   *****************************************************************************
+   */
+  static const int baseIndex = 0;
+
+private:
+  bool getValue(const conduit::Node& node, int& value);
+  bool getValue(const conduit::Node& node, std::string& value);
+  bool getValue(const conduit::Node& node, double& value);
+  bool getValue(const conduit::Node& node, bool& value);
+
+  template <typename T>
+  bool getDictionary(const std::string& id,
+                     std::unordered_map<std::string, T>& values);
+
+  template <typename T>
+  bool getArray(const std::string& id, std::unordered_map<int, T>& values);
+  conduit::Node m_root;
+};
+
+}  // end namespace inlet
+}  // end namespace axom
+
+#endif

--- a/src/axom/inlet/tests/CMakeLists.txt
+++ b/src/axom/inlet/tests/CMakeLists.txt
@@ -11,26 +11,25 @@
 #------------------------------------------------------------------------------
 
 # Add Serial GTests based tests
-if (SOL_FOUND)
-    set(gtest_inlet_tests
-        inlet_Reader.cpp
-        inlet_Inlet.cpp 
-        inlet_object.cpp
-        inlet_function.cpp )
+set(gtest_inlet_tests
+    inlet_Reader.cpp
+    inlet_Inlet.cpp 
+    inlet_object.cpp )
 
-    blt_add_library(NAME        inlet_test_utils
-                    SOURCES     inlet_test_utils.cpp
-                    HEADERS     inlet_test_utils.hpp
-                    DEPENDS_ON  inlet gtest )
+blt_list_append(TO gtest_inlet_tests ELEMENTS inlet_function.cpp IF SOL_FOUND)
 
-    foreach(test ${gtest_inlet_tests})
-        get_filename_component( test_name ${test} NAME_WE )
-        blt_add_executable( NAME       ${test_name}_test
-                            SOURCES    ${test}
-                            OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                            DEPENDS_ON inlet gtest inlet_test_utils
-                            FOLDER     axom/inlet/tests )
-        blt_add_test( NAME    ${test_name} 
-                      COMMAND ${test_name}_test )
-    endforeach()
-endif()
+blt_add_library(NAME        inlet_test_utils
+                SOURCES     inlet_test_utils.cpp
+                HEADERS     inlet_test_utils.hpp
+                DEPENDS_ON  inlet gtest )
+
+foreach(test ${gtest_inlet_tests})
+    get_filename_component( test_name ${test} NAME_WE )
+    blt_add_executable( NAME       ${test_name}_test
+                        SOURCES    ${test}
+                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                        DEPENDS_ON inlet gtest inlet_test_utils
+                        FOLDER     axom/inlet/tests )
+    blt_add_test( NAME    ${test_name} 
+                    COMMAND ${test_name}_test )
+endforeach()

--- a/src/axom/inlet/tests/inlet_Reader.cpp
+++ b/src/axom/inlet/tests/inlet_Reader.cpp
@@ -211,6 +211,18 @@ TEST(inlet_Reader_YAML, mixLevelTables)
   EXPECT_EQ(value, 3);
 }
 
+TEST(inlet_Reader_YAML, mixLevelTables_invalid)
+{
+  axom::inlet::YAMLReader reader;
+  bool result = reader.parseString(
+    "t:\n"
+    "  innerT: foo: 1\n"
+    "  anotherInnerT:\n"
+    "    baz: 3");
+
+  EXPECT_FALSE(result);
+}
+
 #ifdef AXOM_USE_SOL
 // Checks that LuaReader parses array information as expected
 // Discontiguous arrays are lua-specific

--- a/src/axom/inlet/tests/inlet_Reader.cpp
+++ b/src/axom/inlet/tests/inlet_Reader.cpp
@@ -162,6 +162,55 @@ TYPED_TEST(inlet_Reader, getMap)
   // EXPECT_EQ(expectedStrs, strs);
 }
 
+TEST(inlet_Reader_YAML, getInsideBools)
+{
+  axom::inlet::YAMLReader reader;
+  reader.parseString(
+    "foo:\n"
+    "  bar: false\n"
+    "  baz: true");
+  bool value, retValue;
+
+  value = true;
+  retValue = reader.getBool("foo/bar", value);
+  EXPECT_EQ(retValue, true);
+  EXPECT_EQ(value, false);
+
+  value = false;
+  retValue = reader.getBool("foo/baz", value);
+  EXPECT_EQ(retValue, true);
+  EXPECT_EQ(value, true);
+}
+
+TEST(inlet_Reader_YAML, mixLevelTables)
+{
+  axom::inlet::YAMLReader reader;
+  reader.parseString(
+    "t:\n"
+    "  innerT:\n"
+    "    foo: 1\n"
+    "  anotherInnerT:\n"
+    "    baz: 3");
+
+  bool retValue;
+  int value;
+
+  value = 0;
+  retValue = reader.getInt("t/innerT/foo", value);
+  EXPECT_EQ(retValue, true);
+  EXPECT_EQ(value, 1);
+
+  value = 0;
+  retValue = reader.getInt("t/doesntexist", value);
+  EXPECT_EQ(retValue, false);
+  EXPECT_EQ(value, 0);
+
+  value = 0;
+  retValue = reader.getInt("t/anotherInnerT/baz", value);
+  EXPECT_EQ(retValue, true);
+  EXPECT_EQ(value, 3);
+}
+
 #ifdef AXOM_USE_SOL
 // Checks that LuaReader parses array information as expected
 // Discontiguous arrays are lua-specific

--- a/src/axom/inlet/tests/inlet_test_utils.cpp
+++ b/src/axom/inlet/tests/inlet_test_utils.cpp
@@ -6,7 +6,11 @@
 #include "axom/inlet/tests/inlet_test_utils.hpp"
 #include "axom/slic.hpp"
 
-namespace axom::inlet::detail
+namespace axom
+{
+namespace inlet
+{
+namespace detail
 {
 void LuaToYAML::add_token(std::string&& token, std::vector<std::string>& tokens)
 {
@@ -161,4 +165,8 @@ std::string LuaToYAML::convert(const std::string& luaString)
   return result;
 }
 
-}  // namespace axom::inlet::detail
+}  // namespace detail
+
+}  // namespace inlet
+
+}  // namespace axom

--- a/src/axom/inlet/tests/inlet_test_utils.cpp
+++ b/src/axom/inlet/tests/inlet_test_utils.cpp
@@ -7,4 +7,155 @@
 #include "axom/slic.hpp"
 
 namespace axom::inlet::detail
-{ }  // namespace axom::inlet::detail
+{
+void LuaToYAML::add_token(std::string&& token, std::vector<std::string>& tokens)
+{
+  const static std::string punctuation = "{}[];,=";
+  std::vector<std::string> parsed_after;
+  std::size_t pos;
+  while(token.length() > 1 &&
+        ((pos = token.find_first_of(punctuation)) != std::string::npos))
+  {
+    if(pos == 0)
+    {
+      tokens.emplace_back(1, token[pos]);
+      token = token.substr(1, token.length() - 1);
+    }
+    else
+    {
+      // The position could be partway through the string, but
+      // we need the last entry
+      pos = token.find_last_of(punctuation);
+      parsed_after.emplace_back(1, token[pos]);
+      token = token.substr(0, token.length() - 1);
+    }
+  }
+  if(!token.empty())
+  {
+    tokens.push_back(token);
+  }
+  tokens.insert(tokens.end(), parsed_after.rbegin(), parsed_after.rend());
+}
+
+std::vector<std::string> LuaToYAML::tokenize(const std::string& text)
+{
+  std::vector<std::string> result;
+  std::size_t pos = 0;
+
+  // Adds a token starting at the current "pos" up through the next instance
+  // of the selected "end_char"
+  auto find_and_add_until = [&text, &result, &pos](const char end_char) {
+    auto ending_pos = text.find(end_char, pos + 1);
+    add_token(text.substr(pos, ending_pos - pos + 1), result);
+    pos = ending_pos + 1;
+  };
+
+  while(pos < text.length())
+  {
+    // For quoted strings, find the next quote and use that as the end
+    if(text[pos] == '"')
+    {
+      find_and_add_until('"');
+    }
+    else if(text[pos] == '\'')
+    {
+      find_and_add_until('\'');
+    }
+    // If it's a table index, find the next bracket and use that as the end
+    else if(text[pos] == '[')
+    {
+      find_and_add_until(']');
+    }
+    // Otherwise just find the next instance of whitespace
+    else
+    {
+      auto ending_space = text.find(' ', pos + 1);
+      // Remove the leading space if there is one
+      if(text[pos] == ' ')
+      {
+        pos++;
+      }
+      if(ending_space == std::string::npos)
+      {
+        add_token(text.substr(pos, text.length() - pos), result);
+        pos = text.length();
+      }
+      else
+      {
+        add_token(text.substr(pos, ending_space - pos), result);
+        pos = ending_space + 1;
+      }
+    }
+  }
+  return result;
+}
+
+std::string LuaToYAML::convert(const std::string& luaString)
+{
+  const auto tokens = tokenize(luaString);
+  std::size_t i = 0;
+  std::string indent = "";
+  std::string result;
+  while(i < tokens.size())
+  {
+    const auto& token = tokens[i];
+    if((i < tokens.size() - 2) && tokens[i + 1] == "=" && tokens[i + 2] == "{")
+    {
+      result += indent + token + ":\n";
+      indent += "  ";
+      i += 3;
+    }
+    else if(token == "}")
+    {
+      indent = indent.substr(2);
+      i += 1;
+    }
+    else if(token == "," || token == ";")
+    {
+      i += 1;
+    }
+    // The start of an implicitly indexed array
+    else if(token == "{")
+    {
+      result += indent + "-\n";
+      indent += "  ";
+      i += 1;
+    }
+    else if(token == "[")
+    {
+      const auto& key = tokens[i + 1];
+      // Check if this is the start of a new table
+      if(tokens[i + 4] == "{")
+      {
+        result += indent;
+        // Check if it's an integer-keyed table
+        result += isdigit(key.front()) ? "-\n" : key + ":\n";
+        indent += "  ";
+      }
+      // Or if it's a terminal entry in the current table
+      else
+      {
+        const auto& value = tokens[i + 4];
+        if(isdigit(key.front()))
+        {
+          // Assume this is an integer-keyed array
+          result += indent + "- " + value + "\n";
+        }
+        else
+        {
+          result += indent + key + ": " + value + "\n";
+        }
+      }
+      i += 5;
+    }
+    else
+    {
+      const auto& value = tokens[i + 2];
+      result += indent + token + ": " + value + "\n";
+      i += 3;
+    }
+  }
+  return result;
+}
+
+}  // namespace axom::inlet::detail

--- a/src/axom/inlet/tests/inlet_test_utils.cpp
+++ b/src/axom/inlet/tests/inlet_test_utils.cpp
@@ -99,17 +99,20 @@ std::string LuaToYAML::convert(const std::string& luaString)
   while(i < tokens.size())
   {
     const auto& token = tokens[i];
+    // The start of a new table
     if((i < tokens.size() - 2) && tokens[i + 1] == "=" && tokens[i + 2] == "{")
     {
       result += indent + token + ":\n";
       indent += "  ";
       i += 3;
     }
+    // End of a table - only need to reduce the indent
     else if(token == "}")
     {
       indent = indent.substr(2);
       i += 1;
     }
+    // Commas and semicolons can be ignored completely
     else if(token == "," || token == ";")
     {
       i += 1;

--- a/src/axom/inlet/tests/inlet_test_utils.hpp
+++ b/src/axom/inlet/tests/inlet_test_utils.hpp
@@ -17,7 +17,11 @@
   #include "axom/inlet/LuaReader.hpp"
 #endif
 
-namespace axom::inlet::detail
+namespace axom
+{
+namespace inlet
+{
+namespace detail
 {
 /*!
  *******************************************************************************
@@ -36,7 +40,7 @@ public:
    * \brief Converts a Lua string to YAML
    * \param [in] luaString The string to convert
    * \note This function does not check for syntactic validity.  It is the
-   * responsibility of the callet to pass a valid Lua string.
+   * responsibility of the caller to pass a valid Lua string.
    *****************************************************************************
    */
   static std::string convert(const std::string& luaString);
@@ -89,6 +93,10 @@ using ReaderTypes =
 using ReaderTypes = ::testing::Types<axom::inlet::YAMLReader>;
 #endif
 
-}  // namespace axom::inlet::detail
+}  // namespace detail
+
+}  // namespace inlet
+
+}  // namespace axom
 
 #endif


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following:
  - Adds an implementation of the `inlet::Reader` interface for YAML
  - Adds primitive Lua -> YAML translation functionality for testing purposes

I opted for a hand-rolled translation approach to avoid adding dependencies on flex/bison/ANTLR or similar and because the subset of Lua that we care about for testing purposes is fairly minimal.