### PR TITLE
Some tweaks to Windows TPL action

### DIFF
--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -72,3 +72,8 @@ jobs:
         cd build_axom
         ls
         ctest -C ${{ matrix.cfg }}
+    - name: Publish Unit Test Results (Uberenv ${{ matrix.triplet }} ${{ matrix.cfg }})
+      uses: EnricoMi/publish-unit-test-result-action/composite@v1
+      if: always()
+      with:
+        files: build_axom/**/*.xml

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: ${{ always() }}
       with:
-        name: artifacts_${{ matrix.triplet }}_${{ matrix.cfg }}.zip
+        name: uberenv_artifacts_${{ matrix.triplet }}_${{ matrix.cfg }}.zip
         path: |
           ${{ github.workspace }}/uberenv_libs/vcpkg/buildtrees/*/*.log
           ${{ github.workspace }}/uberenv_libs/vcpkg/buildtrees/*/*.err
@@ -72,8 +72,10 @@ jobs:
         cd build_axom
         ls
         ctest -C ${{ matrix.cfg }} --no-compress-output -T Test 
-    - name: Publish Unit Test Results (Uberenv ${{ matrix.triplet }} ${{ matrix.cfg }})
-      uses: EnricoMi/publish-unit-test-result-action/composite@v1
-      if: always()
+    - name: Save CTest logs
+      uses: actions/upload-artifact@v2
+      if: ${{ always() }}
       with:
-        files: build_axom/**/*.xml
+        name: ctest_artifacts_${{ matrix.triplet }}_${{ matrix.cfg }}.zip
+        path: |
+          ${{ github.workspace }}/build_axom/**/*.xml

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -14,8 +14,8 @@ jobs:
     name: Runs ${{ matrix.triplet }} ${{ matrix.cfg }} uberenv with vcpkg
     # The type of runner that the job will run on
     runs-on: windows-latest
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         arch: ["x64", "x86"]
         cfg: ["Debug", "Release"]
@@ -46,7 +46,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: ${{ always() }}
       with:
-        name: artifacts_${{ matrix.triplet }}_${{ matrix.cfg }}
+        name: artifacts_${{ matrix.triplet }}_${{ matrix.cfg }}.zip
         path: |
           ${{ github.workspace }}/uberenv_libs/vcpkg/buildtrees/*/*.log
           ${{ github.workspace }}/uberenv_libs/vcpkg/buildtrees/*/*.err

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -71,7 +71,7 @@ jobs:
       run: |
         cd build_axom
         ls
-        ctest -C ${{ matrix.cfg }}
+        ctest -C ${{ matrix.cfg }} --no-compress-output -T Test 
     - name: Publish Unit Test Results (Uberenv ${{ matrix.triplet }} ${{ matrix.cfg }})
       uses: EnricoMi/publish-unit-test-result-action/composite@v1
       if: always()

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -14,6 +14,7 @@ jobs:
     name: Runs uberenv with vckpkg triplet ${{ matrix.triplet }}
     # The type of runner that the job will run on
     runs-on: windows-latest
+    continue-on-error: true
     strategy:
       matrix:
         arch: ["x64", "x86"]

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -42,10 +42,19 @@ jobs:
       run: ls
     - name: Run uberenv (${{ matrix.triplet }})
       run: python3 ./scripts/uberenv/uberenv.py --triplet ${{ matrix.triplet }}
+    - name: Save Uberenv logs
+      uses: actions/upload-artifact@v2
+      with:	
+        path: |
+          ${{ github.workspace }}/uberenv_libs/vcpkg/buildtrees/*/*.log
+          ${{ github.workspace }}/uberenv_libs/vcpkg/buildtrees/*/*.err
+          ${{ github.workspace }}/uberenv_libs/*.cmake
+
     - name: Copy host-config
       run: |
         ls
         Copy-Item -Path ".\uberenv_libs\*.cmake" -Destination ".\hc.cmake"
+
     - name: Configure axom
       run: |
         python3 config-build.py -bp build_axom -ip install_axom -hc hc.cmake --msvc ${{ matrix.msvc }}

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -11,7 +11,7 @@ on:
 jobs:  
   # This job invokes uberenv to build our TPLs for two "triplets"
   run_uberenv:
-    name: Runs uberenv with vckpkg triplet ${{ matrix.triplet }}
+    name: Runs ${{ matrix.triplet }} ${{ matrix.cfg }} uberenv with vcpkg
     # The type of runner that the job will run on
     runs-on: windows-latest
     continue-on-error: true
@@ -44,7 +44,9 @@ jobs:
       run: python3 ./scripts/uberenv/uberenv.py --triplet ${{ matrix.triplet }}
     - name: Save Uberenv logs
       uses: actions/upload-artifact@v2
-      with:	
+      if: ${{ always() }}
+      with:
+        name: artifacts_${{ matrix.triplet }}_${{ matrix.cfg }}
         path: |
           ${{ github.workspace }}/uberenv_libs/vcpkg/buildtrees/*/*.log
           ${{ github.workspace }}/uberenv_libs/vcpkg/buildtrees/*/*.err


### PR DESCRIPTION
# Summary

* This PR contains some tweaks to improve the Windows TPL action workflow
* Adds option to continue on failure  -- That way one failure won't cancel the entire job.
* Export uberenv and ctest logs as "artifacts"

I tried to "publish" the unit tests so it appears visually, but it didn't seem to be in the right format.
