### PR TITLE
Adds a data collection utility and improves support for loading in MFEMSidreDataCollection

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,6 +39,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Updated the C++ Quest "containment" example to support 2D in/out queries 
   (in addition to the already supported 3D queries)
 - Added `axom::Array` modeled after `std::vector`. Previous `axom::Array` renamed to `axom::MCArray`. Future changes to both arrays are expected.
+- Added a `data_collection_util` tool to generate Mesh Blueprint compliant high order distributed meshes from
+  an mfem mesh or over a Cartesian domain
 
 ### Changed
 - `MFEMSidreDataCollection` now reuses FESpace/QSpace objects with the same basis
@@ -68,6 +70,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Fixed problem with Cray Fortran compiler not recognizing MSVC pragmas in `axom/config.hpp`. 
   The latter are now only added in MSVC configurations.
 - Fixed bug in `Mint`'s VTK output for fields of type `int64` and `float`
+- Improved loading of data collections in `MFEMSidreDataCollection`
 
 
 ## [Version 0.5.0] - Release date 2021-05-14

--- a/src/axom/core/Map.hpp
+++ b/src/axom/core/Map.hpp
@@ -30,7 +30,7 @@ namespace axom_map
 /// @{
 /*!
    * \class Node
-   * 
+   *
    * \brief Node is the foundational data type of the Map, being the lowest-level data storage unit,
    *  with the key and value data for a given item, along with a next value for the linked list.
    *
@@ -52,10 +52,10 @@ struct Node
 
 /*!
    * \class Pair
-   * 
-   * \brief Pair is strictly for returning from insert, to match the pair-returning setup of STL 
+   *
+   * \brief Pair is strictly for returning from insert, to match the pair-returning setup of STL
    *  unordered_map.
-   * 
+   *
    * \tparam Key the type of key stored in the associated Node.
    * \tparam T the type of value stored in the associated Node.
    */
@@ -85,13 +85,13 @@ public:
   /// \name Bucket Construction
   ///@{
   /*!
-     * \brief Default constructor so new Buckets just construct into nothing. 
-     *  Can likely just be removed. 
+     * \brief Default constructor so new Buckets just construct into nothing.
+     *  Can likely just be removed.
      */
   Bucket() { }
 
   /*!
-     * \brief Basic constructor, creates singly-linked list with provided size. 
+     * \brief Basic constructor, creates singly-linked list with provided size.
      *
      * \param [in] len the number of items this Bucket instance needs to be able to store.
      *
@@ -101,7 +101,7 @@ public:
 
   /*!
      * \brief If a Bucket instance is created with the default contructor, this
-     *  is used to initialize and allocate all the member variables. 
+     *  is used to initialize and allocate all the member variables.
      *
      * \param [in] len the number of items this Bucket instance needs to be able to store.
      *
@@ -127,7 +127,7 @@ public:
   /// \name Bucket Methods
   /// @{
   /*!
-     * \brief Inserts a given key-value pair into the linked list if an item with 
+     * \brief Inserts a given key-value pair into the linked list if an item with
      *  given key does not already exist. Fails if list is full or item with given key
      *  already exists.
      *
@@ -181,8 +181,8 @@ public:
   }
 
   /*!
-     * \brief Inserts a given key-value pair into the linked list if an item with 
-     *  given key does not already exist, and updates the item's current value with the supplied 
+     * \brief Inserts a given key-value pair into the linked list if an item with
+     *  given key does not already exist, and updates the item's current value with the supplied
      *  one if item already exists. Fails if list is full.
      *
      * \param [in] key the key of the key-value pair to be inserted.
@@ -190,7 +190,7 @@ public:
      *
      * \return Returns a Pair object, with the first element being a pointer to the inserted node
      *  and the second element being boolean value true if successful. If insertion fails, or assignment
-     *  was performed, the bool is set to False. If assignment occured, the node pointed to is the item 
+     *  was performed, the bool is set to False. If assignment occured, the node pointed to is the item
      *  corresponding to the supplied key. Otherwise, if insertion and assignment failed, the node pointed to is the end node.
      */
   axom_map::Pair<Key, T> insert_update(const Key& key, const T& value)
@@ -250,8 +250,8 @@ public:
      *
      * \param [in] key the key of the item to be found and removed.
      *
-     * \return Returns true if item was found and removed, false otherwise. 
-     *  
+     * \return Returns true if item was found and removed, false otherwise.
+     *
      */
   bool remove(const Key& key)
   {
@@ -340,14 +340,14 @@ public:
 /*!
  * \class Map
  *
- * \brief Provides a hashmap implementation, relying upon chaining to 
- *  resolve hash collisions. Simple hashmap for now, future work will use 
- *  RAJA and Umpire to allow use of map within kernels. Resembles 
+ * \brief Provides a hashmap implementation, relying upon chaining to
+ *  resolve hash collisions. Simple hashmap for now, future work will use
+ *  RAJA and Umpire to allow use of map within kernels. Resembles
  *  unordered_map, which we can't use due to a lack of host-device decoration.
  *
- * \tparam Key the type of keys. Must allow equality comparison, must be copyable. 
+ * \tparam Key the type of keys. Must allow equality comparison, must be copyable.
  * \tparam T the type of values to hold, must be copyable.
- * \tparam Hash functor that takes an object of Key type and returns 
+ * \tparam Hash functor that takes an object of Key type and returns
  *  a hashed value of size_t (for now)
  */
 
@@ -388,23 +388,23 @@ public:
    * from original Map.
    *
    * \param [in] buckets user-specified number of buckets in new Map. -1 to fall back to multiplicative factor.
-   * \param [in] factor user-specified multiplicative factor to determine size of new Map based upon current size. 
+   * \param [in] factor user-specified multiplicative factor to determine size of new Map based upon current size.
    *  -1 to fall back to default -- would be more efficient to specify neither input.
    *
    * \return true if the hash table is now in a safe state, false otherwise
    *
-   * \note if neither input is specified, the new Map will be of size 2*old Map size. 
+   * \note if neither input is specified, the new Map will be of size 2*old Map size.
    * \note both map instances exist in memory until rehash returns. Risks running out of memory.
    * \note Rehash should generally ensure a previously filled bucket is no longer filled, and the load_factor is correct,
    *  if used properly. However, since this highly manual process has room for error this implementation does
-   *  perform a check for if any bucket is now full. 
+   *  perform a check for if any bucket is now full.
    */
   bool rehash(int buckets = -1, int factor = -1)
   {
     int newlen = 0;
     IndexType ind;
     std::size_t hashed;
-    if(buckets != -1 && buckets > m_bucket_count)
+    if(buckets != -1 && buckets > static_cast<int>(m_bucket_count))
     {
       newlen = buckets;
     }
@@ -421,7 +421,7 @@ public:
     m_bucket_fill = false;
     axom_map::Bucket<Key, T>* new_list = alloc_map(newlen, m_bucket_len);
 
-    for(int i = 0; i < m_bucket_count; i++)
+    for(std::size_t i = 0; i < m_bucket_count; i++)
     {
       ind = m_buckets[i].m_head;
       while(ind != -1)
@@ -437,7 +437,7 @@ public:
     destroy_locks(pol);
     m_buckets = new_list;
     m_bucket_count = newlen;
-    for(int i = 0; i < m_bucket_count; i++)
+    for(std::size_t i = 0; i < m_bucket_count; i++)
     {
       if(m_buckets[i].get_size() == m_buckets[i].get_capacity())
       {
@@ -455,7 +455,7 @@ public:
    */
   void clear()
   {
-    for(int i = 0; i < m_bucket_count; i++)
+    for(std::size_t i = 0; i < m_bucket_count; i++)
     {
       axom::deallocate(m_buckets[i].m_list);
     }
@@ -488,13 +488,13 @@ public:
    * \param [in] key the key used to index into the Map to store this item
    * \param [in] val the data value of the pair to insert into the map
    *
-   * \note Deviation from STL unordered_map is that insertion fails when map full, rather than automatically rehashing. 
+   * \note Deviation from STL unordered_map is that insertion fails when map full, rather than automatically rehashing.
    *  Manual call of rehash() required.
    *
    * \note Can set "full bucket" flag for Map, which is only unset by rehashing.
    *
    * \return A pair whose first element is a pointer to the inserted item and bool set to true
-   *  if successful. Otherwise, the second element is set to false, and the first to one of two values: a sentinel node 
+   *  if successful. Otherwise, the second element is set to false, and the first to one of two values: a sentinel node
    *  if the map is overfilled, and the actual node with the given key if an item with given key already exists.
    *
    */
@@ -535,13 +535,13 @@ public:
    * \param [in] key the key used to index into the Map to store this item
    * \param [in] val the data value of the pair to insert into the map
    *
-   * \note Deviation from STL unordered_map is that insertion fails when map full, rather than automatically rehashing. 
+   * \note Deviation from STL unordered_map is that insertion fails when map full, rather than automatically rehashing.
    *  Manual call of rehash() required.
    *
    * \note Can set "full bucket" flag for Map, which is only unset by rehashing.
    *
    * \return A pair whose first element is a pointer to the inserted item and bool set to true
-   *  if insertion was performed. Otherwise, the second element is set to false, and the first to one of two values: a sentinel node 
+   *  if insertion was performed. Otherwise, the second element is set to false, and the first to one of two values: a sentinel node
    *  if the map is overfilled, and the actual node with the given key if an assignment occured.
    *
    */
@@ -578,7 +578,7 @@ public:
 
   /*!
    * \brief Finds reference to value of key-value pair mapped to supplied pair, returns value from sentinel node
-   *  if fails, meaning value at reference will be data type T initialized with 0. 
+   *  if fails, meaning value at reference will be data type T initialized with 0.
    *
    * \param [in] key the key used to index into the Map to find item
    *
@@ -606,7 +606,7 @@ public:
    * \note Deviation from STL unordered_map in returning a boolean instead of an iterator to next item in map.
    *  Mostly useful on sparing logic when this moves to paralellism, since the bucket boundaries would become inconvenient.
    *
-   * \return A bool value of true if the item was successfully removed, false otherwise. 
+   * \return A bool value of true if the item was successfully removed, false otherwise.
    */
   bool erase(const Key& key)
   {
@@ -645,7 +645,7 @@ public:
   }
 
   /*!
-   * \brief Returns id of bucket associated with a 64-bit integer, intended to be the hash 
+   * \brief Returns id of bucket associated with a 64-bit integer, intended to be the hash
    *  of a key.
    *
    * \param [in] hash the id of the bucket to be queried.
@@ -663,7 +663,7 @@ public:
   int bucket_size() const { return m_bucket_len; }
   /*!
    * \brief Returns the number of buckets in the Map.
-   * \return bucket_count 
+   * \return bucket_count
    */
   int bucket_count() const { return m_bucket_count; }
   /*!
@@ -696,7 +696,7 @@ public:
   float max_load_factor() const { return m_load_factor; }
   /*!
    * \brief Sets maximum load factor (ratio between size and bucket count)
-   * hash table will reach before check_rehash returns true. Default value is 
+   * hash table will reach before check_rehash returns true. Default value is
    *  1.0.
    *
    * \param [in] load_factor desired maximum load factor
@@ -710,11 +710,11 @@ public:
   float load_factor() const { return m_size / m_bucket_count; }
 
   /*!
-   * \brief Returns whether a rehash is necessary for this Map instance. Does so based on two metrics. The 
-   *  first is whether the load factor of the map (ratio between size and bucket count) has exceeded its 
-   *  maximum load factor (default 1.0). The second is whether any of the buckets are currently full. 
+   * \brief Returns whether a rehash is necessary for this Map instance. Does so based on two metrics. The
+   *  first is whether the load factor of the map (ratio between size and bucket count) has exceeded its
+   *  maximum load factor (default 1.0). The second is whether any of the buckets are currently full.
    *
-   * \note This function does not exist in the STL unordered_map, because it performs automatic rehashes as 
+   * \note This function does not exist in the STL unordered_map, because it performs automatic rehashes as
    *  necessary. To support the portability constraints put on this data structure, the user must regularly
    *  call this function to verify whether they need to rehash to maintain performance. Another metric is
    *  when an insertion fails and returns end(), but this will yield an answer before such an event.
@@ -739,9 +739,9 @@ private:
    *  Kept separate from constructor and rehasher for sake of modularity in case this needs to be swapped
    *  with a different method in the future.
    *
-   * \param [in] bucount the number of buckets to be in side the allocated Map instance. 
+   * \param [in] bucount the number of buckets to be in side the allocated Map instance.
    * \param [in] bucklen the amount of items that can fit in a bucket in the allocated Map instance.
-   * 
+   *
    * \return A pointer to the now-allocated array of linked lists.
    */
   axom_map::Bucket<Key, T>* alloc_map(int bucount, int bucklen)
@@ -756,7 +756,7 @@ private:
     return tmp;
   }
   /*!
-   * \brief Returns hash value for a given input. 
+   * \brief Returns hash value for a given input.
    *
    * \note Currently uses std::hash, will switch to a custom hasher in future.
    *
@@ -851,7 +851,7 @@ private:
   }
 
   /*!
-   * \brief Deallocates and destroys every lock used for this Map instance. 
+   * \brief Deallocates and destroys every lock used for this Map instance.
    */
   void destroy_locks(axom::OMP_EXEC overload) const
   {

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(gtest_utils_tests
     utils_endianness.hpp
     utils_fileUtilities.hpp
     utils_nvtx_settings.hpp
+    utils_stringUtilities.hpp
     utils_utilities.hpp
     utils_about.hpp
     )

--- a/src/axom/core/tests/core_serial_main.cpp
+++ b/src/axom/core/tests/core_serial_main.cpp
@@ -35,6 +35,7 @@
 #include "utils_endianness.hpp"
 #include "utils_fileUtilities.hpp"
 #include "utils_nvtx_settings.hpp"
+#include "utils_stringUtilities.hpp"
 #include "utils_utilities.hpp"
 #include "utils_about.hpp"
 

--- a/src/axom/core/tests/utils_stringUtilities.hpp
+++ b/src/axom/core/tests/utils_stringUtilities.hpp
@@ -15,8 +15,6 @@
 //------------------------------------------------------------------------------
 TEST(utils_stringUtilities, startsWith)
 {
-  std::cout << "Testing startsWith() functions" << std::endl;
-
   {
     std::string testString = "foo.bar";
     std::string testPrefix = "boo";
@@ -42,8 +40,6 @@ TEST(utils_stringUtilities, startsWith)
 
 TEST(utils_stringUtilities, endsWith)
 {
-  std::cout << "Testing endsWith() functions" << std::endl;
-
   {
     std::string testString = "foo.bar";
     std::string testSuffix = ".baz";
@@ -69,8 +65,6 @@ TEST(utils_stringUtilities, endsWith)
 
 TEST(utils_stringUtilities, removeSuffix)
 {
-  std::cout << "Testing removeSuffix() function" << std::endl;
-
   // different suffix
   {
     std::string testString = "foo.bar";
@@ -106,8 +100,6 @@ TEST(utils_stringUtilities, removeSuffix)
 
 TEST(utils_stringUtilities, toLower)
 {
-  std::cout << "Testing toLower() function" << std::endl;
-
   // already lower
   {
     std::string testString = "foo.bar";
@@ -135,8 +127,6 @@ TEST(utils_stringUtilities, toLower)
 
 TEST(utils_stringUtilities, toUpper)
 {
-  std::cout << "Testing toUpper() function" << std::endl;
-
   // already upper
   {
     std::string testString = "foo.bar";
@@ -164,10 +154,9 @@ TEST(utils_stringUtilities, toUpper)
 
 TEST(utils_stringUtilities, split)
 {
-  std::cout << "Testing split() function" << std::endl;
   using StrVec = std::vector<std::string>;
 
-  // Test w/ proper delim
+  // Test w/ proper delimiter
   {
     std::string testString = "foo/bar/baz";
     StrVec exp {"foo", "bar", "baz"};
@@ -194,7 +183,7 @@ TEST(utils_stringUtilities, split)
     EXPECT_EQ(exp, results);
   }
 
-  // Test other delimeter
+  // Test other delimiter
   {
     std::string testString = "foo.bar.baz";
     StrVec exp {"foo", "bar", "baz"};
@@ -203,7 +192,7 @@ TEST(utils_stringUtilities, split)
     EXPECT_EQ(exp, results);
   }
 
-  // Test different delimeter
+  // Test different delimiter
   {
     std::string testString = "foo.bar.baz";
     StrVec exp {"foo.bar.baz"};
@@ -215,7 +204,6 @@ TEST(utils_stringUtilities, split)
 
 TEST(utils_stringUtilities, splitLastNTokens)
 {
-  std::cout << "Testing split() function" << std::endl;
   using StrVec = std::vector<std::string>;
 
   // Test w/ sufficient tokens
@@ -295,7 +283,7 @@ TEST(utils_stringUtilities, splitLastNTokens)
     EXPECT_EQ(exp, results);
   }
 
-  // Test mixed delim: /
+  // Test mixed delim: '/'
   {
     const std::size_t N = 3;
     std::string testString = "foo.bar/baz.qux";
@@ -306,7 +294,7 @@ TEST(utils_stringUtilities, splitLastNTokens)
     EXPECT_EQ(exp, results);
   }
 
-  // Test mixed delim: .
+  // Test mixed delim: '.'
   {
     const std::size_t N = 3;
     std::string testString = "foo.bar/baz.qux";

--- a/src/axom/core/tests/utils_stringUtilities.hpp
+++ b/src/axom/core/tests/utils_stringUtilities.hpp
@@ -1,0 +1,319 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "gtest/gtest.h"
+
+#include "axom/core/utilities/StringUtilities.hpp"
+
+#include <string>
+#include <vector>
+
+//------------------------------------------------------------------------------
+// UNIT TESTS
+//------------------------------------------------------------------------------
+TEST(utils_stringUtilities, startsWith)
+{
+  std::cout << "Testing startsWith() functions" << std::endl;
+
+  {
+    std::string testString = "foo.bar";
+    std::string testPrefix = "boo";
+    EXPECT_FALSE(axom::utilities::string::startsWith(testString, testPrefix));
+  }
+
+  {
+    std::string testString = "foo.bar";
+    EXPECT_FALSE(axom::utilities::string::startsWith(testString, 'b'));
+  }
+
+  {
+    std::string testString = "foo.bar";
+    std::string testPrefix = "foo";
+    EXPECT_TRUE(axom::utilities::string::startsWith(testString, testPrefix));
+  }
+
+  {
+    std::string testString = "foo.bar";
+    EXPECT_TRUE(axom::utilities::string::startsWith(testString, 'f'));
+  }
+}
+
+TEST(utils_stringUtilities, endsWith)
+{
+  std::cout << "Testing endsWith() functions" << std::endl;
+
+  {
+    std::string testString = "foo.bar";
+    std::string testSuffix = ".baz";
+    EXPECT_FALSE(axom::utilities::string::endsWith(testString, testSuffix));
+  }
+
+  {
+    std::string testString = "foo.bar";
+    EXPECT_FALSE(axom::utilities::string::endsWith(testString, 'z'));
+  }
+
+  {
+    std::string testString = "foo.bar";
+    std::string testSuffix = ".bar";
+    EXPECT_TRUE(axom::utilities::string::endsWith(testString, testSuffix));
+  }
+
+  {
+    std::string testString = "foo.bar";
+    EXPECT_TRUE(axom::utilities::string::endsWith(testString, 'r'));
+  }
+}
+
+TEST(utils_stringUtilities, removeSuffix)
+{
+  std::cout << "Testing removeSuffix() function" << std::endl;
+
+  // different suffix
+  {
+    std::string testString = "foo.bar";
+    std::string testSuffix = ".baz";
+    EXPECT_EQ("foo.bar",
+              axom::utilities::string::removeSuffix(testString, testSuffix));
+  }
+
+  // same suffix
+  {
+    std::string testString = "foo.bar";
+    std::string testSuffix = ".bar";
+    EXPECT_EQ("foo",
+              axom::utilities::string::removeSuffix(testString, testSuffix));
+  }
+
+  // repeated suffix -- only removes one
+  {
+    std::string testString = "foo.bar.bar";
+    std::string testSuffix = ".bar";
+    EXPECT_EQ("foo.bar",
+              axom::utilities::string::removeSuffix(testString, testSuffix));
+  }
+
+  // don't remove from middle
+  {
+    std::string testString = "foo.bar.baz";
+    std::string testSuffix = ".bar";
+    EXPECT_EQ(testString,
+              axom::utilities::string::removeSuffix(testString, testSuffix));
+  }
+}
+
+TEST(utils_stringUtilities, toLower)
+{
+  std::cout << "Testing toLower() function" << std::endl;
+
+  // already lower
+  {
+    std::string testString = "foo.bar";
+    std::string expString = "foo.bar";
+    axom::utilities::string::toLower(testString);
+    EXPECT_EQ(expString, testString);
+  }
+
+  // all upper
+  {
+    std::string testString = "FOO.BAR";
+    std::string expString = "foo.bar";
+    axom::utilities::string::toLower(testString);
+    EXPECT_EQ(expString, testString);
+  }
+
+  // mixed
+  {
+    std::string testString = "FoO.bAr";
+    std::string expString = "foo.bar";
+    axom::utilities::string::toLower(testString);
+    EXPECT_EQ(expString, testString);
+  }
+}
+
+TEST(utils_stringUtilities, toUpper)
+{
+  std::cout << "Testing toUpper() function" << std::endl;
+
+  // already upper
+  {
+    std::string testString = "foo.bar";
+    std::string expString = "FOO.BAR";
+    axom::utilities::string::toUpper(testString);
+    EXPECT_EQ(expString, testString);
+  }
+
+  // all lower
+  {
+    std::string testString = "FOO.BAR";
+    std::string expString = "FOO.BAR";
+    axom::utilities::string::toUpper(testString);
+    EXPECT_EQ(expString, testString);
+  }
+
+  // mixed
+  {
+    std::string testString = "FoO.bAr";
+    std::string expString = "FOO.BAR";
+    axom::utilities::string::toUpper(testString);
+    EXPECT_EQ(expString, testString);
+  }
+}
+
+TEST(utils_stringUtilities, split)
+{
+  std::cout << "Testing split() function" << std::endl;
+  using StrVec = std::vector<std::string>;
+
+  // Test w/ proper delim
+  {
+    std::string testString = "foo/bar/baz";
+    StrVec exp {"foo", "bar", "baz"};
+    StrVec results;
+    axom::utilities::string::split(results, testString, '/');
+    EXPECT_EQ(exp, results);
+  }
+
+  // Test empty
+  {
+    std::string testString = "";
+    StrVec exp;
+    StrVec results;
+    axom::utilities::string::split(results, testString, '/');
+    EXPECT_EQ(exp, results);
+  }
+
+  // Test single
+  {
+    std::string testString = "foo";
+    StrVec exp {"foo"};
+    StrVec results;
+    axom::utilities::string::split(results, testString, '/');
+    EXPECT_EQ(exp, results);
+  }
+
+  // Test other delimeter
+  {
+    std::string testString = "foo.bar.baz";
+    StrVec exp {"foo", "bar", "baz"};
+    StrVec results;
+    axom::utilities::string::split(results, testString, '.');
+    EXPECT_EQ(exp, results);
+  }
+
+  // Test different delimeter
+  {
+    std::string testString = "foo.bar.baz";
+    StrVec exp {"foo.bar.baz"};
+    StrVec results;
+    axom::utilities::string::split(results, testString, ';');
+    EXPECT_EQ(exp, results);
+  }
+}
+
+TEST(utils_stringUtilities, splitLastNTokens)
+{
+  std::cout << "Testing split() function" << std::endl;
+  using StrVec = std::vector<std::string>;
+
+  // Test w/ sufficient tokens
+  {
+    const std::size_t N = 3;
+    std::string testString = "foo/bar/baz";
+    StrVec exp {"foo", "bar", "baz"};
+    StrVec results =
+      axom::utilities::string::splitLastNTokens(testString, N, '/');
+    EXPECT_LE(results.size(), N);
+    EXPECT_EQ(exp, results);
+  }
+
+  // Test w/ extra tokens
+  {
+    const std::size_t N = 2;
+    std::string testString = "foo/bar/baz";
+    StrVec exp {"foo/bar", "baz"};
+    StrVec results =
+      axom::utilities::string::splitLastNTokens(testString, N, '/');
+    EXPECT_LE(results.size(), N);
+    EXPECT_EQ(exp, results);
+  }
+
+  // Test w/ extra tokens
+  {
+    const std::size_t N = 1;
+    std::string testString = "foo/bar/baz";
+    StrVec exp {"foo/bar/baz"};
+    StrVec results =
+      axom::utilities::string::splitLastNTokens(testString, N, '/');
+    EXPECT_LE(results.size(), N);
+    EXPECT_EQ(exp, results);
+  }
+
+  // Test w/ larger N
+  {
+    const std::size_t N = 10;
+    std::string testString = "foo/bar/baz";
+    StrVec exp {"foo", "bar", "baz"};
+    StrVec results =
+      axom::utilities::string::splitLastNTokens(testString, N, '/');
+    EXPECT_LE(results.size(), N);
+    EXPECT_EQ(exp, results);
+  }
+
+  // Test w/ 0 expected tokens
+  {
+    const std::size_t N = 0;
+    std::string testString = "foo/bar/baz";
+    StrVec exp;
+    StrVec results =
+      axom::utilities::string::splitLastNTokens(testString, N, '/');
+    EXPECT_TRUE(results.empty());
+    EXPECT_EQ(exp, results);
+  }
+
+  // Test empty
+  {
+    const std::size_t N = 3;
+    std::string testString = "";
+    StrVec exp;
+    StrVec results =
+      axom::utilities::string::splitLastNTokens(testString, N, '/');
+    EXPECT_LE(results.size(), N);
+    EXPECT_EQ(exp, results);
+  }
+
+  // Test single
+  {
+    const std::size_t N = 3;
+    std::string testString = "foo";
+    StrVec exp {"foo"};
+    StrVec results =
+      axom::utilities::string::splitLastNTokens(testString, N, '/');
+    EXPECT_LE(results.size(), N);
+    EXPECT_EQ(exp, results);
+  }
+
+  // Test mixed delim: /
+  {
+    const std::size_t N = 3;
+    std::string testString = "foo.bar/baz.qux";
+    StrVec exp {"foo.bar", "baz.qux"};
+    StrVec results =
+      axom::utilities::string::splitLastNTokens(testString, N, '/');
+    EXPECT_LE(results.size(), N);
+    EXPECT_EQ(exp, results);
+  }
+
+  // Test mixed delim: .
+  {
+    const std::size_t N = 3;
+    std::string testString = "foo.bar/baz.qux";
+    StrVec exp {"foo", "bar/baz", "qux"};
+    StrVec results =
+      axom::utilities::string::splitLastNTokens(testString, N, '.');
+    EXPECT_LE(results.size(), N);
+    EXPECT_EQ(exp, results);
+  }
+}

--- a/src/axom/core/tests/utils_stringUtilities.hpp
+++ b/src/axom/core/tests/utils_stringUtilities.hpp
@@ -17,17 +17,6 @@ TEST(utils_stringUtilities, startsWith)
 {
   {
     std::string testString = "foo.bar";
-    std::string testPrefix = "boo";
-    EXPECT_FALSE(axom::utilities::string::startsWith(testString, testPrefix));
-  }
-
-  {
-    std::string testString = "foo.bar";
-    EXPECT_FALSE(axom::utilities::string::startsWith(testString, 'b'));
-  }
-
-  {
-    std::string testString = "foo.bar";
     std::string testPrefix = "foo";
     EXPECT_TRUE(axom::utilities::string::startsWith(testString, testPrefix));
   }
@@ -36,21 +25,21 @@ TEST(utils_stringUtilities, startsWith)
     std::string testString = "foo.bar";
     EXPECT_TRUE(axom::utilities::string::startsWith(testString, 'f'));
   }
+
+  {
+    std::string testString = "foo.bar";
+    std::string testPrefix = "boo";
+    EXPECT_FALSE(axom::utilities::string::startsWith(testString, testPrefix));
+  }
+
+  {
+    std::string testString = "foo.bar";
+    EXPECT_FALSE(axom::utilities::string::startsWith(testString, 'b'));
+  }
 }
 
 TEST(utils_stringUtilities, endsWith)
 {
-  {
-    std::string testString = "foo.bar";
-    std::string testSuffix = ".baz";
-    EXPECT_FALSE(axom::utilities::string::endsWith(testString, testSuffix));
-  }
-
-  {
-    std::string testString = "foo.bar";
-    EXPECT_FALSE(axom::utilities::string::endsWith(testString, 'z'));
-  }
-
   {
     std::string testString = "foo.bar";
     std::string testSuffix = ".bar";
@@ -61,18 +50,21 @@ TEST(utils_stringUtilities, endsWith)
     std::string testString = "foo.bar";
     EXPECT_TRUE(axom::utilities::string::endsWith(testString, 'r'));
   }
+
+  {
+    std::string testString = "foo.bar";
+    std::string testSuffix = ".baz";
+    EXPECT_FALSE(axom::utilities::string::endsWith(testString, testSuffix));
+  }
+
+  {
+    std::string testString = "foo.bar";
+    EXPECT_FALSE(axom::utilities::string::endsWith(testString, 'z'));
+  }
 }
 
 TEST(utils_stringUtilities, removeSuffix)
 {
-  // different suffix
-  {
-    std::string testString = "foo.bar";
-    std::string testSuffix = ".baz";
-    EXPECT_EQ("foo.bar",
-              axom::utilities::string::removeSuffix(testString, testSuffix));
-  }
-
   // same suffix
   {
     std::string testString = "foo.bar";
@@ -81,7 +73,15 @@ TEST(utils_stringUtilities, removeSuffix)
               axom::utilities::string::removeSuffix(testString, testSuffix));
   }
 
-  // repeated suffix -- only removes one
+  // different suffix
+  {
+    std::string testString = "foo.bar";
+    std::string testSuffix = ".baz";
+    EXPECT_EQ(testString,
+              axom::utilities::string::removeSuffix(testString, testSuffix));
+  }
+
+  // repeated suffix -- only removes one copy
   {
     std::string testString = "foo.bar.bar";
     std::string testSuffix = ".bar";
@@ -129,7 +129,7 @@ TEST(utils_stringUtilities, toUpper)
 {
   // already upper
   {
-    std::string testString = "foo.bar";
+    std::string testString = "FOO.BAR";
     std::string expString = "FOO.BAR";
     axom::utilities::string::toUpper(testString);
     EXPECT_EQ(expString, testString);
@@ -137,7 +137,7 @@ TEST(utils_stringUtilities, toUpper)
 
   // all lower
   {
-    std::string testString = "FOO.BAR";
+    std::string testString = "foo.bar";
     std::string expString = "FOO.BAR";
     axom::utilities::string::toUpper(testString);
     EXPECT_EQ(expString, testString);
@@ -156,7 +156,6 @@ TEST(utils_stringUtilities, split)
 {
   using StrVec = std::vector<std::string>;
 
-  // Test w/ proper delimiter
   {
     std::string testString = "foo/bar/baz";
     StrVec exp {"foo", "bar", "baz"};
@@ -165,7 +164,7 @@ TEST(utils_stringUtilities, split)
     EXPECT_EQ(exp, results);
   }
 
-  // Test empty
+  // Test empty string
   {
     std::string testString = "";
     StrVec exp;
@@ -174,7 +173,7 @@ TEST(utils_stringUtilities, split)
     EXPECT_EQ(exp, results);
   }
 
-  // Test single
+  // Test single token
   {
     std::string testString = "foo";
     StrVec exp {"foo"};
@@ -183,7 +182,7 @@ TEST(utils_stringUtilities, split)
     EXPECT_EQ(exp, results);
   }
 
-  // Test other delimiter
+  // Test other delimiter: '.'
   {
     std::string testString = "foo.bar.baz";
     StrVec exp {"foo", "bar", "baz"};
@@ -192,7 +191,7 @@ TEST(utils_stringUtilities, split)
     EXPECT_EQ(exp, results);
   }
 
-  // Test different delimiter
+  // Test different delimiter: '.' in string, ';' in function call
   {
     std::string testString = "foo.bar.baz";
     StrVec exp {"foo.bar.baz"};
@@ -217,7 +216,7 @@ TEST(utils_stringUtilities, splitLastNTokens)
     EXPECT_EQ(exp, results);
   }
 
-  // Test w/ extra tokens
+  // Test w/ more string tokens than N
   {
     const std::size_t N = 2;
     std::string testString = "foo/bar/baz";
@@ -228,7 +227,7 @@ TEST(utils_stringUtilities, splitLastNTokens)
     EXPECT_EQ(exp, results);
   }
 
-  // Test w/ extra tokens
+  // Test w/ more string tokens than N
   {
     const std::size_t N = 1;
     std::string testString = "foo/bar/baz";
@@ -239,7 +238,7 @@ TEST(utils_stringUtilities, splitLastNTokens)
     EXPECT_EQ(exp, results);
   }
 
-  // Test w/ larger N
+  // Test w/ fewer string tokens than N
   {
     const std::size_t N = 10;
     std::string testString = "foo/bar/baz";
@@ -250,7 +249,7 @@ TEST(utils_stringUtilities, splitLastNTokens)
     EXPECT_EQ(exp, results);
   }
 
-  // Test w/ 0 expected tokens
+  // Test w/ N==0
   {
     const std::size_t N = 0;
     std::string testString = "foo/bar/baz";
@@ -261,7 +260,7 @@ TEST(utils_stringUtilities, splitLastNTokens)
     EXPECT_EQ(exp, results);
   }
 
-  // Test empty
+  // Test w/ empty string
   {
     const std::size_t N = 3;
     std::string testString = "";
@@ -272,7 +271,7 @@ TEST(utils_stringUtilities, splitLastNTokens)
     EXPECT_EQ(exp, results);
   }
 
-  // Test single
+  // Test w/ single token in string
   {
     const std::size_t N = 3;
     std::string testString = "foo";

--- a/src/axom/core/tests/utils_utilities.hpp
+++ b/src/axom/core/tests/utils_utilities.hpp
@@ -91,16 +91,9 @@ TEST(utils_Utilities, random_real_with_seed)
   constexpr double a = -5.0;
   constexpr double b = 5.0;
 
-  const double expected_reals[5] = {-1.5112829544380526,
-                                    -2.3311429024686219,
-                                    -3.6335370551231403,
-                                    -4.714431326610093,
-                                    3.6893326916732878};
-
-  for(int i = 0; i < 5; ++i)
+  for(int i = 0; i < 1000; ++i)
   {
     const double real = axom::utilities::random_real(a, b, seed);
-    EXPECT_DOUBLE_EQ(real, expected_reals[i]);
     EXPECT_GE(real, a);
     EXPECT_LT(real, b);
   }
@@ -128,8 +121,8 @@ TEST(utils_Utilities, minmax)
     double a = 5.2;
     double b = -1.7;
 
-    int temp_min = axom::utilities::min(a, b);
-    int temp_max = axom::utilities::max(a, b);
+    double temp_min = axom::utilities::min(a, b);
+    double temp_max = axom::utilities::max(a, b);
 
     EXPECT_EQ(b, temp_min);
     EXPECT_EQ(a, temp_max);

--- a/src/axom/core/utilities/StringUtilities.cpp
+++ b/src/axom/core/utilities/StringUtilities.cpp
@@ -48,15 +48,20 @@ std::vector<std::string> splitLastNTokens(const std::string& input,
   auto last_pos = std::string::npos;
   auto pos = input.find_last_of(delim, last_pos - 1);
 
-  while((pos != std::string::npos) && (result.size() < n - 1))
+  if(n > 0 && !input.empty())
   {
-    result.push_back(input.substr(pos + 1, last_pos - pos - 1));
-    last_pos = pos;
-    pos = input.find_last_of(delim, last_pos - 1);
+    while((pos != std::string::npos) && (result.size() < n - 1))
+    {
+      result.push_back(input.substr(pos + 1, last_pos - pos - 1));
+      last_pos = pos;
+      pos = input.find_last_of(delim, last_pos - 1);
+    }
+
+    // Add the rest of the string (first token)
+    result.push_back(input.substr(0, last_pos));
+    std::reverse(result.begin(), result.end());
   }
-  // Add the rest of the string (first token)
-  result.push_back(input.substr(0, last_pos));
-  std::reverse(result.begin(), result.end());
+
   return result;
 }
 

--- a/src/axom/core/utilities/StringUtilities.hpp
+++ b/src/axom/core/utilities/StringUtilities.hpp
@@ -64,6 +64,21 @@ inline bool startsWith(const std::string& str, const char prefix)
 }
 
 /*!
+ * \brief Removes \a suffix from the end of \a str, if present
+ * \param [in] str string to be searched
+ * \param [in] suffix string to check for
+ * \return     String with (one copy of) \a suffix removed from end, if it was present  
+ */
+inline std::string removeSuffix(const std::string& str, const std::string& suffix)
+{
+  if(!suffix.empty() && endsWith(str, suffix))
+  {
+    return str.substr(0, str.size() - suffix.size());
+  }
+  return str;
+}
+
+/*!
  * \brief Splits the given string based on the given delimiter
  * \param [out] tokens    vector that the found tokens are appended to
  * \param [in]  str       string to be tokenized

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -858,10 +858,13 @@ void MFEMSidreDataCollection::Load(const std::string& path,
   #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
   if(m_comm != MPI_COMM_NULL)
   {
-    IOManager reader(m_comm);
     // The conduit abstraction appears to automatically handle the ".root"
     // suffix, but the IOManager does not, so it gets added here
-    reader.read(m_bp_grp->getDataStore()->getRoot(), path + ".root");
+    using axom::utilities::string::endsWith;
+    std::string suffixedPath = endsWith(path, ".root") ? path : path + ".root";
+
+    IOManager reader(m_comm);
+    reader.read(m_bp_grp->getDataStore()->getRoot(), suffixedPath);
   }
   else
   #endif

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -903,7 +903,8 @@ void MFEMSidreDataCollection::Load(const std::string& path,
   }
 
   // Set the mesh nodal grid function when present
-  const std::string gfPath = "topologies/mesh/grid_function";
+  const std::string gfPath =
+    fmt::format("topologies/{}/grid_function", s_mesh_topology_name);
   if(GetBPGroup()->hasView(gfPath))
   {
     const std::string nodalGFName = GetBPGroup()->getView(gfPath)->getString();

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -893,7 +893,6 @@ void MFEMSidreDataCollection::Load(const std::string& path,
 
   // Set the mesh nodal grid function when present
   const std::string gfPath = "topologies/mesh/grid_function";
-  SLIC_INFO("BPGroup path: " << GetBPGroup()->getPath());
   if(GetBPGroup()->hasView(gfPath))
   {
     const std::string nodalGFName = GetBPGroup()->getView(gfPath)->getString();

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -876,8 +876,7 @@ void MFEMSidreDataCollection::Load(const std::string& path,
   // the domain and global groups are, and can restore them after the Load().
   //
   // If the data collection did not create the datastore, the host code must
-  // reset these pointers after the load operation and also reset the state
-  // variables.
+  // reset these pointers after the load operation and also reset the state variables.
   if(m_owns_datastore)
   {
     // Use the same path format as was used to create the datastore
@@ -890,6 +889,19 @@ void MFEMSidreDataCollection::Load(const std::string& path,
 
     UpdateStateFromDS();
     UpdateMeshAndFieldsFromDS();
+  }
+
+  // Set the mesh nodal grid function when present
+  const std::string gfPath = "topologies/mesh/grid_function";
+  SLIC_INFO("BPGroup path: " << GetBPGroup()->getPath());
+  if(GetBPGroup()->hasView(gfPath))
+  {
+    const std::string nodalGFName = GetBPGroup()->getView(gfPath)->getString();
+    if(this->HasField(nodalGFName))
+    {
+      this->SetMeshNodesName(nodalGFName);
+      mesh->NewNodes(*this->GetField(nodalGFName), false);
+    }
   }
 }
 

--- a/src/axom/sidre/spio/IOManager.hpp
+++ b/src/axom/sidre/spio/IOManager.hpp
@@ -283,6 +283,13 @@ public:
    */
   int getNumFilesFromRoot(const std::string& root_file);
 
+  /*!
+   * \brief gets the number of groups in the dataset from the specified root file
+   *
+   * Usually this is the number of MPI ranks that wrote data to this set of files.
+   */
+  int getNumGroupsFromRoot(const std::string& root_file);
+
 private:
   DISABLE_COPY_AND_ASSIGNMENT(IOManager);
 
@@ -300,15 +307,6 @@ private:
    */
   std::string getFilePatternFromRoot(const std::string& root_name,
                                      const std::string& protocol);
-
-  /*!
-   * \brief gets the number of groups in the dataset from the specified root
-   * file
-   *
-   * Usually this is the number of MPI ranks that wrote data to this set
-   * of files.
-   */
-  int getNumGroupsFromRoot(const std::string& root_file);
 
 #ifdef AXOM_USE_HDF5
   std::string getHDF5FilePattern(const std::string& root_name);

--- a/src/axom/spin/BVH.hpp
+++ b/src/axom/spin/BVH.hpp
@@ -148,7 +148,7 @@ private:
   {
   private:
     template <typename U, typename Ret = decltype(std::declval<U&>()[0])>
-    static Ret array_operator_type(U obj)
+    static Ret array_operator_type(U AXOM_NOT_USED(obj))
     { }
 
     static std::false_type array_operator_type(...)
@@ -203,7 +203,7 @@ public:
    *  the code will use the default allocator ID for the execution space
    *  specified via axom::execution_space<ExecSpace>::allocatorID() when the
    *  BVH object is instantiated.
-   * 
+   *
    * \warning The supplied boxes array must point to a buffer in a memory space
    *  that is compatible with the execution space. For example, when using
    *  CUDA_EXEC, boxes must be in unified memory or GPU memory. The code

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -69,6 +69,34 @@ if(AXOM_ENABLE_QUEST)
 endif()
 
 #------------------------------------------------------------------------------
+# data_collection_util is a utility that generates blueprint-conforming sidre
+# output files from an input mfem mesh
+#------------------------------------------------------------------------------
+if( AXOM_ENABLE_SIDRE AND HDF5_FOUND AND MFEM_FOUND AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION )
+
+    set(data_collection_util
+        data_collection_util.cpp
+    )
+    set(data_collection_util_depends
+        axom
+        mfem
+        cli11
+        fmt
+        )
+
+    blt_add_executable(
+        NAME        data_collection_util
+        SOURCES     ${data_collection_util}
+        OUTPUT_DIR  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        DEPENDS_ON  ${data_collection_util_depends}
+        FOLDER      axom/examples
+        )
+    install(TARGETS              data_collection_util
+            DESTINATION          bin
+            )
+
+endif()
+#------------------------------------------------------------------------------
 # Add code checks
 #------------------------------------------------------------------------------
 axom_add_code_checks(PREFIX tools)

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -91,6 +91,12 @@ if( AXOM_ENABLE_SIDRE AND MFEM_FOUND AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION )
         DEPENDS_ON  ${data_collection_util_depends}
         FOLDER      axom/examples
         )
+
+    axom_add_test(
+      NAME    data_collection_util_box2D
+      COMMAND data_collection_util --min -1 -1 --max 1 1 --res 16 16 -p 1
+      )
+
     install(TARGETS              data_collection_util
             DESTINATION          bin
             )

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -19,7 +19,7 @@ if( AXOM_ENABLE_SLAM AND AXOM_ENABLE_SIDRE AND ENABLE_MPI AND HDF5_FOUND )
     set(datastore_converter_sources
         convert_sidre_protocol.cpp
     )
-    set(datastore_converter_depends 
+    set(datastore_converter_depends
         axom
         mpi
         cli11
@@ -45,7 +45,7 @@ endif()
 set(mesh_tester_sources
     mesh_tester.cpp
 )
-set(mesh_tester_depends 
+set(mesh_tester_depends
     axom
     )
 
@@ -72,7 +72,7 @@ endif()
 # data_collection_util is a utility that generates blueprint-conforming sidre
 # output files from an input mfem mesh
 #------------------------------------------------------------------------------
-if( AXOM_ENABLE_SIDRE AND HDF5_FOUND AND MFEM_FOUND AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION )
+if( AXOM_ENABLE_SIDRE AND MFEM_FOUND AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION )
 
     set(data_collection_util
         data_collection_util.cpp

--- a/src/tools/data_collection_util.cpp
+++ b/src/tools/data_collection_util.cpp
@@ -161,6 +161,7 @@ public:
 
   void parse(int argc, char** argv, CLI::App& app)
   {
+    // Options that are always available
     app.add_option("-o, --output-name", dcName)
       ->description(
         "Name of the output mesh. Defaults to box{2,3}d for box meshes, and "
@@ -185,40 +186,44 @@ public:
       ->transform(CLI::CheckedTransformer(meshFormMap, CLI::ignore_case));
 
     // Parameters for the box mesh option
-    auto* minbb = app.add_option("--min", boxMins)
+    auto* box_options =
+      app.add_option_group("box", "Options for setting up a box mesh");
+    auto* minbb = box_options->add_option("--min", boxMins)
                     ->description("Min bounds for box mesh (x,y[,z])")
                     ->expected(2, 3);
-    auto* maxbb = app.add_option("--max", boxMaxs)
+    auto* maxbb = box_options->add_option("--max", boxMaxs)
                     ->description("Max bounds for box mesh (x,y[,z])")
                     ->expected(2, 3);
     minbb->needs(maxbb);
     maxbb->needs(minbb);
 
-    app.add_option("--res", boxResolution)
+    box_options->add_option("--res", boxResolution)
       ->description("Resolution of the box mesh (i,j[,k])")
       ->expected(2, 3);
 
-    app.add_option("-d,--dimension", boxDim)
+    box_options->add_option("-d,--dimension", boxDim)
       ->description("Dimension of the box mesh")
-      ->capture_default_str()
       ->check(CLI::PositiveNumber);
 
-    app.add_option("-p,--polynomial-order", polynomialOrder)
+    box_options->add_option("-p,--polynomial-order", polynomialOrder)
       ->description("polynomial order of the generated mesh")
       ->capture_default_str()
       ->check(CLI::NonNegativeNumber);
 
     // Parameters for the 'file' option
-    app.add_option("-m, --mfem-file", mfemFile)
+    auto* file_options =
+      app.add_option_group("file", "Options for loading from an mfem mesh file");
+
+    file_options->add_option("-m, --mfem-file", mfemFile)
       ->description("Path to a mesh file in the mfem format")
       ->check(CLI::ExistingFile);
 
-    app.add_option("--scale", fileScale)
+    file_options->add_option("--scale", fileScale)
       ->description(
         "Scale factors for the file mesh. Can either be one value or "
         "mesh.Dimension() values")
       ->expected(1, 3);
-    app.add_option("--translate", fileTranslate)
+    file_options->add_option("--translate", fileTranslate)
       ->description("Translation for the file mesh (sx,sy[,sz])")
       ->expected(2, 3);
 

--- a/src/tools/data_collection_util.cpp
+++ b/src/tools/data_collection_util.cpp
@@ -64,6 +64,7 @@ private:
 
   /**
    * Fixes up parameters associated with a box mesh based on user-provided input
+   * \throws CLI::ValidationError if the options are invalid or insufficient
    */
   void fixBoxParams()
   {
@@ -74,8 +75,10 @@ private:
     // First check: we need at least one of: dimension, mins/maxs, resolution
     if(!(dimProvided || rangeProvided || resProvided))
     {
-      throw "Box mesh must have at least one of: dimension, mins and maxs or "
-        "resolution to determine the dimension";
+      throw CLI::ValidationError(
+        "box",
+        "Box mesh must have at least one of: dimension, mins and maxs or "
+        "resolution to determine the dimension");
     }
 
     int szMins = boxMins.size();
@@ -85,32 +88,42 @@ private:
     // Error checking on provided dimension
     if(dimProvided)
     {
-      if(boxDim < 1 || boxDim > 3)
+      if(boxDim <= 1 || boxDim > 3)
       {
-        throw "Dimension cannot exceed 3";
+        throw CLI::ValidationError(
+          "box",
+          fmt::format("Invalid dimension: {}. Only 2D and 3D supported", boxDim));
       }
 
       // Ensure that range and resolution have the right number of entries
       if(rangeProvided && (szMins != boxDim || szMaxs != boxDim))
       {
-        throw "Bounding box has different dimension than provided dimension";
+        throw CLI::ValidationError(
+          "box",
+          "Bounding box has different dimension than provided dimension");
       }
       if(resProvided && (szRes != boxDim))
       {
-        throw "Box resolution has different dimension than provided dimension";
+        throw CLI::ValidationError(
+          "box",
+          "Box resolution has different dimension than provided dimension");
       }
     }
 
     // Error checking on provided range; note: accounts for previous checks on dim
     if(rangeProvided && (szMins != szMaxs))
     {
-      throw "Bounding box mins and maxs has different dimensions";
+      throw CLI::ValidationError(
+        "box",
+        "Bounding box mins and maxs has different dimensions");
     }
 
     // Error checking on provided range and resolution; note: accounts for previous checks on dim and range
     if(rangeProvided && resProvided && (szMins != szRes))
     {
-      throw "Bounding box mins and maxs has different dimensions than resolution";
+      throw CLI::ValidationError(
+        "box",
+        "Bounding box mins and maxs has different dimensions than resolution");
     }
 
     // Now that we've checked errors, let's fill in missing data
@@ -230,7 +243,9 @@ public:
     {
       if(mfemFile.empty())
       {
-        throw "'mfemFile' required when `--mesh-form == File`";
+        throw CLI::ValidationError(
+          "file",
+          "'mfemFile' required when `--mesh-form == File`");
       }
 
       if(dcName.empty())

--- a/src/tools/data_collection_util.cpp
+++ b/src/tools/data_collection_util.cpp
@@ -1,0 +1,416 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+// Axom includes
+#include "axom/config.hpp"
+#include "axom/core.hpp"
+#include "axom/slic.hpp"
+#include "axom/sidre.hpp"
+#include "axom/primal.hpp"
+
+#include "fmt/fmt.hpp"
+#include "CLI11/CLI11.hpp"
+
+// MFEM is required
+#ifndef AXOM_USE_MFEM
+  #error This example requires an Axom configured with MFEM
+#endif
+#include "mfem.hpp"
+
+// MPI is optional
+#ifdef AXOM_USE_MPI
+  #include "mpi.h"
+#endif
+
+namespace slic = axom::slic;
+namespace sidre = axom::sidre;
+namespace primal = axom::primal;
+
+//------------------------------------------------------------------------------
+
+/// Struct to help choose if we're loading a box (Cartesian) mesh or a file
+enum class MeshForm : int
+{
+  Box,
+  File
+};
+
+/// Struct to parse and store the input parameters
+struct Input
+{
+public:
+  std::string dcName {"mesh"};
+
+  int uniformRefinements {0};
+  int polynomialOrder {2};
+
+  MeshForm meshForm {MeshForm::Box};
+
+  // Box mesh parameters
+  std::vector<double> boxMins;
+  std::vector<double> boxMaxs;
+  std::vector<int> boxResolution;
+  int boxDim {-1};
+
+  std::string mfemFile;
+
+private:
+  bool m_verboseOutput {false};
+
+  /**
+   * Fixes up parameters associated with a box mesh based on user-provided input
+   */
+  void fixBoxParams()
+  {
+    const bool dimProvided = boxDim > 0;
+    const bool rangeProvided = !(boxMins.empty() && boxMaxs.empty());
+    const bool resProvided = !boxResolution.empty();
+
+    // First check: we need at least one of: dimension, mins/maxs, resolution
+    if(!(dimProvided || rangeProvided || resProvided))
+    {
+      throw "Box mesh must have at least one of: dimension, mins and maxs or "
+        "resolution to determine the dimension";
+    }
+
+    int szMins = boxMins.size();
+    int szMaxs = boxMaxs.size();
+    int szRes = boxResolution.size();
+
+    // Error checking on provided dimension
+    if(dimProvided)
+    {
+      if(boxDim < 1 || boxDim > 3)
+      {
+        throw "Dimension cannot exceed 3";
+      }
+
+      // Ensure that range and resolution have the right number of entries
+      if(rangeProvided && (szMins != boxDim || szMaxs != boxDim))
+      {
+        throw "Bounding box has different dimension than provided dimension";
+      }
+      if(resProvided && (szRes != boxDim))
+      {
+        throw "Box resolution has different dimension than provided dimension";
+      }
+    }
+
+    // Error checking on provided range; note: accounts for previous checks on dim
+    if(rangeProvided && (szMins != szMaxs))
+    {
+      throw "Bounding box mins and maxs has different dimensions";
+    }
+
+    // Error checking on provided range and resolution; note: accounts for previous checks on dim and range
+    if(rangeProvided && resProvided && (szMins != szRes))
+    {
+      throw "Bounding box mins and maxs has different dimensions than resolution";
+    }
+
+    // Now that we've checked errors, let's fill in missing data
+    const int dim = dimProvided ? boxDim : (resProvided ? szRes : szMins);
+    if(!dimProvided)
+    {
+      boxDim = dim;
+    }
+
+    if(!rangeProvided)  // set range to unit box
+    {
+      boxMins.resize(dim);
+      boxMaxs.resize(dim);
+      for(int i = 0; i < dim; ++i)
+      {
+        boxMins[i] = 0.;
+        boxMaxs[i] = 1.;
+      }
+    }
+
+    if(!resProvided)  // set resolution to 1
+    {
+      boxResolution.resize(dim);
+      for(int i = 0; i < dim; ++i)
+      {
+        boxResolution[i] = 1;
+      }
+    }
+  }
+
+public:
+  Input() = default;
+
+  bool isVerbose() const { return m_verboseOutput; }
+
+  void parse(int argc, char** argv, CLI::App& app)
+  {
+    app.add_option("-m, --mfem-file", mfemFile)
+      ->description("Path to a mesh file in the mfem format")
+      ->check(CLI::ExistingFile);
+
+    app.add_flag("-v,--verbose", m_verboseOutput)
+      ->description("Enable/disable verbose output")
+      ->capture_default_str();
+
+    app.add_option("-p,--polynomial-order", polynomialOrder)
+      ->description("polynomial order of the generated mesh")
+      ->capture_default_str()
+      ->check(CLI::NonNegativeNumber);
+
+    std::map<std::string, MeshForm> meshFormMap {{"box", MeshForm::Box},
+                                                 {"file", MeshForm::File}};
+    app.add_option("-f,--mesh-form", meshForm)
+      ->description("Determines the input type -- either box or file")
+      ->capture_default_str()
+      ->transform(CLI::CheckedTransformer(meshFormMap, CLI::ignore_case));
+
+    app.add_option("-l,--ref-level", uniformRefinements)
+      ->description(
+        "The number of uniform refinement levels to apply to the mesh")
+      ->capture_default_str()
+      ->check(CLI::NonNegativeNumber);
+
+    // Optional bounding box for query region
+    auto* minbb = app.add_option("--min", boxMins)
+                    ->description("Min bounds for box mesh (x,y[,z])")
+                    ->expected(2, 3);
+    auto* maxbb = app.add_option("--max", boxMaxs)
+                    ->description("Max bounds for box mesh (x,y[,z])")
+                    ->expected(2, 3);
+    minbb->needs(maxbb);
+    maxbb->needs(minbb);
+
+    app.add_option("--res", boxResolution)
+      ->description("Reesolution of the box mesh (i,j[,k])")
+      ->expected(2, 3);
+
+    app.add_option("-d,--dimension", boxDim)
+      ->description("dimension of the box mesh")
+      ->capture_default_str()
+      ->check(CLI::PositiveNumber);
+
+    app.get_formatter()->column_width(50);
+
+    // could throw an exception
+    app.parse(argc, argv);
+
+    slic::setLoggingMsgLevel(m_verboseOutput ? slic::message::Debug
+                                             : slic::message::Info);
+
+    if(meshForm == MeshForm::Box)
+    {
+      fixBoxParams();  // Note: throws on error conditions
+    }
+    else
+    {
+      if(mfemFile.empty())
+      {
+        throw "'mfemFile' required when `--mesh-form == File`";
+      }
+    }
+  }
+};
+
+mfem::Mesh* createBoxMesh(Input& params)
+{
+  // Create a background mesh
+  // Generate an mfem Cartesian mesh, scaled to the bounding box range
+
+  const int dim = params.boxDim;
+  auto& lo = params.boxMins;
+  auto& hi = params.boxMaxs;
+  auto& res = params.boxResolution;
+
+  mfem::Mesh* mesh = nullptr;
+
+  // TODO: Convert to MakeCartesian2D and MakeCartesian3D when upgrading to mfem@4.3
+  switch(dim)
+  {
+  case 2:
+    SLIC_INFO(fmt::format(
+      "Creating a box mesh of resolution {} and bounding box {}",
+      primal::Point<int, 2>(res.data()),
+      primal::BoundingBox<double, 2>(primal::Point<double, 2>(lo.data()),
+                                     primal::Point<double, 2>(hi.data()))));
+
+    mesh = new mfem::Mesh(res[0],
+                          res[1],
+                          mfem::Element::QUADRILATERAL,
+                          false,
+                          hi[0] - lo[0],
+                          hi[1] - lo[1]);
+    break;
+  case 3:
+    SLIC_INFO(fmt::format(
+      "Creating a box mesh of resolution {} and bounding box {}",
+      primal::Point<int, 3>(res.data()),
+      primal::BoundingBox<double, 3>(primal::Point<double, 3>(lo.data()),
+                                     primal::Point<double, 3>(hi.data()))));
+
+    mesh = new mfem::Mesh(res[0],
+                          res[1],
+                          res[2],
+                          mfem::Element::HEXAHEDRON,
+                          false,
+                          hi[0] - lo[0],
+                          hi[1] - lo[1],
+                          hi[2] - lo[2]);
+    break;
+  default:
+    SLIC_ERROR("Only 2D and 3D meshes are currently supported.");
+    break;
+  }
+
+  // Offset to the mesh to lie w/in the bounding box
+  for(int i = 0; i < mesh->GetNV(); ++i)
+  {
+    double* v = mesh->GetVertex(i);
+    for(int d = 0; d < dim; ++d)
+    {
+      v[d] += lo[d];
+    }
+  }
+
+  // Ensure that mesh has high order nodes
+  mesh->SetCurvature(params.polynomialOrder);
+
+  return mesh;
+}
+
+/*!
+ * \brief Utility function to initialize the logger
+ */
+void initializeLogger()
+{
+  // Initialize Logger
+  slic::initialize();
+  slic::setLoggingMsgLevel(slic::message::Info);
+
+  slic::LogStream* logStream;
+
+#ifdef AXOM_USE_MPI
+  std::string fmt = "[<RANK>][<LEVEL>]: <MESSAGE>\n";
+  #ifdef AXOM_USE_LUMBERJACK
+  const int RLIMIT = 8;
+  logStream = new slic::LumberjackStream(&std::cout, MPI_COMM_WORLD, RLIMIT, fmt);
+  #else
+  logStream = new slic::SynchronizedStream(&std::cout, MPI_COMM_WORLD, fmt);
+  #endif
+#else
+  std::string fmt = "[<LEVEL>]: <MESSAGE>\n";
+  logStream = new slic::GenericOutputStream(&std::cout, fmt);
+#endif  // AXOM_USE_MPI
+
+  slic::addStreamToAllMsgLevels(logStream);
+}
+
+/*!
+ * \brief Utility function to finalize the logger
+ */
+void finalizeLogger()
+{
+  if(slic::isInitialized())
+  {
+    slic::flushStreams();
+    slic::finalize();
+  }
+}
+
+//------------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+#ifdef AXOM_USE_MPI
+  MPI_Init(&argc, &argv);
+  int my_rank, num_ranks;
+  MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
+#else
+  int my_rank = 0;
+  int num_ranks = 1;
+#endif
+
+  initializeLogger();
+
+  // Set up and parse command line arguments
+  Input params;
+  CLI::App app {"Utility tool to create a blueprint compliant data store"};
+
+  try
+  {
+    params.parse(argc, argv, app);
+  }
+  catch(const CLI::ParseError& e)
+  {
+    int retval = -1;
+    if(my_rank == 0)
+    {
+      retval = app.exit(e);
+    }
+    finalizeLogger();
+
+#ifdef AXOM_USE_MPI
+    MPI_Bcast(&retval, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    MPI_Finalize();
+#endif
+    exit(retval);
+  }
+
+  // Create the mfem sidre data collection
+  sidre::MFEMSidreDataCollection dc(params.dcName, nullptr, true);
+
+  // Create or load the serial mfem mesh
+  mfem::Mesh* mesh = nullptr;
+  switch(params.meshForm)
+  {
+  case MeshForm::Box:
+    mesh = createBoxMesh(params);
+    break;
+
+  case MeshForm::File:
+    mesh = new mfem::Mesh(params.mfemFile.c_str(), 1, 1);
+    break;
+  }
+
+  // Apply uniform refinements
+  for(int i = 0; i < params.uniformRefinements; ++i)
+  {
+    mesh->UniformRefinement();
+  }
+
+  // Handle conversion to parallel mfem mesh
+#if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
+  {
+    int* partitioning = nullptr;
+    int part_method = 0;
+    mfem::Mesh* pmesh =
+      new mfem::ParMesh(MPI_COMM_WORLD, *mesh, partitioning, part_method);
+    delete[] partitioning;
+    delete mesh;
+    mesh = pmesh;
+  }
+#endif
+
+  // Add mfem mesh to data collection
+  dc.SetMeshNodesName("positions");
+#ifdef MFEM_USE_MPI
+  dc.SetMesh(MPI_COMM_WORLD, mesh);
+#else
+  dc.SetMesh(mesh);
+#endif
+
+  // TODO: Optionally convert to low order mesh ?
+
+  SLIC_INFO(fmt::format("Saving mesh file '{}'", dc.GetCollectionName()));
+#ifdef MFEM_USE_MPI
+  dc.Save();
+#endif
+
+  // Cleanup and exit
+  finalizeLogger();
+
+#ifdef AXOM_USE_MPI
+  MPI_Finalize();
+#endif
+  return 0;
+}


### PR DESCRIPTION
# Summary

- This PR is a feature, but also includes some bugfixes
- It adds a new tool for generating distributed blueprint-compliant (high order) meshes over a Cartesian domain or from an mfem mesh: `data_collection_util`. The latter is active when Axom is configured with `mfem` and `AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION`
 
- This PR also improves support for loading data collections in `MFEMSidreDataCollection`. 
- Specifically:
    - It avoids appending the `.root` suffix to an input root file when that suffix is already present
    - It wires up the high order nodal grid function during load (when available)
    - It improves error messages when attempting to load using a different number of ranks than were used to save the file

- This PR also add a new string utility function: `removeSuffix()`
- I noticed that the string utilities did not have unit tests, so I added some
- In doing so, there were a few undocumented edge-case behaviors. I'd like the reviewers to sign off on the changes I made (which I'll point out via comments)

#### TODO:

- [x] Update RELEASE-NOTES