### PR TITLE
Fix libyogrt dependency for SCR

### DIFF
--- a/host-configs/ruby-toss_3_x86_64_ib-clang@10.0.0.cmake
+++ b/host-configs/ruby-toss_3_x86_64_ib-clang@10.0.0.cmake
@@ -87,6 +87,8 @@ set(UMPIRE_DIR "${TPL_ROOT}/umpire-6.0.0axom" CACHE PATH "")
 
 set(SCR_DIR "${TPL_ROOT}/scr-3.0rc2" CACHE PATH "")
 
+set(LIBYOGRT_DIR "/usr" CACHE PATH "")
+
 set(KVTREE_DIR "${TPL_ROOT}/kvtree-1.2.0" CACHE PATH "")
 
 set(DTCMP_DIR "${TPL_ROOT}/dtcmp-1.1.4" CACHE PATH "")

--- a/host-configs/ruby-toss_3_x86_64_ib-gcc@8.1.0_nofortran.cmake
+++ b/host-configs/ruby-toss_3_x86_64_ib-gcc@8.1.0_nofortran.cmake
@@ -79,6 +79,8 @@ set(UMPIRE_DIR "${TPL_ROOT}/umpire-6.0.0axom" CACHE PATH "")
 
 set(SCR_DIR "${TPL_ROOT}/scr-3.0rc2" CACHE PATH "")
 
+set(LIBYOGRT_DIR "/usr" CACHE PATH "")
+
 set(KVTREE_DIR "${TPL_ROOT}/kvtree-1.2.0" CACHE PATH "")
 
 set(DTCMP_DIR "${TPL_ROOT}/dtcmp-1.1.4" CACHE PATH "")

--- a/host-configs/ruby-toss_3_x86_64_ib-gcc@8.3.1.cmake
+++ b/host-configs/ruby-toss_3_x86_64_ib-gcc@8.3.1.cmake
@@ -81,6 +81,8 @@ set(UMPIRE_DIR "${TPL_ROOT}/umpire-6.0.0axom" CACHE PATH "")
 
 set(SCR_DIR "${TPL_ROOT}/scr-3.0rc2" CACHE PATH "")
 
+set(LIBYOGRT_DIR "/usr" CACHE PATH "")
+
 set(KVTREE_DIR "${TPL_ROOT}/kvtree-1.2.0" CACHE PATH "")
 
 set(DTCMP_DIR "${TPL_ROOT}/dtcmp-1.1.4" CACHE PATH "")

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@10.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@10.0.0.cmake
@@ -87,6 +87,8 @@ set(UMPIRE_DIR "${TPL_ROOT}/umpire-6.0.0axom" CACHE PATH "")
 
 set(SCR_DIR "${TPL_ROOT}/scr-3.0rc2" CACHE PATH "")
 
+set(LIBYOGRT_DIR "/usr" CACHE PATH "")
+
 set(KVTREE_DIR "${TPL_ROOT}/kvtree-1.2.0" CACHE PATH "")
 
 set(DTCMP_DIR "${TPL_ROOT}/dtcmp-1.1.4" CACHE PATH "")

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0_nofortran.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0_nofortran.cmake
@@ -79,6 +79,8 @@ set(UMPIRE_DIR "${TPL_ROOT}/umpire-6.0.0axom" CACHE PATH "")
 
 set(SCR_DIR "${TPL_ROOT}/scr-3.0rc2" CACHE PATH "")
 
+set(LIBYOGRT_DIR "/usr" CACHE PATH "")
+
 set(KVTREE_DIR "${TPL_ROOT}/kvtree-1.2.0" CACHE PATH "")
 
 set(DTCMP_DIR "${TPL_ROOT}/dtcmp-1.1.4" CACHE PATH "")

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.3.1.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.3.1.cmake
@@ -81,6 +81,8 @@ set(UMPIRE_DIR "${TPL_ROOT}/umpire-6.0.0axom" CACHE PATH "")
 
 set(SCR_DIR "${TPL_ROOT}/scr-3.0rc2" CACHE PATH "")
 
+set(LIBYOGRT_DIR "/usr" CACHE PATH "")
+
 set(KVTREE_DIR "${TPL_ROOT}/kvtree-1.2.0" CACHE PATH "")
 
 set(DTCMP_DIR "${TPL_ROOT}/dtcmp-1.1.4" CACHE PATH "")

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -428,7 +428,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
             # scr's dependencies
             scr_deps = ('kvtree', 'dtcmp', 'spath', 'axl', 'lwgrp', 'er', 'rankstr',
-                        'redset', 'shuffile', 'yogrt')
+                        'redset', 'shuffile', 'libyogrt')
             for dep in scr_deps:
                 if spec.satisfies('^{0}'.format(dep)):
                     dep_dir = get_spec_path(spec, dep, path_replacements)

--- a/src/cmake/thirdparty/FindSCR.cmake
+++ b/src/cmake/thirdparty/FindSCR.cmake
@@ -99,8 +99,8 @@ find_path( SHUFFILE_INCLUDE_DIR shuffile.h
            NO_SYSTEM_ENVIRONMENT_PATH
            NO_CMAKE_SYSTEM_PATH)
 
-find_path( YOGRT_INCLUDE_DIR yogrt.h
-           PATHS  ${YOGRT_DIR}/include/
+find_path( LIBYOGRT_INCLUDE_DIR yogrt.h
+           PATHS  ${LIBYOGRT_DIR}/include/
            NO_DEFAULT_PATH
            NO_CMAKE_ENVIRONMENT_PATH
            NO_CMAKE_PATH
@@ -118,7 +118,7 @@ set(SCR_INCLUDE_DIRS
     ${RANKSTR_INCLUDE_DIR}
     ${REDSET_INCLUDE_DIR}
     ${SHUFFILE_INCLUDE_DIR}
-    ${YOGRT_INCLUDE_DIR}
+    ${LIBYOGRT_INCLUDE_DIR}
     )
 
 set(_library_names
@@ -147,7 +147,7 @@ set(_library_paths
    ${RANKSTR_DIR}/lib
    ${REDSET_DIR}/lib
    ${SHUFFILE_DIR}/lib
-   ${YOGRT_DIR}/lib
+   ${LIBYOGRT_DIR}/lib
    )
 
 blt_find_libraries(


### PR DESCRIPTION
# Summary

- This PR is a build system/TPL bug fix
- It does the following (modify list as needed):
  - SCR depends on the library `libyogrt` and we had incorrect references to the spack package name for that library. It is `libyogrt` and not `yogrt`.  This was causing configurations to skip including SCR.