### PR TITLE
Device optimization for axom::Array

### DIFF
--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -742,7 +742,6 @@ struct ArrayOpsBase<T, false>
    * \param [in] nelems the number of elements to initialize
    * \note Specialization for when T is default-constructible.
    */
-  template <typename U = void>
   static void init_impl(T* data, IndexType begin, IndexType nelems, std::true_type)
   {
     for(IndexType i = 0; i < nelems; ++i)
@@ -874,7 +873,6 @@ struct ArrayOpsBase<T, true>
    * \param [in] nelems the number of elements to initialize
    * \note Specialization for when T is nontrivially default-constructible.
    */
-  template <typename U = void>
   static void init_impl(T* data,
                         IndexType begin,
                         IndexType nelems,
@@ -899,7 +897,6 @@ struct ArrayOpsBase<T, true>
    * \overload
    * \note Specialization for when T is trivially default-constructible.
    */
-  template <typename U = void>
   static void init_impl(T* data,
                         IndexType begin,
                         IndexType nelems,
@@ -915,9 +912,7 @@ struct ArrayOpsBase<T, true>
    * \overload
    * \note Specialization for when T is not default-constructible.
    */
-  template <typename U = void>
-  static void init_impl(T*, IndexType, IndexType, NoDefaultCtorTag)
-  { }
+  static void init_impl(T*, IndexType, IndexType, NoDefaultCtorTag) { }
 
   /*!
    * \brief Default-initializes the "new" segment of an array
@@ -947,7 +942,6 @@ struct ArrayOpsBase<T, true>
    * \param [in] value the value to set each array element to
    * \note Specialization for when T is not trivially-copyable.
    */
-  template <typename U = void>
   static void fill_impl(T* array,
                         IndexType begin,
                         IndexType nelems,
@@ -968,7 +962,6 @@ struct ArrayOpsBase<T, true>
    * \overload
    * \note Specialization for when T is trivially-copyable.
    */
-  template <typename U = void>
   static void fill_impl(T* array,
                         IndexType begin,
                         IndexType nelems,

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -739,7 +739,7 @@ struct ArrayOpsBase<T, false>
    *
    * \param [inout] data The data to initialize
    * \param [in] begin The beginning of the subset of \a data that should be initialized
-   * \param [in] end The end index (exclusive) of the subset of \a data that is to be initialized
+   * \param [in] nelems the number of elements to initialize
    * \note Specialization for when T is default-constructible.
    */
   template <typename U = void>
@@ -755,16 +755,14 @@ struct ArrayOpsBase<T, false>
    * \overload
    * \note Specialization for when T is not default-constructible.
    */
-  template <typename U = void>
-  static void init_impl(T*, IndexType, IndexType, std::false_type)
-  { }
+  static void init_impl(T*, IndexType, IndexType, std::false_type) { }
 
   /*!
    * \brief Default-initializes the "new" segment of an array
    *
    * \param [inout] data The data to initialize
    * \param [in] begin The beginning of the subset of \a data that should be initialized
-   * \param [in] end The end index (exclusive) of the subset of \a data that is to be initialized
+   * \param [in] nelems the number of elements to initialize
    * \note Specialization for when T is default-constructible.
    */
   static void init(T* data, IndexType begin, IndexType nelems)

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -721,7 +721,7 @@ template <typename T>
 using HasTrivialCopyCtor = ::std::has_trivial_copy_constructor<T>;
 #else
 template <typename T>
-using HasTrivialCopyCtor = ::std::is_trivially_default_constructible<T>;
+using HasTrivialDefaultCtor = ::std::is_trivially_default_constructible<T>;
 template <typename T>
 using HasTrivialCopyCtor = ::std::is_trivially_copy_constructible<T>;
 #endif

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -443,6 +443,85 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_range_set)
 }
 
 //------------------------------------------------------------------------------
+constexpr int MAGIC_DEFAULT_CTOR = 222;
+
+struct NonTrivialDefaultCtor
+{
+  NonTrivialDefaultCtor() = default;
+
+  int m_val {MAGIC_DEFAULT_CTOR};
+};
+
+AXOM_TYPED_TEST(core_array_for_all, nontrivial_default_ctor_obj)
+{
+  using ExecSpace = typename TestFixture::ExecSpace;
+  using DynamicArray =
+    typename TestFixture::template DynamicTArray<NonTrivialDefaultCtor>;
+  using HostArray = typename TestFixture::template HostTArray<NonTrivialDefaultCtor>;
+
+  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+  if(axom::execution_space<ExecSpace>::onDevice())
+  {
+    kernelAllocID = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Device);
+  }
+#endif
+  int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+
+  // Create an array of N items using default MemorySpace for ExecSpace
+  constexpr axom::IndexType N = 374;
+  DynamicArray arr(N, N, kernelAllocID);
+
+  // Check array contents on host
+  {
+    HostArray localArr(arr, hostAllocID);
+    for(int i = 0; i < N; ++i)
+    {
+      EXPECT_EQ(localArr[i].m_val, MAGIC_DEFAULT_CTOR);
+    }
+  }
+
+  const int MAGIC_PREFILL = 111;
+  // Fill with placeholder value
+  auto arr_view = arr.view();
+  axom::for_all<ExecSpace>(
+    N,
+    AXOM_LAMBDA(axom::IndexType idx) { arr_view[idx].m_val = MAGIC_PREFILL; });
+
+  // handles synchronization, if necessary
+  if(axom::execution_space<ExecSpace>::async())
+  {
+    axom::synchronize<ExecSpace>();
+  }
+
+  // Fill with instance of copy-constructed type
+  arr.fill(NonTrivialDefaultCtor {});
+
+  // Check array contents on host
+  {
+    HostArray localArr(arr, hostAllocID);
+    for(int i = 0; i < N; ++i)
+    {
+      EXPECT_EQ(localArr[i].m_val, MAGIC_DEFAULT_CTOR);
+    }
+  }
+
+  // Resize array, adding new default-constructed elements
+  constexpr axom::IndexType N2 = 500;
+  arr.resize(N2);
+
+  // Check array contents on host
+  {
+    HostArray localArr(arr, hostAllocID);
+    for(int i = 0; i < N2; ++i)
+    {
+      EXPECT_EQ(localArr[i].m_val, MAGIC_DEFAULT_CTOR);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
 struct NonTrivialCtor
 {
   NonTrivialCtor(int val) : m_val(val) { }

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -207,6 +207,16 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array)
   constexpr axom::IndexType N = 374;
   DynamicArray arr(N, N, kernelAllocID);
 
+  // Test that array has been initialized to default values (0 for int)
+  {
+    HostArray localArr(arr, hostAllocID);
+    for(int i = 0; i < N; ++i)
+    {
+      int default_value {0};
+      EXPECT_EQ(localArr[i], default_value);
+    }
+  }
+
   // Modify array using lambda and ArrayView
   auto arr_view = arr.view();
   axom::for_all<ExecSpace>(
@@ -220,10 +230,12 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array)
   }
 
   // Check array contents on host
-  HostArray localArr(arr, hostAllocID);
-  for(int i = 0; i < N; ++i)
   {
-    EXPECT_EQ(localArr[i], N - i);
+    HostArray localArr(arr, hostAllocID);
+    for(int i = 0; i < N; ++i)
+    {
+      EXPECT_EQ(localArr[i], N - i);
+    }
   }
 }
 

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -457,7 +457,8 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_default_ctor_obj)
   using ExecSpace = typename TestFixture::ExecSpace;
   using DynamicArray =
     typename TestFixture::template DynamicTArray<NonTrivialDefaultCtor>;
-  using HostArray = typename TestFixture::template HostTArray<NonTrivialDefaultCtor>;
+  using HostArray =
+    typename TestFixture::template HostTArray<NonTrivialDefaultCtor>;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
 #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)


### PR DESCRIPTION
# Summary

Currently, `axom::Array<T>` initializes memory on the device by creating an array on the host, then copying it to the device. This is to work around limitations where `T` has a non-trivial default constructor, as that constructor would need to be device-annotated.

However, if `T` is trivially default-constructible, the host-allocate-and-copy workaround is unnecessary and may cost some performance. In this PR, we launch a kernel for default-initialization if the type `T` is trivially default-constructible.

As a bonus, we replace the use of SFINAE in `detail::ArrayOpsBase` with tag-dispatch.

## Performance

Measured on rzansel with `./bin/mesh_tester --method [accel_method] -p 3 --skipWeld -i [test_mesh]`:

| Test case | `develop` | this PR | speedup |
| ---------- | ---------- | ------- | -------- |
| car.stl - bvh | 0.358s | 0.248s | 1.45x |
| car.stl - implicit | 2.439s | 1.413s | 1.73x | 
| car.stl - uniform | 2.643s | 0.795s | 3.32x |
| porsche.stl - bvh | 0.131s | 0.128s | 1.03x |
| porsche.stl - implicit | 0.207s | 0.159s | 1.3x |
| porsche.stl - uniform | 0.277s | 0.172s | 1.61x |