### PR TITLE
Fix Group::copyToConduitNode so that it handles lists correctly

### DIFF
--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -1340,7 +1340,7 @@ void Group::copyToConduitNode(Node& n) const
   while(indexIsValid(vidx))
   {
     const View* view = getView(vidx);
-    if (isUsingMap())
+    if(isUsingMap())
     {
       Node& v = n["views"].fetch(view->getName());
       view->copyToConduitNode(v);
@@ -1357,7 +1357,7 @@ void Group::copyToConduitNode(Node& n) const
   while(indexIsValid(gidx))
   {
     const Group* group = getGroup(gidx);
-    if (isUsingMap())
+    if(isUsingMap())
     {
       Node& g = n["groups"].fetch(group->getName());
       group->copyToConduitNode(g);

--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -1340,9 +1340,16 @@ void Group::copyToConduitNode(Node& n) const
   while(indexIsValid(vidx))
   {
     const View* view = getView(vidx);
-    Node& v = n["views"].fetch(view->getName());
-    view->copyToConduitNode(v);
-
+    if (isUsingMap())
+    {
+      Node& v = n["views"].fetch(view->getName());
+      view->copyToConduitNode(v);
+    }
+    else
+    {
+      Node& v = n["views"].append();
+      view->copyToConduitNode(v);
+    }
     vidx = getNextValidViewIndex(vidx);
   }
 
@@ -1350,9 +1357,16 @@ void Group::copyToConduitNode(Node& n) const
   while(indexIsValid(gidx))
   {
     const Group* group = getGroup(gidx);
-    Node& g = n["groups"].fetch(group->getName());
-    group->copyToConduitNode(g);
-
+    if (isUsingMap())
+    {
+      Node& g = n["groups"].fetch(group->getName());
+      group->copyToConduitNode(g);
+    }
+    else
+    {
+      Node& g = n["groups"].append();
+      group->copyToConduitNode(g);
+    }
     gidx = getNextValidGroupIndex(gidx);
   }
 }


### PR DESCRIPTION
# Summary

- This PR is a bug fix
- It does the following (modify list as needed):
  - Modifies `Group::copyToConduitNode` to handle Groups using the list format.j
  - Fixes #928 

This method had the assumption that all child items have a name.  This fix adds handling of unnamed items held in a list, and creates lists of unnamed child Nodes in the conduit output.
