### PR TITLE
Attach AXOM_DEBUG to axom's core target

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,17 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ## [Unreleased] - Release date yyyy-mm-dd
 
+###  Added
+- Added a config variable, `AXOM_DEBUG_DEFINE` to control whether the `AXOM_DEBUG` compiler define is enabled.
+  By `DEFAULT`, it is enabled for `Debug` and `RelWithDebInfo` configurations, but this can be overriden
+  by setting `AXOM_DEBUG_DEFINE` to `ON` or `OFF`. 
+###  Changed
+- Renamed `AXOM_NOT_USED` macro to `AXOM_UNUSED_PARAM` for better consistency with other Axom macros
+
+###  Fixed
+- The `AXOM_DEBUG` compiler define is now properly exported via the `axom` CMake target when it is enabled
+
+
 ## [Version 0.6.0] - Release date 2021-11-04
 
 ### Added

--- a/src/axom/core/CMakeLists.txt
+++ b/src/axom/core/CMakeLists.txt
@@ -107,6 +107,12 @@ blt_add_library( NAME        core
                  OBJECT      TRUE
                  )
 
+# Add the AXOM_DEBUG compile definition, if non-empty
+if(AXOM_DEBUG_DEFINE_STRING)
+  blt_add_target_definitions(TO core SCOPE PUBLIC TARGET_DEFINITIONS "${AXOM_DEBUG_DEFINE_STRING}")
+endif()
+
+
 axom_write_unified_header( NAME    core
                            HEADERS ${core_headers}
                            )

--- a/src/axom/core/Macros.hpp
+++ b/src/axom/core/Macros.hpp
@@ -114,20 +114,19 @@
 
 /*!
  *
- * \def AXOM_NOT_USED(x)
- * \brief Macro used to silence compiler warnings in methods with unused
- *  arguments.
+ * \def AXOM_UNUSED_PARAM(x)
+ * \brief Macro used to silence compiler warnings in methods with unused arguments.
  * \note The intent is to use this macro in the function signature. For example:
  * \code
  *
- *  void my_function(int x, int AXOM_NOT_USED(y))
+ *  void my_function(int x, int AXOM_UNUSED_PARAM(y))
  *  {
  *    // my implementation
  *  }
  *
  * \endcode
  */
-#define AXOM_NOT_USED(x)
+#define AXOM_UNUSED_PARAM(x)
 
 /*!
  *

--- a/src/axom/core/Macros.hpp
+++ b/src/axom/core/Macros.hpp
@@ -165,7 +165,7 @@
 /*!
  * \def AXOM_DEBUG_PARAM(x)
  * \brief Macro used to silence compiler warnings about parameters
- *        that are used in debug code but not in release code.
+ *        that are only used when AXOM_DEBUG is defined
  * \note Default values are ok
  * \code
  *

--- a/src/axom/core/examples/core_acceleration.cpp
+++ b/src/axom/core/examples/core_acceleration.cpp
@@ -144,7 +144,7 @@ void demoAxomExecution()
 #endif
 }
 
-int main(int AXOM_NOT_USED(argc), char **AXOM_NOT_USED(argv))
+int main(int AXOM_UNUSED_PARAM(argc), char **AXOM_UNUSED_PARAM(argv))
 {
   demoMemoryManageBasic();
   demoAxomExecution();

--- a/src/axom/core/examples/core_containers.cpp
+++ b/src/axom/core/examples/core_containers.cpp
@@ -176,7 +176,7 @@ void demoArrayBasic()
   // _iteration_end
 }
 
-int main(int AXOM_NOT_USED(argc), char** AXOM_NOT_USED(argv))
+int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
 {
   demoArrayBasic();
   return 0;

--- a/src/axom/core/examples/core_numerics.cpp
+++ b/src/axom/core/examples/core_numerics.cpp
@@ -277,7 +277,7 @@ void demoMatrix()
   // _solve_end
 }
 
-int main(int AXOM_NOT_USED(argc), char** AXOM_NOT_USED(argv))
+int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
 {
   // _timer_start
   axom::utilities::Timer t;

--- a/src/axom/mint/docs/sphinx/sections/tutorial.rst
+++ b/src/axom/mint/docs/sphinx/sections/tutorial.rst
@@ -774,7 +774,7 @@ the cell centroid by averaging the coordinates of the constituent cell
 .. note::
 
    Since this kernel does not use the node IDs, the argument to the kernel
-   is annotated using the ``AXOM_NOT_USED`` macro to silence compiler
+   is annotated using the ``AXOM_UNUSED_PARAM`` macro to silence compiler
    warnings.
 
 .. literalinclude:: ../../../examples/user_guide/mint_tutorial.cpp
@@ -937,7 +937,7 @@ the face centroid by averaging the coordinates of the constituent face
 .. note::
 
    Since this kernel does not use the node IDs, the argument to the kernel
-   is annotated using the ``AXOM_NOT_USED`` macro to silence compiler
+   is annotated using the ``AXOM_UNUSED_PARAM`` macro to silence compiler
    warnings.
 
 .. literalinclude:: ../../../examples/user_guide/mint_tutorial.cpp

--- a/src/axom/mint/examples/mint_curvilinear_mesh.cpp
+++ b/src/axom/mint/examples/mint_curvilinear_mesh.cpp
@@ -24,7 +24,7 @@ constexpr double M = (2 * M_PI) / 50.0;
  * \brief Illustrates how to construct and use a mint::CurvilinearMesh object.
  */
 
-int main(int AXOM_NOT_USED(argc), char** AXOM_NOT_USED(argv))
+int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
 {
   constexpr int N = 100;
   constexpr double h = 0.5;

--- a/src/axom/mint/examples/mint_particle_mesh.cpp
+++ b/src/axom/mint/examples/mint_particle_mesh.cpp
@@ -19,7 +19,7 @@ namespace mint = axom::mint;
 namespace utilities = axom::utilities;
 
 //------------------------------------------------------------------------------
-int main(int AXOM_NOT_USED(argc), char** AXOM_NOT_USED(argv))
+int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
 {
   using int64 = axom::IndexType;
   const axom::IndexType NUM_PARTICLES = 100;

--- a/src/axom/mint/examples/mint_rectilinear_mesh.cpp
+++ b/src/axom/mint/examples/mint_rectilinear_mesh.cpp
@@ -39,7 +39,7 @@ void exponential_distribution(double origin, IndexType N, double* x)
 }
 
 //------------------------------------------------------------------------------
-int main(int AXOM_NOT_USED(argc), char** AXOM_NOT_USED(argv))
+int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
 {
   constexpr int N = 100;
 

--- a/src/axom/mint/examples/mint_unstructured_mixed_topology_mesh.cpp
+++ b/src/axom/mint/examples/mint_unstructured_mixed_topology_mesh.cpp
@@ -27,7 +27,7 @@ inline bool appendQuad(axom::IndexType i, axom::IndexType j)
 }
 
 //------------------------------------------------------------------------------
-int main(int AXOM_NOT_USED(argc), char** AXOM_NOT_USED(argv))
+int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
 {
   SimpleLogger logger;  // create & initialize test logger,
 

--- a/src/axom/mint/examples/mint_unstructured_single_topology_mesh.cpp
+++ b/src/axom/mint/examples/mint_unstructured_single_topology_mesh.cpp
@@ -19,7 +19,7 @@ using namespace axom;
 using axom::slic::SimpleLogger;
 
 //------------------------------------------------------------------------------
-int main(int AXOM_NOT_USED(argc), char** AXOM_NOT_USED(argv))
+int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
 {
   SimpleLogger logger;  // create & initialize test logger,
 

--- a/src/axom/mint/examples/user_guide/mint_tutorial.cpp
+++ b/src/axom/mint/examples/user_guide/mint_tutorial.cpp
@@ -218,7 +218,7 @@ void cell_traversals()
       &mesh,
       AXOM_LAMBDA(IndexType cellIdx,
                   const numerics::Matrix<double>& coords,
-                  const IndexType* AXOM_NOT_USED(nodeIdx)) {
+                  const IndexType* AXOM_UNUSED_PARAM(nodeIdx)) {
         // sum nodal coordinates
         double xsum = 0.0;
         double ysum = 0.0;
@@ -349,7 +349,7 @@ void face_traversals()
       &mesh,
       AXOM_LAMBDA(IndexType faceIdx,
                   const numerics::Matrix<double>& coords,
-                  const IndexType* AXOM_NOT_USED(nodeIdx)) {
+                  const IndexType* AXOM_UNUSED_PARAM(nodeIdx)) {
         // sum nodal coordinates
         double xsum = 0.0;
         double ysum = 0.0;
@@ -382,7 +382,7 @@ void face_traversals()
 
     mint::for_all_faces<exec_policy, mint::xargs::cellids>(
       &mesh,
-      AXOM_LAMBDA(IndexType faceIdx, IndexType AXOM_NOT_USED(c1), IndexType c2) {
+      AXOM_LAMBDA(IndexType faceIdx, IndexType AXOM_UNUSED_PARAM(c1), IndexType c2) {
         boundary[faceIdx] = (c2 == -1) ? ON_BOUNDARY : INTERIOR;
       });
 
@@ -823,7 +823,7 @@ void using_sidre()
 /*!
  * \brief Tutorial main
  */
-int main(int AXOM_NOT_USED(argc), char** AXOM_NOT_USED(argv))
+int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
 {
   // Native construction of various mesh types
   construct_uniform();

--- a/src/axom/mint/execution/internal/for_all_cells.hpp
+++ b/src/axom/mint/execution/internal/for_all_cells.hpp
@@ -314,7 +314,7 @@ inline void for_all_cells_impl(xargs::faceids,
     for_all_cells_impl<ExecPolicy>(
       xargs::ij(),
       m,
-      AXOM_LAMBDA(IndexType cellID, IndexType AXOM_NOT_USED(i), IndexType j) {
+      AXOM_LAMBDA(IndexType cellID, IndexType AXOM_UNUSED_PARAM(i), IndexType j) {
         IndexType faces[4];
 
         /* The I_DIRECTION faces */
@@ -340,7 +340,7 @@ inline void for_all_cells_impl(xargs::faceids,
       xargs::ijk(),
       m,
       AXOM_LAMBDA(IndexType cellID,
-                  IndexType AXOM_NOT_USED(i),
+                  IndexType AXOM_UNUSED_PARAM(i),
                   IndexType j,
                   IndexType k) {
         IndexType faces[6];
@@ -599,7 +599,7 @@ inline void for_all_cells_impl(xargs::coords,
 struct for_all_cell_nodes_functor
 {
   template <typename ExecPolicy, typename MeshType, typename KernelType>
-  inline void operator()(ExecPolicy AXOM_NOT_USED(policy),
+  inline void operator()(ExecPolicy AXOM_UNUSED_PARAM(policy),
                          const MeshType& m,
                          KernelType&& kernel) const
   {
@@ -657,7 +657,7 @@ inline void for_all_cells_impl(xargs::coords,
       m,
       AXOM_LAMBDA(IndexType cellID,
                   const IndexType* nodeIDs,
-                  IndexType AXOM_NOT_USED(numNodes)) {
+                  IndexType AXOM_UNUSED_PARAM(numNodes)) {
         double coords[2] = {x[nodeIDs[0]], x[nodeIDs[1]]};
 
         numerics::Matrix<double> coordsMatrix(dimension, 2, coords, NO_COPY);

--- a/src/axom/mint/execution/internal/for_all_faces.hpp
+++ b/src/axom/mint/execution/internal/for_all_faces.hpp
@@ -309,8 +309,8 @@ inline void for_all_faces_impl(xargs::nodeids,
       xargs::ij(),
       m,
       AXOM_LAMBDA(IndexType faceID,
-                  IndexType AXOM_NOT_USED(i),
-                  IndexType AXOM_NOT_USED(j)) {
+                  IndexType AXOM_UNUSED_PARAM(i),
+                  IndexType AXOM_UNUSED_PARAM(j)) {
         IndexType nodes[2];
         nodes[0] = faceID;
         nodes[1] = nodes[0] + cellNodeOffset3;
@@ -320,7 +320,7 @@ inline void for_all_faces_impl(xargs::nodeids,
     helpers::for_all_J_faces<ExecPolicy>(
       xargs::ij(),
       m,
-      AXOM_LAMBDA(IndexType faceID, IndexType AXOM_NOT_USED(i), IndexType j) {
+      AXOM_LAMBDA(IndexType faceID, IndexType AXOM_UNUSED_PARAM(i), IndexType j) {
         const IndexType shiftedID = faceID - numIFaces;
         IndexType nodes[2];
         nodes[0] = shiftedID + j;
@@ -349,8 +349,8 @@ inline void for_all_faces_impl(xargs::nodeids,
       xargs::ijk(),
       m,
       AXOM_LAMBDA(IndexType faceID,
-                  IndexType AXOM_NOT_USED(i),
-                  IndexType AXOM_NOT_USED(j),
+                  IndexType AXOM_UNUSED_PARAM(i),
+                  IndexType AXOM_UNUSED_PARAM(j),
                   IndexType k) {
         IndexType nodes[4];
         nodes[0] = faceID + k * INodeResolution;
@@ -364,7 +364,7 @@ inline void for_all_faces_impl(xargs::nodeids,
       xargs::ijk(),
       m,
       AXOM_LAMBDA(IndexType faceID,
-                  IndexType AXOM_NOT_USED(i),
+                  IndexType AXOM_UNUSED_PARAM(i),
                   IndexType j,
                   IndexType k) {
         const IndexType shiftedID = faceID - numIFaces;
@@ -380,7 +380,7 @@ inline void for_all_faces_impl(xargs::nodeids,
       xargs::ijk(),
       m,
       AXOM_LAMBDA(IndexType faceID,
-                  IndexType AXOM_NOT_USED(i),
+                  IndexType AXOM_UNUSED_PARAM(i),
                   IndexType j,
                   IndexType k) {
         const IndexType shiftedID = faceID - numIJFaces;
@@ -904,7 +904,7 @@ inline void for_all_faces_impl(xargs::coords,
 struct for_all_face_nodes_functor
 {
   template <typename ExecPolicy, typename MeshType, typename KernelType>
-  inline void operator()(ExecPolicy AXOM_NOT_USED(policy),
+  inline void operator()(ExecPolicy AXOM_UNUSED_PARAM(policy),
                          const MeshType& m,
                          KernelType&& kernel) const
   {

--- a/src/axom/mint/fem/shape_functions/Lagrange.hpp
+++ b/src/axom/mint/fem/shape_functions/Lagrange.hpp
@@ -7,7 +7,7 @@
 #define MINT_LAGRANGE_SHAPEFUNCTION_HPP_
 
 // Axom includes
-#include "axom/core/Macros.hpp"  // For AXOM_STATIC_ASSERT(), AXOM_NOT_USED()
+#include "axom/core/Macros.hpp"
 
 // Mint includes
 #include "axom/mint/mesh/CellTypes.hpp"
@@ -143,7 +143,7 @@ public:
    *
    * \note This method is implemented in specialized instances.
    */
-  static void getCenter(double* AXOM_NOT_USED(center))
+  static void getCenter(double* AXOM_UNUSED_PARAM(center))
   {
     constexpr int cell_value = mint::cellTypeToInt(CELLTYPE);
     AXOM_STATIC_ASSERT(cell_value >= 0 && cell_value < mint::NUM_CELL_TYPES);
@@ -159,7 +159,7 @@ public:
    * \note The coordinates are arranged in column-major flat array layout.
    * \note This method is implemented in specialized instances.
    */
-  static void getCoords(double* AXOM_NOT_USED(coords))
+  static void getCoords(double* AXOM_UNUSED_PARAM(coords))
   {
     constexpr int cell_value = mint::cellTypeToInt(CELLTYPE);
     AXOM_STATIC_ASSERT(cell_value >= 0 && cell_value < mint::NUM_CELL_TYPES);
@@ -178,8 +178,8 @@ public:
    *
    * \note This method is implemented in specialized instances.
    */
-  static void computeShape(const double* AXOM_NOT_USED(nc),
-                           double* AXOM_NOT_USED(phi))
+  static void computeShape(const double* AXOM_UNUSED_PARAM(nc),
+                           double* AXOM_UNUSED_PARAM(phi))
   {
     constexpr int cell_value = mint::cellTypeToInt(CELLTYPE);
     AXOM_STATIC_ASSERT(cell_value >= 0 && cell_value < mint::NUM_CELL_TYPES);
@@ -198,8 +198,8 @@ public:
    *
    * \note This method is implemented in specialized instances.
    */
-  static void computeDerivatives(const double* AXOM_NOT_USED(nc),
-                                 double* AXOM_NOT_USED(phidot))
+  static void computeDerivatives(const double* AXOM_UNUSED_PARAM(nc),
+                                 double* AXOM_UNUSED_PARAM(phidot))
   {
     constexpr int cell_value = mint::cellTypeToInt(CELLTYPE);
     AXOM_STATIC_ASSERT(cell_value >= 0 && cell_value < mint::NUM_CELL_TYPES);

--- a/src/axom/mint/fem/shape_functions/lagrange/lagrange_tetra_4.hpp
+++ b/src/axom/mint/fem/shape_functions/lagrange/lagrange_tetra_4.hpp
@@ -106,7 +106,8 @@ public:
     phi[3] = t;
   }
 
-  static void computeDerivatives(const double* AXOM_NOT_USED(xr), double* phidot)
+  static void computeDerivatives(const double* AXOM_UNUSED_PARAM(xr),
+                                 double* phidot)
   {
     SLIC_ASSERT(phidot != nullptr);
 

--- a/src/axom/mint/fem/shape_functions/lagrange/lagrange_tri_3.hpp
+++ b/src/axom/mint/fem/shape_functions/lagrange/lagrange_tri_3.hpp
@@ -93,7 +93,8 @@ public:
     phi[2] = s;
   }
 
-  static void computeDerivatives(const double* AXOM_NOT_USED(xr), double* phidot)
+  static void computeDerivatives(const double* AXOM_UNUSED_PARAM(xr),
+                                 double* phidot)
   {
     SLIC_ASSERT(phidot != nullptr);
 

--- a/src/axom/mint/mesh/ConnectivityArray.hpp
+++ b/src/axom/mint/mesh/ConnectivityArray.hpp
@@ -430,7 +430,8 @@ public:
    *
    * \post getIDCapacity() >= n_IDs
    */
-  void reserve(IndexType ID_capacity, IndexType AXOM_NOT_USED(value_capacity) = 0)
+  void reserve(IndexType ID_capacity,
+               IndexType AXOM_UNUSED_PARAM(value_capacity) = 0)
   {
     SLIC_ERROR_IF(isExternal() && ID_capacity > m_values->capacity(),
                   "cannot exceed initial capacity of external buffer!");
@@ -446,7 +447,7 @@ public:
    *
    * \post getNumberOfIDs() == newIDSize
    */
-  void resize(IndexType ID_size, IndexType AXOM_NOT_USED(value_size) = 0)
+  void resize(IndexType ID_size, IndexType AXOM_UNUSED_PARAM(value_size) = 0)
   {
     m_values->resize(ID_size);
   }
@@ -523,7 +524,7 @@ public:
    *
    * \param [in] ID not used, does not need to be specified.
    */
-  IndexType getNumberOfValuesForID(IndexType AXOM_NOT_USED(ID) = 0) const
+  IndexType getNumberOfValuesForID(IndexType AXOM_UNUSED_PARAM(ID) = 0) const
   {
     return m_stride;
   }
@@ -533,7 +534,7 @@ public:
    *
    * \param [in] ID not used, does not need to be specified.
    */
-  CellType getIDType(IndexType AXOM_NOT_USED(ID) = 0) const
+  CellType getIDType(IndexType AXOM_UNUSED_PARAM(ID) = 0) const
   {
     return m_cell_type;
   }
@@ -614,8 +615,8 @@ public:
    * \pre values != nullptr
    */
   void append(const IndexType* values,
-              IndexType AXOM_NOT_USED(n_values) = 0,
-              CellType AXOM_NOT_USED(type) = UNDEFINED_CELL)
+              IndexType AXOM_UNUSED_PARAM(n_values) = 0,
+              CellType AXOM_UNUSED_PARAM(type) = UNDEFINED_CELL)
   {
     appendM(values, 1);
   }
@@ -634,8 +635,8 @@ public:
    */
   void appendM(const IndexType* values,
                IndexType n_IDs,
-               const IndexType* AXOM_NOT_USED(offsets) = nullptr,
-               const CellType* AXOM_NOT_USED(types) = nullptr)
+               const IndexType* AXOM_UNUSED_PARAM(offsets) = nullptr,
+               const CellType* AXOM_UNUSED_PARAM(types) = nullptr)
   {
     SLIC_ASSERT(values != nullptr);
     SLIC_ASSERT(n_IDs >= 0);
@@ -693,8 +694,8 @@ public:
    */
   void insert(const IndexType* values,
               IndexType start_ID,
-              IndexType AXOM_NOT_USED(n_values) = 0,
-              CellType AXOM_NOT_USED(type) = UNDEFINED_CELL)
+              IndexType AXOM_UNUSED_PARAM(n_values) = 0,
+              CellType AXOM_UNUSED_PARAM(type) = UNDEFINED_CELL)
   {
     insertM(values, start_ID, 1);
   }
@@ -716,8 +717,8 @@ public:
   void insertM(const IndexType* values,
                IndexType start_ID,
                IndexType n_IDs,
-               const IndexType* AXOM_NOT_USED(offsets) = nullptr,
-               const CellType* AXOM_NOT_USED(types) = nullptr)
+               const IndexType* AXOM_UNUSED_PARAM(offsets) = nullptr,
+               const CellType* AXOM_UNUSED_PARAM(types) = nullptr)
   {
     SLIC_ASSERT(start_ID >= 0);
     SLIC_ASSERT(start_ID <= getNumberOfIDs());

--- a/src/axom/mint/mesh/Mesh.hpp
+++ b/src/axom/mint/mesh/Mesh.hpp
@@ -267,8 +267,8 @@ public:
    * \pre nodes != nullptr
    * \pre 0 <= cellID < getNumberOfCells()
    */
-  virtual IndexType getCellNodeIDs(IndexType AXOM_NOT_USED(cellID),
-                                   IndexType* AXOM_NOT_USED(nodes)) const = 0;
+  virtual IndexType getCellNodeIDs(IndexType AXOM_UNUSED_PARAM(cellID),
+                                   IndexType* AXOM_UNUSED_PARAM(nodes)) const = 0;
 
   /*!
    * \brief Return the number of faces associated with the given cell.
@@ -276,7 +276,7 @@ public:
    * \param [in] cellID the ID of the cell in question.
    */
   virtual IndexType getNumberOfCellFaces(
-    IndexType AXOM_NOT_USED(cellID) = 0) const = 0;
+    IndexType AXOM_UNUSED_PARAM(cellID) = 0) const = 0;
 
   /*!
    * \brief Populates the given buffer with the IDs of the faces of the given
@@ -289,8 +289,8 @@ public:
    * \pre faces != nullptr
    * \pre 0 <= cellID < getNumberOfCells()
    */
-  virtual IndexType getCellFaceIDs(IndexType AXOM_NOT_USED(cellID),
-                                   IndexType* AXOM_NOT_USED(faces)) const = 0;
+  virtual IndexType getCellFaceIDs(IndexType AXOM_UNUSED_PARAM(cellID),
+                                   IndexType* AXOM_UNUSED_PARAM(faces)) const = 0;
 
   /// @}
 
@@ -367,14 +367,15 @@ public:
    *
    * \param [in] faceID the ID of the face in question.
    */
-  virtual CellType getFaceType(IndexType AXOM_NOT_USED(faceID)) const = 0;
+  virtual CellType getFaceType(IndexType AXOM_UNUSED_PARAM(faceID)) const = 0;
 
   /*!
    * \brief Return the number of nodes associated with the given face.
    *
    * \param [in] faceID the ID of the face in question.
    */
-  virtual IndexType getNumberOfFaceNodes(IndexType AXOM_NOT_USED(faceID)) const = 0;
+  virtual IndexType getNumberOfFaceNodes(
+    IndexType AXOM_UNUSED_PARAM(faceID)) const = 0;
 
   /*!
    * \brief Copy the IDs of the nodes that compose the given face into the
@@ -389,8 +390,8 @@ public:
    * \pre nodes != nullptr
    * \pre 0 <= faceID < getNumberOfFaces()
    */
-  virtual IndexType getFaceNodeIDs(IndexType AXOM_NOT_USED(faceID),
-                                   IndexType* AXOM_NOT_USED(nodes)) const = 0;
+  virtual IndexType getFaceNodeIDs(IndexType AXOM_UNUSED_PARAM(faceID),
+                                   IndexType* AXOM_UNUSED_PARAM(nodes)) const = 0;
 
   /*!
    * \brief Copy the IDs of the cells adjacent to the given face into the
@@ -405,9 +406,9 @@ public:
    *
    * \pre 0 <= faceID < getNumberOfFaces()
    */
-  virtual void getFaceCellIDs(IndexType AXOM_NOT_USED(faceID),
-                              IndexType& AXOM_NOT_USED(cellIDOne),
-                              IndexType& AXOM_NOT_USED(cellIDTwo)) const = 0;
+  virtual void getFaceCellIDs(IndexType AXOM_UNUSED_PARAM(faceID),
+                              IndexType& AXOM_UNUSED_PARAM(cellIDOne),
+                              IndexType& AXOM_UNUSED_PARAM(cellIDTwo)) const = 0;
 
   /// @}
 

--- a/src/axom/mint/mesh/ParticleMesh.hpp
+++ b/src/axom/mint/mesh/ParticleMesh.hpp
@@ -235,12 +235,12 @@ public:
   }
 
   virtual IndexType getNumberOfCellNodes(
-    IndexType AXOM_NOT_USED(cellID) = 0) const final override
+    IndexType AXOM_UNUSED_PARAM(cellID) = 0) const final override
   {
     return 1;
   }
 
-  virtual CellType getCellType(IndexType AXOM_NOT_USED(cellID) = 0) const final override
+  virtual CellType getCellType(IndexType AXOM_UNUSED_PARAM(cellID) = 0) const final override
   {
     return VERTEX;
   }
@@ -255,7 +255,7 @@ public:
    * \param [in] cellID the ID of the cell in question.
    */
   virtual IndexType getNumberOfCellFaces(
-    IndexType AXOM_NOT_USED(cellID) = 0) const final override
+    IndexType AXOM_UNUSED_PARAM(cellID) = 0) const final override
   {
     return 0;
   }
@@ -269,8 +269,8 @@ public:
    * \param [out] faces buffer to populate with the face IDs. Must be of length
    *  at least getNumberOfCellFaces( cellID ).
    */
-  virtual IndexType getCellFaceIDs(IndexType AXOM_NOT_USED(cellID),
-                                   IndexType* AXOM_NOT_USED(faces)) const final override
+  virtual IndexType getCellFaceIDs(IndexType AXOM_UNUSED_PARAM(cellID),
+                                   IndexType* AXOM_UNUSED_PARAM(faces)) const final override
   {
     SLIC_ERROR("ParticleMesh does not implement this method.");
     return 0;
@@ -352,7 +352,7 @@ public:
    * 
    * \note The particle mesh does not have any faces so this call errors out.
    */
-  virtual CellType getFaceType(IndexType AXOM_NOT_USED(faceID)) const final override
+  virtual CellType getFaceType(IndexType AXOM_UNUSED_PARAM(faceID)) const final override
   {
     SLIC_ERROR("ParticleMesh does not implement this method.");
     return UNDEFINED_CELL;
@@ -366,7 +366,7 @@ public:
    * \note The particle mesh does not have any faces so this call errors out.
    */
   virtual IndexType getNumberOfFaceNodes(
-    IndexType AXOM_NOT_USED(faceID)) const final override
+    IndexType AXOM_UNUSED_PARAM(faceID)) const final override
   {
     SLIC_ERROR("ParticleMesh does not implement this method.");
     return -1;
@@ -385,8 +385,8 @@ public:
    * 
    * \note The particle mesh does not have any faces so this call errors out.
    */
-  virtual IndexType getFaceNodeIDs(IndexType AXOM_NOT_USED(faceID),
-                                   IndexType* AXOM_NOT_USED(nodes)) const final override
+  virtual IndexType getFaceNodeIDs(IndexType AXOM_UNUSED_PARAM(faceID),
+                                   IndexType* AXOM_UNUSED_PARAM(nodes)) const final override
   {
     SLIC_ERROR("ParticleMesh does not implement this method.");
     return -1;
@@ -402,9 +402,9 @@ public:
    *
    * \note The particle mesh does not have any faces so this call errors out.
    */
-  virtual void getFaceCellIDs(IndexType AXOM_NOT_USED(faceID),
-                              IndexType& AXOM_NOT_USED(cellIDOne),
-                              IndexType& AXOM_NOT_USED(cellIDTwo)) const final override
+  virtual void getFaceCellIDs(IndexType AXOM_UNUSED_PARAM(faceID),
+                              IndexType& AXOM_UNUSED_PARAM(cellIDOne),
+                              IndexType& AXOM_UNUSED_PARAM(cellIDTwo)) const final override
   {
     SLIC_ERROR("ParticleMesh does not implement this method.");
   }

--- a/src/axom/mint/mesh/StructuredMesh.cpp
+++ b/src/axom/mint/mesh/StructuredMesh.cpp
@@ -25,7 +25,7 @@ bool validStructuredMeshType(int type)
           (type == STRUCTURED_UNIFORM_MESH));
 }
 
-inline int dim(const IndexType& AXOM_NOT_USED(Ni),
+inline int dim(const IndexType& AXOM_UNUSED_PARAM(Ni),
                const IndexType& Nj,
                const IndexType& Nk)
 {

--- a/src/axom/mint/mesh/StructuredMesh.hpp
+++ b/src/axom/mint/mesh/StructuredMesh.hpp
@@ -80,7 +80,7 @@ public:
    * \param [in] cellID the ID of the cell in question, this parameter is
    *  ignored.
    */
-  virtual CellType getCellType(IndexType AXOM_NOT_USED(cellID) = 0) const final override
+  virtual CellType getCellType(IndexType AXOM_UNUSED_PARAM(cellID) = 0) const final override
   {
     return (m_ndims == 1) ? SEGMENT : (m_ndims == 2) ? QUAD : HEX;
   }
@@ -92,7 +92,7 @@ public:
    *  ignored.
    */
   virtual IndexType getNumberOfCellNodes(
-    IndexType AXOM_NOT_USED(cellID) = 0) const final override
+    IndexType AXOM_UNUSED_PARAM(cellID) = 0) const final override
   {
     return (m_ndims == 1) ? 2 : (m_ndims == 2) ? 4 : 8;
   }
@@ -120,7 +120,7 @@ public:
    *  ignored.
    */
   virtual IndexType getNumberOfCellFaces(
-    IndexType AXOM_NOT_USED(cellID) = 0) const final override
+    IndexType AXOM_UNUSED_PARAM(cellID) = 0) const final override
   {
     CellType cell_type = getCellType();
     return getCellInfo(cell_type).num_faces;
@@ -218,7 +218,7 @@ public:
    * \param [in] faceID the ID of the face in question, this parameter is
    *  ignored.
    */
-  virtual CellType getFaceType(IndexType AXOM_NOT_USED(faceID) = 0) const final override
+  virtual CellType getFaceType(IndexType AXOM_UNUSED_PARAM(faceID) = 0) const final override
   {
     return (m_ndims == 2) ? SEGMENT : (m_ndims == 3) ? QUAD : UNDEFINED_CELL;
   }
@@ -230,7 +230,7 @@ public:
    *  ignored.
    */
   virtual IndexType getNumberOfFaceNodes(
-    IndexType AXOM_NOT_USED(faceID) = 0) const final override
+    IndexType AXOM_UNUSED_PARAM(faceID) = 0) const final override
   {
     return (m_ndims == 2) ? 2 : (m_ndims == 3) ? 4 : 0;
   }

--- a/src/axom/mint/mesh/UniformMesh.hpp
+++ b/src/axom/mint/mesh/UniformMesh.hpp
@@ -6,11 +6,11 @@
 #ifndef MINT_UNIFORMMESH_HPP_
 #define MINT_UNIFORMMESH_HPP_
 
-#include "axom/core/StackArray.hpp"           // for StackArray
-#include "axom/mint/config.hpp"               // for IndexType, int64
-#include "axom/mint/mesh/StructuredMesh.hpp"  // for StructuredMesh
+#include "axom/core/StackArray.hpp"
+#include "axom/mint/config.hpp"
+#include "axom/mint/mesh/StructuredMesh.hpp"
 
-#include "axom/slic/interface/slic.hpp"  // for SLIC macros
+#include "axom/slic/interface/slic.hpp"
 
 namespace axom
 {
@@ -221,13 +221,13 @@ public:
    */
   /// @{
 
-  virtual double* getCoordinateArray(int AXOM_NOT_USED(dim)) final override
+  virtual double* getCoordinateArray(int AXOM_UNUSED_PARAM(dim)) final override
   {
     SLIC_ERROR("getCoordinateArray() is not supported for UniformMesh");
     return nullptr;
   }
 
-  virtual const double* getCoordinateArray(int AXOM_NOT_USED(dim)) const final override
+  virtual const double* getCoordinateArray(int AXOM_UNUSED_PARAM(dim)) const final override
   {
     SLIC_ERROR("getCoordinateArray() is not supported for UniformMesh");
     return nullptr;

--- a/src/axom/mint/mesh/internal/ConnectivityArray_indirection.hpp
+++ b/src/axom/mint/mesh/internal/ConnectivityArray_indirection.hpp
@@ -437,7 +437,7 @@ public:
    *
    * \param [in] ID not used, does not need to be specified.
    */
-  CellType getIDType(IndexType AXOM_NOT_USED(id) = 0) const
+  CellType getIDType(IndexType AXOM_UNUSED_PARAM(id) = 0) const
   {
     return m_cell_type;
   }
@@ -518,7 +518,7 @@ public:
    */
   void append(const IndexType* values,
               IndexType n_values,
-              CellType AXOM_NOT_USED(type) = UNDEFINED_CELL)
+              CellType AXOM_UNUSED_PARAM(type) = UNDEFINED_CELL)
   {
     SLIC_ASSERT(values != nullptr);
     m_values->append(values, n_values);
@@ -544,7 +544,7 @@ public:
   void appendM(const IndexType* values,
                IndexType n_IDs,
                const IndexType* offsets,
-               const CellType* AXOM_NOT_USED(types) = nullptr)
+               const CellType* AXOM_UNUSED_PARAM(types) = nullptr)
   {
     internal::append(n_IDs, values, offsets, m_values, m_offsets);
   }
@@ -600,7 +600,7 @@ public:
   void insert(const IndexType* values,
               IndexType start_ID,
               IndexType n_values,
-              CellType AXOM_NOT_USED(type) = UNDEFINED_CELL)
+              CellType AXOM_UNUSED_PARAM(type) = UNDEFINED_CELL)
   {
     IndexType offsets[2];
     offsets[0] = 0;
@@ -630,7 +630,7 @@ public:
                IndexType start_ID,
                IndexType n_IDs,
                const IndexType* offsets,
-               const CellType* AXOM_NOT_USED(types) = nullptr)
+               const CellType* AXOM_UNUSED_PARAM(types) = nullptr)
   {
     internal::insert(start_ID, n_IDs, values, offsets, m_values, m_offsets);
   }

--- a/src/axom/mint/mesh/internal/MeshHelpers.hpp
+++ b/src/axom/mint/mesh/internal/MeshHelpers.hpp
@@ -5,7 +5,7 @@
 #ifndef MINT_MESH_HELPERS_HPP_
 #define MINT_MESH_HELPERS_HPP_
 
-#include "axom/core/Macros.hpp"          // for AXOM_NOT_USED
+#include "axom/core/Macros.hpp"          // for AXOM_UNUSED_PARAM
 #include "axom/core/Types.hpp"           // for nullptr
 #include "axom/mint/config.hpp"          // for mint compile-time type
 #include "axom/mint/mesh/CellTypes.hpp"  // for CellType
@@ -20,7 +20,7 @@ class Mesh;  // forward declaration
 
 namespace internal
 {
-inline int dim(const double* AXOM_NOT_USED(x), const double* y, const double* z)
+inline int dim(const double* AXOM_UNUSED_PARAM(x), const double* y, const double* z)
 {
   return ((z != nullptr) ? 3 : ((y != nullptr) ? 2 : 1));
 }

--- a/src/axom/quest/MeshTester.hpp
+++ b/src/axom/quest/MeshTester.hpp
@@ -159,28 +159,29 @@ void findTriMeshIntersectionsBVH(
 
   // Initialize the bounding box for each Triangle and marks
   // if the Triangle is degenerate.
-  AXOM_PERF_MARK_SECTION("init_tri_bb",
-                         mint::for_all_cells<ExecSpace, mint::xargs::coords>(
-                           surface_mesh,
-                           AXOM_LAMBDA(IndexType cellIdx,
-                                       numerics::Matrix<double> & coords,
-                                       const IndexType* AXOM_NOT_USED(nodeIds)) {
-                             detail::Triangle3 tri;
+  AXOM_PERF_MARK_SECTION(
+    "init_tri_bb",
+    mint::for_all_cells<ExecSpace, mint::xargs::coords>(
+      surface_mesh,
+      AXOM_LAMBDA(IndexType cellIdx,
+                  numerics::Matrix<double> & coords,
+                  const IndexType* AXOM_UNUSED_PARAM(nodeIds)) {
+        detail::Triangle3 tri;
 
-                             for(IndexType inode = 0; inode < 3; ++inode)
-                             {
-                               const double* node = coords.getColumn(inode);
-                               tri[inode][0] = node[mint::X_COORDINATE];
-                               tri[inode][1] = node[mint::Y_COORDINATE];
-                               tri[inode][2] = node[mint::Z_COORDINATE];
-                             }  // END for all cells nodes
+        for(IndexType inode = 0; inode < 3; ++inode)
+        {
+          const double* node = coords.getColumn(inode);
+          tri[inode][0] = node[mint::X_COORDINATE];
+          tri[inode][1] = node[mint::Y_COORDINATE];
+          tri[inode][2] = node[mint::Z_COORDINATE];
+        }  // END for all cells nodes
 
-                             degenerate[cellIdx] = (tri.degenerate() ? 1 : 0);
+        degenerate[cellIdx] = (tri.degenerate() ? 1 : 0);
 
-                             tris[cellIdx] = tri;
+        tris[cellIdx] = tri;
 
-                             aabbs[cellIdx] = compute_bounding_box(tri);
-                           }););
+        aabbs[cellIdx] = compute_bounding_box(tri);
+      }););
 
   // Copy degenerate data back to host
   int* host_degenerate =

--- a/src/axom/quest/SamplingShaper.hpp
+++ b/src/axom/quest/SamplingShaper.hpp
@@ -169,7 +169,7 @@ public:
   * in region defined by bounding box \a queryBounds
   */
   void computeVolumeFractionsBaseline(mfem::DataCollection* dc,
-                                      int AXOM_NOT_USED(sampleRes),
+                                      int AXOM_UNUSED_PARAM(sampleRes),
                                       int outputOrder)
   {
     // Step 1 -- generate a QField w/ the spatial coordinates

--- a/src/axom/slam/Map.hpp
+++ b/src/axom/slam/Map.hpp
@@ -394,7 +394,7 @@ private:
 
   // setStride function should not be called after constructor is called.
   // This (should) override the StridePolicy setStride(s) function.
-  void setStride(SetPosition AXOM_NOT_USED(str))
+  void setStride(SetPosition AXOM_UNUSED_PARAM(str))
   {
     SLIC_ASSERT_MSG(false,
                     "Stride should not be changed after construction of map.");

--- a/src/axom/slam/NullSet.hpp
+++ b/src/axom/slam/NullSet.hpp
@@ -50,7 +50,10 @@ public:
   inline bool isSubset() const { return false; }
   const ParentSet* parentSet() const { return this; }
 
-  bool isValid(bool AXOM_NOT_USED(verboseOutput) = false) const { return true; }
+  bool isValid(bool AXOM_UNUSED_PARAM(verboseOutput) = false) const
+  {
+    return true;
+  }
 
   bool empty() const { return true; }
 

--- a/src/axom/slam/policies/CardinalityPolicies.hpp
+++ b/src/axom/slam/policies/CardinalityPolicies.hpp
@@ -92,7 +92,7 @@ struct ConstantCardinality
     m_begins = builder;
   }
 
-  const ElementType size(ElementType AXOM_NOT_USED(fromPos)) const
+  const ElementType size(ElementType AXOM_UNUSED_PARAM(fromPos)) const
   {
     return m_begins.stride();
   }
@@ -111,7 +111,7 @@ struct ConstantCardinality
 
   template <typename FromSetType>
   bool isValid(const FromSetType* fromSet,
-               bool AXOM_NOT_USED(vertboseOutput) = false) const
+               bool AXOM_UNUSED_PARAM(verboseOutput) = false) const
   {
     return m_begins.size() == fromSet->size();
   }

--- a/src/axom/slam/tests/slam_relation_StaticConstant.cpp
+++ b/src/axom/slam/tests/slam_relation_StaticConstant.cpp
@@ -85,7 +85,7 @@ void printVector(StrType const& msg, VecType const& vec)
   SLIC_INFO(msg << ": " << sstr.str());
 }
 
-SetPosition elementCardinality(SetPosition AXOM_NOT_USED(fromPos))
+SetPosition elementCardinality(SetPosition AXOM_UNUSED_PARAM(fromPos))
 {
   return ELEM_STRIDE;
 }

--- a/src/axom/slic/docs/sphinx/sections/architecture.rst
+++ b/src/axom/slic/docs/sphinx/sections/architecture.rst
@@ -400,7 +400,7 @@ The ``MyStream`` class implements the ``LogStream::append()`` method of the
                           const std::string& tagName,
                           const std::string& fileName,
                           int line,
-                          bool AXOM_NOT_USED(filtered_duplicates) )
+                          bool AXOM_UNUSED_PARAM(filtered_duplicates) )
    {
       assert( m_stream != nillptr );
 

--- a/src/axom/slic/examples/basic/logging.cpp
+++ b/src/axom/slic/examples/basic/logging.cpp
@@ -13,7 +13,7 @@
 using namespace axom;
 
 //------------------------------------------------------------------------------
-int main(int AXOM_NOT_USED(argc), char** AXOM_NOT_USED(argv))
+int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
 {
   // SPHINX_SLIC_INIT_BEGIN
 

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -7,7 +7,7 @@
 #define AXOM_SLIC_MACROS_HPP_
 
 #include "axom/config.hpp"
-#include "axom/core/Macros.hpp"  // for AXOM_HOST_DEVICE macros
+#include "axom/core/Macros.hpp"
 
 /*!
  * \file slic_macros.hpp
@@ -125,7 +125,7 @@
  * \brief Asserts that a given expression is true. If the expression is not true
  *  an error will be logged and the application will be aborted.
  * \param [in] EXP user-supplied boolean expression.
- * \note This macro is only active when debugging is turned on.
+ * \note This macro is only active when AXOM_DEBUG is defined.
  * \warning This macro calls processAbort() if EXP is false.
  *
  * Usage:
@@ -150,7 +150,7 @@
  * \brief Same as SLIC_ASSERT, but with a custom error message.
  * \param [in] EXP user-supplied boolean expression.
  * \param [in] msg user-supplied message
- * \note This macro is only active when debugging is turned on.
+ * \note This macro is only active when AXOM_DEBUG is defined.
  * \warning This macro calls processAbort() if EXP is false.
  * \see SLIC_ASSERT( EXP )
  *
@@ -183,7 +183,7 @@
  *  a warning is logged, but, in contrast to the similar SLIC_ASSERT macro the
  *  application is not aborted.
  * \param [in] EXP user-supplied boolean expression.
- * \note This macro is only active when debugging is turned on.
+ * \note This macro is only active when AXOM_DEBUG is defined.
  *
  * Usage:
  * \code
@@ -214,7 +214,7 @@
  * \brief Same as SLIC_CHECK, but with a custom error message.
  * \param [in] EXP user-supplied boolean expression.
  * \param [in] msg user-supplied message
- * \note This macro is only active when debugging is turned on.
+ * \note This macro is only active when AXOM_DEBUG is defined.
  * \see SLIC_DEBUG( EXP )
  *
  * Usage:
@@ -316,7 +316,7 @@
  * \def SLIC_DEBUG( msg )
  * \brief Logs a Debug message.
  * \param [in] msg user-supplied message
- * \note The SLIC_Debug macro is active in debug mode.
+ * \note The SLIC_Debug macro is active when AXOM_DEBUG is defined.
  *
  * Usage:
  * \code
@@ -340,7 +340,7 @@
  * \brief Logs an Debug message iff EXP is true
  * \param [in] EXP user-supplied boolean expression.
  * \param [in] msg user-supplied message.
- * \note The SLIC_DEBUG_IF macro is active in debug mode.
+ * \note The SLIC_DEBUG_IF macro is active when AXOM_DEBUG is defined.
  *
  * Usage:
  * \code

--- a/src/axom/slic/streams/GenericOutputStream.cpp
+++ b/src/axom/slic/streams/GenericOutputStream.cpp
@@ -30,7 +30,7 @@ void GenericOutputStream::append(message::Level msgLevel,
                                  const std::string& tagName,
                                  const std::string& fileName,
                                  int line,
-                                 bool AXOM_NOT_USED(filtered_duplicates))
+                                 bool AXOM_UNUSED_PARAM(filtered_duplicates))
 {
   if(m_stream == nullptr)
   {

--- a/src/axom/slic/streams/LumberjackStream.cpp
+++ b/src/axom/slic/streams/LumberjackStream.cpp
@@ -72,7 +72,7 @@ void LumberjackStream::append(message::Level msgLevel,
                               const std::string& tagName,
                               const std::string& fileName,
                               int line,
-                              bool AXOM_NOT_USED(filter_duplicates))
+                              bool AXOM_UNUSED_PARAM(filter_duplicates))
 {
   if(m_lj == nullptr)
   {

--- a/src/axom/slic/streams/SynchronizedStream.cpp
+++ b/src/axom/slic/streams/SynchronizedStream.cpp
@@ -73,7 +73,7 @@ void SynchronizedStream::append(message::Level msgLevel,
                                 const std::string& tagName,
                                 const std::string& fileName,
                                 int line,
-                                bool AXOM_NOT_USED(filter_duplicates))
+                                bool AXOM_UNUSED_PARAM(filter_duplicates))
 {
   if(m_cache == nullptr)
   {

--- a/src/axom/spin/BVH.hpp
+++ b/src/axom/spin/BVH.hpp
@@ -148,7 +148,7 @@ private:
   {
   private:
     template <typename U, typename Ret = decltype(std::declval<U&>()[0])>
-    static Ret array_operator_type(U AXOM_NOT_USED(obj))
+    static Ret array_operator_type(U AXOM_UNUSED_PARAM(obj))
     { }
 
     static std::false_type array_operator_type(...)

--- a/src/axom/spin/policy/LinearBVH.hpp
+++ b/src/axom/spin/policy/LinearBVH.hpp
@@ -294,8 +294,8 @@ void LinearBVH<FloatType, NDIMS, ExecSpace>::findCandidatesImpl(
         int32 count = 0;
         PrimitiveType primitive {objs[i]};
 
-        auto leafAction = [&count](int32 AXOM_NOT_USED(current_node),
-                                   const int32* AXOM_NOT_USED(leaf_nodes)) {
+        auto leafAction = [&count](int32 AXOM_UNUSED_PARAM(current_node),
+                                   const int32* AXOM_UNUSED_PARAM(leaf_nodes)) {
           count++;
         };
 

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -125,7 +125,7 @@ void generate_aabbs(const mint::Mesh* mesh,
     mesh,
     AXOM_LAMBDA(IndexType cellIdx,
                 numerics::Matrix<double> & coords,
-                const IndexType* AXOM_NOT_USED(nodeIds)) {
+                const IndexType* AXOM_UNUSED_PARAM(nodeIds)) {
       primal::BoundingBox<double, NDIMS> range;
 
       for(IndexType inode = 0; inode < nodes_per_dim; ++inode)
@@ -191,7 +191,7 @@ void generate_aabbs_and_centroids(const mint::Mesh* mesh,
     mesh,
     AXOM_LAMBDA(IndexType cellIdx,
                 numerics::Matrix<double> & coords,
-                const IndexType* AXOM_NOT_USED(nodeIds)) {
+                const IndexType* AXOM_UNUSED_PARAM(nodeIds)) {
       BoxType range;
 
       PointType sum(0.0);

--- a/src/cmake/AxomOptions.cmake
+++ b/src/cmake/AxomOptions.cmake
@@ -27,3 +27,12 @@ option(AXOM_ENABLE_TOOLS "Enables Axom Tools" ON)
 
 cmake_dependent_option(AXOM_ENABLE_MPI3 "Enables use of MPI-3 features" OFF "ENABLE_MPI" OFF)
 mark_as_advanced(AXOM_ENABLE_MPI3)
+
+#--------------------------------------------------------------------------
+# Option to control if AXOM_DEFINE compiler define is enabled
+#
+# Possible values are "ON", "OFF" and "DEFAULT"
+# By default AXOM_DEBUG is defined in Debug and RelWithDebInfo configurations
+#--------------------------------------------------------------------------
+set(AXOM_DEBUG_DEFINE "DEFAULT" CACHE STRING "Determines if AXOM_DEBUG is defined.")
+set_property(CACHE AXOM_DEBUG_DEFINE PROPERTY STRINGS "DEFAULT" "ON" "OFF")

--- a/src/cmake/AxomOptions.cmake
+++ b/src/cmake/AxomOptions.cmake
@@ -29,10 +29,10 @@ cmake_dependent_option(AXOM_ENABLE_MPI3 "Enables use of MPI-3 features" OFF "ENA
 mark_as_advanced(AXOM_ENABLE_MPI3)
 
 #--------------------------------------------------------------------------
-# Option to control if AXOM_DEFINE compiler define is enabled
+# Option to control whether AXOM_DEFINE compiler define is enabled
 #
-# Possible values are "ON", "OFF" and "DEFAULT"
-# By default AXOM_DEBUG is defined in Debug and RelWithDebInfo configurations
+# Possible values are: "ON", "OFF" and "DEFAULT"
+# By default, AXOM_DEBUG is defined in Debug and RelWithDebInfo configurations
 #--------------------------------------------------------------------------
-set(AXOM_DEBUG_DEFINE "DEFAULT" CACHE STRING "Determines if AXOM_DEBUG is defined.")
+set(AXOM_DEBUG_DEFINE "DEFAULT" CACHE STRING "Controls whether AXOM_DEBUG compiler define is enabled")
 set_property(CACHE AXOM_DEBUG_DEFINE PROPERTY STRINGS "DEFAULT" "ON" "OFF")

--- a/src/cmake/CMakeBasics.cmake
+++ b/src/cmake/CMakeBasics.cmake
@@ -45,12 +45,6 @@ else()  # Handle bad value for AXOM_DEBUG_DEFINE variable
     "Invalid value for AXOM_DEBUG_DEFINE. Must be 'DEFAULT', 'ON' or 'OFF'; was '${AXOM_DEBUG_DEFINE}'")
 endif()
 
-# Add the AXOM_DEBUG compile definition, if non-empty
-if(AXOM_DEBUG_DEFINE_STRING)
-  set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS "${AXOM_DEBUG_DEFINE_STRING}")
-endif()
-
-
 #------------------------------------------------------------------------------
 # Fortran Configuration
 #------------------------------------------------------------------------------

--- a/src/cmake/CMakeBasics.cmake
+++ b/src/cmake/CMakeBasics.cmake
@@ -20,10 +20,10 @@ include(cmake/AxomMacros.cmake)
 include(cmake/thirdparty/SetupAxomThirdParty.cmake)
 
 #------------------------------------------------------------------------------
-# Set up AXOM_DEBUG, as appropriate, based on config type.
-# Result is stored in AXOM_DEBUG_DEFINE_STRING variable
+# Set up AXOM_DEBUG compiler define string, as appropriate, based on config type.
+# Result is stored in AXOM_DEBUG_DEFINE_STRING cache variable
 #------------------------------------------------------------------------------
-set(AXOM_DEBUG_DEFINE_STRING)
+set(AXOM_DEBUG_DEFINE_STRING "")
 
 # Handle the three valid values for AXOM_DEBUG_DEFINE: {on, off, default}
 string(TOUPPER "${AXOM_DEBUG_DEFINE}" _axom_debug_define_upper)
@@ -40,10 +40,13 @@ elseif("${_axom_debug_define_upper}" MATCHES "DEFAULT")
   else ()
       set(AXOM_DEBUG_DEFINE_STRING "$<$<CONFIG:Debug,RelWithDebInfo>:AXOM_DEBUG>")
   endif()
-else()  # Handle bad value for AXOM_DEBUG_DEFINE variable
+else()  # Handle bad value for AXOM_DEBUG_DEFINE config variable
   message(FATAL_ERROR 
     "Invalid value for AXOM_DEBUG_DEFINE. Must be 'DEFAULT', 'ON' or 'OFF'; was '${AXOM_DEBUG_DEFINE}'")
 endif()
+
+set(AXOM_DEBUG_DEFINE_STRING "${AXOM_DEBUG_DEFINE_STRING}" CACHE STRING "" FORCE)
+mark_as_advanced(AXOM_DEBUG_DEFINE_STRING)
 
 #------------------------------------------------------------------------------
 # Fortran Configuration

--- a/src/cmake/CMakeBasics.cmake
+++ b/src/cmake/CMakeBasics.cmake
@@ -33,11 +33,11 @@ elseif("${_axom_debug_define_upper}" MATCHES "OFF|FALSE")
   # no-op
 elseif("${_axom_debug_define_upper}" MATCHES "DEFAULT")
   # Default behavior is to be on for Debug and RelWithDebInfo configurations and off otherwise
-  if(NOT CMAKE_CONFIGURATION_TYPES)
+  if(NOT CMAKE_CONFIGURATION_TYPES) # This case handles single-config generators, e.g. make
       if( CMAKE_BUILD_TYPE MATCHES "(Debug|RelWithDebInfo)" )
         set(AXOM_DEBUG_DEFINE_STRING "AXOM_DEBUG")
       endif()
-  else ()
+  else () # This case handles multi-config generators, e.g. MSVC
       set(AXOM_DEBUG_DEFINE_STRING "$<$<CONFIG:Debug,RelWithDebInfo>:AXOM_DEBUG>")
   endif()
 else()  # Handle bad value for AXOM_DEBUG_DEFINE config variable

--- a/src/cmake/axom-config.cmake.in
+++ b/src/cmake/axom-config.cmake.in
@@ -14,14 +14,14 @@ if(NOT AXOM_FOUND)
   # Set version and paths
   #----------------------------------------------------------------------------
   
-  set(AXOM_VERSION       "@AXOM_VERSION_FULL@")
-  set(AXOM_VERSION_MAJOR "@AXOM_VERSION_MAJOR@")
-  set(AXOM_VERSION_MINOR "@AXOM_VERSION_MINOR@")
-  set(AXOM_VERSION_PATCH "@AXOM_VERSION_PATCH@")
+  set(AXOM_VERSION          "@AXOM_VERSION_FULL@")
+  set(AXOM_VERSION_MAJOR    "@AXOM_VERSION_MAJOR@")
+  set(AXOM_VERSION_MINOR    "@AXOM_VERSION_MINOR@")
+  set(AXOM_VERSION_PATCH    "@AXOM_VERSION_PATCH@")
   
-  set(AXOM_INSTALL_PREFIX "@AXOM_INSTALL_PREFIX@")
-  set(AXOM_INCLUDE_DIRS "${AXOM_INSTALL_PREFIX}/include")
-
+  set(AXOM_INSTALL_PREFIX   "@AXOM_INSTALL_PREFIX@")
+  set(AXOM_INCLUDE_DIRS     "${AXOM_INSTALL_PREFIX}/include")
+  
   #----------------------------------------------------------------------------
   # Set user configuration options and features
   #----------------------------------------------------------------------------
@@ -59,6 +59,10 @@ if(NOT AXOM_FOUND)
   set(AXOM_USE_RAJA           "@AXOM_USE_RAJA@")
   set(AXOM_USE_SCR            "@AXOM_USE_SCR@")
   set(AXOM_USE_UMPIRE         "@AXOM_USE_UMPIRE@")
+
+  # Configration for Axom compiler defines
+  set(AXOM_DEBUG_DEFINE         "@AXOM_DEBUG_DEFINE@")
+  set(AXOM_DEBUG_DEFINE_STRING  "@AXOM_DEBUG_DEFINE_STRING@")
 
   #----------------------------------------------------------------------------
   # Bring in required  dependencies for this axom configuration

--- a/src/docs/sphinx/quickstart_guide/config_build.rst
+++ b/src/docs/sphinx/quickstart_guide/config_build.rst
@@ -280,46 +280,51 @@ CMake Configuration Options
 
 Here are the key build system options in Axom:
 
-+------------------------------+---------+--------------------------------+
-| OPTION                       | Default | Description                    |
-+==============================+=========+================================+
-| AXOM_ENABLE_ALL_COMPONENTS   | ON      | Enable all components          |
-|                              |         | by default                     |
-+------------------------------+---------+--------------------------------+
-| AXOM_ENABLE_<FOO>            | ON      | Enables the axom component     |
-|                              |         | named 'foo'                    |
-|                              |         |                                |
-|                              |         | (e.g. AXOM_ENABLE_SIDRE)       |
-|                              |         | for the sidre component        |
-+------------------------------+---------+--------------------------------+
-| AXOM_ENABLE_DOCS             | ON      | Builds documentation           |
-+------------------------------+---------+--------------------------------+
-| AXOM_ENABLE_EXAMPLES         | ON      | Builds examples                |
-+------------------------------+---------+--------------------------------+
-| AXOM_ENABLE_TESTS            | ON      | Builds unit tests              |
-+------------------------------+---------+--------------------------------+
-| AXOM_ENABLE_TOOLS            | ON      | Builds tools                   |
-+------------------------------+---------+--------------------------------+
-| BUILD_SHARED_LIBS            | OFF     | Build shared libraries.        |
-|                              |         | Default is Static libraries    |
-+------------------------------+---------+--------------------------------+
-| ENABLE_ALL_WARNINGS          | ON      | Enable extra compiler warnings |
-|                              |         | in all build targets           |
-+------------------------------+---------+--------------------------------+
-| ENABLE_BENCHMARKS            | OFF     | Enable google benchmark        |
-+------------------------------+---------+--------------------------------+
-| ENABLE_CODECOV               | ON      | Enable code coverage via gcov  |
-+------------------------------+---------+--------------------------------+
-| ENABLE_FORTRAN               | ON      | Enable Fortran compiler        |
-|                              |         | support                        |
-+------------------------------+---------+--------------------------------+
-| ENABLE_MPI                   | OFF     | Enable MPI                     |
-+------------------------------+---------+--------------------------------+
-| ENABLE_OPENMP                | OFF     | Enable OpenMP                  |
-+------------------------------+---------+--------------------------------+
-| ENABLE_WARNINGS_AS_ERRORS    | OFF     | Compiler warnings treated as   |
-|                              |         | errors.                        |
-+------------------------------+---------+--------------------------------+
++------------------------------+---------+----------------------------------------+
+| OPTION                       | Default | Description                            |
++==============================+=========+========================================+
+| AXOM_DEBUG_DEFINE            | DEFAULT | Controls whether the `AXOM_DEBUG`      |
+|                              |         | compiler define is enabled             |
+|                              |         |                                        |
+|                              |         | By DEFAULT, it is enabled for          |
+|                              |         | `Debug` and `RelWithDebInfo` configs   |
+|                              |         | but this can be overridden by setting  |
+|                              |         | `AXOM_DEBUG_DEFINE` to `ON` or `OFF`   |
++------------------------------+---------+----------------------------------------+
+| AXOM_ENABLE_ALL_COMPONENTS   | ON      | Enable all components by default       |
++------------------------------+---------+----------------------------------------+
+| AXOM_ENABLE_<FOO>            | ON      | Enables the axom component named 'foo' |
+|                              |         |                                        |
+|                              |         | (e.g. AXOM_ENABLE_SIDRE)               |
+|                              |         | for the sidre component                |
++------------------------------+---------+----------------------------------------+
+| AXOM_ENABLE_DOCS             | ON      | Builds documentation                   |
++------------------------------+---------+----------------------------------------+
+| AXOM_ENABLE_EXAMPLES         | ON      | Builds examples                        |
++------------------------------+---------+----------------------------------------+
+| AXOM_ENABLE_TESTS            | ON      | Builds unit tests                      |
++------------------------------+---------+----------------------------------------+
+| AXOM_ENABLE_TOOLS            | ON      | Builds tools                           |
++------------------------------+---------+----------------------------------------+
+| BUILD_SHARED_LIBS            | OFF     | Build shared libraries.                |
+|                              |         | Default is Static libraries            |
++------------------------------+---------+----------------------------------------+
+| ENABLE_ALL_WARNINGS          | ON      | Enable extra compiler warnings         |
+|                              |         | in all build targets                   |
++------------------------------+---------+----------------------------------------+
+| ENABLE_BENCHMARKS            | OFF     | Enable google benchmark                |
++------------------------------+---------+----------------------------------------+
+| ENABLE_CODECOV               | ON      | Enable code coverage via gcov          |
++------------------------------+---------+----------------------------------------+
+| ENABLE_FORTRAN               | ON      | Enable Fortran compiler support        |
++------------------------------+---------+----------------------------------------+
+| ENABLE_MPI                   | OFF     | Enable MPI                             |
++------------------------------+---------+----------------------------------------+
+| ENABLE_OPENMP                | OFF     | Enable OpenMP                          |
++------------------------------+---------+----------------------------------------+
+| ENABLE_WARNINGS_AS_ERRORS    | OFF     | Compiler warnings treated as errors    |
+|                              |         | errors.                                |
++------------------------------+---------+----------------------------------------+
 
 If ``AXOM_ENABLE_ALL_COMPONENTS`` is OFF, you must explicitly enable the desired
 components (other than 'core', which is always enabled).


### PR DESCRIPTION
# Summary

- This PR is a bugfix to enable `AXOM_DEBUG` to propagate to axom's user libraries
- It attaches the `AXOM_DEBUG` define to axom's `core` component instead of to all targets in the axom project.
- It also introduces the `AXOM_DEBUG_DEFINE` configuration option, which can allow users to override when
  `AXOM_DEBUG` is defined.
- This addresses the following issues:
    -  #279 
    - #440 
    - Unfortunately, I was not able to move `AXOM_DEBUG` to `axom/config.hpp` due to how `config.hpp` is used by multi-config generators such as visual studio. Specifically, all configurations point to `axom/config.hpp`, and I did not find a clean way to modify this without introducing additional compiler defines.
 - This PR also renames the `AXOM_NOT_USED` macro (in `core/Macros.hpp`) to `AXOM_UNUSED_PARAM` since this is more consistent with the `AXOM_UNUSED_PARAM` and the `AXOM_DEBUG_PARAM` macros
- We discussed this issue at the axom team meeting on 11/1/2021.

I will hold off on merging this until after the `axom@0.6.0` release

#### TODO
- [x] Update RELEASE-NOTES (after `axom@v0.6.0` release)