### PR TITLE
Moves some MSVC-related pragmas out of config.hpp.in

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,6 +47,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ### Fixed
 - Fixed Primal's `intersect(Ray, Segment)` calculation for Segments that do not have unit length
+- Fixed problem with Cray Fortran compiler not recognizing MSVC pragmas in `axom/config.hpp`. 
+  The latter are now only added in MSVC configurations.
 
 
 ## [Version 0.5.0] - Release date 2021-05-14

--- a/src/axom/config.hpp.in
+++ b/src/axom/config.hpp.in
@@ -122,16 +122,9 @@
 
 
 /*
- * Disables some MSVC warnings related to shared libraries
+ * Disable some MSVC warnings related to shared libraries, if applicable
  */
-#if defined(_MSC_VER)
-/* Turn off warning about lack of DLL interface */
-#pragma warning(disable:4251)
-/* Turn off warning non-dll class is base for dll-interface class */
-#pragma warning(disable:4275)
-/* Turn off warning about identifier truncation */
-#pragma warning(disable:4786)
-#endif  /* defined(_MSC_VER) */
+@AXOM_MSVC_PRAGMAS@
 
 
 #endif  /* AXOM_COMMON_CONFIG_HPP */

--- a/src/cmake/AxomConfig.cmake
+++ b/src/cmake/AxomConfig.cmake
@@ -52,7 +52,7 @@ convert_to_native_escaped_file_path(${CMAKE_BINARY_DIR} AXOM_BIN_DIR)
 file(READ ${CMAKE_BINARY_DIR}/axom_export_symbols INLINED_AXOM_EXPORTS)
 
 #------------------------------------------------------------------------------
-# Compiler checks
+# Compiler and language related configuration variables
 #------------------------------------------------------------------------------
 
 if(ENABLE_FORTRAN)
@@ -79,6 +79,23 @@ if(ENABLE_FORTRAN)
 
 endif(ENABLE_FORTRAN)
 
+# The following MSVC pragmas caused problems for the Cray Fortran compiler,
+# so only add them when using MSVC
+if(COMPILER_FAMILY_IS_MSVC)
+  set(AXOM_MSVC_PRAGMAS [=[
+#if defined(_MSC_VER)
+  /* Turn off warning about lack of DLL interface */
+  #pragma warning(disable:4251)
+  /* Turn off warning non-dll class is base for dll-interface class */
+  #pragma warning(disable:4275)
+  /* Turn off warning about identifier truncation */
+  #pragma warning(disable:4786)  
+#endif  /* defined(_MSC_VER) */
+]=])
+endif()
+
+
+# Generate the configuration header file
 axom_configure_file(
     ${PROJECT_SOURCE_DIR}/axom/config.hpp.in
     ${CMAKE_BINARY_DIR}/include/axom/config.hpp


### PR DESCRIPTION
# Summary

This PR moves some MSVC-related pragmas out of `axom/config.hpp` for non-MSVC configurations.

These caused problems with the Cray Fortran compiler and are now only added for MSVC configurations.

The errors were of the form:
```
ftn-1165 crayftn: ERROR AXOM_SIDRE, File = axom/config.hpp, Line = 171, Column = 2
  Conditional compilation has unexpected syntax.  Expected conditional compilation directive.

ftn-1165 crayftn: ERROR AXOM_SIDRE, File = axom/config.hpp, Line = 173, Column = 2
  Conditional compilation has unexpected syntax.  Expected conditional compilation directive.

ftn-1165 crayftn: ERROR AXOM_SIDRE, File = axom/config.hpp, Line = 175, Column = 2
  Conditional compilation has unexpected syntax.  Expected conditional compilation directive.

ftn-855 crayftn: ERROR AXOM_SIDRE, File = <axom>/src/axom/sidre/interface/c_fortran/wrapfsidre.F, Line = 15, Column = 8
  The compiler has detected errors in module "AXOM_SIDRE".  No module information file will be created for this module.
```