### PR TITLE
Adding env variables for CDash site and token

### DIFF
--- a/src/cmake/Dashboard.cmake.in
+++ b/src/cmake/Dashboard.cmake.in
@@ -1,14 +1,17 @@
+set(CTEST_SITE "Axom")
+site_name(CTEST_SITE)
+
 set(CTEST_PROJECT_NAME "Axom")
 set(CTEST_NIGHTLY_START_TIME "01:00:00 UTC")
 
 # drop site options
 set(CTEST_DROP_METHOD "https")
-set(CTEST_DROP_SITE "*** [TODO] Add url here")
+set(CTEST_DROP_SITE "$ENV{LC_CDASH_DROP_SITE}")
 set(CTEST_DROP_LOCATION "/cdash/submit.php?project=${CTEST_PROJECT_NAME}")
 set(CTEST_DROP_SITE_CDASH TRUE)
 
 # this is our token for cdash
-set(_auth_token "*** [TODO]: Add token here")
+set(_auth_token "$ENV{LC_CDASH_TOKEN}")
 
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS           "200" )
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS         "500" )


### PR DESCRIPTION
# Summary

- This PR is a new feature
- It does the following:
  - set site name
  - CTEST_DROP_SITE as environment variable LC_CDASH_DROP_SITE (injected pipeline)
  - _auth_token as env. variable LC_CDASH_TOKEN (injected pipeline)
