### PR TITLE
UniformGrid memory fixes

### DIFF
--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -27,14 +27,14 @@
 .src_build_on_lassen:
   stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 25 -q pdebug"
+    ALLOC_COMMAND: "lalloc 1 -W 25 -q pdebug -alloc_flags atsdisable"
   extends: [.src_build_script, .on_lassen, .src_workflow]
   needs: []
 
 .full_build_on_lassen:
   stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 45 -q pdebug"
+    ALLOC_COMMAND: "lalloc 1 -W 45 -q pdebug -alloc_flags atsdiable"
   extends: [.full_build_script, .on_lassen, .full_workflow]
   needs: []
 

--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -34,7 +34,7 @@
 .full_build_on_lassen:
   stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 45 -q pdebug -alloc_flags atsdiable"
+    ALLOC_COMMAND: "lalloc 1 -W 45 -q pdebug -alloc_flags atsdisable"
   extends: [.full_build_script, .on_lassen, .full_workflow]
   needs: []
 

--- a/src/axom/spin/UniformGrid.hpp
+++ b/src/axom/spin/UniformGrid.hpp
@@ -562,7 +562,7 @@ void UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::initialize(
     });
 
   // 2. Resize bins with counts
-  StoragePolicy::initialize(binCounts);
+  StoragePolicy::template initialize<ExecSpace>(binCounts);
 
   // 3. Reset bin-specific counters
   binCounts.fill(0);

--- a/src/axom/spin/UniformGrid.hpp
+++ b/src/axom/spin/UniformGrid.hpp
@@ -515,7 +515,9 @@ void UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::initialize(
 
   const IndexType numBins = getNumBins();
   // 1. Get number of elements to insert into each bin
-  axom::Array<IndexType> binCounts(numBins);
+  axom::Array<IndexType> binCounts(numBins,
+                                   numBins,
+                                   StoragePolicy::getAllocatorID());
   // TODO: There's an error on operator[] if this isn't const and it only
   // happens for GCC 8.1.0
   const axom::ArrayView<IndexType> binCountsView = binCounts;
@@ -525,14 +527,17 @@ void UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::initialize(
 #endif
 
   primal::NumericArray<int, NDIMS> strides = m_strides;
+  primal::NumericArray<int, NDIMS> resolution = m_resolution;
+  LatticeType lattice = m_lattice;
+
   axom::for_all<ExecSpace>(
     bboxes.size(),
     AXOM_LAMBDA(IndexType idx) {
       const BoxType bbox = bboxes[idx];
       const GridCell lowerCell =
-        getClampedGridCell(m_lattice, m_resolution, bbox.getMin());
+        getClampedGridCell(lattice, resolution, bbox.getMin());
       const GridCell upperCell =
-        getClampedGridCell(m_lattice, m_resolution, bbox.getMax());
+        getClampedGridCell(lattice, resolution, bbox.getMax());
       const int kLower = (NDIMS == 2) ? 0 : lowerCell[2];
       const int kUpper = (NDIMS == 2) ? 0 : upperCell[2];
       const int kStride = (NDIMS == 2) ? 1 : strides[2];
@@ -569,9 +574,9 @@ void UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::initialize(
     AXOM_LAMBDA(IndexType idx) {
       const BoxType bbox = bboxes[idx];
       const GridCell lowerCell =
-        getClampedGridCell(m_lattice, m_resolution, bbox.getMin());
+        getClampedGridCell(lattice, resolution, bbox.getMin());
       const GridCell upperCell =
-        getClampedGridCell(m_lattice, m_resolution, bbox.getMax());
+        getClampedGridCell(lattice, resolution, bbox.getMax());
       const int kLower = (NDIMS == 2) ? 0 : lowerCell[2];
       const int kUpper = (NDIMS == 2) ? 0 : upperCell[2];
       const int kStride = (NDIMS == 2) ? 1 : strides[2];

--- a/src/axom/spin/policy/UniformGridStorage.hpp
+++ b/src/axom/spin/policy/UniformGridStorage.hpp
@@ -58,6 +58,7 @@ struct DynamicGridStorage
     return index >= 0 && index < getNumBins();
   }
 
+  template <typename ExecSpace>
   void initialize(axom::ArrayView<const IndexType> binSizes)
   {
     m_bins.clear();
@@ -162,13 +163,7 @@ struct FlatGridStorage
     : m_binData(0, 0, allocID)
     , m_binOffsets(0, 0, allocID)
     , m_allocatorID(allocID)
-    , m_executeOnDevice(false)
-  {
-#ifdef AXOM_USE_UMPIRE
-    m_executeOnDevice =
-      (axom::detail::getAllocatorSpace(allocID) == axom::MemorySpace::Device);
-#endif
-  }
+  { }
 
   int getAllocatorID() const { return m_allocatorID; }
 
@@ -180,32 +175,23 @@ struct FlatGridStorage
     return index >= 0 && index < getNumBins();
   }
 
+  template <typename ExecSpace>
   void initialize(axom::ArrayView<const IndexType> binSizes)
   {
-#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_GPU)
-    if(m_executeOnDevice)
-    {
-  #ifdef AXOM_USE_CUDA
-      using gpu_exec = axom::CUDA_EXEC<256>;
-  #else
-      using gpu_exec = axom::HIP_EXEC<256>;
-  #endif
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+    using loop_pol = typename axom::execution_space<ExecSpace>::loop_policy;
+    using reduce_pol = typename axom::execution_space<ExecSpace>::reduce_policy;
 
-      using loop_pol = typename axom::execution_space<gpu_exec>::loop_policy;
-      using reduce_pol = typename axom::execution_space<gpu_exec>::reduce_policy;
-
-      RAJA::exclusive_scan<loop_pol>(
-        RAJA::make_span(binSizes.data(), binSizes.size()),
-        RAJA::make_span(m_binOffsets.data(), binSizes.size()),
-        RAJA::operators::plus<IndexType> {});
-      RAJA::ReduceSum<reduce_pol, IndexType> total_elems(0);
-      for_all<gpu_exec>(
-        binSizes.size(),
-        AXOM_LAMBDA(IndexType idx) { total_elems += binSizes[idx]; });
-      m_binData.resize(total_elems.get());
-      return;
-    }
-#endif
+    RAJA::exclusive_scan<loop_pol>(
+      RAJA::make_span(binSizes.data(), binSizes.size()),
+      RAJA::make_span(m_binOffsets.data(), binSizes.size()),
+      RAJA::operators::plus<IndexType> {});
+    RAJA::ReduceSum<reduce_pol, IndexType> total_elems(0);
+    for_all<ExecSpace>(
+      binSizes.size(),
+      AXOM_LAMBDA(IndexType idx) { total_elems += binSizes[idx]; });
+    m_binData.resize(total_elems.get());
+#else
     IndexType total_elems = binSizes[0];
     m_binOffsets[0] = 0;
     for(int i = 1; i < binSizes.size(); i++)
@@ -214,6 +200,7 @@ struct FlatGridStorage
       total_elems += binSizes[i];
     }
     m_binData.resize(total_elems);
+#endif
   }
 
   void insert(IndexType gridIdx, T elem)
@@ -275,7 +262,6 @@ struct FlatGridStorage
   axom::Array<T> m_binData;
   axom::Array<IndexType> m_binOffsets;
   int m_allocatorID;
-  bool m_executeOnDevice;
 };
 
 template <typename T>

--- a/src/axom/spin/policy/UniformGridStorage.hpp
+++ b/src/axom/spin/policy/UniformGridStorage.hpp
@@ -66,7 +66,7 @@ struct DynamicGridStorage
   }
 
   template <typename ExecSpace>
-  void initialize(axom::ArrayView<const IndexType> binSizes)
+  void initialize(const axom::ArrayView<const IndexType> binSizes)
   {
     m_bins.clear();
     for(int i = 0; i < binSizes.size(); i++)
@@ -183,7 +183,7 @@ struct FlatGridStorage
   }
 
   template <typename ExecSpace>
-  void initialize(axom::ArrayView<const IndexType> binSizes)
+  void initialize(const axom::ArrayView<const IndexType> binSizes)
   {
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
     using loop_pol = typename axom::execution_space<ExecSpace>::loop_policy;

--- a/src/axom/spin/policy/UniformGridStorage.hpp
+++ b/src/axom/spin/policy/UniformGridStorage.hpp
@@ -46,7 +46,14 @@ struct DynamicGridStorage
   DynamicGridStorage(int allocID)
     : m_bins(0, 0, allocID)
     , m_allocatorID(allocID)
-  { }
+  {
+#ifdef AXOM_USE_UMPIRE
+    SLIC_ASSERT_MSG(
+      axom::detail::getAllocatorSpace(allocID) != MemorySpace::Device,
+      "Umpire device-only memory is not a supported allocator type for dynamic "
+      "UniformGrid storage.");
+#endif
+  }
 
   int getAllocatorID() const { return m_allocatorID; }
 

--- a/src/axom/spin/policy/UniformGridStorage.hpp
+++ b/src/axom/spin/policy/UniformGridStorage.hpp
@@ -205,7 +205,7 @@ struct FlatGridStorage
       m_binData.resize(total_elems.get());
       return;
     }
-#else
+#endif
     IndexType total_elems = binSizes[0];
     m_binOffsets[0] = 0;
     for(int i = 1; i < binSizes.size(); i++)
@@ -214,8 +214,7 @@ struct FlatGridStorage
       total_elems += binSizes[i];
     }
     m_binData.resize(total_elems);
-#endif
-  };
+  }
 
   void insert(IndexType gridIdx, T elem)
   {

--- a/src/axom/spin/tests/spin_uniform_grid.cpp
+++ b/src/axom/spin/tests/spin_uniform_grid.cpp
@@ -467,3 +467,143 @@ TEST(spin_uniform_grid, delete_stuff_2D)
     checkBinCounts(valid, check);
   }
 }
+
+namespace testing
+{
+template <typename ExecSpace>
+struct ExecTraits
+{
+  static int getAllocatorId()
+  {
+#ifdef AXOM_USE_UMPIRE
+    return axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Host);
+#else
+    return axom::getDefaultAllocatorID();
+#endif
+  }
+};
+
+#ifdef AXOM_USE_CUDA
+template <int BLK_SZ>
+struct ExecTraits<axom::CUDA_EXEC<BLK_SZ>>
+{
+  static int getAllocatorId()
+  {
+    return axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Device);
+  }
+};
+#endif
+
+#ifdef AXOM_USE_HIP
+template <int BLK_SZ>
+struct ExecTraits<axom::HIP_EXEC<BLK_SZ>>
+{
+  static int getAllocatorId()
+  {
+    return axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Device);
+  }
+};
+#endif
+//------------------------------------------------------------------------------
+//  This test harness defines some types that are useful for the tests below
+//------------------------------------------------------------------------------
+template <typename ExecSpace, int DIM>
+class spin_uniform_grid_templated : public ::testing::Test
+{
+public:
+  using PointType = axom::primal::Point<double, DIM>;
+  using BoxType = axom::primal::BoundingBox<double, DIM>;
+  using FlatStorageType = axom::spin::policy::FlatGridStorage<int>;
+  using UniformGridType =
+    axom::spin::UniformGrid<int, DIM, ExecSpace, FlatStorageType>;
+
+  spin_uniform_grid_templated()
+    : m_allocatorID(ExecTraits<ExecSpace>::getAllocatorId())
+  { }
+
+  void setNumObjects(int num_objects) { this->m_numObjects = num_objects; }
+
+  void initializeUniformGrid()
+  {
+    this->m_boundingBoxes =
+      axom::Array<BoxType>(0, this->m_numObjects, m_allocatorID);
+    this->m_iota =
+      axom::Array<int>(this->m_numObjects, this->m_numObjects, m_allocatorID);
+    // generate n random objects to insert into the uniform grid.
+    for(int i = 0; i < this->m_numObjects; i++)
+    {
+      PointType min, max;
+      for(int idim = 0; idim < DIM; idim++)
+      {
+        double val1 = axom::utilities::random_real(0., 1.);
+        double val2 = axom::utilities::random_real(0., 1.);
+        if(val1 > val2)
+        {
+          axom::utilities::swap(val1, val2);
+        }
+        min[idim] = val1;
+        max[idim] = val2;
+      }
+      this->m_boundingBoxes.push_back(BoxType(min, max));
+    }
+
+    const auto iota_v = m_iota.view();
+    axom::for_all<ExecSpace>(
+      this->m_numObjects,
+      AXOM_LAMBDA(int idx) { iota_v[idx] = idx; });
+
+    const int res_raw[3] = {2, 3, 4};
+    const axom::primal::NumericArray<int, DIM> resolution(res_raw);
+    this->m_grid = std::make_unique<UniformGridType>(resolution,
+                                                     m_boundingBoxes.view(),
+                                                     m_iota.view(),
+                                                     m_allocatorID);
+  }
+
+private:
+  int m_allocatorID;
+
+  int m_numObjects;
+  axom::Array<BoxType> m_boundingBoxes;
+  axom::Array<int> m_iota;
+
+  std::unique_ptr<UniformGridType> m_grid;
+};
+
+template <typename ExecSpace>
+using UniformGrid2DTest = spin_uniform_grid_templated<ExecSpace, 2>;
+
+template <typename ExecSpace>
+using UniformGrid3DTest = spin_uniform_grid_templated<ExecSpace, 2>;
+
+using MyTypes = ::testing::Types<
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP)
+  axom::OMP_EXEC,
+#endif
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+  axom::CUDA_EXEC<256>,
+#endif
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
+  axom::HIP_EXEC<256>,
+#endif
+  axom::SEQ_EXEC>;
+
+TYPED_TEST_SUITE(UniformGrid2DTest, MyTypes);
+TYPED_TEST_SUITE(UniformGrid3DTest, MyTypes);
+
+AXOM_TYPED_TEST(UniformGrid2DTest, initialize_tmpl)
+{
+  this->setNumObjects(1000);
+  this->initializeUniformGrid();
+}
+
+AXOM_TYPED_TEST(UniformGrid3DTest, initialize_tmpl)
+{
+  this->setNumObjects(1000);
+  this->initializeUniformGrid();
+}
+
+}  // namespace testing


### PR DESCRIPTION
# Summary

- Various memory fixes for `UniformGrid::initialize()`
  - Allocate `binCounts` array with the user-provided allocatorID
  - Remove dependence on implicit this-capture by using local variables
- Adds a test which exercises `UniformGrid`'s vector-based constructor
- Explicitly disable Address Translation Service in BlueOS CI