### PR TITLE
Renames primal's `PTINY` to `PRIMAL_TINY`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -99,7 +99,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   fields.
 - Adds functions to compute winding numbers and in/out queries for `Polygon` and `CurvedPolygon` objects.
 - Adds `constants.hpp` to primal to track geometric constants. Initially includes
-  a value for `primal::PTINY`, a small constant that can be added to 
+  a value for `PRIMAL_TINY`, a small constant that can be added to 
   denominators to avoid division by zero.
 - `DistributedClosestPoint` query now supports "domain underloading" -- ranks that are passed in can 
   have empty object meshes and/or empty query meshes 

--- a/src/axom/primal/constants.hpp
+++ b/src/axom/primal/constants.hpp
@@ -16,7 +16,7 @@ namespace axom
 namespace primal
 {
 /// Small constant that can be useful for e.g. offsetting denominators to avoid division by zero
-static constexpr double PTINY = 1e-50;
+static constexpr double PRIMAL_TINY = 1e-50;
 }  // namespace primal
 }  // namespace axom
 

--- a/src/axom/primal/geometry/Tetrahedron.hpp
+++ b/src/axom/primal/geometry/Tetrahedron.hpp
@@ -132,7 +132,7 @@ public:
     if(!skipNormalization)
     {
       const double vol = VectorType::scalar_triple_product(B - A, C - A, D - A);
-      const double EPS = vol >= 0 ? primal::PTINY : -primal::PTINY;
+      const double EPS = vol >= 0 ? primal::PRIMAL_TINY : -primal::PRIMAL_TINY;
 
       // Compute one over denominator; offset by a tiny amount to avoid division by zero
       const double ood = 1. / (vol + EPS);
@@ -236,7 +236,7 @@ public:
 
     // Compute one over denominator using a small offset to avoid division by zero
     const double a = VectorType::scalar_triple_product(vx, vy, vz);
-    const double EPS = (a >= 0) ? primal::PTINY : -primal::PTINY;
+    const double EPS = (a >= 0) ? primal::PRIMAL_TINY : -primal::PRIMAL_TINY;
     const double ood = 1. / (2 * a + EPS);
 
     // Compute offset from p0 to center

--- a/src/axom/primal/geometry/Triangle.hpp
+++ b/src/axom/primal/geometry/Triangle.hpp
@@ -178,7 +178,7 @@ public:
 
     // Compute one over denominator using a small value to avoid division by zero
     const double a = determinant(vx[0], vx[1], vy[0], vy[1]);
-    const double EPS = (a >= 0) ? primal::PTINY : -primal::PTINY;
+    const double EPS = (a >= 0) ? primal::PRIMAL_TINY : -primal::PRIMAL_TINY;
     const double ood = 1. / (2 * a + EPS);
 
     // Compute offset from p0 to center
@@ -283,7 +283,7 @@ public:
     if(!skipNormalization)
     {
       // compute one over denominator; add a tiny amount to avoid division by zero
-      const double EPS = (area >= 0) ? primal::PTINY : -primal::PTINY;
+      const double EPS = (area >= 0) ? primal::PRIMAL_TINY : -primal::PRIMAL_TINY;
       const double ood = 1. / (area + EPS);
 
       bary[0] = ood * nu;

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -492,7 +492,7 @@ AXOM_HOST_DEVICE inline Vector<T, NDIMS> Vector<T, NDIMS>::unitVector() const
   Vector v(*this);
 
   const double len_sq = squared_norm();
-  if(len_sq >= primal::PTINY)
+  if(len_sq >= primal::PRIMAL_TINY)
   {
     v /= (std::sqrt(len_sq));
   }

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -148,7 +148,7 @@ bool intersect(const Triangle<T, 3>& tri,
   if(retval)
   {
     // Add a small EPS to avoid dividing by zero
-    double normalizer = p[0] + p[1] + p[2] + primal::PTINY;
+    double normalizer = p[0] + p[1] + p[2] + primal::PRIMAL_TINY;
     p.array() *= 1. / normalizer;
   }
 
@@ -208,7 +208,7 @@ bool intersect(const Triangle<T, 3>& tri,
   if(retval)
   {
     // Add a small EPS to avoid dividing by zero
-    double normalizer = p[0] + p[1] + p[2] + primal::PTINY;
+    double normalizer = p[0] + p[1] + p[2] + primal::PRIMAL_TINY;
     p.array() *= 1. / normalizer;
   }
 

--- a/src/axom/quest/Discretize.cpp
+++ b/src/axom/quest/Discretize.cpp
@@ -35,7 +35,7 @@ Point3D project_to_shape(const Point3D& p, const SphereType& sphere)
   const auto& ctr = sphere.getCenter();
   const double dist2 = primal::squared_distance(ctr, p);
   const double dist = sqrt(dist2);
-  const double drat = sphere.getRadius() * dist / (dist2 + primal::PTINY);
+  const double drat = sphere.getRadius() * dist / (dist2 + primal::PRIMAL_TINY);
 
   return Point3D::lerp(ctr, p, drat);
 }
@@ -118,7 +118,7 @@ bool discretize(const SphereType& sphere, int levels, OctType*& out, int& octcou
     return false;
   }
   // Zero radius: return true without generating octahedra.
-  if(sphere.getRadius() < primal::PTINY)
+  if(sphere.getRadius() < primal::PRIMAL_TINY)
   {
     octcount = 0;
     return true;

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -259,7 +259,7 @@ inline int isend_using_schema(conduit::Node& node,
 // This version works correctly when src is MPI_ANY_SOURCE
 // and tag is MPI_ANY_TAG.  When conduit supports this,
 // this version can be removed.
-int recv_using_schema(conduit::Node& node, int src, int tag, MPI_Comm comm)
+inline int recv_using_schema(conduit::Node& node, int src, int tag, MPI_Comm comm)
 {
   MPI_Status status;
 

--- a/src/axom/quest/detail/Discretize_detail.hpp
+++ b/src/axom/quest/detail/Discretize_detail.hpp
@@ -86,7 +86,7 @@ Point3D rescale_YZ(const Point3D &p, double new_dst)
 {
   const double cur_dst =
     axom::utilities::clampLower(sqrt(p[1] * p[1] + p[2] * p[2]),
-                                axom::primal::PTINY);
+                                axom::primal::PRIMAL_TINY);
 
   Point3D retval;
   retval[0] = p[0];
@@ -156,11 +156,11 @@ int discrSeg(const Point2D &a, const Point2D &b, int levels, OctType *&out, int 
   SLIC_ASSERT(b[1] >= 0);
 
   // Deal with degenerate segments
-  if(b[0] - a[0] < axom::primal::PTINY)
+  if(b[0] - a[0] < axom::primal::PRIMAL_TINY)
   {
     return 0;
   }
-  if(a[1] < axom::primal::PTINY && b[1] < axom::primal::PTINY)
+  if(a[1] < axom::primal::PRIMAL_TINY && b[1] < axom::primal::PRIMAL_TINY)
   {
     return 0;
   }

--- a/src/axom/spin/RectangularLattice.hpp
+++ b/src/axom/spin/RectangularLattice.hpp
@@ -48,8 +48,8 @@ namespace spin
  * and a grid spacing (a SpaceVector).
  *
  * \note Grid spacing coordinates that are really small (magnitude less
- * than primal::PTINY := 1e-50) are snapped to zero to avoid division by zero.
- * \sa primal::PTINY
+ * than primal::PRIMAL_TINY := 1e-50) are snapped to zero to avoid division by zero.
+ * \sa primal::PRIMAL_TINY
  */
 template <int NDIMS, typename SpaceCoordType = double, typename CellCoordType = int>
 class RectangularLattice
@@ -91,7 +91,7 @@ public:
    * \param spacing The lattice's spacing
    *
    * \note The magnitude of the spacing coordinates should be greater than zero.
-   * If they are less than primal::PTINY, the lattice will be degenerate in
+   * If they are less than primal::PRIMAL_TINY, the lattice will be degenerate in
    * that dimension.
    */
   RectangularLattice(const SpacePoint& origin, const SpaceVector& spacing)
@@ -117,8 +117,8 @@ public:
    * \note Spacing will be set to vector or ones if pointer is NULL
    *
    * \note The magnitude of the spacing coordinates should be greater than zero.
-   * If they are less than EPS = primal::PTINY, the lattice will be degenerate in
-   * that dimension.
+   * If they are less than EPS = primal::PRIMAL_TINY, the lattice will be 
+   * degenerate in that dimension.
    */
   RectangularLattice(SpaceCoordType* origin_data, SpaceCoordType* spacing_data)
   {
@@ -194,7 +194,7 @@ private:
    * spacing to zero and to initialize the inverted spacing.
    *
    * A spacing coordinate is considered really small when its magnitude
-   * is less than primal::PTINY.
+   * is less than primal::PRIMAL_TINY.
    *
    * For each coordinate i, the inverted coordinate will be:
    *     m_invSpacing[i] = 1. / m_spacing[i]
@@ -203,7 +203,7 @@ private:
    */
   void initializeSpacingAndInvSpacing()
   {
-    constexpr SpaceCoordType EPS = primal::PTINY;
+    constexpr SpaceCoordType EPS = primal::PRIMAL_TINY;
     constexpr SpaceCoordType ZERO = SpaceCoordType(0.);
     constexpr SpaceCoordType ONE = SpaceCoordType(1.);
 
@@ -240,7 +240,7 @@ private:
  * minimum corner position.
  *
  * \note If the bounding box range along a dimension is near zero (i.e. smaller
- * than primal::PTINY, the grid resolution in that dimension will be 
+ * than primal::PRIMAL_TINY, the grid resolution in that dimension will be 
  * set to zero in that dimension.
  */
 template <int NDIMS, typename SpaceCoordType, typename CellCoordType>


### PR DESCRIPTION
# Summary

- Resolves #892 
- A user code had `PTINY` as a compiler define and this was clashing with our `primal::PTINY` constexpr