### PR TITLE
Defer element orientation checks until nodal GF is set in MFEMSidreDataColl

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -77,6 +77,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Fixed bug in `Mint`'s VTK output for fields of type `int64` and `float`
 - Improved loading of data collections in `MFEMSidreDataCollection`
 - Added workaround to `MFEMSidreDataCollection` for `C++14` standard library feature that was not available in `gcc@4.9.3`
+- Delayed finalization of reloaded meshes in `MFEMSidreDataCollection` until after the setting
+  of the nodal `GridFunction` (when applicable)
 
 
 ## [Version 0.5.0] - Release date 2021-05-14

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -77,8 +77,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Fixed bug in `Mint`'s VTK output for fields of type `int64` and `float`
 - Improved loading of data collections in `MFEMSidreDataCollection`
 - Added workaround to `MFEMSidreDataCollection` for `C++14` standard library feature that was not available in `gcc@4.9.3`
-- Delayed finalization of reloaded meshes in `MFEMSidreDataCollection` until after the setting
-  of the nodal `GridFunction` (when applicable)
+- Delayed finalizing reloaded mesh in `MFEMSidreDataCollection` until after setting
+  the nodal `GridFunction` (when applicable)
 
 
 ## [Version 0.5.0] - Release date 2021-05-14

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -930,8 +930,10 @@ Array<T, DIM>::Array(Args... args)
 {
   static_assert(sizeof...(Args) == DIM,
                 "Array size must match number of dimensions");
-  assert(detail::allPositive({IndexType(args)...}));
-  initialize(detail::packProduct({IndexType(args)...}), 0);
+  // Intel hits internal compiler error when casting as part of function call
+  IndexType tmp_args[] = {args...};
+  assert(detail::allPositive(tmp_args));
+  initialize(detail::packProduct(tmp_args), 0);
 }
 
 //------------------------------------------------------------------------------
@@ -1219,8 +1221,10 @@ inline void Array<T, DIM>::resize(Args... args)
 {
   static_assert(sizeof...(Args) == DIM,
                 "Array size must match number of dimensions");
-  assert(detail::allPositive({IndexType(args)...}));
-  const auto new_num_elements = detail::packProduct({IndexType(args)...});
+  // Intel hits internal compiler error when casting as part of function call
+  IndexType tmp_args[] = {args...};
+  assert(detail::allPositive(tmp_args));
+  const auto new_num_elements = detail::packProduct(tmp_args);
 
   if(new_num_elements > m_capacity)
   {

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -914,6 +914,11 @@ void MFEMSidreDataCollection::Load(const std::string& path,
       mesh->NewNodes(*this->GetField(nodalGFName), false);
     }
   }
+
+  // Now we can finalize the mesh
+  const bool fix_orientation = false;
+  const bool refine = false;
+  mesh->Finalize(refine, fix_orientation);
 }
 
 void MFEMSidreDataCollection::LoadExternalData(const std::string& path)
@@ -1973,9 +1978,7 @@ public:
       }
     }
 
-    const bool fix_orientation = false;
-    const bool refine = false;
-    Finalize(refine, fix_orientation);
+    // Delay the finalization of the mesh until we can set the nodal GridFunction
   }
 
 private:

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -602,7 +602,8 @@ private:
   void reconstructField(Group* field_grp);
 
   // Reconstructs all non-mesh-related fields using the current contents
-  // of the datastore, used as part of Load()
+  // of the datastore, used as part of Load() - it is expected/required
+  // that the nodel grid function has already been reconstructed/registered
   void reconstructFields();
 
   /**

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -505,11 +505,7 @@ public:
 
   /** @brief Updates the DataCollection's mesh and registered fields
       with the values from the data store. */
-  void UpdateMeshAndFieldsFromDS()
-  {
-    reconstructMesh();
-    reconstructFields();
-  }
+  void UpdateMeshAndFieldsFromDS();
 
   /// Verifies that the contents of the mesh blueprint data is valid.
   bool verifyMeshBlueprint();
@@ -601,6 +597,9 @@ private:
   // Reconstructs a mesh using the current contents of the datastore
   // Used as part of Load()
   void reconstructMesh();
+
+  // Reconstructs a single field from its corresponding Sidre group
+  void reconstructField(Group* field_grp);
 
   // Reconstructs all non-mesh-related fields using the current contents
   // of the datastore, used as part of Load()

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -650,7 +650,8 @@ static void testParallelMeshReload(mfem::Mesh& base_mesh,
 {
   mfem::ParMesh parmesh(MPI_COMM_WORLD, base_mesh, nullptr, part_method);
 
-  mfem::H1_FECollection fec(1, base_mesh.Dimension());
+  // Use second-order elements to ensure that the nodal gridfunction gets set up properly as well
+  mfem::H1_FECollection fec(2, base_mesh.Dimension());
   mfem::ParFiniteElementSpace parfes(&parmesh, &fec);
 
   // The mesh must be owned by Sidre to properly manage data in case of

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -701,7 +701,9 @@ static void testParallelMeshReload(mfem::Mesh& base_mesh,
   EXPECT_TRUE(sdc_reader.verifyMeshBlueprint());
 
   // Make sure that orientation checks pass
-  // These can fail if the nodal GF is not set up correction for a periodic (and HO?) mesh
+  // These checks assume that the test mesh is orientable and are intended to make sure
+  // that Mesh::Nodes was set up correctly - otherwise these can fail for periodic (and HO?) meshes
+  // QUESTION: What does this method do for a non-orientable mesh?
   EXPECT_EQ(sdc_reader.GetMesh()->CheckElementOrientation(), 0);
   EXPECT_EQ(sdc_reader.GetMesh()->CheckBdrElementOrientation(), 0);
 }
@@ -786,7 +788,7 @@ TEST(sidre_datacollection, dc_par_reload_mesh_2D_large)
 
 TEST(sidre_datacollection, dc_par_reload_mesh_2D_periodic)
 {
-  // periodi2D mesh divided into triangles
+  // periodic 2D mesh divided into triangles
   mfem::Mesh base_mesh(10, 10, mfem::Element::Type::QUADRILATERAL, false, 1.0, 1.0);
   // FIXME: MFEM 4.3
   // mfem::Mesh::MakeCartesian2D(10,


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Moves the call to `Mesh::Finalize` to after the nodal grid function is set
  - Fixes #643 @alecampos2009

