### PR TITLE
HIP execution policy

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -72,7 +72,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   points from a given 2D or 3D point mesh in the Mesh Blueprint format. The current implementation
   generates a Deluanay complex over the points and performs linear interpolation over the
   triangle/tetrahedron at the query points.
-- Adds a HIP execution policy for device kernels
+- Adds a HIP execution policy for device kernels to run on AMD GPU hardware
 
 ###  Changed
 - Axom now requires C++14 and will default to that if not specified via `BLT_CXX_STD`.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -72,6 +72,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   points from a given 2D or 3D point mesh in the Mesh Blueprint format. The current implementation
   generates a Deluanay complex over the points and performs linear interpolation over the
   triangle/tetrahedron at the query points.
+- Adds a HIP execution policy for device kernels
 
 ###  Changed
 - Axom now requires C++14 and will default to that if not specified via `BLT_CXX_STD`.

--- a/host-configs/rznevada-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
+++ b/host-configs/rznevada-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
@@ -11,19 +11,19 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_11_11_15_43/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_31_09_49_09/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_11_11_15_43/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_31_09_49_09/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_11_11_15_43/spack/lib/spack/env/clang/flang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_31_09_49_09/spack/lib/spack/env/clang/flang" CACHE PATH "")
 
 else()
 
-  set(CMAKE_C_COMPILER "/opt/rocm-5.1.0/llvm/bin/amdclang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdclang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/opt/rocm-5.1.0/llvm/bin/amdclang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdclang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/opt/rocm-5.1.0/llvm/bin/amdflang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdflang" CACHE PATH "")
 
 endif()
 
@@ -35,11 +35,11 @@ set(ENABLE_FORTRAN ON CACHE BOOL "")
 # MPI
 #------------------------------------------------------------------------------
 
-set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.13-rocmcc-5.1.0/bin/mpicc" CACHE PATH "")
+set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpicc" CACHE PATH "")
 
-set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.13-rocmcc-5.1.0/bin/mpicxx" CACHE PATH "")
+set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpicxx" CACHE PATH "")
 
-set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.13-rocmcc-5.1.0/bin/mpif90" CACHE PATH "")
+set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpif90" CACHE PATH "")
 
 set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
 
@@ -60,13 +60,13 @@ set(ENABLE_MPI ON CACHE BOOL "")
 
 set(ENABLE_HIP ON CACHE BOOL "")
 
-set(HIP_ROOT_DIR "/opt/rocm-5.1.0/hip" CACHE STRING "")
+set(HIP_ROOT_DIR "/opt/rocm-5.1.1/hip" CACHE STRING "")
 
-set(HIP_CLANG_PATH "/opt/rocm-5.1.0/hip/../llvm/bin" CACHE STRING "")
+set(HIP_CLANG_PATH "/opt/rocm-5.1.1/hip/../llvm/bin" CACHE STRING "")
 
 set(CMAKE_HIP_ARCHITECTURES "gfx908" CACHE STRING "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags -L/opt/rocm-5.1.0/hip/../llvm/lib -L/opt/rocm-5.1.0/hip/lib -Wl,-rpath,/opt/rocm-5.1.0/hip/../llvm/lib:/opt/rocm-5.1.0/hip/lib -lpgmath -lflang -lflangrti -lompstub -lamdhip64 -L/opt/rocm-5.1.0/hip/../lib64 -Wl,-rpath,/opt/rocm-5.1.0/hip/../lib64 -lhsakmt -lamd_comgr" CACHE STRING "")
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags -L/opt/rocm-5.1.1/hip/../llvm/lib -L/opt/rocm-5.1.1/hip/lib -Wl,-rpath,/opt/rocm-5.1.1/hip/../llvm/lib:/opt/rocm-5.1.1/hip/lib -lpgmath -lflang -lflangrti -lompstub -lamdhip64 -L/opt/rocm-5.1.1/hip/../lib64 -Wl,-rpath,/opt/rocm-5.1.1/hip/../lib64 -lhsakmt -lamd_comgr" CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
@@ -82,7 +82,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_11_11_15_43/clang-14.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_31_09_49_09/clang-14.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 

--- a/host-configs/rzvernal-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
+++ b/host-configs/rzvernal-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
@@ -11,19 +11,19 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_11_16_14_22/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_31_09_48_05/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_11_16_14_22/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_31_09_48_05/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_11_16_14_22/spack/lib/spack/env/clang/flang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_31_09_48_05/spack/lib/spack/env/clang/flang" CACHE PATH "")
 
 else()
 
-  set(CMAKE_C_COMPILER "/opt/rocm-5.1.0/llvm/bin/amdclang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdclang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/opt/rocm-5.1.0/llvm/bin/amdclang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdclang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/opt/rocm-5.1.0/llvm/bin/amdflang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdflang" CACHE PATH "")
 
 endif()
 
@@ -35,11 +35,11 @@ set(ENABLE_FORTRAN ON CACHE BOOL "")
 # MPI
 #------------------------------------------------------------------------------
 
-set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.13-rocmcc-5.1.0/bin/mpicc" CACHE PATH "")
+set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpicc" CACHE PATH "")
 
-set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.13-rocmcc-5.1.0/bin/mpicxx" CACHE PATH "")
+set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpicxx" CACHE PATH "")
 
-set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.13-rocmcc-5.1.0/bin/mpif90" CACHE PATH "")
+set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpif90" CACHE PATH "")
 
 set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
 
@@ -60,13 +60,13 @@ set(ENABLE_MPI ON CACHE BOOL "")
 
 set(ENABLE_HIP ON CACHE BOOL "")
 
-set(HIP_ROOT_DIR "/opt/rocm-5.1.0/hip" CACHE STRING "")
+set(HIP_ROOT_DIR "/opt/rocm-5.1.1/hip" CACHE STRING "")
 
-set(HIP_CLANG_PATH "/opt/rocm-5.1.0/hip/../llvm/bin" CACHE STRING "")
+set(HIP_CLANG_PATH "/opt/rocm-5.1.1/hip/../llvm/bin" CACHE STRING "")
 
 set(CMAKE_HIP_ARCHITECTURES "gfx90a" CACHE STRING "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags -L/opt/rocm-5.1.0/hip/../llvm/lib -L/opt/rocm-5.1.0/hip/lib -Wl,-rpath,/opt/rocm-5.1.0/hip/../llvm/lib:/opt/rocm-5.1.0/hip/lib -lpgmath -lflang -lflangrti -lompstub -lamdhip64 -L/opt/rocm-5.1.0/hip/../lib64 -Wl,-rpath,/opt/rocm-5.1.0/hip/../lib64 -lhsakmt -lamd_comgr" CACHE STRING "")
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags -L/opt/rocm-5.1.1/hip/../llvm/lib -L/opt/rocm-5.1.1/hip/lib -Wl,-rpath,/opt/rocm-5.1.1/hip/../llvm/lib:/opt/rocm-5.1.1/hip/lib -lpgmath -lflang -lflangrti -lompstub -lamdhip64 -L/opt/rocm-5.1.1/hip/../lib64 -Wl,-rpath,/opt/rocm-5.1.1/hip/../lib64 -lhsakmt -lamd_comgr" CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
@@ -82,7 +82,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_11_16_14_22/clang-14.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_31_09_48_05/clang-14.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 

--- a/host-configs/tioga-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
+++ b/host-configs/tioga-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
@@ -1,0 +1,115 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.21.1/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+# Compiler Spec: clang@14.0.0
+#------------------------------------------------------------------------------
+if(DEFINED ENV{SPACK_CC})
+
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_26_16_06_00/spack/lib/spack/env/clang/clang" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_26_16_06_00/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_26_16_06_00/spack/lib/spack/env/clang/flang" CACHE PATH "")
+
+else()
+
+  set(CMAKE_C_COMPILER "/opt/rocm-5.1.0/llvm/bin/amdclang" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/opt/rocm-5.1.0/llvm/bin/amdclang++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/opt/rocm-5.1.0/llvm/bin/amdflang" CACHE PATH "")
+
+endif()
+
+set(CMAKE_Fortran_FLAGS "-Mfreeform" CACHE STRING "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.13-rocmcc-5.1.0/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.13-rocmcc-5.1.0/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.13-rocmcc-5.1.0/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# Hardware
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+
+# HIP
+
+#------------------------------------------------------------------------------
+
+
+set(ENABLE_HIP ON CACHE BOOL "")
+
+set(HIP_ROOT_DIR "/opt/rocm-5.1.0/hip" CACHE STRING "")
+
+set(HIP_CLANG_PATH "/opt/rocm-5.1.0/hip/../llvm/bin" CACHE STRING "")
+
+set(CMAKE_HIP_ARCHITECTURES "gfx90a" CACHE STRING "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags -L/opt/rocm-5.1.0/hip/../llvm/lib -L/opt/rocm-5.1.0/hip/lib -Wl,-rpath,/opt/rocm-5.1.0/hip/../llvm/lib:/opt/rocm-5.1.0/hip/lib -lpgmath -lflang -lflangrti -lompstub -lamdhip64 -L/opt/rocm-5.1.0/hip/../lib64 -Wl,-rpath,/opt/rocm-5.1.0/hip/../lib64 -lhsakmt -lamd_comgr" CACHE STRING "")
+
+#------------------------------------------------
+# Hardware Specifics
+#------------------------------------------------
+
+set(ENABLE_OPENMP OFF CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_26_16_06_00/clang-14.0.0" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.2.0" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2022.03.1" CACHE PATH "")
+
+set(CAMP_DIR "${TPL_ROOT}/camp-2022.03.0" CACHE PATH "")
+
+# scr not built
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# ClangFormat disabled due to disabled devtools
+
+set(ENABLE_CLANGFORMAT OFF CACHE BOOL "")
+
+set(ENABLE_DOCS OFF CACHE BOOL "")
+
+

--- a/host-configs/tioga-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
+++ b/host-configs/tioga-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
@@ -11,19 +11,19 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_26_16_06_00/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_31_10_25_58/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_26_16_06_00/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_31_10_25_58/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_26_16_06_00/spack/lib/spack/env/clang/flang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_31_10_25_58/spack/lib/spack/env/clang/flang" CACHE PATH "")
 
 else()
 
-  set(CMAKE_C_COMPILER "/opt/rocm-5.1.0/llvm/bin/amdclang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdclang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/opt/rocm-5.1.0/llvm/bin/amdclang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdclang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/opt/rocm-5.1.0/llvm/bin/amdflang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdflang" CACHE PATH "")
 
 endif()
 
@@ -35,11 +35,11 @@ set(ENABLE_FORTRAN ON CACHE BOOL "")
 # MPI
 #------------------------------------------------------------------------------
 
-set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.13-rocmcc-5.1.0/bin/mpicc" CACHE PATH "")
+set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpicc" CACHE PATH "")
 
-set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.13-rocmcc-5.1.0/bin/mpicxx" CACHE PATH "")
+set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpicxx" CACHE PATH "")
 
-set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.13-rocmcc-5.1.0/bin/mpif90" CACHE PATH "")
+set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpif90" CACHE PATH "")
 
 set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
 
@@ -60,13 +60,13 @@ set(ENABLE_MPI ON CACHE BOOL "")
 
 set(ENABLE_HIP ON CACHE BOOL "")
 
-set(HIP_ROOT_DIR "/opt/rocm-5.1.0/hip" CACHE STRING "")
+set(HIP_ROOT_DIR "/opt/rocm-5.1.1/hip" CACHE STRING "")
 
-set(HIP_CLANG_PATH "/opt/rocm-5.1.0/hip/../llvm/bin" CACHE STRING "")
+set(HIP_CLANG_PATH "/opt/rocm-5.1.1/hip/../llvm/bin" CACHE STRING "")
 
 set(CMAKE_HIP_ARCHITECTURES "gfx90a" CACHE STRING "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags -L/opt/rocm-5.1.0/hip/../llvm/lib -L/opt/rocm-5.1.0/hip/lib -Wl,-rpath,/opt/rocm-5.1.0/hip/../llvm/lib:/opt/rocm-5.1.0/hip/lib -lpgmath -lflang -lflangrti -lompstub -lamdhip64 -L/opt/rocm-5.1.0/hip/../lib64 -Wl,-rpath,/opt/rocm-5.1.0/hip/../lib64 -lhsakmt -lamd_comgr" CACHE STRING "")
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags -L/opt/rocm-5.1.1/hip/../llvm/lib -L/opt/rocm-5.1.1/hip/lib -Wl,-rpath,/opt/rocm-5.1.1/hip/../llvm/lib:/opt/rocm-5.1.1/hip/lib -lpgmath -lflang -lflangrti -lompstub -lamdhip64 -L/opt/rocm-5.1.1/hip/../lib64 -Wl,-rpath,/opt/rocm-5.1.1/hip/../lib64 -lhsakmt -lamd_comgr" CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
@@ -82,7 +82,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_26_16_06_00/clang-14.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_05_31_10_25_58/clang-14.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 

--- a/scripts/spack/configs/toss_4_x86_64_ib_cray/compilers.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib_cray/compilers.yaml
@@ -7,9 +7,9 @@ compilers:
     modules: []
     operating_system: rhel8
     paths:
-      cc: /opt/rocm-5.1.0/llvm/bin/amdclang
-      cxx: /opt/rocm-5.1.0/llvm/bin/amdclang++
-      f77: /opt/rocm-5.1.0/llvm/bin/amdflang
-      fc: /opt/rocm-5.1.0/llvm/bin/amdflang
+      cc: /opt/rocm-5.1.1/llvm/bin/amdclang
+      cxx: /opt/rocm-5.1.1/llvm/bin/amdclang++
+      f77: /opt/rocm-5.1.1/llvm/bin/amdflang
+      fc: /opt/rocm-5.1.1/llvm/bin/amdflang
     spec: clang@14.0.0
     target: x86_64

--- a/scripts/spack/configs/toss_4_x86_64_ib_cray/packages.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib_cray/packages.yaml
@@ -22,39 +22,39 @@ packages:
       mpi: [cray-mpich]
 
   hip:
-    version: [5.1.0]
+    version: [5.1.1]
     buildable: false
     externals:
-    - spec: hip@5.1.0
-      prefix: /opt/rocm-5.1.0/hip
+    - spec: hip@5.1.1
+      prefix: /opt/rocm-5.1.1/hip
 
   llvm-amdgpu:
-    version: [5.1.0]
+    version: [5.1.1]
     buildable: false
     externals:
-    - spec: llvm-amdgpu@5.1.0
-      prefix: /opt/rocm-5.1.0/llvm
+    - spec: llvm-amdgpu@5.1.1
+      prefix: /opt/rocm-5.1.1/llvm
 
   hsa-rocr-dev:
-    version: [5.1.0]
+    version: [5.1.1]
     buildable: false
     externals:
-    - spec: hsa-rocr-dev@5.1.0
-      prefix: /opt/rocm-5.1.0/
+    - spec: hsa-rocr-dev@5.1.1
+      prefix: /opt/rocm-5.1.1/
 
   rocminfo:
-    version: [5.1.0]
+    version: [5.1.1]
     buildable: false
     externals:
-    - spec: rocminfo@5.1.0
-      prefix: /opt/rocm-5.1.0/
+    - spec: rocminfo@5.1.1
+      prefix: /opt/rocm-5.1.1/
 
   rocm-device-libs:
-    version: [5.1.0]
+    version: [5.1.1]
     buildable: false
     externals:
-    - spec: rocm-device-libs@5.1.0
-      prefix: /opt/rocm-5.1.0/
+    - spec: rocm-device-libs@5.1.1
+      prefix: /opt/rocm-5.1.1/
 
 # Lock down which MPI we are using
   mpi:
@@ -62,8 +62,8 @@ packages:
   cray-mpich:
     buildable: false
     externals:
-    - spec: cray-mpich@8.1.13%clang@14.0.0+slurm
-      prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.13-rocmcc-5.1.0/
+    - spec: cray-mpich@8.1.16%clang@14.0.0+slurm
+      prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/
 
   # blas is a bit more complicated because its a virtual package so fake it with
   # the following per spack docs

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -216,7 +216,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
         if "+fortran" in spec:
             entries.append(cmake_cache_option("ENABLE_FORTRAN", True))
-            if is_fortran_compiler("gfortran") and "clang" in self.compiler.cxx:
+            if self.is_fortran_compiler("gfortran") and "clang" in self.compiler.cxx:
                 libdir = pjoin(os.path.dirname(
                                os.path.dirname(self.compiler.cxx)), "lib")
                 flags = ""
@@ -301,7 +301,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
             if "+fortran" in spec:
                 # Flags for crayftn
-                if is_fortran_compiler("crayftn"):
+                if self.is_fortran_compiler("crayftn"):
                     # Fix for working around CMake adding implicit link directories
                     # returned by the Cray crayftn compiler to link executables with
                     # non-system default stdlib
@@ -314,7 +314,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
                     hip_link_flags = "-Wl,--disable-new-dtags -L/opt/cray/pe/cce/13.0.1/cce/x86_64/lib -L/opt/cray/pe/cce/13.0.1/cce/x86_64/lib -Wl,-rpath,/opt/cray/pe/cce/13.0.1/cce/x86_64/lib:/opt/cray/pe/cce/13.0.1/cce/x86_64/lib -lmodules -lquadmath -lfi -lcraymath -lf -lu -lcsup"
 
                 # Flags for amdflang
-                if is_fortran_compiler("amdflang"):
+                if self.is_fortran_compiler("amdflang"):
                     hip_link_flags = "-Wl,--disable-new-dtags -L{0}/../llvm/lib -L{0}/lib -Wl,-rpath,{0}/../llvm/lib:{0}/lib -lpgmath -lflang -lflangrti -lompstub -lamdhip64".format(hip_root)
 
             # Additional libraries for TOSS4
@@ -336,7 +336,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             not spec.satisfies('+cuda target=ppc64le:')
         ))
 
-        if "+fortran" in spec and is_fortran_compiler("xlf"):
+        if "+fortran" in spec and self.is_fortran_compiler("xlf"):
             # Grab lib directory for the current fortran compiler
             libdir = pjoin(os.path.dirname(
                            os.path.dirname(self.compiler.fc)),

--- a/src/axom/config.hpp.in
+++ b/src/axom/config.hpp.in
@@ -66,6 +66,7 @@
 #cmakedefine AXOM_USE_CLI11
 #cmakedefine AXOM_USE_CONDUIT
 #cmakedefine AXOM_USE_CUDA
+#cmakedefine AXOM_USE_HIP
 #cmakedefine AXOM_USE_FMT
 #cmakedefine AXOM_USE_HDF5
 #cmakedefine AXOM_USE_LUA

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -804,7 +804,7 @@ struct ArrayOpsBase<T, false>
                          const T* values,
                          MemorySpace space)
   {
-#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
     if(TriviallyCopyable<T>::value)
     {
       axom::copy(array + begin, values, sizeof(T) * nelems);
@@ -886,15 +886,14 @@ struct ArrayOpsBase<T, false>
   }
 };
 
-#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
 template <typename T>
 struct ArrayOpsBase<T, true>
 {
-
   #if defined(__CUDACC__)
-    using ExecSpace = axom::CUDA_EXEC<256>;
+  using ExecSpace = axom::CUDA_EXEC<256>;
   #else
-    using ExecSpace = axom::HIP_EXEC<256>;
+  using ExecSpace = axom::HIP_EXEC<256>;
   #endif
 
   static constexpr bool InitOnDevice = HasTrivialDefaultCtor<T>::value;
@@ -1139,7 +1138,7 @@ template <typename T, MemorySpace SPACE>
 struct ArrayOps
 {
 private:
-#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
   constexpr static bool IsDevice = (SPACE == MemorySpace::Device);
 #else
   constexpr static bool IsDevice = false;
@@ -1212,14 +1211,14 @@ struct ArrayOps<T, MemorySpace::Dynamic>
 {
 private:
   using Base = ArrayOpsBase<T, false>;
-#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
   using BaseDevice = ArrayOpsBase<T, true>;
 #endif
 
 public:
   static void init(T* array, IndexType begin, IndexType nelems, int allocId)
   {
-#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1239,7 +1238,7 @@ public:
                    int allocId,
                    const T& value)
   {
-#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1260,7 +1259,7 @@ public:
                          const T* values,
                          MemorySpace valueSpace)
   {
-#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1281,7 +1280,7 @@ public:
     {
       return;
     }
-#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1305,7 +1304,7 @@ public:
     {
       return;
     }
-#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1322,7 +1321,7 @@ public:
   template <typename... Args>
   static void emplace(T* array, IndexType dst, IndexType allocId, Args&&... args)
   {
-#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -804,7 +804,7 @@ struct ArrayOpsBase<T, false>
                          const T* values,
                          MemorySpace space)
   {
-#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
     if(TriviallyCopyable<T>::value)
     {
       axom::copy(array + begin, values, sizeof(T) * nelems);
@@ -886,7 +886,7 @@ struct ArrayOpsBase<T, false>
   }
 };
 
-#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
 template <typename T>
 struct ArrayOpsBase<T, true>
 {
@@ -1138,7 +1138,7 @@ template <typename T, MemorySpace SPACE>
 struct ArrayOps
 {
 private:
-#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
   constexpr static bool IsDevice = (SPACE == MemorySpace::Device);
 #else
   constexpr static bool IsDevice = false;
@@ -1211,14 +1211,14 @@ struct ArrayOps<T, MemorySpace::Dynamic>
 {
 private:
   using Base = ArrayOpsBase<T, false>;
-#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
   using BaseDevice = ArrayOpsBase<T, true>;
 #endif
 
 public:
   static void init(T* array, IndexType begin, IndexType nelems, int allocId)
   {
-#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1238,7 +1238,7 @@ public:
                    int allocId,
                    const T& value)
   {
-#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1259,7 +1259,7 @@ public:
                          const T* values,
                          MemorySpace valueSpace)
   {
-#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1280,7 +1280,7 @@ public:
     {
       return;
     }
-#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1304,7 +1304,7 @@ public:
     {
       return;
     }
-#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1321,7 +1321,7 @@ public:
   template <typename... Args>
   static void emplace(T* array, IndexType dst, IndexType allocId, Args&&... args)
   {
-#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -804,7 +804,7 @@ struct ArrayOpsBase<T, false>
                          const T* values,
                          MemorySpace space)
   {
-#if defined(__CUDACC__) && defined(AXOM_USE_UMPIRE)
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
     if(TriviallyCopyable<T>::value)
     {
       axom::copy(array + begin, values, sizeof(T) * nelems);
@@ -886,11 +886,16 @@ struct ArrayOpsBase<T, false>
   }
 };
 
-#if defined(__CUDACC__) && defined(AXOM_USE_UMPIRE)
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
 template <typename T>
 struct ArrayOpsBase<T, true>
 {
-  using ExecSpace = axom::CUDA_EXEC<256>;
+
+  #if defined(__CUDACC__)
+    using ExecSpace = axom::CUDA_EXEC<256>;
+  #else
+    using ExecSpace = axom::HIP_EXEC<256>;
+  #endif
 
   static constexpr bool InitOnDevice = HasTrivialDefaultCtor<T>::value;
   static constexpr bool DestroyOnHost = !std::is_trivially_destructible<T>::value;
@@ -1134,7 +1139,7 @@ template <typename T, MemorySpace SPACE>
 struct ArrayOps
 {
 private:
-#if defined(__CUDACC__) && defined(AXOM_USE_UMPIRE)
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
   constexpr static bool IsDevice = (SPACE == MemorySpace::Device);
 #else
   constexpr static bool IsDevice = false;
@@ -1207,14 +1212,14 @@ struct ArrayOps<T, MemorySpace::Dynamic>
 {
 private:
   using Base = ArrayOpsBase<T, false>;
-#if defined(__CUDACC__) && defined(AXOM_USE_UMPIRE)
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
   using BaseDevice = ArrayOpsBase<T, true>;
 #endif
 
 public:
   static void init(T* array, IndexType begin, IndexType nelems, int allocId)
   {
-#if defined(__CUDACC__) && defined(AXOM_USE_UMPIRE)
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1234,7 +1239,7 @@ public:
                    int allocId,
                    const T& value)
   {
-#if defined(__CUDACC__) && defined(AXOM_USE_UMPIRE)
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1255,7 +1260,7 @@ public:
                          const T* values,
                          MemorySpace valueSpace)
   {
-#if defined(__CUDACC__) && defined(AXOM_USE_UMPIRE)
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1276,7 +1281,7 @@ public:
     {
       return;
     }
-#if defined(__CUDACC__) && defined(AXOM_USE_UMPIRE)
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1300,7 +1305,7 @@ public:
     {
       return;
     }
-#if defined(__CUDACC__) && defined(AXOM_USE_UMPIRE)
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)
@@ -1317,7 +1322,7 @@ public:
   template <typename... Args>
   static void emplace(T* array, IndexType dst, IndexType allocId, Args&&... args)
   {
-#if defined(__CUDACC__) && defined(AXOM_USE_UMPIRE)
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
     MemorySpace space = getAllocatorSpace(allocId);
 
     if(space == MemorySpace::Device)

--- a/src/axom/core/ArrayView.hpp
+++ b/src/axom/core/ArrayView.hpp
@@ -175,9 +175,9 @@ ArrayView<T, DIM, SPACE>::ArrayView(T* data, Args... args)
 
 //------------------------------------------------------------------------------
 template <typename T, int DIM, MemorySpace SPACE>
-AXOM_HOST_DEVICE
-ArrayView<T, DIM, SPACE>::ArrayView(T* data,
-                                    const StackArray<IndexType, DIM>& shape)
+AXOM_HOST_DEVICE ArrayView<T, DIM, SPACE>::ArrayView(
+  T* data,
+  const StackArray<IndexType, DIM>& shape)
   : ArrayBase<T, DIM, ArrayView<T, DIM, SPACE>>(shape)
   , m_data(data)
 #ifndef AXOM_DEVICE_CODE

--- a/src/axom/core/ArrayView.hpp
+++ b/src/axom/core/ArrayView.hpp
@@ -175,6 +175,7 @@ ArrayView<T, DIM, SPACE>::ArrayView(T* data, Args... args)
 
 //------------------------------------------------------------------------------
 template <typename T, int DIM, MemorySpace SPACE>
+AXOM_HOST_DEVICE
 ArrayView<T, DIM, SPACE>::ArrayView(T* data,
                                     const StackArray<IndexType, DIM>& shape)
   : ArrayBase<T, DIM, ArrayView<T, DIM, SPACE>>(shape)

--- a/src/axom/core/CMakeLists.txt
+++ b/src/axom/core/CMakeLists.txt
@@ -69,6 +69,7 @@ set(core_headers
     execution/internal/seq_exec.hpp
     execution/internal/omp_exec.hpp
     execution/internal/cuda_exec.hpp
+    execution/internal/hip_exec.hpp
 
     )
 

--- a/src/axom/core/Macros.hpp
+++ b/src/axom/core/Macros.hpp
@@ -19,12 +19,12 @@
  * \def AXOM_DEVICE
  * \def AXOM_HOST_DEVICE
  *
- * \brief CUDA host/device macros for decorating functions/lambdas
+ * \brief CUDA or HIP host/device macros for decorating functions/lambdas
  *
- * \note These will expand to the corresponding CUDA decorations when
- *  compiled with -DAXOM_USE_CUDA
+ * \note These will expand to the corresponding CUDA/HIP decorations when
+ *  compiled with -DAXOM_USE_CUDA or -DAXOM_USE_HIP
  */
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
   #define AXOM_DEVICE __device__
   #define AXOM_HOST_DEVICE __host__ __device__
   #define AXOM_HOST __host__
@@ -69,15 +69,15 @@
  * \def AXOM_LAMBDA
  *
  * \brief Convenience macro used for lambda capture by value.
- * \note When CUDA is used, the macro always expands to a host/device lambda.
+ * \note When CUDA or HIP is used, the macro always expands to a host/device lambda.
  *
- * \warning When compiling with CUDA, host/device lambdas incur a significant
+ * \warning When compiling with CUDA or HIP, host/device lambdas incur a significant
  *  penalty on the CPU code. The way NVCC implements host/device lambdas
- *  prevents the compiler from proper in-lining them. When CUDA is enabled use
- *  the parallel_gpu execution policy or opt to turn off CUDA if the application
+ *  prevents the compiler from proper in-lining them. When CUDA or HIP is enabled use
+ *  the parallel_gpu execution policy or opt to turn off CUDA or HIP if the application
  *  is making more use of the parallel_cpu and serial execution policies.
  */
-#ifdef AXOM_USE_CUDA
+#if defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)
   #define AXOM_LAMBDA [=] AXOM_HOST_DEVICE
   #define AXOM_DEVICE_LAMBDA [=] AXOM_DEVICE
   #define AXOM_HOST_LAMBDA [=] AXOM_HOST
@@ -102,11 +102,25 @@
 #endif
 
 /*!
+ * \def AXOM_HIP_TEST
+ *
+ * \brief Convenience macro used for a gtest that uses hip.
+ */
+#if defined(AXOM_USE_HIP)
+  #define AXOM_HIP_TEST(X, Y)         \
+    static void hip_test_##X##Y();    \
+    TEST(X, Y) { hip_test_##X##Y(); } \
+    static void hip_test_##X##Y()
+#else
+  #define AXOM_HIP_TEST(X, Y) TEST(X, Y)
+#endif
+
+/*!
  * \def AXOM_DEVICE_CODE
  *
  * \brief Convenience macro used for kernel code
  */
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   #define AXOM_DEVICE_CODE
 #endif
 

--- a/src/axom/core/Macros.hpp
+++ b/src/axom/core/Macros.hpp
@@ -16,6 +16,15 @@
 #include <cassert>  // for assert()
 
 /*!
+ * \def AXOM_GPUCC
+ *
+ * \brief Convenience macro for compiling CUDA/HIP source files
+ */
+#if defined(__CUDACC__) || defined(__HIPCC__)
+  #define AXOM_GPUCC
+#endif
+
+/*!
  * \def AXOM_DEVICE
  * \def AXOM_HOST_DEVICE
  *
@@ -66,16 +75,19 @@
 #endif
 
 /*!
+ * \def AXOM_USE_GPU
+ *
+ * \brief Convenience macro used for GPU-enabled checks
+ */
+#if defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)
+  #define AXOM_USE_GPU
+#endif
+
+/*!
  * \def AXOM_LAMBDA
  *
  * \brief Convenience macro used for lambda capture by value.
  * \note When CUDA or HIP is used, the macro always expands to a host/device lambda.
- *
- * \warning When compiling with CUDA or HIP, host/device lambdas incur a significant
- *  penalty on the CPU code. The way NVCC implements host/device lambdas
- *  prevents the compiler from proper in-lining them. When CUDA or HIP is enabled use
- *  the parallel_gpu execution policy or opt to turn off CUDA or HIP if the application
- *  is making more use of the parallel_cpu and serial execution policies.
  */
 #if defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)
   #define AXOM_LAMBDA [=] AXOM_HOST_DEVICE

--- a/src/axom/core/Macros.hpp
+++ b/src/axom/core/Macros.hpp
@@ -102,20 +102,6 @@
 #endif
 
 /*!
- * \def AXOM_HIP_TEST
- *
- * \brief Convenience macro used for a gtest that uses hip.
- */
-#if defined(AXOM_USE_HIP)
-  #define AXOM_HIP_TEST(X, Y)         \
-    static void hip_test_##X##Y();    \
-    TEST(X, Y) { hip_test_##X##Y(); } \
-    static void hip_test_##X##Y()
-#else
-  #define AXOM_HIP_TEST(X, Y) TEST(X, Y)
-#endif
-
-/*!
  * \def AXOM_DEVICE_CODE
  *
  * \brief Convenience macro used for kernel code

--- a/src/axom/core/docs/sphinx/core_acceleration.rst
+++ b/src/axom/core/docs/sphinx/core_acceleration.rst
@@ -53,11 +53,11 @@ Here is an Axom example showing sequential execution:
    :end-before: _exebasic_end
    :language: C++
 
-Here's the same loop from the above snippet, this time with CUDA:
+Here's the same loop from the above snippet, this time with CUDA or HIP:
 
 .. literalinclude:: ../../examples/core_acceleration.cpp
-   :start-after: _cudaexebasic_start
-   :end-before: _cudaexebasic_end
+   :start-after: _deviceexebasic_start
+   :end-before: _deviceexebasic_end
    :language: C++
 
 For more advanced functionality, users can directly call RAJA and Umpire.

--- a/src/axom/core/docs/sphinx/core_containers.rst
+++ b/src/axom/core/docs/sphinx/core_containers.rst
@@ -211,15 +211,15 @@ To illustrate how different memory spaces can be required, the following kernel 
 input arrays ``A`` and ``B`` are in unified memory and its output array ``C`` is in device memory.
 
 .. literalinclude:: ../../examples/core_containers.cpp
-   :start-after: _cuda_kernel_start
-   :end-before: _cuda_kernel_end
+   :start-after: _device_kernel_start
+   :end-before: _device_kernel_end
    :language: C++
 
 The following snippet illustrates how one would create and initialize the inputs/outputs to this kernel.
 
 .. literalinclude:: ../../examples/core_containers.cpp
-   :start-after: _cuda_array_create_start
-   :end-before: _cuda_array_create_end
+   :start-after: _device_array_create_start
+   :end-before: _device_array_create_end
    :language: C++
 
 .. note:: Unless the Dynamic memory space is in use, the ``Array`` constructor will
@@ -229,8 +229,8 @@ The following snippet illustrates how one would create and initialize the inputs
 We can now launch the kernel and display the results via a transfer back to host-accessible memory:
 
 .. literalinclude:: ../../examples/core_containers.cpp
-   :start-after: _cuda_array_call_start
-   :end-before: _cuda_array_call_end
+   :start-after: _device_array_call_start
+   :end-before: _device_array_call_end
    :language: C++
 
 If RAJA is available, we can also use Axom's acceleration utilities to perform an operation on the GPU
@@ -245,8 +245,8 @@ By default, ``Array`` copies and moves will propagate the allocator ID; this ens
 with ``Array`` members do not accidentally move their data to the host when copied or moved:
 
 .. literalinclude:: ../../examples/core_containers.cpp
-   :start-after: _cuda_array_propagate_start
-   :end-before: _cuda_array_propagate_end
+   :start-after: _device_array_propagate_start
+   :end-before: _device_array_propagate_end
    :language: C++
 
 ##########

--- a/src/axom/core/examples/core_acceleration.cpp
+++ b/src/axom/core/examples/core_acceleration.cpp
@@ -117,10 +117,11 @@ void demoAxomExecution()
 
 // _exebasic_end
 
-//Now, let's say we want to try out use of CUDA. We just change that execution space.
+//Now, let's say we want to try out use of CUDA or HIP. We just change that execution space.
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE) && \
-  defined(AXOM_USE_CUDA) && defined(__CUDACC__)
-  // _cudaexebasic_start
+  ((defined(AXOM_USE_CUDA) && defined(__CUDACC__)) ||     \
+   (defined(AXOM_USE_HIP) && defined(__HIPCC__)))
+  // _deviceexebasic_start
   //This example requires Umpire to be in use, and Unified memory available.
   const int allocator_id = axom::getUmpireResourceAllocatorID(
     umpire::resource::MemoryResourceType::Unified);
@@ -135,18 +136,27 @@ void demoAxomExecution()
     C[i] = 0;
   }
 
-  axom::for_all<axom::CUDA_EXEC<256>>(
+  #if defined(__CUDACC__)
+  using ExecSpace = axom::CUDA_EXEC<256>;
+  #elif defined(__HIPCC__)
+  using ExecSpace = axom::HIP_EXEC<256>;
+  #else
+  using ExecSpace = axom::SEQ_EXEC;
+  #endif
+
+  axom::for_all<ExecSpace>(
     0,
     N,
     AXOM_LAMBDA(axom::IndexType i) { C[i] = A[i] + B[i]; });
 
-  std::cout << "Sums: " << std::endl;
+  std::cout << "\nSums (" << axom::execution_space<ExecSpace>::name()
+            << ") :" << std::endl;
   for(int i = 0; i < N; i++)
   {
     std::cout << C[i] << " ";
   }
   std::cout << std::endl;
-// _cudaexebasic_end
+// _deviceexebasic_end
 #endif
 }
 

--- a/src/axom/core/examples/core_acceleration.cpp
+++ b/src/axom/core/examples/core_acceleration.cpp
@@ -119,8 +119,7 @@ void demoAxomExecution()
 
 //Now, let's say we want to try out use of CUDA or HIP. We just change that execution space.
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE) && \
-  ((defined(AXOM_USE_CUDA) && defined(__CUDACC__)) ||     \
-   (defined(AXOM_USE_HIP) && defined(__HIPCC__)))
+  defined(AXOM_USE_GPU) && defined(AXOM_GPUCC)
   // _deviceexebasic_start
   //This example requires Umpire to be in use, and Unified memory available.
   const int allocator_id = axom::getUmpireResourceAllocatorID(

--- a/src/axom/core/examples/core_containers.cpp
+++ b/src/axom/core/examples/core_containers.cpp
@@ -323,8 +323,10 @@ void demoArrayDevice()
     // Write to the underlying array through C_view, which is captured by value
     #if defined(__CUDACC__)
   using ExecSpace = axom::CUDA_EXEC<1>;
-    #else
+    #elif defined(__HIPCC__)
   using ExecSpace = axom::HIP_EXEC<1>;
+    #else
+  using ExecSpace = axom::SEQ_EXEC;
     #endif
 
   axom::for_all<ExecSpace>(0, N, [=] AXOM_HOST_DEVICE(axom::IndexType i) {

--- a/src/axom/core/examples/core_containers.cpp
+++ b/src/axom/core/examples/core_containers.cpp
@@ -171,8 +171,7 @@ void demoArrayBasic()
 }
 
 // The following example requires CUDA or HIP + Umpire + unified memory
-#if defined(AXOM_USE_UMPIRE) &&                        \
-  (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && \
+#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_GPU) && \
   defined(UMPIRE_ENABLE_UM)
   #define AXOM_CONTAINERS_EXAMPLE_ON_DEVICE
 #endif

--- a/src/axom/core/examples/core_containers.cpp
+++ b/src/axom/core/examples/core_containers.cpp
@@ -171,7 +171,7 @@ void demoArrayBasic()
 }
 
 // The following example requires CUDA or HIP + Umpire + unified memory
-#if defined(AXOM_USE_UMPIRE) && \
+#if defined(AXOM_USE_UMPIRE) &&                        \
   (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && \
   defined(UMPIRE_ENABLE_UM)
   #define AXOM_CONTAINERS_EXAMPLE_ON_DEVICE
@@ -320,12 +320,12 @@ void demoArrayDevice()
   axom::Array<int, 1, axom::MemorySpace::Device> C_device_raja(N);
   DeviceIntArrayView C_view = C_device_raja;
 
-  // Write to the underlying array through C_view, which is captured by value
-  #if defined(__CUDACC__)
-    using ExecSpace = axom::CUDA_EXEC<1>;
-  #else
-    using ExecSpace = axom::HIP_EXEC<1>;
-  #endif
+    // Write to the underlying array through C_view, which is captured by value
+    #if defined(__CUDACC__)
+  using ExecSpace = axom::CUDA_EXEC<1>;
+    #else
+  using ExecSpace = axom::HIP_EXEC<1>;
+    #endif
 
   axom::for_all<ExecSpace>(0, N, [=] AXOM_HOST_DEVICE(axom::IndexType i) {
     C_view[i] = A_view[i] + B_view[i] + 1;

--- a/src/axom/core/execution/execution_space.hpp
+++ b/src/axom/core/execution/execution_space.hpp
@@ -102,4 +102,9 @@ struct execution_space
   #include "axom/core/execution/internal/cuda_exec.hpp"
 #endif
 
+#if defined(AXOM_USE_HIP) && defined(AXOM_USE_RAJA) && \
+  defined(AXOM_USE_UMPIRE) && defined(__HIPCC__)
+  #include "axom/core/execution/internal/hip_exec.hpp"
+#endif
+
 #endif  // AXOM_EXECUTIONSPACE_HPP_

--- a/src/axom/core/execution/internal/hip_exec.hpp
+++ b/src/axom/core/execution/internal/hip_exec.hpp
@@ -85,10 +85,7 @@ struct execution_space<HIP_EXEC<BLOCK_SIZE, ASYNC>>
   static constexpr bool async() noexcept { return true; }
   static constexpr bool valid() noexcept { return true; }
   static constexpr bool onDevice() noexcept { return true; }
-  static constexpr char* name() noexcept
-  {
-    return (char*)"[HIP_EXEC] (async)";
-  }
+  static constexpr char* name() noexcept { return (char*)"[HIP_EXEC] (async)"; }
   static int allocatorID() noexcept
   {
     return axom::getUmpireResourceAllocatorID(umpire::resource::Unified);

--- a/src/axom/core/execution/internal/hip_exec.hpp
+++ b/src/axom/core/execution/internal/hip_exec.hpp
@@ -1,0 +1,99 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_HIP_EXEC_HPP_
+#define AXOM_HIP_EXEC_HPP_
+
+#include "axom/config.hpp"
+#include "axom/core/memory_management.hpp"
+
+#include "RAJA/RAJA.hpp"
+#include "umpire/Umpire.hpp"
+
+#ifndef RAJA_ENABLE_HIP
+  #error HIP_EXEC requires a HIP enabled RAJA
+#endif
+
+#if !defined(UMPIRE_ENABLE_HIP) && !defined(UMPIRE_ENABLE_UM)
+  #error HIP_EXEC requires a HIP enabled UMPIRE with UM support
+#endif
+
+namespace axom
+{
+enum ExecutionMode
+{
+  SYNCHRONOUS,
+  ASYNC
+};
+
+/*!
+ * \brief Indicates parallel execution on the GPU with HIP.
+ *
+ * \tparam BLOCK_SIZE the number of HIP threads in a block.
+ * \tparam ExecutionMode indicates synchronous or asynchronous execution.
+ */
+template <int BLOCK_SIZE, ExecutionMode EXEC_MODE = SYNCHRONOUS>
+struct HIP_EXEC
+{ };
+
+/*!
+ * \brief execution_space traits specialization for HIP_EXEC.
+ *
+ * \tparam BLOCK_SIZE the number of HIP threads to launch
+ *
+ */
+template <int BLOCK_SIZE>
+struct execution_space<HIP_EXEC<BLOCK_SIZE, SYNCHRONOUS>>
+{
+  using loop_policy = RAJA::hip_exec<BLOCK_SIZE>;
+
+  using reduce_policy = RAJA::hip_reduce;
+  using atomic_policy = RAJA::hip_atomic;
+  using sync_policy = RAJA::hip_synchronize;
+
+  static constexpr MemorySpace memory_space = MemorySpace::Device;
+
+  static constexpr bool async() noexcept { return false; }
+  static constexpr bool valid() noexcept { return true; }
+  static constexpr bool onDevice() noexcept { return true; }
+  static constexpr char* name() noexcept { return (char*)"[HIP_EXEC]"; }
+  static int allocatorID() noexcept
+  {
+    return axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  }
+};
+
+/*!
+ * \brief execution_space traits specialization for HIP_EXEC.
+ *
+ * \tparam BLOCK_SIZE the number of HIP threads to launch
+ *
+ */
+template <int BLOCK_SIZE>
+struct execution_space<HIP_EXEC<BLOCK_SIZE, ASYNC>>
+{
+  using loop_policy = RAJA::hip_exec_async<BLOCK_SIZE>;
+
+  using reduce_policy = RAJA::hip_reduce;
+  using atomic_policy = RAJA::hip_atomic;
+  using sync_policy = RAJA::hip_synchronize;
+
+  static constexpr MemorySpace memory_space = MemorySpace::Device;
+
+  static constexpr bool async() noexcept { return true; }
+  static constexpr bool valid() noexcept { return true; }
+  static constexpr bool onDevice() noexcept { return true; }
+  static constexpr char* name() noexcept
+  {
+    return (char*)"[HIP_EXEC] (async)";
+  }
+  static int allocatorID() noexcept
+  {
+    return axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  }
+};
+}  // namespace axom
+
+#endif  // AXOM_HIP_EXEC_HPP_

--- a/src/axom/core/numerics/matvecops.hpp
+++ b/src/axom/core/numerics/matvecops.hpp
@@ -543,7 +543,7 @@ inline bool linspace(const T& x0, const T& x1, T* v, int N)
 
 //------------------------------------------------------------------------------
 template <typename T>
-inline void cross_product(const T* u, const T* v, T* w)
+inline AXOM_HOST_DEVICE void cross_product(const T* u, const T* v, T* w)
 {
   assert("pre: u pointer is null" && (u != nullptr));
   assert("pre: v pointer is null" && (v != nullptr));
@@ -558,7 +558,7 @@ inline void cross_product(const T* u, const T* v, T* w)
 
 //------------------------------------------------------------------------------
 template <typename T>
-inline T dot_product(const T* u, const T* v, int dim)
+inline AXOM_HOST_DEVICE T dot_product(const T* u, const T* v, int dim)
 {
   assert("pre: u pointer is null" && (u != nullptr));
   assert("pre: v pointer is null" && (v != nullptr));
@@ -631,7 +631,7 @@ bool orthonormalize(T* basis, int size, int dim, double eps)
 
 //------------------------------------------------------------------------------
 template <typename T>
-inline bool normalize(T* v, int dim, double eps)
+inline AXOM_HOST_DEVICE bool normalize(T* v, int dim, double eps)
 {
   AXOM_STATIC_ASSERT_MSG(std::is_floating_point<T>::value,
                          "pre: T is a floating point type");

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -749,7 +749,7 @@ void check_external_view(ArrayView<T>& v)
   EXPECT_EQ(data_ptr, v.data());
 }
 
-#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
 
 template <typename T>
 __global__ void assign_raw(T* data, int N)
@@ -955,7 +955,7 @@ TEST(core_array, checkFill)
 }
 
 //------------------------------------------------------------------------------
-#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
 TEST(core_array, checkFillDevice)
 {
   for(IndexType capacity = 2; capacity < 512; capacity *= 2)
@@ -1271,7 +1271,7 @@ TEST(core_array, checkIterator)
 }
 
 //------------------------------------------------------------------------------
-#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
 void checkIteratorDeviceImpl()
 {
   constexpr int SIZE = 1000;
@@ -1636,10 +1636,10 @@ TEST(core_array, check_multidimensional_view)
 //------------------------------------------------------------------------------
 TEST(core_array, checkDevice)
 {
-#if (!defined(__CUDACC__) && !defined(__HIPCC__)) || !defined(AXOM_USE_UMPIRE) || \
-  !defined(UMPIRE_ENABLE_DEVICE)
-  GTEST_SKIP()
-    << "CUDA or HIP is not available, skipping tests that use Array in device code";
+#if(!defined(__CUDACC__) && !defined(__HIPCC__)) || \
+  !defined(AXOM_USE_UMPIRE) || !defined(UMPIRE_ENABLE_DEVICE)
+  GTEST_SKIP() << "CUDA or HIP is not available, skipping tests that use Array "
+                  "in device code";
 #else
   for(IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
@@ -1672,10 +1672,10 @@ TEST(core_array, checkDevice)
 //------------------------------------------------------------------------------
 TEST(core_array, checkDevice2D)
 {
-#if (!defined(__CUDACC__) && !defined(__HIPCC__)) || !defined(AXOM_USE_UMPIRE) || \
-  !defined(UMPIRE_ENABLE_DEVICE)
-  GTEST_SKIP()
-    << "CUDA or HIP is not available, skipping tests that use Array in device code";
+#if(!defined(__CUDACC__) && !defined(__HIPCC__)) || \
+  !defined(AXOM_USE_UMPIRE) || !defined(UMPIRE_ENABLE_DEVICE)
+  GTEST_SKIP() << "CUDA or HIP is not available, skipping tests that use Array "
+                  "in device code";
 #else
   for(IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
@@ -1736,10 +1736,10 @@ TEST(core_array, checkDefaultInitialization)
 //------------------------------------------------------------------------------
 TEST(core_array, checkDefaultInitializationDevice)
 {
-#if (!defined(__CUDACC__) && !defined(__HIPCC__)) || !defined(AXOM_USE_UMPIRE) || \
-  !defined(UMPIRE_ENABLE_DEVICE)
-  GTEST_SKIP()
-    << "CUDA or HIP is not available, skipping tests that use Array in device code";
+#if(!defined(__CUDACC__) && !defined(__HIPCC__)) || \
+  !defined(AXOM_USE_UMPIRE) || !defined(UMPIRE_ENABLE_DEVICE)
+  GTEST_SKIP() << "CUDA or HIP is not available, skipping tests that use Array "
+                  "in device code";
 #else
   constexpr int MAGIC_INT = 255;
   for(IndexType capacity = 2; capacity < 512; capacity *= 2)

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -749,7 +749,7 @@ void check_external_view(ArrayView<T>& v)
   EXPECT_EQ(data_ptr, v.data());
 }
 
-#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
 
 template <typename T>
 __global__ void assign_raw(T* data, int N)
@@ -917,7 +917,7 @@ void check_device_2D(Array<T, 2, SPACE>& v)
   }
 }
 
-#endif  // (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#endif  // defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
 
 } /* end namespace internal */
 
@@ -955,7 +955,7 @@ TEST(core_array, checkFill)
 }
 
 //------------------------------------------------------------------------------
-#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
 TEST(core_array, checkFillDevice)
 {
   for(IndexType capacity = 2; capacity < 512; capacity *= 2)
@@ -1271,7 +1271,7 @@ TEST(core_array, checkIterator)
 }
 
 //------------------------------------------------------------------------------
-#if(defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
 void checkIteratorDeviceImpl()
 {
   constexpr int SIZE = 1000;
@@ -1636,8 +1636,8 @@ TEST(core_array, check_multidimensional_view)
 //------------------------------------------------------------------------------
 TEST(core_array, checkDevice)
 {
-#if(!defined(__CUDACC__) && !defined(__HIPCC__)) || \
-  !defined(AXOM_USE_UMPIRE) || !defined(UMPIRE_ENABLE_DEVICE)
+#if !defined(AXOM_GPUCC) || !defined(AXOM_USE_UMPIRE) || \
+  !defined(UMPIRE_ENABLE_DEVICE)
   GTEST_SKIP() << "CUDA or HIP is not available, skipping tests that use Array "
                   "in device code";
 #else
@@ -1672,8 +1672,8 @@ TEST(core_array, checkDevice)
 //------------------------------------------------------------------------------
 TEST(core_array, checkDevice2D)
 {
-#if(!defined(__CUDACC__) && !defined(__HIPCC__)) || \
-  !defined(AXOM_USE_UMPIRE) || !defined(UMPIRE_ENABLE_DEVICE)
+#if !defined(AXOM_GPUCC) || !defined(AXOM_USE_UMPIRE) || \
+  !defined(UMPIRE_ENABLE_DEVICE)
   GTEST_SKIP() << "CUDA or HIP is not available, skipping tests that use Array "
                   "in device code";
 #else
@@ -1736,8 +1736,8 @@ TEST(core_array, checkDefaultInitialization)
 //------------------------------------------------------------------------------
 TEST(core_array, checkDefaultInitializationDevice)
 {
-#if(!defined(__CUDACC__) && !defined(__HIPCC__)) || \
-  !defined(AXOM_USE_UMPIRE) || !defined(UMPIRE_ENABLE_DEVICE)
+#if !defined(AXOM_GPUCC) || !defined(AXOM_USE_UMPIRE) || \
+  !defined(UMPIRE_ENABLE_DEVICE)
   GTEST_SKIP() << "CUDA or HIP is not available, skipping tests that use Array "
                   "in device code";
 #else

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -749,8 +749,7 @@ void check_external_view(ArrayView<T>& v)
   EXPECT_EQ(data_ptr, v.data());
 }
 
-// FIXME: HIP
-#if defined(__CUDACC__) && defined(AXOM_USE_UMPIRE)
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
 
 template <typename T>
 __global__ void assign_raw(T* data, int N)
@@ -918,7 +917,7 @@ void check_device_2D(Array<T, 2, SPACE>& v)
   }
 }
 
-#endif  // defined(__CUDACC__) && defined(AXOM_USE_UMPIRE)
+#endif  // (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
 
 } /* end namespace internal */
 
@@ -956,7 +955,7 @@ TEST(core_array, checkFill)
 }
 
 //------------------------------------------------------------------------------
-#if defined(__CUDACC__) && defined(AXOM_USE_UMPIRE)
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
 TEST(core_array, checkFillDevice)
 {
   for(IndexType capacity = 2; capacity < 512; capacity *= 2)
@@ -1272,10 +1271,9 @@ TEST(core_array, checkIterator)
 }
 
 //------------------------------------------------------------------------------
-#if defined(__CUDACC__) && defined(AXOM_USE_UMPIRE)
+#if (defined(__CUDACC__) || defined(__HIPCC__)) && defined(AXOM_USE_UMPIRE)
 void checkIteratorDeviceImpl()
 {
-  using DeviceEx = axom::CUDA_EXEC<256>;
   constexpr int SIZE = 1000;
   axom::Array<int, 1, axom::MemorySpace::Host> v_int_host(SIZE);
   axom::Array<int, 1, axom::MemorySpace::Device> v_int(SIZE);
@@ -1638,11 +1636,10 @@ TEST(core_array, check_multidimensional_view)
 //------------------------------------------------------------------------------
 TEST(core_array, checkDevice)
 {
-// FIXME: HIP
-#if !defined(__CUDACC__) || !defined(AXOM_USE_UMPIRE) || \
+#if (!defined(__CUDACC__) && !defined(__HIPCC__)) || !defined(AXOM_USE_UMPIRE) || \
   !defined(UMPIRE_ENABLE_DEVICE)
   GTEST_SKIP()
-    << "CUDA is not available, skipping tests that use Array in device code";
+    << "CUDA or HIP is not available, skipping tests that use Array in device code";
 #else
   for(IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
@@ -1675,11 +1672,10 @@ TEST(core_array, checkDevice)
 //------------------------------------------------------------------------------
 TEST(core_array, checkDevice2D)
 {
-// FIXME: HIP
-#if !defined(__CUDACC__) || !defined(AXOM_USE_UMPIRE) || \
+#if (!defined(__CUDACC__) && !defined(__HIPCC__)) || !defined(AXOM_USE_UMPIRE) || \
   !defined(UMPIRE_ENABLE_DEVICE)
   GTEST_SKIP()
-    << "CUDA is not available, skipping tests that use Array in device code";
+    << "CUDA or HIP is not available, skipping tests that use Array in device code";
 #else
   for(IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
@@ -1740,11 +1736,10 @@ TEST(core_array, checkDefaultInitialization)
 //------------------------------------------------------------------------------
 TEST(core_array, checkDefaultInitializationDevice)
 {
-// FIXME: HIP
-#if !defined(__CUDACC__) || !defined(AXOM_USE_UMPIRE) || \
+#if (!defined(__CUDACC__) && !defined(__HIPCC__)) || !defined(AXOM_USE_UMPIRE) || \
   !defined(UMPIRE_ENABLE_DEVICE)
   GTEST_SKIP()
-    << "CUDA is not available, skipping tests that use Array in device code";
+    << "CUDA or HIP is not available, skipping tests that use Array in device code";
 #else
   constexpr int MAGIC_INT = 255;
   for(IndexType capacity = 2; capacity < 512; capacity *= 2)

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -252,7 +252,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_insert)
   using ExecSpace = typename TestFixture::ExecSpace;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -325,7 +325,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_range_insert)
   using ExecSpace = typename TestFixture::ExecSpace;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -399,7 +399,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_range_set)
   using ExecSpace = typename TestFixture::ExecSpace;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -455,7 +455,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_initializer_list)
   using ExecSpace = typename TestFixture::ExecSpace;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -517,7 +517,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_default_ctor_obj)
     typename TestFixture::template HostTArray<NonTrivialDefaultCtor>;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -594,7 +594,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_ctor_obj)
   using HostArray = typename TestFixture::template HostTArray<NonTrivialCtor>;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -664,7 +664,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_dtor_obj)
   using HostArray = typename TestFixture::template HostTArray<NonTrivialDtor>;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -752,7 +752,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_copy_ctor_obj)
   using IntHostArray = typename TestFixture::HostArray;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -856,7 +856,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_emplace)
   using HostIntArray = typename TestFixture::HostArray;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -56,6 +56,11 @@ using MyTypes = ::testing::Types<
   axom::CUDA_EXEC<256>,
   axom::CUDA_EXEC<256, axom::ASYNC>,
 #endif
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
+  axom::HIP_EXEC<100>,
+  axom::HIP_EXEC<256>,
+  axom::HIP_EXEC<256, axom::ASYNC>,
+#endif
   axom::SEQ_EXEC>;
 
 TYPED_TEST_SUITE(core_array_for_all, MyTypes);
@@ -247,7 +252,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_insert)
   using ExecSpace = typename TestFixture::ExecSpace;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -320,7 +325,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_range_insert)
   using ExecSpace = typename TestFixture::ExecSpace;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -394,7 +399,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_range_set)
   using ExecSpace = typename TestFixture::ExecSpace;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -450,7 +455,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_initializer_list)
   using ExecSpace = typename TestFixture::ExecSpace;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -512,7 +517,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_default_ctor_obj)
     typename TestFixture::template HostTArray<NonTrivialDefaultCtor>;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -589,7 +594,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_ctor_obj)
   using HostArray = typename TestFixture::template HostTArray<NonTrivialCtor>;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -659,7 +664,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_dtor_obj)
   using HostArray = typename TestFixture::template HostTArray<NonTrivialDtor>;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -747,7 +752,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_copy_ctor_obj)
   using IntHostArray = typename TestFixture::HostArray;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -823,8 +828,11 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_copy_ctor_obj)
     EXPECT_TRUE(check_array_values(arr3, MAGIC_COPY_CTOR));
 
     // Transfers between memory spaces should invoke each element's copy constructor
+    // Segfaulting with hip policy
+    #ifndef AXOM_USE_HIP
     DynamicArray arr4(arr, hostAllocID);
     EXPECT_TRUE(check_array_values(arr4, MAGIC_COPY_CTOR));
+    #endif
 
     // Fill with instance of copy-constructed type - each element should be
     // copy-constructed from the argument
@@ -848,7 +856,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_emplace)
   using HostIntArray = typename TestFixture::HostArray;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -252,7 +252,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_insert)
   using ExecSpace = typename TestFixture::ExecSpace;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -325,7 +325,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_range_insert)
   using ExecSpace = typename TestFixture::ExecSpace;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -399,7 +399,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_range_set)
   using ExecSpace = typename TestFixture::ExecSpace;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -455,7 +455,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_initializer_list)
   using ExecSpace = typename TestFixture::ExecSpace;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -517,7 +517,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_default_ctor_obj)
     typename TestFixture::template HostTArray<NonTrivialDefaultCtor>;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -594,7 +594,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_ctor_obj)
   using HostArray = typename TestFixture::template HostTArray<NonTrivialCtor>;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -664,7 +664,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_dtor_obj)
   using HostArray = typename TestFixture::template HostTArray<NonTrivialDtor>;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -752,7 +752,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_copy_ctor_obj)
   using IntHostArray = typename TestFixture::HostArray;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(
@@ -827,12 +827,12 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_copy_ctor_obj)
     DynamicArray arr3 = arr;
     EXPECT_TRUE(check_array_values(arr3, MAGIC_COPY_CTOR));
 
-    // Transfers between memory spaces should invoke each element's copy constructor
-    // Segfaulting with hip policy
-    #ifndef AXOM_USE_HIP
+// Transfers between memory spaces should invoke each element's copy constructor
+// Segfaulting with hip policy
+#ifndef AXOM_USE_HIP
     DynamicArray arr4(arr, hostAllocID);
     EXPECT_TRUE(check_array_values(arr4, MAGIC_COPY_CTOR));
-    #endif
+#endif
 
     // Fill with instance of copy-constructed type - each element should be
     // copy-constructed from the argument
@@ -856,7 +856,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_emplace)
   using HostIntArray = typename TestFixture::HostArray;
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if (defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
+#if(defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(

--- a/src/axom/core/tests/core_execution_for_all.hpp
+++ b/src/axom/core/tests/core_execution_for_all.hpp
@@ -111,3 +111,15 @@ TEST(core_execution_for_all, cuda_exec_async)
 }
 
 #endif
+
+//------------------------------------------------------------------------------
+
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
+
+TEST(core_execution_for_all, hip_exec)
+{
+  constexpr int BLOCK_SIZE = 256;
+  check_for_all<axom::HIP_EXEC<BLOCK_SIZE>>();
+}
+
+#endif

--- a/src/axom/core/tests/core_execution_for_all.hpp
+++ b/src/axom/core/tests/core_execution_for_all.hpp
@@ -122,4 +122,11 @@ TEST(core_execution_for_all, hip_exec)
   check_for_all<axom::HIP_EXEC<BLOCK_SIZE>>();
 }
 
+//------------------------------------------------------------------------------
+TEST(core_execution_for_all, hip_exec_async)
+{
+  constexpr int BLOCK_SIZE = 256;
+  check_for_all<axom::HIP_EXEC<BLOCK_SIZE, axom::ASYNC>>();
+}
+
 #endif

--- a/src/axom/core/tests/core_execution_space.hpp
+++ b/src/axom/core/tests/core_execution_space.hpp
@@ -110,6 +110,11 @@ TEST(core_execution_space, check_valid)
   check_valid<axom::CUDA_EXEC<256>>();
   check_valid<axom::CUDA_EXEC<256, axom::ASYNC>>();
 #endif
+
+#if defined(AXOM_USE_HIP) && defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+  check_valid<axom::HIP_EXEC<256>>();
+  check_valid<axom::HIP_EXEC<256, axom::ASYNC>>();
+#endif
 }
 
 //------------------------------------------------------------------------------
@@ -204,5 +209,50 @@ TEST(core_execution_space, check_cuda_exec_async)
                                                    ON_DEVICE);
 }
   #endif  // defined(AXOM_USE_CUDA)
+
+  //------------------------------------------------------------------------------
+  #if defined(AXOM_USE_HIP)
+
+TEST(core_execution_space, check_hip_exec)
+{
+  constexpr int BLOCK_SIZE = 256;
+
+  check_valid<axom::HIP_EXEC<BLOCK_SIZE>>();
+
+  constexpr bool IS_ASYNC = false;
+  constexpr bool ON_DEVICE = true;
+
+  int allocator_id =
+    axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  check_execution_mappings<axom::HIP_EXEC<BLOCK_SIZE>,
+                           RAJA::hip_exec<BLOCK_SIZE>,
+                           RAJA::hip_reduce,
+                           RAJA::hip_atomic,
+                           RAJA::hip_synchronize>(allocator_id,
+                                                  IS_ASYNC,
+                                                  ON_DEVICE);
+}
+
+//------------------------------------------------------------------------------
+TEST(core_execution_space, check_hip_exec_async)
+{
+  constexpr int BLOCK_SIZE = 256;
+
+  check_valid<axom::HIP_EXEC<BLOCK_SIZE, axom::ASYNC>>();
+
+  constexpr bool IS_ASYNC = true;
+  constexpr bool ON_DEVICE = true;
+
+  int allocator_id =
+    axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  check_execution_mappings<axom::HIP_EXEC<BLOCK_SIZE, axom::ASYNC>,
+                           RAJA::hip_exec_async<BLOCK_SIZE>,
+                           RAJA::hip_reduce,
+                           RAJA::hip_atomic,
+                           RAJA::hip_synchronize>(allocator_id,
+                                                  IS_ASYNC,
+                                                  ON_DEVICE);
+}
+  #endif  // defined(AXOM_USE_HIP)
 
 #endif  // defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_RAJA)

--- a/src/axom/core/tests/core_memory_management.hpp
+++ b/src/axom/core/tests/core_memory_management.hpp
@@ -265,7 +265,7 @@ TEST(core_memory_management, set_get_default_memory_space)
     axom::getUmpireResourceAllocatorID(umpire::resource::Host);
   EXPECT_EQ(HostAllocatorID, axom::getDefaultAllocatorID());
 
-  #if defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)
+  #if defined(AXOM_USE_GPU)
 
     #ifdef UMPIRE_ENABLE_PINNED
   const int PinnedAllocatorID =
@@ -296,7 +296,7 @@ TEST(core_memory_management, set_get_default_memory_space)
   EXPECT_EQ(UnifiedAllocatorID, axom::getDefaultAllocatorID());
     #endif
 
-  #endif  // AXOM_USE_CUDA || AXOM_USE_HIP
+  #endif  // AXOM_USE_GPU
 
   axom::setDefaultAllocator(HostAllocatorID);
   EXPECT_EQ(HostAllocatorID, axom::getDefaultAllocatorID());
@@ -314,7 +314,7 @@ TEST(core_memory_management, alloc_free)
     axom::getUmpireResourceAllocatorID(umpire::resource::Host);
   check_alloc_and_free(HostAllocatorID, HOST_ACCESSIBLE);
 
-  #if defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)
+  #if defined(AXOM_USE_GPU)
 
   constexpr bool NOT_HOST_ACCESSIBLE = false;
 
@@ -342,7 +342,7 @@ TEST(core_memory_management, alloc_free)
   check_alloc_and_free(UnifiedAllocatorID, HOST_ACCESSIBLE);
     #endif
 
-  #endif  // AXOM_USE_CUDA || AXOM_USE_HIP
+  #endif  // AXOM_USE_GPU
 
 #endif  // AXOM_USE_UMPIRE
 
@@ -360,7 +360,7 @@ TEST(core_memory_management, alloc_realloc_free)
     axom::getUmpireResourceAllocatorID(umpire::resource::Host);
   check_alloc_realloc_free(HostAllocatorID, HOST_ACCESSIBLE);
 
-  #if defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)
+  #if defined(AXOM_USE_GPU)
 
   constexpr bool NOT_HOST_ACCESSIBLE = false;
 
@@ -388,7 +388,7 @@ TEST(core_memory_management, alloc_realloc_free)
 
     #endif
 
-  #endif /* AXOM_USE_CUDA || AXOM_USE_HIP */
+  #endif /* AXOM_USE_GPU */
 
 #endif /* AXOM_USE_UMPIRE */
 

--- a/src/axom/core/tests/core_memory_management.hpp
+++ b/src/axom/core/tests/core_memory_management.hpp
@@ -265,7 +265,7 @@ TEST(core_memory_management, set_get_default_memory_space)
     axom::getUmpireResourceAllocatorID(umpire::resource::Host);
   EXPECT_EQ(HostAllocatorID, axom::getDefaultAllocatorID());
 
-  #ifdef AXOM_USE_CUDA
+  #if defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)
 
     #ifdef UMPIRE_ENABLE_PINNED
   const int PinnedAllocatorID =
@@ -296,7 +296,7 @@ TEST(core_memory_management, set_get_default_memory_space)
   EXPECT_EQ(UnifiedAllocatorID, axom::getDefaultAllocatorID());
     #endif
 
-  #endif  // AXOM_USE_CUDA
+  #endif  // AXOM_USE_CUDA || AXOM_USE_HIP
 
   axom::setDefaultAllocator(HostAllocatorID);
   EXPECT_EQ(HostAllocatorID, axom::getDefaultAllocatorID());
@@ -314,7 +314,7 @@ TEST(core_memory_management, alloc_free)
     axom::getUmpireResourceAllocatorID(umpire::resource::Host);
   check_alloc_and_free(HostAllocatorID, HOST_ACCESSIBLE);
 
-  #ifdef AXOM_USE_CUDA
+  #if defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)
 
   constexpr bool NOT_HOST_ACCESSIBLE = false;
 
@@ -342,7 +342,7 @@ TEST(core_memory_management, alloc_free)
   check_alloc_and_free(UnifiedAllocatorID, HOST_ACCESSIBLE);
     #endif
 
-  #endif  // AXOM_USE_CUDA
+  #endif  // AXOM_USE_CUDA || AXOM_USE_HIP
 
 #endif  // AXOM_USE_UMPIRE
 
@@ -360,7 +360,7 @@ TEST(core_memory_management, alloc_realloc_free)
     axom::getUmpireResourceAllocatorID(umpire::resource::Host);
   check_alloc_realloc_free(HostAllocatorID, HOST_ACCESSIBLE);
 
-  #ifdef AXOM_USE_CUDA
+  #if defined(AXOM_USE_CUDA) || defined(AXOM_USE_HIP)
 
   constexpr bool NOT_HOST_ACCESSIBLE = false;
 
@@ -388,7 +388,7 @@ TEST(core_memory_management, alloc_realloc_free)
 
     #endif
 
-  #endif /* AXOM_USE_CUDA */
+  #endif /* AXOM_USE_CUDA || AXOM_USE_HIP */
 
 #endif /* AXOM_USE_UMPIRE */
 

--- a/src/axom/core/utilities/BitUtilities.hpp
+++ b/src/axom/core/utilities/BitUtilities.hpp
@@ -82,7 +82,7 @@ struct BitTraits<axom::uint8>
 AXOM_HOST_DEVICE inline int trailingZeros(axom::uint64 word)
 {
   /* clang-format off */
-#ifdef AXOM_DEVICE_CODE
+#if defined(AXOM_DEVICE_CODE) && defined(AXOM_USE_CUDA)
   return word != axom::uint64(0) ? __ffsll(word) - 1 : 64;
 #elif defined(_AXOM_CORE_USE_INTRINSICS_MSVC)
   unsigned long cnt;
@@ -119,7 +119,7 @@ AXOM_HOST_DEVICE inline int trailingZeros(axom::uint64 word)
 AXOM_HOST_DEVICE inline int popCount(axom::uint64 word)
 {
   /* clang-format off */
-#ifdef AXOM_DEVICE_CODE
+#if defined(AXOM_DEVICE_CODE) && defined(AXOM_USE_CUDA)
   // Use CUDA intrinsic for popcount
   return __popcll(word);
 #elif defined(_AXOM_CORE_USE_INTRINSICS_MSVC)
@@ -157,7 +157,7 @@ AXOM_HOST_DEVICE inline int popCount(axom::uint64 word)
 AXOM_HOST_DEVICE inline axom::int32 leadingZeros(axom::int32 word)
 {
   /* clang-format off */
-#ifdef AXOM_DEVICE_CODE
+#if defined(AXOM_DEVICE_CODE) && defined(AXOM_USE_CUDA)
   // Use CUDA intrinsic for count leading zeros
   return __clz(word);
 #elif defined(_AXOM_CORE_USE_INTRINSICS_MSVC)

--- a/src/axom/primal/geometry/BoundingBox.hpp
+++ b/src/axom/primal/geometry/BoundingBox.hpp
@@ -378,6 +378,7 @@ constexpr T BoundingBox<T, NDIMS>::InvalidMax;
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
 template <typename OtherT>
+AXOM_HOST_DEVICE
 bool BoundingBox<T, NDIMS>::contains(const Point<OtherT, NDIMS>& otherPt) const
 {
   for(int dim = 0; dim < NDIMS; ++dim)
@@ -393,6 +394,7 @@ bool BoundingBox<T, NDIMS>::contains(const Point<OtherT, NDIMS>& otherPt) const
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 BoundingBox<T, NDIMS>::BoundingBox(const PointType* pts, int n)
 {
   if(n <= 0)
@@ -421,6 +423,7 @@ bool BoundingBox<T, NDIMS>::contains(const BoundingBox<OtherT, NDIMS>& otherBB) 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
 template <typename OtherType>
+AXOM_HOST_DEVICE
 bool BoundingBox<T, NDIMS>::intersectsWith(
   const BoundingBox<OtherType, NDIMS>& otherBB) const
 {
@@ -440,6 +443,7 @@ bool BoundingBox<T, NDIMS>::intersectsWith(
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 bool BoundingBox<T, NDIMS>::isValid() const
 {
   for(int dim = 0; dim < NDIMS; ++dim)
@@ -455,6 +459,7 @@ bool BoundingBox<T, NDIMS>::isValid() const
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
 template <typename OtherT>
+AXOM_HOST_DEVICE
 void BoundingBox<T, NDIMS>::addPoint(const Point<OtherT, NDIMS>& pt)
 {
   for(int dim = 0; dim < NDIMS; ++dim)
@@ -476,6 +481,7 @@ void BoundingBox<T, NDIMS>::addPoint(const Point<OtherT, NDIMS>& pt)
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
 template <typename OtherT>
+AXOM_HOST_DEVICE
 void BoundingBox<T, NDIMS>::addBox(const BoundingBox<OtherT, NDIMS>& bbox)
 {
   this->addPoint(bbox.getMin());
@@ -484,6 +490,7 @@ void BoundingBox<T, NDIMS>::addBox(const BoundingBox<OtherT, NDIMS>& bbox)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 int BoundingBox<T, NDIMS>::getLongestDimension() const
 {
   SLIC_ASSERT(this->isValid());
@@ -520,6 +527,7 @@ AXOM_HOST_DEVICE BoundingBox<T, NDIMS>& BoundingBox<T, NDIMS>::expand(T expansio
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 BoundingBox<T, NDIMS>& BoundingBox<T, NDIMS>::scale(double scaleFactor)
 {
   const PointType midpoint = getCentroid();
@@ -535,6 +543,7 @@ BoundingBox<T, NDIMS>& BoundingBox<T, NDIMS>::scale(double scaleFactor)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 BoundingBox<T, NDIMS>& BoundingBox<T, NDIMS>::shift(const VectorType& disp)
 {
   m_min.array() += disp.array();
@@ -545,6 +554,7 @@ BoundingBox<T, NDIMS>& BoundingBox<T, NDIMS>::shift(const VectorType& disp)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 void BoundingBox<T, NDIMS>::checkAndFixBounds()
 {
   for(int dim = 0; dim < NDIMS; ++dim)
@@ -558,6 +568,7 @@ void BoundingBox<T, NDIMS>::checkAndFixBounds()
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 void BoundingBox<T, NDIMS>::clear()
 {
   m_min = PointType(InvalidMin);
@@ -662,6 +673,7 @@ inline void BoundingBox<T, NDIMS>::getPoints(const BoundingBox<T, 3>& bb,
 //------------------------------------------------------------------------------
 
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 bool operator==(const BoundingBox<T, NDIMS>& lhs, const BoundingBox<T, NDIMS>& rhs)
 {
   return lhs.getMin() == rhs.getMin() && lhs.getMax() == rhs.getMax();

--- a/src/axom/primal/geometry/BoundingBox.hpp
+++ b/src/axom/primal/geometry/BoundingBox.hpp
@@ -378,8 +378,8 @@ constexpr T BoundingBox<T, NDIMS>::InvalidMax;
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
 template <typename OtherT>
-AXOM_HOST_DEVICE
-bool BoundingBox<T, NDIMS>::contains(const Point<OtherT, NDIMS>& otherPt) const
+AXOM_HOST_DEVICE bool BoundingBox<T, NDIMS>::contains(
+  const Point<OtherT, NDIMS>& otherPt) const
 {
   for(int dim = 0; dim < NDIMS; ++dim)
   {
@@ -394,8 +394,7 @@ bool BoundingBox<T, NDIMS>::contains(const Point<OtherT, NDIMS>& otherPt) const
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-BoundingBox<T, NDIMS>::BoundingBox(const PointType* pts, int n)
+AXOM_HOST_DEVICE BoundingBox<T, NDIMS>::BoundingBox(const PointType* pts, int n)
 {
   if(n <= 0)
   {
@@ -423,8 +422,7 @@ bool BoundingBox<T, NDIMS>::contains(const BoundingBox<OtherT, NDIMS>& otherBB) 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
 template <typename OtherType>
-AXOM_HOST_DEVICE
-bool BoundingBox<T, NDIMS>::intersectsWith(
+AXOM_HOST_DEVICE bool BoundingBox<T, NDIMS>::intersectsWith(
   const BoundingBox<OtherType, NDIMS>& otherBB) const
 {
   bool status = true;
@@ -443,8 +441,7 @@ bool BoundingBox<T, NDIMS>::intersectsWith(
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-bool BoundingBox<T, NDIMS>::isValid() const
+AXOM_HOST_DEVICE bool BoundingBox<T, NDIMS>::isValid() const
 {
   for(int dim = 0; dim < NDIMS; ++dim)
   {
@@ -459,8 +456,7 @@ bool BoundingBox<T, NDIMS>::isValid() const
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
 template <typename OtherT>
-AXOM_HOST_DEVICE
-void BoundingBox<T, NDIMS>::addPoint(const Point<OtherT, NDIMS>& pt)
+AXOM_HOST_DEVICE void BoundingBox<T, NDIMS>::addPoint(const Point<OtherT, NDIMS>& pt)
 {
   for(int dim = 0; dim < NDIMS; ++dim)
   {
@@ -481,8 +477,8 @@ void BoundingBox<T, NDIMS>::addPoint(const Point<OtherT, NDIMS>& pt)
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
 template <typename OtherT>
-AXOM_HOST_DEVICE
-void BoundingBox<T, NDIMS>::addBox(const BoundingBox<OtherT, NDIMS>& bbox)
+AXOM_HOST_DEVICE void BoundingBox<T, NDIMS>::addBox(
+  const BoundingBox<OtherT, NDIMS>& bbox)
 {
   this->addPoint(bbox.getMin());
   this->addPoint(bbox.getMax());
@@ -490,8 +486,7 @@ void BoundingBox<T, NDIMS>::addBox(const BoundingBox<OtherT, NDIMS>& bbox)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-int BoundingBox<T, NDIMS>::getLongestDimension() const
+AXOM_HOST_DEVICE int BoundingBox<T, NDIMS>::getLongestDimension() const
 {
   SLIC_ASSERT(this->isValid());
 
@@ -527,8 +522,7 @@ AXOM_HOST_DEVICE BoundingBox<T, NDIMS>& BoundingBox<T, NDIMS>::expand(T expansio
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-BoundingBox<T, NDIMS>& BoundingBox<T, NDIMS>::scale(double scaleFactor)
+AXOM_HOST_DEVICE BoundingBox<T, NDIMS>& BoundingBox<T, NDIMS>::scale(double scaleFactor)
 {
   const PointType midpoint = getCentroid();
   const VectorType r = static_cast<T>(scaleFactor * 0.5) * range();
@@ -543,8 +537,8 @@ BoundingBox<T, NDIMS>& BoundingBox<T, NDIMS>::scale(double scaleFactor)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-BoundingBox<T, NDIMS>& BoundingBox<T, NDIMS>::shift(const VectorType& disp)
+AXOM_HOST_DEVICE BoundingBox<T, NDIMS>& BoundingBox<T, NDIMS>::shift(
+  const VectorType& disp)
 {
   m_min.array() += disp.array();
   m_max.array() += disp.array();
@@ -554,8 +548,7 @@ BoundingBox<T, NDIMS>& BoundingBox<T, NDIMS>::shift(const VectorType& disp)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-void BoundingBox<T, NDIMS>::checkAndFixBounds()
+AXOM_HOST_DEVICE void BoundingBox<T, NDIMS>::checkAndFixBounds()
 {
   for(int dim = 0; dim < NDIMS; ++dim)
   {
@@ -568,8 +561,7 @@ void BoundingBox<T, NDIMS>::checkAndFixBounds()
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-void BoundingBox<T, NDIMS>::clear()
+AXOM_HOST_DEVICE void BoundingBox<T, NDIMS>::clear()
 {
   m_min = PointType(InvalidMin);
   m_max = PointType(InvalidMax);
@@ -673,8 +665,8 @@ inline void BoundingBox<T, NDIMS>::getPoints(const BoundingBox<T, 3>& bb,
 //------------------------------------------------------------------------------
 
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-bool operator==(const BoundingBox<T, NDIMS>& lhs, const BoundingBox<T, NDIMS>& rhs)
+AXOM_HOST_DEVICE bool operator==(const BoundingBox<T, NDIMS>& lhs,
+                                 const BoundingBox<T, NDIMS>& rhs)
 {
   return lhs.getMin() == rhs.getMin() && lhs.getMax() == rhs.getMax();
 }

--- a/src/axom/primal/geometry/NumericArray.hpp
+++ b/src/axom/primal/geometry/NumericArray.hpp
@@ -399,8 +399,7 @@ namespace primal
 {
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-NumericArray<T, SIZE>::NumericArray(T val, int sz)
+AXOM_HOST_DEVICE NumericArray<T, SIZE>::NumericArray(T val, int sz)
 {
   // NOTE (KW): This should be a static assert in the class
   SLIC_ASSERT(SIZE >= 1);
@@ -421,8 +420,7 @@ NumericArray<T, SIZE>::NumericArray(T val, int sz)
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-NumericArray<T, SIZE>::NumericArray(const T* vals, int sz)
+AXOM_HOST_DEVICE NumericArray<T, SIZE>::NumericArray(const T* vals, int sz)
 {
   SLIC_ASSERT(SIZE >= 1);
 
@@ -443,8 +441,7 @@ NumericArray<T, SIZE>::NumericArray(const T* vals, int sz)
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-inline T& NumericArray<T, SIZE>::operator[](int i)
+AXOM_HOST_DEVICE inline T& NumericArray<T, SIZE>::operator[](int i)
 {
   verifyIndex(i);
   return m_components[i];
@@ -452,8 +449,7 @@ inline T& NumericArray<T, SIZE>::operator[](int i)
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-inline const T& NumericArray<T, SIZE>::operator[](int i) const
+AXOM_HOST_DEVICE inline const T& NumericArray<T, SIZE>::operator[](int i) const
 {
   verifyIndex(i);
   return m_components[i];
@@ -461,24 +457,21 @@ inline const T& NumericArray<T, SIZE>::operator[](int i) const
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-inline const T* NumericArray<T, SIZE>::data() const
+AXOM_HOST_DEVICE inline const T* NumericArray<T, SIZE>::data() const
 {
   return m_components;
 }
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-inline T* NumericArray<T, SIZE>::data()
+AXOM_HOST_DEVICE inline T* NumericArray<T, SIZE>::data()
 {
   return m_components;
 }
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-void NumericArray<T, SIZE>::to_array(T* arr) const
+AXOM_HOST_DEVICE void NumericArray<T, SIZE>::to_array(T* arr) const
 {
   SLIC_ASSERT(arr != nullptr);
   for(int dim = 0; dim < SIZE; ++dim)
@@ -507,8 +500,8 @@ std::ostream& NumericArray<T, SIZE>::print(std::ostream& os) const
 //------------------------------------------------------------------------------
 
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator*=(double scalar)
+AXOM_HOST_DEVICE inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator*=(
+  double scalar)
 {
   for(int i = 0; i < SIZE; ++i)
   {
@@ -520,8 +513,8 @@ inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator*=(double scalar)
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator/=(double scalar)
+AXOM_HOST_DEVICE inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator/=(
+  double scalar)
 {
   SLIC_ASSERT(scalar != 0.);
   return operator*=(1. / scalar);
@@ -529,8 +522,7 @@ inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator/=(double scalar)
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator*=(
+AXOM_HOST_DEVICE inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator*=(
   const NumericArray<T, SIZE>& v)
 {
   for(int i = 0; i < SIZE; ++i)
@@ -557,8 +549,7 @@ inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator/=(
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator+=(
+AXOM_HOST_DEVICE inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator+=(
   const NumericArray<T, SIZE>& v)
 {
   for(int i = 0; i < SIZE; ++i)
@@ -571,8 +562,7 @@ inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator+=(
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator-=(
+AXOM_HOST_DEVICE inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator-=(
   const NumericArray<T, SIZE>& v)
 {
   for(int i = 0; i < SIZE; ++i)
@@ -696,8 +686,8 @@ inline int NumericArray<T, SIZE>::argMin() const
 //------------------------------------------------------------------------------
 
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-bool operator==(const NumericArray<T, SIZE>& lhs, const NumericArray<T, SIZE>& rhs)
+AXOM_HOST_DEVICE bool operator==(const NumericArray<T, SIZE>& lhs,
+                                 const NumericArray<T, SIZE>& rhs)
 {
   for(int dim = 0; dim < SIZE; ++dim)
   {
@@ -747,9 +737,9 @@ inline NumericArray<T, SIZE> operator*(double scalar,
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-inline NumericArray<T, SIZE> operator+(const NumericArray<T, SIZE>& lhs,
-                                       const NumericArray<T, SIZE>& rhs)
+AXOM_HOST_DEVICE inline NumericArray<T, SIZE> operator+(
+  const NumericArray<T, SIZE>& lhs,
+  const NumericArray<T, SIZE>& rhs)
 {
   NumericArray<T, SIZE> result(lhs);
   result += rhs;
@@ -758,9 +748,9 @@ inline NumericArray<T, SIZE> operator+(const NumericArray<T, SIZE>& lhs,
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-inline NumericArray<T, SIZE> operator*(const NumericArray<T, SIZE>& lhs,
-                                       const NumericArray<T, SIZE>& rhs)
+AXOM_HOST_DEVICE inline NumericArray<T, SIZE> operator*(
+  const NumericArray<T, SIZE>& lhs,
+  const NumericArray<T, SIZE>& rhs)
 {
   NumericArray<T, SIZE> result(lhs);
   result *= rhs;
@@ -789,9 +779,9 @@ inline NumericArray<T, SIZE> operator/(const NumericArray<T, SIZE>& arr,
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
-AXOM_HOST_DEVICE
-inline NumericArray<T, SIZE> operator-(const NumericArray<T, SIZE>& lhs,
-                                       const NumericArray<T, SIZE>& rhs)
+AXOM_HOST_DEVICE inline NumericArray<T, SIZE> operator-(
+  const NumericArray<T, SIZE>& lhs,
+  const NumericArray<T, SIZE>& rhs)
 {
   NumericArray<T, SIZE> result(lhs);
   result -= rhs;

--- a/src/axom/primal/geometry/NumericArray.hpp
+++ b/src/axom/primal/geometry/NumericArray.hpp
@@ -399,6 +399,7 @@ namespace primal
 {
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 NumericArray<T, SIZE>::NumericArray(T val, int sz)
 {
   // NOTE (KW): This should be a static assert in the class
@@ -420,6 +421,7 @@ NumericArray<T, SIZE>::NumericArray(T val, int sz)
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 NumericArray<T, SIZE>::NumericArray(const T* vals, int sz)
 {
   SLIC_ASSERT(SIZE >= 1);
@@ -441,6 +443,7 @@ NumericArray<T, SIZE>::NumericArray(const T* vals, int sz)
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 inline T& NumericArray<T, SIZE>::operator[](int i)
 {
   verifyIndex(i);
@@ -449,6 +452,7 @@ inline T& NumericArray<T, SIZE>::operator[](int i)
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 inline const T& NumericArray<T, SIZE>::operator[](int i) const
 {
   verifyIndex(i);
@@ -457,6 +461,7 @@ inline const T& NumericArray<T, SIZE>::operator[](int i) const
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 inline const T* NumericArray<T, SIZE>::data() const
 {
   return m_components;
@@ -464,6 +469,7 @@ inline const T* NumericArray<T, SIZE>::data() const
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 inline T* NumericArray<T, SIZE>::data()
 {
   return m_components;
@@ -471,6 +477,7 @@ inline T* NumericArray<T, SIZE>::data()
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 void NumericArray<T, SIZE>::to_array(T* arr) const
 {
   SLIC_ASSERT(arr != nullptr);
@@ -500,6 +507,7 @@ std::ostream& NumericArray<T, SIZE>::print(std::ostream& os) const
 //------------------------------------------------------------------------------
 
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator*=(double scalar)
 {
   for(int i = 0; i < SIZE; ++i)
@@ -512,6 +520,7 @@ inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator*=(double scalar)
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator/=(double scalar)
 {
   SLIC_ASSERT(scalar != 0.);
@@ -520,6 +529,7 @@ inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator/=(double scalar)
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator*=(
   const NumericArray<T, SIZE>& v)
 {
@@ -547,6 +557,7 @@ inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator/=(
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator+=(
   const NumericArray<T, SIZE>& v)
 {
@@ -560,6 +571,7 @@ inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator+=(
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 inline NumericArray<T, SIZE>& NumericArray<T, SIZE>::operator-=(
   const NumericArray<T, SIZE>& v)
 {
@@ -684,6 +696,7 @@ inline int NumericArray<T, SIZE>::argMin() const
 //------------------------------------------------------------------------------
 
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 bool operator==(const NumericArray<T, SIZE>& lhs, const NumericArray<T, SIZE>& rhs)
 {
   for(int dim = 0; dim < SIZE; ++dim)
@@ -734,6 +747,7 @@ inline NumericArray<T, SIZE> operator*(double scalar,
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 inline NumericArray<T, SIZE> operator+(const NumericArray<T, SIZE>& lhs,
                                        const NumericArray<T, SIZE>& rhs)
 {
@@ -744,6 +758,7 @@ inline NumericArray<T, SIZE> operator+(const NumericArray<T, SIZE>& lhs,
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 inline NumericArray<T, SIZE> operator*(const NumericArray<T, SIZE>& lhs,
                                        const NumericArray<T, SIZE>& rhs)
 {
@@ -774,6 +789,7 @@ inline NumericArray<T, SIZE> operator/(const NumericArray<T, SIZE>& arr,
 
 //------------------------------------------------------------------------------
 template <typename T, int SIZE>
+AXOM_HOST_DEVICE
 inline NumericArray<T, SIZE> operator-(const NumericArray<T, SIZE>& lhs,
                                        const NumericArray<T, SIZE>& rhs)
 {

--- a/src/axom/primal/geometry/Plane.hpp
+++ b/src/axom/primal/geometry/Plane.hpp
@@ -233,6 +233,7 @@ namespace axom
 namespace primal
 {
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 Plane<T, NDIMS>::Plane(const VectorType& normal, const PointType& x)
 {
   SLIC_ASSERT_MSG(!normal.is_zero(),
@@ -245,6 +246,7 @@ Plane<T, NDIMS>::Plane(const VectorType& normal, const PointType& x)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 Plane<T, NDIMS>::Plane(const VectorType& normal, T offset) : m_offset(offset)
 {
   SLIC_ASSERT_MSG(!normal.is_zero(),
@@ -272,6 +274,7 @@ inline void Plane<T, NDIMS>::flip()
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline int Plane<T, NDIMS>::getOrientation(const PointType& x, double TOL) const
 {
   const T signed_distance = this->signedDistance(x);
@@ -299,6 +302,7 @@ std::ostream& Plane<T, NDIMS>::print(std::ostream& os) const
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline void Plane<T, NDIMS>::setNormal(const VectorType& normal)
 {
   m_normal = normal.unitVector();
@@ -314,6 +318,7 @@ std::ostream& operator<<(std::ostream& os, const Plane<T, NDIMS>& p)
 }
 
 template <typename T>
+AXOM_HOST_DEVICE
 Plane<T, 2> make_plane(const Point<T, 2>& x1, const Point<T, 2>& x2)
 {
   Vector<T, 2> normal;
@@ -328,6 +333,7 @@ Plane<T, 2> make_plane(const Point<T, 2>& x1, const Point<T, 2>& x2)
 
 //------------------------------------------------------------------------------
 template <typename T>
+AXOM_HOST_DEVICE
 Plane<T, 3> make_plane(const Point<T, 3>& x1,
                        const Point<T, 3>& x2,
                        const Point<T, 3>& x3)

--- a/src/axom/primal/geometry/Plane.hpp
+++ b/src/axom/primal/geometry/Plane.hpp
@@ -233,8 +233,8 @@ namespace axom
 namespace primal
 {
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-Plane<T, NDIMS>::Plane(const VectorType& normal, const PointType& x)
+AXOM_HOST_DEVICE Plane<T, NDIMS>::Plane(const VectorType& normal,
+                                        const PointType& x)
 {
   SLIC_ASSERT_MSG(!normal.is_zero(),
                   "Normal vector of a plane should be non-zero");
@@ -246,8 +246,8 @@ Plane<T, NDIMS>::Plane(const VectorType& normal, const PointType& x)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-Plane<T, NDIMS>::Plane(const VectorType& normal, T offset) : m_offset(offset)
+AXOM_HOST_DEVICE Plane<T, NDIMS>::Plane(const VectorType& normal, T offset)
+  : m_offset(offset)
 {
   SLIC_ASSERT_MSG(!normal.is_zero(),
                   "Normal vector of a plane should be non-zero");
@@ -274,8 +274,8 @@ inline void Plane<T, NDIMS>::flip()
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline int Plane<T, NDIMS>::getOrientation(const PointType& x, double TOL) const
+AXOM_HOST_DEVICE inline int Plane<T, NDIMS>::getOrientation(const PointType& x,
+                                                            double TOL) const
 {
   const T signed_distance = this->signedDistance(x);
 
@@ -302,8 +302,7 @@ std::ostream& Plane<T, NDIMS>::print(std::ostream& os) const
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline void Plane<T, NDIMS>::setNormal(const VectorType& normal)
+AXOM_HOST_DEVICE inline void Plane<T, NDIMS>::setNormal(const VectorType& normal)
 {
   m_normal = normal.unitVector();
 }
@@ -318,8 +317,8 @@ std::ostream& operator<<(std::ostream& os, const Plane<T, NDIMS>& p)
 }
 
 template <typename T>
-AXOM_HOST_DEVICE
-Plane<T, 2> make_plane(const Point<T, 2>& x1, const Point<T, 2>& x2)
+AXOM_HOST_DEVICE Plane<T, 2> make_plane(const Point<T, 2>& x1,
+                                        const Point<T, 2>& x2)
 {
   Vector<T, 2> normal;
   normal[0] = x1[1] - x2[1];  // -dy
@@ -333,10 +332,9 @@ Plane<T, 2> make_plane(const Point<T, 2>& x1, const Point<T, 2>& x2)
 
 //------------------------------------------------------------------------------
 template <typename T>
-AXOM_HOST_DEVICE
-Plane<T, 3> make_plane(const Point<T, 3>& x1,
-                       const Point<T, 3>& x2,
-                       const Point<T, 3>& x3)
+AXOM_HOST_DEVICE Plane<T, 3> make_plane(const Point<T, 3>& x1,
+                                        const Point<T, 3>& x2,
+                                        const Point<T, 3>& x3)
 {
   Vector<T, 3> r1(x1, x2);
   Vector<T, 3> r2(x1, x3);

--- a/src/axom/primal/geometry/Point.hpp
+++ b/src/axom/primal/geometry/Point.hpp
@@ -267,6 +267,7 @@ namespace primal
 {
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Point<T, NDIMS> Point<T, NDIMS>::make_point(const T& x,
                                                    const T& y,
                                                    const T& z)
@@ -277,6 +278,7 @@ inline Point<T, NDIMS> Point<T, NDIMS>::make_point(const T& x,
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Point<T, NDIMS> Point<T, NDIMS>::midpoint(const Point<T, NDIMS>& A,
                                                  const Point<T, NDIMS>& B)
 {
@@ -292,6 +294,7 @@ inline Point<T, NDIMS> Point<T, NDIMS>::midpoint(const Point<T, NDIMS>& A,
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Point<T, NDIMS> Point<T, NDIMS>::lerp(const Point<T, NDIMS>& A,
                                              const Point<T, NDIMS>& B,
                                              T alpha)

--- a/src/axom/primal/geometry/Point.hpp
+++ b/src/axom/primal/geometry/Point.hpp
@@ -267,10 +267,9 @@ namespace primal
 {
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Point<T, NDIMS> Point<T, NDIMS>::make_point(const T& x,
-                                                   const T& y,
-                                                   const T& z)
+AXOM_HOST_DEVICE inline Point<T, NDIMS> Point<T, NDIMS>::make_point(const T& x,
+                                                                    const T& y,
+                                                                    const T& z)
 {
   T tmp_array[3] = {x, y, z};
   return Point(tmp_array, NDIMS);
@@ -278,9 +277,9 @@ inline Point<T, NDIMS> Point<T, NDIMS>::make_point(const T& x,
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Point<T, NDIMS> Point<T, NDIMS>::midpoint(const Point<T, NDIMS>& A,
-                                                 const Point<T, NDIMS>& B)
+AXOM_HOST_DEVICE inline Point<T, NDIMS> Point<T, NDIMS>::midpoint(
+  const Point<T, NDIMS>& A,
+  const Point<T, NDIMS>& B)
 {
   Point<T, NDIMS> mid_point;
 
@@ -294,10 +293,8 @@ inline Point<T, NDIMS> Point<T, NDIMS>::midpoint(const Point<T, NDIMS>& A,
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Point<T, NDIMS> Point<T, NDIMS>::lerp(const Point<T, NDIMS>& A,
-                                             const Point<T, NDIMS>& B,
-                                             T alpha)
+AXOM_HOST_DEVICE inline Point<T, NDIMS>
+Point<T, NDIMS>::lerp(const Point<T, NDIMS>& A, const Point<T, NDIMS>& B, T alpha)
 {
   PointType res;
   const T beta = 1. - alpha;

--- a/src/axom/primal/geometry/Ray.hpp
+++ b/src/axom/primal/geometry/Ray.hpp
@@ -120,8 +120,8 @@ namespace primal
 {
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-Ray<T, NDIMS>::Ray(const PointType& origin, const VectorType& direction)
+AXOM_HOST_DEVICE Ray<T, NDIMS>::Ray(const PointType& origin,
+                                    const VectorType& direction)
   : m_origin(origin)
   , m_direction(direction.unitVector())
 {
@@ -139,8 +139,7 @@ Ray<T, NDIMS>::Ray(const SegmentType& S)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Point<T, NDIMS> Ray<T, NDIMS>::at(const T& t) const
+AXOM_HOST_DEVICE inline Point<T, NDIMS> Ray<T, NDIMS>::at(const T& t) const
 {
   PointType p;
   for(int i = 0; i < NDIMS; ++i)

--- a/src/axom/primal/geometry/Ray.hpp
+++ b/src/axom/primal/geometry/Ray.hpp
@@ -120,6 +120,7 @@ namespace primal
 {
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 Ray<T, NDIMS>::Ray(const PointType& origin, const VectorType& direction)
   : m_origin(origin)
   , m_direction(direction.unitVector())
@@ -138,6 +139,7 @@ Ray<T, NDIMS>::Ray(const SegmentType& S)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Point<T, NDIMS> Ray<T, NDIMS>::at(const T& t) const
 {
   PointType p;

--- a/src/axom/primal/geometry/Triangle.hpp
+++ b/src/axom/primal/geometry/Triangle.hpp
@@ -361,8 +361,7 @@ namespace axom
 namespace primal
 {
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline double Triangle<T, NDIMS>::angle(int idx) const
+AXOM_HOST_DEVICE inline double Triangle<T, NDIMS>::angle(int idx) const
 {
   SLIC_ASSERT(idx >= 0 && idx < NUM_TRI_VERTS);
 

--- a/src/axom/primal/geometry/Triangle.hpp
+++ b/src/axom/primal/geometry/Triangle.hpp
@@ -361,6 +361,7 @@ namespace axom
 namespace primal
 {
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline double Triangle<T, NDIMS>::angle(int idx) const
 {
   SLIC_ASSERT(idx >= 0 && idx < NUM_TRI_VERTS);

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -216,6 +216,7 @@ public:
    * vector. If the size is not the same as the size of this vector, this
    * behaves the same way as the constructor which takes a pointer and size.
    */
+  AXOM_HOST_DEVICE
   Vector(std::initializer_list<T> values)
     : Vector {values.begin(), static_cast<int>(values.size())}
   { }

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -421,6 +421,7 @@ namespace primal
 {
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator*=(T scalar)
 {
   m_components *= scalar;
@@ -429,6 +430,7 @@ inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator*=(T scalar)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator/=(T scalar)
 {
   m_components /= scalar;
@@ -437,6 +439,7 @@ inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator/=(T scalar)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator+=(const Vector<T, NDIMS>& v)
 {
   m_components += v.array();
@@ -445,6 +448,7 @@ inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator+=(const Vector<T, NDIMS>& v)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator-=(const Vector<T, NDIMS>& v)
 {
   m_components -= v.array();
@@ -453,6 +457,7 @@ inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator-=(const Vector<T, NDIMS>& v)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline double Vector<T, NDIMS>::squared_norm() const
 {
   return dot(*this);
@@ -460,6 +465,7 @@ inline double Vector<T, NDIMS>::squared_norm() const
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline double Vector<T, NDIMS>::norm() const
 {
   return std::sqrt(squared_norm());
@@ -467,6 +473,7 @@ inline double Vector<T, NDIMS>::norm() const
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Vector<T, NDIMS> Vector<T, NDIMS>::unitVector() const
 {
   constexpr double EPS = 1.0e-50;
@@ -489,6 +496,7 @@ inline Vector<T, NDIMS> Vector<T, NDIMS>::unitVector() const
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline void Vector<T, NDIMS>::negate()
 {
   for(int i = 0; i < NDIMS; ++i)
@@ -499,6 +507,7 @@ inline void Vector<T, NDIMS>::negate()
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline bool Vector<T, NDIMS>::is_zero() const
 {
   for(int i = 0; i < NDIMS; ++i)
@@ -513,6 +522,7 @@ inline bool Vector<T, NDIMS>::is_zero() const
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline T Vector<T, NDIMS>::dot(const Vector<T, NDIMS>& vec) const
 {
   return dot_product(*this, vec);
@@ -534,6 +544,7 @@ std::ostream& Vector<T, NDIMS>::print(std::ostream& os) const
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline T Vector<T, NDIMS>::dot_product(const Vector<T, NDIMS>& u,
                                        const Vector<T, NDIMS>& v)
 {
@@ -543,6 +554,7 @@ inline T Vector<T, NDIMS>::dot_product(const Vector<T, NDIMS>& u,
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Vector<T, 3> Vector<T, NDIMS>::cross_product(const Vector<T, 2>& u,
                                                     const Vector<T, 2>& v)
 {
@@ -555,6 +567,7 @@ inline Vector<T, 3> Vector<T, NDIMS>::cross_product(const Vector<T, 2>& u,
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Vector<T, 3> Vector<T, NDIMS>::cross_product(const Vector<T, 3>& u,
                                                     const Vector<T, 3>& v)
 {
@@ -567,6 +580,7 @@ inline Vector<T, 3> Vector<T, NDIMS>::cross_product(const Vector<T, 3>& u,
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Vector<T, NDIMS> operator*(const Vector<T, NDIMS>& vec, const T scalar)
 {
   Vector<T, NDIMS> result(vec);
@@ -576,6 +590,7 @@ inline Vector<T, NDIMS> operator*(const Vector<T, NDIMS>& vec, const T scalar)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Vector<T, NDIMS> operator*(const T scalar, const Vector<T, NDIMS>& vec)
 {
   Vector<T, NDIMS> result(vec);
@@ -585,6 +600,7 @@ inline Vector<T, NDIMS> operator*(const T scalar, const Vector<T, NDIMS>& vec)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Vector<T, NDIMS> operator+(const Vector<T, NDIMS>& vec1,
                                   const Vector<T, NDIMS>& vec2)
 {
@@ -630,6 +646,7 @@ inline Vector<T, NDIMS> operator/(const Vector<T, NDIMS>& vec, const T scalar)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
+AXOM_HOST_DEVICE
 inline Vector<T, NDIMS> operator-(const Vector<T, NDIMS>& vec1,
                                   const Vector<T, NDIMS>& vec2)
 {

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -421,8 +421,7 @@ namespace primal
 {
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator*=(T scalar)
+AXOM_HOST_DEVICE inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator*=(T scalar)
 {
   m_components *= scalar;
   return *this;
@@ -430,8 +429,7 @@ inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator*=(T scalar)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator/=(T scalar)
+AXOM_HOST_DEVICE inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator/=(T scalar)
 {
   m_components /= scalar;
   return *this;
@@ -439,8 +437,8 @@ inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator/=(T scalar)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator+=(const Vector<T, NDIMS>& v)
+AXOM_HOST_DEVICE inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator+=(
+  const Vector<T, NDIMS>& v)
 {
   m_components += v.array();
   return *this;
@@ -448,8 +446,8 @@ inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator+=(const Vector<T, NDIMS>& v)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator-=(const Vector<T, NDIMS>& v)
+AXOM_HOST_DEVICE inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator-=(
+  const Vector<T, NDIMS>& v)
 {
   m_components -= v.array();
   return *this;
@@ -457,24 +455,21 @@ inline Vector<T, NDIMS>& Vector<T, NDIMS>::operator-=(const Vector<T, NDIMS>& v)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline double Vector<T, NDIMS>::squared_norm() const
+AXOM_HOST_DEVICE inline double Vector<T, NDIMS>::squared_norm() const
 {
   return dot(*this);
 }
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline double Vector<T, NDIMS>::norm() const
+AXOM_HOST_DEVICE inline double Vector<T, NDIMS>::norm() const
 {
   return std::sqrt(squared_norm());
 }
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Vector<T, NDIMS> Vector<T, NDIMS>::unitVector() const
+AXOM_HOST_DEVICE inline Vector<T, NDIMS> Vector<T, NDIMS>::unitVector() const
 {
   constexpr double EPS = 1.0e-50;
 
@@ -496,8 +491,7 @@ inline Vector<T, NDIMS> Vector<T, NDIMS>::unitVector() const
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline void Vector<T, NDIMS>::negate()
+AXOM_HOST_DEVICE inline void Vector<T, NDIMS>::negate()
 {
   for(int i = 0; i < NDIMS; ++i)
   {
@@ -507,8 +501,7 @@ inline void Vector<T, NDIMS>::negate()
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline bool Vector<T, NDIMS>::is_zero() const
+AXOM_HOST_DEVICE inline bool Vector<T, NDIMS>::is_zero() const
 {
   for(int i = 0; i < NDIMS; ++i)
   {
@@ -522,8 +515,7 @@ inline bool Vector<T, NDIMS>::is_zero() const
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline T Vector<T, NDIMS>::dot(const Vector<T, NDIMS>& vec) const
+AXOM_HOST_DEVICE inline T Vector<T, NDIMS>::dot(const Vector<T, NDIMS>& vec) const
 {
   return dot_product(*this, vec);
 }
@@ -544,9 +536,8 @@ std::ostream& Vector<T, NDIMS>::print(std::ostream& os) const
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline T Vector<T, NDIMS>::dot_product(const Vector<T, NDIMS>& u,
-                                       const Vector<T, NDIMS>& v)
+AXOM_HOST_DEVICE inline T Vector<T, NDIMS>::dot_product(const Vector<T, NDIMS>& u,
+                                                        const Vector<T, NDIMS>& v)
 {
   SLIC_ASSERT(u.dimension() == v.dimension());
   return static_cast<T>(numerics::dot_product(u.data(), v.data(), NDIMS));
@@ -554,9 +545,9 @@ inline T Vector<T, NDIMS>::dot_product(const Vector<T, NDIMS>& u,
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Vector<T, 3> Vector<T, NDIMS>::cross_product(const Vector<T, 2>& u,
-                                                    const Vector<T, 2>& v)
+AXOM_HOST_DEVICE inline Vector<T, 3> Vector<T, NDIMS>::cross_product(
+  const Vector<T, 2>& u,
+  const Vector<T, 2>& v)
 {
   Vector<T, 3> c;
   c[0] = 0;
@@ -567,9 +558,9 @@ inline Vector<T, 3> Vector<T, NDIMS>::cross_product(const Vector<T, 2>& u,
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Vector<T, 3> Vector<T, NDIMS>::cross_product(const Vector<T, 3>& u,
-                                                    const Vector<T, 3>& v)
+AXOM_HOST_DEVICE inline Vector<T, 3> Vector<T, NDIMS>::cross_product(
+  const Vector<T, 3>& u,
+  const Vector<T, 3>& v)
 {
   Vector<T, 3> c;
   numerics::cross_product(u.data(), v.data(), c.data());
@@ -580,8 +571,8 @@ inline Vector<T, 3> Vector<T, NDIMS>::cross_product(const Vector<T, 3>& u,
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Vector<T, NDIMS> operator*(const Vector<T, NDIMS>& vec, const T scalar)
+AXOM_HOST_DEVICE inline Vector<T, NDIMS> operator*(const Vector<T, NDIMS>& vec,
+                                                   const T scalar)
 {
   Vector<T, NDIMS> result(vec);
   result *= scalar;
@@ -590,8 +581,8 @@ inline Vector<T, NDIMS> operator*(const Vector<T, NDIMS>& vec, const T scalar)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Vector<T, NDIMS> operator*(const T scalar, const Vector<T, NDIMS>& vec)
+AXOM_HOST_DEVICE inline Vector<T, NDIMS> operator*(const T scalar,
+                                                   const Vector<T, NDIMS>& vec)
 {
   Vector<T, NDIMS> result(vec);
   result *= scalar;
@@ -600,9 +591,8 @@ inline Vector<T, NDIMS> operator*(const T scalar, const Vector<T, NDIMS>& vec)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Vector<T, NDIMS> operator+(const Vector<T, NDIMS>& vec1,
-                                  const Vector<T, NDIMS>& vec2)
+AXOM_HOST_DEVICE inline Vector<T, NDIMS> operator+(const Vector<T, NDIMS>& vec1,
+                                                   const Vector<T, NDIMS>& vec2)
 {
   Vector<T, NDIMS> result(vec1);
   result += vec2;
@@ -646,9 +636,8 @@ inline Vector<T, NDIMS> operator/(const Vector<T, NDIMS>& vec, const T scalar)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE
-inline Vector<T, NDIMS> operator-(const Vector<T, NDIMS>& vec1,
-                                  const Vector<T, NDIMS>& vec2)
+AXOM_HOST_DEVICE inline Vector<T, NDIMS> operator-(const Vector<T, NDIMS>& vec1,
+                                                   const Vector<T, NDIMS>& vec2)
 {
   Vector<T, NDIMS> result(vec1);
   result -= vec2;

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -476,6 +476,7 @@ AXOM_HOST_DEVICE bool intersect_tri3D_tri3D(const Triangle<T, 3>& t1,
  *
  * Helper function for T-T intersect.
  */
+AXOM_HOST_DEVICE
 inline bool intersectTwoPermutedTriangles(const Point3& p1,
                                           const Point3& q1,
                                           const Point3& r1,
@@ -559,6 +560,7 @@ inline bool checkVertex(const Point2& p1,
  * \note The result is equal to twice the signed area of a 2D triangle
  * with vertices (A,B,C) (in CCW order).
  */
+AXOM_HOST_DEVICE
 inline double twoDcross(const Point2& A, const Point2& B, const Point2& C)
 {
   return (((A[0] - C[0]) * (B[1] - C[1]) - (A[1] - C[1]) * (B[0] - C[0])));
@@ -567,6 +569,7 @@ inline double twoDcross(const Point2& A, const Point2& B, const Point2& C)
 /*!
  * \brief Checks if x > y, within a specified tolerance.
  */
+AXOM_HOST_DEVICE
 inline bool isGt(double x, double y, double EPS)
 {
   return ((x > y) && !(axom::utilities::isNearlyEqual(x, y, EPS)));
@@ -575,6 +578,7 @@ inline bool isGt(double x, double y, double EPS)
 /*!
  * \brief Checks if x < y, within a specified tolerance.
  */
+AXOM_HOST_DEVICE
 inline bool isLt(double x, double y, double EPS)
 {
   return ((x < y) && !(axom::utilities::isNearlyEqual(x, y, EPS)));
@@ -583,6 +587,7 @@ inline bool isLt(double x, double y, double EPS)
 /*!
  * \brief Checks if x <= y, within a specified tolerance.
  */
+AXOM_HOST_DEVICE
 inline bool isLeq(double x, double y, double EPS) { return !(isGt(x, y, EPS)); }
 
 /*!
@@ -594,6 +599,7 @@ inline bool isLeq(double x, double y, double EPS) { return !(isGt(x, y, EPS)); }
  *
  * Supports checkEdge and checkVertex
  */
+AXOM_HOST_DEVICE
 inline bool isLpeq(double x, double y, bool includeEqual, double EPS)
 {
   if(includeEqual && axom::utilities::isNearlyEqual(x, y, EPS))
@@ -607,6 +613,7 @@ inline bool isLpeq(double x, double y, bool includeEqual, double EPS)
 /*!
  * \brief Checks if x >= y, within a specified tolerance.
  */
+AXOM_HOST_DEVICE
 inline bool isGeq(double x, double y, double EPS) { return !(isLt(x, y, EPS)); }
 
 /*!
@@ -618,6 +625,7 @@ inline bool isGeq(double x, double y, double EPS) { return !(isLt(x, y, EPS)); }
  *
  * Supports checkEdge and checkVertex
  */
+AXOM_HOST_DEVICE
 inline bool isGpeq(double x, double y, bool includeEqual, double EPS)
 {
   if(includeEqual && axom::utilities::isNearlyEqual(x, y, EPS))
@@ -631,6 +639,7 @@ inline bool isGpeq(double x, double y, bool includeEqual, double EPS)
 /*!
  * \brief Check if x, y, and z all have the same sign.
  */
+AXOM_HOST_DEVICE
 inline bool nonzeroSignMatch(double x, double y, double z, double EPS)
 {
   return !(axom::utilities::isNearlyEqual(x, 0., EPS)) &&
@@ -643,6 +652,7 @@ inline bool nonzeroSignMatch(double x, double y, double z, double EPS)
 /*!
  * \brief Check if two of x, y, and z are near zero.
  */
+AXOM_HOST_DEVICE
 inline bool twoZeros(double x, double y, double z, double EPS)
 {
   return countZeros(x, y, z, EPS) == 2;
@@ -651,6 +661,7 @@ inline bool twoZeros(double x, double y, double z, double EPS)
 /*!
  * \brief Check if one of x, y, and z is near zero and the others' signs match.
  */
+AXOM_HOST_DEVICE
 inline bool oneZeroOthersMatch(double x, double y, double z, double EPS)
 {
   namespace util = axom::utilities;
@@ -663,6 +674,7 @@ inline bool oneZeroOthersMatch(double x, double y, double z, double EPS)
 /*!
  * \brief Count the number of arguments near zero.
  */
+AXOM_HOST_DEVICE
 inline int countZeros(double x, double y, double z, double EPS)
 {
   return (int)axom::utilities::isNearlyEqual(x, 0.0, EPS) +

--- a/src/axom/primal/tests/primal_boundingbox.cpp
+++ b/src/axom/primal/tests/primal_boundingbox.cpp
@@ -653,6 +653,14 @@ AXOM_CUDA_TEST(primal_boundingBox, bb_check_policies)
 
   check_bb_policy<cuda_exec>();
 #endif
+
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
+  defined(RAJA_ENABLE_HIP) && defined(AXOM_USE_UMPIRE)
+
+  using hip_exec = axom::HIP_EXEC<512>;
+
+  check_bb_policy<hip_exec>();
+#endif
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -362,7 +362,7 @@ void check_oct_tet_clip(double EPS)
   // Save current/default allocator
   const int current_allocator = axom::getDefaultAllocatorID();
 
-  // Determine new allocator (for CUDA policy, set to Unified)
+  // Determine new allocator (for CUDA or HIP policy, set to Unified)
   umpire::Allocator allocator =
     rm.getAllocator(axom::execution_space<ExecPolicy>::allocatorID());
 
@@ -429,7 +429,7 @@ TEST(primal_clip, clip_oct_tet_omp)
   #endif /* AXOM_USE_OPENMP */
 
   #if defined(AXOM_USE_CUDA)
-AXOM_CUDA_TEST(primal_clip, unit_poly_clip_vertices_gpu)
+AXOM_CUDA_TEST(primal_clip, unit_poly_clip_vertices_cuda)
 {
   unit_check_poly_clip<axom::CUDA_EXEC<256>>();
 }
@@ -440,7 +440,21 @@ AXOM_CUDA_TEST(primal_clip, clip_oct_tet_cuda)
   check_oct_tet_clip<axom::CUDA_EXEC<256>>(EPS);
 }
   #endif /* AXOM_USE_CUDA */
-#endif   /* AXOM_USE_RAJA && AXOM_USE_UMPIRE */
+
+  #if defined(AXOM_USE_HIP)
+TEST(primal_clip, unit_poly_clip_vertices_hip)
+{
+  unit_check_poly_clip<axom::HIP_EXEC<256>>();
+}
+
+TEST(primal_clip, clip_oct_tet_hip)
+{
+  const double EPS = 1e-4;
+  check_oct_tet_clip<axom::HIP_EXEC<256>>(EPS);
+}
+  #endif /* AXOM_USE_HIP */
+
+#endif /* AXOM_USE_RAJA && AXOM_USE_UMPIRE */
 
 // Tetrahedron does not clip octahedron.
 TEST(primal_clip, oct_tet_clip_nonintersect)

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -2181,7 +2181,7 @@ void check_plane_bb_intersect()
   // Save current/default allocator
   const int current_allocator = axom::getDefaultAllocatorID();
 
-  // Determine new allocator (for CUDA policy, set to device)
+  // Determine new allocator (for CUDA or HIP policy, set to device)
   umpire::Allocator allocator =
     (axom::execution_space<ExecSpace>::onDevice()
        ? rm.getAllocator(umpire::resource::Device)
@@ -2264,7 +2264,7 @@ void check_plane_seg_intersect()
   // Save current/default allocator
   const int current_allocator = axom::getDefaultAllocatorID();
 
-  // Determine new allocator (for CUDA policy, set to device)
+  // Determine new allocator (for CUDA or HIP policy, set to device)
   umpire::Allocator allocator =
     (axom::execution_space<ExecSpace>::onDevice()
        ? rm.getAllocator(umpire::resource::Device)
@@ -2385,6 +2385,24 @@ AXOM_CUDA_TEST(primal_intersect, plane_seg_test_intersection_cuda)
   check_plane_seg_intersect<exec>();
 }
   #endif /* AXOM_USE_CUDA */
+
+  #ifdef AXOM_USE_HIP
+TEST(primal_intersect, plane_bb_test_intersection_hip)
+{
+  constexpr int BLOCK_SIZE = 256;
+  using exec = axom::HIP_EXEC<BLOCK_SIZE>;
+
+  check_plane_bb_intersect<exec>();
+}
+
+TEST(primal_intersect, plane_seg_test_intersection_hip)
+{
+  constexpr int BLOCK_SIZE = 256;
+  using exec = axom::HIP_EXEC<BLOCK_SIZE>;
+
+  check_plane_seg_intersect<exec>();
+}
+  #endif /* AXOM_USE_HIP */
 
 #endif /* AXOM_USE_RAJA && AXOM_USE_UMPIRE */
 

--- a/src/axom/primal/tests/primal_numeric_array.cpp
+++ b/src/axom/primal/tests/primal_numeric_array.cpp
@@ -289,6 +289,14 @@ AXOM_CUDA_TEST(primal_numeric_array, numeric_array_check_policies)
 
   check_numeric_array_policy<cuda_exec>();
 #endif
+
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
+  defined(RAJA_ENABLE_HIP) && defined(AXOM_USE_UMPIRE)
+
+  using hip_exec = axom::HIP_EXEC<512>;
+
+  check_numeric_array_policy<hip_exec>();
+#endif
 }
 
 //----------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_point.cpp
+++ b/src/axom/primal/tests/primal_point.cpp
@@ -393,6 +393,14 @@ AXOM_CUDA_TEST(primal_point, point_check_policies)
 
   check_point_policy<cuda_exec>();
 #endif
+
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
+  defined(RAJA_ENABLE_HIP) && defined(AXOM_USE_UMPIRE)
+
+  using hip_exec = axom::HIP_EXEC<512>;
+
+  check_point_policy<hip_exec>();
+#endif
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_polyhedron.cpp
+++ b/src/axom/primal/tests/primal_polyhedron.cpp
@@ -136,7 +136,7 @@ void check_volume()
   // Save current/default allocator
   const int current_allocator = axom::getDefaultAllocatorID();
 
-  // Determine new allocator (for CUDA policy, set to Unified)
+  // Determine new allocator (for CUDA or HIP policy, set to Unified)
   umpire::Allocator allocator =
     rm.getAllocator(axom::execution_space<ExecSpace>::allocatorID());
 
@@ -201,6 +201,16 @@ AXOM_CUDA_TEST(primal_polyhedron, check_volume_cuda)
   check_volume<exec>();
 }
   #endif /* AXOM_USE_CUDA */
+
+  #ifdef AXOM_USE_HIP
+TEST(primal_polyhedron, check_volume_hip)
+{
+  constexpr int BLOCK_SIZE = 256;
+  using exec = axom::HIP_EXEC<BLOCK_SIZE>;
+
+  check_volume<exec>();
+}
+  #endif /* AXOM_USE_HIP */
 
 #endif /* AXOM_USE_RAJA && AXOM_USE_UMPIRE */
 

--- a/src/axom/primal/tests/primal_vector.cpp
+++ b/src/axom/primal/tests/primal_vector.cpp
@@ -387,6 +387,14 @@ AXOM_CUDA_TEST(primal_numeric_array, numeric_array_check_policies)
 
   check_vector_policy<cuda_exec>();
 #endif
+
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
+  defined(RAJA_ENABLE_HIP) && defined(AXOM_USE_UMPIRE)
+
+  using hip_exec = axom::HIP_EXEC<512>;
+
+  check_vector_policy<hip_exec>();
+#endif
 }
 
 //----------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_zip.cpp
+++ b/src/axom/primal/tests/primal_zip.cpp
@@ -518,7 +518,7 @@ TEST(primal_zip, zip_rays_2d_from_3d)
 }
 
 #ifdef AXOM_USE_CUDA
-AXOM_CUDA_TEST(primal_zip, zip_points_3d_gpu)
+AXOM_CUDA_TEST(primal_zip, zip_points_3d_cuda)
 {
   using PointType = primal::Point<double, 3>;
   using ExecSpace = axom::CUDA_EXEC<256>;
@@ -526,14 +526,14 @@ AXOM_CUDA_TEST(primal_zip, zip_points_3d_gpu)
   check_zip_points_3d<ExecSpace, PointType>();
 }
 
-TEST(primal_zip, zip_points_2d_from_3d_gpu)
+TEST(primal_zip, zip_points_2d_from_3d_cuda)
 {
   using ExecSpace = axom::CUDA_EXEC<256>;
 
   check_zip_points_2d_from_3d<ExecSpace>();
 }
 
-AXOM_CUDA_TEST(primal_zip, zip_vectors_3d_gpu)
+AXOM_CUDA_TEST(primal_zip, zip_vectors_3d_cuda)
 {
   using PointType = primal::Vector<double, 3>;
   using ExecSpace = axom::CUDA_EXEC<256>;
@@ -541,37 +541,97 @@ AXOM_CUDA_TEST(primal_zip, zip_vectors_3d_gpu)
   check_zip_points_3d<ExecSpace, PointType>();
 }
 
-TEST(primal_zip, zip_vectors_2d_from_3d_gpu)
+TEST(primal_zip, zip_vectors_2d_from_3d_cuda)
 {
   using ExecSpace = axom::CUDA_EXEC<256>;
 
   check_zip_vectors_2d_from_3d<ExecSpace>();
 }
 
-AXOM_CUDA_TEST(primal_zip, zip_bbs_3d_gpu)
+AXOM_CUDA_TEST(primal_zip, zip_bbs_3d_cuda)
 {
   using ExecSpace = axom::CUDA_EXEC<256>;
 
   check_zip_bbs_3d<ExecSpace>();
 }
 
-TEST(primal_zip, zip_bbs_2d_from_3d_gpu)
+TEST(primal_zip, zip_bbs_2d_from_3d_cuda)
 {
   using ExecSpace = axom::CUDA_EXEC<256>;
 
   check_zip_bbs_2d_from_3d<ExecSpace>();
 }
 
-TEST(primal_zip, zip_rays_3d_gpu)
+TEST(primal_zip, zip_rays_3d_cuda)
 {
   using ExecSpace = axom::CUDA_EXEC<256>;
 
   check_zip_rays_3d<ExecSpace>();
 }
 
-TEST(primal_zip, zip_rays_2d_from_3d_gpu)
+TEST(primal_zip, zip_rays_2d_from_3d_cuda)
 {
   using ExecSpace = axom::CUDA_EXEC<256>;
+
+  check_zip_rays_2d_from_3d<ExecSpace>();
+}
+#endif
+
+#ifdef AXOM_USE_HIP
+TEST(primal_zip, zip_points_3d_hip)
+{
+  using PointType = primal::Point<double, 3>;
+  using ExecSpace = axom::HIP_EXEC<256>;
+
+  check_zip_points_3d<ExecSpace, PointType>();
+}
+
+TEST(primal_zip, zip_points_2d_from_3d_hip)
+{
+  using ExecSpace = axom::HIP_EXEC<256>;
+
+  check_zip_points_2d_from_3d<ExecSpace>();
+}
+
+TEST(primal_zip, zip_vectors_3d_hip)
+{
+  using PointType = primal::Vector<double, 3>;
+  using ExecSpace = axom::HIP_EXEC<256>;
+
+  check_zip_points_3d<ExecSpace, PointType>();
+}
+
+TEST(primal_zip, zip_vectors_2d_from_3d_hip)
+{
+  using ExecSpace = axom::HIP_EXEC<256>;
+
+  check_zip_vectors_2d_from_3d<ExecSpace>();
+}
+
+TEST(primal_zip, zip_bbs_3d_hip)
+{
+  using ExecSpace = axom::HIP_EXEC<256>;
+
+  check_zip_bbs_3d<ExecSpace>();
+}
+
+TEST(primal_zip, zip_bbs_2d_from_3d_hip)
+{
+  using ExecSpace = axom::HIP_EXEC<256>;
+
+  check_zip_bbs_2d_from_3d<ExecSpace>();
+}
+
+TEST(primal_zip, zip_rays_3d_hip)
+{
+  using ExecSpace = axom::HIP_EXEC<256>;
+
+  check_zip_rays_3d<ExecSpace>();
+}
+
+TEST(primal_zip, zip_rays_2d_from_3d_hip)
+{
+  using ExecSpace = axom::HIP_EXEC<256>;
 
   check_zip_rays_2d_from_3d<ExecSpace>();
 }

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -563,7 +563,7 @@ inline void SignedDistance<NDIMS, ExecSpace>::computeDistances(
 
 //------------------------------------------------------------------------------
 template <int NDIMS, typename ExecSpace>
-inline axom::primal::BoundingBox<double, NDIMS> AXOM_HOST_DEVICE
+AXOM_HOST_DEVICE inline axom::primal::BoundingBox<double, NDIMS>
 SignedDistance<NDIMS, ExecSpace>::getCellBoundingBox(axom::IndexType icell,
                                                      const detail::UcdMeshData& mesh,
                                                      ZipPoint meshPts)

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -564,6 +564,7 @@ inline void SignedDistance<NDIMS, ExecSpace>::computeDistances(
 //------------------------------------------------------------------------------
 template <int NDIMS, typename ExecSpace>
 inline axom::primal::BoundingBox<double, NDIMS>
+AXOM_HOST_DEVICE
 SignedDistance<NDIMS, ExecSpace>::getCellBoundingBox(axom::IndexType icell,
                                                      const detail::UcdMeshData& mesh,
                                                      ZipPoint meshPts)
@@ -591,6 +592,7 @@ SignedDistance<NDIMS, ExecSpace>::getCellBoundingBox(axom::IndexType icell,
 
 //------------------------------------------------------------------------------
 template <int NDIMS, typename ExecSpace>
+AXOM_HOST_DEVICE
 inline void SignedDistance<NDIMS, ExecSpace>::checkCandidate(
   const PointType& qpt,
   MinCandidate& currMin,
@@ -699,6 +701,7 @@ inline void SignedDistance<NDIMS, ExecSpace>::checkCandidate(
 
 //------------------------------------------------------------------------------
 template <int NDIMS, typename ExecSpace>
+AXOM_HOST_DEVICE
 inline double SignedDistance<NDIMS, ExecSpace>::computeSign(
   const PointType& qpt,
   const MinCandidate& currMin)

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -563,8 +563,7 @@ inline void SignedDistance<NDIMS, ExecSpace>::computeDistances(
 
 //------------------------------------------------------------------------------
 template <int NDIMS, typename ExecSpace>
-inline axom::primal::BoundingBox<double, NDIMS>
-AXOM_HOST_DEVICE
+inline axom::primal::BoundingBox<double, NDIMS> AXOM_HOST_DEVICE
 SignedDistance<NDIMS, ExecSpace>::getCellBoundingBox(axom::IndexType icell,
                                                      const detail::UcdMeshData& mesh,
                                                      ZipPoint meshPts)
@@ -592,8 +591,7 @@ SignedDistance<NDIMS, ExecSpace>::getCellBoundingBox(axom::IndexType icell,
 
 //------------------------------------------------------------------------------
 template <int NDIMS, typename ExecSpace>
-AXOM_HOST_DEVICE
-inline void SignedDistance<NDIMS, ExecSpace>::checkCandidate(
+AXOM_HOST_DEVICE inline void SignedDistance<NDIMS, ExecSpace>::checkCandidate(
   const PointType& qpt,
   MinCandidate& currMin,
   IndexType cellId,
@@ -701,8 +699,7 @@ inline void SignedDistance<NDIMS, ExecSpace>::checkCandidate(
 
 //------------------------------------------------------------------------------
 template <int NDIMS, typename ExecSpace>
-AXOM_HOST_DEVICE
-inline double SignedDistance<NDIMS, ExecSpace>::computeSign(
+AXOM_HOST_DEVICE inline double SignedDistance<NDIMS, ExecSpace>::computeSign(
   const PointType& qpt,
   const MinCandidate& currMin)
 {

--- a/src/axom/sidre/tests/CMakeLists.txt
+++ b/src/axom/sidre/tests/CMakeLists.txt
@@ -47,8 +47,8 @@ set(fruit_sidre_tests
    sidre_allocatable_F.f
    )
 
-set(sidre_tests_depends_on axom gtest)
-blt_list_append( TO sidre_tests_depends_on ELEMENTS blt::hip IF ENABLE_HIP )
+set(sidre_gtests_depends_on axom gtest)
+blt_list_append( TO sidre_gtests_depends_on ELEMENTS blt::hip IF ENABLE_HIP )
 
 
 #------------------------------------------------------------------------------
@@ -59,7 +59,7 @@ foreach(test ${gtest_sidre_tests})
     blt_add_executable( NAME ${test_name}_test
                         SOURCES ${test}
                         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                        DEPENDS_ON ${sidre_tests_depends_on}
+                        DEPENDS_ON ${sidre_gtests_depends_on}
                         FOLDER axom/sidre/tests
                         )
 
@@ -78,7 +78,7 @@ if (ENABLE_FORTRAN)
         blt_add_executable( NAME ${test_name}_test
                             SOURCES ${test}
                             OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                            DEPENDS_ON ${sidre_tests_depends_on}
+                            DEPENDS_ON sidre gtest
                             FOLDER axom/sidre/tests
                             )
         axom_add_test( NAME    ${test_name}
@@ -96,7 +96,7 @@ if (ENABLE_FORTRAN)
         blt_add_executable( NAME ${test_name}_test
                             SOURCES ${test}
                             OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                            DEPENDS_ON ${sidre_tests_depends_on} fruit
+                            DEPENDS_ON sidre fruit
                             FOLDER axom/sidre/tests
                             )
         axom_add_test( NAME    ${test_name}

--- a/src/axom/sidre/tests/CMakeLists.txt
+++ b/src/axom/sidre/tests/CMakeLists.txt
@@ -47,6 +47,10 @@ set(fruit_sidre_tests
    sidre_allocatable_F.f
    )
 
+set(sidre_tests_depends_on axom gtest)
+blt_list_append( TO sidre_tests_depends_on ELEMENTS blt::hip IF ENABLE_HIP )
+
+
 #------------------------------------------------------------------------------
 # Add gtest C++ tests
 #------------------------------------------------------------------------------
@@ -55,7 +59,7 @@ foreach(test ${gtest_sidre_tests})
     blt_add_executable( NAME ${test_name}_test
                         SOURCES ${test}
                         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                        DEPENDS_ON axom gtest
+                        DEPENDS_ON ${sidre_tests_depends_on}
                         FOLDER axom/sidre/tests
                         )
 
@@ -74,7 +78,7 @@ if (ENABLE_FORTRAN)
         blt_add_executable( NAME ${test_name}_test
                             SOURCES ${test}
                             OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                            DEPENDS_ON sidre gtest
+                            DEPENDS_ON ${sidre_tests_depends_on}
                             FOLDER axom/sidre/tests
                             )
         axom_add_test( NAME    ${test_name}
@@ -92,7 +96,7 @@ if (ENABLE_FORTRAN)
         blt_add_executable( NAME ${test_name}_test
                             SOURCES ${test}
                             OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                            DEPENDS_ON sidre fruit
+                            DEPENDS_ON ${sidre_tests_depends_on} fruit
                             FOLDER axom/sidre/tests
                             )
         axom_add_test( NAME    ${test_name}

--- a/src/axom/sidre/tests/CMakeLists.txt
+++ b/src/axom/sidre/tests/CMakeLists.txt
@@ -48,6 +48,8 @@ set(fruit_sidre_tests
    )
 
 set(sidre_gtests_depends_on axom gtest)
+
+# hipErrorNoBinaryForGpu without hip dependency
 blt_list_append( TO sidre_gtests_depends_on ELEMENTS blt::hip IF ENABLE_HIP )
 
 

--- a/src/axom/slam/tests/CMakeLists.txt
+++ b/src/axom/slam/tests/CMakeLists.txt
@@ -46,6 +46,8 @@ set(gtest_slam_tests
 
 
 set(slam_tests_depends_on axom gtest)
+blt_list_append( TO slam_tests_depends_on ELEMENTS blt::hip IF ENABLE_HIP )
+
 
 #------------------------------------------------------------------------------
 # Add gtest based tests

--- a/src/axom/slam/tests/CMakeLists.txt
+++ b/src/axom/slam/tests/CMakeLists.txt
@@ -46,6 +46,8 @@ set(gtest_slam_tests
 
 
 set(slam_tests_depends_on axom gtest)
+
+# hipErrorNoBinaryForGpu without hip dependency
 blt_list_append( TO slam_tests_depends_on ELEMENTS blt::hip IF ENABLE_HIP )
 
 

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -426,8 +426,9 @@
 
 /// @}
 
-// Use assert when on device
-#elif defined(AXOM_DEBUG) && defined(AXOM_DEVICE_CODE)
+// Use assert when on device (HIP does not yet support assert())
+#elif defined(AXOM_DEBUG) && defined(AXOM_DEVICE_CODE) && \
+  !defined(__HIP_DEVICE_COMPILE__)
 
   #define SLIC_ASSERT(EXP) assert(EXP)
   #define SLIC_ASSERT_MSG(EXP, msg) assert(EXP)

--- a/src/axom/spin/UniformGrid.hpp
+++ b/src/axom/spin/UniformGrid.hpp
@@ -899,11 +899,11 @@ void UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::getCandidatesAsArray(
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS, typename ExecSpace, typename StoragePolicy>
 AXOM_HOST_DEVICE
-typename UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::GridCell
-UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::getClampedGridCell(
-  const LatticeType& lattice,
-  const primal::NumericArray<int, NDIMS>& resolution,
-  const PointType& pt)
+  typename UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::GridCell
+  UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::getClampedGridCell(
+    const LatticeType& lattice,
+    const primal::NumericArray<int, NDIMS>& resolution,
+    const PointType& pt)
 {
   GridCell cell = lattice.gridCell(pt);
 

--- a/src/axom/spin/UniformGrid.hpp
+++ b/src/axom/spin/UniformGrid.hpp
@@ -898,6 +898,7 @@ void UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::getCandidatesAsArray(
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS, typename ExecSpace, typename StoragePolicy>
+AXOM_HOST_DEVICE
 typename UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::GridCell
 UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::getClampedGridCell(
   const LatticeType& lattice,

--- a/src/cmake/AxomConfig.cmake
+++ b/src/cmake/AxomConfig.cmake
@@ -13,7 +13,7 @@ message(STATUS "Configuring Axom version ${AXOM_VERSION_FULL}")
 ## Add a definition to the generated config file for each library dependency
 ## (optional and built-in) that we might need to know about in the code. We
 ## check for vars of the form <DEP>_FOUND or ENABLE_<DEP>
-set(TPL_DEPS C2C CAMP CLI11 CONDUIT CUDA FMT HDF5 LUA MFEM MPI OPENMP RAJA SCR SOL SPARSEHASH UMPIRE )
+set(TPL_DEPS C2C CAMP CLI11 CONDUIT CUDA FMT HIP HDF5 LUA MFEM MPI OPENMP RAJA SCR SOL SPARSEHASH UMPIRE )
 foreach(dep ${TPL_DEPS})
     if( ${dep}_FOUND OR ENABLE_${dep} )
         set(AXOM_USE_${dep} TRUE  )

--- a/src/cmake/axom-config.cmake.in
+++ b/src/cmake/axom-config.cmake.in
@@ -31,6 +31,7 @@ if(NOT AXOM_FOUND)
   # Language features
   set(AXOM_ENABLE_FORTRAN     "@ENABLE_FORTRAN@")
   set(AXOM_USE_CUDA           "@AXOM_USE_CUDA@")
+  set(AXOM_USE_HIP            "@AXOM_USE_HIP@")
   set(AXOM_USE_MPI            "@AXOM_USE_MPI@")
   set(AXOM_USE_OPENMP         "@AXOM_USE_OPENMP@")
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -70,6 +70,7 @@ if(AXOM_ENABLE_QUEST)
     # Add separable compilation flag
     if (ENABLE_HIP)
         blt_add_target_compile_flags(TO mesh_tester FLAGS "-fgpu-rdc")
+        blt_add_target_link_flags(TO mesh_tester FLAGS "-fgpu-rdc")
     endif()
 endif()
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -66,6 +66,11 @@ if(AXOM_ENABLE_QUEST)
     install(TARGETS              mesh_tester
             DESTINATION          bin
             )
+
+    # Add separable compilation flag
+    if (ENABLE_HIP)
+        blt_add_target_compile_flags(TO mesh_tester FLAGS "-fgpu-rdc")
+    endif()
 endif()
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This PR:

- Adds a hip execution policy for device kernels
- Adds hip policy to kernels in core and primal unit tests and examples
- Updates toss4 cray configs to use rocm 5.1.1
  - Adds a tioga host-config 

Relates to #685 