### PR TITLE
Adds scattered interpolation capability to quest

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -34,12 +34,12 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Add `const` versions of `begin()` and `end()` for `Array` and `ArrayView`
 - Add support for passing compatible custom allocator IDs to `axom::Array` with explicitly specified
   memory space
-- Adds constructor overloads to `axom::Array` that uses both uninitialized data (`ArrayOptions::Uninitialized`) 
+- Adds constructor overloads to `axom::Array` that uses both uninitialized data (`ArrayOptions::Uninitialized`)
   and custom allocators
 - Adds a comparison operator (`operator<()`) to `StackArray`. This allows it to be used as a key for `std::map`
 - Use compiler intrinsics for axom's bit utility functions: `popCount()`, `trailingZeros()` and `leadingZeros()`
 - Adds a random-access iterator to `slam::DynamicSet`
-- Adds an overload to `ImpicitGrid::getCandidates()` from a grid cell of the lattice. 
+- Adds an overload to `ImpicitGrid::getCandidates()` from a grid cell of the lattice.
   This makes it easier to iterate over the bins of the spatial index.
 - Defines iterator traits on `axom::Array<T>`/`ArrayView<T>` iterators, to allow passing iterator
   pairs to standard library functions
@@ -68,6 +68,10 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   without constructing or initializing new elements
 - Adds examples and tests for using Slic interface in Fortran
 - Adds examples for using the BVH device traversal API
+- Adds a `ScatteredInterpolation` query to quest, which enables interpolating scalar fields at arbitrary
+  points from a given 2D or 3D point mesh in the Mesh Blueprint format. The current implementation
+  generates a Deluanay complex over the points and performs linear interpolation over the
+  triangle/tetrahedron at the query points.
 
 ###  Changed
 - Axom now requires C++14 and will default to that if not specified via `BLT_CXX_STD`.
@@ -83,13 +87,13 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   corresponding range/set of valid values are now included in the error message
 - IOManager::write now allows the calling code to pass in the full name of
   the root file that it will produce
-- Improved consistency of orientation operations in `primal::Plane`, `primal::Sphere`, `primal::orientation()` 
+- Improved consistency of orientation operations in `primal::Plane`, `primal::Sphere`, `primal::orientation()`
   and `primal::in_sphere()`
-- Improved efficiency for `primal::in_sphere()` -- the computations are now based on `(D+1)x(D+1)` determinants 
-  instead of `(D+2)x(D+2)` determinants for `D`-dimensional spheres 
+- Improved efficiency for `primal::in_sphere()` -- the computations are now based on `(D+1)x(D+1)` determinants
+  instead of `(D+2)x(D+2)` determinants for `D`-dimensional spheres
 - Improved efficiency for (signed) area/volume functions of `primal::Segment`, `primal::Triangle` and `primal::Tetrahedron`
 - Updates interface for `primal::Sphere` to use more of `primal`, e.g. uses `primal::Point` instead of `T*` to represent points
-- Adds `circumsphere()` functions to `primal::Triangle` and `primal::Tetrahedron` to return the `Sphere` 
+- Adds `circumsphere()` functions to `primal::Triangle` and `primal::Tetrahedron` to return the `Sphere`
   that circumscribes the triangle/tetrahedron's vertices
 - Adds operator overloads to subtract a `primal::Vector` from a `primal::Point` to yield a new `primal::Point`
 - Consolidates `quest::findTriMeshIntersections*()` implementations for `BVH` and `ImplicitGrid`
@@ -167,10 +171,10 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   portion of the segment contained within the BoundingBox (when the intersection exists)
 - Generalizes Quest's `InOutOctree` class to work with 2D line segment meshes. Previously,
   it only worked with 3D triangle meshes
-- Added support for reading `c2c` ".contour" files in Quest. Contours that enclose a 2D region can be linearized 
+- Added support for reading `c2c` ".contour" files in Quest. Contours that enclose a 2D region can be linearized
   into line segment meshes and loaded into Quest's `InOutOctree` for in/out queries.
 - Updated the Quest `inout` C API to support 2D queries using the `c2c` library, when Axom is configured with `c2c`
-- Updated the C++ Quest "containment" example to support 2D in/out queries 
+- Updated the C++ Quest "containment" example to support 2D in/out queries
   (in addition to the already supported 3D queries)
 - Added `axom::Array` modeled after `std::vector`. Previous `axom::Array` renamed to `axom::MCArray`. Future changes to both arrays are expected.
 - Added a `data_collection_util` tool to generate Mesh Blueprint compliant high order distributed meshes from
@@ -224,14 +228,14 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   enables signed-distance queries to run on the GPU, as specified via a new template
   parameter.
 - Spin: Removed `BVHTree` class in favor of `BVH`.
-- Quest's `signed_distance` C API: Removed functions related to old `BVHTree` class 
+- Quest's `signed_distance` C API: Removed functions related to old `BVHTree` class
   and added functions related to `BVH` class
     * Removed: `void signed_distance_set_max_levels( int maxLevels )`
     * Removed: `void signed_distance_set_max_occupancy( int maxOccupancy )`
     * Added: `void signed_distance_set_allocator( int allocatorID )`
     * Added: `void signed_distance_set_execution_space( SignedDistExec execSpace )`
 - All built-in third-party libraries (`fmt`, `cli11`, `sol`, and `sparsehash`) have been guarded to allow downstream users to
-  have their own versions. This includes moving their headers under `include/axom` instead of `include/` and 
+  have their own versions. This includes moving their headers under `include/axom` instead of `include/` and
   moving their C++ namespace under `axom` (eg. `fmt` to `axom::fmt`).  If you don't use our built-n TPLs this has no
   affect on you, but if you do these are some the changes you will need to make:
 
@@ -241,7 +245,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
     | sol        | `sol::` &rarr; `axom::sol::`      | `#include "sol/sol.hpp"` &rarr; `#include "axom/sol.hpp"`       |
     | sparsehash | `google::` &rarr; `axom::google::`| `#include "sparsehash` &rarr; `#include "axom/sparsehash`       |
     | cli11      | `CLI::` &rarr; `axom::CLI::`      | `#include "CLI11/CLI11.hpp"` &rarr; `#include "axom/CLI11.hpp"` |
-    
+
 - Moved `axom::MCArray` and the `sidre::Array` it was based on into `mint`
   as `axom::deprecated::MCArray` and `sidre::deprecated::MCArray`, respectively.
   `sidre::Array` is now based on `axom::Array`.
@@ -249,7 +253,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   Inlet's string utilities were moved to Core, and `splitLastNTokens` was renamed to `rsplitN`
 - `axom::Array`-related classes have been moved into individual files.
 - RAJA dependency updated to 0.14.0
-- Umpire dependency updated to 0.6.0. Support for versions prior to v2.1.0 was removed. 
+- Umpire dependency updated to 0.6.0. Support for versions prior to v2.1.0 was removed.
 - Conduit dependency updated to 0.7.2+ (develop as of Sept 13, 2021). This was required because Spack
   is now using `HDF5`'s CMake build system.
 - Internal BLT dependency updated to 0.4.1
@@ -257,7 +261,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ### Fixed
 - Fixed Primal's `intersect(Ray, Segment)` calculation for Segments that do not have unit length
-- Fixed problem with Cray Fortran compiler not recognizing MSVC pragmas in `axom/config.hpp`. 
+- Fixed problem with Cray Fortran compiler not recognizing MSVC pragmas in `axom/config.hpp`.
   The latter are now only added in MSVC configurations.
 - Fixed bug in `Mint`'s VTK output for fields of type `int64` and `float`
 - Improved loading of data collections in `MFEMSidreDataCollection`
@@ -317,7 +321,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ### Changed
 - Converted [Uberenv] to a git submodule. We previously vendored a copy of this script.
-- The Sidre Datastore no longer rewires Conduit's error handlers to Slic by default. 
+- The Sidre Datastore no longer rewires Conduit's error handlers to Slic by default.
   It can be  explicitly rewired using the static
   `DataStore::setConduitSLICMessageHandlers()` method.
 - Inlet: Changed `SchemaCreator` to an abstract class and added missing functions
@@ -390,37 +394,37 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Added new component, Inlet, to assist in retrieving and storing data from
   an input deck.
 - Added the ability to specify an [Umpire] allocator ID to use with the
-  BVH. This allows the application to use a device allocator for the BVH and 
-  avoid use of Unified Memory (UM) on the GPU, which can hinder perfomrmance, 
+  BVH. This allows the application to use a device allocator for the BVH and
+  avoid use of Unified Memory (UM) on the GPU, which can hinder perfomrmance,
   or use a pool allocator to mitigate the latencies associated with allocation/deallocation.
   The allocator ID is specified as an optional argument to the BVH constructor.
-- Added new CMake option, `AXOM_ENABLE_ANNOTATIONS`, to enable/disable code 
+- Added new CMake option, `AXOM_ENABLE_ANNOTATIONS`, to enable/disable code
   annotations in Axom. Default is OFF.
 - Added Axom annotation macros. The macros can be used to annotate functions,
   using the `AXOM_PERF_MARK_FUNCTION` macro, or at a more fine grain level,
   different sections of code can be annotated by wrapping them within an
   `AXOM_PERF_MARK_SECTION` block. As a first cut, this works with NVTX tools.
-  However, the hooks are in place to add support for Caliper in the future. 
+  However, the hooks are in place to add support for Caliper in the future.
 - Added a simple interface to NVTX that allows an application to set the color
   and category for NVTX ranges corresponding to annotated code in Axom. The
-  application can now call `axom::nvtx:set_color()` and 
-  `axom::nvtx::set_category()` to set the corresponding parameters respectively. 
-  This facilitates in the performance evaluation by allowing developers to easily 
+  application can now call `axom::nvtx:set_color()` and
+  `axom::nvtx::set_category()` to set the corresponding parameters respectively.
+  This facilitates in the performance evaluation by allowing developers to easily
   filter out calls by category or visually by setting a different color to use
   in GUI tools, such as, NVVP and NSight.
-- Added a portable floating_point_limits traits class, to return min(), max(), lowest() 
-  and epsilon() of a `float` or `double` type. The functionality is equivalent to that provided by 
+- Added a portable floating_point_limits traits class, to return min(), max(), lowest()
+  and epsilon() of a `float` or `double` type. The functionality is equivalent to that provided by
   std::numeric_limits, but, the code is host/device decorated accordingly such that it
   can also be called on the device.
-- Added initial support for ray queries using the BVH. The caller may now supply a set of rays to 
+- Added initial support for ray queries using the BVH. The caller may now supply a set of rays to
   a BVH and the BVH will return a set of candidate BVH bins that intersect each ray.
 - Added initial support for bounding box queries using the BVH. The caller may
-  now supply a set of bounding boxes to a BVH and the BVH will return a set of 
+  now supply a set of bounding boxes to a BVH and the BVH will return a set of
   candidate BVH bins that intersect each bounding box.
 - Added an `axom-config.cmake` file to axom's installation to streamline incorporating axom
   into user applications. See `<axom-install>/examples/axom` for example usages.
 - Added [Sol] as a built-in TPL for fast and simple `C++` and `Lua` binding.
-  Sol is automatically enabled when `LUA_DIR` is found. 
+  Sol is automatically enabled when `LUA_DIR` is found.
   The version of Sol used in this release is `v2.20.6`, which requires `C++14`.
 
 ### Removed
@@ -440,7 +444,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Renamed the `AXOM_USE_MPI3`option to `AXOM_ENABLE_MPI3` for consistency.
 - Modified the API for the BVH to accomodate different query types. The queries are now
   more explicitly called `BVH::findPoints()` and `BVH::findRays()`.
-- Modified the API of Axom's memory management routines to not leak usage of Umpire. Instead of 
+- Modified the API of Axom's memory management routines to not leak usage of Umpire. Instead of
   passing an `umpire::Allocator` object to specify an allocator, we now use the corresponding
   integer ID associated with the allocator.
 - All names in the C API now preserve the case of the C++ function.
@@ -454,7 +458,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ### Fixed
 - Fixed a bug in `primal::intersect(Segment, BoundingBox)` and added regression tests.
-- Spin's octrees can now be used with 64-bit indexes. This allows octrees 
+- Spin's octrees can now be used with 64-bit indexes. This allows octrees
   with up to 64 levels of resolution when using a 64-bit index type.
 - Resolved issue with `AXOM_USE_64BIT_INDEXTYPE` configurations. Axom can once again
   be configured with 64-bit index types.
@@ -463,14 +467,14 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Fixed issue in the parallel construction of the BVH on GPUs, due to incoherent
   L1 cache that could result in some data corruption in the BVH. The code now
   calls ``__threadfence_system()`` after the parent is computed and stored back
-  to global memory to ensure that the *write*  is visible to all threads. 
+  to global memory to ensure that the *write*  is visible to all threads.
 - Fixed issue in Mint that would cause the clang@9.0.0 compiler to segfault. The
   `mint_cell_types.cpp` test was causing a segfault in the compiler. The main
   issue triggering this compiler bug was the use of `constexpr` when defining the
   static `cell_info` array of structs. The code has been modified to use `const`
   instead.
 - Fixed issue in Quest's Signed Distance query that would prevent consecutive
-  calls to Quest when MPI-3 shared memory is enabled due to not properly 
+  calls to Quest when MPI-3 shared memory is enabled due to not properly
   nullifying internal pointers when finalize is called.
 - Fixed issue where the BVH would dispatch to the CPU sort() routine when the
   specified execution policy was CUDA_EXEC async. Now, when the execution policy
@@ -493,7 +497,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   workaround for the IBM XL compiler is provided.
 - There is a known bug in MVAPICH that prevents consecutive creation/deletion
   of MPI windows. This was encountered on LC platforms when enabling shared
-  memory in the Signed Distance Query. See the corresponding 
+  memory in the Signed Distance Query. See the corresponding
   [Github Issue](https://github.com/LLNL/axom/issues/257) for details.
 
 ## [Version 0.3.3] - Release date 2020-01-31
@@ -510,7 +514,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Updated Conduit to v0.5.1
 - Updated RAJA to v0.11.0
 - Updated Umpire to v2.1.0, which, natively handles zero byte re-allocations consistently. Workaround
-  for older releases of Umpire is in place for backwards compatibility. 
+  for older releases of Umpire is in place for backwards compatibility.
 - Updated BLT to develop (f0ab9a4) as of Jan 15, 2020
 - Set CUDA_SEPARABLE_COMPILATION globally instead of just in a few components.
 - Reduced verbosity of quest's InOutOctree in cases where query point lies on surface.

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -493,9 +493,6 @@ public:
   AXOM_HOST_DEVICE
   double volume() const
   {
-    SLIC_CHECK_MSG(hasNeighbors(),
-                   "Polyhedron::volume() is only valid with vertex neighbors.");
-
     double retVol = 0.0;
 
     // 0 if less than 4 vertices
@@ -508,6 +505,10 @@ public:
     // faces and an arbitrary origin (the first vertex)
     else
     {
+      SLIC_CHECK_MSG(
+        hasNeighbors(),
+        "Polyhedron::volume() is only valid with vertex neighbors.");
+
       // faces is an overestimation
       int faces[MAX_VERTS * MAX_VERTS];
       int face_size[MAX_VERTS * 2];

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -451,16 +451,16 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipOctahedron(
   //Clip octahedron by each plane
   for(int planeIndex = 0; planeIndex < 4; planeIndex++)
   {
-    // Each bit value indicates if that Polyhedron vertex is formed from
-    // Octahedron clipping with a plane.
-    unsigned int clipped = 0;
-
     PlaneType plane = planes[planeIndex];
 
     // Check that plane intersects Polyhedron
     if(intersect(plane, polyBox, true, eps))
     {
       int numVerts = poly.numVertices();
+
+      // Each bit value indicates if that Polyhedron vertex is formed from
+      // Octahedron clipping with a plane.
+      unsigned int clipped = 0;
 
       // Clip polyhedron against current plane, generating extra vertices
       // where edges meet the plane.

--- a/src/axom/primal/tests/primal_zip.cpp
+++ b/src/axom/primal/tests/primal_zip.cpp
@@ -22,6 +22,14 @@ using namespace axom;
 
 //------------------------------------------------------------------------------
 
+template <typename PrimitiveType>
+void check_default_ctor()
+{
+  using ZipType = primal::ZipIndexable<PrimitiveType>;
+
+  ZipType zip;
+}
+
 template <typename ExecSpace, typename PrimitiveType>
 void check_zip_points_3d()
 {
@@ -430,6 +438,25 @@ void check_zip_rays_2d_from_3d()
 
   axom::deallocate(valid);
   axom::setDefaultAllocator(current_allocator);
+}
+
+TEST(primal_zip, default_ctor)
+{
+  check_default_ctor<primal::Point<double, 1>>();
+  check_default_ctor<primal::Point<double, 2>>();
+  check_default_ctor<primal::Point<double, 3>>();
+
+  check_default_ctor<primal::Vector<double, 1>>();
+  check_default_ctor<primal::Vector<double, 2>>();
+  check_default_ctor<primal::Vector<double, 3>>();
+
+  check_default_ctor<primal::Ray<double, 1>>();
+  check_default_ctor<primal::Ray<double, 2>>();
+  check_default_ctor<primal::Ray<double, 3>>();
+
+  check_default_ctor<primal::BoundingBox<double, 1>>();
+  check_default_ctor<primal::BoundingBox<double, 2>>();
+  check_default_ctor<primal::BoundingBox<double, 3>>();
 }
 
 TEST(primal_zip, zip_points_3d)

--- a/src/axom/primal/utils/ZipBoundingBox.hpp
+++ b/src/axom/primal/utils/ZipBoundingBox.hpp
@@ -29,12 +29,20 @@ struct ZipBase<BoundingBox<T, NDIMS>>
 
   static constexpr bool Exists = true;
 
+  /// Default constructor for a ZipBase of primal::BoundingBox
+  ZipBase()
+  {
+    for(int d = 0; d < NDIMS; ++d)
+    {
+      bb_min_arrays[d] = nullptr;
+      bb_max_arrays[d] = nullptr;
+    }
+  }
+
   /*!
    * \brief Creates a ZipIndexable from a set of arrays
-   * \param [in] min_arrays the arrays storing the min coordinate for each
-   *  dimension
-   * \param [in] max_arrays the arrays storing the max coordinate for each
-   *  dimension
+   * \param [in] min_arrays the arrays storing the min coordinate for each dimension
+   * \param [in] max_arrays the arrays storing the max coordinate for each dimension
    *
    * \pre Size1 >= NDIMS
    * \pre Size2 >= NDIMS
@@ -45,10 +53,10 @@ struct ZipBase<BoundingBox<T, NDIMS>>
   {
     AXOM_STATIC_ASSERT_MSG(Size1 >= NDIMS, "Must provide at least NDIMS arrays");
     AXOM_STATIC_ASSERT_MSG(Size2 >= NDIMS, "Must provide at least NDIMS arrays");
-    for(int i = 0; i < NDIMS; i++)
+    for(int d = 0; d < NDIMS; ++d)
     {
-      bb_min_arrays[i] = min_arrays[i];
-      bb_max_arrays[i] = max_arrays[i];
+      bb_min_arrays[d] = min_arrays[d];
+      bb_max_arrays[d] = max_arrays[d];
     }
   }
 
@@ -60,7 +68,7 @@ struct ZipBase<BoundingBox<T, NDIMS>>
   {
     using PointType = typename GeomType::PointType;
     StackArray<T, NDIMS> min_data, max_data;
-    for(int d = 0; d < NDIMS; d++)
+    for(int d = 0; d < NDIMS; ++d)
     {
       min_data[d] = bb_min_arrays[d][i];
       max_data[d] = bb_max_arrays[d][i];

--- a/src/axom/primal/utils/ZipPoint.hpp
+++ b/src/axom/primal/utils/ZipPoint.hpp
@@ -29,6 +29,15 @@ struct ZipBase<Point<T, NDIMS>>
 
   static constexpr bool Exists = true;
 
+  /// Default constructor for a ZipBase of primal::Point
+  ZipBase()
+  {
+    for(int d = 0; d < NDIMS; ++d)
+    {
+      pts_arrays[d] = nullptr;
+    }
+  }
+
   /*!
    * \brief Creates a ZipIndexable over a set of arrays.
    * \param [in] arrays the arrays storing coordinate data for each dimension
@@ -39,9 +48,9 @@ struct ZipBase<Point<T, NDIMS>>
   ZipBase(const T* const (&arrays)[Size])
   {
     AXOM_STATIC_ASSERT_MSG(Size >= NDIMS, "Must provide at least NDIMS arrays");
-    for(int i = 0; i < NDIMS; i++)
+    for(int d = 0; d < NDIMS; ++d)
     {
-      pts_arrays[i] = arrays[i];
+      pts_arrays[d] = arrays[d];
     }
   }
 
@@ -52,7 +61,7 @@ struct ZipBase<Point<T, NDIMS>>
   AXOM_HOST_DEVICE GeomType operator[](int i) const
   {
     StackArray<T, NDIMS> pt_data;
-    for(int d = 0; d < NDIMS; d++)
+    for(int d = 0; d < NDIMS; ++d)
     {
       pt_data[d] = pts_arrays[d][i];
     }

--- a/src/axom/primal/utils/ZipRay.hpp
+++ b/src/axom/primal/utils/ZipRay.hpp
@@ -29,6 +29,16 @@ struct ZipBase<Ray<T, NDIMS>>
 
   static constexpr bool Exists = true;
 
+  /// Default constructor for a ZipBase of primal::Ray
+  ZipBase()
+  {
+    for(int d = 0; d < NDIMS; ++d)
+    {
+      ray_origs[d] = nullptr;
+      ray_dirs[d] = nullptr;
+    }
+  }
+
   /*!
    * \brief Creates a ZipIndexable from a set of arrays
    * \param [in] orig_arrays the arrays for each dimension storing the origin
@@ -45,10 +55,10 @@ struct ZipBase<Ray<T, NDIMS>>
   {
     AXOM_STATIC_ASSERT_MSG(Size1 >= NDIMS, "Must provide at least NDIMS arrays");
     AXOM_STATIC_ASSERT_MSG(Size2 >= NDIMS, "Must provide at least NDIMS arrays");
-    for(int i = 0; i < NDIMS; i++)
+    for(int d = 0; d < NDIMS; ++d)
     {
-      ray_origs[i] = orig_arrays[i];
-      ray_dirs[i] = dir_arrays[i];
+      ray_origs[d] = orig_arrays[d];
+      ray_dirs[d] = dir_arrays[d];
     }
   }
 
@@ -61,7 +71,7 @@ struct ZipBase<Ray<T, NDIMS>>
     using PointType = typename GeomType::PointType;
     using VectorType = typename GeomType::VectorType;
     StackArray<T, NDIMS> orig_data, dir_data;
-    for(int d = 0; d < NDIMS; d++)
+    for(int d = 0; d < NDIMS; ++d)
     {
       orig_data[d] = ray_origs[d][i];
       dir_data[d] = ray_dirs[d][i];

--- a/src/axom/primal/utils/ZipVector.hpp
+++ b/src/axom/primal/utils/ZipVector.hpp
@@ -26,6 +26,15 @@ struct ZipBase<Vector<T, NDIMS>>
 
   static constexpr bool Exists = true;
 
+  /// Default constructor for a ZipBase of primal::Vector
+  ZipBase()
+  {
+    for(int d = 0; d < NDIMS; ++d)
+    {
+      vec_arrays[d] = nullptr;
+    }
+  }
+
   /*!
    * \brief Creates a ZipIndexable over a set of arrays.
    * \param [in] arrays the arrays storing coordinate data for each dimension
@@ -36,9 +45,9 @@ struct ZipBase<Vector<T, NDIMS>>
   ZipBase(const T* const (&arrays)[Size])
   {
     AXOM_STATIC_ASSERT_MSG(Size >= NDIMS, "Must provide at least NDIMS arrays");
-    for(int i = 0; i < NDIMS; i++)
+    for(int d = 0; d < NDIMS; ++d)
     {
-      vec_arrays[i] = arrays[i];
+      vec_arrays[d] = arrays[d];
     }
   }
 
@@ -49,7 +58,7 @@ struct ZipBase<Vector<T, NDIMS>>
   AXOM_HOST_DEVICE GeomType operator[](int i) const
   {
     StackArray<T, NDIMS> pt_data;
-    for(int d = 0; d < NDIMS; d++)
+    for(int d = 0; d < NDIMS; ++d)
     {
       pt_data[d] = vec_arrays[d][i];
     }

--- a/src/axom/quest/CMakeLists.txt
+++ b/src/axom/quest/CMakeLists.txt
@@ -99,12 +99,16 @@ blt_list_append(TO quest_depends_on IF ENABLE_OPENMP ELEMENTS openmp)
 blt_list_append(TO quest_depends_on IF SPARSEHASH_FOUND ELEMENTS sparsehash)
 blt_list_append(TO quest_depends_on IF MFEM_FOUND ELEMENTS mfem)
 
+if(CONDUIT_FOUND)
+    list(APPEND quest_headers    ScatteredInterpolation.hpp )
+    list(APPEND quest_depends_on conduit::conduit)
+endif()
+
 if(CONDUIT_FOUND AND ENABLE_MPI)
-    list(APPEND quest_headers DistributedClosestPoint.hpp )
+    list(APPEND quest_headers    DistributedClosestPoint.hpp )
     list(APPEND quest_depends_on conduit::conduit
                                  conduit::conduit_mpi)
 endif()
-
 
 if(MFEM_FOUND AND AXOM_ENABLE_KLEE AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION)
     list(APPEND quest_headers Shaper.hpp

--- a/src/axom/quest/CMakeLists.txt
+++ b/src/axom/quest/CMakeLists.txt
@@ -93,15 +93,15 @@ set( quest_depends_on
     fmt
     )
 
+blt_list_append(TO quest_depends_on IF AXOM_ENABLE_SIDRE ELEMENTS sidre)
 blt_list_append(TO quest_depends_on IF ENABLE_CUDA ELEMENTS cuda)
 blt_list_append(TO quest_depends_on IF ENABLE_HIP ELEMENTS blt::hip_runtime)
 blt_list_append(TO quest_depends_on IF ENABLE_OPENMP ELEMENTS openmp)
 blt_list_append(TO quest_depends_on IF SPARSEHASH_FOUND ELEMENTS sparsehash)
 blt_list_append(TO quest_depends_on IF MFEM_FOUND ELEMENTS mfem)
 
-if(CONDUIT_FOUND)
+if(AXOM_ENABLE_SIDRE)
     list(APPEND quest_headers    ScatteredInterpolation.hpp )
-    list(APPEND quest_depends_on conduit::conduit)
 endif()
 
 if(CONDUIT_FOUND AND ENABLE_MPI)

--- a/src/axom/quest/Delaunay.hpp
+++ b/src/axom/quest/Delaunay.hpp
@@ -395,9 +395,9 @@ public:
     return valid;
   }
 
-private:
   /// \brief Find the index of the element that contains the query point, or the element closest to the point.
-  IndexType findContainingElement(const PointType& query_pt)
+  IndexType findContainingElement(const PointType& query_pt,
+                                  bool warnOnInvalid = true)
   {
     if(m_mesh.isEmpty())
     {
@@ -451,15 +451,23 @@ private:
       // Logically, this should never happen.
       if(!m_mesh.isValidElement(element_i))
       {
-        SLIC_WARNING(fmt::format(
-          "Entered invalid element in "
-          "Delaunay::findContainingElement(). Underlying mesh {} valid",
-          m_mesh.isValid() ? "is" : "is not"));
+        SLIC_WARNING_IF(
+          warnOnInvalid,
+          fmt::format(
+            "Entered invalid element in "
+            "Delaunay::findContainingElement(). Underlying mesh {} valid",
+            m_mesh.isValid() ? "is" : "is not"));
         return INVALID_INDEX;
       }
     }
   }
 
+  /**
+   * \brief helper function to retrieve the barycentric coordinate of the query point in the element
+   */
+  BaryCoordType getBaryCoords(IndexType element_idx, const PointType& q_pt) const;
+
+private:
   /// \brief Predicate for when to compact internal mesh data structures after removing elements
   bool shouldCompactMesh() const
   {
@@ -484,11 +492,6 @@ private:
   void generateInitialMesh(std::vector<DataType>& points,
                            std::vector<IndexType>& elem,
                            const BoundingBox& bb);
-
-  /**
-   * \brief helper function to retrieve the barycentric coordinate of the query point in the element
-   */
-  BaryCoordType getBaryCoords(IndexType element_idx, const PointType& q_pt) const;
 
 private:
   /// Helper struct to find the first element near a point to be inserted

--- a/src/axom/quest/Delaunay.hpp
+++ b/src/axom/quest/Delaunay.hpp
@@ -401,14 +401,16 @@ public:
   {
     if(m_mesh.isEmpty())
     {
-      SLIC_ERROR(
+      SLIC_ERROR_IF(
+        warnOnInvalid,
         "Attempting to insert point into empty Delaunay triangulation."
         "Delaunay::initializeBoundary() needs to be called first");
       return INVALID_INDEX;
     }
     if(!m_bounding_box.contains(query_pt))
     {
-      SLIC_WARNING(
+      SLIC_WARNING_IF(
+        warnOnInvalid,
         "Attempting to locate element at location outside valid domain");
       return INVALID_INDEX;
     }

--- a/src/axom/quest/ScatteredInterpolation.hpp
+++ b/src/axom/quest/ScatteredInterpolation.hpp
@@ -1,0 +1,167 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef QUEST_SCATTERED_INTERPOLATION_H_
+#define QUEST_SCATTERED_INTERPOLATION_H_
+
+#include "axom/core.hpp"
+#include "axom/slic.hpp"
+#include "axom/slam.hpp"
+#include "axom/primal.hpp"
+#include "axom/mint.hpp"
+#include "axom/spin.hpp"
+
+#include "axom/fmt.hpp"
+
+#include "conduit_blueprint.hpp"
+
+#include <list>
+#include <vector>
+#include <set>
+#include <cstdlib>
+#include <cmath>
+
+namespace
+{
+/// Helper function to extract the dimension from the coordinate values group
+/// of a mesh blueprint coordset
+inline int extractDimension(const conduit::Node& values_node)
+{
+  SLIC_ASSERT(values_node.has_child("x"));
+  return values_node.has_child("z") ? 3 : (values_node.has_child("y") ? 2 : 1);
+}
+
+/// Helper function to extract the number of points from the coordinate values group
+/// of a mesh blueprint coordset
+inline int extractSize(const conduit::Node& values_node)
+{
+  SLIC_ASSERT(values_node.has_child("x"));
+  return values_node["x"].dtype().number_of_elements();
+}
+
+/**
+ * \brief Utility function to create an axom::ArrayView over the array
+ * of native types stored by a conduit::Node
+ */
+template <typename T>
+inline axom::ArrayView<T> ArrayView_from_Node(conduit::Node& node, int sz)
+{
+  T* ptr = node.value();
+  return axom::ArrayView<T>(ptr, sz);
+}
+
+/**
+ * \brief Template specialization of ArrayView_from_Node for Point<double,2>
+ *
+ * \warning Assumes the underlying data is an MCArray with stride 2 access
+ */
+template <>
+inline axom::ArrayView<axom::primal::Point<double, 2>> ArrayView_from_Node(
+  conduit::Node& node,
+  int sz)
+{
+  using PointType = axom::primal::Point<double, 2>;
+
+  PointType* ptr = static_cast<PointType*>(node.data_ptr());
+  return axom::ArrayView<PointType>(ptr, sz);
+}
+
+/**
+ * \brief Template specialization of ArrayView_from_Node for Point<double,3>
+ *
+ * \warning Assumes the underlying data is an MCArray with stride 3 access
+ */
+template <>
+inline axom::ArrayView<axom::primal::Point<double, 3>> ArrayView_from_Node(
+  conduit::Node& node,
+  int sz)
+{
+  using PointType = axom::primal::Point<double, 3>;
+
+  PointType* ptr = static_cast<PointType*>(node.data_ptr());
+  return axom::ArrayView<PointType>(ptr, sz);
+}
+
+}  // namespace
+
+namespace axom
+{
+namespace quest
+{
+/**
+ * \brief A class to perform scattered data interpolation at arbitrary points
+ * over an input point set
+ *
+ * The class uses linear interpolation over a Delaunay triangulation of the point set.
+ */
+template <int NDIMS = 3>
+class ScatteredInterpolation
+{
+public:
+  static constexpr int DIM = NDIMS;
+  using DelaunayTriangulation = Delaunay<DIM>;
+  using PointType = typename DelaunayTriangulation::PointType;
+  using BoundingBoxType = typename DelaunayTriangulation::BoundingBox;
+
+  void buildTriangulation(conduit::Node& mesh_node, const std::string& coordset)
+  {
+    // Perform some simple error checking
+    SLIC_ASSERT(this->isValidBlueprint(mesh_node));
+
+    auto valuesPath = fmt::format("coordsets/{}/values", coordset);
+    SLIC_ASSERT(mesh_node.has_path(valuesPath));
+    auto& values = mesh_node[valuesPath];
+
+    SLIC_ASSERT(::extractDimension(values) == DIM);
+    const int npts = ::extractSize(values);
+
+    // Assume initially that coords are interleaved
+    auto coords = ::ArrayView_from_Node<PointType>(values["x"], npts);
+
+    // Compute the bounding box
+    BoundingBoxType bb;
+    for(const auto& pt : coords)
+    {
+      bb.addPoint(pt);
+    }
+    bb.scale(1.5);
+
+    m_delaunay.initializeBoundary(bb);
+    for(const auto& pt : coords)
+    {
+      m_delaunay.insertPoint(pt);
+    }
+
+    m_delaunay.removeBoundary();
+
+    m_delaunay.writeToVTKFile(fmt::format("delaunay_{}d.vtk", DIM));
+  }
+
+private:
+  /// Check validity of blueprint group
+  bool isValidBlueprint(const conduit::Node& mesh_node) const
+  {
+    bool success = true;
+    conduit::Node info;
+    if(!conduit::blueprint::verify("mesh", mesh_node, info))
+    {
+      SLIC_INFO("Invalid blueprint for particle mesh: \n" << info.to_yaml());
+      success = false;
+    }
+
+    return success;
+  }
+
+private:
+  DelaunayTriangulation m_delaunay;
+};
+
+template <int NDIMS>
+constexpr int ScatteredInterpolation<NDIMS>::DIM;
+
+}  // namespace quest
+}  // namespace axom
+
+#endif  // QUEST_SCATTERED_INTERPOLATION_H_

--- a/src/axom/quest/ScatteredInterpolation.hpp
+++ b/src/axom/quest/ScatteredInterpolation.hpp
@@ -17,11 +17,8 @@
 
 #include "conduit_blueprint.hpp"
 
-#include <list>
-#include <vector>
-#include <set>
-#include <cstdlib>
 #include <cmath>
+#include <limits>
 
 namespace
 {
@@ -116,15 +113,8 @@ public:
     // Perform some simple error checking
     SLIC_ASSERT(this->isValidBlueprint(mesh_node));
 
-    auto valuesPath = fmt::format("coordsets/{}/values", coordset);
-    SLIC_ASSERT(mesh_node.has_path(valuesPath));
-    auto& values = mesh_node[valuesPath];
-
-    SLIC_ASSERT(::extractDimension(values) == DIM);
-    const int npts = ::extractSize(values);
-
-    // Assume initially that coords are interleaved
-    auto coords = ::ArrayView_from_Node<PointType>(values["x"], npts);
+    // Extract coordinates as ArrayView of PointType
+    auto coords = getCoordinatesArrayView(mesh_node, coordset);
 
     // Compute the bounding box
     BoundingBoxType bb;
@@ -149,11 +139,11 @@ public:
   /**
    * \brief Locates cell from Delaunay complex containing each point in \a query_mesh
    *
-   * \param [inout] query_node Conduit node for the query points in mesh Blueprint format; 
+   * \param [inout] query_node Conduit node for the query points in mesh Blueprint format;
    * results will be placed into the `cell_idx` field
    * \param [in] coordset The name of the coordinate set for the query mesh
    *
-   * \pre query_mesh is the root of a valid mesh blueprint with an unstructured 
+   * \pre query_mesh is the root of a valid mesh blueprint with an unstructured
    * coordinate set \a coordset and a scalar field named `cell_idx` to store the results
    * \note Uses `Delaunay::INVALID_INDEX` for points that cannot be located within the mesh
    */
@@ -162,15 +152,8 @@ public:
     // Perform some simple error checking
     SLIC_ASSERT(this->isValidBlueprint(query_mesh));
 
-    auto valuesPath = fmt::format("coordsets/{}/values", coordset);
-    SLIC_ASSERT(query_mesh.has_path(valuesPath));
-    auto& values = query_mesh[valuesPath];
-
-    SLIC_ASSERT(::extractDimension(values) == DIM);
-    const int npts = ::extractSize(values);
-
-    // Assume initially that coords are interleaved
-    auto coords = ::ArrayView_from_Node<PointType>(values["x"], npts);
+    auto coords = getCoordinatesArrayView(query_mesh, coordset);
+    const int npts = coords.size();
 
     SLIC_ERROR_IF(!query_mesh.has_path("fields/cell_idx/values"),
                   "Query mesh for ScatteredInterpolation::locatePoints() is "
@@ -189,6 +172,69 @@ public:
     }
   }
 
+  /**
+   * \brief Interpolates a field from an \a input_mesh to one on a \a query_mesh
+   *
+   * \param [inout] query_mesh Root node of mesh (in blueprint format) containing field to generate
+   * \param [in] coordset The name of the coords for query points in \a query_mesh
+   * \param [in] input_mesh Root node of mesh (in blueprint format) containing the field to interpolate
+   * \param [in] input_field_name Name of field on \a input_mesh
+   * \param [in] output_field_name Name of field on \a query_mesh
+   * \param [in] INVALID_VALUE Value to use for points that are not in the \a input_mesh
+   *
+   * \pre \a input_mesh and \a query_mesh must conform to the mesh blueprint schema for point meshes
+   * \pre \a input_mesh must contain a nodal scalar field named \a input_field_name
+   * \pre \a query_mesh must contain a nodal scalar field named \a output_field_name
+   * \pre \a query_mesh must contain a nodal scalar field named \a cell_idx whose values
+   * are the index of the cell from the Delaunay triangulation containing the query points.
+   * These can be computed in the \a locatePoints() function
+   * \post Scalar field \a output_field_name on \a query_mesh will contain the interpolated
+   * values of \a input_field_name from \a input_mesh for all query points that have a valid
+   * \a cell_idx to a cell in the \a input_mesh.
+   */
+  void interpolateField(
+    conduit::Node& query_mesh,
+    const std::string& coordset,
+    conduit::Node& input_mesh,
+    const std::string& input_field_name,
+    const std::string& output_field_name,
+    const double INVALID_VALUE = std::numeric_limits<double>::quiet_NaN())
+  {
+    constexpr auto INVALID_INDEX = DelaunayTriangulation::INVALID_INDEX;
+
+    SLIC_ASSERT(this->isValidBlueprint(query_mesh));
+    SLIC_ASSERT(this->isValidBlueprint(input_mesh));
+
+    // Extract the required fields from the input and query meshes
+    auto in_fld = getField<double>(input_mesh, input_field_name);
+    auto out_fld = getField<double>(query_mesh, output_field_name);
+    auto containing_cell = getField<axom::IndexType>(query_mesh, "cell_idx");
+    auto coords = getCoordinatesArrayView(query_mesh, coordset);
+
+    // Interpolate field at query points
+    const int npts = coords.size();
+    for(int idx = 0; idx < npts; ++idx)
+    {
+      const auto cell_id = containing_cell[idx];
+      if(cell_id == INVALID_INDEX)
+      {
+        out_fld[idx] = INVALID_VALUE;
+      }
+      else
+      {
+        double res = 0.;
+        const auto baryCoords = m_delaunay.getBaryCoords(cell_id, coords[idx]);
+        const auto verts = m_delaunay.getMeshData()->boundaryVertices(cell_id);
+        for(auto it = verts.begin(); it < verts.end(); ++it)
+        {
+          res += in_fld[*it] * baryCoords[it.index()];
+        }
+
+        out_fld[idx] = res;
+      }
+    }
+  }
+
 private:
   /// Check validity of blueprint group
   bool isValidBlueprint(const conduit::Node& mesh_node) const
@@ -202,6 +248,54 @@ private:
     }
 
     return success;
+  }
+
+  /**
+   * \brief Returns and ArrayView to the desired field from a mesh blueprint, which must be present
+   *
+   * \param [in] mesh_node The root conduit node of a valid mesh blueprint
+   * \param [in] field_name The name of the field to return; Can either be either the name of the field,
+   *  or the path to the field, e.g. fields/<field_name>/values
+   *
+   * \pre The field named \a field_name must be present in \a mesh_node or code will error out
+   * \note Only currently supports scalar fields
+   */
+  template <typename T>
+  ArrayView<T> getField(conduit::Node& mesh_node, const std::string& field_name)
+  {
+    using axom::utilities::string::startsWith;
+
+    const std::string field_path = startsWith(field_name, "field")
+      ? field_name
+      : fmt::format("fields/{}/values", field_name);
+    SLIC_ERROR_IF(
+      !mesh_node.has_path(field_path),
+      fmt::format("Mesh blueprint is missing required field '{}'", field_name));
+
+    auto& values = mesh_node[field_path];
+    const auto sz = values.dtype().number_of_elements();
+
+    return ::ArrayView_from_Node<T>(values, sz);
+  }
+
+  /**
+   * \brief Returns an \a ArrayView<PointType> of the coordinates of the given \a mesh_node
+   *
+   * \param [in] mesh_node The root conduit node of a valid mesh blueprint
+   * \param [in] coordset The name of the coordinate set within \a mesh_node that we're returning
+   */
+  axom::ArrayView<PointType> getCoordinatesArrayView(conduit::Node& mesh_node,
+                                                     const std::string& coordset)
+  {
+    const auto valuesPath = fmt::format("coordsets/{}/values", coordset);
+    SLIC_ASSERT(mesh_node.has_path(valuesPath));
+    auto& values = mesh_node[valuesPath];
+
+    SLIC_ASSERT(::extractDimension(values) == DIM);
+    const int npts = ::extractSize(values);
+
+    // Assume initially that coords are interleaved
+    return ::ArrayView_from_Node<PointType>(values["x"], npts);
   }
 
 private:

--- a/src/axom/quest/ScatteredInterpolation.hpp
+++ b/src/axom/quest/ScatteredInterpolation.hpp
@@ -102,7 +102,6 @@ public:
 
   /// Constructor from a multi-component array Conduit node
   explicit InterleavedOrStridedPoints(conduit::Node& values)
-    : m_strided {{nullptr, nullptr, nullptr}}
   {
     SLIC_ASSERT(isMultiComponentArray(values));
 
@@ -128,7 +127,6 @@ public:
 
   /// Constructor from a multi-component array Sidre group node
   explicit InterleavedOrStridedPoints(const sidre::Group* values)
-    : m_strided {{nullptr, nullptr, nullptr}}
   {
     conduit::Node vals;
     SLIC_ASSERT(values != nullptr);

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -68,6 +68,16 @@ foreach(d 2 3)
         )
 endforeach()
 
+if(AXOM_ENABLE_SIDRE)
+    blt_add_executable(
+        NAME        quest_scattered_interpolation_ex
+        SOURCES     scattered_interpolation.cpp
+        OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
+        DEPENDS_ON  ${quest_example_depends}
+        FOLDER      axom/quest/examples
+        )
+endif()
+
 
 ## Quest interface examples
 

--- a/src/axom/quest/examples/delaunay_triangulation.cpp
+++ b/src/axom/quest/examples/delaunay_triangulation.cpp
@@ -42,8 +42,8 @@ public:
 
     app.add_option("-d,--dim", dimension)
       ->description(
-        "The dimension of the mesh. 2 for triangle mesh in 2D; 3 for "
-        "tetrahedral mesh in 3D")
+        "The dimension of the mesh. 2 for triangle mesh in 2D; "
+        "3 for tetrahedral mesh in 3D")
       ->capture_default_str();
 
     app.add_option("-s,--outputsteps", numOutputSteps)

--- a/src/axom/quest/examples/scattered_interpolation.cpp
+++ b/src/axom/quest/examples/scattered_interpolation.cpp
@@ -709,9 +709,8 @@ int main(int argc, char** argv)
 
   // Write input mesh to file
   {
-    std::string file = params.outputFile + "_mesh_after_generate";
-    SLIC_INFO(
-      axom::fmt::format("After generate points -- writing mesh file: '{}'", file));
+    std::string file = params.outputFile + "_input";
+    SLIC_INFO(axom::fmt::format("Writing input mesh to '{}'", file));
     inputMesh.saveMesh(file, params.outputProtocol);
   }
 
@@ -777,10 +776,8 @@ int main(int argc, char** argv)
 
   // Write query mesh to file
   {
-    std::string file = params.outputFile + "_mesh_after_query";
-    SLIC_INFO(
-      axom::fmt::format("After locating points on Delaunay triangulation: '{}'",
-                        file));
+    std::string file = params.outputFile + "_interpolated";
+    SLIC_INFO(axom::fmt::format("Writing interpolated point mesh to '{}'", file));
     queryMesh.saveMesh(file, params.outputProtocol);
   }
 

--- a/src/axom/quest/examples/scattered_interpolation.cpp
+++ b/src/axom/quest/examples/scattered_interpolation.cpp
@@ -1,0 +1,480 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ * \file scattered_interpolation.cpp
+ * \brief This examples uses a Delaunay mesh to perform scattered data
+ * interpolation on fields defined over a point set
+ */
+
+#include "axom/core.hpp"
+#include "axom/slic.hpp"
+#include "axom/slam.hpp"
+#include "axom/sidre.hpp"
+#include "axom/primal.hpp"
+#include "axom/quest.hpp"
+
+#include "conduit_blueprint.hpp"
+
+#include "axom/fmt.hpp"
+#include "axom/CLI11.hpp"
+
+#include <memory>
+
+namespace primal = axom::primal;
+namespace quest = axom::quest;
+namespace sidre = axom::sidre;
+
+namespace internal
+{
+namespace blueprint
+{
+/**
+ *  \brief Simple wrapper to a blueprint particle mesh
+ *
+ *  Given a sidre Group, creates the stubs for a mesh blueptint particle mesh
+ */
+struct PointMesh
+{
+public:
+  explicit PointMesh(sidre::Group* group = nullptr,
+                     const std::string& coordset = "coords",
+                     const std::string& topology = "mesh")
+    : m_group(group)
+    , m_meshName(topology)
+    , m_coordName(coordset)
+  {
+    setBlueprintGroup(m_group, coordset, topology);
+  }
+  /// Gets the root group for this mesh blueprint
+  sidre::Group* rootGroup() const { return m_group; }
+  /// Gets the parent group for the blueprint coordinate set
+  sidre::Group* coordsGroup() const { return m_coordsGroup; }
+  /// Gets the parent group for the blueprint mesh topology
+  sidre::Group* topoGroup() const { return m_topoGroup; }
+
+  /// Returns true if points have been added to the particle mesh
+  bool hasPoints() const
+  {
+    return m_coordsGroup != nullptr && m_coordsGroup->hasGroup("values");
+  }
+
+  /// Returns the number of points in the particle mesh
+  int numPoints() const
+  {
+    return hasPoints() ? m_coordsGroup->getView("values/x")->getNumElements() : 0;
+  }
+
+  int dimension() const
+  {
+    if(hasPoints())
+    {
+      return m_coordsGroup->hasView("values/z")
+        ? 3
+        : (m_coordsGroup->hasView("values/y") ? 2 : 1);
+    }
+    return 0;
+  }
+
+  /**
+   * Sets the parent group for the entire mesh and sets up the blueprint stubs
+   * for the "coordset", "topologies", "fields" and "state"
+   */
+  void setBlueprintGroup(sidre::Group* group,
+                         const std::string& coordset = "coords",
+                         const std::string& topology = "mesh")
+  {
+    // TODO: Ensure that we delete previous hierarchy if it existed
+
+    m_group = group;
+    m_meshName = topology;
+    m_coordName = coordset;
+
+    if(m_group != nullptr)
+    {
+      createBlueprintStubs(coordset, topology);
+    }
+  }
+
+  /// Set the coordinate data from an array of primal Points, templated on the dimension
+  template <int NDIMS>
+  void setPoints(const axom::Array<primal::Point<double, NDIMS>>& pts)
+  {
+    SLIC_ASSERT_MSG(m_group != nullptr,
+                    "Must set blueprint group before setPoints()");
+
+    const int SZ = pts.size();
+
+    // create views into a shared buffer for the coordinates, with stride NDIMS
+    auto* buf =
+      m_group->getDataStore()->createBuffer(sidre::DOUBLE_ID, NDIMS * SZ)->allocate();
+    switch(NDIMS)
+    {
+    case 3:
+      m_coordsGroup->createView("values/x")->attachBuffer(buf)->apply(SZ, 0, NDIMS);
+      m_coordsGroup->createView("values/y")->attachBuffer(buf)->apply(SZ, 1, NDIMS);
+      m_coordsGroup->createView("values/z")->attachBuffer(buf)->apply(SZ, 2, NDIMS);
+      break;
+    case 2:
+      m_coordsGroup->createView("values/x")->attachBuffer(buf)->apply(SZ, 0, NDIMS);
+      m_coordsGroup->createView("values/y")->attachBuffer(buf)->apply(SZ, 1, NDIMS);
+      break;
+    default:
+      m_coordsGroup->createView("values/x")->attachBuffer(buf)->apply(SZ, 0, NDIMS);
+      break;
+    }
+
+    // copy coordinate data into the buffer
+    const std::size_t nbytes = sizeof(double) * SZ * NDIMS;
+    axom::copy(buf->getVoidPtr(), pts.data(), nbytes);
+
+    // set the default connectivity
+    sidre::Array<int> arr(m_topoGroup->createView("elements/connectivity"), SZ, SZ);
+    for(int i = 0; i < SZ; ++i)
+    {
+      arr[i] = i;
+    }
+  }
+
+  template <typename T>
+  void registerNodalScalarField(const std::string& fieldName)
+  {
+    SLIC_ASSERT_MSG(hasPoints(),
+                    "Cannot register a field with the BlueprintParticleMesh "
+                    "before adding points");
+
+    auto* fld = m_fieldsGroup->createGroup(fieldName);
+    fld->createViewString("association", "vertex");
+    fld->createViewString("topology", m_topoGroup->getName());
+    fld->createViewAndAllocate("values",
+                               sidre::detail::SidreTT<T>::id,
+                               numPoints());
+  }
+
+  template <typename T>
+  void registerNodalVectorField(const std::string& fieldName)
+  {
+    SLIC_ASSERT_MSG(hasPoints(),
+                    "Cannot register a field with the BlueprintParticleMesh "
+                    "before adding points");
+
+    const int SZ = numPoints();
+    const int DIM = dimension();
+
+    auto* fld = m_fieldsGroup->createGroup(fieldName);
+    fld->createViewString("association", "vertex");
+    fld->createViewString("topology", m_topoGroup->getName());
+
+    // create views into a shared buffer for the coordinates, with stride NDIMS
+    auto* buf = m_group->getDataStore()
+                  ->createBuffer(sidre::detail::SidreTT<T>::id, DIM * SZ)
+                  ->allocate();
+    switch(DIM)
+    {
+    case 3:
+      fld->createView("values/x")->attachBuffer(buf)->apply(SZ, 0, DIM);
+      fld->createView("values/y")->attachBuffer(buf)->apply(SZ, 1, DIM);
+      fld->createView("values/z")->attachBuffer(buf)->apply(SZ, 2, DIM);
+      break;
+    case 2:
+      fld->createView("values/x")->attachBuffer(buf)->apply(SZ, 0, DIM);
+      fld->createView("values/y")->attachBuffer(buf)->apply(SZ, 1, DIM);
+      break;
+    default:
+      fld->createView("values/x")->attachBuffer(buf)->apply(SZ, 0, DIM);
+      break;
+    }
+  }
+
+  bool hasField(const std::string& fieldName) const
+  {
+    return m_fieldsGroup->hasGroup(fieldName);
+  }
+
+  template <typename T>
+  axom::ArrayView<T> getNodalScalarField(const std::string& fieldName) const
+  {
+    SLIC_ASSERT_MSG(hasPoints(),
+                    "Cannot extract a field from the BlueprintParticleMesh "
+                    "before adding points");
+
+    T* data = hasField(fieldName)
+      ? static_cast<T*>(
+          m_fieldsGroup->getView(axom::fmt::format("{}/values", fieldName))
+            ->getVoidPtr())
+      : nullptr;
+
+    return axom::ArrayView<T>(data, numPoints());
+  }
+
+  template <typename T>
+  axom::ArrayView<T> getNodalVectorField(const std::string& fieldName) const
+  {
+    SLIC_ASSERT_MSG(hasPoints(),
+                    "Cannot extract a field from the BlueprintParticleMesh "
+                    "before adding points");
+
+    T* data = hasField(fieldName)
+      ? static_cast<T*>(
+          m_fieldsGroup->getView(axom::fmt::format("{}/values/x", fieldName))
+            ->getVoidPtr())
+      : nullptr;
+
+    return axom::ArrayView<T>(data, numPoints());
+  }
+
+  /// Checks whether the blueprint is valid and prints diagnostics
+  bool isValid() const
+  {
+    conduit::Node mesh_node;
+    m_group->createNativeLayout(mesh_node);
+
+    bool success = true;
+    conduit::Node info;
+    if(!conduit::blueprint::verify("mesh", mesh_node, info))
+    {
+      SLIC_INFO("Invalid blueprint for particle mesh: \n" << info.to_yaml());
+      success = false;
+    }
+
+    return success;
+  }
+
+  /// Outputs the object mesh to disk
+  void saveMesh(const std::string& outputMesh)
+  {
+    auto* ds = m_group->getDataStore();
+
+    ds->generateBlueprintIndex(
+      m_group->getPathName(),
+      m_group->getName(),
+      axom::fmt::format("blueprint_index/{}", m_group->getName()),
+      1);
+
+    const std::string fname = axom::fmt::format("{}.root", outputMesh);
+    const std::string protocol = "json";
+
+    // // Add some blueprint metadata
+    if(!ds->getRoot()->hasView("number_of_files"))
+    {
+      ds->getRoot()->createViewScalar("number_of_files", 1);
+      ds->getRoot()->createViewString("file_pattern", fname);
+      ds->getRoot()->createViewScalar("number_of_trees", 1);
+      ds->getRoot()->createViewString("tree_pattern", "/");
+      ds->getRoot()->createViewString("protocol/name", protocol);
+      ds->getRoot()->createViewString("protocol/version", "0.8.2");
+    }
+    else
+    {
+      ds->getRoot()->getView("file_pattern")->setString(fname);
+    }
+
+    ds->getRoot()->save(fname, protocol);
+  }
+
+private:
+  /// Creates blueprint stubs for this mesh
+  void createBlueprintStubs(const std::string& coords, const std::string& topo)
+  {
+    SLIC_ASSERT(m_group != nullptr);
+
+    m_coordsGroup = m_group->createGroup("coordsets")->createGroup(coords);
+    m_coordsGroup->createViewString("type", "explicit");
+    m_coordsGroup->createGroup("values");
+
+    m_topoGroup = m_group->createGroup("topologies")->createGroup(topo);
+    m_topoGroup->createViewString("coordset", coords);
+    m_topoGroup->createViewString("type", "unstructured");
+    m_topoGroup->createViewString("elements/shape", "point");
+
+    m_fieldsGroup = m_group->createGroup("fields");
+  }
+
+private:
+  sidre::Group* m_group;
+
+  sidre::Group* m_coordsGroup;
+  sidre::Group* m_topoGroup;
+  sidre::Group* m_fieldsGroup;
+
+  std::string m_meshName;
+  std::string m_coordName;
+};
+
+}  // namespace blueprint
+}  // namespace internal
+
+/// Struct to parse and contain command line arguments
+struct Input
+{
+  std::string outputFile {"scattered_interpolation"};
+  int numRandPoints {20};
+  int numQueryPoints {20};
+  int dimension {2};
+  std::vector<double> boundsMin;
+  std::vector<double> boundsMax;
+
+public:
+  void parse(int argc, char** argv, axom::CLI::App& app)
+  {
+    app.add_option("-n,--nrandpt", numRandPoints)
+      ->description("The number of points in the input mesh")
+      ->capture_default_str();
+
+    app.add_option("-q,--nquerypt", numQueryPoints)
+      ->description("The number of query points")
+      ->capture_default_str();
+
+    app.add_option("-d,--dim", dimension)
+      ->description(
+        "The dimension of the mesh. 2 for triangle mesh in 2D; "
+        "3 for tetrahedral mesh in 3D")
+      ->capture_default_str();
+
+    app.add_option("-o,--outfile", outputFile)
+      ->description("The output file")
+      ->capture_default_str();
+
+    // Optional bounding box for query region
+    auto* minbb = app.add_option("--min", boundsMin)
+                    ->description("Min bounds for query box (x,y[,z])")
+                    ->expected(2, 3);
+    auto* maxbb = app.add_option("--max", boundsMax)
+                    ->description(
+                      "Max bounds for query box (x,y[,z]). "
+                      "Defaults to unit square/cube when not provided")
+                    ->expected(2, 3);
+    minbb->needs(maxbb);
+    maxbb->needs(minbb);
+
+    app.get_formatter()->column_width(45);
+
+    // could throw an exception
+    app.parse(argc, argv);
+
+    // If user doesn't provide bounds, default to unit cube
+    if(boundsMin.empty())
+    {
+      boundsMin.clear();
+      boundsMax.clear();
+      for(int i = 0; i < dimension; ++i)
+      {
+        boundsMin.push_back(0.);
+        boundsMax.push_back(1.);
+      }
+    }
+
+    SLIC_INFO(axom::fmt::format(R"(Using parameter values:
+    {{
+      dimension: {}
+      nrandpt: {}
+      nquerypt: {}
+      bounding box min: {{{}}}
+      bounding box max: {{{}}}
+      outfile = '{}'
+    }})",
+                                dimension,
+                                numRandPoints,
+                                numQueryPoints,
+                                axom::fmt::join(boundsMin, ", "),
+                                axom::fmt::join(boundsMax, ", "),
+                                outputFile));
+  }
+};
+
+template <int DIM>
+axom::Array<primal::Point<double, DIM>> generatePts(const Input& params)
+{
+  using axom::utilities::random_real;
+
+  using PointType = typename primal::Point<double, DIM>;
+  using BoundingBox = typename primal::BoundingBox<double, DIM>;
+
+  const int numPoints = params.numRandPoints;
+  axom::Array<PointType> pts(numPoints, numPoints);
+
+  BoundingBox bbox {PointType(params.boundsMin.data()),
+                    PointType(params.boundsMax.data())};
+
+  // generate random points within bounding box
+  for(int i = 0; i < numPoints; ++i)
+  {
+    PointType& pt = pts[i];
+    for(int d = 0; d < DIM; ++d)
+    {
+      pt[d] = random_real(bbox.getMin()[d], bbox.getMax()[d]);
+    }
+  }
+
+  return pts;
+}
+
+int main(int argc, char** argv)
+{
+  // Initialize the SLIC logger
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
+
+  // Initialize default parameters and update with command line arguments:
+  Input params;
+  axom::CLI::App app {"Scattered interpolation over 2D or 3D point collection"};
+
+  try
+  {
+    params.parse(argc, argv, app);
+  }
+  catch(const axom::CLI::ParseError& e)
+  {
+    return app.exit(e);
+  }
+
+  sidre::DataStore ds;
+  const std::string coordsName = "coords";
+  const std::string meshName = "mesh";
+  auto* ptMeshGroup = ds.getRoot()->createGroup("point_mesh");
+
+  internal::blueprint::PointMesh inputMesh(ptMeshGroup, coordsName, meshName);
+
+  // Initialize the mesh points
+  switch(params.dimension)
+  {
+  case 2:
+    inputMesh.setPoints(generatePts<2>(params));
+    break;
+  case 3:
+    inputMesh.setPoints(generatePts<3>(params));
+    break;
+  }
+
+  {
+    std::string file = params.outputFile + "_after_generate";
+    SLIC_INFO(
+      axom::fmt::format("After generate points -- writing mesh file: '{}'", file));
+    inputMesh.saveMesh(file);
+  }
+
+  std::unique_ptr<quest::ScatteredInterpolation<2>> scattered_2d;
+  std::unique_ptr<quest::ScatteredInterpolation<3>> scattered_3d;
+
+  // Convert blueprint mesh from Sidre to Conduit
+  conduit::Node bp_input;
+  inputMesh.rootGroup()->createNativeLayout(bp_input);
+
+  // Initialize the mesh points
+  switch(params.dimension)
+  {
+  case 2:
+    scattered_2d = std::unique_ptr<quest::ScatteredInterpolation<2>>(
+      new quest::ScatteredInterpolation<2>);
+    scattered_2d->buildTriangulation(bp_input, coordsName);
+    break;
+  case 3:
+    scattered_3d = std::unique_ptr<quest::ScatteredInterpolation<3>>(
+      new quest::ScatteredInterpolation<3>);
+    scattered_3d->buildTriangulation(bp_input, coordsName);
+    break;
+  }
+
+  return 0;
+}

--- a/src/axom/quest/examples/scattered_interpolation.cpp
+++ b/src/axom/quest/examples/scattered_interpolation.cpp
@@ -768,6 +768,8 @@ int main(int argc, char** argv)
     scattered_2d = std::unique_ptr<quest::ScatteredInterpolation<2>>(
       new quest::ScatteredInterpolation<2>);
     scattered_2d->buildTriangulation(bp_input, inputMesh.coordsName());
+    scattered_2d->exportDelaunayComplex(bp_input, "delaunay_2d.vtk");
+
     scattered_2d->locatePoints(bp_query, query_coords_name);
 
     for(const auto& fld : inputMesh.getFieldNames())
@@ -779,6 +781,8 @@ int main(int argc, char** argv)
     scattered_3d = std::unique_ptr<quest::ScatteredInterpolation<3>>(
       new quest::ScatteredInterpolation<3>);
     scattered_3d->buildTriangulation(bp_input, inputMesh.coordsName());
+    scattered_3d->exportDelaunayComplex(bp_input, "delaunay_3d.vtk");
+
     scattered_3d->locatePoints(bp_query, query_coords_name);
 
     for(const auto& fld : inputMesh.getFieldNames())

--- a/src/axom/quest/examples/scattered_interpolation.cpp
+++ b/src/axom/quest/examples/scattered_interpolation.cpp
@@ -723,7 +723,7 @@ int main(int argc, char** argv)
 
   // Write input mesh to file
   {
-    std::string file = params.outputFile + "_input";
+    std::string file = params.outputFile + "_input_mesh";
     SLIC_INFO(axom::fmt::format("Writing input mesh to '{}'", file));
     inputMesh.saveMesh(file, params.outputProtocol);
   }
@@ -790,7 +790,7 @@ int main(int argc, char** argv)
 
   // Write query mesh to file
   {
-    std::string file = params.outputFile + "_interpolated";
+    std::string file = params.outputFile + "_output_mesh";
     SLIC_INFO(axom::fmt::format("Writing interpolated point mesh to '{}'", file));
     queryMesh.saveMesh(file, params.outputProtocol);
   }

--- a/src/axom/quest/examples/scattered_interpolation.cpp
+++ b/src/axom/quest/examples/scattered_interpolation.cpp
@@ -556,6 +556,9 @@ public:
                                 axom::fmt::join(boundsMax, ", "),
                                 outputFile,
                                 outputProtocol));
+
+    axom::slic::setLoggingMsgLevel(verboseOutput ? axom::slic::message::Debug
+                                                 : axom::slic::message::Info);
   }
 };
 


### PR DESCRIPTION
# Summary

- This PR is a feature
- It adds a scattered data interpolation capability to `quest`
- Given a point mesh with scalar fields, following the [Conduit mesh blueprint schema](https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html) and a collection of query points, the class enables interpolating the scalar fields at the query points 
- This PR also adds an example application to quest that either reads in a mesh blueprint file from disk, or generates a random collection of points and uses the point coordinate positions as scalar fields. 

#### Implementation notes
- The implementation builds a Delaunay triangulation over the input point set
- It then locates the simplex (triangle or tetrahedron) containing each query point and performs linear interpolation to interpolate the scalar value at its location
- If the query point is not contained in any cell of the triangulation, no interpolation is done, and the code returns a user-provided value (e.g. `NaN`) to signify this

#### Example  runs and visualizations
```
# Generate 100 random samples and query at 500 random points
> ./examples/quest_scattered_interpolation_ex -d2 -n100 -q500
```
Visualizing cell ids for the query points:
![scattered_2d_n100_q500_cell_id](https://user-images.githubusercontent.com/5626552/171318435-8fa53b47-d143-48a4-a1db-77fea89f19c8.png)
Points that are not in a triangle are marked with red squares.

Visualizing the interpolated component position fields: `pos_x` and `pos_y`:
![scattered_2d_n100_q500_pos_x](https://user-images.githubusercontent.com/5626552/171318512-6a2c842f-9d38-4bc0-bd5d-17b43c715ece.png)
![scattered_2d_n100_q500_pos_y](https://user-images.githubusercontent.com/5626552/171318524-a53125d8-ca6b-4232-8330-4584e3673639.png)

We can also load the input mesh from a blueprint file on disk:
```
# Generate a blueprint point mesh with 100 vertices using `gen2D` as the output mesh prefix
> ./examples/quest_scattered_interpolation_ex -d2 -n100 -o gen2d
# Load in the blueprint mesh from the previous run, and query at 5000 random points
> ./examples/quest_scattered_interpolation_ex -d2 -i gen2d_mesh_after_generate.root -q5000
```
Here is the `pos_x` field from the previous run
![scattered_2d_n100_q5000_pos_x_from_file](https://user-images.githubusercontent.com/5626552/171319236-f4989348-a7a4-4e2f-b298-b65da9cf9feb.png)

This also works in 3D. Here is  the `pos_z` field on a mesh with 1000 input points and 5000 query points:
```
> ./examples/quest_scattered_interpolation_ex -d3 -n1000 -q5000
```
![scattered_3d_n1000_q5000_pos_z](https://user-images.githubusercontent.com/5626552/171319816-cbec662b-5221-461b-84e6-392ba2bc83fc.png)



#### Next steps
When running on a user-provided input mesh, I noticed a few issues related to duplicated and/or co-planar points. I think these can be resolved by welding vertices that are sufficiently close, by rearranging the insertion order of the points. These will be the subject of a future PR.

