### PR TITLE
Bugfix point in cell query

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -36,8 +36,10 @@ Lee A. Taylor <taylor16@llnl.gov>               Lee A. Taylor <taylor@cab688.lln
 Lee A. Taylor <taylor16@llnl.gov>               Lee Taylor <ltaylor@llnl.gov>
 Lee A. Taylor <taylor16@llnl.gov>               Lee Taylor <taylor16@llnl.gov>
 Lee A. Taylor <taylor16@llnl.gov>               Lee Taylor <31938638+ltaylor16@users.noreply.github.com>
-Matt Larsen <larsen30@llnl.gov>		            mclarsen <larsen30@llnl.gov>
+Matt Larsen <larsen30@llnl.gov>                 mclarsen <larsen30@llnl.gov>
 Max Yang <yang39@llnl.gov>                      kanye-quest <yang39@llnl.gov>
+Misha Zakharchanka <mishaz@llnl.gov>            Misha Zakharchanka <35752952+MishaZakharchanka@users.noreply.github.com>
+Misha Zakharchanka <mishaz@llnl.gov>            MishaZakharchanka <mishaz@rzgenie16.llnl.gov>
 Noah S. Elliott <elliott22@llnl.gov>            Noah Elliott <elliott22@llnl.gov>
 Punita P. Sinha <sinha2@llnl.gov>               Punita P. Sinha <sinha2@cab687.llnl.gov>
 Punita P. Sinha <sinha2@llnl.gov>               Punita P. Sinha <sinha2@cab669.llnl.gov>

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -51,6 +51,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Fixed over-eager caching of restored `mfem::FiniteElementSpaces` in `sidre::MFEMSidreDataCollection`
 - Fixed a bug in which Inlet verification bails out on the first failure, which resulted in
   incomplete error lists
+- Fixed a bug in `quest::PointInCell` when not using RAJA
 
 ## [Version 0.6.1] - Release date 2021-11-17
 

--- a/src/axom/quest/PointInCell.hpp
+++ b/src/axom/quest/PointInCell.hpp
@@ -89,15 +89,14 @@ template <typename mesh_tag, typename ExecSpace = axom::SEQ_EXEC>
 class PointInCell
 {
 public:
+  using Point2DType = primal::Point<double, 2>;
+  using Point3DType = primal::Point<double, 3>;
+
   using MeshTraits = PointInCellTraits<mesh_tag>;
   using MeshType = typename MeshTraits::MeshType;
   using IndexType = typename MeshTraits::IndexType;
 
-  using Point2DType = primal::Point<double, 2>;
-  using Point3DType = primal::Point<double, 3>;
-
   using MeshWrapperType = detail::PointInCellMeshWrapper<mesh_tag>;
-
   using PointFinder2D = detail::PointFinder<2, mesh_tag, ExecSpace>;
   using PointFinder3D = detail::PointFinder<3, mesh_tag, ExecSpace>;
 

--- a/src/axom/quest/detail/PointFinder.hpp
+++ b/src/axom/quest/detail/PointFinder.hpp
@@ -42,13 +42,13 @@ template <int NDIMS, typename mesh_tag, typename ExecSpace>
 class PointFinder
 {
 public:
-  using GridType = spin::ImplicitGrid<NDIMS, ExecSpace>;
+  using MeshWrapperType = PointInCellMeshWrapper<mesh_tag>;
+  using IndexType = typename MeshWrapperType::IndexType;
+
+  using GridType = spin::ImplicitGrid<NDIMS, ExecSpace, IndexType>;
 
   using SpacePoint = typename GridType::SpacePoint;
   using SpatialBoundingBox = typename GridType::SpatialBoundingBox;
-
-  using MeshWrapperType = PointInCellMeshWrapper<mesh_tag>;
-  using IndexType = typename MeshWrapperType::IndexType;
 
 private:
   constexpr static bool DeviceExec = axom::execution_space<ExecSpace>::onDevice();

--- a/src/axom/quest/detail/PointFinder.hpp
+++ b/src/axom/quest/detail/PointFinder.hpp
@@ -314,6 +314,7 @@ public:
     {
       SpacePoint pt = pts[i];
       SpacePoint isopar;
+      outCellIds[i] = PointInCellTraits<mesh_tag>::NO_CELL;
       gridQuery.visitCandidates(pt, [&](int candidateIdx) -> bool {
         if(m_cellBBoxes[candidateIdx].contains(pts[i]))
         {

--- a/src/axom/quest/detail/PointInCellMeshWrapper_mfem.hpp
+++ b/src/axom/quest/detail/PointInCellMeshWrapper_mfem.hpp
@@ -7,7 +7,7 @@
 #define AXOM_QUEST_POINT_IN_CELL_MFEM_IMPL_HPP_
 
 /*!
- * \file
+ * \file PointInCellMeshWrapper_mfem.hpp
  *
  * This file contains implementation classes for an mfem-based
  * specialization of quest's PointInCell query on meshes or
@@ -57,8 +57,8 @@ template <>
 struct PointInCellTraits<quest_point_in_cell_mfem_tag>
 {
 public:
-  typedef mfem::Mesh MeshType;
-  typedef int IndexType;
+  using MeshType = mfem::Mesh;
+  using IndexType = int;
 
   /*!  Special value to indicate an unsuccessful query */
   enum Values : IndexType
@@ -86,8 +86,8 @@ template <>
 class PointInCellMeshWrapper<quest_point_in_cell_mfem_tag>
 {
 public:
-  typedef int IndexType;
-  typedef PointInCellMeshWrapper<quest_point_in_cell_mfem_tag> MeshWrapper;
+  using IndexType = int;
+  using MeshWrapper = PointInCellMeshWrapper<quest_point_in_cell_mfem_tag>;
 
   PointInCellMeshWrapper(mfem::Mesh* mesh) : m_mesh(mesh)
   {
@@ -287,8 +287,8 @@ private:
     axom::primal::BoundingBox<double, NDIMS>* eltBBoxes,
     axom::primal::BoundingBox<double, NDIMS>& meshBBox) const
   {
-    typedef axom::primal::Point<double, NDIMS> SpacePoint;
-    typedef axom::primal::BoundingBox<double, NDIMS> SpatialBoundingBox;
+    using SpacePoint = axom::primal::Point<double, NDIMS>;
+    using SpatialBoundingBox = axom::primal::BoundingBox<double, NDIMS>;
 
     // Sanity checks
     SLIC_ASSERT(m_isHighOrder);
@@ -402,8 +402,8 @@ private:
     axom::primal::BoundingBox<double, NDIMS>* eltBBoxes,
     axom::primal::BoundingBox<double, NDIMS>& meshBBox) const
   {
-    typedef axom::primal::Point<double, NDIMS> SpacePoint;
-    typedef axom::primal::BoundingBox<double, NDIMS> SpatialBoundingBox;
+    using SpacePoint = axom::primal::Point<double, NDIMS>;
+    using SpatialBoundingBox = axom::primal::BoundingBox<double, NDIMS>;
 
     SLIC_ASSERT(!m_isHighOrder);
     SLIC_ASSERT(bboxScaleFactor >= 1.);

--- a/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
+++ b/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
@@ -476,7 +476,7 @@ public:
 
   int getAllocatorId() const { return m_allocatorID; }
 
-  double getTolerance() const { return m_EPS;}
+  double getTolerance() const { return m_EPS; }
 
 protected:
   std::string m_meshDescriptorStr;

--- a/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
+++ b/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
@@ -13,16 +13,10 @@
 #include "gtest/gtest.h"
 
 #include "axom/config.hpp"
-#include "axom/core/utilities/Timer.hpp"
-
-#include "axom/mint/mesh/CurvilinearMesh.hpp"
-#include "axom/mint/mesh/FieldVariable.hpp"
-#include "axom/mint/utils/vtk_utils.hpp"
-
-#include "axom/primal/geometry/Point.hpp"
-#include "axom/primal/geometry/BoundingBox.hpp"
-
-#include "axom/spin/ImplicitGrid.hpp"
+#include "axom/core.hpp"
+#include "axom/mint.hpp"
+#include "axom/primal.hpp"
+#include "axom/spin.hpp"
 // _quest_pic_include_start
 #include "axom/quest/PointInCell.hpp"
 
@@ -108,15 +102,15 @@ public:
   using BBox = axom::primal::BoundingBox<double, DIM>;
   using SpacePt = axom::primal::Point<double, DIM>;
   using SpaceVec = axom::primal::Vector<double, DIM>;
+
   // _quest_pic_typedef_start
-  using GridCell = axom::primal::Point<int, DIM>;
-
   using mesh_tag = axom::quest::quest_point_in_cell_mfem_tag;
-  using MeshTraits = axom::quest::PointInCellTraits<mesh_tag>;
-
   using PointInCellType = axom::quest::PointInCell<mesh_tag, ExecSpace>;
+  using MeshTraits = typename PointInCellType::MeshTraits;
   using IndexType = typename PointInCellType::IndexType;
   // _quest_pic_typedef_end
+
+  using GridCell = axom::primal::Point<IndexType, DIM>;
 
 public:
   PointInCellTest()
@@ -272,15 +266,18 @@ public:
     axom::Array<SpacePt> pts;
 
     const int k_max = (DIM == 3) ? res : 0;
+    const int sz = (res + 1) * (res + 1) * (k_max + 1);
+    pts.reserve(sz);
+
     for(int i = 0; i <= res; ++i)
       for(int j = 0; j <= res; ++j)
         for(int k = 0; k <= k_max; ++k)
         {
           // Get the corresponding isoparametric value
           // Note: point constructor ignores coordinates higher than point's DIM
-          pts.emplace_back(SpacePt {static_cast<double>(i) / res,
-                                    static_cast<double>(j) / res,
-                                    static_cast<double>(k) / res});
+          pts.push_back(SpacePt {static_cast<double>(i) / res,
+                                 static_cast<double>(j) / res,
+                                 static_cast<double>(k) / res});
         }
 
     return pts;

--- a/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
+++ b/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
@@ -291,7 +291,7 @@ public:
     // Generate a PointInCell structure over the mesh
     axom::utilities::Timer constructTimer(true);
     // _quest_pic_init_start
-    PointInCellType spatialIndex(m_mesh, GridCell(25).data(), m_EPS, m_allocatorID);
+    PointInCellType spatialIndex(m_mesh, GridCell(25).data(), m_EPS);
     // _quest_pic_init_end
     SLIC_INFO(axom::fmt::format(
       "Constructing index over {} quad mesh with {} elems took {} s",
@@ -381,7 +381,7 @@ public:
 
     // Add mesh to the grid
     axom::utilities::Timer constructTimer(true);
-    PointInCellType spatialIndex(m_mesh, GridCell(25).data(), m_EPS, m_allocatorID);
+    PointInCellType spatialIndex(m_mesh, GridCell(25).data(), m_EPS);
     SLIC_INFO(axom::fmt::format(
       "Constructing index over {} quad mesh with {} elems took {} s",
       meshTypeStr,
@@ -1179,20 +1179,14 @@ TYPED_TEST(PointInCell2DTest, pic_curved_quad_c_shaped)
 
   // Create PointInCell structures over mesh1 and mesh2
   axom::utilities::Timer constructTimer(true);
-  PointInCellType spatialIndex1(&mesh1,
-                                GridCell(10).data(),
-                                this->getTolerance(),
-                                this->getAllocatorId());
+  PointInCellType spatialIndex1(&mesh1, GridCell(10).data(), this->getTolerance());
   SLIC_INFO(axom::fmt::format(
     "Constructing index over curved quad mesh1 with {} elems took {} s",
     mesh1.GetNE(),
     constructTimer.elapsed()));
 
   axom::utilities::Timer constructTimer2(true);
-  PointInCellType spatialIndex2(&mesh2,
-                                GridCell(10).data(),
-                                this->getTolerance(),
-                                this->getAllocatorId());
+  PointInCellType spatialIndex2(&mesh2, GridCell(10).data(), this->getTolerance());
   SLIC_INFO(axom::fmt::format(
     "Constructing index over curved quad mesh2 with {} elems took {} s",
     mesh2.GetNE(),
@@ -1337,10 +1331,7 @@ TYPED_TEST(PointInCell2DTest, pic_curved_quad_c_shaped_output_mesh)
   // mesh1 contains a single C-shaped quadratic quad element
   mfem::Mesh& mesh1 = *this->getMesh();
 
-  PointInCellType spatialIndex1(&mesh1,
-                                GridCell(5).data(),
-                                this->getTolerance(),
-                                this->getAllocatorId());
+  PointInCellType spatialIndex1(&mesh1, GridCell(5).data(), this->getTolerance());
 
   /// spatialIndex1.enableDebugMeshGeneration();
 

--- a/src/axom/slam/BitSet.hpp
+++ b/src/axom/slam/BitSet.hpp
@@ -116,7 +116,7 @@ public:
   using Index = int;
   using Word = axom::uint64;
 
-  // Use vector for initial implementation -- TODO: update using a policy
+  // TODO: update using a policy
   using ArrayType = axom::Array<Word>;
 
   static constexpr Index npos = -2;
@@ -146,7 +146,7 @@ public:
       "slam::BitSet must be initialized with a non-zero number of bits");
 
     m_numBits = axom::utilities::max(numBits, 0);
-    IndexType numWords = (m_numBits == 0) ? 1 : 1 + (m_numBits - 1) / BitsPerWord;
+    Index numWords = (m_numBits == 0) ? 1 : 1 + (m_numBits - 1) / BitsPerWord;
 
     m_data = ArrayType(numWords, numWords, allocatorID);
     m_data.fill(0);

--- a/src/axom/slam/BitSet.hpp
+++ b/src/axom/slam/BitSet.hpp
@@ -117,7 +117,7 @@ public:
   using Word = axom::uint64;
 
   // TODO: update using a policy
-  using ArrayType = axom::Array<Word>;
+  using ArrayType = axom::Array<Word, 1>;
 
   static constexpr Index npos = -2;
   static constexpr int BitsPerWord =
@@ -146,7 +146,8 @@ public:
       "slam::BitSet must be initialized with a non-zero number of bits");
 
     m_numBits = axom::utilities::max(numBits, 0);
-    Index numWords = (m_numBits == 0) ? 1 : 1 + (m_numBits - 1) / BitsPerWord;
+    axom::IndexType numWords =
+      (m_numBits == 0) ? 1 : 1 + (m_numBits - 1) / BitsPerWord;
 
     m_data = ArrayType(numWords, numWords, allocatorID);
     m_data.fill(0);

--- a/src/axom/spin/tests/spin_implicit_grid.cpp
+++ b/src/axom/spin/tests/spin_implicit_grid.cpp
@@ -460,8 +460,6 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_pt_vectorized)
             << axom::execution_space<typename TestFixture::ExecSpace>::name()
             << " execution space for points in " << DIM << "D");
 
-  using IndexType = typename GridT::IndexType;
-
   // Note: A 10 x 10 x 10 implicit grid in the unit cube.
   //       Grid cells have a spacing of .1 along each dimension
   GridCell res(10);
@@ -734,8 +732,6 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_box_vectorized)
   SLIC_INFO("Test ImplicitGrid getCandidatesAsArray() with "
             << axom::execution_space<typename TestFixture::ExecSpace>::name()
             << " execution space for boxes in " << DIM << "D");
-
-  using IndexType = typename GridT::IndexType;
 
   // Note: A 10 x 10 x 10 implicit grid in the unit cube.
   //       Grid cells have a spacing of .1 along each dimension


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It resolves #755 
- It adds a missing 3rd parameter to the `PointInCell` class. The 3rd and 4th parameters have default values, and the code was supplying the 1st, 2nd and 4th parameters.
  - **Update:** I had to remove the fourth parameter from `PointInCell` invocation in the `point_in_cell_mfem` unit tests. This will be resolved in #757 
- It also initializes a variable that was not being initialized in non-RAJA runs (like our manual Windows CI, which have `mfem` and `conduit`, but do not yet have `raja` or `umpire`)
