### PR TITLE
Fixes for building on Windows with Intel OneAPI.

### DIFF
--- a/src/axom/sidre/core/Buffer.hpp
+++ b/src/axom/sidre/core/Buffer.hpp
@@ -33,6 +33,7 @@ namespace axom
 namespace sidre
 {
 class DataStore;
+class Group;
 class View;
 
 /*!

--- a/src/thirdparty/axom/fmt/format.h
+++ b/src/thirdparty/axom/fmt/format.h
@@ -175,10 +175,10 @@ AXOM_FMT_END_NAMESPACE
 #if (AXOM_FMT_GCC_VERSION || AXOM_FMT_HAS_BUILTIN(__builtin_clzll)) && !AXOM_FMT_MSC_VER
 #  define AXOM_FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
 #endif
-#if (AXOM_FMT_GCC_VERSION || AXOM_FMT_HAS_BUILTIN(__builtin_ctz))
+#if (AXOM_FMT_GCC_VERSION || AXOM_FMT_HAS_BUILTIN(__builtin_ctz)) && !AXOM_FMT_MSC_VER
 #  define AXOM_FMT_BUILTIN_CTZ(n) __builtin_ctz(n)
 #endif
-#if (AXOM_FMT_GCC_VERSION || AXOM_FMT_HAS_BUILTIN(__builtin_ctzll))
+#if (AXOM_FMT_GCC_VERSION || AXOM_FMT_HAS_BUILTIN(__builtin_ctzll)) && !AXOM_FMT_MSC_VER
 #  define AXOM_FMT_BUILTIN_CTZLL(n) __builtin_ctzll(n)
 #endif
 


### PR DESCRIPTION
# Summary

- This PR consists of two bugfixes from Al Nichols.
- It does the following:
  - Forward declares class Group within sidre/core/Buffer.hpp
  - Guards use of __builtin_ctz(n) and __builtin_ctzll(n) so against use with Clang-based Windows compilers
