### PR TITLE
Improves robustsness of intersection operators against bounding boxes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,6 +25,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   - `Array::back()`: returns a reference to the last element
   - `Array::resize(size, T value)`: resizes the array, and sets any new elements to `value`.
 - Adds an `ArrayView::empty()` method to return whether the view is empty or not.
+- Adds an `area()` function to `primal::Polygon`
 
 ### Changed
 - `axom::Array` move constructors are now `noexcept`.
@@ -47,6 +48,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ###  Fixed
 - Fixed issues with CUDA build in CMake versions 3.14.5 and above. Now require CMake 3.18+
   for CUDA/non-gpu builds.
+- Checks validity of bounding boxes in `primal`'s intersection operators against planes 
+  and triangles before using the geometry.
 
 ## [Version 0.7.0] - Release date 2022-08-30
 

--- a/src/axom/primal/geometry/BoundingBox.hpp
+++ b/src/axom/primal/geometry/BoundingBox.hpp
@@ -10,7 +10,7 @@
 
 #include "axom/config.hpp"
 
-#include "axom/core/Macros.hpp"  // for AXOM_HOST__DEVICE
+#include "axom/core/Macros.hpp"
 #include "axom/core/numerics/floating_point_limits.hpp"
 
 #include "axom/primal/geometry/Point.hpp"
@@ -67,10 +67,10 @@ template <typename T, int NDIMS>
 class BoundingBox
 {
 public:
-  typedef T CoordType;
-  typedef Point<T, NDIMS> PointType;
-  typedef Vector<T, NDIMS> VectorType;
-  typedef BoundingBox<T, NDIMS> BoxType;
+  using CoordType = T;
+  using PointType = Point<T, NDIMS>;
+  using VectorType = Vector<T, NDIMS>;
+  using BoxType = BoundingBox<T, NDIMS>;
 
   static constexpr T InvalidMin = std::numeric_limits<T>::max();
   static constexpr T InvalidMax = std::numeric_limits<T>::lowest();

--- a/src/axom/primal/geometry/Polygon.hpp
+++ b/src/axom/primal/geometry/Polygon.hpp
@@ -101,6 +101,86 @@ public:
     return sum;
   }
 
+  /**
+   * \brief Returns the area of the polygon (3D specialization)
+   *
+   * The algorithm sums up contributions from triangles defined by each edge 
+   * of the polygon and a local origin (at the Polygon's \a vertexMean()).
+   * The algorithm assumes a planar polygon embedded in 3D, however it will return 
+   * a value for non-planar polygons.
+   *
+   * The area is always non-negative since 3D polygons do not have a unique orientation.
+   */
+  template <int TDIM = NDIMS>
+  typename std::enable_if<TDIM == 3, double>::type area() const
+  {
+    const int nVerts = numVertices();
+    double sum = 0.;
+
+    // check for early return
+    if(nVerts < 3)
+    {
+      return sum;
+    }
+
+    // Add up areas of triangles connecting polygon edges the vertex average
+    const auto O = vertexMean();  // 'O' for (local) origin
+    for(int curr = 0, prev = nVerts - 1; curr < nVerts; prev = curr++)
+    {
+      const auto& P = m_vertices[prev];
+      const auto& C = m_vertices[curr];
+      // clang-format off
+      sum += axom::numerics::determinant(P[0] - O[0], C[0] - O[0],
+                                         P[1] - O[1], C[1] - O[1]);
+      // clang-format on
+    }
+
+    return axom::utilities::abs(0.5 * sum);
+  }
+
+  /**
+   * \brief Returns the area of a planar polygon (2D specialization)
+   *
+   * The area is always non-negative.
+   * \sa signedArea()
+   */
+  template <int TDIM = NDIMS>
+  typename std::enable_if<TDIM == 2, double>::type area() const
+  {
+    return axom::utilities::abs(signedArea());
+  }
+
+  /**
+   * \brief Returns the signed area of a 2D polygon
+   *
+   * The signed area accounts for the orientation of the polygon.
+   * It is positive when the vertices are oriented counter-clockwise
+   * and negative when the vertices are oriented clockwise.
+   * \note Signed area is only defined in 2D.
+   * \sa area()
+   */
+  template <int TDIM = NDIMS>
+  typename std::enable_if<TDIM == 2, double>::type signedArea() const
+  {
+    const int nVerts = numVertices();
+    double sum = 0.;
+
+    // check for early return
+    if(nVerts < 3)
+    {
+      return sum;
+    }
+
+    // use shoelace algorithm
+    for(int curr = 0, prev = nVerts - 1; curr < nVerts; prev = curr++)
+    {
+      sum += m_vertices[prev][0] * m_vertices[curr][1]  //
+        - m_vertices[curr][0] * m_vertices[prev][1];
+    }
+
+    return 0.5 * sum;
+  }
+
   /*!
    * \brief Simple formatted print of a polygon instance
    *

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -520,18 +520,18 @@ public:
 
       const PointType& origin = m_vertices[0];
 
-      for(int i = 0; i < face_count; i++)
+      for(int i = 0; i < face_count; ++i)
       {
-        int n = face_size[i];
-        VectorType v0 = m_vertices[faces[face_offset[i]]] - origin;
+        const int N = face_size[i];
+        const int i_offset = face_offset[i];
+        const VectorType v0 = m_vertices[faces[i_offset]] - origin;
 
-        for(int j = 1; j < n - 1; ++j)
+        for(int j = 1, k = 2; j < N - 1; ++j, ++k)
         {
-          const int k = (j + 1) < n ? j + 1 : 0;
           retVol += VectorType::scalar_triple_product(
             v0,
-            m_vertices[faces[face_offset[i] + j]] - origin,
-            m_vertices[faces[face_offset[i] + k]] - origin);
+            m_vertices[faces[i_offset + j]] - origin,
+            m_vertices[faces[i_offset + k]] - origin);
         }
       }
     }

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -635,7 +635,7 @@ std::ostream& operator<<(std::ostream& os, const Polyhedron<T, NDIMS>& poly)
 }  // namespace primal
 }  // namespace axom
 
-/// Overload to format a primal::Tetrahedron using fmt
+/// Overload to format a primal::Polyhedron using fmt
 template <typename T, int NDIMS>
 struct axom::fmt::formatter<axom::primal::Polyhedron<T, NDIMS>> : ostream_formatter
 { };

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -18,7 +18,7 @@
 #include "axom/primal/geometry/Vector.hpp"
 #include "axom/primal/geometry/NumericArray.hpp"
 
-#include <ostream>  // for std::ostream
+#include <ostream>
 
 namespace axom
 {
@@ -376,12 +376,15 @@ public:
 
     NumArrayType sum;
 
-    for(int i = 0; i < numVertices(); ++i)
+    const int nVerts = numVertices();
+    if(nVerts > 0)
     {
-      sum += m_vertices[i].array();
+      for(int i = 0; i < nVerts; ++i)
+      {
+        sum += m_vertices[i].array();
+      }
+      sum /= nVerts;
     }
-    sum /= numVertices();
-
     return PointType(sum);
   }
 
@@ -408,7 +411,7 @@ private:
     axom::int8 checkedEdges[MAX_VERTS * 2 * 2] = {0};
 
     // Check each vertex
-    for(int i = 0; i < numVertices(); i++)
+    for(int i = 0; i < numVertices(); ++i)
     {
       // Check each neighbor index (edge) of the vertex
       for(int j = 0; j < m_neighbors.getNumNeighbors(i); j++)
@@ -495,8 +498,7 @@ public:
   {
     double retVol = 0.0;
 
-    // 0 if less than 4 vertices
-    if(numVertices() < 4)
+    if(!isValid())
     {
       return retVol;
     }
@@ -516,27 +518,25 @@ public:
       int face_count;
       getFaces(faces, face_size, face_offset, face_count);
 
-      VectorType origin(m_vertices[0].data());
+      const PointType& origin = m_vertices[0];
 
       for(int i = 0; i < face_count; i++)
       {
         int n = face_size[i];
-        VectorType v0(m_vertices[faces[face_offset[i]]].data());
-        v0 -= origin;
+        VectorType v0 = m_vertices[faces[face_offset[i]]] - origin;
 
         for(int j = 1; j < n - 1; ++j)
         {
-          VectorType v1(m_vertices[faces[face_offset[i] + j]].data());
-          v1 -= origin;
-          VectorType v2(m_vertices[faces[face_offset[i] + ((j + 1) % n)]].data());
-          v2 -= origin;
-          double partialVol = v0.dot(VectorType::cross_product(v1, v2));
-          retVol += partialVol;
+          const int k = (j + 1) < n ? j + 1 : 0;
+          retVol += VectorType::scalar_triple_product(
+            v0,
+            m_vertices[faces[face_offset[i] + j]] - origin,
+            m_vertices[faces[face_offset[i] + k]] - origin);
         }
       }
     }
 
-    return retVol / 6.0;
+    return retVol / 6.;
   }
 
   /*!
@@ -634,5 +634,10 @@ std::ostream& operator<<(std::ostream& os, const Polyhedron<T, NDIMS>& poly)
 
 }  // namespace primal
 }  // namespace axom
+
+/// Overload to format a primal::Tetrahedron using fmt
+template <typename T, int NDIMS>
+struct axom::fmt::formatter<axom::primal::Polyhedron<T, NDIMS>> : ostream_formatter
+{ };
 
 #endif  // AXOM_PRIMAL_POLYHEDRON_HPP_

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -721,20 +721,24 @@ bool intersect_tri_bbox(const primal::Triangle<T, 3>& tri,
   //           1 test for the triangle face normal
   // We use early termination if we find a separating axis between the shapes
 
-  typedef typename BoundingBox<T, 3>::PointType PointType;
-  typedef typename BoundingBox<T, 3>::VectorType VectorType;
+  using PointType = typename BoundingBox<T, 3>::PointType;
+  using VectorType = typename BoundingBox<T, 3>::VectorType;
+
+  // Check for early return -- nothing intersects an empty/invalid bounding box
+  if(!bb.isValid())
+  {
+    return false;
+  }
 
   // Extent: vector center to max corner of BB
-  VectorType e = 0.5 * bb.range();
+  const VectorType e = 0.5 * bb.range();
 
   // Make the AABB center the origin by moving the triangle vertices
-  PointType center(bb.getMin().array() + e.array());
-  VectorType v[3] = {VectorType(center, tri[0]),
-                     VectorType(center, tri[1]),
-                     VectorType(center, tri[2])};
+  const PointType center = bb.getMin() + e;
+  const VectorType v[3] = {tri[0] - center, tri[1] - center, tri[2] - center};
 
   // Create the edge vectors of the triangle
-  VectorType f[3] = {v[1] - v[0], v[2] - v[1], v[0] - v[2]};
+  const VectorType f[3] = {v[1] - v[0], v[2] - v[1], v[0] - v[2]};
 
   /* clang-format off */
 
@@ -771,12 +775,13 @@ bool intersect_tri_bbox(const primal::Triangle<T, 3>& tri,
   }
 
   /// Final test -- face normal of triangle's plane
-  VectorType planeNormal = VectorType::cross_product(f[0], f[1]);
-  double planeDist = planeNormal.dot(VectorType(tri[0]));
+  const VectorType planeNormal = VectorType::cross_product(f[0], f[1]);
+  const double planeDist = planeNormal.dot(VectorType(tri[0]));
 
-  double r = e[0] * std::abs(planeNormal[0]) + e[1] * std::abs(planeNormal[1]) +
-    e[2] * std::abs(planeNormal[2]);
-  double s = planeNormal.dot(VectorType(center)) - planeDist;
+  const double r = e[0] * std::abs(planeNormal[0])  //
+    + e[1] * std::abs(planeNormal[1])               //
+    + e[2] * std::abs(planeNormal[2]);
+  const double s = planeNormal.dot(VectorType(center)) - planeDist;
 
   return std::abs(s) <= r;
 }

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -1136,20 +1136,19 @@ bool intersect_obb3D_obb3D(const OrientedBoundingBox<T, 3>& b1,
 
 /*!
  * \brief Determines if a 3D plane intersects a 3D bounding box.
- *        By default (checkOverlaps is false), checks if |s| <= r, 
- *        where "s" is the distance of the bounding box center to the plane,
- *        and "r" is the projected radius of the bounding box along the line
+ *        By default (i.e. \a checkOverlaps is false), checks if |s| <= r, 
+ *        where \a s is the distance of the bounding box center to the plane,
+ *        and \a r is the projected radius of the bounding box along the line
  *        parallel to the plane normal and going through the box center.
- *        If checkOverlaps is true, checks if |s| < r,
+ *        If \a checkOverlaps is true, checks if |s| < r,
  *        where the bounding box overlaps both half spaces of the plane.
  * \param [in] p A 3D plane
  * \param [in] bb A 3D bounding box
  * \param [in] checkOverlaps If true, checks if bounding box overlaps both 
- *             halfspaces of the plane.
- *             Otherwise, overlap of both halfspaces is not guaranteed.
- *             Default is false.
- * \param [in] EPS tolerance parameter for determining if "s"
- *             is just within min/max of "r".
+ *             halfspaces of the plane. Otherwise, overlap of both halfspaces 
+ *             is not guaranteed. Default is false.
+ * \param [in] EPS tolerance parameter for determining if \a s
+ *             is just within min/max of \a r.
  * \return true iff plane intersects with bounding box, otherwise, false.
  */
 template <typename T>
@@ -1158,26 +1157,26 @@ AXOM_HOST_DEVICE bool intersect_plane_bbox(const Plane<T, 3>& p,
                                            bool checkOverlaps = false,
                                            double EPS = 1E-12)
 {
-  typedef Vector<T, 3> VectorType;
+  using VectorType = Vector<T, 3>;
 
-  VectorType c(bb.getCentroid());
-  VectorType e(bb.getCentroid(), bb.getMax());
-
-  T r = e[0] * utilities::abs<T>(p.getNormal()[0]) +
-    e[1] * utilities::abs<T>(p.getNormal()[1]) +
-    e[2] * utilities::abs<T>(p.getNormal()[2]);
-
-  T s = p.getNormal().dot(c) - p.getOffset();
-
-  if(checkOverlaps)
+  // Check for early return -- planes cannot intersect invalid bounding boxes
+  if(!bb.isValid())
   {
-    return isLt(utilities::abs<T>(s), r, EPS);
+    return false;
   }
 
-  else
-  {
-    return isLeq(utilities::abs<T>(s), r, EPS);
-  }
+  const auto centroid = bb.getCentroid();
+  const VectorType e = bb.getMax() - centroid;
+
+  const auto& N = p.getNormal();
+  const T r = e[0] * utilities::abs<T>(N[0])  //
+    + e[1] * utilities::abs<T>(N[1])          //
+    + e[2] * utilities::abs<T>(N[2]);
+
+  const T s = p.signedDistance(centroid);
+
+  return checkOverlaps ? isLt(utilities::abs<T>(s), r, EPS)
+                       : isLeq(utilities::abs<T>(s), r, EPS);
 }
 
 /*!
@@ -1193,7 +1192,7 @@ AXOM_HOST_DEVICE bool intersect_plane_seg(const Plane<T, 3>& plane,
                                           const Segment<T, 3>& seg,
                                           T& t)
 {
-  typedef Vector<T, 3> VectorType;
+  using VectorType = Vector<T, 3>;
 
   VectorType ab(seg.source(), seg.target());
   VectorType normal = plane.getNormal();

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -101,7 +101,7 @@ TEST(primal_clip, simple_clip)
 TEST(primal_clip, unit_simplex)
 {
   using namespace Primal3D;
-  double delta = 1e-5;
+  constexpr double delta = 1e-5;
 
   // Test the "unit simplex", and a jittered version
   PointType points[] = {PointType {1, 0, 0},
@@ -143,8 +143,8 @@ TEST(primal_clip, boundingBoxOptimization)
   SLIC_INFO("Checking correctness of optimization for skipping clipping "
             << " of planes that the triangle's bounding box doesn't cover");
 
-  const double VAL1 = 3.;
-  const double VAL2 = 2.;
+  constexpr double VAL1 = 3.;
+  constexpr double VAL2 = 2.;
 
   BoundingBoxType bbox;
   bbox.addPoint(PointType(-1.));
@@ -187,7 +187,7 @@ TEST(primal_clip, experimentalData)
 {
   using namespace Primal3D;
 
-  const double EPS = 1e-8;
+  constexpr double EPS = 1e-8;
 
   // Triangle 248 from sphere mesh
   TriangleType tri(PointType {0.405431, 3.91921, 3.07821},
@@ -371,17 +371,17 @@ void check_oct_tet_clip(double EPS)
   OctahedronType* oct = axom::allocate<OctahedronType>(1);
   PolyhedronType* res = axom::allocate<PolyhedronType>(1);
 
-  tet[0] = TetrahedronType(PointType({1, 0, 0}),
-                           PointType({1, 1, 0}),
-                           PointType({0, 1, 0}),
-                           PointType({1, 0, 1}));
+  tet[0] = TetrahedronType(PointType {1, 0, 0},
+                           PointType {1, 1, 0},
+                           PointType {0, 1, 0},
+                           PointType {1, 0, 1});
 
-  oct[0] = OctahedronType(PointType({1, 0, 0}),
-                          PointType({1, 1, 0}),
-                          PointType({0, 1, 0}),
-                          PointType({0, 1, 1}),
-                          PointType({0, 0, 1}),
-                          PointType({1, 0, 1}));
+  oct[0] = OctahedronType(PointType {1, 0, 0},
+                          PointType {1, 1, 0},
+                          PointType {0, 1, 0},
+                          PointType {0, 1, 1},
+                          PointType {0, 0, 1},
+                          PointType {1, 0, 1});
 
   axom::for_all<ExecPolicy>(
     1,
@@ -412,15 +412,15 @@ void check_tet_tet_clip(double EPS)
   TetrahedronType* tet2 = axom::allocate<TetrahedronType>(1);
   PolyhedronType* res = axom::allocate<PolyhedronType>(1);
 
-  tet1[0] = TetrahedronType(PointType({1, 0, 0}),
-                            PointType({1, 1, 0}),
-                            PointType({0, 1, 0}),
-                            PointType({1, 1, 1}));
+  tet1[0] = TetrahedronType(PointType {1, 0, 0},
+                            PointType {1, 1, 0},
+                            PointType {0, 1, 0},
+                            PointType {1, 1, 1});
 
-  tet2[0] = TetrahedronType(PointType({0, 0, 0}),
-                            PointType({1, 0, 0}),
-                            PointType({1, 1, 0}),
-                            PointType({1, 1, 1}));
+  tet2[0] = TetrahedronType(PointType {0, 0, 0},
+                            PointType {1, 0, 0},
+                            PointType {1, 1, 0},
+                            PointType {1, 1, 1});
 
   axom::for_all<ExecPolicy>(
     1,
@@ -442,13 +442,13 @@ TEST(primal_clip, unit_poly_clip_vertices_sequential)
 
 TEST(primal_clip, clip_oct_tet_sequential)
 {
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
   check_oct_tet_clip<axom::SEQ_EXEC>(EPS);
 }
 
 TEST(primal_clip, clip_tet_tet_sequential)
 {
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
   check_tet_tet_clip<axom::SEQ_EXEC>(EPS);
 }
 
@@ -460,13 +460,13 @@ TEST(primal_clip, unit_poly_clip_vertices_omp)
 
 TEST(primal_clip, clip_oct_tet_omp)
 {
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
   check_oct_tet_clip<axom::OMP_EXEC>(EPS);
 }
 
 TEST(primal_clip, clip_tet_tet_omp)
 {
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
   check_tet_tet_clip<axom::OMP_EXEC>(EPS);
 }
   #endif /* AXOM_USE_OPENMP */
@@ -479,13 +479,13 @@ AXOM_CUDA_TEST(primal_clip, unit_poly_clip_vertices_cuda)
 
 AXOM_CUDA_TEST(primal_clip, clip_oct_tet_cuda)
 {
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
   check_oct_tet_clip<axom::CUDA_EXEC<256>>(EPS);
 }
 
 TEST(primal_clip, clip_tet_tet_cuda)
 {
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
   check_tet_tet_clip<axom::CUDA_EXEC<256>>(EPS);
 }
   #endif /* AXOM_USE_CUDA */
@@ -498,13 +498,13 @@ TEST(primal_clip, unit_poly_clip_vertices_hip)
 
 TEST(primal_clip, clip_oct_tet_hip)
 {
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
   check_oct_tet_clip<axom::HIP_EXEC<256>>(EPS);
 }
 
 TEST(primal_clip, clip_tet_tet_hip)
 {
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
   check_tet_tet_clip<axom::HIP_EXEC<256>>(EPS);
 }
   #endif /* AXOM_USE_HIP */
@@ -516,16 +516,16 @@ TEST(primal_clip, oct_tet_clip_nonintersect)
 {
   using namespace Primal3D;
 
-  TetrahedronType tet(PointType({-1, -1, -1}),
-                      PointType({-1, 0, 0}),
-                      PointType({-1, -1, 0}),
-                      PointType({0, 0, 0}));
-  OctahedronType oct(PointType({1, 0, 0}),
-                     PointType({1, 1, 0}),
-                     PointType({0, 1, 0}),
-                     PointType({0, 1, 1}),
-                     PointType({0, 0, 1}),
-                     PointType({1, 0, 1}));
+  TetrahedronType tet(PointType {-1, -1, -1},
+                      PointType {-1, 0, 0},
+                      PointType {-1, -1, 0},
+                      PointType {0, 0, 0});
+  OctahedronType oct(PointType {1, 0, 0},
+                     PointType {1, 1, 0},
+                     PointType {0, 1, 0},
+                     PointType {0, 1, 1},
+                     PointType {0, 0, 1},
+                     PointType {1, 0, 1});
 
   PolyhedronType poly = axom::primal::clip(oct, tet);
   EXPECT_EQ(0.0, poly.volume());
@@ -535,18 +535,18 @@ TEST(primal_clip, oct_tet_clip_nonintersect)
 TEST(primal_clip, oct_tet_clip_encapsulate)
 {
   using namespace Primal3D;
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
 
-  TetrahedronType tet(PointType({1, 0, 0}),
-                      PointType({1, 1, 0}),
-                      PointType({0, 1, 0}),
-                      PointType({1, 0, 1}));
-  OctahedronType oct(PointType({1, 0, 0}),
-                     PointType({1, 1, 0}),
-                     PointType({0, 1, 0}),
-                     PointType({0, 1, 1}),
-                     PointType({0, 0, 1}),
-                     PointType({1, 0, 1}));
+  TetrahedronType tet(PointType {1, 0, 0},
+                      PointType {1, 1, 0},
+                      PointType {0, 1, 0},
+                      PointType {1, 0, 1});
+  OctahedronType oct(PointType {1, 0, 0},
+                     PointType {1, 1, 0},
+                     PointType {0, 1, 0},
+                     PointType {0, 1, 1},
+                     PointType {0, 0, 1},
+                     PointType {1, 0, 1});
 
   PolyhedronType poly = axom::primal::clip(oct, tet);
 
@@ -558,18 +558,18 @@ TEST(primal_clip, oct_tet_clip_encapsulate)
 TEST(primal_clip, oct_tet_clip_encapsulate_inv)
 {
   using namespace Primal3D;
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
 
-  TetrahedronType tet(PointType({0, 0, 0}),
-                      PointType({0, 2, 0}),
-                      PointType({0, 0, 2}),
-                      PointType({2, 0, 0}));
-  OctahedronType oct(PointType({1, 0, 0}),
-                     PointType({1, 1, 0}),
-                     PointType({0, 1, 0}),
-                     PointType({0, 1, 1}),
-                     PointType({0, 0, 1}),
-                     PointType({1, 0, 1}));
+  TetrahedronType tet(PointType {0, 0, 0},
+                      PointType {0, 2, 0},
+                      PointType {0, 0, 2},
+                      PointType {2, 0, 0});
+  OctahedronType oct(PointType {1, 0, 0},
+                     PointType {1, 1, 0},
+                     PointType {0, 1, 0},
+                     PointType {0, 1, 1},
+                     PointType {0, 0, 1},
+                     PointType {1, 0, 1});
 
   PolyhedronType poly = axom::primal::clip(oct, tet);
 
@@ -581,18 +581,18 @@ TEST(primal_clip, oct_tet_clip_encapsulate_inv)
 TEST(primal_clip, oct_tet_clip_half)
 {
   using namespace Primal3D;
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
 
-  TetrahedronType tet(PointType({0.5, 0.5, 2}),
-                      PointType({2, -1, 0}),
-                      PointType({-1, -1, 0}),
-                      PointType({-1, 2, 0}));
-  OctahedronType oct(PointType({1, 0, 0}),
-                     PointType({1, 1, 0}),
-                     PointType({0, 1, 0}),
-                     PointType({0, 1, 1}),
-                     PointType({0, 0, 1}),
-                     PointType({1, 0, 1}));
+  TetrahedronType tet(PointType {0.5, 0.5, 2},
+                      PointType {2, -1, 0},
+                      PointType {-1, -1, 0},
+                      PointType {-1, 2, 0});
+  OctahedronType oct(PointType {1, 0, 0},
+                     PointType {1, 1, 0},
+                     PointType {0, 1, 0},
+                     PointType {0, 1, 1},
+                     PointType {0, 0, 1},
+                     PointType {1, 0, 1});
 
   PolyhedronType poly = axom::primal::clip(oct, tet);
 
@@ -605,16 +605,16 @@ TEST(primal_clip, oct_tet_clip_adjacent)
 {
   using namespace Primal3D;
 
-  TetrahedronType tet(PointType({0, -1, 0}),
-                      PointType({0, 0, 1}),
-                      PointType({1, 0, 1}),
-                      PointType({1, 0, 0}));
-  OctahedronType oct(PointType({1, 0, 0}),
-                     PointType({1, 1, 0}),
-                     PointType({0, 1, 0}),
-                     PointType({0, 1, 1}),
-                     PointType({0, 0, 1}),
-                     PointType({1, 0, 1}));
+  TetrahedronType tet(PointType {0, -1, 0},
+                      PointType {0, 0, 1},
+                      PointType {1, 0, 1},
+                      PointType {1, 0, 0});
+  OctahedronType oct(PointType {1, 0, 0},
+                     PointType {1, 1, 0},
+                     PointType {0, 1, 0},
+                     PointType {0, 1, 1},
+                     PointType {0, 0, 1},
+                     PointType {1, 0, 1});
 
   PolyhedronType poly = axom::primal::clip(oct, tet);
 
@@ -626,16 +626,16 @@ TEST(primal_clip, oct_tet_clip_point)
 {
   using namespace Primal3D;
 
-  TetrahedronType tet(PointType({-1, -1, 0}),
-                      PointType({-0.5, 0.5, 0}),
-                      PointType({0, 0, 2}),
-                      PointType({0.5, -0.5, 0}));
-  OctahedronType oct(PointType({1, 0, 0}),
-                     PointType({1, 1, 0}),
-                     PointType({0, 1, 0}),
-                     PointType({0, 1, 1}),
-                     PointType({0, 0, 1}),
-                     PointType({1, 0, 1}));
+  TetrahedronType tet(PointType {-1, -1, 0},
+                      PointType {-0.5, 0.5, 0},
+                      PointType {0, 0, 2},
+                      PointType {0.5, -0.5, 0});
+  OctahedronType oct(PointType {1, 0, 0},
+                     PointType {1, 1, 0},
+                     PointType {0, 1, 0},
+                     PointType {0, 1, 1},
+                     PointType {0, 0, 1},
+                     PointType {1, 0, 1});
 
   PolyhedronType poly = axom::primal::clip(oct, tet);
 
@@ -645,29 +645,29 @@ TEST(primal_clip, oct_tet_clip_point)
 TEST(primal_clip, oct_tet_clip_special_case_1)
 {
   using namespace Primal3D;
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
 
-  TetrahedronType tet(PointType({0.5, 0.5, 0.5}),
-                      PointType({1, 1, 0}),
-                      PointType({1, 0, 0}),
-                      PointType({0.5, 0.5, 0}));
+  TetrahedronType tet(PointType {0.5, 0.5, 0.5},
+                      PointType {1, 1, 0},
+                      PointType {1, 0, 0},
+                      PointType {0.5, 0.5, 0});
 
-  OctahedronType oct(PointType({0.5, 0.853553, 0.146447}),
-                     PointType({0.853553, 0.853553, 0.5}),
-                     PointType({0.853553, 0.5, 0.146447}),
-                     PointType({1, 0.5, 0.5}),
-                     PointType({0.5, 0.5, 0}),
-                     PointType({0.5, 1, 0.5}));
+  OctahedronType oct(PointType {0.5, 0.853553, 0.146447},
+                     PointType {0.853553, 0.853553, 0.5},
+                     PointType {0.853553, 0.5, 0.146447},
+                     PointType {1, 0.5, 0.5},
+                     PointType {0.5, 0.5, 0},
+                     PointType {0.5, 1, 0.5});
 
   // NOTE: Order of vertices 1,2 and 4,5 are flipped due
   // to winding being opposite of what volume() expects
   PolyhedronType octPoly;
-  octPoly.addVertex(PointType({0.5, 0.853553, 0.146447}));
-  octPoly.addVertex(PointType({0.853553, 0.5, 0.146447}));
-  octPoly.addVertex(PointType({0.853553, 0.853553, 0.5}));
-  octPoly.addVertex(PointType({1, 0.5, 0.5}));
-  octPoly.addVertex(PointType({0.5, 1, 0.5}));
-  octPoly.addVertex(PointType({0.5, 0.5, 0}));
+  octPoly.addVertex(PointType {0.5, 0.853553, 0.146447});
+  octPoly.addVertex(PointType {0.853553, 0.5, 0.146447});
+  octPoly.addVertex(PointType {0.853553, 0.853553, 0.5});
+  octPoly.addVertex(PointType {1, 0.5, 0.5});
+  octPoly.addVertex(PointType {0.5, 1, 0.5});
+  octPoly.addVertex(PointType {0.5, 0.5, 0});
 
   octPoly.addNeighbors(0, {1, 5, 4, 2});
   octPoly.addNeighbors(1, {0, 2, 3, 5});
@@ -686,29 +686,29 @@ TEST(primal_clip, oct_tet_clip_special_case_1)
 TEST(primal_clip, oct_tet_clip_special_case_2)
 {
   using namespace Primal3D;
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
 
-  TetrahedronType tet(PointType({0.5, 0.5, 0.5}),
-                      PointType({0, 1, 0}),
-                      PointType({1, 1, 0}),
-                      PointType({0.5, 0.5, 0}));
+  TetrahedronType tet(PointType {0.5, 0.5, 0.5},
+                      PointType {0, 1, 0},
+                      PointType {1, 1, 0},
+                      PointType {0.5, 0.5, 0});
 
-  OctahedronType oct(PointType({0.5, 0.853553, 0.146447}),
-                     PointType({0.853553, 0.853553, 0.5}),
-                     PointType({0.853553, 0.5, 0.146447}),
-                     PointType({1, 0.5, 0.5}),
-                     PointType({0.5, 0.5, 0}),
-                     PointType({0.5, 1, 0.5}));
+  OctahedronType oct(PointType {0.5, 0.853553, 0.146447},
+                     PointType {0.853553, 0.853553, 0.5},
+                     PointType {0.853553, 0.5, 0.146447},
+                     PointType {1, 0.5, 0.5},
+                     PointType {0.5, 0.5, 0},
+                     PointType {0.5, 1, 0.5});
 
   // NOTE: Order of vertices 1,2 and 4,5 are flipped due
   // to winding being opposite of what volume() expects
   PolyhedronType octPoly;
-  octPoly.addVertex(PointType({0.5, 0.853553, 0.146447}));
-  octPoly.addVertex(PointType({0.853553, 0.5, 0.146447}));
-  octPoly.addVertex(PointType({0.853553, 0.853553, 0.5}));
-  octPoly.addVertex(PointType({1, 0.5, 0.5}));
-  octPoly.addVertex(PointType({0.5, 1, 0.5}));
-  octPoly.addVertex(PointType({0.5, 0.5, 0}));
+  octPoly.addVertex(PointType {0.5, 0.853553, 0.146447});
+  octPoly.addVertex(PointType {0.853553, 0.5, 0.146447});
+  octPoly.addVertex(PointType {0.853553, 0.853553, 0.5});
+  octPoly.addVertex(PointType {1, 0.5, 0.5});
+  octPoly.addVertex(PointType {0.5, 1, 0.5});
+  octPoly.addVertex(PointType {0.5, 0.5, 0});
 
   octPoly.addNeighbors(0, {1, 5, 4, 2});
   octPoly.addNeighbors(1, {0, 2, 3, 5});
@@ -729,18 +729,40 @@ TEST(primal_clip, tet_tet_clip_nonintersect)
 {
   using namespace Primal3D;
 
-  TetrahedronType tet1(PointType({-1, -1, -1}),
-                       PointType({-1, 0, 0}),
-                       PointType({-1, -1, 0}),
-                       PointType({0, 0, 0}));
+  {
+    TetrahedronType tet1(PointType {-1, -1, -1},
+                         PointType {-1, 0, 0},
+                         PointType {-1, -1, 0},
+                         PointType {0, 0, 0});
+    EXPECT_TRUE(tet1.signedVolume() > 0.);
 
-  TetrahedronType tet2(PointType({1, 0, 0}),
-                       PointType({1, 1, 0}),
-                       PointType({0, 1, 0}),
-                       PointType({1, 0, 1}));
+    TetrahedronType tet2(PointType {1, 0, 0},
+                         PointType {1, 1, 0},
+                         PointType {0, 1, 0},
+                         PointType {1, 0, 1});
+    EXPECT_TRUE(tet2.signedVolume() > 0.);
 
-  PolyhedronType poly = axom::primal::clip(tet1, tet2);
-  EXPECT_EQ(0.0, poly.volume());
+    PolyhedronType poly = axom::primal::clip(tet1, tet2);
+    EXPECT_EQ(0.0, poly.volume());
+  }
+
+  // User-provided test case; tetrahedra do not overlap
+  {
+    TetrahedronType tet1(PointType {0, 1, 0},
+                         PointType {-1, 0, 0},
+                         PointType {0, -1, 0},
+                         PointType {-0.25, 0, 0.25});
+    EXPECT_TRUE(tet1.signedVolume() > 0.);
+
+    TetrahedronType tet2(PointType {0.74899999999999922, 0, 1},
+                         PointType {1.7489999999999992, 0, 0},
+                         PointType {0.74899999999999922, -1, 0},
+                         PointType {0.99899999999999922, 0, 0.25});
+    EXPECT_TRUE(tet2.signedVolume() > 0.);
+
+    PolyhedronType poly = axom::primal::clip(tet1, tet2);
+    EXPECT_EQ(0.0, poly.volume());
+  }
 }
 
 // Tetrahedron is adjacent to tetrahedron
@@ -748,15 +770,15 @@ TEST(primal_clip, tet_tet_clip_adjacent)
 {
   using namespace Primal3D;
 
-  TetrahedronType tet1(PointType({1, 0, 0}),
-                       PointType({1, 1, 0}),
-                       PointType({0, 1, 0}),
-                       PointType({1, 0, 1}));
+  TetrahedronType tet1(PointType {1, 0, 0},
+                       PointType {1, 1, 0},
+                       PointType {0, 1, 0},
+                       PointType {1, 0, 1});
 
-  TetrahedronType tet2(PointType({1, 0, 1}),
-                       PointType({0, 1, 0}),
-                       PointType({1, 0, 0}),
-                       PointType({0, 0, 0}));
+  TetrahedronType tet2(PointType {1, 0, 1},
+                       PointType {0, 1, 0},
+                       PointType {1, 0, 0},
+                       PointType {0, 0, 0});
 
   PolyhedronType poly = axom::primal::clip(tet1, tet2);
   EXPECT_EQ(0.0, poly.volume());
@@ -767,15 +789,15 @@ TEST(primal_clip, tet_tet_clip_point)
 {
   using namespace Primal3D;
 
-  TetrahedronType tet1(PointType({1, 0, 0}),
-                       PointType({1, 1, 0}),
-                       PointType({0, 1, 0}),
-                       PointType({1, 0, 1}));
+  TetrahedronType tet1(PointType {1, 0, 0},
+                       PointType {1, 1, 0},
+                       PointType {0, 1, 0},
+                       PointType {1, 0, 1});
 
-  TetrahedronType tet2(PointType({0, 1, 0}),
-                       PointType({0, 0, 0}),
-                       PointType({-1, 0, 0}),
-                       PointType({0, 0, 1}));
+  TetrahedronType tet2(PointType {0, 1, 0},
+                       PointType {0, 0, 0},
+                       PointType {-1, 0, 0},
+                       PointType {0, 0, 1});
 
   PolyhedronType poly = axom::primal::clip(tet1, tet2);
   EXPECT_EQ(0.0, poly.volume());
@@ -787,10 +809,10 @@ TEST(primal_clip, tet_tet_equal)
   using namespace Primal3D;
   const double EPS = 1e-4;
 
-  TetrahedronType tet(PointType({1, 0, 0}),
-                      PointType({1, 1, 0}),
-                      PointType({0, 1, 0}),
-                      PointType({1, 0, 1}));
+  TetrahedronType tet(PointType {1, 0, 0},
+                      PointType {1, 1, 0},
+                      PointType {0, 1, 0},
+                      PointType {1, 0, 1});
 
   PolyhedronType poly = axom::primal::clip(tet, tet);
 
@@ -802,17 +824,17 @@ TEST(primal_clip, tet_tet_equal)
 TEST(primal_clip, tet_tet_encapsulate)
 {
   using namespace Primal3D;
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
 
-  TetrahedronType tet1(PointType({1, 0, 0}),
-                       PointType({1, 1, 0}),
-                       PointType({0, 1, 0}),
-                       PointType({1, 0, 1}));
+  TetrahedronType tet1(PointType {1, 0, 0},
+                       PointType {1, 1, 0},
+                       PointType {0, 1, 0},
+                       PointType {1, 0, 1});
 
-  TetrahedronType tet2(PointType({3, 0, 0}),
-                       PointType({0, 3, 0}),
-                       PointType({-3, 0, 0}),
-                       PointType({0, 0, 3}));
+  TetrahedronType tet2(PointType {3, 0, 0},
+                       PointType {0, 3, 0},
+                       PointType {-3, 0, 0},
+                       PointType {0, 0, 3});
 
   PolyhedronType poly = axom::primal::clip(tet1, tet2);
 
@@ -824,17 +846,17 @@ TEST(primal_clip, tet_tet_encapsulate)
 TEST(primal_clip, tet_tet_half)
 {
   using namespace Primal3D;
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
 
-  TetrahedronType tet1(PointType({1, 0, 0}),
-                       PointType({1, 1, 0}),
-                       PointType({0, 1, 0}),
-                       PointType({1, 1, 1}));
+  TetrahedronType tet1(PointType {1, 0, 0},
+                       PointType {1, 1, 0},
+                       PointType {0, 1, 0},
+                       PointType {1, 1, 1});
 
-  TetrahedronType tet2(PointType({0, 0, 0}),
-                       PointType({1, 0, 0}),
-                       PointType({1, 1, 0}),
-                       PointType({1, 1, 1}));
+  TetrahedronType tet2(PointType {0, 0, 0},
+                       PointType {1, 0, 0},
+                       PointType {1, 1, 0},
+                       PointType {1, 1, 1});
 
   PolyhedronType poly = axom::primal::clip(tet1, tet2);
 
@@ -849,18 +871,18 @@ TEST(primal_clip, tet_tet_half)
 TEST(primal_clip, tet_tet_clip_split)
 {
   using namespace Primal3D;
-  const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
 
-  TetrahedronType tet(PointType({0.5, 0.5, 2}),
-                      PointType({2, -1, 0}),
-                      PointType({-1, -1, 0}),
-                      PointType({-1, 2, 0}));
-  OctahedronType oct(PointType({1, 0, 0}),
-                     PointType({1, 1, 0}),
-                     PointType({0, 1, 0}),
-                     PointType({0, 1, 1}),
-                     PointType({0, 0, 1}),
-                     PointType({1, 0, 1}));
+  TetrahedronType tet(PointType {0.5, 0.5, 2},
+                      PointType {2, -1, 0},
+                      PointType {-1, -1, 0},
+                      PointType {-1, 2, 0});
+  OctahedronType oct(PointType {1, 0, 0},
+                     PointType {1, 1, 0},
+                     PointType {0, 1, 0},
+                     PointType {0, 1, 1},
+                     PointType {0, 0, 1},
+                     PointType {1, 0, 1});
 
   PolyhedronType poly = axom::primal::clip(oct, tet);
 

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -286,9 +286,24 @@ TEST(primal_intersect, more_ray_segment_intersection)
   }
 }
 
+TEST(primal_intersect, triangle_empty_aabb_intersection)
+{
+  constexpr int DIM = 3;
+  using PointType = primal::Point<double, DIM>;
+  using TriangleType = primal::Triangle<double, DIM>;
+  using BoundingBoxType = primal::BoundingBox<double, DIM>;
+
+  TriangleType unitTri(PointType {1., 0., 0.},
+                       PointType {0., 1., 0.},
+                       PointType {0., 0., 1.});
+  BoundingBoxType emptyBB;
+
+  EXPECT_FALSE(primal::intersect(unitTri, emptyBB));
+}
+
 TEST(primal_intersect, triangle_aabb_intersection)
 {
-  const int DIM = 3;
+  constexpr int DIM = 3;
   using PointType = primal::Point<double, DIM>;
   using TriangleType = primal::Triangle<double, DIM>;
   using BoundingBoxType = primal::BoundingBox<double, DIM>;

--- a/src/axom/primal/tests/primal_intersect_impl.cpp
+++ b/src/axom/primal/tests/primal_intersect_impl.cpp
@@ -8,11 +8,11 @@
 
 #include "axom/primal/operators/detail/intersect_impl.hpp"
 
-using namespace axom;
+namespace primal = axom::primal;
 
 TEST(primal_intersection_impl, fuzzy_comparisons)
 {
-  const double eps = 0.1;
+  constexpr double eps = 0.1;
 
   SLIC_INFO("This test demonstrates the fuzzy comparison"
             << " operators used in quest's intersection tests"
@@ -87,7 +87,7 @@ TEST(primal_intersection_impl, fuzzy_comparisons)
 
 TEST(primal_intersection_impl, zero_count)
 {
-  const double eps = 0.1;
+  constexpr double eps = 0.1;
 
   int expectedCount = 0;
 
@@ -139,7 +139,6 @@ int main(int argc, char* argv[])
 
   ::testing::InitGoogleTest(&argc, argv);
 
-  // create & initialize test logger, finalized when exiting main scope
   axom::slic::SimpleLogger logger;
 
   result = RUN_ALL_TESTS();

--- a/src/axom/primal/tests/primal_polygon.cpp
+++ b/src/axom/primal/tests/primal_polygon.cpp
@@ -9,7 +9,7 @@
 #include "axom/slic.hpp"
 
 //------------------------------------------------------------------------------
-TEST(primal_polygon, polygon_empty)
+TEST(primal_polygon, empty)
 {
   using PolygonType = axom::primal::Polygon<double, 3>;
   PolygonType poly;
@@ -17,7 +17,7 @@ TEST(primal_polygon, polygon_empty)
 }
 
 //------------------------------------------------------------------------------
-TEST(primal_polygon, polygon_winding_number)
+TEST(primal_polygon, winding_number)
 {
   using PolygonType = axom::primal::Polygon<double, 2>;
   using PointType = axom::primal::Point<double, 2>;
@@ -29,10 +29,10 @@ TEST(primal_polygon, polygon_winding_number)
   PolygonType poly(vertices);
 
   // Test the specific winding numbers
-  EXPECT_EQ(winding_number(PointType({0.25, 0.5}), poly), 1);
-  EXPECT_EQ(winding_number(PointType({0.75, 0.5}), poly), -1);
-  EXPECT_EQ(winding_number(PointType({0.5, 0.25}), poly), 0);
-  EXPECT_EQ(winding_number(PointType({0.5, 0.75}), poly), 0);
+  EXPECT_EQ(winding_number(PointType {0.25, 0.5}, poly), 1);
+  EXPECT_EQ(winding_number(PointType {0.75, 0.5}, poly), -1);
+  EXPECT_EQ(winding_number(PointType {0.5, 0.25}, poly), 0);
+  EXPECT_EQ(winding_number(PointType {0.5, 0.75}, poly), 0);
 
   vertices = axom::Array<PointType>({PointType {0, 1},
                                      PointType {0, -1},
@@ -42,19 +42,19 @@ TEST(primal_polygon, polygon_winding_number)
                                      PointType {-2, -2}});
 
   poly = PolygonType(vertices);
-  EXPECT_EQ(winding_number(PointType({-0.1, 0.0}), poly), -2);
-  EXPECT_EQ(winding_number(PointType({0.1, 0.0}), poly), -1);
-  EXPECT_EQ(winding_number(PointType({-2.0, 0.0}), poly), 0);
-  EXPECT_EQ(winding_number(PointType({2.5, 0.0}), poly), 0);
+  EXPECT_EQ(winding_number(PointType {-0.1, 0.0}, poly), -2);
+  EXPECT_EQ(winding_number(PointType {0.1, 0.0}, poly), -1);
+  EXPECT_EQ(winding_number(PointType {-2.0, 0.0}, poly), 0);
+  EXPECT_EQ(winding_number(PointType {2.5, 0.0}, poly), 0);
 
   // Current policy is to return 1 on edges without strict inclusion,
   //  0 on edges with strict inclusion, as 0 always indicates "interior"
-  EXPECT_EQ(winding_number(PointType({0.0, 0.0}), poly, !useStrictInclusion), 1);
-  EXPECT_EQ(winding_number(PointType({0.0, 0.0}), poly, useStrictInclusion), 0);
+  EXPECT_EQ(winding_number(PointType {0.0, 0.0}, poly, !useStrictInclusion), 1);
+  EXPECT_EQ(winding_number(PointType {0.0, 0.0}, poly, useStrictInclusion), 0);
 }
 
 //------------------------------------------------------------------------------
-TEST(primal_polygon, polygon_containment)
+TEST(primal_polygon, containment)
 {
   using PolygonType = axom::primal::Polygon<double, 2>;
   using PointType = axom::primal::Point<double, 2>;
@@ -67,21 +67,21 @@ TEST(primal_polygon, polygon_containment)
   PolygonType poly(vertices);
 
   // Simple cases on non-convex polygon
-  EXPECT_TRUE(in_polygon(PointType({0.25, 0.5}), poly));
-  EXPECT_TRUE(in_polygon(PointType({0.75, 0.5}), poly));
-  EXPECT_FALSE(in_polygon(PointType({0.5, 0.25}), poly));
-  EXPECT_FALSE(in_polygon(PointType({0.5, 0.75}), poly));
+  EXPECT_TRUE(in_polygon(PointType {0.25, 0.5}, poly));
+  EXPECT_TRUE(in_polygon(PointType {0.75, 0.5}, poly));
+  EXPECT_FALSE(in_polygon(PointType {0.5, 0.25}, poly));
+  EXPECT_FALSE(in_polygon(PointType {0.5, 0.75}, poly));
 
   // Edge cases, where vertex is aligned with edge
-  EXPECT_FALSE(in_polygon(PointType({-0.25, -0.25}), poly));
-  EXPECT_FALSE(in_polygon(PointType({1.25, 1.25}), poly));
-  EXPECT_FALSE(in_polygon(PointType({-0.25, 1.25}), poly));
-  EXPECT_FALSE(in_polygon(PointType({1.25, -0.25}), poly));
-  EXPECT_FALSE(in_polygon(PointType({0.0, 1.25}), poly));
-  EXPECT_FALSE(in_polygon(PointType({0.0, -0.25}), poly));
-  EXPECT_FALSE(in_polygon(PointType({-1.0, 0.0}), poly));
-  EXPECT_FALSE(in_polygon(PointType({1.0, 1.25}), poly));
-  EXPECT_FALSE(in_polygon(PointType({1.0, -0.25}), poly));
+  EXPECT_FALSE(in_polygon(PointType {-0.25, -0.25}, poly));
+  EXPECT_FALSE(in_polygon(PointType {1.25, 1.25}, poly));
+  EXPECT_FALSE(in_polygon(PointType {-0.25, 1.25}, poly));
+  EXPECT_FALSE(in_polygon(PointType {1.25, -0.25}, poly));
+  EXPECT_FALSE(in_polygon(PointType {0.0, 1.25}, poly));
+  EXPECT_FALSE(in_polygon(PointType {0.0, -0.25}, poly));
+  EXPECT_FALSE(in_polygon(PointType {-1.0, 0.0}, poly));
+  EXPECT_FALSE(in_polygon(PointType {1.0, 1.25}, poly));
+  EXPECT_FALSE(in_polygon(PointType {1.0, -0.25}, poly));
 
   // Test different in/out protocols for polygon with extra loop
   vertices = axom::Array<PointType>({PointType {0, 1},
@@ -94,11 +94,11 @@ TEST(primal_polygon, polygon_containment)
   poly = PolygonType(vertices);
 
   // true denotes nonzero protocol. Default for SVG
-  EXPECT_TRUE(in_polygon(PointType({-0.1, 0.0}), poly));
-  EXPECT_TRUE(in_polygon(PointType({-0.1, 0.0}), poly, useNonzeroRule));
+  EXPECT_TRUE(in_polygon(PointType {-0.1, 0.0}, poly));
+  EXPECT_TRUE(in_polygon(PointType {-0.1, 0.0}, poly, useNonzeroRule));
 
   // false denotes evenodd protocol
-  EXPECT_FALSE(in_polygon(PointType({-0.1, 0.0}), poly, useEvenOddRule));
+  EXPECT_FALSE(in_polygon(PointType {-0.1, 0.0}, poly, useEvenOddRule));
 
   // Test in/out on degenerate example in Hormann2001, Figure 6
   axom::Array<PointType> init_vertices(
@@ -123,7 +123,7 @@ TEST(primal_polygon, polygon_containment)
   }
 }
 
-TEST(primal_polygon, polygon_containment_invariants)
+TEST(primal_polygon, containment_invariants)
 {
   using PolygonType = axom::primal::Polygon<double, 2>;
   using PointType = axom::primal::Point<double, 2>;
@@ -134,12 +134,14 @@ TEST(primal_polygon, polygon_containment_invariants)
   PolygonType poly;
   for(int i = 0; i < 4; i++)
     for(int j = 0; j < 3; j++)  // Duplicate each element 3 times
+    {
       poly.addVertex(vertices[i]);
+    }
 
-  EXPECT_TRUE(in_polygon(PointType({0.25, 0.5}), poly));
-  EXPECT_TRUE(in_polygon(PointType({0.75, 0.5}), poly));
-  EXPECT_FALSE(in_polygon(PointType({0.5, 0.25}), poly));
-  EXPECT_FALSE(in_polygon(PointType({0.5, 0.75}), poly));
+  EXPECT_TRUE(in_polygon(PointType {0.25, 0.5}, poly));
+  EXPECT_TRUE(in_polygon(PointType {0.75, 0.5}, poly));
+  EXPECT_FALSE(in_polygon(PointType {0.5, 0.25}, poly));
+  EXPECT_FALSE(in_polygon(PointType {0.5, 0.75}, poly));
 
   // Verify checks up to rotation of vertices
   vertices = axom::Array<PointType>(
@@ -149,14 +151,14 @@ TEST(primal_polygon, polygon_containment_invariants)
   {
     poly.clear();
     for(int j = 0; j < 4; j++) poly.addVertex(vertices[(j + i) % 4]);
-    EXPECT_TRUE(in_polygon(PointType({0.25, 0.5}), poly));
-    EXPECT_TRUE(in_polygon(PointType({0.75, 0.5}), poly));
-    EXPECT_FALSE(in_polygon(PointType({0.5, 0.25}), poly));
-    EXPECT_FALSE(in_polygon(PointType({0.5, 0.75}), poly));
+    EXPECT_TRUE(in_polygon(PointType {0.25, 0.5}, poly));
+    EXPECT_TRUE(in_polygon(PointType {0.75, 0.5}, poly));
+    EXPECT_FALSE(in_polygon(PointType {0.5, 0.25}, poly));
+    EXPECT_FALSE(in_polygon(PointType {0.5, 0.75}, poly));
   }
 }
 
-TEST(primal_polygon, polygon_containment_edge)
+TEST(primal_polygon, containment_edge)
 {
   using PolygonType = axom::primal::Polygon<double, 2>;
   using PointType = axom::primal::Point<double, 2>;
@@ -174,29 +176,29 @@ TEST(primal_polygon, polygon_containment_edge)
   for(bool useNonzeroRule : {true, false})
   {
     EXPECT_TRUE(
-      in_polygon(PointType({0, 0.5}), poly, useNonzeroRule, !useStrictInclusion));
+      in_polygon(PointType {0, 0.5}, poly, useNonzeroRule, !useStrictInclusion));
     EXPECT_TRUE(
-      in_polygon(PointType({0.5, 0.5}), poly, useNonzeroRule, !useStrictInclusion));
+      in_polygon(PointType {0.5, 0.5}, poly, useNonzeroRule, !useStrictInclusion));
     EXPECT_TRUE(
-      in_polygon(PointType({.25, .25}), poly, useNonzeroRule, !useStrictInclusion));
+      in_polygon(PointType {.25, .25}, poly, useNonzeroRule, !useStrictInclusion));
     EXPECT_TRUE(
-      in_polygon(PointType({.25, .75}), poly, useNonzeroRule, !useStrictInclusion));
+      in_polygon(PointType {.25, .75}, poly, useNonzeroRule, !useStrictInclusion));
     EXPECT_TRUE(
-      in_polygon(PointType({1, 0.5}), poly, useNonzeroRule, !useStrictInclusion));
+      in_polygon(PointType {1, 0.5}, poly, useNonzeroRule, !useStrictInclusion));
   }
 
   for(bool useNonzeroRule : {true, false})
   {
     EXPECT_FALSE(
-      in_polygon(PointType({0, 0.5}), poly, useNonzeroRule, useStrictInclusion));
+      in_polygon(PointType {0, 0.5}, poly, useNonzeroRule, useStrictInclusion));
     EXPECT_FALSE(
-      in_polygon(PointType({0.5, 0.5}), poly, useNonzeroRule, useStrictInclusion));
+      in_polygon(PointType {0.5, 0.5}, poly, useNonzeroRule, useStrictInclusion));
     EXPECT_FALSE(
-      in_polygon(PointType({.25, .25}), poly, useNonzeroRule, useStrictInclusion));
+      in_polygon(PointType {.25, .25}, poly, useNonzeroRule, useStrictInclusion));
     EXPECT_FALSE(
-      in_polygon(PointType({.25, .75}), poly, useNonzeroRule, useStrictInclusion));
+      in_polygon(PointType {.25, .75}, poly, useNonzeroRule, useStrictInclusion));
     EXPECT_FALSE(
-      in_polygon(PointType({1, 0.5}), poly, useNonzeroRule, useStrictInclusion));
+      in_polygon(PointType {1, 0.5}, poly, useNonzeroRule, useStrictInclusion));
   }
 
   // Corner cases, where query is on a vertex
@@ -220,7 +222,7 @@ TEST(primal_polygon, polygon_containment_edge)
 }
 
 //------------------------------------------------------------------------------
-TEST(primal_polygon, polygon_convexity)
+TEST(primal_polygon, convexity)
 {
   using PolygonType = axom::primal::Polygon<double, 2>;
   using PointType = axom::primal::Point<double, 2>;
@@ -240,7 +242,9 @@ TEST(primal_polygon, polygon_convexity)
   poly.clear();
   for(int i = 0; i < 4; i++)
     for(int j = 0; j < 3; j++)  // Duplicate each element 3 times
+    {
       poly.addVertex(vertices[i]);
+    }
 
   EXPECT_TRUE(is_convex(poly));
 
@@ -263,6 +267,105 @@ TEST(primal_polygon, polygon_convexity)
     poly.clear();
     for(int j = 0; j < 4; j++) poly.addVertex(vertices[(j + i) % 4]);
     EXPECT_TRUE(is_convex(poly));
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_polygon, signed_area_2d)
+{
+  using Polygon2D = axom::primal::Polygon<double, 2>;
+  using Point2D = axom::primal::Point<double, 2>;
+  using axom::utilities::abs;
+
+  // test a simple right triangle in CW and CCW orientations
+  {
+    Polygon2D poly2D_ccw({Point2D {0, 0}, Point2D {1, 0}, Point2D {1, 1}});
+    Polygon2D poly2D_cw({Point2D {0, 0}, Point2D {1, 1}, Point2D {1, 0}});
+
+    // Signed area is positive for CCW and negative for CW
+    EXPECT_DOUBLE_EQ(.5, poly2D_ccw.signedArea());
+    EXPECT_DOUBLE_EQ(-.5, poly2D_cw.signedArea());
+
+    // The two triangles have reverse orientations (signedArea)
+    // but the same (unsigned) area
+    EXPECT_DOUBLE_EQ(-poly2D_ccw.signedArea(), poly2D_cw.signedArea());
+    EXPECT_DOUBLE_EQ(poly2D_ccw.area(), poly2D_cw.area());
+
+    // compare signed and unsigned areas
+    EXPECT_DOUBLE_EQ(poly2D_ccw.area(), poly2D_ccw.signedArea());
+    EXPECT_DOUBLE_EQ(-poly2D_cw.area(), poly2D_cw.signedArea());
+  }
+
+  // test regular polygons with CW and CCW orienations
+  for(int nSides = 3; nSides < 10; ++nSides)
+  {
+    Polygon2D poly2D_ccw(nSides);
+    Polygon2D poly2D_cw(nSides);
+
+    for(int i = 0; i < nSides; ++i)
+    {
+      const double angle = 2. * M_PI * i / nSides;
+      poly2D_ccw.addVertex(Point2D {cos(angle), sin(angle)});
+      poly2D_cw.addVertex(Point2D {sin(angle), cos(angle)});
+    }
+
+    const double expected_area = nSides / 2. * sin(2 * M_PI / nSides);
+
+    // The areas are the same; signed areas are opposite
+    EXPECT_DOUBLE_EQ(expected_area, poly2D_ccw.area());
+    EXPECT_DOUBLE_EQ(expected_area, poly2D_cw.area());
+    EXPECT_DOUBLE_EQ(poly2D_cw.area(), poly2D_ccw.area());
+    EXPECT_DOUBLE_EQ(-poly2D_cw.signedArea(), poly2D_ccw.signedArea());
+
+    EXPECT_DOUBLE_EQ(poly2D_ccw.signedArea(), poly2D_ccw.area());
+    EXPECT_DOUBLE_EQ(-poly2D_cw.signedArea(), poly2D_cw.area());
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_polygon, area_2d_3d)
+{
+  using Polygon2D = axom::primal::Polygon<double, 2>;
+  using Point2D = axom::primal::Point<double, 2>;
+
+  using Polygon3D = axom::primal::Polygon<double, 3>;
+  using Point3D = axom::primal::Point<double, 3>;
+
+  // test a simple right triangle
+  // use same xy-data in 2D and 3D
+  {
+    Polygon2D poly2D({Point2D {0, 0}, Point2D {1, 0}, Point2D {1, 1}});
+    EXPECT_DOUBLE_EQ(.5, poly2D.area());
+
+    Polygon3D poly3Da({Point3D {0, 0, 0}, Point3D {1, 0, 0}, Point3D {1, 1, 0}});
+    EXPECT_DOUBLE_EQ(.5, poly3Da.area());
+
+    Polygon3D poly3Db({Point3D {0, 0, 1}, Point3D {1, 0, 1}, Point3D {1, 1, 1}});
+    EXPECT_DOUBLE_EQ(.5, poly3Db.area());
+  }
+
+  // test regular polygons
+  // use same xy-data in 2D and 3D
+  for(int nSides = 3; nSides < 10; ++nSides)
+  {
+    Polygon2D poly2D(nSides);
+    Polygon3D poly3D(nSides);
+
+    // choose an arbitrary z_offset for 3D polygon
+    const double z_offset = 5.;
+
+    for(int i = 0; i < nSides; ++i)
+    {
+      const double angle = 2. * M_PI * i / nSides;
+      poly2D.addVertex(Point2D {cos(angle), sin(angle)});
+      poly3D.addVertex(Point3D {cos(angle), sin(angle), z_offset});
+    }
+
+    const double expected_area = nSides / 2. * sin(2 * M_PI / nSides);
+
+    EXPECT_DOUBLE_EQ(expected_area, poly2D.area());
+    EXPECT_DOUBLE_EQ(expected_area, poly3D.area());
+    EXPECT_DOUBLE_EQ(poly2D.area(), poly3D.area());
   }
 }
 

--- a/src/axom/primal/tests/primal_polyhedron.cpp
+++ b/src/axom/primal/tests/primal_polyhedron.cpp
@@ -5,6 +5,8 @@
 
 #include "gtest/gtest.h"
 
+#include "axom/primal/geometry/Point.hpp"
+#include "axom/primal/geometry/Tetrahedron.hpp"
 #include "axom/primal/geometry/Polyhedron.hpp"
 
 #include "axom/core.hpp"
@@ -20,6 +22,8 @@ TEST(primal_polyhedron, polyhedron_empty)
   PolyhedronType poly;
   EXPECT_FALSE(poly.isValid());
   EXPECT_FALSE(poly.hasNeighbors());
+
+  EXPECT_NEAR(0., poly.volume(), 1e-12);
 }
 
 //------------------------------------------------------------------------------
@@ -51,34 +55,56 @@ TEST(primal_polyhedron, polyhedron_unit_cube)
 //------------------------------------------------------------------------------
 TEST(primal_polyhedron, polyhedron_tetrahedron)
 {
+  using PointType = primal::Point<double, 3>;
+  using TetrahedronType = primal::Tetrahedron<double, 3>;
   using PolyhedronType = primal::Polyhedron<double, 3>;
 
-  static const double EPS = 1e-4;
-  PolyhedronType poly;
-  poly.addVertex({1, 1, 1});
-  poly.addVertex({-1, 1, -1});
-  poly.addVertex({1, -1, -1});
-  poly.addVertex({-1, -1, 1});
+  constexpr double EPS = 1e-4;
+  {
+    TetrahedronType tet {PointType {1, 1, 1},
+                         PointType {-1, 1, -1},
+                         PointType {1, -1, -1},
+                         PointType {-1, -1, 1}};
 
-  poly.addNeighbors(poly[0], {1, 3, 2});
-  poly.addNeighbors(poly[1], {0, 2, 3});
-  poly.addNeighbors(poly[2], {0, 3, 1});
-  poly.addNeighbors(poly[3], {0, 1, 2});
+    EXPECT_TRUE(tet.signedVolume() > 0.);
 
-  EXPECT_NEAR(2.6666, poly.volume(), EPS);
+    PolyhedronType poly;
+    poly.addVertex(tet[0]);
+    poly.addVertex(tet[1]);
+    poly.addVertex(tet[2]);
+    poly.addVertex(tet[3]);
 
-  PolyhedronType polyB;
-  polyB.addVertex({1, 0, 0});
-  polyB.addVertex({1, 1, 0});
-  polyB.addVertex({0, 1, 0});
-  polyB.addVertex({1, 0, 1});
+    poly.addNeighbors(0, {1, 3, 2});
+    poly.addNeighbors(1, {0, 2, 3});
+    poly.addNeighbors(2, {0, 3, 1});
+    poly.addNeighbors(3, {0, 1, 2});
 
-  polyB.addNeighbors(polyB[0], {1, 3, 2});
-  polyB.addNeighbors(polyB[1], {0, 2, 3});
-  polyB.addNeighbors(polyB[2], {0, 3, 1});
-  polyB.addNeighbors(polyB[3], {0, 1, 2});
+    EXPECT_NEAR(tet.volume(), poly.volume(), EPS);
+    EXPECT_NEAR(2.6666, poly.volume(), EPS);
+  }
 
-  EXPECT_NEAR(0.1666, polyB.volume(), EPS);
+  {
+    TetrahedronType tet {PointType {1, 0, 0},
+                         PointType {1, 1, 0},
+                         PointType {0, 1, 0},
+                         PointType {1, 0, 1}};
+
+    EXPECT_TRUE(tet.signedVolume() > 0.);
+
+    PolyhedronType poly;
+    poly.addVertex(tet[0]);
+    poly.addVertex(tet[1]);
+    poly.addVertex(tet[2]);
+    poly.addVertex(tet[3]);
+
+    poly.addNeighbors(0, {1, 3, 2});
+    poly.addNeighbors(1, {0, 2, 3});
+    poly.addNeighbors(2, {0, 3, 1});
+    poly.addNeighbors(3, {0, 1, 2});
+
+    EXPECT_NEAR(tet.volume(), poly.volume(), EPS);
+    EXPECT_NEAR(0.1666, poly.volume(), EPS);
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -86,7 +112,7 @@ TEST(primal_polyhedron, polyhedron_octahedron)
 {
   using PolyhedronType = primal::Polyhedron<double, 3>;
 
-  static const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
   PolyhedronType octA;
   octA.addVertex({0, 0, -1});
   octA.addVertex({1, 0, 0});
@@ -219,7 +245,7 @@ TEST(primal_polyhedron, polyhedron_decomposition)
   using PolyhedronType = primal::Polyhedron<double, 3>;
   using PointType = primal::Point<double, 3>;
 
-  static const double EPS = 1e-4;
+  constexpr double EPS = 1e-4;
 
   PolyhedronType poly;
   poly.addVertex({0, 0, 0});

--- a/src/axom/primal/tests/primal_polyhedron.cpp
+++ b/src/axom/primal/tests/primal_polyhedron.cpp
@@ -442,6 +442,8 @@ TEST(primal_polyhedron, polygonal_cone)
   using Point3D = primal::Point<double, 3>;
   using MatrixType = numerics::Matrix<double>;
 
+  constexpr double EPS = 1e-8;
+
   // Lambda to generate a 3D rotation matrix from an angle and axis
   // Formulation from https://en.wikipedia.org/wiki/Rotation_matrix#Axis_and_angle
   auto angleAxisRotMatrix = [](double theta, const Vector3D& axis) -> MatrixType {
@@ -481,7 +483,7 @@ TEST(primal_polyhedron, polygonal_cone)
     const double alpha = 2. * M_PI * i / N;
     penta.addVertex({cos(alpha), sin(alpha), 0});
   }
-  SLIC_INFO(axom::fmt::format("Pentagon w/ signed area {}", penta.signedArea()));
+  SLIC_DEBUG(axom::fmt::format("Pentagon w/ signed area {}", penta.signedArea()));
 
   // Create several rotated cones with a polygonal base.
   // The volume of a cone is 1/3 * base_area * height, so it should equal
@@ -499,7 +501,7 @@ TEST(primal_polyhedron, polygonal_cone)
     {
       poly.addVertex(rotatePoint(matx, Point3D {penta[i][0], penta[i][1], 0}));
     }
-    // Add apex of cone; z is at 3 since
+    // Add apex of cone; z == 3 for volume to match area of polygonal base
     poly.addVertex(rotatePoint(matx, Point3D {0, 0, 3}));
 
     // Set up edge adjacencies
@@ -510,9 +512,9 @@ TEST(primal_polyhedron, polygonal_cone)
     poly.addNeighbors(4, {5, 3, 0});
     poly.addNeighbors(5, {0, 1, 2, 3, 4});
 
-    SLIC_INFO(axom::fmt::format("Polyhedron {}", poly));
+    SLIC_DEBUG(axom::fmt::format("Polyhedron {}", poly));
 
-    EXPECT_DOUBLE_EQ(penta.area(), poly.volume());
+    EXPECT_NEAR(penta.area(), poly.volume(), EPS);
   }
 }
 

--- a/src/examples/using-with-blt/example.cpp
+++ b/src/examples/using-with-blt/example.cpp
@@ -19,7 +19,7 @@ int main()
 {
    // Using fmt library exported by axom
    std::cout << axom::fmt::format(
-        "Example of using and installed version of Axom {}",
+        "Example of using an installed version of Axom {}",
         axom::getVersion()) << std::endl << std::endl;
 
    // Uses installed axom library

--- a/src/examples/using-with-cmake/example.cpp
+++ b/src/examples/using-with-cmake/example.cpp
@@ -19,7 +19,7 @@ int main()
 {
    // Using fmt library exported by axom
    std::cout << axom::fmt::format(
-        "Example of using and installed version of Axom {}",
+        "Example of using an installed version of Axom {}",
         axom::getVersion()) << std::endl << std::endl;
 
    // Uses installed axom library


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It improves the robustness of primal's `intersect` operators for bounding boxes against planes and triangles by first checking if the bounding box is valid before using its geometry.
- This PR also has some minor modernization in the implementation of `primal::intersect`, `primal::Polyhedron` and related unit tests

Credit: Thank you @liyangrock for bringing this bug to our attention in #1005 and for creating a reproducer!