### PR TITLE
Small usability improvement for `slic::SimpleLogger`

### DIFF
--- a/src/axom/inlet/tests/inlet_Inlet.cpp
+++ b/src/axom/inlet/tests/inlet_Inlet.cpp
@@ -3,20 +3,19 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+#include "axom/slic.hpp"
+#include "axom/sidre.hpp"
+
+#include "axom/inlet/Inlet.hpp"
+#include "axom/inlet/tests/inlet_test_utils.hpp"
+
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
 #include <string>
 #include <vector>
 #include <unordered_map>
-
 #include <iostream>
-
-#include "axom/sidre.hpp"
-
-#include "axom/inlet/Inlet.hpp"
-
-#include "axom/inlet/tests/inlet_test_utils.hpp"
 
 using axom::inlet::Container;
 using axom::inlet::Field;
@@ -1627,18 +1626,12 @@ TEST(inlet_Inlet_array_lua, inletArraysInSidre)
 #endif
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/inlet/tests/inlet_Reader.cpp
+++ b/src/axom/inlet/tests/inlet_Reader.cpp
@@ -3,15 +3,16 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+#include "axom/config.hpp"
+#include "axom/slic.hpp"
+
+#include "axom/inlet/tests/inlet_test_utils.hpp"
+
 #include "gtest/gtest.h"
 
 #include <string>
 #include <vector>
 #include <memory>
-
-#include "axom/config.hpp"
-
-#include "axom/inlet/tests/inlet_test_utils.hpp"
 
 template <typename InletReader>
 class inlet_Reader : public testing::Test
@@ -423,18 +424,12 @@ TEST(inlet_Reader_lua, getDiscontiguousMap)
 #endif
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/inlet/tests/inlet_errors.cpp
+++ b/src/axom/inlet/tests/inlet_errors.cpp
@@ -3,10 +3,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "gtest/gtest.h"
+#include "axom/slic.hpp"
 
 #include "axom/inlet/Inlet.hpp"
 #include "axom/inlet/tests/inlet_test_utils.hpp"
+
+#include "gtest/gtest.h"
 
 using axom::inlet::Inlet;
 using axom::inlet::VerificationError;
@@ -393,18 +395,12 @@ TEST(inlet_errors_lua, function_verifier)
 #endif
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/inlet/tests/inlet_function.cpp
+++ b/src/axom/inlet/tests/inlet_function.cpp
@@ -3,19 +3,19 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+#include "axom/slic.hpp"
+#include "axom/sidre.hpp"
+
+#include "axom/inlet/LuaReader.hpp"
+#include "axom/inlet/Inlet.hpp"
+
 #include "gtest/gtest.h"
 
 #include <array>
 #include <string>
 #include <vector>
 #include <unordered_map>
-
 #include <iostream>
-
-#include "axom/sidre.hpp"
-
-#include "axom/inlet/LuaReader.hpp"
-#include "axom/inlet/Inlet.hpp"
 
 using axom::inlet::FunctionTag;
 using axom::inlet::FunctionType;
@@ -743,18 +743,12 @@ TEST(inlet_function_usertype, lua_usertype_named_access)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/inlet/tests/inlet_jsonschema_writer.cpp
+++ b/src/axom/inlet/tests/inlet_jsonschema_writer.cpp
@@ -3,19 +3,20 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+#include "axom/slic.hpp"
+
+#include "axom/inlet/Inlet.hpp"
+#include "axom/inlet/JSONSchemaWriter.hpp"
+#include "axom/inlet/tests/inlet_test_utils.hpp"
+
 #include "gtest/gtest.h"
 
 #include <cstdlib>
-
 #include <string>
 #include <vector>
 #include <memory>
 #include <fstream>
 #include <streambuf>
-
-#include "axom/inlet/Inlet.hpp"
-#include "axom/inlet/JSONSchemaWriter.hpp"
-#include "axom/inlet/tests/inlet_test_utils.hpp"
 
 using axom::inlet::Inlet;
 using axom::inlet::JSONSchemaWriter;
@@ -224,18 +225,12 @@ TYPED_TEST(inlet_jsonschema_writer, top_level_strings_valid_set_fail)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -3,6 +3,13 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+#include "axom/core/Path.hpp"
+#include "axom/slic/core/SimpleLogger.hpp"
+#include "axom/sidre.hpp"
+
+#include "axom/inlet/Inlet.hpp"
+#include "axom/inlet/tests/inlet_test_utils.hpp"
+
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
@@ -10,14 +17,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
-
 #include <iostream>
-
-#include "axom/core/Path.hpp"
-#include "axom/sidre.hpp"
-
-#include "axom/inlet/Inlet.hpp"
-#include "axom/inlet/tests/inlet_test_utils.hpp"
 
 using axom::Path;
 using axom::inlet::Inlet;
@@ -1448,18 +1448,12 @@ TEST(inlet_object_lua_dict, mixed_keys_object)
 #endif
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/examples/mint_nbody_solver.cpp
+++ b/src/axom/mint/examples/mint_nbody_solver.cpp
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 /*!
- * \file
+ * \file mint_nbody_solver.cpp
  *
  * \brief A simple, naive, N-Body solver to illustrate the use of the
  *  ParticleMesh class. The N-Body solver simulates a collection of N particles
@@ -19,7 +19,6 @@
 
 // Axom namespace aliases
 namespace mint = axom::mint;
-namespace slic = axom::slic;
 namespace utilities = axom::utilities;
 
 // C/C++ includes
@@ -52,7 +51,7 @@ void apply_forces(mint::ParticleMesh& particles, double dt);
 int main(int argc, char** argv)
 {
   // STEP 0: initialize logger & parse arguments
-  slic::SimpleLogger logger;
+  axom::slic::SimpleLogger logger;
   parse_arguments(argc, argv);
 
   // STEP 1: construct particle mesh

--- a/src/axom/mint/examples/mint_unstructured_mixed_topology_mesh.cpp
+++ b/src/axom/mint/examples/mint_unstructured_mixed_topology_mesh.cpp
@@ -28,7 +28,7 @@ inline bool appendQuad(axom::IndexType i, axom::IndexType j)
 //------------------------------------------------------------------------------
 int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
 {
-  axom::slic::SimpleLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger
 
   constexpr int DIMENSION = 2;
   constexpr axom::IndexType X_EXTENT = 11;

--- a/src/axom/mint/examples/mint_unstructured_mixed_topology_mesh.cpp
+++ b/src/axom/mint/examples/mint_unstructured_mixed_topology_mesh.cpp
@@ -16,10 +16,9 @@
 #include "axom/slic.hpp"
 
 // C/C++ includes
-#include <random> /* for random number generator */
+#include <random>
 
 using namespace axom;
-using axom::slic::SimpleLogger;
 
 inline bool appendQuad(axom::IndexType i, axom::IndexType j)
 {
@@ -29,7 +28,7 @@ inline bool appendQuad(axom::IndexType i, axom::IndexType j)
 //------------------------------------------------------------------------------
 int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
 {
-  SimpleLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   constexpr int DIMENSION = 2;
   constexpr axom::IndexType X_EXTENT = 11;

--- a/src/axom/mint/examples/mint_unstructured_single_topology_mesh.cpp
+++ b/src/axom/mint/examples/mint_unstructured_single_topology_mesh.cpp
@@ -16,12 +16,11 @@
 #include "axom/slic.hpp"
 
 using namespace axom;
-using axom::slic::SimpleLogger;
 
 //------------------------------------------------------------------------------
 int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
 {
-  SimpleLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   constexpr int DIMENSION = 2;
   constexpr axom::IndexType X_EXTENT = 11;

--- a/src/axom/mint/examples/mint_unstructured_single_topology_mesh.cpp
+++ b/src/axom/mint/examples/mint_unstructured_single_topology_mesh.cpp
@@ -20,7 +20,7 @@ using namespace axom;
 //------------------------------------------------------------------------------
 int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
 {
-  axom::slic::SimpleLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;
 
   constexpr int DIMENSION = 2;
   constexpr axom::IndexType X_EXTENT = 11;

--- a/src/axom/mint/tests/mint_deprecated_mcarray.cpp
+++ b/src/axom/mint/tests/mint_deprecated_mcarray.cpp
@@ -3,13 +3,14 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/mint/deprecated/MCArray.hpp" /* for axom::deprecated::MCArray */
-#include "axom/core/memory_management.hpp"  /* for alloc() and free() */
+#include "axom/slic.hpp"
+#include "axom/core/memory_management.hpp"
+#include "axom/mint/deprecated/MCArray.hpp"
 
-#include "gtest/gtest.h" /* for TEST and EXPECT_* macros */
+#include "gtest/gtest.h"
 
 // C/C++ includes
-#include <algorithm> /* for std::fill_n */
+#include <algorithm>
 
 namespace axom
 {
@@ -1047,18 +1048,12 @@ TEST(core_mcarray_DeathTest, checkExternal)
 } /* end namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_execution_cell_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_cell_traversals.cpp
@@ -4,22 +4,22 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 // Axom includes
-#include "axom/config.hpp"                          // compile-time definitions
-#include "axom/core/execution/execution_space.hpp"  // for execution_space traits
-#include "axom/core/utilities/Utilities.hpp"        // for alloc() /free()
-#include "axom/core/numerics/Matrix.hpp"            // for Matrix
+#include "axom/config.hpp"
+#include "axom/core/execution/execution_space.hpp"
+#include "axom/core/utilities/Utilities.hpp"
+#include "axom/core/numerics/Matrix.hpp"
 
 // Mint includes
-#include "axom/mint/config.hpp"               // mint compile-time definitions
-#include "axom/mint/execution/interface.hpp"  // for_all()
+#include "axom/mint/config.hpp"
+#include "axom/mint/execution/interface.hpp"
 
 // Slic includes
-#include "axom/slic.hpp"  // for SLIC macros
+#include "axom/slic.hpp"
 
 #include "mint_test_utilities.hpp"
 
 // gtest includes
-#include "gtest/gtest.h"  // for gtest
+#include "gtest/gtest.h"
 
 namespace axom
 {
@@ -604,18 +604,12 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_index)
 } /* namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_execution_face_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_face_traversals.cpp
@@ -426,18 +426,12 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_faces_index)
 } /* namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_execution_node_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_node_traversals.cpp
@@ -576,18 +576,12 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_index)
 } /* namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_execution_xargs.cpp
+++ b/src/axom/mint/tests/mint_execution_xargs.cpp
@@ -4,10 +4,10 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "axom/mint/execution/xargs.hpp"  // execution xargs types/traits
-#include "axom/slic/interface/slic.hpp"   // for SLIC macros
+#include "axom/slic.hpp"
 
 // gtest includes
-#include "gtest/gtest.h"  // for gtest macros
+#include "gtest/gtest.h"
 
 // C/C++ includes
 #include <cstring>
@@ -57,18 +57,12 @@ TEST(mint_execution_xargs, check_types)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_fem_shape_functions.cpp
+++ b/src/axom/mint/tests/mint_fem_shape_functions.cpp
@@ -11,7 +11,7 @@
 #include "axom/mint/fem/FEBasisTypes.hpp"
 #include "axom/mint/mesh/CellTypes.hpp"
 
-#include "axom/slic/interface/slic.hpp"
+#include "axom/slic.hpp"
 
 // C/C++ includes
 #include <limits>
@@ -239,18 +239,12 @@ TEST(mint_fem_shape_functions, check_partition_of_unity)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_fem_single_fe.cpp
+++ b/src/axom/mint/tests/mint_fem_single_fe.cpp
@@ -7,10 +7,11 @@
 
 // Axom includes
 #include "axom/config.hpp"
-#include "axom/core/Types.hpp"  // for nullptr
+#include "axom/core/Types.hpp"
+#include "axom/slic.hpp"
 
-#include "axom/core/numerics/Matrix.hpp"        // for Matrix class definition
-#include "axom/core/numerics/Determinants.hpp"  // for numerics::determinant()
+#include "axom/core/numerics/Matrix.hpp"
+#include "axom/core/numerics/Determinants.hpp"
 
 // Mint includes
 #include "axom/mint/mesh/CellTypes.hpp"
@@ -25,9 +26,6 @@
 #include "axom/mint/fem/shape_functions/ShapeFunction.hpp"
 #include "axom/mint/mesh/UnstructuredMesh.hpp"
 #include "axom/mint/utils/vtk_utils.hpp"
-
-// Slic includes
-#include "axom/slic/interface/slic.hpp"
 
 // C/C++ includes
 #include <cmath>  // for sin(), cos(), sqrt(), etc.
@@ -1000,18 +998,12 @@ TEST(mint_fem_single_fe, check_fe_interp)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_mesh.cpp
+++ b/src/axom/mint/tests/mint_mesh.cpp
@@ -18,7 +18,8 @@
 namespace sidre = axom::sidre;
 #endif
 
-#include "gtest/gtest.h"  // for gtest macros
+#include "axom/slic.hpp"
+#include "gtest/gtest.h"
 
 // C/C++ includes
 #include <cmath>    // for cosh, etc.
@@ -730,18 +731,12 @@ TEST(mint_mesh, get_mixed_topology_unstructured_from_sidre)
 } /* namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_mesh_blueprint.cpp
+++ b/src/axom/mint/tests/mint_mesh_blueprint.cpp
@@ -4,9 +4,10 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 #include "axom/mint/mesh/blueprint.hpp"
 
-// Mint includes
+// axom includes
 #include "axom/mint/config.hpp"          // for compile-time definitions
 #include "axom/mint/mesh/MeshTypes.hpp"  // for MeshTypes enum
+#include "axom/slic.hpp"
 
 // gtest includes
 #include "gtest/gtest.h"
@@ -370,18 +371,12 @@ TEST(mint_mesh_blueprint, get_set_uniform_mesh)
 #endif /* AXOM_MINT_USE_SIDRE */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_mesh_cell_types.cpp
+++ b/src/axom/mint/tests/mint_mesh_cell_types.cpp
@@ -4,14 +4,14 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 // Axom includes
-#include "axom/slic/interface/slic.hpp"  // for slic macros
-#include "axom/mint/mesh/CellTypes.hpp"  // for CellTypes
+#include "axom/slic.hpp"
+#include "axom/mint/mesh/CellTypes.hpp"
 
 // gtest includes
-#include "gtest/gtest.h"  // for gtest macros
+#include "gtest/gtest.h"
 
 // C/C++ includes
-#include <cstring>  // for strlen()
+#include <cstring>
 
 // namespace aliases
 namespace mint = axom::mint;
@@ -200,18 +200,12 @@ TEST(mint_mesh_cell_types, check_cell_types)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_mesh_connectivity_array.cpp
+++ b/src/axom/mint/tests/mint_mesh_connectivity_array.cpp
@@ -13,8 +13,7 @@
 #include "axom/mint/mesh/ConnectivityArray.hpp"
 #include "axom/mint/mesh/CellTypes.hpp"
 #include "axom/mint/config.hpp"
-#include "axom/slic/interface/slic.hpp"
-#include "axom/slic/core/SimpleLogger.hpp" /* for SimpleLogger */
+#include "axom/slic.hpp"
 
 #ifdef AXOM_MINT_USE_SIDRE
   #include "axom/sidre/core/sidre.hpp"
@@ -2066,13 +2065,12 @@ TEST(mint_connectivity_array_DeathTest, IndirectionSidreCapacity)
 } /* end namespace axom */
 
 //------------------------------------------------------------------------------
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
   ::testing::InitGoogleTest(&argc, argv);
-  SimpleLogger logger;
+  axom::slic::SimpleLogger logger;
+
   result = RUN_ALL_TESTS();
   return result;
 }

--- a/src/axom/mint/tests/mint_mesh_coordinates.cpp
+++ b/src/axom/mint/tests/mint_mesh_coordinates.cpp
@@ -3,18 +3,17 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/slic/interface/slic.hpp"  // for slic macros
+#include "axom/core/utilities/Utilities.hpp"
+#include "axom/slic.hpp"
 
-#include "axom/core/utilities/Utilities.hpp"  // for utilities::max()
-
-#include "axom/mint/config.hpp"                // for IndexType
-#include "axom/mint/mesh/MeshCoordinates.hpp"  // for MeshCoordinates
+#include "axom/mint/config.hpp"
+#include "axom/mint/mesh/MeshCoordinates.hpp"
 
 #ifdef AXOM_MINT_USE_SIDRE
-  #include "axom/sidre/core/sidre.hpp"  // for sidre::Group, View, Array
+  #include "axom/sidre/core/sidre.hpp"
 #endif
 
-#include "gtest/gtest.h"  // for gtest macros
+#include "gtest/gtest.h"
 
 namespace utilities = axom::utilities;
 
@@ -1382,18 +1381,12 @@ TEST(mint_mesh_coordinates_DeathTest, invalid_construction)
 } /* namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_mesh_curvilinear_mesh.cpp
+++ b/src/axom/mint/tests/mint_mesh_curvilinear_mesh.cpp
@@ -13,7 +13,7 @@
 #include "StructuredMesh_helpers.hpp"  // for StructuredMesh test helpers
 
 // Slic includes
-#include "axom/slic/interface/slic.hpp"  // for slic macros
+#include "axom/slic.hpp"
 
 // Sidre includes
 #ifdef AXOM_MINT_USE_SIDRE
@@ -21,7 +21,7 @@
 namespace sidre = axom::sidre;
 #endif
 
-#include "gtest/gtest.h"  // for gtest macros
+#include "gtest/gtest.h"
 
 using namespace axom::mint;
 using IndexType = axom::IndexType;
@@ -330,18 +330,12 @@ TEST(mint_mesh_curvilinear_mesh, sidre_constructor)
 #endif /* AXOM_MINT_USE_SIDRE */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_mesh_face_relation.cpp
+++ b/src/axom/mint/tests/mint_mesh_face_relation.cpp
@@ -6,12 +6,10 @@
 #include "axom/mint/mesh/UnstructuredMesh.hpp" /* for mint::UnstructuredMesh */
 #include "axom/mint/mesh/internal/MeshHelpers.hpp" /* for mint::initFaces */
 
-#include "axom/core/utilities/Utilities.hpp" /* for utilities::max */
+#include "axom/core/utilities/Utilities.hpp"
+#include "axom/slic.hpp"
 
-#include "axom/slic/core/SimpleLogger.hpp" /* for SimpleLogger */
-#include "axom/slic/interface/slic.hpp"    /* for slic macros */
-
-#include "gtest/gtest.h" /* for TEST and EXPECT_* macros */
+#include "gtest/gtest.h"
 
 #include <string>
 #include <sstream>
@@ -1440,15 +1438,10 @@ TEST(mint_mesh_face_relation, correct_construction)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char *argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   return RUN_ALL_TESTS();
 }

--- a/src/axom/mint/tests/mint_mesh_field.cpp
+++ b/src/axom/mint/tests/mint_mesh_field.cpp
@@ -10,7 +10,7 @@
 #include "axom/mint/mesh/FieldVariable.hpp"  // for mint::FieldVariable
 #include "axom/mint/fem/FEBasis.hpp"         // for FEBasisTypes
 
-#include "axom/slic/interface/slic.hpp"  // for SLIC macros
+#include "axom/slic.hpp"
 
 // gtest includes
 #include "gtest/gtest.h"
@@ -115,18 +115,12 @@ TEST(mint_mesh_field, get_dataptr)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_mesh_field_data.cpp
+++ b/src/axom/mint/tests/mint_mesh_field_data.cpp
@@ -4,12 +4,12 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 // Axom includes
-#include "axom/slic/interface/slic.hpp"         // for slic macros
+#include "axom/slic.hpp"
 #include "axom/mint/mesh/FieldData.hpp"         // for mint::FieldData
 #include "axom/mint/mesh/FieldAssociation.hpp"  // for FieldAssociation enum
 
 // gtest includes
-#include "gtest/gtest.h"  // for gtest macros
+#include "gtest/gtest.h"
 
 // C/C++ includes
 #include <algorithm>  // for std::fill()
@@ -726,18 +726,12 @@ TEST(mint_mesh_field_data, shrink)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_mesh_field_types.cpp
+++ b/src/axom/mint/tests/mint_mesh_field_types.cpp
@@ -6,7 +6,9 @@
 #include "axom/mint/mesh/FieldTypes.hpp"
 
 #include "axom/core/Types.hpp"
-#include "gtest/gtest.h"  // for gtest macros
+#include "axom/slic.hpp"
+
+#include "gtest/gtest.h"
 
 // namespace aliases
 namespace mint = axom::mint;
@@ -28,18 +30,12 @@ TEST(mint_mesh_fieldtypes, field_traits)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_mesh_field_variable.cpp
+++ b/src/axom/mint/tests/mint_mesh_field_variable.cpp
@@ -7,7 +7,7 @@
 #include "axom/mint/mesh/FieldVariable.hpp"  // for mint::FieldVariable
 #include "axom/mint/mesh/FieldTypes.hpp"     // for FieldTypes enum
 #include "axom/core/numerics/Matrix.hpp"     // for numerics::Matrix
-#include "axom/slic/interface/slic.hpp"      // for slic macros
+#include "axom/slic.hpp"
 
 // Sidre includes
 #ifdef AXOM_MINT_USE_SIDRE
@@ -16,7 +16,7 @@ namespace sidre = axom::sidre;
 #endif
 
 // gtest includes
-#include "gtest/gtest.h"  // for gtest macros
+#include "gtest/gtest.h"
 
 // namespace aliases
 namespace mint = axom::mint;
@@ -405,18 +405,12 @@ TEST(mint_mesh_field_variable, shrink)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_mesh_particle_mesh.cpp
+++ b/src/axom/mint/tests/mint_mesh_particle_mesh.cpp
@@ -7,7 +7,7 @@
 #include "axom/mint/mesh/blueprint.hpp"     // for mint::blueprint() functions
 #include "axom/mint/mesh/ParticleMesh.hpp"  // for ParticleMesh definition
 
-#include "axom/slic/interface/slic.hpp"  // for slic macros
+#include "axom/slic.hpp"
 
 // Sidre includes
 #ifdef AXOM_MINT_USE_SIDRE
@@ -15,7 +15,7 @@
 namespace sidre = axom::sidre;
 #endif
 
-#include "gtest/gtest.h"  // for gtest macros
+#include "gtest/gtest.h"
 
 // namespace aliases
 namespace mint = axom::mint;
@@ -549,18 +549,12 @@ TEST(mint_mesh_particle_mesh, shrink)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_mesh_rectilinear_mesh.cpp
+++ b/src/axom/mint/tests/mint_mesh_rectilinear_mesh.cpp
@@ -12,7 +12,7 @@
 #include "StructuredMesh_helpers.hpp"  // for StructuredMesh test helpers
 
 // Slic includes
-#include "axom/slic/interface/slic.hpp"  // for slic macros
+#include "axom/slic.hpp"
 
 // Sidre includes
 #ifdef AXOM_MINT_USE_SIDRE
@@ -20,7 +20,7 @@
 namespace sidre = axom::sidre;
 #endif
 
-#include "gtest/gtest.h"  // for gtest macros
+#include "gtest/gtest.h"
 
 // C/C++ includes
 #include <cmath>  // for exp
@@ -361,18 +361,13 @@ TEST(mint_mesh_rectilinear_mesh, get_node)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
+  axom::slic::SimpleLogger logger;
 
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
   result = RUN_ALL_TESTS();
   return result;
 }

--- a/src/axom/mint/tests/mint_mesh_uniform_mesh.cpp
+++ b/src/axom/mint/tests/mint_mesh_uniform_mesh.cpp
@@ -2,24 +2,22 @@
 // other Axom Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-#include "axom/mint/config.hpp"  // for compile-time type
-                                 // definitions
-
+#include "axom/mint/config.hpp"             // for compile-time type definitions
 #include "axom/mint/mesh/blueprint.hpp"     // for blueprint functions
 #include "axom/mint/mesh/CellTypes.hpp"     // for CellTypes enum definition
 #include "axom/mint/mesh/ParticleMesh.hpp"  // for ParticleMesh
 #include "axom/mint/mesh/UniformMesh.hpp"   // for UniformMesh
 #include "StructuredMesh_helpers.hpp"       // for StructuredMesh test helpers
 
-#include "axom/slic/interface/slic.hpp"  // for slic macros
+#include "axom/slic.hpp"
 
 // Sidre includes
 #ifdef AXOM_MINT_USE_SIDRE
-  #include "axom/sidre/core/sidre.hpp"  // for sidre classes
+  #include "axom/sidre/core/sidre.hpp"
 namespace sidre = axom::sidre;
 #endif
 
-#include "gtest/gtest.h"  // for gtest macros
+#include "gtest/gtest.h"
 
 using namespace axom::mint;
 using IndexType = axom::IndexType;
@@ -333,18 +331,12 @@ TEST(mint_mesh_uniform_mesh, check_evaluate_coordinate)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/mint/tests/mint_mesh_unstructured_mesh.cpp
+++ b/src/axom/mint/tests/mint_mesh_unstructured_mesh.cpp
@@ -5,21 +5,19 @@
 #include "axom/mint/config.hpp"                /* for mint defintions */
 #include "axom/mint/mesh/UnstructuredMesh.hpp" /* for mint::Array */
 
-#include "axom/core/utilities/Utilities.hpp" /* for utilities::max */
-
-#include "axom/slic/core/SimpleLogger.hpp" /* for SimpleLogger */
-#include "axom/slic/interface/slic.hpp"    /* for slic macros */
+#include "axom/core/utilities/Utilities.hpp"
+#include "axom/slic.hpp"
 
 #include "mint_test_utilities.hpp" /* for create_mesh() */
 
-#include "gtest/gtest.h" /* for TEST and EXPECT_* macros */
+#include "gtest/gtest.h"
 
 #ifdef AXOM_MINT_USE_SIDRE
   #include "axom/sidre/core/sidre.hpp"
 #endif
 
 // C/C++ includes
-#include <algorithm> /* for std::fill_n */
+#include <algorithm>
 #include <string>
 #include <sstream>
 #include <unordered_map>
@@ -3369,15 +3367,10 @@ TEST(mint_mesh_unstructured_mesh, check_face_connectivity)
 } /* end namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   return RUN_ALL_TESTS();
 }

--- a/src/axom/mint/tests/mint_su2_io.cpp
+++ b/src/axom/mint/tests/mint_su2_io.cpp
@@ -9,11 +9,10 @@
 #include "axom/mint/utils/su2_utils.hpp"       /* for su2 i/o */
 
 // Slic includes
-#include "axom/slic/interface/slic.hpp"    /* for slic macros */
-#include "axom/slic/core/SimpleLogger.hpp" /* for SimpleLogger */
+#include "axom/slic.hpp"
 
 // gtest includes
-#include "gtest/gtest.h" /* for gtest macros */
+#include "gtest/gtest.h"
 
 // C/C++ includes
 #include <cstdio> /* for std::remove() */
@@ -220,13 +219,12 @@ TEST(mint_su2_io, write_read_single_cell_topology_mesh)
 }
 
 //------------------------------------------------------------------------------
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
   ::testing::InitGoogleTest(&argc, argv);
-  SimpleLogger logger;
+  axom::slic::SimpleLogger logger;
+
   result = RUN_ALL_TESTS();
   return result;
 }

--- a/src/axom/mint/tests/mint_util_write_vtk.cpp
+++ b/src/axom/mint/tests/mint_util_write_vtk.cpp
@@ -23,8 +23,7 @@
 #include "mint_test_utilities.hpp"             /* for create_mesh */
 
 // Slic includes
-#include "axom/slic/interface/slic.hpp"    /* for slic macros */
-#include "axom/slic/core/SimpleLogger.hpp" /* for SimpleLogger */
+#include "axom/slic.hpp"
 
 // C/C++ includes
 #include <cmath>   /* for std::exp */
@@ -36,7 +35,7 @@
 #include <set>     /* for std::set */
 
 // gtest includes
-#include "gtest/gtest.h" /* for TEST and EXPECT_* macros */
+#include "gtest/gtest.h"
 
 #ifndef DELETE_VTK_FILES
   #define DELETE_VTK_FILES 1
@@ -937,13 +936,12 @@ TEST(mint_util_write_vtk, ParticleMesh)
 } /* end namespace axom */
 
 //------------------------------------------------------------------------------
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
   ::testing::InitGoogleTest(&argc, argv);
-  SimpleLogger logger;
+  axom::slic::SimpleLogger logger;
+
   result = RUN_ALL_TESTS();
   return result;
 }

--- a/src/axom/primal/tests/primal_bezier_curve.cpp
+++ b/src/axom/primal/tests/primal_bezier_curve.cpp
@@ -409,7 +409,6 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
   axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   result = RUN_ALL_TESTS();

--- a/src/axom/primal/tests/primal_bezier_intersect.cpp
+++ b/src/axom/primal/tests/primal_bezier_intersect.cpp
@@ -459,7 +459,6 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
   axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   result = RUN_ALL_TESTS();

--- a/src/axom/primal/tests/primal_bounding_box_intersect.cpp
+++ b/src/axom/primal/tests/primal_bounding_box_intersect.cpp
@@ -5,6 +5,7 @@
 
 #include "axom/primal/operators/detail/intersect_bounding_box_impl.hpp"
 
+#include "axom/slic.hpp"
 #include "gtest/gtest.h"
 
 //------------------------------------------------------------------------------
@@ -118,18 +119,12 @@ TEST(primal_bounding_box_intersect, aabb_aabb_non_intersecting)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_boundingbox.cpp
+++ b/src/axom/primal/tests/primal_boundingbox.cpp
@@ -6,9 +6,10 @@
 #include <limits>
 
 #include "gtest/gtest.h"
+#include "axom/slic.hpp"
 
-#include "axom/core/execution/execution_space.hpp"  // for execution_space traits
-#include "axom/core/execution/for_all.hpp"          // for_all()
+#include "axom/core/execution/execution_space.hpp"
+#include "axom/core/execution/for_all.hpp"
 
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/BoundingBox.hpp"
@@ -655,18 +656,12 @@ AXOM_CUDA_TEST(primal_boundingBox, bb_check_policies)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -659,7 +659,7 @@ TEST(primal_clip, oct_tet_clip_special_case_2)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-  axom::slic::SimpleLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;
 
   int result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -6,9 +6,10 @@
 #include "gtest/gtest.h"
 
 #include "axom/config.hpp"
+#include "axom/slic.hpp"
 
 #include "axom/core/Types.hpp"
-#include "axom/core/execution/for_all.hpp"  // for for_all, execution policies
+#include "axom/core/execution/for_all.hpp"
 #include "axom/core/memory_management.hpp"
 
 #include "axom/primal/geometry/Point.hpp"
@@ -655,14 +656,10 @@ TEST(primal_clip, oct_tet_clip_special_case_2)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   int result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_in_sphere.cpp
+++ b/src/axom/primal/tests/primal_in_sphere.cpp
@@ -185,9 +185,7 @@ TEST(primal_in_sphere, compare_to_sphere_orientation)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  axom::slic::SimpleLogger logger;
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();
   return result;

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -2394,9 +2394,7 @@ AXOM_CUDA_TEST(primal_intersect, plane_seg_test_intersection_cuda)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  axom::slic::SimpleLogger logger;
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Warning);
+  axom::slic::SimpleLogger logger(axom::slic::message::Warning);
 
   int result = RUN_ALL_TESTS();
   return result;

--- a/src/axom/primal/tests/primal_intersect_impl.cpp
+++ b/src/axom/primal/tests/primal_intersect_impl.cpp
@@ -4,8 +4,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "gtest/gtest.h"
-
-#include "axom/slic/interface/slic.hpp"
+#include "axom/slic.hpp"
 
 #include "axom/primal/operators/detail/intersect_impl.hpp"
 
@@ -134,9 +133,6 @@ TEST(primal_intersection_impl, zero_count)
 
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
@@ -144,7 +140,7 @@ int main(int argc, char* argv[])
   ::testing::InitGoogleTest(&argc, argv);
 
   // create & initialize test logger, finalized when exiting main scope
-  SimpleLogger logger;
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_numeric_array.cpp
+++ b/src/axom/primal/tests/primal_numeric_array.cpp
@@ -10,8 +10,7 @@
 #include "axom/core/execution/execution_space.hpp"  // for execution_space traits
 #include "axom/core/execution/for_all.hpp"          // for_all()
 
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
+#include "axom/slic.hpp"
 
 using namespace axom;
 
@@ -300,10 +299,7 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_octahedron.cpp
+++ b/src/axom/primal/tests/primal_octahedron.cpp
@@ -125,9 +125,7 @@ TEST_F(OctahedronTest, equals)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  axom::slic::SimpleLogger logger;
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();
   return result;

--- a/src/axom/primal/tests/primal_orientation.cpp
+++ b/src/axom/primal/tests/primal_orientation.cpp
@@ -223,8 +223,8 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
   axom::slic::SimpleLogger logger;
+
   result = RUN_ALL_TESTS();
 
   return result;

--- a/src/axom/primal/tests/primal_point.cpp
+++ b/src/axom/primal/tests/primal_point.cpp
@@ -6,8 +6,9 @@
 #include "gtest/gtest.h"
 
 #include "axom/primal/geometry/Point.hpp"
-#include "axom/core/execution/execution_space.hpp"  // for execution_space traits
-#include "axom/core/execution/for_all.hpp"          // for_all()
+#include "axom/core/execution/execution_space.hpp"
+#include "axom/core/execution/for_all.hpp"
+#include "axom/slic.hpp"
 
 using namespace axom;
 
@@ -395,18 +396,12 @@ AXOM_CUDA_TEST(primal_point, point_check_policies)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_polygon.cpp
+++ b/src/axom/primal/tests/primal_polygon.cpp
@@ -22,9 +22,7 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  axom::slic::SimpleLogger logger;
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_polyhedron.cpp
+++ b/src/axom/primal/tests/primal_polyhedron.cpp
@@ -399,10 +399,7 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  namespace slic = axom::slic;
-  slic::SimpleLogger logger;
-  slic::setLoggingMsgLevel(slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_ray_intersect.cpp
+++ b/src/axom/primal/tests/primal_ray_intersect.cpp
@@ -6,8 +6,9 @@
 #include "axom/config.hpp"
 #include "axom/primal/operators/detail/intersect_ray_impl.hpp"
 
-#include "axom/core/numerics/Matrix.hpp"     // for numerics::Matrix
-#include "axom/core/numerics/matvecops.hpp"  // for matrix-vector operators
+#include "axom/core/numerics/Matrix.hpp"
+#include "axom/core/numerics/matvecops.hpp"
+#include "axom/slic.hpp"
 
 #include "gtest/gtest.h"
 
@@ -385,18 +386,12 @@ TEST(primal_ray_intersect, ray_aabb_intersection_3D)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/primal/tests/primal_segment.cpp
+++ b/src/axom/primal/tests/primal_segment.cpp
@@ -307,9 +307,7 @@ TEST(primal_segment, circle_normal_2d)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  axom::slic::SimpleLogger logger;
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();
   return result;

--- a/src/axom/primal/tests/primal_sphere.cpp
+++ b/src/axom/primal/tests/primal_sphere.cpp
@@ -250,7 +250,6 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
   axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();

--- a/src/axom/primal/tests/primal_tetrahedron.cpp
+++ b/src/axom/primal/tests/primal_tetrahedron.cpp
@@ -506,9 +506,7 @@ TEST_F(TetrahedronTest, regularTetrahedron)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  axom::slic::SimpleLogger logger;  // create & initialize test logger,
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();
   return result;

--- a/src/axom/primal/tests/primal_triangle.cpp
+++ b/src/axom/primal/tests/primal_triangle.cpp
@@ -451,9 +451,7 @@ TEST(primal_triangle, triangle_2D_circumsphere)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  axom::slic::SimpleLogger logger;
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();
   return result;

--- a/src/axom/primal/tests/primal_zip.cpp
+++ b/src/axom/primal/tests/primal_zip.cpp
@@ -7,6 +7,7 @@
 
 #include "axom/core/execution/for_all.hpp"
 #include "axom/core/memory_management.hpp"
+#include "axom/slic.hpp"
 
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/utils/ZipIndexable.hpp"
@@ -550,18 +551,12 @@ TEST(primal_zip, zip_rays_2d_from_3d_gpu)
 #endif
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/quest/Delaunay.hpp
+++ b/src/axom/quest/Delaunay.hpp
@@ -74,7 +74,7 @@ private:
 public:
   /**
    * \brief Default constructor
-   * \note User must to call initializeBoundary(BoundingBox) before adding points.
+   * \note User must call initializeBoundary(BoundingBox) before adding points.
    */
   Delaunay()
     : m_has_boundary(false)

--- a/src/axom/quest/examples/delaunay_triangulation.cpp
+++ b/src/axom/quest/examples/delaunay_triangulation.cpp
@@ -197,8 +197,7 @@ void run_delaunay(const Input& params)
 int main(int argc, char** argv)
 {
   // Initialize the SLIC logger
-  axom::slic::SimpleLogger logger;
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   // Initialize default parameters and update with command line arguments:
   Input params;

--- a/src/axom/quest/tests/quest_all_nearest_neighbors.cpp
+++ b/src/axom/quest/tests/quest_all_nearest_neighbors.cpp
@@ -353,8 +353,6 @@ TEST(quest_all_nearnbr, file_query)
 
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
@@ -362,6 +360,7 @@ int main(int argc, char* argv[])
   outfname = nullptr;
 
   ::testing::InitGoogleTest(&argc, argv);
+  axom::slic::SimpleLogger logger;
 
   if(argc > 1)
   {
@@ -371,10 +370,6 @@ int main(int argc, char* argv[])
       outfname = argv[2];
     }
   }
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/quest/tests/quest_discretize.cpp
+++ b/src/axom/quest/tests/quest_discretize.cpp
@@ -807,8 +807,8 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
   axom::slic::SimpleLogger logger;
+
   result = RUN_ALL_TESTS();
 
   return result;

--- a/src/axom/quest/tests/quest_inout_interface.cpp
+++ b/src/axom/quest/tests/quest_inout_interface.cpp
@@ -290,7 +290,6 @@ int main(int argc, char** argv)
   MPI_Init(&argc, &argv);
 #endif
   ::testing::InitGoogleTest(&argc, argv);
-
   axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   int result = RUN_ALL_TESTS();

--- a/src/axom/quest/tests/quest_inout_octree.cpp
+++ b/src/axom/quest/tests/quest_inout_octree.cpp
@@ -245,9 +245,7 @@ TEST(quest_inout_octree, tetrahedron_mesh)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  namespace slic = axom::slic;
-  slic::SimpleLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;
 
 #ifdef INOUT_OCTREE_TESTER_SHOULD_SEED
   std::srand(std::time(0));

--- a/src/axom/quest/tests/quest_inout_quadtree.cpp
+++ b/src/axom/quest/tests/quest_inout_quadtree.cpp
@@ -202,7 +202,6 @@ TEST(quest_inout_quadtree, circle_mesh)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
   axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
 #ifdef INOUT_OCTREE_TESTER_SHOULD_SEED

--- a/src/axom/quest/tests/quest_meshtester.cpp
+++ b/src/axom/quest/tests/quest_meshtester.cpp
@@ -527,10 +527,7 @@ TEST(quest_mesh_tester, surfacemesh_watertight_ondisk)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  namespace slic = axom::slic;
-  slic::SimpleLogger logger;  // create & initialize test logger,
-  slic::setLoggingMsgLevel(slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();
   return result;

--- a/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
+++ b/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
@@ -1601,9 +1601,7 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  axom::slic::SimpleLogger logger;
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   std::srand(SRAND_SEED);
 

--- a/src/axom/quest/tests/quest_regression.cpp
+++ b/src/axom/quest/tests/quest_regression.cpp
@@ -64,7 +64,6 @@ namespace mint = axom::mint;
 namespace primal = axom::primal;
 namespace quest = axom::quest;
 namespace sidre = axom::sidre;
-namespace slic = axom::slic;
 namespace utilities = axom::utilities;
 
 using SpaceBoundingBox = primal::BoundingBox<double, DIM>;
@@ -789,7 +788,7 @@ int main(int argc, char** argv)
   // initialize the problem
   MPI_Init(&argc, &argv);
 
-  slic::SimpleLogger logger;
+  axom::slic::SimpleLogger logger;
   sidre::DataStore ds;
 
   // parse the command arguments

--- a/src/axom/quest/tests/quest_signed_distance.cpp
+++ b/src/axom/quest/tests/quest_signed_distance.cpp
@@ -431,7 +431,6 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
   axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();

--- a/src/axom/quest/tests/quest_signed_distance_interface.cpp
+++ b/src/axom/quest/tests/quest_signed_distance_interface.cpp
@@ -26,9 +26,7 @@
 #include "quest_test_utilities.hpp"                  // test-utility functions
 
 // Slic includes
-#include "axom/slic/interface/slic.hpp"     // for SLIC macros
-#include "axom/slic/core/SimpleLogger.hpp"  // for the unit test logger
-using axom::slic::SimpleLogger;
+#include "axom/slic.hpp"
 
 // gtest
 #ifdef AXOM_USE_MPI
@@ -547,10 +545,7 @@ int main(int argc, char* argv[])
 
   // add this line to avoid a warning in the output about thread safety
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/quest/tests/quest_stl_reader.cpp
+++ b/src/axom/quest/tests/quest_stl_reader.cpp
@@ -5,6 +5,7 @@
 
 #include "axom/quest/readers/STLReader.hpp"
 #include "axom/mint/mesh/UnstructuredMesh.hpp"
+#include "axom/slic.hpp"
 
 // gtest includes
 #include "gtest/gtest.h"
@@ -205,15 +206,10 @@ TEST(quest_stl_reader, read_stl_external)
 }
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   return RUN_ALL_TESTS();
 }

--- a/src/axom/quest/tests/quest_vertex_weld.cpp
+++ b/src/axom/quest/tests/quest_vertex_weld.cpp
@@ -4,8 +4,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "gtest/gtest.h"
-
-#include "axom/slic/interface/slic.hpp"
+#include "axom/slic.hpp"
 
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/mint/mesh/UnstructuredMesh.hpp"
@@ -306,18 +305,12 @@ TEST(quest_vertex_weld, indexedOctahedron)
 
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/sidre/examples/sidre_array.cpp
+++ b/src/axom/sidre/examples/sidre_array.cpp
@@ -18,7 +18,6 @@
 
 // aliases
 namespace sidre = axom::sidre;
-namespace slic = axom::slic;
 
 int main(int argc, char** argv)
 {
@@ -30,7 +29,7 @@ int main(int argc, char** argv)
   MPI_Comm_rank(problem_comm, &myrank);
   MPI_Comm_size(problem_comm, &nranks);
 
-  slic::SimpleLogger logger;
+  axom::slic::SimpleLogger logger;
 
   // STEP 0: create the data store
   sidre::DataStore* dataStore1 = new sidre::DataStore();

--- a/src/axom/sidre/examples/sidre_external_array.cpp
+++ b/src/axom/sidre/examples/sidre_external_array.cpp
@@ -18,7 +18,6 @@
 
 // aliases
 namespace sidre = axom::sidre;
-namespace slic = axom::slic;
 
 #if defined(AXOM_USE_HDF5)
 //------------------------------------------------------------------------------
@@ -114,7 +113,7 @@ int main(int argc, char** argv)
 #if defined(AXOM_USE_HDF5)
   MPI_Comm problem_comm = MPI_COMM_WORLD;
 
-  slic::SimpleLogger logger;
+  axom::slic::SimpleLogger logger;
 
   // STEP 0: create some data
   constexpr axom::IndexType NUM_NODES = 10;

--- a/src/axom/sidre/tests/sidre_mcarray.cpp
+++ b/src/axom/sidre/tests/sidre_mcarray.cpp
@@ -3,15 +3,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/core/utilities/Utilities.hpp" /* for utilities::max */
-
-#include "axom/slic/core/SimpleLogger.hpp" /* for SimpleLogger */
-#include "axom/slic/interface/slic.hpp"    /* for slic macros */
-
-#include "gtest/gtest.h" /* for TEST and EXPECT_* macros */
-
+#include "axom/core/utilities/Utilities.hpp"
 #include "axom/core/ArrayView.hpp"
+#include "axom/slic.hpp"
 #include "axom/sidre/core/sidre.hpp"
+
+#include "gtest/gtest.h"
 
 // C/C++ includes
 #include <algorithm> /* for std::fill_n */
@@ -1243,18 +1240,12 @@ TEST(sidre_core_mcarray, checkSidrePermanence)
 } /* end namespace axom */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -1066,7 +1066,6 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
   axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
 #ifdef AXOM_USE_MPI

--- a/src/axom/sidre/tests/sidre_native_layout.cpp
+++ b/src/axom/sidre/tests/sidre_native_layout.cpp
@@ -7,6 +7,7 @@
 
 #include "axom/config.hpp"
 #include "axom/core/Macros.hpp"
+#include "axom/slic.hpp"
 #include "axom/sidre/core/sidre.hpp"
 
 #include "conduit_blueprint.hpp"
@@ -656,18 +657,12 @@ TEST(sidre_native_layout, basic_demo_compare)
 
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger, finalized when
-                        // exiting main scope
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Debug);
+  axom::slic::SimpleLogger logger(axom::slic::message::Debug);
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/sidre/tests/sidre_view.cpp
+++ b/src/axom/sidre/tests/sidre_view.cpp
@@ -4,10 +4,10 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "gtest/gtest.h"
+#include "axom/slic.hpp"
+#include "axom/core/Types.hpp"
 
 #include "axom/sidre/core/sidre.hpp"
-
-#include "axom/core/Types.hpp"
 
 using axom::sidre::Buffer;
 using axom::sidre::CHAR8_STR_ID;
@@ -2246,16 +2246,12 @@ INSTANTIATE_TEST_SUITE_P(sidre_view,
                                             ::testing::ValuesIn(offsets)));
 
 //----------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/sidre/tests/spio/spio_main.cpp
+++ b/src/axom/sidre/tests/spio/spio_main.cpp
@@ -7,7 +7,8 @@
 
 #include "mpi.h"
 
-#include "axom/config.hpp"  // for compile-time definitions
+#include "axom/config.hpp"
+#include "axom/slic.hpp"
 
 namespace
 {
@@ -23,16 +24,12 @@ const std::string ROOT_EXT = ".root";
 #include "spio_parallel.hpp"
 #include "spio_serial.hpp"
 
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   MPI_Init(&argc, &argv);
   result = RUN_ALL_TESTS();

--- a/src/axom/sidre/tests/spio/spio_main.cpp
+++ b/src/axom/sidre/tests/spio/spio_main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-  axom::slic::SimpleLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;
 
   MPI_Init(&argc, &argv);
   result = RUN_ALL_TESTS();

--- a/src/axom/slam/benchmarks/slam_array.cpp
+++ b/src/axom/slam/benchmarks/slam_array.cpp
@@ -529,7 +529,6 @@ int main(int argc, char* argv[])
   std::srand(std::time(NULL));
 
   ::benchmark::Initialize(&argc, argv);
-
   axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   ::benchmark::RunSpecifiedBenchmarks();

--- a/src/axom/slam/examples/HandleMesh.cpp
+++ b/src/axom/slam/examples/HandleMesh.cpp
@@ -16,7 +16,6 @@
 #include <ostream>
 
 namespace slam = axom::slam;
-namespace slic = axom::slic;
 
 namespace
 {
@@ -59,7 +58,7 @@ std::ostream& operator<<(std::ostream& os, const Handle<T>& h)
 
 int main(int, char**)
 {
-  slic::SimpleLogger logger;
+  axom::slic::SimpleLogger logger;
 
   using PosType = slam::DefaultPositionType;
   using HandleType = Handle<PosType>;

--- a/src/axom/slam/examples/UserDocs.cpp
+++ b/src/axom/slam/examples/UserDocs.cpp
@@ -389,9 +389,8 @@ void quadMeshExample()
   quadMesh.outputVTKMesh();
 }
 
-int main(int /* argc */, char** /* argv */)
+int main()
 {
   axom::slic::SimpleLogger logger;
-
   quadMeshExample();
 }

--- a/src/axom/slam/examples/tinyHydro/tests/slam_tinyHydro_sedovTwoPart.cpp
+++ b/src/axom/slam/examples/tinyHydro/tests/slam_tinyHydro_sedovTwoPart.cpp
@@ -121,16 +121,11 @@ void tinyHydroSedov_2part()
 }
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main()
 {
   int result = 0;
+  axom::slic::SimpleLogger logger;
 
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
   tinyHydroSedov_2part();
 
   return result;

--- a/src/axom/slam/examples/tinyHydro/tests/slam_tinyHydro_sod1DTwoPart.cpp
+++ b/src/axom/slam/examples/tinyHydro/tests/slam_tinyHydro_sod1DTwoPart.cpp
@@ -158,16 +158,11 @@ void tinyHydroSod1D_2part()
 }
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main()
 {
   int result = 0;
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
+  
   tinyHydroSod1D_2part();
 
   return result;

--- a/src/axom/slam/examples/tinyHydro/tests/slam_tinyHydro_unitTests.cpp
+++ b/src/axom/slam/examples/tinyHydro/tests/slam_tinyHydro_unitTests.cpp
@@ -583,18 +583,12 @@ TEST(slam_tinyHydro,test_06_PdV_work)
 }
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char * argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_AccessingRelationDataInMap.cpp
+++ b/src/axom/slam/tests/slam_AccessingRelationDataInMap.cpp
@@ -146,15 +146,11 @@ TEST(slam_set_relation_map, access_pattern)
 }
 
 //----------------------------------------------------------------------
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  // create & initialize test logger. finalized when exiting main scope
   axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();

--- a/src/axom/slam/tests/slam_Map.cpp
+++ b/src/axom/slam/tests/slam_Map.cpp
@@ -379,8 +379,7 @@ int main(int argc, char* argv[])
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 #endif
 
-  axom::slic::SimpleLogger logger;  // create & initialize test logger,
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_map_BivariateMap.cpp
+++ b/src/axom/slam/tests/slam_map_BivariateMap.cpp
@@ -406,8 +406,7 @@ int main(int argc, char* argv[])
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 #endif
 
-  axom::slic::SimpleLogger logger;  // create & initialize test logger,
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_map_DynamicMap.cpp
+++ b/src/axom/slam/tests/slam_map_DynamicMap.cpp
@@ -119,9 +119,7 @@ TEST(slam_map, modify_size_increases_set)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  axom::slic::SimpleLogger logger;  // create & initialize test logger,
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_map_SubMap.cpp
+++ b/src/axom/slam/tests/slam_map_SubMap.cpp
@@ -220,8 +220,7 @@ int main(int argc, char* argv[])
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 #endif
 
-  axom::slic::SimpleLogger logger;  // create & initialize test logger,
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_relation_DynamicConstant.cpp
+++ b/src/axom/slam/tests/slam_relation_DynamicConstant.cpp
@@ -238,8 +238,7 @@ TEST(slam_relation_dynamic_constant, remove)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-  axom::slic::SimpleLogger logger;
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_relation_DynamicVariable.cpp
+++ b/src/axom/slam/tests/slam_relation_DynamicVariable.cpp
@@ -213,10 +213,7 @@ TEST(slam_relation_dynamic_variable, iterate_relation)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  // create & initialize test logger. finalized when exiting main scope
-  axom::slic::SimpleLogger logger;
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_relation_StaticConstant.cpp
+++ b/src/axom/slam/tests/slam_relation_StaticConstant.cpp
@@ -585,8 +585,6 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  // create & initialize test logger. finalized when exiting main scope
   axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();

--- a/src/axom/slam/tests/slam_relation_StaticVariable.cpp
+++ b/src/axom/slam/tests/slam_relation_StaticVariable.cpp
@@ -350,8 +350,6 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  // create & initialize test logger. finalized when exiting main scope
   axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();

--- a/src/axom/slam/tests/slam_set_BitSet.cpp
+++ b/src/axom/slam/tests/slam_set_BitSet.cpp
@@ -467,7 +467,6 @@ int main(int argc, char* argv[])
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 #endif
 
-  // create & initialize test logger. finalized when exiting main scope
   axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();

--- a/src/axom/slam/tests/slam_set_DynamicSet.cpp
+++ b/src/axom/slam/tests/slam_set_DynamicSet.cpp
@@ -347,7 +347,6 @@ int main(int argc, char* argv[])
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 #endif
 
-  // create & initialize test logger. finalized when exiting main scope
   axom::slic::SimpleLogger logger;
 
   int result = RUN_ALL_TESTS();

--- a/src/axom/slam/tests/slam_set_Iterator.cpp
+++ b/src/axom/slam/tests/slam_set_Iterator.cpp
@@ -437,8 +437,7 @@ int main(int argc, char* argv[])
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 #endif
 
-  axom::slic::SimpleLogger logger;  // create & initialize test logger,
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   int result = RUN_ALL_TESTS();
 

--- a/src/axom/slam/tests/slam_set_NullSet.cpp
+++ b/src/axom/slam/tests/slam_set_NullSet.cpp
@@ -64,7 +64,6 @@ int main(int argc, char* argv[])
 {
   int result = 0;
   ::testing::InitGoogleTest(&argc, argv);
-
   axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   result = RUN_ALL_TESTS();

--- a/src/axom/slam/tests/slam_set_PositionSet.cpp
+++ b/src/axom/slam/tests/slam_set_PositionSet.cpp
@@ -260,8 +260,6 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  // create & initialize test logger. finalized when exiting main scope
   axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();

--- a/src/axom/slam/tests/slam_set_RangeSet.cpp
+++ b/src/axom/slam/tests/slam_set_RangeSet.cpp
@@ -495,7 +495,6 @@ int main(int argc, char* argv[])
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 #endif
 
-  // create & initialize test logger, finalized when exiting main scope
   axom::slic::SimpleLogger logger;
   //axom::slic::debug::checksAreErrors = true;
 

--- a/src/axom/slic/core/SimpleLogger.hpp
+++ b/src/axom/slic/core/SimpleLogger.hpp
@@ -10,11 +10,12 @@
  *
  */
 
-#ifndef SIMPLELOGGER_HPP_
-#define SIMPLELOGGER_HPP_
+#ifndef SLIC_SIMPLELOGGER_HPP_
+#define SLIC_SIMPLELOGGER_HPP_
 
 // Other axom headers
-#include "axom/core/Macros.hpp"  // defines DISABLE_{COPY,MOVE}_AND_ASSIGNMENT
+#include "axom/config.hpp"
+#include "axom/core/Macros.hpp"
 
 // slic component headers
 #include "axom/slic/interface/slic.hpp"
@@ -31,7 +32,7 @@ namespace slic
  * finalize operations of the slic::Logger class that is helpful for
  * unit tests and simple applications in axom.
  *
- * To use, create an instance of of this class before tests are run. This
+ * To use, create an instance of this class before tests are run. This
  * initializes the slic logger. When the object is destroyed (e.g., goes out
  * of scope), the slic logger is finalized. For example, when using gtest,
  * a simple main program can be used in each test source file to do this:
@@ -60,10 +61,10 @@ public:
   /*!
    * \brief Constructor initializes slic logging environment.
    */
-  SimpleLogger()
+  explicit SimpleLogger(message::Level level = message::Debug)
   {
     initialize();
-    setLoggingMsgLevel(message::Debug);
+    setLoggingMsgLevel(level);
 
     // Formatting for warning, errors and fatal message
     std::string wefFormatStr =
@@ -89,14 +90,21 @@ public:
   /*!
    * \brief Destructor finalizes slic loging environment.
    */
-  ~SimpleLogger() { finalize(); }
+  ~SimpleLogger()
+  {
+    if(isInitialized())
+    {
+      flushStreams();
+      finalize();
+    }
+  }
 
 private:
   DISABLE_COPY_AND_ASSIGNMENT(SimpleLogger);
   DISABLE_MOVE_AND_ASSIGNMENT(SimpleLogger);
 };
 
-} /* end namespace slic */
-} /* end namespace axom */
+}  // namespace slic
+}  // namespace axom
 
-#endif /* SIMPLELOGGER_HPP_ */
+#endif  // SLIC_SIMPLELOGGER_HPP_

--- a/src/axom/slic/tests/slic_asserts.cpp
+++ b/src/axom/slic/tests/slic_asserts.cpp
@@ -7,10 +7,9 @@
 
 #include "axom/slic/interface/slic.hpp"
 #include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
 
 /*!
- * \file
+ * \file slic_asserts.cpp
  *
  * The tests in this file check that SLIC macros properly output their message
  * and exit (when appropriate) when run from constructors and destructors.
@@ -184,9 +183,7 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-                        // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;  // create & initialize test logger,
 
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   result = RUN_ALL_TESTS();

--- a/src/axom/slic/tests/slic_benchmark_asserts.cpp
+++ b/src/axom/slic/tests/slic_benchmark_asserts.cpp
@@ -6,7 +6,6 @@
 #include "benchmark/benchmark_api.h"
 #include "axom/slic/interface/slic.hpp"
 #include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
 
 /*!
  * \file

--- a/src/axom/slic/tests/slic_fmt.cpp
+++ b/src/axom/slic/tests/slic_fmt.cpp
@@ -4,18 +4,14 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 /*!
- * \file
+ * \file slic_fmt.cpp
  *
  * \brief A simple test to see if we can use the fmt library within slic macros.
  */
 
 #include "axom/config.hpp"
 #include "axom/fmt.hpp"
-
-#include "axom/slic/interface/slic.hpp"
-#include "axom/slic/core/SimpleLogger.hpp"
-
-using axom::slic::SimpleLogger;
+#include "axom/slic.hpp"
 
 #include "gtest/gtest.h"
 
@@ -57,9 +53,7 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-                        // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -3,30 +3,14 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-// axom/core includes
+// axom includes
 #include "axom/config.hpp"
+#include "axom/core.hpp"
+#include "axom/primal.hpp"
+#include "axom/mint.hpp"
 
-#include "axom/core/Types.hpp"
-#include "axom/core/execution/execution_space.hpp"
-#include "axom/core/memory_management.hpp"
-#include "axom/core/numerics/Matrix.hpp"
-
-// axom/primal includes
-#include "axom/primal/geometry/BoundingBox.hpp"
-#include "axom/primal/geometry/Point.hpp"
-#include "axom/primal/geometry/Vector.hpp"
-#include "axom/primal/utils/ZipPoint.hpp"
-#include "axom/primal/utils/ZipBoundingBox.hpp"
-
-// axom/spin includes
 #include "axom/spin/BVH.hpp"
 #include "axom/spin/UniformGrid.hpp"
-
-// axom/mint includes
-#include "axom/mint/mesh/Mesh.hpp"
-#include "axom/mint/mesh/UniformMesh.hpp"
-#include "axom/mint/execution/interface.hpp"
-#include "axom/mint/utils/vtk_utils.hpp"
 
 // gtest includes
 #include "gtest/gtest.h"
@@ -1704,18 +1688,12 @@ AXOM_CUDA_TEST(spin_bvh, use_pool_allocator)
 #endif /* AXOM_USE_CUDA && AXOM_USE_RAJA && AXOM_USE_UMPIRE */
 
 //------------------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/spin/tests/spin_implicit_grid.cpp
+++ b/src/axom/spin/tests/spin_implicit_grid.cpp
@@ -18,7 +18,7 @@
 
 #include <vector>
 #include <unordered_set>
-#include <algorithm>  // for std::find
+#include <algorithm>
 
 /*!
  * Templated test fixture for ImplicitGrid tests
@@ -850,9 +850,7 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  axom::slic::SimpleLogger logger;
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/spin/tests/spin_morton.cpp
+++ b/src/axom/spin/tests/spin_morton.cpp
@@ -8,8 +8,7 @@
 #include "axom/spin/MortonIndex.hpp"
 
 #include "axom/primal/geometry/Point.hpp"
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
+#include "axom/slic.hpp"
 
 #include <cstdlib>
 #include <limits>
@@ -290,10 +289,7 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  SimpleLogger logger;  // create & initialize test logger,
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
 #ifdef MORTON_TESTER_SHOULD_SEED
   std::srand(std::time(0));

--- a/src/axom/spin/tests/spin_octree.cpp
+++ b/src/axom/spin/tests/spin_octree.cpp
@@ -7,7 +7,7 @@
 
 #include "axom/spin/OctreeBase.hpp"
 
-#include "axom/slic/interface/slic.hpp"
+#include "axom/slic.hpp"
 
 //------------------------------------------------------------------------------
 TEST(spin_octree, topological_octree_parent_child)
@@ -338,18 +338,12 @@ TEST(spin_octree, count_octree_blocks)
 
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 

--- a/src/axom/spin/tests/spin_rectangular_lattice.cpp
+++ b/src/axom/spin/tests/spin_rectangular_lattice.cpp
@@ -7,8 +7,7 @@
 
 #include "axom/spin/RectangularLattice.hpp"
 
-#include "axom/slic/interface/slic.hpp"
-#include "axom/slic/core/SimpleLogger.hpp"
+#include "axom/slic.hpp"
 
 // Define some helpful typedefs for 1D rectangular lattices
 namespace lattice_1D
@@ -679,12 +678,7 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  using axom::slic::SimpleLogger;
-  SimpleLogger logger;  // create & initialize test logger,
-  axom::slic::setLoggingMsgLevel(axom::slic::message::Info);
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
 
   std::srand(105);
 

--- a/src/axom/spin/tests/spin_spatial_octree.cpp
+++ b/src/axom/spin/tests/spin_spatial_octree.cpp
@@ -7,7 +7,7 @@
 
 #include "axom/spin/SpatialOctree.hpp"
 
-#include "axom/slic/interface/slic.hpp"
+#include "axom/slic.hpp"
 
 TEST(spin_spatial_octree, spatial_octree_point_location)
 {
@@ -68,18 +68,12 @@ TEST(spin_spatial_octree, spatial_octree_point_location)
 
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
-#include "axom/slic/core/SimpleLogger.hpp"
-using axom::slic::SimpleLogger;
-
 int main(int argc, char* argv[])
 {
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  SimpleLogger logger;  // create & initialize test logger,
-
-  // finalized when exiting main scope
+  axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();
 


### PR DESCRIPTION
# Summary

- This PR adds a small usability tweak to `slic::SimpleLogger` and fixes up its usage throughout our tests and examples
- It allow one to set the initial logging level in the constructor for SimpleLogger
- I had this improvement in a feature branch that's not yet ready to merge and wanted to use it in another branch
