### PR TITLE
Adds support for RAJA and Umpire to Windows build

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -41,6 +41,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Updates to [fmt version 9.1.0](https://github.com/fmtlib/fmt/releases/tag/9.1.0)
 - Updates uberenv submodule to HEAD of main on 28Dec2022
 - Updates blt submodule to HEAD of develop on 28Dec2022
+- Adds `vcpkg` ports for `RAJA`, `Umpire` with optional `OpenMP` feature for automated Windows build
 
 ## [Version 0.7.0] - Release date 2022-08-30
 

--- a/scripts/vcpkg_ports/axom/portfile.cmake
+++ b/scripts/vcpkg_ports/axom/portfile.cmake
@@ -149,8 +149,12 @@ set(RAJA_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
 set(CAMP_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
 ]=])
 
+set(_openmp_dep [=[
+set(ENABLE_OPENMP ON CACHE BOOL "")
+]=])
+
 # TODO:
-#  * Add TPLs: mfem, umpire, raja
+#  * Add features/TPLs: umpire, lua, mpi
 #  * Add tools: uncrustify, sphinx, doxygen
 
 # Create a copyright file
@@ -181,6 +185,9 @@ if("raja" IN_LIST FEATURES)
   file(APPEND ${_hc_file}.in ${_raja_dep})
 endif()
 
+if("openmp" IN_LIST FEATURES)
+  file(APPEND ${_hc_file}.in ${_openmp_dep})
+endif()
 
 configure_file(${_hc_file}.in ${_hc_file} @ONLY)
 

--- a/scripts/vcpkg_ports/axom/portfile.cmake
+++ b/scripts/vcpkg_ports/axom/portfile.cmake
@@ -126,15 +126,32 @@ set(ENABLE_MPI OFF CACHE BOOL "")
 #------------------------------------------------------------------------------
 # Set TPLs
 #------------------------------------------------------------------------------
+]=])
+
+set(_conduit_dep_on [=[
 set(CONDUIT_DIR "@CURRENT_INSTALLED_DIR@/share/conduit" CACHE PATH "")
 set(HDF5_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
+]=])
+set(_conduit_dep_off [=[
+# conduit is disabled
+# sidre requires conduit; inlet and klee require sidre
+set(AXOM_ENABLE_SIDRE OFF CACHE BOOL "")
+set(AXOM_ENABLE_INLET OFF CACHE BOOL "")
+set(AXOM_ENABLE_KLEE OFF CACHE BOOL "")
+]=])
+
+set(_mfem_dep [=[
 set(MFEM_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
+]=])
+
+set(_raja_dep [=[
+set(RAJA_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
+set(CAMP_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
+]=])
 
 # TODO:
 #  * Add TPLs: mfem, umpire, raja
 #  * Add tools: uncrustify, sphinx, doxygen
-
-]=])
 
 # Create a copyright file
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/${PORT} )
@@ -145,6 +162,25 @@ file(WRITE ${_copyright_file} "${_copyright}")
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/include/${PORT} )
 set(_hc_file ${CURRENT_PACKAGES_DIR}/include/${PORT}/hc.cmake)
 
+# Add enabled features to host-config
+message(STATUS "FEATURES: ${FEATURES}")
+
 file(WRITE ${_hc_file}.in ${_host-config_hdr})
+
+if("conduit" IN_LIST FEATURES)
+  file(APPEND ${_hc_file}.in ${_conduit_dep_on})
+else()
+  file(APPEND ${_hc_file}.in ${_conduit_dep_off})
+endif()
+
+if("mfem" IN_LIST FEATURES)
+  file(APPEND ${_hc_file}.in ${_mfem_dep})
+endif()
+
+if("raja" IN_LIST FEATURES)
+  file(APPEND ${_hc_file}.in ${_raja_dep})
+endif()
+
+
 configure_file(${_hc_file}.in ${_hc_file} @ONLY)
 

--- a/scripts/vcpkg_ports/axom/portfile.cmake
+++ b/scripts/vcpkg_ports/axom/portfile.cmake
@@ -129,10 +129,12 @@ set(ENABLE_MPI OFF CACHE BOOL "")
 ]=])
 
 set(_conduit_dep_on [=[
+
 set(CONDUIT_DIR "@CURRENT_INSTALLED_DIR@/share/conduit" CACHE PATH "")
 set(HDF5_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
 ]=])
 set(_conduit_dep_off [=[
+
 # conduit is disabled
 # sidre requires conduit; inlet and klee require sidre
 set(AXOM_ENABLE_SIDRE OFF CACHE BOOL "")
@@ -141,20 +143,34 @@ set(AXOM_ENABLE_KLEE OFF CACHE BOOL "")
 ]=])
 
 set(_mfem_dep [=[
+
 set(MFEM_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
 ]=])
 
-set(_raja_dep [=[
-set(RAJA_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
+set(_camp_dep [=[
+
 set(CAMP_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
 ]=])
 
+set(_raja_dep [=[
+
+set(RAJA_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
+]=])
+
+set(_umpire_dep [=[
+
+set(UMPIRE_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
+]=])
+
 set(_openmp_dep [=[
+
+# Setup OpenMP; fix MSVC linker error about unknown flag
 set(ENABLE_OPENMP ON CACHE BOOL "")
+set(BLT_OPENMP_LINK_FLAGS " " CACHE STRING "")
 ]=])
 
 # TODO:
-#  * Add features/TPLs: umpire, lua, mpi
+#  * Add features/TPLs: lua, mpi
 #  * Add tools: uncrustify, sphinx, doxygen
 
 # Create a copyright file
@@ -169,25 +185,23 @@ set(_hc_file ${CURRENT_PACKAGES_DIR}/include/${PORT}/hc.cmake)
 # Add enabled features to host-config
 message(STATUS "FEATURES: ${FEATURES}")
 
-file(WRITE ${_hc_file}.in ${_host-config_hdr})
+file(WRITE ${_hc_file}.in "${_host-config_hdr}")
 
 if("conduit" IN_LIST FEATURES)
-  file(APPEND ${_hc_file}.in ${_conduit_dep_on})
+  file(APPEND ${_hc_file}.in "${_conduit_dep_on}")
 else()
-  file(APPEND ${_hc_file}.in ${_conduit_dep_off})
+  file(APPEND ${_hc_file}.in "${_conduit_dep_off}")
 endif()
 
-if("mfem" IN_LIST FEATURES)
-  file(APPEND ${_hc_file}.in ${_mfem_dep})
-endif()
+foreach(_dep openmp mfem raja umpire)
+  if(${_dep} IN_LIST FEATURES)
+    file(APPEND ${_hc_file}.in "${_${_dep}_dep}")
+  endif()
+endforeach()
 
-if("raja" IN_LIST FEATURES)
-  file(APPEND ${_hc_file}.in ${_raja_dep})
-endif()
-
-if("openmp" IN_LIST FEATURES)
-  file(APPEND ${_hc_file}.in ${_openmp_dep})
+# camp is required if umpire or raja are present
+if(raja IN_LIST FEATURES OR umpire IN_LIST FEATURES)
+  file(APPEND ${_hc_file}.in "${_camp_dep}")
 endif()
 
 configure_file(${_hc_file}.in ${_hc_file} @ONLY)
-

--- a/scripts/vcpkg_ports/axom/vcpkg.json
+++ b/scripts/vcpkg_ports/axom/vcpkg.json
@@ -5,10 +5,11 @@
   "description": "Host-config generator for Axom TPLs",
   "dependencies": ["blt"],
   "default-features": [
-    "mfem",
     "conduit",
+    "mfem",
+    "openmp",
     "raja",
-    "openmp"
+    "umpire"
   ],
   "features": {
     "mfem": {
@@ -23,11 +24,21 @@
       "description": "raja functionality for axom",
       "dependencies": ["raja"]
     },
+    "umpire": {
+      "description": "umpire functionality for axom",
+      "dependencies": ["umpire"]
+    },
     "openmp": {
       "description": "openmp functionality for axom",
       "dependencies": [
         {
           "name": "raja",
+          "features": [
+            "openmp"
+          ]
+        },
+        {
+          "name": "umpire",
           "features": [
             "openmp"
           ]

--- a/scripts/vcpkg_ports/axom/vcpkg.json
+++ b/scripts/vcpkg_ports/axom/vcpkg.json
@@ -6,7 +6,8 @@
   "dependencies": ["blt"],
   "default-features": [
     "mfem",
-    "conduit"
+    "conduit",
+    "raja"
   ],
   "features": {
     "mfem": {
@@ -16,6 +17,10 @@
     "conduit": {
       "description": "conduit functionality for axom",
       "dependencies": ["conduit"]
+    },
+    "raja": {
+      "description": "raja functionality for axom",
+      "dependencies": ["raja"]
     }
   },
   "supports": "!uwp"

--- a/scripts/vcpkg_ports/axom/vcpkg.json
+++ b/scripts/vcpkg_ports/axom/vcpkg.json
@@ -7,7 +7,8 @@
   "default-features": [
     "mfem",
     "conduit",
-    "raja"
+    "raja",
+    "openmp"
   ],
   "features": {
     "mfem": {
@@ -21,6 +22,17 @@
     "raja": {
       "description": "raja functionality for axom",
       "dependencies": ["raja"]
+    },
+    "openmp": {
+      "description": "openmp functionality for axom",
+      "dependencies": [
+        {
+          "name": "raja",
+          "features": [
+            "openmp"
+          ]
+        }
+      ]
     }
   },
   "supports": "!uwp"

--- a/scripts/vcpkg_ports/camp/portfile.cmake
+++ b/scripts/vcpkg_ports/camp/portfile.cmake
@@ -11,6 +11,17 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     set(_is_shared FALSE)
 endif()
 
+if("openmp" IN_LIST FEATURES)
+    set(_use_)
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        openmp       ENABLE_OPENMP
+)
+
+
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -22,10 +33,12 @@ vcpkg_configure_cmake(
         -DENABLE_EXAMPLES=OFF
         -DENABLE_TESTS=OFF
         -DBUILD_SHARED_LIBS=${_is_shared}
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()
-vcpkg_cmake_config_fixup()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/camp
+                          TARGET_PATH share/camp)
 vcpkg_copy_pdbs()
 
 
@@ -44,7 +57,28 @@ foreach(_dir "bin" "debug/bin")
 endforeach()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    # Note: Not tested
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+else()
+    set(_config_dir "${CURRENT_PACKAGES_DIR}/share/camp")
+
+    # Move dll files from lib to bin directory
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/bin )
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug/bin )
+
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/camp.dll
+                ${CURRENT_PACKAGES_DIR}/bin/camp.dll)
+
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/camp.dll
+                ${CURRENT_PACKAGES_DIR}/debug/bin/camp.dll)
+
+    # Update paths to dlls in CMake config files
+    foreach(_c  debug release)
+        set(_f ${_config_dir}/campTargets-${_c}.cmake)
+        file(READ ${_f} _fdata)
+        string(REPLACE "lib/camp.dll" "bin/camp.dll" _fdata "${_fdata}")
+        file(WRITE  ${_f} "${_fdata}")
+    endforeach()
 endif()
 
 # Put the license file where vcpkg expects it

--- a/scripts/vcpkg_ports/camp/portfile.cmake
+++ b/scripts/vcpkg_ports/camp/portfile.cmake
@@ -1,0 +1,51 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO llnl/camp
+    REF v2022.03.2
+    SHA512 d124c0e933f042525e9b48c21b93e7f4f634dfc0f87742e018a1c7de43ed6e30670d8f8e4ce369018a8e1c884b2b27f4755ee9f07a077820b2a3133546f6d622
+    HEAD_REF develop
+)
+
+set(_is_shared TRUE)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(_is_shared FALSE)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS 
+        -DBLT_SOURCE_DIR=${CURRENT_INSTALLED_DIR}/share/blt
+        -DENABLE_COVERAGE=OFF
+        -DENABLE_ALL_WARNINGS=OFF
+        -DENABLE_DOCS=OFF
+        -DENABLE_EXAMPLES=OFF
+        -DENABLE_TESTS=OFF
+        -DBUILD_SHARED_LIBS=${_is_shared}
+)
+
+vcpkg_install_cmake()
+vcpkg_cmake_config_fixup()
+vcpkg_copy_pdbs()
+
+
+## shuffle the output directories to make vcpkg happy
+# Remove extraneous debug header files
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Remove exe files -- vcpkg doesn't like them
+# (Future): It might be possible to move them to the vcpkg 'tools' directory
+foreach(_dir "bin" "debug/bin")
+    file(GLOB _exe ${CURRENT_PACKAGES_DIR}/${_dir}/*.exe)
+    if(_exe)
+        file(REMOVE ${_exe})
+    endif()
+endforeach()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
+
+# Put the license file where vcpkg expects it
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/camp RENAME copyright)

--- a/scripts/vcpkg_ports/camp/vcpkg.json
+++ b/scripts/vcpkg_ports/camp/vcpkg.json
@@ -6,5 +6,10 @@
   "dependencies": [
     "blt"
   ],
+  "features": {
+    "openmp": {
+      "description": "openmp functionality for camp"
+    }
+  },
   "supports": "!uwp"
 }

--- a/scripts/vcpkg_ports/camp/vcpkg.json
+++ b/scripts/vcpkg_ports/camp/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "camp",
+  "version-string": "2022.03.2",
+  "homepage": "https://github.com/llnl/camp",
+  "description": "Compiler agnostic metaprogramming library",
+  "dependencies": [
+    "blt"
+  ],
+  "supports": "!uwp"
+}

--- a/scripts/vcpkg_ports/raja/portfile.cmake
+++ b/scripts/vcpkg_ports/raja/portfile.cmake
@@ -13,6 +13,11 @@ else()
     set(_extra_cxx_flags "/DRAJASHAREDDLL_EXPORTS")
 endif()
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        openmp       ENABLE_OPENMP
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -32,6 +37,7 @@ vcpkg_configure_cmake(
         -DRAJA_ENABLE_BENCHMARKS:BOOL=OFF
         -DBUILD_SHARED_LIBS:BOOL=${_is_shared}
         -DBLT_CXX_FLAGS:STRING=${_extra_cxx_flags}
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()

--- a/scripts/vcpkg_ports/raja/portfile.cmake
+++ b/scripts/vcpkg_ports/raja/portfile.cmake
@@ -1,0 +1,76 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO llnl/raja
+    REF v2022.03.1
+    SHA512 36e2f59e0f4c3e8fcc07a21fc1eeec701c2be147db9395efedad9aa87bcc078e84a5334698c0fb3e2fbd3670c2eaacdebcd63c4caaa3721a3900ff02dfb44ad7
+    HEAD_REF develop
+)
+
+set(_is_shared TRUE)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(_is_shared FALSE)
+else()
+    set(_extra_cxx_flags "/DRAJASHAREDDLL_EXPORTS")
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS 
+        -DBLT_SOURCE_DIR:PATH=${CURRENT_INSTALLED_DIR}/share/blt
+        -Dcamp_DIR:PATH=${CURRENT_INSTALLED_DIR}
+        -DENABLE_ALL_WARNINGS:BOOL=OFF
+        -DENABLE_COVERAGE:BOOL=OFF
+        -DENABLE_EXAMPLES:BOOL=OFF
+        -DENABLE_TESTS:BOOL=OFF
+        -DRAJA_ENABLE_RUNTIME_PLUGINS:BOOL=OFF
+        -DRAJA_ENABLE_TESTS:BOOL=OFF
+        -DRAJA_ENABLE_EXAMPLES:BOOL=OFF
+        -DRAJA_ENABLE_EXERCISES:BOOL=OFF
+        -DRAJA_ENABLE_REPRODUCERS:BOOL=OFF
+        -DRAJA_ENABLE_DOCUMENTATION:BOOL=OFF
+        -DRAJA_ENABLE_BENCHMARKS:BOOL=OFF
+        -DBUILD_SHARED_LIBS:BOOL=${_is_shared}
+        -DBLT_CXX_FLAGS:STRING=${_extra_cxx_flags}
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/raja
+                          TARGET_PATH share/raja)
+vcpkg_copy_pdbs()
+
+
+## shuffle the output directories to make vcpkg happy
+# Remove extraneous debug header files
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+message(STATUS "CURRENT_PACKAGES_DIR -- ${CURRENT_PACKAGES_DIR}")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    # Note: Not tested
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+else()
+    set(_config_dir "${CURRENT_PACKAGES_DIR}/share/raja")
+
+    # Move dll files from lib to bin directory
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/bin )
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug/bin )
+
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/RAJA.dll
+                ${CURRENT_PACKAGES_DIR}/bin/RAJA.dll)
+
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/RAJA.dll
+                ${CURRENT_PACKAGES_DIR}/debug/bin/RAJA.dll)
+
+    # Update paths to dlls in CMake config files
+    foreach(_c  debug release)
+        set(_f ${_config_dir}/RAJA-${_c}.cmake)
+        file(READ ${_f} _fdata)
+        string(REPLACE "lib/RAJA.dll" "bin/RAJA.dll" _fdata "${_fdata}")
+        file(WRITE  ${_f} "${_fdata}")
+    endforeach()
+endif()
+
+# Put the license file where vcpkg expects it
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/raja RENAME copyright)

--- a/scripts/vcpkg_ports/raja/vcpkg.json
+++ b/scripts/vcpkg_ports/raja/vcpkg.json
@@ -7,5 +7,18 @@
     "blt",
     "camp"
   ],
+  "features": {
+    "openmp": {
+      "description": "openmp functionality for raja",
+      "dependencies": [
+        {
+          "name": "camp",
+          "features": [
+            "openmp"
+          ]
+        }
+      ]
+    }
+  },
   "supports": "!uwp"
 }

--- a/scripts/vcpkg_ports/raja/vcpkg.json
+++ b/scripts/vcpkg_ports/raja/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "raja",
+  "version-string": "2022.03.1",
+  "homepage": "https://github.com/llnl/raja",
+  "description": "RAJA Performance Portability Layer (C++)",
+  "dependencies": [
+    "blt",
+    "camp"
+  ],
+  "supports": "!uwp"
+}

--- a/scripts/vcpkg_ports/umpire/portfile.cmake
+++ b/scripts/vcpkg_ports/umpire/portfile.cmake
@@ -1,0 +1,97 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO llnl/umpire
+    REF v2022.10.0
+    SHA512 38bc74c360ee73e8ee04fbb652cff160551597a46af587f8c9da755cef591ae4add66d9af038a0a14722653d135007b01b37d3addf4d64ca0d1ed129e0461428
+    HEAD_REF develop
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        openmp       ENABLE_OPENMP
+)
+
+set(_is_shared TRUE)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(_is_shared FALSE)
+else()
+    list(APPEND FEATURE_OPTIONS -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON)
+endif()
+
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS 
+        -DBLT_SOURCE_DIR:PATH=${CURRENT_INSTALLED_DIR}/share/blt
+        -Dcamp_DIR:PATH=${CURRENT_INSTALLED_DIR}
+        -DENABLE_ALL_WARNINGS:BOOL=OFF
+        -DENABLE_WARNINGS_AS_ERRORS:BOOL=OFF
+        -DENABLE_COVERAGE:BOOL=OFF
+        -DENABLE_EXAMPLES:BOOL=OFF
+        -DENABLE_TESTS:BOOL=OFF
+        -DENABLE_BENCHMARKS:BOOL=OFF
+        -DUMPIRE_ENABLE_FILESYSTEM:BOOL=ON
+        -DBLT_CXX_STD:STRING=c++17
+        -DBLT_OPENMP_LINK_FLAGS:STRING=" "
+        -DUMPIRE_ENABLE_TOOLS:BOOL=OFF
+        -DUMPIRE_ENABLE_TESTS:BOOL=OFF
+        -DUMPIRE_ENABLE_BENCHMARKS:BOOL=OFF
+        -DUMPIRE_ENABLE_DEVELOPER_BENCHMARKS:BOOL=OFF
+        -DBUILD_SHARED_LIBS:BOOL=${_is_shared}
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/umpire
+                          TARGET_PATH share/umpire)
+vcpkg_copy_pdbs()
+
+
+## shuffle the output directories to make vcpkg happy
+# Remove extraneous debug header files
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+message(STATUS "CURRENT_PACKAGES_DIR -- ${CURRENT_PACKAGES_DIR}")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    # Note: Not tested
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+else()
+    set(_config_dir "${CURRENT_PACKAGES_DIR}/share/umpire")
+    
+    # Move dll files from lib to bin directory
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/bin )
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug/bin )
+
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/umpire.dll
+                ${CURRENT_PACKAGES_DIR}/bin/umpire.dll)
+
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/umpire.dll
+                ${CURRENT_PACKAGES_DIR}/debug/bin/umpire.dll)
+
+    # Update paths to dlls in CMake config files
+    foreach(_c  debug release)
+        set(_f ${_config_dir}/umpire-targets-${_c}.cmake)
+        file(READ ${_f} _fdata)
+        string(REPLACE "lib/umpire.dll" "bin/umpire.dll" _fdata "${_fdata}")
+        file(WRITE  ${_f} "${_fdata}")
+    endforeach()
+
+    # Fix erroneous "include" path appended as system include directories
+    set(_f ${_config_dir}/umpire-targets.cmake)
+    set(_pattern "INTERFACE_SYSTEM_INCLUDE_DIRECTORIES \"include.*")
+    file(STRINGS ${_f} _file_lines)
+    file(WRITE ${_f} "")
+    foreach(_line IN LISTS _file_lines)
+        #message(STATUS "\t\tRegex input:  ${_line}")
+        string(REGEX REPLACE ${_pattern} "" _stripped "${_line}")
+        #message(STATUS "\t\tRegex output: ${_stripped}")
+        file(APPEND ${_f} "${_stripped}\n")
+    endforeach()
+endif()
+
+
+# Put the license file where vcpkg expects it
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/umpire RENAME copyright)

--- a/scripts/vcpkg_ports/umpire/vcpkg.json
+++ b/scripts/vcpkg_ports/umpire/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "umpire",
+  "version-string": "2022.10.0",
+  "homepage": "https://github.com/llnl/umpire",
+  "description": "An application-focused API for memory management on NUMA and GPU architectures",
+  "dependencies": [
+    "blt",
+    "camp"
+  ],
+  "features": {
+    "openmp": {
+      "description": "openmp functionality for umpire",
+      "dependencies": [
+        {
+          "name": "camp",
+          "features": [
+            "openmp"
+          ]
+        }
+      ]
+    }
+  },
+  "supports": "!uwp"
+}

--- a/src/axom/inlet/tests/CMakeLists.txt
+++ b/src/axom/inlet/tests/CMakeLists.txt
@@ -24,7 +24,8 @@ blt_list_append(TO gtest_inlet_tests ELEMENTS inlet_function.cpp IF SOL_FOUND)
 blt_add_library(NAME        inlet_test_utils
                 SOURCES     inlet_test_utils.cpp
                 HEADERS     inlet_test_utils.hpp
-                DEPENDS_ON  axom gtest gmock)
+                DEPENDS_ON  axom gtest gmock
+                FOLDER      axom/inlet/tests )
 
 foreach(test ${gtest_inlet_tests})
     get_filename_component( test_name ${test} NAME_WE )

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -659,11 +659,13 @@ public:
       "{:-^80}",
       " Decomposing each hexahedron element into 24 tetrahedrons "));
 
+    using TetHexArray = axom::StackArray<TetrahedronType, NUM_TETS_PER_HEX>;
+
     AXOM_PERF_MARK_SECTION("init_tets",
                            axom::for_all<ExecSpace>(
                              NE,
                              AXOM_LAMBDA(axom::IndexType i) {
-                               TetrahedronType cur_tets[NUM_TETS_PER_HEX];
+                               TetHexArray cur_tets;
                                decompose_hex_to_tets(local_hexes[i], cur_tets);
 
                                for(int j = 0; j < NUM_TETS_PER_HEX; j++)


### PR DESCRIPTION
# Summary

- This PR is a feature
- It adds `vcpkg` ports for `RAJA`, `Umpire` and `camp`
   - I used the Umpire@2022.10 release since the 2022.03 release had problems with zero-sized allocations on Windows
   - This also required updating our `fmt` version due to an incompatibility between the vendored copies of `fmt` in `axom` and `Umpire`. Specifically, the [strerror overloads in `fmt@7.1/format-inl.h`](https://github.com/LLNL/axom/blob/8da4ba2f8eec19b5b0cbd91857ae57c41b40a771/src/thirdparty/axom/fmt/format-inl.h#L30-L33) differed only in return type. These were removed in `fmt@9.1`
- It also adds an optional `OpenMP` feature to the Windows build
- These are all enabled by default
- This PR resolves #982 