### PR TITLE
Bugfix for sign computation in `quest::SignedDistance`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -83,6 +83,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Inlined some fully specialized functions in `quest::Delaunay` to avoid "multiply-defined" linker errors
 - Fixed `axom::Array<T>` fill operations on uninitialized memory
 - Fixed behavior of `axom::Array<T>::resize(new_size)` with `new_size < curr_size`
+- Fixed computation of signs in `quest::SignedDistance` when closest point is along an edge
+  with a sharp dihedral angle and the adjacent triangles have significantly different areas
 
 ## [Version 0.6.1] - Release date 2021-11-17
 

--- a/src/axom/quest/tests/CMakeLists.txt
+++ b/src/axom/quest/tests/CMakeLists.txt
@@ -195,6 +195,9 @@ if (ENABLE_MPI AND AXOM_ENABLE_SIDRE)
                         boxedSphere:40
                         cap:16
                         cap:32
+                        fin0:32
+                        fin1:32
+                        fin2:32
                         naca0012:16
                         naca0012:32
                         plane_binary:16


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It resolves #783 
- The problem was related to cases where the closest point was along an edge with an acute dihedral angle and the incident triangles had (vastly) different areas. The sign is related to a pseudo-normal computation that sums the normals of the two incident triangles, and the code was not unitizing the normals before adding them. This can cause a problem when one of the triangles had a very small area, since the larger triangles was disproportionately weighting the sum.
- I created a few regression meshes in https://github.com/LLNL/axom_data/pull/9 that were failing before my fix and passing afterwards

#### TODO

- [x] Update the data submodule again after merging https://github.com/LLNL/axom_data/pull/9 into `axom_data@main`
