### PR TITLE
Fix non-trivial axom::Array<T> insertion behavior

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -178,6 +178,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   since C syntax is required in this file.
 - Fixed bug on two-dimensional `sidre::Array<T>` construction where the size is set to the underlying buffer
   capacity, instead of the actual number of elements
+- Fixed `axom::Array<T>::insert` behavior with non-trivial types.
 
 ## [Version 0.6.1] - Release date 2021-11-17
 

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -861,12 +861,16 @@ struct ArrayOpsBase<T, false>
       auto rbegin = std::make_reverse_iterator(array + src_end);
       auto rend = std::make_reverse_iterator(array + src_begin);
       auto rdest = std::make_reverse_iterator(array + dst_last);
+      // Do an "uninitialized-move" in reverse order, to avoid overwriting
+      // any existing elements.
       std::uninitialized_copy(std::make_move_iterator(rbegin),
                               std::make_move_iterator(rend),
                               rdest);
     }
     else if(src_begin > dst)
     {
+      // This substitutes for std::uninitialized_move(), which is only
+      // available in C++17.
       std::uninitialized_copy(std::make_move_iterator(array + src_begin),
                               std::make_move_iterator(array + src_end),
                               array + dst);

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -858,11 +858,18 @@ struct ArrayOpsBase<T, false>
     if(src_begin < dst)
     {
       IndexType dst_last = dst + src_end - src_begin;
-      std::move_backward(array + src_begin, array + src_end, array + dst_last);
+      auto rbegin = std::make_reverse_iterator(array + src_end);
+      auto rend = std::make_reverse_iterator(array + src_begin);
+      auto rdest = std::make_reverse_iterator(array + dst_last);
+      std::uninitialized_copy(std::make_move_iterator(rbegin),
+                              std::make_move_iterator(rend),
+                              rdest);
     }
     else if(src_begin > dst)
     {
-      std::move(array + src_begin, array + src_end, array + dst);
+      std::uninitialized_copy(std::make_move_iterator(array + src_begin),
+                              std::make_move_iterator(array + src_end),
+                              array + dst);
     }
   }
 };

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -858,9 +858,9 @@ struct ArrayOpsBase<T, false>
     if(src_begin < dst)
     {
       IndexType dst_last = dst + src_end - src_begin;
-      auto rbegin = std::make_reverse_iterator(array + src_end);
-      auto rend = std::make_reverse_iterator(array + src_begin);
-      auto rdest = std::make_reverse_iterator(array + dst_last);
+      auto rbegin = std::reverse_iterator<T*>(array + src_end);
+      auto rend = std::reverse_iterator<T*>(array + src_begin);
+      auto rdest = std::reverse_iterator<T*>(array + dst_last);
       // Do an "uninitialized-move" in reverse order, to avoid overwriting
       // any existing elements.
       std::uninitialized_copy(std::make_move_iterator(rbegin),

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -542,10 +542,31 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_of_arrays)
     }
   }
 
-  // Insert an array at the beginning
+  // Insert a few subarrays
   // A move operation will be triggered to allocate a slot for the new
   // element
   arr_2d.insert(arr_2d.begin(), DynamicArray({0, 1, 2}));
+  arr_2d.insert(arr_2d.begin() + 3, DynamicArray({2, 3, 4}));
+  EXPECT_EQ(arr_2d.size(), 6);
+
+  // Check values on host
+  {
+    HostArrayOfArrays arr_2d_host = arr_2d;
+    for(int i = 0; i < arr_2d_host.size(); i++)
+    {
+      HostArray subarr_host = arr_2d_host[i];
+      EXPECT_EQ(subarr_host.size(), 3);
+      int offset = (i >= 3) ? -1 : 0;
+      for(int j = 0; j < subarr_host.size(); j++)
+      {
+        EXPECT_EQ(subarr_host[j], i + j + offset);
+      }
+    }
+  }
+
+  // Erase an element in the middle of the array
+  // A move operation will be triggered to compact the remaining elements
+  arr_2d.erase(arr_2d.begin() + 2);
   EXPECT_EQ(arr_2d.size(), 5);
 
   // Check values on host
@@ -558,26 +579,6 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_of_arrays)
       for(int j = 0; j < subarr_host.size(); j++)
       {
         EXPECT_EQ(subarr_host[j], i + j);
-      }
-    }
-  }
-
-  // Erase an element in the middle of the array
-  // A move operation will be triggered to compact the remaining elements
-  arr_2d.erase(arr_2d.begin() + 2);
-  EXPECT_EQ(arr_2d.size(), 4);
-
-  // Check values on host
-  {
-    HostArrayOfArrays arr_2d_host = arr_2d;
-    for(int i = 0; i < arr_2d_host.size(); i++)
-    {
-      HostArray subarr_host = arr_2d_host[i];
-      EXPECT_EQ(subarr_host.size(), 3);
-      int offset = (i >= 2) ? 1 : 0;
-      for(int j = 0; j < subarr_host.size(); j++)
-      {
-        EXPECT_EQ(subarr_host[j], i + j + offset);
       }
     }
   }


### PR DESCRIPTION
# Summary

Fixes a segfault caused by calling `axom::Array<T>::insert()/::erase()` for a non-trivial type.

In order to create a slot for a new element in the middle of an array, or compact an array after erasing elements in the middle, we have an `ArrayOps::move()` helper to move a block of elements within an array. The resulting call to `std::move/move_backwards` will move-assign elements in the array to an uninitialized index, containing a junk pointer-to-data. The move assignment operator then attempts to deallocate this junk pointer, which causes the segfault.

The fix is to use `std::uninitialized_copy` with move iterators to correctly handle move-construction of objects in uninitialized memory.

Resolves #869.