### PR TITLE
Rename Group methods to createViewWithShape

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -113,6 +113,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   This is an advanced feature that could cause users to break an input file state after verification. This also alows us
   to not expose `axom/sol.hpp` to all users of Inlet. This greatly reduces compile times. Using this feature requires
   both a derived class and including `axom/sol.hpp` in the user code.
+- Renamed some overloads of function `createView` of
+  `axom::sidre::Group` which accept `int ndims, IndexType *shape`
+  arguments to be `createViewWithShape` or `createViewWithShapeAndAllocate`.
 
 ###  Fixed
 - Fixed a bug relating to swap and assignment operations for multidimensional `axom::Array`s
@@ -130,6 +133,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Fixed bug in axom::Path that ignored the leading delimiter character if one was present
 - Fixed gcc compiler errors in configurations without RAJA or Umpire
 - Fixed `axom::Array<T>` behavior on copy-construction when `T` is a non-trivial type
+- Replaced `using` statement in `SidreDataTypesIds.h` with `typedef`
+  since C syntax is required in this file.
 
 ## [Version 0.6.1] - Release date 2021-11-17
 

--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -265,10 +265,10 @@ View* Group::createView(const std::string& path, TypeID type, IndexType num_elem
  *
  *************************************************************************
  */
-View* Group::createView(const std::string& path,
-                        TypeID type,
-                        int ndims,
-                        const IndexType* shape)
+View* Group::createViewWithShape(const std::string& path,
+                                 TypeID type,
+                                 int ndims,
+                                 const IndexType* shape)
 {
   if(type == NO_TYPE_ID || ndims < 0 || shape == nullptr)
   {
@@ -366,13 +366,13 @@ View* Group::createView(const std::string& path,
  *
  *************************************************************************
  */
-View* Group::createView(const std::string& path,
-                        TypeID type,
-                        int ndims,
-                        const IndexType* shape,
-                        Buffer* buff)
+View* Group::createViewWithShape(const std::string& path,
+                                 TypeID type,
+                                 int ndims,
+                                 const IndexType* shape,
+                                 Buffer* buff)
 {
-  View* view = createView(path, type, ndims, shape);
+  View* view = createViewWithShape(path, type, ndims, shape);
   if(view != nullptr)
   {
     view->attachBuffer(buff);
@@ -452,13 +452,13 @@ View* Group::createView(const std::string& path,
  *
  *************************************************************************
  */
-View* Group::createView(const std::string& path,
-                        TypeID type,
-                        int ndims,
-                        const IndexType* shape,
-                        void* external_ptr)
+View* Group::createViewWithShape(const std::string& path,
+                                 TypeID type,
+                                 int ndims,
+                                 const IndexType* shape,
+                                 void* external_ptr)
 {
-  View* view = createView(path, type, ndims, shape);
+  View* view = createViewWithShape(path, type, ndims, shape);
   if(view != nullptr)
   {
     view->setExternalDataPtr(external_ptr);
@@ -523,15 +523,15 @@ View* Group::createViewAndAllocate(const std::string& path,
  *
  *************************************************************************
  */
-View* Group::createViewAndAllocate(const std::string& path,
-                                   TypeID type,
-                                   int ndims,
-                                   const IndexType* shape,
-                                   int allocID)
+View* Group::createViewWithShapeAndAllocate(const std::string& path,
+                                            TypeID type,
+                                            int ndims,
+                                            const IndexType* shape,
+                                            int allocID)
 {
   allocID = getValidAllocatorID(allocID);
 
-  View* view = createView(path, type, ndims, shape);
+  View* view = createViewWithShape(path, type, ndims, shape);
   if(view != nullptr)
   {
     view->allocate(allocID);

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -426,10 +426,10 @@ public:
    *
    * \return pointer to new View object or nullptr if one is not created.
    */
-  View* createView(const std::string& path,
-                   TypeID type,
-                   int ndims,
-                   const IndexType* shape);
+  View* createViewWithShape(const std::string& path,
+                            TypeID type,
+                            int ndims,
+                            const IndexType* shape);
 
   /*!
    * \brief Create View object with given name or path in this Group that
@@ -515,11 +515,11 @@ public:
    *
    * \sa View::attachBuffer()
    */
-  View* createView(const std::string& path,
-                   TypeID type,
-                   int ndims,
-                   const IndexType* shape,
-                   Buffer* buff);
+  View* createViewWithShape(const std::string& path,
+                            TypeID type,
+                            int ndims,
+                            const IndexType* shape,
+                            Buffer* buff);
 
   /*!
    * \brief Create View object with given name or path in this Group that
@@ -607,11 +607,11 @@ public:
    *
    * \sa View::setExternalDataPtr()
    */
-  View* createView(const std::string& path,
-                   TypeID type,
-                   int ndims,
-                   const IndexType* shape,
-                   void* external_ptr);
+  View* createViewWithShape(const std::string& path,
+                            TypeID type,
+                            int ndims,
+                            const IndexType* shape,
+                            void* external_ptr);
   /*!
    * \brief Create View object with given name or path in this Group that
    * is described by a Conduit DataType object and attach externally-owned
@@ -675,11 +675,11 @@ public:
    *
    * \sa View::allocate()
    */
-  View* createViewAndAllocate(const std::string& path,
-                              TypeID type,
-                              int ndims,
-                              const IndexType* shape,
-                              int allocID = INVALID_ALLOCATOR_ID);
+  View* createViewWithShapeAndAllocate(const std::string& path,
+                                       TypeID type,
+                                       int ndims,
+                                       const IndexType* shape,
+                                       int allocID = INVALID_ALLOCATOR_ID);
 
   /*!
    * \brief Create View object with given name or path in this Group that

--- a/src/axom/sidre/core/SidreDataTypeIds.h
+++ b/src/axom/sidre/core/SidreDataTypeIds.h
@@ -11,6 +11,11 @@
  *
  */
 
+/*
+ * Note: Use only C code in this file
+ *       since it might be included from a C file.
+ */
+
 #ifndef SIDRE_DATATYPEIDS_H_
 #define SIDRE_DATATYPEIDS_H_
 

--- a/src/axom/sidre/core/SidreDataTypeIds.h
+++ b/src/axom/sidre/core/SidreDataTypeIds.h
@@ -19,7 +19,7 @@
 
 #include <stdint.h> /* for int64_t */
 
-using SIDRE_IndexType = int64_t;
+typedef int64_t SIDRE_IndexType;
 
 const SIDRE_IndexType SIDRE_InvalidIndex = -1;
 

--- a/src/axom/sidre/examples/sidre_stressgroups.cpp
+++ b/src/axom/sidre/examples/sidre_stressgroups.cpp
@@ -80,7 +80,7 @@ int main(int argc, char* argv[])
   std::random_shuffle(names.begin(), names.end());
 
   axom::utilities::Timer create_timer(true);
-  for(unsigned int i = 0; i < num_groups; ++i)
+  for(int i = 0; i < num_groups; ++i)
   {
     root->createGroup(names[i]);
   }
@@ -90,7 +90,7 @@ int main(int argc, char* argv[])
   std::random_shuffle(names.begin(), names.end());
 
   axom::utilities::Timer query_timer(true);
-  for(unsigned int i = 0; i < num_groups; ++i)
+  for(int i = 0; i < num_groups; ++i)
   {
     if(!root->hasGroup(names[i]))
     {
@@ -103,7 +103,7 @@ int main(int argc, char* argv[])
   std::random_shuffle(names.begin(), names.end());
 
   axom::utilities::Timer destroy_timer(true);
-  for(unsigned int i = 0; i < num_groups; ++i)
+  for(int i = 0; i < num_groups; ++i)
   {
     root->destroyGroup(names[i]);
   }

--- a/src/axom/sidre/examples/sidre_stressgroups.cpp
+++ b/src/axom/sidre/examples/sidre_stressgroups.cpp
@@ -27,7 +27,7 @@ int main(int argc, char* argv[])
   DataStore* ds = new DataStore();
   Group* root = ds->getRoot();
 
-  IndexType num_groups = 0;
+  size_t num_groups = 0;
   if(argc > 1)
   {
     num_groups = static_cast<IndexType>(atoi(argv[1]));
@@ -47,7 +47,7 @@ int main(int argc, char* argv[])
 
   std::set<std::string> name_set;
 
-  while(static_cast<IndexType>(name_set.size()) < num_groups)
+  while(name_set.size() < num_groups)
   {
     std::string new_string;
     for(int c = 0; c < 8; ++c)
@@ -80,7 +80,7 @@ int main(int argc, char* argv[])
   std::random_shuffle(names.begin(), names.end());
 
   axom::utilities::Timer create_timer(true);
-  for(int i = 0; i < num_groups; ++i)
+  for(size_t i = 0; i < num_groups; ++i)
   {
     root->createGroup(names[i]);
   }
@@ -90,7 +90,7 @@ int main(int argc, char* argv[])
   std::random_shuffle(names.begin(), names.end());
 
   axom::utilities::Timer query_timer(true);
-  for(int i = 0; i < num_groups; ++i)
+  for(size_t i = 0; i < num_groups; ++i)
   {
     if(!root->hasGroup(names[i]))
     {
@@ -103,7 +103,7 @@ int main(int argc, char* argv[])
   std::random_shuffle(names.begin(), names.end());
 
   axom::utilities::Timer destroy_timer(true);
-  for(int i = 0; i < num_groups; ++i)
+  for(size_t i = 0; i < num_groups; ++i)
   {
     root->destroyGroup(names[i]);
   }

--- a/src/axom/sidre/interface/c_fortran/wrapGroup.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapGroup.cpp
@@ -440,19 +440,19 @@ SIDRE_View *SIDRE_Group_create_view_from_type_bufferify(SIDRE_Group *self,
   // splicer end class.Group.method.create_view_from_type_bufferify
 }
 
-SIDRE_View *SIDRE_Group_create_view_from_shape(SIDRE_Group *self,
-                                               const char *path,
-                                               int type,
-                                               int ndims,
-                                               const SIDRE_IndexType *shape,
-                                               SIDRE_View *SHC_rv)
+SIDRE_View *SIDRE_Group_create_view_with_shape_base(SIDRE_Group *self,
+                                                    const char *path,
+                                                    int type,
+                                                    int ndims,
+                                                    const SIDRE_IndexType *shape,
+                                                    SIDRE_View *SHC_rv)
 {
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
-  // splicer begin class.Group.method.create_view_from_shape
+  // splicer begin class.Group.method.create_view_with_shape_base
   const std::string SHCXX_path(path);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   axom::sidre::View *SHCXX_rv =
-    SH_this->createView(SHCXX_path, SHCXX_type, ndims, shape);
+    SH_this->createViewWithShape(SHCXX_path, SHCXX_type, ndims, shape);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -464,27 +464,28 @@ SIDRE_View *SIDRE_Group_create_view_from_shape(SIDRE_Group *self,
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
-  // splicer end class.Group.method.create_view_from_shape
+  // splicer end class.Group.method.create_view_with_shape_base
 }
 
-SIDRE_View *SIDRE_Group_create_view_from_shape_bufferify(SIDRE_Group *self,
-                                                         const char *path,
-                                                         int Lpath,
-                                                         int type,
-                                                         int ndims,
-                                                         const SIDRE_IndexType *shape,
-                                                         SIDRE_View *SHC_rv)
+SIDRE_View *SIDRE_Group_create_view_with_shape_base_bufferify(
+  SIDRE_Group *self,
+  const char *path,
+  int Lpath,
+  int type,
+  int ndims,
+  const SIDRE_IndexType *shape,
+  SIDRE_View *SHC_rv)
 {
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
-  // splicer begin class.Group.method.create_view_from_shape_bufferify
+  // splicer begin class.Group.method.create_view_with_shape_base_bufferify
   const std::string SHCXX_path(path, Lpath);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   axom::sidre::View *SHCXX_rv =
-    SH_this->createView(SHCXX_path, SHCXX_type, ndims, shape);
+    SH_this->createViewWithShape(SHCXX_path, SHCXX_type, ndims, shape);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
-  // splicer end class.Group.method.create_view_from_shape_bufferify
+  // splicer end class.Group.method.create_view_with_shape_base_bufferify
 }
 
 SIDRE_View *SIDRE_Group_create_view_into_buffer(SIDRE_Group *self,
@@ -582,7 +583,7 @@ SIDRE_View *SIDRE_Group_create_view_from_type_and_buffer_bufferify(
   // splicer end class.Group.method.create_view_from_type_and_buffer_bufferify
 }
 
-SIDRE_View *SIDRE_Group_create_view_from_shape_and_buffer(SIDRE_Group *self,
+SIDRE_View *SIDRE_Group_create_view_with_shape_and_buffer(SIDRE_Group *self,
                                                           const char *path,
                                                           int type,
                                                           int ndims,
@@ -591,13 +592,13 @@ SIDRE_View *SIDRE_Group_create_view_from_shape_and_buffer(SIDRE_Group *self,
                                                           SIDRE_View *SHC_rv)
 {
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
-  // splicer begin class.Group.method.create_view_from_shape_and_buffer
+  // splicer begin class.Group.method.create_view_with_shape_and_buffer
   const std::string SHCXX_path(path);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   axom::sidre::Buffer *SHCXX_buff =
     static_cast<axom::sidre::Buffer *>(buff->addr);
   axom::sidre::View *SHCXX_rv =
-    SH_this->createView(SHCXX_path, SHCXX_type, ndims, shape, SHCXX_buff);
+    SH_this->createViewWithShape(SHCXX_path, SHCXX_type, ndims, shape, SHCXX_buff);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -609,10 +610,10 @@ SIDRE_View *SIDRE_Group_create_view_from_shape_and_buffer(SIDRE_Group *self,
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
-  // splicer end class.Group.method.create_view_from_shape_and_buffer
+  // splicer end class.Group.method.create_view_with_shape_and_buffer
 }
 
-SIDRE_View *SIDRE_Group_create_view_from_shape_and_buffer_bufferify(
+SIDRE_View *SIDRE_Group_create_view_with_shape_and_buffer_bufferify(
   SIDRE_Group *self,
   const char *path,
   int Lpath,
@@ -623,17 +624,17 @@ SIDRE_View *SIDRE_Group_create_view_from_shape_and_buffer_bufferify(
   SIDRE_View *SHC_rv)
 {
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
-  // splicer begin class.Group.method.create_view_from_shape_and_buffer_bufferify
+  // splicer begin class.Group.method.create_view_with_shape_and_buffer_bufferify
   const std::string SHCXX_path(path, Lpath);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   axom::sidre::Buffer *SHCXX_buff =
     static_cast<axom::sidre::Buffer *>(buff->addr);
   axom::sidre::View *SHCXX_rv =
-    SH_this->createView(SHCXX_path, SHCXX_type, ndims, shape, SHCXX_buff);
+    SH_this->createViewWithShape(SHCXX_path, SHCXX_type, ndims, shape, SHCXX_buff);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
-  // splicer end class.Group.method.create_view_from_shape_and_buffer_bufferify
+  // splicer end class.Group.method.create_view_with_shape_and_buffer_bufferify
 }
 
 SIDRE_View *SIDRE_Group_create_view_external(SIDRE_Group *self,
@@ -723,7 +724,7 @@ SIDRE_View *SIDRE_Group_create_view_from_type_external_bufferify(
   // splicer end class.Group.method.create_view_from_type_external_bufferify
 }
 
-SIDRE_View *SIDRE_Group_create_view_from_shape_external(SIDRE_Group *self,
+SIDRE_View *SIDRE_Group_create_view_with_shape_external(SIDRE_Group *self,
                                                         const char *path,
                                                         int type,
                                                         int ndims,
@@ -732,11 +733,11 @@ SIDRE_View *SIDRE_Group_create_view_from_shape_external(SIDRE_Group *self,
                                                         SIDRE_View *SHC_rv)
 {
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
-  // splicer begin class.Group.method.create_view_from_shape_external
+  // splicer begin class.Group.method.create_view_with_shape_external
   const std::string SHCXX_path(path);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   axom::sidre::View *SHCXX_rv =
-    SH_this->createView(SHCXX_path, SHCXX_type, ndims, shape, external_ptr);
+    SH_this->createViewWithShape(SHCXX_path, SHCXX_type, ndims, shape, external_ptr);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -748,10 +749,10 @@ SIDRE_View *SIDRE_Group_create_view_from_shape_external(SIDRE_Group *self,
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
-  // splicer end class.Group.method.create_view_from_shape_external
+  // splicer end class.Group.method.create_view_with_shape_external
 }
 
-SIDRE_View *SIDRE_Group_create_view_from_shape_external_bufferify(
+SIDRE_View *SIDRE_Group_create_view_with_shape_external_bufferify(
   SIDRE_Group *self,
   const char *path,
   int Lpath,
@@ -762,15 +763,15 @@ SIDRE_View *SIDRE_Group_create_view_from_shape_external_bufferify(
   SIDRE_View *SHC_rv)
 {
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
-  // splicer begin class.Group.method.create_view_from_shape_external_bufferify
+  // splicer begin class.Group.method.create_view_with_shape_external_bufferify
   const std::string SHCXX_path(path, Lpath);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   axom::sidre::View *SHCXX_rv =
-    SH_this->createView(SHCXX_path, SHCXX_type, ndims, shape, external_ptr);
+    SH_this->createViewWithShape(SHCXX_path, SHCXX_type, ndims, shape, external_ptr);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
-  // splicer end class.Group.method.create_view_from_shape_external_bufferify
+  // splicer end class.Group.method.create_view_with_shape_external_bufferify
 }
 
 SIDRE_View *SIDRE_Group_create_view_and_allocate_nelems(SIDRE_Group *self,
@@ -819,19 +820,20 @@ SIDRE_View *SIDRE_Group_create_view_and_allocate_nelems_bufferify(
   // splicer end class.Group.method.create_view_and_allocate_nelems_bufferify
 }
 
-SIDRE_View *SIDRE_Group_create_view_and_allocate_shape(SIDRE_Group *self,
-                                                       const char *path,
-                                                       int type,
-                                                       int ndims,
-                                                       const SIDRE_IndexType *shape,
-                                                       SIDRE_View *SHC_rv)
+SIDRE_View *SIDRE_Group_create_view_with_shape_and_allocate(
+  SIDRE_Group *self,
+  const char *path,
+  int type,
+  int ndims,
+  const SIDRE_IndexType *shape,
+  SIDRE_View *SHC_rv)
 {
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
-  // splicer begin class.Group.method.create_view_and_allocate_shape
+  // splicer begin class.Group.method.create_view_with_shape_and_allocate
   const std::string SHCXX_path(path);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   axom::sidre::View *SHCXX_rv =
-    SH_this->createViewAndAllocate(SHCXX_path, SHCXX_type, ndims, shape);
+    SH_this->createViewWithShapeAndAllocate(SHCXX_path, SHCXX_type, ndims, shape);
   // C_error_pattern
   if(SHCXX_rv == nullptr)
   {
@@ -843,10 +845,10 @@ SIDRE_View *SIDRE_Group_create_view_and_allocate_shape(SIDRE_Group *self,
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
-  // splicer end class.Group.method.create_view_and_allocate_shape
+  // splicer end class.Group.method.create_view_with_shape_and_allocate
 }
 
-SIDRE_View *SIDRE_Group_create_view_and_allocate_shape_bufferify(
+SIDRE_View *SIDRE_Group_create_view_with_shape_and_allocate_bufferify(
   SIDRE_Group *self,
   const char *path,
   int Lpath,
@@ -856,15 +858,15 @@ SIDRE_View *SIDRE_Group_create_view_and_allocate_shape_bufferify(
   SIDRE_View *SHC_rv)
 {
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
-  // splicer begin class.Group.method.create_view_and_allocate_shape_bufferify
+  // splicer begin class.Group.method.create_view_with_shape_and_allocate_bufferify
   const std::string SHCXX_path(path, Lpath);
   axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
   axom::sidre::View *SHCXX_rv =
-    SH_this->createViewAndAllocate(SHCXX_path, SHCXX_type, ndims, shape);
+    SH_this->createViewWithShapeAndAllocate(SHCXX_path, SHCXX_type, ndims, shape);
   SHC_rv->addr = SHCXX_rv;
   SHC_rv->idtor = 0;
   return SHC_rv;
-  // splicer end class.Group.method.create_view_and_allocate_shape_bufferify
+  // splicer end class.Group.method.create_view_with_shape_and_allocate_bufferify
 }
 
 SIDRE_View *SIDRE_Group_create_view_scalar_int(SIDRE_Group *self,

--- a/src/axom/sidre/interface/c_fortran/wrapGroup.h
+++ b/src/axom/sidre/interface/c_fortran/wrapGroup.h
@@ -127,20 +127,21 @@ SIDRE_View* SIDRE_Group_create_view_from_type_bufferify(SIDRE_Group* self,
                                                         SIDRE_IndexType num_elems,
                                                         SIDRE_View* SHC_rv);
 
-SIDRE_View* SIDRE_Group_create_view_from_shape(SIDRE_Group* self,
-                                               const char* path,
-                                               int type,
-                                               int ndims,
-                                               const SIDRE_IndexType* shape,
-                                               SIDRE_View* SHC_rv);
+SIDRE_View* SIDRE_Group_create_view_with_shape_base(SIDRE_Group* self,
+                                                    const char* path,
+                                                    int type,
+                                                    int ndims,
+                                                    const SIDRE_IndexType* shape,
+                                                    SIDRE_View* SHC_rv);
 
-SIDRE_View* SIDRE_Group_create_view_from_shape_bufferify(SIDRE_Group* self,
-                                                         const char* path,
-                                                         int Lpath,
-                                                         int type,
-                                                         int ndims,
-                                                         const SIDRE_IndexType* shape,
-                                                         SIDRE_View* SHC_rv);
+SIDRE_View* SIDRE_Group_create_view_with_shape_base_bufferify(
+  SIDRE_Group* self,
+  const char* path,
+  int Lpath,
+  int type,
+  int ndims,
+  const SIDRE_IndexType* shape,
+  SIDRE_View* SHC_rv);
 
 SIDRE_View* SIDRE_Group_create_view_into_buffer(SIDRE_Group* self,
                                                 const char* path,
@@ -169,7 +170,7 @@ SIDRE_View* SIDRE_Group_create_view_from_type_and_buffer_bufferify(
   SIDRE_Buffer* buff,
   SIDRE_View* SHC_rv);
 
-SIDRE_View* SIDRE_Group_create_view_from_shape_and_buffer(SIDRE_Group* self,
+SIDRE_View* SIDRE_Group_create_view_with_shape_and_buffer(SIDRE_Group* self,
                                                           const char* path,
                                                           int type,
                                                           int ndims,
@@ -177,7 +178,7 @@ SIDRE_View* SIDRE_Group_create_view_from_shape_and_buffer(SIDRE_Group* self,
                                                           SIDRE_Buffer* buff,
                                                           SIDRE_View* SHC_rv);
 
-SIDRE_View* SIDRE_Group_create_view_from_shape_and_buffer_bufferify(
+SIDRE_View* SIDRE_Group_create_view_with_shape_and_buffer_bufferify(
   SIDRE_Group* self,
   const char* path,
   int Lpath,
@@ -214,7 +215,7 @@ SIDRE_View* SIDRE_Group_create_view_from_type_external_bufferify(
   void* external_ptr,
   SIDRE_View* SHC_rv);
 
-SIDRE_View* SIDRE_Group_create_view_from_shape_external(SIDRE_Group* self,
+SIDRE_View* SIDRE_Group_create_view_with_shape_external(SIDRE_Group* self,
                                                         const char* path,
                                                         int type,
                                                         int ndims,
@@ -222,7 +223,7 @@ SIDRE_View* SIDRE_Group_create_view_from_shape_external(SIDRE_Group* self,
                                                         void* external_ptr,
                                                         SIDRE_View* SHC_rv);
 
-SIDRE_View* SIDRE_Group_create_view_from_shape_external_bufferify(
+SIDRE_View* SIDRE_Group_create_view_with_shape_external_bufferify(
   SIDRE_Group* self,
   const char* path,
   int Lpath,
@@ -246,14 +247,15 @@ SIDRE_View* SIDRE_Group_create_view_and_allocate_nelems_bufferify(
   SIDRE_IndexType num_elems,
   SIDRE_View* SHC_rv);
 
-SIDRE_View* SIDRE_Group_create_view_and_allocate_shape(SIDRE_Group* self,
-                                                       const char* path,
-                                                       int type,
-                                                       int ndims,
-                                                       const SIDRE_IndexType* shape,
-                                                       SIDRE_View* SHC_rv);
+SIDRE_View* SIDRE_Group_create_view_with_shape_and_allocate(
+  SIDRE_Group* self,
+  const char* path,
+  int type,
+  int ndims,
+  const SIDRE_IndexType* shape,
+  SIDRE_View* SHC_rv);
 
-SIDRE_View* SIDRE_Group_create_view_and_allocate_shape_bufferify(
+SIDRE_View* SIDRE_Group_create_view_with_shape_and_allocate_bufferify(
   SIDRE_Group* self,
   const char* path,
   int Lpath,

--- a/src/axom/sidre/interface/c_fortran/wrapfsidre.F
+++ b/src/axom/sidre/interface/c_fortran/wrapfsidre.F
@@ -115,18 +115,18 @@ module axom_sidre
         procedure :: create_view_empty => group_create_view_empty
         procedure :: create_view_from_type_int32_t => group_create_view_from_type_int32_t
         procedure :: create_view_from_type_int64_t => group_create_view_from_type_int64_t
-        procedure :: create_view_from_shape => group_create_view_from_shape
+        procedure :: create_view_with_shape_base => group_create_view_with_shape_base
         procedure :: create_view_into_buffer => group_create_view_into_buffer
         procedure :: create_view_from_type_and_buffer_int32_t => group_create_view_from_type_and_buffer_int32_t
         procedure :: create_view_from_type_and_buffer_int64_t => group_create_view_from_type_and_buffer_int64_t
-        procedure :: create_view_from_shape_and_buffer => group_create_view_from_shape_and_buffer
+        procedure :: create_view_with_shape_and_buffer => group_create_view_with_shape_and_buffer
         procedure :: create_view_external => group_create_view_external
         procedure :: create_view_from_type_external_int32_t => group_create_view_from_type_external_int32_t
         procedure :: create_view_from_type_external_int64_t => group_create_view_from_type_external_int64_t
-        procedure :: create_view_from_shape_external => group_create_view_from_shape_external
+        procedure :: create_view_with_shape_external => group_create_view_with_shape_external
         procedure :: create_view_and_allocate_nelems_int32_t => group_create_view_and_allocate_nelems_int32_t
         procedure :: create_view_and_allocate_nelems_int64_t => group_create_view_and_allocate_nelems_int64_t
-        procedure :: create_view_and_allocate_shape => group_create_view_and_allocate_shape
+        procedure :: create_view_with_shape_and_allocate => group_create_view_with_shape_and_allocate
         procedure :: create_view_scalar_int => group_create_view_scalar_int
         procedure :: create_view_scalar_long => group_create_view_scalar_long
         procedure :: create_view_scalar_float => group_create_view_scalar_float
@@ -166,20 +166,20 @@ module axom_sidre
         procedure :: associated => group_associated
         generic :: create_view => create_view_empty,  &
             create_view_from_type_int32_t, create_view_from_type_int64_t &
-            , create_view_from_shape, create_view_into_buffer,  &
+            , create_view_into_buffer,  &
             create_view_from_type_and_buffer_int32_t,  &
             create_view_from_type_and_buffer_int64_t,  &
-            create_view_from_shape_and_buffer, create_view_external,  &
-            create_view_from_type_external_int32_t,  &
-            create_view_from_type_external_int64_t,  &
-            create_view_from_shape_external
+            create_view_external, create_view_from_type_external_int32_t &
+            , create_view_from_type_external_int64_t
         generic :: create_view_and_allocate =>  &
             create_view_and_allocate_nelems_int32_t,  &
-            create_view_and_allocate_nelems_int64_t,  &
-            create_view_and_allocate_shape
+            create_view_and_allocate_nelems_int64_t
         generic :: create_view_scalar => create_view_scalar_int,  &
             create_view_scalar_long, create_view_scalar_float,  &
             create_view_scalar_double
+        generic :: create_view_with_shape => create_view_with_shape_base &
+            , create_view_with_shape_and_buffer,  &
+            create_view_with_shape_external
         generic :: destroy_group => destroy_group_name,  &
             destroy_group_index_int32_t, destroy_group_index_int64_t
         generic :: destroy_view_and_data => destroy_view_and_data_name,  &
@@ -956,10 +956,10 @@ module axom_sidre
             type(C_PTR) SHT_rv
         end function c_group_create_view_from_type_bufferify
 
-        function c_group_create_view_from_shape(self, path, type, ndims, &
-                shape, SHT_crv) &
+        function c_group_create_view_with_shape_base(self, path, type, &
+                ndims, shape, SHT_crv) &
                 result(SHT_rv) &
-                bind(C, name="SIDRE_Group_create_view_from_shape")
+                bind(C, name="SIDRE_Group_create_view_with_shape_base")
             use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
             import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
@@ -970,12 +970,12 @@ module axom_sidre
             integer(C_INT64_T), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
-        end function c_group_create_view_from_shape
+        end function c_group_create_view_with_shape_base
 
-        function c_group_create_view_from_shape_bufferify(self, path, &
-                Lpath, type, ndims, shape, SHT_crv) &
+        function c_group_create_view_with_shape_base_bufferify(self, &
+                path, Lpath, type, ndims, shape, SHT_crv) &
                 result(SHT_rv) &
-                bind(C, name="SIDRE_Group_create_view_from_shape_bufferify")
+                bind(C, name="SIDRE_Group_create_view_with_shape_base_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
             import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
@@ -987,7 +987,7 @@ module axom_sidre
             integer(C_INT64_T), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
-        end function c_group_create_view_from_shape_bufferify
+        end function c_group_create_view_with_shape_base_bufferify
 
         function c_group_create_view_into_buffer(self, path, buff, &
                 SHT_crv) &
@@ -1051,10 +1051,10 @@ module axom_sidre
             type(C_PTR) SHT_rv
         end function c_group_create_view_from_type_and_buffer_bufferify
 
-        function c_group_create_view_from_shape_and_buffer(self, path, &
+        function c_group_create_view_with_shape_and_buffer(self, path, &
                 type, ndims, shape, buff, SHT_crv) &
                 result(SHT_rv) &
-                bind(C, name="SIDRE_Group_create_view_from_shape_and_buffer")
+                bind(C, name="SIDRE_Group_create_view_with_shape_and_buffer")
             use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
             import :: SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
@@ -1066,12 +1066,12 @@ module axom_sidre
             type(SIDRE_SHROUD_buffer_capsule), intent(INOUT) :: buff
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
-        end function c_group_create_view_from_shape_and_buffer
+        end function c_group_create_view_with_shape_and_buffer
 
-        function c_group_create_view_from_shape_and_buffer_bufferify( &
+        function c_group_create_view_with_shape_and_buffer_bufferify( &
                 self, path, Lpath, type, ndims, shape, buff, SHT_crv) &
                 result(SHT_rv) &
-                bind(C, name="SIDRE_Group_create_view_from_shape_and_buffer_bufferify")
+                bind(C, name="SIDRE_Group_create_view_with_shape_and_buffer_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
             import :: SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
@@ -1084,7 +1084,7 @@ module axom_sidre
             type(SIDRE_SHROUD_buffer_capsule), intent(INOUT) :: buff
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
-        end function c_group_create_view_from_shape_and_buffer_bufferify
+        end function c_group_create_view_with_shape_and_buffer_bufferify
 
         function c_group_create_view_external(self, path, external_ptr, &
                 SHT_crv) &
@@ -1148,10 +1148,10 @@ module axom_sidre
             type(C_PTR) SHT_rv
         end function c_group_create_view_from_type_external_bufferify
 
-        function c_group_create_view_from_shape_external(self, path, &
+        function c_group_create_view_with_shape_external(self, path, &
                 type, ndims, shape, external_ptr, SHT_crv) &
                 result(SHT_rv) &
-                bind(C, name="SIDRE_Group_create_view_from_shape_external")
+                bind(C, name="SIDRE_Group_create_view_with_shape_external")
             use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
             import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
@@ -1163,12 +1163,12 @@ module axom_sidre
             type(C_PTR), value, intent(IN) :: external_ptr
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
-        end function c_group_create_view_from_shape_external
+        end function c_group_create_view_with_shape_external
 
-        function c_group_create_view_from_shape_external_bufferify(self, &
+        function c_group_create_view_with_shape_external_bufferify(self, &
                 path, Lpath, type, ndims, shape, external_ptr, SHT_crv) &
                 result(SHT_rv) &
-                bind(C, name="SIDRE_Group_create_view_from_shape_external_bufferify")
+                bind(C, name="SIDRE_Group_create_view_with_shape_external_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
             import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
@@ -1181,7 +1181,7 @@ module axom_sidre
             type(C_PTR), value, intent(IN) :: external_ptr
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
-        end function c_group_create_view_from_shape_external_bufferify
+        end function c_group_create_view_with_shape_external_bufferify
 
         function c_group_create_view_and_allocate_nelems(self, path, &
                 type, num_elems, SHT_crv) &
@@ -1214,10 +1214,10 @@ module axom_sidre
             type(C_PTR) SHT_rv
         end function c_group_create_view_and_allocate_nelems_bufferify
 
-        function c_group_create_view_and_allocate_shape(self, path, &
+        function c_group_create_view_with_shape_and_allocate(self, path, &
                 type, ndims, shape, SHT_crv) &
                 result(SHT_rv) &
-                bind(C, name="SIDRE_Group_create_view_and_allocate_shape")
+                bind(C, name="SIDRE_Group_create_view_with_shape_and_allocate")
             use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
             import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
@@ -1228,12 +1228,12 @@ module axom_sidre
             integer(C_INT64_T), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
-        end function c_group_create_view_and_allocate_shape
+        end function c_group_create_view_with_shape_and_allocate
 
-        function c_group_create_view_and_allocate_shape_bufferify(self, &
-                path, Lpath, type, ndims, shape, SHT_crv) &
+        function c_group_create_view_with_shape_and_allocate_bufferify( &
+                self, path, Lpath, type, ndims, shape, SHT_crv) &
                 result(SHT_rv) &
-                bind(C, name="SIDRE_Group_create_view_and_allocate_shape_bufferify")
+                bind(C, name="SIDRE_Group_create_view_with_shape_and_allocate_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
             import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
@@ -1245,7 +1245,7 @@ module axom_sidre
             integer(C_INT64_T), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
-        end function c_group_create_view_and_allocate_shape_bufferify
+        end function c_group_create_view_with_shape_and_allocate_bufferify
 
         function c_group_create_view_scalar_int(self, path, value, &
                 SHT_crv) &
@@ -3040,7 +3040,8 @@ contains
         ! splicer end class.Group.method.create_view_from_type_int64_t
     end function group_create_view_from_type_int64_t
 
-    function group_create_view_from_shape(obj, path, type, ndims, shape) &
+    function group_create_view_with_shape_base(obj, path, type, ndims, &
+            shape) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
         class(SidreGroup) :: obj
@@ -3049,13 +3050,13 @@ contains
         integer(C_INT), value, intent(IN) :: ndims
         integer(C_INT64_T), intent(IN) :: shape(:)
         type(SidreView) :: SHT_rv
-        ! splicer begin class.Group.method.create_view_from_shape
+        ! splicer begin class.Group.method.create_view_with_shape_base
         type(C_PTR) :: SHT_prv
-        SHT_prv = c_group_create_view_from_shape_bufferify(obj%cxxmem, &
+        SHT_prv = c_group_create_view_with_shape_base_bufferify(obj%cxxmem, &
             path, len_trim(path, kind=C_INT), type, ndims, shape, &
             SHT_rv%cxxmem)
-        ! splicer end class.Group.method.create_view_from_shape
-    end function group_create_view_from_shape
+        ! splicer end class.Group.method.create_view_with_shape_base
+    end function group_create_view_with_shape_base
 
     function group_create_view_into_buffer(obj, path, buff) &
             result(SHT_rv)
@@ -3108,7 +3109,7 @@ contains
         ! splicer end class.Group.method.create_view_from_type_and_buffer_int64_t
     end function group_create_view_from_type_and_buffer_int64_t
 
-    function group_create_view_from_shape_and_buffer(obj, path, type, &
+    function group_create_view_with_shape_and_buffer(obj, path, type, &
             ndims, shape, buff) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
@@ -3119,13 +3120,13 @@ contains
         integer(C_INT64_T), intent(IN) :: shape(:)
         type(SidreBuffer), intent(INOUT) :: buff
         type(SidreView) :: SHT_rv
-        ! splicer begin class.Group.method.create_view_from_shape_and_buffer
+        ! splicer begin class.Group.method.create_view_with_shape_and_buffer
         type(C_PTR) :: SHT_prv
-        SHT_prv = c_group_create_view_from_shape_and_buffer_bufferify(obj%cxxmem, &
+        SHT_prv = c_group_create_view_with_shape_and_buffer_bufferify(obj%cxxmem, &
             path, len_trim(path, kind=C_INT), type, ndims, shape, &
             buff%cxxmem, SHT_rv%cxxmem)
-        ! splicer end class.Group.method.create_view_from_shape_and_buffer
-    end function group_create_view_from_shape_and_buffer
+        ! splicer end class.Group.method.create_view_with_shape_and_buffer
+    end function group_create_view_with_shape_and_buffer
 
     function group_create_view_external(obj, path, external_ptr) &
             result(SHT_rv)
@@ -3178,7 +3179,7 @@ contains
         ! splicer end class.Group.method.create_view_from_type_external_int64_t
     end function group_create_view_from_type_external_int64_t
 
-    function group_create_view_from_shape_external(obj, path, type, &
+    function group_create_view_with_shape_external(obj, path, type, &
             ndims, shape, external_ptr) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
@@ -3189,13 +3190,13 @@ contains
         integer(C_INT64_T), intent(IN) :: shape(:)
         type(C_PTR), intent(IN) :: external_ptr
         type(SidreView) :: SHT_rv
-        ! splicer begin class.Group.method.create_view_from_shape_external
+        ! splicer begin class.Group.method.create_view_with_shape_external
         type(C_PTR) :: SHT_prv
-        SHT_prv = c_group_create_view_from_shape_external_bufferify(obj%cxxmem, &
+        SHT_prv = c_group_create_view_with_shape_external_bufferify(obj%cxxmem, &
             path, len_trim(path, kind=C_INT), type, ndims, shape, &
             external_ptr, SHT_rv%cxxmem)
-        ! splicer end class.Group.method.create_view_from_shape_external
-    end function group_create_view_from_shape_external
+        ! splicer end class.Group.method.create_view_with_shape_external
+    end function group_create_view_with_shape_external
 
     function group_create_view_and_allocate_nelems_int32_t(obj, path, &
             type, num_elems) &
@@ -3231,7 +3232,7 @@ contains
         ! splicer end class.Group.method.create_view_and_allocate_nelems_int64_t
     end function group_create_view_and_allocate_nelems_int64_t
 
-    function group_create_view_and_allocate_shape(obj, path, type, &
+    function group_create_view_with_shape_and_allocate(obj, path, type, &
             ndims, shape) &
             result(SHT_rv)
         use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
@@ -3241,13 +3242,13 @@ contains
         integer(C_INT), value, intent(IN) :: ndims
         integer(C_INT64_T), intent(IN) :: shape(:)
         type(SidreView) :: SHT_rv
-        ! splicer begin class.Group.method.create_view_and_allocate_shape
+        ! splicer begin class.Group.method.create_view_with_shape_and_allocate
         type(C_PTR) :: SHT_prv
-        SHT_prv = c_group_create_view_and_allocate_shape_bufferify(obj%cxxmem, &
+        SHT_prv = c_group_create_view_with_shape_and_allocate_bufferify(obj%cxxmem, &
             path, len_trim(path, kind=C_INT), type, ndims, shape, &
             SHT_rv%cxxmem)
-        ! splicer end class.Group.method.create_view_and_allocate_shape
-    end function group_create_view_and_allocate_shape
+        ! splicer end class.Group.method.create_view_with_shape_and_allocate
+    end function group_create_view_with_shape_and_allocate
 
     function group_create_view_scalar_int(obj, path, value) &
             result(SHT_rv)

--- a/src/axom/sidre/interface/sidre_shroud.yaml
+++ b/src/axom/sidre/interface/sidre_shroud.yaml
@@ -221,12 +221,13 @@ declarations:
     C_error_pattern: C_null_to_error_capsule
     PY_error_pattern: PY_null_to_none
 
-  - decl: View *createView( const std::string& path,
+  - decl: View *createViewWithShape(
+                            const std::string& path,
                             TypeID type,
                             int ndims,
                             const IndexType * shape+rank(1))
     format:
-      function_suffix: _from_shape
+      function_suffix: _base
     C_error_pattern: C_null_to_error_capsule
     PY_error_pattern: PY_null_to_none
 
@@ -254,13 +255,14 @@ declarations:
     C_error_pattern: C_null_to_error_capsule
     PY_error_pattern: PY_null_to_none
 
-  - decl: View *createView( const std::string& path,
+  - decl: View *createViewWithShape(
+                            const std::string& path,
                             TypeID type,
                             int ndims,
                             const IndexType * shape+rank(1),
                             Buffer * buff)
     format:
-      function_suffix: _from_shape_and_buffer
+      function_suffix: _and_buffer
     C_error_pattern: C_null_to_error_capsule
     PY_error_pattern: PY_null_to_none
 
@@ -286,13 +288,14 @@ declarations:
     C_error_pattern: C_null_to_error_capsule
     PY_error_pattern: PY_null_to_none
 
-  - decl: View *createView( const std::string& path,
+  - decl: View *createViewWithShape(
+                            const std::string& path,
                             TypeID type,
                             int ndims,
                             const IndexType * shape+rank(1),
                             void * external_ptr)
     format:
-      function_suffix: _from_shape_external
+      function_suffix: _external
     C_error_pattern: C_null_to_error_capsule
     PY_error_pattern: PY_null_to_none
 
@@ -310,12 +313,11 @@ declarations:
     C_error_pattern: C_null_to_error_capsule
     PY_error_pattern: PY_null_to_none
 
-  - decl: View *createViewAndAllocate( const std::string& path,
+  - decl: View *createViewWithShapeAndAllocate(
+                                       const std::string& path,
                                        TypeID type,
                                        int ndims,
                                        const IndexType *shape+rank(1))
-    format:
-      function_suffix: _shape
     C_error_pattern: C_null_to_error_capsule
     PY_error_pattern: PY_null_to_none
 

--- a/src/axom/sidre/tests/sidre_allocatable_F.f
+++ b/src/axom/sidre/tests/sidre_allocatable_F.f
@@ -238,7 +238,7 @@ contains
     ds = SidreDataStore()
     root = ds%get_root()
 
-    view = root%create_view_and_allocate("iarray", SIDRE_INT_ID, 3, extents_in)
+    view = root%create_view_with_shape_and_allocate("iarray", SIDRE_INT_ID, 3, extents_in)
 
     call view%get_data(ipointer)
 

--- a/src/axom/sidre/tests/sidre_buffer.cpp
+++ b/src/axom/sidre/tests/sidre_buffer.cpp
@@ -241,10 +241,11 @@ TEST(sidre_buffer, create_buffer_view)
       break;
 
     case 4:
-      view = root->createView("data4", INT_ID, ndims, shape, buff);
+      view = root->createViewWithShape("data4", INT_ID, ndims, shape, buff);
       break;
     case 5:
-      view = root->createView("data5", INT_ID, ndims, shape)->attachBuffer(buff);
+      view =
+        root->createViewWithShape("data5", INT_ID, ndims, shape)->attachBuffer(buff);
       break;
     case 6:
       view = root->createView("data6")->attachBuffer(INT_ID, ndims, shape, buff);

--- a/src/axom/sidre/tests/sidre_external.cpp
+++ b/src/axom/sidre/tests/sidre_external.cpp
@@ -57,11 +57,11 @@ TEST(sidre_external, create_external_view)
       break;
 
     case 4:
-      view = root->createView("data4", INT_ID, ndims, shape, idata);
+      view = root->createViewWithShape("data4", INT_ID, ndims, shape, idata);
       break;
     case 5:
-      view =
-        root->createView("data5", INT_ID, ndims, shape)->setExternalDataPtr(idata);
+      view = root->createViewWithShape("data5", INT_ID, ndims, shape)
+               ->setExternalDataPtr(idata);
       break;
     case 6:
       view =

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -1781,7 +1781,7 @@ TEST(sidre_group, save_restore_external_data)
   // XXX this falls into createView(name, type, ndims, shape)
   // root1->createView("empty_array", INT_ID, nfoo, NULL);
   root1->createView("external_undescribed")->setExternalDataPtr(foo4);
-  root1->createView("int2d", INT_ID, 2, shape, int2d1);
+  root1->createViewWithShape("int2d", INT_ID, 2, shape, int2d1);
 
   for(int i = 0; i < nprotocols; ++i)
   {
@@ -2043,9 +2043,10 @@ TEST(sidre_group, save_restore_other)
 
   root1->createView("empty_view");
   root1->createView("empty_described", INT_ID, ndata);
-  root1->createView("empty_shape", INT_ID, 2, shape1);
+  root1->createViewWithShape("empty_shape", INT_ID, 2, shape1);
 
-  auto* view = root1->createViewAndAllocate("buffer_shape", INT_ID, 2, shape1);
+  auto* view =
+    root1->createViewWithShapeAndAllocate("buffer_shape", INT_ID, 2, shape1);
 
   // fill the data
   {
@@ -2725,7 +2726,8 @@ TEST_P(UmpireTest, allocate)
 
   {
     IndexType shape[] = {1, SIZE, 1};
-    View* view = root->createViewAndAllocate("v", INT_ID, 3, shape, allocID);
+    View* view =
+      root->createViewWithShapeAndAllocate("v", INT_ID, 3, shape, allocID);
 
     ASSERT_EQ(allocID, rm.getAllocator(view->getVoidPtr()).getId());
     root->destroyViewAndData("v");
@@ -2755,7 +2757,7 @@ TEST_P(UmpireTest, allocate_default)
 
   {
     IndexType shape[] = {1, SIZE, 1};
-    View* view = root->createViewAndAllocate("v", INT_ID, 3, shape);
+    View* view = root->createViewWithShapeAndAllocate("v", INT_ID, 3, shape);
 
     ASSERT_EQ(allocID, rm.getAllocator(view->getVoidPtr()).getId());
     root->destroyViewAndData("v");

--- a/src/axom/sidre/tests/sidre_group_F.F
+++ b/src/axom/sidre/tests/sidre_group_F.F
@@ -907,9 +907,9 @@ contains
     shape1 = [ndata, 2]
     view1 = root1%create_view("empty_view")
     view2 = root1%create_view("empty_described", SIDRE_INT_ID, ndata)
-    view3 = root1%create_view("empty_shape", SIDRE_INT_ID, 2, shape1)
+    view3 = root1%create_view_with_shape("empty_shape", SIDRE_INT_ID, 2, shape1)
 
-    view4 = root1%create_view_and_allocate("buffer_shape", &
+    view4 = root1%create_view_with_shape_and_allocate("buffer_shape", &
          SIDRE_INT_ID, 2, shape1)
 
     do i = 1, nprotocols

--- a/src/axom/sidre/tests/sidre_view.cpp
+++ b/src/axom/sidre/tests/sidre_view.cpp
@@ -712,7 +712,7 @@ TEST(sidre_view, int_alloc_view)
   dv->allocate();
   EXPECT_TRUE(checkViewValues(dv, BUFFER, true, true, true, BLEN));
 
-  dv = root->createView("v1", INT_ID, 1, shape);
+  dv = root->createViewWithShape("v1", INT_ID, 1, shape);
   EXPECT_TRUE(checkViewValues(dv, EMPTY, true, false, false, BLEN));
   dv->allocate();
   EXPECT_TRUE(checkViewValues(dv, BUFFER, true, true, true, BLEN));
@@ -725,7 +725,7 @@ TEST(sidre_view, int_alloc_view)
   dv = root->createViewAndAllocate("a0", INT_ID, BLEN);
   EXPECT_TRUE(checkViewValues(dv, BUFFER, true, true, true, BLEN));
 
-  dv = root->createViewAndAllocate("a1", INT_ID, 1, shape);
+  dv = root->createViewWithShapeAndAllocate("a1", INT_ID, 1, shape);
   EXPECT_TRUE(checkViewValues(dv, BUFFER, true, true, true, BLEN));
 
   dv = root->createViewAndAllocate("a2", DataType::c_int(BLEN));


### PR DESCRIPTION
# Summary

- When IndexType is set to int32_t, the sidre_external and sidre_group tests fail.  The wrong overload of createView is being called since the prototypes are now too similar.

```
    View* Group::createView(const std::string& path,
                            TypeID type,
                            int ndims,
                            const IndexType* shape)

    View* Group::createView(const std::string& path,
                            TypeID type,
                            IndexType num_elems,
                            void* external_ptr)
```

- Consistently renamed createView functions with `int ndims, IndexType *shape` by adding `WithShape`. There are now `createViewWithShape` and  `createViewWithShapeAndAllocate`.
- Did not rename `View` methods with `int ndims, IndexType* shape` arguments.
- Update `Shroud` interface.

# Design review

On June 6, 2022 We discussed the design ideas.

1. Append `WithShape` to some `createView` methods.
2. In issue #43, suggested adding `using Shape = std::vector<IndexType>` to replace 'int ndims, IndexType *shape`.

This PR implements 1.  It leaves out 2. for the following reasons

- Changes more of the API by changing methods on `View` object as well.
- Adds a `std::vector` to the API. Decided native types were simpler.
