### PR TITLE
Augments sidre_native_layout tests with zero-sized arrays

### DIFF
--- a/src/axom/sidre/core/Buffer.cpp
+++ b/src/axom/sidre/core/Buffer.cpp
@@ -194,8 +194,11 @@ Buffer* Buffer::copyBytesIntoBuffer(void* src, IndexType nbytes)
 {
   if(src == nullptr || nbytes < 0 || nbytes > getTotalBytes())
   {
-    SLIC_CHECK_MSG(src != nullptr,
-                   "Cannot copy data into Buffer from null pointer.");
+    if(src == nullptr)
+    {
+      SLIC_CHECK_MSG(nbytes == 0,
+                     "Cannot copy data into Buffer from null pointer.");
+    }
     SLIC_CHECK_MSG(nbytes >= 0, "Cannot copy < 0 bytes of data into Buffer.");
     SLIC_CHECK_MSG(nbytes <= getTotalBytes(),
                    "Unable to copy " << nbytes << " bytes of data into Buffer with "
@@ -299,8 +302,14 @@ void Buffer::importFrom(conduit::Node& buffer_holder)
   {
     allocate();
     conduit::Node& buffer_data_holder = buffer_holder["data"];
-    copyBytesIntoBuffer(buffer_data_holder.element_ptr(0),
-                        buffer_data_holder.total_strided_bytes());
+
+    const auto num_bytes = buffer_data_holder.total_strided_bytes();
+    if(num_bytes > 0)
+    {
+      copyBytesIntoBuffer(buffer_data_holder.element_ptr(0), num_bytes);
+    }
+
+    this->print();
   }
 }
 

--- a/src/axom/sidre/core/Buffer.cpp
+++ b/src/axom/sidre/core/Buffer.cpp
@@ -308,8 +308,6 @@ void Buffer::importFrom(conduit::Node& buffer_holder)
     {
       copyBytesIntoBuffer(buffer_data_holder.element_ptr(0), num_bytes);
     }
-
-    this->print();
   }
 }
 

--- a/src/axom/sidre/tests/sidre_native_layout.cpp
+++ b/src/axom/sidre/tests/sidre_native_layout.cpp
@@ -546,6 +546,9 @@ TEST(sidre_native_layout, basic_demo_compare)
     a5_view_ptr[i] = sidre_vals_1[i];
   }
 
+  // one array of size 0
+  group3->createViewAndAllocate("a0_i64", axom::sidre::DataType::int64(0));
+
   // one external array
   group3->createView("a5_i64_ext", conduit::DataType::int64(5))
     ->setExternalDataPtr(sidre_vals_1);
@@ -564,8 +567,13 @@ TEST(sidre_native_layout, basic_demo_compare)
     buff_ptr[i] = sidre_vals_2[i];
   }
 
+  View* v0 = group3->createView("b_v0");
   View* v1 = group3->createView("b_v1");
   View* v2 = group3->createView("b_v2");
+
+  // v0 is a view of size zero into this buffer
+  v0->attachBuffer(buff);
+  v0->apply(conduit::DataType::float64(0));
 
   // with these settings, bv1 should have 1.0 as all vals
   v1->attachBuffer(buff);
@@ -604,6 +612,7 @@ TEST(sidre_native_layout, basic_demo_compare)
   // create an equiv conduit tree for testing
   //
 
+  axom::int64 conduit_vals_0[] = {};
   axom::int64 conduit_vals_1[5] = {0, 1, 2, 3, 4};
   axom::float64 conduit_vals_2[6] = {
     1.0,
@@ -620,7 +629,9 @@ TEST(sidre_native_layout, basic_demo_compare)
   n["my_strings/s0"] = "s0 string";
   n["my_strings/s1"] = "s1 string";
   n["my_arrays/a5_i64"].set(conduit_vals_1, 5);
+  n["my_arrays/a0_i64"].set(conduit_vals_0, 0);
   n["my_arrays/a5_i64_ext"].set_external(conduit_vals_1, 5);
+  n["my_arrays/b_v0"].set(conduit_vals_2, 0);
   n["my_arrays/b_v1"].set(conduit_vals_2, 3, 0, 2 * sizeof(conduit::float64));
   n["my_arrays/b_v2"].set(conduit_vals_2,
                           3,

--- a/src/axom/sidre/tests/sidre_native_layout.cpp
+++ b/src/axom/sidre/tests/sidre_native_layout.cpp
@@ -612,7 +612,6 @@ TEST(sidre_native_layout, basic_demo_compare)
   // create an equiv conduit tree for testing
   //
 
-  axom::int64 conduit_vals_0[] = {};
   axom::int64 conduit_vals_1[5] = {0, 1, 2, 3, 4};
   axom::float64 conduit_vals_2[6] = {
     1.0,
@@ -622,14 +621,17 @@ TEST(sidre_native_layout, basic_demo_compare)
     1.0,
     2.0,
   };
+  // Note: use a std::vector for the empty array as workaround for
+  // MSVC error C2466 about allocating arrays of constant size 0
+  std::vector<conduit::int64> conduit_vals_0;
 
   axom::sidre::Node n;
   n["my_scalars/i64"].set_int64(1);
   n["my_scalars/f64"].set_float64(10.0);
   n["my_strings/s0"] = "s0 string";
   n["my_strings/s1"] = "s1 string";
+  n["my_arrays/a0_i64"].set(conduit_vals_0.data(), 0);
   n["my_arrays/a5_i64"].set(conduit_vals_1, 5);
-  n["my_arrays/a0_i64"].set(conduit_vals_0, 0);
   n["my_arrays/a5_i64_ext"].set_external(conduit_vals_1, 5);
   n["my_arrays/b_v0"].set(conduit_vals_2, 0);
   n["my_arrays/b_v1"].set(conduit_vals_2, 3, 0, 2 * sizeof(conduit::float64));

--- a/src/axom/sidre/tests/sidre_native_layout.cpp
+++ b/src/axom/sidre/tests/sidre_native_layout.cpp
@@ -645,6 +645,7 @@ TEST(sidre_native_layout, basic_demo_compare)
 
   axom::sidre::Node n_info;
   EXPECT_FALSE(n.diff(n_sidre, n_info));
+  n_info.print();
 
   //
   // TODO: When using newer conduit that has relay support for sidre i/o

--- a/src/axom/sidre/tests/spio/spio_parallel.hpp
+++ b/src/axom/sidre/tests/spio/spio_parallel.hpp
@@ -81,9 +81,12 @@ TEST(spio_parallel, parallel_writeread)
   Group* flds = root->createGroup("fields");
   Group* flds2 = root->createGroup("fields2");
 
+  // Add a scalar view under group "a"
   Group* ga = flds->createGroup("a");
-  Group* gb = flds2->createGroup("b");
   ga->createViewScalar<int>("i0", 101 * my_rank);
+
+  // Add an array view under group "b"
+  Group* gb = flds2->createGroup("b");
   gb->createView("i1")->allocate(DataType::c_int(10));
   int* i1_vals = gb->getView("i1")->getData();
 
@@ -91,6 +94,10 @@ TEST(spio_parallel, parallel_writeread)
   {
     i1_vals[i] = (i + 10) * (404 - my_rank - i);
   }
+
+  // Add an array view of size 0 under group "c"
+  Group* gc = flds2->createGroup("c");
+  gc->createView("i2")->allocate(DataType::c_int(0));
 
   // The namespace qualifying IOManager is not necessary for compilation
   // (because are already using axom::sidre::IOManager), but we've kept it
@@ -188,29 +195,48 @@ TEST(spio_parallel, parallel_writeread)
    */
   EXPECT_TRUE(ds2->getRoot()->isEquivalentTo(root));
 
-  int testvalue =
-    ds->getRoot()->getGroup("fields")->getGroup("a")->getView("i0")->getData();
-  int testvalue2 =
-    ds2->getRoot()->getGroup("fields")->getGroup("a")->getView("i0")->getData();
-
-  EXPECT_EQ(testvalue, testvalue2);
-
-  View* view_i1_orig =
-    ds->getRoot()->getGroup("fields2")->getGroup("b")->getView("i1");
-  View* view_i1_restored =
-    ds2->getRoot()->getGroup("fields2")->getGroup("b")->getView("i1");
-
-  int num_elems = view_i1_orig->getNumElements();
-  EXPECT_EQ(view_i1_restored->getNumElements(), num_elems);
-  if(view_i1_restored->getNumElements() == num_elems)
+  // check group "a", which should contain a view with a single scalar
   {
-    int* i1_orig = view_i1_orig->getData();
-    int* i1_restored = view_i1_restored->getData();
+    int testvalue =
+      ds->getRoot()->getGroup("fields")->getGroup("a")->getView("i0")->getData();
+    int testvalue2 =
+      ds2->getRoot()->getGroup("fields")->getGroup("a")->getView("i0")->getData();
 
-    for(int i = 0; i < num_elems; ++i)
+    EXPECT_EQ(testvalue, testvalue2);
+  }
+
+  // check group "b", which should contain a view with an array of ints
+  {
+    View* view_i1_orig =
+      ds->getRoot()->getGroup("fields2")->getGroup("b")->getView("i1");
+    View* view_i1_restored =
+      ds2->getRoot()->getGroup("fields2")->getGroup("b")->getView("i1");
+
+    int num_elems = view_i1_orig->getNumElements();
+    EXPECT_EQ(view_i1_restored->getNumElements(), num_elems);
+    if(view_i1_restored->getNumElements() == num_elems)
     {
-      EXPECT_EQ(i1_orig[i], i1_restored[i]);
+      int* i1_orig = view_i1_orig->getData();
+      int* i1_restored = view_i1_restored->getData();
+
+      for(int i = 0; i < num_elems; ++i)
+      {
+        EXPECT_EQ(i1_orig[i], i1_restored[i]);
+      }
     }
+  }
+
+  // check group "c", which should contain a view with an array of size 0
+  {
+    View* view_i2_orig =
+      ds->getRoot()->getGroup("fields2")->getGroup("c")->getView("i2");
+    View* view_i2_restored =
+      ds2->getRoot()->getGroup("fields2")->getGroup("c")->getView("i2");
+
+    int num_elems_orig = view_i2_orig->getNumElements();
+    int num_elems_rest = view_i2_restored->getNumElements();
+    EXPECT_EQ(0, num_elems_orig);
+    EXPECT_EQ(0, num_elems_rest);
   }
 
   delete ds;


### PR DESCRIPTION
# Summary

- Attempting to track down a bug with zero-sized arrays when opening blueprint meshes in VisIt