### PR TITLE
Guard Sol State and Sol header

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -104,6 +104,10 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   move the array to host memory, and will instead maintain the same allocator ID as the source array.
 - The device traversal method `BVH::TraverserType::traverse_tree()` now supports passing in arbitrary query objects
   for BVH traversal.
+- Moved `inlet::LuaReader::solState()` to be a protected function that now returns a `std::shared_ptr<axom::sol::state>`.
+  This is an advanced feature that could cause users to break an input file state after verification. This also alows us
+  to not expose `axom/sol.hpp` to all users of Inlet. This greatly reduces compile times. Using this feature requires
+  both a derived class and including `axom/sol.hpp` in the user code.
 
 ###  Fixed
 - Fixed a bug relating to swap and assignment operations for multidimensional `axom::Array`s

--- a/src/axom/inlet/LuaReader.cpp
+++ b/src/axom/inlet/LuaReader.cpp
@@ -22,6 +22,14 @@
 #include "axom/fmt.hpp"
 #include "axom/slic.hpp"
 
+#include "axom/sol.hpp"
+
+extern "C" {
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
+}
+
 namespace axom
 {
 namespace inlet
@@ -101,11 +109,12 @@ void nameRetrievalHelper(const std::vector<std::string>& ignores,
 
 LuaReader::LuaReader()
 {
-  m_lua.open_libraries(axom::sol::lib::base,
-                       axom::sol::lib::math,
-                       axom::sol::lib::string,
-                       axom::sol::lib::package);
-  auto vec_type = m_lua.new_usertype<FunctionType::Vector>(
+  m_lua = std::make_shared<axom::sol::state>();
+  m_lua->open_libraries(axom::sol::lib::base,
+                        axom::sol::lib::math,
+                        axom::sol::lib::string,
+                        axom::sol::lib::package);
+  auto vec_type = m_lua->new_usertype<FunctionType::Vector>(
     "Vector",  // Name of the class in Lua
     // Add make_vector as a constructor to enable "new Vector(x,y,z)"
     // Use lambdas for 2D and "default" cases - default arguments cannot be
@@ -196,7 +205,7 @@ LuaReader::LuaReader()
   // Pass the preloaded globals as both the set to ignore and the set to add
   // to, such that only the top-level preloaded globals are added
   detail::nameRetrievalHelper(m_preloaded_globals,
-                              m_lua.globals(),
+                              m_lua->globals(),
                               "",
                               m_preloaded_globals);
 }
@@ -210,7 +219,7 @@ bool LuaReader::parseFile(const std::string& filePath)
     return false;
   }
 
-  auto script = m_lua.script_file(filePath);
+  auto script = m_lua->script_file(filePath);
   if(!script.valid())
   {
     SLIC_WARNING(
@@ -226,7 +235,7 @@ bool LuaReader::parseString(const std::string& luaString)
     SLIC_WARNING("Inlet: Given an empty Lua string to parse.");
     return false;
   }
-  m_lua.script(luaString);
+  m_lua->script(luaString);
   return true;
 }
 
@@ -311,12 +320,12 @@ bool LuaReader::traverseToTable(Iter begin, Iter end, axom::sol::table& table)
     return true;
   }
 
-  if(!m_lua[*begin].valid())
+  if(!(*m_lua)[*begin].valid())
   {
     return false;
   }
 
-  table = m_lua[*begin];  // Use the first one to index into the global lua state
+  table = (*m_lua)[*begin];  // Use the first one to index into the global lua state
   ++begin;
 
   // Then use the remaining keys to walk down to the requested table
@@ -544,9 +553,9 @@ ReaderResult LuaReader::getValue(const std::string& id, T& value)
 
   if(tokens.size() == 1)
   {
-    if(m_lua[tokens[0]].valid())
+    if((*m_lua)[tokens[0]].valid())
     {
-      return detail::checkedGet(m_lua[tokens[0]], value);
+      return detail::checkedGet((*m_lua)[tokens[0]], value);
     }
     return ReaderResult::NotFound;
   }
@@ -567,7 +576,7 @@ ReaderResult LuaReader::getValue(const std::string& id, T& value)
 std::vector<std::string> LuaReader::getAllNames()
 {
   std::vector<std::string> result;
-  detail::nameRetrievalHelper(m_preloaded_globals, m_lua.globals(), "", result);
+  detail::nameRetrievalHelper(m_preloaded_globals, m_lua->globals(), "", result);
   return result;
 }
 
@@ -650,10 +659,10 @@ axom::sol::protected_function LuaReader::getFunctionInternal(const std::string& 
 
   if(tokens.size() == 1)
   {
-    if(m_lua[tokens[0]].valid())
+    if((*m_lua)[tokens[0]].valid())
     {
-      lua_func = m_lua[tokens[0]];
-      detail::checkedGet(m_lua[tokens[0]], lua_func);
+      lua_func = (*m_lua)[tokens[0]];
+      detail::checkedGet((*m_lua)[tokens[0]], lua_func);
     }
   }
   else

--- a/src/axom/inlet/LuaReader.cpp
+++ b/src/axom/inlet/LuaReader.cpp
@@ -325,7 +325,8 @@ bool LuaReader::traverseToTable(Iter begin, Iter end, axom::sol::table& table)
     return false;
   }
 
-  table = (*m_lua)[*begin];  // Use the first one to index into the global lua state
+  // Use the first one to index into the global lua state
+  table = (*m_lua)[*begin];
   ++begin;
 
   // Then use the remaining keys to walk down to the requested table

--- a/src/axom/inlet/LuaReader.hpp
+++ b/src/axom/inlet/LuaReader.hpp
@@ -15,16 +15,19 @@
 #define INLET_LUAMAP_HPP
 
 #include "axom/inlet/Reader.hpp"
-#include "axom/sol.hpp"
-
-extern "C" {
-#include "lua.h"
-#include "lualib.h"
-#include "lauxlib.h"
-}
+#include "axom/sol_forward.hpp"
 
 namespace axom
 {
+
+// Forward declarations to avoid having to include "sol.hpp" in everything
+// that depends on Inlet
+namespace sol
+{
+class state;
+enum class type;
+}
+
 namespace inlet
 {
 /*!
@@ -97,11 +100,15 @@ public:
    * \brief Returns the Sol Lua state
    *
    * This allows the user to access functionality that was not provided by Inlet.
+   * 
+   * \note This is an advanced feature. If you need to modify the Sol `state`,
+   *   be sure to include `axom/sol/sol.hpp`. This is to avoid incuring large
+   *   compile times to all users of Inlet.
    *
-   * \return Reference to the Sol Lua state
+   * \return Shared pointer to the Sol Lua state
    *****************************************************************************
    */
-  axom::sol::state& solState() { return m_lua; }
+  std::shared_ptr<axom::sol::state> solState() { return m_lua; }
 
 private:
   // Expect this to be called for only Inlet-supported types.
@@ -149,7 +156,8 @@ private:
    */
   axom::sol::protected_function getFunctionInternal(const std::string& id);
 
-  axom::sol::state m_lua;
+  std::shared_ptr<axom::sol::state> m_lua;
+
   // The elements in the global table preloaded by Sol/Lua, these are ignored
   // to ensure that name retrieval only includes user-provided paths
   std::vector<std::string> m_preloaded_globals;

--- a/src/axom/inlet/LuaReader.hpp
+++ b/src/axom/inlet/LuaReader.hpp
@@ -19,14 +19,13 @@
 
 namespace axom
 {
-
 // Forward declarations to avoid having to include "sol.hpp" in everything
 // that depends on Inlet
 namespace sol
 {
 class state;
 enum class type;
-}
+}  // namespace sol
 
 namespace inlet
 {
@@ -95,15 +94,18 @@ public:
    */
   static const int baseIndex = 1;
 
+protected:
   /*!
    *****************************************************************************
    * \brief Returns the Sol Lua state
    *
    * This allows the user to access functionality that was not provided by Inlet.
    * 
-   * \note This is an advanced feature. If you need to modify the Sol `state`,
-   *   be sure to include `axom/sol/sol.hpp`. This is to avoid incuring large
-   *   compile times to all users of Inlet.
+   * \note This is an advanced feature and could change the input file state after
+   *   it has been validated by Inlet. If you need to modify the Sol `state`,
+   *   be sure to include `axom/sol.hpp` and derive a new class to access this
+   *   publically. See the `lua_library.cpp` example. Including `sol.hpp` can
+   *   increase compile time significantly.
    *
    * \return Shared pointer to the Sol Lua state
    *****************************************************************************

--- a/src/axom/inlet/docs/sphinx/readers.rst
+++ b/src/axom/inlet/docs/sphinx/readers.rst
@@ -57,7 +57,7 @@ reader class here:
 Inlet opens four Lua libraries by default: ``base``, ``math``, ``string``, ``package``. All libraries are documented
 in `Sol's open_library documentation <https://sol2.readthedocs.io/en/v2.20.6/api/state.html?highlight=open_libraries#enumerations>`_. 
 
-For example, you can add the `io` library by doing this:
+For example, you can add the ``io`` library by doing this:
 
 .. literalinclude:: ../../examples/lua_library.cpp
    :start-after: _inlet_io_library_add_start

--- a/src/axom/inlet/docs/sphinx/readers.rst
+++ b/src/axom/inlet/docs/sphinx/readers.rst
@@ -40,11 +40,22 @@ Below is a table that lists supported features:
      - 
 
 ***********************
-Extra Lua functionality
+Extra Lua Functionality
 ***********************
 
-Inlet opens four Lua libraries by default: ``base``, ``math``, ``string``, ``package``.  All libraries are
-documented `here <https://sol2.readthedocs.io/en/v2.20.6/api/state.html?highlight=open_libraries#enumerations>`_. 
+The `LuaReader` class has the ability to access the entire Lua State via the protected member function
+``LuaReader::solState()``.  This allows you fully utilize the Sol library, documented in
+`Sol's documentation <https://sol2.readthedocs.io/en/v2.20.6/index.html>`_. This is an advanced feature
+and not recommended unless there is a good reason.  We provide an example on how to create a derived
+reader class here:
+
+.. literalinclude:: ../../examples/lua_library.cpp
+   :start-after: _inlet_sol_state_start
+   :end-before: _inlet_sol_state_end
+   :language: C++
+
+Inlet opens four Lua libraries by default: ``base``, ``math``, ``string``, ``package``. All libraries are documented
+in `Sol's open_library documentation <https://sol2.readthedocs.io/en/v2.20.6/api/state.html?highlight=open_libraries#enumerations>`_. 
 
 For example, you can add the `io` library by doing this:
 

--- a/src/axom/inlet/examples/lua_library.cpp
+++ b/src/axom/inlet/examples/lua_library.cpp
@@ -12,6 +12,7 @@
 #include "axom/slic/core/SimpleLogger.hpp"
 
 // _inlet_sol_state_start
+// Header required here because `axom::sol::state` is only forward declared in LuaReader.hpp.
 #include "axom/sol.hpp"
 
 class SolStateReader : public axom::inlet::LuaReader

--- a/src/axom/inlet/examples/lua_library.cpp
+++ b/src/axom/inlet/examples/lua_library.cpp
@@ -9,6 +9,7 @@
 #include <stdio.h>
 
 #include "axom/inlet.hpp"
+#include "axom/sol.hpp"
 #include "axom/slic/core/SimpleLogger.hpp"
 
 int main()
@@ -37,7 +38,7 @@ int main()
   auto lr = std::make_unique<axom::inlet::LuaReader>();
 
   // Load extra io Lua library
-  lr->solState().open_libraries(axom::sol::lib::io);
+  lr->solState()->open_libraries(axom::sol::lib::io);
 
   // Parse example input string
   lr->parseString(input);

--- a/src/axom/inlet/examples/lua_library.cpp
+++ b/src/axom/inlet/examples/lua_library.cpp
@@ -9,8 +9,17 @@
 #include <stdio.h>
 
 #include "axom/inlet.hpp"
-#include "axom/sol.hpp"
 #include "axom/slic/core/SimpleLogger.hpp"
+
+// _inlet_sol_state_start
+#include "axom/sol.hpp"
+
+class SolStateReader : public axom::inlet::LuaReader
+{
+public:
+  using LuaReader::solState;
+};
+// _inlet_sol_state_end
 
 int main()
 {
@@ -35,20 +44,20 @@ int main()
 
   // _inlet_io_library_add_start
   // Create Inlet Reader that supports Lua input files
-  auto lr = std::make_unique<axom::inlet::LuaReader>();
+  auto reader = std::make_unique<SolStateReader>();
 
   // Load extra io Lua library
-  lr->solState()->open_libraries(axom::sol::lib::io);
+  reader->solState()->open_libraries(axom::sol::lib::io);
 
   // Parse example input string
-  lr->parseString(input);
+  reader->parseString(input);
   // _inlet_io_library_add_end
 
   // Inlet stores all input information in the Sidre DataStore
   axom::sidre::DataStore ds;
 
   // Create Inlet with LuaReader and the Sidre Group which Inlet will use
-  axom::inlet::Inlet myinlet(std::move(lr), ds.getRoot());
+  axom::inlet::Inlet myinlet(std::move(reader), ds.getRoot());
 
   // Define and store the values in the input file
   myinlet.addFunction("read_str",

--- a/src/axom/inlet/tests/inlet_function.cpp
+++ b/src/axom/inlet/tests/inlet_function.cpp
@@ -9,6 +9,8 @@
 #include "axom/inlet/LuaReader.hpp"
 #include "axom/inlet/Inlet.hpp"
 
+#include "axom/sol.hpp"
+
 #include "gtest/gtest.h"
 
 #include <array>
@@ -511,7 +513,7 @@ TEST(inlet_function_usertype, lua_usertype_basic)
   std::string testString = "function func(vec) return 7 end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec {1, 2, 3};
   int result = checkedCall<int>(func, vec);
   EXPECT_EQ(result, 7);
@@ -523,7 +525,7 @@ TEST(inlet_function_usertype, lua_usertype_basic_ret)
     "function func(x, y, z) return Vector.new(x, y, z) end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec {1, 2, 3};
   auto result = checkedCall<axom::inlet::FunctionType::Vector>(func, 1, 2, 3);
   EXPECT_EQ(vec, result);
@@ -534,7 +536,7 @@ TEST(inlet_function_usertype, lua_usertype_basic_ret_2d)
   std::string testString = "function func(x, y, z) return Vector.new(x, y) end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec {1, 2};
   auto result = checkedCall<axom::inlet::FunctionType::Vector>(func, 1, 2, 3);
   EXPECT_EQ(vec, result);
@@ -545,7 +547,7 @@ TEST(inlet_function_usertype, lua_usertype_basic_ret_default)
   std::string testString = "function func(x, y, z) return Vector.new() end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec {0, 0, 0};
   auto result = checkedCall<axom::inlet::FunctionType::Vector>(func, 1, 2, 3);
   EXPECT_EQ(vec, result);
@@ -556,7 +558,7 @@ TEST(inlet_function_usertype, lua_usertype_basic_add)
   std::string testString = "function func(vec1, vec2) return vec1 + vec2 end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec1 {1, 2, 3};
   axom::inlet::FunctionType::Vector vec2 {4, 5, 6};
   const axom::inlet::FunctionType::Vector sum {5, 7, 9};
@@ -569,7 +571,7 @@ TEST(inlet_function_usertype, lua_usertype_basic_sub)
   std::string testString = "function func(vec1, vec2) return vec1 - vec2 end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec1 {1, 2, 3};
   axom::inlet::FunctionType::Vector vec2 {4, 5, 6};
   const axom::inlet::FunctionType::Vector difference {-3, -3, -3};
@@ -582,7 +584,7 @@ TEST(inlet_function_usertype, lua_usertype_basic_negate)
   std::string testString = "function func(vec) return -vec end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec {1, 2, 3};
   const axom::inlet::FunctionType::Vector negated {-1, -2, -3};
   auto result = checkedCall<axom::inlet::FunctionType::Vector>(func, vec);
@@ -596,8 +598,8 @@ TEST(inlet_function_usertype, lua_usertype_basic_scalar_mult)
     "x * vec end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func1 = lr.solState()["func1"];
-  axom::sol::protected_function func2 = lr.solState()["func2"];
+  axom::sol::protected_function func1 = (*lr.solState())["func1"];
+  axom::sol::protected_function func2 = (*lr.solState())["func2"];
   axom::inlet::FunctionType::Vector vec {1, 2, 3};
   const axom::inlet::FunctionType::Vector doubled {2, 4, 6};
   auto result = checkedCall<axom::inlet::FunctionType::Vector>(func1, vec, 2.0);
@@ -612,7 +614,7 @@ TEST(inlet_function_usertype, lua_usertype_basic_index_get)
   std::string testString = "function func(vec, idx) return vec[idx] end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec {1, 2, 3};
   // Use 1-based indexing in these tests as lua is 1-indexed
   auto result = checkedCall<double>(func, vec, 1);
@@ -629,7 +631,7 @@ TEST(inlet_function_usertype, lua_usertype_basic_index_set)
     "function func(idx) vec = Vector.new(1,1,1); vec[idx] = -1; return vec end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   auto result = checkedCall<axom::inlet::FunctionType::Vector>(func, 1);
   EXPECT_FLOAT_EQ(-1, result[0]);
   result = checkedCall<axom::inlet::FunctionType::Vector>(func, 2);
@@ -643,7 +645,7 @@ TEST(inlet_function_usertype, lua_usertype_basic_norm)
   std::string testString = "function func(vec) return vec:norm() end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec {1, 2, 3};
   const double l2_norm = std::sqrt((1 * 1) + (2 * 2) + (3 * 3));
   auto result = checkedCall<double>(func, vec);
@@ -655,7 +657,7 @@ TEST(inlet_function_usertype, lua_usertype_basic_squared_norm)
   std::string testString = "function func(vec) return vec:squared_norm() end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec {1, 2, 3};
   const double squared_l2_norm = (1 * 1) + (2 * 2) + (3 * 3);
   auto result = checkedCall<double>(func, vec);
@@ -667,7 +669,7 @@ TEST(inlet_function_usertype, lua_usertype_basic_unit_vec)
   std::string testString = "function func(vec) return vec:unitVector() end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec {1, 2, 3};
   const double l2_norm = std::sqrt((1 * 1) + (2 * 2) + (3 * 3));
   const axom::inlet::FunctionType::Vector unit {1 / l2_norm,
@@ -683,7 +685,7 @@ TEST(inlet_function_usertype, lua_usertype_basic_dot)
     "function func(vec1, vec2) return vec1:dot(vec2) end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec1 {1, 2, 3};
   axom::inlet::FunctionType::Vector vec2 {4, 5, 6};
   const double dot = (1 * 4) + (2 * 5) + (3 * 6);
@@ -697,7 +699,7 @@ TEST(inlet_function_usertype, lua_usertype_basic_cross)
     "function func(vec1, vec2) return vec1:cross(vec2) end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec1 {1, 2, 3};
   axom::inlet::FunctionType::Vector vec2 {4, 5, 6};
   const double i = (2 * 6) - (3 * 5);
@@ -713,7 +715,7 @@ TEST(inlet_function_usertype, lua_usertype_check_dim)
   std::string testString = "function func(vec) return vec.dim end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec1 {1, 2, 3};
   axom::inlet::FunctionType::Vector vec2 {4, 5};
   auto result = checkedCall<double>(func, vec1);
@@ -730,7 +732,7 @@ TEST(inlet_function_usertype, lua_usertype_named_access)
     "then return vec.y else return vec.z end end";
   LuaReader lr;
   lr.parseString(testString);
-  axom::sol::protected_function func = lr.solState()["func"];
+  axom::sol::protected_function func = (*lr.solState())["func"];
   axom::inlet::FunctionType::Vector vec1 {4, 5, 6};
   auto result = checkedCall<double>(func, vec1, 1);
   EXPECT_EQ(result, 4);

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -13,7 +13,7 @@
 
 if (LUA_FOUND)
   blt_add_library(NAME    sol
-                  HEADERS axom/sol.hpp)
+                  HEADERS axom/sol.hpp axom/sol_forward.hpp)
 
   target_include_directories(sol SYSTEM INTERFACE
               $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/thirdparty>)
@@ -22,6 +22,7 @@ if (LUA_FOUND)
           EXPORT               axom-targets
           INCLUDES DESTINATION include)
   install(FILES        ${PROJECT_SOURCE_DIR}/thirdparty/axom/sol.hpp
+                       ${PROJECT_SOURCE_DIR}/thirdparty/axom/sol_forward.hpp
           DESTINATION include/axom )
   install(EXPORT axom-targets DESTINATION lib/cmake)
 

--- a/src/thirdparty/axom/sol_forward.hpp
+++ b/src/thirdparty/axom/sol_forward.hpp
@@ -1,0 +1,374 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013-2018 Rapptz, ThePhD and contributors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// This file was generated with a script.
+// Generated 2018-11-28 08:50:22.827662 UTC
+// This header was generated with sol v2.20.6 (revision 9b782ff)
+// https://github.com/ThePhD/sol2
+
+#ifndef SOL_SINGLE_INCLUDE_FORWARD_HPP
+#define SOL_SINGLE_INCLUDE_FORWARD_HPP
+
+// beginning of sol/forward.hpp
+
+// beginning of sol/feature_test.hpp
+
+// start axom change
+#define SOL_CXX17_FEATURES 0
+
+/*
+#if (defined(__cplusplus) && __cplusplus == 201703L) || (defined(_MSC_VER) && _MSC_VER > 1900 && ((defined(_HAS_CXX17) && _HAS_CXX17 == 1) || (defined(_MSVC_LANG) && (_MSVC_LANG > 201402L))))
+#ifndef SOL_CXX17_FEATURES
+#define SOL_CXX17_FEATURES 1
+#endif // C++17 features macro
+#endif // C++17 features check
+*/
+// end axom change
+
+#if defined(SOL_CXX17_FEATURES) && SOL_CXX17_FEATURES
+#if defined(__cpp_noexcept_function_type) || ((defined(_MSC_VER) && _MSC_VER > 1911) && (defined(_MSVC_LANG) && ((_MSVC_LANG >= 201403L))))
+#ifndef SOL_NOEXCEPT_FUNCTION_TYPE
+#define SOL_NOEXCEPT_FUNCTION_TYPE 1
+#endif // noexcept is part of a function's type
+#endif // compiler-specific checks
+#if defined(__clang__) && defined(__APPLE__)
+#if defined(__has_include)
+#if __has_include(<variant>)
+#define SOL_STD_VARIANT 1
+#endif // has include nonsense
+#endif // __has_include
+#else
+#define SOL_STD_VARIANT 1
+#endif // Clang screws up variant
+#endif // C++17 only
+
+// beginning of sol/config.hpp
+
+#ifdef _MSC_VER
+	#if defined(_DEBUG) && !defined(NDEBUG)
+
+	#ifndef SOL_IN_DEBUG_DETECTED
+	#define SOL_IN_DEBUG_DETECTED 1
+	#endif
+
+	#endif // VC++ Debug macros
+
+	#ifndef _CPPUNWIND
+	#ifndef SOL_NO_EXCEPTIONS
+	#define SOL_NO_EXCEPTIONS 1
+	#endif
+	#endif // Automatic Exceptions
+
+	#ifndef _CPPRTTI
+	#ifndef SOL_NO_RTTI
+	#define SOL_NO_RTTI 1
+	#endif
+	#endif // Automatic RTTI
+#elif defined(__GNUC__) || defined(__clang__)
+
+	#if !defined(NDEBUG) && !defined(__OPTIMIZE__)
+
+	#ifndef SOL_IN_DEBUG_DETECTED
+	#define SOL_IN_DEBUG_DETECTED 1
+	#endif
+
+	#endif // Not Debug && g++ optimizer flag
+
+	#ifndef __EXCEPTIONS
+	#ifndef SOL_NO_EXCEPTIONS
+	#define SOL_NO_EXCEPTIONS 1
+	#endif
+	#endif // No Exceptions
+
+	#ifndef __GXX_RTTI
+	#ifndef SOL_NO_RTII
+	#define SOL_NO_RTTI 1
+	#endif
+	#endif // No RTTI
+
+#endif // vc++ || clang++/g++
+
+#if defined(SOL_CHECK_ARGUMENTS) && SOL_CHECK_ARGUMENTS
+
+	// Checks low-level getter function
+	// (and thusly, affects nearly entire framework)
+	#if !defined(SOL_SAFE_GETTER)
+	#define SOL_SAFE_GETTER 1
+	#endif
+
+	// Checks access on usertype functions
+	// local my_obj = my_type.new()
+	// my_obj.my_member_function()
+	// -- bad syntax and crash
+	#if !defined(SOL_SAFE_USERTYPE)
+	#define SOL_SAFE_USERTYPE 1
+	#endif
+
+	// Checks sol::reference derived boundaries
+	// sol::function ref(L, 1);
+	// sol::userdata sref(L, 2);
+	#if !defined(SOL_SAFE_REFERENCES)
+	#define SOL_SAFE_REFERENCES 1
+	#endif
+
+	// Changes all typedefs of sol::function to point to the 
+	// protected_function version, instead of unsafe_function
+	#if !defined(SOL_SAFE_FUNCTION)
+	#define SOL_SAFE_FUNCTION 1
+	#endif
+
+	// Checks function parameters and
+	// returns upon call into/from Lua
+	// local a = 1
+	// local b = "woof"
+	// my_c_function(a, b)
+	#if !defined(SOL_SAFE_FUNCTION_CALLS)
+	#define SOL_SAFE_FUNCTION_CALLS 1
+	#endif
+
+	// Checks conversions
+	// int v = lua["bark"];
+	// int v2 = my_sol_function();
+	#if !defined(SOL_SAFE_PROXIES)
+	#define SOL_SAFE_PROXIES 1
+	#endif
+
+	// Check overflowing number conversions
+	// for things like 64 bit integers that don't fit in a typical lua_Number
+	// for Lua 5.1 and 5.2
+	#if !defined(SOL_SAFE_NUMERICS)
+	#define SOL_SAFE_NUMERICS 1
+	#endif
+
+	// Turn off Number Precision Checks
+	// if this is defined, we do not do range 
+	// checks on integers / unsigned integers that might
+	// be bigger than what Lua can represent
+	#if !defined(SOL_NO_CHECK_NUMBER_PRECISION)
+	// off by default
+	#define SOL_NO_CHECK_NUMBER_PRECISION 0
+	#endif
+
+#endif // Turn on Safety for all if top-level macro is defined
+
+#if defined(SOL_IN_DEBUG_DETECTED) && SOL_IN_DEBUG_DETECTED
+
+	#if !defined(SOL_SAFE_REFERENCES)
+	// Ensure that references are forcefully type-checked upon construction
+	#define SOL_SAFE_REFERENCES 1
+	#endif
+
+	// Safe usertypes checks for errors such as
+	// obj = my_type.new()
+	// obj.f() -- note the '.' instead of ':'
+	// usertypes should be safe no matter what
+	#if !defined(SOL_SAFE_USERTYPE)
+	#define SOL_SAFE_USERTYPE 1
+	#endif
+
+	#if !defined(SOL_SAFE_FUNCTION_CALLS)
+	// Function calls from Lua should be automatically safe in debug mode
+	#define SOL_SAFE_FUNCTION_CALLS 1
+	#endif
+
+	// Print any exceptions / errors that occur
+	// in debug mode to the default error stream / console
+	#if !defined(SOL_PRINT_ERRORS)
+	#define SOL_PRINT_ERRORS 1
+	#endif
+
+#endif // DEBUG: Turn on all debug safety features for VC++ / g++ / clang++ and similar
+
+#if !defined(SOL_PRINT_ERRORS)
+#define SOL_PRINT_ERRORS 0
+#endif
+
+#if !defined(SOL_DEFAULT_PASS_ON_ERROR)
+#define SOL_DEFAULT_PASS_ON_ERROR 0
+#endif
+
+#if !defined(SOL_ENABLE_INTEROP)
+#define SOL_ENABLE_INTEROP 0
+#endif
+
+#if defined(__MAC_OS_X_VERSION_MAX_ALLOWED) || defined(__OBJC__) || defined(nil)
+#if !defined(SOL_NO_NIL)
+#define SOL_NO_NIL 1
+#endif
+#endif // avoiding nil defines / keywords
+
+#if defined(SOL_USE_BOOST) && SOL_USE_BOOST
+#ifndef SOL_UNORDERED_MAP_COMPATIBLE_HASH
+#define SOL_UNORDERED_MAP_COMPATIBLE_HASH 1
+#endif // SOL_UNORDERED_MAP_COMPATIBLE_HASH
+#endif 
+
+#ifndef SOL_STACK_STRING_OPTIMIZATION_SIZE
+#define SOL_STACK_STRING_OPTIMIZATION_SIZE 1024
+#endif // Optimized conversion routines using a KB or so off the stack
+
+// end of sol/config.hpp
+
+// beginning of sol/config_setup.hpp
+
+// end of sol/config_setup.hpp
+
+// end of sol/feature_test.hpp
+
+namespace axom {
+namespace sol {
+
+	template <bool b>
+	class basic_reference;
+	using reference = basic_reference<false>;
+	using main_reference = basic_reference<true>;
+	class stack_reference;
+
+	struct proxy_base_tag;
+	template <typename Super>
+	struct proxy_base;
+	template <typename Table, typename Key>
+	struct proxy;
+
+	template <typename T>
+	class usertype;
+	template <typename T>
+	class simple_usertype;
+	template <bool, typename T>
+	class basic_table_core;
+	template <bool b>
+	using table_core = basic_table_core<b, reference>;
+	template <bool b>
+	using main_table_core = basic_table_core<b, main_reference>;
+	template <bool b>
+	using stack_table_core = basic_table_core<b, stack_reference>;
+	template <typename T>
+	using basic_table = basic_table_core<false, T>;
+	typedef table_core<false> table;
+	typedef table_core<true> global_table;
+	typedef main_table_core<false> main_table;
+	typedef main_table_core<true> main_global_table;
+	typedef stack_table_core<false> stack_table;
+	typedef stack_table_core<true> stack_global_table;
+	template <typename base_t>
+	struct basic_environment;
+	using environment = basic_environment<reference>;
+	using main_environment = basic_environment<main_reference>;
+	using stack_environment = basic_environment<stack_reference>;
+	template <typename T, bool>
+	class basic_function;
+	template <typename T, bool, typename H>
+	class basic_protected_function;
+	using unsafe_function = basic_function<reference, false>;
+	using safe_function = basic_protected_function<reference, false, reference>;
+	using main_unsafe_function = basic_function<main_reference, false>;
+	using main_safe_function = basic_protected_function<main_reference, false, reference>;
+	using stack_unsafe_function = basic_function<stack_reference, false>;
+	using stack_safe_function = basic_protected_function<stack_reference, false, reference>;
+	using stack_aligned_unsafe_function = basic_function<stack_reference, true>;
+	using stack_aligned_safe_function = basic_protected_function<stack_reference, true, reference>;
+	using protected_function = safe_function;
+	using main_protected_function = main_safe_function;
+	using stack_protected_function = stack_safe_function;
+	using stack_aligned_protected_function = stack_aligned_safe_function;
+#if defined(SOL_SAFE_FUNCTION) && SOL_SAFE_FUNCTION
+	using function = protected_function;
+	using main_function = main_protected_function;
+	using stack_function = stack_protected_function;
+#else
+	using function = unsafe_function;
+	using main_function = main_unsafe_function;
+	using stack_function = stack_unsafe_function;
+#endif
+	using stack_aligned_function = stack_aligned_unsafe_function;
+	using stack_aligned_stack_handler_function = basic_protected_function<stack_reference, true, stack_reference>;
+
+	struct unsafe_function_result;
+	struct protected_function_result;
+	using safe_function_result = protected_function_result;
+#if defined(SOL_SAFE_FUNCTION) && SOL_SAFE_FUNCTION
+	using function_result = safe_function_result;
+#else
+	using function_result = unsafe_function_result;
+#endif
+
+	template <typename base_t>
+	class basic_object;
+	template <typename base_t>
+	class basic_userdata;
+	template <typename base_t>
+	class basic_lightuserdata;
+	template <typename base_t>
+	class basic_coroutine;
+	template <typename base_t>
+	class basic_thread;
+
+	using object = basic_object<reference>;
+	using userdata = basic_userdata<reference>;
+	using lightuserdata = basic_lightuserdata<reference>;
+	using thread = basic_thread<reference>;
+	using coroutine = basic_coroutine<reference>;
+	using main_object = basic_object<main_reference>;
+	using main_userdata = basic_userdata<main_reference>;
+	using main_lightuserdata = basic_lightuserdata<main_reference>;
+	using main_coroutine = basic_coroutine<main_reference>;
+	using stack_object = basic_object<stack_reference>;
+	using stack_userdata = basic_userdata<stack_reference>;
+	using stack_lightuserdata = basic_lightuserdata<stack_reference>;
+	using stack_thread = basic_thread<stack_reference>;
+	using stack_coroutine = basic_coroutine<stack_reference>;
+
+	struct stack_proxy_base;
+	struct stack_proxy;
+	struct variadic_args;
+	struct variadic_results;
+	struct stack_count;
+	struct this_state;
+	struct this_main_state;
+	struct this_environment;
+
+	template <typename T>
+	struct as_table_t;
+	template <typename T>
+	struct as_container_t;
+	template <typename T>
+	struct nested;
+	template <typename T>
+	struct light;
+	template <typename T>
+	struct user;
+	template <typename T>
+	struct as_args_t;
+	template <typename T>
+	struct protect_t;
+	template <typename F, typename... Filters>
+	struct filter_wrapper;
+
+	template <typename T>
+	struct usertype_traits;
+	template <typename T>
+	struct unique_usertype_traits;
+} // namespace sol
+} // namespace axom
+
+// end of sol/forward.hpp
+
+#endif // SOL_SINGLE_INCLUDE_FORWARD_HPP


### PR DESCRIPTION
`sol.hpp` is a very heavily templated header.  This causes large compile times of any users of Inlet. We originally exposed the Sol `state` class for a user but that never went anywhere.

This moves the `LuaReader::solState()` getter to protected in case someone does want it and documents it that they need to derive there own class and include `sol.hpp` in their own code.

**Axom Build Times**
develop: 2m08s
This branch: 1m51s