### PR TITLE
Bugfixes in support of Windows build

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -45,12 +45,14 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Adds `vcpkg` ports for `RAJA`, `Umpire` with optional `OpenMP` feature for automated Windows build
 - Reduce size of `ArrayView::subspan` to prevent accessing invalid memory.
 - Updates [conduit dependency to v0.8.6](https://github.com/LLNL/conduit/compare/v0.8.3...v0.8.6)
+- Adds `vcpkg` port for `lua` as optional dependency on Windows
 
 ###  Fixed
 - Fixed issues with CUDA build in CMake versions 3.14.5 and above. Now require CMake 3.18+
   for CUDA/non-gpu builds.
 - Checks validity of bounding boxes in `primal`'s intersection operators against planes 
   and triangles before using the geometry.
+- Improves import logic for `lua` dependency
 
 ## [Version 0.7.0] - Release date 2022-08-30
 

--- a/scripts/vcpkg_ports/axom/portfile.cmake
+++ b/scripts/vcpkg_ports/axom/portfile.cmake
@@ -142,6 +142,11 @@ set(AXOM_ENABLE_INLET OFF CACHE BOOL "")
 set(AXOM_ENABLE_KLEE OFF CACHE BOOL "")
 ]=])
 
+set(_lua_dep [=[
+
+set(LUA_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
+]=])
+
 set(_mfem_dep [=[
 
 set(MFEM_DIR "@CURRENT_INSTALLED_DIR@" CACHE PATH "")
@@ -170,7 +175,7 @@ set(BLT_OPENMP_LINK_FLAGS " " CACHE STRING "")
 ]=])
 
 # TODO:
-#  * Add features/TPLs: lua, mpi
+#  * Add features/TPLs: mpi
 #  * Add tools: uncrustify, sphinx, doxygen
 
 # Create a copyright file
@@ -187,15 +192,17 @@ message(STATUS "FEATURES: ${FEATURES}")
 
 file(WRITE ${_hc_file}.in "${_host-config_hdr}")
 
-if("conduit" IN_LIST FEATURES)
+if(conduit IN_LIST FEATURES)
   file(APPEND ${_hc_file}.in "${_conduit_dep_on}")
 else()
   file(APPEND ${_hc_file}.in "${_conduit_dep_off}")
 endif()
 
-foreach(_dep openmp mfem raja umpire)
+foreach(_dep lua mfem openmp raja umpire)
   if(${_dep} IN_LIST FEATURES)
     file(APPEND ${_hc_file}.in "${_${_dep}_dep}")
+  else()
+    file(APPEND ${_hc_file}.in "# ${_dep} dependency disabled")
   endif()
 endforeach()
 

--- a/scripts/vcpkg_ports/axom/vcpkg.json
+++ b/scripts/vcpkg_ports/axom/vcpkg.json
@@ -6,19 +6,24 @@
   "dependencies": ["blt"],
   "default-features": [
     "conduit",
+    "lua",
     "mfem",
     "openmp",
     "raja",
     "umpire"
   ],
   "features": {
-    "mfem": {
-      "description": "mfem functionality for axom",
-      "dependencies" : ["mfem"]
-    },
     "conduit": {
       "description": "conduit functionality for axom",
       "dependencies": ["conduit"]
+    },
+    "lua": {
+      "description": "lua functionality for axom",
+      "dependencies": ["lua"]
+    },
+    "mfem": {
+      "description": "mfem functionality for axom",
+      "dependencies" : ["mfem"]
     },
     "raja": {
       "description": "raja functionality for axom",

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -35,7 +35,7 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
 endif()
 
 # Distributed closest point example -------------------------------------------
-if(AXOM_ENABLE_MPI AND AXOM_ENABLE_SIDRE)
+if(AXOM_ENABLE_MPI AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_HDF5)
     blt_add_executable(
             NAME        quest_distributed_distance_query_ex
             SOURCES     quest_distributed_distance_query_example.cpp

--- a/src/axom/quest/tests/CMakeLists.txt
+++ b/src/axom/quest/tests/CMakeLists.txt
@@ -143,10 +143,10 @@ endforeach()
 cmake_dependent_option(
     AXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS
     "Enable extra regression tests for quest" OFF
-    "AXOM_ENABLE_MPI;AXOM_ENABLE_SIDRE;AXOM_DATA_DIR" OFF )
+    "AXOM_ENABLE_MPI;AXOM_ENABLE_SIDRE;AXOM_DATA_DIR;AXOM_ENABLE_HDF5" OFF )
 mark_as_advanced(AXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS)
 
-if (AXOM_ENABLE_MPI AND AXOM_ENABLE_SIDRE)
+if (AXOM_ENABLE_MPI AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_HDF5)
 
     set(quest_regression_depends
         ${quest_tests_depends}

--- a/src/axom/sidre/tests/spio/spio_parallel.hpp
+++ b/src/axom/sidre/tests/spio/spio_parallel.hpp
@@ -186,7 +186,7 @@ TEST(spio_parallel, parallel_writeread)
    */
   IOManager reader(MPI_COMM_WORLD);
 
-  reader.read(ds2->getRoot(), root_name);
+  reader.read(ds2->getRoot(), root_name, PROTOCOL);
   // _parallel_io_load_end
 
   /*
@@ -958,7 +958,7 @@ TEST(spio_parallel, parallel_decrease_procs)
 
   MPI_Comm_free(&split_comm);
 
-#endif
+#endif  // AXOM_USE_HDF5
 }
 
 TEST(spio_parallel, sidre_simple_blueprint_example)
@@ -1027,5 +1027,5 @@ TEST(spio_parallel, sidre_simple_blueprint_example)
                                        "out_spio_blueprint_example.root",
                                        "mesh");
 
-#endif
+#endif  // AXOM_USE_HDF5
 }

--- a/src/axom/sidre/tests/spio/spio_serial.hpp
+++ b/src/axom/sidre/tests/spio/spio_serial.hpp
@@ -177,6 +177,7 @@ TEST(spio_serial, write_read_write)
 }
 
 //------------------------------------------------------------------------------
+#ifdef AXOM_USE_HDF5
 TEST(spio_serial, rootfile_suffix)
 {
   // This test verifies the usage of the string passed to writer.write() to
@@ -221,3 +222,4 @@ TEST(spio_serial, rootfile_suffix)
   EXPECT_EQ(ds_suffix.getRoot()->getView("grp/i")->getData<int>(),
             ds_nosuffix.getRoot()->getView("grp/i")->getData<int>());
 }
+#endif  // AXOM_USE_HDF5

--- a/src/cmake/thirdparty/FindLUA.cmake
+++ b/src/cmake/thirdparty/FindLUA.cmake
@@ -5,11 +5,8 @@
 #------------------------------------------------------------------------------
 # Setup Lua
 #------------------------------------------------------------------------------
-# This file defines:
-#  LUA_FOUND - If Lua was found
-#  LUA_INCLUDE_DIRS - The Lua include directories
-#  LUA_LIBRARY - The Lua library
-#------------------------------------------------------------------------------
+# find_package(LUA) can use the LUA_DIR env variable as a hint
+# ------------------------------------------------------------------------------
 
 # first Check for LUA_DIR
 if (NOT EXISTS "${LUA_DIR}")
@@ -20,36 +17,24 @@ if (NOT IS_DIRECTORY "${LUA_DIR}")
     message(FATAL_ERROR "Given LUA_DIR is not a directory: ${LUA_DIR}")
 endif()
 
-# Find includes directory
-find_path( LUA_INCLUDE_DIR lua.hpp
-           PATHS  ${LUA_DIR}/include/
-                  ${LUA_DIR}/include/lua
-           NO_DEFAULT_PATH
-           NO_CMAKE_ENVIRONMENT_PATH
-           NO_CMAKE_PATH
-           NO_SYSTEM_ENVIRONMENT_PATH
-           NO_CMAKE_SYSTEM_PATH)
+# Add LUA_DIR as env variable
+set(ENV{LUA_DIR} ${LUA_DIR})
 
-# Find libraries
-find_library( LUA_LIBRARY NAMES lua liblua
-              PATHS ${LUA_DIR}/lib
-              NO_DEFAULT_PATH
-              NO_CMAKE_ENVIRONMENT_PATH
-              NO_CMAKE_PATH
-              NO_SYSTEM_ENVIRONMENT_PATH
-              NO_CMAKE_SYSTEM_PATH)
+# Uncomment the following for more debug output in FindLUA
+#set(LUA_Debug TRUE)
 
-
-include(FindPackageHandleStandardArgs)
-# handle the QUIETLY and REQUIRED arguments and set LUA_FOUND to TRUE
-# if all listed variables are TRUE
-find_package_handle_standard_args(LUA  DEFAULT_MSG
-                                  LUA_INCLUDE_DIR
-                                  LUA_LIBRARY )
+# HACK: Workaround for lua@5.4 and older versions of cmake (e.g. 3.16)
+# which did not account for versions of lua beyond 5.3
+string(FIND ${LUA_DIR} lua-5.4 _is_lua_5_4)
+if(_is_lua_5_4)
+    find_package(Lua 5.4 EXACT REQUIRED) 
+else()
+    find_package(Lua REQUIRED) 
+endif()
 
 if(NOT LUA_FOUND)
     message(FATAL_ERROR "LUA_DIR is not a path to a valid Lua install")
 endif()
 
 message(STATUS "Lua Includes: ${LUA_INCLUDE_DIR}")
-message(STATUS "Lua Libraries: ${LUA_LIBRARY}")
+message(STATUS "Lua Libraries: ${LUA_LIBRARIES}")

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -77,7 +77,7 @@ if (UMPIRE_DIR)
         message(FATAL_ERROR "Umpire failed to load: ${UMPIRE_DIR}")
     else()
         message(STATUS "Umpire loaded: ${UMPIRE_DIR}")
-        set_property(TARGET umpire 
+        set_property(TARGET umpire
                      APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
                     ${UMPIRE_INCLUDE_DIRS})
         set(UMPIRE_FOUND TRUE CACHE BOOL "")
@@ -110,7 +110,7 @@ if (RAJA_DIR)
         set(RAJA_FOUND TRUE CACHE BOOL "")
     endif()
 
-    # Suppress warnings from cub and cuda related to the (low) version 
+    # Suppress warnings from cub and cuda related to the (low) version
     # of clang that XL compiler pretends to be.
     if(C_COMPILER_FAMILY_IS_XL)
         if(TARGET RAJA::cub)
@@ -142,11 +142,11 @@ if (CONDUIT_DIR)
     include(cmake/thirdparty/FindConduit.cmake)
 
     # Manually set includes as system includes
-    set_property(TARGET conduit::conduit 
+    set_property(TARGET conduit::conduit
                  APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
                  "${CONDUIT_INSTALL_PREFIX}/include/")
 
-    set_property(TARGET conduit::conduit 
+    set_property(TARGET conduit::conduit
                  APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
                  "${CONDUIT_INSTALL_PREFIX}/include/conduit/")
 else()
@@ -243,6 +243,9 @@ if (LUA_DIR)
                             INCLUDES    ${LUA_INCLUDE_DIR}
                             EXPORTABLE  ON)
     endif()
+    blt_print_target_properties(TARGET lua)
+    blt_print_variables(NAME_REGEX lua IGNORE_CASE)
+
     blt_patch_target(NAME lua TREAT_INCLUDES_AS_SYSTEM ON)
     blt_list_append(TO TPL_DEPS ELEMENTS lua)
 else()

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -244,23 +244,8 @@ if (LUA_DIR)
                             EXPORTABLE  ON)
     endif()
 
-    blt_print_target_properties(TARGET lua)
-    blt_print_variables(NAME_REGEX lua IGNORE_CASE)
-
-    # Mark includes as SYSTEM if target is not IMPORTED
-    # Includes for IMPORTED are already marked as system
-    # and calling it would generate a CMake error.
-    # TODO: This logic should be incorporated into blt_patch_target
-    get_target_property(_is_lua_imported lua IMPORTED)
-    if(NOT ${_is_lua_imported})
-        blt_patch_target(NAME lua TREAT_INCLUDES_AS_SYSTEM ON)
-    endif()
-
+    blt_convert_to_system_includes(TARGET lua)
     blt_list_append(TO TPL_DEPS ELEMENTS lua)
-
-    blt_print_target_properties(TARGET lua)
-    blt_print_variables(NAME_REGEX lua IGNORE_CASE)
-    blt_print_variables(VALUE_REGEX lua IGNORE_CASE)
 else()
     message(STATUS "LUA support is OFF")
     set(LUA_FOUND OFF CACHE BOOL "")

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -237,12 +237,13 @@ endif()
 #------------------------------------------------------------------------------
 if (LUA_DIR)
     include(cmake/thirdparty/FindLUA.cmake)
-    blt_import_library(
-        NAME          lua
-        INCLUDES      ${LUA_INCLUDE_DIR}
-        LIBRARIES     ${LUA_LIBRARY}
-        TREAT_INCLUDES_AS_SYSTEM ON
-        EXPORTABLE    ON)
+    if(NOT TARGET lua)
+        blt_import_library( NAME        lua
+                            LIBRARIES   ${LUA_LIBRARIES}
+                            INCLUDES    ${LUA_INCLUDE_DIR}
+                            EXPORTABLE  ON)
+    endif()
+    blt_patch_target(NAME lua TREAT_INCLUDES_AS_SYSTEM ON)
     blt_list_append(TO TPL_DEPS ELEMENTS lua)
 else()
     message(STATUS "LUA support is OFF")

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -243,11 +243,24 @@ if (LUA_DIR)
                             INCLUDES    ${LUA_INCLUDE_DIR}
                             EXPORTABLE  ON)
     endif()
+
     blt_print_target_properties(TARGET lua)
     blt_print_variables(NAME_REGEX lua IGNORE_CASE)
 
-    blt_patch_target(NAME lua TREAT_INCLUDES_AS_SYSTEM ON)
+    # Mark includes as SYSTEM if target is not IMPORTED
+    # Includes for IMPORTED are already marked as system
+    # and calling it would generate a CMake error.
+    # TODO: This logic should be incorporated into blt_patch_target
+    get_target_property(_is_lua_imported lua IMPORTED)
+    if(NOT ${_is_lua_imported})
+        blt_patch_target(NAME lua TREAT_INCLUDES_AS_SYSTEM ON)
+    endif()
+
     blt_list_append(TO TPL_DEPS ELEMENTS lua)
+
+    blt_print_target_properties(TARGET lua)
+    blt_print_variables(NAME_REGEX lua IGNORE_CASE)
+    blt_print_variables(VALUE_REGEX lua IGNORE_CASE)
 else()
     message(STATUS "LUA support is OFF")
     set(LUA_FOUND OFF CACHE BOOL "")


### PR DESCRIPTION
# Summary

- This PR contains several bugfixes
- It improves the constraints on axom's `mfem` dependency in its spack package
- It adds an optional `lua` dependency to the Windows build
- It improves the import logic for lua (this manifested in a local WSL build, where `-dl` was required and missing from our previous formulation)
- It also fixes some failing tests when axom is configured without `hdf5`. 
    - An observed failure in the `spio_parallel` tests for this configuration will be resolved in
     #1018 