### PR TITLE
Don't rewrite generated headers if they haven't changed

### DIFF
--- a/src/cmake/AxomConfig.cmake
+++ b/src/cmake/AxomConfig.cmake
@@ -76,7 +76,7 @@ if(ENABLE_FORTRAN)
 
 endif(ENABLE_FORTRAN)
 
-configure_file(
+axom_configure_file(
     ${PROJECT_SOURCE_DIR}/axom/config.hpp.in
     ${CMAKE_BINARY_DIR}/include/axom/config.hpp
 )

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -338,18 +338,19 @@ macro(axom_write_unified_header)
     string(TOUPPER ${arg_NAME} _ucname)
     string(TOLOWER ${arg_NAME} _lcname)
     set(_header ${CMAKE_BINARY_DIR}/include/axom/${_lcname}.hpp)
+    set(_tmp_header ${_header}.tmp)
 
-    file(WRITE ${_header} "\/\/ Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+    file(WRITE ${_tmp_header} "\/\/ Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
 \/\/ other Axom Project Developers. See the top-level COPYRIGHT file for details.
 \/\/
 \/\/ SPDX-License-Identifier: (BSD-3-Clause)
 \n
 ")
 
-    file(APPEND ${_header} "#ifndef AXOM_UNIFIED_${_ucname}_HPP\n")
-    file(APPEND ${_header} "#define AXOM_UNIFIED_${_ucname}_HPP\n\n")
+    file(APPEND ${_tmp_header} "#ifndef AXOM_UNIFIED_${_ucname}_HPP\n")
+    file(APPEND ${_tmp_header} "#define AXOM_UNIFIED_${_ucname}_HPP\n\n")
 
-    file(APPEND ${_header} "#include \"axom\/config.hpp\"\n\n")
+    file(APPEND ${_tmp_header} "#include \"axom\/config.hpp\"\n\n")
 
     foreach(_file ${arg_HEADERS})
         set(_headerPath "axom\/${_lcname}\/${_file}")
@@ -359,13 +360,31 @@ macro(axom_write_unified_header)
         elseif(${_headerPath} MATCHES "(\/detail\/)|(\/internal\/)")
             continue()
         else()
-            file(APPEND ${_header} "#include \"${_headerPath}\"\n")
+            file(APPEND ${_tmp_header} "#include \"${_headerPath}\"\n")
         endif()
     endforeach()
 
-    file(APPEND ${_header} "\n#endif // AXOM_UNIFIED_${_ucname}_HPP\n")
+    file(APPEND ${_tmp_header} "\n#endif // AXOM_UNIFIED_${_ucname}_HPP\n")
+
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_tmp_header} ${_header})
+    execute_process(COMMAND ${CMAKE_COMMAND} -E remove ${_tmp_header})
 
     install(FILES       ${_header}
             DESTINATION include/axom)
 
 endmacro(axom_write_unified_header)
+
+##------------------------------------------------------------------------------
+## axom_configure_file
+##
+## This macro is a thin wrapper over the builtin configure_file command.
+## It has the same arguments/options as configure_file but introduces an
+## intermediate file that is only copied to the target file if the target differs
+## from the intermediate.
+##------------------------------------------------------------------------------
+macro(axom_configure_file _source _target)
+    set(_tmp_target ${_target}.tmp)
+    configure_file(${_source} ${_tmp_target} ${ARGN})
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_tmp_target} ${_target})
+    execute_process(COMMAND ${CMAKE_COMMAND} -E remove ${_tmp_target})
+endmacro(axom_configure_file)


### PR DESCRIPTION
# Summary

- This PR is a build system refactoring
- It does the following:
  - Avoids rewriting headers that would not otherwise change when CMake is reconfigured

This PR is primarily intended to address the unnecessary full rebuilds that take place every time CMake is reconfigured.
Specifically, any modification to a CMakeLists.txt anywhere within Axom will cause CMake to reconfigure (which is reasonable).
The issue is that this will "touch" the config header and per-component unified headers, which most Axom components are dependent on - meaning that everything will rebuild.

These changes improve developer efficiency by only "touch"ing the generated headers if doing so would change their contents.
