### PR TITLE
Nested primitive array lookups must filter their paths

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -71,6 +71,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   target if version is unknown or wrong.
 - Inlet: Apply lambda verifiers on generic containers to individual elements
   for consistency
+- Inlet: Fixed a bug relating to nested table lookups of primitive arrays and functions
 
 
 ## [Version 0.4.0] - Release date 2020-09-22

--- a/src/axom/inlet/Table.cpp
+++ b/src/axom/inlet/Table.cpp
@@ -612,6 +612,8 @@ Verifiable<Table>& Table::addPrimitiveArray(const std::string& name,
       addTable(appendPrefix(name, detail::CONTAINER_GROUP_NAME), description);
     const std::string& fullName = appendPrefix(m_name, name);
     std::string lookupPath = (pathOverride.empty()) ? fullName : pathOverride;
+    lookupPath =
+      removeAllInstances(lookupPath, detail::CONTAINER_GROUP_NAME + "/");
     if(isDict)
     {
       detail::PrimitiveArrayHelper<VariantKey, T>(table, m_reader, lookupPath);
@@ -667,6 +669,8 @@ Verifiable<Function>& Table::addFunction(const std::string& name,
     // If a pathOverride is specified, needed when Inlet-internal groups
     // are part of fullName
     std::string lookupPath = (pathOverride.empty()) ? fullName : pathOverride;
+    lookupPath =
+      removeAllInstances(lookupPath, detail::CONTAINER_GROUP_NAME + "/");
     auto func = m_reader.getFunction(lookupPath, ret_type, arg_types);
     return addFunctionInternal(sidreGroup, std::move(func), fullName, name);
   }

--- a/src/axom/inlet/examples/nested_structs.cpp
+++ b/src/axom/inlet/examples/nested_structs.cpp
@@ -34,6 +34,7 @@ struct Operator
   double x;
   double y;
   double z;
+  Vector origin;
   enum class Type
   {
     Translate,
@@ -58,6 +59,7 @@ struct Operator
     slice.addDouble("x");
     slice.addDouble("y");
     slice.addDouble("z");
+    slice.addDoubleArray("origin");
 
     // Verify that exactly one type of operator is defined
     table.registerVerifier([](const inlet::Table& table) {
@@ -116,6 +118,10 @@ struct FromInlet<Operator>
       {
         result.z = slice["z"];
       }
+      if(slice.contains("origin"))
+      {
+        result.origin = toVector(slice["origin"]);
+      }
     }
     return result;
   }
@@ -139,6 +145,7 @@ std::ostream& operator<<(std::ostream& os, const Operator& op)
     os << fmt::format("      with x-coord: {0}\n", op.x);
     os << fmt::format("      with y-coord: {0}\n", op.y);
     os << fmt::format("      with z-coord: {0}\n", op.z);
+    os << fmt::format("       with origin: {0}\n", op.origin);
     break;
   default:
     SLIC_ERROR("Operator had unknown type");
@@ -282,6 +289,7 @@ shapes:
           center: [4, 5, 6]
         - slice:
             x: 10
+            origin: [40, 50, 60]
         - translate: [5, 6]
   - name: tire
     material: rubber

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -540,6 +540,48 @@ TYPED_TEST(inlet_object, implicit_conversion_primitives)
   EXPECT_EQ(arr, expected_arr);
 }
 
+struct BarWithFooWithArray
+{
+  FooWithArray foo;
+  bool operator==(const BarWithFooWithArray& other) const
+  {
+    return foo == other.foo;
+  }
+};
+
+template <>
+struct FromInlet<BarWithFooWithArray>
+{
+  BarWithFooWithArray operator()(const axom::inlet::Table& base)
+  {
+    BarWithFooWithArray b;
+    b.foo = base["foo"].get<FooWithArray>();
+    return b;
+  }
+};
+
+TYPED_TEST(inlet_object, nested_array_of_struct_containing_array)
+{
+  std::string testString =
+    "bars = { [0] = { foo = { arr = { [0] = 3 }; } }, "
+    "         [1] = { foo = { arr = { [0] = 2 }; } } }";
+  DataStore ds;
+  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+
+  auto& bar_table = inlet.addGenericArray("bars");
+  auto& foo_table = bar_table.addStruct("foo");
+  foo_table.addIntArray("arr", "arr's description");
+
+  // Contiguous indexing for generality
+  std::unordered_map<int, BarWithFooWithArray> expected_bars = {
+    {0, {{{{0, 3}}}}},
+    {1, {{{{0, 2}}}}}};
+  std::unordered_map<int, BarWithFooWithArray> bars_with_foo;
+  bars_with_foo =
+    inlet["bars"].get<std::unordered_map<int, BarWithFooWithArray>>();
+  EXPECT_EQ(bars_with_foo, expected_bars);
+}
+
 struct QuuxWithFooArray
 {
   std::unordered_map<int, Foo> arr;


### PR DESCRIPTION
# Summary

- This PR is a hotfix
- It does the following:
  - Fixes a bug where paths are not filtered before calls to the `Reader` as they already are in `addPrimitive` and `addGenericContainer`
