### PR TITLE
Fix 'make check' segfault and re-enable cppcheck on azure-pipelines

### DIFF
--- a/scripts/azure-pipelines/linux-check.sh
+++ b/scripts/azure-pipelines/linux-check.sh
@@ -42,7 +42,7 @@ echo "~~~~~~~~~~~~~~~~~~~~~~"
 
 
 echo "~~~~~~ RUNNING CMAKE ~~~~~~~~"
-or_die ./config-build.py -hc /home/axom/axom/host-configs/docker/${HOST_CONFIG}.cmake -DENABLE_CPPCHECK=OFF
+or_die ./config-build.py -hc /home/axom/axom/host-configs/docker/${HOST_CONFIG}.cmake
 or_die cd build-$HOST_CONFIG-debug
 echo "~~~~~~ RUNNING make check ~~~~~~~~"
 or_die make VERBOSE=1 check

--- a/src/axom/slam/tests/slam_map_SubMap.cpp
+++ b/src/axom/slam/tests/slam_map_SubMap.cpp
@@ -50,7 +50,9 @@ static PositionType const MAX_SET_SIZE = 10;
 
 TEST(slam_map, construct_empty_subsetmap)
 {
-  SubMap<int, Map<int>> m;
+  using MapType = Map<int>;
+  using SubMapType = SubMap<int, MapType>;
+  SubMapType m;
 
   EXPECT_TRUE(m.isValid(true));
 }


### PR DESCRIPTION
This PR fixes a segfault issue when running 'make check', and re-enables cppcheck on azure-pipelines.

This PR addresses #368 .