### PR TITLE
Various cuda fixes and CZ host-configs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -18,8 +18,12 @@ Chris White <white238@llnl.gov>                 Christopher A. White <white238@l
 Cyrus D. Harrison <harrison37@llnl.gov>         Cyrus Harrison <cyrush@llnl.gov>
 Cyrus D. Harrison <harrison37@llnl.gov>         Cyrus Harrison <harrison37@llnl.gov>
 Cyrus D. Harrison <harrison37@llnl.gov>         Cyrus <cyrush@llnl.gov>
+Esteban Pauli <pauli2@llnl.gov>                 Esteban Pauli <40901502+estebanpauli@users.noreply.github.com>
 Evan Taylor Desantola <desantola1@llnl.gov>     Evan Taylor DeSantola <desantola1@llnl.gov>
 George Zagaris <zagaris2@llnl.gov>              George Zagaris <george.zagaris@gmail.com>
+Joe Hennis <hennis1@llnl.gov>                   Hennis <hennis1@luz.llnl.gov>
+Joe Hennis <hennis1@llnl.gov>                   hennis1 <73615573+hennis1@users.noreply.github.com>
+Josh Essman <essman1@llnl.gov>                  Josh Essman <68349992+joshessman-llnl@users.noreply.github.com>
 Kenneth Weiss <weiss27@llnl.gov>                Kenneth Weiss <kweiss@llnl.gov>
 Kenneth Weiss <weiss27@llnl.gov>                Kenny Weiss <kennyweiss@users.noreply.github.com>
 Kenneth Weiss <weiss27@llnl.gov>                Kenny Weiss <kenny@kennyweiss.com>

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@8.0.1_nvcc_xlf.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@8.0.1_nvcc_xlf.cmake
@@ -1,0 +1,123 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# SYS_TYPE: blueos_3_ppc64le_ib_p9
+# Compiler Spec: clang@8.0.1_nvcc_xlf
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-8.0.1/bin/clang" CACHE PATH "")
+
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-8.0.1/bin/clang++" CACHE PATH "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_01_06_17_58_22/clang-8.0.1_nvcc_xlf" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+# SCR not built
+
+set(RAJA_DIR "${TPL_ROOT}/raja-0.12.1" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-4.0.1" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-8.0.1/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-8.0.1/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-8.0.1/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-8.0.1/bin/mpirun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
+
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# Root directory for generated developer tools
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/2020_08_21_21_29_26/gcc-8.3.1" CACHE PATH "")
+
+set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
+
+set(ENABLE_DOCS ON CACHE BOOL "")
+
+set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.14/bin/doxygen" CACHE PATH "")
+
+set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/sphinx-build" CACHE PATH "")
+
+set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/shroud" CACHE PATH "")
+
+set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
+
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_OPENMP OFF CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
+
+set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE STRING "Converts C-style comments to Fortran style in preprocessed files")
+
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Cuda
+#------------------------------------------------------------------------------
+
+set(ENABLE_CUDA ON CACHE BOOL "")
+
+set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-10.1.243" CACHE PATH "")
+
+set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc" CACHE PATH "")
+
+set(CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "")
+
+set(AXOM_ENABLE_ANNOTATIONS ON CACHE BOOL "")
+
+set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
+
+set(CMAKE_CUDA_FLAGS "-restrict --expt-extended-lambda -arch sm_${CMAKE_CUDA_ARCHITECTURES} -std=c++11 " CACHE STRING "")
+
+set(CMAKE_CUDA_HOST_COMPILER "${MPI_CXX_COMPILER}" CACHE PATH "")
+
+# nvcc does not like gtest's 'pthreads' flag
+set(gtest_disable_pthreads ON CACHE BOOL "")
+
+

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@9.0.0_upstream_xlf.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@9.0.0_upstream_xlf.cmake
@@ -1,0 +1,100 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# SYS_TYPE: blueos_3_ppc64le_ib_p9
+# Compiler Spec: clang@9.0.0_upstream_xlf
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-upstream-2019.08.15/bin/clang" CACHE PATH "")
+
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-upstream-2019.08.15/bin/clang++" CACHE PATH "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_01_06_17_58_22/clang-9.0.0_upstream_xlf" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+# SCR not built
+
+set(RAJA_DIR "${TPL_ROOT}/raja-0.12.1" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-4.0.1" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-upstream-2019.08.15/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-upstream-2019.08.15/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-upstream-2019.08.15/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-upstream-2019.08.15/bin/mpirun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
+
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# Root directory for generated developer tools
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/2020_08_21_21_29_26/gcc-8.3.1" CACHE PATH "")
+
+set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
+
+set(ENABLE_DOCS ON CACHE BOOL "")
+
+set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.14/bin/doxygen" CACHE PATH "")
+
+set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/sphinx-build" CACHE PATH "")
+
+set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/shroud" CACHE PATH "")
+
+set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
+
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_OPENMP OFF CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
+
+set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE STRING "Converts C-style comments to Fortran style in preprocessed files")
+
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
+
+

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-gcc@7.3.1.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-gcc@7.3.1.cmake
@@ -1,0 +1,92 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# SYS_TYPE: blueos_3_ppc64le_ib_p9
+# Compiler Spec: gcc@7.3.1
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-7.3.1/bin/gcc" CACHE PATH "")
+
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-7.3.1/bin/g++" CACHE PATH "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-7.3.1/bin/gfortran" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_01_06_17_58_22/gcc-7.3.1" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+# SCR not built
+
+set(RAJA_DIR "${TPL_ROOT}/raja-0.12.1" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-4.0.1" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-7.3.1/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-7.3.1/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-7.3.1/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-7.3.1/bin/mpirun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
+
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# Root directory for generated developer tools
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/2020_08_21_21_29_26/gcc-8.3.1" CACHE PATH "")
+
+set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
+
+set(ENABLE_DOCS ON CACHE BOOL "")
+
+set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.14/bin/doxygen" CACHE PATH "")
+
+set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/sphinx-build" CACHE PATH "")
+
+set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/shroud" CACHE PATH "")
+
+set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
+
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
+
+

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1_coral.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1_coral.cmake
@@ -1,0 +1,104 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# SYS_TYPE: blueos_3_ppc64le_ib_p9
+# Compiler Spec: xl@16.1.1_coral
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+set(CMAKE_C_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlc" CACHE PATH "")
+
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlC" CACHE PATH "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_01_06_17_58_22/xl-16.1.1_coral" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+# SCR not built
+
+set(RAJA_DIR "${TPL_ROOT}/raja-0.12.1" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-4.0.1" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/bin/mpixlc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/bin/mpixlC" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/bin/mpixlf" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/bin/mpirun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
+
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# Root directory for generated developer tools
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/2020_08_21_21_29_26/gcc-8.3.1" CACHE PATH "")
+
+set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
+
+set(ENABLE_DOCS ON CACHE BOOL "")
+
+set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.14/bin/doxygen" CACHE PATH "")
+
+set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/sphinx-build" CACHE PATH "")
+
+set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/shroud" CACHE PATH "")
+
+set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
+
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_OPENMP OFF CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
+
+set(CMAKE_C_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
+
+set(CMAKE_CXX_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
+
+set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE STRING "Converts C-style comments to Fortran style in preprocessed files")
+
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
+
+

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1_nvcc.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1_nvcc.cmake
@@ -1,0 +1,127 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# SYS_TYPE: blueos_3_ppc64le_ib_p9
+# Compiler Spec: xl@16.1.1_nvcc
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+set(CMAKE_C_COMPILER "/usr/tce/packages/xl/xl-2019.08.20/bin/xlc" CACHE PATH "")
+
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/xl/xl-2019.08.20/bin/xlC" CACHE PATH "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.08.20/bin/xlf2003" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_01_06_17_58_22/xl-16.1.1_nvcc" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+# SCR not built
+
+set(RAJA_DIR "${TPL_ROOT}/raja-0.12.1" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-4.0.1" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/bin/mpixlc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/bin/mpixlC" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/bin/mpixlf" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/bin/mpirun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
+
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# Root directory for generated developer tools
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/2020_08_21_21_29_26/gcc-8.3.1" CACHE PATH "")
+
+set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
+
+set(ENABLE_DOCS ON CACHE BOOL "")
+
+set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.14/bin/doxygen" CACHE PATH "")
+
+set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/sphinx-build" CACHE PATH "")
+
+set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/shroud" CACHE PATH "")
+
+set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
+
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_OPENMP OFF CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
+
+set(CMAKE_C_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
+
+set(CMAKE_CXX_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
+
+set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE STRING "Converts C-style comments to Fortran style in preprocessed files")
+
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Cuda
+#------------------------------------------------------------------------------
+
+set(ENABLE_CUDA ON CACHE BOOL "")
+
+set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-10.1.243" CACHE PATH "")
+
+set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc" CACHE PATH "")
+
+set(CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "")
+
+set(AXOM_ENABLE_ANNOTATIONS ON CACHE BOOL "")
+
+set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
+
+set(CMAKE_CUDA_FLAGS "-restrict --expt-extended-lambda -arch sm_${CMAKE_CUDA_ARCHITECTURES} -std=c++11 " CACHE STRING "")
+
+set(CMAKE_CUDA_HOST_COMPILER "${MPI_CXX_COMPILER}" CACHE PATH "")
+
+# nvcc does not like gtest's 'pthreads' flag
+set(gtest_disable_pthreads ON CACHE BOOL "")
+
+

--- a/host-configs/quartz-toss_3_x86_64_ib-clang@10.0.0.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-clang@10.0.0.cmake
@@ -1,0 +1,94 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# SYS_TYPE: toss_3_x86_64_ib
+# Compiler Spec: clang@10.0.0
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-10.0.0/bin/clang" CACHE PATH "")
+
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-10.0.0/bin/clang++" CACHE PATH "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran" CACHE PATH "")
+
+set(CMAKE_C_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0" CACHE STRING "")
+
+set(CMAKE_CXX_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0" CACHE STRING "")
+
+set(BLT_EXE_LINKER_FLAGS " -Wl,-rpath,/usr/tce/packages/clang/clang-10.0.0/lib" CACHE STRING "Adds a missing libstdc++ rpath")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_01_06_18_15_52/clang-10.0.0" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+# SCR not built
+
+set(RAJA_DIR "${TPL_ROOT}/raja-0.12.1" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-4.0.1" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-clang-10.0.0/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-clang-10.0.0/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-clang-10.0.0/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# Root directory for generated developer tools
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/2020_08_21_22_18_57/gcc-8.1.0" CACHE PATH "")
+
+set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
+
+set(ENABLE_DOCS ON CACHE BOOL "")
+
+set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.14/bin/doxygen" CACHE PATH "")
+
+set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/sphinx-build" CACHE PATH "")
+
+set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/shroud" CACHE PATH "")
+
+set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
+
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+

--- a/host-configs/quartz-toss_3_x86_64_ib-clang@9.0.0.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-clang@9.0.0.cmake
@@ -1,0 +1,94 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# SYS_TYPE: toss_3_x86_64_ib
+# Compiler Spec: clang@9.0.0
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-9.0.0/bin/clang" CACHE PATH "")
+
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-9.0.0/bin/clang++" CACHE PATH "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran" CACHE PATH "")
+
+set(CMAKE_C_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0" CACHE STRING "")
+
+set(CMAKE_CXX_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0" CACHE STRING "")
+
+set(BLT_EXE_LINKER_FLAGS " -Wl,-rpath,/usr/tce/packages/clang/clang-9.0.0/lib" CACHE STRING "Adds a missing libstdc++ rpath")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_01_06_18_15_52/clang-9.0.0" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+# SCR not built
+
+set(RAJA_DIR "${TPL_ROOT}/raja-0.12.1" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-4.0.1" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-clang-9.0.0/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-clang-9.0.0/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-clang-9.0.0/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# Root directory for generated developer tools
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/2020_08_21_22_18_57/gcc-8.1.0" CACHE PATH "")
+
+set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
+
+set(ENABLE_DOCS ON CACHE BOOL "")
+
+set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.14/bin/doxygen" CACHE PATH "")
+
+set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/sphinx-build" CACHE PATH "")
+
+set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/shroud" CACHE PATH "")
+
+set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
+
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+

--- a/host-configs/quartz-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -1,0 +1,88 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# SYS_TYPE: toss_3_x86_64_ib
+# Compiler Spec: gcc@8.1.0
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc" CACHE PATH "")
+
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/g++" CACHE PATH "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_01_06_18_15_52/gcc-8.1.0" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+# SCR not built
+
+set(RAJA_DIR "${TPL_ROOT}/raja-0.12.1" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-4.0.1" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# Root directory for generated developer tools
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/2020_08_21_22_18_57/gcc-8.1.0" CACHE PATH "")
+
+set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
+
+set(ENABLE_DOCS ON CACHE BOOL "")
+
+set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.14/bin/doxygen" CACHE PATH "")
+
+set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/sphinx-build" CACHE PATH "")
+
+set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/shroud" CACHE PATH "")
+
+set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
+
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+

--- a/host-configs/quartz-toss_3_x86_64_ib-gcc@8.1_no_fortran.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-gcc@8.1_no_fortran.cmake
@@ -1,0 +1,84 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# SYS_TYPE: toss_3_x86_64_ib
+# Compiler Spec: gcc@8.1_no_fortran
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc" CACHE PATH "")
+
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/g++" CACHE PATH "")
+
+set(ENABLE_FORTRAN OFF CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_01_06_18_15_52/gcc-8.1_no_fortran" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+# SCR not built
+
+set(RAJA_DIR "${TPL_ROOT}/raja-0.12.1" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-4.0.1" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0/bin/mpicxx" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# Root directory for generated developer tools
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/2020_08_21_22_18_57/gcc-8.1.0" CACHE PATH "")
+
+set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
+
+set(ENABLE_DOCS ON CACHE BOOL "")
+
+set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.14/bin/doxygen" CACHE PATH "")
+
+set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/sphinx-build" CACHE PATH "")
+
+set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/shroud" CACHE PATH "")
+
+set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
+
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+

--- a/host-configs/quartz-toss_3_x86_64_ib-intel@18.0.2.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-intel@18.0.2.cmake
@@ -1,0 +1,88 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# SYS_TYPE: toss_3_x86_64_ib
+# Compiler Spec: intel@18.0.2
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+set(CMAKE_C_COMPILER "/usr/tce/packages/intel/intel-18.0.2/bin/icc" CACHE PATH "")
+
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/intel/intel-18.0.2/bin/icpc" CACHE PATH "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-18.0.2/bin/ifort" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_01_06_18_15_52/intel-18.0.2" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+# SCR not built
+
+set(RAJA_DIR "${TPL_ROOT}/raja-0.12.1" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-4.0.1" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.2/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.2/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.2/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# Root directory for generated developer tools
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/2020_08_21_22_18_57/gcc-8.1.0" CACHE PATH "")
+
+set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
+
+set(ENABLE_DOCS ON CACHE BOOL "")
+
+set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.14/bin/doxygen" CACHE PATH "")
+
+set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/sphinx-build" CACHE PATH "")
+
+set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/shroud" CACHE PATH "")
+
+set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
+
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+

--- a/host-configs/quartz-toss_3_x86_64_ib-intel@19.0.4.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-intel@19.0.4.cmake
@@ -1,0 +1,94 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# SYS_TYPE: toss_3_x86_64_ib
+# Compiler Spec: intel@19.0.4
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+
+set(CMAKE_C_COMPILER "/usr/tce/packages/intel/intel-19.0.4/bin/icc" CACHE PATH "")
+
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/intel/intel-19.0.4/bin/icpc" CACHE PATH "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-19.0.4/bin/ifort" CACHE PATH "")
+
+set(CMAKE_C_FLAGS "-gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc" CACHE STRING "")
+
+set(CMAKE_CXX_FLAGS "-gxx-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/g++" CACHE STRING "")
+
+set(CMAKE_Fortran_FLAGS "-gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_01_06_18_15_52/intel-19.0.4" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+# SCR not built
+
+set(RAJA_DIR "${TPL_ROOT}/raja-0.12.1" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-4.0.1" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_C_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.0/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.0/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.0/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# Root directory for generated developer tools
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_3_x86_64_ib/2020_08_21_22_18_57/gcc-8.1.0" CACHE PATH "")
+
+set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/python3.7" CACHE PATH "")
+
+set(ENABLE_DOCS ON CACHE BOOL "")
+
+set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.14/bin/doxygen" CACHE PATH "")
+
+set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/sphinx-build" CACHE PATH "")
+
+set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.7/bin/shroud" CACHE PATH "")
+
+set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
+
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Other machine specifics
+#------------------------------------------------------------------------------
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@8.0.1_nvcc_xlf.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@8.0.1_nvcc_xlf.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_12_15_15_14_19/clang-8.0.1_nvcc_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_01_06_14_06_47/clang-8.0.1_nvcc_xlf" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -54,9 +54,9 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-re
 
 set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-8.0.1/bin/mpirun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-np" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
 
-set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools
@@ -87,13 +87,15 @@ set(ENABLE_OPENMP OFF CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")
 
-set(CMAKE_Fortran_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_Fortran_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
+set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE STRING "Converts C-style comments to Fortran style in preprocessed files")
 
-set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
 
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Cuda
@@ -109,9 +111,9 @@ set(CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "")
 
 set(AXOM_ENABLE_ANNOTATIONS ON CACHE BOOL "")
 
-set(AXOM_CUDA_ARCH "sm_70" CACHE PATH "")
+set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
 
-set(CMAKE_CUDA_FLAGS "-restrict -arch ${AXOM_CUDA_ARCH} -std=c++11 --expt-extended-lambda -G " CACHE PATH "")
+set(CMAKE_CUDA_FLAGS "-restrict --expt-extended-lambda -arch sm_${CMAKE_CUDA_ARCHITECTURES} -std=c++11 " CACHE STRING "")
 
 set(CMAKE_CUDA_HOST_COMPILER "${MPI_CXX_COMPILER}" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@9.0.0_upstream_xlf.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@9.0.0_upstream_xlf.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_12_15_15_14_19/clang-9.0.0_upstream_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_01_06_14_06_47/clang-9.0.0_upstream_xlf" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -54,9 +54,9 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-re
 
 set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-upstream-2019.08.15/bin/mpirun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-np" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
 
-set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools
@@ -87,12 +87,14 @@ set(ENABLE_OPENMP OFF CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
-set(CMAKE_Fortran_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_Fortran_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
+set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE STRING "Converts C-style comments to Fortran style in preprocessed files")
 
-set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
 
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
 
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@7.3.1.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@7.3.1.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-7.3.1/bin/gfortran" CACHE 
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_12_15_15_14_19/gcc-7.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_01_06_14_06_47/gcc-7.3.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -54,9 +54,9 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-re
 
 set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-7.3.1/bin/mpirun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-np" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
 
-set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools
@@ -86,5 +86,7 @@ set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-forma
 set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
 
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1_coral.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1_coral.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_12_15_15_14_19/xl-16.1.1_coral" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_01_06_14_06_47/xl-16.1.1_coral" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -54,9 +54,9 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-re
 
 set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/bin/mpirun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-np" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
 
-set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools
@@ -87,16 +87,18 @@ set(ENABLE_OPENMP OFF CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
-set(CMAKE_Fortran_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_Fortran_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(CMAKE_C_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_C_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(CMAKE_CXX_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_CXX_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
+set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE STRING "Converts C-style comments to Fortran style in preprocessed files")
 
-set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
 
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
 
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1_nvcc.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1_nvcc.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.08.20/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2020_12_15_15_14_19/xl-16.1.1_nvcc" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_01_06_14_06_47/xl-16.1.1_nvcc" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -54,9 +54,9 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-re
 
 set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/bin/mpirun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-np" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
 
-set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools
@@ -87,17 +87,19 @@ set(ENABLE_OPENMP OFF CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")
 
-set(CMAKE_Fortran_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_Fortran_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(CMAKE_C_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_C_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(CMAKE_CXX_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_CXX_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
+set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE STRING "Converts C-style comments to Fortran style in preprocessed files")
 
-set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
 
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Cuda
@@ -113,9 +115,9 @@ set(CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "")
 
 set(AXOM_ENABLE_ANNOTATIONS ON CACHE BOOL "")
 
-set(AXOM_CUDA_ARCH "sm_70" CACHE PATH "")
+set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
 
-set(CMAKE_CUDA_FLAGS "-restrict -arch ${AXOM_CUDA_ARCH} -std=c++11 --expt-extended-lambda -G " CACHE PATH "")
+set(CMAKE_CUDA_FLAGS "-restrict --expt-extended-lambda -arch sm_${CMAKE_CUDA_ARCHITECTURES} -std=c++11 " CACHE STRING "")
 
 set(CMAKE_CUDA_HOST_COMPILER "${MPI_CXX_COMPILER}" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@10.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@10.0.0.cmake
@@ -19,18 +19,18 @@ set(ENABLE_FORTRAN ON CACHE BOOL "")
 
 set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran" CACHE PATH "")
 
-set(CMAKE_C_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0" CACHE PATH "")
+set(CMAKE_C_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0" CACHE STRING "")
 
-set(CMAKE_CXX_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0" CACHE PATH "")
+set(CMAKE_CXX_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0" CACHE STRING "")
 
-set(BLT_EXE_LINKER_FLAGS " -Wl,-rpath,/usr/tce/packages/clang/clang-10.0.0/lib" CACHE PATH "Adds a missing libstdc++ rpath")
+set(BLT_EXE_LINKER_FLAGS " -Wl,-rpath,/usr/tce/packages/clang/clang-10.0.0/lib" CACHE STRING "Adds a missing libstdc++ rpath")
 
 #------------------------------------------------------------------------------
 # TPLs
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_12_17_09_27_38/clang-10.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_01_06_14_12_59/clang-10.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -60,7 +60,7 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-clang-10.0.0/b
 
 set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@9.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@9.0.0.cmake
@@ -19,18 +19,18 @@ set(ENABLE_FORTRAN ON CACHE BOOL "")
 
 set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran" CACHE PATH "")
 
-set(CMAKE_C_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0" CACHE PATH "")
+set(CMAKE_C_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0" CACHE STRING "")
 
-set(CMAKE_CXX_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0" CACHE PATH "")
+set(CMAKE_CXX_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0" CACHE STRING "")
 
-set(BLT_EXE_LINKER_FLAGS " -Wl,-rpath,/usr/tce/packages/clang/clang-9.0.0/lib" CACHE PATH "Adds a missing libstdc++ rpath")
+set(BLT_EXE_LINKER_FLAGS " -Wl,-rpath,/usr/tce/packages/clang/clang-9.0.0/lib" CACHE STRING "Adds a missing libstdc++ rpath")
 
 #------------------------------------------------------------------------------
 # TPLs
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_12_17_09_27_38/clang-9.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_01_06_14_12_59/clang-9.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -60,7 +60,7 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-clang-9.0.0/bi
 
 set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-8.1.0/bin/gfortran" CACHE 
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_12_17_09_27_38/gcc-8.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_01_06_14_12_59/gcc-8.1.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -54,7 +54,7 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0/bin/
 
 set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1_no_fortran.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1_no_fortran.cmake
@@ -22,7 +22,7 @@ set(ENABLE_FORTRAN OFF CACHE BOOL "")
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_12_17_09_27_38/gcc-8.1_no_fortran" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_01_06_14_12_59/gcc-8.1_no_fortran" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -50,7 +50,7 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0/bin/mpic
 
 set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@18.0.2.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@18.0.2.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-18.0.2/bin/ifort" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_12_17_09_27_38/intel-18.0.2" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_01_06_14_12_59/intel-18.0.2" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -54,7 +54,7 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-intel-18.0.2/b
 
 set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.4.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.4.cmake
@@ -19,18 +19,18 @@ set(ENABLE_FORTRAN ON CACHE BOOL "")
 
 set(CMAKE_Fortran_COMPILER "/usr/tce/packages/intel/intel-19.0.4/bin/ifort" CACHE PATH "")
 
-set(CMAKE_C_FLAGS "-gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc" CACHE PATH "")
+set(CMAKE_C_FLAGS "-gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc" CACHE STRING "")
 
-set(CMAKE_CXX_FLAGS "-gxx-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/g++" CACHE PATH "")
+set(CMAKE_CXX_FLAGS "-gxx-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/g++" CACHE STRING "")
 
-set(CMAKE_Fortran_FLAGS "-gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc" CACHE PATH "")
+set(CMAKE_Fortran_FLAGS "-gcc-name=/usr/tce/packages/gcc/gcc-8.1.0/bin/gcc" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # TPLs
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2020_12_17_09_27_38/intel-19.0.4" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_01_06_14_12_59/intel-19.0.4" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -60,7 +60,7 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.0/b
 
 set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@8.0.1_nvcc_xlf.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@8.0.1_nvcc_xlf.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_12_15_16_23_32/clang-8.0.1_nvcc_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_01_06_14_16_51/clang-8.0.1_nvcc_xlf" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -54,9 +54,9 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-re
 
 set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-8.0.1/bin/mpirun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-np" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
 
-set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools
@@ -87,13 +87,15 @@ set(ENABLE_OPENMP OFF CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")
 
-set(CMAKE_Fortran_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_Fortran_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
+set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE STRING "Converts C-style comments to Fortran style in preprocessed files")
 
-set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
 
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Cuda
@@ -109,9 +111,9 @@ set(CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "")
 
 set(AXOM_ENABLE_ANNOTATIONS ON CACHE BOOL "")
 
-set(AXOM_CUDA_ARCH "sm_60" CACHE PATH "")
+set(CMAKE_CUDA_ARCHITECTURES "60" CACHE STRING "")
 
-set(CMAKE_CUDA_FLAGS "-restrict -arch ${AXOM_CUDA_ARCH} -std=c++11 --expt-extended-lambda -G " CACHE PATH "")
+set(CMAKE_CUDA_FLAGS "-restrict --expt-extended-lambda -arch sm_${CMAKE_CUDA_ARCHITECTURES} -std=c++11 " CACHE STRING "")
 
 set(CMAKE_CUDA_HOST_COMPILER "${MPI_CXX_COMPILER}" CACHE PATH "")
 

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@9.0.0_upstream_xlf.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@9.0.0_upstream_xlf.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_12_15_16_23_32/clang-9.0.0_upstream_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_01_06_14_16_51/clang-9.0.0_upstream_xlf" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -54,9 +54,9 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-re
 
 set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-upstream-2019.08.15/bin/mpirun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-np" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
 
-set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools
@@ -87,12 +87,14 @@ set(ENABLE_OPENMP OFF CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
-set(CMAKE_Fortran_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_Fortran_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
+set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE STRING "Converts C-style comments to Fortran style in preprocessed files")
 
-set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
 
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
 
 

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-gcc@7.3.1.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-gcc@7.3.1.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-7.3.1/bin/gfortran" CACHE 
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_12_15_16_23_32/gcc-7.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_01_06_14_16_51/gcc-7.3.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -54,9 +54,9 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-re
 
 set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-7.3.1/bin/mpirun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-np" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
 
-set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools
@@ -86,5 +86,7 @@ set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-forma
 set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
 
 

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-xl@16.1.1_coral.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-xl@16.1.1_coral.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_12_15_16_23_32/xl-16.1.1_coral" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_01_06_14_16_51/xl-16.1.1_coral" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -54,9 +54,9 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-re
 
 set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/bin/mpirun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-np" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
 
-set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools
@@ -87,16 +87,18 @@ set(ENABLE_OPENMP OFF CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
-set(CMAKE_Fortran_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_Fortran_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(CMAKE_C_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_C_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(CMAKE_CXX_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_CXX_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
+set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE STRING "Converts C-style comments to Fortran style in preprocessed files")
 
-set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
 
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.12.23/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
 
 

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-xl@16.1.1_nvcc.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-xl@16.1.1_nvcc.cmake
@@ -24,7 +24,7 @@ set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.08.20/bin/xlf2003" CACH
 #------------------------------------------------------------------------------
 
 # Root directory for generated TPLs
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2020_12_15_16_23_32/xl-16.1.1_nvcc" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_01_06_14_16_51/xl-16.1.1_nvcc" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.6.0" CACHE PATH "")
 
@@ -54,9 +54,9 @@ set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-re
 
 set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2019.08.20/bin/mpirun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-np" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
 
-set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Devtools
@@ -87,17 +87,19 @@ set(ENABLE_OPENMP OFF CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")
 
-set(CMAKE_Fortran_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_Fortran_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(CMAKE_C_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_C_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(CMAKE_CXX_COMPILER_ID "XL" CACHE PATH "Override to proper compiler family for XL")
+set(CMAKE_CXX_COMPILER_ID "XL" CACHE STRING "Override to proper compiler family for XL")
 
-set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE PATH "Converts C-style comments to Fortran style in preprocessed files")
+set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE STRING "Converts C-style comments to Fortran style in preprocessed files")
 
-set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(BLT_EXE_LINKER_FLAGS "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
 
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE PATH "Adds a missing rpath for libraries associated with the fortran compiler")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2019.08.20/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Cuda
@@ -113,9 +115,9 @@ set(CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "")
 
 set(AXOM_ENABLE_ANNOTATIONS ON CACHE BOOL "")
 
-set(AXOM_CUDA_ARCH "sm_60" CACHE PATH "")
+set(CMAKE_CUDA_ARCHITECTURES "60" CACHE STRING "")
 
-set(CMAKE_CUDA_FLAGS "-restrict -arch ${AXOM_CUDA_ARCH} -std=c++11 --expt-extended-lambda -G " CACHE PATH "")
+set(CMAKE_CUDA_FLAGS "-restrict --expt-extended-lambda -arch sm_${CMAKE_CUDA_ARCHITECTURES} -std=c++11 " CACHE STRING "")
 
 set(CMAKE_CUDA_HOST_COMPILER "${MPI_CXX_COMPILER}" CACHE PATH "")
 

--- a/scripts/uberenv/packages/axom/package.py
+++ b/scripts/uberenv/packages/axom/package.py
@@ -12,9 +12,15 @@ from os.path import join as pjoin
 import llnl.util.tty as tty
 
 
-def cmake_cache_entry(name, value, comment=""):
-    """Generate a string for a cmake cache variable"""
+def cmake_cache_path(name, value, comment=""):
+    """Generate a string for a cmake cache string variable"""
     return 'set({0} "{1}" CACHE PATH "{2}")\n\n'.format(name, value, comment)
+
+
+def cmake_cache_string(name, string, comment=""):
+    """Generate a string for a cmake cache path variable"""
+
+    return 'set({0} "{1}" CACHE STRING "{2}")\n\n'.format(name, string, comment)
 
 
 def cmake_cache_option(name, boolean_value, comment=""):
@@ -209,12 +215,12 @@ class Axom(CMakePackage, CudaPackage):
         cfg.write("# Compilers\n")
         cfg.write("#------------------{0}\n\n".format("-" * 60))
 
-        cfg.write(cmake_cache_entry("CMAKE_C_COMPILER", c_compiler))
-        cfg.write(cmake_cache_entry("CMAKE_CXX_COMPILER", cpp_compiler))
+        cfg.write(cmake_cache_path("CMAKE_C_COMPILER", c_compiler))
+        cfg.write(cmake_cache_path("CMAKE_CXX_COMPILER", cpp_compiler))
 
         if "+fortran" in spec or f_compiler is not None:
             cfg.write(cmake_cache_option("ENABLE_FORTRAN", True))
-            cfg.write(cmake_cache_entry("CMAKE_Fortran_COMPILER", f_compiler))
+            cfg.write(cmake_cache_path("CMAKE_Fortran_COMPILER", f_compiler))
         else:
             cfg.write(cmake_cache_option("ENABLE_FORTRAN", False))
 
@@ -225,13 +231,13 @@ class Axom(CMakePackage, CudaPackage):
             cppflags += ' '
         cflags = cppflags + ' '.join(spec.compiler_flags['cflags'])
         if cflags:
-            cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))
+            cfg.write(cmake_cache_string("CMAKE_C_FLAGS", cflags))
         cxxflags = cppflags + ' '.join(spec.compiler_flags['cxxflags'])
         if cxxflags:
-            cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS", cxxflags))
+            cfg.write(cmake_cache_string("CMAKE_CXX_FLAGS", cxxflags))
         fflags = ' '.join(spec.compiler_flags['fflags'])
         if fflags:
-            cfg.write(cmake_cache_entry("CMAKE_Fortran_FLAGS", fflags))
+            cfg.write(cmake_cache_string("CMAKE_Fortran_FLAGS", fflags))
 
         if ((f_compiler is not None)
            and ("gfortran" in f_compiler)
@@ -244,11 +250,11 @@ class Axom(CMakePackage, CudaPackage):
                     flags += " -Wl,-rpath,{0}".format(_libpath)
             description = ("Adds a missing libstdc++ rpath")
             if flags:
-                cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS", flags,
-                                            description))
+                cfg.write(cmake_cache_string("BLT_EXE_LINKER_FLAGS", flags,
+                                             description))
 
         if "+cpp14" in spec:
-            cfg.write(cmake_cache_entry("BLT_CXX_STD", "c++14", ""))
+            cfg.write(cmake_cache_string("BLT_CXX_STD", "c++14", ""))
 
         # TPL locations
         cfg.write("#------------------{0}\n".format("-" * 60))
@@ -265,46 +271,46 @@ class Axom(CMakePackage, CudaPackage):
             tpl_root = os.path.realpath(pjoin(prefix_paths[0], compiler_str))
             path_replacements[tpl_root] = "${TPL_ROOT}"
             cfg.write("# Root directory for generated TPLs\n")
-            cfg.write(cmake_cache_entry("TPL_ROOT", tpl_root))
+            cfg.write(cmake_cache_path("TPL_ROOT", tpl_root))
 
         conduit_dir = get_spec_path(spec, "conduit", path_replacements)
-        cfg.write(cmake_cache_entry("CONDUIT_DIR", conduit_dir))
+        cfg.write(cmake_cache_path("CONDUIT_DIR", conduit_dir))
 
         # optional tpls
 
         if "+mfem" in spec:
             mfem_dir = get_spec_path(spec, "mfem", path_replacements)
-            cfg.write(cmake_cache_entry("MFEM_DIR", mfem_dir))
+            cfg.write(cmake_cache_path("MFEM_DIR", mfem_dir))
         else:
             cfg.write("# MFEM not built\n\n")
 
         if "+hdf5" in spec:
             hdf5_dir = get_spec_path(spec, "hdf5", path_replacements)
-            cfg.write(cmake_cache_entry("HDF5_DIR", hdf5_dir))
+            cfg.write(cmake_cache_path("HDF5_DIR", hdf5_dir))
         else:
             cfg.write("# HDF5 not built\n\n")
 
         if "+lua" in spec:
             lua_dir = get_spec_path(spec, "lua", path_replacements)
-            cfg.write(cmake_cache_entry("LUA_DIR", lua_dir))
+            cfg.write(cmake_cache_path("LUA_DIR", lua_dir))
         else:
             cfg.write("# Lua not built\n\n")
 
         if "+scr" in spec:
             scr_dir = get_spec_path(spec, "scr", path_replacements)
-            cfg.write(cmake_cache_entry("SCR_DIR", scr_dir))
+            cfg.write(cmake_cache_path("SCR_DIR", scr_dir))
         else:
             cfg.write("# SCR not built\n\n")
 
         if "+raja" in spec:
             raja_dir = get_spec_path(spec, "raja", path_replacements)
-            cfg.write(cmake_cache_entry("RAJA_DIR", raja_dir))
+            cfg.write(cmake_cache_path("RAJA_DIR", raja_dir))
         else:
             cfg.write("# RAJA not built\n\n")
 
         if "+umpire" in spec:
             umpire_dir = get_spec_path(spec, "umpire", path_replacements)
-            cfg.write(cmake_cache_entry("UMPIRE_DIR", umpire_dir))
+            cfg.write(cmake_cache_path("UMPIRE_DIR", umpire_dir))
         else:
             cfg.write("# Umpire not built\n\n")
 
@@ -314,12 +320,12 @@ class Axom(CMakePackage, CudaPackage):
 
         if "+mpi" in spec:
             cfg.write(cmake_cache_option("ENABLE_MPI", True))
-            cfg.write(cmake_cache_entry("MPI_C_COMPILER", spec['mpi'].mpicc))
-            cfg.write(cmake_cache_entry("MPI_CXX_COMPILER",
-                                        spec['mpi'].mpicxx))
+            cfg.write(cmake_cache_path("MPI_C_COMPILER", spec['mpi'].mpicc))
+            cfg.write(cmake_cache_path("MPI_CXX_COMPILER",
+                                       spec['mpi'].mpicxx))
             if "+fortran" in spec or f_compiler is not None:
-                cfg.write(cmake_cache_entry("MPI_Fortran_COMPILER",
-                                            spec['mpi'].mpifc))
+                cfg.write(cmake_cache_path("MPI_Fortran_COMPILER",
+                                           spec['mpi'].mpifc))
 
             # Check for slurm
             using_slurm = False
@@ -348,19 +354,19 @@ class Axom(CMakePackage, CudaPackage):
                 # starting with cmake 3.10, FindMPI expects MPIEXEC_EXECUTABLE
                 # vs the older versions which expect MPIEXEC
                 if self.spec["cmake"].satisfies('@3.10:'):
-                    cfg.write(cmake_cache_entry("MPIEXEC_EXECUTABLE", mpiexec))
+                    cfg.write(cmake_cache_path("MPIEXEC_EXECUTABLE", mpiexec))
                 else:
-                    cfg.write(cmake_cache_entry("MPIEXEC", mpiexec))
+                    cfg.write(cmake_cache_path("MPIEXEC", mpiexec))
 
             # Determine MPIEXEC_NUMPROC_FLAG
             if using_slurm:
-                cfg.write(cmake_cache_entry("MPIEXEC_NUMPROC_FLAG", "-n"))
+                cfg.write(cmake_cache_string("MPIEXEC_NUMPROC_FLAG", "-n"))
             else:
-                cfg.write(cmake_cache_entry("MPIEXEC_NUMPROC_FLAG", "-np"))
+                cfg.write(cmake_cache_string("MPIEXEC_NUMPROC_FLAG", "-np"))
 
             if spec['mpi'].name == 'spectrum-mpi':
-                cfg.write(cmake_cache_entry("BLT_MPI_COMMAND_APPEND",
-                                            "mpibind"))
+                cfg.write(cmake_cache_string("BLT_MPI_COMMAND_APPEND",
+                                             "mpibind"))
         else:
             cfg.write(cmake_cache_option("ENABLE_MPI", False))
 
@@ -380,13 +386,13 @@ class Axom(CMakePackage, CudaPackage):
             devtools_root = os.path.commonprefix([path1, path2])[:-1]
             path_replacements[devtools_root] = "${DEVTOOLS_ROOT}"
             cfg.write("# Root directory for generated developer tools\n")
-            cfg.write(cmake_cache_entry("DEVTOOLS_ROOT", devtools_root))
+            cfg.write(cmake_cache_path("DEVTOOLS_ROOT", devtools_root))
 
         if "+python" in spec or "+devtools" in spec:
             python_path = os.path.realpath(spec['python'].command.path)
             for key in path_replacements:
                 python_path = python_path.replace(key, path_replacements[key])
-            cfg.write(cmake_cache_entry("PYTHON_EXECUTABLE", python_path))
+            cfg.write(cmake_cache_path("PYTHON_EXECUTABLE", python_path))
 
         if "doxygen" in spec or "py-sphinx" in spec:
             cfg.write(cmake_cache_option("ENABLE_DOCS", True))
@@ -395,37 +401,36 @@ class Axom(CMakePackage, CudaPackage):
                 doxygen_bin_dir = get_spec_path(spec, "doxygen",
                                                 path_replacements,
                                                 use_bin=True)
-                cfg.write(cmake_cache_entry("DOXYGEN_EXECUTABLE",
-                                            pjoin(doxygen_bin_dir,
-                                                  "doxygen")))
+                cfg.write(cmake_cache_path("DOXYGEN_EXECUTABLE",
+                                           pjoin(doxygen_bin_dir, "doxygen")))
 
             if "py-sphinx" in spec:
                 python_bin_dir = get_spec_path(spec, "python",
                                                path_replacements,
                                                use_bin=True)
-                cfg.write(cmake_cache_entry("SPHINX_EXECUTABLE",
-                                            pjoin(python_bin_dir,
-                                                  "sphinx-build")))
+                cfg.write(cmake_cache_path("SPHINX_EXECUTABLE",
+                                           pjoin(python_bin_dir,
+                                                 "sphinx-build")))
         else:
             cfg.write(cmake_cache_option("ENABLE_DOCS", False))
 
         if "py-shroud" in spec:
             shroud_bin_dir = get_spec_path(spec, "py-shroud",
                                            path_replacements, use_bin=True)
-            cfg.write(cmake_cache_entry("SHROUD_EXECUTABLE",
-                                        pjoin(shroud_bin_dir, "shroud")))
+            cfg.write(cmake_cache_path("SHROUD_EXECUTABLE",
+                                       pjoin(shroud_bin_dir, "shroud")))
 
         if "cppcheck" in spec:
             cppcheck_bin_dir = get_spec_path(spec, "cppcheck",
                                              path_replacements, use_bin=True)
-            cfg.write(cmake_cache_entry("CPPCHECK_EXECUTABLE",
-                                        pjoin(cppcheck_bin_dir, "cppcheck")))
+            cfg.write(cmake_cache_path("CPPCHECK_EXECUTABLE",
+                                       pjoin(cppcheck_bin_dir, "cppcheck")))
 
         # Only turn on clangformat support if devtools is on
         if "+devtools" in spec:
             clang_fmt_path = spec['llvm'].prefix.bin.join('clang-format')
-            cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE",
-                                        clang_fmt_path))
+            cfg.write(cmake_cache_path("CLANGFORMAT_EXECUTABLE",
+                                       clang_fmt_path))
         else:
             cfg.write("# ClangFormat disabled due to disabled devtools\n")
             cfg.write(cmake_cache_option("ENABLE_CLANGFORMAT", False))
@@ -453,87 +458,89 @@ class Axom(CMakePackage, CudaPackage):
         # Override XL compiler family
         familymsg = ("Override to proper compiler family for XL")
         if (f_compiler is not None) and ("xlf" in f_compiler):
-            cfg.write(cmake_cache_entry("CMAKE_Fortran_COMPILER_ID", "XL",
-                                        familymsg))
+            cfg.write(cmake_cache_string("CMAKE_Fortran_COMPILER_ID", "XL",
+                                         familymsg))
         if "xlc" in c_compiler:
-            cfg.write(cmake_cache_entry("CMAKE_C_COMPILER_ID", "XL",
-                                        familymsg))
+            cfg.write(cmake_cache_string("CMAKE_C_COMPILER_ID", "XL",
+                                         familymsg))
         if "xlC" in cpp_compiler:
-            cfg.write(cmake_cache_entry("CMAKE_CXX_COMPILER_ID", "XL",
-                                        familymsg))
+            cfg.write(cmake_cache_string("CMAKE_CXX_COMPILER_ID", "XL",
+                                         familymsg))
 
         if spec.satisfies('target=ppc64le:'):
             if (f_compiler is not None) and ("xlf" in f_compiler):
                 description = ("Converts C-style comments to Fortran style "
                                "in preprocessed files")
-                cfg.write(cmake_cache_entry("BLT_FORTRAN_FLAGS",
-                                            "-WF,-C!  -qxlf2003=polymorphic",
-                                            description))
+                cfg.write(cmake_cache_string("BLT_FORTRAN_FLAGS",
+                                             "-WF,-C!  -qxlf2003=polymorphic",
+                                             description))
                 # Grab lib directory for the current fortran compiler
                 libdir = os.path.join(os.path.dirname(
                                       os.path.dirname(f_compiler)), "lib")
                 description = ("Adds a missing rpath for libraries "
                                "associated with the fortran compiler")
                 linker_flags = "${BLT_EXE_LINKER_FLAGS} -Wl,-rpath," + libdir
-                cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS",
+                cfg.write(cmake_cache_string("BLT_EXE_LINKER_FLAGS",
                                             linker_flags, description))
                 if "+shared" in spec:
                     linker_flags = "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath," \
                                    + libdir
-                    cfg.write(cmake_cache_entry("CMAKE_SHARED_LINKER_FLAGS",
-                                                linker_flags, description))
+                    cfg.write(cmake_cache_string("CMAKE_SHARED_LINKER_FLAGS",
+                                                 linker_flags, description))
 
-            if "+cuda" in spec:
-                cfg.write("#------------------{0}\n".format("-" * 60))
-                cfg.write("# Cuda\n")
-                cfg.write("#------------------{0}\n\n".format("-" * 60))
+            # Fix for working around CMake adding implicit link directories
+            # returned by the BlueOS compilers to link executables with
+            # non-system default stdlib
+            _gcc_prefix = "/usr/tce/packages/gcc/gcc-4.9.3/lib64"
+            if os.path.exists(_gcc_prefix):
+                _gcc_prefix2 = pjoin(_gcc_prefix,
+                    "gcc/powerpc64le-unknown-linux-gnu/4.9.3")
+                _link_dirs = "{0};{1}".format(_gcc_prefix, _gcc_prefix2)
+                cfg.write(cmake_cache_string(
+                    "BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE", _link_dirs))
 
-                cfg.write(cmake_cache_option("ENABLE_CUDA", True))
+        if "+cuda" in spec:
+            cfg.write("#------------------{0}\n".format("-" * 60))
+            cfg.write("# Cuda\n")
+            cfg.write("#------------------{0}\n\n".format("-" * 60))
 
-                cudatoolkitdir = spec['cuda'].prefix
-                cfg.write(cmake_cache_entry("CUDA_TOOLKIT_ROOT_DIR",
-                                            cudatoolkitdir))
-                cudacompiler = "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc"
-                cfg.write(cmake_cache_entry("CMAKE_CUDA_COMPILER",
-                                            cudacompiler))
+            cfg.write(cmake_cache_option("ENABLE_CUDA", True))
 
-                cfg.write(cmake_cache_option("CUDA_SEPARABLE_COMPILATION",
-                                             True))
+            cudatoolkitdir = spec['cuda'].prefix
+            cfg.write(cmake_cache_path("CUDA_TOOLKIT_ROOT_DIR", cudatoolkitdir))
+            cudacompiler = "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc"
+            cfg.write(cmake_cache_path("CMAKE_CUDA_COMPILER", cudacompiler))
 
-                cfg.write(cmake_cache_option("AXOM_ENABLE_ANNOTATIONS", True))
+            cfg.write(cmake_cache_option("CUDA_SEPARABLE_COMPILATION", True))
 
-                # CUDA_FLAGS
-                cudaflags  = "-restrict "
+            cfg.write(cmake_cache_option("AXOM_ENABLE_ANNOTATIONS", True))
 
-                if not spec.satisfies('cuda_arch=none'):
-                    cuda_arch = spec.variants['cuda_arch'].value
-                    cfg.write(cmake_cache_entry("CMAKE_CUDA_ARCHITECTURES", cuda_arch))
-                    cudaflags += '-arch sm_${CMAKE_CUDA_ARCHITECTURES} '
-                else:
-                    cfg.write("# cuda_arch could not be determined\n\n")
+            # CUDA_FLAGS
+            cudaflags  = "-restrict --expt-extended-lambda "
 
-                cudaflags += "--expt-extended-lambda -G "
-                if `cpp14` in spec:
-                    cudaflags += "-std=c++14 "
-                else:
-                    cudaflags += "-std=c++11 "
-                cfg.write(cmake_cache_entry("CMAKE_CUDA_FLAGS", cudaflags))
+            if not spec.satisfies('cuda_arch=none'):
+                cuda_arch = spec.variants['cuda_arch'].value[0]
+                cfg.write(cmake_cache_string("CMAKE_CUDA_ARCHITECTURES",
+                                             cuda_arch))
+                cudaflags += '-arch sm_${CMAKE_CUDA_ARCHITECTURES} '
+            else:
+                cfg.write("# cuda_arch could not be determined\n\n")
 
-                if "+mpi" in spec:
-                    cfg.write(cmake_cache_entry("CMAKE_CUDA_HOST_COMPILER",
-                                                "${MPI_CXX_COMPILER}"))
-                else:
-                    cfg.write(cmake_cache_entry("CMAKE_CUDA_HOST_COMPILER",
-                                                "${CMAKE_CXX_COMPILER}"))
+            if "cpp14" in spec:
+                cudaflags += "-std=c++14 "
+            else:
+                cudaflags += "-std=c++11 "
+            cfg.write(cmake_cache_string("CMAKE_CUDA_FLAGS", cudaflags))
 
-                cfg.write("# nvcc does not like gtest's 'pthreads' flag\n")
-                cfg.write(cmake_cache_option("gtest_disable_pthreads", True))
+            if "+mpi" in spec:
+                cfg.write(cmake_cache_path("CMAKE_CUDA_HOST_COMPILER",
+                                           "${MPI_CXX_COMPILER}"))
+            else:
+                cfg.write(cmake_cache_path("CMAKE_CUDA_HOST_COMPILER",
+                                           "${CMAKE_CXX_COMPILER}"))
 
-                # Very specific fix for working around CMake adding implicit link directories returned by the BlueOS
-                # compilers to link CUDA executables 
-                cfg.write(cmake_cache_string("BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE", \
-                                             "/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;"
-                                             "/usr/tce/packages/gcc/gcc-4.9.3/lib64"))
+            cfg.write("# nvcc does not like gtest's 'pthreads' flag\n")
+            cfg.write(cmake_cache_option("gtest_disable_pthreads", True))
 
         cfg.write("\n")
         cfg.close()

--- a/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/compilers.yaml
+++ b/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/compilers.yaml
@@ -64,5 +64,23 @@ compilers:
       fc:  /usr/tce/packages/xl/xl-2019.08.20/bin/xlf2003
     spec: xl@16.1.1_nvcc
     target: ppc64le
+- compiler:
+    environment:
+      # Temporary workaround: Spack issue #18156
+      set:
+        SPACK_TARGET_ARGS: ""
+    extra_rpaths: []
+    flags:
+      # Required as spack cannot recognize compiler-specific linker
+      # flags in mixed toolchains
+      ldlibs: -lgfortran
+    modules: []
+    operating_system: rhel7
+    paths:
+      cc:  /usr/tce/packages/clang/clang-ibm-10.0.1-gcc-8.3.1/bin/clang
+      cxx: /usr/tce/packages/clang/clang-ibm-10.0.1-gcc-8.3.1/bin/clang++
+      f77: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+      fc:  /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+    spec: clang@10.0.1_nvcc
+    target: ppc64le
 
- 

--- a/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/compilers.yaml
+++ b/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/compilers.yaml
@@ -64,23 +64,3 @@ compilers:
       fc:  /usr/tce/packages/xl/xl-2019.08.20/bin/xlf2003
     spec: xl@16.1.1_nvcc
     target: ppc64le
-- compiler:
-    environment:
-      # Temporary workaround: Spack issue #18156
-      set:
-        SPACK_TARGET_ARGS: ""
-    extra_rpaths: []
-    flags:
-      # Required as spack cannot recognize compiler-specific linker
-      # flags in mixed toolchains
-      ldlibs: -lgfortran
-    modules: []
-    operating_system: rhel7
-    paths:
-      cc:  /usr/tce/packages/clang/clang-ibm-10.0.1-gcc-8.3.1/bin/clang
-      cxx: /usr/tce/packages/clang/clang-ibm-10.0.1-gcc-8.3.1/bin/clang++
-      f77: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
-      fc:  /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
-    spec: clang@10.0.1_nvcc
-    target: ppc64le
-

--- a/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/packages.yaml
+++ b/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/packages.yaml
@@ -25,8 +25,10 @@ packages:
   cuda:
     buildable: false
     externals:
-    - spec: cuda@10.1.243
-      prefix: /usr/tce/packages/cuda/cuda-10.1.243
+      - spec: cuda@11.1.1
+        prefix: /usr/tce/packages/cuda/cuda-11.1.1
+      - spec: cuda@10.1.243
+        prefix: /usr/tce/packages/cuda/cuda-10.1.243
 
 # LLNL blueos mpi
   mpi:
@@ -70,11 +72,11 @@ packages:
     - spec: bzip2
       prefix: /usr
   cmake:
-    version: [3.14.5]
+    version: [3.18.0]
     buildable: false
     externals:
     - spec: cmake
-      prefix: /usr/tce/packages/cmake/cmake-3.14.5
+      prefix: /usr/tce/packages/cmake/cmake-3.18.0
   gettext:
     buildable: false
     externals:

--- a/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/packages.yaml
+++ b/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/packages.yaml
@@ -25,8 +25,6 @@ packages:
   cuda:
     buildable: false
     externals:
-      - spec: cuda@11.1.1
-        prefix: /usr/tce/packages/cuda/cuda-11.1.1
       - spec: cuda@10.1.243
         prefix: /usr/tce/packages/cuda/cuda-10.1.243
 

--- a/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/packages.yaml
+++ b/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/packages.yaml
@@ -25,8 +25,8 @@ packages:
   cuda:
     buildable: false
     externals:
-      - spec: cuda@10.1.243
-        prefix: /usr/tce/packages/cuda/cuda-10.1.243
+    - spec: cuda@10.1.243
+      prefix: /usr/tce/packages/cuda/cuda-10.1.243
 
 # LLNL blueos mpi
   mpi:
@@ -70,11 +70,11 @@ packages:
     - spec: bzip2
       prefix: /usr
   cmake:
-    version: [3.18.0]
+    version: [3.14.5]
     buildable: false
     externals:
     - spec: cmake
-      prefix: /usr/tce/packages/cmake/cmake-3.18.0
+      prefix: /usr/tce/packages/cmake/cmake-3.14.5
   gettext:
     buildable: false
     externals:

--- a/scripts/uberenv/specs.json
+++ b/scripts/uberenv/specs.json
@@ -29,8 +29,7 @@
       "xl@16.1.1_nvcc~cpp14~openmp+devtools+mfem+cuda cuda_arch=60" ],
 
     "blueos_3_ppc64le_ib_p9":
-    [ "clang@10.0.1_nvcc~openmp+devtools+mfem+cuda cuda_arch=70",
-      "clang@9.0.0_upstream_xlf~cpp14~openmp+devtools+mfem",
+    [ "clang@9.0.0_upstream_xlf~cpp14~openmp+devtools+mfem",
       "clang@8.0.1_nvcc_xlf~cpp14~openmp+devtools+mfem+cuda cuda_arch=70",
       "gcc@7.3.1~cpp14+devtools+mfem",
       "xl@16.1.1_coral~cpp14~openmp+devtools+mfem",

--- a/scripts/uberenv/specs.json
+++ b/scripts/uberenv/specs.json
@@ -29,7 +29,8 @@
       "xl@16.1.1_nvcc~cpp14~openmp+devtools+mfem+cuda cuda_arch=60" ],
 
     "blueos_3_ppc64le_ib_p9":
-    [ "clang@9.0.0_upstream_xlf~cpp14~openmp+devtools+mfem",
+    [ "clang@10.0.1_nvcc~openmp+devtools+mfem+cuda cuda_arch=70",
+      "clang@9.0.0_upstream_xlf~cpp14~openmp+devtools+mfem",
       "clang@8.0.1_nvcc_xlf~cpp14~openmp+devtools+mfem+cuda cuda_arch=70",
       "gcc@7.3.1~cpp14+devtools+mfem",
       "xl@16.1.1_coral~cpp14~openmp+devtools+mfem",

--- a/src/axom/core/execution/execution_space.hpp
+++ b/src/axom/core/execution/execution_space.hpp
@@ -95,7 +95,7 @@ struct execution_space
   #include "axom/core/execution/internal/omp_exec.hpp"
 #endif
 
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE) && defined(__CUDACC__)
   #include "axom/core/execution/internal/cuda_exec.hpp"
 #endif
 

--- a/src/axom/inlet/tests/CMakeLists.txt
+++ b/src/axom/inlet/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ foreach(test ${gtest_inlet_tests})
     blt_add_executable( NAME       ${test_name}_test
                         SOURCES    ${test}
                         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                        DEPENDS_ON inlet gtest inlet_test_utils
+                        DEPENDS_ON gtest inlet_test_utils
                         FOLDER     axom/inlet/tests )
     axom_add_test( NAME    ${test_name} 
                    COMMAND ${test_name}_test )

--- a/src/axom/quest/tests/CMakeLists.txt
+++ b/src/axom/quest/tests/CMakeLists.txt
@@ -173,10 +173,6 @@ if (ENABLE_MPI AND AXOM_ENABLE_SIDRE)
 
     endif()
 
-    if ( "$ENV{SYS_TYPE}" STREQUAL "bgqos_0" )
-       blt_add_target_link_flags( TO ${test_name} FLAGS "${AXOM_ALLOW_MULTIPLE_DEFINITIONS}" )
-    endif()
-
     # Add resolution tests for each dataset and resolution
     if(AXOM_DATA_DIR)
         set(quest_data_dir  ${AXOM_DATA_DIR}/quest)


### PR DESCRIPTION
Ran into these via serac

* Update mailmap
* Use the correct cmake cache type in host-configs
* Add BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE that will cause problems in any >C++11 build on blueos
* Move cuda logic out of blueos if block in host-config generation
* Remove old bgq logic
* Guard cuda code in header with `__CUDACC__`
* Add new CZ host configs to be used by gitlab ci