### PR TITLE
Set  number of output files MFEMSidreDataCollection

### DIFF
--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -162,8 +162,8 @@ void MFEMSidreDataCollection::SetComm(MPI_Comm comm)
 
 void MFEMSidreDataCollection::SetNumFiles(int num_files)
 {
-   SLIC_ASSERT_MSG(num_files > 0, "Output must be to at least 1 file");
-   m_num_files = num_files;
+  SLIC_ASSERT_MSG(num_files > 0, "Output must be to at least 1 file");
+  m_num_files = num_files;
 }
   #endif
 
@@ -841,10 +841,7 @@ void MFEMSidreDataCollection::SetMesh(MPI_Comm comm, Mesh* new_mesh)
 {
   // use MFEMSidreDataCollection's custom SetMesh, then set MPI info
   SetMesh(new_mesh);
-
-  m_comm = comm;
-  MPI_Comm_rank(comm, &myid);
-  MPI_Comm_size(comm, &num_procs);
+  SetComm(comm);
 }
   #endif
 
@@ -1088,9 +1085,12 @@ void MFEMSidreDataCollection::Save(const std::string& filename,
     temp_domain_grp->copyGroup(domain_grp);
 
     int num_files = num_procs;
-    if (m_num_files > 0) {
-       SLIC_ASSERT_MSG(num_files <= num_procs, "Save output must have num_files less than or equal to number of mpi ranks");
-       num_files = m_num_files;
+    if (m_num_files > 0) 
+    {
+      SLIC_ASSERT_MSG(num_files <= num_procs, 
+                      "Save output must have num_files less than or equal to "
+                      "number of mpi ranks");
+      num_files = m_num_files;
     }
     writer.write(temp_root, num_files, file_path, protocol);
 

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -86,6 +86,7 @@ MFEMSidreDataCollection::MFEMSidreDataCollection(const std::string& collection_n
   , m_owns_datastore(true)
   , m_owns_mesh_data(own_mesh_data)
   , m_meshNodesGFName("mesh_nodes")
+  , m_num_files(-1)
 {
   m_datastore_ptr = new sidre::DataStore();
 
@@ -126,6 +127,7 @@ MFEMSidreDataCollection::MFEMSidreDataCollection(const std::string& collection_n
   , m_owns_datastore(false)
   , m_owns_mesh_data(own_mesh_data)
   , m_meshNodesGFName("mesh_nodes")
+  , m_num_files(-1)
   , m_datastore_ptr(nullptr)
   , m_bp_index_grp(bp_index_grp)
 {
@@ -155,6 +157,13 @@ void MFEMSidreDataCollection::SetComm(MPI_Comm comm)
   appendRankToFileName = true;
   MPI_Comm_rank(m_comm, &myid);
   MPI_Comm_size(m_comm, &num_procs);
+}
+
+
+void MFEMSidreDataCollection::SetNumFiles(int num_files)
+{
+   SLIC_ASSERT_MSG(num_files > 0, "Output must be to at least 1 file");
+   m_num_files = num_files;
 }
   #endif
 
@@ -1078,7 +1087,12 @@ void MFEMSidreDataCollection::Save(const std::string& filename,
     }
     temp_domain_grp->copyGroup(domain_grp);
 
-    writer.write(temp_root, num_procs, file_path, protocol);
+    int num_files = num_procs;
+    if (m_num_files > 0) {
+       SLIC_ASSERT_MSG(num_files <= num_procs, "Save output must have num_files less than or equal to number of mpi ranks");
+       num_files = m_num_files;
+    }
+    writer.write(temp_root, num_files, file_path, protocol);
 
     // Now that we've written the data, we can delete the temporary group
     temp_root->getParent()->destroyGroup("_sidre_tmp_save");

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -1085,9 +1085,9 @@ void MFEMSidreDataCollection::Save(const std::string& filename,
     temp_domain_grp->copyGroup(domain_grp);
 
     int num_files = num_procs;
-    if (m_num_files > 0) 
+    if (m_num_files > 0)
     {
-      SLIC_ASSERT_MSG(num_files <= num_procs, 
+      SLIC_ASSERT_MSG(num_files <= num_procs,
                       "Save output must have num_files less than or equal to "
                       "number of mpi ranks");
       num_files = m_num_files;

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -1085,7 +1085,7 @@ void MFEMSidreDataCollection::Save(const std::string& filename,
     temp_domain_grp->copyGroup(domain_grp);
 
     int num_files = num_procs;
-    if (m_num_files > 0)
+    if(m_num_files > 0)
     {
       SLIC_ASSERT_MSG(num_files <= num_procs,
                       "Save output must have num_files less than or equal to "

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -19,6 +19,7 @@
   #include "MFEMSidreDataCollection.hpp"
 
   #include "axom/core/utilities/StringUtilities.hpp"
+  #include "axom/core/utilities/Utilities.hpp"
 
 using mfem::Array;
 using mfem::GridFunction;
@@ -1090,6 +1091,7 @@ void MFEMSidreDataCollection::Save(const std::string& filename,
                       "Save output must have num_files less than or equal to "
                       "number of mpi ranks");
       num_files = m_num_files;
+      num_files = axom::utilities::clampUpper(num_files, num_procs);
     }
     writer.write(temp_root, num_files, file_path, protocol);
 

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -159,7 +159,6 @@ void MFEMSidreDataCollection::SetComm(MPI_Comm comm)
   MPI_Comm_size(m_comm, &num_procs);
 }
 
-
 void MFEMSidreDataCollection::SetNumFiles(int num_files)
 {
   SLIC_ASSERT_MSG(num_files > 0, "Output must be to at least 1 file");

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -228,7 +228,7 @@ public:
   void SetComm(MPI_Comm comm);
 
   /// Set number of files for parallel writing
-  /*( Allows the user to consolidate data for N ranks into M files, 0 < M <= N
+  /** Allows the user to consolidate data for N ranks into M files, 0 < M <= N
   */
   void SetNumFiles(int num_files);
   #endif

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -226,6 +226,11 @@ public:
   /** If no mesh was associated with the collection, this method should be
       called before using any of the Load() methods to read parallel data. */
   void SetComm(MPI_Comm comm);
+
+  /// Set number of files for parallel writing
+  /*( Allows the user to consolidate data for N ranks into M files, 0 < M <= N
+  */
+  void SetNumFiles(int num_files);
   #endif
 
   /// Register a GridFunction in the Sidre DataStore.
@@ -529,6 +534,10 @@ private:
   // SetMeshNodesName().
   // Default value: "mesh_nodes".
   std::string m_meshNodesGFName;
+
+  // For Parallel IO, the user can specify a number of files less tnan or equal to the
+  // number of processors.
+  int m_num_files;
 
   // If the data collection owns the datastore, it will store a pointer to it.
   // Otherwise, this pointer is nullptr.

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -228,7 +228,9 @@ public:
   void SetComm(MPI_Comm comm);
 
   /// Set number of files for parallel writing
-  /** Allows the user to consolidate data for N ranks into M files, 0 < M <= N
+  /** Allows the user to consolidate data for N ranks into M files, 0 < M <= N .
+  *   num_files should be less than or equal to the number of ranks N.
+  *   If num_files is less than or equal to zero (default), there will be one file per rank.
   */
   void SetNumFiles(int num_files);
   #endif

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -537,7 +537,7 @@ private:
   // Default value: "mesh_nodes".
   std::string m_meshNodesGFName;
 
-  // For Parallel IO, the user can specify a number of files less tnan or equal to the
+  // For Parallel IO, the user can specify a number of files less than or equal to the
   // number of processors.
   int m_num_files;
 

--- a/src/axom/sidre/examples/sidre_mfem_datacollection_restart.cpp
+++ b/src/axom/sidre/examples/sidre_mfem_datacollection_restart.cpp
@@ -220,6 +220,7 @@ int main(int argc, char* argv[])
   std::string protocol = "sidre_conduit_json";
 #endif
 
+  int num_files = -1;
   app.add_option("--cycle", cycle_to_load)
     ->description("Optional simulation cycle to load")
     ->capture_default_str();
@@ -227,7 +228,19 @@ int main(int argc, char* argv[])
     ->description("Optional sidre protocol to use for checkpoints and restarts")
     ->check(axom::CLI::IsMember(sidre_protocols))
     ->capture_default_str();
+  app.add_option("--num_files", num_files)
+    ->description(
+      "Optional flag to set the number of output files for parallel "
+      "simulations (default one output file per rank)")
+    ->capture_default_str();
   CLI11_PARSE(app, argc, argv);
+
+#ifdef EXAMPLE_USES_MPI
+  if(num_files > 0)
+  {
+    dc.SetNumFiles(num_files);
+  }
+#endif
 
   // Initialize the simulation data structures
   SimulationState sim_state(dc, cycle_to_load);

--- a/src/axom/sidre/examples/sidre_mfem_datacollection_restart.cpp
+++ b/src/axom/sidre/examples/sidre_mfem_datacollection_restart.cpp
@@ -189,8 +189,10 @@ private:
 
 int main(int argc, char* argv[])
 {
+  int num_procs = 1;
 #ifdef EXAMPLE_USES_MPI
   MPI_Init(&argc, &argv);
+  MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
 #endif
 
   // Initialize the datacollection
@@ -232,7 +234,8 @@ int main(int argc, char* argv[])
     ->description(
       "Optional flag to set the number of output files for parallel "
       "simulations (default one output file per rank)")
-    ->capture_default_str();
+    ->capture_default_str()
+    ->check(axom::CLI::Range(1, num_procs).description("Range [1,num_procs]"));
   CLI11_PARSE(app, argc, argv);
 
 #ifdef EXAMPLE_USES_MPI

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -135,7 +135,7 @@ TEST(sidre_datacollection, dc_save_two_files)
   // Try to go from N ranks to 2 files if we are running with more than 2 ranks
   int num_procs;
   MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-  if(num_procs > 2)
+  if(num_procs >= 2)
   {
     sdc.SetNumFiles(2);
   }

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -107,6 +107,49 @@ TEST(sidre_datacollection, dc_save)
   EXPECT_TRUE(sdc.verifyMeshBlueprint());
 }
 
+TEST(sidre_datacollection, dc_save_single_file)
+{
+  // 1D mesh divided into 10 segments
+  mfem::Mesh mesh(10);
+  MFEMSidreDataCollection sdc(testName(), &mesh);
+
+#if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
+  sdc.SetComm(MPI_COMM_WORLD);
+  sdc.SetNumFiles(1);
+#endif
+
+  sdc.Save();
+
+  EXPECT_TRUE(sdc.verifyMeshBlueprint());
+}
+
+TEST(sidre_datacollection, dc_save_two_files)
+{
+  // 1D mesh divided into 10 segments
+  mfem::Mesh mesh(10);
+  MFEMSidreDataCollection sdc(testName());
+
+#if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
+  sdc.SetMesh(MPI_COMM_WORLD, &mesh);
+
+  // Try to go from N ranks to 2 files if we are running with more than 2 ranks
+  int num_procs;
+  MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
+  if(num_procs > 2)
+  {
+    sdc.SetNumFiles(2);
+  }
+  else
+  {
+    sdc.SetNumFiles(1);
+  }
+#endif
+
+  sdc.Save();
+
+  EXPECT_TRUE(sdc.verifyMeshBlueprint());
+}
+
 TEST(sidre_datacollection, dc_reload_gf)
 {
   const std::string field_name = "test_field";


### PR DESCRIPTION
# Summary
Allow the user to set the number of output files for Parallel IO in MFEMSidreDataCollection

- This PR is a feature
- It does the following:
  - Add setter method for number of files
  - use this user-specified number of files (if given) when writing out the files to disk. If not provided, use num_procs as before.
