### PR TITLE
Miscellaneous axom::Array improvements

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -63,11 +63,14 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   - `FlatGridStorage` stores the bins as a flat array of elements, where each bin is a slice of the
     array
 - Adds a templated uniform grid-based surface mesh tester function to Quest
+- Adds an initializer list constructor and assignment operator to `axom::Array`
+- Adds an overload of `axom::Array::resize(ArrayOptions::Uninitialized, dims)` to support resizes
+  without constructing or initializing new elements
 
 ###  Changed
 - Moved bit-twiddling functions to core component
-- `axom::Array` now default-initializes its data by default. To leave data uninitialized, pass 
-  an `axom::ArrayOptions::Uninitialized` as the first constructor argument
+- `axom::Array` now default-initializes its data by default. To create an Array with uninitialized
+  elements, pass an `axom::ArrayOptions::Uninitialized` as the first constructor argument.
 - `axom::ArrayView<const T>` can now be created from a `const Array<T>`
 - Added new `ExecSpace` template parameter to `spin::ImplicitGrid`.
   `ExecSpace` is now the second template parameter (out of three) and defaults to `axom::SEQ_EXEC`.
@@ -112,6 +115,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   with a sharp dihedral angle and the adjacent triangles have significantly different areas
 - Fixed bug in axom::Path that ignored the leading delimiter character if one was present
 - Fixed gcc compiler errors in configurations without RAJA or Umpire
+- Fixed `axom::Array<T>` behavior on copy-construction when `T` is a non-trivial type
 
 ## [Version 0.6.1] - Release date 2021-11-17
 

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -182,6 +182,16 @@ public:
       sizeof...(Args) == DIM && detail::all_types_are_integral<Args...>::value>::type>
   Array(ArrayOptions::Uninitialized, Args... args);
 
+  /*!
+   * \brief Initializer list constructor for a one-dimensional Array
+   *
+   * \param [in] elems The elements to initialize the array with
+   * \param [in] allocator_id the ID of the allocator to use (optional)
+   */
+  template <int UDIM = DIM, typename Enable = typename std::enable_if<UDIM == 1>::type>
+  Array(std::initializer_list<T> elems,
+        int allocator_id = axom::detail::getAllocatorID<SPACE>());
+
   /*! 
    * \brief Copy constructor for an Array instance 
    */
@@ -294,6 +304,19 @@ public:
       other.m_allocator_id = INVALID_ALLOCATOR_ID;
     }
 
+    return *this;
+  }
+
+  /*!
+   * \brief Initializer list assignment operator for Array.
+   *
+   * \param [in] elems the elements to set the array to.
+   */
+  template <int UDIM = DIM, typename Enable = typename std::enable_if<UDIM == 1>::type>
+  Array& operator=(std::initializer_list<T> elems)
+  {
+    clear();
+    insert(0, elems.size(), elems.begin());
     return *this;
   }
 
@@ -816,7 +839,16 @@ Array<T, DIM, SPACE>::Array(ArrayOptions::Uninitialized,
     m_allocator_id = axom::detail::getAllocatorID<SPACE>();
   }
   initialize(num_elements, capacity);
-}  // namespace axom
+}
+
+//------------------------------------------------------------------------------
+template <typename T, int DIM, MemorySpace SPACE>
+template <int UDIM, typename Enable>
+Array<T, DIM, SPACE>::Array(std::initializer_list<T> elems, int allocator_id)
+  : m_allocator_id(allocator_id)
+{
+  initialize_from_other(elems.begin(), elems.size(), MemorySpace::Dynamic, true);
+}
 
 //------------------------------------------------------------------------------
 template <typename T, int DIM, MemorySpace SPACE>

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -248,7 +248,9 @@ public:
       m_resize_ratio = other.m_resize_ratio;
       m_default_construct = other.m_default_construct;
       initialize(other.size(), other.capacity());
-      axom::copy(m_data, other.data(), m_num_elements * sizeof(T));
+      // Use fill_range to ensure that copy constructors are invoked for each
+      // element.
+      OpHelper::fill_range(m_data, 0, m_num_elements, m_allocator_id, other.data());
     }
 
     return *this;
@@ -814,7 +816,9 @@ Array<T, DIM, SPACE>::Array(const Array& other)
   , m_default_construct(other.m_default_construct)
 {
   initialize(other.size(), other.capacity());
-  axom::copy(m_data, other.data(), m_num_elements * sizeof(T));
+  // Use fill_range to ensure that copy constructors are invoked for each
+  // element.
+  OpHelper::fill_range(m_data, 0, m_num_elements, m_allocator_id, other.data());
 }
 
 //------------------------------------------------------------------------------
@@ -1195,9 +1199,9 @@ inline void Array<T, DIM, SPACE>::initialize_from_other(
     m_allocator_id = axom::detail::getAllocatorID<SPACE>();
   }
   initialize(num_elements, num_elements);
-  // axom::copy is aware of pointers registered in Umpire, so this will handle
-  // the transfer between memory spaces
-  axom::copy(m_data, other_data, m_num_elements * sizeof(T));
+  // Use fill_range to ensure that copy constructors are invoked for each
+  // element.
+  OpHelper::fill_range(m_data, 0, m_num_elements, m_allocator_id, other_data);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -686,7 +686,7 @@ protected:
    *
    * \param [in] num_elements the number of elements the Array holds.
    * \param [in] capacity the number of elements to allocate space for.
-   * \param [in] default_construct whether to create default-constructed
+   * \param [in] should_default_construct whether to create default-constructed
    *  objects in the region [0, num_elements). Defaults to true.
    *
    * \note If no capacity or capacity less than num_elements is specified
@@ -702,7 +702,7 @@ protected:
    */
   void initialize(IndexType num_elements,
                   IndexType capacity,
-                  bool default_construct = true);
+                  bool should_default_construct = true);
 
   /*!
    * \brief Helper function for initializing an Array instance with an existing

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -19,6 +19,7 @@
 #include <iostream>  // for std::cerr and std::ostream
 #include <numeric>   // for std::accumulate
 #if defined(__GLIBCXX__) && !defined(_GLIBCXX_USE_CXX11_ABI)
+  // Workaround for unimplemented C++11 type traits in libstdc++ versions <5
   #include <tr1/type_traits>
 #endif
 

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1803,6 +1803,11 @@ TEST(core_array, checkUninitialized)
 
       EXPECT_LE(capacity, arr.capacity());
       EXPECT_EQ(capacity, arr.size());
+
+      arr.resize(ArrayOptions::Uninitialized {}, capacity * 2);
+
+      EXPECT_LE(capacity * 2, arr.capacity());
+      EXPECT_EQ(capacity * 2, arr.size());
     }
 
     // Test default 1D Array with trivially copyable HasDefault type
@@ -1834,6 +1839,11 @@ TEST(core_array, checkUninitialized)
 
       EXPECT_LE(capacity * capacity, arr.capacity());
       EXPECT_EQ(capacity * capacity, arr.size());
+
+      arr.resize(ArrayOptions::Uninitialized {}, capacity * 2, capacity * 2);
+
+      EXPECT_LE(capacity * capacity * 4, arr.capacity());
+      EXPECT_EQ(capacity * capacity * 4, arr.size());
     }
 
     // Tests uninitialized with 1D Array with user-supplied allocator
@@ -1845,6 +1855,12 @@ TEST(core_array, checkUninitialized)
 
       EXPECT_EQ(capacity, arr.capacity());
       EXPECT_EQ(capacity, arr.size());
+      EXPECT_EQ(axom::getDefaultAllocatorID(), arr.getAllocatorID());
+
+      arr.resize(ArrayOptions::Uninitialized {}, capacity * 2);
+
+      EXPECT_LE(capacity * 2, arr.capacity());
+      EXPECT_EQ(capacity * 2, arr.size());
       EXPECT_EQ(axom::getDefaultAllocatorID(), arr.getAllocatorID());
     }
   }

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1803,17 +1803,6 @@ TEST(core_array, checkUninitialized)
 
       EXPECT_LE(capacity, arr.capacity());
       EXPECT_EQ(capacity, arr.size());
-
-      Array<FailsOnConstruction> copied(arr);
-      EXPECT_LE(arr.capacity(), copied.capacity());
-      EXPECT_EQ(arr.size(), copied.size());
-      EXPECT_EQ(arr, copied);
-
-      Array<FailsOnConstruction> assigned;
-      assigned = arr;
-      EXPECT_LE(arr.capacity(), assigned.capacity());
-      EXPECT_EQ(arr.size(), assigned.size());
-      EXPECT_EQ(arr, assigned);
     }
 
     // Test default 1D Array with trivially copyable HasDefault type
@@ -1845,17 +1834,6 @@ TEST(core_array, checkUninitialized)
 
       EXPECT_LE(capacity * capacity, arr.capacity());
       EXPECT_EQ(capacity * capacity, arr.size());
-
-      Array<FailsOnConstruction, 2> copied(arr);
-      EXPECT_LE(arr.capacity(), copied.capacity());
-      EXPECT_EQ(arr.size(), copied.size());
-      EXPECT_EQ(arr, copied);
-
-      Array<FailsOnConstruction, 2> assigned;
-      assigned = arr;
-      EXPECT_LE(arr.capacity(), assigned.capacity());
-      EXPECT_EQ(arr.size(), assigned.size());
-      EXPECT_EQ(arr, assigned);
     }
 
     // Tests uninitialized with 1D Array with user-supplied allocator
@@ -1868,17 +1846,6 @@ TEST(core_array, checkUninitialized)
       EXPECT_EQ(capacity, arr.capacity());
       EXPECT_EQ(capacity, arr.size());
       EXPECT_EQ(axom::getDefaultAllocatorID(), arr.getAllocatorID());
-
-      Array<FailsOnConstruction> copied(arr);
-      EXPECT_LE(arr.capacity(), copied.capacity());
-      EXPECT_EQ(arr.size(), copied.size());
-      EXPECT_EQ(arr, copied);
-
-      Array<FailsOnConstruction> assigned;
-      assigned = arr;
-      EXPECT_LE(arr.capacity(), assigned.capacity());
-      EXPECT_EQ(arr.size(), assigned.size());
-      EXPECT_EQ(arr, assigned);
     }
   }
 }

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -819,7 +819,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_copy_ctor_obj)
     EXPECT_TRUE(check_array_values(arr2, MAGIC_COPY_CTOR));
 
     // Array copy-assignment should invoke each element's copy constructor
-    DynamicArray arr3(arr);
+    DynamicArray arr3 = arr;
     EXPECT_TRUE(check_array_values(arr3, MAGIC_COPY_CTOR));
 
     // Transfers between memory spaces should invoke each element's copy constructor


### PR DESCRIPTION
# Summary

This is an assortment of changes for `axom::Array`.

Public interface changes:
- Adds an initializer list constructor and assignment operator for 1-D arrays
- Adds an uninitialized memory overload for `Array::resize()`
- The "uninitialized-ness" of an Array is no longer a property of the array instance; instead, memory is only left uninitialized at the point of a call to the constructor or `Array::resize()`.

Robustness fixes:

- `ArrayOps::fill_range` now accepts a memory space argument for the source array; this allows for the proper invocation of copy constructors on the host side for arrays of a non-trivially-copyable type.
- Calls to `axom::copy` in the Array copy constructor have been replaced with a call to `ArrayOp::fill_range`.
- The type trait `HasTrivialCopyCtor<T>` which aliases `std::is_trivially_copy_constructible<T>` has been replaced with `TriviallyCopyable<T>`, aliasing `std::is_trivially_copyable<T>`. This fixes device-side `Array::fill()` for some types.