### PR TITLE
Add and harden various CMake options

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,7 +25,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ### Changed
 - `MFEMSidreDataCollection` now reuses FESpace/QSpace objects with the same basis
-- Harden BLT tools (style, code quality, etc.) against being enabled for users.  Developers will
+- Harden configuration options for BLT tools (style, code quality, etc.) against accidentally being enabled for users.  Developers will
   always give a full path (e.g. `CLANGFORMAT_EXECUTABLE`)
 
 ## [Version 0.5.0] - Release date 2021-05-14

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,6 +18,16 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 The Axom project release numbers follow [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased] - Release date yyyy-mm-dd
+
+### Added
+- Added new CMake option to allow users to turn off Axom created tools: `AXOM_ENABLE_TOOLS`
+
+### Changed
+- `MFEMSidreDataCollection` now reuses FESpace/QSpace objects with the same basis
+- Harden BLT tools (style, code quality, etc.) against being enabled for users.  Developers will
+  always give a full path (e.g. `CLANGFORMAT_EXECUTABLE`)
+
 ## [Version 0.5.0] - Release date 2021-05-14
 
 ### Added

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -57,6 +57,9 @@ class Axom(CachedCMakePackage, CudaPackage):
     variant('debug',    default=False,
             description='Build debug instead of optimized version')
 
+    variant('examples', default=True, description='Build examples')
+    variant('tools',    default=True, description='Build tools')
+
     variant('cpp14',    default=True, description="Build with C++14 support")
 
     variant('fortran',  default=True, description="Build with Fortran support")
@@ -407,6 +410,10 @@ class Axom(CachedCMakePackage, CudaPackage):
 
         options.append(self.define_from_variant(
             'BUILD_SHARED_LIBS', 'shared'))
+        options.append(self.define_from_variant(
+            'AXOM_ENABLE_EXAMPLES', 'examples'))
+        options.append(self.define_from_variant(
+            'AXOM_ENABLE_TOOLS', 'tools'))
 
         return options
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,7 @@ if (“${PROJECT_SOURCE_DIR}” STREQUAL “${CMAKE_SOURCE_DIR}”)
     endif()
 
     # These are not used in Axom, turn them off
-    set(AXOM_NOT_USED_BLT_TOOLS
+    set(_unused_blt_tools
         CLANGQUERY
         CLANGTIDY
         VALGRIND
@@ -56,18 +56,18 @@ if (“${PROJECT_SOURCE_DIR}” STREQUAL “${CMAKE_SOURCE_DIR}”)
         CMAKEFORMAT
         UNCRUSTIFY
         YAPF)
-    foreach(_tool ${AXOM_NOT_USED_BLT_TOOLS})
+    foreach(_tool ${_unused_blt_tools})
         set(ENABLE_${_tool} OFF CACHE BOOL "")
     endforeach()
 
     # These are only used by Axom developers, so turn them off
     # unless an explicit executable path is given
-    set(AXOM_USED_BLT_TOOLS
+    set(_used_blt_tools
         CLANGFORMAT
         CPPCHECK
         DOXYGEN
         SPHINX)
-    foreach(_tool ${AXOM_NOT_USED_BLT_TOOLS})
+    foreach(_tool ${_used_blt_tools})
         if(NOT ${_tool}_EXECUTABLE)
             set(ENABLE_${_tool} OFF CACHE BOOL "")
         else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,8 @@ if (“${PROJECT_SOURCE_DIR}” STREQUAL “${CMAKE_SOURCE_DIR}”)
     foreach(_tool ${AXOM_NOT_USED_BLT_TOOLS})
         if(NOT ${_tool}_EXECUTABLE)
             set(ENABLE_${_tool} OFF CACHE BOOL "")
+        else()
+            set(ENABLE_${_tool} ON CACHE BOOL "")
         endif()
     endforeach()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,9 +12,6 @@ else()
     cmake_minimum_required(VERSION 3.8.2)
 endif()
 
-message(STATUS "Using CMake version ${CMAKE_VERSION}")
-
-
 project(axom LANGUAGES C CXX)
 
 if (ENABLE_FORTRAN)
@@ -50,9 +47,31 @@ if (“${PROJECT_SOURCE_DIR}” STREQUAL “${CMAKE_SOURCE_DIR}”)
         set(BLT_CXX_STD "c++11" CACHE STRING "")
     endif()
 
-    set(ENABLE_ASTYLE      OFF CACHE BOOL "")
-    set(ENABLE_CLANGTIDY   OFF CACHE BOOL "")
-    set(ENABLE_UNCRUSTIFY  OFF CACHE BOOL "")
+    # These are not used in Axom, turn them off
+    set(AXOM_NOT_USED_BLT_TOOLS
+        CLANGQUERY
+        CLANGTIDY
+        VALGRIND
+        ASTYLE
+        CMAKEFORMAT
+        UNCRUSTIFY
+        YAPF)
+    foreach(_tool ${AXOM_NOT_USED_BLT_TOOLS})
+        set(ENABLE_${_tool} OFF CACHE BOOL "")
+    endforeach()
+
+    # These are only used by Axom developers, so turn them off
+    # unless an explicit executable path is given
+    set(AXOM_USED_BLT_TOOLS
+        CLANGFORMAT
+        CPPCHECK
+        DOXYGEN
+        SPHINX)
+    foreach(_tool ${AXOM_NOT_USED_BLT_TOOLS})
+        if(NOT ${_tool}_EXECUTABLE)
+            set(ENABLE_${_tool} OFF CACHE BOOL "")
+        endif()
+    endforeach()
 
     set(BLT_REQUIRED_CLANGFORMAT_VERSION  "10" CACHE STRING "")
 
@@ -94,14 +113,18 @@ add_subdirectory(thirdparty)
 include(cmake/AxomVersion.cmake)
 add_subdirectory(axom)
 
-add_subdirectory(tools)
+if(AXOM_ENABLE_TOOLS)
+    add_subdirectory(tools)
+endif()
+
+# Using Axom install examples
 add_subdirectory(examples)
 
-if (AXOM_ENABLE_DOCS)
-  if (SPHINX_FOUND)
-    blt_add_sphinx_target( axom_docs )
-  endif()
-  add_subdirectory(docs)
+if(AXOM_ENABLE_DOCS)
+    if(SPHINX_FOUND)
+        blt_add_sphinx_target( axom_docs )
+    endif()
+    add_subdirectory(docs)
 endif()
 
 #------------------------------------------------------------------------------

--- a/src/cmake/AxomOptions.cmake
+++ b/src/cmake/AxomOptions.cmake
@@ -23,6 +23,7 @@ endif()
 cmake_dependent_option(AXOM_ENABLE_TESTS "Enables Axom Tests" ON "ENABLE_TESTS" OFF)
 cmake_dependent_option(AXOM_ENABLE_DOCS "Enables Axom Docs" ON "ENABLE_DOCS" OFF)
 cmake_dependent_option(AXOM_ENABLE_EXAMPLES "Enables Axom Examples" ON "ENABLE_EXAMPLES" OFF)
+option(AXOM_ENABLE_TOOLS "Enables Axom Tools" ON)
 
 cmake_dependent_option(AXOM_ENABLE_MPI3 "Enables use of MPI-3 features" OFF "ENABLE_MPI" OFF)
 mark_as_advanced(AXOM_ENABLE_MPI3)


### PR DESCRIPTION
- This PR is a bugfix/feature
- It does the following (modify list as needed):
  - Adds new AXOM_ENABLE_TOOLS and guards the appropriate tools from built
  - Harden our guards against developer tools from bleeding into users

Closes #560 
Closes #114