### PR TITLE
Tetrahedron - Tetrahedron Clipping

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -104,6 +104,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - `DistributedClosestPoint` query now supports "domain underloading" -- ranks that are passed in can 
   have empty object meshes and/or empty query meshes 
 - 'BezierCurve' objects now support Rational Bezier curve functionality
+- Primal: Adds a `clip()` operator for computing the intersection of a `Tetrahedron` and another `Tetrahedron` as a `Polyhedron`
 
 ###  Changed
 - Axom now requires C++14 and will default to that if not specified via `BLT_CXX_STD`.

--- a/src/axom/core/ArrayIteratorBase.hpp
+++ b/src/axom/core/ArrayIteratorBase.hpp
@@ -44,6 +44,7 @@ public:
 
   ArrayIteratorBase() : BaseType(0) { }
 
+  AXOM_HOST_DEVICE
   ArrayIteratorBase(IndexType pos, ArrayPointerType arr)
     : BaseType(pos)
     , m_arrayPtr(arr)
@@ -52,6 +53,7 @@ public:
   /**
    * \brief Returns the current iterator value
    */
+  AXOM_HOST_DEVICE
   ValueType& operator*() const
   {
     return m_arrayPtr->flatIndex(BaseType::m_pos);
@@ -59,6 +61,7 @@ public:
 
 protected:
   /** Implementation of advance() as required by IteratorBase */
+  AXOM_HOST_DEVICE
   void advance(IndexType n) { BaseType::m_pos += n; }
 
 protected:

--- a/src/axom/core/ArrayView.hpp
+++ b/src/axom/core/ArrayView.hpp
@@ -98,12 +98,14 @@ public:
   /*!
    * \brief Returns an ArrayViewIterator to the first element of the Array
    */
+  AXOM_HOST_DEVICE
   ArrayViewIterator begin() const { return ArrayViewIterator(0, this); }
 
   /*!
    * \brief Returns an ArrayViewIterator to the element following the last
    *  element of the Array.
    */
+  AXOM_HOST_DEVICE
   ArrayViewIterator end() const { return ArrayViewIterator(size(), this); }
 
   /*!

--- a/src/axom/core/IteratorBase.hpp
+++ b/src/axom/core/IteratorBase.hpp
@@ -51,6 +51,8 @@ class IteratorBase
 
 protected:
   IteratorBase() : m_pos(PosType()) { }
+
+  AXOM_HOST_DEVICE
   explicit IteratorBase(PosType pos) : m_pos(pos) { }
 
 private:
@@ -60,6 +62,7 @@ private:
    */
   struct accessor : IterType
   {
+    AXOM_HOST_DEVICE
     static void adv(IterType& derived, PosType n)
     {
       void (IterType::*fn)(PosType) = &accessor::advance;
@@ -69,6 +72,7 @@ private:
 
 private:
   /// Call the derived iterator's advance() function
+  AXOM_HOST_DEVICE
   void adv(IterType& derived, PosType n) const { accessor::adv(derived, n); }
 
 public:
@@ -83,6 +87,7 @@ public:
     return lhs.m_pos == rhs.m_pos;
   }
   /// Inequality operator
+  AXOM_HOST_DEVICE
   friend bool operator!=(const iterator& lhs, const iterator& rhs)
   {
     return lhs.m_pos != rhs.m_pos;
@@ -114,6 +119,7 @@ public:
   /// \{
 
   /// Pre-increment operator
+  AXOM_HOST_DEVICE
   IterType& operator++()
   {
     adv(getIter(), 1);
@@ -186,8 +192,11 @@ public:
 
 private:
   /// Accessor to derived class
+  AXOM_HOST_DEVICE
   IterType& getIter() { return *static_cast<IterType*>(this); }
+
   /// Const accessor to derived class
+  AXOM_HOST_DEVICE
   const IterType& getIter() const
   {
     return *static_cast<const IterType*>(this);

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -129,6 +129,36 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Octahedron<T, 3>& oct,
   return detail::clipOctahedron(oct, tet, eps);
 }
 
+/*!
+ * \brief Clips a 3D tetrahedron against a tetrahedron in 3D, returning
+ *        the geometric intersection as a polyhedron
+ *
+ *  This function clips the first tetrahedron by the 4 planes obtained from the
+ *  second tetrahedron's faces (normals point inward). Clipping the
+ *  tetrahedron/polyhedron by each plane gives the polyhedron above that plane.
+ *  Clipping the polyhedron by a plane involves
+ *  finding new vertices at the intersection of the polyhedron edges and
+ *  the plane, removing vertices from the polyhedron that are below the
+ *  plane, and redefining the neighbors for each vertex (a vertex is a
+ *  neighbor of another vertex if there is an edge between them).
+ *
+ *
+ * \param [in] tet1 The tetrahedron to clip
+ * \param [in] tet2 The tetrahedron to clip against
+ * \param [in] eps The epsilon value
+ * \return A polyhedron of the tetrahedron clipped against the tetrahedron.
+ *
+ * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
+ *
+ */
+template <typename T>
+AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet1,
+                                       const Tetrahedron<T, 3>& tet2,
+                                       double eps = 1.e-10)
+{
+  return detail::clipTetrahedron(tet1, tet2, eps);
+}
+
 }  // namespace primal
 }  // namespace axom
 

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -130,7 +130,7 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Octahedron<T, 3>& oct,
 }
 
 /*!
- * \brief Clips a 3D tetrahedron against a tetrahedron in 3D, returning
+ * \brief Clips a 3D tetrahedron against another tetrahedron in 3D, returning
  *        the geometric intersection as a polyhedron
  *
  *  This function clips the first tetrahedron by the 4 planes obtained from the
@@ -146,7 +146,8 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Octahedron<T, 3>& oct,
  * \param [in] tet1 The tetrahedron to clip
  * \param [in] tet2 The tetrahedron to clip against
  * \param [in] eps The epsilon value
- * \return A polyhedron of the tetrahedron clipped against the tetrahedron.
+ * \return A polyhedron of the tetrahedron clipped against
+ *         the other tetrahedron.
  *
  * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
  *

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -403,16 +403,17 @@ AXOM_HOST_DEVICE void poly_clip_reindex(Polyhedron<T, NDIMS>& poly,
  *        poly and an Array of Plane planes.
  *
  * \param [in] poly The polyhedron
- * \param [in] planes The Array of planes
+ * \param [in] planes The planes
+ * \param [in] numPlanes The number of planes
  * \param [in] eps The tolerance for plane point orientation.
  * \return The Polyhedron formed from clipping the polyhedron with a set of planes.
  *
  */
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(
-  Polyhedron<T, NDIMS>& poly,
-  const axom::ArrayView<const Plane<T,NDIMS>>& planes,
-  double eps = 1.e-10)
+AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(Polyhedron<T, NDIMS>& poly,
+                                                     const Plane<T, NDIMS>* planes,
+                                                     unsigned int numPlanes,
+                                                     double eps = 1.e-10)
 {
   using PointType = Point<T, NDIMS>;
   using BoxType = BoundingBox<T, NDIMS>;
@@ -422,7 +423,7 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(
   BoxType polyBox(&poly[0], poly.numVertices());
 
   //Clip octahedron by each plane
-  for(int planeIndex = 0; planeIndex < planes.size(); planeIndex++)
+  for(unsigned int planeIndex = 0; planeIndex < numPlanes; planeIndex++)
   {
     PlaneType plane = planes[planeIndex];
 
@@ -530,9 +531,7 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipOctahedron(
                          make_plane(tet[0], tet[3], tet[1]),
                          make_plane(tet[0], tet[1], tet[2])};
 
-  const ArrayView< const PlaneType> planes_view(planes, 4);
-
-  return clipPolyhedron(poly, planes_view, eps);
+  return clipPolyhedron(poly, planes, 4, eps);
 }
 
 }  // namespace detail

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -400,21 +400,20 @@ AXOM_HOST_DEVICE void poly_clip_reindex(Polyhedron<T, NDIMS>& poly,
 
 /*!
  * \brief Finds the clipped intersection Polyhedron between Polyhedron
- *        poly and a collection of Planes.
+ *        poly and an array of Planes.
  *
  * \param [in] poly The polyhedron
- * \param [in] planes The planes
- * \param [in] numPlanes The number of planes
+ * \param [in] planes The array of planes
  * \param [in] eps The tolerance for plane point orientation.
  *
  * \return The Polyhedron formed from clipping the polyhedron with a set of planes.
  *
  */
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(Polyhedron<T, NDIMS>& poly,
-                                                     const Plane<T, NDIMS>* planes,
-                                                     unsigned int numPlanes,
-                                                     double eps = 1.e-10)
+AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(
+  Polyhedron<T, NDIMS>& poly,
+  axom::ArrayView<Plane<T, NDIMS>> planes,
+  double eps)
 {
   using PointType = Point<T, NDIMS>;
   using BoxType = BoundingBox<T, NDIMS>;
@@ -424,10 +423,8 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(Polyhedron<T, NDIMS>& poly,
   BoxType polyBox(&poly[0], poly.numVertices());
 
   //Clip Polyhedron by each plane
-  for(unsigned int planeIndex = 0; planeIndex < numPlanes; planeIndex++)
+  for(PlaneType plane : planes)
   {
-    PlaneType plane = planes[planeIndex];
-
     // Check that plane intersects Polyhedron
     if(intersect(plane, polyBox, true, eps))
     {
@@ -495,7 +492,7 @@ template <typename T, int NDIMS>
 AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipOctahedron(
   const Octahedron<T, NDIMS>& oct,
   const Tetrahedron<T, NDIMS>& tet,
-  double eps = 1.e-10)
+  double eps)
 {
   using PointType = Point<T, NDIMS>;
   using PlaneType = Plane<T, NDIMS>;
@@ -531,7 +528,10 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipOctahedron(
                          make_plane(tet[0], tet[3], tet[1]),
                          make_plane(tet[0], tet[1], tet[2])};
 
-  return clipPolyhedron(poly, planes, 4, eps);
+  axom::StackArray<IndexType, 1> planeSize = {4};
+  axom::ArrayView<PlaneType> planesView(planes, planeSize);
+
+  return clipPolyhedron(poly, planesView, eps);
 }
 
 /*!
@@ -548,7 +548,7 @@ template <typename T, int NDIMS>
 AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
   const Tetrahedron<T, NDIMS>& tet1,
   const Tetrahedron<T, NDIMS>& tet2,
-  double eps = 1.e-10)
+  double eps)
 {
   using PointType = Point<T, NDIMS>;
   using PlaneType = Plane<T, NDIMS>;
@@ -579,7 +579,10 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
                          make_plane(tet2[0], tet2[3], tet2[1]),
                          make_plane(tet2[0], tet2[1], tet2[2])};
 
-  return clipPolyhedron(poly, planes, 4, eps);
+  axom::StackArray<IndexType, 1> planeSize = {4};
+  axom::ArrayView<PlaneType> planesView(planes, planeSize);
+
+  return clipPolyhedron(poly, planesView, eps);
 }
 
 }  // namespace detail

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -423,7 +423,7 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(Polyhedron<T, NDIMS>& poly,
   //Bounding Box of Polyhedron
   BoxType polyBox(&poly[0], poly.numVertices());
 
-  //Clip octahedron by each plane
+  //Clip Polyhedron by each plane
   for(unsigned int planeIndex = 0; planeIndex < numPlanes; planeIndex++)
   {
     PlaneType plane = planes[planeIndex];
@@ -434,7 +434,7 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(Polyhedron<T, NDIMS>& poly,
       int numVerts = poly.numVertices();
 
       // Each bit value indicates if that Polyhedron vertex is formed from
-      // Octahedron clipping with a plane.
+      // Polyhedron clipping with a plane.
       unsigned int clipped = 0;
 
       // Clip polyhedron against current plane, generating extra vertices

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -671,6 +671,124 @@ TEST(primal_clip, oct_tet_clip_special_case_2)
   EXPECT_NEAR(0.0041, poly.volume(), EPS);
 }
 
+// Tetrahedron does not clip tetrahedron.
+TEST(primal_clip, tet_tet_clip_nonintersect)
+{
+  using namespace Primal3D;
+
+  TetrahedronType tet1(PointType({-1, -1, -1}),
+                       PointType({-1, 0, 0}),
+                       PointType({-1, -1, 0}),
+                       PointType({0, 0, 0}));
+
+  TetrahedronType tet2(PointType({1, 0, 0}),
+                       PointType({1, 1, 0}),
+                       PointType({0, 1, 0}),
+                       PointType({1, 0, 1}));
+
+  PolyhedronType poly = axom::primal::clip(tet1, tet2);
+  EXPECT_EQ(0.0, poly.volume());
+}
+
+// Tetrahedron is adjacent to tetrahedron
+TEST(primal_clip, tet_tet_clip_adjacent)
+{
+  using namespace Primal3D;
+
+  TetrahedronType tet1(PointType({1, 0, 0}),
+                       PointType({1, 1, 0}),
+                       PointType({0, 1, 0}),
+                       PointType({1, 0, 1}));
+
+  TetrahedronType tet2(PointType({1, 0, 1}),
+                       PointType({0, 1, 0}),
+                       PointType({1, 0, 0}),
+                       PointType({0, 0, 0}));
+
+  PolyhedronType poly = axom::primal::clip(tet1, tet2);
+  EXPECT_EQ(0.0, poly.volume());
+}
+
+// Tetrahedron clips tetrahedron at a single vertex
+TEST(primal_clip, tet_tet_clip_point)
+{
+  using namespace Primal3D;
+
+  TetrahedronType tet1(PointType({1, 0, 0}),
+                       PointType({1, 1, 0}),
+                       PointType({0, 1, 0}),
+                       PointType({1, 0, 1}));
+
+  TetrahedronType tet2(PointType({0, 1, 0}),
+                       PointType({0, 0, 0}),
+                       PointType({-1, 0, 0}),
+                       PointType({0, 0, 1}));
+
+  PolyhedronType poly = axom::primal::clip(tet1, tet2);
+  EXPECT_EQ(0.0, poly.volume());
+}
+
+// Tetrahedrons are the same
+TEST(primal_clip, tet_tet_equal)
+{
+  using namespace Primal3D;
+  const double EPS = 1e-4;
+
+  TetrahedronType tet(PointType({1, 0, 0}),
+                      PointType({1, 1, 0}),
+                      PointType({0, 1, 0}),
+                      PointType({1, 0, 1}));
+
+  PolyhedronType poly = axom::primal::clip(tet, tet);
+
+  // Expected result should be 0.666 / 4 = 0.1666, volume of tet.
+  EXPECT_NEAR(0.1666, poly.volume(), EPS);
+}
+
+// Tetrahedron is encapsulated inside the other tetrahedron
+TEST(primal_clip, tet_tet_encapsulate)
+{
+  using namespace Primal3D;
+  const double EPS = 1e-4;
+
+  TetrahedronType tet1(PointType({1, 0, 0}),
+                       PointType({1, 1, 0}),
+                       PointType({0, 1, 0}),
+                       PointType({1, 0, 1}));
+
+  TetrahedronType tet2(PointType({3, 0, 0}),
+                       PointType({0, 3, 0}),
+                       PointType({-3, 0, 0}),
+                       PointType({0, 0, 3}));
+
+  PolyhedronType poly = axom::primal::clip(tet1, tet2);
+
+  // Expected result should be 0.666 / 4 = 0.1666, volume of tet.
+  EXPECT_NEAR(0.1666, poly.volume(), EPS);
+}
+
+// Half of the tetrahedron is clipped by the other tetrahedron
+TEST(primal_clip, tet_tet_half)
+{
+  using namespace Primal3D;
+  const double EPS = 1e-4;
+
+  TetrahedronType tet1(PointType({1, 0, 0}),
+                       PointType({1, 1, 0}),
+                       PointType({0, 1, 0}),
+                       PointType({1, 1, 1}));
+
+  TetrahedronType tet2(PointType({0, 0, 0}),
+                       PointType({1, 0, 0}),
+                       PointType({1, 1, 0}),
+                       PointType({1, 1, 1}));
+
+  PolyhedronType poly = axom::primal::clip(tet1, tet2);
+
+  // Expected result should be 0.666 / 4 / 2 = 0.0833, volume of tet.
+  EXPECT_NEAR(0.0833, poly.volume(), EPS);
+}
+
 //------------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -359,27 +359,16 @@ void check_oct_tet_clip(double EPS)
 {
   using namespace Primal3D;
 
-  umpire::ResourceManager& rm = umpire::ResourceManager::getInstance();
-
   // Save current/default allocator
   const int current_allocator = axom::getDefaultAllocatorID();
 
-  // Determine new allocator (for CUDA or HIP policy, set to Unified)
-  umpire::Allocator allocator =
-    rm.getAllocator(axom::execution_space<ExecPolicy>::allocatorID());
-
-  // Set new default to device
-  axom::setDefaultAllocator(allocator.getId());
+  // Set new default to device if available
+  axom::setDefaultAllocator(axom::execution_space<ExecPolicy>::allocatorID());
 
   // Allocate memory for shapes
   TetrahedronType* tet = axom::allocate<TetrahedronType>(1);
   OctahedronType* oct = axom::allocate<OctahedronType>(1);
-
-  PolyhedronType* res = (axom::execution_space<ExecPolicy>::onDevice()
-                           ? axom::allocate<PolyhedronType>(
-                               1,
-                               rm.getAllocator(umpire::resource::Unified).getId())
-                           : axom::allocate<PolyhedronType>(1));
+  PolyhedronType* res = axom::allocate<PolyhedronType>(1);
 
   tet[0] = TetrahedronType(PointType({1, 0, 0}),
                            PointType({1, 1, 0}),
@@ -411,27 +400,16 @@ void check_tet_tet_clip(double EPS)
 {
   using namespace Primal3D;
 
-  umpire::ResourceManager& rm = umpire::ResourceManager::getInstance();
-
   // Save current/default allocator
   const int current_allocator = axom::getDefaultAllocatorID();
 
-  // Determine new allocator (for CUDA or HIP policy, set to Unified)
-  umpire::Allocator allocator =
-    rm.getAllocator(axom::execution_space<ExecPolicy>::allocatorID());
-
-  // Set new default to device
-  axom::setDefaultAllocator(allocator.getId());
+  // Set new default to device if available
+  axom::setDefaultAllocator(axom::execution_space<ExecPolicy>::allocatorID());
 
   // Allocate memory for shapes
   TetrahedronType* tet1 = axom::allocate<TetrahedronType>(1);
   TetrahedronType* tet2 = axom::allocate<TetrahedronType>(1);
-
-  PolyhedronType* res = (axom::execution_space<ExecPolicy>::onDevice()
-                           ? axom::allocate<PolyhedronType>(
-                               1,
-                               rm.getAllocator(umpire::resource::Unified).getId())
-                           : axom::allocate<PolyhedronType>(1));
+  PolyhedronType* res = axom::allocate<PolyhedronType>(1);
 
   tet1[0] = TetrahedronType(PointType({1, 0, 0}),
                             PointType({1, 1, 0}),


### PR DESCRIPTION
This PR:
- Generalizes the `clipOctahedron()` input to take a Polyhedron,  becoming `clipPolyhedron()`
- Adds overloaded function `clip(tet1, tet2)` for clipping of two tetrahedrons