### PR TITLE
Whitespace changes from running clangformat on generated code

### DIFF
--- a/src/axom/sidre/interface/c_fortran/typesSidre.h
+++ b/src/axom/sidre/interface/c_fortran/typesSidre.h
@@ -17,7 +17,7 @@ extern "C" {
 // helper capsule_SIDRE_Buffer
 struct s_SIDRE_Buffer
 {
-  void* addr; /* address of C++ memory */
+  void *addr; /* address of C++ memory */
   int idtor;  /* index of destructor */
 };
 typedef struct s_SIDRE_Buffer SIDRE_Buffer;
@@ -25,7 +25,7 @@ typedef struct s_SIDRE_Buffer SIDRE_Buffer;
 // helper capsule_SIDRE_DataStore
 struct s_SIDRE_DataStore
 {
-  void* addr; /* address of C++ memory */
+  void *addr; /* address of C++ memory */
   int idtor;  /* index of destructor */
 };
 typedef struct s_SIDRE_DataStore SIDRE_DataStore;
@@ -33,7 +33,7 @@ typedef struct s_SIDRE_DataStore SIDRE_DataStore;
 // helper capsule_SIDRE_Group
 struct s_SIDRE_Group
 {
-  void* addr; /* address of C++ memory */
+  void *addr; /* address of C++ memory */
   int idtor;  /* index of destructor */
 };
 typedef struct s_SIDRE_Group SIDRE_Group;
@@ -41,7 +41,7 @@ typedef struct s_SIDRE_Group SIDRE_Group;
 // helper capsule_SIDRE_View
 struct s_SIDRE_View
 {
-  void* addr; /* address of C++ memory */
+  void *addr; /* address of C++ memory */
   int idtor;  /* index of destructor */
 };
 typedef struct s_SIDRE_View SIDRE_View;
@@ -49,12 +49,12 @@ typedef struct s_SIDRE_View SIDRE_View;
 // helper capsule_data_helper
 struct s_SIDRE_SHROUD_capsule_data
 {
-  void* addr; /* address of C++ memory */
+  void *addr; /* address of C++ memory */
   int idtor;  /* index of destructor */
 };
 typedef struct s_SIDRE_SHROUD_capsule_data SIDRE_SHROUD_capsule_data;
 
-void SIDRE_SHROUD_memory_destructor(SIDRE_SHROUD_capsule_data* cap);
+void SIDRE_SHROUD_memory_destructor(SIDRE_SHROUD_capsule_data *cap);
 
 #ifdef __cplusplus
 }

--- a/src/axom/sidre/interface/c_fortran/wrapBuffer.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapBuffer.cpp
@@ -16,39 +16,39 @@ extern "C" {
 // splicer begin class.Buffer.C_definitions
 // splicer end class.Buffer.C_definitions
 
-SIDRE_IndexType SIDRE_Buffer_get_index(const SIDRE_Buffer* self)
+SIDRE_IndexType SIDRE_Buffer_get_index(const SIDRE_Buffer *self)
 {
-  const axom::sidre::Buffer* SH_this =
-    static_cast<const axom::sidre::Buffer*>(self->addr);
+  const axom::sidre::Buffer *SH_this =
+    static_cast<const axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.get_index
   axom::sidre::IndexType SHC_rv = SH_this->getIndex();
   return SHC_rv;
   // splicer end class.Buffer.method.get_index
 }
 
-size_t SIDRE_Buffer_get_num_views(const SIDRE_Buffer* self)
+size_t SIDRE_Buffer_get_num_views(const SIDRE_Buffer *self)
 {
-  const axom::sidre::Buffer* SH_this =
-    static_cast<const axom::sidre::Buffer*>(self->addr);
+  const axom::sidre::Buffer *SH_this =
+    static_cast<const axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.get_num_views
   size_t SHC_rv = SH_this->getNumViews();
   return SHC_rv;
   // splicer end class.Buffer.method.get_num_views
 }
 
-void* SIDRE_Buffer_get_void_ptr(SIDRE_Buffer* self)
+void *SIDRE_Buffer_get_void_ptr(SIDRE_Buffer *self)
 {
-  axom::sidre::Buffer* SH_this = static_cast<axom::sidre::Buffer*>(self->addr);
+  axom::sidre::Buffer *SH_this = static_cast<axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.get_void_ptr
-  void* SHC_rv = SH_this->getVoidPtr();
+  void *SHC_rv = SH_this->getVoidPtr();
   return SHC_rv;
   // splicer end class.Buffer.method.get_void_ptr
 }
 
-int SIDRE_Buffer_get_type_id(const SIDRE_Buffer* self)
+int SIDRE_Buffer_get_type_id(const SIDRE_Buffer *self)
 {
-  const axom::sidre::Buffer* SH_this =
-    static_cast<const axom::sidre::Buffer*>(self->addr);
+  const axom::sidre::Buffer *SH_this =
+    static_cast<const axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.get_type_id
   axom::sidre::TypeID SHCXX_rv = SH_this->getTypeID();
   int SHC_rv = static_cast<int>(SHCXX_rv);
@@ -56,76 +56,76 @@ int SIDRE_Buffer_get_type_id(const SIDRE_Buffer* self)
   // splicer end class.Buffer.method.get_type_id
 }
 
-size_t SIDRE_Buffer_get_num_elements(const SIDRE_Buffer* self)
+size_t SIDRE_Buffer_get_num_elements(const SIDRE_Buffer *self)
 {
-  const axom::sidre::Buffer* SH_this =
-    static_cast<const axom::sidre::Buffer*>(self->addr);
+  const axom::sidre::Buffer *SH_this =
+    static_cast<const axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.get_num_elements
   size_t SHC_rv = SH_this->getNumElements();
   return SHC_rv;
   // splicer end class.Buffer.method.get_num_elements
 }
 
-size_t SIDRE_Buffer_get_total_bytes(const SIDRE_Buffer* self)
+size_t SIDRE_Buffer_get_total_bytes(const SIDRE_Buffer *self)
 {
-  const axom::sidre::Buffer* SH_this =
-    static_cast<const axom::sidre::Buffer*>(self->addr);
+  const axom::sidre::Buffer *SH_this =
+    static_cast<const axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.get_total_bytes
   size_t SHC_rv = SH_this->getTotalBytes();
   return SHC_rv;
   // splicer end class.Buffer.method.get_total_bytes
 }
 
-size_t SIDRE_Buffer_get_bytes_per_element(const SIDRE_Buffer* self)
+size_t SIDRE_Buffer_get_bytes_per_element(const SIDRE_Buffer *self)
 {
-  const axom::sidre::Buffer* SH_this =
-    static_cast<const axom::sidre::Buffer*>(self->addr);
+  const axom::sidre::Buffer *SH_this =
+    static_cast<const axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.get_bytes_per_element
   size_t SHC_rv = SH_this->getBytesPerElement();
   return SHC_rv;
   // splicer end class.Buffer.method.get_bytes_per_element
 }
 
-void SIDRE_Buffer_describe(SIDRE_Buffer* self, int type, SIDRE_IndexType num_elems)
+void SIDRE_Buffer_describe(SIDRE_Buffer *self, int type, SIDRE_IndexType num_elems)
 {
-  axom::sidre::Buffer* SH_this = static_cast<axom::sidre::Buffer*>(self->addr);
+  axom::sidre::Buffer *SH_this = static_cast<axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.describe
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   SH_this->describe(SHCXX_type, num_elems);
   // splicer end class.Buffer.method.describe
 }
 
-void SIDRE_Buffer_allocate_existing(SIDRE_Buffer* self)
+void SIDRE_Buffer_allocate_existing(SIDRE_Buffer *self)
 {
-  axom::sidre::Buffer* SH_this = static_cast<axom::sidre::Buffer*>(self->addr);
+  axom::sidre::Buffer *SH_this = static_cast<axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.allocate_existing
   SH_this->allocate();
   // splicer end class.Buffer.method.allocate_existing
 }
 
-void SIDRE_Buffer_allocate_from_type(SIDRE_Buffer* self,
+void SIDRE_Buffer_allocate_from_type(SIDRE_Buffer *self,
                                      int type,
                                      SIDRE_IndexType num_elems)
 {
-  axom::sidre::Buffer* SH_this = static_cast<axom::sidre::Buffer*>(self->addr);
+  axom::sidre::Buffer *SH_this = static_cast<axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.allocate_from_type
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   SH_this->allocate(SHCXX_type, num_elems);
   // splicer end class.Buffer.method.allocate_from_type
 }
 
-void SIDRE_Buffer_reallocate(SIDRE_Buffer* self, SIDRE_IndexType num_elems)
+void SIDRE_Buffer_reallocate(SIDRE_Buffer *self, SIDRE_IndexType num_elems)
 {
-  axom::sidre::Buffer* SH_this = static_cast<axom::sidre::Buffer*>(self->addr);
+  axom::sidre::Buffer *SH_this = static_cast<axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.reallocate
   SH_this->reallocate(num_elems);
   // splicer end class.Buffer.method.reallocate
 }
 
-void SIDRE_Buffer_print(const SIDRE_Buffer* self)
+void SIDRE_Buffer_print(const SIDRE_Buffer *self)
 {
-  const axom::sidre::Buffer* SH_this =
-    static_cast<const axom::sidre::Buffer*>(self->addr);
+  const axom::sidre::Buffer *SH_this =
+    static_cast<const axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.print
   SH_this->print();
   // splicer end class.Buffer.method.print

--- a/src/axom/sidre/interface/c_fortran/wrapDataStore.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapDataStore.cpp
@@ -21,56 +21,56 @@ extern "C" {
 // splicer begin class.DataStore.C_definitions
 // splicer end class.DataStore.C_definitions
 
-SIDRE_DataStore* SIDRE_DataStore_new(SIDRE_DataStore* SHC_rv)
+SIDRE_DataStore *SIDRE_DataStore_new(SIDRE_DataStore *SHC_rv)
 {
   // splicer begin class.DataStore.method.new
-  axom::sidre::DataStore* SHCXX_rv = new axom::sidre::DataStore();
-  SHC_rv->addr = static_cast<void*>(SHCXX_rv);
+  axom::sidre::DataStore *SHCXX_rv = new axom::sidre::DataStore();
+  SHC_rv->addr = static_cast<void *>(SHCXX_rv);
   SHC_rv->idtor = 1;
   return SHC_rv;
   // splicer end class.DataStore.method.new
 }
 
-void SIDRE_DataStore_delete(SIDRE_DataStore* self)
+void SIDRE_DataStore_delete(SIDRE_DataStore *self)
 {
-  axom::sidre::DataStore* SH_this =
-    static_cast<axom::sidre::DataStore*>(self->addr);
+  axom::sidre::DataStore *SH_this =
+    static_cast<axom::sidre::DataStore *>(self->addr);
   // splicer begin class.DataStore.method.delete
   delete SH_this;
   self->addr = nullptr;
   // splicer end class.DataStore.method.delete
 }
 
-SIDRE_Group* SIDRE_DataStore_get_root(SIDRE_DataStore* self, SIDRE_Group* SHC_rv)
+SIDRE_Group *SIDRE_DataStore_get_root(SIDRE_DataStore *self, SIDRE_Group *SHC_rv)
 {
-  axom::sidre::DataStore* SH_this =
-    static_cast<axom::sidre::DataStore*>(self->addr);
+  axom::sidre::DataStore *SH_this =
+    static_cast<axom::sidre::DataStore *>(self->addr);
   // splicer begin class.DataStore.method.get_root
-  axom::sidre::Group* SHCXX_rv = SH_this->getRoot();
+  axom::sidre::Group *SHCXX_rv = SH_this->getRoot();
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.DataStore.method.get_root
 }
 
-size_t SIDRE_DataStore_get_num_buffers(const SIDRE_DataStore* self)
+size_t SIDRE_DataStore_get_num_buffers(const SIDRE_DataStore *self)
 {
-  const axom::sidre::DataStore* SH_this =
-    static_cast<const axom::sidre::DataStore*>(self->addr);
+  const axom::sidre::DataStore *SH_this =
+    static_cast<const axom::sidre::DataStore *>(self->addr);
   // splicer begin class.DataStore.method.get_num_buffers
   size_t SHC_rv = SH_this->getNumBuffers();
   return SHC_rv;
   // splicer end class.DataStore.method.get_num_buffers
 }
 
-SIDRE_Buffer* SIDRE_DataStore_get_buffer(SIDRE_DataStore* self,
+SIDRE_Buffer *SIDRE_DataStore_get_buffer(SIDRE_DataStore *self,
                                          SIDRE_IndexType idx,
-                                         SIDRE_Buffer* SHC_rv)
+                                         SIDRE_Buffer *SHC_rv)
 {
-  axom::sidre::DataStore* SH_this =
-    static_cast<axom::sidre::DataStore*>(self->addr);
+  axom::sidre::DataStore *SH_this =
+    static_cast<axom::sidre::DataStore *>(self->addr);
   // splicer begin class.DataStore.method.get_buffer
-  axom::sidre::Buffer* SHCXX_rv = SH_this->getBuffer(idx);
+  axom::sidre::Buffer *SHCXX_rv = SH_this->getBuffer(idx);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -85,29 +85,29 @@ SIDRE_Buffer* SIDRE_DataStore_get_buffer(SIDRE_DataStore* self,
   // splicer end class.DataStore.method.get_buffer
 }
 
-SIDRE_Buffer* SIDRE_DataStore_create_buffer_empty(SIDRE_DataStore* self,
-                                                  SIDRE_Buffer* SHC_rv)
+SIDRE_Buffer *SIDRE_DataStore_create_buffer_empty(SIDRE_DataStore *self,
+                                                  SIDRE_Buffer *SHC_rv)
 {
-  axom::sidre::DataStore* SH_this =
-    static_cast<axom::sidre::DataStore*>(self->addr);
+  axom::sidre::DataStore *SH_this =
+    static_cast<axom::sidre::DataStore *>(self->addr);
   // splicer begin class.DataStore.method.create_buffer_empty
-  axom::sidre::Buffer* SHCXX_rv = SH_this->createBuffer();
+  axom::sidre::Buffer *SHCXX_rv = SH_this->createBuffer();
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.DataStore.method.create_buffer_empty
 }
 
-SIDRE_Buffer* SIDRE_DataStore_create_buffer_from_type(SIDRE_DataStore* self,
+SIDRE_Buffer *SIDRE_DataStore_create_buffer_from_type(SIDRE_DataStore *self,
                                                       int type,
                                                       SIDRE_IndexType num_elems,
-                                                      SIDRE_Buffer* SHC_rv)
+                                                      SIDRE_Buffer *SHC_rv)
 {
-  axom::sidre::DataStore* SH_this =
-    static_cast<axom::sidre::DataStore*>(self->addr);
+  axom::sidre::DataStore *SH_this =
+    static_cast<axom::sidre::DataStore *>(self->addr);
   // splicer begin class.DataStore.method.create_buffer_from_type
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::Buffer* SHCXX_rv = SH_this->createBuffer(SHCXX_type, num_elems);
+  axom::sidre::Buffer *SHCXX_rv = SH_this->createBuffer(SHCXX_type, num_elems);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -122,23 +122,23 @@ SIDRE_Buffer* SIDRE_DataStore_create_buffer_from_type(SIDRE_DataStore* self,
   // splicer end class.DataStore.method.create_buffer_from_type
 }
 
-void SIDRE_DataStore_destroy_buffer(SIDRE_DataStore* self, SIDRE_IndexType id)
+void SIDRE_DataStore_destroy_buffer(SIDRE_DataStore *self, SIDRE_IndexType id)
 {
-  axom::sidre::DataStore* SH_this =
-    static_cast<axom::sidre::DataStore*>(self->addr);
+  axom::sidre::DataStore *SH_this =
+    static_cast<axom::sidre::DataStore *>(self->addr);
   // splicer begin class.DataStore.method.destroy_buffer
   SH_this->destroyBuffer(id);
   // splicer end class.DataStore.method.destroy_buffer
 }
 
-bool SIDRE_DataStore_generate_blueprint_index(SIDRE_DataStore* self,
-                                              const char* domain_path,
-                                              const char* mesh_name,
-                                              const char* index_path,
+bool SIDRE_DataStore_generate_blueprint_index(SIDRE_DataStore *self,
+                                              const char *domain_path,
+                                              const char *mesh_name,
+                                              const char *index_path,
                                               int num_domains)
 {
-  axom::sidre::DataStore* SH_this =
-    static_cast<axom::sidre::DataStore*>(self->addr);
+  axom::sidre::DataStore *SH_this =
+    static_cast<axom::sidre::DataStore *>(self->addr);
   // splicer begin class.DataStore.method.generate_blueprint_index
   const std::string SHCXX_domain_path(domain_path);
   const std::string SHCXX_mesh_name(mesh_name);
@@ -151,17 +151,17 @@ bool SIDRE_DataStore_generate_blueprint_index(SIDRE_DataStore* self,
   // splicer end class.DataStore.method.generate_blueprint_index
 }
 
-bool SIDRE_DataStore_generate_blueprint_index_bufferify(SIDRE_DataStore* self,
-                                                        const char* domain_path,
+bool SIDRE_DataStore_generate_blueprint_index_bufferify(SIDRE_DataStore *self,
+                                                        const char *domain_path,
                                                         int Ldomain_path,
-                                                        const char* mesh_name,
+                                                        const char *mesh_name,
                                                         int Lmesh_name,
-                                                        const char* index_path,
+                                                        const char *index_path,
                                                         int Lindex_path,
                                                         int num_domains)
 {
-  axom::sidre::DataStore* SH_this =
-    static_cast<axom::sidre::DataStore*>(self->addr);
+  axom::sidre::DataStore *SH_this =
+    static_cast<axom::sidre::DataStore *>(self->addr);
   // splicer begin class.DataStore.method.generate_blueprint_index_bufferify
   const std::string SHCXX_domain_path(domain_path, Ldomain_path);
   const std::string SHCXX_mesh_name(mesh_name, Lmesh_name);
@@ -174,10 +174,10 @@ bool SIDRE_DataStore_generate_blueprint_index_bufferify(SIDRE_DataStore* self,
   // splicer end class.DataStore.method.generate_blueprint_index_bufferify
 }
 
-void SIDRE_DataStore_print(const SIDRE_DataStore* self)
+void SIDRE_DataStore_print(const SIDRE_DataStore *self)
 {
-  const axom::sidre::DataStore* SH_this =
-    static_cast<const axom::sidre::DataStore*>(self->addr);
+  const axom::sidre::DataStore *SH_this =
+    static_cast<const axom::sidre::DataStore *>(self->addr);
   // splicer begin class.DataStore.method.print
   SH_this->print();
   // splicer end class.DataStore.method.print

--- a/src/axom/sidre/interface/c_fortran/wrapGroup.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapGroup.cpp
@@ -23,7 +23,7 @@ extern "C" {
 // Copy src into dest, blank fill to ndest characters
 // Truncate if dest is too short.
 // dest will not be NULL terminated.
-static void ShroudStrCopy(char* dest, int ndest, const char* src, int nsrc)
+static void ShroudStrCopy(char *dest, int ndest, const char *src, int nsrc)
 {
   if(src == NULL)
   {
@@ -40,34 +40,34 @@ static void ShroudStrCopy(char* dest, int ndest, const char* src, int nsrc)
 // splicer begin class.Group.C_definitions
 // splicer end class.Group.C_definitions
 
-SIDRE_IndexType SIDRE_Group_get_index(SIDRE_Group* self)
+SIDRE_IndexType SIDRE_Group_get_index(SIDRE_Group *self)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_index
   axom::sidre::IndexType SHC_rv = SH_this->getIndex();
   return SHC_rv;
   // splicer end class.Group.method.get_index
 }
 
-const char* SIDRE_Group_get_name(const SIDRE_Group* self)
+const char *SIDRE_Group_get_name(const SIDRE_Group *self)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_name
-  const std::string& SHCXX_rv = SH_this->getName();
-  const char* SHC_rv = SHCXX_rv.c_str();
+  const std::string &SHCXX_rv = SH_this->getName();
+  const char *SHC_rv = SHCXX_rv.c_str();
   return SHC_rv;
   // splicer end class.Group.method.get_name
 }
 
-void SIDRE_Group_get_name_bufferify(const SIDRE_Group* self,
-                                    char* SHF_rv,
+void SIDRE_Group_get_name_bufferify(const SIDRE_Group *self,
+                                    char *SHF_rv,
                                     int NSHF_rv)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_name_bufferify
-  const std::string& SHCXX_rv = SH_this->getName();
+  const std::string &SHCXX_rv = SH_this->getName();
   if(SHCXX_rv.empty())
   {
     ShroudStrCopy(SHF_rv, NSHF_rv, nullptr, 0);
@@ -79,12 +79,12 @@ void SIDRE_Group_get_name_bufferify(const SIDRE_Group* self,
   // splicer end class.Group.method.get_name_bufferify
 }
 
-void SIDRE_Group_get_path_bufferify(const SIDRE_Group* self,
-                                    char* SHF_rv,
+void SIDRE_Group_get_path_bufferify(const SIDRE_Group *self,
+                                    char *SHF_rv,
                                     int NSHF_rv)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_path_bufferify
   std::string SHCXX_rv = SH_this->getPath();
   if(SHCXX_rv.empty())
@@ -98,12 +98,12 @@ void SIDRE_Group_get_path_bufferify(const SIDRE_Group* self,
   // splicer end class.Group.method.get_path_bufferify
 }
 
-void SIDRE_Group_get_path_name_bufferify(const SIDRE_Group* self,
-                                         char* SHF_rv,
+void SIDRE_Group_get_path_name_bufferify(const SIDRE_Group *self,
+                                         char *SHF_rv,
                                          int NSHF_rv)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_path_name_bufferify
   std::string SHCXX_rv = SH_this->getPathName();
   if(SHCXX_rv.empty())
@@ -117,55 +117,55 @@ void SIDRE_Group_get_path_name_bufferify(const SIDRE_Group* self,
   // splicer end class.Group.method.get_path_name_bufferify
 }
 
-SIDRE_Group* SIDRE_Group_get_parent(const SIDRE_Group* self, SIDRE_Group* SHC_rv)
+SIDRE_Group *SIDRE_Group_get_parent(const SIDRE_Group *self, SIDRE_Group *SHC_rv)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_parent
-  const axom::sidre::Group* SHCXX_rv = SH_this->getParent();
-  SHC_rv->addr = const_cast<axom::sidre::Group*>(SHCXX_rv);
+  const axom::sidre::Group *SHCXX_rv = SH_this->getParent();
+  SHC_rv->addr = const_cast<axom::sidre::Group *>(SHCXX_rv);
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.Group.method.get_parent
 }
 
-size_t SIDRE_Group_get_num_groups(const SIDRE_Group* self)
+size_t SIDRE_Group_get_num_groups(const SIDRE_Group *self)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_num_groups
   size_t SHC_rv = SH_this->getNumGroups();
   return SHC_rv;
   // splicer end class.Group.method.get_num_groups
 }
 
-size_t SIDRE_Group_get_num_views(const SIDRE_Group* self)
+size_t SIDRE_Group_get_num_views(const SIDRE_Group *self)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_num_views
   size_t SHC_rv = SH_this->getNumViews();
   return SHC_rv;
   // splicer end class.Group.method.get_num_views
 }
 
-SIDRE_DataStore* SIDRE_Group_get_data_store(const SIDRE_Group* self,
-                                            SIDRE_DataStore* SHC_rv)
+SIDRE_DataStore *SIDRE_Group_get_data_store(const SIDRE_Group *self,
+                                            SIDRE_DataStore *SHC_rv)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_data_store
-  const axom::sidre::DataStore* SHCXX_rv = SH_this->getDataStore();
-  SHC_rv->addr = const_cast<axom::sidre::DataStore*>(SHCXX_rv);
+  const axom::sidre::DataStore *SHCXX_rv = SH_this->getDataStore();
+  SHC_rv->addr = const_cast<axom::sidre::DataStore *>(SHCXX_rv);
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.Group.method.get_data_store
 }
 
-bool SIDRE_Group_has_view(const SIDRE_Group* self, const char* path)
+bool SIDRE_Group_has_view(const SIDRE_Group *self, const char *path)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.has_view
   const std::string SHCXX_path(path);
   bool SHC_rv = SH_this->hasView(SHCXX_path);
@@ -173,12 +173,12 @@ bool SIDRE_Group_has_view(const SIDRE_Group* self, const char* path)
   // splicer end class.Group.method.has_view
 }
 
-bool SIDRE_Group_has_view_bufferify(const SIDRE_Group* self,
-                                    const char* path,
+bool SIDRE_Group_has_view_bufferify(const SIDRE_Group *self,
+                                    const char *path,
                                     int Lpath)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.has_view_bufferify
   const std::string SHCXX_path(path, Lpath);
   bool SHC_rv = SH_this->hasView(SHCXX_path);
@@ -186,10 +186,10 @@ bool SIDRE_Group_has_view_bufferify(const SIDRE_Group* self,
   // splicer end class.Group.method.has_view_bufferify
 }
 
-bool SIDRE_Group_has_child_view(const SIDRE_Group* self, const char* name)
+bool SIDRE_Group_has_child_view(const SIDRE_Group *self, const char *name)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.has_child_view
   const std::string SHCXX_name(name);
   bool SHC_rv = SH_this->hasChildView(SHCXX_name);
@@ -197,12 +197,12 @@ bool SIDRE_Group_has_child_view(const SIDRE_Group* self, const char* name)
   // splicer end class.Group.method.has_child_view
 }
 
-bool SIDRE_Group_has_child_view_bufferify(const SIDRE_Group* self,
-                                          const char* name,
+bool SIDRE_Group_has_child_view_bufferify(const SIDRE_Group *self,
+                                          const char *name,
                                           int Lname)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.has_child_view_bufferify
   const std::string SHCXX_name(name, Lname);
   bool SHC_rv = SH_this->hasChildView(SHCXX_name);
@@ -210,11 +210,11 @@ bool SIDRE_Group_has_child_view_bufferify(const SIDRE_Group* self,
   // splicer end class.Group.method.has_child_view_bufferify
 }
 
-SIDRE_IndexType SIDRE_Group_get_view_index(const SIDRE_Group* self,
-                                           const char* name)
+SIDRE_IndexType SIDRE_Group_get_view_index(const SIDRE_Group *self,
+                                           const char *name)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_view_index
   const std::string SHCXX_name(name);
   axom::sidre::IndexType SHC_rv = SH_this->getViewIndex(SHCXX_name);
@@ -222,12 +222,12 @@ SIDRE_IndexType SIDRE_Group_get_view_index(const SIDRE_Group* self,
   // splicer end class.Group.method.get_view_index
 }
 
-SIDRE_IndexType SIDRE_Group_get_view_index_bufferify(const SIDRE_Group* self,
-                                                     const char* name,
+SIDRE_IndexType SIDRE_Group_get_view_index_bufferify(const SIDRE_Group *self,
+                                                     const char *name,
                                                      int Lname)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_view_index_bufferify
   const std::string SHCXX_name(name, Lname);
   axom::sidre::IndexType SHC_rv = SH_this->getViewIndex(SHCXX_name);
@@ -235,32 +235,32 @@ SIDRE_IndexType SIDRE_Group_get_view_index_bufferify(const SIDRE_Group* self,
   // splicer end class.Group.method.get_view_index_bufferify
 }
 
-const char* SIDRE_Group_get_view_name(const SIDRE_Group* self, SIDRE_IndexType idx)
+const char *SIDRE_Group_get_view_name(const SIDRE_Group *self, SIDRE_IndexType idx)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_view_name
-  const std::string& SHCXX_rv = SH_this->getViewName(idx);
+  const std::string &SHCXX_rv = SH_this->getViewName(idx);
   // C_error_pattern
   if(!axom::sidre::nameIsValid(SHCXX_rv))
   {
     return SIDRE_InvalidName;
   }
 
-  const char* SHC_rv = SHCXX_rv.c_str();
+  const char *SHC_rv = SHCXX_rv.c_str();
   return SHC_rv;
   // splicer end class.Group.method.get_view_name
 }
 
-void SIDRE_Group_get_view_name_bufferify(const SIDRE_Group* self,
+void SIDRE_Group_get_view_name_bufferify(const SIDRE_Group *self,
                                          SIDRE_IndexType idx,
-                                         char* SHF_rv,
+                                         char *SHF_rv,
                                          int NSHF_rv)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_view_name_bufferify
-  const std::string& SHCXX_rv = SH_this->getViewName(idx);
+  const std::string &SHCXX_rv = SH_this->getViewName(idx);
   // C_error_pattern
   if(!axom::sidre::nameIsValid(SHCXX_rv))
   {
@@ -279,14 +279,14 @@ void SIDRE_Group_get_view_name_bufferify(const SIDRE_Group* self,
   // splicer end class.Group.method.get_view_name_bufferify
 }
 
-SIDRE_View* SIDRE_Group_get_view_from_name(SIDRE_Group* self,
-                                           const char* path,
-                                           SIDRE_View* SHC_rv)
+SIDRE_View *SIDRE_Group_get_view_from_name(SIDRE_Group *self,
+                                           const char *path,
+                                           SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_view_from_name
   const std::string SHCXX_path(path);
-  axom::sidre::View* SHCXX_rv = SH_this->getView(SHCXX_path);
+  axom::sidre::View *SHCXX_rv = SH_this->getView(SHCXX_path);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -301,28 +301,28 @@ SIDRE_View* SIDRE_Group_get_view_from_name(SIDRE_Group* self,
   // splicer end class.Group.method.get_view_from_name
 }
 
-SIDRE_View* SIDRE_Group_get_view_from_name_bufferify(SIDRE_Group* self,
-                                                     const char* path,
+SIDRE_View *SIDRE_Group_get_view_from_name_bufferify(SIDRE_Group *self,
+                                                     const char *path,
                                                      int Lpath,
-                                                     SIDRE_View* SHC_rv)
+                                                     SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_view_from_name_bufferify
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::View* SHCXX_rv = SH_this->getView(SHCXX_path);
+  axom::sidre::View *SHCXX_rv = SH_this->getView(SHCXX_path);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.Group.method.get_view_from_name_bufferify
 }
 
-SIDRE_View* SIDRE_Group_get_view_from_index(SIDRE_Group* self,
+SIDRE_View *SIDRE_Group_get_view_from_index(SIDRE_Group *self,
                                             const SIDRE_IndexType idx,
-                                            SIDRE_View* SHC_rv)
+                                            SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_view_from_index
-  axom::sidre::View* SHCXX_rv = SH_this->getView(idx);
+  axom::sidre::View *SHCXX_rv = SH_this->getView(idx);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -337,35 +337,35 @@ SIDRE_View* SIDRE_Group_get_view_from_index(SIDRE_Group* self,
   // splicer end class.Group.method.get_view_from_index
 }
 
-SIDRE_IndexType SIDRE_Group_get_first_valid_view_index(const SIDRE_Group* self)
+SIDRE_IndexType SIDRE_Group_get_first_valid_view_index(const SIDRE_Group *self)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_first_valid_view_index
   axom::sidre::IndexType SHC_rv = SH_this->getFirstValidViewIndex();
   return SHC_rv;
   // splicer end class.Group.method.get_first_valid_view_index
 }
 
-SIDRE_IndexType SIDRE_Group_get_next_valid_view_index(const SIDRE_Group* self,
+SIDRE_IndexType SIDRE_Group_get_next_valid_view_index(const SIDRE_Group *self,
                                                       SIDRE_IndexType idx)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_next_valid_view_index
   axom::sidre::IndexType SHC_rv = SH_this->getNextValidViewIndex(idx);
   return SHC_rv;
   // splicer end class.Group.method.get_next_valid_view_index
 }
 
-SIDRE_View* SIDRE_Group_create_view_empty(SIDRE_Group* self,
-                                          const char* path,
-                                          SIDRE_View* SHC_rv)
+SIDRE_View *SIDRE_Group_create_view_empty(SIDRE_Group *self,
+                                          const char *path,
+                                          SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_empty
   const std::string SHCXX_path(path);
-  axom::sidre::View* SHCXX_rv = SH_this->createView(SHCXX_path);
+  axom::sidre::View *SHCXX_rv = SH_this->createView(SHCXX_path);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -380,32 +380,32 @@ SIDRE_View* SIDRE_Group_create_view_empty(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_empty
 }
 
-SIDRE_View* SIDRE_Group_create_view_empty_bufferify(SIDRE_Group* self,
-                                                    const char* path,
+SIDRE_View *SIDRE_Group_create_view_empty_bufferify(SIDRE_Group *self,
+                                                    const char *path,
                                                     int Lpath,
-                                                    SIDRE_View* SHC_rv)
+                                                    SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_empty_bufferify
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::View* SHCXX_rv = SH_this->createView(SHCXX_path);
+  axom::sidre::View *SHCXX_rv = SH_this->createView(SHCXX_path);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.Group.method.create_view_empty_bufferify
 }
 
-SIDRE_View* SIDRE_Group_create_view_from_type(SIDRE_Group* self,
-                                              const char* path,
+SIDRE_View *SIDRE_Group_create_view_from_type(SIDRE_Group *self,
+                                              const char *path,
                                               int type,
                                               SIDRE_IndexType num_elems,
-                                              SIDRE_View* SHC_rv)
+                                              SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_type
   const std::string SHCXX_path(path);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, num_elems);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
@@ -421,18 +421,18 @@ SIDRE_View* SIDRE_Group_create_view_from_type(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_from_type
 }
 
-SIDRE_View* SIDRE_Group_create_view_from_type_bufferify(SIDRE_Group* self,
-                                                        const char* path,
+SIDRE_View *SIDRE_Group_create_view_from_type_bufferify(SIDRE_Group *self,
+                                                        const char *path,
                                                         int Lpath,
                                                         int type,
                                                         SIDRE_IndexType num_elems,
-                                                        SIDRE_View* SHC_rv)
+                                                        SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_type_bufferify
   const std::string SHCXX_path(path, Lpath);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, num_elems);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
@@ -440,18 +440,18 @@ SIDRE_View* SIDRE_Group_create_view_from_type_bufferify(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_from_type_bufferify
 }
 
-SIDRE_View* SIDRE_Group_create_view_from_shape(SIDRE_Group* self,
-                                               const char* path,
+SIDRE_View *SIDRE_Group_create_view_from_shape(SIDRE_Group *self,
+                                               const char *path,
                                                int type,
                                                int ndims,
-                                               const SIDRE_IndexType* shape,
-                                               SIDRE_View* SHC_rv)
+                                               const SIDRE_IndexType *shape,
+                                               SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_shape
   const std::string SHCXX_path(path);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, ndims, shape);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
@@ -467,19 +467,19 @@ SIDRE_View* SIDRE_Group_create_view_from_shape(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_from_shape
 }
 
-SIDRE_View* SIDRE_Group_create_view_from_shape_bufferify(SIDRE_Group* self,
-                                                         const char* path,
+SIDRE_View *SIDRE_Group_create_view_from_shape_bufferify(SIDRE_Group *self,
+                                                         const char *path,
                                                          int Lpath,
                                                          int type,
                                                          int ndims,
-                                                         const SIDRE_IndexType* shape,
-                                                         SIDRE_View* SHC_rv)
+                                                         const SIDRE_IndexType *shape,
+                                                         SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_shape_bufferify
   const std::string SHCXX_path(path, Lpath);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, ndims, shape);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
@@ -487,16 +487,17 @@ SIDRE_View* SIDRE_Group_create_view_from_shape_bufferify(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_from_shape_bufferify
 }
 
-SIDRE_View* SIDRE_Group_create_view_into_buffer(SIDRE_Group* self,
-                                                const char* path,
-                                                SIDRE_Buffer* buff,
-                                                SIDRE_View* SHC_rv)
+SIDRE_View *SIDRE_Group_create_view_into_buffer(SIDRE_Group *self,
+                                                const char *path,
+                                                SIDRE_Buffer *buff,
+                                                SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_into_buffer
   const std::string SHCXX_path(path);
-  axom::sidre::Buffer* SHCXX_buff = static_cast<axom::sidre::Buffer*>(buff->addr);
-  axom::sidre::View* SHCXX_rv = SH_this->createView(SHCXX_path, SHCXX_buff);
+  axom::sidre::Buffer *SHCXX_buff =
+    static_cast<axom::sidre::Buffer *>(buff->addr);
+  axom::sidre::View *SHCXX_rv = SH_this->createView(SHCXX_path, SHCXX_buff);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -511,36 +512,38 @@ SIDRE_View* SIDRE_Group_create_view_into_buffer(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_into_buffer
 }
 
-SIDRE_View* SIDRE_Group_create_view_into_buffer_bufferify(SIDRE_Group* self,
-                                                          const char* path,
+SIDRE_View *SIDRE_Group_create_view_into_buffer_bufferify(SIDRE_Group *self,
+                                                          const char *path,
                                                           int Lpath,
-                                                          SIDRE_Buffer* buff,
-                                                          SIDRE_View* SHC_rv)
+                                                          SIDRE_Buffer *buff,
+                                                          SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_into_buffer_bufferify
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::Buffer* SHCXX_buff = static_cast<axom::sidre::Buffer*>(buff->addr);
-  axom::sidre::View* SHCXX_rv = SH_this->createView(SHCXX_path, SHCXX_buff);
+  axom::sidre::Buffer *SHCXX_buff =
+    static_cast<axom::sidre::Buffer *>(buff->addr);
+  axom::sidre::View *SHCXX_rv = SH_this->createView(SHCXX_path, SHCXX_buff);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.Group.method.create_view_into_buffer_bufferify
 }
 
-SIDRE_View* SIDRE_Group_create_view_from_type_and_buffer(SIDRE_Group* self,
-                                                         const char* path,
+SIDRE_View *SIDRE_Group_create_view_from_type_and_buffer(SIDRE_Group *self,
+                                                         const char *path,
                                                          int type,
                                                          SIDRE_IndexType num_elems,
-                                                         SIDRE_Buffer* buff,
-                                                         SIDRE_View* SHC_rv)
+                                                         SIDRE_Buffer *buff,
+                                                         SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_type_and_buffer
   const std::string SHCXX_path(path);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::Buffer* SHCXX_buff = static_cast<axom::sidre::Buffer*>(buff->addr);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::Buffer *SHCXX_buff =
+    static_cast<axom::sidre::Buffer *>(buff->addr);
+  axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, num_elems, SHCXX_buff);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
@@ -556,21 +559,22 @@ SIDRE_View* SIDRE_Group_create_view_from_type_and_buffer(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_from_type_and_buffer
 }
 
-SIDRE_View* SIDRE_Group_create_view_from_type_and_buffer_bufferify(
-  SIDRE_Group* self,
-  const char* path,
+SIDRE_View *SIDRE_Group_create_view_from_type_and_buffer_bufferify(
+  SIDRE_Group *self,
+  const char *path,
   int Lpath,
   int type,
   SIDRE_IndexType num_elems,
-  SIDRE_Buffer* buff,
-  SIDRE_View* SHC_rv)
+  SIDRE_Buffer *buff,
+  SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_type_and_buffer_bufferify
   const std::string SHCXX_path(path, Lpath);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::Buffer* SHCXX_buff = static_cast<axom::sidre::Buffer*>(buff->addr);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::Buffer *SHCXX_buff =
+    static_cast<axom::sidre::Buffer *>(buff->addr);
+  axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, num_elems, SHCXX_buff);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
@@ -578,20 +582,21 @@ SIDRE_View* SIDRE_Group_create_view_from_type_and_buffer_bufferify(
   // splicer end class.Group.method.create_view_from_type_and_buffer_bufferify
 }
 
-SIDRE_View* SIDRE_Group_create_view_from_shape_and_buffer(SIDRE_Group* self,
-                                                          const char* path,
+SIDRE_View *SIDRE_Group_create_view_from_shape_and_buffer(SIDRE_Group *self,
+                                                          const char *path,
                                                           int type,
                                                           int ndims,
-                                                          const SIDRE_IndexType* shape,
-                                                          SIDRE_Buffer* buff,
-                                                          SIDRE_View* SHC_rv)
+                                                          const SIDRE_IndexType *shape,
+                                                          SIDRE_Buffer *buff,
+                                                          SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_shape_and_buffer
   const std::string SHCXX_path(path);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::Buffer* SHCXX_buff = static_cast<axom::sidre::Buffer*>(buff->addr);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::Buffer *SHCXX_buff =
+    static_cast<axom::sidre::Buffer *>(buff->addr);
+  axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, ndims, shape, SHCXX_buff);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
@@ -607,23 +612,23 @@ SIDRE_View* SIDRE_Group_create_view_from_shape_and_buffer(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_from_shape_and_buffer
 }
 
-SIDRE_View* SIDRE_Group_create_view_from_shape_and_buffer_bufferify(
-  SIDRE_Group* self,
-  const char* path,
+SIDRE_View *SIDRE_Group_create_view_from_shape_and_buffer_bufferify(
+  SIDRE_Group *self,
+  const char *path,
   int Lpath,
   int type,
   int ndims,
-  const SIDRE_IndexType* shape,
-  SIDRE_Buffer* buff,
-  SIDRE_View* SHC_rv)
+  const SIDRE_IndexType *shape,
+  SIDRE_Buffer *buff,
+  SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
-  // splicer begin
-  // class.Group.method.create_view_from_shape_and_buffer_bufferify
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
+  // splicer begin class.Group.method.create_view_from_shape_and_buffer_bufferify
   const std::string SHCXX_path(path, Lpath);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::Buffer* SHCXX_buff = static_cast<axom::sidre::Buffer*>(buff->addr);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::Buffer *SHCXX_buff =
+    static_cast<axom::sidre::Buffer *>(buff->addr);
+  axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, ndims, shape, SHCXX_buff);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
@@ -631,15 +636,15 @@ SIDRE_View* SIDRE_Group_create_view_from_shape_and_buffer_bufferify(
   // splicer end class.Group.method.create_view_from_shape_and_buffer_bufferify
 }
 
-SIDRE_View* SIDRE_Group_create_view_external(SIDRE_Group* self,
-                                             const char* path,
-                                             void* external_ptr,
-                                             SIDRE_View* SHC_rv)
+SIDRE_View *SIDRE_Group_create_view_external(SIDRE_Group *self,
+                                             const char *path,
+                                             void *external_ptr,
+                                             SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_external
   const std::string SHCXX_path(path);
-  axom::sidre::View* SHCXX_rv = SH_this->createView(SHCXX_path, external_ptr);
+  axom::sidre::View *SHCXX_rv = SH_this->createView(SHCXX_path, external_ptr);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -654,34 +659,34 @@ SIDRE_View* SIDRE_Group_create_view_external(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_external
 }
 
-SIDRE_View* SIDRE_Group_create_view_external_bufferify(SIDRE_Group* self,
-                                                       const char* path,
+SIDRE_View *SIDRE_Group_create_view_external_bufferify(SIDRE_Group *self,
+                                                       const char *path,
                                                        int Lpath,
-                                                       void* external_ptr,
-                                                       SIDRE_View* SHC_rv)
+                                                       void *external_ptr,
+                                                       SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_external_bufferify
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::View* SHCXX_rv = SH_this->createView(SHCXX_path, external_ptr);
+  axom::sidre::View *SHCXX_rv = SH_this->createView(SHCXX_path, external_ptr);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.Group.method.create_view_external_bufferify
 }
 
-SIDRE_View* SIDRE_Group_create_view_from_type_external(SIDRE_Group* self,
-                                                       const char* path,
+SIDRE_View *SIDRE_Group_create_view_from_type_external(SIDRE_Group *self,
+                                                       const char *path,
                                                        int type,
                                                        SIDRE_IndexType num_elems,
-                                                       void* external_ptr,
-                                                       SIDRE_View* SHC_rv)
+                                                       void *external_ptr,
+                                                       SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_type_external
   const std::string SHCXX_path(path);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, num_elems, external_ptr);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
@@ -697,20 +702,20 @@ SIDRE_View* SIDRE_Group_create_view_from_type_external(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_from_type_external
 }
 
-SIDRE_View* SIDRE_Group_create_view_from_type_external_bufferify(
-  SIDRE_Group* self,
-  const char* path,
+SIDRE_View *SIDRE_Group_create_view_from_type_external_bufferify(
+  SIDRE_Group *self,
+  const char *path,
   int Lpath,
   int type,
   SIDRE_IndexType num_elems,
-  void* external_ptr,
-  SIDRE_View* SHC_rv)
+  void *external_ptr,
+  SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_type_external_bufferify
   const std::string SHCXX_path(path, Lpath);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, num_elems, external_ptr);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
@@ -718,19 +723,19 @@ SIDRE_View* SIDRE_Group_create_view_from_type_external_bufferify(
   // splicer end class.Group.method.create_view_from_type_external_bufferify
 }
 
-SIDRE_View* SIDRE_Group_create_view_from_shape_external(SIDRE_Group* self,
-                                                        const char* path,
+SIDRE_View *SIDRE_Group_create_view_from_shape_external(SIDRE_Group *self,
+                                                        const char *path,
                                                         int type,
                                                         int ndims,
-                                                        const SIDRE_IndexType* shape,
-                                                        void* external_ptr,
-                                                        SIDRE_View* SHC_rv)
+                                                        const SIDRE_IndexType *shape,
+                                                        void *external_ptr,
+                                                        SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_shape_external
   const std::string SHCXX_path(path);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, ndims, shape, external_ptr);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
@@ -746,21 +751,21 @@ SIDRE_View* SIDRE_Group_create_view_from_shape_external(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_from_shape_external
 }
 
-SIDRE_View* SIDRE_Group_create_view_from_shape_external_bufferify(
-  SIDRE_Group* self,
-  const char* path,
+SIDRE_View *SIDRE_Group_create_view_from_shape_external_bufferify(
+  SIDRE_Group *self,
+  const char *path,
   int Lpath,
   int type,
   int ndims,
-  const SIDRE_IndexType* shape,
-  void* external_ptr,
-  SIDRE_View* SHC_rv)
+  const SIDRE_IndexType *shape,
+  void *external_ptr,
+  SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_shape_external_bufferify
   const std::string SHCXX_path(path, Lpath);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, ndims, shape, external_ptr);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
@@ -768,17 +773,17 @@ SIDRE_View* SIDRE_Group_create_view_from_shape_external_bufferify(
   // splicer end class.Group.method.create_view_from_shape_external_bufferify
 }
 
-SIDRE_View* SIDRE_Group_create_view_and_allocate_nelems(SIDRE_Group* self,
-                                                        const char* path,
+SIDRE_View *SIDRE_Group_create_view_and_allocate_nelems(SIDRE_Group *self,
+                                                        const char *path,
                                                         int type,
                                                         SIDRE_IndexType num_elems,
-                                                        SIDRE_View* SHC_rv)
+                                                        SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_and_allocate_nelems
   const std::string SHCXX_path(path);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createViewAndAllocate(SHCXX_path, SHCXX_type, num_elems);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
@@ -794,19 +799,19 @@ SIDRE_View* SIDRE_Group_create_view_and_allocate_nelems(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_and_allocate_nelems
 }
 
-SIDRE_View* SIDRE_Group_create_view_and_allocate_nelems_bufferify(
-  SIDRE_Group* self,
-  const char* path,
+SIDRE_View *SIDRE_Group_create_view_and_allocate_nelems_bufferify(
+  SIDRE_Group *self,
+  const char *path,
   int Lpath,
   int type,
   SIDRE_IndexType num_elems,
-  SIDRE_View* SHC_rv)
+  SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_and_allocate_nelems_bufferify
   const std::string SHCXX_path(path, Lpath);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createViewAndAllocate(SHCXX_path, SHCXX_type, num_elems);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
@@ -814,18 +819,18 @@ SIDRE_View* SIDRE_Group_create_view_and_allocate_nelems_bufferify(
   // splicer end class.Group.method.create_view_and_allocate_nelems_bufferify
 }
 
-SIDRE_View* SIDRE_Group_create_view_and_allocate_shape(SIDRE_Group* self,
-                                                       const char* path,
+SIDRE_View *SIDRE_Group_create_view_and_allocate_shape(SIDRE_Group *self,
+                                                       const char *path,
                                                        int type,
                                                        int ndims,
-                                                       const SIDRE_IndexType* shape,
-                                                       SIDRE_View* SHC_rv)
+                                                       const SIDRE_IndexType *shape,
+                                                       SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_and_allocate_shape
   const std::string SHCXX_path(path);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createViewAndAllocate(SHCXX_path, SHCXX_type, ndims, shape);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
@@ -841,20 +846,20 @@ SIDRE_View* SIDRE_Group_create_view_and_allocate_shape(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_and_allocate_shape
 }
 
-SIDRE_View* SIDRE_Group_create_view_and_allocate_shape_bufferify(
-  SIDRE_Group* self,
-  const char* path,
+SIDRE_View *SIDRE_Group_create_view_and_allocate_shape_bufferify(
+  SIDRE_Group *self,
+  const char *path,
   int Lpath,
   int type,
   int ndims,
-  const SIDRE_IndexType* shape,
-  SIDRE_View* SHC_rv)
+  const SIDRE_IndexType *shape,
+  SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_and_allocate_shape_bufferify
   const std::string SHCXX_path(path, Lpath);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createViewAndAllocate(SHCXX_path, SHCXX_type, ndims, shape);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
@@ -862,15 +867,15 @@ SIDRE_View* SIDRE_Group_create_view_and_allocate_shape_bufferify(
   // splicer end class.Group.method.create_view_and_allocate_shape_bufferify
 }
 
-SIDRE_View* SIDRE_Group_create_view_scalar_int(SIDRE_Group* self,
-                                               const char* path,
+SIDRE_View *SIDRE_Group_create_view_scalar_int(SIDRE_Group *self,
+                                               const char *path,
                                                int value,
-                                               SIDRE_View* SHC_rv)
+                                               SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_scalar_int
   const std::string SHCXX_path(path);
-  axom::sidre::View* SHCXX_rv = SH_this->createViewScalar<int>(SHCXX_path, value);
+  axom::sidre::View *SHCXX_rv = SH_this->createViewScalar<int>(SHCXX_path, value);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -885,31 +890,31 @@ SIDRE_View* SIDRE_Group_create_view_scalar_int(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_scalar_int
 }
 
-SIDRE_View* SIDRE_Group_create_view_scalar_bufferify_int(SIDRE_Group* self,
-                                                         const char* path,
+SIDRE_View *SIDRE_Group_create_view_scalar_bufferify_int(SIDRE_Group *self,
+                                                         const char *path,
                                                          int Lpath,
                                                          int value,
-                                                         SIDRE_View* SHC_rv)
+                                                         SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_scalar_bufferify_int
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::View* SHCXX_rv = SH_this->createViewScalar<int>(SHCXX_path, value);
+  axom::sidre::View *SHCXX_rv = SH_this->createViewScalar<int>(SHCXX_path, value);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.Group.method.create_view_scalar_bufferify_int
 }
 
-SIDRE_View* SIDRE_Group_create_view_scalar_long(SIDRE_Group* self,
-                                                const char* path,
+SIDRE_View *SIDRE_Group_create_view_scalar_long(SIDRE_Group *self,
+                                                const char *path,
                                                 long value,
-                                                SIDRE_View* SHC_rv)
+                                                SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_scalar_long
   const std::string SHCXX_path(path);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createViewScalar<long>(SHCXX_path, value);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
@@ -925,16 +930,16 @@ SIDRE_View* SIDRE_Group_create_view_scalar_long(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_scalar_long
 }
 
-SIDRE_View* SIDRE_Group_create_view_scalar_bufferify_long(SIDRE_Group* self,
-                                                          const char* path,
+SIDRE_View *SIDRE_Group_create_view_scalar_bufferify_long(SIDRE_Group *self,
+                                                          const char *path,
                                                           int Lpath,
                                                           long value,
-                                                          SIDRE_View* SHC_rv)
+                                                          SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_scalar_bufferify_long
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createViewScalar<long>(SHCXX_path, value);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
@@ -942,15 +947,15 @@ SIDRE_View* SIDRE_Group_create_view_scalar_bufferify_long(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_scalar_bufferify_long
 }
 
-SIDRE_View* SIDRE_Group_create_view_scalar_float(SIDRE_Group* self,
-                                                 const char* path,
+SIDRE_View *SIDRE_Group_create_view_scalar_float(SIDRE_Group *self,
+                                                 const char *path,
                                                  float value,
-                                                 SIDRE_View* SHC_rv)
+                                                 SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_scalar_float
   const std::string SHCXX_path(path);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createViewScalar<float>(SHCXX_path, value);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
@@ -966,16 +971,16 @@ SIDRE_View* SIDRE_Group_create_view_scalar_float(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_scalar_float
 }
 
-SIDRE_View* SIDRE_Group_create_view_scalar_bufferify_float(SIDRE_Group* self,
-                                                           const char* path,
+SIDRE_View *SIDRE_Group_create_view_scalar_bufferify_float(SIDRE_Group *self,
+                                                           const char *path,
                                                            int Lpath,
                                                            float value,
-                                                           SIDRE_View* SHC_rv)
+                                                           SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_scalar_bufferify_float
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createViewScalar<float>(SHCXX_path, value);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
@@ -983,15 +988,15 @@ SIDRE_View* SIDRE_Group_create_view_scalar_bufferify_float(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_scalar_bufferify_float
 }
 
-SIDRE_View* SIDRE_Group_create_view_scalar_double(SIDRE_Group* self,
-                                                  const char* path,
+SIDRE_View *SIDRE_Group_create_view_scalar_double(SIDRE_Group *self,
+                                                  const char *path,
                                                   double value,
-                                                  SIDRE_View* SHC_rv)
+                                                  SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_scalar_double
   const std::string SHCXX_path(path);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createViewScalar<double>(SHCXX_path, value);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
@@ -1007,16 +1012,16 @@ SIDRE_View* SIDRE_Group_create_view_scalar_double(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_scalar_double
 }
 
-SIDRE_View* SIDRE_Group_create_view_scalar_bufferify_double(SIDRE_Group* self,
-                                                            const char* path,
+SIDRE_View *SIDRE_Group_create_view_scalar_bufferify_double(SIDRE_Group *self,
+                                                            const char *path,
                                                             int Lpath,
                                                             double value,
-                                                            SIDRE_View* SHC_rv)
+                                                            SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_scalar_bufferify_double
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createViewScalar<double>(SHCXX_path, value);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
@@ -1024,16 +1029,16 @@ SIDRE_View* SIDRE_Group_create_view_scalar_bufferify_double(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_scalar_bufferify_double
 }
 
-SIDRE_View* SIDRE_Group_create_view_string(SIDRE_Group* self,
-                                           const char* path,
-                                           const char* value,
-                                           SIDRE_View* SHC_rv)
+SIDRE_View *SIDRE_Group_create_view_string(SIDRE_Group *self,
+                                           const char *path,
+                                           const char *value,
+                                           SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_string
   const std::string SHCXX_path(path);
   const std::string SHCXX_value(value);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createViewString(SHCXX_path, SHCXX_value);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
@@ -1049,18 +1054,18 @@ SIDRE_View* SIDRE_Group_create_view_string(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_string
 }
 
-SIDRE_View* SIDRE_Group_create_view_string_bufferify(SIDRE_Group* self,
-                                                     const char* path,
+SIDRE_View *SIDRE_Group_create_view_string_bufferify(SIDRE_Group *self,
+                                                     const char *path,
                                                      int Lpath,
-                                                     const char* value,
+                                                     const char *value,
                                                      int Lvalue,
-                                                     SIDRE_View* SHC_rv)
+                                                     SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_string_bufferify
   const std::string SHCXX_path(path, Lpath);
   const std::string SHCXX_value(value, Lvalue);
-  axom::sidre::View* SHCXX_rv =
+  axom::sidre::View *SHCXX_rv =
     SH_this->createViewString(SHCXX_path, SHCXX_value);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
@@ -1068,86 +1073,86 @@ SIDRE_View* SIDRE_Group_create_view_string_bufferify(SIDRE_Group* self,
   // splicer end class.Group.method.create_view_string_bufferify
 }
 
-void SIDRE_Group_destroy_view(SIDRE_Group* self, const char* path)
+void SIDRE_Group_destroy_view(SIDRE_Group *self, const char *path)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.destroy_view
   const std::string SHCXX_path(path);
   SH_this->destroyView(SHCXX_path);
   // splicer end class.Group.method.destroy_view
 }
 
-void SIDRE_Group_destroy_view_bufferify(SIDRE_Group* self,
-                                        const char* path,
+void SIDRE_Group_destroy_view_bufferify(SIDRE_Group *self,
+                                        const char *path,
                                         int Lpath)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.destroy_view_bufferify
   const std::string SHCXX_path(path, Lpath);
   SH_this->destroyView(SHCXX_path);
   // splicer end class.Group.method.destroy_view_bufferify
 }
 
-void SIDRE_Group_destroy_view_and_data_name(SIDRE_Group* self, const char* path)
+void SIDRE_Group_destroy_view_and_data_name(SIDRE_Group *self, const char *path)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.destroy_view_and_data_name
   const std::string SHCXX_path(path);
   SH_this->destroyViewAndData(SHCXX_path);
   // splicer end class.Group.method.destroy_view_and_data_name
 }
 
-void SIDRE_Group_destroy_view_and_data_name_bufferify(SIDRE_Group* self,
-                                                      const char* path,
+void SIDRE_Group_destroy_view_and_data_name_bufferify(SIDRE_Group *self,
+                                                      const char *path,
                                                       int Lpath)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.destroy_view_and_data_name_bufferify
   const std::string SHCXX_path(path, Lpath);
   SH_this->destroyViewAndData(SHCXX_path);
   // splicer end class.Group.method.destroy_view_and_data_name_bufferify
 }
 
-void SIDRE_Group_destroy_view_and_data_index(SIDRE_Group* self,
+void SIDRE_Group_destroy_view_and_data_index(SIDRE_Group *self,
                                              SIDRE_IndexType idx)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.destroy_view_and_data_index
   SH_this->destroyViewAndData(idx);
   // splicer end class.Group.method.destroy_view_and_data_index
 }
 
-SIDRE_View* SIDRE_Group_move_view(SIDRE_Group* self,
-                                  SIDRE_View* view,
-                                  SIDRE_View* SHC_rv)
+SIDRE_View *SIDRE_Group_move_view(SIDRE_Group *self,
+                                  SIDRE_View *view,
+                                  SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.move_view
-  axom::sidre::View* SHCXX_view = static_cast<axom::sidre::View*>(view->addr);
-  axom::sidre::View* SHCXX_rv = SH_this->moveView(SHCXX_view);
+  axom::sidre::View *SHCXX_view = static_cast<axom::sidre::View *>(view->addr);
+  axom::sidre::View *SHCXX_rv = SH_this->moveView(SHCXX_view);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.Group.method.move_view
 }
 
-SIDRE_View* SIDRE_Group_copy_view(SIDRE_Group* self,
-                                  SIDRE_View* view,
-                                  SIDRE_View* SHC_rv)
+SIDRE_View *SIDRE_Group_copy_view(SIDRE_Group *self,
+                                  SIDRE_View *view,
+                                  SIDRE_View *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.copy_view
-  axom::sidre::View* SHCXX_view = static_cast<axom::sidre::View*>(view->addr);
-  axom::sidre::View* SHCXX_rv = SH_this->copyView(SHCXX_view);
+  axom::sidre::View *SHCXX_view = static_cast<axom::sidre::View *>(view->addr);
+  axom::sidre::View *SHCXX_rv = SH_this->copyView(SHCXX_view);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.Group.method.copy_view
 }
 
-bool SIDRE_Group_has_group(SIDRE_Group* self, const char* path)
+bool SIDRE_Group_has_group(SIDRE_Group *self, const char *path)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.has_group
   const std::string SHCXX_path(path);
   bool SHC_rv = SH_this->hasGroup(SHCXX_path);
@@ -1155,9 +1160,9 @@ bool SIDRE_Group_has_group(SIDRE_Group* self, const char* path)
   // splicer end class.Group.method.has_group
 }
 
-bool SIDRE_Group_has_group_bufferify(SIDRE_Group* self, const char* path, int Lpath)
+bool SIDRE_Group_has_group_bufferify(SIDRE_Group *self, const char *path, int Lpath)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.has_group_bufferify
   const std::string SHCXX_path(path, Lpath);
   bool SHC_rv = SH_this->hasGroup(SHCXX_path);
@@ -1165,9 +1170,9 @@ bool SIDRE_Group_has_group_bufferify(SIDRE_Group* self, const char* path, int Lp
   // splicer end class.Group.method.has_group_bufferify
 }
 
-bool SIDRE_Group_has_child_group(SIDRE_Group* self, const char* name)
+bool SIDRE_Group_has_child_group(SIDRE_Group *self, const char *name)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.has_child_group
   const std::string SHCXX_name(name);
   bool SHC_rv = SH_this->hasChildGroup(SHCXX_name);
@@ -1175,11 +1180,11 @@ bool SIDRE_Group_has_child_group(SIDRE_Group* self, const char* name)
   // splicer end class.Group.method.has_child_group
 }
 
-bool SIDRE_Group_has_child_group_bufferify(SIDRE_Group* self,
-                                           const char* name,
+bool SIDRE_Group_has_child_group_bufferify(SIDRE_Group *self,
+                                           const char *name,
                                            int Lname)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.has_child_group_bufferify
   const std::string SHCXX_name(name, Lname);
   bool SHC_rv = SH_this->hasChildGroup(SHCXX_name);
@@ -1187,11 +1192,11 @@ bool SIDRE_Group_has_child_group_bufferify(SIDRE_Group* self,
   // splicer end class.Group.method.has_child_group_bufferify
 }
 
-SIDRE_IndexType SIDRE_Group_get_group_index(const SIDRE_Group* self,
-                                            const char* name)
+SIDRE_IndexType SIDRE_Group_get_group_index(const SIDRE_Group *self,
+                                            const char *name)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_group_index
   const std::string SHCXX_name(name);
   axom::sidre::IndexType SHC_rv = SH_this->getGroupIndex(SHCXX_name);
@@ -1199,12 +1204,12 @@ SIDRE_IndexType SIDRE_Group_get_group_index(const SIDRE_Group* self,
   // splicer end class.Group.method.get_group_index
 }
 
-SIDRE_IndexType SIDRE_Group_get_group_index_bufferify(const SIDRE_Group* self,
-                                                      const char* name,
+SIDRE_IndexType SIDRE_Group_get_group_index_bufferify(const SIDRE_Group *self,
+                                                      const char *name,
                                                       int Lname)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_group_index_bufferify
   const std::string SHCXX_name(name, Lname);
   axom::sidre::IndexType SHC_rv = SH_this->getGroupIndex(SHCXX_name);
@@ -1212,33 +1217,33 @@ SIDRE_IndexType SIDRE_Group_get_group_index_bufferify(const SIDRE_Group* self,
   // splicer end class.Group.method.get_group_index_bufferify
 }
 
-const char* SIDRE_Group_get_group_name(const SIDRE_Group* self,
+const char *SIDRE_Group_get_group_name(const SIDRE_Group *self,
                                        SIDRE_IndexType idx)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_group_name
-  const std::string& SHCXX_rv = SH_this->getGroupName(idx);
+  const std::string &SHCXX_rv = SH_this->getGroupName(idx);
   // C_error_pattern
   if(!axom::sidre::nameIsValid(SHCXX_rv))
   {
     return SIDRE_InvalidName;
   }
 
-  const char* SHC_rv = SHCXX_rv.c_str();
+  const char *SHC_rv = SHCXX_rv.c_str();
   return SHC_rv;
   // splicer end class.Group.method.get_group_name
 }
 
-void SIDRE_Group_get_group_name_bufferify(const SIDRE_Group* self,
+void SIDRE_Group_get_group_name_bufferify(const SIDRE_Group *self,
                                           SIDRE_IndexType idx,
-                                          char* SHF_rv,
+                                          char *SHF_rv,
                                           int NSHF_rv)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_group_name_bufferify
-  const std::string& SHCXX_rv = SH_this->getGroupName(idx);
+  const std::string &SHCXX_rv = SH_this->getGroupName(idx);
   // C_error_pattern
   if(!axom::sidre::nameIsValid(SHCXX_rv))
   {
@@ -1257,14 +1262,14 @@ void SIDRE_Group_get_group_name_bufferify(const SIDRE_Group* self,
   // splicer end class.Group.method.get_group_name_bufferify
 }
 
-SIDRE_Group* SIDRE_Group_get_group_from_name(SIDRE_Group* self,
-                                             const char* path,
-                                             SIDRE_Group* SHC_rv)
+SIDRE_Group *SIDRE_Group_get_group_from_name(SIDRE_Group *self,
+                                             const char *path,
+                                             SIDRE_Group *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_group_from_name
   const std::string SHCXX_path(path);
-  axom::sidre::Group* SHCXX_rv = SH_this->getGroup(SHCXX_path);
+  axom::sidre::Group *SHCXX_rv = SH_this->getGroup(SHCXX_path);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -1279,28 +1284,28 @@ SIDRE_Group* SIDRE_Group_get_group_from_name(SIDRE_Group* self,
   // splicer end class.Group.method.get_group_from_name
 }
 
-SIDRE_Group* SIDRE_Group_get_group_from_name_bufferify(SIDRE_Group* self,
-                                                       const char* path,
+SIDRE_Group *SIDRE_Group_get_group_from_name_bufferify(SIDRE_Group *self,
+                                                       const char *path,
                                                        int Lpath,
-                                                       SIDRE_Group* SHC_rv)
+                                                       SIDRE_Group *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_group_from_name_bufferify
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::Group* SHCXX_rv = SH_this->getGroup(SHCXX_path);
+  axom::sidre::Group *SHCXX_rv = SH_this->getGroup(SHCXX_path);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.Group.method.get_group_from_name_bufferify
 }
 
-SIDRE_Group* SIDRE_Group_get_group_from_index(SIDRE_Group* self,
+SIDRE_Group *SIDRE_Group_get_group_from_index(SIDRE_Group *self,
                                               SIDRE_IndexType idx,
-                                              SIDRE_Group* SHC_rv)
+                                              SIDRE_Group *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_group_from_index
-  axom::sidre::Group* SHCXX_rv = SH_this->getGroup(idx);
+  axom::sidre::Group *SHCXX_rv = SH_this->getGroup(idx);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -1315,35 +1320,35 @@ SIDRE_Group* SIDRE_Group_get_group_from_index(SIDRE_Group* self,
   // splicer end class.Group.method.get_group_from_index
 }
 
-SIDRE_IndexType SIDRE_Group_get_first_valid_group_index(const SIDRE_Group* self)
+SIDRE_IndexType SIDRE_Group_get_first_valid_group_index(const SIDRE_Group *self)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_first_valid_group_index
   axom::sidre::IndexType SHC_rv = SH_this->getFirstValidGroupIndex();
   return SHC_rv;
   // splicer end class.Group.method.get_first_valid_group_index
 }
 
-SIDRE_IndexType SIDRE_Group_get_next_valid_group_index(const SIDRE_Group* self,
+SIDRE_IndexType SIDRE_Group_get_next_valid_group_index(const SIDRE_Group *self,
                                                        SIDRE_IndexType idx)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.get_next_valid_group_index
   axom::sidre::IndexType SHC_rv = SH_this->getNextValidGroupIndex(idx);
   return SHC_rv;
   // splicer end class.Group.method.get_next_valid_group_index
 }
 
-SIDRE_Group* SIDRE_Group_create_group(SIDRE_Group* self,
-                                      const char* path,
-                                      SIDRE_Group* SHC_rv)
+SIDRE_Group *SIDRE_Group_create_group(SIDRE_Group *self,
+                                      const char *path,
+                                      SIDRE_Group *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_group
   const std::string SHCXX_path(path);
-  axom::sidre::Group* SHCXX_rv = SH_this->createGroup(SHCXX_path);
+  axom::sidre::Group *SHCXX_rv = SH_this->createGroup(SHCXX_path);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -1358,90 +1363,90 @@ SIDRE_Group* SIDRE_Group_create_group(SIDRE_Group* self,
   // splicer end class.Group.method.create_group
 }
 
-SIDRE_Group* SIDRE_Group_create_group_bufferify(SIDRE_Group* self,
-                                                const char* path,
+SIDRE_Group *SIDRE_Group_create_group_bufferify(SIDRE_Group *self,
+                                                const char *path,
                                                 int Lpath,
-                                                SIDRE_Group* SHC_rv)
+                                                SIDRE_Group *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_group_bufferify
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::Group* SHCXX_rv = SH_this->createGroup(SHCXX_path);
+  axom::sidre::Group *SHCXX_rv = SH_this->createGroup(SHCXX_path);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.Group.method.create_group_bufferify
 }
 
-void SIDRE_Group_destroy_group_name(SIDRE_Group* self, const char* path)
+void SIDRE_Group_destroy_group_name(SIDRE_Group *self, const char *path)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.destroy_group_name
   const std::string SHCXX_path(path);
   SH_this->destroyGroup(SHCXX_path);
   // splicer end class.Group.method.destroy_group_name
 }
 
-void SIDRE_Group_destroy_group_name_bufferify(SIDRE_Group* self,
-                                              const char* path,
+void SIDRE_Group_destroy_group_name_bufferify(SIDRE_Group *self,
+                                              const char *path,
                                               int Lpath)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.destroy_group_name_bufferify
   const std::string SHCXX_path(path, Lpath);
   SH_this->destroyGroup(SHCXX_path);
   // splicer end class.Group.method.destroy_group_name_bufferify
 }
 
-void SIDRE_Group_destroy_group_index(SIDRE_Group* self, SIDRE_IndexType idx)
+void SIDRE_Group_destroy_group_index(SIDRE_Group *self, SIDRE_IndexType idx)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.destroy_group_index
   SH_this->destroyGroup(idx);
   // splicer end class.Group.method.destroy_group_index
 }
 
-SIDRE_Group* SIDRE_Group_move_group(SIDRE_Group* self,
-                                    SIDRE_Group* grp,
-                                    SIDRE_Group* SHC_rv)
+SIDRE_Group *SIDRE_Group_move_group(SIDRE_Group *self,
+                                    SIDRE_Group *grp,
+                                    SIDRE_Group *SHC_rv)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.move_group
-  axom::sidre::Group* SHCXX_grp = static_cast<axom::sidre::Group*>(grp->addr);
-  axom::sidre::Group* SHCXX_rv = SH_this->moveGroup(SHCXX_grp);
+  axom::sidre::Group *SHCXX_grp = static_cast<axom::sidre::Group *>(grp->addr);
+  axom::sidre::Group *SHCXX_rv = SH_this->moveGroup(SHCXX_grp);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.Group.method.move_group
 }
 
-void SIDRE_Group_print(const SIDRE_Group* self)
+void SIDRE_Group_print(const SIDRE_Group *self)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.print
   SH_this->print();
   // splicer end class.Group.method.print
 }
 
-bool SIDRE_Group_is_equivalent_to(const SIDRE_Group* self, SIDRE_Group* other)
+bool SIDRE_Group_is_equivalent_to(const SIDRE_Group *self, SIDRE_Group *other)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.is_equivalent_to
-  const axom::sidre::Group* SHCXX_other =
-    static_cast<const axom::sidre::Group*>(other->addr);
+  const axom::sidre::Group *SHCXX_other =
+    static_cast<const axom::sidre::Group *>(other->addr);
   bool SHC_rv = SH_this->isEquivalentTo(SHCXX_other);
   return SHC_rv;
   // splicer end class.Group.method.is_equivalent_to
 }
 
-void SIDRE_Group_save(const SIDRE_Group* self,
-                      const char* file_path,
-                      const char* protocol)
+void SIDRE_Group_save(const SIDRE_Group *self,
+                      const char *file_path,
+                      const char *protocol)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.save
   const std::string SHCXX_file_path(file_path);
   const std::string SHCXX_protocol(protocol);
@@ -1449,14 +1454,14 @@ void SIDRE_Group_save(const SIDRE_Group* self,
   // splicer end class.Group.method.save
 }
 
-void SIDRE_Group_save_bufferify(const SIDRE_Group* self,
-                                const char* file_path,
+void SIDRE_Group_save_bufferify(const SIDRE_Group *self,
+                                const char *file_path,
                                 int Lfile_path,
-                                const char* protocol,
+                                const char *protocol,
                                 int Lprotocol)
 {
-  const axom::sidre::Group* SH_this =
-    static_cast<const axom::sidre::Group*>(self->addr);
+  const axom::sidre::Group *SH_this =
+    static_cast<const axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.save_bufferify
   const std::string SHCXX_file_path(file_path, Lfile_path);
   const std::string SHCXX_protocol(protocol, Lprotocol);
@@ -1464,11 +1469,11 @@ void SIDRE_Group_save_bufferify(const SIDRE_Group* self,
   // splicer end class.Group.method.save_bufferify
 }
 
-void SIDRE_Group_load_0(SIDRE_Group* self,
-                        const char* file_path,
-                        const char* protocol)
+void SIDRE_Group_load_0(SIDRE_Group *self,
+                        const char *file_path,
+                        const char *protocol)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.load_0
   const std::string SHCXX_file_path(file_path);
   const std::string SHCXX_protocol(protocol);
@@ -1476,13 +1481,13 @@ void SIDRE_Group_load_0(SIDRE_Group* self,
   // splicer end class.Group.method.load_0
 }
 
-void SIDRE_Group_load_0_bufferify(SIDRE_Group* self,
-                                  const char* file_path,
+void SIDRE_Group_load_0_bufferify(SIDRE_Group *self,
+                                  const char *file_path,
                                   int Lfile_path,
-                                  const char* protocol,
+                                  const char *protocol,
                                   int Lprotocol)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.load_0_bufferify
   const std::string SHCXX_file_path(file_path, Lfile_path);
   const std::string SHCXX_protocol(protocol, Lprotocol);
@@ -1490,12 +1495,12 @@ void SIDRE_Group_load_0_bufferify(SIDRE_Group* self,
   // splicer end class.Group.method.load_0_bufferify
 }
 
-void SIDRE_Group_load_1(SIDRE_Group* self,
-                        const char* file_path,
-                        const char* protocol,
+void SIDRE_Group_load_1(SIDRE_Group *self,
+                        const char *file_path,
+                        const char *protocol,
                         bool preserve_contents)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.load_1
   const std::string SHCXX_file_path(file_path);
   const std::string SHCXX_protocol(protocol);
@@ -1503,14 +1508,14 @@ void SIDRE_Group_load_1(SIDRE_Group* self,
   // splicer end class.Group.method.load_1
 }
 
-void SIDRE_Group_load_1_bufferify(SIDRE_Group* self,
-                                  const char* file_path,
+void SIDRE_Group_load_1_bufferify(SIDRE_Group *self,
+                                  const char *file_path,
                                   int Lfile_path,
-                                  const char* protocol,
+                                  const char *protocol,
                                   int Lprotocol,
                                   bool preserve_contents)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.load_1_bufferify
   const std::string SHCXX_file_path(file_path, Lfile_path);
   const std::string SHCXX_protocol(protocol, Lprotocol);
@@ -1518,29 +1523,29 @@ void SIDRE_Group_load_1_bufferify(SIDRE_Group* self,
   // splicer end class.Group.method.load_1_bufferify
 }
 
-void SIDRE_Group_load_external_data(SIDRE_Group* self, const char* file_path)
+void SIDRE_Group_load_external_data(SIDRE_Group *self, const char *file_path)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.load_external_data
   const std::string SHCXX_file_path(file_path);
   SH_this->loadExternalData(SHCXX_file_path);
   // splicer end class.Group.method.load_external_data
 }
 
-void SIDRE_Group_load_external_data_bufferify(SIDRE_Group* self,
-                                              const char* file_path,
+void SIDRE_Group_load_external_data_bufferify(SIDRE_Group *self,
+                                              const char *file_path,
                                               int Lfile_path)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.load_external_data_bufferify
   const std::string SHCXX_file_path(file_path, Lfile_path);
   SH_this->loadExternalData(SHCXX_file_path);
   // splicer end class.Group.method.load_external_data_bufferify
 }
 
-bool SIDRE_Group_rename(SIDRE_Group* self, const char* new_name)
+bool SIDRE_Group_rename(SIDRE_Group *self, const char *new_name)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.rename
   const std::string SHCXX_new_name(new_name);
   bool SHC_rv = SH_this->rename(SHCXX_new_name);
@@ -1548,11 +1553,11 @@ bool SIDRE_Group_rename(SIDRE_Group* self, const char* new_name)
   // splicer end class.Group.method.rename
 }
 
-bool SIDRE_Group_rename_bufferify(SIDRE_Group* self,
-                                  const char* new_name,
+bool SIDRE_Group_rename_bufferify(SIDRE_Group *self,
+                                  const char *new_name,
                                   int Lnew_name)
 {
-  axom::sidre::Group* SH_this = static_cast<axom::sidre::Group*>(self->addr);
+  axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.rename_bufferify
   const std::string SHCXX_new_name(new_name, Lnew_name);
   bool SHC_rv = SH_this->rename(SHCXX_new_name);

--- a/src/axom/sidre/interface/c_fortran/wrapView.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapView.cpp
@@ -22,7 +22,7 @@ extern "C" {
 // Copy src into dest, blank fill to ndest characters
 // Truncate if dest is too short.
 // dest will not be NULL terminated.
-static void ShroudStrCopy(char* dest, int ndest, const char* src, int nsrc)
+static void ShroudStrCopy(char *dest, int ndest, const char *src, int nsrc)
 {
   if(src == NULL)
   {
@@ -39,32 +39,32 @@ static void ShroudStrCopy(char* dest, int ndest, const char* src, int nsrc)
 // splicer begin class.View.C_definitions
 // splicer end class.View.C_definitions
 
-SIDRE_IndexType SIDRE_View_get_index(SIDRE_View* self)
+SIDRE_IndexType SIDRE_View_get_index(SIDRE_View *self)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_index
   axom::sidre::IndexType SHC_rv = SH_this->getIndex();
   return SHC_rv;
   // splicer end class.View.method.get_index
 }
 
-const char* SIDRE_View_get_name(const SIDRE_View* self)
+const char *SIDRE_View_get_name(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_name
-  const std::string& SHCXX_rv = SH_this->getName();
-  const char* SHC_rv = SHCXX_rv.c_str();
+  const std::string &SHCXX_rv = SH_this->getName();
+  const char *SHC_rv = SHCXX_rv.c_str();
   return SHC_rv;
   // splicer end class.View.method.get_name
 }
 
-void SIDRE_View_get_name_bufferify(const SIDRE_View* self, char* SHF_rv, int NSHF_rv)
+void SIDRE_View_get_name_bufferify(const SIDRE_View *self, char *SHF_rv, int NSHF_rv)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_name_bufferify
-  const std::string& SHCXX_rv = SH_this->getName();
+  const std::string &SHCXX_rv = SH_this->getName();
   if(SHCXX_rv.empty())
   {
     ShroudStrCopy(SHF_rv, NSHF_rv, nullptr, 0);
@@ -76,10 +76,10 @@ void SIDRE_View_get_name_bufferify(const SIDRE_View* self, char* SHF_rv, int NSH
   // splicer end class.View.method.get_name_bufferify
 }
 
-void SIDRE_View_get_path_bufferify(const SIDRE_View* self, char* SHF_rv, int NSHF_rv)
+void SIDRE_View_get_path_bufferify(const SIDRE_View *self, char *SHF_rv, int NSHF_rv)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_path_bufferify
   std::string SHCXX_rv = SH_this->getPath();
   if(SHCXX_rv.empty())
@@ -93,12 +93,12 @@ void SIDRE_View_get_path_bufferify(const SIDRE_View* self, char* SHF_rv, int NSH
   // splicer end class.View.method.get_path_bufferify
 }
 
-void SIDRE_View_get_path_name_bufferify(const SIDRE_View* self,
-                                        char* SHF_rv,
+void SIDRE_View_get_path_name_bufferify(const SIDRE_View *self,
+                                        char *SHF_rv,
                                         int NSHF_rv)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_path_name_bufferify
   std::string SHCXX_rv = SH_this->getPathName();
   if(SHCXX_rv.empty())
@@ -112,121 +112,121 @@ void SIDRE_View_get_path_name_bufferify(const SIDRE_View* self,
   // splicer end class.View.method.get_path_name_bufferify
 }
 
-SIDRE_Group* SIDRE_View_get_owning_group(SIDRE_View* self, SIDRE_Group* SHC_rv)
+SIDRE_Group *SIDRE_View_get_owning_group(SIDRE_View *self, SIDRE_Group *SHC_rv)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_owning_group
-  axom::sidre::Group* SHCXX_rv = SH_this->getOwningGroup();
+  axom::sidre::Group *SHCXX_rv = SH_this->getOwningGroup();
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.View.method.get_owning_group
 }
 
-bool SIDRE_View_has_buffer(const SIDRE_View* self)
+bool SIDRE_View_has_buffer(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.has_buffer
   bool SHC_rv = SH_this->hasBuffer();
   return SHC_rv;
   // splicer end class.View.method.has_buffer
 }
 
-SIDRE_Buffer* SIDRE_View_get_buffer(SIDRE_View* self, SIDRE_Buffer* SHC_rv)
+SIDRE_Buffer *SIDRE_View_get_buffer(SIDRE_View *self, SIDRE_Buffer *SHC_rv)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_buffer
-  axom::sidre::Buffer* SHCXX_rv = SH_this->getBuffer();
+  axom::sidre::Buffer *SHCXX_rv = SH_this->getBuffer();
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
   // splicer end class.View.method.get_buffer
 }
 
-bool SIDRE_View_is_external(const SIDRE_View* self)
+bool SIDRE_View_is_external(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.is_external
   bool SHC_rv = SH_this->isExternal();
   return SHC_rv;
   // splicer end class.View.method.is_external
 }
 
-bool SIDRE_View_is_allocated(SIDRE_View* self)
+bool SIDRE_View_is_allocated(SIDRE_View *self)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.is_allocated
   bool SHC_rv = SH_this->isAllocated();
   return SHC_rv;
   // splicer end class.View.method.is_allocated
 }
 
-bool SIDRE_View_is_applied(const SIDRE_View* self)
+bool SIDRE_View_is_applied(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.is_applied
   bool SHC_rv = SH_this->isApplied();
   return SHC_rv;
   // splicer end class.View.method.is_applied
 }
 
-bool SIDRE_View_is_described(const SIDRE_View* self)
+bool SIDRE_View_is_described(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.is_described
   bool SHC_rv = SH_this->isDescribed();
   return SHC_rv;
   // splicer end class.View.method.is_described
 }
 
-bool SIDRE_View_is_empty(const SIDRE_View* self)
+bool SIDRE_View_is_empty(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.is_empty
   bool SHC_rv = SH_this->isEmpty();
   return SHC_rv;
   // splicer end class.View.method.is_empty
 }
 
-bool SIDRE_View_is_opaque(const SIDRE_View* self)
+bool SIDRE_View_is_opaque(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.is_opaque
   bool SHC_rv = SH_this->isOpaque();
   return SHC_rv;
   // splicer end class.View.method.is_opaque
 }
 
-bool SIDRE_View_is_scalar(const SIDRE_View* self)
+bool SIDRE_View_is_scalar(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.is_scalar
   bool SHC_rv = SH_this->isScalar();
   return SHC_rv;
   // splicer end class.View.method.is_scalar
 }
 
-bool SIDRE_View_is_string(const SIDRE_View* self)
+bool SIDRE_View_is_string(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.is_string
   bool SHC_rv = SH_this->isString();
   return SHC_rv;
   // splicer end class.View.method.is_string
 }
 
-int SIDRE_View_get_type_id(const SIDRE_View* self)
+int SIDRE_View_get_type_id(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_type_id
   axom::sidre::TypeID SHCXX_rv = SH_this->getTypeID();
   int SHC_rv = static_cast<int>(SHCXX_rv);
@@ -234,383 +234,386 @@ int SIDRE_View_get_type_id(const SIDRE_View* self)
   // splicer end class.View.method.get_type_id
 }
 
-size_t SIDRE_View_get_total_bytes(const SIDRE_View* self)
+size_t SIDRE_View_get_total_bytes(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_total_bytes
   size_t SHC_rv = SH_this->getTotalBytes();
   return SHC_rv;
   // splicer end class.View.method.get_total_bytes
 }
 
-size_t SIDRE_View_get_num_elements(const SIDRE_View* self)
+size_t SIDRE_View_get_num_elements(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_num_elements
   size_t SHC_rv = SH_this->getNumElements();
   return SHC_rv;
   // splicer end class.View.method.get_num_elements
 }
 
-size_t SIDRE_View_get_bytes_per_element(const SIDRE_View* self)
+size_t SIDRE_View_get_bytes_per_element(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_bytes_per_element
   size_t SHC_rv = SH_this->getBytesPerElement();
   return SHC_rv;
   // splicer end class.View.method.get_bytes_per_element
 }
 
-size_t SIDRE_View_get_offset(const SIDRE_View* self)
+size_t SIDRE_View_get_offset(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_offset
   size_t SHC_rv = SH_this->getOffset();
   return SHC_rv;
   // splicer end class.View.method.get_offset
 }
 
-size_t SIDRE_View_get_stride(const SIDRE_View* self)
+size_t SIDRE_View_get_stride(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_stride
   size_t SHC_rv = SH_this->getStride();
   return SHC_rv;
   // splicer end class.View.method.get_stride
 }
 
-int SIDRE_View_get_num_dimensions(const SIDRE_View* self)
+int SIDRE_View_get_num_dimensions(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_num_dimensions
   int SHC_rv = SH_this->getNumDimensions();
   return SHC_rv;
   // splicer end class.View.method.get_num_dimensions
 }
 
-int SIDRE_View_get_shape(const SIDRE_View* self, int ndims, SIDRE_IndexType* shape)
+int SIDRE_View_get_shape(const SIDRE_View *self, int ndims, SIDRE_IndexType *shape)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_shape
   int SHC_rv = SH_this->getShape(ndims, shape);
   return SHC_rv;
   // splicer end class.View.method.get_shape
 }
 
-void SIDRE_View_allocate_simple(SIDRE_View* self)
+void SIDRE_View_allocate_simple(SIDRE_View *self)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.allocate_simple
   SH_this->allocate();
   // splicer end class.View.method.allocate_simple
 }
 
-void SIDRE_View_allocate_from_type(SIDRE_View* self,
+void SIDRE_View_allocate_from_type(SIDRE_View *self,
                                    int type,
                                    SIDRE_IndexType num_elems)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.allocate_from_type
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   SH_this->allocate(SHCXX_type, num_elems);
   // splicer end class.View.method.allocate_from_type
 }
 
-void SIDRE_View_reallocate(SIDRE_View* self, SIDRE_IndexType num_elems)
+void SIDRE_View_reallocate(SIDRE_View *self, SIDRE_IndexType num_elems)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.reallocate
   SH_this->reallocate(num_elems);
   // splicer end class.View.method.reallocate
 }
 
-void SIDRE_View_attach_buffer_only(SIDRE_View* self, SIDRE_Buffer* buff)
+void SIDRE_View_attach_buffer_only(SIDRE_View *self, SIDRE_Buffer *buff)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.attach_buffer_only
-  axom::sidre::Buffer* SHCXX_buff = static_cast<axom::sidre::Buffer*>(buff->addr);
+  axom::sidre::Buffer *SHCXX_buff =
+    static_cast<axom::sidre::Buffer *>(buff->addr);
   SH_this->attachBuffer(SHCXX_buff);
   // splicer end class.View.method.attach_buffer_only
 }
 
-void SIDRE_View_attach_buffer_type(SIDRE_View* self,
+void SIDRE_View_attach_buffer_type(SIDRE_View *self,
                                    int type,
                                    SIDRE_IndexType num_elems,
-                                   SIDRE_Buffer* buff)
+                                   SIDRE_Buffer *buff)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.attach_buffer_type
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::Buffer* SHCXX_buff = static_cast<axom::sidre::Buffer*>(buff->addr);
+  axom::sidre::Buffer *SHCXX_buff =
+    static_cast<axom::sidre::Buffer *>(buff->addr);
   SH_this->attachBuffer(SHCXX_type, num_elems, SHCXX_buff);
   // splicer end class.View.method.attach_buffer_type
 }
 
-void SIDRE_View_attach_buffer_shape(SIDRE_View* self,
+void SIDRE_View_attach_buffer_shape(SIDRE_View *self,
                                     int type,
                                     int ndims,
-                                    const SIDRE_IndexType* shape,
-                                    SIDRE_Buffer* buff)
+                                    const SIDRE_IndexType *shape,
+                                    SIDRE_Buffer *buff)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.attach_buffer_shape
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
-  axom::sidre::Buffer* SHCXX_buff = static_cast<axom::sidre::Buffer*>(buff->addr);
+  axom::sidre::Buffer *SHCXX_buff =
+    static_cast<axom::sidre::Buffer *>(buff->addr);
   SH_this->attachBuffer(SHCXX_type, ndims, shape, SHCXX_buff);
   // splicer end class.View.method.attach_buffer_shape
 }
 
-void SIDRE_View_apply_0(SIDRE_View* self)
+void SIDRE_View_apply_0(SIDRE_View *self)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.apply_0
   SH_this->apply();
   // splicer end class.View.method.apply_0
 }
 
-void SIDRE_View_apply_nelems(SIDRE_View* self, SIDRE_IndexType num_elems)
+void SIDRE_View_apply_nelems(SIDRE_View *self, SIDRE_IndexType num_elems)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.apply_nelems
   SH_this->apply(num_elems);
   // splicer end class.View.method.apply_nelems
 }
 
-void SIDRE_View_apply_nelems_offset(SIDRE_View* self,
+void SIDRE_View_apply_nelems_offset(SIDRE_View *self,
                                     SIDRE_IndexType num_elems,
                                     SIDRE_IndexType offset)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.apply_nelems_offset
   SH_this->apply(num_elems, offset);
   // splicer end class.View.method.apply_nelems_offset
 }
 
-void SIDRE_View_apply_nelems_offset_stride(SIDRE_View* self,
+void SIDRE_View_apply_nelems_offset_stride(SIDRE_View *self,
                                            SIDRE_IndexType num_elems,
                                            SIDRE_IndexType offset,
                                            SIDRE_IndexType stride)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.apply_nelems_offset_stride
   SH_this->apply(num_elems, offset, stride);
   // splicer end class.View.method.apply_nelems_offset_stride
 }
 
-void SIDRE_View_apply_type_nelems(SIDRE_View* self,
+void SIDRE_View_apply_type_nelems(SIDRE_View *self,
                                   int type,
                                   SIDRE_IndexType num_elems)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.apply_type_nelems
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   SH_this->apply(SHCXX_type, num_elems);
   // splicer end class.View.method.apply_type_nelems
 }
 
-void SIDRE_View_apply_type_nelems_offset(SIDRE_View* self,
+void SIDRE_View_apply_type_nelems_offset(SIDRE_View *self,
                                          int type,
                                          SIDRE_IndexType num_elems,
                                          SIDRE_IndexType offset)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.apply_type_nelems_offset
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   SH_this->apply(SHCXX_type, num_elems, offset);
   // splicer end class.View.method.apply_type_nelems_offset
 }
 
-void SIDRE_View_apply_type_nelems_offset_stride(SIDRE_View* self,
+void SIDRE_View_apply_type_nelems_offset_stride(SIDRE_View *self,
                                                 int type,
                                                 SIDRE_IndexType num_elems,
                                                 SIDRE_IndexType offset,
                                                 SIDRE_IndexType stride)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.apply_type_nelems_offset_stride
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   SH_this->apply(SHCXX_type, num_elems, offset, stride);
   // splicer end class.View.method.apply_type_nelems_offset_stride
 }
 
-void SIDRE_View_apply_type_shape(SIDRE_View* self,
+void SIDRE_View_apply_type_shape(SIDRE_View *self,
                                  int type,
                                  int ndims,
-                                 const SIDRE_IndexType* shape)
+                                 const SIDRE_IndexType *shape)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.apply_type_shape
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   SH_this->apply(SHCXX_type, ndims, shape);
   // splicer end class.View.method.apply_type_shape
 }
 
-void SIDRE_View_set_scalar_int(SIDRE_View* self, int value)
+void SIDRE_View_set_scalar_int(SIDRE_View *self, int value)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.set_scalar_int
   SH_this->setScalar<int>(value);
   // splicer end class.View.method.set_scalar_int
 }
 
-void SIDRE_View_set_scalar_long(SIDRE_View* self, long value)
+void SIDRE_View_set_scalar_long(SIDRE_View *self, long value)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.set_scalar_long
   SH_this->setScalar<long>(value);
   // splicer end class.View.method.set_scalar_long
 }
 
-void SIDRE_View_set_scalar_float(SIDRE_View* self, float value)
+void SIDRE_View_set_scalar_float(SIDRE_View *self, float value)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.set_scalar_float
   SH_this->setScalar<float>(value);
   // splicer end class.View.method.set_scalar_float
 }
 
-void SIDRE_View_set_scalar_double(SIDRE_View* self, double value)
+void SIDRE_View_set_scalar_double(SIDRE_View *self, double value)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.set_scalar_double
   SH_this->setScalar<double>(value);
   // splicer end class.View.method.set_scalar_double
 }
 
-void SIDRE_View_set_string(SIDRE_View* self, const char* value)
+void SIDRE_View_set_string(SIDRE_View *self, const char *value)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.set_string
   const std::string SHCXX_value(value);
   SH_this->setString(SHCXX_value);
   // splicer end class.View.method.set_string
 }
 
-void SIDRE_View_set_string_bufferify(SIDRE_View* self, const char* value, int Lvalue)
+void SIDRE_View_set_string_bufferify(SIDRE_View *self, const char *value, int Lvalue)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.set_string_bufferify
   const std::string SHCXX_value(value, Lvalue);
   SH_this->setString(SHCXX_value);
   // splicer end class.View.method.set_string_bufferify
 }
 
-void SIDRE_View_set_external_data_ptr_only(SIDRE_View* self, void* external_ptr)
+void SIDRE_View_set_external_data_ptr_only(SIDRE_View *self, void *external_ptr)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.set_external_data_ptr_only
   SH_this->setExternalDataPtr(external_ptr);
   // splicer end class.View.method.set_external_data_ptr_only
 }
 
-void SIDRE_View_set_external_data_ptr_type(SIDRE_View* self,
+void SIDRE_View_set_external_data_ptr_type(SIDRE_View *self,
                                            int type,
                                            SIDRE_IndexType num_elems,
-                                           void* external_ptr)
+                                           void *external_ptr)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.set_external_data_ptr_type
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   SH_this->setExternalDataPtr(SHCXX_type, num_elems, external_ptr);
   // splicer end class.View.method.set_external_data_ptr_type
 }
 
-void SIDRE_View_set_external_data_ptr_shape(SIDRE_View* self,
+void SIDRE_View_set_external_data_ptr_shape(SIDRE_View *self,
                                             int type,
                                             int ndims,
-                                            const SIDRE_IndexType* shape,
-                                            void* external_ptr)
+                                            const SIDRE_IndexType *shape,
+                                            void *external_ptr)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.set_external_data_ptr_shape
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   SH_this->setExternalDataPtr(SHCXX_type, ndims, shape, external_ptr);
   // splicer end class.View.method.set_external_data_ptr_shape
 }
 
-const char* SIDRE_View_get_string(SIDRE_View* self)
+const char *SIDRE_View_get_string(SIDRE_View *self)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_string
-  const char* SHC_rv = SH_this->getString();
+  const char *SHC_rv = SH_this->getString();
   return SHC_rv;
   // splicer end class.View.method.get_string
 }
 
-void SIDRE_View_get_string_bufferify(SIDRE_View* self, char* name, int Nname)
+void SIDRE_View_get_string_bufferify(SIDRE_View *self, char *name, int Nname)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_string_bufferify
-  const char* SHC_rv = SH_this->getString();
+  const char *SHC_rv = SH_this->getString();
   ShroudStrCopy(name, Nname, SHC_rv, -1);
   // splicer end class.View.method.get_string_bufferify
 }
 
-int SIDRE_View_get_data_int(SIDRE_View* self)
+int SIDRE_View_get_data_int(SIDRE_View *self)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_data_int
   int SHC_rv = SH_this->getData<int>();
   return SHC_rv;
   // splicer end class.View.method.get_data_int
 }
 
-long SIDRE_View_get_data_long(SIDRE_View* self)
+long SIDRE_View_get_data_long(SIDRE_View *self)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_data_long
   long SHC_rv = SH_this->getData<long>();
   return SHC_rv;
   // splicer end class.View.method.get_data_long
 }
 
-float SIDRE_View_get_data_float(SIDRE_View* self)
+float SIDRE_View_get_data_float(SIDRE_View *self)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_data_float
   float SHC_rv = SH_this->getData<float>();
   return SHC_rv;
   // splicer end class.View.method.get_data_float
 }
 
-double SIDRE_View_get_data_double(SIDRE_View* self)
+double SIDRE_View_get_data_double(SIDRE_View *self)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_data_double
   double SHC_rv = SH_this->getData<double>();
   return SHC_rv;
   // splicer end class.View.method.get_data_double
 }
 
-void* SIDRE_View_get_void_ptr(const SIDRE_View* self)
+void *SIDRE_View_get_void_ptr(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_void_ptr
-  void* SHC_rv = SH_this->getVoidPtr();
+  void *SHC_rv = SH_this->getVoidPtr();
   return SHC_rv;
   // splicer end class.View.method.get_void_ptr
 }
 
-void SIDRE_View_print(const SIDRE_View* self)
+void SIDRE_View_print(const SIDRE_View *self)
 {
-  const axom::sidre::View* SH_this =
-    static_cast<const axom::sidre::View*>(self->addr);
+  const axom::sidre::View *SH_this =
+    static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.print
   SH_this->print();
   // splicer end class.View.method.print
 }
 
-bool SIDRE_View_rename(SIDRE_View* self, const char* new_name)
+bool SIDRE_View_rename(SIDRE_View *self, const char *new_name)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.rename
   const std::string SHCXX_new_name(new_name);
   bool SHC_rv = SH_this->rename(SHCXX_new_name);
@@ -618,11 +621,11 @@ bool SIDRE_View_rename(SIDRE_View* self, const char* new_name)
   // splicer end class.View.method.rename
 }
 
-bool SIDRE_View_rename_bufferify(SIDRE_View* self,
-                                 const char* new_name,
+bool SIDRE_View_rename_bufferify(SIDRE_View *self,
+                                 const char *new_name,
                                  int Lnew_name)
 {
-  axom::sidre::View* SH_this = static_cast<axom::sidre::View*>(self->addr);
+  axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.rename_bufferify
   const std::string SHCXX_new_name(new_name, Lnew_name);
   bool SHC_rv = SH_this->rename(SHCXX_new_name);


### PR DESCRIPTION
# Summary

- This PR is a change of whitespace formatting only
- It does the following (modify list as needed):
Runs clangformat on sidre's shroud-generated code to make it consistent with expected style.