### PR TITLE
Add Inlet constructor that doesn't require a Sidre group

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,6 +28,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Harden configuration options for BLT tools (style, code quality, etc.) against accidentally being enabled for users.  Developers will
   always give a full path (e.g. `CLANGFORMAT_EXECUTABLE`)
 - Inlet: `Writer`s are passed directly to `Inlet::write` instead of being registered
+- `Inlet` objects can now be constructed without a user-provided `sidre::DataStore`
 
 ## [Version 0.5.0] - Release date 2021-05-14
 

--- a/src/axom/inlet/Inlet.hpp
+++ b/src/axom/inlet/Inlet.hpp
@@ -80,6 +80,25 @@ public:
     m_unexpectedNames = m_reader->getAllNames();
   }
 
+  /// \overload
+  Inlet(std::unique_ptr<Reader> reader,
+        bool docEnabled = true,
+        bool reconstruct = false)
+    : m_reader(std::move(reader))
+    , m_datastore(new sidre::DataStore)
+    , m_sidreRootGroup(m_datastore->getRoot())
+    , m_globalContainer("",
+                        "",
+                        *m_reader,
+                        m_sidreRootGroup,
+                        m_unexpectedNames,
+                        docEnabled,
+                        reconstruct)
+    , m_docEnabled(docEnabled)
+  {
+    m_unexpectedNames = m_reader->getAllNames();
+  }
+
   // Inlet objects must be move only - delete the implicit shallow copy constructor
   Inlet(const Inlet&) = delete;
   Inlet(Inlet&&) = default;
@@ -482,6 +501,8 @@ public:
   // TODO add update value functions
 private:
   std::unique_ptr<Reader> m_reader;
+  // Used only in the case where the user does not provide an initial root group
+  std::unique_ptr<sidre::DataStore> m_datastore;
   axom::sidre::Group* m_sidreRootGroup = nullptr;
   Container m_globalContainer;
   bool m_docEnabled;

--- a/src/axom/inlet/examples/arrays.cpp
+++ b/src/axom/inlet/examples/arrays.cpp
@@ -15,10 +15,8 @@ int main()
   // Parse example input file
   lr->parseString("values = { [1] = 'start', [2] = 'stop', [3] = 'pause' }");
 
-  axom::sidre::DataStore ds;
-
   // Initialize Inlet
-  axom::inlet::Inlet inlet(std::move(lr), ds.getRoot());
+  axom::inlet::Inlet inlet(std::move(lr));
 
   // Register the verifier, which will verify the array values
   auto& vals = inlet.getGlobalContainer().addStringArray("values");

--- a/src/axom/inlet/examples/nested_structs.cpp
+++ b/src/axom/inlet/examples/nested_structs.cpp
@@ -321,10 +321,9 @@ int main(int argc, char** argv)
                "Warns if any unexpected fields are provided");
   CLI11_PARSE(app, argc, argv);
 
-  axom::sidre::DataStore ds;
   auto reader = std::unique_ptr<inlet::YAMLReader>(new inlet::YAMLReader());
   reader->parseString(input);
-  inlet::Inlet inlet(std::move(reader), ds.getRoot());
+  inlet::Inlet inlet(std::move(reader));
 
   // _inlet_nested_struct_array_start
   auto& shapes_container = inlet.addStructArray("shapes");

--- a/src/axom/inlet/examples/user_defined_type.cpp
+++ b/src/axom/inlet/examples/user_defined_type.cpp
@@ -12,7 +12,6 @@
 using axom::inlet::FunctionType;
 using axom::inlet::Inlet;
 using axom::inlet::LuaReader;
-using axom::sidre::DataStore;
 
 namespace inlet = axom::inlet;
 // _inlet_userdef_simple_start
@@ -89,10 +88,9 @@ int main()
   // Inlet requires a SLIC logger to be initialized to output runtime information
   axom::slic::SimpleLogger logger;
 
-  DataStore ds;
   auto lr = std::make_unique<LuaReader>();
   lr->parseString(input);
-  Inlet inlet(std::move(lr), ds.getRoot());
+  Inlet inlet(std::move(lr));
 
   // _inlet_userdef_simple_usage_start
   // Create a container off the global container for the car object

--- a/src/axom/inlet/examples/verification.cpp
+++ b/src/axom/inlet/examples/verification.cpp
@@ -16,8 +16,7 @@ int main()
   // Initialize Inlet
   auto lr = std::make_unique<axom::inlet::LuaReader>();
   lr->parseString("dimensions = 2; vector = { x = 1.0; y = 2.0; z = 3.0; }");
-  axom::sidre::DataStore ds;
-  axom::inlet::Inlet myInlet(std::move(lr), ds.getRoot());
+  axom::inlet::Inlet myInlet(std::move(lr));
 
   // _inlet_workflow_defining_schema_start
   // defines a required global field named "dimensions" with a default value of 2

--- a/src/axom/inlet/tests/inlet_Inlet.cpp
+++ b/src/axom/inlet/tests/inlet_Inlet.cpp
@@ -22,17 +22,14 @@ using axom::inlet::Field;
 using axom::inlet::Inlet;
 using axom::inlet::InletType;
 using axom::inlet::Proxy;
-using axom::sidre::DataStore;
 
 template <typename InletReader>
-Inlet createBasicInlet(DataStore* ds,
-                       const std::string& luaString,
-                       bool enableDocs = true)
+Inlet createBasicInlet(const std::string& luaString, bool enableDocs = true)
 {
   std::unique_ptr<InletReader> reader(new InletReader());
   reader->parseString(axom::inlet::detail::fromLuaTo<InletReader>(luaString));
 
-  return Inlet(std::move(reader), ds->getRoot(), enableDocs);
+  return Inlet(std::move(reader), enableDocs);
 }
 
 template <typename InletReader>
@@ -44,8 +41,7 @@ TYPED_TEST_SUITE(inlet_Inlet_basic, axom::inlet::detail::ReaderTypes);
 TYPED_TEST(inlet_Inlet_basic, getTopLevelBools)
 {
   std::string testString = "foo = true; bar = false";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   //
   // Define schema
@@ -85,8 +81,7 @@ TYPED_TEST(inlet_Inlet_basic, getTopLevelBools)
 TYPED_TEST(inlet_Inlet_basic, getNestedBools)
 {
   std::string testString = "foo = { bar = true; baz = false }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   //
   // Define schema
@@ -120,8 +115,7 @@ TYPED_TEST(inlet_Inlet_basic, getNestedBools)
 TYPED_TEST(inlet_Inlet_basic, getDoublyNestedBools)
 {
   std::string testString = "foo = { quux = { bar = true; baz = false } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   //
   // Define schema
@@ -157,8 +151,7 @@ TYPED_TEST(inlet_Inlet_basic, getDeeplyNestedBools)
   std::string testString =
     "foo = { quux = { corge = { quuz = { grault = { bar = true; baz = false } "
     "} } } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   //
   // Define schema
@@ -192,8 +185,7 @@ TYPED_TEST(inlet_Inlet_basic, getDeeplyNestedBools)
 TYPED_TEST(inlet_Inlet_basic, getNestedBoolsThroughContainer)
 {
   std::string testString = "foo = { bar = true; baz = false }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   //
   // Define schema
@@ -232,8 +224,7 @@ TYPED_TEST(inlet_Inlet_basic, getDeeplyNestedBoolsThroughContainer)
   std::string testString =
     "foo = { quux = { corge = { quuz = { grault = { bar = true; baz = false } "
     "} } } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   //
   // Define schema
@@ -271,8 +262,7 @@ TYPED_TEST(inlet_Inlet_basic, getDeeplyNestedBoolsThroughField)
   std::string testString =
     "foo = { quux = { corge = { quuz = { grault = { bar = true; baz = false } "
     "} } } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   //
   // Define schema
@@ -308,8 +298,7 @@ TYPED_TEST(inlet_Inlet_basic, getDeeplyNestedBoolsThroughField)
 TYPED_TEST(inlet_Inlet_basic, getTopLevelDoubles)
 {
   std::string testString = "foo = 5.05; bar = 15.1";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   //
   // Define schema
@@ -343,8 +332,7 @@ TYPED_TEST(inlet_Inlet_basic, getTopLevelDoubles)
 TYPED_TEST(inlet_Inlet_basic, getNestedDoubles)
 {
   std::string testString = "foo = { bar = 200.5; baz = 100.987654321 }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   //
   // Define schema
@@ -378,8 +366,7 @@ TYPED_TEST(inlet_Inlet_basic, getNestedDoubles)
 TYPED_TEST(inlet_Inlet_basic, getTopLevelInts)
 {
   std::string testString = "foo = 5; bar = 15";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   //
   // Define schema
@@ -413,8 +400,7 @@ TYPED_TEST(inlet_Inlet_basic, getTopLevelInts)
 TYPED_TEST(inlet_Inlet_basic, getNestedInts)
 {
   std::string testString = "foo = { bar = 200; baz = 100 }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   //
   // Define schema
@@ -448,8 +434,7 @@ TYPED_TEST(inlet_Inlet_basic, getNestedInts)
 TYPED_TEST(inlet_Inlet_basic, getTopLevelStrings)
 {
   std::string testString = "foo = 'test string'; bar = 'other test string'";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   //
   // Define schema
@@ -484,8 +469,7 @@ TYPED_TEST(inlet_Inlet_basic, getNestedStrings)
 {
   std::string testString =
     "foo = { bar = 'yet another string'; baz = 'string 2' }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   //
   // Define schema
@@ -525,8 +509,7 @@ TYPED_TEST(inlet_Inlet_basic, getNestedValuesAddedUsingContainer)
 
   std::string testString =
     "foo = { bar = 'yet another string'; so = 3.5; re = 9; mi = true }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Check for existing fields
   Container& container = inlet.addStruct("foo", "A container called foo");
@@ -566,8 +549,7 @@ TYPED_TEST(inlet_Inlet_views, NestedContainerViewCheck1)
   std::string testString =
     "field1 = true; field2 = 5632; NewContainer = { str = 'hello'; integer = "
     "32 }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
   inlet.addBool("field1", "this is field #1, a boolean value").required(true);
   inlet.addInt("field2", "this is field #2, an integer").required(false);
   Container& t = inlet.addStruct("NewContainer", "It's blue").required(false);
@@ -598,8 +580,7 @@ TYPED_TEST(inlet_Inlet_views, NestedContainerViewCheck2)
     "foo = false; bar = true; Container1 = { float1 = 3.14; Container11 = { "
     "Container111 = "
     "{ x = 4 } } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
   inlet.addBool("foo", "foo's description").required(true);
   inlet.addBool("bar", "bar's description").required(false);
 
@@ -632,8 +613,7 @@ TYPED_TEST(inlet_Inlet_views, NestedContainerViewCheck3)
     "Container1 = { float1 = 5.6 }; Container2 = { int1 = 95 }; Container3 = { "
     "bool1 = "
     "true }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& t = inlet.addStruct("Container1", "The first container");
   t.addDouble("float1", " A floating point number in Container 1");
@@ -664,7 +644,6 @@ TYPED_TEST(inlet_Inlet_classes, mixLevelContainers)
   // regression test for the lua stack being at the wrong
   // level with nested containers with non-nested values
 
-  axom::sidre::DataStore dataStore;
   std::string input =
     "thermal_solver={"
     "   u0 = { type = 'function', func = 'BoundaryTemperature'},"
@@ -679,7 +658,7 @@ TYPED_TEST(inlet_Inlet_classes, mixLevelContainers)
     "   }"
     "}";
 
-  Inlet inlet = createBasicInlet<TypeParam>(&dataStore, input);
+  Inlet inlet = createBasicInlet<TypeParam>(input);
 
   //
   // Define input file schema
@@ -753,9 +732,8 @@ TYPED_TEST(inlet_Inlet_classes, defaultValuesDocsEnabled)
     "Container1 = { float1 = 5.6; Container2 = { int1 = 95; Container4 = { "
     "str1= 'hi' } } "
     "}; Container3 = { bool1 = true }";
-  DataStore ds;
   // Creating basic inlet with documentation enabled (indicated by the last param)
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString, true);
+  Inlet inlet = createBasicInlet<TypeParam>(testString, true);
 
   // new fields
   inlet.addDouble("field1").defaultValue(2);  // int argument will get casted to double
@@ -843,9 +821,8 @@ TYPED_TEST(inlet_Inlet_classes, defaultValuesDocsDisabled)
     "Container1 = { float1 = 5.6; Container2 = { int1 = 95; Container4 = { "
     "str1= 'hi' } } "
     "}; Container3 = { bool1 = true }";
-  DataStore ds;
   // Creating basic inlet with documentation disabled (indicated by the last param)
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString, false);
+  Inlet inlet = createBasicInlet<TypeParam>(testString, false);
 
   // new fields
   inlet.addDouble("field1").defaultValue(2.0);
@@ -907,8 +884,7 @@ TYPED_TEST(inlet_Inlet_classes, ranges)
     "Container1 = { float1 = 5.6; Container2 = { int1 = 95; Container4 = { "
     "str1= 'hi' } } "
     "}; Container3 = { bool1 = true }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   axom::sidre::Group* sidreGroup = inlet.sidreGroup();
 
@@ -961,8 +937,7 @@ TYPED_TEST(inlet_Inlet_verify, verifyRequired)
   std::string testString =
     "field1 = true; field2 = 5632; NewContainer = { str = 'hello'; integer = "
     "32 }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addString("NewContainer/str").required(true);
   inlet.addInt("NewContainer/int").required(false);
@@ -982,8 +957,7 @@ TYPED_TEST(inlet_Inlet_verify, verifyDoubleRange)
     "field1 = true; field2 = 56.32; NewContainer = { str = 'hello'; field4 = "
     "22.19 "
     "}";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addDouble("field2").range(1.0, 57.2);
   EXPECT_TRUE(inlet.verify());
@@ -999,8 +973,7 @@ TYPED_TEST(inlet_Inlet_verify, verifyDoubleRange)
     "field1 = true; field2 = 56.32; NewContainer = { str = 'hello'; field4 = "
     "22.19 "
     "}";
-  DataStore ds1;
-  Inlet inlet1 = createBasicInlet<TypeParam>(&ds1, testString1);
+  Inlet inlet1 = createBasicInlet<TypeParam>(testString1);
 
   inlet1.addDouble("field2").defaultValue(5).range(
     0,
@@ -1016,8 +989,7 @@ TYPED_TEST(inlet_Inlet_verify, verifyIntRange)
   // For checking values
   std::string testString =
     "field1 = true; field2 = 56; NewContainer = { field4 = 22; field5 = 48 }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addInt("field2").range(0, 56);
   EXPECT_TRUE(inlet.verify());
@@ -1034,8 +1006,7 @@ TYPED_TEST(inlet_Inlet_verify, verifyIntRange)
   // For checking default values
   std::string testString1 =
     "field1 = true; field2 = 56; NewContainer = { field4 = 22; field5 = 48 }";
-  DataStore ds1;
-  Inlet inlet1 = createBasicInlet<TypeParam>(&ds1, testString1);
+  Inlet inlet1 = createBasicInlet<TypeParam>(testString1);
   inlet1.addInt("field2").range(0, 56).defaultValue(32);
   EXPECT_TRUE(inlet1.verify());
 
@@ -1051,8 +1022,7 @@ TYPED_TEST(inlet_Inlet_verify, verifyValidIntValues)
   // check values
   std::string testString =
     "field1 = true; field2 = 56; NewContainer = { field4 = 22; field5 = 48 }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addInt("field2").validValues({1, 2, 3, 56, 57, 58});
   EXPECT_TRUE(inlet.verify());
@@ -1071,8 +1041,7 @@ TYPED_TEST(inlet_Inlet_verify, verifyValidIntValues)
   // check default values
   std::string testString1 =
     "field1 = true; field2 = 56; NewContainer = { field4 = 22; field5 = 48 }";
-  DataStore ds1;
-  Inlet inlet1 = createBasicInlet<TypeParam>(&ds1, testString1);
+  Inlet inlet1 = createBasicInlet<TypeParam>(testString1);
 
   inlet1.addInt("field2").validValues({1, 2, 3, 56, 57, 58}).defaultValue(2);
   EXPECT_TRUE(inlet1.verify());
@@ -1094,8 +1063,7 @@ TYPED_TEST(inlet_Inlet_verify, verifyValidDoubleValues)
     "field1 = true; field2 = 56.0; NewContainer = { field4 = 22.0; field5 = "
     "48.23 "
     "}";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addDouble("field2").validValues({1, 2, 3, 56, 57, 58});
   EXPECT_TRUE(inlet.verify());
@@ -1116,8 +1084,7 @@ TYPED_TEST(inlet_Inlet_verify, verifyValidDoubleValues)
     "field1 = true; field2 = 56.0; NewContainer = { field4 = 22.0; field5 = "
     "48.23 "
     "}";
-  DataStore ds1;
-  Inlet inlet1 = createBasicInlet<TypeParam>(&ds1, testString1);
+  Inlet inlet1 = createBasicInlet<TypeParam>(testString1);
 
   inlet1.addDouble("field2").validValues({1, 2, 3, 56, 57, 58}).defaultValue(2.);
   EXPECT_TRUE(inlet1.verify());
@@ -1140,8 +1107,7 @@ TYPED_TEST(inlet_Inlet_verify, verifyValidStringValues)
   std::string testString =
     "field1 = true; field2 = 'abc'; NewContainer = { field3 = 'xyz'; field4 = "
     "'yes' }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addString("field2").validValues({"abc", "defg", "hijk", "lm"});
   EXPECT_TRUE(inlet.verify());
@@ -1159,8 +1125,7 @@ TYPED_TEST(inlet_Inlet_verify, verifyValidStringValues)
 
   // check default values
   std::string testString1 = "field1 = true; NewContainer = { field5 = 'nop' }";
-  DataStore ds1;
-  Inlet inlet1 = createBasicInlet<TypeParam>(&ds1, testString1);
+  Inlet inlet1 = createBasicInlet<TypeParam>(testString1);
 
   inlet1.addString("field2")
     .validValues({"abc", "defg", "hijk", "lm"})
@@ -1182,8 +1147,7 @@ TYPED_TEST(inlet_Inlet_verify, verifyFieldLambda)
   std::string testString =
     "field1 = true; field2 = 'abc'; NewContainer = { field3 = 'xyz'; field4 = "
     "'yes' }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addBool("field1");
   auto& field2 = inlet.addString("field2");
@@ -1207,8 +1171,7 @@ TYPED_TEST(inlet_Inlet_verify, verifyContainerLambda1)
   std::string testString =
     "field1 = true; field2 = 'abc'; NewContainer = { field3 = 'xyz'; field4 = "
     "'yes' }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addBool("field1");
   auto& field2 = inlet.addString("field2");
@@ -1241,8 +1204,7 @@ TYPED_TEST(inlet_Inlet_verify, verifyContainerLambda1)
 TYPED_TEST(inlet_Inlet_verify, verifyContainerLambda3)
 {
   std::string testString = "dimensions = 2; vector = { x = 1; y = 2; z = 3; }";
-  DataStore ds;
-  auto myInlet = createBasicInlet<TypeParam>(&ds, testString);
+  auto myInlet = createBasicInlet<TypeParam>(testString);
   myInlet.addInt("dimensions").required(true);
   auto& v = myInlet.addStruct("vector").required(true);
   v.addInt("x");
@@ -1287,13 +1249,12 @@ TYPED_TEST_SUITE(inlet_Inlet_array, axom::inlet::detail::ReaderTypes);
 // Checks all of the Container::getArray functions
 TYPED_TEST(inlet_Inlet_array, getArray)
 {
-  DataStore ds;
   std::string testString =
     "luaArrays = { arr1 = { [0] = 4}, "
     "              arr2 = {[0] = true, [1] = false}, "
     "              arr3 = {[0] = 'hello', [1] = 'bye'}, "
     "              arr4 = { [0] = 2.4 } }";
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addIntArray("luaArrays/arr1");
   inlet.addBoolArray("luaArrays/arr2");
@@ -1322,13 +1283,12 @@ TYPED_TEST(inlet_Inlet_array, getArray)
 // Checks the underlying Sidre representation of the arrays added from Lua
 TYPED_TEST(inlet_Inlet_array, inletArraysInSidre)
 {
-  DataStore ds;
   std::string testString =
     "luaArrays = { arr1 = { [0] = 4, [1] = 5, [2] = 6 , [3] = 2.4}, "
     "              arr2 = { [0] = true, [1] = false}, "
     "              arr3 = { [0] = 'hello', [1] = 'bye'}, "
     "              arr4 = { [0] = 2.4 } }";
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addIntArray("luaArrays/arr1");
 
@@ -1394,8 +1354,7 @@ TYPED_TEST(inlet_Inlet_array, inletArraysInSidre)
 TEST(inlet_Inlet_basic_lua, getTopLevelStrings)
 {
   std::string testString = "foo = 'test string'; bar = '15'";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   //
   // Define schema
@@ -1430,8 +1389,7 @@ TEST(inlet_Inlet_basic_lua, getTopLevelStrings)
 TEST(inlet_Inlet_basic_lua, getNestedStrings)
 {
   std::string testString = "foo = { bar = 'yet another string'; baz = '' }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   //
   // Define schema
@@ -1475,8 +1433,7 @@ TEST(inlet_Inlet_verify_lua, verifyContainerLambda2)
     "material.attribute = 1\n"
     "material.thermalview = 'isotropic'\n"
     "material.solidview = 'hyperelastic'";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
   inlet.addInt("thermal_solver/order");
   inlet.addString("thermal_solver/timestepper");
   inlet.addInt("solid_solver/order");
@@ -1532,8 +1489,7 @@ TEST(inlet_Inlet_verify_lua, requiredContainer)
     "material.attribute = 1\n"
     "material.thermalview = 'isotropic'\n"
     "material.solidview = 'hyperelastic'";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
   auto& material = inlet.addStruct("material");
   material.required(true);
 
@@ -1551,13 +1507,12 @@ TEST(inlet_Inlet_verify_lua, requiredContainer)
 // Check discontiguous arrays specifically
 TEST(inlet_Inlet_array_lua, getArray)
 {
-  DataStore ds;
   std::string testString =
     "luaArrays = { arr1 = { [1] = 4}, "
     "              arr2 = {[4] = true, [8] = false}, "
     "              arr3 = {[33] = 'hello', [2] = 'bye'}, "
     "              arr4 = { [12] = 2.4 } }";
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   inlet.addIntArray("luaArrays/arr1");
   inlet.addBoolArray("luaArrays/arr2");
@@ -1586,13 +1541,12 @@ TEST(inlet_Inlet_array_lua, getArray)
 // Checks the underlying Sidre representation of the arrays added from Lua
 TEST(inlet_Inlet_array_lua, inletArraysInSidre)
 {
-  DataStore ds;
   std::string testString =
     "luaArrays = { arr1 = { [1] = 4, [2] = 5, [3] = 6 , [12] = 2.4}, "
     "              arr2 = { [4] = true, [8] = false}, "
     "              arr3 = { [33] = 'hello', [2] = 'bye'}, "
     "              arr4 = { [12] = 2.4 } }";
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   inlet.addIntArray("luaArrays/arr1");
 

--- a/src/axom/inlet/tests/inlet_function.cpp
+++ b/src/axom/inlet/tests/inlet_function.cpp
@@ -22,23 +22,18 @@ using axom::inlet::FunctionType;
 using axom::inlet::Inlet;
 using axom::inlet::InletType;
 using axom::inlet::LuaReader;
-using axom::sidre::DataStore;
 
-Inlet createBasicInlet(DataStore* ds,
-                       const std::string& luaString,
-                       bool enableDocs = true)
+Inlet createBasicInlet(const std::string& luaString, bool enableDocs = true)
 {
   auto lr = std::make_unique<LuaReader>();
   lr->parseString(luaString);
-
-  return Inlet(std::move(lr), ds->getRoot(), enableDocs);
+  return Inlet(std::move(lr), enableDocs);
 }
 
 TEST(inlet_function, simple_vec3_to_double_raw)
 {
   std::string testString = "function foo (v) return v.x + v.y + v.z end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   auto func =
     inlet.reader().getFunction("foo", FunctionTag::Double, {FunctionTag::Vector});
@@ -51,8 +46,7 @@ TEST(inlet_function, simple_vec3_to_double_raw)
 TEST(inlet_function, simple_vec3_to_vec3_raw)
 {
   std::string testString = "function foo (v) return 2*v end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   auto func =
     inlet.reader().getFunction("foo", FunctionTag::Vector, {FunctionTag::Vector});
@@ -67,8 +61,7 @@ TEST(inlet_function, simple_vec3_to_vec3_raw)
 TEST(inlet_function, simple_vec3_to_vec3_raw_partial_init)
 {
   std::string testString = "function foo (v) return 2*v end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   auto func =
     inlet.reader().getFunction("foo", FunctionTag::Vector, {FunctionTag::Vector});
@@ -89,8 +82,7 @@ TEST(inlet_function, simple_vec3_to_vec3_raw_partial_init)
 TEST(inlet_function, simple_vec3_to_double_through_container)
 {
   std::string testString = "function foo (v) return v.x + v.y + v.z end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   inlet.addFunction("foo",
                     FunctionTag::Double,
@@ -105,8 +97,7 @@ TEST(inlet_function, simple_vec3_to_double_through_container)
 TEST(inlet_function, simple_vec3_to_vec3_through_container)
 {
   std::string testString = "function foo (v) return 2*v end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   inlet.addFunction("foo",
                     FunctionTag::Vector,
@@ -124,8 +115,7 @@ TEST(inlet_function, simple_vec3_to_vec3_through_container)
 TEST(inlet_function, simple_double_to_double_through_container)
 {
   std::string testString = "function foo (a) return (a * 3.4) + 9.64 end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   inlet.addFunction("foo",
                     FunctionTag::Double,
@@ -142,8 +132,7 @@ TEST(inlet_function, simple_double_to_double_through_container)
 TEST(inlet_function, simple_void_to_double_through_container)
 {
   std::string testString = "function foo () return 9.64 end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   inlet.addFunction("foo", FunctionTag::Double, {}, "foo's description");
 
@@ -156,8 +145,7 @@ TEST(inlet_function, simple_double_to_void_through_container)
 {
   // Test a function that returns nothing by using it to modify a global
   std::string testString = "bar = 19.9; function foo (a) bar = a end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   inlet.addFunction("foo",
                     FunctionTag::Void,
@@ -182,8 +170,7 @@ TEST(inlet_function, simple_string_to_double_through_container)
     "  elseif s == 'b' then return -6.3 "
     "  else return 66.5 end "
     "end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   inlet.addFunction("foo",
                     FunctionTag::Double,
@@ -206,8 +193,7 @@ TEST(inlet_function, simple_double_to_string_through_container)
     "  elseif d == 2 then return 'b' "
     "  else return 'c' end "
     "end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   inlet.addFunction("foo",
                     FunctionTag::String,
@@ -224,8 +210,7 @@ TEST(inlet_function, simple_double_to_string_through_container)
 TEST(inlet_function, simple_vec3_to_double_through_container_call)
 {
   std::string testString = "function foo (v) return v.x + v.y + v.z end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   inlet.addFunction("foo",
                     FunctionTag::Double,
@@ -239,8 +224,7 @@ TEST(inlet_function, simple_vec3_to_double_through_container_call)
 TEST(inlet_function, simple_vec3_to_vec3_through_container_call)
 {
   std::string testString = "function foo (v) return 2*v end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   inlet.addFunction("foo",
                     FunctionTag::Vector,
@@ -258,8 +242,7 @@ TEST(inlet_function, simple_vec3_double_to_double_through_container_call)
 {
   std::string testString =
     "function foo (v, t) return t * (v.x + v.y + v.z) end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   inlet.addFunction("foo",
                     FunctionTag::Double,
@@ -273,8 +256,7 @@ TEST(inlet_function, simple_vec3_double_to_double_through_container_call)
 TEST(inlet_function, simple_vec3_double_to_vec3_through_container_call)
 {
   std::string testString = "function foo (v, t) return t*v end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   inlet.addFunction("foo",
                     FunctionTag::Vector,
@@ -291,8 +273,7 @@ TEST(inlet_function, simple_vec3_double_to_vec3_through_container_call)
 TEST(inlet_function, simple_vec3_to_vec3_verify_lambda_pass)
 {
   std::string testString = "function foo (v) return 2*v end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   auto& func = inlet
                  .addFunction("foo",
@@ -311,8 +292,7 @@ TEST(inlet_function, simple_vec3_to_vec3_verify_lambda_pass)
 TEST(inlet_function, simple_vec3_to_vec3_verify_lambda_fail)
 {
   std::string testString = "function foo (v) return 2*v end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   auto& func = inlet
                  .addFunction("foo",
@@ -348,8 +328,7 @@ TEST(inlet_function, simple_vec3_to_vec3_struct)
 {
   std::string testString =
     "foo = { bar = true; baz = function (v) return 2*v end }";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   // Define schema
   inlet.addBool("foo/bar", "bar's description");
@@ -375,8 +354,7 @@ TEST(inlet_function, simple_vec3_to_vec3_array_of_struct)
     "       [12] = { bar = false, "
     "                baz = function (v) return 3*v end } "
     "}";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -415,8 +393,7 @@ TEST(inlet_function, dimension_dependent_result)
     "return Vector.new(first, 0, last) "
     "end "
     "end";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   inlet.addFunction("foo",
                     FunctionTag::Vector,
@@ -461,8 +438,7 @@ TEST(inlet_function, nested_function_in_struct)
   std::string testString =
     "quux = { [0] = { foo = { bar = function (x) return x + 1 end } }, "
     "         [1] = { foo = { bar = function (x) return x + 3 end } } }";
-  DataStore ds;
-  auto inlet = createBasicInlet(&ds, testString);
+  auto inlet = createBasicInlet(testString);
 
   auto& quux_schema = inlet.addStructArray("quux");
   auto& foo_schema = quux_schema.addStruct("foo");

--- a/src/axom/inlet/tests/inlet_jsonschema_writer.cpp
+++ b/src/axom/inlet/tests/inlet_jsonschema_writer.cpp
@@ -19,7 +19,6 @@
 
 using axom::inlet::Inlet;
 using axom::inlet::JSONSchemaWriter;
-using axom::sidre::DataStore;
 
 #define JSONSCHEMA_EXECUTABLE "jsonschema"
 
@@ -48,12 +47,12 @@ bool validateString(Inlet& inlet, const std::string& luaString)
 }
 
 template <typename InletReader>
-Inlet createBasicInlet(DataStore* ds, const std::string& luaString)
+Inlet createBasicInlet(const std::string& luaString)
 {
   std::unique_ptr<InletReader> reader(new InletReader());
   reader->parseString(axom::inlet::detail::fromLuaTo<InletReader>(luaString));
   const bool enableDocs = true;
-  return Inlet(std::move(reader), ds->getRoot(), enableDocs);
+  return Inlet(std::move(reader), enableDocs);
 }
 
 template <typename InletReader>
@@ -74,8 +73,7 @@ TYPED_TEST_SUITE(inlet_jsonschema_writer, axom::inlet::detail::ReaderTypes);
 TYPED_TEST(inlet_jsonschema_writer, top_level_bools)
 {
   std::string testString = "foo = true; bar = false";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Check for existing fields
   inlet.addBool("foo", "foo's description");
@@ -93,8 +91,7 @@ TYPED_TEST(inlet_jsonschema_writer, top_level_bools)
 TYPED_TEST(inlet_jsonschema_writer, top_level_bools_reqd)
 {
   std::string testString = "foo = true";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Check for existing fields
   inlet.addBool("foo", "foo's description");
@@ -112,8 +109,7 @@ TYPED_TEST(inlet_jsonschema_writer, top_level_bools_reqd)
 TYPED_TEST(inlet_jsonschema_writer, top_level_ints)
 {
   std::string testString = "foo = 12; bar = 16";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addInt("foo", "foo's description");
   inlet.addInt("bar", "bar's description");
@@ -127,8 +123,7 @@ TYPED_TEST(inlet_jsonschema_writer, top_level_ints)
 TYPED_TEST(inlet_jsonschema_writer, top_level_ints_wrong_type)
 {
   std::string testString = "foo = 'first'; bar = 'second'";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // We specify the default as a "hint" to the JSONSchemaWriter
   // since expected type information is not stored explicitly in the datastore
@@ -144,8 +139,7 @@ TYPED_TEST(inlet_jsonschema_writer, top_level_ints_wrong_type)
 TYPED_TEST(inlet_jsonschema_writer, top_level_ints_range_pass)
 {
   std::string testString = "foo = 5; bar = 12";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addInt("foo", "foo's description").range(2, 10);
   inlet.addInt("bar", "bar's description").range(10, 15);
@@ -159,8 +153,7 @@ TYPED_TEST(inlet_jsonschema_writer, top_level_ints_range_pass)
 TYPED_TEST(inlet_jsonschema_writer, top_level_ints_range_fail)
 {
   std::string testString = "foo = 12; bar = 5";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addInt("foo", "foo's description").range(2, 10);
   inlet.addInt("bar", "bar's description").range(10, 15);
@@ -174,8 +167,7 @@ TYPED_TEST(inlet_jsonschema_writer, top_level_ints_range_fail)
 TYPED_TEST(inlet_jsonschema_writer, top_level_ints_valid_set)
 {
   std::string testString = "foo = 5; bar = 8";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addInt("foo", "foo's description").validValues({5, 7, 9});
   inlet.addInt("bar", "bar's description").validValues({4, 6, 8});
@@ -189,8 +181,7 @@ TYPED_TEST(inlet_jsonschema_writer, top_level_ints_valid_set)
 TYPED_TEST(inlet_jsonschema_writer, top_level_ints_valid_set_fail)
 {
   std::string testString = "foo = 8; bar = 5";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addInt("foo", "foo's description").validValues({5, 7, 9});
   inlet.addInt("bar", "bar's description").validValues({4, 6, 8});
@@ -206,8 +197,7 @@ TYPED_TEST(inlet_jsonschema_writer, top_level_ints_valid_set_fail)
 TYPED_TEST(inlet_jsonschema_writer, top_level_strings_valid_set)
 {
   std::string testString = "foo = 'first'; bar = 'second'";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addString("foo", "foo's description").validValues({"first", "second"});
   inlet.addString("bar", "bar's description").validValues({"first", "second"});
@@ -221,8 +211,7 @@ TYPED_TEST(inlet_jsonschema_writer, top_level_strings_valid_set)
 TYPED_TEST(inlet_jsonschema_writer, top_level_strings_valid_set_fail)
 {
   std::string testString = "foo = 'first'; bar = 'third'";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addString("foo", "foo's description").validValues({"first", "second"});
   inlet.addString("bar", "bar's description").validValues({"first", "second"});

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -20,17 +20,13 @@
 using axom::inlet::Inlet;
 using axom::inlet::InletType;
 using axom::inlet::VariantKey;
-using axom::sidre::DataStore;
 
 template <typename InletReader>
-Inlet createBasicInlet(DataStore* ds,
-                       const std::string& luaString,
-                       bool enableDocs = true)
+Inlet createBasicInlet(const std::string& luaString, bool enableDocs = true)
 {
   std::unique_ptr<InletReader> reader(new InletReader());
   reader->parseString(axom::inlet::detail::fromLuaTo<InletReader>(luaString));
-
-  return Inlet(std::move(reader), ds->getRoot(), enableDocs);
+  return Inlet(std::move(reader), enableDocs);
 }
 
 struct Foo
@@ -63,8 +59,7 @@ TYPED_TEST_SUITE(inlet_object, axom::inlet::detail::ReaderTypes);
 TYPED_TEST(inlet_object, simple_struct_by_value)
 {
   std::string testString = "foo = { bar = true; baz = false }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Define schema
   inlet.addBool("foo/bar", "bar's description");
@@ -80,8 +75,7 @@ TYPED_TEST(inlet_object, simple_struct_by_value)
 TYPED_TEST(inlet_object, simple_struct_verify_pass)
 {
   std::string testString = "";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& foo_table = inlet.addStruct("foo");
   foo_table.addBool("bar", "bar's description").required(true);
@@ -94,8 +88,7 @@ TYPED_TEST(inlet_object, simple_struct_verify_pass)
 TYPED_TEST(inlet_object, simple_struct_verify_fail)
 {
   std::string testString = "foo = { baz = true }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& foo_table = inlet.addStruct("foo");
   foo_table.addBool("bar", "bar's description").required(true);
@@ -114,8 +107,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_by_value)
   std::string testString =
     "foo = { [0] = { bar = true; baz = false}, "
     "        [1] = { bar = false; baz = true} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -132,8 +124,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_implicit_idx)
   std::string testString =
     "foo = { { bar = true; baz = false}, "
     "        { bar = false; baz = true} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -152,8 +143,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_verify_optional)
   std::string testString =
     "foo = { [4] = { bar = true;}, "
     "        [7] = { bar = false;} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -168,8 +158,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_verify_reqd)
   std::string testString =
     "foo = { [4] = { bar = true;}, "
     "        [7] = { bar = false;} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -182,8 +171,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_verify_reqd)
 TYPED_TEST(inlet_object, simple_array_of_struct_optional_empty_pass)
 {
   std::string testString = "foo = { }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
   // Even though these are required, the input file should still
@@ -197,8 +185,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_optional_empty_pass)
 TYPED_TEST(inlet_object, simple_array_of_struct_required_empty_pass)
 {
   std::string testString = "foo = { }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Verification should pass because the array exists but is empty
   auto& arr_container = inlet.addStructArray("foo").required(true);
@@ -211,8 +198,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_required_empty_pass)
 TYPED_TEST(inlet_object, simple_array_of_primitive_required_empty_pass)
 {
   std::string testString = "foo = { }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Verification should pass because the array exists but is empty
   inlet.addIntArray("foo").required(true);
@@ -223,8 +209,7 @@ TYPED_TEST(inlet_object, simple_array_of_primitive_required_empty_pass)
 TYPED_TEST(inlet_object, simple_array_of_struct_nonexistent_fail)
 {
   std::string testString = "";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Verification should fail because the array does not exist
   auto& arr_container = inlet.addStructArray("foo").required(true);
@@ -237,8 +222,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_nonexistent_fail)
 TYPED_TEST(inlet_object, simple_array_of_primitive_nonexistent_fail)
 {
   std::string testString = "";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Verification should fail because the array does not exist
   inlet.addIntArray("foo").required(true);
@@ -251,8 +235,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_verify_lambda)
   std::string testString =
     "foo = { [4] = { bar = true;}, "
     "        [7] = { bar = false;} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -270,8 +253,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_verify_lambda_pass)
   std::string testString =
     "foo = { [4] = { bar = true;}, "
     "        [7] = { baz = false;} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -291,8 +273,7 @@ TYPED_TEST(inlet_object, simple_array_of_struct_verify_lambda_fail)
   std::string testString =
     "foo = { [4] = { bar = true;}, "
     "        [7] = { bar = false; baz = true} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -328,8 +309,7 @@ TYPED_TEST(inlet_object, array_of_struct_containing_array)
   std::string testString =
     "foo = { [0] = { arr = { [0] = 3 }; }, "
     "        [1] = { arr = { [0] = 2 }; } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -365,8 +345,7 @@ struct FromInlet<MoveOnlyFoo>
 TYPED_TEST(inlet_object, simple_moveonly_struct_by_value)
 {
   std::string testString = "foo = { bar = true; baz = false }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Define schema
   // Check for existing fields
@@ -382,8 +361,7 @@ TYPED_TEST(inlet_object, simple_moveonly_struct_by_value)
 TYPED_TEST(inlet_object, simple_value_from_bracket)
 {
   std::string testString = "foo = true";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Define schema
   // Check for existing fields
@@ -396,8 +374,7 @@ TYPED_TEST(inlet_object, simple_value_from_bracket)
 TYPED_TEST(inlet_object, simple_struct_from_bracket)
 {
   std::string testString = "foo = { bar = true; baz = false }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Define schema
   // Check for existing fields
@@ -413,8 +390,7 @@ TYPED_TEST(inlet_object, simple_struct_from_bracket)
 TYPED_TEST(inlet_object, contains_from_bracket)
 {
   std::string testString = "foo = { bar = true; baz = false }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Define schema
   // Check for existing fields
@@ -428,13 +404,12 @@ TYPED_TEST(inlet_object, contains_from_bracket)
 
 TYPED_TEST(inlet_object, array_from_bracket)
 {
-  DataStore ds;
   std::string testString =
     "luaArrays = { arr1 = { [0] = 4}, "
     "              arr2 = {[0] = true, [1] = false}, "
     "              arr3 = {[0] = 'hello', [1] = 'bye'}, "
     "              arr4 = { [0] = 2.4 } }";
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   std::unordered_map<int, int> intMap;
   std::unordered_map<int, bool> boolMap;
@@ -467,8 +442,7 @@ TYPED_TEST(inlet_object, primitive_type_checks)
 {
   std::string testString =
     " bar = true; baz = 12; quux = 2.5; corge = 'hello' ";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Define schema
   // Check for existing fields
@@ -503,8 +477,7 @@ TYPED_TEST(inlet_object, composite_type_checks)
     "luaArrays = { arr1 = { [1] = 4}, "
     "              arr2 = {[4] = true, [8] = false} }; "
     "foo = { bar = true; baz = false }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Define schema
   // Check for existing fields
@@ -537,8 +510,7 @@ TYPED_TEST(inlet_object, implicit_conversion_primitives)
   std::string testString =
     " bar = true; baz = 12; quux = 2.5; corge = 'hello'; arr = { [0] = 4, [1] "
     "= 6, [2] = 10}";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Define schema
   inlet.addBool("bar", "bar's description");
@@ -601,8 +573,7 @@ TYPED_TEST(inlet_object, nested_array_of_struct_containing_array)
   std::string testString =
     "bars = { [0] = { foo = { arr = { [0] = 3 }; } }, "
     "         [1] = { foo = { arr = { [0] = 2 }; } } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& bar_container = inlet.addStructArray("bars");
   auto& foo_container = bar_container.addStruct("foo");
@@ -645,8 +616,7 @@ TYPED_TEST(inlet_object, nested_array_of_struct)
     "                         [1] = { bar = false; baz = true} } }, "
     "         [1] = { arr = { [0] = { bar = false; baz = false}, "
     "                         [1] = { bar = true; baz = true} } } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& quux_container = inlet.addStructArray("quux");
   auto& foo_container = quux_container.addStructArray("arr");
@@ -670,8 +640,7 @@ TYPED_TEST(inlet_object, nested_dict_of_array_of_struct)
     "                                [1] = { bar = false; baz = true} } }, "
     "         ['second'] = { arr = { [0] = { bar = false; baz = false}, "
     "                                [1] = { bar = true; baz = true} } } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& quux_container = inlet.addStructDictionary("quux");
   auto& foo_container = quux_container.addStructArray("arr");
@@ -723,8 +692,7 @@ TYPED_TEST(inlet_object, nested_array_of_dict_of_array_of_struct)
     "                          ['fourth'] = { arr = { [0] = { bar = false; baz = false}, "
     "                                                 [1] = { bar = true; baz = true} } } } } }";
   // clang-format on
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& corge_container = inlet.addStructArray("corge");
   auto& quux_container = corge_container.addStructDictionary("dict");
@@ -774,8 +742,7 @@ TYPED_TEST(inlet_object, nested_dict_of_array_of_struct_with_array)
     "                                      [1] = { arr = { [0] = 2 } } } }, "
     "         ['second'] = { outer_arr = { [0] = { arr = { [0] = 3 } }, "
     "                                      [1] = { arr = { [0] = 4 } } } } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& quux_container = inlet.addStructDictionary("quux");
   auto& foo_container = quux_container.addStructArray("outer_arr");
@@ -817,8 +784,7 @@ TYPED_TEST(inlet_object, nested_array_of_nested_structs)
   std::string testString =
     "quux = { [0] = { foo = { bar = true; baz = false } }, "
     "         [1] = { foo = { bar = false; baz = true } } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& quux_schema = inlet.addStructArray("quux");
   auto& foo_schema = quux_schema.addStruct("foo");
@@ -839,8 +805,7 @@ TYPED_TEST(inlet_object, nested_array_of_nested_structs)
 TYPED_TEST(inlet_object, nested_array_of_struct_verify_pass)
 {
   std::string testString = "quux = { }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& quux_schema = inlet.addStructArray("quux");
 
@@ -862,8 +827,7 @@ TYPED_TEST(inlet_object, nested_array_of_struct_verify_pass)
 TYPED_TEST(inlet_object, primitive_arrays_as_std_vector)
 {
   std::string testString = " arr = { [0] = 4, [1] = 6, [2] = 10}";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Define schema
   inlet.addIntArray("arr");
@@ -884,8 +848,7 @@ TYPED_TEST(inlet_object, primitive_arrays_as_std_vector)
 TYPED_TEST(inlet_object, primitive_arrays_as_std_vector_wrong_type)
 {
   std::string testString = " arr = { [0] = 'a', [1] = 'b', [2] = 'c'}";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Define schema
   inlet.addIntArray("arr");
@@ -898,8 +861,7 @@ TYPED_TEST(inlet_object, primitive_arrays_as_std_vector_wrong_type)
 TYPED_TEST(inlet_object, primitive_arrays_as_std_vector_wrong_type_reqd_fail)
 {
   std::string testString = " arr = { [0] = 'a', [1] = 'b', [2] = 'c'}";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Define schema
   inlet.addIntArray("arr").required();
@@ -911,8 +873,7 @@ TYPED_TEST(inlet_object, primitive_arrays_as_std_vector_wrong_type_reqd_fail)
 TYPED_TEST(inlet_object, primitive_arrays_as_std_vector_mixed_type)
 {
   std::string testString = " arr = { [0] = 4, [1] = 6, [2] = 'a', [3] = 'b'}";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   // Define schema
   inlet.addIntArray("arr");
@@ -927,8 +888,7 @@ TYPED_TEST(inlet_object, struct_arrays_as_std_vector)
   std::string testString =
     "foo = { [0] = { bar = true; baz = false}, "
     "        [1] = { bar = false; baz = true} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -942,8 +902,7 @@ TYPED_TEST(inlet_object, struct_arrays_as_std_vector)
 TYPED_TEST(inlet_object, default_scalar_user_provided)
 {
   std::string testString = " ";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& scalar = inlet.addInt("foo").defaultValue(2);
   // The field itself exists but was not provided by the user
@@ -962,8 +921,7 @@ TYPED_TEST(inlet_object, default_scalar_user_provided)
 TYPED_TEST(inlet_object, default_struct_field_user_provided)
 {
   std::string testString = " ";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& foo_container = inlet.addStruct("foo");
   foo_container.addBool("bar", "bar's description").defaultValue(true);
@@ -985,8 +943,7 @@ TYPED_TEST(inlet_object, default_struct_field_user_provided)
 TYPED_TEST(inlet_object, default_struct_field_user_provided_reqd)
 {
   std::string testString = " ";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& foo_container = inlet.addStruct("foo").required();
   foo_container.addBool("bar", "bar's description").defaultValue(true);
@@ -1011,8 +968,7 @@ TYPED_TEST(inlet_object, default_struct_field_user_provided_reqd)
 TYPED_TEST(inlet_object, default_struct_field_marked_true)
 {
   std::string testString = "foo = { bar = true }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& foo_container = inlet.addStruct("foo");
   foo_container.addBool("bar", "bar's description").defaultValue(true);
@@ -1036,8 +992,7 @@ TYPED_TEST(inlet_object, basic_unused_names)
   std::string testString =
     "foo = { [0] = { bar = true; baz = false}, "
     "        [1] = { bar = false; baz = true} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -1056,8 +1011,7 @@ TYPED_TEST(inlet_object, basic_unused_names_strict)
   std::string testString =
     "foo = { [0] = { bar = true; baz = false}, "
     "        [1] = { bar = false; baz = true} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo").strict();
 
@@ -1073,8 +1027,7 @@ TYPED_TEST(inlet_object, basic_unused_names_substring)
   std::string testString =
     "foo = { [0] = { bar = true; barz = false}, "
     "        [1] = { bar = false; barz = true} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -1094,8 +1047,7 @@ TYPED_TEST(inlet_object, basic_unused_names_substring_strict)
   std::string testString =
     "foo = { [0] = { bar = true; barz = false}, "
     "        [1] = { bar = false; barz = true} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo").strict();
 
@@ -1115,8 +1067,7 @@ TYPED_TEST_SUITE(inlet_object_dict, axom::inlet::detail::ReaderTypes);
 TYPED_TEST(inlet_object_dict, basic_dicts)
 {
   std::string testString = "foo = { ['key1'] = 4, ['key3'] = 6, ['key2'] = 10}";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   inlet.addIntDictionary("foo", "foo's description");
   std::unordered_map<std::string, int> dict = inlet["foo"];
@@ -1131,8 +1082,7 @@ TYPED_TEST(inlet_object_dict, simple_dict_of_struct_by_value)
   std::string testString =
     "foo = { ['key1'] = { bar = true; baz = false}, "
     "        ['key2'] = { bar = false; baz = true} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& dict_container = inlet.addStructDictionary("foo");
 
@@ -1166,8 +1116,7 @@ TYPED_TEST(inlet_object_dict, dict_of_struct_containing_dict)
   std::string testString =
     "foo = { ['key3'] = { arr = { ['key1'] = 3 }; }, "
     "        ['key4'] = { arr = { ['key2'] = 2 }; } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& dict_container = inlet.addStructDictionary("foo");
 
@@ -1186,8 +1135,7 @@ TYPED_TEST(inlet_object_dict, dict_of_struct_containing_array)
   std::string testString =
     "foo = { ['key3'] = { arr = { [0] = 3 }; }, "
     "        ['key4'] = { arr = { [0] = 2 }; } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& dict_container = inlet.addStructDictionary("foo");
 
@@ -1206,8 +1154,7 @@ TYPED_TEST(inlet_object_dict, array_of_struct_containing_dict)
   std::string testString =
     "foo = { [0] = { arr = { ['key1'] = 3 }; }, "
     "        [1] = { arr = { ['key2'] = 2 }; } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<TypeParam>(&ds, testString);
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -1226,7 +1173,6 @@ or handled differently these tests can be re-enabled.
 TEST(inlet_dict, mixed_keys_primitive_duplicated)
 {
   std::string testString = "foo = { ['1'] = 4, [1] = 6 }";
-  DataStore ds;
   auto inlet = createBasicInlet(&ds, testString);
 
   inlet.addIntDictionary("foo", "foo's description");
@@ -1239,7 +1185,6 @@ TEST(inlet_dict, key_with_slash)
 {
   std::string testString =
     "foo = { ['key1/subkey1'] = 4, ['key3'] = 6, ['key2'] = 10}";
-  DataStore ds;
   Inlet inlet = createBasicInlet(&ds, testString);
 
   inlet.addIntDictionary("foo", "foo's description");
@@ -1259,8 +1204,7 @@ TEST(inlet_object_lua, array_of_struct_containing_array)
   std::string testString =
     "foo = { [4] = { arr = { [1] = 3 }; }, "
     "        [7] = { arr = { [6] = 2 }; } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -1274,13 +1218,12 @@ TEST(inlet_object_lua, array_of_struct_containing_array)
 
 TEST(inlet_object_lua, array_from_bracket)
 {
-  DataStore ds;
   std::string testString =
     "luaArrays = { arr1 = { [1] = 4}, "
     "              arr2 = {[4] = true, [8] = false}, "
     "              arr3 = {[33] = 'hello', [2] = 'bye'}, "
     "              arr4 = { [12] = 2.4 } }";
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   std::unordered_map<int, int> intMap;
   std::unordered_map<int, bool> boolMap;
@@ -1312,8 +1255,7 @@ TEST(inlet_object_lua, array_from_bracket)
 TEST(inlet_object_lua, primitive_arrays_as_std_vector_discontiguous)
 {
   std::string testString = " arr = { [0] = 4, [8] = 6, [12] = 10}";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   // Define schema
   inlet.addIntArray("arr");
@@ -1331,8 +1273,7 @@ TEST(inlet_object_lua, struct_arrays_as_std_vector_discontiguous)
   std::string testString =
     "foo = { [6] = { bar = true; baz = false}, "
     "        [11] = { bar = false; baz = true} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -1346,8 +1287,7 @@ TEST(inlet_object_lua, struct_arrays_as_std_vector_discontiguous)
 TEST(inlet_object_lua, primitive_arrays_as_std_vector_implicit_idx)
 {
   std::string testString = " arr = { 4, 6, 10}";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   // Define schema
   inlet.addIntArray("arr");
@@ -1365,8 +1305,7 @@ TEST(inlet_object_lua, struct_arrays_as_std_vector_implicit_idx)
   std::string testString =
     "foo = { { bar = true; baz = false}, "
     "        { bar = false; baz = true} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -1382,8 +1321,7 @@ TEST(inlet_object_lua_dict, dict_of_struct_containing_array)
   std::string testString =
     "foo = { ['key3'] = { arr = { [1] = 3 }; }, "
     "        ['key4'] = { arr = { [6] = 2 }; } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   auto& dict_container = inlet.addStructDictionary("foo");
 
@@ -1402,8 +1340,7 @@ TEST(inlet_object_lua_dict, array_of_struct_containing_dict)
   std::string testString =
     "foo = { [7] = { arr = { ['key1'] = 3 }; }, "
     "        [4] = { arr = { ['key2'] = 2 }; } }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   auto& arr_container = inlet.addStructArray("foo");
 
@@ -1418,8 +1355,7 @@ TEST(inlet_object_lua_dict, array_of_struct_containing_dict)
 TEST(inlet_object_lua_dict, mixed_keys_primitive)
 {
   std::string testString = "foo = { ['key1'] = 4, [1] = 6 }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   inlet.addIntDictionary("foo", "foo's description");
   std::unordered_map<VariantKey, int> dict = inlet["foo"];
@@ -1430,8 +1366,7 @@ TEST(inlet_object_lua_dict, mixed_keys_primitive)
 TEST(inlet_object_lua_dict, mixed_keys_primitive_ignore_string_only)
 {
   std::string testString = "foo = { ['key1'] = 4, [1] = 6 }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   inlet.addIntDictionary("foo", "foo's description");
   std::unordered_map<std::string, int> dict = inlet["foo"];
@@ -1442,8 +1377,7 @@ TEST(inlet_object_lua_dict, mixed_keys_primitive_ignore_string_only)
 TEST(inlet_object_lua_dict, mixed_keys_primitive_ignore_int_only)
 {
   std::string testString = "foo = { ['key1'] = 4, [1] = 6 }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   inlet.addIntArray("foo", "foo's description");
   std::unordered_map<int, int> array = inlet["foo"];
@@ -1456,8 +1390,7 @@ TEST(inlet_object_lua_dict, mixed_keys_object)
   std::string testString =
     "foo = { ['key1'] = { bar = true; baz = false}, "
     "        [1] = { bar = false; baz = true} }";
-  DataStore ds;
-  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(&ds, testString);
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
 
   auto& dict_container = inlet.addStructDictionary("foo");
 


### PR DESCRIPTION
# Summary

- This PR is a refactoring
- It does the following:
  - Modifies `inlet::Inlet` to not require a user-provided Sidre root group
  - Fixes #569 
  - Removes the no-longer-necessary manual datastore creation from most tests and some examples 

