### PR TITLE
Consistent behavior for unexpected types in primitive arrays

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -75,6 +75,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   for consistency
 - Inlet: Fixed a bug relating to nested table lookups of primitive arrays and functions
 - Fixed a bug relating to deeply nested callback functions in Inlet
+- Inlet: Always ignore primitive array elements that do not match the requested type
 
 
 ## [Version 0.4.0] - Release date 2020-09-22

--- a/src/axom/inlet/Table.cpp
+++ b/src/axom/inlet/Table.cpp
@@ -434,6 +434,8 @@ namespace detail
 /*!
   *****************************************************************************
   * \brief Adds the contents of an array to the table
+  * 
+  * \return The keys that were added
   *****************************************************************************
   */
 template <typename T>
@@ -452,6 +454,8 @@ std::vector<VariantKey> registerCollection(Table& table,
 /*!
   *****************************************************************************
   * \brief Adds the contents of a dict to the table
+  * 
+  * \return The keys that were added
   *****************************************************************************
   */
 template <typename T>
@@ -495,6 +499,8 @@ struct PrimitiveArrayHelper<Key, bool>
    * \param [inout] table The table to add the collection to
    * \param [in] reader The Reader object to read the collection from
    * \param [in] lookupPath The path within the input file to the collection
+   * 
+   * \return The keys from the collection that was added
    *****************************************************************************
    */
   static std::vector<VariantKey> add(Table& table,

--- a/src/axom/inlet/Table.hpp
+++ b/src/axom/inlet/Table.hpp
@@ -633,7 +633,7 @@ public:
     if(!hasField(name))
     {
       const std::string msg = fmt::format(
-        "[Inlet] Field with specified path"
+        "[Inlet] Field with specified path "
         "does not exist: {0}",
         name);
       SLIC_ERROR(msg);

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -802,6 +802,58 @@ TYPED_TEST(inlet_object, primitive_arrays_as_std_vector)
   EXPECT_EQ(arr_w_indices, expected_arr_w_indices);
 }
 
+TYPED_TEST(inlet_object, primitive_arrays_as_std_vector_wrong_type)
+{
+  std::string testString = " arr = { [0] = 'a', [1] = 'b', [2] = 'c'}";
+  DataStore ds;
+  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+
+  // Define schema
+  inlet.addIntArray("arr");
+
+  // The array was empty (same as if it didn't exist), but *not* marked as required
+  EXPECT_TRUE(inlet.verify());
+
+  // Attempt both construction and assignment
+  std::vector<int> expected_arr {};
+  std::vector<int> arr = inlet["arr"];
+  EXPECT_EQ(arr, expected_arr);
+  arr = inlet["arr"];
+  EXPECT_EQ(arr, expected_arr);
+}
+
+TYPED_TEST(inlet_object, primitive_arrays_as_std_vector_wrong_type_reqd_fail)
+{
+  std::string testString = " arr = { [0] = 'a', [1] = 'b', [2] = 'c'}";
+  DataStore ds;
+  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+
+  // Define schema
+  inlet.addIntArray("arr").required();
+
+  // The array was empty (same as if it didn't exist), but marked as required
+  EXPECT_FALSE(inlet.verify());
+}
+
+TYPED_TEST(inlet_object, primitive_arrays_as_std_vector_mixed_type)
+{
+  std::string testString = " arr = { [0] = 4, [1] = 6, [2] = 'a', [3] = 'b'}";
+  DataStore ds;
+  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+
+  // Define schema
+  inlet.addIntArray("arr");
+
+  EXPECT_TRUE(inlet.verify());
+
+  // Attempt both construction and assignment
+  std::vector<int> expected_arr {4, 6};
+  std::vector<int> arr = inlet["arr"];
+  EXPECT_EQ(arr, expected_arr);
+  arr = inlet["arr"];
+  EXPECT_EQ(arr, expected_arr);
+}
+
 TYPED_TEST(inlet_object, struct_arrays_as_std_vector)
 {
   std::string testString =


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Partially addresses #476 by ignoring indices of elements that are not of the requested type

# Design review

Currently, having elements of type other than the one requested in an array or dictionary is not an error - these elements are just ignored.  This PR ensures that these other elements are always ignored, but this means that an array that contains the wrong types is indistinguishable from an array that does not exist.  Both cases will cause verification to fail.  

The logic to ignore elements of unexpected type is implemented at the `Reader` level, so one option would be to throw errors there if unexpected elements are found.  This would clash with the current convention of avoiding throwing errors from the `Reader`s (and instead letting Inlet handle things at verification time).  Deferring to verification time would require introducing and propagating a means of distinguishing an empty array due to it not being provided vs not having any elements of the requested type.