### PR TITLE
Improves user control of `PointInCell` query

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,6 +47,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Reduce size of `ArrayView::subspan` to prevent accessing invalid memory.
 - Updates [conduit dependency to v0.8.6](https://github.com/LLNL/conduit/compare/v0.8.3...v0.8.6)
 - Adds `vcpkg` port for `lua` as optional dependency on Windows
+- Adds additional parameters to quest's `PointInCell` query to control the Newton solve
+  from physical to reference space for a given element
 
 ###  Fixed
 - Fixed issues with CUDA build in CMake versions 3.14.5 and above. Now require CMake 3.18+

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -315,10 +315,13 @@ public:
   /// \brief Set the shape
   AXOM_HOST_DEVICE void setShape(const StackArray<IndexType, DIM>& shape_)
   {
+#ifndef NDEBUG
     for(auto s : shape_)
     {
       assert(s >= 0);
     }
+#endif
+
     m_shape = shape_;
     updateStrides();
   }

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -621,6 +621,7 @@ public:
                              mpi_traits<double>::type,
                              m_mpiComm);
     SLIC_ASSERT(errf == MPI_SUCCESS);
+    AXOM_UNUSED_VAR(errf);
 
     all_aabbs.clear();
     all_aabbs.reserve(m_nranks);

--- a/src/axom/quest/PointInCell.hpp
+++ b/src/axom/quest/PointInCell.hpp
@@ -281,6 +281,55 @@ public:
    */
   void setPrintLevel(int level) { m_meshWrapper.setPrintLevel(level); }
 
+  /*!
+   * \brief Sets the initial guess type for the element-based point in cell query
+   *
+   * \param [in] guessType The guess type
+   *  
+   *  For the mfem mesh wrapper, the valid options are: 
+   *  - 0: Use the element center in reference space
+   *  - 1: Use the closest physical node on a grid of points in physical space
+   *  - 2: Use the closest reference node on a grid of points in reference space
+   * 
+   *  The grid size is controlled by setInitialGridOrder()
+   */
+  void setInitialGuessType(int guessType)
+  {
+    m_meshWrapper.setInitialGuessType(guessType);
+  }
+
+  /*!
+   * \brief Sets the grid size for the initial guess in the element-based point in cell query
+   *
+   * \param [in] order The order for the grid size 
+   *  
+   *  For the mfem mesh wrapper, the number of points in each spatial direction 
+   *  is given by `max(trans_order+order,0)+1`, where trans_order is the order 
+   *  of the current element.
+   * 
+   *  \sa setInitialGuessType
+   */
+  void setInitialGridOrder(int order)
+  {
+    m_meshWrapper.setInitialGridOrder(order);
+  }
+
+  /*!
+   * \brief Sets the solution strategy for the element-based point in cell query
+   *
+   * \param [in] type The strategy type
+   *  
+   *  For the mfem mesh wrapper, the valid options all use a Newton solve
+   *  but differ in their handling of iterates that leave the reference element
+   *  - 0: Allow the iterates to leave the reference element
+   *  - 1: Project external iterates to the reference space boundary along their current line
+   *  - 2: Project external iterates to the closest reference space boundary location
+   */
+  void setSolverProjectionType(int type)
+  {
+    m_meshWrapper.setSolverProjectionType(type);
+  }
+
 private:
   MeshWrapperType m_meshWrapper;
 

--- a/src/axom/quest/PointInCell.hpp
+++ b/src/axom/quest/PointInCell.hpp
@@ -265,6 +265,22 @@ public:
   /*! Returns the dimension of the mesh */
   int meshDimension() const { return m_meshWrapper.meshDimension(); }
 
+  /*!
+   * \brief Sets the print verbosity level for the point in cell query
+   *
+   * \param [in] level The verbosity level (increases with level)
+   *  
+   * This is useful for debugging the point in cell query
+   * 
+   *  For the mfem mesh wrapper, the valid options are: 
+   *  - -1: never print (default)
+   *  -  0: print only errors
+   *  -  1: print the first and last iterations
+   *  -  2: print every iteration
+   *  -  3: print every iteration including point coordinates.
+   */
+  void setPrintLevel(int level) { m_meshWrapper.setPrintLevel(level); }
+
 private:
   MeshWrapperType m_meshWrapper;
 

--- a/src/axom/quest/detail/PointInCellMeshWrapper_mfem.hpp
+++ b/src/axom/quest/detail/PointInCellMeshWrapper_mfem.hpp
@@ -188,6 +188,22 @@ public:
   mfem::Mesh* getMesh() const { return m_mesh; }
 
   /*!
+   * \brief Sets the print verbosity level for the query
+   *
+   * \param [in] level The verbosity level (increases with level)
+   *  
+   * This is useful for debugging the point in cell query
+   * 
+   *  The valid options are: 
+   *  - -1: never print (default)
+   *  -  0: print only errors
+   *  -  1: print the first and last iterations
+   *  -  2: print every iteration
+   *  -  3: print every iteration including point coordinates.
+   */
+  void setPrintLevel(int level) { m_printLevel = level; }
+
+  /*!
    * Computes the bounding boxes of all mesh elements
    *
    * \param [in] bboxScaleFactor A scaling factor to expand the bounding boxes
@@ -264,6 +280,9 @@ public:
 
     invTrans.SetSolverType(InvTransform::Newton);
     invTrans.SetInitialGuessType(InvTransform::ClosestPhysNode);
+    invTrans.SetPrintLevel(m_printLevel);
+
+    SLIC_DEBUG_IF(m_printLevel >= 0, "Checking element " << eltIdx);
 
     // Status codes: {0 -> successful; 1 -> outside elt; 2-> did not converge}
     int err = invTrans.Transform(ptSpace, ipRef);
@@ -432,6 +451,9 @@ private:
 private:
   mfem::Mesh* m_mesh;
   bool m_isHighOrder;
+
+  // Parameters for inverse transformation
+  int m_printLevel {-1};
 };
 
 }  // end namespace detail

--- a/src/axom/quest/examples/point_in_cell_benchmark.cpp
+++ b/src/axom/quest/examples/point_in_cell_benchmark.cpp
@@ -46,9 +46,6 @@ const std::map<std::string, ExecPolicy> validExecPolicies
 };
 /* clang-format on */
 
-void initialize_logger();
-void finalize_logger();
-
 template <int NDIMS>
 primal::Point<double, NDIMS> get_rand_pt(
   const primal::BoundingBox<double, NDIMS>& bbox)
@@ -172,8 +169,7 @@ struct Arguments
 
 int main(int argc, char** argv)
 {
-  // STEP 1: initialize the logger
-  initialize_logger();
+  slic::SimpleLogger logger(slic::message::Info);
 
   // STEP 2: parse command line arguments
   Arguments args;
@@ -187,7 +183,6 @@ int main(int argc, char** argv)
   {
     int retval = -1;
     retval = app.exit(e);
-    finalize_logger();
     return retval;
   }
 #ifdef AXOM_USE_GPU
@@ -239,31 +234,6 @@ int main(int argc, char** argv)
     SLIC_ERROR("Unsupported execution space.");
     return 1;
   }
-  finalize_logger();
+
   return 0;
-}
-
-//------------------------------------------------------------------------------
-void initialize_logger()
-{
-  // initialize logger
-  slic::initialize();
-  slic::setLoggingMsgLevel(slic::message::Info);
-
-  // setup the logstreams
-  std::string fmt = "";
-  slic::LogStream* logStream = nullptr;
-
-  fmt = "[<LEVEL>]: <MESSAGE>\n";
-  logStream = new slic::GenericOutputStream(&std::cout, fmt);
-
-  // register stream objects with the logger
-  slic::addStreamToAllMsgLevels(logStream);
-}
-
-//------------------------------------------------------------------------------
-void finalize_logger()
-{
-  slic::flushStreams();
-  slic::finalize();
 }

--- a/src/axom/quest/examples/point_in_cell_benchmark.cpp
+++ b/src/axom/quest/examples/point_in_cell_benchmark.cpp
@@ -77,7 +77,7 @@ void benchmark_point_in_cell(mfem::Mesh& mesh, int npts, int nbins)
     meshBb.addPoint(PointType(meshMax.GetData()));
   }
 
-  PointType* pts = axom::allocate<PointType>(npts);
+  axom::Array<PointType> pts(npts, npts, axom::getDefaultAllocatorID());
 
   utilities::Timer timeInitRandPts(true);
   // Generate random points
@@ -96,17 +96,15 @@ void benchmark_point_in_cell(mfem::Mesh& mesh, int npts, int nbins)
   SLIC_INFO(axom::fmt::format("Initialized point-in-cell query in {} s.",
                               timeInitQuery.elapsed()));
 
-  IndexType* outCellIds = axom::allocate<IndexType>(npts);
+  axom::Array<IndexType> outCellIds(npts, npts, axom::getDefaultAllocatorID());
   // Run query
   utilities::Timer timeRunQuery(true);
-  query.locatePoints(axom::ArrayView<const PointType>(pts, npts), outCellIds);
+  query.locatePoints(pts.view(), outCellIds.data());
   double time = timeRunQuery.elapsed();
   SLIC_INFO(axom::fmt::format("Ran query on {} points in {} s -- rate: {} q/s",
                               npts,
                               time,
                               npts / time));
-
-  axom::deallocate(pts);
 }
 
 template <typename ExecSpace>

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -1118,9 +1118,11 @@ void MFEMSidreDataCollection::Save(const std::string& filename,
       {
         View* num_domains =
           m_bp_index_grp->getView("state/number_of_domains")->setScalar(num_procs);
+
         SLIC_ASSERT_MSG(num_domains,
                         "Failed to reset View 'state/number_of_domains' "
                         "in blueprint index to correct number of domains.");
+        AXOM_UNUSED_VAR(num_domains);
       }
       else
       {

--- a/src/axom/sidre/examples/spio/IO_SCR_Checkpoint.cpp
+++ b/src/axom/sidre/examples/spio/IO_SCR_Checkpoint.cpp
@@ -294,6 +294,7 @@ int main(int argc, char* argv[])
   // run the test from spio_scr.hpp
   int result = RUN_ALL_TESTS();
   SLIC_ASSERT(result == 0);
+  AXOM_UNUSED_VAR(result);
 
   int my_rank, num_ranks;
   MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
@@ -422,6 +423,7 @@ int main(int argc, char* argv[])
   bool success = simpleTestCompare(ds_output, ds_input);
 
   SLIC_ASSERT(success);
+  AXOM_UNUSED_VAR(success);
 
   MPI_Finalize();
 


### PR DESCRIPTION
# Summary

- This PR is a feature
- It exposes some additional parameters to control the initial guess and solver projection strategy for the per-element `InverseElementTransformation` within quest's `PointInCell` query
- It also exposes those parameters in the `point_in_cell_benchmark` example, and refactors that example
- Resolves #1038 
- Minor: It also fixes some warnings in Release builds

#### TODO
- [x] Add table showing improvements on user-provided mesh from #1038


#### Performance

Using the new parameters exposed in the point_in_cell benchmark example, I ran some experiments on the 336 element cubic mesh from #1038, varying the "projection type" (i.e. what to do when the query leaves the element's reference space), as well as its "guess type" and "guess order", which relate to initializing the query.

Each result was for 1,000,000 query points and is the average of three runs. The goal was to locate as many points as possible (i.e. minimize "missed" points) and to roughly estimate the expected runtime.
I used a release build of axom on LLNL's toss3 cluster using the clang@10 compiler.
Note that inverse queries are all independent, so could potentially be parallelized, but are currently run sequentially.

| project-type | guess-type | guess-order  |  missed  | query time (s)  |
|--------------|------------|---------------|----------|----------------|
| boundary     | center        | -                   | 3,322      |  4.48 s              |
| none            | center        | -                   | 15,355     |  4.83 s              |
| segment      | center        | -                    | 23,315     |  3.13 s              |
| boundary     | phys          | -1                   | 142        |  5.44 s              |
| boundary     | phys          | 0                   | 116         |  6.15 s              |
| boundary     | phys          | 1                   | 27           |  7.13 s              |
| **boundary**     | **phys**          | **2**                   | **4**             |  **8.39 s**              |
| boundary     | phys          | 3                   | 2             |  9.54 s              |
| none            | phys          | -1                 | 591         |  5.36 s              |
| none            | phys          | 0                   | 331         |  6.05 s              |
| none            | phys          | 1                   | 168          |  7.02 s              |
| none            | phys          | 2                   | 52            |  8.25 s              |
| none            | phys          | 3                   | 10            |  9.53 s              |
| segment       | phys          | -1                 | 1,505       |  4.07 s              |
| segment       | phys          | 0                   | 809         |  4.77 s              |
| segment       | phys          | 1                   | 475         |  5.71 s              |
| segment       | phys          | 2                   | 240         |  6.97 s              |
| segment       | phys          | 3                   | 159         |  8.11 s              |
| boundary     | ref              | -1                  | 36         |  8.92 s              |
| boundary     | ref              | 0                   | 7           |  12.99 s              |
| boundary     | ref              | 1                   | 5           |  17.36 s              |
| boundary     | ref              | 2                   | 1           |  23.14 s              |
| boundary     | ref              | 3                   | 4           |  29.73 s              |
| none            | ref              | -1                  | 191         |  8.95 s              |
| none            | ref              | 0                   | 38           |  12.77 s              |
| none            | ref              | 1                   | 16           |  17.30 s              |
| none            | ref              | 2                   | 9             |  23.12 s              |
| none            | ref              | 3                   | 4            |  29.70 s              |
| segment      | ref              | -1                  | 1,574         |  7.56 s              |
| segment      | ref              | 0                   | 735           |  11.41 s              |
| segment      | ref              | 1                   | 431           |  16.01 s              |
| segment      | ref              | 2                   | 267           |  21.80 s              |
| segment      | ref              | 3                   | 171           |  28.47 s              |

From the above, the best compromise appears to be to use `boundary` projection when the query leaves reference space, and to initialize the query using a grid in physical space with a guess order of 2.

An alternate strategy might be to initialize the query using the center point, and rerun the query on the points that cannot be found using a more expensive initialization strategy.
