### PR TITLE
fix exported conduit dependency

### DIFF
--- a/src/cmake/axom-config.cmake.in
+++ b/src/cmake/axom-config.cmake.in
@@ -76,7 +76,8 @@ if(NOT AXOM_FOUND)
     if(NOT CONDUIT_DIR) 
       set(CONDUIT_DIR ${AXOM_CONDUIT_DIR}) 
     endif()
-    find_dependency(Conduit REQUIRED NO_DEFAULT_PATH PATHS "@AXOM_CONDUIT_CONFIG_DIR@")
+    find_dependency(Conduit REQUIRED NO_DEFAULT_PATH
+                    PATHS "${CONDUIT_DIR}/@AXOM_CONDUIT_CONFIG_DIR@")
   endif()
 
   # hdf5

--- a/src/cmake/axom-config.cmake.in
+++ b/src/cmake/axom-config.cmake.in
@@ -76,7 +76,7 @@ if(NOT AXOM_FOUND)
     if(NOT CONDUIT_DIR) 
       set(CONDUIT_DIR ${AXOM_CONDUIT_DIR}) 
     endif()
-    find_dependency(Conduit REQUIRED NO_DEFAULT_PATH PATHS "${CONDUIT_DIR}/lib/cmake/conduit")
+    find_dependency(Conduit REQUIRED NO_DEFAULT_PATH PATHS "@AXOM_CONDUIT_CONFIG_DIR@")
   endif()
 
   # hdf5

--- a/src/cmake/axom-config.cmake.in
+++ b/src/cmake/axom-config.cmake.in
@@ -77,7 +77,7 @@ if(NOT AXOM_FOUND)
       set(CONDUIT_DIR ${AXOM_CONDUIT_DIR}) 
     endif()
     find_dependency(Conduit REQUIRED NO_DEFAULT_PATH
-                    PATHS "${CONDUIT_DIR}/@AXOM_CONDUIT_CONFIG_DIR@")
+                    PATHS "${CONDUIT_DIR}/@AXOM_CONDUIT_CONFIG_SUBDIR@")
   endif()
 
   # hdf5

--- a/src/cmake/axom-config.cmake.in
+++ b/src/cmake/axom-config.cmake.in
@@ -76,7 +76,7 @@ if(NOT AXOM_FOUND)
     if(NOT CONDUIT_DIR) 
       set(CONDUIT_DIR ${AXOM_CONDUIT_DIR}) 
     endif()
-    find_dependency(Conduit REQUIRED NO_DEFAULT_PATH PATHS "${CONDUIT_DIR}/lib/cmake")
+    find_dependency(Conduit REQUIRED NO_DEFAULT_PATH PATHS "${CONDUIT_DIR}/lib/cmake/conduit")
   endif()
 
   # hdf5

--- a/src/cmake/thirdparty/FindConduit.cmake
+++ b/src/cmake/thirdparty/FindConduit.cmake
@@ -17,21 +17,23 @@ if(NOT CONDUIT_DIR)
     MESSAGE(FATAL_ERROR "Could not find Conduit. Conduit requires explicit CONDUIT_DIR.")
 endif()
 
+# This is used in axom-config.cmake.in
+set(AXOM_CONDUIT_CONFIG_DIR "${CONDUIT_DIR}/lib/cmake/conduit" CACHE PATH "")
 
 if(NOT WIN32)
-    set(_conduit_config "${CONDUIT_DIR}/lib/cmake/conduit/ConduitConfig.cmake")
+    set(_conduit_config "${AXOM_CONDUIT_CONFIG_DIR}/ConduitConfig.cmake")
     if(NOT EXISTS ${_conduit_config})
         MESSAGE(FATAL_ERROR "Could not find Conduit cmake include file ${_conduit_config}")
     endif()
 
     find_package(Conduit REQUIRED
                  NO_DEFAULT_PATH
-                 PATHS ${CONDUIT_DIR}/lib/cmake/conduit)
+                 PATHS ${AXOM_CONDUIT_CONFIG_DIR})
 else()
     # Allow for several different configurations of Conduit
     find_package(Conduit CONFIG 
         REQUIRED
-        HINTS ${CONDUIT_DIR}/lib/cmake/conduit
+        HINTS ${AXOM_CONDUIT_CONFIG_DIR}
               ${CONDUIT_DIR}/cmake/conduit
               ${CONDUIT_DIR}/share/cmake/conduit
               ${CONDUIT_DIR}/share/conduit

--- a/src/cmake/thirdparty/FindConduit.cmake
+++ b/src/cmake/thirdparty/FindConduit.cmake
@@ -18,22 +18,22 @@ if(NOT CONDUIT_DIR)
 endif()
 
 # This is used in axom-config.cmake.in
-set(AXOM_CONDUIT_CONFIG_DIR "lib/cmake/conduit" CACHE PATH "")
+set(AXOM_CONDUIT_CONFIG_SUBDIR "lib/cmake/conduit" CACHE PATH "")
 
 if(NOT WIN32)
-    set(_conduit_config "${CONDUIT_DIR}/${AXOM_CONDUIT_CONFIG_DIR}/ConduitConfig.cmake")
+    set(_conduit_config "${CONDUIT_DIR}/${AXOM_CONDUIT_CONFIG_SUBDIR}/ConduitConfig.cmake")
     if(NOT EXISTS ${_conduit_config})
         MESSAGE(FATAL_ERROR "Could not find Conduit cmake include file ${_conduit_config}")
     endif()
 
     find_package(Conduit REQUIRED
                  NO_DEFAULT_PATH
-                 PATHS ${CONDUIT_DIR}/${AXOM_CONDUIT_CONFIG_DIR})
+                 PATHS ${CONDUIT_DIR}/${AXOM_CONDUIT_CONFIG_SUBDIR})
 else()
     # Allow for several different configurations of Conduit
     find_package(Conduit CONFIG 
         REQUIRED
-        HINTS ${CONDUIT_DIR}/${AXOM_CONDUIT_CONFIG_DIR}
+        HINTS ${CONDUIT_DIR}/${AXOM_CONDUIT_CONFIG_SUBDIR}
               ${CONDUIT_DIR}/cmake/conduit
               ${CONDUIT_DIR}/share/cmake/conduit
               ${CONDUIT_DIR}/share/conduit

--- a/src/cmake/thirdparty/FindConduit.cmake
+++ b/src/cmake/thirdparty/FindConduit.cmake
@@ -18,22 +18,22 @@ if(NOT CONDUIT_DIR)
 endif()
 
 # This is used in axom-config.cmake.in
-set(AXOM_CONDUIT_CONFIG_DIR "${CONDUIT_DIR}/lib/cmake/conduit" CACHE PATH "")
+set(AXOM_CONDUIT_CONFIG_DIR "lib/cmake/conduit" CACHE PATH "")
 
 if(NOT WIN32)
-    set(_conduit_config "${AXOM_CONDUIT_CONFIG_DIR}/ConduitConfig.cmake")
+    set(_conduit_config "${CONDUIT_DIR}/${AXOM_CONDUIT_CONFIG_DIR}/ConduitConfig.cmake")
     if(NOT EXISTS ${_conduit_config})
         MESSAGE(FATAL_ERROR "Could not find Conduit cmake include file ${_conduit_config}")
     endif()
 
     find_package(Conduit REQUIRED
                  NO_DEFAULT_PATH
-                 PATHS ${AXOM_CONDUIT_CONFIG_DIR})
+                 PATHS ${CONDUIT_DIR}/${AXOM_CONDUIT_CONFIG_DIR})
 else()
     # Allow for several different configurations of Conduit
     find_package(Conduit CONFIG 
         REQUIRED
-        HINTS ${AXOM_CONDUIT_CONFIG_DIR}
+        HINTS ${CONDUIT_DIR}/${AXOM_CONDUIT_CONFIG_DIR}
               ${CONDUIT_DIR}/cmake/conduit
               ${CONDUIT_DIR}/share/cmake/conduit
               ${CONDUIT_DIR}/share/conduit


### PR DESCRIPTION
I missed one of the two directories that need to be moved in parallel.  This affects downstream users.

This should probably be fixed in conduit ultimately because this fails in a very subtle way (`conduit` is created instead of all the `conduit::conduit` targets)

Conduit outputs two sets of cmake config files, limited set in `${CONDUIT_DIR}\lib\cmake` and the full set in `${CONDUIT_DIR}\lib\cmake\conduit`

Limited set:

```
[white238@rzgenie5:repo]$ ls -al /usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/clang-10.0.0/conduit-0.7.2/lib/cmake/
total 24
drwxrwsr-x 3 weiss27 axom 4096 Jun  9 00:12 .
drwxrwsr-x 3 weiss27 axom 4096 Jun  9 00:12 ..
drwxrwsr-x 2 weiss27 axom 4096 Jun  9 00:12 conduit
-rw-rw-r-- 1 weiss27 axom 3472 Jun  9 00:11 conduit-relwithdebinfo.cmake
-rw-rw-r-- 1 weiss27 axom 7276 Jun  9 00:11 conduit.cmake
```

Full set:

```
[white238@rzgenie5:repo]$ ls -al /usr/WS1/axom/libs/toss_3_x86_64_ib/2021_06_08_23_40_14/clang-10.0.0/conduit-0.7.2/lib/cmake/conduit
total 44
drwxrwsr-x 2 weiss27 axom 4096 Jun  9 00:12 .
drwxrwsr-x 3 weiss27 axom 4096 Jun  9 00:12 ..
-rw-rw-r-- 1 weiss27 axom 3210 Jun  9 00:11 ConduitConfig.cmake
-rw-rw-r-- 1 weiss27 axom 1386 Jun  9 00:11 ConduitConfigVersion.cmake
-rw-rw-r-- 1 weiss27 axom 3472 Jun  9 00:11 conduit-relwithdebinfo.cmake
-rw-rw-r-- 1 weiss27 axom 7340 Jun  9 00:11 conduit.cmake
-rw-rw-r-- 1 weiss27 axom 6453 May  5 11:02 conduit_setup_deps.cmake
-rw-rw-r-- 1 weiss27 axom 4876 May  5 11:02 conduit_setup_targets.cmake
```