### PR TITLE
Bugfixes for bugfixes

### DIFF
--- a/src/axom/primal/tests/primal_orientedboundingbox.cpp
+++ b/src/axom/primal/tests/primal_orientedboundingbox.cpp
@@ -490,31 +490,26 @@ TEST(primal_OBBox, obb_contains_obb)
 TEST(primal_OBBox, obb_to_local)
 {
   constexpr int DIM = 3;
+  constexpr double EPS = 1e-8;
+
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
   using QVector = primal::Vector<CoordType, DIM>;
   using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
-  QPoint pt1;      // origin
-  QVector u[DIM];  // make standard axes
-  QVector u_o[DIM];
-  for(int i = 0; i < DIM; i++)
-  {
-    u[i] = QVector();
-    u[i][i] = 1.;
-    u_o[i] = QVector();
-  }
-  u_o[0][0] = 1.;
-  u_o[0][2] = -1.;
-  u_o[1][0] = 1.;
-  u_o[1][2] = 1.;
-  u_o[2][1] = 1.;
+  // standard axes
+  QVector u[DIM] = {QVector {1, 0, 0}, QVector {0, 1, 0}, QVector {0, 0, 1}};
 
-  QVector e(1.);
+  // another othogonal basis
+  QVector u_o[DIM] = {QVector {1, 0, -1}, QVector {1, 0, 1}, QVector {0, 1, 0}};
+
+  QPoint pt1;
+  QVector vec0(0.);
 
   QPoint pt2(10.);
-  QVector vec0(0.);
   QVector vec1(10.);
+
+  QVector e(1.);
 
   QOBBox obbox1(pt1, u, e);
 
@@ -534,7 +529,7 @@ TEST(primal_OBBox, obb_to_local)
 
   // can roughly compute local coords of pt2
   QVector vec2(obbox2.toLocal(pt2));
-  EXPECT_DOUBLE_EQ(vec2[0], 0.);
+  EXPECT_NEAR(vec2[0], 0., EPS);
   EXPECT_TRUE(((vec2[1] - 14.142) < 0.1) && ((14.142 - vec2[1]) < 0.1));
   EXPECT_TRUE(((vec2[2] - 10.) < 0.1) && ((10. - vec2[2]) < 0.1));
 }

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -15,9 +15,6 @@
 // gtest includes
 #include "gtest/gtest.h"
 
-using namespace axom;
-namespace xargs = mint::xargs;
-
 // Uncomment the following for debugging
 //#define VTK_DEBUG
 
@@ -26,6 +23,16 @@ namespace xargs = mint::xargs;
 //------------------------------------------------------------------------------
 namespace
 {
+namespace primal = axom::primal;
+namespace spin = axom::spin;
+namespace mint = axom::mint;
+namespace numerics = axom::numerics;
+namespace xargs = mint::xargs;
+
+using IndexType = axom::IndexType;
+
+constexpr double EPS = 1e-6;
+
 //------------------------------------------------------------------------------
 template <typename FloatType, int NDIMS>
 void dump_ray(const std::string& file,
@@ -177,34 +184,28 @@ void generate_aabbs_and_centroids(const mint::Mesh* mesh,
                 numerics::Matrix<double> & coords,
                 const IndexType* AXOM_UNUSED_PARAM(nodeIds)) {
       BoxType range;
-
-      PointType sum(0.0);
+      PointType sum;
 
       for(IndexType inode = 0; inode < NUM_NODES_PER_CELL; ++inode)
       {
         const double* node = coords.getColumn(inode);
 
         PointType coords;
-        for(int dim = 0; dim < NDIMS; dim++)
+        for(int dim = 0; dim < NDIMS; ++dim)
         {
           coords[dim] = node[dim];
           sum[dim] += node[dim];
         }
 
         range.addPoint(coords);
-      }  // END for all cells nodes
-      for(int dim = 0; dim < NDIMS; dim++)
-      {
-        sum[dim] /= NUM_NODES_PER_CELL;
       }
+
+      sum.array() /= NUM_NODES_PER_CELL;
 
       c[cellIdx] = range.getCentroid();
 
 #ifndef AXOM_DEVICE_CODE
-      for(int dim = 0; dim < NDIMS; dim++)
-      {
-        EXPECT_DOUBLE_EQ(c[cellIdx][dim], sum[dim]);
-      }
+      EXPECT_NEAR(primal::squared_distance(c[cellIdx], sum), 0., EPS);
 #endif
 
       aabbs[cellIdx] = range;
@@ -248,8 +249,8 @@ void check_build_bvh2d()
 
   for(int idim = 0; idim < NDIMS; ++idim)
   {
-    EXPECT_DOUBLE_EQ(bounds.getMin()[idim], 0.0);
-    EXPECT_DOUBLE_EQ(bounds.getMax()[idim], 2.0);
+    EXPECT_NEAR(bounds.getMin()[idim], 0.0, EPS);
+    EXPECT_NEAR(bounds.getMax()[idim], 2.0, EPS);
   }
 
   axom::deallocate(boxes);
@@ -290,8 +291,8 @@ void check_build_bvh3d()
 
   for(int idim = 0; idim < NDIMS; ++idim)
   {
-    EXPECT_DOUBLE_EQ(bounds.getMin()[idim], 0.0);
-    EXPECT_DOUBLE_EQ(bounds.getMax()[idim], 2.0);
+    EXPECT_NEAR(bounds.getMin()[idim], 0.0, EPS);
+    EXPECT_NEAR(bounds.getMax()[idim], 2.0, EPS);
   }
 
   axom::deallocate(boxes);
@@ -344,8 +345,8 @@ void check_find_bounding_boxes3d()
 
   for(int idim = 0; idim < NDIMS; ++idim)
   {
-    EXPECT_DOUBLE_EQ(bounds.getMin()[idim], lo[idim]);
-    EXPECT_DOUBLE_EQ(bounds.getMax()[idim], hi[idim]);
+    EXPECT_NEAR(bounds.getMin()[idim], lo[idim], EPS);
+    EXPECT_NEAR(bounds.getMax()[idim], hi[idim], EPS);
   }
 
   // traverse the BVH to find the candidates for all the bounding boxes
@@ -461,8 +462,8 @@ void check_find_bounding_boxes2d()
 
   for(int idim = 0; idim < NDIMS; ++idim)
   {
-    EXPECT_DOUBLE_EQ(bounds.getMin()[idim], lo[idim]);
-    EXPECT_DOUBLE_EQ(bounds.getMax()[idim], hi[idim]);
+    EXPECT_NEAR(bounds.getMin()[idim], lo[idim], EPS);
+    EXPECT_NEAR(bounds.getMax()[idim], hi[idim], EPS);
   }
 
   // traverse the BVH to find the candidates for all the bounding boxes
@@ -565,8 +566,8 @@ void check_find_rays3d()
 
   for(int idim = 0; idim < NDIMS; ++idim)
   {
-    EXPECT_DOUBLE_EQ(bounds.getMin()[idim], lo[idim]);
-    EXPECT_DOUBLE_EQ(bounds.getMax()[idim], hi[idim]);
+    EXPECT_NEAR(bounds.getMin()[idim], lo[idim], EPS);
+    EXPECT_NEAR(bounds.getMax()[idim], hi[idim], EPS);
   }
 
   // traverse the BVH to find the candidates for all the centroids
@@ -695,8 +696,8 @@ void check_find_rays2d()
 
   for(int idim = 0; idim < NDIMS; ++idim)
   {
-    EXPECT_DOUBLE_EQ(bounds.getMin()[idim], lo[idim]);
-    EXPECT_DOUBLE_EQ(bounds.getMax()[idim], hi[idim]);
+    EXPECT_NEAR(bounds.getMin()[idim], lo[idim], EPS);
+    EXPECT_NEAR(bounds.getMax()[idim], hi[idim], EPS);
   }
 
   // traverse the BVH to find the candidates for all the centroids
@@ -805,8 +806,8 @@ void check_find_points3d()
 
   for(int idim = 0; idim < NDIMS; ++idim)
   {
-    EXPECT_DOUBLE_EQ(bounds.getMin()[idim], lo[idim]);
-    EXPECT_DOUBLE_EQ(bounds.getMax()[idim], hi[idim]);
+    EXPECT_NEAR(bounds.getMin()[idim], lo[idim], EPS);
+    EXPECT_NEAR(bounds.getMax()[idim], hi[idim], EPS);
   }
 
   // traverse the BVH to find the candidates for all the centroids
@@ -897,8 +898,8 @@ void check_find_points2d()
 
   for(int idim = 0; idim < NDIMS; ++idim)
   {
-    EXPECT_DOUBLE_EQ(bounds.getMin()[idim], lo[idim]);
-    EXPECT_DOUBLE_EQ(bounds.getMax()[idim], hi[idim]);
+    EXPECT_NEAR(bounds.getMin()[idim], lo[idim], EPS);
+    EXPECT_NEAR(bounds.getMax()[idim], hi[idim], EPS);
   }
 
   // traverse the BVH to find the candidates for all the centroids
@@ -971,8 +972,8 @@ void check_single_box2d()
 
   for(int idim = 0; idim < NDIMS; ++idim)
   {
-    EXPECT_DOUBLE_EQ(bounds.getMin()[idim], 0.0);
-    EXPECT_DOUBLE_EQ(bounds.getMax()[idim], 1.0);
+    EXPECT_NEAR(bounds.getMin()[idim], 0.0, EPS);
+    EXPECT_NEAR(bounds.getMax()[idim], 1.0, EPS);
   }
 
   // run the find algorithm w/ the centroid of the bounding box as input.
@@ -1037,8 +1038,8 @@ void check_single_box3d()
 
   for(int idim = 0; idim < NDIMS; ++idim)
   {
-    EXPECT_DOUBLE_EQ(bounds.getMin()[idim], 0.0);
-    EXPECT_DOUBLE_EQ(bounds.getMax()[idim], 1.0);
+    EXPECT_NEAR(bounds.getMin()[idim], 0.0, EPS);
+    EXPECT_NEAR(bounds.getMax()[idim], 1.0, EPS);
   }
 
   // run the find algorithm w/ the centroid of the bounding box as input.
@@ -1115,8 +1116,8 @@ void check_build_bvh_zip3d()
 
   for(int idim = 0; idim < NDIMS; ++idim)
   {
-    EXPECT_DOUBLE_EQ(bounds.getMin()[idim], 0.0);
-    EXPECT_DOUBLE_EQ(bounds.getMax()[idim], 2.0);
+    EXPECT_NEAR(bounds.getMin()[idim], 0.0, EPS);
+    EXPECT_NEAR(bounds.getMax()[idim], 2.0, EPS);
   }
 
   axom::deallocate(xmin);
@@ -1194,8 +1195,8 @@ void check_find_points_zip3d()
 
   for(int idim = 0; idim < NDIMS; ++idim)
   {
-    EXPECT_DOUBLE_EQ(bounds.getMin()[idim], lo[idim]);
-    EXPECT_DOUBLE_EQ(bounds.getMax()[idim], hi[idim]);
+    EXPECT_NEAR(bounds.getMin()[idim], lo[idim], EPS);
+    EXPECT_NEAR(bounds.getMax()[idim], hi[idim], EPS);
   }
 
   // traverse the BVH to find the candidates for all the centroids
@@ -1285,8 +1286,8 @@ void check_find_points_zip2d()
 
   for(int idim = 0; idim < NDIMS; ++idim)
   {
-    EXPECT_DOUBLE_EQ(bounds.getMin()[idim], lo[idim]);
-    EXPECT_DOUBLE_EQ(bounds.getMax()[idim], hi[idim]);
+    EXPECT_NEAR(bounds.getMin()[idim], lo[idim], EPS);
+    EXPECT_NEAR(bounds.getMax()[idim], hi[idim], EPS);
   }
 
   // traverse the BVH to find the candidates for all the centroids
@@ -1397,12 +1398,13 @@ void bvh_compute_point_distances_2d(BVHType& bvh,
   npts = query_pts.size();
   axom::for_all<ExecSpace>(
     npts,
-    AXOM_LAMBDA(int32 idx) mutable {
+    AXOM_LAMBDA(axom::int32 idx) mutable {
       // Get the current query point.
       auto qpt = query_pts_view[idx];
       MinCandidate curr_min;
 
-      auto checkMinDist = [&](int32 current_node, const int32* leaf_nodes) {
+      auto checkMinDist = [&](axom::int32 current_node,
+                              const axom::int32* leaf_nodes) {
         int candidate_idx = leaf_nodes[current_node];
         const PointType candidate_pt = pointsView[candidate_idx];
         const double sq_dist = squared_distance(qpt, candidate_pt);

--- a/src/cmake/thirdparty/FindLUA.cmake
+++ b/src/cmake/thirdparty/FindLUA.cmake
@@ -26,7 +26,7 @@ set(ENV{LUA_DIR} ${LUA_DIR})
 # HACK: Workaround for lua@5.4 and older versions of cmake (e.g. 3.16)
 # which did not account for versions of lua beyond 5.3
 string(FIND ${LUA_DIR} lua-5.4 _is_lua_5_4)
-if(_is_lua_5_4)
+if(NOT ${_is_lua_5_4} EQUAL -1)
     find_package(Lua 5.4 EXACT REQUIRED) 
 else()
     find_package(Lua REQUIRED) 


### PR DESCRIPTION
# Summary

- This PR contains some bugfixes for previous bugfix PRs
- It improves the import logic for lua (https://github.com/LLNL/axom/pull/1017)
    - CMake's `string(FIND )` returns an index, not a boolean
- It improves some floating point tests (https://github.com/LLNL/axom/pull/1025)
    - We need to use `EXPECT_NEAR` with a provided tolerance rather than `EXPECT_DOUBLE_EQ`
- I also slightly cleaned up the code in the test files