### PR TITLE
Bugfix for 3D MFEM Cartesian Mesh generation

### DIFF
--- a/src/tools/data_collection_util.cpp
+++ b/src/tools/data_collection_util.cpp
@@ -311,10 +311,10 @@ mfem::Mesh* createBoxMesh(const Input& params)
                                                       res[1],
                                                       res[2],
                                                       mfem::Element::HEXAHEDRON,
-                                                      false,
                                                       hi[0] - lo[0],
                                                       hi[1] - lo[1],
-                                                      hi[2] - lo[2]));
+                                                      hi[2] - lo[2],
+                                                      false));
     break;
   default:
     SLIC_ERROR("Only 2D and 3D meshes are currently supported.");


### PR DESCRIPTION
This PR fixes a small bug with the parameter order:
https://github.com/mfem/mfem/blob/3dd5cbbe074607d5e98b568269ba38e0eb0a6951/mesh/mesh.hpp#L609-L612