### PR TITLE
Enable use of spack packages as a spack repo

### DIFF
--- a/scripts/spack/packages/axom/examples-oneapi.patch
+++ b/scripts/spack/packages/axom/examples-oneapi.patch
@@ -1,0 +1,12 @@
+diff -ruN spack-src/src/axom/quest/examples/CMakeLists.txt spack-src-patched/src/axom/quest/examples/CMakeLists.txt
+--- spack-src/src/axom/quest/examples/CMakeLists.txt	2022-08-08 08:51:26.746637415 -0700
++++ spack-src-patched/src/axom/quest/examples/CMakeLists.txt	2022-08-08 08:52:26.238959054 -0700
+@@ -103,7 +103,7 @@
+     # When CUDA is enabled, BLT will determine the correct linker, so don't override it here
+     if (NOT ENABLE_CUDA)
+         # When using the Intel compiler we need to link with the Fortran compiler to get openmp to work correctly.
+-        if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
++	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM")
+             set_target_properties( quest_signed_distance_interface_F_ex
+                                    PROPERTIES LINKER_LANGUAGE Fortran)
+ 

--- a/scripts/spack/packages/mfem/mfem-3.3-3.4-petsc-3.9.patch
+++ b/scripts/spack/packages/mfem/mfem-3.3-3.4-petsc-3.9.patch
@@ -1,0 +1,71 @@
+diff --git a/examples/petsc/rc_ex3p b/examples/petsc/rc_ex3p
+index 2cbe07ef2..c585d9b52 100644
+--- a/examples/petsc/rc_ex3p
++++ b/examples/petsc/rc_ex3p
+@@ -6,4 +6,4 @@
+ # it needs PETSc configured with MUMPS
+ 
+ -solver_pc_type cholesky
+--solver_pc_factor_mat_solver_package mumps
++-solver_pc_factor_mat_solver_type mumps
+diff --git a/examples/petsc/rc_ex3p_bddc b/examples/petsc/rc_ex3p_bddc
+index ea887bb29..2e1eba0d5 100644
+--- a/examples/petsc/rc_ex3p_bddc
++++ b/examples/petsc/rc_ex3p_bddc
+@@ -16,7 +16,7 @@
+ #-pc_bddc_adaptive_threshold 10
+ 
+ # Customization of the local solvers
+-#-pc_bddc_neumann_pc_factor_mat_solver_package mumps
+-#-pc_bddc_dirichlet_pc_factor_mat_solver_package mumps
++#-pc_bddc_neumann_pc_factor_mat_solver_type mumps
++#-pc_bddc_dirichlet_pc_factor_mat_solver_type mumps
+ #-pc_bddc_coarse_pc_type cholesky
+-#-pc_bddc_coarse_pc_factor_mat_solver_package mumps
++#-pc_bddc_coarse_pc_factor_mat_solver_type mumps
+diff --git a/examples/petsc/rc_ex4p b/examples/petsc/rc_ex4p
+index f734f35fe..64fbe9427 100644
+--- a/examples/petsc/rc_ex4p
++++ b/examples/petsc/rc_ex4p
+@@ -2,4 +2,4 @@
+ # it needs PETSc configured with MUMPS
+ 
+ -solver_pc_type cholesky
+--solver_pc_factor_mat_solver_package mumps
++-solver_pc_factor_mat_solver_type mumps
+diff --git a/examples/petsc/rc_ex4p_bddc b/examples/petsc/rc_ex4p_bddc
+index 9507ad431..e8ef99db7 100644
+--- a/examples/petsc/rc_ex4p_bddc
++++ b/examples/petsc/rc_ex4p_bddc
+@@ -13,7 +13,7 @@
+ #-pc_bddc_adaptive_threshold 10
+ 
+ # Customization of the local solvers
+-#-pc_bddc_neumann_pc_factor_mat_solver_package mumps
+-#-pc_bddc_dirichlet_pc_factor_mat_solver_package mumps
++#-pc_bddc_neumann_pc_factor_mat_solver_type mumps
++#-pc_bddc_dirichlet_pc_factor_mat_solver_type mumps
+ #-pc_bddc_coarse_pc_type cholesky
+-#-pc_bddc_coarse_pc_factor_mat_solver_package mumps
++#-pc_bddc_coarse_pc_factor_mat_solver_type mumps
+diff --git a/examples/petsc/rc_ex5p_bddc b/examples/petsc/rc_ex5p_bddc
+index b243c53c8..a4bc899c3 100644
+--- a/examples/petsc/rc_ex5p_bddc
++++ b/examples/petsc/rc_ex5p_bddc
+@@ -28,13 +28,13 @@
+ # local solvers (needs PETSc compiled with support for SuiteSparse)
+ # default solvers will fail
+ -prec_pc_bddc_neumann_pc_type lu
+--prec_pc_bddc_neumann_pc_factor_mat_solver_package umfpack
++-prec_pc_bddc_neumann_pc_factor_mat_solver_type umfpack
+ -prec_pc_bddc_dirichlet_pc_type lu
+--prec_pc_bddc_dirichlet_pc_factor_mat_solver_package umfpack
++-prec_pc_bddc_dirichlet_pc_factor_mat_solver_type umfpack
+ 
+ # coarse solver (needs PETSc compiled with support for MUMPS)
+ # default solver may fail
+--prec_pc_bddc_coarse_pc_factor_mat_solver_package mumps
++-prec_pc_bddc_coarse_pc_factor_mat_solver_type mumps
+ -prec_pc_bddc_coarse_pc_type cholesky
+ 
+ # deluxe scaling (needs PETSc compiled with support for MUMPS)

--- a/scripts/spack/packages/mfem/mfem-3.4.patch
+++ b/scripts/spack/packages/mfem/mfem-3.4.patch
@@ -1,0 +1,36 @@
+diff --git a/config/test.mk b/config/test.mk
+index 4821b084d..62479fc63 100644
+--- a/config/test.mk
++++ b/config/test.mk
+@@ -14,11 +14,13 @@
+ # Colors used below:
+ # green    '\033[0;32m'
+ # red      '\033[0;31m'
++# yellow   '\033[0;33m'
+ # no color '\033[0m'
+ COLOR_PRINT = if [ -t 1 ]; then \
+    printf $(1)$(2)'\033[0m'$(3); else printf $(2)$(3); fi
+ PRINT_OK = $(call COLOR_PRINT,'\033[0;32m',OK,"  ($$1 $$2)\n")
+ PRINT_FAILED = $(call COLOR_PRINT,'\033[0;31m',FAILED,"  ($$1 $$2)\n")
++PRINT_SKIP = $(call COLOR_PRINT,'\033[0;33m',SKIP,"\n")
+ 
+ # Timing support
+ define TIMECMD_detect
+diff --git a/examples/pumi/makefile b/examples/pumi/makefile
+index 2f98eeca7..5ff652aca 100644
+--- a/examples/pumi/makefile
++++ b/examples/pumi/makefile
+@@ -51,6 +51,13 @@ endif
+ MFEM_TESTS = EXAMPLES
+ include $(MFEM_TEST_MK)
+ 
++ifneq (,$(filter test%,$(MAKECMDGOALS)))
++   ifeq (,$(wildcard ../../data/pumi))
++      $(info PUMI data directory not found. The PUMI tests will be SKIPPED.)
++      mfem-test = printf "   $(3) [$(2) $(1) ... ]: "; $(PRINT_SKIP)
++   endif
++endif
++
+ # Testing: Parallel vs. serial runs
+ RUN_MPI_NP = $(MFEM_MPIEXEC) $(MFEM_MPIEXEC_NP)
+ RUN_MPI = $(RUN_MPI_NP) $(MFEM_MPI_NP)

--- a/scripts/spack/packages/mfem/mfem-4.0.0-makefile-syntax-fix.patch
+++ b/scripts/spack/packages/mfem/mfem-4.0.0-makefile-syntax-fix.patch
@@ -1,0 +1,27 @@
+From e2147e51e2bff8907207036557bb9f45d45baaf8 Mon Sep 17 00:00:00 2001
+From: Geoffrey M Oxberry <goxberry@gmail.com>
+Date: Sun, 25 Aug 2019 00:30:15 -0700
+Subject: [PATCH] makefile: add missing parenthesis to conditional
+
+This commit adds a missing parenthesis to a conditional in the MFEM
+makefile that checks if PREFIX is set when MFEM_USE_OCCA equals YES.
+---
+ makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/makefile b/makefile
+index 98a29f3c9..22a9b5bac 100644
+--- a/makefile
++++ b/makefile
+@@ -346,7 +346,7 @@ ifneq (,$(filter install,$(MAKECMDGOALS)))
+       @MFEM_EXT_LIBS@
+    MFEM_LIB_FILE = @MFEM_LIB_DIR@/libmfem.$(if $(shared),$(SO_VER),a)
+    ifeq ($(MFEM_USE_OCCA),YES)
+-      ifneq ($(MFEM_INSTALL_DIR),$(abspath $(PREFIX))
++      ifneq ($(MFEM_INSTALL_DIR),$(abspath $(PREFIX)))
+          $(error OCCA is enabled: PREFIX must be set during configuration!)
+       endif
+    endif
+-- 
+2.23.0
+

--- a/scripts/spack/packages/mfem/mfem-4.2-petsc-3.15.0.patch
+++ b/scripts/spack/packages/mfem/mfem-4.2-petsc-3.15.0.patch
@@ -1,0 +1,32 @@
+diff --git a/linalg/petsc.cpp b/linalg/petsc.cpp
+index fcfdd325f..90eedf042 100644
+--- a/linalg/petsc.cpp
++++ b/linalg/petsc.cpp
+@@ -1872,8 +1872,13 @@ void PetscSolver::SetPrintLevel(int plev)
+          {
+             ierr = PetscViewerAndFormatCreate(viewer,PETSC_VIEWER_DEFAULT,&vf);
+             PCHKERRQ(viewer,ierr);
++#if PETSC_VERSION_LT(3,15,0)
+             ierr = KSPMonitorSet(ksp,(myMonitor)KSPMonitorTrueResidualNorm,vf,
+                                  (myPetscFunc)PetscViewerAndFormatDestroy);
++#else
++            ierr = KSPMonitorSet(ksp,(myMonitor)KSPMonitorTrueResidual,vf,
++                                 (myPetscFunc)PetscViewerAndFormatDestroy);
++#endif
+             PCHKERRQ(ksp,ierr);
+          }
+       }
+@@ -2887,8 +2892,13 @@ void PetscBDDCSolver::BDDCSolverConstructor(const PetscBDDCSolverParams &opts)
+ 
+                ierr = VecGetArrayRead(pvec_coords,&garray); CCHKERRQ(PETSC_COMM_SELF,ierr);
+                ierr = VecGetArray(lvec_coords,&larray); CCHKERRQ(PETSC_COMM_SELF,ierr);
++#if PETSC_VERSION_LT(3,15,0)
+                ierr = PetscSFBcastBegin(sf,MPIU_SCALAR,garray,larray); CCHKERRQ(comm,ierr);
+                ierr = PetscSFBcastEnd(sf,MPIU_SCALAR,garray,larray); CCHKERRQ(comm,ierr);
++#else
++               ierr = PetscSFBcastBegin(sf,MPIU_SCALAR,garray,larray,MPI_REPLACE); CCHKERRQ(comm,ierr);
++               ierr = PetscSFBcastEnd(sf,MPIU_SCALAR,garray,larray,MPI_REPLACE); CCHKERRQ(comm,ierr);
++#endif
+                ierr = VecRestoreArrayRead(pvec_coords,&garray); CCHKERRQ(PETSC_COMM_SELF,ierr);
+                ierr = VecRestoreArray(lvec_coords,&larray); CCHKERRQ(PETSC_COMM_SELF,ierr);
+             }

--- a/scripts/spack/packages/mfem/mfem-4.2-slepc.patch
+++ b/scripts/spack/packages/mfem/mfem-4.2-slepc.patch
@@ -1,0 +1,40 @@
+diff --git a/linalg/slepc.hpp b/linalg/slepc.hpp
+index 7f8911ba2..5b1f1c686 100644
+--- a/linalg/slepc.hpp
++++ b/linalg/slepc.hpp
+@@ -19,12 +19,15 @@
+ 
+ #include "petsc.hpp"
+ 
+-// Forward declarations
+-typedef struct _p_EPS *EPS;
++// Forward declaration of SLEPc's internal struct _p_EPS:
++struct _p_EPS;
+ 
+ namespace mfem
+ {
+ 
++// Declare an alias of SLEPc's EPS type, mfem::slepc::EPS:
++namespace slepc { typedef struct ::_p_EPS *EPS; }
++
+ void MFEMInitializeSlepc();
+ void MFEMInitializeSlepc(int*,char***);
+ void MFEMInitializeSlepc(int*,char***,const char[],const char[]);
+@@ -37,7 +40,7 @@ private:
+    mutable bool clcustom;
+ 
+    /// SLEPc linear eigensolver object
+-   EPS eps;
++   slepc::EPS eps;
+ 
+    /// Real and imaginary part of eigenvector
+    mutable PetscParVector *VR, *VC;
+@@ -102,7 +105,7 @@ public:
+    void SetSpectralTransformation(SpectralTransformation transformation);
+ 
+    /// Conversion function to SLEPc's EPS type.
+-   operator EPS() const { return eps; }
++   operator slepc::EPS() const { return eps; }
+ 
+    /// Conversion function to PetscObject
+    operator PetscObject() const {return (PetscObject)eps; }

--- a/scripts/spack/packages/mfem/mfem-4.2-umpire.patch
+++ b/scripts/spack/packages/mfem/mfem-4.2-umpire.patch
@@ -1,0 +1,24 @@
+diff --git a/general/mem_manager.cpp b/general/mem_manager.cpp
+index ff4a03465..748f6e673 100644
+--- a/general/mem_manager.cpp
++++ b/general/mem_manager.cpp
+@@ -482,7 +482,8 @@ public:
+       HostMemorySpace(),
+       name(mm.GetUmpireAllocatorHostName()),
+       rm(umpire::ResourceManager::getInstance()),
+-      h_allocator(rm.isAllocator(name)? rm.getAllocator(name):
++      h_allocator((!std::strcmp(name, "HOST") || rm.isAllocator(name)) ?
++                  rm.getAllocator(name) :
+                   rm.makeAllocator<umpire::strategy::DynamicPool>
+                   (name, rm.getAllocator("HOST"))),
+       strat(h_allocator.getAllocationStrategy()) { }
+@@ -506,7 +507,8 @@ public:
+       DeviceMemorySpace(),
+       name(mm.GetUmpireAllocatorDeviceName()),
+       rm(umpire::ResourceManager::getInstance()),
+-      d_allocator(rm.isAllocator(name)? rm.getAllocator(name):
++      d_allocator((!std::strcmp(name, "DEVICE") || rm.isAllocator(name)) ?
++                  rm.getAllocator(name) :
+                   rm.makeAllocator<umpire::strategy::DynamicPool>
+                   (name, rm.getAllocator("DEVICE"))) { }
+    void Alloc(Memory &base) { base.d_ptr = d_allocator.allocate(base.bytes); }

--- a/scripts/spack/packages/mfem/mfem-4.3-cusparse-11.4.patch
+++ b/scripts/spack/packages/mfem/mfem-4.3-cusparse-11.4.patch
@@ -1,0 +1,80 @@
+diff --git a/linalg/sparsemat.cpp b/linalg/sparsemat.cpp
+index 12136e035..0be73cf7b 100644
+--- a/linalg/sparsemat.cpp
++++ b/linalg/sparsemat.cpp
+@@ -33,7 +33,12 @@ int SparseMatrix::SparseMatrixCount = 0;
+ cusparseHandle_t SparseMatrix::handle = nullptr;
+ size_t SparseMatrix::bufferSize = 0;
+ void * SparseMatrix::dBuffer = nullptr;
+-#endif
++#  if CUSPARSE_VERSION >=  11400
++#    define MFEM_CUSPARSE_ALG CUSPARSE_SPMV_CSR_ALG1
++#  else
++#    define MFEM_CUSPARSE_ALG CUSPARSE_CSRMV_ALG1
++#  endif // CUSPARSE_VERSION >= 11400
++#endif // MFEM_USE_CUDA
+ 
+ void SparseMatrix::InitCuSparse()
+ {
+@@ -679,25 +684,16 @@ void SparseMatrix::AddMult(const Vector &x, Vector &y, const double a) const
+          cusparseCreateMatDescr(&matA_descr);
+          cusparseSetMatIndexBase(matA_descr, CUSPARSE_INDEX_BASE_ZERO);
+          cusparseSetMatType(matA_descr, CUSPARSE_MATRIX_TYPE_GENERAL);
+-
+ #endif
+-
+          initBuffers = true;
+       }
+       // Allocate kernel space. Buffer is shared between different sparsemats
+       size_t newBufferSize = 0;
+ 
+-#if CUDA_VERSION >= 11020
+-      cusparseSpMV_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha,
+-                              matA_descr,
+-                              vecX_descr, &beta, vecY_descr, CUDA_R_64F,
+-                              CUSPARSE_SPMV_CSR_ALG1, &newBufferSize);
+-#elif CUDA_VERSION >= 10010
+       cusparseSpMV_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha,
+                               matA_descr,
+                               vecX_descr, &beta, vecY_descr, CUDA_R_64F,
+-                              CUSPARSE_CSRMV_ALG1, &newBufferSize);
+-#endif
++                              MFEM_CUSPARSE_ALG, &newBufferSize);
+ 
+       // Check if we need to resize
+       if (newBufferSize > bufferSize)
+@@ -707,30 +703,22 @@ void SparseMatrix::AddMult(const Vector &x, Vector &y, const double a) const
+          CuMemAlloc(&dBuffer, bufferSize);
+       }
+ 
+-#if CUDA_VERSION >= 11020
+-      // Update input/output vectors
+-      cusparseDnVecSetValues(vecX_descr, const_cast<double *>(d_x));
+-      cusparseDnVecSetValues(vecY_descr, d_y);
+-
+-      // Y = alpha A * X + beta * Y
+-      cusparseSpMV(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, matA_descr,
+-                   vecX_descr, &beta, vecY_descr, CUDA_R_64F, CUSPARSE_SPMV_CSR_ALG1, dBuffer);
+-#elif CUDA_VERSION >= 10010
++#if CUDA_VERSION >= 10010
+       // Update input/output vectors
+       cusparseDnVecSetValues(vecX_descr, const_cast<double *>(d_x));
+       cusparseDnVecSetValues(vecY_descr, d_y);
+ 
+       // Y = alpha A * X + beta * Y
+       cusparseSpMV(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, matA_descr,
+-                   vecX_descr, &beta, vecY_descr, CUDA_R_64F, CUSPARSE_CSRMV_ALG1, dBuffer);
++                   vecX_descr, &beta, vecY_descr, CUDA_R_64F, MFEM_CUSPARSE_ALG, dBuffer);
+ #else
+       cusparseDcsrmv(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+                      Height(), Width(), J.Capacity(),
+                      &alpha, matA_descr,
+                      const_cast<double *>(d_A), const_cast<int *>(d_I), const_cast<int *>(d_J),
+                      const_cast<double *>(d_x), &beta, d_y);
+-#endif
+-#endif
++#endif // CUDA_VERSION >= 10010
++#endif // MFEM_USE_CUDA
+    }
+    else
+    {

--- a/scripts/spack/packages/mfem/mfem-4.3-hypre-2.23.0.patch
+++ b/scripts/spack/packages/mfem/mfem-4.3-hypre-2.23.0.patch
@@ -1,0 +1,575 @@
+diff --git a/fem/pfespace.cpp b/fem/pfespace.cpp
+index 1e2a47a5b..53964328e 100644
+--- a/fem/pfespace.cpp
++++ b/fem/pfespace.cpp
+@@ -1278,12 +1278,17 @@ const FiniteElement *ParFiniteElementSpace::GetFaceNbrFaceFE(int i) const
+ 
+ void ParFiniteElementSpace::Lose_Dof_TrueDof_Matrix()
+ {
++   P -> StealData();
++#if MFEM_HYPRE_VERSION <= 22200
+    hypre_ParCSRMatrix *csrP = (hypre_ParCSRMatrix*)(*P);
+    hypre_ParCSRMatrixOwnsRowStarts(csrP) = 1;
+    hypre_ParCSRMatrixOwnsColStarts(csrP) = 1;
+-   P -> StealData();
+    dof_offsets.LoseData();
+    tdof_offsets.LoseData();
++#else
++   dof_offsets.DeleteAll();
++   tdof_offsets.DeleteAll();
++#endif
+ }
+ 
+ void ParFiniteElementSpace::ConstructTrueDofs()
+diff --git a/linalg/complex_operator.cpp b/linalg/complex_operator.cpp
+index 1f42ab425..8a2f8e580 100644
+--- a/linalg/complex_operator.cpp
++++ b/linalg/complex_operator.cpp
+@@ -787,10 +787,16 @@ HypreParMatrix * ComplexHypreParMatrix::GetSystemMatrix() const
+                                            2 * num_cols_offd, cmap,
+                                            true);
+ 
++#if MFEM_HYPRE_VERSION <= 22200
+    // Give the new matrix ownership of row_starts and col_starts
+    hypre_ParCSRMatrix *hA = (hypre_ParCSRMatrix*)(*A);
++
+    hypre_ParCSRMatrixSetRowStartsOwner(hA,1);
+    hypre_ParCSRMatrixSetColStartsOwner(hA,1);
++#else
++   mfem_hypre_TFree_host(row_starts);
++   mfem_hypre_TFree_host(col_starts);
++#endif
+ 
+    return A;
+ }
+diff --git a/linalg/hypre.cpp b/linalg/hypre.cpp
+index 3f393e39a..6ca80e987 100644
+--- a/linalg/hypre.cpp
++++ b/linalg/hypre.cpp
+@@ -88,7 +88,9 @@ HypreParVector::HypreParVector(MPI_Comm comm, HYPRE_BigInt glob_size,
+ {
+    x = hypre_ParVectorCreate(comm,glob_size,col);
+    hypre_ParVectorInitialize(x);
++#if MFEM_HYPRE_VERSION <= 22200
+    hypre_ParVectorSetPartitioningOwner(x,0);
++#endif
+    // The data will be destroyed by hypre (this is the default)
+    hypre_ParVectorSetDataOwner(x,1);
+    hypre_SeqVectorSetDataOwner(hypre_ParVectorLocalVector(x),1);
+@@ -105,7 +107,9 @@ HypreParVector::HypreParVector(MPI_Comm comm, HYPRE_BigInt glob_size,
+    hypre_ParVectorSetDataOwner(x,1); // owns the seq vector
+    hypre_Vector *x_loc = hypre_ParVectorLocalVector(x);
+    hypre_SeqVectorSetDataOwner(x_loc,0);
++#if MFEM_HYPRE_VERSION <= 22200
+    hypre_ParVectorSetPartitioningOwner(x,0);
++#endif
+    double tmp = 0.0;
+    hypre_VectorData(x_loc) = &tmp;
+ #ifdef HYPRE_USING_CUDA
+@@ -128,7 +132,9 @@ HypreParVector::HypreParVector(const HypreParVector &y) : Vector()
+    x = hypre_ParVectorCreate(y.x -> comm, y.x -> global_size,
+                              y.x -> partitioning);
+    hypre_ParVectorInitialize(x);
++#if MFEM_HYPRE_VERSION <= 22200
+    hypre_ParVectorSetPartitioningOwner(x,0);
++#endif
+    hypre_ParVectorSetDataOwner(x,1);
+    hypre_SeqVectorSetDataOwner(hypre_ParVectorLocalVector(x),1);
+    _SetDataAndSize_();
+@@ -162,7 +168,9 @@ HypreParVector::HypreParVector(ParFiniteElementSpace *pfes)
+    x = hypre_ParVectorCreate(pfes->GetComm(), pfes->GlobalTrueVSize(),
+                              pfes->GetTrueDofOffsets());
+    hypre_ParVectorInitialize(x);
++#if MFEM_HYPRE_VERSION <= 22200
+    hypre_ParVectorSetPartitioningOwner(x,0);
++#endif
+    // The data will be destroyed by hypre (this is the default)
+    hypre_ParVectorSetDataOwner(x,1);
+    hypre_SeqVectorSetDataOwner(hypre_ParVectorLocalVector(x),1);
+@@ -683,8 +691,10 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm, HYPRE_BigInt glob_size,
+    A = hypre_ParCSRMatrixCreate(comm, glob_size, glob_size, row_starts,
+                                 row_starts, 0, diag->NumNonZeroElems(), 0);
+    hypre_ParCSRMatrixSetDataOwner(A,1);
++#if MFEM_HYPRE_VERSION <= 22200
+    hypre_ParCSRMatrixSetRowStartsOwner(A,0);
+    hypre_ParCSRMatrixSetColStartsOwner(A,0);
++#endif
+ 
+    hypre_CSRMatrixSetDataOwner(A->diag,0);
+    diagOwner = CopyCSR(diag, mem_diag, A->diag, false);
+@@ -726,8 +736,10 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm,
+                                 row_starts, col_starts,
+                                 0, diag->NumNonZeroElems(), 0);
+    hypre_ParCSRMatrixSetDataOwner(A,1);
++#if MFEM_HYPRE_VERSION <= 22200
+    hypre_ParCSRMatrixSetRowStartsOwner(A,0);
+    hypre_ParCSRMatrixSetColStartsOwner(A,0);
++#endif
+ 
+    hypre_CSRMatrixSetDataOwner(A->diag,0);
+    diagOwner = CopyCSR(diag, mem_diag, A->diag, false);
+@@ -770,8 +782,10 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm,
+                                 offd->Width(), diag->NumNonZeroElems(),
+                                 offd->NumNonZeroElems());
+    hypre_ParCSRMatrixSetDataOwner(A,1);
++#if MFEM_HYPRE_VERSION <= 22200
+    hypre_ParCSRMatrixSetRowStartsOwner(A,0);
+    hypre_ParCSRMatrixSetColStartsOwner(A,0);
++#endif
+ 
+    hypre_CSRMatrixSetDataOwner(A->diag,0);
+    diagOwner = CopyCSR(diag, mem_diag, A->diag, own_diag_offd);
+@@ -817,8 +831,10 @@ HypreParMatrix::HypreParMatrix(
+    A = hypre_ParCSRMatrixCreate(comm, global_num_rows, global_num_cols,
+                                 row_starts, col_starts, offd_num_cols, 0, 0);
+    hypre_ParCSRMatrixSetDataOwner(A,1);
++#if MFEM_HYPRE_VERSION <= 22200
+    hypre_ParCSRMatrixSetRowStartsOwner(A,0);
+    hypre_ParCSRMatrixSetColStartsOwner(A,0);
++#endif
+ 
+    HYPRE_Int local_num_rows = hypre_CSRMatrixNumRows(A->diag);
+ 
+@@ -931,8 +947,10 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm,
+    A = hypre_ParCSRMatrixCreate(comm, global_num_rows, global_num_cols,
+                                 row_starts, col_starts, 0, nnz, 0);
+    hypre_ParCSRMatrixSetDataOwner(A,1);
++#if MFEM_HYPRE_VERSION <= 22200
+    hypre_ParCSRMatrixSetRowStartsOwner(A,0);
+    hypre_ParCSRMatrixSetColStartsOwner(A,0);
++#endif
+ 
+    hypre_CSRMatrixSetDataOwner(A->diag,0);
+    diagOwner = CopyBoolCSR(diag, mem_diag, A->diag);
+@@ -989,8 +1007,10 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm, int id, int np,
+    }
+ 
+    hypre_ParCSRMatrixSetDataOwner(A,1);
++#if MFEM_HYPRE_VERSION <= 22200
+    hypre_ParCSRMatrixSetRowStartsOwner(A,0);
+    hypre_ParCSRMatrixSetColStartsOwner(A,0);
++#endif
+ 
+    mem_diag.data.New(diag_nnz);
+    for (HYPRE_Int i = 0; i < diag_nnz; i++)
+@@ -1177,6 +1197,13 @@ HypreParMatrix::HypreParMatrix(MPI_Comm comm, int nrows,
+    {
+       hypre_CSRMatrixReorder(hypre_ParCSRMatrixDiag(A));
+    }
++#if MFEM_HYPRE_VERSION > 22200
++   mfem_hypre_TFree_host(row_starts);
++   if (rows != cols)
++   {
++      mfem_hypre_TFree_host(col_starts);
++   }
++#endif
+    hypre_MatvecCommPkgCreate(A);
+ 
+    height = GetNumRows();
+@@ -1263,6 +1290,7 @@ void HypreParMatrix::SetOwnerFlags(signed char diag, signed char offd,
+ 
+ void HypreParMatrix::CopyRowStarts()
+ {
++#if MFEM_HYPRE_VERSION <= 22200
+    if (!A || hypre_ParCSRMatrixOwnsRowStarts(A) ||
+        (hypre_ParCSRMatrixRowStarts(A) == hypre_ParCSRMatrixColStarts(A) &&
+         hypre_ParCSRMatrixOwnsColStarts(A)))
+@@ -1297,10 +1325,12 @@ void HypreParMatrix::CopyRowStarts()
+       hypre_ParCSRMatrixColStarts(A) = new_row_starts;
+       hypre_ParCSRMatrixOwnsColStarts(A) = 0;
+    }
++#endif
+ }
+ 
+ void HypreParMatrix::CopyColStarts()
+ {
++#if MFEM_HYPRE_VERSION <= 22200
+    if (!A || hypre_ParCSRMatrixOwnsColStarts(A) ||
+        (hypre_ParCSRMatrixRowStarts(A) == hypre_ParCSRMatrixColStarts(A) &&
+         hypre_ParCSRMatrixOwnsRowStarts(A)))
+@@ -1339,6 +1369,7 @@ void HypreParMatrix::CopyColStarts()
+    {
+       hypre_ParCSRMatrixOwnsColStarts(A) = 1;
+    }
++#endif
+ }
+ 
+ void HypreParMatrix::GetDiag(Vector &diag) const
+@@ -1490,6 +1521,10 @@ HypreParMatrix * HypreParMatrix::Transpose() const
+ HypreParMatrix *HypreParMatrix::ExtractSubmatrix(const Array<int> &indices,
+                                                  double threshold) const
+ {
++   // hypre_ParCSRMatrixExtractSubmatrixFC works on host only, so we move this
++   // matrix to host, temporarily:
++   HostRead();
++
+    if (!(A->comm))
+    {
+       hypre_MatvecCommPkgCreate(A);
+@@ -1501,15 +1536,28 @@ HypreParMatrix *HypreParMatrix::ExtractSubmatrix(const Array<int> &indices,
+    int local_num_vars = hypre_CSRMatrixNumRows(hypre_ParCSRMatrixDiag(A));
+ 
+    // Form hypre CF-splitting array designating submatrix as F-points (-1)
++#ifdef hypre_IntArrayData
++   // hypre_BoomerAMGCoarseParms needs CF_marker to be hypre_IntArray *
++   hypre_IntArray *CF_marker;
++
++   CF_marker = hypre_IntArrayCreate(local_num_vars);
++   hypre_IntArrayInitialize_v2(CF_marker, HYPRE_MEMORY_HOST);
++   hypre_IntArraySetConstantValues(CF_marker, 1);
++#else
+    Array<HYPRE_Int> CF_marker(local_num_vars);
+    CF_marker = 1;
++#endif
+    for (int j=0; j<indices.Size(); j++)
+    {
+       if (indices[j] > local_num_vars)
+       {
+          MFEM_WARNING("WARNING : " << indices[j] << " > " << local_num_vars);
+       }
++#ifdef hypre_IntArrayData
++      hypre_IntArrayData(CF_marker)[indices[j]] = -1;
++#else
+       CF_marker[indices[j]] = -1;
++#endif
+    }
+ 
+    // Construct cpts_global array on hypre matrix structure
+@@ -1518,10 +1566,22 @@ HypreParMatrix *HypreParMatrix::ExtractSubmatrix(const Array<int> &indices,
+                               CF_marker, NULL, &cpts_global);
+ 
+    // Extract submatrix into *submat
++#ifdef hypre_IntArrayData
++   hypre_ParCSRMatrixExtractSubmatrixFC(A, hypre_IntArrayData(CF_marker),
++                                        cpts_global, "FF", &submat,
++                                        threshold);
++#else
+    hypre_ParCSRMatrixExtractSubmatrixFC(A, CF_marker, cpts_global,
+                                         "FF", &submat, threshold);
++#endif
+ 
+    mfem_hypre_TFree(cpts_global);
++#ifdef hypre_IntArrayData
++   hypre_IntArrayDestroy(CF_marker);
++#endif
++
++   HypreRead(); // restore the matrix location to the default hypre location
++
+    return new HypreParMatrix(submat);
+ }
+ #endif
+@@ -1791,9 +1851,14 @@ HypreParMatrix* HypreParMatrix::LeftDiagMult(const SparseMatrix &D,
+                          DA_diag, DA_offd, new_col_map_offd,
+                          own_diag_offd);
+ 
++#if MFEM_HYPRE_VERSION <= 22200
+    // Give ownership of row_starts, col_starts, and col_map_offd to DA
+    hypre_ParCSRMatrixSetRowStartsOwner(DA->A, 1);
+    hypre_ParCSRMatrixSetColStartsOwner(DA->A, 1);
++#else
++   mfem_hypre_TFree_host(new_row_starts);
++   mfem_hypre_TFree_host(new_col_starts);
++#endif
+    DA->colMapOwner = 1;
+ 
+    return DA;
+@@ -1948,18 +2013,22 @@ void HypreParMatrix::Threshold(double threshold)
+    row_starts = hypre_ParCSRMatrixRowStarts(A);
+    col_starts = hypre_ParCSRMatrixColStarts(A);
+ 
++#if MFEM_HYPRE_VERSION <= 22200
+    bool old_owns_row = hypre_ParCSRMatrixOwnsRowStarts(A);
+    bool old_owns_col = hypre_ParCSRMatrixOwnsColStarts(A);
++#endif
+    HYPRE_BigInt global_num_rows = hypre_ParCSRMatrixGlobalNumRows(A);
+    HYPRE_BigInt global_num_cols = hypre_ParCSRMatrixGlobalNumCols(A);
+    parcsr_A_ptr = hypre_ParCSRMatrixCreate(comm, global_num_rows,
+                                            global_num_cols,
+                                            row_starts, col_starts,
+                                            0, 0, 0);
++#if MFEM_HYPRE_VERSION <= 22200
+    hypre_ParCSRMatrixOwnsRowStarts(parcsr_A_ptr) = old_owns_row;
+    hypre_ParCSRMatrixOwnsColStarts(parcsr_A_ptr) = old_owns_col;
+    hypre_ParCSRMatrixOwnsRowStarts(A) = 0;
+    hypre_ParCSRMatrixOwnsColStarts(A) = 0;
++#endif
+ 
+    csr_A = hypre_MergeDiagAndOffd(A);
+ 
+@@ -1994,7 +2063,12 @@ void HypreParMatrix::Threshold(double threshold)
+ 
+    hypre_ParCSRMatrixSetNumNonzeros(A);
+    /* Make sure that the first entry in each row is the diagonal one. */
++#if MFEM_HYPRE_VERSION <= 22200
+    if (row_starts == col_starts)
++#else
++   if ((row_starts[0] == col_starts[0]) &&
++       (row_starts[1] == col_starts[1]))
++#endif
+    {
+       hypre_CSRMatrixReorder(hypre_ParCSRMatrixDiag(A));
+    }
+@@ -2310,7 +2384,7 @@ inline void delete_hypre_ParCSRMatrixColMapOffd(hypre_ParCSRMatrix *A)
+ {
+    HYPRE_BigInt  *A_col_map_offd = hypre_ParCSRMatrixColMapOffd(A);
+    int size = hypre_CSRMatrixNumCols(hypre_ParCSRMatrixOffd(A));
+-   Memory<HYPRE_Int>(A_col_map_offd, size, true).Delete();
++   Memory<HYPRE_BigInt>(A_col_map_offd, size, true).Delete();
+ }
+ 
+ void HypreParMatrix::Destroy()
+@@ -2503,11 +2577,14 @@ HypreParMatrix * RAP(const HypreParMatrix *A, const HypreParMatrix *P)
+       // hypre_ParCSRMatrixRAPKT
+    }
+ #else
++#if MFEM_HYPRE_VERSION <= 22200
+    HYPRE_Int P_owns_its_col_starts =
+       hypre_ParCSRMatrixOwnsColStarts((hypre_ParCSRMatrix*)(*P));
++#endif
+ 
+    hypre_BoomerAMGBuildCoarseOperator(*P,*A,*P,&rap);
+ 
++#if MFEM_HYPRE_VERSION <= 22200
+    /* Warning: hypre_BoomerAMGBuildCoarseOperator steals the col_starts
+       from P (even if it does not own them)! */
+    hypre_ParCSRMatrixSetRowStartsOwner(rap,0);
+@@ -2516,6 +2593,7 @@ HypreParMatrix * RAP(const HypreParMatrix *A, const HypreParMatrix *P)
+    {
+       hypre_ParCSRMatrixSetColStartsOwner(*P, 1);
+    }
++#endif
+ #endif
+ 
+    hypre_ParCSRMatrixSetNumNonzeros(rap);
+@@ -2536,13 +2614,16 @@ HypreParMatrix * RAP(const HypreParMatrix * Rt, const HypreParMatrix *A,
+       hypre_ParCSRMatrixDestroy(Q);
+    }
+ #else
++#if MFEM_HYPRE_VERSION <= 22200
+    HYPRE_Int P_owns_its_col_starts =
+       hypre_ParCSRMatrixOwnsColStarts((hypre_ParCSRMatrix*)(*P));
+    HYPRE_Int Rt_owns_its_col_starts =
+       hypre_ParCSRMatrixOwnsColStarts((hypre_ParCSRMatrix*)(*Rt));
++#endif
+ 
+    hypre_BoomerAMGBuildCoarseOperator(*Rt,*A,*P,&rap);
+ 
++#if MFEM_HYPRE_VERSION <= 22200
+    /* Warning: hypre_BoomerAMGBuildCoarseOperator steals the col_starts
+       from Rt and P (even if they do not own them)! */
+    hypre_ParCSRMatrixSetRowStartsOwner(rap,0);
+@@ -2555,6 +2636,7 @@ HypreParMatrix * RAP(const HypreParMatrix * Rt, const HypreParMatrix *A,
+    {
+       hypre_ParCSRMatrixSetColStartsOwner(*Rt, 1);
+    }
++#endif
+ #endif
+ 
+    hypre_ParCSRMatrixSetNumNonzeros(rap);
+@@ -3144,8 +3226,12 @@ void HypreSmoother::SetOperator(const Operator &op)
+       }
+       else
+       {
++#if MFEM_HYPRE_VERSION <= 22200
+          min_eig_est = 0;
+          hypre_ParCSRMaxEigEstimate(*A, poly_scale, &max_eig_est);
++#else
++         hypre_ParCSRMaxEigEstimate(*A, poly_scale, &max_eig_est, &min_eig_est);
++#endif
+       }
+       Z = new HypreParVector(*A);
+    }
+@@ -3159,8 +3245,12 @@ void HypreSmoother::SetOperator(const Operator &op)
+       }
+       else
+       {
++#if MFEM_HYPRE_VERSION <= 22200
+          min_eig_est = 0;
+          hypre_ParCSRMaxEigEstimate(*A, poly_scale, &max_eig_est);
++#else
++         hypre_ParCSRMaxEigEstimate(*A, poly_scale, &max_eig_est, &min_eig_est);
++#endif
+       }
+ 
+       // The Taubin and FIR polynomials are defined on [0, 2]
+@@ -4472,9 +4562,8 @@ void HypreBoomerAMG::SetSystemsOptions(int dim, bool order_bynodes)
+    // HYPRE_BoomerAMGSetDofFunc as in the following code.
+    if (order_bynodes)
+    {
+-      // hypre actually deletes the following pointer in HYPRE_BoomerAMGDestroy,
+-      // so we don't need to track it
+-      HYPRE_Int *mapping = mfem_hypre_CTAlloc_host(HYPRE_Int, height);
++      // Generate DofFunc mapping on the host
++      HYPRE_Int *h_mapping = mfem_hypre_CTAlloc_host(HYPRE_Int, height);
+       int h_nnodes = height / dim; // nodes owned in linear algebra (not fem)
+       MFEM_VERIFY(height % dim == 0, "Ordering does not work as claimed!");
+       int k = 0;
+@@ -4482,9 +4571,24 @@ void HypreBoomerAMG::SetSystemsOptions(int dim, bool order_bynodes)
+       {
+          for (int j = 0; j < h_nnodes; ++j)
+          {
+-            mapping[k++] = i;
++            h_mapping[k++] = i;
+          }
+       }
++
++      // After the addition of hypre_IntArray, mapping is assumed
++      // to be a device pointer. Previously, it was assumed to be
++      // a host pointer.
++#if defined(hypre_IntArrayData) && defined(HYPRE_USING_GPU)
++      HYPRE_Int *mapping = mfem_hypre_CTAlloc(HYPRE_Int, height);
++      hypre_TMemcpy(mapping, h_mapping, HYPRE_Int, height,
++                    HYPRE_MEMORY_DEVICE, HYPRE_MEMORY_HOST);
++      mfem_hypre_TFree_host(h_mapping);
++#else
++      HYPRE_Int *mapping = h_mapping;
++#endif
++
++      // hypre actually deletes the mapping pointer in HYPRE_BoomerAMGDestroy,
++      // so we don't need to track it
+       HYPRE_BoomerAMGSetDofFunc(amg_precond, mapping);
+    }
+ 
+@@ -4529,7 +4633,8 @@ void HypreBoomerAMG::RecomputeRBMs()
+ 
+       rbms.SetSize(nrbms);
+       gf_rbms.SetSize(nrbms);
+-      gf_rbms[0] = rbms_rxy.ParallelAverage();
++      gf_rbms[0] = fespace->NewTrueDofVector();
++      rbms_rxy.GetTrueDofs(*gf_rbms[0]);
+    }
+    else if (dim == 3)
+    {
+@@ -4548,9 +4653,12 @@ void HypreBoomerAMG::RecomputeRBMs()
+ 
+       rbms.SetSize(nrbms);
+       gf_rbms.SetSize(nrbms);
+-      gf_rbms[0] = rbms_rxy.ParallelAverage();
+-      gf_rbms[1] = rbms_ryz.ParallelAverage();
+-      gf_rbms[2] = rbms_rzx.ParallelAverage();
++      gf_rbms[0] = fespace->NewTrueDofVector();
++      gf_rbms[1] = fespace->NewTrueDofVector();
++      gf_rbms[2] = fespace->NewTrueDofVector();
++      rbms_rxy.GetTrueDofs(*gf_rbms[0]);
++      rbms_ryz.GetTrueDofs(*gf_rbms[1]);
++      rbms_rzx.GetTrueDofs(*gf_rbms[2]);
+    }
+    else
+    {
+@@ -4997,11 +5105,11 @@ HypreADS::HypreADS(const HypreParMatrix &A, ParFiniteElementSpace *face_fespace)
+ void HypreADS::Init(ParFiniteElementSpace *face_fespace)
+ {
+    int cycle_type       = 11;
+-   int rlx_type         = 2;
+    int rlx_sweeps       = 1;
+    double rlx_weight    = 1.0;
+    double rlx_omega     = 1.0;
+ #ifndef HYPRE_USING_CUDA
++   int rlx_type         = 2;
+    int amg_coarsen_type = 10;
+    int amg_agg_levels   = 1;
+    int amg_rlx_type     = 8;
+@@ -5009,6 +5117,7 @@ void HypreADS::Init(ParFiniteElementSpace *face_fespace)
+    int amg_interp_type  = 6;
+    int amg_Pmax         = 4;
+ #else
++   int rlx_type         = 1;
+    int amg_coarsen_type = 8;
+    int amg_agg_levels   = 0;
+    int amg_rlx_type     = 18;
+@@ -5592,16 +5701,18 @@ HypreLOBPCG::OperatorMatvec( void *matvec_data,
+ 
+    Operator *Aop = (Operator*)A;
+ 
+-   int width = Aop->Width();
+-
+    hypre_ParVector * xPar = (hypre_ParVector *)x;
+    hypre_ParVector * yPar = (hypre_ParVector *)y;
+ 
+-   Vector xVec(xPar->local_vector->data, width);
+-   Vector yVec(yPar->local_vector->data, width);
++   HypreParVector xVec(xPar);
++   HypreParVector yVec(yPar);
+ 
+    Aop->Mult( xVec, yVec );
+ 
++   // Move data back to hypre's device memory location in case the above Mult
++   // operation moved it to host.
++   yVec.HypreReadWrite();
++
+    return 0;
+ }
+ 
+@@ -5617,19 +5728,20 @@ HypreLOBPCG::PrecondSolve(void *solver,
+                           void *b,
+                           void *x)
+ {
+-   Solver   *PC = (Solver*)solver;
+-   Operator *OP = (Operator*)A;
+-
+-   int width = OP->Width();
++   Solver *PC = (Solver*)solver;
+ 
+    hypre_ParVector * bPar = (hypre_ParVector *)b;
+    hypre_ParVector * xPar = (hypre_ParVector *)x;
+ 
+-   Vector bVec(bPar->local_vector->data, width);
+-   Vector xVec(xPar->local_vector->data, width);
++   HypreParVector bVec(bPar);
++   HypreParVector xVec(xPar);
+ 
+    PC->Mult( bVec, xVec );
+ 
++   // Move data back to hypre's device memory location in case the above Mult
++   // operation moved it to host.
++   xVec.HypreReadWrite();
++
+    return 0;
+ }
+ 
+diff --git a/linalg/hypre_parcsr.cpp b/linalg/hypre_parcsr.cpp
+index 5f1f50f3f..1c1ba1640 100644
+--- a/linalg/hypre_parcsr.cpp
++++ b/linalg/hypre_parcsr.cpp
+@@ -508,8 +508,10 @@ void hypre_ParCSRMatrixEliminateAAe(hypre_ParCSRMatrix *A,
+                                   hypre_ParCSRMatrixColStarts(A),
+                                   0, 0, 0);
+ 
++#if MFEM_HYPRE_VERSION <= 22200
+    hypre_ParCSRMatrixSetRowStartsOwner(*Ae, 0);
+    hypre_ParCSRMatrixSetColStartsOwner(*Ae, 0);
++#endif
+ 
+    hypre_CSRMatrix *Ae_diag = hypre_ParCSRMatrixDiag(*Ae);
+    hypre_CSRMatrix *Ae_offd = hypre_ParCSRMatrixOffd(*Ae);
+@@ -1002,10 +1004,17 @@ void hypre_ParCSRMatrixSplit(hypre_ParCSRMatrix *A,
+ 
+       hypre_ParCSRMatrixOwnsData(blocks[i]) = 1;
+ 
++#if MFEM_HYPRE_VERSION <= 22200
+       /* only the first block will own the row/col_starts */
+       hypre_ParCSRMatrixOwnsRowStarts(blocks[i]) = !i;
+       hypre_ParCSRMatrixOwnsColStarts(blocks[i]) = !i;
++#endif
+    }
++
++#if MFEM_HYPRE_VERSION > 22200
++   mfem_hypre_TFree_host(row_starts);
++   mfem_hypre_TFree_host(col_starts);
++#endif
+ }
+ 
+ /* Based on hypre_CSRMatrixMatvec in hypre's csr_matvec.c */
+@@ -1916,9 +1925,12 @@ hypre_ParCSRMatrixAdd(hypre_ParCSRMatrix *A,
+ 
+    /* C owns diag, offd, and cmap. */
+    hypre_ParCSRMatrixSetDataOwner(C, 1);
++
++#if MFEM_HYPRE_VERSION <= 22200
+    /* C does not own row and column starts. */
+    hypre_ParCSRMatrixSetRowStartsOwner(C, 0);
+    hypre_ParCSRMatrixSetColStartsOwner(C, 0);
++#endif
+ 
+    return C;
+ }

--- a/scripts/spack/packages/mfem/mfem-4.5.patch
+++ b/scripts/spack/packages/mfem/mfem-4.5.patch
@@ -1,0 +1,36 @@
+diff --git a/miniapps/common/makefile b/miniapps/common/makefile
+index 12506bf8b..681d9e83c 100644
+--- a/miniapps/common/makefile
++++ b/miniapps/common/makefile
+@@ -31,10 +31,12 @@ MFEM_LIB_FILE = mfem_is_not_built
+ ifneq (clean,$(MAKECMDGOALS))
+    -include $(CONFIG_MK)
+ 
+-   ifeq ($(MFEM_USE_CUDA)$(MFEM_USE_HIP),NONO)
+-      XLINKER = $(CXX_XLINKER)
+-   else ifeq ($(MFEM_USE_CUDA),YES)
++   ifeq ($(MFEM_USE_CUDA),YES)
+       XLINKER = $(CUDA_XLINKER)
++   else ifeq ($(MFEM_USE_HIP),YES)
++      XLINKER = $(HIP_XLINKER)
++   else
++      XLINKER = $(CXX_XLINKER)
+    endif
+ 
+    BUILD_REAL_DIR = $(realpath .)
+diff --git a/miniapps/hooke/makefile b/miniapps/hooke/makefile
+index 7687a7eb3..6c5c2b24d 100644
+--- a/miniapps/hooke/makefile
++++ b/miniapps/hooke/makefile
+@@ -29,6 +29,11 @@ HOOKE_OBJ = $(HOOKE_SRC:.cpp=.o)
+ 
+ SEQ_MINIAPPS =
+ PAR_MINIAPPS = hooke
++# The hooke miniapp crashes the AMD HIP compiler, so for now we disable it
++# when HIP is enabled:
++ifeq ($(MFEM_USE_HIP),YES)
++   PAR_MINIAPPS =
++endif
+ ifeq ($(MFEM_USE_MPI),NO)
+    MINIAPPS = $(SEQ_MINIAPPS)
+ else

--- a/scripts/spack/packages/mfem/mfem_ppc_build.patch
+++ b/scripts/spack/packages/mfem/mfem_ppc_build.patch
@@ -1,0 +1,10 @@
+--- mfem/miniapps/performance/makefile	2017-06-07 13:51:29.366596901 -0700
++++ mfem/miniapps/performance/makefile.new	2017-06-07 13:51:57.087104178 -0700
+@@ -26,7 +26,6 @@
+ # Compiler specific optimizations.
+ # For best performance, GCC 5 (or newer) is recommended.
+ ifneq (,$(findstring $(MFEM_CXX),g++ mpicxx))
+-   MFEM_CXXFLAGS += -march=native
+    # MFEM_CXXFLAGS += -std=c++03
+    MFEM_CXXFLAGS += -std=c++11
+    MFEM_CXXFLAGS += -pedantic -Wall

--- a/scripts/spack/packages/mfem/package.py
+++ b/scripts/spack/packages/mfem/package.py
@@ -655,7 +655,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             all_hypre_libs = hypre.libs + hypre["lapack"].libs + hypre["blas"].libs
             hypre_gpu_libs = ""
             if "+cuda" in hypre:
-                hypre_gpu_libs = " -lcusparse -lcurand"
+                hypre_gpu_libs = " -lcusparse -lcurand -lcublas"
             elif "+rocm" in hypre:
                 hypre_rocm_libs = LibraryList([])
                 if "^rocsparse" in hypre:

--- a/scripts/spack/repo.yaml
+++ b/scripts/spack/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: 'llnl.axom'


### PR DESCRIPTION
# Fix MFEM package to work with MFEM 4.5 which has a new cublas dependency.  Also add ability to use spack packages as a spack repo.

I also added some missing .patch files present in spack github but not in this repo.

This PR implements <will insert issue here>.