### PR TITLE
Ran clang-format on codebase

### DIFF
--- a/src/axom/inlet/Container.cpp
+++ b/src/axom/inlet/Container.cpp
@@ -896,7 +896,6 @@ VerifiableScalar& Container::addString(const std::string& name,
   return addPrimitive<std::string>(name, description);
 }
 
-
 Verifiable<Function>& Container::addFunction(const std::string& name,
                                              const FunctionTag ret_type,
                                              const std::vector<FunctionTag>& arg_types,

--- a/src/axom/sidre/examples/spio/IO_SCR_Checkpoint.cpp
+++ b/src/axom/sidre/examples/spio/IO_SCR_Checkpoint.cpp
@@ -209,14 +209,13 @@ int main(int argc, char* argv[])
 {
   axom::slic::SimpleLogger logger;
 
-
   ::testing::InitGoogleTest(&argc, argv);
 
   MPI_Init(&argc, &argv);
 
   // run the test from spio_scr.hpp
   int result = RUN_ALL_TESTS();
-  SLIC_ASSERT(result == 0); 
+  SLIC_ASSERT(result == 0);
 
   int my_rank, num_ranks;
   MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);


### PR DESCRIPTION
# Summary

- Our style checker is passing on develop, but locally some files were failing `make check`
- Not sure why.
- Very low priority, but somewhat annoying when running make style on the rest of the code...

Here's what I got w/ make check:
```
>make check
Scanning dependencies of target tools_clangformat_check
[  0%] Running ClangFormat source code formatting checks.
[  0%] Built target tools_clangformat_check
Scanning dependencies of target thirdparty_tests_clangformat_check
[  0%] Running ClangFormat source code formatting checks.
[  0%] Built target thirdparty_tests_clangformat_check
Scanning dependencies of target core_clangformat_check
[ 16%] Running ClangFormat source code formatting checks.
[ 16%] Built target core_clangformat_check
Scanning dependencies of target lumberjack_clangformat_check
[ 16%] Running ClangFormat source code formatting checks.
[ 16%] Built target lumberjack_clangformat_check
Scanning dependencies of target slic_clangformat_check
[ 16%] Running ClangFormat source code formatting checks.
[ 16%] Built target slic_clangformat_check
Scanning dependencies of target slam_clangformat_check
[ 33%] Running ClangFormat source code formatting checks.
[ 33%] Built target slam_clangformat_check
Scanning dependencies of target primal_clangformat_check
[ 33%] Running ClangFormat source code formatting checks.
[ 33%] Built target primal_clangformat_check
Scanning dependencies of target sidre_clangformat_check
[ 33%] Running ClangFormat source code formatting checks.
--- ../src/axom/sidre/examples/spio/IO_SCR_Checkpoint.cpp	(original)
+++ ../src/axom/sidre/examples/spio/IO_SCR_Checkpoint.cpp	(reformatted)
@@ -209,14 +209,13 @@
 {
   axom::slic::SimpleLogger logger;
 
-
   ::testing::InitGoogleTest(&argc, argv);
 
   MPI_Init(&argc, &argv);
 
   // run the test from spio_scr.hpp
   int result = RUN_ALL_TESTS();
-  SLIC_ASSERT(result == 0); 
+  SLIC_ASSERT(result == 0);
 
   int my_rank, num_ranks;
   MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
make[3]: *** [axom/sidre/CMakeFiles/sidre_clangformat_check] Error 1
make[2]: *** [axom/sidre/CMakeFiles/sidre_clangformat_check.dir/all] Error 2
make[1]: *** [CMakeFiles/check.dir/rule] Error 2
make: *** [check] Error 2
rzgenie11:build-axom (bugfix/kweiss/formatting) >echo $?
2

```