### PR TITLE
Fix direct formulas for `winding_number` on endpoint of Bezier curves

### DIFF
--- a/src/axom/primal/geometry/BezierCurve.hpp
+++ b/src/axom/primal/geometry/BezierCurve.hpp
@@ -348,11 +348,11 @@ public:
 
     SegmentType seg(m_controlPoints[0], m_controlPoints[ord]);
     double sqDist = 0.0;
-    for(int p = 1; p < ord && sqDist < tol; ++p)  // check interior control points
+    for(int p = 1; p < ord && sqDist <= tol; ++p)  // check interior control points
     {
       sqDist += squared_distance(m_controlPoints[p], seg);
     }
-    return (sqDist < tol);
+    return (sqDist <= tol);
   }
 
   /*!

--- a/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
+++ b/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
@@ -71,7 +71,7 @@ double linear_winding_number(const Point<T, 2>& q,
  * \param [in] c The BezierCurve object to compute the winding number along
  * \param [in] edge_tol The tolerance at which control nodes are indistinguishable
  * \param [in] EPS Tolerance for isNearlyZero
- * \pre 
+ * \pre Control polygon for c must be convex
  *
  * The winding number for a Bezier curve with a convex control polygon is
  * given by the signed angle between the tangent vector at that endpoint and
@@ -109,7 +109,9 @@ double convex_endpoint_winding_number(const Point<T, 2>& q,
 
   // This means the bounding vectors are anti-parallel.
   //  Parallel tangents can't happen with nontrivial convex control polygons
-  if(axom::utilities::isNearlyEqual(orient, 0.0, EPS))
+  if(ord <= 3)
+    return 0;
+  else if(axom::utilities::isNearlyEqual(orient, 0.0, EPS))
   {
     for(int i = 1; i < ord; ++i)
     {

--- a/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
+++ b/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
@@ -90,18 +90,17 @@ double convex_endpoint_winding_number(const Point<T, 2>& q,
 
   if(ord == 1) return 0;
 
-  int i;
-  Vector<T, 2> V1, V2;
+  int idx;
 
   // Need to find vectors that subtend the entire curve.
   //   We must ignore duplicate nodes
-  for(i = 0; i <= ord; ++i)
-    if(squared_distance(q, c[i]) > edge_tol * edge_tol) break;
-  V1 = Vector<T, 2>(q, c[i]);
+  for(idx = 0; idx <= ord; ++idx)
+    if(squared_distance(q, c[idx]) > edge_tol * edge_tol) break;
+  Vector<T, 2> V1(q, c[idx]);
 
-  for(i = ord; i >= 0; --i)
-    if(squared_distance(q, c[i]) > edge_tol * edge_tol) break;
-  V2 = Vector<T, 2>(q, c[i]);
+  for(idx = ord; idx >= 0; --idx)
+    if(squared_distance(q, c[idx]) > edge_tol * edge_tol) break;
+  Vector<T, 2> V2(q, c[idx]);
 
   // clang-format off
   double orient = axom::numerics::determinant(V1[0] - V2[0], V2[0], 
@@ -112,11 +111,10 @@ double convex_endpoint_winding_number(const Point<T, 2>& q,
   //  Parallel tangents can't happen with nontrivial convex control polygons
   if(axom::utilities::isNearlyEqual(orient, 0.0, EPS))
   {
-    V1 = Vector<T, 2>(c[0], c[1]);
-
     for(int i = 1; i < ord; ++i)
     {
-      V2 = Vector<T, 2>(c[0], c[i]);
+      // Need to find the first non-parallel control node
+      V2 = Vector<T, 2>(q, c[i]);
 
       // clang-format off
       double orient = axom::numerics::determinant(V1[0] - V2[0], V2[0], 

--- a/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
+++ b/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
@@ -133,7 +133,6 @@ double adaptive_winding_number(const Point2D& q,
 {
   const int ord = c.getOrder();
 
-  double cl_winding_num = closure_winding_number(q, c);
   Polygon<T, 2> controlPolygon(c.getControlPoints());
 
   // Use linearity as base case for recursion
@@ -142,12 +141,12 @@ double adaptive_winding_number(const Point2D& q,
     if(squared_distance(q, Segment<T, 2>(c[0], c[ord])) <= edge_tol)
       return 0;
     else
-      return -cl_winding_num;
+      return -closure_winding_number(q, c);
   }
 
   // If outside control polygon (with nonzero protocol)
   if(!in_polygon(q, controlPolygon, true, false, edge_tol))
-    return -cl_winding_num;
+    return -closure_winding_number(q, c);
 
   // Check if our new curve is convex, if we have to
   if(!convex_cp) convex_cp = is_convex(controlPolygon);

--- a/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
+++ b/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
@@ -188,7 +188,7 @@ double adaptive_winding_number(const Point<T, 2>& q,
 
   Polygon<T, 2> controlPolygon(c.getControlPoints());
 
-  // If q is outside the control polygon, for an open Bezier curve, the winding 
+  // If q is outside the control polygon, for an open Bezier curve, the winding
   //  number for the shape connected at the endpoints with straight lines is zero.
   //  We then subtract the contribution of this line segment.
   if(!in_polygon(q, controlPolygon, true, false, EPS))

--- a/src/axom/primal/operators/in_curved_polygon.hpp
+++ b/src/axom/primal/operators/in_curved_polygon.hpp
@@ -32,7 +32,8 @@ namespace primal
  *
  * \param [in] query The query point to test
  * \param [in] cpoly The CurvedPolygon object to test for containment
- * \param [in] edge_tol The physical distance level which objects are indistinguishable
+ * \param [in] edge_tol The physical distance level at which objects are 
+ *                      considered indistinguishable
  * \param [in] EPS Miscellaneous numerical tolerance level for nonphysical distances
  * 
  * Determines containment using the (rounded) winding number with respect
@@ -63,7 +64,8 @@ inline bool in_curved_polygon(const Point<T, 2>& query,
  *
  * \param [in] query The query point to test
  * \param [in] cpoly The CurvedPolygon object
- * \param [in] edge_tol The physical distance level which objects are indistinguishable
+ * \param [in] edge_tol The physical distance level at which objects are 
+ *                      considered indistinguishable
  * \param [in] EPS Miscellaneous numerical tolerance level for nonphysical distances
  *
  * Computes the winding number using a recursive, bisection algorithm.
@@ -90,7 +92,8 @@ double winding_number(const Point<T, 2>& q,
  *
  * \param [in] query The query point to test
  * \param [in] cpoly The Bezier curve object 
- * \param [in] edge_tol The physical distance level which objects are indistinguishable
+ * \param [in] edge_tol The physical distance level at which objects are 
+ *                      considered indistinguishable
  * \param [in] EPS Miscellaneous numerical tolerance level for nonphysical distances
  *
  * Computes the winding number using a recursive, bisection algorithm,

--- a/src/axom/primal/operators/in_curved_polygon.hpp
+++ b/src/axom/primal/operators/in_curved_polygon.hpp
@@ -21,7 +21,6 @@
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/BezierCurve.hpp"
 #include "axom/primal/geometry/CurvedPolygon.hpp"
-#include "axom/primal/operators/split.hpp"
 #include "axom/primal/operators/detail/in_curved_polygon_impl.hpp"
 
 namespace axom
@@ -106,62 +105,6 @@ double winding_number(const Point<T, 2>& q,
                       const double EPS = 1e-8)
 {
   return detail::adaptive_winding_number(q, c, false, edge_tol, EPS);
-}
-
-
-template <typename T>
-double winding_number_quad(const Point<T, 2>& q,
-                           const BezierCurve<T, 2>& c,
-                           const int n_qpts = 15,
-                           const double edge_tol = 1e-8)
-{
-  CurvedPolygon<T, 2> cpoly;
-  cpoly.addEdge(c);
-
-  axom::Array<BezierCurve<T, 2>> cvx_components;
-  split_to_convex(cpoly, cvx_components);
-  axom::Array<int> orientations(detail::convex_orientation(cvx_components));
-
-  // Get quadrature nodes from MFEM
-  static mfem::IntegrationRules my_IntRules(0, mfem::Quadrature1D::GaussLegendre);
-  const mfem::IntegrationRule& quad =
-    my_IntRules.Get(mfem::Geometry::SEGMENT, 2 * n_qpts - 1);
-
-  double ret_val = 0;
-  for(int i = 0; i < cvx_components.size(); i++)
-    ret_val += detail::convex_winding_number(q,
-                                             cvx_components[i],
-                                             orientations[i],
-                                             quad,
-                                             edge_tol);
-
-  return ret_val;
-}
-
-template <typename T>
-double winding_number_quad(const Point<T, 2>& q,
-                           const CurvedPolygon<T, 2>& cpoly,
-                           const int n_qpts = 15,
-                           const double edge_tol = 1e-8)
-{
-  axom::Array<BezierCurve<T, 2>> cvx_components;
-  split_to_convex(cpoly, cvx_components);
-  axom::Array<int> orientations(detail::convex_orientation(cvx_components));
-
-  // Get quadrature nodes from MFEM
-  static mfem::IntegrationRules my_IntRules(0, mfem::Quadrature1D::GaussLegendre);
-  const mfem::IntegrationRule& quad =
-    my_IntRules.Get(mfem::Geometry::SEGMENT, 2 * n_qpts - 1);
-
-  double ret_val = 0;
-  for(int i = 0; i < cvx_components.size(); i++)
-    ret_val += detail::convex_winding_number(q,
-                                             cvx_components[i],
-                                             orientations[i],
-                                             quad,
-                                             edge_tol);
-
-  return ret_val;
 }
 
 }  // namespace primal

--- a/src/axom/primal/operators/in_curved_polygon.hpp
+++ b/src/axom/primal/operators/in_curved_polygon.hpp
@@ -32,8 +32,8 @@ namespace primal
  *
  * \param [in] query The query point to test
  * \param [in] cpoly The CurvedPolygon object to test for containment
- * \param [in] linear_tol The tolerance level at which a Bezier curve is linear
- * \param [in] edge_tol The tolerance level at which the query point is on the curve
+ * \param [in] edge_tol The physical distance level which objects are indistinguishable
+ * \param [in] EPS Miscellaneous numerical tolerance level for nonphysical distances
  * 
  * Determines containment using the (rounded) winding number with respect
  * to the given curved polygon. This algorithm is robust, as the winding number is rounded 
@@ -47,9 +47,9 @@ namespace primal
 template <typename T>
 inline bool in_curved_polygon(const Point<T, 2>& query,
                               const CurvedPolygon<T, 2>& cpoly,
-                              const bool useNonzeroRule = true,
-                              const double edge_tol = 1e-8,
-                              const double EPS = 1e-8)
+                              bool useNonzeroRule = true,
+                              double edge_tol = 1e-8,
+                              double EPS = 1e-8)
 {
   double winding_num = winding_number(query, cpoly, edge_tol, EPS);
 
@@ -62,9 +62,9 @@ inline bool in_curved_polygon(const Point<T, 2>& query,
  * \brief Computes the generalized winding number for a curved polygon
  *
  * \param [in] query The query point to test
- * \param [in] cpoly The CurvedPolygon object 
- * \param [in] linear_tol The tolerance level at which a Bezier curve is linear
- * \param [in] edge_tol The tolerance level at which the query point is on the curve
+ * \param [in] cpoly The CurvedPolygon object
+ * \param [in] edge_tol The physical distance level which objects are indistinguishable
+ * \param [in] EPS Miscellaneous numerical tolerance level for nonphysical distances
  *
  * Computes the winding number using a recursive, bisection algorithm.
  * Iterates over the edges of a curved polygon object, and uses nearly-linear 
@@ -75,8 +75,8 @@ inline bool in_curved_polygon(const Point<T, 2>& query,
 template <typename T>
 double winding_number(const Point<T, 2>& q,
                       const CurvedPolygon<T, 2>& cpoly,
-                      const double edge_tol = 1e-8,
-                      const double EPS = 1e-8)
+                      double edge_tol = 1e-8,
+                      double EPS = 1e-8)
 {
   double ret_val = 0.0;
   for(int i = 0; i < cpoly.numEdges(); i++)
@@ -90,8 +90,8 @@ double winding_number(const Point<T, 2>& q,
  *
  * \param [in] query The query point to test
  * \param [in] cpoly The Bezier curve object 
- * \param [in] linear_tol The tolerance level at which a Bezier curve is linear
- * \param [in] edge_tol The tolerance level at which the query point is on the curve
+ * \param [in] edge_tol The physical distance level which objects are indistinguishable
+ * \param [in] EPS Miscellaneous numerical tolerance level for nonphysical distances
  *
  * Computes the winding number using a recursive, bisection algorithm,
  * using nearly-linear Bezier curves as a base case.
@@ -101,8 +101,8 @@ double winding_number(const Point<T, 2>& q,
 template <typename T>
 double winding_number(const Point<T, 2>& q,
                       const BezierCurve<T, 2>& c,
-                      const double edge_tol = 1e-8,
-                      const double EPS = 1e-8)
+                      double edge_tol = 1e-8,
+                      double EPS = 1e-8)
 {
   return detail::adaptive_winding_number(q, c, false, edge_tol, EPS);
 }

--- a/src/axom/primal/operators/in_polygon.hpp
+++ b/src/axom/primal/operators/in_polygon.hpp
@@ -33,7 +33,7 @@ namespace primal
  *
  * \param [in] R The query point to test
  * \param [in] P The Polygon object to test for containment
- * \param [in] strict If true, points on the boundary are considered exterior.
+ * \param [in] useStrictInclusion If true, points on the boundary are considered exterior.
  * \param [in] EPS The tolerance level for collinearity
  * 
  * Uses an adapted ray-casting approach that counts quarter-rotation
@@ -48,8 +48,8 @@ namespace primal
 template <typename T>
 int winding_number(const Point<T, 2>& R,
                    const Polygon<T, 2>& P,
-                   const bool strict = false,
-                   const double EPS = 1e-8)
+                   bool useStrictInclusion = false,
+                   double EPS = 1e-8)
 {
   const int nverts = P.numVertices();
 
@@ -57,7 +57,7 @@ int winding_number(const Point<T, 2>& R,
   //  as "inside" by evenodd or nonzero protocols
   if(axom::utilities::isNearlyEqual(P[0][0], R[0], EPS) &&
      axom::utilities::isNearlyEqual(P[0][1], R[1], EPS))
-    return !strict;
+    return !useStrictInclusion;
 
   int winding_num = 0;
   for(int i = 0; i < nverts; i++)
@@ -67,9 +67,9 @@ int winding_number(const Point<T, 2>& R,
     if(axom::utilities::isNearlyEqual(P[j][1], R[1], EPS))
     {
       if(axom::utilities::isNearlyEqual(P[j][0], R[0], EPS))
-        return !strict;  // On vertex
+        return !useStrictInclusion;  // On vertex
       else if(P[i][1] == R[1] && ((P[j][0] > R[0]) == (P[i][0] < R[0])))
-        return !strict;  // On horizontal edge
+        return !useStrictInclusion;  // On horizontal edge
     }
 
     // Check if edge crosses horizontal line
@@ -88,7 +88,8 @@ int winding_number(const Point<T, 2>& R,
           // clang-format on
 
           // On edge
-          if(axom::utilities::isNearlyEqual(det, 0.0, EPS)) return !strict;
+          if(axom::utilities::isNearlyEqual(det, 0.0, EPS))
+            return !useStrictInclusion;
 
           // Check if edge intersects horitonal ray to the right of R
           if((det > 0) == (P[j][1] > P[i][1]))
@@ -101,11 +102,12 @@ int winding_number(const Point<T, 2>& R,
         {
           // clang-format off
           det = axom::numerics::determinant(P[i][0] - R[0], P[j][0] - R[0],
-                                          P[i][1] - R[1], P[j][1] - R[1]);
+                                            P[i][1] - R[1], P[j][1] - R[1]);
           // clang-format on
 
           // On edge
-          if(axom::utilities::isNearlyEqual(det, 0.0, EPS)) return !strict;
+          if(axom::utilities::isNearlyEqual(det, 0.0, EPS))
+            return !useStrictInclusion;
 
           // Check if edge intersects horitonal ray to the right of R
           if((det > 0) == (P[j][1] > P[i][1]))
@@ -124,7 +126,7 @@ int winding_number(const Point<T, 2>& R,
  * \param [in] query The query point to test
  * \param [in] poly The Polygon object to test for containment
  * \param [in] useNonzeroRule If false, use even/odd protocol for inclusion
- * \param [in] strict If true, points on the boundary are considered exterior.
+ * \param [in] useStrictInclusion If true, points on the boundary are considered exterior.
  * \param [in] EPS The tolerance level for collinearity
  * 
  * Determines containment using the winding number with respect to the 
@@ -138,9 +140,9 @@ int winding_number(const Point<T, 2>& R,
 template <typename T>
 bool in_polygon(const Point<T, 2>& query,
                 const Polygon<T, 2>& poly,
-                const bool useNonzeroRule = true,
-                const bool strict = false,
-                const double EPS = 1e-8)
+                bool useNonzeroRule = true,
+                bool strict = false,
+                double EPS = 1e-8)
 {
   // Else, use EvenOdd rule
   return useNonzeroRule ? winding_number(query, poly, strict, EPS) != 0

--- a/src/axom/primal/operators/in_polygon.hpp
+++ b/src/axom/primal/operators/in_polygon.hpp
@@ -55,7 +55,7 @@ int winding_number(const Point<T, 2>& R,
 
   // If the query is a vertex, return a value interpreted
   //  as "inside" by evenodd or nonzero protocols
-  if(axom::utilities::isNearlyEqual(P[0][0], R[1], EPS) &&
+  if(axom::utilities::isNearlyEqual(P[0][0], R[0], EPS) &&
      axom::utilities::isNearlyEqual(P[0][1], R[1], EPS))
     return !strict;
 

--- a/src/axom/primal/operators/is_convex.hpp
+++ b/src/axom/primal/operators/is_convex.hpp
@@ -32,7 +32,7 @@ namespace primal
  * \return A boolean value indicating convexity
  */
 template <typename T>
-bool is_convex(const Polygon<T, 2>& poly)
+bool is_convex(const Polygon<T, 2>& poly, double EPS = 1e-8)
 {
   int n = poly.numVertices() - 1;
   if(n + 1 < 3) return true;  // Triangles and lines are convex
@@ -42,13 +42,13 @@ bool is_convex(const Polygon<T, 2>& poly)
     // For each non-endpoint, check if that point and one of the endpoints
     //  are on the same side as the segment connecting the adjacent nodes
     Segment<T, 2> seg(poly[i - 1], poly[i + 1]);
-    int res1 = orientation(poly[i], seg);
+    int res1 = orientation(poly[i], seg, EPS);
 
     // Edge case
     if(res1 == primal::ON_BOUNDARY) continue;
 
     // Ensure other point to check against isn't adjacent
-    if(res1 == orientation(poly[(i < n / 2) ? n : 0], seg)) return false;
+    if(res1 == orientation(poly[(i < n / 2) ? n : 0], seg, EPS)) return false;
   }
 
   return true;

--- a/src/axom/primal/operators/split.hpp
+++ b/src/axom/primal/operators/split.hpp
@@ -17,11 +17,6 @@
 #include "axom/primal/geometry/Octahedron.hpp"
 #include "axom/primal/geometry/Tetrahedron.hpp"
 
-#include "axom/primal/geometry/BezierCurve.hpp"
-#include "axom/primal/geometry/Polygon.hpp"
-#include "axom/primal/geometry/CurvedPolygon.hpp"
-#include "axom/primal/operators/is_convex.hpp"
-
 #include "axom/slic.hpp"
 
 // perhaps #include split_impl.hpp here
@@ -82,53 +77,6 @@ void split(const Octahedron<Tp, NDIMS>& oct,
   out.push_back(Tet(oct[P], oct[T], oct[R], C));
   out.push_back(Tet(oct[Q], oct[S], oct[U], C));
 };
-
-/*!
- * \brief Splits a BezierCurve object into convex Bezier Curves
- *
- * \param [in] c BezierCurve to split
- * \param [out] out The \a axom::Array of BezierCurve objects; a set of convex
- *              components of c are appended to out.
- *
- * \pre NDIMS == 2
- *
- * Uses a bisection method, splitting the curve recursively until each section
- * is convex.
- * 
- */
-template <typename Tp, int NDIMS = 2>
-void split_to_convex(const BezierCurve<Tp, NDIMS>& c,
-                     axom::Array<BezierCurve<Tp, NDIMS>>& out)
-{
-  // Implemented for two dimensions
-  SLIC_ASSERT(NDIMS == 2);
-
-  using Poly = Polygon<Tp, NDIMS>;
-  using Bez = BezierCurve<Tp, NDIMS>;
-
-  if(is_convex(Poly(c.getControlPoints())))
-    out.push_back(Bez(c));
-  else
-  {
-    Bez c1, c2;
-    c.split(0.5, c1, c2);
-    split_to_convex(c1, out);
-    split_to_convex(c2, out);
-  }
-}
-
-template <typename Tp, int NDIMS = 2>
-void split_to_convex(const CurvedPolygon<Tp, NDIMS>& cpoly,
-                     axom::Array<BezierCurve<Tp, NDIMS>>& out)
-{
-  // Implemented for two dimensions
-  SLIC_ASSERT(NDIMS == 2);
-
-  using Poly = Polygon<Tp, NDIMS>;
-  using Bez = BezierCurve<Tp, NDIMS>;
-
-  for(int i = 0; i < cpoly.numEdges(); i++) split_to_convex(cpoly[i], out);
-}
 
 }  // namespace primal
 }  // namespace axom

--- a/src/axom/primal/operators/split.hpp
+++ b/src/axom/primal/operators/split.hpp
@@ -17,6 +17,11 @@
 #include "axom/primal/geometry/Octahedron.hpp"
 #include "axom/primal/geometry/Tetrahedron.hpp"
 
+#include "axom/primal/geometry/BezierCurve.hpp"
+#include "axom/primal/geometry/Polygon.hpp"
+#include "axom/primal/geometry/CurvedPolygon.hpp"
+#include "axom/primal/operators/is_convex.hpp"
+
 #include "axom/slic.hpp"
 
 // perhaps #include split_impl.hpp here
@@ -77,6 +82,53 @@ void split(const Octahedron<Tp, NDIMS>& oct,
   out.push_back(Tet(oct[P], oct[T], oct[R], C));
   out.push_back(Tet(oct[Q], oct[S], oct[U], C));
 };
+
+/*!
+ * \brief Splits a BezierCurve object into convex Bezier Curves
+ *
+ * \param [in] c BezierCurve to split
+ * \param [out] out The \a axom::Array of BezierCurve objects; a set of convex
+ *              components of c are appended to out.
+ *
+ * \pre NDIMS == 2
+ *
+ * Uses a bisection method, splitting the curve recursively until each section
+ * is convex.
+ * 
+ */
+template <typename Tp, int NDIMS = 2>
+void split_to_convex(const BezierCurve<Tp, NDIMS>& c,
+                     axom::Array<BezierCurve<Tp, NDIMS>>& out)
+{
+  // Implemented for two dimensions
+  SLIC_ASSERT(NDIMS == 2);
+
+  using Poly = Polygon<Tp, NDIMS>;
+  using Bez = BezierCurve<Tp, NDIMS>;
+
+  if(is_convex(Poly(c.getControlPoints())))
+    out.push_back(Bez(c));
+  else
+  {
+    Bez c1, c2;
+    c.split(0.5, c1, c2);
+    split_to_convex(c1, out);
+    split_to_convex(c2, out);
+  }
+}
+
+template <typename Tp, int NDIMS = 2>
+void split_to_convex(const CurvedPolygon<Tp, NDIMS>& cpoly,
+                     axom::Array<BezierCurve<Tp, NDIMS>>& out)
+{
+  // Implemented for two dimensions
+  SLIC_ASSERT(NDIMS == 2);
+
+  using Poly = Polygon<Tp, NDIMS>;
+  using Bez = BezierCurve<Tp, NDIMS>;
+
+  for(int i = 0; i < cpoly.numEdges(); i++) split_to_convex(cpoly[i], out);
+}
 
 }  // namespace primal
 }  // namespace axom

--- a/src/axom/primal/tests/primal_polygon.cpp
+++ b/src/axom/primal/tests/primal_polygon.cpp
@@ -79,6 +79,7 @@ TEST(primal_polygon, polygon_containment)
   EXPECT_FALSE(in_polygon(PointType({1.25, -0.25}), poly));
   EXPECT_FALSE(in_polygon(PointType({0.0, 1.25}), poly));
   EXPECT_FALSE(in_polygon(PointType({0.0, -0.25}), poly));
+  EXPECT_FALSE(in_polygon(PointType({-1.0, 0.0}), poly));
   EXPECT_FALSE(in_polygon(PointType({1.0, 1.25}), poly));
   EXPECT_FALSE(in_polygon(PointType({1.0, -0.25}), poly));
 

--- a/src/axom/primal/tests/primal_rational_bezier.cpp
+++ b/src/axom/primal/tests/primal_rational_bezier.cpp
@@ -428,8 +428,8 @@ TEST(primal_rationalbezier, winding_number)
   using CPolygon = primal::CurvedPolygon<double, 2>;
 
   double abs_tol = 1e-8;
-  double lin_tol = 0;
   double edge_tol = 0;
+  double EPS = 0;
 
   // Simple quarter circle shape
   Point2D circle_nodes[] = {Point2D {1.0, 0.0},
@@ -459,16 +459,16 @@ TEST(primal_rationalbezier, winding_number)
       EXPECT_NEAR(
         winding_number(Point2D({ri * std::cos(theta), ri * std::sin(theta)}),
                        quarter_circle,
-                       lin_tol,
-                       edge_tol),
+                       edge_tol,
+                       EPS),
         1.0,
         abs_tol);
 
       EXPECT_NEAR(
         winding_number(Point2D({ro * std::cos(theta), ro * std::sin(theta)}),
                        quarter_circle,
-                       lin_tol,
-                       edge_tol),
+                       edge_tol,
+                       EPS),
         0.0,
         abs_tol);
     }

--- a/src/axom/primal/tests/primal_winding_number.cpp
+++ b/src/axom/primal/tests/primal_winding_number.cpp
@@ -21,6 +21,7 @@ namespace primal = axom::primal;
 
 TEST(primal_winding_number, containment_protocol)
 {
+  // Test that containment procedures are consistent
   using Point2D = primal::Point<double, 2>;
   using Bezier = primal::BezierCurve<double, 2>;
   using CPolygon = primal::CurvedPolygon<double, 2>;
@@ -51,6 +52,8 @@ TEST(primal_winding_number, containment_protocol)
 
 TEST(primal_winding_number, simple_cases)
 {
+  // Test points that are straightforwardly "inside" or "outside"
+  //  the closed shape
   using Point2D = primal::Point<double, 2>;
   using Bezier = primal::BezierCurve<double, 2>;
   using CPolygon = primal::CurvedPolygon<double, 2>;
@@ -59,7 +62,7 @@ TEST(primal_winding_number, simple_cases)
   double edge_tol = 1e-8;
   double EPS = 1e-50;
 
-  // Simple cubic shape
+  // Simple closed shape with cubic edges
   Point2D top_nodes[] = {Point2D {0.0, 0.0},
                          Point2D {0.0, 1.0},
                          Point2D {-1.0, 1.0},
@@ -111,35 +114,20 @@ TEST(primal_winding_number, simple_cases)
     abs_tol);
 }
 
-TEST(primal_winding_number, edge_cases)
+TEST(primal_winding_number, closure_edge_cases)
 {
-  // Check the edge cases for the winding number closure formulation
+  // Tests for when query is on the linear closure
   using Point2D = primal::Point<double, 2>;
   using Bezier = primal::BezierCurve<double, 2>;
 
-  double abs_tol = 1e-10;
+  double abs_tol = 1e-8;
   double edge_tol = 1e-8;
   double EPS = 1e-50;
 
-  // Line segment
-  Point2D nodes1[] = {Point2D {0.0, 0.0}, Point2D {1.0, 1.0}};
-  Bezier linear(nodes1, 1);
-
-  // Cubic curve
-  Point2D nodes2[] = {Point2D {0.0, 0.0},
-                      Point2D {0.0, 1.0},
-                      Point2D {-1.0, 1.0},
-                      Point2D {-1.0, 0.0}};
-  Bezier cubic(nodes2, 3);
-
-  // Flipped Cubic curve
-  Point2D fnodes2[] = {Point2D {0.0, 0.0},
-                       Point2D {0.0, -1.0},
-                       Point2D {-1.0, -1.0},
-                       Point2D {-1.0, 0.0}};
-  Bezier fcubic(fnodes2, 3);
-
   // Test on linear cases
+  Point2D linear_nodes[] = {Point2D {0.0, 0.0}, Point2D {1.0, 1.0}};
+  Bezier linear(linear_nodes, 1);
+
   EXPECT_NEAR(winding_number(Point2D({-0.45, -0.45}), linear, edge_tol, EPS),
               0.0,
               abs_tol);
@@ -147,42 +135,23 @@ TEST(primal_winding_number, edge_cases)
               0.0,
               abs_tol);
 
-  // Test on cubic. If query is outside the range of the two endpoints, return 0
-  EXPECT_NEAR(winding_number(Point2D({-2.5, 0.0}), cubic, edge_tol, EPS),
-              0.0,
-              abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({-2.5, 0.0}), fcubic, edge_tol, EPS),
-              0.0,
-              abs_tol);
-
-  // If query point between the endpoints, return +0.5/-0.5
-  EXPECT_NEAR(winding_number(Point2D({-0.5, 0.0}), cubic, edge_tol, EPS),
-              0.5,
-              abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({-0.5, 0.0}), fcubic, edge_tol, EPS),
-              -0.5,
-              abs_tol);
-
-  cubic.reverseOrientation();
-  fcubic.reverseOrientation();
-  EXPECT_NEAR(winding_number(Point2D({-0.5, 0.0}), cubic, edge_tol, EPS),
-              -0.5,
-              abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({-0.5, 0.0}), fcubic, edge_tol, EPS),
-              0.5,
-              abs_tol);
-
   // Extra tests if initial and terminal tangent lines are colinear
-  Point2D nodes3[] = {Point2D {0.1, 0.0},
-                      Point2D {1.0, 0.0},
-                      Point2D {0.0, 1.0},
-                      Point2D {-1.0, 0.0},
-                      Point2D {-0.1, 0.0}};
-  Bezier quartic(nodes3, 4);
+  Point2D quartic_nodes[] = {Point2D {0.1, 0.0},
+                             Point2D {1.0, 0.0},
+                             Point2D {0.0, 1.0},
+                             Point2D {-1.0, 0.0},
+                             Point2D {-0.1, 0.0}};
+  Bezier quartic(quartic_nodes, 4);
 
   // Tangent lines in opposite directions
   EXPECT_NEAR(winding_number(Point2D({0, 0}), quartic, edge_tol, EPS),
               0.5,
+              abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({2.5, 0}), quartic, edge_tol, EPS),
+              0.0,
+              abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({-2.5, 0}), quartic, edge_tol, EPS),
+              0.0,
               abs_tol);
 
   // Flip the curve vertically
@@ -190,11 +159,23 @@ TEST(primal_winding_number, edge_cases)
   EXPECT_NEAR(winding_number(Point2D({0, 0}), quartic, edge_tol, EPS),
               -0.5,
               abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({2.5, 0}), quartic, edge_tol, EPS),
+              0.0,
+              abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({-2.5, 0}), quartic, edge_tol, EPS),
+              0.0,
+              abs_tol);
 
   // Flip one of the tangent lines
   quartic[1] = Point2D({0.0, 0.0});
   EXPECT_NEAR(winding_number(Point2D({0, 0}), quartic, edge_tol, EPS),
               -0.5,
+              abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({2.5, 0}), quartic, edge_tol, EPS),
+              0.0,
+              abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({-2.5, 0}), quartic, edge_tol, EPS),
+              0.0,
               abs_tol);
 
   // Flip vertically again
@@ -202,33 +183,37 @@ TEST(primal_winding_number, edge_cases)
   EXPECT_NEAR(winding_number(Point2D({0, 0}), quartic, edge_tol, EPS),
               0.5,
               abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({2.5, 0}), quartic, edge_tol, EPS),
+              0.0,
+              abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({-2.5, 0}), quartic, edge_tol, EPS),
+              0.0,
+              abs_tol);
 }
 
 TEST(primal_winding_number, corner_cases)
 {
+  // Tests for when query is identically on either endpoint of theBezier curve.
+  //  Conventionally undefined mathematically, we return the limiting value,
+  //  which depends on tangent lines at the query point
   using Point2D = primal::Point<double, 2>;
   using Bezier = primal::BezierCurve<double, 2>;
 
-  double abs_tol = 1e-4;
+  double abs_tol = 1e-8;
   double edge_tol = 1e-8;
   double EPS = 1e-50;
 
   // Line segment
-  Point2D nodes1[] = {Point2D {0.0, 0.0}, Point2D {1.0, 1.0}};
-  Bezier linear(nodes1, 1);
+  Point2D linear_nodes[] = {Point2D {0.0, 0.0}, Point2D {1.0, 1.0}};
+  Bezier linear(linear_nodes, 1);
 
   // Cubic curve
-  Point2D nodes2[] = {Point2D {0.0, 0.0},
-                      Point2D {0.0, 1.0},
-                      Point2D {-1.0, 1.0},
-                      Point2D {-1.0, 0.0}};
-  Bezier cubic(nodes2, 3);
+  Point2D cubic_nodes[] = {Point2D {0.0, 0.0},
+                           Point2D {0.0, 1.0},
+                           Point2D {-1.0, 1.0},
+                           Point2D {-1.0, 0.0}};
+  Bezier cubic(cubic_nodes, 3);
 
-  // At any point on a line, returns 0
-  EXPECT_NEAR(  // Query on linear curve
-    winding_number(Point2D({0.45, 0.45}), linear, edge_tol, EPS),
-    0.0,
-    abs_tol);
   EXPECT_NEAR(  // Query on endpoint of linear
     winding_number(Point2D({0.0, 0.0}), linear, edge_tol, EPS),
     0.0,
@@ -252,20 +237,24 @@ TEST(primal_winding_number, corner_cases)
               0.312832962673,
               abs_tol);
 
-  // The query is not on an endpoint after any number of bisections
-  EXPECT_NEAR(winding_number(cubic.evaluate(0.4), cubic, edge_tol, EPS),
-              0.310998027957,
+  // Query point on both endpoints
+  Point2D closed_cubic_nodes[] = {Point2D {0.0, 0.0},
+                                  Point2D {2.0, 1.0},
+                                  Point2D {-1.0, 1.0},
+                                  Point2D {0.0, 0.0}};
+  Bezier cubic_closed(closed_cubic_nodes, 3);
+  EXPECT_NEAR(winding_number(Point2D({0.0, 0.0}), cubic_closed, edge_tol, EPS),
+              0.301208191175,
               abs_tol);
 
   // Extra tests if initial and terminal tangent lines are colinear
-  Point2D nodes3[] = {Point2D {0.1, 0.0},
-                      Point2D {1.0, 0.0},
-                      Point2D {0.0, 1.0},
-                      Point2D {-1.0, 0.0},
-                      Point2D {-0.1, 0.0}};
-  Bezier quartic(nodes3, 4);
+  Point2D quartic_nodes[] = {Point2D {0.1, 0.0},
+                             Point2D {1.0, 0.0},
+                             Point2D {0.0, 1.0},
+                             Point2D {-1.0, 0.0},
+                             Point2D {-0.1, 0.0}};
+  Bezier quartic(quartic_nodes, 4);
 
-  // Bugs out because endpoint tangent lines point in opposite directions
   EXPECT_NEAR(winding_number(Point2D({0.1, 0}), quartic, edge_tol, EPS),
               0.5,
               abs_tol);
@@ -301,8 +290,11 @@ TEST(primal_winding_number, corner_cases)
               abs_tol);
 }
 
-TEST(primal_winding_number, self_intersecting_cases)
+TEST(primal_winding_number, edge_cases)
 {
+  // Tests for when query is identically on interior of Bezier curve.
+  //   Conventionally undefined mathematically. Uses endpoint formulas
+  //   to determine value after some number of bisections
   using Point2D = primal::Point<double, 2>;
   using Bezier = primal::BezierCurve<double, 2>;
 
@@ -310,106 +302,111 @@ TEST(primal_winding_number, self_intersecting_cases)
   double edge_tol = 1e-8;
   double EPS = 1e-50;
 
-  // Cubic curve with cusp
-  Point2D nodes1[] = {Point2D {0.0, 0.0},
-                      Point2D {1.0, 1.0},
-                      Point2D {0.0, 1.0},
-                      Point2D {1.0, 0.0}};
-  Bezier cubic_cusp(nodes1, 3);
+  // Line segment
+  Point2D linear_nodes[] = {Point2D {0.0, 0.0}, Point2D {1.0, 1.0}};
+  Bezier linear(linear_nodes, 1);
 
-  EXPECT_NEAR(winding_number(Point2D({0.5, 0.5}), cubic_cusp, edge_tol, EPS),
-              -0.75,
+  // At any point on a line, returns 0
+  for(double t = 0.1; t < 1; t += 0.1)
+    EXPECT_NEAR(winding_number(Point2D({t, t}), linear, edge_tol, EPS),
+                0.0,
+                abs_tol);
+
+  // Cubic curve, where query is not on an endpoint after any number of bisections
+  Point2D cubic_nodes[] = {Point2D {0.0, 0.0},
+                           Point2D {0.0, 1.0},
+                           Point2D {-1.0, 1.0},
+                           Point2D {-1.0, 0.0}};
+  Bezier cubic(cubic_nodes, 3);
+
+  EXPECT_NEAR(winding_number(cubic.evaluate(0.1), cubic, edge_tol, EPS),
+              0.276676361896,
+              abs_tol);
+  EXPECT_NEAR(winding_number(cubic.evaluate(0.4), cubic, edge_tol, EPS),
+              0.310998033871,
+              abs_tol);
+  EXPECT_NEAR(winding_number(cubic.evaluate(0.7), cubic, edge_tol, EPS),
+              0.305165888012,
               abs_tol);
 
-  // Bugs out because it has a duplicate endpoint after one split.
-  EXPECT_NEAR(winding_number(Point2D({0.5, 0.75}), cubic_cusp, edge_tol, EPS),
-              0.18716704181099889,
-              abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({0.5, 1.5}), cubic_cusp, edge_tol, EPS),
-              0.10241638235,
-              abs_tol);
-
-  // Cubic curve with loop
-  Point2D nodes2[] = {Point2D {0.0, 0.0},
-                      Point2D {2.0, 1.0},
-                      Point2D {-1.0, 1.0},
-                      Point2D {1.0, 0.0}};
-  Bezier cubic_loop(nodes2, 3);
+  // Cubic curve with internal loop
+  Point2D cubic_loop_nodes[] = {Point2D {0.0, 0.0},
+                                Point2D {2.0, 1.0},
+                                Point2D {-1.0, 1.0},
+                                Point2D {1.0, 0.0}};
+  Bezier cubic_loop(cubic_loop_nodes, 3);
   EXPECT_NEAR(winding_number(Point2D({0.5, 0.3}), cubic_loop, edge_tol, EPS),
               0.327979130377,
               abs_tol);
   EXPECT_NEAR(winding_number(Point2D({0.5, 0.75}), cubic_loop, edge_tol, EPS),
               0.687167046798,
               abs_tol);
-
-  // Closed cubic curve
-  Point2D nodes3[] = {Point2D {0.0, 0.0},
-                      Point2D {2.0, 1.0},
-                      Point2D {-1.0, 1.0},
-                      Point2D {0.0, 0.0}};
-  Bezier cubic_closed(nodes3, 3);
-  EXPECT_NEAR(winding_number(Point2D({0.0, 0.0}), cubic_closed, edge_tol, EPS),
-              0.301208191175,
-              abs_tol);
 }
 
 TEST(primal_winding_number, degenerate_cases)
 {
+  // Tests for when Bezier curves are defined with duplicate nodes
   using Point2D = primal::Point<double, 2>;
   using Bezier = primal::BezierCurve<double, 2>;
 
-  double abs_tol = 1e-4;
+  double abs_tol = 1e-8;
   double edge_tol = 1e-8;
   double EPS = 1e-50;
 
-  // Backtracking quadratic curve
-  Point2D bt_nodes[] = {Point2D {0.0, 0.0},
-                        Point2D {0.0, 1.0},
-                        Point2D {0.0, 0.5}};
-  Bezier bt_curve(bt_nodes, 2);
-  EXPECT_NEAR(winding_number(Point2D({0.0, -0.25}), bt_curve, edge_tol, EPS),
-              0,
+  // Flat curve with anti-parallel tangent lines
+  Point2D double_bt_nodes[] = {Point2D {0.0, 1.0},
+                               Point2D {0.0, 2.0},
+                               Point2D {0.0, 0.0},
+                               Point2D {0.0, -2.0},
+                               Point2D {0.0, -1.0}};
+  Bezier double_bt(double_bt_nodes, 4);
+
+  Point2D linear_nodes[] = {Point2D {0.0, 1.0}, Point2D {0.0, -1.0}};
+  Bezier linear(linear_nodes, 1);
+
+  for(double t = -3.0; t <= 3.0; t += 0.1)
+  {
+    EXPECT_NEAR(winding_number(Point2D({0.0, t}), double_bt, edge_tol, EPS),
+                0.0,
+                abs_tol);
+    EXPECT_NEAR(winding_number(Point2D({1.0, t}), double_bt, edge_tol, EPS),
+                winding_number(Point2D({1.0, t}), linear, edge_tol, EPS),
+                abs_tol);
+  }
+
+  // Check endpoints specifically
+  EXPECT_NEAR(winding_number(Point2D({0.0, 1.0}), double_bt, edge_tol, EPS),
+              0.0,
               abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({0.0, 0.25}), bt_curve, edge_tol, EPS),
-              0,
-              abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({0.0, 0.75}), bt_curve, edge_tol, EPS),
-              0,
-              abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({0.0, 1.25}), bt_curve, edge_tol, EPS),
-              0,
-              abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({0.25, 0.25}), bt_curve, edge_tol, EPS),
-              -0.25,
+  EXPECT_NEAR(winding_number(Point2D({0.0, -1.0}), double_bt, edge_tol, EPS),
+              0.0,
               abs_tol);
 
-  // empty curve, high order. Gets caught by isLinear
+  // empty curve, high order.
   Point2D empty_nodes[] = {Point2D {0.0, 0.0},
                            Point2D {0.0, 0.0},
                            Point2D {0.0, 0.0},
                            Point2D {0.0, 0.0}};
   Bezier empty_curve(empty_nodes, 3);
-  axom::Array<Point2D> test_points = {Point2D {0.0, 1.0},
+  axom::Array<Point2D> test_points = {Point2D {0.0, 0.0},
+                                      Point2D {0.0, 1.0},
                                       Point2D {1.0, 0.0},
                                       Point2D {1.0, 1.0},
                                       Point2D {0.0, 1.0}};
 
-  EXPECT_NEAR(winding_number(Point2D({0, 0}), empty_curve, edge_tol, EPS),
-              0,
-              abs_tol);
-
   for(auto pt : test_points)
-  {
     EXPECT_NEAR(winding_number(pt, empty_curve, edge_tol, EPS), 0, abs_tol);
-    pt[0] *= -1;
-    EXPECT_NEAR(winding_number(pt, empty_curve, edge_tol, EPS), 0, abs_tol);
-    pt[1] *= -1;
-    EXPECT_NEAR(winding_number(pt, empty_curve, edge_tol, EPS), 0, abs_tol);
-    pt[0] *= -1;
-    EXPECT_NEAR(winding_number(pt, empty_curve, edge_tol, EPS), 0, abs_tol);
-  }
 
-  // Cubic curve
+  // Check default empty Bezier curves
+  Bezier very_empty_curve(-1);
+  for(auto pt : test_points)
+    EXPECT_NEAR(winding_number(pt, very_empty_curve, edge_tol, EPS), 0, abs_tol);
+
+  very_empty_curve.setOrder(0);
+  for(auto pt : test_points)
+    EXPECT_NEAR(winding_number(pt, very_empty_curve, edge_tol, EPS), 0, abs_tol);
+
+  // Cubic curve with many duplicated endpoints
   Point2D cubic_nodes[] = {Point2D {0.0, 0.0},
                            Point2D {0.0, 0.0},
                            Point2D {0.0, 0.0},

--- a/src/axom/primal/tests/primal_winding_number.cpp
+++ b/src/axom/primal/tests/primal_winding_number.cpp
@@ -56,8 +56,8 @@ TEST(primal_winding_number, simple_cases)
   using CPolygon = primal::CurvedPolygon<double, 2>;
 
   double abs_tol = 1e-8;
-  double lin_tol = 0;
-  double edge_tol = 0;
+  double edge_tol = 1e-8;
+  double EPS = 1e-50;
 
   // Simple cubic shape
   Point2D top_nodes[] = {Point2D {0.0, 0.0},
@@ -75,45 +75,40 @@ TEST(primal_winding_number, simple_cases)
   CPolygon simple_shape(simple_shape_edges, 2);
 
   // Check interior points
-  for(int i = 1; i < 9; i++)
+  for(int i = 1; i < 7; i++)
   {
     double offset = std::pow(10, -i);
     Point2D q_vert({-0.352, 0.72 - offset});
     Point2D q_horz({-0.352 - offset, 0.72});
 
-    EXPECT_NEAR(winding_number(q_vert, simple_shape, lin_tol, edge_tol),
-                1.0,
-                abs_tol);
-    EXPECT_NEAR(winding_number(q_horz, simple_shape, lin_tol, edge_tol),
-                1.0,
-                abs_tol);
+    EXPECT_NEAR(winding_number(q_vert, simple_shape, edge_tol, EPS), 1.0, abs_tol);
+    EXPECT_NEAR(winding_number(q_horz, simple_shape, edge_tol, EPS), 1.0, abs_tol);
   }
 
   // Check exterior points
-  for(int i = 1; i < 9; i++)
+  for(int i = 1; i < 7; i++)
   {
     double offset = std::pow(10, -i);
     Point2D q_vert({-0.352, 0.72 + offset});
     Point2D q_horz({-0.352 + offset, 0.72});
 
-    EXPECT_NEAR(winding_number(q_vert, simple_shape, lin_tol, edge_tol),
-                0.0,
-                abs_tol);
-    EXPECT_NEAR(winding_number(q_horz, simple_shape, lin_tol, edge_tol),
-                0.0,
-                abs_tol);
+    EXPECT_NEAR(winding_number(q_vert, simple_shape, edge_tol, EPS), 0.0, abs_tol);
+    EXPECT_NEAR(winding_number(q_horz, simple_shape, edge_tol, EPS), 0.0, abs_tol);
   }
 
   // Test that points on either side of cubic are offset by 1
-  EXPECT_NEAR(winding_number(Point2D({-0.352, 0.72 - 1e-16}), top_curve, 0, 0) -
-                winding_number(Point2D({-0.352, 0.72 + 1e-16}), top_curve, 0, 0),
-              1,
-              abs_tol);
+  EXPECT_NEAR(
+    winding_number(Point2D({-0.352, 0.72 - edge_tol * 2}), top_curve, edge_tol, EPS) -
+      winding_number(Point2D({-0.352, 0.72 + edge_tol * 2}), top_curve, edge_tol, EPS),
+    1,
+    abs_tol);
+
   top_curve.reverseOrientation();
-  EXPECT_NEAR(winding_number(Point2D({-0.352, 0.72 + 1e-16}), top_curve, 0, 0) -
-                winding_number(Point2D({-0.352, 0.72 - 1e-16}), top_curve, 0, 0),
-              1,
-              abs_tol);
+  EXPECT_NEAR(
+    winding_number(Point2D({-0.352, 0.72 + edge_tol * 2}), top_curve, edge_tol, EPS) -
+      winding_number(Point2D({-0.352, 0.72 - edge_tol * 2}), top_curve, edge_tol, EPS),
+    1,
+    abs_tol);
 }
 
 TEST(primal_winding_number, edge_cases)
@@ -123,8 +118,8 @@ TEST(primal_winding_number, edge_cases)
   using Bezier = primal::BezierCurve<double, 2>;
 
   double abs_tol = 1e-10;
-  double lin_tol = 1e-16;
-  double edge_tol = 1e-16;
+  double edge_tol = 1e-8;
+  double EPS = 1e-50;
 
   // Line segment
   Point2D nodes1[] = {Point2D {0.0, 0.0}, Point2D {1.0, 1.0}};
@@ -145,35 +140,35 @@ TEST(primal_winding_number, edge_cases)
   Bezier fcubic(fnodes2, 3);
 
   // Test on linear cases
-  EXPECT_NEAR(winding_number(Point2D({-0.45, -0.45}), linear, lin_tol, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({-0.45, -0.45}), linear, edge_tol, EPS),
               0.0,
               abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({1.45, 1.45}), linear, lin_tol, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({1.45, 1.45}), linear, edge_tol, EPS),
               0.0,
               abs_tol);
 
   // Test on cubic. If query is outside the range of the two endpoints, return 0
-  EXPECT_NEAR(winding_number(Point2D({-2.5, 0.0}), cubic, lin_tol, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({-2.5, 0.0}), cubic, edge_tol, EPS),
               0.0,
               abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({-2.5, 0.0}), fcubic, lin_tol, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({-2.5, 0.0}), fcubic, edge_tol, EPS),
               0.0,
               abs_tol);
 
   // If query point between the endpoints, return +0.5/-0.5
-  EXPECT_NEAR(winding_number(Point2D({-0.5, 0.0}), cubic, lin_tol, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({-0.5, 0.0}), cubic, edge_tol, EPS),
               0.5,
               abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({-0.5, 0.0}), fcubic, lin_tol, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({-0.5, 0.0}), fcubic, edge_tol, EPS),
               -0.5,
               abs_tol);
 
   cubic.reverseOrientation();
   fcubic.reverseOrientation();
-  EXPECT_NEAR(winding_number(Point2D({-0.5, 0.0}), cubic, lin_tol, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({-0.5, 0.0}), cubic, edge_tol, EPS),
               -0.5,
               abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({-0.5, 0.0}), fcubic, lin_tol, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({-0.5, 0.0}), fcubic, edge_tol, EPS),
               0.5,
               abs_tol);
 
@@ -186,19 +181,27 @@ TEST(primal_winding_number, edge_cases)
   Bezier quartic(nodes3, 4);
 
   // Tangent lines in opposite directions
-  EXPECT_NEAR(winding_number(Point2D({0, 0}), quartic, 0, edge_tol), 0.5, abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({0, 0}), quartic, edge_tol, EPS),
+              0.5,
+              abs_tol);
 
   // Flip the curve vertically
   quartic[2] = Point2D({0.0, -1.0});
-  EXPECT_NEAR(winding_number(Point2D({0, 0}), quartic, 0, edge_tol), -0.5, abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({0, 0}), quartic, edge_tol, EPS),
+              -0.5,
+              abs_tol);
 
   // Flip one of the tangent lines
   quartic[1] = Point2D({0.0, 0.0});
-  EXPECT_NEAR(winding_number(Point2D({0, 0}), quartic, 0, edge_tol), -0.5, abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({0, 0}), quartic, edge_tol, EPS),
+              -0.5,
+              abs_tol);
 
   // Flip vertically again
   quartic[2] = Point2D({0.0, 1.0});
-  EXPECT_NEAR(winding_number(Point2D({0, 0}), quartic, 0, edge_tol), 0.5, abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({0, 0}), quartic, edge_tol, EPS),
+              0.5,
+              abs_tol);
 }
 
 TEST(primal_winding_number, corner_cases)
@@ -206,8 +209,9 @@ TEST(primal_winding_number, corner_cases)
   using Point2D = primal::Point<double, 2>;
   using Bezier = primal::BezierCurve<double, 2>;
 
-  double abs_tol = 1e-8;
+  double abs_tol = 1e-4;
   double edge_tol = 1e-8;
+  double EPS = 1e-50;
 
   // Line segment
   Point2D nodes1[] = {Point2D {0.0, 0.0}, Point2D {1.0, 1.0}};
@@ -226,34 +230,34 @@ TEST(primal_winding_number, corner_cases)
 
   // At any point on a line, returns 0
   EXPECT_NEAR(  // Query on linear curve
-    winding_number(Point2D({0.45, 0.45}), linear, 0, edge_tol),
+    winding_number(Point2D({0.45, 0.45}), linear, edge_tol, EPS),
     0.0,
     abs_tol);
   EXPECT_NEAR(  // Query on endpoint of linear
-    winding_number(Point2D({0.0, 0.0}), linear, 0, edge_tol),
+    winding_number(Point2D({0.0, 0.0}), linear, edge_tol, EPS),
     0.0,
     abs_tol);
   EXPECT_NEAR(  // Query on endpoint of linear
-    winding_number(Point2D({1.0, 1.0}), linear, 0, edge_tol),
+    winding_number(Point2D({1.0, 1.0}), linear, edge_tol, EPS),
     0.0,
     abs_tol);
 
   EXPECT_NEAR(  // Query on initial endpoint of cubic
-    winding_number(Point2D({-1.0, 0.0}), cubic, 0, edge_tol),
+    winding_number(Point2D({-1.0, 0.0}), cubic, edge_tol, EPS),
     0.25,
     abs_tol);
   EXPECT_NEAR(  // Query on terminal endpoint of cubic
-    winding_number(Point2D({-1.0, 0.0}), cubic, 0, edge_tol),
+    winding_number(Point2D({-1.0, 0.0}), cubic, edge_tol, EPS),
     0.25,
     abs_tol);
 
   // The query is on the endpoint after one bisection
-  EXPECT_NEAR(winding_number(Point2D({-0.5, 0.75}), cubic, 0, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({-0.5, 0.75}), cubic, edge_tol, EPS),
               0.312832962673,
               abs_tol);
 
   // The query is not on an endpoint after any number of bisections
-  EXPECT_NEAR(winding_number(cubic.evaluate(0.4), cubic, 0, edge_tol),
+  EXPECT_NEAR(winding_number(cubic.evaluate(0.4), cubic, edge_tol, EPS),
               0.310998027957,
               abs_tol);
 }
@@ -263,8 +267,9 @@ TEST(primal_winding_number, self_intersecting_cases)
   using Point2D = primal::Point<double, 2>;
   using Bezier = primal::BezierCurve<double, 2>;
 
-  double abs_tol = 1e-8;
+  double abs_tol = 1e-4;
   double edge_tol = 1e-8;
+  double EPS = 1e-50;
 
   // Cubic curve with cusp
   Point2D nodes1[] = {Point2D {0.0, 0.0},
@@ -273,13 +278,13 @@ TEST(primal_winding_number, self_intersecting_cases)
                       Point2D {1.0, 0.0}};
   Bezier cubic_cusp(nodes1, 3);
 
-  EXPECT_NEAR(winding_number(Point2D({0.5, 0.5}), cubic_cusp, 0, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({0.5, 0.5}), cubic_cusp, edge_tol, EPS),
               -0.75,
               abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({0.5, 0.75}), cubic_cusp, 0, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({0.5, 0.75}), cubic_cusp, edge_tol, EPS),
               0.18716704181099889,
               abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({0.5, 1.5}), cubic_cusp, 0, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({0.5, 1.5}), cubic_cusp, edge_tol, EPS),
               0.10241638235,
               abs_tol);
 
@@ -289,10 +294,10 @@ TEST(primal_winding_number, self_intersecting_cases)
                       Point2D {-1.0, 1.0},
                       Point2D {1.0, 0.0}};
   Bezier cubic_loop(nodes2, 3);
-  EXPECT_NEAR(winding_number(Point2D({0.5, 0.3}), cubic_loop, 0, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({0.5, 0.3}), cubic_loop, edge_tol, EPS),
               0.327979130377,
               abs_tol);
-  EXPECT_NEAR(winding_number(Point2D({0.5, 0.75}), cubic_loop, 0, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({0.5, 0.75}), cubic_loop, edge_tol, EPS),
               0.687167046798,
               abs_tol);
 
@@ -302,9 +307,56 @@ TEST(primal_winding_number, self_intersecting_cases)
                       Point2D {-1.0, 1.0},
                       Point2D {0.0, 0.0}};
   Bezier cubic_closed(nodes3, 3);
-  EXPECT_NEAR(winding_number(Point2D({0.0, 0.0}), cubic_closed, 0, edge_tol),
+  EXPECT_NEAR(winding_number(Point2D({0.0, 0.0}), cubic_closed, edge_tol, EPS),
               0.301208191175,
               abs_tol);
+
+  // Backtracking quadratic curve
+  Point2D bt_nodes[] = {Point2D {0.0, 0.0},
+                        Point2D {0.0, 1.0},
+                        Point2D {0.0, 0.5}};
+  Bezier bt_curve(bt_nodes, 2);
+  EXPECT_NEAR(winding_number(Point2D({0.0, -0.25}), bt_curve, edge_tol, EPS),
+              0,
+              abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({0.0, 0.25}), bt_curve, edge_tol, EPS),
+              0,
+              abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({0.0, 0.75}), bt_curve, edge_tol, EPS),
+              0,
+              abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({0.0, 1.25}), bt_curve, edge_tol, EPS),
+              0,
+              abs_tol);
+  EXPECT_NEAR(winding_number(Point2D({0.25, 0.25}), bt_curve, edge_tol, EPS),
+              -0.25,
+              abs_tol);
+
+  // Very degenerate curve
+  Point2D empty_nodes[] = {Point2D {0.0, 0.0},
+                           Point2D {0.0, 0.0},
+                           Point2D {0.0, 0.0},
+                           Point2D {0.0, 0.0}};
+  Bezier empty_curve(empty_nodes, 3);
+  axom::Array<Point2D> test_points = {Point2D {0.0, 1.0},
+                                      Point2D {1.0, 0.0},
+                                      Point2D {1.0, 1.0},
+                                      Point2D {0.0, 1.0}};
+
+  EXPECT_NEAR(winding_number(Point2D({0, 0}), empty_curve, edge_tol, EPS),
+              0,
+              abs_tol);
+
+  for(auto pt : test_points)
+  {
+    EXPECT_NEAR(winding_number(pt, empty_curve, edge_tol, EPS), 0, abs_tol);
+    pt[0] *= -1;
+    EXPECT_NEAR(winding_number(pt, empty_curve, edge_tol, EPS), 0, abs_tol);
+    pt[1] *= -1;
+    EXPECT_NEAR(winding_number(pt, empty_curve, edge_tol, EPS), 0, abs_tol);
+    pt[0] *= -1;
+    EXPECT_NEAR(winding_number(pt, empty_curve, edge_tol, EPS), 0, abs_tol);
+  }
 }
 
 int main(int argc, char** argv)

--- a/src/axom/primal/tests/primal_winding_number.cpp
+++ b/src/axom/primal/tests/primal_winding_number.cpp
@@ -60,7 +60,7 @@ TEST(primal_winding_number, simple_cases)
 
   double abs_tol = 1e-8;
   double edge_tol = 1e-8;
-  double EPS = 1e-50;
+  double EPS = primal::PRIMAL_TINY;
 
   // Simple closed shape with cubic edges
   Point2D top_nodes[] = {Point2D {0.0, 0.0},
@@ -122,7 +122,7 @@ TEST(primal_winding_number, closure_edge_cases)
 
   double abs_tol = 1e-8;
   double edge_tol = 1e-8;
-  double EPS = 1e-50;
+  double EPS = primal::PRIMAL_TINY;
 
   // Test on linear cases
   Point2D linear_nodes[] = {Point2D {0.0, 0.0}, Point2D {1.0, 1.0}};
@@ -135,7 +135,7 @@ TEST(primal_winding_number, closure_edge_cases)
               0.0,
               abs_tol);
 
-  // Extra tests if initial and terminal tangent lines are colinear
+  // Extra tests if initial and terminal tangent lines are collinear
   Point2D quartic_nodes[] = {Point2D {0.1, 0.0},
                              Point2D {1.0, 0.0},
                              Point2D {0.0, 1.0},
@@ -193,7 +193,7 @@ TEST(primal_winding_number, closure_edge_cases)
 
 TEST(primal_winding_number, corner_cases)
 {
-  // Tests for when query is identically on either endpoint of theBezier curve.
+  // Tests for when query is identically on either endpoint of the Bezier curve.
   //  Conventionally undefined mathematically, we return the limiting value,
   //  which depends on tangent lines at the query point
   using Point2D = primal::Point<double, 2>;
@@ -201,7 +201,7 @@ TEST(primal_winding_number, corner_cases)
 
   double abs_tol = 1e-8;
   double edge_tol = 1e-8;
-  double EPS = 1e-50;
+  double EPS = primal::PRIMAL_TINY;
 
   // Line segment
   Point2D linear_nodes[] = {Point2D {0.0, 0.0}, Point2D {1.0, 1.0}};
@@ -247,7 +247,7 @@ TEST(primal_winding_number, corner_cases)
               0.301208191175,
               abs_tol);
 
-  // Extra tests if initial and terminal tangent lines are colinear
+  // Extra tests if initial and terminal tangent lines are collinear
   Point2D quartic_nodes[] = {Point2D {0.1, 0.0},
                              Point2D {1.0, 0.0},
                              Point2D {0.0, 1.0},
@@ -300,7 +300,7 @@ TEST(primal_winding_number, edge_cases)
 
   double abs_tol = 1e-4;
   double edge_tol = 1e-8;
-  double EPS = 1e-50;
+  double EPS = primal::PRIMAL_TINY;
 
   // Line segment
   Point2D linear_nodes[] = {Point2D {0.0, 0.0}, Point2D {1.0, 1.0}};
@@ -351,7 +351,7 @@ TEST(primal_winding_number, degenerate_cases)
 
   double abs_tol = 1e-8;
   double edge_tol = 1e-8;
-  double EPS = 1e-50;
+  double EPS = primal::PRIMAL_TINY;
 
   // Flat curve with anti-parallel tangent lines
   Point2D double_bt_nodes[] = {Point2D {0.0, 1.0},


### PR DESCRIPTION
# Summary

This PR addresses issue #894, and is a bugfix for the following issues
-  Evaluation of winding numbers at endpoints of Bezier curves fails when endpoints are duplicated
-- Solution: Endpoint formula iterates over nodes until distinct one is found
-  Evaluation of winding numbers at endpoints of Bezier curves fails when tangent lines are anti-parallel
-- Solution: When this case is identified, iterating over interior nodes identifies orientation and returns correct winding number
- `in_polygon` returns incorrect value when point is on same horizontal line as initial vertex
-- Solution: Replace a `1` with a `0`

Additional tests were added to `primal_winding_number.cpp` and `primal_polygon.cpp` to account for these errors. Additionally, this PR addresses issues of efficiency and readability for methods in `in_curved_polygon`, such as renaming `closure_winding_number` to the more mathematically direct `linear_winding_number`. Additionally, error tolerances are renamed so that `edge_tol` is used exclusively for physical distances, while `EPS` for all other numerical tolerances.