### PR TITLE
Improves robustness of `SignedDistance` query

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ stages:
     - ASSIGN_ID=$(if [[ -n "${JOBID}" ]]; then echo "--jobid=${JOBID}"; fi)
     # BUILD + TEST
     - echo -e "\e[0Ksection_start:$(date +%s):src_build_and_test\r\e[0KSource Build and Test ${CI_PROJECT_NAME}"
-    - ${ALLOC_COMMAND} ${ASSIGN_ID} python3 scripts/llnl_scripts/build_src.py -v --host-config ${HOST_CONFIG} --extra-cmake-options -DENABLE_DOCS=OFF
+    - ${ALLOC_COMMAND} ${ASSIGN_ID} python3 scripts/llnl_scripts/build_src.py -v --host-config ${HOST_CONFIG} --extra-cmake-options '-DENABLE_DOCS=OFF ${EXTRA_CMAKE_OPTIONS}' --build-type ${BUILD_TYPE:-Debug}
     - echo -e "\e[0Ksection_end:$(date +%s):src_build_and_test\r\e[0K"
   artifacts:
     paths:

--- a/.gitlab/build_ruby.yml
+++ b/.gitlab/build_ruby.yml
@@ -63,6 +63,14 @@ ruby-clang_10_0_0-src:
     HOST_CONFIG: "ruby-toss_3_x86_64_ib-${COMPILER}.cmake"
   extends: .src_build_on_ruby
 
+ruby-clang_10_0_0-release-src:
+  variables:
+    COMPILER: "clang@10.0.0"
+    HOST_CONFIG: "ruby-toss_3_x86_64_ib-${COMPILER}.cmake"
+    BUILD_TYPE: "Release"
+    EXTRA_CMAKE_OPTIONS: "-DAXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS:BOOL=ON"
+  extends: .src_build_on_ruby
+
 ruby-clang_9_0_0-src:
   variables:
     COMPILER: "clang@9.0.0"

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,7 +22,11 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ###  Added
 - Added a config variable, `AXOM_DEBUG_DEFINE` to control whether the `AXOM_DEBUG` compiler define is enabled.
   By `DEFAULT`, it is enabled for `Debug` and `RelWithDebInfo` configurations, but this can be overriden
-  by setting `AXOM_DEBUG_DEFINE` to `ON` or `OFF`. 
+  by setting `AXOM_DEBUG_DEFINE` to `ON` or `OFF`.
+- `axom::Array` is now GPU-compatible, in particular via a memory space template parameter and via
+  extensions to `axom::ArrayView` that allow for copying into kernels and transfers between memory spaces.
+- Adds some utility arithmetic operators for adding and subracting `primal::Point`s and `primal::Vector`s
+
 ###  Changed
 - Renamed `AXOM_NOT_USED` macro to `AXOM_UNUSED_PARAM` for better consistency with other Axom macros
 - Added `explicit` to `axom::Inlet::InletVector` constructors and added a constructor that accepts a `double*`
@@ -31,6 +35,11 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ###  Fixed
 - The `AXOM_DEBUG` compiler define is now properly exported via the `axom` CMake target when it is enabled
+- Added tolerance parameter `EPS` to `primal::closest_point()` operator. This effectively snaps
+  closest points to the triangle boundaries vertices and edges when they are within `EPS`,
+  improving consistency when, e.g., querying multiple triangles from the same mesh.
+- Fixed regression in `SignedDistance` queries for query points closest to edges or vertices
+  of the input triangle mesh
 
 
 ## [Version 0.6.0] - Release date 2021-11-04
@@ -76,8 +85,6 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Added Sidre function `View::clear()`.
 - Core now provides an `axom::ArrayView` that provides view/indexing semantics over a raw pointer.
   This replaces the external buffer logic previously provided by `axom::Array`.
-- `axom::Array` is now GPU-compatible, in particular via a memory space template parameter and via 
-  extensions to `axom::ArrayView` that allow for copying into kernels and transfers between memory spaces.
 
 ### Changed
 - `MFEMSidreDataCollection` now reuses FESpace/QSpace objects with the same basis

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ jobs:
         VM_ImageName: 'ubuntu-18.04'
         Compiler_ImageName: '$(CLANG10_IMAGENAME)'
         CMAKE_EXTRA_FLAGS: '-DBUILD_SHARED_LIBS=ON -DAXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS:BOOL=ON'
+        BUILD_TYPE: 'Release'
         COMPILER: 'clang++'
         TEST_TARGET: 'linux_clang10'
         HOST_CONFIG: 'docker-linux-ubuntu18.04-x86_64-clang@10.0.0'
@@ -90,7 +91,7 @@ jobs:
   - script:  |
       echo " -e $TEST_TARGET -e $COMPILER -e $DO_BUILD -e $DO_TEST -e $CMAKE_EXTRA_FLAGS $(Compiler_ImageName) ./scripts/azure-pipelines/linux-build_and_test.sh"
       docker run --rm --user='root' -v `pwd`:/home/axom/axom $(Compiler_ImageName) chown -R axom /home/axom
-      docker run --rm -v `pwd`:/home/axom/axom -e TEST_TARGET -e COMPILER -e DO_BUILD -e DO_TEST -e DO_CLEAN -e HOST_CONFIG -e CMAKE_EXTRA_FLAGS $(Compiler_ImageName) ./axom/scripts/azure-pipelines/linux-build_and_test.sh
+      docker run --rm -v `pwd`:/home/axom/axom -e TEST_TARGET -e COMPILER -e DO_BUILD -e DO_TEST -e DO_CLEAN -e HOST_CONFIG -e CMAKE_EXTRA_FLAGS -e BUILD_TYPE $(Compiler_ImageName) ./axom/scripts/azure-pipelines/linux-build_and_test.sh
 
     condition: eq( variables['Agent.OS'], 'Linux')
     displayName: 'Linux Build & Test ($(TEST_TARGET))'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
       linux_clang10:
         VM_ImageName: 'ubuntu-18.04'
         Compiler_ImageName: '$(CLANG10_IMAGENAME)'
-        CMAKE_EXTRA_FLAGS: '-DBUILD_SHARED_LIBS=ON '
+        CMAKE_EXTRA_FLAGS: '-DBUILD_SHARED_LIBS=ON -DAXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS:BOOL=ON'
         COMPILER: 'clang++'
         TEST_TARGET: 'linux_clang10'
         HOST_CONFIG: 'docker-linux-ubuntu18.04-x86_64-clang@10.0.0'

--- a/scripts/azure-pipelines/linux-build_and_test.sh
+++ b/scripts/azure-pipelines/linux-build_and_test.sh
@@ -18,16 +18,19 @@ function or_die () {
 }
 
 or_die cd axom
-git submodule init 
-git submodule update 
+git submodule init
+git submodule update
 
 echo HOST_CONFIG
 echo $HOST_CONFIG
 
+export BUILD_TYPE=${BUILD_TYPE:-Debug}
+
+
 if [[ "$DO_BUILD" == "yes" ]] ; then
     echo "~~~~~~ RUNNING CMAKE ~~~~~~~~"
-    or_die ./config-build.py -hc /home/axom/axom/host-configs/docker/${HOST_CONFIG}.cmake -DENABLE_GTEST_DEATH_TESTS=ON ${CMAKE_EXTRA_FLAGS}
-    or_die cd build-$HOST_CONFIG-debug
+    or_die ./config-build.py -hc /home/axom/axom/host-configs/docker/${HOST_CONFIG}.cmake -bt ${BUILD_TYPE} -DENABLE_GTEST_DEATH_TESTS=ON ${CMAKE_EXTRA_FLAGS}
+    or_die cd build-$HOST_CONFIG-${BUILD_TYPE,,}
     echo "~~~~~~ BUILDING ~~~~~~~~"
     if [[ ${CMAKE_EXTRA_FLAGS} == *COVERAGE* ]] ; then
         or_die make -j 10

--- a/scripts/llnl_scripts/build_src.py
+++ b/scripts/llnl_scripts/build_src.py
@@ -109,7 +109,7 @@ def main():
             res = build_and_test_host_configs(repo_dir, job_name, timestamp, False,
                                               report_to_stdout = opts["verbose"],
                                               extra_cmake_options = opts["extra_cmake_options"],
-                                              build_type = opts["build_type"])
+                                              build_type = opts["buildtype"])
         # Otherwise try to build a specific host-config
         else:
             # Command-line arg has highest priority
@@ -161,7 +161,7 @@ def main():
             res = build_and_test_host_config(test_root, hostconfig_path,
                                              report_to_stdout = opts["verbose"],
                                              extra_cmake_options = opts["extra_cmake_options"],
-                                             build_type = opts["build_type"])
+                                             build_type = opts["buildtype"])
 
         # Archive logs
         if opts["archive"] != "":

--- a/scripts/llnl_scripts/build_src.py
+++ b/scripts/llnl_scripts/build_src.py
@@ -9,7 +9,7 @@
 """
  file: build_src.py
 
- description: 
+ description:
   Builds all Axom with the host-configs for the current machine.
 
 """
@@ -37,6 +37,12 @@ def parse_args():
                       dest="hostconfig",
                       default="",
                       help="Specific host-config file to build (Tries multiple known paths to locate given file)")
+    # Build type for the configuration
+    parser.add_option("--build-type",
+                      dest="buildtype",
+                      default="Debug",
+                      choices = ("Debug", "RelWithDebInfo", "Release", "MinSizeRel"),
+                      help="The CMake build type to use")
     # Extra cmake options to pass to config build
     parser.add_option("--extra-cmake-options",
                       dest="extra_cmake_options",
@@ -56,7 +62,7 @@ def parse_args():
     # parse args
     ###############
     opts, extras = parser.parse_args()
-    # we want a dict b/c the values could 
+    # we want a dict b/c the values could
     # be passed without using optparse
     opts = vars(opts)
 
@@ -100,7 +106,10 @@ def main():
         # Default to build all SYS_TYPE's host-configs in host-config/
         build_all = not opts["hostconfig"] and not opts["automation"]
         if build_all:
-            res = build_and_test_host_configs(repo_dir, job_name, timestamp, False, opts["verbose"], opts["extra_cmake_options"])
+            res = build_and_test_host_configs(repo_dir, job_name, timestamp, False,
+                                              report_to_stdout = opts["verbose"],
+                                              extra_cmake_options = opts["extra_cmake_options"],
+                                              build_type = opts["build_type"])
         # Otherwise try to build a specific host-config
         else:
             # Command-line arg has highest priority
@@ -149,7 +158,10 @@ def main():
             test_root = get_build_and_test_root(repo_dir, timestamp)
             test_root = "{0}_{1}".format(test_root, hostconfig.replace(".cmake", "").replace("@","_"))
             os.mkdir(test_root)
-            res = build_and_test_host_config(test_root, hostconfig_path, opts["verbose"], opts["extra_cmake_options"])
+            res = build_and_test_host_config(test_root, hostconfig_path,
+                                             report_to_stdout = opts["verbose"],
+                                             extra_cmake_options = opts["extra_cmake_options"],
+                                             build_type = opts["build_type"])
 
         # Archive logs
         if opts["archive"] != "":

--- a/scripts/llnl_scripts/llnl_lc_build_tools.py
+++ b/scripts/llnl_scripts/llnl_lc_build_tools.py
@@ -8,7 +8,7 @@
 """
  file: llnl_lc_uberenv_install_tools.py
 
- description: 
+ description:
   helpers for installing axom tpls on llnl lc systems.
 
 """
@@ -232,7 +232,7 @@ def archive_tpl_logs(prefix, job_name, timestamp):
             os.makedirs(archive_spec_dir)
 
         copy_if_exists(tpl_log, pjoin(archive_spec_dir, "output.log.spack.txt"))
-        
+
         # Note: There should only be one of these per spec
         config_spec_logs = glob.glob(pjoin(build_and_test_root, "output.log.*-" + spec + ".configure.txt"))
         if len(config_spec_logs) > 0:
@@ -296,7 +296,7 @@ def uberenv_build(prefix, spec, project_file, mirror_path):
     cmd += "--mirror=\"{0}\" ".format(mirror_path)
     if project_file:
         cmd += "--project-json=\"{0}\" ".format(project_file)
-        
+
     spack_tpl_build_log = pjoin(prefix,"output.log.spack.tpl.build.%s.txt" % spec.replace(" ", "_"))
     print("[starting tpl install of spec %s]" % spec)
     print("[log file: %s]" % spack_tpl_build_log)
@@ -322,7 +322,10 @@ def uberenv_build(prefix, spec, project_file, mirror_path):
 # helpers for testing a set of host configs
 ############################################################
 
-def build_and_test_host_config(test_root, host_config, report_to_stdout = False, extra_cmake_options = ""):
+def build_and_test_host_config(test_root, host_config, 
+                               report_to_stdout = False,
+                               extra_cmake_options = "",
+                               build_type = "Debug"):
     host_config_root = get_host_config_root(host_config)
     # setup build and install dirs
     build_dir   = pjoin(test_root,"build-%s"   % host_config_root)
@@ -335,7 +338,7 @@ def build_and_test_host_config(test_root, host_config, report_to_stdout = False,
     cfg_output_file = pjoin(test_root,"output.log.%s.configure.txt" % host_config_root)
     print("[starting configure of %s]" % host_config)
     print("[log file: %s]" % cfg_output_file)
-    res = sexe("python config-build.py -bp %s -ip %s -hc %s %s" % (build_dir, install_dir, host_config, extra_cmake_options),
+    res = sexe("python config-build.py -bp %s -ip %s -bt %s -hc %s %s" % (build_dir, install_dir, build_type, host_config, extra_cmake_options),
                output_file = cfg_output_file,
                echo=True)
 
@@ -346,11 +349,11 @@ def build_and_test_host_config(test_root, host_config, report_to_stdout = False,
     if res != 0:
         print("[ERROR: Configure for host-config: %s failed]\n" % host_config)
         return res
-        
+
     ####
     # build, test, and install
     ####
-    
+
     # build the code
     bld_output_file =  pjoin(build_dir,"output.log.make.txt")
     print("[starting build]")
@@ -512,7 +515,13 @@ def build_and_test_host_config(test_root, host_config, report_to_stdout = False,
     return 0
 
 
-def build_and_test_host_configs(prefix, job_name, timestamp, use_generated_host_configs, report_to_stdout = False, extra_cmake_options = ""):
+def build_and_test_host_configs(prefix,
+                                job_name,
+                                timestamp,
+                                use_generated_host_configs,
+                                report_to_stdout = False,
+                                extra_cmake_options = "",
+                                build_type = "Debug"):
     host_configs = get_host_configs_for_current_machine(prefix, use_generated_host_configs)
     if len(host_configs) == 0:
         log_failure(prefix,"[ERROR: No host configs found at %s]" % prefix)
@@ -524,14 +533,17 @@ def build_and_test_host_configs(prefix, job_name, timestamp, use_generated_host_
 
     test_root =  get_build_and_test_root(prefix, timestamp)
     os.mkdir(test_root)
-    write_build_info(pjoin(test_root,"info.json"), job_name) 
+    write_build_info(pjoin(test_root,"info.json"), job_name)
     ok  = []
     bad = []
     for host_config in host_configs:
         build_dir = get_build_dir(test_root, host_config)
 
         start_time = time.time()
-        if build_and_test_host_config(test_root, host_config, report_to_stdout, extra_cmake_options) == 0:
+        if build_and_test_host_config(test_root, host_config,
+                                      report_to_stdout = report_to_stdout,
+                                      extra_cmake_options=extra_cmake_options,
+                                      build_type = build_type) == 0:
             ok.append(host_config)
             log_success(build_dir, job_name, timestamp)
         else:
@@ -566,8 +578,7 @@ def build_and_test_host_configs(prefix, job_name, timestamp, use_generated_host_
 
 def set_group_and_perms(directory):
     """
-    Sets the proper group and access permissions of given input
-    directory. 
+    Sets the proper group and access permissions of given input directory.
     """
 
     skip = True
@@ -657,7 +668,7 @@ def full_build_and_test_of_tpls(builds_dir, job_name, timestamp, spec, report_to
             src_build_failed = True
         else:
             print("[SUCCESS: Build and test of src vs tpls test passed.]\n")
- 
+
     # set proper perms for installed tpls
     set_group_and_perms(prefix)
 
@@ -861,7 +872,7 @@ def get_compiler_from_spec(spec):
     compiler = spec
     for c in ['~', '+']:
         index = compiler.find(c)
-        if index != -1: 
+        if index != -1:
             compiler = compiler[:index]
     return compiler
 

--- a/src/axom/core/execution/execution_space.hpp
+++ b/src/axom/core/execution/execution_space.hpp
@@ -86,7 +86,7 @@ struct execution_space
   static int allocatorID() noexcept { return axom::INVALID_ALLOCATOR_ID; };
 };
 
-} /* namespace axom */
+}  // namespace axom
 
 // execution_space traits specialization
 #include "axom/core/execution/internal/seq_exec.hpp"
@@ -100,4 +100,4 @@ struct execution_space
   #include "axom/core/execution/internal/cuda_exec.hpp"
 #endif
 
-#endif /* AXOM_SPIN_EXECUTIONSPACE_HPP_ */
+#endif  // AXOM_EXECUTIONSPACE_HPP_

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -27,6 +27,9 @@ namespace primal
 template <typename T, int NDIMS>
 class Vector;
 
+template <typename T, int NDIMS>
+class Point;
+
 /// \name Forward Declared Overloaded Operators
 /// @{
 
@@ -39,6 +42,26 @@ class Vector;
 template <typename T, int NDIMS>
 AXOM_HOST_DEVICE Vector<T, NDIMS> operator+(const Vector<T, NDIMS>& A,
                                             const Vector<T, NDIMS>& B);
+
+/*!
+ * \brief Adds vector \a V to point \a P and stores the result into a new point
+ * \param [in] P point on the left-hand side.
+ * \param [in] V vector on the right-hand side.
+ * \return resulting point, \f$ p'_i = p_i + v_i \forall i \f$
+ */
+template <typename T, int NDIMS>
+AXOM_HOST_DEVICE Point<T, NDIMS> operator+(const Point<T, NDIMS>& P,
+                                           const Vector<T, NDIMS>& V);
+
+/*!
+ * \brief Adds vector \a V to point \a P and stores the result into a new point
+ * \param [in] V vector on the left-hand side.
+ * \param [in] P point on the right-hand side.
+ * \return resulting point, \f$ p'_i = v_i + p_i \forall i \f$
+ */
+template <typename T, int NDIMS>
+AXOM_HOST_DEVICE Point<T, NDIMS> operator+(const Vector<T, NDIMS>& V,
+                                           const Point<T, NDIMS>& P);
 
 /*!
  * \brief Subtracts vectors A, B and stores the result into a new vector C
@@ -548,6 +571,23 @@ inline Vector<T, NDIMS> operator+(const Vector<T, NDIMS>& vec1,
   Vector<T, NDIMS> result(vec1);
   result += vec2;
   return result;
+}
+
+//------------------------------------------------------------------------------
+template <typename T, int NDIMS>
+AXOM_HOST_DEVICE Point<T, NDIMS> operator+(const Point<T, NDIMS>& P,
+                                           const Vector<T, NDIMS>& V)
+{
+  Point<T, NDIMS> result(P);
+  result.array() += V.array();
+  return result;
+}
+
+template <typename T, int NDIMS>
+AXOM_HOST_DEVICE Point<T, NDIMS> operator+(const Vector<T, NDIMS>& V,
+                                           const Point<T, NDIMS>& P)
+{
+  return P + V;
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -74,6 +74,16 @@ AXOM_HOST_DEVICE Vector<T, NDIMS> operator-(const Vector<T, NDIMS>& A,
                                             const Vector<T, NDIMS>& B);
 
 /*!
+ * \brief Subtracts Point \a t from Point \a h, yielding a vector
+ * \param [in] h the head of the resulting vector
+ * \param [in] t the tail of the resulting vector
+ * \return resulting vector, \f$ V_i = h_i - t_i \forall i \f$
+ */
+template <typename T, int NDIMS>
+AXOM_HOST_DEVICE Vector<T, NDIMS> operator-(const Point<T, NDIMS>& h,
+                                            const Point<T, NDIMS>& t);
+
+/*!
  * \brief Unary negation of a vector instance.
  * \param [in] vec1 vector instance to negate.
  * \return C resulting vector from unary negation.
@@ -607,6 +617,14 @@ inline Vector<T, NDIMS> operator-(const Vector<T, NDIMS>& vec1,
   Vector<T, NDIMS> result(vec1);
   result -= vec2;
   return result;
+}
+
+//------------------------------------------------------------------------------
+template <typename T, int NDIMS>
+AXOM_HOST_DEVICE Vector<T, NDIMS> operator-(const Point<T, NDIMS>& h,
+                                            const Point<T, NDIMS>& t)
+{
+  return Vector<T, NDIMS>(t, h);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_vector.cpp
+++ b/src/axom/primal/tests/primal_vector.cpp
@@ -4,8 +4,10 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "gtest/gtest.h"
+#include "axom/slic.hpp"
 
 #include "axom/primal/geometry/Vector.hpp"
+#include "axom/primal/geometry/Point.hpp"
 
 #include "axom/core/execution/execution_space.hpp"  // for execution_space traits
 #include "axom/core/execution/for_all.hpp"          // for_all()
@@ -296,6 +298,38 @@ TEST(primal_vector, vector_zero)
 }
 
 //------------------------------------------------------------------------------
+TEST(primal_vector, add_point_vector)
+{
+  constexpr int DIM = 3;
+  using QPt = primal::Point<double, DIM>;
+  using QVec = primal::Vector<double, DIM>;
+
+  {
+    QPt one {1.};
+    QVec zero {0.0};
+    EXPECT_EQ(one, one + zero);
+    EXPECT_EQ(one, zero + one);
+    EXPECT_EQ(zero + one, one + zero);
+  }
+
+  {
+    QPt pt {1.23, 4.56, 7.89};
+    QVec vec {.23, .56, .89};
+
+    EXPECT_EQ(pt + vec, vec + pt);
+
+    QPt pv = pt + -vec;
+    QPt vp = -vec + pt;
+    QPt exp {1, 4, 7};
+    for(int i = 0; i < DIM; ++i)
+    {
+      EXPECT_DOUBLE_EQ(pv[i], vp[i]);
+      EXPECT_DOUBLE_EQ(exp[i], pv[i]);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
 AXOM_CUDA_TEST(primal_numeric_array, numeric_array_check_policies)
 {
   using seq_exec = axom::SEQ_EXEC;
@@ -319,19 +353,13 @@ AXOM_CUDA_TEST(primal_numeric_array, numeric_array_check_policies)
 }
 
 //----------------------------------------------------------------------
-//----------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
 
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_vector.cpp
+++ b/src/axom/primal/tests/primal_vector.cpp
@@ -330,6 +330,39 @@ TEST(primal_vector, add_point_vector)
 }
 
 //------------------------------------------------------------------------------
+TEST(primal_vector, subtract_points)
+{
+  constexpr int DIM = 3;
+  using QPt = primal::Point<double, DIM>;
+  using QVec = primal::Vector<double, DIM>;
+
+  {
+    QPt zeroPt {0.0};
+    QPt onePt {1.0};
+
+    QVec oneVec {1.0};
+
+    EXPECT_EQ(oneVec, onePt - zeroPt);
+    EXPECT_EQ(-oneVec, zeroPt - onePt);
+  }
+
+  {
+    QPt head {1.23, 4.56, 7.89};
+    QPt tail {.23, .56, .89};
+
+    QVec diff = head - tail;
+    QVec exp {1, 4, 7};
+    QVec ctor(tail, head);
+
+    for(int i = 0; i < DIM; ++i)
+    {
+      EXPECT_DOUBLE_EQ(exp[i], diff[i]);
+      EXPECT_DOUBLE_EQ(ctor[i], diff[i]);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
 AXOM_CUDA_TEST(primal_numeric_array, numeric_array_check_policies)
 {
   using seq_exec = axom::SEQ_EXEC;

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -142,6 +142,8 @@ private:
     TriangleType minTri;
     /// Weighted sum of normals when closest pt is on edge or vertex
     VectorType sumNormals {};
+    /// Count of the number of elements found at the current closest distance
+    int minCount {0};
   };
 
 public:
@@ -627,6 +629,7 @@ inline void SignedDistance<NDIMS, ExecSpace>::checkCandidate(
       if(computeNormal && shouldClearNormals)
       {
         currMin.sumNormals = VectorType {};
+        currMin.minCount = 0;
       }
 
       shouldUpdateNormals = (computeNormal && is_cpt_shared);
@@ -641,6 +644,7 @@ inline void SignedDistance<NDIMS, ExecSpace>::checkCandidate(
     if(shouldUpdateNormals)
     {
       VectorType norm = surface_elems[ei].normal();
+      ++currMin.minCount;
 
       switch(cpt_type)
       {

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -592,7 +592,7 @@ inline void SignedDistance<NDIMS, ExecSpace>::checkCandidate(
   using axom::utilities::isNearlyEqual;
   using detail::getClosestPointLocType;
   using detail::isClosestPointTypeShared;
-  constexpr double EPS = 1e-8;
+  constexpr double EPS = 1e-12;
 
   for(int ei = 0; ei < num_candidates; ei++)
   {

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -87,7 +87,7 @@ enum class ClosestPointLocType
 };
 
 /// Converts from \a loc code returned by primal::closest_point() to a \a ClosestPointLocType enum
-inline ClosestPointLocType getClosestPointLocType(int loc)
+AXOM_HOST_DEVICE inline ClosestPointLocType getClosestPointLocType(int loc)
 {
   SLIC_ASSERT_MSG(loc >= -3,
                   "Invalid closest point location type: "
@@ -108,7 +108,7 @@ inline ClosestPointLocType getClosestPointLocType(int loc)
 }
 
 /// A \a ClosestPointLocType is shared for a vertex or edge, unshared otherwise
-inline bool isClosestPointTypeShared(ClosestPointLocType cpt)
+AXOM_HOST_DEVICE inline bool isClosestPointTypeShared(ClosestPointLocType cpt)
 {
   return cpt == ClosestPointLocType::edge || cpt == ClosestPointLocType::vertex;
 }
@@ -656,10 +656,6 @@ inline void SignedDistance<NDIMS, ExecSpace>::checkCandidate(
           // normal of a face potentially sharing a vertex
           double alpha = surface_elems[ei].angle(candidate_loc);
           currMin.sumNormals += (norm.unitVector() * alpha);
-        }
-        else
-        {
-          SLIC_WARNING("Triangle for closest point was degenerate");
         }
         break;
       default:

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -653,7 +653,7 @@ inline void SignedDistance<NDIMS, ExecSpace>::checkCandidate(
         // potentially-adjacent face
         currMin.sumNormals += norm;
         break;
-      case detail::ClosestPointLocType::face:
+      case detail::ClosestPointLocType::vertex:
         if(!surface_elems[ei].degenerate())
         {
           // Candidate closest point is on a vertex - add the angle-weighted

--- a/src/axom/quest/examples/quest_signed_distance_interface.cpp
+++ b/src/axom/quest/examples/quest_signed_distance_interface.cpp
@@ -78,7 +78,7 @@ struct Arguments
   bool use_shared {false};
   bool use_batched_query {false};
   bool ignore_signs {false};
-  quest::SignedDistExec exec_space;
+  quest::SignedDistExec exec_space {quest::SignedDistExec::CPU};
 
   void parse(int argc, char** argv, axom::CLI::App& app)
   {

--- a/src/axom/quest/tests/CMakeLists.txt
+++ b/src/axom/quest/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ set(quest_tests
     quest_vertex_weld.cpp
    )
 
-blt_list_append(TO       quest_tests 
+blt_list_append(TO       quest_tests
                 IF       C2C_FOUND
                 ELEMENTS quest_c2c_reader.cpp)
 
@@ -96,7 +96,7 @@ set(quest_mpi_tests
     )
 
 # Optionally, add tests that require AXOM_DATA_DIR
-blt_list_append(TO       quest_mpi_tests 
+blt_list_append(TO       quest_mpi_tests
                 IF       AXOM_DATA_DIR
                 ELEMENTS quest_inout_interface.cpp )
 
@@ -182,39 +182,40 @@ if (ENABLE_MPI AND AXOM_ENABLE_SIDRE)
     # Add resolution tests for each dataset and resolution
     if(AXOM_DATA_DIR)
         set(quest_data_dir  ${AXOM_DATA_DIR}/quest)
-        
-        set(quest_regression_datasets
-            sphere
-        )
-        set(quest_regression_resolutions
-            16
-        )
 
+        # Datasets contain a mesh name and resolution delimited by a colon
+        set(quest_regression_datasets sphere:16)
+
+        # Add additional regression datasets when its config variable is defined
         blt_list_append(
             TO          quest_regression_datasets
-            ELEMENTS    aatbase_3_binary
-                        cap
-                        naca0012
-                        plane_binary
-                        plane_simp
-            IF          AXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS
-           )
-        blt_list_append(
-            TO          quest_regression_resolutions
-            ELEMENTS    32
+            ELEMENTS    aatbase_3_binary:16
+                        aatbase_3_binary:32
+                        cap:16
+                        cap:32
+                        naca0012:16
+                        naca0012:32
+                        plane_binary:16
+                        plane_binary:32
+                        plane_simp:16
+                        plane_simp:32
+                        sphere:32
             IF          AXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS
            )
 
-        foreach(dataset ${quest_regression_datasets})
-            foreach(res ${quest_regression_resolutions})
-                axom_add_test(
-                    NAME quest_regression_${dataset}_${res}
-                    COMMAND ${test_name}
-                            --mesh ${quest_data_dir}/${dataset}.stl
-                            --baseline ${quest_data_dir}/regression/${dataset}_${res}_baseline.root
-                    NUM_MPI_TASKS 1
-                )
-            endforeach()
+        foreach(el ${quest_regression_datasets})
+            # Extract mesh and resolution from the dataset string
+            string(REPLACE ":" ";" _dataset_res ${el})
+            list(GET _dataset_res 0 _dataset)
+            list(GET _dataset_res 1 _res)
+
+            axom_add_test(
+                NAME quest_regression_${_dataset}_${_res}
+                COMMAND ${test_name}
+                        --mesh ${quest_data_dir}/${_dataset}.stl
+                        --baseline ${quest_data_dir}/regression/${_dataset}_${_res}_baseline.root
+                NUM_MPI_TASKS 1
+            )
         endforeach()
     endif()
 endif()

--- a/src/axom/quest/tests/CMakeLists.txt
+++ b/src/axom/quest/tests/CMakeLists.txt
@@ -184,13 +184,15 @@ if (ENABLE_MPI AND AXOM_ENABLE_SIDRE)
         set(quest_data_dir  ${AXOM_DATA_DIR}/quest)
 
         # Datasets contain a mesh name and resolution delimited by a colon
-        set(quest_regression_datasets sphere:16)
+        set(quest_regression_datasets sphere:16
+                                      tetrahedron:31)
 
         # Add additional regression datasets when its config variable is defined
         blt_list_append(
             TO          quest_regression_datasets
             ELEMENTS    aatbase_3_binary:16
                         aatbase_3_binary:32
+                        boxedSphere:40
                         cap:16
                         cap:32
                         naca0012:16
@@ -199,7 +201,9 @@ if (ENABLE_MPI AND AXOM_ENABLE_SIDRE)
                         plane_binary:32
                         plane_simp:16
                         plane_simp:32
+                        plane_simp:120_120_60
                         sphere:32
+                        tetrahedron:100
             IF          AXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS
            )
 

--- a/src/axom/spin/BVH.hpp
+++ b/src/axom/spin/BVH.hpp
@@ -100,11 +100,13 @@ struct BVHPolicy<FloatType, NDIMS, ExecType, BVHType::LinearBVH>
  *     spin::BVH< DIMENSION, axom::OMP_EXEC > bvh;
  *     bvh.initialize( aabbs, numItems );
  *
- *     // query points supplied in arrays, qx, qy, qz,
+ *     // query points supplied in arrays, qx, qy, qz
  *     const axom::IndexType numPoints = ...
  *     const double* qx = ...
  *     const double* qy = ...
  *     const double* qz = ...
+ *     //use the ZipPoint class to tie them together
+ *     ZipPoint qpts {{qx,qy,qz}};
  *
  *     // output array buffers
  *     axom::IndexType* offsets    = axom::allocate< IndexType >( numPoints );
@@ -113,7 +115,7 @@ struct BVHPolicy<FloatType, NDIMS, ExecType, BVHType::LinearBVH>
  *
  *     // find candidates in parallel, allocates and populates the supplied
  *     // candidates array
- *     bvh.findPoints( offsets, counts, candidates, numPoints, qx, qy, qz );
+ *     bvh.findPoints( offsets, counts, candidates, numPoints, qpts );
  *     SLIC_ASSERT( candidates != nullptr );
  *
  *     ...


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It resolves #703 
- It improves the robustness of `primal::closest_point(pt, triangle)` by adding an `EPS` tolerance parameter and using fuzzy comparisons to better determine if/when the closest point is on an edge or vertex of the triangle
- It uses this in `SignedDistance` to better track whether the closest point is on an edge or vertex.
  For these two cases, we need to track the weighted sum of all triangles incident in the edge or vertex
- It also improves how `SignedDistance` tracks which case it is in (face, edge or vertex)
- This improvement was tested against a configuration of the `plane_simp.stl` triangle mesh that was reported in #703 
   as well as a new `tetrahedron.stl` mesh that was added for this PR
- Also resolves #708
- Also resolve #346

#### TODO

- [x] Check this code against GPU configurations. Some functions will likely need to be host/device decorated
- [x] Add regression tests for the new failures (`plane_simp` and `tetrahedron`)
- [x] Ensure that all quest regression tests are passing
- [x] Update RELEASE-NOTES
- [x] Update `data` submodule after merging https://github.com/LLNL/axom_data/pull/8
- [x] Enable extra quest regression tests in a subset of CI jobs
