### PR TITLE
fix: display type name when primitive type differs from expected

### DIFF
--- a/src/axom/inlet/Field.cpp
+++ b/src/axom/inlet/Field.cpp
@@ -257,11 +257,11 @@ const axom::sidre::View* Field::checkExistenceAndType(
   if(valueView->getTypeID() != expected)
   {
     const std::string msg = fmt::format(
-      "[Inlet] Field with name '{0}' was expected to be of type {1}"
-      " but was actually of type {2}",
+      "[Inlet] Field with name '{0}' was expected to be of type '{1}'"
+      " but was actually of type '{2}'",
       name(),
-      expected,
-      valueView->getTypeID());
+      conduit::DataType::id_to_name(expected),
+      conduit::DataType::id_to_name(valueView->getTypeID()));
     SLIC_ERROR(msg);
   }
 

--- a/src/axom/inlet/Table.cpp
+++ b/src/axom/inlet/Table.cpp
@@ -362,7 +362,7 @@ VerifiableScalar& Table::addPrimitive(const std::string& name,
     axom::sidre::Group* sidreGroup = createSidreGroup(fullName, description);
     SLIC_ERROR_IF(
       sidreGroup == nullptr,
-      fmt::format("Failed to create Sidre group with name {0}", fullName));
+      fmt::format("Failed to create Sidre group with name '{0}'", fullName));
     // If a pathOverride is specified, needed when Inlet-internal groups
     // are part of fullName
     std::string lookupPath = (pathOverride.empty()) ? fullName : pathOverride;
@@ -663,7 +663,7 @@ Verifiable<Function>& Table::addFunction(const std::string& name,
     axom::sidre::Group* sidreGroup = createSidreGroup(fullName, description);
     SLIC_ERROR_IF(
       sidreGroup == nullptr,
-      fmt::format("Failed to create Sidre group with name {0}", fullName));
+      fmt::format("Failed to create Sidre group with name '{0}'", fullName));
     // If a pathOverride is specified, needed when Inlet-internal groups
     // are part of fullName
     std::string lookupPath = (pathOverride.empty()) ? fullName : pathOverride;
@@ -684,7 +684,7 @@ Proxy Table::operator[](const std::string& name) const
   {
     const std::string msg = fmt::format(
       "[Inlet] Ambiguous lookup - more than one of a table/field/function with "
-      "name {0} exist",
+      "name '{0}' exist",
       name);
     SLIC_ERROR(msg);
     return Proxy();
@@ -709,7 +709,7 @@ Proxy Table::operator[](const std::string& name) const
   else
   {
     std::string msg =
-      fmt::format("[Inlet] No table, field, or function with name {0} exists",
+      fmt::format("[Inlet] No table, field, or function with name '{0}' exists",
                   name);
     SLIC_ERROR(msg);
     return Proxy();

--- a/src/axom/inlet/Table.hpp
+++ b/src/axom/inlet/Table.hpp
@@ -776,7 +776,7 @@ public:
       if(!hasTable(name))
       {
         std::string msg =
-          fmt::format("[Inlet] Table with name {0} does not exist", name);
+          fmt::format("[Inlet] Table with name '{0}' does not exist", name);
         SLIC_ERROR(msg);
       }
       return from_inlet(getTable(name));


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Adds more helpful warnings when attempting to retrieve a primitive type that does not match the `sidre::View`'s type
  - Single-quotes names in error messages to avoid ambiguity, e.g., if a user has a field called `name` in their input file:
      `[Inlet] No table, field, or function with name 'name' exists` is clearer than 
      `[Inlet] No table, field, or function with name name exists`

Resolves #443 

`[Inlet] Field with name 'a_simple_int' was expected to be of type 3 but was actually of type 5`
is replaced with
`[Inlet] Field with name 'a_simple_int' was expected to be of type 'int32' but was actually of type 'int8'`
