### PR TITLE
Reorders input points in Scattered Interpolation query

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -151,6 +151,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   `axom:IndexType`. Before, Sidre always used `int64_t`. Now it
   respects the define `AXOM_USE_64BIT_INDEXTYPE`.
 - Mint now depends on the Slam component.
+- Renames indirection policies in slam: The c-array indirection policy was renamed from `ArrayIndirection` to `CArrayIndirection` 
+  and the axom::Array-based indirection policy was renamed from `CoreArrayIndirection` to `ArrayIndirection`.
 
 ###  Fixed
 - Fixed a bug relating to swap and assignment operations for multidimensional `axom::Array`s

--- a/src/axom/core/utilities/Utilities.hpp
+++ b/src/axom/core/utilities/Utilities.hpp
@@ -123,7 +123,7 @@ inline AXOM_HOST_DEVICE T lerp(T A, T B, T t)
  * \param [in] val The input value
  */
 template <typename T>
-inline T log2(T& val)
+inline T log2(T val)
 {
   return static_cast<T>(std::log2(val));
 }

--- a/src/axom/mint/mesh/Field.hpp
+++ b/src/axom/mint/mesh/Field.hpp
@@ -241,7 +241,7 @@ inline T* Field::getDataPtr(Field* field)
   SLIC_ASSERT(field != nullptr);
 
   // check type
-  int type = field_traits<T>::type();
+  constexpr int type = field_traits<T>::type();
   int ftype = field->getType();
   SLIC_ERROR_IF(
     (type == UNDEFINED_FIELD_TYPE),

--- a/src/axom/mint/mesh/UnstructuredMesh.hpp
+++ b/src/axom/mint/mesh/UnstructuredMesh.hpp
@@ -707,7 +707,6 @@ public:
    */
   virtual IndexType getNumberOfCellNodes(IndexType cellID = 0) const final override
   {
-    using CardinalityPolicy = typename CellToNodeRelation::CardinalityPolicy;
     return m_cell_node_rel.CardinalityPolicy::size(cellID);
   }
 
@@ -887,7 +886,6 @@ public:
    */
   virtual IndexType getNumberOfFaceNodes(IndexType faceID = 0) const final override
   {
-    using CardinalityPolicy = typename FaceToNodeRelation::CardinalityPolicy;
     return m_face_node_rel.CardinalityPolicy::size(faceID);
   }
 

--- a/src/axom/mint/mesh/UnstructuredMesh.hpp
+++ b/src/axom/mint/mesh/UnstructuredMesh.hpp
@@ -707,7 +707,8 @@ public:
    */
   virtual IndexType getNumberOfCellNodes(IndexType cellID = 0) const final override
   {
-    return m_cell_node_rel.CardinalityPolicy::size(cellID);
+    using CardinalityPolicy = typename CellToNodeRelation::CardinalityPolicy;
+    return static_cast<CardinalityPolicy>(m_cell_node_rel).size(cellID);
   }
 
   /*!
@@ -886,7 +887,8 @@ public:
    */
   virtual IndexType getNumberOfFaceNodes(IndexType faceID = 0) const final override
   {
-    return m_face_node_rel.CardinalityPolicy::size(faceID);
+    using CardinalityPolicy = typename FaceToNodeRelation::CardinalityPolicy;
+    return static_cast<CardinalityPolicy>(m_face_node_rel).size(faceID);
   }
 
   /*!

--- a/src/axom/quest/Delaunay.hpp
+++ b/src/axom/quest/Delaunay.hpp
@@ -397,7 +397,7 @@ public:
 
   /// \brief Find the index of the element that contains the query point, or the element closest to the point.
   IndexType findContainingElement(const PointType& query_pt,
-                                  bool warnOnInvalid = true)
+                                  bool warnOnInvalid = true) const
   {
     if(m_mesh.isEmpty())
     {
@@ -553,7 +553,7 @@ private:
      * \note Some bins might not point to a vertex, so users should check
      * that the returned index is a valid vertex, e.g. using \a mesh.isValidVertex(vertex_id)
      */
-    inline IndexType getNearbyVertex(const PointType& pt)
+    inline IndexType getNearbyVertex(const PointType& pt) const
     {
       const auto cell = m_lattice.gridCell(pt);
       return flatIndex(cell);
@@ -570,7 +570,14 @@ private:
     /// Returns a reference to the index in the array for the ND point with grid index \a cell
     inline IndexType& flatIndex(const typename LatticeType::GridCell& cell)
     {
-      IndexType idx =
+      const IndexType idx =
+        numerics::dot_product(cell.data(), m_bins.strides().begin(), DIM);
+      return m_bins.flatIndex(idx);
+    }
+
+    inline const IndexType& flatIndex(const typename LatticeType::GridCell& cell) const
+    {
+      const IndexType idx =
         numerics::dot_product(cell.data(), m_bins.strides().begin(), DIM);
       return m_bins.flatIndex(idx);
     }

--- a/src/axom/quest/ScatteredInterpolation.hpp
+++ b/src/axom/quest/ScatteredInterpolation.hpp
@@ -252,7 +252,7 @@ private:
 
   using VertexSet = typename DelaunayTriangulation::IAMeshType::VertexSet;
   using VertexIndirectionSet =
-    slam::CoreArrayIndirectionSet<typename VertexSet::PositionType, axom::IndexType>;
+    slam::ArrayIndirectionSet<typename VertexSet::PositionType, axom::IndexType>;
 
 private:
   /**

--- a/src/axom/quest/ScatteredInterpolation.hpp
+++ b/src/axom/quest/ScatteredInterpolation.hpp
@@ -320,6 +320,7 @@ private:
     using MortonizerType =
       spin::Mortonizer<QuantizedCoordType, MortonIndexType, DIM>;
 
+    // Fit as many bits as possible per dimension into an int64, i.e. floor(63/DIM)
     constexpr int shift_bits = (DIM == 2) ? 31 : 21;
     primal::NumericArray<QuantizedCoordType, DIM> res(1 << shift_bits, DIM);
     auto quantizer =

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -77,7 +77,7 @@ if(AXOM_ENABLE_TESTS)
     endforeach()
 endif()
 
-## Scattered interpolation example --------------------------------------------
+# Scattered interpolation example --------------------------------------------
 if(AXOM_ENABLE_SIDRE)
     blt_add_executable(
         NAME        quest_scattered_interpolation_ex
@@ -116,10 +116,10 @@ blt_add_executable(
     FOLDER      axom/quest/examples
     )
 
-# Add a test for the quest interface; Set up for MPI, when available
 set(quest_data_dir  ${AXOM_DATA_DIR}/quest)
 
 if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR)
+    # Add a test for the quest interface; Set up for MPI, when available
     if (ENABLE_MPI)
         axom_add_test(
             NAME quest_inout_interface_3D_mpi_test

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -14,6 +14,7 @@ blt_list_append(TO quest_example_depends ELEMENTS cuda IF ENABLE_CUDA)
 blt_list_append(TO quest_example_depends ELEMENTS blt::hip IF ENABLE_HIP)
 blt_list_append(TO quest_example_depends ELEMENTS RAJA IF RAJA_FOUND)
 
+# In/out octree containment example -------------------------------------------
 blt_add_executable(
     NAME        quest_containment_driver_ex
     SOURCES     containment_driver.cpp
@@ -22,6 +23,7 @@ blt_add_executable(
     FOLDER      axom/quest/examples
     )
 
+# Shaping example -------------------------------------------------------------
 if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
               AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION
               AND AXOM_ENABLE_KLEE)
@@ -34,6 +36,7 @@ if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
         )
 endif()
 
+# Distributed closest point example -------------------------------------------
 if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
               AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION)
     blt_add_executable(
@@ -45,6 +48,7 @@ if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
             )
 endif()
 
+# Point in cell example -------------------------------------------------------
 if(MFEM_FOUND)
     blt_add_executable(
         NAME        quest_point_in_cell_benchmark_ex
@@ -55,6 +59,7 @@ if(MFEM_FOUND)
         )
 endif()
 
+# Delaunay triangulation example ----------------------------------------------
 blt_add_executable(
     NAME        quest_delaunay_triangulation_ex
     SOURCES     delaunay_triangulation.cpp
@@ -63,13 +68,16 @@ blt_add_executable(
     FOLDER      axom/quest/examples
     )
 
-foreach(d 2 3)
-    axom_add_test(
-        NAME quest_delaunay_${d}_test
-        COMMAND quest_delaunay_triangulation_ex -d ${d} -o delaunay_mesh_${d}d -n 100
-        )
-endforeach()
+if(AXOM_ENABLE_TESTS)
+    foreach(d 2 3)
+        axom_add_test(
+            NAME quest_delaunay_${d}_test
+            COMMAND quest_delaunay_triangulation_ex -d ${d} -o delaunay_mesh_${d}d -n 100
+            )
+    endforeach()
+endif()
 
+## Scattered interpolation example --------------------------------------------
 if(AXOM_ENABLE_SIDRE)
     blt_add_executable(
         NAME        quest_scattered_interpolation_ex
@@ -78,10 +86,19 @@ if(AXOM_ENABLE_SIDRE)
         DEPENDS_ON  ${quest_example_depends}
         FOLDER      axom/quest/examples
         )
+
+    if(AXOM_ENABLE_TESTS)
+        foreach(d 2 3)
+            axom_add_test(
+                NAME quest_scattered_interpolation_${d}_test
+                COMMAND quest_scattered_interpolation_ex -d ${d} -n 10000 -q 20000
+                )
+        endforeach()
+    endif()
 endif()
 
 
-## Quest interface examples
+# Quest signed distance and inout interface examples (C++ and Fortran) --------
 
 blt_add_executable(
     NAME       quest_signed_distance_interface_ex

--- a/src/axom/quest/examples/scattered_interpolation.cpp
+++ b/src/axom/quest/examples/scattered_interpolation.cpp
@@ -609,7 +609,7 @@ void initializeInputMesh(Input& params, internal::blueprint::PointMesh& inputMes
 
     // recompute and reset bounding box based on input mesh
     const int nPts = inputMesh.numPoints();
-    auto coords = quest::detail::InterleavedOrStridedPoints<DIM>(
+    auto coords = quest::detail::InterleavedOrStridedPoints<double, DIM>(
       inputMesh.coordsGroup()->getGroup("values"));
 
     BBoxType bbox;
@@ -638,7 +638,7 @@ void initializeInputMesh(Input& params, internal::blueprint::PointMesh& inputMes
 
     // Extract coordinate positions as scalar fields
     const int nPts = inputMesh.numPoints();
-    auto coords = quest::detail::InterleavedOrStridedPoints<DIM>(
+    auto coords = quest::detail::InterleavedOrStridedPoints<double, DIM>(
       inputMesh.coordsGroup()->getGroup("values"));
 
     inputMesh.registerNodalScalarField<double>("pos_x");
@@ -700,7 +700,7 @@ bool checkInterpolation(
 
   using InterpIndices = primal::Point<axom::IndexType, DIM + 1>;
   using InterpWeights = primal::Point<double, DIM + 1>;
-  using PointArray = InterleavedOrStridedPoints<DIM>;
+  using PointArray = InterleavedOrStridedPoints<double, DIM>;
 
   constexpr double EPS = 1e-8;
 

--- a/src/axom/quest/examples/scattered_interpolation.cpp
+++ b/src/axom/quest/examples/scattered_interpolation.cpp
@@ -727,7 +727,9 @@ int main(int argc, char** argv)
   // Write input mesh to file
   {
     std::string file = params.outputFile + "_input_mesh";
-    SLIC_INFO(axom::fmt::format("Writing input mesh to '{}/{}'", axom::utilities::filesystem::getCWD(),file));
+    SLIC_INFO(axom::fmt::format("Writing input mesh to '{}/{}'",
+                                axom::utilities::filesystem::getCWD(),
+                                file));
     inputMesh.saveMesh(file, params.outputProtocol);
   }
 

--- a/src/axom/quest/examples/scattered_interpolation.cpp
+++ b/src/axom/quest/examples/scattered_interpolation.cpp
@@ -727,7 +727,7 @@ int main(int argc, char** argv)
   // Write input mesh to file
   {
     std::string file = params.outputFile + "_input_mesh";
-    SLIC_INFO(axom::fmt::format("Writing input mesh to '{}'", file));
+    SLIC_INFO(axom::fmt::format("Writing input mesh to '{}/{}'", axom::utilities::filesystem::getCWD(),file));
     inputMesh.saveMesh(file, params.outputProtocol);
   }
 
@@ -798,7 +798,10 @@ int main(int argc, char** argv)
   // Write query mesh to file
   {
     std::string file = params.outputFile + "_output_mesh";
-    SLIC_INFO(axom::fmt::format("Writing interpolated point mesh to '{}'", file));
+    SLIC_INFO(axom::fmt::format("Writing interpolated point mesh to '{}/{}'",
+                                axom::utilities::filesystem::getCWD(),
+                                file));
+
     queryMesh.saveMesh(file, params.outputProtocol);
   }
 

--- a/src/axom/quest/examples/scattered_interpolation.cpp
+++ b/src/axom/quest/examples/scattered_interpolation.cpp
@@ -897,6 +897,7 @@ int main(int argc, char** argv)
 
   // Generate the Delaunay complex
   int numVerts = 0, numSimps = 0;
+  std::string bboxStr;
   axom::utilities::Timer timer(true);
   switch(params.dimension)
   {
@@ -904,22 +905,26 @@ int main(int argc, char** argv)
     scattered_2d->buildTriangulation(bp_input, inputMesh.coordsName());
     numVerts = scattered_2d->numVertices();
     numSimps = scattered_2d->numSimplices();
+    bboxStr = axom::fmt::format("{}", scattered_2d->boundingBox());
     break;
   case 3:
     scattered_3d->buildTriangulation(bp_input, inputMesh.coordsName());
     numVerts = scattered_3d->numVertices();
     numSimps = scattered_3d->numSimplices();
+    bboxStr = axom::fmt::format("{}", scattered_3d->boundingBox());
     break;
   }
   timer.stop();
-  SLIC_INFO(axom::fmt::format(
-    "It took {} seconds to create a Delaunay complex with {} "
-    "points. Mesh has {} {}. Insertion rate of {:.1f} points per second.",
-    timer.elapsedTimeInSec(),
-    numVerts,
-    numSimps,
-    params.dimension == 2 ? "triangles" : "tetrahedra",
-    numVerts / timer.elapsedTimeInSec()));
+  SLIC_INFO(
+    axom::fmt::format("It took {} seconds to create a Delaunay complex with {} "
+                      "points, {} {} and bounding box {}. "
+                      "Insertion rate of {:.1f} points per second.",
+                      timer.elapsedTimeInSec(),
+                      numVerts,
+                      numSimps,
+                      params.dimension == 2 ? "triangles" : "tetrahedra",
+                      bboxStr,
+                      numVerts / timer.elapsedTimeInSec()));
 
   // Dump the Delaunay complex to disk as a vtk file
   switch(params.dimension)

--- a/src/axom/quest/examples/scattered_interpolation.cpp
+++ b/src/axom/quest/examples/scattered_interpolation.cpp
@@ -770,12 +770,10 @@ int main(int argc, char** argv)
   switch(params.dimension)
   {
   case 2:
-    scattered_2d = std::unique_ptr<quest::ScatteredInterpolation<2>>(
-      new quest::ScatteredInterpolation<2>);
+    scattered_2d = std::make_unique<quest::ScatteredInterpolation<2>>();
     break;
   case 3:
-    scattered_3d = std::unique_ptr<quest::ScatteredInterpolation<3>>(
-      new quest::ScatteredInterpolation<3>);
+    scattered_3d = std::make_unique<quest::ScatteredInterpolation<3>>();
     break;
   }
 

--- a/src/axom/slam/DynamicMap.hpp
+++ b/src/axom/slam/DynamicMap.hpp
@@ -163,7 +163,7 @@ public:
   }
 
   /**
-   * \brief Insert vale \a value into position \a position in the map
+   * \brief Insert \a value into \a position in the map
    *
    * \note Increases the map size if position is out of range
    */

--- a/src/axom/slam/IndirectionSet.hpp
+++ b/src/axom/slam/IndirectionSet.hpp
@@ -22,7 +22,7 @@ namespace axom
 namespace slam
 {
 /**
- * \brief Alias template for an OrderedSet with indirection over an array
+ * \brief Alias template for an OrderedSet with indirection over a C array
  *
  * \tparam PosType The position type for indexing into the set
  * \tparam ElemType The type for the set's elements
@@ -30,13 +30,13 @@ namespace slam
  */
 template <typename PosType = slam::DefaultPositionType,
           typename ElemType = slam::DefaultElementType>
-using ArrayIndirectionSet =
+using CArrayIndirectionSet =
   OrderedSet<PosType,
              ElemType,
              policies::RuntimeSize<PosType>,
              policies::ZeroOffset<PosType>,
              policies::StrideOne<PosType>,
-             policies::ArrayIndirection<PosType, ElemType>>;
+             policies::CArrayIndirection<PosType, ElemType>>;
 
 /**
  * \brief Alias template for an OrderedSet with indirection over an stl vector

--- a/src/axom/slam/IndirectionSet.hpp
+++ b/src/axom/slam/IndirectionSet.hpp
@@ -72,6 +72,23 @@ using ArrayViewIndirectionSet =
              policies::StrideOne<PosType>,
              policies::ArrayViewIndirection<PosType, ElemType>>;
 
+/**
+ * \brief Alias template for an OrderedSet with indirection over an axom::Array
+ *
+ * \tparam PosType The position type for indexing into the set
+ * \tparam ElemType The type for the set's elements
+ * \sa OrderedSet
+ */
+template <typename PosType = slam::DefaultPositionType,
+          typename ElemType = slam::DefaultElementType>
+using CoreArrayIndirectionSet =
+  OrderedSet<PosType,
+             ElemType,
+             policies::RuntimeSize<PosType>,
+             policies::ZeroOffset<PosType>,
+             policies::StrideOne<PosType>,
+             policies::CoreArrayIndirection<PosType, ElemType>>;
+
 }  // end namespace slam
 }  // end namespace axom
 

--- a/src/axom/slam/IndirectionSet.hpp
+++ b/src/axom/slam/IndirectionSet.hpp
@@ -56,6 +56,23 @@ using VectorIndirectionSet =
              policies::STLVectorIndirection<PosType, ElemType>>;
 
 /**
+ * \brief Alias template for an OrderedSet with indirection over an axom::Array
+ *
+ * \tparam PosType The position type for indexing into the set
+ * \tparam ElemType The type for the set's elements
+ * \sa OrderedSet
+ */
+template <typename PosType = slam::DefaultPositionType,
+          typename ElemType = slam::DefaultElementType>
+using ArrayIndirectionSet =
+  OrderedSet<PosType,
+             ElemType,
+             policies::RuntimeSize<PosType>,
+             policies::ZeroOffset<PosType>,
+             policies::StrideOne<PosType>,
+             policies::ArrayIndirection<PosType, ElemType>>;
+
+/**
  * \brief Alias template for an OrderedSet with indirection over an axom::ArrayView
  *
  * \tparam PosType The position type for indexing into the set
@@ -71,23 +88,6 @@ using ArrayViewIndirectionSet =
              policies::ZeroOffset<PosType>,
              policies::StrideOne<PosType>,
              policies::ArrayViewIndirection<PosType, ElemType>>;
-
-/**
- * \brief Alias template for an OrderedSet with indirection over an axom::Array
- *
- * \tparam PosType The position type for indexing into the set
- * \tparam ElemType The type for the set's elements
- * \sa OrderedSet
- */
-template <typename PosType = slam::DefaultPositionType,
-          typename ElemType = slam::DefaultElementType>
-using CoreArrayIndirectionSet =
-  OrderedSet<PosType,
-             ElemType,
-             policies::RuntimeSize<PosType>,
-             policies::ZeroOffset<PosType>,
-             policies::StrideOne<PosType>,
-             policies::CoreArrayIndirection<PosType, ElemType>>;
 
 }  // end namespace slam
 }  // end namespace axom

--- a/src/axom/slam/examples/UserDocs.cpp
+++ b/src/axom/slam/examples/UserDocs.cpp
@@ -92,7 +92,7 @@ struct SimpleQuadMesh
   // _quadmesh_example_set_typedefs_end
 
   // _quadmesh_example_common_typedefs_start
-  using ArrayIndir = slam::policies::ArrayIndirection<PosType, ElemType>;
+  using ArrayIndir = slam::policies::CArrayIndirection<PosType, ElemType>;
   // _quadmesh_example_common_typedefs_end
 
   /// Type aliases for relations

--- a/src/axom/slam/policies/IndirectionPolicies.hpp
+++ b/src/axom/slam/policies/IndirectionPolicies.hpp
@@ -211,7 +211,7 @@ private:
  * \brief A policy class for sets with axom::Array-based indirection
  */
 template <typename PositionType, typename ElementType>
-struct CoreArrayIndirection
+struct ArrayIndirection
 {
   using IndirectionResult = ElementType&;
   using ConstIndirectionResult = const ElementType&;
@@ -220,29 +220,27 @@ struct CoreArrayIndirection
   using IndirectionBufferType = VectorType;
   using IndirectionPtrType = IndirectionBufferType*;
 
-  CoreArrayIndirection(IndirectionBufferType* buf = nullptr) : m_vecBuf(buf) { }
+  ArrayIndirection(IndirectionBufferType* buf = nullptr) : m_vecBuf(buf) { }
 
   IndirectionBufferType*& data() { return m_vecBuf; }
   IndirectionBufferType* const& data() const { return m_vecBuf; }
 
   inline ConstIndirectionResult indirection(PositionType pos) const
   {
-    SLIC_ASSERT_MSG(hasIndirection(),
-                    "SLAM::Set:CoreArrayIndirection -- Tried to dereference "
-                      << "a null vector in a vector based indirection set.");
-    //SLIC_ASSERT_MSG( pos < m_vecBuf->size(),
-    //  "SLAM::Set:CoreArrayIndirection -- "
-    //  << "Tried to access an out of bounds element at position "
-    //  << pos << " in vector with only " << m_vecBuf->size() << " elements.");
+    SLIC_ASSERT_MSG(
+      hasIndirection(),
+      "SLAM::Set:ArrayIndirection -- Tried to dereference "
+        << "a null vector in an axom::Array-based indirection set.");
 
     return (*m_vecBuf)[pos];
   }
 
   inline IndirectionResult indirection(PositionType pos)
   {
-    SLIC_ASSERT_MSG(hasIndirection(),
-                    "SLAM::Set:CoreArrayIndirection -- Tried to dereference "
-                      << "a null vector in a vector based indirection set.");
+    SLIC_ASSERT_MSG(
+      hasIndirection(),
+      "SLAM::Set:ArrayIndirection -- Tried to dereference "
+        << "a null vector in an axom::Array-based indirection set.");
 
     return (*m_vecBuf)[pos];
   }
@@ -297,22 +295,20 @@ struct ArrayViewIndirection
 
   inline ConstIndirectionResult indirection(PositionType pos) const
   {
-    SLIC_ASSERT_MSG(hasIndirection(),
-                    "SLAM::Set:ArrayViewIndirection -- Tried to dereference "
-                      << "a null vector in a vector based indirection set.");
-    //SLIC_ASSERT_MSG( pos < m_vecBuf->size(),
-    //  "SLAM::Set:ArrayViewIndirection -- "
-    //  << "Tried to access an out of bounds element at position "
-    //  << pos << " in vector with only " << m_vecBuf->size() << " elements.");
+    SLIC_ASSERT_MSG(
+      hasIndirection(),
+      "SLAM::Set:ArrayViewIndirection -- Tried to dereference "
+        << "a null vector in an axom::ArrayView-based indirection set.");
 
     return m_vecBuf[pos];
   }
 
   inline IndirectionResult indirection(PositionType pos)
   {
-    SLIC_ASSERT_MSG(hasIndirection(),
-                    "SLAM::Set:ArrayViewIndirection -- Tried to dereference "
-                      << "a null vector in a vector based indirection set.");
+    SLIC_ASSERT_MSG(
+      hasIndirection(),
+      "SLAM::Set:ArrayViewIndirection -- Tried to dereference "
+        << "a null vector in an axom::ArrayView-based indirection set.");
 
     return m_vecBuf[pos];
   }
@@ -443,10 +439,10 @@ bool STLVectorIndirection<PosType, ElemType>::isValid(PosType size,
 }
 
 template <typename PosType, typename ElemType>
-bool CoreArrayIndirection<PosType, ElemType>::isValid(PosType size,
-                                                      PosType offset,
-                                                      PosType stride,
-                                                      bool verboseOutput) const
+bool ArrayIndirection<PosType, ElemType>::isValid(PosType size,
+                                                  PosType offset,
+                                                  PosType stride,
+                                                  bool verboseOutput) const
 {
   AXOM_UNUSED_VAR(verboseOutput);
 
@@ -467,7 +463,7 @@ bool CoreArrayIndirection<PosType, ElemType>::isValid(PosType size,
   }
   else
   {
-    // Verify underlying vector has sufficient storage for all set elements
+    // Verify underlying array has sufficient storage for all set elements
     // Note: it is valid for the data buffer to have extra space
     PosType firstEltInd = offset;
     PosType lastEltInd = (size - 1) * stride + offset;
@@ -512,7 +508,7 @@ bool ArrayViewIndirection<PosType, ElemType>::isValid(PosType size,
   if(!hasIndirection())
   {
     SLIC_DEBUG_IF(verboseOutput,
-                  "Array-based indirection set with non-zero size "
+                  "ArrayView-based indirection set with non-zero size "
                     << "(size=" << size << ") requires a valid data buffer,"
                     << "but buffer pointer was null.");
 
@@ -520,7 +516,7 @@ bool ArrayViewIndirection<PosType, ElemType>::isValid(PosType size,
   }
   else
   {
-    // Verify underlying vector has sufficient storage for all set elements
+    // Verify underlying array has sufficient storage for all set elements
     // Note: it is valid for the data buffer to have extra space
     PosType firstEltInd = offset;
     PosType lastEltInd = (size - 1) * stride + offset;
@@ -533,7 +529,7 @@ bool ArrayViewIndirection<PosType, ElemType>::isValid(PosType size,
     {
       SLIC_DEBUG_IF(
         verboseOutput,
-        "Invalid array-based IndirectionSet -- Data buffer "
+        "Invalid ArrayView-based IndirectionSet -- Data buffer "
           << "must be large enough to hold all elements of the set. "
           << "Underlying buffer size is " << vecSize << "."
           << " Offset of " << offset << " leads to a first index of "

--- a/src/axom/slam/policies/IndirectionPolicies.hpp
+++ b/src/axom/slam/policies/IndirectionPolicies.hpp
@@ -86,10 +86,10 @@ struct NoIndirection
 };
 
 /**
- * \brief A policy class for sets with array-based indirection
+ * \brief A policy class for sets with C-style array-based indirection
  */
 template <typename PositionType, typename ElementType>
-struct ArrayIndirection
+struct CArrayIndirection
 {
   using IndirectionResult = ElementType&;
   using ConstIndirectionResult = const ElementType&;
@@ -97,14 +97,14 @@ struct ArrayIndirection
   using IndirectionBufferType = ElementType;
   using IndirectionPtrType = IndirectionBufferType*;
 
-  ArrayIndirection(IndirectionBufferType* buf = nullptr) : m_arrBuf(buf) { }
+  CArrayIndirection(IndirectionBufferType* buf = nullptr) : m_arrBuf(buf) { }
 
   IndirectionBufferType*& data() { return m_arrBuf; }
 
   inline ConstIndirectionResult indirection(PositionType pos) const
   {
     SLIC_ASSERT_MSG(hasIndirection(),
-                    "SLAM::Set:ArrayIndirection -- Tried to dereference "
+                    "SLAM::Set:CArrayIndirection -- Tried to dereference "
                       << " a null array in an array based indirection set.");
     return m_arrBuf[pos];
   }
@@ -112,7 +112,7 @@ struct ArrayIndirection
   inline IndirectionResult indirection(PositionType pos)
   {
     SLIC_ASSERT_MSG(hasIndirection(),
-                    "SLAM::Set:ArrayIndirection -- Tried to dereference "
+                    "SLAM::Set:CArrayIndirection -- Tried to dereference "
                       << " a null array in an array based indirection set.");
     return m_arrBuf[pos];
   }
@@ -341,10 +341,10 @@ private:
 /// \}
 
 template <typename PosType, typename ElemType>
-bool ArrayIndirection<PosType, ElemType>::isValid(PosType size,
-                                                  PosType offset,
-                                                  PosType stride,
-                                                  bool verboseOutput) const
+bool CArrayIndirection<PosType, ElemType>::isValid(PosType size,
+                                                   PosType offset,
+                                                   PosType stride,
+                                                   bool verboseOutput) const
 {
   AXOM_UNUSED_VAR(verboseOutput);
 
@@ -366,9 +366,7 @@ bool ArrayIndirection<PosType, ElemType>::isValid(PosType size,
   else
   {
     // Check that none of the elements have negative indices within the array
-    // Note: We do not have sufficient information about the array to know its
-    // upper bound
-
+    // Note: We do not have sufficient information about the array to know its upper bound
     PosType firstEltInd = offset;
     PosType lastEltInd = (size - 1) * stride + offset;
 
@@ -377,7 +375,7 @@ bool ArrayIndirection<PosType, ElemType>::isValid(PosType size,
     {
       SLIC_DEBUG_IF(
         verboseOutput,
-        "Array-based indirection does not allow access "
+        "C-style array-based indirection does not allow access "
           << "to data with lower addresses than its underlying pointer."
           << " Offset of " << offset << " leads to a first index of "
           << firstEltInd << "."

--- a/src/axom/slam/tests/slam_AccessingRelationDataInMap.cpp
+++ b/src/axom/slam/tests/slam_AccessingRelationDataInMap.cpp
@@ -44,12 +44,10 @@ using RelationType = slam::Relation<SetPosition, SetElement>;
 
 using IndexVec = std::vector<SetPosition>;
 
-const SetPosition FROMSET_SIZE = 10;
-const SetPosition TOSET_SIZE = 8;
+constexpr SetPosition FROMSET_SIZE = 10;
+constexpr SetPosition TOSET_SIZE = 8;
 
 using STLIndirection = policies::STLVectorIndirection<SetPosition, SetElement>;
-
-using ArrayIndirection = policies::ArrayIndirection<SetPosition, SetElement>;
 
 using VariableCardinality =
   policies::VariableCardinality<SetPosition, STLIndirection>;

--- a/src/axom/slam/tests/slam_relation_DynamicConstant.cpp
+++ b/src/axom/slam/tests/slam_relation_DynamicConstant.cpp
@@ -34,9 +34,9 @@ using ElementType = slam::DefaultElementType;
 
 using RangeSetType = slam::RangeSet<PositionType, ElementType>;
 
-const PositionType FROMSET_SIZE = 5;
-const PositionType TOSET_SIZE = 6;
-const PositionType ELEM_STRIDE = 6;
+constexpr PositionType FROMSET_SIZE = 5;
+constexpr PositionType TOSET_SIZE = 6;
+constexpr PositionType ELEM_STRIDE = 6;
 
 using CTStride = policies::CompileTimeStride<PositionType, ELEM_STRIDE>;
 using RTStride = policies::RuntimeStride<PositionType>;
@@ -47,7 +47,6 @@ using ConstantCardinalityRT =
   policies::ConstantCardinality<PositionType, RTStride>;
 
 using STLIndirection = policies::STLVectorIndirection<PositionType, ElementType>;
-using ArrayIndirection = policies::ArrayIndirection<PositionType, ElementType>;
 
 using IndexVec = std::vector<PositionType>;
 using RelationType =

--- a/src/axom/slam/tests/slam_relation_StaticConstant.cpp
+++ b/src/axom/slam/tests/slam_relation_StaticConstant.cpp
@@ -44,9 +44,9 @@ using SetElement = slam::DefaultElementType;
 
 using RangeSetType = slam::RangeSet<SetPosition, SetElement>;
 
-const SetPosition FROMSET_SIZE = 5;
-const SetPosition TOSET_SIZE = 6;
-const SetPosition ELEM_STRIDE = 5;
+constexpr SetPosition FROMSET_SIZE = 5;
+constexpr SetPosition TOSET_SIZE = 6;
+constexpr SetPosition ELEM_STRIDE = 5;
 
 using CTStride = policies::CompileTimeStride<SetPosition, ELEM_STRIDE>;
 using RTStride = policies::RuntimeStride<SetPosition>;
@@ -57,7 +57,7 @@ using ConstantCardinalityRT =
   policies::ConstantCardinality<SetPosition, RTStride>;
 
 using STLIndirection = policies::STLVectorIndirection<SetPosition, SetElement>;
-using ArrayIndirection = policies::ArrayIndirection<SetPosition, SetElement>;
+using CArrayIndirection = policies::CArrayIndirection<SetPosition, SetElement>;
 
 using IndexVec = std::vector<SetPosition>;
 
@@ -432,16 +432,16 @@ TEST(slam_relation_static_constant, runtime_stride_STLIndirection)
   iterateRelation_range(builderRel);
 }
 
-TEST(slam_relation_static_constant, runtime_stride_ArrayIndirection)
+TEST(slam_relation_static_constant, runtime_stride_CArrayIndirection)
 {
   SLIC_INFO("Tests for Static Relation "
-            << " with runtime stride and array Indirection");
+            << " with runtime stride and C-array Indirection");
 
   using StaticConstantRelation_RT_Array =
     slam::StaticRelation<SetPosition,
                          SetElement,
                          ConstantCardinalityRT,
-                         ArrayIndirection,
+                         CArrayIndirection,
                          RangeSetType,
                          RangeSetType>;
 
@@ -492,16 +492,16 @@ TEST(slam_relation_static_constant, runtime_stride_ArrayIndirection)
   iterateRelation_range(builderRel);
 }
 
-TEST(slam_relation_static_constant, compileTime_stride_ArrayIndirection)
+TEST(slam_relation_static_constant, compileTime_stride_CArrayIndirection)
 {
   SLIC_INFO("Tests for Static Relation with "
-            << " runtime stride and array Indirection");
+            << " runtime stride and C-array Indirection");
 
   using StaticConstantRelation_CT_Array =
     slam::StaticRelation<SetPosition,
                          SetElement,
                          ConstantCardinalityCT,
-                         ArrayIndirection,
+                         CArrayIndirection,
                          RangeSetType,
                          RangeSetType>;
 
@@ -524,7 +524,7 @@ TEST(slam_relation_static_constant, compileTime_stride_ArrayIndirection)
   relation.bindIndices(relIndices.size(), data);
 
   // Note: Since the striding is a compile time constant,
-  //       we don't need to set the striding,
+  //       we don't need to set the striding
   EXPECT_TRUE(relation.isValid(true));
 
   //        .. but we can, if we'd like to

--- a/src/axom/slam/tests/slam_relation_StaticVariable.cpp
+++ b/src/axom/slam/tests/slam_relation_StaticVariable.cpp
@@ -39,11 +39,10 @@ using RelationType = slam::Relation<SetPosition, SetElement>;
 
 using IndexVec = std::vector<SetPosition>;
 
-const SetPosition FROMSET_SIZE = 7;
-const SetPosition TOSET_SIZE = 8;
+constexpr SetPosition FROMSET_SIZE = 7;
+constexpr SetPosition TOSET_SIZE = 8;
 
 using STLIndirection = policies::STLVectorIndirection<SetPosition, SetElement>;
-using ArrayIndirection = policies::ArrayIndirection<SetPosition, SetElement>;
 
 using VariableCardinality =
   policies::VariableCardinality<SetPosition, STLIndirection>;

--- a/src/axom/slam/tests/slam_set_IndirectionSet.cpp
+++ b/src/axom/slam/tests/slam_set_IndirectionSet.cpp
@@ -89,7 +89,7 @@ public:
 
   /**
    * Get a pointer to the data buffer
-   * Specialization for ArrayIndirection
+   * Specialization for CArrayIndirection
    * \pre index must be 0, 1 or 2
    */
   void getDataBuffer(ElemType*& ptr, int index = 0)
@@ -160,7 +160,7 @@ bool compareData(axom::ArrayView<ElemType> a, axom::ArrayView<ElemType> b)
 
 // Tests several types of indirection sets
 using MyTypes =
-  ::testing::Types<slam::ArrayIndirectionSet<axom::int32, axom::int64>,
+  ::testing::Types<slam::CArrayIndirectionSet<axom::int32, axom::int64>,
                    slam::VectorIndirectionSet<axom::int32, axom::int64>,
                    slam::CoreArrayIndirectionSet<axom::int32, axom::int64>,
                    slam::ArrayViewIndirectionSet<axom::int32, axom::int64>>;
@@ -432,7 +432,7 @@ TEST(slam_set_indirectionset, compare_array_and_vector)
   using E = int;
 
   using VecSet = slam::VectorIndirectionSet<P, E>;
-  using ArrSet = slam::ArrayIndirectionSet<P, E>;
+  using CArrSet = slam::CArrayIndirectionSet<P, E>;
   using PosSet = slam::PositionSet<P, E>;
 
   const int SZ = MAX_SET_SIZE;
@@ -446,9 +446,9 @@ TEST(slam_set_indirectionset, compare_array_and_vector)
               .size(SZ)           //
               .data(&vVals));
 
-  ArrSet as(ArrSet::SetBuilder()  //
-              .size(SZ)           //
-              .data(aVals.data()));
+  CArrSet as(CArrSet::SetBuilder()  //
+               .size(SZ)            //
+               .data(aVals.data()));
 
   EXPECT_NE(vs, ps);
   EXPECT_NE(as, ps);
@@ -479,13 +479,13 @@ TEST(slam_set_indirectionset, negative_stride)
   using OffPol = policies::RuntimeOffset<SetPosition>;
   using StridePol = policies::RuntimeStride<SetPosition>;
   using VecIndPol = policies::STLVectorIndirection<SetPosition, SetElement>;
-  using ArrIndPol = policies::ArrayIndirection<SetPosition, SetElement>;
+  using CArrIndPol = policies::CArrayIndirection<SetPosition, SetElement>;
 
   using VecSet =
     slam::OrderedSet<SetPosition, SetElement, SizePol, OffPol, StridePol, VecIndPol>;
 
-  using ArrSet =
-    slam::OrderedSet<SetPosition, SetElement, SizePol, OffPol, StridePol, ArrIndPol>;
+  using CArrSet =
+    slam::OrderedSet<SetPosition, SetElement, SizePol, OffPol, StridePol, CArrIndPol>;
 
   // Set up data -- an array of incrementing integers
   std::vector<SetElement> intVec(MAX_SET_SIZE);
@@ -557,28 +557,28 @@ TEST(slam_set_indirectionset, negative_stride)
     SLIC_DEBUG_IF(bVerbose, "--- Done.");
   }
 
-  // Setup the VectorIndirectionSet and test basic functionality
-  ArrSet aSet(ArrSet::SetBuilder()  //
-                .size(setSize)      //
-                .offset(setOffset)  //
-                .stride(setStride)  //
-                .data(intVec.data()));
+  // Setup the CArrayIndirectionSet and test basic functionality
+  CArrSet cSet(CArrSet::SetBuilder()  //
+                 .size(setSize)       //
+                 .offset(setOffset)   //
+                 .stride(setStride)   //
+                 .data(intVec.data()));
   {
-    EXPECT_TRUE(aSet.isValid());
-    EXPECT_FALSE(aSet.empty());
-    EXPECT_EQ(setSize, aSet.size());
-    EXPECT_TRUE(aSet.hasIndirection());
+    EXPECT_TRUE(cSet.isValid());
+    EXPECT_FALSE(cSet.empty());
+    EXPECT_EQ(setSize, cSet.size());
+    EXPECT_TRUE(cSet.hasIndirection());
 
-    EXPECT_EQ(intVec[setOffset], aSet[0]);
+    EXPECT_EQ(intVec[setOffset], cSet[0]);
 
     SLIC_INFO("Ordered array set has:"
-              << "{ size: " << aSet.size() << ", stride: " << aSet.stride()
-              << ", offset: " << aSet.offset() << ", first elt: " << aSet[0]
-              << ", last elt: " << aSet[aSet.size() - 1] << "}");
+              << "{ size: " << cSet.size() << ", stride: " << cSet.stride()
+              << ", offset: " << cSet.offset() << ", first elt: " << cSet[0]
+              << ", last elt: " << cSet[cSet.size() - 1] << "}");
 
-    for(int i = 0; i < aSet.size(); ++i)
+    for(int i = 0; i < cSet.size(); ++i)
     {
-      EXPECT_EQ(setOffset + setStride * i, aSet[i]);
+      EXPECT_EQ(setOffset + setStride * i, cSet[i]);
     }
 
     /// Several checks that sets with bad offsets and strides are invalid
@@ -586,38 +586,38 @@ TEST(slam_set_indirectionset, negative_stride)
                   "--- Checking isValid() on several sets with "
                     << "bad sizes, offsets and strides.");
 
-    ArrSet noDataASet(ArrSet::SetBuilder()  // Note: Missing a data pointer
-                        .size(setSize)
-                        .offset(setOffset)
-                        .stride(setStride));
-    EXPECT_FALSE(noDataASet.isValid(bVerbose));
+    CArrSet noDataCSet(CArrSet::SetBuilder()  // Note: Missing a data pointer
+                         .size(setSize)
+                         .offset(setOffset)
+                         .stride(setStride));
+    EXPECT_FALSE(noDataCSet.isValid(bVerbose));
 
-    ArrSet outOfBoundsASet1(ArrSet::SetBuilder()
-                              .size(setSize + 1)  // Note: last index is out of bounds
-                              .offset(setOffset)
-                              .stride(setStride)
-                              .data(intVec.data()));
-    EXPECT_FALSE(outOfBoundsASet1.isValid(bVerbose));
+    CArrSet outOfBoundsCSet1(CArrSet::SetBuilder()
+                               .size(setSize + 1)  // Note: last index is out of bounds
+                               .offset(setOffset)
+                               .stride(setStride)
+                               .data(intVec.data()));
+    EXPECT_FALSE(outOfBoundsCSet1.isValid(bVerbose));
 
-    ArrSet outOfBoundsASet2(ArrSet::SetBuilder()
-                              .size(setSize)
-                              .offset(-1)  // Note: first index is out of bounds
-                              .stride(1)
-                              .data(intVec.data()));
-    EXPECT_FALSE(outOfBoundsASet2.isValid(bVerbose));
+    CArrSet outOfBoundsCSet2(CArrSet::SetBuilder()
+                               .size(setSize)
+                               .offset(-1)  // Note: first index is out of bounds
+                               .stride(1)
+                               .data(intVec.data()));
+    EXPECT_FALSE(outOfBoundsCSet2.isValid(bVerbose));
 
-    ArrSet zeroStrideASet(ArrSet::SetBuilder()
-                            .size(setSize)
-                            .offset(setOffset)
-                            .stride(0)  // Note: A stride of zero is not valid
-                            .data(intVec.data()));
-    EXPECT_FALSE(zeroStrideASet.isValid(bVerbose));
+    CArrSet zeroStrideCSet(CArrSet::SetBuilder()
+                             .size(setSize)
+                             .offset(setOffset)
+                             .stride(0)  // Note: stride of zero is not valid
+                             .data(intVec.data()));
+    EXPECT_FALSE(zeroStrideCSet.isValid(bVerbose));
 
     SLIC_DEBUG_IF(bVerbose, "--- Done.");
   }
 
-  // check that vset and aset are equivalent
-  EXPECT_EQ(vSet, aSet);
+  // check that vset and cset are equivalent
+  EXPECT_EQ(vSet, cSet);
 }
 
 //----------------------------------------------------------------------

--- a/src/axom/slam/tests/slam_set_IndirectionSet.cpp
+++ b/src/axom/slam/tests/slam_set_IndirectionSet.cpp
@@ -111,7 +111,7 @@ public:
 
   /**
    * Get a pointer to the data buffer
-   * Specialization for CoreArrayIndirection
+   * Specialization for ArrayIndirection
    * \pre index must be 0, 1 or 2
    */
   void getDataBuffer(axom::Array<ElemType>*& ptr, int index = 0)
@@ -120,6 +120,11 @@ public:
     ptr = &mDataArr[index];
   }
 
+  /**
+   * Get a pointer to the data buffer
+   * Specialization for ArrayViewIndirection
+   * \pre index must be 0, 1 or 2
+   */
   void getDataBuffer(axom::ArrayView<ElemType>& ptr, int index = 0)
   {
     checkIndex(index);
@@ -128,7 +133,7 @@ public:
   }
 
 private:
-  /** Check that the index is valid; fail test if not */
+  /// Check that the index is valid; fail test if not
   void checkIndex(int index)
   {
     ASSERT_GE(index, 0);
@@ -162,7 +167,7 @@ bool compareData(axom::ArrayView<ElemType> a, axom::ArrayView<ElemType> b)
 using MyTypes =
   ::testing::Types<slam::CArrayIndirectionSet<axom::int32, axom::int64>,
                    slam::VectorIndirectionSet<axom::int32, axom::int64>,
-                   slam::CoreArrayIndirectionSet<axom::int32, axom::int64>,
+                   slam::ArrayIndirectionSet<axom::int32, axom::int64>,
                    slam::ArrayViewIndirectionSet<axom::int32, axom::int64>>;
 
 TYPED_TEST_SUITE(IndirectionSetTester, MyTypes);

--- a/src/axom/slam/tests/slam_set_Iterator.cpp
+++ b/src/axom/slam/tests/slam_set_Iterator.cpp
@@ -39,7 +39,7 @@ using SetBase = slam::Set<SetPosition, SetElement>;
 using PositionSet = slam::PositionSet<SetPosition, SetElement>;
 using RangeSet = slam::RangeSet<SetPosition, SetElement>;
 using VectorSet = slam::VectorIndirectionSet<SetPosition, SetElement>;
-using ArraySet = slam::ArrayIndirectionSet<SetPosition, SetElement>;
+using CArraySet = slam::CArrayIndirectionSet<SetPosition, SetElement>;
 
 static const int SET_SIZE = 10;
 
@@ -72,11 +72,11 @@ VectorSet generateSet(std::vector<SetElement>& vec, int size)
   return VectorSet(VectorSet::SetBuilder().size(size).data(&vec));
 }
 
-/// Specialization of \a generateSet for \a ArraySet
+/// Specialization of \a generateSet for \a CArraySet
 template <>
-ArraySet generateSet(std::vector<SetElement>& vec, int size)
+CArraySet generateSet(std::vector<SetElement>& vec, int size)
 {
-  return ArraySet(ArraySet::SetBuilder().size(size).data(vec.data()));
+  return CArraySet(CArraySet::SetBuilder().size(size).data(vec.data()));
 }
 
 }  // end anonymous namespace
@@ -117,7 +117,7 @@ private:
 };
 
 // Tests several types of sets
-using MyTypes = ::testing::Types<PositionSet, RangeSet, VectorSet, ArraySet>;
+using MyTypes = ::testing::Types<PositionSet, RangeSet, VectorSet, CArraySet>;
 TYPED_TEST_SUITE(OrderedSetIteratorTester, MyTypes);
 
 TYPED_TEST(OrderedSetIteratorTester, basic_operations)

--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -74,7 +74,7 @@ public:
   using BinBitMap =
     slam::Map<BitsetType,
               slam::Set<IndexType, IndexType>,
-              slam::policies::CoreArrayIndirection<IndexType, BitsetType>,
+              slam::policies::ArrayIndirection<IndexType, BitsetType>,
               slam::policies::StrideOne<IndexType>>;
 
   struct QueryObject;
@@ -205,7 +205,6 @@ public:
     for(int i = 0; i < NDIMS; ++i)
     {
       m_bins[i] = BinSet(m_gridRes[i]);
-      m_binData[i] = BinBitMap(&m_bins[i]);
       m_binData[i] =
         BinBitMap(&m_bins[i], BitsetType(numElts, allocatorID), 1, allocatorID);
 
@@ -618,10 +617,7 @@ namespace axom
 {
 namespace spin
 {
-/*!
- * \brief Device-copyable query object for running implicit grid queries on the
- *  GPU.
- */
+/// Device-copyable query object for running implicit grid queries on the GPU
 template <int NDIMS, typename ExecSpace, typename IndexType>
 struct ImplicitGrid<NDIMS, ExecSpace, IndexType>::QueryObject
 {
@@ -635,7 +631,7 @@ public:
   using BinBitMap =
     slam::Map<BitsetType,
               slam::Set<IndexType, IndexType>,
-              slam::policies::CoreArrayIndirection<IndexType, BitsetType>,
+              slam::policies::ArrayIndirection<IndexType, BitsetType>,
               slam::policies::StrideOne<IndexType>>;
 
   QueryObject(const SpatialBoundingBox& spaceBb,


### PR DESCRIPTION
# Summary

- This PR is a feature
- It reorders the input points for the scattered interpolation example following the Biased Randomized Insertion Order (BRIO) algorithm. This improves the theoretical expected runtime as well as the practical performance of the Delaunay mesh generation algorithm.
- BRIO was introduced in the following paper: 
   N. Amenta, S. Choi, and G. Rote. "Incremental constructions con BRIO." 
   Proceedings of the 19th annual symposium on Computational geometry, 2003.

- This PR also adds a function to `quest::ScatteredInterpolation` to directly get the interpolation indices and weights. This allows users to perform the interpolation themselves.
- The scattered_interpolation example uses the latter to compare the two interpolation schemes and to check interpolation for the position of the input points
- Finally, we add unit tests for the scattered_interpolation example
- Also renames some internal policy classes in slam now that we're using `axom::Array`. Specifically `slam::policies::ArrayIndirection` is now `slam::policies::CArrayIndirection` and `slam::policies::CoreArrayIndirection` is now `slam::policies::ArrayIndirection`.

### Performance improvement

To measure the improvement in this branch, I ran experiments in 2D and 3D on a series of randomly generated input and query points in the unit square/cube. 

I configured the code with the clang@10 compiler on a toss3 machine in LLNL's LC cluster using the `RelWithDebInfo` configuration, the `-march=native` compiler flag and the `-DAXOM_DEBUG_DEFINE=OFF` axom option (which removes asserts). I ran each experiment three times and took the average.

| With BRIO   | 2D         |            |            |            |    3D      |           |            |   |
|   ---            |  --:       |   --:      |  --:       |  --:       |  --:       |  --:      |  --:       |    --:         |
|  # input and query points | 10,000     | 100,000    | 1,000,000  | 10,000,000 | 10,000     | 100,000   | 1,000,000  | 10,000,000 |
| Insert input points | 270,460    | 277,592    | 277,323    | 264,894    | 51,833     | 52,358    | 52,643     | 51,655* |
| Locate query points | 1,542,527  | 657,566    | 313,124    | 96,237     | 950,174    | 512,505   | 247,778    | 113,028* |
| Interpolate fields  | 25,890,575 | 21,424,170 | 9,513,809  | 5,182,302  | 12,862,174 | 9,678,306 | 4,642,876  | 2,717,755* |
---
| Original (w/o BRIO) | 2D         |            |            |            |    3D      |           |            |                 |
|   ---            |  --:       |   --:      |  --:       |  --:       |  --:       |  --:      |  --:       |    --:         |
|  # input and query points | 10,000     | 100,000    | 1,000,000  | 10,000,000 | 10,000     | 100,000   | 1,000,000  | 10,000,000 |
| Insert input points | 253,648    | 218,569    | 150,548    | 70,897     | 48,285     | 46,622    | 36,502     | 28,346* |
| Locate query points | 1,642,490  | 777,691    | 295,070    | 82,584     | 1,094,842  | 631,869   | 255,445    | 125,962* |
| Interpolate fields  | 24,669,485 | 14,711,874 | 9,287,055  | 4,222,028  | 13,326,577 | 9,727,948 | 4,115,913  | 2,643,922* |

(*) Only one of the three runs were available for the 10,000,000 sample runs in 3D

As can be seen in the tables, reordering the input vertices using BRIO yields a uniform generation rate across different dataset sizes -- roughly an insertion rate of 270k pts/second in 2D and 50k pts/second in 3D.  Without BRIO, the rate was steadily declining as the mesh size increased.

Since the query points are not coherent, the query rates still reduce as the mesh gets larger.
I'm not entirely sure why the interpolation rates are reducing. I'd speculate that this is due to memory/cache coherence.

#### TODO
- [x] Update RELEASE-NOTES
- [x]  Post performance data