### PR TITLE
Adds manually triggered github actions workflow for testing Windows TPLs

### DIFF
--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -36,4 +36,4 @@ jobs:
       run: dir
     - name: Run uberenv (w/ default settings) 
       run: |
-        python3 scripts/uberenv/uberenv.py
+        python3 .\scripts\uberenv\uberenv.py

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -40,6 +40,14 @@ jobs:
         dir
         dir scripts
         dir scripts/uberenv
-    - name: Run uberenv (w/ default settings) 
-      run: |
-        python3 ./scripts/uberenv/uberenv.py
+    - name: Run uberenv (x64-windows)
+      run: python3 ./scripts/uberenv/uberenv.py --triplet "x64-windows"
+    - name: Copy host-config
+      run: Copy-Item -Path ".\uberenv_libs\*.cmake" -Destination "hc.cmake"
+    - name: Configure axom
+      run: python3 config-build.py -bp build-axom -ip install-axom -hc hc.cmake --msvc 201964
+    - name: Build axom debug
+      run: cmake --build . --config Debug
+    - name: Test axom debug
+      run: ctest -C Debug
+

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: List path and files
-      run: dir
+      run: ls
     - name: Run uberenv (x64-windows)
       run: python3 ./scripts/uberenv/uberenv.py --triplet "x64-windows"
     - name: Copy host-config
@@ -42,11 +42,18 @@ jobs:
     - name: Configure axom
       run: |
         python3 config-build.py -bp build-axom -ip install-axom -hc hc.cmake --msvc 201964
+    - name: cd into build directory
+      run: |
         cd build-axom
+        ls
     - name: Build axom debug
-      run: cmake --build . --config Debug
+      run: |
+        ls
+        cmake --build . --config Debug
     - name: Test axom debug
-      run: ctest -C Debug
+      run: |
+        ls
+        ctest -C Debug
     - name: Build axom release
       run: cmake --build . --config Release
     - name: Test axom release

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -26,6 +26,10 @@ jobs:
         python-version: '3.7'
     - name: List path and files
       run: ls
+    - name: Temp -- checkout update-mfem branch
+      run: |
+        git checkout feature/kweiss/update-mfem
+        git status
     - name: Run uberenv (x64-windows)
       run: python3 ./scripts/uberenv/uberenv.py --triplet "x64-windows"
     - name: Copy host-config

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -33,21 +33,21 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.7'
-    - name: Show path
-      run: pwd
-    - name: List files
-      run: |
-        dir
-        dir scripts
-        dir scripts/uberenv
+    - name: List path and files
+      run: dir
     - name: Run uberenv (x64-windows)
       run: python3 ./scripts/uberenv/uberenv.py --triplet "x64-windows"
     - name: Copy host-config
       run: Copy-Item -Path ".\uberenv_libs\*.cmake" -Destination "hc.cmake"
     - name: Configure axom
-      run: python3 config-build.py -bp build-axom -ip install-axom -hc hc.cmake --msvc 201964
+      run: |
+        python3 config-build.py -bp build-axom -ip install-axom -hc hc.cmake --msvc 201964
+        cd build-axom
     - name: Build axom debug
       run: cmake --build . --config Debug
     - name: Test axom debug
       run: ctest -C Debug
-
+    - name: Build axom release
+      run: cmake --build . --config Release
+    - name: Test axom release
+      run: ctest -C Release

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -50,6 +50,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+    - uses: 
     - name: List path and files
       run: ls
     - name: Run uberenv

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -30,4 +30,4 @@ jobs:
       with:
         python-version: '3.7'
     - name: Send python greeting
-      run: python2 -c "print(F'Hello ${{ github.event.inputs.name }}')"
+      run: python3 -c 'print(F"Hello ${{ github.event.inputs.name }}")'

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -30,4 +30,4 @@ jobs:
       with:
         python-version: '3.7'
     - name: Send python greeting
-      run: python3 -c 'print(F"Hello ${{ github.event.inputs.name }}")'
+      run: python3 -c "print(F\"Hello ${{ github.event.inputs.name }}\")"

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -9,12 +9,10 @@ on:
   
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This job will check out the repo and invoke uberenv to build and test our TPLs
-  run_uberenv:
-    # The type of runner that the job will run on
+  # The first job checks out the code and sets up python
+  checkout_code:
     runs-on: windows-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout repo w/ submodules
       uses: actions/checkout@v2
@@ -24,32 +22,54 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.7'
+  
+  # This job invokes uberenv to build our TPLs for two "triplets"
+  run_uberenv:
+    name: Runs uberenv with vckpkg triplet ${{ matrix.triplet }}
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+    needs: checkout_code
+    strategy:
+      matrix:
+        triplet: ["x64-windows",      "x86-windows"]
+        msvc:    ["201964",           "2019"]
+        hc:      ["hc_x64.cmake",     "hc_x86.cmake"]
+        prefix:  ["uberenv_libs_x64", "uberenv_libs_x86"]
+        build:   ["build_x64",        "build_x86"]
+        install: ["install_x64",      "install_x86"]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
     - name: List path and files
       run: ls
-    - name: Run uberenv (x64-windows)
-      run: python3 ./scripts/uberenv/uberenv.py --triplet "x64-windows"
+    - name: Run uberenv
+      run: python3 ./scripts/uberenv/uberenv.py --triplet ${{ matrix.triplet }} --prefix ${{ matrix.prefix }}
     - name: Copy host-config
-      run: Copy-Item -Path ".\uberenv_libs\*.cmake" -Destination "hc.cmake"
+      run: Copy-Item -Path ".\${{ matrix.prefix }}\*.cmake" -Destination "${{ matrix.hc }}"
     - name: Configure axom
       run: |
-        python3 config-build.py -bp build-axom -ip install-axom -hc hc.cmake --msvc 201964
-    - name: Build axom debug
+        python3 config-build.py -bp ${{ matrix.build }} -ip ${{ matrix.install }} -hc ${{ matrix.hc }} --msvc ${{ matrix.msvc }}
+
+  # Our next job builds and tests the code in Debug and Release mode
+  build_and_test:
+    name: Builds and tests the ${{ matrix.name }} configuration
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+    needs: run_uberenv
+    strategy:
+      matrix:
+        name:      ["x64_Debug",  "x64_Release", "x86_Debug",  "x86_Release"]
+        build_dir: ["build_x64",  "build_x64",   "build_x86",  "build_x86"  ]
+        cfg:       ["Debug",      "Release",     "Debug",      "Release"    ]
+
+    steps:
+    - name: Build axom ${{ matrix.name}}
       run: |
-        cd build-axom
+        cd build-${{ matrix.build_dir }}
         ls
-        cmake --build . --config Debug
+        cmake --build . --config ${{ matrix.cfg }}
     - name: Test axom debug
       run: |
         cd build-axom
         ls
-        ctest -C Debug
-    - name: Build axom release
-      run: |
-        cd build-axom
-        ls
-        cmake --build . --config Release
-    - name: Test axom release
-      run: |
-        cd build-axom
-        ls
-        ctest -C Release
+        ctest -C ${{ matrix.cfg }}

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -26,8 +26,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - name: Set up python
+      uses: actions/setup-python@v2
       with:
         python-version: '3.7'
-    - name: Send python greeting
-      run: python3 -c "print(F\"Hello ${{ github.event.inputs.name }}\")"
+    - name: Display python version
+      run: python3 -c "import sys; print(sys.version)"

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -42,7 +42,9 @@ jobs:
     - name: Run uberenv (${{ matrix.triplet }})
       run: python3 ./scripts/uberenv/uberenv.py --triplet ${{ matrix.triplet }}
     - name: Copy host-config
-      run: Copy-Item -Path ".\uberenv_libs\*.cmake" -Destination "hc.cmake"
+      run: |
+        ls
+        Copy-Item -Path ".\uberenv_libs\*.cmake" -Destination ".\hc.cmake"
     - name: Configure axom
       run: |
         python3 config-build.py -bp build_axom -ip install_axom -hc hc.cmake --msvc ${{ matrix.msvc }}

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -26,10 +26,6 @@ jobs:
         python-version: '3.7'
     - name: List path and files
       run: ls
-    - name: Temp -- checkout update-mfem branch
-      run: |
-        git checkout feature/kweiss/update-mfem
-        git status
     - name: Run uberenv (x64-windows)
       run: python3 ./scripts/uberenv/uberenv.py --triplet "x64-windows"
     - name: Copy host-config

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -33,7 +33,10 @@ jobs:
     - name: Show path
       run: pwd
     - name: List files
-      run: dir
+      run: |
+        dir
+        dir scripts
+        dir scripts/uberenv
     - name: Run uberenv (w/ default settings) 
       run: |
         python3 .\scripts\uberenv\uberenv.py

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -31,12 +31,22 @@ jobs:
     needs: checkout_code
     strategy:
       matrix:
-        triplet: ["x64-windows",      "x86-windows"]
-        msvc:    ["201964",           "2019"]
-        hc:      ["hc_x64.cmake",     "hc_x86.cmake"]
-        prefix:  ["uberenv_libs_x64", "uberenv_libs_x86"]
-        build:   ["build_x64",        "build_x86"]
-        install: ["install_x64",      "install_x86"]
+        arch: ["x64", "x86"]
+        include:
+        - arch: "x64"
+          triplet: "x64-windows"
+          msvc:    "201964"
+          hc:      "hc_x64.cmake"
+          prefix:  "uberenv_libs_x64"
+          build:   "build_x64"
+          install: "install_x64"
+        - arch: "x86"
+          triplet: "x86-windows"
+          msvc:    "2019"
+          hc:      "hc_x86.cmake"
+          prefix:  "uberenv_libs_x86"
+          build:   "build_x86"
+          install: "install_x86"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -52,24 +62,23 @@ jobs:
 
   # Our next job builds and tests the code in Debug and Release mode
   build_and_test:
-    name: Builds and tests the ${{ matrix.name }} configuration
+    name: Builds and tests the ${{ matrix.arch }}_${{ matrix.cfg }} configuration
     # The type of runner that the job will run on
     runs-on: windows-latest
     needs: run_uberenv
     strategy:
       matrix:
-        name:      ["x64_Debug",  "x64_Release", "x86_Debug",  "x86_Release"]
-        build_dir: ["build_x64",  "build_x64",   "build_x86",  "build_x86"  ]
-        cfg:       ["Debug",      "Release",     "Debug",      "Release"    ]
-
+        arch:  ["x64",  "x86"]
+        cfg:   ["Debug", "Release"] 
+        
     steps:
-    - name: Build axom ${{ matrix.name}}
+    - name: Build axom ${{ matrix.arch }}_${{ matrix.cfg }}
       run: |
-        cd build-${{ matrix.build_dir }}
+        cd build_${{ matrix.arch }}
         ls
         cmake --build . --config ${{ matrix.cfg }}
     - name: Test axom debug
       run: |
-        cd build-axom
+        cd build_${{ matrix.arch }}
         ls
         ctest -C ${{ matrix.cfg }}

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -2,20 +2,11 @@
 
 name: Manual test for Axom's TPLs on Windows
 
-# Controls when the action will run. Workflow runs when manually triggered using the UI
-# or API.
+# Controls when the action will run. 
+# This workflow runs when manually triggered using the UI or API.
 on:
   workflow_dispatch:
-    # Inputs the workflow accepts.
-    inputs:
-      name:
-        # Friendly description to be shown in the UI instead of 'name'
-        description: 'Person to greet'
-        # Default value if no value is explicitly provided
-        default: 'World'
-        # Input has to be provided for the workflow to run
-        required: true
-
+  
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This job will check out the repo and invoke uberenv to build and test our TPLs

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -36,5 +36,4 @@ jobs:
       run: dir
     - name: Run uberenv (w/ default settings) 
       run: |
-        cd axom
-        python3 ./scripts/uberenv/uberenv.py
+        python3 scripts/uberenv/uberenv.py

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -25,6 +25,9 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Runs a single command using the runners shell
-    - name: Send greeting
-      run: echo "Hello ${{ github.event.inputs.name }}"
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+    - name: Send python greeting
+      run: python2 -c "print(F'Hello ${{ github.event.inputs.name }}')"

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -25,7 +25,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout repo w/ submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Set up python
       uses: actions/setup-python@v2
       with:
@@ -39,4 +42,4 @@ jobs:
         dir scripts/uberenv
     - name: Run uberenv (w/ default settings) 
       run: |
-        python3 .\scripts\uberenv\uberenv.py
+        python3 ./scripts/uberenv/uberenv.py

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         arch: ["x64", "x86"]
-        cgf: ["Debug", "Release"]
+        cfg: ["Debug", "Release"]
         include:
         - arch: "x64"
           triplet: "x64-windows"

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -8,78 +8,53 @@ on:
   workflow_dispatch:
   
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
-jobs:
-  # The first job checks out the code and sets up python
-  checkout_code:
+jobs:  
+  # This job invokes uberenv to build our TPLs for two "triplets"
+  run_uberenv:
+    name: Runs uberenv with vckpkg triplet ${{ matrix.triplet }}
+    # The type of runner that the job will run on
     runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: ["x64", "x86"]
+        cgf: ["Debug", "Release"]
+        include:
+        - arch: "x64"
+          triplet: "x64-windows"
+          msvc:    "201964"
+        - arch: "x86"
+          triplet: "x86-windows"
+          msvc:    "2019"
 
     steps:
     - name: Checkout repo w/ submodules
       uses: actions/checkout@v2
       with:
         submodules: recursive
+        
     - name: Set up python
       uses: actions/setup-python@v2
       with:
         python-version: '3.7'
-  
-  # This job invokes uberenv to build our TPLs for two "triplets"
-  run_uberenv:
-    name: Runs uberenv with vckpkg triplet ${{ matrix.triplet }}
-    # The type of runner that the job will run on
-    runs-on: windows-latest
-    needs: checkout_code
-    strategy:
-      matrix:
-        arch: ["x64", "x86"]
-        include:
-        - arch: "x64"
-          triplet: "x64-windows"
-          msvc:    "201964"
-          hc:      "hc_x64.cmake"
-          prefix:  "uberenv_libs_x64"
-          build:   "build_x64"
-          install: "install_x64"
-        - arch: "x86"
-          triplet: "x86-windows"
-          msvc:    "2019"
-          hc:      "hc_x86.cmake"
-          prefix:  "uberenv_libs_x86"
-          build:   "build_x86"
-          install: "install_x86"
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    - uses: 
+        
     - name: List path and files
       run: ls
-    - name: Run uberenv
-      run: python3 ./scripts/uberenv/uberenv.py --triplet ${{ matrix.triplet }} --prefix ${{ matrix.prefix }}
+    - name: Run uberenv (${{ matrix.triplet }})
+      run: python3 ./scripts/uberenv/uberenv.py --triplet ${{ matrix.triplet }}
     - name: Copy host-config
-      run: Copy-Item -Path ".\${{ matrix.prefix }}\*.cmake" -Destination "${{ matrix.hc }}"
+      run: Copy-Item -Path ".\uberenv_libs\*.cmake" -Destination "hc.cmake"
     - name: Configure axom
       run: |
-        python3 config-build.py -bp ${{ matrix.build }} -ip ${{ matrix.install }} -hc ${{ matrix.hc }} --msvc ${{ matrix.msvc }}
+        python3 config-build.py -bp build_axom -ip install_axom -hc hc.cmake --msvc ${{ matrix.msvc }}
 
-  # Our next job builds and tests the code in Debug and Release mode
-  build_and_test:
-    name: Builds and tests the ${{ matrix.arch }}_${{ matrix.cfg }} configuration
-    # The type of runner that the job will run on
-    runs-on: windows-latest
-    needs: run_uberenv
-    strategy:
-      matrix:
-        arch:  ["x64",  "x86"]
-        cfg:   ["Debug", "Release"] 
-        
-    steps:
-    - name: Build axom ${{ matrix.arch }}_${{ matrix.cfg }}
+    - name: Build axom (${{ matrix.triplet }} ${{ matrix.cfg }})
       run: |
-        cd build_${{ matrix.arch }}
+        cd build_axom
         ls
         cmake --build . --config ${{ matrix.cfg }}
-    - name: Test axom debug
+        
+    - name: Test axom (${{ matrix.triplet }} ${{ matrix.cfg }})
       run: |
-        cd build_${{ matrix.arch }}
+        cd build_axom
         ls
         ctest -C ${{ matrix.cfg }}

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -31,4 +31,4 @@ jobs:
       with:
         python-version: '3.7'
     - name: Run uberenv (w/ default settings) 
-      run: ./scripts/uberenv/uberenv.py
+      run: python3 ./scripts/uberenv/uberenv.py

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -42,19 +42,23 @@ jobs:
     - name: Configure axom
       run: |
         python3 config-build.py -bp build-axom -ip install-axom -hc hc.cmake --msvc 201964
-    - name: cd into build directory
-      run: |
-        cd build-axom
-        ls
     - name: Build axom debug
       run: |
+        cd build-axom
         ls
         cmake --build . --config Debug
     - name: Test axom debug
       run: |
+        cd build-axom
         ls
         ctest -C Debug
     - name: Build axom release
-      run: cmake --build . --config Release
+      run: |
+        cd build-axom
+        ls
+        cmake --build . --config Release
     - name: Test axom release
-      run: ctest -C Release
+      run: |
+        cd build-axom
+        ls
+        ctest -C Release

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -30,5 +30,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.7'
+    - name: Show path
+      run: pwd
+    - name: List files
+      run: dir
     - name: Run uberenv (w/ default settings) 
-      run: python3 ./scripts/uberenv/uberenv.py
+      run: |
+        cd axom
+        python3 ./scripts/uberenv/uberenv.py

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -18,8 +18,8 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "greet"
-  greet:
+  # This job will check out the repo and invoke uberenv to build and test our TPLs
+  run_uberenv:
     # The type of runner that the job will run on
     runs-on: windows-latest
 
@@ -30,5 +30,5 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.7'
-    - name: Display python version
-      run: python3 -c "import sys; print(sys.version)"
+    - name: Run uberenv (w/ default settings) 
+      run: ./scripts/uberenv/uberenv.py


### PR DESCRIPTION
# Summary

- This PR adds a manually triggered github actions workflow to test our Windows TPLs
- The workflow builds our TPLs via `uberenv`/`vcpkg` using the `x64-windows` and `x86-windows` triplets
   and tests Axom against these for Axom's `Debug` and `Release` builds
- As a future extension, it might be nice if we could cache the TPLs. Then we could test these against PRs into develop. 
- See issue #546 for more details
- I'm planning to squash merge this to reduce due to all the trial and error commits

Successful run of this workflow after merging #502:  
* https://github.com/LLNL/axom/actions/runs/824679693
