### PR TITLE
Further improves import logic for caliper-enabled mfem target

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -51,9 +51,10 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ###  Fixed
 - Fixed issues with CUDA build in CMake versions 3.14.5 and above. Now require CMake 3.18+
   for CUDA/non-gpu builds.
-- Checks validity of bounding boxes in `primal`'s intersection operators against planes 
+- Checks validity of bounding boxes in `primal`'s intersection operators against planes
   and triangles before using the geometry.
 - Improves import logic for `lua` dependency
+- Improves import logic for `mfem` dependency in device builds when `mfem` is configured with `caliper`
 
 ## [Version 0.7.0] - Release date 2022-08-30
 

--- a/src/cmake/thirdparty/FindROCTracer.cmake
+++ b/src/cmake/thirdparty/FindROCTracer.cmake
@@ -1,0 +1,39 @@
+# Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+# other Axom Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+#------------------------------------------------------------------------------
+# Sets up target for roctracer and roctx libraries
+#------------------------------------------------------------------------------
+
+if(NOT ENABLE_HIP)
+  message(FATAL_ERROR "Please set up hip before setting up ROC-tracer")
+endif()
+
+find_path(ROCTRACER_INCLUDE_DIR
+          NAMES roctracer.h
+          HINTS ${ROCM_PATH}/include/roctracer)
+
+blt_find_libraries(
+    FOUND_LIBS ROCTRACER_LIBRARIES
+    NAMES roctracer64 roctx64
+    REQUIRED FALSE
+    PATHS ${ROCM_PATH}/lib)
+
+find_package_handle_standard_args(ROCTRACER
+  DEFAULT_MSG
+  ROCTRACER_LIBRARIES
+  ROCTRACER_INCLUDE_DIR)
+
+mark_as_advanced(
+    ROCTRACER_LIBRARIES
+    ROCTRACER_INCLUDE_DIR)
+
+blt_import_library(
+  NAME roctracer
+  INCLUDES ${ROCTRACER_INCLUDE_DIR}
+  LIBRARIES  ${ROCTRACER_LIBRARIES}
+  TREAT_INCLUDES_AS_SYSTEM ON
+  EXPORTABLE ON
+)
+


### PR DESCRIPTION
# Summary

- This PR is a bugfix for importing a `caliper`-enabled `mfem` in `hip` configurations
- In this case, `caliper` depends on roctracer/roctx, but this is not properly exported by caliper or mfem
- This PR is a companion to #1025 which had a similar improvement for handling the implicit `cupti` dependency in `cuda` configs

Credit: Thanks @white238 for helping me set up and export the new `roctracer` target