### PR TITLE
Update config.yaml to modern spec.format syntax

### DIFF
--- a/scripts/spack/configs/config.yaml
+++ b/scripts/spack/configs/config.yaml
@@ -19,7 +19,7 @@ config:
   install_tree:
     root: $spack/..
     projections:
-     all: "${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}"
+     all: "{compiler.name}-{compiler.version}/{name}-{version}"
     # install_tree can include an optional padded length (int or boolean)
     # default is False (do not pad)
     # if padded_length is True, Spack will pad as close to the system max path

--- a/scripts/spack/devtools_configs/config.yaml
+++ b/scripts/spack/devtools_configs/config.yaml
@@ -19,7 +19,7 @@ config:
   install_tree:
     root: $spack/..
     projections:
-     all: "${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}"
+     all: "{compiler.name}-{compiler.version}/{name}-{version}"
     # install_tree can include an optional padded length (int or boolean)
     # default is False (do not pad)
     # if padded_length is True, Spack will pad as close to the system max path


### PR DESCRIPTION
This should eliminate warnings from newer versions of Spack