### PR TITLE
Use libstdc++ 8 with XL compilers on blueos

### DIFF
--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1.1.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1.1.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
 
 else()
 
@@ -75,7 +75,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/clang-10.0.1.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/clang-10.0.1.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1.2_cuda.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1.2_cuda.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
 
 else()
 
@@ -99,7 +99,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/clang-10.0.1.2" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/clang-10.0.1.2" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 
@@ -109,7 +109,7 @@ set(MFEM_DIR "${TPL_ROOT}/mfem-4.4.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
 
-set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
+set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
 
 set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-gcc@8.3.1.1.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-gcc@8.3.1.1.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/gcc/g++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
 
 else()
 
@@ -67,7 +67,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/gcc-8.3.1.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/gcc-8.3.1.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 
@@ -77,7 +77,7 @@ set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
 
-set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
+set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
 
 set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-gcc@8.3.1.2_cuda.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-gcc@8.3.1.2_cuda.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/gcc/g++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
 
 else()
 
@@ -91,7 +91,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/gcc-8.3.1.2" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/gcc-8.3.1.2" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 
@@ -101,7 +101,7 @@ set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
 
-set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
+set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
 
 set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1.1.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1.1.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/xl/xlc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/xl/xlc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
 
 else()
 
@@ -26,6 +26,12 @@ else()
   set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2022.08.19/bin/xlf2003" CACHE PATH "")
 
 endif()
+
+set(CMAKE_C_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" CACHE STRING "")
+
+set(CMAKE_CXX_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" CACHE STRING "")
+
+set(CMAKE_Fortran_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" CACHE STRING "")
 
 set(ENABLE_FORTRAN ON CACHE BOOL "")
 
@@ -73,7 +79,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/xl-16.1.1.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/xl-16.1.1.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 
@@ -83,7 +89,7 @@ set(MFEM_DIR "${TPL_ROOT}/mfem-4.4.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
 
-set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
+set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
 
 set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1.2_cuda.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1.2_cuda.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/xl/xlc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/xl/xlc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
 
 else()
 
@@ -26,6 +26,12 @@ else()
   set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2022.08.19-cuda-11.2.0/bin/xlf2003" CACHE PATH "")
 
 endif()
+
+set(CMAKE_C_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" CACHE STRING "")
+
+set(CMAKE_CXX_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" CACHE STRING "")
+
+set(CMAKE_Fortran_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" CACHE STRING "")
 
 set(ENABLE_FORTRAN ON CACHE BOOL "")
 
@@ -69,7 +75,7 @@ set(AXOM_ENABLE_ANNOTATIONS ON CACHE BOOL "")
 
 set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
 
-set(CMAKE_CUDA_FLAGS "-restrict --expt-extended-lambda -arch sm_${CMAKE_CUDA_ARCHITECTURES} " CACHE STRING "")
+set(CMAKE_CUDA_FLAGS "-restrict --expt-extended-lambda -Xcompiler=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -arch sm_${CMAKE_CUDA_ARCHITECTURES} " CACHE STRING "")
 
 # nvcc does not like gtest's 'pthreads' flag
 
@@ -97,7 +103,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/xl-16.1.1.2" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/xl-16.1.1.2" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 
@@ -107,7 +113,7 @@ set(MFEM_DIR "${TPL_ROOT}/mfem-4.4.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
 
-set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_19_47/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
+set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_30_45/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
 
 set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@10.0.1.1.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@10.0.1.1.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
 
 else()
 
@@ -75,7 +75,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/clang-10.0.1.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/clang-10.0.1.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@10.0.1.2_cuda.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@10.0.1.2_cuda.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
 
 else()
 
@@ -99,7 +99,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/clang-10.0.1.2" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/clang-10.0.1.2" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 
@@ -109,7 +109,7 @@ set(MFEM_DIR "${TPL_ROOT}/mfem-4.4.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
 
-set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
+set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
 
 set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@8.3.1.1.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@8.3.1.1.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/gcc/g++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
 
 else()
 
@@ -67,7 +67,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/gcc-8.3.1.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/gcc-8.3.1.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 
@@ -77,7 +77,7 @@ set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
 
-set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
+set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
 
 set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@8.3.1.2_cuda.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@8.3.1.2_cuda.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/gcc/g++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
 
 else()
 
@@ -91,7 +91,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/gcc-8.3.1.2" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/gcc-8.3.1.2" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 
@@ -101,7 +101,7 @@ set(C2C_DIR "${TPL_ROOT}/c2c-1.3.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
 
-set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
+set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
 
 set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1.1.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1.1.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/xl/xlc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/xl/xlc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
 
 else()
 
@@ -26,6 +26,12 @@ else()
   set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2022.08.19/bin/xlf2003" CACHE PATH "")
 
 endif()
+
+set(CMAKE_C_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" CACHE STRING "")
+
+set(CMAKE_CXX_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" CACHE STRING "")
+
+set(CMAKE_Fortran_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" CACHE STRING "")
 
 set(ENABLE_FORTRAN ON CACHE BOOL "")
 
@@ -73,7 +79,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/xl-16.1.1.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/xl-16.1.1.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 
@@ -83,7 +89,7 @@ set(MFEM_DIR "${TPL_ROOT}/mfem-4.4.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
 
-set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
+set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
 
 set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1.2_cuda.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1.2_cuda.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/xl/xlc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/xl/xlc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/xl/xlc++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/spack/lib/spack/env/xl/xlf90" CACHE PATH "")
 
 else()
 
@@ -26,6 +26,12 @@ else()
   set(CMAKE_Fortran_COMPILER "/usr/tce/packages/xl/xl-2022.08.19-cuda-11.2.0/bin/xlf2003" CACHE PATH "")
 
 endif()
+
+set(CMAKE_C_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" CACHE STRING "")
+
+set(CMAKE_CXX_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" CACHE STRING "")
+
+set(CMAKE_Fortran_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" CACHE STRING "")
 
 set(ENABLE_FORTRAN ON CACHE BOOL "")
 
@@ -69,7 +75,7 @@ set(AXOM_ENABLE_ANNOTATIONS ON CACHE BOOL "")
 
 set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
 
-set(CMAKE_CUDA_FLAGS "-restrict --expt-extended-lambda -arch sm_${CMAKE_CUDA_ARCHITECTURES} " CACHE STRING "")
+set(CMAKE_CUDA_FLAGS "-restrict --expt-extended-lambda -Xcompiler=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -arch sm_${CMAKE_CUDA_ARCHITECTURES} " CACHE STRING "")
 
 # nvcc does not like gtest's 'pthreads' flag
 
@@ -97,7 +103,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/xl-16.1.1.2" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/xl-16.1.1.2" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 
@@ -107,7 +113,7 @@ set(MFEM_DIR "${TPL_ROOT}/mfem-4.4.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
 
-set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_11_09_10_58_09/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
+set(LUA_DIR "/usr/WS1/axom/libs/blueos_3_ppc64le_ib_p9/2022_12_01_14_11_21/clang-10.0.1.1/lua-5.4.4" CACHE PATH "")
 
 set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
 

--- a/scripts/spack/configs/blueos_3_ppc64le_ib_p9/compilers.yaml
+++ b/scripts/spack/configs/blueos_3_ppc64le_ib_p9/compilers.yaml
@@ -58,7 +58,10 @@ compilers:
 - compiler:
     environment: {}
     extra_rpaths: []
-    flags: {}
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
     modules: []
     operating_system: rhel7
     paths:
@@ -71,7 +74,10 @@ compilers:
 - compiler:
     environment: {}
     extra_rpaths: []
-    flags: {}
+    flags:
+      cflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      cxxflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
+      fflags: --gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1
     modules: []
     operating_system: rhel7
     paths:

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -244,7 +244,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
             # Pass through any cxxflags to the host compiler via nvcc's Xcompiler flag
             host_cxx_flags = spec.compiler_flags['cxxflags']
-            cudaflags += ' '.join(['-Xcompiler=%s' % flag for flag in host_cxx_flags])
+            cudaflags += ' '.join(['-Xcompiler=%s ' % flag for flag in host_cxx_flags])
 
             if not spec.satisfies("cuda_arch=none"):
                 cuda_arch = spec.variants["cuda_arch"].value[0]

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -242,6 +242,10 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             # CUDA_FLAGS
             cudaflags = "-restrict --expt-extended-lambda "
 
+            # Pass through any cxxflags to the host compiler via nvcc's Xcompiler flag
+            host_cxx_flags = spec.compiler_flags['cxxflags']
+            cudaflags += ' '.join(['-Xcompiler=%s' % flag for flag in host_cxx_flags])
+
             if not spec.satisfies("cuda_arch=none"):
                 cuda_arch = spec.variants["cuda_arch"].value[0]
                 entries.append(cmake_cache_string("CMAKE_CUDA_ARCHITECTURES", cuda_arch))

--- a/scripts/spack/packages/mfem/package.py
+++ b/scripts/spack/packages/mfem/package.py
@@ -493,7 +493,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             'MFEM_MPIEXEC=%s' % mfem_mpiexec,
             'MFEM_MPIEXEC_NP=%s' % mfem_mpiexec_np]
 
-        cxxflags = spec.compiler_flags['cxxflags']
+        cxxflags = spec.compiler_flags['cxxflags'][:]
 
         if cxxflags:
             # Add opt/debug flags if they are not present in global cxx flags


### PR DESCRIPTION
Updates the XL compilers to use the GCC 8.3.1 toolchain on blueos.

Also:
- modifies the Axom Spack package to pass through C++ compiler flags to the host compiler when using NVCC
- fixes an issue with the MFEM Spack package when C++ compiler flags are present in the compiler spec