### PR TITLE
Added a few standard lua base packages to the LuaReader class

### DIFF
--- a/src/axom/inlet/LuaReader.hpp
+++ b/src/axom/inlet/LuaReader.hpp
@@ -39,7 +39,7 @@ namespace inlet
 class LuaReader : public Reader
 {
 public:
-  LuaReader() { m_lua.open_libraries(sol::lib::base); }
+  LuaReader() { m_lua.open_libraries(sol::lib::base, sol::lib::math, sol::lib::string, sol::lib::io, sol::lib::package); }
 
   /*!
    *****************************************************************************

--- a/src/axom/inlet/LuaReader.hpp
+++ b/src/axom/inlet/LuaReader.hpp
@@ -39,7 +39,7 @@ namespace inlet
 class LuaReader : public Reader
 {
 public:
-  LuaReader() { m_lua.open_libraries(sol::lib::base, sol::lib::math, sol::lib::string, sol::lib::io, sol::lib::package); }
+  LuaReader() { m_lua.open_libraries(sol::lib::base, sol::lib::math, sol::lib::string, sol::lib::package); }
 
   /*!
    *****************************************************************************


### PR DESCRIPTION
# Summary
This change should enable standard lua math libraries, string, io, and package libraries in inlet. The main utility of this is to be able to calculate certain model parameters that are not compute intensive directly in lua or load external libraries no included by default.

