### PR TITLE
Fix for ImplicitGrid performance regression

### DIFF
--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -767,7 +767,7 @@ struct ArrayOpsBase<T, true>
   {
     // Similar to fill(), except we can allocate stack memory and placement-new
     // the object with a move constructor.
-    alignas(T) unsigned char host_buf[sizeof(T)];
+    alignas(T) axom::uint8 host_buf[sizeof(T)];
     T* host_obj = ::new(&host_buf) T(std::forward<Args>(args)...);
     axom::copy(array + i, host_obj, sizeof(T));
   }

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -767,7 +767,7 @@ struct ArrayOpsBase<T, true>
   {
     // Similar to fill(), except we can allocate stack memory and placement-new
     // the object with a move constructor.
-    std::aligned_storage<sizeof(T), alignof(T)> host_buf;
+    alignas(T) unsigned char host_buf[sizeof(T)];
     T* host_obj = ::new(&host_buf) T(std::forward<Args>(args)...);
     axom::copy(array + i, host_obj, sizeof(T));
   }

--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -204,8 +204,20 @@ public:
     for(int i = 0; i < NDIMS; ++i)
     {
       m_bins[i] = BinSet(m_gridRes[i]);
-      m_binData[i] =
-        BinBitMap(&m_bins[i], BitsetType(numElts, allocatorID), 1, allocatorID);
+      m_binData[i] = BinBitMap(&m_bins[i]);
+
+      // Workaround because axom::Array doesn't propagate allocator ID on copy
+      // construction
+      {
+        typename BinBitMap::OrderedMap bitmaps(axom::IndexType {0},
+                                               axom::IndexType {m_gridRes[i]},
+                                               allocatorID);
+        for(int ibin = 0; ibin < m_gridRes[i]; ibin++)
+        {
+          bitmaps.emplace_back(numElts, allocatorID);
+        }
+        m_binData[i].data() = std::move(bitmaps);
+      }
 
       axom::IndexType gridResDim = m_gridRes[i];
       m_minBlockBin[i] =


### PR DESCRIPTION
# Summary

- Fixes a performance regression on `ImplicitGrid` queries on the GPU, as a result of data not being correctly allocated in device memory
  - On the `car.stl` mesh tester run, the ImplicitGrid kernels were running ~10 times slower than before
- As a bonus, removes usage of `aligned_storage` - it wasn't used correctly in `ArrayOps`, and it's getting deprecated in C++23 anyways