### PR TITLE
Fix doxygen on ReadTheDocs (+ return to srun for MPI tests on tioga)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,8 @@ build:
     python: "3.7"
   jobs:
     post_build:
-      - tree -J
+      - tree 
+      #- tree -J // tree not found?
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,15 @@
 # Required
 version: 2
 
+# Print tree
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.7"
+  jobs:
+    post_build:
+      - tree -J
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: src/conf.py
@@ -18,9 +27,3 @@ python:
   install:
     - requirements: src/docs/requirements.txt
 
-# Print tree
-build:
-  os: "ubuntu-20.04"
-  jobs:
-    post_build:
-      - tree -J

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 # Print tree
 build:
-  os: "ubuntu-20.04"
+  os: ubuntu-20.04
   tools:
     python: "3.7"
   jobs:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,7 +20,7 @@ python:
 
 # Print tree
 build:
+  os: "ubuntu-20.04"
   jobs:
     post_build:
       - tree -J
-

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,7 @@ build:
     post_build:
       #- tree /home/docs/checkouts/readthedocs.org/user_builds/axom/checkouts/test-han12-doxytree/
       #- tree Not found? The directory or the command?
-      - tree -J // tree not found?
+      - tree -J 
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,8 @@ build:
     python: "3.7"
   jobs:
     post_build:
-      - tree 
+      - tree /home/docs/checkouts/readthedocs.org/user_builds/axom/checkouts/test-han12-doxytree/
+      #- tree Not found? The directory or the command?
       #- tree -J // tree not found?
 
 # Build documentation in the docs/ directory with Sphinx

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,7 +23,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+#  version: 3.7
   install:
     - requirements: src/docs/requirements.txt
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,13 +8,15 @@ version: 2
 # Print tree
 build:
   os: ubuntu-20.04
+  apt_packages:
+    - tree
   tools:
     python: "3.7"
   jobs:
     post_build:
-      - tree /home/docs/checkouts/readthedocs.org/user_builds/axom/checkouts/test-han12-doxytree/
+      #- tree /home/docs/checkouts/readthedocs.org/user_builds/axom/checkouts/test-han12-doxytree/
       #- tree Not found? The directory or the command?
-      #- tree -J // tree not found?
+      - tree -J // tree not found?
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,19 +5,6 @@
 # Required
 version: 2
 
-# Print tree
-build:
-  os: ubuntu-20.04
-  apt_packages:
-    - tree
-  tools:
-    python: "3.7"
-  jobs:
-    post_build:
-      #- tree /home/docs/checkouts/readthedocs.org/user_builds/axom/checkouts/test-han12-doxytree/
-      #- tree Not found? The directory or the command?
-      - tree -J 
-
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: src/conf.py
@@ -27,7 +14,6 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-#  version: 3.7
+  version: 3.7
   install:
     - requirements: src/docs/requirements.txt
-

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,3 +17,10 @@ python:
   version: 3.7
   install:
     - requirements: src/docs/requirements.txt
+
+# Print tree
+build:
+  jobs:
+    post_build:
+      - tree -J
+

--- a/host-configs/tioga-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
+++ b/host-configs/tioga-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
@@ -41,9 +41,9 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-
 
 set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.2.3/bin/mpif90" CACHE PATH "")
 
-set(MPIEXEC_EXECUTABLE "/usr/bin/flux" CACHE PATH "")
+set(MPIEXEC_EXECUTABLE "srun" CACHE PATH "")
 
-set(MPIEXEC_NUMPROC_FLAG "mini;run;-n" CACHE STRING "")
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
 
 set(ENABLE_MPI ON CACHE BOOL "")
 

--- a/src/conf.py
+++ b/src/conf.py
@@ -21,13 +21,13 @@ read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
 if read_the_docs_build:
 
     # Makes sure directory exists for doxygen output
-    cwd=os.getcwd()
-    buildpath=os.path.join(cwd,"_build")
-    if (os.path.isdir(buildpath) == 0):
-        os.mkdir(buildpath)
-    htmlpath=os.path.join(buildpath,"html")
-    if (os.path.isdir(htmlpath) == 0):
-        os.mkdir(htmlpath)
+    # cwd=os.getcwd()
+    # buildpath=os.path.join(cwd,"_build")
+    # if (os.path.isdir(buildpath) == 0):
+    #     os.mkdir(buildpath)
+    # htmlpath=os.path.join(buildpath,"html")
+    # if (os.path.isdir(htmlpath) == 0):
+    #     os.mkdir(htmlpath)
 
     # Modify Doxyfile for ReadTheDocs compatibility
     with open('./docs/doxygen/Doxyfile.in', 'r') as f:
@@ -36,7 +36,8 @@ if read_the_docs_build:
     with open('./docs/doxygen/Doxyfile.in', 'w') as f:
         f.write(fdata)
     with open('./docs/doxygen/Doxyfile.in', 'a') as f:
-        f.write("\nOUTPUT_DIRECTORY=./_build/html/doxygen")
+        f.write("\nOUTPUT_DIRECTORY=../_readthedocs/html/doxygen")
+        # f.write("\nOUTPUT_DIRECTORY=./_build/html/doxygen")
 
     # Call doxygen
     from subprocess import call

--- a/src/conf.py
+++ b/src/conf.py
@@ -20,15 +20,6 @@ import shlex
 read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
 if read_the_docs_build:
 
-    # Makes sure directory exists for doxygen output
-    # cwd=os.getcwd()
-    # buildpath=os.path.join(cwd,"_build")
-    # if (os.path.isdir(buildpath) == 0):
-    #     os.mkdir(buildpath)
-    # htmlpath=os.path.join(buildpath,"html")
-    # if (os.path.isdir(htmlpath) == 0):
-    #     os.mkdir(htmlpath)
-
     # Modify Doxyfile for ReadTheDocs compatibility
     with open('./docs/doxygen/Doxyfile.in', 'r') as f:
         fdata = f.read()
@@ -37,7 +28,6 @@ if read_the_docs_build:
         f.write(fdata)
     with open('./docs/doxygen/Doxyfile.in', 'a') as f:
         f.write("\nOUTPUT_DIRECTORY=../_readthedocs/html/doxygen")
-        # f.write("\nOUTPUT_DIRECTORY=./_build/html/doxygen")
 
     # Call doxygen
     from subprocess import call


### PR DESCRIPTION
This PR:

- Fixes #1012  (404 Doxygen pages)
  - Issue was related to filepath name changes on the ReadTheDocs end.
  - [ReadTheDocs link ](https://axom.readthedocs.io/en/test-han12-doxytree/) to documentation generated by this PR.
- Reverts #1011
  - Tioga has flux wrappers for SLURM commands so `srun` calls `flux mini run` underneath. Issue last week was flux wrappers not being initialized by default on the system after updates.