### PR TITLE
Improves robustness of barycentric and circumsphere computations

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -98,6 +98,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Adds a new component to Axom, `multimat`, to simplify the handing of multi-material meshes and
   fields.
 - Adds functions to compute winding numbers and in/out queries for `Polygon` and `CurvedPolygon` objects.
+- Adds `constants.hpp` to primal to track geometric constants. Initially includes
+  a value for `primal::PTINY`, a small constant that can be added to 
+  denominators to avoid division by zero.
 
 ###  Changed
 - Axom now requires C++14 and will default to that if not specified via `BLT_CXX_STD`.
@@ -159,6 +162,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   and the axom::Array-based indirection policy was renamed from `CoreArrayIndirection` to `ArrayIndirection`.
 - Mfem dependency updated to 4.4
 - `primal::detail::intersect_ray` now correctly identifies intersections between collinear `Segment` and `Ray` objects.
+- Improved efficiency and robustness of barycentric coordinate
+  and circumsphere computation for Triangles and Tetrahedra.
 
 ###  Fixed
 - Fixed a bug relating to swap and assignment operations for multidimensional `axom::Array`s

--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -17,53 +17,55 @@ axom_component_requires(NAME       PRIMAL
 #------------------------------------------------------------------------------
 set( primal_headers
 
-     ## geometry
-     geometry/BezierCurve.hpp
-     geometry/BoundingBox.hpp
-     geometry/CurvedPolygon.hpp
-     geometry/OrientedBoundingBox.hpp
-     geometry/OrientationResult.hpp
-     geometry/NumericArray.hpp
-     geometry/Plane.hpp
-     geometry/Point.hpp
-     geometry/Polygon.hpp
-     geometry/Ray.hpp
-     geometry/Segment.hpp
-     geometry/Sphere.hpp
-     geometry/Polyhedron.hpp
-     geometry/Tetrahedron.hpp
-     geometry/Octahedron.hpp
-     geometry/Triangle.hpp
-     geometry/Vector.hpp
+    constants.hpp
 
-     ## operators
-     operators/clip.hpp
-     operators/closest_point.hpp
-     operators/intersect.hpp
-     operators/orientation.hpp
-     operators/squared_distance.hpp
-     operators/compute_bounding_box.hpp
-     operators/compute_moments.hpp
-     operators/in_curved_polygon.hpp
-     operators/in_polygon.hpp
-     operators/in_sphere.hpp
-     operators/is_convex.hpp
-     operators/split.hpp
+    ## geometry
+    geometry/BezierCurve.hpp
+    geometry/BoundingBox.hpp
+    geometry/CurvedPolygon.hpp
+    geometry/OrientedBoundingBox.hpp
+    geometry/OrientationResult.hpp
+    geometry/NumericArray.hpp
+    geometry/Plane.hpp
+    geometry/Point.hpp
+    geometry/Polygon.hpp
+    geometry/Ray.hpp
+    geometry/Segment.hpp
+    geometry/Sphere.hpp
+    geometry/Polyhedron.hpp
+    geometry/Tetrahedron.hpp
+    geometry/Octahedron.hpp
+    geometry/Triangle.hpp
+    geometry/Vector.hpp
 
-     operators/detail/clip_impl.hpp
-     operators/detail/compute_moments_impl.hpp
-     operators/detail/in_curved_polygon_impl.hpp
-     operators/detail/intersect_bezier_impl.hpp
-     operators/detail/intersect_bounding_box_impl.hpp
-     operators/detail/intersect_impl.hpp
-     operators/detail/intersect_ray_impl.hpp
+    ## operators
+    operators/clip.hpp
+    operators/closest_point.hpp
+    operators/intersect.hpp
+    operators/orientation.hpp
+    operators/squared_distance.hpp
+    operators/compute_bounding_box.hpp
+    operators/compute_moments.hpp
+    operators/in_curved_polygon.hpp
+    operators/in_polygon.hpp
+    operators/in_sphere.hpp
+    operators/is_convex.hpp
+    operators/split.hpp
+
+    operators/detail/clip_impl.hpp
+    operators/detail/compute_moments_impl.hpp
+    operators/detail/in_curved_polygon_impl.hpp
+    operators/detail/intersect_bezier_impl.hpp
+    operators/detail/intersect_bounding_box_impl.hpp
+    operators/detail/intersect_impl.hpp
+    operators/detail/intersect_ray_impl.hpp
      
-     ## utils
-     utils/ZipIndexable.hpp
-     utils/ZipBoundingBox.hpp
-     utils/ZipPoint.hpp
-     utils/ZipRay.hpp
-     utils/ZipVector.hpp
+    ## utils
+    utils/ZipIndexable.hpp
+    utils/ZipBoundingBox.hpp
+    utils/ZipPoint.hpp
+    utils/ZipRay.hpp
+    utils/ZipVector.hpp
    )
 
 set( primal_sources

--- a/src/axom/primal/constants.hpp
+++ b/src/axom/primal/constants.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_PRIMAL_CONSTANTS_HPP_
+#define AXOM_PRIMAL_CONSTANTS_HPP_
+
+/*! 
+ * \file constants.hpp
+ * \brief This file contains some useful constants to use throughout primal
+ */
+
+namespace axom
+{
+namespace primal
+{
+/// Small constant that can be useful for e.g. offsetting denominators to avoid division by zero
+static constexpr double PTINY = 1e-50;
+}  // namespace primal
+}  // namespace axom
+
+#endif  // AXOM_PRIMAL_CONSTANTS_

--- a/src/axom/primal/geometry/NumericArray.hpp
+++ b/src/axom/primal/geometry/NumericArray.hpp
@@ -374,6 +374,9 @@ public:
    */
   int argMin() const;
 
+  /// \brief Computes the sum of the components
+  T sum() const;
+
 private:
   AXOM_HOST_DEVICE
   void verifyIndex(int AXOM_DEBUG_PARAM(idx)) const
@@ -679,6 +682,19 @@ inline int NumericArray<T, SIZE>::argMin() const
   }
 
   return idx;
+}
+
+//------------------------------------------------------------------------------
+template <typename T, int SIZE>
+inline T NumericArray<T, SIZE>::sum() const
+{
+  T result {};
+  for(int i = 0; i < SIZE; ++i)
+  {
+    result += this->m_components[i];
+  }
+
+  return result;
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/geometry/Polygon.hpp
+++ b/src/axom/primal/geometry/Polygon.hpp
@@ -25,7 +25,7 @@ namespace primal
 template <typename T, int NDIMS>
 class Polygon;
 
-/*! \brief Overloaded output operator for polygons */
+/// \brief Overloaded output operator for polygons
 template <typename T, int NDIMS>
 std::ostream& operator<<(std::ostream& os, const Polygon<T, NDIMS>& poly);
 
@@ -45,7 +45,7 @@ public:
   using PointType = Point<T, NDIMS>;
 
 public:
-  /*! Default constructor for an empty polygon   */
+  /// Default constructor for an empty polygon
   Polygon() { }
 
   /*!
@@ -62,23 +62,21 @@ public:
     m_vertices.reserve(numExpectedVerts);
   }
 
-  /*!
-   * \brief Constructor for a polygon with the given vertices
-   */
+  /// \brief Constructor for a polygon with the given vertices
   Polygon(const axom::Array<PointType>& vertices) { m_vertices = vertices; }
 
-  /*! Return the number of vertices in the polygon */
-  const int numVertices() const { return static_cast<int>(m_vertices.size()); }
+  /// Return the number of vertices in the polygon
+  int numVertices() const { return static_cast<int>(m_vertices.size()); }
 
-  /*! Appends a vertex to the list of vertices */
+  /// Appends a vertex to the list of vertices
   void addVertex(const PointType& pt) { m_vertices.push_back(pt); }
 
-  /*! Clears the list of vertices */
+  /// Clears the list of vertices
   void clear() { m_vertices.clear(); }
 
-  /*! Retrieves the vertex at index idx */
+  /// Retrieves the vertex at index idx
   PointType& operator[](int idx) { return m_vertices[idx]; }
-  /*! Retrieves the vertex at index idx */
+  /// Retrieves the vertex at index idx
   const PointType& operator[](int idx) const { return m_vertices[idx]; }
 
   /*!

--- a/src/axom/primal/geometry/Tetrahedron.hpp
+++ b/src/axom/primal/geometry/Tetrahedron.hpp
@@ -52,6 +52,10 @@ public:
    * \param [in] B Vertex B of the tetrahedron
    * \param [in] C Vertex C of the tetrahedron
    * \param [in] D Vertex D of the tetrahedron
+   * 
+   * \note The orientation of the tetrahedron is determined from the 
+   * scalar triple product of the vectors from B, C and D to A, respectively,
+   * i.e. \f$ dot(B-A, cross(C-A, D-A)) \f$.
    */
   AXOM_HOST_DEVICE
   Tetrahedron(const PointType& A,

--- a/src/axom/primal/geometry/Tetrahedron.hpp
+++ b/src/axom/primal/geometry/Tetrahedron.hpp
@@ -14,6 +14,7 @@
 #include "axom/primal/geometry/Sphere.hpp"
 
 #include "axom/slic/interface/slic.hpp"
+#include "axom/fmt.hpp"
 
 #include <ostream>
 
@@ -127,8 +128,10 @@ public:
     {
       constexpr double EPS = 1.0e-50;
       const double vol = VectorType::scalar_triple_product(B - A, C - A, D - A);
-      // Compute one over denominator; add a tiny amount to avoid division by zero
-      const double ood = 1. / (vol - EPS);
+      const double offset = vol >= 0 ? EPS : -EPS;
+
+      // Compute one over denominator; offset by a tiny amount to avoid division by zero
+      const double ood = 1. / (vol + offset);
 
       bary[0] = detA * ood;
       bary[1] = detB * ood;
@@ -229,10 +232,10 @@ public:
                          vx[1] * vx[1] + vy[1] * vy[1] + vz[1] * vz[1],
                          vx[2] * vx[2] + vy[2] * vy[2] + vz[2] * vz[2]};
 
-    // Compute one over denominator using a small value to avoid division by zero
-    // Note: a has opposite sign of signedVolume()
+    // Compute one over denominator using a small offset to avoid division by zero
     const double a = VectorType::scalar_triple_product(vx, vy, vz);
-    const double ood = 1. / (2 * a - EPS);
+    const double offset = a >= 0 ? EPS : -EPS;
+    const double ood = 1. / (2 * a + offset);
 
     // Compute offset from p0 to center
     const auto center_offset = ood *

--- a/src/axom/primal/geometry/Tetrahedron.hpp
+++ b/src/axom/primal/geometry/Tetrahedron.hpp
@@ -8,6 +8,7 @@
 
 #include "axom/core.hpp"
 
+#include "axom/primal/constants.hpp"
 #include "axom/primal/geometry/NumericArray.hpp"
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
@@ -126,12 +127,11 @@ public:
 
     if(!skipNormalization)
     {
-      constexpr double EPS = 1.0e-50;
       const double vol = VectorType::scalar_triple_product(B - A, C - A, D - A);
-      const double offset = vol >= 0 ? EPS : -EPS;
+      const double EPS = vol >= 0 ? primal::PTINY : -primal::PTINY;
 
       // Compute one over denominator; offset by a tiny amount to avoid division by zero
-      const double ood = 1. / (vol + offset);
+      const double ood = 1. / (vol + EPS);
 
       bary[0] = detA * ood;
       bary[1] = detB * ood;
@@ -214,8 +214,6 @@ public:
   template <int TDIM = NDIMS>
   typename std::enable_if<TDIM == 3, SphereType>::type circumsphere() const
   {
-    constexpr double EPS = 1.0e-50;
-
     const PointType& p0 = m_points[0];
     const PointType& p1 = m_points[1];
     const PointType& p2 = m_points[2];
@@ -234,8 +232,8 @@ public:
 
     // Compute one over denominator using a small offset to avoid division by zero
     const double a = VectorType::scalar_triple_product(vx, vy, vz);
-    const double offset = a >= 0 ? EPS : -EPS;
-    const double ood = 1. / (2 * a + offset);
+    const double EPS = (a >= 0) ? primal::PTINY : -primal::PTINY;
+    const double ood = 1. / (2 * a + EPS);
 
     // Compute offset from p0 to center
     const auto center_offset = ood *

--- a/src/axom/primal/geometry/Tetrahedron.hpp
+++ b/src/axom/primal/geometry/Tetrahedron.hpp
@@ -45,11 +45,11 @@ public:
   { }
 
   /*!
-   * \brief Custom Constructor. Creates a tetrahedron from the 4 points A,B,C,D.
-   * \param [in] A point instance corresponding to vertex A of the tetrahedron.
-   * \param [in] B point instance corresponding to vertex B of the tetrahedron.
-   * \param [in] C point instance corresponding to vertex C of the tetrahedron.
-   * \param [in] D point instance corresponding to vertex D of the tetrahedron.
+   * \brief Tetrahedron constructor from 4 points A,B,C,D.
+   * \param [in] A Vertex A of the tetrahedron
+   * \param [in] B Vertex B of the tetrahedron
+   * \param [in] C Vertex C of the tetrahedron
+   * \param [in] D Vertex D of the tetrahedron
    */
   AXOM_HOST_DEVICE
   Tetrahedron(const PointType& A,
@@ -93,7 +93,7 @@ public:
 
   /*!
    * \brief Returns the barycentric coordinates of a point within a tetrahedron
-   * \return The barycentric coordinates of the tetrahedron
+   *
    * \post The barycentric coordinates sum to 1.
    */
   Point<double, 4> physToBarycentric(const PointType& p) const
@@ -136,7 +136,6 @@ public:
   /*!
    * \brief Returns the physical coordinates of a barycentric point
    * \param [in] bary Barycentric coordinates relative to this tetrahedron
-   * \return Physical point represented by bary
    */
   PointType baryToPhysical(const Point<double, 4>& bary) const
   {
@@ -252,22 +251,11 @@ private:
   AXOM_HOST_DEVICE
   double ppedVolume() const
   {
-    if(NDIMS != 3)
-    {
-      return 0.;
-    }
-    else
-    {
-      const VectorType A(m_points[0], m_points[1]);
-      const VectorType B(m_points[0], m_points[2]);
-      const VectorType C(m_points[0], m_points[3]);
-
-      // clang-format off
-      return axom::numerics::determinant<double>(A[0], A[1], A[2],
-                                                 B[0], B[1], B[2],
-                                                 C[0], C[1], C[2]);
-      // clang-format on
-    }
+    return NDIMS != 3
+      ? 0.
+      : VectorType::scalar_triple_product(m_points[1] - m_points[0],
+                                          m_points[2] - m_points[0],
+                                          m_points[3] - m_points[0]);
   }
 
 private:

--- a/src/axom/primal/geometry/Triangle.hpp
+++ b/src/axom/primal/geometry/Triangle.hpp
@@ -179,7 +179,8 @@ public:
     // Compute one over denominator using a small value to avoid division by zero
     // Note: a has opposite sign of signedArea()
     const double a = determinant(vx[0], vx[1], vy[0], vy[1]);
-    const double ood = 1. / (2 * a - EPS);
+    const double offset = a >= 0 ? EPS : -EPS;
+    const double ood = 1. / (2 * a + offset);
 
     // Compute offset from p0 to center
     const auto center_offset = ood *
@@ -284,7 +285,8 @@ public:
     {
       // compute one over denominator; add a tiny amount to avoid division by zero
       constexpr double EPS = 1.0e-50;
-      const double ood = 1. / (area + EPS);
+      const double offset = area >= 0 ? EPS : -EPS;
+      const double ood = 1. / (area + offset);
 
       bary[0] = ood * nu;
       bary[1] = ood * nv;

--- a/src/axom/primal/geometry/Triangle.hpp
+++ b/src/axom/primal/geometry/Triangle.hpp
@@ -10,6 +10,7 @@
 #include "axom/core.hpp"
 #include "axom/slic/interface/slic.hpp"
 
+#include "axom/primal/constants.hpp"
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
 #include "axom/primal/geometry/Sphere.hpp"
@@ -161,7 +162,6 @@ public:
   typename std::enable_if<TDIM == 2, SphereType>::type circumsphere() const
   {
     using axom::numerics::determinant;
-    constexpr double EPS = 1.0e-50;
 
     const PointType& p0 = m_points[0];
     const PointType& p1 = m_points[1];
@@ -177,10 +177,9 @@ public:
                          vx[1] * vx[1] + vy[1] * vy[1]};
 
     // Compute one over denominator using a small value to avoid division by zero
-    // Note: a has opposite sign of signedArea()
     const double a = determinant(vx[0], vx[1], vy[0], vy[1]);
-    const double offset = a >= 0 ? EPS : -EPS;
-    const double ood = 1. / (2 * a + offset);
+    const double EPS = (a >= 0) ? primal::PTINY : -primal::PTINY;
+    const double ood = 1. / (2 * a + EPS);
 
     // Compute offset from p0 to center
     const auto center_offset = ood *
@@ -284,9 +283,8 @@ public:
     if(!skipNormalization)
     {
       // compute one over denominator; add a tiny amount to avoid division by zero
-      constexpr double EPS = 1.0e-50;
-      const double offset = area >= 0 ? EPS : -EPS;
-      const double ood = 1. / (area + offset);
+      const double EPS = (area >= 0) ? primal::PTINY : -primal::PTINY;
+      const double ood = 1. / (area + EPS);
 
       bary[0] = ood * nu;
       bary[1] = ood * nv;
@@ -343,7 +341,7 @@ public:
    * \return true iff P is in the triangle
    * \see primal::Point
    */
-  bool checkInTriangle(const PointType& p, double eps = 1.0e-8) const
+  bool checkInTriangle(const PointType& p, double eps = 1e-8) const
   {
     if(!axom::utilities::isNearlyEqual(ppedVolume(p), 0., eps))
     {
@@ -381,8 +379,8 @@ private:
   PointType m_points[3];
 };
 
-} /* namespace primal */
-} /* namespace axom */
+}  // namespace primal
+}  // namespace axom
 
 //------------------------------------------------------------------------------
 //  Triangle implementation

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -17,7 +17,7 @@
 #include "axom/primal/geometry/Point.hpp"
 
 // C/C++ includes
-#include <cmath>  // for sqrt()
+#include <cmath>
 
 namespace axom
 {
@@ -550,11 +550,7 @@ AXOM_HOST_DEVICE inline Vector<T, 3> Vector<T, NDIMS>::cross_product(
   const Vector<T, 2>& u,
   const Vector<T, 2>& v)
 {
-  Vector<T, 3> c;
-  c[0] = 0;
-  c[1] = 0;
-  c[2] = numerics::determinant(u[0], u[1], v[0], v[1]);
-  return (c);
+  return Vector<T, 3> {0, 0, numerics::determinant(u[0], u[1], v[0], v[1])};
 }
 
 //------------------------------------------------------------------------------
@@ -563,9 +559,10 @@ AXOM_HOST_DEVICE inline Vector<T, 3> Vector<T, NDIMS>::cross_product(
   const Vector<T, 3>& u,
   const Vector<T, 3>& v)
 {
-  Vector<T, 3> c;
-  numerics::cross_product(u.data(), v.data(), c.data());
-  return (c);
+  // note: u and v are transposed in second component
+  return Vector<T, 3> {numerics::determinant(u[1], u[2], v[1], v[2]),
+                       numerics::determinant(v[0], v[2], u[0], u[2]),
+                       numerics::determinant(u[0], u[1], v[0], v[1])};
 }
 
 ///  Free functions involving vectors

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -389,6 +389,22 @@ public:
   static Vector<T, 3> cross_product(const Vector<T, 3>& u, const Vector<T, 3>& v);
 
   /*!
+   * \brief Computes the 3-D scalar triple product of vectors u, v and w
+   *
+   * \param [in] u the first vector
+   * \param [in] v the second vector
+   * \param [in] w the third vector
+   * \return The scalar triple product of u, v and w
+   *
+   * The scalar triple product dot(u, v x w) is the signed volume 
+   * of the parallelepiped defined by the three 3D vectors
+   */
+  AXOM_HOST_DEVICE
+  static T scalar_triple_product(const Vector<T, 3>& u,
+                                 const Vector<T, 3>& v,
+                                 const Vector<T, 3>& w);
+
+  /*!
    * \brief Utility function to constructs a Vector with the given coordinates.
    * \param [in] x the x--coordinate of the vector.
    * \param [in] y the y--coordinate of the vector.
@@ -567,6 +583,17 @@ AXOM_HOST_DEVICE inline Vector<T, 3> Vector<T, NDIMS>::cross_product(
   return Vector<T, 3> {numerics::determinant(u[1], u[2], v[1], v[2]),
                        numerics::determinant(v[0], v[2], u[0], u[2]),
                        numerics::determinant(u[0], u[1], v[0], v[1])};
+}
+
+//------------------------------------------------------------------------------
+template <typename T, int NDIMS>
+AXOM_HOST_DEVICE T inline Vector<T, NDIMS>::scalar_triple_product(
+  const Vector<T, 3>& u,
+  const Vector<T, 3>& v,
+  const Vector<T, 3>& w)
+{
+  return static_cast<T>(
+    numerics::determinant(u[0], u[1], u[2], v[0], v[1], v[2], w[0], w[1], w[2]));
 }
 
 ///  Free functions involving vectors

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -540,8 +540,12 @@ template <typename T, int NDIMS>
 AXOM_HOST_DEVICE inline T Vector<T, NDIMS>::dot_product(const Vector<T, NDIMS>& u,
                                                         const Vector<T, NDIMS>& v)
 {
-  SLIC_ASSERT(u.dimension() == v.dimension());
-  return static_cast<T>(numerics::dot_product(u.data(), v.data(), NDIMS));
+  T res {};
+  for(int d = 0; d < NDIMS; ++d)
+  {
+    res += u[d] * v[d];
+  }
+  return res;
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -13,6 +13,7 @@
 #include "axom/core/utilities/Utilities.hpp"
 
 // Primal includes
+#include "axom/primal/constants.hpp"
 #include "axom/primal/geometry/NumericArray.hpp"
 #include "axom/primal/geometry/Point.hpp"
 
@@ -488,12 +489,10 @@ AXOM_HOST_DEVICE inline double Vector<T, NDIMS>::norm() const
 template <typename T, int NDIMS>
 AXOM_HOST_DEVICE inline Vector<T, NDIMS> Vector<T, NDIMS>::unitVector() const
 {
-  constexpr double EPS = 1.0e-50;
-
   Vector v(*this);
 
   const double len_sq = squared_norm();
-  if(len_sq >= EPS)
+  if(len_sq >= primal::PTINY)
   {
     v /= (std::sqrt(len_sq));
   }

--- a/src/axom/primal/operators/in_sphere.hpp
+++ b/src/axom/primal/operators/in_sphere.hpp
@@ -46,18 +46,18 @@ inline bool in_sphere(const Point<T, 2>& q,
                       const Point<T, 2>& p2,
                       double EPS = 1e-8)
 {
-  const Point<T, 2> a(p0.array() - q.array());
-  const Point<T, 2> b(p1.array() - q.array());
-  const Point<T, 2> c(p2.array() - q.array());
+  const auto ba = p1 - p0;
+  const auto ca = p2 - p0;
+  const auto qa = q - p0;
 
   // clang-format off
   const double det = axom::numerics::determinant(
-    a[0], a[1], (a[0]*a[0] + a[1]*a[1]),
-    b[0], b[1], (b[0]*b[0] + b[1]*b[1]),
-    c[0], c[1], (c[0]*c[0] + c[1]*c[1]));
+    ba[0], ba[1], ba.squared_norm(),
+    ca[0], ca[1], ca.squared_norm(),
+    qa[0], qa[1], qa.squared_norm());
   // clang-format on
 
-  return axom::utilities::isNearlyEqual(det, 0., EPS) ? false : (det > 0);
+  return axom::utilities::isNearlyEqual(det, 0., EPS) ? false : (det < 0);
 }
 
 /*!
@@ -100,17 +100,17 @@ inline bool in_sphere(const Point<T, 3>& q,
                       const Point<T, 3>& p3,
                       double EPS = 1e-8)
 {
-  const Point<T, 3> a(p0.array() - q.array());
-  const Point<T, 3> b(p1.array() - q.array());
-  const Point<T, 3> c(p2.array() - q.array());
-  const Point<T, 3> d(p3.array() - q.array());
+  const auto ba = p1 - p0;
+  const auto ca = p2 - p0;
+  const auto da = p3 - p0;
+  const auto qa = q - p0;
 
   // clang-format off
   const double det = axom::numerics::determinant(
-    a[0], a[1], a[2], (a[0]*a[0] + a[1]*a[1] + a[2]*a[2]),
-    b[0], b[1], b[2], (b[0]*b[0] + b[1]*b[1] + b[2]*b[2]),
-    c[0], c[1], c[2], (c[0]*c[0] + c[1]*c[1] + c[2]*c[2]),
-    d[0], d[1], d[2], (d[0]*d[0] + d[1]*d[1] + d[2]*d[2]));
+    ba[0], ba[1], ba[2], ba.squared_norm(),
+    ca[0], ca[1], ca[2], ca.squared_norm(),
+    da[0], da[1], da[2], da.squared_norm(),
+    qa[0], qa[1], qa[2], qa.squared_norm());
   // clang-format on
 
   return axom::utilities::isNearlyEqual(det, 0., EPS) ? false : (det < 0);

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -16,6 +16,7 @@
 #include "axom/core/Macros.hpp"
 #include "axom/core/utilities/Utilities.hpp"
 
+#include "axom/primal/constants.hpp"
 #include "axom/primal/geometry/BoundingBox.hpp"
 #include "axom/primal/geometry/OrientedBoundingBox.hpp"
 #include "axom/primal/geometry/Plane.hpp"
@@ -147,8 +148,7 @@ bool intersect(const Triangle<T, 3>& tri,
   if(retval)
   {
     // Add a small EPS to avoid dividing by zero
-    const double EPS = 1e-80;
-    double normalizer = p[0] + p[1] + p[2] + EPS;
+    double normalizer = p[0] + p[1] + p[2] + primal::PTINY;
     p.array() *= 1. / normalizer;
   }
 
@@ -208,8 +208,7 @@ bool intersect(const Triangle<T, 3>& tri,
   if(retval)
   {
     // Add a small EPS to avoid dividing by zero
-    const double EPS = 1e-80;
-    double normalizer = p[0] + p[1] + p[2] + EPS;
+    double normalizer = p[0] + p[1] + p[2] + primal::PTINY;
     p.array() *= 1. / normalizer;
   }
 

--- a/src/axom/primal/tests/primal_numeric_array.cpp
+++ b/src/axom/primal/tests/primal_numeric_array.cpp
@@ -3,22 +3,19 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+#include "axom/core.hpp"
+#include "axom/slic.hpp"
+#include "axom/primal.hpp"
+
 #include "gtest/gtest.h"
 
-#include "axom/primal/geometry/NumericArray.hpp"
-
-#include "axom/core/execution/execution_space.hpp"  // for execution_space traits
-#include "axom/core/execution/for_all.hpp"          // for_all()
-
-#include "axom/slic.hpp"
-
-using namespace axom;
+namespace primal = axom::primal;
 
 //------------------------------------------------------------------------------
 template <typename ExecSpace>
 void check_numeric_array_policy()
 {
-  const int DIM = 3;
+  constexpr int DIM = 3;
   using NumericArrayType = primal::NumericArray<double, DIM>;
 
   double* coords =
@@ -38,9 +35,9 @@ void check_numeric_array_policy()
 //------------------------------------------------------------------------------
 TEST(primal_numeric_array, constructors)
 {
-  static const int DIM = 5;
-  typedef double CoordType;
-  typedef primal::NumericArray<CoordType, DIM> QArray;
+  constexpr int DIM = 5;
+  using CoordType = double;
+  using QArray = primal::NumericArray<CoordType, DIM>;
 
   QArray arr1;
   EXPECT_EQ(QArray::size(), DIM);
@@ -113,9 +110,9 @@ TEST(primal_numeric_array, constructors)
 //------------------------------------------------------------------------------
 TEST(primal_numeric_array, num_array_to_array)
 {
-  static const int DIM = 5;
-  typedef double CoordType;
-  typedef primal::NumericArray<CoordType, DIM> QArray;
+  constexpr int DIM = 5;
+  using CoordType = double;
+  using QArray = primal::NumericArray<CoordType, DIM>;
 
   // Compare array initialized from arbitrary array
   CoordType valsArr[DIM] = {12., 23., 34., 45., 56.432};
@@ -139,9 +136,9 @@ TEST(primal_numeric_array, num_array_to_array)
 //------------------------------------------------------------------------------
 TEST(primal_numeric_array, component_wise_arithmetic)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::NumericArray<CoordType, DIM> QArray;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QArray = primal::NumericArray<CoordType, DIM>;
 
   CoordType ca1[] = {3, 0, 1.2};
   CoordType ca2[] = {0, 4, 1.2};
@@ -188,44 +185,59 @@ TEST(primal_numeric_array, component_wise_arithmetic)
 //------------------------------------------------------------------------------
 TEST(primal_numeric_array, component_min_max)
 {
-  static const int DIM = 3;
-  typedef int CoordType;
-  typedef primal::NumericArray<CoordType, DIM> QArray;
+  constexpr int DIM = 3;
+  using CoordType = int;
+  using QArray = primal::NumericArray<CoordType, DIM>;
 
-  CoordType incSeq[] = {1, 2, 3};
-  CoordType decSeq[] = {3, 2, 1};
-  CoordType upDownSeq[] = {5, 8, 3};
-  CoordType downUpSeq[] = {6, 2, 5};
-
-  QArray incArr(incSeq);
-  QArray decArr(decSeq);
-  QArray udArr(upDownSeq);
-  QArray duArr(downUpSeq);
+  QArray incArr {1, 2, 3};
+  QArray decArr {3, 2, 1};
+  QArray udArr {5, 8, 3};
+  QArray duArr {6, 2, 5};
 
   // testing component-wise min and max functions
-  EXPECT_EQ(incArr.max(), 3);
-  EXPECT_EQ(decArr.max(), 3);
-  EXPECT_EQ(incArr.argMax(), 2);
-  EXPECT_EQ(decArr.argMax(), 0);
+  EXPECT_EQ(3, incArr.max());
+  EXPECT_EQ(3, decArr.max());
+  EXPECT_EQ(2, incArr.argMax());
+  EXPECT_EQ(0, decArr.argMax());
 
-  EXPECT_EQ(udArr.max(), 8);
-  EXPECT_EQ(udArr.argMax(), 1);
+  EXPECT_EQ(8, udArr.max());
+  EXPECT_EQ(1, udArr.argMax());
 
-  EXPECT_EQ(incArr.min(), 1);
-  EXPECT_EQ(decArr.min(), 1);
-  EXPECT_EQ(incArr.argMin(), 0);
-  EXPECT_EQ(decArr.argMin(), 2);
+  EXPECT_EQ(1, incArr.min());
+  EXPECT_EQ(1, decArr.min());
+  EXPECT_EQ(0, incArr.argMin());
+  EXPECT_EQ(2, decArr.argMin());
 
-  EXPECT_EQ(duArr.min(), 2);
-  EXPECT_EQ(duArr.argMin(), 1);
+  EXPECT_EQ(2, duArr.min());
+  EXPECT_EQ(1, duArr.argMin());
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_numeric_array, component_sum)
+{
+  constexpr int DIM = 3;
+  using CoordType = int;
+  using QArray = primal::NumericArray<CoordType, DIM>;
+
+  QArray incArr {1, 2, 3};
+  QArray decArr {3, 2, 1};
+
+  QArray udArr {5, 8, 3};
+  QArray duArr {6, 2, 5};
+
+  // testing component-wise min and max functions
+  EXPECT_EQ(6, incArr.sum());
+  EXPECT_EQ(6, decArr.sum());
+  EXPECT_EQ(16, udArr.sum());
+  EXPECT_EQ(13, duArr.sum());
 }
 
 //------------------------------------------------------------------------------
 TEST(primal_numeric_array, clamping)
 {
-  static const int DIM = 3;
-  typedef int CoordType;
-  typedef primal::NumericArray<CoordType, DIM> QArray;
+  constexpr int DIM = 3;
+  using CoordType = int;
+  using QArray = primal::NumericArray<CoordType, DIM>;
 
   CoordType seq[] = {15, 4, 2};
   CoordType seqClampUp7[] = {7, 4, 2};

--- a/src/axom/primal/tests/primal_tetrahedron.cpp
+++ b/src/axom/primal/tests/primal_tetrahedron.cpp
@@ -263,6 +263,98 @@ TEST_F(TetrahedronTest, barycentric)
 }
 
 //------------------------------------------------------------------------------
+TEST_F(TetrahedronTest, barycentric_skipNormalization)
+{
+  using CoordType = TetrahedronTest::CoordType;
+  using QPoint = TetrahedronTest::QPoint;
+  using RPoint = primal::Point<CoordType, 4>;
+  using TestVec = std::vector<std::pair<QPoint, RPoint>>;
+
+  for(int i = 0; i < this->numTetrahedra(); ++i)
+  {
+    const auto tet = this->getTet(i);
+    QPoint pt[4] = {tet[0], tet[1], tet[2], tet[3]};
+
+    TestVec testData;
+
+    // Test the four vertices
+    testData.push_back(std::make_pair(pt[0], RPoint {1., 0., 0., 0.}));
+    testData.push_back(std::make_pair(pt[1], RPoint {0., 1., 0., 0.}));
+    testData.push_back(std::make_pair(pt[2], RPoint {0., 0., 1., 0.}));
+    testData.push_back(std::make_pair(pt[3], RPoint {0., 0., 0., 1.}));
+
+    // Test the edge midpoints
+    testData.push_back(std::make_pair(QPoint::midpoint(pt[0], pt[1]),
+                                      RPoint {0.5, 0.5, 0., 0.}));
+    testData.push_back(std::make_pair(QPoint::midpoint(pt[1], pt[2]),
+                                      RPoint {0., 0.5, 0.5, 0.}));
+    testData.push_back(std::make_pair(QPoint::midpoint(pt[2], pt[3]),
+                                      RPoint {0., 0., 0.5, 0.5}));
+    testData.push_back(std::make_pair(QPoint::midpoint(pt[0], pt[2]),
+                                      RPoint {0.5, 0., 0.5, 0.}));
+    testData.push_back(std::make_pair(QPoint::midpoint(pt[0], pt[3]),
+                                      RPoint {0.5, 0., 0., 0.5}));
+    testData.push_back(std::make_pair(QPoint::midpoint(pt[1], pt[3]),
+                                      RPoint {0., 0.5, 0., 0.5}));
+
+    // Test the face midpoints
+    constexpr double one_third = 1. / 3.;
+    testData.push_back(std::make_pair(
+      QPoint(one_third * (pt[0].array() + pt[1].array() + pt[2].array())),
+      RPoint {one_third, one_third, one_third, 0.}));
+    testData.push_back(std::make_pair(
+      QPoint(one_third * (pt[0].array() + pt[1].array() + pt[3].array())),
+      RPoint {one_third, one_third, 0., one_third}));
+    testData.push_back(std::make_pair(
+      QPoint(one_third * (pt[0].array() + pt[2].array() + pt[3].array())),
+      RPoint {one_third, 0., one_third, one_third}));
+    testData.push_back(std::make_pair(
+      QPoint(one_third * (pt[1].array() + pt[2].array() + pt[3].array())),
+      RPoint {0., one_third, one_third, one_third}));
+
+    // Test the centroid
+    testData.push_back(std::make_pair(
+      QPoint(.25 * (pt[0].array() + pt[1].array() + pt[2].array() + pt[3].array())),
+      RPoint {.25, .25, .25, .25}));
+
+    // Test a point outside the tetrahedron
+    testData.push_back(std::make_pair(
+      QPoint(-0.4 * pt[0].array() + 1.2 * pt[1].array() + 0.2 * pt[2].array()),
+      RPoint {-0.4, 1.2, 0.2, 0.}));
+
+    // Now run the actual tests
+    for(const auto& data : testData)
+    {
+      const QPoint& query = data.first;
+      const RPoint& expBary = data.second;
+      RPoint bary = tet.physToBarycentric(query, false);
+      RPoint baryUnnormalized = tet.physToBarycentric(query, true);
+
+      // The unnormalized weights are proportional to the actual barycentric weights
+      // The factor of 6 is due to the use of parallelepiped volumes instead of tet volumes
+      const double volumeScale = 6 * tet.signedVolume();
+
+      SLIC_INFO(axom::fmt::format(
+        "For tet {} and point {} "
+        "-- barycentric coods {} (unnormalized barycentric {})"
+        "-- signed volume {}",
+        tet,
+        query,
+        bary,
+        baryUnnormalized,
+        tet.signedVolume()));
+
+      EXPECT_NEAR(volumeScale, baryUnnormalized.array().sum(), this->EPS);
+      for(int d = 0; d <= 3; ++d)
+      {
+        EXPECT_NEAR(bary[d] * volumeScale, baryUnnormalized[d], this->EPS);
+        EXPECT_NEAR(expBary[d] * volumeScale, baryUnnormalized[d], this->EPS);
+      }
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
 TEST_F(TetrahedronTest, tetrahedron_roundtrip_bary_to_physical)
 {
   const double EPS = 1e-12;

--- a/src/axom/primal/tests/primal_tetrahedron.cpp
+++ b/src/axom/primal/tests/primal_tetrahedron.cpp
@@ -477,18 +477,22 @@ TEST_F(TetrahedronTest, tet_3D_circumsphere)
   using primal::ON_NEGATIVE_SIDE;
   using primal::ON_POSITIVE_SIDE;
 
-  // Test tets
-  std::vector<QTet> tets = {this->getTet(0),
-                            this->getTet(1),
-                            this->getTet(2),
-                            this->getTet(3)};
-
-  // Compute circumsphere of test triangles and test some points
-  for(const auto& tet : tets)
+  // Compute circumsphere of test tetrahedra and test some points
+  for(int ti = 0; ti < this->numTetrahedra(); ++ti)
   {
+    QTet tet = this->getTet(ti);
     QSphere circumsphere = tet.circumsphere();
 
     SLIC_INFO("Circumsphere for tetrahedron: " << tet << " is " << circumsphere);
+
+    // check that each vertex is on the sphere
+    for(int i = 0; i < 4; ++i)
+    {
+      auto qpt = tet[i];
+      EXPECT_NEAR(circumsphere.getRadius(),
+                  sqrt(primal::squared_distance(qpt, circumsphere.getCenter())),
+                  EPS);
+    }
 
     // test vertices
     for(int i = 0; i < 4; ++i)
@@ -513,8 +517,8 @@ TEST_F(TetrahedronTest, tet_3D_circumsphere)
 
     // test face centers
     {
-      const CoordType third = 1. / 3.;
-      const CoordType zero {0};
+      constexpr CoordType third = 1. / 3.;
+      constexpr CoordType zero {0};
       QPoint qpt[4] = {tet.baryToPhysical(RPoint {third, third, third, zero}),
                        tet.baryToPhysical(RPoint {third, third, zero, third}),
                        tet.baryToPhysical(RPoint {third, zero, third, third}),

--- a/src/axom/primal/tests/primal_triangle.cpp
+++ b/src/axom/primal/tests/primal_triangle.cpp
@@ -477,6 +477,15 @@ TEST(primal_triangle, triangle_2D_circumsphere)
 
     SLIC_INFO("Circumsphere for triangle: " << tri << " is " << circumsphere);
 
+    // check that each vertex is on the sphere
+    for(int i = 0; i < 3; ++i)
+    {
+      auto qpt = tri[i];
+      EXPECT_NEAR(circumsphere.getRadius(),
+                  sqrt(primal::squared_distance(qpt, circumsphere.getCenter())),
+                  EPS);
+    }
+
     for(int i = 0; i < 3; i++)
     {
       QPoint qpt = tri[i];

--- a/src/axom/primal/tests/primal_triangle.cpp
+++ b/src/axom/primal/tests/primal_triangle.cpp
@@ -4,14 +4,9 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "axom/config.hpp"
-
-#include "axom/primal/geometry/Point.hpp"
-#include "axom/primal/geometry/Triangle.hpp"
-#include "axom/primal/geometry/Sphere.hpp"
-#include "axom/primal/geometry/OrientationResult.hpp"
-#include "axom/primal/operators/squared_distance.hpp"
-
 #include "axom/slic.hpp"
+#include "axom/primal.hpp"
+
 #include "axom/fmt.hpp"
 
 #include "gtest/gtest.h"
@@ -22,8 +17,8 @@ namespace primal = axom::primal;
 
 TEST(primal_triangle, triangle_area_2D)
 {
-  const int DIM = 2;
-  const double EPS = 1e-12;
+  constexpr int DIM = 2;
+  constexpr double EPS = 1e-12;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
   using QTri = primal::Triangle<CoordType, DIM>;
@@ -59,8 +54,8 @@ TEST(primal_triangle, triangle_area_2D)
 //------------------------------------------------------------------------------
 TEST(primal_triangle, triangle_area_3D)
 {
-  const int DIM = 3;
-  const double EPS = 1e-12;
+  constexpr int DIM = 3;
+  constexpr double EPS = 1e-12;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
   using QTri = primal::Triangle<CoordType, DIM>;
@@ -92,8 +87,8 @@ TEST(primal_triangle, triangle_area_3D)
 //------------------------------------------------------------------------------
 TEST(primal_triangle, triangle_physical_to_bary)
 {
-  const int DIM = 3;
-  const double EPS = 1e-12;
+  constexpr int DIM = 3;
+  constexpr double EPS = 1e-12;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
   using QTri = primal::Triangle<CoordType, DIM>;
@@ -154,8 +149,8 @@ TEST(primal_triangle, triangle_physical_to_bary)
 //------------------------------------------------------------------------------
 TEST(primal_triangle, triangle_bary_to_physical)
 {
-  const int DIM = 3;
-  const double EPS = 1e-12;
+  constexpr int DIM = 3;
+  constexpr double EPS = 1e-12;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
   using QTri = primal::Triangle<CoordType, DIM>;
@@ -217,8 +212,8 @@ TEST(primal_triangle, triangle_bary_to_physical)
 //------------------------------------------------------------------------------
 TEST(primal_triangle, triangle_roundtrip_bary_to_physical)
 {
-  const int DIM = 2;
-  const double EPS = 1e-12;
+  constexpr int DIM = 2;
+  constexpr double EPS = 1e-12;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
   using QTri = primal::Triangle<CoordType, DIM>;
@@ -270,7 +265,7 @@ TEST(primal_triangle, triangle_roundtrip_bary_to_physical)
 
   // test barycenter
   {
-    const double third = 1. / 3.;
+    constexpr double third = 1. / 3.;
     RPoint b_in[1] = {RPoint {third, third, third}};
 
     QPoint p_exp[1] = {
@@ -290,8 +285,8 @@ TEST(primal_triangle, triangle_roundtrip_bary_to_physical)
 //-----------------------------------------------------------------------------
 TEST(primal_triangle, triangle_2D_point_containment)
 {
-  const int DIM = 2;
-  const double EPS = 1e-12;
+  constexpr int DIM = 2;
+  constexpr double EPS = 1e-12;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
   using QTri = primal::Triangle<CoordType, DIM>;
@@ -341,8 +336,8 @@ TEST(primal_triangle, triangle_2D_point_containment)
 //------------------------------------------------------------------------------
 TEST(primal_triangle, triangle_3D_point_containment)
 {
-  const int DIM = 3;
-  const double EPS = 1e-12;
+  constexpr int DIM = 3;
+  constexpr double EPS = 1e-12;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
   using QTri = primal::Triangle<CoordType, DIM>;
@@ -395,8 +390,8 @@ TEST(primal_triangle, triangle_3D_point_containment)
 //------------------------------------------------------------------------------
 TEST(primal_triangle, triangle_2D_circumsphere)
 {
-  const int DIM = 2;
-  const double EPS = 1e-9;
+  constexpr int DIM = 2;
+  constexpr double EPS = 1e-9;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
   using BaryPoint = primal::Point<CoordType, DIM + 1>;
@@ -443,6 +438,51 @@ TEST(primal_triangle, triangle_2D_circumsphere)
       QPoint qpt = tri.baryToPhysical(BaryPoint {-1, 3, -1});
       EXPECT_EQ(ON_POSITIVE_SIDE, circumsphere.getOrientation(qpt, EPS));
     }
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_triangle, triangle_3D_normal)
+{
+  constexpr int DIM = 3;
+  constexpr double EPS = 1e-9;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVec = primal::Vector<CoordType, DIM>;
+  using QTri = primal::Triangle<CoordType, DIM>;
+
+  // Define some points
+  QPoint o {0, 0, 0};
+  QPoint i {1, 0, 0};
+  QPoint j {0, 1, 0};
+  QPoint k {0, 0, 1};
+  QPoint ij {1, 1, 0};
+
+  // Check some easy normals
+  EXPECT_EQ(QTri(i, j, k).normal(), (QVec {1, 1, 1}));
+  EXPECT_EQ(QTri(i, k, j).normal(), (QVec {-1, -1, -1}));
+  EXPECT_EQ(QTri(o, i, j).normal(), (QVec {0, 0, 1}));
+  EXPECT_EQ(QTri(o, j, i).normal(), (QVec {0, 0, -1}));
+
+  EXPECT_EQ(QTri(i, j, k).normal(), -QTri(i, k, j).normal());
+
+  // More test triangles
+  std::vector<QTri> tris = {
+    QTri(i, j, k),
+    QTri(i, k, j),
+    QTri(o, i, ij),
+    QTri(o, i, j),
+    QTri(o, j, i),
+    QTri(i, j, i),
+    QTri(QPoint {2, 0, 0}, QPoint {0, 2, 0}, QPoint {0, 0, 2})};
+
+  // Check that length of normal is twice the triangle area
+  for(const auto& tri : tris)
+  {
+    auto normal = tri.normal();
+    SLIC_INFO(axom::fmt::format("Normal for triangle {} is {}", tri, normal));
+
+    EXPECT_NEAR(normal.norm() / 2., tri.area(), EPS);
   }
 }
 

--- a/src/axom/primal/tests/primal_triangle.cpp
+++ b/src/axom/primal/tests/primal_triangle.cpp
@@ -12,6 +12,7 @@
 #include "gtest/gtest.h"
 
 #include <cmath>
+#include <vector>
 
 namespace primal = axom::primal;
 
@@ -360,7 +361,7 @@ TEST(primal_triangle, triangle_2D_point_containment)
 
   QTri tri(pt[0], pt[1], pt[2]);
 
-  typedef std::vector<QPoint> TestVec;
+  using TestVec = std::vector<QPoint>;
   TestVec successes, failures;
 
   // Tests that should succeed:
@@ -411,7 +412,7 @@ TEST(primal_triangle, triangle_3D_point_containment)
 
   QTri tri(pt[0], pt[1], pt[2]);
 
-  typedef std::vector<QPoint> TestVec;
+  using TestVec = std::vector<QPoint>;
   TestVec successes, failures;
 
   // Tests that should succeed:

--- a/src/axom/primal/tests/primal_vector.cpp
+++ b/src/axom/primal/tests/primal_vector.cpp
@@ -260,25 +260,85 @@ TEST(primal_vector, vector_inner_product)
 }
 
 //------------------------------------------------------------------------------
-TEST(primal_vector, vector_outer_product)
+TEST(primal_vector, vector3_outer_product)
 {
   static const int DIM = 3;
   using CoordType = double;
-  using QPoint = primal::Point<CoordType, DIM>;
   using QVec = primal::Vector<CoordType, DIM>;
 
-  QPoint p1 {3, 0};
-  QPoint p2 {0, 4};
+  {
+    QVec v1 {3, 0};
+    QVec v2 {0, 4};
 
-  QVec v1(p1);
-  QVec v2(p2);
+    QVec vRes {0, 0, 12};
 
-  QVec vRes;
-  vRes[2] = 12.;
+    EXPECT_EQ(QVec::cross_product(v1, v2), vRes);
+    EXPECT_EQ(QVec::cross_product(v2, v1), -vRes);
+    EXPECT_EQ(QVec::cross_product(v1, v2), -QVec::cross_product(v2, v1));
+  }
 
-  EXPECT_EQ(QVec::cross_product(v1, v2), vRes);
-  EXPECT_EQ(QVec::cross_product(v2, v1), -vRes);
-  EXPECT_EQ(QVec::cross_product(v1, v2), -QVec::cross_product(v2, v1));
+  {
+    QVec v1 {1, 1, 1};
+    QVec v2 {1, 1, 1};
+
+    QVec vRes {0, 0, 0};
+
+    EXPECT_EQ(QVec::cross_product(v1, v2), vRes);
+    EXPECT_EQ(QVec::cross_product(v2, v1), -vRes);
+    EXPECT_EQ(QVec::cross_product(v1, v2), -QVec::cross_product(v2, v1));
+  }
+
+  {
+    QVec v1 {1, -1, 1};
+    QVec v2 {-.125, .25, -.5};
+
+    QVec vRes {0.25, 0.375, 0.125};
+
+    EXPECT_EQ(QVec::cross_product(v1, v2), vRes);
+    EXPECT_EQ(QVec::cross_product(v2, v1), -vRes);
+    EXPECT_EQ(QVec::cross_product(v1, v2), -QVec::cross_product(v2, v1));
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_vector, vector2_outer_product)
+{
+  using CoordType = double;
+  using QVec2 = primal::Vector<CoordType, 2>;
+  using QVec3 = primal::Vector<CoordType, 3>;
+
+  {
+    QVec2 v1 {3, 0};
+    QVec2 v2 {0, 4};
+
+    QVec3 vRes {0, 0, 12};
+
+    EXPECT_EQ(QVec2::cross_product(v1, v2), vRes);
+    EXPECT_EQ(QVec2::cross_product(v2, v1), -vRes);
+    EXPECT_EQ(QVec2::cross_product(v1, v2), -QVec2::cross_product(v2, v1));
+  }
+
+  {
+    QVec2 v1 {1, -1};
+    QVec2 v2 {.25, 4};
+
+    QVec3 vRes {0, 0, 4.25};
+
+    EXPECT_EQ(QVec2::cross_product(v1, v2), vRes);
+    EXPECT_EQ(QVec2::cross_product(v2, v1), -vRes);
+    EXPECT_EQ(QVec2::cross_product(v1, v2), -QVec2::cross_product(v2, v1));
+  }
+
+  {
+    QVec2 v1 {1, 1};
+    QVec2 v2 {-1, -1};
+
+    QVec3 vRes {0, 0, 0};
+
+    EXPECT_EQ(QVec2::cross_product(v1, v2), vRes);
+    EXPECT_EQ(QVec2::cross_product(v2, v1), -vRes);
+    EXPECT_EQ(QVec2::cross_product(v1, v2), -QVec2::cross_product(v2, v1));
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_vector.cpp
+++ b/src/axom/primal/tests/primal_vector.cpp
@@ -12,7 +12,9 @@
 #include "axom/core/execution/execution_space.hpp"
 #include "axom/core/execution/for_all.hpp"
 
-using namespace axom;
+#include <array>
+
+namespace primal = axom::primal;
 
 //------------------------------------------------------------------------------
 template <typename ExecSpace>
@@ -39,7 +41,7 @@ void check_vector_policy()
 //------------------------------------------------------------------------------
 TEST(primal_vector, vector_constructors)
 {
-  static const int DIM = 5;
+  constexpr int DIM = 5;
   using CoordType = double;
   using QArray = primal::NumericArray<CoordType, DIM>;
   using QVec = primal::Vector<CoordType, DIM>;
@@ -124,7 +126,7 @@ TEST(primal_vector, vector_constructors)
 //------------------------------------------------------------------------------
 TEST(primal_vector, vector_from_points_constructor)
 {
-  static const int DIM = 5;
+  constexpr int DIM = 5;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
   using QVec = primal::Vector<CoordType, DIM>;
@@ -159,7 +161,7 @@ TEST(primal_vector, vector_from_points_constructor)
 //------------------------------------------------------------------------------
 TEST(primal_vector, vector_normalize)
 {
-  static const int DIM = 3;
+  constexpr int DIM = 3;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
   using QVec = primal::Vector<CoordType, DIM>;
@@ -182,7 +184,7 @@ TEST(primal_vector, vector_normalize)
 //------------------------------------------------------------------------------
 TEST(primal_vector, vector_norm)
 {
-  static const int DIM = 2;
+  constexpr int DIM = 2;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
   using QVec = primal::Vector<CoordType, DIM>;
@@ -196,7 +198,7 @@ TEST(primal_vector, vector_norm)
 //------------------------------------------------------------------------------
 TEST(primal_vector, vector_arithmetic)
 {
-  static const int DIM = 3;
+  constexpr int DIM = 3;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
   using QVec = primal::Vector<CoordType, DIM>;
@@ -238,7 +240,7 @@ TEST(primal_vector, vector_arithmetic)
 //------------------------------------------------------------------------------
 TEST(primal_vector, vector_inner_product)
 {
-  static const int DIM = 3;
+  constexpr int DIM = 3;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
   using QVec = primal::Vector<CoordType, DIM>;
@@ -262,7 +264,7 @@ TEST(primal_vector, vector_inner_product)
 //------------------------------------------------------------------------------
 TEST(primal_vector, vector3_outer_product)
 {
-  static const int DIM = 3;
+  constexpr int DIM = 3;
   using CoordType = double;
   using QVec = primal::Vector<CoordType, DIM>;
 

--- a/src/axom/primal/tests/primal_vector.cpp
+++ b/src/axom/primal/tests/primal_vector.cpp
@@ -342,6 +342,55 @@ TEST(primal_vector, vector2_outer_product)
 }
 
 //------------------------------------------------------------------------------
+TEST(primal_vector, scalar_triple_product)
+{
+  using CoordType = double;
+  using QVec = primal::Vector<CoordType, 3>;
+  using QVecTriple = std::array<QVec, 3>;
+
+  QVec o {0, 0, 0};
+  QVec e_0 {1, 0, 0};
+  QVec e_1 {0, 1, 0};
+  QVec e_2 {0, 0, 1};
+
+  // explicitly test some examples
+  EXPECT_EQ(1., QVec::scalar_triple_product(e_0, e_1, e_2));
+  EXPECT_EQ(-1., QVec::scalar_triple_product(e_0, e_2, e_1));
+  EXPECT_DOUBLE_EQ(-10, QVec::scalar_triple_product(-e_0, 2.5 * e_1, 4. * e_2));
+
+  // test properties for a few examples
+  std::vector<QVecTriple> data = {
+    QVecTriple {e_0, e_1, e_2},
+    QVecTriple {e_0, e_2, e_1},
+    QVecTriple {e_0, e_0, e_1},
+    QVecTriple {o, e_0, e_1},
+    QVecTriple {e_0, e_0 + e_1, e_0 + e_1 + e_2},
+    QVecTriple {-3.33 * e_0, 2.25 * e_1, .1111 * e_2}};
+
+  for(auto triplet : data)
+  {
+    const auto& i = triplet[0];
+    const auto& j = triplet[1];
+    const auto& k = triplet[2];
+
+    // check definition
+    EXPECT_EQ(QVec::dot_product(i, QVec::cross_product(j, k)),
+              QVec::scalar_triple_product(i, j, k));
+
+    // check rotations
+    EXPECT_EQ(QVec::scalar_triple_product(i, j, k),
+              QVec::scalar_triple_product(j, k, i));
+
+    EXPECT_EQ(QVec::scalar_triple_product(i, j, k),
+              QVec::scalar_triple_product(k, i, j));
+
+    // check swap permutation
+    EXPECT_EQ(-QVec::scalar_triple_product(i, j, k),
+              QVec::scalar_triple_product(i, k, j));
+  }
+}
+
+//------------------------------------------------------------------------------
 TEST(primal_vector, vector_zero)
 {
   constexpr int DIM = 5;

--- a/src/axom/primal/tests/primal_winding_number.cpp
+++ b/src/axom/primal/tests/primal_winding_number.cpp
@@ -207,7 +207,6 @@ TEST(primal_winding_number, corner_cases)
   using Bezier = primal::BezierCurve<double, 2>;
 
   double abs_tol = 1e-8;
-  double lin_tol = 1e-8;
   double edge_tol = 1e-8;
 
   // Line segment
@@ -265,7 +264,6 @@ TEST(primal_winding_number, self_intersecting_cases)
   using Bezier = primal::BezierCurve<double, 2>;
 
   double abs_tol = 1e-8;
-  double lin_tol = 1e-8;
   double edge_tol = 1e-8;
 
   // Cubic curve with cusp

--- a/src/axom/quest/Discretize.cpp
+++ b/src/axom/quest/Discretize.cpp
@@ -6,6 +6,8 @@
 #include "axom/quest/Discretize.hpp"
 
 #include "axom/core.hpp"
+
+#include "axom/primal/constants.hpp"
 #include "axom/primal/geometry/NumericArray.hpp"
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
@@ -13,9 +15,10 @@
 #include "axom/primal/geometry/Polyhedron.hpp"
 #include "axom/primal/operators/squared_distance.hpp"
 #include "axom/primal/operators/split.hpp"
+
 #include "axom/mint/config.hpp"
-#include "axom/mint/mesh/Mesh.hpp"             /* for Mesh base class */
-#include "axom/mint/mesh/UnstructuredMesh.hpp" /* for UnstructuredMesh */
+#include "axom/mint/mesh/Mesh.hpp"
+#include "axom/mint/mesh/UnstructuredMesh.hpp"
 #include "axom/mint/mesh/CellTypes.hpp"
 
 #include <cmath>
@@ -32,7 +35,7 @@ Point3D project_to_shape(const Point3D& p, const SphereType& sphere)
   const auto& ctr = sphere.getCenter();
   const double dist2 = primal::squared_distance(ctr, p);
   const double dist = sqrt(dist2);
-  const double drat = sphere.getRadius() * dist / (dist2 + PTINY);
+  const double drat = sphere.getRadius() * dist / (dist2 + primal::PTINY);
 
   return Point3D::lerp(ctr, p, drat);
 }
@@ -115,7 +118,7 @@ bool discretize(const SphereType& sphere, int levels, OctType*& out, int& octcou
     return false;
   }
   // Zero radius: return true without generating octahedra.
-  if(sphere.getRadius() < PTINY)
+  if(sphere.getRadius() < primal::PTINY)
   {
     octcount = 0;
     return true;

--- a/src/axom/quest/Discretize.hpp
+++ b/src/axom/quest/Discretize.hpp
@@ -7,7 +7,7 @@
 #define QUEST_DISCRETIZE_HPP_
 
 // Axom includes
-#include "axom/core/Macros.hpp"  // for axom macros
+#include "axom/core/Macros.hpp"
 
 // Geometry
 #include "axom/primal/geometry/Sphere.hpp"
@@ -118,4 +118,4 @@ int mesh_from_discretized_polyline(const OctType* octs,
 
 #include "detail/Discretize_detail.hpp"
 
-#endif /* QUEST_DISCRETIZE_HPP_ */
+#endif  // QUEST_DISCRETIZE_HPP_

--- a/src/axom/quest/detail/Discretize_detail.hpp
+++ b/src/axom/quest/detail/Discretize_detail.hpp
@@ -6,6 +6,8 @@
 #ifndef AXOM_QUEST_DISCRETIZE_DETAIL_
 #define AXOM_QUEST_DISCRETIZE_DETAIL_
 
+#include "axom/primal/constants.hpp"
+
 namespace
 {
 enum
@@ -17,8 +19,6 @@ enum
   T,
   U
 };
-
-constexpr double PTINY = 1e-80;
 
 using SphereType = axom::quest::SphereType;
 using OctType = axom::quest::OctType;
@@ -84,11 +84,10 @@ inline int count_segment_prisms(int levels)
 AXOM_HOST_DEVICE
 Point3D rescale_YZ(const Point3D &p, double new_dst)
 {
-  double cur_dst = sqrt(p[1] * p[1] + p[2] * p[2]);
-  if(cur_dst < PTINY)
-  {
-    cur_dst = PTINY;
-  }
+  const double cur_dst =
+    axom::utilities::clampLower(sqrt(p[1] * p[1] + p[2] * p[2]),
+                                axom::primal::PTINY);
+
   Point3D retval;
   retval[0] = p[0];
   retval[1] = p[1] * new_dst / cur_dst;
@@ -157,11 +156,11 @@ int discrSeg(const Point2D &a, const Point2D &b, int levels, OctType *&out, int 
   SLIC_ASSERT(b[1] >= 0);
 
   // Deal with degenerate segments
-  if(b[0] - a[0] < PTINY)
+  if(b[0] - a[0] < axom::primal::PTINY)
   {
     return 0;
   }
-  if(a[1] < PTINY && b[1] < PTINY)
+  if(a[1] < axom::primal::PTINY && b[1] < axom::primal::PTINY)
   {
     return 0;
   }

--- a/src/axom/spin/RectangularLattice.hpp
+++ b/src/axom/spin/RectangularLattice.hpp
@@ -9,13 +9,14 @@
 #include "axom/config.hpp"
 #include "axom/core/utilities/Utilities.hpp"
 
+#include "axom/primal/constants.hpp"
 #include "axom/primal/geometry/BoundingBox.hpp"
 #include "axom/primal/geometry/NumericArray.hpp"
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
 
-#include <cmath>     // for std::floor
-#include <iostream>  // for ostream
+#include <cmath>
+#include <iostream>
 
 namespace axom
 {
@@ -47,7 +48,8 @@ namespace spin
  * and a grid spacing (a SpaceVector).
  *
  * \note Grid spacing coordinates that are really small (magnitude less
- * than 1E-50) are snapped to zero to avoid division by zero.
+ * than primal::PTINY := 1e-50) are snapped to zero to avoid division by zero.
+ * \sa primal::PTINY
  */
 template <int NDIMS, typename SpaceCoordType = double, typename CellCoordType = int>
 class RectangularLattice
@@ -89,7 +91,7 @@ public:
    * \param spacing The lattice's spacing
    *
    * \note The magnitude of the spacing coordinates should be greater than zero.
-   * If they are less than EPS = 1E-50, the lattice will be degenerate in
+   * If they are less than primal::PTINY, the lattice will be degenerate in
    * that dimension.
    */
   RectangularLattice(const SpacePoint& origin, const SpaceVector& spacing)
@@ -115,7 +117,7 @@ public:
    * \note Spacing will be set to vector or ones if pointer is NULL
    *
    * \note The magnitude of the spacing coordinates should be greater than zero.
-   * If they are less than EPS = 1E-50, the lattice will be degenerate in
+   * If they are less than EPS = primal::PTINY, the lattice will be degenerate in
    * that dimension.
    */
   RectangularLattice(SpaceCoordType* origin_data, SpaceCoordType* spacing_data)
@@ -192,7 +194,7 @@ private:
    * spacing to zero and to initialize the inverted spacing.
    *
    * A spacing coordinate is considered really small when its magnitude
-   * is less than EPS = 1E-50.
+   * is less than primal::PTINY.
    *
    * For each coordinate i, the inverted coordinate will be:
    *     m_invSpacing[i] = 1. / m_spacing[i]
@@ -201,7 +203,7 @@ private:
    */
   void initializeSpacingAndInvSpacing()
   {
-    constexpr SpaceCoordType EPS = 1.0e-50;
+    constexpr SpaceCoordType EPS = primal::PTINY;
     constexpr SpaceCoordType ZERO = SpaceCoordType(0.);
     constexpr SpaceCoordType ONE = SpaceCoordType(1.);
 
@@ -238,8 +240,8 @@ private:
  * minimum corner position.
  *
  * \note If the bounding box range along a dimension is near zero (i.e. smaller
- * than 1E-50, the grid resolution in that dimension will be set to zero in
- * that dimension.
+ * than primal::PTINY, the grid resolution in that dimension will be 
+ * set to zero in that dimension.
  */
 template <int NDIMS, typename SpaceCoordType, typename CellCoordType>
 RectangularLattice<NDIMS, SpaceCoordType, CellCoordType>


### PR DESCRIPTION
# Summary

- This PR is a feature
- It improves the robustness of several operations on primal's Triangles and Tetrahedra, including the computation of areas/volumes, barycentric coordinates and circumspheres.
- Specifically, it recasts several coordinate-based determinants as operations on vectors. This reduces the dimension of the underlying matrices by one and better uses the limited floating point precision
- It also adds a `skipNormalization` parameter to Triangle and Tetrahedron's `physToBarycentric()` method (defaulting to `false`) to avoid normalizing the results by the element's volume. This can be useful in cases where we only need the relative weights and can avoid division by zero for (nearly) degenerate elements. It also adds a tiny amount (`1e-50`) to the denominator when `skipNormalization` is off to avoid division by zero.
- This PR is in support of forthcoming improvements to quest's `Delaunay` and `ScatteredInterpolation` classes when the input points are very close to each other leading to numerical problems associated with nearly degenerate triangles/tetrahedra