### PR TITLE
Fix duplicate symbol when compiling with intel oneapi

### DIFF
--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -61,7 +61,7 @@ enum class DistributedClosestPointRuntimePolicy
 };
 
 /// Utility function to allow formating a DistributedClosestPointRuntimePolicy
-auto format_as(DistributedClosestPointRuntimePolicy pol)
+inline auto format_as(DistributedClosestPointRuntimePolicy pol)
 {
   return fmt::underlying(pol);
 }


### PR DESCRIPTION
@adayton hit the following:

```
ld.lld: error: duplicate symbol: axom::quest::format_as(axom::quest::DistributedClosestPointRuntimePolicy)
>>> defined at DistributedClosestPoint.hpp:65 (lib/toss3_intel.oneapi.2022/axom/include/axom/quest/DistributedClosestPoint.hpp:65)
>>>            CMakeFiles/dir/__/io/ReadStl.cc.o:(axom::quest::format_as(axom::quest::DistributedClosestPointRuntimePolicy))
>>> defined at DistributedClosestPoint.hpp:65 (lib/toss3_intel.oneapi.2022/axom/include/axom/quest/DistributedClosestPoint.hpp:65)
>>>            CMakeFiles/dir/__/shapegen/ShapeFileStl.cxx.o:(.text._ZN4axom5quest9format_asENS0_36DistributedClosestPointRuntimePolicyE+0x0)
```