### PR TITLE
Extend isUserProvided() to accept a name parameter

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,6 +43,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Conduit version changed to v. 0.7.2
 - Renames `AXOM_DEBUG_VAR` macro to `AXOM_UNUSED_VAR` since there were many cases where the latter
   was not the appropriate name. This macro elides warnings about unused variables
+- Inlet's `isUserProvided` can now be used to query the status of subobjects of a `Container` via a name parameter
 
 ### Fixed
 - Fixed Primal's `intersect(Ray, Segment)` calculation for Segments that do not have unit length

--- a/src/axom/inlet/Container.cpp
+++ b/src/axom/inlet/Container.cpp
@@ -1315,6 +1315,26 @@ bool Container::isUserProvided() const
   return has_containers || has_fields || has_functions;
 }
 
+bool Container::isUserProvided(const std::string& name) const
+{
+  if(auto container = getChildInternal<Container>(name))
+  {
+    // Check if the container itself was provided by the user
+    return container->isUserProvided();
+  }
+  else if(auto field = getChildInternal<Field>(name))
+  {
+    // Check if the field itself was provided by the user
+    return field->isUserProvided();
+  }
+  else if(auto function = getChildInternal<Function>(name))
+  {
+    // call operator bool on the function itself
+    return static_cast<bool>(*function);
+  }
+  return false;
+}
+
 const std::unordered_map<std::string, std::unique_ptr<Container>>&
 Container::getChildContainers() const
 {

--- a/src/axom/inlet/Container.hpp
+++ b/src/axom/inlet/Container.hpp
@@ -834,6 +834,16 @@ public:
 
   /*!
    *****************************************************************************
+   * \brief  Return whether a Container or Field with the given name were
+   * provided in the input file
+   *
+   * \param [in] name The path relative to the calling Container to search
+   *****************************************************************************
+   */
+  bool isUserProvided(const std::string& name) const;
+
+  /*!
+   *****************************************************************************
    * \return An unordered map from Field names to the child Field pointers for 
    * this Container.
    *****************************************************************************

--- a/src/axom/inlet/Inlet.hpp
+++ b/src/axom/inlet/Inlet.hpp
@@ -261,6 +261,18 @@ public:
   }
 
   /*!
+   *****************************************************************************
+   * \brief Return whether a subobject with the given name was provided by the user
+   *
+   * \see Container::isUserProvided
+   *****************************************************************************
+   */
+  bool isUserProvided(const std::string& name) const
+  {
+    return m_globalContainer.isUserProvided(name);
+  }
+
+  /*!
    *******************************************************************************
    * \brief Obtains a proxy view into the datastore.
    * 

--- a/src/axom/inlet/docs/sphinx/simple_types.rst
+++ b/src/axom/inlet/docs/sphinx/simple_types.rst
@@ -54,8 +54,15 @@ can lead to compile time ambiquity depending on how it is used.  The example bel
 an example of this.
 
 Prior to accessing optional fields, you should verify they were provided by the user via
-the ``contains`` function.  Accessing a value that was not provided by the user, or 
-a default value, will result in a runtime error. 
+the ``contains`` function.
+
+The ``contains`` function returns ``true`` if the field was *either*
+provided by the user or via a default.  To check if the field was provided by the user (and not
+via a default), you can use the ``isUserProvided`` method, which returns ``true`` if the value
+was provided by the user in the input file.
+
+Accessing a value that was not provided by the user, or 
+a default value, will result in a runtime error.
 
 .. literalinclude:: ../../examples/fields.cpp
    :start-after: _inlet_simple_types_fields_access_start

--- a/src/axom/inlet/examples/fields.cpp
+++ b/src/axom/inlet/examples/fields.cpp
@@ -101,6 +101,9 @@ int main()
   // without checking contains
   int a_defaulted_int = inlet["a_defaulted_int"];
   std::cout << "a_defaulted_int = " << a_defaulted_int << std::endl;
+  // We can also verify that the user did not provided a value
+  std::cout << "a_defaulted_int provided by user: "
+            << inlet.isUserProvided("a_defaulted_int") << std::endl;
 
   // _inlet_simple_types_fields_access_end
 

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -922,6 +922,7 @@ TYPED_TEST(inlet_object, default_scalar_user_provided)
   auto& field = static_cast<axom::inlet::Field&>(scalar);
   EXPECT_TRUE(field.exists());
   EXPECT_FALSE(field.isUserProvided());
+  EXPECT_FALSE(inlet.isUserProvided("foo"));
 
   // ...but it should still be possible to retrieve the default
   const int foo = inlet["foo"];
@@ -943,6 +944,7 @@ TYPED_TEST(inlet_object, default_struct_field_user_provided)
   // The container itself exists but was not provided by the user
   EXPECT_TRUE(foo_container.exists());
   EXPECT_FALSE(foo_container.isUserProvided());
+  EXPECT_FALSE(inlet.isUserProvided("foo"));
 
   // ...but it should still be possible to retrieve the default
   const Foo expected_foo {true, false};
@@ -965,6 +967,7 @@ TYPED_TEST(inlet_object, default_struct_field_user_provided_reqd)
   // The container itself exists but was not provided by the user
   EXPECT_TRUE(foo_container.exists());
   EXPECT_FALSE(foo_container.isUserProvided());
+  EXPECT_FALSE(inlet.isUserProvided("foo"));
 
   // ...but it should still be possible to retrieve the default
   const Foo expected_foo {true, false};
@@ -990,6 +993,7 @@ TYPED_TEST(inlet_object, default_struct_field_marked_true)
   // The container itself exists and was provided by the user
   EXPECT_TRUE(foo_container.exists());
   EXPECT_TRUE(foo_container.isUserProvided());
+  EXPECT_TRUE(inlet.isUserProvided("foo"));
 
   // ...and it should still be possible to retrieve the full struct
   const Foo expected_foo {true, false};

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -920,7 +920,11 @@ TYPED_TEST(inlet_object, default_scalar_user_provided)
   auto& scalar = inlet.addInt("foo").defaultValue(2);
   // The field itself exists but was not provided by the user
   auto& field = static_cast<axom::inlet::Field&>(scalar);
+  // "foo" exists because it has the default value of 2
   EXPECT_TRUE(field.exists());
+  // It can also be said that the hierarchy "contains" foo - again because it has a default
+  EXPECT_TRUE(inlet.contains("foo"));
+  // But because the input string was empty "foo" was not provided by the user
   EXPECT_FALSE(field.isUserProvided());
   EXPECT_FALSE(inlet.isUserProvided("foo"));
 
@@ -941,8 +945,10 @@ TYPED_TEST(inlet_object, default_struct_field_user_provided)
   foo_container.addBool("bar", "bar's description").defaultValue(true);
   foo_container.addBool("baz", "baz's description").defaultValue(false);
 
-  // The container itself exists but was not provided by the user
+  // The container itself exists (has defaults) but was not provided by the user
   EXPECT_TRUE(foo_container.exists());
+  EXPECT_TRUE(inlet.contains("foo"));
+  // But no struct elements were provided by the user b/c empty input string
   EXPECT_FALSE(foo_container.isUserProvided());
   EXPECT_FALSE(inlet.isUserProvided("foo"));
 
@@ -964,8 +970,10 @@ TYPED_TEST(inlet_object, default_struct_field_user_provided_reqd)
   foo_container.addBool("bar", "bar's description").defaultValue(true);
   foo_container.addBool("baz", "baz's description").defaultValue(false);
 
-  // The container itself exists but was not provided by the user
+  // The container itself exists (has defaults) but was not provided by the user
   EXPECT_TRUE(foo_container.exists());
+  EXPECT_TRUE(inlet.contains("foo"));
+  // But no struct elements were provided by the user b/c empty input string
   EXPECT_FALSE(foo_container.isUserProvided());
   EXPECT_FALSE(inlet.isUserProvided("foo"));
 
@@ -992,8 +1000,25 @@ TYPED_TEST(inlet_object, default_struct_field_marked_true)
 
   // The container itself exists and was provided by the user
   EXPECT_TRUE(foo_container.exists());
+  EXPECT_TRUE(inlet.contains("foo"));
   EXPECT_TRUE(foo_container.isUserProvided());
   EXPECT_TRUE(inlet.isUserProvided("foo"));
+
+  // If we examine the individual struct fields, "bar" will exist and be user-provided
+  EXPECT_TRUE(inlet.contains("foo/bar"));
+  EXPECT_TRUE(foo_container.contains("bar"));
+  EXPECT_TRUE(foo_container.isUserProvided("bar"));
+  EXPECT_TRUE(inlet.isUserProvided("foo/bar"));
+  // ...but "baz" will exist and not be user-provided
+  EXPECT_TRUE(inlet.contains("foo/baz"));
+  EXPECT_TRUE(foo_container.contains("baz"));
+  EXPECT_FALSE(foo_container.isUserProvided("baz"));
+  EXPECT_FALSE(inlet.isUserProvided("foo/baz"));
+  // ... while a nonexistent "quux" will be neither
+  EXPECT_FALSE(inlet.contains("foo/quux"));
+  EXPECT_FALSE(foo_container.contains("quux"));
+  EXPECT_FALSE(foo_container.isUserProvided("quux"));
+  EXPECT_FALSE(inlet.isUserProvided("foo/quux"));
 
   // ...and it should still be possible to retrieve the full struct
   const Foo expected_foo {true, false};


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following (modify list as needed):
  - Adds a name parameter (via overload) to `Container::isUserProvided` to allow for easy querying of subobjects

Provides a better solution for the workaround implemented in https://github.com/LLNL/serac/pull/491
