### PR TITLE
Use service user for gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 
 variables:
+  LLNL_SERVICE_USER: atk
   GIT_SUBMODULE_STRATEGY: recursive
   PROJECT_ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   BUILD_ROOT: ${CI_PROJECT_DIR}


### PR DESCRIPTION
Without this the dedicated ci allocation won't work for retries through the UI.  We should move to this anyways.