### PR TITLE
BVH optimization for SignedDistance

### DIFF
--- a/src/axom/spin/internal/linear_bvh/bvh_traverse.hpp
+++ b/src/axom/spin/internal/linear_bvh/bvh_traverse.hpp
@@ -49,8 +49,9 @@ inline bool leaf_node(const int32& nodeIdx) { return (nodeIdx < 0); }
  *    (1) The left child bounding box
  *    (2) The right child bounding box
  *    (3) The primitive being queried
- *  It should return true if the right child is closer (indicating a swap is
- *  necessary) and false if the left child is closer.
+ *  It should return true if the primitive is closer to the right child bounding
+ *  box (indicating a swap is necessary) and false if the primitive is closer to
+ *  the left child bounding box.
  *
  * \see BVHData for the details on the internal data layout of the BVH.
  *


### PR DESCRIPTION
# Summary

This PR adds an optimization for point queries against a BVH with the device traversal API. At a given node in the BVH, when both child nodes need to be traversed, we first traverse the node with the bounding box that is closer to the query point. This improves the performance of signed-distance queries, since the current-minimum distance for a given query point converges much faster to the actual minimum distance. As a result, more of the tree can be excluded from traversal.

This is not added to the `BVH::findCandidates` methods, because in that case, we must traverse all tentatively-intersecting nodes regardless.

## Performance

Measured with `./examples/quest_signed_distance_interface_ex --batched --box_dims 200 200 200 --file ../data/quest/plane.stl`

|          | `develop` | this branch | speedup |
| ------ | ---------- | ------------ | --------- |
| rzgenie | 109.177s | 29.8469s | 3.66x |
| rzansel | 9.75109s | 3.3926s | 2.87x |