### PR TITLE
fix some spack package build options

### DIFF
--- a/scripts/spack/packages/raja/package.py
+++ b/scripts/spack/packages/raja/package.py
@@ -132,7 +132,12 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries.append(cmake_cache_path("camp_DIR", spec['camp'].prefix))
         entries.append(cmake_cache_option("BUILD_SHARED_LIBS", '+shared' in spec))
         entries.append(cmake_cache_option("ENABLE_EXAMPLES", '+examples' in spec))
-        entries.append(cmake_cache_option("ENABLE_EXERCISES", '+exercises' in spec))
+        if spec.satisfies('@0.14.0:'):
+            entries.append(cmake_cache_option("RAJA_ENABLE_EXERCISES",
+                                              '+exercises' in spec))
+        else:
+            entries.append(cmake_cache_option("ENABLE_EXERCISES",
+                                              '+exercises' in spec))
 
         # Work around spack adding -march=ppc64le to SPACK_TARGET_ARGS which
         # is used by the spack compiler wrapper.  This can go away when BLT

--- a/scripts/spack/packages/umpire/package.py
+++ b/scripts/spack/packages/umpire/package.py
@@ -195,6 +195,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries.append(cmake_cache_option(
             "ENABLE_BENCHMARKS", 'tests=benchmarks' in spec))
         entries.append(cmake_cache_option("ENABLE_EXAMPLES", '+examples' in spec))
+        entries.append(cmake_cache_option("ENABLE_DOCS", False))
         entries.append(cmake_cache_option("BUILD_SHARED_LIBS", '+shared' in spec))
         entries.append(cmake_cache_option("ENABLE_TESTS", 'tests=none' not in spec))
 


### PR DESCRIPTION
Found these while doing other builds. They have been upstreamed to Spack but cut a lot of time off the builds and don't want to forget next time we do a TPL build.

These are not worth rebuilding TPLs now.