### PR TITLE
Implement threshold to reduce computations in closest point query.

### DIFF
--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -22,6 +22,7 @@
 #include "conduit_relay_io.hpp"
 
 #include <memory>
+#include <limits>
 #include <cstdlib>
 #include <cmath>
 
@@ -280,11 +281,22 @@ public:
   DistributedClosestPointImpl(RuntimePolicy runtimePolicy, bool isVerbose)
     : m_runtimePolicy(runtimePolicy)
     , m_isVerbose(isVerbose)
+    , m_sqDistanceThreshold(std::numeric_limits<double>::max())
   {
     setAllocatorID();
 
     MPI_Comm_rank(MPI_COMM_WORLD, &m_rank);
     MPI_Comm_size(MPI_COMM_WORLD, &m_nranks);
+  }
+
+  /**
+   * \brief Sets the threshold for the query
+   *
+   * \param [in] threshold Ignore distances greater than this value.
+   */
+  void setSquaredDistanceThreshold(double sqThreshold)
+  {
+    m_sqDistanceThreshold = sqThreshold;
   }
 
 public:
@@ -754,7 +766,9 @@ public:
 
           auto traversePredicate = [&](const PointType& p,
                                        const BoxType& bb) -> bool {
-            return squared_distance(p, bb) <= curr_min.minSqDist;
+            auto sqDist = squared_distance(p, bb);
+            return sqDist <= curr_min.minSqDist &&
+              sqDist <= m_sqDistanceThreshold;
           };
 
           // Traverse the tree, searching for the point with minimum distance.
@@ -829,6 +843,7 @@ public:
 private:
   RuntimePolicy m_runtimePolicy;
   bool m_isVerbose {false};
+  double m_sqDistanceThreshold;
   int m_allocatorID;
   int m_rank;
   int m_nranks;
@@ -932,6 +947,17 @@ public:
     m_dimension = dim;
   }
 
+  /**
+   * \brief Sets the threshold for the query
+   *
+   * \param [in] threshold Ignore distances greater than this value.
+   */
+  void setDistanceThreshold(double threshold)
+  {
+    SLIC_ERROR_IF(threshold < 0.0, "Distance threshold must be non-negative.");
+    m_sqDistanceThreshold = threshold * threshold;
+  }
+
   /// Sets the logging verbosity of the query. By default the query is not verbose
   void setVerbosity(bool isVerbose) { m_isVerbose = isVerbose; }
 
@@ -1021,9 +1047,11 @@ public:
     switch(m_dimension)
     {
     case 2:
+      m_dcp_2->setSquaredDistanceThreshold(m_sqDistanceThreshold);
       m_dcp_2->computeClosestPoints(query_node, cooordset);
       break;
     case 3:
+      m_dcp_3->setSquaredDistanceThreshold(m_sqDistanceThreshold);
       m_dcp_3->computeClosestPoints(query_node, cooordset);
       break;
     }
@@ -1073,6 +1101,7 @@ private:
   RuntimePolicy m_runtimePolicy {RuntimePolicy::seq};
   int m_dimension {-1};
   bool m_isVerbose {false};
+  double m_sqDistanceThreshold {std::numeric_limits<double>::max()};
 
   bool m_objectMeshCreated {false};
 

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -61,6 +61,8 @@ public:
   int circlePoints {100};
   RuntimePolicy policy {RuntimePolicy::seq};
 
+  double distThreshold {1e100};
+
 private:
   bool m_verboseOutput {false};
 
@@ -107,6 +109,10 @@ public:
 
     app.add_option("-r,--radius", circleRadius)
       ->description("Radius for circle")
+      ->capture_default_str();
+
+    app.add_option("-d,--dist-threshold", distThreshold)
+      ->description("Distance threshold to search")
       ->capture_default_str();
 
     app.add_option("-n,--num-samples", circlePoints)
@@ -775,6 +781,7 @@ int main(int argc, char** argv)
   query.setRuntimePolicy(params.policy);
   query.setDimension(DIM);
   query.setVerbosity(params.isVerbose());
+  query.setDistanceThreshold(params.distThreshold);
   query.setObjectMesh(object_mesh_node, object_mesh_wrapper.getCoordsetName());
 
   // Build the spatial index over the object on each rank


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following (modify list as needed):
  - Adds a distance threshold to the distributed closest point query so users can avoid searching spaces known to yield unproductive results, at the request of @kennyweiss 

Added method setDistanceThreshold is to DistributedClosestPoint class.
Added command-line switch, --dist-threshold to quest_distributed_distance_query_example so user can specify the threshold when running the example.