### PR TITLE
Adds `axom::Array::view()` method and improves testing with kernels

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ## [Unreleased] - Release date yyyy-mm-dd
 
+###  Added
+- Adds a `view()` method to `axom::Array` class to simplify creation of a corresponding `axom::ArrayView`
+  
 ###  Fixed
 - Fixed a bug relating to swap and assignment operations for multidimensional `axom::Array`s
 

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -6,16 +6,17 @@
 #ifndef AXOM_ARRAY_HPP_
 #define AXOM_ARRAY_HPP_
 
-#include "axom/config.hpp"                    // for compile-time defines
-#include "axom/core/Macros.hpp"               // for axom macros
-#include "axom/core/utilities/Utilities.hpp"  // for processAbort()
-#include "axom/core/Types.hpp"                // for IndexType definition
+#include "axom/config.hpp"
+#include "axom/core/Macros.hpp"
+#include "axom/core/utilities/Utilities.hpp"
+#include "axom/core/Types.hpp"
 #include "axom/core/ArrayBase.hpp"
 #include "axom/core/ArrayIteratorBase.hpp"
+#include "axom/core/ArrayView.hpp"
 
 // C/C++ includes
-#include <algorithm>  // for std::transform
-#include <iostream>   // for std::cerr and std::ostream
+#include <algorithm>
+#include <iostream>
 
 namespace axom
 {
@@ -73,6 +74,8 @@ public:
   using value_type = T;
   static constexpr MemorySpace space = SPACE;
   using ArrayIterator = ArrayIteratorBase<Array<T, DIM, SPACE>>;
+
+  using ArrayViewType = ArrayView<T, DIM, SPACE>;
 
 public:
   /// \name Native Storage Array Constructors
@@ -515,6 +518,18 @@ public:
    * \brief Get the ID for the umpire allocator
    */
   int getAllocatorID() const { return m_allocator_id; }
+
+  /*!
+   * \brief Returns a view of the array
+   * \sa ArrayView
+   */
+  const ArrayViewType view() const { return ArrayViewType(*this); }
+
+  /*!
+   * \brief Returns a view of the array
+   * \sa ArrayView
+   */
+  ArrayViewType view() { return ArrayViewType(*this); }
 
   /// @}
 

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -523,12 +523,6 @@ public:
    * \brief Returns a view of the array
    * \sa ArrayView
    */
-  const ArrayViewType view() const { return ArrayViewType(*this); }
-
-  /*!
-   * \brief Returns a view of the array
-   * \sa ArrayView
-   */
   ArrayViewType view() { return ArrayViewType(*this); }
 
   /// @}

--- a/src/axom/core/Macros.hpp
+++ b/src/axom/core/Macros.hpp
@@ -258,7 +258,7 @@
 /*!
  * \def AXOM_TYPED_TEST(CaseName, TestName)
  * \brief Minor tweak of gtest's TYPED_TEST macro to work with device code
- * \note Can be used after including `gtest/gtest.h`
+ * \note Can be used in test files after including `gtest/gtest.h`
  */
 // Specifically, we expose the `TestBody()` method as public instead of private
 #define AXOM_TYPED_TEST(CaseName, TestName)                                         \

--- a/src/axom/core/Macros.hpp
+++ b/src/axom/core/Macros.hpp
@@ -4,11 +4,9 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 /*!
- *
  * \file AxomMacros.hpp
  *
  * \brief Contains several useful macros for the axom project
- *
  */
 
 #ifndef AXOM_MACROS_HPP_
@@ -257,4 +255,38 @@
   className(className&&) = delete;             \
   className& operator=(className&&) = delete
 
-#endif /* AXOM_MACROS_HPP_ */
+/*!
+ * \def AXOM_TYPED_TEST(CaseName, TestName)
+ * \brief Minor tweak of gtest's TYPED_TEST macro to work with device code
+ * \note Can be used after including `gtest/gtest.h`
+ */
+// Specifically, we expose the `TestBody()` method as public instead of private
+#define AXOM_TYPED_TEST(CaseName, TestName)                                         \
+  static_assert(sizeof(GTEST_STRINGIFY_(TestName)) > 1,                             \
+                "test-name must not be empty");                                     \
+  template <typename gtest_TypeParam_>                                              \
+  class GTEST_TEST_CLASS_NAME_(CaseName, TestName)                                  \
+    : public CaseName<gtest_TypeParam_>                                             \
+  {                                                                                 \
+  public:                                                                           \
+    typedef CaseName<gtest_TypeParam_> TestFixture;                                 \
+    typedef gtest_TypeParam_ TypeParam;                                             \
+    void TestBody() override;                                                       \
+  };                                                                                \
+  static bool gtest_##CaseName##_##TestName##_registered_ GTEST_ATTRIBUTE_UNUSED_ = \
+    ::testing::internal::TypeParameterizedTest<                                     \
+      CaseName,                                                                     \
+      ::testing::internal::TemplateSel<GTEST_TEST_CLASS_NAME_(CaseName, TestName)>, \
+      GTEST_TYPE_PARAMS_(CaseName)>::                                               \
+      Register(                                                                     \
+        "",                                                                         \
+        ::testing::internal::CodeLocation(__FILE__, __LINE__),                      \
+        GTEST_STRINGIFY_(CaseName),                                                 \
+        GTEST_STRINGIFY_(TestName),                                                 \
+        0,                                                                          \
+        ::testing::internal::GenerateNames<GTEST_NAME_GENERATOR_(CaseName),         \
+                                           GTEST_TYPE_PARAMS_(CaseName)>());        \
+  template <typename gtest_TypeParam_>                                              \
+  void GTEST_TEST_CLASS_NAME_(CaseName, TestName)<gtest_TypeParam_>::TestBody()
+
+#endif  // AXOM_MACROS_HPP_

--- a/src/axom/core/docs/sphinx/core_containers.rst
+++ b/src/axom/core/docs/sphinx/core_containers.rst
@@ -241,6 +241,8 @@ via a lambda:
    :end-before: _array_w_raja_end
    :language: C++
 
+.. note:: We need to mark the lambda as `mutable` if we want to modify the array (array view) data.
+
 ##########
 StackArray
 ##########

--- a/src/axom/core/examples/core_containers.cpp
+++ b/src/axom/core/examples/core_containers.cpp
@@ -219,12 +219,17 @@ void demoArrayDevice()
   // _basic_array_device_implicit_end
 
   // _basic_array_device_explicit_start
-  axom::ArrayView<int, 1, axom::MemorySpace::Device> view_of_dynamic_array(
-    device_array_dynamic);
+  using DeviceArrayView = axom::ArrayView<int, 1, axom::MemorySpace::Device>;
+
+  DeviceArrayView view_of_dynamic_array(device_array_dynamic);
   takesDeviceArrayView(view_of_dynamic_array);
-  axom::ArrayView<int, 1, axom::MemorySpace::Device> view_of_template_array(
-    device_array_template);
+
+  DeviceArrayView view_of_template_array(device_array_template);
   takesDeviceArrayView(view_of_template_array);
+
+  // Create an explicit ArrayView using Array::view()
+  auto view_of_array_using_view_method = device_array_dynamic.view();
+  takesDeviceArrayView(view_of_array_using_view_method);
   // _basic_array_device_explicit_end
 
   // _cuda_array_create_start

--- a/src/axom/core/execution/execution_space.hpp
+++ b/src/axom/core/execution/execution_space.hpp
@@ -10,7 +10,7 @@
 #include "axom/core/memory_management.hpp"
 
 /*!
- * \file
+ * \file execution_space.hpp
  *
  * \brief Defines the list of available execution spaces for axom.
  *

--- a/src/axom/core/execution/execution_space.hpp
+++ b/src/axom/core/execution/execution_space.hpp
@@ -79,11 +79,13 @@ struct execution_space
   using atomic_policy = void;
   using sync_policy = void;
 
-  static constexpr bool async() noexcept { return false; };
-  static constexpr bool valid() noexcept { return false; };
-  static constexpr bool onDevice() noexcept { return false; };
-  static constexpr char* name() noexcept { return (char*)"[UNDEFINED]"; };
-  static int allocatorID() noexcept { return axom::INVALID_ALLOCATOR_ID; };
+  static constexpr MemorySpace memory_space = MemorySpace::Dynamic;
+
+  static constexpr bool async() noexcept { return false; }
+  static constexpr bool valid() noexcept { return false; }
+  static constexpr bool onDevice() noexcept { return false; }
+  static constexpr char* name() noexcept { return (char*)"[UNDEFINED]"; }
+  static int allocatorID() noexcept { return axom::INVALID_ALLOCATOR_ID; }
 };
 
 }  // namespace axom

--- a/src/axom/core/execution/for_all.hpp
+++ b/src/axom/core/execution/for_all.hpp
@@ -6,14 +6,14 @@
 #ifndef AXOM_CORE_EXECUTION_FOR_ALL_HPP_
 #define AXOM_CORE_EXECUTION_FOR_ALL_HPP_
 
-#include "axom/config.hpp"                         /* compile time defs */
-#include "axom/core/execution/execution_space.hpp" /* execution_space traits */
-#include "axom/core/Macros.hpp"                    /* for axom Macros */
-#include "axom/core/Types.hpp"                     /* for axom::IndexType */
+#include "axom/config.hpp"
+#include "axom/core/execution/execution_space.hpp"
+#include "axom/core/Macros.hpp"
+#include "axom/core/Types.hpp"
 
 // C/C++ includes
-#include <type_traits>  // for std::is_same()
-#include <utility>      // for std::forward()
+#include <type_traits>
+#include <utility>
 
 namespace axom
 {
@@ -106,6 +106,6 @@ inline void for_all(const IndexType& N, KernelType&& kernel) noexcept
 
 /// @}
 
-} /* namespace axom */
+}  // namespace axom
 
-#endif /* AXOM_CORE_EXECUTION_FOR_ALL_HPP_ */
+#endif  // AXOM_CORE_EXECUTION_FOR_ALL_HPP_

--- a/src/axom/core/execution/internal/cuda_exec.hpp
+++ b/src/axom/core/execution/internal/cuda_exec.hpp
@@ -53,14 +53,16 @@ struct execution_space<CUDA_EXEC<BLOCK_SIZE, SYNCHRONOUS>>
   using atomic_policy = RAJA::cuda_atomic;
   using sync_policy = RAJA::cuda_synchronize;
 
-  static constexpr bool async() noexcept { return false; };
-  static constexpr bool valid() noexcept { return true; };
-  static constexpr bool onDevice() noexcept { return true; };
-  static constexpr char* name() noexcept { return (char*)"[CUDA_EXEC]"; };
+  static constexpr MemorySpace memory_space = MemorySpace::Device;
+
+  static constexpr bool async() noexcept { return false; }
+  static constexpr bool valid() noexcept { return true; }
+  static constexpr bool onDevice() noexcept { return true; }
+  static constexpr char* name() noexcept { return (char*)"[CUDA_EXEC]"; }
   static int allocatorID() noexcept
   {
     return axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
-  };
+  }
 };
 
 /*!
@@ -78,18 +80,20 @@ struct execution_space<CUDA_EXEC<BLOCK_SIZE, ASYNC>>
   using atomic_policy = RAJA::cuda_atomic;
   using sync_policy = RAJA::cuda_synchronize;
 
-  static constexpr bool async() noexcept { return true; };
-  static constexpr bool valid() noexcept { return true; };
-  static constexpr bool onDevice() noexcept { return true; };
+  static constexpr MemorySpace memory_space = MemorySpace::Device;
+
+  static constexpr bool async() noexcept { return true; }
+  static constexpr bool valid() noexcept { return true; }
+  static constexpr bool onDevice() noexcept { return true; }
   static constexpr char* name() noexcept
   {
     return (char*)"[CUDA_EXEC] (async)";
-  };
+  }
   static int allocatorID() noexcept
   {
     return axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
-  };
+  }
 };
-} /* namespace axom */
+}  // namespace axom
 
-#endif /* AXOM_CUDA_EXEC_HPP_ */
+#endif  // AXOM_CUDA_EXEC_HPP_

--- a/src/axom/core/execution/internal/omp_exec.hpp
+++ b/src/axom/core/execution/internal/omp_exec.hpp
@@ -41,10 +41,16 @@ struct execution_space<OMP_EXEC>
   using atomic_policy = RAJA::omp_atomic;
   using sync_policy = RAJA::omp_synchronize;
 
-  static constexpr bool async() noexcept { return false; };
-  static constexpr bool valid() noexcept { return true; };
-  static constexpr bool onDevice() noexcept { return false; };
-  static constexpr char* name() noexcept { return (char*)"[OMP_EXEC]"; };
+#ifdef AXOM_USE_UMPIRE
+  static constexpr MemorySpace memory_space = MemorySpace::Host;
+#else
+  static constexpr MemorySpace memory_space = MemorySpace::Dynamic;
+#endif
+
+  static constexpr bool async() noexcept { return false; }
+  static constexpr bool valid() noexcept { return true; }
+  static constexpr bool onDevice() noexcept { return false; }
+  static constexpr char* name() noexcept { return (char*)"[OMP_EXEC]"; }
 
   static int allocatorID() noexcept
   {
@@ -53,9 +59,9 @@ struct execution_space<OMP_EXEC>
 #else
     return axom::getDefaultAllocatorID();
 #endif
-  };
+  }
 };
 
-} /* namespace axom */
+}  // namespace axom
 
-#endif /* AXOM_OMP_EXEC_HPP_ */
+#endif  // AXOM_OMP_EXEC_HPP_

--- a/src/axom/core/execution/internal/seq_exec.hpp
+++ b/src/axom/core/execution/internal/seq_exec.hpp
@@ -46,10 +46,16 @@ struct execution_space<SEQ_EXEC>
 
   using sync_policy = void;
 
-  static constexpr bool async() noexcept { return false; };
-  static constexpr bool valid() noexcept { return true; };
-  static constexpr bool onDevice() noexcept { return false; };
-  static constexpr char* name() noexcept { return (char*)"[SEQ_EXEC]"; };
+#ifdef AXOM_USE_UMPIRE
+  static constexpr MemorySpace memory_space = MemorySpace::Host;
+#else
+  static constexpr MemorySpace memory_space = MemorySpace::Dynamic;
+#endif
+
+  static constexpr bool async() noexcept { return false; }
+  static constexpr bool valid() noexcept { return true; }
+  static constexpr bool onDevice() noexcept { return false; }
+  static constexpr char* name() noexcept { return (char*)"[SEQ_EXEC]"; }
   static int allocatorID() noexcept
   {
 #ifdef AXOM_USE_UMPIRE
@@ -57,9 +63,9 @@ struct execution_space<SEQ_EXEC>
 #else
     return axom::getDefaultAllocatorID();
 #endif
-  };
+  }
 };
 
-} /* namespace axom */
+}  // namespace axom
 
-#endif /* AXOM_SEQ_EXEC_HPP_ */
+#endif  // AXOM_SEQ_EXEC_HPP_

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -16,6 +16,7 @@
 
 set(core_serial_tests
     core_array.hpp
+    core_array_for_all.hpp
     core_execution_for_all.hpp
     core_execution_space.hpp
     core_memory_management.hpp

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -4,19 +4,24 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 #------------------------------------------------------------------------------
 # Tests for Axom's Core component
+#
+# Note: The tests in this file are consolidated into a few executables.
+# In addition to adding files to the lists below, you'll also have  to #include 
+# your headers in the appropriate 'main' cpp file, e.g. `core_serial_main.cpp`
 #------------------------------------------------------------------------------
 
 #------------------------------------------------------------------------------
-# Specify list of tests
+# Specify list of serial tests
 #------------------------------------------------------------------------------
 
-set(gtest_utils_tests
+set(core_serial_tests
     core_array.hpp
     core_execution_for_all.hpp
     core_execution_space.hpp
     core_memory_management.hpp
     core_Path.hpp
     core_stack_array.hpp
+    core_map.hpp
 
     numerics_determinants.hpp
     numerics_eigen_solve.hpp
@@ -39,12 +44,12 @@ set(gtest_utils_tests
     utils_about.hpp
     )
 
-set(utils_tests_depends
+set(core_test_depends
     axom
     gtest
     )
 
-blt_list_append( TO utils_tests_depends ELEMENTS cuda IF ${ENABLE_CUDA} )
+blt_list_append( TO core_test_depends ELEMENTS cuda IF ENABLE_CUDA )
 
 #------------------------------------------------------------------------------
 # Serial GTests
@@ -52,17 +57,17 @@ blt_list_append( TO utils_tests_depends ELEMENTS cuda IF ${ENABLE_CUDA} )
 
 # Only enable this test in serial mode if ENABLE_MPI is off
 if (NOT ENABLE_MPI)
-  list(APPEND gtest_utils_tests core_types.hpp)
+  list(APPEND core_serial_tests core_types.hpp)
 endif()
 
 blt_add_executable( NAME       core_serial_tests
                     SOURCES    core_serial_main.cpp
-                    HEADERS    ${gtest_utils_tests}
+                    HEADERS    ${core_serial_tests}
                     OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                    DEPENDS_ON ${utils_tests_depends}
+                    DEPENDS_ON ${core_test_depends}
                     FOLDER     axom/core/tests )
 
-foreach(test_suite ${gtest_utils_tests})
+foreach(test_suite ${core_serial_tests})
     get_filename_component( test_suite ${test_suite} NAME_WE )
     axom_add_test( NAME    ${test_suite}_serial
                    COMMAND core_serial_tests --gtest_filter=${test_suite}* )
@@ -80,7 +85,7 @@ if (ENABLE_MPI)
                       SOURCES    core_mpi_main.cpp
                       HEADERS    ${core_mpi_tests}
                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                      DEPENDS_ON ${utils_tests_depends} mpi
+                      DEPENDS_ON ${core_test_depends} mpi
                       FOLDER     axom/core/tests )
 
   foreach( test_suite ${core_mpi_tests} )
@@ -103,7 +108,7 @@ if (ENABLE_OPENMP AND AXOM_USE_RAJA)
                       SOURCES    core_openmp_main.cpp
                       HEADERS    ${core_mpi_tests}
                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                      DEPENDS_ON ${utils_tests_depends} openmp
+                      DEPENDS_ON ${core_test_depends} openmp
                       FOLDER     axom/core/tests )
 
   foreach( test_suite ${core_openmp_tests} )

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -19,10 +19,10 @@ set(core_serial_tests
     core_array_for_all.hpp
     core_execution_for_all.hpp
     core_execution_space.hpp
+    core_map.hpp
     core_memory_management.hpp
     core_Path.hpp
     core_stack_array.hpp
-    core_map.hpp
 
     numerics_determinants.hpp
     numerics_eigen_solve.hpp
@@ -35,14 +35,14 @@ set(core_serial_tests
     numerics_matvecops.hpp
     numerics_polynomial_solvers.hpp
 
-    utils_Timer.hpp
+    utils_about.hpp
     utils_endianness.hpp
     utils_fileUtilities.hpp
     utils_nvtx_settings.hpp
     utils_stringUtilities.hpp
     utils_system.hpp
+    utils_Timer.hpp
     utils_utilities.hpp
-    utils_about.hpp
     )
 
 set(core_test_depends

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -983,14 +983,13 @@ TEST(core_array, checkResize)
 //------------------------------------------------------------------------------
 TEST(core_array_DeathTest, checkResize)
 {
-  const char IGNORE_OUTPUT[] = ".*";
   constexpr IndexType ZERO = 0;
   IndexType size = 100;
 
   /* Resizing isn't allowed with a ratio less than 1.0. */
   Array<int> v_int(ZERO, size);
   v_int.setResizeRatio(0.99);
-  EXPECT_DEATH_IF_SUPPORTED(internal::check_resize(v_int), IGNORE_OUTPUT);
+  EXPECT_DEATH_IF_SUPPORTED(internal::check_resize(v_int), "");
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -80,7 +80,7 @@ AXOM_TYPED_TEST(core_array_for_all, explicit_ArrayView)
     axom::synchronize<ExecSpace>();
   }
 
-  // Check array contents on device
+  // Check array contents on host
   HostArray localArr = arr;
   for(int i = 0; i < N; ++i)
   {
@@ -111,7 +111,7 @@ AXOM_TYPED_TEST(core_array_for_all, auto_ArrayView)
     axom::synchronize<ExecSpace>();
   }
 
-  // Check array contents on device
+  // Check array contents on host
   HostArray localArr = arr;
   for(int i = 0; i < N; ++i)
   {
@@ -145,7 +145,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array)
     axom::synchronize<ExecSpace>();
   }
 
-  // Check array contents on device
+  // Check array contents on host
   HostArray localArr(arr, hostAllocID);
   for(int i = 0; i < N; ++i)
   {

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -79,3 +79,27 @@ AXOM_TYPED_TEST(core_array_for_all, explicit_ArrayView)
     EXPECT_EQ(localArr[i], N - i);
   }
 }
+
+AXOM_TYPED_TEST(core_array_for_all, auto_ArrayView)
+{
+  using ExecSpace = typename TestFixture::ExecSpace;
+  using KernelArray = typename TestFixture::KernelArray;
+  using HostArray = typename TestFixture::HostArray;
+
+  // Create an array of N items using default MemorySpace for ExecSpace
+  constexpr int N = 374;
+  KernelArray arr(N);
+
+  // Modify array using mutable lambda and ArrayView
+  auto arr_view = arr.view();
+  axom::for_all<ExecSpace>(
+    N,
+    AXOM_LAMBDA(axom::IndexType idx) mutable { arr_view[idx] = N - idx; });
+
+  // Check array contents on device
+  HostArray localArr = arr;
+  for(int i = 0; i < N; ++i)
+  {
+    EXPECT_EQ(localArr[i], N - i);
+  }
+}

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -14,7 +14,7 @@
 // gtest includes
 #include "gtest/gtest.h"
 
-namespace
+namespace testing
 {
 //------------------------------------------------------------------------------
 //  This test harness defines some types that are useful for the tests below
@@ -55,8 +55,6 @@ using MyTypes = ::testing::Types<
   axom::SEQ_EXEC>;
 
 TYPED_TEST_SUITE(core_array_for_all, MyTypes);
-
-}  // end anonymous namespace
 
 //------------------------------------------------------------------------------
 AXOM_TYPED_TEST(core_array_for_all, explicit_ArrayView)
@@ -154,3 +152,5 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array)
     EXPECT_EQ(localArr[i], N - i);
   }
 }
+
+}  // end namespace testing

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+// Axom includes
+#include "axom/config.hpp"
+#include "axom/core/Array.hpp"
+#include "axom/core/execution/execution_space.hpp"
+#include "axom/core/execution/for_all.hpp"
+
+// gtest includes
+#include "gtest/gtest.h"
+
+//------------------------------------------------------------------------------
+//  HELPER METHODS
+//------------------------------------------------------------------------------
+namespace
+{
+//------------------------------------------------------------------------------
+template <typename ExecSpace>
+void check_array_for_all_templated_memory()
+{
+  // Introduce some type aliases
+#ifdef AXOM_USE_UMPIRE
+  constexpr axom::MemorySpace host_memory = axom::MemorySpace::Host;
+#else
+  constexpr axom::MemorySpace host_memory = axom::MemorySpace::Dynamic;
+#endif
+
+  constexpr axom::MemorySpace exec_space_memory =
+    axom::execution_space<ExecSpace>::memory_space;
+
+  using HostArray = axom::Array<int, 1, host_memory>;
+  using KernelArray = axom::Array<int, 1, exec_space_memory>;
+  using KernelArrayView = axom::ArrayView<int, 1, exec_space_memory>;
+
+  // Create an array of N items using default allocator ExecSpace
+  constexpr int N = 374;
+  KernelArray arr(N);
+
+  // Modify array using mutable lambda and ArrayView
+  KernelArrayView arr_view(arr);
+  axom::for_all<ExecSpace>(
+    N,
+    AXOM_LAMBDA(axom::IndexType idx) mutable { arr_view[idx] = N - idx; });
+
+  // Check array contents on device
+  HostArray localArr = arr;
+  for(int i = 0; i < N; ++i)
+  {
+    EXPECT_EQ(localArr[i], N - i);
+  }
+}
+
+}  // namespace
+
+//------------------------------------------------------------------------------
+//  UNIT TESTS
+//------------------------------------------------------------------------------
+TEST(core_array_for_all, seq_exec)
+{
+  check_array_for_all_templated_memory<axom::SEQ_EXEC>();
+}
+
+//------------------------------------------------------------------------------
+
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP)
+TEST(core_array_for_all, omp_exec)
+{
+  check_array_for_all_templated_memory<axom::OMP_EXEC>();
+}
+#endif
+
+//------------------------------------------------------------------------------
+
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+TEST(core_array_for_all, cuda_exec)
+{
+  constexpr int BLOCK_SIZE = 256;
+  check_array_for_all_templated_memory<axom::CUDA_EXEC<BLOCK_SIZE>>();
+}
+#endif

--- a/src/axom/core/tests/core_map.hpp
+++ b/src/axom/core/tests/core_map.hpp
@@ -8,14 +8,22 @@
 #include "gtest/gtest.h" /* for TEST and EXPECT_* macros */
 #include <string>
 
-namespace axom
+namespace experimental = axom::experimental;
+
+namespace
 {
-namespace internal
+struct TestHash
 {
-template <typename Key, typename T>
-experimental::Map<Key, T> init(int N, int len)
+  std::size_t operator()(int i) const { return i; }
+};
+
+using TestKey = int;
+using TestVal = int;
+using TestMap = experimental::Map<TestKey, TestVal, TestHash>;
+
+TestMap init(int N, int len)
 {
-  experimental::Map<Key, T> test(N, len);
+  TestMap test(N, len);
   EXPECT_EQ(N * len, test.max_size());
   EXPECT_EQ(0, test.size());
   EXPECT_EQ(true, test.empty());
@@ -24,17 +32,20 @@ experimental::Map<Key, T> init(int N, int len)
   return test;
 }
 
-template <typename Key, typename T>
-void test_storage(experimental::Map<Key, T> &test)
+void test_storage(TestMap& test)
 {
+  using Key = TestMap::key_type;
+  using T = TestMap::mapped_type;
+
+  EXPECT_TRUE(test.empty());
   for(int i = 0; i < test.max_size(); i++)
   {
     Key key = i;
     T value = key * 27;
     auto ret_test = test.insert(key, value);
-    EXPECT_EQ(true, ret_test.second);
+    EXPECT_TRUE(ret_test.second);
   }
-  EXPECT_EQ(false, test.empty());
+  EXPECT_FALSE(test.empty());
   for(int i = 0; i < test.max_size(); i++)
   {
     Key key = i;
@@ -42,12 +53,12 @@ void test_storage(experimental::Map<Key, T> &test)
   }
   //This should fail, since we're at capacity.
   auto ret = test.insert(test.max_size(), 900);
-  EXPECT_EQ(false, ret.second);
+  EXPECT_FALSE(ret.second);
 }
 
-template <typename Key, typename T>
-void test_subscript(experimental::Map<Key, T> &test)
+void test_subscript(TestMap& test)
 {
+  using Key = TestMap::key_type;
   for(int i = 0; i < test.size(); i++)
   {
     Key key = i;
@@ -55,9 +66,11 @@ void test_subscript(experimental::Map<Key, T> &test)
   }
 }
 
-template <typename Key, typename T>
-void test_insert_assign(experimental::Map<Key, T> &test)
+void test_insert_assign(TestMap& test)
 {
+  using Key = TestMap::key_type;
+  using T = TestMap::mapped_type;
+
   for(int i = 0; i < test.max_size(); i++)
   {
     Key key = i;
@@ -89,9 +102,10 @@ void test_insert_assign(experimental::Map<Key, T> &test)
   }
 }
 
-template <typename Key, typename T>
-void test_remove(experimental::Map<Key, T> &test)
+void test_remove(TestMap& test)
 {
+  using Key = TestMap::key_type;
+
   std::size_t to_erase = test.size();
   for(std::size_t i = 0; i < to_erase; i++)
   {
@@ -107,9 +121,11 @@ void test_remove(experimental::Map<Key, T> &test)
   EXPECT_EQ(test.size(), 1);
 }
 
-template <typename Key, typename T>
-void test_rehash(experimental::Map<Key, T> &test, int num, int fact)
+void test_rehash(TestMap& test, int num, int fact)
 {
+  using Key = TestMap::key_type;
+  using T = TestMap::mapped_type;
+
   auto original_size = test.size();
   test.rehash(num, fact);
 
@@ -136,7 +152,99 @@ void test_rehash(experimental::Map<Key, T> &test, int num, int fact)
   EXPECT_EQ(false, ret.second);
 }
 
-}  // namespace internal
+template <typename Key, typename T>
+experimental::axom_map::Node<Key, T> init_node(axom::IndexType next = -1,
+                                               Key key = 5,
+                                               T value = 15)
+{
+  axom::experimental::axom_map::Node<Key, T> n;
+  n.next = next;
+  n.key = key;
+  n.value = value;
+
+  return n;
+}
+
+template <typename Key, typename T>
+experimental::axom_map::Pair<Key, T> init_pair(
+  experimental::axom_map::Node<Key, T>* node = nullptr,
+  bool status = false)
+{
+  axom::experimental::axom_map::Pair<Key, T> p(node, status);
+
+  return p;
+}
+
+template <typename Key, typename T>
+experimental::axom_map::Bucket<Key, T> init_bucket(int length)
+{
+  axom::experimental::axom_map::Bucket<Key, T> b(length);
+
+  return b;
+}
+
+// The first parameter is the number of buckets;
+// the second is a lambda to fill the buckets
+template <typename Key, typename T>
+experimental::axom_map::Bucket<Key, T> init_filled_bucket(int length,
+                                                          std::function<T(Key)>&& fn)
+{
+  axom::experimental::axom_map::Bucket<Key, T> b(length);
+
+  for(int i = 0; i < length; ++i)
+  {
+    b.insert_update(i, fn(i));
+  }
+
+  return b;
+}
+
+template <typename MapType>
+MapType init_filled_map(
+  int numBucket,
+  int bucketLength,
+  std::function<typename MapType::mapped_type(typename MapType::key_type)>&& fn)
+{
+  using T = typename MapType::mapped_type;
+
+  MapType map(numBucket, bucketLength);
+
+  const int sz = numBucket * bucketLength;
+  bool validState = true;
+  do
+  {
+    if(!validState)
+    {
+      validState = map.rehash();
+    }
+
+    if(validState)
+    {
+      for(int i = 0; i < sz; ++i)
+      {
+        auto res = map.insert_or_assign(i, fn(i));
+        const bool validInsert = (res.second == true || res.first->key == i);
+        if(!validInsert)
+        {
+          validState = false;
+          break;
+        }
+      }
+    }
+  } while(!validState);
+
+  // Check that the values actually got inserted
+  for(int i = 0; i < sz; ++i)
+  {
+    T exp_value = fn(i);
+    T value = map[i];
+    EXPECT_EQ(exp_value, value);
+  }
+
+  return map;
+}
+
+}  // end anonymous namespace
 
 TEST(core_map, initialization)
 {
@@ -144,7 +252,7 @@ TEST(core_map, initialization)
   {
     for(int j : {1, 2, 5, 10})
     {
-      experimental::Map<int, int> test = internal::init<int, int>(i, j);
+      TestMap test = ::init(i, j);
     }
   }
 }
@@ -155,8 +263,8 @@ TEST(core_map, insertion)
   {
     for(int j : {1, 2, 5, 10})
     {
-      experimental::Map<int, int> test = internal::init<int, int>(i, j);
-      internal::test_storage<int, int>(test);
+      TestMap test = ::init(i, j);
+      ::test_storage(test);
     }
   }
 }
@@ -167,8 +275,8 @@ TEST(core_map, insert_or_assign)
   {
     for(int j : {1, 2, 5, 10})
     {
-      experimental::Map<int, int> test = internal::init<int, int>(i, j);
-      internal::test_insert_assign<int, int>(test);
+      TestMap test = ::init(i, j);
+      ::test_insert_assign(test);
     }
   }
 }
@@ -179,9 +287,9 @@ TEST(core_map, subscript)
   {
     for(int j : {1, 2, 5, 10})
     {
-      experimental::Map<int, int> test = internal::init<int, int>(i, j);
-      internal::test_storage<int, int>(test);
-      internal::test_subscript<int, int>(test);
+      TestMap test = ::init(i, j);
+      ::test_storage(test);
+      ::test_subscript(test);
     }
   }
 }
@@ -192,9 +300,9 @@ TEST(core_map, removal)
   {
     for(int j : {1, 2, 5, 10})
     {
-      experimental::Map<int, int> test = internal::init<int, int>(i, j);
-      internal::test_storage<int, int>(test);
-      internal::test_remove<int, int>(test);
+      TestMap test = ::init(i, j);
+      ::test_storage(test);
+      ::test_remove(test);
     }
   }
 }
@@ -207,11 +315,11 @@ TEST(core_map, rehash)
     {
       for(int k : {2, 4, 8})
       {
-        experimental::Map<int, int> test = internal::init<int, int>(i, j);
-        internal::test_storage<int, int>(test);
-        internal::test_rehash<int, int>(test, -1, k);
+        TestMap test = ::init(i, j);
+        ::test_storage(test);
+        ::test_rehash(test, -1, k);
         EXPECT_EQ(test.max_size(), k * i * j);
-        internal::test_remove<int, int>(test);
+        ::test_remove(test);
       }
     }
   }
@@ -221,13 +329,139 @@ TEST(core_map, rehash)
     {
       for(int k = 1; k < 4; k++)
       {
-        experimental::Map<int, int> test = internal::init<int, int>(i, j);
-        internal::test_storage<int, int>(test);
-        internal::test_rehash<int, int>(test, test.max_size() + 20 * k, -1);
+        TestMap test = ::init(i, j);
+        ::test_storage(test);
+        ::test_rehash(test, test.max_size() + 20 * k, -1);
         EXPECT_EQ((i * j + 20 * k) * j, test.max_size());
-        internal::test_remove<int, int>(test);
+        ::test_remove(test);
       }
     }
   }
 }
-} /* namespace axom */
+
+TEST(core_map, node_return_value)
+{
+  using Key = int;
+  using T = int;
+  using NodeType = experimental::axom_map::Node<Key, T>;
+
+  axom::IndexType n = -1;
+  Key k = 5;
+  T v = 15;
+  NodeType node = ::init_node<Key, T>(n, k, v);
+
+  EXPECT_EQ(n, node.next);
+  EXPECT_EQ(k, node.key);
+  EXPECT_EQ(v, node.value);
+}
+
+TEST(core_map, pair_return_value)
+{
+  using Key = int;
+  using T = int;
+  using NodeType = experimental::axom_map::Node<Key, T>;
+  using PairType = experimental::axom_map::Pair<Key, T>;
+
+  {
+    axom::IndexType n = -1;
+    Key k = 5;
+    T v = 15;
+    NodeType node = ::init_node<Key, T>(n, k, v);
+    PairType pair = ::init_pair<Key, T>(&node, true);
+
+    EXPECT_EQ(node, *pair.first);
+    EXPECT_TRUE(pair.second);
+  }
+  {
+    PairType pair = ::init_pair<Key, T>(nullptr, false);
+
+    EXPECT_EQ(nullptr, pair.first);
+    EXPECT_FALSE(pair.second);
+  }
+}
+
+TEST(core_map, bucket_return_value)
+{
+  using Key = int;
+  using T = int;
+  using BucketType = experimental::axom_map::Bucket<Key, T>;
+
+  {
+    const int length = 5;
+    BucketType bucket = ::init_bucket<Key, T>(length);
+
+    EXPECT_EQ(0, bucket.get_size());
+    EXPECT_EQ(length, bucket.get_capacity());
+  }
+  {
+    const int length = 5;
+    auto fn = [](Key i) { return i * i; };
+    BucketType bucket = ::init_filled_bucket<Key, T>(length, fn);
+
+    EXPECT_EQ(length, bucket.get_size());
+    EXPECT_EQ(length, bucket.get_capacity());
+
+    for(int i = 0; i < length; ++i)
+    {
+      auto& node = bucket.find(i);
+      EXPECT_EQ(i, node.key);
+      EXPECT_EQ(fn(i), node.value);
+    }
+  }
+
+  {
+    const int length = 15;
+    auto fn = [](Key i) { return i * i * i - 1; };
+    BucketType bucket = ::init_filled_bucket<Key, T>(length, fn);
+
+    EXPECT_EQ(length, bucket.get_size());
+    EXPECT_EQ(length, bucket.get_capacity());
+
+    for(int i = 0; i < length; ++i)
+    {
+      auto& node = bucket.find(i);
+      EXPECT_EQ(i, node.key);
+      EXPECT_EQ(fn(i), node.value);
+    }
+  }
+}
+
+TEST(core_map, hashmap_return_value)
+{
+  {
+    const int buckets_num = 100;
+    const int buckets_len = 3;
+    auto fn = [](TestKey i) { return i * i + i; };
+
+    // Use the test map
+    {
+      auto map = ::init_filled_map<TestMap>(buckets_num, buckets_len, fn);
+
+      // Check that all expected values are present
+      const int sz = buckets_num;
+      for(int i = 0; i < sz; ++i)
+      {
+        TestKey k = i;
+        TestVal exp_value = fn(k);
+        TestVal value = map[k];
+        EXPECT_EQ(exp_value, value);
+      }
+    }
+    // Use a map with the default hash function
+    {
+      using DefaultHasherMap = experimental::Map<TestKey, TestVal>;
+      auto map =
+        ::init_filled_map<DefaultHasherMap>(buckets_num, buckets_len, fn);
+
+      // Check that all expected values are present
+      const int sz = buckets_num;
+      for(int i = 0; i < sz; ++i)
+      {
+        TestKey k = i;
+        TestVal exp_value = fn(k);
+        TestVal value = map[k];
+        EXPECT_EQ(exp_value, value);
+      }
+    }
+  }
+}

--- a/src/axom/core/tests/core_serial_main.cpp
+++ b/src/axom/core/tests/core_serial_main.cpp
@@ -11,10 +11,10 @@
 #include "core_array_for_all.hpp"
 #include "core_execution_for_all.hpp"
 #include "core_execution_space.hpp"
+#include "core_map.hpp"
 #include "core_memory_management.hpp"
 #include "core_Path.hpp"
 #include "core_stack_array.hpp"
-#include "core_map.hpp"
 
 #ifndef AXOM_USE_MPI
   #include "core_types.hpp"
@@ -31,14 +31,14 @@
 #include "numerics_matvecops.hpp"
 #include "numerics_polynomial_solvers.hpp"
 
-#include "utils_Timer.hpp"
+#include "utils_about.hpp"
 #include "utils_endianness.hpp"
 #include "utils_fileUtilities.hpp"
 #include "utils_nvtx_settings.hpp"
 #include "utils_stringUtilities.hpp"
 #include "utils_system.hpp"
+#include "utils_Timer.hpp"
 #include "utils_utilities.hpp"
-#include "utils_about.hpp"
 
 int main(int argc, char** argv)
 {

--- a/src/axom/core/tests/core_serial_main.cpp
+++ b/src/axom/core/tests/core_serial_main.cpp
@@ -7,13 +7,14 @@
 
 #include "axom/config.hpp"  // for compile-time definitions
 
+#include "core_array.hpp"
+#include "core_array_for_all.hpp"
 #include "core_execution_for_all.hpp"
 #include "core_execution_space.hpp"
 #include "core_memory_management.hpp"
 #include "core_Path.hpp"
 #include "core_stack_array.hpp"
 #include "core_map.hpp"
-#include "core_array.hpp"
 
 #ifndef AXOM_USE_MPI
   #include "core_types.hpp"
@@ -27,8 +28,8 @@
 #include "numerics_linear_solve.hpp"
 #include "numerics_lu.hpp"
 #include "numerics_matrix.hpp"
-#include "numerics_polynomial_solvers.hpp"
 #include "numerics_matvecops.hpp"
+#include "numerics_polynomial_solvers.hpp"
 
 #include "utils_Timer.hpp"
 #include "utils_endianness.hpp"


### PR DESCRIPTION
# Summary

- This PR improves testing of `axom::Array` and `axom::ArrayView` when called through `axom::for_all` kernels
- It adds a `view()` method to `axom::Array` to make it easier to get an `ArrayView` corresponding to an `Array`
- It highlights the need to mark lambdas as `mutable` if you want to modify the `ArrayView`'s data
- I also added a new macro -- `AXOM_TYPED_TEST` -- to allow using gtest's `TYPED_TESTS` with device code. The only difference was that it exposes `TestBody()` as a public method instead of a private method 

Thanks @joshessman-llnl  for a helpful discussion.
I noticed that there are potentially difficult-to-diagnose problems that can arise when (accidentally) using an `axom::Array` within a kernel. I attempted to resolve this, but after a few false turns created #724 to track this for a future PR.