### PR TITLE
Signed distance cleanup

### DIFF
--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -110,7 +110,7 @@ public:
    * \param [in] surfaceMesh user-supplied surface mesh.
    * \param [in] isWatertight indicates if the surface mesh is closed.
    * \param [in] computeSign indicates if distance queries should compute signs (optional).
-   * \param [in] allocatorID the allocator to create the underlying BVH with.
+   * \param [in] allocatorID the allocator to create the underlying BVH with (optional).
    *
    * \note computeSign defaults to \a true when not specified.
    *
@@ -133,7 +133,7 @@ public:
    * \brief Reinitializes a SignedDistance instance with a new surface mesh.
    *
    * \param [in] surfaceMesh user-supplied surface mesh.
-   * \param [in] allocatorID the allocator to create the underlying BVH with.
+   * \param [in] allocatorID the allocator to create the underlying BVH with (optional).
    *
    * \note The given surface mesh must be allocated in a memory space
    *  compatible with the execution space specified in the SignedDistance

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -403,6 +403,8 @@ bool SignedDistance<NDIMS, ExecSpace>::setMesh(const mint::Mesh* surfaceMesh,
   // Build bounding volume hierarchy
   m_bvh.setAllocatorID(allocatorID);
   int result = m_bvh.initialize(boxes, ncells);
+
+  axom::deallocate(boxes);
   return (result == spin::BVH_BUILD_OK);
 }
 

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -112,22 +112,46 @@ public:
    * \param [in] maxObjects max number of objects for spatial decomposition.
    * \param [in] maxLevels max levels for spatial decomposition.
    * \param [in] computeSign indicates if distance queries should compute signs (optional).
+   * \param [in] allocatorID the allocator to create the underlying BVH with.
+   *
    * \note computeSign defaults to \a true when not specified.
+   *
+   * \note The given surface mesh must be allocated in a memory space
+   *  compatible with the execution space specified in the SignedDistance
+   *  instantiation.
+   *
+   * \note The given allocatorID must be compatible with the execution space
+   *  specified in the SignedDistance instantiation. By default, a compatible
+   *  allocator ID used if allocatorID is not specified.
+   *
    * \pre surfaceMesh != nullptr
    */
   SignedDistance(const mint::Mesh* surfaceMesh,
                  bool isWatertight,
                  int maxObjects,
                  int maxLevels,
-                 bool computeSign = true);
+                 bool computeSign = true,
+                 int allocatorID = axom::execution_space<ExecSpace>::allocatorID());
 
   /*!
    * \brief Reinitializes a SignedDistance instance with a new surface mesh.
+   *
    * \param [in] surfaceMesh user-supplied surface mesh.
+   * \param [in] allocatorID the allocator to create the underlying BVH with.
+   *
+   * \note The given surface mesh must be allocated in a memory space
+   *  compatible with the execution space specified in the SignedDistance
+   *  instantiation.
+   *
+   * \note The given allocatorID must be compatible with the execution space
+   *  specified in the SignedDistance instantiation. By default, a compatible
+   *  allocator ID used if allocatorID is not specified.
+   *
    * \return status true if reinitialization was successful.
    * \pre surfaceMesh != nullptr
    */
-  bool setMesh(const mint::Mesh* surfaceMesh);
+  bool setMesh(const mint::Mesh* surfaceMesh,
+               int allocatorID = axom::execution_space<ExecSpace>::allocatorID());
 
   /*!
    * \brief Computes the distance of the given point to the input surface mesh.
@@ -288,7 +312,8 @@ SignedDistance<NDIMS, ExecSpace>::SignedDistance(const mint::Mesh* surfaceMesh,
                                                  bool isWatertight,
                                                  int maxObjects,
                                                  int maxLevels,
-                                                 bool computeSign)
+                                                 bool computeSign,
+                                                 int allocatorID)
   : m_isInputWatertight(isWatertight)
   , m_computeSign(computeSign)
 {
@@ -296,13 +321,14 @@ SignedDistance<NDIMS, ExecSpace>::SignedDistance(const mint::Mesh* surfaceMesh,
   SLIC_ASSERT(surfaceMesh != nullptr);
   SLIC_ASSERT(maxLevels >= 1);
 
-  bool bvh_constructed = setMesh(surfaceMesh);
+  bool bvh_constructed = setMesh(surfaceMesh, allocatorID);
   SLIC_ASSERT(bvh_constructed);
 }
 
 //------------------------------------------------------------------------------
 template <int NDIMS, typename ExecSpace>
-bool SignedDistance<NDIMS, ExecSpace>::setMesh(const mint::Mesh* surfaceMesh)
+bool SignedDistance<NDIMS, ExecSpace>::setMesh(const mint::Mesh* surfaceMesh,
+                                               int allocatorID)
 {
   AXOM_PERF_MARK_FUNCTION("SignedDistance::setMesh");
   SLIC_ASSERT(surfaceMesh != nullptr);
@@ -367,7 +393,7 @@ bool SignedDistance<NDIMS, ExecSpace>::setMesh(const mint::Mesh* surfaceMesh)
 
   // Initialize BVH with the surface elements.
 
-  BoxType* boxes = axom::allocate<BoxType>(ncells);
+  BoxType* boxes = axom::allocate<BoxType>(ncells, allocatorID);
   for_all<ExecSpace>(
     ncells,
     AXOM_LAMBDA(axom::IndexType icell) {
@@ -375,6 +401,7 @@ bool SignedDistance<NDIMS, ExecSpace>::setMesh(const mint::Mesh* surfaceMesh)
     });
 
   // Build bounding volume hierarchy
+  m_bvh.setAllocatorID(allocatorID);
   int result = m_bvh.initialize(boxes, ncells);
   return (result == spin::BVH_BUILD_OK);
 }

--- a/src/axom/quest/docs/sphinx/point_mesh_query.rst
+++ b/src/axom/quest/docs/sphinx/point_mesh_query.rst
@@ -108,9 +108,17 @@ Before initialization, a code can set some parameters for the distance query.
   lets the user read in a non-closed "terrain mesh" that divides
   its bounding box into "above" (positive distance to the surface mesh)
   and "below" (negative distance).
-- ``quest::signed_distance_set_max_levels()`` and
-  ``quest::signed_distance_set_max_occupancy()`` control options for the
-  BVH tree spatial index used to accelerate signed distance queries.
+- ``quest::signed_distance_set_execution_space()`` allows setting the execution
+  space to run the signed distance query in. The following values are accepted:
+   - ``quest::SignedDistExec::CPU`` runs the signed distance query on the CPU.
+   - ``quest::SignedDistExec::OpenMP`` runs the signed distance query with multiple
+     threads using OpenMP. Requires building Axom with OpenMP support.
+   - ``quest::SignedDistExec::GPU`` runs the signed distance query on the GPU,
+     if supported. This currently requires CUDA support.
+- ``quest::signed_distance_set_allocator()`` allows setting a custom
+  Umpire allocator to allocate the underlying BVH in. The allocator should be
+  compatible with the execution space set in the call to
+  ``quest::signed_distance_set_execution_space()``.
 - If the SLIC logging environment is in use, passing ``true`` to
   ``quest::signed_distance_set_verbose()`` will turn on verbose logging.
 - Use of MPI-3 shared memory can be enabled by passing ``true`` to

--- a/src/axom/quest/docs/sphinx/point_mesh_query.rst
+++ b/src/axom/quest/docs/sphinx/point_mesh_query.rst
@@ -112,7 +112,7 @@ Before initialization, a code can set some parameters for the distance query.
   space to run the signed distance query in. The following values are accepted:
    - ``quest::SignedDistExec::CPU`` runs the signed distance query on the CPU.
    - ``quest::SignedDistExec::OpenMP`` runs the signed distance query with multiple
-     threads using OpenMP. Requires building Axom with OpenMP support.
+     threads on the CPU using OpenMP. Requires building Axom with OpenMP support.
    - ``quest::SignedDistExec::GPU`` runs the signed distance query on the GPU,
      if supported. This currently requires CUDA support.
 - ``quest::signed_distance_set_allocator()`` allows setting a custom

--- a/src/axom/quest/docs/sphinx/point_mesh_query_cpp.rst
+++ b/src/axom/quest/docs/sphinx/point_mesh_query_cpp.rst
@@ -77,7 +77,9 @@ The constructor takes several arguments:
 - ``bool computeSign`` (default ``true``): Optional. Enables or disables the
   computation of signs in distance queries.
 - ``int allocatorID``: Optional. Sets a custom Umpire allocator to use in
-  constructing the underlying BVH.
+  constructing the underlying BVH; by default, this is set to a default allocator
+  for the execution space the ``SignedDistance`` class is instantiated in
+  (host-side memory for CPU and OpenMP, unified memory for GPUs).
 
 Note that the second and subsequent arguments to the constructor correspond to
 ``quest::signed_distance_set`` functions in the C API.

--- a/src/axom/quest/docs/sphinx/point_mesh_query_cpp.rst
+++ b/src/axom/quest/docs/sphinx/point_mesh_query_cpp.rst
@@ -66,16 +66,19 @@ Class header:
    :end-before: _quest_distance_cpp_include_end
    :language: C++
 
-The constructor takes several arguments.  Here, ``surface_mesh`` is a pointer to
-a triangle surface mesh.  The second argument indicates the mesh is a watertight
-mesh, a manifold.  The signed distance from a point to a manifold is
-mathematically well-defined.  When the input is not a closed surface mesh, the
-mesh must span the entire computational mesh domain, dividing it into two regions.
-The third argument is optional, and allows toggling the computation of signs in
-distance queries; by default, this is set to ``true``, enabling the computation
-of signs in queries.  The fourth argument is also optional, and allows for setting
-a custom Umpire allocator to use in constructing the underlying bounding volume
-hierarchy.
+The constructor takes several arguments:
+
+- ``const mint::Mesh* surfaceMesh``: A pointer to a surface mesh with triangles
+  and/or quadrilaterals.
+- ``bool isWatertight``: Indicates the mesh is a watertight mesh, a manifold.
+  The signed distance from a point to a manifold is mathematically well-defined.
+  When the input is not a closed surface mesh, the mesh must span the entire
+  computational mesh domain, dividing it into two regions.
+- ``bool computeSign`` (default ``true``): Optional. Enables or disables the
+  computation of signs in distance queries.
+- ``int allocatorID``: Optional. Sets a custom Umpire allocator to use in
+  constructing the underlying BVH.
+
 Note that the second and subsequent arguments to the constructor correspond to
 ``quest::signed_distance_set`` functions in the C API.
 
@@ -90,10 +93,24 @@ OpenMP or on a GPU.
    :language: C++
 
 Test a query point.
-::
+.. code-block:: C++
 
    axom::primal::Point< double,3 > pt =
      axom::primal::Point< double,3 >::make_point(2., 3., 1.);
    double signedDistance = signed_distance.computeDistance(pt);
+
+Test a batch of query points.
+.. code-block:: C++
+
+   const int numPoints = 20;
+   axom::primal::Point<double, 3>* pts =
+     axom::allocate<axom::primal::Point<double, 3>>(numPoints);
+   for (int ipt = 0; ipt < numPoints; ipt++)
+   {
+     // fill pts array
+     pts[ipt] = ...;
+   }
+   double signedDists = axom::allocate<double>(20);
+   signed_distance.computeDistances(numPts, pts, signedDists);
 
 The object destructor takes care of all cleanup.

--- a/src/axom/quest/docs/sphinx/point_mesh_query_cpp.rst
+++ b/src/axom/quest/docs/sphinx/point_mesh_query_cpp.rst
@@ -71,15 +71,18 @@ a triangle surface mesh.  The second argument indicates the mesh is a watertight
 mesh, a manifold.  The signed distance from a point to a manifold is
 mathematically well-defined.  When the input is not a closed surface mesh, the
 mesh must span the entire computational mesh domain, dividing it into two regions.
-The third and fourth arguments are used to build the underlying BVH tree
-spatial index.  They indicate that BVH tree buckets will be split after 25 objects
-and that the BVH tree will contain at most 10 levels.  These are safe default 
-values and can be adjusted if application benchmarking shows a need.  Note that
-the second and subsequent arguments to the constructor correspond to
+The third argument is optional, and allows toggling the computation of signs in
+distance queries; by default, this is set to ``true``, enabling the computation
+of signs in queries.  The fourth argument is also optional, and allows for setting
+a custom Umpire allocator to use in constructing the underlying bounding volume
+hierarchy.
+Note that the second and subsequent arguments to the constructor correspond to
 ``quest::signed_distance_set`` functions in the C API.
 
 As with the ``InOutOctree``, the class is templated on the dimensionality
-of the mesh, with only 3D meshes being supported.
+of the mesh, with only 3D meshes being supported. The class also accepts a
+template parameter for execution space, for running signed distance queries with
+OpenMP or on a GPU.
 
 .. literalinclude:: ../../tests/quest_signed_distance.cpp
    :start-after: _quest_distance_cpp_init_start

--- a/src/axom/quest/examples/quest_signed_distance_interface.F
+++ b/src/axom/quest/examples/quest_signed_distance_interface.F
@@ -48,8 +48,6 @@ program quest_signed_distance_interface
 !...variables  
   integer :: ierr, rc, i, file_name_length
   integer :: ndims = 3, N=10
-  integer :: max_occupancy = 5
-  integer :: max_levels = 15
   character(LEN=:), allocatable :: file_name
   logical :: is_verbose = .true.
   logical :: is_watertight = .true.
@@ -68,8 +66,6 @@ program quest_signed_distance_interface
 
 !...set various parameters for the signed distance query
   call quest_signed_distance_set_dimension( ndims )
-  call quest_signed_distance_set_max_levels( max_levels )
-  call quest_signed_distance_set_max_occupancy( max_occupancy )
   call quest_signed_distance_set_closed_surface( is_watertight )
   call quest_signed_distance_set_verbose( is_verbose )
   call quest_signed_distance_set_compute_signs( compute_signs )

--- a/src/axom/quest/examples/quest_signed_distance_interface.cpp
+++ b/src/axom/quest/examples/quest_signed_distance_interface.cpp
@@ -70,8 +70,6 @@ struct Arguments
 {
   std::string fileName;
   int ndims {3};
-  int maxLevels {15};
-  int maxOccupancy {5};
   std::vector<axom::IndexType> box_dims {32, 32, 32};
   std::vector<double> box_min;
   std::vector<double> box_max;
@@ -90,18 +88,6 @@ struct Arguments
       ->required();
 
     app.add_option("--dimension", this->ndims, "the problem dimension")
-      ->capture_default_str();
-
-    app
-      .add_option("--maxLevels",
-                  this->maxLevels,
-                  "max levels of subdivision for the BVH")
-      ->capture_default_str();
-
-    app
-      .add_option("--maxOccupancy",
-                  this->maxOccupancy,
-                  "max number of item per BVH bin")
       ->capture_default_str();
 
     app.add_option("--box-dims", box_dims, "the dimensions of the box mesh")
@@ -226,16 +212,12 @@ int main(int argc, char** argv)
   // STEP 3: initialize the signed distance interface
   SLIC_INFO("initializing signed distance function...");
   SLIC_INFO("input file: " << args.fileName);
-  SLIC_INFO("max_levels=" << args.maxLevels);
-  SLIC_INFO("max_occupancy=" << args.maxOccupancy);
   SLIC_INFO("exec_space=" << (int)args.exec_space);
   slic::flushStreams();
 
   timer.start();
   quest::signed_distance_use_shared_memory(args.use_shared);
   quest::signed_distance_set_closed_surface(args.is_water_tight);
-  quest::signed_distance_set_max_levels(args.maxLevels);
-  quest::signed_distance_set_max_occupancy(args.maxOccupancy);
   quest::signed_distance_set_compute_signs(!args.ignore_signs);
   quest::signed_distance_set_execution_space(args.exec_space);
   // _quest_distance_interface_init_start

--- a/src/axom/quest/examples/quest_signed_distance_interface.cpp
+++ b/src/axom/quest/examples/quest_signed_distance_interface.cpp
@@ -215,6 +215,13 @@ int main(int argc, char** argv)
 #endif
     exit(retval);
   }
+#ifdef AXOM_USE_CUDA
+  if(args.exec_space == quest::SignedDistExec::GPU)
+  {
+    using GPUExec = axom::CUDA_EXEC<256>;
+    axom::setDefaultAllocator(axom::execution_space<GPUExec>::allocatorID());
+  }
+#endif
 
   // STEP 3: initialize the signed distance interface
   SLIC_INFO("initializing signed distance function...");

--- a/src/axom/quest/interface/c_fortran/wrapQUEST.cpp
+++ b/src/axom/quest/interface/c_fortran/wrapQUEST.cpp
@@ -248,20 +248,6 @@ void QUEST_signed_distance_set_compute_signs(bool computeSign)
   // splicer end function.signed_distance_set_compute_signs
 }
 
-void QUEST_signed_distance_set_max_levels(int maxLevels)
-{
-  // splicer begin function.signed_distance_set_max_levels
-  axom::quest::signed_distance_set_max_levels(maxLevels);
-  // splicer end function.signed_distance_set_max_levels
-}
-
-void QUEST_signed_distance_set_max_occupancy(int maxOccupancy)
-{
-  // splicer begin function.signed_distance_set_max_occupancy
-  axom::quest::signed_distance_set_max_occupancy(maxOccupancy);
-  // splicer end function.signed_distance_set_max_occupancy
-}
-
 void QUEST_signed_distance_set_verbose(bool status)
 {
   // splicer begin function.signed_distance_set_verbose

--- a/src/axom/quest/interface/c_fortran/wrapQUEST.cpp
+++ b/src/axom/quest/interface/c_fortran/wrapQUEST.cpp
@@ -248,6 +248,13 @@ void QUEST_signed_distance_set_compute_signs(bool computeSign)
   // splicer end function.signed_distance_set_compute_signs
 }
 
+void QUEST_signed_distance_set_allocator(int allocatorID)
+{
+  // splicer begin function.signed_distance_set_allocator
+  axom::quest::signed_distance_set_allocator(allocatorID);
+  // splicer end function.signed_distance_set_allocator
+}
+
 void QUEST_signed_distance_set_verbose(bool status)
 {
   // splicer begin function.signed_distance_set_verbose

--- a/src/axom/quest/interface/c_fortran/wrapQUEST.h
+++ b/src/axom/quest/interface/c_fortran/wrapQUEST.h
@@ -110,6 +110,8 @@ void QUEST_signed_distance_set_closed_surface(bool status);
 
 void QUEST_signed_distance_set_compute_signs(bool computeSign);
 
+void QUEST_signed_distance_set_allocator(int allocatorID);
+
 void QUEST_signed_distance_set_verbose(bool status);
 
 void QUEST_signed_distance_use_shared_memory(bool status);

--- a/src/axom/quest/interface/c_fortran/wrapQUEST.h
+++ b/src/axom/quest/interface/c_fortran/wrapQUEST.h
@@ -110,10 +110,6 @@ void QUEST_signed_distance_set_closed_surface(bool status);
 
 void QUEST_signed_distance_set_compute_signs(bool computeSign);
 
-void QUEST_signed_distance_set_max_levels(int maxLevels);
-
-void QUEST_signed_distance_set_max_occupancy(int maxOccupancy);
-
 void QUEST_signed_distance_set_verbose(bool status);
 
 void QUEST_signed_distance_use_shared_memory(bool status);

--- a/src/axom/quest/interface/c_fortran/wrapfquest.F
+++ b/src/axom/quest/interface/c_fortran/wrapfquest.F
@@ -270,6 +270,13 @@ module axom_quest
             logical(C_BOOL), value, intent(IN) :: computeSign
         end subroutine c_signed_distance_set_compute_signs
 
+        subroutine quest_signed_distance_set_allocator(allocatorID) &
+                bind(C, name="QUEST_signed_distance_set_allocator")
+            use iso_c_binding, only : C_INT
+            implicit none
+            integer(C_INT), value, intent(IN) :: allocatorID
+        end subroutine quest_signed_distance_set_allocator
+
         subroutine c_signed_distance_set_verbose(status) &
                 bind(C, name="QUEST_signed_distance_set_verbose")
             use iso_c_binding, only : C_BOOL

--- a/src/axom/quest/interface/c_fortran/wrapfquest.F
+++ b/src/axom/quest/interface/c_fortran/wrapfquest.F
@@ -270,20 +270,6 @@ module axom_quest
             logical(C_BOOL), value, intent(IN) :: computeSign
         end subroutine c_signed_distance_set_compute_signs
 
-        subroutine quest_signed_distance_set_max_levels(maxLevels) &
-                bind(C, name="QUEST_signed_distance_set_max_levels")
-            use iso_c_binding, only : C_INT
-            implicit none
-            integer(C_INT), value, intent(IN) :: maxLevels
-        end subroutine quest_signed_distance_set_max_levels
-
-        subroutine quest_signed_distance_set_max_occupancy(maxOccupancy) &
-                bind(C, name="QUEST_signed_distance_set_max_occupancy")
-            use iso_c_binding, only : C_INT
-            implicit none
-            integer(C_INT), value, intent(IN) :: maxOccupancy
-        end subroutine quest_signed_distance_set_max_occupancy
-
         subroutine c_signed_distance_set_verbose(status) &
                 bind(C, name="QUEST_signed_distance_set_verbose")
             use iso_c_binding, only : C_BOOL

--- a/src/axom/quest/interface/python/pyQUESTmodule.cpp
+++ b/src/axom/quest/interface/python/pyQUESTmodule.cpp
@@ -414,48 +414,6 @@ static PyObject *PY_signed_distance_set_compute_signs(PyObject *SHROUD_UNUSED(se
   // splicer end function.signed_distance_set_compute_signs
 }
 
-static char PY_signed_distance_set_max_levels__doc__[] = "documentation";
-
-static PyObject *PY_signed_distance_set_max_levels(PyObject *SHROUD_UNUSED(self),
-                                                   PyObject *args,
-                                                   PyObject *kwds)
-{
-  // splicer begin function.signed_distance_set_max_levels
-  int maxLevels;
-  const char *SHT_kwlist[] = {"maxLevels", nullptr};
-
-  if(!PyArg_ParseTupleAndKeywords(args,
-                                  kwds,
-                                  "i:signed_distance_set_max_levels",
-                                  const_cast<char **>(SHT_kwlist),
-                                  &maxLevels))
-    return nullptr;
-  axom::quest::signed_distance_set_max_levels(maxLevels);
-  Py_RETURN_NONE;
-  // splicer end function.signed_distance_set_max_levels
-}
-
-static char PY_signed_distance_set_max_occupancy__doc__[] = "documentation";
-
-static PyObject *PY_signed_distance_set_max_occupancy(PyObject *SHROUD_UNUSED(self),
-                                                      PyObject *args,
-                                                      PyObject *kwds)
-{
-  // splicer begin function.signed_distance_set_max_occupancy
-  int maxOccupancy;
-  const char *SHT_kwlist[] = {"maxOccupancy", nullptr};
-
-  if(!PyArg_ParseTupleAndKeywords(args,
-                                  kwds,
-                                  "i:signed_distance_set_max_occupancy",
-                                  const_cast<char **>(SHT_kwlist),
-                                  &maxOccupancy))
-    return nullptr;
-  axom::quest::signed_distance_set_max_occupancy(maxOccupancy);
-  Py_RETURN_NONE;
-  // splicer end function.signed_distance_set_max_occupancy
-}
-
 static char PY_signed_distance_set_verbose__doc__[] = "documentation";
 
 static PyObject *PY_signed_distance_set_verbose(PyObject *SHROUD_UNUSED(self),
@@ -704,14 +662,6 @@ static PyMethodDef PY_methods[] = {
    (PyCFunction)PY_signed_distance_set_compute_signs,
    METH_VARARGS | METH_KEYWORDS,
    PY_signed_distance_set_compute_signs__doc__},
-  {"signed_distance_set_max_levels",
-   (PyCFunction)PY_signed_distance_set_max_levels,
-   METH_VARARGS | METH_KEYWORDS,
-   PY_signed_distance_set_max_levels__doc__},
-  {"signed_distance_set_max_occupancy",
-   (PyCFunction)PY_signed_distance_set_max_occupancy,
-   METH_VARARGS | METH_KEYWORDS,
-   PY_signed_distance_set_max_occupancy__doc__},
   {"signed_distance_set_verbose",
    (PyCFunction)PY_signed_distance_set_verbose,
    METH_VARARGS | METH_KEYWORDS,

--- a/src/axom/quest/interface/python/pyQUESTmodule.cpp
+++ b/src/axom/quest/interface/python/pyQUESTmodule.cpp
@@ -414,6 +414,27 @@ static PyObject *PY_signed_distance_set_compute_signs(PyObject *SHROUD_UNUSED(se
   // splicer end function.signed_distance_set_compute_signs
 }
 
+static char PY_signed_distance_set_allocator__doc__[] = "documentation";
+
+static PyObject *PY_signed_distance_set_allocator(PyObject *SHROUD_UNUSED(self),
+                                                  PyObject *args,
+                                                  PyObject *kwds)
+{
+  // splicer begin function.signed_distance_set_allocator
+  int allocatorID;
+  const char *SHT_kwlist[] = {"allocatorID", nullptr};
+
+  if(!PyArg_ParseTupleAndKeywords(args,
+                                  kwds,
+                                  "i:signed_distance_set_allocator",
+                                  const_cast<char **>(SHT_kwlist),
+                                  &allocatorID))
+    return nullptr;
+  axom::quest::signed_distance_set_allocator(allocatorID);
+  Py_RETURN_NONE;
+  // splicer end function.signed_distance_set_allocator
+}
+
 static char PY_signed_distance_set_verbose__doc__[] = "documentation";
 
 static PyObject *PY_signed_distance_set_verbose(PyObject *SHROUD_UNUSED(self),
@@ -662,6 +683,10 @@ static PyMethodDef PY_methods[] = {
    (PyCFunction)PY_signed_distance_set_compute_signs,
    METH_VARARGS | METH_KEYWORDS,
    PY_signed_distance_set_compute_signs__doc__},
+  {"signed_distance_set_allocator",
+   (PyCFunction)PY_signed_distance_set_allocator,
+   METH_VARARGS | METH_KEYWORDS,
+   PY_signed_distance_set_allocator__doc__},
   {"signed_distance_set_verbose",
    (PyCFunction)PY_signed_distance_set_verbose,
    METH_VARARGS | METH_KEYWORDS,

--- a/src/axom/quest/interface/quest_shroud.yaml
+++ b/src/axom/quest/interface/quest_shroud.yaml
@@ -98,8 +98,6 @@ declarations:
       - decl: void signed_distance_set_dimension( int dim )
       - decl: void signed_distance_set_closed_surface( bool status )
       - decl: void signed_distance_set_compute_signs( bool computeSign )
-      - decl: void signed_distance_set_max_levels( int maxLevels )
-      - decl: void signed_distance_set_max_occupancy( int maxOccupancy )
       - decl: void signed_distance_set_verbose( bool status )
       - decl: void signed_distance_use_shared_memory( bool status )
       - decl: void signed_distance_set_execution_space( SignedDistExec execSpace )

--- a/src/axom/quest/interface/quest_shroud.yaml
+++ b/src/axom/quest/interface/quest_shroud.yaml
@@ -98,6 +98,7 @@ declarations:
       - decl: void signed_distance_set_dimension( int dim )
       - decl: void signed_distance_set_closed_surface( bool status )
       - decl: void signed_distance_set_compute_signs( bool computeSign )
+      - decl: void signed_distance_set_allocator( int allocatorID )
       - decl: void signed_distance_set_verbose( bool status )
       - decl: void signed_distance_use_shared_memory( bool status )
       - decl: void signed_distance_set_execution_space( SignedDistExec execSpace )

--- a/src/axom/quest/interface/signed_distance.cpp
+++ b/src/axom/quest/interface/signed_distance.cpp
@@ -56,7 +56,7 @@ static struct parameters_t
   bool is_closed_surface; /*!< indicates if the input is a closed surface */
   bool use_shared_memory; /*!< use MPI-3 shared memory for the surface mesh */
   bool compute_sign;      /*!< indicates if sign should be computed */
-  int allocator_id; /*!< the allocator ID to create BVH with (-1 for default) */
+  int allocator_id;       /*!< the allocator ID to create BVH with (-1 for default) */
   SignedDistExec exec_space; /*!< indicates the execution space to run in */
 
   /*!

--- a/src/axom/quest/interface/signed_distance.cpp
+++ b/src/axom/quest/interface/signed_distance.cpp
@@ -191,16 +191,12 @@ int signed_distance_init(const mint::Mesh* m, MPI_Comm comm)
   case SignedDistExec::CPU:
     s_query = new SignedDistance3D(s_surface_mesh,
                                    Parameters.is_closed_surface,
-                                   Parameters.max_occupancy,
-                                   Parameters.max_levels,
                                    Parameters.compute_sign);
     break;
 #ifdef AXOM_USE_OPENMP
   case SignedDistExec::OpenMP:
     s_query_omp = new SignedDistance3DOMP(s_surface_mesh,
                                           Parameters.is_closed_surface,
-                                          Parameters.max_occupancy,
-                                          Parameters.max_levels,
                                           Parameters.compute_sign);
     break;
 #endif
@@ -208,8 +204,6 @@ int signed_distance_init(const mint::Mesh* m, MPI_Comm comm)
   case SignedDistExec::GPU:
     s_query_gpu = new SignedDistance3DGPU(s_surface_mesh,
                                           Parameters.is_closed_surface,
-                                          Parameters.max_occupancy,
-                                          Parameters.max_levels,
                                           Parameters.compute_sign);
     break;
 #endif

--- a/src/axom/quest/interface/signed_distance.cpp
+++ b/src/axom/quest/interface/signed_distance.cpp
@@ -337,30 +337,20 @@ void signed_distance_set_execution_space(SignedDistExec exec_space)
     signed_distance_initialized(),
     "signed distance query already initialized; setting option has no effect!");
 
-  if(exec_space == SignedDistExec::CPU)
+#ifndef AXOM_USE_OPENMP
+  if(exec_space == SignedDistExec::OpenMP)
   {
-    axom::setDefaultAllocator(axom::execution_space<ExecSeq>::allocatorID());
-  }
-  else if(exec_space == SignedDistExec::OpenMP)
-  {
-#ifdef AXOM_USE_OPENMP
-    axom::setDefaultAllocator(axom::execution_space<ExecSeq>::allocatorID());
-#else
     SLIC_ERROR("Signed distance query not compiled with OpenMP support");
-#endif
   }
-  else if(exec_space == SignedDistExec::GPU)
+#endif
+
+#ifndef AXOM_USE_CUDA
+  if(exec_space == SignedDistExec::GPU)
   {
-#ifdef AXOM_USE_CUDA
-    axom::setDefaultAllocator(axom::execution_space<ExecGPU>::allocatorID());
-#else
     SLIC_ERROR("Signed distance query not compiled with GPU support");
+  }
 #endif
-  }
-  else
-  {
-    SLIC_ERROR("Requested execution space value out of bounds");
-  }
+
   Parameters.exec_space = exec_space;
 }
 

--- a/src/axom/quest/interface/signed_distance.cpp
+++ b/src/axom/quest/interface/signed_distance.cpp
@@ -34,8 +34,9 @@ using SignedDistance3D = SignedDistance<3>;
 using SignedDistance2D = SignedDistance<2>;
 
 #ifdef AXOM_USE_OPENMP
-using SignedDistance3DOMP = SignedDistance<3, axom::OMP_EXEC>;
-using SignedDistance2DOMP = SignedDistance<2, axom::OMP_EXEC>;
+using ExecOMP = axom::OMP_EXEC;
+using SignedDistance3DOMP = SignedDistance<3, ExecOMP>;
+using SignedDistance2DOMP = SignedDistance<2, ExecOMP>;
 #endif
 
 #ifdef AXOM_USE_CUDA
@@ -55,6 +56,7 @@ static struct parameters_t
   bool is_closed_surface; /*!< indicates if the input is a closed surface */
   bool use_shared_memory; /*!< use MPI-3 shared memory for the surface mesh */
   bool compute_sign;      /*!< indicates if sign should be computed */
+  int allocator_id; /*!< the allocator ID to create BVH with (-1 for default) */
   SignedDistExec exec_space; /*!< indicates the execution space to run in */
 
   /*!
@@ -66,6 +68,7 @@ static struct parameters_t
     , is_closed_surface(true)
     , use_shared_memory(false)
     , compute_sign(true)
+    , allocator_id(-1)
     , exec_space(SignedDistExec::CPU)
   { }
 
@@ -182,25 +185,41 @@ int signed_distance_init(const mint::Mesh* m, MPI_Comm comm)
     s_must_delete_mesh = false;
   }
 
+  int allocatorID = Parameters.allocator_id;
   switch(Parameters.exec_space)
   {
   case SignedDistExec::CPU:
+    if(allocatorID == -1)
+    {
+      allocatorID = axom::execution_space<ExecSeq>::allocatorID();
+    }
     s_query = new SignedDistance3D(s_surface_mesh,
                                    Parameters.is_closed_surface,
-                                   Parameters.compute_sign);
+                                   Parameters.compute_sign,
+                                   allocatorID);
     break;
 #ifdef AXOM_USE_OPENMP
   case SignedDistExec::OpenMP:
+    if(allocatorID == -1)
+    {
+      allocatorID = axom::execution_space<ExecOMP>::allocatorID();
+    }
     s_query_omp = new SignedDistance3DOMP(s_surface_mesh,
                                           Parameters.is_closed_surface,
-                                          Parameters.compute_sign);
+                                          Parameters.compute_sign,
+                                          allocatorID);
     break;
 #endif
 #ifdef AXOM_USE_CUDA
   case SignedDistExec::GPU:
+    if(allocatorID == -1)
+    {
+      allocatorID = axom::execution_space<ExecGPU>::allocatorID();
+    }
     s_query_gpu = new SignedDistance3DGPU(s_surface_mesh,
                                           Parameters.is_closed_surface,
-                                          Parameters.compute_sign);
+                                          Parameters.compute_sign,
+                                          allocatorID);
     break;
 #endif
   default:
@@ -273,6 +292,16 @@ void signed_distance_set_compute_signs(bool computeSign)
     "signed distance query already initialized; setting option has no effect!");
 
   Parameters.compute_sign = computeSign;
+}
+
+//------------------------------------------------------------------------------
+void signed_distance_set_allocator(int allocatorID)
+{
+  SLIC_ERROR_IF(
+    signed_distance_initialized(),
+    "signed distance query already initialized; setting option has no effect!");
+
+  Parameters.allocator_id = allocatorID;
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/quest/interface/signed_distance.cpp
+++ b/src/axom/quest/interface/signed_distance.cpp
@@ -56,7 +56,7 @@ static struct parameters_t
   bool is_closed_surface; /*!< indicates if the input is a closed surface */
   bool use_shared_memory; /*!< use MPI-3 shared memory for the surface mesh */
   bool compute_sign;      /*!< indicates if sign should be computed */
-  int allocator_id;       /*!< the allocator ID to create BVH with (-1 for default) */
+  int allocator_id; /*!< the allocator ID to create BVH with (-1 for default) */
   SignedDistExec exec_space; /*!< indicates the execution space to run in */
 
   /*!

--- a/src/axom/quest/interface/signed_distance.cpp
+++ b/src/axom/quest/interface/signed_distance.cpp
@@ -51,8 +51,6 @@ static struct parameters_t
 {
   int dimension; /*!< the dimension, 2 or 3 */
 
-  int max_levels;         /*!< max levels of subdivision for the BVH */
-  int max_occupancy;      /*!< max occupancy per BVH bin */
   bool verbose;           /*!< logger verbosity */
   bool is_closed_surface; /*!< indicates if the input is a closed surface */
   bool use_shared_memory; /*!< use MPI-3 shared memory for the surface mesh */
@@ -64,8 +62,6 @@ static struct parameters_t
    */
   parameters_t()
     : dimension(3)
-    , max_levels(12)
-    , max_occupancy(5)
     , verbose(false)
     , is_closed_surface(true)
     , use_shared_memory(false)
@@ -277,26 +273,6 @@ void signed_distance_set_compute_signs(bool computeSign)
     "signed distance query already initialized; setting option has no effect!");
 
   Parameters.compute_sign = computeSign;
-}
-
-//------------------------------------------------------------------------------
-void signed_distance_set_max_levels(int maxLevels)
-{
-  SLIC_ERROR_IF(
-    signed_distance_initialized(),
-    "signed distance query already initialized; setting option has no effect!");
-
-  Parameters.max_levels = maxLevels;
-}
-
-//------------------------------------------------------------------------------
-void signed_distance_set_max_occupancy(int threshold)
-{
-  SLIC_ERROR_IF(
-    signed_distance_initialized(),
-    "signed distance query already initialized; setting option has no effect!");
-
-  Parameters.max_occupancy = threshold;
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/quest/interface/signed_distance.hpp
+++ b/src/axom/quest/interface/signed_distance.hpp
@@ -189,6 +189,15 @@ void signed_distance_set_closed_surface(bool status);
 void signed_distance_set_compute_signs(bool computeSign);
 
 /*!
+ * \brief Sets the allocator to use for creating internal signed distance query
+ *  data structures.
+ * \param [in] allocatorID the allocator ID to use
+ *
+ * \note Allocator should be compatible with the set execution space.
+ */
+void signed_distance_set_allocator(int allocatorID);
+
+/*!
  * \brief Enables/Disables verbose output for the Signed Distance Query.
  * \param [in] status flag indicating whether to enable/disable verbose output
  *

--- a/src/axom/quest/interface/signed_distance.hpp
+++ b/src/axom/quest/interface/signed_distance.hpp
@@ -189,26 +189,6 @@ void signed_distance_set_closed_surface(bool status);
 void signed_distance_set_compute_signs(bool computeSign);
 
 /*!
- * \brief Sets the maximum levels of subdivision for the BVH decomposition.
- * \param [in] maxLevels the maximum levels of subdivision.
- *
- * \note Options must be set before initializing the Signed Distance Query.
- */
-void signed_distance_set_max_levels(int maxLevels);
-
-/*!
- * \brief Sets threshold on the max number of items per BVH bin. This option
- *  controls the BVH decomposition.
- *
- * \param [in] threshold max number of items per bin.
- *
- * \note Options must be set before initializing the Signed Distance Query.
- *
- * \pre theshold >= 1
- */
-void signed_distance_set_max_occupancy(int threshold);
-
-/*!
  * \brief Enables/Disables verbose output for the Signed Distance Query.
  * \param [in] status flag indicating whether to enable/disable verbose output
  *

--- a/src/axom/quest/tests/quest_regression.cpp
+++ b/src/axom/quest/tests/quest_regression.cpp
@@ -408,19 +408,10 @@ void runContainmentQueries(Input& clargs)
  */
 void runDistanceQueries(Input& clargs)
 {
-  constexpr int maxDepth = 10;
-  constexpr int maxEltsPerBucket = 25;
-
-  SLIC_INFO(
-    fmt::format("Initializing BVH tree (maxDepth: {}, "
-                "maxEltsPerBucket: {}) over mesh '{}'...",
-                maxDepth,
-                maxEltsPerBucket,
-                clargs.meshName));
+  SLIC_INFO(fmt::format("Initializing linear BVH tree over mesh '{}'...",
+                        clargs.meshName));
   utilities::Timer buildTimer(true);
 
-  quest::signed_distance_set_max_levels(maxDepth);
-  quest::signed_distance_set_max_occupancy(maxEltsPerBucket);
   quest::signed_distance_init(clargs.meshName, MPI_COMM_WORLD);
 
   buildTimer.stop();

--- a/src/axom/quest/tests/quest_regression.cpp
+++ b/src/axom/quest/tests/quest_regression.cpp
@@ -408,8 +408,8 @@ void runContainmentQueries(Input& clargs)
  */
 void runDistanceQueries(Input& clargs)
 {
-  SLIC_INFO(fmt::format("Initializing linear BVH tree over mesh '{}'...",
-                        clargs.meshName));
+  SLIC_INFO(
+    fmt::format("Initializing linear BVH over mesh '{}'...", clargs.meshName));
   utilities::Timer buildTimer(true);
 
   quest::signed_distance_init(clargs.meshName, MPI_COMM_WORLD);
@@ -440,12 +440,12 @@ void runDistanceQueries(Input& clargs)
   #pragma omp parallel
   #pragma omp master
   SLIC_INFO(
-    fmt::format("Querying BVH tree on uniform grid "
+    fmt::format("Querying BVH on uniform grid "
                 "of resolution {} using {} threads",
                 clargs.queryResolution,
                 omp_get_num_threads()));
 #else
-  SLIC_INFO(fmt::format("Querying BVH tree on uniform grid of resolution {}",
+  SLIC_INFO(fmt::format("Querying BVH on uniform grid of resolution {}",
                         clargs.queryResolution));
 #endif
 

--- a/src/axom/quest/tests/quest_signed_distance.cpp
+++ b/src/axom/quest/tests/quest_signed_distance.cpp
@@ -128,13 +128,11 @@ TEST(quest_signed_distance, sphere_test)
   const int nnodes = umesh->getNumberOfNodes();
 
   SLIC_INFO("Generate BVHTree...");
-  // _quest_distance_cpp_init_start
   constexpr bool is_watertight = true;
   constexpr bool compute_signs = true;
   axom::quest::SignedDistance<3> signed_distance(surface_mesh,
                                                  is_watertight,
                                                  compute_signs);
-  // _quest_distance_cpp_init_end
 
   SLIC_INFO("Compute signed distance...");
 
@@ -226,13 +224,11 @@ void run_vectorized_sphere_test()
   const int nnodes = umesh->getNumberOfNodes();
 
   SLIC_INFO("Generate BVHTree...");
-  // _quest_distance_cpp_init_start
   constexpr bool is_watertight = true;
   constexpr bool compute_signs = true;
   quest::SignedDistance<3, ExecSpace> signed_distance(surface_mesh,
                                                       is_watertight,
                                                       compute_signs);
-  // _quest_distance_cpp_init_end
 
   SLIC_INFO("Compute signed distance...");
 
@@ -306,12 +302,135 @@ TEST(quest_signed_distance, sphere_vec_omp_test)
 
 //------------------------------------------------------------------------------
 #if defined(AXOM_USE_CUDA)
-TEST(quest_signed_distance, sphere_vec_cuda_test)
+AXOM_CUDA_TEST(quest_signed_distance, sphere_vec_cuda_test)
 {
   constexpr int BLOCK_SIZE = 256;
   using exec = axom::CUDA_EXEC<BLOCK_SIZE>;
 
   run_vectorized_sphere_test<exec>();
+}
+
+//------------------------------------------------------------------------------
+AXOM_CUDA_TEST(quest_signed_distance, sphere_vec_cuda_custom_alloc)
+{
+  using PointType = primal::Point<double, 3>;
+
+  const int curr_allocator = axom::getDefaultAllocatorID();
+  axom::setDefaultAllocator(
+    axom::execution_space<axom::CUDA_EXEC<256>>::allocatorID());
+
+  constexpr double l1norm_expected = 6.7051997372579715;
+  constexpr double l2norm_expected = 2.5894400431865519;
+  constexpr double linf_expected = 0.00532092;
+  constexpr double TOL = 1.e-3;
+
+  constexpr double SPHERE_RADIUS = 0.5;
+  constexpr int SPHERE_THETA_RES = 25;
+  constexpr int SPHERE_PHI_RES = 25;
+  const double SPHERE_CENTER[3] = {0.0, 0.0, 0.0};
+
+  primal::Sphere<double, 3> analytic_sphere(SPHERE_RADIUS);
+
+  SLIC_INFO("Constructing sphere mesh...");
+  UMesh* surface_mesh = new UMesh(3, mint::TRIANGLE);
+  quest::utilities::getSphereSurfaceMesh(surface_mesh,
+                                         SPHERE_CENTER,
+                                         SPHERE_RADIUS,
+                                         SPHERE_THETA_RES,
+                                         SPHERE_PHI_RES);
+
+  SLIC_INFO("Generating uniform mesh...");
+  mint::UniformMesh* umesh = nullptr;
+  getUniformMesh(surface_mesh, umesh);
+
+  double* phi_computed =
+    umesh->createField<double>("phi_computed", mint::NODE_CENTERED);
+  double* phi_expected =
+    umesh->createField<double>("phi_expected", mint::NODE_CENTERED);
+  double* phi_diff = umesh->createField<double>("phi_diff", mint::NODE_CENTERED);
+  double* phi_err = umesh->createField<double>("phi_err", mint::NODE_CENTERED);
+
+  const int nnodes = umesh->getNumberOfNodes();
+
+  SLIC_INFO("Generate BVHTree...");
+  // _quest_distance_cpp_init_start
+  // Set execution space
+  constexpr int BlockSize = 256;
+  using ExecSpace = axom::CUDA_EXEC<BlockSize>;
+
+  // Create a custom allocator
+  constexpr size_t PoolSize = 1024 * 1024 * 1024;
+  umpire::ResourceManager& rm = umpire::ResourceManager::getInstance();
+  umpire::Allocator device_allocator =
+    rm.makeAllocator<umpire::strategy::DynamicPool>(
+      "DEVICE_POOL",
+      rm.getAllocator(umpire::resource::Device),
+      PoolSize);
+  int device_pool_id = device_allocator.getId();
+
+  // Set SignedDistance options
+  constexpr bool is_watertight = true;
+  constexpr bool compute_signs = true;
+  quest::SignedDistance<3, ExecSpace> signed_distance(surface_mesh,
+                                                      is_watertight,
+                                                      compute_signs,
+                                                      device_pool_id);
+  // _quest_distance_cpp_init_end
+
+  SLIC_INFO("Compute signed distance...");
+
+  double l1norm = 0.0;
+  double l2norm = 0.0;
+  double linf = std::numeric_limits<double>::min();
+
+  PointType* queryPts = axom::allocate<PointType>(nnodes);
+  for(int inode = 0; inode < nnodes; inode++)
+  {
+    umesh->getNode(inode, queryPts[inode].data());
+  }
+
+  signed_distance.computeDistances(nnodes, queryPts, phi_computed);
+
+  for(int inode = 0; inode < nnodes; ++inode)
+  {
+    phi_expected[inode] =
+      analytic_sphere.computeSignedDistance(queryPts[inode].data());
+    EXPECT_NEAR(phi_computed[inode], phi_expected[inode], 1.e-2);
+
+    // compute error
+    phi_diff[inode] = phi_computed[inode] - phi_expected[inode];
+    phi_err[inode] = std::fabs(phi_diff[inode]);
+
+    // update norms
+    l1norm += phi_err[inode];
+    l2norm += phi_diff[inode];
+    linf = (phi_err[inode] > linf) ? phi_err[inode] : linf;
+
+  }  // END for all nodes
+
+  l2norm = std::sqrt(l2norm);
+
+  SLIC_INFO("l1 = " << l1norm);
+  SLIC_INFO("l2 = " << l2norm);
+  SLIC_INFO("linf = " << linf);
+
+  #ifdef QUEST_SIGNED_DISTANCE_TEST_DUMP_VTK
+  mint::write_vtk(umesh, "uniform_mesh.vtk");
+  mint::write_vtk(surface_mesh, "sphere_mesh.vtk");
+  #endif
+
+  EXPECT_NEAR(l1norm_expected, l1norm, TOL);
+  EXPECT_NEAR(l2norm_expected, l2norm, TOL);
+  EXPECT_NEAR(linf_expected, linf, TOL);
+
+  axom::deallocate(queryPts);
+
+  delete surface_mesh;
+  delete umesh;
+
+  axom::setDefaultAllocator(curr_allocator);
+
+  SLIC_INFO("Done.");
 }
 #endif  // AXOM_USE_CUDA
 

--- a/src/axom/quest/tests/quest_signed_distance.cpp
+++ b/src/axom/quest/tests/quest_signed_distance.cpp
@@ -130,13 +130,9 @@ TEST(quest_signed_distance, sphere_test)
   SLIC_INFO("Generate BVHTree...");
   // _quest_distance_cpp_init_start
   constexpr bool is_watertight = true;
-  constexpr int max_objects = 25;
-  constexpr int max_levels = 10;
   constexpr bool compute_signs = true;
   axom::quest::SignedDistance<3> signed_distance(surface_mesh,
                                                  is_watertight,
-                                                 max_objects,
-                                                 max_levels,
                                                  compute_signs);
   // _quest_distance_cpp_init_end
 
@@ -232,13 +228,9 @@ void run_vectorized_sphere_test()
   SLIC_INFO("Generate BVHTree...");
   // _quest_distance_cpp_init_start
   constexpr bool is_watertight = true;
-  constexpr int max_objects = 25;
-  constexpr int max_levels = 10;
   constexpr bool compute_signs = true;
   quest::SignedDistance<3, ExecSpace> signed_distance(surface_mesh,
                                                       is_watertight,
-                                                      max_objects,
-                                                      max_levels,
                                                       compute_signs);
   // _quest_distance_cpp_init_end
 

--- a/src/axom/quest/tests/quest_signed_distance_interface.cpp
+++ b/src/axom/quest/tests/quest_signed_distance_interface.cpp
@@ -336,12 +336,6 @@ TEST(quest_signed_distance_interface_DeathTest, set_params_after_init)
   EXPECT_DEATH_IF_SUPPORTED(quest::signed_distance_set_closed_surface(true),
                             IGNORE_OUTPUT);
 
-  EXPECT_DEATH_IF_SUPPORTED(quest::signed_distance_set_max_levels(5),
-                            IGNORE_OUTPUT);
-
-  EXPECT_DEATH_IF_SUPPORTED(quest::signed_distance_set_max_occupancy(5),
-                            IGNORE_OUTPUT);
-
   EXPECT_DEATH_IF_SUPPORTED(quest::signed_distance_set_verbose(true),
                             IGNORE_OUTPUT);
 
@@ -490,8 +484,6 @@ TEST(quest_signed_distance_interface, analytic_sphere)
   double* phi_err = umesh->createField<double>("phi_err", mint::NODE_CENTERED);
 
   // STEP 3: initialize the signed distance query
-  quest::signed_distance_set_max_levels(MAX_LEVELS);
-  quest::signed_distance_set_max_occupancy(MAX_OCCUPANCY);
   quest::signed_distance_set_closed_surface(true);
   quest::signed_distance_init(surface_mesh);
   EXPECT_TRUE(quest::signed_distance_initialized());


### PR DESCRIPTION
# Summary

- Removes obsolete/unused options from `SignedDistance`
- Adds capability to specify custom allocator in `SignedDistance` for both C and C++ interface
- Update documentation

Resolves #655.