### PR TITLE
Misc cleanup

### DIFF
--- a/src/cmake/AxomConfig.cmake
+++ b/src/cmake/AxomConfig.cmake
@@ -160,6 +160,7 @@ set(_axom_exported_targets axom)
 
 blt_list_append(TO _axom_exported_targets ELEMENTS cuda cuda_runtime IF ENABLE_CUDA)
 blt_list_append(TO _axom_exported_targets ELEMENTS hip hip_runtime IF ENABLE_HIP)
+blt_list_append(TO _axom_exported_targets ELEMENTS mfem IF MFEM_FOUND)
 
 set(_optional_targets cli11 fmt hdf5 lua openmp sol sparsehash)
 foreach(_tar ${_optional_targets})

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -141,6 +141,7 @@ if (TARGET mfem)
     # Case: included axom in project that also creates an mfem target, no need to recreate mfem
     message(STATUS "MFEM support is ON, using existing mfem target")
     blt_list_append(TO TPL_DEPS ELEMENTS mfem)
+    set(MFEM_FOUND TRUE CACHE BOOL "" FORCE)
 elseif (MFEM_DIR)
     include(cmake/thirdparty/FindMFEM.cmake)
     # If the CMake build system was used, a CMake target for mfem already exists

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -137,7 +137,11 @@ endif()
 #------------------------------------------------------------------------------
 # MFEM
 #------------------------------------------------------------------------------
-if (MFEM_DIR)
+if (TARGET mfem)
+    # Case: included axom in project that also creates an mfem target, no need to recreate mfem
+    message(STATUS "MFEM support is ON, using existing mfem target")
+    blt_list_append(TO TPL_DEPS ELEMENTS mfem)
+elseif (MFEM_DIR)
     include(cmake/thirdparty/FindMFEM.cmake)
     # If the CMake build system was used, a CMake target for mfem already exists
     if (NOT TARGET mfem)

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -122,32 +122,8 @@ mark_as_advanced(FMT_FOUND)
 
 if (AXOM_ENABLE_SPARSEHASH)
 
-  include(CheckIncludeFileCXX)
-
-  # Try to find the necessary include and namespace for hash functions
-  # This depends on the compiler and C++ standard library version
-  
-  set(_found_hash FALSE)
-
-  set(_hdr <functional>)
-  set(_ns  std)
-  set(_src "#include ${_hdr} \n int main() { int h = ${_ns}::hash<int>()(5)\; return 0\;}")
-  axom_check_code_compiles(SOURCE_STRING "${_src}" CODE_COMPILES _found_hash)
- 
-  if(NOT ${_found_hash})
-    set(_hdr <tr1/functional>)
-    set(_ns  std::tr1)
-    set(_src "#include ${_hdr} \n int main() { int h = ${_ns}::hash<int>()(5)\; return 0\;}")
-    axom_check_code_compiles(SOURCE_STRING "${_src}" CODE_COMPILES _found_hash)
-
-  endif()
-    
-  # Set up sparsehash, if we've found it
-  if(${_found_hash})
-    message(STATUS "Sparsehash configured with '${_hdr}' header")
-    
-    set(SPARSEHASH_HASHFUN_HEADER ${_hdr} CACHE INTERNAL "")
-    set(SPARSEHASH_HASHFUN_NAMESPACE ${_ns} CACHE INTERNAL "")
+    set(SPARSEHASH_HASHFUN_HEADER <functional> CACHE INTERNAL "")
+    set(SPARSEHASH_HASHFUN_NAMESPACE std CACHE INTERNAL "")
     set(SPARSEHASH_FOUND TRUE CACHE INTERNAL "")
 
     mark_as_advanced(
@@ -203,10 +179,6 @@ if (AXOM_ENABLE_SPARSEHASH)
             DESTINATION include/axom)
 
     install(EXPORT axom-targets DESTINATION lib/cmake)
-
-  else()
-    message(STATUS "Could not configure sparsehash")
-  endif()
 endif()
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This PR does two cleanup things:

1. Allows users to provide their own `mfem` CMake target.  This is useful for projects that co-develop multiple projects together. For example, Serac has the option to co-develop MFEM and Axom in one build. Fixes #874
2.  Removes the now unnecessary sparsehash header check. `std::tr1` was deprecated pre-c++11

