### PR TITLE
Deprecate axom integer types

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -32,6 +32,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Adds `const_iterator` support to `slam::BivariateMap` and `slam::SubMap`
 
 ### Changed
+- Integer types in `src/axom/core/Types.hpp` are deprecated because c++-11 supports their equivalents.
 - `IntersectionShaper` now implements material replacement rules.
 - `axom::Array` move constructors are now `noexcept`.
 - Exported CMake targets, `cli11`, `fmt`, `sol`, and `sparsehash`, have been prefixed with `axom::`

--- a/src/axom/CMakeLists.txt
+++ b/src/axom/CMakeLists.txt
@@ -106,3 +106,25 @@ if(WIN32)
             TARGET_DEFINITIONS "axom_EXPORTS")
     endforeach()
 endif()
+
+
+#------------------------------------------------------------------------------
+# With C++11, some Axom types in src/axom/core/Types.hpp are obsolete.
+# They will be removed in steps, as the AXOM_DEPRECATED_TYPES variable
+# defaults to WARN, then ERROR, then eventually removed.
+#------------------------------------------------------------------------------
+if (NOT AXOM_DEPRECATED_TYPES)
+  set( AXOM_DEPRECATED_TYPES "WARN" )
+endif()
+message(STATUS "AXOM_DEPRECATED_TYPES: " ${AXOM_DEPRECATED_TYPES}  ".  (Can be WARN, ALLOW or ERROR.)")
+if (NOT ${AXOM_DEPRECATED_TYPES} MATCHES "^(WARN|ERROR|ALLOW)$")
+  message(FATAL_ERROR "AXOM_DEPRECATED_TYPES (" ${AXOM_DEPRECATED_TYPES} ") must be WARN, ERROR or ALLOW")
+endif()
+
+if ("${AXOM_DEPRECATED_TYPES}" STREQUAL "WARN")
+  set(AXOM_DEPRECATED_TYPES_N 1 CACHE STRING "Allow using deprecated Axom integer types, with a warning." FORCE)
+elseif("${AXOM_DEPRECATED_TYPES}" STREQUAL "ALLOW")
+  set(AXOM_DEPRECATED_TYPES_N 2 CACHE STRING "Allow using deprecated Axom integer types, without warning." FORCE)
+else()
+  set(AXOM_DEPRECATED_TYPES_N -1 CACHE STRING "Do not allow using deprecated Axom integer types." FORCE)
+endif()

--- a/src/axom/config.hpp.in
+++ b/src/axom/config.hpp.in
@@ -115,6 +115,15 @@
 
 
 /*
+ * For gradual removal of types that have been deprecated in favor of
+ * c++-11 types.  Value can be 1 to allow with compiler warnings, 2 to
+ * allow silently, and -1 to disallow.  Corresponds to cmake variable
+ * AXOM_DEPRECATED_TYPES values of WARN, ALLOW and ERROR.
+ */
+#cmakedefine AXOM_DEPRECATED_TYPES_N @AXOM_DEPRECATED_TYPES_N@
+
+
+/*
  * Compiler defines to configure the built-in fmt library
  * Redefines AXOM_FMT_DEPRECATED to workaround nvcc compiler error
  */

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -1104,7 +1104,7 @@ struct ArrayOpsBase<T, true>
   {
     // Similar to fill(), except we can allocate stack memory and placement-new
     // the object with a move constructor.
-    alignas(T) axom::uint8 host_buf[sizeof(T)];
+    alignas(T) std::uint8_t host_buf[sizeof(T)];
     T* host_obj = ::new(&host_buf) T(std::forward<Args>(args)...);
     axom::copy(array + i, host_obj, sizeof(T));
   }

--- a/src/axom/core/Types.cpp
+++ b/src/axom/core/Types.cpp
@@ -16,16 +16,16 @@ const MPI_Datatype mpi_traits<AxomType>::type = MPI_DATATYPE_NULL;
 // Initialization of mpi_traits specializations
 const MPI_Datatype mpi_traits<float64>::type = MPI_DOUBLE;
 const MPI_Datatype mpi_traits<float32>::type = MPI_FLOAT;
-const MPI_Datatype mpi_traits<int8>::type = MPI_INT8_T;
-const MPI_Datatype mpi_traits<uint8>::type = MPI_UINT8_T;
-const MPI_Datatype mpi_traits<int16>::type = MPI_INT16_T;
-const MPI_Datatype mpi_traits<uint16>::type = MPI_UINT16_T;
-const MPI_Datatype mpi_traits<int32>::type = MPI_INT32_T;
-const MPI_Datatype mpi_traits<uint32>::type = MPI_UINT32_T;
+const MPI_Datatype mpi_traits<std::int8_t>::type = MPI_INT8_T;
+const MPI_Datatype mpi_traits<std::uint8_t>::type = MPI_UINT8_T;
+const MPI_Datatype mpi_traits<std::int16_t>::type = MPI_INT16_T;
+const MPI_Datatype mpi_traits<std::uint16_t>::type = MPI_UINT16_T;
+const MPI_Datatype mpi_traits<std::int32_t>::type = MPI_INT32_T;
+const MPI_Datatype mpi_traits<std::uint32_t>::type = MPI_UINT32_T;
 
   #ifndef AXOM_NO_INT64_T
-const MPI_Datatype mpi_traits<int64>::type = MPI_INT64_T;
-const MPI_Datatype mpi_traits<uint64>::type = MPI_UINT64_T;
+const MPI_Datatype mpi_traits<std::int64_t>::type = MPI_INT64_T;
+const MPI_Datatype mpi_traits<std::uint64_t>::type = MPI_UINT64_T;
   #endif /* end AXOM_NO_INT64_T */
 
 #endif /* end AXOM_USE_MPI */

--- a/src/axom/core/Types.hpp
+++ b/src/axom/core/Types.hpp
@@ -25,6 +25,17 @@
 
 namespace axom
 {
+/*
+  Axom integer types are deprecated.
+  Their use can trigger an warning or an error, or be quietly allowed,
+  by using cmake -DAXOM_DEPRECATED_TYPES=<WARN|ERROR|ALLOW>
+  Eventually, these types will be removed.
+*/
+#if AXOM_DEPRECATED_TYPES_N == 1 || AXOM_DEPRECATED_TYPES_N == 2
+  #if AXOM_DEPRECATED_TYPES_N == 1
+    #warning \
+      "Using deprecated Axom types.  Please see cmake variable AXOM_DEPRECATED_TYPES"
+  #endif
 using int8 = std::int8_t;   /*!< 8-bit signed integer type      */
 using uint8 = std::uint8_t; /*!< 8-bit unsigned integer type    */
 
@@ -34,11 +45,12 @@ using uint16 = std::uint16_t; /*!< 16-bit unsigned integer type   */
 using int32 = std::int32_t;   /*!< 32-bit signed integer type     */
 using uint32 = std::uint32_t; /*!< 32-bit unsigned integer type   */
 
-// Note: KW -- We assume that AXOM_NO_INT64_T will be defined
-// on systems/compilers that do not support 64 bit integer types
-#ifndef AXOM_NO_INT64_T
+  // Note: KW -- We assume that AXOM_NO_INT64_T will be defined
+  // on systems/compilers that do not support 64 bit integer types
+  #ifndef AXOM_NO_INT64_T
 using int64 = std::int64_t;   /*!< 64-bit signed integer type     */
 using uint64 = std::uint64_t; /*!< 64-bit unsigned integer type   */
+  #endif
 #endif
 
 using float32 = float;

--- a/src/axom/core/Types.hpp
+++ b/src/axom/core/Types.hpp
@@ -57,9 +57,9 @@ using float32 = float;
 using float64 = double;
 
 #if defined(AXOM_USE_64BIT_INDEXTYPE) && !defined(AXOM_NO_INT64_T)
-using IndexType = int64;
+using IndexType = std::int64_t;
 #else
-using IndexType = int32;
+using IndexType = std::int32_t;
 #endif
 
 #ifdef AXOM_USE_MPI
@@ -95,42 +95,42 @@ struct mpi_traits<float32>
 
 //------------------------------------------------------------------------------
 template <>
-struct mpi_traits<int8>
+struct mpi_traits<std::int8_t>
 {
   static const MPI_Datatype type;
 };
 
 //------------------------------------------------------------------------------
 template <>
-struct mpi_traits<uint8>
+struct mpi_traits<std::uint8_t>
 {
   static const MPI_Datatype type;
 };
 
 //------------------------------------------------------------------------------
 template <>
-struct mpi_traits<int16>
+struct mpi_traits<std::int16_t>
 {
   static const MPI_Datatype type;
 };
 
 //------------------------------------------------------------------------------
 template <>
-struct mpi_traits<uint16>
+struct mpi_traits<std::uint16_t>
 {
   static const MPI_Datatype type;
 };
 
 //------------------------------------------------------------------------------
 template <>
-struct mpi_traits<int32>
+struct mpi_traits<std::int32_t>
 {
   static const MPI_Datatype type;
 };
 
 //------------------------------------------------------------------------------
 template <>
-struct mpi_traits<uint32>
+struct mpi_traits<std::uint32_t>
 {
   static const MPI_Datatype type;
 };
@@ -138,14 +138,14 @@ struct mpi_traits<uint32>
   //------------------------------------------------------------------------------
   #ifndef AXOM_NO_INT64_T
 template <>
-struct mpi_traits<int64>
+struct mpi_traits<std::int64_t>
 {
   static const MPI_Datatype type;
 };
 
 //------------------------------------------------------------------------------
 template <>
-struct mpi_traits<uint64>
+struct mpi_traits<std::uint64_t>
 {
   static const MPI_Datatype type;
 };

--- a/src/axom/core/tests/core_bit_utilities.hpp
+++ b/src/axom/core/tests/core_bit_utilities.hpp
@@ -29,14 +29,14 @@ T random_int()
   return static_cast<T>(val);
 }
 
-axom::uint64 shifted(int bit) { return static_cast<axom::uint64>(1) << bit; }
+std::uint64_t shifted(int bit) { return static_cast<std::uint64_t>(1) << bit; }
 
 }  // namespace
 
 TEST(core_bit_utilities, trailingZeroes)
 {
-  constexpr axom::uint64 ZERO = axom::uint64(0);
-  constexpr int BITS = axom::utilities::BitTraits<axom::uint64>::BITS_PER_WORD;
+  constexpr std::uint64_t ZERO = std::uint64_t(0);
+  constexpr int BITS = axom::utilities::BitTraits<std::uint64_t>::BITS_PER_WORD;
   ASSERT_EQ(64, BITS);
 
   // Axom's trailingZeros will return 64 when given 0
@@ -47,13 +47,13 @@ TEST(core_bit_utilities, trailingZeroes)
   // Test with a known trailing bit
   for(int i = 0; i < BITS; ++i)
   {
-    axom::uint64 val = ::shifted(i);
+    std::uint64_t val = ::shifted(i);
     EXPECT_EQ(i, axom::utilities::trailingZeros(val));
 
     // Value doesn't change when you set bits to left of trailing bit
     for(int j = i + 1; j < BITS; ++j)
     {
-      axom::uint64 val2 = ::shifted(i) + ::shifted(j);
+      std::uint64_t val2 = ::shifted(i) + ::shifted(j);
       EXPECT_EQ(axom::utilities::trailingZeros(val),
                 axom::utilities::trailingZeros(val2));
     }
@@ -62,7 +62,7 @@ TEST(core_bit_utilities, trailingZeroes)
   // Test trailing zeros on some random numbers
   for(int n = 0; n < NRAND_SAMPLES; ++n)
   {
-    axom::uint64 rand_val = ::random_int<axom::uint64>();
+    std::uint64_t rand_val = ::random_int<std::uint64_t>();
 
     // Explicitly find first bit and check that it matches
     int bit = 0;
@@ -76,8 +76,8 @@ TEST(core_bit_utilities, trailingZeroes)
 
 TEST(core_bit_utilities, popCount)
 {
-  constexpr axom::uint64 ZERO = axom::uint64(0);
-  constexpr int BITS = axom::utilities::BitTraits<axom::uint64>::BITS_PER_WORD;
+  constexpr std::uint64_t ZERO = std::uint64_t(0);
+  constexpr int BITS = axom::utilities::BitTraits<std::uint64_t>::BITS_PER_WORD;
   ASSERT_EQ(64, BITS);
 
   // Test pop count when zero bits are set
@@ -89,7 +89,7 @@ TEST(core_bit_utilities, popCount)
   // Test pop count when one bit is set
   for(int i = 0; i < BITS; ++i)
   {
-    axom::uint64 val = ::shifted(i);
+    std::uint64_t val = ::shifted(i);
     EXPECT_EQ(1, axom::utilities::popCount(val));
     EXPECT_EQ(BITS - 1, axom::utilities::popCount(~val));
   }
@@ -99,7 +99,7 @@ TEST(core_bit_utilities, popCount)
   {
     for(int j = 0; j < i; ++j)
     {
-      axom::uint64 val = shifted(i) + shifted(j);
+      std::uint64_t val = shifted(i) + shifted(j);
       EXPECT_EQ(2, axom::utilities::popCount(val));
       EXPECT_EQ(BITS - 2, axom::utilities::popCount(~val));
     }
@@ -112,7 +112,7 @@ TEST(core_bit_utilities, popCount)
     {
       for(int k = 0; k < j; ++k)
       {
-        axom::uint64 val = shifted(i) + shifted(j) + shifted(k);
+        std::uint64_t val = shifted(i) + shifted(j) + shifted(k);
         EXPECT_EQ(3, axom::utilities::popCount(val));
         EXPECT_EQ(BITS - 3, axom::utilities::popCount(~val));
       }
@@ -122,7 +122,7 @@ TEST(core_bit_utilities, popCount)
   // Test pop count on some random numbers
   for(int n = 0; n < NRAND_SAMPLES; ++n)
   {
-    auto val = ::random_int<axom::uint64>();
+    auto val = ::random_int<std::uint64_t>();
 
     int bits = 0;
     for(int i = 0; i < BITS; ++i)
@@ -136,8 +136,8 @@ TEST(core_bit_utilities, popCount)
 
 TEST(core_bit_utilities, leadingZeros)
 {
-  constexpr axom::int32 ZERO = axom::int32(0);
-  constexpr int BITS = axom::utilities::BitTraits<axom::uint32>::BITS_PER_WORD;
+  constexpr std::int32_t ZERO = std::int32_t(0);
+  constexpr int BITS = axom::utilities::BitTraits<std::uint32_t>::BITS_PER_WORD;
   ASSERT_EQ(32, BITS);
 
   // Axom's leadingZeros will return 32 when given 0
@@ -145,13 +145,13 @@ TEST(core_bit_utilities, leadingZeros)
 
   for(int i = 0; i < BITS; ++i)
   {
-    axom::int32 val = ::shifted(i);
+    std::int32_t val = ::shifted(i);
     EXPECT_EQ(BITS - i - 1, axom::utilities::leadingZeros(val));
 
     // Value doesn't change if you set bits to right of leading zero
     for(int j = 0; j < i; ++j)
     {
-      axom::int32 val2 = ::shifted(i) + ::shifted(j);
+      std::int32_t val2 = ::shifted(i) + ::shifted(j);
       EXPECT_EQ(axom::utilities::leadingZeros(val),
                 axom::utilities::leadingZeros(val2));
     }
@@ -160,7 +160,7 @@ TEST(core_bit_utilities, leadingZeros)
   // Test leading zeros on some random numbers
   for(int n = 0; n < NRAND_SAMPLES; ++n)
   {
-    axom::int32 rand_val = ::random_int<axom::int32>();
+    std::int32_t rand_val = ::random_int<std::int32_t>();
 
     // Explicitly find first bit and check that it matches
     int bit = 0;

--- a/src/axom/core/tests/core_types.hpp
+++ b/src/axom/core/tests/core_types.hpp
@@ -93,7 +93,7 @@ TEST(core_types, check_int8)
   constexpr int NUM_DIGITS = 7;
   constexpr bool IS_SIGNED = true;
 
-  check_integral_type<axom::int8>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_INT8_T);
+  check_integral_type<std::int8_t>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_INT8_T);
 }
 
 //------------------------------------------------------------------------------
@@ -103,7 +103,7 @@ TEST(core_types, check_uint8)
   constexpr int NUM_DIGITS = 8;
   constexpr bool IS_SIGNED = false;
 
-  check_integral_type<axom::uint8>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_UINT8_T);
+  check_integral_type<std::uint8_t>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_UINT8_T);
 }
 
 //------------------------------------------------------------------------------
@@ -113,7 +113,7 @@ TEST(core_types, check_int16)
   constexpr int NUM_DIGITS = 15;
   constexpr bool IS_SIGNED = true;
 
-  check_integral_type<axom::int16>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_INT16_T);
+  check_integral_type<std::int16_t>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_INT16_T);
 }
 
 //------------------------------------------------------------------------------
@@ -123,7 +123,7 @@ TEST(core_types, check_uint16)
   constexpr int NUM_DIGITS = 16;
   constexpr bool IS_SIGNED = false;
 
-  check_integral_type<axom::uint16>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_UINT16_T);
+  check_integral_type<std::uint16_t>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_UINT16_T);
 }
 
 //------------------------------------------------------------------------------
@@ -133,7 +133,7 @@ TEST(core_types, check_int32)
   constexpr int NUM_DIGITS = 31;
   constexpr bool IS_SIGNED = true;
 
-  check_integral_type<axom::int32>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_INT32_T);
+  check_integral_type<std::int32_t>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_INT32_T);
 }
 
 //------------------------------------------------------------------------------
@@ -143,7 +143,7 @@ TEST(core_types, check_uint32)
   constexpr int NUM_DIGITS = 32;
   constexpr bool IS_SIGNED = false;
 
-  check_integral_type<axom::uint32>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_UINT32_T);
+  check_integral_type<std::uint32_t>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_UINT32_T);
 }
 
 #ifndef AXOM_NO_INT64_T
@@ -155,7 +155,7 @@ TEST(core_types, check_int64)
   constexpr int NUM_DIGITS = 63;
   constexpr bool IS_SIGNED = true;
 
-  check_integral_type<axom::int64>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_INT64_T);
+  check_integral_type<std::int64_t>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_INT64_T);
 }
 
 //------------------------------------------------------------------------------
@@ -165,7 +165,7 @@ TEST(core_types, check_uint64)
   constexpr int NUM_DIGITS = 64;
   constexpr bool IS_SIGNED = false;
 
-  check_integral_type<axom::uint64>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_UINT64_T);
+  check_integral_type<std::uint64_t>(EXP_BYTES, IS_SIGNED, NUM_DIGITS, MPI_UINT64_T);
 }
 
 //------------------------------------------------------------------------------
@@ -191,7 +191,7 @@ TEST(core_types, check_indextype)
 
 #ifdef AXOM_USE_64BIT_INDEXTYPE
 
-  constexpr bool is_int64 = std::is_same<axom::IndexType, axom::int64>::value;
+  constexpr bool is_int64 = std::is_same<axom::IndexType, std::int64_t>::value;
   EXPECT_TRUE(is_int64);
 
   constexpr std::size_t EXP_BYTES = 8;
@@ -202,7 +202,7 @@ TEST(core_types, check_indextype)
                                        MPI_INT64_T);
 #else
 
-  constexpr bool is_int32 = std::is_same<axom::IndexType, axom::int32>::value;
+  constexpr bool is_int32 = std::is_same<axom::IndexType, std::int32_t>::value;
   EXPECT_TRUE(is_int32);
 
   constexpr std::size_t EXP_BYTES = 4;

--- a/src/axom/core/tests/utils_endianness.hpp
+++ b/src/axom/core/tests/utils_endianness.hpp
@@ -25,9 +25,9 @@ TEST(utils_endianness, endianness_16)
 {
   union SixteenBit
   {
-    axom::uint8 raw[2];
-    axom::int16 i_val;
-    axom::uint16 ui_val;
+    std::uint8_t raw[2];
+    std::int16_t i_val;
+    std::uint16_t ui_val;
     short short_val;
     unsigned short ushort_val;
   };
@@ -59,9 +59,9 @@ TEST(utils_endianness, endianness_16)
 
   // Test int16
   {
-    axom::int16 v1 = valOrig.i_val;
-    axom::int16 v2 = axom::utilities::swapEndian(v1);
-    axom::int16 v3 = axom::utilities::swapEndian(v2);
+    std::int16_t v1 = valOrig.i_val;
+    std::int16_t v2 = axom::utilities::swapEndian(v1);
+    std::int16_t v3 = axom::utilities::swapEndian(v2);
 
     EXPECT_EQ(valOrig.i_val, v1);
     EXPECT_EQ(valSwap.i_val, v2);
@@ -70,9 +70,9 @@ TEST(utils_endianness, endianness_16)
 
   // Test uint16
   {
-    axom::uint16 v1 = valOrig.i_val;
-    axom::uint16 v2 = axom::utilities::swapEndian(v1);
-    axom::uint16 v3 = axom::utilities::swapEndian(v2);
+    std::uint16_t v1 = valOrig.i_val;
+    std::uint16_t v2 = axom::utilities::swapEndian(v1);
+    std::uint16_t v3 = axom::utilities::swapEndian(v2);
 
     EXPECT_EQ(valOrig.ui_val, v1);
     EXPECT_EQ(valSwap.ui_val, v2);
@@ -84,9 +84,9 @@ TEST(utils_endianness, endianness_32)
 {
   union ThirtyTwoBit
   {
-    axom::uint8 raw[4];
-    axom::int32 i_val;
-    axom::uint32 ui_val;
+    std::uint8_t raw[4];
+    std::int32_t i_val;
+    std::uint32_t ui_val;
     int int_val;
     unsigned int uint_val;
     float f_val;
@@ -119,9 +119,9 @@ TEST(utils_endianness, endianness_32)
 
   // Test int32
   {
-    axom::int32 v1 = valOrig.i_val;
-    axom::int32 v2 = axom::utilities::swapEndian(v1);
-    axom::int32 v3 = axom::utilities::swapEndian(v2);
+    std::int32_t v1 = valOrig.i_val;
+    std::int32_t v2 = axom::utilities::swapEndian(v1);
+    std::int32_t v3 = axom::utilities::swapEndian(v2);
 
     EXPECT_EQ(valOrig.i_val, v1);
     EXPECT_EQ(valSwap.i_val, v2);
@@ -130,9 +130,9 @@ TEST(utils_endianness, endianness_32)
 
   // Test uint32
   {
-    axom::uint32 v1 = valOrig.i_val;
-    axom::uint32 v2 = axom::utilities::swapEndian(v1);
-    axom::uint32 v3 = axom::utilities::swapEndian(v2);
+    std::uint32_t v1 = valOrig.i_val;
+    std::uint32_t v2 = axom::utilities::swapEndian(v1);
+    std::uint32_t v3 = axom::utilities::swapEndian(v2);
 
     EXPECT_EQ(valOrig.ui_val, v1);
     EXPECT_EQ(valSwap.ui_val, v2);
@@ -155,10 +155,10 @@ TEST(utils_endianness, endianness_64)
 {
   union SixtyFourBit
   {
-    axom::uint8 raw[8];
+    std::uint8_t raw[8];
 #ifndef AXOM_NO_INT64_T
-    axom::int64 i_val;
-    axom::uint64 ui_val;
+    std::int64_t i_val;
+    std::uint64_t ui_val;
 #endif
     double d_val;
   };
@@ -169,9 +169,9 @@ TEST(utils_endianness, endianness_64)
 #ifndef AXOM_NO_INT64_T
   // Test int64
   {
-    axom::int64 v1 = valOrig.i_val;
-    axom::int64 v2 = axom::utilities::swapEndian(v1);
-    axom::int64 v3 = axom::utilities::swapEndian(v2);
+    std::int64_t v1 = valOrig.i_val;
+    std::int64_t v2 = axom::utilities::swapEndian(v1);
+    std::int64_t v3 = axom::utilities::swapEndian(v2);
 
     EXPECT_EQ(valOrig.i_val, v1);
     EXPECT_EQ(valSwap.i_val, v2);
@@ -180,9 +180,9 @@ TEST(utils_endianness, endianness_64)
 
   // Test uint64
   {
-    axom::uint64 v1 = valOrig.i_val;
-    axom::uint64 v2 = axom::utilities::swapEndian(v1);
-    axom::uint64 v3 = axom::utilities::swapEndian(v2);
+    std::uint64_t v1 = valOrig.i_val;
+    std::uint64_t v2 = axom::utilities::swapEndian(v1);
+    std::uint64_t v3 = axom::utilities::swapEndian(v2);
 
     EXPECT_EQ(valOrig.ui_val, v1);
     EXPECT_EQ(valSwap.ui_val, v2);
@@ -208,15 +208,15 @@ TEST(utils_endianness, endianness_64)
 TEST(utils_endianness,invalid_byte_width)
 {
   {
-    axom::int8 v1 = 5;
-    axom::int8 v2 = axom::utilities::swapEndian(v1);
+    std::int8_t v1 = 5;
+    std::int8_t v2 = axom::utilities::swapEndian(v1);
 
     EXPECT_EQ(v1, v2);
   }
 
   {
-    axom::uint8 v1 = 5;
-    axom::uint8 v2 = axom::utilities::swapEndian(v1);
+    std::uint8_t v1 = 5;
+    std::uint8_t v2 = axom::utilities::swapEndian(v1);
 
     EXPECT_EQ(v1, v2);
   }
@@ -230,8 +230,8 @@ TEST(utils_endianness,invalid_non_native_types)
 {
   struct AxomUtilsTestsNonNative
   {
-    axom::uint16 a;
-    axom::uint16 b;
+    std::uint16_t a;
+    std::uint16_t b;
   };
 
   AxomUtilsTestsNonNative v1;

--- a/src/axom/core/utilities/BitUtilities.hpp
+++ b/src/axom/core/utilities/BitUtilities.hpp
@@ -42,7 +42,7 @@ template <typename T>
 struct BitTraits;
 
 template <>
-struct BitTraits<axom::uint64>
+struct BitTraits<std::uint64_t>
 {
   constexpr static int NUM_BYTES = 8;
   constexpr static int BITS_PER_WORD = NUM_BYTES << 3;
@@ -50,7 +50,7 @@ struct BitTraits<axom::uint64>
 };
 
 template <>
-struct BitTraits<axom::uint32>
+struct BitTraits<std::uint32_t>
 {
   constexpr static int NUM_BYTES = 4;
   constexpr static int BITS_PER_WORD = NUM_BYTES << 3;
@@ -58,7 +58,7 @@ struct BitTraits<axom::uint32>
 };
 
 template <>
-struct BitTraits<axom::uint16>
+struct BitTraits<std::uint16_t>
 {
   constexpr static int NUM_BYTES = 2;
   constexpr static int BITS_PER_WORD = NUM_BYTES << 3;
@@ -66,7 +66,7 @@ struct BitTraits<axom::uint16>
 };
 
 template <>
-struct BitTraits<axom::uint8>
+struct BitTraits<std::uint8_t>
 {
   constexpr static int NUM_BYTES = 1;
   constexpr static int BITS_PER_WORD = NUM_BYTES << 3;
@@ -79,25 +79,25 @@ struct BitTraits<axom::uint8>
  * \return The number of zeros to the right of the first set bit in \word,
  * starting with the least significant bit, or 64 if \a word == 0.
  */
-AXOM_HOST_DEVICE inline int trailingZeros(axom::uint64 word)
+AXOM_HOST_DEVICE inline int trailingZeros(std::uint64_t word)
 {
   /* clang-format off */
 #if defined(AXOM_DEVICE_CODE) && defined(AXOM_USE_CUDA)
-  return word != axom::uint64(0) ? __ffsll(word) - 1 : 64;
+  return word != std::uint64_t(0) ? __ffsll(word) - 1 : 64;
 #elif defined(_AXOM_CORE_USE_INTRINSICS_MSVC)
   unsigned long cnt;
   return _BitScanForward64(&cnt, word) ? cnt : 64;
 #elif defined(_AXOM_CORE_USE_INTRINSICS_GCC) || defined(_AXOM_CORE_USE_INTRINSICS_PPC)
-  return word != axom::uint64(0) ? __builtin_ctzll(word) : 64;
+  return word != std::uint64_t(0) ? __builtin_ctzll(word) : 64;
 #else
   // Explicit implementation adapted from bit twiddling hacks
   // https://graphics.stanford.edu/~seander/bithacks.html#ZerosOnRightParallel
   // and modified for 64 bits:
 
   // cnt tracks the number of zero bits on the right of the first set bit
-  int cnt = BitTraits<axom::uint64>::BITS_PER_WORD;
+  int cnt = BitTraits<std::uint64_t>::BITS_PER_WORD;
 
-  word &= -static_cast<axom::int64>(word);
+  word &= -static_cast<std::int64_t>(word);
   if (word)                      { cnt--;     }
   if (word & 0x00000000FFFFFFFF) { cnt -= 32; }
   if (word & 0x0000FFFF0000FFFF) { cnt -= 16; }
@@ -116,7 +116,7 @@ AXOM_HOST_DEVICE inline int trailingZeros(axom::uint64 word)
  * \accelerated
  * \return number of bits in \a word that are set to 1
  */
-AXOM_HOST_DEVICE inline int popCount(axom::uint64 word)
+AXOM_HOST_DEVICE inline int popCount(std::uint64_t word)
 {
   /* clang-format off */
 #if defined(AXOM_DEVICE_CODE) && defined(AXOM_USE_CUDA)
@@ -130,7 +130,7 @@ AXOM_HOST_DEVICE inline int popCount(axom::uint64 word)
   // 64 bit popcount implementation from:
   // http://chessprogramming.wikispaces.com/Population+Count#SWARPopcount
 
-  using Word = axom::uint64;
+  using Word = std::uint64_t;
 
   const Word masks[] = {
     0x5555555555555555,  //  0 --  -1/3
@@ -155,7 +155,7 @@ AXOM_HOST_DEVICE inline int popCount(axom::uint64 word)
  * \return The number of zeros to the left of the first set bit in \word,
  * starting with the least significant bit.
  */
-AXOM_HOST_DEVICE inline axom::int32 leadingZeros(axom::int32 word)
+AXOM_HOST_DEVICE inline std::int32_t leadingZeros(std::int32_t word)
 {
   /* clang-format off */
 #if defined(AXOM_DEVICE_CODE) && defined(AXOM_USE_CUDA)
@@ -165,16 +165,16 @@ AXOM_HOST_DEVICE inline axom::int32 leadingZeros(axom::int32 word)
   unsigned long cnt;
   return _BitScanReverse(&cnt, word) ? 31 - cnt : 32;
 #elif defined(_AXOM_CORE_USE_INTRINSICS_GCC) || defined(_AXOM_CORE_USE_INTRINSICS_PPC)
-  return word != axom::int32(0) ? __builtin_clz(word) : 32;
+  return word != std::int32_t(0) ? __builtin_clz(word) : 32;
 #else
-  axom::int32 y;
-  axom::int32 n = 32;
+  std::int32_t y;
+  std::int32_t n = 32;
   y = word >> 16; if(y != 0) { n -= 16; word = y;}
   y = word >>  8; if(y != 0) { n -=  8; word = y;}
   y = word >>  4; if(y != 0) { n -=  4; word = y;}
   y = word >>  2; if(y != 0) { n -=  2; word = y;}
-  y = word >>  1; if(y != 0) { return axom::int32(n - 2); }
-  return axom::int32(n - word);
+  y = word >>  1; if(y != 0) { return std::int32_t(n - 2); }
+  return std::int32_t(n - word);
 #endif
   /* clang-format off */
 }

--- a/src/axom/core/utilities/Utilities.hpp
+++ b/src/axom/core/utilities/Utilities.hpp
@@ -257,8 +257,8 @@ inline bool isLittleEndian()
 
   const union
   {
-    axom::uint8 raw[4];
-    axom::uint32 value;
+    std::uint8_t raw[4];
+    std::uint32_t value;
   } host_order = {{0, 1, 2, 3}};
 
   return host_order.value == O32_LITTLE_ENDIAN;
@@ -286,11 +286,11 @@ T swapEndian(T val)
 
   union
   {
-    axom::uint8 raw[NBYTES];
+    std::uint8_t raw[NBYTES];
     T val;
   } swp;
 
-  axom::uint8* src = reinterpret_cast<axom::uint8*>(&val);
+  std::uint8_t* src = reinterpret_cast<std::uint8_t*>(&val);
 
   // Reverse the bytes
   for(int i = 0; i < NBYTES; ++i)

--- a/src/axom/inlet/Container.cpp
+++ b/src/axom/inlet/Container.cpp
@@ -398,7 +398,7 @@ axom::sidre::DataTypeId Container::addPrimitiveHelper<bool>(
   const auto result = m_reader.getBool(lookupPath, val);
   if(forArray || result == ReaderResult::Success)
   {
-    sidreGroup->createViewScalar("value", val ? int8(1) : int8(0));
+    sidreGroup->createViewScalar("value", val ? std::int8_t(1) : std::int8_t(0));
   }
   if(!forArray)
   {

--- a/src/axom/inlet/Field.cpp
+++ b/src/axom/inlet/Field.cpp
@@ -107,7 +107,7 @@ Field& Field::defaultValue(bool value)
     SLIC_WARNING("[Inlet] Field value type did not match BOOL");
     setWarningFlag(m_sidreRootGroup);
   }
-  setDefaultValue((int8)value);
+  setDefaultValue((std::int8_t)value);
   return *this;
 }
 
@@ -207,8 +207,8 @@ template <>
 bool Field::get<bool>() const
 {
   const auto valueView = checkExistenceAndType(axom::sidre::INT8_ID);
-  // There is no boolean type in conduit/sidre so we use int8
-  const int8 intValue = valueView->getScalar();
+  // There is no boolean type in conduit/sidre so we use std::int8_t
+  const std::int8_t intValue = valueView->getScalar();
   if(intValue < 0 || intValue > 1)
   {
     const std::string msg = fmt::format(

--- a/src/axom/inlet/Function.hpp
+++ b/src/axom/inlet/Function.hpp
@@ -128,7 +128,7 @@ struct FunctionBuffer
   static constexpr size_t Alignment = alignof(std::function<void()>);
   static constexpr size_t Size = sizeof(std::function<void()>);
 
-  alignas(Alignment) axom::uint8 m_bytes[Size];
+  alignas(Alignment) std::uint8_t m_bytes[Size];
 };
 
 template <typename Func>

--- a/src/axom/inlet/JSONSchemaWriter.cpp
+++ b/src/axom/inlet/JSONSchemaWriter.cpp
@@ -167,7 +167,7 @@ void recordFieldSchema(const Field& field, conduit::Node& node)
       node["default"] = std::string(default_view->getString());
       break;
     case sidre::INT8_ID:
-      node["default"] = static_cast<int8>(default_view->getData());
+      node["default"] = static_cast<std::int8_t>(default_view->getData());
       break;
     default:
       break;

--- a/src/axom/inlet/SphinxWriter.cpp
+++ b/src/axom/inlet/SphinxWriter.cpp
@@ -218,7 +218,7 @@ std::string SphinxWriter::getValueAsString(const axom::sidre::View* view)
   axom::sidre::TypeID type = view->getTypeID();
   if(type == axom::sidre::TypeID::INT8_ID)
   {
-    int8 val = view->getData();
+    std::int8_t val = view->getData();
     return val ? "True" : "False";
   }
   else if(type == axom::sidre::TypeID::INT_ID)
@@ -324,7 +324,7 @@ void SphinxWriter::extractFieldMetadata(const axom::sidre::Group* sidreGroup,
 
   if(sidreGroup->hasView("required"))
   {
-    int8 required = sidreGroup->getView("required")->getData();
+    std::int8_t required = sidreGroup->getView("required")->getData();
     fieldAttributes[4] = required ? "|check|" : "|uncheck|";
   }
   else
@@ -381,7 +381,7 @@ void SphinxWriter::extractFunctionMetadata(const axom::sidre::Group* sidreGroup,
 
   if(sidreGroup->hasView("required"))
   {
-    int8 required = sidreGroup->getView("required")->getData();
+    std::int8_t required = sidreGroup->getView("required")->getData();
     functionAttributes[3] = required ? "|check|" : "|uncheck|";
   }
   else

--- a/src/axom/inlet/inlet_utils.cpp
+++ b/src/axom/inlet/inlet_utils.cpp
@@ -22,11 +22,11 @@ void setFlag(axom::sidre::Group& target,
              const std::string& flag,
              bool value)
 {
-  const int8 bval = value ? 1 : 0;
+  const std::int8_t bval = value ? 1 : 0;
   if(target.hasView(flag))
   {
     auto flagView = target.getView(flag);
-    if(flagView->getData<int8>() != bval)
+    if(flagView->getData<std::int8_t>() != bval)
     {
       const std::string msg =
         fmt::format("[Inlet] '{0}' value has already been defined for: {1}",
@@ -59,7 +59,7 @@ bool checkFlag(const axom::sidre::Group& target,
     return false;
   }
   const axom::sidre::View* valueView = target.getView(flag);
-  const int8 intValue = valueView->getScalar();
+  const std::int8_t intValue = valueView->getScalar();
   if(intValue < 0 || intValue > 1)
   {
     const std::string msg = fmt::format(
@@ -90,7 +90,7 @@ bool verifyRequired(const axom::sidre::Group& target,
 
   if(target.hasView("required"))
   {
-    int8 required = target.getView("required")->getData();
+    std::int8_t required = target.getView("required")->getData();
     // If it wasn't found at all, it's only an error if the object was required and not provided
     // The retrieval_status will typically (but not always) be NotFound in these cases, but that
     // information isn't needed here unless it's a collection group - empty collections are permissible,
@@ -135,7 +135,7 @@ void markAsStructCollection(axom::sidre::Group& target)
       fmt::format(
         "[Inlet] Struct collection flag of group '{0}' was not a scalar",
         target.getName()));
-    const int8 value = flag->getScalar();
+    const std::int8_t value = flag->getScalar();
     SLIC_ERROR_IF(value != 1,
                   fmt::format("[Inlet] Struct collection flag of group '{0}' "
                               "had a value other than 1",
@@ -143,7 +143,7 @@ void markAsStructCollection(axom::sidre::Group& target)
   }
   else
   {
-    target.createViewScalar(detail::STRUCT_COLLECTION_FLAG, static_cast<int8>(1));
+    target.createViewScalar(detail::STRUCT_COLLECTION_FLAG, static_cast<std::int8_t>(1));
   }
 }
 

--- a/src/axom/inlet/inlet_utils.cpp
+++ b/src/axom/inlet/inlet_utils.cpp
@@ -143,7 +143,8 @@ void markAsStructCollection(axom::sidre::Group& target)
   }
   else
   {
-    target.createViewScalar(detail::STRUCT_COLLECTION_FLAG, static_cast<std::int8_t>(1));
+    target.createViewScalar(detail::STRUCT_COLLECTION_FLAG,
+                            static_cast<std::int8_t>(1));
   }
 }
 

--- a/src/axom/mint/core/config.hpp.in
+++ b/src/axom/mint/core/config.hpp.in
@@ -17,7 +17,7 @@ namespace mint
 {
 
 constexpr IndexType USE_DEFAULT = -1;
-using int64 = axom::int64;
+using int64 = std::int64_t;
 
 } /* end namespace mint */
 } /* end namespace axom */

--- a/src/axom/mint/mesh/FieldData.cpp
+++ b/src/axom/mint/mesh/FieldData.cpp
@@ -28,8 +28,8 @@ mint::Field* getFieldFromView(const std::string& name, sidre::View* view)
   SLIC_ASSERT(view != nullptr);
   SLIC_ASSERT(!view->isEmpty());
 
-  using int32 = axom::int32;
-  using int64 = axom::int64;
+  using int32 = std::int32_t;
+  using int64 = std::int64_t;
 
   mint::Field* f = nullptr;
 

--- a/src/axom/mint/mesh/FieldTypes.hpp
+++ b/src/axom/mint/mesh/FieldTypes.hpp
@@ -55,14 +55,14 @@ struct field_traits<axom::float64>
 
 //------------------------------------------------------------------------------
 template <>
-struct field_traits<axom::int32>
+struct field_traits<std::int32_t>
 {
   static constexpr int type() { return INT32_FIELD_TYPE; };
 };
 
 //------------------------------------------------------------------------------
 template <>
-struct field_traits<axom::int64>
+struct field_traits<std::int64_t>
 {
   static constexpr int type() { return INT64_FIELD_TYPE; };
 };

--- a/src/axom/mint/tests/mint_mesh_field.cpp
+++ b/src/axom/mint/tests/mint_mesh_field.cpp
@@ -64,8 +64,8 @@ TEST(mint_mesh_field, instantiate)
 {
   check_field_instantiation<double>();
   check_field_instantiation<float>();
-  check_field_instantiation<axom::int32>();
-  check_field_instantiation<axom::int64>();
+  check_field_instantiation<std::int32_t>();
+  check_field_instantiation<std::int64_t>();
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/mint/tests/mint_mesh_field_types.cpp
+++ b/src/axom/mint/tests/mint_mesh_field_types.cpp
@@ -18,8 +18,8 @@ namespace mint = axom::mint;
 //------------------------------------------------------------------------------
 TEST(mint_mesh_fieldtypes, field_traits)
 {
-  using int32 = axom::int32;
-  using int64 = axom::int64;
+  using int32 = std::int32_t;
+  using int64 = std::int64_t;
 
   EXPECT_EQ(mint::field_traits<char>::type(), mint::UNDEFINED_FIELD_TYPE);
   EXPECT_EQ(mint::field_traits<float>::type(), mint::FLOAT_FIELD_TYPE);

--- a/src/axom/mint/utils/vtk_utils.cpp
+++ b/src/axom/mint/utils/vtk_utils.cpp
@@ -282,10 +282,10 @@ void write_scalar_data(const Field* field, std::ofstream& file)
     write_scalar_helper<double>("double", field, file);
     break;
   case INT32_FIELD_TYPE:
-    write_scalar_helper<axom::int32>("int", field, file);
+    write_scalar_helper<std::int32_t>("int", field, file);
     break;
   case INT64_FIELD_TYPE:
-    write_scalar_helper<axom::int64>("long", field, file);
+    write_scalar_helper<std::int64_t>("long", field, file);
     break;
   default:
     SLIC_WARNING(
@@ -347,10 +347,10 @@ void write_vector_data(const Field* field, std::ofstream& file)
     write_vector_helper<double>("double", field, file);
     break;
   case INT32_FIELD_TYPE:
-    write_vector_helper<axom::int32>("int", field, file);
+    write_vector_helper<std::int32_t>("int", field, file);
     break;
   case INT64_FIELD_TYPE:
-    write_vector_helper<axom::int64>("long", field, file);
+    write_vector_helper<std::int64_t>("long", field, file);
     break;
   default:
     SLIC_WARNING(
@@ -410,10 +410,10 @@ void write_multidim_data(const Field* field, std::ofstream& file)
     write_multidim_helper<double>("double", field, file);
     break;
   case INT32_FIELD_TYPE:
-    write_multidim_helper<axom::int32>("int", field, file);
+    write_multidim_helper<std::int32_t>("int", field, file);
     break;
   case INT64_FIELD_TYPE:
-    write_multidim_helper<axom::int64>("long", field, file);
+    write_multidim_helper<std::int64_t>("long", field, file);
     break;
   default:
     SLIC_WARNING(

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -43,7 +43,7 @@ public:
   static constexpr int MAX_VERTS = 32;
   static constexpr int MAX_NBRS_PER_VERT = 8;
 
-  using VertexNbrs = axom::StackArray<axom::int8, MAX_NBRS_PER_VERT>;
+  using VertexNbrs = axom::StackArray<std::int8_t, MAX_NBRS_PER_VERT>;
 
 public:
   /*!
@@ -118,14 +118,14 @@ public:
    *
    * \pre vtx < MAX_VERTS
    */
-  AXOM_HOST_DEVICE void addNeighbors(axom::int8 vtx,
-                                     std::initializer_list<axom::int8> nbrIds)
+  AXOM_HOST_DEVICE void addNeighbors(std::int8_t vtx,
+                                     std::initializer_list<std::int8_t> nbrIds)
   {
     SLIC_ASSERT(num_nbrs[vtx] + nbrIds.size() <= MAX_NBRS_PER_VERT);
     SLIC_ASSERT(vtx >= 0 && vtx < MAX_VERTS);
-    for(axom::int8 nbr : nbrIds)
+    for(std::int8_t nbr : nbrIds)
     {
-      axom::int8 idx_insert = num_nbrs[vtx];
+      std::int8_t idx_insert = num_nbrs[vtx];
       nbrs[vtx][idx_insert] = nbr;
       num_nbrs[vtx]++;
     }
@@ -139,11 +139,11 @@ public:
    *
    * \pre vtx < MAX_VERTS
    */
-  AXOM_HOST_DEVICE void addNeighbors(axom::int8 vtx, axom::int8 nbrId)
+  AXOM_HOST_DEVICE void addNeighbors(std::int8_t vtx, std::int8_t nbrId)
   {
     SLIC_ASSERT(num_nbrs[vtx] + 1 <= MAX_NBRS_PER_VERT);
     SLIC_ASSERT(vtx >= 0 && vtx < MAX_VERTS);
-    axom::int8 idx_insert = num_nbrs[vtx];
+    std::int8_t idx_insert = num_nbrs[vtx];
     nbrs[vtx][idx_insert] = nbrId;
     num_nbrs[vtx]++;
   };
@@ -159,14 +159,14 @@ public:
    * \pre vtx < MAX_VERTS
    * \pre pos <= num_nbrs[vtx]
    */
-  AXOM_HOST_DEVICE void insertNeighborAtPos(axom::int8 vtx,
-                                            axom::int8 nbr,
-                                            axom::int8 pos)
+  AXOM_HOST_DEVICE void insertNeighborAtPos(std::int8_t vtx,
+                                            std::int8_t nbr,
+                                            std::int8_t pos)
   {
     SLIC_ASSERT(num_nbrs[vtx] + 1 <= MAX_NBRS_PER_VERT);
     SLIC_ASSERT(vtx >= 0 && vtx < MAX_VERTS);
     SLIC_ASSERT(pos <= num_nbrs[vtx]);
-    axom::uint8 old_nbrs[MAX_NBRS_PER_VERT];
+    std::uint8_t old_nbrs[MAX_NBRS_PER_VERT];
     // copy elements from [pos, nnbrs)
     for(int ip = pos; ip < num_nbrs[vtx]; ip++)
     {
@@ -199,7 +199,7 @@ public:
   }
 
 private:
-  axom::int8 num_nbrs[MAX_VERTS];
+  std::int8_t num_nbrs[MAX_VERTS];
   VertexNbrs nbrs[MAX_VERTS];
 };
 
@@ -284,7 +284,7 @@ public:
    * \param [in] nbrs The neighbors to add to the list of neighbors
    */
   AXOM_HOST_DEVICE
-  void addNeighbors(const PointType& pt, std::initializer_list<axom::int8> nbrs)
+  void addNeighbors(const PointType& pt, std::initializer_list<std::int8_t> nbrs)
   {
     for(int i = 0; i < m_num_vertices; i++)
     {
@@ -307,7 +307,7 @@ public:
    * \pre vtxId < getVertices()
    */
   AXOM_HOST_DEVICE
-  void addNeighbors(int vtxId, std::initializer_list<axom::int8> nbrs)
+  void addNeighbors(int vtxId, std::initializer_list<std::int8_t> nbrs)
   {
     m_neighbors.addNeighbors(vtxId, nbrs);
   }
@@ -416,11 +416,11 @@ public:
   AXOM_HOST_DEVICE
   void getFaces(int* faces, int* face_size, int* face_offset, int& face_count) const
   {
-    axom::int8 curFaceIndex = 0;
-    axom::int8 checkedSize = 0;
-    axom::int8 facesAdded = 0;
+    std::int8_t curFaceIndex = 0;
+    std::int8_t checkedSize = 0;
+    std::int8_t facesAdded = 0;
     // # edges * (# vertices per edge) * (# orientation per edge)
-    axom::int8 checkedEdges[MAX_VERTS * 2 * 2] = {0};
+    std::int8_t checkedEdges[MAX_VERTS * 2 * 2] = {0};
 
     // Check each vertex
     for(int i = 0; i < numVertices(); ++i)
@@ -448,10 +448,10 @@ public:
         {
           face_offset[facesAdded] = curFaceIndex;
           faces[curFaceIndex++] = i;
-          axom::int8 curFaceSize = 1;
-          axom::int8 vstart = i;
-          axom::int8 vnext = ni;
-          axom::int8 vprev = i;
+          std::int8_t curFaceSize = 1;
+          std::int8_t vstart = i;
+          std::int8_t vnext = ni;
+          std::int8_t vprev = i;
 
           // Add neighboring vertices until we reach the starting vertex.
           while(vnext != vstart)

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -205,7 +205,7 @@ AXOM_HOST_DEVICE void poly_clip_vertices(Polyhedron<T, NDIMS>& poly,
 
   // Loop over Polyhedron vertices
   int numVerts = poly.numVertices();
-  for(axom::int8 i = 0; i < numVerts; i++)
+  for(std::int8_t i = 0; i < numVerts; i++)
   {
     int orientation = plane.getOrientation(poly[i], eps);
 
@@ -219,7 +219,7 @@ AXOM_HOST_DEVICE void poly_clip_vertices(Polyhedron<T, NDIMS>& poly,
       int numNeighbors = poly.getNumNeighbors(i);
       for(int j = 0; j < numNeighbors; j++)
       {
-        axom::int8 neighborIndex = poly.getNeighbors(i)[j];
+        std::int8_t neighborIndex = poly.getNeighbors(i)[j];
 
         int neighborOrientation = plane.getOrientation(poly[neighborIndex], eps);
 
@@ -357,7 +357,7 @@ AXOM_HOST_DEVICE void poly_clip_reindex(Polyhedron<T, NDIMS>& poly,
                                         const unsigned int clipped)
 {
   // Dictionary for old indices to new indices positions
-  axom::int8 newIndices[Polyhedron<T, NDIMS>::MAX_VERTS] = {0};
+  std::int8_t newIndices[Polyhedron<T, NDIMS>::MAX_VERTS] = {0};
 
   Polyhedron<T, NDIMS> old_poly;
 

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -227,7 +227,7 @@ inline int isend_using_schema(conduit::Node& node,
   request->m_buffer.set_schema(s_msg_compact);
 
   // set up the message's node using this schema
-  request->m_buffer["schema_len"].set((int64)snd_schema_json.length());
+  request->m_buffer["schema_len"].set((std::int64_t)snd_schema_json.length());
   request->m_buffer["schema"].set(snd_schema_json);
   request->m_buffer["data"].update(node);
 
@@ -298,12 +298,12 @@ inline int recv_using_schema(conduit::Node& node, int src, int tag, MPI_Comm com
                        comm,
                        &status);
 
-  uint8* n_buff_ptr = (uint8*)n_buffer.data_ptr();
+  std::uint8_t* n_buff_ptr = (std::uint8_t*)n_buffer.data_ptr();
 
   conduit::Node n_msg;
   // length of the schema is sent as a 64-bit signed int
   // NOTE: we aren't using this value  ...
-  n_msg["schema_len"].set_external((int64*)n_buff_ptr);
+  n_msg["schema_len"].set_external((std::int64_t*)n_buff_ptr);
   n_buff_ptr += 8;
   // wrap the schema string
   n_msg["schema"].set_external_char8_str((char*)(n_buff_ptr));
@@ -1141,7 +1141,6 @@ public:
   {
     using ExecSpace = typename BVHTreeType::ExecSpaceType;
     using axom::primal::squared_distance;
-    using int32 = axom::int32;
 
     // Note: There is some additional computation the first time this function
     // is called for a query node, even if the local object mesh is empty
@@ -1250,7 +1249,7 @@ public:
           "ComputeClosestPoints",
           axom::for_all<ExecSpace>(
             qPtCount,
-            AXOM_LAMBDA(int32 idx) mutable {
+            AXOM_LAMBDA(std::int32_t idx) mutable {
               PointType qpt = query_pts[idx];
 
               MinCandidate curr_min {};
@@ -1263,8 +1262,8 @@ public:
                 curr_min.rank = query_ranks[idx];
               }
 
-              auto checkMinDist = [&](int32 current_node,
-                                      const int32* leaf_nodes) {
+              auto checkMinDist = [&](std::int32_t current_node,
+                                      const std::int32_t* leaf_nodes) {
                 const int candidate_point_idx = leaf_nodes[current_node];
                 const int candidate_domain_idx =
                   ptDomainIdsView[candidate_point_idx];

--- a/src/axom/quest/MeshTester.cpp
+++ b/src/axom/quest/MeshTester.cpp
@@ -221,7 +221,7 @@ WatertightStatus isSurfaceMeshWatertight(detail::UMesh* surface_mesh)
 void weldTriMeshVertices(detail::UMesh** surface_mesh, double eps)
 {
   // Note: Use 64-bit index to accomodate small values of epsilon
-  using IdxType = axom::int64;
+  using IdxType = std::int64_t;
   using Lattice3 = spin::RectangularLattice<3, double, IdxType>;
   using GridCell = Lattice3::GridCell;
 

--- a/src/axom/quest/ScatteredInterpolation.hpp
+++ b/src/axom/quest/ScatteredInterpolation.hpp
@@ -249,7 +249,7 @@ public:
   using CoordType = typename PointType::CoordType;
 
 private:
-  using MortonIndexType = axom::uint64;
+  using MortonIndexType = std::uint64_t;
 
   using VertexSet = typename DelaunayTriangulation::IAMeshType::VertexSet;
   using VertexIndirectionSet =
@@ -316,7 +316,7 @@ private:
 
     // We use a Morton index, quantized over the mesh bounding box to
     // order the points on each level
-    using QuantizedCoordType = axom::uint32;
+    using QuantizedCoordType = std::uint32_t;
     using MortonizerType =
       spin::Mortonizer<QuantizedCoordType, MortonIndexType, DIM>;
 

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -576,7 +576,8 @@ inline void SignedDistance<NDIMS, ExecSpace>::computeDistances(
 
         MinCandidate curr_min {};
 
-        auto searchMinDist = [&](std::int32_t current_node, const std::int32_t* leaf_nodes) {
+        auto searchMinDist = [&](std::int32_t current_node,
+                                 const std::int32_t* leaf_nodes) {
           int candidate_idx = leaf_nodes[current_node];
 
           checkCandidate(qpt,

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -571,12 +571,12 @@ inline void SignedDistance<NDIMS, ExecSpace>::computeDistances(
     "ComputeDistances",
     for_all<ExecSpace>(
       npts,
-      AXOM_LAMBDA(int32 idx) {
+      AXOM_LAMBDA(std::int32_t idx) {
         PointType qpt = queryPts[idx];
 
         MinCandidate curr_min {};
 
-        auto searchMinDist = [&](int32 current_node, const int32* leaf_nodes) {
+        auto searchMinDist = [&](std::int32_t current_node, const std::int32_t* leaf_nodes) {
           int candidate_idx = leaf_nodes[current_node];
 
           checkCandidate(qpt,

--- a/src/axom/quest/readers/STLReader.cpp
+++ b/src/axom/quest/readers/STLReader.cpp
@@ -59,15 +59,15 @@ bool STLReader::isAsciiFormat() const
 
   // Find out the file size
   ifs.seekg(0, ifs.end);
-  axom::int32 fileSize = static_cast<axom::int32>(ifs.tellg());
+  std::int32_t fileSize = static_cast<std::int32_t>(ifs.tellg());
 
-  const int totalHeaderSize = (BINARY_HEADER_SIZE + sizeof(axom::int32));
+  const int totalHeaderSize = (BINARY_HEADER_SIZE + sizeof(std::int32_t));
   if(fileSize < totalHeaderSize) return true;
 
   // Find the number of triangles (if the file were binary)
   int numTris = 0;
   ifs.seekg(BINARY_HEADER_SIZE, ifs.beg);
-  ifs.read((char*)&numTris, sizeof(axom::int32));
+  ifs.read((char*)&numTris, sizeof(std::int32_t));
 
   if(!utilities::isLittleEndian())
   {
@@ -132,13 +132,13 @@ int STLReader::readBinarySTL()
   // A local union data structure for triangles in a binary STL
   union BinarySTLTri
   {
-    axom::int8 raw[BINARY_TRI_SIZE];
+    std::int8_t raw[BINARY_TRI_SIZE];
 
     struct
     {
       float normal[3];
       float vert[9];
-      axom::uint16 attr;
+      std::uint16_t attr;
     } data;
 
   } tri;
@@ -156,7 +156,7 @@ int STLReader::readBinarySTL()
   ifs.seekg(BINARY_HEADER_SIZE);
 
   // read the num faces and reserve room for the vertex positions
-  ifs.read((char*)&m_num_faces, sizeof(axom::int32));
+  ifs.read((char*)&m_num_faces, sizeof(std::int32_t));
 
   if(!isLittleEndian)
   {

--- a/src/axom/sidre/core/Buffer.cpp
+++ b/src/axom/sidre/core/Buffer.cpp
@@ -140,7 +140,7 @@ Buffer* Buffer::reallocate(IndexType num_elems)
   dtype.set_number_of_elements(num_elems);
   IndexType new_size = dtype.strided_bytes();
   void* new_data_ptr =
-    axom::reallocate(static_cast<axom::uint8*>(old_data_ptr), new_size);
+    axom::reallocate(static_cast<std::uint8_t*>(old_data_ptr), new_size);
 
   if(num_elems == 0 || new_data_ptr != nullptr)
   {
@@ -409,7 +409,7 @@ void Buffer::detachFromAllViews()
 void* Buffer::allocateBytes(IndexType num_bytes, int allocID)
 {
   allocID = getValidAllocatorID(allocID);
-  return axom::allocate<axom::int8>(num_bytes, allocID);
+  return axom::allocate<std::int8_t>(num_bytes, allocID);
 }
 
 /*
@@ -422,7 +422,7 @@ void* Buffer::allocateBytes(IndexType num_bytes, int allocID)
 void Buffer::releaseBytes(void* ptr)
 {
   // Pointer type here should always match new call in allocateBytes.
-  axom::int8* ptr_copy = static_cast<axom::int8*>(ptr);
+  std::int8_t* ptr_copy = static_cast<std::int8_t*>(ptr);
   axom::deallocate(ptr_copy);
 }
 

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -1778,7 +1778,7 @@ void MFEMSidreDataCollection::AssociateSpeciesSet(
   m_specset_associations[species_field_name] = specset_name;
   Group* specset_grp = m_bp_grp->createGroup("specsets/" + specset_name);
   specset_grp->createViewScalar("volume_dependent",
-                                static_cast<int8>(volume_dependent));
+                                static_cast<std::int8_t>(volume_dependent));
   // Since we're creating the species set, associate it with a material set
   specset_grp->createViewString("matset", matset_name);
 }

--- a/src/axom/sidre/core/SidreTypes.hpp
+++ b/src/axom/sidre/core/SidreTypes.hpp
@@ -116,43 +116,43 @@ struct SidreTT
 };
 
 template <>
-struct SidreTT<axom::int8>
+struct SidreTT<std::int8_t>
 {
   static const DataTypeId id = INT8_ID;
 };
 template <>
-struct SidreTT<axom::int16>
+struct SidreTT<std::int16_t>
 {
   static const DataTypeId id = INT16_ID;
 };
 template <>
-struct SidreTT<axom::int32>
+struct SidreTT<std::int32_t>
 {
   static const DataTypeId id = INT32_ID;
 };
 template <>
-struct SidreTT<axom::int64>
+struct SidreTT<std::int64_t>
 {
   static const DataTypeId id = INT64_ID;
 };
 
 template <>
-struct SidreTT<axom::uint8>
+struct SidreTT<std::uint8_t>
 {
   static const DataTypeId id = UINT8_ID;
 };
 template <>
-struct SidreTT<axom::uint16>
+struct SidreTT<std::uint16_t>
 {
   static const DataTypeId id = UINT16_ID;
 };
 template <>
-struct SidreTT<axom::uint32>
+struct SidreTT<std::uint32_t>
 {
   static const DataTypeId id = UINT32_ID;
 };
 template <>
-struct SidreTT<axom::uint64>
+struct SidreTT<std::uint64_t>
 {
   static const DataTypeId id = UINT64_ID;
 };

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -469,7 +469,7 @@ TEST(sidre_datacollection, create_specset)
   EXPECT_TRUE(bp_grp->hasGroup("specsets"));
   EXPECT_TRUE(bp_grp->hasGroup("specsets/specset"));
   EXPECT_TRUE(bp_grp->hasView("specsets/specset/volume_dependent"));
-  EXPECT_FALSE(static_cast<axom::int8>(
+  EXPECT_FALSE(static_cast<std::int8_t>(
     bp_grp->getView("specsets/specset/volume_dependent")->getScalar()));
   EXPECT_TRUE(bp_grp->hasView("specsets/specset/matset"));
   EXPECT_EQ(std::string(bp_grp->getView("specsets/specset/matset")->getString()),
@@ -523,7 +523,7 @@ TEST(sidre_datacollection, create_specset_multi_fraction)
   EXPECT_TRUE(bp_grp->hasGroup("specsets"));
   EXPECT_TRUE(bp_grp->hasGroup("specsets/specset"));
   EXPECT_TRUE(bp_grp->hasView("specsets/specset/volume_dependent"));
-  EXPECT_FALSE(static_cast<axom::int8>(
+  EXPECT_FALSE(static_cast<std::int8_t>(
     bp_grp->getView("specsets/specset/volume_dependent")->getScalar()));
   EXPECT_TRUE(bp_grp->hasView("specsets/specset/matset"));
   EXPECT_EQ(std::string(bp_grp->getView("specsets/specset/matset")->getString()),

--- a/src/axom/sidre/tests/sidre_native_layout.cpp
+++ b/src/axom/sidre/tests/sidre_native_layout.cpp
@@ -515,7 +515,7 @@ TEST(sidre_native_layout, basic_demo_compare)
   // we use int64 and float64 b/c those types persist even with
   // json or yaml output
 
-  axom::int64 sidre_vals_1[5] = {0, 1, 2, 3, 4};
+  std::int64_t sidre_vals_1[5] = {0, 1, 2, 3, 4};
   axom::float64 sidre_vals_2[6] = {
     1.0,
     2.0,
@@ -540,7 +540,7 @@ TEST(sidre_native_layout, basic_demo_compare)
   View* a5_view =
     group3->createViewAndAllocate("a5_i64", axom::sidre::DataType::int64(5));
 
-  axom::int64* a5_view_ptr = a5_view->getData();
+  std::int64_t* a5_view_ptr = a5_view->getData();
 
   for(int i = 0; i < 5; i++)
   {
@@ -613,7 +613,7 @@ TEST(sidre_native_layout, basic_demo_compare)
   // create an equiv conduit tree for testing
   //
 
-  axom::int64 conduit_vals_1[5] = {0, 1, 2, 3, 4};
+  std::int64_t conduit_vals_1[5] = {0, 1, 2, 3, 4};
   axom::float64 conduit_vals_2[6] = {
     1.0,
     2.0,

--- a/src/axom/sidre/tests/sidre_types_C.cpp
+++ b/src/axom/sidre/tests/sidre_types_C.cpp
@@ -49,18 +49,18 @@ void testTypesForEquality()
 //------------------------------------------------------------------------------
 TEST(sidre_types, compare_common_types)
 {
-  testTypesForEquality<axom::int8, conduit_int8>();
-  testTypesForEquality<axom::uint8, conduit_uint8>();
+  testTypesForEquality<std::int8_t, conduit_int8>();
+  testTypesForEquality<std::uint8_t, conduit_uint8>();
 
-  testTypesForEquality<axom::int16, conduit_int16>();
-  testTypesForEquality<axom::uint16, conduit_uint16>();
+  testTypesForEquality<std::int16_t, conduit_int16>();
+  testTypesForEquality<std::uint16_t, conduit_uint16>();
 
-  testTypesForEquality<axom::int32, conduit_int32>();
-  testTypesForEquality<axom::uint32, conduit_uint32>();
+  testTypesForEquality<std::int32_t, conduit_int32>();
+  testTypesForEquality<std::uint32_t, conduit_uint32>();
 
 #ifndef AXOM_NO_INT64_T
-  testTypesForEquality<axom::int64, conduit_int64>();
-  testTypesForEquality<axom::uint64, conduit_uint64>();
+  testTypesForEquality<std::int64_t, conduit_int64>();
+  testTypesForEquality<std::uint64_t, conduit_uint64>();
 #endif
 
   testTypesForEquality<axom::float32, conduit_float32>();

--- a/src/axom/sidre/tests/sidre_view.cpp
+++ b/src/axom/sidre/tests/sidre_view.cpp
@@ -1182,18 +1182,18 @@ TEST(sidre_view, view_offset_and_stride)
 
   typedef std::vector<View*> ViewVec;
   ViewVec views;
-  axom::uint8 ui8 = 3;
-  axom::uint16 ui16 = 4;
-  axom::uint32 ui32 = 5;
+  std::uint8_t ui8 = 3;
+  std::uint16_t ui16 = 4;
+  std::uint32_t ui32 = 5;
 #ifndef AXOM_NO_INT46_T
-  axom::uint64 ui64 = 6;
+  std::uint64_t ui64 = 6;
 #endif
 
-  axom::int8 i8 = -3;
-  axom::int16 i16 = -4;
-  axom::int32 i32 = -5;
+  std::int8_t i8 = -3;
+  std::int16_t i16 = -4;
+  std::int32_t i32 = -5;
 #ifndef AXOM_NO_INT46_T
-  axom::int64 i64 = -6;
+  std::int64_t i64 = -6;
 #endif
 
   axom::float32 f32 = 7.7f;

--- a/src/axom/sidre/tests/spio/spio_parallel.hpp
+++ b/src/axom/sidre/tests/spio/spio_parallel.hpp
@@ -993,7 +993,7 @@ TEST(spio_parallel, sidre_simple_blueprint_example)
   n_mesh["fields/rank/values"].set(conduit::DataType::int64(4));
 
   // fill rank field values
-  axom::int64* rank_vals_ptr = n_mesh["fields/rank/values"].value();
+  std::int64_t* rank_vals_ptr = n_mesh["fields/rank/values"].value();
 
   for(int i = 0; i < 4; i++)
   {

--- a/src/axom/sidre/tests/spio/spio_serial.hpp
+++ b/src/axom/sidre/tests/spio/spio_serial.hpp
@@ -6,7 +6,7 @@
 #include "gtest/gtest.h"
 
 #include "axom/config.hpp"      // for AXOM_USE_HDF5
-#include "axom/core/Types.hpp"  // for common::int64
+#include "axom/core/Types.hpp"  // for common::std::int64_t
 #include "axom/sidre.hpp"
 #include <list>
 
@@ -16,7 +16,7 @@ using axom::sidre::DataStore;
 using axom::sidre::Group;
 using axom::sidre::IOManager;
 
-using axom::int64;
+using std::int64_t;
 
 //------------------------------------------------------------------------------
 
@@ -33,8 +33,8 @@ TEST(spio_serial, basic_writeread)
   Group* gb = flds2->createGroup("b");
 
   // Note: use 64-bit integers since that is the native type for json
-  ga->createViewScalar<int64>("i0", 101);
-  gb->createViewScalar<int64>("i1", 404);
+  ga->createViewScalar<std::int64_t>("i0", 101);
+  gb->createViewScalar<std::int64_t>("i1", 404);
 
   int num_files = 1;
   IOManager writer(MPI_COMM_WORLD);
@@ -51,9 +51,9 @@ TEST(spio_serial, basic_writeread)
 
   EXPECT_TRUE(ds2->getRoot()->isEquivalentTo(root1));
 
-  int64 testvalue1 =
+  std::int64_t testvalue1 =
     ds1->getRoot()->getGroup("fields")->getGroup("a")->getView("i0")->getData();
-  int64 testvalue2 =
+  std::int64_t testvalue2 =
     ds2->getRoot()->getGroup("fields")->getGroup("a")->getView("i0")->getData();
 
   EXPECT_EQ(testvalue1, testvalue2);
@@ -100,8 +100,8 @@ TEST(spio_serial, basic_writeread_protocols)
     Group* gb = flds2->createGroup("b");
 
     // Note: use 64-bit integers since that is the native type for json
-    ga->createViewScalar<int64>("i0", 101);
-    gb->createViewScalar<int64>("i1", 404);
+    ga->createViewScalar<std::int64_t>("i0", 101);
+    gb->createViewScalar<std::int64_t>("i1", 404);
 
     int num_files = 1;
     IOManager writer(MPI_COMM_WORLD);
@@ -118,9 +118,9 @@ TEST(spio_serial, basic_writeread_protocols)
 
     EXPECT_TRUE(ds2->getRoot()->isEquivalentTo(root1));
 
-    int64 testvalue1 =
+    std::int64_t testvalue1 =
       ds1->getRoot()->getGroup("fields")->getGroup("a")->getView("i0")->getData();
-    int64 testvalue2 =
+    std::int64_t testvalue2 =
       ds2->getRoot()->getGroup("fields")->getGroup("a")->getView("i0")->getData();
 
     EXPECT_EQ(testvalue1, testvalue2);

--- a/src/axom/slam/BitSet.hpp
+++ b/src/axom/slam/BitSet.hpp
@@ -114,7 +114,7 @@ class BitSet
 {
 public:
   using Index = int;
-  using Word = axom::uint64;
+  using Word = std::uint64_t;
 
   // TODO: update using a policy
   using ArrayType = axom::Array<Word, 1>;

--- a/src/axom/slam/tests/slam_set_IndirectionSet.cpp
+++ b/src/axom/slam/tests/slam_set_IndirectionSet.cpp
@@ -165,10 +165,10 @@ bool compareData(axom::ArrayView<ElemType> a, axom::ArrayView<ElemType> b)
 
 // Tests several types of indirection sets
 using MyTypes =
-  ::testing::Types<slam::CArrayIndirectionSet<axom::int32, axom::int64>,
-                   slam::VectorIndirectionSet<axom::int32, axom::int64>,
-                   slam::ArrayIndirectionSet<axom::int32, axom::int64>,
-                   slam::ArrayViewIndirectionSet<axom::int32, axom::int64>>;
+  ::testing::Types<slam::CArrayIndirectionSet<std::int32_t, std::int64_t>,
+                   slam::VectorIndirectionSet<std::int32_t, std::int64_t>,
+                   slam::ArrayIndirectionSet<std::int32_t, std::int64_t>,
+                   slam::ArrayViewIndirectionSet<std::int32_t, std::int64_t>>;
 
 TYPED_TEST_SUITE(IndirectionSetTester, MyTypes);
 

--- a/src/axom/spin/MortonIndex.hpp
+++ b/src/axom/spin/MortonIndex.hpp
@@ -43,7 +43,7 @@ struct NumReps
 };
 
 template <>
-struct NumReps<axom::int64>
+struct NumReps<std::int64_t>
 {
   enum
   {
@@ -51,7 +51,7 @@ struct NumReps<axom::int64>
   };
 };
 template <>
-struct NumReps<axom::uint64>
+struct NumReps<std::uint64_t>
 {
   enum
   {
@@ -60,7 +60,7 @@ struct NumReps<axom::uint64>
 };
 
 template <>
-struct NumReps<axom::int32>
+struct NumReps<std::int32_t>
 {
   enum
   {
@@ -68,7 +68,7 @@ struct NumReps<axom::int32>
   };
 };
 template <>
-struct NumReps<axom::uint32>
+struct NumReps<std::uint32_t>
 {
   enum
   {
@@ -77,7 +77,7 @@ struct NumReps<axom::uint32>
 };
 
 template <>
-struct NumReps<axom::int16>
+struct NumReps<std::int16_t>
 {
   enum
   {
@@ -85,7 +85,7 @@ struct NumReps<axom::int16>
   };
 };
 template <>
-struct NumReps<axom::uint16>
+struct NumReps<std::uint16_t>
 {
   enum
   {
@@ -94,7 +94,7 @@ struct NumReps<axom::uint16>
 };
 
 template <>
-struct NumReps<axom::int8>
+struct NumReps<std::int8_t>
 {
   enum
   {
@@ -102,7 +102,7 @@ struct NumReps<axom::int8>
   };
 };
 template <>
-struct NumReps<axom::uint8>
+struct NumReps<std::uint8_t>
 {
   enum
   {

--- a/src/axom/spin/OctreeBase.hpp
+++ b/src/axom/spin/OctreeBase.hpp
@@ -431,10 +431,10 @@ private:
     MAX_SPARSE64_LEV = 64 / DIM
   };
 
-  using DenseOctLevType = DenseOctreeLevel<DIM, BlockDataType, axom::uint16>;
-  using Sparse16OctLevType = SparseOctreeLevel<DIM, BlockDataType, axom::uint16>;
-  using Sparse32OctLevType = SparseOctreeLevel<DIM, BlockDataType, axom::uint32>;
-  using Sparse64OctLevType = SparseOctreeLevel<DIM, BlockDataType, axom::uint64>;
+  using DenseOctLevType = DenseOctreeLevel<DIM, BlockDataType, std::uint16_t>;
+  using Sparse16OctLevType = SparseOctreeLevel<DIM, BlockDataType, std::uint16_t>;
+  using Sparse32OctLevType = SparseOctreeLevel<DIM, BlockDataType, std::uint32_t>;
+  using Sparse64OctLevType = SparseOctreeLevel<DIM, BlockDataType, std::uint64_t>;
   using SparsePtOctLevType = SparseOctreeLevel<DIM, BlockDataType, GridPt>;
 
   using DenseOctLevPtr = DenseOctLevType*;

--- a/src/axom/spin/examples/spin_bvh_two_pass.cpp
+++ b/src/axom/spin/examples/spin_bvh_two_pass.cpp
@@ -177,8 +177,8 @@ void find_collisions_broadphase(const mint::Mesh* mesh,
       // Define a function that is called on every leaf node reached during
       // traversal. The function below simply counts the number of candidate
       // collisions with the given query object.
-      auto countCollisions = [&](axom::int32 currentNode,
-                                 const axom::int32* leafNodes) {
+      auto countCollisions = [&](std::int32_t currentNode,
+                                 const std::int32_t* leafNodes) {
         AXOM_UNUSED_VAR(leafNodes);
         if(currentNode > icell)
         {
@@ -219,8 +219,8 @@ void find_collisions_broadphase(const mint::Mesh* mesh,
       IndexType offset = v_offsets[icell];
 
       // Define a leaf node function that stores the intersection candidate.
-      auto fillCollisions = [&](axom::int32 currentNode,
-                                const axom::int32* leafs) {
+      auto fillCollisions = [&](std::int32_t currentNode,
+                                const std::int32_t* leafs) {
         if(currentNode > icell)
         {
           v_first_pair[offset] = icell;

--- a/src/axom/spin/internal/linear_bvh/RadixTree.hpp
+++ b/src/axom/spin/internal/linear_bvh/RadixTree.hpp
@@ -32,36 +32,36 @@ struct RadixTree
 {
   using BoxType = primal::BoundingBox<FloatType, NDIMS>;
 
-  int32 m_size;
-  int32 m_inner_size;
+  std::int32_t m_size;
+  std::int32_t m_inner_size;
 
-  axom::Array<int32> m_left_children;
-  axom::Array<int32> m_right_children;
-  axom::Array<int32> m_parents;
+  axom::Array<std::int32_t> m_left_children;
+  axom::Array<std::int32_t> m_right_children;
+  axom::Array<std::int32_t> m_parents;
   axom::Array<BoxType> m_inner_aabbs;
 
-  axom::Array<int32> m_leafs;
-  axom::Array<uint32> m_mcodes;
+  axom::Array<std::int32_t> m_leafs;
+  axom::Array<std::uint32_t> m_mcodes;
   axom::Array<BoxType> m_leaf_aabbs;
 
-  void allocate(int32 size, int allocID)
+  void allocate(std::int32_t size, int allocID)
   {
     AXOM_PERF_MARK_FUNCTION("RadixTree::allocate");
 
     m_size = size;
     m_inner_size = m_size - 1;
-    int32 parent_size = m_size + m_inner_size;
+    std::int32_t parent_size = m_size + m_inner_size;
 
-    m_left_children = axom::Array<int32>(m_inner_size, m_inner_size, allocID);
-    m_right_children = axom::Array<int32>(m_inner_size, m_inner_size, allocID);
-    m_parents = axom::Array<int32>(parent_size, parent_size, allocID);
+    m_left_children = axom::Array<std::int32_t>(m_inner_size, m_inner_size, allocID);
+    m_right_children = axom::Array<std::int32_t>(m_inner_size, m_inner_size, allocID);
+    m_parents = axom::Array<std::int32_t>(parent_size, parent_size, allocID);
     m_inner_aabbs = axom::Array<BoxType>(ArrayOptions::Uninitialized {},
                                          m_inner_size,
                                          m_inner_size,
                                          allocID);
 
-    m_leafs = axom::Array<int32>(m_size, m_size, allocID);
-    m_mcodes = axom::Array<uint32>(m_size, m_size, allocID);
+    m_leafs = axom::Array<std::int32_t>(m_size, m_size, allocID);
+    m_mcodes = axom::Array<std::uint32_t>(m_size, m_size, allocID);
     m_leaf_aabbs =
       axom::Array<BoxType>(ArrayOptions::Uninitialized {}, m_size, m_size, allocID);
   }

--- a/src/axom/spin/internal/linear_bvh/RadixTree.hpp
+++ b/src/axom/spin/internal/linear_bvh/RadixTree.hpp
@@ -52,8 +52,10 @@ struct RadixTree
     m_inner_size = m_size - 1;
     std::int32_t parent_size = m_size + m_inner_size;
 
-    m_left_children = axom::Array<std::int32_t>(m_inner_size, m_inner_size, allocID);
-    m_right_children = axom::Array<std::int32_t>(m_inner_size, m_inner_size, allocID);
+    m_left_children =
+      axom::Array<std::int32_t>(m_inner_size, m_inner_size, allocID);
+    m_right_children =
+      axom::Array<std::int32_t>(m_inner_size, m_inner_size, allocID);
     m_parents = axom::Array<std::int32_t>(parent_size, parent_size, allocID);
     m_inner_aabbs = axom::Array<BoxType>(ArrayOptions::Uninitialized {},
                                          m_inner_size,

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -72,8 +72,8 @@ static inline AXOM_HOST_DEVICE std::int32_t morton32_encode(
 //Returns 30 bit morton code for coordinates for
 //coordinates in the unit cude
 static inline AXOM_HOST_DEVICE std::int64_t morton64_encode(axom::float32 x,
-                                                           axom::float32 y,
-                                                           axom::float32 z = 0.0)
+                                                            axom::float32 y,
+                                                            axom::float32 z = 0.0)
 {
   //take the first 21 bits. Note, 2^21= 2097152.0f
   x = fmin(fmax(x * 2097152.0f, 0.0f), 2097151.0f);
@@ -81,7 +81,9 @@ static inline AXOM_HOST_DEVICE std::int64_t morton64_encode(axom::float32 x,
   z = fmin(fmax(z * 2097152.0f, 0.0f), 2097151.0f);
 
   primal::Point<std::int64_t, 3> integer_pt =
-    primal::Point<std::int64_t, 3>::make_point((std::int64_t)x, (std::int64_t)y, (std::int64_t)z);
+    primal::Point<std::int64_t, 3>::make_point((std::int64_t)x,
+                                               (std::int64_t)y,
+                                               (std::int64_t)z);
 
   return convertPointToMorton<std::int64_t>(integer_pt);
 }
@@ -145,7 +147,8 @@ primal::BoundingBox<FloatType, NDIMS> reduce(
 
   primal::BoundingBox<FloatType, NDIMS> global_bounds;
 
-  for_all<ExecSpace>(size, [&](std::int32_t i) { global_bounds.addBox(aabbs[i]); });
+  for_all<ExecSpace>(size,
+                     [&](std::int32_t i) { global_bounds.addBox(aabbs[i]); });
 
   return global_bounds;
 #endif
@@ -236,7 +239,9 @@ void reorder(const ArrayView<const std::int32_t> indices,
    ((RAJA_VERSION_MAJOR == 0) && (RAJA_VERSION_MINOR >= 12)))
 
 template <typename ExecSpace>
-void sort_mcodes(ArrayView<std::uint32_t> mcodes, std::int32_t size, ArrayView<std::int32_t> iter)
+void sort_mcodes(ArrayView<std::uint32_t> mcodes,
+                 std::int32_t size,
+                 ArrayView<std::int32_t> iter)
 {
   AXOM_PERF_MARK_FUNCTION("sort_mcodes");
 
@@ -253,18 +258,21 @@ void sort_mcodes(ArrayView<std::uint32_t> mcodes, std::int32_t size, ArrayView<s
 
 // fall back to std::stable_sort
 template <typename ExecSpace>
-void sort_mcodes(Array<std::uint32_t>& mcodes, std::int32_t size, const ArrayView<std::int32_t> iter)
+void sort_mcodes(Array<std::uint32_t>& mcodes,
+                 std::int32_t size,
+                 const ArrayView<std::int32_t> iter)
 {
   AXOM_PERF_MARK_FUNCTION("sort_mcodes");
 
   array_counting<ExecSpace>(iter, size, 0, 1);
 
-  AXOM_PERF_MARK_SECTION(
-    "cpu_sort",
+  AXOM_PERF_MARK_SECTION("cpu_sort",
 
-    std::stable_sort(iter.begin(),
-                     iter.begin() + size,
-                     [&](std::int32_t i1, std::int32_t i2) { return mcodes[i1] < mcodes[i2]; });
+                         std::stable_sort(iter.begin(),
+                                          iter.begin() + size,
+                                          [&](std::int32_t i1, std::int32_t i2) {
+                                            return mcodes[i1] < mcodes[i2];
+                                          });
 
   );
 
@@ -321,7 +329,7 @@ void build_tree(RadixTree<FloatType, NDIMS>& data)
     AXOM_LAMBDA(std::int32_t i) {
       //determine range direction
       std::int32_t d = 0 > (delta(i, i + 1, inner_size, mcodes_ptr) -
-                           delta(i, i - 1, inner_size, mcodes_ptr))
+                            delta(i, i - 1, inner_size, mcodes_ptr))
         ? -1
         : 1;
 
@@ -552,7 +560,8 @@ void propagate_aabbs(RadixTree<FloatType, NDIMS>& data, int allocatorID)
         // TODO: If RAJA atomics get memory ordering policies in the future,
         // we should look at replacing the sync_load/sync_stores by changing
         // the below atomic to an acquire/release atomic.
-        std::int32_t old = atomic_increment<ExecSpace>(&(counters_ptr[current_node]));
+        std::int32_t old =
+          atomic_increment<ExecSpace>(&(counters_ptr[current_node]));
 
         if(old == 0)
         {

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -48,7 +48,7 @@ namespace linear_bvh
 //Returns 30 bit morton code for coordinates for
 // x, y, and z are expecting to be between [0,1]
 template <typename FloatType, int Dims>
-static inline AXOM_HOST_DEVICE axom::int32 morton32_encode(
+static inline AXOM_HOST_DEVICE std::int32_t morton32_encode(
   const primal::Vector<FloatType, Dims>& point)
 {
   //for a float, take the first 10 bits. Note, 2^10 = 1024
@@ -56,22 +56,22 @@ static inline AXOM_HOST_DEVICE axom::int32 morton32_encode(
   constexpr FloatType FLOAT_TO_INT = 1 << NUM_BITS_PER_DIM;
   constexpr FloatType FLOAT_CEILING = FLOAT_TO_INT - 1;
 
-  int32 int_coords[Dims];
+  std::int32_t int_coords[Dims];
   for(int i = 0; i < Dims; i++)
   {
     int_coords[i] =
       fmin(fmax(point[i] * FLOAT_TO_INT, (FloatType)0), FLOAT_CEILING);
   }
 
-  primal::Point<int32, Dims> integer_pt(int_coords);
+  primal::Point<std::int32_t, Dims> integer_pt(int_coords);
 
-  return convertPointToMorton<int32>(integer_pt);
+  return convertPointToMorton<std::int32_t>(integer_pt);
 }
 
 //------------------------------------------------------------------------------
 //Returns 30 bit morton code for coordinates for
 //coordinates in the unit cude
-static inline AXOM_HOST_DEVICE axom::int64 morton64_encode(axom::float32 x,
+static inline AXOM_HOST_DEVICE std::int64_t morton64_encode(axom::float32 x,
                                                            axom::float32 y,
                                                            axom::float32 z = 0.0)
 {
@@ -80,23 +80,23 @@ static inline AXOM_HOST_DEVICE axom::int64 morton64_encode(axom::float32 x,
   y = fmin(fmax(y * 2097152.0f, 0.0f), 2097151.0f);
   z = fmin(fmax(z * 2097152.0f, 0.0f), 2097151.0f);
 
-  primal::Point<int64, 3> integer_pt =
-    primal::Point<int64, 3>::make_point((int64)x, (int64)y, (int64)z);
+  primal::Point<std::int64_t, 3> integer_pt =
+    primal::Point<std::int64_t, 3>::make_point((std::int64_t)x, (std::int64_t)y, (std::int64_t)z);
 
-  return convertPointToMorton<int64>(integer_pt);
+  return convertPointToMorton<std::int64_t>(integer_pt);
 }
 
 template <typename ExecSpace, typename BoxIndexable, typename FloatType, int NDIMS>
 void transform_boxes(const BoxIndexable boxes,
                      ArrayView<primal::BoundingBox<FloatType, NDIMS>> aabbs,
-                     int32 size,
+                     std::int32_t size,
                      FloatType scale_factor)
 {
   AXOM_PERF_MARK_FUNCTION("transform_boxes");
 
   for_all<ExecSpace>(
     size,
-    AXOM_LAMBDA(int32 i) {
+    AXOM_LAMBDA(std::int32_t i) {
       primal::BoundingBox<FloatType, NDIMS> aabb = boxes[i];
 
       aabb.scale(scale_factor);
@@ -109,7 +109,7 @@ void transform_boxes(const BoxIndexable boxes,
 template <typename ExecSpace, typename FloatType, int NDIMS>
 primal::BoundingBox<FloatType, NDIMS> reduce(
   ArrayView<const primal::BoundingBox<FloatType, NDIMS>> aabbs,
-  int32 size)
+  std::int32_t size)
 {
   AXOM_PERF_MARK_FUNCTION("reduce_abbs");
 
@@ -128,7 +128,7 @@ primal::BoundingBox<FloatType, NDIMS> reduce(
 
     for_all<ExecSpace>(
       size,
-      AXOM_LAMBDA(int32 i) {
+      AXOM_LAMBDA(std::int32_t i) {
         const primal::BoundingBox<FloatType, NDIMS>& aabb = aabbs[i];
         min_coord.min(aabb.getMin()[dim]);
         max_coord.max(aabb.getMax()[dim]);
@@ -145,7 +145,7 @@ primal::BoundingBox<FloatType, NDIMS> reduce(
 
   primal::BoundingBox<FloatType, NDIMS> global_bounds;
 
-  for_all<ExecSpace>(size, [&](int32 i) { global_bounds.addBox(aabbs[i]); });
+  for_all<ExecSpace>(size, [&](std::int32_t i) { global_bounds.addBox(aabbs[i]); });
 
   return global_bounds;
 #endif
@@ -154,9 +154,9 @@ primal::BoundingBox<FloatType, NDIMS> reduce(
 //------------------------------------------------------------------------------
 template <typename ExecSpace, typename FloatType, int NDIMS>
 void get_mcodes(ArrayView<const primal::BoundingBox<FloatType, NDIMS>> aabbs,
-                int32 size,
+                std::int32_t size,
                 const primal::BoundingBox<FloatType, NDIMS>& bounds,
-                const ArrayView<uint32> mcodes)
+                const ArrayView<std::uint32_t> mcodes)
 {
   AXOM_PERF_MARK_FUNCTION("get_mcodes");
 
@@ -175,7 +175,7 @@ void get_mcodes(ArrayView<const primal::BoundingBox<FloatType, NDIMS>> aabbs,
 
   for_all<ExecSpace>(
     size,
-    AXOM_LAMBDA(int32 i) {
+    AXOM_LAMBDA(std::int32_t i) {
       const primal::BoundingBox<FloatType, NDIMS>& aabb = aabbs[i];
 
       // get the center and normalize it
@@ -197,7 +197,7 @@ void array_counting(ArrayView<IntType> iterator,
 
   for_all<ExecSpace>(
     size,
-    AXOM_LAMBDA(int32 i) { iterator[i] = start + i * step; });
+    AXOM_LAMBDA(std::int32_t i) { iterator[i] = start + i * step; });
 }
 
 //------------------------------------------------------------------------------
@@ -208,9 +208,9 @@ void array_counting(ArrayView<IntType> iterator,
 // result  [b,a,c]
 //
 template <typename ExecSpace, typename T>
-void reorder(const ArrayView<const int32> indices,
+void reorder(const ArrayView<const std::int32_t> indices,
              Array<T>& array,
-             int32 size,
+             std::int32_t size,
              int allocatorID)
 {
   AXOM_PERF_MARK_FUNCTION("reorder");
@@ -222,8 +222,8 @@ void reorder(const ArrayView<const int32> indices,
 
   for_all<ExecSpace>(
     size,
-    AXOM_LAMBDA(int32 i) {
-      int32 in_idx = indices[i];
+    AXOM_LAMBDA(std::int32_t i) {
+      std::int32_t in_idx = indices[i];
       temp_v[i] = array_v[in_idx];
     });
 
@@ -236,7 +236,7 @@ void reorder(const ArrayView<const int32> indices,
    ((RAJA_VERSION_MAJOR == 0) && (RAJA_VERSION_MINOR >= 12)))
 
 template <typename ExecSpace>
-void sort_mcodes(ArrayView<uint32> mcodes, int32 size, ArrayView<int32> iter)
+void sort_mcodes(ArrayView<std::uint32_t> mcodes, std::int32_t size, ArrayView<std::int32_t> iter)
 {
   AXOM_PERF_MARK_FUNCTION("sort_mcodes");
 
@@ -253,7 +253,7 @@ void sort_mcodes(ArrayView<uint32> mcodes, int32 size, ArrayView<int32> iter)
 
 // fall back to std::stable_sort
 template <typename ExecSpace>
-void sort_mcodes(Array<uint32>& mcodes, int32 size, const ArrayView<int32> iter)
+void sort_mcodes(Array<std::uint32_t>& mcodes, std::int32_t size, const ArrayView<std::int32_t> iter)
 {
   AXOM_PERF_MARK_FUNCTION("sort_mcodes");
 
@@ -264,7 +264,7 @@ void sort_mcodes(Array<uint32>& mcodes, int32 size, const ArrayView<int32> iter)
 
     std::stable_sort(iter.begin(),
                      iter.begin() + size,
-                     [&](int32 i1, int32 i2) { return mcodes[i1] < mcodes[i2]; });
+                     [&](std::int32_t i1, std::int32_t i2) { return mcodes[i1] < mcodes[i2]; });
 
   );
 
@@ -284,15 +284,15 @@ AXOM_HOST_DEVICE IntType delta(const IntType& a,
   bool tie = false;
   bool out_of_range = (b < 0 || b > inner_size);
   //still make the call but with a valid adderss
-  const int32 bb = (out_of_range) ? 0 : b;
-  const uint32 acode = mcodes[a];
-  const uint32 bcode = mcodes[bb];
+  const std::int32_t bb = (out_of_range) ? 0 : b;
+  const std::uint32_t acode = mcodes[a];
+  const std::uint32_t bcode = mcodes[bb];
   //use xor to find where they differ
-  uint32 exor = acode ^ bcode;
+  std::uint32_t exor = acode ^ bcode;
   tie = (exor == 0);
   //break the tie, a and b must always differ
-  exor = tie ? uint32(a) ^ uint32(bb) : exor;
-  int32 count = axom::utilities::leadingZeros(exor);
+  exor = tie ? std::uint32_t(a) ^ std::uint32_t(bb) : exor;
+  std::int32_t count = axom::utilities::leadingZeros(exor);
   if(tie) count += 32;
   count = (out_of_range) ? -1 : count;
   return count;
@@ -310,7 +310,7 @@ void build_tree(RadixTree<FloatType, NDIMS>& data)
   // of a huge amount of pain and suffering due so cuda
   // lambda captures of pointers inside a struct. Bad memories
   // of random segfaults ........ be warned
-  const int32 inner_size = data.m_inner_size;
+  const std::int32_t inner_size = data.m_inner_size;
   const auto lchildren_ptr = data.m_left_children.view();
   const auto rchildren_ptr = data.m_right_children.view();
   const auto parent_ptr = data.m_parents.view();
@@ -318,22 +318,22 @@ void build_tree(RadixTree<FloatType, NDIMS>& data)
 
   for_all<ExecSpace>(
     inner_size,
-    AXOM_LAMBDA(int32 i) {
+    AXOM_LAMBDA(std::int32_t i) {
       //determine range direction
-      int32 d = 0 > (delta(i, i + 1, inner_size, mcodes_ptr) -
-                     delta(i, i - 1, inner_size, mcodes_ptr))
+      std::int32_t d = 0 > (delta(i, i + 1, inner_size, mcodes_ptr) -
+                           delta(i, i - 1, inner_size, mcodes_ptr))
         ? -1
         : 1;
 
       //find upper bound for the length of the range
-      int32 min_delta = delta(i, i - d, inner_size, mcodes_ptr);
-      int32 lmax = 2;
+      std::int32_t min_delta = delta(i, i - d, inner_size, mcodes_ptr);
+      std::int32_t lmax = 2;
       while(delta(i, i + lmax * d, inner_size, mcodes_ptr) > min_delta)
         lmax *= 2;
 
       //binary search to find the lower bound
-      int32 l = 0;
-      for(int32 t = lmax / 2; t >= 1; t /= 2)
+      std::int32_t l = 0;
+      for(std::int32_t t = lmax / 2; t >= 1; t /= 2)
       {
         if(delta(i, i + (l + t) * d, inner_size, mcodes_ptr) > min_delta)
         {
@@ -341,13 +341,13 @@ void build_tree(RadixTree<FloatType, NDIMS>& data)
         }
       }
 
-      int32 j = i + l * d;
-      int32 delta_node = delta(i, j, inner_size, mcodes_ptr);
-      int32 s = 0;
+      std::int32_t j = i + l * d;
+      std::int32_t delta_node = delta(i, j, inner_size, mcodes_ptr);
+      std::int32_t s = 0;
       FloatType div_factor = 2.f;
       //find the split postition using a binary search
-      for(int32 t = (int32)ceil(float32(l) / div_factor);;
-          div_factor *= 2, t = (int32)ceil(float32(l) / div_factor))
+      for(std::int32_t t = (std::int32_t)ceil(float32(l) / div_factor);;
+          div_factor *= 2, t = (std::int32_t)ceil(float32(l) / div_factor))
       {
         if(delta(i, i + (s + t) * d, inner_size, mcodes_ptr) > delta_node)
         {
@@ -356,7 +356,7 @@ void build_tree(RadixTree<FloatType, NDIMS>& data)
         if(t == 1) break;
       }
 
-      int32 split = i + s * d + utilities::min(d, 0);
+      std::int32_t split = i + s * d + utilities::min(d, 0);
       // assign parent/child pointers
       if(utilities::min(i, j) == split)
       {
@@ -537,22 +537,22 @@ void propagate_aabbs(RadixTree<FloatType, NDIMS>& data, int allocatorID)
     inner_size,
     AXOM_LAMBDA(IndexType idx) { inner_aabb_ptr[idx] = BoxType {}; });
 
-  Array<int32> counters(inner_size, inner_size, allocatorID);
+  Array<std::int32_t> counters(inner_size, inner_size, allocatorID);
   const auto counters_ptr = counters.view();
 
   for_all<ExecSpace>(
     leaf_size,
-    AXOM_LAMBDA(int32 i) {
+    AXOM_LAMBDA(std::int32_t i) {
       BoxType aabb = leaf_aabb_ptr[i];
-      int32 last_node = inner_size + i;
-      int32 current_node = parent_ptr[inner_size + i];
+      std::int32_t last_node = inner_size + i;
+      std::int32_t current_node = parent_ptr[inner_size + i];
 
       while(current_node != -1)
       {
         // TODO: If RAJA atomics get memory ordering policies in the future,
         // we should look at replacing the sync_load/sync_stores by changing
         // the below atomic to an acquire/release atomic.
-        int32 old = atomic_increment<ExecSpace>(&(counters_ptr[current_node]));
+        std::int32_t old = atomic_increment<ExecSpace>(&(counters_ptr[current_node]));
 
         if(old == 0)
         {
@@ -560,10 +560,10 @@ void propagate_aabbs(RadixTree<FloatType, NDIMS>& data, int allocatorID)
           return;
         }
 
-        int32 lchild = lchildren_ptr[current_node];
-        int32 rchild = rchildren_ptr[current_node];
+        std::int32_t lchild = lchildren_ptr[current_node];
+        std::int32_t rchild = rchildren_ptr[current_node];
 
-        int32 other_child = (lchild == last_node) ? rchild : lchild;
+        std::int32_t other_child = (lchild == last_node) ? rchild : lchild;
 
         primal::BoundingBox<FloatType, NDIMS> other_aabb;
         if(other_child >= inner_size)

--- a/src/axom/spin/internal/linear_bvh/bvh_traverse.hpp
+++ b/src/axom/spin/internal/linear_bvh/bvh_traverse.hpp
@@ -25,7 +25,7 @@ namespace linear_bvh
  * \return status true if the node is a leaf node, otherwise, false.
  */
 AXOM_HOST_DEVICE
-inline bool leaf_node(const int32& nodeIdx) { return (nodeIdx < 0); }
+inline bool leaf_node(const std::int32_t& nodeIdx) { return (nodeIdx < 0); }
 
 /*!
  * \brief Generic BVH traversal routine.
@@ -71,8 +71,8 @@ template <int NDIMS,
           typename TraversePref>
 AXOM_HOST_DEVICE inline void bvh_traverse(
   axom::ArrayView<const primal::BoundingBox<FloatType, NDIMS>> inner_nodes,
-  axom::ArrayView<const int32> inner_node_children,
-  axom::ArrayView<const int32> leaf_nodes,
+  axom::ArrayView<const std::int32_t> inner_node_children,
+  axom::ArrayView<const std::int32_t> leaf_nodes,
   const PrimitiveType& p,
   InBinCheck&& B,
   LeafAction&& A,
@@ -81,14 +81,14 @@ AXOM_HOST_DEVICE inline void bvh_traverse(
   using BBoxType = primal::BoundingBox<FloatType, NDIMS>;
 
   // setup stack
-  constexpr int32 STACK_SIZE = 64;
-  constexpr int32 BARRIER = -2000000000;
-  int32 todo[STACK_SIZE];
-  int32 stackptr = 0;
+  constexpr std::int32_t STACK_SIZE = 64;
+  constexpr std::int32_t BARRIER = -2000000000;
+  std::int32_t todo[STACK_SIZE];
+  std::int32_t stackptr = 0;
   todo[stackptr] = BARRIER;
 
-  int32 found_leaf = 0;
-  int32 current_node = 0;
+  std::int32_t found_leaf = 0;
+  std::int32_t current_node = 0;
 
   while(current_node != BARRIER)
   {
@@ -99,8 +99,8 @@ AXOM_HOST_DEVICE inline void bvh_traverse(
       BBoxType right_bin = inner_nodes[current_node + 1];
       const bool in_left = left_bin.isValid() ? B(p, left_bin) : false;
       const bool in_right = right_bin.isValid() ? B(p, right_bin) : false;
-      int32 l_child = inner_node_children[current_node + 0];
-      int32 r_child = inner_node_children[current_node + 1];
+      std::int32_t l_child = inner_node_children[current_node + 0];
+      std::int32_t r_child = inner_node_children[current_node + 1];
       bool swap = Comp(left_bin, right_bin, p);
 
       if(!in_left && !in_right)

--- a/src/axom/spin/internal/linear_bvh/bvh_vtkio.hpp
+++ b/src/axom/spin/internal/linear_bvh/bvh_vtkio.hpp
@@ -22,8 +22,8 @@ void write_box2d(const FloatType& xmin,
                  const FloatType& ymin,
                  const FloatType& xmax,
                  const FloatType& ymax,
-                 int32& numPoints,
-                 int32& numBins,
+                 std::int32_t& numPoints,
+                 std::int32_t& numBins,
                  std::ostringstream& nodes,
                  std::ostringstream& cells)
 {
@@ -32,10 +32,10 @@ void write_box2d(const FloatType& xmin,
   nodes << xmax << " " << ymax << " 0.0\n";
   nodes << xmin << " " << ymax << " 0.0\n";
 
-  constexpr int32 NUM_NODES = 4;
-  int32 offset = numPoints;
+  constexpr std::int32_t NUM_NODES = 4;
+  std::int32_t offset = numPoints;
   cells << NUM_NODES << " ";
-  for(int32 i = 0; i < NUM_NODES; ++i)
+  for(std::int32_t i = 0; i < NUM_NODES; ++i)
   {
     cells << (offset + i) << " ";
   }
@@ -53,8 +53,8 @@ void write_box3d(const FloatType& xmin,
                  const FloatType& xmax,
                  const FloatType& ymax,
                  const FloatType& zmax,
-                 int32& numPoints,
-                 int32& numBins,
+                 std::int32_t& numPoints,
+                 std::int32_t& numBins,
                  std::ostringstream& nodes,
                  std::ostringstream& cells)
 {
@@ -68,10 +68,10 @@ void write_box3d(const FloatType& xmin,
   nodes << xmax << " " << ymax << " " << zmax << std::endl;
   nodes << xmin << " " << ymax << " " << zmax << std::endl;
 
-  constexpr int32 NUM_NODES = 8;
-  int32 offset = numPoints;
+  constexpr std::int32_t NUM_NODES = 8;
+  std::int32_t offset = numPoints;
   cells << NUM_NODES << " ";
-  for(int32 i = 0; i < NUM_NODES; ++i)
+  for(std::int32_t i = 0; i < NUM_NODES; ++i)
   {
     cells << (offset + i) << " ";
   }
@@ -84,8 +84,8 @@ void write_box3d(const FloatType& xmin,
 //------------------------------------------------------------------------------
 template <typename FloatType, int NDIMS>
 void write_box(const primal::BoundingBox<FloatType, NDIMS>& box,
-               int32& numPoints,
-               int32& numBins,
+               std::int32_t& numPoints,
+               std::int32_t& numBins,
                std::ostringstream& nodes,
                std::ostringstream& cells)
 {
@@ -111,8 +111,8 @@ void write_box(const primal::BoundingBox<FloatType, NDIMS>& box,
 //------------------------------------------------------------------------------
 template <typename FloatType>
 void write_root(const primal::BoundingBox<FloatType, 2>& root,
-                int32& numPoints,
-                int32& numBins,
+                std::int32_t& numPoints,
+                std::int32_t& numBins,
                 std::ostringstream& nodes,
                 std::ostringstream& cells,
                 std::ostringstream& levels)
@@ -131,8 +131,8 @@ void write_root(const primal::BoundingBox<FloatType, 2>& root,
 //------------------------------------------------------------------------------
 template <typename FloatType>
 void write_root(const primal::BoundingBox<FloatType, 3>& root,
-                int32& numPoints,
-                int32& numBins,
+                std::int32_t& numPoints,
+                std::int32_t& numBins,
                 std::ostringstream& nodes,
                 std::ostringstream& cells,
                 std::ostringstream& levels)
@@ -153,11 +153,11 @@ void write_root(const primal::BoundingBox<FloatType, 3>& root,
 //------------------------------------------------------------------------------
 template <typename FloatType, int NDIMS>
 void write_recursive(ArrayView<const primal::BoundingBox<FloatType, NDIMS>> inner_nodes,
-                     ArrayView<const int32> inner_node_children,
-                     int32 current_node,
-                     int32 level,
-                     int32& numPoints,
-                     int32& numBins,
+                     ArrayView<const std::int32_t> inner_node_children,
+                     std::int32_t current_node,
+                     std::int32_t level,
+                     std::int32_t& numPoints,
+                     std::int32_t& numBins,
                      std::ostringstream& nodes,
                      std::ostringstream& cells,
                      std::ostringstream& levels)
@@ -167,8 +167,8 @@ void write_recursive(ArrayView<const primal::BoundingBox<FloatType, NDIMS>> inne
   primal::BoundingBox<FloatType, NDIMS> r_box = inner_nodes[current_node + 1];
 
   // STEP 1: extract children information
-  int32 l_child = inner_node_children[current_node + 0];
-  int32 r_child = inner_node_children[current_node + 1];
+  std::int32_t l_child = inner_node_children[current_node + 0];
+  std::int32_t r_child = inner_node_children[current_node + 1];
 
   write_box<FloatType, NDIMS>(l_box, numPoints, numBins, nodes, cells);
   levels << level << std::endl;

--- a/src/axom/spin/policy/LinearBVH.hpp
+++ b/src/axom/spin/policy/LinearBVH.hpp
@@ -339,9 +339,8 @@ axom::Array<IndexType> LinearBVH<FloatType, NDIMS, ExecSpace>::findCandidatesImp
         PrimitiveType primitive {objs[i]};
 
         auto leafAction = [&count](std::int32_t AXOM_UNUSED_PARAM(current_node),
-                                   const std::int32_t* AXOM_UNUSED_PARAM(leaf_nodes)) {
-          count++;
-        };
+                                   const std::int32_t* AXOM_UNUSED_PARAM(
+                                     leaf_nodes)) { count++; };
 
         lbvh::bvh_traverse(inner_nodes,
                            inner_node_children,

--- a/src/axom/spin/policy/LinearBVH.hpp
+++ b/src/axom/spin/policy/LinearBVH.hpp
@@ -62,8 +62,8 @@ public:
   using PointType = primal::Point<FloatType, NDIMS>;
 
   LinearBVHTraverser(axom::ArrayView<const BoxType> bboxes,
-                     axom::ArrayView<const int32> inner_node_children,
-                     axom::ArrayView<const int32> leaf_nodes)
+                     axom::ArrayView<const std::int32_t> inner_node_children,
+                     axom::ArrayView<const std::int32_t> leaf_nodes)
     : m_inner_nodes(bboxes)
     , m_inner_node_children(inner_node_children)
     , m_leaf_nodes(leaf_nodes)
@@ -121,8 +121,8 @@ public:
 
 private:
   axom::ArrayView<const BoxType> m_inner_nodes;  // BVH bins including leafs
-  axom::ArrayView<const int32> m_inner_node_children;
-  axom::ArrayView<const int32> m_leaf_nodes;  // leaf data
+  axom::ArrayView<const std::int32_t> m_inner_node_children;
+  axom::ArrayView<const std::int32_t> m_leaf_nodes;  // leaf data
 };
 
 /*!
@@ -190,7 +190,7 @@ public:
   }
 
 private:
-  void allocate(int32 size, int allocID)
+  void allocate(std::int32_t size, int allocID)
   {
     AXOM_PERF_MARK_FUNCTION("LinearBVH::allocate");
     IndexType numInnerNodes = (size - 1) * 2;
@@ -202,14 +202,14 @@ private:
                                    numInnerNodes,
                                    allocID);
     m_inner_node_children =
-      axom::Array<int32>(numInnerNodes, numInnerNodes, allocID);
-    m_leaf_nodes = axom::Array<int32>(size, size, allocID);
+      axom::Array<std::int32_t>(numInnerNodes, numInnerNodes, allocID);
+    m_leaf_nodes = axom::Array<std::int32_t>(size, size, allocID);
   }
 
   bool m_initialized {false};
   axom::Array<BoundingBoxType> m_inner_nodes;  // BVH bins including leafs
-  axom::Array<int32> m_inner_node_children;
-  axom::Array<int32> m_leaf_nodes;  // leaf data
+  axom::Array<std::int32_t> m_inner_node_children;
+  axom::Array<std::int32_t> m_leaf_nodes;  // leaf data
   primal::BoundingBox<FloatType, NDIMS> m_bounds;
 };
 
@@ -238,9 +238,9 @@ void LinearBVH<FloatType, NDIMS, ExecSpace>::buildImpl(const BoxIndexable boxes,
   allocate(numBoxes, allocatorID);
 
   // STEP 3: emit the BVH
-  const int32 size = radix_tree.m_size;
+  const std::int32_t size = radix_tree.m_size;
   AXOM_UNUSED_VAR(size);
-  const int32 inner_size = radix_tree.m_inner_size;
+  const std::int32_t inner_size = radix_tree.m_inner_size;
   SLIC_ASSERT(inner_size == size - 1);
 
   const auto lchildren_ptr = radix_tree.m_left_children.view();
@@ -255,10 +255,10 @@ void LinearBVH<FloatType, NDIMS, ExecSpace>::buildImpl(const BoxIndexable boxes,
   AXOM_PERF_MARK_SECTION("emit_bvh_parents",
                          for_all<ExecSpace>(
                            inner_size,
-                           AXOM_LAMBDA(int32 node) {
+                           AXOM_LAMBDA(std::int32_t node) {
                              BoundingBoxType l_aabb, r_aabb;
 
-                             int32 lchild = lchildren_ptr[node];
+                             std::int32_t lchild = lchildren_ptr[node];
                              if(lchild >= inner_size)
                              {
                                l_aabb = leaf_aabb_ptr[lchild - inner_size];
@@ -271,7 +271,7 @@ void LinearBVH<FloatType, NDIMS, ExecSpace>::buildImpl(const BoxIndexable boxes,
                                lchild *= 2;
                              }
 
-                             int32 rchild = rchildren_ptr[node];
+                             std::int32_t rchild = rchildren_ptr[node];
                              if(rchild >= inner_size)
                              {
                                r_aabb = leaf_aabb_ptr[rchild - inner_size];
@@ -284,7 +284,7 @@ void LinearBVH<FloatType, NDIMS, ExecSpace>::buildImpl(const BoxIndexable boxes,
                                rchild *= 2;
                              }
 
-                             const int32 out_offset = node * 2;
+                             const std::int32_t out_offset = node * 2;
                              bvh_inner_nodes[out_offset + 0] = l_aabb;
                              bvh_inner_nodes[out_offset + 1] = r_aabb;
 
@@ -335,11 +335,11 @@ axom::Array<IndexType> LinearBVH<FloatType, NDIMS, ExecSpace>::findCandidatesImp
     for_all<ExecSpace>(
       numObjs,
       AXOM_LAMBDA(IndexType i) {
-        int32 count = 0;
+        std::int32_t count = 0;
         PrimitiveType primitive {objs[i]};
 
-        auto leafAction = [&count](int32 AXOM_UNUSED_PARAM(current_node),
-                                   const int32* AXOM_UNUSED_PARAM(leaf_nodes)) {
+        auto leafAction = [&count](std::int32_t AXOM_UNUSED_PARAM(current_node),
+                                   const std::int32_t* AXOM_UNUSED_PARAM(leaf_nodes)) {
           count++;
         };
 
@@ -379,12 +379,12 @@ axom::Array<IndexType> LinearBVH<FloatType, NDIMS, ExecSpace>::findCandidatesImp
                          for_all<ExecSpace>(
                            numObjs,
                            AXOM_LAMBDA(IndexType i) {
-                             int32 offset = offsets[i];
+                             std::int32_t offset = offsets[i];
 
                              PrimitiveType obj {objs[i]};
                              auto leafAction = [&offset, candidates_v](
-                                                 int32 current_node,
-                                                 const int32* leafs) {
+                                                 std::int32_t current_node,
+                                                 const std::int32_t* leafs) {
                                candidates_v[offset] = leafs[current_node];
                                offset++;
                              };
@@ -411,7 +411,7 @@ axom::Array<IndexType> LinearBVH<FloatType, NDIMS, ExecSpace>::findCandidatesImp
       PrimitiveType obj {objs[i]};
       offsets[i] = current_offset;
 
-      auto leafAction = [&](int32 current_node, const int32* leafs) {
+      auto leafAction = [&](std::int32_t current_node, const std::int32_t* leafs) {
         search_candidates.emplace_back(leafs[current_node]);
         matching_leaves++;
         current_offset++;
@@ -450,12 +450,12 @@ void LinearBVH<FloatType, NDIMS, ExecSpace>::writeVtkFileImpl(
   ofs << "DATASET UNSTRUCTURED_GRID\n";
 
   // STEP 1: write root
-  int32 numPoints = 0;
-  int32 numBins = 0;
+  std::int32_t numPoints = 0;
+  std::int32_t numBins = 0;
   lbvh::write_root(m_bounds, numPoints, numBins, nodes, cells, levels);
 
   // STEP 2: traverse the BVH and dump each bin
-  constexpr int32 ROOT = 0;
+  constexpr std::int32_t ROOT = 0;
   lbvh::write_recursive<FloatType, NDIMS>(m_inner_nodes,
                                           m_inner_node_children,
                                           ROOT,
@@ -471,14 +471,14 @@ void LinearBVH<FloatType, NDIMS, ExecSpace>::writeVtkFileImpl(
   ofs << nodes.str() << std::endl;
 
   // STEP 4: write cells
-  const int32 nnodes = (NDIMS == 2) ? 4 : 8;
+  const std::int32_t nnodes = (NDIMS == 2) ? 4 : 8;
   ofs << "CELLS " << numBins << " " << numBins * (nnodes + 1) << std::endl;
   ofs << cells.str() << std::endl;
 
   // STEP 5: write cell types
   ofs << "CELL_TYPES " << numBins << std::endl;
-  const int32 cellType = (NDIMS == 2) ? 9 : 12;
-  for(int32 i = 0; i < numBins; ++i)
+  const std::int32_t cellType = (NDIMS == 2) ? 9 : 12;
+  for(std::int32_t i = 0; i < numBins; ++i)
   {
     ofs << cellType << std::endl;
   }

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -1398,13 +1398,13 @@ void bvh_compute_point_distances_2d(BVHType& bvh,
   npts = query_pts.size();
   axom::for_all<ExecSpace>(
     npts,
-    AXOM_LAMBDA(axom::int32 idx) mutable {
+    AXOM_LAMBDA(std::int32_t idx) mutable {
       // Get the current query point.
       auto qpt = query_pts_view[idx];
       MinCandidate curr_min;
 
-      auto checkMinDist = [&](axom::int32 current_node,
-                              const axom::int32* leaf_nodes) {
+      auto checkMinDist = [&](std::int32_t current_node,
+                              const std::int32_t* leaf_nodes) {
         int candidate_idx = leaf_nodes[current_node];
         const PointType candidate_pt = pointsView[candidate_idx];
         const double sq_dist = squared_distance(qpt, candidate_pt);

--- a/src/axom/spin/tests/spin_morton.cpp
+++ b/src/axom/spin/tests/spin_morton.cpp
@@ -164,55 +164,55 @@ template <int DIM>
 void testIntegralTypes()
 {
   SLIC_INFO("Testing char in " << DIM << "d -- ");
-  testMortonizer<axom::int8, axom::uint8, DIM>();
-  testMortonizer<axom::int8, axom::uint16, DIM>();
-  testMortonizer<axom::int8, axom::uint32, DIM>();
-  testMortonizer<axom::int8, axom::uint64, DIM>();
+  testMortonizer<std::int8_t, std::uint8_t, DIM>();
+  testMortonizer<std::int8_t, std::uint16_t, DIM>();
+  testMortonizer<std::int8_t, std::uint32_t, DIM>();
+  testMortonizer<std::int8_t, std::uint64_t, DIM>();
 
   SLIC_INFO("Testing uchar in " << DIM << "d -- ");
-  testMortonizer<axom::uint8, axom::uint8, DIM>();
-  testMortonizer<axom::uint8, axom::uint16, DIM>();
-  testMortonizer<axom::uint8, axom::uint32, DIM>();
-  testMortonizer<axom::uint8, axom::uint64, DIM>();
+  testMortonizer<std::uint8_t, std::uint8_t, DIM>();
+  testMortonizer<std::uint8_t, std::uint16_t, DIM>();
+  testMortonizer<std::uint8_t, std::uint32_t, DIM>();
+  testMortonizer<std::uint8_t, std::uint64_t, DIM>();
 
   // --
   SLIC_INFO("Testing short in " << DIM << "d -- ");
-  testMortonizer<axom::int16, axom::uint8, DIM>();
-  testMortonizer<axom::int16, axom::uint16, DIM>();
-  testMortonizer<axom::int16, axom::uint32, DIM>();
-  testMortonizer<axom::int16, axom::uint64, DIM>();
+  testMortonizer<std::int16_t, std::uint8_t, DIM>();
+  testMortonizer<std::int16_t, std::uint16_t, DIM>();
+  testMortonizer<std::int16_t, std::uint32_t, DIM>();
+  testMortonizer<std::int16_t, std::uint64_t, DIM>();
 
   SLIC_INFO("Testing ushort in " << DIM << "d -- ");
-  testMortonizer<axom::uint16, axom::uint8, DIM>();
-  testMortonizer<axom::uint16, axom::uint16, DIM>();
-  testMortonizer<axom::uint16, axom::uint32, DIM>();
-  testMortonizer<axom::uint16, axom::uint64, DIM>();
+  testMortonizer<std::uint16_t, std::uint8_t, DIM>();
+  testMortonizer<std::uint16_t, std::uint16_t, DIM>();
+  testMortonizer<std::uint16_t, std::uint32_t, DIM>();
+  testMortonizer<std::uint16_t, std::uint64_t, DIM>();
 
   // --
   SLIC_INFO("Testing int in " << DIM << "d -- ");
-  testMortonizer<axom::int32, axom::uint8, DIM>();
-  testMortonizer<axom::int32, axom::uint16, DIM>();
-  testMortonizer<axom::int32, axom::uint32, DIM>();
-  testMortonizer<axom::int32, axom::uint64, DIM>();
+  testMortonizer<std::int32_t, std::uint8_t, DIM>();
+  testMortonizer<std::int32_t, std::uint16_t, DIM>();
+  testMortonizer<std::int32_t, std::uint32_t, DIM>();
+  testMortonizer<std::int32_t, std::uint64_t, DIM>();
 
   SLIC_INFO("Testing uint in " << DIM << "d -- ");
-  testMortonizer<axom::uint32, axom::uint8, DIM>();
-  testMortonizer<axom::uint32, axom::uint16, DIM>();
-  testMortonizer<axom::uint32, axom::uint32, DIM>();
-  testMortonizer<axom::uint32, axom::uint64, DIM>();
+  testMortonizer<std::uint32_t, std::uint8_t, DIM>();
+  testMortonizer<std::uint32_t, std::uint16_t, DIM>();
+  testMortonizer<std::uint32_t, std::uint32_t, DIM>();
+  testMortonizer<std::uint32_t, std::uint64_t, DIM>();
 
   // --
   SLIC_INFO("Testing long long in " << DIM << "d -- ");
-  testMortonizer<axom::int64, axom::uint8, DIM>();
-  testMortonizer<axom::int64, axom::uint16, DIM>();
-  testMortonizer<axom::int64, axom::uint32, DIM>();
-  testMortonizer<axom::int64, axom::uint64, DIM>();
+  testMortonizer<std::int64_t, std::uint8_t, DIM>();
+  testMortonizer<std::int64_t, std::uint16_t, DIM>();
+  testMortonizer<std::int64_t, std::uint32_t, DIM>();
+  testMortonizer<std::int64_t, std::uint64_t, DIM>();
 
   SLIC_INFO("Testing ull in " << DIM << "d -- ");
-  testMortonizer<axom::uint64, axom::uint8, DIM>();
-  testMortonizer<axom::uint64, axom::uint16, DIM>();
-  testMortonizer<axom::uint64, axom::uint32, DIM>();
-  testMortonizer<axom::uint64, axom::uint64, DIM>();
+  testMortonizer<std::uint64_t, std::uint8_t, DIM>();
+  testMortonizer<std::uint64_t, std::uint16_t, DIM>();
+  testMortonizer<std::uint64_t, std::uint32_t, DIM>();
+  testMortonizer<std::uint64_t, std::uint64_t, DIM>();
 }
 
 TEST(spin_morton, test_integral_types_2D)

--- a/src/tools/convert_sidre_protocol.cpp
+++ b/src/tools/convert_sidre_protocol.cpp
@@ -264,28 +264,28 @@ void modifyFinalValues(sidre::View* view, int origSize)
   switch(view->getTypeID())
   {
   case sidre::INT8_ID:
-    modifyFinalValuesImpl<axom::int8>(view, origSize);
+    modifyFinalValuesImpl<std::int8_t>(view, origSize);
     break;
   case sidre::INT16_ID:
-    modifyFinalValuesImpl<axom::int16>(view, origSize);
+    modifyFinalValuesImpl<std::int16_t>(view, origSize);
     break;
   case sidre::INT32_ID:
-    modifyFinalValuesImpl<axom::int32>(view, origSize);
+    modifyFinalValuesImpl<std::int32_t>(view, origSize);
     break;
   case sidre::INT64_ID:
-    modifyFinalValuesImpl<axom::int64>(view, origSize);
+    modifyFinalValuesImpl<std::int64_t>(view, origSize);
     break;
   case sidre::UINT8_ID:
-    modifyFinalValuesImpl<axom::uint8>(view, origSize);
+    modifyFinalValuesImpl<std::uint8_t>(view, origSize);
     break;
   case sidre::UINT16_ID:
-    modifyFinalValuesImpl<axom::uint16>(view, origSize);
+    modifyFinalValuesImpl<std::uint16_t>(view, origSize);
     break;
   case sidre::UINT32_ID:
-    modifyFinalValuesImpl<axom::uint32>(view, origSize);
+    modifyFinalValuesImpl<std::uint32_t>(view, origSize);
     break;
   case sidre::UINT64_ID:
-    modifyFinalValuesImpl<axom::uint64>(view, origSize);
+    modifyFinalValuesImpl<std::uint64_t>(view, origSize);
     break;
   case sidre::FLOAT32_ID:
     modifyFinalValuesImpl<axom::float32>(view, origSize);


### PR DESCRIPTION
# Deprecate axom integer types

- This PR is a code deprecation.
- It does the following (modify list as needed):
  - Adds the cmake `AXOM_DEPRECATED_TYPES` variable to allow staged removal of the deprecated types.
  - Guards the `axom::int*` types from `Types.hpp`, depending on the value of `AXOM_DEPRECATED_TYPES`.
  - Replaced all Axom use of the deprecated types with equivalent c++11 types.

`AXOM_DEPRECATED_TYPES` admits 3 values:
1. `ERROR` The deprecated types are removed and any use results in a compile error.  This is the eventual behavior.
2. `WARN` The deprecated types are supported, but with a deprecation warning.  This is the current default and is meant to motivate users to update their codes.
3. `ALLOW` The deprecated types are quietly allowed.

In a future date, we should set the default to `ERROR` and eventually remove the obsolete code and the `AXOM_DEPRECATED_TYPES` logic.

This PR resolves issue https://github.com/LLNL/axom/issues/223