### PR TITLE
Use different filenames for serial and parallel test runs of sidre examples

### DIFF
--- a/src/axom/sidre/examples/sidre_createdatastore.cpp
+++ b/src/axom/sidre/examples/sidre_createdatastore.cpp
@@ -576,6 +576,9 @@ void generate_blueprint_to_path(DataStore* ds)
 #ifdef AXOM_USE_MPI
 void generate_spio_blueprint(DataStore* ds)
 {
+  int comm_size;
+  MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
+
   // _blueprint_spio_toplevel_start
   std::string domain_name = "domain";
   std::string domain_location = "domain_data/" + domain_name;
@@ -612,9 +615,15 @@ void generate_spio_blueprint(DataStore* ds)
   #else
     std::string protocol = "sidre_json";
   #endif
-    std::string bp_rootfile("bpspio.root");
+    std::string output_name = "bpspio";
+    if(comm_size > 1)
+    {
+      output_name = output_name + "_par";
+    }
 
-    writer.write(ds->getRoot()->getGroup(domain_location), 1, "bpspio", protocol);
+    std::string bp_rootfile = output_name + ".root";
+
+    writer.write(ds->getRoot()->getGroup(domain_location), 1, output_name, protocol);
 
     writer.writeBlueprintIndexToRootFile(ds, domain_mesh, bp_rootfile, mesh_name);
   }
@@ -623,6 +632,9 @@ void generate_spio_blueprint(DataStore* ds)
 
 void generate_spio_blueprint_to_path(DataStore* ds)
 {
+  int comm_size;
+  MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
+
   // _blueprint_spio_path_start
   std::string domain_name = "domain";
   std::string domain_location = "domain_data/level/domains/" + domain_name;
@@ -654,14 +666,20 @@ void generate_spio_blueprint_to_path(DataStore* ds)
                                      info,
                                      MPI_COMM_WORLD))
   {
-    std::string bp_rootfile("pathbpspio.root");
+    std::string output_name = "pathbpspio";
+    if(comm_size > 1)
+    {
+      output_name = output_name + "_par";
+    }
+
+    std::string bp_rootfile = output_name + ".root";
   #if defined(AXOM_USE_HDF5)
     std::string protocol = "sidre_hdf5";
   #else
     std::string protocol = "sidre_json";
   #endif
 
-    writer.write(ds->getRoot()->getGroup("domain_data"), 1, "pathbpspio", protocol);
+    writer.write(ds->getRoot()->getGroup("domain_data"), 1, output_name, protocol);
 
     writer.writeBlueprintIndexToRootFile(ds,
                                          domain_mesh,

--- a/src/axom/sidre/examples/sidre_generateindex.cpp
+++ b/src/axom/sidre/examples/sidre_generateindex.cpp
@@ -202,7 +202,7 @@ void generate_spio_blueprint(DataStore* ds, bool dense)
   // dense places domains on all ranks when true. When not true, it
   // leaves off rank zero to show that the index can still be generated
   // with some ranks empty.
-  if(dense || my_rank > 0 || comm_size == 0)
+  if(dense || my_rank > 0 || comm_size == 1)
   {
     Group* mroot = holder->createGroup(domain_name);
     Group* coords = mroot->createGroup("coordsets/coords");
@@ -243,6 +243,12 @@ void generate_spio_blueprint(DataStore* ds, bool dense)
     {
       output_name = "bpsparse";
     }
+
+    if(comm_size > 1)
+    {
+      output_name = output_name + "_par";
+    }
+
     std::string bp_rootfile = output_name + ".root";
 
     writer.write(ds->getRoot()->getGroup("domain_data"), 1, output_name, protocol);


### PR DESCRIPTION


# Summary

- This PR is a bugfix
- It does the following:
  - Adds a "_par" to the filenames used in SPIO output when running the sidre_createdatastore and sidre_generateindex examples in parallel.  This should eliminate the possibility that the serial and parallel runs of these examples might simultaneously write to the same files during regression testing.