### PR TITLE
Inlet interface cleanup

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -64,6 +64,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - The `MFEMSidreDataCollection` will now reconstruct fields and the mesh when a
   datastore is `Load` ed in
 - Inlet: Exposed primal::Vector in Lua for use in input-file-defined functions
+- Inlet: Cleaned up `Table` interface to eliminate ambiguity and duplicated functionality
 
 ### Fixed
 - Updated to new BLT version that does not fail when ClangFormat returns an empty

--- a/src/axom/inlet/Field.hpp
+++ b/src/axom/inlet/Field.hpp
@@ -77,7 +77,7 @@ public:
    * \return Pointer to the Sidre Group class for this Field
    *****************************************************************************
    */
-  axom::sidre::Group* sidreGroup() { return m_sidreGroup; };
+  const axom::sidre::Group* sidreGroup() const { return m_sidreGroup; };
 
   /*!
    *****************************************************************************

--- a/src/axom/inlet/Inlet.cpp
+++ b/src/axom/inlet/Inlet.cpp
@@ -23,11 +23,6 @@ namespace axom
 {
 namespace inlet
 {
-Table& Inlet::addTable(const std::string& name, const std::string& description)
-{
-  return m_globalTable.addTable(name, description);
-}
-
 Table& Inlet::addStruct(const std::string& name, const std::string& description)
 {
   return m_globalTable.addStruct(name, description);

--- a/src/axom/inlet/Inlet.hpp
+++ b/src/axom/inlet/Inlet.hpp
@@ -104,23 +104,6 @@ public:
 
   /*!
    *****************************************************************************
-   * \brief Add a Table to the input file schema.
-   *
-   * Adds a Table to the input file schema. Tables hold a varying amount Fields
-   * defined by the user.  By default, it is not required unless marked with
-   * Table::isRequired(). This creates the Sidre Group class with the given name and
-   * stores the given description.
-   *
-   * \param [in] name Name of the Table expected in the input file
-   * \param [in] description Description of the Table
-   *
-   * \return Reference to the created Table
-   *****************************************************************************
-   */
-  Table& addTable(const std::string& name, const std::string& description = "");
-
-  /*!
-   *****************************************************************************
    * \brief Add a structure to the input file schema.
    *
    * Adds a structure/record to the input file schema. Structures can contain
@@ -304,82 +287,6 @@ public:
    *****************************************************************************
    */
   Table& getGlobalTable() { return m_globalTable; }
-
-  /*!
-   *****************************************************************************
-   * \brief Retrieves the matching Table.
-   * 
-   * \param [in] The string indicating the target name of the Table to be searched for.
-   * 
-   * \return The Table matching the target name. If no such Table is found,
-   * a nullptr is returned.
-   *****************************************************************************
-   */
-  Table& getTable(const std::string& name) const
-  {
-    return m_globalTable.getTable(name);
-  }
-
-  /*!
-   *****************************************************************************
-   * \brief Retrieves the matching Field.
-   * 
-   * \param [in] The string indicating the target name of the Field to be searched for.
-   * 
-   * \return The child Field matching the target name. If no such Field is found,
-   * a nullptr is returned.
-   *****************************************************************************
-   */
-  Field& getField(const std::string& name) const
-  {
-    return m_globalTable.getField(name);
-  }
-
-  /*!
-   *****************************************************************************
-   * \brief Return whether a Table with the given name is present in Inlet.
-   *
-   * \return Boolean value indicating whether this Inlet contains the Table.
-   *****************************************************************************
-   */
-  bool hasTable(const std::string& name) const
-  {
-    return m_globalTable.hasTable(name);
-  }
-
-  /*!
-   *****************************************************************************
-   * \brief Return whether a Field with the given name is present in Inlet.
-   *
-   * \return Boolean value indicating whether this Inlet contains the Field.
-   *****************************************************************************
-   */
-  bool hasField(const std::string& name) const
-  {
-    return m_globalTable.hasField(name);
-  }
-
-  /*!
-   *****************************************************************************
-   * \return An unordered map from Field names to the child Field pointers for 
-   * this Table.
-   *****************************************************************************
-   */
-  const std::unordered_map<std::string, std::unique_ptr<Field>>& getChildFields() const
-  {
-    return m_globalTable.getChildFields();
-  }
-
-  /*!
-   *****************************************************************************
-   * \return An unordered map from Table names to the child Table pointers for 
-   * this Table.
-   *****************************************************************************
-   */
-  const std::unordered_map<std::string, std::unique_ptr<Table>>& getChildTables() const
-  {
-    return m_globalTable.getChildTables();
-  }
 
   /*!
    *****************************************************************************

--- a/src/axom/inlet/Inlet.hpp
+++ b/src/axom/inlet/Inlet.hpp
@@ -445,23 +445,6 @@ public:
     return m_globalTable.addStringArray(name, description);
   }
 
-  // FIXME: Remove in future PR
-  /*!
-   *****************************************************************************
-   * \brief Add an array of user-defined types to the input file schema.
-   *
-   * \param [in] name Name of the array
-   * \param [in] description Description of the array
-   *
-   * \return Reference to the created array
-   *****************************************************************************
-   */
-  Table& addGenericArray(const std::string& name,
-                         const std::string& description = "")
-  {
-    return m_globalTable.addGenericArray(name, description);
-  }
-
   /*!
    *****************************************************************************
    * \brief Add an array of user-defined type to the input file schema.
@@ -559,23 +542,6 @@ public:
                                          const std::string& description = "")
   {
     return m_globalTable.addStringDictionary(name, description);
-  }
-
-  // FIXME: Remove in future PR
-  /*!
-   *****************************************************************************
-   * \brief Add a dictionary of user-defined types to the input file schema.
-   *
-   * \param [in] name Name of the dict
-   * \param [in] description Description of the dictionary
-   *
-   * \return Reference to the created dictionary
-   *****************************************************************************
-   */
-  Table& addGenericDictionary(const std::string& name,
-                              const std::string& description = "")
-  {
-    return m_globalTable.addGenericDictionary(name, description);
   }
 
   /*!

--- a/src/axom/inlet/Proxy.cpp
+++ b/src/axom/inlet/Proxy.cpp
@@ -15,7 +15,7 @@ InletType Proxy::type() const
   if(m_table != nullptr)
   {
     // This is how Inlet stores array types in the datastore
-    if(m_table->hasTable(detail::CONTAINER_GROUP_NAME))
+    if(m_table->contains(detail::CONTAINER_GROUP_NAME))
     {
       return InletType::Container;
     }
@@ -47,6 +47,49 @@ Proxy Proxy::operator[](const std::string& name) const
     SLIC_ERROR("[Inlet] Cannot index a proxy that refers to a field");
   }
   return (*m_table)[name];
+}
+
+const axom::sidre::Group* Proxy::sidreGroup() const
+{
+  if(m_table != nullptr)
+  {
+    return m_table->sidreGroup();
+  }
+  else if(m_field != nullptr)
+  {
+    return m_field->sidreGroup();
+  }
+  else if(m_func != nullptr)
+  {
+    SLIC_ERROR("[Inlet] Cannot retrieve the sidre::Group for a Function");
+  }
+  else
+  {
+    SLIC_ERROR("[Inlet] Cannot retrieve the sidre::Group of an empty Proxy");
+  }
+  return nullptr;
+}
+
+std::string Proxy::name() const
+{
+  // FIXME: With C++14 we can implement a visit() method that takes a generic lambda
+  if(m_table != nullptr)
+  {
+    return m_table->name();
+  }
+  else if(m_field != nullptr)
+  {
+    return m_field->name();
+  }
+  else if(m_func != nullptr)
+  {
+    return m_func->name();
+  }
+  else
+  {
+    SLIC_ERROR("[Inlet] Cannot retrieve the name of an empty Proxy");
+  }
+  return "";
 }
 
 }  // end namespace inlet

--- a/src/axom/inlet/Proxy.hpp
+++ b/src/axom/inlet/Proxy.hpp
@@ -45,7 +45,7 @@ public:
    * \param [in] table The table to construct a proxy into
    *******************************************************************************
    */
-  Proxy(Table& table) : m_table(&table) { }
+  Proxy(const Table& table) : m_table(&table) { }
 
   /*!
    *******************************************************************************
@@ -54,7 +54,7 @@ public:
    * \param [in] field The field to construct a proxy into
    *******************************************************************************
    */
-  Proxy(Field& field) : m_field(&field) { }
+  Proxy(const Field& field) : m_field(&field) { }
 
   /*!
    *******************************************************************************
@@ -63,7 +63,7 @@ public:
    * \param [in] func The function to construct a proxy into
    *******************************************************************************
    */
-  Proxy(Function& func) : m_func(&func) { }
+  Proxy(const Function& func) : m_func(&func) { }
 
   /*!
    *******************************************************************************
@@ -121,6 +121,23 @@ public:
    *******************************************************************************
    */
   Proxy operator[](const std::string& name) const;
+
+  /*!
+   *****************************************************************************
+   * \brief Returns pointer to the Sidre Group for the underlying object
+   *
+   * Provides access to the Sidre Group class that holds all the stored
+   * information for the underlying object.
+   *****************************************************************************
+   */
+  const axom::sidre::Group* sidreGroup() const;
+
+  /*!
+   *****************************************************************************
+   * \return The full name for the underlying object.
+   *****************************************************************************
+  */
+  std::string name() const;
 
   /*!
    *******************************************************************************
@@ -201,9 +218,9 @@ public:
   }
 
 private:
-  Table* m_table = nullptr;
-  Field* m_field = nullptr;
-  Function* m_func = nullptr;
+  const Table* const m_table = nullptr;
+  const Field* const m_field = nullptr;
+  const Function* const m_func = nullptr;
 };
 
 }  // end namespace inlet

--- a/src/axom/inlet/Table.cpp
+++ b/src/axom/inlet/Table.cpp
@@ -718,9 +718,9 @@ Proxy Table::operator[](const std::string& name) const
 
 Table& Table::required(bool isRequired)
 {
-  // If it's a generic container we set the individual fields as required,
+  // If it's a struct container we set the individual fields as required,
   // and also the container table itself, as the user would expect that marking
-  // a generic container as required means that it is non-empty
+  // a struct container as required means that it is non-empty
   if(isStructContainer())
   {
     forEachContainerElement(

--- a/src/axom/inlet/Table.cpp
+++ b/src/axom/inlet/Table.cpp
@@ -210,7 +210,7 @@ Table& Table::addStructContainer(const std::string& name,
     fullName = removeAllInstances(fullName, detail::CONTAINER_GROUP_NAME + "/");
     if(m_reader.getIndices(fullName, indices))
     {
-      detail::addIndicesGroupToTable(table, indices, description);
+      table.addIndicesGroup(indices, description);
     }
     markAsStructContainer(*table.m_sidreGroup);
   }
@@ -553,27 +553,27 @@ void addIndexViewToGroup(sidre::Group& group, const VariantKey& index)
   }
 }
 
+}  // end namespace detail
+
 template <typename Key>
-void addIndicesGroupToTable(Table& table,
-                            const std::vector<Key>& indices,
+void Table::addIndicesGroup(const std::vector<Key>& indices,
                             const std::string& description)
 {
   sidre::Group* indices_group =
-    table.sidreGroup()->createGroup(CONTAINER_INDICES_NAME,
-                                    /* list_format = */ true);
+    m_sidreGroup->createGroup(detail::CONTAINER_INDICES_NAME,
+                              /* list_format = */ true);
   // For each index, add a table whose name is its index
   // Schema for struct is defined using the returned table
   for(const auto& idx : indices)
   {
-    const std::string string_idx = removeBeforeDelimiter(indexToString(idx));
-    table.addTable(string_idx, description);
-    std::string absolute = appendPrefix(table.name(), indexToString(idx));
+    const std::string string_idx =
+      removeBeforeDelimiter(detail::indexToString(idx));
+    addTable(string_idx, description);
+    std::string absolute = appendPrefix(m_name, detail::indexToString(idx));
     absolute = removeAllInstances(absolute, detail::CONTAINER_GROUP_NAME + "/");
-    addIndexViewToGroup(*indices_group, absolute);
+    detail::addIndexViewToGroup(*indices_group, absolute);
   }
 }
-
-}  // end namespace detail
 
 template <typename T, typename SFINAE>
 Verifiable<Table>& Table::addPrimitiveArray(const std::string& name,
@@ -624,7 +624,7 @@ Verifiable<Table>& Table::addPrimitiveArray(const std::string& name,
     std::vector<VariantKey> indices;
     if(m_reader.getIndices(lookupPath, indices))
     {
-      detail::addIndicesGroupToTable(table, indices, description);
+      table.addIndicesGroup(indices, description);
     }
     return table;
   }

--- a/src/axom/inlet/Table.cpp
+++ b/src/axom/inlet/Table.cpp
@@ -217,8 +217,8 @@ Table& Table::addGenericContainer(const std::string& name,
   return table;
 }
 
-Table& Table::addGenericArray(const std::string& name,
-                              const std::string& description)
+Table& Table::addStructArray(const std::string& name,
+                             const std::string& description)
 {
   return addGenericContainer<int>(name, description);
 }
@@ -247,8 +247,8 @@ Verifiable<Table>& Table::addStringDictionary(const std::string& name,
   return addPrimitiveArray<std::string>(name, description, true);
 }
 
-Table& Table::addGenericDictionary(const std::string& name,
-                                   const std::string& description)
+Table& Table::addStructDictionary(const std::string& name,
+                                  const std::string& description)
 {
   return addGenericContainer<VariantKey>(name, description);
 }

--- a/src/axom/inlet/Table.hpp
+++ b/src/axom/inlet/Table.hpp
@@ -1192,8 +1192,8 @@ private:
    *****************************************************************************
    */
   template <typename Key>
-  Table& addGenericContainer(const std::string& name,
-                             const std::string& description = "");
+  Table& addStructContainer(const std::string& name,
+                            const std::string& description = "");
 
   /*!
    *****************************************************************************
@@ -1201,7 +1201,7 @@ private:
    * i.e., an array or dictionary of user-defined type
    *****************************************************************************
    */
-  bool isGenericContainer() const
+  bool isStructContainer() const
   {
     return m_sidreGroup->hasView(detail::GENERIC_CONTAINER_FLAG);
   }
@@ -1213,7 +1213,7 @@ private:
    * 
    * \param [in] func The function to apply to individual container elements
    * 
-   * \pre The calling table must be a generic container, i.e., isGenericContainer()
+   * \pre The calling table must be a generic container, i.e., isStructContainer()
    * returns true
    * 
    * \pre The function must accept a single argument of type Table&

--- a/src/axom/inlet/Table.hpp
+++ b/src/axom/inlet/Table.hpp
@@ -243,22 +243,6 @@ inline int toIndex(const std::string& idx)
 
 /*!
  *******************************************************************************
- * \brief Adds a group containing the indices of a container to a table, and a 
- * subtable for each index
- * 
- * \param [inout] table The table to add to
- * \param [in] indices The indices to add
- * \param [in] description The optional description of the subtables
- * \tparam Key The type of the indices to add
- *******************************************************************************
- */
-template <typename Key>
-void addIndicesGroupToTable(Table& table,
-                            const std::vector<Key>& indices,
-                            const std::string& description = "");
-
-/*!
- *******************************************************************************
  * \brief Determines whether a variant key is convertible to another type
  * 
  * \tparam Key The type to check the validity of the conversion to
@@ -375,29 +359,11 @@ public:
    * \return Pointer to the Sidre Group for this Table
    *****************************************************************************
    */
-  axom::sidre::Group* sidreGroup() { return m_sidreGroup; };
+  const axom::sidre::Group* sidreGroup() const { return m_sidreGroup; };
 
   //
   // Functions that define the input file schema
   //
-
-  // FIXME: Make private in future PR
-  /*!
-   *****************************************************************************
-   * \brief Add a Table to the input file schema.
-   *
-   * Adds a Table to the input file schema. Tables hold a varying amount Fields
-   * defined by the user.  By default, it is not required unless marked with
-   * Table::isRequired(). This creates the Sidre Group class with the given name and
-   * stores the given description.
-   *
-   * \param [in] name Name of the Table expected in the input file
-   * \param [in] description Description of the Table
-   *
-   * \return Reference to the created Table
-   *****************************************************************************
-   */
-  Table& addTable(const std::string& name, const std::string& description = "");
 
   /*!
    *****************************************************************************
@@ -628,58 +594,6 @@ public:
 
   /*!
    *****************************************************************************
-   * \brief Add a Field to the input file schema.
-   *
-   * Adds a Field to the input file schema. It may or may not be required
-   * to be present in the input file. This creates the Sidre Group class with the
-   * given name and stores the given description. If present in the input file the
-   * value is read and stored in the datastore. 
-   *
-   * \param [in] name Name of the Table expected in the input file
-   * \param [in] description Description of the Table
-   * \param [in] forArray Whether the primitive is in an array, in which
-   * case the provided value should be inserted instead of the one read from
-   * the input file
-   * \param [in] val A provided value, will be overwritten if found at specified
-   * path in input file
-   * \param [in] pathOverride The path within the input file to read from, if
-   * different than the structure of the Sidre datastore
-   *
-   * \return Reference to the created Field
-   *****************************************************************************
-   */
-  template <typename T,
-            typename SFINAE =
-              typename std::enable_if<detail::is_inlet_primitive<T>::value>::type>
-  VerifiableScalar& addPrimitive(const std::string& name,
-                                 const std::string& description = "",
-                                 bool forArray = false,
-                                 T val = T {},
-                                 const std::string& pathOverride = "");
-
-  /*!
-   *****************************************************************************
-   * \brief Add an array of primitive Fields to the input file schema.
-   *
-   * \param [in] name Name of the array
-   * \param [in] description Description of the Field
-   * \param [in] isDict Whether to use string-valued keys for the container
-   * \param [in] pathOverride The path within the input file to read from, if
-   * different than the structure of the Sidre datastore
-   *
-   * \return Reference to the created Field
-   *****************************************************************************
-   */
-  template <typename T,
-            typename SFINAE =
-              typename std::enable_if<detail::is_inlet_primitive<T>::value>::type>
-  Verifiable<Table>& addPrimitiveArray(const std::string& name,
-                                       const std::string& description = "",
-                                       const bool isDict = false,
-                                       const std::string& pathOverride = "");
-
-  /*!
-   *****************************************************************************
    * \brief Get a function from the input deck
    *
    * \param [in] name         Name of the function
@@ -903,35 +817,6 @@ public:
 
   /*!
    *****************************************************************************
-   * \brief Return whether a Table with the given name is present in this Table's subtree.
-   *
-   * \return Boolean value indicating whether this Table's subtree contains this Table.
-   *****************************************************************************
-   */
-  bool hasTable(const std::string& tableName) const;
-
-  /*!
-   *****************************************************************************
-   * \brief Return whether a Field with the given name is present in this Table's
-   *  subtree.
-   *
-   * \return Boolean value indicating whether this Table's subtree contains this Field.
-   *****************************************************************************
-   */
-  bool hasField(const std::string& fieldName) const;
-
-  /*!
-   *****************************************************************************
-   * \brief Return whether a Function with the given name is present in this Table's
-   *  subtree.
-   *
-   * \return Boolean value indicating whether this Table's subtree contains this Function.
-   *****************************************************************************
-   */
-  bool hasFunction(const std::string& fieldName) const;
-
-  /*!
-   *****************************************************************************
    * \brief Return whether a Table or Field with the given name is present in 
    * this Table's subtree.
    *
@@ -974,6 +859,106 @@ public:
 
   /*!
    *****************************************************************************
+   * \brief Add a Field to the input file schema.
+   *
+   * Adds a Field to the input file schema. It may or may not be required
+   * to be present in the input file. This creates the Sidre Group class with the
+   * given name and stores the given description. If present in the input file the
+   * value is read and stored in the datastore. 
+   *
+   * \param [in] name Name of the Table expected in the input file
+   * \param [in] description Description of the Table
+   * \param [in] forArray Whether the primitive is in an array, in which
+   * case the provided value should be inserted instead of the one read from
+   * the input file
+   * \param [in] val A provided value, will be overwritten if found at specified
+   * path in input file
+   * \param [in] pathOverride The path within the input file to read from, if
+   * different than the structure of the Sidre datastore
+   *
+   * \return Reference to the created Field
+   *****************************************************************************
+   */
+
+  template <typename T,
+            typename SFINAE =
+              typename std::enable_if<detail::is_inlet_primitive<T>::value>::type>
+  VerifiableScalar& addPrimitive(const std::string& name,
+                                 const std::string& description = "",
+                                 bool forArray = false,
+                                 T val = T {},
+                                 const std::string& pathOverride = "");
+
+private:
+  /*!
+   *****************************************************************************
+   * \brief Add a Table to the input file schema.
+   *
+   * Adds a Table to the input file schema. Tables hold a varying amount Fields
+   * defined by the user.  By default, it is not required unless marked with
+   * Table::isRequired(). This creates the Sidre Group class with the given name and
+   * stores the given description.
+   *
+   * \param [in] name Name of the Table expected in the input file
+   * \param [in] description Description of the Table
+   *
+   * \return Reference to the created Table
+   *****************************************************************************
+   */
+  Table& addTable(const std::string& name, const std::string& description = "");
+
+  /*!
+   *****************************************************************************
+   * \brief Add an array of primitive Fields to the input file schema.
+   *
+   * \param [in] name Name of the array
+   * \param [in] description Description of the Field
+   * \param [in] isDict Whether to use string-valued keys for the container
+   * \param [in] pathOverride The path within the input file to read from, if
+   * different than the structure of the Sidre datastore
+   *
+   * \return Reference to the created Field
+   *****************************************************************************
+   */
+  template <typename T,
+            typename SFINAE =
+              typename std::enable_if<detail::is_inlet_primitive<T>::value>::type>
+  Verifiable<Table>& addPrimitiveArray(const std::string& name,
+                                       const std::string& description = "",
+                                       const bool isDict = false,
+                                       const std::string& pathOverride = "");
+
+  /*!
+   *****************************************************************************
+   * \brief Return whether a Table with the given name is present in this Table's subtree.
+   *
+   * \return Boolean value indicating whether this Table's subtree contains this Table.
+   *****************************************************************************
+   */
+  bool hasTable(const std::string& tableName) const;
+
+  /*!
+   *****************************************************************************
+   * \brief Return whether a Field with the given name is present in this Table's
+   *  subtree.
+   *
+   * \return Boolean value indicating whether this Table's subtree contains this Field.
+   *****************************************************************************
+   */
+  bool hasField(const std::string& fieldName) const;
+
+  /*!
+   *****************************************************************************
+   * \brief Return whether a Function with the given name is present in this Table's
+   *  subtree.
+   *
+   * \return Boolean value indicating whether this Table's subtree contains this Function.
+   *****************************************************************************
+   */
+  bool hasFunction(const std::string& fieldName) const;
+
+  /*!
+   *****************************************************************************
    * \brief Retrieves the matching Table.
    * 
    * \param [in] The string indicating the target name of the Table to be searched for.
@@ -1005,7 +990,6 @@ public:
    */
   Function& getFunction(const std::string& funcName) const;
 
-private:
   /*!
    *****************************************************************************
    * \brief Helper method template for adding primitives
@@ -1180,6 +1164,20 @@ private:
     }
     return map;
   }
+
+  /*!
+   *******************************************************************************
+   * \brief Adds a group containing the indices of a container to the calling 
+   * table, and a subtable for each index
+   * 
+   * \param [in] indices The indices to add
+   * \param [in] description The optional description of the subtables
+   * \tparam Key The type of the indices to add
+   *******************************************************************************
+   */
+  template <typename Key>
+  void addIndicesGroup(const std::vector<Key>& indices,
+                       const std::string& description = "");
 
   /*!
    *****************************************************************************

--- a/src/axom/inlet/Table.hpp
+++ b/src/axom/inlet/Table.hpp
@@ -468,7 +468,6 @@ public:
   Verifiable<Table>& addStringArray(const std::string& name,
                                     const std::string& description = "");
 
-  // FIXME: Remove in future PR
   /*!
    *****************************************************************************
    * \brief Add an array of Fields to the input file schema.
@@ -479,25 +478,8 @@ public:
    * \return Reference to the created array
    *****************************************************************************
    */
-  Table& addGenericArray(const std::string& name,
-                         const std::string& description = "");
-
-  /*!
-   *****************************************************************************
-   * \brief Add an array of user-defined type to the input file schema.
-   *
-   * \param [in] name Name of the array
-   * \param [in] description Description of the array
-   *
-   * \return Reference to the created array
-   *****************************************************************************
-   */
   Table& addStructArray(const std::string& name,
-                        const std::string& description = "")
-  {
-    return addGenericArray(name, description);
-  }
-
+                        const std::string& description = "");
   /*!
    *****************************************************************************
    * \brief Add a dictionary of Boolean Fields to the input file schema.
@@ -549,7 +531,6 @@ public:
   Verifiable<Table>& addStringDictionary(const std::string& name,
                                          const std::string& description = "");
 
-  // FIXME: Remove in future PR
   /*!
    *****************************************************************************
    * \brief Add a dictionary of user-defined types to the input file schema.
@@ -560,25 +541,8 @@ public:
    * \return Reference to the created dictionary
    *****************************************************************************
    */
-  Table& addGenericDictionary(const std::string& name,
-                              const std::string& description = "");
-
-  /*!
-   *****************************************************************************
-   * \brief Add an dictionary of user-defined type to the input file schema.
-   *
-   * \param [in] name Name of the dictionary
-   * \param [in] description Description of the dictionary
-   *
-   * \return Reference to the created dictionary
-   *****************************************************************************
-   */
   Table& addStructDictionary(const std::string& name,
-                             const std::string& description = "")
-  {
-    return addGenericDictionary(name, description);
-  }
-
+                             const std::string& description = "");
   /*!
    *****************************************************************************
    * \brief Add a Boolean Field to the input file schema.

--- a/src/axom/inlet/Table.hpp
+++ b/src/axom/inlet/Table.hpp
@@ -861,7 +861,7 @@ public:
    *****************************************************************************
    * \brief Add a Field to the input file schema.
    *
-   * Adds a Field to the input file schema. It may or may not be required
+   * Adds a primitive Field to the input file schema. It may or may not be required
    * to be present in the input file. This creates the Sidre Group class with the
    * given name and stores the given description. If present in the input file the
    * value is read and stored in the datastore. 
@@ -932,7 +932,8 @@ private:
    *****************************************************************************
    * \brief Return whether a Table with the given name is present in this Table's subtree.
    *
-   * \return Boolean value indicating whether this Table's subtree contains this Table.
+   * \return Boolean value indicating whether the calling Table's subtree
+   * contains a Table with the given name.
    *****************************************************************************
    */
   bool hasTable(const std::string& tableName) const;
@@ -942,7 +943,8 @@ private:
    * \brief Return whether a Field with the given name is present in this Table's
    *  subtree.
    *
-   * \return Boolean value indicating whether this Table's subtree contains this Field.
+   * \return Boolean value indicating whether the calling Table's subtree
+   * contains a Field with the given name.
    *****************************************************************************
    */
   bool hasField(const std::string& fieldName) const;
@@ -952,7 +954,8 @@ private:
    * \brief Return whether a Function with the given name is present in this Table's
    *  subtree.
    *
-   * \return Boolean value indicating whether this Table's subtree contains this Function.
+   * \return Boolean value indicating whether the calling Table's subtree
+   * contains a Function with the given name.
    *****************************************************************************
    */
   bool hasFunction(const std::string& fieldName) const;
@@ -1168,7 +1171,7 @@ private:
   /*!
    *******************************************************************************
    * \brief Adds a group containing the indices of a container to the calling 
-   * table, and a subtable for each index
+   * table and a subtable for each index
    * 
    * \param [in] indices The indices to add
    * \param [in] description The optional description of the subtables
@@ -1195,13 +1198,13 @@ private:
 
   /*!
    *****************************************************************************
-   * \brief Returns true if the calling object is part of a generic container,
+   * \brief Returns true if the calling object is part of a struct container,
    * i.e., an array or dictionary of user-defined type
    *****************************************************************************
    */
   bool isStructContainer() const
   {
-    return m_sidreGroup->hasView(detail::GENERIC_CONTAINER_FLAG);
+    return m_sidreGroup->hasView(detail::STRUCT_CONTAINER_FLAG);
   }
 
   /*!
@@ -1211,7 +1214,7 @@ private:
    * 
    * \param [in] func The function to apply to individual container elements
    * 
-   * \pre The calling table must be a generic container, i.e., isStructContainer()
+   * \pre The calling table must be a struct container, i.e., isStructContainer()
    * returns true
    * 
    * \pre The function must accept a single argument of type Table&
@@ -1239,7 +1242,7 @@ private:
   std::vector<AggregateField> m_aggregate_fields;
   std::vector<AggregateVerifiable<Function>> m_aggregate_funcs;
 
-  // Used when the calling Table is a generic container within a generic container
+  // Used when the calling Table is a struct container within a struct container
   // Need to delegate schema-defining calls (add*) to the elements of the nested
   // container
   std::vector<std::reference_wrapper<Table>> m_nested_aggregates;

--- a/src/axom/inlet/examples/documentation_generation.cpp
+++ b/src/axom/inlet/examples/documentation_generation.cpp
@@ -99,43 +99,44 @@ void defineSchema(Inlet& inlet)
     .addDouble("thermal_solver/kappa/constant", "description for kappa constant")
     .required();
 
-  // Add description to solver table by using the addTable function
-  auto& table =
-    inlet.addTable("thermal_solver/solver",
-                   "This is the solver sub-table in the thermal_solver table");
+  // Add description to solver table by using the addStruct function
+  auto& solver_schema =
+    inlet.addStruct("thermal_solver/solver",
+                    "This is the solver sub-table in the thermal_solver table");
 
   // You can also add fields through a table
 
   auto& rel_tol_field =
-    table.addDouble("rel_tol", "description for solver rel tol");
+    solver_schema.addDouble("rel_tol", "description for solver rel tol");
   rel_tol_field.required(false);
   rel_tol_field.defaultValue(1.e-6);
   rel_tol_field.range(0.0, std::numeric_limits<double>::max());
 
   auto& abs_tol_field =
-    table.addDouble("abs_tol", "description for solver abs tol");
+    solver_schema.addDouble("abs_tol", "description for solver abs tol");
   abs_tol_field.required(true);
   abs_tol_field.defaultValue(1.e-12);
   abs_tol_field.range(0.0, std::numeric_limits<double>::max());
 
   auto& print_level_field =
-    table.addInt("print_level", "description for solver print level");
+    solver_schema.addInt("print_level", "description for solver print level");
   print_level_field.required(true);
   print_level_field.defaultValue(0);
   print_level_field.range(0, 3);
 
   auto& max_iter_field =
-    table.addInt("max_iter", "description for solver max iter");
+    solver_schema.addInt("max_iter", "description for solver max iter");
   max_iter_field.required(false);
   max_iter_field.defaultValue(100);
   max_iter_field.range(1, std::numeric_limits<int>::max());
 
-  auto& dt_field = table.addDouble("dt", "description for solver dt");
+  auto& dt_field = solver_schema.addDouble("dt", "description for solver dt");
   dt_field.required(true);
   dt_field.defaultValue(1);
   dt_field.range(0.0, std::numeric_limits<double>::max());
 
-  auto& steps_field = table.addInt("steps", "description for solver steps");
+  auto& steps_field =
+    solver_schema.addInt("steps", "description for solver steps");
   steps_field.required(true);
   steps_field.defaultValue(1);
   steps_field.range(1, std::numeric_limits<int>::max());

--- a/src/axom/inlet/examples/mfem_coefficient.cpp
+++ b/src/axom/inlet/examples/mfem_coefficient.cpp
@@ -175,8 +175,8 @@ int main(int argc, char** argv)
   Inlet inlet(std::move(lr), ds.getRoot());
 
   // We only need the boundary condition sub-table
-  auto& bc_table = inlet.addStructArray("bcs", "List of boundary conditions");
-  BoundaryCondition::defineSchema(bc_table);
+  auto& bc_schema = inlet.addStructArray("bcs", "List of boundary conditions");
+  BoundaryCondition::defineSchema(bc_schema);
 
   if(!inlet.verify())
   {

--- a/src/axom/inlet/examples/mfem_coefficient.cpp
+++ b/src/axom/inlet/examples/mfem_coefficient.cpp
@@ -175,7 +175,7 @@ int main(int argc, char** argv)
   Inlet inlet(std::move(lr), ds.getRoot());
 
   // We only need the boundary condition sub-table
-  auto& bc_table = inlet.addGenericArray("bcs", "List of boundary conditions");
+  auto& bc_table = inlet.addStructArray("bcs", "List of boundary conditions");
   BoundaryCondition::defineSchema(bc_table);
 
   if(!inlet.verify())

--- a/src/axom/inlet/examples/tables.cpp
+++ b/src/axom/inlet/examples/tables.cpp
@@ -56,14 +56,14 @@ int main()
 
   // Define and store the values in the input file
   // _inlet_simple_types_tables_add_start
-  auto& driver_table = inlet.addTable("driver", "A description of driver");
-  driver_table.addString("name", "Name of driver");
+  auto& driver_schema = inlet.addStruct("driver", "A description of driver");
+  driver_schema.addString("name", "Name of driver");
 
-  auto& car_table = driver_table.addTable("car", "Car of driver");
-  car_table.addString("make", "Make of car");
-  car_table.addString("color", "Color of car").defaultValue("red");
-  car_table.addInt("seats", "Number of seats");
-  car_table.addInt("horsepower", "Amount of horsepower");
+  auto& car_schema = driver_schema.addStruct("car", "Car of driver");
+  car_schema.addString("make", "Make of car");
+  car_schema.addString("color", "Color of car").defaultValue("red");
+  car_schema.addInt("seats", "Number of seats");
+  car_schema.addInt("horsepower", "Amount of horsepower");
   // _inlet_simple_types_tables_add_end
 
   // Access values stored in the Datastore via Inlet

--- a/src/axom/inlet/examples/user_defined_type.cpp
+++ b/src/axom/inlet/examples/user_defined_type.cpp
@@ -196,7 +196,7 @@ struct ThermalSolver
     // Schema only needs to be defined once, will propagate through to each
     // element of the array, namely, the subtable at each found index in the input file
     auto& bc_table =
-      schema.addGenericDictionary("bcs", "List of boundary conditions");
+      schema.addStructDictionary("bcs", "List of boundary conditions");
     BoundaryCondition::defineSchema(bc_table);
     // _inlet_userdef_array_usage_end
   }

--- a/src/axom/inlet/examples/user_defined_type.cpp
+++ b/src/axom/inlet/examples/user_defined_type.cpp
@@ -195,9 +195,9 @@ struct ThermalSolver
     // _inlet_userdef_array_usage_start
     // Schema only needs to be defined once, will propagate through to each
     // element of the array, namely, the subtable at each found index in the input file
-    auto& bc_table =
+    auto& bc_schema =
       schema.addStructDictionary("bcs", "List of boundary conditions");
-    BoundaryCondition::defineSchema(bc_table);
+    BoundaryCondition::defineSchema(bc_schema);
     // _inlet_userdef_array_usage_end
   }
 };

--- a/src/axom/inlet/examples/verification.cpp
+++ b/src/axom/inlet/examples/verification.cpp
@@ -24,7 +24,7 @@ int main()
   myInlet.addInt("dimensions").required(true).defaultValue(2);
 
   // defines a required table named vector with an internal field named 'x'
-  auto& v = myInlet.addTable("vector").required(true);
+  auto& v = myInlet.addStruct("vector").required(true);
   v.addDouble("x");
   // _inlet_workflow_defining_schema_end
 

--- a/src/axom/inlet/inlet_utils.cpp
+++ b/src/axom/inlet/inlet_utils.cpp
@@ -142,7 +142,7 @@ bool checkedConvertToInt(const std::string& number, int& result)
   return *ptr == 0;
 }
 
-void markAsGenericContainer(axom::sidre::Group& target)
+void markAsStructContainer(axom::sidre::Group& target)
 {
   if(target.hasView(detail::GENERIC_CONTAINER_FLAG))
   {

--- a/src/axom/inlet/inlet_utils.cpp
+++ b/src/axom/inlet/inlet_utils.cpp
@@ -144,24 +144,24 @@ bool checkedConvertToInt(const std::string& number, int& result)
 
 void markAsStructContainer(axom::sidre::Group& target)
 {
-  if(target.hasView(detail::GENERIC_CONTAINER_FLAG))
+  if(target.hasView(detail::STRUCT_CONTAINER_FLAG))
   {
     // This flag should only ever be one, so we verify that and error otherwise
-    const sidre::View* flag = target.getView(detail::GENERIC_CONTAINER_FLAG);
+    const sidre::View* flag = target.getView(detail::STRUCT_CONTAINER_FLAG);
     SLIC_ERROR_IF(
       !flag->isScalar(),
       fmt::format(
-        "[Inlet] Generic container flag of group '{0}' was not a scalar",
+        "[Inlet] Struct container flag of group '{0}' was not a scalar",
         target.getName()));
     const int8 value = flag->getScalar();
     SLIC_ERROR_IF(value != 1,
-                  fmt::format("[Inlet] Generic container flag of group '{0}' "
+                  fmt::format("[Inlet] Struct container flag of group '{0}' "
                               "had a value other than 1",
                               target.getName()));
   }
   else
   {
-    target.createViewScalar(detail::GENERIC_CONTAINER_FLAG, static_cast<int8>(1));
+    target.createViewScalar(detail::STRUCT_CONTAINER_FLAG, static_cast<int8>(1));
   }
 }
 

--- a/src/axom/inlet/inlet_utils.hpp
+++ b/src/axom/inlet/inlet_utils.hpp
@@ -149,7 +149,7 @@ namespace detail
   */
 const std::string CONTAINER_GROUP_NAME = "_inlet_container";
 const std::string CONTAINER_INDICES_NAME = "_inlet_container_indices";
-const std::string GENERIC_CONTAINER_FLAG = "_inlet_generic_container";
+const std::string STRUCT_CONTAINER_FLAG = "_inlet_struct_container";
 }  // namespace detail
 
 /*!
@@ -166,7 +166,7 @@ inline bool isContainerGroup(const std::string& name)
 
 /*!
 *****************************************************************************
-* \brief Marks the sidre::Group as a "generic container" by adding a
+* \brief Marks the sidre::Group as a "struct container" by adding a
 * corresponding flag to the group
 *
 * \param [inout] target The group to tag

--- a/src/axom/inlet/inlet_utils.hpp
+++ b/src/axom/inlet/inlet_utils.hpp
@@ -172,7 +172,7 @@ inline bool isContainerGroup(const std::string& name)
 * \param [inout] target The group to tag
 *****************************************************************************
 */
-void markAsGenericContainer(axom::sidre::Group& target);
+void markAsStructContainer(axom::sidre::Group& target);
 
 namespace cpp11_compat
 {

--- a/src/axom/inlet/tests/inlet_function.cpp
+++ b/src/axom/inlet/tests/inlet_function.cpp
@@ -378,7 +378,7 @@ TEST(inlet_function, simple_vec3_to_vec3_array_of_struct)
   DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   // Define schema
   arr_table.addBool("bar", "bar's description");

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -760,7 +760,7 @@ TYPED_TEST(inlet_object, primitive_arrays_as_std_vector)
   EXPECT_EQ(arr_w_indices, expected_arr_w_indices);
 }
 
-TYPED_TEST(inlet_object, generic_arrays_as_std_vector)
+TYPED_TEST(inlet_object, struct_arrays_as_std_vector)
 {
   std::string testString =
     "foo = { [0] = { bar = true; baz = false}, "
@@ -997,7 +997,7 @@ TEST(inlet_object_lua, primitive_arrays_as_std_vector_discontiguous)
   EXPECT_EQ(arr, expected_arr);
 }
 
-TEST(inlet_object_lua, generic_arrays_as_std_vector_discontiguous)
+TEST(inlet_object_lua, struct_arrays_as_std_vector_discontiguous)
 {
   std::string testString =
     "foo = { [6] = { bar = true; baz = false}, "
@@ -1031,7 +1031,7 @@ TEST(inlet_object_lua, primitive_arrays_as_std_vector_implicit_idx)
   EXPECT_EQ(arr, expected_arr);
 }
 
-TEST(inlet_object_lua, generic_arrays_as_std_vector_implicit_idx)
+TEST(inlet_object_lua, struct_arrays_as_std_vector_implicit_idx)
 {
   std::string testString =
     "foo = { { bar = true; baz = false}, "

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -85,7 +85,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_by_value)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   arr_table.addBool("bar", "bar's description");
   arr_table.addBool("baz", "baz's description");
@@ -103,7 +103,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_implicit_idx)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   arr_table.addBool("bar", "bar's description");
   arr_table.addBool("baz", "baz's description");
@@ -123,7 +123,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_verify_optional)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   arr_table.addBool("bar", "bar's description").required(true);
   arr_table.addBool("baz", "baz's description").required(false);
@@ -139,7 +139,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_verify_reqd)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   arr_table.addBool("bar", "bar's description").required(true);
   arr_table.addBool("baz", "baz's description").required(true);
@@ -153,7 +153,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_verify_empty_pass)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
   // Even though these are required, the input file should still
   // "verify" as the array is empty
   arr_table.addBool("bar", "bar's description").required(true);
@@ -170,7 +170,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_verify_empty_fail)
 
   // Verification should fail because the array is empty
   // and was required
-  auto& arr_table = inlet.addGenericArray("foo").required(true);
+  auto& arr_table = inlet.addStructArray("foo").required(true);
   arr_table.addBool("bar", "bar's description").required(true);
   arr_table.addBool("baz", "baz's description").required(true);
 
@@ -198,7 +198,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_verify_lambda)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   arr_table.addBool("bar", "bar's description").required();
 
@@ -217,7 +217,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_verify_lambda_pass)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   arr_table.addBool("bar", "bar's description");
   arr_table.addBool("baz", "baz's description");
@@ -238,7 +238,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_verify_lambda_fail)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   arr_table.addBool("bar", "bar's description");
   arr_table.addBool("baz", "baz's description");
@@ -275,7 +275,7 @@ TYPED_TEST(inlet_object, array_of_struct_containing_array)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   arr_table.addIntArray("arr", "arr's description");
   // Contiguous indexing for generality
@@ -570,8 +570,8 @@ TYPED_TEST(inlet_object, nested_array_of_struct)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& quux_table = inlet.addGenericArray("quux");
-  auto& foo_table = quux_table.addGenericArray("arr");
+  auto& quux_table = inlet.addStructArray("quux");
+  auto& foo_table = quux_table.addStructArray("arr");
 
   foo_table.addBool("bar", "bar's description");
   foo_table.addBool("baz", "baz's description");
@@ -595,8 +595,8 @@ TYPED_TEST(inlet_object, nested_dict_of_array_of_struct)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& quux_table = inlet.addGenericDictionary("quux");
-  auto& foo_table = quux_table.addGenericArray("arr");
+  auto& quux_table = inlet.addStructDictionary("quux");
+  auto& foo_table = quux_table.addStructArray("arr");
 
   foo_table.addBool("bar", "bar's description");
   foo_table.addBool("baz", "baz's description");
@@ -648,9 +648,9 @@ TYPED_TEST(inlet_object, nested_array_of_dict_of_array_of_struct)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& corge_table = inlet.addGenericArray("corge");
-  auto& quux_table = corge_table.addGenericDictionary("dict");
-  auto& foo_table = quux_table.addGenericArray("arr");
+  auto& corge_table = inlet.addStructArray("corge");
+  auto& quux_table = corge_table.addStructDictionary("dict");
+  auto& foo_table = quux_table.addStructArray("arr");
 
   foo_table.addBool("bar", "bar's description");
   foo_table.addBool("baz", "baz's description");
@@ -699,8 +699,8 @@ TYPED_TEST(inlet_object, nested_dict_of_array_of_struct_with_array)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& quux_table = inlet.addGenericDictionary("quux");
-  auto& foo_table = quux_table.addGenericArray("outer_arr");
+  auto& quux_table = inlet.addStructDictionary("quux");
+  auto& foo_table = quux_table.addStructArray("outer_arr");
 
   foo_table.addIntArray("arr", "arr's description");
 
@@ -788,7 +788,7 @@ TYPED_TEST(inlet_object, generic_arrays_as_std_vector)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   arr_table.addBool("bar", "bar's description");
   arr_table.addBool("baz", "baz's description");
@@ -825,7 +825,7 @@ TYPED_TEST(inlet_object_dict, simple_dict_of_struct_by_value)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& dict_table = inlet.addGenericDictionary("foo");
+  auto& dict_table = inlet.addStructDictionary("foo");
 
   dict_table.addBool("bar", "bar's description");
   dict_table.addBool("baz", "baz's description");
@@ -860,7 +860,7 @@ TYPED_TEST(inlet_object_dict, dict_of_struct_containing_dict)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& dict_table = inlet.addGenericDictionary("foo");
+  auto& dict_table = inlet.addStructDictionary("foo");
 
   dict_table.addIntDictionary("arr", "arr's description");
   std::unordered_map<std::string, FooWithDict> expected_foos = {
@@ -880,7 +880,7 @@ TYPED_TEST(inlet_object_dict, dict_of_struct_containing_array)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& dict_table = inlet.addGenericDictionary("foo");
+  auto& dict_table = inlet.addStructDictionary("foo");
 
   dict_table.addIntArray("arr", "arr's description");
   std::unordered_map<std::string, FooWithArray> expected_foos = {
@@ -900,7 +900,7 @@ TYPED_TEST(inlet_object_dict, array_of_struct_containing_dict)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   arr_table.addIntDictionary("arr", "arr's description");
   std::unordered_map<int, FooWithDict> expected_foos = {{0, {{{"key1", 3}}}},
@@ -953,7 +953,7 @@ TEST(inlet_object_lua, array_of_struct_containing_array)
   DataStore ds;
   Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   arr_table.addIntArray("arr", "arr's description");
   std::unordered_map<int, FooWithArray> expected_foos = {{4, {{{1, 3}}}},
@@ -1025,7 +1025,7 @@ TEST(inlet_object_lua, generic_arrays_as_std_vector_discontiguous)
   DataStore ds;
   Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   arr_table.addBool("bar", "bar's description");
   arr_table.addBool("baz", "baz's description");
@@ -1059,7 +1059,7 @@ TEST(inlet_object_lua, generic_arrays_as_std_vector_implicit_idx)
   DataStore ds;
   Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   arr_table.addBool("bar", "bar's description");
   arr_table.addBool("baz", "baz's description");
@@ -1076,7 +1076,7 @@ TEST(inlet_object_lua_dict, dict_of_struct_containing_array)
   DataStore ds;
   Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
 
-  auto& dict_table = inlet.addGenericDictionary("foo");
+  auto& dict_table = inlet.addStructDictionary("foo");
 
   dict_table.addIntArray("arr", "arr's description");
   std::unordered_map<std::string, FooWithArray> expected_foos = {
@@ -1096,7 +1096,7 @@ TEST(inlet_object_lua_dict, array_of_struct_containing_dict)
   DataStore ds;
   Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
 
-  auto& arr_table = inlet.addGenericArray("foo");
+  auto& arr_table = inlet.addStructArray("foo");
 
   arr_table.addIntDictionary("arr", "arr's description");
   std::unordered_map<int, FooWithDict> expected_foos = {{7, {{{"key1", 3}}}},
@@ -1150,7 +1150,7 @@ TEST(inlet_object_lua_dict, mixed_keys_object)
   DataStore ds;
   Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
 
-  auto& dict_table = inlet.addGenericDictionary("foo");
+  auto& dict_table = inlet.addStructDictionary("foo");
 
   dict_table.addBool("bar", "bar's description");
   dict_table.addBool("baz", "baz's description");

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -548,7 +548,7 @@ TYPED_TEST(inlet_object, nested_array_of_struct_containing_array)
   DataStore ds;
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
-  auto& bar_table = inlet.addGenericArray("bars");
+  auto& bar_table = inlet.addStructArray("bars");
   auto& foo_table = bar_table.addStruct("foo");
   foo_table.addIntArray("arr", "arr's description");
 

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -354,26 +354,6 @@ TYPED_TEST(inlet_object, simple_struct_from_bracket)
   EXPECT_FALSE(foo.baz);
 }
 
-TYPED_TEST(inlet_object, contains_from_table)
-{
-  std::string testString = "foo = { bar = true; baz = false }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
-
-  // Define schema
-  // Check for existing fields
-  inlet.addBool("foo/bar", "bar's description");
-
-  inlet.addBool("foo/baz", "baz's description");
-
-  EXPECT_TRUE(inlet.contains("foo/bar"));
-  EXPECT_TRUE(inlet.contains("foo/baz"));
-
-  auto& foo_table = inlet.getTable("foo");
-  EXPECT_TRUE(foo_table.contains("bar"));
-  EXPECT_TRUE(foo_table.contains("baz"));
-}
-
 TYPED_TEST(inlet_object, contains_from_bracket)
 {
   std::string testString = "foo = { bar = true; baz = false }";


### PR DESCRIPTION
# Summary

- This PR is a cleanup
- It does the following:
  - Restricts the public interface of `Inlet::Table`, in particular by removing duplicated functionality

Per my comments in https://github.com/LLNL/axom/pull/434#discussion_r564056514 and https://github.com/LLNL/axom/pull/434#issue-558533411, the interface has been tweaked a bit.

* The `addGenericArray`/`addGenericDictionary` aliases for `addStructArray`/`addStructDictionary` have been removed
* `addTable` is now private - `addStruct` should be used for nested data in the input file
* "Type-erased" implementations of `name()` and `sidreGroup` for `inlet::Proxy` have been implemented that forward to the underlying object. 
* The `Proxy` object (via `op[]`) is now the only method of access/retrieval (instead of with `getTable`) - this motivated the above
* Similarly, `contains` is now the only way of checking if something exists in the input file.  This eliminates ambiguity with `hasTable` et al, which don't check the input file and only indicate whether something is in the schema (only useful internally).  The type of the underlying object can still be queried from the `Proxy`.
