### PR TITLE
Feature/kweiss/multimat_revamp

### DIFF
--- a/src/axom/multimat/examples/traversal.cpp
+++ b/src/axom/multimat/examples/traversal.cpp
@@ -396,7 +396,7 @@ int main(int argc, char** argv)
   //default options
   int ncells = 10000;
   int nmats = 50;
-  int ncomp = 3;
+  int ncomp = 1;
   bool use_sparse = true;
   double fill_percentage = .2;
 

--- a/src/axom/multimat/mmsubfield.hpp
+++ b/src/axom/multimat/mmsubfield.hpp
@@ -18,7 +18,7 @@ namespace multimat
 
 template <typename Field2DType>
 class MMSubField2D
-  : public slam::SubMap<typename Field2DType::BiVarMapType, slam::RangeSet<int, int>>
+  : public slam::SubMap<typename Field2DType::BiVarMapType, slam::RangeSet<> >
 {
 public:
   using SubSetType = MultiMat::RangeSetType;

--- a/src/axom/multimat/multimat.hpp
+++ b/src/axom/multimat/multimat.hpp
@@ -525,7 +525,7 @@ private:
   };
 
   //Layout used during the static mode
-  std::vector<Layout> m_layout_when_static;
+  std::vector<Layout> m_layout_when_static; //per field
   Layout m_static_layout;
 
   bool m_dynamic_mode;  //true if in dynamic mode

--- a/src/axom/multimat/tests/multimat_test.cpp
+++ b/src/axom/multimat/tests/multimat_test.cpp
@@ -427,7 +427,7 @@ TEST(multimat, test_data_setval)
 {
   const int num_cells = 20;
   const int num_mats = 10;
-  const int stride_val = 4;
+  const int stride_val = 1;
   MM_test_data<double> data(num_cells, num_mats, stride_val);
 
   {  //remove everything, add everything back, and check
@@ -471,7 +471,7 @@ TEST(multimat, construct_multimat_1_array)
 {
   const int num_cells = 20;
   const int num_mats = 10;
-  const int stride_val = 4;
+  const int stride_val = 1;
   MM_test_data<double> data(num_cells, num_mats, stride_val);
 
   std::vector<DataLayout> data_layouts = {DataLayout::CELL_DOM,
@@ -539,7 +539,7 @@ TEST(multimat, test_dynamic_multimat_1_array)
 {
   const int num_cells = 20;
   const int num_mats = 10;
-  const int stride_val = 4;
+  const int stride_val = 1;
 
   std::vector<DataLayout> data_layouts = {DataLayout::CELL_DOM,
                                           DataLayout::MAT_DOM};

--- a/src/axom/multimat/tests/multimat_test.cpp
+++ b/src/axom/multimat/tests/multimat_test.cpp
@@ -592,7 +592,7 @@ TEST(multimat, test_dynamic_multimat_1_array)
               idx1 = mi, idx2 = ci;
             }
 
-            EXPECT_TRUE(mm.removeEntry(idx1, idx2));
+            EXPECT_TRUE(mm.removeEntry(ci, mi));
             volfrac_field(idx1, idx2) = 0.0;
             for(int s = 0; s < stride_val; s++) arr(idx1, idx2, s) = 0.0;
           }
@@ -614,7 +614,7 @@ TEST(multimat, test_dynamic_multimat_1_array)
           idx1 = 0, idx2 = ci;
         }
 
-        mm.addEntry(idx1, idx2);
+        EXPECT_TRUE(mm.addEntry(ci, 0));
         volfrac_field(idx1, idx2) = 1.0;
         for(int s = 0; s < stride_val; s++)
           arr(idx1, idx2, s) =

--- a/src/axom/slam/examples/tinyHydro/TinyHydroTypes.hpp
+++ b/src/axom/slam/examples/tinyHydro/TinyHydroTypes.hpp
@@ -27,11 +27,11 @@ namespace tinyHydro {
 
   using IndexField = slam::Map<int>;
 
-  using ScalarField = slam::Map<double>;
+  using ScalarField = slam::Map<double,SetBase>;
   using NodalScalarField = ScalarField;
   using ZonalScalarField = ScalarField;
 
-  using VectorField = slam::Map<VectorXY>;
+  using VectorField = slam::Map<VectorXY,SetBase>;
   using NodalVectorField = VectorField;
   using ZonalVectorField = VectorField;
   using FaceVectorField = VectorField;


### PR DESCRIPTION
This PR is to fix the multimat unit tests

It does the following:

- Make unit test compatible with the new layout-per-field feature
- Fix traversal to run with just 1 component (until field2D with higher number of components are added)
- Reduce unit test to use 1 component as that's temporarily hard-coded
- Fix compilation errors with SubMap index type clash
- Fix tinyHydro compilation error with unmatched Map constructor