### PR TITLE
Fix sign error in primal::Triangle::signedArea()

### DIFF
--- a/src/axom/primal/geometry/Triangle.hpp
+++ b/src/axom/primal/geometry/Triangle.hpp
@@ -138,8 +138,8 @@ public:
     const PointType& C = m_points[2];
 
     // clang-format off
-    return 0.5 * determinant(B[0]-A[0], B[1]-A[1],
-                             C[0]-A[0], C[1]-A[1]);
+    return 0.5 * determinant(B[0]-A[0], C[0]-A[0],
+                             B[1]-A[1], C[1]-A[1]);
     // clang-format on
   }
 

--- a/src/axom/primal/geometry/Triangle.hpp
+++ b/src/axom/primal/geometry/Triangle.hpp
@@ -138,8 +138,8 @@ public:
     const PointType& C = m_points[2];
 
     // clang-format off
-    return 0.5 * determinant(C[0]-A[0], C[1]-A[1],
-                             B[0]-A[0], B[1]-A[1]);
+    return 0.5 * determinant(B[0]-A[0], B[1]-A[1],
+                             C[0]-A[0], C[1]-A[1]);
     // clang-format on
   }
 

--- a/src/axom/primal/tests/primal_triangle.cpp
+++ b/src/axom/primal/tests/primal_triangle.cpp
@@ -32,8 +32,8 @@ TEST(primal_triangle, triangle_area_2D)
   for(CoordType scale : {.333, 1., 2.5, 3.})
   {
     QPoint pt[3] = {QPoint {0, 0},  //
-                    QPoint {0, scale},
-                    QPoint {scale, 0}};
+                    QPoint {scale, 0},
+                    QPoint {0, scale}};
 
     const CoordType exp_area = scale * scale / 2;
 


### PR DESCRIPTION
# Summary

This PR fixes a sign error in the `signedArea()` method of `primal::Triangle` objects, and updates the relevant test in `primal_triangle` that expects the incorrect behavior. Currently, triangles whose vertices are oriented counter-clockwise incorrectly return a negative area. This is also inconsistent with the behavior described by the Doxygen header. 

This is fixed by adjusting the determinant calculated in `signedArea()` to be consistent with the ["Shoelace Theorem"](https://artofproblemsolving.com/wiki/index.php/Shoelace_Theorem) for finding the oriented area of a polygon. The relevant test in `primal_triangle` is adjusted so that the points are oriented counter-clockwise.