### PR TITLE
Attempt to fix slic linker warning in mint test when building shared

### DIFF
--- a/src/axom/mint/tests/CMakeLists.txt
+++ b/src/axom/mint/tests/CMakeLists.txt
@@ -40,7 +40,7 @@ set( mint_tests
      mint_util_write_vtk.cpp
    )
 
-set( mint_test_dependencies mint )
+set( mint_test_dependencies axom )
 
 blt_list_append( TO mint_test_dependencies ELEMENTS cuda IF ${ENABLE_CUDA} )
 

--- a/src/axom/mint/tests/CMakeLists.txt
+++ b/src/axom/mint/tests/CMakeLists.txt
@@ -40,7 +40,7 @@ set( mint_tests
      mint_util_write_vtk.cpp
    )
 
-set( mint_test_dependencies axom )
+set( mint_test_dependencies slic mint )
 
 blt_list_append( TO mint_test_dependencies ELEMENTS cuda IF ${ENABLE_CUDA} )
 


### PR DESCRIPTION
# Summary

- Attempt to resolve #548 by linking against all of axom, not just mint.
