### PR TITLE
Attempted fix for CI flakiness on blueos

### DIFF
--- a/src/axom/quest/detail/Discretize_detail.hpp
+++ b/src/axom/quest/detail/Discretize_detail.hpp
@@ -262,6 +262,7 @@ bool discretize(Point2D *&polyline,
                 OctType *&out,
                 int &octcount)
 {
+  int allocId = axom::execution_space<ExecSpace>::allocatorID();
   // Check for invalid input.  If any segment is invalid, exit returning false.
   bool stillValid = true;
   int segmentcount = pointcount - 1;
@@ -289,7 +290,7 @@ bool discretize(Point2D *&polyline,
   // That was the octahedron count for one segment.  Multiply by the number
   // of segments we will compute.
   int totaloctcount = segoctcount * segmentcount;
-  out = axom::allocate<OctType>(totaloctcount);
+  out = axom::allocate<OctType>(totaloctcount, allocId);
   octcount = 0;
 
   for(int seg = 0; seg < segmentcount; ++seg)

--- a/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
+++ b/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
@@ -379,6 +379,9 @@ public:
   /*! Tests PointInCell class using isoparametric points within each cell */
   void testIsoGridPointsOnMesh(const std::string& meshTypeStr)
   {
+    int devAllocID = axom::execution_space<ExecSpace>::allocatorID();
+    int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+
     std::string filename =
       axom::fmt::format("quest_point_in_cell_{}_quad", meshTypeStr);
 
@@ -391,22 +394,20 @@ public:
       m_mesh->GetNE(),
       constructTimer.elapsed()));
 
-#ifdef AXOM_USE_UMPIRE
-    using SpacePtArray = axom::Array<SpacePt, 1, axom::MemorySpace::Unified>;
-    using IndexArray = axom::Array<IndexType, 1, axom::MemorySpace::Unified>;
-#else
     using SpacePtArray = axom::Array<SpacePt>;
     using IndexArray = axom::Array<IndexType>;
-#endif
 
     // Test that a fixed set of isoparametric coords on each cell
     // maps to the correct place.
     SpacePtArray isoPts = generateIsoParTestPoints(::TEST_GRID_RES);
 
     const auto SZ = isoPts.size();
-    SpacePtArray spacePts(SZ, SZ, m_allocatorID);
-    SpacePtArray foundIso(SZ, SZ, m_allocatorID);
-    IndexArray foundIDs(SZ, SZ, m_allocatorID);
+    axom::Array<SpacePt> spacePts(SZ, SZ);
+    axom::Array<SpacePt> foundIso(SZ, SZ);
+    axom::Array<IndexType> foundIDs(SZ, SZ);
+
+    axom::Array<SpacePt> foundIsoDevice(SZ, SZ, devAllocID);
+    axom::Array<IndexType> foundIDsDevice(SZ, SZ, devAllocID);
 
     axom::utilities::Timer queryTimer2(true);
     SpacePt foundIsoPar;
@@ -421,7 +422,27 @@ public:
       }
 
       // locate the reconstructed points (using EXEC space)
-      spatialIndex.locatePoints(spacePts.view(), foundIDs.data(), foundIso.data());
+      if(axom::execution_space<ExecSpace>::onDevice())
+      {
+        int devAllocID = axom::execution_space<ExecSpace>::allocatorID();
+        // copy query points to device
+        axom::Array<SpacePt> spacePtsDevice(spacePts, devAllocID);
+
+        // run device query
+        spatialIndex.locatePoints(spacePtsDevice.view(),
+                                  foundIDsDevice.data(),
+                                  foundIsoDevice.data());
+
+        // copy results back to host
+        foundIso = axom::Array<SpacePt>(foundIsoDevice, hostAllocID);
+        foundIDs = axom::Array<IndexType>(foundIDsDevice, hostAllocID);
+      }
+      else
+      {
+        spatialIndex.locatePoints(spacePts.view(),
+                                  foundIDs.data(),
+                                  foundIso.data());
+      }
 
       // check results
       for(int idx = 0; idx < SZ; ++idx)

--- a/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
+++ b/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
@@ -391,14 +391,22 @@ public:
       m_mesh->GetNE(),
       constructTimer.elapsed()));
 
+#ifdef AXOM_USE_UMPIRE
+    using SpacePtArray = axom::Array<SpacePt, 1, axom::MemorySpace::Unified>;
+    using IndexArray = axom::Array<IndexType, 1, axom::MemorySpace::Unified>;
+#else
+    using SpacePtArray = axom::Array<SpacePt>;
+    using IndexArray = axom::Array<IndexType>;
+#endif
+
     // Test that a fixed set of isoparametric coords on each cell
     // maps to the correct place.
-    axom::Array<SpacePt> isoPts = generateIsoParTestPoints(::TEST_GRID_RES);
+    SpacePtArray isoPts = generateIsoParTestPoints(::TEST_GRID_RES);
 
     const auto SZ = isoPts.size();
-    axom::Array<SpacePt> spacePts(SZ, SZ);
-    axom::Array<SpacePt> foundIso(SZ, SZ);
-    axom::Array<IndexType> foundIDs(SZ, SZ);
+    SpacePtArray spacePts(SZ, SZ, m_allocatorID);
+    SpacePtArray foundIso(SZ, SZ, m_allocatorID);
+    IndexArray foundIDs(SZ, SZ, m_allocatorID);
 
     axom::utilities::Timer queryTimer2(true);
     SpacePt foundIsoPar;

--- a/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
+++ b/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
@@ -394,12 +394,9 @@ public:
       m_mesh->GetNE(),
       constructTimer.elapsed()));
 
-    using SpacePtArray = axom::Array<SpacePt>;
-    using IndexArray = axom::Array<IndexType>;
-
     // Test that a fixed set of isoparametric coords on each cell
     // maps to the correct place.
-    SpacePtArray isoPts = generateIsoParTestPoints(::TEST_GRID_RES);
+    axom::Array<SpacePt> isoPts = generateIsoParTestPoints(::TEST_GRID_RES);
 
     const auto SZ = isoPts.size();
     axom::Array<SpacePt> spacePts(SZ, SZ);

--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -245,7 +245,18 @@ public:
    */
   void insert(const SpatialBoundingBox& bbox, IndexType idx)
   {
-    insert(1, &bbox, idx);
+    if(axom::execution_space<ExecSpace>::onDevice())
+    {
+      int deviceAllocId = axom::execution_space<ExecSpace>::allocatorID();
+      // Copy host box to device array
+      ArrayView<const SpatialBoundingBox> bbox_host(&bbox, 1);
+      Array<SpatialBoundingBox> bbox_device(bbox_host, deviceAllocId);
+      insert(1, bbox_device.data(), idx);
+    }
+    else
+    {
+      insert(1, &bbox, idx);
+    }
   }
 
   /*!

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -1006,11 +1006,13 @@ void check_single_box2d()
   // Should return one and only one candidate that corresponds to the
   // single bounding box.
   PointType centroid {0.5, 0.5};
+  PointType* centroid_device = axom::allocate<PointType>(1);
+  axom::copy(centroid_device, &centroid, sizeof(PointType));
 
   IndexType* offsets = axom::allocate<IndexType>(NUM_BOXES);
   IndexType* counts = axom::allocate<IndexType>(NUM_BOXES);
   IndexType* candidates = nullptr;
-  bvh.findPoints(offsets, counts, candidates, NUM_BOXES, &centroid);
+  bvh.findPoints(offsets, counts, candidates, NUM_BOXES, centroid_device);
   EXPECT_TRUE(candidates != nullptr);
   EXPECT_EQ(counts[0], 1);
   EXPECT_EQ(0, candidates[offsets[0]]);
@@ -1019,9 +1021,11 @@ void check_single_box2d()
   // shift centroid outside of the BVH, should return no candidates.
   centroid[0] += 10.0;
   centroid[1] += 10.0;
-  bvh.findPoints(offsets, counts, candidates, NUM_BOXES, &centroid);
+  axom::copy(centroid_device, &centroid, sizeof(PointType));
+  bvh.findPoints(offsets, counts, candidates, NUM_BOXES, centroid_device);
   EXPECT_EQ(counts[0], 0);
 
+  axom::deallocate(centroid_device);
   axom::deallocate(boxes);
   axom::deallocate(offsets);
   axom::deallocate(counts);
@@ -1071,11 +1075,13 @@ void check_single_box3d()
   // Should return one and only one candidate that corresponds to the
   // single bounding box.
   PointType centroid {0.5, 0.5, 0.5};
+  PointType* centroid_device = axom::allocate<PointType>(1);
+  axom::copy(centroid_device, &centroid, sizeof(PointType));
 
   IndexType* offsets = axom::allocate<IndexType>(NUM_BOXES);
   IndexType* counts = axom::allocate<IndexType>(NUM_BOXES);
   IndexType* candidates = nullptr;
-  bvh.findPoints(offsets, counts, candidates, NUM_BOXES, &centroid);
+  bvh.findPoints(offsets, counts, candidates, NUM_BOXES, centroid_device);
   EXPECT_TRUE(candidates != nullptr);
   EXPECT_EQ(counts[0], 1);
   EXPECT_EQ(0, candidates[offsets[0]]);
@@ -1084,9 +1090,11 @@ void check_single_box3d()
   // shift centroid outside of the BVH, should return no candidates.
   centroid[0] += 10.0;
   centroid[1] += 10.0;
-  bvh.findPoints(offsets, counts, candidates, NUM_BOXES, &centroid);
+  axom::copy(centroid_device, &centroid, sizeof(PointType));
+  bvh.findPoints(offsets, counts, candidates, NUM_BOXES, centroid_device);
   EXPECT_EQ(counts[0], 0);
 
+  axom::deallocate(centroid_device);
   axom::deallocate(boxes);
   axom::deallocate(offsets);
   axom::deallocate(counts);

--- a/src/axom/spin/tests/spin_implicit_grid.cpp
+++ b/src/axom/spin/tests/spin_implicit_grid.cpp
@@ -459,10 +459,14 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_pt_vectorized)
   using BBox = typename TestFixture::BBox;
   using GridT = typename TestFixture::GridT;
   using SpacePt = typename TestFixture::SpacePt;
+  using ExecSpace = typename TestFixture::ExecSpace;
 
   SLIC_INFO("Test ImplicitGrid getCandidatesAsArray() with "
-            << axom::execution_space<typename TestFixture::ExecSpace>::name()
+            << axom::execution_space<ExecSpace>::name()
             << " execution space for points in " << DIM << "D");
+
+  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
+  int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   // Note: A 10 x 10 x 10 implicit grid in the unit cube.
   //       Grid cells have a spacing of .1 along each dimension
@@ -494,9 +498,27 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_pt_vectorized)
     };
 
     axom::Array<int> count, offset, candidates;
+    {
+      // Copy query points to the device
+      axom::ArrayView<const SpacePt> queryPtsHost(queryPts, 9);
+      axom::Array<SpacePt> queryPtsDevice(queryPtsHost, kernelAllocID);
 
-    // Run query against implicit grid
-    grid.getCandidatesAsArray(9, queryPts, offset, count, candidates);
+      axom::Array<int> countDevice, offsetDevice, candidatesDevice;
+
+      // Run query against implicit grid
+      grid.getCandidatesAsArray(9,
+                                queryPtsDevice.data(),
+                                offsetDevice,
+                                countDevice,
+                                candidatesDevice);
+
+      // Copy results back to the host
+      count = axom::Array<int>(countDevice, hostAllocID);
+      offset = axom::Array<int>(offsetDevice, hostAllocID);
+      candidates = axom::Array<int>(candidatesDevice, hostAllocID);
+    }
+
+    // Copy results back to the host
 
     // Test some points that are expected to match
     for(int i = 0; i < 5; ++i)
@@ -528,9 +550,24 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_pt_vectorized)
                           SpacePt {.85, .85, .85}};
 
     axom::Array<int> count, offset, candidates;
+    {
+      // Copy query points to the device
+      axom::ArrayView<const SpacePt> queryPtsHost(queryPts, 3);
+      axom::Array<SpacePt> queryPtsDevice(queryPtsHost, kernelAllocID);
 
-    // Run query against implicit grid
-    grid.getCandidatesAsArray(3, queryPts, offset, count, candidates);
+      axom::Array<int> countDevice, offsetDevice, candidatesDevice;
+      // Run query against implicit grid
+      grid.getCandidatesAsArray(3,
+                                queryPtsDevice.data(),
+                                offsetDevice,
+                                countDevice,
+                                candidatesDevice);
+
+      // Copy results back to the host
+      count = axom::Array<int>(countDevice, hostAllocID);
+      offset = axom::Array<int>(offsetDevice, hostAllocID);
+      candidates = axom::Array<int>(candidatesDevice, hostAllocID);
+    }
     std::unordered_set<int> expected[] = {{2}, {3}, {2, 3}};
 
     for(int i = 0; i < 3; i++)
@@ -729,10 +766,14 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_box_vectorized)
   using BBox = typename TestFixture::BBox;
   using GridT = typename TestFixture::GridT;
   using SpacePt = typename TestFixture::SpacePt;
+  using ExecSpace = typename TestFixture::ExecSpace;
 
   SLIC_INFO("Test ImplicitGrid getCandidatesAsArray() with "
-            << axom::execution_space<typename TestFixture::ExecSpace>::name()
+            << axom::execution_space<ExecSpace>::name()
             << " execution space for boxes in " << DIM << "D");
+
+  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
+  int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   // Note: A 10 x 10 x 10 implicit grid in the unit cube.
   //       Grid cells have a spacing of .1 along each dimension
@@ -825,9 +866,25 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_box_vectorized)
                                    DIM * 10};
 
   axom::Array<int> offset, count, candidates;
+  {
+    // Copy query points to the device
+    axom::ArrayView<const BBox> queryBoxesHost(queryBoxes, N_QUERIES);
+    axom::Array<BBox> queryBoxesDevice(queryBoxesHost, kernelAllocID);
 
-  // Run query against implicit grid
-  grid.getCandidatesAsArray(N_QUERIES, queryBoxes, offset, count, candidates);
+    axom::Array<int> countDevice, offsetDevice, candidatesDevice;
+
+    // Run query against implicit grid
+    grid.getCandidatesAsArray(N_QUERIES,
+                              queryBoxesDevice.data(),
+                              offsetDevice,
+                              countDevice,
+                              candidatesDevice);
+
+    // Copy results back to the host
+    count = axom::Array<int>(countDevice, hostAllocID);
+    offset = axom::Array<int>(offsetDevice, hostAllocID);
+    candidates = axom::Array<int>(candidatesDevice, hostAllocID);
+  }
 
   for(int i = 0; i < N_QUERIES; i++)
   {


### PR DESCRIPTION
# Summary

On some of our open PRs, a couple of our GPU tests were failing on the blueos CI runs. While these failures were somewhat spurious, they always happened on the same set of tests.

As it turns out, some of our tests were trying to access host memory from device kernels; the address translation service on blueos systems would normally bail us out on these, but that capability seems to have gotten flakier recently. This PR tries to fix that by explicitly copying the offending memory to/from the device.