### PR TITLE
Fixes misidentification for containment within `CurvedPolygon`s with nonconvex edges

### DIFF
--- a/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
+++ b/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
@@ -188,23 +188,23 @@ double adaptive_winding_number(const Point<T, 2>& q,
 
   Polygon<T, 2> controlPolygon(c.getControlPoints());
 
-  // If q is outside the control polygon, for an open Bezier curve, the winding
-  //  number for the shape connected at the endpoints with straight lines is zero.
-  //  We then subtract the contribution of this line segment.
-  if(!in_polygon(q, controlPolygon, true, false, EPS))
-    return 0.0 - linear_winding_number(q, c[0], c[ord], edge_tol);
-
   // Check if our new curve is convex.
   //  If so, all subcurves will be convex as well
   if(!isConvexControlPolygon)
     isConvexControlPolygon = is_convex(controlPolygon, EPS);
+  else // Formulas for winding number only work if shape is convex
+  {
+    // If q is outside the control polygon, for an open Bezier curve, the winding
+    //  number for the shape connected at the endpoints with straight lines is zero.
+    //  We then subtract the contribution of this line segment.
+    if(!in_polygon(q, controlPolygon, true, false, EPS))
+      return 0.0 - linear_winding_number(q, c[0], c[ord], edge_tol);
 
-  // If the query point is at either endpoint, use direct formula
-  //   Can only use formula if the control polygon is convex
-  if(isConvexControlPolygon &&
-     ((squared_distance(q, c[0]) <= edge_tol * edge_tol) ||
-      (squared_distance(q, c[ord]) <= edge_tol * edge_tol)))
-    return convex_endpoint_winding_number(q, c, edge_tol, EPS);
+    // If the query point is at either endpoint, use direct formula
+    if((squared_distance(q, c[0]) <= edge_tol * edge_tol) ||
+       (squared_distance(q, c[ord]) <= edge_tol * edge_tol))
+      return convex_endpoint_winding_number(q, c, edge_tol, EPS);
+  }
 
   // Recursively split curve until query is outside each control polygon
   BezierCurve<T, 2> c1, c2;

--- a/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
+++ b/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
@@ -190,7 +190,9 @@ double adaptive_winding_number(const Point<T, 2>& q,
   // Check if our new curve is convex.
   //  If so, all subcurves will be convex as well
   if(!isConvexControlPolygon)
+  {
     isConvexControlPolygon = is_convex(controlPolygon, EPS);
+  }
   else  // Formulas for winding number only work if shape is convex
   {
     // If q is outside the control polygon, for an open Bezier curve, the winding

--- a/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
+++ b/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
@@ -62,7 +62,7 @@ double linear_winding_number(const Point<T, 2>& q,
     -1.0,
     1.0);
 
-  return -0.5 * M_1_PI * acos(dotprod) * ((tri_area > 0) ? 1 : -1);
+  return 0.5 * M_1_PI * acos(dotprod) * ((tri_area > 0) ? 1 : -1);
 }
 
 /*!
@@ -184,7 +184,7 @@ double adaptive_winding_number(const Point<T, 2>& q,
 
   // Use linearity as base case for recursion
   if(c.isLinear(EPS))
-    return 0.0 - linear_winding_number(q, c[0], c[ord], edge_tol);
+    return linear_winding_number(q, c[0], c[ord], edge_tol);
 
   Polygon<T, 2> controlPolygon(c.getControlPoints());
 
@@ -198,7 +198,7 @@ double adaptive_winding_number(const Point<T, 2>& q,
     //  number for the shape connected at the endpoints with straight lines is zero.
     //  We then subtract the contribution of this line segment.
     if(!in_polygon(q, controlPolygon, true, false, EPS))
-      return 0.0 - linear_winding_number(q, c[0], c[ord], edge_tol);
+      return 0.0 - linear_winding_number(q, c[ord], c[0], edge_tol);
 
     // If the query point is at either endpoint, use direct formula
     if((squared_distance(q, c[0]) <= edge_tol * edge_tol) ||

--- a/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
+++ b/src/axom/primal/operators/detail/in_curved_polygon_impl.hpp
@@ -183,8 +183,7 @@ double adaptive_winding_number(const Point<T, 2>& q,
   if(ord <= 0) return 0.0;  // Catch degenerate cases
 
   // Use linearity as base case for recursion
-  if(c.isLinear(EPS))
-    return linear_winding_number(q, c[0], c[ord], edge_tol);
+  if(c.isLinear(EPS)) return linear_winding_number(q, c[0], c[ord], edge_tol);
 
   Polygon<T, 2> controlPolygon(c.getControlPoints());
 
@@ -192,7 +191,7 @@ double adaptive_winding_number(const Point<T, 2>& q,
   //  If so, all subcurves will be convex as well
   if(!isConvexControlPolygon)
     isConvexControlPolygon = is_convex(controlPolygon, EPS);
-  else // Formulas for winding number only work if shape is convex
+  else  // Formulas for winding number only work if shape is convex
   {
     // If q is outside the control polygon, for an open Bezier curve, the winding
     //  number for the shape connected at the endpoints with straight lines is zero.

--- a/src/axom/primal/tests/primal_winding_number.cpp
+++ b/src/axom/primal/tests/primal_winding_number.cpp
@@ -112,6 +112,18 @@ TEST(primal_winding_number, simple_cases)
       winding_number(Point2D({-0.352, 0.72 - edge_tol * 2}), top_curve, edge_tol, EPS),
     1,
     abs_tol);
+
+  // Test containment on non-convex shape, where the query point is outside 
+  //  the control polygon, but interior to the closed Bezier curve
+  Point2D cubic_loop_nodes[] = {Point2D {0.0, 0.0},
+                                Point2D {2.0, 1.0},
+                                Point2D {-1.0, 1.0},
+                                Point2D {1.0, 0.0}};
+  Bezier cubic_loop(cubic_loop_nodes, 3);
+
+  EXPECT_NEAR(winding_number(Point2D({0.4, 0.21}), cubic_loop, edge_tol, EPS),
+              -0.630526441742,
+              abs_tol);
 }
 
 TEST(primal_winding_number, closure_edge_cases)

--- a/src/axom/primal/tests/primal_winding_number.cpp
+++ b/src/axom/primal/tests/primal_winding_number.cpp
@@ -113,7 +113,7 @@ TEST(primal_winding_number, simple_cases)
     1,
     abs_tol);
 
-  // Test containment on non-convex shape, where the query point is outside 
+  // Test containment on non-convex shape, where the query point is outside
   //  the control polygon, but interior to the closed Bezier curve
   Point2D cubic_loop_nodes[] = {Point2D {0.0, 0.0},
                                 Point2D {2.0, 1.0},


### PR DESCRIPTION
This PR is a bugfix that fixes the behavior of `winding_number` with respect to nonconvex Bezier curve objects. We now require that the control polygon of a Bezier curve be convex before we can ensure our winding number formulations will be correct, which is enforced by repeated recursion until such a condition is met. Previously, there existed cases where a query point could be external to the control polygon, but still contained in the shape formed by closing the Bezier curve. A new test has been added in `primal_winding_number.cpp` to detect this incorrect behavior, and verify the correct behavior in this update.

Additionally, this PR addresses issue #907 by fixing the sign in the output of `linear_winding_number`, and adjusting signs in other areas of the winding number functionality to ensure consistency. This change is nonfunctional, but adds significant mathematical clarity.