### PR TITLE
Fix cmake error to search camp lib

### DIFF
--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -31,7 +31,9 @@ if (CAMP_DIR)
         message(FATAL_ERROR "Given CAMP_DIR is not a directory: ${CAMP_DIR}")
     endif()
 
-    find_package(camp REQUIRED PATHS ${CAMP_DIR})
+    if (NOT TARGET camp)
+      find_package(camp CONFIG NO_DEFAULT_PATH PATHS ${CAMP_DIR})
+    endif ()
 
     message(STATUS "Checking for expected Camp target 'camp'")
     if (NOT TARGET camp)


### PR DESCRIPTION
# Summary

- This PR is a bugfix for following CMake Error, in which the camp is installed parallel with RAJA (ENABLE_OPENMP): 
```
CMake Error at cmake/thirdparty/SetupAxomThirdParty.cmake:34 (find_package):
  Found package configuration file:

    /home/liyang/AxomInstall/TPL/raja/lib/cmake/camp/campConfig.cmake

  but it set camp_FOUND to FALSE so package "camp" is considered to be NOT
  FOUND.  Reason given by package:

  The following imported targets are referenced, but are missing:
  RAJA::openmp

Call Stack (most recent call first):
  cmake/CMakeBasics.cmake:20 (include)
  CMakeLists.txt:120 (include)
```
