### PR TITLE
Adds c2c library as an optional TPL for Axom

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ### Added
 - Added new CMake option to allow users to turn off Axom created tools: `AXOM_ENABLE_TOOLS`
 - Inlet can now log verification errors to a user-processable list instead of using SLIC
+- Added support for optional third-party `c2c` ("contours to codes") library for parsing 2D spline data.
+  `c2c` is currently only available for Axom configurations on LLNL platforms.
 
 ### Changed
 - `MFEMSidreDataCollection` now reuses FESpace/QSpace objects with the same basis

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@8.0.1_nvcc_xlf.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@8.0.1_nvcc_xlf.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/clang/flang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/clang/flang" CACHE PATH "")
 
 else()
 
@@ -99,9 +99,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/clang-8.0.1_nvcc_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/clang-8.0.1_nvcc_xlf" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@9.0.0_upstream_xlf.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@9.0.0_upstream_xlf.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/clang/flang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/clang/flang" CACHE PATH "")
 
 else()
 
@@ -75,9 +75,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/clang-9.0.0_upstream_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/clang-9.0.0_upstream_xlf" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-gcc@7.3.1.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-gcc@7.3.1.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/gcc/g++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
 
 else()
 
@@ -67,9 +67,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/gcc-7.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/gcc-7.3.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1_coral.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1_coral.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/xl/xlc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/xl/xlc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
 
 else()
 
@@ -79,9 +79,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/xl-16.1.1_coral" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/xl-16.1.1_coral" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1_nvcc.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1_nvcc.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/xl/xlc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/xl/xlc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
 
 else()
 
@@ -103,9 +103,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_01_13_49_37/xl-16.1.1_nvcc" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_23_59_50/xl-16.1.1_nvcc" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/ruby-toss_3_x86_64_ib-clang@10.0.0.cmake
+++ b/host-configs/ruby-toss_3_x86_64_ib-clang@10.0.0.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
 
 else()
 
@@ -69,9 +69,11 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/clang-10.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/clang-10.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/ruby-toss_3_x86_64_ib-clang@9.0.0.cmake
+++ b/host-configs/ruby-toss_3_x86_64_ib-clang@9.0.0.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
 
 else()
 
@@ -69,9 +69,11 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/clang-9.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/clang-9.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/ruby-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/ruby-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/gcc/g++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
 
 else()
 
@@ -63,9 +63,11 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/gcc-8.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/gcc-8.1.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/ruby-toss_3_x86_64_ib-gcc@8.1_no_fortran.cmake
+++ b/host-configs/ruby-toss_3_x86_64_ib-gcc@8.1_no_fortran.cmake
@@ -11,9 +11,9 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/gcc/g++" CACHE PATH "")
 
   # No Fortran compiler defined in spec
 else()
@@ -61,9 +61,11 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/gcc-8.1_no_fortran" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/gcc-8.1_no_fortran" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/ruby-toss_3_x86_64_ib-intel@18.0.2.cmake
+++ b/host-configs/ruby-toss_3_x86_64_ib-intel@18.0.2.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/intel/icc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/intel/icc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/intel/icpc" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/intel/icpc" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/intel/ifort" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/intel/ifort" CACHE PATH "")
 
 else()
 
@@ -63,9 +63,11 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/intel-18.0.2" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/intel-18.0.2" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/ruby-toss_3_x86_64_ib-intel@19.0.4.cmake
+++ b/host-configs/ruby-toss_3_x86_64_ib-intel@19.0.4.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/intel/icc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/intel/icc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/intel/icpc" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/intel/icpc" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/spack/lib/spack/env/intel/ifort" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/spack/lib/spack/env/intel/ifort" CACHE PATH "")
 
 else()
 
@@ -69,9 +69,11 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_20_55_42/intel-19.0.4" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_58_38/intel-19.0.4" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@8.0.1_nvcc_xlf.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@8.0.1_nvcc_xlf.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/clang/flang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/clang/flang" CACHE PATH "")
 
 else()
 
@@ -99,9 +99,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/clang-8.0.1_nvcc_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/clang-8.0.1_nvcc_xlf" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@9.0.0_upstream_xlf.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@9.0.0_upstream_xlf.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/clang/flang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/clang/flang" CACHE PATH "")
 
 else()
 
@@ -75,9 +75,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/clang-9.0.0_upstream_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/clang-9.0.0_upstream_xlf" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@7.3.1.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@7.3.1.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/gcc/g++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
 
 else()
 
@@ -67,9 +67,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/gcc-7.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/gcc-7.3.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1_coral.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1_coral.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/xl/xlc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/xl/xlc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
 
 else()
 
@@ -79,9 +79,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/xl-16.1.1_coral" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/xl-16.1.1_coral" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1_nvcc.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1_nvcc.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/xl/xlc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/xl/xlc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
 
 else()
 
@@ -103,9 +103,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_05_26_14_16_38/xl-16.1.1_nvcc" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2021_06_08_16_10_35/xl-16.1.1_nvcc" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@10.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@10.0.0.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
 
 else()
 
@@ -69,9 +69,11 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/clang-10.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/clang-10.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@9.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@9.0.0.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
 
 else()
 
@@ -69,9 +69,11 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/clang-9.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/clang-9.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/gcc/g++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
 
 else()
 
@@ -63,9 +63,11 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/gcc-8.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/gcc-8.1.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1_no_fortran.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1_no_fortran.cmake
@@ -11,9 +11,9 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/gcc/g++" CACHE PATH "")
 
   # No Fortran compiler defined in spec
 else()
@@ -61,9 +61,11 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/gcc-8.1_no_fortran" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/gcc-8.1_no_fortran" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@18.0.2.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@18.0.2.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/intel/icc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/intel/icc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/intel/icpc" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/intel/icpc" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/intel/ifort" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/intel/ifort" CACHE PATH "")
 
 else()
 
@@ -63,9 +63,11 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/intel-18.0.2" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/intel-18.0.2" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.4.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.4.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/intel/icc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/intel/icc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/intel/icpc" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/intel/icpc" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/spack/lib/spack/env/intel/ifort" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/spack/lib/spack/env/intel/ifort" CACHE PATH "")
 
 else()
 
@@ -69,9 +69,11 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_05_26_14_17_12/intel-19.0.4" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/intel-19.0.4" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@8.0.1_nvcc_xlf.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@8.0.1_nvcc_xlf.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/clang/flang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/clang/flang" CACHE PATH "")
 
 else()
 
@@ -99,9 +99,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/clang-8.0.1_nvcc_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/clang-8.0.1_nvcc_xlf" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@9.0.0_upstream_xlf.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-clang@9.0.0_upstream_xlf.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/clang/flang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/clang/flang" CACHE PATH "")
 
 else()
 
@@ -75,9 +75,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/clang-9.0.0_upstream_xlf" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/clang-9.0.0_upstream_xlf" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-gcc@7.3.1.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-gcc@7.3.1.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/gcc/g++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
 
 else()
 
@@ -67,9 +67,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/gcc-7.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/gcc-7.3.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-xl@16.1.1_coral.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-xl@16.1.1_coral.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/xl/xlc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/xl/xlc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
 
 else()
 
@@ -79,9 +79,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/xl-16.1.1_coral" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/xl-16.1.1_coral" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/host-configs/rzmanta-blueos_3_ppc64le_ib-xl@16.1.1_nvcc.cmake
+++ b/host-configs/rzmanta-blueos_3_ppc64le_ib-xl@16.1.1_nvcc.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/xl/xlc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/xl/xlc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
 
 else()
 
@@ -103,9 +103,11 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_05_26_16_22_41/xl-16.1.1_nvcc" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib/2021_06_08_16_11_03/xl-16.1.1_nvcc" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.7.2" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
 

--- a/scripts/llnl_scripts/batch_scripts/bsub_llnl_rz_blueos_all_compilers.sh
+++ b/scripts/llnl_scripts/batch_scripts/bsub_llnl_rz_blueos_all_compilers.sh
@@ -6,9 +6,8 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 
 #BSUB -W 240
-#BSUB -G wbronze
 #BSUB -o b.out.rz.blueos.all.compilers.%J.txt
-#BSUB -q pbatch
+#BSUB -q pdebug
 #
 # usage: 
 #  cd {to directory with this script}

--- a/scripts/llnl_scripts/batch_scripts/msub_llnl_rz_toss3_all_compilers.sh
+++ b/scripts/llnl_scripts/batch_scripts/msub_llnl_rz_toss3_all_compilers.sh
@@ -7,7 +7,7 @@
 
 #MSUB -l nodes=1:ppn=36
 #MSUB -q pdebug
-#MSUB -l walltime=8:00:00
+#MSUB -l walltime=4:00:00
 #MSUB -j oe
 #MSUB -o m.out.rz.uberenv.toss3.all.compilers.%j.%N.txt
 #

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -69,6 +69,7 @@ class Axom(CachedCMakePackage, CudaPackage):
     variant("mpi",      default=True, description="Build MPI support")
     variant('openmp',   default=True, description='Turn on OpenMP support.')
 
+    variant("c2c",      default=False, description="Build with c2c")
     variant("mfem",     default=False, description="Build with mfem")
     variant("hdf5",     default=True, description="Build with hdf5")
     variant("lua",      default=True, description="Build with Lua")
@@ -115,6 +116,8 @@ class Axom(CachedCMakePackage, CudaPackage):
                    when='+raja cuda_arch={0}'.format(sm_))
         depends_on('umpire cuda_arch={0}'.format(sm_),
                    when='+umpire cuda_arch={0}'.format(sm_))
+
+    depends_on("c2c", when="+c2c")
 
     depends_on("mfem", when="+mfem")
     depends_on("mfem~mpi", when="+mfem~mpi")
@@ -321,7 +324,7 @@ class Axom(CachedCMakePackage, CudaPackage):
         entries.append(cmake_cache_path("CONDUIT_DIR", conduit_dir))
 
         # optional tpls
-        for dep in ('mfem', 'hdf5', 'lua', 'raja', 'umpire'):
+        for dep in ('c2c', 'mfem', 'hdf5', 'lua', 'raja', 'umpire'):
             if '+%s' % dep in spec:
                 dep_dir = get_spec_path(spec, dep, path_replacements)
                 entries.append(cmake_cache_path('%s_DIR' % dep.upper(),

--- a/scripts/spack/packages/c2c/package.py
+++ b/scripts/spack/packages/c2c/package.py
@@ -8,7 +8,7 @@ class C2c(CMakePackage):
     """Contour Parser Library"""
 
     homepage = 'https://rzlc.llnl.gov/c2c'
-    url = 'file:///usr/gapps/c2c/dist/c2c-0.11.0.tgz'
+    url = 'file:///collab/usr/gapps/c2c/dist/c2c-0.11.0.tgz'
 
     version('develop', git='ssh://git@rz-bitbucket.llnl.gov:7999/wp/copa.git',
             submodules=True, branch='develop')

--- a/scripts/spack/packages/c2c/package.py
+++ b/scripts/spack/packages/c2c/package.py
@@ -1,0 +1,194 @@
+from spack import *
+
+import os
+import socket
+
+
+class C2c(CMakePackage):
+    """Contour Parser Library"""
+
+    homepage = 'https://rzlc.llnl.gov/c2c'
+    url = 'file:///usr/gapps/c2c/dist/c2c-0.11.0.tgz'
+
+    version('develop', git='ssh://git@rz-bitbucket.llnl.gov:7999/wp/copa.git',
+            submodules=True, branch='develop')
+
+    version('1.3.0', sha256='8dd3ba73651f61d2f6d0dea43ab9568a566fd73c591c8bcae8792b44cb654c59')
+    version('0.12.0', '250aa61251589215dd7f90f7b31dd443')
+    version('0.11.0', '28cb091711af15bcb27e01b5ed2a4921')
+    version('0.10.0', '99d797383f32ece809c12682fd5ce5cc')
+    version('0.9.1', 'a2de3857e9581f63eb1f411e165d7e3d')
+    version('0.9.0', 'a7ad2f3c8121c585d2bcd7edc22542a5')
+    version('0.8.2', '934244b225e85ed335455c9dd22df961')
+    version('0.8.0', '5d40e39def358115232d8b7fd6b0032a')
+
+    variant('dev', default=False,
+            description='For developers. Needed for modifying parser')
+    variant('docs', default=False,
+            description='Allow generating documentation')
+    variant('tools', default=False,
+            description='Build command-line tools in addition to library')
+
+    depends_on('cmake@3.8.0:', type='build')
+    depends_on('doxygen', type='build', when='+docs')
+    depends_on('bison@3.6.0:', type='build', when='+dev')
+    depends_on('flex@2.6.0:', type='build', when='+dev')
+    depends_on('nlohmann-json', when='+tools')
+
+    phases = ['hostconfig'] + CMakePackage.phases
+
+    def configure_args(self):
+        spec = self.spec if self.spec is not None else ""
+        return [
+            '-DBUILD_TOOLS={0}'.format('YES' if '+tools' in spec else 'NO'),
+            '-DGENERATE_PARSER={0}'.format('YES' if '+dev' in spec else 'NO'),
+            '-DRUN_TESTS={0}'.format('YES' if '+dev' in spec else 'NO'),
+            '-DBUILD_DOCS={0}'.format('YES' if '+docs' in spec else 'NO'),
+        ]
+
+
+    def hostconfig(self, spec, prefix, py_site_pgs_dir=None):
+        """
+        Create a 'host-config' file with all the options used to configure
+        this package.
+        """
+
+        host_config_path = self._get_host_config_path(spec)
+        with open(host_config_path, 'w') as cfg:
+            self._write_header(spec, cfg)
+            self._write_compiler_settings(spec, cfg)
+            self._write_dev_tools(spec, prefix, cfg)
+
+    def _write_header(self, spec, cfg):
+            cfg.write("####################################################################\n")
+            cfg.write("# Generated host-config - Edit at own risk!\n")
+            cfg.write("####################################################################\n")
+
+            cmake_exe = spec['cmake'].command.path
+            cmake_exe = os.path.realpath(cmake_exe)
+            cfg.write("#---------------------------------------\n")
+            cfg.write("# SYS_TYPE: {0}\n".format(self._get_sys_type(spec)))
+            cfg.write("# Compiler Spec: {0}\n".format(spec.compiler))
+            cfg.write("# CMake executable path: %s\n" % cmake_exe)
+            cfg.write("#---------------------------------------\n\n")
+
+    def _write_compiler_settings(self, spec, cfg):
+            cfg.write("#---------------------------------------\n")
+            cfg.write("# Compilers\n")
+            cfg.write("#---------------------------------------\n")
+            cfg.write(cmake_cache_path("CMAKE_C_COMPILER", env['SPACK_CC']))
+            cfg.write(cmake_cache_path("CMAKE_CXX_COMPILER", env['SPACK_CXX']))
+
+            # use global spack compiler flags
+            cflags = ' '.join(spec.compiler_flags['cflags'])
+            if cflags:
+                cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))
+            cxxflags = ' '.join(spec.compiler_flags['cxxflags'])
+            if cxxflags:
+                cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS", cxxflags))
+
+    def _write_dev_tools(self, spec, prefix, cfg):
+            cfg.write("#---------------------------------------\n")
+            cfg.write("# Library Dependencies\n")
+            cfg.write("#---------------------------------------\n")
+
+            path_replacements = {}
+
+            # Try to find the common prefix of the TPL directory, including the compiler
+            # If found, we will use this in the TPL paths
+            compiler_str = str(spec.compiler).replace('@','-')
+            prefix_paths = prefix.split(compiler_str)
+            tpl_root = ""
+            if len(prefix_paths) == 2:
+                tpl_root = os.path.join( prefix_paths[0], compiler_str )
+                path_replacements[tpl_root] = "${TPL_ROOT}"
+                cfg.write(cmake_cache_path("TPL_ROOT", tpl_root))
+
+            cfg.write("#------------------{}\n".format("-"*60))
+            cfg.write("# Devtools\n")
+            cfg.write("#------------------{}\n\n".format("-"*60))
+
+            # Add common prefix to path replacement list
+            if '+dev' in spec:
+                # Grab common devtools root and strip the trailing slash
+                path1 = os.path.realpath(spec['flex'].prefix)
+                path2 = os.path.realpath(spec['bison'].prefix)
+                devtools_root = os.path.commonprefix([path1, path2])
+                if len(devtools_root) > 1:
+                    devtools_root = devtools_root[:-1]
+                    path_replacements[devtools_root] = "${DEVTOOLS_ROOT}"
+                    cfg.write("# Root directory for generated developer tools\n")
+                    cfg.write(cmake_cache_path("DEVTOOLS_ROOT", devtools_root))
+
+                cfg.write(cmake_cache_option('GENERATE_PARSER', True))
+                cfg.write(cmake_cache_option('RUN_TESTS', True))
+
+                flex_bin_dir = get_spec_path(spec, 'flex', path_replacements, use_bin=True)
+                cfg.write(cmake_cache_path('FLEX_EXECUTABLE', os.path.join(flex_bin_dir, 'flex')))
+
+                bison_bin_dir = get_spec_path(spec, 'bison', path_replacements, use_bin=True)
+                cfg.write(cmake_cache_path('BISON_EXECUTABLE', os.path.join(bison_bin_dir, 'bison')))
+
+            if '+tools' in spec:
+                cfg.write(cmake_cache_option('BUILD_TOOLS', True))
+
+                # If we just set NLOHMANN_JSON_DIR, cmake can't find the
+                # library. We can set this directly, but sometimes need it
+                # to point under the lib directory, and others uners lib64.
+                # Appending this to CMAKE_PREFIX_PATH works.
+                nlohmann_dir = get_spec_path(spec, 'nlohmann-json', path_replacements)
+                cfg.write(cmake_cache_entry('CMAKE_PREFIX_PATH', '${CMAKE_PREFIX_PATH};' + nlohmann_dir))
+
+            if '+docs' in spec:
+                cfg.write(cmake_cache_option('BUILD_DOCS', True))
+
+                doxygen_bin_dir = get_spec_path(spec, 'doxygen', path_replacements, use_bin=True)
+                cfg.write(cmake_cache_path('DOXYGEN_EXECUTABLE', os.path.join(doxygen_bin_dir, 'doxygen')))
+
+    def _get_host_config_path(self, spec):
+        var=''
+        host_config_path = "%s-%s-%s%s.cmake" % (socket.gethostname().rstrip('1234567890'),
+                                                 self._get_sys_type(spec),
+                                                 spec.compiler, var)
+        dest_dir = self.stage.source_path
+        host_config_path = os.path.abspath(os.path.join(dest_dir, host_config_path))
+        return host_config_path
+
+    def _get_sys_type(self, spec):
+        # if on llnl systems, we can use the SYS_TYPE
+        return os.environ.get('SYS_TYPE', spec.architecture)
+
+
+def cmake_cache_path(name, value, comment=""):
+    """Generate a string for a cmake cache variable"""
+    return 'set(%s "%s" CACHE PATH "%s")\n\n' % (name, value, comment)
+
+
+def cmake_cache_entry(name, value, comment=""):
+    """Generate a string for a cmake cache variable"""
+    return 'set(%s "%s" CACHE STRING "%s")\n\n' % (name, value, comment)
+
+
+def cmake_cache_option(name, boolean_value, comment=""):
+    """Generate a string for a cmake configuration option"""
+    value = "ON" if boolean_value else "OFF"
+    return 'set(%s %s CACHE BOOL "%s")\n\n' % (name, value, comment)
+
+
+def get_spec_path(spec, package_name, path_replacements = {}, use_bin = False) :
+    """Extracts the prefix path for the given spack package
+       path_replacements is a dictionary with string replacements for the path.
+    """
+
+    if not use_bin:
+        path = spec[package_name].prefix
+    else:
+        path = spec[package_name].prefix.bin
+
+    path = os.path.realpath(path)
+
+    for key in path_replacements:
+        path = path.replace(key, path_replacements[key])
+
+    return path
+

--- a/scripts/spack/specs.json
+++ b/scripts/spack/specs.json
@@ -14,26 +14,26 @@
     "__comment__":"##############################################################################",
 
     "toss_3_x86_64_ib":
-    [ "clang@9.0.0~cpp14+devtools+mfem",
-      "clang@10.0.0~cpp14+devtools+mfem",
-      "gcc@8.1.0~cpp14+devtools+mfem+scr",
-      "gcc@8.1_no_fortran~cpp14~fortran+devtools+mfem",
-      "intel@18.0.2~cpp14~openmp+devtools+mfem",
-      "intel@19.0.4~cpp14~openmp+devtools+mfem" ],
+    [ "clang@9.0.0~cpp14+devtools+mfem+c2c",
+      "clang@10.0.0~cpp14+devtools+mfem+c2c",
+      "gcc@8.1.0~cpp14+devtools+mfem+scr+c2c",
+      "gcc@8.1_no_fortran~cpp14~fortran+devtools+mfem+c2c",
+      "intel@18.0.2~cpp14~openmp+devtools+mfem+c2c",
+      "intel@19.0.4~cpp14~openmp+devtools+mfem+c2c" ],
 
     "blueos_3_ppc64le_ib":
-    [ "clang@9.0.0_upstream_xlf~cpp14~openmp+devtools+mfem",
-      "clang@8.0.1_nvcc_xlf~cpp14~openmp+devtools+mfem+cuda cuda_arch=60",
-      "gcc@7.3.1~cpp14+devtools+mfem",
-      "xl@16.1.1_coral~cpp14~openmp+devtools+mfem",
-      "xl@16.1.1_nvcc~cpp14~openmp+devtools+mfem+cuda cuda_arch=60" ],
+    [ "clang@9.0.0_upstream_xlf~cpp14~openmp+devtools+mfem+c2c",
+      "clang@8.0.1_nvcc_xlf~cpp14~openmp+devtools+mfem+cuda+c2c cuda_arch=60",
+      "gcc@7.3.1~cpp14+devtools+mfem+c2c",
+      "xl@16.1.1_coral~cpp14~openmp+devtools+mfem+c2c",
+      "xl@16.1.1_nvcc~cpp14~openmp+devtools+mfem+cuda+c2c cuda_arch=60" ],
 
     "blueos_3_ppc64le_ib_p9":
-    [ "clang@9.0.0_upstream_xlf~cpp14~openmp+devtools+mfem",
-      "clang@8.0.1_nvcc_xlf~cpp14~openmp+devtools+mfem+cuda cuda_arch=70",
-      "gcc@7.3.1~cpp14+devtools+mfem",
-      "xl@16.1.1_coral~cpp14~openmp+devtools+mfem",
-      "xl@16.1.1_nvcc~cpp14~openmp+devtools+mfem+cuda cuda_arch=70" ],
+    [ "clang@9.0.0_upstream_xlf~cpp14~openmp+devtools+mfem+c2c",
+      "clang@8.0.1_nvcc_xlf~cpp14~openmp+devtools+mfem+cuda+c2c cuda_arch=70",
+      "gcc@7.3.1~cpp14+devtools+mfem+c2c",
+      "xl@16.1.1_coral~cpp14~openmp+devtools+mfem+c2c",
+      "xl@16.1.1_nvcc~cpp14~openmp+devtools+mfem+cuda+c2c cuda_arch=70" ],
 
     "darwin-x86_64":
     [ "clang@9.0.0~cpp14+devtools+mfem" ]

--- a/src/axom/config.hpp.in
+++ b/src/axom/config.hpp.in
@@ -59,6 +59,7 @@
 /*
  * Compiler defines for libraries (built-in and third party)
  */
+#cmakedefine AXOM_USE_C2C
 #cmakedefine AXOM_USE_CLI11
 #cmakedefine AXOM_USE_CONDUIT
 #cmakedefine AXOM_USE_CUDA

--- a/src/axom/core/examples/core_utilities.cpp
+++ b/src/axom/core/examples/core_utilities.cpp
@@ -123,7 +123,7 @@ int main(int argc, char** argv)
 
   if(argc == 1)
   {
-    std::cerr << "Error: not path given on command line" << std::endl;
+    std::cerr << "Error: no path given on command line" << std::endl;
     return 1;
   }
   else

--- a/src/axom/core/tests/utils_config.cpp
+++ b/src/axom/core/tests/utils_config.cpp
@@ -54,6 +54,10 @@ TEST(utils_config, config_libraries)
 
   std::vector<std::string> libs;
 
+#ifdef AXOM_USE_C2C
+  libs.push_back("c2c");
+#endif
+
 #ifdef AXOM_USE_CLI11
   libs.push_back("CLI11");
 #endif

--- a/src/axom/core/utilities/About.cpp
+++ b/src/axom/core/utilities/About.cpp
@@ -92,6 +92,10 @@ void about(std::ostream &oss)
 
   std::vector<std::string> libs;
 
+#ifdef AXOM_USE_C2C
+  libs.push_back("c2c");
+#endif
+
 #ifdef AXOM_USE_CLI11
   libs.push_back("CLI11");
 #endif

--- a/src/cmake/AxomConfig.cmake
+++ b/src/cmake/AxomConfig.cmake
@@ -13,7 +13,7 @@ message(STATUS "Configuring Axom version ${AXOM_VERSION_FULL}")
 ## Add a definition to the generated config file for each library dependency
 ## (optional and built-in) that we might need to know about in the code. We
 ## check for vars of the form <DEP>_FOUND or ENABLE_<DEP>
-set(TPL_DEPS CLI11 CONDUIT CUDA FMT HDF5 LUA MFEM MPI OPENMP RAJA SCR SOL SPARSEHASH UMPIRE )
+set(TPL_DEPS C2C CLI11 CONDUIT CUDA FMT HDF5 LUA MFEM MPI OPENMP RAJA SCR SOL SPARSEHASH UMPIRE )
 foreach(dep ${TPL_DEPS})
     if( ${dep}_FOUND OR ENABLE_${dep} )
         set(AXOM_USE_${dep} TRUE  )

--- a/src/cmake/axom-config.cmake.in
+++ b/src/cmake/axom-config.cmake.in
@@ -50,6 +50,7 @@ if(NOT AXOM_FOUND)
   set(AXOM_USE_SPARSEHASH     "@AXOM_USE_SPARSEHASH@")
 
   # Axom external TPLs
+  set(AXOM_USE_C2C            "@AXOM_USE_C2C@")
   set(AXOM_USE_CONDUIT        "@AXOM_USE_CONDUIT@")
   set(AXOM_USE_HDF5           "@AXOM_USE_HDF5@")
   set(AXOM_USE_LUA            "@AXOM_USE_LUA@")
@@ -62,6 +63,12 @@ if(NOT AXOM_FOUND)
   # Bring in required  dependencies for this axom configuration
   #----------------------------------------------------------------------------
   include(CMakeFindDependencyMacro)
+
+  # c2c
+  if(AXOM_USE_C2C)
+    set(AXOM_C2C_DIR     "@C2C_DIR@")
+    # Note: Targets not currently imported
+  endif()
 
   # conduit
   if(AXOM_USE_CONDUIT)

--- a/src/cmake/thirdparty/FindC2C.cmake
+++ b/src/cmake/thirdparty/FindC2C.cmake
@@ -1,0 +1,54 @@
+# Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+# other Axom Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+#------------------------------------------------------------------------------
+# Setup C2C
+#------------------------------------------------------------------------------
+# This file defines:
+#  C2C_FOUND - If c2c was found
+#  C2C_INCLUDE_DIRS - The c2c include directories
+#  C2C_LIBRARY - The c2c library
+#------------------------------------------------------------------------------
+
+# First check for C2C_DIR
+if (NOT EXISTS "${C2C_DIR}")
+    message(FATAL_ERROR "Given C2C_DIR does not exist: ${C2C_DIR}")
+endif()
+
+if (NOT IS_DIRECTORY "${C2C_DIR}")
+    message(FATAL_ERROR "Given C2C_DIR is not a directory: ${C2C_DIR}")
+endif()
+
+# Find includes directory
+find_path( C2C_INCLUDE_DIR c2c/C2C.hpp
+           PATHS  ${C2C_DIR}/include
+           NO_DEFAULT_PATH
+           NO_CMAKE_ENVIRONMENT_PATH
+           NO_CMAKE_PATH
+           NO_SYSTEM_ENVIRONMENT_PATH
+           NO_CMAKE_SYSTEM_PATH)
+
+# Find libraries
+find_library( C2C_LIBRARY NAMES c2c libc2c
+              PATHS ${C2C_DIR}/lib
+              NO_DEFAULT_PATH
+              NO_CMAKE_ENVIRONMENT_PATH
+              NO_CMAKE_PATH
+              NO_SYSTEM_ENVIRONMENT_PATH
+              NO_CMAKE_SYSTEM_PATH)
+
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set C2C_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(C2C  DEFAULT_MSG
+                                  C2C_INCLUDE_DIR
+                                  C2C_LIBRARY )
+
+if(NOT C2C_FOUND)
+    message(FATAL_ERROR "C2C_DIR is not a path to a valid c2c install: ${C2C_DIR}")
+endif()
+
+message(STATUS "c2c includes: ${C2C_INCLUDE_DIR}")
+message(STATUS "c2c libraries: ${C2C_LIBRARY}")

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -206,6 +206,24 @@ else()
     set(LUA_FOUND OFF CACHE BOOL "")
 endif()
 
+
+#------------------------------------------------------------------------------
+# C2C
+#------------------------------------------------------------------------------
+if (C2C_DIR)
+    include(cmake/thirdparty/FindC2C.cmake)
+    blt_import_library(
+        NAME          c2c
+        INCLUDES      ${C2C_INCLUDE_DIR}
+        LIBRARIES     ${C2C_LIBRARY}
+        TREAT_INCLUDES_AS_SYSTEM ON
+        EXPORTABLE    ON)
+    blt_list_append(TO TPL_DEPS ELEMENTS c2c)
+else()
+    message(STATUS "c2c support is OFF")
+    set(C2C_FOUND OFF CACHE BOOL "")
+endif()
+
 #------------------------------------------------------------------------------
 # Targets that need to be exported but don't have a CMake config file
 #------------------------------------------------------------------------------

--- a/src/docs/sphinx/dev_guide/component_org.rst
+++ b/src/docs/sphinx/dev_guide/component_org.rst
@@ -27,15 +27,15 @@ tasks to be done when adding a new software component to Axom. These include:
 Component Directory Structure
 ====================================
 
-In the `axom/src/components` directory, you will find a subdirectory for
+In the `axom/src/axom` directory, you will find a subdirectory for
 each Axom component. For example::
 
-  $ cd axom/src/components
+  $ cd axom/src/axom
   $ ls -1
   CMakeLists.txt
-  axom_utils
+  core
+  inlet
   lumberjack
-  mint
   ...
 
 All files for each component are contained in subdirectories in the
@@ -43,12 +43,12 @@ component directory.
 
 To illustrate, consider the *sidre* component directory::
 
-  $ cd axom/src/components/sidre
+  $ cd axom/src/axom/sidre
   $ ls -1 -F
   CMakeLists.txt
+  core/
   docs/
   examples/
-  src/
   tests/
 
 Note that, besides directories, the top-level component directory contains
@@ -56,6 +56,11 @@ a few files:
 
 * **CMakeLists.txt** contains CMake information for the component in the Axom build system.
     
+Components are free to organize their header and source files in whatever 
+manner makes sense. For example, in *sidre*, these core header and source files
+are in a subdirectory called `core`. As is common practice for C++ libraries, 
+associated  header and source files are co-located in the same directories. 
+
 The **docs** directory contains the component documentation. Subdirectories in 
 the docs directory are named for each type of documentation. The directories 
 `doxygen` and `sphinx` are required. Each Axom component uses *Doxygen* for 
@@ -63,13 +68,6 @@ source code documentation and *Sphinx* for user documentation. Other
 documentation directories can be used as needed. For example, *sidre* also 
 contains documentation directories `dot` for dot-generated figures, and 
 `design` for design documents.
-
-The **src** directory contains all header and source files for the component.
-These files, which are typically C++, can be organized in subdirectories
-within the `src` directory in whatever manner makes sense. For example, in 
-*sidre*, these core header and source files are in a subdirectory called 
-`core`. As is common practice for C++ libraries, associated  header and 
-source files are co-located in the same directories. 
 
 The **interface** directory contains interface files for use by languages 
 other than C++. To make it easy for applications written in C and
@@ -85,7 +83,7 @@ An **examples** directory is optional, but recommended. It contains simple
 code examples illustrating component usage.
 
 .. important:: For consistency, these subdirectory names within the top-level 
-               component directory should be the same for each Axom components. 
+               component directory should be the same for each Axom component. 
 
 ====================================
 CMake Files and Variables
@@ -382,6 +380,5 @@ We have a useful discussion of our Doxygen usage conventions in the
 The `Doxygen Manual <http://www.doxygen.nl/manual/>`_ contains
 a lot more details.
 
-**Fill in more details when we have a better handle on how we want to organize 
-our doxygen stuff...**
-
+`Axom's code documentation <https://axom.readthedocs.io/en/develop/doxygen/html>`_ 
+is published along with our `user documentation. <https://axom.readthedocs.io>`_

--- a/src/docs/sphinx/dev_guide/continuous_integration.rst
+++ b/src/docs/sphinx/dev_guide/continuous_integration.rst
@@ -11,8 +11,8 @@ Continuous Integration
 
 The Axom project uses two CI tools,
 `Azure Pipelines <https://azure.microsoft.com/en-us/services/devops/pipelines/>`_
-via Github and `Bamboo <https://www.atlassian.com/software/bamboo>`_ 
-on the LC Restricted Zone (RZ).
+via Github and `GitLab CI <https://docs.gitlab.com/ee/ci/>`_ 
+on the LLNL LC Collaboration Zone (CZ).
 
 .. _azure_pipelines-label:
 
@@ -25,23 +25,25 @@ CI jobs to ensure that the Axom source builds and passes our unit tests.
 These configurations mimic the LC compilers and systems as closely as possible
 via Docker containers that have our third-party libraries pre-built on them.
 
+Axom's Github project is also configured to require pull requests to pass checks 
+from our LC GitLab CI (as described below).
+
 
 .. _bamboo-label:
 
 ==========
-RZ Bamboo 
+LC GitLab 
 ==========
 
-We use the `Axom RZ Bamboo project <https://rzlc.llnl.gov/bamboo/browse/ASC>`_ 
-primarily for testing the develop branch against the various LC System Types.
-There are two types of Bamboo Plans which are automatically triggered to build
-and run tests against the develop branch.  The first is triggered nightly and
-on any repository change on Github that builds and tests the current Axom source
-against previously built third-party libraries.  The second is triggered nightly
-and builds and tests the complete third-party library build and then the Axom source
-against those libraries.
+We also maintain a mirror of the `Axom project on LLNL's LC GitLab instance <https://lc.llnl.gov/gitlab/axom/axom>`_
+primarily for testing Axom pull requests against the various LC System Types and compilers.
 
-This plan may be run manually at any time by selecting the plan and clicking
-on 'Run plan' as described above. Each member of the team receives an email 
-notification every morning about the current state of all jobs.
+There are two types of GitLab plans.
+The first is triggered automatically by pull requests on GitHub,
+while the second runs nightly and tests
+Axom's ``develop`` branch against a new build of our third-party library stack.
+
+Our GitLab CI configuration also allows manual runs. To initiate a new run, 
+navigate to the `CI/CD page, <https://lc.llnl.gov/gitlab/axom/axom/-/pipelines>`_
+click on the "Run pipeline" button and select the branch to test.
 

--- a/src/docs/sphinx/quickstart_guide/config_build.rst
+++ b/src/docs/sphinx/quickstart_guide/config_build.rst
@@ -53,18 +53,20 @@ Library Dependencies
 """"""""""""""""""""
 
 ================== ==================================== ======================
-  Library            Dependent Components                Build system variable
+  Library          Dependent Components                 Build system variable
 ================== ==================================== ======================
-  `Conduit`_       Required: Sidre                       CONDUIT_DIR
-  `HDF5`_          Optional: Sidre                       HDF5_DIR
-  `Lua`_           Optional: Inlet                       LUA_DIR
-  `MFEM`_          Optional: Quest                       MFEM_DIR
-  `RAJA`_          Optional: Mint, Spin, Quest           RAJA_DIR
-  `SCR`_           Optional: Sidre                       SCR_DIR
-  `Umpire`_        Optional: Core, Spin, Quest           UMPIRE_DIR
+  `Conduit`_       Required: Sidre                      CONDUIT_DIR
+  `c2c`_           Optional                             C2C_DIR
+  `HDF5`_          Optional: Sidre                      HDF5_DIR
+  `Lua`_           Optional: Inlet                      LUA_DIR
+  `MFEM`_          Optional: Quest                      MFEM_DIR
+  `RAJA`_          Optional: Mint, Spin, Quest          RAJA_DIR
+  `SCR`_           Optional: Sidre                      SCR_DIR
+  `Umpire`_        Optional: Core, Spin, Quest          UMPIRE_DIR
 ================== ==================================== ======================
 
 .. _Conduit: https://llnl-conduit.readthedocs.io/en/latest
+.. _c2c: https://rzlc.llnl.gov/c2c
 .. _HDF5: https://www.hdfgroup.org/solutions/hdf5/
 .. _Lua: https://www.lua.org/
 .. _MFEM: https://mfem.org/
@@ -75,6 +77,9 @@ Library Dependencies
 Each library dependency has a corresponding build system variable
 (with the suffix ``_DIR``) to supply the path to the library's installation directory.
 For example, ``hdf5`` has a corresponding variable ``HDF5_DIR``.
+
+.. note::
+  Optional `c2c` library is currently only available for configurations on LLNL clusters.
 
 
 Tool Dependencies

--- a/src/thirdparty/tests/CMakeLists.txt
+++ b/src/thirdparty/tests/CMakeLists.txt
@@ -181,6 +181,22 @@ if (SOL_FOUND)
 endif()
 
 #------------------------------------------------------------------------------
+# Smoke test for c2c third party library
+#------------------------------------------------------------------------------
+
+if (C2C_FOUND)
+    blt_add_executable(
+        NAME       c2c_smoke_test
+        SOURCES    c2c_smoke.cpp
+        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+        DEPENDS_ON c2c gtest
+        FOLDER     axom/thirdparty/tests )
+
+    axom_add_test(NAME    c2c_smoke
+                  COMMAND c2c_smoke_test)
+endif()
+
+#------------------------------------------------------------------------------
 # Add compiler flag tests.
 #
 # Test whether custom compiler flags actually work as expected on all compilers.

--- a/src/thirdparty/tests/c2c_smoke.cpp
+++ b/src/thirdparty/tests/c2c_smoke.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/config.hpp"
+#include "gtest/gtest.h"  // for gtest
+
+#include "c2c/config.hpp"
+#include "c2c/Literals.hpp"
+#include "c2c/Point.hpp"
+#include "c2c/EllipticalArc.hpp"
+#include "c2c/NURBS.hpp"
+
+#include <cmath>
+
+//------------------------------------------------------------------------------
+// UNIT TESTS
+//------------------------------------------------------------------------------
+TEST(c2c_smoke, check_version)
+{
+  std::cout << "Using c2c version: "     //
+            << C2C_VERSION_MAJOR << "."  //
+            << C2C_VERSION_MINOR << "."  //
+            << C2C_VERSION_PATCH << std::endl;
+
+  EXPECT_TRUE(C2C_VERSION_MAJOR >= 0);
+  EXPECT_TRUE(C2C_VERSION_MINOR >= 0);
+  EXPECT_TRUE(C2C_VERSION_PATCH >= 0);
+}
+
+TEST(c2c_smoke, check_code)
+{
+  double EPS = 1.e-8;
+  using namespace c2c::literals;
+
+  c2c::Length rRadius = 20.0_cm;
+  c2c::Length zRadius = 150.0_mm;  // note: different unit
+  c2c::Point origin {100.0_cm, 200.0_cm};
+  c2c::RotationalDirection dir = c2c::RotationalDirection::IncreasingAngle;
+  c2c::EllipticalArc arc {origin, rRadius, zRadius, 0.0_deg, 90.0_deg, dir};
+
+  // Helper lambda to check if two c2c points are within tolerance EPS of each other
+  auto c2cPointsAreNear = [=](const c2c::Point& p1, const c2c::Point& p2) {
+    auto cm = c2c::LengthUnit::cm;
+    return  //
+      std::abs(p1.getR().convertValue(cm) - p2.getR().convertValue(cm)) < EPS &&
+      std::abs(p1.getZ().convertValue(cm) - p2.getZ().convertValue(cm)) < EPS;
+  };
+
+  // Check properties of the arc's end points
+  {
+    EXPECT_TRUE(c2cPointsAreNear(c2c::Point {100.0_cm, 215.0_cm}, arc.getStart()));
+    EXPECT_TRUE(c2cPointsAreNear(c2c::Point {120.0_cm, 200.0_cm}, arc.getEnd()));
+  }
+
+  // Check conversion to NURBS
+  {
+    // These tests assume the EllipticalArc is converted to a simple
+    // endpoint-interpolating quadratic NURBS curve with no internal knots
+
+    c2c::NURBSData curve = toNurbs(arc, c2c::LengthUnit::cm);
+
+    // Check order
+    // NOTE: The order of C2C NURBS curves is one higher than the polynomial order
+    const int quadratic_c2c_order = 3;
+    EXPECT_EQ(quadratic_c2c_order, static_cast<int>(curve.order));
+
+    // Check knots
+    EXPECT_EQ(6, static_cast<int>(curve.knots.size()));
+    EXPECT_DOUBLE_EQ(0, curve.knots[0]);
+    EXPECT_DOUBLE_EQ(0, curve.knots[1]);
+    EXPECT_DOUBLE_EQ(0, curve.knots[2]);
+    EXPECT_DOUBLE_EQ(1, curve.knots[3]);
+    EXPECT_DOUBLE_EQ(1, curve.knots[4]);
+    EXPECT_DOUBLE_EQ(1, curve.knots[5]);
+
+    // check control points
+    EXPECT_EQ(3, static_cast<int>(curve.controlPoints.size()));
+    EXPECT_TRUE(c2cPointsAreNear(arc.getStart(), curve.controlPoints[0]));
+    EXPECT_TRUE(c2cPointsAreNear(arc.getEnd(), curve.controlPoints[2]));
+    c2c::Point midPoint {arc.getEnd().getR(), arc.getStart().getZ()};
+    EXPECT_TRUE(c2cPointsAreNear(midPoint, curve.controlPoints[1]));
+
+    // check weights
+    EXPECT_NEAR(1., curve.weights[0], EPS);
+    EXPECT_NEAR(std::sqrt(2) / 2., curve.weights[1], EPS);
+    EXPECT_NEAR(1., curve.weights[2], EPS);
+  }
+}


### PR DESCRIPTION
# Summary

- This PR adds the `c2c` library as an optional TPL for Axom and adds a smoke test for this library
- The c2c library defines a format for specifying 2D curve data
- The spack package for c2c was provided by @estebanpauli 
- c2c is currently only available within configurations of Axom on LLNL's clusters

TODO:
- [x] Update host-configs for LLNL's RZ and CZ networks
- [x] Update docs and RELEASE-NOTES