### PR TITLE
Reduce size of ArrayView returned by `subspan`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -42,6 +42,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Updates uberenv submodule to HEAD of main on 28Dec2022
 - Updates blt submodule to HEAD of develop on 28Dec2022
 - Adds `vcpkg` ports for `RAJA`, `Umpire` with optional `OpenMP` feature for automated Windows build
+- Reduce size of `ArrayView::subspan` to prevent accessing invalid memory.
 
 ## [Version 0.7.0] - Release date 2022-08-30
 

--- a/src/axom/core/ArrayView.hpp
+++ b/src/axom/core/ArrayView.hpp
@@ -135,18 +135,23 @@ public:
    * \param [in] count The number of elements to include in the subspan, or -1
    *  to take all elements after offset (default).
    *
-   * \return A subspan ArrayView that spans the indices [offset, offset + count),
-   *  or [offset, num_elements) if count == -1.
+   * \return An ArrayView that spans the indices [offset, offset + count),
+   *  or [offset, num_elements) if count < 0.
    *
-   * \pre offset + count <= m_num_elements if count != -1
+   * \pre offset + count <= m_num_elements if count < 0
    */
   template <int UDIM = DIM, typename Enable = typename std::enable_if<UDIM == 1>::type>
   AXOM_HOST_DEVICE ArrayView subspan(IndexType offset, IndexType count = -1) const
   {
-    assert(offset + count <= m_num_elements);
+    assert(offset >= 0 && offset < m_num_elements);
+    if(count >= 0)
+    {
+      assert(offset + count <= m_num_elements);
+    }
+
     ArrayView slice = *this;
     slice.m_data += offset;
-    if(count == -1)
+    if(count < 0)
     {
       slice.m_num_elements -= offset;
     }

--- a/src/axom/core/ArrayView.hpp
+++ b/src/axom/core/ArrayView.hpp
@@ -135,8 +135,8 @@ public:
    * \param [in] count The number of elements to include in the subspan, or -1
    *  to take all elements after offset (default).
    *
-   * \return A subspan ArrayView that spans the indices [offsets, offsets + count),
-   *  or [offsets, num_elements) if count == -1.
+   * \return A subspan ArrayView that spans the indices [offset, offset + count),
+   *  or [offset, num_elements) if count == -1.
    *
    * \pre offset + count <= m_num_elements if count != -1
    */
@@ -146,7 +146,11 @@ public:
     assert(offset + count <= m_num_elements);
     ArrayView slice = *this;
     slice.m_data += offset;
-    if(count != -1)
+    if(count == -1)
+    {
+      slice.m_num_elements -= offset;
+    }
+    else
     {
       slice.m_num_elements = count;
     }

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1931,4 +1931,18 @@ TEST(core_array, checkVariadicCtors)
   Array<int, 3> arr12(s, s, s);
 }
 
+//------------------------------------------------------------------------------
+
+TEST(core_array, check_subspan_range)
+{
+  int m = 10;
+  int n = 3;
+  Array<int> arr(m);
+  ArrayView<int> arrv1(arr);
+  ArrayView<int> arrv2 = arrv1.subspan(n);
+  EXPECT_EQ(arrv2.size() + n, arrv1.size());
+  EXPECT_GE(&arrv2[0], &arr[0]);
+  EXPECT_LE(&arrv2[arrv2.size()-1], &arr[arr.size()-1]);
+}
+
 } /* end namespace axom */

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1937,12 +1937,21 @@ TEST(core_array, check_subspan_range)
 {
   int m = 10;
   int n = 3;
+  int l = 5;
   Array<int> arr(m);
+
   ArrayView<int> arrv1(arr);
+  EXPECT_EQ(arrv1.size(), arr.size());
+
   ArrayView<int> arrv2 = arrv1.subspan(n);
   EXPECT_EQ(arrv2.size() + n, arrv1.size());
   EXPECT_EQ(&arrv2[0], &arr[n]);
   EXPECT_EQ(&arrv2[arrv2.size() - 1], &arr[arr.size() - 1]);
+
+  ArrayView<int> arrv3 = arrv1.subspan(n, l);
+  EXPECT_EQ(arrv3.size(), l);
+  EXPECT_EQ(&arrv3[0], &arr[n]);
+  EXPECT_EQ(&arrv3[arrv3.size() - 1], &arr[n + l - 1]);
 }
 
 } /* end namespace axom */

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1942,7 +1942,7 @@ TEST(core_array, check_subspan_range)
   ArrayView<int> arrv2 = arrv1.subspan(n);
   EXPECT_EQ(arrv2.size() + n, arrv1.size());
   EXPECT_GE(&arrv2[0], &arr[0]);
-  EXPECT_LE(&arrv2[arrv2.size()-1], &arr[arr.size()-1]);
+  EXPECT_LE(&arrv2[arrv2.size() - 1], &arr[arr.size() - 1]);
 }
 
 } /* end namespace axom */

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1941,8 +1941,8 @@ TEST(core_array, check_subspan_range)
   ArrayView<int> arrv1(arr);
   ArrayView<int> arrv2 = arrv1.subspan(n);
   EXPECT_EQ(arrv2.size() + n, arrv1.size());
-  EXPECT_GE(&arrv2[0], &arr[0]);
-  EXPECT_LE(&arrv2[arrv2.size() - 1], &arr[arr.size() - 1]);
+  EXPECT_EQ(&arrv2[0], &arr[n]);
+  EXPECT_EQ(&arrv2[arrv2.size() - 1], &arr[arr.size() - 1]);
 }
 
 } /* end namespace axom */


### PR DESCRIPTION
The over-large size was allowing access of potentially invalid memory by the `ArrayView`.  This can happen in the object returned by `ArrayView::subspan`.

- This PR is a bugfix
- It does the following:
  - Reduce the size of the new `ArrayView` by the offset amount, to make it NOT okay to access data past the end of the original view.
  - Make the returned view consistent with the doxygen comments.
  - Add unit test on the range of the created `ArrayView`.

I added the unit test because `subspan` isn't used anywhere in the library.  This change may affect application code that makes use of the buggy feature.  The change is indicated in the release notes.