### PR TITLE
Various axom::Array changes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,16 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ## [Unreleased] - Release date yyyy-mm-dd
 
+### Added
+- Adds the following methods to `axom::Array` to conform more closely with the `std::vector` interface:
+  - `Array::front()`: returns a reference to the first element
+  - `Array::back()`: returns a reference to the last element
+  - `Array::resize(size, T value)`: resizes the array, and sets any new elements to `value`.
+- Adds an `ArrayView::empty()` method to return whether the view is empty or not.
+
+### Changed
+- `axom::Array` move constructors are now `noexcept`.
+
 ## [Version 0.7.0] - Release date 2022-08-30
 
 ###  Added

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -632,6 +632,42 @@ public:
   ConstArrayIterator end() const { return ConstArrayIterator(size(), this); }
 
   /*!
+   * \brief Returns a reference to the first element in the Array.
+   *
+   * \pre array.empty() == false
+   */
+  T& front()
+  {
+    assert(!empty());
+    return *begin();
+  }
+
+  /// \overload
+  const T& front() const
+  {
+    assert(!empty());
+    return *begin();
+  }
+
+  /*!
+   * \brief Returns a reference to the last element in the Array.
+   *
+   * \pre array.size() > 0
+   */
+  T& back()
+  {
+    assert(!empty());
+    return *(end() - 1);
+  }
+
+  /// \overload
+  const T& back() const
+  {
+    assert(!empty());
+    return *(end() - 1);
+  }
+
+  /*!
    * \brief Shrink the capacity to be equal to the size.
    */
   void shrink() { setCapacity(m_num_elements); }

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -200,7 +200,7 @@ public:
   /*! 
    * \brief Move constructor for an Array instance 
    */
-  Array(Array&& other);
+  Array(Array&& other) noexcept;
 
   /*!
    * \brief Constructor for transferring between memory spaces
@@ -278,7 +278,7 @@ public:
   /*! 
    * \brief Move assignment operator for Array
    */
-  Array& operator=(Array&& other)
+  Array& operator=(Array&& other) noexcept
   {
     if(this != &other)
     {
@@ -924,7 +924,7 @@ Array<T, DIM, SPACE>::Array(const Array& other)
 
 //------------------------------------------------------------------------------
 template <typename T, int DIM, MemorySpace SPACE>
-Array<T, DIM, SPACE>::Array(Array&& other)
+Array<T, DIM, SPACE>::Array(Array&& other) noexcept
   : ArrayBase<T, DIM, Array<T, DIM, SPACE>>(
       static_cast<ArrayBase<T, DIM, Array<T, DIM, SPACE>>&&>(std::move(other)))
   , m_resize_ratio(0.0)

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -704,10 +704,6 @@ public:
   template <typename... Args, typename Enable = std::enable_if_t<sizeof...(Args) == DIM>>
   void resize(ArrayOptions::Uninitialized, Args... args)
   {
-    static_assert(std::is_default_constructible<T>::value,
-                  "Cannot call Array<T>::resize() when T is non-trivially-"
-                  "constructible. Use Array<T>::reserve() and emplace_back()"
-                  "instead.");
     const StackArray<IndexType, DIM> dims {static_cast<IndexType>(args)...};
     resize(dims, false);
   }

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -689,11 +689,9 @@ public:
    *
    * \note Reallocation is done if the new size will exceed the capacity.
    */
-  template <typename... Args>
+  template <typename... Args, typename Enable = std::enable_if_t<sizeof...(Args) == DIM>>
   void resize(Args... args)
   {
-    static_assert(sizeof...(Args) == DIM,
-                  "Array size must match number of dimensions");
     static_assert(std::is_default_constructible<T>::value,
                   "Cannot call Array<T>::resize() when T is non-trivially-"
                   "constructible. Use Array<T>::reserve() and emplace_back()"
@@ -703,11 +701,9 @@ public:
   }
 
   /// \overload
-  template <typename... Args>
+  template <typename... Args, typename Enable = std::enable_if_t<sizeof...(Args) == DIM>>
   void resize(ArrayOptions::Uninitialized, Args... args)
   {
-    static_assert(sizeof...(Args) == DIM,
-                  "Array size must match number of dimensions");
     static_assert(std::is_default_constructible<T>::value,
                   "Cannot call Array<T>::resize() when T is non-trivially-"
                   "constructible. Use Array<T>::reserve() and emplace_back()"

--- a/src/axom/core/ArrayView.hpp
+++ b/src/axom/core/ArrayView.hpp
@@ -96,6 +96,11 @@ public:
   inline AXOM_HOST_DEVICE IndexType size() const { return m_num_elements; }
 
   /*!
+   * \brief Returns true iff the ArrayView stores no elements.
+   */
+  bool empty() const { return m_num_elements == 0; }
+
+  /*!
    * \brief Returns an ArrayViewIterator to the first element of the Array
    */
   AXOM_HOST_DEVICE
@@ -191,7 +196,14 @@ AXOM_HOST_DEVICE ArrayView<T, DIM, SPACE>::ArrayView(
                 "T must be const if memory space is Constant memory");
 #endif
   // Intel hits internal compiler error when casting as part of function call
-  m_num_elements = detail::packProduct(shape.m_data);
+  if(data != nullptr)
+  {
+    m_num_elements = detail::packProduct(shape.m_data);
+  }
+  else
+  {
+    m_num_elements = 0;
+  }
 
 #if !defined(AXOM_DEVICE_CODE) && defined(AXOM_USE_UMPIRE)
   // If we have Umpire, we can try and see what space the pointer is allocated in

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -556,6 +556,7 @@ void check_insert_iterator(Array<T>& v)
     capacity = calc_new_capacity(v, 1);
     typename axom::Array<T>::ArrayIterator ret3 = v.insert(v.begin(), 1, i);
     EXPECT_EQ(ret3, v.begin());
+    EXPECT_EQ(i, v.front());
     size++;
   }
 
@@ -641,6 +642,7 @@ void check_emplace(Array<T>& v)
     capacity = calc_new_capacity(v, 1);
     typename axom::Array<T>::ArrayIterator ret3 = v.emplace(v.begin(), i);
     EXPECT_EQ(ret3, v.begin());
+    EXPECT_EQ(i, v.front());
     size++;
   }
 
@@ -1235,7 +1237,9 @@ TEST(core_array, checkIterator)
   }
 
   EXPECT_EQ(*v_int.begin(), 0);
+  EXPECT_EQ(v_int.front(), 0);
   EXPECT_EQ(*(v_int.end() - 1), SIZE - 1);
+  EXPECT_EQ(v_int.back(), SIZE - 1);
   EXPECT_EQ(v_int.size(), SIZE);
 
   /* Erase nothing */
@@ -1251,7 +1255,9 @@ TEST(core_array, checkIterator)
 
   EXPECT_EQ(ret2, v_int.begin());
   EXPECT_EQ(*v_int.begin(), SIZE / 2);
+  EXPECT_EQ(v_int.front(), SIZE / 2);
   EXPECT_EQ(*(v_int.end() - 1), SIZE - 1);
+  EXPECT_EQ(v_int.back(), SIZE - 1);
   EXPECT_EQ(v_int.size(), SIZE / 2);
 
   /* Erase first, last elements */
@@ -1259,11 +1265,13 @@ TEST(core_array, checkIterator)
 
   EXPECT_EQ(ret3, v_int.begin());
   EXPECT_EQ(*v_int.begin(), SIZE / 2 + 1);
+  EXPECT_EQ(v_int.front(), SIZE / 2 + 1);
 
   axom::Array<int>::ArrayIterator ret4 = v_int.erase(v_int.end() - 1);
 
   EXPECT_EQ(ret4, v_int.end());
   EXPECT_EQ(*(v_int.end() - 1), SIZE - 2);
+  EXPECT_EQ(v_int.back(), SIZE - 2);
 
   /* Clear the rest of the array */
   v_int.clear();

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -110,6 +110,7 @@ AXOM_TYPED_TEST(core_array_for_all, auto_ArrayView)
 
   // Modify array using lambda and ArrayView
   auto arr_view = arr.view();
+  EXPECT_FALSE(arr_view.empty());
   axom::for_all<ExecSpace>(
     N,
     AXOM_LAMBDA(axom::IndexType idx) { arr_view[idx] = N - idx; });
@@ -126,6 +127,11 @@ AXOM_TYPED_TEST(core_array_for_all, auto_ArrayView)
   {
     EXPECT_EQ(localArr[i], N - i);
   }
+
+  // Empty the array and create a view from it. ArrayView::empty() should return true.
+  arr.clear();
+  auto empty_view = arr.view();
+  EXPECT_TRUE(empty_view.empty());
 }
 
 //------------------------------------------------------------------------------
@@ -149,6 +155,7 @@ AXOM_TYPED_TEST(core_array_for_all, auto_ArrayView_const)
   // Then copy it over to the device
   KernelArray kernelSource = source;
   auto kernelSourceView = kernelSource.view();
+  EXPECT_FALSE(kernelSourceView.empty());
 
   // First, modify array using lambda and KernelArray::ArrayView operator[] const
   auto arrData = arr.data();
@@ -177,6 +184,7 @@ AXOM_TYPED_TEST(core_array_for_all, auto_ArrayView_const)
 
   const KernelArray& kernelSourceCref = kernelSource;
   auto kernelSourceConstView = kernelSourceCref.view();
+  EXPECT_FALSE(kernelSourceConstView.empty());
 
   axom::for_all<ExecSpace>(
     N,
@@ -196,6 +204,11 @@ AXOM_TYPED_TEST(core_array_for_all, auto_ArrayView_const)
   {
     EXPECT_EQ(localArr[i], N - i);
   }
+
+  // Empty the array and create a view from it. ArrayView::empty() should return true.
+  arr.clear();
+  auto empty_view = arr.view();
+  EXPECT_TRUE(empty_view.empty());
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

- Adds `Array::front()`, `Array::back()` methods, and `Array::resize(size, value)` overload to more closely conform with `std::vector` API
- Adds `ArrayView::empty()` method to match `std::span`
- Makes `Array` move constructors noexcept