### PR TITLE
Document call-back functors for traversing BVH

### DIFF
--- a/src/axom/spin/internal/linear_bvh/bvh_traverse.hpp
+++ b/src/axom/spin/internal/linear_bvh/bvh_traverse.hpp
@@ -58,6 +58,10 @@ inline bool leaf_node(const int32& nodeIdx) { return (nodeIdx < 0); }
  * \note Moreover, the functor `B` returns a boolean status that indicates
  *  if the specified traversal predicate is satisfied.
  *
+ * \note Functors A, B and Comp may access only memory available in
+ * the execution space.  For example, GPU execution may access only
+ * device and unified memory.
+ *
  */
 template <int NDIMS,
           typename FloatType,

--- a/src/axom/spin/policy/LinearBVH.hpp
+++ b/src/axom/spin/policy/LinearBVH.hpp
@@ -36,6 +36,24 @@ namespace policy
 {
 namespace lbvh = internal::linear_bvh;
 
+/*
+ * \brief Interface for traversing a BVH tree.
+ *
+ * \brief Traverse a tree to perform user-specified actions at the
+ * leaves, while limiting the search to branches satisfying a
+ * user-provided predicate.
+ *
+ * To a initiate traversals, use traverse_tree.  It requires
+ * -# an action functor to call at the leaves,
+ * -# a predicate functor to decide whether to descend a branch and
+ * -# some data to pass to the functors
+ *
+ * Both functors should only access memory that's available to the
+ * execution space.  For example, GPU execution should access only
+ * device and unified memory.
+ *
+ * \see internal::linear_bvh::bvh_traverse
+ */
 template <typename FloatType, int NDIMS>
 class LinearBVHTraverser
 {
@@ -71,6 +89,11 @@ public:
                        traversePref);
   }
 
+  /*
+   * Functors lf and predicate should access only memory compatible
+   * with the execution space.  For example, GPU execution should access
+   * only device and unified memory.
+   */
   template <typename Primitive, typename LeafAction, typename Predicate>
   AXOM_HOST_DEVICE void traverse_tree(const Primitive& p,
                                       LeafAction&& lf,

--- a/src/axom/spin/policy/LinearBVH.hpp
+++ b/src/axom/spin/policy/LinearBVH.hpp
@@ -43,7 +43,7 @@ namespace lbvh = internal::linear_bvh;
  * leaves, while limiting the search to branches satisfying a
  * user-provided predicate.
  *
- * To a initiate traversals, use traverse_tree.  It requires
+ * To initiate traversals, use \a traverse_tree.  It requires
  * -# an action functor to call at the leaves,
  * -# a predicate functor to decide whether to descend a branch and
  * -# some data to pass to the functors
@@ -90,7 +90,7 @@ public:
   }
 
   /*
-   * Functors lf and predicate should access only memory compatible
+   * Functors \a lf and \a predicate should access only memory compatible
    * with the execution space.  For example, GPU execution should access
    * only device and unified memory.
    */


### PR DESCRIPTION
Add documentations for public interfaces and mention that call-back functors should use memory available in their execution environment.

# Summary

- This PR is a source-code documentation update

- It does the following (modify list as needed):
  - Add documentation about the call-backs used in BVH tree traversals.
  - State that the call-backs should only access memory available in the execution space of the traversal code.

The BVH code is factored to several files.  We've mentioned a similar requirement for data to initialize the BVH class.  But we lack similar documentations on the call-back functions used in the tree traverser class.