### PR TITLE
Bugfix/yang39/allocator propagation

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -74,6 +74,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   `axom::about()`
 - Use more specific type trait checks in `ArrayOps`, to avoid generating unnecessary copies in
   fill/destroy operations on otherwise trivially-copyable/destructible types.
+- `axom::Array` now consistently propagates the allocator ID on copy, move, and swap operations when possible.
 
 ###  Fixed
 - Fixed a bug relating to swap and assignment operations for multidimensional `axom::Array`s

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -210,10 +210,7 @@ public:
   /// @{
 
   /*! 
-   * \brief Copy assignment operator for Array 
-   *
-   * \note The data will be allocated using the allocator ID of the
-   *  copy-assigned Array, not the argument Array.
+   * \brief Copy assignment operator for Array
    * 
    * \pre T must be TriviallyCopyable
    */
@@ -222,6 +219,7 @@ public:
     if(this != &other)
     {
       static_cast<ArrayBase<T, DIM, Array<T, DIM, SPACE>>&>(*this) = other;
+      m_allocator_id = other.m_allocator_id;
       m_resize_ratio = other.m_resize_ratio;
       m_default_construct = other.m_default_construct;
       initialize(other.size(), other.capacity());

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -810,6 +810,17 @@ Array<T, DIM, SPACE>::Array(const ArrayBase<T, DIM, OtherArrayType>& other,
   : ArrayBase<T, DIM, Array<T, DIM, SPACE>>(other)
   , m_allocator_id(allocatorId)
 {
+  // If a memory space has been explicitly set for the Array object, check that
+  // the space of the user-provided allocator matches the explicit space.
+  if(SPACE != MemorySpace::Dynamic &&
+     SPACE != axom::detail::getAllocatorSpace(m_allocator_id))
+  {
+#ifdef AXOM_DEBUG
+    std::cerr << "Incorrect allocator ID was provided for an Array object with "
+                 "explicit memory space - using default for space\n";
+#endif
+    m_allocator_id = axom::detail::getAllocatorID<SPACE>();
+  }
   initialize(static_cast<const OtherArrayType&>(other).size(),
              static_cast<const OtherArrayType&>(other).size());
   // axom::copy is aware of pointers registered in Umpire, so this will handle
@@ -827,6 +838,17 @@ Array<T, DIM, SPACE>::Array(const ArrayBase<const T, DIM, OtherArrayType>& other
   : ArrayBase<T, DIM, Array<T, DIM, SPACE>>(other)
   , m_allocator_id(allocatorId)
 {
+  // If a memory space has been explicitly set for the Array object, check that
+  // the space of the user-provided allocator matches the explicit space.
+  if(SPACE != MemorySpace::Dynamic &&
+     SPACE != axom::detail::getAllocatorSpace(m_allocator_id))
+  {
+#ifdef AXOM_DEBUG
+    std::cerr << "Incorrect allocator ID was provided for an Array object with "
+                 "explicit memory space - using default for space\n";
+#endif
+    m_allocator_id = axom::detail::getAllocatorID<SPACE>();
+  }
   initialize(static_cast<const OtherArrayType&>(other).size(),
              static_cast<const OtherArrayType&>(other).size());
   // axom::copy is aware of pointers registered in Umpire, so this will handle

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -196,13 +196,12 @@ public:
    * \param [in] allocator_id the ID of the allocator to use (optional)
    */
   template <typename OtherArrayType>
-  Array(const ArrayBase<T, DIM, OtherArrayType>& other,
-        int allocator_id = axom::detail::getAllocatorID<SPACE>());
+  Array(const ArrayBase<T, DIM, OtherArrayType>& other, int allocator_id = -1);
 
   /// \overload
   template <typename OtherArrayType>
   Array(const ArrayBase<const T, DIM, OtherArrayType>& other,
-        int allocator_id = axom::detail::getAllocatorID<SPACE>());
+        int allocator_id = -1);
 
   /// @}
 
@@ -809,15 +808,23 @@ Array<T, DIM, SPACE>::Array(const ArrayBase<T, DIM, OtherArrayType>& other,
   : ArrayBase<T, DIM, Array<T, DIM, SPACE>>(other)
   , m_allocator_id(allocatorId)
 {
+  if(allocatorId == -1)
+  {
+    // Allocator is unspecified - propagate from the other container.
+    m_allocator_id = static_cast<const OtherArrayType&>(other).getAllocatorID();
+  }
   // If a memory space has been explicitly set for the Array object, check that
   // the space of the user-provided allocator matches the explicit space.
   if(SPACE != MemorySpace::Dynamic &&
      SPACE != axom::detail::getAllocatorSpace(m_allocator_id))
   {
+    if(allocatorId != -1)
+    {
 #ifdef AXOM_DEBUG
-    std::cerr << "Incorrect allocator ID was provided for an Array object with "
-                 "explicit memory space - using default for space\n";
+      std::cerr << "Incorrect allocator ID was provided for an Array object "
+                   "with explicit memory space - using default for space\n";
 #endif
+    }
     m_allocator_id = axom::detail::getAllocatorID<SPACE>();
   }
   initialize(static_cast<const OtherArrayType&>(other).size(),
@@ -837,15 +844,23 @@ Array<T, DIM, SPACE>::Array(const ArrayBase<const T, DIM, OtherArrayType>& other
   : ArrayBase<T, DIM, Array<T, DIM, SPACE>>(other)
   , m_allocator_id(allocatorId)
 {
+  if(allocatorId == -1)
+  {
+    // Allocator is unspecified - propagate from the other container.
+    m_allocator_id = static_cast<const OtherArrayType&>(other).getAllocatorID();
+  }
   // If a memory space has been explicitly set for the Array object, check that
   // the space of the user-provided allocator matches the explicit space.
   if(SPACE != MemorySpace::Dynamic &&
      SPACE != axom::detail::getAllocatorSpace(m_allocator_id))
   {
+    if(allocatorId != -1)
+    {
 #ifdef AXOM_DEBUG
-    std::cerr << "Incorrect allocator ID was provided for an Array object with "
-                 "explicit memory space - using default for space\n";
+      std::cerr << "Incorrect allocator ID was provided for an Array object "
+                   "with explicit memory space - using default for space\n";
 #endif
+    }
     m_allocator_id = axom::detail::getAllocatorID<SPACE>();
   }
   initialize(static_cast<const OtherArrayType&>(other).size(),

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -1110,6 +1110,7 @@ inline void Array<T, DIM, SPACE>::swap(Array<T, DIM, SPACE>& other)
   axom::utilities::swap(m_capacity, other.m_capacity);
   axom::utilities::swap(m_resize_ratio, other.m_resize_ratio);
   axom::utilities::swap(m_default_construct, other.m_default_construct);
+  axom::utilities::swap(m_allocator_id, other.m_allocator_id);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -181,11 +181,8 @@ public:
 
   /*! 
    * \brief Copy constructor for an Array instance 
-   * 
-   * \param [in] allocator_id the ID of the allocator to use (optional)
    */
-  Array(const Array& other,
-        int allocator_id = axom::detail::getAllocatorID<SPACE>());
+  Array(const Array& other);
 
   /*! 
    * \brief Move constructor for an Array instance 
@@ -775,23 +772,12 @@ Array<T, DIM, SPACE>::Array(ArrayOptions::Uninitialized,
 
 //------------------------------------------------------------------------------
 template <typename T, int DIM, MemorySpace SPACE>
-Array<T, DIM, SPACE>::Array(const Array& other, int allocator_id)
+Array<T, DIM, SPACE>::Array(const Array& other)
   : ArrayBase<T, DIM, Array<T, DIM, SPACE>>(
       static_cast<const ArrayBase<T, DIM, Array<T, DIM, SPACE>>&>(other))
-  , m_allocator_id(allocator_id)
+  , m_allocator_id(other.m_allocator_id)
   , m_default_construct(other.m_default_construct)
 {
-  // If a memory space has been explicitly set for the Array object, check that
-  // the space of the user-provided allocator matches the explicit space.
-  if(SPACE != MemorySpace::Dynamic &&
-     SPACE != axom::detail::getAllocatorSpace(m_allocator_id))
-  {
-#ifdef AXOM_DEBUG
-    std::cerr << "Incorrect allocator ID was provided for an Array object with "
-                 "explicit memory space - using default for space\n";
-#endif
-    m_allocator_id = axom::detail::getAllocatorID<SPACE>();
-  }
   initialize(other.size(), other.capacity());
   axom::copy(m_data, other.data(), m_num_elements * sizeof(T));
 }

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -786,7 +786,6 @@ Array<T, DIM, SPACE>::Array(Array&& other)
   : ArrayBase<T, DIM, Array<T, DIM, SPACE>>(
       static_cast<ArrayBase<T, DIM, Array<T, DIM, SPACE>>&&>(std::move(other)))
   , m_resize_ratio(0.0)
-  , m_allocator_id(axom::detail::getAllocatorID<SPACE>())
 {
   m_data = other.m_data;
   m_num_elements = other.m_num_elements;

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -139,7 +139,8 @@ void check_fill(Array<T, DIM, SPACE>& v)
   EXPECT_EQ(data_ptr, v.data());
 
   // To check entries, we copy data to a dynamic array
-  Array<T, DIM> v_host = v;
+  int host_alloc_id = axom::detail::getAllocatorID<axom::MemorySpace::Host>();
+  Array<T, DIM> v_host(v, host_alloc_id);
 
   /* Check that the entries are all MAGIC_NUM_0. */
   for(IndexType i = 0; i < size; ++i)
@@ -156,7 +157,7 @@ void check_fill(Array<T, DIM, SPACE>& v)
   EXPECT_EQ(ratio, v.getResizeRatio());
   EXPECT_EQ(data_ptr, v.data());
 
-  v_host = v;
+  v_host = Array<T, DIM>(v, host_alloc_id);
 
   /* Check that the entries are all MAGIC_NUM_1. */
   for(IndexType i = 0; i < size; ++i)
@@ -839,8 +840,9 @@ void check_device_2D(Array<T, 2, SPACE>& v)
   assign_raw_2d<<<1, 1>>>(v.data(), M, N);
 
   // Check the contents of the array by assigning to a Dynamic array
-  // The default Umpire allocator should be Host, so we can access it from the CPU
-  Array<T, 2> check_raw_array_dynamic = v;
+  // The Umpire allocator should be Host, so we can access it from the CPU
+  int host_alloc_id = axom::detail::getAllocatorID<axom::MemorySpace::Host>();
+  Array<T, 2> check_raw_array_dynamic(v, host_alloc_id);
   EXPECT_EQ(check_raw_array_dynamic.size(), size);
   EXPECT_EQ(check_raw_array_dynamic.shape(), v.shape());
 
@@ -870,8 +872,8 @@ void check_device_2D(Array<T, 2, SPACE>& v)
   assign_view_2d<<<1, 1>>>(view);
 
   // Check the contents of the array by assigning to a Dynamic array
-  // The default Umpire allocator should be Host, so we can access it from the CPU
-  Array<T, 2> check_view_array_dynamic = view;
+  // The Umpire allocator should be Host, so we can access it from the CPU
+  Array<T, 2> check_view_array_dynamic(view, host_alloc_id);
   EXPECT_EQ(check_view_array_dynamic.size(), size);
   EXPECT_EQ(check_view_array_dynamic.shape(), v.shape());
 

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -139,7 +139,7 @@ void check_fill(Array<T, DIM, SPACE>& v)
   EXPECT_EQ(data_ptr, v.data());
 
   // To check entries, we copy data to a dynamic array
-  int host_alloc_id = axom::detail::getAllocatorID<axom::MemorySpace::Host>();
+  int host_alloc_id = axom::getDefaultAllocatorID();
   Array<T, DIM> v_host(v, host_alloc_id);
 
   /* Check that the entries are all MAGIC_NUM_0. */
@@ -783,7 +783,7 @@ void check_device(Array<T, DIM, SPACE>& v)
 
   // Check the contents of the array by assigning to a Dynamic array
   // The Umpire allocator should be Host, so we can access it from the CPU
-  int host_alloc_id = axom::detail::getAllocatorID<axom::MemorySpace::Host>();
+  int host_alloc_id = axom::getDefaultAllocatorID();
   Array<T, 1> check_raw_array_dynamic(v, host_alloc_id);
   EXPECT_EQ(check_raw_array_dynamic.size(), size);
   for(int i = 0; i < check_raw_array_dynamic.size(); i++)
@@ -860,7 +860,7 @@ void check_device_2D(Array<T, 2, SPACE>& v)
 
   // Check the contents of the array by assigning to a Dynamic array
   // The Umpire allocator should be Host, so we can access it from the CPU
-  int host_alloc_id = axom::detail::getAllocatorID<axom::MemorySpace::Host>();
+  int host_alloc_id = axom::getDefaultAllocatorID();
   Array<T, 2> check_raw_array_dynamic(v, host_alloc_id);
   EXPECT_EQ(check_raw_array_dynamic.size(), size);
   EXPECT_EQ(check_raw_array_dynamic.shape(), v.shape());

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -781,7 +781,17 @@ void check_device(Array<T, DIM, SPACE>& v)
   // Then assign to it via a raw device pointer
   assign_raw<<<1, 1>>>(v.data(), size);
 
-  // Check the contents by assigning to an explicitly Host array
+  // Check the contents of the array by assigning to a Dynamic array
+  // The Umpire allocator should be Host, so we can access it from the CPU
+  int host_alloc_id = axom::detail::getAllocatorID<axom::MemorySpace::Host>();
+  Array<T, 1> check_raw_array_dynamic(v, host_alloc_id);
+  EXPECT_EQ(check_raw_array_dynamic.size(), size);
+  for(int i = 0; i < check_raw_array_dynamic.size(); i++)
+  {
+    EXPECT_EQ(check_raw_array_dynamic[i], i);
+  }
+
+  // Then check the contents by assigning to an explicitly Host array
   Array<T, 1, axom::MemorySpace::Host> check_raw_array_host = v;
   EXPECT_EQ(check_raw_array_host.size(), size);
   for(int i = 0; i < check_raw_array_host.size(); i++)
@@ -793,7 +803,16 @@ void check_device(Array<T, DIM, SPACE>& v)
   ArrayView<T, DIM, SPACE> view(v);
   assign_view<<<1, 1>>>(view);
 
-  // Check the contents by assigning to an explicitly Host array
+  // Check the contents of the array by assigning to a Dynamic array
+  // The Umpire allocator should be Host, so we can access it from the CPU
+  Array<T, 1> check_view_array_dynamic(view, host_alloc_id);
+  EXPECT_EQ(check_view_array_dynamic.size(), size);
+  for(int i = 0; i < check_view_array_dynamic.size(); i++)
+  {
+    EXPECT_EQ(check_view_array_dynamic[i], i * 2);
+  }
+
+  // Then check the contents by assigning to an explicitly Host array
   Array<T, 1, axom::MemorySpace::Host> check_view_array_host = view;
   EXPECT_EQ(check_view_array_host.size(), size);
   for(int i = 0; i < check_view_array_host.size(); i++)

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -780,16 +780,7 @@ void check_device(Array<T, DIM, SPACE>& v)
   // Then assign to it via a raw device pointer
   assign_raw<<<1, 1>>>(v.data(), size);
 
-  // Check the contents of the array by assigning to a Dynamic array
-  // The default Umpire allocator should be Host, so we can access it from the CPU
-  Array<T, 1> check_raw_array_dynamic = v;
-  EXPECT_EQ(check_raw_array_dynamic.size(), size);
-  for(int i = 0; i < check_raw_array_dynamic.size(); i++)
-  {
-    EXPECT_EQ(check_raw_array_dynamic[i], i);
-  }
-
-  // Then check the contents by assigning to an explicitly Host array
+  // Check the contents by assigning to an explicitly Host array
   Array<T, 1, axom::MemorySpace::Host> check_raw_array_host = v;
   EXPECT_EQ(check_raw_array_host.size(), size);
   for(int i = 0; i < check_raw_array_host.size(); i++)
@@ -801,16 +792,7 @@ void check_device(Array<T, DIM, SPACE>& v)
   ArrayView<T, DIM, SPACE> view(v);
   assign_view<<<1, 1>>>(view);
 
-  // Check the contents of the array by assigning to a Dynamic array
-  // The default Umpire allocator should be Host, so we can access it from the CPU
-  Array<T, 1> check_view_array_dynamic = view;
-  EXPECT_EQ(check_view_array_dynamic.size(), size);
-  for(int i = 0; i < check_view_array_dynamic.size(); i++)
-  {
-    EXPECT_EQ(check_view_array_dynamic[i], i * 2);
-  }
-
-  // Then check the contents by assigning to an explicitly Host array
+  // Check the contents by assigning to an explicitly Host array
   Array<T, 1, axom::MemorySpace::Host> check_view_array_host = view;
   EXPECT_EQ(check_view_array_host.size(), size);
   for(int i = 0; i < check_view_array_host.size(); i++)

--- a/src/axom/quest/detail/MeshTester_detail.hpp
+++ b/src/axom/quest/detail/MeshTester_detail.hpp
@@ -300,9 +300,9 @@ void CandidateFinderBase<ExecSpace, FloatType>::findTriMeshIntersections(
   secondIsectPair.resize(isectCounter);
 
   {
-    // copy results to output
-    firstIndex = firstIsectPair;
-    secondIndex = secondIsectPair;
+    // copy results to output on host
+    firstIndex = HostIndexArray(firstIsectPair);
+    secondIndex = HostIndexArray(secondIsectPair);
     HostIndexArray host_degenerate = m_degenerate;
     for(int i = 0; i < host_degenerate.size(); i++)
     {

--- a/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
+++ b/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
@@ -315,9 +315,15 @@ public:
     spatialIndex.locatePoints(pts, outCellIds.data(), outIsopar.data());
     // _quest_pic_locate_end
 
-    axom::Array<SpacePt> qptHost = pts;
-    axom::Array<IndexType> cellIdsHost = outCellIds;
-    axom::Array<SpacePt> isoparHost = outIsopar;
+#ifdef AXOM_USE_UMPIRE
+    axom::Array<SpacePt, 1, axom::MemorySpace::Host> qptHost = pts;
+    axom::Array<IndexType, 1, axom::MemorySpace::Host> cellIdsHost = outCellIds;
+    axom::Array<SpacePt, 1, axom::MemorySpace::Host> isoparHost = outIsopar;
+#else
+    auto qptHost = pts.view();
+    auto cellIdsHost = outCellIds.view();
+    auto isoparHost = outIsopar.view();
+#endif
     for(int i = 0; i < pts.size(); i++)
     {
       const SpacePt& queryPoint = qptHost[i];


### PR DESCRIPTION
# Summary

- Resolves #791
- `axom::Array` now consistently propagates the allocator ID for moves, copies, and swaps
  - This effectively corresponds to an `std::vector` instantiated with an allocator that defines the allocator traits `propagate_on_container_copy_assignment/move_assignment/swap` to `std::true_type`
  - If the destination array has an explicitly-specified memory space, the allocator ID is propagated from the source array only if the source allocator ID is compatible
  - This provides a more general fix to the regression resolved in #789