### PR TITLE
Fixes configuration with clang C/C++ compiler and Intel Fortran compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ uberenv_libs
 *_build*
 .idea
 *.opendb
+scripts/make_local_branch_from_fork_pr.sh

--- a/host-configs/other/no-tpl-toss_3_x86_64_ib-clang@10-ifort@19.cmake
+++ b/host-configs/other/no-tpl-toss_3_x86_64_ib-clang@10-ifort@19.cmake
@@ -1,0 +1,78 @@
+# Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and
+# other Axom Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+#------------------------------------------------------------------------------
+# Minimal host-config (cmake cache file) to build Axom without any pre-built
+# third party libraries using the clang compiler for C++ 
+# and the intel compiler  for Fortran
+#
+# Note: Sidre requires Conduit and is therefore disabled. Similarly, the Inlet
+# and Klee components both depend on Sidre and must be disabled.
+#
+# To build the code with this host-config,
+# run the following from your build directory:
+#
+#   cd <axom_root>
+#   mkdir build
+#   cd build
+#   cmake -C ../host-config/other/no-tpl-toss_3_x86_64_ib-clang@10-ifort@19.cmake \
+#         -DCMAKE_BUILD_TYPE={Debug,Release}                                      \
+#         -DBUILD_SHARED_LIBS={ON,OFF(DEFAULT)}                                   \
+#         -DENABLE_EXAMPLES={ON,OFF}                                              \
+#         -DENABLE_TESTS={ON,OFF}                                                 \
+#         -DCMAKE_INSTALL_PREFIX= /path/to/install/dir                            \
+#         ../src
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.21.1/bin/cmake
+#------------------------------------------------------------------------------
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(_gnu_root   "/usr/tce/packages/gcc/gcc-8.3.1" CACHE PATH "")
+set(_clang_root "/usr/tce/packages/clang/clang-10.0.0" CACHE PATH "")
+set(_intel_root "/usr/tce/packages/intel/intel-19.0.4" CACHE PATH "")
+
+set(CMAKE_C_COMPILER   "${_clang_root}/bin/clang" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "${_clang_root}/bin/clang++" CACHE PATH "")
+set(CMAKE_Fortran_COMPILER "${_intel_root}/bin/ifort" CACHE PATH "")
+
+# Tell clang and the intel compiler to use a newer (non-default) version of gcc
+# and remove implicit linker paths associated with the default gcc
+set(CMAKE_C_FLAGS   "--gcc-toolchain=${_gnu_root} -gcc-name=${_gnu_root}/bin/gcc" CACHE STRING "")
+set(CMAKE_CXX_FLAGS "--gcc-toolchain=${_gnu_root} -gcc-name=${_gnu_root}/bin/gcc" CACHE STRING "")
+set(BLT_EXE_LINKER_FLAGS " -Wl,-rpath,${COMPILER_HOME}/lib" CACHE STRING "Adds a missing libstdc++ rpath")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE
+        ${_clang_root}/release/lib
+        /usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/x86_64-unknown-linux-gnu/4.9.3
+        /usr/tce/packages/gcc/gcc-4.9.3/lib64
+    CACHE STRING "")
+
+# Sidre requires conduit and hdf5, so disable it in this host-config
+# Inlet and Klee both depend on Sidre, so disable them too
+set(AXOM_ENABLE_SIDRE OFF CACHE BOOL "")
+set(AXOM_ENABLE_INLET OFF CACHE BOOL "")
+set(AXOM_ENABLE_KLEE  OFF CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(_mpi_root            "/usr/tce/packages/mvapich2/mvapich2-2.3-clang-10.0.0" CACHE PATH "")
+set(MPI_C_COMPILER       "${_mpi_root}/bin/mpicc" CACHE PATH "")
+set(MPI_CXX_COMPILER     "${_mpi_root}/bin/mpicxx" CACHE PATH "")
+set(MPI_Fortran_COMPILER "${_mpi_root}/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE   "/usr/bin/srun" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Other
+#------------------------------------------------------------------------------
+set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+set(ENABLE_DOCS OFF CACHE BOOL "")
+
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format" CACHE PATH "")

--- a/src/axom/primal/tests/primal_rational_bezier.cpp
+++ b/src/axom/primal/tests/primal_rational_bezier.cpp
@@ -478,8 +478,7 @@ TEST(primal_rationalbezier, rational_intersection)
 {
   using Point2D = primal::Point<double, 2>;
   using Bezier = primal::BezierCurve<double, 2>;
-  using CPolygon = primal::CurvedPolygon<double, 2>;
-  double abs_tol = 1e-8;
+  constexpr double abs_tol = 1e-8;
 
   // Intersecting of rational, circular arc shapes
   Point2D bot_nodes[] = {Point2D {1.0, 0.0},

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -189,63 +189,49 @@ endif()
 
 if (ENABLE_FORTRAN)
 
+    set(quest_fortran_examples quest_signed_distance_interface)
+    
+    # The inout Fortran example fails to compile with hipcc/amdflang in debug configurations
+    if("${CMAKE_Fortran_COMPILER}" MATCHES "amdflang$" AND "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+        set(_has_inout_fortran_example FALSE)
+    else()
+        set(_has_inout_fortran_example TRUE)
+        blt_list_append(TO quest_fortran_examples ELEMENTS quest_inout_interface)
+    endif()
+
     blt_list_append(TO quest_example_fortran_depends ELEMENTS mpi IF ENABLE_MPI)
 
-    blt_add_executable(
-        NAME       quest_signed_distance_interface_F_ex
-        SOURCES    quest_signed_distance_interface.F
-        OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-        DEPENDS_ON ${quest_example_depends} ${quest_example_fortran_depends}
-        FOLDER     axom/quest/examples
-        )
-
-    # This target fails to compile with hipcc/amdflang in debug configurations
-    if(NOT "${CMAKE_Fortran_COMPILER}" MATCHES "amdflang$" OR NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+    foreach(_t ${quest_fortran_examples})
+        set(_example_name "${_t}_F_ex")
         blt_add_executable(
-            NAME        quest_inout_interface_F_ex
-            SOURCES     quest_inout_interface.F
-            OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
-            DEPENDS_ON  ${quest_example_depends} ${quest_example_fortran_depends}
-            FOLDER      axom/quest/examples
-            )
+            NAME       ${_example_name}
+            SOURCES    ${_t}.F
+            OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
+            DEPENDS_ON ${quest_example_depends} ${quest_example_fortran_depends}
+            FOLDER     axom/quest/examples)
 
-        if (NOT ENABLE_CUDA)
+        # When CUDA is enabled, BLT will determine the correct linker, so don't override it here
+        if(NOT ENABLE_CUDA)
             if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM")
-                set_target_properties(quest_inout_interface_F_ex
+                set_target_properties(${_example_name}
                                       PROPERTIES LINKER_LANGUAGE Fortran)
             else()
-                set_target_properties(quest_inout_interface_F_ex
+                set_target_properties(${_example_name}
                                       PROPERTIES LINKER_LANGUAGE CXX)
             endif()
         endif()
-    endif()
+    endforeach()
 
-    # When CUDA is enabled, BLT will determine the correct linker, so don't override it here
-    if (NOT ENABLE_CUDA)
-        # When using the Intel compiler we need to link with the Fortran compiler to get openmp to work correctly.
-        if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM")
-            set_target_properties( quest_signed_distance_interface_F_ex
-                                   PROPERTIES LINKER_LANGUAGE Fortran)
+    if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR AND ${_has_inout_fortran_example})
+        if (ENABLE_MPI)
+            axom_add_test(
+                NAME quest_inout_interface_mpi_F_test
+                COMMAND quest_inout_interface_F_ex ${quest_data_dir}/sphere_binary.stl
+                NUM_MPI_TASKS 2)
         else()
-            set_target_properties( quest_signed_distance_interface_F_ex
-                                   PROPERTIES LINKER_LANGUAGE CXX)
-        endif()
-    endif()
-
-    if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR)
-        if(NOT "${CMAKE_Fortran_COMPILER}" MATCHES "amdflang$" OR NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-            if (ENABLE_MPI)
-                axom_add_test(
-                    NAME quest_inout_interface_mpi_F_test
-                    COMMAND quest_inout_interface_F_ex ${quest_data_dir}/sphere_binary.stl
-                    NUM_MPI_TASKS 2
-                    )
-            else()
-                axom_add_test(
-                    NAME quest_inout_interface_F_test
-                    COMMAND quest_inout_interface_F_ex ${quest_data_dir}/sphere_binary.stl
-                    )
-            endif()
+            axom_add_test(
+                NAME quest_inout_interface_F_test
+                COMMAND quest_inout_interface_F_ex ${quest_data_dir}/sphere_binary.stl)
         endif()
     endif()
 endif()

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -199,7 +199,7 @@ if (ENABLE_FORTRAN)
         FOLDER     axom/quest/examples
         )
 
-    # This target fails to compile with hipcc/amdflang on debugs
+    # This target fails to compile with hipcc/amdflang in debug configurations
     if(NOT "${CMAKE_Fortran_COMPILER}" MATCHES "amdflang$" OR NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
         blt_add_executable(
             NAME        quest_inout_interface_F_ex
@@ -210,7 +210,7 @@ if (ENABLE_FORTRAN)
             )
 
         if (NOT ENABLE_CUDA)
-            if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM")
+            if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM")
                 set_target_properties(quest_inout_interface_F_ex
                                       PROPERTIES LINKER_LANGUAGE Fortran)
             else()
@@ -223,7 +223,7 @@ if (ENABLE_FORTRAN)
     # When CUDA is enabled, BLT will determine the correct linker, so don't override it here
     if (NOT ENABLE_CUDA)
         # When using the Intel compiler we need to link with the Fortran compiler to get openmp to work correctly.
-        if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM")
+        if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM")
             set_target_properties( quest_signed_distance_interface_F_ex
                                    PROPERTIES LINKER_LANGUAGE Fortran)
         else()


### PR DESCRIPTION
# Summary

- This PR tweaks our build system to allow mixing clang as the C/C++ compiler with ifort as the Fortran compiler and adds a simple (no-tpl) host-config
- In doing so, it cleans up how we add Fortran examples and associated tests in quest
- It also resolves #905 by adding a line to the `.gitignore` file
