### PR TITLE
Fixes build in configurations without MPI

### DIFF
--- a/src/axom/quest/examples/quest_inout_interface.cpp
+++ b/src/axom/quest/examples/quest_inout_interface.cpp
@@ -138,6 +138,7 @@ int main(int argc, char** argv)
 #else
   int my_rank = 0;
   int num_ranks = 1;
+  AXOM_UNUSED_VAR(num_ranks);
 #endif
 
   // -- Initialize logger

--- a/src/axom/quest/interface/internal/QuestHelpers.cpp
+++ b/src/axom/quest/interface/internal/QuestHelpers.cpp
@@ -13,8 +13,12 @@
   #include "axom/quest/readers/PSTLReader.hpp"
 #endif
 
-#if defined(AXOM_USE_MPI) && defined(AXOM_USE_C2C)
-  #include "axom/quest/readers/PC2CReader.hpp"
+#if defined(AXOM_USE_C2C)
+  #if defined(AXOM_USE_MPI)
+    #include "axom/quest/readers/PC2CReader.hpp"
+  #else
+    #include "axom/quest/readers/C2CReader.hpp"
+  #endif
 #endif
 
 #include <limits>
@@ -370,7 +374,7 @@ int read_c2c_mesh(const std::string& file,
   m = new SegmentMesh(DIMENSION, mint::SEGMENT);
 
   // STEP 2: construct C2C reader
-  #ifdef AXOM_USE_MPI
+  #if defined(AXOM_USE_MPI) && defined(AXOM_USE_C2C)
   quest::PC2CReader reader(comm);
   #else
   AXOM_UNUSED_VAR(comm);

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -17,7 +17,9 @@
   #include "axom/fmt.hpp"
 
   #include "MFEMSidreDataCollection.hpp"
-  #include "axom/sidre/spio/IOManager.hpp"
+  #ifdef AXOM_USE_MPI
+    #include "axom/sidre/spio/IOManager.hpp"
+  #endif
 
   #include "axom/core/utilities/StringUtilities.hpp"
   #include "axom/core/utilities/Utilities.hpp"


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It fixes the build for configurations without MPI. 
- There were two issues 
    - one had an unguarded inclusion of spio (which is only available when MPI is available. See: #849.
       Looks like I introduced this problem in #837 when I got rid of `sidre/core/sidre.hpp`
    - the other was for configs with C2C but not MPI.
- Resolves #849 
