### PR TITLE
Updates EAS3 compiler to `rocm@5.2.3`

### DIFF
--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase": "initconfig",
 "package_source_dir": "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_commit": "bb1cd430c0d6f8bebfb655c65244a25bcc325d8d",
+"spack_commit": "ddc6e233c70273dd5dfd8dab31729eaf538693b8",
 "spack_configs_path": "scripts/spack/configs",
 "spack_packages_path": "scripts/spack/packages",
 "spack_concretizer": "clingo",

--- a/host-configs/rzvernal-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
+++ b/host-configs/rzvernal-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
@@ -11,19 +11,19 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_09_27_09_46_00/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_12_07_22_19_51/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_09_27_09_46_00/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_12_07_22_19_51/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_09_27_09_46_00/spack/lib/spack/env/clang/flang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_12_07_22_19_51/spack/lib/spack/env/clang/flang" CACHE PATH "")
 
 else()
 
-  set(CMAKE_C_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdclang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/opt/rocm-5.2.3/llvm/bin/amdclang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdclang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/opt/rocm-5.2.3/llvm/bin/amdclang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdflang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/opt/rocm-5.2.3/llvm/bin/amdflang" CACHE PATH "")
 
 endif()
 
@@ -35,11 +35,11 @@ set(ENABLE_FORTRAN ON CACHE BOOL "")
 # MPI
 #------------------------------------------------------------------------------
 
-set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpicc" CACHE PATH "")
+set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.2.3/bin/mpicc" CACHE PATH "")
 
-set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpicxx" CACHE PATH "")
+set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.2.3/bin/mpicxx" CACHE PATH "")
 
-set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpif90" CACHE PATH "")
+set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.2.3/bin/mpif90" CACHE PATH "")
 
 set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
 
@@ -60,13 +60,15 @@ set(ENABLE_MPI ON CACHE BOOL "")
 
 set(ENABLE_HIP ON CACHE BOOL "")
 
-set(HIP_ROOT_DIR "/opt/rocm-5.1.1/hip" CACHE STRING "")
+set(HIP_ROOT_DIR "/opt/rocm-5.2.3/hip" CACHE STRING "")
 
-set(HIP_CLANG_PATH "/opt/rocm-5.1.1/hip/../llvm/bin" CACHE STRING "")
+set(HIP_CLANG_INCLUDE_PATH "/opt/rocm-5.2.3/hip/../llvm/lib/clang/14.0.0/include" CACHE PATH "")
+
+set(CMAKE_CXX_FLAGS "--std=c++14" CACHE STRING "")
 
 set(CMAKE_HIP_ARCHITECTURES "gfx90a" CACHE STRING "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags -L/opt/rocm-5.1.1/hip/../llvm/lib -L/opt/rocm-5.1.1/hip/lib -Wl,-rpath,/opt/rocm-5.1.1/hip/../llvm/lib:/opt/rocm-5.1.1/hip/lib -lpgmath -lflang -lflangrti -lompstub -lamdhip64  -L/opt/rocm-5.1.1/hip/../lib64 -Wl,-rpath,/opt/rocm-5.1.1/hip/../lib64 -lhsakmt -lamd_comgr" CACHE STRING "")
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags -L/opt/rocm-5.2.3/hip/../llvm/lib -L/opt/rocm-5.2.3/hip/lib -Wl,-rpath,/opt/rocm-5.2.3/hip/../llvm/lib:/opt/rocm-5.2.3/hip/lib -lpgmath -lflang -lflangrti -lompstub -lamdhip64  -L/opt/rocm-5.2.3/hip/../lib64 -Wl,-rpath,/opt/rocm-5.2.3/hip/../lib64 -lhsakmt " CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
@@ -82,7 +84,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_09_27_09_46_00/clang-14.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_12_07_22_19_51/clang-14.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 
@@ -92,7 +94,7 @@ set(MFEM_DIR "${TPL_ROOT}/mfem-4.4.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
 
-set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+set(LUA_DIR "${TPL_ROOT}/lua-5.4.4" CACHE PATH "")
 
 set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
 

--- a/host-configs/tioga-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
+++ b/host-configs/tioga-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
@@ -11,19 +11,19 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_09_27_09_37_17/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_12_08_12_04_04/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_09_27_09_37_17/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_12_08_12_04_04/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_09_27_09_37_17/spack/lib/spack/env/clang/flang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_12_08_12_04_04/spack/lib/spack/env/clang/flang" CACHE PATH "")
 
 else()
 
-  set(CMAKE_C_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdclang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/opt/rocm-5.2.3/llvm/bin/amdclang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdclang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/opt/rocm-5.2.3/llvm/bin/amdclang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/opt/rocm-5.1.1/llvm/bin/amdflang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/opt/rocm-5.2.3/llvm/bin/amdflang" CACHE PATH "")
 
 endif()
 
@@ -35,11 +35,11 @@ set(ENABLE_FORTRAN ON CACHE BOOL "")
 # MPI
 #------------------------------------------------------------------------------
 
-set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpicc" CACHE PATH "")
+set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.2.3/bin/mpicc" CACHE PATH "")
 
-set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpicxx" CACHE PATH "")
+set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.2.3/bin/mpicxx" CACHE PATH "")
 
-set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpif90" CACHE PATH "")
+set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.2.3/bin/mpif90" CACHE PATH "")
 
 set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
 
@@ -60,13 +60,15 @@ set(ENABLE_MPI ON CACHE BOOL "")
 
 set(ENABLE_HIP ON CACHE BOOL "")
 
-set(HIP_ROOT_DIR "/opt/rocm-5.1.1/hip" CACHE STRING "")
+set(HIP_ROOT_DIR "/opt/rocm-5.2.3/hip" CACHE STRING "")
 
-set(HIP_CLANG_PATH "/opt/rocm-5.1.1/hip/../llvm/bin" CACHE STRING "")
+set(HIP_CLANG_INCLUDE_PATH "/opt/rocm-5.2.3/hip/../llvm/lib/clang/14.0.0/include" CACHE PATH "")
+
+set(CMAKE_CXX_FLAGS "--std=c++14" CACHE STRING "")
 
 set(CMAKE_HIP_ARCHITECTURES "gfx90a" CACHE STRING "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags -L/opt/rocm-5.1.1/hip/../llvm/lib -L/opt/rocm-5.1.1/hip/lib -Wl,-rpath,/opt/rocm-5.1.1/hip/../llvm/lib:/opt/rocm-5.1.1/hip/lib -lpgmath -lflang -lflangrti -lompstub -lamdhip64  -L/opt/rocm-5.1.1/hip/../lib64 -Wl,-rpath,/opt/rocm-5.1.1/hip/../lib64 -lhsakmt -lamd_comgr" CACHE STRING "")
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags -L/opt/rocm-5.2.3/hip/../llvm/lib -L/opt/rocm-5.2.3/hip/lib -Wl,-rpath,/opt/rocm-5.2.3/hip/../llvm/lib:/opt/rocm-5.2.3/hip/lib -lpgmath -lflang -lflangrti -lompstub -lamdhip64  -L/opt/rocm-5.2.3/hip/../lib64 -Wl,-rpath,/opt/rocm-5.2.3/hip/../lib64 -lhsakmt " CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
@@ -82,7 +84,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 # Root directory for generated TPLs
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_09_27_09_37_17/clang-14.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2022_12_08_12_04_04/clang-14.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.3" CACHE PATH "")
 
@@ -92,7 +94,7 @@ set(MFEM_DIR "${TPL_ROOT}/mfem-4.4.0" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22" CACHE PATH "")
 
-set(LUA_DIR "${TPL_ROOT}/lua-5.3.5" CACHE PATH "")
+set(LUA_DIR "${TPL_ROOT}/lua-5.4.4" CACHE PATH "")
 
 set(RAJA_DIR "${TPL_ROOT}/raja-2022.03.0" CACHE PATH "")
 

--- a/scripts/spack/configs/toss_4_x86_64_ib_cray/compilers.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib_cray/compilers.yaml
@@ -7,9 +7,9 @@ compilers:
     modules: []
     operating_system: rhel8
     paths:
-      cc: /opt/rocm-5.1.1/llvm/bin/amdclang
-      cxx: /opt/rocm-5.1.1/llvm/bin/amdclang++
-      f77: /opt/rocm-5.1.1/llvm/bin/amdflang
-      fc: /opt/rocm-5.1.1/llvm/bin/amdflang
+      cc: /opt/rocm-5.2.3/llvm/bin/amdclang
+      cxx: /opt/rocm-5.2.3/llvm/bin/amdclang++
+      f77: /opt/rocm-5.2.3/llvm/bin/amdflang
+      fc: /opt/rocm-5.2.3/llvm/bin/amdflang
     spec: clang@14.0.0
     target: x86_64

--- a/scripts/spack/configs/toss_4_x86_64_ib_cray/packages.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib_cray/packages.yaml
@@ -22,39 +22,53 @@ packages:
       mpi: [cray-mpich]
 
   hip:
-    version: [5.1.1]
+    version: [5.2.3]
     buildable: false
     externals:
-    - spec: hip@5.1.1
-      prefix: /opt/rocm-5.1.1/hip
+    - spec: hip@5.2.3
+      prefix: /opt/rocm-5.2.3/hip
 
   llvm-amdgpu:
-    version: [5.1.1]
+    version: [5.2.3]
     buildable: false
     externals:
-    - spec: llvm-amdgpu@5.1.1
-      prefix: /opt/rocm-5.1.1/llvm
+    - spec: llvm-amdgpu@5.2.3
+      prefix: /opt/rocm-5.2.3/llvm
 
   hsa-rocr-dev:
-    version: [5.1.1]
+    version: [5.2.3]
     buildable: false
     externals:
-    - spec: hsa-rocr-dev@5.1.1
-      prefix: /opt/rocm-5.1.1/
+    - spec: hsa-rocr-dev@5.2.3
+      prefix: /opt/rocm-5.2.3/
+
+  rocblas:
+    version: [5.2.3]
+    buildable: false
+    externals:
+    - spec: rocblas@5.2.3
+      prefix: /opt/rocm-5.2.3/
 
   rocminfo:
-    version: [5.1.1]
+    version: [5.2.3]
     buildable: false
     externals:
-    - spec: rocminfo@5.1.1
-      prefix: /opt/rocm-5.1.1/
+    - spec: rocminfo@5.2.3
+      prefix: /opt/rocm-5.2.3/
+
+  rocprim:
+    version: [5.2.3]
+    buildable: false
+    externals:
+    - spec: rocprim@5.2.3
+      prefix: /opt/rocm-5.2.3/
 
   rocm-device-libs:
-    version: [5.1.1]
+    version: [5.2.3]
     buildable: false
     externals:
-    - spec: rocm-device-libs@5.1.1
-      prefix: /opt/rocm-5.1.1/
+    - spec: rocm-device-libs@5.2.3
+      prefix: /opt/rocm-5.2.3/
 
 # Lock down which MPI we are using
   mpi:
@@ -63,7 +77,7 @@ packages:
     buildable: false
     externals:
     - spec: cray-mpich@8.1.16%clang@14.0.0+slurm
-      prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/
+      prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.2.3/
 
   # blas is a bit more complicated because its a virtual package so fake it with
   # the following per spack docs

--- a/scripts/spack/packages/raja/package.py
+++ b/scripts/spack/packages/raja/package.py
@@ -141,13 +141,13 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
 
                 # C++ 14 error fix in camp
                 entries.append(cmake_cache_string("CMAKE_CXX_FLAGS","--std=c++14"))
-                # END AXOM EDIT
 
             archs = self.spec.variants['amdgpu_target'].value
             if archs != 'none':
                 arch_str = ",".join(archs)
-                entries.append(cmake_cache_string(
-                    "HIP_HIPCC_FLAGS", '--amdgpu-target={0}'.format(arch_str)))
+                entries.append(cmake_cache_string("HIP_HIPCC_FLAGS", "--amdgpu-target={0}".format(arch_str)))
+                entries.append(cmake_cache_string("CMAKE_HIP_ARCHITECTURES", arch_str))
+            # END AXOM EDIT
         else:
             entries.append(cmake_cache_option("ENABLE_HIP", False))
 


### PR DESCRIPTION
# Summary

- This is a maintenance PR in support of a user request / bug report
- It resolves #971 
- It updates spack to the HEAD of its develop branch on 7Dec2022, which incorporates a bugfix for properly setting the `ROCM_PATH` relative to the provided `HIP_ROOT_DIR` (https://github.com/spack/spack/pull/33772)
    - Spack diff: https://github.com/spack/spack/compare/bb1cd430c0d6f8bebfb655c65244a25bcc325d8d...ddc6e233c70273dd5dfd8dab31729eaf538693b8
- It updates our EAS3 compiler from `rocm@5.1.1` to `rocm@5.2.3`

#### TODO:
- [x] Update RZ host-configs for EAS3
- [x] Update CZ host-configs for EAS3