### PR TITLE
Workaround for C++14 feature missing from gcc@4.9.3

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -72,6 +72,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   The latter are now only added in MSVC configurations.
 - Fixed bug in `Mint`'s VTK output for fields of type `int64` and `float`
 - Improved loading of data collections in `MFEMSidreDataCollection`
+- Added workaround to `MFEMSidreDataCollection` for `C++14` standard library feature that was not available in `gcc@4.9.3`
 
 
 ## [Version 0.5.0] - Release date 2021-05-14

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -2419,15 +2419,15 @@ void MFEMSidreDataCollection::reconstructFields()
       {
         // The vdim is being overwritten here with the value in the basis string so we
         // can correctly construct the QuadratureFunction
-        m_quadspaces.emplace(basis_name,
-                             detail::NewQuadratureSpace(basis_name, mesh, vdim));
+        m_quadspaces[basis_name] = std::unique_ptr<mfem::QuadratureSpace>(
+          detail::NewQuadratureSpace(basis_name, mesh, vdim));
         is_gridfunc = false;
       }
       // Only need to create a new FEColl if one doesn't already exist
       else if(m_fecolls.count(basis_name) == 0)
       {
-        m_fecolls.emplace(basis_name,
-                          mfem::FiniteElementCollection::New(basis_name.c_str()));
+        m_fecolls[basis_name] = std::unique_ptr<mfem::FiniteElementCollection>(
+          mfem::FiniteElementCollection::New(basis_name.c_str()));
       }
 
       View* value_view = nullptr;
@@ -2462,8 +2462,7 @@ void MFEMSidreDataCollection::reconstructFields()
         auto parmesh = dynamic_cast<mfem::ParMesh*>(mesh);
         if(parmesh)
         {
-          m_fespaces.emplace(
-            basis_name,
+          m_fespaces[basis_name] = std::unique_ptr<mfem::ParFiniteElementSpace>(
             new mfem::ParFiniteElementSpace(parmesh,
                                             m_fecolls.at(basis_name).get(),
                                             vdim,
@@ -2472,8 +2471,7 @@ void MFEMSidreDataCollection::reconstructFields()
         else
   #endif
         {
-          m_fespaces.emplace(
-            basis_name,
+          m_fespaces[basis_name] = std::unique_ptr<mfem::FiniteElementSpace>(
             new mfem::FiniteElementSpace(mesh,
                                          m_fecolls.at(basis_name).get(),
                                          vdim,


### PR DESCRIPTION
# Summary

- Some user configurations are built with C++14, but are pointing at a gcc@4.9.3 standard library
- The latter is not fully C++14 compliant, but is the default on some platforms, and it can be difficult to propagate the right flags in some build configuration.
- This change allows the code to build in the above configuration.

Possible resolution of #616

Note: This workaround doesn't fix the underlying problem of using `C++14` but pointing to a pre-`C++14` library. It only avoids using a feature from `C++14` that is missing from `gcc@4.9.3`'s standard library implementation, and thus not triggering the error.