### PR TITLE
Fix for Intel compiler bug

### DIFF
--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -930,8 +930,10 @@ Array<T, DIM>::Array(Args... args)
 {
   static_assert(sizeof...(Args) == DIM,
                 "Array size must match number of dimensions");
-  assert(detail::allPositive({IndexType(args)...}));
-  initialize(detail::packProduct({IndexType(args)...}), 0);
+  // Intel hits internal compiler error when casting as part of function call
+  IndexType tmp_args[] = {args...};
+  assert(detail::allPositive(tmp_args));
+  initialize(detail::packProduct(tmp_args), 0);
 }
 
 //------------------------------------------------------------------------------
@@ -1219,8 +1221,10 @@ inline void Array<T, DIM>::resize(Args... args)
 {
   static_assert(sizeof...(Args) == DIM,
                 "Array size must match number of dimensions");
-  assert(detail::allPositive({IndexType(args)...}));
-  const auto new_num_elements = detail::packProduct({IndexType(args)...});
+  // Intel hits internal compiler error when casting as part of function call
+  IndexType tmp_args[] = {args...};
+  assert(detail::allPositive(tmp_args));
+  const auto new_num_elements = detail::packProduct(tmp_args);
 
   if(new_num_elements > m_capacity)
   {


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Workaround for internal compiler bug with both Intel 18 and Intel 19

The following error is produced:

```sh
/usr/WS2/white238/gitlabbuilds/UrMJDUmU/0/gitlab/axom/axom/src/axom/core/Array.hpp(1222): internal error: assertion failed at: "shared/cfe/edgcpfe/overload.c", line 24884

    assert(detail::allPositive({IndexType(args)...}));
    ^
```

The following example is sufficient to reproduce the issue:

```cpp
template <int N>
bool bar(const int (&arr)[N])
{
  return true;
}

template <typename... Args>
void foo(Args... args)
{
    return bar({int(args)...});
}

int main()
{
    foo(1,2,3);
}
```

```sh
$ icpc -std=c++11 test.cpp 
test.cpp(10): internal error: assertion failed at: "shared/cfe/edgcpfe/overload.c", line 24884

      return bar({int(args)...});
             ^

compilation aborted for test.cpp (code 4)

```

