### PR TITLE
Update config-build and uberenv for MSVC 2022

### DIFF
--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -22,10 +22,10 @@ jobs:
         include:
         - arch: "x64"
           triplet: "x64-windows"
-          msvc:    "201964"
+          msvc:    "202264"
         - arch: "x86"
           triplet: "x86-windows"
-          msvc:    "2019"
+          msvc:    "2022"
 
     steps:
     - name: Checkout repo w/ submodules

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -9,7 +9,7 @@
 "spack_packages_path": "scripts/spack/packages",
 "spack_concretizer": "clingo",
 "vcpkg_url": "https://github.com/microsoft/vcpkg",
-"vcpkg_commit": "5568f110b509a9fd90711978a7cb76bae75bb092",
+"vcpkg_commit": "14e7bb4ae24616ec54ff6b2f6ef4e8659434ea44",
 "vcpkg_triplet": "x64-windows",
 "vcpkg_ports_path": "scripts/vcpkg_ports"
 }

--- a/config-build.py
+++ b/config-build.py
@@ -92,10 +92,14 @@ def parse_arguments():
     msvcversions = {'2017': 'Visual Studio 15 2017',
                     '201764': 'Visual Studio 15 2017 Win64',
                     '2019': 'Visual Studio 16 2019',
-                    '201964': 'Visual Studio 16 2019'}
+                    '201964': 'Visual Studio 16 2019',
+                    '2022': 'Visual Studio 17 2022',
+                    '202264': 'Visual Studio 17 2022'}
     # Newer versions  of MSVC might supply an architecture flag
     generator_archs = {'2019': 'Win32',
-                       '201964': 'x64'}
+                       '201964': 'x64',
+                       '2022': 'Win32',
+                       '202264': 'x64'}
     parser.add_argument(
         "--msvc",
         type=str,
@@ -305,6 +309,7 @@ def run_cmake(buildpath, cmakeline):
     os.chdir(buildpath)
     print("Executing CMake line: '%s'" % cmakeline)
     print("")
+
     returncode = subprocess.call(cmakeline, shell=True)
     if not returncode == 0:
         print(


### PR DESCRIPTION
# Summary

- This PR is a feature
- It updates vcpkg to 2022.05.10 release
- It updates config-build.py to use MSVC 2022

Note: A sidre data collection test was failing in develop. This appears to be related to #820.