### PR TITLE
Adds support for loading C2C mesh files in quest

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -33,6 +33,11 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   portion of the segment contained within the BoundingBox (when the intersection exists)
 - Generalizes Quest's `InOutOctree` class to work with 2D line segment meshes. Previously,
   it only worked with 3D triangle meshes
+- Added support for reading `c2c` ".contour" files in Quest. Contours that enclose a 2D region can be linearized 
+  into line segment meshes and loaded into Quest's `InOutOctree` for in/out queries.
+- Updated the Quest `inout` C API to support 2D queries using the `c2c` library, when Axom is configured with `c2c`
+- Updated the C++ Quest "containment" example to support 2D in/out queries 
+  (in addition to the already supported 3D queries)
 
 ### Changed
 - `MFEMSidreDataCollection` now reuses FESpace/QSpace objects with the same basis
@@ -46,11 +51,14 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Inlet's `isUserProvided` can now be used to query the status of subobjects of a `Container` via a name parameter
 - Upgrades our `vcpkg` usage for automated Windows builds of our TPLs to its [2021.05.12 release](https://github.com/microsoft/vcpkg/releases/tag/2021.05.12)
 - Upgrades built-in `cli11` library to its [v1.9.1 release](https://github.com/CLIUtils/CLI11/releases/tag/v1.9.1)
+- Quest's `inout` C API has two new functions: `inout_set_dimension()` and `inout_set_segments_per_knot_span()`.
+  The latter is only applicable for 2D queries on `c2c` contours
 
 ### Fixed
 - Fixed Primal's `intersect(Ray, Segment)` calculation for Segments that do not have unit length
 - Fixed problem with Cray Fortran compiler not recognizing MSVC pragmas in `axom/config.hpp`. 
   The latter are now only added in MSVC configurations.
+- Fixed bug in `Mint`'s VTK output for fields of type `int64` and `float`
 
 
 ## [Version 0.5.0] - Release date 2021-05-14

--- a/src/axom/mint/mesh/UnstructuredMesh.hpp
+++ b/src/axom/mint/mesh/UnstructuredMesh.hpp
@@ -1838,7 +1838,7 @@ private:
   /*! \brief Construct and fill the cell-to-face connectivity. */
   void buildCellFaceConnectivity(IndexType* c2fdata, IndexType* c2foffsets);
 
-  /*! \brief Return a new empty CellToFaceConnectivty instance. */
+  /*! \brief Return a new empty CellToFaceConnectivity instance. */
   CellToFaceConnectivity* initializeCellToFace(
     CellType cell_type = UNDEFINED_CELL) const;
 

--- a/src/axom/primal/geometry/Segment.hpp
+++ b/src/axom/primal/geometry/Segment.hpp
@@ -66,8 +66,7 @@ public:
   };
 
 public:
-  /// Disable the default constructor
-  Segment() = delete;
+  Segment() = default;
 
   /*!
    * \brief Creates a segment instance from point A to point B.

--- a/src/axom/quest/CMakeLists.txt
+++ b/src/axom/quest/CMakeLists.txt
@@ -40,7 +40,6 @@ set( quest_headers
     detail/PointInCellMeshWrapper_mfem.hpp
 
     ## File readers
-    readers/C2CReader.hpp
     readers/STLReader.hpp
 
     ## quest interface
@@ -60,7 +59,6 @@ set( quest_sources
     MeshTester.cpp
 
     ## File readers
-    readers/C2CReader.cpp
     readers/STLReader.cpp
 
     ## quest interface
@@ -69,6 +67,8 @@ set( quest_sources
     interface/signed_distance.cpp
 
    )
+
+
 
 set( quest_depends_on
      core
@@ -80,17 +80,22 @@ set( quest_depends_on
      fmt
      )
 
-blt_list_append(TO quest_depends_on IF C2C_FOUND ELEMENTS c2c)
 blt_list_append(TO quest_depends_on IF ENABLE_CUDA ELEMENTS cuda)
 blt_list_append(TO quest_depends_on IF ENABLE_OPENMP ELEMENTS openmp)
 blt_list_append(TO quest_depends_on IF SPARSEHASH_FOUND ELEMENTS sparsehash)
+     
+if(C2C_FOUND)
+     list(APPEND quest_headers readers/C2CReader.hpp)
+     list(APPEND quest_sources readers/C2CReader.cpp)
+     list(APPEND quest_depends_on c2c)
+endif()
 
 if (ENABLE_MPI)
     list(APPEND quest_headers readers/PSTLReader.hpp)
-    list(APPEND quest_sources readers/PSTLReader.cpp)
+    blt_list_append(TO quest_headers IF C2C_FOUND ELEMENTS readers/PC2CReader.hpp)
 
-    list(APPEND quest_headers readers/PC2CReader.hpp)
-    list(APPEND quest_sources readers/PC2CReader.cpp)
+    list(APPEND quest_sources readers/PSTLReader.cpp)
+    blt_list_append(TO quest_sources IF C2C_FOUND ELEMENTS readers/PC2CReader.cpp)
     
     list(APPEND quest_depends_on mpi)
     blt_list_append(TO quest_depends_on IF AXOM_ENABLE_LUMBERJACK ELEMENTS lumberjack )

--- a/src/axom/quest/CMakeLists.txt
+++ b/src/axom/quest/CMakeLists.txt
@@ -71,23 +71,23 @@ set( quest_sources
 
 
 set( quest_depends_on
-     core
-     slic
-     mint
-     slam
-     spin
-     primal
-     fmt
-     )
+    core
+    slic
+    mint
+    slam
+    spin
+    primal
+    fmt
+    )
 
 blt_list_append(TO quest_depends_on IF ENABLE_CUDA ELEMENTS cuda)
 blt_list_append(TO quest_depends_on IF ENABLE_OPENMP ELEMENTS openmp)
 blt_list_append(TO quest_depends_on IF SPARSEHASH_FOUND ELEMENTS sparsehash)
      
 if(C2C_FOUND)
-     list(APPEND quest_headers readers/C2CReader.hpp)
-     list(APPEND quest_sources readers/C2CReader.cpp)
-     list(APPEND quest_depends_on c2c)
+    list(APPEND quest_headers readers/C2CReader.hpp)
+    list(APPEND quest_sources readers/C2CReader.cpp)
+    list(APPEND quest_depends_on c2c)
 endif()
 
 if (ENABLE_MPI)
@@ -98,7 +98,6 @@ if (ENABLE_MPI)
     blt_list_append(TO quest_sources IF C2C_FOUND ELEMENTS readers/PC2CReader.cpp)
     
     list(APPEND quest_depends_on mpi)
-    blt_list_append(TO quest_depends_on IF AXOM_ENABLE_LUMBERJACK ELEMENTS lumberjack )
 endif()
 
 if (SHROUD_FOUND)
@@ -145,11 +144,11 @@ axom_install_component(NAME    quest
 # Add tests and examples
 #------------------------------------------------------------------------------
 if (AXOM_ENABLE_EXAMPLES)
-  add_subdirectory(examples)
+    add_subdirectory(examples)
 endif()
 
 if (AXOM_ENABLE_TESTS)
-  add_subdirectory(tests)
+    add_subdirectory(tests)
 endif()
 
 axom_add_code_checks(PREFIX quest)

--- a/src/axom/quest/CMakeLists.txt
+++ b/src/axom/quest/CMakeLists.txt
@@ -31,21 +31,21 @@ set( quest_headers
     detail/inout/InOutOctreeStats.hpp
     detail/inout/InOutOctreeValidator.hpp
 
-    # Mesh tester headers
+    # Mesh tester
     MeshTester.hpp
 
-    # PointInCell headers
+    # PointInCell
     PointInCell.hpp
     detail/PointFinder.hpp
     detail/PointInCellMeshWrapper_mfem.hpp
 
-    ## STL library headers
+    ## File readers
+    readers/C2CReader.hpp
     readers/STLReader.hpp
 
-    ## quest interface headers
+    ## quest interface
     interface/internal/mpicomm_wrapper.hpp
     interface/internal/QuestHelpers.hpp
-
     interface/inout.hpp
     interface/signed_distance.hpp
 
@@ -56,18 +56,15 @@ set( quest_sources
     ## All-nearest-neighbors query
     AllNearestNeighbors.cpp
 
-    ## Geometry Sources
-    # <nothing yet>
-
-    ## Mesh tester sources
+    ## Mesh tester
     MeshTester.cpp
 
-    ## STL library sources
+    ## File readers
+    readers/C2CReader.cpp
     readers/STLReader.cpp
 
-    ## quest interface sources
+    ## quest interface
     interface/internal/QuestHelpers.cpp
-
     interface/inout.cpp
     interface/signed_distance.cpp
 
@@ -83,9 +80,10 @@ set( quest_depends_on
      fmt
      )
 
-blt_list_append(TO quest_depends_on IF SPARSEHASH_FOUND ELEMENTS sparsehash)
-blt_list_append(TO quest_depends_on IF ENABLE_OPENMP ELEMENTS openmp)
+blt_list_append(TO quest_depends_on IF C2C_FOUND ELEMENTS c2c)
 blt_list_append(TO quest_depends_on IF ENABLE_CUDA ELEMENTS cuda)
+blt_list_append(TO quest_depends_on IF ENABLE_OPENMP ELEMENTS openmp)
+blt_list_append(TO quest_depends_on IF SPARSEHASH_FOUND ELEMENTS sparsehash)
 
 if (ENABLE_MPI)
     list(APPEND quest_headers readers/PSTLReader.hpp)

--- a/src/axom/quest/CMakeLists.txt
+++ b/src/axom/quest/CMakeLists.txt
@@ -89,11 +89,11 @@ if (ENABLE_MPI)
     list(APPEND quest_headers readers/PSTLReader.hpp)
     list(APPEND quest_sources readers/PSTLReader.cpp)
 
-    blt_list_append(TO quest_depends_on
-                    IF AXOM_ENABLE_LUMBERJACK
-                    ELEMENTS lumberjack )
-
+    list(APPEND quest_headers readers/PC2CReader.hpp)
+    list(APPEND quest_sources readers/PC2CReader.cpp)
+    
     list(APPEND quest_depends_on mpi)
+    blt_list_append(TO quest_depends_on IF AXOM_ENABLE_LUMBERJACK ELEMENTS lumberjack )
 endif()
 
 if (SHROUD_FOUND)

--- a/src/axom/quest/CMakeLists.txt
+++ b/src/axom/quest/CMakeLists.txt
@@ -40,7 +40,7 @@ set( quest_headers
     detail/PointInCellMeshWrapper_mfem.hpp
 
     ## STL library headers
-    stl/STLReader.hpp
+    readers/STLReader.hpp
 
     ## quest interface headers
     interface/internal/mpicomm_wrapper.hpp
@@ -63,7 +63,7 @@ set( quest_sources
     MeshTester.cpp
 
     ## STL library sources
-    stl/STLReader.cpp
+    readers/STLReader.cpp
 
     ## quest interface sources
     interface/internal/QuestHelpers.cpp
@@ -88,8 +88,8 @@ blt_list_append(TO quest_depends_on IF ENABLE_OPENMP ELEMENTS openmp)
 blt_list_append(TO quest_depends_on IF ENABLE_CUDA ELEMENTS cuda)
 
 if (ENABLE_MPI)
-    list(APPEND quest_headers stl/PSTLReader.hpp)
-    list(APPEND quest_sources stl/PSTLReader.cpp)
+    list(APPEND quest_headers readers/PSTLReader.hpp)
+    list(APPEND quest_sources readers/PSTLReader.cpp)
 
     blt_list_append(TO quest_depends_on
                     IF AXOM_ENABLE_LUMBERJACK

--- a/src/axom/quest/InOutOctree.hpp
+++ b/src/axom/quest/InOutOctree.hpp
@@ -167,15 +167,14 @@ public:
 
 public:
   /**
-   * \brief Construct an InOutOctree to handle containment queries on a surface
-   * mesh
+   * \brief Construct an InOutOctree to handle containment queries on a surface mesh
    *
    * \param [in] bb The spatial extent covered by the octree
    * \note We slightly scale the bounding box so all mesh elements are
    * guaranteed to be enclosed by the octree and to remedy problems we've
    * encountered related to meshes that are aligned with the octree grid
    * \note The InOutOctree modifies its mesh in an effort to repair common
-   * problems.  Please make sure to discard all old copies of the meshPtr.
+   * problems. Please make sure to discard all old copies of the meshPtr.
    */
   InOutOctree(const GeometricBoundingBox& bb, SurfaceMesh*& meshPtr)
     : SpatialOctreeType(

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -6,9 +6,7 @@
 # Quest examples
 #------------------------------------------------------------------------------
 
-set(quest_example_depends
-        axom
-        )
+set(quest_example_depends axom fmt cli11)
 
 blt_list_append(TO quest_example_depends ELEMENTS cuda IF ENABLE_CUDA)
 blt_list_append(TO quest_example_depends ELEMENTS RAJA IF RAJA_FOUND)
@@ -17,7 +15,7 @@ blt_add_executable(
     NAME        quest_containment_driver_ex
     SOURCES     containment_driver.cpp
     OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
-    DEPENDS_ON  ${quest_example_depends} fmt cli11
+    DEPENDS_ON  ${quest_example_depends}
     FOLDER      axom/quest/examples
     )
 
@@ -27,7 +25,7 @@ blt_add_executable(
     NAME       quest_signed_distance_interface_ex
     SOURCES    quest_signed_distance_interface.cpp
     OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-    DEPENDS_ON ${quest_example_depends} cli11
+    DEPENDS_ON ${quest_example_depends}
     FOLDER      axom/quest/examples
     )
 
@@ -39,21 +37,34 @@ blt_add_executable(
     FOLDER      axom/quest/examples
     )
 
-# Add a test for the quest interface.  Set up for MPI, when available
+# Add a test for the quest interface; Set up for MPI, when available
 set(quest_data_dir  ${AXOM_DATA_DIR}/quest)
 
 if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR)
     if (ENABLE_MPI)
         axom_add_test(
-            NAME quest_inout_interface_mpi_test
-            COMMAND quest_inout_interface_ex ${quest_data_dir}/sphere_binary.stl
-            NUM_MPI_TASKS 2
+            NAME quest_inout_interface_3D_mpi_test
+            COMMAND quest_inout_interface_ex -i ${quest_data_dir}/sphere_binary.stl
+            NUM_MPI_TASKS 2 
             )
+        if(C2C_FOUND)
+            axom_add_test(
+                NAME quest_inout_interface_2D_mpi_test
+                COMMAND quest_inout_interface_ex -i ${AXOM_DATA_DIR}/contours/unit_circle.contour
+                NUM_MPI_TASKS 2 
+                )
+        endif()
     else()
         axom_add_test(
-            NAME quest_inout_interface_test
-            COMMAND quest_inout_interface_ex ${quest_data_dir}/sphere_binary.stl
+            NAME quest_inout_interface_3D_test
+            COMMAND quest_inout_interface_ex -i ${quest_data_dir}/sphere_binary.stl
             )
+        if(C2C_FOUND)
+            axom_add_test(
+                NAME quest_inout_interface_2D_test
+                COMMAND quest_inout_interface_ex -i ${AXOM_DATA_DIR}/contours/unit_circle.contour
+                )
+        endif()
     endif()
 endif()
 

--- a/src/axom/quest/examples/containment_driver.cpp
+++ b/src/axom/quest/examples/containment_driver.cpp
@@ -207,7 +207,6 @@ public:
     delete umesh;
   }
 
-private:
   void batchedPointContainment2D(mint::UniformMesh* umesh,
                                  axom::utilities::Timer& timer)
   {
@@ -285,6 +284,7 @@ private:
     timer.stop();
   }
 
+private:
   /**
   * \brief Extracts the vertex indices of cell \a cellIndex from the mesh
   */

--- a/src/axom/quest/examples/containment_driver.cpp
+++ b/src/axom/quest/examples/containment_driver.cpp
@@ -358,7 +358,7 @@ void refineAndPrint(Octree3D& octree,
 struct Input
 {
 public:
-  std::string stlFile;
+  std::string inputFile;
   int maxQueryLevel {7};
   std::vector<double> queryBoxMins;
   std::vector<double> queryBoxMaxs;
@@ -376,7 +376,7 @@ public:
     {
       namespace fs = axom::utilities::filesystem;
       const auto dir = fs::joinPath(AXOM_DATA_DIR, "quest");
-      stlFile = fs::joinPath(dir, "plane_simp.stl");
+      inputFile = fs::joinPath(dir, "plane_simp.stl");
     }
 #endif
 
@@ -394,7 +394,8 @@ public:
 
   void parse(int argc, char** argv, CLI::App& app)
   {
-    app.add_option("stlFile", stlFile, "Path to input mesh")->check(CLI::ExistingFile);
+    app.add_option("-i,--input", inputFile, "Path to input file")
+      ->check(CLI::ExistingFile);
 
     app
       .add_flag("-v,--verbose",
@@ -444,7 +445,7 @@ public:
 //------------------------------------------------------------------------------
 int main(int argc, char** argv)
 {
-  axom::slic::SimpleLogger logger;  // create & initialize logger
+  axom::slic::SimpleLogger logger;
   // slic::debug::checksAreErrors = true;
 
   // Set up and parse command line arguments
@@ -464,10 +465,10 @@ int main(int argc, char** argv)
   mint::Mesh* surface_mesh = nullptr;
   {
     SLIC_INFO(fmt::format("{:*^80}", " Loading the mesh "));
-    SLIC_INFO("Reading file: " << params.stlFile << "...");
+    SLIC_INFO("Reading file: " << params.inputFile << "...");
 
     quest::STLReader* reader = new quest::STLReader();
-    reader->setFileName(params.stlFile);
+    reader->setFileName(params.inputFile);
     reader->read();
 
     // Create surface mesh

--- a/src/axom/quest/examples/containment_driver.cpp
+++ b/src/axom/quest/examples/containment_driver.cpp
@@ -85,6 +85,8 @@ public:
 #else
   void loadContourMesh(const std::string& inputFile, int segmentsPerPiece = 100)
   {
+    AXOM_UNUSED_VAR(inputFile);
+    AXOM_UNUSED_VAR(segmentsPerPiece);
     SLIC_ERROR(
       "Configuration error: Loading contour files is only supported when Axom "
       "is configured with C2C support.");

--- a/src/axom/quest/examples/containment_driver.cpp
+++ b/src/axom/quest/examples/containment_driver.cpp
@@ -72,16 +72,13 @@ public:
 #ifdef AXOM_USE_C2C
   void loadContourMesh(const std::string& inputFile, int segmentsPerKnotSpan)
   {
-    quest::C2CReader* reader = new quest::C2CReader();
-    reader->setFileName(inputFile);
-    reader->read();
+    quest::C2CReader reader;
+    reader.setFileName(inputFile);
+    reader.read();
 
     // Create surface mesh
     m_surfaceMesh = new UMesh(2, mint::SEGMENT);
-    reader->getLinearMesh(static_cast<UMesh*>(m_surfaceMesh),
-                          segmentsPerKnotSpan);
-
-    delete reader;
+    reader.getLinearMesh(static_cast<UMesh*>(m_surfaceMesh), segmentsPerKnotSpan);
   }
 #else
   void loadContourMesh(const std::string& inputFile, int segmentsPerKnotSpan)
@@ -96,15 +93,13 @@ public:
 
   void loadSTLMesh(const std::string& inputFile)
   {
-    quest::STLReader* reader = new quest::STLReader();
-    reader->setFileName(inputFile);
-    reader->read();
+    quest::STLReader reader;
+    reader.setFileName(inputFile);
+    reader.read();
 
     // Create surface mesh
     m_surfaceMesh = new UMesh(3, mint::TRIANGLE);
-    reader->getMesh(static_cast<UMesh*>(m_surfaceMesh));
-
-    delete reader;
+    reader.getMesh(static_cast<UMesh*>(m_surfaceMesh));
   }
 
   mint::Mesh* getSurfaceMesh() const { return m_surfaceMesh; }
@@ -511,12 +506,7 @@ public:
   bool isInput2D() const
   {
     using axom::utilities::string::endsWith;
-    if(endsWith(inputFile, ".contour"))
-    {
-      return true;
-    }
-
-    return false;
+    return endsWith(inputFile, ".contour");
   }
 
   bool isVerbose() const { return m_verboseOutput; }

--- a/src/axom/quest/examples/quest_inout_interface.cpp
+++ b/src/axom/quest/examples/quest_inout_interface.cpp
@@ -6,15 +6,19 @@
 /*!
  * \file quest_inout_interface.cpp
  *
- * \brief Simple example that exercises the C-style quest_inout interface
- * which determines if a point is contained within an enclosed volume
- * defined by a surface mesh.
+ * Exercises the C-style quest_inout interface which determines if a point
+ * is contained within an enclosed volume defined by a surface mesh.
+ * Supports 3D queries against STL meshes and 2D queries against C2C contour files.
+ * Note: 2D queries are only supported when Axom is configured with C2C.
  */
 
 // Axom includes
 #include "axom/core.hpp"
 #include "axom/slic.hpp"
 #include "axom/primal.hpp"
+
+#include "fmt/fmt.hpp"
+#include "CLI11/CLI11.hpp"
 
 // _quest_inout_interface_include_start
 #include "axom/quest/interface/inout.hpp"
@@ -31,9 +35,11 @@ namespace slic = axom::slic;
 namespace primal = axom::primal;
 namespace quest = axom::quest;
 
-typedef primal::Point<double, 3> PointType;
-typedef primal::BoundingBox<double, 3> BoxType;
-typedef std::vector<PointType> CoordsVec;
+using Point2D = primal::Point<double, 2>;
+using Box2D = primal::BoundingBox<double, 2>;
+using Point3D = primal::Point<double, 3>;
+using Box3D = primal::BoundingBox<double, 3>;
+using CoordsVec = std::vector<Point3D>;
 
 //------------------------------------------------------------------------------
 
@@ -44,17 +50,23 @@ typedef std::vector<PointType> CoordsVec;
  * \param [out] queryPoints The generated set of query points
  * \param [in] bbox The bounding box for the query points
  * \param [in] numPoints The number of points to generate
+ * \param [in] dim The number of coordinates to generate per point (2 or 3)
  */
-void generateQueryPoints(CoordsVec& queryPoints, BoxType const& bbox, int numPoints)
+void generateQueryPoints(CoordsVec& queryPoints,
+                         Box3D const& bbox,
+                         int numPoints,
+                         int dim)
 {
+  using axom::utilities::random_real;
+
   queryPoints.clear();
   queryPoints.reserve(numPoints);
   for(int i = 0; i < numPoints; ++i)
   {
-    double x = axom::utilities::random_real(bbox.getMin()[0], bbox.getMax()[0]);
-    double y = axom::utilities::random_real(bbox.getMin()[1], bbox.getMax()[1]);
-    double z = axom::utilities::random_real(bbox.getMin()[2], bbox.getMax()[2]);
-    queryPoints.push_back(PointType::make_point(x, y, z));
+    double x = random_real(bbox.getMin()[0], bbox.getMax()[0]);
+    double y = random_real(bbox.getMin()[1], bbox.getMax()[1]);
+    double z = dim == 3 ? random_real(bbox.getMin()[2], bbox.getMax()[2]) : 0.;
+    queryPoints.emplace_back(Point3D {x, y, z});
   }
 }
 
@@ -113,47 +125,82 @@ void cleanAbort()
   axom::utilities::processAbort();
 }
 
-/*!
- * \brief A simple example illustrating the use of the Quest C-Style interface.
- *
- * \note To run the example
- * \verbatim
- *
- *   [mpirun -np N] ./quest_inout_interface_ex <stl_file>
- *
- * \endverbatim
- */
+/// \brief A simple example illustrating the use of the Quest C-Style interface.
 int main(int argc, char** argv)
 {
   // -- Initialize MPI
 #ifdef AXOM_USE_MPI
   MPI_Init(&argc, &argv);
+
+  int my_rank, num_ranks;
+  MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
+#else
+  int my_rank = 0;
+  int num_ranks = 1;
 #endif
 
   // -- Initialize logger
   initializeLogger();
 
-  // -- Parse command line options
-  if(argc != 2)
-  {
-#ifdef AXOM_USE_MPI
-    SLIC_WARNING("Usage: [mpirun -np N] ./quest_inout_interface_ex <stl_file>");
-#else
-    SLIC_WARNING("Usage: ./quest_inout_interface_ex <stl_file>");
-#endif
-    cleanAbort();
-  }
-
-  std::string fileName = std::string(argv[1]);
+  // -- Set up and parse command line options
+  std::string fileName;
   bool isVerbose = false;
-  const int npoints = 100000;
+  int npoints = 100000;
   double weldThresh = 1E-9;
+
+  CLI::App app {"Driver for containment query using inout API"};
+  app.add_option("-i,--input", fileName)
+    ->description("The input file describing a closed surface in 2D or 3D")
+    ->check(CLI::ExistingFile)
+    ->required();
+  app.add_flag("-v,--verbose", isVerbose)
+    ->description("Enable/disable verbose output")
+    ->capture_default_str();
+  app.add_option("-t,--weld-threshold", weldThresh)
+    ->description("Threshold for welding")
+    ->check(CLI::NonNegativeNumber)
+    ->capture_default_str();
+  app.add_option("-n,--num-samples", npoints)
+    ->description("Number of query points")
+    ->check(CLI::NonNegativeNumber)
+    ->capture_default_str();
+  app.get_formatter()->column_width(50);
+
+  try
+  {
+    app.parse(argc, argv);
+  }
+  catch(const CLI::ParseError& e)
+  {
+    int retval = -1;
+    if(my_rank == 0)
+    {
+      retval = app.exit(e);
+    }
+    finalizeLogger();
+
+#ifdef AXOM_USE_MPI
+    MPI_Bcast(&retval, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    MPI_Finalize();
+#endif
+    exit(retval);
+  }
 
   int rc = quest::QUEST_INOUT_SUCCESS;
 
   // _quest_inout_interface_parameters_start
   // -- Set quest_inout parameters
   rc = quest::inout_set_verbose(isVerbose);
+  if(rc != quest::QUEST_INOUT_SUCCESS)
+  {
+    cleanAbort();
+  }
+
+  // Note: contour files are only supported when Axom is configured with C2C
+  using axom::utilities::string::endsWith;
+  const int dim = endsWith(fileName, ".contour") ? 2 : 3;
+  rc = quest::inout_set_dimension(dim);
   if(rc != quest::QUEST_INOUT_SUCCESS)
   {
     cleanAbort();
@@ -209,26 +256,33 @@ int main(int argc, char** argv)
     cleanAbort();
   }
 
-  BoxType bbox = BoxType(PointType(bbMin), PointType(bbMax));
-  SLIC_INFO("Mesh bounding box: " << bbox);
-  SLIC_INFO("Mesh center of mass: " << PointType(cMass));
+  switch(quest::inout_get_dimension())
+  {
+  case 2:
+    SLIC_INFO("Mesh bounding box: " << Box2D(Point2D(bbMin), Point2D(bbMax)));
+    SLIC_INFO("Mesh center of mass: " << Point2D(cMass));
+    break;
+  case 3:
+  default:
+    SLIC_INFO("Mesh bounding box: " << Box3D(Point3D(bbMin), Point3D(bbMax)));
+    SLIC_INFO("Mesh center of mass: " << Point3D(cMass));
+    break;
+  }
+  slic::flushStreams();
 
   // -- Generate query points
+  Box3D bbox {Point3D(bbMin), Point3D(bbMax)};
   CoordsVec queryPoints;
-  generateQueryPoints(queryPoints, bbox, npoints);
+  generateQueryPoints(queryPoints, bbox, npoints, dim);
 
-  // -- Run the queries
+  // -- Run the queries (the z-coordinate is ignored for 2D queries)
   int numInside = 0;
-  SLIC_INFO("Querying mesh with " << npoints << " query points...");
+  SLIC_INFO(fmt::format("Querying mesh with {} query points...", npoints));
   timer.start();
   for(auto& pt : queryPoints)
   {
     // _quest_inout_interface_test_start
-    const double x = pt[0];
-    const double y = pt[1];
-    const double z = pt[2];
-
-    const bool ins = quest::inout_evaluate(x, y, z);
+    const bool ins = quest::inout_evaluate(pt[0], pt[1], pt[2]);
     numInside += ins ? 1 : 0;
     // _quest_inout_interface_test_end
   }
@@ -236,16 +290,14 @@ int main(int argc, char** argv)
 
   // -- Output some query statistics
   {
-    SLIC_INFO("  queries took " << timer.elapsed() << " seconds.");
-
-    const double rate = queryPoints.size() / timer.elapsed();
-    SLIC_INFO("  query rate: " << rate << " queries per second.");
-
-    const double intPercent =
-      (100 * numInside) / static_cast<double>(queryPoints.size());
-    SLIC_INFO("  " << numInside << " of " << queryPoints.size() << " ("
-                   << intPercent << "%) "
-                   << " of the query points were contained in the surface.");
+    SLIC_INFO(fmt::format("  queries took {} seconds.", timer.elapsed()));
+    SLIC_INFO(fmt::format("  query rate: {} queries per second.",
+                          queryPoints.size() / timer.elapsed()));
+    SLIC_INFO(fmt::format(
+      "  {} of {} ({}%) of the query points were contained in the surface.",
+      numInside,
+      queryPoints.size(),
+      (100 * numInside) / static_cast<double>(queryPoints.size())));
   }
 
   // -- Finalize quest_inout

--- a/src/axom/quest/interface/c_fortran/typesQUEST.h
+++ b/src/axom/quest/interface/c_fortran/typesQUEST.h
@@ -17,12 +17,12 @@ extern "C" {
 // helper capsule_data_helper
 struct s_QUEST_SHROUD_capsule_data
 {
-  void* addr; /* address of C++ memory */
+  void *addr; /* address of C++ memory */
   int idtor;  /* index of destructor */
 };
 typedef struct s_QUEST_SHROUD_capsule_data QUEST_SHROUD_capsule_data;
 
-void QUEST_SHROUD_memory_destructor(QUEST_SHROUD_capsule_data* cap);
+void QUEST_SHROUD_memory_destructor(QUEST_SHROUD_capsule_data *cap);
 
 #ifdef __cplusplus
 }

--- a/src/axom/quest/interface/c_fortran/wrapQUEST.cpp
+++ b/src/axom/quest/interface/c_fortran/wrapQUEST.cpp
@@ -21,7 +21,7 @@ extern "C" {
 // splicer end C_definitions
 
 #ifdef AXOM_USE_MPI
-int QUEST_inout_init_mpi(const char* fileName, MPI_Fint comm)
+int QUEST_inout_init_mpi(const char *fileName, MPI_Fint comm)
 {
   // splicer begin function.inout_init_mpi
   const std::string SHCXX_fileName(fileName);
@@ -33,7 +33,7 @@ int QUEST_inout_init_mpi(const char* fileName, MPI_Fint comm)
 #endif  // ifdef AXOM_USE_MPI
 
 #ifdef AXOM_USE_MPI
-int QUEST_inout_init_mpi_bufferify(const char* fileName,
+int QUEST_inout_init_mpi_bufferify(const char *fileName,
                                    int LfileName,
                                    MPI_Fint comm)
 {
@@ -47,7 +47,7 @@ int QUEST_inout_init_mpi_bufferify(const char* fileName,
 #endif  // ifdef AXOM_USE_MPI
 
 #ifndef AXOM_USE_MPI
-int QUEST_inout_init_serial(const char* fileName)
+int QUEST_inout_init_serial(const char *fileName)
 {
   // splicer begin function.inout_init_serial
   const std::string SHCXX_fileName(fileName);
@@ -58,7 +58,7 @@ int QUEST_inout_init_serial(const char* fileName)
 #endif  // ifndef AXOM_USE_MPI
 
 #ifndef AXOM_USE_MPI
-int QUEST_inout_init_serial_bufferify(const char* fileName, int LfileName)
+int QUEST_inout_init_serial_bufferify(const char *fileName, int LfileName)
 {
   // splicer begin function.inout_init_serial_bufferify
   const std::string SHCXX_fileName(fileName, LfileName);
@@ -74,6 +74,14 @@ bool QUEST_inout_initialized(void)
   bool SHC_rv = axom::quest::inout_initialized();
   return SHC_rv;
   // splicer end function.inout_initialized
+}
+
+int QUEST_inout_set_dimension(int dim)
+{
+  // splicer begin function.inout_set_dimension
+  int SHC_rv = axom::quest::inout_set_dimension(dim);
+  return SHC_rv;
+  // splicer end function.inout_set_dimension
 }
 
 int QUEST_inout_set_verbose(bool verbosity)
@@ -92,6 +100,14 @@ int QUEST_inout_set_vertex_weld_threshold(double thresh)
   // splicer end function.inout_set_vertex_weld_threshold
 }
 
+int QUEST_inout_set_segments_per_knot_span(int segmentsPerKnotSpan)
+{
+  // splicer begin function.inout_set_segments_per_knot_span
+  int SHC_rv = axom::quest::inout_set_segments_per_knot_span(segmentsPerKnotSpan);
+  return SHC_rv;
+  // splicer end function.inout_set_segments_per_knot_span
+}
+
 bool QUEST_inout_evaluate_0(double x, double y)
 {
   // splicer begin function.inout_evaluate_0
@@ -108,7 +124,7 @@ bool QUEST_inout_evaluate_1(double x, double y, double z)
   // splicer end function.inout_evaluate_1
 }
 
-int QUEST_inout_mesh_min_bounds(double* coords)
+int QUEST_inout_mesh_min_bounds(double *coords)
 {
   // splicer begin function.inout_mesh_min_bounds
   int SHC_rv = axom::quest::inout_mesh_min_bounds(coords);
@@ -116,7 +132,7 @@ int QUEST_inout_mesh_min_bounds(double* coords)
   // splicer end function.inout_mesh_min_bounds
 }
 
-int QUEST_inout_mesh_max_bounds(double* coords)
+int QUEST_inout_mesh_max_bounds(double *coords)
 {
   // splicer begin function.inout_mesh_max_bounds
   int SHC_rv = axom::quest::inout_mesh_max_bounds(coords);
@@ -124,7 +140,7 @@ int QUEST_inout_mesh_max_bounds(double* coords)
   // splicer end function.inout_mesh_max_bounds
 }
 
-int QUEST_inout_mesh_center_of_mass(double* coords)
+int QUEST_inout_mesh_center_of_mass(double *coords)
 {
   // splicer begin function.inout_mesh_center_of_mass
   int SHC_rv = axom::quest::inout_mesh_center_of_mass(coords);
@@ -149,7 +165,7 @@ int QUEST_inout_finalize(void)
 }
 
 #ifdef AXOM_USE_MPI
-int QUEST_signed_distance_init_mpi(const char* file, MPI_Fint comm)
+int QUEST_signed_distance_init_mpi(const char *file, MPI_Fint comm)
 {
   // splicer begin function.signed_distance_init_mpi
   const std::string SHCXX_file(file);
@@ -161,7 +177,7 @@ int QUEST_signed_distance_init_mpi(const char* file, MPI_Fint comm)
 #endif  // ifdef AXOM_USE_MPI
 
 #ifdef AXOM_USE_MPI
-int QUEST_signed_distance_init_mpi_bufferify(const char* file,
+int QUEST_signed_distance_init_mpi_bufferify(const char *file,
                                              int Lfile,
                                              MPI_Fint comm)
 {
@@ -175,7 +191,7 @@ int QUEST_signed_distance_init_mpi_bufferify(const char* file,
 #endif  // ifdef AXOM_USE_MPI
 
 #ifndef AXOM_USE_MPI
-int QUEST_signed_distance_init_serial(const char* file)
+int QUEST_signed_distance_init_serial(const char *file)
 {
   // splicer begin function.signed_distance_init_serial
   const std::string SHCXX_file(file);
@@ -186,7 +202,7 @@ int QUEST_signed_distance_init_serial(const char* file)
 #endif  // ifndef AXOM_USE_MPI
 
 #ifndef AXOM_USE_MPI
-int QUEST_signed_distance_init_serial_bufferify(const char* file, int Lfile)
+int QUEST_signed_distance_init_serial_bufferify(const char *file, int Lfile)
 {
   // splicer begin function.signed_distance_init_serial_bufferify
   const std::string SHCXX_file(file, Lfile);
@@ -204,7 +220,7 @@ bool QUEST_signed_distance_initialized(void)
   // splicer end function.signed_distance_initialized
 }
 
-void QUEST_signed_distance_get_mesh_bounds(double* lo, double* hi)
+void QUEST_signed_distance_get_mesh_bounds(double *lo, double *hi)
 {
   // splicer begin function.signed_distance_get_mesh_bounds
   axom::quest::signed_distance_get_mesh_bounds(lo, hi);
@@ -276,7 +292,7 @@ void QUEST_signed_distance_finalize(void)
 }
 
 // Release library allocated memory.
-void QUEST_SHROUD_memory_destructor(QUEST_SHROUD_capsule_data* cap)
+void QUEST_SHROUD_memory_destructor(QUEST_SHROUD_capsule_data *cap)
 {
   cap->addr = nullptr;
   cap->idtor = 0;  // avoid deleting again

--- a/src/axom/quest/interface/c_fortran/wrapQUEST.h
+++ b/src/axom/quest/interface/c_fortran/wrapQUEST.h
@@ -52,9 +52,13 @@ int QUEST_inout_init_serial_bufferify(const char* fileName, int LfileName);
 
 bool QUEST_inout_initialized(void);
 
+int QUEST_inout_set_dimension(int dim);
+
 int QUEST_inout_set_verbose(bool verbosity);
 
 int QUEST_inout_set_vertex_weld_threshold(double thresh);
+
+int QUEST_inout_set_segments_per_knot_span(int segmentsPerKnotSpan);
 
 bool QUEST_inout_evaluate_0(double x, double y);
 

--- a/src/axom/quest/interface/c_fortran/wrapfquest.F
+++ b/src/axom/quest/interface/c_fortran/wrapfquest.F
@@ -78,6 +78,15 @@ module axom_quest
             logical(C_BOOL) :: SHT_rv
         end function c_inout_initialized
 
+        function quest_inout_set_dimension(dim) &
+                result(SHT_rv) &
+                bind(C, name="QUEST_inout_set_dimension")
+            use iso_c_binding, only : C_INT
+            implicit none
+            integer(C_INT), value, intent(IN) :: dim
+            integer(C_INT) :: SHT_rv
+        end function quest_inout_set_dimension
+
         function c_inout_set_verbose(verbosity) &
                 result(SHT_rv) &
                 bind(C, name="QUEST_inout_set_verbose")
@@ -95,6 +104,16 @@ module axom_quest
             real(C_DOUBLE), value, intent(IN) :: thresh
             integer(C_INT) :: SHT_rv
         end function quest_inout_set_vertex_weld_threshold
+
+        function quest_inout_set_segments_per_knot_span( &
+                segmentsPerKnotSpan) &
+                result(SHT_rv) &
+                bind(C, name="QUEST_inout_set_segments_per_knot_span")
+            use iso_c_binding, only : C_INT
+            implicit none
+            integer(C_INT), value, intent(IN) :: segmentsPerKnotSpan
+            integer(C_INT) :: SHT_rv
+        end function quest_inout_set_segments_per_knot_span
 
         function c_inout_evaluate_0(x, y) &
                 result(SHT_rv) &

--- a/src/axom/quest/interface/inout.cpp
+++ b/src/axom/quest/interface/inout.cpp
@@ -411,6 +411,7 @@ int inout_init(mint::Mesh*& mesh, MPI_Comm comm)
     {
       s_inoutHelper2D.restoreLoggingLevel();
     }
+    break;
 
   case 3:
     s_inoutHelper3D.setVerbose(s_inoutParams.m_verbose);

--- a/src/axom/quest/interface/inout.cpp
+++ b/src/axom/quest/interface/inout.cpp
@@ -24,14 +24,14 @@ struct InOutParameters
 {
   bool m_verbose {false};
   int m_dimension {3};
-  int m_segmentsPerPiece {100};  /// Used when linearizing curves
+  int m_segmentsPerKnotSpan {25};  /// Used when linearizing curves
   double m_vertexWeldThreshold {1E-9};
 
   void setDefault()
   {
     m_verbose = false;
     m_dimension = 3;
-    m_segmentsPerPiece = 100;
+    m_segmentsPerKnotSpan = 25;
     m_vertexWeldThreshold = 1E-9;
   }
 };
@@ -94,9 +94,9 @@ struct InOutHelper
     m_params.m_vertexWeldThreshold = thresh;
   }
 
-  void setSegmentsPerPiece(int numSegments)
+  void setSegmentsPerKnotSpan(int numSegments)
   {
-    m_params.m_segmentsPerPiece = numSegments;
+    m_params.m_segmentsPerKnotSpan = numSegments;
   }
 
   /// Saves the current slic logging level
@@ -136,7 +136,7 @@ struct InOutHelper
     case 2:
 #ifdef AXOM_USE_C2C
       rc = internal::read_c2c_mesh(file,
-                                   m_params.m_segmentsPerPiece,
+                                   m_params.m_segmentsPerKnotSpan,
                                    m_params.m_vertexWeldThreshold,
                                    mesh,
                                    comm);
@@ -372,7 +372,7 @@ int inout_init(const std::string& file, MPI_Comm comm)
   {
   case 2:
     s_inoutHelper2D.setVerbose(s_inoutParams.m_verbose);
-    s_inoutHelper2D.setSegmentsPerPiece(s_inoutParams.m_segmentsPerPiece);
+    s_inoutHelper2D.setSegmentsPerKnotSpan(s_inoutParams.m_segmentsPerKnotSpan);
     s_inoutHelper2D.setVertexWeldThreshold(s_inoutParams.m_vertexWeldThreshold);
 
     rc = s_inoutHelper2D.initialize(file, comm);
@@ -416,7 +416,7 @@ int inout_init(mint::Mesh*& mesh, MPI_Comm comm)
   {
   case 2:
     s_inoutHelper2D.setVerbose(s_inoutParams.m_verbose);
-    s_inoutHelper2D.setSegmentsPerPiece(s_inoutParams.m_segmentsPerPiece);
+    s_inoutHelper2D.setSegmentsPerKnotSpan(s_inoutParams.m_segmentsPerKnotSpan);
     s_inoutHelper2D.setVertexWeldThreshold(s_inoutParams.m_vertexWeldThreshold);
 
     rc = s_inoutHelper2D.initialize(mesh, comm);
@@ -427,7 +427,7 @@ int inout_init(mint::Mesh*& mesh, MPI_Comm comm)
 
   case 3:
     s_inoutHelper3D.setVerbose(s_inoutParams.m_verbose);
-    s_inoutHelper3D.setSegmentsPerPiece(s_inoutParams.m_segmentsPerPiece);
+    s_inoutHelper3D.setSegmentsPerKnotSpan(s_inoutParams.m_segmentsPerKnotSpan);
     s_inoutHelper3D.setVertexWeldThreshold(s_inoutParams.m_vertexWeldThreshold);
 
     rc = s_inoutHelper3D.initialize(mesh, comm);
@@ -670,29 +670,6 @@ int inout_set_dimension(int dim)
   return QUEST_INOUT_SUCCESS;
 }
 
-int inout_set_segments_per_piece(int num_segments)
-{
-  if(inout_initialized())
-  {
-    SLIC_WARNING("quest inout query must NOT be initialized "
-                 << "prior to calling 'inout_set_segments_per_piece'");
-
-    return QUEST_INOUT_FAILED;
-  }
-
-  if(num_segments < 1)
-  {
-    SLIC_WARNING("quest inout query: segments per piece must be at least 1."
-                 << " Supplied value was " << num_segments);
-
-    return QUEST_INOUT_FAILED;
-  }
-
-  s_inoutParams.m_segmentsPerPiece = num_segments;
-
-  return QUEST_INOUT_SUCCESS;
-}
-
 int inout_set_vertex_weld_threshold(double thresh)
 {
   if(inout_initialized())
@@ -712,6 +689,29 @@ int inout_set_vertex_weld_threshold(double thresh)
   }
 
   s_inoutParams.m_vertexWeldThreshold = thresh;
+
+  return QUEST_INOUT_SUCCESS;
+}
+
+int inout_set_segments_per_knot_span(int segmentsPerKnotSpan)
+{
+  if(inout_initialized())
+  {
+    SLIC_WARNING("quest inout query must NOT be initialized "
+                 << "prior to calling 'inout_set_segments_per_knot_span'");
+
+    return QUEST_INOUT_FAILED;
+  }
+
+  if(segmentsPerKnotSpan < 1)
+  {
+    SLIC_WARNING("quest inout query: segmentsPerKnotSpan must be at least 1."
+                 << " Supplied value was " << segmentsPerKnotSpan);
+
+    return QUEST_INOUT_FAILED;
+  }
+
+  s_inoutParams.m_segmentsPerKnotSpan = segmentsPerKnotSpan;
 
   return QUEST_INOUT_SUCCESS;
 }

--- a/src/axom/quest/interface/inout.cpp
+++ b/src/axom/quest/interface/inout.cpp
@@ -129,7 +129,7 @@ struct InOutHelper
 
     // load the mesh
     int rc = QUEST_INOUT_FAILED;
-    rc = internal::read_mesh(file, mesh, comm);
+    rc = internal::read_stl_mesh(file, mesh, comm);
 
     if(rc != QUEST_INOUT_SUCCESS)
     {

--- a/src/axom/quest/interface/inout.cpp
+++ b/src/axom/quest/interface/inout.cpp
@@ -135,7 +135,11 @@ struct InOutHelper
     {
     case 2:
 #ifdef AXOM_USE_C2C
-      rc = internal::read_c2c_mesh(file, m_params.m_segmentsPerPiece, mesh, comm);
+      rc = internal::read_c2c_mesh(file,
+                                   m_params.m_segmentsPerPiece,
+                                   m_params.m_vertexWeldThreshold,
+                                   mesh,
+                                   comm);
 #else
       SLIC_WARNING(fmt::format(
         "Cannot read contour file: C2C not enabled in this configuration.",

--- a/src/axom/quest/interface/inout.cpp
+++ b/src/axom/quest/interface/inout.cpp
@@ -27,13 +27,7 @@ struct InOutParameters
   int m_segmentsPerKnotSpan {25};  /// Used when linearizing curves
   double m_vertexWeldThreshold {1E-9};
 
-  void setDefault()
-  {
-    m_verbose = false;
-    m_dimension = 3;
-    m_segmentsPerKnotSpan = 25;
-    m_vertexWeldThreshold = 1E-9;
-  }
+  void setDefault() { *this = InOutParameters {}; }
 };
 
 /*!
@@ -56,20 +50,13 @@ struct InOutHelper
   /// State variables for the InOutQuery
   struct State
   {
-    bool m_initialized;
-    bool m_logger_is_initialized;
-    bool m_should_delete_logger;
-    bool m_should_delete_mesh;
-    slic::message::Level m_previousLevel;
+    bool m_initialized {false};
+    bool m_logger_is_initialized {false};
+    bool m_should_delete_logger {false};
+    bool m_should_delete_mesh {false};
+    slic::message::Level m_previousLevel {slic::message::Num_Levels};
 
-    void setDefault()
-    {
-      m_initialized = false;
-      m_logger_is_initialized = false;
-      m_should_delete_logger = false;
-      m_should_delete_mesh = false;
-      m_previousLevel = slic::message::Num_Levels;
-    }
+    void setDefault() { *this = State {}; }
   };
 
   InOutHelper() : m_surfaceMesh(nullptr), m_inoutTree(nullptr)

--- a/src/axom/quest/interface/inout.cpp
+++ b/src/axom/quest/interface/inout.cpp
@@ -133,7 +133,13 @@ struct InOutHelper
     switch(DIM)
     {
     case 2:
+#ifdef AXOM_USE_C2C
       rc = internal::read_c2c_mesh(file, m_params.m_segmentsPerPiece, mesh, comm);
+#else
+      SLIC_WARNING(fmt::format(
+        "Cannot read contour file: C2C not enabled in this configuration.",
+        file));
+#endif
       break;
     case 3:
       rc = internal::read_stl_mesh(file, mesh, comm);

--- a/src/axom/quest/interface/inout.cpp
+++ b/src/axom/quest/interface/inout.cpp
@@ -126,6 +126,7 @@ struct InOutHelper
   int initialize(const std::string& file, MPI_Comm comm)
   {
     mint::Mesh* mesh = nullptr;
+    m_params.m_dimension = getDimension();
 
     // load the mesh
     int rc = QUEST_INOUT_FAILED;
@@ -185,10 +186,10 @@ struct InOutHelper
     }
     m_surfaceMesh = mesh;
 
-    if(m_surfaceMesh->getDimension() != m_params.m_dimension)
+    if(m_surfaceMesh->getDimension() != getDimension())
     {
       SLIC_WARNING("Incorrect dimensionality for mesh."
-                   << "Expected " << m_params.m_dimension << ", "
+                   << "Expected " << getDimension() << ", "
                    << "but got " << m_surfaceMesh->getDimension());
       return QUEST_INOUT_FAILED;
     }

--- a/src/axom/quest/interface/inout.hpp
+++ b/src/axom/quest/interface/inout.hpp
@@ -230,9 +230,26 @@ int inout_set_verbose(bool verbosity);
  * \return Return code is QUEST_INOUT_SUCCESS if successful
  *  and QUEST_INOUT_FAILED otherwise.
  * \pre inout_initialized() == false
- * \pre thresh >= 0
+ * \pre thresh > 0
  */
 int inout_set_vertex_weld_threshold(double thresh);
+
+/*!
+ * \brief Sets the number of samples for each knot span (2D only)
+ *
+ * By default, the welding threshold is 25
+ *
+ * Span intervals are the segments of each curve. This parameter controls
+ * the number of samples to use when linearizing each knot span
+ * of the contour splines 
+ *
+ * \param segmentsPerKnotSpan The number of segments for each knot span
+ * \return Return code is QUEST_INOUT_SUCCESS if successful
+ *  and QUEST_INOUT_FAILED otherwise.
+ * \pre inout_initialized() == false
+ * \pre segmentsPerKnotSpan >= 1
+ */
+int inout_set_segments_per_knot_span(int segmentsPerKnotSpan);
 
 /// @}
 

--- a/src/axom/quest/interface/inout.hpp
+++ b/src/axom/quest/interface/inout.hpp
@@ -180,12 +180,10 @@ int inout_mesh_center_of_mass(double* coords);
 /*!
  * \brief Gets the spatial dimension of the query
  *
- * \return Returns the spatial dimension for query points when the query has
- * been successfully initialized and QUEST_INOUT_FAILED otherwise.
- * \note This determines the number of coordinates for query points in
- * \a inout_evaluate() and the number of returned coordinates in functions like
- * \a inout_mesh_min_bounds()
- * \pre inout_initialized() == true
+ * \return Returns the spatial dimension for the inout query
+ * \note This determines the number of coordinates for the input mesh
+ * \note The default dimension is 3
+ * \sa inout_set_dimension
  */
 int inout_get_dimension();
 
@@ -194,6 +192,16 @@ int inout_get_dimension();
 /// \name InOut query -- setup options and parameters
 /// \note These must be called before \a inout_init()
 /// @{
+
+/*!
+ * \brief Sets the spatial dimension of the query
+ *
+ * \param dim The dimension for the inout query
+ * \return Return code is QUEST_INOUT_SUCCESS if successful, QUEST_INOUT_FAILED otherwise
+ * \pre dim == 2 || dim == 3
+ * \pre inout_initialized() == false
+ */
+int inout_set_dimension(int dim);
 
 /*!
  * \brief Enables/disables verbose logging output
@@ -231,4 +239,4 @@ int inout_set_vertex_weld_threshold(double thresh);
 }  // end namespace quest
 }  // end namespace axom
 
-#endif /* QUEST_INOUT_INTERFACE_HPP_ */
+#endif  // QUEST_INOUT_INTERFACE_HPP_

--- a/src/axom/quest/interface/internal/QuestHelpers.cpp
+++ b/src/axom/quest/interface/internal/QuestHelpers.cpp
@@ -321,21 +321,20 @@ int read_stl_mesh(const std::string& file, mint::Mesh*& m, MPI_Comm comm)
   // STEP 1: allocate output mesh object
   m = new TriangleMesh(DIMENSION, mint::TRIANGLE);
 
-  // STEP 2: allocate reader
-  quest::STLReader* reader = nullptr;
+  // STEP 2: construct STL reader
 #ifdef AXOM_USE_MPI
-  reader = new quest::PSTLReader(comm);
+  quest::PSTLReader reader(comm);
 #else
   AXOM_UNUSED_VAR(comm);
-  reader = new quest::STLReader();
+  quest::STLReader reader;
 #endif
 
   // STEP 3: read the mesh from the STL file
-  reader->setFileName(file);
-  int rc = reader->read();
+  reader.setFileName(file);
+  int rc = reader.read();
   if(rc == READ_SUCCESS)
   {
-    reader->getMesh(static_cast<TriangleMesh*>(m));
+    reader.getMesh(static_cast<TriangleMesh*>(m));
   }
   else
   {
@@ -343,10 +342,6 @@ int read_stl_mesh(const std::string& file, mint::Mesh*& m, MPI_Comm comm)
     delete m;
     m = nullptr;
   }
-
-  // STEP 4: delete the reader
-  delete reader;
-  reader = nullptr;
 
   return rc;
 }
@@ -375,22 +370,21 @@ int read_c2c_mesh(const std::string& file,
   // STEP 1: allocate output mesh object
   m = new SegmentMesh(DIMENSION, mint::SEGMENT);
 
-  // STEP 2: allocate reader
-  quest::C2CReader* reader = nullptr;
+  // STEP 2: construct C2C reader
   #ifdef AXOM_USE_MPI
-  reader = new quest::PC2CReader(comm);
+  quest::PC2CReader reader(comm);
   #else
   AXOM_UNUSED_VAR(comm);
-  reader = new quest::C2CReader();
+  quest::C2CReader reader;
   #endif
 
-  // STEP 3: read the mesh from the STL file
-  reader->setFileName(file);
-  reader->setVertexWeldingThreshold(vertexWeldThreshold);
-  int rc = reader->read();
+  // STEP 3: read the mesh from the input file
+  reader.setFileName(file);
+  reader.setVertexWeldingThreshold(vertexWeldThreshold);
+  int rc = reader.read();
   if(rc == READ_SUCCESS)
   {
-    reader->getLinearMesh(static_cast<SegmentMesh*>(m), segmentsPerPiece);
+    reader.getLinearMesh(static_cast<SegmentMesh*>(m), segmentsPerPiece);
   }
   else
   {
@@ -398,10 +392,6 @@ int read_c2c_mesh(const std::string& file,
     delete m;
     m = nullptr;
   }
-
-  // STEP 4: delete the reader
-  delete reader;
-  reader = nullptr;
 
   return rc;
 }

--- a/src/axom/quest/interface/internal/QuestHelpers.cpp
+++ b/src/axom/quest/interface/internal/QuestHelpers.cpp
@@ -195,12 +195,12 @@ MPI_Aint allocate_shared_buffer(int local_rank_id,
  * Reads in the surface mesh from the specified file into a shared
  * memory buffer that is attached to the given MPI shared window.
  */
-int read_mesh_shared(const std::string& file,
-                     MPI_Comm global_comm,
-                     unsigned char*& mesh_buffer,
-                     mint::Mesh*& m,
-                     MPI_Comm& intra_node_comm,
-                     MPI_Win& shared_window)
+int read_stl_mesh_shared(const std::string& file,
+                         MPI_Comm global_comm,
+                         unsigned char*& mesh_buffer,
+                         mint::Mesh*& m,
+                         MPI_Comm& intra_node_comm,
+                         MPI_Win& shared_window)
 {
   SLIC_ASSERT(global_comm != MPI_COMM_NULL);
   SLIC_ASSERT(intra_node_comm == MPI_COMM_NULL);
@@ -301,7 +301,7 @@ int read_mesh_shared(const std::string& file,
 /*
  * Reads in the surface mesh from the specified file.
  */
-int read_mesh(const std::string& file, mint::Mesh*& m, MPI_Comm comm)
+int read_stl_mesh(const std::string& file, mint::Mesh*& m, MPI_Comm comm)
 {
   // NOTE: STL meshes are always 3D
   constexpr int DIMENSION = 3;

--- a/src/axom/quest/interface/internal/QuestHelpers.cpp
+++ b/src/axom/quest/interface/internal/QuestHelpers.cpp
@@ -3,24 +3,15 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/core.hpp"
 #include "axom/quest/interface/internal/QuestHelpers.hpp"
 
-// Slic includes
-#include "axom/slic/interface/slic.hpp"  // for SLIC macros
-#include "axom/slic/streams/GenericOutputStream.hpp"
-#if defined(AXOM_USE_MPI) && defined(AXOM_USE_LUMBERJACK)
-  #include "axom/slic/streams/LumberjackStream.hpp"
-#elif defined(AXOM_USE_MPI) && !defined(AXOM_USE_LUMBERJACK)
-  #include "axom/slic/streams/SynchronizedStream.hpp"
-#endif
-
-// Mint includes
-#include "axom/mint/mesh/UnstructuredMesh.hpp"  // for mint::UnstructuredMesh
+#include "axom/core.hpp"
+#include "axom/slic.hpp"
+#include "axom/mint/mesh/UnstructuredMesh.hpp"
 
 // Quest includes
 #ifdef AXOM_USE_MPI
-  #include "axom/quest/stl/PSTLReader.hpp"
+  #include "axom/quest/readers/PSTLReader.hpp"
 #endif
 
 #include <limits>
@@ -448,6 +439,6 @@ void logger_finalize(bool mustFinalize)
   }
 }
 
-} /* end namespace internal */
-} /* end namespace quest    */
-} /* end namespace axom     */
+}  // end namespace internal
+}  // end namespace quest
+}  // end namespace axom

--- a/src/axom/quest/interface/internal/QuestHelpers.cpp
+++ b/src/axom/quest/interface/internal/QuestHelpers.cpp
@@ -14,6 +14,10 @@
   #include "axom/quest/readers/PSTLReader.hpp"
 #endif
 
+#if defined(AXOM_USE_MPI) && defined(AXOM_USE_C2C)
+  #include "axom/quest/readers/PC2CReader.hpp"
+#endif
+
 #include <limits>
 
 namespace axom
@@ -346,6 +350,60 @@ int read_stl_mesh(const std::string& file, mint::Mesh*& m, MPI_Comm comm)
 
   return rc;
 }
+
+#ifdef AXOM_USE_C2C
+/*
+ * Reads in the contour mesh from the specified file.
+ */
+int read_c2c_mesh(const std::string& file,
+                  int segmentsPerPiece,
+                  mint::Mesh*& m,
+                  MPI_Comm comm)
+{
+  // NOTE: C2C meshes are always 2D
+  constexpr int DIMENSION = 2;
+  using SegmentMesh = mint::UnstructuredMesh<mint::SINGLE_SHAPE>;
+
+  // STEP 0: check input mesh pointer
+  if(m != nullptr)
+  {
+    SLIC_WARNING("supplied mesh pointer is not null!");
+    return READ_FAILED;
+  }
+
+  // STEP 1: allocate output mesh object
+  m = new SegmentMesh(DIMENSION, mint::SEGMENT);
+
+  // STEP 2: allocate reader
+  quest::C2CReader* reader = nullptr;
+  #ifdef AXOM_USE_MPI
+  reader = new quest::PC2CReader(comm);
+  #else
+  AXOM_UNUSED_VAR(comm);
+  reader = new quest::C2CReader();
+  #endif
+
+  // STEP 3: read the mesh from the STL file
+  reader->setFileName(file);
+  int rc = reader->read();
+  if(rc == READ_SUCCESS)
+  {
+    reader->getLinearMesh(static_cast<SegmentMesh*>(m), segmentsPerPiece);
+  }
+  else
+  {
+    SLIC_WARNING("reading C2C file failed, setting mesh to NULL");
+    delete m;
+    m = nullptr;
+  }
+
+  // STEP 4: delete the reader
+  delete reader;
+  reader = nullptr;
+
+  return rc;
+}
+#endif  // AXOM_USE_C2C
 
 /// Mesh Helper Methods
 

--- a/src/axom/quest/interface/internal/QuestHelpers.cpp
+++ b/src/axom/quest/interface/internal/QuestHelpers.cpp
@@ -357,6 +357,7 @@ int read_stl_mesh(const std::string& file, mint::Mesh*& m, MPI_Comm comm)
  */
 int read_c2c_mesh(const std::string& file,
                   int segmentsPerPiece,
+                  double vertexWeldThreshold,
                   mint::Mesh*& m,
                   MPI_Comm comm)
 {
@@ -385,6 +386,7 @@ int read_c2c_mesh(const std::string& file,
 
   // STEP 3: read the mesh from the STL file
   reader->setFileName(file);
+  reader->setVertexWeldingThreshold(vertexWeldThreshold);
   int rc = reader->read();
   if(rc == READ_SUCCESS)
   {

--- a/src/axom/quest/interface/internal/QuestHelpers.hpp
+++ b/src/axom/quest/interface/internal/QuestHelpers.hpp
@@ -232,13 +232,11 @@ int read_stl_mesh(const std::string& file,
 /*!
  * \brief Reads in the contour mesh from the specified file
  *
- * \param [in] file the file consisting of the surface
+ * \param [in] file the file consisting of a C2C contour defined by one or more c2c::Piece
  * \param [in] segmentsPerPiece number of segments to sample per contour Piece
  * \param [in] vertexWeldThreshold threshold for welding vertices of adjacent curves
  * \param [out] m user-supplied pointer to point to the mesh object
  * \param [in] comm the MPI communicator, only applicable when MPI is available
- *
- * \note This method currently expects the contours to be given in the C2C format
  *
  * \note The caller is responsible for properly de-allocating the mesh object
  *  that is returned by this function

--- a/src/axom/quest/interface/internal/QuestHelpers.hpp
+++ b/src/axom/quest/interface/internal/QuestHelpers.hpp
@@ -206,8 +206,7 @@ int read_stl_mesh_shared(const std::string& file,
  * \param [out] m user-supplied pointer to point to the mesh object.
  * \param [in] comm the MPI communicator, only applicable when MPI is available.
  *
- * \note This method currently expects the surface mesh to be given in STL
- *  format.
+ * \note This method currently expects the surface mesh to be given in STL format.
  *
  * \note The caller is responsible for properly de-allocating the mesh object
  *  that is returned by this function.
@@ -228,6 +227,39 @@ int read_stl_mesh_shared(const std::string& file,
 int read_stl_mesh(const std::string& file,
                   mint::Mesh*& m,
                   MPI_Comm comm = MPI_COMM_SELF);
+
+#ifdef AXOM_USE_C2C
+/*!
+ * \brief Reads in the contour mesh from the specified file.
+ *
+ * \param [in] file the file consisting of the surface
+ * \param [in] segmentsPerPiece number of segments to sample per contour Piece
+ * \param [out] m user-supplied pointer to point to the mesh object.
+ * \param [in] comm the MPI communicator, only applicable when MPI is available.
+ *
+ * \note This method currently expects the contours to be given in the C2C format.
+ *
+ * \note The caller is responsible for properly de-allocating the mesh object
+ *  that is returned by this function.
+ *
+ * \return status set to zero on success, or to a non-zero value otherwise.
+ *
+ * \pre m == nullptr
+ * \pre !file.empty()
+ *
+ * \post m != nullptr
+ * \post m->getMeshType() == mint::UNSTRUCTURED_MESH
+ * \post m->hasMixedCellTypes() == false
+ * \post m->getCellType() == mint::SEGMENT
+ *
+ * \see C2CReader
+ * \see PC2CReader
+ */
+int read_c2c_mesh(const std::string& file,
+                  int segmentsPerPiece,
+                  mint::Mesh*& m,
+                  MPI_Comm comm = MPI_COMM_SELF);
+#endif  // AXOM_USE_C2C
 
 /// @}
 

--- a/src/axom/quest/interface/internal/QuestHelpers.hpp
+++ b/src/axom/quest/interface/internal/QuestHelpers.hpp
@@ -7,20 +7,16 @@
 #define QUEST_HELPERS_HPP_
 
 // Axom includes
-#include "axom/config.hpp"  // for compile-time definitions
-
-// Mint includes
-#include "axom/mint/mesh/Mesh.hpp"  // for mint::Mesh
-
-// Quest includes
+#include "axom/config.hpp"
+#include "axom/mint/mesh/Mesh.hpp"
 #include "axom/quest/interface/internal/mpicomm_wrapper.hpp"
-#include "axom/quest/stl/STLReader.hpp"
+#include "axom/quest/readers/STLReader.hpp"
 
 // C/C++ includes
-#include <string>  // for C++ string
+#include <string>
 
 /*!
- * \file
+ * \file QuestHelpers.hpp
  *
  * \brief Helper methods that can be used across the different Quest queries.
  */

--- a/src/axom/quest/interface/internal/QuestHelpers.hpp
+++ b/src/axom/quest/interface/internal/QuestHelpers.hpp
@@ -230,19 +230,20 @@ int read_stl_mesh(const std::string& file,
 
 #ifdef AXOM_USE_C2C
 /*!
- * \brief Reads in the contour mesh from the specified file.
+ * \brief Reads in the contour mesh from the specified file
  *
  * \param [in] file the file consisting of the surface
  * \param [in] segmentsPerPiece number of segments to sample per contour Piece
- * \param [out] m user-supplied pointer to point to the mesh object.
- * \param [in] comm the MPI communicator, only applicable when MPI is available.
+ * \param [in] vertexWeldThreshold threshold for welding vertices of adjacent curves
+ * \param [out] m user-supplied pointer to point to the mesh object
+ * \param [in] comm the MPI communicator, only applicable when MPI is available
  *
- * \note This method currently expects the contours to be given in the C2C format.
+ * \note This method currently expects the contours to be given in the C2C format
  *
  * \note The caller is responsible for properly de-allocating the mesh object
- *  that is returned by this function.
+ *  that is returned by this function
  *
- * \return status set to zero on success, or to a non-zero value otherwise.
+ * \return status set to zero on success, or to a non-zero value otherwise
  *
  * \pre m == nullptr
  * \pre !file.empty()
@@ -257,6 +258,7 @@ int read_stl_mesh(const std::string& file,
  */
 int read_c2c_mesh(const std::string& file,
                   int segmentsPerPiece,
+                  double vertexWeldThreshold,
                   mint::Mesh*& m,
                   MPI_Comm comm = MPI_COMM_SELF);
 #endif  // AXOM_USE_C2C

--- a/src/axom/quest/interface/internal/QuestHelpers.hpp
+++ b/src/axom/quest/interface/internal/QuestHelpers.hpp
@@ -191,12 +191,12 @@ MPI_Aint allocate_shared_buffer(int local_rank_id,
  * \post intra_node_comm != MPI_COMM_NULL
  * \post shared_window != MPI_WIN_NULL
  */
-int read_mesh_shared(const std::string& file,
-                     MPI_Comm global_comm,
-                     unsigned char*& mesh_buffer,
-                     mint::Mesh*& m,
-                     MPI_Comm& intra_node_comm,
-                     MPI_Win& shared_window);
+int read_stl_mesh_shared(const std::string& file,
+                         MPI_Comm global_comm,
+                         unsigned char*& mesh_buffer,
+                         mint::Mesh*& m,
+                         MPI_Comm& intra_node_comm,
+                         MPI_Win& shared_window);
 #endif
 
 /*!
@@ -225,9 +225,9 @@ int read_mesh_shared(const std::string& file,
  * \see STLReader
  * \see PSTLReader
  */
-int read_mesh(const std::string& file,
-              mint::Mesh*& m,
-              MPI_Comm comm = MPI_COMM_SELF);
+int read_stl_mesh(const std::string& file,
+                  mint::Mesh*& m,
+                  MPI_Comm comm = MPI_COMM_SELF);
 
 /// @}
 

--- a/src/axom/quest/interface/python/pyQUESTmodule.cpp
+++ b/src/axom/quest/interface/python/pyQUESTmodule.cpp
@@ -26,25 +26,25 @@
 
 // splicer begin C_definition
 // splicer end C_definition
-PyObject* PY_error_obj;
+PyObject *PY_error_obj;
 // splicer begin additional_functions
 // splicer end additional_functions
 
 #ifdef AXOM_USE_MPI
-static PyObject* PY_inout_init_mpi(PyObject* SHROUD_UNUSED(self),
-                                   PyObject* args,
-                                   PyObject* kwds)
+static PyObject *PY_inout_init_mpi(PyObject *SHROUD_UNUSED(self),
+                                   PyObject *args,
+                                   PyObject *kwds)
 {
   // splicer begin function.inout_init_mpi
-  char* fileName;
+  char *fileName;
   MPI_Fint comm;
-  const char* SHT_kwlist[] = {"fileName", "comm", nullptr};
-  PyObject* SHTPy_rv = nullptr;
+  const char *SHT_kwlist[] = {"fileName", "comm", nullptr};
+  PyObject *SHTPy_rv = nullptr;
 
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "sO:inout_init",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &fileName,
                                   &comm))
     return nullptr;
@@ -52,48 +52,48 @@ static PyObject* PY_inout_init_mpi(PyObject* SHROUD_UNUSED(self),
   MPI_Comm SH_comm = MPI_Comm_f2c(comm);
   int SHCXX_rv = axom::quest::inout_init(SH_fileName, SH_comm);
   SHTPy_rv = PyInt_FromLong(SHCXX_rv);
-  return (PyObject*)SHTPy_rv;
+  return (PyObject *)SHTPy_rv;
   // splicer end function.inout_init_mpi
 }
 #endif  // ifdef AXOM_USE_MPI
 
 #ifndef AXOM_USE_MPI
-static PyObject* PY_inout_init_serial(PyObject* SHROUD_UNUSED(self),
-                                      PyObject* args,
-                                      PyObject* kwds)
+static PyObject *PY_inout_init_serial(PyObject *SHROUD_UNUSED(self),
+                                      PyObject *args,
+                                      PyObject *kwds)
 {
   // splicer begin function.inout_init_serial
-  char* fileName;
-  const char* SHT_kwlist[] = {"fileName", nullptr};
-  PyObject* SHTPy_rv = nullptr;
+  char *fileName;
+  const char *SHT_kwlist[] = {"fileName", nullptr};
+  PyObject *SHTPy_rv = nullptr;
 
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "s:inout_init",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &fileName))
     return nullptr;
   const std::string SH_fileName(fileName);
   int SHCXX_rv = axom::quest::inout_init(SH_fileName);
   SHTPy_rv = PyInt_FromLong(SHCXX_rv);
-  return (PyObject*)SHTPy_rv;
+  return (PyObject *)SHTPy_rv;
   // splicer end function.inout_init_serial
 }
 #endif  // ifndef AXOM_USE_MPI
 
 static char PY_inout_initialized__doc__[] = "documentation";
 
-static PyObject* PY_inout_initialized(PyObject* SHROUD_UNUSED(self),
-                                      PyObject* SHROUD_UNUSED(args),
-                                      PyObject* SHROUD_UNUSED(kwds))
+static PyObject *PY_inout_initialized(PyObject *SHROUD_UNUSED(self),
+                                      PyObject *SHROUD_UNUSED(args),
+                                      PyObject *SHROUD_UNUSED(kwds))
 {
   // splicer begin function.inout_initialized
-  PyObject* SHTPy_rv = nullptr;
+  PyObject *SHTPy_rv = nullptr;
 
   bool SHCXX_rv = axom::quest::inout_initialized();
   SHTPy_rv = PyBool_FromLong(SHCXX_rv);
   if(SHTPy_rv == nullptr) goto fail;
-  return (PyObject*)SHTPy_rv;
+  return (PyObject *)SHTPy_rv;
 
 fail:
   Py_XDECREF(SHTPy_rv);
@@ -101,76 +101,123 @@ fail:
   // splicer end function.inout_initialized
 }
 
+static char PY_inout_set_dimension__doc__[] = "documentation";
+
+static PyObject *PY_inout_set_dimension(PyObject *SHROUD_UNUSED(self),
+                                        PyObject *args,
+                                        PyObject *kwds)
+{
+  // splicer begin function.inout_set_dimension
+  int dim;
+  const char *SHT_kwlist[] = {"dim", nullptr};
+  PyObject *SHTPy_rv = nullptr;
+
+  if(!PyArg_ParseTupleAndKeywords(args,
+                                  kwds,
+                                  "i:inout_set_dimension",
+                                  const_cast<char **>(SHT_kwlist),
+                                  &dim))
+    return nullptr;
+  int SHCXX_rv = axom::quest::inout_set_dimension(dim);
+  SHTPy_rv = PyInt_FromLong(SHCXX_rv);
+  return (PyObject *)SHTPy_rv;
+  // splicer end function.inout_set_dimension
+}
+
 static char PY_inout_set_verbose__doc__[] = "documentation";
 
-static PyObject* PY_inout_set_verbose(PyObject* SHROUD_UNUSED(self),
-                                      PyObject* args,
-                                      PyObject* kwds)
+static PyObject *PY_inout_set_verbose(PyObject *SHROUD_UNUSED(self),
+                                      PyObject *args,
+                                      PyObject *kwds)
 {
   // splicer begin function.inout_set_verbose
   bool verbosity;
-  PyObject* SHPy_verbosity;
-  const char* SHT_kwlist[] = {"verbosity", nullptr};
-  PyObject* SHTPy_rv = nullptr;
+  PyObject *SHPy_verbosity;
+  const char *SHT_kwlist[] = {"verbosity", nullptr};
+  PyObject *SHTPy_rv = nullptr;
 
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "O!:inout_set_verbose",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &PyBool_Type,
                                   &SHPy_verbosity))
     return nullptr;
   verbosity = PyObject_IsTrue(SHPy_verbosity);
   int SHCXX_rv = axom::quest::inout_set_verbose(verbosity);
   SHTPy_rv = PyInt_FromLong(SHCXX_rv);
-  return (PyObject*)SHTPy_rv;
+  return (PyObject *)SHTPy_rv;
   // splicer end function.inout_set_verbose
 }
 
 static char PY_inout_set_vertex_weld_threshold__doc__[] = "documentation";
 
-static PyObject* PY_inout_set_vertex_weld_threshold(PyObject* SHROUD_UNUSED(self),
-                                                    PyObject* args,
-                                                    PyObject* kwds)
+static PyObject *PY_inout_set_vertex_weld_threshold(PyObject *SHROUD_UNUSED(self),
+                                                    PyObject *args,
+                                                    PyObject *kwds)
 {
   // splicer begin function.inout_set_vertex_weld_threshold
   double thresh;
-  const char* SHT_kwlist[] = {"thresh", nullptr};
-  PyObject* SHTPy_rv = nullptr;
+  const char *SHT_kwlist[] = {"thresh", nullptr};
+  PyObject *SHTPy_rv = nullptr;
 
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "d:inout_set_vertex_weld_threshold",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &thresh))
     return nullptr;
   int SHCXX_rv = axom::quest::inout_set_vertex_weld_threshold(thresh);
   SHTPy_rv = PyInt_FromLong(SHCXX_rv);
-  return (PyObject*)SHTPy_rv;
+  return (PyObject *)SHTPy_rv;
   // splicer end function.inout_set_vertex_weld_threshold
+}
+
+static char PY_inout_set_segments_per_knot_span__doc__[] = "documentation";
+
+static PyObject *PY_inout_set_segments_per_knot_span(PyObject *SHROUD_UNUSED(self),
+                                                     PyObject *args,
+                                                     PyObject *kwds)
+{
+  // splicer begin function.inout_set_segments_per_knot_span
+  int segmentsPerKnotSpan;
+  const char *SHT_kwlist[] = {"segmentsPerKnotSpan", nullptr};
+  PyObject *SHTPy_rv = nullptr;
+
+  if(!PyArg_ParseTupleAndKeywords(args,
+                                  kwds,
+                                  "i:inout_set_segments_per_knot_span",
+                                  const_cast<char **>(SHT_kwlist),
+                                  &segmentsPerKnotSpan))
+    return nullptr;
+  int SHCXX_rv =
+    axom::quest::inout_set_segments_per_knot_span(segmentsPerKnotSpan);
+  SHTPy_rv = PyInt_FromLong(SHCXX_rv);
+  return (PyObject *)SHTPy_rv;
+  // splicer end function.inout_set_segments_per_knot_span
 }
 
 static char PY_inout_evaluate_1__doc__[] = "documentation";
 
-static PyObject* PY_inout_evaluate_1(PyObject* SHROUD_UNUSED(self),
-                                     PyObject* args,
-                                     PyObject* kwds)
+static PyObject *PY_inout_evaluate_1(PyObject *SHROUD_UNUSED(self),
+                                     PyObject *args,
+                                     PyObject *kwds)
 {
   // splicer begin function.inout_evaluate
   Py_ssize_t SH_nargs = 0;
   double x;
   double y;
   double z;
-  const char* SHT_kwlist[] = {"x", "y", "z", nullptr};
+  const char *SHT_kwlist[] = {"x", "y", "z", nullptr};
   bool SHCXX_rv;
-  PyObject* SHTPy_rv = nullptr;
+  PyObject *SHTPy_rv = nullptr;
 
   if(args != nullptr) SH_nargs += PyTuple_Size(args);
   if(kwds != nullptr) SH_nargs += PyDict_Size(args);
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "dd|d:inout_evaluate",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &x,
                                   &y,
                                   &z))
@@ -189,7 +236,7 @@ static PyObject* PY_inout_evaluate_1(PyObject* SHROUD_UNUSED(self),
   }
   SHTPy_rv = PyBool_FromLong(SHCXX_rv);
   if(SHTPy_rv == nullptr) goto fail;
-  return (PyObject*)SHTPy_rv;
+  return (PyObject *)SHTPy_rv;
 
 fail:
   Py_XDECREF(SHTPy_rv);
@@ -199,49 +246,49 @@ fail:
 
 static char PY_inout_get_dimension__doc__[] = "documentation";
 
-static PyObject* PY_inout_get_dimension(PyObject* SHROUD_UNUSED(self),
-                                        PyObject* SHROUD_UNUSED(args),
-                                        PyObject* SHROUD_UNUSED(kwds))
+static PyObject *PY_inout_get_dimension(PyObject *SHROUD_UNUSED(self),
+                                        PyObject *SHROUD_UNUSED(args),
+                                        PyObject *SHROUD_UNUSED(kwds))
 {
   // splicer begin function.inout_get_dimension
-  PyObject* SHTPy_rv = nullptr;
+  PyObject *SHTPy_rv = nullptr;
 
   int SHCXX_rv = axom::quest::inout_get_dimension();
   SHTPy_rv = PyInt_FromLong(SHCXX_rv);
-  return (PyObject*)SHTPy_rv;
+  return (PyObject *)SHTPy_rv;
   // splicer end function.inout_get_dimension
 }
 
 static char PY_inout_finalize__doc__[] = "documentation";
 
-static PyObject* PY_inout_finalize(PyObject* SHROUD_UNUSED(self),
-                                   PyObject* SHROUD_UNUSED(args),
-                                   PyObject* SHROUD_UNUSED(kwds))
+static PyObject *PY_inout_finalize(PyObject *SHROUD_UNUSED(self),
+                                   PyObject *SHROUD_UNUSED(args),
+                                   PyObject *SHROUD_UNUSED(kwds))
 {
   // splicer begin function.inout_finalize
-  PyObject* SHTPy_rv = nullptr;
+  PyObject *SHTPy_rv = nullptr;
 
   int SHCXX_rv = axom::quest::inout_finalize();
   SHTPy_rv = PyInt_FromLong(SHCXX_rv);
-  return (PyObject*)SHTPy_rv;
+  return (PyObject *)SHTPy_rv;
   // splicer end function.inout_finalize
 }
 
 #ifdef AXOM_USE_MPI
-static PyObject* PY_signed_distance_init_mpi(PyObject* SHROUD_UNUSED(self),
-                                             PyObject* args,
-                                             PyObject* kwds)
+static PyObject *PY_signed_distance_init_mpi(PyObject *SHROUD_UNUSED(self),
+                                             PyObject *args,
+                                             PyObject *kwds)
 {
   // splicer begin function.signed_distance_init_mpi
-  char* file;
+  char *file;
   MPI_Fint comm;
-  const char* SHT_kwlist[] = {"file", "comm", nullptr};
-  PyObject* SHTPy_rv = nullptr;
+  const char *SHT_kwlist[] = {"file", "comm", nullptr};
+  PyObject *SHTPy_rv = nullptr;
 
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "sO:signed_distance_init",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &file,
                                   &comm))
     return nullptr;
@@ -249,48 +296,48 @@ static PyObject* PY_signed_distance_init_mpi(PyObject* SHROUD_UNUSED(self),
   MPI_Comm SH_comm = MPI_Comm_f2c(comm);
   int SHCXX_rv = axom::quest::signed_distance_init(SH_file, SH_comm);
   SHTPy_rv = PyInt_FromLong(SHCXX_rv);
-  return (PyObject*)SHTPy_rv;
+  return (PyObject *)SHTPy_rv;
   // splicer end function.signed_distance_init_mpi
 }
 #endif  // ifdef AXOM_USE_MPI
 
 #ifndef AXOM_USE_MPI
-static PyObject* PY_signed_distance_init_serial(PyObject* SHROUD_UNUSED(self),
-                                                PyObject* args,
-                                                PyObject* kwds)
+static PyObject *PY_signed_distance_init_serial(PyObject *SHROUD_UNUSED(self),
+                                                PyObject *args,
+                                                PyObject *kwds)
 {
   // splicer begin function.signed_distance_init_serial
-  char* file;
-  const char* SHT_kwlist[] = {"file", nullptr};
-  PyObject* SHTPy_rv = nullptr;
+  char *file;
+  const char *SHT_kwlist[] = {"file", nullptr};
+  PyObject *SHTPy_rv = nullptr;
 
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "s:signed_distance_init",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &file))
     return nullptr;
   const std::string SH_file(file);
   int SHCXX_rv = axom::quest::signed_distance_init(SH_file);
   SHTPy_rv = PyInt_FromLong(SHCXX_rv);
-  return (PyObject*)SHTPy_rv;
+  return (PyObject *)SHTPy_rv;
   // splicer end function.signed_distance_init_serial
 }
 #endif  // ifndef AXOM_USE_MPI
 
 static char PY_signed_distance_initialized__doc__[] = "documentation";
 
-static PyObject* PY_signed_distance_initialized(PyObject* SHROUD_UNUSED(self),
-                                                PyObject* SHROUD_UNUSED(args),
-                                                PyObject* SHROUD_UNUSED(kwds))
+static PyObject *PY_signed_distance_initialized(PyObject *SHROUD_UNUSED(self),
+                                                PyObject *SHROUD_UNUSED(args),
+                                                PyObject *SHROUD_UNUSED(kwds))
 {
   // splicer begin function.signed_distance_initialized
-  PyObject* SHTPy_rv = nullptr;
+  PyObject *SHTPy_rv = nullptr;
 
   bool SHCXX_rv = axom::quest::signed_distance_initialized();
   SHTPy_rv = PyBool_FromLong(SHCXX_rv);
   if(SHTPy_rv == nullptr) goto fail;
-  return (PyObject*)SHTPy_rv;
+  return (PyObject *)SHTPy_rv;
 
 fail:
   Py_XDECREF(SHTPy_rv);
@@ -300,18 +347,18 @@ fail:
 
 static char PY_signed_distance_set_dimension__doc__[] = "documentation";
 
-static PyObject* PY_signed_distance_set_dimension(PyObject* SHROUD_UNUSED(self),
-                                                  PyObject* args,
-                                                  PyObject* kwds)
+static PyObject *PY_signed_distance_set_dimension(PyObject *SHROUD_UNUSED(self),
+                                                  PyObject *args,
+                                                  PyObject *kwds)
 {
   // splicer begin function.signed_distance_set_dimension
   int dim;
-  const char* SHT_kwlist[] = {"dim", nullptr};
+  const char *SHT_kwlist[] = {"dim", nullptr};
 
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "i:signed_distance_set_dimension",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &dim))
     return nullptr;
   axom::quest::signed_distance_set_dimension(dim);
@@ -321,19 +368,19 @@ static PyObject* PY_signed_distance_set_dimension(PyObject* SHROUD_UNUSED(self),
 
 static char PY_signed_distance_set_closed_surface__doc__[] = "documentation";
 
-static PyObject* PY_signed_distance_set_closed_surface(PyObject* SHROUD_UNUSED(self),
-                                                       PyObject* args,
-                                                       PyObject* kwds)
+static PyObject *PY_signed_distance_set_closed_surface(PyObject *SHROUD_UNUSED(self),
+                                                       PyObject *args,
+                                                       PyObject *kwds)
 {
   // splicer begin function.signed_distance_set_closed_surface
   bool status;
-  PyObject* SHPy_status;
-  const char* SHT_kwlist[] = {"status", nullptr};
+  PyObject *SHPy_status;
+  const char *SHT_kwlist[] = {"status", nullptr};
 
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "O!:signed_distance_set_closed_surface",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &PyBool_Type,
                                   &SHPy_status))
     return nullptr;
@@ -345,19 +392,19 @@ static PyObject* PY_signed_distance_set_closed_surface(PyObject* SHROUD_UNUSED(s
 
 static char PY_signed_distance_set_compute_signs__doc__[] = "documentation";
 
-static PyObject* PY_signed_distance_set_compute_signs(PyObject* SHROUD_UNUSED(self),
-                                                      PyObject* args,
-                                                      PyObject* kwds)
+static PyObject *PY_signed_distance_set_compute_signs(PyObject *SHROUD_UNUSED(self),
+                                                      PyObject *args,
+                                                      PyObject *kwds)
 {
   // splicer begin function.signed_distance_set_compute_signs
   bool computeSign;
-  PyObject* SHPy_computeSign;
-  const char* SHT_kwlist[] = {"computeSign", nullptr};
+  PyObject *SHPy_computeSign;
+  const char *SHT_kwlist[] = {"computeSign", nullptr};
 
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "O!:signed_distance_set_compute_signs",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &PyBool_Type,
                                   &SHPy_computeSign))
     return nullptr;
@@ -369,18 +416,18 @@ static PyObject* PY_signed_distance_set_compute_signs(PyObject* SHROUD_UNUSED(se
 
 static char PY_signed_distance_set_max_levels__doc__[] = "documentation";
 
-static PyObject* PY_signed_distance_set_max_levels(PyObject* SHROUD_UNUSED(self),
-                                                   PyObject* args,
-                                                   PyObject* kwds)
+static PyObject *PY_signed_distance_set_max_levels(PyObject *SHROUD_UNUSED(self),
+                                                   PyObject *args,
+                                                   PyObject *kwds)
 {
   // splicer begin function.signed_distance_set_max_levels
   int maxLevels;
-  const char* SHT_kwlist[] = {"maxLevels", nullptr};
+  const char *SHT_kwlist[] = {"maxLevels", nullptr};
 
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "i:signed_distance_set_max_levels",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &maxLevels))
     return nullptr;
   axom::quest::signed_distance_set_max_levels(maxLevels);
@@ -390,18 +437,18 @@ static PyObject* PY_signed_distance_set_max_levels(PyObject* SHROUD_UNUSED(self)
 
 static char PY_signed_distance_set_max_occupancy__doc__[] = "documentation";
 
-static PyObject* PY_signed_distance_set_max_occupancy(PyObject* SHROUD_UNUSED(self),
-                                                      PyObject* args,
-                                                      PyObject* kwds)
+static PyObject *PY_signed_distance_set_max_occupancy(PyObject *SHROUD_UNUSED(self),
+                                                      PyObject *args,
+                                                      PyObject *kwds)
 {
   // splicer begin function.signed_distance_set_max_occupancy
   int maxOccupancy;
-  const char* SHT_kwlist[] = {"maxOccupancy", nullptr};
+  const char *SHT_kwlist[] = {"maxOccupancy", nullptr};
 
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "i:signed_distance_set_max_occupancy",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &maxOccupancy))
     return nullptr;
   axom::quest::signed_distance_set_max_occupancy(maxOccupancy);
@@ -411,19 +458,19 @@ static PyObject* PY_signed_distance_set_max_occupancy(PyObject* SHROUD_UNUSED(se
 
 static char PY_signed_distance_set_verbose__doc__[] = "documentation";
 
-static PyObject* PY_signed_distance_set_verbose(PyObject* SHROUD_UNUSED(self),
-                                                PyObject* args,
-                                                PyObject* kwds)
+static PyObject *PY_signed_distance_set_verbose(PyObject *SHROUD_UNUSED(self),
+                                                PyObject *args,
+                                                PyObject *kwds)
 {
   // splicer begin function.signed_distance_set_verbose
   bool status;
-  PyObject* SHPy_status;
-  const char* SHT_kwlist[] = {"status", nullptr};
+  PyObject *SHPy_status;
+  const char *SHT_kwlist[] = {"status", nullptr};
 
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "O!:signed_distance_set_verbose",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &PyBool_Type,
                                   &SHPy_status))
     return nullptr;
@@ -435,19 +482,19 @@ static PyObject* PY_signed_distance_set_verbose(PyObject* SHROUD_UNUSED(self),
 
 static char PY_signed_distance_use_shared_memory__doc__[] = "documentation";
 
-static PyObject* PY_signed_distance_use_shared_memory(PyObject* SHROUD_UNUSED(self),
-                                                      PyObject* args,
-                                                      PyObject* kwds)
+static PyObject *PY_signed_distance_use_shared_memory(PyObject *SHROUD_UNUSED(self),
+                                                      PyObject *args,
+                                                      PyObject *kwds)
 {
   // splicer begin function.signed_distance_use_shared_memory
   bool status;
-  PyObject* SHPy_status;
-  const char* SHT_kwlist[] = {"status", nullptr};
+  PyObject *SHPy_status;
+  const char *SHT_kwlist[] = {"status", nullptr};
 
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "O!:signed_distance_use_shared_memory",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &PyBool_Type,
                                   &SHPy_status))
     return nullptr;
@@ -459,36 +506,36 @@ static PyObject* PY_signed_distance_use_shared_memory(PyObject* SHROUD_UNUSED(se
 
 static char PY_signed_distance_evaluate__doc__[] = "documentation";
 
-static PyObject* PY_signed_distance_evaluate(PyObject* SHROUD_UNUSED(self),
-                                             PyObject* args,
-                                             PyObject* kwds)
+static PyObject *PY_signed_distance_evaluate(PyObject *SHROUD_UNUSED(self),
+                                             PyObject *args,
+                                             PyObject *kwds)
 {
   // splicer begin function.signed_distance_evaluate
   double x;
   double y;
   double z;
-  const char* SHT_kwlist[] = {"x", "y", "z", nullptr};
-  PyObject* SHTPy_rv = nullptr;
+  const char *SHT_kwlist[] = {"x", "y", "z", nullptr};
+  PyObject *SHTPy_rv = nullptr;
 
   if(!PyArg_ParseTupleAndKeywords(args,
                                   kwds,
                                   "ddd:signed_distance_evaluate",
-                                  const_cast<char**>(SHT_kwlist),
+                                  const_cast<char **>(SHT_kwlist),
                                   &x,
                                   &y,
                                   &z))
     return nullptr;
   double SHCXX_rv = axom::quest::signed_distance_evaluate(x, y, z);
   SHTPy_rv = PyFloat_FromDouble(SHCXX_rv);
-  return (PyObject*)SHTPy_rv;
+  return (PyObject *)SHTPy_rv;
   // splicer end function.signed_distance_evaluate
 }
 
 static char PY_signed_distance_finalize__doc__[] = "documentation";
 
-static PyObject* PY_signed_distance_finalize(PyObject* SHROUD_UNUSED(self),
-                                             PyObject* SHROUD_UNUSED(args),
-                                             PyObject* SHROUD_UNUSED(kwds))
+static PyObject *PY_signed_distance_finalize(PyObject *SHROUD_UNUSED(self),
+                                             PyObject *SHROUD_UNUSED(args),
+                                             PyObject *SHROUD_UNUSED(kwds))
 {
   // splicer begin function.signed_distance_finalize
   axom::quest::signed_distance_finalize();
@@ -498,13 +545,13 @@ static PyObject* PY_signed_distance_finalize(PyObject* SHROUD_UNUSED(self),
 
 static char PY_inout_init__doc__[] = "documentation";
 
-static PyObject* PY_inout_init(PyObject* self, PyObject* args, PyObject* kwds)
+static PyObject *PY_inout_init(PyObject *self, PyObject *args, PyObject *kwds)
 {
   // splicer begin function.inout_init
   Py_ssize_t SHT_nargs = 0;
   if(args != nullptr) SHT_nargs += PyTuple_Size(args);
   if(kwds != nullptr) SHT_nargs += PyDict_Size(args);
-  PyObject* rvobj;
+  PyObject *rvobj;
 #ifdef AXOM_USE_MPI
   if(SHT_nargs == 2)
   {
@@ -542,15 +589,15 @@ static PyObject* PY_inout_init(PyObject* self, PyObject* args, PyObject* kwds)
 
 static char PY_signed_distance_init__doc__[] = "documentation";
 
-static PyObject* PY_signed_distance_init(PyObject* self,
-                                         PyObject* args,
-                                         PyObject* kwds)
+static PyObject *PY_signed_distance_init(PyObject *self,
+                                         PyObject *args,
+                                         PyObject *kwds)
 {
   // splicer begin function.signed_distance_init
   Py_ssize_t SHT_nargs = 0;
   if(args != nullptr) SHT_nargs += PyTuple_Size(args);
   if(kwds != nullptr) SHT_nargs += PyDict_Size(args);
-  PyObject* rvobj;
+  PyObject *rvobj;
 #ifdef AXOM_USE_MPI
   if(SHT_nargs == 2)
   {
@@ -590,6 +637,10 @@ static PyMethodDef PY_methods[] = {
    (PyCFunction)PY_inout_initialized,
    METH_NOARGS,
    PY_inout_initialized__doc__},
+  {"inout_set_dimension",
+   (PyCFunction)PY_inout_set_dimension,
+   METH_VARARGS | METH_KEYWORDS,
+   PY_inout_set_dimension__doc__},
   {"inout_set_verbose",
    (PyCFunction)PY_inout_set_verbose,
    METH_VARARGS | METH_KEYWORDS,
@@ -598,6 +649,10 @@ static PyMethodDef PY_methods[] = {
    (PyCFunction)PY_inout_set_vertex_weld_threshold,
    METH_VARARGS | METH_KEYWORDS,
    PY_inout_set_vertex_weld_threshold__doc__},
+  {"inout_set_segments_per_knot_span",
+   (PyCFunction)PY_inout_set_segments_per_knot_span,
+   METH_VARARGS | METH_KEYWORDS,
+   PY_inout_set_segments_per_knot_span__doc__},
   {"inout_evaluate",
    (PyCFunction)PY_inout_evaluate_1,
    METH_VARARGS | METH_KEYWORDS,
@@ -669,24 +724,24 @@ static char PY__doc__[] = "library documentation";
 
 struct module_state
 {
-  PyObject* error;
+  PyObject *error;
 };
 
 #if PY_MAJOR_VERSION >= 3
-  #define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+  #define GETSTATE(m) ((struct module_state *)PyModule_GetState(m))
 #else
   #define GETSTATE(m) (&_state)
 static struct module_state _state;
 #endif
 
 #if PY_MAJOR_VERSION >= 3
-static int quest_traverse(PyObject* m, visitproc visit, void* arg)
+static int quest_traverse(PyObject *m, visitproc visit, void *arg)
 {
   Py_VISIT(GETSTATE(m)->error);
   return 0;
 }
 
-static int quest_clear(PyObject* m)
+static int quest_clear(PyObject *m)
 {
   Py_CLEAR(GETSTATE(m)->error);
   return 0;
@@ -718,8 +773,8 @@ PyInit_quest(void)
 initquest(void)
 #endif
 {
-  PyObject* m = nullptr;
-  const char* error_name = "quest.Error";
+  PyObject *m = nullptr;
+  const char *error_name = "quest.Error";
 
   // splicer begin C_init_locals
   // splicer end C_init_locals
@@ -731,13 +786,13 @@ initquest(void)
   m = Py_InitModule4("quest",
                      PY_methods,
                      PY__doc__,
-                     (PyObject*)nullptr,
+                     (PyObject *)nullptr,
                      PYTHON_API_VERSION);
 #endif
   if(m == nullptr) return RETVAL;
-  struct module_state* st = GETSTATE(m);
+  struct module_state *st = GETSTATE(m);
 
-  PY_error_obj = PyErr_NewException((char*)error_name, nullptr, nullptr);
+  PY_error_obj = PyErr_NewException((char *)error_name, nullptr, nullptr);
   if(PY_error_obj == nullptr) return RETVAL;
   st->error = PY_error_obj;
   PyModule_AddObject(m, "Error", st->error);

--- a/src/axom/quest/interface/python/pyQUESTmodule.hpp
+++ b/src/axom/quest/interface/python/pyQUESTmodule.hpp
@@ -16,7 +16,7 @@
 // splicer begin header.C_declaration
 // splicer end header.C_declaration
 
-extern PyObject* PY_error_obj;
+extern PyObject *PY_error_obj;
 
 #if PY_MAJOR_VERSION >= 3
 extern "C" PyMODINIT_FUNC PyInit_quest(void);

--- a/src/axom/quest/interface/quest_shroud.yaml
+++ b/src/axom/quest/interface/quest_shroud.yaml
@@ -49,8 +49,10 @@ declarations:
 
       - decl: bool inout_initialized()
 
+      - decl: int inout_set_dimension( int dim )
       - decl: int inout_set_verbose( bool verbosity )
       - decl: int inout_set_vertex_weld_threshold( double thresh )
+      - decl: int inout_set_segments_per_knot_span( int segmentsPerKnotSpan )
 
       - decl: bool inout_evaluate(double x, double y, double z=0.0)
 

--- a/src/axom/quest/interface/signed_distance.cpp
+++ b/src/axom/quest/interface/signed_distance.cpp
@@ -104,16 +104,16 @@ int signed_distance_init(const std::string& file, MPI_Comm comm)
 
   if(Parameters.use_shared_memory)
   {
-    rc = internal::read_mesh_shared(file,
-                                    comm,
-                                    s_shared_mesh_buffer,
-                                    s_surface_mesh,
-                                    s_intra_node_comm,
-                                    s_window);
+    rc = internal::read_stl_mesh_shared(file,
+                                        comm,
+                                        s_shared_mesh_buffer,
+                                        s_surface_mesh,
+                                        s_intra_node_comm,
+                                        s_window);
   }
   else
   {
-    rc = internal::read_mesh(file, s_surface_mesh, comm);
+    rc = internal::read_stl_mesh(file, s_surface_mesh, comm);
   }
 
 #else
@@ -122,7 +122,7 @@ int signed_distance_init(const std::string& file, MPI_Comm comm)
                   "Shared memory requires MPI3 and building Axom with "
                   "AXOM_USE_MPI3 set to ON");
 
-  rc = internal::read_mesh(file, s_surface_mesh, comm);
+  rc = internal::read_stl_mesh(file, s_surface_mesh, comm);
 #endif
 
   if(rc != 0)

--- a/src/axom/quest/readers/C2CReader.cpp
+++ b/src/axom/quest/readers/C2CReader.cpp
@@ -1,0 +1,302 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/quest/readers/C2CReader.hpp"
+
+// This file is only applicable if axom was configured with the C2C library
+#ifdef AXOM_USE_C2C
+
+  #include "axom/core.hpp"
+  #include "axom/slic.hpp"
+  #include "axom/primal.hpp"
+  #include "fmt/fmt.hpp"
+
+namespace axom
+{
+namespace quest
+{
+/// returns the linear interpolation of \a A and \a B at \a t. i.e. (1-t)A+tB
+inline double lerp(double A, double B, double t) { return (1 - t) * A + t * B; }
+
+/*!
+ * \brief Helper class for interpolating points on a NURBS curve
+ *
+ * This class was adapted from a similar class in the C2C library's testing framework.
+ * The algorithms are adapted from: Piegl and Tiller's "The NURBS Book", 2nd Ed,  (Springer, 1997) 
+ */
+struct NURBSInterpolator
+{
+  using BasisVector = std::vector<double>;
+  using PointType = primal::Point<double, 2>;
+
+  NURBSInterpolator(const c2c::NURBSData& curve) : m_curve(curve)
+  {
+    int p = m_curve.order - 1;
+    int knotSize = m_curve.knots.size();
+    SLIC_ASSERT(p >= 1);
+    SLIC_ASSERT(knotSize >= 2 * p);
+  }
+
+  /*!
+   * \brief Checks that the knots of the NURBS curve are closed
+   *
+   * The knots vector is closed when it begins with \a m_curve.order equal knot values
+   * and ends with the same number of equal knot values
+   */
+  bool isClosed(double EPS = 1E-8) const
+  {
+    using axom::utilities::isNearlyEqual;
+    const auto& U = m_curve.knots;
+
+    int p = m_curve.order - 1;
+
+    const double startKnot = U[0];
+    for(int i = 1; i <= p; ++i)
+    {
+      if(!isNearlyEqual(startKnot, U[i], EPS))
+      {
+        return false;
+      }
+    }
+
+    const int endIndex = U.size() - 1;
+    const double endKnot = U[endIndex];
+    for(int i = 1; i <= p; ++i)
+    {
+      const int index = endIndex - p - 1;
+      if(!isNearlyEqual(endKnot, U[index], EPS))
+      {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  double startParameter() const { return m_curve.knots[0]; }
+  double endParameter() const
+  {
+    return m_curve.knots[m_curve.knots.size() - 1];
+  }
+
+  /*!
+   * \brief Finds the index of the knot span containing parameter \a u
+   * 
+   * Implementation adapted from Algorithm A2.1 on page 68 of "The NURBS Book"
+   */
+  int findSpan(double u) const
+  {
+    const auto& U = m_curve.knots;
+    const int knotSize = U.size();
+    const int p = m_curve.order - 1;
+    const int n = knotSize - 1 - p - 1;
+
+    if(U[n] <= u && u <= U[n + 1])
+    {
+      return n;
+    }
+
+    // perform binary search on the knots
+    int low = p;
+    int high = n + 1;
+    int mid = (low + high) / 2;
+    while(u < U[mid] || u >= U[mid + 1])
+    {
+      (u < U[mid]) ? high = mid : low = mid;
+      mid = (low + high) / 2;
+    }
+    return mid;
+  }
+
+  /*!
+   * \brief Evaluates the B-spline basis functions for span \a span at parameter value \a u 
+   * 
+   * Implementation adapted from Algorithm A2.2 on page 70 of "The NURBS Book".
+   */
+  BasisVector calculateBasisFunctions(int span, double u)
+  {
+    const int p = m_curve.order - 1;
+    const auto& U = m_curve.knots;
+
+    BasisVector N(p + 1);
+    BasisVector left(p + 1);
+    BasisVector right(p + 1);
+
+    // Note: This implementation avoids division by zero and redundant computation
+    // that might arise from a direct implementation of the recurrence relation
+    // for basis functions. See "The NURBS Book" for details.
+    N[0] = 1.0;
+    for(int j = 1; j <= p; ++j)
+    {
+      left[j] = u - U[span + 1 - j];
+      right[j] = U[span + j] - u;
+      double saved = 0.0;
+      for(int r = 0; r < j; ++r)
+      {
+        double temp = N[r] / (right[r + 1] + left[j - r]);
+        N[r] = saved + right[r + 1] * temp;
+        saved = left[j - r] * temp;
+      }
+      N[j] = saved;
+    }
+    return N;
+  }
+
+  /*!
+   * \brief Finds the point on the curve at parameter \a u
+   *
+   * Adapted from Algorithm A4.1 on page 124 of "The NURBS Book"
+   */
+  PointType at(double u)
+  {
+    using GrassmanPoint = primal::Point<double, 3>;
+    GrassmanPoint cw {0.0};
+
+    const auto span = findSpan(u);
+    const auto N = calculateBasisFunctions(span, u);
+    const int p = m_curve.order - 1;
+    for(int j = 0; j <= p; ++j)
+    {
+      const int offset = span - p + j;
+      const double weight = m_curve.weights[offset];
+      const auto& controlPoint = m_curve.controlPoints[offset];
+
+      cw[0] += N[j] * weight * controlPoint.getR().getValue();
+      cw[1] += N[j] * weight * controlPoint.getZ().getValue();
+      cw[2] += N[j] * weight;
+    }
+
+    // Return projected point
+    // All units should have been normalized by c2c::toNurbs(piece, units)
+    return PointType {cw[0] / cw[2], cw[1] / cw[2]};
+  }
+
+private:
+  const c2c::NURBSData& m_curve;
+};
+
+int C2CReader::read()
+{
+  SLIC_WARNING_IF(m_fileName.empty(), "Missing a filename in C2CReader::read()");
+
+  using axom::utilities::string::endsWith;
+
+  int ret = 1;
+
+  if(endsWith(m_fileName, ".contour"))
+  {
+    ret = readContour();
+  }
+  else if(endsWith(m_fileName, ".assembly"))
+  {
+    SLIC_WARNING("Input was an assembly! This is not currently supported");
+  }
+  else
+  {
+    SLIC_WARNING("Not a valid c2c file");
+  }
+
+  return ret;
+}
+
+int C2CReader::readContour()
+{
+  c2c::Contour contour = c2c::parseContour(m_fileName);
+
+  SLIC_INFO(
+    fmt::format("Loading contour with {} pieces", contour.getNumEntries()));
+
+  for(auto* piece : contour.getPieces())
+  {
+    m_nurbsData.emplace_back(c2c::toNurbs(*piece, m_lengthUnit));
+  }
+
+  return 0;
+}
+
+void C2CReader::log()
+{
+  std::stringstream sstr;
+
+  sstr << fmt::format("The contour has {} pieces\n", m_nurbsData.size());
+
+  int index = 0;
+  for(const auto& nurbs : m_nurbsData)
+  {
+    sstr << fmt::format("Piece {}\n{{", index);
+    sstr << fmt::format("\torder: {}\n", nurbs.order);
+    sstr << fmt::format("\tknots: {}\n", fmt::join(nurbs.knots, " "));
+    sstr << fmt::format("\tweights: {}\n", fmt::join(nurbs.weights, " "));
+    sstr << fmt::format("\tcontrol points: {}\n",
+                        fmt::join(nurbs.controlPoints, " "));
+    sstr << "}\n";
+    ++index;
+  }
+
+  SLIC_INFO(sstr.str());
+}
+
+void C2CReader::getLinearMesh(mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh,
+                              int segmentsPerPiece)
+{
+  // Sanity checks
+  SLIC_ERROR_IF(mesh == nullptr, "supplied mesh is null!");
+  SLIC_ERROR_IF(mesh->getDimension() != 2, "C2C reader expects a 2D mesh!");
+  SLIC_ERROR_IF(mesh->getCellType() != mint::SEGMENT,
+                "C2C reader expects a segment mesh!");
+  SLIC_ERROR_IF(segmentsPerPiece < 1,
+                "C2C reader: Need at least one sample per NURBs span");
+
+  using PointType = primal::Point<double, 2>;
+  using PointsArray = std::vector<PointType>;
+
+  for(const auto& nurbs : m_nurbsData)
+  {
+    NURBSInterpolator interpolator(nurbs);
+
+    PointsArray pts;
+
+    // Generate points on the curve
+    {
+      pts.reserve(segmentsPerPiece + 1);
+
+      const double startParameter = interpolator.startParameter();
+      const double endParameter = interpolator.endParameter();
+
+      double denom = static_cast<double>(segmentsPerPiece);
+      for(int i = 0; i <= segmentsPerPiece; ++i)
+      {
+        double u = lerp(startParameter, endParameter, i / denom);
+        pts.emplace_back(interpolator.at(u));
+      }
+    }
+
+    // Add the new points and segments to the mesh
+    {
+      const int startNode = mesh->getNumberOfNodes();
+      const int numNewNodes = pts.size();
+      mesh->reserveNodes(startNode + numNewNodes);
+
+      for(int i = 0; i < numNewNodes; ++i)
+      {
+        mesh->appendNode(pts[i][0], pts[i][1]);
+      }
+
+      const int startCell = mesh->getNumberOfCells();
+      const int numNewSegments = pts.size() - 1;
+      mesh->reserveCells(startCell + numNewSegments);
+      for(int i = 0; i < numNewSegments; ++i)
+      {
+        IndexType seg[2] = {startNode + i, startNode + i + 1};
+        mesh->appendCell(seg, mint::SEGMENT);
+      }
+    }
+  }
+}
+
+#endif  // AXOM_USE_C2C
+
+}  // end namespace quest
+}  // end namespace axom

--- a/src/axom/quest/readers/C2CReader.cpp
+++ b/src/axom/quest/readers/C2CReader.cpp
@@ -43,6 +43,7 @@ struct NURBSInterpolator
     computeSpanIntervals(EPS);
   }
 
+  // Helper function to compute the start and end index of each knot span
   void computeSpanIntervals(double EPS)
   {
     using axom::utilities::isNearlyEqual;
@@ -55,11 +56,8 @@ struct NURBSInterpolator
     {
       const double left = U[i];
       const double right = U[i + 1];
-      SLIC_INFO(fmt::format("At index {}: left {}, right {}", i, left, right));
-
       if(!isNearlyEqual(left, right, EPS))
       {
-        SLIC_INFO(fmt::format("\t Added interval [{},{}]", left, right));
         m_spanIntervals.push_back(std::make_pair(left, right));
       }
     }

--- a/src/axom/quest/readers/C2CReader.cpp
+++ b/src/axom/quest/readers/C2CReader.cpp
@@ -43,7 +43,7 @@ struct NURBSInterpolator
     computeSpanIntervals(EPS);
   }
 
-  // Helper function to compute the start and end index of each knot span
+  /// Helper function to compute the start and end parametric coordinates of each knot span
   void computeSpanIntervals(double EPS)
   {
     using axom::utilities::isNearlyEqual;
@@ -106,6 +106,7 @@ struct NURBSInterpolator
     const bool inRange = span >= 0 && span < numSpans();
     return inRange ? m_spanIntervals[span].first : m_curve.knots[0];
   }
+
   double endParameter(int span = -1) const
   {
     const bool inRange = span >= 0 && span < numSpans();

--- a/src/axom/quest/readers/C2CReader.cpp
+++ b/src/axom/quest/readers/C2CReader.cpp
@@ -296,7 +296,7 @@ void C2CReader::getLinearMesh(mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh,
   }
 }
 
-#endif  // AXOM_USE_C2C
-
 }  // end namespace quest
 }  // end namespace axom
+
+#endif  // AXOM_USE_C2C

--- a/src/axom/quest/readers/C2CReader.cpp
+++ b/src/axom/quest/readers/C2CReader.cpp
@@ -177,6 +177,8 @@ private:
   const c2c::NURBSData& m_curve;
 };
 
+void C2CReader::clear() { m_nurbsData.clear(); }
+
 int C2CReader::read()
 {
   SLIC_WARNING_IF(m_fileName.empty(), "Missing a filename in C2CReader::read()");

--- a/src/axom/quest/readers/C2CReader.cpp
+++ b/src/axom/quest/readers/C2CReader.cpp
@@ -5,13 +5,14 @@
 
 #include "axom/quest/readers/C2CReader.hpp"
 
-// This file is only applicable if axom was configured with the C2C library
-#ifdef AXOM_USE_C2C
+#ifndef AXOM_USE_C2C
+  #error C2CReader should only be included when Axom is configured with C2C
+#endif
 
-  #include "axom/core.hpp"
-  #include "axom/slic.hpp"
-  #include "axom/primal.hpp"
-  #include "fmt/fmt.hpp"
+#include "axom/core.hpp"
+#include "axom/slic.hpp"
+#include "axom/primal.hpp"
+#include "fmt/fmt.hpp"
 
 namespace axom
 {
@@ -300,5 +301,3 @@ void C2CReader::getLinearMesh(mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh,
 
 }  // end namespace quest
 }  // end namespace axom
-
-#endif  // AXOM_USE_C2C

--- a/src/axom/quest/readers/C2CReader.hpp
+++ b/src/axom/quest/readers/C2CReader.hpp
@@ -39,6 +39,9 @@ public:
 
   void setLengthUnit(c2c::LengthUnit lengthUnit) { m_lengthUnit = lengthUnit; }
 
+  /// Clears data associated with this reader
+  void clear();
+
   /*!
    * \brief Read the contour file provided by \a setFileName()
    * 
@@ -59,14 +62,14 @@ public:
 protected:
   int readContour();
 
-private:
+protected:
   std::string m_fileName;
   c2c::LengthUnit m_lengthUnit {c2c::LengthUnit::cm};
 
   std::vector<c2c::NURBSData> m_nurbsData;
 };
 
-}  // end namespace quest
+}  // namespace quest
 }  // namespace axom
 
 #endif  // AXOM_USE_C2C

--- a/src/axom/quest/readers/C2CReader.hpp
+++ b/src/axom/quest/readers/C2CReader.hpp
@@ -8,14 +8,15 @@
 
 #include "axom/config.hpp"
 
-// This file is only applicable if axom was configured with the C2C library
-#ifdef AXOM_USE_C2C
+#ifndef AXOM_USE_C2C
+  #error C2CReader should only be included when Axom is configured with C2C
+#endif
 
-  #include "axom/mint.hpp"
-  #include "c2c/C2C.hpp"
+#include "axom/mint.hpp"
+#include "c2c/C2C.hpp"
 
-  #include <string>
-  #include <vector>
+#include <string>
+#include <vector>
 
 namespace axom
 {
@@ -71,7 +72,5 @@ protected:
 
 }  // namespace quest
 }  // namespace axom
-
-#endif  // AXOM_USE_C2C
 
 #endif  // QUEST_C2CREADER_HPP_

--- a/src/axom/quest/readers/C2CReader.hpp
+++ b/src/axom/quest/readers/C2CReader.hpp
@@ -36,9 +36,17 @@ public:
 
   virtual ~C2CReader() = default;
 
+  /// Sets the name of the contour file to load. Must be called before \a read()
   void setFileName(const std::string& fileName) { m_fileName = fileName; }
 
+  /// Sets the length unit. All lengths will be converted to this unit when reading the mesh
   void setLengthUnit(c2c::LengthUnit lengthUnit) { m_lengthUnit = lengthUnit; }
+
+  /// Sets the threshold for welding vertices of adjacent Pieces of curves
+  void setVertexWeldingThreshold(double thresh)
+  {
+    m_vertexWeldThreshold = thresh;
+  }
 
   /// Clears data associated with this reader
   void clear();
@@ -54,8 +62,8 @@ public:
   virtual void log();
 
   /*!
-   * \brief Projects high-order NURBS contours onto a linear mesh using \a segmentsPerPiece linear segments
-   * per \a Piece of the contour
+   * \brief Projects high-order NURBS contours onto a linear mesh using \a segmentsPerPiece 
+   * linear segments per \a Piece of the contour
    */
   void getLinearMesh(mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh,
                      int segmentsPerPiece);
@@ -66,6 +74,7 @@ protected:
 protected:
   std::string m_fileName;
   c2c::LengthUnit m_lengthUnit {c2c::LengthUnit::cm};
+  double m_vertexWeldThreshold {1E-9};
 
   std::vector<c2c::NURBSData> m_nurbsData;
 };

--- a/src/axom/quest/readers/C2CReader.hpp
+++ b/src/axom/quest/readers/C2CReader.hpp
@@ -63,10 +63,12 @@ public:
 
   /*!
    * \brief Projects high-order NURBS contours onto a linear mesh using \a segmentsPerPiece 
-   * linear segments per \a Piece of the contour
+   * linear segments per knot span of the contour
+   * 
+   * Knot spans are the sub-intervals within a spline
    */
   void getLinearMesh(mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh,
-                     int segmentsPerPiece);
+                     int segmentsPerKnotSpan);
 
 protected:
   int readContour();

--- a/src/axom/quest/readers/C2CReader.hpp
+++ b/src/axom/quest/readers/C2CReader.hpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef QUEST_C2CREADER_HPP_
+#define QUEST_C2CREADER_HPP_
+
+#include "axom/config.hpp"
+
+// This file is only applicable if axom was configured with the C2C library
+#ifdef AXOM_USE_C2C
+
+  #include "axom/mint.hpp"
+  #include "c2c/C2C.hpp"
+
+  #include <string>
+  #include <vector>
+
+namespace axom
+{
+namespace quest
+{
+/*
+ * \class C2CReader
+ *
+ * \brief A class to help with reading C2C contour files and converting them to 1D meshes
+ *
+ * We treat all contours as NURBS curves and sample them to create segment meshes.
+ */
+class C2CReader
+{
+public:
+  C2CReader() = default;
+
+  virtual ~C2CReader() = default;
+
+  void setFileName(const std::string& fileName) { m_fileName = fileName; }
+
+  void setLengthUnit(c2c::LengthUnit lengthUnit) { m_lengthUnit = lengthUnit; }
+
+  /*!
+   * \brief Read the contour file provided by \a setFileName()
+   * 
+   * \return 0 for a successful read; non-zero otherwise
+   */
+  virtual int read();
+
+  /// \brief Utility function to log details about the read in file
+  virtual void log();
+
+  /*!
+   * \brief Projects high-order NURBS contours onto a linear mesh using \a segmentsPerPiece linear segments
+   * per \a Piece of the contour
+   */
+  void getLinearMesh(mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh,
+                     int segmentsPerPiece);
+
+protected:
+  int readContour();
+
+private:
+  std::string m_fileName;
+  c2c::LengthUnit m_lengthUnit {c2c::LengthUnit::cm};
+
+  std::vector<c2c::NURBSData> m_nurbsData;
+};
+
+}  // end namespace quest
+}  // namespace axom
+
+#endif  // AXOM_USE_C2C
+
+#endif  // QUEST_C2CREADER_HPP_

--- a/src/axom/quest/readers/PC2CReader.cpp
+++ b/src/axom/quest/readers/PC2CReader.cpp
@@ -5,10 +5,11 @@
 
 #include "axom/quest/readers/PC2CReader.hpp"
 
-// This file is only applicable if axom was configured with the C2C library
-#ifdef AXOM_USE_C2C
+#ifndef AXOM_USE_C2C
+  #error PC2CReader should only be included when Axom is configured with C2C
+#endif
 
-  #include "axom/slic.hpp"
+#include "axom/slic.hpp"
 
 namespace axom
 {
@@ -149,5 +150,3 @@ void PC2CReader::bcastVector(std::vector<T>& vec)
 
 }  // namespace quest
 }  // namespace axom
-
-#endif  // AXOM_USE_C2C

--- a/src/axom/quest/readers/PC2CReader.cpp
+++ b/src/axom/quest/readers/PC2CReader.cpp
@@ -1,0 +1,153 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/quest/readers/PC2CReader.hpp"
+
+// This file is only applicable if axom was configured with the C2C library
+#ifdef AXOM_USE_C2C
+
+  #include "axom/slic.hpp"
+
+namespace axom
+{
+namespace quest
+{
+namespace
+{
+constexpr int READER_SUCCESS = 0;
+constexpr int READER_FAILED = -1;
+
+}  // end anonymous namespace
+
+//------------------------------------------------------------------------------
+PC2CReader::PC2CReader(MPI_Comm comm) : m_comm(comm)
+{
+  MPI_Comm_rank(m_comm, &m_my_rank);
+}
+
+//------------------------------------------------------------------------------
+int PC2CReader::read()
+{
+  SLIC_ASSERT(m_comm != MPI_COMM_NULL);
+
+  // Clear internal data-structures
+  this->clear();
+
+  int rc = -1;  // return code
+
+  switch(m_my_rank)
+  {
+  case 0:
+
+    rc = C2CReader::read();
+    if(rc == READER_SUCCESS)
+    {
+      int numNURBS = m_nurbsData.size();
+      MPI_Bcast(&numNURBS, 1, axom::mpi_traits<int>::type, 0, m_comm);
+
+      for(int i = 0; i < numNURBS; ++i)
+      {
+        auto& nd = m_nurbsData[i];
+
+        // send the order
+        MPI_Bcast(&nd.order, 1, axom::mpi_traits<unsigned>::type, 0, m_comm);
+
+        // send the knots, weights and spline interp params vectors
+        bcastVector<double>(nd.knots);
+        bcastVector<double>(nd.weights);
+        bcastVector<double>(nd.splineInterpolationPointParameters);
+
+        // pack R and Z coordinates of control points into arrays and bcast
+        // note: when converting to NURBSData, all units are converted to m_lengthUnit
+        // so we do not need to transmit this to the other ranks
+        std::vector<double> r, z;
+        r.reserve(nd.controlPoints.size());
+        z.reserve(nd.controlPoints.size());
+        for(const auto& pt : nd.controlPoints)
+        {
+          r.push_back(pt.getR().getValue());
+          z.push_back(pt.getZ().getValue());
+        }
+        bcastVector<double>(r);
+        bcastVector<double>(z);
+      }
+    }
+    else
+    {
+      MPI_Bcast(&rc, 1, MPI_INT, 0, m_comm);
+    }
+    break;
+
+  default:
+
+    // Rank 0 broadcasts the number of NURBSData entities, a positive integer, if the
+    // C2C file is read successfully, or sends a READER_FAILED flag, indicating
+    // that the read was not successful.
+    int numNURBS = -1;
+    MPI_Bcast(&numNURBS, 1, axom::mpi_traits<int>::type, 0, m_comm);
+
+    if(numNURBS != READER_FAILED)
+    {
+      rc = READER_SUCCESS;
+
+      m_nurbsData.reserve(numNURBS);
+
+      // Receive and reconstruct each NURBSData
+      for(int i = 0; i < numNURBS; ++i)
+      {
+        c2c::NURBSData nd;
+
+        // receive the NURBS order
+        MPI_Bcast(&nd.order, 1, axom::mpi_traits<unsigned>::type, 0, m_comm);
+
+        // receive the knots, weights and spline interp params vectors
+        bcastVector<double>(nd.knots);
+        bcastVector<double>(nd.weights);
+        bcastVector<double>(nd.splineInterpolationPointParameters);
+
+        // get the points data and reconstruct the control points
+        std::vector<double> r, z;
+        bcastVector<double>(r);
+        bcastVector<double>(z);
+        int ptSize = r.size();
+        for(int j = 0; j < ptSize; ++j)
+        {
+          const c2c::Length rlen {r[j], m_lengthUnit};
+          const c2c::Length zlen {z[j], m_lengthUnit};
+          nd.controlPoints.emplace_back(c2c::Point(rlen, zlen));
+        }
+
+        m_nurbsData.emplace_back(nd);
+      }
+    }
+  }
+
+  return (rc);
+}
+
+template <typename T>
+void PC2CReader::bcastVector(std::vector<T>& vec)
+{
+  int sz = -1;
+
+  switch(m_my_rank)
+  {
+  case 0:
+    sz = vec.size();
+    MPI_Bcast(&sz, 1, axom::mpi_traits<int>::type, 0, m_comm);
+    MPI_Bcast(vec.data(), sz, axom::mpi_traits<T>::type, 0, m_comm);
+    break;
+  default:
+    MPI_Bcast(&sz, 1, axom::mpi_traits<int>::type, 0, m_comm);
+    vec.resize(sz);  // resize to allocate sufficient data
+    MPI_Bcast(vec.data(), sz, axom::mpi_traits<T>::type, 0, m_comm);
+    break;
+  }
+}
+
+}  // namespace quest
+}  // namespace axom
+
+#endif  // AXOM_USE_C2C

--- a/src/axom/quest/readers/PC2CReader.hpp
+++ b/src/axom/quest/readers/PC2CReader.hpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef QUEST_PC2CREADER_HPP_
+#define QUEST_PC2CREADER_HPP_
+
+#include "axom/config.hpp"
+
+// This file is only applicable if axom was configured with the C2C library
+#ifdef AXOM_USE_C2C
+
+  #include "axom/core/Macros.hpp"
+  #include "axom/quest/readers/C2CReader.hpp"  // base class
+
+  #include "mpi.h"
+
+namespace axom
+{
+namespace quest
+{
+class PC2CReader : public C2CReader
+{
+public:
+  PC2CReader() = delete;
+  PC2CReader(MPI_Comm comm);
+
+  virtual ~PC2CReader() = default;
+
+  /*!
+   * \brief Reads in a C2C file to all ranks in the associated communicator
+   *
+   * \note Rank 0 reads in the C2C mesh file and broadcasts to the other ranks
+   * \return status set to zero on success; non-zero otherwise
+   */
+  virtual int read() final override;
+
+private:
+  /// Utility function to broadcast a vector of primitive types
+  template <typename T>
+  void bcastVector(std::vector<T>& vec);
+
+private:
+  MPI_Comm m_comm {MPI_COMM_NULL};
+  int m_my_rank {0};
+
+  DISABLE_COPY_AND_ASSIGNMENT(PC2CReader);
+  DISABLE_MOVE_AND_ASSIGNMENT(PC2CReader);
+};
+
+}  // namespace quest
+}  // namespace axom
+
+#endif  // AXOM_USE_C2C
+#endif  // QUEST_PC2CREADER_HPP_

--- a/src/axom/quest/readers/PC2CReader.hpp
+++ b/src/axom/quest/readers/PC2CReader.hpp
@@ -35,7 +35,7 @@ public:
    * \note Rank 0 reads in the C2C mesh file and broadcasts to the other ranks
    * \return status set to zero on success; non-zero otherwise
    */
-  virtual int read() final override;
+  int read() final override;
 
 private:
   /// Utility function to broadcast a vector of primitive types

--- a/src/axom/quest/readers/PC2CReader.hpp
+++ b/src/axom/quest/readers/PC2CReader.hpp
@@ -8,13 +8,14 @@
 
 #include "axom/config.hpp"
 
-// This file is only applicable if axom was configured with the C2C library
-#ifdef AXOM_USE_C2C
+#ifndef AXOM_USE_C2C
+  #error PC2CReader should only be included when Axom is configured with C2C
+#endif
 
-  #include "axom/core/Macros.hpp"
-  #include "axom/quest/readers/C2CReader.hpp"  // base class
+#include "axom/core/Macros.hpp"
+#include "axom/quest/readers/C2CReader.hpp"  // base class
 
-  #include "mpi.h"
+#include "mpi.h"
 
 namespace axom
 {
@@ -52,5 +53,4 @@ private:
 }  // namespace quest
 }  // namespace axom
 
-#endif  // AXOM_USE_C2C
 #endif  // QUEST_PC2CREADER_HPP_

--- a/src/axom/quest/readers/PSTLReader.cpp
+++ b/src/axom/quest/readers/PSTLReader.cpp
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/quest/stl/PSTLReader.hpp"
+#include "axom/quest/readers/PSTLReader.hpp"
 
 namespace axom
 {

--- a/src/axom/quest/readers/PSTLReader.hpp
+++ b/src/axom/quest/readers/PSTLReader.hpp
@@ -19,40 +19,28 @@ namespace quest
 class PSTLReader : public STLReader
 {
 public:
-  /*!
-   * \brief Constructor.
-   * \param [in] comm user-supplied MPI communicator.
-   */
+  PSTLReader() = delete;
   PSTLReader(MPI_Comm comm);
 
-  /*!
-   * \brief Destructor.
-   */
   virtual ~PSTLReader();
 
   /*!
    * \brief Reads in an STL file to all ranks in the associated communicator.
-   * \note Rank 0 reads in the STL mesh file and broadcasts the data the rest
-   *  of the ranks.
+   * 
+   * \note Rank 0 reads in the STL mesh file and broadcasts to the other ranks.
    * \return status set to zero on success; set to a non-zero value otherwise.
    */
   virtual int read() final override;
 
 private:
-  /*!
-   * \brief Default constructor. Does nothing.
-   * \note Made private to prevent its use in application code.
-   */
-  PSTLReader() : m_comm(MPI_COMM_NULL), m_my_rank(0) {};
-
-  MPI_Comm m_comm; /*!< MPI communicator */
-  int m_my_rank;   /*!< MPI rank ID      */
+  MPI_Comm m_comm {MPI_COMM_NULL};
+  int m_my_rank {0};
 
   DISABLE_COPY_AND_ASSIGNMENT(PSTLReader);
   DISABLE_MOVE_AND_ASSIGNMENT(PSTLReader);
 };
 
-}  // end namespace quest
-}  // end namespace axom
+}  // namespace quest
+}  // namespace axom
 
 #endif /* QUEST_PSTLREADER_HPP_ */

--- a/src/axom/quest/readers/PSTLReader.hpp
+++ b/src/axom/quest/readers/PSTLReader.hpp
@@ -30,7 +30,7 @@ public:
    * \note Rank 0 reads in the STL mesh file and broadcasts to the other ranks.
    * \return status set to zero on success; set to a non-zero value otherwise.
    */
-  virtual int read() final override;
+  int read() final override;
 
 private:
   MPI_Comm m_comm {MPI_COMM_NULL};

--- a/src/axom/quest/readers/PSTLReader.hpp
+++ b/src/axom/quest/readers/PSTLReader.hpp
@@ -6,8 +6,9 @@
 #ifndef QUEST_PSTLREADER_HPP_
 #define QUEST_PSTLREADER_HPP_
 
+#include "axom/config.hpp"
 #include "axom/core/Macros.hpp"
-#include "axom/quest/stl/STLReader.hpp"  // base class
+#include "axom/quest/readers/STLReader.hpp"  // base class
 
 #include "mpi.h"
 

--- a/src/axom/quest/readers/STLReader.cpp
+++ b/src/axom/quest/readers/STLReader.cpp
@@ -3,18 +3,15 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/quest/stl/STLReader.hpp"
+#include "axom/quest/readers/STLReader.hpp"
 
-#include "axom/core/utilities/Utilities.hpp"  // isLittleEndian()/swapEndian()
-
-// Mint includes
-#include "axom/mint/mesh/CellTypes.hpp"  // for mint::Triangle
-
-// Slic includes
-#include "axom/slic/interface/slic.hpp"  // for SLIC macros
+// Axom includes
+#include "axom/core/utilities/Utilities.hpp"
+#include "axom/mint/mesh/CellTypes.hpp"
+#include "axom/slic/interface/slic.hpp"
 
 // C/C++ includes
-#include <fstream>  // for ifstream
+#include <fstream>
 
 namespace
 {

--- a/src/axom/quest/readers/STLReader.hpp
+++ b/src/axom/quest/readers/STLReader.hpp
@@ -117,7 +117,7 @@ private:
   DISABLE_MOVE_AND_ASSIGNMENT(STLReader);
 };
 
-}  // end namespace quest
-}  // end namespace axom
+}  // namespace quest
+}  // namespace axom
 
 #endif  // QUEST_STLREADER_HPP_

--- a/src/axom/quest/readers/STLReader.hpp
+++ b/src/axom/quest/readers/STLReader.hpp
@@ -7,9 +7,8 @@
 #define QUEST_STLREADER_HPP_
 
 // Axom includes
-#include "axom/core/Macros.hpp"  // for axom macros
-
-// Mint includes
+#include "axom/config.hpp"
+#include "axom/core/Macros.hpp"
 #include "axom/mint/mesh/UnstructuredMesh.hpp"
 
 // C/C++ includes
@@ -121,4 +120,4 @@ private:
 }  // end namespace quest
 }  // end namespace axom
 
-#endif /* QUEST_STLREADER_HPP_ */
+#endif  // QUEST_STLREADER_HPP_

--- a/src/axom/quest/tests/CMakeLists.txt
+++ b/src/axom/quest/tests/CMakeLists.txt
@@ -15,6 +15,10 @@ set(quest_tests
     quest_vertex_weld.cpp
    )
 
+blt_list_append(TO       quest_tests 
+                IF       C2C_FOUND
+                ELEMENTS quest_c2c_reader.cpp)
+
 # Optionally, add tests that require AXOM_DATA_DIR
 blt_list_append(TO       quest_tests
                 IF       AXOM_DATA_DIR
@@ -44,6 +48,10 @@ foreach(test ${quest_tests})
         )
 endforeach()
 
+
+#------------------------------------------------------------------------------
+# Tests that use MFEM when available
+#------------------------------------------------------------------------------
 
 if(MFEM_FOUND)
     set(test_name quest_point_in_cell_mfem)

--- a/src/axom/quest/tests/quest_c2c_reader.cpp
+++ b/src/axom/quest/tests/quest_c2c_reader.cpp
@@ -125,14 +125,18 @@ TEST(quest_c2c_reader, interpolate_circle)
   using MeshType = mint::UnstructuredMesh<mint::SINGLE_SHAPE>;
   MeshType* mesh = new MeshType(DIM, mint::SEGMENT);
 
-  int segmentsPerPiece = 100;
-  reader.getLinearMesh(mesh, segmentsPerPiece);
+  const int segmentsPerKnotSpan = 25;
+  reader.getLinearMesh(mesh, segmentsPerKnotSpan);
 
+  // The circle is defined by a single NURBS curve with four spans
   SLIC_INFO(fmt::format("Mesh has {} nodes and {} cells",
                         mesh->getNumberOfNodes(),
                         mesh->getNumberOfCells()));
-  EXPECT_EQ(segmentsPerPiece + 1, mesh->getNumberOfNodes());
-  EXPECT_EQ(segmentsPerPiece, mesh->getNumberOfCells());
+  const int numSpans = 4;
+  const int expVerts = numSpans * (segmentsPerKnotSpan + 1);
+  EXPECT_EQ(expVerts, mesh->getNumberOfNodes());
+  const int expSegments = numSpans * segmentsPerKnotSpan;
+  EXPECT_EQ(expSegments, mesh->getNumberOfCells());
 
   // This is a unit circle; check that its vertices have unit magnitude
   {
@@ -166,17 +170,20 @@ TEST(quest_c2c_reader, interpolate_square)
   using MeshType = mint::UnstructuredMesh<mint::SINGLE_SHAPE>;
   MeshType* mesh = new MeshType(DIM, mint::SEGMENT);
 
-  int segmentsPerPiece = 10;
-  reader.getLinearMesh(mesh, segmentsPerPiece);
+  int segmentsPerKnotSpan = 10;
+  reader.getLinearMesh(mesh, segmentsPerKnotSpan);
 
   SLIC_INFO(fmt::format("Mesh has {} nodes and {} cells",
                         mesh->getNumberOfNodes(),
                         mesh->getNumberOfCells()));
 
-  const int expVerts = 4 * (segmentsPerPiece + 1);
+  const int numPieces = 4;
+  const int spansPerPiece = 1;
+  const int totalSpans = numPieces * spansPerPiece;
+  const int expVerts = totalSpans * (segmentsPerKnotSpan + 1);
   EXPECT_EQ(expVerts, mesh->getNumberOfNodes());
 
-  const int expSegs = 4 * segmentsPerPiece;
+  const int expSegs = totalSpans * segmentsPerKnotSpan;
   EXPECT_EQ(expSegs, mesh->getNumberOfCells());
 
   mint::write_vtk(mesh, "test_square.vtk");
@@ -197,12 +204,19 @@ TEST(quest_c2c_reader, interpolate_spline)
   using MeshType = mint::UnstructuredMesh<mint::SINGLE_SHAPE>;
   MeshType* mesh = new MeshType(DIM, mint::SEGMENT);
 
-  int segmentsPerPiece = 200;
-  reader.getLinearMesh(mesh, segmentsPerPiece);
+  int segmentsPerKnotSpan = 20;
+  reader.getLinearMesh(mesh, segmentsPerKnotSpan);
 
   SLIC_INFO(fmt::format("Mesh has {} nodes and {} cells",
                         mesh->getNumberOfNodes(),
                         mesh->getNumberOfCells()));
+
+  const int numSpans = 6 + 1 + 1 + 1;
+  const int expVerts = numSpans * (segmentsPerKnotSpan + 1);
+  EXPECT_EQ(expVerts, mesh->getNumberOfNodes());
+
+  const int expSegs = numSpans * segmentsPerKnotSpan;
+  EXPECT_EQ(expSegs, mesh->getNumberOfCells());
 
   mint::write_vtk(mesh, "test_spline.vtk");
 }

--- a/src/axom/quest/tests/quest_c2c_reader.cpp
+++ b/src/axom/quest/tests/quest_c2c_reader.cpp
@@ -1,0 +1,218 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/config.hpp"
+
+#ifndef AXOM_USE_C2C
+  #error These tests should only be included when Axom is configured with C2C
+#endif
+
+#include "axom/quest/readers/C2CReader.hpp"
+#include "axom/slic.hpp"
+#include "axom/mint.hpp"
+#include "axom/primal.hpp"
+#include "fmt/fmt.hpp"
+
+// gtest includes
+#include "gtest/gtest.h"
+
+// C/C++ includes
+#include <cstdio>
+#include <string>
+#include <fstream>
+#include <limits>
+#include <math.h>
+
+// namespace aliases
+namespace mint = axom::mint;
+namespace primal = axom::primal;
+namespace quest = axom::quest;
+
+namespace
+{
+static const std::string C2C_LINE_FILENAME = "test_line.contour";
+static const std::string C2C_CIRCLE_FILENAME = "test_circle.contour";
+static const std::string C2C_SQUARE_FILENAME = "test_square.contour";
+static const std::string C2C_SPLINE_FILENAME = "test_spline.contour";
+}  // end anonymous namespace
+
+/// Writes out a c2c file for a circle
+void writeSimpleCircle(const std::string& filename)
+{
+  std::ofstream c2cFile(filename, std::ios::out);
+  c2cFile
+    << "piece = circle(origin=(0cm, 0cm), radius=1cm, start=0deg, end=360deg)"
+    << std::endl;
+}
+
+/// Writes out a c2c file for a line
+void writeSimpleLine(const std::string& filename)
+{
+  std::ofstream c2cFile(filename, std::ios::out);
+  c2cFile << "piece = line(start=(0cm, 0cm), end=(1cm, 1cm))" << std::endl;
+}
+
+/// Writes out a c2c file for a unit square
+void writeSquare(const std::string& filename)
+{
+  std::ofstream c2cFile(filename, std::ios::out);
+  c2cFile << "point = start" << std::endl;
+  c2cFile << "piece = line(start=(0cm, 0cm), end=(1cm, 0cm))" << std::endl;
+  c2cFile << "piece = line()" << std::endl;
+  c2cFile << "piece = line(start=(1cm, 1cm), end=(0cm, 1cm))" << std::endl;
+  c2cFile << "piece = line(end=start)" << std::endl;
+}
+
+/// Writes out a c2c file for a rectangle cut by a cosine wave
+void writeSpline(const std::string& filename)
+{
+  std::vector<std::string> pts;
+  // generate a cubic spline approximation to a cosine wave
+  // with domain [0, 2*PI] and range defined by a y-offset, amplitude and frequency
+  const double offset = 1.;
+  const double amplitude = .5;
+  const double freq = 3;
+  const int NPTS = 2 * freq;
+  for(int i = 0; i <= NPTS; ++i)
+  {
+    double x = 2 * M_PI * static_cast<double>(i) / NPTS;
+    double y = offset + amplitude * cos(freq * x);
+    pts.emplace_back(fmt::format("{} {}", x, y));
+  }
+
+  std::ofstream c2cFile(filename, std::ios::out);
+  // output sine wave spline
+  c2cFile << "point = spline_start" << std::endl;
+  c2cFile << fmt::format(
+               "piece = rz(units=cm, spline=cubic, beginTan=-90deg, "
+               "endTan=-90deg, rz={})",
+               fmt::join(pts.rbegin(), pts.rend(), "\n\t\t"))
+          << std::endl;
+  c2cFile << "point = spline_end" << std::endl;
+
+  // add straight edges within first quadrant
+  c2cFile << "piece = line(end=(0cm,0cm))" << std::endl;
+  c2cFile << fmt::format("piece = line(end=({}cm,0cm))", 2 * M_PI) << std::endl;
+  c2cFile << "piece = line(end=spline_start)" << std::endl;
+}
+
+TEST(quest_c2c_reader, basic_read)
+{
+  std::string fileName = C2C_CIRCLE_FILENAME;
+  writeSimpleCircle(fileName);
+
+  quest::C2CReader reader;
+  reader.setFileName(fileName);
+
+  reader.read();
+  reader.log();
+}
+
+TEST(quest_c2c_reader, interpolate_circle)
+{
+  std::string fileName = C2C_CIRCLE_FILENAME;
+  writeSimpleCircle(fileName);
+
+  quest::C2CReader reader;
+  reader.setFileName(fileName);
+
+  reader.read();
+  reader.log();
+
+  const int DIM = 2;
+  using MeshType = mint::UnstructuredMesh<mint::SINGLE_SHAPE>;
+  MeshType* mesh = new MeshType(DIM, mint::SEGMENT);
+
+  int segmentsPerPiece = 100;
+  reader.getLinearMesh(mesh, segmentsPerPiece);
+
+  SLIC_INFO(fmt::format("Mesh has {} nodes and {} cells",
+                        mesh->getNumberOfNodes(),
+                        mesh->getNumberOfCells()));
+  EXPECT_EQ(segmentsPerPiece + 1, mesh->getNumberOfNodes());
+  EXPECT_EQ(segmentsPerPiece, mesh->getNumberOfCells());
+
+  // This is a unit circle; check that its vertices have unit magnitude
+  {
+    double* x = mesh->getCoordinateArray(mint::X_COORDINATE);
+    double* y = mesh->getCoordinateArray(mint::Y_COORDINATE);
+    const int numPts = mesh->getNumberOfNodes();
+    for(int i = 0; i < numPts; ++i)
+    {
+      double mag = primal::Vector<double, 2> {x[i], y[i]}.norm();
+      EXPECT_DOUBLE_EQ(1., mag);
+    }
+  }
+
+  mint::write_vtk(mesh, "test_circle.vtk");
+
+  delete mesh;
+}
+
+TEST(quest_c2c_reader, interpolate_square)
+{
+  std::string fileName = C2C_SQUARE_FILENAME;
+  writeSquare(fileName);
+
+  quest::C2CReader reader;
+  reader.setFileName(fileName);
+
+  reader.read();
+  reader.log();
+
+  const int DIM = 2;
+  using MeshType = mint::UnstructuredMesh<mint::SINGLE_SHAPE>;
+  MeshType* mesh = new MeshType(DIM, mint::SEGMENT);
+
+  int segmentsPerPiece = 10;
+  reader.getLinearMesh(mesh, segmentsPerPiece);
+
+  SLIC_INFO(fmt::format("Mesh has {} nodes and {} cells",
+                        mesh->getNumberOfNodes(),
+                        mesh->getNumberOfCells()));
+
+  const int expVerts = 4 * (segmentsPerPiece + 1);
+  EXPECT_EQ(expVerts, mesh->getNumberOfNodes());
+
+  const int expSegs = 4 * segmentsPerPiece;
+  EXPECT_EQ(expSegs, mesh->getNumberOfCells());
+
+  mint::write_vtk(mesh, "test_square.vtk");
+}
+
+TEST(quest_c2c_reader, interpolate_spline)
+{
+  std::string fileName = C2C_SPLINE_FILENAME;
+  writeSpline(fileName);
+
+  quest::C2CReader reader;
+  reader.setFileName(fileName);
+
+  reader.read();
+  reader.log();
+
+  const int DIM = 2;
+  using MeshType = mint::UnstructuredMesh<mint::SINGLE_SHAPE>;
+  MeshType* mesh = new MeshType(DIM, mint::SEGMENT);
+
+  int segmentsPerPiece = 200;
+  reader.getLinearMesh(mesh, segmentsPerPiece);
+
+  SLIC_INFO(fmt::format("Mesh has {} nodes and {} cells",
+                        mesh->getNumberOfNodes(),
+                        mesh->getNumberOfCells()));
+
+  mint::write_vtk(mesh, "test_spline.vtk");
+}
+
+//------------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  axom::slic::SimpleLogger logger;
+
+  return RUN_ALL_TESTS();
+}

--- a/src/axom/quest/tests/quest_inout_interface.cpp
+++ b/src/axom/quest/tests/quest_inout_interface.cpp
@@ -91,7 +91,7 @@ TEST_F(InOutInterfaceTest, initialize_from_mesh)
   EXPECT_TRUE(axom::utilities::filesystem::pathExists(this->meshfile));
 
   axom::mint::Mesh* mesh = nullptr;
-  int rc = axom::quest::internal::read_mesh(this->meshfile, mesh);
+  int rc = axom::quest::internal::read_stl_mesh(this->meshfile, mesh);
   EXPECT_EQ(0, rc);
 
   // Initialize the InOut query

--- a/src/axom/quest/tests/quest_inout_interface.cpp
+++ b/src/axom/quest/tests/quest_inout_interface.cpp
@@ -128,7 +128,6 @@ TEST_F(InOutInterfaceTest, query_properties)
     EXPECT_EQ(failCode, axom::quest::inout_mesh_min_bounds(lo.data()));
     EXPECT_EQ(failCode, axom::quest::inout_mesh_max_bounds(hi.data()));
     EXPECT_EQ(failCode, axom::quest::inout_mesh_center_of_mass(cm.data()));
-    EXPECT_EQ(failCode, axom::quest::inout_get_dimension());
     SLIC_INFO("--]==]");
   }
 

--- a/src/axom/quest/tests/quest_inout_interface.cpp
+++ b/src/axom/quest/tests/quest_inout_interface.cpp
@@ -15,11 +15,28 @@
 
 #include <string>
 
+/// Helper class to wrap a template for the dimension.
+/// Appears to be required to use non-type template parameters with TYPED_TEST
+template <int NDIMS>
+struct DimWrapper
+{
+  static const int DIM = NDIMS;
+};
+template <int NDIMS>
+const int DimWrapper<NDIMS>::DIM;
+
 /// Test fixture for quest::inout_query interface
+template <typename DimWrapper>
 class InOutInterfaceTest : public ::testing::Test
 {
 public:
-  static const int DIM = 3;
+  static const int DIM = DimWrapper::DIM;
+
+#ifdef AXOM_USE_C2C
+  static_assert(DIM == 2 || DIM == 3, "Dimension must be either 2 or 3");
+#else
+  static_assert(DIM == 3, "Dimension must be 3");
+#endif
 
   using CoordType = double;
   using InOutPoint = axom::primal::Point<CoordType, DIM>;
@@ -30,10 +47,20 @@ protected:
   {
     // Setup meshfile
 #ifdef AXOM_DATA_DIR
-    namespace fs = axom::utilities::filesystem;
-    const std::string DATA_DIR = fs::joinPath(AXOM_DATA_DIR, "quest");
-    const std::string fileName = "sphere.stl";
-    meshfile = fs::joinPath(DATA_DIR, fileName);
+    if(DIM == 2)
+    {
+      namespace fs = axom::utilities::filesystem;
+      const std::string DATA_DIR = fs::joinPath(AXOM_DATA_DIR, "contours");
+      const std::string fileName = "unit_circle.contour";
+      meshfile = fs::joinPath(DATA_DIR, fileName);
+    }
+    else  // DIM == 3
+    {
+      namespace fs = axom::utilities::filesystem;
+      const std::string DATA_DIR = fs::joinPath(AXOM_DATA_DIR, "quest");
+      const std::string fileName = "sphere.stl";
+      meshfile = fs::joinPath(DATA_DIR, fileName);
+    }
 #else
     FAIL() << "quest_inout_interface test requires AXOM_DATA_DIR";
 #endif
@@ -42,14 +69,29 @@ protected:
   std::string meshfile;
 };
 
-TEST_F(InOutInterfaceTest, initialize_and_finalize)
+// ----------------------------------------------------------------------------
+// Set up the list of types we want to test.
+// ----------------------------------------------------------------------------
+#ifdef AXOM_USE_C2C
+using MyDims = ::testing::Types<DimWrapper<2>, DimWrapper<3>>;
+#else
+using MyDims = ::testing::Types<DimWrapper<3>>;
+#endif
+TYPED_TEST_SUITE(InOutInterfaceTest, MyDims);
+
+// ----------------------------------------------------------------------------
+
+TYPED_TEST(InOutInterfaceTest, initialize_and_finalize)
 {
+  const int DIM = TestFixture::DIM;
+
   EXPECT_TRUE(axom::utilities::filesystem::pathExists(this->meshfile));
 
   // InOut begins uninitialized
   EXPECT_FALSE(axom::quest::inout_initialized());
 
   // Initialize the InOut query
+  EXPECT_EQ(0, axom::quest::inout_set_dimension(DIM));
   EXPECT_EQ(0, axom::quest::inout_init(this->meshfile));
 
   // InOut should now be initialized
@@ -62,13 +104,15 @@ TEST_F(InOutInterfaceTest, initialize_and_finalize)
   EXPECT_FALSE(axom::quest::inout_initialized());
 }
 
-TEST_F(InOutInterfaceTest, logger_inited)
+TYPED_TEST(InOutInterfaceTest, logger_inited)
 {
+  const int DIM = TestFixture::DIM;
   const bool origSlicInited = axom::slic::isInitialized();
 
   auto origLogLevel = axom::slic::getLoggingMsgLevel();
 
   // Initialize the InOut query
+  EXPECT_EQ(0, axom::quest::inout_set_dimension(DIM));
   EXPECT_EQ(0, axom::quest::inout_init(this->meshfile));
 
   // slic is initialized now
@@ -86,15 +130,41 @@ TEST_F(InOutInterfaceTest, logger_inited)
   }
 }
 
-TEST_F(InOutInterfaceTest, initialize_from_mesh)
+TYPED_TEST(InOutInterfaceTest, initialize_from_mesh)
 {
+  const int DIM = TestFixture::DIM;
+  const int failCode = axom::quest::QUEST_INOUT_FAILED;
+
   EXPECT_TRUE(axom::utilities::filesystem::pathExists(this->meshfile));
 
   axom::mint::Mesh* mesh = nullptr;
-  int rc = axom::quest::internal::read_stl_mesh(this->meshfile, mesh);
+
+  int rc = failCode;
+
+  if(DIM == 2)
+  {
+#ifdef AXOM_USE_C2C
+    int segmentsPerKnotSpan = 10;
+    double weldThreshold = 1E-9;
+    rc = axom::quest::internal::read_c2c_mesh(this->meshfile,
+                                              segmentsPerKnotSpan,
+                                              weldThreshold,
+                                              mesh);
+#endif  // AXOM_USE_C2C
+  }
+  else  // DIM == 3
+  {
+    rc = axom::quest::internal::read_stl_mesh(this->meshfile, mesh);
+  }
+
   EXPECT_EQ(0, rc);
 
+  ASSERT_NE(nullptr, mesh);
+  EXPECT_GT(mesh->getNumberOfNodes(), 0);
+  EXPECT_GT(mesh->getNumberOfCells(), 0);
+
   // Initialize the InOut query
+  EXPECT_EQ(0, axom::quest::inout_set_dimension(DIM));
   EXPECT_EQ(0, axom::quest::inout_init(mesh));
 
   // InOut should now be initialized
@@ -107,13 +177,13 @@ TEST_F(InOutInterfaceTest, initialize_from_mesh)
   EXPECT_FALSE(axom::quest::inout_initialized());
 }
 
-TEST_F(InOutInterfaceTest, query_properties)
+TYPED_TEST(InOutInterfaceTest, query_properties)
 {
   const int failCode = axom::quest::QUEST_INOUT_FAILED;
   const int successCode = axom::quest::QUEST_INOUT_SUCCESS;
 
-  using PointType = InOutInterfaceTest::InOutPoint;
-  using BBoxType = InOutInterfaceTest::InOutBBox;
+  using PointType = typename TestFixture::InOutPoint;
+  using BBoxType = typename TestFixture::InOutBBox;
   PointType lo, hi, cm;
 
   // first, test before initializing
@@ -133,15 +203,17 @@ TEST_F(InOutInterfaceTest, query_properties)
 
   // next, test after initialization
   {
+    const int DIM = TestFixture::DIM;
+    EXPECT_EQ(0, axom::quest::inout_set_dimension(DIM));
     axom::quest::inout_init(this->meshfile);
 
     EXPECT_EQ(successCode, axom::quest::inout_mesh_min_bounds(lo.data()));
     EXPECT_EQ(successCode, axom::quest::inout_mesh_max_bounds(hi.data()));
     EXPECT_EQ(successCode, axom::quest::inout_mesh_center_of_mass(cm.data()));
 
-    const int expSpatialDim = 3;
+    const int expectedSpatialDim = DIM;
     int spatialDim = axom::quest::inout_get_dimension();
-    EXPECT_EQ(expSpatialDim, spatialDim);
+    EXPECT_EQ(expectedSpatialDim, spatialDim);
 
     SLIC_INFO("Mesh bounding box is " << BBoxType(lo, hi));
     SLIC_INFO("Mesh center of mass is " << cm);
@@ -151,8 +223,9 @@ TEST_F(InOutInterfaceTest, query_properties)
   }
 }
 
-TEST_F(InOutInterfaceTest, set_params)
+TYPED_TEST(InOutInterfaceTest, set_params)
 {
+  const int DIM = TestFixture::DIM;
   const int failCode = axom::quest::QUEST_INOUT_FAILED;
   const int successCode = axom::quest::QUEST_INOUT_SUCCESS;
   const double EPS = 1E-6;
@@ -163,7 +236,7 @@ TEST_F(InOutInterfaceTest, set_params)
 
     EXPECT_EQ(successCode, axom::quest::inout_set_verbose(true));
     EXPECT_EQ(successCode, axom::quest::inout_set_vertex_weld_threshold(EPS));
-    EXPECT_EQ(successCode, axom::quest::inout_set_dimension(3));
+    EXPECT_EQ(successCode, axom::quest::inout_set_dimension(DIM));
     // The following is not used in 3D, but we can still invoke it
     EXPECT_EQ(successCode, axom::quest::inout_set_segments_per_knot_span(10));
   }
@@ -182,7 +255,7 @@ TEST_F(InOutInterfaceTest, set_params)
 
     EXPECT_EQ(failCode, axom::quest::inout_set_verbose(true));
     EXPECT_EQ(failCode, axom::quest::inout_set_vertex_weld_threshold(EPS));
-    EXPECT_EQ(failCode, axom::quest::inout_set_dimension(3));
+    EXPECT_EQ(failCode, axom::quest::inout_set_dimension(DIM));
     // The following is not used in 3D, but we can still invoke it, and get a warning
     EXPECT_EQ(failCode, axom::quest::inout_set_segments_per_knot_span(10));
 
@@ -192,11 +265,14 @@ TEST_F(InOutInterfaceTest, set_params)
   axom::quest::inout_finalize();
 }
 
-TEST_F(InOutInterfaceTest, query)
+TYPED_TEST(InOutInterfaceTest, query)
 {
-  typedef InOutInterfaceTest::InOutPoint PointType;
+  using PointType = typename TestFixture::InOutPoint;
   PointType query;
 
+  const int DIM = TestFixture::DIM;
+  EXPECT_EQ(0, axom::quest::inout_set_verbose(true));
+  EXPECT_EQ(0, axom::quest::inout_set_dimension(DIM));
   axom::quest::inout_init(this->meshfile);
 
   // test an inside point

--- a/src/axom/quest/tests/quest_inout_interface.cpp
+++ b/src/axom/quest/tests/quest_inout_interface.cpp
@@ -3,16 +3,16 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "gtest/gtest.h"  // for gtest macros
+#include "gtest/gtest.h"
 
 #include "axom/core.hpp"
 #include "axom/slic.hpp"
 #include "axom/primal.hpp"
 
 #include "axom/quest/interface/inout.hpp"
-#include "axom/quest/interface/internal/QuestHelpers.hpp"  // for test that reads
-                                                           // in a mesh without
-                                                           // the interface
+// for test that reads in a mesh without the interface
+#include "axom/quest/interface/internal/QuestHelpers.hpp"
+
 #include <string>
 
 /// Test fixture for quest::inout_query interface
@@ -163,6 +163,9 @@ TEST_F(InOutInterfaceTest, set_params)
 
     EXPECT_EQ(successCode, axom::quest::inout_set_verbose(true));
     EXPECT_EQ(successCode, axom::quest::inout_set_vertex_weld_threshold(EPS));
+    EXPECT_EQ(successCode, axom::quest::inout_set_dimension(3));
+    // The following is not used in 3D, but we can still invoke it
+    EXPECT_EQ(successCode, axom::quest::inout_set_segments_per_knot_span(10));
   }
 
   // Initialize the query
@@ -179,6 +182,9 @@ TEST_F(InOutInterfaceTest, set_params)
 
     EXPECT_EQ(failCode, axom::quest::inout_set_verbose(true));
     EXPECT_EQ(failCode, axom::quest::inout_set_vertex_weld_threshold(EPS));
+    EXPECT_EQ(failCode, axom::quest::inout_set_dimension(3));
+    // The following is not used in 3D, but we can still invoke it, and get a warning
+    EXPECT_EQ(failCode, axom::quest::inout_set_segments_per_knot_span(10));
 
     SLIC_INFO("--]==]");
   }

--- a/src/axom/quest/tests/quest_stl_reader.cpp
+++ b/src/axom/quest/tests/quest_stl_reader.cpp
@@ -3,17 +3,17 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/quest/stl/STLReader.hpp"
+#include "axom/quest/readers/STLReader.hpp"
 #include "axom/mint/mesh/UnstructuredMesh.hpp"
 
 // gtest includes
 #include "gtest/gtest.h"
 
 // C/C++ includes
-#include <cstdio>   // for std::remove()
-#include <string>   // for std::string
-#include <fstream>  // for std::ofstream
-#include <limits>   // for std::numeric_limits
+#include <cstdio>
+#include <string>
+#include <fstream>
+#include <limits>
 
 // namespace aliases
 namespace mint = axom::mint;

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -20,7 +20,7 @@
 #include "axom/spin/UniformGrid.hpp"
 
 // _read_stl_include1_start
-#include "axom/quest/stl/STLReader.hpp"
+#include "axom/quest/readers/STLReader.hpp"
 // _read_stl_include1_end
 // _check_repair_include_start
 #include "axom/quest/MeshTester.hpp"


### PR DESCRIPTION
# Summary

- This PR add support to quest for reading C2C `.contour` files
- The contours are converted to NURBS and can be sampled onto a linear segment mesh using `C2CReader::getLinearMesh()`
- When the 2D segment mesh is closed, we can pass it into `quest::InOutOctree<2>` for in/out queries
- It updates the quest `containment_driver` example to support loading in 2D contours from the command line, generating an `InOutOctree<2>` over the contours and sampling the in/out field at the vertices of a regular grid
- ~~This PR also upgrades axom's built-in CLI11 library from `v1.8.0` to `v1.9.2`~~ 
  CLI11 update was moved to #607
- It updates the `inout` C API (and driver example) to support 2D queries
- It includes a bugfix for Mint's  VTK writer to support dumping fields of type `float` and `int64`. 

### Example
For this example contour file:
```
>cat test_spline.contour 
point = spline_start
piece = rz(  units=cm, spline=cubic, 
             beginTan=-90deg, endTan=-90deg, 
             rz=6.283185307179586 1.5
		5.235987755982989 0.5
		4.1887902047863905 1.5
		3.141592653589793 0.5
		2.0943951023931953 1.5
		1.0471975511965976 0.5
		0 1.5)
point = spline_end
piece = line(end=(0cm,0cm))
piece = line(end=(6.283185307179586cm,0cm))
piece = line(end=spline_start)

```

 w/ a sinusoidal cubic spline and three linear segments:
![image](https://user-images.githubusercontent.com/5626552/125236814-7114e300-e299-11eb-8e2e-8be81071bcca.png)

We get the following linear mesh (sampled using 100 segments per contour):
![image](https://user-images.githubusercontent.com/5626552/125237080-f4cecf80-e299-11eb-9f9d-ecc5cd6fb364.png)

When querying at the vertices of a `256^2` grid, using the following command line args:
```
>./examples/quest_containment_driver_ex -i test_spline.contour -v        \
                                        --min -.2 -.2  --max 6.5 2.2     \
                                        -l9 --batched
```

we construct the following In/Out field:
![image](https://user-images.githubusercontent.com/5626552/125237312-53944900-e29a-11eb-881c-51f3f4f72f17.png)

### TODO

- [x] Add MPI-based C2C loader (similar to STL / PSTL reader)
- [x] Incorporate into quest::inout C-API and Fortran API
- [x] Add some examples to axom_data -- https://github.com/LLNL/axom_data/pull/5
- [x] Update data submodule
- [x] Update RELEASE-NOTES