### PR TITLE
Adjust Field::operator bool to ignore default values

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -70,8 +70,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Inlet collections of mixed or incorrect type will now fail verification, even if they're
   not marked as required
 - Required collections no longer fail Inlet verification if they are empty in the input file
-- Inlet: Default values no longer impact the "truthiness" of `Field` objects - a `Field` evaluates
-  to true only if a value was provided in the input file
+- Inlet: `operator bool` for `Field` and `Container` has been replaced with more precise `isUserProvided`
+  and `exists`, which also returns `true` if a default value was specified.
 
 ### Fixed
 - Updated to new BLT version that does not fail when ClangFormat returns an empty

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -70,6 +70,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Inlet collections of mixed or incorrect type will now fail verification, even if they're
   not marked as required
 - Required collections no longer fail Inlet verification if they are empty in the input file
+- Inlet: Default values no longer impact the "truthiness" of `Field` objects - a `Field` evaluates
+  to true only if a value was provided in the input file
 
 ### Fixed
 - Updated to new BLT version that does not fail when ClangFormat returns an empty

--- a/src/axom/inlet/Container.cpp
+++ b/src/axom/inlet/Container.cpp
@@ -841,10 +841,10 @@ Container& Container::registerVerifier(std::function<bool(const Container&)> lam
 
 bool Container::verify() const
 {
-  // Whether the calling container has any "truthy" subcontainers, fields, or functions
+  // Whether the calling container has anything in it
   // If the name is empty then we're the global (root) container, which we always
   // consider to be defined
-  const bool this_container_defined = static_cast<bool>(*this) || m_name.empty();
+  const bool this_container_defined = isUserProvided() || m_name.empty();
 
   // If this container was required, make sure something was defined in it
   bool verified =
@@ -858,7 +858,7 @@ bool Container::verify() const
       fmt::format("[Inlet] Container failed verification: {0}", m_name));
   }
 
-  // Checking the child objects is not needed if the container is empty
+  // Checking the child objects is not needed if the container wasn't defined in the input file
   if(this_container_defined)
   {
     // Verify the child Fields of this Container
@@ -999,13 +999,13 @@ bool Container::contains(const std::string& name) const
 {
   if(auto container = getChildInternal<Container>(name))
   {
-    // call operator bool on the container itself
-    return static_cast<bool>(*container);
+    // Check if the container itself exists
+    return container->exists();
   }
   else if(auto field = getChildInternal<Field>(name))
   {
-    // call operator bool on the field itself
-    return static_cast<bool>(*field);
+    // Check if the field itself exists
+    return field->exists();
   }
   else if(auto function = getChildInternal<Function>(name))
   {
@@ -1015,23 +1015,52 @@ bool Container::contains(const std::string& name) const
   return false;
 }
 
-Container::operator bool() const
+bool Container::exists() const
 {
-  // Check if any of its child containers are nontrivial
+  // Check if any of its child containers exist
   const bool has_containers =
     std::any_of(m_containerChildren.begin(),
                 m_containerChildren.end(),
                 [](const decltype(m_containerChildren)::value_type& entry) {
-                  return static_cast<bool>(*entry.second);
+                  return entry.second->exists();
                 });
 
   const bool has_fields =
     std::any_of(m_fieldChildren.begin(),
                 m_fieldChildren.end(),
                 [](const decltype(m_fieldChildren)::value_type& entry) {
+                  return entry.second->exists();
+                });
+
+  // Functions cannot be defaulted and thus have an unambiguous operator bool
+  const bool has_functions =
+    std::any_of(m_functionChildren.begin(),
+                m_functionChildren.end(),
+                [](const decltype(m_functionChildren)::value_type& entry) {
                   return static_cast<bool>(*entry.second);
                 });
 
+  return has_containers || has_fields || has_functions;
+}
+
+bool Container::isUserProvided() const
+{
+  // Check if any of its child containers had user-provided fields
+  const bool has_containers =
+    std::any_of(m_containerChildren.begin(),
+                m_containerChildren.end(),
+                [](const decltype(m_containerChildren)::value_type& entry) {
+                  return entry.second->isUserProvided();
+                });
+
+  const bool has_fields =
+    std::any_of(m_fieldChildren.begin(),
+                m_fieldChildren.end(),
+                [](const decltype(m_fieldChildren)::value_type& entry) {
+                  return entry.second->isUserProvided();
+                });
+
+  // Functions cannot be defaulted and thus have an unambiguous operator bool
   const bool has_functions =
     std::any_of(m_functionChildren.begin(),
                 m_functionChildren.end(),

--- a/src/axom/inlet/Container.cpp
+++ b/src/axom/inlet/Container.cpp
@@ -390,7 +390,10 @@ axom::sidre::DataTypeId Container::addPrimitiveHelper<bool>(
   {
     sidreGroup->createViewScalar("value", val ? int8(1) : int8(0));
   }
-  markRetrievalStatus(*sidreGroup, result);
+  if(!forArray)
+  {
+    markRetrievalStatus(*sidreGroup, result);
+  }
   return axom::sidre::DataTypeId::INT8_ID;
 }
 
@@ -406,7 +409,10 @@ axom::sidre::DataTypeId Container::addPrimitiveHelper<int>(
   {
     sidreGroup->createViewScalar("value", val);
   }
-  markRetrievalStatus(*sidreGroup, result);
+  if(!forArray)
+  {
+    markRetrievalStatus(*sidreGroup, result);
+  }
   return axom::sidre::DataTypeId::INT_ID;
 }
 
@@ -422,7 +428,10 @@ axom::sidre::DataTypeId Container::addPrimitiveHelper<double>(
   {
     sidreGroup->createViewScalar("value", val);
   }
-  markRetrievalStatus(*sidreGroup, result);
+  if(!forArray)
+  {
+    markRetrievalStatus(*sidreGroup, result);
+  }
   return axom::sidre::DataTypeId::DOUBLE_ID;
 }
 
@@ -438,7 +447,10 @@ axom::sidre::DataTypeId Container::addPrimitiveHelper<std::string>(
   {
     sidreGroup->createViewString("value", val);
   }
-  markRetrievalStatus(*sidreGroup, result);
+  if(!forArray)
+  {
+    markRetrievalStatus(*sidreGroup, result);
+  }
   return axom::sidre::DataTypeId::CHAR8_STR_ID;
 }
 

--- a/src/axom/inlet/Container.hpp
+++ b/src/axom/inlet/Container.hpp
@@ -833,11 +833,20 @@ public:
 
   /*!
    *****************************************************************************
-   * \brief Returns whether this container or any of its subcontainers contain a non-
-   * empty field
+   * \brief Returns whether this container or any of its subcontainers exist, 
+   * i.e., if they contain a Field or Function that exists
    *****************************************************************************
    */
-  explicit operator bool() const;
+  bool exists() const;
+
+  /*!
+   *****************************************************************************
+   * \brief Returns whether this container or any of its subcontainers were
+   * provided in the input file, i.e., if they contain a Field or Function that
+   * was provided in the input file
+   *****************************************************************************
+   */
+  bool isUserProvided() const;
 
   /*!
    *****************************************************************************

--- a/src/axom/inlet/Field.cpp
+++ b/src/axom/inlet/Field.cpp
@@ -297,6 +297,20 @@ InletType Field::type() const
   }
 }
 
+Field::operator bool() const
+{
+  if(m_sidreGroup->hasView("retrieval_status"))
+  {
+    auto status = static_cast<ReaderResult>(
+      static_cast<int>(m_sidreGroup->getView("retrieval_status")->getData()));
+    if(status != ReaderResult::Success)
+    {
+      return false;
+    }
+  }
+  return m_sidreGroup->hasView("value");
+}
+
 template <typename T>
 void Field::setScalarValidValues(std::vector<T> set)
 {

--- a/src/axom/inlet/Field.cpp
+++ b/src/axom/inlet/Field.cpp
@@ -297,7 +297,9 @@ InletType Field::type() const
   }
 }
 
-Field::operator bool() const
+bool Field::exists() const { return m_sidreGroup->hasView("value"); }
+
+bool Field::isUserProvided() const
 {
   if(m_sidreGroup->hasView("retrieval_status"))
   {
@@ -308,7 +310,7 @@ Field::operator bool() const
       return false;
     }
   }
-  return m_sidreGroup->hasView("value");
+  return exists();
 }
 
 template <typename T>

--- a/src/axom/inlet/Field.hpp
+++ b/src/axom/inlet/Field.hpp
@@ -314,10 +314,18 @@ public:
 
   /*!
    *****************************************************************************
+   * \brief Returns whether a value for the Field exists, i.e., if a value 
+   * was provided in the input file or if a default was provided
+   *****************************************************************************
+   */
+  bool exists() const;
+
+  /*!
+   *****************************************************************************
    * \brief Returns whether a value was provided in the input file
    *****************************************************************************
    */
-  explicit operator bool() const;
+  bool isUserProvided() const;
 
 private:
   /*!

--- a/src/axom/inlet/Field.hpp
+++ b/src/axom/inlet/Field.hpp
@@ -314,10 +314,10 @@ public:
 
   /*!
    *****************************************************************************
-   * \brief Returns whether an actual value is stored
+   * \brief Returns whether a value was provided in the input file
    *****************************************************************************
    */
-  explicit operator bool() const { return m_sidreGroup->hasView("value"); }
+  explicit operator bool() const;
 
 private:
   /*!

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -946,9 +946,10 @@ TYPED_TEST(inlet_object, default_scalar_marked_false)
   Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
 
   auto& scalar = inlet.addInt("foo").defaultValue(2);
-  // The field itself should evaluate to false because nothing was provided
+  // The field itself exists but was not provided by the user
   auto& field = static_cast<axom::inlet::Field&>(scalar);
-  EXPECT_FALSE(static_cast<bool>(field));
+  EXPECT_TRUE(field.exists());
+  EXPECT_FALSE(field.isUserProvided());
 
   // ...but it should still be possible to retrieve the default
   const int foo = inlet["foo"];
@@ -968,8 +969,9 @@ TYPED_TEST(inlet_object, default_struct_field_marked_false)
   foo_container.addBool("bar", "bar's description").defaultValue(true);
   foo_container.addBool("baz", "baz's description").defaultValue(false);
 
-  // The struct itself should evaluate to false because nothing was provided
-  EXPECT_FALSE(static_cast<bool>(foo_container));
+  // The container itself exists but was not provided by the user
+  EXPECT_TRUE(foo_container.exists());
+  EXPECT_FALSE(foo_container.isUserProvided());
 
   // ...but it should still be possible to retrieve the default
   const Foo expected_foo {true, false};
@@ -990,8 +992,9 @@ TYPED_TEST(inlet_object, default_struct_field_marked_true)
   foo_container.addBool("bar", "bar's description").defaultValue(true);
   foo_container.addBool("baz", "baz's description").defaultValue(false);
 
-  // The struct itself should evaluate to true because at least one field was provided
-  EXPECT_TRUE(static_cast<bool>(foo_container));
+  // The container itself exists and was provided by the user
+  EXPECT_TRUE(foo_container.exists());
+  EXPECT_TRUE(foo_container.isUserProvided());
 
   // ...and it should still be possible to retrieve the full struct
   const Foo expected_foo {true, false};

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -939,7 +939,7 @@ TYPED_TEST(inlet_object, struct_arrays_as_std_vector)
   EXPECT_EQ(foos, expected_foos);
 }
 
-TYPED_TEST(inlet_object, default_scalar_marked_false)
+TYPED_TEST(inlet_object, default_scalar_user_provided)
 {
   std::string testString = " ";
   DataStore ds;
@@ -959,7 +959,7 @@ TYPED_TEST(inlet_object, default_scalar_marked_false)
   EXPECT_TRUE(inlet.verify());
 }
 
-TYPED_TEST(inlet_object, default_struct_field_marked_false)
+TYPED_TEST(inlet_object, default_struct_field_user_provided)
 {
   std::string testString = " ";
   DataStore ds;
@@ -980,6 +980,32 @@ TYPED_TEST(inlet_object, default_struct_field_marked_false)
 
   // and it should not impede verification
   EXPECT_TRUE(inlet.verify());
+}
+
+TYPED_TEST(inlet_object, default_struct_field_user_provided_reqd)
+{
+  std::string testString = " ";
+  DataStore ds;
+  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+
+  auto& foo_container = inlet.addStruct("foo").required();
+  foo_container.addBool("bar", "bar's description").defaultValue(true);
+  foo_container.addBool("baz", "baz's description").defaultValue(false);
+
+  // The container itself exists but was not provided by the user
+  EXPECT_TRUE(foo_container.exists());
+  EXPECT_FALSE(foo_container.isUserProvided());
+
+  // ...but it should still be possible to retrieve the default
+  const Foo expected_foo {true, false};
+  const auto foo = inlet["foo"].get<Foo>();
+  EXPECT_EQ(foo, expected_foo);
+
+  // and it should not impede verification
+  // EXPECT_TRUE(inlet.verify()); // fails here...
+  // FIXME: This one is a bit of a degenerate case where all fields have defaults
+  // and the struct is marked as required - need to determine how this can be
+  // handled in the general case
 }
 
 TYPED_TEST(inlet_object, default_struct_field_marked_true)


### PR DESCRIPTION
# Summary

- This PR is a feature/bugfix
- It does the following:
  - Modifies `Field::operator bool` to ignore default values

This is sort of an extension of the discussion here: https://github.com/LLNL/axom/pull/478#discussion_r583117072
and a follow-up to #481.  With this latest set of changes, a `Container` will now only be verified if something was specified in the input file (the desired behavior) and *not* when defaults were provided in `Field`s within that `Container` (the current behavior).
