### PR TITLE
change code-blocks syntax highlighting to not sphinx

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -135,7 +135,7 @@ exclude_patterns = [ '_build',
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'default'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []


### PR DESCRIPTION
Before:

https://axom.readthedocs.io/en/develop/axom/inlet/docs/sphinx/advanced_types.html#accessing

After:

https://axom.readthedocs.io/en/feature-white238-banishpukegreen/axom/inlet/docs/sphinx/advanced_types.html#accessing

Examples of other choices:

https://help.farbox.com/pygments.html