### PR TITLE
Import existing volume fractions into sampling shaper

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -54,6 +54,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   instance.
 - Multimat: adds an overload of `MultiMat::setCellMatRel()` that supports setting a
   multi-material relation in a compressed sparse-row (CSR) representation.
+- Quest: Adds ability to import volume fractions into `SamplingShaper` before processing `Klee` input
 
 ### Changed
 - Updates blt submodule to HEAD of develop on 24Jan2023

--- a/src/axom/quest/SamplingShaper.hpp
+++ b/src/axom/quest/SamplingShaper.hpp
@@ -488,8 +488,15 @@ public:
       const auto& name = entry.first;
       auto* gf = entry.second;
 
+      SLIC_INFO(
+        axom::fmt::format("Importing volume fraction field for '{}' material",
+                          name));
+
       if(gf == nullptr)
       {
+        SLIC_WARNING(axom::fmt::format(
+          "Skipping missing volume fraction field for material '{}'",
+          name));
         continue;
       }
 

--- a/src/axom/quest/SamplingShaper.hpp
+++ b/src/axom/quest/SamplingShaper.hpp
@@ -464,7 +464,7 @@ public:
    * The imported grid functions are interpolated at quadrature points and registered
    * with the supplied names as material-based quadrature fields
    */
-  void projectInitialVolumeFractions(
+  void importInitialVolumeFractions(
     const std::map<std::string, mfem::GridFunction*> initialGridFunctions)
   {
     internal::ScopedLogLevelChanger logLevelChanger(

--- a/src/axom/quest/SamplingShaper.hpp
+++ b/src/axom/quest/SamplingShaper.hpp
@@ -465,7 +465,7 @@ public:
    * with the supplied names as material-based quadrature fields
    */
   void importInitialVolumeFractions(
-    const std::map<std::string, mfem::GridFunction*> initialGridFunctions)
+    const std::map<std::string, mfem::GridFunction*>& initialGridFunctions)
   {
     internal::ScopedLogLevelChanger logLevelChanger(
       this->isVerbose() ? slic::message::Debug : slic::message::Warning);

--- a/src/axom/quest/SamplingShaper.hpp
+++ b/src/axom/quest/SamplingShaper.hpp
@@ -296,12 +296,12 @@ public:
   void prepareShapeQuery(klee::Dimensions shapeDimension,
                          const klee::Shape& shape) override
   {
-    const auto& shapeName = shape.getName();
+    internal::ScopedLogLevelChanger logLevelChanger(
+      this->isVerbose() ? slic::message::Debug : slic::message::Warning);
 
     SLIC_INFO(axom::fmt::format("{:-^80}", " Generating the octree "));
 
-    internal::ScopedLogLevelChanger logLevelChanger(
-      this->isVerbose() ? slic::message::Debug : slic::message::Warning);
+    const auto& shapeName = shape.getName();
 
     switch(shapeDimension)
     {
@@ -347,12 +347,12 @@ public:
 
   void runShapeQuery(const klee::Shape& shape) override
   {
+    internal::ScopedLogLevelChanger logLevelChanger(
+      this->isVerbose() ? slic::message::Debug : slic::message::Warning);
+
     SLIC_INFO(axom::fmt::format(
       "{:-^80}",
       axom::fmt::format(" Querying the octree for shape '{}'", shape.getName())));
-
-    internal::ScopedLogLevelChanger logLevelChanger(
-      this->isVerbose() ? slic::message::Debug : slic::message::Warning);
 
     switch(getShapeDimension())
     {
@@ -369,14 +369,14 @@ public:
   {
     using axom::utilities::string::rsplitN;
 
+    internal::ScopedLogLevelChanger logLevelChanger(
+      this->isVerbose() ? slic::message::Debug : slic::message::Warning);
+
     const auto& shapeName = shape.getName();
     SLIC_INFO(axom::fmt::format(
       "{:-^80}",
       axom::fmt::format("Applying replacement rules over for shape '{}'",
                         shapeName)));
-
-    internal::ScopedLogLevelChanger logLevelChanger(
-      this->isVerbose() ? slic::message::Debug : slic::message::Warning);
 
     // Get inout qfunc for this shape
     auto* shapeQFunc =

--- a/src/axom/quest/Shaper.cpp
+++ b/src/axom/quest/Shaper.cpp
@@ -159,6 +159,9 @@ void Shaper::loadShapeInternal(const klee::Shape& shape,
 {
   using axom::utilities::string::endsWith;
 
+  internal::ScopedLogLevelChanger logLevelChanger(
+    this->isVerbose() ? slic::message::Debug : slic::message::Warning);
+
   SLIC_INFO(axom::fmt::format(
     "{:-^80}",
     axom::fmt::format(" Loading shape '{}' ", shape.getName())));

--- a/src/axom/quest/detail/shaping/shaping_helpers.cpp
+++ b/src/axom/quest/detail/shaping/shaping_helpers.cpp
@@ -188,7 +188,7 @@ void computeVolumeFractions(const std::string& matField,
     mfem::DomainLFIntegrator rhs(qfc);
 
     const auto& ir =
-      inout->GetSpace()->GetIntRule(0);  // assume all elts are the same
+      inout->GetSpace()->GetIntRule(0);  // assume all elements are the same
     rhs.SetIntRule(&ir);
 
     mfem::DenseMatrix m;

--- a/src/axom/quest/detail/shaping/shaping_helpers.cpp
+++ b/src/axom/quest/detail/shaping/shaping_helpers.cpp
@@ -127,10 +127,7 @@ void generatePositionsQFunction(mfem::Mesh* mesh,
   inoutQFuncs.Register("positions", pos_coef, true);
 }
 
-/**
- * Compute volume fractions function for shape on a grid of resolution \a gridRes
- * in region defined by bounding box \a queryBounds
- */
+/// Generate a volume fraction from a quadrature field for \a matField using FCT
 void computeVolumeFractions(const std::string& matField,
                             mfem::DataCollection* dc,
                             QFunctionCollection& inoutQFuncs,
@@ -163,24 +160,35 @@ void computeVolumeFractions(const std::string& matField,
                               dim,
                               NE));
 
-  // Project QField onto volume fractions field
+  // Access or create a registered volume fraction grid function from the data collection
+  mfem::FiniteElementSpace* fes = nullptr;
+  mfem::GridFunction* volFrac = nullptr;
+  if(dc->HasField(volFracName))
+  {
+    volFrac = dc->GetField(volFracName);
+    fes = volFrac->FESpace();
+  }
+  else
+  {
+    const auto basis = mfem::BasisType::Positive;
+    auto* fec = new mfem::L2_FECollection(outputOrder, dim, basis);
+    fes = new mfem::FiniteElementSpace(mesh, fec);
+    volFrac = new mfem::GridFunction(fes);
+    volFrac->MakeOwner(fec);
 
-  mfem::L2_FECollection* fec =
-    new mfem::L2_FECollection(outputOrder, dim, mfem::BasisType::Positive);
-  mfem::FiniteElementSpace* fes = new mfem::FiniteElementSpace(mesh, fec);
-  mfem::GridFunction* volFrac = new mfem::GridFunction(fes);
-  volFrac->MakeOwner(fec);
-  dc->RegisterField(volFracName, volFrac);
+    dc->RegisterField(volFracName, volFrac);
+  }
 
+  // Project QField onto volume fractions field using flux corrected transport (FCT)
+  // to keep the range of values between 0 and 1
   axom::utilities::Timer timer(true);
   {
-    mfem::MassIntegrator mass_integrator;  // use the default for exact integration; lower for approximate
-
+    mfem::MassIntegrator mass_integrator;
     mfem::QuadratureFunctionCoefficient qfc(*inout);
     mfem::DomainLFIntegrator rhs(qfc);
 
-    // assume all elts are the same
-    const auto& ir = inout->GetSpace()->GetIntRule(0);
+    const auto& ir =
+      inout->GetSpace()->GetIntRule(0);  // assume all elts are the same
     rhs.SetIntRule(&ir);
 
     mfem::DenseMatrix m;
@@ -200,9 +208,6 @@ void computeVolumeFractions(const std::string& matField,
       rhs.AssembleRHSElementVect(*el, *T, b);
       mInv.Factor(m);
 
-      // Use FCT limiting -- similar to Remap
-      // Limit the function to be between 0 and 1
-      // Q: Is there a better way limiting algorithm for this?
       if(one.Size() != b.Size())
       {
         one.SetSize(b.Size());

--- a/src/axom/quest/detail/shaping/shaping_helpers.hpp
+++ b/src/axom/quest/detail/shaping/shaping_helpers.hpp
@@ -55,8 +55,16 @@ void generatePositionsQFunction(mfem::Mesh* mesh,
                                 int sampleRes);
 
 /**
- * Compute volume fractions function for shape on a grid of resolution \a gridRes
- * in region defined by bounding box \a queryBounds
+ * \brief Compute volume fractions for a given material using its associated quadrature function
+ *
+ * \param [in] matField The name of the material
+ * \param [in] dc The DataCollection containing the specified material
+ * \param [in] inoutQFuncs A collection of quadrature functions containing the quadrature
+ * values associated with the specified material
+ * \param [in] outputOrder The order the grid function that we're generating
+ *
+ * The generated grid function will be prefixed by `vol_frac_`
+ * 
  */
 void computeVolumeFractions(const std::string& matField,
                             mfem::DataCollection* dc,

--- a/src/axom/quest/examples/shaping_driver.cpp
+++ b/src/axom/quest/examples/shaping_driver.cpp
@@ -179,7 +179,7 @@ public:
                              "Options related to sampling-based queries");
 
       sampling_options->add_option("-o,--order", outputOrder)
-        ->description("order of the output grid function")
+        ->description("Order of the output grid function")
         ->capture_default_str()
         ->check(axom::CLI::NonNegativeNumber);
 
@@ -534,8 +534,8 @@ int main(int argc, char** argv)
       initial_grid_functions[material] = shapingDC.GetField(name);
     }
 
-    // Project volume fractions to data at quadrature points
-    samplingShaper->projectInitialVolumeFractions(initial_grid_functions);
+    // Project provided volume fraction grid functions as quadrature point data
+    samplingShaper->importInitialVolumeFractions(initial_grid_functions);
   }
 
   //---------------------------------------------------------------------------

--- a/src/thirdparty/tests/umpire_smoke.cpp
+++ b/src/thirdparty/tests/umpire_smoke.cpp
@@ -8,7 +8,9 @@
 #include "umpire/Allocator.hpp"
 #include "umpire/ResourceManager.hpp"
 
-#include "gtest/gtest.h"  // for gtest
+#include "gtest/gtest.h"
+
+#include <iostream>
 
 //------------------------------------------------------------------------------
 // UNIT TESTS
@@ -26,6 +28,11 @@ TEST(umpire_smoke, check_version)
     EXPECT_TRUE(UMPIRE_VERSION_MINOR >= 0);
   }
   EXPECT_TRUE(UMPIRE_VERSION_PATCH >= 0);
+
+  std::cout << "Umpire version: "           //
+            << UMPIRE_VERSION_MAJOR << "."  //
+            << UMPIRE_VERSION_MINOR << "."  //
+            << UMPIRE_VERSION_PATCH << std::endl;
 }
 
 //------------------------------------------------------------------------------
@@ -55,6 +62,27 @@ TEST(umpire_smoke, basic_use)
 
   allocator.deallocate(data);
   data = nullptr;
+}
+
+TEST(umpire_smoke, available_allocators)
+{
+  auto& rm = umpire::ResourceManager::getInstance();
+
+  std::cout << "Available Umpire allocators: \n";
+  for(const auto& name : rm.getAllocatorNames())
+  {
+    auto alloc = rm.getAllocator(name);
+    std::cout << "  {name: " << alloc.getName()             //
+              << ", id: " << alloc.getId()                  //
+              << ", strategy: " << alloc.getStrategyName()  //
+    // umpire@2022.10 introduced a function to convert a Platform to a string
+#if(UMPIRE_VERSION_MAJOR > 2022) || \
+  (UMPIRE_VERSION_MAJOR == 2022 && UMPIRE_VERSION_MINOR > 3)
+              << ", platform: "
+              << umpire::platform_to_string(alloc.getPlatform())  //
+#endif
+              << "}\n";
+  }
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

- This PR is a feature
- It enables importing existing volume fractions into quest's sample-based shaping query
- The klee-based shapes are then painted on top of these.
- Resolves #1040
- Adds a `--background-material` command line argument to the shaping example to exercise this capability
- Misc: Also reduces default verbosity of shaping query
- Misc: umpire smoke test now prints out version and available allocators


#### TODO:

- [x] Update `RELEASE-NOTES`


#### Examples:

* The default run of the ["circles" problem](https://github.com/LLNL/axom_data/blob/main/shaping/circles.yaml) has two materials defined by nested circles/spheres: `steel` and `void`:  
`> ./examples/quest_shaping_driver_ex -m box_2d.root -i ../data/shaping/circles.yaml `
<img width="711" alt="shaping_steel_void" src="https://user-images.githubusercontent.com/5626552/229920334-4e93d250-3f7b-48c4-8a47-dfb6bd921bee.PNG">
("steel" on left; "void" on right)

* If we set the background material to `"background"`, we get a third material
`> ./examples/quest_shaping_driver_ex -m box_2d.root -i ../data/shaping/circles.yaml --background-material background`
<img width="1066" alt="shaping_background_steel_void" src="https://user-images.githubusercontent.com/5626552/229921929-ab65d9a5-127d-45f1-8b35-ddadfcadbd4f.PNG">
("background" on left; "steel" in center; "void" on right)

* We can also use an existing material, such as `"void"` or `"steel"` as the background material:

`> ./examples/quest_shaping_driver_ex -m box_2d.root -i ../data/shaping/circles.yaml --background-material void`
<img width="701" alt="shaping_void_steel_void" src="https://user-images.githubusercontent.com/5626552/229922408-0eb40026-a702-4ed1-9e50-ffeab40e7927.PNG">
("steel" on left; "void" on right)

`> ./examples/quest_shaping_driver_ex -m box_2d.root -i ../data/shaping/circles.yaml --background-material steel`
<img width="706" alt="shaping_steel_steel_void" src="https://user-images.githubusercontent.com/5626552/229922489-26c96725-7b02-4f88-9f09-9ca098d3a091.PNG">
("steel" on left; "void" on right)

