### PR TITLE
Disable corona gitlab CI test until update to rocm 5.1.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,4 +57,4 @@ stages:
 include:
   - local: .gitlab/build_ruby.yml
   - local: .gitlab/build_lassen.yml
-  - local: .gitlab/build_corona.yml
+#  - local: .gitlab/build_corona.yml


### PR DESCRIPTION
This PR disables corona gitlab CI test until update to rocm 5.1.0 (4.5.2 removed)