### PR TITLE
Sub-array indexing of multi-dimensional Array and ArrayView

### DIFF
--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -39,6 +39,9 @@ template <typename T, int DIM, MemorySpace SPACE>
 struct ArrayTraits<Array<T, DIM, SPACE>>
 {
   constexpr static bool is_view = false;
+
+  template <int SliceDim>
+  using Slice = ArrayView<T, DIM - SliceDim, SPACE>;
 };
 
 }  // namespace detail

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -697,7 +697,7 @@ template <typename T, int DIM, MemorySpace SPACE>
 template <typename... Args,
           typename std::enable_if<detail::all_types_are_integral<Args...>::value>::type*>
 Array<T, DIM, SPACE>::Array(Args... args)
-  : ArrayBase<T, DIM, Array<T, DIM, SPACE>>(args...)
+  : ArrayBase<T, DIM, Array<T, DIM, SPACE>>({args...})
   , m_allocator_id(axom::detail::getAllocatorID<SPACE>())
 {
   static_assert(sizeof...(Args) == DIM,
@@ -713,7 +713,7 @@ template <typename T, int DIM, MemorySpace SPACE>
 template <typename... Args,
           typename std::enable_if<detail::all_types_are_integral<Args...>::value>::type*>
 Array<T, DIM, SPACE>::Array(ArrayOptions::Uninitialized, Args... args)
-  : ArrayBase<T, DIM, Array<T, DIM, SPACE>>(args...)
+  : ArrayBase<T, DIM, Array<T, DIM, SPACE>>({args...})
   , m_allocator_id(axom::detail::getAllocatorID<SPACE>())
   , m_default_construct(false)
 {
@@ -1065,12 +1065,12 @@ inline void Array<T, DIM, SPACE>::resize(Args... args)
   static_assert(sizeof...(Args) == DIM,
                 "Array size must match number of dimensions");
   // Intel hits internal compiler error when casting as part of function call
-  const IndexType tmp_args[] = {args...};
+  const IndexType tmp_args[] = {static_cast<IndexType>(args)...};
   assert(detail::allNonNegative(tmp_args));
   const auto new_num_elements = detail::packProduct(tmp_args);
 
   static_cast<ArrayBase<T, DIM, Array<T, DIM, SPACE>>&>(*this) =
-    ArrayBase<T, DIM, Array<T, DIM, SPACE>> {static_cast<IndexType>(args)...};
+    ArrayBase<T, DIM, Array<T, DIM, SPACE>> {{static_cast<IndexType>(args)...}};
 
   const IndexType prev_num_elements = m_num_elements;
 

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -122,14 +122,15 @@ public:
     RealConstT&,
     typename detail::ArrayTraits<ArrayType>::template Slice<SliceDim>>::type;
 
-  ArrayBase() : m_dims {} { updateStrides(); }
+  AXOM_HOST_DEVICE ArrayBase() : m_dims {} { updateStrides(); }
 
   /*!
    * \brief Parameterized constructor that sets up the default strides
    *
    * \param [in] args the parameter pack of sizes in each dimension.
    */
-  ArrayBase(const StackArray<IndexType, DIM>& args) : m_dims {args}
+  AXOM_HOST_DEVICE ArrayBase(const StackArray<IndexType, DIM>& args)
+    : m_dims {args}
   {
     updateStrides();
   }
@@ -304,7 +305,7 @@ protected:
    * In the future, this class will support different striding schemes (e.g., column-major)
    * and/or user-provided striding
    */
-  void updateStrides()
+  AXOM_HOST_DEVICE void updateStrides()
   {
     // Row-major
     m_strides[DIM - 1] = 1;
@@ -405,9 +406,9 @@ public:
    */
   using RealConstT = typename std::conditional<is_array_view, T, const T>::type;
 
-  ArrayBase(IndexType = 0) { }
+  AXOM_HOST_DEVICE ArrayBase(IndexType = 0) { }
 
-  ArrayBase(const StackArray<IndexType, 1>&) { }
+  AXOM_HOST_DEVICE ArrayBase(const StackArray<IndexType, 1>&) { }
 
   // Empy implementation because no member data
   template <typename OtherArrayType>
@@ -607,9 +608,14 @@ namespace detail
 {
 // Takes the product of a parameter pack of T
 template <typename T, int N>
-T packProduct(const T (&arr)[N])
+AXOM_HOST_DEVICE T packProduct(const T (&arr)[N])
 {
-  return std::accumulate(arr, arr + N, 1, std::multiplies<T> {});
+  T prod = 1;
+  for(int idx = 0; idx < N; idx++)
+  {
+    prod *= arr[idx];
+  }
+  return prod;
 }
 
 template <typename T, int N>

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -186,6 +186,18 @@ public:
     return (*this)[indices];
   }
 
+  AXOM_HOST_DEVICE SliceType<1> operator[](const IndexType idx)
+  {
+    const StackArray<IndexType, 1> slice {idx};
+    return (*this)[slice];
+  }
+
+  AXOM_HOST_DEVICE ConstSliceType<1> operator[](const IndexType idx) const
+  {
+    const StackArray<IndexType, 1> slice {idx};
+    return (*this)[slice];
+  }
+
   template <int UDim>
   AXOM_HOST_DEVICE SliceType<UDim> operator[](const StackArray<IndexType, UDim>& idx)
   {

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -110,13 +110,14 @@ public:
    */
   using RealConstT = typename std::conditional<is_array_view, T, const T>::type;
 
+  ArrayBase() : m_dims {} { updateStrides(); }
+
   /*!
    * \brief Parameterized constructor that sets up the default strides
    *
    * \param [in] args the parameter pack of sizes in each dimension.
    */
-  template <typename... Args>
-  ArrayBase(Args... args) : m_dims {static_cast<IndexType>(args)...}
+  ArrayBase(const StackArray<IndexType, DIM>& args) : m_dims {args}
   {
     updateStrides();
   }
@@ -319,6 +320,8 @@ public:
   using RealConstT = typename std::conditional<is_array_view, T, const T>::type;
 
   ArrayBase(IndexType = 0) { }
+
+  ArrayBase(const StackArray<IndexType, 1>&) { }
 
   // Empy implementation because no member data
   template <typename OtherArrayType>

--- a/src/axom/core/ArrayIteratorBase.hpp
+++ b/src/axom/core/ArrayIteratorBase.hpp
@@ -48,8 +48,8 @@ public:
    */
   ValueType& operator*()
   {
-    return (*m_arrayPtr)[IteratorBase<ArrayIteratorBase<ArrayType, ValueType>,
-                                      IndexType>::m_pos];
+    return m_arrayPtr->flatIdx(
+      IteratorBase<ArrayIteratorBase<ArrayType, ValueType>, IndexType>::m_pos);
   }
 
 protected:

--- a/src/axom/core/ArrayView.hpp
+++ b/src/axom/core/ArrayView.hpp
@@ -143,7 +143,7 @@ using MCArrayView = ArrayView<T, 2>;
 template <typename T, int DIM, MemorySpace SPACE>
 template <typename... Args>
 ArrayView<T, DIM, SPACE>::ArrayView(T* data, Args... args)
-  : ArrayBase<T, DIM, ArrayView<T, DIM, SPACE>>(args...)
+  : ArrayBase<T, DIM, ArrayView<T, DIM, SPACE>>({args...})
   , m_data(data)
   , m_allocator_id(axom::detail::getAllocatorID<SPACE>())
 {

--- a/src/axom/core/examples/core_containers.cpp
+++ b/src/axom/core/examples/core_containers.cpp
@@ -164,7 +164,7 @@ void demoArrayBasic()
   std::cout << "Standard for loop over ArrayView c yields: ";
   for(int i = 0; i < c.size(); i++)
   {
-    std::cout << c[i] << " ";
+    std::cout << c.flatIdx(i) << " ";
   }
   std::cout << std::endl;
   // _iteration_end

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1453,6 +1453,21 @@ TEST(core_array, check_multidimensional)
     // For a multidim array, op[] is a "flat" index into the raw data
     EXPECT_EQ(v_double.flatIdx(i), v_double_flat[i]);
   }
+
+  for(int i = 0; i < v_double.shape()[0]; i++)
+  {
+    Array<double, 2> v_double_subarray_2d = v_double[i];
+    for(int j = 0; j < v_double.shape()[1]; j++)
+    {
+      Array<double> v_double_subarray_1d = v_double(i, j);
+      for(int k = 0; k < v_double.shape()[2]; k++)
+      {
+        EXPECT_EQ(v_double(i, j, k), v_double[i][j][k]);
+        EXPECT_EQ(v_double(i, j, k), v_double_subarray_2d(j, k));
+        EXPECT_EQ(v_double(i, j, k), v_double_subarray_1d[k]);
+      }
+    }
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -1520,6 +1535,21 @@ TEST(core_array, check_multidimensional_view)
   {
     // For a multidim array, op[] is a "flat" index into the raw data
     EXPECT_EQ(v_double_view.flatIdx(i), v_double_flat_view[i]);
+  }
+
+  for(int i = 0; i < v_double_view.shape()[0]; i++)
+  {
+    Array<double, 2> v_double_subarray_2d = v_double_view[i];
+    for(int j = 0; j < v_double_view.shape()[1]; j++)
+    {
+      Array<double> v_double_subarray_1d = v_double_view(i, j);
+      for(int k = 0; k < v_double_view.shape()[2]; k++)
+      {
+        EXPECT_EQ(v_double_view(i, j, k), v_double_view[i][j][k]);
+        EXPECT_EQ(v_double_view(i, j, k), v_double_subarray_2d(j, k));
+        EXPECT_EQ(v_double_view(i, j, k), v_double_subarray_1d[k]);
+      }
+    }
   }
 }
 

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -665,8 +665,8 @@ void check_swap(Array<T, DIM>& v)
   /* Push 0...size elements */
   for(int i = 0; i < v.size(); i++)
   {
-    v[i] = i;
-    v_two[i] = -i;
+    v.flatIdx(i) = i;
+    v_two.flatIdx(i) = -i;
   }
 
   /* Create copies */
@@ -1421,7 +1421,7 @@ TEST(core_array, check_multidimensional)
   for(int i = 0; i < v_int_flat.size(); i++)
   {
     // For a multidim array, op[] is a "flat" index into the raw data
-    EXPECT_EQ(v_int[i], v_int_flat[i]);
+    EXPECT_EQ(v_int.flatIdx(i), v_int_flat[i]);
   }
 
   Array<double, 3> v_double(4, 3, 2);
@@ -1451,7 +1451,7 @@ TEST(core_array, check_multidimensional)
   for(int i = 0; i < v_double.size(); i++)
   {
     // For a multidim array, op[] is a "flat" index into the raw data
-    EXPECT_EQ(v_double[i], v_double_flat[i]);
+    EXPECT_EQ(v_double.flatIdx(i), v_double_flat[i]);
   }
 }
 
@@ -1486,8 +1486,8 @@ TEST(core_array, check_multidimensional_view)
 
   for(int i = 0; i < v_int_flat_view.size(); i++)
   {
-    // For a multidim array, op[] is a "flat" index into the raw data
-    EXPECT_EQ(v_int_view[i], v_int_flat_view[i]);
+    // For a multidim array, flatIdx(i) is a "flat" index into the raw data
+    EXPECT_EQ(v_int_view.flatIdx(i), v_int_flat_view[i]);
   }
 
   double v_double_arr[4 * 3 * 2];
@@ -1519,7 +1519,7 @@ TEST(core_array, check_multidimensional_view)
   for(int i = 0; i < v_double_view.size(); i++)
   {
     // For a multidim array, op[] is a "flat" index into the raw data
-    EXPECT_EQ(v_double_view[i], v_double_flat_view[i]);
+    EXPECT_EQ(v_double_view.flatIdx(i), v_double_flat_view[i]);
   }
 }
 

--- a/src/axom/sidre/tests/sidre_mcarray.cpp
+++ b/src/axom/sidre/tests/sidre_mcarray.cpp
@@ -153,7 +153,7 @@ void check_storage(MCArray<T>& v)
     for(axom::IndexType j = 0; j < num_components; ++j)
     {
       EXPECT_EQ(v(i, j), i * num_components + j);
-      EXPECT_EQ(v[i * num_components + j], i * num_components + j);
+      EXPECT_EQ(v.flatIdx(i * num_components + j), i * num_components + j);
       EXPECT_EQ(data_ptr[i * num_components + j], i * num_components + j);
     }
   }
@@ -173,7 +173,7 @@ void check_storage(MCArray<T>& v)
     for(axom::IndexType j = 0; j < num_components; ++j)
     {
       EXPECT_EQ(v(i, j), i * j - 5 * i + 7 * j);
-      EXPECT_EQ(v[i * num_components + j], i * j - 5 * i + 7 * j);
+      EXPECT_EQ(v.flatIdx(i * num_components + j), i * j - 5 * i + 7 * j);
       EXPECT_EQ(data_ptr[i * num_components + j], i * j - 5 * i + 7 * j);
     }
   }


### PR DESCRIPTION
# Summary

This is an exploratory PR for handling multi-dimensional array sub-slicing.
- Allow for the creation of sub-arrays from multi-dimensional `ArrayBase::operator(Args... args)` when number of arguments is less than array's number of dimensions
  - Sub-array type is `ArrayView<T, N>` where `N = DIMS - IndexDims`
  - For `DIMS == IndexDims` sub-array type decays to scalar reference of full index into data array
- Add alternative indexing function `ArrayBase::operator[](StackArray<IndexType, UDim>& idxs)` as found in the mdspan paper
- Scalar `operator[](IndexType idx)` now returns a sub-array of dimensionality `DIMS - 1`; flat indexing now achieved by `ArrayBase::flatIdx(IndexType idx)`
  - This lets us do stuff like `double_vector_3d[i][j][k]` in addition to `double_vector_3d(i,j,k)`

## Open questions

- Should we have the iterator interface return over subarrays instead of over raw values as well?
- Are there any users that are using flat indexing via `operator[]`?
