### PR TITLE
Add test macro wrapper and fix spin_bvh test

### DIFF
--- a/src/axom/core/examples/CMakeLists.txt
+++ b/src/axom/core/examples/CMakeLists.txt
@@ -29,7 +29,7 @@ foreach(example_source ${example_sources})
         FOLDER      axom/core/examples )
 
     if(AXOM_ENABLE_TESTS)
-        blt_add_test(
+        axom_add_test(
             NAME    ${exe_name}
             COMMAND ${exe_name}_ex )
     endif()
@@ -43,7 +43,7 @@ blt_add_executable(
     FOLDER      axom/core/examples )
 
 if(AXOM_ENABLE_TESTS)
-    blt_add_test(
+    axom_add_test(
         NAME    core_utilities
         COMMAND core_utilities_ex ${CMAKE_CURRENT_SOURCE_DIR} )
 endif()

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -63,8 +63,8 @@ blt_add_executable( NAME       core_serial_tests
 
 foreach(test_suite ${gtest_utils_tests})
     get_filename_component( test_suite ${test_suite} NAME_WE )
-    blt_add_test( NAME    ${test_suite}_serial
-                  COMMAND core_serial_tests --gtest_filter=${test_suite}* )
+    axom_add_test( NAME    ${test_suite}_serial
+                   COMMAND core_serial_tests --gtest_filter=${test_suite}* )
 endforeach()
 
 #------------------------------------------------------------------------------
@@ -84,9 +84,9 @@ if (ENABLE_MPI)
 
   foreach( test_suite ${core_mpi_tests} )
     get_filename_component( test_suite ${test_suite} NAME_WE )
-    blt_add_test( NAME          ${test_suite}_mpi
-                  COMMAND       core_mpi_tests --gtest_filter=${test_suite}*
-                  NUM_MPI_TASKS 1 )
+    axom_add_test( NAME          ${test_suite}_mpi
+                   COMMAND       core_mpi_tests --gtest_filter=${test_suite}*
+                   NUM_MPI_TASKS 1 )
   endforeach()
 endif()
 
@@ -104,8 +104,8 @@ blt_add_executable( NAME       utils_config_test
                     DEPENDS_ON ${utils_config_test_depends}
                     FOLDER     axom/core/tests )
 
-blt_add_test( NAME    utils_config
-              COMMAND utils_config_test )
+axom_add_test( NAME    utils_config
+               COMMAND utils_config_test )
 
 # Add flag to ignore unknown openmp pragmas in utils_config
 set_property(TARGET utils_config_test

--- a/src/axom/inlet/examples/CMakeLists.txt
+++ b/src/axom/inlet/examples/CMakeLists.txt
@@ -26,12 +26,12 @@ if (SOL_FOUND)
                             FOLDER     axom/inlet/examples )
     endforeach()
 
-    blt_add_test( NAME    inlet_verification_ex
-                  COMMAND inlet_verification_ex )
+    axom_add_test( NAME    inlet_verification_ex
+                   COMMAND inlet_verification_ex )
 
-    blt_add_test( NAME    inlet_documentation_generation_ex
-                  COMMAND inlet_documentation_generation_ex --enableDocs --file ${CMAKE_CURRENT_LIST_DIR}/example1.lua )
+    axom_add_test( NAME    inlet_documentation_generation_ex
+                   COMMAND inlet_documentation_generation_ex --enableDocs --file ${CMAKE_CURRENT_LIST_DIR}/example1.lua )
 
-    blt_add_test( NAME    inlet_user_defined_type_ex
-                  COMMAND inlet_user_defined_type_ex --file ${CMAKE_CURRENT_LIST_DIR}/example1.lua)
+    axom_add_test( NAME    inlet_user_defined_type_ex
+                   COMMAND inlet_user_defined_type_ex --file ${CMAKE_CURRENT_LIST_DIR}/example1.lua)
 endif()

--- a/src/axom/inlet/tests/CMakeLists.txt
+++ b/src/axom/inlet/tests/CMakeLists.txt
@@ -30,7 +30,7 @@ if (SOL_FOUND)
                             OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                             DEPENDS_ON inlet gtest inlet_test_utils
                             FOLDER     axom/inlet/tests )
-        blt_add_test( NAME    ${test_name} 
-                      COMMAND ${test_name}_test )
+        axom_add_test( NAME    ${test_name} 
+                       COMMAND ${test_name}_test )
     endforeach()
 endif()

--- a/src/axom/lumberjack/tests/CMakeLists.txt
+++ b/src/axom/lumberjack/tests/CMakeLists.txt
@@ -23,8 +23,8 @@ blt_add_executable(NAME       lumberjack_serial_tests
 
 foreach(test_suite ${lumberjack_serial_tests})
     get_filename_component(test_suite ${test_suite} NAME_WE)
-    blt_add_test(NAME    ${test_suite}
-                 COMMAND lumberjack_serial_tests --gtest_filter=${test_suite}* )
+    axom_add_test(NAME    ${test_suite}
+                  COMMAND lumberjack_serial_tests --gtest_filter=${test_suite}* )
 endforeach()
 
 
@@ -45,9 +45,9 @@ blt_add_executable(NAME       lumberjack_mpi_tests
 foreach(test_suite ${lumberjack_mpi_tests})
     get_filename_component( test_suite ${test_suite} NAME_WE )
     foreach(task_count RANGE 1 8)
-        blt_add_test(NAME          ${test_suite}_${task_count}
-                     COMMAND       lumberjack_mpi_tests --gtest_filter=${test_suite}*
-                     NUM_MPI_TASKS ${task_count} )
+        axom_add_test(NAME          ${test_suite}_${task_count}
+                      COMMAND       lumberjack_mpi_tests --gtest_filter=${test_suite}*
+                      NUM_MPI_TASKS ${task_count} )
     endforeach()
 endforeach()
 
@@ -61,10 +61,10 @@ blt_add_executable(NAME       lumberjack_speed_test
                    FOLDER     axom/lumberjack/tests )
 
 set(lumberjack_sample_input_dir ${PROJECT_SOURCE_DIR}/axom/lumberjack/tests/sampleInput)
-blt_add_test(NAME          lumberjack_speedTest_binary
-             COMMAND       lumberjack_speed_test b 10 ${lumberjack_sample_input_dir}/loremIpsum02
-             NUM_MPI_TASKS 4)
+axom_add_test(NAME          lumberjack_speedTest_binary
+              COMMAND       lumberjack_speed_test b 10 ${lumberjack_sample_input_dir}/loremIpsum02
+              NUM_MPI_TASKS 4)
               
-blt_add_test(NAME          lumberjack_speedTest_root
-             COMMAND       lumberjack_speed_test r 10 ${lumberjack_sample_input_dir}/loremIpsum02
-             NUM_MPI_TASKS 4)       
+axom_add_test(NAME          lumberjack_speedTest_root
+              COMMAND       lumberjack_speed_test r 10 ${lumberjack_sample_input_dir}/loremIpsum02
+              NUM_MPI_TASKS 4)       

--- a/src/axom/mint/tests/CMakeLists.txt
+++ b/src/axom/mint/tests/CMakeLists.txt
@@ -66,9 +66,9 @@ foreach( test ${mint_tests} )
         FOLDER     axom/mint/tests
         )
 
-   blt_add_test( NAME    ${test_name}
-                 COMMAND ${test_name}_test
-                 NUM_OMP_THREADS 4
-               )
+   axom_add_test( NAME    ${test_name}
+                  COMMAND ${test_name}_test
+                  NUM_OMP_THREADS 4
+                  )
 
 endforeach()

--- a/src/axom/primal/tests/CMakeLists.txt
+++ b/src/axom/primal/tests/CMakeLists.txt
@@ -46,7 +46,7 @@ foreach ( test ${primal_tests} )
         FOLDER     axom/primal/tests
        )
 
-   blt_add_test(
+   axom_add_test(
         NAME    ${test_name}
         COMMAND ${test_name}_test
        )

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -49,13 +49,13 @@ set(quest_data_dir  ${AXOM_DATA_DIR}/quest)
 
 if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR)
     if (ENABLE_MPI)
-        blt_add_test(
+        axom_add_test(
             NAME quest_inout_interface_mpi_test
             COMMAND quest_inout_interface_ex ${quest_data_dir}/sphere_binary.stl
             NUM_MPI_TASKS 2
             )
     else()
-        blt_add_test(
+        axom_add_test(
             NAME quest_inout_interface_test
             COMMAND quest_inout_interface_ex ${quest_data_dir}/sphere_binary.stl
             )
@@ -97,13 +97,13 @@ if (ENABLE_FORTRAN)
 
     if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR)
         if (ENABLE_MPI)
-            blt_add_test(
+            axom_add_test(
                 NAME quest_inout_interface_mpi_F_test
                 COMMAND quest_inout_interface_F_ex ${quest_data_dir}/sphere_binary.stl
                 NUM_MPI_TASKS 2
                 )
         else()
-            blt_add_test(
+            axom_add_test(
                 NAME quest_inout_interface_F_test
                 COMMAND quest_inout_interface_F_ex ${quest_data_dir}/sphere_binary.stl
                 )

--- a/src/axom/quest/tests/CMakeLists.txt
+++ b/src/axom/quest/tests/CMakeLists.txt
@@ -42,7 +42,7 @@ foreach(test ${quest_tests})
         FOLDER axom/quest/tests
         )
 
-    blt_add_test(
+    axom_add_test(
         NAME ${test_name}
         COMMAND ${test_name}_test
         )
@@ -67,7 +67,7 @@ if(MFEM_FOUND)
 
     blt_add_target_compile_flags( TO ${test_name} FLAGS "${MFEM_COMPILE_FLAGS}" )
 
-    blt_add_test(
+    axom_add_test(
         NAME ${test_name}
         COMMAND ${test_name}
         )
@@ -112,13 +112,13 @@ foreach(test ${quest_mpi_tests})
     endif()
 
     if (ENABLE_MPI)
-        blt_add_test(
+        axom_add_test(
             NAME ${test_name}
             COMMAND ${test_name}_test
             NUM_MPI_TASKS ${_numMPITasks}
         )
     else()
-        blt_add_test(
+        axom_add_test(
             NAME ${test_name}
             COMMAND ${test_name}_test
         )
@@ -202,7 +202,7 @@ if (ENABLE_MPI AND AXOM_ENABLE_SIDRE)
 
         foreach(dataset ${quest_regression_datasets})
             foreach(res ${quest_regression_resolutions})
-                blt_add_test(
+                axom_add_test(
                     NAME quest_regression_${dataset}_${res}
                     COMMAND ${test_name}
                             --mesh ${quest_data_dir}/${dataset}.stl

--- a/src/axom/sidre/examples/CMakeLists.txt
+++ b/src/axom/sidre/examples/CMakeLists.txt
@@ -62,7 +62,7 @@ foreach(example_source ${example_sources})
         FOLDER axom/sidre/examples )
 
     if(AXOM_ENABLE_TESTS)
-        blt_add_test(
+        axom_add_test(
             NAME ${exe_name}
             COMMAND ${exe_name}_ex )
     endif()
@@ -82,10 +82,10 @@ if(ENABLE_MPI)
             FOLDER axom/sidre/examples)
 
         if(AXOM_ENABLE_TESTS)
-            blt_add_test( NAME ${exe_name}
-                          COMMAND ${exe_name}_ex
-                          NUM_MPI_TASKS 1
-                          )
+            axom_add_test( NAME ${exe_name}
+                           COMMAND ${exe_name}_ex
+                           NUM_MPI_TASKS 1
+                           )
         endif()
     endforeach()
 endif()
@@ -104,7 +104,7 @@ if(ENABLE_FORTRAN)
             FOLDER axom/sidre/examples )
 
         if(AXOM_ENABLE_TESTS)
-            blt_add_test(
+            axom_add_test(
                 NAME ${exe_name}
                 COMMAND ${exe_name}_ex )
         endif()

--- a/src/axom/sidre/examples/lulesh2/CMakeLists.txt
+++ b/src/axom/sidre/examples/lulesh2/CMakeLists.txt
@@ -37,13 +37,13 @@ blt_add_executable(
 
 if(AXOM_ENABLE_TESTS)
     if(ENABLE_MPI)
-        blt_add_test(NAME sidre_lulesh2
-                     COMMAND sidre_lulesh2_ex -s 5
-                     NUM_MPI_TASKS 1
-                     NUM_OMP_THREADS 2 )
+        axom_add_test(NAME sidre_lulesh2
+                      COMMAND sidre_lulesh2_ex -s 5
+                      NUM_MPI_TASKS 1
+                      NUM_OMP_THREADS 2 )
     else()
-        blt_add_test(NAME sidre_lulesh2 -s 5
-                     COMMAND sidre_lulesh2_ex
-                     NUM_OMP_THREADS 2 )
+        axom_add_test(NAME sidre_lulesh2 -s 5
+                      COMMAND sidre_lulesh2_ex
+                      NUM_OMP_THREADS 2 )
     endif()
 endif()

--- a/src/axom/sidre/tests/CMakeLists.txt
+++ b/src/axom/sidre/tests/CMakeLists.txt
@@ -69,9 +69,9 @@ foreach(test ${gtest_sidre_tests})
                         FOLDER axom/sidre/tests
                         )
 
-    blt_add_test( NAME ${test_name}
-                  COMMAND ${test_name}_test
-                  )
+    axom_add_test( NAME    ${test_name}
+                   COMMAND ${test_name}_test
+                   )
 endforeach()
 
 #------------------------------------------------------------------------------
@@ -87,9 +87,9 @@ if (ENABLE_FORTRAN)
                             DEPENDS_ON ${sidre_test_depends} gtest
                             FOLDER axom/sidre/tests
                             )
-        blt_add_test( NAME ${test_name}
-                      COMMAND ${test_name}_test
-                      )
+        axom_add_test( NAME    ${test_name}
+                       COMMAND ${test_name}_test
+                       )
     endforeach()
 endif()
 
@@ -105,9 +105,9 @@ if (ENABLE_FORTRAN)
                             DEPENDS_ON ${sidre_test_depends} fruit
                             FOLDER axom/sidre/tests
                             )
-        blt_add_test( NAME ${test_name}
-                      COMMAND ${test_name}_test
-                      )
+        axom_add_test( NAME    ${test_name}
+                       COMMAND ${test_name}_test
+                       )
     endforeach()
 endif()
 
@@ -122,14 +122,14 @@ if (AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION)
                         FOLDER axom/sidre/tests
                         )
     if (ENABLE_MPI)
-        blt_add_test( NAME sidre_mfem_datacollection
-                        COMMAND sidre_mfem_datacollection_test
-                        NUM_MPI_TASKS 2
-                        )
+        axom_add_test( NAME sidre_mfem_datacollection
+                       COMMAND sidre_mfem_datacollection_test
+                       NUM_MPI_TASKS 2
+                       )
     else()
-        blt_add_test( NAME sidre_mfem_datacollection
-                        COMMAND sidre_mfem_datacollection_test
-                        )
+        axom_add_test( NAME    sidre_mfem_datacollection
+                       COMMAND sidre_mfem_datacollection_test
+                       )
     endif()
 endif()
 

--- a/src/axom/sidre/tests/spio/CMakeLists.txt
+++ b/src/axom/sidre/tests/spio/CMakeLists.txt
@@ -45,18 +45,18 @@ blt_add_executable( NAME       spio_tests
 
 foreach(test ${gtest_spio_serial_tests})
     get_filename_component( test_name ${test} NAME_WE )
-    blt_add_test( NAME          ${test_name} 
-                  COMMAND       spio_tests --gtest_filter=${test_name}*
-                  NUM_MPI_TASKS 1
-                 )
+    axom_add_test( NAME          ${test_name} 
+                   COMMAND       spio_tests --gtest_filter=${test_name}*
+                   NUM_MPI_TASKS 1
+                   )
 endforeach()
 
 foreach(test ${gtest_spio_parallel_tests})
     get_filename_component( test_name ${test} NAME_WE )
-    blt_add_test( NAME          ${test_name} 
-                  COMMAND       spio_tests --gtest_filter=${test_name}*
-                  NUM_MPI_TASKS 4
-                  )
+    axom_add_test( NAME          ${test_name} 
+                   COMMAND       spio_tests --gtest_filter=${test_name}*
+                   NUM_MPI_TASKS 4
+                   )
 endforeach()
 
 #------------------------------------------------------------------------------
@@ -78,7 +78,7 @@ if(ENABLE_FORTRAN)
                             DEPENDS_ON ${spio_test_depends}
                             FOLDER     axom/sidre/tests
                             )
-        blt_add_test( NAME    ${test_name}_F
+        axom_add_test( NAME    ${test_name}_F
                       COMMAND ${test_name}_F_test
                       NUM_MPI_TASKS 1
                       )
@@ -100,10 +100,10 @@ if(ENABLE_FORTRAN)
                             DEPENDS_ON ${spio_test_depends}
                             FOLDER     axom/sidre/tests
                             )
-        blt_add_test( NAME    ${test_name}_F
-                      COMMAND ${test_name}_F_test
-                      NUM_MPI_TASKS 4
-                      )
+        axom_add_test( NAME    ${test_name}_F
+                       COMMAND ${test_name}_F_test
+                       NUM_MPI_TASKS 4
+                       )
     endforeach()
 
     # Fruit parallel tests with 4 MPI task
@@ -120,10 +120,10 @@ if(ENABLE_FORTRAN)
                             DEPENDS_ON ${spio_test_depends} fruit
                             FOLDER     axom/sidre/tests
                             )
-        blt_add_test( NAME    ${test_name}_F
-                      COMMAND ${test_name}_F_test
-                      NUM_MPI_TASKS 4
-                      )
+        axom_add_test( NAME    ${test_name}_F
+                       COMMAND ${test_name}_F_test
+                       NUM_MPI_TASKS 4
+                       )
     endforeach()
 
 endif()

--- a/src/axom/slam/examples/CMakeLists.txt
+++ b/src/axom/slam/examples/CMakeLists.txt
@@ -35,7 +35,7 @@ foreach(example_source ${example_sources})
         FOLDER      axom/slam/examples )
 
     if(AXOM_ENABLE_TESTS)
-        blt_add_test(
+        axom_add_test(
             NAME        slam_${example_name}
             COMMAND     slam_${example_name}_ex )
     endif()
@@ -61,7 +61,7 @@ blt_add_executable(
     FOLDER      axom/slam/examples )
 
 if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR)
-    blt_add_test(
+    axom_add_test(
         NAME        slam_unstructMesh
         COMMAND     slam_unstructMesh_ex ${AXOM_DATA_DIR}/slam )
 endif()

--- a/src/axom/slam/examples/lulesh2.0.3/CMakeLists.txt
+++ b/src/axom/slam/examples/lulesh2.0.3/CMakeLists.txt
@@ -41,14 +41,14 @@ blt_add_executable(
 
 if(AXOM_ENABLE_TESTS)
     if(ENABLE_MPI)
-        blt_add_test(NAME        slam_lulesh
-                     COMMAND     slam_lulesh_ex
-                     NUM_MPI_TASKS   8
-                     NUM_OMP_THREADS 4 )
+        axom_add_test(NAME        slam_lulesh
+                      COMMAND     slam_lulesh_ex
+                      NUM_MPI_TASKS   8
+                      NUM_OMP_THREADS 4 )
     else()
-        blt_add_test(NAME        slam_lulesh
-                     COMMAND     slam_lulesh_ex
-                     NUM_OMP_THREADS 4 )
+        axom_add_test(NAME        slam_lulesh
+                      COMMAND     slam_lulesh_ex
+                      NUM_OMP_THREADS 4 )
     endif()
 endif()
 

--- a/src/axom/slam/examples/tinyHydro/CMakeLists.txt
+++ b/src/axom/slam/examples/tinyHydro/CMakeLists.txt
@@ -50,7 +50,7 @@ if(AXOM_ENABLE_TESTS)
         DEPENDS_ON  ${slam_tiny_hydro_tests_depends_on} gtest
         FOLDER      axom/slam/examples )
 
-    blt_add_test(
+    axom_add_test(
         NAME        slam_tinyHydro_unitTests
         COMMAND     slam_tinyHydro_unitTests_ex )
 endif()
@@ -66,7 +66,7 @@ blt_add_executable(
     FOLDER      axom/slam/examples )
 
 if(AXOM_ENABLE_TESTS)
-    blt_add_test(
+    axom_add_test(
         NAME        slam_tinyHydro_sod
         COMMAND     slam_tinyHydro_sod_ex )
 endif()

--- a/src/axom/slam/tests/CMakeLists.txt
+++ b/src/axom/slam/tests/CMakeLists.txt
@@ -53,6 +53,6 @@ foreach(test ${gtest_slam_tests})
                         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                         DEPENDS_ON ${slam_tests_depends_on}
                         FOLDER axom/slam/tests )
-    blt_add_test( NAME ${test_name}
-                  COMMAND ${test_name}_test )
+    axom_add_test( NAME ${test_name}
+                   COMMAND ${test_name}_test )
 endforeach()

--- a/src/axom/slic/examples/CMakeLists.txt
+++ b/src/axom/slic/examples/CMakeLists.txt
@@ -24,15 +24,15 @@ endif()
 
 foreach( example_source ${example_sources} )
     get_filename_component( example_name ${example_source} NAME_WE )
-    blt_add_executable( NAME "slic_${example_name}_ex" 
-                        SOURCES ${example_source} 
+    blt_add_executable( NAME       slic_${example_name}_ex
+                        SOURCES    ${example_source} 
                         DEPENDS_ON slic
                         OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-                        FOLDER axom/slic/examples )
+                        FOLDER     axom/slic/examples )
 
     if(AXOM_ENABLE_TESTS)
-        blt_add_test( NAME "slic_${example_name}"
-                      COMMAND "slic_${example_name}_ex" )
+        axom_add_test( NAME   slic_${example_name}
+                      COMMAND slic_${example_name}_ex )
     endif()
 endforeach()
 
@@ -40,16 +40,16 @@ endforeach()
 if ( ENABLE_MPI )
     foreach( example_source ${mpi_example_sources} )
         get_filename_component( example_name ${example_source} NAME_WE )
-        blt_add_executable( NAME "slic_mpi_${example_name}_ex" 
-                            SOURCES ${example_source} 
+        blt_add_executable( NAME       slic_mpi_${example_name}_ex
+                            SOURCES    ${example_source}
                             OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
                             DEPENDS_ON slic 
-                            FOLDER      axom/slic/examples )
+                            FOLDER     axom/slic/examples )
 
         if(AXOM_ENABLE_TESTS)
-            blt_add_test( NAME "slic_mpi_${example_name}"
-                          COMMAND "slic_mpi_${example_name}_ex"
-                          NUM_MPI_TASKS 4)
+            axom_add_test( NAME    slic_mpi_${example_name}
+                           COMMAND slic_mpi_${example_name}_ex
+                           NUM_MPI_TASKS 4)
         endif()
     endforeach()
 endif()

--- a/src/axom/slic/tests/CMakeLists.txt
+++ b/src/axom/slic/tests/CMakeLists.txt
@@ -11,10 +11,10 @@
 #
 
 set(gtest_slic_tests
-   slic_asserts.cpp
-   slic_interface.cpp
-   slic_macros.cpp
-   )
+    slic_asserts.cpp
+    slic_interface.cpp
+    slic_macros.cpp
+    )
 
 set(bench_slic_tests
     slic_benchmark_asserts.cpp
@@ -31,8 +31,8 @@ foreach(test ${gtest_slic_tests})
                         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                         DEPENDS_ON slic gtest
                         FOLDER      axom/slic/tests )
-    blt_add_test( NAME ${test_name}
-                  COMMAND ${test_name}_test )
+    axom_add_test( NAME ${test_name}
+                   COMMAND ${test_name}_test )
 endforeach()
 
 blt_add_executable( NAME slic_fmt_test
@@ -40,8 +40,8 @@ blt_add_executable( NAME slic_fmt_test
                     OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                     DEPENDS_ON slic gtest fmt
                     FOLDER      axom/slic/tests )
-blt_add_test( NAME slic_fmt
-              COMMAND slic_fmt_test )
+axom_add_test( NAME slic_fmt
+               COMMAND slic_fmt_test )
 
 
 
@@ -58,7 +58,7 @@ if (ENABLE_BENCHMARKS)
 
         blt_add_benchmark(
             NAME ${test_name}
-            COMMAND ${test_name} "--benchmark_min_time=0.0001"
+            COMMAND ${test_name} --benchmark_min_time=0.0001
             )
     endforeach()
 endif()

--- a/src/axom/spin/internal/linear_bvh/vec.hpp
+++ b/src/axom/spin/internal/linear_bvh/vec.hpp
@@ -33,7 +33,7 @@ public:
   T m_data[S];
 
   //
-  //  Use only default contructors to keep this a POD type
+  //  Use only default constructors to keep this a POD type
   //
   inline Vec<T, S>() = default;
   inline Vec<T, S>(const Vec<T, S> &v) = default;

--- a/src/axom/spin/tests/CMakeLists.txt
+++ b/src/axom/spin/tests/CMakeLists.txt
@@ -6,7 +6,7 @@
 # Unit tests for Spin component
 #------------------------------------------------------------------------------
 
-set( spin_tests
+set(spin_tests
     spin_bvhtree.cpp
     spin_implicit_grid.cpp
     spin_morton.cpp
@@ -16,14 +16,14 @@ set( spin_tests
     spin_uniform_grid.cpp
    )
 
-set( spin_depends
-     core
-     slic
-     slam
-     primal
-     spin
-     gtest
-     fmt
+set(spin_depends
+    core
+    slic
+    slam
+    primal
+    spin
+    gtest
+    fmt
     )
 
 blt_list_append( TO spin_depends ELEMENTS RAJA IF ${RAJA_FOUND} )
@@ -33,38 +33,46 @@ blt_list_append( TO spin_depends ELEMENTS cuda IF ${ENABLE_CUDA} )
 
 foreach ( test ${spin_tests} )
 
-   get_filename_component( test_name ${test} NAME_WE )
+    get_filename_component( test_name ${test} NAME_WE )
 
-   blt_add_executable(
-        NAME       ${test_name}_test
-        SOURCES    ${test}
-        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-        DEPENDS_ON ${spin_depends}
-        FOLDER     axom/spin/tests
-       )
+    blt_add_executable(
+      NAME       ${test_name}_test
+      SOURCES    ${test}
+      OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+      DEPENDS_ON ${spin_depends}
+      FOLDER     axom/spin/tests
+      )
 
-   blt_add_test(
-        NAME    ${test_name}
-        COMMAND ${test_name}_test
-       )
+    axom_add_test(
+      NAME    ${test_name}
+      COMMAND ${test_name}_test
+      )
 
 endforeach()
 
 if ( RAJA_FOUND AND UMPIRE_FOUND )
 
-   blt_add_executable(
+    blt_add_executable(
       NAME       spin_bvh_test
       SOURCES    spin_bvh.cpp
       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
       DEPENDS_ON mint ${spin_depends}
       FOLDER     axom/spin/tests
-     )
+      )
 
-   blt_add_test(
-      NAME    spin_bvh
-      COMMAND spin_bvh_test
+    axom_add_test(
+      NAME            spin_bvh
+      COMMAND         spin_bvh_test
       NUM_OMP_THREADS 4
-     )
+      )
+
+    # fix for rzmanta of following runtime error:
+    #   CUDAassert: peer access is not supported between these two devices /unimportant/path/raja-0.12.1/include/RAJA/policy/cuda/sort.hpp 341
+    #   unknown file: Failure
+    #   C++ exception with description "CUDAassert" thrown in the test body.
+    set_property(TEST spin_bvh
+                 APPEND
+                 PROPERTY ENVIRONMENT  "CUDA_VISIBLE_DEVICES=1")
 
 endif()
 

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -1744,14 +1744,14 @@ TEST(spin_bvh, traversal_predicates_pointInRightBin)
 }
 
 //------------------------------------------------------------------------------
-TEST(spin_bvh, contruct2D_sequential)
+TEST(spin_bvh, construct2D_sequential)
 {
   check_build_bvh2d<axom::SEQ_EXEC, double>();
   check_build_bvh2d<axom::SEQ_EXEC, float>();
 }
 
 //------------------------------------------------------------------------------
-TEST(spin_bvh, contruct3D_sequential)
+TEST(spin_bvh, construct3D_sequential)
 {
   check_build_bvh3d<axom::SEQ_EXEC, double>();
   check_build_bvh3d<axom::SEQ_EXEC, float>();
@@ -1816,14 +1816,14 @@ TEST(spin_bvh, single_box3d_sequential)
 //------------------------------------------------------------------------------
 #ifdef AXOM_USE_OPENMP
 
-TEST(spin_bvh, contruct2D_omp)
+TEST(spin_bvh, construct2D_omp)
 {
   check_build_bvh2d<axom::OMP_EXEC, double>();
   check_build_bvh2d<axom::OMP_EXEC, float>();
 }
 
 //------------------------------------------------------------------------------
-TEST(spin_bvh, contruct3D_omp)
+TEST(spin_bvh, construct3D_omp)
 {
   check_build_bvh3d<axom::OMP_EXEC, double>();
   check_build_bvh3d<axom::OMP_EXEC, float>();
@@ -1889,7 +1889,7 @@ TEST(spin_bvh, single_box3d_omp)
 //------------------------------------------------------------------------------
 #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
 
-AXOM_CUDA_TEST(spin_bvh, contruct2D_cuda)
+AXOM_CUDA_TEST(spin_bvh, construct2D_cuda)
 {
   constexpr int BLOCK_SIZE = 256;
   using exec = axom::CUDA_EXEC<BLOCK_SIZE>;
@@ -1899,7 +1899,7 @@ AXOM_CUDA_TEST(spin_bvh, contruct2D_cuda)
 }
 
 //------------------------------------------------------------------------------
-AXOM_CUDA_TEST(spin_bvh, contruct3D_cuda)
+AXOM_CUDA_TEST(spin_bvh, construct3D_cuda)
 {
   constexpr int BLOCK_SIZE = 256;
   using exec = axom::CUDA_EXEC<BLOCK_SIZE>;

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -122,7 +122,7 @@ endmacro(axom_add_component)
 ##               NUM_OMP_THREADS [n]
 ##               CONFIGURATIONS  [config1 [config2...]])
 ##
-## Wrapper around axom_add_test() that handles functionality that Axom applies to all
+## Wrapper around blt_add_test() that handles functionality that Axom applies to all
 ## tests.
 ##------------------------------------------------------------------------------
 macro(axom_add_test)

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -116,6 +116,46 @@ endmacro(axom_add_component)
 
 
 ##------------------------------------------------------------------------------
+## axom_add_test(NAME            [name]
+##               COMMAND         [command] 
+##               NUM_MPI_TASKS   [n]
+##               NUM_OMP_THREADS [n]
+##               CONFIGURATIONS  [config1 [config2...]])
+##
+## Wrapper around axom_add_test() that handles functionality that Axom applies to all
+## tests.
+##------------------------------------------------------------------------------
+macro(axom_add_test)
+
+    set(options )
+    set(singleValueArgs NAME NUM_MPI_TASKS NUM_OMP_THREADS)
+    set(multiValueArgs COMMAND CONFIGURATIONS)
+
+    # Parse the arguments to the macro
+    cmake_parse_arguments(arg
+        "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+
+    blt_add_test(NAME            ${arg_NAME}
+                 COMMAND         ${arg_COMMAND}
+                 NUM_MPI_TASKS   ${arg_NUM_MPI_TASKS}
+                 NUM_OMP_THREADS ${arg_NUM_OMP_THREADS}
+                 CONFIGURATIONS  ${arg_CONFIGURATIONS} )
+
+    ###########################################################################
+    # Newer versions of OpenMPI require OMPI_MCA_rmaps_base_oversubscribe=1
+    # to run with more tasks than actual cores
+    # Since this is an OpenMPI specific env var, it shouldn't interfere
+    # with other mpi implementations.
+    ###########################################################################
+    set_property(TEST ${arg_NAME}
+                 APPEND
+                 PROPERTY ENVIRONMENT  "OMPI_MCA_rmaps_base_oversubscribe=1")
+
+endmacro(axom_add_test)
+
+
+##------------------------------------------------------------------------------
 ## convert_to_native_escaped_file_path( path output )
 ##
 ## This macro converts a cmake path to a platform specific string literal

--- a/src/docs/sphinx/dev_guide/testing.rst
+++ b/src/docs/sphinx/dev_guide/testing.rst
@@ -274,7 +274,7 @@ following items:
 
   #. An executable and test variable for each test executable to be
      generated. These variables use the `blt_add_executable` and
-     `blt_add_test` macros, respectively, as described above.
+     `axom_add_test` macros, respectively, as described above.
 
 .. note:: Fortran executables and tests should be guarded to prevent
           generation when Fortran is not enabled.
@@ -310,7 +310,7 @@ following items:
 
   #. An executable and test variable for each example executable to be
      generated and each executable to be run as a test. These definitions
-     use the `blt_add_executable` and `blt_add_test` macros, respectively.
+     use the `blt_add_executable` and `axom_add_test` macros, respectively.
      For example::
 
        blt_add_executable(NAME  <example executable name>
@@ -320,8 +320,8 @@ following items:
 
      and::
 
-       blt_add_test(NAME <example executable name>
-                    COMMAND <example executable name>)
+       axom_add_test(NAME <example executable name>
+                     COMMAND <example executable name>)
 
      Fortran executables and tests should be guarded to prevent generation if
      Fortran is not enabled.

--- a/src/thirdparty/tests/CMakeLists.txt
+++ b/src/thirdparty/tests/CMakeLists.txt
@@ -24,8 +24,8 @@ if ( UMPIRE_FOUND )
                       DEPENDS_ON ${umpire_smoke_dependencies}
                       FOLDER axom/thirdparty/tests )
 
-  blt_add_test( NAME umpire_smoke
-                COMMAND umpire_smoke_test )
+  axom_add_test( NAME    umpire_smoke
+                 COMMAND umpire_smoke_test )
 
 endif()
 
@@ -47,8 +47,8 @@ if ( RAJA_FOUND )
                       DEPENDS_ON ${raja_smoke_dependencies}
                       FOLDER axom/thirdparty/tests )
 
-  blt_add_test( NAME raja_smoke
-                COMMAND raja_smoke_test )
+  axom_add_test( NAME    raja_smoke
+                 COMMAND raja_smoke_test )
 
 endif()
 
@@ -67,7 +67,7 @@ if( HDF5_FOUND)
                        DEPENDS_ON ${hdf5_smoke_dependencies}
                        FOLDER axom/thirdparty/tests )
 
-    blt_add_test(NAME hdf5_smoke
+    axom_add_test(NAME hdf5_smoke
                  COMMAND hdf5_smoke_test)
 endif()
 
@@ -81,7 +81,7 @@ if (CONDUIT_FOUND)
                        DEPENDS_ON conduit::conduit gtest
                        FOLDER     axom/thirdparty/tests )
 
-    blt_add_test(NAME conduit_smoke
+    axom_add_test(NAME conduit_smoke
                  COMMAND conduit_smoke_test)
 
     if (ENABLE_FORTRAN)
@@ -91,7 +91,7 @@ if (CONDUIT_FOUND)
                            DEPENDS_ON conduit::conduit fruit
                            FOLDER     axom/thirdparty/tests )
 
-        blt_add_test(NAME conduit_smoke_F
+        axom_add_test(NAME conduit_smoke_F
                      COMMAND conduit_smoke_F_test)
   endif()
 endif()
@@ -111,8 +111,8 @@ if (MFEM_FOUND)
         TARGET mfem_smoke_test
         APPEND_STRING PROPERTY COMPILE_FLAGS "${AXOM_DISABLE_UNUSED_PARAMETER_WARNINGS}")
 
-    blt_add_test(NAME mfem_smoke
-                 COMMAND mfem_smoke_test)
+    axom_add_test(NAME    mfem_smoke
+                  COMMAND mfem_smoke_test)
 
 endif()
 
@@ -126,8 +126,8 @@ blt_add_executable(
     DEPENDS_ON fmt gtest
     FOLDER axom/thirdparty/tests )
     
-blt_add_test(NAME fmt_smoke
-             COMMAND fmt_smoke_test)
+axom_add_test(NAME    fmt_smoke
+              COMMAND fmt_smoke_test)
 
 #------------------------------------------------------------------------------
 # Smoke test for CLI11 third party library
@@ -139,11 +139,11 @@ blt_add_executable(
     DEPENDS_ON cli11
     FOLDER axom/thirdparty/tests )
 
-blt_add_test(
+axom_add_test(
     NAME cli11_smoke_help
     COMMAND cli11_smoke_test --help)
 
-blt_add_test(
+axom_add_test(
     NAME cli11_smoke_with_options
     COMMAND cli11_smoke_test -b -i 42 --some-float=3.14 --some-string "hello world")
 
@@ -159,8 +159,8 @@ if (SPARSEHASH_FOUND)
     DEPENDS_ON sparsehash gtest
     FOLDER axom/thirdparty/tests )
 
-  blt_add_test(NAME sparsehash_smoke
-             COMMAND sparsehash_smoke_test)
+  axom_add_test(NAME    sparsehash_smoke
+                COMMAND sparsehash_smoke_test)
 endif()
 
 #------------------------------------------------------------------------------
@@ -175,8 +175,8 @@ if (SOL_FOUND)
         DEPENDS_ON sol lua gtest
         FOLDER     axom/thirdparty/tests )
 
-    blt_add_test(NAME    sol_smoke
-                 COMMAND sol_smoke_test)
+    axom_add_test(NAME    sol_smoke
+                  COMMAND sol_smoke_test)
 endif()
 
 #------------------------------------------------------------------------------
@@ -212,7 +212,7 @@ foreach(test ${BLT_SMOKE_TESTS})
         USE_OPENMP False
         FOLDER axom/thirdparty/tests)
 
-    blt_add_test(
+    axom_add_test(
         NAME ${test_name}
         COMMAND ${test_name}_test)
 


### PR DESCRIPTION
#349 

* Adds a common `axom_add_test` macro, this allows us to do project-wide changes to all our tests in one place
* Fix spin_bvh test by setting environment variable `CUDA_VISIBLE_DEVICES`