### PR TITLE
hotfix: remove make_unique from C++11-compatible tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,11 +45,11 @@ jobs:
         HOST_CONFIG: 'docker-linux-ubuntu18.04-x86_64-clang@10.0.0'
       osx_gcc:
         VM_ImageName: 'macos-10.14'
-        CMAKE_EXTRA_FLAGS: ''
+        CMAKE_EXTRA_FLAGS: '-DAXOM_ENABLE_SIDRE=Off'
         TEST_TARGET: 'osx_gcc'
       windows:
         VM_ImageName: 'windows-2019'
-        CMAKE_EXTRA_FLAGS: ''
+        CMAKE_EXTRA_FLAGS: '-DAXOM_ENABLE_SIDRE=Off'
         TEST_TARGET: 'win_vs'
 
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,13 @@ jobs:
         COMPILER: 'clang++'
         TEST_TARGET: 'linux_clang10'
         HOST_CONFIG: 'docker-linux-ubuntu18.04-x86_64-clang@10.0.0'
+      linux_clang10_cxx11:
+        VM_ImageName: 'ubuntu-18.04'
+        Compiler_ImageName: 'axom/tpls:clang-10_12-21-20_20h-48m'
+        CMAKE_EXTRA_FLAGS: '-DBLT_CXX_STD=c++11'
+        COMPILER: 'clang++'
+        TEST_TARGET: 'linux_clang10'
+        HOST_CONFIG: 'docker-linux-ubuntu18.04-x86_64-clang@10.0.0'
       osx_gcc:
         VM_ImageName: 'macos-10.14'
         CMAKE_EXTRA_FLAGS: '-DAXOM_ENABLE_SIDRE=Off'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,11 +45,11 @@ jobs:
         HOST_CONFIG: 'docker-linux-ubuntu18.04-x86_64-clang@10.0.0'
       osx_gcc:
         VM_ImageName: 'macos-10.14'
-        CMAKE_EXTRA_FLAGS: '-DAXOM_ENABLE_SIDRE=Off'
+        CMAKE_EXTRA_FLAGS: ''
         TEST_TARGET: 'osx_gcc'
       windows:
         VM_ImageName: 'windows-2019'
-        CMAKE_EXTRA_FLAGS: '-DAXOM_ENABLE_SIDRE=Off'
+        CMAKE_EXTRA_FLAGS: ''
         TEST_TARGET: 'win_vs'
 
   pool:

--- a/scripts/azure-pipelines/linux-build_and_test.sh
+++ b/scripts/azure-pipelines/linux-build_and_test.sh
@@ -26,7 +26,7 @@ echo $HOST_CONFIG
 
 if [[ "$DO_BUILD" == "yes" ]] ; then
     echo "~~~~~~ RUNNING CMAKE ~~~~~~~~"
-    or_die ./config-build.py -hc /home/axom/axom/host-configs/docker/${HOST_CONFIG}.cmake -DENABLE_GTEST_DEATH_TESTS=ON
+    or_die ./config-build.py -hc /home/axom/axom/host-configs/docker/${HOST_CONFIG}.cmake -DENABLE_GTEST_DEATH_TESTS=ON ${CMAKE_EXTRA_FLAGS}
     or_die cd build-$HOST_CONFIG-debug
     echo "~~~~~~ BUILDING ~~~~~~~~"
     if [[ ${CMAKE_EXTRA_FLAGS} == *COVERAGE* ]] ; then

--- a/src/axom/inlet/tests/inlet_Inlet.cpp
+++ b/src/axom/inlet/tests/inlet_Inlet.cpp
@@ -20,7 +20,6 @@
 using axom::inlet::Field;
 using axom::inlet::Inlet;
 using axom::inlet::InletType;
-using axom::inlet::LuaReader;
 using axom::inlet::Proxy;
 using axom::inlet::Table;
 using axom::sidre::DataStore;
@@ -30,10 +29,10 @@ Inlet createBasicInlet(DataStore* ds,
                        const std::string& luaString,
                        bool enableDocs = true)
 {
-  auto lr = std::make_unique<InletReader>();
-  lr->parseString(axom::inlet::detail::fromLuaTo<InletReader>(luaString));
+  std::unique_ptr<InletReader> reader(new InletReader());
+  reader->parseString(axom::inlet::detail::fromLuaTo<InletReader>(luaString));
 
-  return Inlet(std::move(lr), ds->getRoot(), enableDocs);
+  return Inlet(std::move(reader), ds->getRoot(), enableDocs);
 }
 
 template <typename InletReader>

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -19,7 +19,6 @@
 
 using axom::inlet::Inlet;
 using axom::inlet::InletType;
-using axom::inlet::LuaReader;
 using axom::sidre::DataStore;
 
 template <typename InletReader>
@@ -27,10 +26,10 @@ Inlet createBasicInlet(DataStore* ds,
                        const std::string& luaString,
                        bool enableDocs = true)
 {
-  auto lr = std::make_unique<InletReader>();
-  lr->parseString(axom::inlet::detail::fromLuaTo<InletReader>(luaString));
+  std::unique_ptr<InletReader> reader(new InletReader());
+  reader->parseString(axom::inlet::detail::fromLuaTo<InletReader>(luaString));
 
-  return Inlet(std::move(lr), ds->getRoot(), enableDocs);
+  return Inlet(std::move(reader), ds->getRoot(), enableDocs);
 }
 
 struct Foo


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following
  - Removes >= C++14 `std::make_unique`
  - Adds a CI job to prevent cxx11 regressions