### PR TITLE
Add conversion of arrays to std::vector<T>

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -38,6 +38,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Inlet: Added support for mixed-key (integer and string) associative arrays
 - Inlet: Added support for deeply nested containers of structs
 - Inlet: Added support for `void` and strings in Lua-defined functions
+- Inlet: Added `get<std::vector<T>>` for retrieving arrays without index information
 
 ### Changed
 - The Sidre Datastore no longer rewires Conduit's error handlers to SLIC by default. 

--- a/src/axom/inlet/Proxy.hpp
+++ b/src/axom/inlet/Proxy.hpp
@@ -76,12 +76,12 @@ public:
    * or T{}
    *******************************************************************************
    */
-  template <typename T,
-            typename SFINAE =
-              typename std::enable_if<detail::is_inlet_primitive<T>::value ||
-                                      detail::is_inlet_primitive_array<T>::value ||
-                                      detail::is_inlet_primitive_dict<T>::value ||
-                                      detail::is_std_function<T>::value>::type>
+  template <
+    typename T,
+    typename SFINAE = typename std::enable_if<
+      detail::is_inlet_primitive<T>::value || detail::is_inlet_primitive_array<T>::value ||
+      detail::is_inlet_primitive_dict<T>::value || detail::is_std_function<T>::value ||
+      detail::is_primitive_std_vector<T>::value>::type>
   operator T() const
   {
     return get<T>();

--- a/src/axom/inlet/examples/nested_structs.cpp
+++ b/src/axom/inlet/examples/nested_structs.cpp
@@ -15,23 +15,13 @@
 namespace inlet = axom::inlet;
 using Vector = inlet::FunctionType::Vector;
 
-// Used to convert an unordered map (the type Inlet uses) to represent arrays
+// Used to convert a std::vector (the type Inlet uses to represent arrays)
 // to a geometric vector type
-// FIXME: Clean this up/remove when PR #429 is merged
-Vector mapToVector(const std::unordered_map<int, double>& map)
+Vector toVector(const std::vector<double>& vec)
 {
-  Vector result;
-  // Make sure the elements are accessed in order
-  for(int i = 0; i < 3; i++)
-  {
-    const auto ele = map.find(i);
-    if(ele != map.end())
-    {
-      result[i] = ele->second;
-      result.dim = i + 1;
-    }
-  }
-  return result;
+  // Narrow from std::size_t to int
+  const int size = vec.size();
+  return {{vec.data(), size}, size};
 }
 
 // A union of the members required for each of the operations is stored for simplicity
@@ -99,14 +89,14 @@ struct FromInlet<Operator>
     if(base.contains("translate"))
     {
       result.type = Operator::Type::Translate;
-      result.translate = mapToVector(base["translate"]);
+      result.translate = toVector(base["translate"]);
     }
     else if(base.contains("rotate"))
     {
       result.type = Operator::Type::Rotate;
       result.rotate = base["rotate"];
-      result.axis = mapToVector(base["axis"]);
-      result.center = mapToVector(base["center"]);
+      result.axis = toVector(base["axis"]);
+      result.center = toVector(base["center"]);
     }
     else if(base.contains("slice"))
     {

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -758,6 +758,23 @@ TYPED_TEST(inlet_object, nested_array_of_nested_structs)
   EXPECT_EQ(quuxs_with_foo, expected_quuxs);
 }
 
+TYPED_TEST(inlet_object, primitive_arrays_as_std_vector)
+{
+  std::string testString = " arr = { [0] = 4, [1] = 6, [2] = 10}";
+  DataStore ds;
+  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+
+  // Define schema
+  inlet.addIntArray("arr");
+
+  // Attempt both construction and assignment
+  std::vector<int> expected_arr {4, 6, 10};
+  std::vector<int> arr = inlet["arr"];
+  EXPECT_EQ(arr, expected_arr);
+  arr = inlet["arr"];
+  EXPECT_EQ(arr, expected_arr);
+}
+
 template <typename InletReader>
 class inlet_object_dict : public ::testing::Test
 { };

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -775,6 +775,23 @@ TYPED_TEST(inlet_object, primitive_arrays_as_std_vector)
   EXPECT_EQ(arr, expected_arr);
 }
 
+TYPED_TEST(inlet_object, generic_arrays_as_std_vector)
+{
+  std::string testString =
+    "foo = { [0] = { bar = true; baz = false}, "
+    "        [1] = { bar = false; baz = true} }";
+  DataStore ds;
+  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+
+  auto& arr_table = inlet.addGenericArray("foo");
+
+  arr_table.addBool("bar", "bar's description");
+  arr_table.addBool("baz", "baz's description");
+  std::vector<Foo> expected_foos = {{true, false}, {false, true}};
+  auto foos = inlet["foo"].get<std::vector<Foo>>();
+  EXPECT_EQ(foos, expected_foos);
+}
+
 template <typename InletReader>
 class inlet_object_dict : public ::testing::Test
 { };
@@ -976,6 +993,74 @@ TEST(inlet_object_lua, array_from_bracket)
 
   doubleMap = inlet["luaArrays/arr4"].get<std::unordered_map<int, double>>();
   EXPECT_EQ(doubleMap, expectedDoubles);
+}
+
+TEST(inlet_object_lua, primitive_arrays_as_std_vector_discontiguous)
+{
+  std::string testString = " arr = { [0] = 4, [8] = 6, [12] = 10}";
+  DataStore ds;
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+
+  // Define schema
+  inlet.addIntArray("arr");
+
+  // Attempt both construction and assignment
+  std::vector<int> expected_arr {4, 6, 10};
+  std::vector<int> arr = inlet["arr"];
+  EXPECT_EQ(arr, expected_arr);
+  arr = inlet["arr"];
+  EXPECT_EQ(arr, expected_arr);
+}
+
+TEST(inlet_object_lua, generic_arrays_as_std_vector_discontiguous)
+{
+  std::string testString =
+    "foo = { [6] = { bar = true; baz = false}, "
+    "        [11] = { bar = false; baz = true} }";
+  DataStore ds;
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+
+  auto& arr_table = inlet.addGenericArray("foo");
+
+  arr_table.addBool("bar", "bar's description");
+  arr_table.addBool("baz", "baz's description");
+  std::vector<Foo> expected_foos = {{true, false}, {false, true}};
+  auto foos = inlet["foo"].get<std::vector<Foo>>();
+  EXPECT_EQ(foos, expected_foos);
+}
+
+TEST(inlet_object_lua, primitive_arrays_as_std_vector_implicit_idx)
+{
+  std::string testString = " arr = { 4, 6, 10}";
+  DataStore ds;
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+
+  // Define schema
+  inlet.addIntArray("arr");
+
+  // Attempt both construction and assignment
+  std::vector<int> expected_arr {4, 6, 10};
+  std::vector<int> arr = inlet["arr"];
+  EXPECT_EQ(arr, expected_arr);
+  arr = inlet["arr"];
+  EXPECT_EQ(arr, expected_arr);
+}
+
+TEST(inlet_object_lua, generic_arrays_as_std_vector_implicit_idx)
+{
+  std::string testString =
+    "foo = { { bar = true; baz = false}, "
+    "        { bar = false; baz = true} }";
+  DataStore ds;
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+
+  auto& arr_table = inlet.addGenericArray("foo");
+
+  arr_table.addBool("bar", "bar's description");
+  arr_table.addBool("baz", "baz's description");
+  std::vector<Foo> expected_foos = {{true, false}, {false, true}};
+  auto foos = inlet["foo"].get<std::vector<Foo>>();
+  EXPECT_EQ(foos, expected_foos);
 }
 
 TEST(inlet_object_lua_dict, dict_of_struct_containing_array)

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -773,6 +773,11 @@ TYPED_TEST(inlet_object, primitive_arrays_as_std_vector)
   EXPECT_EQ(arr, expected_arr);
   arr = inlet["arr"];
   EXPECT_EQ(arr, expected_arr);
+
+  // Also possible to retrieve with indices
+  std::unordered_map<int, int> expected_arr_w_indices {{0, 4}, {1, 6}, {2, 10}};
+  std::unordered_map<int, int> arr_w_indices = inlet["arr"];
+  EXPECT_EQ(arr_w_indices, expected_arr_w_indices);
 }
 
 TYPED_TEST(inlet_object, generic_arrays_as_std_vector)


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following:
  - Adds a method to retrieve `std::vector`s of containers that ignores indices

Inlet currently uses `std::unordered_map<int, T>` as the primary representation for array types, as some `Reader`s support array discontiguous indexing.  In some cases only the contents of the array is useful (i.e., not its indices), so the added method provides a means of obtaining just the values.  Values are returned in ascending order by index.

This approach is more permissive than one that checks for contiguity and errors out accordingly, but since the user is specifically requesting a vector of the contents, I think it is reasonable to not require contiguity as long as the order of the returned vector is guaranteed.