### PR TITLE
Bugfix for empty string literals in XLF

### DIFF
--- a/src/axom/mint/mesh/CurvilinearMesh.hpp
+++ b/src/axom/mint/mesh/CurvilinearMesh.hpp
@@ -198,9 +198,9 @@ public:
                   IndexType Nk = -1);
 
   AXOM_EXPORT CurvilinearMesh(sidre::Group* group,
-                  IndexType Ni,
-                  IndexType Nj = -1,
-                  IndexType Nk = -1)
+                              IndexType Ni,
+                              IndexType Nj = -1,
+                              IndexType Nk = -1)
     : CurvilinearMesh(group, "", "", Ni, Nj, Nk)
   { }
 

--- a/src/axom/mint/mesh/RectilinearMesh.hpp
+++ b/src/axom/mint/mesh/RectilinearMesh.hpp
@@ -198,9 +198,9 @@ public:
                   IndexType Nk = -1);
 
   AXOM_EXPORT RectilinearMesh(sidre::Group* group,
-                  IndexType Ni,
-                  IndexType Nj = -1,
-                  IndexType Nk = -1)
+                              IndexType Ni,
+                              IndexType Nj = -1,
+                              IndexType Nk = -1)
     : RectilinearMesh(group, "", "", Ni, Nj, Nk)
   { }
 

--- a/src/axom/sidre/tests/sidre_group_F.F
+++ b/src/axom/sidre/tests/sidre_group_F.F
@@ -62,16 +62,16 @@ contains
     grp2 = root%get_group("test/a")
     grp3 = root%get_group("test")
 
-    call assert_true(root%get_name() == "" )
-    call assert_true(root%get_path() == "" )
-    call assert_true(root%get_path_name() == "" )
+    call assert_true(root%get_name() == " " )
+    call assert_true(root%get_path() == " " )
+    call assert_true(root%get_path_name() == " " )
 
     call assert_true(grp2%get_name() == "a" )
     call assert_true(grp2%get_path() == "test" )
     call assert_true(grp2%get_path_name() == "test/a" )
 
     call assert_true(grp3%get_name() == "test" )
-    call assert_true(grp3%get_path() == "" )
+    call assert_true(grp3%get_path() == " " )
     call assert_true(grp3%get_path_name() == "test" )
 
     call assert_true(group%get_name() == "c" )

--- a/src/axom/sidre/tests/sidre_view_F.f
+++ b/src/axom/sidre/tests/sidre_view_F.f
@@ -87,7 +87,7 @@ contains
     call assert_true(v2%get_path_name() == "test/v2")
 
     call assert_true(v3%get_name() == "v3")
-    call assert_true(v3%get_path() == "")
+    call assert_true(v3%get_path() == " ")
     call assert_true(v3%get_path_name() == "v3")
 
     call ds%delete()


### PR DESCRIPTION
# Summary

- This PR is a bugfix for Fortran tests with XLF
- It converts empty string literals (`""`) into string literals with a space (`" "`) in some comparisons a string which is expected to be empty
- These literals are implicitly trimmed by XLF for the actual comparison
- I think we've encountered this in the past, but couldn't find it
- I also ran clang-format for two files that were somehow missed and are passing in our CI