### PR TITLE
Adds first cut at Distributed Closest Point query with example application

### DIFF
--- a/src/axom/quest/CMakeLists.txt
+++ b/src/axom/quest/CMakeLists.txt
@@ -21,7 +21,8 @@ set( quest_headers
 
     Delaunay.hpp
     SignedDistance.hpp
-
+    DistributedClosestPoint.hpp
+    
     ## All-nearest-neighbors query
     AllNearestNeighbors.hpp
     detail/AllNearestNeighbors_detail.hpp

--- a/src/axom/quest/CMakeLists.txt
+++ b/src/axom/quest/CMakeLists.txt
@@ -21,7 +21,6 @@ set( quest_headers
 
     Delaunay.hpp
     SignedDistance.hpp
-    DistributedClosestPoint.hpp
     
     ## All-nearest-neighbors query
     AllNearestNeighbors.hpp
@@ -99,6 +98,13 @@ blt_list_append(TO quest_depends_on IF ENABLE_HIP ELEMENTS hip_runtime)
 blt_list_append(TO quest_depends_on IF ENABLE_OPENMP ELEMENTS openmp)
 blt_list_append(TO quest_depends_on IF SPARSEHASH_FOUND ELEMENTS sparsehash)
 blt_list_append(TO quest_depends_on IF MFEM_FOUND ELEMENTS mfem)
+
+if(CONDUIT_FOUND AND ENABLE_MPI)
+    list(APPEND quest_headers DistributedClosestPoint.hpp )
+    list(APPEND quest_depends_on conduit::conduit
+                                 conduit::conduit_mpi)
+endif()
+
 
 if(MFEM_FOUND AND AXOM_ENABLE_KLEE AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION)
     list(APPEND quest_headers Shaper.hpp

--- a/src/axom/quest/CMakeLists.txt
+++ b/src/axom/quest/CMakeLists.txt
@@ -21,7 +21,7 @@ set( quest_headers
 
     Delaunay.hpp
     SignedDistance.hpp
-    
+
     ## All-nearest-neighbors query
     AllNearestNeighbors.hpp
     detail/AllNearestNeighbors_detail.hpp

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -370,7 +370,7 @@ public:
    * \brief Computes the closest point within the objects for each query point
    * in the provided particle mesh, provided in the mesh blueprint rooted at \a meshGroup
    *
-   * \param meshGroup The root of a mesh blueprint for the query points
+   * \param mesh_node The root node of a mesh blueprint for the query points
    * \param coordset The coordinate set for the query points
    *
    * Uses the \a coordset coordinate set of the provided blueprint mesh
@@ -845,13 +845,25 @@ private:
  * Each of these are distributed over the problem's mpi ranks. This class orchestrates passing
  * the query points to all ranks whose object meshes might contain a closest point.
  *
+ * \note This class assumes that the object mesh and the query mesh are decomposed over the same
+ * number of mpi ranks.
+ * \warning This class will need to support cases where some ranks have zero object points.
+ * This is not currently supported.
+ *
  * \note The class currently supports object meshes that are comprised of a collection of points.
  * In the future, we'd like to consider more general object meshes, e.g. triangle meshes.
+ *
+ * \note The class currently supports object meshes and query meshes with a single domain per MPI rank.
+ * We intend to add support for multiple computational domains on each rank.
  *
  * To use this class, first set some parameters, such as the runtime execution policy,
  * then pass in the object mesh and build a spatial index over this mesh.
  * Finally, compute the closest points in the object mesh to each point in a query mesh 
  * using the \a computeClosestPoint() function.
+ *
+ * \note The implementation currently assumes that the coordinates for the positions and vector field
+ * data are interleaved (i.e. xyzxyzxyz....). We will relax this assumption in the future to support both
+ * interleaved and strided data.
  */
 class DistributedClosestPoint
 {

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -1,0 +1,180 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef QUEST_DISTRIBUTED_CLOSEST_POINT_H_
+#define QUEST_DISTRIBUTED_CLOSEST_POINT_H_
+
+#include "axom/core.hpp"
+#include "axom/slic.hpp"
+#include "axom/slam.hpp"
+#include "axom/primal.hpp"
+#include "axom/mint.hpp"
+#include "axom/spin.hpp"
+
+#include "axom/fmt.hpp"
+
+#include <list>
+#include <vector>
+#include <set>
+#include <cstdlib>
+#include <cmath>
+
+namespace axom
+{
+namespace quest
+{
+template <int NDIMS = 2, typename ExecSpace = axom::SEQ_EXEC>
+class DistributedClosestPoint
+{
+public:
+  // TODO: generalize to 3D
+  static_assert(NDIMS == 2,
+                "DistributedClosestPoint only currently supports 2D");
+
+  static constexpr int DIM = NDIMS;
+  using PointType = primal::Point<double, DIM>;
+  using BoxType = primal::BoundingBox<double, DIM>;
+  using PointArray = axom::Array<PointType>;
+  using BoxArray = axom::Array<BoxType>;
+  using BVHTreeType = spin::BVH<DIM, ExecSpace>;
+
+private:
+  struct MinCandidate
+  {
+    /// Squared distance to query point
+    double minSqDist {numerics::floating_point_limits<double>::max()};
+    /// Index within mesh of closest element
+    int minElem;
+  };
+
+public:
+  DistributedClosestPoint(
+    int allocatorID = axom::execution_space<ExecSpace>::allocatorID())
+    : m_allocatorID(allocatorID)
+  { }
+
+public:  // Query properties
+  void setVerbosity(bool isVerbose) { m_isVerbose = isVerbose; }
+
+public:
+  /// Utility function to generate an array of 2D points
+  void generatePoints(double radius, int numPoints)
+  {
+    using axom::utilities::random_real;
+
+    // Generate in host because random_real is not yet ported to the device
+    PointArray pts;
+    pts.reserve(numPoints);
+    for(int i = 0; i < numPoints; ++i)
+    {
+      const double angleInRadians = random_real(0., 2 * M_PI);
+      const double rsinT = radius * std::sin(angleInRadians);
+      const double rcosT = radius * std::cos(angleInRadians);
+
+      pts.emplace_back(PointType {rcosT, rsinT});
+    }
+
+    if(m_isVerbose)
+    {
+      SLIC_INFO("Points on object:");
+      const auto& arr = m_points;
+      for(auto i : slam::PositionSet<int>(arr.size()))
+      {
+        const double mag = sqrt(arr[i][0] * arr[i][0] + arr[i][1] * arr[i][1]);
+        SLIC_INFO(axom::fmt::format("\t{}: {} -- {}", i, arr[i], mag));
+      }
+    }
+
+    m_points = PointArray(pts, m_allocatorID);  // copy to ExecSpace
+  }
+
+  bool generateBVHTree()
+  {
+    const int npts = m_points.size();
+    axom::Array<BoxType> boxesArray(npts, npts, m_allocatorID);
+    auto boxesView = boxesArray.view();
+    axom::for_all<ExecSpace>(
+      npts,
+      AXOM_LAMBDA(axom::IndexType i) { boxesView[i] = BoxType {m_points[i]}; });
+
+    // Build bounding volume hierarchy
+    m_bvh.setAllocatorID(m_allocatorID);
+    int result = m_bvh.initialize(boxesView, npts);
+
+    return (result == spin::BVH_BUILD_OK);
+  }
+
+  void computeClosestPoints(const PointArray& queryPts,
+                            axom::Array<axom::IndexType>& cpIndexes) const
+  {
+    SLIC_ASSERT(!queryPts.empty());
+
+    const int nPts = queryPts.size();
+
+    /// Create an ArrayView in ExecSpace that is compatible with cpIndexes
+    axom::Array<axom::IndexType> cp_idx(nPts, nPts, m_allocatorID);
+    auto query_inds = cp_idx.view();
+
+    /// Create an ArrayView in ExecSpace that is compatible with queryPts
+    PointArray execPoints(nPts, nPts, m_allocatorID);
+    execPoints = queryPts;
+    auto query_pts = execPoints.view();
+
+    // Get a device-useable iterator
+    auto it = m_bvh.getTraverser();
+
+    using axom::primal::squared_distance;
+    using int32 = axom::int32;
+
+    AXOM_PERF_MARK_SECTION(
+      "ComputeClosestPoints",
+      axom::for_all<ExecSpace>(
+        nPts,
+        AXOM_LAMBDA(int32 idx) mutable {
+          PointType qpt = query_pts[idx];
+
+          MinCandidate curr_min {};
+
+          auto searchMinDist = [&](int32 current_node, const int32* leaf_nodes) {
+            const int candidate_idx = leaf_nodes[current_node];
+            const PointType candidate_pt = m_points[candidate_idx];
+            const double sq_dist = squared_distance(qpt, candidate_pt);
+
+            if(sq_dist < curr_min.minSqDist)
+            {
+              curr_min.minSqDist = sq_dist;
+              curr_min.minElem = candidate_idx;
+            }
+          };
+
+          auto traversePredicate = [&](const PointType& p,
+                                       const BoxType& bb) -> bool {
+            return squared_distance(p, bb) <= curr_min.minSqDist;
+          };
+
+          // Traverse the tree, searching for the point with minimum distance.
+          it.traverse_tree(qpt, searchMinDist, traversePredicate);
+
+          query_inds[idx] = curr_min.minElem;
+        }););
+
+    cpIndexes = query_inds;
+  }
+
+  const PointArray& points() const { return m_points; }
+
+private:
+  PointArray m_points;
+  BoxArray m_boxes;
+  BVHTreeType m_bvh;
+
+  int m_allocatorID;
+  bool m_isVerbose {false};
+};
+
+}  // end namespace quest
+}  // end namespace axom
+
+#endif  //  QUEST_DISTRIBUTED_CLOSEST_POINT_H_

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -18,6 +18,8 @@
 
 #include "conduit_blueprint.hpp"
 #include "conduit_blueprint_mpi.hpp"
+#include "conduit_relay_mpi.hpp"
+#include "conduit_relay_io.hpp"
 
 #include <list>
 #include <vector>
@@ -36,6 +38,17 @@ namespace quest
 {
 namespace internal
 {
+/** 
+ * \brief Utility function to get a typed pointer to the beginning of an array 
+ * stored by a conduit::Node
+ */
+template <typename T>
+T* getPointer(conduit::Node& node)
+{
+  T* ptr = node.value();
+  return ptr;
+}
+
 /** 
  * \brief Utility function to create an axom::ArrayView over the array 
  * of native types stored by a conduit::Node
@@ -60,6 +73,75 @@ axom::ArrayView<primal::Point<double, 2>> ArrayView_from_Node(conduit::Node& nod
 
   PointType* ptr = static_cast<PointType*>(node.data_ptr());
   return axom::ArrayView<PointType>(ptr, sz);
+}
+
+/**
+ * \brief Sends a conduit node along with its schema using MPI_Isend
+ * 
+ * \param [in] node node to send
+ * \param [in] dest ID of MPI rank to send to
+ * \param [in] tag tag for MPI message
+ * \param [in] comm MPI communicator to use
+ * \note Adapted from conduit's relay::mpi::send_using_schema to use 
+ * non-blocking \a MPI_Isend instead of blocking \a MPI_Send
+ */
+int isend_using_schema(const conduit::Node& node, int dest, int tag, MPI_Comm comm)
+{
+  conduit::Schema s_data_compact;
+
+  // schema will only be valid if compact and contig
+  if(node.is_compact() && node.is_contiguous())
+  {
+    s_data_compact = node.schema();
+  }
+  else
+  {
+    node.schema().compact_to(s_data_compact);
+  }
+
+  std::string snd_schema_json = s_data_compact.to_json();
+
+  conduit::Schema s_msg;
+  s_msg["schema_len"].set(conduit::DataType::int64());
+  s_msg["schema"].set(conduit::DataType::char8_str(snd_schema_json.size() + 1));
+  s_msg["data"].set(s_data_compact);
+
+  // create a compact schema to use
+  conduit::Schema s_msg_compact;
+  s_msg.compact_to(s_msg_compact);
+
+  conduit::Node n_msg(s_msg_compact);
+  // these sets won't realloc since schemas are compatible
+  n_msg["schema_len"].set((int64)snd_schema_json.length());
+  n_msg["schema"].set(snd_schema_json);
+  n_msg["data"].update(node);
+
+  auto msg_data_size = n_msg.total_bytes_compact();
+
+  MPI_Request mpiRequest;
+  int mpi_error = MPI_Isend(const_cast<void*>(n_msg.data_ptr()),
+                            static_cast<int>(msg_data_size),
+                            MPI_BYTE,
+                            dest,
+                            tag,
+                            comm,
+                            &mpiRequest);
+
+  MPI_Request_free(&mpiRequest);
+
+  if(static_cast<int>(mpi_error) != MPI_SUCCESS)
+  {
+    char check_mpi_err_str_buff[MPI_MAX_ERROR_STRING];
+    int check_mpi_err_str_len = 0;
+    MPI_Error_string(mpi_error, check_mpi_err_str_buff, &check_mpi_err_str_len);
+
+    SLIC_ERROR(
+      fmt::format("MPI call failed: error code = {} error message = {}",
+                  mpi_error,
+                  check_mpi_err_str_buff));
+  }
+
+  return mpi_error;
 }
 
 }  // namespace internal
@@ -115,7 +197,7 @@ public:
     SLIC_ASSERT(this->isValidBlueprint(mesh_node));
 
     // Extract the dimension and number of points from the coordinate values group
-    auto valuesPath = axom::fmt::format("coordsets/{}/values", coordset);
+    auto valuesPath = fmt::format("coordsets/{}/values", coordset);
     SLIC_ASSERT(mesh_node.has_path(valuesPath));
     auto& values = mesh_node[valuesPath];
 
@@ -161,6 +243,7 @@ public:
    * Uses the \a coordset coordinate set of the provided blueprint mesh
    * 
    * The particle mesh must contain the following fields:
+   *   - cp_rank: Will hold the rank of the object point containing the closest point
    *   - cp_index: Will hold the index of the object point containing the closest point
    *   - closest_point: Will hold the position of the closest point
    * 
@@ -170,76 +253,223 @@ public:
   void computeClosestPoints(conduit::Node& mesh_node,
                             const std::string& coordset) const
   {
+    // Utility function to dump a conduit node on each rank, e.g. for debugging
+    auto dumpNode = [=](const conduit::Node& n,
+                        const std::string&& fname,
+                        const std::string& protocol = "json") {
+      conduit::relay::io::save(n, fname, protocol);
+    };
+
     // Perform some simple error checking
     SLIC_ASSERT(this->isValidBlueprint(mesh_node));
 
+    // create conduit node containing data that has to xfer between ranks
+    conduit::Node xfer_node;
+    {
+      // clang-format off
+      auto& coords = mesh_node[fmt::format("coordsets/{}/values", coordset)];
+      const int dim = extractDimension(coords);
+      const int npts = extractSize(coords);
+
+      xfer_node["npts"] = npts;
+      xfer_node["dim"] = dim;
+      xfer_node["src_rank"] = m_rank;
+      xfer_node["coords"].set_external(internal::getPointer<double>(coords["x"]), dim * npts);
+      xfer_node["cp_index"].set_external(internal::getPointer<axom::IndexType>(mesh_node["fields/cp_index/values"]), npts);
+      xfer_node["cp_rank"].set_external(internal::getPointer<axom::IndexType>(mesh_node["fields/cp_rank/values"]), npts);
+      xfer_node["closest_point"].set_external(internal::getPointer<double>(mesh_node["fields/closest_point/values/x"]), dim * npts);
+      xfer_node["debug/min_distance"].set_external(internal::getPointer<double>(mesh_node["fields/min_distance/values"]), npts);
+      // clang-format on
+    }
+
+    if(m_isVerbose)
+    {
+      dumpNode(xfer_node, fmt::format("round_{}_r{}_begin.json", 0, m_rank));
+    }
+
+    // Find initial values on this rank
+    computeLocalClosestPoints(xfer_node, true);
+
+    if(m_isVerbose)
+    {
+      dumpNode(xfer_node, fmt::format("round_{}_r{}_end.json", 0, m_rank));
+    }
+
+    if(m_nranks > 1)
+    {
+      // arbitrary tags for sending data to other ranks and getting it back
+      const int tag_before = 1234;
+      const int tag_after = 4321;
+
+      // NOTE: uses a naive algorithm to computed distributed closest points
+      // Every rank sends it data to every other rank.
+      // TODO: Devise a more efficient algorithm to only send data to ranks with closer points
+      for(int i = 1; i < m_nranks; ++i)
+      {
+        if(m_rank == 0)
+        {
+          SLIC_INFO(fmt::format("=======  Round {}/{} =======", i, m_nranks));
+        }
+        const int dst_rank = (m_rank + i) % m_nranks;
+        const int rec_rank = (m_rank - i + m_nranks) % m_nranks;
+
+        if(m_isVerbose)
+        {
+          SLIC_INFO(fmt::format("Rank {} -- sending to dst {}", m_rank, dst_rank));
+        }
+
+        if(m_isVerbose)
+        {
+          dumpNode(xfer_node, fmt::format("round_{}_r{}_begin.json", i, m_rank));
+        }
+
+        // send and receive the query point data
+        conduit::Node rec_node;
+        {
+          internal::isend_using_schema(xfer_node,
+                                       dst_rank,
+                                       tag_before,
+                                       MPI_COMM_WORLD);
+          conduit::relay::mpi::recv_using_schema(rec_node,
+                                                 rec_rank,
+                                                 tag_before,
+                                                 MPI_COMM_WORLD);
+        }
+
+        const int src_rank = rec_node["src_rank"].value();
+        if(m_isVerbose)
+        {
+          dumpNode(
+            rec_node,
+            fmt::format("round_{}_r{}_comm_from_{}_A.json", i, m_rank, src_rank));
+        }
+
+        // compute the local data
+        computeLocalClosestPoints(rec_node, false);
+
+        if(m_isVerbose)
+        {
+          dumpNode(
+            rec_node,
+            fmt::format("round_{}_r{}_comm_from_{}_B.json", i, m_rank, src_rank));
+        }
+
+        // update results
+        conduit::Node proc_node;
+        {
+          internal::isend_using_schema(rec_node,
+                                       src_rank,
+                                       tag_after,
+                                       MPI_COMM_WORLD);
+          conduit::relay::mpi::recv_using_schema(proc_node,
+                                                 dst_rank,
+                                                 tag_after,
+                                                 MPI_COMM_WORLD);
+        }
+
+        if(m_isVerbose)
+        {
+          dumpNode(
+            proc_node,
+            fmt::format("round_{}_r{}_comm_from_{}_C.json", i, m_rank, dst_rank));
+        }
+
+        // copy data to mesh_node from proc_node
+        const int npts = proc_node["npts"].value();
+        axom::copy(xfer_node["cp_rank"].data_ptr(),
+                   proc_node["cp_rank"].data_ptr(),
+                   npts * sizeof(axom::IndexType));
+        axom::copy(xfer_node["cp_index"].data_ptr(),
+                   proc_node["cp_index"].data_ptr(),
+                   npts * sizeof(axom::IndexType));
+        axom::copy(xfer_node["closest_point"].data_ptr(),
+                   proc_node["closest_point"].data_ptr(),
+                   npts * sizeof(PointType));
+
+        if(m_isVerbose)
+        {
+          dumpNode(mesh_node,
+                   axom::fmt::format("round_{}_r{}_end.json", i, m_rank));
+
+          SLIC_ASSERT_MSG(
+            conduit::blueprint::mcarray::is_interleaved(
+              mesh_node["fields/closest_point/values"]),
+            fmt::format("After copy on iteration {}, 'closest_point' field of "
+                        "'mesh_node' is not interleaved",
+                        i));
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        slic::flushStreams();
+      }
+    }
+  }
+
+  void computeLocalClosestPoints(conduit::Node& xfer_node, bool is_first) const
+  {
+    using axom::primal::squared_distance;
+    using int32 = axom::int32;
+
     // Extract the dimension and number of points from the coordinate values group
-    const auto valuesPath = axom::fmt::format("coordsets/{}/values", coordset);
-    SLIC_ASSERT(mesh_node.has_path(valuesPath));
-    auto& values = mesh_node[valuesPath];
-    const int dim = extractDimension(values);
-    const int nPts = extractSize(values);
+    const int dim = xfer_node["dim"].value();
+    const int npts = xfer_node["npts"].value();
     SLIC_ASSERT(dim == NDIMS);
 
-    // Extract the points array
-    auto queryPts = internal::ArrayView_from_Node<PointType>(values["x"], nPts);
-
-    // Extract the cp_index array
-    const std::string cp_index_path = "fields/cp_index/values";
-    SLIC_ASSERT_MSG(
-      mesh_node.has_path(cp_index_path),
-      "Input to `computeClosestPoint()` must have a field named `cp_index`");
+    /// Extract fields from the input node as ArrayViews
+    auto queryPts =
+      internal::ArrayView_from_Node<PointType>(xfer_node["coords"], npts);
     auto cpIndexes =
-      internal::ArrayView_from_Node<axom::IndexType>(mesh_node[cp_index_path],
-                                                     nPts);
-
-    // Extract the cp_index array
-    const std::string cp_rank_path = "fields/cp_rank/values";
-    SLIC_ASSERT_MSG(
-      mesh_node.has_path(cp_rank_path),
-      "Input to `computeClosestPoint()` must have a field named `cp_rank`");
+      internal::ArrayView_from_Node<axom::IndexType>(xfer_node["cp_index"], npts);
     auto cpRanks =
-      internal::ArrayView_from_Node<axom::IndexType>(mesh_node[cp_rank_path],
-                                                     nPts);
-
-    // Extract the closest points array
-    const std::string cp_start_path = "fields/closest_point/values/x";
-    SLIC_ASSERT_MSG(mesh_node.has_path(cp_start_path),
-                    "Input to `computeClosestPoint()` must have a field named "
-                    "`closest_point`");
+      internal::ArrayView_from_Node<axom::IndexType>(xfer_node["cp_rank"], npts);
     auto closestPts =
-      internal::ArrayView_from_Node<PointType>(mesh_node[cp_start_path], nPts);
+      internal::ArrayView_from_Node<PointType>(xfer_node["closest_point"], npts);
 
-    // Create an ArrayView in ExecSpace that is compatible with cpIndexes
-    // TODO: Avoid copying (here and at the end) if both are on the host
-    axom::Array<axom::IndexType> cp_idx(nPts, nPts, m_allocatorID);
+    /// Create ArrayViews in ExecSpace that are compatible with fields
+    // TODO: Avoid copying arrays (here and at the end) if both are on the host
+    auto cp_idx = is_first
+      ? axom::Array<axom::IndexType>(npts, npts, m_allocatorID)
+      : axom::Array<axom::IndexType>(cpIndexes, m_allocatorID);
+    auto cp_ranks = is_first
+      ? axom::Array<axom::IndexType>(npts, npts, m_allocatorID)
+      : axom::Array<axom::IndexType>(cpRanks, m_allocatorID);
+
+    /// PROBLEM: The striding does not appear to be retained by conduit relay
+    ///          We might need to transform it? or to use a single array w/ pointers into it?
+    auto cp_pos = is_first ? axom::Array<PointType>(npts, npts, m_allocatorID)
+                           : axom::Array<PointType>(closestPts, m_allocatorID);
+
+    // DEBUG
+    auto minDist =
+      internal::ArrayView_from_Node<double>(xfer_node["debug/min_distance"],
+                                            npts);
+    auto cp_dist = is_first ? axom::Array<double>(npts, npts, m_allocatorID)
+                            : axom::Array<double>(minDist, m_allocatorID);
+    ;
+    auto query_min_dist = cp_dist.view();
+    // END DEBUG
+
+    if(is_first)
+    {
+      cp_ranks.fill(-1);
+      cp_idx.fill(-1);
+    }
     auto query_inds = cp_idx.view();
-
-    axom::Array<axom::IndexType> cp_ranks(nPts, nPts, m_allocatorID);
     auto query_ranks = cp_ranks.view();
-
-    // Create an ArrayView in ExecSpace that is compatible with cpIndexes
-    // TODO: Avoid copying (here and at the end) if both are on the host
-    axom::Array<PointType> cp_pos(nPts, nPts, m_allocatorID);
     auto query_pos = cp_pos.view();
 
     /// Create an ArrayView in ExecSpace that is compatible with queryPts
-    PointArray execPoints(nPts, nPts, m_allocatorID);
-    execPoints = queryPts;
+    PointArray execPoints(queryPts, m_allocatorID);
     auto query_pts = execPoints.view();
 
     // Get a device-useable iterator
     auto it = m_bvh.getTraverser();
-
-    using axom::primal::squared_distance;
-    using int32 = axom::int32;
-
     const int rank = m_rank;
 
     AXOM_PERF_MARK_SECTION(
       "ComputeClosestPoints",
       axom::for_all<ExecSpace>(
-        nPts,
+        npts,
         AXOM_LAMBDA(int32 idx) mutable {
           PointType qpt = query_pts[idx];
 
@@ -247,6 +477,8 @@ public:
           if(query_ranks[idx] >= 0)  // i.e. we've already found a candidate closest
           {
             curr_min.minSqDist = squared_distance(qpt, query_pos[idx]);
+            curr_min.minElem = query_inds[idx];
+            curr_min.minRank = query_ranks[idx];
           }
 
           auto searchMinDist = [&](int32 current_node, const int32* leaf_nodes) {
@@ -273,10 +505,45 @@ public:
           // If modified, update the fields that changed
           if(curr_min.minRank == rank)
           {
+            // SLIC_INFO(
+            //   fmt::format("[On rank {}] Updating dist for particle {} ::"
+            //               "{{ cp: {}->{}; "
+            //               "dist: {}->{}; "
+            //               "rank: {}->{}; "
+            //               "elem: {}->{}}}",
+            //               rank,
+            //               idx,
+            //               query_pos[idx],             //cp
+            //               m_points[curr_min.minElem],
+            //               query_min_dist[idx],        // dist
+            //               sqrt(curr_min.minSqDist),
+            //               query_ranks[idx],           // rank
+            //               curr_min.minRank,
+            //               query_inds[idx],            // index
+            //               curr_min.minElem));
+
             query_inds[idx] = curr_min.minElem;
             query_ranks[idx] = curr_min.minRank;
             query_pos[idx] = m_points[curr_min.minElem];
+
+            //DEBUG
+            query_min_dist[idx] = sqrt(curr_min.minSqDist);
           }
+          // else
+          // {
+          //   SLIC_INFO(
+          //     fmt::format("[On rank {}] Didn't update dist for particle {} ::"
+          //                 "{{ cp: {}; "
+          //                 "dist: {}; "
+          //                 "rank: {}; "
+          //                 "elem: {}}}",
+          //                 rank,
+          //                 idx,
+          //                 query_pos[idx],
+          //                 query_min_dist[idx],
+          //                 query_ranks[idx],
+          //                 query_inds[idx]));
+          // }
         }););
 
     axom::copy(cpIndexes.data(),
@@ -289,27 +556,26 @@ public:
                query_pos.data(),
                closestPts.size() * sizeof(PointType));
 
-    // std::cout << fmt::format("After: closest points ({}): {}",
-    //                          fmt::ptr(closestPts.data()),
-    //                          closestPts)
-    //           << std::endl;
+    // DEBUG
+    axom::copy(minDist.data(),
+               query_min_dist.data(),
+               minDist.size() * sizeof(double));
   }
 
 private:
-  // Check validity of blueprint group
+  /// Check validity of blueprint group
   bool isValidBlueprint(const conduit::Node& mesh_node) const
   {
     bool success = true;
     conduit::Node info;
     if(!conduit::blueprint::mpi::verify("mesh", mesh_node, info, MPI_COMM_WORLD))
     {
-      SLIC_INFO("Invalid blueprint for particle mesh: \n" << info.to_yaml());
+      SLIC_INFO(
+        fmt::format("Invalid blueprint on rank {} for particle mesh: \n{}",
+                    m_rank,
+                    info.to_yaml()));
       success = false;
     }
-    // else
-    // {
-    //   SLIC_INFO("Valid blueprint for particle mesh: \n" << info.to_yaml());
-    // }
 
     return success;
   }
@@ -326,6 +592,32 @@ private:
   {
     SLIC_ASSERT(values_node.has_child("x"));
     return values_node["x"].dtype().number_of_elements();
+  }
+
+  /**
+   * \brief Extracts a field \a fieldName from the mesh blueprint
+   * 
+   * \tparam T The type for the underlying array
+   * \param mesh_node The conduit node at the root of the mesh blueprint
+   * \param field_name The name of the field
+   * \param field_template Template string for the path to the field
+   * \param num_points The size of the field
+   * \return An arrayview over the field data
+   */
+  template <typename T>
+  axom::ArrayView<T> extractField(conduit::Node& mesh_node,
+                                  std::string&& field_name,
+                                  std::string&& path_template,
+                                  int num_points) const
+  {
+    const std::string path = axom::fmt::format(path_template, field_name);
+    SLIC_ASSERT_MSG(
+      mesh_node.has_path(path),
+      fmt::format(
+        "Input to `computeClosestPoint()` must have a field named `{}`",
+        field_name));
+
+    return internal::ArrayView_from_Node<T>(mesh_node[path], num_points);
   }
 
 private:

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -36,10 +36,18 @@ namespace axom
 {
 namespace quest
 {
+/// Enum for RAJA runtime policy
+enum class DistributedClosestPointRuntimePolicy
+{
+  seq = 0,
+  omp = 1,
+  cuda = 2
+};
+
 namespace internal
 {
-/** 
- * \brief Utility function to get a typed pointer to the beginning of an array 
+/**
+ * \brief Utility function to get a typed pointer to the beginning of an array
  * stored by a conduit::Node
  */
 template <typename T>
@@ -49,8 +57,8 @@ T* getPointer(conduit::Node& node)
   return ptr;
 }
 
-/** 
- * \brief Utility function to create an axom::ArrayView over the array 
+/**
+ * \brief Utility function to create an axom::ArrayView over the array
  * of native types stored by a conduit::Node
  */
 template <typename T>
@@ -60,7 +68,7 @@ axom::ArrayView<T> ArrayView_from_Node(conduit::Node& node, int sz)
   return axom::ArrayView<T>(ptr, sz);
 }
 
-/** 
+/**
  * \brief Template specialization of ArrayView_from_Node for Point<double,2>
  *
  * \warning Assumes the underlying data is an MCArray with stride 2 access
@@ -73,6 +81,37 @@ axom::ArrayView<primal::Point<double, 2>> ArrayView_from_Node(conduit::Node& nod
 
   PointType* ptr = static_cast<PointType*>(node.data_ptr());
   return axom::ArrayView<PointType>(ptr, sz);
+}
+
+/**
+ * \brief Template specialization of ArrayView_from_Node for Point<double,3>
+ *
+ * \warning Assumes the underlying data is an MCArray with stride 3 access
+ */
+template <>
+axom::ArrayView<primal::Point<double, 3>> ArrayView_from_Node(conduit::Node& node,
+                                                              int sz)
+{
+  using PointType = primal::Point<double, 3>;
+
+  PointType* ptr = static_cast<PointType*>(node.data_ptr());
+  return axom::ArrayView<PointType>(ptr, sz);
+}
+
+/// Helper function to extract the dimension from the coordinate values group
+/// of a mesh blueprint coordset
+int extractDimension(const conduit::Node& values_node)
+{
+  SLIC_ASSERT(values_node.has_child("x"));
+  return values_node.has_child("z") ? 3 : (values_node.has_child("y") ? 2 : 1);
+}
+
+/// Helper function to extract the number of points from the coordinate values group
+/// of a mesh blueprint coordset
+int extractSize(const conduit::Node& values_node)
+{
+  SLIC_ASSERT(values_node.has_child("x"));
+  return values_node["x"].dtype().number_of_elements();
 }
 
 namespace relay
@@ -90,13 +129,13 @@ struct ISendRequest
 
 /**
  * \brief Sends a conduit node along with its schema using MPI_Isend
- * 
+ *
  * \param [in] node node to send
  * \param [in] dest ID of MPI rank to send to
  * \param [in] tag tag for MPI message
  * \param [in] comm MPI communicator to use
  * \param [in] request An instance of ISendRequest that holds state for the sent data
- * \note Adapted from conduit's relay::mpi's \a send_using_schema and \a isend to use 
+ * \note Adapted from conduit's relay::mpi's \a send_using_schema and \a isend to use
  * non-blocking \a MPI_Isend instead of blocking \a MPI_Send
  */
 int isend_using_schema(conduit::Node& node,
@@ -155,6 +194,20 @@ int isend_using_schema(conduit::Node& node,
   return mpi_error;
 }
 
+/**
+ * \brief Orchestrates sending and receiving conduit nodes among mpi ranks
+ *
+ * \param [in] send_node rooted node to send
+ * \param [in] recv_node rooted node to receive
+ * \param [in] send_rank MPI rank to send \a send_node to
+ * \param [in] recv_rank MPI rank to receive \a recv_node from
+ * \param [in] tag tag for MPI messages
+ * \param [in] comm MPI communicator to use
+ * 
+ * Sends/receives a pair of conduit nodes (along with their schemas) from the current rank.
+ * Uses non-blocking send (isend) and blocking receives and ensures that the request
+ * objects associated with the send are finalized
+ */
 void send_and_recv_node(conduit::Node& send_node,
                         conduit::Node& recv_node,
                         int send_rank,
@@ -176,22 +229,33 @@ void send_and_recv_node(conduit::Node& send_node,
 
 }  // namespace mpi
 }  // namespace relay
-}  // namespace internal
 
-template <int NDIMS = 2, typename ExecSpace = axom::SEQ_EXEC>
-class DistributedClosestPoint
+/**
+ * \brief Implements the DistributedClosestPoint query for a specified dimension
+ * using a provided execution policy (e.g. sequential, openmp, cuda)
+ *
+ * \tparam NDIMS The dimension of the object mesh and query points
+ */
+template <int NDIMS>
+class DistributedClosestPointImpl
 {
 public:
-  // TODO: generalize to 3D
-  static_assert(NDIMS == 2,
-                "DistributedClosestPoint only currently supports 2D");
-
   static constexpr int DIM = NDIMS;
+  using RuntimePolicy = DistributedClosestPointRuntimePolicy;
   using PointType = primal::Point<double, DIM>;
   using BoxType = primal::BoundingBox<double, DIM>;
   using PointArray = axom::Array<PointType>;
   using BoxArray = axom::Array<BoxType>;
-  using BVHTreeType = spin::BVH<DIM, ExecSpace>;
+
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+  using SeqBVHTree = spin::BVH<DIM, axom::SEQ_EXEC>;
+  #ifdef AXOM_USE_OPENMP
+  using OmpBVHTree = spin::BVH<DIM, axom::OMP_EXEC>;
+  #endif
+  #ifdef AXOM_USE_CUDA
+  using CudaBVHTree = spin::BVH<DIM, axom::CUDA_EXEC<256>>;
+  #endif
+#endif
 
 private:
   struct MinCandidate
@@ -205,86 +269,151 @@ private:
   };
 
 public:
-  DistributedClosestPoint(
-    int allocatorID = axom::execution_space<ExecSpace>::allocatorID())
-    : m_allocatorID(allocatorID)
+  DistributedClosestPointImpl(RuntimePolicy runtimePolicy, bool isVerbose)
+    : m_runtimePolicy(runtimePolicy)
+    , m_isVerbose(isVerbose)
   {
+    setAllocatorID();
+
     MPI_Comm_rank(MPI_COMM_WORLD, &m_rank);
     MPI_Comm_size(MPI_COMM_WORLD, &m_nranks);
   }
 
-public:  // Query properties
-  void setVerbosity(bool isVerbose) { m_isVerbose = isVerbose; }
+  ~DistributedClosestPointImpl()
+  {
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+    delete m_bvh_seq;
+    m_bvh_seq = nullptr;
+
+  #ifdef AXOM_USE_OPENMP
+    delete m_bvh_omp;
+    m_bvh_omp = nullptr;
+  #endif
+
+  #ifdef AXOM_USE_CUDA
+    delete m_bvh_cuda;
+    m_bvh_cuda = nullptr;
+  #endif
+
+#endif
+  }
 
 public:
-  /** 
+  /**
    * Utility function to set the array of points
    *
-   * \param [in] meshGroup The root group of a mesh blueprint
+   * \param [in] coords The root group of a mesh blueprint's coordinate values
    * \note This function currently supports mesh blueprints with the "point" topology
    */
-  void setObjectMesh(const conduit::Node& mesh_node, const std::string& coordset)
+  void importObjectPoints(const conduit::Node& coords, int nPts)
   {
-    // Perform some simple error checking
-    SLIC_ASSERT(this->isValidBlueprint(mesh_node));
-
-    // Extract the dimension and number of points from the coordinate values group
-    auto valuesPath = fmt::format("coordsets/{}/values", coordset);
-    SLIC_ASSERT(mesh_node.has_path(valuesPath));
-    auto& values = mesh_node[valuesPath];
-
-    const int dim = extractDimension(values);
-    const int N = extractSize(values);
-    SLIC_ASSERT(dim == NDIMS);
-
     // Extract pointers to the coordinate data
     // Note: The following assumes the coordinates are contiguous with stride NDIMS
     // TODO: Generalize to support other strides
 
+    // TODO: Add error checking for children 'x', 'y' and 'z' and striding
+
     // Copy the data into the point array of primal points
-    PointArray pts(N, N);
-    const std::size_t nbytes = sizeof(double) * dim * N;
-    axom::copy(pts.data(), values["x"].data_ptr(), nbytes);
+    PointArray pts(nPts, nPts);
+    const std::size_t nbytes = sizeof(double) * DIM * nPts;
+    axom::copy(pts.data(), coords["x"].data_ptr(), nbytes);
 
     m_points = PointArray(pts, m_allocatorID);  // copy point array to ExecSpace
   }
 
+  /// Predicate to check if the BVH tree has been initialized
+  bool isBVHTreeInitialized() const
+  {
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+    switch(m_runtimePolicy)
+    {
+    case RuntimePolicy::seq:
+      return m_bvh_seq != nullptr;
+
+    case RuntimePolicy::omp:
+  #ifdef AXOM_USE_OPENMP
+      return m_bvh_omp != nullptr;
+  #else
+      break;
+  #endif
+    case RuntimePolicy::cuda:
+  #ifdef AXOM_USE_CUDA
+      return m_bvh_cuda != nullptr;
+  #else
+      break;
+  #endif
+    }
+#endif
+
+    return false;
+  }
+
+  /// Generates the BVH tree for the classes execution space
   bool generateBVHTree()
   {
-    const int npts = m_points.size();
-    axom::Array<BoxType> boxesArray(npts, npts, m_allocatorID);
-    auto boxesView = boxesArray.view();
-    axom::for_all<ExecSpace>(
-      npts,
-      AXOM_LAMBDA(axom::IndexType i) { boxesView[i] = BoxType {m_points[i]}; });
+    // Delegates to generateBVHTreeImpl<> which uses
+    // the execution space templated bvh tree
 
-    // Build bounding volume hierarchy
-    m_bvh.setAllocatorID(m_allocatorID);
-    int result = m_bvh.initialize(boxesView, npts);
+    SLIC_ASSERT_MSG(!isBVHTreeInitialized(), "BVH tree already initialized");
 
-    return (result == spin::BVH_BUILD_OK);
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+    switch(m_runtimePolicy)
+    {
+    case RuntimePolicy::seq:
+      m_bvh_seq = new SeqBVHTree;
+      return generateBVHTreeImpl<SeqBVHTree>(m_bvh_seq);
+
+    case RuntimePolicy::omp:
+  #ifdef AXOM_USE_OPENMP
+      m_bvh_omp = new OmpBVHTree;
+      return generateBVHTreeImpl<OmpBVHTree>(m_bvh_omp);
+  #else
+      break;
+  #endif
+
+    case RuntimePolicy::cuda:
+  #ifdef AXOM_USE_CUDA
+      m_bvh_cuda = new CudaBVHTree;
+      return generateBVHTreeImpl<CudaBVHTree>(m_bvh_cuda);
+  #else
+      break;
+  #endif
+    }
+#endif
+
+    // Fail safe -- we should never reach this line!
+    SLIC_ERROR("Failed to initialize the BVH tree");
+
+    return false;
   }
 
   /**
    * \brief Computes the closest point within the objects for each query point
    * in the provided particle mesh, provided in the mesh blueprint rooted at \a meshGroup
-   * 
+   *
    * \param meshGroup The root of a mesh blueprint for the query points
    * \param coordset The coordinate set for the query points
-   * 
+   *
    * Uses the \a coordset coordinate set of the provided blueprint mesh
-   * 
+   *
    * The particle mesh must contain the following fields:
    *   - cp_rank: Will hold the rank of the object point containing the closest point
    *   - cp_index: Will hold the index of the object point containing the closest point
    *   - closest_point: Will hold the position of the closest point
-   * 
+   *
    * \note The current implementation assumes that the coordinates and closest_points and contiguous
    * with stride NDIMS. We intend to loosen this restriction in the future
+   *
+   * \note We're temporarily also using a min_distance class while debugging this class
+   * and will likely add an option to only use this when a debug flag is presented
    */
   void computeClosestPoints(conduit::Node& mesh_node,
                             const std::string& coordset) const
   {
+    SLIC_ASSERT_MSG(
+      isBVHTreeInitialized(),
+      "BVH tree must be initialized before calling 'computeClosestPoints");
+
     // Utility function to dump a conduit node on each rank, e.g. for debugging
     auto dumpNode = [=](const conduit::Node& n,
                         const std::string&& fname,
@@ -292,16 +421,13 @@ public:
       conduit::relay::io::save(n, fname, protocol);
     };
 
-    // Perform some simple error checking
-    SLIC_ASSERT(this->isValidBlueprint(mesh_node));
-
     // create conduit node containing data that has to xfer between ranks
     conduit::Node xfer_node;
     {
       // clang-format off
       auto& coords = mesh_node[fmt::format("coordsets/{}/values", coordset)];
-      const int dim = extractDimension(coords);
-      const int npts = extractSize(coords);
+      const int dim = internal::extractDimension(coords);
+      const int npts = internal::extractSize(coords);
 
       xfer_node["npts"] = npts;
       xfer_node["dim"] = dim;
@@ -320,7 +446,26 @@ public:
     }
 
     // Find initial values on this rank
-    computeLocalClosestPoints(xfer_node, true);
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+    switch(m_runtimePolicy)
+    {
+    case RuntimePolicy::seq:
+      computeLocalClosestPoints<SeqBVHTree>(m_bvh_seq, xfer_node, true);
+
+      break;
+    case RuntimePolicy::omp:
+  #ifdef AXOM_USE_OPENMP
+      computeLocalClosestPoints<OmpBVHTree>(m_bvh_omp, xfer_node, true);
+  #endif
+      break;
+
+    case RuntimePolicy::cuda:
+  #ifdef AXOM_USE_CUDA
+      computeLocalClosestPoints<CudaBVHTree>(m_bvh_cuda, xfer_node, true);
+  #endif
+      break;
+    }
+#endif
 
     if(m_isVerbose)
     {
@@ -373,7 +518,27 @@ public:
         }
 
         // compute the local data
-        computeLocalClosestPoints(rec_node, false);
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+        switch(m_runtimePolicy)
+        {
+        case RuntimePolicy::seq:
+          computeLocalClosestPoints<SeqBVHTree>(m_bvh_seq, rec_node, false);
+
+          break;
+
+        case RuntimePolicy::omp:
+  #ifdef AXOM_USE_OPENMP
+          computeLocalClosestPoints<OmpBVHTree>(m_bvh_omp, rec_node, false);
+  #endif
+          break;
+
+        case RuntimePolicy::cuda:
+  #ifdef AXOM_USE_CUDA
+          computeLocalClosestPoints<CudaBVHTree>(m_bvh_cuda, rec_node, false);
+  #endif
+          break;
+        }
+#endif
 
         if(m_isVerbose)
         {
@@ -429,8 +594,90 @@ public:
     }
   }
 
-  void computeLocalClosestPoints(conduit::Node& xfer_node, bool is_first) const
+private:
+  /// Sets the allocator ID to the default associated with the execution policy
+  void setAllocatorID()
   {
+    // This function uses the default allocator ID for the execution space
+    // TODO: Add overload to allow the user to set an allocator ID
+
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+    switch(m_runtimePolicy)
+    {
+    case RuntimePolicy::seq:
+      m_allocatorID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+      break;
+    case RuntimePolicy::omp:
+  #ifdef AXOM_USE_OPENMP
+      m_allocatorID = axom::execution_space<axom::OMP_EXEC>::allocatorID();
+  #endif
+      break;
+
+    case RuntimePolicy::cuda:
+  #ifdef AXOM_USE_CUDA
+      m_allocatorID = axom::execution_space<axom::CUDA_EXEC<256>>::allocatorID();
+  #endif
+      break;
+    }
+#endif
+  }
+
+  /// Templated implementation of generateBVHTree function
+  template <typename BVHTreeType>
+  bool generateBVHTreeImpl(BVHTreeType* bvh)
+  {
+    using ExecSpace = typename BVHTreeType::ExecSpaceType;
+
+    SLIC_ASSERT(bvh != nullptr);
+
+    const int npts = m_points.size();
+    axom::Array<BoxType> boxesArray(npts, npts, m_allocatorID);
+    auto boxesView = boxesArray.view();
+
+    /// GOT TO HERE -- fix for templated ExecSpace!
+    axom::for_all<ExecSpace>(
+      npts,
+      AXOM_LAMBDA(axom::IndexType i) { boxesView[i] = BoxType {m_points[i]}; });
+
+    // Build bounding volume hierarchy
+    bvh->setAllocatorID(m_allocatorID);
+    int result = bvh->initialize(boxesView, npts);
+
+    return (result == spin::BVH_BUILD_OK);
+  }
+
+  /**
+   * \brief Extracts a field \a fieldName from the mesh blueprint
+   *
+   * \tparam T The type for the underlying array
+   * \param mesh_node The conduit node at the root of the mesh blueprint
+   * \param field_name The name of the field
+   * \param field_template Template string for the path to the field
+   * \param num_points The size of the field
+   * \return An arrayview over the field data
+   */
+  template <typename T>
+  axom::ArrayView<T> extractField(conduit::Node& mesh_node,
+                                  std::string&& field_name,
+                                  std::string&& path_template,
+                                  int num_points) const
+  {
+    const std::string path = axom::fmt::format(path_template, field_name);
+    SLIC_ASSERT_MSG(
+      mesh_node.has_path(path),
+      fmt::format(
+        "Input to `computeClosestPoint()` must have a field named `{}`",
+        field_name));
+
+    return internal::ArrayView_from_Node<T>(mesh_node[path], num_points);
+  }
+
+  template <typename BVHTreeType>
+  void computeLocalClosestPoints(const BVHTreeType* bvh,
+                                 conduit::Node& xfer_node,
+                                 bool is_first) const
+  {
+    using ExecSpace = typename BVHTreeType::ExecSpaceType;
     using axom::primal::squared_distance;
     using int32 = axom::int32;
 
@@ -440,14 +687,13 @@ public:
     SLIC_ASSERT(dim == NDIMS);
 
     /// Extract fields from the input node as ArrayViews
-    auto queryPts =
-      internal::ArrayView_from_Node<PointType>(xfer_node["coords"], npts);
+    auto queryPts = ArrayView_from_Node<PointType>(xfer_node["coords"], npts);
     auto cpIndexes =
-      internal::ArrayView_from_Node<axom::IndexType>(xfer_node["cp_index"], npts);
+      ArrayView_from_Node<axom::IndexType>(xfer_node["cp_index"], npts);
     auto cpRanks =
-      internal::ArrayView_from_Node<axom::IndexType>(xfer_node["cp_rank"], npts);
+      ArrayView_from_Node<axom::IndexType>(xfer_node["cp_rank"], npts);
     auto closestPts =
-      internal::ArrayView_from_Node<PointType>(xfer_node["closest_point"], npts);
+      ArrayView_from_Node<PointType>(xfer_node["closest_point"], npts);
 
     /// Create ArrayViews in ExecSpace that are compatible with fields
     // TODO: Avoid copying arrays (here and at the end) if both are on the host
@@ -465,8 +711,7 @@ public:
 
     // DEBUG
     auto minDist =
-      internal::ArrayView_from_Node<double>(xfer_node["debug/min_distance"],
-                                            npts);
+      ArrayView_from_Node<double>(xfer_node["debug/min_distance"], npts);
     auto cp_dist = is_first ? axom::Array<double>(npts, npts, m_allocatorID)
                             : axom::Array<double>(minDist, m_allocatorID);
     ;
@@ -487,7 +732,7 @@ public:
     auto query_pts = execPoints.view();
 
     // Get a device-useable iterator
-    auto it = m_bvh.getTraverser();
+    auto it = bvh->getTraverser();
     const int rank = m_rank;
 
     AXOM_PERF_MARK_SECTION(
@@ -587,6 +832,233 @@ public:
   }
 
 private:
+  RuntimePolicy m_runtimePolicy;
+  bool m_isVerbose {false};
+  int m_allocatorID;
+  int m_rank;
+  int m_nranks;
+
+  PointArray m_points;
+  BoxArray m_boxes;
+
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+  SeqBVHTree* m_bvh_seq {nullptr};
+
+  #ifdef AXOM_USE_OPENMP
+  OmpBVHTree* m_bvh_omp {nullptr};
+  #endif
+
+  #ifdef AXOM_USE_CUDA
+  CudaBVHTree* m_bvh_cuda {nullptr};
+  #endif
+#endif
+};
+
+}  // namespace internal
+
+/**
+ * \brief Encapsulated the Distributed closest point query for a collection of query points 
+ * over an "object mesh"
+ *
+ * The object mesh and the query mesh are provided as conduit nodes using the mesh blueprint schema.
+ * Each of these are distributed over the problem's mpi ranks. This class orchestrates passing
+ * the query points to all ranks whose object meshes might contain a closest point.
+ *
+ * \note The class currently supports object meshes that are comprised of a collection of points.
+ * In the future, we'd like to consider more general object meshes, e.g. triangle meshes.
+ *
+ * To use this class, first set some parameters, such as the runtime execution policy,
+ * then pass in the object mesh and build a spatial index over this mesh.
+ * Finally, compute the closest points in the object mesh to each point in a query mesh 
+ * using the \a computeClosestPoint() function.
+ */
+class DistributedClosestPoint
+{
+public:
+  using RuntimePolicy = DistributedClosestPointRuntimePolicy;
+
+  ~DistributedClosestPoint()
+  {
+    delete m_dcp_2;
+    m_dcp_2 = nullptr;
+
+    delete m_dcp_3;
+    m_dcp_3 = nullptr;
+  }
+
+public:
+  /// Set the runtime execution policy for the query
+  void setRuntimePolicy(RuntimePolicy policy)
+  {
+    SLIC_ASSERT_MSG(
+      isValidRuntimePolicy(policy),
+      fmt::format("Policy '{}' is not a valid runtime policy", policy));
+    m_runtimePolicy = policy;
+  }
+
+  /// Predicate to determine if a given \a RuntimePolicy is valid for this configuration
+  bool isValidRuntimePolicy(RuntimePolicy policy) const
+  {
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+    switch(policy)
+    {
+    case RuntimePolicy::seq:
+      return true;
+
+    case RuntimePolicy::omp:
+  #ifdef AXOM_USE_OPENMP
+      return true;
+  #else
+      return
+  #endif
+
+    case RuntimePolicy::cuda:
+  #ifdef AXOM_USE_CUDA
+      return true;
+  #else
+        return false;
+  #endif
+    }
+#endif
+
+    return false;
+  }
+
+  /**
+   * \brief Sets the dimension for the query
+   *
+   * \note Users do not need to call this function explicitly. The dimension 
+   * is set by the \a setObjectMesh function
+   */
+  void setDimension(int dim)
+  {
+    SLIC_ERROR_IF(
+      dim < 2 || dim > 3,
+      "DistributedClosestPoint query only supports 2D or 3D queries");
+    m_dimension = dim;
+  }
+
+  /// Sets the logging verbosity of the query. By default the query is not verbose
+  void setVerbosity(bool isVerbose) { m_isVerbose = isVerbose; }
+
+  /**
+   * \brief Sets the object mesh for the query
+   *
+   * \param [in] mesh_node Conduit node for the object mesh
+   * \param [in] coordset The name of the coordset for the object mesh's coordinates
+   *
+   * \pre \a mesh_node must follow the mesh blueprint convention
+   * \pre Dimension of the mesh must be 2D or 3D
+   */
+  void setObjectMesh(const conduit::Node& mesh_node, const std::string& coordset)
+  {
+    // Perform some simple error checking
+    SLIC_ASSERT(this->isValidBlueprint(mesh_node));
+
+    // Extract the dimension and number of points from the coordinate values group
+    auto valuesPath = fmt::format("coordsets/{}/values", coordset);
+    SLIC_ASSERT(mesh_node.has_path(valuesPath));
+    auto& values = mesh_node[valuesPath];
+
+    const int dim = internal::extractDimension(values);
+    setDimension(dim);
+
+    allocateQueryInstance();
+
+    const int N = internal::extractSize(values);
+
+    // dispatch to implementation class over dimension
+    switch(m_dimension)
+    {
+    case 2:
+      m_dcp_2->importObjectPoints(values, N);
+      break;
+    case 3:
+      m_dcp_3->importObjectPoints(values, N);
+      break;
+    }
+  }
+
+  /**
+   * \brief Generates a BVH tree over the object mesh using the runtime execution policy
+   *
+   * \pre Users must set the object mesh before generating the BVH tree
+   * \sa setObjectMesh()
+   */
+  bool generateBVHTree()
+  {
+    SLIC_ASSERT_MSG(m_objectMeshCreated,
+                    "Must call 'setObjectMesh' before calling generateBVHTree");
+
+    bool success = false;
+
+    // dispatch to implementation class over dimension
+    switch(m_dimension)
+    {
+    case 2:
+      success = m_dcp_2->generateBVHTree();
+      break;
+    case 3:
+      success = m_dcp_3->generateBVHTree();
+      break;
+    }
+
+    return success;
+  }
+
+  /**
+   * \brief Computes the closest point on the object mesh for each point 
+   * on the provided query mesh
+   *
+   * \param [in] query_node conduit node containing the query points
+   * \param [in] coordset The name of the coordinates within query_node
+   *
+   * \pre query_node must follow the conduit mesh blueprint convention
+   */
+  void computeClosestPoints(conduit::Node& query_node,
+                            const std::string& cooordset)
+  {
+    SLIC_ASSERT_MSG(m_objectMeshCreated,
+                    "Must call 'setObjectMesh' before calling generateBVHTree");
+
+    SLIC_ASSERT(this->isValidBlueprint(query_node));
+
+    // dispatch to implementation class over dimension
+    switch(m_dimension)
+    {
+    case 2:
+      m_dcp_2->computeClosestPoints(query_node, cooordset);
+      break;
+    case 3:
+      m_dcp_3->computeClosestPoints(query_node, cooordset);
+      break;
+    }
+  }
+
+private:
+  void allocateQueryInstance()
+  {
+    SLIC_ASSERT_MSG(m_objectMeshCreated == false, "Object mesh already created");
+
+    switch(m_dimension)
+    {
+    case 2:
+      m_dcp_2 = new internal::DistributedClosestPointImpl<2>(m_runtimePolicy,
+                                                             m_isVerbose);
+      m_objectMeshCreated = true;
+      break;
+    case 3:
+      m_dcp_3 = new internal::DistributedClosestPointImpl<3>(m_runtimePolicy,
+                                                             m_isVerbose);
+      m_objectMeshCreated = true;
+      break;
+    }
+
+    SLIC_ASSERT_MSG(
+      m_objectMeshCreated,
+      "Called allocateQueryInstance, but did not create an instance");
+  }
+
   /// Check validity of blueprint group
   bool isValidBlueprint(const conduit::Node& mesh_node) const
   {
@@ -594,66 +1066,23 @@ private:
     conduit::Node info;
     if(!conduit::blueprint::mpi::verify("mesh", mesh_node, info, MPI_COMM_WORLD))
     {
-      SLIC_INFO(
-        fmt::format("Invalid blueprint on rank {} for particle mesh: \n{}",
-                    m_rank,
-                    info.to_yaml()));
+      SLIC_INFO("Invalid blueprint for particle mesh: \n" << info.to_yaml());
       success = false;
     }
 
     return success;
   }
 
-  /// Helper function to extract the dimension from the coordinate values group
-  int extractDimension(const conduit::Node& values_node) const
-  {
-    SLIC_ASSERT(values_node.has_child("x"));
-    return values_node.has_child("z") ? 3 : (values_node.has_child("y") ? 2 : 1);
-  }
-
-  /// Helper function to extract the number of points from the coordinate values group
-  int extractSize(const conduit::Node& values_node) const
-  {
-    SLIC_ASSERT(values_node.has_child("x"));
-    return values_node["x"].dtype().number_of_elements();
-  }
-
-  /**
-   * \brief Extracts a field \a fieldName from the mesh blueprint
-   * 
-   * \tparam T The type for the underlying array
-   * \param mesh_node The conduit node at the root of the mesh blueprint
-   * \param field_name The name of the field
-   * \param field_template Template string for the path to the field
-   * \param num_points The size of the field
-   * \return An arrayview over the field data
-   */
-  template <typename T>
-  axom::ArrayView<T> extractField(conduit::Node& mesh_node,
-                                  std::string&& field_name,
-                                  std::string&& path_template,
-                                  int num_points) const
-  {
-    const std::string path = axom::fmt::format(path_template, field_name);
-    SLIC_ASSERT_MSG(
-      mesh_node.has_path(path),
-      fmt::format(
-        "Input to `computeClosestPoint()` must have a field named `{}`",
-        field_name));
-
-    return internal::ArrayView_from_Node<T>(mesh_node[path], num_points);
-  }
-
 private:
-  PointArray m_points;
-  BoxArray m_boxes;
-  BVHTreeType m_bvh;
-
-  int m_allocatorID;
+  RuntimePolicy m_runtimePolicy {RuntimePolicy::seq};
+  int m_dimension {-1};
   bool m_isVerbose {false};
 
-  int m_rank;
-  int m_nranks;
+  bool m_objectMeshCreated {false};
+
+  // One instance per dimension
+  internal::DistributedClosestPointImpl<2>* m_dcp_2 {nullptr};
+  internal::DistributedClosestPointImpl<3>* m_dcp_3 {nullptr};
 };
 
 }  // end namespace quest

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -59,35 +59,21 @@ public:  // Query properties
   void setVerbosity(bool isVerbose) { m_isVerbose = isVerbose; }
 
 public:
-  /// Utility function to generate an array of 2D points
-  void generatePoints(double radius, int numPoints)
+  /// Utility function to set the array of 2D points
+  void setObjectPoints(const PointArray& pts)
   {
-    using axom::utilities::random_real;
-
-    // Generate in host because random_real is not yet ported to the device
-    PointArray pts;
-    pts.reserve(numPoints);
-    for(int i = 0; i < numPoints; ++i)
-    {
-      const double angleInRadians = random_real(0., 2 * M_PI);
-      const double rsinT = radius * std::sin(angleInRadians);
-      const double rcosT = radius * std::cos(angleInRadians);
-
-      pts.emplace_back(PointType {rcosT, rsinT});
-    }
-
+    // Optionally, output some diagnostic information about the input puts
     if(m_isVerbose)
     {
       SLIC_INFO("Points on object:");
-      const auto& arr = m_points;
-      for(auto i : slam::PositionSet<int>(arr.size()))
+      for(auto i : slam::PositionSet<int>(pts.size()))
       {
-        const double mag = sqrt(arr[i][0] * arr[i][0] + arr[i][1] * arr[i][1]);
-        SLIC_INFO(axom::fmt::format("\t{}: {} -- {}", i, arr[i], mag));
+        const double mag = sqrt(pts[i][0] * pts[i][0] + pts[i][1] * pts[i][1]);
+        SLIC_INFO(axom::fmt::format("\t{}: {} -- {}", i, pts[i], mag));
       }
     }
 
-    m_points = PointArray(pts, m_allocatorID);  // copy to ExecSpace
+    m_points = PointArray(pts, m_allocatorID);  // copy point array to ExecSpace
   }
 
   bool generateBVHTree()

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -895,17 +895,18 @@ private:
 
 private:
   ExecPolicy m_execPolicy {seq};
-  double m_vertexWeldThreshold {1.e-10};
   int m_level {7};
-  int m_octcount {0};
   int m_num_elements {0};
+  double* m_hex_volumes {nullptr};
+  double* m_overlap_volumes {nullptr};
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+  double m_vertexWeldThreshold {1.e-10};
+  int m_octcount {0};
   OctahedronType* m_octs {nullptr};
   BoundingBoxType* m_aabbs {nullptr};
   PolyhedronType* m_hexes {nullptr};
   BoundingBoxType* m_hex_bbs {nullptr};
-  double* m_hex_volumes {nullptr};
-  double* m_overlap_volumes {nullptr};
-
+#endif
   // What do I need here?
   // Probably size of stuff
 };

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -20,8 +20,8 @@ blt_add_executable(
     FOLDER      axom/quest/examples
     )
 
-if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI 
-              AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION 
+if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
+              AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION
               AND AXOM_ENABLE_KLEE)
     blt_add_executable(
         NAME        quest_shaping_driver_ex
@@ -30,6 +30,17 @@ if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
         DEPENDS_ON  ${quest_example_depends} mfem mpi
         FOLDER      axom/quest/examples
         )
+endif()
+
+if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
+              AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION)
+    blt_add_executable(
+            NAME        quest_distributed_distance_query_ex
+            SOURCES     quest_distributed_distance_query_example.cpp
+            OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
+            DEPENDS_ON  ${quest_example_depends} mfem mpi
+            FOLDER      axom/quest/examples
+            )
 endif()
 
 if(MFEM_FOUND)
@@ -84,13 +95,13 @@ if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR)
         axom_add_test(
             NAME quest_inout_interface_3D_mpi_test
             COMMAND quest_inout_interface_ex -i ${quest_data_dir}/sphere_binary.stl
-            NUM_MPI_TASKS 2 
+            NUM_MPI_TASKS 2
             )
         if(C2C_FOUND)
             axom_add_test(
                 NAME quest_inout_interface_2D_mpi_test
                 COMMAND quest_inout_interface_ex -i ${AXOM_DATA_DIR}/contours/unit_circle.contour
-                NUM_MPI_TASKS 2 
+                NUM_MPI_TASKS 2
                 )
         endif()
     else()

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and
 // other Axom Project Developers. See the top-level COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
@@ -108,7 +108,7 @@ public:
       }
     }
 
-    m_points = PointArray(pts, m_allocatorID); // copy to ExecSpace
+    m_points = PointArray(pts, m_allocatorID);  // copy to ExecSpace
   }
 
   bool generateBVHTree()
@@ -513,6 +513,9 @@ int main(int argc, char** argv)
     "{:=^80}",
     axom::fmt::format("Computing closest points for {} query points", nQueryPts));
 
+  axom::utilities::Timer initTimer(false);
+  axom::utilities::Timer queryTimer(false);
+
   switch(params.policy)
   {
   case RuntimePolicy::seq:
@@ -522,10 +525,14 @@ int main(int argc, char** argv)
     query.generatePoints(params.circleRadius, params.circlePoints);
 
     SLIC_INFO(init_str);
+    initTimer.start();
     query.generateBVHTree();
+    initTimer.stop();
 
     SLIC_INFO(query_str);
+    queryTimer.start();
     query.computeClosestPoints(qPts, cpIndices);
+    queryTimer.stop();
     objectPts = query.points();
   }
   break;
@@ -538,10 +545,15 @@ int main(int argc, char** argv)
     query.generatePoints(params.circleRadius, params.circlePoints);
 
     SLIC_INFO(init_str);
+    initTimer.start();
     query.generateBVHTree();
+    initTimer.stop();
 
     SLIC_INFO(query_str);
+    queryTimer.start();
     query.computeClosestPoints(qPts, cpIndices);
+    queryTimer.stop();
+
     objectPts = query.points();
   }
 #endif
@@ -554,10 +566,15 @@ int main(int argc, char** argv)
     query.generatePoints(params.circleRadius, params.circlePoints);
 
     SLIC_INFO(init_str);
+    initTimer.start();
     query.generateBVHTree();
+    initTimer.stop();
 
     SLIC_INFO(query_str);
+    queryTimer.start();
     query.computeClosestPoints(qPts, cpIndices);
+    queryTimer.stop();
+
     objectPts = query.points();
   }
 #endif
@@ -572,6 +589,13 @@ int main(int argc, char** argv)
       SLIC_INFO(axom::fmt::format("\t{}: {}", i, cpIndices[i]));
     }
   }
+
+  SLIC_INFO(axom::fmt::format("Initialization with policy {} took {} seconds",
+                              params.policy,
+                              initTimer.elapsedTimeInSec()));
+  SLIC_INFO(axom::fmt::format("Query with policy {} took {} seconds",
+                              params.policy,
+                              queryTimer.elapsedTimeInSec()));
 
   //---------------------------------------------------------------------------
   // Transform closest points to distances and directions

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -346,7 +346,7 @@ public:
   {
     auto* ds = m_group->getDataStore();
     sidre::IOManager writer(MPI_COMM_WORLD);
-    writer.write(ds->getRoot(), 1, outputMesh, "sidre_hdf5");
+    writer.write(ds->getRoot(), m_nranks, outputMesh, "sidre_hdf5");
 
     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -374,7 +374,7 @@ private:
 
     m_fieldsGroup = m_group->createGroup("fields");
 
-    m_group->createViewScalar<axom::int32>("state/domain_id", m_rank);
+    m_group->createViewScalar<axom::int64>("state/domain_id", m_rank);
   }
 
 private:
@@ -424,9 +424,12 @@ public:
     using PointArray = axom::Array<PointType>;
 
     PointArray pts(0, numPoints);
+    const double thetaScale = 2. * M_PI / m_mesh.getNumRanks();
+    const double thetaStart = m_mesh.getRank() * thetaScale;
+    const double thetaEnd = (m_mesh.getRank() + 1) * thetaScale;
     for(int i = 0; i < numPoints; ++i)
     {
-      const double angleInRadians = random_real(0., 2 * M_PI);
+      const double angleInRadians = random_real(thetaStart, thetaEnd);
       const double rsinT = radius * std::sin(angleInRadians);
       const double rcosT = radius * std::cos(angleInRadians);
 

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -1,0 +1,458 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ * \file quest_distributed_distance_query_example.cpp
+ * \brief Driver for a distributed distance query
+ */
+
+// Axom includes
+#include "axom/config.hpp"
+#include "axom/core.hpp"
+#include "axom/slic.hpp"
+#include "axom/primal.hpp"
+#include "axom/sidre.hpp"
+#include "axom/quest.hpp"
+#include "axom/slam.hpp"
+
+#include "axom/fmt.hpp"
+#include "axom/CLI11.hpp"
+
+#ifndef AXOM_USE_MFEM
+  #error This example requires Axom to be configured with MFEM and the AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION option
+#endif
+#include "mfem.hpp"
+
+#ifdef AXOM_USE_MPI
+  #include "mpi.h"
+#endif
+
+// RAJA
+#ifdef AXOM_USE_RAJA
+  #include "RAJA/RAJA.hpp"
+#endif
+
+// C/C++ includes
+#include <string>
+#include <map>
+#include <cmath>
+
+namespace quest = axom::quest;
+namespace slic = axom::slic;
+namespace sidre = axom::sidre;
+namespace slam = axom::slam;
+namespace spin = axom::spin;
+namespace primal = axom::primal;
+namespace numerics = axom::numerics;
+
+template <int NDIMS = 2, typename ExecSpace = axom::SEQ_EXEC>
+class ClosestPointQuery
+{
+public:
+  // TODO: generalize to 3D
+  static_assert(NDIMS == 2, "ClosestPointQuery only currently supports 2D");
+
+  static constexpr int DIM = NDIMS;
+  using PointType = primal::Point<double, DIM>;
+  using BoxType = primal::BoundingBox<double, DIM>;
+  using PointArray = axom::Array<PointType>;
+  using BoxArray = axom::Array<BoxType>;
+  using BVHTreeType = spin::BVH<DIM, ExecSpace>;
+
+private:
+  struct MinCandidate
+  {
+    /// Squared distance to query point
+    double minSqDist {numerics::floating_point_limits<double>::max()};
+    /// Index within mesh of closest element
+    int minElem;
+  };
+
+public:
+  ClosestPointQuery(
+    int allocatorID = axom::execution_space<ExecSpace>::allocatorID())
+    : m_allocatorID(allocatorID)
+  { }
+
+  /// Utility function to generate an array of 2D points
+  void generatePoints(double radius, int numPoints)
+  {
+    using axom::utilities::random_real;
+
+    m_points.clear();
+    m_points.reserve(numPoints);
+
+    for(int i = 0; i < numPoints; ++i)
+    {
+      const double angleInRadians = random_real(0., 2 * M_PI);
+      const double rsinT = radius * std::sin(angleInRadians);
+      const double rcosT = radius * std::cos(angleInRadians);
+
+      m_points.emplace_back(Point2D {rcosT, rsinT});
+    }
+  }
+
+  bool generateBVHTree()
+  {
+    const int npts = m_points.size();
+    BoxType* boxes = axom::allocate<BoxType>(npts, m_allocatorID);
+    axom::for_all<ExecSpace>(
+      npts,
+      AXOM_LAMBDA(axom::IndexType i) { boxes[i] = BoxType {m_points[i]}; });
+
+    // Build bounding volume hierarchy
+    m_bvh.setAllocatorID(m_allocatorID);
+    int result = m_bvh.initialize(boxes, npts);
+
+    axom::deallocate(boxes);
+    return (result == spin::BVH_BUILD_OK);
+  }
+
+  void computeClosestPoints(const PointArray& queryPts,
+                            axom::Array<axom::IndexType>& cpIndexes) const
+  {
+    SLIC_ASSERT(!queryPts.empty());
+
+    const int nPts = queryPts.size();
+
+    cpIndexes.resize(nPts);
+    axom::IndexType* indexData = cpIndexes.data();
+
+    // Get a device-useable iterator
+    auto it = m_bvh.getTraverser();
+
+    using axom::primal::squared_distance;
+    using int32 = axom::int32;
+
+    AXOM_PERF_MARK_SECTION(
+      "ComputeClosestPoints",
+      axom::for_all<ExecSpace>(
+        nPts,
+        AXOM_LAMBDA(int32 idx) {
+          PointType qpt = queryPts[idx];
+
+          MinCandidate curr_min {};
+
+          auto searchMinDist = [&](int32 current_node, const int32* leaf_nodes) {
+            const int candidate_idx = leaf_nodes[current_node];
+            const PointType candidate_pt = m_points[candidate_idx];
+            const double sq_dist = squared_distance(qpt, candidate_pt);
+
+            if(sq_dist < curr_min.minSqDist)
+            {
+              curr_min.minSqDist = sq_dist;
+              curr_min.minElem = candidate_idx;
+            }
+          };
+
+          auto traversePredicate = [&](const PointType& p,
+                                       const BoxType& bb) -> bool {
+            return squared_distance(p, bb) <= curr_min.minSqDist;
+          };
+
+          // Traverse the tree, searching for the point with minimum distance.
+          it.traverse_tree(qpt, searchMinDist, traversePredicate);
+
+          indexData[idx] = curr_min.minElem;
+        }););
+  }
+
+  const PointArray& points() const { return m_points; }
+
+private:
+  PointArray m_points;
+  BoxArray m_boxes;
+  BVHTreeType m_bvh;
+
+  int m_allocatorID;
+};
+
+/// Struct to parse and store the input parameters
+struct Input
+{
+public:
+  std::string meshFile;
+
+  double circleRadius {1.0};
+  int circlePoints {100};
+
+private:
+  bool m_verboseOutput {false};
+
+public:
+  bool isVerbose() const { return m_verboseOutput; }
+
+  std::string getDCMeshName() const
+  {
+    using axom::utilities::string::removeSuffix;
+
+    // Remove the parent directories and file suffix
+    std::string name = axom::Path(meshFile).baseName();
+    name = removeSuffix(name, ".root");
+
+    return name;
+  }
+
+  void parse(int argc, char** argv, axom::CLI::App& app)
+  {
+    app.add_option("-m,--mesh-file", meshFile)
+      ->description(
+        "Path to computational mesh (generated by MFEMSidreDataCollection)")
+      ->check(axom::CLI::ExistingFile)
+      ->required();
+
+    app.add_flag("-v,--verbose,!--no-verbose", m_verboseOutput)
+      ->description("Enable/disable verbose output")
+      ->capture_default_str();
+
+    app.add_option("-r,--radius", circleRadius)
+      ->description("Radius for circle")
+      ->capture_default_str();
+
+    app.add_option("-n,--num-samples", circlePoints)
+      ->description("Number of points for circle")
+      ->capture_default_str();
+
+    app.get_formatter()->column_width(60);
+
+    // could throw an exception
+    app.parse(argc, argv);
+
+    slic::setLoggingMsgLevel(m_verboseOutput ? slic::message::Debug
+                                             : slic::message::Info);
+  }
+};
+
+/**
+ * \brief Print some info about the mesh
+ *
+ * \note In MPI-based configurations, this is a collective call, but only prints on rank 0
+ */
+void printMeshInfo(mfem::Mesh* mesh, const std::string& prefixMessage = "")
+{
+  namespace primal = axom::primal;
+
+  int myRank = 0;
+#ifdef AXOM_USE_MPI
+  MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
+#endif
+
+  int numElements = mesh->GetNE();
+
+  mfem::Vector mins, maxs;
+#ifdef MFEM_USE_MPI
+  auto* pmesh = dynamic_cast<mfem::ParMesh*>(mesh);
+  if(pmesh != nullptr)
+  {
+    pmesh->GetBoundingBox(mins, maxs);
+    numElements = pmesh->ReduceInt(numElements);
+    myRank = pmesh->GetMyRank();
+  }
+  else
+#endif
+  {
+    mesh->GetBoundingBox(mins, maxs);
+  }
+
+  if(myRank == 0)
+  {
+    switch(mesh->Dimension())
+    {
+    case 2:
+      SLIC_INFO(axom::fmt::format(
+        "{} mesh has {} elements and (approximate) bounding box {}",
+        prefixMessage,
+        numElements,
+        primal::BoundingBox<double, 2>(primal::Point<double, 2>(mins.GetData()),
+                                       primal::Point<double, 2>(maxs.GetData()))));
+      break;
+    case 3:
+      SLIC_INFO(axom::fmt::format(
+        "{} mesh has {} elements and (approximate) bounding box {}",
+        prefixMessage,
+        numElements,
+        primal::BoundingBox<double, 3>(primal::Point<double, 3>(mins.GetData()),
+                                       primal::Point<double, 3>(maxs.GetData()))));
+      break;
+    }
+  }
+
+  slic::flushStreams();
+}
+
+//------------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+#ifdef AXOM_USE_MPI
+  MPI_Init(&argc, &argv);
+  int my_rank, num_ranks;
+  MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
+#else
+  int my_rank = 0;
+  int num_ranks = 1;
+#endif
+
+  slic::SimpleLogger logger;
+
+  //---------------------------------------------------------------------------
+  // Set up and parse command line arguments
+  //---------------------------------------------------------------------------
+  Input params;
+  axom::CLI::App app {"Driver for distributed distance query"};
+
+  try
+  {
+    params.parse(argc, argv, app);
+  }
+  catch(const axom::CLI::ParseError& e)
+  {
+    int retval = -1;
+    if(my_rank == 0)
+    {
+      retval = app.exit(e);
+    }
+
+#ifdef AXOM_USE_MPI
+    MPI_Bcast(&retval, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    MPI_Finalize();
+#endif
+    exit(retval);
+  }
+
+  //---------------------------------------------------------------------------
+  // Load mesh
+  //---------------------------------------------------------------------------
+  constexpr int DIM = 2;
+
+  SLIC_INFO(axom::fmt::format(
+    "{:=^80}",
+    axom::fmt::format("Loading '{}' mesh", params.getDCMeshName())));
+
+  const bool dc_owns_data = true;
+  mfem::Mesh* originalMesh = nullptr;
+  sidre::MFEMSidreDataCollection originalMeshDC(params.getDCMeshName(),
+                                                originalMesh,
+                                                dc_owns_data);
+  {
+    originalMeshDC.SetComm(MPI_COMM_WORLD);
+    std::string protocol = "sidre_hdf5";
+    originalMeshDC.Load(params.meshFile, protocol);
+  }
+  SLIC_ASSERT_MSG(originalMeshDC.GetMesh()->Dimension() == DIM,
+                  "This application currently only supports 2D meshes");
+  // TODO: Check order and apply LOR, if necessary
+
+  mfem::Mesh* cpMesh = nullptr;
+  sidre::MFEMSidreDataCollection closestPointDC("closest_point",
+                                                cpMesh,
+                                                dc_owns_data);
+  {
+    closestPointDC.SetMeshNodesName("positions");
+
+    auto* pmesh = dynamic_cast<mfem::ParMesh*>(originalMeshDC.GetMesh());
+    cpMesh = (pmesh != nullptr) ? new mfem::ParMesh(*pmesh)
+                                : new mfem::Mesh(*originalMeshDC.GetMesh());
+    closestPointDC.SetMesh(cpMesh);
+  }
+  printMeshInfo(closestPointDC.GetMesh(), "After loading");
+
+  //---------------------------------------------------------------------------
+  // Initialize spatial index
+  //---------------------------------------------------------------------------
+
+  SLIC_INFO(
+    axom::fmt::format("{:=^80}",
+                      axom::fmt::format("Initializing BVH tree over {} points",
+                                        params.circlePoints)));
+
+  using ExecSpace = axom::SEQ_EXEC;
+  using ClosestPointQueryType = ClosestPointQuery<2, ExecSpace>;
+  using PointArray = ClosestPointQueryType::PointArray;
+  ClosestPointQueryType query;
+
+  query.generatePoints(params.circleRadius, params.circlePoints);
+
+  if(params.isVerbose())
+  {
+    SLIC_INFO("Points on object:");
+    const auto& arr = query.points();
+    for(auto i : slam::PositionSet<>(arr.size()))
+    {
+      const double mag = sqrt(arr[i][0] * arr[i][0] + arr[i][1] * arr[i][1]);
+      SLIC_INFO(axom::fmt::format("\t{}: {} -- {}", i, arr[i], mag));
+    }
+  }
+
+  // Generate BVH tree over the points
+  query.generateBVHTree();
+
+  //---------------------------------------------------------------------------
+  // Set up query points
+  //---------------------------------------------------------------------------
+  const int nQueryPts = cpMesh->GetNV();
+
+  SLIC_INFO(axom::fmt::format(
+    "{:=^80}",
+    axom::fmt::format("Computing closest points for {} query points", nQueryPts)));
+
+  PointArray qPts(nQueryPts);
+  for(auto i : slam::PositionSet<>(nQueryPts))
+  {
+    cpMesh->GetNode(i, qPts[i].data());
+  }
+
+  // Register the distances grid function
+  constexpr int order = 1;
+  auto* fec = new mfem::H1_FECollection(order, DIM, mfem::BasisType::Positive);
+  mfem::FiniteElementSpace* fes = new mfem::FiniteElementSpace(cpMesh, fec);
+  mfem::GridFunction* distances = new mfem::GridFunction(fes);
+  distances->MakeOwner(fec);
+  closestPointDC.RegisterField("distance", distances);
+
+  using IndexArray = axom::Array<axom::IndexType>;
+  IndexArray cpIndices;
+  query.computeClosestPoints(qPts, cpIndices);
+
+  if(params.isVerbose())
+  {
+    SLIC_INFO(axom::fmt::format("Closest points ({}):", cpIndices.size()));
+    for(auto i : slam::PositionSet<>(cpIndices.size()))
+    {
+      SLIC_INFO(axom::fmt::format("\t{}: {}", i, cpIndices[i]));
+    }
+  }
+
+  SLIC_INFO(axom::fmt::format(" distance size: {}", distances->Size()));
+
+  using primal::squared_distance;
+  const auto& objectPts = query.points();
+  for(auto i : slam::PositionSet<>(nQueryPts))
+  {
+    (*distances)[i] = sqrt(squared_distance(qPts[i], objectPts[cpIndices[i]]));
+  }
+
+  //---------------------------------------------------------------------------
+  // Save meshes and fields
+  //---------------------------------------------------------------------------
+#ifdef MFEM_USE_MPI
+  SLIC_INFO(
+    axom::fmt::format("{:=^80}",
+                      axom::fmt::format("Saving mesh '{}' to disk",
+                                        closestPointDC.GetCollectionName())));
+
+  closestPointDC.Save();
+#endif
+
+  //---------------------------------------------------------------------------
+  // Cleanup and exit
+  //---------------------------------------------------------------------------
+
+#ifdef AXOM_USE_MPI
+  MPI_Finalize();
+#endif
+
+  return 0;
+}

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -17,6 +17,8 @@
 #include "axom/quest.hpp"
 #include "axom/slam.hpp"
 
+#include "axom/quest/DistributedClosestPoint.hpp"
+
 #include "axom/fmt.hpp"
 #include "axom/CLI11.hpp"
 
@@ -46,154 +48,6 @@ namespace slam = axom::slam;
 namespace spin = axom::spin;
 namespace primal = axom::primal;
 namespace numerics = axom::numerics;
-
-template <int NDIMS = 2, typename ExecSpace = axom::SEQ_EXEC>
-class ClosestPointQuery
-{
-public:
-  // TODO: generalize to 3D
-  static_assert(NDIMS == 2, "ClosestPointQuery only currently supports 2D");
-
-  static constexpr int DIM = NDIMS;
-  using PointType = primal::Point<double, DIM>;
-  using BoxType = primal::BoundingBox<double, DIM>;
-  using PointArray = axom::Array<PointType>;
-  using BoxArray = axom::Array<BoxType>;
-  using BVHTreeType = spin::BVH<DIM, ExecSpace>;
-
-private:
-  struct MinCandidate
-  {
-    /// Squared distance to query point
-    double minSqDist {numerics::floating_point_limits<double>::max()};
-    /// Index within mesh of closest element
-    int minElem;
-  };
-
-public:
-  ClosestPointQuery(
-    int allocatorID = axom::execution_space<ExecSpace>::allocatorID())
-    : m_allocatorID(allocatorID)
-  { }
-
-public:  // Query properties
-  void setVerbosity(bool isVerbose) { m_isVerbose = isVerbose; }
-
-public:
-  /// Utility function to generate an array of 2D points
-  void generatePoints(double radius, int numPoints)
-  {
-    using axom::utilities::random_real;
-
-    // Generate in host because random_real is not yet ported to the device
-    PointArray pts;
-    pts.reserve(numPoints);
-    for(int i = 0; i < numPoints; ++i)
-    {
-      const double angleInRadians = random_real(0., 2 * M_PI);
-      const double rsinT = radius * std::sin(angleInRadians);
-      const double rcosT = radius * std::cos(angleInRadians);
-
-      pts.emplace_back(PointType {rcosT, rsinT});
-    }
-
-    if(m_isVerbose)
-    {
-      SLIC_INFO("Points on object:");
-      const auto& arr = m_points;
-      for(auto i : slam::PositionSet<int>(arr.size()))
-      {
-        const double mag = sqrt(arr[i][0] * arr[i][0] + arr[i][1] * arr[i][1]);
-        SLIC_INFO(axom::fmt::format("\t{}: {} -- {}", i, arr[i], mag));
-      }
-    }
-
-    m_points = PointArray(pts, m_allocatorID);  // copy to ExecSpace
-  }
-
-  bool generateBVHTree()
-  {
-    const int npts = m_points.size();
-    axom::Array<BoxType> boxesArray(npts, npts, m_allocatorID);
-    auto boxesView = boxesArray.view();
-    axom::for_all<ExecSpace>(
-      npts,
-      AXOM_LAMBDA(axom::IndexType i) { boxesView[i] = BoxType {m_points[i]}; });
-
-    // Build bounding volume hierarchy
-    m_bvh.setAllocatorID(m_allocatorID);
-    int result = m_bvh.initialize(boxesView, npts);
-
-    return (result == spin::BVH_BUILD_OK);
-  }
-
-  void computeClosestPoints(const PointArray& queryPts,
-                            axom::Array<axom::IndexType>& cpIndexes) const
-  {
-    SLIC_ASSERT(!queryPts.empty());
-
-    const int nPts = queryPts.size();
-
-    /// Create an ArrayView in ExecSpace that is compatible with cpIndexes
-    axom::Array<axom::IndexType> cp_idx(nPts, nPts, m_allocatorID);
-    auto query_inds = cp_idx.view();
-
-    /// Create an ArrayView in ExecSpace that is compatible with queryPts
-    PointArray execPoints(nPts, nPts, m_allocatorID);
-    execPoints = queryPts;
-    auto query_pts = execPoints.view();
-
-    // Get a device-useable iterator
-    auto it = m_bvh.getTraverser();
-
-    using axom::primal::squared_distance;
-    using int32 = axom::int32;
-
-    AXOM_PERF_MARK_SECTION(
-      "ComputeClosestPoints",
-      axom::for_all<ExecSpace>(
-        nPts,
-        AXOM_LAMBDA(int32 idx) mutable {
-          PointType qpt = query_pts[idx];
-
-          MinCandidate curr_min {};
-
-          auto searchMinDist = [&](int32 current_node, const int32* leaf_nodes) {
-            const int candidate_idx = leaf_nodes[current_node];
-            const PointType candidate_pt = m_points[candidate_idx];
-            const double sq_dist = squared_distance(qpt, candidate_pt);
-
-            if(sq_dist < curr_min.minSqDist)
-            {
-              curr_min.minSqDist = sq_dist;
-              curr_min.minElem = candidate_idx;
-            }
-          };
-
-          auto traversePredicate = [&](const PointType& p,
-                                       const BoxType& bb) -> bool {
-            return squared_distance(p, bb) <= curr_min.minSqDist;
-          };
-
-          // Traverse the tree, searching for the point with minimum distance.
-          it.traverse_tree(qpt, searchMinDist, traversePredicate);
-
-          query_inds[idx] = curr_min.minElem;
-        }););
-
-    cpIndexes = query_inds;
-  }
-
-  const PointArray& points() const { return m_points; }
-
-private:
-  PointArray m_points;
-  BoxArray m_boxes;
-  BVHTreeType m_bvh;
-
-  int m_allocatorID;
-  bool m_isVerbose {false};
-};
 
 class MeshWrapper
 {
@@ -466,14 +320,17 @@ int main(int argc, char** argv)
   constexpr int DIM = 2;
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
-  using SeqClosestPointQueryType = ClosestPointQuery<2, axom::SEQ_EXEC>;
+  using SeqClosestPointQueryType =
+    quest::DistributedClosestPoint<2, axom::SEQ_EXEC>;
 
   #ifdef AXOM_USE_OPENMP
-  using OmpClosestPointQueryType = ClosestPointQuery<2, axom::OMP_EXEC>;
+  using OmpClosestPointQueryType =
+    quest::DistributedClosestPoint<2, axom::OMP_EXEC>;
   #endif
 
   #ifdef AXOM_USE_CUDA
-  using CudaClosestPointQueryType = ClosestPointQuery<2, axom::CUDA_EXEC<256>>;
+  using CudaClosestPointQueryType =
+    quest::DistributedClosestPoint<2, axom::CUDA_EXEC<256>>;
   #endif
 #endif
 

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -733,6 +733,13 @@ int main(int argc, char** argv)
   axom::utilities::Timer initTimer(false);
   axom::utilities::Timer queryTimer(false);
 
+  // Convert blueprint representation from sidre to conduit
+  conduit::Node object_mesh_node;
+  object_mesh_wrapper.getBlueprintGroup()->createNativeLayout(object_mesh_node);
+
+  conduit::Node query_mesh_node;
+  query_mesh_wrapper.getBlueprintGroup()->createNativeLayout(query_mesh_node);
+
   switch(params.policy)
   {
   case RuntimePolicy::seq:
@@ -740,8 +747,7 @@ int main(int argc, char** argv)
     SeqClosestPointQueryType query;
     query.setVerbosity(params.isVerbose());
     SLIC_INFO(init_str);
-    query.setObjectMesh(object_mesh_wrapper.getBlueprintGroup(),
-                        object_mesh_wrapper.getCoordsetName());
+    query.setObjectMesh(object_mesh_node, object_mesh_wrapper.getCoordsetName());
 
     SLIC_INFO(init_str);
     initTimer.start();
@@ -750,7 +756,7 @@ int main(int argc, char** argv)
 
     SLIC_INFO(query_str);
     queryTimer.start();
-    query.computeClosestPoints(query_mesh_wrapper.getBlueprintGroup(),
+    query.computeClosestPoints(query_mesh_node,
                                query_mesh_wrapper.getCoordsetName());
     queryTimer.stop();
   }
@@ -761,8 +767,7 @@ int main(int argc, char** argv)
   {
     OmpClosestPointQueryType query;
     query.setVerbosity(params.isVerbose());
-    query.setObjectMesh(object_mesh_wrapper.getBlueprintGroup(),
-                        object_mesh_wrapper.getCoordsetName());
+    query.setObjectMesh(object_mesh_node, object_mesh_wrapper.getCoordsetName());
 
     SLIC_INFO(init_str);
     initTimer.start();
@@ -771,7 +776,7 @@ int main(int argc, char** argv)
 
     SLIC_INFO(query_str);
     queryTimer.start();
-    query.computeClosestPoints(query_mesh_wrapper.getBlueprintGroup(),
+    query.computeClosestPoints(query_mesh_node,
                                query_mesh_wrapper.getCoordsetName());
     queryTimer.stop();
   }
@@ -782,8 +787,7 @@ int main(int argc, char** argv)
   {
     CudaClosestPointQueryType query;
     query.setVerbosity(params.isVerbose());
-    query.setObjectMesh(object_mesh_wrapper.getBlueprintGroup(),
-                        object_mesh_wrapper.getCoordsetName());
+    query.setObjectMesh(object_mesh_node, object_mesh_wrapper.getCoordsetName());
 
     SLIC_INFO(init_str);
     initTimer.start();
@@ -792,7 +796,7 @@ int main(int argc, char** argv)
 
     SLIC_INFO(query_str);
     queryTimer.start();
-    query.computeClosestPoints(query_mesh_wrapper.getBlueprintGroup(),
+    query.computeClosestPoints(query_mesh_node,
                                query_mesh_wrapper.getCoordsetName());
     queryTimer.stop();
   }

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -35,11 +35,6 @@
 #endif
 #include "mpi.h"
 
-// RAJA
-#ifdef AXOM_USE_RAJA
-  #include "RAJA/RAJA.hpp"
-#endif
-
 // C/C++ includes
 #include <string>
 #include <map>
@@ -70,16 +65,17 @@ private:
   bool m_verboseOutput {false};
 
   // clang-format off
-  const std::map<std::string, RuntimePolicy> s_validPolicies{
-    #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+  const std::map<std::string, RuntimePolicy> s_validPolicies
+  {
       {"seq", RuntimePolicy::seq}
-      #ifdef AXOM_USE_OPENMP
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+  #ifdef AXOM_USE_OPENMP
     , {"omp", RuntimePolicy::omp}
-      #endif
-      #ifdef AXOM_USE_CUDA
+  #endif
+  #ifdef AXOM_USE_CUDA
     , {"cuda", RuntimePolicy::cuda}
-      #endif
-    #endif
+  #endif
+#endif
   };
   // clang-format on
 
@@ -520,7 +516,7 @@ public:
     m_queryMesh = BlueprintParticleMesh(dsRoot->createGroup("query_mesh"));
 
     const int DIM = m_dc.GetMesh()->Dimension();
-    SLIC_ERROR_IF(DIM != 2 || DIM != 3,
+    SLIC_ERROR_IF(DIM != 2 && DIM != 3,
                   "Only 2D and 3D meshes are supported in setupParticleMesh(). "
                   "Attempted mesh dimension was "
                     << DIM);

--- a/src/axom/spin/BVH.hpp
+++ b/src/axom/spin/BVH.hpp
@@ -186,6 +186,7 @@ public:
   using RayType = typename primal::Ray<FloatType, NDIMS>;
 
   using TraverserType = typename ImplType::TraverserType;
+  using ExecSpaceType = ExecSpace;
 
 public:
   /*!

--- a/src/axom/spin/UniformGrid.hpp
+++ b/src/axom/spin/UniformGrid.hpp
@@ -727,9 +727,9 @@ void UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::getCandidatesAsArray(
 
   // TODO: There's an error on operator[] if these aren't const and it only
   // happens for GCC 8.1.0
+#ifdef AXOM_USE_RAJA
   const auto offsets_view = outOffsets;
   const auto counts_view = outCounts;
-#ifdef AXOM_USE_RAJA
   using reduce_pol = typename axom::execution_space<ExecSpace>::reduce_policy;
   RAJA::ReduceSum<reduce_pol, IndexType> totalCountReduce(0);
   // Step 1: count number of candidate intersections for each point
@@ -879,7 +879,7 @@ void UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::getCandidatesAsArray(
                                     RAJA::operators::plus<IndexType> {});
   outCandidates = std::move(dedupedCandidates);
 
-#else
+#else   // AXOM_USE_RAJA
   outOffsets[0] = 0;
   for(int i = 0; i < qsize; i++)
   {
@@ -893,7 +893,7 @@ void UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::getCandidatesAsArray(
       outOffsets[i + 1] = outOffsets[i] + outCounts[i];
     }
   }
-#endif
+#endif  // AXOM_USE_RAJA
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

- This PR is a feature
- It adds a `DistributedClosestPoint` class to quest, which solves the following problem:
    - Given an "object" mesh composed of a collection of points distributed across MPI ranks
       and a "query" mesh composed of a collection of points, distributed across the MPI ranks
    - Find the closest point in the object mesh to each point in the query mesh. (Also find the rank containing the closest point and the index of the object on that rank).
    - This can be used, e.g. to compute the distance and/or direction to the object
- The class takes the dimension (2 or 3) and the execution space (sequential CPU, openmp CPU or CUDA) as runtime parameters
- The current approach to solving the distributed problem is for each rank to generate a spatial index over its "object mesh" and to send its "query mesh" data to every other rank to update the closest point. This will be optimized in future PRs by only sending data between ranks that could affect the closest point.

- This PR also adds an example executable that uses this class. 
   - The example uses a circle as the object mesh and the vertices of a mesh in the mesh blueprint format as the query mesh
   - The latter can be generated for a Cartesian mesh in 2D or 3D or from an mfem mesh using axom's `data_collection_util`.

Here are two example runs:
```bash
## Generate a 30x30 Cartesian mesh distributed over 3 ranks 
## and run the distributed closest point query against a circular object w/ 100 samples per rank
srun -n3 ./bin/data_collection_util -p1 --min -1.5 -1.5 --max 1.5 1.5 --res 30 30
srun -n3 ./examples/quest_distributed_distance_query_ex -m box_2d.root -n 100

## Generate a Star mesh over 36 ranks, query against a circular object
cp <path/to/mfem>/data/star.mesh star.mesh
srun -n36 ./bin/data_collection_util -p1 -f 1 -m  star.mesh -l 4 --scale 1.25
srun -n36 ./examples/quest_distributed_distance_query_ex -m star.root -n 100
```

Here is a visualization of a 12 rank run on LLNL's blueos (3 nodes with 4 GPUs each) on a 300x300 Cartesian mesh:
![dcp_12rank_gpu_300x300](https://user-images.githubusercontent.com/5626552/167048795-06c4d56e-18b1-485b-b312-9a5884577dec.png)
The left side shows two derived fields of the closest point -- distance and direction to the object.
The right side shows the ranks containing the object and query points.

Here is a similar visualization of a 36 rank run on LLNL's toss3 platform on the star mesh:
![dcp_36rank_cpu_star](https://user-images.githubusercontent.com/5626552/167049293-edf8e268-0c7b-4f22-86c9-e0f5dfafc09a.png)

#### Known limitations
We will follow up with future PRs to:
* Add support for 3D queries to the application. I.e. the DistributedClosestPoint class is set up for 3D, but I haven't tested this yet
*  Optimize the MPI communications. The current code sends data from each rank to every other rank.
* Remove unnecessary memory transfers. The current code contains some extra memory copies when running on the CPU. These can be eliminated
* Improve the robustness of how the input meshes are laid out. The code currently assumes the coordinate data and computed closest_point fields have interleaved data, e.g. `xyzxyzxyz....`. It should also support coordinates in three separate stride-1 arrays, e.g. `xxx.....yyy...zzz....`


