### PR TITLE
Adds signed distance overload to return closest point and surface normal

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -84,7 +84,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   with a similar syntax, e.g. `for(auto& buf : datastore.buffers()){...}`.
 - Adds an overload of `ImplicitGrid::getCandidatesAsArray()` to accept query points/bounding boxes
   as an `axom::ArrayView`.
-- Adds a `primal::closest_point` overload to finding the closest point on a sphere to a given point
+- Adds a `primal::closest_point(point,sphere)` overload to find the closest point on a sphere to a given point
 - Adds an overload to quest's `SignedDistance` query to return the closest point on the surface 
   to the query point and the surface normal at that point. Also exposes this functionality 
   in quest's signed_distance C API.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -84,6 +84,10 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   with a similar syntax, e.g. `for(auto& buf : datastore.buffers()){...}`.
 - Adds an overload of `ImplicitGrid::getCandidatesAsArray()` to accept query points/bounding boxes
   as an `axom::ArrayView`.
+- Adds a `primal::closest_point` overload to finding the closest point on a sphere to a given point
+- Adds an overload to quest's `SignedDistance` query to return the closest point on the surface 
+  to the query point and the surface normal at that point. Also exposes this functionality 
+  in quest's signed_distance C API.
 
 ###  Changed
 - Axom now requires C++14 and will default to that if not specified via `BLT_CXX_STD`.

--- a/src/axom/mint/utils/vtk_utils.cpp
+++ b/src/axom/mint/utils/vtk_utils.cpp
@@ -335,6 +335,7 @@ void write_vector_data(const Field* field, std::ofstream& file)
 {
   SLIC_ASSERT(field != nullptr);
   const int num_components = field->getNumComponents();
+  AXOM_UNUSED_VAR(num_components);  // silence warning in release configs
   SLIC_ASSERT(num_components == 2 || num_components == 3);
 
   switch(field->getType())

--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -233,9 +233,9 @@ inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& pt,
  * \param [in] sphere user-supplied triangle
  * \return cp the closest point on sphere \a sphere to point P
  *
- * \note The closest point is uniquely defined everyone except at the sphere's origin.
- * We handle that case by returning the point on the sphere along the direction
- * determined by \a primal::Vector::unitVector() for the zero vector
+ * \note The closest point is uniquely defined everywhere except at the sphere's center.
+ * We handle that case by returning the point on the sphere along an arbitrary direction
+ * (specifically, the direction determined by \a primal::Vector::unitVector() )
  */
 template <typename T, int NDIMS>
 AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,

--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -16,6 +16,7 @@
 
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Triangle.hpp"
+#include "axom/primal/geometry/Sphere.hpp"
 #include "axom/primal/geometry/OrientedBoundingBox.hpp"
 #include "axom/primal/operators/detail/intersect_impl.hpp"
 namespace axom
@@ -223,6 +224,27 @@ inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& pt,
   }
 
   return Point<T, NDIMS>(res.array());
+}
+
+/*!
+ * \brief Computes the closest point from a point, P, to a sphere.
+ *
+ * \param [in] P the query point
+ * \param [in] sphere user-supplied triangle
+ * \return cp the closest point on sphere \a sphere to point P
+ *
+ * \note The closest point is uniquely defined everyone except at the sphere's origin.
+ * We handle that case by returning the point on the sphere along the direction
+ * determined by \a primal::Vector::unitVector() for the zero vector
+ */
+template <typename T, int NDIMS>
+AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
+                                                      const Sphere<T, NDIMS>& sphere)
+{
+  using VectorType = Vector<T, NDIMS>;
+
+  const auto v = VectorType(sphere.getCenter(), P).unitVector();
+  return sphere.getCenter() + sphere.getRadius() * v;
 }
 
 }  // namespace primal

--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -230,8 +230,8 @@ inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& pt,
  * \brief Computes the closest point from a point, P, to a sphere.
  *
  * \param [in] P the query point
- * \param [in] sphere user-supplied triangle
- * \return cp the closest point on sphere \a sphere to point P
+ * \param [in] sphere user-supplied sphere
+ * \return cp the closest point on \a sphere to point \a P
  *
  * \note The closest point is uniquely defined everywhere except at the sphere's center.
  * We handle that case by returning the point on the sphere along an arbitrary direction

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -12,6 +12,9 @@
 #ifndef AXOM_PRIMAL_CLIP_IMPL_HPP_
 #define AXOM_PRIMAL_CLIP_IMPL_HPP_
 
+#include "axom/config.hpp"
+#include "axom/core/Macros.hpp"
+
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Triangle.hpp"
 #include "axom/primal/geometry/BoundingBox.hpp"
@@ -223,7 +226,8 @@ AXOM_HOST_DEVICE void poly_clip_vertices(Polyhedron<T, NDIMS>& poly,
         // Insert new vertex to polyhedron, where edge intersects plane.
         if(neighborOrientation == ON_POSITIVE_SIDE)
         {
-          int expectedVertexIndex = poly.numVertices();
+          const int expectedVertexIndex = poly.numVertices();
+          AXOM_UNUSED_VAR(expectedVertexIndex);  // silence warning in release configs
 
           T lerp_val;
           SegmentType seg(poly[i], poly[neighborIndex]);

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -7,13 +7,7 @@
 #include <algorithm>
 
 #include "gtest/gtest.h"
-
-#include "axom/primal/geometry/NumericArray.hpp"
-#include "axom/primal/geometry/Point.hpp"
-#include "axom/primal/geometry/Vector.hpp"
-#include "axom/primal/geometry/OrientedBoundingBox.hpp"
-#include "axom/primal/operators/squared_distance.hpp"
-#include "axom/primal/operators/closest_point.hpp"
+#include "axom/primal.hpp"
 
 namespace primal = axom::primal;
 

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -14,18 +14,18 @@
 #include "axom/primal/geometry/OrientedBoundingBox.hpp"
 #include "axom/primal/operators/closest_point.hpp"
 
-using namespace axom;
+namespace primal = axom::primal;
 
 //------------------------------------------------------------------------------
 TEST(primal_closest_point, obb_test_closest_point_interior)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
-  const double ONE_OVER_SQRT_TWO = 0.7071;
+  constexpr double ONE_OVER_SQRT_TWO = 0.7071;
   QPoint pt1;      // origin
   QVector u[DIM];  // make axes
   u[0][0] = ONE_OVER_SQRT_TWO;
@@ -45,13 +45,13 @@ TEST(primal_closest_point, obb_test_closest_point_interior)
 //------------------------------------------------------------------------------
 TEST(primal_closest_point, obb_test_closest_point_vertex)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
-  const double ONE_OVER_SQRT_TWO = 0.7071;
+  constexpr double ONE_OVER_SQRT_TWO = 0.7071;
   QPoint pt1;      // origin
   QVector u[DIM];  // make axes
   u[0][0] = ONE_OVER_SQRT_TWO;
@@ -74,14 +74,14 @@ TEST(primal_closest_point, obb_test_closest_point_vertex)
 //------------------------------------------------------------------------------
 TEST(primal_closest_point, obb_test_closest_point_face)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
-  const double ONE_OVER_SQRT_TWO = 0.7071;
-  const double EPS = 0.01;
+  constexpr double ONE_OVER_SQRT_TWO = 0.7071;
+  constexpr double EPS = 0.01;
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
   u[0][0] = ONE_OVER_SQRT_TWO;
@@ -106,14 +106,14 @@ TEST(primal_closest_point, obb_test_closest_point_face)
 //------------------------------------------------------------------------------
 TEST(primal_closest_point, obb_test_closest_point_edge)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
-  const double ONE_OVER_SQRT_TWO = 0.7071;
-  const double EPS = 0.01;
+  constexpr double ONE_OVER_SQRT_TWO = 0.7071;
+  constexpr double EPS = 0.01;
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
   u[0][0] = ONE_OVER_SQRT_TWO;

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -12,6 +12,7 @@
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
 #include "axom/primal/geometry/OrientedBoundingBox.hpp"
+#include "axom/primal/operators/squared_distance.hpp"
 #include "axom/primal/operators/closest_point.hpp"
 
 namespace primal = axom::primal;
@@ -133,4 +134,139 @@ TEST(primal_closest_point, obb_test_closest_point_edge)
 
   // closest point is on an edge
   EXPECT_TRUE((found - expected).squared_norm() < EPS);
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_closest_point, sphere_point_2D)
+{
+  constexpr int DIM = 2;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QSphere = primal::Sphere<CoordType, DIM>;
+
+  constexpr double EPS = 1e-12;
+
+  // define several test points
+  axom::Array<QPoint> test_points = {
+    QPoint {1, 0},
+    QPoint {0, 1},
+    QPoint {-1, 0},
+    QPoint {0, -1},
+    QPoint {1, 1},
+    QPoint {2, 2},
+    QPoint {5.234, -6.432},
+  };
+
+  // check test points against unit sphere
+  for(const auto& pt : test_points)
+  {
+    auto unit_sphere = QSphere(1.);
+    auto cp = primal::closest_point(pt, unit_sphere);
+    auto exp_cp = unit_sphere.getCenter() + QVector(pt).unitVector();
+
+    EXPECT_NEAR(exp_cp[0], cp[0], EPS);
+    EXPECT_NEAR(exp_cp[1], cp[1], EPS);
+    EXPECT_NEAR(0., primal::squared_distance(exp_cp, cp), EPS);
+  }
+
+  // define several spheres of different centers and radii
+  axom::Array<double> radii = {1., .12345, 543.21, .4, 0.001, 87, 0.};
+  axom::Array<QPoint> centers = {QPoint {0, 0},
+                                 QPoint {1, 0, 0},
+                                 QPoint {7.5, 8.25},
+                                 QPoint {-1.3, 2.3},
+                                 QPoint {-20, -40},
+                                 QPoint {4.3, 0},
+                                 QPoint {0, -3.4}};
+
+  // add sphere centers to test_points
+  for(const auto& pt : centers)
+  {
+    test_points.push_back(pt);
+  }
+
+  // check that closest_point lies on the sphere
+  for(const auto& pt : test_points)
+  {
+    for(const auto r : radii)
+    {
+      for(const auto& ctr : centers)
+      {
+        auto sphere = QSphere(ctr, r);
+        auto cp = primal::closest_point(pt, sphere);
+        EXPECT_NEAR(sphere.getRadius(),
+                    sqrt(primal::squared_distance(sphere.getCenter(), cp)),
+                    EPS);
+      }
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_closest_point, sphere_point_3D)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QSphere = primal::Sphere<CoordType, DIM>;
+
+  constexpr double EPS = 1e-12;
+
+  // define several test points
+  axom::Array<QPoint> test_points = {
+    QPoint {1, 0, 0},
+    QPoint {0, 1, 0},
+    QPoint {0, 0, 1},
+    QPoint {-1, 0, 1},
+    QPoint {0, -1, -1},
+    QPoint {1, 1, 1},
+    QPoint {2, 4, 8},
+    QPoint {5.234, -6.432, 7.345},
+  };
+
+  // check test points against unit sphere
+  for(const auto& pt : test_points)
+  {
+    auto unit_sphere = QSphere(1.);
+    auto cp = primal::closest_point(pt, unit_sphere);
+    auto exp_cp = unit_sphere.getCenter() + QVector(pt).unitVector();
+
+    EXPECT_NEAR(exp_cp[0], cp[0], EPS);
+    EXPECT_NEAR(exp_cp[1], cp[1], EPS);
+    EXPECT_NEAR(exp_cp[2], cp[2], EPS);
+    EXPECT_NEAR(0., primal::squared_distance(exp_cp, cp), EPS);
+  }
+
+  // define several spheres of different centers and radii
+  axom::Array<double> radii = {1., .12345, 543.21, .4, 0.001, 87, 0.};
+  axom::Array<QPoint> centers = {QPoint {0, 0, 0},
+                                 QPoint {1, 0, 0},
+                                 QPoint {7.5, 8.25, 9.7125},
+                                 QPoint {-1.3, 2.3, -3.45},
+                                 QPoint {-20, -40, -80},
+                                 QPoint {0, -3.4, -1}};
+
+  // add sphere centers to test_points
+  for(const auto& pt : centers)
+  {
+    test_points.push_back(pt);
+  }
+
+  // check that closest_point lies on the sphere
+  for(const auto& pt : test_points)
+  {
+    for(const auto r : radii)
+    {
+      for(const auto& ctr : centers)
+      {
+        auto sphere = QSphere(ctr, r);
+        auto cp = primal::closest_point(pt, sphere);
+        EXPECT_NEAR(sphere.getRadius(),
+                    sqrt(primal::squared_distance(sphere.getCenter(), cp)),
+                    EPS);
+      }
+    }
+  }
 }

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -173,7 +173,7 @@ TEST(primal_closest_point, sphere_point_2D)
   // define several spheres of different centers and radii
   axom::Array<double> radii = {1., .12345, 543.21, .4, 0.001, 87, 0.};
   axom::Array<QPoint> centers = {QPoint {0, 0},
-                                 QPoint {1, 0, 0},
+                                 QPoint {1, 0},
                                  QPoint {7.5, 8.25},
                                  QPoint {-1.3, 2.3},
                                  QPoint {-20, -40},

--- a/src/axom/quest/Discretize.cpp
+++ b/src/axom/quest/Discretize.cpp
@@ -222,9 +222,8 @@ int mesh_from_discretized_polyline(const OctType* octs,
   const int tetcount = 8 * octcount;
   const int vertcount = 4 * tetcount;
   int octPerSeg = octcount / segcount;
-  int remainderOcts = octcount % segcount;
   SLIC_ASSERT_MSG(
-    remainderOcts == 0,
+    (octcount % segcount) == 0,  // remainderOcts
     "Total octahedron count is not evenly divisible by segment count");
 
   // Step 0: create the UnstructuredMesh

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -678,10 +678,9 @@ public:
     using axom::primal::squared_distance;
     using int32 = axom::int32;
 
-    // Extract the dimension and number of points from the coordinate values group
-    const int dim = xfer_node["dim"].value();
+    // Check dimension and extract the number of points
+    SLIC_ASSERT(xfer_node["dim"].as_int32() == NDIMS);
     const int npts = xfer_node["npts"].value();
-    SLIC_ASSERT(dim == NDIMS);
 
     /// Extract fields from the input node as ArrayViews
     auto queryPts = ArrayView_from_Node<PointType>(xfer_node["coords"], npts);

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -798,7 +798,7 @@ public:
     }
 
     /// Implementation here -- update material volume fractions based on replacement rules
-    // Note: we're not yet using the shape volume fractions
+    // Note: we're not yet updating the shape volume fractions
     AXOM_UNUSED_VAR(shapeVolFrac);
   }
 

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -320,12 +320,13 @@ public:
     }
 
     // Generate the Octahedra
-    bool disc_status = axom::quest::discretize<ExecSpace>(polyline,
-                                                          polyline_size,
-                                                          m_level,
-                                                          m_octs,
-                                                          m_octcount);
+    const bool disc_status = axom::quest::discretize<ExecSpace>(polyline,
+                                                                polyline_size,
+                                                                m_level,
+                                                                m_octs,
+                                                                m_octcount);
 
+    AXOM_UNUSED_VAR(disc_status);  // silence warnings in release configs
     SLIC_ASSERT_MSG(
       disc_status,
       "Discretization of contour has failed. Check that contour is valid");
@@ -797,6 +798,8 @@ public:
     }
 
     /// Implementation here -- update material volume fractions based on replacement rules
+    // Note: we're not yet using the shape volume fractions
+    AXOM_UNUSED_VAR(shapeVolFrac);
   }
 
   void finalizeShapeQuery() override

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -421,7 +421,8 @@ SignedDistance<NDIMS, ExecSpace>::SignedDistance(const mint::Mesh* surfaceMesh,
   // Sanity checks
   SLIC_ASSERT(surfaceMesh != nullptr);
 
-  bool bvh_constructed = setMesh(surfaceMesh, allocatorID);
+  const bool bvh_constructed = setMesh(surfaceMesh, allocatorID);
+  AXOM_UNUSED_VAR(bvh_constructed);  // silence warning in release mode
   SLIC_ASSERT(bvh_constructed);
 }
 
@@ -629,6 +630,7 @@ SignedDistance<NDIMS, ExecSpace>::getCellBoundingBox(axom::IndexType icell,
   // Get the cell type, for now we support linear triangle,quad in 3-D and
   // line segments in 2-D.
   const mint::CellType cellType = mesh.getCellType(icell);
+  AXOM_UNUSED_VAR(cellType);  // silence warning in release configs
   SLIC_ASSERT(cellType == mint::TRIANGLE || cellType == mint::QUAD ||
               cellType == mint::SEGMENT);
 

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -18,7 +18,6 @@
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Triangle.hpp"
 #include "axom/primal/geometry/Vector.hpp"
-
 #include "axom/primal/utils/ZipPoint.hpp"
 
 // mint includes
@@ -30,7 +29,7 @@
 #include "axom/mint/mesh/Mesh.hpp"
 
 // C/C++ includes
-#include <cmath>  // for std::sqrt()
+#include <cmath>
 
 namespace axom
 {
@@ -240,7 +239,7 @@ public:
    *  everywhere. Specifically, the sign is ambiguous for all points for which
    *  a normal projection onto the surface does not exist.
    *
-   * \return minDist minimum signed distance of the query point to the surface.
+   * \return minimum signed distance of the query point to the surface.
    */
   double computeDistance(double x, double y, double z = 0.0)
   {
@@ -263,7 +262,7 @@ public:
    *  everywhere. Specifically, the sign is ambiguous for all points for which
    *  a normal projection onto the surface does not exist.
    *
-   * \return minDist the signed minimum distance to the surface mesh.
+   * \return the signed minimum distance to the surface mesh.
    */
   double computeDistance(const PointType& queryPnt) const;
 
@@ -288,7 +287,7 @@ public:
    *  everywhere. Specifically, the sign is ambiguous for all points for which
    *  a normal projection onto the surface does not exist.
    *
-   * \return minDist the signed minimum distance to the surface mesh.
+   * \return the signed minimum distance to the surface mesh.
    */
   double computeDistance(const PointType& queryPnt,
                          PointType& closestPnt,
@@ -321,7 +320,7 @@ public:
    *  everywhere. Specifically, the sign is ambiguous for all points for which
    *  a normal projection onto the surface does not exist.
    *
-   * \return minDist the signed minimum distance to the surface mesh.
+   * \return the signed minimum distance to the surface mesh.
    *
    * \pre outSgnDist != nullptr
    */
@@ -384,7 +383,7 @@ private:
    * \param [in] qpt query point to check against surface element
    * \param [in] currMin the minimum-distance surface element data
    *
-   * \return sgn 1.0 if outside, -1.0 if inside
+   * \return 1.0 if outside, -1.0 if inside
    */
   AXOM_HOST_DEVICE static double computeSign(const PointType& qpt,
                                              const MinCandidate& currMin);

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -268,7 +268,37 @@ public:
   double computeDistance(const PointType& queryPnt) const;
 
   /*!
+   * \brief Computes the distance of the given point to the surface mesh
+   * This overload also returns the computed closest point on the surface to the query point
+   * and the surface normal at that point
+   *
+   * \param [in] queryPnt user-supplied point.
+   * \param [out] closestPnt the closest point on the surface to \a queryPnt
+   * \param [out] surfaceNormal the surface normal of \a closestPt
+   *
+   * \note When the input is not a closed surface mesh, the assumption is that
+   *  the surface mesh divides the computational mesh domain into two regions.
+   *  Hence, the surface mesh has to span the entire domain of interest, e.g.,
+   *  the computational mesh at which the signed distance field is evaluated,
+   *  along some plane.
+   *
+   * \warning The sign of the distance from a given query point is determined by
+   *  a pseudo-normal which is computed at the closest point on the surface
+   *  mesh. For a non-watertight mesh, the sign of the distance is not defined
+   *  everywhere. Specifically, the sign is ambiguous for all points for which
+   *  a normal projection onto the surface does not exist.
+   *
+   * \return minDist the signed minimum distance to the surface mesh.
+   */
+  double computeDistance(const PointType& queryPnt,
+                         PointType& closestPnt,
+                         VectorType& surfaceNormal) const;
+
+  /*!
    * \brief Computes the distances of a set of points to the surface mesh.
+   * Optionally also returns the computed closest points on the surface to each 
+   * query point and the surface normals at those points
+   *
    * \param [in] npts number of points to query
    * \param [in] queryPnt user-supplied point indexable type. This can be a
    *  pointer-to-array, or a ZipIndexable<PointType>.
@@ -276,6 +306,8 @@ public:
    *  for query points
    * \param [out] outClosestPts array to fill with closest points on the mesh.
    *  Optional.
+   * \param [out] outNormals array to fill with surface normals associated with 
+   * closest points on the mesh. Optional.
    *
    * \note When the input is not a closed surface mesh, the assumption is that
    *  the surface mesh divides the computational mesh domain into two regions.
@@ -297,7 +329,8 @@ public:
   void computeDistances(int npts,
                         PointIndexable queryPts,
                         double* outSgnDist,
-                        PointType* outClosestPts = nullptr) const;
+                        PointType* outClosestPts = nullptr,
+                        VectorType* outNormals = nullptr) const;
 
   /*!
    * \brief Returns a const reference to the underlying bucket tree.
@@ -336,6 +369,14 @@ private:
                                               const detail::UcdMeshData& mesh,
                                               ZipPoint meshPts,
                                               bool computeSign);
+
+  /*!
+   * \brief Returns the surface (pseudo)-normal at the closest point 
+   * to the query point associated with \a currMin
+   *
+   * \param [in] currMin the minimum-distance surface element data
+   */
+  AXOM_HOST_DEVICE static VectorType getSurfaceNormal(const MinCandidate& currMin);
 
   /*!
    * \brief Computes the sign of the given query point given the closest point data
@@ -472,9 +513,20 @@ template <int NDIMS, typename ExecSpace>
 inline double SignedDistance<NDIMS, ExecSpace>::computeDistance(
   const PointType& pt) const
 {
-  PointType closest_pt;
   double dist;
-  this->computeDistances(1, &pt, &dist, &closest_pt);
+  this->computeDistances(1, &pt, &dist, nullptr, nullptr);
+  return (dist);
+}
+
+//------------------------------------------------------------------------------
+template <int NDIMS, typename ExecSpace>
+inline double SignedDistance<NDIMS, ExecSpace>::computeDistance(
+  const PointType& queryPnt,
+  PointType& closestPnt,
+  VectorType& surfaceNormal) const
+{
+  double dist;
+  this->computeDistances(1, &queryPnt, &dist, &closestPnt, &surfaceNormal);
   return (dist);
 }
 
@@ -485,7 +537,8 @@ inline void SignedDistance<NDIMS, ExecSpace>::computeDistances(
   int npts,
   PointIndexable queryPts,
   double* outSgnDist,
-  PointType* outClosestPts) const
+  PointType* outClosestPts,
+  VectorType* outNormals) const
 {
   SLIC_ASSERT(npts > 0);
   SLIC_ASSERT(m_surfaceMesh != nullptr);
@@ -557,6 +610,11 @@ inline void SignedDistance<NDIMS, ExecSpace>::computeDistances(
         if(outClosestPts)
         {
           outClosestPts[idx] = curr_min.minPt;
+        }
+
+        if(outNormals)
+        {
+          outNormals[idx] = getSurfaceNormal(curr_min).unitVector();
         }
       }););
 }
@@ -699,31 +757,30 @@ AXOM_HOST_DEVICE inline void SignedDistance<NDIMS, ExecSpace>::checkCandidate(
 
 //------------------------------------------------------------------------------
 template <int NDIMS, typename ExecSpace>
+AXOM_HOST_DEVICE inline typename SignedDistance<NDIMS, ExecSpace>::VectorType
+SignedDistance<NDIMS, ExecSpace>::getSurfaceNormal(const MinCandidate& currMin)
+{
+  // Closest point is either internal to a face of the surface or, for points on
+  // a boundary edge or vertex, we already computed the (pseudo)-normal during the traversal
+  return (currMin.minType == detail::ClosestPointLocType::face)
+    ? currMin.minTri.normal()
+    : currMin.sumNormals;
+}
+
+//------------------------------------------------------------------------------
+template <int NDIMS, typename ExecSpace>
 AXOM_HOST_DEVICE inline double SignedDistance<NDIMS, ExecSpace>::computeSign(
   const PointType& qpt,
   const MinCandidate& currMin)
 {
-  double sgn = 1.0;
-  // STEP 1: Select the pseudo-normal N at the closest point to calculate the sign.
-  // There are effectively 3 cases based on the location of the closest point.
-  VectorType N;
-  switch(currMin.minType)
-  {
-  case detail::ClosestPointLocType::face:
-    // CASE 1: closest point is on the face of the surface element
-    N = currMin.minTri.normal();
-    break;
-  default:  // Use precomputed normal for edges and vertices
-    N = currMin.sumNormals;
-    break;
-  }
+  // Get the pseudo-normal at the closest point
+  const VectorType n = getSurfaceNormal(currMin);
 
-  // STEP 2: Given the pseudo-normal, N, and the vector r from the closest point
-  // to the query point, compute the sign by checking the sign of their dot product.
-  VectorType r(currMin.minPt, qpt);
-  double dotprod = r.dot(N);
-  sgn = (dotprod >= 0.0) ? 1.0 : -1.0;
-  return sgn;
+  // and the vector from the closest point to the query point
+  const VectorType r(currMin.minPt, qpt);
+
+  // determine the sign from their dot product
+  return (r.dot(n) >= 0.0) ? 1.0 : -1.0;
 }
 
 }  // end namespace quest

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -275,7 +275,7 @@ public:
    * \param [out] closestPnt the closest point on the surface to \a queryPnt
    * \param [out] surfaceNormal the surface normal of \a closestPt
    *
-   * \note When the input is not a closed surface mesh, the assumption is that
+   * \note When the underlying surface mesh is not watertight, the assumption is that
    *  the surface mesh divides the computational mesh domain into two regions.
    *  Hence, the surface mesh has to span the entire domain of interest, e.g.,
    *  the computational mesh at which the signed distance field is evaluated,
@@ -295,7 +295,7 @@ public:
 
   /*!
    * \brief Computes the distances of a set of points to the surface mesh.
-   * Optionally also returns the computed closest points on the surface to each 
+   * Optionally also returns the computed closest points on the surface to each
    * query point and the surface normals at those points
    *
    * \param [in] npts number of points to query
@@ -305,7 +305,7 @@ public:
    *  for query points
    * \param [out] outClosestPts array to fill with closest points on the mesh.
    *  Optional.
-   * \param [out] outNormals array to fill with surface normals associated with 
+   * \param [out] outNormals array to fill with surface normals associated with
    * closest points on the mesh. Optional.
    *
    * \note When the input is not a closed surface mesh, the assumption is that
@@ -370,7 +370,7 @@ private:
                                               bool computeSign);
 
   /*!
-   * \brief Returns the surface (pseudo)-normal at the closest point 
+   * \brief Returns the surface (pseudo)-normal at the closest point
    * to the query point associated with \a currMin
    *
    * \param [in] currMin the minimum-distance surface element data

--- a/src/axom/quest/examples/quest_signed_distance_interface.F
+++ b/src/axom/quest/examples/quest_signed_distance_interface.F
@@ -52,7 +52,7 @@ program quest_signed_distance_interface
   logical :: is_verbose = .true.
   logical :: is_watertight = .true.
   logical :: compute_signs = .true.
-  real(C_DOUBLE) :: mesh_bb_min(3), mesh_bb_max(3), pt(3), phi
+  real(C_DOUBLE) :: mesh_bb_min(3), mesh_bb_max(3), pt(3), cp(3), normal(3), phi, phi_cp, eps, radius
 
 !...initialize mpi  
 #ifdef AXOM_USE_MPI
@@ -91,8 +91,23 @@ program quest_signed_distance_interface
        pt(j) = random_double( mesh_bb_min(j), mesh_bb_max(j) )
      end do ! end for all dimensions
 
+     ! evaluate signed distance (simple)
      phi = quest_signed_distance_evaluate( pt(1), pt(2), pt(3) )
-     print *, "phi=", phi
+
+     ! evaluate signed distance with closest point and normal at that point
+     phi_cp = quest_signed_distance_evaluate( pt(1), pt(2), pt(3), &
+                                              cp(1), cp(2), cp(3), &
+                                              normal(1), normal(2), normal(3) )
+     
+     radius = sqrt(cp(1)**2 + cp(2)**2 + cp(3)**2)
+
+     ! check that the two calls gave approximately the same answer
+     if (abs(phi-phi_cp) >= epsilon(phi)) then
+        print*, 'Got different values when calling overloads of quest_signed_distance_evaluate! ', phi, phi_cp
+     end if
+
+     print '("phi: ",F8.3,"; closest_point: ",F8.3, F8.3, F8.3, "; normal: ",F8.3,F8.3,F8.3,"; radius @ cp: ", F8.3)',  &
+            phi, cp(1), cp(2), cp(3), normal(1), normal(2), normal(3), radius
 
   end do ! end for all points
 

--- a/src/axom/quest/interface/c_fortran/wrapQUEST.cpp
+++ b/src/axom/quest/interface/c_fortran/wrapQUEST.cpp
@@ -278,12 +278,36 @@ void QUEST_signed_distance_set_execution_space(int execSpace)
   // splicer end function.signed_distance_set_execution_space
 }
 
-double QUEST_signed_distance_evaluate(double x, double y, double z)
+double QUEST_signed_distance_evaluate_0(double x, double y, double z)
 {
-  // splicer begin function.signed_distance_evaluate
+  // splicer begin function.signed_distance_evaluate_0
   double SHC_rv = axom::quest::signed_distance_evaluate(x, y, z);
   return SHC_rv;
-  // splicer end function.signed_distance_evaluate
+  // splicer end function.signed_distance_evaluate_0
+}
+
+double QUEST_signed_distance_evaluate_1(double x,
+                                        double y,
+                                        double z,
+                                        double *cp_x,
+                                        double *cp_y,
+                                        double *cp_z,
+                                        double *n_x,
+                                        double *n_y,
+                                        double *n_z)
+{
+  // splicer begin function.signed_distance_evaluate_1
+  double SHC_rv = axom::quest::signed_distance_evaluate(x,
+                                                        y,
+                                                        z,
+                                                        *cp_x,
+                                                        *cp_y,
+                                                        *cp_z,
+                                                        *n_x,
+                                                        *n_y,
+                                                        *n_z);
+  return SHC_rv;
+  // splicer end function.signed_distance_evaluate_1
 }
 
 void QUEST_signed_distance_finalize(void)

--- a/src/axom/quest/interface/c_fortran/wrapQUEST.h
+++ b/src/axom/quest/interface/c_fortran/wrapQUEST.h
@@ -118,7 +118,17 @@ void QUEST_signed_distance_use_shared_memory(bool status);
 
 void QUEST_signed_distance_set_execution_space(int execSpace);
 
-double QUEST_signed_distance_evaluate(double x, double y, double z);
+double QUEST_signed_distance_evaluate_0(double x, double y, double z);
+
+double QUEST_signed_distance_evaluate_1(double x,
+                                        double y,
+                                        double z,
+                                        double* cp_x,
+                                        double* cp_y,
+                                        double* cp_z,
+                                        double* n_x,
+                                        double* n_y,
+                                        double* n_z);
 
 void QUEST_signed_distance_finalize(void);
 

--- a/src/axom/quest/interface/c_fortran/wrapfquest.F
+++ b/src/axom/quest/interface/c_fortran/wrapfquest.F
@@ -298,16 +298,34 @@ module axom_quest
             integer(C_INT), value, intent(IN) :: execSpace
         end subroutine quest_signed_distance_set_execution_space
 
-        function quest_signed_distance_evaluate(x, y, z) &
+        function c_signed_distance_evaluate_0(x, y, z) &
                 result(SHT_rv) &
-                bind(C, name="QUEST_signed_distance_evaluate")
+                bind(C, name="QUEST_signed_distance_evaluate_0")
             use iso_c_binding, only : C_DOUBLE
             implicit none
             real(C_DOUBLE), value, intent(IN) :: x
             real(C_DOUBLE), value, intent(IN) :: y
             real(C_DOUBLE), value, intent(IN) :: z
             real(C_DOUBLE) :: SHT_rv
-        end function quest_signed_distance_evaluate
+        end function c_signed_distance_evaluate_0
+
+        function c_signed_distance_evaluate_1(x, y, z, cp_x, cp_y, cp_z, &
+                n_x, n_y, n_z) &
+                result(SHT_rv) &
+                bind(C, name="QUEST_signed_distance_evaluate_1")
+            use iso_c_binding, only : C_DOUBLE
+            implicit none
+            real(C_DOUBLE), value, intent(IN) :: x
+            real(C_DOUBLE), value, intent(IN) :: y
+            real(C_DOUBLE), value, intent(IN) :: z
+            real(C_DOUBLE), intent(INOUT) :: cp_x
+            real(C_DOUBLE), intent(INOUT) :: cp_y
+            real(C_DOUBLE), intent(INOUT) :: cp_z
+            real(C_DOUBLE), intent(INOUT) :: n_x
+            real(C_DOUBLE), intent(INOUT) :: n_y
+            real(C_DOUBLE), intent(INOUT) :: n_z
+            real(C_DOUBLE) :: SHT_rv
+        end function c_signed_distance_evaluate_1
 
         subroutine quest_signed_distance_finalize() &
                 bind(C, name="QUEST_signed_distance_finalize")
@@ -331,6 +349,11 @@ module axom_quest
         module procedure quest_inout_init_serial
 #endif
     end interface quest_inout_init
+
+    interface quest_signed_distance_evaluate
+        module procedure quest_signed_distance_evaluate_0
+        module procedure quest_signed_distance_evaluate_1
+    end interface quest_signed_distance_evaluate
 
     interface quest_signed_distance_init
 #ifdef AXOM_USE_MPI
@@ -489,6 +512,38 @@ contains
         call c_signed_distance_use_shared_memory(SH_status)
         ! splicer end function.signed_distance_use_shared_memory
     end subroutine quest_signed_distance_use_shared_memory
+
+    function quest_signed_distance_evaluate_0(x, y, z) &
+            result(SHT_rv)
+        use iso_c_binding, only : C_DOUBLE
+        real(C_DOUBLE), value, intent(IN) :: x
+        real(C_DOUBLE), value, intent(IN) :: y
+        real(C_DOUBLE), value, intent(IN) :: z
+        real(C_DOUBLE) :: SHT_rv
+        ! splicer begin function.signed_distance_evaluate_0
+        SHT_rv = c_signed_distance_evaluate_0(x, y, z)
+        ! splicer end function.signed_distance_evaluate_0
+    end function quest_signed_distance_evaluate_0
+
+    function quest_signed_distance_evaluate_1(x, y, z, cp_x, cp_y, cp_z, &
+            n_x, n_y, n_z) &
+            result(SHT_rv)
+        use iso_c_binding, only : C_DOUBLE
+        real(C_DOUBLE), value, intent(IN) :: x
+        real(C_DOUBLE), value, intent(IN) :: y
+        real(C_DOUBLE), value, intent(IN) :: z
+        real(C_DOUBLE), intent(INOUT) :: cp_x
+        real(C_DOUBLE), intent(INOUT) :: cp_y
+        real(C_DOUBLE), intent(INOUT) :: cp_z
+        real(C_DOUBLE), intent(INOUT) :: n_x
+        real(C_DOUBLE), intent(INOUT) :: n_y
+        real(C_DOUBLE), intent(INOUT) :: n_z
+        real(C_DOUBLE) :: SHT_rv
+        ! splicer begin function.signed_distance_evaluate_1
+        SHT_rv = c_signed_distance_evaluate_1(x, y, z, cp_x, cp_y, cp_z, &
+            n_x, n_y, n_z)
+        ! splicer end function.signed_distance_evaluate_1
+    end function quest_signed_distance_evaluate_1
 
     ! splicer begin additional_functions
     ! splicer end additional_functions

--- a/src/axom/quest/interface/python/pyQUESTmodule.cpp
+++ b/src/axom/quest/interface/python/pyQUESTmodule.cpp
@@ -506,13 +506,11 @@ static PyObject *PY_signed_distance_set_execution_space(PyObject *SHROUD_UNUSED(
   // splicer end function.signed_distance_set_execution_space
 }
 
-static char PY_signed_distance_evaluate__doc__[] = "documentation";
-
-static PyObject *PY_signed_distance_evaluate(PyObject *SHROUD_UNUSED(self),
-                                             PyObject *args,
-                                             PyObject *kwds)
+static PyObject *PY_signed_distance_evaluate_0(PyObject *SHROUD_UNUSED(self),
+                                               PyObject *args,
+                                               PyObject *kwds)
 {
-  // splicer begin function.signed_distance_evaluate
+  // splicer begin function.signed_distance_evaluate_0
   double x;
   double y;
   double z;
@@ -530,7 +528,46 @@ static PyObject *PY_signed_distance_evaluate(PyObject *SHROUD_UNUSED(self),
   double SHCXX_rv = axom::quest::signed_distance_evaluate(x, y, z);
   SHTPy_rv = PyFloat_FromDouble(SHCXX_rv);
   return (PyObject *)SHTPy_rv;
-  // splicer end function.signed_distance_evaluate
+  // splicer end function.signed_distance_evaluate_0
+}
+
+static PyObject *PY_signed_distance_evaluate_1(PyObject *SHROUD_UNUSED(self),
+                                               PyObject *args,
+                                               PyObject *kwds)
+{
+  // splicer begin function.signed_distance_evaluate_1
+  double x;
+  double y;
+  double z;
+  double cp_x;
+  double cp_y;
+  double cp_z;
+  double n_x;
+  double n_y;
+  double n_z;
+  const char *SHT_kwlist[] =
+    {"x", "y", "z", "cp_x", "cp_y", "cp_z", "n_x", "n_y", "n_z", nullptr};
+  PyObject *SHTPy_rv = nullptr;  // return value object
+
+  if(!PyArg_ParseTupleAndKeywords(args,
+                                  kwds,
+                                  "ddddddddd:signed_distance_evaluate",
+                                  const_cast<char **>(SHT_kwlist),
+                                  &x,
+                                  &y,
+                                  &z,
+                                  &cp_x,
+                                  &cp_y,
+                                  &cp_z,
+                                  &n_x,
+                                  &n_y,
+                                  &n_z))
+    return nullptr;
+  double SHCXX_rv =
+    axom::quest::signed_distance_evaluate(x, y, z, cp_x, cp_y, cp_z, n_x, n_y, n_z);
+  SHTPy_rv = Py_BuildValue("ddddddd", SHCXX_rv, cp_x, cp_y, cp_z, n_x, n_y, n_z);
+  return SHTPy_rv;
+  // splicer end function.signed_distance_evaluate_1
 }
 
 static char PY_signed_distance_finalize__doc__[] = "documentation";
@@ -634,6 +671,48 @@ static PyObject *PY_signed_distance_init(PyObject *self,
   return nullptr;
   // splicer end function.signed_distance_init
 }
+
+static char PY_signed_distance_evaluate__doc__[] = "documentation";
+
+static PyObject *PY_signed_distance_evaluate(PyObject *self,
+                                             PyObject *args,
+                                             PyObject *kwds)
+{
+  // splicer begin function.signed_distance_evaluate
+  Py_ssize_t SHT_nargs = 0;
+  if(args != nullptr) SHT_nargs += PyTuple_Size(args);
+  if(kwds != nullptr) SHT_nargs += PyDict_Size(args);
+  PyObject *rvobj;
+  if(SHT_nargs == 3)
+  {
+    rvobj = PY_signed_distance_evaluate_0(self, args, kwds);
+    if(!PyErr_Occurred())
+    {
+      return rvobj;
+    }
+    else if(!PyErr_ExceptionMatches(PyExc_TypeError))
+    {
+      return rvobj;
+    }
+    PyErr_Clear();
+  }
+  if(SHT_nargs == 9)
+  {
+    rvobj = PY_signed_distance_evaluate_1(self, args, kwds);
+    if(!PyErr_Occurred())
+    {
+      return rvobj;
+    }
+    else if(!PyErr_ExceptionMatches(PyExc_TypeError))
+    {
+      return rvobj;
+    }
+    PyErr_Clear();
+  }
+  PyErr_SetString(PyExc_TypeError, "wrong arguments multi-dispatch");
+  return nullptr;
+  // splicer end function.signed_distance_evaluate
+}
 static PyMethodDef PY_methods[] = {
   {"inout_initialized",
    (PyCFunction)PY_inout_initialized,
@@ -699,10 +778,6 @@ static PyMethodDef PY_methods[] = {
    (PyCFunction)PY_signed_distance_set_execution_space,
    METH_VARARGS | METH_KEYWORDS,
    PY_signed_distance_set_execution_space__doc__},
-  {"signed_distance_evaluate",
-   (PyCFunction)PY_signed_distance_evaluate,
-   METH_VARARGS | METH_KEYWORDS,
-   PY_signed_distance_evaluate__doc__},
   {"signed_distance_finalize",
    (PyCFunction)PY_signed_distance_finalize,
    METH_NOARGS,
@@ -715,6 +790,10 @@ static PyMethodDef PY_methods[] = {
    (PyCFunction)PY_signed_distance_init,
    METH_VARARGS | METH_KEYWORDS,
    PY_signed_distance_init__doc__},
+  {"signed_distance_evaluate",
+   (PyCFunction)PY_signed_distance_evaluate,
+   METH_VARARGS | METH_KEYWORDS,
+   PY_signed_distance_evaluate__doc__},
   {nullptr, (PyCFunction) nullptr, 0, nullptr} /* sentinel */
 };
 

--- a/src/axom/quest/interface/quest_shroud.yaml
+++ b/src/axom/quest/interface/quest_shroud.yaml
@@ -104,7 +104,9 @@ declarations:
       - decl: void signed_distance_set_execution_space( SignedDistExec execSpace )
 
       - decl: double signed_distance_evaluate( double x, double y, double z )
-
+      - decl: double signed_distance_evaluate( double x,     double y,     double z,
+                                               double& cp_x, double& cp_y, double& cp_z,
+                                               double& n_x,  double& n_y,  double& n_z)
       - decl: void signed_distance_finalize()
 
 

--- a/src/axom/quest/interface/signed_distance.hpp
+++ b/src/axom/quest/interface/signed_distance.hpp
@@ -248,6 +248,32 @@ void signed_distance_set_execution_space(SignedDistExec execSpace);
 double signed_distance_evaluate(double x, double y, double z = 0.0);
 
 /*!
+ * \brief Evaluates the signed distance function at the given 3D point.
+ *
+ * \param [in] x the x-coordinate of the point in query
+ * \param [in] y the y-coordinate of the point in query
+ * \param [in] z the z-coordinate of the point in query
+ * \param [out] cp_x the x-coordinate of the computed closest point on surface to query point
+ * \param [out] cp_y the y-coordinate of the computed closest point on surface to query point
+ * \param [out] cp_z the z-coordinate of the computed closest point on surface to query point
+ * \param [out] n_x the x-coordinate of the surface normal at the computed closest point
+ * \param [out] n_y the y-coordinate of the surface normal at the computed closest point
+ * \param [out] n_z the z-coordinate of the surface normal at the computed closest point
+ *
+ * \return d the signed distance evaluated at the specified point. The closest surface point
+ * to the query point and the normal at that point are returned as OUT parameters 
+ */
+double signed_distance_evaluate(double x,
+                                double y,
+                                double z,
+                                double& cp_x,
+                                double& cp_y,
+                                double& cp_z,
+                                double& n_x,
+                                double& n_y,
+                                double& n_z);
+
+/*!
  * \brief Evaluates the signed distance function at the given set of points.
  *
  * \param [in] x array consisting of the x-coordinates for each query point

--- a/src/axom/quest/readers/C2CReader.cpp
+++ b/src/axom/quest/readers/C2CReader.cpp
@@ -35,8 +35,12 @@ struct NURBSInterpolator
   NURBSInterpolator(const c2c::NURBSData& curve, double EPS = 1E-9)
     : m_curve(curve)
   {
-    int p = m_curve.order - 1;
-    int knotSize = m_curve.knots.size();
+    const int p = m_curve.order - 1;
+    const int knotSize = m_curve.knots.size();
+
+    AXOM_UNUSED_VAR(p);  // silence warnings in release configs
+    AXOM_UNUSED_VAR(knotSize);
+
     SLIC_ASSERT(p >= 1);
     SLIC_ASSERT(knotSize >= 2 * p);
     computeSpanIntervals(EPS);

--- a/src/axom/quest/tests/quest_signed_distance.cpp
+++ b/src/axom/quest/tests/quest_signed_distance.cpp
@@ -265,6 +265,12 @@ TEST(quest_signed_distance, sphere_test_with_normals)
     const auto normal_expected = VectorType(cp_expected).unitVector();
     EXPECT_NEAR(1., normal.dot(normal_expected), 1e-2);
 
+    // Check that the distance (squared) is the same as the distance
+    // between the query point and the returned closest point
+    EXPECT_NEAR(phi_computed[inode] * phi_computed[inode],
+                primal::squared_distance(pt, cp),
+                1e-8);
+
     phi_expected[inode] = analytic_sphere.computeSignedDistance(pt);
     EXPECT_NEAR(phi_computed[inode], phi_expected[inode], 1.e-2);
 

--- a/src/axom/quest/tests/quest_signed_distance.cpp
+++ b/src/axom/quest/tests/quest_signed_distance.cpp
@@ -5,17 +5,14 @@
 
 #include "axom/config.hpp"
 #include "axom/slic.hpp"
-
 #include "axom/mint.hpp"
+#include "axom/primal.hpp"
 
-#include "axom/primal/geometry/BoundingBox.hpp"
-#include "axom/primal/geometry/Sphere.hpp"
 // _quest_distance_cpp_include_start
-#include "axom/primal/geometry/Point.hpp"
-
-#include "axom/quest/SignedDistance.hpp"  // quest::SignedDistance
+#include "axom/quest/SignedDistance.hpp"
 // _quest_distance_cpp_include_end
-#include "quest_test_utilities.hpp"  // for test-utility functions
+
+#include "quest_test_utilities.hpp"
 
 // Google Test includes
 #include "gtest/gtest.h"
@@ -174,6 +171,134 @@ TEST(quest_signed_distance, sphere_test)
   SLIC_INFO("Done.");
 }
 
+//------------------------------------------------------------------------------
+TEST(quest_signed_distance, sphere_test_with_normals)
+{
+  using PointType = primal::Point<double, 3>;
+  using VectorType = primal::Vector<double, 3>;
+  using SphereType = primal::Sphere<double, 3>;
+
+  constexpr double l1norm_expected = 6.7051997372579715;
+  constexpr double l2norm_expected = 2.5894400431865519;
+  constexpr double linf_expected = 0.00532092;
+  constexpr double TOL = 1.e-3;
+
+  constexpr double SPHERE_RADIUS = 0.5;
+  constexpr int SPHERE_THETA_RES = 25;
+  constexpr int SPHERE_PHI_RES = 25;
+  const double SPHERE_CENTER[3] = {0.0, 0.0, 0.0};
+
+  SphereType analytic_sphere(SPHERE_RADIUS);
+
+  SLIC_INFO("Constructing sphere mesh...");
+  UMesh* surface_mesh = new UMesh(3, mint::TRIANGLE);
+  quest::utilities::getSphereSurfaceMesh(surface_mesh,
+                                         SPHERE_CENTER,
+                                         SPHERE_RADIUS,
+                                         SPHERE_THETA_RES,
+                                         SPHERE_PHI_RES);
+
+  SLIC_INFO("Generating uniform mesh...");
+  mint::UniformMesh* umesh = nullptr;
+  getUniformMesh(surface_mesh, umesh);
+
+  double* phi_computed =
+    umesh->createField<double>("phi_computed", mint::NODE_CENTERED);
+  double* phi_expected =
+    umesh->createField<double>("phi_expected", mint::NODE_CENTERED);
+  double* phi_diff = umesh->createField<double>("phi_diff", mint::NODE_CENTERED);
+  double* phi_err = umesh->createField<double>("phi_err", mint::NODE_CENTERED);
+
+  double* cp_computed_x =
+    umesh->createField<double>("cp_computed_x", mint::NODE_CENTERED);
+  double* cp_computed_y =
+    umesh->createField<double>("cp_computed_y", mint::NODE_CENTERED);
+  double* cp_computed_z =
+    umesh->createField<double>("cp_computed_z", mint::NODE_CENTERED);
+
+  double* normal_computed_x =
+    umesh->createField<double>("normal_computed_x", mint::NODE_CENTERED);
+  double* normal_computed_y =
+    umesh->createField<double>("normal_computed_y", mint::NODE_CENTERED);
+  double* normal_computed_z =
+    umesh->createField<double>("normal_computed_z", mint::NODE_CENTERED);
+
+  const int nnodes = umesh->getNumberOfNodes();
+
+  SLIC_INFO("Generate BVHTree...");
+  constexpr bool is_watertight = true;
+  constexpr bool compute_signs = true;
+  axom::quest::SignedDistance<3> signed_distance(surface_mesh,
+                                                 is_watertight,
+                                                 compute_signs);
+
+  SLIC_INFO("Compute signed distance...");
+
+  double l1norm = 0.0;
+  double l2norm = 0.0;
+  double linf = std::numeric_limits<double>::min();
+
+  for(int inode = 0; inode < nnodes; ++inode)
+  {
+    PointType pt;
+    umesh->getNode(inode, pt.data());
+
+    PointType cp;
+    VectorType normal;
+
+    phi_computed[inode] = signed_distance.computeDistance(pt, cp, normal);
+
+    // Check that the computed closest point on the discretized sphere is close
+    // to where it would be on an analytic sphere
+    cp_computed_x[inode] = cp[0];
+    cp_computed_y[inode] = cp[1];
+    cp_computed_z[inode] = cp[2];
+    const auto cp_expected = primal::closest_point(pt, analytic_sphere);
+    EXPECT_NEAR(0., primal::squared_distance(cp_expected, cp), 1e-2);
+
+    // Check that the computed (pseudo)-normal on the discretized sphere is close
+    // to where it would be on an analytic sphere, i.e. the dot product
+    // between the two should be close to 1
+    normal_computed_x[inode] = normal[0];
+    normal_computed_y[inode] = normal[1];
+    normal_computed_z[inode] = normal[2];
+    const auto normal_expected = VectorType(cp_expected).unitVector();
+    EXPECT_NEAR(1., normal.dot(normal_expected), 1e-2);
+
+    phi_expected[inode] = analytic_sphere.computeSignedDistance(pt);
+    EXPECT_NEAR(phi_computed[inode], phi_expected[inode], 1.e-2);
+
+    // compute error
+    phi_diff[inode] = phi_computed[inode] - phi_expected[inode];
+    phi_err[inode] = std::fabs(phi_diff[inode]);
+
+    // update norms
+    l1norm += phi_err[inode];
+    l2norm += phi_diff[inode];
+    linf = (phi_err[inode] > linf) ? phi_err[inode] : linf;
+
+  }  // END for all nodes
+
+  l2norm = std::sqrt(l2norm);
+
+  SLIC_INFO("l1 = " << l1norm);
+  SLIC_INFO("l2 = " << l2norm);
+  SLIC_INFO("linf = " << linf);
+
+#ifdef QUEST_SIGNED_DISTANCE_TEST_DUMP_VTK
+  mint::write_vtk(umesh, "uniform_mesh_with_normals.vtk");
+  mint::write_vtk(surface_mesh, "sphere_mesh_with_normals.vtk");
+#endif
+
+  EXPECT_NEAR(l1norm_expected, l1norm, TOL);
+  EXPECT_NEAR(l2norm_expected, l2norm, TOL);
+  EXPECT_NEAR(linf_expected, linf, TOL);
+
+  delete surface_mesh;
+  delete umesh;
+
+  SLIC_INFO("Done.");
+}
 //------------------------------------------------------------------------------
 template <typename ExecSpace>
 void run_vectorized_sphere_test()

--- a/src/axom/quest/tests/quest_signed_distance_interface.cpp
+++ b/src/axom/quest/tests/quest_signed_distance_interface.cpp
@@ -604,6 +604,12 @@ TEST(quest_signed_distance_interface, analytic_sphere_with_closest_pt_and_normal
     const auto normal_expected = VectorType(cp_expected).unitVector();
     EXPECT_NEAR(1., normal.dot(normal_expected), 1e-2);
 
+    // Check that the distance (squared) is the same as the distance
+    // between the query point and the returned closest point
+    EXPECT_NEAR(phi_computed[inode] * phi_computed[inode],
+                primal::squared_distance(pt, closest_point),
+                1e-8);
+
     // compute error
     phi_diff[inode] = phi_computed[inode] - phi_expected[inode];
     phi_err[inode] = utilities::abs(phi_diff[inode]);

--- a/src/axom/quest/tests/quest_signed_distance_interface.cpp
+++ b/src/axom/quest/tests/quest_signed_distance_interface.cpp
@@ -4,29 +4,15 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 // Axom utils
-#include "axom/config.hpp"  // axom compile-time definitions
-#include "axom/core/utilities/Utilities.hpp"
-
-// Mint includes
-#include "axom/mint/config.hpp"                 // mint compile-time definitions
-#include "axom/mint/mesh/CellTypes.hpp"         // for cell types enum
-#include "axom/mint/mesh/Mesh.hpp"              // defines mint::Mesh
-#include "axom/mint/mesh/MeshTypes.hpp"         // for mesh types enum
-#include "axom/mint/mesh/UniformMesh.hpp"       // for mint::UniformMesh
-#include "axom/mint/mesh/UnstructuredMesh.hpp"  // for mint::UnstructuredMesh
-#include "axom/mint/utils/vtk_utils.hpp"        // for mint::write_vtk()
-
-// Primal includes
-#include "axom/primal/geometry/BoundingBox.hpp"  // primal::BoundingBox
-#include "axom/primal/geometry/Plane.hpp"        // defines primal::Plane
-#include "axom/primal/geometry/Sphere.hpp"       // defines primal::Sphere
+#include "axom/config.hpp"
+#include "axom/core.hpp"
+#include "axom/mint.hpp"
+#include "axom/primal.hpp"
+#include "axom/slic.hpp"
 
 // Quest includes
-#include "axom/quest/interface/signed_distance.hpp"  // for signed distance
-#include "quest_test_utilities.hpp"                  // test-utility functions
-
-// Slic includes
-#include "axom/slic.hpp"
+#include "axom/quest/interface/signed_distance.hpp"
+#include "quest_test_utilities.hpp"
 
 // gtest
 #ifdef AXOM_USE_MPI
@@ -497,6 +483,126 @@ TEST(quest_signed_distance_interface, analytic_sphere)
     phi_computed[inode] = quest::signed_distance_evaluate(pt[0], pt[1], pt[2]);
     phi_expected[inode] = analytic_sphere.computeSignedDistance(pt);
     EXPECT_NEAR(phi_computed[inode], phi_expected[inode], 1.e-2);
+
+    // compute error
+    phi_diff[inode] = phi_computed[inode] - phi_expected[inode];
+    phi_err[inode] = utilities::abs(phi_diff[inode]);
+
+    // update norms
+    l1norm += phi_err[inode];
+    l2norm += phi_diff[inode];
+    linf = (phi_err[inode] > linf) ? phi_err[inode] : linf;
+
+  }  // END for all nodes
+
+  l2norm = std::sqrt(l2norm);
+
+  EXPECT_NEAR(l1norm_expected, l1norm, TOL);
+  EXPECT_NEAR(l2norm_expected, l2norm, TOL);
+  EXPECT_NEAR(linf_expected, linf, TOL);
+
+  // STEP 5: finalize the signed distance query
+  quest::signed_distance_finalize();
+  EXPECT_FALSE(quest::signed_distance_initialized());
+
+#ifdef WRITE_VTK_OUTPUT
+  mint::write_vtk(umesh, "analytic_sphere_test_mesh.vtk");
+  mint::write_vtk(surface_mesh, "input_sphere_mesh.vtk");
+#endif
+
+  // STEP 6: delete mesh objects
+  delete umesh;
+  delete surface_mesh;
+
+  umesh = nullptr;
+  surface_mesh = nullptr;
+}
+
+//------------------------------------------------------------------------------
+TEST(quest_signed_distance_interface, analytic_sphere_with_closest_pt_and_normal)
+{
+  // STEP 0: constants
+  constexpr int NDIMS = 3;
+  constexpr double l1norm_expected = 6.7051997372579715;
+  constexpr double l2norm_expected = 2.5894400431865519;
+  constexpr double linf_expected = 0.00532092;
+  constexpr double TOL = 1.e-3;
+
+  constexpr double SPHERE_RADIUS = 0.5;
+  constexpr int SPHERE_THETA_RES = 25;
+  constexpr int SPHERE_PHI_RES = 25;
+  const double SPHERE_CENTER[3] = {0.0, 0.0, 0.0};
+
+  using PointType = primal::Point<double, 3>;
+  using VectorType = primal::Vector<double, 3>;
+  using SphereType = primal::Sphere<double, 3>;
+
+  // STEP 1: create analytic sphere object to compare results with
+  SphereType analytic_sphere(SPHERE_RADIUS);
+
+  // STEP 2: generate sphere mesh to pass to the signed distance query
+  UnstructuredMesh* surface_mesh = new UnstructuredMesh(NDIMS, mint::TRIANGLE);
+  quest::utilities::getSphereSurfaceMesh(surface_mesh,
+                                         SPHERE_CENTER,
+                                         SPHERE_RADIUS,
+                                         SPHERE_THETA_RES,
+                                         SPHERE_PHI_RES);
+
+  // STEP 1: generate the uniform mesh where the signed distance will be
+  //         computed
+  mint::UniformMesh* umesh = nullptr;
+  getUniformMesh(surface_mesh, umesh);
+
+  // STEP 2: create node-centered fields on the uniform mesh to store
+  //         the signed distance etc.
+  double* phi_computed =
+    umesh->createField<double>("phi_computed", mint::NODE_CENTERED);
+  double* phi_expected =
+    umesh->createField<double>("phi_expected", mint::NODE_CENTERED);
+  double* phi_diff = umesh->createField<double>("phi_diff", mint::NODE_CENTERED);
+  double* phi_err = umesh->createField<double>("phi_err", mint::NODE_CENTERED);
+
+  // STEP 3: initialize the signed distance query
+  quest::signed_distance_set_closed_surface(true);
+  quest::signed_distance_init(surface_mesh);
+  EXPECT_TRUE(quest::signed_distance_initialized());
+
+  // STEP 4: Compute signed distance
+  double l1norm = 0.0;
+  double l2norm = 0.0;
+  double linf = std::numeric_limits<double>::min();
+  axom::IndexType nnodes = umesh->getNumberOfNodes();
+  for(axom::IndexType inode = 0; inode < nnodes; ++inode)
+  {
+    PointType pt;
+    umesh->getNode(inode, pt.data());
+
+    PointType closest_point;
+    VectorType normal;
+
+    phi_computed[inode] = quest::signed_distance_evaluate(pt[0],
+                                                          pt[1],
+                                                          pt[2],
+                                                          closest_point[0],
+                                                          closest_point[1],
+                                                          closest_point[2],
+                                                          normal[0],
+                                                          normal[1],
+                                                          normal[2]);
+
+    phi_expected[inode] = analytic_sphere.computeSignedDistance(pt);
+    EXPECT_NEAR(phi_computed[inode], phi_expected[inode], 1.e-2);
+
+    // Check that the computed closest point on the discretized sphere is close
+    // to where it would be on an analytic sphere
+    const auto cp_expected = primal::closest_point(pt, analytic_sphere);
+    EXPECT_NEAR(0., primal::squared_distance(cp_expected, closest_point), 1e-2);
+
+    // Check that the computed (pseudo)-normal on the discretized sphere is close
+    // to where it would be on an analytic sphere, i.e. the dot product
+    // between the two should be close to 1
+    const auto normal_expected = VectorType(cp_expected).unitVector();
+    EXPECT_NEAR(1., normal.dot(normal_expected), 1e-2);
 
     // compute error
     phi_diff[inode] = phi_computed[inode] - phi_expected[inode];


### PR DESCRIPTION
# Summary

- This PR is a feature based on a user request from @dtaller 
- It adds an overload to quest's `SignedDistance` query to return the closest point on the surface to the query point as well as the surface normal at that point
- It also exposes this to quest's signed distance C/Fortran API
- Resolves #845 