### PR TITLE
Fixes for SCR test in CI

### DIFF
--- a/src/axom/sidre/examples/spio/CMakeLists.txt
+++ b/src/axom/sidre/examples/spio/CMakeLists.txt
@@ -45,7 +45,7 @@ endforeach()
                 axom_add_test(
                     NAME spio_IO_SCR_Checkpoint
                     COMMAND spio_IO_SCR_Checkpoint_ex 
-                    NUM_MPI_TASKS 1 )
+                    NUM_MPI_TASKS 2 )
             else()
                 axom_add_test(
                     NAME spio_IO_SCR_Checkpoint

--- a/src/axom/sidre/examples/spio/CMakeLists.txt
+++ b/src/axom/sidre/examples/spio/CMakeLists.txt
@@ -41,9 +41,15 @@ endforeach()
 
     if(AXOM_ENABLE_TESTS)
         if(SCR_FOUND)
-            axom_add_test(
-                NAME spio_IO_SCR_Checkpoint
-                COMMAND spio_IO_SCR_Checkpoint_ex )
+            if(ENABLE_MPI)
+                axom_add_test(
+                    NAME spio_IO_SCR_Checkpoint
+                    COMMAND spio_IO_SCR_Checkpoint_ex 
+                    NUM_MPI_TASKS 1 )
+            else()
+                axom_add_test(
+                    NAME spio_IO_SCR_Checkpoint
+                    COMMAND spio_IO_SCR_Checkpoint_ex )
+            endif()
         endif()
     endif()
-


### PR DESCRIPTION
PR needed to trigger GitLab pipeline

Since we've run into this before, would it be worth extending `axom_add_test` as follows (pseudocode)?

```py
if not num_mpi_tasks and enable_mpi:
  num_mpi_tasks = 1
```

See the current definition of `axom_add_test` below:
https://github.com/LLNL/axom/blob/f7d112c808e0a2767e57e6055c05d934c9538cca/src/cmake/AxomMacros.cmake#L118-L155