### PR TITLE
Remove now unnecessary C++11 compatible `make_unique`

### DIFF
--- a/src/axom/inlet/Container.cpp
+++ b/src/axom/inlet/Container.cpp
@@ -64,23 +64,23 @@ Container::Container(const std::string& name,
         {
           m_containerChildren.emplace(
             childName,
-            cpp11_compat::make_unique<Container>(childName,
-                                                 "",
-                                                 m_reader,
-                                                 m_sidreRootGroup,
-                                                 m_unexpectedNames,
-                                                 m_docEnabled,
-                                                 true));
+            std::make_unique<Container>(childName,
+                                        "",
+                                        m_reader,
+                                        m_sidreRootGroup,
+                                        m_unexpectedNames,
+                                        m_docEnabled,
+                                        true));
         }
         else if(inletType == "Field")
         {
           // FIXME: We probably need to write the type to the datastore
           m_fieldChildren.emplace(
             childName,
-            cpp11_compat::make_unique<Field>(group,
-                                             m_sidreRootGroup,
-                                             sidre::DataTypeId::NO_TYPE_ID,
-                                             m_docEnabled));
+            std::make_unique<Field>(group,
+                                    m_sidreRootGroup,
+                                    sidre::DataTypeId::NO_TYPE_ID,
+                                    m_docEnabled));
         }
       }
     }
@@ -145,12 +145,12 @@ Container& Container::addContainer(const std::string& name,
       // or do we need std::piecewise_construct/std::forward_as_tuple?
       const auto& emplaceResult = currContainer->m_containerChildren.emplace(
         currContainerName,
-        cpp11_compat::make_unique<Container>(currContainerName,
-                                             currDescr,
-                                             m_reader,
-                                             m_sidreRootGroup,
-                                             m_unexpectedNames,
-                                             m_docEnabled));
+        std::make_unique<Container>(currContainerName,
+                                    currDescr,
+                                    m_reader,
+                                    m_sidreRootGroup,
+                                    m_unexpectedNames,
+                                    m_docEnabled));
       // emplace_result is a pair whose first element is an iterator to the inserted element
       currContainer = emplaceResult.first->second.get();
     }
@@ -312,10 +312,7 @@ Field& Container::addField(axom::sidre::Group* sidreGroup,
   }
   const auto& emplace_result = currContainer->m_fieldChildren.emplace(
     fullName,
-    cpp11_compat::make_unique<Field>(sidreGroup,
-                                     m_sidreRootGroup,
-                                     type,
-                                     m_docEnabled));
+    std::make_unique<Field>(sidreGroup, m_sidreRootGroup, type, m_docEnabled));
   // emplace_result is a pair whose first element is an iterator to the inserted element
   return *(emplace_result.first->second);
 }
@@ -334,9 +331,7 @@ Function& Container::addFunctionInternal(axom::sidre::Group* sidreGroup,
   }
   const auto& emplace_result = currContainer->m_functionChildren.emplace(
     fullName,
-    cpp11_compat::make_unique<Function>(sidreGroup,
-                                        m_sidreRootGroup,
-                                        std::move(func)));
+    std::make_unique<Function>(sidreGroup, m_sidreRootGroup, std::move(func)));
   // emplace_result is a pair whose first element is an iterator to the inserted element
   return *(emplace_result.first->second);
 }

--- a/src/axom/inlet/inlet_utils.hpp
+++ b/src/axom/inlet/inlet_utils.hpp
@@ -192,28 +192,6 @@ void markRetrievalStatus(axom::sidre::Group& target, const ReaderResult result);
 ReaderResult collectionRetrievalResult(const bool contains_other_type,
                                        const bool contains_requested_type);
 
-namespace cpp11_compat
-{
-/*!
-*****************************************************************************
-* \brief This function provides backwards compatibility for std::make_unique,
-* which is not implemented until C++14.  It should be removed when either
-* Axom or the Inlet component is no longer required to support C++11
-*
-* \tparam T The type to construct
-* \tparam Args The variadic argument list to forward to T's constructor
-*
-* \return A unique ptr constructed with the given arguments
-*****************************************************************************
-*/
-template <typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args&&... args)
-{
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
-
-}  // namespace cpp11_compat
-
 }  // namespace inlet
 }  // namespace axom
 


### PR DESCRIPTION
This removes the now unneeded `cpp11_compat::make_unique`. 