### PR TITLE
Set value number_of_domains in blueprint index to the correct value

### DIFF
--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -1110,6 +1110,23 @@ void MFEMSidreDataCollection::Save(const std::string& filename,
 
     if(myid == 0)
     {
+      // 'state/number_of_domains` may have been previously set to an incorrect
+      // value before this object had access to the MPI communicator. Here
+      // we reset to the correct value, or create a View to hold the value if
+      // one does not already exist.
+      if(m_bp_index_grp->hasView("state/number_of_domains"))
+      {
+        View* num_domains =
+          m_bp_index_grp->getView("state/number_of_domains")->setScalar(num_procs);
+        SLIC_ASSERT_MSG(num_domains,
+                        "Failed to reset View 'state/number_of_domains' "
+                        "in blueprint index to correct number of domains.");
+      }
+      else
+      {
+        m_bp_index_grp->createViewScalar("state/number_of_domains", num_procs);
+      }
+
       if(protocol == "sidre_hdf5")
       {
         writer.writeGroupToRootFile(blueprint_indicies_grp, file_path + ".root");


### PR DESCRIPTION
# Summary

- This PR is a bug fix
- It does the following:
  - The value `number_of_domains` in the blueprint index produced by MFEMSidreDataCollection was not set correctly because it was set prior to the data collection getting access to the MPI communicator (the true number of domains is equal to the number of procs in the communicator).  This fix sets the value correctly immediately prior to writing the index to the root file.