### PR TITLE
IndexType32

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -145,6 +145,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Spin: `BVH::findPoints/Rays/BoundingBoxes()` candidate search methods now accept an `axom::ArrayView<IndexType>`
   for the `offsets` and `counts` output arrays, and return `candidates` as an `axom::Array<IndexType>`.
 - Renamed `primal::Polygon::centroid()` to `primal::Polygon::vertexMean()` because it was not actually computing the centroid.
+- `axom:sidre:IndexType` is now the same type as
+  `axom:IndexType`. Before, Sidre always used `int64_t`. Now it
+  respects the define `AXOM_USE_64BIT_INDEXTYPE`.
 
 ###  Fixed
 - Fixed a bug relating to swap and assignment operations for multidimensional `axom::Array`s

--- a/src/axom/sidre/core/SidreDataTypeIds.h
+++ b/src/axom/sidre/core/SidreDataTypeIds.h
@@ -13,7 +13,7 @@
 
 /*
  * Note: Use only C code in this file
- *       since it might be included from a C file.
+ *       since it will be included from a C file.
  */
 
 #ifndef SIDRE_DATATYPEIDS_H_
@@ -22,11 +22,7 @@
 // Libraries and other axom headers
 #include "conduit.h"
 
-#include <stdint.h> /* for int64_t */
-
-typedef int64_t SIDRE_IndexType;
-
-const SIDRE_IndexType SIDRE_InvalidIndex = -1;
+#define SIDRE_InvalidIndex -1
 
 #define SIDRE_NO_TYPE_ID CONDUIT_EMPTY_ID
 #define SIDRE_INT8_ID CONDUIT_INT8_ID

--- a/src/axom/sidre/core/SidreTypes.hpp
+++ b/src/axom/sidre/core/SidreTypes.hpp
@@ -42,7 +42,7 @@ using Schema = conduit::Schema;
  * \brief IndexType is used for any labeling of a sidre object by an
  *        integer identifier.
  */
-using IndexType = int64_t;
+using IndexType = axom::IndexType;
 
 /*!
  * \brief Common invalid index identifier used in sidre.

--- a/src/axom/sidre/core/SidreTypes.hpp
+++ b/src/axom/sidre/core/SidreTypes.hpp
@@ -42,7 +42,7 @@ using Schema = conduit::Schema;
  * \brief IndexType is used for any labeling of a sidre object by an
  *        integer identifier.
  */
-using IndexType = SIDRE_IndexType;
+using IndexType = int64_t;
 
 /*!
  * \brief Common invalid index identifier used in sidre.

--- a/src/axom/sidre/interface/SidreTypes.h
+++ b/src/axom/sidre/interface/SidreTypes.h
@@ -13,8 +13,18 @@
 #ifndef SIDRETYPES_H
 #define SIDRETYPES_H
 
+// Axom includes
 #include "axom/config.hpp"
 #include "axom/sidre/core/SidreDataTypeIds.h"
+
+// C includes
+#include <stdint.h> /* for int64_t */
+
+#if defined(AXOM_USE_64BIT_INDEXTYPE) && !defined(AXOM_NO_INT64_T)
+typedef int64_t SIDRE_IndexType;
+#else
+typedef int64_t SIDRE_IndexType;
+#endif
 
 #define SIDRE_InvalidName NULL
 

--- a/src/axom/sidre/interface/SidreTypes.h
+++ b/src/axom/sidre/interface/SidreTypes.h
@@ -10,6 +10,12 @@
  *         SiDRe toolkit component.
  *
  */
+
+/*
+ * Note: Use only C code in this file.
+ *       It is part of the C wrapper.
+ */
+
 #ifndef SIDRETYPES_H
 #define SIDRETYPES_H
 
@@ -27,6 +33,7 @@ typedef int32_t SIDRE_IndexType;
 #endif
 
 typedef short SIDRE_TypeID;
+typedef int SIDRE_TypeIDint;
 
 #define SIDRE_InvalidName NULL
 

--- a/src/axom/sidre/interface/SidreTypes.h
+++ b/src/axom/sidre/interface/SidreTypes.h
@@ -23,8 +23,10 @@
 #if defined(AXOM_USE_64BIT_INDEXTYPE) && !defined(AXOM_NO_INT64_T)
 typedef int64_t SIDRE_IndexType;
 #else
-typedef int64_t SIDRE_IndexType;
+typedef int32_t SIDRE_IndexType;
 #endif
+
+typedef short SIDRE_TypeID;
 
 #define SIDRE_InvalidName NULL
 

--- a/src/axom/sidre/interface/c_fortran/fsidresplicer.f
+++ b/src/axom/sidre/interface/c_fortran/fsidresplicer.f
@@ -29,7 +29,7 @@ use conduit, only : &
     CONDUIT_ULONG_ID, &
     CONDUIT_FLOAT_ID, &
     CONDUIT_DOUBLE_ID
-use, intrinsic :: iso_c_binding, only : C_SHORT, C_INT32_T, C_INT64_T
+use, intrinsic :: iso_c_binding, only : C_SHORT, C_INT, C_INT32_T, C_INT64_T
 ! splicer end module_use
 
 ! splicer begin module_top
@@ -42,6 +42,7 @@ integer, parameter :: SIDRE_IndexType = C_INT32_T
 #endif
 
 integer, parameter :: TypeID = C_SHORT
+integer, parameter :: TypeIDint = C_INT
 
 integer(TypeID), parameter :: &
     SIDRE_NO_TYPE_ID    = CONDUIT_EMPTY_ID, &

--- a/src/axom/sidre/interface/c_fortran/fsidresplicer.f
+++ b/src/axom/sidre/interface/c_fortran/fsidresplicer.f
@@ -29,7 +29,7 @@ use conduit, only : &
     CONDUIT_ULONG_ID, &
     CONDUIT_FLOAT_ID, &
     CONDUIT_DOUBLE_ID
-use, intrinsic :: iso_c_binding, only : C_INT32_T, C_INT64_T
+use, intrinsic :: iso_c_binding, only : C_SHORT, C_INT32_T, C_INT64_T
 ! splicer end module_use
 
 ! splicer begin module_top
@@ -38,10 +38,12 @@ integer, parameter :: MAXNAMESIZE = 128
 #if defined(AXOM_USE_64BIT_INDEXTYPE) && !defined(AXOM_NO_INT64_T)
 integer, parameter :: SIDRE_IndexType = C_INT64_T
 #else
-integer, parameter :: SIDRE_IndexType = C_INT64_T
+integer, parameter :: SIDRE_IndexType = C_INT32_T
 #endif
 
-integer, parameter :: &
+integer, parameter :: TypeID = C_SHORT
+
+integer(TypeID), parameter :: &
     SIDRE_NO_TYPE_ID    = CONDUIT_EMPTY_ID, &
     SIDRE_INT8_ID       = CONDUIT_INT8_ID, &
     SIDRE_INT16_ID      = CONDUIT_INT16_ID, &

--- a/src/axom/sidre/interface/c_fortran/fsidresplicer.f
+++ b/src/axom/sidre/interface/c_fortran/fsidresplicer.f
@@ -10,33 +10,56 @@
 ! splicer end file_top
 
 ! splicer begin module_use
-! map conduit type names to sidre type names
 use conduit, only : &
-    SIDRE_NO_TYPE_ID    => CONDUIT_EMPTY_ID, &
-    SIDRE_INT8_ID       => CONDUIT_INT8_ID, &
-    SIDRE_INT16_ID      => CONDUIT_INT16_ID, &
-    SIDRE_INT32_ID      => CONDUIT_INT32_ID, &
-    SIDRE_INT64_ID      => CONDUIT_INT64_ID, &
-    SIDRE_UINT8_ID      => CONDUIT_UINT8_ID, &
-    SIDRE_UINT16_ID     => CONDUIT_UINT16_ID, &
-    SIDRE_UINT32_ID     => CONDUIT_UINT32_ID, &
-    SIDRE_UINT64_ID     => CONDUIT_UINT64_ID, &
-    SIDRE_FLOAT32_ID    => CONDUIT_FLOAT32_ID, &
-    SIDRE_FLOAT64_ID    => CONDUIT_FLOAT64_ID, &
-    SIDRE_CHAR8_STR_ID  => CONDUIT_CHAR8_STR_ID, &
-    SIDRE_INT_ID        => CONDUIT_INT_ID, &
-    SIDRE_UINT_ID       => CONDUIT_UINT_ID, &
-    SIDRE_LONG_ID       => CONDUIT_LONG_ID, &
-    SIDRE_ULONG_ID      => CONDUIT_ULONG_ID, &
-    SIDRE_FLOAT_ID      => CONDUIT_FLOAT_ID, &
-    SIDRE_DOUBLE_ID     => CONDUIT_DOUBLE_ID
-use, intrinsic :: iso_c_binding, only : C_INT64_T
+    CONDUIT_EMPTY_ID, &
+    CONDUIT_INT8_ID, &
+    CONDUIT_INT16_ID, &
+    CONDUIT_INT32_ID, &
+    CONDUIT_INT64_ID, &
+    CONDUIT_UINT8_ID, &
+    CONDUIT_UINT16_ID, &
+    CONDUIT_UINT32_ID, &
+    CONDUIT_UINT64_ID, &
+    CONDUIT_FLOAT32_ID, &
+    CONDUIT_FLOAT64_ID, &
+    CONDUIT_CHAR8_STR_ID, &
+    CONDUIT_INT_ID, &
+    CONDUIT_UINT_ID, &
+    CONDUIT_LONG_ID, &
+    CONDUIT_ULONG_ID, &
+    CONDUIT_FLOAT_ID, &
+    CONDUIT_DOUBLE_ID
+use, intrinsic :: iso_c_binding, only : C_INT32_T, C_INT64_T
 ! splicer end module_use
 
 ! splicer begin module_top
 integer, parameter :: MAXNAMESIZE = 128
 
+#if defined(AXOM_USE_64BIT_INDEXTYPE) && !defined(AXOM_NO_INT64_T)
 integer, parameter :: SIDRE_IndexType = C_INT64_T
+#else
+integer, parameter :: SIDRE_IndexType = C_INT64_T
+#endif
+
+integer, parameter :: &
+    SIDRE_NO_TYPE_ID    = CONDUIT_EMPTY_ID, &
+    SIDRE_INT8_ID       = CONDUIT_INT8_ID, &
+    SIDRE_INT16_ID      = CONDUIT_INT16_ID, &
+    SIDRE_INT32_ID      = CONDUIT_INT32_ID, &
+    SIDRE_INT64_ID      = CONDUIT_INT64_ID, &
+    SIDRE_UINT8_ID      = CONDUIT_UINT8_ID, &
+    SIDRE_UINT16_ID     = CONDUIT_UINT16_ID, &
+    SIDRE_UINT32_ID     = CONDUIT_UINT32_ID, &
+    SIDRE_UINT64_ID     = CONDUIT_UINT64_ID, &
+    SIDRE_FLOAT32_ID    = CONDUIT_FLOAT32_ID, &
+    SIDRE_FLOAT64_ID    = CONDUIT_FLOAT64_ID, &
+    SIDRE_CHAR8_STR_ID  = CONDUIT_CHAR8_STR_ID, &
+    SIDRE_INT_ID        = CONDUIT_INT_ID, &
+    SIDRE_UINT_ID       = CONDUIT_UINT_ID, &
+    SIDRE_LONG_ID       = CONDUIT_LONG_ID, &
+    SIDRE_ULONG_ID      = CONDUIT_ULONG_ID, &
+    SIDRE_FLOAT_ID      = CONDUIT_FLOAT_ID, &
+    SIDRE_DOUBLE_ID     = CONDUIT_DOUBLE_ID
 
 integer, parameter :: invalid_index = -1_SIDRE_IndexType
 ! splicer end module_top

--- a/src/axom/sidre/interface/c_fortran/genfsidresplicer.py
+++ b/src/axom/sidre/interface/c_fortran/genfsidresplicer.py
@@ -88,7 +88,7 @@ function group_create_array_view_{typename}{nd}(grp, name, value) result(rv)
     integer(C_INT) :: lname
     type(SidreView) :: rv
     integer(SIDRE_IndexType) :: {extents_decl}
-    integer(C_INT), parameter :: type = {sidre_type}
+    integer(TypeID), parameter :: type = {sidre_type}
     type(C_PTR) addr, viewptr
 
     lname = len_trim(name)

--- a/src/axom/sidre/interface/c_fortran/wrapBuffer.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapBuffer.cpp
@@ -45,13 +45,13 @@ void *SIDRE_Buffer_get_void_ptr(SIDRE_Buffer *self)
   // splicer end class.Buffer.method.get_void_ptr
 }
 
-SIDRE_TypeID SIDRE_Buffer_get_type_id(const SIDRE_Buffer *self)
+SIDRE_TypeIDint SIDRE_Buffer_get_type_id(const SIDRE_Buffer *self)
 {
   const axom::sidre::Buffer *SH_this =
     static_cast<const axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.get_type_id
   axom::sidre::TypeID SHCXX_rv = SH_this->getTypeID();
-  SIDRE_TypeID SHC_rv = static_cast<SIDRE_TypeID>(SHCXX_rv);
+  SIDRE_TypeIDint SHC_rv = static_cast<SIDRE_TypeIDint>(SHCXX_rv);
   return SHC_rv;
   // splicer end class.Buffer.method.get_type_id
 }

--- a/src/axom/sidre/interface/c_fortran/wrapBuffer.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapBuffer.cpp
@@ -45,13 +45,13 @@ void *SIDRE_Buffer_get_void_ptr(SIDRE_Buffer *self)
   // splicer end class.Buffer.method.get_void_ptr
 }
 
-int SIDRE_Buffer_get_type_id(const SIDRE_Buffer *self)
+SIDRE_TypeID SIDRE_Buffer_get_type_id(const SIDRE_Buffer *self)
 {
   const axom::sidre::Buffer *SH_this =
     static_cast<const axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.get_type_id
   axom::sidre::TypeID SHCXX_rv = SH_this->getTypeID();
-  int SHC_rv = static_cast<int>(SHCXX_rv);
+  SIDRE_TypeID SHC_rv = static_cast<SIDRE_TypeID>(SHCXX_rv);
   return SHC_rv;
   // splicer end class.Buffer.method.get_type_id
 }
@@ -86,11 +86,13 @@ size_t SIDRE_Buffer_get_bytes_per_element(const SIDRE_Buffer *self)
   // splicer end class.Buffer.method.get_bytes_per_element
 }
 
-void SIDRE_Buffer_describe(SIDRE_Buffer *self, int type, SIDRE_IndexType num_elems)
+void SIDRE_Buffer_describe(SIDRE_Buffer *self,
+                           SIDRE_TypeID type,
+                           SIDRE_IndexType num_elems)
 {
   axom::sidre::Buffer *SH_this = static_cast<axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.describe
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   SH_this->describe(SHCXX_type, num_elems);
   // splicer end class.Buffer.method.describe
 }
@@ -104,12 +106,12 @@ void SIDRE_Buffer_allocate_existing(SIDRE_Buffer *self)
 }
 
 void SIDRE_Buffer_allocate_from_type(SIDRE_Buffer *self,
-                                     int type,
+                                     SIDRE_TypeID type,
                                      SIDRE_IndexType num_elems)
 {
   axom::sidre::Buffer *SH_this = static_cast<axom::sidre::Buffer *>(self->addr);
   // splicer begin class.Buffer.method.allocate_from_type
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   SH_this->allocate(SHCXX_type, num_elems);
   // splicer end class.Buffer.method.allocate_from_type
 }

--- a/src/axom/sidre/interface/c_fortran/wrapBuffer.h
+++ b/src/axom/sidre/interface/c_fortran/wrapBuffer.h
@@ -39,7 +39,7 @@ size_t SIDRE_Buffer_get_num_views(const SIDRE_Buffer* self);
 
 void* SIDRE_Buffer_get_void_ptr(SIDRE_Buffer* self);
 
-SIDRE_TypeID SIDRE_Buffer_get_type_id(const SIDRE_Buffer* self);
+SIDRE_TypeIDint SIDRE_Buffer_get_type_id(const SIDRE_Buffer* self);
 
 size_t SIDRE_Buffer_get_num_elements(const SIDRE_Buffer* self);
 

--- a/src/axom/sidre/interface/c_fortran/wrapBuffer.h
+++ b/src/axom/sidre/interface/c_fortran/wrapBuffer.h
@@ -14,14 +14,13 @@
 #ifndef WRAPBUFFER_H
 #define WRAPBUFFER_H
 
+#include "axom/sidre/interface/SidreTypes.h"
 #include "typesSidre.h"
 #ifdef __cplusplus
   #include <cstddef>
-  #include <cstdint>
   #include "axom/sidre/core/SidreTypes.hpp"
 #else
   #include <stddef.h>
-  #include "axom/sidre/interface/SidreTypes.h"
 #endif
 
 // splicer begin class.Buffer.CXX_declarations

--- a/src/axom/sidre/interface/c_fortran/wrapBuffer.h
+++ b/src/axom/sidre/interface/c_fortran/wrapBuffer.h
@@ -39,7 +39,7 @@ size_t SIDRE_Buffer_get_num_views(const SIDRE_Buffer* self);
 
 void* SIDRE_Buffer_get_void_ptr(SIDRE_Buffer* self);
 
-int SIDRE_Buffer_get_type_id(const SIDRE_Buffer* self);
+SIDRE_TypeID SIDRE_Buffer_get_type_id(const SIDRE_Buffer* self);
 
 size_t SIDRE_Buffer_get_num_elements(const SIDRE_Buffer* self);
 
@@ -47,12 +47,14 @@ size_t SIDRE_Buffer_get_total_bytes(const SIDRE_Buffer* self);
 
 size_t SIDRE_Buffer_get_bytes_per_element(const SIDRE_Buffer* self);
 
-void SIDRE_Buffer_describe(SIDRE_Buffer* self, int type, SIDRE_IndexType num_elems);
+void SIDRE_Buffer_describe(SIDRE_Buffer* self,
+                           SIDRE_TypeID type,
+                           SIDRE_IndexType num_elems);
 
 void SIDRE_Buffer_allocate_existing(SIDRE_Buffer* self);
 
 void SIDRE_Buffer_allocate_from_type(SIDRE_Buffer* self,
-                                     int type,
+                                     SIDRE_TypeID type,
                                      SIDRE_IndexType num_elems);
 
 void SIDRE_Buffer_reallocate(SIDRE_Buffer* self, SIDRE_IndexType num_elems);

--- a/src/axom/sidre/interface/c_fortran/wrapDataStore.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapDataStore.cpp
@@ -98,14 +98,14 @@ SIDRE_Buffer *SIDRE_DataStore_create_buffer_empty(SIDRE_DataStore *self,
 }
 
 SIDRE_Buffer *SIDRE_DataStore_create_buffer_from_type(SIDRE_DataStore *self,
-                                                      int type,
+                                                      SIDRE_TypeID type,
                                                       SIDRE_IndexType num_elems,
                                                       SIDRE_Buffer *SHC_rv)
 {
   axom::sidre::DataStore *SH_this =
     static_cast<axom::sidre::DataStore *>(self->addr);
   // splicer begin class.DataStore.method.create_buffer_from_type
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::Buffer *SHCXX_rv = SH_this->createBuffer(SHCXX_type, num_elems);
   // C_error_pattern
   if(SHCXX_rv == nullptr)

--- a/src/axom/sidre/interface/c_fortran/wrapDataStore.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapDataStore.cpp
@@ -11,7 +11,6 @@
 #include "axom/sidre/core/Buffer.hpp"
 #include "axom/sidre/core/DataStore.hpp"
 #include "axom/sidre/core/Group.hpp"
-#include "axom/sidre/interface/SidreTypes.h"
 
 // splicer begin class.DataStore.CXX_definitions
 // splicer end class.DataStore.CXX_definitions

--- a/src/axom/sidre/interface/c_fortran/wrapDataStore.h
+++ b/src/axom/sidre/interface/c_fortran/wrapDataStore.h
@@ -53,7 +53,7 @@ SIDRE_Buffer* SIDRE_DataStore_create_buffer_empty(SIDRE_DataStore* self,
                                                   SIDRE_Buffer* SHC_rv);
 
 SIDRE_Buffer* SIDRE_DataStore_create_buffer_from_type(SIDRE_DataStore* self,
-                                                      int type,
+                                                      SIDRE_TypeID type,
                                                       SIDRE_IndexType num_elems,
                                                       SIDRE_Buffer* SHC_rv);
 

--- a/src/axom/sidre/interface/c_fortran/wrapDataStore.h
+++ b/src/axom/sidre/interface/c_fortran/wrapDataStore.h
@@ -14,18 +14,17 @@
 #ifndef WRAPDATASTORE_H
 #define WRAPDATASTORE_H
 
+#include "axom/sidre/interface/SidreTypes.h"
 #ifdef AXOM_USE_MPI
   #include "mpi.h"
 #endif
 #include "typesSidre.h"
 #ifdef __cplusplus
   #include <cstddef>
-  #include <cstdint>
   #include "axom/sidre/core/SidreTypes.hpp"
 #else
   #include <stdbool.h>
   #include <stddef.h>
-  #include "axom/sidre/interface/SidreTypes.h"
 #endif
 
 // splicer begin class.DataStore.CXX_declarations

--- a/src/axom/sidre/interface/c_fortran/wrapGroup.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapGroup.cpp
@@ -396,14 +396,14 @@ SIDRE_View *SIDRE_Group_create_view_empty_bufferify(SIDRE_Group *self,
 
 SIDRE_View *SIDRE_Group_create_view_from_type(SIDRE_Group *self,
                                               const char *path,
-                                              int type,
+                                              SIDRE_TypeID type,
                                               SIDRE_IndexType num_elems,
                                               SIDRE_View *SHC_rv)
 {
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_type
   const std::string SHCXX_path(path);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, num_elems);
   // C_error_pattern
@@ -423,14 +423,14 @@ SIDRE_View *SIDRE_Group_create_view_from_type(SIDRE_Group *self,
 SIDRE_View *SIDRE_Group_create_view_from_type_bufferify(SIDRE_Group *self,
                                                         const char *path,
                                                         int Lpath,
-                                                        int type,
+                                                        SIDRE_TypeID type,
                                                         SIDRE_IndexType num_elems,
                                                         SIDRE_View *SHC_rv)
 {
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_type_bufferify
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, num_elems);
   SHC_rv->addr = SHCXX_rv;
@@ -441,7 +441,7 @@ SIDRE_View *SIDRE_Group_create_view_from_type_bufferify(SIDRE_Group *self,
 
 SIDRE_View *SIDRE_Group_create_view_with_shape_base(SIDRE_Group *self,
                                                     const char *path,
-                                                    int type,
+                                                    SIDRE_TypeID type,
                                                     int ndims,
                                                     const SIDRE_IndexType *shape,
                                                     SIDRE_View *SHC_rv)
@@ -449,7 +449,7 @@ SIDRE_View *SIDRE_Group_create_view_with_shape_base(SIDRE_Group *self,
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_with_shape_base
   const std::string SHCXX_path(path);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::View *SHCXX_rv =
     SH_this->createViewWithShape(SHCXX_path, SHCXX_type, ndims, shape);
   // C_error_pattern
@@ -470,7 +470,7 @@ SIDRE_View *SIDRE_Group_create_view_with_shape_base_bufferify(
   SIDRE_Group *self,
   const char *path,
   int Lpath,
-  int type,
+  SIDRE_TypeID type,
   int ndims,
   const SIDRE_IndexType *shape,
   SIDRE_View *SHC_rv)
@@ -478,7 +478,7 @@ SIDRE_View *SIDRE_Group_create_view_with_shape_base_bufferify(
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_with_shape_base_bufferify
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::View *SHCXX_rv =
     SH_this->createViewWithShape(SHCXX_path, SHCXX_type, ndims, shape);
   SHC_rv->addr = SHCXX_rv;
@@ -532,7 +532,7 @@ SIDRE_View *SIDRE_Group_create_view_into_buffer_bufferify(SIDRE_Group *self,
 
 SIDRE_View *SIDRE_Group_create_view_from_type_and_buffer(SIDRE_Group *self,
                                                          const char *path,
-                                                         int type,
+                                                         SIDRE_TypeID type,
                                                          SIDRE_IndexType num_elems,
                                                          SIDRE_Buffer *buff,
                                                          SIDRE_View *SHC_rv)
@@ -540,7 +540,7 @@ SIDRE_View *SIDRE_Group_create_view_from_type_and_buffer(SIDRE_Group *self,
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_type_and_buffer
   const std::string SHCXX_path(path);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::Buffer *SHCXX_buff =
     static_cast<axom::sidre::Buffer *>(buff->addr);
   axom::sidre::View *SHCXX_rv =
@@ -563,7 +563,7 @@ SIDRE_View *SIDRE_Group_create_view_from_type_and_buffer_bufferify(
   SIDRE_Group *self,
   const char *path,
   int Lpath,
-  int type,
+  SIDRE_TypeID type,
   SIDRE_IndexType num_elems,
   SIDRE_Buffer *buff,
   SIDRE_View *SHC_rv)
@@ -571,7 +571,7 @@ SIDRE_View *SIDRE_Group_create_view_from_type_and_buffer_bufferify(
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_type_and_buffer_bufferify
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::Buffer *SHCXX_buff =
     static_cast<axom::sidre::Buffer *>(buff->addr);
   axom::sidre::View *SHCXX_rv =
@@ -584,7 +584,7 @@ SIDRE_View *SIDRE_Group_create_view_from_type_and_buffer_bufferify(
 
 SIDRE_View *SIDRE_Group_create_view_with_shape_and_buffer(SIDRE_Group *self,
                                                           const char *path,
-                                                          int type,
+                                                          SIDRE_TypeID type,
                                                           int ndims,
                                                           const SIDRE_IndexType *shape,
                                                           SIDRE_Buffer *buff,
@@ -593,7 +593,7 @@ SIDRE_View *SIDRE_Group_create_view_with_shape_and_buffer(SIDRE_Group *self,
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_with_shape_and_buffer
   const std::string SHCXX_path(path);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::Buffer *SHCXX_buff =
     static_cast<axom::sidre::Buffer *>(buff->addr);
   axom::sidre::View *SHCXX_rv =
@@ -616,7 +616,7 @@ SIDRE_View *SIDRE_Group_create_view_with_shape_and_buffer_bufferify(
   SIDRE_Group *self,
   const char *path,
   int Lpath,
-  int type,
+  SIDRE_TypeID type,
   int ndims,
   const SIDRE_IndexType *shape,
   SIDRE_Buffer *buff,
@@ -625,7 +625,7 @@ SIDRE_View *SIDRE_Group_create_view_with_shape_and_buffer_bufferify(
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_with_shape_and_buffer_bufferify
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::Buffer *SHCXX_buff =
     static_cast<axom::sidre::Buffer *>(buff->addr);
   axom::sidre::View *SHCXX_rv =
@@ -677,7 +677,7 @@ SIDRE_View *SIDRE_Group_create_view_external_bufferify(SIDRE_Group *self,
 
 SIDRE_View *SIDRE_Group_create_view_from_type_external(SIDRE_Group *self,
                                                        const char *path,
-                                                       int type,
+                                                       SIDRE_TypeID type,
                                                        SIDRE_IndexType num_elems,
                                                        void *external_ptr,
                                                        SIDRE_View *SHC_rv)
@@ -685,7 +685,7 @@ SIDRE_View *SIDRE_Group_create_view_from_type_external(SIDRE_Group *self,
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_type_external
   const std::string SHCXX_path(path);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, num_elems, external_ptr);
   // C_error_pattern
@@ -706,7 +706,7 @@ SIDRE_View *SIDRE_Group_create_view_from_type_external_bufferify(
   SIDRE_Group *self,
   const char *path,
   int Lpath,
-  int type,
+  SIDRE_TypeID type,
   SIDRE_IndexType num_elems,
   void *external_ptr,
   SIDRE_View *SHC_rv)
@@ -714,7 +714,7 @@ SIDRE_View *SIDRE_Group_create_view_from_type_external_bufferify(
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_from_type_external_bufferify
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::View *SHCXX_rv =
     SH_this->createView(SHCXX_path, SHCXX_type, num_elems, external_ptr);
   SHC_rv->addr = SHCXX_rv;
@@ -725,7 +725,7 @@ SIDRE_View *SIDRE_Group_create_view_from_type_external_bufferify(
 
 SIDRE_View *SIDRE_Group_create_view_with_shape_external(SIDRE_Group *self,
                                                         const char *path,
-                                                        int type,
+                                                        SIDRE_TypeID type,
                                                         int ndims,
                                                         const SIDRE_IndexType *shape,
                                                         void *external_ptr,
@@ -734,7 +734,7 @@ SIDRE_View *SIDRE_Group_create_view_with_shape_external(SIDRE_Group *self,
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_with_shape_external
   const std::string SHCXX_path(path);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::View *SHCXX_rv =
     SH_this->createViewWithShape(SHCXX_path, SHCXX_type, ndims, shape, external_ptr);
   // C_error_pattern
@@ -755,7 +755,7 @@ SIDRE_View *SIDRE_Group_create_view_with_shape_external_bufferify(
   SIDRE_Group *self,
   const char *path,
   int Lpath,
-  int type,
+  SIDRE_TypeID type,
   int ndims,
   const SIDRE_IndexType *shape,
   void *external_ptr,
@@ -764,7 +764,7 @@ SIDRE_View *SIDRE_Group_create_view_with_shape_external_bufferify(
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_with_shape_external_bufferify
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::View *SHCXX_rv =
     SH_this->createViewWithShape(SHCXX_path, SHCXX_type, ndims, shape, external_ptr);
   SHC_rv->addr = SHCXX_rv;
@@ -775,14 +775,14 @@ SIDRE_View *SIDRE_Group_create_view_with_shape_external_bufferify(
 
 SIDRE_View *SIDRE_Group_create_view_and_allocate_nelems(SIDRE_Group *self,
                                                         const char *path,
-                                                        int type,
+                                                        SIDRE_TypeID type,
                                                         SIDRE_IndexType num_elems,
                                                         SIDRE_View *SHC_rv)
 {
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_and_allocate_nelems
   const std::string SHCXX_path(path);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::View *SHCXX_rv =
     SH_this->createViewAndAllocate(SHCXX_path, SHCXX_type, num_elems);
   // C_error_pattern
@@ -803,14 +803,14 @@ SIDRE_View *SIDRE_Group_create_view_and_allocate_nelems_bufferify(
   SIDRE_Group *self,
   const char *path,
   int Lpath,
-  int type,
+  SIDRE_TypeID type,
   SIDRE_IndexType num_elems,
   SIDRE_View *SHC_rv)
 {
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_and_allocate_nelems_bufferify
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::View *SHCXX_rv =
     SH_this->createViewAndAllocate(SHCXX_path, SHCXX_type, num_elems);
   SHC_rv->addr = SHCXX_rv;
@@ -822,7 +822,7 @@ SIDRE_View *SIDRE_Group_create_view_and_allocate_nelems_bufferify(
 SIDRE_View *SIDRE_Group_create_view_with_shape_and_allocate(
   SIDRE_Group *self,
   const char *path,
-  int type,
+  SIDRE_TypeID type,
   int ndims,
   const SIDRE_IndexType *shape,
   SIDRE_View *SHC_rv)
@@ -830,7 +830,7 @@ SIDRE_View *SIDRE_Group_create_view_with_shape_and_allocate(
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_with_shape_and_allocate
   const std::string SHCXX_path(path);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::View *SHCXX_rv =
     SH_this->createViewWithShapeAndAllocate(SHCXX_path, SHCXX_type, ndims, shape);
   // C_error_pattern
@@ -851,7 +851,7 @@ SIDRE_View *SIDRE_Group_create_view_with_shape_and_allocate_bufferify(
   SIDRE_Group *self,
   const char *path,
   int Lpath,
-  int type,
+  SIDRE_TypeID type,
   int ndims,
   const SIDRE_IndexType *shape,
   SIDRE_View *SHC_rv)
@@ -859,7 +859,7 @@ SIDRE_View *SIDRE_Group_create_view_with_shape_and_allocate_bufferify(
   axom::sidre::Group *SH_this = static_cast<axom::sidre::Group *>(self->addr);
   // splicer begin class.Group.method.create_view_with_shape_and_allocate_bufferify
   const std::string SHCXX_path(path, Lpath);
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::View *SHCXX_rv =
     SH_this->createViewWithShapeAndAllocate(SHCXX_path, SHCXX_type, ndims, shape);
   SHC_rv->addr = SHCXX_rv;

--- a/src/axom/sidre/interface/c_fortran/wrapGroup.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapGroup.cpp
@@ -12,7 +12,6 @@
 #include "axom/sidre/core/DataStore.hpp"
 #include "axom/sidre/core/Group.hpp"
 #include "axom/sidre/core/View.hpp"
-#include "axom/sidre/interface/SidreTypes.h"
 
 // splicer begin class.Group.CXX_definitions
 // splicer end class.Group.CXX_definitions

--- a/src/axom/sidre/interface/c_fortran/wrapGroup.h
+++ b/src/axom/sidre/interface/c_fortran/wrapGroup.h
@@ -115,20 +115,20 @@ SIDRE_View* SIDRE_Group_create_view_empty_bufferify(SIDRE_Group* self,
 
 SIDRE_View* SIDRE_Group_create_view_from_type(SIDRE_Group* self,
                                               const char* path,
-                                              int type,
+                                              SIDRE_TypeID type,
                                               SIDRE_IndexType num_elems,
                                               SIDRE_View* SHC_rv);
 
 SIDRE_View* SIDRE_Group_create_view_from_type_bufferify(SIDRE_Group* self,
                                                         const char* path,
                                                         int Lpath,
-                                                        int type,
+                                                        SIDRE_TypeID type,
                                                         SIDRE_IndexType num_elems,
                                                         SIDRE_View* SHC_rv);
 
 SIDRE_View* SIDRE_Group_create_view_with_shape_base(SIDRE_Group* self,
                                                     const char* path,
-                                                    int type,
+                                                    SIDRE_TypeID type,
                                                     int ndims,
                                                     const SIDRE_IndexType* shape,
                                                     SIDRE_View* SHC_rv);
@@ -137,7 +137,7 @@ SIDRE_View* SIDRE_Group_create_view_with_shape_base_bufferify(
   SIDRE_Group* self,
   const char* path,
   int Lpath,
-  int type,
+  SIDRE_TypeID type,
   int ndims,
   const SIDRE_IndexType* shape,
   SIDRE_View* SHC_rv);
@@ -155,7 +155,7 @@ SIDRE_View* SIDRE_Group_create_view_into_buffer_bufferify(SIDRE_Group* self,
 
 SIDRE_View* SIDRE_Group_create_view_from_type_and_buffer(SIDRE_Group* self,
                                                          const char* path,
-                                                         int type,
+                                                         SIDRE_TypeID type,
                                                          SIDRE_IndexType num_elems,
                                                          SIDRE_Buffer* buff,
                                                          SIDRE_View* SHC_rv);
@@ -164,14 +164,14 @@ SIDRE_View* SIDRE_Group_create_view_from_type_and_buffer_bufferify(
   SIDRE_Group* self,
   const char* path,
   int Lpath,
-  int type,
+  SIDRE_TypeID type,
   SIDRE_IndexType num_elems,
   SIDRE_Buffer* buff,
   SIDRE_View* SHC_rv);
 
 SIDRE_View* SIDRE_Group_create_view_with_shape_and_buffer(SIDRE_Group* self,
                                                           const char* path,
-                                                          int type,
+                                                          SIDRE_TypeID type,
                                                           int ndims,
                                                           const SIDRE_IndexType* shape,
                                                           SIDRE_Buffer* buff,
@@ -181,7 +181,7 @@ SIDRE_View* SIDRE_Group_create_view_with_shape_and_buffer_bufferify(
   SIDRE_Group* self,
   const char* path,
   int Lpath,
-  int type,
+  SIDRE_TypeID type,
   int ndims,
   const SIDRE_IndexType* shape,
   SIDRE_Buffer* buff,
@@ -200,7 +200,7 @@ SIDRE_View* SIDRE_Group_create_view_external_bufferify(SIDRE_Group* self,
 
 SIDRE_View* SIDRE_Group_create_view_from_type_external(SIDRE_Group* self,
                                                        const char* path,
-                                                       int type,
+                                                       SIDRE_TypeID type,
                                                        SIDRE_IndexType num_elems,
                                                        void* external_ptr,
                                                        SIDRE_View* SHC_rv);
@@ -209,14 +209,14 @@ SIDRE_View* SIDRE_Group_create_view_from_type_external_bufferify(
   SIDRE_Group* self,
   const char* path,
   int Lpath,
-  int type,
+  SIDRE_TypeID type,
   SIDRE_IndexType num_elems,
   void* external_ptr,
   SIDRE_View* SHC_rv);
 
 SIDRE_View* SIDRE_Group_create_view_with_shape_external(SIDRE_Group* self,
                                                         const char* path,
-                                                        int type,
+                                                        SIDRE_TypeID type,
                                                         int ndims,
                                                         const SIDRE_IndexType* shape,
                                                         void* external_ptr,
@@ -226,7 +226,7 @@ SIDRE_View* SIDRE_Group_create_view_with_shape_external_bufferify(
   SIDRE_Group* self,
   const char* path,
   int Lpath,
-  int type,
+  SIDRE_TypeID type,
   int ndims,
   const SIDRE_IndexType* shape,
   void* external_ptr,
@@ -234,7 +234,7 @@ SIDRE_View* SIDRE_Group_create_view_with_shape_external_bufferify(
 
 SIDRE_View* SIDRE_Group_create_view_and_allocate_nelems(SIDRE_Group* self,
                                                         const char* path,
-                                                        int type,
+                                                        SIDRE_TypeID type,
                                                         SIDRE_IndexType num_elems,
                                                         SIDRE_View* SHC_rv);
 
@@ -242,14 +242,14 @@ SIDRE_View* SIDRE_Group_create_view_and_allocate_nelems_bufferify(
   SIDRE_Group* self,
   const char* path,
   int Lpath,
-  int type,
+  SIDRE_TypeID type,
   SIDRE_IndexType num_elems,
   SIDRE_View* SHC_rv);
 
 SIDRE_View* SIDRE_Group_create_view_with_shape_and_allocate(
   SIDRE_Group* self,
   const char* path,
-  int type,
+  SIDRE_TypeID type,
   int ndims,
   const SIDRE_IndexType* shape,
   SIDRE_View* SHC_rv);
@@ -258,7 +258,7 @@ SIDRE_View* SIDRE_Group_create_view_with_shape_and_allocate_bufferify(
   SIDRE_Group* self,
   const char* path,
   int Lpath,
-  int type,
+  SIDRE_TypeID type,
   int ndims,
   const SIDRE_IndexType* shape,
   SIDRE_View* SHC_rv);

--- a/src/axom/sidre/interface/c_fortran/wrapGroup.h
+++ b/src/axom/sidre/interface/c_fortran/wrapGroup.h
@@ -14,15 +14,14 @@
 #ifndef WRAPGROUP_H
 #define WRAPGROUP_H
 
+#include "axom/sidre/interface/SidreTypes.h"
 #include "typesSidre.h"
 #ifdef __cplusplus
   #include <cstddef>
-  #include <cstdint>
   #include "axom/sidre/core/SidreTypes.hpp"
 #else
   #include <stdbool.h>
   #include <stddef.h>
-  #include "axom/sidre/interface/SidreTypes.h"
 #endif
 
 // splicer begin class.Group.CXX_declarations

--- a/src/axom/sidre/interface/c_fortran/wrapView.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapView.cpp
@@ -11,7 +11,6 @@
 #include "axom/sidre/core/Buffer.hpp"
 #include "axom/sidre/core/Group.hpp"
 #include "axom/sidre/core/View.hpp"
-#include "axom/sidre/interface/SidreTypes.h"
 
 // splicer begin class.View.CXX_definitions
 // splicer end class.View.CXX_definitions

--- a/src/axom/sidre/interface/c_fortran/wrapView.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapView.cpp
@@ -222,13 +222,13 @@ bool SIDRE_View_is_string(const SIDRE_View *self)
   // splicer end class.View.method.is_string
 }
 
-int SIDRE_View_get_type_id(const SIDRE_View *self)
+SIDRE_TypeID SIDRE_View_get_type_id(const SIDRE_View *self)
 {
   const axom::sidre::View *SH_this =
     static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_type_id
   axom::sidre::TypeID SHCXX_rv = SH_this->getTypeID();
-  int SHC_rv = static_cast<int>(SHCXX_rv);
+  SIDRE_TypeID SHC_rv = static_cast<SIDRE_TypeID>(SHCXX_rv);
   return SHC_rv;
   // splicer end class.View.method.get_type_id
 }
@@ -312,12 +312,12 @@ void SIDRE_View_allocate_simple(SIDRE_View *self)
 }
 
 void SIDRE_View_allocate_from_type(SIDRE_View *self,
-                                   int type,
+                                   SIDRE_TypeID type,
                                    SIDRE_IndexType num_elems)
 {
   axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.allocate_from_type
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   SH_this->allocate(SHCXX_type, num_elems);
   // splicer end class.View.method.allocate_from_type
 }
@@ -341,13 +341,13 @@ void SIDRE_View_attach_buffer_only(SIDRE_View *self, SIDRE_Buffer *buff)
 }
 
 void SIDRE_View_attach_buffer_type(SIDRE_View *self,
-                                   int type,
+                                   SIDRE_TypeID type,
                                    SIDRE_IndexType num_elems,
                                    SIDRE_Buffer *buff)
 {
   axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.attach_buffer_type
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::Buffer *SHCXX_buff =
     static_cast<axom::sidre::Buffer *>(buff->addr);
   SH_this->attachBuffer(SHCXX_type, num_elems, SHCXX_buff);
@@ -355,14 +355,14 @@ void SIDRE_View_attach_buffer_type(SIDRE_View *self,
 }
 
 void SIDRE_View_attach_buffer_shape(SIDRE_View *self,
-                                    int type,
+                                    SIDRE_TypeID type,
                                     int ndims,
                                     const SIDRE_IndexType *shape,
                                     SIDRE_Buffer *buff)
 {
   axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.attach_buffer_shape
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   axom::sidre::Buffer *SHCXX_buff =
     static_cast<axom::sidre::Buffer *>(buff->addr);
   SH_this->attachBuffer(SHCXX_type, ndims, shape, SHCXX_buff);
@@ -415,49 +415,49 @@ void SIDRE_View_apply_nelems_offset_stride(SIDRE_View *self,
 }
 
 void SIDRE_View_apply_type_nelems(SIDRE_View *self,
-                                  int type,
+                                  SIDRE_TypeID type,
                                   SIDRE_IndexType num_elems)
 {
   axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.apply_type_nelems
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   SH_this->apply(SHCXX_type, num_elems);
   // splicer end class.View.method.apply_type_nelems
 }
 
 void SIDRE_View_apply_type_nelems_offset(SIDRE_View *self,
-                                         int type,
+                                         SIDRE_TypeID type,
                                          SIDRE_IndexType num_elems,
                                          SIDRE_IndexType offset)
 {
   axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.apply_type_nelems_offset
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   SH_this->apply(SHCXX_type, num_elems, offset);
   // splicer end class.View.method.apply_type_nelems_offset
 }
 
 void SIDRE_View_apply_type_nelems_offset_stride(SIDRE_View *self,
-                                                int type,
+                                                SIDRE_TypeID type,
                                                 SIDRE_IndexType num_elems,
                                                 SIDRE_IndexType offset,
                                                 SIDRE_IndexType stride)
 {
   axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.apply_type_nelems_offset_stride
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   SH_this->apply(SHCXX_type, num_elems, offset, stride);
   // splicer end class.View.method.apply_type_nelems_offset_stride
 }
 
 void SIDRE_View_apply_type_shape(SIDRE_View *self,
-                                 int type,
+                                 SIDRE_TypeID type,
                                  int ndims,
                                  const SIDRE_IndexType *shape)
 {
   axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.apply_type_shape
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   SH_this->apply(SHCXX_type, ndims, shape);
   // splicer end class.View.method.apply_type_shape
 }
@@ -521,26 +521,26 @@ void SIDRE_View_set_external_data_ptr_only(SIDRE_View *self, void *external_ptr)
 }
 
 void SIDRE_View_set_external_data_ptr_type(SIDRE_View *self,
-                                           int type,
+                                           SIDRE_TypeID type,
                                            SIDRE_IndexType num_elems,
                                            void *external_ptr)
 {
   axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.set_external_data_ptr_type
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   SH_this->setExternalDataPtr(SHCXX_type, num_elems, external_ptr);
   // splicer end class.View.method.set_external_data_ptr_type
 }
 
 void SIDRE_View_set_external_data_ptr_shape(SIDRE_View *self,
-                                            int type,
+                                            SIDRE_TypeID type,
                                             int ndims,
                                             const SIDRE_IndexType *shape,
                                             void *external_ptr)
 {
   axom::sidre::View *SH_this = static_cast<axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.set_external_data_ptr_shape
-  axom::sidre::TypeID SHCXX_type = axom::sidre::getTypeID(type);
+  axom::sidre::TypeID SHCXX_type = static_cast<axom::sidre::TypeID>(type);
   SH_this->setExternalDataPtr(SHCXX_type, ndims, shape, external_ptr);
   // splicer end class.View.method.set_external_data_ptr_shape
 }

--- a/src/axom/sidre/interface/c_fortran/wrapView.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapView.cpp
@@ -222,13 +222,13 @@ bool SIDRE_View_is_string(const SIDRE_View *self)
   // splicer end class.View.method.is_string
 }
 
-SIDRE_TypeID SIDRE_View_get_type_id(const SIDRE_View *self)
+SIDRE_TypeIDint SIDRE_View_get_type_id(const SIDRE_View *self)
 {
   const axom::sidre::View *SH_this =
     static_cast<const axom::sidre::View *>(self->addr);
   // splicer begin class.View.method.get_type_id
   axom::sidre::TypeID SHCXX_rv = SH_this->getTypeID();
-  SIDRE_TypeID SHC_rv = static_cast<SIDRE_TypeID>(SHCXX_rv);
+  SIDRE_TypeIDint SHC_rv = static_cast<SIDRE_TypeIDint>(SHCXX_rv);
   return SHC_rv;
   // splicer end class.View.method.get_type_id
 }

--- a/src/axom/sidre/interface/c_fortran/wrapView.h
+++ b/src/axom/sidre/interface/c_fortran/wrapView.h
@@ -72,7 +72,7 @@ bool SIDRE_View_is_scalar(const SIDRE_View* self);
 
 bool SIDRE_View_is_string(const SIDRE_View* self);
 
-int SIDRE_View_get_type_id(const SIDRE_View* self);
+SIDRE_TypeID SIDRE_View_get_type_id(const SIDRE_View* self);
 
 size_t SIDRE_View_get_total_bytes(const SIDRE_View* self);
 
@@ -91,7 +91,7 @@ int SIDRE_View_get_shape(const SIDRE_View* self, int ndims, SIDRE_IndexType* sha
 void SIDRE_View_allocate_simple(SIDRE_View* self);
 
 void SIDRE_View_allocate_from_type(SIDRE_View* self,
-                                   int type,
+                                   SIDRE_TypeID type,
                                    SIDRE_IndexType num_elems);
 
 void SIDRE_View_reallocate(SIDRE_View* self, SIDRE_IndexType num_elems);
@@ -99,12 +99,12 @@ void SIDRE_View_reallocate(SIDRE_View* self, SIDRE_IndexType num_elems);
 void SIDRE_View_attach_buffer_only(SIDRE_View* self, SIDRE_Buffer* buff);
 
 void SIDRE_View_attach_buffer_type(SIDRE_View* self,
-                                   int type,
+                                   SIDRE_TypeID type,
                                    SIDRE_IndexType num_elems,
                                    SIDRE_Buffer* buff);
 
 void SIDRE_View_attach_buffer_shape(SIDRE_View* self,
-                                    int type,
+                                    SIDRE_TypeID type,
                                     int ndims,
                                     const SIDRE_IndexType* shape,
                                     SIDRE_Buffer* buff);
@@ -125,22 +125,22 @@ void SIDRE_View_apply_nelems_offset_stride(SIDRE_View* self,
                                            SIDRE_IndexType stride);
 
 void SIDRE_View_apply_type_nelems(SIDRE_View* self,
-                                  int type,
+                                  SIDRE_TypeID type,
                                   SIDRE_IndexType num_elems);
 
 void SIDRE_View_apply_type_nelems_offset(SIDRE_View* self,
-                                         int type,
+                                         SIDRE_TypeID type,
                                          SIDRE_IndexType num_elems,
                                          SIDRE_IndexType offset);
 
 void SIDRE_View_apply_type_nelems_offset_stride(SIDRE_View* self,
-                                                int type,
+                                                SIDRE_TypeID type,
                                                 SIDRE_IndexType num_elems,
                                                 SIDRE_IndexType offset,
                                                 SIDRE_IndexType stride);
 
 void SIDRE_View_apply_type_shape(SIDRE_View* self,
-                                 int type,
+                                 SIDRE_TypeID type,
                                  int ndims,
                                  const SIDRE_IndexType* shape);
 
@@ -161,12 +161,12 @@ void SIDRE_View_set_string_bufferify(SIDRE_View* self,
 void SIDRE_View_set_external_data_ptr_only(SIDRE_View* self, void* external_ptr);
 
 void SIDRE_View_set_external_data_ptr_type(SIDRE_View* self,
-                                           int type,
+                                           SIDRE_TypeID type,
                                            SIDRE_IndexType num_elems,
                                            void* external_ptr);
 
 void SIDRE_View_set_external_data_ptr_shape(SIDRE_View* self,
-                                            int type,
+                                            SIDRE_TypeID type,
                                             int ndims,
                                             const SIDRE_IndexType* shape,
                                             void* external_ptr);

--- a/src/axom/sidre/interface/c_fortran/wrapView.h
+++ b/src/axom/sidre/interface/c_fortran/wrapView.h
@@ -72,7 +72,7 @@ bool SIDRE_View_is_scalar(const SIDRE_View* self);
 
 bool SIDRE_View_is_string(const SIDRE_View* self);
 
-SIDRE_TypeID SIDRE_View_get_type_id(const SIDRE_View* self);
+SIDRE_TypeIDint SIDRE_View_get_type_id(const SIDRE_View* self);
 
 size_t SIDRE_View_get_total_bytes(const SIDRE_View* self);
 

--- a/src/axom/sidre/interface/c_fortran/wrapView.h
+++ b/src/axom/sidre/interface/c_fortran/wrapView.h
@@ -14,15 +14,14 @@
 #ifndef WRAPVIEW_H
 #define WRAPVIEW_H
 
+#include "axom/sidre/interface/SidreTypes.h"
 #include "typesSidre.h"
 #ifdef __cplusplus
   #include <cstddef>
-  #include <cstdint>
   #include "axom/sidre/core/SidreTypes.hpp"
 #else
   #include <stdbool.h>
   #include <stddef.h>
-  #include "axom/sidre/interface/SidreTypes.h"
 #endif
 
 // splicer begin class.View.CXX_declarations

--- a/src/axom/sidre/interface/c_fortran/wrapfsidre.F
+++ b/src/axom/sidre/interface/c_fortran/wrapfsidre.F
@@ -15,34 +15,57 @@
 module axom_sidre
     use iso_c_binding, only : C_INT, C_NULL_PTR, C_PTR
     ! splicer begin module_use
-    ! map conduit type names to sidre type names
     use conduit, only : &
-        SIDRE_NO_TYPE_ID    => CONDUIT_EMPTY_ID, &
-        SIDRE_INT8_ID       => CONDUIT_INT8_ID, &
-        SIDRE_INT16_ID      => CONDUIT_INT16_ID, &
-        SIDRE_INT32_ID      => CONDUIT_INT32_ID, &
-        SIDRE_INT64_ID      => CONDUIT_INT64_ID, &
-        SIDRE_UINT8_ID      => CONDUIT_UINT8_ID, &
-        SIDRE_UINT16_ID     => CONDUIT_UINT16_ID, &
-        SIDRE_UINT32_ID     => CONDUIT_UINT32_ID, &
-        SIDRE_UINT64_ID     => CONDUIT_UINT64_ID, &
-        SIDRE_FLOAT32_ID    => CONDUIT_FLOAT32_ID, &
-        SIDRE_FLOAT64_ID    => CONDUIT_FLOAT64_ID, &
-        SIDRE_CHAR8_STR_ID  => CONDUIT_CHAR8_STR_ID, &
-        SIDRE_INT_ID        => CONDUIT_INT_ID, &
-        SIDRE_UINT_ID       => CONDUIT_UINT_ID, &
-        SIDRE_LONG_ID       => CONDUIT_LONG_ID, &
-        SIDRE_ULONG_ID      => CONDUIT_ULONG_ID, &
-        SIDRE_FLOAT_ID      => CONDUIT_FLOAT_ID, &
-        SIDRE_DOUBLE_ID     => CONDUIT_DOUBLE_ID
-    use, intrinsic :: iso_c_binding, only : C_INT64_T
+        CONDUIT_EMPTY_ID, &
+        CONDUIT_INT8_ID, &
+        CONDUIT_INT16_ID, &
+        CONDUIT_INT32_ID, &
+        CONDUIT_INT64_ID, &
+        CONDUIT_UINT8_ID, &
+        CONDUIT_UINT16_ID, &
+        CONDUIT_UINT32_ID, &
+        CONDUIT_UINT64_ID, &
+        CONDUIT_FLOAT32_ID, &
+        CONDUIT_FLOAT64_ID, &
+        CONDUIT_CHAR8_STR_ID, &
+        CONDUIT_INT_ID, &
+        CONDUIT_UINT_ID, &
+        CONDUIT_LONG_ID, &
+        CONDUIT_ULONG_ID, &
+        CONDUIT_FLOAT_ID, &
+        CONDUIT_DOUBLE_ID
+    use, intrinsic :: iso_c_binding, only : C_INT32_T, C_INT64_T
     ! splicer end module_use
     implicit none
 
     ! splicer begin module_top
     integer, parameter :: MAXNAMESIZE = 128
 
+#if defined(AXOM_USE_64BIT_INDEXTYPE) && !defined(AXOM_NO_INT64_T)
     integer, parameter :: SIDRE_IndexType = C_INT64_T
+#else
+    integer, parameter :: SIDRE_IndexType = C_INT64_T
+#endif
+
+    integer, parameter :: &
+        SIDRE_NO_TYPE_ID    = CONDUIT_EMPTY_ID, &
+        SIDRE_INT8_ID       = CONDUIT_INT8_ID, &
+        SIDRE_INT16_ID      = CONDUIT_INT16_ID, &
+        SIDRE_INT32_ID      = CONDUIT_INT32_ID, &
+        SIDRE_INT64_ID      = CONDUIT_INT64_ID, &
+        SIDRE_UINT8_ID      = CONDUIT_UINT8_ID, &
+        SIDRE_UINT16_ID     = CONDUIT_UINT16_ID, &
+        SIDRE_UINT32_ID     = CONDUIT_UINT32_ID, &
+        SIDRE_UINT64_ID     = CONDUIT_UINT64_ID, &
+        SIDRE_FLOAT32_ID    = CONDUIT_FLOAT32_ID, &
+        SIDRE_FLOAT64_ID    = CONDUIT_FLOAT64_ID, &
+        SIDRE_CHAR8_STR_ID  = CONDUIT_CHAR8_STR_ID, &
+        SIDRE_INT_ID        = CONDUIT_INT_ID, &
+        SIDRE_UINT_ID       = CONDUIT_UINT_ID, &
+        SIDRE_LONG_ID       = CONDUIT_LONG_ID, &
+        SIDRE_ULONG_ID      = CONDUIT_ULONG_ID, &
+        SIDRE_FLOAT_ID      = CONDUIT_FLOAT_ID, &
+        SIDRE_DOUBLE_ID     = CONDUIT_DOUBLE_ID
 
     integer, parameter :: invalid_index = -1_SIDRE_IndexType
     ! splicer end module_top
@@ -540,11 +563,10 @@ module axom_sidre
         pure function c_buffer_get_index(self) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Buffer_get_index")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_buffer_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule
             implicit none
             type(SIDRE_SHROUD_buffer_capsule), intent(IN) :: self
-            integer(C_INT64_T) :: SHT_rv
+            integer(SIDRE_IndexType) :: SHT_rv
         end function c_buffer_get_index
 
         pure function c_buffer_get_num_views(self) &
@@ -609,12 +631,12 @@ module axom_sidre
 
         subroutine c_buffer_describe(self, type, num_elems) &
                 bind(C, name="SIDRE_Buffer_describe")
-            use iso_c_binding, only : C_INT, C_INT64_T
-            import :: SIDRE_SHROUD_buffer_capsule
+            use iso_c_binding, only : C_INT
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule
             implicit none
             type(SIDRE_SHROUD_buffer_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         end subroutine c_buffer_describe
 
         subroutine c_buffer_allocate_existing(self) &
@@ -626,21 +648,20 @@ module axom_sidre
 
         subroutine c_buffer_allocate_from_type(self, type, num_elems) &
                 bind(C, name="SIDRE_Buffer_allocate_from_type")
-            use iso_c_binding, only : C_INT, C_INT64_T
-            import :: SIDRE_SHROUD_buffer_capsule
+            use iso_c_binding, only : C_INT
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule
             implicit none
             type(SIDRE_SHROUD_buffer_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         end subroutine c_buffer_allocate_from_type
 
         subroutine c_buffer_reallocate(self, num_elems) &
                 bind(C, name="SIDRE_Buffer_reallocate")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_buffer_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule
             implicit none
             type(SIDRE_SHROUD_buffer_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         end subroutine c_buffer_reallocate
 
         subroutine c_buffer_print(self) &
@@ -656,11 +677,10 @@ module axom_sidre
         function c_group_get_index(self) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_get_index")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_group_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
-            integer(C_INT64_T) :: SHT_rv
+            integer(SIDRE_IndexType) :: SHT_rv
         end function c_group_get_index
 
         pure function c_group_get_name(self) &
@@ -796,46 +816,46 @@ module axom_sidre
         pure function c_group_get_view_index(self, name) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_get_view_index")
-            use iso_c_binding, only : C_CHAR, C_INT64_T
-            import :: SIDRE_SHROUD_group_capsule
+            use iso_c_binding, only : C_CHAR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: name(*)
-            integer(C_INT64_T) :: SHT_rv
+            integer(SIDRE_IndexType) :: SHT_rv
         end function c_group_get_view_index
 
         pure function c_group_get_view_index_bufferify(self, name, &
                 Lname) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_get_view_index_bufferify")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T
-            import :: SIDRE_SHROUD_group_capsule
+            use iso_c_binding, only : C_CHAR, C_INT
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: name(*)
             integer(C_INT), value, intent(IN) :: Lname
-            integer(C_INT64_T) :: SHT_rv
+            integer(SIDRE_IndexType) :: SHT_rv
         end function c_group_get_view_index_bufferify
 
         pure function c_group_get_view_name(self, idx) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_get_view_name")
-            use iso_c_binding, only : C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule
+            use iso_c_binding, only : C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: idx
+            integer(SIDRE_IndexType), value, intent(IN) :: idx
             type(C_PTR) SHT_rv
         end function c_group_get_view_name
 
         subroutine c_group_get_view_name_bufferify(self, idx, SHF_rv, &
                 NSHF_rv) &
                 bind(C, name="SIDRE_Group_get_view_name_bufferify")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T
-            import :: SIDRE_SHROUD_group_capsule
+            use iso_c_binding, only : C_CHAR, C_INT
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: idx
+            integer(SIDRE_IndexType), value, intent(IN) :: idx
             character(kind=C_CHAR), intent(OUT) :: SHF_rv(*)
             integer(C_INT), value, intent(IN) :: NSHF_rv
         end subroutine c_group_get_view_name_bufferify
@@ -869,11 +889,11 @@ module axom_sidre
         function c_group_get_view_from_index(self, idx, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_get_view_from_index")
-            use iso_c_binding, only : C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: idx
+            integer(SIDRE_IndexType), value, intent(IN) :: idx
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_group_get_view_from_index
@@ -881,22 +901,20 @@ module axom_sidre
         pure function c_group_get_first_valid_view_index(self) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_get_first_valid_view_index")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_group_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
-            integer(C_INT64_T) :: SHT_rv
+            integer(SIDRE_IndexType) :: SHT_rv
         end function c_group_get_first_valid_view_index
 
         pure function c_group_get_next_valid_view_index(self, idx) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_get_next_valid_view_index")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_group_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: idx
-            integer(C_INT64_T) :: SHT_rv
+            integer(SIDRE_IndexType), value, intent(IN) :: idx
+            integer(SIDRE_IndexType) :: SHT_rv
         end function c_group_get_next_valid_view_index
 
         function c_group_create_view_empty(self, path, SHT_crv) &
@@ -929,13 +947,13 @@ module axom_sidre
                 num_elems, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_from_type")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_group_create_view_from_type
@@ -944,14 +962,14 @@ module axom_sidre
                 Lpath, type, num_elems, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_from_type_bufferify")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_group_create_view_from_type_bufferify
@@ -960,14 +978,14 @@ module axom_sidre
                 ndims, shape, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_base")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
-            integer(C_INT64_T), intent(IN) :: shape(*)
+            integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_group_create_view_with_shape_base
@@ -976,15 +994,15 @@ module axom_sidre
                 path, Lpath, type, ndims, shape, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_base_bufferify")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
             integer(C_INT), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
-            integer(C_INT64_T), intent(IN) :: shape(*)
+            integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_group_create_view_with_shape_base_bufferify
@@ -1022,13 +1040,13 @@ module axom_sidre
                 type, num_elems, buff, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_from_type_and_buffer")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_buffer_capsule), intent(INOUT) :: buff
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
@@ -1038,14 +1056,14 @@ module axom_sidre
                 self, path, Lpath, type, num_elems, buff, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_from_type_and_buffer_bufferify")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_buffer_capsule), intent(INOUT) :: buff
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
@@ -1055,14 +1073,14 @@ module axom_sidre
                 type, ndims, shape, buff, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_and_buffer")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
-            integer(C_INT64_T), intent(IN) :: shape(*)
+            integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_buffer_capsule), intent(INOUT) :: buff
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
@@ -1072,15 +1090,15 @@ module axom_sidre
                 self, path, Lpath, type, ndims, shape, buff, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_and_buffer_bufferify")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
             integer(C_INT), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
-            integer(C_INT64_T), intent(IN) :: shape(*)
+            integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_buffer_capsule), intent(INOUT) :: buff
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
@@ -1119,13 +1137,13 @@ module axom_sidre
                 type, num_elems, external_ptr, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_from_type_external")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(C_PTR), value, intent(IN) :: external_ptr
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
@@ -1135,14 +1153,14 @@ module axom_sidre
                 path, Lpath, type, num_elems, external_ptr, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_from_type_external_bufferify")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(C_PTR), value, intent(IN) :: external_ptr
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
@@ -1152,14 +1170,14 @@ module axom_sidre
                 type, ndims, shape, external_ptr, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_external")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
-            integer(C_INT64_T), intent(IN) :: shape(*)
+            integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(C_PTR), value, intent(IN) :: external_ptr
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
@@ -1169,15 +1187,15 @@ module axom_sidre
                 path, Lpath, type, ndims, shape, external_ptr, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_external_bufferify")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
             integer(C_INT), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
-            integer(C_INT64_T), intent(IN) :: shape(*)
+            integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(C_PTR), value, intent(IN) :: external_ptr
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
@@ -1187,13 +1205,13 @@ module axom_sidre
                 type, num_elems, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_and_allocate_nelems")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_group_create_view_and_allocate_nelems
@@ -1202,14 +1220,14 @@ module axom_sidre
                 path, Lpath, type, num_elems, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_and_allocate_nelems_bufferify")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_group_create_view_and_allocate_nelems_bufferify
@@ -1218,14 +1236,14 @@ module axom_sidre
                 type, ndims, shape, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_and_allocate")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
-            integer(C_INT64_T), intent(IN) :: shape(*)
+            integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_group_create_view_with_shape_and_allocate
@@ -1234,15 +1252,15 @@ module axom_sidre
                 self, path, Lpath, type, ndims, shape, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_and_allocate_bufferify")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
             integer(C_INT), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
-            integer(C_INT64_T), intent(IN) :: shape(*)
+            integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_group_create_view_with_shape_and_allocate_bufferify
@@ -1433,11 +1451,10 @@ module axom_sidre
 
         subroutine c_group_destroy_view_and_data_index(self, idx) &
                 bind(C, name="SIDRE_Group_destroy_view_and_data_index")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_group_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: idx
+            integer(SIDRE_IndexType), value, intent(IN) :: idx
         end subroutine c_group_destroy_view_and_data_index
 
         function c_group_move_view(self, view, SHT_crv) &
@@ -1513,46 +1530,46 @@ module axom_sidre
         pure function c_group_get_group_index(self, name) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_get_group_index")
-            use iso_c_binding, only : C_CHAR, C_INT64_T
-            import :: SIDRE_SHROUD_group_capsule
+            use iso_c_binding, only : C_CHAR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: name(*)
-            integer(C_INT64_T) :: SHT_rv
+            integer(SIDRE_IndexType) :: SHT_rv
         end function c_group_get_group_index
 
         pure function c_group_get_group_index_bufferify(self, name, &
                 Lname) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_get_group_index_bufferify")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T
-            import :: SIDRE_SHROUD_group_capsule
+            use iso_c_binding, only : C_CHAR, C_INT
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: name(*)
             integer(C_INT), value, intent(IN) :: Lname
-            integer(C_INT64_T) :: SHT_rv
+            integer(SIDRE_IndexType) :: SHT_rv
         end function c_group_get_group_index_bufferify
 
         pure function c_group_get_group_name(self, idx) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_get_group_name")
-            use iso_c_binding, only : C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule
+            use iso_c_binding, only : C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: idx
+            integer(SIDRE_IndexType), value, intent(IN) :: idx
             type(C_PTR) SHT_rv
         end function c_group_get_group_name
 
         subroutine c_group_get_group_name_bufferify(self, idx, SHF_rv, &
                 NSHF_rv) &
                 bind(C, name="SIDRE_Group_get_group_name_bufferify")
-            use iso_c_binding, only : C_CHAR, C_INT, C_INT64_T
-            import :: SIDRE_SHROUD_group_capsule
+            use iso_c_binding, only : C_CHAR, C_INT
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: idx
+            integer(SIDRE_IndexType), value, intent(IN) :: idx
             character(kind=C_CHAR), intent(OUT) :: SHF_rv(*)
             integer(C_INT), value, intent(IN) :: NSHF_rv
         end subroutine c_group_get_group_name_bufferify
@@ -1586,11 +1603,11 @@ module axom_sidre
         function c_group_get_group_from_index(self, idx, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_get_group_from_index")
-            use iso_c_binding, only : C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_group_capsule
+            use iso_c_binding, only : C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: idx
+            integer(SIDRE_IndexType), value, intent(IN) :: idx
             type(SIDRE_SHROUD_group_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_group_get_group_from_index
@@ -1598,22 +1615,20 @@ module axom_sidre
         pure function c_group_get_first_valid_group_index(self) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_get_first_valid_group_index")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_group_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
-            integer(C_INT64_T) :: SHT_rv
+            integer(SIDRE_IndexType) :: SHT_rv
         end function c_group_get_first_valid_group_index
 
         pure function c_group_get_next_valid_group_index(self, idx) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_get_next_valid_group_index")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_group_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: idx
-            integer(C_INT64_T) :: SHT_rv
+            integer(SIDRE_IndexType), value, intent(IN) :: idx
+            integer(SIDRE_IndexType) :: SHT_rv
         end function c_group_get_next_valid_group_index
 
         function c_group_create_group(self, path, SHT_crv) &
@@ -1664,11 +1679,10 @@ module axom_sidre
 
         subroutine c_group_destroy_group_index(self, idx) &
                 bind(C, name="SIDRE_Group_destroy_group_index")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_group_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: idx
+            integer(SIDRE_IndexType), value, intent(IN) :: idx
         end subroutine c_group_destroy_group_index
 
         function c_group_move_group(self, grp, SHT_crv) &
@@ -1822,11 +1836,10 @@ module axom_sidre
         function c_view_get_index(self) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_View_get_index")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT64_T) :: SHT_rv
+            integer(SIDRE_IndexType) :: SHT_rv
         end function c_view_get_index
 
         pure function c_view_get_name(self) &
@@ -2054,12 +2067,12 @@ module axom_sidre
         function c_view_get_shape(self, ndims, shape) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_View_get_shape")
-            use iso_c_binding, only : C_INT, C_INT64_T
-            import :: SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_INT
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: ndims
-            integer(C_INT64_T), intent(OUT) :: shape(*)
+            integer(SIDRE_IndexType), intent(OUT) :: shape(*)
             integer(C_INT) :: SHT_rv
         end function c_view_get_shape
 
@@ -2072,21 +2085,20 @@ module axom_sidre
 
         subroutine c_view_allocate_from_type(self, type, num_elems) &
                 bind(C, name="SIDRE_View_allocate_from_type")
-            use iso_c_binding, only : C_INT, C_INT64_T
-            import :: SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_INT
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         end subroutine c_view_allocate_from_type
 
         subroutine c_view_reallocate(self, num_elems) &
                 bind(C, name="SIDRE_View_reallocate")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         end subroutine c_view_reallocate
 
         subroutine c_view_attach_buffer_only(self, buff) &
@@ -2100,25 +2112,25 @@ module axom_sidre
         subroutine c_view_attach_buffer_type(self, type, num_elems, &
                 buff) &
                 bind(C, name="SIDRE_View_attach_buffer_type")
-            use iso_c_binding, only : C_INT, C_INT64_T
-            import :: SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_INT
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_buffer_capsule), intent(INOUT) :: buff
         end subroutine c_view_attach_buffer_type
 
         subroutine c_view_attach_buffer_shape(self, type, ndims, shape, &
                 buff) &
                 bind(C, name="SIDRE_View_attach_buffer_shape")
-            use iso_c_binding, only : C_INT, C_INT64_T
-            import :: SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_INT
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
-            integer(C_INT64_T), intent(IN) :: shape(*)
+            integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_buffer_capsule), intent(INOUT) :: buff
         end subroutine c_view_attach_buffer_shape
 
@@ -2138,79 +2150,76 @@ module axom_sidre
 
         subroutine c_view_apply_nelems(self, num_elems) &
                 bind(C, name="SIDRE_View_apply_nelems")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         end subroutine c_view_apply_nelems
 
         subroutine c_view_apply_nelems_offset(self, num_elems, offset) &
                 bind(C, name="SIDRE_View_apply_nelems_offset")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: num_elems
-            integer(C_INT64_T), value, intent(IN) :: offset
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: offset
         end subroutine c_view_apply_nelems_offset
 
         subroutine c_view_apply_nelems_offset_stride(self, num_elems, &
                 offset, stride) &
                 bind(C, name="SIDRE_View_apply_nelems_offset_stride")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: num_elems
-            integer(C_INT64_T), value, intent(IN) :: offset
-            integer(C_INT64_T), value, intent(IN) :: stride
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: offset
+            integer(SIDRE_IndexType), value, intent(IN) :: stride
         end subroutine c_view_apply_nelems_offset_stride
 
         subroutine c_view_apply_type_nelems(self, type, num_elems) &
                 bind(C, name="SIDRE_View_apply_type_nelems")
-            use iso_c_binding, only : C_INT, C_INT64_T
-            import :: SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_INT
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         end subroutine c_view_apply_type_nelems
 
         subroutine c_view_apply_type_nelems_offset(self, type, &
                 num_elems, offset) &
                 bind(C, name="SIDRE_View_apply_type_nelems_offset")
-            use iso_c_binding, only : C_INT, C_INT64_T
-            import :: SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_INT
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
-            integer(C_INT64_T), value, intent(IN) :: offset
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: offset
         end subroutine c_view_apply_type_nelems_offset
 
         subroutine c_view_apply_type_nelems_offset_stride(self, type, &
                 num_elems, offset, stride) &
                 bind(C, name="SIDRE_View_apply_type_nelems_offset_stride")
-            use iso_c_binding, only : C_INT, C_INT64_T
-            import :: SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_INT
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
-            integer(C_INT64_T), value, intent(IN) :: offset
-            integer(C_INT64_T), value, intent(IN) :: stride
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: offset
+            integer(SIDRE_IndexType), value, intent(IN) :: stride
         end subroutine c_view_apply_type_nelems_offset_stride
 
         subroutine c_view_apply_type_shape(self, type, ndims, shape) &
                 bind(C, name="SIDRE_View_apply_type_shape")
-            use iso_c_binding, only : C_INT, C_INT64_T
-            import :: SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_INT
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
-            integer(C_INT64_T), intent(IN) :: shape(*)
+            integer(SIDRE_IndexType), intent(IN) :: shape(*)
         end subroutine c_view_apply_type_shape
 
         subroutine c_view_set_scalar_int(self, value) &
@@ -2280,25 +2289,25 @@ module axom_sidre
         subroutine c_view_set_external_data_ptr_type(self, type, &
                 num_elems, external_ptr) &
                 bind(C, name="SIDRE_View_set_external_data_ptr_type")
-            use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(C_PTR), value, intent(IN) :: external_ptr
         end subroutine c_view_set_external_data_ptr_type
 
         subroutine c_view_set_external_data_ptr_shape(self, type, ndims, &
                 shape, external_ptr) &
                 bind(C, name="SIDRE_View_set_external_data_ptr_shape")
-            use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
-            integer(C_INT64_T), intent(IN) :: shape(*)
+            integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(C_PTR), value, intent(IN) :: external_ptr
         end subroutine c_view_set_external_data_ptr_shape
 
@@ -2446,11 +2455,11 @@ module axom_sidre
         function c_datastore_get_buffer(self, idx, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_DataStore_get_buffer")
-            use iso_c_binding, only : C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_datastore_capsule
+            use iso_c_binding, only : C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_datastore_capsule
             implicit none
             type(SIDRE_SHROUD_datastore_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: idx
+            integer(SIDRE_IndexType), value, intent(IN) :: idx
             type(SIDRE_SHROUD_buffer_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_datastore_get_buffer
@@ -2470,23 +2479,22 @@ module axom_sidre
                 num_elems, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_DataStore_create_buffer_from_type")
-            use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
-            import :: SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_datastore_capsule
+            use iso_c_binding, only : C_INT, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_datastore_capsule
             implicit none
             type(SIDRE_SHROUD_datastore_capsule), intent(IN) :: self
             integer(C_INT), value, intent(IN) :: type
-            integer(C_INT64_T), value, intent(IN) :: num_elems
+            integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_buffer_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
         end function c_datastore_create_buffer_from_type
 
         subroutine c_datastore_destroy_buffer(self, id) &
                 bind(C, name="SIDRE_DataStore_destroy_buffer")
-            use iso_c_binding, only : C_INT64_T
-            import :: SIDRE_SHROUD_datastore_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_datastore_capsule
             implicit none
             type(SIDRE_SHROUD_datastore_capsule), intent(IN) :: self
-            integer(C_INT64_T), value, intent(IN) :: id
+            integer(SIDRE_IndexType), value, intent(IN) :: id
         end subroutine c_datastore_destroy_buffer
 
         function c_datastore_generate_blueprint_index_0(self, &
@@ -2607,7 +2615,7 @@ contains
             result(SHT_rv)
         use iso_c_binding, only : C_INT64_T
         class(SidreBuffer) :: obj
-        integer(C_INT64_T) :: SHT_rv
+        integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.Buffer.method.get_index
         SHT_rv = c_buffer_get_index(obj%cxxmem)
         ! splicer end class.Buffer.method.get_index
@@ -2779,7 +2787,7 @@ contains
             result(SHT_rv)
         use iso_c_binding, only : C_INT64_T
         class(SidreGroup) :: obj
-        integer(C_INT64_T) :: SHT_rv
+        integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.Group.method.get_index
         SHT_rv = c_group_get_index(obj%cxxmem)
         ! splicer end class.Group.method.get_index
@@ -2889,7 +2897,7 @@ contains
         use iso_c_binding, only : C_INT, C_INT64_T
         class(SidreGroup) :: obj
         character(len=*), intent(IN) :: name
-        integer(C_INT64_T) :: SHT_rv
+        integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.Group.method.get_view_index
         SHT_rv = c_group_get_view_index_bufferify(obj%cxxmem, name, &
             len_trim(name, kind=C_INT))
@@ -2963,7 +2971,7 @@ contains
             result(SHT_rv)
         use iso_c_binding, only : C_INT64_T
         class(SidreGroup) :: obj
-        integer(C_INT64_T) :: SHT_rv
+        integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.Group.method.get_first_valid_view_index
         SHT_rv = c_group_get_first_valid_view_index(obj%cxxmem)
         ! splicer end class.Group.method.get_first_valid_view_index
@@ -2974,7 +2982,7 @@ contains
         use iso_c_binding, only : C_INT32_T, C_INT64_T
         class(SidreGroup) :: obj
         integer(C_INT32_T), value, intent(IN) :: idx
-        integer(C_INT64_T) :: SHT_rv
+        integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.Group.method.get_next_valid_view_index_int32_t
         SHT_rv = c_group_get_next_valid_view_index(obj%cxxmem, &
             int(idx, C_INT64_t))
@@ -2986,7 +2994,7 @@ contains
         use iso_c_binding, only : C_INT64_T
         class(SidreGroup) :: obj
         integer(C_INT64_T), value, intent(IN) :: idx
-        integer(C_INT64_T) :: SHT_rv
+        integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.Group.method.get_next_valid_view_index_int64_t
         SHT_rv = c_group_get_next_valid_view_index(obj%cxxmem, &
             int(idx, C_INT64_t))
@@ -3048,7 +3056,7 @@ contains
         character(len=*), intent(IN) :: path
         integer(C_INT), value, intent(IN) :: type
         integer(C_INT), value, intent(IN) :: ndims
-        integer(C_INT64_T), intent(IN) :: shape(:)
+        integer(SIDRE_IndexType), intent(IN) :: shape(:)
         type(SidreView) :: SHT_rv
         ! splicer begin class.Group.method.create_view_with_shape_base
         type(C_PTR) :: SHT_prv
@@ -3117,7 +3125,7 @@ contains
         character(len=*), intent(IN) :: path
         integer(C_INT), value, intent(IN) :: type
         integer(C_INT), value, intent(IN) :: ndims
-        integer(C_INT64_T), intent(IN) :: shape(:)
+        integer(SIDRE_IndexType), intent(IN) :: shape(:)
         type(SidreBuffer), intent(INOUT) :: buff
         type(SidreView) :: SHT_rv
         ! splicer begin class.Group.method.create_view_with_shape_and_buffer
@@ -3187,7 +3195,7 @@ contains
         character(len=*), intent(IN) :: path
         integer(C_INT), value, intent(IN) :: type
         integer(C_INT), value, intent(IN) :: ndims
-        integer(C_INT64_T), intent(IN) :: shape(:)
+        integer(SIDRE_IndexType), intent(IN) :: shape(:)
         type(C_PTR), intent(IN) :: external_ptr
         type(SidreView) :: SHT_rv
         ! splicer begin class.Group.method.create_view_with_shape_external
@@ -3240,7 +3248,7 @@ contains
         character(len=*), intent(IN) :: path
         integer(C_INT), value, intent(IN) :: type
         integer(C_INT), value, intent(IN) :: ndims
-        integer(C_INT64_T), intent(IN) :: shape(:)
+        integer(SIDRE_IndexType), intent(IN) :: shape(:)
         type(SidreView) :: SHT_rv
         ! splicer begin class.Group.method.create_view_with_shape_and_allocate
         type(C_PTR) :: SHT_prv
@@ -3416,7 +3424,7 @@ contains
         use iso_c_binding, only : C_INT, C_INT64_T
         class(SidreGroup) :: obj
         character(len=*), intent(IN) :: name
-        integer(C_INT64_T) :: SHT_rv
+        integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.Group.method.get_group_index
         SHT_rv = c_group_get_group_index_bufferify(obj%cxxmem, name, &
             len_trim(name, kind=C_INT))
@@ -3490,7 +3498,7 @@ contains
             result(SHT_rv)
         use iso_c_binding, only : C_INT64_T
         class(SidreGroup) :: obj
-        integer(C_INT64_T) :: SHT_rv
+        integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.Group.method.get_first_valid_group_index
         SHT_rv = c_group_get_first_valid_group_index(obj%cxxmem)
         ! splicer end class.Group.method.get_first_valid_group_index
@@ -3501,7 +3509,7 @@ contains
         use iso_c_binding, only : C_INT32_T, C_INT64_T
         class(SidreGroup) :: obj
         integer(C_INT32_T), value, intent(IN) :: idx
-        integer(C_INT64_T) :: SHT_rv
+        integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.Group.method.get_next_valid_group_index_int32_t
         SHT_rv = c_group_get_next_valid_group_index(obj%cxxmem, &
             int(idx, C_INT64_t))
@@ -3513,7 +3521,7 @@ contains
         use iso_c_binding, only : C_INT64_T
         class(SidreGroup) :: obj
         integer(C_INT64_T), value, intent(IN) :: idx
-        integer(C_INT64_T) :: SHT_rv
+        integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.Group.method.get_next_valid_group_index_int64_t
         SHT_rv = c_group_get_next_valid_group_index(obj%cxxmem, &
             int(idx, C_INT64_t))
@@ -4934,7 +4942,7 @@ contains
             result(SHT_rv)
         use iso_c_binding, only : C_INT64_T
         class(SidreView) :: obj
-        integer(C_INT64_T) :: SHT_rv
+        integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.View.method.get_index
         SHT_rv = c_view_get_index(obj%cxxmem)
         ! splicer end class.View.method.get_index
@@ -5160,7 +5168,7 @@ contains
         use iso_c_binding, only : C_INT, C_INT64_T
         class(SidreView) :: obj
         integer(C_INT), value, intent(IN) :: ndims
-        integer(C_INT64_T), intent(OUT) :: shape(:)
+        integer(SIDRE_IndexType), intent(OUT) :: shape(:)
         integer(C_INT) :: SHT_rv
         ! splicer begin class.View.method.get_shape
         SHT_rv = c_view_get_shape(obj%cxxmem, ndims, shape)
@@ -5253,7 +5261,7 @@ contains
         class(SidreView) :: obj
         integer(C_INT), value, intent(IN) :: type
         integer(C_INT), value, intent(IN) :: ndims
-        integer(C_INT64_T), intent(IN) :: shape(:)
+        integer(SIDRE_IndexType), intent(IN) :: shape(:)
         type(SidreBuffer), intent(INOUT) :: buff
         ! splicer begin class.View.method.attach_buffer_shape
         call c_view_attach_buffer_shape(obj%cxxmem, type, ndims, shape, &
@@ -5278,7 +5286,7 @@ contains
     subroutine view_apply_nelems(obj, num_elems)
         use iso_c_binding, only : C_INT64_T
         class(SidreView) :: obj
-        integer(C_INT64_T), value, intent(IN) :: num_elems
+        integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         ! splicer begin class.View.method.apply_nelems
         call c_view_apply_nelems(obj%cxxmem, num_elems)
         ! splicer end class.View.method.apply_nelems
@@ -5287,8 +5295,8 @@ contains
     subroutine view_apply_nelems_offset(obj, num_elems, offset)
         use iso_c_binding, only : C_INT64_T
         class(SidreView) :: obj
-        integer(C_INT64_T), value, intent(IN) :: num_elems
-        integer(C_INT64_T), value, intent(IN) :: offset
+        integer(SIDRE_IndexType), value, intent(IN) :: num_elems
+        integer(SIDRE_IndexType), value, intent(IN) :: offset
         ! splicer begin class.View.method.apply_nelems_offset
         call c_view_apply_nelems_offset(obj%cxxmem, num_elems, offset)
         ! splicer end class.View.method.apply_nelems_offset
@@ -5298,9 +5306,9 @@ contains
             stride)
         use iso_c_binding, only : C_INT64_T
         class(SidreView) :: obj
-        integer(C_INT64_T), value, intent(IN) :: num_elems
-        integer(C_INT64_T), value, intent(IN) :: offset
-        integer(C_INT64_T), value, intent(IN) :: stride
+        integer(SIDRE_IndexType), value, intent(IN) :: num_elems
+        integer(SIDRE_IndexType), value, intent(IN) :: offset
+        integer(SIDRE_IndexType), value, intent(IN) :: stride
         ! splicer begin class.View.method.apply_nelems_offset_stride
         call c_view_apply_nelems_offset_stride(obj%cxxmem, num_elems, &
             offset, stride)
@@ -5311,7 +5319,7 @@ contains
         use iso_c_binding, only : C_INT, C_INT64_T
         class(SidreView) :: obj
         integer(C_INT), value, intent(IN) :: type
-        integer(C_INT64_T), value, intent(IN) :: num_elems
+        integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         ! splicer begin class.View.method.apply_type_nelems
         call c_view_apply_type_nelems(obj%cxxmem, type, num_elems)
         ! splicer end class.View.method.apply_type_nelems
@@ -5322,8 +5330,8 @@ contains
         use iso_c_binding, only : C_INT, C_INT64_T
         class(SidreView) :: obj
         integer(C_INT), value, intent(IN) :: type
-        integer(C_INT64_T), value, intent(IN) :: num_elems
-        integer(C_INT64_T), value, intent(IN) :: offset
+        integer(SIDRE_IndexType), value, intent(IN) :: num_elems
+        integer(SIDRE_IndexType), value, intent(IN) :: offset
         ! splicer begin class.View.method.apply_type_nelems_offset
         call c_view_apply_type_nelems_offset(obj%cxxmem, type, &
             num_elems, offset)
@@ -5335,9 +5343,9 @@ contains
         use iso_c_binding, only : C_INT, C_INT64_T
         class(SidreView) :: obj
         integer(C_INT), value, intent(IN) :: type
-        integer(C_INT64_T), value, intent(IN) :: num_elems
-        integer(C_INT64_T), value, intent(IN) :: offset
-        integer(C_INT64_T), value, intent(IN) :: stride
+        integer(SIDRE_IndexType), value, intent(IN) :: num_elems
+        integer(SIDRE_IndexType), value, intent(IN) :: offset
+        integer(SIDRE_IndexType), value, intent(IN) :: stride
         ! splicer begin class.View.method.apply_type_nelems_offset_stride
         call c_view_apply_type_nelems_offset_stride(obj%cxxmem, type, &
             num_elems, offset, stride)
@@ -5349,7 +5357,7 @@ contains
         class(SidreView) :: obj
         integer(C_INT), value, intent(IN) :: type
         integer(C_INT), value, intent(IN) :: ndims
-        integer(C_INT64_T), intent(IN) :: shape(:)
+        integer(SIDRE_IndexType), intent(IN) :: shape(:)
         ! splicer begin class.View.method.apply_type_shape
         call c_view_apply_type_shape(obj%cxxmem, type, ndims, shape)
         ! splicer end class.View.method.apply_type_shape
@@ -5442,7 +5450,7 @@ contains
         class(SidreView) :: obj
         integer(C_INT), value, intent(IN) :: type
         integer(C_INT), value, intent(IN) :: ndims
-        integer(C_INT64_T), intent(IN) :: shape(:)
+        integer(SIDRE_IndexType), intent(IN) :: shape(:)
         type(C_PTR), intent(IN) :: external_ptr
         ! splicer begin class.View.method.set_external_data_ptr_shape
         call c_view_set_external_data_ptr_shape(obj%cxxmem, type, ndims, &

--- a/src/axom/sidre/interface/c_fortran/wrapfsidre.F
+++ b/src/axom/sidre/interface/c_fortran/wrapfsidre.F
@@ -34,7 +34,7 @@ module axom_sidre
         CONDUIT_ULONG_ID, &
         CONDUIT_FLOAT_ID, &
         CONDUIT_DOUBLE_ID
-    use, intrinsic :: iso_c_binding, only : C_SHORT, C_INT32_T, C_INT64_T
+    use, intrinsic :: iso_c_binding, only : C_SHORT, C_INT, C_INT32_T, C_INT64_T
     ! splicer end module_use
     implicit none
 
@@ -48,6 +48,7 @@ module axom_sidre
 #endif
 
     integer, parameter :: TypeID = C_SHORT
+    integer, parameter :: TypeIDint = C_INT
 
     integer(TypeID), parameter :: &
         SIDRE_NO_TYPE_ID    = CONDUIT_EMPTY_ID, &
@@ -594,10 +595,10 @@ module axom_sidre
         pure function c_buffer_get_type_id(self) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Buffer_get_type_id")
-            import :: SIDRE_SHROUD_buffer_capsule, TypeID
+            import :: SIDRE_SHROUD_buffer_capsule, TypeIDint
             implicit none
             type(SIDRE_SHROUD_buffer_capsule), intent(IN) :: self
-            integer(TypeID) :: SHT_rv
+            integer(TypeIDint) :: SHT_rv
         end function c_buffer_get_type_id
 
         pure function c_buffer_get_num_elements(self) &
@@ -1996,10 +1997,10 @@ module axom_sidre
         pure function c_view_get_type_id(self) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_View_get_type_id")
-            import :: SIDRE_SHROUD_view_capsule, TypeID
+            import :: SIDRE_SHROUD_view_capsule, TypeIDint
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(TypeID) :: SHT_rv
+            integer(TypeIDint) :: SHT_rv
         end function c_view_get_type_id
 
         pure function c_view_get_total_bytes(self) &
@@ -2636,9 +2637,9 @@ contains
 
     function buffer_get_type_id(obj) &
             result(SHT_rv)
-        use iso_c_binding, only : C_SHORT
+        use iso_c_binding, only : C_INT
         class(SidreBuffer) :: obj
-        integer(TypeID) :: SHT_rv
+        integer(TypeIDint) :: SHT_rv
         ! splicer begin class.Buffer.method.get_type_id
         SHT_rv = c_buffer_get_type_id(obj%cxxmem)
         ! splicer end class.Buffer.method.get_type_id
@@ -5092,9 +5093,9 @@ contains
 
     function view_get_type_id(obj) &
             result(SHT_rv)
-        use iso_c_binding, only : C_SHORT
+        use iso_c_binding, only : C_INT
         class(SidreView) :: obj
-        integer(TypeID) :: SHT_rv
+        integer(TypeIDint) :: SHT_rv
         ! splicer begin class.View.method.get_type_id
         SHT_rv = c_view_get_type_id(obj%cxxmem)
         ! splicer end class.View.method.get_type_id

--- a/src/axom/sidre/interface/c_fortran/wrapfsidre.F
+++ b/src/axom/sidre/interface/c_fortran/wrapfsidre.F
@@ -34,7 +34,7 @@ module axom_sidre
         CONDUIT_ULONG_ID, &
         CONDUIT_FLOAT_ID, &
         CONDUIT_DOUBLE_ID
-    use, intrinsic :: iso_c_binding, only : C_INT32_T, C_INT64_T
+    use, intrinsic :: iso_c_binding, only : C_SHORT, C_INT32_T, C_INT64_T
     ! splicer end module_use
     implicit none
 
@@ -44,10 +44,12 @@ module axom_sidre
 #if defined(AXOM_USE_64BIT_INDEXTYPE) && !defined(AXOM_NO_INT64_T)
     integer, parameter :: SIDRE_IndexType = C_INT64_T
 #else
-    integer, parameter :: SIDRE_IndexType = C_INT64_T
+    integer, parameter :: SIDRE_IndexType = C_INT32_T
 #endif
 
-    integer, parameter :: &
+    integer, parameter :: TypeID = C_SHORT
+
+    integer(TypeID), parameter :: &
         SIDRE_NO_TYPE_ID    = CONDUIT_EMPTY_ID, &
         SIDRE_INT8_ID       = CONDUIT_INT8_ID, &
         SIDRE_INT16_ID      = CONDUIT_INT16_ID, &
@@ -592,11 +594,10 @@ module axom_sidre
         pure function c_buffer_get_type_id(self) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Buffer_get_type_id")
-            use iso_c_binding, only : C_INT
-            import :: SIDRE_SHROUD_buffer_capsule
+            import :: SIDRE_SHROUD_buffer_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_buffer_capsule), intent(IN) :: self
-            integer(C_INT) :: SHT_rv
+            integer(TypeID) :: SHT_rv
         end function c_buffer_get_type_id
 
         pure function c_buffer_get_num_elements(self) &
@@ -631,11 +632,10 @@ module axom_sidre
 
         subroutine c_buffer_describe(self, type, num_elems) &
                 bind(C, name="SIDRE_Buffer_describe")
-            use iso_c_binding, only : C_INT
-            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_buffer_capsule), intent(IN) :: self
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         end subroutine c_buffer_describe
 
@@ -648,11 +648,10 @@ module axom_sidre
 
         subroutine c_buffer_allocate_from_type(self, type, num_elems) &
                 bind(C, name="SIDRE_Buffer_allocate_from_type")
-            use iso_c_binding, only : C_INT
-            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_buffer_capsule), intent(IN) :: self
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         end subroutine c_buffer_allocate_from_type
 
@@ -947,12 +946,12 @@ module axom_sidre
                 num_elems, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_from_type")
-            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
@@ -963,12 +962,12 @@ module axom_sidre
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_from_type_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
@@ -979,11 +978,11 @@ module axom_sidre
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_base")
             use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
             integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
@@ -995,12 +994,12 @@ module axom_sidre
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_base_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
             integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
@@ -1040,12 +1039,12 @@ module axom_sidre
                 type, num_elems, buff, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_from_type_and_buffer")
-            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_buffer_capsule), intent(INOUT) :: buff
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
@@ -1057,12 +1056,12 @@ module axom_sidre
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_from_type_and_buffer_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_buffer_capsule), intent(INOUT) :: buff
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
@@ -1074,11 +1073,11 @@ module axom_sidre
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_and_buffer")
             use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
             integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_buffer_capsule), intent(INOUT) :: buff
@@ -1091,12 +1090,12 @@ module axom_sidre
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_and_buffer_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
             integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_buffer_capsule), intent(INOUT) :: buff
@@ -1137,12 +1136,12 @@ module axom_sidre
                 type, num_elems, external_ptr, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_from_type_external")
-            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(C_PTR), value, intent(IN) :: external_ptr
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
@@ -1154,12 +1153,12 @@ module axom_sidre
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_from_type_external_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(C_PTR), value, intent(IN) :: external_ptr
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
@@ -1171,11 +1170,11 @@ module axom_sidre
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_external")
             use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
             integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(C_PTR), value, intent(IN) :: external_ptr
@@ -1188,12 +1187,12 @@ module axom_sidre
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_external_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
             integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(C_PTR), value, intent(IN) :: external_ptr
@@ -1205,12 +1204,12 @@ module axom_sidre
                 type, num_elems, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_and_allocate_nelems")
-            use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_CHAR, C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
@@ -1221,12 +1220,12 @@ module axom_sidre
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_and_allocate_nelems_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
@@ -1237,11 +1236,11 @@ module axom_sidre
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_and_allocate")
             use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
             integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
@@ -1253,12 +1252,12 @@ module axom_sidre
                 result(SHT_rv) &
                 bind(C, name="SIDRE_Group_create_view_with_shape_and_allocate_bufferify")
             use iso_c_binding, only : C_CHAR, C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_group_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_group_capsule), intent(IN) :: self
             character(kind=C_CHAR), intent(IN) :: path(*)
             integer(C_INT), value, intent(IN) :: Lpath
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
             integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_view_capsule), intent(OUT) :: SHT_crv
@@ -1997,11 +1996,10 @@ module axom_sidre
         pure function c_view_get_type_id(self) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_View_get_type_id")
-            use iso_c_binding, only : C_INT
-            import :: SIDRE_SHROUD_view_capsule
+            import :: SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT) :: SHT_rv
+            integer(TypeID) :: SHT_rv
         end function c_view_get_type_id
 
         pure function c_view_get_total_bytes(self) &
@@ -2085,11 +2083,10 @@ module axom_sidre
 
         subroutine c_view_allocate_from_type(self, type, num_elems) &
                 bind(C, name="SIDRE_View_allocate_from_type")
-            use iso_c_binding, only : C_INT
-            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         end subroutine c_view_allocate_from_type
 
@@ -2112,11 +2109,10 @@ module axom_sidre
         subroutine c_view_attach_buffer_type(self, type, num_elems, &
                 buff) &
                 bind(C, name="SIDRE_View_attach_buffer_type")
-            use iso_c_binding, only : C_INT
-            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_buffer_capsule), intent(INOUT) :: buff
         end subroutine c_view_attach_buffer_type
@@ -2125,10 +2121,10 @@ module axom_sidre
                 buff) &
                 bind(C, name="SIDRE_View_attach_buffer_shape")
             use iso_c_binding, only : C_INT
-            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
             integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(SIDRE_SHROUD_buffer_capsule), intent(INOUT) :: buff
@@ -2178,22 +2174,20 @@ module axom_sidre
 
         subroutine c_view_apply_type_nelems(self, type, num_elems) &
                 bind(C, name="SIDRE_View_apply_type_nelems")
-            use iso_c_binding, only : C_INT
-            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         end subroutine c_view_apply_type_nelems
 
         subroutine c_view_apply_type_nelems_offset(self, type, &
                 num_elems, offset) &
                 bind(C, name="SIDRE_View_apply_type_nelems_offset")
-            use iso_c_binding, only : C_INT
-            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             integer(SIDRE_IndexType), value, intent(IN) :: offset
         end subroutine c_view_apply_type_nelems_offset
@@ -2201,11 +2195,10 @@ module axom_sidre
         subroutine c_view_apply_type_nelems_offset_stride(self, type, &
                 num_elems, offset, stride) &
                 bind(C, name="SIDRE_View_apply_type_nelems_offset_stride")
-            use iso_c_binding, only : C_INT
-            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             integer(SIDRE_IndexType), value, intent(IN) :: offset
             integer(SIDRE_IndexType), value, intent(IN) :: stride
@@ -2214,10 +2207,10 @@ module axom_sidre
         subroutine c_view_apply_type_shape(self, type, ndims, shape) &
                 bind(C, name="SIDRE_View_apply_type_shape")
             use iso_c_binding, only : C_INT
-            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
             integer(SIDRE_IndexType), intent(IN) :: shape(*)
         end subroutine c_view_apply_type_shape
@@ -2289,11 +2282,11 @@ module axom_sidre
         subroutine c_view_set_external_data_ptr_type(self, type, &
                 num_elems, external_ptr) &
                 bind(C, name="SIDRE_View_set_external_data_ptr_type")
-            use iso_c_binding, only : C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
+            use iso_c_binding, only : C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(C_PTR), value, intent(IN) :: external_ptr
         end subroutine c_view_set_external_data_ptr_type
@@ -2302,10 +2295,10 @@ module axom_sidre
                 shape, external_ptr) &
                 bind(C, name="SIDRE_View_set_external_data_ptr_shape")
             use iso_c_binding, only : C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule
+            import :: SIDRE_IndexType, SIDRE_SHROUD_view_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_view_capsule), intent(IN) :: self
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(C_INT), value, intent(IN) :: ndims
             integer(SIDRE_IndexType), intent(IN) :: shape(*)
             type(C_PTR), value, intent(IN) :: external_ptr
@@ -2479,11 +2472,11 @@ module axom_sidre
                 num_elems, SHT_crv) &
                 result(SHT_rv) &
                 bind(C, name="SIDRE_DataStore_create_buffer_from_type")
-            use iso_c_binding, only : C_INT, C_PTR
-            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_datastore_capsule
+            use iso_c_binding, only : C_PTR
+            import :: SIDRE_IndexType, SIDRE_SHROUD_buffer_capsule, SIDRE_SHROUD_datastore_capsule, TypeID
             implicit none
             type(SIDRE_SHROUD_datastore_capsule), intent(IN) :: self
-            integer(C_INT), value, intent(IN) :: type
+            integer(TypeID), value, intent(IN) :: type
             integer(SIDRE_IndexType), value, intent(IN) :: num_elems
             type(SIDRE_SHROUD_buffer_capsule), intent(OUT) :: SHT_crv
             type(C_PTR) SHT_rv
@@ -2643,9 +2636,9 @@ contains
 
     function buffer_get_type_id(obj) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT
+        use iso_c_binding, only : C_SHORT
         class(SidreBuffer) :: obj
-        integer(C_INT) :: SHT_rv
+        integer(TypeID) :: SHT_rv
         ! splicer begin class.Buffer.method.get_type_id
         SHT_rv = c_buffer_get_type_id(obj%cxxmem)
         ! splicer end class.Buffer.method.get_type_id
@@ -2682,24 +2675,24 @@ contains
     end function buffer_get_bytes_per_element
 
     subroutine buffer_describe_int32_t(obj, type, num_elems)
-        use iso_c_binding, only : C_INT, C_INT32_T, C_INT64_T
+        use iso_c_binding, only : C_INT32_T, C_INT64_T, C_SHORT
         class(SidreBuffer) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT32_T), value, intent(IN) :: num_elems
         ! splicer begin class.Buffer.method.describe_int32_t
         call c_buffer_describe(obj%cxxmem, type, &
-            int(num_elems, C_INT64_t))
+            int(num_elems, SIDRE_IndexType))
         ! splicer end class.Buffer.method.describe_int32_t
     end subroutine buffer_describe_int32_t
 
     subroutine buffer_describe_int64_t(obj, type, num_elems)
-        use iso_c_binding, only : C_INT, C_INT64_T
+        use iso_c_binding, only : C_INT64_T, C_SHORT
         class(SidreBuffer) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT64_T), value, intent(IN) :: num_elems
         ! splicer begin class.Buffer.method.describe_int64_t
         call c_buffer_describe(obj%cxxmem, type, &
-            int(num_elems, C_INT64_t))
+            int(num_elems, SIDRE_IndexType))
         ! splicer end class.Buffer.method.describe_int64_t
     end subroutine buffer_describe_int64_t
 
@@ -2711,24 +2704,24 @@ contains
     end subroutine buffer_allocate_existing
 
     subroutine buffer_allocate_from_type_int32_t(obj, type, num_elems)
-        use iso_c_binding, only : C_INT, C_INT32_T, C_INT64_T
+        use iso_c_binding, only : C_INT32_T, C_INT64_T, C_SHORT
         class(SidreBuffer) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT32_T), value, intent(IN) :: num_elems
         ! splicer begin class.Buffer.method.allocate_from_type_int32_t
         call c_buffer_allocate_from_type(obj%cxxmem, type, &
-            int(num_elems, C_INT64_t))
+            int(num_elems, SIDRE_IndexType))
         ! splicer end class.Buffer.method.allocate_from_type_int32_t
     end subroutine buffer_allocate_from_type_int32_t
 
     subroutine buffer_allocate_from_type_int64_t(obj, type, num_elems)
-        use iso_c_binding, only : C_INT, C_INT64_T
+        use iso_c_binding, only : C_INT64_T, C_SHORT
         class(SidreBuffer) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT64_T), value, intent(IN) :: num_elems
         ! splicer begin class.Buffer.method.allocate_from_type_int64_t
         call c_buffer_allocate_from_type(obj%cxxmem, type, &
-            int(num_elems, C_INT64_t))
+            int(num_elems, SIDRE_IndexType))
         ! splicer end class.Buffer.method.allocate_from_type_int64_t
     end subroutine buffer_allocate_from_type_int64_t
 
@@ -2737,7 +2730,8 @@ contains
         class(SidreBuffer) :: obj
         integer(C_INT32_T), value, intent(IN) :: num_elems
         ! splicer begin class.Buffer.method.reallocate_int32_t
-        call c_buffer_reallocate(obj%cxxmem, int(num_elems, C_INT64_t))
+        call c_buffer_reallocate(obj%cxxmem, &
+            int(num_elems, SIDRE_IndexType))
         ! splicer end class.Buffer.method.reallocate_int32_t
     end subroutine buffer_reallocate_int32_t
 
@@ -2746,7 +2740,8 @@ contains
         class(SidreBuffer) :: obj
         integer(C_INT64_T), value, intent(IN) :: num_elems
         ! splicer begin class.Buffer.method.reallocate_int64_t
-        call c_buffer_reallocate(obj%cxxmem, int(num_elems, C_INT64_t))
+        call c_buffer_reallocate(obj%cxxmem, &
+            int(num_elems, SIDRE_IndexType))
         ! splicer end class.Buffer.method.reallocate_int64_t
     end subroutine buffer_reallocate_int64_t
 
@@ -2912,7 +2907,7 @@ contains
         character(len=MAXNAMESIZE) :: SHT_rv
         ! splicer begin class.Group.method.get_view_name_int32_t
         call c_group_get_view_name_bufferify(obj%cxxmem, &
-            int(idx, C_INT64_t), SHT_rv, len(SHT_rv, kind=C_INT))
+            int(idx, SIDRE_IndexType), SHT_rv, len(SHT_rv, kind=C_INT))
         ! splicer end class.Group.method.get_view_name_int32_t
     end function group_get_view_name_int32_t
 
@@ -2924,7 +2919,7 @@ contains
         character(len=MAXNAMESIZE) :: SHT_rv
         ! splicer begin class.Group.method.get_view_name_int64_t
         call c_group_get_view_name_bufferify(obj%cxxmem, &
-            int(idx, C_INT64_t), SHT_rv, len(SHT_rv, kind=C_INT))
+            int(idx, SIDRE_IndexType), SHT_rv, len(SHT_rv, kind=C_INT))
         ! splicer end class.Group.method.get_view_name_int64_t
     end function group_get_view_name_int64_t
 
@@ -2950,7 +2945,7 @@ contains
         ! splicer begin class.Group.method.get_view_from_index_int32_t
         type(C_PTR) :: SHT_prv
         SHT_prv = c_group_get_view_from_index(obj%cxxmem, &
-            int(idx, C_INT64_t), SHT_rv%cxxmem)
+            int(idx, SIDRE_IndexType), SHT_rv%cxxmem)
         ! splicer end class.Group.method.get_view_from_index_int32_t
     end function group_get_view_from_index_int32_t
 
@@ -2963,7 +2958,7 @@ contains
         ! splicer begin class.Group.method.get_view_from_index_int64_t
         type(C_PTR) :: SHT_prv
         SHT_prv = c_group_get_view_from_index(obj%cxxmem, &
-            int(idx, C_INT64_t), SHT_rv%cxxmem)
+            int(idx, SIDRE_IndexType), SHT_rv%cxxmem)
         ! splicer end class.Group.method.get_view_from_index_int64_t
     end function group_get_view_from_index_int64_t
 
@@ -2985,7 +2980,7 @@ contains
         integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.Group.method.get_next_valid_view_index_int32_t
         SHT_rv = c_group_get_next_valid_view_index(obj%cxxmem, &
-            int(idx, C_INT64_t))
+            int(idx, SIDRE_IndexType))
         ! splicer end class.Group.method.get_next_valid_view_index_int32_t
     end function group_get_next_valid_view_index_int32_t
 
@@ -2997,7 +2992,7 @@ contains
         integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.Group.method.get_next_valid_view_index_int64_t
         SHT_rv = c_group_get_next_valid_view_index(obj%cxxmem, &
-            int(idx, C_INT64_t))
+            int(idx, SIDRE_IndexType))
         ! splicer end class.Group.method.get_next_valid_view_index_int64_t
     end function group_get_next_valid_view_index_int64_t
 
@@ -3017,44 +3012,44 @@ contains
     function group_create_view_from_type_int32_t(obj, path, type, &
             num_elems) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_INT32_T, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT, C_INT32_T, C_INT64_T, C_PTR, C_SHORT
         class(SidreGroup) :: obj
         character(len=*), intent(IN) :: path
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT32_T), value, intent(IN) :: num_elems
         type(SidreView) :: SHT_rv
         ! splicer begin class.Group.method.create_view_from_type_int32_t
         type(C_PTR) :: SHT_prv
         SHT_prv = c_group_create_view_from_type_bufferify(obj%cxxmem, &
             path, len_trim(path, kind=C_INT), type, &
-            int(num_elems, C_INT64_t), SHT_rv%cxxmem)
+            int(num_elems, SIDRE_IndexType), SHT_rv%cxxmem)
         ! splicer end class.Group.method.create_view_from_type_int32_t
     end function group_create_view_from_type_int32_t
 
     function group_create_view_from_type_int64_t(obj, path, type, &
             num_elems) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR, C_SHORT
         class(SidreGroup) :: obj
         character(len=*), intent(IN) :: path
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT64_T), value, intent(IN) :: num_elems
         type(SidreView) :: SHT_rv
         ! splicer begin class.Group.method.create_view_from_type_int64_t
         type(C_PTR) :: SHT_prv
         SHT_prv = c_group_create_view_from_type_bufferify(obj%cxxmem, &
             path, len_trim(path, kind=C_INT), type, &
-            int(num_elems, C_INT64_t), SHT_rv%cxxmem)
+            int(num_elems, SIDRE_IndexType), SHT_rv%cxxmem)
         ! splicer end class.Group.method.create_view_from_type_int64_t
     end function group_create_view_from_type_int64_t
 
     function group_create_view_with_shape_base(obj, path, type, ndims, &
             shape) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR, C_SHORT
         class(SidreGroup) :: obj
         character(len=*), intent(IN) :: path
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT), value, intent(IN) :: ndims
         integer(SIDRE_IndexType), intent(IN) :: shape(:)
         type(SidreView) :: SHT_rv
@@ -3084,10 +3079,10 @@ contains
     function group_create_view_from_type_and_buffer_int32_t(obj, path, &
             type, num_elems, buff) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_INT32_T, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT, C_INT32_T, C_INT64_T, C_PTR, C_SHORT
         class(SidreGroup) :: obj
         character(len=*), intent(IN) :: path
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT32_T), value, intent(IN) :: num_elems
         type(SidreBuffer), intent(INOUT) :: buff
         type(SidreView) :: SHT_rv
@@ -3095,17 +3090,17 @@ contains
         type(C_PTR) :: SHT_prv
         SHT_prv = c_group_create_view_from_type_and_buffer_bufferify(obj%cxxmem, &
             path, len_trim(path, kind=C_INT), type, &
-            int(num_elems, C_INT64_t), buff%cxxmem, SHT_rv%cxxmem)
+            int(num_elems, SIDRE_IndexType), buff%cxxmem, SHT_rv%cxxmem)
         ! splicer end class.Group.method.create_view_from_type_and_buffer_int32_t
     end function group_create_view_from_type_and_buffer_int32_t
 
     function group_create_view_from_type_and_buffer_int64_t(obj, path, &
             type, num_elems, buff) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR, C_SHORT
         class(SidreGroup) :: obj
         character(len=*), intent(IN) :: path
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT64_T), value, intent(IN) :: num_elems
         type(SidreBuffer), intent(INOUT) :: buff
         type(SidreView) :: SHT_rv
@@ -3113,17 +3108,17 @@ contains
         type(C_PTR) :: SHT_prv
         SHT_prv = c_group_create_view_from_type_and_buffer_bufferify(obj%cxxmem, &
             path, len_trim(path, kind=C_INT), type, &
-            int(num_elems, C_INT64_t), buff%cxxmem, SHT_rv%cxxmem)
+            int(num_elems, SIDRE_IndexType), buff%cxxmem, SHT_rv%cxxmem)
         ! splicer end class.Group.method.create_view_from_type_and_buffer_int64_t
     end function group_create_view_from_type_and_buffer_int64_t
 
     function group_create_view_with_shape_and_buffer(obj, path, type, &
             ndims, shape, buff) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR, C_SHORT
         class(SidreGroup) :: obj
         character(len=*), intent(IN) :: path
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT), value, intent(IN) :: ndims
         integer(SIDRE_IndexType), intent(IN) :: shape(:)
         type(SidreBuffer), intent(INOUT) :: buff
@@ -3154,10 +3149,10 @@ contains
     function group_create_view_from_type_external_int32_t(obj, path, &
             type, num_elems, external_ptr) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_INT32_T, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT, C_INT32_T, C_INT64_T, C_PTR, C_SHORT
         class(SidreGroup) :: obj
         character(len=*), intent(IN) :: path
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT32_T), value, intent(IN) :: num_elems
         type(C_PTR), intent(IN) :: external_ptr
         type(SidreView) :: SHT_rv
@@ -3165,17 +3160,18 @@ contains
         type(C_PTR) :: SHT_prv
         SHT_prv = c_group_create_view_from_type_external_bufferify(obj%cxxmem, &
             path, len_trim(path, kind=C_INT), type, &
-            int(num_elems, C_INT64_t), external_ptr, SHT_rv%cxxmem)
+            int(num_elems, SIDRE_IndexType), external_ptr, &
+            SHT_rv%cxxmem)
         ! splicer end class.Group.method.create_view_from_type_external_int32_t
     end function group_create_view_from_type_external_int32_t
 
     function group_create_view_from_type_external_int64_t(obj, path, &
             type, num_elems, external_ptr) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR, C_SHORT
         class(SidreGroup) :: obj
         character(len=*), intent(IN) :: path
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT64_T), value, intent(IN) :: num_elems
         type(C_PTR), intent(IN) :: external_ptr
         type(SidreView) :: SHT_rv
@@ -3183,17 +3179,18 @@ contains
         type(C_PTR) :: SHT_prv
         SHT_prv = c_group_create_view_from_type_external_bufferify(obj%cxxmem, &
             path, len_trim(path, kind=C_INT), type, &
-            int(num_elems, C_INT64_t), external_ptr, SHT_rv%cxxmem)
+            int(num_elems, SIDRE_IndexType), external_ptr, &
+            SHT_rv%cxxmem)
         ! splicer end class.Group.method.create_view_from_type_external_int64_t
     end function group_create_view_from_type_external_int64_t
 
     function group_create_view_with_shape_external(obj, path, type, &
             ndims, shape, external_ptr) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR, C_SHORT
         class(SidreGroup) :: obj
         character(len=*), intent(IN) :: path
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT), value, intent(IN) :: ndims
         integer(SIDRE_IndexType), intent(IN) :: shape(:)
         type(C_PTR), intent(IN) :: external_ptr
@@ -3209,44 +3206,44 @@ contains
     function group_create_view_and_allocate_nelems_int32_t(obj, path, &
             type, num_elems) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_INT32_T, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT, C_INT32_T, C_INT64_T, C_PTR, C_SHORT
         class(SidreGroup) :: obj
         character(len=*), intent(IN) :: path
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT32_T), value, intent(IN) :: num_elems
         type(SidreView) :: SHT_rv
         ! splicer begin class.Group.method.create_view_and_allocate_nelems_int32_t
         type(C_PTR) :: SHT_prv
         SHT_prv = c_group_create_view_and_allocate_nelems_bufferify(obj%cxxmem, &
             path, len_trim(path, kind=C_INT), type, &
-            int(num_elems, C_INT64_t), SHT_rv%cxxmem)
+            int(num_elems, SIDRE_IndexType), SHT_rv%cxxmem)
         ! splicer end class.Group.method.create_view_and_allocate_nelems_int32_t
     end function group_create_view_and_allocate_nelems_int32_t
 
     function group_create_view_and_allocate_nelems_int64_t(obj, path, &
             type, num_elems) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR, C_SHORT
         class(SidreGroup) :: obj
         character(len=*), intent(IN) :: path
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT64_T), value, intent(IN) :: num_elems
         type(SidreView) :: SHT_rv
         ! splicer begin class.Group.method.create_view_and_allocate_nelems_int64_t
         type(C_PTR) :: SHT_prv
         SHT_prv = c_group_create_view_and_allocate_nelems_bufferify(obj%cxxmem, &
             path, len_trim(path, kind=C_INT), type, &
-            int(num_elems, C_INT64_t), SHT_rv%cxxmem)
+            int(num_elems, SIDRE_IndexType), SHT_rv%cxxmem)
         ! splicer end class.Group.method.create_view_and_allocate_nelems_int64_t
     end function group_create_view_and_allocate_nelems_int64_t
 
     function group_create_view_with_shape_and_allocate(obj, path, type, &
             ndims, shape) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR, C_SHORT
         class(SidreGroup) :: obj
         character(len=*), intent(IN) :: path
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT), value, intent(IN) :: ndims
         integer(SIDRE_IndexType), intent(IN) :: shape(:)
         type(SidreView) :: SHT_rv
@@ -3355,7 +3352,7 @@ contains
         integer(C_INT32_T), value, intent(IN) :: idx
         ! splicer begin class.Group.method.destroy_view_and_data_index_int32_t
         call c_group_destroy_view_and_data_index(obj%cxxmem, &
-            int(idx, C_INT64_t))
+            int(idx, SIDRE_IndexType))
         ! splicer end class.Group.method.destroy_view_and_data_index_int32_t
     end subroutine group_destroy_view_and_data_index_int32_t
 
@@ -3365,7 +3362,7 @@ contains
         integer(C_INT64_T), value, intent(IN) :: idx
         ! splicer begin class.Group.method.destroy_view_and_data_index_int64_t
         call c_group_destroy_view_and_data_index(obj%cxxmem, &
-            int(idx, C_INT64_t))
+            int(idx, SIDRE_IndexType))
         ! splicer end class.Group.method.destroy_view_and_data_index_int64_t
     end subroutine group_destroy_view_and_data_index_int64_t
 
@@ -3439,7 +3436,7 @@ contains
         character(len=MAXNAMESIZE) :: SHT_rv
         ! splicer begin class.Group.method.get_group_name_int32_t
         call c_group_get_group_name_bufferify(obj%cxxmem, &
-            int(idx, C_INT64_t), SHT_rv, len(SHT_rv, kind=C_INT))
+            int(idx, SIDRE_IndexType), SHT_rv, len(SHT_rv, kind=C_INT))
         ! splicer end class.Group.method.get_group_name_int32_t
     end function group_get_group_name_int32_t
 
@@ -3451,7 +3448,7 @@ contains
         character(len=MAXNAMESIZE) :: SHT_rv
         ! splicer begin class.Group.method.get_group_name_int64_t
         call c_group_get_group_name_bufferify(obj%cxxmem, &
-            int(idx, C_INT64_t), SHT_rv, len(SHT_rv, kind=C_INT))
+            int(idx, SIDRE_IndexType), SHT_rv, len(SHT_rv, kind=C_INT))
         ! splicer end class.Group.method.get_group_name_int64_t
     end function group_get_group_name_int64_t
 
@@ -3477,7 +3474,7 @@ contains
         ! splicer begin class.Group.method.get_group_from_index_int32_t
         type(C_PTR) :: SHT_prv
         SHT_prv = c_group_get_group_from_index(obj%cxxmem, &
-            int(idx, C_INT64_t), SHT_rv%cxxmem)
+            int(idx, SIDRE_IndexType), SHT_rv%cxxmem)
         ! splicer end class.Group.method.get_group_from_index_int32_t
     end function group_get_group_from_index_int32_t
 
@@ -3490,7 +3487,7 @@ contains
         ! splicer begin class.Group.method.get_group_from_index_int64_t
         type(C_PTR) :: SHT_prv
         SHT_prv = c_group_get_group_from_index(obj%cxxmem, &
-            int(idx, C_INT64_t), SHT_rv%cxxmem)
+            int(idx, SIDRE_IndexType), SHT_rv%cxxmem)
         ! splicer end class.Group.method.get_group_from_index_int64_t
     end function group_get_group_from_index_int64_t
 
@@ -3512,7 +3509,7 @@ contains
         integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.Group.method.get_next_valid_group_index_int32_t
         SHT_rv = c_group_get_next_valid_group_index(obj%cxxmem, &
-            int(idx, C_INT64_t))
+            int(idx, SIDRE_IndexType))
         ! splicer end class.Group.method.get_next_valid_group_index_int32_t
     end function group_get_next_valid_group_index_int32_t
 
@@ -3524,7 +3521,7 @@ contains
         integer(SIDRE_IndexType) :: SHT_rv
         ! splicer begin class.Group.method.get_next_valid_group_index_int64_t
         SHT_rv = c_group_get_next_valid_group_index(obj%cxxmem, &
-            int(idx, C_INT64_t))
+            int(idx, SIDRE_IndexType))
         ! splicer end class.Group.method.get_next_valid_group_index_int64_t
     end function group_get_next_valid_group_index_int64_t
 
@@ -3557,7 +3554,7 @@ contains
         integer(C_INT32_T), value, intent(IN) :: idx
         ! splicer begin class.Group.method.destroy_group_index_int32_t
         call c_group_destroy_group_index(obj%cxxmem, &
-            int(idx, C_INT64_t))
+            int(idx, SIDRE_IndexType))
         ! splicer end class.Group.method.destroy_group_index_int32_t
     end subroutine group_destroy_group_index_int32_t
 
@@ -3567,7 +3564,7 @@ contains
         integer(C_INT64_T), value, intent(IN) :: idx
         ! splicer begin class.Group.method.destroy_group_index_int64_t
         call c_group_destroy_group_index(obj%cxxmem, &
-            int(idx, C_INT64_t))
+            int(idx, SIDRE_IndexType))
         ! splicer end class.Group.method.destroy_group_index_int64_t
     end subroutine group_destroy_group_index_int64_t
 
@@ -3819,7 +3816,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(1)
-        integer(C_INT), parameter :: type = SIDRE_INT_ID
+        integer(TypeID), parameter :: type = SIDRE_INT_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -3845,7 +3842,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(1)
-        integer(C_INT), parameter :: type = SIDRE_INT_ID
+        integer(TypeID), parameter :: type = SIDRE_INT_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -3871,7 +3868,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(2)
-        integer(C_INT), parameter :: type = SIDRE_INT_ID
+        integer(TypeID), parameter :: type = SIDRE_INT_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -3897,7 +3894,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(3)
-        integer(C_INT), parameter :: type = SIDRE_INT_ID
+        integer(TypeID), parameter :: type = SIDRE_INT_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -3923,7 +3920,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(4)
-        integer(C_INT), parameter :: type = SIDRE_INT_ID
+        integer(TypeID), parameter :: type = SIDRE_INT_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -3949,7 +3946,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(1)
-        integer(C_INT), parameter :: type = SIDRE_LONG_ID
+        integer(TypeID), parameter :: type = SIDRE_LONG_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -3975,7 +3972,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(1)
-        integer(C_INT), parameter :: type = SIDRE_LONG_ID
+        integer(TypeID), parameter :: type = SIDRE_LONG_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -4001,7 +3998,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(2)
-        integer(C_INT), parameter :: type = SIDRE_LONG_ID
+        integer(TypeID), parameter :: type = SIDRE_LONG_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -4027,7 +4024,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(3)
-        integer(C_INT), parameter :: type = SIDRE_LONG_ID
+        integer(TypeID), parameter :: type = SIDRE_LONG_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -4053,7 +4050,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(4)
-        integer(C_INT), parameter :: type = SIDRE_LONG_ID
+        integer(TypeID), parameter :: type = SIDRE_LONG_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -4079,7 +4076,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(1)
-        integer(C_INT), parameter :: type = SIDRE_FLOAT_ID
+        integer(TypeID), parameter :: type = SIDRE_FLOAT_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -4105,7 +4102,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(1)
-        integer(C_INT), parameter :: type = SIDRE_FLOAT_ID
+        integer(TypeID), parameter :: type = SIDRE_FLOAT_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -4131,7 +4128,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(2)
-        integer(C_INT), parameter :: type = SIDRE_FLOAT_ID
+        integer(TypeID), parameter :: type = SIDRE_FLOAT_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -4157,7 +4154,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(3)
-        integer(C_INT), parameter :: type = SIDRE_FLOAT_ID
+        integer(TypeID), parameter :: type = SIDRE_FLOAT_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -4183,7 +4180,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(4)
-        integer(C_INT), parameter :: type = SIDRE_FLOAT_ID
+        integer(TypeID), parameter :: type = SIDRE_FLOAT_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -4209,7 +4206,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(1)
-        integer(C_INT), parameter :: type = SIDRE_DOUBLE_ID
+        integer(TypeID), parameter :: type = SIDRE_DOUBLE_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -4235,7 +4232,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(1)
-        integer(C_INT), parameter :: type = SIDRE_DOUBLE_ID
+        integer(TypeID), parameter :: type = SIDRE_DOUBLE_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -4261,7 +4258,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(2)
-        integer(C_INT), parameter :: type = SIDRE_DOUBLE_ID
+        integer(TypeID), parameter :: type = SIDRE_DOUBLE_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -4287,7 +4284,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(3)
-        integer(C_INT), parameter :: type = SIDRE_DOUBLE_ID
+        integer(TypeID), parameter :: type = SIDRE_DOUBLE_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -4313,7 +4310,7 @@ contains
         integer(C_INT) :: lname
         type(SidreView) :: rv
         integer(SIDRE_IndexType) :: extents(4)
-        integer(C_INT), parameter :: type = SIDRE_DOUBLE_ID
+        integer(TypeID), parameter :: type = SIDRE_DOUBLE_ID
         type(C_PTR) addr, viewptr
 
         lname = len_trim(name)
@@ -5095,9 +5092,9 @@ contains
 
     function view_get_type_id(obj) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT
+        use iso_c_binding, only : C_SHORT
         class(SidreView) :: obj
-        integer(C_INT) :: SHT_rv
+        integer(TypeID) :: SHT_rv
         ! splicer begin class.View.method.get_type_id
         SHT_rv = c_view_get_type_id(obj%cxxmem)
         ! splicer end class.View.method.get_type_id
@@ -5183,24 +5180,24 @@ contains
     end subroutine view_allocate_simple
 
     subroutine view_allocate_from_type_int32_t(obj, type, num_elems)
-        use iso_c_binding, only : C_INT, C_INT32_T, C_INT64_T
+        use iso_c_binding, only : C_INT32_T, C_INT64_T, C_SHORT
         class(SidreView) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT32_T), value, intent(IN) :: num_elems
         ! splicer begin class.View.method.allocate_from_type_int32_t
         call c_view_allocate_from_type(obj%cxxmem, type, &
-            int(num_elems, C_INT64_t))
+            int(num_elems, SIDRE_IndexType))
         ! splicer end class.View.method.allocate_from_type_int32_t
     end subroutine view_allocate_from_type_int32_t
 
     subroutine view_allocate_from_type_int64_t(obj, type, num_elems)
-        use iso_c_binding, only : C_INT, C_INT64_T
+        use iso_c_binding, only : C_INT64_T, C_SHORT
         class(SidreView) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT64_T), value, intent(IN) :: num_elems
         ! splicer begin class.View.method.allocate_from_type_int64_t
         call c_view_allocate_from_type(obj%cxxmem, type, &
-            int(num_elems, C_INT64_t))
+            int(num_elems, SIDRE_IndexType))
         ! splicer end class.View.method.allocate_from_type_int64_t
     end subroutine view_allocate_from_type_int64_t
 
@@ -5209,7 +5206,8 @@ contains
         class(SidreView) :: obj
         integer(C_INT32_T), value, intent(IN) :: num_elems
         ! splicer begin class.View.method.reallocate_int32_t
-        call c_view_reallocate(obj%cxxmem, int(num_elems, C_INT64_t))
+        call c_view_reallocate(obj%cxxmem, &
+            int(num_elems, SIDRE_IndexType))
         ! splicer end class.View.method.reallocate_int32_t
     end subroutine view_reallocate_int32_t
 
@@ -5218,7 +5216,8 @@ contains
         class(SidreView) :: obj
         integer(C_INT64_T), value, intent(IN) :: num_elems
         ! splicer begin class.View.method.reallocate_int64_t
-        call c_view_reallocate(obj%cxxmem, int(num_elems, C_INT64_t))
+        call c_view_reallocate(obj%cxxmem, &
+            int(num_elems, SIDRE_IndexType))
         ! splicer end class.View.method.reallocate_int64_t
     end subroutine view_reallocate_int64_t
 
@@ -5232,34 +5231,34 @@ contains
 
     subroutine view_attach_buffer_type_int32_t(obj, type, num_elems, &
             buff)
-        use iso_c_binding, only : C_INT, C_INT32_T, C_INT64_T
+        use iso_c_binding, only : C_INT32_T, C_INT64_T, C_SHORT
         class(SidreView) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT32_T), value, intent(IN) :: num_elems
         type(SidreBuffer), intent(INOUT) :: buff
         ! splicer begin class.View.method.attach_buffer_type_int32_t
         call c_view_attach_buffer_type(obj%cxxmem, type, &
-            int(num_elems, C_INT64_t), buff%cxxmem)
+            int(num_elems, SIDRE_IndexType), buff%cxxmem)
         ! splicer end class.View.method.attach_buffer_type_int32_t
     end subroutine view_attach_buffer_type_int32_t
 
     subroutine view_attach_buffer_type_int64_t(obj, type, num_elems, &
             buff)
-        use iso_c_binding, only : C_INT, C_INT64_T
+        use iso_c_binding, only : C_INT64_T, C_SHORT
         class(SidreView) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT64_T), value, intent(IN) :: num_elems
         type(SidreBuffer), intent(INOUT) :: buff
         ! splicer begin class.View.method.attach_buffer_type_int64_t
         call c_view_attach_buffer_type(obj%cxxmem, type, &
-            int(num_elems, C_INT64_t), buff%cxxmem)
+            int(num_elems, SIDRE_IndexType), buff%cxxmem)
         ! splicer end class.View.method.attach_buffer_type_int64_t
     end subroutine view_attach_buffer_type_int64_t
 
     subroutine view_attach_buffer_shape(obj, type, ndims, shape, buff)
-        use iso_c_binding, only : C_INT, C_INT64_T
+        use iso_c_binding, only : C_INT, C_INT64_T, C_SHORT
         class(SidreView) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT), value, intent(IN) :: ndims
         integer(SIDRE_IndexType), intent(IN) :: shape(:)
         type(SidreBuffer), intent(INOUT) :: buff
@@ -5316,9 +5315,9 @@ contains
     end subroutine view_apply_nelems_offset_stride
 
     subroutine view_apply_type_nelems(obj, type, num_elems)
-        use iso_c_binding, only : C_INT, C_INT64_T
+        use iso_c_binding, only : C_INT64_T, C_SHORT
         class(SidreView) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         ! splicer begin class.View.method.apply_type_nelems
         call c_view_apply_type_nelems(obj%cxxmem, type, num_elems)
@@ -5327,9 +5326,9 @@ contains
 
     subroutine view_apply_type_nelems_offset(obj, type, num_elems, &
             offset)
-        use iso_c_binding, only : C_INT, C_INT64_T
+        use iso_c_binding, only : C_INT64_T, C_SHORT
         class(SidreView) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         integer(SIDRE_IndexType), value, intent(IN) :: offset
         ! splicer begin class.View.method.apply_type_nelems_offset
@@ -5340,9 +5339,9 @@ contains
 
     subroutine view_apply_type_nelems_offset_stride(obj, type, &
             num_elems, offset, stride)
-        use iso_c_binding, only : C_INT, C_INT64_T
+        use iso_c_binding, only : C_INT64_T, C_SHORT
         class(SidreView) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(SIDRE_IndexType), value, intent(IN) :: num_elems
         integer(SIDRE_IndexType), value, intent(IN) :: offset
         integer(SIDRE_IndexType), value, intent(IN) :: stride
@@ -5353,9 +5352,9 @@ contains
     end subroutine view_apply_type_nelems_offset_stride
 
     subroutine view_apply_type_shape(obj, type, ndims, shape)
-        use iso_c_binding, only : C_INT, C_INT64_T
+        use iso_c_binding, only : C_INT, C_INT64_T, C_SHORT
         class(SidreView) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT), value, intent(IN) :: ndims
         integer(SIDRE_IndexType), intent(IN) :: shape(:)
         ! splicer begin class.View.method.apply_type_shape
@@ -5420,35 +5419,35 @@ contains
 
     subroutine view_set_external_data_ptr_type_int32_t(obj, type, &
             num_elems, external_ptr)
-        use iso_c_binding, only : C_INT, C_INT32_T, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT32_T, C_INT64_T, C_PTR, C_SHORT
         class(SidreView) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT32_T), value, intent(IN) :: num_elems
         type(C_PTR), intent(IN) :: external_ptr
         ! splicer begin class.View.method.set_external_data_ptr_type_int32_t
         call c_view_set_external_data_ptr_type(obj%cxxmem, type, &
-            int(num_elems, C_INT64_t), external_ptr)
+            int(num_elems, SIDRE_IndexType), external_ptr)
         ! splicer end class.View.method.set_external_data_ptr_type_int32_t
     end subroutine view_set_external_data_ptr_type_int32_t
 
     subroutine view_set_external_data_ptr_type_int64_t(obj, type, &
             num_elems, external_ptr)
-        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT64_T, C_PTR, C_SHORT
         class(SidreView) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT64_T), value, intent(IN) :: num_elems
         type(C_PTR), intent(IN) :: external_ptr
         ! splicer begin class.View.method.set_external_data_ptr_type_int64_t
         call c_view_set_external_data_ptr_type(obj%cxxmem, type, &
-            int(num_elems, C_INT64_t), external_ptr)
+            int(num_elems, SIDRE_IndexType), external_ptr)
         ! splicer end class.View.method.set_external_data_ptr_type_int64_t
     end subroutine view_set_external_data_ptr_type_int64_t
 
     subroutine view_set_external_data_ptr_shape(obj, type, ndims, shape, &
             external_ptr)
-        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR, C_SHORT
         class(SidreView) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT), value, intent(IN) :: ndims
         integer(SIDRE_IndexType), intent(IN) :: shape(:)
         type(C_PTR), intent(IN) :: external_ptr
@@ -6578,7 +6577,7 @@ contains
         ! splicer begin class.DataStore.method.get_buffer_int32_t
         type(C_PTR) :: SHT_prv
         SHT_prv = c_datastore_get_buffer(obj%cxxmem, &
-            int(idx, C_INT64_t), SHT_rv%cxxmem)
+            int(idx, SIDRE_IndexType), SHT_rv%cxxmem)
         ! splicer end class.DataStore.method.get_buffer_int32_t
     end function datastore_get_buffer_int32_t
 
@@ -6591,7 +6590,7 @@ contains
         ! splicer begin class.DataStore.method.get_buffer_int64_t
         type(C_PTR) :: SHT_prv
         SHT_prv = c_datastore_get_buffer(obj%cxxmem, &
-            int(idx, C_INT64_t), SHT_rv%cxxmem)
+            int(idx, SIDRE_IndexType), SHT_rv%cxxmem)
         ! splicer end class.DataStore.method.get_buffer_int64_t
     end function datastore_get_buffer_int64_t
 
@@ -6610,30 +6609,30 @@ contains
     function datastore_create_buffer_from_type_int32_t(obj, type, &
             num_elems) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_INT32_T, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT32_T, C_INT64_T, C_PTR, C_SHORT
         class(SidreDataStore) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT32_T), value, intent(IN) :: num_elems
         type(SidreBuffer) :: SHT_rv
         ! splicer begin class.DataStore.method.create_buffer_from_type_int32_t
         type(C_PTR) :: SHT_prv
         SHT_prv = c_datastore_create_buffer_from_type(obj%cxxmem, type, &
-            int(num_elems, C_INT64_t), SHT_rv%cxxmem)
+            int(num_elems, SIDRE_IndexType), SHT_rv%cxxmem)
         ! splicer end class.DataStore.method.create_buffer_from_type_int32_t
     end function datastore_create_buffer_from_type_int32_t
 
     function datastore_create_buffer_from_type_int64_t(obj, type, &
             num_elems) &
             result(SHT_rv)
-        use iso_c_binding, only : C_INT, C_INT64_T, C_PTR
+        use iso_c_binding, only : C_INT64_T, C_PTR, C_SHORT
         class(SidreDataStore) :: obj
-        integer(C_INT), value, intent(IN) :: type
+        integer(TypeID), value, intent(IN) :: type
         integer(C_INT64_T), value, intent(IN) :: num_elems
         type(SidreBuffer) :: SHT_rv
         ! splicer begin class.DataStore.method.create_buffer_from_type_int64_t
         type(C_PTR) :: SHT_prv
         SHT_prv = c_datastore_create_buffer_from_type(obj%cxxmem, type, &
-            int(num_elems, C_INT64_t), SHT_rv%cxxmem)
+            int(num_elems, SIDRE_IndexType), SHT_rv%cxxmem)
         ! splicer end class.DataStore.method.create_buffer_from_type_int64_t
     end function datastore_create_buffer_from_type_int64_t
 
@@ -6642,7 +6641,8 @@ contains
         class(SidreDataStore) :: obj
         integer(C_INT32_T), value, intent(IN) :: id
         ! splicer begin class.DataStore.method.destroy_buffer_int32_t
-        call c_datastore_destroy_buffer(obj%cxxmem, int(id, C_INT64_t))
+        call c_datastore_destroy_buffer(obj%cxxmem, &
+            int(id, SIDRE_IndexType))
         ! splicer end class.DataStore.method.destroy_buffer_int32_t
     end subroutine datastore_destroy_buffer_int32_t
 
@@ -6651,7 +6651,8 @@ contains
         class(SidreDataStore) :: obj
         integer(C_INT64_T), value, intent(IN) :: id
         ! splicer begin class.DataStore.method.destroy_buffer_int64_t
-        call c_datastore_destroy_buffer(obj%cxxmem, int(id, C_INT64_t))
+        call c_datastore_destroy_buffer(obj%cxxmem, &
+            int(id, SIDRE_IndexType))
         ! splicer end class.DataStore.method.destroy_buffer_int64_t
     end subroutine datastore_destroy_buffer_int64_t
 

--- a/src/axom/sidre/interface/sidre_shroud.yaml
+++ b/src/axom/sidre/interface/sidre_shroud.yaml
@@ -39,6 +39,7 @@ declarations:
     c_header : axom/sidre/interface/SidreTypes.h
     cxx_header : axom/sidre/interface/SidreTypes.h
     c_type   : SIDRE_IndexType
+    f_cast: int({f_var}, SIDRE_IndexType)
     f_type: integer(SIDRE_IndexType)
     f_kind: SIDRE_IndexType
     f_module_name: axom_sidre
@@ -46,13 +47,21 @@ declarations:
       "--import--":
       -  SIDRE_IndexType
 
-- decl: typedef int TypeID
+- decl: typedef short TypeID
   fields:
     # enum for types
     c_header : axom/sidre/interface/SidreTypes.h
     cxx_header : axom/sidre/core/SidreTypes.hpp
-    c_to_cxx : axom::sidre::getTypeID({c_var})
-    cxx_to_c : static_cast<int>({cxx_var})
+    c_to_cxx : static_cast<axom::sidre::TypeID>({c_var})
+    cxx_to_c : static_cast<SIDRE_TypeID>({cxx_var})
+    c_type   : SIDRE_TypeID
+    f_cast: int({f_var}, TypeID)
+    f_type: integer(TypeID)
+    f_kind: TypeID
+    f_module_name: axom_sidre
+    f_c_module:
+      "--import--":
+      -  TypeID
 
 # XXX
 # parameters:

--- a/src/axom/sidre/interface/sidre_shroud.yaml
+++ b/src/axom/sidre/interface/sidre_shroud.yaml
@@ -63,6 +63,26 @@ declarations:
       "--import--":
       -  TypeID
 
+# This typedef is to work around a problem with amdflang.
+# The compiler fails on getTypeID type-bound procedures that return a C_SHORT.
+# Instead, return a C_INT.
+- decl: typedef int TypeIDint
+  fields:
+    # enum for types
+    c_header : axom/sidre/interface/SidreTypes.h
+    cxx_header : axom/sidre/core/SidreTypes.hpp
+    c_to_cxx : static_cast<axom::sidre::TypeIDint>({c_var})
+    cxx_to_c : static_cast<SIDRE_TypeIDint>({cxx_var})
+    cxx_type : axom::sidre::TypeID
+    c_type   : SIDRE_TypeIDint
+    f_cast: int({f_var}, TypeIDint)
+    f_type: integer(TypeIDint)
+    f_kind: TypeIDint
+    f_module_name: axom_sidre
+    f_c_module:
+      "--import--":
+      -  TypeIDint
+
 # XXX
 # parameters:
 #  InvalidID: IDTYPE -1
@@ -487,7 +507,7 @@ declarations:
 
     # Methods to query and access Buffer data
     - decl: void* getVoidPtr()
-    - decl: TypeID getTypeID() const
+    - decl: TypeIDint getTypeID() const
     - decl: size_t getNumElements() const
     - decl: size_t getTotalBytes() const
     - decl: size_t getBytesPerElement() const
@@ -553,7 +573,7 @@ declarations:
   - decl: bool isOpaque() const
   - decl: bool isScalar() const
   - decl: bool isString() const
-  - decl: TypeID getTypeID() const
+  - decl: TypeIDint getTypeID() const
   - decl: size_t getTotalBytes() const
   - decl: size_t getNumElements() const
   - decl: size_t getBytesPerElement() const

--- a/src/axom/sidre/interface/sidre_shroud.yaml
+++ b/src/axom/sidre/interface/sidre_shroud.yaml
@@ -37,7 +37,14 @@ declarations:
   fields:
     # defined in SidreTypes.hpp
     c_header : axom/sidre/interface/SidreTypes.h
+    cxx_header : axom/sidre/interface/SidreTypes.h
     c_type   : SIDRE_IndexType
+    f_type: integer(SIDRE_IndexType)
+    f_kind: SIDRE_IndexType
+    f_module_name: axom_sidre
+    f_c_module:
+      "--import--":
+      -  SIDRE_IndexType
 
 - decl: typedef int TypeID
   fields:
@@ -58,7 +65,7 @@ declarations:
 
 - decl: class Group
   # SidreTypes.h is required for C_invalid_name pattern.
-  cxx_header: axom/sidre/core/Group.hpp axom/sidre/interface/SidreTypes.h
+  cxx_header: axom/sidre/core/Group.hpp
   format:
     F_derived_name:  SidreGroup
 

--- a/src/axom/sidre/tests/sidre_allocatable_F.f
+++ b/src/axom/sidre/tests/sidre_allocatable_F.f
@@ -49,7 +49,7 @@ contains
     call assert_true(view%is_external())
 
     type = view%get_type_id()
-    call assert_equals(type, SIDRE_INT_ID)
+    call assert_true(type == SIDRE_INT_ID)
 
     num_elements = view%get_num_elements()
     call assert_equals(num_elements, size(iarray))
@@ -106,7 +106,7 @@ contains
     call assert_true(view%is_external())
 
     type = view%get_type_id()
-    call assert_equals(type, SIDRE_INT_ID)
+    call assert_true(type == SIDRE_INT_ID)
 
     num_elements = view%get_num_elements()
     call assert_equals(num_elements, size(iarray))
@@ -141,7 +141,7 @@ contains
     type(SidreDataStore) ds
     type(SidreGroup) root
     type(SidreView)  view
-    integer type
+    integer(TypeID) type
     integer num_elements
     integer i
 
@@ -157,7 +157,7 @@ contains
     view = root%create_array_view("iarray", iarray)
 
     type = view%get_type_id()
-    call assert_equals(type, SIDRE_INT_ID)
+    call assert_true(type == SIDRE_INT_ID)
 
     num_elements = view%get_num_elements()
     call assert_equals(num_elements, 10)
@@ -181,7 +181,7 @@ contains
     type(SidreGroup) root
     type(SidreView)  view
     integer num_elements
-    integer type
+    integer(TypeID) type
     integer i
 
     call set_case_name("external_allocatable_double")
@@ -198,7 +198,7 @@ contains
     view = root%create_array_view("darray", darray)
 
     type = view%get_type_id()
-    call assert_equals(type, SIDRE_DOUBLE_ID)
+    call assert_true(type == SIDRE_DOUBLE_ID)
 
     num_elements = view%get_num_elements()
     call assert_equals(num_elements, 10)
@@ -223,7 +223,7 @@ contains
     type(SidreDataStore) ds
     type(SidreGroup) root
     type(SidreView)  view
-    integer type
+    integer(TypeID) type
     integer num_elements
     integer i, j, k
     integer rank
@@ -243,7 +243,7 @@ contains
     call view%get_data(ipointer)
 
     type = view%get_type_id()
-    call assert_equals(type, SIDRE_INT_ID)
+    call assert_true(type == SIDRE_INT_ID)
 
     num_elements = view%get_num_elements()
     call assert_equals(num_elements, size(ipointer))

--- a/src/axom/sidre/tests/sidre_buffer_F.f
+++ b/src/axom/sidre/tests/sidre_buffer_F.f
@@ -54,7 +54,7 @@ contains
 
     call dbuff%allocate(SIDRE_INT_ID, elem_count)
 
-    call assert_equals(dbuff%get_type_id(), SIDRE_INT_ID, "dbuff%get_typeid()")
+    call assert_true(dbuff%get_type_id() == SIDRE_INT_ID, "dbuff%get_typeid()")
     call assert_true(dbuff%get_num_elements() == elem_count, "dbuff%get_num_elements()")
     call assert_true(dbuff%get_bytes_per_element() == int_size)
     call assert_true(dbuff%get_total_bytes() == int_size * elem_count)
@@ -92,7 +92,7 @@ contains
 
     call dbuff%allocate(SIDRE_INT_ID, elem_count)
 
-    call assert_equals(dbuff%get_type_id(), SIDRE_INT_ID, "dbuff%get_type_id()")
+    call assert_true(dbuff%get_type_id() == SIDRE_INT_ID, "dbuff%get_type_id()")
     call assert_true(dbuff%get_num_elements() == elem_count, "dbuff%get_num_elements")
     call assert_true(dbuff%get_bytes_per_element() == int_size)
     call assert_true(dbuff%get_total_bytes() == int_size * elem_count)
@@ -133,7 +133,7 @@ contains
 
     call dbuff%allocate(SIDRE_LONG_ID, orig_elem_count)
 
-    call assert_equals(dbuff%get_type_id(), SIDRE_LONG_ID, "dbuff%get_type_id()")
+    call assert_true(dbuff%get_type_id() == SIDRE_LONG_ID, "dbuff%get_type_id()")
     call assert_true(dbuff%get_num_elements() == orig_elem_count, "dbuff%get_num_elements()")
     call assert_true(dbuff%get_bytes_per_element() == long_size)
     call assert_true(dbuff%get_total_bytes() == long_size * orig_elem_count)
@@ -147,7 +147,7 @@ contains
   
     call dbuff%reallocate( mod_elem_count )
 
-    call assert_equals(dbuff%get_type_id(), SIDRE_LONG_ID, "dbuff%get_type_id() after realloc")
+    call assert_true(dbuff%get_type_id() == SIDRE_LONG_ID, "dbuff%get_type_id() after realloc")
     call assert_true(dbuff%get_num_elements() == mod_elem_count, "dbuff%get_num_elements() after realloc")
     call assert_true(dbuff%get_bytes_per_element() == long_size)
     call assert_true(dbuff%get_total_bytes() == long_size * mod_elem_count)

--- a/src/axom/sidre/tests/sidre_external.cpp
+++ b/src/axom/sidre/tests/sidre_external.cpp
@@ -72,6 +72,7 @@ TEST(sidre_external, create_external_view)
       break;
     }
 
+    EXPECT_TRUE(view != nullptr);
     EXPECT_EQ(root->getNumViews(), i + 1);
 
     EXPECT_TRUE(view->isDescribed());
@@ -124,6 +125,7 @@ TEST(sidre_external, create_external_view_null)
       break;
     }
 
+    EXPECT_TRUE(view != nullptr);
     EXPECT_TRUE(view->isDescribed());
     EXPECT_FALSE(view->isAllocated());
     EXPECT_FALSE(view->isApplied());
@@ -164,6 +166,7 @@ TEST(sidre_external, transition_external_view_to_empty)
   }
 
   View* view = root->createView("data0", INT_ID, len)->setExternalDataPtr(idata);
+  EXPECT_TRUE(view != nullptr);
   EXPECT_TRUE(view->isExternal());
   EXPECT_EQ(idata, view->getVoidPtr());
 

--- a/src/axom/sidre/tests/sidre_external_F.f
+++ b/src/axom/sidre/tests/sidre_external_F.f
@@ -22,7 +22,7 @@ contains
     real(C_DOUBLE), allocatable, target :: ddata(:)
     integer(C_INT), pointer :: idata_chk(:)
     real(C_DOUBLE), pointer :: ddata_chk(:)
-    integer(C_LONG), parameter :: len = 11
+    integer(SIDRE_IndexType), parameter :: len = 11
     integer ii
 
     call set_case_name("create_external_view")
@@ -72,7 +72,7 @@ contains
     real(C_DOUBLE), allocatable, target :: ddata(:)
     integer(C_INT), pointer :: idata_chk(:)
     real(C_DOUBLE), pointer :: ddata_chk(:)
-    integer(C_LONG), parameter :: len = 11
+    integer(SIDRE_IndexType), parameter :: len = 11
     integer ii
 
     call set_case_name("save_load_external_view")

--- a/src/axom/sidre/tests/sidre_group_F.F
+++ b/src/axom/sidre/tests/sidre_group_F.F
@@ -186,7 +186,7 @@ contains
     type(SidreDataStore) ds
     type(SidreGroup) root, parent
     type(SidreView) view1, view2
-    integer(SIDRE_IndexType) idx1, idx2, idx3    ! IndexType
+    integer(SIDRE_IndexType) idx1, idx2, idx3
     character(len=MAXNAMESIZE) name1, name2, name3
 
     call set_case_name("get_view_name_index")
@@ -229,7 +229,7 @@ contains
     type(SidreDataStore) ds
     type(SidreGroup) root, parent, emptygrp
     type(SidreGroup) group1, group2, group1out, group2out
-    integer(SIDRE_IndexType) idx1, idx2, idx3, badidx1, badidx2    ! IndexType
+    integer(SIDRE_IndexType) idx1, idx2, idx3, badidx1, badidx2
 
     call set_case_name("get_first_and_next_group_index")
 
@@ -271,7 +271,7 @@ contains
     type(SidreDataStore) ds
     type(SidreGroup) root, parent, emptygrp
     type(SidreView) view1, view2, view1out, view2out
-    integer(SIDRE_IndexType) idx1, idx2, idx3, badidx1, badidx2    ! IndexType
+    integer(SIDRE_IndexType) idx1, idx2, idx3, badidx1, badidx2
 
     call set_case_name("get_first_and_next_view_index")
 
@@ -312,7 +312,7 @@ contains
   subroutine get_group_name_index
     type(SidreDataStore) ds
     type(SidreGroup) root, parent, grp1, grp2
-    integer(SIDRE_IndexType) idx1, idx2, idx3     ! IndexType
+    integer(SIDRE_IndexType) idx1, idx2, idx3
     character(len=MAXNAMESIZE) name1, name2, name3
 
     call set_case_name("get_group_name_index")
@@ -551,7 +551,7 @@ contains
     type(SidreView) view1, view2
     type(SidreBuffer) tmpbuf
 !XX    type(SidreBuffer) buffer1, tmpbuf
-    integer(SIDRE_IndexType) bufferid1      ! IndexType
+    integer(SIDRE_IndexType) bufferid1
     character(len=30) view_name1, view_name2
 !XX    logical buffvalid
 
@@ -812,7 +812,7 @@ contains
     view1 = root1%create_array_view("external_array", foo1)
     ! unable to use create_array_view since foo3 is not associated.
     view2 = root1%create_view("empty_array")
-    call view2%apply_type_nelems(SIDRE_INT_ID, 0_C_LONG)
+    call view2%apply_type_nelems(SIDRE_INT_ID, 0_SIDRE_IndexType)
     view3 = root1%create_view("external_undescribed")
     call view3%set_external_data_ptr(C_LOC(foo4))
     view4 = root1%create_array_view("int2d", int2d1)
@@ -843,14 +843,14 @@ contains
        view1 = root2%get_view("external_array")
        call assert_true(view1%is_external(), "external_array is_external")
        call assert_true(view1%is_described(), "external_array is_described")
-       call assert_equals(view1%get_type_id(), SIDRE_INT_ID, "external_array get_type_id")
+       call assert_true(view1%get_type_id() == SIDRE_INT_ID, "external_array get_type_id")
        call assert_true(view1%get_num_elements() == nfoo, "external_array get_num_elements")
        call view1%set_array_data_ptr(foo2)
 
        view2 = root2%get_view("empty_array")
        call assert_true(view2%is_empty(), "empty_array is_empty")
        call assert_true(view2%is_described(), "empty_array is_described")
-       call assert_equals(view2%get_type_id(), SIDRE_INT_ID, "empty_array get_type_id")
+       call assert_true(view2%get_type_id() == SIDRE_INT_ID, "empty_array get_type_id")
        call assert_true(view2%get_num_elements() == 0, "empty_array get_num_elements")
 !       call view2%set_array_data_ptr(foo3)
 !       call root2%set_array_data_ptr("empty_array", foo3)
@@ -862,7 +862,7 @@ contains
        view4 = root2%get_view("int2d")
        call assert_true(view4%is_external(), "int2d is_external")
        call assert_true(view4%is_described(), "int2d is_described")
-       call assert_equals(view4%get_type_id(), SIDRE_INT_ID, "int2d get_type_id")
+       call assert_true(view4%get_type_id() == SIDRE_INT_ID, "int2d get_type_id")
        call assert_true(view4%get_num_elements() == nfoo*2, "int2d get_num_elements")
        call assert_equals(view4%get_num_dimensions(), 2, "int2d get_num_dimensions")
        rank = view4%get_shape(7, extents)
@@ -940,13 +940,13 @@ contains
        view2 = root2%get_view("empty_described")
        call assert_true(view2%is_empty(), "empty_described is_empty")
        call assert_true(view2%is_described(), "empty_described is_described")
-       call assert_equals(view2%get_type_id(), SIDRE_INT_ID, "empty_described get_type_id")
+       call assert_true(view2%get_type_id() == SIDRE_INT_ID, "empty_described get_type_id")
        call assert_true(view2%get_num_elements() == ndata, "empty_described get_num_elements")
 
        view3 = root2%get_view("empty_shape")
        call assert_true(view3%is_empty(), "empty_shape is_empty")
        call assert_true(view3%is_described(), "empty_shape is_described")
-       call assert_equals(view3%get_type_id(), SIDRE_INT_ID, "empty_shape get_type_id")
+       call assert_true(view3%get_type_id() == SIDRE_INT_ID, "empty_shape get_type_id")
        call assert_true(view3%get_num_elements() == ndata*2, "empty_shape get_num_elements")
        shape2(:) = 0
        rank = view3%get_shape(7, shape2)
@@ -956,7 +956,7 @@ contains
        view4 = root2%get_view("buffer_shape")
        call assert_true(view4%has_buffer(), "buffer_shape has_buffer")
        call assert_true(view4%is_described(), "buffer_shape is_described")
-       call assert_equals(view4%get_type_id(), SIDRE_INT_ID, "buffer_shape get_type_id")
+       call assert_true(view4%get_type_id() == SIDRE_INT_ID, "buffer_shape get_type_id")
        call assert_true(view4%get_num_elements() == ndata*2, "buffer_shape get_num_elements")
        shape2(:) = 0
        rank = view4%get_shape(7, shape2)

--- a/src/axom/sidre/tests/sidre_view_F.f
+++ b/src/axom/sidre/tests/sidre_view_F.f
@@ -210,7 +210,7 @@ contains
         type(SidreView), intent(IN) :: view
         integer, intent(IN) :: state
         logical, intent(IN) :: is_described, is_allocated, is_applied
-        integer, intent(IN) :: type
+        integer(TypeID), intent(IN) :: type
         integer, intent(IN) :: length
         character(30) name
 
@@ -223,7 +223,7 @@ contains
         call assert_equals(view%is_allocated(), is_allocated, trim(name) // "is_allocated")
         call assert_equals(view%is_applied(), is_applied, trim(name) // " is_applied")
 
-        call assert_equals(view%get_type_id(), type, trim(name) // " get_type_id")
+        call assert_true(view%get_type_id() == type, trim(name) // " get_type_id")
         call assert_equals(int(view%get_num_elements(), kind(length)), length, trim(name) // " get_num_elements")
         call assert_equals(view%get_num_dimensions(), 1, trim(name) // " get_num_dimensions")
         call assert_true(view%get_shape(1, dims) == 1, trim(name) // " get_shape")
@@ -251,7 +251,7 @@ contains
     root = ds%get_root()
 
     dv = root%create_view_and_allocate("u0", SIDRE_INT_ID, elem_count)
-    call assert_equals(dv%get_type_id(), SIDRE_INT_ID, "dv%get_type_id(), SIDRE_INT_ID")
+    call assert_true(dv%get_type_id() == SIDRE_INT_ID, "dv%get_type_id(), SIDRE_INT_ID")
     call dv%get_data(data)
 
     do i = 1, elem_count
@@ -437,8 +437,8 @@ contains
     integer(C_INT), pointer :: data(:)
     type(C_PTR) data_ptr
     integer i
-    integer(C_LONG) depth_nelems
-    integer(C_LONG) total_nelems
+    integer(SIDRE_IndexType) depth_nelems
+    integer(SIDRE_IndexType) total_nelems
 
     call set_case_name("int_array_depth_view")
 
@@ -516,9 +516,9 @@ contains
     integer(C_INT), pointer :: data(:)
     type(C_PTR) data_ptr
     integer i
-    integer(C_LONG) field_nelems
-    integer(C_LONG) elem_count
-    integer(C_LONG) offset0, offset1
+    integer(SIDRE_IndexType) field_nelems
+    integer(SIDRE_IndexType) elem_count
+    integer(SIDRE_IndexType) offset0, offset1
 
     call set_case_name("int_array_view_attach_buffer")
 
@@ -601,10 +601,10 @@ contains
     real(C_DOUBLE), pointer :: data(:)
     type(C_PTR) data_ptr
     integer(C_INT) i
-    integer(C_LONG) field_nelems
-    integer(C_LONG) v1_nelems, v1_stride, v1_offset
-    integer(C_LONG) v2_nelems, v2_stride, v2_offset
-    integer(C_LONG) v3_nelems, v3_stride, v3_offset
+    integer(SIDRE_IndexType) field_nelems
+    integer(SIDRE_IndexType) v1_nelems, v1_stride, v1_offset
+    integer(SIDRE_IndexType) v2_nelems, v2_stride, v2_offset
+    integer(SIDRE_INdexType) v3_nelems, v3_stride, v3_offset
     real(C_DOUBLE), pointer :: data1(:), data2(:), data3(:)
     real(C_DOUBLE) :: elem
     integer int_size, double_size


### PR DESCRIPTION
# Set `axom::Sidre::IndexType` to `axom::IndexType`

- This PR is a bugfix or maybe a feature.
- It does the following:
  - Makes a consistent size for `IndexType` between Core and Sidre components.
  - This changes the default `IndexType` from `int64` to `int32` for Sidre.
  - Adds parameter `SIDRE_IndexType` to Fortran for the kind of `IndexType`.
  - Adds parameter `SIDRE_TypeID` to C and `TypeID` to Fortran to use with `axom::sidre::TypeID`
  - Fixes #43
  - Uses the current Shroud in the TPLs so I had to work around a bug by naming the Fortran parameter as `TypeID` instead of `SIDRE_TypeID`.  But I like that better anyways.
  - The C and Fortran type for the C++ enum `TypeID` was set to `short` instead of `int`. This removes some ambiguity in some Fortran generic interface for `View::apply``.
