### PR TITLE
Remove corona allocate/release from gitlab

### DIFF
--- a/.gitlab/build_corona.yml
+++ b/.gitlab/build_corona.yml
@@ -17,36 +17,12 @@
     - when: on_success
 
 ####
-# In pre-build phase, allocate a node for builds
-corona_allocate:
-  variables:
-    GIT_STRATEGY: none
-  extends: [.on_corona, .src_workflow]
-  stage: allocate
-  script:
-    - salloc -p pbatch -N 1 -c 36 -t 60 --no-shell --job-name=${PROJECT_ALLOC_NAME}
-  needs: []
-
-####
-# In post-build phase, deallocate resources
-# Note : make sure this is run even on build phase failure
-corona_release:
-  variables:
-    GIT_STRATEGY: none
-  extends: [.on_corona, .src_workflow]
-  stage: release
-  script:
-    - export JOBID=$(squeue -h --name=${PROJECT_ALLOC_NAME} --format=%A)
-    - if [[ -n "${JOBID}" ]]; then scancel ${JOBID}; fi
-
-####
 # Template
 .src_build_on_corona:
   stage: build
   variables:
     ALLOC_COMMAND: "srun -p pbatch -t 60 -N 1 "
   extends: [.src_build_script, .on_corona, .src_workflow]
-  needs: [corona_allocate]
 
 .full_build_on_corona:
   stage: build

--- a/.gitlab/build_corona.yml
+++ b/.gitlab/build_corona.yml
@@ -12,8 +12,6 @@
   rules:
     - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_CORONA == "OFF"' #run except if ...
       when: never
-    - if: '$CI_JOB_NAME =~ /corona_release/'
-      when: always
     - when: on_success
 
 ####


### PR DESCRIPTION
This PR removes the allocate and release stages from the corona job.