### PR TITLE
Local PR for #960

### DIFF
--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -96,6 +96,8 @@ target_include_directories(fmt SYSTEM INTERFACE
 target_include_directories(fmt INTERFACE 
             $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include> )
 
+set_target_properties(fmt PROPERTIES EXPORT_NAME axom::fmt)
+
 # Setup some variables for fmt in Axom's config.hpp
 set(AXOM_FMT_EXCEPTIONS FALSE PARENT_SCOPE)
 set(AXOM_FMT_HEADER_ONLY TRUE PARENT_SCOPE)


### PR DESCRIPTION
sets EXPORT_NAME of the fmt target to axom::fmt to avoid conflicts in external projects consuming both axom and fmt

resolves https://github.com/LLNL/axom/issues/959