### PR TITLE
Add test that puts strings from a vector into a Group with list format

### DIFF
--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -597,7 +597,8 @@ TEST(sidre_group, string_list)
   str_vec.push_back("format");
 
   // my_strings is a Group in list format.
-  Group* my_strings = root->createGroup("my_strings", true);
+  const bool use_list_collection = true;
+  Group* my_strings = root->createGroup("my_strings", use_list_collection);
 
   // Put strings into the Group.
   for(auto itr = str_vec.begin(); itr != str_vec.end(); ++itr)

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -603,6 +603,8 @@ TEST(sidre_group, string_list)
   // Put strings into the Group.
   for(auto itr = str_vec.begin(); itr != str_vec.end(); ++itr)
   {
+    // The first parameter will be ignored when creating a View in a Group
+    // that uses list collections, so we use the empty string
     View* str_view = my_strings->createViewString("", *itr);
     EXPECT_FALSE(str_view == nullptr);
     EXPECT_TRUE(str_view->isString());

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -450,6 +450,9 @@ TEST(sidre_group, get_first_and_next_group_index)
   delete ds;
 }
 
+//------------------------------------------------------------------------------
+// Verify Groups holding items in the list format
+//------------------------------------------------------------------------------
 TEST(sidre_group, child_lists)
 {
   DataStore* ds = new DataStore();
@@ -569,6 +572,55 @@ TEST(sidre_group, child_lists)
   root->destroyGroup("parent");
 
   delete ds;
+}
+
+//------------------------------------------------------------------------------
+// Test Group's list format for holding contents of a vector of strings.
+//------------------------------------------------------------------------------
+TEST(sidre_group, string_list)
+{
+  // Round-trip test from std::vector<std::string> to Group and back.
+  DataStore* ds = new DataStore();
+  Group* root = ds->getRoot();
+
+  std::vector<std::string> str_vec;
+  str_vec.push_back("This");
+  str_vec.push_back("is");
+  str_vec.push_back("a");
+  str_vec.push_back("vector");
+  str_vec.push_back("to");
+  str_vec.push_back("test");
+  str_vec.push_back("strings");
+  str_vec.push_back("in");
+  str_vec.push_back("sidre::Group's");
+  str_vec.push_back("list");
+  str_vec.push_back("format");
+
+  // my_strings is a Group in list format.
+  Group* my_strings = root->createGroup("my_strings", true);
+
+  // Put strings into the Group.
+  for(auto itr = str_vec.begin(); itr != str_vec.end(); ++itr)
+  {
+    View* str_view = my_strings->createViewString("", *itr);
+    EXPECT_FALSE(str_view == nullptr);
+    EXPECT_TRUE(str_view->isString());
+  }
+
+  std::vector<std::string> test_vec;
+
+  // Get strings from the Group.
+  for(IndexType idx = my_strings->getFirstValidViewIndex(); indexIsValid(idx);
+      idx = my_strings->getNextValidViewIndex(idx))
+  {
+    View* str_view = my_strings->getView(idx);
+    EXPECT_FALSE(str_view == nullptr);
+    EXPECT_TRUE(str_view->isString());
+    std::string vstr = str_view->getString();
+    test_vec.push_back(vstr);
+  }
+
+  EXPECT_TRUE(str_vec == test_vec);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

- This PR is a new test
- It does the following:
  - Adds a test that puts strings from a vector of strings into a sidre `Group` using `Group`'s list format, which uses `ListCollection` under the hood.
  - Demonstrates how the list format can be used to address the request in #746 