### PR TITLE
Bugfix for importing caliper-enabled mfem in cuda configs

### DIFF
--- a/src/axom/primal/tests/primal_curved_polygon.cpp
+++ b/src/axom/primal/tests/primal_curved_polygon.cpp
@@ -377,7 +377,7 @@ TEST(primal_curvedpolygon, moments_triangle_mixed_order)
   CoordType trueA = -.0906666666666666666666;
   PointType trueC {.2970147058823527, 1.55764705882353};
 
-  checkMoments(bPolygon, trueA, trueC, 1e-14, 1e-15);
+  checkMoments(bPolygon, trueA, trueC, 1e-14, 1e-14);
 }
 
 //----------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_orientedboundingbox.cpp
+++ b/src/axom/primal/tests/primal_orientedboundingbox.cpp
@@ -14,14 +14,14 @@
 #include "axom/primal/geometry/Vector.hpp"
 #include "axom/primal/geometry/OrientedBoundingBox.hpp"
 
-using namespace axom;
+namespace primal = axom::primal;
 
 TEST(primal_OBBox, obb_default_constructor)
 {
-  static const int DIM = 2;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 2;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QOBBox bbox;
   EXPECT_FALSE(bbox.isValid()) << "Default constructed bounding box is invalid";
@@ -34,11 +34,11 @@ TEST(primal_OBBox, obb_default_constructor)
 //------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_ctor_from_singlePt)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
@@ -84,11 +84,11 @@ TEST(primal_OBBox, obb_ctor_from_singlePt)
 //------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_ctor_from_data)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
@@ -122,11 +122,11 @@ TEST(primal_OBBox, obb_ctor_from_data)
 //------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_test_clear)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
@@ -153,11 +153,11 @@ TEST(primal_OBBox, obb_test_clear)
 //------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_test_vertices)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
@@ -191,11 +191,11 @@ TEST(primal_OBBox, obb_test_vertices)
 //------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_test_add_point)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
@@ -241,11 +241,11 @@ TEST(primal_OBBox, obb_test_add_point)
 //------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_test_add_box)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
@@ -280,11 +280,11 @@ TEST(primal_OBBox, obb_test_add_box)
 //------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_test_expand)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
@@ -322,11 +322,11 @@ TEST(primal_OBBox, obb_test_expand)
 //------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_test_scale)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
@@ -372,11 +372,11 @@ TEST(primal_OBBox, obb_test_scale)
 //------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_test_shift)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
@@ -402,11 +402,11 @@ TEST(primal_OBBox, obb_test_shift)
 //------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_copy_and_assignment)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
@@ -448,11 +448,11 @@ TEST(primal_OBBox, obb_copy_and_assignment)
 //------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_contains_obb)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
@@ -489,11 +489,11 @@ TEST(primal_OBBox, obb_contains_obb)
 //------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_to_local)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
@@ -542,11 +542,11 @@ TEST(primal_OBBox, obb_to_local)
 //------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_bisect)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
@@ -575,11 +575,11 @@ TEST(primal_OBBox, obb_bisect)
 
 TEST(primal_OBBox, obb_test_furthest_point)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes

--- a/src/axom/primal/tests/primal_orientedboundingbox.cpp
+++ b/src/axom/primal/tests/primal_orientedboundingbox.cpp
@@ -534,7 +534,7 @@ TEST(primal_OBBox, obb_to_local)
 
   // can roughly compute local coords of pt2
   QVector vec2(obbox2.toLocal(pt2));
-  EXPECT_EQ(vec2[0], 0.);
+  EXPECT_DOUBLE_EQ(vec2[0], 0.);
   EXPECT_TRUE(((vec2[1] - 14.142) < 0.1) && ((14.142 - vec2[1]) < 0.1));
   EXPECT_TRUE(((vec2[2] - 10.) < 0.1) && ((10. - vec2[2]) < 0.1));
 }

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -199,8 +199,12 @@ void generate_aabbs_and_centroids(const mint::Mesh* mesh,
       }
 
       c[cellIdx] = range.getCentroid();
+
 #ifndef AXOM_DEVICE_CODE
-      EXPECT_EQ(c[cellIdx], sum);
+      for(int dim = 0; dim < NDIMS; dim++)
+      {
+        EXPECT_DOUBLE_EQ(c[cellIdx][dim], sum[dim]);
+      }
 #endif
 
       aabbs[cellIdx] = range;

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -196,6 +196,23 @@ else()
     message(STATUS "MFEM support is OFF")
 endif()
 
+# caliper-enabled mfem in cuda configs depends on cupti, which is not properly exported
+if(TARGET mfem AND ENABLE_CUDA)
+    # check if mfem depends on caliper; if so, patch it with cupti
+    get_target_property(_mfem_libs mfem INTERFACE_LINK_LIBRARIES)
+    if("${_mfem_libs}" MATCHES "caliper")
+        if(NOT TARGET CUDA::toolkit)
+            find_package(CUDAToolkit REQUIRED)
+        endif()
+
+        if(TARGET CUDA::toolkit)
+            blt_patch_target(NAME mfem DEPENDS_ON CUDA::toolkit)
+        endif()
+        if(TARGET CUDA::cupti)
+            blt_patch_target(NAME mfem DEPENDS_ON CUDA::cupti)
+        endif()
+    endif()
+endif()
 
 #------------------------------------------------------------------------------
 # Shroud - Generates C/Fortran/Python bindings

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -198,16 +198,13 @@ endif()
 
 # caliper-enabled mfem in cuda configs depends on cupti, which is not properly exported
 if(TARGET mfem AND ENABLE_CUDA)
-    # check if mfem depends on caliper; if so, patch it with cupti
+    # check if mfem depends on caliper; if so, patch it with CUDAToolkit's cupti
     get_target_property(_mfem_libs mfem INTERFACE_LINK_LIBRARIES)
     if("${_mfem_libs}" MATCHES "caliper")
-        if(NOT TARGET CUDA::toolkit)
+        if(NOT TARGET CUDA::cupti)
             find_package(CUDAToolkit REQUIRED)
         endif()
 
-        if(TARGET CUDA::toolkit)
-            blt_patch_target(NAME mfem DEPENDS_ON CUDA::toolkit)
-        endif()
         if(TARGET CUDA::cupti)
             blt_patch_target(NAME mfem DEPENDS_ON CUDA::cupti)
         endif()


### PR DESCRIPTION
# Summary

- This PR is a bugfix for importing a `caliper`-enabled `mfem` in a `cuda` configuration
    - The former depends on `cupti` which was not being exported, leading to compiler errors
    - As a hack, we patch mfem to depend on `CUDA::cupti`
- It also fixes some floating point comparisons in axom's unit tests