### PR TITLE
Clean up + add documentation for unexpectedNames/strict()

### DIFF
--- a/src/axom/inlet/docs/sphinx/verification.rst
+++ b/src/axom/inlet/docs/sphinx/verification.rst
@@ -103,7 +103,7 @@ The list of unexpected names can also be retrieved relative to an individual ``C
 
 
 These lists of unexpected names can be useful if you'd like to implement custom/targeted error messages - in the example above, one might
-wish to provide a message indicating that "dimension" should be used instead of just "dim".  In other cases, it may be sufficient to just
+wish to provide a message indicating that ``dimension`` should be used instead of just ``dim``.  In other cases, it may be sufficient to just
 require that all or part of the input file have no unexpected entries.  This is supported via the ``strict()`` method, which will cause a
 ``Container`` to fail verification if it contains any unexpected entries:
 

--- a/src/axom/inlet/docs/sphinx/verification.rst
+++ b/src/axom/inlet/docs/sphinx/verification.rst
@@ -79,9 +79,35 @@ Unexpected Entries in Input Files
 ---------------------------------
 
 In order to better detect user error, e.g., misspelled names, Inlet provides a method to retrieve the names of entries
-in the input file that were not requested in the schema definition phase.  Given a top-level ``Inlet`` object named ``inlet``,
-the names can be retrieved as follows:
+in the input file that were not requested in the schema definition phase.  Consider the following input:
 
-.. code-block:: C++
+.. literalinclude:: ../../examples/verification.cpp
+   :start-after: _inlet_verification_input_start
+   :end-before: _inlet_verification_input_end
+   :language: C++
 
-  std::unordered_set<std::string> unexpected_names = inlet.unexpectedNames();
+
+The full set of unexpected names across the entire input file can be retrieved from the top-level ``Inlet`` object as follows:
+
+.. literalinclude:: ../../examples/verification.cpp
+   :start-after: _inlet_verification_toplevel_unexpected_start
+   :end-before: _inlet_verification_toplevel_unexpected_end
+   :language: C++
+
+The list of unexpected names can also be retrieved relative to an individual ``Container`` - that is, anywhere within/below that container:
+
+.. literalinclude:: ../../examples/verification.cpp
+   :start-after: _inlet_verification_container_unexpected_start
+   :end-before: _inlet_verification_container_unexpected_end
+   :language: C++
+
+
+These lists of unexpected names can be useful if you'd like to implement custom/targeted error messages - in the example above, one might
+wish to provide a message indicating that "dimension" should be used instead of just "dim".  In other cases, it may be sufficient to just
+require that all or part of the input file have no unexpected entries.  This is supported via the ``strict()`` method, which will cause a
+``Container`` to fail verification if it contains any unexpected entries:
+
+.. literalinclude:: ../../examples/verification.cpp
+   :start-after: _inlet_verification_strict_start
+   :end-before: _inlet_verification_strict_end
+   :language: C++

--- a/src/axom/inlet/docs/sphinx/verification.rst
+++ b/src/axom/inlet/docs/sphinx/verification.rst
@@ -97,6 +97,11 @@ The full set of unexpected names across the entire input file can be retrieved f
 The list of unexpected names can also be retrieved relative to an individual ``Container`` - that is, anywhere within/below that container:
 
 .. literalinclude:: ../../examples/verification.cpp
+   :start-after: _inlet_verification_container_start
+   :end-before: _inlet_verification_container_end
+   :language: C++
+
+.. literalinclude:: ../../examples/verification.cpp
    :start-after: _inlet_verification_container_unexpected_start
    :end-before: _inlet_verification_container_unexpected_end
    :language: C++

--- a/src/axom/inlet/examples/verification.cpp
+++ b/src/axom/inlet/examples/verification.cpp
@@ -34,8 +34,10 @@ int main()
   // defines a required global field named "dimensions" with a default value of 2
   myInlet.addInt("dimensions").required(true).defaultValue(2);
 
+  // _inlet_verification_container_start
   // defines a required container named vector with an internal field named 'x'
   auto& v = myInlet.addStruct("vector").required(true);
+  // _inlet_verification_container_end
   v.addDouble("x");
   // _inlet_workflow_defining_schema_end
 


### PR DESCRIPTION
# Summary

- This PR is a docs update
- It does the following:
  - Updates the docs to match the current unexpectedNames/strict() functionality


https://axom.readthedocs.io/en/docs-essman-container_strict/axom/inlet/docs/sphinx/verification.html#unexpected-entries-in-input-files
