### PR TITLE
Bugfix for RAJA's optional RAJA::roctx dependency

### DIFF
--- a/src/axom/core/CMakeLists.txt
+++ b/src/axom/core/CMakeLists.txt
@@ -103,6 +103,12 @@ blt_list_append( TO core_depends ELEMENTS blt::hip_runtime IF ENABLE_HIP)
 blt_list_append( TO core_depends ELEMENTS openmp IF ENABLE_OPENMP)
 blt_list_append( TO core_depends ELEMENTS mpi IF ENABLE_MPI )
 
+# HACK: RAJA's dependencies are not getting added to core due to a bug in
+# dependency propagation in blt_register_library. Explicitly add it in the short term.
+if(TARGET RAJA::roctx)
+    list(APPEND core_depends RAJA::roctx)
+endif()
+
 #------------------------------------------------------------------------------
 # Make/Install the library
 #------------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

- This PR is a workaround for a potential bug in blt
- When we specify that `core` depends on `RAJA` in `blt_add_library`, it should transitively depend on RAJA's dependencies. However, the `RAJA::roctx` dependency was not being properly propagated. The latter is present when RAJA is configured with `RAJA_ENABLE_ROCTX`.
- Since `core` is a CMake  `OBJECT` library, we're internally setting it up as a `blt_register_library`
- As a temporary workaround, this PR explicitly adds `RAJA::roctx` when available/needed