### PR TITLE
Adds support to Distributed closest point query for empty ranks 

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -101,6 +101,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Adds `constants.hpp` to primal to track geometric constants. Initially includes
   a value for `primal::PTINY`, a small constant that can be added to 
   denominators to avoid division by zero.
+- `DistributedClosestPoint` query now supports "domain underloading" -- ranks that are passed in can 
+  have empty object meshes and/or empty query meshes 
 
 ###  Changed
 - Axom now requires C++14 and will default to that if not specified via `BLT_CXX_STD`.

--- a/src/axom/primal/operators/squared_distance.hpp
+++ b/src/axom/primal/operators/squared_distance.hpp
@@ -20,6 +20,8 @@
 #include "axom/primal/geometry/Vector.hpp"
 #include "axom/primal/operators/closest_point.hpp"
 
+#include "axom/core/utilities/Utilities.hpp"
+
 #include "axom/slic/interface/slic.hpp"
 
 #include <limits>
@@ -69,32 +71,30 @@ AXOM_HOST_DEVICE inline double squared_distance(const Point<T, NDIMS>& A,
  *  given axis-aligned bounding box B.
  * \param [in] P the query point.
  * \param [in] B the axis-aligned bounding box.
- * \return the squared distance from P to the closest point on box B.
+ * \return the squared distance from P to the closest point on box \a B
+ * or std::numeric_limits<T>::max() if \a B is invalid. 
  */
 template <typename T, int NDIMS>
 AXOM_HOST_DEVICE inline double squared_distance(const Point<T, NDIMS>& P,
                                                 const BoundingBox<T, NDIMS>& B)
 {
+  using axom::utilities::clampVal;
+
+  if(!B.isValid())
+  {
+    return std::numeric_limits<double>::max();
+  }
+
   if(B.contains(P))
   {
-    /* short-circuit */
-    return 0.0f;
+    return 0;
   }
 
   // compute closest point to the box
   Point<T, NDIMS> cp;
   for(int i = 0; i < NDIMS; ++i)
   {
-    cp[i] = P[i];
-    if(cp[i] < B.getMin()[i])
-    {
-      cp[i] = B.getMin()[i];
-    }
-
-    if(cp[i] > B.getMax()[i])
-    {
-      cp[i] = B.getMax()[i];
-    }
+    cp[i] = clampVal(P[i], B.getMin()[i], B.getMax()[i]);
   }
 
   // return squared distance to the closest point
@@ -107,7 +107,7 @@ AXOM_HOST_DEVICE inline double squared_distance(const Point<T, NDIMS>& P,
  * \param [in] B the second axis-aligned bounding box.
  * If the boxes overlap, the minimum distance is zero.
  * \return the squared distance between the closest points on A and B
- * or NaN if either box is invalid.
+ * or std::numeric_limits<T>::max() if either box is invalid.
  */
 template <typename T, int NDIMS>
 AXOM_HOST_DEVICE inline double squared_distance(const BoundingBox<T, NDIMS>& A,
@@ -131,7 +131,7 @@ AXOM_HOST_DEVICE inline double squared_distance(const BoundingBox<T, NDIMS>& A,
     return v.squared_norm();
   }
 
-  return std::numeric_limits<T>::quiet_NaN();
+  return std::numeric_limits<T>::max();
 }
 
 /*!

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -441,12 +441,12 @@ public:
     switch(m_runtimePolicy)
     {
     case RuntimePolicy::seq:
-      m_bvh_seq = std::unique_ptr<SeqBVHTree>(new SeqBVHTree);
+      m_bvh_seq = std::make_unique<SeqBVHTree>();
       return generateBVHTreeImpl<SeqBVHTree>(m_bvh_seq.get());
 
     case RuntimePolicy::omp:
 #ifdef _AXOM_DCP_USE_OPENMP
-      m_bvh_omp = std::unique_ptr<OmpBVHTree>(new OmpBVHTree);
+      m_bvh_omp = std::make_unique<OmpBVHTree>();
       return generateBVHTreeImpl<OmpBVHTree>(m_bvh_omp.get());
 #else
       break;
@@ -454,7 +454,7 @@ public:
 
     case RuntimePolicy::cuda:
 #ifdef _AXOM_DCP_USE_CUDA
-      m_bvh_cuda = std::unique_ptr<CudaBVHTree>(new CudaBVHTree);
+      m_bvh_cuda = std::make_unique<CudaBVHTree>();
       return generateBVHTreeImpl<CudaBVHTree>(m_bvh_cuda.get());
 #else
       break;
@@ -462,7 +462,7 @@ public:
 
     case RuntimePolicy::hip:
 #ifdef _AXOM_DCP_USE_HIP
-      m_bvh_hip = std::unique_ptr<HipBVHTree>(new HipBVHTree);
+      m_bvh_hip = std::make_unique<HipBVHTree>();
       return generateBVHTreeImpl<HipBVHTree>(m_bvh_hip.get());
 #else
       break;
@@ -1343,15 +1343,15 @@ private:
     switch(m_dimension)
     {
     case 2:
-      m_dcp_2 = std::unique_ptr<internal::DistributedClosestPointImpl<2>>(
-        new internal::DistributedClosestPointImpl<2>(m_runtimePolicy,
-                                                     m_isVerbose));
+      m_dcp_2 = std::make_unique<internal::DistributedClosestPointImpl<2>>(
+        m_runtimePolicy,
+        m_isVerbose);
       m_objectMeshCreated = true;
       break;
     case 3:
-      m_dcp_3 = std::unique_ptr<internal::DistributedClosestPointImpl<3>>(
-        new internal::DistributedClosestPointImpl<3>(m_runtimePolicy,
-                                                     m_isVerbose));
+      m_dcp_3 = std::make_unique<internal::DistributedClosestPointImpl<3>>(
+        m_runtimePolicy,
+        m_isVerbose);
       m_objectMeshCreated = true;
       break;
     }

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -63,9 +63,9 @@ enum class DistributedClosestPointRuntimePolicy
 namespace internal
 {
 // Utility function to dump a conduit node on each rank, e.g. for debugging
-void dump_node(const conduit::Node& n,
-               const std::string&& fname,
-               const std::string& protocol = "json")
+inline void dump_node(const conduit::Node& n,
+                      const std::string&& fname,
+                      const std::string& protocol = "json")
 {
   conduit::relay::io::save(n, fname, protocol);
 };
@@ -98,8 +98,9 @@ axom::ArrayView<T> ArrayView_from_Node(conduit::Node& node, int sz)
  * \warning Assumes the underlying data is an MCArray with stride 2 access
  */
 template <>
-axom::ArrayView<primal::Point<double, 2>> ArrayView_from_Node(conduit::Node& node,
-                                                              int sz)
+inline axom::ArrayView<primal::Point<double, 2>> ArrayView_from_Node(
+  conduit::Node& node,
+  int sz)
 {
   using PointType = primal::Point<double, 2>;
 
@@ -113,8 +114,9 @@ axom::ArrayView<primal::Point<double, 2>> ArrayView_from_Node(conduit::Node& nod
  * \warning Assumes the underlying data is an MCArray with stride 3 access
  */
 template <>
-axom::ArrayView<primal::Point<double, 3>> ArrayView_from_Node(conduit::Node& node,
-                                                              int sz)
+inline axom::ArrayView<primal::Point<double, 3>> ArrayView_from_Node(
+  conduit::Node& node,
+  int sz)
 {
   using PointType = primal::Point<double, 3>;
 

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -52,6 +52,10 @@ if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
     if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR)
         set(_nranks 3)
 
+        # Bugfix: Serialize ordering of DCP tests as workaround for MPI issues 
+        # encountered when these tests ran in parallel
+        set(_dcp_previous_test)
+
         # Run the distributed closest point example on N ranks for each enabled policy
         set(_policies "seq")
         blt_list_append(TO _policies ELEMENTS "omp" IF ENABLE_OPENMP)
@@ -74,6 +78,11 @@ if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                 set_property(TEST ${_test} APPEND PROPERTY ENVIRONMENT OMP_NUM_THREADS=4)
             endif()
 
+            if(_dcp_previous_test)
+                set_tests_properties(${_test} PROPERTIES DEPENDS ${_dcp_previous_test})
+            endif()
+            set(_dcp_previous_test ${_test})
+
             # Add test with data on a subset of the ranks
             set(_test "quest_distributed_closest_point_run_2D_empty_ranks_${_pol}")
             axom_add_test(
@@ -90,12 +99,16 @@ if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
             if(${_pol} STREQUAL "omp")
                 set_property(TEST ${_test} APPEND PROPERTY ENVIRONMENT OMP_NUM_THREADS=4)
             endif()
+
+            set_tests_properties(${_test} PROPERTIES DEPENDS ${_dcp_previous_test})
+            set(_dcp_previous_test ${_test})
     
         endforeach()
 
         unset(_nranks)
         unset(_policies)
         unset(_test)
+        unset(_dcp_previous_test)
     endif()
 endif()
 

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -58,8 +58,8 @@ if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
         blt_list_append(TO _policies ELEMENTS "cuda" IF ENABLE_CUDA)
         blt_list_append(TO _policies ELEMENTS "hip" IF ENABLE_HIP)
         foreach(_pol ${_policies})
+            # Add test with data on all ranks
             set(_test "quest_distributed_closest_point_run_2D_${_pol}")
-
             axom_add_test(
                 NAME    ${_test}
                 COMMAND quest_distributed_distance_query_ex
@@ -70,10 +70,27 @@ if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                             --object-file dcp_object_mesh_2d_${_pol}
                             --distance-file dcp_closest_point_2d_${_pol}
                 NUM_MPI_TASKS ${_nranks})
-
             if(${_pol} STREQUAL "omp")
                 set_property(TEST ${_test} APPEND PROPERTY ENVIRONMENT OMP_NUM_THREADS=4)
             endif()
+
+            # Add test with data on a subset of the ranks
+            set(_test "quest_distributed_closest_point_run_2D_empty_ranks_${_pol}")
+            axom_add_test(
+                NAME    ${_test}
+                COMMAND quest_distributed_distance_query_ex
+                            --mesh-file ${quest_data_dir}/box_2D_r${_nranks}.root
+                            --num-samples 500
+                            --dist-threshold .45
+                            --policy ${_pol}
+                            --object-file dcp_object_mesh_2d_${_pol}
+                            --distance-file dcp_closest_point_2d_${_pol}
+                            --empty-rank-probability .5
+                NUM_MPI_TASKS ${_nranks})
+            if(${_pol} STREQUAL "omp")
+                set_property(TEST ${_test} APPEND PROPERTY ENVIRONMENT OMP_NUM_THREADS=4)
+            endif()
+    
         endforeach()
 
         unset(_nranks)


### PR DESCRIPTION
# Summary

- This PR is a feature
- It allows quest's `DistributedClosestPoint` query to be run on meshes where some ranks have empty "object meshes" and/or "query meshes". 
- This matches how users are planning to run the code, where the "object meshes" might be features that exist on only a subset of the ranks, and similarly, where the query points might also only exist on a subset of the ranks.
- I tried to minimize changes to the `DistributedClosestPoint` class in anticipation of merging #879 (I'm not sure which one will get merged first)

The following picture was run on a 36 rank problem where ~25% of the ranks did not have any object points (the points on the circle) and, independently, ~25% of the ranks did not send any data to the distributed closest point query. This run also used a cutoff distance of .5 units
![dcp_36ranks_20percentoff_ 5cutoff](https://user-images.githubusercontent.com/5626552/182769015-88128453-2a6e-4e22-ab1b-68211b163b57.png)

The command line for this run was:
> \>srun -n36 ./bin/data_collection_util -p1 --min -1.5 -1.5 --max 1.5 1.5 --res 1000 1000
> \>srun -n36 ./examples/quest_distributed_distance_query_ex -m box_2d.root -n 1000 --empty-rank-probability=.25 -d .5

