### PR TITLE
Support legacy hdf5 cmake build system

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -107,6 +107,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   verification
 - Quest: Fixed a bug with InOutOctree for triangles that lie on faces of octree blocks
 - Updated to use newer Conduit config directory
+- Add support for legacy hdf5 cmake build system
 
 ## [Version 0.4.0] - Release date 2020-09-22
 

--- a/scripts/spack/configs/toss_3_x86_64_ib/packages.yaml
+++ b/scripts/spack/configs/toss_3_x86_64_ib/packages.yaml
@@ -138,6 +138,11 @@ packages:
   conduit:
     version: [0.6.0]
     variants: ~shared
+  hdf5:
+    buildable: False
+    externals:
+    - spec: hdf5@1.8.10~shared
+      prefix: /usr/gapps/ale3d/toss_3_x86_64_ib/icc19/PUBLIC/packages/hdf5/1.8.10.1c
   mfem:
     variants: ~mpi~metis~zlib
   scr:

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -126,6 +126,8 @@ class Axom(CachedCMakePackage, CudaPackage):
     depends_on("py-shroud", when="+devtools")
     depends_on("llvm+clang@10.0.0", when="+devtools", type='build')
 
+    conflict("conduit@:0.6.0", when="@0.5.0:")
+
     def _get_sys_type(self, spec):
         sys_type = spec.architecture
         # if on llnl systems, we can use the SYS_TYPE

--- a/scripts/spack/packages/conduit/package.py
+++ b/scripts/spack/packages/conduit/package.py
@@ -112,8 +112,8 @@ class Conduit(Package):
     #
     # Use HDF5 1.8, for wider output compatibly
     # variants reflect we are not using hdf5's mpi or fortran features.
-    depends_on("hdf5@1.8.19:1.8.999~cxx", when="+hdf5+hdf5_compat+shared")
-    depends_on("hdf5@1.8.19:1.8.999~shared~cxx", when="+hdf5+hdf5_compat~shared")
+    depends_on("hdf5@1.8.10~cxx", when="+hdf5+hdf5_compat+shared")
+    depends_on("hdf5@1.8.10~shared~cxx", when="+hdf5+hdf5_compat~shared")
     depends_on("hdf5~cxx", when="+hdf5~hdf5_compat+shared")
     depends_on("hdf5~shared~cxx", when="+hdf5~hdf5_compat~shared")
 

--- a/src/cmake/thirdparty/SetupHDF5.cmake
+++ b/src/cmake/thirdparty/SetupHDF5.cmake
@@ -125,6 +125,13 @@ elseif(WIN32 AND TARGET hdf5::hdf5-static )
     blt_import_library(NAME      hdf5
                        LIBRARIES hdf5::hdf5-static
                        EXPORTABLE ON)
+elseif(TARGET hdf5)
+    # legacy hdf5 CMake build system support
+    message(STATUS "HDF5 using hdf5 target")
+
+    set_property(TARGET hdf5 
+                 APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                 "${HDF5_INCLUDE_DIRS}")
 else()
     # reg includes and libs with blt
     message(STATUS "HDF5 using HDF5_DEFINITIONS + HDF5_INCLUDE_DIRS + HDF5_LIBRARIES")

--- a/src/cmake/thirdparty/SetupHDF5.cmake
+++ b/src/cmake/thirdparty/SetupHDF5.cmake
@@ -126,7 +126,7 @@ elseif(WIN32 AND TARGET hdf5::hdf5-static )
                        LIBRARIES hdf5::hdf5-static
                        EXPORTABLE ON)
 elseif(TARGET hdf5)
-    # legacy hdf5 CMake build system support
+    # legacy hdf5 CMake build system support creates an hdf5 target we use directly
     message(STATUS "HDF5 using hdf5 target")
 
     set_property(TARGET hdf5 


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following (modify list as needed):
  - Adds support for legacy (?) hdf5 cmake build system which creates an `hdf5` target not `hdf5::hdf5-static` etc
