### PR TITLE
Add missing host/device annotations to Primal/Spin functions

### DIFF
--- a/src/axom/primal/geometry/NumericArray.hpp
+++ b/src/axom/primal/geometry/NumericArray.hpp
@@ -99,8 +99,8 @@ NumericArray<T, SIZE> operator*(double scalar, const NumericArray<T, SIZE>& arr)
  * \return C resulting numeric array, \f$ \ni: C_i = lhs_i * rhs_i, \forall i\f$
  */
 template <typename T, int SIZE>
-NumericArray<T, SIZE> operator*(const NumericArray<T, SIZE>& lhs,
-                                const NumericArray<T, SIZE>& rhs);
+AXOM_HOST_DEVICE NumericArray<T, SIZE> operator*(const NumericArray<T, SIZE>& lhs,
+                                                 const NumericArray<T, SIZE>& rhs);
 
 /*!
  * \brief Component-wise division of NumericArrays

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -45,7 +45,8 @@ Vector<T, NDIMS> operator+(const Vector<T, NDIMS>& A, const Vector<T, NDIMS>& B)
  * \return C resulting vector, \f$ C_i = A_i - B_i \forall i \f$
  */
 template <typename T, int NDIMS>
-Vector<T, NDIMS> operator-(const Vector<T, NDIMS>& A, const Vector<T, NDIMS>& B);
+AXOM_HOST_DEVICE Vector<T, NDIMS> operator-(const Vector<T, NDIMS>& A,
+                                            const Vector<T, NDIMS>& B);
 
 /*!
  * \brief Unary negation of a vector instance.
@@ -238,6 +239,7 @@ public:
    * \param [in] v the vector to subtract.
    * \return A reference to the Vector instance after vector subtraction.
    */
+  AXOM_HOST_DEVICE
   Vector<T, NDIMS>& operator-=(const Vector<T, NDIMS>& v);
 
   /*!

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -536,7 +536,7 @@ AXOM_HOST_DEVICE static inline void sync_store(BBoxType& box,
 
 //------------------------------------------------------------------------------
 template <typename ExecSpace>
-static inline int atomic_increment(int* addr)
+AXOM_HOST_DEVICE static inline int atomic_increment(int* addr)
 {
 #ifdef AXOM_USE_RAJA
   using atomic_policy = typename axom::execution_space<ExecSpace>::atomic_policy;


### PR DESCRIPTION
# Summary

- Fixes an issue identified by @steveg21, where initializing `spin::BVH` fails with CUDA.

  `nvcc` somehow doesn't warn us about certain functions with missing `AXOM_HOST_DEVICE` annotations, and instead will generate a call instruction to address `0x0`. The existing tests for the BVH code weren't able to catch the issue, since the functions in question are somehow getting inlined when our tests are being built, which avoids the problematic call instruction.