### PR TITLE
Use flux instead of srun on tioga

### DIFF
--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -8,7 +8,7 @@
 .on_tioga:
   tags:
     - shell
-    - tioga
+    - tioga10
   rules:
     - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_TIOGA == "OFF"' #run except if ...
       when: never

--- a/host-configs/tioga-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
+++ b/host-configs/tioga-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
@@ -41,9 +41,9 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-
 
 set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.2.3/bin/mpif90" CACHE PATH "")
 
-set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
+set(MPIEXEC_EXECUTABLE "/usr/bin/flux" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+set(MPIEXEC_NUMPROC_FLAG "mini;run;-n" CACHE STRING "")
 
 set(ENABLE_MPI ON CACHE BOOL "")
 


### PR DESCRIPTION
This PR:
-  Includes fix from PR #1010
-  Uses flux instead of srun for MPI tests on tioga (srun hangs MPI tests)