### PR TITLE
Add material set support to MFEMSidreDataCollection

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,6 +39,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Inlet: Added support for deeply nested containers of structs
 - Inlet: Added support for `void` and strings in Lua-defined functions
 - Inlet: Added `get<std::vector<T>>` for retrieving arrays without index information
+- Added support for registering material and species sets in `MFEMSidreDataCollection`
 
 ### Changed
 - The Sidre Datastore no longer rewires Conduit's error handlers to SLIC by default. 

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -48,7 +48,7 @@ namespace detail
  * Splits a string starting from the end of the string into a maximum of @p n tokens
  */
 std::vector<std::string> splitLastNTokens(const std::string& input,
-                                          const int n,
+                                          const std::size_t n,
                                           const char delim)
 {
   std::vector<std::string> result;

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -1391,7 +1391,6 @@ void MFEMSidreDataCollection::AssociateMaterialSet(
   // Since we're creating the matset, associate it with a topology
   // FIXME: Will these always be associated with the mesh?
   matset_group->createViewString("topology", s_mesh_topology_name);
-  matset_group->createGroup("volume_fractions");
 }
 
 void MFEMSidreDataCollection::AssociateSpeciesSet(
@@ -1415,7 +1414,6 @@ void MFEMSidreDataCollection::AssociateSpeciesSet(
                                 static_cast<int8>(volume_dependent));
   // Since we're creating the species set, associate it with a material set
   specset_grp->createViewString("matset", matset_name);
-  specset_grp->createGroup("matset_values");
 }
 
 void MFEMSidreDataCollection::AssociateMaterialDependentField(
@@ -1477,9 +1475,9 @@ void MFEMSidreDataCollection::checkForMaterialSet(const std::string& field_name)
 
   View* vol_fractions_view = getFieldValuesView(field_name);
 
-  Group* matset_group = m_bp_grp->getGroup("matsets/" + matset_name);
-  View* matset_frac_view =
-    matset_group->getGroup("volume_fractions")->copyView(vol_fractions_view);
+  Group* fractions_group =
+    alloc_group(m_bp_grp, "matsets/" + matset_name + "/volume_fractions");
+  View* matset_frac_view = fractions_group->copyView(vol_fractions_view);
   matset_frac_view->rename(material_id);
 
   // FIXME: Do we need to add anything to the index group?
@@ -1519,9 +1517,9 @@ void MFEMSidreDataCollection::checkForSpeciesSet(const std::string& field_name)
 
   View* species_values_view = getFieldValuesView(field_name);
 
-  Group* specset_group =
-    m_bp_grp->getGroup("specsets/" + specset_name + "/matset_values");
-  Group* specset_material_group = alloc_group(specset_group, material_id);
+  Group* specset_material_group =
+    alloc_group(m_bp_grp,
+                "specsets/" + specset_name + "/matset_values/" + material_id);
   View* specset_values = specset_material_group->copyView(species_values_view);
   specset_values->rename(component_id);
 

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -1442,8 +1442,11 @@ void MFEMSidreDataCollection::checkForMaterialSet(const std::string& field_name)
     return;
   }
 
-  // FIXME: I think the naming of this is wrong, since it might be just "values" or "x0"
-  matset_group->getGroup("volume_fractions")->copyView(vol_fractions_view);
+  View* matset_frac_view =
+    matset_group->getGroup("volume_fractions")->copyView(vol_fractions_view);
+  matset_frac_view->rename(material_id);
+
+  // FIXME: Do we need to add anything to the index group?
 }
 
 // private method

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -1368,6 +1368,21 @@ void MFEMSidreDataCollection::DeregisterField(const std::string& field_name)
   FreeNamedBuffer(field_name);
 }
 
+void MFEMSidreDataCollection::AssociateMaterialSet(
+  const std::string& volume_fraction_field_name,
+  const std::string& matset_name)
+{
+  auto iter = m_matset_associations.find(volume_fraction_field_name);
+  if(iter != m_matset_associations.end())
+  {
+    SLIC_WARNING("Volume fraction field "
+                 << volume_fraction_field_name
+                 << " has already been associated with a material set: "
+                 << iter->second);
+  }
+  m_matset_associations[volume_fraction_field_name] = matset_name;
+}
+
 // private method
 std::string MFEMSidreDataCollection::getElementName(mfem::Element::Type elementEnum)
 {

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -288,7 +288,7 @@ public:
   virtual void DeregisterField(const std::string& field_name);
 
   /// Associates a field name with a multi-buffer material set
-  /** Subsequent calls to RegisterField iwth field_names of the form
+  /** Subsequent calls to RegisterField with field_names of the form
    * @p volume_fraction_field_name_<material_id> will result in the addition
    * of a volume buffer to the matset @p matset_name corresponding to @p material_id.
    * 
@@ -301,6 +301,26 @@ public:
    */
   void AssociateMaterialSet(const std::string& volume_fraction_field_name,
                             const std::string& matset_name);
+
+  /// Associates a field name with a species set
+  /** Subsequent calls to RegisterField with field_names of the form
+   * @p matset_vals_field_name_<material_id>_<component> will result in the addition
+   * of its values to the specset @p specset_name corresponding to @p material_id.
+   * and specified component
+   * 
+   * Note that this does not inhibit the addition of the field - that is, the GridFunction
+   * data will be present as both a field and within the species set
+   * 
+   * @param species_field_name The field name to associate with the species set matset values
+   * @param specset_name The name of the species set to associate added matset values with
+   * @param matset_name The material set to associate with the species set
+   * @param volume_dependent Whether the species set is volume-dependent
+   *
+   */
+  void AssociateSpeciesSet(const std::string& species_field_name,
+                           const std::string& specset_name,
+                           const std::string& matset_name,
+                           const bool volume_dependent);
 
   /// Delete all owned data.
   virtual ~MFEMSidreDataCollection();
@@ -565,9 +585,18 @@ private:
   void createMeshBlueprintAdjacencies(bool hasBP);
   #endif
 
+  /// Retrieves a pointer to the View onto the data for a Field
+  /// For vector-valued Fields, retrieves the view to the first component
+  /// as data is interleaved
+  View* getFieldValuesView(const std::string& field_name);
+
   /// After a Field has been registered, check if it's part of a material
   /// set - if it is, add it to the matset
   void checkForMaterialSet(const std::string& field_name);
+
+  /// After a Field has been registered, check if it's part of a species
+  /// set - if it is, add it to the specset
+  void checkForSpeciesSet(const std::string& field_name);
 
   // /// Verifies that the contents of the mesh blueprint data is valid.
   // void verifyMeshBlueprint();
@@ -579,9 +608,11 @@ private:
   static const std::string s_attribute_suffix;
   static const std::string s_coordset_name;
 
-  // Associations between field names and material sets
+  // Associations between field names and material metadata
   // Maps field names onto matset names
   std::unordered_map<std::string, std::string> m_matset_associations;
+  // Maps field names onto specset names
+  std::unordered_map<std::string, std::string> m_specset_associations;
 };
 
 } /* namespace sidre */

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -20,6 +20,7 @@ namespace sidre
 {
 /** @brief Data collection with Sidre routines following the Conduit mesh
     blueprint specification. */
+// clang-format off
 /** MFEMSidreDataCollection provides an HDF5-based file format for visualization
    or
     restart capability.  This functionality is aimed primarily at customers of
@@ -43,56 +44,39 @@ namespace sidre
          │              ├── coordsets
          │              │    └── coords
          │              │         ├─• path = "<bp-path>/coordsets/coords"
-         │              │         ├─• type ─> <bp-grp>/coordsets/coords/type =
-            "explicit"
+         │              │         ├─• type ─> <bp-grp>/coordsets/coords/type = "explicit"
          │              │         └─• coord_system = "x"|"xy"|"xyz"
          │              ├── topologies
          │              │    ├── mesh
          │              │    │    ├─• path = "<bp-path>/topologies/mesh"
-         │              │    │    ├─• type              ─>
-            <bp-grp>/topologies/mesh/type = "unstructured"
-         │              │    │    ├─• coordset          ─>
-            <bp-grp>/topologies/mesh/coordset = "coords"
-         │              │    │    ├─• grid_function     ─>
-            <bp-grp>/topologies/mesh/grid_function = "<nodes-field-name>"
-         │              │    │    └─• boundary_topology ─>
-            <bp-grp>/topologies/mesh/boundary_topology = "boundary"
+         │              │    │    ├─• type              ─> <bp-grp>/topologies/mesh/type = "unstructured"
+         │              │    │    ├─• coordset          ─> <bp-grp>/topologies/mesh/coordset = "coords"
+         │              │    │    ├─• grid_function     ─> <bp-grp>/topologies/mesh/grid_function = "<nodes-field-name>"
+         │              │    │    └─• boundary_topology ─> <bp-grp>/topologies/mesh/boundary_topology = "boundary"
          │              │    └── boundary
          │              │         ├─• path = "<bp-path>/topologies/mesh"
-         │              │         ├─• type     ─>
-            <bp-grp>/topologies/boundary/type = "unstructured"
-         │              │         └─• coordset ─>
-            <bp-grp>/topologies/boundary/coordset = "coords"
+         │              │         ├─• type     ─> <bp-grp>/topologies/boundary/type = "unstructured"
+         │              │         └─• coordset ─> <bp-grp>/topologies/boundary/coordset = "coords"
          │              └── fields
          │                   ├── mesh_material_attribute
-         │                   │    ├─• path =
-            "<bp-path>/fields/mesh_material_attribute"
-         │                   │    ├─• association ─>
-            <bp-grp>/fields/mesh_material_attribute/association = "element"
-         │                   │    ├─• topology    ─>
-            <bp-grp>/fields/mesh_material_attribute/topology = "mesh"
+         │                   │    ├─• path = "<bp-path>/fields/mesh_material_attribute"
+         │                   │    ├─• association ─> <bp-grp>/fields/mesh_material_attribute/association = "element"
+         │                   │    ├─• topology    ─> <bp-grp>/fields/mesh_material_attribute/topology = "mesh"
          │                   │    └─• number_of_components = 1
          │                   ├── boundary_material_attribute
-         │                   │    ├─• path =
-            "<bp-path>/fields/boundary_material_attribute"
-         │                   │    ├─• association ─>
-            <bp-grp>/fields/boundary_material_attribute/association = "element"
-         │                   │    ├─• topology    ─>
-            <bp-grp>/fields/boundary_material_attribute/topology = "boundary"
+         │                   │    ├─• path = "<bp-path>/fields/boundary_material_attribute"
+         │                   │    ├─• association ─> <bp-grp>/fields/boundary_material_attribute/association = "element"
+         │                   │    ├─• topology    ─> <bp-grp>/fields/boundary_material_attribute/topology = "boundary"
          │                   │    └─• number_of_components = 1
          │                   ├── grid-function-1
          │                   │    ├─• path = "<bp-path>/fields/grid-function-1"
-         │                   │    ├─• basis    ─>
-            <bp-grp>/fields/grid-function-1/basis = "<fe-coll-name>"
-         │                   │    ├─• topology ─>
-            <bp-grp>/fields/grid-function-1/topology = "mesh"
+         │                   │    ├─• basis    ─> <bp-grp>/fields/grid-function-1/basis = "<fe-coll-name>"
+         │                   │    ├─• topology ─> <bp-grp>/fields/grid-function-1/topology = "mesh"
          │                   │    └─• number_of_components = gf1->VectorDim()
          │                   ├── grid-function-2
          │                   │    ├─• path = "<bp-path>/fields/grid-function-2"
-         │                   │    ├─• basis    ─>
-            <bp-grp>/fields/grid-function-2/basis = "<fe-coll-name>"
-         │                   │    ├─• topology ─>
-            <bp-grp>/fields/grid-function-2/topology = "mesh"
+         │                   │    ├─• basis    ─> <bp-grp>/fields/grid-function-2/basis = "<fe-coll-name>"
+         │                   │    ├─• topology ─> <bp-grp>/fields/grid-function-2/topology = "mesh"
          │                   │    └─• number_of_components = gf2->VectorDim()
          │                   ├── ...
          │                  ...
@@ -107,12 +91,9 @@ namespace sidre
               │    │    └── coords
               │    │         ├─• type = "explicit"
               │    │         └── values
-              │    │              ├─• x = view in
-                 <vertex-coords-buffer>/<ext-double-data>
-              │    │              ├─• y = view in
-                 <vertex-coords-buffer>/<ext-double-data>
-              │    │              └─• z = view in
-                 <vertex-coords-buffer>/<ext-double-data>
+              │    │              ├─• x = view in <vertex-coords-buffer>/<ext-double-data>
+              │    │              ├─• y = view in <vertex-coords-buffer>/<ext-double-data>
+              │    │              └─• z = view in <vertex-coords-buffer>/<ext-double-data>
               │    ├── topologies
               │    │    ├── mesh
               │    │    │    ├─• type = "unstructured"
@@ -128,6 +109,16 @@ namespace sidre
               │    │         │    ├─• shape = "points"|"lines"|...
               │    │         │    └─• connectivity = <vert-idx-array>
               │    │         └─• coordset = "coords"
+              │    ├── matsets
+              │    │    ├── matset
+              │    │    │    ├─• topology = "mesh"
+              │    │    │    └── volume_fractions
+              │    │    │         ├─• 001: view in <ext-double-array>/<named-buffer>
+              │    │    │         ├─• 002: view in <ext-double-array>/<named-buffer>
+              │    │    │         ...
+              │    │    │         └─• 00N: view in <ext-double-array>/<named-buffer>
+              │    │    ├── ...
+              │    │   ...
               │    └── fields
               │         ├── mesh_material_attribute
               │         │    ├─• association = "element"
@@ -140,18 +131,14 @@ namespace sidre
               │         ├── grid-function-1   (name can include path)
               │         │    ├─• basis = "<fe-coll-name>"
               │         │    ├─• topology = "mesh"
-              │         │    └─• values = <ext-double-array>/<named-buffer>
-                 (vdim == 1)
+              │         │    └─• values = <ext-double-array>/<named-buffer> (vdim == 1)
               │         ├── grid-function-2   (name can include path)
               │         │    ├─• basis = "<fe-coll-name>"
               │         │    ├─• topology = "mesh"
               │         │    └── values   (vdim > 1)
-              │         │         ├─• x0 = view into
-                 <ext-double-array>/<named-buffer>
-              │         │         ├─• x1 = view into
-                 <ext-double-array>/<named-buffer>
-              │         │         └─• x2 = view into
-                 <ext-double-array>/<named-buffer>
+              │         │         ├─• x0 = view into <ext-double-array>/<named-buffer>
+              │         │         ├─• x1 = view into <ext-double-array>/<named-buffer>
+              │         │         └─• x2 = view into <ext-double-array>/<named-buffer>
               │         ├── ...
               │        ...
               └── named_buffers                (named_buffers group)
@@ -174,6 +161,7 @@ namespace sidre
     releases, it may not be backward compatible, and the output files generated
     by the current version may become unreadable.
  */
+// clang-format on
 class MFEMSidreDataCollection : public mfem::DataCollection
 {
 public:
@@ -298,6 +286,21 @@ public:
   /** The field is removed from the #field_map and the DataStore, including
       deleting it from the named_buffers group, if allocated. */
   virtual void DeregisterField(const std::string& field_name);
+
+  /// Associates a field name with a multi-buffer material set
+  /** Subsequent calls to RegisterField iwth field_names of the form
+   * @p volume_fraction_field_name_<material_id> will result in the addition
+   * of a volume buffer to the matset @p matset_name corresponding to @p material_id.
+   * 
+   * Note that this does not inhibit the addition of the field - that is, the GridFunction
+   * data will be present as both a field and a volume fraction buffer
+   * 
+   * @param volume_fraction_field_name The field name to associate with volume fractions
+   * @param matset_name The material set to associate subsequently added volume fractions with
+   *
+   */
+  void AssociateMaterialSet(const std::string& volume_fraction_field_name,
+                            const std::string& matset_name);
 
   /// Delete all owned data.
   virtual ~MFEMSidreDataCollection();
@@ -571,6 +574,10 @@ private:
   static const std::string s_boundary_topology_name;
   static const std::string s_attribute_suffix;
   static const std::string s_coordset_name;
+
+  // Associations between field names and material sets
+  // Maps field names onto matset names
+  std::unordered_map<std::string, std::string> m_matset_associations;
 };
 
 } /* namespace sidre */

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -321,7 +321,7 @@ public:
 
   /// Associates a field name with a species set
   /** Subsequent calls to RegisterField with field_names of the form
-   * @p matset_vals_field_name_<material_id>_<component> will result in the addition
+   * @p species_field_name_<material_id>_<component> will result in the addition
    * of its values to the specset @p specset_name corresponding to @p material_id.
    * and specified component
    * 
@@ -338,6 +338,22 @@ public:
                            const std::string& specset_name,
                            const std::string& matset_name,
                            const bool volume_dependent);
+
+  /// Associates a material-dependent field with its corresponding material set
+  /** Subsequent calls to RegisterField with field_names of the form
+   * @p dependent_field_name_<material_id> will result in the addition
+   * of its values to the to the matset_vals of the @p dependent_field_name corresponding to
+   * @p material_id
+   * 
+   * Note that this does not inhibit the addition of the field - that is, the GridFunction
+   * data will be present as both a field on its own and as part of the "top-level" field
+   * 
+   * @param material_dependent_field_name The name of the field to mark as material-dependent
+   * @param matset_name The material set to associate with the field
+   *
+   */
+  void AssociateMaterialDependentField(const std::string& material_dependent_field_name,
+                                       const std::string& matset_name);
 
   /// Delete all owned data.
   virtual ~MFEMSidreDataCollection();
@@ -615,6 +631,10 @@ private:
   /// set - if it is, add it to the specset
   void checkForSpeciesSet(const std::string& field_name);
 
+  /// After a Field has been registered, check if it's a material-dependent
+  /// field - if it is, add it to the matset_values
+  void checkForMaterialDependentField(const std::string& field_name);
+
   // /// Verifies that the contents of the mesh blueprint data is valid.
   // void verifyMeshBlueprint();
 
@@ -630,6 +650,8 @@ private:
   std::unordered_map<std::string, std::string> m_matset_associations;
   // Maps field names onto specset names
   std::unordered_map<std::string, std::string> m_specset_associations;
+  // Maps material-dependent field names onto the material set they're associated with
+  std::unordered_map<std::string, std::string> m_material_dependent_fields;
 };
 
 } /* namespace sidre */

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -113,10 +113,27 @@ namespace sidre
               │    │    ├── matset
               │    │    │    ├─• topology = "mesh"
               │    │    │    └── volume_fractions
-              │    │    │         ├─• 001: view in <ext-double-array>/<named-buffer>
-              │    │    │         ├─• 002: view in <ext-double-array>/<named-buffer>
+              │    │    │         ├─• material-1: view in <ext-double-array>/<named-buffer>
+              │    │    │         ├─• material-2: view in <ext-double-array>/<named-buffer>
               │    │    │         ...
-              │    │    │         └─• 00N: view in <ext-double-array>/<named-buffer>
+              │    │    │         └─• material-N: view in <ext-double-array>/<named-buffer>
+              │    │    ├── ...
+              │    │   ...
+              │    ├── specsets
+              │    │    ├── specset
+              │    │    │    ├─• volume_dependent
+              │    │    │    ├─• matset = "matset"
+              │    │    │    └── matset_values
+              │    │    │         ├── material-1
+              │    │    │         │    ├─• component-1: view in <ext-double-array>/<named-buffer>
+              │    │    │         │    ├─• component-2: view in <ext-double-array>/<named-buffer>
+              │    │    │         │    ...
+              │    │    │         │    └─• component-N: view in <ext-double-array>/<named-buffer>
+              │    │    │         ├── material-2
+              │    │    │              └─• ...
+              │    │    │        ...
+              │    │    │         └── material-N
+              │    │    │              └─• ...
               │    │    ├── ...
               │    │   ...
               │    └── fields

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -565,6 +565,10 @@ private:
   void createMeshBlueprintAdjacencies(bool hasBP);
   #endif
 
+  /// After a Field has been registered, check if it's part of a material
+  /// set - if it is, add it to the matset
+  void checkForMaterialSet(const std::string& field_name);
+
   // /// Verifies that the contents of the mesh blueprint data is valid.
   // void verifyMeshBlueprint();
 

--- a/src/axom/sidre/docs/sphinx/mfem_sidre_datacollection.rst
+++ b/src/axom/sidre/docs/sphinx/mfem_sidre_datacollection.rst
@@ -5,25 +5,61 @@
 
 .. _mfem-sidre-datacollection:
 
-******************************************************
+*********************
 Using Sidre with MFEM
-******************************************************
+*********************
 
 The ``MFEMSidreDataCollection`` class implements `MFEM <https://mfem.org>`_'s 
-``DataCollection`` interface for collecting data for a given simulation.
-It combines fields and the mesh on which they are defined.  
+``DataCollection`` interface for recording simulation data.
+Specifically, it knows about fields (``mfem::GridFunction``) and the mesh on which the fields defined.
 
-``MFEMSidreDataCollection`` internally uses the Mesh Blueprint, a standardized
- representation, to store its data.
+The ``MFEMSidreDataCollection`` internally uses the Mesh Blueprint, a standardized
+representation, to store its data.
 
 See the :ref:`Conduit page <sidre-conduit>` for more information on the Mesh Blueprint.
 
-Uses
---------------
+In this document, we first discuss `Getting Started`_ and how MFEM objects can be associated with the ``DataCollection``.
+We then explain the process for and options available when `Saving Data to a File`_.
+The workflow for reading saved data back in is discussed in `Restarting a Simulation`_.
+
+Getting Started
+---------------
+
+In order for the ``MFEMSidreDataCollection`` to save fields and a mesh to a file, the MFEM entities must
+be "registered".  The mesh can be registered when an instance of the class is constructed:
+
+.. literalinclude:: ../../examples/sidre_mfem_datacollection_vis.cpp
+   :start-after: _sidredc_vis_construct_start
+   :end-before: _sidredc_vis_construct_end
+   :language: C++
+
+It can also be registered after construction:
+
+.. code-block:: C++
+
+  dc.SetMesh(/* mfem::Mesh* */ mesh);
+
+.. note::
+   There is a 1-1 relationship between ``DataCollection`` instances and meshes.  That is, multiple meshes
+   cannot be associated with a ``DataCollection``.
+
+Once a mesh has been registered, fields of interest can be association with the ``DataCollection``:
+
+.. literalinclude:: ../../examples/sidre_mfem_datacollection_vis.cpp
+   :start-after: _sidredc_vis_field_start
+   :end-before: _sidredc_vis_field_end
+   :language: C++
+
+Special kinds of fields (material-dependent fields, material set volume fraction fields,
+and species set values fields) require some setup before they can be registered - see `Mixed-material Fields`_
+for more info.
+
+Saving Data to a File
+---------------------
 
 The data in an instance of the ``MFEMSidreDataCollection`` class can be saved to a file using a variety of formats.  
-This provides visualization and restart capabilities, as these files can also be
-loaded back into an instance of the class.
+These files can be visualized with tools like `VisIt <https://wci.llnl.gov/simulation/computer-codes/visit>`_, or used
+to restart a simulation by loading them back into an instance of the class (see `Restarting a Simulation`_).
 
 Current options for output formats (protocols) include:
 
@@ -35,51 +71,55 @@ Current options for output formats (protocols) include:
 .. Note::
    The ``AXOM_USE_HDF5`` build option must be enabled to use the HDF5-based formats.
 
-A typical visualization example might look like the following:
+Before saving, simulation state metadata should be updated.  Currently, this metadata consists of:
 
-.. code-block::
+- ``cycle``, the current iteration number for the simulation
+- ``time``, the current simulation time
+- ``time_step``, the current simulation time step (sometimes called ``dt``)
 
-   mfem::Mesh mesh;
-   // ...read the mesh in from a file
-   MFEMSidreDataCollection dc("data_name", &mesh);
+Each of these variables has a corresponding "setter" function:
 
-   mfem::GridFunction soln;
-   // ...initialize with FiniteElementSpace, etc
+.. literalinclude:: ../../examples/sidre_mfem_datacollection_vis.cpp
+   :start-after: _sidredc_vis_state_start
+   :end-before: _sidredc_vis_state_end
+   :language: C++
 
-   // Note: Any number of fields can be registered
-   dc.RegisterField("solution", &soln);
+.. note::
+   There are also corresponding accessors for these state variables (``GetCycle``, ``GetTime``, ``GetTimeStep``)
 
-   // Save the initial state
-   dc.SetCycle(0); // Iteration counter
-   dc.SetTime(0.0); // Simulation time
-   // Filename and protocol, both of which are optional
-   dc.Save("data_name", "sidre_hdf5");
+Once state information has been updated, the complete simulation state can be written to a file:
 
-   for (int i = 0; i < n_iter; i++)
-   {
-      // Calculate the next iteration of the solution field, then...
-      
-      dc.SetCycle(i);
-      dc.SetTime(dt * i);
-      dc.Save("data_name", "sidre_hdf5");
-   }
+.. literalinclude:: ../../examples/sidre_mfem_datacollection_vis.cpp
+   :start-after: _sidredc_vis_save_start
+   :end-before: _sidredc_vis_save_end
+   :language: C++
+
+.. note::
+   By default, save files will be written to the current directory.  To write to/read from a different directory,
+   use ``SetPrefixPath`` to change the ``DataCollection``'s "working directory".
 
 See the ``sidre_mfem_datacollection_vis`` example for a more thorough example of the above functionality.
 
-.. Note::
-   The ``owns_mesh_data`` option must be set to true when constructing an instance of the class for the 
-   mesh to be read back in properly when a restart occurs.
-
 .. Warning::
-   Although the ``mfem::DataCollection`` interface provides functionality for collection quadrature fields,
+   Although the ``mfem::DataCollection`` interface provides functionality for registering quadrature fields,
    this is not supported by ``MFEMSidreDataCollection``.
 
-Experimental support for complete reconstruction of a simulation's mesh and fields is also provided by
-``MFEMSidreDataCollection``.  That is, when an output file is read in using ``MFEMSidreDataCollection::Load``,
-the data read in will be used to reconstruct MFEM objects than can be accessed with the ``GetField`` and
-``GetMesh`` methods.  
+Restarting a Simulation
+-----------------------
 
-This functionality is demonstrated in the ``sidre_mfem_datacollection_restart`` example, which is a stripped-down
+Experimental support for complete reconstruction of a simulation's mesh and fields is also provided by
+``MFEMSidreDataCollection``.  That is, when a saved simulation is read in using ``MFEMSidreDataCollection::Load``,
+the data read in will be used to reconstruct MFEM objects than can be accessed with the ``GetField`` and
+``GetMesh`` methods.
+
+.. warning::
+   Currently, the ``MFEMSidreDataCollection`` must own the mesh and field data in order to completely reconstruct
+   simulation state.  Mesh data ownership can be configured with the ``owns_mesh_data`` constructor option (should
+   be set to ``true``), and field data ownership requires that the ``GridFunction`` be unallocated when passed to
+   ``RegisterField``, which performs the allocation within Sidre-owned memory.  After registering, the ``GridFunction``
+   can be used normally.
+
+A complete demonstration of functionality is provided in the ``sidre_mfem_datacollection_restart`` example, which is a stripped-down
 example of how a simulation code might utilize the automatic reconstruction logic when loading in a datastore.
 
 .. Note::
@@ -90,3 +130,63 @@ example of how a simulation code might utilize the automatic reconstruction logi
   * There must be a coordinate set named ``coords``
   * There must be a topology named ``mesh`` with corresponding attributes stored in a field named ``mesh_material_attribute``
   * There must be a topology named ``boundary`` with corresponding attributes stored in a field named ``boundary_material_attribute``
+
+Mixed-material Fields
+---------------------
+
+The Conduit Blueprint provides support for mixed-material simulations through its "material set" construct.
+Material metadata (stored in ``mfem::GridFunction`` s) can be registered in the ``DataCollection`` like
+any other field (with ``RegisterField``), given that some additional setup is performed and the field names
+match a specific naming convention.
+
+Currently, there are three kinds of "special" fields that can be associated with mixed-material metadata:
+
+- Volume fraction fields in a material set (the per-element proportion of a given material)
+- Material-dependent fields (a different set of values for each material)
+- Species set fields (a different set of values for each material and for each dimension)
+
+`Material sets <https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html#material-sets>`_ are
+defined by associating a volume fraction field name with a material set name:
+
+.. literalinclude:: ../../examples/sidre_mfem_datacollection_materials.cpp
+   :start-after: _sidredc_material_matset_start
+   :end-before: _sidredc_material_matset_end
+   :language: C++
+
+Once this association has been made, corresponding fields can be registered.  Their names must satisfy
+``<associated volume fraction field name>_<material id>``, for example:
+
+.. literalinclude:: ../../examples/sidre_mfem_datacollection_materials.cpp
+   :start-after: _sidredc_material_matset_register_start
+   :end-before: _sidredc_material_matset_register_end
+   :language: C++
+
+`Material-dependent fields <https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html#fields>`_ are
+defined by associating a field name with a material set name:
+
+.. literalinclude:: ../../examples/sidre_mfem_datacollection_materials.cpp
+   :start-after: _sidredc_material_depfield_start
+   :end-before: _sidredc_material_depfield_end
+   :language: C++
+
+Material-specific values can be registered with the name ``<associated dependent field name>_<material id>``:
+
+.. literalinclude:: ../../examples/sidre_mfem_datacollection_materials.cpp
+   :start-after: _sidredc_material_depfield_register_start
+   :end-before: _sidredc_material_depfield_register_end
+   :language: C++
+
+`Species sets <https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html#species-sets>`_ are
+defined by associating a field name with a species set name and corresponding material set name:
+
+.. literalinclude:: ../../examples/sidre_mfem_datacollection_materials.cpp
+   :start-after: _sidredc_material_specset_start
+   :end-before: _sidredc_material_specset_end
+   :language: C++
+
+Species set values can be registered with the name ``<associated field name>_<material id>_<component>``:
+
+.. literalinclude:: ../../examples/sidre_mfem_datacollection_materials.cpp
+   :start-after: _sidredc_material_specset_register_start
+   :end-before: _sidredc_material_specset_register_end
+   :language: C++

--- a/src/axom/sidre/examples/CMakeLists.txt
+++ b/src/axom/sidre/examples/CMakeLists.txt
@@ -48,6 +48,7 @@ blt_list_append(TO sidre_example_depends ELEMENTS mpi IF MPI_FOUND)
 if(MFEM_FOUND AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION)
     list(APPEND example_sources sidre_mfem_datacollection_vis.cpp)
     list(APPEND example_sources sidre_mfem_datacollection_restart.cpp)
+    list(APPEND example_sources sidre_mfem_datacollection_materials.cpp)
     list(APPEND sidre_example_depends mfem)
 endif()
 

--- a/src/axom/sidre/examples/sidre_mfem_datacollection_materials.cpp
+++ b/src/axom/sidre/examples/sidre_mfem_datacollection_materials.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file sidre_mfem_datacollection_vis.cpp
+ * @brief This example code is a basic demonstration of Sidre's
+ * MFEMSidreDataCollection class for visualizing a time-marching
+ * simulation.  It is a more thorough version of the snippet
+ * provided in Sidre's Sphinx documentation.
+ */
+
+// Datacollection header
+#include "axom/sidre/core/MFEMSidreDataCollection.hpp"
+
+// MFEM includes - needed to set up simulation
+#include "mfem.hpp"
+
+int main()
+{
+  // Built a 2D mesh with 100 square elements
+  mfem::Mesh mesh(10, 10, mfem::Element::QUADRILATERAL);
+
+  // Set up the FiniteElementSpace - needed for the grid functions
+  // Initialize with H1 elements of order 1
+  mfem::H1_FECollection fec(/*order=*/1, /*dimension=*/2);
+  mfem::FiniteElementSpace fes(&mesh, &fec);
+
+  // Initialize the datacollection with the mesh
+  // Note: all fields (added with RegisterField) must be on this mesh
+  axom::sidre::MFEMSidreDataCollection dc("sidre_mfem_datacoll_materials_ex",
+                                          &mesh);
+
+  // _sidredc_material_matset_start
+  // Inform the DataCollection that volume fraction information for a material set
+  // called "matset" will be in fields called "volume_fraction"
+  dc.AssociateMaterialSet("volume_fraction", "matset");
+  // _sidredc_material_matset_end
+
+  // _sidredc_material_depfield_start
+  // Inform the DataCollection of a material-dependent field "density" associated
+  // with a material set called "matset"
+  dc.AssociateMaterialDependentField("density", "matset");
+  // _sidredc_material_depfield_end
+
+  // _sidredc_material_specset_start
+  // Inform the DataCollection that species set data for the species set "specset"
+  // associated with material set "matset" will be in fields called "partial_density"
+  const bool volume_dependent = false;
+  dc.AssociateSpeciesSet("partial_density", "specset", "matset", volume_dependent);
+  // _sidredc_material_specset_end
+
+  mfem::GridFunction vol_frac_1(&fes);
+  vol_frac_1 = 0.65;
+  mfem::GridFunction vol_frac_2(&fes);
+  vol_frac_2 = 0.35;
+  // _sidredc_material_matset_register_start
+  dc.RegisterField("volume_fraction_001", &vol_frac_1);
+  dc.RegisterField("volume_fraction_002", &vol_frac_2);
+  // _sidredc_material_matset_register_end
+
+  mfem::GridFunction density_indenpendent(&fes);
+  density_indenpendent = 1.0;
+  mfem::GridFunction density_dependent_1(&fes);
+  density_dependent_1 = 0.2;
+  mfem::GridFunction density_dependent_2(&fes);
+  density_dependent_2 = 0.3;
+  // _sidredc_material_depfield_register_start
+  dc.RegisterField("density", &density_indenpendent);
+  dc.RegisterField("density_001", &density_dependent_1);
+  dc.RegisterField("density_002", &density_dependent_2);
+  // _sidredc_material_depfield_register_end
+
+  mfem::GridFunction partial_density_1_1(&fes);
+  partial_density_1_1 = 0.4;
+  mfem::GridFunction partial_density_1_2(&fes);
+  partial_density_1_2 = 0.3;
+  mfem::GridFunction partial_density_2_1(&fes);
+  partial_density_2_1 = 0.2;
+  mfem::GridFunction partial_density_2_2(&fes);
+  partial_density_2_2 = 0.1;
+  // _sidredc_material_specset_register_start
+  dc.RegisterField("partial_density_001_001", &partial_density_1_1);
+  dc.RegisterField("partial_density_001_002", &partial_density_1_2);
+  dc.RegisterField("partial_density_002_001", &partial_density_2_1);
+  dc.RegisterField("partial_density_002_002", &partial_density_2_2);
+  // _sidredc_material_specset_register_end
+
+  // This is where the time-dependent operator would be set up...
+
+  // Save the initial state
+  dc.SetCycle(0);   // Iteration counter
+  dc.SetTime(0.0);  // Simulation time
+  // Filename and protocol, both of which are optional
+  dc.Save("sidre_mfem_datacoll_materials_ex", "sidre_conduit_json");
+}

--- a/src/axom/sidre/examples/sidre_mfem_datacollection_vis.cpp
+++ b/src/axom/sidre/examples/sidre_mfem_datacollection_vis.cpp
@@ -43,9 +43,11 @@ int main(int argc, char* argv[])
   mfem::H1_FECollection fec(/*order=*/1, /*dimension=*/2);
   mfem::FiniteElementSpace fes(mesh, &fec);
 
+  // _sidredc_vis_construct_start
   // Initialize the datacollection with the mesh
   // Note: all fields (added with RegisterField) must be on this mesh
   axom::sidre::MFEMSidreDataCollection dc("sidre_mfem_datacoll_vis_ex", mesh);
+  // _sidredc_vis_construct_end
 
 // This is where the time-dependent operator would be set up...
 
@@ -58,18 +60,25 @@ int main(int argc, char* argv[])
 #endif
   soln = 0.0;
 
+  // _sidredc_vis_field_start
   // Note: Any number of fields can be registered
   dc.RegisterField("solution", &soln);
+  // _sidredc_vis_field_end
 
+  double dt = 0.05;
+  // _sidredc_vis_state_start
   // Save the initial state
-  dc.SetCycle(0);   // Iteration counter
-  dc.SetTime(0.0);  // Simulation time
+  dc.SetCycle(0);      // Iteration counter
+  dc.SetTime(0.0);     // Simulation time
+  dc.SetTimeStep(dt);  // Time step
+  // _sidredc_vis_state_end
+  // _sidredc_vis_save_start
   // Filename and protocol, both of which are optional
   dc.Save("sidre_mfem_datacoll_vis_ex", "sidre_hdf5");
+  // _sidredc_vis_save_end
 
   // Sample time parameters
   int n_iter = 10;
-  double dt = 0.05;
 
   for(int i = 0; i < n_iter; i++)
   {

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -406,6 +406,80 @@ TEST(sidre_datacollection, create_specset_multi_fraction)
   EXPECT_TRUE(bp_grp->hasView("specsets/specset/matset_values/002/002"));
 }
 
+TEST(sidre_datacollection, create_material_dependent_field)
+{
+  // 1D mesh divided into 10 segments
+  mfem::Mesh mesh(10);
+  MFEMSidreDataCollection sdc(testName(), &mesh);
+  mfem::H1_FECollection fec(1, mesh.Dimension());
+  mfem::FiniteElementSpace fes(&mesh, &fec);
+
+  // Add a material set so we can associate the field with it
+  sdc.AssociateMaterialSet("volume_fraction", "matset");
+  mfem::GridFunction vol_frac_1(&fes);
+  vol_frac_1 = 1.0;
+  sdc.RegisterField("volume_fraction_001", &vol_frac_1);
+
+  // Then mark the field as material-dependent
+  sdc.AssociateMaterialDependentField("density", "matset");
+
+  mfem::GridFunction density_indenpendent(&fes);
+  density_indenpendent = 1.0;
+  sdc.RegisterField("density", &density_indenpendent);
+
+  mfem::GridFunction density_dependent(&fes);
+  density_dependent = 0.2;
+  sdc.RegisterField("density_001", &density_dependent);
+
+  EXPECT_TRUE(sdc.verifyMeshBlueprint());
+
+  const auto bp_grp = sdc.GetBPGroup();
+  EXPECT_TRUE(bp_grp->hasGroup("fields/density"));
+  EXPECT_TRUE(bp_grp->hasGroup("fields/density/matset_values"));
+  EXPECT_TRUE(bp_grp->hasView("fields/density/matset_values/001"));
+}
+
+TEST(sidre_datacollection, create_material_dependent_field_multi_fraction)
+{
+  // 1D mesh divided into 10 segments
+  mfem::Mesh mesh(10);
+  MFEMSidreDataCollection sdc(testName(), &mesh);
+  mfem::H1_FECollection fec(1, mesh.Dimension());
+  mfem::FiniteElementSpace fes(&mesh, &fec);
+
+  // Add a material set so we can associate the field with it
+  sdc.AssociateMaterialSet("volume_fraction", "matset");
+  mfem::GridFunction vol_frac_1(&fes);
+  vol_frac_1 = 0.65;
+  sdc.RegisterField("volume_fraction_001", &vol_frac_1);
+  mfem::GridFunction vol_frac_2(&fes);
+  vol_frac_2 = 0.35;
+  sdc.RegisterField("volume_fraction_002", &vol_frac_2);
+
+  // Then mark the field as material-dependent
+  sdc.AssociateMaterialDependentField("density", "matset");
+
+  mfem::GridFunction density_indenpendent(&fes);
+  density_indenpendent = 1.0;
+  sdc.RegisterField("density", &density_indenpendent);
+
+  mfem::GridFunction density_dependent_1(&fes);
+  density_dependent_1 = 0.2;
+  sdc.RegisterField("density_001", &density_dependent_1);
+
+  mfem::GridFunction density_dependent_2(&fes);
+  density_dependent_2 = 0.3;
+  sdc.RegisterField("density_002", &density_dependent_2);
+
+  EXPECT_TRUE(sdc.verifyMeshBlueprint());
+
+  const auto bp_grp = sdc.GetBPGroup();
+  EXPECT_TRUE(bp_grp->hasGroup("fields/density"));
+  EXPECT_TRUE(bp_grp->hasGroup("fields/density/matset_values"));
+  EXPECT_TRUE(bp_grp->hasView("fields/density/matset_values/001"));
+  EXPECT_TRUE(bp_grp->hasView("fields/density/matset_values/002"));
+}
+
   //----------------------------------------------------------------------
   #include "axom/slic/core/SimpleLogger.hpp"
 using axom::slic::SimpleLogger;

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -318,6 +318,94 @@ TEST(sidre_datacollection, create_matset_multi_fraction)
   EXPECT_TRUE(bp_grp->hasView("matsets/matset/volume_fractions/002"));
 }
 
+TEST(sidre_datacollection, create_specset)
+{
+  // 1D mesh divided into 10 segments
+  mfem::Mesh mesh(10);
+  MFEMSidreDataCollection sdc(testName(), &mesh);
+  mfem::H1_FECollection fec(1, mesh.Dimension());
+  mfem::FiniteElementSpace fes(&mesh, &fec);
+
+  // Add a material set so we can associate the specset with it
+  sdc.AssociateMaterialSet("volume_fraction", "matset");
+  mfem::GridFunction vol_frac_1(&fes);
+  vol_frac_1 = 1.0;
+  sdc.RegisterField("volume_fraction_001", &vol_frac_1);
+
+  // Then add the species set
+  const bool volume_dependent = false;
+  sdc.AssociateSpeciesSet("partial_density", "specset", "matset", volume_dependent);
+
+  mfem::GridFunction partial_density_1_1(&fes);
+  partial_density_1_1 = 1.0;
+
+  sdc.RegisterField("partial_density_001_001", &partial_density_1_1);
+
+  EXPECT_TRUE(sdc.verifyMeshBlueprint());
+
+  const auto bp_grp = sdc.GetBPGroup();
+  EXPECT_TRUE(bp_grp->hasGroup("specsets"));
+  EXPECT_TRUE(bp_grp->hasGroup("specsets/specset"));
+  EXPECT_TRUE(bp_grp->hasView("specsets/specset/volume_dependent"));
+  EXPECT_FALSE(static_cast<axom::int8>(
+    bp_grp->getView("specsets/specset/volume_dependent")->getScalar()));
+  EXPECT_TRUE(bp_grp->hasView("specsets/specset/matset"));
+  EXPECT_EQ(std::string(bp_grp->getView("specsets/specset/matset")->getString()),
+            "matset");
+  EXPECT_TRUE(bp_grp->hasView("specsets/specset/matset_values/001/001"));
+}
+
+TEST(sidre_datacollection, create_specset_multi_fraction)
+{
+  // 1D mesh divided into 10 segments
+  mfem::Mesh mesh(10);
+  MFEMSidreDataCollection sdc(testName(), &mesh);
+  mfem::H1_FECollection fec(1, mesh.Dimension());
+  mfem::FiniteElementSpace fes(&mesh, &fec);
+
+  // Add a material set so we can associate the specset with it
+  sdc.AssociateMaterialSet("volume_fraction", "matset");
+  mfem::GridFunction vol_frac_1(&fes);
+  vol_frac_1 = 0.7;
+  sdc.RegisterField("volume_fraction_001", &vol_frac_1);
+  mfem::GridFunction vol_frac_2(&fes);
+  vol_frac_2 = 0.3;
+  sdc.RegisterField("volume_fraction_002", &vol_frac_2);
+
+  // Then add the species set
+  const bool volume_dependent = false;
+  sdc.AssociateSpeciesSet("partial_density", "specset", "matset", volume_dependent);
+
+  mfem::GridFunction partial_density_1_1(&fes);
+  partial_density_1_1 = 0.4;
+  sdc.RegisterField("partial_density_001_001", &partial_density_1_1);
+  mfem::GridFunction partial_density_1_2(&fes);
+  partial_density_1_2 = 0.3;
+  sdc.RegisterField("partial_density_001_002", &partial_density_1_2);
+  mfem::GridFunction partial_density_2_1(&fes);
+  partial_density_2_1 = 0.2;
+  sdc.RegisterField("partial_density_002_001", &partial_density_2_1);
+  mfem::GridFunction partial_density_2_2(&fes);
+  partial_density_2_2 = 0.1;
+  sdc.RegisterField("partial_density_002_002", &partial_density_2_2);
+
+  EXPECT_TRUE(sdc.verifyMeshBlueprint());
+
+  const auto bp_grp = sdc.GetBPGroup();
+  EXPECT_TRUE(bp_grp->hasGroup("specsets"));
+  EXPECT_TRUE(bp_grp->hasGroup("specsets/specset"));
+  EXPECT_TRUE(bp_grp->hasView("specsets/specset/volume_dependent"));
+  EXPECT_FALSE(static_cast<axom::int8>(
+    bp_grp->getView("specsets/specset/volume_dependent")->getScalar()));
+  EXPECT_TRUE(bp_grp->hasView("specsets/specset/matset"));
+  EXPECT_EQ(std::string(bp_grp->getView("specsets/specset/matset")->getString()),
+            "matset");
+  EXPECT_TRUE(bp_grp->hasView("specsets/specset/matset_values/001/001"));
+  EXPECT_TRUE(bp_grp->hasView("specsets/specset/matset_values/001/002"));
+  EXPECT_TRUE(bp_grp->hasView("specsets/specset/matset_values/002/001"));
+  EXPECT_TRUE(bp_grp->hasView("specsets/specset/matset_values/002/002"));
+}
+
   //----------------------------------------------------------------------
   #include "axom/slic/core/SimpleLogger.hpp"
 using axom::slic::SimpleLogger;

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -261,6 +261,28 @@ TEST(sidre_datacollection, dc_alloc_nonowning_parmesh)
   EXPECT_TRUE(sdc.verifyMeshBlueprint());
 }
 
+TEST(sidre_datacollection, create_matset)
+{
+  // 1D mesh divided into 10 segments
+  mfem::Mesh mesh(10);
+  MFEMSidreDataCollection sdc(testName(), &mesh);
+  sdc.AssociateMaterialSet("volume_fraction", "matset");
+
+  mfem::H1_FECollection fec(1, mesh.Dimension());
+  mfem::FiniteElementSpace fes(&mesh, &fec);
+
+  mfem::GridFunction vol_frac_1(&fes);
+  *vol_frac_1 = 1.0;
+
+  sdc.RegisterField("volume_fraction_001", &vol_frac_1);
+
+  EXPECT_TRUE(sdc.verifyMeshBlueprint());
+
+  const auto bp_grp = sdc.GetBPGroup();
+  EXPECT_TRUE(bp_grp->hasGroup("matsets"));
+  EXPECT_TRUE(bp_grp->hasGroup("matsets/matset"));
+}
+
   //----------------------------------------------------------------------
   #include "axom/slic/core/SimpleLogger.hpp"
 using axom::slic::SimpleLogger;


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following:
  - Adds new functions for registering mixed-material-related field names such that they can be parsed and added to the correct sections of the blueprint by `RegisterField`

This PR resolves #447 by saving the union of the two options presented - both the regular fields and the matsets/specsets/etc will be created.  The intended workflow is documented in a new example and in an addition to the Sphinx page, which I've updated a bit.