### PR TITLE
Document Collective SLIC Functions

### DIFF
--- a/src/axom/slic/core/Logger.hpp
+++ b/src/axom/slic/core/Logger.hpp
@@ -172,11 +172,16 @@ public:
   //! \attention These methods are collective operations.
   //! All ranks in the user-supplied communicator must call the method
   //! when used within an MPI distributed environment.
-  //! The logMessage method is collective if:
-  //!  - Level of the given message is Error and abort on error messages
-  //!    is enabled (default is enabled)
-  //!  - Level of the given message is Warning and abort on warning messages
-  //!    is enabled (default is disabled)
+  //! The logMessage method is collective if either:
+  //!  - Level of the given message is Error and slic::enableAbortOnError() is
+  //!    called (default is enabled)
+  //!  - Level of the given message is Warning and slic::enableAbortOnWarning()
+  //!    is called (default is disabled)
+  //!
+  //! \sa axom::slic::Logger::isAbortOnErrorsEnabled()
+  //! \sa axom::slic::Logger::setAbortOnError(bool status)
+  //! \sa axom::slic::Logger::isAbortOnWarningsEnabled()
+  //! \sa axom::slic::Logger::setAbortOnWarning(bool status)
   //!
 
   /*!

--- a/src/axom/slic/core/Logger.hpp
+++ b/src/axom/slic/core/Logger.hpp
@@ -173,6 +173,13 @@ public:
    * \param [in] filter_duplicates optional parameter that indicates whether
    * duplicate messages resulting from running in parallel will be filtered out.
    * Default is false.
+   * \note When used within an MPI distributed environment, and:
+   *  - Level of the given message is Error and abort on error messages
+   *    is enabled (default is enabled)
+   *  - Level of the given message is Warning and abort on warning messages
+   *    is enabled (default is disabled)
+   * \note this method is a collective operation. All ranks in the user-supplied
+   * communicator must call this method.
    */
   void logMessage(message::Level level,
                   const std::string& message,
@@ -186,6 +193,13 @@ public:
    * \param [in] filter_duplicates optional parameter that indicates whether
    * duplicate messages resulting from running in parallel will be filtered out.
    * Default is false.
+   * \note When used within an MPI distributed environment, and:
+   *  - Level of the given message is Error and abort on error messages
+   *    is enabled (default is enabled)
+   *  - Level of the given message is Warning and abort on warning messages
+   *    is enabled (default is disabled)
+   * \note this method is a collective operation. All ranks in the user-supplied
+   * communicator must call this method.
    */
   void logMessage(message::Level level,
                   const std::string& message,
@@ -201,6 +215,13 @@ public:
    * \param [in] filter_duplicates optional parameter that indicates whether
    * duplicate messages resulting from running in parallel will be filtered out.
    * Default is false.
+   * \note When used within an MPI distributed environment, and:
+   *  - Level of the given message is Error and abort on error messages
+   *    is enabled (default is enabled)
+   *  - Level of the given message is Warning and abort on warning messages
+   *    is enabled (default is disabled)
+   * \note this method is a collective operation. All ranks in the user-supplied
+   * communicator must call this method.
    */
   void logMessage(message::Level level,
                   const std::string& message,
@@ -218,6 +239,13 @@ public:
    * \param [in] filter_duplicates optional parameter that indicates whether
    * duplicate messages resulting from running in parallel will be filtered out.
    * Default is false.
+   * \note When used within an MPI distributed environment, and:
+   *  - Level of the given message is Error and abort on error messages
+   *    is enabled (default is enabled)
+   *  - Level of the given message is Warning and abort on warning messages
+   *    is enabled (default is disabled)
+   * \note this method is a collective operation. All ranks in the user-supplied
+   * communicator must call this method.
    */
   void logMessage(message::Level level,
                   const std::string& message,

--- a/src/axom/slic/core/Logger.hpp
+++ b/src/axom/slic/core/Logger.hpp
@@ -172,7 +172,7 @@ public:
   //! \attention These methods are collective operations.
   //! All ranks in the user-supplied communicator must call the method
   //! when used within an MPI distributed environment.
-  //! Additionally, for logMessage:
+  //! The logMessage method is collective if:
   //!  - Level of the given message is Error and abort on error messages
   //!    is enabled (default is enabled)
   //!  - Level of the given message is Warning and abort on warning messages

--- a/src/axom/slic/core/Logger.hpp
+++ b/src/axom/slic/core/Logger.hpp
@@ -166,6 +166,19 @@ public:
    */
   LogStream* getStream(message::Level level, int i);
 
+  ///@{
+  //! \name Collective Methods
+  //!
+  //! \attention These methods are collective operations.
+  //! All ranks in the user-supplied communicator must call the method
+  //! when used within an MPI distributed environment.
+  //! Additionally, for logMessage:
+  //!  - Level of the given message is Error and abort on error messages
+  //!    is enabled (default is enabled)
+  //!  - Level of the given message is Warning and abort on warning messages
+  //!    is enabled (default is disabled)
+  //!
+
   /*!
    * \brief Logs the given message to all registered streams.
    * \param [in] level the level of the given message.
@@ -173,13 +186,6 @@ public:
    * \param [in] filter_duplicates optional parameter that indicates whether
    * duplicate messages resulting from running in parallel will be filtered out.
    * Default is false.
-   * \note When used within an MPI distributed environment, and:
-   *  - Level of the given message is Error and abort on error messages
-   *    is enabled (default is enabled)
-   *  - Level of the given message is Warning and abort on warning messages
-   *    is enabled (default is disabled)
-   * \note this method is a collective operation. All ranks in the user-supplied
-   * communicator must call this method.
    */
   void logMessage(message::Level level,
                   const std::string& message,
@@ -193,13 +199,6 @@ public:
    * \param [in] filter_duplicates optional parameter that indicates whether
    * duplicate messages resulting from running in parallel will be filtered out.
    * Default is false.
-   * \note When used within an MPI distributed environment, and:
-   *  - Level of the given message is Error and abort on error messages
-   *    is enabled (default is enabled)
-   *  - Level of the given message is Warning and abort on warning messages
-   *    is enabled (default is disabled)
-   * \note this method is a collective operation. All ranks in the user-supplied
-   * communicator must call this method.
    */
   void logMessage(message::Level level,
                   const std::string& message,
@@ -215,13 +214,6 @@ public:
    * \param [in] filter_duplicates optional parameter that indicates whether
    * duplicate messages resulting from running in parallel will be filtered out.
    * Default is false.
-   * \note When used within an MPI distributed environment, and:
-   *  - Level of the given message is Error and abort on error messages
-   *    is enabled (default is enabled)
-   *  - Level of the given message is Warning and abort on warning messages
-   *    is enabled (default is disabled)
-   * \note this method is a collective operation. All ranks in the user-supplied
-   * communicator must call this method.
    */
   void logMessage(message::Level level,
                   const std::string& message,
@@ -239,13 +231,6 @@ public:
    * \param [in] filter_duplicates optional parameter that indicates whether
    * duplicate messages resulting from running in parallel will be filtered out.
    * Default is false.
-   * \note When used within an MPI distributed environment, and:
-   *  - Level of the given message is Error and abort on error messages
-   *    is enabled (default is enabled)
-   *  - Level of the given message is Warning and abort on warning messages
-   *    is enabled (default is disabled)
-   * \note this method is a collective operation. All ranks in the user-supplied
-   * communicator must call this method.
    */
   void logMessage(message::Level level,
                   const std::string& message,
@@ -256,19 +241,15 @@ public:
 
   /*!
    * \brief Flushes all streams.
-   * \note When used within an MPI distributed environment, flushStreams is
-   *  a collective operation. All ranks in the user-supplied communicator must
-   *  call this method.
    */
   void flushStreams();
 
   /*!
    * \brief Pushes messages incrementally up all streams.
-   * \note When used within an MPI distributed environment, pushStreams is
-   *  a collective operation. All ranks in the user-supplied communicator must
-   *  call this method.
    */
   void pushStreams();
+
+  ///@}
 
   /// \name Static Methods
   ///@{

--- a/src/axom/slic/core/Logger.hpp
+++ b/src/axom/slic/core/Logger.hpp
@@ -283,6 +283,9 @@ public:
   /*!
    * \brief Finalizes the logging environment.
    * \post Logger::getActiveLogger() == NULL.
+   * \attention This method is a collective operation.
+   * All ranks in the user-supplied communicator must call the method
+   * when used within an MPI distributed environment.
    */
   static void finalize();
 

--- a/src/axom/slic/core/Logger.hpp
+++ b/src/axom/slic/core/Logger.hpp
@@ -181,6 +181,7 @@ public:
 
   /*!
    * \brief Logs the given message to all registered streams.
+   * \collective
    * \param [in] level the level of the given message.
    * \param [in] message the user-supplied message to log.
    * \param [in] filter_duplicates optional parameter that indicates whether
@@ -193,6 +194,7 @@ public:
 
   /*!
    * \brief Logs the given message to all registered streams.
+   * \collective
    * \param [in] level the level of the given message.
    * \param [in] message the user-supplied message to log.
    * \param [in] tagName user-supplied tag to associated with the given message.
@@ -207,6 +209,7 @@ public:
 
   /*!
    * \brief Logs the given message to all registered streams.
+   * \collective
    * \param [in] level the level of the given message.
    * \param [in] message the user-supplied message to log.
    * \param [in] fileName name of the file this call is made from.
@@ -223,6 +226,7 @@ public:
 
   /*!
    * \brief Logs the given message to all registered streams.
+   * \collective
    * \param [in] level the level of the given message.
    * \param [in] message the user-supplied message to log.
    * \param [in] tagName user-supplied tag to associated with the given message.
@@ -241,11 +245,13 @@ public:
 
   /*!
    * \brief Flushes all streams.
+   * \collective
    */
   void flushStreams();
 
   /*!
    * \brief Pushes messages incrementally up all streams.
+   * \collective
    */
   void pushStreams();
 
@@ -282,6 +288,7 @@ public:
 
   /*!
    * \brief Finalizes the logging environment.
+   * \collective
    * \post Logger::getActiveLogger() == NULL.
    * \attention This method is a collective operation.
    * All ranks in the user-supplied communicator must call the method

--- a/src/axom/slic/docs/doxygen_collective_list.doc
+++ b/src/axom/slic/docs/doxygen_collective_list.doc
@@ -1,0 +1,9 @@
+/*! 
+ *  @page collective_list Collective Operations in Slic
+ *  @brief Slic collective operations page
+ * 
+ * A subset of Slic methods and macros that are collective operations.
+ * 
+ * All ranks in the user-supplied communicator must call them
+ * when used within an MPI distributed environment.
+ */

--- a/src/axom/slic/docs/doxygen_collective_list.doc
+++ b/src/axom/slic/docs/doxygen_collective_list.doc
@@ -7,3 +7,4 @@
  * All ranks in the user-supplied communicator must call them
  * when used within an MPI distributed environment.
  */
+

--- a/src/axom/slic/docs/sphinx/sections/appendix.rst
+++ b/src/axom/slic/docs/sphinx/sections/appendix.rst
@@ -57,7 +57,7 @@ logging within an application.
 Collective Slic Macros
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 A subset of SLIC macros are collective operations when used with
-MPI-aware :ref:`logStream` instances such as :ref:`SynchronizedOutputStream`
+MPI-aware :ref:`logStream` instances such as :ref:`SynchronizedStream`
 or :ref:`LumberjackStream`.
 
 Additionally, macros such as ``SLIC_WARNING`` and ``SLIC_CHECK`` become collective

--- a/src/axom/slic/docs/sphinx/sections/appendix.rst
+++ b/src/axom/slic/docs/sphinx/sections/appendix.rst
@@ -175,6 +175,12 @@ facilitate debugging.
   ``slic::enableAbortOnError()`` and ``slic::disableAbortOnError()`` accordingly.
   See the `Slic Doxygen API Documentation`_ for more information.
 
+.. warning::
+
+   ``SLIC_ERROR`` is a collective operation. See the
+   `Slic Macro Doxygen Reference`_  here for more information.
+
+
 SLIC_ERROR_IF
 """"""""""""""
 
@@ -198,6 +204,11 @@ expression, ``(jacobian < 0.0 + TOL)`` evaluates to ``true``.
   cleaner and more compact code style by encapsulating the conditional branching
   logic within a macro.
 
+.. warning::
+
+   ``SLIC_ERROR_IF`` is a collective operation. See the
+   `Slic Macro Doxygen Reference`_  here for more information.
+
 .. _SLIC_WARNING:
 
 SLIC_WARNING
@@ -213,6 +224,11 @@ macro.
 .. code-block:: c++
 
     SLIC_WARNING( "Region [" << ir << "] defined but not used in the problem!" );
+
+.. warning::
+
+   ``SLIC_WARNING`` can set as a collective operation. See the
+   `Slic Macro Doxygen Reference`_  here for more information.
 
 SLIC_WARNING_IF
 """"""""""""""""
@@ -239,6 +255,11 @@ expression, ``(val < 1)``, evaluates to `` true``.
   cleaner and more compact code style by encapsulating the conditional branching
   logic within a macro.
 
+.. warning::
+
+   ``SLIC_WARNING_IF`` can be set as a collective operation. See the
+   `Slic Macro Doxygen Reference`_  here for more information.
+
 .. _SLIC_DEBUG:
 
 SLIC_DEBUG
@@ -256,8 +277,8 @@ macro
 
 .. warning::
 
-   This macro will log messages only when the `Axom Toolkit`_ is configured and
-   built with debug symbols. Consult the `Axom Quick Start Guide`_ for more
+   This macro will log messages only when Axom is configured and
+   built with ``AXOM_DEBUG``. Consult the `Axom Quick Start Guide`_ for more
    information.
 
 SLIC_DEBUG_IF
@@ -286,8 +307,8 @@ expression, ``(value <0)``, evaluates to ``true``.
 
 .. warning::
 
-   This macro will log messages only when the `Axom Toolkit`_ is configured and
-   built with debug symbols. Consult the `Axom Quick Start Guide`_ for more
+   This macro will log messages only when Axom is configured and
+   built with ``AXOM_DEBUG``. Consult the `Axom Quick Start Guide`_ for more
    information.
 
 .. _SLIC_ASSERT:
@@ -313,9 +334,12 @@ macro.
 
 .. warning::
 
-   This macro will log messages only when the `Axom Toolkit`_ is configured and
-   built with debug symbols. Consult the `Axom Quick Start Guide`_ for more
+   This macro will log messages only when Axom is configured and
+   built with ``AXOM_DEBUG``. Consult the `Axom Quick Start Guide`_ for more
    information.
+
+   ``SLIC_ASSERT`` is a collective operation. See the
+   `Slic Macro Doxygen Reference`_  here for more information.
 
 SLIC_ASSERT_MSG
 """"""""""""""""
@@ -333,9 +357,12 @@ macro.
 
 .. warning::
 
-   This macro will log messages only when the `Axom Toolkit`_ is configured and
-   built with debug symbols. Consult the `Axom Quick Start Guide`_ for more
+   This macro will log messages only when Axom is configured and
+   built with ``AXOM_DEBUG``. Consult the `Axom Quick Start Guide`_ for more
    information.
+
+   ``SLIC_ASSERT_MSG`` is a collective operation. See the
+   `Slic Macro Doxygen Reference`_  here for more information.
 
 .. _SLIC_CHECK:
 
@@ -357,9 +384,12 @@ macro.
 
 .. warning::
 
-   This macro will log messages only when the `Axom Toolkit`_ is configured and
-   built with debug symbols. Consult the `Axom Quick Start Guide`_ for more
+   This macro will log messages only when Axom is configured and
+   built with ``AXOM_DEBUG``. Consult the `Axom Quick Start Guide`_ for more
    information.
+
+   ``SLIC_CHECK`` can be set as a collective operation. See the
+   `Slic Macro Doxygen Reference`_  here for more information.
 
 SLIC_CHECK_MSG
 """"""""""""""""
@@ -377,9 +407,12 @@ macro.
 
 .. warning::
 
-   This macro will log messages only when the `Axom Toolkit`_ is configured and
-   built with debug symbols. Consult the `Axom Quick Start Guide`_ for more
+   This macro will log messages only when Axom is configured and
+   built with ``AXOM_DEBUG``. Consult the `Axom Quick Start Guide`_ for more
    information.
+
+   ``SLIC_CHECK_MSG`` can be set as a collective operation. See the
+   `Slic Macro Doxygen Reference`_  here for more information.
 
 .. #############################################################################
 ..  CITATIONS

--- a/src/axom/slic/docs/sphinx/sections/appendix.rst
+++ b/src/axom/slic/docs/sphinx/sections/appendix.rst
@@ -57,15 +57,18 @@ logging within an application.
 Collective Slic Macros
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 A subset of SLIC macros are collective operations when used with
-MPI-aware :ref:`logStream` instances such as ``SynchronizedStream`` or ``LumberjackStream``.
+MPI-aware :ref:`logStream` instances such as :ref:`SynchronizedOutputStream`
+or :ref:`LumberjackStream`.
 
 Additionally, macros such as ``SLIC_WARNING`` and ``SLIC_CHECK`` become collective
-operations when certain flags are toggled on.
+operations when certain flags are toggled on or functions are called. Other macros
+such as ``SLIC_ERROR`` and ``SLIC_ASSERT`` can be made not collective when certain
+functions are called.
 
 The table below details which SLIC macros are collective:
 
 .. list-table:: Title
-   :widths: 25 25 50
+   :widths: 20 20 60
    :header-rows: 1
 
    * - Macro
@@ -79,16 +82,16 @@ The table below details which SLIC macros are collective:
      - 
    * - ``SLIC_ERROR``
      - Yes
-     - 
+     - Not collective when ``slic::disableAbortOnError()`` is called
    * - ``SLIC_ERROR_IF``
      - Yes
-     - 
+     - Not collective when ``slic::disableAbortOnError()`` is called
    * - ``SLIC_WARNING``
      - Yes (see Note)
-     - 
+     - Collective when ``slic::enableAbortOnWarning()`` is called
    * - ``SLIC_WARNING_IF``
      - Yes (see Note)
-     - 
+     - Collective when ``slic::enableAbortOnWarning()`` is called
    * - ``SLIC_DEBUG``
      - No
      - 
@@ -97,16 +100,16 @@ The table below details which SLIC macros are collective:
      - 
    * - ``SLIC_ASSERT``
      - Yes
-     - 
+     - Not collective when ``slic::disableAbortOnError()`` is called
    * - ``SLIC_ASSERT_MSG``
      - Yes
-     - 
+     - Not collective when ``slic::disableAbortOnError()`` is called
    * - ``SLIC_CHECK``
      - Yes (see Note)
-     - 
+     - Collective when ``slic::debug::checksAreErrors`` is set to true
    * - ``SLIC_CHECK_MSG``
      - Yes (see Note)
-     - 
+     - Collective when ``slic::debug::checksAreErrors`` is set to true
 
 
 .. _SLIC_INFO:

--- a/src/axom/slic/docs/sphinx/sections/appendix.rst
+++ b/src/axom/slic/docs/sphinx/sections/appendix.rst
@@ -57,7 +57,7 @@ logging within an application.
 Collective Slic Macros
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 A subset of SLIC macros are collective operations when used with
-MPI-aware :ref:`logStream` instances such as :ref:`SynchronizedStream`
+MPI-aware :ref:`LogStream` instances such as :ref:`SynchronizedStream`
 or :ref:`LumberjackStream`.
 
 Additionally, macros such as ``SLIC_WARNING`` and ``SLIC_CHECK`` become collective
@@ -67,8 +67,8 @@ functions are called.
 
 The table below details which SLIC macros are collective:
 
-.. list-table:: Title
-   :widths: 20 20 60
+.. list-table:: Macros, Collective and Non-Collective
+   :widths: 20 10 70
    :header-rows: 1
 
    * - Macro
@@ -82,16 +82,16 @@ The table below details which SLIC macros are collective:
      - 
    * - ``SLIC_ERROR``
      - Yes
-     - Not collective when ``slic::disableAbortOnError()`` is called
+     - Not collective after ``slic::disableAbortOnError()`` is called
    * - ``SLIC_ERROR_IF``
      - Yes
-     - Not collective when ``slic::disableAbortOnError()`` is called
+     - Not collective after ``slic::disableAbortOnError()`` is called
    * - ``SLIC_WARNING``
-     - Yes (see Note)
-     - Collective when ``slic::enableAbortOnWarning()`` is called
+     - Yes
+     - Collective after ``slic::enableAbortOnWarning()`` is called
    * - ``SLIC_WARNING_IF``
-     - Yes (see Note)
-     - Collective when ``slic::enableAbortOnWarning()`` is called
+     - Yes
+     - Collective after ``slic::enableAbortOnWarning()`` is called
    * - ``SLIC_DEBUG``
      - No
      - 
@@ -100,16 +100,16 @@ The table below details which SLIC macros are collective:
      - 
    * - ``SLIC_ASSERT``
      - Yes
-     - Not collective when ``slic::disableAbortOnError()`` is called
+     - Not collective after ``slic::disableAbortOnError()`` is called
    * - ``SLIC_ASSERT_MSG``
      - Yes
-     - Not collective when ``slic::disableAbortOnError()`` is called
+     - Not collective after ``slic::disableAbortOnError()`` is called
    * - ``SLIC_CHECK``
-     - Yes (see Note)
-     - Collective when ``slic::debug::checksAreErrors`` is set to true
+     - Yes
+     - Collective after ``slic::debug::checksAreErrors`` is set to true
    * - ``SLIC_CHECK_MSG``
-     - Yes (see Note)
-     - Collective when ``slic::debug::checksAreErrors`` is set to true
+     - Yes
+     - Collective after ``slic::debug::checksAreErrors`` is set to true
 
 
 .. _SLIC_INFO:

--- a/src/axom/slic/docs/sphinx/sections/appendix.rst
+++ b/src/axom/slic/docs/sphinx/sections/appendix.rst
@@ -52,6 +52,63 @@ logging within an application.
   functionality in application specific macros to better suit the requirements
   of the application.
 
+.. _CollectiveSlicMacros:
+
+Collective Slic Macros
+^^^^^^^^^^^^^^^^^^^^^^^^^
+A subset of SLIC macros are collective operations when used with
+MPI-aware :ref:`logStream` instances such as ``SynchronizedStream`` or ``LumberjackStream``.
+
+Additionally, macros such as ``SLIC_WARNING`` and ``SLIC_CHECK`` become collective
+operations when certain flags are toggled on.
+
+The table below details which SLIC macros are collective:
+
+.. list-table:: Title
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Macro
+     - Collective
+     - Notes
+   * - ``SLIC_INFO``
+     - No
+     - 
+   * - ``SLIC_INFO_IF``
+     - No
+     - 
+   * - ``SLIC_ERROR``
+     - Yes
+     - 
+   * - ``SLIC_ERROR_IF``
+     - Yes
+     - 
+   * - ``SLIC_WARNING``
+     - Yes (see Note)
+     - 
+   * - ``SLIC_WARNING_IF``
+     - Yes (see Note)
+     - 
+   * - ``SLIC_DEBUG``
+     - No
+     - 
+   * - ``SLIC_DEBUG_IF``
+     - No
+     - 
+   * - ``SLIC_ASSERT``
+     - Yes
+     - 
+   * - ``SLIC_ASSERT_MSG``
+     - Yes
+     - 
+   * - ``SLIC_CHECK``
+     - Yes (see Note)
+     - 
+   * - ``SLIC_CHECK_MSG``
+     - Yes (see Note)
+     - 
+
+
 .. _SLIC_INFO:
 
 SLIC_INFO

--- a/src/axom/slic/docs/sphinx/sections/appendix.rst
+++ b/src/axom/slic/docs/sphinx/sections/appendix.rst
@@ -67,50 +67,27 @@ functions are called.
 
 The table below details which SLIC macros are collective:
 
-.. list-table:: Macros, Collective and Non-Collective
-   :widths: 20 10 70
-   :header-rows: 1
-
-   * - Macro
-     - Collective
-     - Notes
-   * - ``SLIC_INFO``
-     - No
-     - 
-   * - ``SLIC_INFO_IF``
-     - No
-     - 
-   * - ``SLIC_ERROR``
-     - Yes
-     - Not collective after ``slic::disableAbortOnError()`` is called
-   * - ``SLIC_ERROR_IF``
-     - Yes
-     - Not collective after ``slic::disableAbortOnError()`` is called
-   * - ``SLIC_WARNING``
-     - Yes
-     - Collective after ``slic::enableAbortOnWarning()`` is called
-   * - ``SLIC_WARNING_IF``
-     - Yes
-     - Collective after ``slic::enableAbortOnWarning()`` is called
-   * - ``SLIC_DEBUG``
-     - No
-     - 
-   * - ``SLIC_DEBUG_IF``
-     - No
-     - 
-   * - ``SLIC_ASSERT``
-     - Yes
-     - Not collective after ``slic::disableAbortOnError()`` is called
-   * - ``SLIC_ASSERT_MSG``
-     - Yes
-     - Not collective after ``slic::disableAbortOnError()`` is called
-   * - ``SLIC_CHECK``
-     - Yes
-     - Collective after ``slic::debug::checksAreErrors`` is set to true
-   * - ``SLIC_CHECK_MSG``
-     - Yes
-     - Collective after ``slic::debug::checksAreErrors`` is set to true
-
++-----------------------+------------+--------------------------------------------------------------------------+
+| Macro                 | Collective | Notes                                                                    |
++=======================+============+==========================================================================+
+| | ``SLIC_INFO``       | | No       | |                                                                        |
+| | ``SLIC_INFO_IF``    | |          | |                                                                        |
+|                       |            |                                                                          |
+| | ``SLIC_ERROR``      | | Yes      | | Not collective after ``slic::disableAbortOnError()`` is called         |
+| | ``SLIC_ERROR_IF``   | |          | |                                                                        |
+|                       |            |                                                                          |
+| | ``SLIC_WARNING``    | | Yes      | | Collective after ``slic::enableAbortOnWarning()`` is called            |
+| | ``SLIC_WARNING_IF`` | |          | |                                                                        |
+|                       |            |                                                                          |
+| | ``SLIC_DEBUG``      | | No       | |                                                                        |
+| | ``SLIC_DEBUG_IF``   | |          | |                                                                        |
+|                       |            |                                                                          |
+| | ``SLIC_ASSERT``     | | Yes      | | Not collective after ``slic::disableAbortOnError()`` is called         |
+| | ``SLIC_ASSERT_MSG`` | |          | |                                                                        |
+|                       |            |                                                                          |
+| | ``SLIC_CHECK``      | | Yes      | | Collective after ``slic::debug::checksAreErrors`` is set to true       |
+| | ``SLIC_CHECK_MSG``  | |          | |                                                                        |
++-----------------------+------------+--------------------------------------------------------------------------+
 
 .. _SLIC_INFO:
 

--- a/src/axom/slic/docs/sphinx/sections/architecture.rst
+++ b/src/axom/slic/docs/sphinx/sections/architecture.rst
@@ -90,8 +90,7 @@ enable the application to filter out messages with lower severity.
 
 .. warning::
 
-   No messages will be logged if you forget to call ``slic::setLoggingMsgLevel()``.
-   All messages will be ignored.
+   All messages will be ignored until the first call to ``slic::setLoggingMsgLevel()``.
 
 .. _LogStream:
 

--- a/src/axom/slic/docs/sphinx/sections/architecture.rst
+++ b/src/axom/slic/docs/sphinx/sections/architecture.rst
@@ -155,7 +155,7 @@ The list of keywords is summarized in the table below.
 | **<RANK>**          | The MPI rank that emmitted the message. Only applicable|
 |                     | when the `Axom Toolkit`_ is compiled with MPI enabled  |
 |                     | and with MPI-aware :ref:`logStream` instances, such as,|
-|                     | the :ref:`SynchronizedStream` and                |
+|                     | the :ref:`SynchronizedStream` and                      |
 |                     | :ref:`LumberjackStream`.                               |
 +---------------------+--------------------------------------------------------+
 

--- a/src/axom/slic/docs/sphinx/sections/architecture.rst
+++ b/src/axom/slic/docs/sphinx/sections/architecture.rst
@@ -32,17 +32,17 @@ The basic component architecture of Slic, depicted in
    * A Logger consists of *four* log message levels: ``ERROR``,
      ``WARNING``, ``INFO`` and ``DEBUG``.
 
-   * Each :ref:`logMessageLevel` can have one or more :ref:`logStream` instances,
+   * Each :ref:`logMessageLevel` can have one or more :ref:`LogStream` instances,
      which, specify the output destination, format and filtering of
      messages.
 
-#. One or more :ref:`logStream` instances, bound to a particular logger, that
+#. One or more :ref:`LogStream` instances, bound to a particular logger, that
    can be shared between log message levels.
 
 The application logs messages at an appropriate :ref:`logMessageLevel`, i.e.,
 ``ERROR``, ``WARNING``, ``INFO``, or, ``DEBUG`` using the static API.
 Internally, the Logger routes the message to the corresponding
-:ref:`logStream` instances that are bound to the associated
+:ref:`LogStream` instances that are bound to the associated
 :ref:`logMessageLevel`.
 
 The following sections discuss some of these concepts in more detail.
@@ -93,32 +93,32 @@ enable the application to filter out messages with lower severity.
    No messages will be logged if you forget to call ``slic::setLoggingMsgLevel()``.
    All messages will be ignored.
 
-.. _logStream:
+.. _LogStream:
 
 Log Stream
 ^^^^^^^^^^^
 
-The :ref:`logStream` class, is an abstract base class that facilitates the
+The :ref:`LogStream` class, is an abstract base class that facilitates the
 following:
 
 * Specifying the :ref:`logMessageFormat` and output destination of log messages.
 
 * Implementing logic for handling and filtering messages.
 
-* Defines a pure abstract interface for all :ref:`logStream` instances.
+* Defines a pure abstract interface for all :ref:`LogStream` instances.
 
-Since :ref:`logStream` is an abstract base class, it cannot be instantiated
+Since :ref:`LogStream` is an abstract base class, it cannot be instantiated
 and used directly. Slic provides a set of :ref:`BuiltInLogStreams`, which provide
-concrete implementations of the :ref:`logStream` base class that support
+concrete implementations of the :ref:`LogStream` base class that support
 common use cases for logging, e.g., logging to a file or output to
 the console.
 
-Applications requiring custom functionality, may extend the :ref:`logStream`
-class and provide a concrete :ref:`logStream` instance implementation that
-implements the abstract interface defined by the :ref:`logStream` base class.
+Applications requiring custom functionality, may extend the :ref:`LogStream`
+class and provide a concrete :ref:`LogStream` instance implementation that
+implements the abstract interface defined by the :ref:`LogStream` base class.
 See the :ref:`addACustomLogStream` section for details.
 
-A concrete :ref:`logStream` instance can be attached to one or more
+A concrete :ref:`LogStream` instance can be attached to one or more
 :ref:`logMessageLevel` by calling ``slic::addStreamToMsgLevel()`` and
 ``slic::addStreamToAllMsgLevels()``. See the `Slic Doxygen API Documentation`_
 for more details.
@@ -154,7 +154,7 @@ The list of keywords is summarized in the table below.
 +---------------------+--------------------------------------------------------+
 | **<RANK>**          | The MPI rank that emitted the message. Only applicable |
 |                     | when the `Axom Toolkit`_ is compiled with MPI enabled  |
-|                     | and with MPI-aware :ref:`logStream` instances, such as,|
+|                     | and with MPI-aware :ref:`LogStream` instances, such as,|
 |                     | the :ref:`SynchronizedStream` and                      |
 |                     | :ref:`LumberjackStream`.                               |
 +---------------------+--------------------------------------------------------+
@@ -186,7 +186,7 @@ and line where the message was emitted.
 Default Message Format
 """""""""""""""""""""""
 
-If the :ref:`logMessageFormat` is not specified, the :ref:`logStream` base class
+If the :ref:`logMessageFormat` is not specified, the :ref:`LogStream` base class
 defines a default format that is set to the following:
 
 .. code-block:: c++
@@ -220,7 +220,7 @@ Generic Output Stream
 """"""""""""""""""""""
 
 The :ref:`GenericOutputStream`, is a concrete implementation of the
-:ref:`logStream` base class, that can be constructed by specifying:
+:ref:`LogStream` base class, that can be constructed by specifying:
 
 #. A C++ ``std::ostream`` object instance, e.g., ``std::cout`, ``std::cerr`` for
    console output, or to a file by passing a C++ ``std::ofstream`` object, and,
@@ -290,7 +290,7 @@ The following code snippet illustrates how to register a
 Lumberjack Stream
 """""""""""""""""
 
-The :ref:`LumberjackStream`, is intended to be used with parallel MPI
+The :ref:`LumberjackStream` is intended to be used with parallel MPI
 applications. In contrast to the :ref:`SynchronizedStream`, which logs
 messages from all ranks, the :ref:`LumberjackStream` uses `Lumberjack`_
 internally to filter out duplicate messages that are emitted from multiple
@@ -330,22 +330,22 @@ object with Slic to log messages to ``std::cout``.
 Add a Custom Log Stream
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Slic can be customized by implementing a new subclass of the :ref:`logStream`.
+Slic can be customized by implementing a new subclass of the :ref:`LogStream`.
 This section demonstrates the basic steps required to :ref:`addACustomLogStream`
-by walking through the implementation of a new :ref:`logStream` instance, which
+by walking through the implementation of a new :ref:`LogStream` instance, which
 we will call ``MyStream``.
 
 .. note::
 
   ``MyStream`` provides the same functionality as the :ref:`GenericOutputStream`.
   The implementation presented herein is primarily intended for demonstrating
-  the basic process for extending Slic by providing a custom :ref:`logStream`.
+  the basic process for extending Slic by providing a custom :ref:`LogStream`.
 
 Create a LogStream Subclass
 """""""""""""""""""""""""""
 
 First, we create a new class, ``MyStream``, that is a subclass of the
-:ref:`logStream` class, as illustrated in the code snippet below.
+:ref:`LogStream` class, as illustrated in the code snippet below.
 
 .. code-block:: c++
    :linenos:
@@ -387,7 +387,7 @@ for log messages, which can be any ``std::ostream`` instance, e.g., ``std::cout`
 The reference to the ``std::ostream`` is specified in the class constructor and
 is supplied by the application when a ``MyStream`` object is instantiated.
 
-Since ``MyStream`` is a concrete instance of the :ref:`logStream` base class,
+Since ``MyStream`` is a concrete instance of the :ref:`LogStream` base class,
 it must implement the ``append()`` method, which is a pure *virtual* method.
 
 
@@ -395,7 +395,7 @@ Implement LogStream::append()
 """""""""""""""""""""""""""""
 
 The ``MyStream`` class implements the ``LogStream::append()`` method of the
-:ref:`logStream` base class, as demonstrated in the code snippet below.
+:ref:`LogStream` base class, as demonstrated in the code snippet below.
 
 .. code-block:: c++
    :linenos:
@@ -432,7 +432,7 @@ its argument list:
 * The line location within the file where the message was emitted
 
 The ``append()`` method calls ``LogStream::getFormatedMessage()``, a method
-implemented in the :ref:`logStream` base class, which, applies the
+implemented in the :ref:`LogStream` base class, which, applies the
 :ref:`logMessageFormat` according to the specified format string supplied
 to the ``MyStream`` class constructor, when the class is instantiated.
 
@@ -440,7 +440,7 @@ to the ``MyStream`` class constructor, when the class is instantiated.
 Register the new class with Slic
 """"""""""""""""""""""""""""""""
 
-The new :ref:`logStream` class may be used with Slic in a similar manner to
+The new :ref:`LogStream` class may be used with Slic in a similar manner to
 any of the :ref:`BuiltInLogStreams`, as demonstrated in the code snippet below:
 
 .. code-block:: c++

--- a/src/axom/slic/docs/sphinx/sections/architecture.rst
+++ b/src/axom/slic/docs/sphinx/sections/architecture.rst
@@ -145,14 +145,14 @@ The list of keywords is summarized in the table below.
 +---------------------+--------------------------------------------------------+
 | **<MESSAGE>**       | The supplied message that is being logged.             |
 +---------------------+--------------------------------------------------------+
-| **<FILE>**          | The file from where the message was emmitted.          |
+| **<FILE>**          | The file from where the message was emitted.           |
 +---------------------+--------------------------------------------------------+
-| **<LINE>**          | The line location where the message was emmitted.      |
+| **<LINE>**          | The line location where the message was emitted.       |
 +---------------------+--------------------------------------------------------+
 | **<TAG>**           | A string tag associated with a given message, e.g., for|
 |                     | filtering during post-processing, etc.                 |
 +---------------------+--------------------------------------------------------+
-| **<RANK>**          | The MPI rank that emmitted the message. Only applicable|
+| **<RANK>**          | The MPI rank that emitted the message. Only applicable |
 |                     | when the `Axom Toolkit`_ is compiled with MPI enabled  |
 |                     | and with MPI-aware :ref:`logStream` instances, such as,|
 |                     | the :ref:`SynchronizedStream` and                      |

--- a/src/axom/slic/docs/sphinx/sections/architecture.rst
+++ b/src/axom/slic/docs/sphinx/sections/architecture.rst
@@ -88,6 +88,11 @@ This indicates that all messages with a level of severity of ``WARNING`` and
 higher will be captured, namely ``WARNING`` and ``ERROR`` messages. Thereby,
 enable the application to filter out messages with lower severity.
 
+.. warning::
+
+   No messages will be logged if you forget to call ``slic::setLoggingMsgLevel()``.
+   All messages will be ignored.
+
 .. _logStream:
 
 Log Stream

--- a/src/axom/slic/docs/sphinx/sections/architecture.rst
+++ b/src/axom/slic/docs/sphinx/sections/architecture.rst
@@ -155,7 +155,7 @@ The list of keywords is summarized in the table below.
 | **<RANK>**          | The MPI rank that emmitted the message. Only applicable|
 |                     | when the `Axom Toolkit`_ is compiled with MPI enabled  |
 |                     | and with MPI-aware :ref:`logStream` instances, such as,|
-|                     | the :ref:`SynchronizedOutputStream` and                |
+|                     | the :ref:`SynchronizedStream` and                |
 |                     | :ref:`LumberjackStream`.                               |
 +---------------------+--------------------------------------------------------+
 
@@ -208,7 +208,7 @@ table, followed by a brief description for each.
 | :ref:`GenericOutputStream`      | Always available. Used in serial applications, |
 |                                 | or, for logging on rank zero.                  |
 +---------------------------------+------------------------------------------------+
-| :ref:`SynchronizedOutputStream` | Requires MPI. Used with MPI applications.      |
+| :ref:`SynchronizedStream`       | Requires MPI. Used with MPI applications.      |
 +---------------------------------+------------------------------------------------+
 | :ref:`LumberjackStream`         | Requires MPI. Used with MPI applications.      |
 +---------------------------------+------------------------------------------------+
@@ -246,18 +246,18 @@ object that is bound to a file.
     slic::addStreamToAllMsgLevels(
       new slic::GenericOutputStream( &log_file, format ) );
 
-.. _SynchronizedOutputStream:
+.. _SynchronizedStream:
 
-Synchronized Output Stream
+Synchronized Stream
 """""""""""""""""""""""""""
 
-The :ref:`SynchronizedOutputStream` is intended to be used with parallel MPI
-applications, primarily for debugging. The :ref:`SynchronizedOutputStream`
+The :ref:`SynchronizedStream` is intended to be used with parallel MPI
+applications, primarily for debugging. The :ref:`SynchronizedStream`
 provides similar functionality to the :ref:`GenericOutputStream`, however, the
 log messages are synchronized across the MPI ranks of the specified
 communicator.
 
-Similar to the :ref:`GenericOutputStream` the :ref:`SynchronizedOutputStream`
+Similar to the :ref:`GenericOutputStream` the :ref:`SynchronizedStream`
 is constructed by specifying:
 
 #. A C++ ``std::ostream`` object instance, e.g., ``std::cout`, ``std::cerr`` for
@@ -268,18 +268,18 @@ is constructed by specifying:
 #. Optionally, a string that specifies the :ref:`logMessageFormat`.
 
 The following code snippet illustrates how to register a
-:ref:`SynchronizedOutputStream` object with Slic to log messages to
+:ref:`SynchronizedStream` object with Slic to log messages to
 ``std::cout``.
 
 .. code-block:: c++
 
     slic::addStreamToAllMsgLevels(
-       new slic::SynchronizedOutputStream( &std::cout, mpi_comm, format ) );
+       new slic::SynchronizedStream( &std::cout, mpi_comm, format ) );
 
 
 .. note::
 
-   Since, the :ref:`SynchronizedOutputStream` works across MPI ranks, logging
+   Since, the :ref:`SynchronizedStream` works across MPI ranks, logging
    messages using the :ref:`SlicMacros` or the static API directly
    only logs the messages locally. To send the messages to the output destination
    the application must call ``slic::flushStreams()`` explicitly, which, in
@@ -291,7 +291,7 @@ Lumberjack Stream
 """""""""""""""""
 
 The :ref:`LumberjackStream`, is intended to be used with parallel MPI
-applications. In contrast to the :ref:`SynchronizedOutputStream`, which logs
+applications. In contrast to the :ref:`SynchronizedStream`, which logs
 messages from all ranks, the :ref:`LumberjackStream` uses `Lumberjack`_
 internally to filter out duplicate messages that are emitted from multiple
 ranks.

--- a/src/axom/slic/docs/sphinx/sections/citations.rst
+++ b/src/axom/slic/docs/sphinx/sections/citations.rst
@@ -11,4 +11,5 @@
 .. _WCI: https://wci.llnl.gov/
 .. _WSC: https://wci.llnl.gov/about-us/weapon-simulation-and-computing
 .. _Slic Doxygen API Documentation: ../../../../../doxygen/html/slictop.html
+.. _Slic Macro Doxygen Reference: ../../../../../doxygen/html/slic__macros_8hpp.html
 

--- a/src/axom/slic/docs/sphinx/sections/getting_started.rst
+++ b/src/axom/slic/docs/sphinx/sections/getting_started.rst
@@ -57,7 +57,7 @@ the following sections.
 
 .. warning::
 
-   If you forget to initialize Slic, Slic will call ``slic::initialize()``,
+   If you do not initialize Slic, Slic will call ``slic::initialize()``,
    setup a minimal configuration (perform Steps 2 through 5), and issue a warning
    message. It is recommended that you call ``slic::initialize()`` to get rid
    of the warning and perform your own configuration.
@@ -122,7 +122,7 @@ severity level, all messages will be captured in this case.
 
 .. warning::
 
-   No messages will be logged if you forget to call ``slic::setLoggingMsgLevel()``.
+   No messages will be logged if you do not call ``slic::setLoggingMsgLevel()``.
    All messages will be ignored.
 
 .. _slicExampleStep5:

--- a/src/axom/slic/docs/sphinx/sections/getting_started.rst
+++ b/src/axom/slic/docs/sphinx/sections/getting_started.rst
@@ -212,6 +212,13 @@ finalized, as follows:
 Calling ``slic::finalize()`` will properly deallocate the registered
 :ref:`LogStream` objects and terminate the Slic Logging Environment.
 
+.. note::
+
+   ``slic::finalize()`` is a collective operation when used with
+   MPI-aware :ref:`LogStream` instances such as :ref:`SynchronizedStream`
+   or :ref:`LumberjackStream`. See the `Slic Doxygen API Documentation`_
+   for more details.
+
 Step 8: Run the Example
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/axom/slic/docs/sphinx/sections/getting_started.rst
+++ b/src/axom/slic/docs/sphinx/sections/getting_started.rst
@@ -193,7 +193,7 @@ below.
 .. note::
 
    A subset of SLIC macros are collective operations when used with
-   MPI-aware :ref:`logStream` instances such as :ref:`SynchronizedOutputStream`
+   MPI-aware :ref:`logStream` instances such as :ref:`SynchronizedStream`
    or :ref:`LumberjackStream`. Consult :ref:`CollectiveSlicMacros`
    for a list of collective Axom macros.
 

--- a/src/axom/slic/docs/sphinx/sections/getting_started.rst
+++ b/src/axom/slic/docs/sphinx/sections/getting_started.rst
@@ -131,7 +131,7 @@ Step 5: Register a Log Stream
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Log messages can have one or more output destination. The output destination
-is specified by registering a corresponding :ref:`logStream` object to each
+is specified by registering a corresponding :ref:`LogStream` object to each
 :ref:`logMessageLevel`.
 
 The following code snippet uses the :ref:`GenericOutputStream` object,
@@ -148,7 +148,7 @@ as the output destination for messages at each :ref:`logMessageLevel`.
 
    Instead of calling ``slic::addStreamToAllMsgLevels()`` an application
    may use ``slic::addStreamToMsgLevel()`` that allows more fine grain
-   control of how to bind :ref:`logStream` objects to each
+   control of how to bind :ref:`LogStream` objects to each
    :ref:`logMessageLevel`. Consult the `Slic Doxygen API Documentation`_
    for more information.
 
@@ -165,7 +165,7 @@ The :ref:`GenericOutputStream`,  takes two arguments in its constructor:
 
 .. note::
 
-   Slic maintains ownership of all registered :ref:`logStream` instances and
+   Slic maintains ownership of all registered :ref:`LogStream` instances and
    will deallocate them when ``slic::finalize()`` is called.
 
 Step 6: Log Messages
@@ -193,7 +193,7 @@ below.
 .. note::
 
    A subset of SLIC macros are collective operations when used with
-   MPI-aware :ref:`logStream` instances such as :ref:`SynchronizedStream`
+   MPI-aware :ref:`LogStream` instances such as :ref:`SynchronizedStream`
    or :ref:`LumberjackStream`. Consult :ref:`CollectiveSlicMacros`
    for a list of collective Axom macros.
 
@@ -210,7 +210,7 @@ finalized, as follows:
    :linenos:
 
 Calling ``slic::finalize()`` will properly deallocate the registered
-:ref:`logStream` objects and terminate the Slic Logging Environment.
+:ref:`LogStream` objects and terminate the Slic Logging Environment.
 
 Step 8: Run the Example
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/axom/slic/docs/sphinx/sections/getting_started.rst
+++ b/src/axom/slic/docs/sphinx/sections/getting_started.rst
@@ -55,6 +55,14 @@ an application must first specify an output destination and optionally,
 prescribe the format of the log messages. These steps are demonstrated in
 the following sections.
 
+.. warning::
+
+   If you forget to initialize Slic, Slic will call ``slic::initialize()``,
+   setup a minimal configuration (perform Steps 2 through 5), and issue a warning
+   message. It is recommended that you call ``slic::initialize()`` to get rid
+   of the warning and perform your own configuration.
+
+
 .. _slicExampleStep3:
 
 Step 3: Set the Message Format
@@ -112,6 +120,11 @@ This indicates that all log messages that are *debug* or higher
 are captured otherwise, the messages are ignored. Since *debug* is the lowest
 severity level, all messages will be captured in this case.
 
+.. warning::
+
+   No messages will be logged if you forget to call ``slic::setLoggingMsgLevel()``.
+   All messages will be ignored.
+
 .. _slicExampleStep5:
 
 Step 5: Register a Log Stream
@@ -155,7 +168,7 @@ The :ref:`GenericOutputStream`,  takes two arguments in its constructor:
    Slic maintains ownership of all registered :ref:`logStream` instances and
    will deallocate them when ``slic::finalize()`` is called.
 
-Step 5: Log Messages
+Step 6: Log Messages
 ^^^^^^^^^^^^^^^^^^^^^
 
 Once the output destination of messages is specified, messages can be logged
@@ -177,7 +190,14 @@ below.
    registered with ``slic::setAbortFunction()``. See the `Slic Doxygen API Documentation`_
    for more details.
 
-Step 6: Finalize Slic
+.. note::
+
+   A subset of SLIC macros are collective operations when used with
+   MPI-aware :ref:`logStream` instances such as :ref:`SynchronizedOutputStream`
+   or :ref:`LumberjackStream`. Consult :ref:`CollectiveSlicMacros`
+   for a list of collective Axom macros.
+
+Step 7: Finalize Slic
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Before the application terminates, the Slic Logging Environment must be
@@ -192,7 +212,7 @@ finalized, as follows:
 Calling ``slic::finalize()`` will properly deallocate the registered
 :ref:`logStream` objects and terminate the Slic Logging Environment.
 
-Step 7: Run the Example
+Step 8: Run the Example
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 After building the `Axom Toolkit`_ the :ref:`SlicApplicationCodeExample` may be

--- a/src/axom/slic/docs/sphinx/sections/getting_started.rst
+++ b/src/axom/slic/docs/sphinx/sections/getting_started.rst
@@ -122,8 +122,7 @@ severity level, all messages will be captured in this case.
 
 .. warning::
 
-   No messages will be logged if you do not call ``slic::setLoggingMsgLevel()``.
-   All messages will be ignored.
+   All messages will be ignored until the first call to ``slic::setLoggingMsgLevel()``.
 
 .. _slicExampleStep5:
 

--- a/src/axom/slic/docs/sphinx/sections/wrapping_slic_in_macros.rst
+++ b/src/axom/slic/docs/sphinx/sections/wrapping_slic_in_macros.rst
@@ -71,7 +71,7 @@ These macros can then be used in the application code as follows:
 .. warning::
    Macros that use ``slic::logMessage()`` with a :ref:`logMessageLevel` of
    ``WARNING`` or ``ERROR`` are collective operations when used with
-   MPI-aware :ref:`logStream` instances. Consult :ref:`CollectiveSlicMacros`
+   MPI-aware :ref:`LogStream` instances. Consult :ref:`CollectiveSlicMacros`
    for a list of collective Axom macros.
 
 The :ref:`SlicMacros` provide a good resource for the type of macros that an

--- a/src/axom/slic/docs/sphinx/sections/wrapping_slic_in_macros.rst
+++ b/src/axom/slic/docs/sphinx/sections/wrapping_slic_in_macros.rst
@@ -68,7 +68,6 @@ These macros can then be used in the application code as follows:
    pass the ``__FILE__`` and ``__LINE__`` to the ``logMessage()`` function
    each time.
 
-.. warning::
    Macros that use ``slic::logMessage()`` with a :ref:`logMessageLevel` of
    ``WARNING`` or ``ERROR`` are collective operations when used with
    MPI-aware :ref:`LogStream` instances. Consult :ref:`CollectiveSlicMacros`

--- a/src/axom/slic/docs/sphinx/sections/wrapping_slic_in_macros.rst
+++ b/src/axom/slic/docs/sphinx/sections/wrapping_slic_in_macros.rst
@@ -68,6 +68,12 @@ These macros can then be used in the application code as follows:
    pass the ``__FILE__`` and ``__LINE__`` to the ``logMessage()`` function
    each time.
 
+.. warning::
+   Macros that use ``slic::logMessage()`` with a :ref:`logMessageLevel` of
+   ``WARNING`` or ``ERROR`` are collective operations when used with
+   MPI-aware :ref:`logStream` instances. Consult :ref:`CollectiveSlicMacros`
+   for a list of collective Axom macros.
+
 The :ref:`SlicMacros` provide a good resource for the type of macros that an
 application may want to adopt and extend. Although these macros are tailored
 for use within the `Axom Toolkit`_, these are also callable by application code.

--- a/src/axom/slic/interface/slic.hpp
+++ b/src/axom/slic/interface/slic.hpp
@@ -168,6 +168,13 @@ void addStreamToAllMsgLevels(LogStream* ls);
  * \param [in] filter_duplicates optional parameter that indicates whether
  * duplicate messages resulting from running in parallel will be filtered out.
  * Default is false.
+ * \note When used within an MPI distributed environment, and:
+ *  - Level of the given message is Error and abort on error messages
+ *    is enabled for the current active logger (default is enabled for loggers)
+ *  - Level of the given message is Warning and abort on warning messages
+ *    is enabled for the current active logger (default is disabled for loggers)
+ * \note this method is a collective operation. All ranks in the user-supplied
+ * communicator must call this method.
  */
 void logMessage(message::Level level,
                 const std::string& message,
@@ -181,6 +188,13 @@ void logMessage(message::Level level,
  * \param [in] filter_duplicates optional parameter that indicates whether
  * duplicate messages resulting from running in parallel will be filtered out.
  * Default is false.
+ * \note When used within an MPI distributed environment, and:
+ *  - Level of the given message is Error and abort on error messages
+ *    is enabled for the current active logger (default is enabled for loggers)
+ *  - Level of the given message is Warning and abort on warning messages
+ *    is enabled for the current active logger (default is disabled for loggers)
+ * \note this method is a collective operation. All ranks in the user-supplied
+ * communicator must call this method.
  */
 void logMessage(message::Level level,
                 const std::string& message,
@@ -196,6 +210,13 @@ void logMessage(message::Level level,
  * \param [in] filter_duplicates optional parameter that indicates whether
  * duplicate messages resulting from running in parallel will be filtered out.
  * Default is false.
+ * \note When used within an MPI distributed environment, and:
+ *  - Level of the given message is Error and abort on error messages
+ *    is enabled for the current active logger (default is enabled for loggers)
+ *  - Level of the given message is Warning and abort on warning messages
+ *    is enabled for the current active logger (default is disabled for loggers)
+ * \note this method is a collective operation. All ranks in the user-supplied
+ * communicator must call this method.
  */
 void logMessage(message::Level level,
                 const std::string& message,
@@ -213,6 +234,13 @@ void logMessage(message::Level level,
  * \param [in] filter_duplicates optional parameter that indicates whether
  * duplicate messages resulting from running in parallel will be filtered out.
  * Default is false.
+ * \note When used within an MPI distributed environment, and:
+ *  - Level of the given message is Error and abort on error messages
+ *    is enabled for the current active logger (default is enabled for loggers)
+ *  - Level of the given message is Warning and abort on warning messages
+ *    is enabled for the current active logger (default is disabled for loggers)
+ * \note this method is a collective operation. All ranks in the user-supplied
+ * communicator must call this method.
  */
 void logMessage(message::Level level,
                 const std::string& message,
@@ -226,6 +254,10 @@ void logMessage(message::Level level,
  * \param [in] message user-supplied message.
  * \param [in] fileName the name of the file this message is logged from.
  * \param [in] line the line number within the file that the message is logged.
+ * \note When used within an MPI distributed environment, and abort on error
+ * messages is enabled for the current active logger (default is enabled
+ * for loggers), this method is a collective operation. All ranks in the
+ * user-supplied communicator must call this method.
  */
 void logErrorMessage(const std::string& message,
                      const std::string& fileName,
@@ -236,6 +268,10 @@ void logErrorMessage(const std::string& message,
  * \param [in] message user-supplied message.
  * \param [in] fileName the name of the file this message is logged from.
  * \param [in] line the line number within the file that the message is logged.
+ * \note When used within an MPI distributed environment, and abort on warning
+ * messages is enabled for the current active logger (default is disabled
+ * for loggers), this method is a collective operation. All ranks in the
+ * user-supplied communicator must call this method.
  */
 void logWarningMessage(const std::string& message,
                        const std::string& fileName,
@@ -244,12 +280,18 @@ void logWarningMessage(const std::string& message,
 /*!
  * \brief Flushes all streams.
  * \see Logger::flushStreams.
+ * \note When used within an MPI distributed environment, flushStreams is
+ *  a collective operation. All ranks in the user-supplied communicator must
+ *  call this method.
  */
 void flushStreams();
 
 /*!
  * \brief Pushes all streams.
  * \see Logger::pushStreams.
+ * \note When used within an MPI distributed environment, pushStreams is
+ *  a collective operation. All ranks in the user-supplied communicator must
+ *  call this method.
  */
 void pushStreams();
 

--- a/src/axom/slic/interface/slic.hpp
+++ b/src/axom/slic/interface/slic.hpp
@@ -176,6 +176,7 @@ void addStreamToAllMsgLevels(LogStream* ls);
 
 /*!
  * \brief Logs the given message to all registered streams.
+ * \collective
  * \param [in] level the level of the message being logged.
  * \param [in] message user-supplied message.
  * \param [in] filter_duplicates optional parameter that indicates whether
@@ -188,6 +189,7 @@ void logMessage(message::Level level,
 
 /*!
  * \brief Logs the given message to all registered streams.
+ * \collective
  * \param [in] level the level of the message being logged.
  * \param [in] message user-supplied message.
  * \param [in] tag user-supplied associated with this message.
@@ -202,6 +204,7 @@ void logMessage(message::Level level,
 
 /*!
  * \brief Logs the given message to all registered streams.
+ * \collective
  * \param [in] level the level of the message being logged.
  * \param [in] message user-supplied message.
  * \param [in] fileName the name of the file this message is logged from.
@@ -218,6 +221,7 @@ void logMessage(message::Level level,
 
 /*!
  * \brief Logs the given message to all registered streams.
+ * \collective
  * \param [in] level the level of the message being logged.
  * \param [in] message user-supplied message.
  * \param [in] tag user-supplied tag associated with the message.
@@ -236,6 +240,7 @@ void logMessage(message::Level level,
 
 /*!
  * \brief Convenience method to log an error message.
+ * \collective
  * \param [in] message user-supplied message.
  * \param [in] fileName the name of the file this message is logged from.
  * \param [in] line the line number within the file that the message is logged.
@@ -246,6 +251,7 @@ void logErrorMessage(const std::string& message,
 
 /*!
  * \brief Convenience method to log warning messages.
+ * \collective
  * \param [in] message user-supplied message.
  * \param [in] fileName the name of the file this message is logged from.
  * \param [in] line the line number within the file that the message is logged.
@@ -256,6 +262,7 @@ void logWarningMessage(const std::string& message,
 
 /*!
  * \brief Flushes all streams.
+ * \collective
  * \see Logger::flushStreams.
  * \note When used within an MPI distributed environment, flushStreams is
  *  a collective operation. All ranks in the user-supplied communicator must
@@ -265,6 +272,7 @@ void flushStreams();
 
 /*!
  * \brief Pushes all streams.
+ * \collective
  * \see Logger::pushStreams.
  * \note When used within an MPI distributed environment, pushStreams is
  *  a collective operation. All ranks in the user-supplied communicator must
@@ -274,6 +282,7 @@ void pushStreams();
 
 /*!
  * \brief Finalizes the slic logging environment.
+ * \collective
  */
 void finalize();
 

--- a/src/axom/slic/interface/slic.hpp
+++ b/src/axom/slic/interface/slic.hpp
@@ -161,6 +161,19 @@ void addStreamToMsgLevel(LogStream* ls, message::Level level);
  */
 void addStreamToAllMsgLevels(LogStream* ls);
 
+///@{
+//! \name Collective Methods
+//!
+//! \attention These methods are collective operations.
+//! All ranks in the user-supplied communicator must call the method
+//! when used within an MPI distributed environment.
+//! Additionally, for logMessage:
+//!  - Level of the given message is Error and abort on error messages
+//!    is enabled for the current active logger (default is enabled for loggers)
+//!  - Level of the given message is Warning and abort on warning messages
+//!    is enabled for the current active logger (default is disabled for loggers)
+//!
+
 /*!
  * \brief Logs the given message to all registered streams.
  * \param [in] level the level of the message being logged.
@@ -168,13 +181,6 @@ void addStreamToAllMsgLevels(LogStream* ls);
  * \param [in] filter_duplicates optional parameter that indicates whether
  * duplicate messages resulting from running in parallel will be filtered out.
  * Default is false.
- * \note When used within an MPI distributed environment, and:
- *  - Level of the given message is Error and abort on error messages
- *    is enabled for the current active logger (default is enabled for loggers)
- *  - Level of the given message is Warning and abort on warning messages
- *    is enabled for the current active logger (default is disabled for loggers)
- * \note this method is a collective operation. All ranks in the user-supplied
- * communicator must call this method.
  */
 void logMessage(message::Level level,
                 const std::string& message,
@@ -188,13 +194,6 @@ void logMessage(message::Level level,
  * \param [in] filter_duplicates optional parameter that indicates whether
  * duplicate messages resulting from running in parallel will be filtered out.
  * Default is false.
- * \note When used within an MPI distributed environment, and:
- *  - Level of the given message is Error and abort on error messages
- *    is enabled for the current active logger (default is enabled for loggers)
- *  - Level of the given message is Warning and abort on warning messages
- *    is enabled for the current active logger (default is disabled for loggers)
- * \note this method is a collective operation. All ranks in the user-supplied
- * communicator must call this method.
  */
 void logMessage(message::Level level,
                 const std::string& message,
@@ -210,13 +209,6 @@ void logMessage(message::Level level,
  * \param [in] filter_duplicates optional parameter that indicates whether
  * duplicate messages resulting from running in parallel will be filtered out.
  * Default is false.
- * \note When used within an MPI distributed environment, and:
- *  - Level of the given message is Error and abort on error messages
- *    is enabled for the current active logger (default is enabled for loggers)
- *  - Level of the given message is Warning and abort on warning messages
- *    is enabled for the current active logger (default is disabled for loggers)
- * \note this method is a collective operation. All ranks in the user-supplied
- * communicator must call this method.
  */
 void logMessage(message::Level level,
                 const std::string& message,
@@ -234,13 +226,6 @@ void logMessage(message::Level level,
  * \param [in] filter_duplicates optional parameter that indicates whether
  * duplicate messages resulting from running in parallel will be filtered out.
  * Default is false.
- * \note When used within an MPI distributed environment, and:
- *  - Level of the given message is Error and abort on error messages
- *    is enabled for the current active logger (default is enabled for loggers)
- *  - Level of the given message is Warning and abort on warning messages
- *    is enabled for the current active logger (default is disabled for loggers)
- * \note this method is a collective operation. All ranks in the user-supplied
- * communicator must call this method.
  */
 void logMessage(message::Level level,
                 const std::string& message,
@@ -254,10 +239,6 @@ void logMessage(message::Level level,
  * \param [in] message user-supplied message.
  * \param [in] fileName the name of the file this message is logged from.
  * \param [in] line the line number within the file that the message is logged.
- * \note When used within an MPI distributed environment, and abort on error
- * messages is enabled for the current active logger (default is enabled
- * for loggers), this method is a collective operation. All ranks in the
- * user-supplied communicator must call this method.
  */
 void logErrorMessage(const std::string& message,
                      const std::string& fileName,
@@ -268,10 +249,6 @@ void logErrorMessage(const std::string& message,
  * \param [in] message user-supplied message.
  * \param [in] fileName the name of the file this message is logged from.
  * \param [in] line the line number within the file that the message is logged.
- * \note When used within an MPI distributed environment, and abort on warning
- * messages is enabled for the current active logger (default is disabled
- * for loggers), this method is a collective operation. All ranks in the
- * user-supplied communicator must call this method.
  */
 void logWarningMessage(const std::string& message,
                        const std::string& fileName,
@@ -294,6 +271,8 @@ void flushStreams();
  *  call this method.
  */
 void pushStreams();
+
+///@}
 
 /*!
  * \brief Finalizes the slic logging environment.

--- a/src/axom/slic/interface/slic.hpp
+++ b/src/axom/slic/interface/slic.hpp
@@ -167,7 +167,7 @@ void addStreamToAllMsgLevels(LogStream* ls);
 //! \attention These methods are collective operations.
 //! All ranks in the user-supplied communicator must call the method
 //! when used within an MPI distributed environment.
-//! Additionally, for logMessage:
+//! The logMessage method is collective if:
 //!  - Level of the given message is Error and abort on error messages
 //!    is enabled for the current active logger (default is enabled for loggers)
 //!  - Level of the given message is Warning and abort on warning messages

--- a/src/axom/slic/interface/slic.hpp
+++ b/src/axom/slic/interface/slic.hpp
@@ -167,11 +167,16 @@ void addStreamToAllMsgLevels(LogStream* ls);
 //! \attention These methods are collective operations.
 //! All ranks in the user-supplied communicator must call the method
 //! when used within an MPI distributed environment.
-//! The logMessage method is collective if:
-//!  - Level of the given message is Error and abort on error messages
-//!    is enabled for the current active logger (default is enabled for loggers)
-//!  - Level of the given message is Warning and abort on warning messages
-//!    is enabled for the current active logger (default is disabled for loggers)
+//! The logMessage method is collective if either:
+//!  - Level of the given message is Error and slic::enableAbortOnError() is
+//!    called for the current active logger (default is enabled for loggers)
+//!  - Level of the given message is Warning and slic::enableAbortOnWarning()
+//!    is called for the current active logger (default is disabled for loggers)
+//!
+//! \sa axom::slic::isAbortOnErrorsEnabled()
+//! \sa axom::slic::setAbortOnError(bool status)
+//! \sa axom::slic::isAbortOnWarningsEnabled()
+//! \sa axom::slic::setAbortOnWarning(bool status)
 //!
 
 /*!

--- a/src/axom/slic/interface/slic.hpp
+++ b/src/axom/slic/interface/slic.hpp
@@ -272,12 +272,12 @@ void flushStreams();
  */
 void pushStreams();
 
-///@}
-
 /*!
  * \brief Finalizes the slic logging environment.
  */
 void finalize();
+
+///@}
 
 /*!
  * \brief Uses glibc's backtrace() functionality to return a stacktrace

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -14,8 +14,9 @@
  */
 
 ///@{
-//! \name ERROR MACROS
+//! \name SLIC_ERROR MACROS
 //!
+//! \collective
 //! \attention These error macros are collective operations.
 //! All ranks in the user-supplied communicator must call the macro
 //! when used within an MPI distributed environment, and abort on error
@@ -72,8 +73,9 @@
 ///@}
 
 ///@{
-//! \name WARNING MACROS
+//! \name SLIC_WARNING MACROS
 //!
+//! \collective
 //! \attention These warning macros can be set as collective operations.
 //! These warning macros are collective if abort on warning
 //! messages is enabled for the current active logger (default is disabled
@@ -134,8 +136,9 @@
 
   //-----------------------------------------------------------------------------
   /// @{
-  //! \name ASSERT MACROS
+  //! \name SLIC_ASSERT MACROS
   //!
+  //! \collective
   //! \attention These assert macros are collective operations.
   //! All ranks in the user-supplied communicator must call the macro
   //! when used within an MPI distributed environment, and abort on error
@@ -198,8 +201,9 @@
 
   //-----------------------------------------------------------------------------
   /// @{
-  //! \name CHECK MACROS
+  //! \name SLIC_CHECK MACROS
   //!
+  //! \collective
   //! \attention These check macros can be set as collective operations.
   //! These check macros are collective if either:
   //! - slic::debug::checksAreErrors is set to true (default is false) and abort

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -20,8 +20,12 @@
  * \def SLIC_ERROR( msg )
  * \brief Logs an error and aborts the application.
  * \param [in] msg user-supplied message
- * \note The SLIC_ERROR macro is always active.
  * \warning This macro calls processAbort().
+ * \note The SLIC_ERROR macro is always active.
+ * \warning When used within an MPI distributed environment, and abort on error
+ * messages is enabled for the current active logger (default is enabled
+ * for loggers), this macro is a collective operation. All ranks in the
+ * user-supplied communicator must call this macro.
  *
  * Usage:
  * \code
@@ -42,8 +46,12 @@
  * \brief Logs an error iff EXP is true and aborts the application.
  * \param [in] EXP user-supplied boolean expression.
  * \param [in] msg user-supplied message.
- * \note The SLIC_ERROR_IF macro is always active.
  * \warning This macro calls processAbort() if EXP is true.
+ * \note The SLIC_ERROR_IF macro is always active.
+ * \warning When used within an MPI distributed environment, and abort on error
+ * messages is enabled for the current active logger (default is enabled
+ * for loggers), this macro is a collective operation. All ranks in the
+ * user-supplied communicator must call this macro.
  *
  * Usage:
  * \code
@@ -72,6 +80,10 @@
  * \brief Logs a warning message.
  * \param [in] msg user-supplied message
  * \note The SLIC_WARNING macro is always active.
+ * \warning When used within an MPI distributed environment, and abort on warning
+ * messages is enabled for the current active logger (default is disabled
+ * for loggers), this macro is a collective operation. All ranks in the
+ * user-supplied communicator must call this macro.
  *
  * Usage:
  * \code
@@ -93,6 +105,10 @@
  * \param [in] EXP user-supplied boolean expression.
  * \param [in] msg user-supplied message.
  * \note The SLIC_WARNING_IF macro is always active.
+ * \warning When used within an MPI distributed environment, and abort on warning
+ * messages is enabled for the current active logger (default is disabled
+ * for loggers), this macro is a collective operation. All ranks in the
+ * user-supplied communicator must call this macro.
  *
  * Usage:
  * \code
@@ -125,8 +141,12 @@
  * \brief Asserts that a given expression is true. If the expression is not true
  *  an error will be logged and the application will be aborted.
  * \param [in] EXP user-supplied boolean expression.
- * \note This macro is only active when AXOM_DEBUG is defined.
  * \warning This macro calls processAbort() if EXP is false.
+ * \note This macro is only active when AXOM_DEBUG is defined.
+ * \warning When used within an MPI distributed environment, and abort on error
+ * messages is enabled for the current active logger (default is enabled
+ * for loggers), this macro is a collective operation. All ranks in the
+ * user-supplied communicator must call this macro.
  *
  * Usage:
  * \code
@@ -150,8 +170,12 @@
  * \brief Same as SLIC_ASSERT, but with a custom error message.
  * \param [in] EXP user-supplied boolean expression.
  * \param [in] msg user-supplied message
- * \note This macro is only active when AXOM_DEBUG is defined.
  * \warning This macro calls processAbort() if EXP is false.
+ * \note This macro is only active when AXOM_DEBUG is defined.
+ * \warning When used within an MPI distributed environment, and abort on error
+ * messages is enabled for the current active logger (default is enabled
+ * for loggers), this macro is a collective operation. All ranks in the
+ * user-supplied communicator must call this macro.
  * \see SLIC_ASSERT( EXP )
  *
  * Usage:
@@ -184,6 +208,15 @@
  *  application is not aborted.
  * \param [in] EXP user-supplied boolean expression.
  * \note This macro is only active when AXOM_DEBUG is defined.
+ * \warning When used within an MPI distributed environment, and either:
+ * - slic::debug::checksAreErrors is set to true (default is false) and abort
+ * on error messages is enabled for the current active logger (default is enabled
+ * for loggers)
+ * - slic::debug::checksAreErrors is set to false (default is false) and abort
+ * on warning messages is enabled for the current active logger (default is disabled
+ * for loggers)
+ * \warning this macro is a collective operation. All ranks in the
+ * user-supplied communicator must call this macro.
  *
  * Usage:
  * \code
@@ -215,6 +248,15 @@
  * \param [in] EXP user-supplied boolean expression.
  * \param [in] msg user-supplied message
  * \note This macro is only active when AXOM_DEBUG is defined.
+ * \warning When used within an MPI distributed environment, and either:
+ * - slic::debug::checksAreErrors is set to true (default is false) and abort
+ * on error messages is enabled for the current active logger (default is enabled
+ * for loggers)
+ * - slic::debug::checksAreErrors is set to false (default is false) and abort
+ * on warning messages is enabled for the current active logger (default is disabled
+ * for loggers)
+ * \warning this macro is a collective operation. All ranks in the
+ * user-supplied communicator must call this macro.
  * \see SLIC_DEBUG( EXP )
  *
  * Usage:

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -13,8 +13,15 @@
  * \file slic_macros.hpp
  */
 
-/// \name ERROR MACROS
-/// @{
+///@{
+//! \name ERROR MACROS
+//!
+//! \attention These error macros are collective operations.
+//! All ranks in the user-supplied communicator must call the macro
+//! when used within an MPI distributed environment, and abort on error
+//! messages is enabled for the current active logger (default is enabled
+//! for loggers)
+//!
 
 /*!
  * \def SLIC_ERROR( msg )
@@ -22,10 +29,6 @@
  * \param [in] msg user-supplied message
  * \warning This macro calls processAbort().
  * \note The SLIC_ERROR macro is always active.
- * \warning When used within an MPI distributed environment, and abort on error
- * messages is enabled for the current active logger (default is enabled
- * for loggers), this macro is a collective operation. All ranks in the
- * user-supplied communicator must call this macro.
  *
  * Usage:
  * \code
@@ -48,10 +51,6 @@
  * \param [in] msg user-supplied message.
  * \warning This macro calls processAbort() if EXP is true.
  * \note The SLIC_ERROR_IF macro is always active.
- * \warning When used within an MPI distributed environment, and abort on error
- * messages is enabled for the current active logger (default is enabled
- * for loggers), this macro is a collective operation. All ranks in the
- * user-supplied communicator must call this macro.
  *
  * Usage:
  * \code
@@ -70,20 +69,23 @@
     }                                                               \
   } while(axom::slic::detail::false_value)
 
-/// @}
+///@}
 
-/// \name WARNING MACROS
-/// @{
+///@{
+//! \name WARNING MACROS
+//!
+//! \attention These warning macros are collective operations.
+//! All ranks in the user-supplied communicator must call the macro
+//! when used within an MPI distributed environment, and abort on warning
+//! messages is enabled for the current active logger (default is disabled
+//! for loggers)
+//!
 
 /*!
  * \def SLIC_WARNING( msg )
  * \brief Logs a warning message.
  * \param [in] msg user-supplied message
  * \note The SLIC_WARNING macro is always active.
- * \warning When used within an MPI distributed environment, and abort on warning
- * messages is enabled for the current active logger (default is disabled
- * for loggers), this macro is a collective operation. All ranks in the
- * user-supplied communicator must call this macro.
  *
  * Usage:
  * \code
@@ -105,10 +107,6 @@
  * \param [in] EXP user-supplied boolean expression.
  * \param [in] msg user-supplied message.
  * \note The SLIC_WARNING_IF macro is always active.
- * \warning When used within an MPI distributed environment, and abort on warning
- * messages is enabled for the current active logger (default is disabled
- * for loggers), this macro is a collective operation. All ranks in the
- * user-supplied communicator must call this macro.
  *
  * Usage:
  * \code
@@ -127,14 +125,21 @@
     }                                                                 \
   } while(axom::slic::detail::false_value)
 
-/// @}
+///@}
 
 // Use complete debug macros when not on device
 #if defined(AXOM_DEBUG) && !defined(AXOM_DEVICE_CODE)
 
   //-----------------------------------------------------------------------------
-  /// \name ASSERT MACROS
   /// @{
+  //! \name ASSERT MACROS
+  //!
+  //! \attention These assert macros are collective operations.
+  //! All ranks in the user-supplied communicator must call the macro
+  //! when used within an MPI distributed environment, and abort on error
+  //! messages is enabled for the current active logger (default is enabled
+  //! for loggers)
+  //!
 
   /*!
  * \def SLIC_ASSERT( EXP )
@@ -143,10 +148,6 @@
  * \param [in] EXP user-supplied boolean expression.
  * \warning This macro calls processAbort() if EXP is false.
  * \note This macro is only active when AXOM_DEBUG is defined.
- * \warning When used within an MPI distributed environment, and abort on error
- * messages is enabled for the current active logger (default is enabled
- * for loggers), this macro is a collective operation. All ranks in the
- * user-supplied communicator must call this macro.
  *
  * Usage:
  * \code
@@ -172,10 +173,6 @@
  * \param [in] msg user-supplied message
  * \warning This macro calls processAbort() if EXP is false.
  * \note This macro is only active when AXOM_DEBUG is defined.
- * \warning When used within an MPI distributed environment, and abort on error
- * messages is enabled for the current active logger (default is enabled
- * for loggers), this macro is a collective operation. All ranks in the
- * user-supplied communicator must call this macro.
  * \see SLIC_ASSERT( EXP )
  *
  * Usage:
@@ -195,11 +192,22 @@
       }                                                                      \
     } while(axom::slic::detail::false_value)
 
-  /// @}
+  ///@}
 
   //-----------------------------------------------------------------------------
-  /// \name DEBUG MACROS
   /// @{
+  //! \name CHECK MACROS
+  //!
+  //! \attention These check macros are collective operations.
+  //! All ranks in the user-supplied communicator must call the macro
+  //! when used within an MPI distributed environment, and and either:
+  //! - slic::debug::checksAreErrors is set to true (default is false) and abort
+  //! on error messages is enabled for the current active logger (default is
+  //! enabled for loggers)
+  //! - slic::debug::checksAreErrors is set to false (default is false) and abort
+  //! on warning messages is enabled for the current active logger (default is
+  //! disabled for loggers)
+  //!
 
   /*!
  * \def SLIC_CHECK( EXP )
@@ -208,15 +216,6 @@
  *  application is not aborted.
  * \param [in] EXP user-supplied boolean expression.
  * \note This macro is only active when AXOM_DEBUG is defined.
- * \warning When used within an MPI distributed environment, and either:
- * - slic::debug::checksAreErrors is set to true (default is false) and abort
- * on error messages is enabled for the current active logger (default is enabled
- * for loggers)
- * - slic::debug::checksAreErrors is set to false (default is false) and abort
- * on warning messages is enabled for the current active logger (default is disabled
- * for loggers)
- * \warning this macro is a collective operation. All ranks in the
- * user-supplied communicator must call this macro.
  *
  * Usage:
  * \code
@@ -248,15 +247,6 @@
  * \param [in] EXP user-supplied boolean expression.
  * \param [in] msg user-supplied message
  * \note This macro is only active when AXOM_DEBUG is defined.
- * \warning When used within an MPI distributed environment, and either:
- * - slic::debug::checksAreErrors is set to true (default is false) and abort
- * on error messages is enabled for the current active logger (default is enabled
- * for loggers)
- * - slic::debug::checksAreErrors is set to false (default is false) and abort
- * on warning messages is enabled for the current active logger (default is disabled
- * for loggers)
- * \warning this macro is a collective operation. All ranks in the
- * user-supplied communicator must call this macro.
  * \see SLIC_DEBUG( EXP )
  *
  * Usage:

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -19,9 +19,11 @@
 //! \collective
 //! \attention These error macros are collective operations.
 //! All ranks in the user-supplied communicator must call the macro
-//! when used within an MPI distributed environment, and abort on error
-//! messages is enabled for the current active logger (default is enabled
+//! when used within an MPI distributed environment, and slic::enableAbortOnError()
+//! is called for the current active logger (default is enabled
 //! for loggers)
+//! \sa axom::slic::isAbortOnErrorsEnabled()
+//! \sa axom::slic::setAbortOnError(bool status)
 //!
 
 /*!
@@ -77,12 +79,14 @@
 //!
 //! \collective
 //! \attention These warning macros can be set as collective operations.
-//! These warning macros are collective if abort on warning
-//! messages is enabled for the current active logger (default is disabled
+//! These warning macros are collective if slic::enableAbortOnWarning()
+//! is called for the current active logger (default is disabled
 //! for loggers).
 //! These warning macros must then be called by all ranks in the
 //! user-supplied communicator when used within an MPI distributed
 //! environment.
+//! \sa axom::slic::isAbortOnWarningsEnabled()
+//! \sa axom::slic::setAbortOnWarning(bool status)
 //!
 
 /*!
@@ -141,9 +145,11 @@
   //! \collective
   //! \attention These assert macros are collective operations.
   //! All ranks in the user-supplied communicator must call the macro
-  //! when used within an MPI distributed environment, and abort on error
-  //! messages is enabled for the current active logger (default is enabled
+  //! when used within an MPI distributed environment, and slic::enableAbortOnError()
+  //! is called for the current active logger (default is enabled
   //! for loggers)
+  //! \sa axom::slic::isAbortOnErrorsEnabled()
+  //! \sa axom::slic::setAbortOnError(bool status)
   //!
 
   /*!
@@ -206,16 +212,21 @@
   //! \collective
   //! \attention These check macros can be set as collective operations.
   //! These check macros are collective if either:
-  //! - slic::debug::checksAreErrors is set to true (default is false) and abort
-  //! on error messages is enabled for the current active logger (default is
+  //! - slic::debug::checksAreErrors is set to true (default is false) and
+  //! slic::enableAbortOnError() is called for the current active logger (default is
   //! enabled for loggers)
-  //! - slic::debug::checksAreErrors is set to false (default is false) and abort
-  //! on warning messages is enabled for the current active logger (default is
+  //! - slic::debug::checksAreErrors is set to false (default is false) and
+  //! slic::enableAbortOnWarning() is called for the current active logger (default is
   //! disabled for loggers)
   //!
   //! These check macros must then be called by all ranks in the
   //! user-supplied communicator when used within an MPI distributed
   //! environment.
+  //!
+  //! \sa axom::slic::isAbortOnErrorsEnabled()
+  //! \sa axom::slic::setAbortOnError(bool status)
+  //! \sa axom::slic::isAbortOnWarningsEnabled()
+  //! \sa axom::slic::setAbortOnWarning(bool status)
   //!
 
   /*!

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -74,11 +74,13 @@
 ///@{
 //! \name WARNING MACROS
 //!
-//! \attention These warning macros are collective operations.
-//! All ranks in the user-supplied communicator must call the macro
-//! when used within an MPI distributed environment, and abort on warning
+//! \attention These warning macros can be set as collective operations.
+//! These warning macros are collective if abort on warning
 //! messages is enabled for the current active logger (default is disabled
-//! for loggers)
+//! for loggers).
+//! These warning macros must then be called by all ranks in the
+//! user-supplied communicator when used within an MPI distributed
+//! environment.
 //!
 
 /*!
@@ -198,15 +200,18 @@
   /// @{
   //! \name CHECK MACROS
   //!
-  //! \attention These check macros are collective operations.
-  //! All ranks in the user-supplied communicator must call the macro
-  //! when used within an MPI distributed environment, and and either:
+  //! \attention These check macros can be set as collective operations.
+  //! These check macros are collective if either:
   //! - slic::debug::checksAreErrors is set to true (default is false) and abort
   //! on error messages is enabled for the current active logger (default is
   //! enabled for loggers)
   //! - slic::debug::checksAreErrors is set to false (default is false) and abort
   //! on warning messages is enabled for the current active logger (default is
   //! disabled for loggers)
+  //!
+  //! These check macros must then be called by all ranks in the
+  //! user-supplied communicator when used within an MPI distributed
+  //! environment.
   //!
 
   /*!

--- a/src/axom/slic/streams/LumberjackStream.hpp
+++ b/src/axom/slic/streams/LumberjackStream.hpp
@@ -83,13 +83,17 @@ public:
   /*!
    * \brief Pushes all messages to the output node according to Lumberjack's
    *  Communication scheme. Then writes it to the given stream.
+   * \note This method is a collective operation
+   *  intended for a synchronization checkpoint.
    */
   virtual void flush();
 
   /*!
    * \brief Pushes all messages once to their parent node according to
    *  Lumberjack's Communication scheme.
-
+   *
+   * \note This method is a collective operation
+   *  intended for a synchronization checkpoint.
    * \note This does not guarantee all messages have reached the output node.
    * \note This does not write out to the given stream.
    */

--- a/src/axom/slic/streams/LumberjackStream.hpp
+++ b/src/axom/slic/streams/LumberjackStream.hpp
@@ -83,6 +83,8 @@ public:
   /*!
    * \brief Pushes all messages to the output node according to Lumberjack's
    *  Communication scheme. Then writes it to the given stream.
+   *
+   * \collective
    * \note This method is a collective operation
    *  intended for a synchronization checkpoint.
    */
@@ -92,6 +94,7 @@ public:
    * \brief Pushes all messages once to their parent node according to
    *  Lumberjack's Communication scheme.
    *
+   * \collective
    * \note This method is a collective operation
    *  intended for a synchronization checkpoint.
    * \note This does not guarantee all messages have reached the output node.

--- a/src/axom/slic/streams/SynchronizedStream.hpp
+++ b/src/axom/slic/streams/SynchronizedStream.hpp
@@ -74,6 +74,7 @@ public:
 
   /*!
    * \brief Dumps the messages to the console in rank-order.
+   * \collective
    * \note This method is a collective operation
    *  intended for a synchronization checkpoint.
    */

--- a/src/axom/slic/streams/SynchronizedStream.hpp
+++ b/src/axom/slic/streams/SynchronizedStream.hpp
@@ -74,6 +74,8 @@ public:
 
   /*!
    * \brief Dumps the messages to the console in rank-order.
+   * \note This method is a collective operation
+   *  intended for a synchronization checkpoint.
    */
   virtual void flush();
 

--- a/src/docs/doxygen/Doxyfile.in
+++ b/src/docs/doxygen/Doxyfile.in
@@ -228,7 +228,8 @@ TAB_SIZE               = 4
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                = "accelerated=\xrefitem accelerated_list \"\"\"\"" 
+ALIASES                = "accelerated=\xrefitem accelerated_list \"\"\"\"" \
+                         "collective=\xrefitem collective_list \"\"\"\""
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"
@@ -805,6 +806,7 @@ INPUT                  = @PROJECT_SOURCE_DIR@/axom/doxygen_mainpage.md \
                          @PROJECT_SOURCE_DIR@/axom/slam/doxygen_mainpage.md \
                          @PROJECT_SOURCE_DIR@/axom/slam/policies \
                          @PROJECT_SOURCE_DIR@/axom/slic/doxygen_mainpage.md \
+                         @PROJECT_SOURCE_DIR@/axom/slic/docs/doxygen_collective_list.doc \
                          @PROJECT_SOURCE_DIR@/axom/slic/core \
                          @PROJECT_SOURCE_DIR@/axom/slic/interface \
                          @PROJECT_SOURCE_DIR@/axom/slic/streams \

--- a/src/docs/doxygen/Doxyfile.in
+++ b/src/docs/doxygen/Doxyfile.in
@@ -2076,7 +2076,8 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = MINT_USE_SIDRE
+PREDEFINED             = MINT_USE_SIDRE \
+                         AXOM_DEBUG
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
This PR updates ReadTheDocs and doxygen to document which SLIC macros/functions are collective operations.
Resolves #524, relates to #26 discussion.

RTD of this branch:
https://axom.readthedocs.io/en/docs-han12-slicmpi/index.html

Table of collective SLIC macros:
https://axom.readthedocs.io/en/docs-han12-slicmpi/axom/slic/docs/sphinx/sections/appendix.html#collective-slic-macros

Slic Doxygen link:
https://axom.readthedocs.io/en/docs-han12-slicmpi/doxygen/html/namespaceaxom_1_1slic.html

Slic Macros Doxygen Link:
https://axom.readthedocs.io/en/docs-han12-slicmpi/doxygen/html/slic__macros_8hpp.html

