### PR TITLE
Convert slurm to flux on tioga

### DIFF
--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -19,7 +19,7 @@
 .src_build_on_tioga:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun -p pdebug -t 25 -N 1 "
+    ALLOC_COMMAND: "flux mini run --time-limit=25m --nodes=1"
     EXTRA_OPTIONS: "--test-serial"
   extends: [.src_build_script, .on_tioga, .src_workflow]
   needs: []
@@ -27,7 +27,7 @@
 .full_build_on_tioga:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun -p pbatch -t 60 -N 1 "
+    ALLOC_COMMAND: "flux mini run --time-limit=60m --nodes=1"
   extends: [.full_build_script, .on_tioga, .full_workflow]
   needs: []
 


### PR DESCRIPTION
This PR converts slurm command to flux on tioga (note: there are no partitions in flux, checked with `flux resource list` ).