### PR TITLE
Add method to import Node holding array data into a View

### DIFF
--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -2181,28 +2181,8 @@ bool Group::importConduitTree(const conduit::Node& node, bool preserve_contents)
         }
         else
         {
-          // create view with buffer
-          Buffer* buff = getDataStore()->createBuffer();
-
-          conduit::index_t num_ele = cld_dtype.number_of_elements();
-          conduit::index_t ele_bytes = DataType::default_bytes(cld_dtype.id());
-
-          buff->allocate((TypeID)cld_dtype.id(), num_ele);
-          // copy the data in a way that matches
-          // to compact representation of the buffer
-          conduit::uint8* data_ptr = (conduit::uint8*)buff->getVoidPtr();
-          for(conduit::index_t i = 0; i < num_ele; i++)
-          {
-            memcpy(data_ptr, cld_node.element_ptr(i), ele_bytes);
-            data_ptr += ele_bytes;
-          }
-
           View* view = createView(cld_name);
-          view->attachBuffer(buff);
-          // it is important to not use the data type directly
-          // it could contain offsets that are no longer
-          // valid our new buffer
-          view->apply((TypeID)cld_dtype.id(), cld_dtype.number_of_elements());
+          view->importArrayNode(cld_node);
         }
       }
       else

--- a/src/axom/sidre/core/View.cpp
+++ b/src/axom/sidre/core/View.cpp
@@ -1270,6 +1270,13 @@ void View::importFrom(conduit::Node& data_holder,
   }
 }
 
+/*
+ *************************************************************************
+ *
+ * Import Node holding an array into a View with an attached Buffer.
+ *
+ *************************************************************************
+ */
 View* View::importArrayNode(const Node& array)
 {
 

--- a/src/axom/sidre/core/View.cpp
+++ b/src/axom/sidre/core/View.cpp
@@ -1317,7 +1317,7 @@ View* View::importArrayNode(const Node& array)
     {
       SLIC_CHECK_MSG(m_state == EMPTY,
                      SIDRE_VIEW_LOG_PREPEND
-                       << "Unable to set Buffer on view with state: "
+                       << "Unable to import array Node to View with state: "
                        << getStateStringName(m_state));
     }
   }
@@ -1325,7 +1325,7 @@ View* View::importArrayNode(const Node& array)
   {
     SLIC_CHECK_MSG(array_dtype.is_number(),
                    SIDRE_VIEW_LOG_PREPEND
-                     << "Unable to set Buffer view using Node of type: "
+                     << "Unable to import array from Node of type: "
                      << array_dtype.name());
   }
 

--- a/src/axom/sidre/core/View.cpp
+++ b/src/axom/sidre/core/View.cpp
@@ -1279,7 +1279,6 @@ void View::importFrom(conduit::Node& data_holder,
  */
 View* View::importArrayNode(const Node& array)
 {
-
   conduit::DataType array_dtype = array.dtype();
 
   if(array_dtype.is_number())
@@ -1331,7 +1330,6 @@ View* View::importArrayNode(const Node& array)
 
   return this;
 }
-
 
 /*
  *************************************************************************

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -644,6 +644,25 @@ public:
     return this;
   }
 
+  /*
+ * \brief set the View to hold an array in a Buffer
+ *
+ * This takes a Node that holds an array of data and sets up the View to
+ * hold a copy of that data in an attached Buffer.
+ *
+ * The prerequisites are that the Node must have numerical conduit data type
+ * (it returns true for a call to conduit::DataType::is_number()), and the
+ * state of this View must be either EMPTY or BUFFER when entering.  If the
+ * prerequisites are not met, a warning will be issued and this View will be
+ * unchanged.
+ *
+ * If this View has the state BUFFER when this method is called, it will
+ * become detached from its previous Buffer.
+ *
+ * \return pointer to this View object
+ */
+  View* importArrayNode(const Node& array);
+
   //
   // RDH -- Add an overload of the following that takes a const char *.
   //

--- a/src/axom/sidre/tests/sidre_view.cpp
+++ b/src/axom/sidre/tests/sidre_view.cpp
@@ -1657,7 +1657,7 @@ TEST(sidre_view, import_array_node)
 
   //Import Node holding int array
   std::vector<int> int_vec;
-  for (int i = 0; i < 10; ++i)
+  for(int i = 0; i < 10; ++i)
   {
     int_vec.push_back(i * i + 3);
   }
@@ -1675,16 +1675,16 @@ TEST(sidre_view, import_array_node)
 
   int* v_ints = v1->getData();
 
-  for (int i = 0; i < 10; ++i)
+  for(int i = 0; i < 10; ++i)
   {
     EXPECT_EQ(v_ints[i], i * i + 3);
   }
 
   //Import Node holding double array
   std::vector<double> dbl_vec;
-  for (int i = 0; i < 8; ++i)
+  for(int i = 0; i < 8; ++i)
   {
-    dbl_vec.push_back(static_cast<double>(i)/2.0 + 1.1);
+    dbl_vec.push_back(static_cast<double>(i) / 2.0 + 1.1);
   }
 
   conduit::Node n_dbls;
@@ -1700,9 +1700,9 @@ TEST(sidre_view, import_array_node)
 
   double* v_dbls = v2->getData();
 
-  for (int i = 0; i < 8; ++i)
+  for(int i = 0; i < 8; ++i)
   {
-    EXPECT_NEAR(v_dbls[i], static_cast<double>(i)/2.0 + 1.1, 1.0e-12);
+    EXPECT_NEAR(v_dbls[i], static_cast<double>(i) / 2.0 + 1.1, 1.0e-12);
   }
 
   //Attempt to import a non-array node, will not work.
@@ -1714,13 +1714,12 @@ TEST(sidre_view, import_array_node)
 
   EXPECT_TRUE(v3->isEmpty());
 
-  //Attempt to import into View that is already a string, will not work. 
+  //Attempt to import into View that is already a string, will not work.
   View* v4 = root->createView("v4");
   v4->setString("string_view");
 
   v4->importArrayNode(n_ints);
   EXPECT_TRUE(v4->isString());
-
 }
 
 #ifdef AXOM_USE_UMPIRE

--- a/src/axom/sidre/tests/sidre_view.cpp
+++ b/src/axom/sidre/tests/sidre_view.cpp
@@ -1649,6 +1649,80 @@ TEST(sidre_view, value_from_uninited_view)
   DataStore::setConduitDefaultMessageHandlers();
 }
 
+//------------------------------------------------------------------------------
+TEST(sidre_view, import_array_node)
+{
+  DataStore* ds = new DataStore();
+  Group* root = ds->getRoot();
+
+  //Import Node holding int array
+  std::vector<int> int_vec;
+  for (int i = 0; i < 10; ++i)
+  {
+    int_vec.push_back(i * i + 3);
+  }
+
+  conduit::Node n_ints;
+  n_ints.set(int_vec);
+
+  View* v1 = root->createView("v1");
+  v1->importArrayNode(n_ints);
+
+  EXPECT_TRUE(v1->hasBuffer());
+  EXPECT_TRUE(v1->isAllocated());
+  EXPECT_TRUE(v1->isApplied());
+  EXPECT_EQ(v1->getNumElements(), 10);
+
+  int* v_ints = v1->getData();
+
+  for (int i = 0; i < 10; ++i)
+  {
+    EXPECT_EQ(v_ints[i], i * i + 3);
+  }
+
+  //Import Node holding double array
+  std::vector<double> dbl_vec;
+  for (int i = 0; i < 8; ++i)
+  {
+    dbl_vec.push_back(static_cast<double>(i)/2.0 + 1.1);
+  }
+
+  conduit::Node n_dbls;
+  n_dbls.set(dbl_vec);
+
+  View* v2 = root->createView("v2");
+  v2->importArrayNode(n_dbls);
+
+  EXPECT_TRUE(v2->hasBuffer());
+  EXPECT_TRUE(v2->isAllocated());
+  EXPECT_TRUE(v2->isApplied());
+  EXPECT_EQ(v2->getNumElements(), 8);
+
+  double* v_dbls = v2->getData();
+
+  for (int i = 0; i < 8; ++i)
+  {
+    EXPECT_NEAR(v_dbls[i], static_cast<double>(i)/2.0 + 1.1, 1.0e-12);
+  }
+
+  //Attempt to import a non-array node, will not work.
+  conduit::Node n_obj;
+  n_obj.set(conduit::DataType::object());
+
+  View* v3 = root->createView("v3");
+  v3->importArrayNode(n_obj);
+
+  EXPECT_TRUE(v3->isEmpty());
+
+  //Attempt to import into View that is already a string, will not work. 
+  View* v4 = root->createView("v4");
+  v4->setString("string_view");
+
+  v4->importArrayNode(n_ints);
+  EXPECT_TRUE(v4->isString());
+
+}
+
 #ifdef AXOM_USE_UMPIRE
 
 class UmpireTest : public ::testing::TestWithParam<int>


### PR DESCRIPTION
# Summary

- This PR is a refactoring
- It does the following (modify list as needed):
  - Refactors code that was in `Group::importConduitTree` to create a standalone method to import a Node holding an array into a View

As I have been working on some SPIO changes to deal with changes to the Blueprint index, I found the need to import a Node that had a simple array of integers into a View that would hold a copy of that array in an internal attached Buffer.  `importConduitTree` has the code to do this, but it only works when the array Node is a leaf in a larger tree of hierarchical conduit data, and Sidre did not provide a method to do this operation by itself.

This PR refactors the existing code that did this task in `importConduitTree` into a standalone method `importArrayNode`.
