### PR TITLE
More submodule work

### DIFF
--- a/src/cmake/AxomConfig.cmake
+++ b/src/cmake/AxomConfig.cmake
@@ -160,7 +160,6 @@ set(_axom_exported_targets axom)
 
 blt_list_append(TO _axom_exported_targets ELEMENTS cuda cuda_runtime IF ENABLE_CUDA)
 blt_list_append(TO _axom_exported_targets ELEMENTS hip hip_runtime IF ENABLE_HIP)
-blt_list_append(TO _axom_exported_targets ELEMENTS mfem IF MFEM_FOUND)
 
 set(_optional_targets cli11 fmt hdf5 lua openmp sol sparsehash)
 foreach(_tar ${_optional_targets})

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -138,9 +138,14 @@ endif()
 # MFEM
 #------------------------------------------------------------------------------
 if (TARGET mfem)
-    # Case: included axom in project that also creates an mfem target, no need to recreate mfem
+    # Case: Axom included in project that also creates an mfem target, no need to recreate mfem
+    # Note - white238: I can't seem to get this to pass install testing due to mfem being included
+    # in multiple export sets
     message(STATUS "MFEM support is ON, using existing mfem target")
-    blt_list_append(TO TPL_DEPS ELEMENTS mfem)
+    # Add it to this export set but don't prefix it with axom::
+    install(TARGETS              mfem
+            EXPORT               axom-targets
+            DESTINATION          lib)
     set(MFEM_FOUND TRUE CACHE BOOL "" FORCE)
 elseif (MFEM_DIR)
     include(cmake/thirdparty/FindMFEM.cmake)


### PR DESCRIPTION
I am getting closer but I am beginning to think it's not really possible to toggle between `add_subdirectory()` and `find_package()` in a clean way.

This at least allows me to build and test Axom/MFEM inside of Serac but not install.  Though that is not our normal usage so this seems okay for now.