### PR TITLE
Document behavior when a non-existent Attribute is looked up.

### DIFF
--- a/src/axom/sidre/core/Array.hpp
+++ b/src/axom/sidre/core/Array.hpp
@@ -97,7 +97,7 @@ inline IndexType getViewShapeImpl<2>(int dim, const View* view)
  *
  *  Objects of the sidre::Array class may be constructed from a View.
  *  All array operations can be performed as with the base
- *  axom::utilities::Array class.  The size of the Array can grow as needed,
+ *  axom::Array class.  The size of the Array can grow as needed,
  *  and all memory management is delegated to Sidre.
  *
  *  \note When the Array object is deleted, it does not delete the associated

--- a/src/axom/sidre/core/AttrValues.hpp
+++ b/src/axom/sidre/core/AttrValues.hpp
@@ -90,6 +90,8 @@ private:
    * Create vector of Nodes and push empty nodes up to attr's index.
    * Called as part of View::createAttributeScalar and
    * View::createAttributeString.
+   *
+   * \return true
    */
   bool createNode(IndexType idx);
 

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -929,12 +929,24 @@ public:
   //@{
   //!  @name Attribute Value query and accessor methods
 
+  /*!
+   * \return the index-specified Attribute, or nullptr if it doesn't exist.
+   */
   Attribute* getAttribute(IndexType idx);
 
+  /*!
+   * \return the index-specified Attribute, or nullptr if it doesn't exist.
+   */
   const Attribute* getAttribute(IndexType idx) const;
 
+  /*!
+   * \return the name-specified Attribute, or nullptr if it doesn't exist.
+   */
   Attribute* getAttribute(const std::string& name);
 
+  /*!
+   * \return the name-specified Attribute, or nullptr if it doesn't exist.
+   */
   const Attribute* getAttribute(const std::string& name) const;
 
   /*!
@@ -1052,6 +1064,8 @@ public:
 
   /*!
    * \brief Set Attribute for a View from Attribute index.
+   *
+   * If no such Attribute exists, this is a no-op.
    */
   bool setAttributeString(IndexType indx, const std::string& value);
 
@@ -1164,6 +1178,8 @@ public:
    * \brief Return a string attribute from the Attribute index.
    *
    * If the value has not been explicitly set, return the current default.
+   *
+   * \return The Attribute name, or nullptr if no such Attribute.
    */
   const char* getAttributeString(IndexType idx) const;
 
@@ -1171,6 +1187,8 @@ public:
    * \brief Return a string attribute from the Attribute name.
    *
    * If the value has not been explicitly set, return the current default.
+   *
+   * \return The Attribute name, or nullptr if no such Attribute.
    */
   const char* getAttributeString(const std::string& name) const;
 
@@ -1178,6 +1196,8 @@ public:
    * \brief Return a string attribute from the Attribute pointer.
    *
    * If the value has not been explicitly set, return the current default.
+   *
+   * \return The Attribute name, or nullptr if no such Attribute.
    */
   const char* getAttributeString(const Attribute* attr) const;
 
@@ -1185,6 +1205,8 @@ public:
    * \brief Return reference to attribute node from Attribute index.
    *
    * If the value has not been explicitly set, return the current default.
+   *
+   * \return The Attribute Node, or an empty Node if no such Attribute.
    */
   const Node& getAttributeNodeRef(IndexType idx) const
   {
@@ -1196,6 +1218,8 @@ public:
    * \brief Return reference to attribute node from Attribute name.
    *
    * If the value has not been explicitly set, return the current default.
+   *
+   * \return The Attribute Node, or an empty Node if no such Attribute.
    */
   const Node& getAttributeNodeRef(const std::string& name) const
   {
@@ -1207,6 +1231,8 @@ public:
    * \brief Return reference to attribute node from Attribute pointer.
    *
    * If the value has not been explicitly set, return the current default.
+   *
+   * \return The Attribute Node, or an empty Node if no such Attribute.
    */
   const Node& getAttributeNodeRef(const Attribute* attr) const
   {

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -930,22 +930,26 @@ public:
   //!  @name Attribute Value query and accessor methods
 
   /*!
-   * \return the index-specified Attribute, or nullptr if it doesn't exist.
+   * \brief Get an Attribute.
+   *
+   * \param [in] idx Attribute identifier.
+   *
+   * \return the specified Attribute, or nullptr if it doesn't exist.
    */
   Attribute* getAttribute(IndexType idx);
 
   /*!
-   * \return the index-specified Attribute, or nullptr if it doesn't exist.
+   * \overload
    */
   const Attribute* getAttribute(IndexType idx) const;
 
   /*!
-   * \return the name-specified Attribute, or nullptr if it doesn't exist.
+   * \overload
    */
   Attribute* getAttribute(const std::string& name);
 
   /*!
-   * \return the name-specified Attribute, or nullptr if it doesn't exist.
+   * \overload
    */
   const Attribute* getAttribute(const std::string& name) const;
 
@@ -980,7 +984,8 @@ public:
   }
 
   /*!
-   * \brief Set Attribute to its default value from Attribute index.
+   * \brief Set Attribute to its default value.
+   * \param [in] idx Attribute identifier
    *
    * This causes hasAttributeValue to return false for the attribute.
    */
@@ -991,9 +996,7 @@ public:
   }
 
   /*!
-   * \brief Set Attribute to its default value from Attribute name.
-   *
-   * This causes hasAttributeValue to return false for the attribute.
+   * \overload
    */
   bool setAttributeToDefault(const std::string& name)
   {
@@ -1002,9 +1005,7 @@ public:
   }
 
   /*!
-   * \brief Set Attribute to its default value from Attribute pointer.
-   *
-   * This causes hasAttributeValue to return false for the attribute.
+   * \overload
    */
   bool setAttributeToDefault(const Attribute* attr)
   {
@@ -1016,7 +1017,11 @@ public:
   }
 
   /*!
-   * \brief Set Attribute for a View from Attribute index.
+   * \brief Set Attribute to a scalar value.
+   * \param [in] idx Attribute identifier
+   * \param [in] value Value of Attribute
+   *
+   * If no such Attribute exists, this is a no-op.
    */
   template <typename ScalarType>
   bool setAttributeScalar(IndexType idx, ScalarType value)
@@ -1031,7 +1036,7 @@ public:
   }
 
   /*!
-   * \brief Set Attribute for a View from Attribute name.
+   * \overload
    */
   template <typename ScalarType>
   bool setAttributeScalar(const std::string& name, ScalarType value)
@@ -1046,7 +1051,7 @@ public:
   }
 
   /*!
-   * \brief Set Attribute for a View from Attribute pointer.
+   * \overload
    */
   template <typename ScalarType>
   bool setAttributeScalar(const Attribute* attr, ScalarType value)
@@ -1063,24 +1068,29 @@ public:
   }
 
   /*!
-   * \brief Set Attribute for a View from Attribute index.
+   * \brief Set Attribute to a string value.
+   * \param [in] indx Attribute identifier.
+   * \param [in] value Value of attribute.
    *
    * If no such Attribute exists, this is a no-op.
    */
   bool setAttributeString(IndexType indx, const std::string& value);
 
   /*!
-   * \brief Set Attribute for a View from Attribute name.
+   * \overload
    */
   bool setAttributeString(const std::string& name, const std::string& value);
 
   /*!
-   * \brief Set Attribute for a View from Attribute pointer.
+   * \overload
    */
   bool setAttributeString(const Attribute* attr, const std::string& value);
 
   /*!
-   * \brief Return scalar attribute value from Attribute indx.
+   * \brief Return scalar Attribute value.
+   * \param [in] idx Attribute identifier.
+   *
+   * If no such Attribute exists, return empty scalar value.
    */
   Node::ConstValue getAttributeScalar(IndexType idx) const
   {
@@ -1094,7 +1104,7 @@ public:
   }
 
   /*!
-   * \brief Return scalar attribute value from Attribute name.
+   * \overload
    */
   Node::ConstValue getAttributeScalar(const std::string& name) const
   {
@@ -1108,7 +1118,7 @@ public:
   }
 
   /*!
-   * \brief Return scalar attribute value from Attribute pointer.
+   * \overload
    */
   Node::ConstValue getAttributeScalar(const Attribute* attr) const
   {
@@ -1175,7 +1185,8 @@ public:
   }
 
   /*!
-   * \brief Return a string attribute from the Attribute index.
+   * \brief Return a string attribute.
+   * \param [in] idx Attribute identifer.
    *
    * If the value has not been explicitly set, return the current default.
    *
@@ -1184,25 +1195,18 @@ public:
   const char* getAttributeString(IndexType idx) const;
 
   /*!
-   * \brief Return a string attribute from the Attribute name.
-   *
-   * If the value has not been explicitly set, return the current default.
-   *
-   * \return The Attribute name, or nullptr if no such Attribute.
+   * \overload
    */
   const char* getAttributeString(const std::string& name) const;
 
   /*!
-   * \brief Return a string attribute from the Attribute pointer.
-   *
-   * If the value has not been explicitly set, return the current default.
-   *
-   * \return The Attribute name, or nullptr if no such Attribute.
+   * \overload
    */
   const char* getAttributeString(const Attribute* attr) const;
 
   /*!
-   * \brief Return reference to attribute node from Attribute index.
+   * \brief Return reference to an Attribute node.
+   * \param [in] idx Attribute identifier
    *
    * If the value has not been explicitly set, return the current default.
    *
@@ -1215,11 +1219,7 @@ public:
   }
 
   /*!
-   * \brief Return reference to attribute node from Attribute name.
-   *
-   * If the value has not been explicitly set, return the current default.
-   *
-   * \return The Attribute Node, or an empty Node if no such Attribute.
+   * \overload
    */
   const Node& getAttributeNodeRef(const std::string& name) const
   {
@@ -1228,11 +1228,7 @@ public:
   }
 
   /*!
-   * \brief Return reference to attribute node from Attribute pointer.
-   *
-   * If the value has not been explicitly set, return the current default.
-   *
-   * \return The Attribute Node, or an empty Node if no such Attribute.
+   * \overload
    */
   const Node& getAttributeNodeRef(const Attribute* attr) const
   {


### PR DESCRIPTION
# Document behavior when a non-existent Attribute is looked up.

- This PR adds documentation
- It does the following (modify list as needed):
  - Add "\return" comments for `View` methods that look up `Attribute`s.

Attribute look-ups return nullptr and Attribute-setting methods are no-ops when there's no such `Attribute`.

The added comments are based on my reading of the code.