### PR TITLE
Bugfix/gunney/inconsistent allocator distributed closest point

### DIFF
--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -1073,10 +1073,8 @@ public:
       auto it = bvh->getTraverser();
       const int rank = m_rank;
 
-      double* sqDistThresh =
-        axom::allocate<double>(1,
-                               axom::execution_space<ExecSpace>::allocatorID());
-      *sqDistThresh = m_sqDistanceThreshold;
+      auto sqDistThresh = axom::allocate<double>(1, m_allocatorID);
+      axom::copy(sqDistThresh, &m_sqDistanceThreshold, sizeof(m_sqDistanceThreshold));
 
       auto pointsView = m_points.view();
 

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -369,7 +369,9 @@ public:
     , m_mpiComm(MPI_COMM_NULL)
     , m_rank(-1)
     , m_nranks(-1)
+    , m_points(0, 0, allocatorID)
   {
+    SLIC_ASSERT(allocatorID != axom::INVALID_ALLOCATOR_ID);
     setAllocatorID(allocatorID);
 
     setMpiCommunicator(MPI_COMM_WORLD);
@@ -405,6 +407,11 @@ public:
     SLIC_ASSERT(allocatorID != axom::INVALID_ALLOCATOR_ID);
     // TODO: If appropriate, how to check for compatibility with runtime policy?
     m_allocatorID = allocatorID;
+    if(m_points.getAllocatorID() != m_allocatorID)
+    {
+      PointArray tmpPoints(m_points, m_allocatorID);
+      m_points.swap(tmpPoints);
+    }
   }
 
 public:
@@ -423,11 +430,9 @@ public:
     // TODO: Add error checking for children 'x', 'y' and 'z' and striding
 
     // Copy the data into the point array of primal points
-    PointArray pts(nPts, nPts);
+    m_points.resize(nPts);
     const std::size_t nbytes = sizeof(double) * DIM * nPts;
-    axom::copy(pts.data(), coords["x"].data_ptr(), nbytes);
-
-    m_points = PointArray(pts, m_allocatorID);  // copy point array to ExecSpace
+    axom::copy(m_points.data(), coords["x"].data_ptr(), nbytes);
   }
 
   /// Predicate to check if the BVH tree has been initialized

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -361,7 +361,9 @@ private:
   };
 
 public:
-  DistributedClosestPointImpl(RuntimePolicy runtimePolicy, int allocatorID, bool isVerbose)
+  DistributedClosestPointImpl(RuntimePolicy runtimePolicy,
+                              int allocatorID,
+                              bool isVerbose)
     : m_runtimePolicy(runtimePolicy)
     , m_isVerbose(isVerbose)
     , m_sqDistanceThreshold(std::numeric_limits<double>::max())
@@ -1074,7 +1076,9 @@ public:
       const int rank = m_rank;
 
       auto sqDistThresh = axom::allocate<double>(1, m_allocatorID);
-      axom::copy(sqDistThresh, &m_sqDistanceThreshold, sizeof(m_sqDistanceThreshold));
+      axom::copy(sqDistThresh,
+                 &m_sqDistanceThreshold,
+                 sizeof(m_sqDistanceThreshold));
 
       auto pointsView = m_points.view();
 
@@ -1304,19 +1308,23 @@ public:
 
     case RuntimePolicy::cuda:
 #ifdef _AXOM_DCP_USE_CUDA
-      defaultAllocatorID = axom::execution_space<axom::CUDA_EXEC<256>>::allocatorID();
+      defaultAllocatorID =
+        axom::execution_space<axom::CUDA_EXEC<256>>::allocatorID();
 #endif
       break;
 
     case RuntimePolicy::hip:
 #ifdef _AXOM_DCP_USE_HIP
-      defaultAllocatorID = axom::execution_space<axom::HIP_EXEC<256>>::allocatorID();
+      defaultAllocatorID =
+        axom::execution_space<axom::HIP_EXEC<256>>::allocatorID();
 #endif
       break;
     }
     if(defaultAllocatorID == axom::INVALID_ALLOCATOR_ID)
     {
-      SLIC_ERROR(axom::fmt::format("There is no default allocator for runtime policy {}", m_runtimePolicy));
+      SLIC_ERROR(
+        axom::fmt::format("There is no default allocator for runtime policy {}",
+                          m_runtimePolicy));
     }
     setAllocatorID(defaultAllocatorID);
   }

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -361,15 +361,16 @@ private:
   };
 
 public:
-  DistributedClosestPointImpl(RuntimePolicy runtimePolicy, bool isVerbose)
+  DistributedClosestPointImpl(RuntimePolicy runtimePolicy, int allocatorID, bool isVerbose)
     : m_runtimePolicy(runtimePolicy)
     , m_isVerbose(isVerbose)
     , m_sqDistanceThreshold(std::numeric_limits<double>::max())
+    , m_allocatorID(axom::INVALID_ALLOCATOR_ID)
     , m_mpiComm(MPI_COMM_NULL)
     , m_rank(-1)
     , m_nranks(-1)
   {
-    setDefaultAllocatorID();
+    setAllocatorID(allocatorID);
 
     setMpiCommunicator(MPI_COMM_WORLD);
   }
@@ -394,36 +395,6 @@ public:
     SLIC_ERROR_IF(sqThreshold < 0.0,
                   "Squared distance-threshold must be non-negative.");
     m_sqDistanceThreshold = sqThreshold;
-  }
-
-  /*!  @brief Sets the allocator ID to the default associated with the
-    execution policy
-  */
-  void setDefaultAllocatorID()
-  {
-    switch(m_runtimePolicy)
-    {
-    case RuntimePolicy::seq:
-      m_allocatorID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
-      break;
-    case RuntimePolicy::omp:
-#ifdef _AXOM_DCP_USE_OPENMP
-      m_allocatorID = axom::execution_space<axom::OMP_EXEC>::allocatorID();
-#endif
-      break;
-
-    case RuntimePolicy::cuda:
-#ifdef _AXOM_DCP_USE_CUDA
-      m_allocatorID = axom::execution_space<axom::CUDA_EXEC<256>>::allocatorID();
-#endif
-      break;
-
-    case RuntimePolicy::hip:
-#ifdef _AXOM_DCP_USE_HIP
-      m_allocatorID = axom::execution_space<axom::HIP_EXEC<256>>::allocatorID();
-#endif
-      break;
-    }
   }
 
   /*!  @brief Sets the allocator ID to the default associated with the
@@ -1210,7 +1181,7 @@ private:
 #ifdef _AXOM_DCP_USE_HIP
   std::unique_ptr<HipBVHTree> m_bvh_hip;
 #endif
-};
+};  // DistributedClosestPointImpl
 
 }  // namespace internal
 
@@ -1253,6 +1224,7 @@ public:
     : m_mpiComm(MPI_COMM_WORLD)
     , m_mpiCommIsPrivate(false)
   {
+    setDefaultAllocatorID();
     setMpiCommunicator(MPI_COMM_WORLD);
   }
 
@@ -1313,11 +1285,56 @@ public:
   /*!  @brief Sets the allocator ID to the default associated with the
     execution policy
   */
+  void setDefaultAllocatorID()
+  {
+    int defaultAllocatorID = axom::INVALID_ALLOCATOR_ID;
+    switch(m_runtimePolicy)
+    {
+    case RuntimePolicy::seq:
+      defaultAllocatorID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+      break;
+    case RuntimePolicy::omp:
+#ifdef _AXOM_DCP_USE_OPENMP
+      defaultAllocatorID = axom::execution_space<axom::OMP_EXEC>::allocatorID();
+#endif
+      break;
+
+    case RuntimePolicy::cuda:
+#ifdef _AXOM_DCP_USE_CUDA
+      defaultAllocatorID = axom::execution_space<axom::CUDA_EXEC<256>>::allocatorID();
+#endif
+      break;
+
+    case RuntimePolicy::hip:
+#ifdef _AXOM_DCP_USE_HIP
+      defaultAllocatorID = axom::execution_space<axom::HIP_EXEC<256>>::allocatorID();
+#endif
+      break;
+    }
+    if(defaultAllocatorID == axom::INVALID_ALLOCATOR_ID)
+    {
+      SLIC_ERROR(axom::fmt::format("There is no default allocator for runtime policy {}", m_runtimePolicy));
+    }
+    setAllocatorID(defaultAllocatorID);
+  }
+
+  /*!  @brief Sets the allocator ID to the default associated with the
+    execution policy
+  */
   void setAllocatorID(int allocatorID)
   {
     SLIC_ASSERT_MSG(allocatorID != axom::INVALID_ALLOCATOR_ID,
                     "Invalid allocator id.");
     m_allocatorID = allocatorID;
+
+    if(m_dcp_2 != nullptr)
+    {
+      m_dcp_2->setAllocatorID(m_allocatorID);
+    }
+    if(m_dcp_3 != nullptr)
+    {
+      m_dcp_3->setAllocatorID(m_allocatorID);
+    }
   }
 
   /**
@@ -1473,19 +1490,11 @@ public:
     switch(m_dimension)
     {
     case 2:
-      if(m_allocatorID != axom::INVALID_ALLOCATOR_ID)
-      {
-        m_dcp_2->setAllocatorID(m_allocatorID);
-      }
       m_dcp_2->setSquaredDistanceThreshold(m_sqDistanceThreshold);
       m_dcp_2->setMpiCommunicator(m_mpiComm);
       m_dcp_2->computeClosestPoints(query_node, coordset);
       break;
     case 3:
-      if(m_allocatorID != axom::INVALID_ALLOCATOR_ID)
-      {
-        m_dcp_3->setAllocatorID(m_allocatorID);
-      }
       m_dcp_3->setSquaredDistanceThreshold(m_sqDistanceThreshold);
       m_dcp_3->setMpiCommunicator(m_mpiComm);
       m_dcp_3->computeClosestPoints(query_node, coordset);
@@ -1503,12 +1512,14 @@ private:
     case 2:
       m_dcp_2 = std::make_unique<internal::DistributedClosestPointImpl<2>>(
         m_runtimePolicy,
+        m_allocatorID,
         m_isVerbose);
       m_objectMeshCreated = true;
       break;
     case 3:
       m_dcp_3 = std::make_unique<internal::DistributedClosestPointImpl<3>>(
         m_runtimePolicy,
+        m_allocatorID,
         m_isVerbose);
       m_objectMeshCreated = true;
       break;


### PR DESCRIPTION
# Fix unneeded copies across memory spaces in `DistributedClosestPoint`

Inconsistent allocator usage placed data in different memory spaces.  This requires copies that cause performance issues in `DistributedClosestPoint`.  We now use the same allocator on all the data used in the search operation.

- This PR is a bugfix
- It does the following:
  - Sets the custom allocator earlier in the set-up to ensure the allocator is used throughout the search.
  - Fixes a couple of places in `DistributedClosestPoint` where the default allocator was used instead of the custom allocator.
