### PR TITLE
Extend Array to multiple dimensions

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -67,6 +67,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Spin: Removed hard dependency on RAJA and Umpire from `BVH`.
 - Moved `slam::IteratorBase` to `axom::IteratorBase`.
 - `sidre::Array` now derives from `axom::MCArray`.
+- `axom::Array` is now multidimensional; it intends to behave like `std::vector` in the 1D case
+  and `numpy.ndarray` in the multidimensional case
 
 ### Fixed
 - Fixed Primal's `intersect(Ray, Segment)` calculation for Segments that do not have unit length

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -74,6 +74,13 @@ bool operator!=(const Array<T>& lhs, const Array<T>& rhs);
  *
  *  The Array class mirrors std::vector, with future support for GPUs
  *  in-development.
+ * 
+ *  This class is meant to be a drop-in replacement for std::vector.
+ *  However, it differs in its memory management and construction semantics.
+ *  Specifically, we also allow axom::Array to wrap memory that it does
+ *  not own (external storage), we do not require axom::Array to initialize/construct
+ *  its memory at allocation time, and we use axom's memory_management
+ *  and allocator ID abstractions rather than std::allocator.
  *
  *  Depending on which constructor is used, the Array object can have two
  *  different underlying storage types:

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -1176,7 +1176,7 @@ inline void Array<T, dim>::resize(Args... args)
   updateNumElements(new_num_elements);
 
   // Can't reinitialize a raw array so we have to throw it into a temp
-  IndexType temp_dims[] = {static_cast<std::size_t>(args)...};
+  IndexType temp_dims[] = {static_cast<IndexType>(args)...};
   std::copy(temp_dims, temp_dims + dim, m_dims);
   // Row-major
   m_strides[dim - 1] = 1;

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -105,6 +105,12 @@ class ArrayImpl
 {
 public:
   using ArrayType = Array<T, DIM>;
+
+  /*!
+   * \brief Parameterized constructor that sets up the default strides
+   *
+   * \param [in] args the parameter pack of sizes in each dimension.
+   */
   template <typename... Args>
   ArrayImpl(Args... args) : m_dims {static_cast<IndexType>(args)...}
   {
@@ -148,6 +154,7 @@ public:
     return asDerived().data()[idx];
   }
 
+  /// \brief Swaps two ArrayImpls
   friend void swap(ArrayImpl& lhs, ArrayImpl& rhs)
   {
     std::swap(lhs.m_dims, rhs.m_dims);
@@ -216,6 +223,9 @@ public:
   // Double curly braces needed for C++11 prior to resolution of CWG issue 1720
   std::array<IndexType, 1> shape() const { return {{asDerived().size()}}; }
 
+  /// \brief Swaps two ArrayImpls
+  friend void swap(ArrayImpl& lhs, ArrayImpl& rhs) { }
+
 private:
   ArrayType& asDerived() { return static_cast<ArrayType&>(*this); }
   const ArrayType& asDerived() const
@@ -223,10 +233,6 @@ private:
     return static_cast<const ArrayType&>(*this);
   }
 };
-
-template <typename T>
-void swap(ArrayImpl<T, 1>& lhs, ArrayImpl<T, 1>& rhs)
-{ }
 
 /*!
  * \class Array
@@ -245,13 +251,6 @@ void swap(ArrayImpl<T, 1>& lhs, ArrayImpl<T, 1>& rhs)
  *  multidimensional arrays that roughly resemble numpy's ndarray.
  * 
  *  \see https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html
- * 
- *  In the 1-dimensional case, this class will behave like std::vector.
- *  In higher dimensions some vector-like functionality will be unavailable,
- *  e.g., @p push_back , and multidimensional-specific operations will mirror
- *  ndarray when possible.  In the future, it will be possible to take "views"
- *  of the underlying array data that allow for flexible reinterpretation via
- *  different striding.
  * 
  *  This class is meant to be a drop-in replacement for std::vector.
  *  However, it differs in its memory management and construction semantics.

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -15,6 +15,7 @@
 
 // C/C++ includes
 #include <iostream>  // for std::cerr and std::ostream
+#include <numeric>   // for std::inner_product
 
 namespace axom
 {

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -213,7 +213,8 @@ public:
 
   /// \brief Returns the dimensions of the Array
   // FIXME: std::array is used for consistency with multidim case, should we just return the scalar?
-  std::array<IndexType, 1> shape() const { return {asDerived().size()}; }
+  // Double curly braces needed for C++11 prior to resolution of CWG issue 1720
+  std::array<IndexType, 1> shape() const { return {{asDerived().size()}}; }
 
 private:
   ArrayType& asDerived() { return static_cast<ArrayType&>(*this); }

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -965,7 +965,7 @@ Array<T, DIM>::Array(T* data, IndexType num_elements, IndexType capacity)
 //------------------------------------------------------------------------------
 template <typename T, int DIM>
 Array<T, DIM>::Array(const Array& other, int allocator_id)
-  : ArrayImpl<T, DIM>(static_cast<const ArrayImpl<T, DIM>&>(other))
+  : ArrayImpl<T, DIM>(other)
   , m_allocator_id(allocator_id)
 {
   initialize(other.size(), other.capacity());
@@ -975,7 +975,7 @@ Array<T, DIM>::Array(const Array& other, int allocator_id)
 //------------------------------------------------------------------------------
 template <typename T, int DIM>
 Array<T, DIM>::Array(Array&& other)
-  : ArrayImpl<T, DIM>(static_cast<ArrayImpl<T, DIM>&&>(other))
+  : ArrayImpl<T, DIM>(std::move(other))
   , m_resize_ratio(0.0)
   , m_allocator_id(axom::getDefaultAllocatorID())
 {
@@ -1237,8 +1237,7 @@ inline void Array<T, DIM>::resize(Args... args)
 template <typename T, int DIM>
 inline void Array<T, DIM>::swap(Array<T, DIM>& other)
 {
-  static_cast<ArrayImpl<T, DIM>&>(*this).swap(
-    static_cast<ArrayImpl<T, DIM>&>(other));
+  ArrayImpl<T, DIM>::swap(other);
   T* temp_data = m_data;
   IndexType temp_num_elements = m_num_elements;
   IndexType temp_capacity = m_capacity;

--- a/src/axom/core/docs/sphinx/core_containers.rst
+++ b/src/axom/core/docs/sphinx/core_containers.rst
@@ -7,11 +7,25 @@
 Core containers
 ******************************************************
 
-Axom Core contains the Array and StackArray classes.  Among other things, these
+.. warning::
+   Axom's containers are currently the target of a refactoring effort. The following
+   information is subject to change, as are the interfaces for the containers themselves.
+
+Axom Core contains the Array, MCArray, and StackArray classes.  Among other things, these
 data containers facilitate porting code that uses `std::vector` to the GPU.
 
+Array is a multidimensional contiguous container template.  In the 1-dimensional case,
+this class will behave like std::vector.  In higher dimensions some vector-like
+functionality will be unavailable, e.g., ``push_back``, and multidimensional-specific
+operations will mirror the ``ndarray`` provided by ``numpy`` when possible.
+In the future, it will be possible to take "views" of the underlying array data that
+allow for flexible reinterpretation via different striding.
 
-Here's an example showing how to use Array instead of `std::vector`.
+MCArray (or Multi-Component Array) is a container template for a contiguous array of tuples.
+In this sense it can be thought of as a two-dimensional array.  MCArray will be removed
+imminently as Array provides/will provide this multidimensional functionality.
+
+Here's an example showing how to use MCArray instead of `std::vector`.
 
 .. literalinclude:: ../../examples/core_containers.cpp
    :start-after: _arraybasic_start
@@ -19,14 +33,14 @@ Here's an example showing how to use Array instead of `std::vector`.
    :language: C++
 
 Applications commonly store tuples of data in a flat array or a `std::vector`.
-The Array class formalizes tuple storage, as shown in the next example.
+The MCArray class formalizes tuple storage, as shown in the next example.
 
 .. literalinclude:: ../../examples/core_containers.cpp
    :start-after: _arraytuple_start
    :end-before: _arraytuple_end
    :language: C++
 
-The Array class can use an external memory buffer, with the restriction that 
+The MCArray class can use an external memory buffer, with the restriction that 
 operations that would cause the buffer to resize are not permitted.
 
 .. literalinclude:: ../../examples/core_containers.cpp
@@ -34,7 +48,7 @@ operations that would cause the buffer to resize are not permitted.
    :end-before: _extbuffer_end
    :language: C++
 
-Similar to `std::vector`, when using an internal array the Array class can
+Similar to `std::vector`, when using an internal array the Array and MCArray classes can
 reserve memory in anticipation of future growth as well as shrink to just the
 memory currently in use.
 

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -245,6 +245,7 @@ inline T* reallocate(T* pointer, std::size_t n, int allocID) noexcept
     pointer = axom::allocate<T>(0);
   }
 
+  AXOM_UNUSED_VAR(allocID);
 #endif
 
   return pointer;

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -93,7 +93,7 @@ endif()
 #------------------------------------------------------------------------------
 # OpenMP GTests
 #------------------------------------------------------------------------------
-if (ENABLE_OPENMP)
+if (ENABLE_OPENMP AND AXOM_USE_RAJA)
   set( core_openmp_tests
        core_openmp_map.hpp
        )

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1092,4 +1092,41 @@ TEST(core_array, check_move_copy)
   }
 }
 
+//------------------------------------------------------------------------------
+TEST(core_array, check_multidimensional)
+{
+  constexpr int MAGIC_INT = 255;
+  constexpr double MAGIC_DOUBLE = 5683578.8;
+
+  // First test multidimensional int arrays
+  Array<int, 2> v_int;
+  v_int.resize(2, 2);
+  v_int.fill(MAGIC_INT);
+  // Make sure the number of elements and contents are correct
+  EXPECT_EQ(v_int.fullSize(), 4);
+  for(const auto val : v_int)
+  {
+    EXPECT_EQ(val, MAGIC_INT);
+  }
+  // Then assign different values to each element
+  v_int(0, 0) = 1;
+  v_int(0, 1) = 2;
+  v_int(1, 0) = 3;
+  v_int(1, 1) = 4;
+
+  // FIXME: Should we add a std::initializer_list ctor?
+  Array<int> v_int_flat(4);
+  v_int_flat[0] = 1;
+  v_int_flat[1] = 2;
+  v_int_flat[2] = 3;
+  v_int_flat[3] = 4;
+
+  // FIXME: Should we be able to compare arrays of different dimension (by comparing the raw data)?
+  for(int i = 0; i < v_int_flat.size(); i++)
+  {
+    // For a multidim array, op[] is a "flat" index into the raw data
+    EXPECT_EQ(v_int[i], v_int_flat[i]);
+  }
+}
+
 } /* end namespace axom */

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1103,7 +1103,7 @@ TEST(core_array, check_multidimensional)
   v_int.resize(2, 2);
   v_int.fill(MAGIC_INT);
   // Make sure the number of elements and contents are correct
-  EXPECT_EQ(v_int.size(), 4);
+  EXPECT_EQ(v_int.size(), 2 * 2);
   std::array<IndexType, 2> expected_shape = {2, 2};
   EXPECT_EQ(v_int.shape(), expected_shape);
   for(const auto val : v_int)
@@ -1125,11 +1125,40 @@ TEST(core_array, check_multidimensional)
   std::array<IndexType, 1> expected_flat_shape = {4};
   EXPECT_EQ(v_int_flat.shape(), expected_flat_shape);
 
-  // FIXME: Should we be able to compare arrays of different dimension (by comparing the raw data)?
   for(int i = 0; i < v_int_flat.size(); i++)
   {
     // For a multidim array, op[] is a "flat" index into the raw data
     EXPECT_EQ(v_int[i], v_int_flat[i]);
+  }
+
+  Array<double, 3> v_double(4, 3, 2);
+  v_double.fill(MAGIC_DOUBLE);
+  EXPECT_EQ(v_double.size(), 4 * 3 * 2);
+  std::array<IndexType, 3> expected_double_shape = {4, 3, 2};
+  EXPECT_EQ(v_double.shape(), expected_double_shape);
+  for(const auto val : v_double)
+  {
+    EXPECT_EQ(val, MAGIC_DOUBLE);
+  }
+
+  Array<double> v_double_flat(4 * 3 * 2);
+  int double_flat_idx = 0;
+  for(int i = 0; i < v_double.shape()[0]; i++)
+  {
+    for(int j = 0; j < v_double.shape()[1]; j++)
+    {
+      for(int k = 0; k < v_double.shape()[2]; k++)
+      {
+        v_double(i, j, k) = (i * i) + (5 * j) + k;
+        v_double_flat[double_flat_idx++] = (i * i) + (5 * j) + k;
+      }
+    }
+  }
+
+  for(int i = 0; i < v_double.size(); i++)
+  {
+    // For a multidim array, op[] is a "flat" index into the raw data
+    EXPECT_EQ(v_double[i], v_double_flat[i]);
   }
 }
 

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1103,7 +1103,9 @@ TEST(core_array, check_multidimensional)
   v_int.resize(2, 2);
   v_int.fill(MAGIC_INT);
   // Make sure the number of elements and contents are correct
-  EXPECT_EQ(v_int.fullSize(), 4);
+  EXPECT_EQ(v_int.size(), 4);
+  std::array<IndexType, 2> expected_shape = {2, 2};
+  EXPECT_EQ(v_int.shape(), expected_shape);
   for(const auto val : v_int)
   {
     EXPECT_EQ(val, MAGIC_INT);
@@ -1120,6 +1122,8 @@ TEST(core_array, check_multidimensional)
   v_int_flat[1] = 2;
   v_int_flat[2] = 3;
   v_int_flat[3] = 4;
+  std::array<IndexType, 1> expected_flat_shape = {4};
+  EXPECT_EQ(v_int_flat.shape(), expected_flat_shape);
 
   // FIXME: Should we be able to compare arrays of different dimension (by comparing the raw data)?
   for(int i = 0; i < v_int_flat.size(); i++)

--- a/src/axom/core/tests/numerics_eigen_solve.hpp
+++ b/src/axom/core/tests/numerics_eigen_solve.hpp
@@ -181,4 +181,7 @@ TEST(numerics_eigen_solve, eigen_solve_with_three_by_three)
   EXPECT_NEAR(lambdas[0], 10., EPS);
   EXPECT_NEAR(lambdas[1], 6., EPS);
   EXPECT_NEAR(lambdas[2], 4., EPS);
+
+  delete[] u;
+  delete[] lambdas;
 }

--- a/src/axom/core/tests/numerics_matvecops.hpp
+++ b/src/axom/core/tests/numerics_matvecops.hpp
@@ -471,4 +471,7 @@ TEST(numerics_matvecops, vector_normalize)
 
   // normalize should fail
   EXPECT_FALSE(axom::numerics::normalize<double>(u, dim));
+
+  delete[] u;
+  delete[] v;
 }


### PR DESCRIPTION
# Summary

- This PR is a refactor
- It does the following:
  - Modifies/refactors `axom::Array` by adding a template parameter for the dimension of the array

This is the first of several array-related PRs, which I'm trying to minimize the size of in order to make reviewing easier.

See #633 for a more thorough plan of action
