### PR TITLE
Fix inconsistency in importConduitTreeExternal, and add test coverage

### DIFF
--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -2275,13 +2275,14 @@ bool Group::importConduitTreeExternal(conduit::Node& node, bool preserve_content
     while(itr.has_next())
     {
       Node& cld_node = itr.next();
-      std::string cld_name = itr.name();
+      std::string cld_name = m_is_list ? "" : itr.name();
       DataType cld_dtype = cld_node.dtype();
 
       if(cld_dtype.is_object() || cld_dtype.is_list())
       {
         // create group
-        Group* grp = createGroup(cld_name, cld_dtype.is_list());
+        Group* grp = m_is_list ? createUnnamedGroup(cld_dtype.is_list())
+                               : createGroup(cld_name, cld_dtype.is_list());
         success = grp->importConduitTreeExternal(cld_node, preserve_contents);
       }
       else if(cld_dtype.is_empty())


### PR DESCRIPTION
# Summary

- This PR is a fix for a code inconsistency, possibly a bug, and adds test coverage
- It does the following (modify list as needed):
  - Modifies Group::importConduitTreeExternal to make it handle lists with unnamed members the same way as importConduitTree. The two methods should construct their Sidre hierarchical representation of the Conduit input tree in the same way. I noticed this while preparing #937
  - Adds test coverage for importing Conduit lists using importConduitTreeExternal; nothing for this was existent.
