### PR TITLE
Primal zip iterators

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -42,6 +42,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Added a `data_collection_util` tool to generate Mesh Blueprint compliant high order distributed meshes from
   an mfem mesh or over a Cartesian domain
 - Added utility functions `axom::utilities::getHostName()` and `axom::utilities::getUserName()`.
+- Added new `axom::primal::ZipIterable<T>` type to convert structure-of-arrays data to a given
+  Primal geometric primitive.
 
 ### Changed
 - `MFEMSidreDataCollection` now reuses FESpace/QSpace objects with the same basis

--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -50,6 +50,7 @@ set( primal_headers
 
      ## utils
      utils/ZipIndexable.hpp
+     utils/ZipBoundingBox.hpp
      utils/ZipPoint.hpp
      utils/ZipVector.hpp
    )

--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -52,6 +52,7 @@ set( primal_headers
      utils/ZipIndexable.hpp
      utils/ZipBoundingBox.hpp
      utils/ZipPoint.hpp
+     utils/ZipRay.hpp
      utils/ZipVector.hpp
    )
 

--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -47,6 +47,11 @@ set( primal_headers
      operators/detail/intersect_ray_impl.hpp
      operators/detail/intersect_bounding_box_impl.hpp
      operators/detail/intersect_impl.hpp
+
+     ## utils
+     utils/ZipIndexable.hpp
+     utils/ZipPoint.hpp
+     utils/ZipVector.hpp
    )
 
 set( primal_sources

--- a/src/axom/primal/geometry/BoundingBox.hpp
+++ b/src/axom/primal/geometry/BoundingBox.hpp
@@ -33,8 +33,8 @@ class BoundingBox;
  * Two bounding boxes are equal when they have the same bounds
  */
 template <typename T, int NDIMS>
-bool operator==(const BoundingBox<T, NDIMS>& lhs,
-                const BoundingBox<T, NDIMS>& rhs);
+AXOM_HOST_DEVICE bool operator==(const BoundingBox<T, NDIMS>& lhs,
+                                 const BoundingBox<T, NDIMS>& rhs);
 
 /*!
  * \brief Inequality comparison operator for bounding boxes.

--- a/src/axom/primal/geometry/NumericArray.hpp
+++ b/src/axom/primal/geometry/NumericArray.hpp
@@ -33,8 +33,8 @@ class NumericArray;
  * \return status true if lhs==rhs, otherwise, false.
  */
 template <typename T, int SIZE>
-bool operator==(const NumericArray<T, SIZE>& lhs,
-                const NumericArray<T, SIZE>& rhs);
+AXOM_HOST_DEVICE bool operator==(const NumericArray<T, SIZE>& lhs,
+                                 const NumericArray<T, SIZE>& rhs);
 
 /*!
  * \brief Checks if two numeric arrays are *not* component-wise equal.

--- a/src/axom/primal/geometry/Point.hpp
+++ b/src/axom/primal/geometry/Point.hpp
@@ -161,6 +161,7 @@ public:
   /*!
    * \brief Equality comparison operator for points
    */
+  AXOM_HOST_DEVICE
   friend inline bool operator==(const Point& lhs, const Point& rhs)
   {
     return lhs.m_components == rhs.m_components;

--- a/src/axom/primal/geometry/Ray.hpp
+++ b/src/axom/primal/geometry/Ray.hpp
@@ -42,6 +42,7 @@ template <typename T, int NDIMS>
 class Ray
 {
 public:
+  using CoordType = T;
   using PointType = Point<T, NDIMS>;
   using SegmentType = Segment<T, NDIMS>;
   using VectorType = Vector<T, NDIMS>;

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -114,6 +114,7 @@ class Vector
 {
 public:
   using PointType = Point<T, NDIMS>;
+  using CoordType = T;
 
 public:
   /*!
@@ -214,6 +215,7 @@ public:
   /*!
    * \brief Equality comparison operator for vectors.
    */
+  AXOM_HOST_DEVICE
   friend bool operator==(const Vector& lhs, const Vector& rhs)
   {
     return lhs.m_components == rhs.m_components;

--- a/src/axom/primal/tests/CMakeLists.txt
+++ b/src/axom/primal/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ set( primal_tests
     primal_tetrahedron.cpp
     primal_triangle.cpp
     primal_vector.cpp
+    primal_zip.cpp
    )
 
 set(primal_test_depends axom fmt gtest)

--- a/src/axom/primal/tests/primal_zip.cpp
+++ b/src/axom/primal/tests/primal_zip.cpp
@@ -186,8 +186,8 @@ void check_zip_rays_3d()
       PointType orig {xo[idx], yo[idx], zo[idx]};
       VectorType dir {xd[idx], yd[idx], zd[idx]};
       RayType actual(orig, dir);
-      valid[idx] = (it[idx].origin() == actual.origin())
-                && (it[idx].direction() == actual.direction());
+      valid[idx] = (it[idx].origin() == actual.origin()) &&
+        (it[idx].direction() == actual.direction());
     });
 
   for(int i = 0; i < N; i++)

--- a/src/axom/primal/tests/primal_zip.cpp
+++ b/src/axom/primal/tests/primal_zip.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/config.hpp"
+
+#include "axom/core/execution/for_all.hpp"
+#include "axom/core/memory_management.hpp"
+
+#include "axom/primal/geometry/Point.hpp"
+#include "axom/primal/utils/ZipIndexable.hpp"
+#include "axom/primal/utils/ZipPoint.hpp"
+#include "axom/primal/utils/ZipVector.hpp"
+
+#include "gtest/gtest.h"
+
+using namespace axom;
+
+//------------------------------------------------------------------------------
+
+template <typename ExecSpace, typename PrimitiveType>
+void check_zip_points_3d()
+{
+  using ZipType = primal::ZipIndexable<PrimitiveType>;
+
+  const int current_allocator = axom::getDefaultAllocatorID();
+  axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+
+  // create arrays of data
+  constexpr int N = 8;
+  double* x = axom::allocate<double>(N);
+  double* y = axom::allocate<double>(N);
+  double* z = axom::allocate<double>(N);
+
+  bool* valid = axom::allocate<bool>(N);
+
+  axom::for_all<ExecSpace>(
+    0,
+    8,
+    AXOM_LAMBDA(int idx) {
+      x[idx] = (idx % 2) + 1;
+      y[idx] = ((idx / 2) % 2) + 1;
+      z[idx] = (idx / 4) + 1;
+    });
+
+  ZipType it {x, y, z};
+
+  axom::for_all<ExecSpace>(
+    0,
+    8,
+    AXOM_LAMBDA(int idx) {
+      valid[idx] = (it[idx] == PrimitiveType {x[idx], y[idx], z[idx]});
+    });
+
+  for(int i = 0; i < N; i++)
+  {
+    EXPECT_EQ(valid[i], true);
+  }
+
+  axom::deallocate(x);
+  axom::deallocate(y);
+  axom::deallocate(z);
+  axom::deallocate(valid);
+  axom::setDefaultAllocator(current_allocator);
+}
+
+TEST(primal_zip, zip_points_3d)
+{
+  using PointType = primal::Point<double, 3>;
+  using ExecSpace = axom::SEQ_EXEC;
+
+  check_zip_points_3d<ExecSpace, PointType>();
+}
+
+TEST(primal_zip, zip_vectors_3d)
+{
+  using PointType = primal::Vector<double, 3>;
+  using ExecSpace = axom::SEQ_EXEC;
+
+  check_zip_points_3d<ExecSpace, PointType>();
+}
+
+#ifdef AXOM_USE_CUDA
+AXOM_CUDA_TEST(primal_zip, zip_points_3d_gpu)
+{
+  using PointType = primal::Point<double, 3>;
+  using ExecSpace = axom::CUDA_EXEC<256>;
+
+  check_zip_points_3d<ExecSpace, PointType>();
+}
+
+AXOM_CUDA_TEST(primal_zip, zip_vectors_3d_gpu)
+{
+  using PointType = primal::Vector<double, 3>;
+  using ExecSpace = axom::CUDA_EXEC<256>;
+
+  check_zip_points_3d<ExecSpace, PointType>();
+}
+#endif
+
+//------------------------------------------------------------------------------
+#include "axom/slic/core/SimpleLogger.hpp"
+using axom::slic::SimpleLogger;
+
+int main(int argc, char* argv[])
+{
+  int result = 0;
+
+  ::testing::InitGoogleTest(&argc, argv);
+
+  SimpleLogger logger;  // create & initialize test logger,
+
+  // finalized when exiting main scope
+
+  result = RUN_ALL_TESTS();
+
+  return result;
+}

--- a/src/axom/primal/tests/primal_zip.cpp
+++ b/src/axom/primal/tests/primal_zip.cpp
@@ -44,7 +44,7 @@ void check_zip_points_3d()
       z[idx] = (idx / 4) + 1;
     });
 
-  ZipType it {x, y, z};
+  ZipType it {{x, y, z}};
 
   axom::for_all<ExecSpace>(
     0,

--- a/src/axom/primal/tests/primal_zip.cpp
+++ b/src/axom/primal/tests/primal_zip.cpp
@@ -39,7 +39,7 @@ void check_zip_points_3d()
 
   axom::for_all<ExecSpace>(
     0,
-    8,
+    N,
     AXOM_LAMBDA(int idx) {
       x[idx] = (idx % 2) + 1;
       y[idx] = ((idx / 2) % 2) + 1;
@@ -50,14 +50,14 @@ void check_zip_points_3d()
 
   axom::for_all<ExecSpace>(
     0,
-    8,
+    N,
     AXOM_LAMBDA(int idx) {
       valid[idx] = (it[idx] == PrimitiveType {x[idx], y[idx], z[idx]});
     });
 
   for(int i = 0; i < N; i++)
   {
-    EXPECT_EQ(valid[i], true);
+    EXPECT_TRUE(valid[i]);
   }
 
   axom::deallocate(x);
@@ -103,7 +103,7 @@ void check_zip_points_2d_from_3d()
 
   for(int i = 0; i < N; i++)
   {
-    EXPECT_EQ(valid[i], true);
+    EXPECT_TRUE(valid[i]);
   }
 
   axom::deallocate(x);
@@ -148,7 +148,7 @@ void check_zip_vectors_2d_from_3d()
 
   for(int i = 0; i < N; i++)
   {
-    EXPECT_EQ(valid[i], true);
+    EXPECT_TRUE(valid[i]);
   }
 
   axom::deallocate(x);
@@ -181,7 +181,7 @@ void check_zip_bbs_3d()
 
   axom::for_all<ExecSpace>(
     0,
-    8,
+    N,
     AXOM_LAMBDA(int idx) {
       xmin[idx] = (idx % 2) + 1;
       ymin[idx] = ((idx / 2) % 2) + 1;
@@ -196,7 +196,7 @@ void check_zip_bbs_3d()
 
   axom::for_all<ExecSpace>(
     0,
-    8,
+    N,
     AXOM_LAMBDA(int idx) {
       BoxType actual;
       actual.addPoint(PointType {xmin[idx], ymin[idx], zmin[idx]});
@@ -206,7 +206,7 @@ void check_zip_bbs_3d()
 
   for(int i = 0; i < N; i++)
   {
-    EXPECT_EQ(valid[i], true);
+    EXPECT_TRUE(valid[i]);
   }
 
   axom::deallocate(xmin);
@@ -268,7 +268,7 @@ void check_zip_bbs_2d_from_3d()
 
   for(int i = 0; i < N; i++)
   {
-    EXPECT_EQ(valid[i], true);
+    EXPECT_TRUE(valid[i]);
   }
 
   axom::deallocate(xmin);
@@ -306,7 +306,7 @@ void check_zip_rays_3d()
 
   axom::for_all<ExecSpace>(
     0,
-    4,
+    N,
     AXOM_LAMBDA(int idx) {
       if(idx < 2)
       {
@@ -331,7 +331,7 @@ void check_zip_rays_3d()
 
   axom::for_all<ExecSpace>(
     0,
-    4,
+    N,
     AXOM_LAMBDA(int idx) {
       PointType orig {xo[idx], yo[idx], zo[idx]};
       VectorType dir {xd[idx], yd[idx], zd[idx]};
@@ -342,7 +342,7 @@ void check_zip_rays_3d()
 
   for(int i = 0; i < N; i++)
   {
-    EXPECT_EQ(valid[i], true);
+    EXPECT_TRUE(valid[i]);
   }
 
   axom::deallocate(xo);
@@ -382,7 +382,7 @@ void check_zip_rays_2d_from_3d()
 
   axom::for_all<ExecSpace>(
     0,
-    4,
+    N,
     AXOM_LAMBDA(int idx) {
       if(idx < 2)
       {
@@ -407,7 +407,7 @@ void check_zip_rays_2d_from_3d()
 
   axom::for_all<ExecSpace>(
     0,
-    4,
+    N,
     AXOM_LAMBDA(int idx) {
       PointType orig {xo[idx], yo[idx]};
       VectorType dir {xd[idx], yd[idx]};
@@ -418,7 +418,7 @@ void check_zip_rays_2d_from_3d()
 
   for(int i = 0; i < N; i++)
   {
-    EXPECT_EQ(valid[i], true);
+    EXPECT_TRUE(valid[i]);
   }
 
   axom::deallocate(xo);

--- a/src/axom/primal/utils/ZipBoundingBox.hpp
+++ b/src/axom/primal/utils/ZipBoundingBox.hpp
@@ -19,6 +19,9 @@ namespace primal
 {
 namespace detail
 {
+/*!
+ * \brief Implements ZipIndexable for a primal::BoundingBox instantiation
+ */
 template <typename FloatType, int NDIMS>
 struct ZipBase<BoundingBox<FloatType, NDIMS>>
 {

--- a/src/axom/primal/utils/ZipBoundingBox.hpp
+++ b/src/axom/primal/utils/ZipBoundingBox.hpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_PRIMAL_ZIP_BOUNDINGBOX_HPP_
+#define AXOM_PRIMAL_ZIP_BOUNDINGBOX_HPP_
+
+#include "axom/config.hpp"
+#include "axom/core/StackArray.hpp"
+#include "axom/slic/interface/slic.hpp"
+
+#include "axom/primal/geometry/BoundingBox.hpp"
+#include "axom/primal/utils/ZipIndexable.hpp"
+
+namespace axom
+{
+namespace primal
+{
+namespace detail
+{
+template <typename FloatType, int NDIMS>
+struct ZipBase<BoundingBox<FloatType, NDIMS>>
+{
+  using GeomType = BoundingBox<FloatType, NDIMS>;
+  using CoordType = FloatType;
+
+  static constexpr int Dims = NDIMS;
+  static constexpr bool Exists = true;
+
+  /*!
+   * \brief Creates a ZipIndexable from a set of arrays
+   * \param [in] min_arrays the arrays storing the min coordinate for each
+   *  dimension
+   * \param [in] max_arrays the arrays storing the max coordinate for each
+   *  dimension
+   */
+  ZipBase(const StackArray<const FloatType*, NDIMS>& min_arrays,
+          const StackArray<const FloatType*, NDIMS>& max_arrays)
+  {
+    for(int i = 0; i < NDIMS; i++)
+    {
+      bb_min_arrays[i] = min_arrays[i];
+      bb_max_arrays[i] = max_arrays[i];
+    }
+  }
+
+  /*!
+   * \brief Returns the BoundingBox at an index i.
+   * \param [in] i the index to access
+   */
+  AXOM_HOST_DEVICE GeomType operator[](int i) const
+  {
+    using PointType = typename GeomType::PointType;
+    StackArray<FloatType, NDIMS> min_data, max_data;
+    for(int d = 0; d < NDIMS; d++)
+    {
+      min_data[d] = bb_min_arrays[d][i];
+      max_data[d] = bb_max_arrays[d][i];
+    }
+    return GeomType(PointType(min_data), PointType(max_data));
+  }
+
+private:
+  const FloatType* bb_min_arrays[NDIMS];
+  const FloatType* bb_max_arrays[NDIMS];
+};
+
+}  // namespace detail
+}  // namespace primal
+}  // namespace axom
+
+#endif  // AXOM_PRIMAL_ZIP_BOUNDINGBOX_HPP_

--- a/src/axom/primal/utils/ZipBoundingBox.hpp
+++ b/src/axom/primal/utils/ZipBoundingBox.hpp
@@ -22,10 +22,10 @@ namespace detail
 /*!
  * \brief Implements ZipIndexable for a primal::BoundingBox instantiation
  */
-template <typename FloatType, int NDIMS>
-struct ZipBase<BoundingBox<FloatType, NDIMS>>
+template <typename T, int NDIMS>
+struct ZipBase<BoundingBox<T, NDIMS>>
 {
-  using GeomType = BoundingBox<FloatType, NDIMS>;
+  using GeomType = BoundingBox<T, NDIMS>;
 
   static constexpr bool Exists = true;
 
@@ -40,8 +40,8 @@ struct ZipBase<BoundingBox<FloatType, NDIMS>>
    * \pre Size2 >= NDIMS
    */
   template <size_t Size1, size_t Size2>
-  ZipBase(const FloatType* const (&min_arrays)[Size1],
-          const FloatType* const (&max_arrays)[Size2])
+  ZipBase(const T* const (&min_arrays)[Size1],
+          const T* const (&max_arrays)[Size2])
   {
     AXOM_STATIC_ASSERT_MSG(Size1 >= NDIMS, "Must provide at least NDIMS arrays");
     AXOM_STATIC_ASSERT_MSG(Size2 >= NDIMS, "Must provide at least NDIMS arrays");
@@ -59,7 +59,7 @@ struct ZipBase<BoundingBox<FloatType, NDIMS>>
   AXOM_HOST_DEVICE GeomType operator[](int i) const
   {
     using PointType = typename GeomType::PointType;
-    StackArray<FloatType, NDIMS> min_data, max_data;
+    StackArray<T, NDIMS> min_data, max_data;
     for(int d = 0; d < NDIMS; d++)
     {
       min_data[d] = bb_min_arrays[d][i];
@@ -69,8 +69,8 @@ struct ZipBase<BoundingBox<FloatType, NDIMS>>
   }
 
 private:
-  const FloatType* bb_min_arrays[NDIMS];
-  const FloatType* bb_max_arrays[NDIMS];
+  const T* bb_min_arrays[NDIMS];
+  const T* bb_max_arrays[NDIMS];
 };
 
 }  // namespace detail

--- a/src/axom/primal/utils/ZipBoundingBox.hpp
+++ b/src/axom/primal/utils/ZipBoundingBox.hpp
@@ -35,10 +35,16 @@ struct ZipBase<BoundingBox<FloatType, NDIMS>>
    *  dimension
    * \param [in] max_arrays the arrays storing the max coordinate for each
    *  dimension
+   *
+   * \pre Size1 >= NDIMS
+   * \pre Size2 >= NDIMS
    */
-  ZipBase(const StackArray<const FloatType*, NDIMS>& min_arrays,
-          const StackArray<const FloatType*, NDIMS>& max_arrays)
+  template <size_t Size1, size_t Size2>
+  ZipBase(FloatType* const (&min_arrays)[Size1],
+          FloatType* const (&max_arrays)[Size2])
   {
+    AXOM_STATIC_ASSERT_MSG(Size1 >= NDIMS, "Must provide at least NDIMS arrays");
+    AXOM_STATIC_ASSERT_MSG(Size2 >= NDIMS, "Must provide at least NDIMS arrays");
     for(int i = 0; i < NDIMS; i++)
     {
       bb_min_arrays[i] = min_arrays[i];

--- a/src/axom/primal/utils/ZipBoundingBox.hpp
+++ b/src/axom/primal/utils/ZipBoundingBox.hpp
@@ -26,9 +26,7 @@ template <typename FloatType, int NDIMS>
 struct ZipBase<BoundingBox<FloatType, NDIMS>>
 {
   using GeomType = BoundingBox<FloatType, NDIMS>;
-  using CoordType = FloatType;
 
-  static constexpr int Dims = NDIMS;
   static constexpr bool Exists = true;
 
   /*!

--- a/src/axom/primal/utils/ZipBoundingBox.hpp
+++ b/src/axom/primal/utils/ZipBoundingBox.hpp
@@ -40,8 +40,8 @@ struct ZipBase<BoundingBox<FloatType, NDIMS>>
    * \pre Size2 >= NDIMS
    */
   template <size_t Size1, size_t Size2>
-  ZipBase(FloatType* const (&min_arrays)[Size1],
-          FloatType* const (&max_arrays)[Size2])
+  ZipBase(const FloatType* const (&min_arrays)[Size1],
+          const FloatType* const (&max_arrays)[Size2])
   {
     AXOM_STATIC_ASSERT_MSG(Size1 >= NDIMS, "Must provide at least NDIMS arrays");
     AXOM_STATIC_ASSERT_MSG(Size2 >= NDIMS, "Must provide at least NDIMS arrays");

--- a/src/axom/primal/utils/ZipIndexable.hpp
+++ b/src/axom/primal/utils/ZipIndexable.hpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_PRIMAL_ZIP_INDEXABLE_HPP_
+#define AXOM_PRIMAL_ZIP_INDEXABLE_HPP_
+
+#include "axom/config.hpp"
+
+namespace axom
+{
+namespace primal
+{
+namespace detail
+{
+template <typename T>
+class ZipBase
+{
+  static constexpr bool Exists = false;
+};
+
+}  // namespace detail
+
+/*!
+ * \class ZipIndexable
+ *
+ * \brief Utility class which allows iterating over Primal objects stored in
+ *  memory as a structure of arrays.
+ *
+ *  \tparam GeomType the Primal instance type
+ */
+template <typename GeomType>
+class ZipIndexable : detail::ZipBase<GeomType>
+{
+public:
+  using CoordType = typename GeomType::CoordType;
+
+  static_assert(detail::ZipBase<GeomType>::Exists,
+                "A ZipBase specialization is not defined for this geometry "
+                "type. Check that you are passing in a supported Primal type "
+                "as a template parameter.");
+
+  using detail::ZipBase<GeomType>::ZipBase;
+  using detail::ZipBase<GeomType>::operator[];
+};
+
+}  // namespace primal
+}  // namespace axom
+
+#endif  // AXOM_PRIMAL_ZIP_INDEXABLE_HPP

--- a/src/axom/primal/utils/ZipIndexable.hpp
+++ b/src/axom/primal/utils/ZipIndexable.hpp
@@ -41,7 +41,14 @@ public:
                 "type. Check that you are passing in a supported Primal type "
                 "as a template parameter.");
 
+  /**
+   * \brief Inherited constructor from detail instance.
+   */
   using detail::ZipBase<GeomType>::ZipBase;
+
+  /**
+   * \brief Inherited implementation of array index operator.
+   */
   using detail::ZipBase<GeomType>::operator[];
 };
 

--- a/src/axom/primal/utils/ZipPoint.hpp
+++ b/src/axom/primal/utils/ZipPoint.hpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_PRIMAL_ZIP_POINT_HPP_
+#define AXOM_PRIMAL_ZIP_POINT_HPP_
+
+#include "axom/config.hpp"
+#include "axom/core/StackArray.hpp"
+#include "axom/slic/interface/slic.hpp"
+
+#include "axom/primal/geometry/Point.hpp"
+#include "axom/primal/utils/ZipIndexable.hpp"
+
+#include <initializer_list>
+
+namespace axom
+{
+namespace primal
+{
+namespace detail
+{
+/*!
+ * \brief Implements ZipIndexable for a primal::Point instantiation
+ */
+template <typename FloatType, int NDIMS>
+class ZipBase<Point<FloatType, NDIMS>>
+{
+  using GeomType = Point<FloatType, NDIMS>;
+  using CoordType = FloatType;
+
+  static constexpr int Dims = NDIMS;
+  static constexpr bool Exists = true;
+
+  /*!
+   * \brief Creates a ZipIndexable from an initializer list of arrays.
+   * \param [in] arrays the arrays storing coordinate data for each dimension
+   */
+  ZipBase(std::initializer_list<const FloatType*> arrays)
+  {
+#if __cplusplus >= 201402L
+    // initializer_list::size() was made constexpr in C++14
+    AXOM_STATIC_ASSERT_MSG(arrays.size() == NDIMS);
+#else
+    SLIC_ASSERT(arrays.size() == NDIMS);
+#endif
+    auto it = arrays.begin();
+    for(int i = 0; i < NDIMS; i++)
+    {
+      pts_arrays[i] = *it;
+      it++;
+    }
+  }
+
+  /*!
+   * \brief Returns the Point at an index i.
+   * \param [in] i the index to access
+   */
+  AXOM_HOST_DEVICE GeomType operator[](int i) const
+  {
+    StackArray<FloatType, NDIMS> pt_data;
+    for(int d = 0; d < NDIMS; d++)
+    {
+      pt_data[d] = pts_arrays[d][i];
+    }
+    return GeomType(pt_data);
+  }
+
+private:
+  const FloatType* pts_arrays[NDIMS];
+};
+
+}  // namespace detail
+}  // namespace primal
+}  // namespace axom
+
+#endif  // AXOM_PRIMAL_ZIP_POINT_HPP_

--- a/src/axom/primal/utils/ZipPoint.hpp
+++ b/src/axom/primal/utils/ZipPoint.hpp
@@ -26,9 +26,7 @@ template <typename FloatType, int NDIMS>
 struct ZipBase<Point<FloatType, NDIMS>>
 {
   using GeomType = Point<FloatType, NDIMS>;
-  using CoordType = FloatType;
 
-  static constexpr int Dims = NDIMS;
   static constexpr bool Exists = true;
 
   /*!

--- a/src/axom/primal/utils/ZipPoint.hpp
+++ b/src/axom/primal/utils/ZipPoint.hpp
@@ -32,7 +32,7 @@ struct ZipBase<Point<FloatType, NDIMS>>
   static constexpr bool Exists = true;
 
   /*!
-   * \brief Creates a ZipIndexable from an initializer list of arrays.
+   * \brief Creates a ZipIndexable over a set of arrays.
    * \param [in] arrays the arrays storing coordinate data for each dimension
    */
   ZipBase(const StackArray<const FloatType*, NDIMS>& arrays)

--- a/src/axom/primal/utils/ZipPoint.hpp
+++ b/src/axom/primal/utils/ZipPoint.hpp
@@ -22,10 +22,10 @@ namespace detail
 /*!
  * \brief Implements ZipIndexable for a primal::Point instantiation
  */
-template <typename FloatType, int NDIMS>
-struct ZipBase<Point<FloatType, NDIMS>>
+template <typename T, int NDIMS>
+struct ZipBase<Point<T, NDIMS>>
 {
-  using GeomType = Point<FloatType, NDIMS>;
+  using GeomType = Point<T, NDIMS>;
 
   static constexpr bool Exists = true;
 
@@ -36,7 +36,7 @@ struct ZipBase<Point<FloatType, NDIMS>>
    * \pre Size >= NDIMS
    */
   template <size_t Size>
-  ZipBase(const FloatType* const (&arrays)[Size])
+  ZipBase(const T* const (&arrays)[Size])
   {
     AXOM_STATIC_ASSERT_MSG(Size >= NDIMS, "Must provide at least NDIMS arrays");
     for(int i = 0; i < NDIMS; i++)
@@ -51,7 +51,7 @@ struct ZipBase<Point<FloatType, NDIMS>>
    */
   AXOM_HOST_DEVICE GeomType operator[](int i) const
   {
-    StackArray<FloatType, NDIMS> pt_data;
+    StackArray<T, NDIMS> pt_data;
     for(int d = 0; d < NDIMS; d++)
     {
       pt_data[d] = pts_arrays[d][i];
@@ -60,7 +60,7 @@ struct ZipBase<Point<FloatType, NDIMS>>
   }
 
 private:
-  const FloatType* pts_arrays[NDIMS];
+  const T* pts_arrays[NDIMS];
 };
 
 }  // namespace detail

--- a/src/axom/primal/utils/ZipPoint.hpp
+++ b/src/axom/primal/utils/ZipPoint.hpp
@@ -32,9 +32,13 @@ struct ZipBase<Point<FloatType, NDIMS>>
   /*!
    * \brief Creates a ZipIndexable over a set of arrays.
    * \param [in] arrays the arrays storing coordinate data for each dimension
+   *
+   * \pre Size >= NDIMS
    */
-  ZipBase(const StackArray<const FloatType*, NDIMS>& arrays)
+  template <size_t Size>
+  ZipBase(FloatType* const (&arrays)[Size])
   {
+    AXOM_STATIC_ASSERT_MSG(Size >= NDIMS, "Must provide at least NDIMS arrays");
     for(int i = 0; i < NDIMS; i++)
     {
       pts_arrays[i] = arrays[i];

--- a/src/axom/primal/utils/ZipPoint.hpp
+++ b/src/axom/primal/utils/ZipPoint.hpp
@@ -13,8 +13,6 @@
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/utils/ZipIndexable.hpp"
 
-#include <initializer_list>
-
 namespace axom
 {
 namespace primal
@@ -25,7 +23,7 @@ namespace detail
  * \brief Implements ZipIndexable for a primal::Point instantiation
  */
 template <typename FloatType, int NDIMS>
-class ZipBase<Point<FloatType, NDIMS>>
+struct ZipBase<Point<FloatType, NDIMS>>
 {
   using GeomType = Point<FloatType, NDIMS>;
   using CoordType = FloatType;
@@ -37,19 +35,11 @@ class ZipBase<Point<FloatType, NDIMS>>
    * \brief Creates a ZipIndexable from an initializer list of arrays.
    * \param [in] arrays the arrays storing coordinate data for each dimension
    */
-  ZipBase(std::initializer_list<const FloatType*> arrays)
+  ZipBase(const StackArray<const FloatType*, NDIMS>& arrays)
   {
-#if __cplusplus >= 201402L
-    // initializer_list::size() was made constexpr in C++14
-    AXOM_STATIC_ASSERT_MSG(arrays.size() == NDIMS);
-#else
-    SLIC_ASSERT(arrays.size() == NDIMS);
-#endif
-    auto it = arrays.begin();
     for(int i = 0; i < NDIMS; i++)
     {
-      pts_arrays[i] = *it;
-      it++;
+      pts_arrays[i] = arrays[i];
     }
   }
 

--- a/src/axom/primal/utils/ZipPoint.hpp
+++ b/src/axom/primal/utils/ZipPoint.hpp
@@ -36,7 +36,7 @@ struct ZipBase<Point<FloatType, NDIMS>>
    * \pre Size >= NDIMS
    */
   template <size_t Size>
-  ZipBase(FloatType* const (&arrays)[Size])
+  ZipBase(const FloatType* const (&arrays)[Size])
   {
     AXOM_STATIC_ASSERT_MSG(Size >= NDIMS, "Must provide at least NDIMS arrays");
     for(int i = 0; i < NDIMS; i++)

--- a/src/axom/primal/utils/ZipRay.hpp
+++ b/src/axom/primal/utils/ZipRay.hpp
@@ -22,10 +22,10 @@ namespace detail
 /*!
  * \brief Implements ZipIndexable for a primal::Ray instantiation
  */
-template <typename FloatType, int NDIMS>
-struct ZipBase<Ray<FloatType, NDIMS>>
+template <typename T, int NDIMS>
+struct ZipBase<Ray<T, NDIMS>>
 {
-  using GeomType = Ray<FloatType, NDIMS>;
+  using GeomType = Ray<T, NDIMS>;
 
   static constexpr bool Exists = true;
 
@@ -40,8 +40,8 @@ struct ZipBase<Ray<FloatType, NDIMS>>
    * \pre Size2 >= NDIMS
    */
   template <size_t Size1, size_t Size2>
-  ZipBase(const FloatType* const (&orig_arrays)[Size1],
-          const FloatType* const (&dir_arrays)[Size2])
+  ZipBase(const T* const (&orig_arrays)[Size1],
+          const T* const (&dir_arrays)[Size2])
   {
     AXOM_STATIC_ASSERT_MSG(Size1 >= NDIMS, "Must provide at least NDIMS arrays");
     AXOM_STATIC_ASSERT_MSG(Size2 >= NDIMS, "Must provide at least NDIMS arrays");
@@ -60,7 +60,7 @@ struct ZipBase<Ray<FloatType, NDIMS>>
   {
     using PointType = typename GeomType::PointType;
     using VectorType = typename GeomType::VectorType;
-    StackArray<FloatType, NDIMS> orig_data, dir_data;
+    StackArray<T, NDIMS> orig_data, dir_data;
     for(int d = 0; d < NDIMS; d++)
     {
       orig_data[d] = ray_origs[d][i];
@@ -70,8 +70,8 @@ struct ZipBase<Ray<FloatType, NDIMS>>
   }
 
 private:
-  const FloatType* ray_origs[NDIMS];
-  const FloatType* ray_dirs[NDIMS];
+  const T* ray_origs[NDIMS];
+  const T* ray_dirs[NDIMS];
 };
 
 }  // namespace detail

--- a/src/axom/primal/utils/ZipRay.hpp
+++ b/src/axom/primal/utils/ZipRay.hpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_PRIMAL_ZIP_RAY_HPP_
+#define AXOM_PRIMAL_ZIP_RAY_HPP_
+
+#include "axom/config.hpp"
+#include "axom/core/StackArray.hpp"
+#include "axom/slic/interface/slic.hpp"
+
+#include "axom/primal/geometry/Ray.hpp"
+#include "axom/primal/utils/ZipIndexable.hpp"
+
+namespace axom
+{
+namespace primal
+{
+namespace detail
+{
+template <typename FloatType, int NDIMS>
+struct ZipBase<Ray<FloatType, NDIMS>>
+{
+  using GeomType = Ray<FloatType, NDIMS>;
+  using CoordType = FloatType;
+
+  static constexpr int Dims = NDIMS;
+  static constexpr bool Exists = true;
+
+  /*!
+   * \brief Creates a ZipIndexable from a set of arrays
+   * \param [in] orig_arrays the arrays for each dimension storing the origin
+   *  of the ray
+   * \param [in] dir_arrays the arrays storing for each dimension the direction
+   *  of the ray
+   */
+  ZipBase(const StackArray<const FloatType*, NDIMS>& orig_arrays,
+          const StackArray<const FloatType*, NDIMS>& dir_arrays)
+  {
+    for(int i = 0; i < NDIMS; i++)
+    {
+      ray_origs[i] = orig_arrays[i];
+      ray_dirs[i] = dir_arrays[i];
+    }
+  }
+
+  /*!
+   * \brief Returns the Ray at an index i.
+   * \param [in] i the index to access
+   */
+  AXOM_HOST_DEVICE GeomType operator[](int i) const
+  {
+    using PointType = typename GeomType::PointType;
+    using VectorType = typename GeomType::VectorType;
+    StackArray<FloatType, NDIMS> orig_data, dir_data;
+    for(int d = 0; d < NDIMS; d++)
+    {
+      orig_data[d] = ray_origs[d][i];
+      dir_data[d] = ray_dirs[d][i];
+    }
+    return GeomType(PointType(orig_data), VectorType(dir_data));
+  }
+
+private:
+  const FloatType* ray_origs[NDIMS];
+  const FloatType* ray_dirs[NDIMS];
+};
+
+}  // namespace detail
+}  // namespace primal
+}  // namespace axom
+
+#endif  // AXOM_PRIMAL_ZIP_RAY_HPP_

--- a/src/axom/primal/utils/ZipRay.hpp
+++ b/src/axom/primal/utils/ZipRay.hpp
@@ -19,6 +19,9 @@ namespace primal
 {
 namespace detail
 {
+/*!
+ * \brief Implements ZipIndexable for a primal::Ray instantiation
+ */
 template <typename FloatType, int NDIMS>
 struct ZipBase<Ray<FloatType, NDIMS>>
 {

--- a/src/axom/primal/utils/ZipRay.hpp
+++ b/src/axom/primal/utils/ZipRay.hpp
@@ -35,10 +35,16 @@ struct ZipBase<Ray<FloatType, NDIMS>>
    *  of the ray
    * \param [in] dir_arrays the arrays storing for each dimension the direction
    *  of the ray
+   *
+   * \pre Size1 >= NDIMS
+   * \pre Size2 >= NDIMS
    */
-  ZipBase(const StackArray<const FloatType*, NDIMS>& orig_arrays,
-          const StackArray<const FloatType*, NDIMS>& dir_arrays)
+  template <size_t Size1, size_t Size2>
+  ZipBase(FloatType* const (&orig_arrays)[Size1],
+          FloatType* const (&dir_arrays)[Size2])
   {
+    AXOM_STATIC_ASSERT_MSG(Size1 >= NDIMS, "Must provide at least NDIMS arrays");
+    AXOM_STATIC_ASSERT_MSG(Size2 >= NDIMS, "Must provide at least NDIMS arrays");
     for(int i = 0; i < NDIMS; i++)
     {
       ray_origs[i] = orig_arrays[i];

--- a/src/axom/primal/utils/ZipRay.hpp
+++ b/src/axom/primal/utils/ZipRay.hpp
@@ -26,9 +26,7 @@ template <typename FloatType, int NDIMS>
 struct ZipBase<Ray<FloatType, NDIMS>>
 {
   using GeomType = Ray<FloatType, NDIMS>;
-  using CoordType = FloatType;
 
-  static constexpr int Dims = NDIMS;
   static constexpr bool Exists = true;
 
   /*!

--- a/src/axom/primal/utils/ZipRay.hpp
+++ b/src/axom/primal/utils/ZipRay.hpp
@@ -40,8 +40,8 @@ struct ZipBase<Ray<FloatType, NDIMS>>
    * \pre Size2 >= NDIMS
    */
   template <size_t Size1, size_t Size2>
-  ZipBase(FloatType* const (&orig_arrays)[Size1],
-          FloatType* const (&dir_arrays)[Size2])
+  ZipBase(const FloatType* const (&orig_arrays)[Size1],
+          const FloatType* const (&dir_arrays)[Size2])
   {
     AXOM_STATIC_ASSERT_MSG(Size1 >= NDIMS, "Must provide at least NDIMS arrays");
     AXOM_STATIC_ASSERT_MSG(Size2 >= NDIMS, "Must provide at least NDIMS arrays");

--- a/src/axom/primal/utils/ZipVector.hpp
+++ b/src/axom/primal/utils/ZipVector.hpp
@@ -13,8 +13,6 @@
 #include "axom/primal/geometry/Vector.hpp"
 #include "axom/primal/utils/ZipIndexable.hpp"
 
-#include <initializer_list>
-
 namespace axom
 {
 namespace primal
@@ -34,19 +32,11 @@ struct ZipBase<Vector<FloatType, NDIMS>>
    * \brief Creates a ZipIndexable from an initializer list of arrays.
    * \param [in] arrays the arrays storing coordinate data for each dimension
    */
-  ZipBase(std::initializer_list<const FloatType*> arrays)
+  ZipBase(const StackArray<const FloatType*, NDIMS>& arrays)
   {
-#if __cplusplus >= 201402L
-    // initializer_list::size() was made constexpr in C++14
-    AXOM_STATIC_ASSERT_MSG(arrays.size() == NDIMS);
-#else
-    SLIC_ASSERT(arrays.size() == NDIMS);
-#endif
-    auto it = arrays.begin();
     for(int i = 0; i < NDIMS; i++)
     {
-      vec_arrays[i] = *it;
-      it++;
+      vec_arrays[i] = arrays[i];
     }
   }
 

--- a/src/axom/primal/utils/ZipVector.hpp
+++ b/src/axom/primal/utils/ZipVector.hpp
@@ -19,10 +19,10 @@ namespace primal
 {
 namespace detail
 {
-template <typename FloatType, int NDIMS>
-struct ZipBase<Vector<FloatType, NDIMS>>
+template <typename T, int NDIMS>
+struct ZipBase<Vector<T, NDIMS>>
 {
-  using GeomType = Vector<FloatType, NDIMS>;
+  using GeomType = Vector<T, NDIMS>;
 
   static constexpr bool Exists = true;
 
@@ -33,7 +33,7 @@ struct ZipBase<Vector<FloatType, NDIMS>>
    * \pre Size >= NDIMS
    */
   template <size_t Size>
-  ZipBase(const FloatType* const (&arrays)[Size])
+  ZipBase(const T* const (&arrays)[Size])
   {
     AXOM_STATIC_ASSERT_MSG(Size >= NDIMS, "Must provide at least NDIMS arrays");
     for(int i = 0; i < NDIMS; i++)
@@ -48,7 +48,7 @@ struct ZipBase<Vector<FloatType, NDIMS>>
    */
   AXOM_HOST_DEVICE GeomType operator[](int i) const
   {
-    StackArray<FloatType, NDIMS> pt_data;
+    StackArray<T, NDIMS> pt_data;
     for(int d = 0; d < NDIMS; d++)
     {
       pt_data[d] = vec_arrays[d][i];
@@ -57,7 +57,7 @@ struct ZipBase<Vector<FloatType, NDIMS>>
   }
 
 private:
-  const FloatType* vec_arrays[NDIMS];
+  const T* vec_arrays[NDIMS];
 };
 
 }  // namespace detail

--- a/src/axom/primal/utils/ZipVector.hpp
+++ b/src/axom/primal/utils/ZipVector.hpp
@@ -29,9 +29,13 @@ struct ZipBase<Vector<FloatType, NDIMS>>
   /*!
    * \brief Creates a ZipIndexable over a set of arrays.
    * \param [in] arrays the arrays storing coordinate data for each dimension
+   *
+   * \pre Size >= NDIMS
    */
-  ZipBase(const StackArray<const FloatType*, NDIMS>& arrays)
+  template <size_t Size>
+  ZipBase(FloatType* const (&arrays)[Size])
   {
+    AXOM_STATIC_ASSERT_MSG(Size >= NDIMS, "Must provide at least NDIMS arrays");
     for(int i = 0; i < NDIMS; i++)
     {
       vec_arrays[i] = arrays[i];

--- a/src/axom/primal/utils/ZipVector.hpp
+++ b/src/axom/primal/utils/ZipVector.hpp
@@ -29,7 +29,7 @@ struct ZipBase<Vector<FloatType, NDIMS>>
   static constexpr bool Exists = true;
 
   /*!
-   * \brief Creates a ZipIndexable from an initializer list of arrays.
+   * \brief Creates a ZipIndexable over a set of arrays.
    * \param [in] arrays the arrays storing coordinate data for each dimension
    */
   ZipBase(const StackArray<const FloatType*, NDIMS>& arrays)

--- a/src/axom/primal/utils/ZipVector.hpp
+++ b/src/axom/primal/utils/ZipVector.hpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_PRIMAL_ZIP_VECTOR_HPP_
+#define AXOM_PRIMAL_ZIP_VECTOR_HPP_
+
+#include "axom/config.hpp"
+#include "axom/core/StackArray.hpp"
+#include "axom/slic/interface/slic.hpp"
+
+#include "axom/primal/geometry/Vector.hpp"
+#include "axom/primal/utils/ZipIndexable.hpp"
+
+#include <initializer_list>
+
+namespace axom
+{
+namespace primal
+{
+namespace detail
+{
+template <typename FloatType, int NDIMS>
+struct ZipBase<Vector<FloatType, NDIMS>>
+{
+  using GeomType = Vector<FloatType, NDIMS>;
+  using CoordType = FloatType;
+
+  static constexpr int Dims = NDIMS;
+  static constexpr bool Exists = true;
+
+  /*!
+   * \brief Creates a ZipIndexable from an initializer list of arrays.
+   * \param [in] arrays the arrays storing coordinate data for each dimension
+   */
+  ZipBase(std::initializer_list<const FloatType*> arrays)
+  {
+#if __cplusplus >= 201402L
+    // initializer_list::size() was made constexpr in C++14
+    AXOM_STATIC_ASSERT_MSG(arrays.size() == NDIMS);
+#else
+    SLIC_ASSERT(arrays.size() == NDIMS);
+#endif
+    auto it = arrays.begin();
+    for(int i = 0; i < NDIMS; i++)
+    {
+      vec_arrays[i] = *it;
+      it++;
+    }
+  }
+
+  /*!
+   * \brief Returns the Vector at an index i.
+   * \param [in] i the index to access
+   */
+  AXOM_HOST_DEVICE GeomType operator[](int i) const
+  {
+    StackArray<FloatType, NDIMS> pt_data;
+    for(int d = 0; d < NDIMS; d++)
+    {
+      pt_data[d] = vec_arrays[d][i];
+    }
+    return GeomType(pt_data);
+  }
+
+private:
+  const FloatType* vec_arrays[NDIMS];
+};
+
+}  // namespace detail
+}  // namespace primal
+}  // namespace axom
+
+#endif  // AXOM_PRIMAL_ZIP_VECTOR_HPP_

--- a/src/axom/primal/utils/ZipVector.hpp
+++ b/src/axom/primal/utils/ZipVector.hpp
@@ -23,9 +23,7 @@ template <typename FloatType, int NDIMS>
 struct ZipBase<Vector<FloatType, NDIMS>>
 {
   using GeomType = Vector<FloatType, NDIMS>;
-  using CoordType = FloatType;
 
-  static constexpr int Dims = NDIMS;
   static constexpr bool Exists = true;
 
   /*!

--- a/src/axom/primal/utils/ZipVector.hpp
+++ b/src/axom/primal/utils/ZipVector.hpp
@@ -33,7 +33,7 @@ struct ZipBase<Vector<FloatType, NDIMS>>
    * \pre Size >= NDIMS
    */
   template <size_t Size>
-  ZipBase(FloatType* const (&arrays)[Size])
+  ZipBase(const FloatType* const (&arrays)[Size])
   {
     AXOM_STATIC_ASSERT_MSG(Size >= NDIMS, "Must provide at least NDIMS arrays");
     for(int i = 0; i < NDIMS; i++)

--- a/src/axom/spin/BVH.hpp
+++ b/src/axom/spin/BVH.hpp
@@ -473,7 +473,6 @@ void BVH<NDIMS, ExecSpace, FloatType, Impl>::findPoints(IndexType* offsets,
   SLIC_ASSERT(offsets != nullptr);
   SLIC_ASSERT(counts != nullptr);
   SLIC_ASSERT(candidates == nullptr);
-  SLIC_ASSERT(pts != nullptr);
 
   // Define traversal predicates
   auto predicate = [=] AXOM_HOST_DEVICE(const PointType& p,
@@ -511,7 +510,6 @@ void BVH<NDIMS, ExecSpace, FloatType, Impl>::findRays(IndexType* offsets,
   SLIC_ASSERT(offsets != nullptr);
   SLIC_ASSERT(counts != nullptr);
   SLIC_ASSERT(candidates == nullptr);
-  SLIC_ASSERT(rays != nullptr);
 
   const FloatType TOL = m_tolerance;
 
@@ -554,7 +552,6 @@ void BVH<NDIMS, ExecSpace, FloatType, Impl>::findBoundingBoxes(
   SLIC_ASSERT(offsets != nullptr);
   SLIC_ASSERT(counts != nullptr);
   SLIC_ASSERT(candidates == nullptr);
-  SLIC_ASSERT(boxes != nullptr);
 
   // STEP 2: define traversal predicates
   auto predicate = [=] AXOM_HOST_DEVICE(const BoxType& bb1,

--- a/src/axom/spin/BVH.hpp
+++ b/src/axom/spin/BVH.hpp
@@ -160,7 +160,7 @@ private:
     // The base object of the return type of a call to iter[], or std::false_type
     // if operator[] does not exist.
     using BaseType =
-      typename std::decay<decltype(array_operator_type(It {}))>::type;
+      typename std::decay<decltype(array_operator_type(std::declval<It>()))>::type;
 
     // The iterator must be an array-like type.
     static_assert(

--- a/src/axom/spin/BVH.hpp
+++ b/src/axom/spin/BVH.hpp
@@ -437,11 +437,11 @@ int BVH<NDIMS, ExecSpace, FloatType, Impl>::initialize(const BoxIndexable boxes,
           boxesptr[i] = empty_box;
         }
       });
-    m_bvh->template buildImpl(boxesptr, numBoxes, m_scaleFactor, m_AllocatorID);
+    m_bvh->buildImpl(boxesptr, numBoxes, m_scaleFactor, m_AllocatorID);
   }
   else
   {
-    m_bvh->template buildImpl(boxes, numBoxes, m_scaleFactor, m_AllocatorID);
+    m_bvh->buildImpl(boxes, numBoxes, m_scaleFactor, m_AllocatorID);
   }
 
   // STEP 5: deallocate boxesptr if user supplied a single box

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -85,8 +85,8 @@ static inline AXOM_HOST_DEVICE axom::int64 morton64_encode(axom::float32 x,
   return convertPointToMorton<int64>(integer_pt);
 }
 
-template <typename ExecSpace, typename FloatType, int NDIMS>
-void transform_boxes(const primal::BoundingBox<FloatType, NDIMS>* boxes,
+template <typename ExecSpace, typename BoxIndexable, typename FloatType, int NDIMS>
+void transform_boxes(const BoxIndexable boxes,
                      primal::BoundingBox<FloatType, NDIMS>* aabbs,
                      int32 size,
                      FloatType scale_factor)
@@ -629,8 +629,8 @@ void propagate_aabbs(RadixTree<FloatType, NDIMS>& data, int allocatorID)
 }
 
 //------------------------------------------------------------------------------
-template <typename ExecSpace, typename FloatType, int NDIMS>
-void build_radix_tree(const primal::BoundingBox<FloatType, NDIMS>* boxes,
+template <typename ExecSpace, typename BoxIndexable, typename FloatType, int NDIMS>
+void build_radix_tree(const BoxIndexable boxes,
                       int size,
                       primal::BoundingBox<FloatType, NDIMS>& bounds,
                       RadixTree<FloatType, NDIMS>& radix_tree,
@@ -640,7 +640,6 @@ void build_radix_tree(const primal::BoundingBox<FloatType, NDIMS>* boxes,
   AXOM_PERF_MARK_FUNCTION("build_radix_tree");
 
   // sanity checks
-  SLIC_ASSERT(boxes != nullptr);
   SLIC_ASSERT(size > 0);
 
   radix_tree.allocate(size, allocatorID);

--- a/src/axom/spin/policy/LinearBVH.hpp
+++ b/src/axom/spin/policy/LinearBVH.hpp
@@ -62,7 +62,8 @@ public:
    * \param [in] numBoxes the number of bounding boxes
    * \param [in] scaleFactor scale factor applied to each bounding box before insertion into the BVH
    */
-  void buildImpl(const BoundingBoxType* boxes,
+  template <typename BoxIndexable>
+  void buildImpl(const BoxIndexable boxes,
                  IndexType numBoxes,
                  FloatType scaleFactor,
                  int allocatorID);
@@ -116,7 +117,8 @@ private:
 };
 
 template <typename FloatType, int NDIMS, typename ExecSpace>
-void LinearBVH<FloatType, NDIMS, ExecSpace>::buildImpl(const BoundingBoxType* boxes,
+template <typename BoxIndexable>
+void LinearBVH<FloatType, NDIMS, ExecSpace>::buildImpl(const BoxIndexable boxes,
                                                        IndexType numBoxes,
                                                        FloatType scaleFactor,
                                                        int allocatorID)

--- a/src/axom/spin/policy/LinearBVH.hpp
+++ b/src/axom/spin/policy/LinearBVH.hpp
@@ -219,8 +219,7 @@ void LinearBVH<FloatType, NDIMS, ExecSpace>::findCandidatesImpl(
   AXOM_PERF_MARK_FUNCTION("LinearBVH::findCandidatesImpl");
 
   SLIC_ERROR_IF(offsets == nullptr, "supplied null pointer for offsets!");
-  SLIC_ERROR_IF(counts == nullptr, "supplied null pointer for counts!");
-  SLIC_ERROR_IF(objs == nullptr, "supplied null pointer for test primitives!");
+  SLIC_ERROR_IF(counts == nullptr, "supplied null value for counts!");
 
   const BoundingBoxType* inner_nodes = m_inner_nodes;
   const int32* inner_node_children = m_inner_node_children;

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -15,6 +15,7 @@
 #include "axom/primal/geometry/BoundingBox.hpp"
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
+#include "axom/primal/utils/ZipPoint.hpp"
 
 // axom/spin includes
 #include "axom/spin/BVH.hpp"
@@ -1108,6 +1109,103 @@ void check_single_box3d()
   axom::setDefaultAllocator(current_allocator);
 }
 
+//------------------------------------------------------------------------------
+
+/*!
+ * \brief Tests the find algorithm of the BVH in 3D.
+ *
+ *  A uniform mesh is used for this test where the query points are generated
+ *  by taking the centroids of the constituent cells of the mesh. Since the
+ *  mesh is a uniform, cartesian mesh the find algorithm should return exactly
+ *  one candidate for each query point corresponding to the cell on the mesh
+ *  that generated the centroid. This property is checked by using the
+ *  spin::UniformGrid class.
+ *
+ *  In addition, the test shifts the points by an offset to ensure that points
+ *  outside the mesh return no candidate.
+ *
+ */
+template <typename ExecSpace, typename FloatType>
+void check_find_points_zip3d()
+{
+  constexpr int NDIMS = 3;
+  constexpr IndexType N = 4;
+
+  const int current_allocator = axom::getDefaultAllocatorID();
+  axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+
+  using BoxType = typename primal::BoundingBox<FloatType, NDIMS>;
+  using PointType = primal::Point<FloatType, NDIMS>;
+  using PointDbl = primal::Point<double, NDIMS>;
+
+  double lo[NDIMS] = {0.0, 0.0, 0.0};
+  double hi[NDIMS] = {3.0, 3.0, 3.0};
+  int res[NDIMS] = {N - 1, N - 1, N - 1};
+
+  mint::UniformMesh mesh(lo, hi, N, N, N);
+  FloatType* centroids_raw =
+    mesh.createField<FloatType>("centroid", mint::CELL_CENTERED, NDIMS);
+  PointType* centroids = reinterpret_cast<PointType*>(centroids_raw);
+  const IndexType ncells = mesh.getNumberOfCells();
+
+  BoxType* aabbs = nullptr;
+  generate_aabbs_and_centroids(&mesh, aabbs, centroids);
+
+  FloatType* xs = axom::allocate<FloatType>(ncells);
+  FloatType* ys = axom::allocate<FloatType>(ncells);
+  FloatType* zs = axom::allocate<FloatType>(ncells);
+
+  for(int icell = 0; icell < ncells; icell++)
+  {
+    xs[icell] = centroids[icell][0];
+    ys[icell] = centroids[icell][1];
+    zs[icell] = centroids[icell][2];
+  }
+
+  primal::ZipIndexable<PointType> zip_test {{xs, ys, zs}};
+
+  // construct the BVH
+  spin::BVH<NDIMS, ExecSpace, FloatType> bvh;
+  bvh.setScaleFactor(1.0);  // i.e., no scaling
+  bvh.initialize(aabbs, ncells);
+
+  BoxType bounds = bvh.getBounds();
+
+  for(int idim = 0; idim < NDIMS; ++idim)
+  {
+    EXPECT_DOUBLE_EQ(bounds.getMin()[idim], lo[idim]);
+    EXPECT_DOUBLE_EQ(bounds.getMax()[idim], hi[idim]);
+  }
+
+  // traverse the BVH to find the candidates for all the centroids
+  IndexType* offsets = axom::allocate<IndexType>(ncells);
+  IndexType* counts = axom::allocate<IndexType>(ncells);
+  IndexType* candidates = nullptr;
+  bvh.findPoints(offsets, counts, candidates, ncells, zip_test);
+
+  EXPECT_TRUE(candidates != nullptr);
+
+  spin::UniformGrid<IndexType, NDIMS> ug(lo, hi, res);
+
+  for(IndexType i = 0; i < ncells; ++i)
+  {
+    PointDbl q = PointDbl {centroids[i][0], centroids[i][1], centroids[i][2]};
+    const int donorCellIdx = ug.getBinIndex(q);
+    EXPECT_EQ(counts[i], 1);
+    EXPECT_EQ(donorCellIdx, candidates[offsets[i]]);
+  }  // END for all cell centroids
+
+  axom::deallocate(xs);
+  axom::deallocate(ys);
+  axom::deallocate(zs);
+  axom::deallocate(offsets);
+  axom::deallocate(candidates);
+  axom::deallocate(counts);
+  axom::deallocate(aabbs);
+
+  axom::setDefaultAllocator(current_allocator);
+}
+
 } /* end unnamed namespace */
 
 //------------------------------------------------------------------------------
@@ -1180,6 +1278,13 @@ TEST(spin_bvh, single_box3d_sequential)
 {
   check_single_box3d<axom::SEQ_EXEC, double>();
   check_single_box3d<axom::SEQ_EXEC, float>();
+}
+
+//------------------------------------------------------------------------------
+TEST(spin_bvh, find_points_3d_sequential_zip)
+{
+  check_find_points_zip3d<axom::SEQ_EXEC, double>();
+  check_find_points_zip3d<axom::SEQ_EXEC, float>();
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

- Adds a helper template class `primal::ZipIndexable<GeomType>` which can be used to index into primitive data stored in struct-of-arrays format
- Adds implementations of `ZipIndexable` for `primal::Point`, `primal::Vector`, `primal::BoundingBox`, and `primal::Ray` via an inherited detail class `ZipBase<T>`

Resolves #604 