### PR TITLE
Remove global include directories

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,12 +104,6 @@ include(CMakeDependentOption)
 include(cmake/CMakeBasics.cmake)
 
 #------------------------------------------------------------------------------
-# Global includes for the Axom projects (restrict these as much as possible)
-#------------------------------------------------------------------------------
-include_directories(${CMAKE_BINARY_DIR}/include)
-include_directories(${PROJECT_SOURCE_DIR})
-
-#------------------------------------------------------------------------------
 # Add source directories
 #------------------------------------------------------------------------------
 add_subdirectory(thirdparty)

--- a/src/axom/core/CMakeLists.txt
+++ b/src/axom/core/CMakeLists.txt
@@ -107,6 +107,13 @@ blt_add_library( NAME        core
                  OBJECT      TRUE
                  )
 
+# Basic includes that should be inherited to all Axom targets
+target_include_directories(core PUBLIC 
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    )
+
 # Add the AXOM_DEBUG compile definition, if non-empty
 if(AXOM_DEBUG_DEFINE_STRING)
   blt_add_target_definitions(TO core SCOPE PUBLIC TARGET_DEFINITIONS "${AXOM_DEBUG_DEFINE_STRING}")

--- a/src/axom/quest/tests/quest_regression.cpp
+++ b/src/axom/quest/tests/quest_regression.cpp
@@ -114,7 +114,8 @@ struct Input
       .add_option("-m,--mesh",
                   meshName,
                   "Surface mesh file (STL files are currently supported)")
-      ->required();
+      ->required()
+      ->check(axom::CLI::ExistingFile);
 
     app
       .add_flag("--distance,!--no-distance",
@@ -130,10 +131,12 @@ struct Input
     // Note: Baselines comparisons only supported when Axom is configured with hdf5
     // Users must supply either a baseline, or both the query resolution and bounding box
 #ifdef AXOM_USE_HDF5
-    app.add_option("-b,--baseline",
-                   baselineRoot,
-                   "root file of baseline, a sidre rootfile.\n"
-                   "Note: Only supported when Axom configured with hdf5");
+    app
+      .add_option("-b,--baseline",
+                  baselineRoot,
+                  "root file of baseline, a sidre rootfile.\n"
+                  "Note: Only supported when Axom configured with hdf5")
+      ->check(axom::CLI::ExistingFile);
 #endif
 
     // user can supply 1 or 3 values for resolution

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -84,6 +84,9 @@ blt_add_library(NAME    fmt
 target_include_directories(fmt SYSTEM INTERFACE
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/thirdparty>)
 
+target_include_directories(fmt INTERFACE 
+            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include> )
+
 # Setup some variables for fmt in Axom's config.hpp
 set(FMT_EXCEPTIONS FALSE PARENT_SCOPE)
 set(FMT_HEADER_ONLY TRUE PARENT_SCOPE)
@@ -170,6 +173,9 @@ if (AXOM_ENABLE_SPARSEHASH)
      
     target_include_directories(sparsehash SYSTEM INTERFACE
                 $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/thirdparty>)
+
+    target_include_directories(sparsehash INTERFACE 
+                $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include> )
 
     # Disable warning introduced in gcc@8.1+ related to how sparsehash casts memory
     # The double guarding for compiler family helps when compiling libraries with GNU

--- a/src/thirdparty/tests/CMakeLists.txt
+++ b/src/thirdparty/tests/CMakeLists.txt
@@ -48,6 +48,10 @@ if ( RAJA_FOUND )
                       DEPENDS_ON ${raja_smoke_dependencies}
                       FOLDER axom/thirdparty/tests )
 
+  target_include_directories(raja_smoke_test PUBLIC 
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+      $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
+
   axom_add_test( NAME    raja_smoke
                  COMMAND raja_smoke_test )
 
@@ -69,8 +73,12 @@ if( HDF5_FOUND)
                        DEPENDS_ON ${hdf5_smoke_dependencies}
                        FOLDER axom/thirdparty/tests )
 
+    target_include_directories(hdf5_smoke_test PUBLIC 
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include> )
+
     axom_add_test(NAME hdf5_smoke
-                 COMMAND hdf5_smoke_test)
+                  COMMAND hdf5_smoke_test)
 endif()
 
 #------------------------------------------------------------------------------

--- a/src/thirdparty/tests/c2c_smoke.cpp
+++ b/src/thirdparty/tests/c2c_smoke.cpp
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/config.hpp"
 #include "gtest/gtest.h"  // for gtest
 
 #include "c2c/config.hpp"

--- a/src/thirdparty/tests/cli11_smoke.cpp
+++ b/src/thirdparty/tests/cli11_smoke.cpp
@@ -9,7 +9,6 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "axom/config.hpp"
 #include "axom/CLI11.hpp"
 
 #include <iostream>


### PR DESCRIPTION
This removes all global include directories from Axom.  These go against CMake best practices.