### PR TITLE
Host-config with OpenMP and CUDA enabled

### DIFF
--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -39,7 +39,7 @@
 
 ####
 # PR Build jobs
-lassen-clang_8_0_1_cuda-src:
+lassen-clang_8_0_1_cuda_11_0_2-src:
   variables:
     COMPILER: "clang@8.0.1_cuda"
     HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}.cmake"
@@ -57,13 +57,13 @@ lassen-gcc_7_3_1-src:
     HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}.cmake"
   extends: [.src_build_on_lassen]
 
-lassen-gcc_8_3_1_cuda-src:
+lassen-gcc_8_3_1_cuda_11_0_2-src:
   variables:
     COMPILER: "gcc@8.3.1_cuda"
     HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}.cmake"
   extends: [.src_build_on_lassen, .with_cuda]
 
-lassen-xl_16_1_1_11_cuda-src:
+lassen-xl_16_1_1_11_cuda_11_0_2-src:
   variables:
     COMPILER: "xl@16.1.1.11_cuda"
     HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}.cmake"
@@ -78,7 +78,7 @@ lassen-xl_16_1_1_12-src:
 
 ####
 # Full Build jobs
-lassen-clang_8_0_1_cuda-full:
+lassen-clang_8_0_1_cuda_11_0_2-full:
   variables:
     COMPILER: "clang@8.0.1"
     SPEC: "%${COMPILER}+mfem+cuda~openmp"
@@ -97,14 +97,14 @@ lassen-gcc_7_3_1-full:
     SPEC: "%${COMPILER}+mfem"
   extends: [.full_build_on_lassen]
 
-lassen-gcc_8_3_1_cuda-full:
+lassen-gcc_8_3_1_cuda_11_0_2-full:
   variables:
     COMPILER: "gcc@8.3.1"
     SPEC: "%${COMPILER}~mfem+cuda"
     EXTRA_SPEC: "cuda_arch=70"
   extends: [.full_build_on_lassen, .with_cuda]
 
-lassen-xl_16_1_1_11_cuda-full:
+lassen-xl_16_1_1_11_cuda_11_0_2-full:
   variables:
     COMPILER: "xl@16.1.1.11"
     SPEC: "%${COMPILER}+mfem+cuda~openmp~cpp14"

--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -57,6 +57,12 @@ lassen-gcc_7_3_1-src:
     HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}.cmake"
   extends: [.src_build_on_lassen]
 
+lassen-gcc_8_3_1_cuda-src:
+  variables:
+    COMPILER: "gcc@8.3.1_cuda"
+    HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}.cmake"
+  extends: [.src_build_on_lassen, .with_cuda]
+
 lassen-xl_16_1_1_11_cuda-src:
   variables:
     COMPILER: "xl@16.1.1.11_cuda"
@@ -90,6 +96,13 @@ lassen-gcc_7_3_1-full:
     COMPILER: "gcc@7.3.1"
     SPEC: "%${COMPILER}+mfem"
   extends: [.full_build_on_lassen]
+
+lassen-gcc_8_3_1_cuda-full:
+  variables:
+    COMPILER: "gcc@8.3.1"
+    SPEC: "%${COMPILER}~mfem+cuda"
+    EXTRA_SPEC: "cuda_arch=70"
+  extends: [.full_build_on_lassen, .with_cuda]
 
 lassen-xl_16_1_1_11_cuda-full:
   variables:

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -33,7 +33,7 @@
 
 ####
 # PR Build jobs
-tioga-clang_14_0_0_hip-src:
+tioga-clang_14_0_0_hip_5_1_1-src:
   variables:
     COMPILER: "clang@14.0.0_hip"
     HOST_CONFIG: "tioga-toss_4_x86_64_ib_cray-${COMPILER}.cmake"
@@ -42,7 +42,7 @@ tioga-clang_14_0_0_hip-src:
 
 ####
 # Full Build jobs
-tioga-clang_14_0_0_hip-full:
+tioga-clang_14_0_0_hip_5_1_1-full:
   variables:
     COMPILER: "clang@14.0.0_hip"
     SPEC: "%${COMPILER}~openmp+rocm+mfem+c2c"

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@8.0.1_cuda.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@8.0.1_cuda.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_06_23_21_51_07/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_26_15_35_50/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_06_23_21_51_07/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_26_15_35_50/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_06_23_21_51_07/spack/lib/spack/env/clang/flang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_26_15_35_50/spack/lib/spack/env/clang/flang" CACHE PATH "")
 
 else()
 
@@ -23,7 +23,7 @@ else()
 
   set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-8.0.1/bin/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003_r" CACHE PATH "")
 
 endif()
 
@@ -79,7 +79,7 @@ set(gtest_disable_pthreads ON CACHE BOOL "")
 # Hardware Specifics
 #------------------------------------------------
 
-set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")
 
@@ -89,6 +89,8 @@ set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/
 
 set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE STRING "Converts C-style comments to Fortran style in preprocessed files")
 
+set(BLT_OPENMP_LINK_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-qsmp=omp>" CACHE STRING "Different OpenMP linker flag between CXX and Fortran")
+
 set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
 
 #------------------------------------------------------------------------------
@@ -97,7 +99,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_06_23_21_51_07/clang-8.0.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_26_15_35_50/clang-8.0.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 
@@ -107,7 +109,7 @@ set(MFEM_DIR "${TPL_ROOT}/mfem-4.4.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
 
-set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_06_23_21_51_07/clang-9.0.0/lua-5.3.5" CACHE PATH "")
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
 
 set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-gcc@8.3.1_cuda.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-gcc@8.3.1_cuda.cmake
@@ -1,0 +1,136 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+# Compiler Spec: gcc@8.3.1
+#------------------------------------------------------------------------------
+if(DEFINED ENV{SPACK_CC})
+
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_06_16_43_54/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_06_16_43_54/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_06_16_43_54/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
+
+else()
+
+  set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/g++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran" CACHE PATH "")
+
+endif()
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(MPI_C_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1/bin/mpirun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Hardware
+#------------------------------------------------------------------------------
+
+#------------------------------------------------
+# Cuda
+#------------------------------------------------
+
+set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-11.0.2" CACHE PATH "")
+
+set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc" CACHE PATH "")
+
+set(CMAKE_CUDA_HOST_COMPILER "${MPI_CXX_COMPILER}" CACHE PATH "")
+
+set(ENABLE_CUDA ON CACHE BOOL "")
+
+set(CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "")
+
+set(AXOM_ENABLE_ANNOTATIONS ON CACHE BOOL "")
+
+set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
+
+set(CMAKE_CUDA_FLAGS "-restrict --expt-extended-lambda -arch sm_${CMAKE_CUDA_ARCHITECTURES}  -std=c++14" CACHE STRING "")
+
+# nvcc does not like gtest's 'pthreads' flag
+
+set(gtest_disable_pthreads ON CACHE BOOL "")
+
+#------------------------------------------------
+# Hardware Specifics
+#------------------------------------------------
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_06_16_43_54/gcc-8.3.1" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
+
+# MFEM not built
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2022.03.1" CACHE PATH "")
+
+set(CAMP_DIR "${TPL_ROOT}/camp-2022.03.0" CACHE PATH "")
+
+# scr not built
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# Root directory for generated developer tools
+
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/2022_07_12_11_54_06/gcc-8.3.1" CACHE PATH "")
+
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format" CACHE PATH "")
+
+set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.9.13/bin/python3.9" CACHE PATH "")
+
+set(ENABLE_DOCS ON CACHE BOOL "")
+
+set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/py-sphinx-5.0.2/bin/sphinx-build" CACHE PATH "")
+
+set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/py-shroud-0.12.2/bin/shroud" CACHE PATH "")
+
+set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.8/bin/cppcheck" CACHE PATH "")
+
+set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.14/bin/doxygen" CACHE PATH "")
+
+

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@8.0.1_cuda.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@8.0.1_cuda.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_07_05_12_53_31/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_26_13_36_57/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_07_05_12_53_31/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_26_13_36_57/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_07_05_12_53_31/spack/lib/spack/env/clang/flang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_26_13_36_57/spack/lib/spack/env/clang/flang" CACHE PATH "")
 
 else()
 
@@ -23,7 +23,7 @@ else()
 
   set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-8.0.1/bin/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003_r" CACHE PATH "")
 
 endif()
 
@@ -79,7 +79,7 @@ set(gtest_disable_pthreads ON CACHE BOOL "")
 # Hardware Specifics
 #------------------------------------------------
 
-set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")
 
@@ -89,6 +89,8 @@ set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/
 
 set(BLT_FORTRAN_FLAGS "-WF,-C!  -qxlf2003=polymorphic" CACHE STRING "Converts C-style comments to Fortran style in preprocessed files")
 
+set(BLT_OPENMP_LINK_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-qsmp=omp>" CACHE STRING "Different OpenMP linker flag between CXX and Fortran")
+
 set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
 
 #------------------------------------------------------------------------------
@@ -97,7 +99,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_07_05_12_53_31/clang-8.0.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_26_13_36_57/clang-8.0.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 
@@ -107,7 +109,7 @@ set(MFEM_DIR "${TPL_ROOT}/mfem-4.4.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
 
-set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_07_05_12_53_31/clang-9.0.0/lua-5.3.5" CACHE PATH "")
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
 
 set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@8.3.1_cuda.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@8.3.1_cuda.cmake
@@ -1,0 +1,136 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.14.5/bin/cmake
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+# Compiler Spec: gcc@8.3.1
+#------------------------------------------------------------------------------
+if(DEFINED ENV{SPACK_CC})
+
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_06_15_53_41/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_06_15_53_41/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_06_15_53_41/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
+
+else()
+
+  set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/g++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran" CACHE PATH "")
+
+endif()
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(MPI_C_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1/bin/mpirun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Hardware
+#------------------------------------------------------------------------------
+
+#------------------------------------------------
+# Cuda
+#------------------------------------------------
+
+set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-11.0.2" CACHE PATH "")
+
+set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc" CACHE PATH "")
+
+set(CMAKE_CUDA_HOST_COMPILER "${MPI_CXX_COMPILER}" CACHE PATH "")
+
+set(ENABLE_CUDA ON CACHE BOOL "")
+
+set(CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "")
+
+set(AXOM_ENABLE_ANNOTATIONS ON CACHE BOOL "")
+
+set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
+
+set(CMAKE_CUDA_FLAGS "-restrict --expt-extended-lambda -arch sm_${CMAKE_CUDA_ARCHITECTURES}  -std=c++14" CACHE STRING "")
+
+# nvcc does not like gtest's 'pthreads' flag
+
+set(gtest_disable_pthreads ON CACHE BOOL "")
+
+#------------------------------------------------
+# Hardware Specifics
+#------------------------------------------------
+
+set(ENABLE_OPENMP ON CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")
+
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+# Root directory for generated TPLs
+
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_09_06_15_53_41/gcc-8.3.1" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
+
+# MFEM not built
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+
+set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2022.03.1" CACHE PATH "")
+
+set(CAMP_DIR "${TPL_ROOT}/camp-2022.03.0" CACHE PATH "")
+
+# scr not built
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# Root directory for generated developer tools
+
+set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/2022_07_12_11_54_06/gcc-8.3.1" CACHE PATH "")
+
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format" CACHE PATH "")
+
+set(PYTHON_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.9.13/bin/python3.9" CACHE PATH "")
+
+set(ENABLE_DOCS ON CACHE BOOL "")
+
+set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/py-sphinx-5.0.2/bin/sphinx-build" CACHE PATH "")
+
+set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/py-shroud-0.12.2/bin/shroud" CACHE PATH "")
+
+set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.8/bin/cppcheck" CACHE PATH "")
+
+set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.14/bin/doxygen" CACHE PATH "")
+
+

--- a/scripts/spack/configs/blueos_3_ppc64le_ib_p9/compilers.yaml
+++ b/scripts/spack/configs/blueos_3_ppc64le_ib_p9/compilers.yaml
@@ -19,6 +19,19 @@ compilers:
     modules: []
     operating_system: rhel7
     paths:
+      cc:  /usr/tce/packages/gcc/gcc-8.3.1/bin/gcc
+      cxx: /usr/tce/packages/gcc/gcc-8.3.1/bin/g++
+      f77: /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+      fc:  /usr/tce/packages/gcc/gcc-8.3.1/bin/gfortran
+    spec: gcc@8.3.1
+    target: ppc64le
+- compiler:
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules: []
+    operating_system: rhel7
+    paths:
       cc:  /usr/tce/packages/clang/clang-upstream-2019.08.15/bin/clang
       cxx: /usr/tce/packages/clang/clang-upstream-2019.08.15/bin/clang++
       f77: /usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003

--- a/scripts/spack/configs/blueos_3_ppc64le_ib_p9/compilers.yaml
+++ b/scripts/spack/configs/blueos_3_ppc64le_ib_p9/compilers.yaml
@@ -47,8 +47,8 @@ compilers:
     paths:
       cc:  /usr/tce/packages/clang/clang-8.0.1/bin/clang
       cxx: /usr/tce/packages/clang/clang-8.0.1/bin/clang++
-      f77: /usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003
-      fc:  /usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003
+      f77: /usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003_r
+      fc:  /usr/tce/packages/xl/xl-2019.12.23/bin/xlf2003_r
     spec: clang@8.0.1
     target: ppc64le
 - compiler:

--- a/scripts/spack/configs/blueos_3_ppc64le_ib_p9/packages.yaml
+++ b/scripts/spack/configs/blueos_3_ppc64le_ib_p9/packages.yaml
@@ -34,6 +34,8 @@ packages:
   spectrum-mpi:
     buildable: false
     externals:
+    - spec: spectrum-mpi@release%gcc@7.3.1
+      prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-7.3.1/
     - spec: spectrum-mpi@release%gcc@8.3.1
       prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1/
     - spec: spectrum-mpi@release%clang@9.0.0

--- a/scripts/spack/configs/blueos_3_ppc64le_ib_p9/packages.yaml
+++ b/scripts/spack/configs/blueos_3_ppc64le_ib_p9/packages.yaml
@@ -34,8 +34,8 @@ packages:
   spectrum-mpi:
     buildable: false
     externals:
-    - spec: spectrum-mpi@release%gcc@7.3.1
-      prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-7.3.1/
+    - spec: spectrum-mpi@release%gcc@8.3.1
+      prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3.1/
     - spec: spectrum-mpi@release%clang@9.0.0
       prefix: /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-upstream-2019.08.15/
     - spec: spectrum-mpi@release%clang@8.0.1

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -363,6 +363,18 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
                 "-WF,-C!  -qxlf2003=polymorphic",
                 description))
 
+            if "clang" in self.compiler.cxx and "+openmp" in spec:
+                openmp_gen_exp = ( "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:"
+                                   "-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:"
+                                   "Fortran>:-qsmp=omp>")
+
+                description = ("Different OpenMP linker flag between "
+                               "CXX and Fortran")
+                entries.append(cmake_cache_string(
+                    "BLT_OPENMP_LINK_FLAGS",
+                    openmp_gen_exp,
+                    description))
+
         if spec.satisfies('target=ppc64le:'):
             # Fix for working around CMake adding implicit link directories
             # returned by the BlueOS compilers to link executables with

--- a/scripts/spack/specs.json
+++ b/scripts/spack/specs.json
@@ -29,7 +29,7 @@
 
     "blueos_3_ppc64le_ib_p9":
     [ "clang@9.0.0~openmp+devtools+mfem+c2c",
-      "clang@8.0.1~openmp+devtools+mfem+c2c+cuda cuda_arch=70",
+      "clang@8.0.1+devtools+mfem+c2c+cuda cuda_arch=70",
       "gcc@7.3.1+devtools~mfem+c2c",
       "gcc@8.3.1+devtools~mfem+c2c+cuda cuda_arch=70",
       "xl@16.1.1.11~openmp+devtools+mfem+c2c+cuda cuda_arch=70",

--- a/scripts/spack/specs.json
+++ b/scripts/spack/specs.json
@@ -31,6 +31,7 @@
     [ "clang@9.0.0~openmp+devtools+mfem+c2c",
       "clang@8.0.1~openmp+devtools+mfem+c2c+cuda cuda_arch=70",
       "gcc@7.3.1+devtools~mfem+c2c",
+      "gcc@8.3.1+devtools~mfem+c2c+cuda cuda_arch=70",
       "xl@16.1.1.11~openmp+devtools+mfem+c2c+cuda cuda_arch=70",
       "xl@16.1.1.12~openmp+devtools+mfem+c2c" ],
 

--- a/src/axom/mint/tests/mint_mesh_unstructured_mesh.cpp
+++ b/src/axom/mint/tests/mint_mesh_unstructured_mesh.cpp
@@ -232,7 +232,7 @@ void check_fields(const Mesh* mesh, int assoc, bool newValues = false)
   {
     for(IndexType j = 0; j < num_components; ++j)
     {
-      EXPECT_EQ(data[i * num_components + j], fieldValue(i, j));
+      EXPECT_DOUBLE_EQ(data[i * num_components + j], fieldValue(i, j));
     }
   }
 }

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -533,6 +533,7 @@ public:
     case RuntimePolicy::omp:
 #ifdef _AXOM_DCP_USE_OPENMP
       local_bb = m_bvh_omp->getBounds();
+      break;
 #else
       break;
 #endif
@@ -540,6 +541,7 @@ public:
     case RuntimePolicy::cuda:
 #ifdef _AXOM_DCP_USE_CUDA
       local_bb = m_bvh_cuda->getBounds();
+      break;
 #else
       break;
 #endif
@@ -547,6 +549,7 @@ public:
     case RuntimePolicy::hip:
 #ifdef _AXOM_DCP_USE_HIP
       local_bb = m_bvh_hip->getBounds();
+      break;
 #else
       break;
 #endif

--- a/src/axom/sidre/tests/sidre_group_F.F
+++ b/src/axom/sidre/tests/sidre_group_F.F
@@ -784,7 +784,7 @@ contains
     character(80) file_path
     integer i, j
     integer, parameter :: nfoo = 10
-    integer foo1(nfoo), foo2(nfoo)
+    integer(C_INT), target :: foo1(nfoo), foo2(nfoo)
 !    integer, pointer :: foo3(:) => null()
     integer(C_INT), target :: foo4(nfoo)
     integer int2d1(nfoo,2), int2d2(nfoo,2)

--- a/src/axom/sidre/tests/spio/F_spio_externalWriteRead.F
+++ b/src/axom/sidre/tests/spio/F_spio_externalWriteRead.F
@@ -15,7 +15,7 @@ program spio_external_write_read
   include 'mpif.h'
 
   integer, parameter :: nvals = 10
-  integer orig_vals1(nvals), restored_vals1(nvals)
+  integer(C_INT), target :: orig_vals1(nvals), restored_vals1(nvals)
   integer(C_INT), target :: orig_vals2(nvals), restored_vals2(nvals)
   integer my_rank, num_ranks, mpierr
   integer num_output, num_files
@@ -61,7 +61,7 @@ program spio_external_write_read
 
   ga = flds%create_group("a")
   gb = flds2%create_group("b")
-  
+
   view1 = ga%create_array_view("external_array", orig_vals1)
   view1 = gb%create_view("external_undescribed")
   call view1%set_external_data_ptr(c_loc(orig_vals2))

--- a/src/axom/sidre/tests/spio/F_spio_externalWriteRead.F
+++ b/src/axom/sidre/tests/spio/F_spio_externalWriteRead.F
@@ -61,7 +61,6 @@ program spio_external_write_read
 
   ga = flds%create_group("a")
   gb = flds2%create_group("b")
-
   view1 = ga%create_array_view("external_array", orig_vals1)
   view1 = gb%create_view("external_undescribed")
   call view1%set_external_data_ptr(c_loc(orig_vals2))

--- a/src/axom/slam/examples/lulesh2.0.3/CMakeLists.txt
+++ b/src/axom/slam/examples/lulesh2.0.3/CMakeLists.txt
@@ -43,6 +43,13 @@ blt_add_executable(
 
 if(AXOM_ENABLE_TESTS)
     if(ENABLE_MPI)
+
+        # CMake inserts Fortran flag that forces one OpenMP thread with MPI
+        # with xlf
+        if(ENABLE_FORTRAN)
+          list(REMOVE_ITEM CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES "xlomp_ser")
+        endif()
+
         axom_add_test(NAME        slam_lulesh
                       COMMAND     slam_lulesh_ex
                       NUM_MPI_TASKS   8
@@ -53,4 +60,3 @@ if(AXOM_ENABLE_TESTS)
                       NUM_OMP_THREADS 4 )
     endif()
 endif()
-

--- a/src/axom/slam/examples/lulesh2.0.3/CMakeLists.txt
+++ b/src/axom/slam/examples/lulesh2.0.3/CMakeLists.txt
@@ -44,8 +44,8 @@ blt_add_executable(
 if(AXOM_ENABLE_TESTS)
     if(ENABLE_MPI)
 
-        # CMake inserts Fortran flag that forces one OpenMP thread with MPI
-        # with xlf
+        # CMake inserts Fortran flag that forces one OpenMP thread when
+        # compiling with MPI and xlf
         if(ENABLE_FORTRAN)
           list(REMOVE_ITEM CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES "xlomp_ser")
         endif()

--- a/src/axom/slam/tests/slam_map_Map.cpp
+++ b/src/axom/slam/tests/slam_map_Map.cpp
@@ -349,8 +349,8 @@ void constructAndTestMapIteratorWithStride(int stride)
       EXPECT_EQ(*iter, static_cast<double>(idx * multFac));
       for(auto idx2 = 0; idx2 < iter.numComp(); ++idx2)
       {
-        EXPECT_EQ(iter(idx2),
-                  static_cast<double>(idx * multFac + idx2 * multFac2));
+        EXPECT_DOUBLE_EQ(iter(idx2),
+                         static_cast<double>(idx * multFac + idx2 * multFac2));
       }
       idx++;
     }


### PR DESCRIPTION
This PR:

- Adds a gcc@8.3.1 host-config with both openmp and cuda enabled.
- Relates to #520 

EDIT: 

- Adds openmp to the clang@8+xlf+cuda host-config