### PR TITLE
Add tioga to Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ stages:
     - ASSIGN_ID=$(if [[ -n "${JOBID}" ]]; then echo "--jobid=${JOBID}"; fi)
     # BUILD + TEST
     - echo -e "\e[0Ksection_start:$(date +%s):src_build_and_test\r\e[0KSource Build and Test ${CI_PROJECT_NAME}"
-    - ${ALLOC_COMMAND} ${ASSIGN_ID} python3 scripts/llnl_scripts/build_src.py -v --host-config ${HOST_CONFIG} --extra-cmake-options '-DENABLE_DOCS=OFF ${EXTRA_CMAKE_OPTIONS}' --build-type ${BUILD_TYPE:-Debug}
+    - ${ALLOC_COMMAND} ${ASSIGN_ID} python3 scripts/llnl_scripts/build_src.py -v --host-config ${HOST_CONFIG} --extra-cmake-options '-DENABLE_DOCS=OFF ${EXTRA_CMAKE_OPTIONS}' --build-type ${BUILD_TYPE:-Debug} ${EXTRA_OPTIONS}
     - echo -e "\e[0Ksection_end:$(date +%s):src_build_and_test\r\e[0K"
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,4 +57,4 @@ stages:
 include:
   - local: .gitlab/build_ruby.yml
   - local: .gitlab/build_lassen.yml
-  - local: .gitlab/build_corona.yml
+  - local: .gitlab/build_tioga.yml

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -20,6 +20,7 @@
   stage: build
   variables:
     ALLOC_COMMAND: "srun -p pdebug -t 25 -N 1 "
+    EXTRA_OPTIONS: "--test-serial"
   extends: [.src_build_script, .on_tioga, .src_workflow]
   needs: []
 

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -4,45 +4,47 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 
 ####
-# This is the shared configuration of jobs for corona
-.on_corona:
+# This is the shared configuration of jobs for tioga
+.on_tioga:
   tags:
     - shell
-    - corona
+    - tioga
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_CORONA == "OFF"' #run except if ...
+    - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_TIOGA == "OFF"' #run except if ...
       when: never
     - when: on_success
 
 ####
 # Template
-.src_build_on_corona:
+.src_build_on_tioga:
   stage: build
   variables:
     ALLOC_COMMAND: "srun -p pdebug -t 25 -N 1 "
-  extends: [.src_build_script, .on_corona, .src_workflow]
+  extends: [.src_build_script, .on_tioga, .src_workflow]
   needs: []
 
-.full_build_on_corona:
+.full_build_on_tioga:
   stage: build
   variables:
     ALLOC_COMMAND: "srun -p pbatch -t 60 -N 1 "
-  extends: [.full_build_script, .on_corona, .full_workflow]
+  extends: [.full_build_script, .on_tioga, .full_workflow]
   needs: []
 
 ####
 # PR Build jobs
-corona-clang_14_0_0_hip-src:
+tioga-clang_14_0_0_hip-src:
   variables:
     COMPILER: "clang@14.0.0_hip"
-    HOST_CONFIG: "corona-toss_4_x86_64_ib-${COMPILER}.cmake"
-  extends: .src_build_on_corona
+    HOST_CONFIG: "tioga-toss_4_x86_64_ib_cray-${COMPILER}.cmake"
+  extends: .src_build_on_tioga
+  allow_failure: true
 
 ####
 # Full Build jobs
-corona-clang_14_0_0_hip-full:
+tioga-clang_14_0_0_hip-full:
   variables:
     COMPILER: "clang@14.0.0_hip"
     SPEC: "%${COMPILER}~openmp+rocm+mfem+c2c"
-    EXTRASPEC: "amdgpu_target=gfx906 ^raja~openmp+rocm ^umpire~openmp+rocm"
-  extends: .full_build_on_corona
+    EXTRASPEC: "amdgpu_target=gfx90a ^raja~openmp+rocm ^umpire~openmp+rocm"
+  extends: .full_build_on_tioga
+  allow_failure: true

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -19,14 +19,14 @@
 .src_build_on_tioga:
   stage: build
   variables:
-    ALLOC_COMMAND: "salloc -p pdebug -t 25 -N 1 "
+    ALLOC_COMMAND: "srun -p pdebug -t 25 -N 1 --mpi=pmi2  "
   extends: [.src_build_script, .on_tioga, .src_workflow]
   needs: []
 
 .full_build_on_tioga:
   stage: build
   variables:
-    ALLOC_COMMAND: "salloc -p pbatch -t 60 -N 1 "
+    ALLOC_COMMAND: "srun -p pbatch -t 60 -N 1 --mpi=pmi2 "
   extends: [.full_build_script, .on_tioga, .full_workflow]
   needs: []
 

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -19,14 +19,14 @@
 .src_build_on_tioga:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun -p pdebug -t 25 -N 1 "
+    ALLOC_COMMAND: "salloc -p pdebug -t 25 -N 1 "
   extends: [.src_build_script, .on_tioga, .src_workflow]
   needs: []
 
 .full_build_on_tioga:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun -p pbatch -t 60 -N 1 "
+    ALLOC_COMMAND: "salloc -p pbatch -t 60 -N 1 "
   extends: [.full_build_script, .on_tioga, .full_workflow]
   needs: []
 

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -19,14 +19,14 @@
 .src_build_on_tioga:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun -p pdebug -t 25 -N 1 --mpi=pmi2  "
+    ALLOC_COMMAND: "srun -p pdebug -t 25 -N 1 "
   extends: [.src_build_script, .on_tioga, .src_workflow]
   needs: []
 
 .full_build_on_tioga:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun -p pbatch -t 60 -N 1 --mpi=pmi2 "
+    ALLOC_COMMAND: "srun -p pbatch -t 60 -N 1 "
   extends: [.full_build_script, .on_tioga, .full_workflow]
   needs: []
 

--- a/scripts/llnl_scripts/build_src.py
+++ b/scripts/llnl_scripts/build_src.py
@@ -38,6 +38,12 @@ def parse_args():
                       default="Debug",
                       choices = ("Debug", "RelWithDebInfo", "Release", "MinSizeRel"),
                       help="The CMake build type to use")
+    # Run unit tests serially (MPI Bug on El Capitan)
+    parser.add_option("--test-serial",
+                      action="store_true",
+                      dest="testserial",
+                      default=False,
+                      help="Run unit tests serially")
     # Extra cmake options to pass to config build
     parser.add_option("--extra-cmake-options",
                       dest="extra_cmake_options",
@@ -99,7 +105,8 @@ def main():
             res = build_and_test_host_configs(repo_dir, timestamp, False,
                                               report_to_stdout = opts["verbose"],
                                               extra_cmake_options = opts["extra_cmake_options"],
-                                              build_type = opts["buildtype"])
+                                              build_type = opts["buildtype"],
+                                              test_serial = opts["testserial"])
         # Otherwise try to build a specific host-config
         else:
             # Command-line arg has highest priority
@@ -151,7 +158,8 @@ def main():
             res = build_and_test_host_config(test_root, hostconfig_path,
                                              report_to_stdout = opts["verbose"],
                                              extra_cmake_options = opts["extra_cmake_options"],
-                                             build_type = opts["buildtype"])
+                                             build_type = opts["buildtype"],
+                                             test_serial = opts["testserial"])
 
     finally:
         os.chdir(original_wd)

--- a/scripts/llnl_scripts/llnl_lc_build_tools.py
+++ b/scripts/llnl_scripts/llnl_lc_build_tools.py
@@ -192,7 +192,8 @@ def uberenv_build(prefix, spec, project_file, mirror_path):
 def build_and_test_host_config(test_root, host_config, 
                                report_to_stdout = False,
                                extra_cmake_options = "",
-                               build_type = "Debug"):
+                               build_type = "Debug",
+                               test_serial = False):
     host_config_root = get_host_config_root(host_config)
     # setup build and install dirs
     build_dir   = pjoin(test_root,"build-%s"   % host_config_root)
@@ -242,7 +243,8 @@ def build_and_test_host_config(test_root, host_config,
     print("[starting unit tests]")
     print("[log file: %s]" % tst_output_file)
 
-    tst_cmd = "cd %s && make CTEST_OUTPUT_ON_FAILURE=1 test ARGS=\"--no-compress-output -T Test -VV \"" % build_dir
+    parallel_test = "" if test_serial else "-j16"
+    tst_cmd = "cd %s && make CTEST_OUTPUT_ON_FAILURE=1 test ARGS=\"--no-compress-output -T Test -VV %s\"" % (build_dir, parallel_test)
 
     res = sexe(tst_cmd,
                output_file = tst_output_file,
@@ -387,7 +389,8 @@ def build_and_test_host_configs(prefix,
                                 use_generated_host_configs,
                                 report_to_stdout = False,
                                 extra_cmake_options = "",
-                                build_type = "Debug"):
+                                build_type = "Debug",
+                                test_serial = False):
     host_configs = get_host_configs_for_current_machine(prefix, use_generated_host_configs)
     if len(host_configs) == 0:
         log_failure(prefix,"[ERROR: No host configs found at %s]" % prefix)
@@ -409,7 +412,8 @@ def build_and_test_host_configs(prefix,
         if build_and_test_host_config(test_root, host_config,
                                       report_to_stdout = report_to_stdout,
                                       extra_cmake_options=extra_cmake_options,
-                                      build_type = build_type) == 0:
+                                      build_type = build_type,
+                                      test_serial = test_serial) == 0:
             ok.append(host_config)
             log_success(build_dir, "[Success: Built host-config: {0}]".format(host_config), timestamp)
         else:

--- a/scripts/llnl_scripts/llnl_lc_build_tools.py
+++ b/scripts/llnl_scripts/llnl_lc_build_tools.py
@@ -242,7 +242,7 @@ def build_and_test_host_config(test_root, host_config,
     print("[starting unit tests]")
     print("[log file: %s]" % tst_output_file)
 
-    tst_cmd = "cd %s && make CTEST_OUTPUT_ON_FAILURE=1 test ARGS=\"--no-compress-output -T Test -VV -j16\"" % build_dir
+    tst_cmd = "cd %s && make CTEST_OUTPUT_ON_FAILURE=1 test ARGS=\"--no-compress-output -T Test -VV \"" % build_dir
 
     res = sexe(tst_cmd,
                output_file = tst_output_file,


### PR DESCRIPTION
This PR:
- Adds tioga, removes corona from gitlab CI
  - Adds a `--test-serial` option to build_src.py to run unit tests serially (`make test -j16` is current default) 
    - This is to get around a srun/mpibind issue on tioga, where issuing multiple srun's in parallel results in `Fatal error in PMPI_Init` errors (recent discussion on Mattermost on why this is happening)

EDIT: Tioga job allowed to fail for now to safeguard against future, regular system updates.