### PR TITLE
Bugfix for gcc@8.1 config without RAJA or Umpire

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -89,6 +89,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Fixed computation of signs in `quest::SignedDistance` when closest point is along an edge
   with a sharp dihedral angle and the adjacent triangles have significantly different areas
 - Fixed bug in axom::Path that ignored the leading delimiter character if one was present
+- Fixed gcc compiler errors in configurations without RAJA or Umpire
 
 ## [Version 0.6.1] - Release date 2021-11-17
 

--- a/scripts/spack/configs/toss_3_x86_64_ib/compilers.yaml
+++ b/scripts/spack/configs/toss_3_x86_64_ib/compilers.yaml
@@ -51,6 +51,19 @@ compilers:
     modules: []
     operating_system: rhel7
     paths:
+      cc:  /usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-8.3.1/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+      fc:  /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+    spec: gcc@8.3.1
+    target: x86_64
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: rhel7
+    paths:
       cc:  /usr/tce/packages/gcc/gcc-8.1.0/bin/gcc
       cxx: /usr/tce/packages/gcc/gcc-8.1.0/bin/g++
       f77:

--- a/scripts/spack/configs/toss_3_x86_64_ib/packages.yaml
+++ b/scripts/spack/configs/toss_3_x86_64_ib/packages.yaml
@@ -43,6 +43,8 @@ packages:
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-clang-10.0.0
     - spec: mvapich2@2.3%gcc@8.1.0 process_managers=slurm arch=linux-rhel7-ivybridge
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0
+    - spec: mvapich2@2.3%gcc@8.3.1 process_managers=slurm arch=linux-rhel7-ivybridge
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.3.1
     - spec: mvapich2@2.3%gcc@8.1.0_no_fortran process_managers=slurm arch=linux-rhel7-ivybridge
       prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.1.0
     - spec: mvapich2@2.3%intel@18.0.2 process_managers=slurm arch=linux-rhel7-ivybridge

--- a/src/axom/core/Macros.hpp
+++ b/src/axom/core/Macros.hpp
@@ -79,10 +79,12 @@
  */
 #ifdef AXOM_USE_CUDA
   #define AXOM_LAMBDA [=] AXOM_HOST_DEVICE
+  #define AXOM_MUTABLE_LAMBDA [=] AXOM_HOST_DEVICE
   #define AXOM_DEVICE_LAMBDA [=] AXOM_DEVICE
   #define AXOM_HOST_LAMBDA [=] AXOM_HOST
 #else
   #define AXOM_LAMBDA [=]
+  #define AXOM_MUTABLE_LAMBDA [&]
   #define AXOM_DEVICE_LAMBDA [=]
   #define AXOM_HOST_LAMBDA [=]
 #endif

--- a/src/axom/core/Macros.hpp
+++ b/src/axom/core/Macros.hpp
@@ -79,12 +79,10 @@
  */
 #ifdef AXOM_USE_CUDA
   #define AXOM_LAMBDA [=] AXOM_HOST_DEVICE
-  #define AXOM_MUTABLE_LAMBDA [=] AXOM_HOST_DEVICE
   #define AXOM_DEVICE_LAMBDA [=] AXOM_DEVICE
   #define AXOM_HOST_LAMBDA [=] AXOM_HOST
 #else
   #define AXOM_LAMBDA [=]
-  #define AXOM_MUTABLE_LAMBDA [&]
   #define AXOM_DEVICE_LAMBDA [=]
   #define AXOM_HOST_LAMBDA [=]
 #endif

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -308,6 +308,7 @@ inline MemorySpace getAllocatorSpace(int allocatorId)
     return MemorySpace::Dynamic;
   }
 #else
+  AXOM_UNUSED_VAR(allocatorId);
   return MemorySpace::Dynamic;
 #endif
 }

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -242,7 +242,6 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_insert)
       umpire::resource::MemoryResourceType::Device);
   }
 #endif
-  int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   constexpr axom::IndexType N = 374;
   DynamicArray arr(N, N, kernelAllocID);
@@ -316,7 +315,6 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_range_insert)
       umpire::resource::MemoryResourceType::Device);
   }
 #endif
-  int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   constexpr axom::IndexType N = 374;
   DynamicArray arr(N, N, kernelAllocID);
@@ -391,7 +389,6 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_range_set)
       umpire::resource::MemoryResourceType::Device);
   }
 #endif
-  int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   constexpr axom::IndexType N = 374;
   DynamicArray arr(N, N, kernelAllocID);

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -835,6 +835,8 @@ public:
   #endif  // AXOM_USE_CUDA
 #endif    // AXOM_USE_RAJA && AXOM_USE_UMPIRE
     default:
+      AXOM_UNUSED_VAR(shapeDimension);
+      AXOM_UNUSED_VAR(shape);
       SLIC_ERROR("Unhandled runtime policy case " << m_execPolicy);
       break;
     }
@@ -862,6 +864,7 @@ public:
   #endif  // AXOM_USE_CUDA
 #endif    // AXOM_USE_RAJA && AXOM_USE_UMPIRE
     default:
+      AXOM_UNUSED_VAR(shape);
       SLIC_ERROR("Unhandled runtime policy case " << m_execPolicy);
       break;
     }

--- a/src/axom/quest/detail/MeshTester_detail.hpp
+++ b/src/axom/quest/detail/MeshTester_detail.hpp
@@ -168,9 +168,9 @@ void CandidateFinderBase<ExecSpace, FloatType>::initialize()
   // if the Triangle is degenerate.
   mint::for_all_cells<ExecSpace, mint::xargs::coords>(
     m_surfaceMesh,
-    AXOM_LAMBDA(IndexType cellIdx,
-                numerics::Matrix<double> & coords,
-                const IndexType* nodeIds) {
+    [&](IndexType cellIdx,
+        numerics::Matrix<double>& coords,
+        const IndexType* nodeIds) {
       AXOM_UNUSED_VAR(nodeIds);
 
       detail::Triangle3 tri;
@@ -227,24 +227,22 @@ void CandidateFinderBase<ExecSpace, FloatType>::findTriMeshIntersections(
     auto v_counts = counts.view();
 
     // Initialize triangle indices and valid candidates
-    for_all<ExecSpace>(
-      ncells,
-      AXOM_LAMBDA(IndexType i) {
-        for(int j = 0; j < v_counts[i]; j++)
+    for_all<ExecSpace>(ncells, [&](IndexType i) {
+      for(int j = 0; j < v_counts[i]; j++)
+      {
+        if(i < candidates[v_offsets[i] + j])
         {
-          if(i < candidates[v_offsets[i] + j])
-          {
 #ifdef AXOM_USE_RAJA
-            auto idx = RAJA::atomicAdd<atomic_pol>(&v_numValidCandidates[0],
-                                                   IndexType {1});
+          auto idx =
+            RAJA::atomicAdd<atomic_pol>(&v_numValidCandidates[0], IndexType {1});
 #else
             auto idx = v_numValidCandidates[0]++;
 #endif
-            v_indices[idx] = i;
-            v_validCandidates[idx] = candidates[v_offsets[i] + j];
-          }
+          v_indices[idx] = i;
+          v_validCandidates[idx] = candidates[v_offsets[i] + j];
         }
-      });
+      }
+    });
 
     axom::copy(&numCandidates, numValidCandidates.data(), sizeof(IndexType));
   }
@@ -263,27 +261,25 @@ void CandidateFinderBase<ExecSpace, FloatType>::findTriMeshIntersections(
     double intersectionThreshold = m_intersectionThreshold;
 
     // Perform triangle-triangle tests
-    for_all<ExecSpace>(
-      numCandidates,
-      AXOM_LAMBDA(IndexType i) {
-        int index = v_indices[i];
-        int candidate = v_validCandidates[i];
-        if(primal::intersect(v_tris[index],
-                             v_tris[candidate],
-                             false,
-                             intersectionThreshold))
-        {
+    for_all<ExecSpace>(numCandidates, [&](IndexType i) {
+      int index = v_indices[i];
+      int candidate = v_validCandidates[i];
+      if(primal::intersect(v_tris[index],
+                           v_tris[candidate],
+                           false,
+                           intersectionThreshold))
+      {
 #ifdef AXOM_USE_RAJA
-          auto idx =
-            RAJA::atomicAdd<atomic_pol>(&v_numIsectPairs[0], IndexType {1});
+        auto idx =
+          RAJA::atomicAdd<atomic_pol>(&v_numIsectPairs[0], IndexType {1});
 #else
           auto idx = v_numIsectPairs[0];
           v_numIsectPairs[0]++;
 #endif
-          v_firstIsectPair[idx] = index;
-          v_secondIsectPair[idx] = candidate;
-        }
-      });
+        v_firstIsectPair[idx] = index;
+        v_secondIsectPair[idx] = candidate;
+      }
+    });
     axom::copy(&isectCounter, numIsectPairs.data(), sizeof(IndexType));
   }
 

--- a/src/axom/quest/detail/PointFinder.hpp
+++ b/src/axom/quest/detail/PointFinder.hpp
@@ -154,8 +154,10 @@ public:
                     SpacePoint* outIsoparametricCoords) const
   {
     using IndexArray = axom::Array<IndexType>;
+
+#ifdef AXOM_USE_RAJA
     using IndexView = axom::ArrayView<IndexType>;
-#ifdef AXOM_USE_UMPIRE
+  #ifdef AXOM_USE_UMPIRE
     using HostIndexArray = axom::Array<IndexType, 1, axom::MemorySpace::Host>;
     using HostPointArray = axom::Array<SpacePoint, 1, axom::MemorySpace::Host>;
 
@@ -163,14 +165,15 @@ public:
     using HostPointView = axom::ArrayView<SpacePoint, 1, axom::MemorySpace::Host>;
     using ConstHostPointView =
       axom::ArrayView<const SpacePoint, 1, axom::MemorySpace::Host>;
-#else
+  #else
     using HostIndexArray = IndexArray;
     using HostPointArray = axom::Array<SpacePoint>;
 
     using HostIndexView = IndexView;
     using HostPointView = axom::Array<SpacePoint>;
     using ConstHostPointView = axom::ArrayView<const SpacePoint>;
-#endif  // AXOM_USE_UMPIRE
+  #endif  // AXOM_USE_UMPIRE
+#endif    // AXOM_USE_RAJA
 
     auto gridQuery = m_grid.getQueryObject();
 
@@ -309,7 +312,7 @@ public:
                  outIsoparHost.data(),
                  outIsoparHost.size() * sizeof(SpacePoint));
     }
-#else
+#else   // AXOM_USE_RAJA
     for(int i = 0; i < npts; i++)
     {
       SpacePoint pt = pts[i];
@@ -333,7 +336,7 @@ public:
         outIsoparametricCoords[i] = isopar;
       }
     }
-#endif
+#endif  // AXOM_USE_RAJA
   }
 
   /*! Returns a const reference to the given cells's bounding box */

--- a/src/axom/quest/examples/quest_signed_distance_interface.cpp
+++ b/src/axom/quest/examples/quest_signed_distance_interface.cpp
@@ -21,13 +21,15 @@ using MPI_Comm = int;
 #endif
 
 // C/C++ includes
-#include <cstring>  // for strcmp()
+#include <cstring>
 
 /*!
- * \file
+ * \file quest_signed_distance_interfaces.cpp
  *
- * \brief Simple example that illustrates the use of Quest's C-style Signed
- *  Distance interface from within a C++ application.
+ * Example that illustrates the use of Quest's C-style Signed Distance 
+ * interface from within a C++ application. Supports sequential execution ("seq")
+ * as well as accelerated execution via RAJA using openmp on the host ("omp") 
+ * and cuda on the device ("gpu")
  */
 
 // namespace aliases
@@ -53,13 +55,16 @@ MPI_Comm global_comm;
 int mpirank;
 int numranks;
 
-const std::map<std::string, quest::SignedDistExec> validExecPolicies {
+const std::map<std::string, quest::SignedDistExec> validExecPolicies
+{
   {"seq", quest::SignedDistExec::CPU},
-#ifdef AXOM_USE_OPENMP
-  {"omp", quest::SignedDistExec::OpenMP},
+#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
+    {"omp", quest::SignedDistExec::OpenMP},
 #endif
-#ifdef AXOM_USE_CUDA
-  {"gpu", quest::SignedDistExec::GPU}
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
+  {
+    "gpu", quest::SignedDistExec::GPU
+  }
 #endif
 };
 
@@ -134,10 +139,10 @@ struct Arguments
     std::string pol_info =
       "Sets execution space of the SignedDistance query.\n";
     pol_info += "Set to \'seq\' to use sequential execution policy.";
-#ifdef AXOM_USE_OPENMP
+#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
     pol_info += "\nSet to \'omp\' to use an OpenMP execution policy.";
 #endif
-#ifdef AXOM_USE_CUDA
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
     pol_info += "\nSet to \'gpu\' to use a GPU execution policy.";
 #endif
     app.add_option("-e, --exec_space", this->exec_space, pol_info)
@@ -201,7 +206,7 @@ int main(int argc, char** argv)
 #endif
     exit(retval);
   }
-#ifdef AXOM_USE_CUDA
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
   if(args.exec_space == quest::SignedDistExec::GPU)
   {
     using GPUExec = axom::CUDA_EXEC<256>;

--- a/src/axom/quest/interface/signed_distance.cpp
+++ b/src/axom/quest/interface/signed_distance.cpp
@@ -33,13 +33,13 @@ using ExecSeq = axom::SEQ_EXEC;
 using SignedDistance3D = SignedDistance<3>;
 using SignedDistance2D = SignedDistance<2>;
 
-#ifdef AXOM_USE_OPENMP
+#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
 using ExecOMP = axom::OMP_EXEC;
 using SignedDistance3DOMP = SignedDistance<3, ExecOMP>;
 using SignedDistance2DOMP = SignedDistance<2, ExecOMP>;
 #endif
 
-#ifdef AXOM_USE_CUDA
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
 using ExecGPU = axom::CUDA_EXEC<256>;
 using SignedDistance3DGPU = SignedDistance<3, ExecGPU>;
 using SignedDistance2DGPU = SignedDistance<2, ExecGPU>;
@@ -76,10 +76,10 @@ static struct parameters_t
 
 // TODO: note the SignedDistance query is currently only supported in 3-D
 static SignedDistance3D* s_query = nullptr;
-#ifdef AXOM_USE_OPENMP
+#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
 static SignedDistance3DOMP* s_query_omp = nullptr;
 #endif
-#ifdef AXOM_USE_CUDA
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
 static SignedDistance3DGPU* s_query_gpu = nullptr;
 #endif
 static mint::Mesh* s_surface_mesh = nullptr;
@@ -198,7 +198,7 @@ int signed_distance_init(const mint::Mesh* m, MPI_Comm comm)
                                    Parameters.compute_sign,
                                    allocatorID);
     break;
-#ifdef AXOM_USE_OPENMP
+#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
   case SignedDistExec::OpenMP:
     if(allocatorID == -1)
     {
@@ -210,7 +210,7 @@ int signed_distance_init(const mint::Mesh* m, MPI_Comm comm)
                                           allocatorID);
     break;
 #endif
-#ifdef AXOM_USE_CUDA
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
   case SignedDistExec::GPU:
     if(allocatorID == -1)
     {
@@ -237,11 +237,11 @@ bool signed_distance_initialized()
   {
   case SignedDistExec::CPU:
     return (s_query != nullptr);
-#ifdef AXOM_USE_OPENMP
+#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
   case SignedDistExec::OpenMP:
     return (s_query_omp != nullptr);
 #endif
-#ifdef AXOM_USE_CUDA
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
   case SignedDistExec::GPU:
     return (s_query_gpu != nullptr);
 #endif
@@ -336,14 +336,14 @@ void signed_distance_set_execution_space(SignedDistExec exec_space)
     signed_distance_initialized(),
     "signed distance query already initialized; setting option has no effect!");
 
-#ifndef AXOM_USE_OPENMP
+#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
   if(exec_space == SignedDistExec::OpenMP)
   {
     SLIC_ERROR("Signed distance query not compiled with OpenMP support");
   }
 #endif
 
-#ifndef AXOM_USE_CUDA
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
   if(exec_space == SignedDistExec::GPU)
   {
     SLIC_ERROR("Signed distance query not compiled with GPU support");
@@ -366,12 +366,12 @@ double signed_distance_evaluate(double x, double y, double z)
   case SignedDistExec::CPU:
     phi = s_query->computeDistance(x, y, z);
     break;
-#ifdef AXOM_USE_OPENMP
+#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
   case SignedDistExec::OpenMP:
     phi = s_query_omp->computeDistance(x, y, z);
     break;
 #endif
-#ifdef AXOM_USE_CUDA
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
   case SignedDistExec::GPU:
     phi = s_query_gpu->computeDistance(x, y, z);
     break;
@@ -408,12 +408,12 @@ void signed_distance_evaluate(const double* x,
   case SignedDistExec::CPU:
     s_query->computeDistances(npoints, it, phi);
     break;
-#ifdef AXOM_USE_OPENMP
+#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
   case SignedDistExec::OpenMP:
     s_query_omp->computeDistances(npoints, it, phi);
     break;
 #endif
-#ifdef AXOM_USE_CUDA
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
   case SignedDistExec::GPU:
     s_query_gpu->computeDistances(npoints, it, phi);
     break;
@@ -433,7 +433,7 @@ void signed_distance_finalize()
     s_query = nullptr;
   }
 
-#ifdef AXOM_USE_OPENMP
+#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
   if(s_query_omp != nullptr)
   {
     delete s_query_omp;
@@ -441,7 +441,7 @@ void signed_distance_finalize()
   }
 #endif
 
-#ifdef AXOM_USE_CUDA
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
   if(s_query_gpu != nullptr)
   {
     delete s_query_gpu;

--- a/src/axom/quest/tests/quest_signed_distance.cpp
+++ b/src/axom/quest/tests/quest_signed_distance.cpp
@@ -285,7 +285,7 @@ TEST(quest_signed_distance, sphere_vec_test)
 }
 
 //------------------------------------------------------------------------------
-#if defined(AXOM_USE_OPENMP)
+#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
 TEST(quest_signed_distance, sphere_vec_omp_test)
 {
   run_vectorized_sphere_test<axom::OMP_EXEC>();
@@ -293,7 +293,7 @@ TEST(quest_signed_distance, sphere_vec_omp_test)
 #endif  // AXOM_USE_OPENMP
 
 //------------------------------------------------------------------------------
-#if defined(AXOM_USE_CUDA)
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
 AXOM_CUDA_TEST(quest_signed_distance, sphere_vec_cuda_test)
 {
   constexpr int BLOCK_SIZE = 256;
@@ -423,7 +423,7 @@ AXOM_CUDA_TEST(quest_signed_distance, sphere_vec_cuda_custom_alloc)
 
   SLIC_INFO("Done.");
 }
-#endif  // AXOM_USE_CUDA
+#endif  // defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
 
 //------------------------------------------------------------------------------
 int main(int argc, char* argv[])

--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -286,7 +286,9 @@ public:
       maxBlkBins[i] = m_maxBlockBin[i].data();
     }
 
+#ifdef AXOM_USE_RAJA
     using AtomicPol = typename axom::execution_space<ExecSpace>::atomic_policy;
+#endif
 
     for_all<ExecSpace>(
       nelems,


### PR DESCRIPTION
# Summary

- This PR is a bugfix for user-reported compiler errors in a `gcc@8.1` configuration without RAJA or Umpire.
   - We do not currently have a CI test for this configuration and I am not sure that we need one.
- GCC was complaining about several kernels in `MeshTester` that modified lambda-captured `axom::ArrayView`s passed in by-value (using `AXOM_LAMBDA`. The fix was to change the default lambda capture to `by-reference`
   - Update: This appears to be a compiler bug in `gcc@8.1` that is fixed in `gcc@8.3`
- I added the spec for the `gcc@8.3.1` compiler to our spack configuration on toss3
   - I tested this branch (locally) against `%gcc@8.3.1~cpp14+devtools+mfem+c2c` and `%gcc@8.3.1~cpp14+devtools+mfem+c2c~raja~umpire`, but did not add host-configs for these new specs
- Also fixes some errors and warning in configs where `OpenMP` is enabled, but not RAJA or Umpire
