### PR TITLE
Rename UnitTestLogger to SimpleLogger

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -38,6 +38,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Inlet: `std::shared_ptr<T>` has been replaced with `T&` in non-owning contexts
   and `std::unique_ptr<T>` in owning contexts
 - Unified core and SPIO unit tests into fewer executables to limit size of build directory
+- Renamed `axom::slic::UnitTestLogger` to `axom::slic:SimpleLogger` because it's used in
+  more than just unit tests.
 
 ### Fixed
 - Updated to new BLT version that does not fail when ClangFormat returns an empty

--- a/src/axom/core/execution/execution_space.hpp
+++ b/src/axom/core/execution/execution_space.hpp
@@ -95,7 +95,8 @@ struct execution_space
   #include "axom/core/execution/internal/omp_exec.hpp"
 #endif
 
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE) && defined(__CUDACC__)
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA) && \
+  defined(AXOM_USE_UMPIRE) && defined(__CUDACC__)
   #include "axom/core/execution/internal/cuda_exec.hpp"
 #endif
 

--- a/src/axom/inlet/examples/documentation_generation.cpp
+++ b/src/axom/inlet/examples/documentation_generation.cpp
@@ -6,7 +6,7 @@
 // usage : ./inlet_documentation_generation_example --enableDocs --fil lua_file.lua
 
 #include "axom/inlet.hpp"
-#include "axom/slic/core/UnitTestLogger.hpp"
+#include "axom/slic/core/SimpleLogger.hpp"
 
 #include "CLI11/CLI11.hpp"
 #include <iostream>
@@ -177,7 +177,7 @@ int main(int argc, char** argv)
 {
   // Inlet requires a SLIC logger to be initialized to output runtime information
   // This is a generic basic SLIC logger
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
 
   CLI::App app {"Basic example of Axom's Inlet component"};
   bool docsEnabled {false};

--- a/src/axom/inlet/examples/user_defined_type.cpp
+++ b/src/axom/inlet/examples/user_defined_type.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 #include <unordered_map>
 #include "CLI11/CLI11.hpp"
-#include "axom/slic/core/UnitTestLogger.hpp"
+#include "axom/slic/core/SimpleLogger.hpp"
 
 using axom::inlet::Inlet;
 using axom::inlet::LuaReader;
@@ -235,7 +235,7 @@ struct FromInlet<ThermalSolver>
 int main(int argc, char** argv)
 {
   // Inlet requires a SLIC logger to be initialized to output runtime information
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
 
   CLI::App app {"Example of Axom's Inlet component with user-defined types"};
   std::string inputFileName;

--- a/src/axom/inlet/examples/verification.cpp
+++ b/src/axom/inlet/examples/verification.cpp
@@ -5,13 +5,13 @@
 
 #include <iostream>
 #include "axom/inlet.hpp"
-#include "axom/slic/core/UnitTestLogger.hpp"
+#include "axom/slic/core/SimpleLogger.hpp"
 
 int main()
 {
   // Inlet requires a SLIC logger to be initialized to output runtime information
   // This is a generic basic SLIC logger
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
 
   // Initialize Inlet
   auto lr = std::make_unique<axom::inlet::LuaReader>();

--- a/src/axom/inlet/tests/inlet_Inlet.cpp
+++ b/src/axom/inlet/tests/inlet_Inlet.cpp
@@ -1628,8 +1628,8 @@ TEST(inlet_Inlet_array_lua, inletArraysInSidre)
 #endif
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -1637,7 +1637,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/inlet/tests/inlet_Reader.cpp
+++ b/src/axom/inlet/tests/inlet_Reader.cpp
@@ -345,8 +345,8 @@ TEST(inlet_Reader_lua, getDiscontiguousMap)
 #endif
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -354,7 +354,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/inlet/tests/inlet_function.cpp
+++ b/src/axom/inlet/tests/inlet_function.cpp
@@ -252,8 +252,8 @@ TEST(inlet_function, simple_vec3_to_vec3_array_of_struct)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -261,7 +261,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -684,8 +684,8 @@ TEST(inlet_object_lua_dict, array_of_struct_containing_dict)
 #endif
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -693,7 +693,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/examples/mint_nbody_solver.cpp
+++ b/src/axom/mint/examples/mint_nbody_solver.cpp
@@ -52,7 +52,7 @@ void apply_forces(mint::ParticleMesh& particles, double dt);
 int main(int argc, char** argv)
 {
   // STEP 0: initialize logger & parse arguments
-  slic::UnitTestLogger logger;
+  slic::SimpleLogger logger;
   parse_arguments(argc, argv);
 
   // STEP 1: construct particle mesh

--- a/src/axom/mint/examples/mint_unstructured_mixed_topology_mesh.cpp
+++ b/src/axom/mint/examples/mint_unstructured_mixed_topology_mesh.cpp
@@ -19,7 +19,7 @@
 #include <random> /* for random number generator */
 
 using namespace axom;
-using axom::slic::UnitTestLogger;
+using axom::slic::SimpleLogger;
 
 inline bool appendQuad(axom::IndexType i, axom::IndexType j)
 {
@@ -29,7 +29,7 @@ inline bool appendQuad(axom::IndexType i, axom::IndexType j)
 //------------------------------------------------------------------------------
 int main(int AXOM_NOT_USED(argc), char** AXOM_NOT_USED(argv))
 {
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   constexpr int DIMENSION = 2;
   constexpr axom::IndexType X_EXTENT = 11;

--- a/src/axom/mint/examples/mint_unstructured_single_topology_mesh.cpp
+++ b/src/axom/mint/examples/mint_unstructured_single_topology_mesh.cpp
@@ -16,12 +16,12 @@
 #include "axom/slic.hpp"
 
 using namespace axom;
-using axom::slic::UnitTestLogger;
+using axom::slic::SimpleLogger;
 
 //------------------------------------------------------------------------------
 int main(int AXOM_NOT_USED(argc), char** AXOM_NOT_USED(argv))
 {
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   constexpr int DIMENSION = 2;
   constexpr axom::IndexType X_EXTENT = 11;

--- a/src/axom/mint/tests/mint_execution_cell_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_cell_traversals.cpp
@@ -604,8 +604,8 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_index)
 } /* namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -613,7 +613,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_execution_face_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_face_traversals.cpp
@@ -426,8 +426,8 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_faces_index)
 } /* namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -435,7 +435,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_execution_node_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_node_traversals.cpp
@@ -576,8 +576,8 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_index)
 } /* namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -585,7 +585,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_execution_xargs.cpp
+++ b/src/axom/mint/tests/mint_execution_xargs.cpp
@@ -57,8 +57,8 @@ TEST(mint_execution_xargs, check_types)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -66,7 +66,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_fem_shape_functions.cpp
+++ b/src/axom/mint/tests/mint_fem_shape_functions.cpp
@@ -239,8 +239,8 @@ TEST(mint_fem_shape_functions, check_partition_of_unity)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -248,7 +248,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_fem_single_fe.cpp
+++ b/src/axom/mint/tests/mint_fem_single_fe.cpp
@@ -999,8 +999,8 @@ TEST(mint_fem_single_fe, check_fe_interp)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -1008,7 +1008,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_mesh.cpp
+++ b/src/axom/mint/tests/mint_mesh.cpp
@@ -730,8 +730,8 @@ TEST(mint_mesh, get_mixed_topology_unstructured_from_sidre)
 } /* namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -739,7 +739,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_mesh_blueprint.cpp
+++ b/src/axom/mint/tests/mint_mesh_blueprint.cpp
@@ -369,8 +369,8 @@ TEST(mint_mesh_blueprint, get_set_uniform_mesh)
 #endif /* AXOM_MINT_USE_SIDRE */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -378,7 +378,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_mesh_cell_types.cpp
+++ b/src/axom/mint/tests/mint_mesh_cell_types.cpp
@@ -200,8 +200,8 @@ TEST(mint_mesh_cell_types, check_cell_types)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -209,7 +209,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_mesh_connectivity_array.cpp
+++ b/src/axom/mint/tests/mint_mesh_connectivity_array.cpp
@@ -14,7 +14,7 @@
 #include "axom/mint/mesh/CellTypes.hpp"
 #include "axom/mint/config.hpp"
 #include "axom/slic/interface/slic.hpp"
-#include "axom/slic/core/UnitTestLogger.hpp" /* for UnitTestLogger */
+#include "axom/slic/core/SimpleLogger.hpp" /* for SimpleLogger */
 
 #ifdef AXOM_MINT_USE_SIDRE
   #include "axom/sidre/core/sidre.hpp"
@@ -2066,13 +2066,13 @@ TEST(mint_connectivity_array_DeathTest, IndirectionSidreCapacity)
 } /* end namespace axom */
 
 //------------------------------------------------------------------------------
-using axom::slic::UnitTestLogger;
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
   int result = 0;
   ::testing::InitGoogleTest(&argc, argv);
-  UnitTestLogger logger;
+  SimpleLogger logger;
   result = RUN_ALL_TESTS();
   return result;
 }

--- a/src/axom/mint/tests/mint_mesh_coordinates.cpp
+++ b/src/axom/mint/tests/mint_mesh_coordinates.cpp
@@ -1383,8 +1383,8 @@ TEST(mint_mesh_coordinates_DeathTest, invalid_construction)
 } /* namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -1392,7 +1392,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_mesh_curvilinear_mesh.cpp
+++ b/src/axom/mint/tests/mint_mesh_curvilinear_mesh.cpp
@@ -330,8 +330,8 @@ TEST(mint_mesh_curvilinear_mesh, sidre_constructor)
 #endif /* AXOM_MINT_USE_SIDRE */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -339,7 +339,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_mesh_face_relation.cpp
+++ b/src/axom/mint/tests/mint_mesh_face_relation.cpp
@@ -8,8 +8,8 @@
 
 #include "axom/core/utilities/Utilities.hpp" /* for utilities::max */
 
-#include "axom/slic/core/UnitTestLogger.hpp" /* for UnitTestLogger */
-#include "axom/slic/interface/slic.hpp"      /* for slic macros */
+#include "axom/slic/core/SimpleLogger.hpp" /* for SimpleLogger */
+#include "axom/slic/interface/slic.hpp"    /* for slic macros */
 
 #include "gtest/gtest.h" /* for TEST and EXPECT_* macros */
 
@@ -1440,14 +1440,14 @@ TEST(mint_mesh_face_relation, correct_construction)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char *argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
   // finalized when exiting main scope
 
   return RUN_ALL_TESTS();

--- a/src/axom/mint/tests/mint_mesh_field.cpp
+++ b/src/axom/mint/tests/mint_mesh_field.cpp
@@ -115,8 +115,8 @@ TEST(mint_mesh_field, get_dataptr)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -124,7 +124,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_mesh_field_data.cpp
+++ b/src/axom/mint/tests/mint_mesh_field_data.cpp
@@ -725,8 +725,8 @@ TEST(mint_mesh_field_data, shrink)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -734,7 +734,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_mesh_field_types.cpp
+++ b/src/axom/mint/tests/mint_mesh_field_types.cpp
@@ -28,8 +28,8 @@ TEST(mint_mesh_fieldtypes, field_traits)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -37,7 +37,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_mesh_field_variable.cpp
+++ b/src/axom/mint/tests/mint_mesh_field_variable.cpp
@@ -405,8 +405,8 @@ TEST(mint_mesh_field_variable, shrink)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -414,7 +414,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_mesh_particle_mesh.cpp
+++ b/src/axom/mint/tests/mint_mesh_particle_mesh.cpp
@@ -549,8 +549,8 @@ TEST(mint_mesh_particle_mesh, shrink)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -558,7 +558,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_mesh_rectilinear_mesh.cpp
+++ b/src/axom/mint/tests/mint_mesh_rectilinear_mesh.cpp
@@ -361,8 +361,8 @@ TEST(mint_mesh_rectilinear_mesh, get_node)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -370,7 +370,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
   result = RUN_ALL_TESTS();

--- a/src/axom/mint/tests/mint_mesh_uniform_mesh.cpp
+++ b/src/axom/mint/tests/mint_mesh_uniform_mesh.cpp
@@ -333,8 +333,8 @@ TEST(mint_mesh_uniform_mesh, check_evaluate_coordinate)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -342,7 +342,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/mint/tests/mint_mesh_unstructured_mesh.cpp
+++ b/src/axom/mint/tests/mint_mesh_unstructured_mesh.cpp
@@ -7,8 +7,8 @@
 
 #include "axom/core/utilities/Utilities.hpp" /* for utilities::max */
 
-#include "axom/slic/core/UnitTestLogger.hpp" /* for UnitTestLogger */
-#include "axom/slic/interface/slic.hpp"      /* for slic macros */
+#include "axom/slic/core/SimpleLogger.hpp" /* for SimpleLogger */
+#include "axom/slic/interface/slic.hpp"    /* for slic macros */
 
 #include "mint_test_utilities.hpp" /* for create_mesh() */
 
@@ -3369,14 +3369,14 @@ TEST(mint_mesh_unstructured_mesh, check_face_connectivity)
 } /* end namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
   // finalized when exiting main scope
 
   return RUN_ALL_TESTS();

--- a/src/axom/mint/tests/mint_su2_io.cpp
+++ b/src/axom/mint/tests/mint_su2_io.cpp
@@ -9,8 +9,8 @@
 #include "axom/mint/utils/su2_utils.hpp"       /* for su2 i/o */
 
 // Slic includes
-#include "axom/slic/interface/slic.hpp"      /* for slic macros */
-#include "axom/slic/core/UnitTestLogger.hpp" /* for UnitTestLogger */
+#include "axom/slic/interface/slic.hpp"    /* for slic macros */
+#include "axom/slic/core/SimpleLogger.hpp" /* for SimpleLogger */
 
 // gtest includes
 #include "gtest/gtest.h" /* for gtest macros */
@@ -220,13 +220,13 @@ TEST(mint_su2_io, write_read_single_cell_topology_mesh)
 }
 
 //------------------------------------------------------------------------------
-using axom::slic::UnitTestLogger;
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
   int result = 0;
   ::testing::InitGoogleTest(&argc, argv);
-  UnitTestLogger logger;
+  SimpleLogger logger;
   result = RUN_ALL_TESTS();
   return result;
 }

--- a/src/axom/mint/tests/mint_util_write_vtk.cpp
+++ b/src/axom/mint/tests/mint_util_write_vtk.cpp
@@ -23,8 +23,8 @@
 #include "mint_test_utilities.hpp"             /* for create_mesh */
 
 // Slic includes
-#include "axom/slic/interface/slic.hpp"      /* for slic macros */
-#include "axom/slic/core/UnitTestLogger.hpp" /* for UnitTestLogger */
+#include "axom/slic/interface/slic.hpp"    /* for slic macros */
+#include "axom/slic/core/SimpleLogger.hpp" /* for SimpleLogger */
 
 // C/C++ includes
 #include <cmath>   /* for std::exp */
@@ -937,13 +937,13 @@ TEST(mint_util_write_vtk, ParticleMesh)
 } /* end namespace axom */
 
 //------------------------------------------------------------------------------
-using axom::slic::UnitTestLogger;
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
   int result = 0;
   ::testing::InitGoogleTest(&argc, argv);
-  UnitTestLogger logger;
+  SimpleLogger logger;
   result = RUN_ALL_TESTS();
   return result;
 }

--- a/src/axom/primal/tests/primal_bezier_curve.cpp
+++ b/src/axom/primal/tests/primal_bezier_curve.cpp
@@ -410,7 +410,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  axom::slic::UnitTestLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_bezier_intersect.cpp
+++ b/src/axom/primal/tests/primal_bezier_intersect.cpp
@@ -459,7 +459,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  axom::slic::UnitTestLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_bounding_box_intersect.cpp
+++ b/src/axom/primal/tests/primal_bounding_box_intersect.cpp
@@ -118,8 +118,8 @@ TEST(primal_bounding_box_intersect, aabb_aabb_non_intersecting)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -127,7 +127,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/primal/tests/primal_boundingbox.cpp
+++ b/src/axom/primal/tests/primal_boundingbox.cpp
@@ -599,8 +599,8 @@ TEST(primal_boundingBox, bb_get_centroid)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -608,7 +608,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -234,14 +234,14 @@ TEST(primal_clip, experimentalData)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   int result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_in_sphere.cpp
+++ b/src/axom/primal/tests/primal_in_sphere.cpp
@@ -95,14 +95,14 @@ TEST(primal_in_sphere, test_in_sphere_3d)
 
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
   axom::slic::setLoggingMsgLevel(axom::slic::message::Warning);
 
   int result = RUN_ALL_TESTS();

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -1997,14 +1997,14 @@ TEST(primal_intersect, obb_obb_test_intersection3D)
 
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
   axom::slic::setLoggingMsgLevel(axom::slic::message::Warning);
 
   int result = RUN_ALL_TESTS();

--- a/src/axom/primal/tests/primal_intersect_impl.cpp
+++ b/src/axom/primal/tests/primal_intersect_impl.cpp
@@ -134,8 +134,8 @@ TEST(primal_intersection_impl, zero_count)
 
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -144,7 +144,7 @@ int main(int argc, char* argv[])
   ::testing::InitGoogleTest(&argc, argv);
 
   // create & initialize test logger, finalized when exiting main scope
-  UnitTestLogger logger;
+  SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_numeric_array.cpp
+++ b/src/axom/primal/tests/primal_numeric_array.cpp
@@ -7,8 +7,8 @@
 
 #include "axom/primal/geometry/NumericArray.hpp"
 
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 using namespace axom;
 
@@ -254,7 +254,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/primal/tests/primal_orientation.cpp
+++ b/src/axom/primal/tests/primal_orientation.cpp
@@ -69,8 +69,8 @@ TEST(primal_orientation, orient2D)
 
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -78,7 +78,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/primal/tests/primal_plane.cpp
+++ b/src/axom/primal/tests/primal_plane.cpp
@@ -322,8 +322,8 @@ TEST(primal_plane, flip)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -331,7 +331,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/primal/tests/primal_point.cpp
+++ b/src/axom/primal/tests/primal_point.cpp
@@ -349,8 +349,8 @@ TEST(primal_point, point_linear_interpolation)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -358,7 +358,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/primal/tests/primal_ray_intersect.cpp
+++ b/src/axom/primal/tests/primal_ray_intersect.cpp
@@ -384,8 +384,8 @@ TEST(primal_ray_intersect, ray_aabb_intersection_3D)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -393,7 +393,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/primal/tests/primal_sphere.cpp
+++ b/src/axom/primal/tests/primal_sphere.cpp
@@ -227,8 +227,8 @@ TEST(primal_sphere, sphere_sphere_intersection)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -236,7 +236,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/primal/tests/primal_tetrahedron.cpp
+++ b/src/axom/primal/tests/primal_tetrahedron.cpp
@@ -188,14 +188,14 @@ TEST_F(TetrahedronTest, barycentric)
 
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
   axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();

--- a/src/axom/primal/tests/primal_triangle.cpp
+++ b/src/axom/primal/tests/primal_triangle.cpp
@@ -316,14 +316,14 @@ TEST(primal_triangle, triangle_3D_point_containment)
 
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
   axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();

--- a/src/axom/primal/tests/primal_vector.cpp
+++ b/src/axom/primal/tests/primal_vector.cpp
@@ -256,8 +256,8 @@ TEST(primal_vector, vector_outer_product)
 
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -265,7 +265,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/quest/examples/containment_driver.cpp
+++ b/src/axom/quest/examples/containment_driver.cpp
@@ -441,7 +441,7 @@ public:
 //------------------------------------------------------------------------------
 int main(int argc, char** argv)
 {
-  axom::slic::UnitTestLogger logger;  // create & initialize logger
+  axom::slic::SimpleLogger logger;  // create & initialize logger
   // slic::debug::checksAreErrors = true;
 
   // Set up and parse command line arguments

--- a/src/axom/quest/tests/quest_all_nearest_neighbors.cpp
+++ b/src/axom/quest/tests/quest_all_nearest_neighbors.cpp
@@ -353,7 +353,7 @@ TEST(quest_all_nearnbr, file_query)
 
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-using axom::slic::UnitTestLogger;
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -372,7 +372,7 @@ int main(int argc, char* argv[])
     }
   }
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/quest/tests/quest_inout_interface.cpp
+++ b/src/axom/quest/tests/quest_inout_interface.cpp
@@ -210,8 +210,7 @@ int main(int argc, char** argv)
 #endif
   ::testing::InitGoogleTest(&argc, argv);
 
-  axom::slic::UnitTestLogger logger;  // create & initialize test logger,
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Debug);
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   int result = RUN_ALL_TESTS();
 

--- a/src/axom/quest/tests/quest_inout_octree.cpp
+++ b/src/axom/quest/tests/quest_inout_octree.cpp
@@ -247,8 +247,7 @@ int main(int argc, char* argv[])
   ::testing::InitGoogleTest(&argc, argv);
 
   namespace slic = axom::slic;
-  slic::UnitTestLogger logger;  // create & initialize test logger,
-  slic::setLoggingMsgLevel(slic::message::Debug);
+  slic::SimpleLogger logger;  // create & initialize test logger,
 
 #ifdef INOUT_OCTREE_TESTER_SHOULD_SEED
   std::srand(std::time(0));

--- a/src/axom/quest/tests/quest_meshtester.cpp
+++ b/src/axom/quest/tests/quest_meshtester.cpp
@@ -529,7 +529,7 @@ int main(int argc, char* argv[])
   ::testing::InitGoogleTest(&argc, argv);
 
   namespace slic = axom::slic;
-  slic::UnitTestLogger logger;  // create & initialize test logger,
+  slic::SimpleLogger logger;  // create & initialize test logger,
   slic::setLoggingMsgLevel(slic::message::Info);
 
   int result = RUN_ALL_TESTS();

--- a/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
+++ b/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
@@ -34,8 +34,8 @@
 
 #include "quest_test_utilities.hpp"
 
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 #include "fmt/fmt.hpp"
 
@@ -1509,7 +1509,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
   axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
 
   std::srand(SRAND_SEED);

--- a/src/axom/quest/tests/quest_regression.cpp
+++ b/src/axom/quest/tests/quest_regression.cpp
@@ -866,11 +866,11 @@ int main(int argc, char** argv)
   MPI_Init(&argc, &argv);
 
   {
-    // Note: this code is in a different context since UnitTestLogger's
+    // Note: this code is in a different context since SimpleLogger's
     // destructor
     //       might have MPI calls and would otherwise be invoked after
     // MPI_Finalize()
-    slic::UnitTestLogger logger;
+    slic::SimpleLogger logger;
     sidre::DataStore ds;
 
     // parse the command arguments

--- a/src/axom/quest/tests/quest_signed_distance.cpp
+++ b/src/axom/quest/tests/quest_signed_distance.cpp
@@ -5,8 +5,8 @@
 
 #include "axom/config.hpp"
 #include "axom/slic/interface/slic.hpp"
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 #include "axom/mint/mesh/CellTypes.hpp"
 #include "axom/mint/config.hpp"
@@ -194,7 +194,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/quest/tests/quest_signed_distance_interface.cpp
+++ b/src/axom/quest/tests/quest_signed_distance_interface.cpp
@@ -26,9 +26,9 @@
 #include "quest_test_utilities.hpp"                  // test-utility functions
 
 // Slic includes
-#include "axom/slic/interface/slic.hpp"       // for SLIC macros
-#include "axom/slic/core/UnitTestLogger.hpp"  // for the unit test logger
-using axom::slic::UnitTestLogger;
+#include "axom/slic/interface/slic.hpp"     // for SLIC macros
+#include "axom/slic/core/SimpleLogger.hpp"  // for the unit test logger
+using axom::slic::SimpleLogger;
 
 // gtest
 #ifdef AXOM_USE_MPI
@@ -554,7 +554,7 @@ int main(int argc, char* argv[])
   // add this line to avoid a warning in the output about thread safety
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/quest/tests/quest_stl_reader.cpp
+++ b/src/axom/quest/tests/quest_stl_reader.cpp
@@ -205,14 +205,14 @@ TEST(quest_stl_reader, read_stl_external)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
   // finalized when exiting main scope
 
   return RUN_ALL_TESTS();

--- a/src/axom/quest/tests/quest_vertex_weld.cpp
+++ b/src/axom/quest/tests/quest_vertex_weld.cpp
@@ -306,8 +306,8 @@ TEST(quest_vertex_weld, indexedOctahedron)
 
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -315,7 +315,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/sidre/examples/sidre_array.cpp
+++ b/src/axom/sidre/examples/sidre_array.cpp
@@ -30,7 +30,7 @@ int main(int argc, char** argv)
   MPI_Comm_rank(problem_comm, &myrank);
   MPI_Comm_size(problem_comm, &nranks);
 
-  slic::UnitTestLogger logger;
+  slic::SimpleLogger logger;
 
   // STEP 0: create the data store
   sidre::DataStore* dataStore1 = new sidre::DataStore();

--- a/src/axom/sidre/examples/sidre_external_array.cpp
+++ b/src/axom/sidre/examples/sidre_external_array.cpp
@@ -114,7 +114,7 @@ int main(int argc, char** argv)
 #if defined(AXOM_USE_HDF5)
   MPI_Comm problem_comm = MPI_COMM_WORLD;
 
-  slic::UnitTestLogger logger;
+  slic::SimpleLogger logger;
 
   // STEP 0: create some data
   constexpr axom::IndexType NUM_NODES = 10;

--- a/src/axom/sidre/examples/spio/IORead.cpp
+++ b/src/axom/sidre/examples/spio/IORead.cpp
@@ -23,7 +23,7 @@ using axom::sidre::IOManager;
 int main(int argc, char* argv[])
 {
   MPI_Init(&argc, &argv);
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
 
   SLIC_ERROR_IF(argc != 2,
                 "Missing required command line argument. \n\t"

--- a/src/axom/sidre/examples/spio/IOSCRRead.cpp
+++ b/src/axom/sidre/examples/spio/IOSCRRead.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[])
 {
   MPI_Init(&argc, &argv);
   SCR_Init();
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
 
   SLIC_ERROR_IF(argc != 2,
                 "Missing required command line argument. \n\t"

--- a/src/axom/sidre/examples/spio/IOSCRWrite.cpp
+++ b/src/axom/sidre/examples/spio/IOSCRWrite.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[])
 {
   MPI_Init(&argc, &argv);
   SCR_Init();
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
 
   SLIC_ERROR_IF(argc != 3,
                 "Missing command line arguments. \n\t"

--- a/src/axom/sidre/examples/spio/IOWrite.cpp
+++ b/src/axom/sidre/examples/spio/IOWrite.cpp
@@ -27,7 +27,7 @@ using namespace axom::utilities;
 int main(int argc, char* argv[])
 {
   MPI_Init(&argc, &argv);
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
 
   SLIC_ERROR_IF(argc != 3,
                 "Missing command line arguments. \n\t"

--- a/src/axom/sidre/tests/sidre_array.cpp
+++ b/src/axom/sidre/tests/sidre_array.cpp
@@ -6,8 +6,8 @@
 #include "axom/core/Array.hpp"               /* for axom::Array */
 #include "axom/core/utilities/Utilities.hpp" /* for utilities::max */
 
-#include "axom/slic/core/UnitTestLogger.hpp" /* for UnitTestLogger */
-#include "axom/slic/interface/slic.hpp"      /* for slic macros */
+#include "axom/slic/core/SimpleLogger.hpp" /* for SimpleLogger */
+#include "axom/slic/interface/slic.hpp"    /* for slic macros */
 
 #include "gtest/gtest.h" /* for TEST and EXPECT_* macros */
 
@@ -1186,8 +1186,8 @@ TEST(sidre_core_array, checkSidrePermanence)
 } /* end namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -1195,7 +1195,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -172,8 +172,8 @@ TEST(sidre_datacollection, dc_par_reload)
 }
 
     //----------------------------------------------------------------------
-    #include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+    #include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -181,7 +181,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   MPI_Init(&argc, &argv);
   result = RUN_ALL_TESTS();

--- a/src/axom/sidre/tests/sidre_native_layout.cpp
+++ b/src/axom/sidre/tests/sidre_native_layout.cpp
@@ -642,8 +642,8 @@ TEST(sidre_native_layout, basic_demo_compare)
 
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -651,8 +651,8 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger, finalized when
-                          // exiting main scope
+  SimpleLogger logger;  // create & initialize test logger, finalized when
+                        // exiting main scope
   axom::slic::setLoggingMsgLevel(axom::slic::message::Debug);
 
   result = RUN_ALL_TESTS();

--- a/src/axom/sidre/tests/sidre_view.cpp
+++ b/src/axom/sidre/tests/sidre_view.cpp
@@ -2070,8 +2070,8 @@ INSTANTIATE_TEST_SUITE_P(sidre_view,
                                             ::testing::ValuesIn(offsets)));
 
 //----------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -2079,7 +2079,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/sidre/tests/spio/spio_main.cpp
+++ b/src/axom/sidre/tests/spio/spio_main.cpp
@@ -24,8 +24,8 @@ const std::string ROOT_EXT = ".root";
 #include "spio_scr.hpp"
 #include "spio_serial.hpp"
 
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -33,7 +33,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   MPI_Init(&argc, &argv);
   result = RUN_ALL_TESTS();

--- a/src/axom/slam/benchmarks/slam_array.cpp
+++ b/src/axom/slam/benchmarks/slam_array.cpp
@@ -530,7 +530,7 @@ int main(int argc, char* argv[])
 
   ::benchmark::Initialize(&argc, argv);
 
-  axom::slic::UnitTestLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   ::benchmark::RunSpecifiedBenchmarks();
 

--- a/src/axom/slam/benchmarks/slam_sets.cpp
+++ b/src/axom/slam/benchmarks/slam_sets.cpp
@@ -244,7 +244,7 @@ BENCHMARK(positionSet_runtimeTimeSize_iter)->Apply(CustomArgs);
 int main(int argc, char* argv[])
 {
   std::srand(std::time(NULL));
-  axom::slic::UnitTestLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   ::benchmark::Initialize(&argc, argv);
   ::benchmark::RunSpecifiedBenchmarks();

--- a/src/axom/slam/examples/HandleMesh.cpp
+++ b/src/axom/slam/examples/HandleMesh.cpp
@@ -59,7 +59,7 @@ std::ostream& operator<<(std::ostream& os, const Handle<T>& h)
 
 int main(int, char**)
 {
-  slic::UnitTestLogger logger;
+  slic::SimpleLogger logger;
 
   using PosType = slam::DefaultPositionType;
   using HandleType = Handle<PosType>;

--- a/src/axom/slam/examples/ShockTube.cpp
+++ b/src/axom/slam/examples/ShockTube.cpp
@@ -632,7 +632,7 @@ void dumpData(ShockTubeMesh const& mesh)
 int main(void)
 {
   using namespace slamShocktube;
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
 
   // We should be able to parallelize pretty easily by
   // adding an MPI_Init() here, modifying the setup slightly,

--- a/src/axom/slam/examples/UnstructMeshField.cpp
+++ b/src/axom/slam/examples/UnstructMeshField.cpp
@@ -485,7 +485,7 @@ int main(int argc, char** argv)
 {
   using namespace slamUnstructuredHex;
 
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
 
 #ifndef USE_ONE
   int const NUM_RESOLUTIONS = 4;

--- a/src/axom/slam/examples/UserDocs.cpp
+++ b/src/axom/slam/examples/UserDocs.cpp
@@ -390,7 +390,7 @@ void quadMeshExample()
 
 int main(int /* argc */, char** /* argv */)
 {
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
 
   quadMeshExample();
 }

--- a/src/axom/slam/examples/tinyHydro/tests/slam_tinyHydro_sedovTwoPart.cpp
+++ b/src/axom/slam/examples/tinyHydro/tests/slam_tinyHydro_sedovTwoPart.cpp
@@ -121,14 +121,14 @@ void tinyHydroSedov_2part()
 }
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main()
 {
   int result = 0;
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
   tinyHydroSedov_2part();

--- a/src/axom/slam/examples/tinyHydro/tests/slam_tinyHydro_sod1DTwoPart.cpp
+++ b/src/axom/slam/examples/tinyHydro/tests/slam_tinyHydro_sod1DTwoPart.cpp
@@ -156,14 +156,14 @@ void tinyHydroSod1D_2part()
 }
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main()
 {
   int result = 0;
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
   tinyHydroSod1D_2part();

--- a/src/axom/slam/examples/tinyHydro/tests/slam_tinyHydro_unitTests.cpp
+++ b/src/axom/slam/examples/tinyHydro/tests/slam_tinyHydro_unitTests.cpp
@@ -582,8 +582,8 @@ TEST(slam_tinyHydro,test_06_PdV_work)
 }
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char * argv[])
 {
@@ -591,7 +591,7 @@ int main(int argc, char * argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/slam/tests/slam_AccessingRelationDataInMap.cpp
+++ b/src/axom/slam/tests/slam_AccessingRelationDataInMap.cpp
@@ -146,7 +146,7 @@ TEST(slam_set_relation_map, access_pattern)
 }
 
 //----------------------------------------------------------------------
-using axom::slic::UnitTestLogger;
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -155,8 +155,7 @@ int main(int argc, char* argv[])
   ::testing::InitGoogleTest(&argc, argv);
 
   // create & initialize test logger. finalized when exiting main scope
-  axom::slic::UnitTestLogger logger;
-  // axom::slic::setLoggingMsgLevel( axom::slic::message::Debug);
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_Map.cpp
+++ b/src/axom/slam/tests/slam_Map.cpp
@@ -379,7 +379,7 @@ int main(int argc, char* argv[])
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 #endif
 
-  axom::slic::UnitTestLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
   axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();

--- a/src/axom/slam/tests/slam_ModularInt.cpp
+++ b/src/axom/slam/tests/slam_ModularInt.cpp
@@ -334,7 +334,7 @@ int main(int argc, char* argv[])
   int result = 0;
   ::testing::InitGoogleTest(&argc, argv);
 
-  axom::slic::UnitTestLogger logger;  // create & initialize test logger
+  axom::slic::SimpleLogger logger;  // create & initialize test logger
 
   result = RUN_ALL_TESTS();
   return result;

--- a/src/axom/slam/tests/slam_map_BivariateMap.cpp
+++ b/src/axom/slam/tests/slam_map_BivariateMap.cpp
@@ -406,7 +406,7 @@ int main(int argc, char* argv[])
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 #endif
 
-  axom::slic::UnitTestLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
   axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();

--- a/src/axom/slam/tests/slam_map_DynamicMap.cpp
+++ b/src/axom/slam/tests/slam_map_DynamicMap.cpp
@@ -120,7 +120,7 @@ int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
 
-  axom::slic::UnitTestLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
   axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();

--- a/src/axom/slam/tests/slam_map_SubMap.cpp
+++ b/src/axom/slam/tests/slam_map_SubMap.cpp
@@ -218,7 +218,7 @@ int main(int argc, char* argv[])
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 #endif
 
-  axom::slic::UnitTestLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
   axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();

--- a/src/axom/slam/tests/slam_relation_DynamicConstant.cpp
+++ b/src/axom/slam/tests/slam_relation_DynamicConstant.cpp
@@ -232,7 +232,7 @@ int main(int argc, char* argv[])
   ::testing::InitGoogleTest(&argc, argv);
 
   // create & initialize test logger. finalized when exiting main scope
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
   axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();

--- a/src/axom/slam/tests/slam_relation_DynamicVariable.cpp
+++ b/src/axom/slam/tests/slam_relation_DynamicVariable.cpp
@@ -215,7 +215,7 @@ int main(int argc, char* argv[])
   ::testing::InitGoogleTest(&argc, argv);
 
   // create & initialize test logger. finalized when exiting main scope
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
   axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();

--- a/src/axom/slam/tests/slam_relation_StaticConstant.cpp
+++ b/src/axom/slam/tests/slam_relation_StaticConstant.cpp
@@ -587,8 +587,7 @@ int main(int argc, char* argv[])
   ::testing::InitGoogleTest(&argc, argv);
 
   // create & initialize test logger. finalized when exiting main scope
-  axom::slic::UnitTestLogger logger;
-  // axom::slic::setLoggingMsgLevel( axom::slic::message::Debug);
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_relation_StaticVariable.cpp
+++ b/src/axom/slam/tests/slam_relation_StaticVariable.cpp
@@ -352,7 +352,7 @@ int main(int argc, char* argv[])
   ::testing::InitGoogleTest(&argc, argv);
 
   // create & initialize test logger. finalized when exiting main scope
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_set_BitSet.cpp
+++ b/src/axom/slam/tests/slam_set_BitSet.cpp
@@ -462,7 +462,7 @@ int main(int argc, char* argv[])
 #endif
 
   // create & initialize test logger. finalized when exiting main scope
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_set_DynamicSet.cpp
+++ b/src/axom/slam/tests/slam_set_DynamicSet.cpp
@@ -272,8 +272,8 @@ TEST(slam_set_dynamicset, find_index)
 
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -285,7 +285,7 @@ int main(int argc, char* argv[])
 #endif
 
   // create & initialize test logger. finalized when exiting main scope
-  UnitTestLogger logger;
+  SimpleLogger logger;
 
   int result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_set_IndirectionSet.cpp
+++ b/src/axom/slam/tests/slam_set_IndirectionSet.cpp
@@ -589,7 +589,7 @@ int main(int argc, char* argv[])
   ::testing::InitGoogleTest(&argc, argv);
 
   // create & initialize test logger. finalized when exiting main scope
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
 
   int result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_set_Iterator.cpp
+++ b/src/axom/slam/tests/slam_set_Iterator.cpp
@@ -437,7 +437,7 @@ int main(int argc, char* argv[])
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 #endif
 
-  axom::slic::UnitTestLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
   axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();

--- a/src/axom/slam/tests/slam_set_NullSet.cpp
+++ b/src/axom/slam/tests/slam_set_NullSet.cpp
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
   int result = 0;
   ::testing::InitGoogleTest(&argc, argv);
 
-  axom::slic::UnitTestLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   result = RUN_ALL_TESTS();
   return result;

--- a/src/axom/slam/tests/slam_set_PositionSet.cpp
+++ b/src/axom/slam/tests/slam_set_PositionSet.cpp
@@ -262,7 +262,7 @@ int main(int argc, char* argv[])
   ::testing::InitGoogleTest(&argc, argv);
 
   // create & initialize test logger. finalized when exiting main scope
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_set_RangeSet.cpp
+++ b/src/axom/slam/tests/slam_set_RangeSet.cpp
@@ -419,7 +419,7 @@ int main(int argc, char* argv[])
 #endif
 
   // create & initialize test logger, finalized when exiting main scope
-  axom::slic::UnitTestLogger logger;
+  axom::slic::SimpleLogger logger;
   //axom::slic::debug::checksAreErrors = true;
 
   result = RUN_ALL_TESTS();

--- a/src/axom/slic/CMakeLists.txt
+++ b/src/axom/slic/CMakeLists.txt
@@ -13,7 +13,7 @@ set(slic_headers
     core/Logger.hpp
     core/LogStream.hpp
     core/MessageLevel.hpp
-    core/UnitTestLogger.hpp
+    core/SimpleLogger.hpp
 
     interface/slic.hpp
     interface/slic_macros.hpp

--- a/src/axom/slic/core/SimpleLogger.hpp
+++ b/src/axom/slic/core/SimpleLogger.hpp
@@ -4,14 +4,14 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 /*!
- *  \file UnitTestLogger.hpp
+ *  \file SimpleLogger.hpp
  *
- *  \brief Header file containing definition of UnitTestLogger class.
+ *  \brief Header file containing definition of SimpleLogger class.
  *
  */
 
-#ifndef UNITTESTLOGGER_HPP_
-#define UNITTESTLOGGER_HPP_
+#ifndef SIMPLELOGGER_HPP_
+#define SIMPLELOGGER_HPP_
 
 // Other axom headers
 #include "axom/core/Macros.hpp"  // defines DISABLE_{COPY,MOVE}_AND_ASSIGNMENT
@@ -25,9 +25,9 @@ namespace axom
 namespace slic
 {
 /*!
- * \class UnitTestLogger
+ * \class SimpleLogger
  *
- * \brief UnitTestLogger is a simple wrapper around the initialization and
+ * \brief SimpleLogger is a simple wrapper around the initialization and
  * finalize operations of the slic::Logger class that is helpful for
  * unit tests and simple applications in axom.
  *
@@ -45,7 +45,7 @@ namespace slic
  *     ::testing::InitGoogleTest(&argc, argv);
  *
  *     // create & initialize test logger, finalized when exiting main scope
- *     UnitTestLogger logger;
+ *     axom::slic::SimpleLogger logger;
  *
  *     result = RUN_ALL_TESTS();
  *
@@ -54,13 +54,13 @@ namespace slic
  *
  * \endverbatim
  */
-class UnitTestLogger
+class SimpleLogger
 {
 public:
   /*!
-   * \brief Constructor initializes slic loging environment.
+   * \brief Constructor initializes slic logging environment.
    */
-  UnitTestLogger()
+  SimpleLogger()
   {
     initialize();
     setLoggingMsgLevel(message::Debug);
@@ -89,14 +89,14 @@ public:
   /*!
    * \brief Destructor finalizes slic loging environment.
    */
-  ~UnitTestLogger() { finalize(); }
+  ~SimpleLogger() { finalize(); }
 
 private:
-  DISABLE_COPY_AND_ASSIGNMENT(UnitTestLogger);
-  DISABLE_MOVE_AND_ASSIGNMENT(UnitTestLogger);
+  DISABLE_COPY_AND_ASSIGNMENT(SimpleLogger);
+  DISABLE_MOVE_AND_ASSIGNMENT(SimpleLogger);
 };
 
 } /* end namespace slic */
 } /* end namespace axom */
 
-#endif /* UNITTESTLOGGER_HPP_ */
+#endif /* SIMPLELOGGER_HPP_ */

--- a/src/axom/slic/tests/slic_asserts.cpp
+++ b/src/axom/slic/tests/slic_asserts.cpp
@@ -6,15 +6,15 @@
 #include "gtest/gtest.h"
 
 #include "axom/slic/interface/slic.hpp"
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 /*!
  * \file
  *
  * The tests in this file check that SLIC macros properly output their message
  * and exit (when appropriate) when run from constructors and destructors.
- * They also exercise the SLIC UnitTestLogger.
+ * They also exercise the SLIC SimpleLogger.
  */
 
 namespace
@@ -185,8 +185,8 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
-                          // finalized when exiting main scope
+  SimpleLogger logger;  // create & initialize test logger,
+                        // finalized when exiting main scope
 
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   result = RUN_ALL_TESTS();

--- a/src/axom/slic/tests/slic_benchmark_asserts.cpp
+++ b/src/axom/slic/tests/slic_benchmark_asserts.cpp
@@ -5,8 +5,8 @@
 
 #include "benchmark/benchmark_api.h"
 #include "axom/slic/interface/slic.hpp"
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 /*!
  * \file
@@ -187,7 +187,7 @@ int main(int argc, char* argv[])
   printMsg("at start of main");
 
   printMsg(" Before init logger");
-  axom::slic::UnitTestLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
   printMsg(" After init logger");
 
   printMsg(" Before init benchmark");

--- a/src/axom/slic/tests/slic_fmt.cpp
+++ b/src/axom/slic/tests/slic_fmt.cpp
@@ -13,9 +13,9 @@
 #include "fmt/fmt.hpp"
 
 #include "axom/slic/interface/slic.hpp"
-#include "axom/slic/core/UnitTestLogger.hpp"
+#include "axom/slic/core/SimpleLogger.hpp"
 
-using axom::slic::UnitTestLogger;
+using axom::slic::SimpleLogger;
 
 #include "gtest/gtest.h"
 
@@ -53,8 +53,8 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
-                          // finalized when exiting main scope
+  SimpleLogger logger;  // create & initialize test logger,
+                        // finalized when exiting main scope
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -2059,8 +2059,8 @@ AXOM_CUDA_TEST(spin_bvh, use_pool_allocator)
 #endif /* AXOM_USE_CUDA && AXOM_USE_RAJA && AXOM_USE_UMPIRE */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -2068,7 +2068,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/spin/tests/spin_bvhtree.cpp
+++ b/src/axom/spin/tests/spin_bvhtree.cpp
@@ -61,8 +61,8 @@ TEST(spin_bucket_tree, insert_object)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -70,7 +70,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/spin/tests/spin_implicit_grid.cpp
+++ b/src/axom/spin/tests/spin_implicit_grid.cpp
@@ -605,7 +605,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  axom::slic::UnitTestLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
   axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
 
   result = RUN_ALL_TESTS();

--- a/src/axom/spin/tests/spin_morton.cpp
+++ b/src/axom/spin/tests/spin_morton.cpp
@@ -8,8 +8,8 @@
 #include "axom/spin/MortonIndex.hpp"
 
 #include "axom/primal/geometry/Point.hpp"
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 #include <cstdlib>
 #include <limits>
@@ -290,7 +290,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
   axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
 
   // finalized when exiting main scope

--- a/src/axom/spin/tests/spin_octree.cpp
+++ b/src/axom/spin/tests/spin_octree.cpp
@@ -338,8 +338,8 @@ TEST(spin_octree, count_octree_blocks)
 
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -347,7 +347,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/axom/spin/tests/spin_rectangular_lattice.cpp
+++ b/src/axom/spin/tests/spin_rectangular_lattice.cpp
@@ -8,7 +8,7 @@
 #include "axom/spin/RectangularLattice.hpp"
 
 #include "axom/slic/interface/slic.hpp"
-#include "axom/slic/core/UnitTestLogger.hpp"
+#include "axom/slic/core/SimpleLogger.hpp"
 
 // Define some helpful typedefs for 1D rectangular lattices
 namespace lattice_1D
@@ -680,8 +680,8 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  using axom::slic::UnitTestLogger;
-  UnitTestLogger logger;  // create & initialize test logger,
+  using axom::slic::SimpleLogger;
+  SimpleLogger logger;  // create & initialize test logger,
   axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
 
   // finalized when exiting main scope

--- a/src/axom/spin/tests/spin_spatial_octree.cpp
+++ b/src/axom/spin/tests/spin_spatial_octree.cpp
@@ -68,8 +68,8 @@ TEST(spin_spatial_octree, spatial_octree_point_location)
 
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/UnitTestLogger.hpp"
-using axom::slic::UnitTestLogger;
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  UnitTestLogger logger;  // create & initialize test logger,
+  SimpleLogger logger;  // create & initialize test logger,
 
   // finalized when exiting main scope
 

--- a/src/docs/sphinx/dev_guide/testing.rst
+++ b/src/docs/sphinx/dev_guide/testing.rst
@@ -146,7 +146,7 @@ object to be used in tests::
 
     ::testing::InitGoogleTest(&argc, argv);
 
-    UnitTestLogger logger;  // create & initialize test logger,
+    SimpleLogger logger;  // create & initialize test logger,
                             // finalized when exiting main scope
 
     ::testing::FLAGS_gtest_death_test_style = "threadsafe";
@@ -156,7 +156,7 @@ object to be used in tests::
   }
 
 Note that Google Test is initialized first, followed by initialization of the
-slic UnitTestLogger object. The `RUN_ALL_TESTS()` Google Test macro will 
+slic SimpleLogger object. The `RUN_ALL_TESTS()` Google Test macro will 
 run all the tests in the file. 
 
 As another example, consider a set of tests that use MPI.  The 'main()' 
@@ -169,7 +169,7 @@ respectively::
 
     ::testing::InitGoogleTest(&argc, argv);
 
-    UnitTestLogger logger;  // create & initialize test logger,
+    SimpleLogger logger;  // create & initialize test logger,
                             // finalized when exiting main scope
 
     MPI_Init(&argc, &argv);


### PR DESCRIPTION
# Summary

- This PR is a refactoring
- It does the following:
  - Renames `UnitTestLogger` to `SimpleLogger`

#395 