### PR TITLE
Consolidate bit-twiddle functions

### DIFF
--- a/src/axom/core/utilities/BitUtilities.hpp
+++ b/src/axom/core/utilities/BitUtilities.hpp
@@ -120,6 +120,48 @@ AXOM_HOST_DEVICE inline int popCount(axom::uint64 word)
 #endif
 }
 
+//------------------------------------------------------------------------------
+//
+// count leading zeros
+//
+AXOM_HOST_DEVICE inline axom::int32 leadingZeros(axom::int32 x)
+{
+#ifdef AXOM_DEVICE_CODE
+  // Use CUDA intrinsic for count leading zeros
+  return __clz(x);
+#else
+  axom::int32 y;
+  axom::int32 n = 32;
+  y = x >> 16;
+  if(y != 0)
+  {
+    n = n - 16;
+    x = y;
+  }
+  y = x >> 8;
+  if(y != 0)
+  {
+    n = n - 8;
+    x = y;
+  }
+  y = x >> 4;
+  if(y != 0)
+  {
+    n = n - 4;
+    x = y;
+  }
+  y = x >> 2;
+  if(y != 0)
+  {
+    n = n - 2;
+    x = y;
+  }
+  y = x >> 1;
+  if(y != 0) return axom::int32(n - 2);
+  return axom::int32(n - x);
+#endif
+}
+
 }  // namespace utilities
 }  // namespace axom
 

--- a/src/axom/core/utilities/BitUtilities.hpp
+++ b/src/axom/core/utilities/BitUtilities.hpp
@@ -134,37 +134,37 @@ AXOM_HOST_DEVICE inline axom::int32 leadingZeros(axom::int32 word)
 {
 #ifdef AXOM_DEVICE_CODE
   // Use CUDA intrinsic for count leading zeros
-  return __clz(x);
+  return __clz(word);
 #else
   axom::int32 y;
   axom::int32 n = 32;
-  y = x >> 16;
+  y = word >> 16;
   if(y != 0)
   {
     n = n - 16;
-    x = y;
+    word = y;
   }
-  y = x >> 8;
+  y = word >> 8;
   if(y != 0)
   {
     n = n - 8;
-    x = y;
+    word = y;
   }
-  y = x >> 4;
+  y = word >> 4;
   if(y != 0)
   {
     n = n - 4;
-    x = y;
+    word = y;
   }
-  y = x >> 2;
+  y = word >> 2;
   if(y != 0)
   {
     n = n - 2;
-    x = y;
+    word = y;
   }
-  y = x >> 1;
+  y = word >> 1;
   if(y != 0) return axom::int32(n - 2);
-  return axom::int32(n - x);
+  return axom::int32(n - word);
 #endif
 }
 

--- a/src/axom/core/utilities/BitUtilities.hpp
+++ b/src/axom/core/utilities/BitUtilities.hpp
@@ -61,8 +61,8 @@ struct BitTraits<axom::uint8>
 };
 
 /**
- * Counts the number of trailing zeros in \a word
- *
+ * \brief Counts the number of trailing zeros in \a word
+ * \accelerated
  * \return The number of zeros to the right of the first set bit in \word,
  * starting with the least significant bit, or 64 if \a word == 0.
  */
@@ -93,7 +93,11 @@ AXOM_HOST_DEVICE inline int trailingZeros(axom::uint64 word)
 }
 /* clang-format on */
 
-/** Counts the number of set bits in \a word */
+/*!
+ * \brief Counts the number of set bits in \a word
+ * \accelerated
+ * \return number of bits in \a word that are set to 1
+ */
 AXOM_HOST_DEVICE inline int popCount(axom::uint64 word)
 {
 #ifdef AXOM_DEVICE_CODE
@@ -120,11 +124,13 @@ AXOM_HOST_DEVICE inline int popCount(axom::uint64 word)
 #endif
 }
 
-//------------------------------------------------------------------------------
-//
-// count leading zeros
-//
-AXOM_HOST_DEVICE inline axom::int32 leadingZeros(axom::int32 x)
+/*!
+ * \brief Counts the number of leading zeros in \a word
+ * \accelerated
+ * \return The number of zeros to the left of the first set bit in \word,
+ * starting with the least significant bit.
+ */
+AXOM_HOST_DEVICE inline axom::int32 leadingZeros(axom::int32 word)
 {
 #ifdef AXOM_DEVICE_CODE
   // Use CUDA intrinsic for count leading zeros

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -20,8 +20,9 @@
 
 #include "axom/spin/MortonIndex.hpp"
 
-#include "axom/core/utilities/Utilities.hpp"  // for isNearlyEqual()
-#include "axom/slic/interface/slic.hpp"       // for slic
+#include "axom/core/utilities/Utilities.hpp"     // for isNearlyEqual()
+#include "axom/core/utilities/BitUtilities.hpp"  // for leadingZeros()
+#include "axom/slic/interface/slic.hpp"          // for slic
 
 #if defined(AXOM_USE_RAJA)
   // RAJA includes
@@ -269,43 +270,6 @@ void sort_mcodes(uint32*& mcodes, int32 size, int32* iter)
 #endif /* RAJA version 0.12.0 and above */
 
 //------------------------------------------------------------------------------
-//
-// count leading zeros
-//
-inline AXOM_HOST_DEVICE axom::int32 clz(axom::int32 x)
-{
-  axom::int32 y;
-  axom::int32 n = 32;
-  y = x >> 16;
-  if(y != 0)
-  {
-    n = n - 16;
-    x = y;
-  }
-  y = x >> 8;
-  if(y != 0)
-  {
-    n = n - 8;
-    x = y;
-  }
-  y = x >> 4;
-  if(y != 0)
-  {
-    n = n - 4;
-    x = y;
-  }
-  y = x >> 2;
-  if(y != 0)
-  {
-    n = n - 2;
-    x = y;
-  }
-  y = x >> 1;
-  if(y != 0) return axom::int32(n - 2);
-  return axom::int32(n - x);
-}
-
-//------------------------------------------------------------------------------
 template <typename IntType, typename MCType>
 AXOM_HOST_DEVICE IntType delta(const IntType& a,
                                const IntType& b,
@@ -323,7 +287,7 @@ AXOM_HOST_DEVICE IntType delta(const IntType& a,
   tie = (exor == 0);
   //break the tie, a and b must always differ
   exor = tie ? uint32(a) ^ uint32(bb) : exor;
-  int32 count = clz(exor);
+  int32 count = axom::utilities::leadingZeros(exor);
   if(tie) count += 32;
   count = (out_of_range) ? -1 : count;
   return count;


### PR DESCRIPTION
# Summary

- Resolves #583 
- Adds call to `__clz()` CUDA intrinsic for `axom::utilities::leadingZeros()` function
