### PR TITLE
Task/sidre data info

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -37,6 +37,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   intersection between a primitive and a `Tetrahedron`
 - Primal: Adds a `primal::Polyhedron::from_primitive()` operator that returns a
   `Polyhedron` object from a given primitive.
+- Adds `DataStore::getBufferInfo()` and `Group::getDataInfo` methods that insert information into a conduit Node about buffers in a datastore object or data in a group subtree. The information can be accessed from the Node by the caller from specifically named fields in the Node.
 
 
 ### Changed

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -37,7 +37,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   intersection between a primitive and a `Tetrahedron`
 - Primal: Adds a `primal::Polyhedron::from_primitive()` operator that returns a
   `Polyhedron` object from a given primitive.
-- Adds `DataStore::getBufferInfo()` and `Group::getDataInfo` methods that insert information into a conduit Node about buffers in a datastore object or data in a group subtree. The information can be accessed from the Node by the caller from specifically named fields in the Node.
+- Adds `DataStore::getBufferInfo()` and `Group::getDataInfo` methods that insert information into a Conduit `Node` about buffers in a `DataStore` object or data in a `Group` subtree. The information can be accessed from the `Node` by the caller from specifically named fields in the `Node`.
 
 
 ### Changed

--- a/src/axom/sidre/core/DataStore.cpp
+++ b/src/axom/sidre/core/DataStore.cpp
@@ -283,7 +283,7 @@ void DataStore::getBufferInfo(Node& n) const
 #else
   IndexType num_buffers = getNumBuffers();
   IndexType num_buffers_referenced = getNumReferencedBuffers();
-  IndexType num_bytes_allocated = getTotalAllocatedBytesInBuffers(); 
+  IndexType num_bytes_allocated = getTotalAllocatedBytesInBuffers();
 #endif
 
   n["num_buffers"] = num_buffers;

--- a/src/axom/sidre/core/DataStore.cpp
+++ b/src/axom/sidre/core/DataStore.cpp
@@ -191,17 +191,12 @@ IndexType DataStore::getNumReferencedBuffers() const
 {
   IndexType num_buffers_referenced = 0;
 
-  IndexType bidx = getFirstValidBufferIndex();
-  while(indexIsValid(bidx))
+  for(const auto& buf : buffers())
   {
-    Buffer* buf = getBuffer(bidx);
-
-    if(buf->getNumViews() > 0)
+    if(buf.getNumViews() > 0)
     {
       num_buffers_referenced++;
     }
-
-    bidx = getNextValidBufferIndex(bidx);
   }
 
   return num_buffers_referenced;
@@ -218,17 +213,12 @@ IndexType DataStore::getTotalAllocatedBytesInBuffers() const
 {
   IndexType num_bytes_allocated = 0;
 
-  IndexType bidx = getFirstValidBufferIndex();
-  while(indexIsValid(bidx))
+  for(const auto& buf : buffers())
   {
-    Buffer* buf = getBuffer(bidx);
-
-    if(buf->isAllocated())
+    if(buf.isAllocated())
     {
-      num_bytes_allocated += buf->getTotalBytes();
+      num_bytes_allocated += buf.getTotalBytes();
     }
-
-    bidx = getNextValidBufferIndex(bidx);
   }
 
   return num_bytes_allocated;

--- a/src/axom/sidre/core/DataStore.cpp
+++ b/src/axom/sidre/core/DataStore.cpp
@@ -170,13 +170,68 @@ void DataStore::setConduitDefaultMessageHandlers()
 /*
  *************************************************************************
  *
- * Return number of Buffers in the DataStore *
+ * Return number of Buffers in the DataStore
  *
  *************************************************************************
  */
 IndexType DataStore::getNumBuffers() const
 {
   return m_buffer_coll->getNumItems();
+}
+
+/*
+ *************************************************************************
+ *
+ * Return number of Buffers in the DataStore that are referenced 
+ * by at least one View
+ *
+ *************************************************************************
+ */
+IndexType DataStore::getNumReferencedBuffers() const
+{
+  IndexType num_buffers_referenced = 0;
+
+  IndexType bidx = getFirstValidBufferIndex();
+  while(indexIsValid(bidx))
+  {
+    Buffer* buf = getBuffer(bidx);
+
+    if(buf->getNumViews() > 0)
+    {
+      num_buffers_referenced++;
+    }
+
+    bidx = getNextValidBufferIndex(bidx);
+  }
+
+  return num_buffers_referenced;
+}
+
+/*
+ *************************************************************************
+ *
+ * Return total bytes allocated in Buffers in the DataStore
+ *
+ *************************************************************************
+ */
+IndexType DataStore::getTotalAllocatedBytesInBuffers() const
+{
+  IndexType num_bytes_allocated = 0;
+
+  IndexType bidx = getFirstValidBufferIndex();
+  while(indexIsValid(bidx))
+  {
+    Buffer* buf = getBuffer(bidx);
+
+    if(buf->isAllocated())
+    {
+      num_bytes_allocated += buf->getTotalBytes();
+    }
+
+    bidx = getNextValidBufferIndex(bidx);
+  }
+
+  return num_bytes_allocated;
 }
 
 /*
@@ -194,13 +249,14 @@ bool DataStore::hasBuffer(IndexType idx) const
 /*
  *************************************************************************
  *
- * Return information about DataStore Buffers in fields of given
+ * Insert information about DataStore Buffers in fields of given
  * Conduit Node.
  *
  *************************************************************************
  */
 void DataStore::getBufferInfo(Node& n) const
 {
+#if 0
   IndexType num_buffers = 0;
   IndexType num_buffers_referenced = 0;
   IndexType num_bytes_allocated = 0;
@@ -224,6 +280,11 @@ void DataStore::getBufferInfo(Node& n) const
 
     bidx = getNextValidBufferIndex(bidx);
   }
+#else
+  IndexType num_buffers = getNumBuffers();
+  IndexType num_buffers_referenced = getNumReferencedBuffers();
+  IndexType num_bytes_allocated = getTotalAllocatedBytesInBuffers(); 
+#endif
 
   n["num_buffers"] = num_buffers;
   n["num_buffers_referenced"] = num_buffers_referenced;

--- a/src/axom/sidre/core/DataStore.cpp
+++ b/src/axom/sidre/core/DataStore.cpp
@@ -203,7 +203,7 @@ void DataStore::getBufferInfo(Node& n) const
 {
   IndexType num_buffers = 0;
   IndexType num_buffers_referenced = 0;
-  IndexType num_bytes_allocated = 0; 
+  IndexType num_bytes_allocated = 0;
 
   IndexType bidx = getFirstValidBufferIndex();
   while(indexIsValid(bidx))
@@ -212,12 +212,12 @@ void DataStore::getBufferInfo(Node& n) const
 
     num_buffers++;
 
-    if (buf->getNumViews() > 0)
+    if(buf->getNumViews() > 0)
     {
       num_buffers_referenced++;
     }
 
-    if (buf->isAllocated())
+    if(buf->isAllocated())
     {
       num_bytes_allocated += buf->getTotalBytes();
     }

--- a/src/axom/sidre/core/DataStore.cpp
+++ b/src/axom/sidre/core/DataStore.cpp
@@ -256,35 +256,9 @@ bool DataStore::hasBuffer(IndexType idx) const
  */
 void DataStore::getBufferInfo(Node& n) const
 {
-#if 0
-  IndexType num_buffers = 0;
-  IndexType num_buffers_referenced = 0;
-  IndexType num_bytes_allocated = 0;
-
-  IndexType bidx = getFirstValidBufferIndex();
-  while(indexIsValid(bidx))
-  {
-    Buffer* buf = getBuffer(bidx);
-
-    num_buffers++;
-
-    if(buf->getNumViews() > 0)
-    {
-      num_buffers_referenced++;
-    }
-
-    if(buf->isAllocated())
-    {
-      num_bytes_allocated += buf->getTotalBytes();
-    }
-
-    bidx = getNextValidBufferIndex(bidx);
-  }
-#else
   IndexType num_buffers = getNumBuffers();
   IndexType num_buffers_referenced = getNumReferencedBuffers();
   IndexType num_bytes_allocated = getTotalAllocatedBytesInBuffers();
-#endif
 
   n["num_buffers"] = num_buffers;
   n["num_buffers_referenced"] = num_buffers_referenced;

--- a/src/axom/sidre/core/DataStore.cpp
+++ b/src/axom/sidre/core/DataStore.cpp
@@ -194,6 +194,46 @@ bool DataStore::hasBuffer(IndexType idx) const
 /*
  *************************************************************************
  *
+ * Return information about DataStore Buffers in fields of given
+ * Conduit Node.
+ *
+ *************************************************************************
+ */
+void DataStore::getBufferInfo(Node& n) const
+{
+  IndexType num_buffers = 0;
+  IndexType num_buffers_referenced = 0;
+  IndexType num_bytes_allocated = 0; 
+
+  IndexType bidx = getFirstValidBufferIndex();
+  while(indexIsValid(bidx))
+  {
+    Buffer* buf = getBuffer(bidx);
+
+    num_buffers++;
+
+    if (buf->getNumViews() > 0)
+    {
+      num_buffers_referenced++;
+    }
+
+    if (buf->isAllocated())
+    {
+      num_bytes_allocated += buf->getTotalBytes();
+    }
+
+    bidx = getNextValidBufferIndex(bidx);
+  }
+
+  n["num_buffers"] = num_buffers;
+  n["num_buffers_referenced"] = num_buffers_referenced;
+  n["num_buffers_detached"] = num_buffers - num_buffers_referenced;
+  n["num_bytes_allocated"] = num_bytes_allocated;
+}
+
+/*
+ *************************************************************************
+ *
  * Return non-const pointer to Buffer with given index or null ptr.
  *
  *************************************************************************

--- a/src/axom/sidre/core/DataStore.hpp
+++ b/src/axom/sidre/core/DataStore.hpp
@@ -99,6 +99,28 @@ public:
   bool hasBuffer(IndexType idx) const;
 
   /*!
+   * \brief Return information about DataStore Buffers in fields of given
+   *        Conduit Node.
+   *
+   *        Fields in Conduit Node will be named:
+   * 
+   *          - "num_buffers" : number of Buffer objects owned by DataStore
+   *          - "num_buffers_referenced" : number of Buffers with View attached
+   *          - "num_buffers_detached" : number of Buffers with no View attached
+   *          - "num_bytes_allocated" : total number of allocated bytes over
+   *                                    all buffers
+   *
+   * Numeric values associated with these fields may be accessed as type 
+   * axom::IndexType, which is defined at compile-time. For example,
+   *
+   * Node n;
+   * datastore->getBufferInfo(n);
+   * axom::IndexType num_buffers = n.value("num_buffers");
+   * // etc...
+   */
+  void getBufferInfo(Node& n) const;
+
+  /*!
    * \brief Return (non-const) pointer to Buffer object with the given
    *        index, or nullptr if none exists.
    */

--- a/src/axom/sidre/core/DataStore.hpp
+++ b/src/axom/sidre/core/DataStore.hpp
@@ -95,11 +95,20 @@ public:
   /// \brief Return number of Buffers in the DataStore.
   IndexType getNumBuffers() const;
 
+  /*!
+   *  \brief Return number of Buffers in the DataStore that are referenced 
+   *         by at least one View. 
+   */
+  IndexType getNumReferencedBuffers() const;
+
+  /// \brief Return total bytes allocated in Buffers in the DataStore.
+  IndexType getTotalAllocatedBytesInBuffers() const;
+
   /// \brief Return true if DataStore owns a Buffer with given index; else false
   bool hasBuffer(IndexType idx) const;
 
   /*!
-   * \brief Return information about DataStore Buffers in fields of given
+   * \brief Insert information about DataStore Buffers in fields of given
    *        Conduit Node.
    *
    *        Fields in Conduit Node will be named:

--- a/src/axom/sidre/core/DataStore.hpp
+++ b/src/axom/sidre/core/DataStore.hpp
@@ -115,7 +115,7 @@ public:
    *
    * Node n;
    * datastore->getBufferInfo(n);
-   * axom::IndexType num_buffers = n.value("num_buffers");
+   * axom::IndexType num_buffers = n["num_buffers"].value();
    * // etc...
    */
   void getBufferInfo(Node& n) const;

--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -107,7 +107,7 @@ std::string Group::getPath() const
 /*
  *************************************************************************
  *
- * Return information about data associated with Group subtree with this 
+ * Insert information about data associated with Group subtree with this 
  * Group at root of tree (default 'recursive' is true), or for this Group 
  * only ('recursive' is false) in fields of given Conduit Node.
  *
@@ -125,7 +125,7 @@ void Group::getDataInfo(Node& n, bool recursive) const
   IndexType num_views_external = 0;
   IndexType num_views_scalar = 0;
   IndexType num_views_string = 0;
-  IndexType num_bytes_allocated = 0;
+  IndexType num_bytes_assoc_with_views = 0;
   IndexType num_bytes_external = 0;
 
   n["num_groups"] = num_groups;
@@ -135,7 +135,7 @@ void Group::getDataInfo(Node& n, bool recursive) const
   n["num_views_external"] = num_views_external;
   n["num_views_scalar"] = num_views_scalar;
   n["num_views_string"] = num_views_string;
-  n["num_bytes_allocated"] = num_bytes_allocated;
+  n["num_bytes_assoc_with_views"] = num_bytes_assoc_with_views;
   n["num_bytes_external"] = num_bytes_external;
 
   getDataInfoHelper(n, recursive);
@@ -160,10 +160,12 @@ void Group::getDataInfoHelper(Node& n, bool recursive) const
   IndexType num_views_external = n["num_views_external"].value();
   IndexType num_views_scalar = n["num_views_scalar"].value();
   IndexType num_views_string = n["num_views_string"].value();
-  IndexType num_bytes_allocated = n["num_bytes_allocated"].value();
+  IndexType num_bytes_assoc_with_views = 
+    n["num_bytes_assoc_with_views"].value();
   IndexType num_bytes_external = n["num_bytes_external"].value();
 
   num_groups += 1;  // count this group
+  num_views += getNumViews();
 
   //
   // Gather info from Views owned by this Group
@@ -173,8 +175,6 @@ void Group::getDataInfoHelper(Node& n, bool recursive) const
   {
     const View* view = getView(vidx);
 
-    num_views += 1;
-
     if(view->isExternal())
     {
       num_views_external += 1;
@@ -183,19 +183,19 @@ void Group::getDataInfoHelper(Node& n, bool recursive) const
     else if(view->isScalar())
     {
       num_views_scalar += 1;
-      num_bytes_allocated += view->getTotalBytes();
+      num_bytes_assoc_with_views += view->getTotalBytes();
     }
     else if(view->isString())
     {
       num_views_string += 1;
-      num_bytes_allocated += view->getTotalBytes();
+      num_bytes_assoc_with_views += view->getTotalBytes();
     }
     else if(view->hasBuffer())
     {
       num_views_buffer += 1;
       if(view->isAllocated())
       {
-        num_bytes_allocated += view->getTotalBytes();
+        num_bytes_assoc_with_views += view->getTotalBytes();
       }
     }
     else
@@ -216,7 +216,7 @@ void Group::getDataInfoHelper(Node& n, bool recursive) const
   n["num_views_external"] = num_views_external;
   n["num_views_scalar"] = num_views_scalar;
   n["num_views_string"] = num_views_string;
-  n["num_bytes_allocated"] = num_bytes_allocated;
+  n["num_bytes_assoc_with_views"] = num_bytes_assoc_with_views;
   n["num_bytes_external"] = num_bytes_external;
 
   //

--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -169,41 +169,36 @@ void Group::getDataInfoHelper(Node& n, bool recursive) const
   //
   // Gather info from Views owned by this Group
   //
-  IndexType vidx = getFirstValidViewIndex();
-  while(indexIsValid(vidx))
+  for(auto& view : views())
   {
-    const View* view = getView(vidx);
-
-    if(view->isExternal())
+    if(view.isExternal())
     {
       num_views_external += 1;
-      num_bytes_external += view->getTotalBytes();
+      num_bytes_external += view.getTotalBytes();
     }
-    else if(view->isScalar())
+    else if(view.isScalar())
     {
       num_views_scalar += 1;
-      num_bytes_assoc_with_views += view->getTotalBytes();
+      num_bytes_assoc_with_views += view.getTotalBytes();
     }
-    else if(view->isString())
+    else if(view.isString())
     {
       num_views_string += 1;
-      num_bytes_assoc_with_views += view->getTotalBytes();
+      num_bytes_assoc_with_views += view.getTotalBytes();
     }
-    else if(view->hasBuffer())
+    else if(view.hasBuffer())
     {
       num_views_buffer += 1;
-      if(view->isAllocated())
+      if(view.isAllocated())
       {
-        num_bytes_assoc_with_views += view->getTotalBytes();
+        num_bytes_assoc_with_views += view.getTotalBytes();
       }
     }
     else
     {
       num_views_empty += 1;
     }
-
-    vidx = getNextValidViewIndex(vidx);
-  }
+  } 
 
   //
   // Update Node entries with data info for this Group
@@ -223,12 +218,9 @@ void Group::getDataInfoHelper(Node& n, bool recursive) const
   //
   if(recursive)
   {
-    IndexType gidx = getFirstValidGroupIndex();
-    while(indexIsValid(gidx))
+    for(auto& group : groups())
     {
-      this->getGroup(gidx)->getDataInfoHelper(n, recursive);
-
-      gidx = getNextValidGroupIndex(gidx);
+      group.getDataInfoHelper(n, recursive);
     }
   }
 }

--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -117,7 +117,7 @@ void Group::getDataInfo(Node& n, bool recursive) const
 {
   //
   // Initialize Node fields
-  // 
+  //
   IndexType num_groups = 0;
   IndexType num_views = 0;
   IndexType num_views_empty = 0;
@@ -163,7 +163,7 @@ void Group::getDataInfoHelper(Node& n, bool recursive) const
   IndexType num_bytes_allocated = n["num_bytes_allocated"].value();
   IndexType num_bytes_external = n["num_bytes_external"].value();
 
-  num_groups += 1;   // count this group
+  num_groups += 1;  // count this group
 
   //
   // Gather info from Views owned by this Group
@@ -175,31 +175,31 @@ void Group::getDataInfoHelper(Node& n, bool recursive) const
 
     num_views += 1;
 
-    if ( view->isExternal() )
+    if(view->isExternal())
     {
       num_views_external += 1;
-      num_bytes_external += view->getTotalBytes(); 
-    } 
-    else if ( view->isScalar() )
+      num_bytes_external += view->getTotalBytes();
+    }
+    else if(view->isScalar())
     {
       num_views_scalar += 1;
-      num_bytes_allocated += view->getTotalBytes(); 
-    } 
-    else if ( view->isString() )
+      num_bytes_allocated += view->getTotalBytes();
+    }
+    else if(view->isString())
     {
       num_views_string += 1;
-      num_bytes_allocated += view->getTotalBytes(); 
-    } 
-    else if ( view->hasBuffer() )
+      num_bytes_allocated += view->getTotalBytes();
+    }
+    else if(view->hasBuffer())
     {
-       num_views_buffer += 1;
-       if ( view->isAllocated() )
-       {
-         num_bytes_allocated += view->getTotalBytes(); 
-       }
-    } 
+      num_views_buffer += 1;
+      if(view->isAllocated())
+      {
+        num_bytes_allocated += view->getTotalBytes();
+      }
+    }
     else
-    { 
+    {
       num_views_empty += 1;
     }
 
@@ -222,15 +222,15 @@ void Group::getDataInfoHelper(Node& n, bool recursive) const
   //
   // Recursively gather info for Group subtree, if requested
   //
-  if ( recursive ) 
+  if(recursive)
   {
     IndexType gidx = getFirstValidGroupIndex();
     while(indexIsValid(gidx))
     {
-       this->getGroup(gidx)->getDataInfoHelper(n, recursive);
+      this->getGroup(gidx)->getDataInfoHelper(n, recursive);
 
-       gidx = getNextValidGroupIndex(gidx);
-    } 
+      gidx = getNextValidGroupIndex(gidx);
+    }
   }
 }
 

--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -138,17 +138,17 @@ void Group::getDataInfo(Node& n, bool recursive) const
   n["num_bytes_assoc_with_views"] = num_bytes_assoc_with_views;
   n["num_bytes_external"] = num_bytes_external;
 
-  std::set<IndexType> buffer_ids; 
+  std::set<IndexType> buffer_ids;
 
   getDataInfoHelper(n, buffer_ids, recursive);
 
   const DataStore* ds = getDataStore();
   IndexType num_bytes_in_buffers = 0;
-  for (auto it = buffer_ids.begin(); it != buffer_ids.end(); ++it)
+  for(auto it = buffer_ids.begin(); it != buffer_ids.end(); ++it)
   {
     num_bytes_in_buffers += ds->getBuffer(*it)->getTotalBytes();
   }
-  n["num_bytes_in_buffers"] = num_bytes_in_buffers; 
+  n["num_bytes_in_buffers"] = num_bytes_in_buffers;
 }
 
 /*
@@ -158,7 +158,8 @@ void Group::getDataInfo(Node& n, bool recursive) const
  *
  *************************************************************************
  */
-void Group::getDataInfoHelper(Node& n, std::set<IndexType>& buffer_ids,
+void Group::getDataInfoHelper(Node& n,
+                              std::set<IndexType>& buffer_ids,
                               bool recursive) const
 {
   //

--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -198,7 +198,7 @@ void Group::getDataInfoHelper(Node& n, bool recursive) const
     {
       num_views_empty += 1;
     }
-  } 
+  }
 
   //
   // Update Node entries with data info for this Group

--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -160,8 +160,7 @@ void Group::getDataInfoHelper(Node& n, bool recursive) const
   IndexType num_views_external = n["num_views_external"].value();
   IndexType num_views_scalar = n["num_views_scalar"].value();
   IndexType num_views_string = n["num_views_string"].value();
-  IndexType num_bytes_assoc_with_views = 
-    n["num_bytes_assoc_with_views"].value();
+  IndexType num_bytes_assoc_with_views = n["num_bytes_assoc_with_views"].value();
   IndexType num_bytes_external = n["num_bytes_external"].value();
 
   num_groups += 1;  // count this group

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -282,6 +282,47 @@ public:
   }
 #endif
 
+  /*!
+   * \brief Return information about data associated with Group subtree with
+   *        this Group at root of tree (default 'recursive' is true), or for 
+   *        this Group only ('recursive' is false) in fields of given 
+   *        Conduit Node.
+   *
+   *        Fields in Conduit Node will be named:
+   *
+   *          - "num_groups" : total number of Groups in subtree or single Group
+   *          - "num_views" : total number of Views in subtree or single Group
+   *          - "num_views_nodata" : total number of Views with no associated
+   *                                 Buffer or data 
+   *                                 (may or may not be described)
+   *          - "num_views_buffer" : total number of Views associated
+   *                                 with a DataStore Buffer 
+   *          - "num_views_external" : total number of Views associated with
+   *                                   external data 
+   *          - "num_views_scalar" : total number of Views associated with
+   *                                 single scalar data item 
+   *          - "num_views_string" : total number of Views associated with
+   *                                 string data
+   *          - "num_bytes_allocated" : total number of bytes associated with 
+   *                                    Views in subtree or single Group 
+   *                                    that are allocated in Buffers in 
+   *                                    the DataStore
+   *          - "num_bytes_external" : total number of bytes in described, 
+   *                                   external Views in Group subtree or 
+   *                                   single Group
+   *
+   * Numeric values associated with these fields may be accessed as type
+   * axom::IndexType, which is defined at compile-time. For example,
+   *
+   * Group* gp = ...;
+   * 
+   * Node n;
+   * gp->getDataInfo(n);
+   * axom::IndexType num_views = n["num_views"].value();
+   * // etc...
+   */
+  void getDataInfo(Node& n, bool recursive = true) const;
+
   //@}
 
   //@{
@@ -986,6 +1027,14 @@ private:
    * \sa isUsingMap, isUsingList
    */
   const MapCollection<Group>* getNamedGroups() const;
+
+  /*!
+   * \brief Method to (recursively) accumulate information about data in
+   *        a Group subtree.
+   *
+   * \sa getDataInfo
+   */
+  void getDataInfoHelper(Node& n, bool recursive) const;
 
 public:
   //@{

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -292,7 +292,7 @@ public:
    *
    *          - "num_groups" : total number of Groups in subtree or single Group
    *          - "num_views" : total number of Views in subtree or single Group
-   *          - "num_views_nodata" : total number of Views with no associated
+   *          - "num_views_empty" : total number of Views with no associated
    *                                 Buffer or data 
    *                                 (may or may not be described)
    *          - "num_views_buffer" : total number of Views associated
@@ -320,7 +320,7 @@ public:
    *                                   an over-count.
    *          - "num_bytes_in_buffers" : total number of bytes allocated in
    *                                     Buffers referenced by Views in
-   *                                     subtree pr single Group 
+   *                                     subtree or single Group 
    *
    * Numeric values associated with these fields may be accessed as type
    * axom::IndexType, which is defined at compile-time. For example,

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -283,7 +283,7 @@ public:
 #endif
 
   /*!
-   * \brief Return information about data associated with Group subtree with
+   * \brief Insert information about data associated with Group subtree with
    *        this Group at root of tree (default 'recursive' is true), or for 
    *        this Group only ('recursive' is false) in fields of given 
    *        Conduit Node.
@@ -303,13 +303,20 @@ public:
    *                                 single scalar data item 
    *          - "num_views_string" : total number of Views associated with
    *                                 string data
-   *          - "num_bytes_allocated" : total number of bytes associated with 
-   *                                    Views in subtree or single Group 
-   *                                    that are allocated in Buffers in 
-   *                                    the DataStore
-   *          - "num_bytes_external" : total number of bytes in described, 
+   *          - "num_bytes_assoc_with_views" : total number of bytes 
+   *                                           associated with Views in subtree
+   *                                           or single Group that are 
+   *                                           allocated in Buffers in 
+   *                                           the DataStore. NOTE: This 
+   *                                           may be an over-count if two
+   *                                           Views data overlaps in a shared
+   *                                           Buffer. 
+   *          - "num_bytes_external" : total number of bytes described by
    *                                   external Views in Group subtree or 
-   *                                   single Group
+   *                                   single Group. NOTE: The data may or
+   *                                   may not be allocated, and there may
+   *                                   be overlaps in actual data associated
+   *                                   with external views.
    *
    * Numeric values associated with these fields may be accessed as type
    * axom::IndexType, which is defined at compile-time. For example,

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -308,15 +308,19 @@ public:
    *                                           or single Group that are 
    *                                           allocated in Buffers in 
    *                                           the DataStore. NOTE: This 
-   *                                           may be an over-count if two
-   *                                           Views data overlaps in a shared
-   *                                           Buffer. 
+   *                                           may be an over-count if data 
+   *                                           for two or more Views overlaps 
+   *                                           in a shared Buffer. 
    *          - "num_bytes_external" : total number of bytes described by
    *                                   external Views in Group subtree or 
-   *                                   single Group. NOTE: The data may or
-   *                                   may not be allocated, and there may
-   *                                   be overlaps in actual data associated
-   *                                   with external views.
+   *                                   single Group. The data may or may not 
+   *                                   be allocated. NOTE: If there are
+   *                                   overlaps in data associated with 
+   *                                   multiple external Views, this may be 
+   *                                   an over-count.
+   *          - "num_bytes_in_buffers" : total number of bytes allocated in
+   *                                     Buffers referenced by Views in
+   *                                     subtree pr single Group 
    *
    * Numeric values associated with these fields may be accessed as type
    * axom::IndexType, which is defined at compile-time. For example,
@@ -1041,7 +1045,8 @@ private:
    *
    * \sa getDataInfo
    */
-  void getDataInfoHelper(Node& n, bool recursive) const;
+  void getDataInfoHelper(Node& n, std::set<IndexType>& buffer_ids, 
+                         bool recursive) const;
 
 public:
   //@{

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -1043,6 +1043,12 @@ private:
    * \brief Method to (recursively) accumulate information about data in
    *        a Group subtree.
    *
+   * \param n Conduit node in which to insert accumulated data
+   * \param buffer_ids std::set used to gather set of unique buffer ids
+   *                   for reporting total bytes in buffers
+   * \param recursive boolean value indicating whether to recurse to child
+   *                  groups of this group.
+   *
    * \sa getDataInfo
    */
   void getDataInfoHelper(Node& n,

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -1045,7 +1045,8 @@ private:
    *
    * \sa getDataInfo
    */
-  void getDataInfoHelper(Node& n, std::set<IndexType>& buffer_ids, 
+  void getDataInfoHelper(Node& n,
+                         std::set<IndexType>& buffer_ids,
                          bool recursive) const;
 
 public:

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -1449,7 +1449,7 @@ private:
   {
     EMPTY,     // View created with name only :
                //    has no data or data description
-    BUFFER,    // View has a buffer attached, either via call to 
+    BUFFER,    // View has a buffer attached, either via call to
                // View::attachBuffer(), View::allocate(), etc. :
                //    applied may be true or false
     EXTERNAL,  // View holds pointer to external data (no buffer) :

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -1449,7 +1449,8 @@ private:
   {
     EMPTY,     // View created with name only :
                //    has no data or data description
-    BUFFER,    // View has a buffer attached explicitly. :
+    BUFFER,    // View has a buffer attached, either via call to 
+               // View::attachBuffer(), View::allocate(), etc. :
                //    applied may be true or false
     EXTERNAL,  // View holds pointer to external data (no buffer) :
                //    applied may be true or false

--- a/src/axom/sidre/docs/sphinx/core_concepts.rst
+++ b/src/axom/sidre/docs/sphinx/core_concepts.rst
@@ -34,4 +34,4 @@ of these Sidre classes.
    view 
    attribute
    data_vs_metadata
-
+   query_data

--- a/src/axom/sidre/docs/sphinx/query_data.rst
+++ b/src/axom/sidre/docs/sphinx/query_data.rst
@@ -28,7 +28,9 @@ contains. For example::
   ds->getBufferInfo(n);
 
 This method call inserts four fields into the Node that have numeric values
-accessible as type axom::IndexType. For example::
+accessible as type ``axom::IndexType``. For example::
+
+  using IndexType = axom::IndexType;
 
   IndexType num_buffers = n["num_buffers"].value();
   IndexType num_buffers_referenced = n["num_buffers_referenced"].value();
@@ -64,7 +66,9 @@ with the entire group subtree rooted at the group. For example::
 
 Similar to the ``Datastore::getBufferInfo`` method described above, the 
 ``Group::getDataInfo`` method inserts fields into the given Conduit Node
-that have numeric values accessible as type axom::IndexType.  For example::
+that have numeric values accessible as type ``axom::IndexType``.  For example::
+
+  using IndexType = axom::IndexType;
 
   IndexType num_groups = n["num_groups"].value();
   IndexType num_views = n["num_views"].value();

--- a/src/axom/sidre/docs/sphinx/query_data.rst
+++ b/src/axom/sidre/docs/sphinx/query_data.rst
@@ -26,6 +26,7 @@ contains. For example::
 
   conduit::Node n;
   ds->getBufferInfo(n);
+  n.print();   // print Conduit node contents to std out, if desired
 
 This method call inserts four fields into the Node that have numeric values
 accessible as type ``axom::IndexType``. For example::
@@ -58,11 +59,13 @@ with the entire group subtree rooted at the group. For example::
   // get information about a single group
   conduit::Node n;
   group->getDataInfo(n, recursive);
+  n.print();   // print Conduit node contents to std out, if desired
 
   // get information about entire subtree rooted at group
   recursive = true;
   conduit::Node n1;
   group->getDataInfo(n1, recursive);
+  n1.print();   // print Conduit node contents to std out, if desired
 
 Similar to the ``Datastore::getBufferInfo`` method described above, the 
 ``Group::getDataInfo`` method inserts fields into the given Conduit Node
@@ -92,7 +95,7 @@ entire group subtree:
   * ``num_views_scalar`` : Number of views associated with a single scalar data item.
   * ``num_views_string`` : Number of views associated with string data.
   * ``num_bytes_assoc_with_views`` : Total number of bytes associated with views (buffer, string, and scalar). Note that this may be an over-count if two or more views share a buffer and their data overlap, for example.
-  * ``num_bytes_external`` : Total number of bytes described by external views. Note that this may be an over-count if two or more views share an external allocation and their data overlaps, for example.
+  * ``num_bytes_external`` : Total number of bytes described by external views. Note that this may be an over-count. For example, if two or more views share an external allocation and their data overlaps more bytes may be reported than exist.
   * ``num_bytes_in_buffers`` : Total number of bytes allocated in buffers that are attached to views. Each buffer is counted exactly once if attached to multiple views.
 
 .. important:: ``num_bytes_assoc_with_views`` and ``num_bytes_external`` may over-count the actual data that exists. For example, if two or more views share a buffer or if two or more views share an external allocation and the view data overlaps in either case.

--- a/src/axom/sidre/docs/sphinx/query_data.rst
+++ b/src/axom/sidre/docs/sphinx/query_data.rst
@@ -26,7 +26,11 @@ contains. For example::
 
   conduit::Node n;
   ds->getBufferInfo(n);
-  n.print();   // print Conduit node contents to std out, if desired
+
+  // Print Conduit node contents to stdout, if desired.
+  // Note that when running with multiple MPI ranks, each rank will 
+  // independently print its node contents to stdout, which may not be wanted.
+  n.print();
 
 This method call inserts four fields into the Node that have numeric values
 accessible as type ``axom::IndexType``. For example::
@@ -59,7 +63,11 @@ associated with the entire subtree rooted at the group. For example::
   // get information about a single group
   conduit::Node n;
   group->getDataInfo(n, recursive);
-  n.print();   // print Conduit node contents to std out, if desired
+
+  // Print Conduit node contents to stdout, if desired.
+  // Note that when running with multiple MPI ranks, each rank will 
+  // independently print its node contents to stdout, which may not be wanted.
+  n.print();
 
   // get information about entire subtree rooted at group
   recursive = true;

--- a/src/axom/sidre/docs/sphinx/query_data.rst
+++ b/src/axom/sidre/docs/sphinx/query_data.rst
@@ -41,7 +41,7 @@ accessible as type ``axom::IndexType``. For example::
 The variables have the following values:
 
   * ``num_buffers`` : Total number of buffer objects in the datastore.
-  * ``num_buffers_referenced`` : Number of buffers referenced by a view (i.e., attached to a view.
+  * ``num_buffers_referenced`` : Number of buffers referenced (i.e. attached to) a view.
   * ``num_buffers_detached`` : Number of buffers not referenced by a view. Note: ``num_buffers_detached`` = ``num_buffers`` - ``num_buffers_referenced``.
   * ``num_bytes_allocated`` : Total number of bytes allocated in all buffers.
 
@@ -50,7 +50,7 @@ Group Subtree Query
 --------------------
 
 A group can be queried for information about the data associated with it, or
-with the entire group subtree rooted at the group. For example::
+associated with the entire subtree rooted at the group. For example::
 
   Group* group = ...;
 

--- a/src/axom/sidre/docs/sphinx/query_data.rst
+++ b/src/axom/sidre/docs/sphinx/query_data.rst
@@ -1,0 +1,95 @@
+.. ## Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+.. ## other Axom Project Developers. See the top-level LICENSE file for details.
+.. ##
+.. ## SPDX-License-Identifier: (BSD-3-Clause)
+
+.. _dataconcepts-label:
+
+===========================
+Datastore Queries
+===========================
+
+Sidre provides a couple of methods that can be called to query certain
+information about the contents of a datastore object. Each method takes
+a Conduit Node and inserts information related to the query into it. The
+caller can then inspect the information by retrieving values of specifically 
+named fields from the Node. This is often helpful for debugging.
+
+-------------
+Buffer Query
+-------------
+
+A datastore object can be queried for information about the buffer objects it
+contains. For example::
+
+  Datastore* ds = ...;
+
+  conduit::Node n;
+  ds->getBufferInfo(n);
+
+This method call inserts four fields into the Node that have numeric values
+accessible as type axom::IndexType. For example::
+
+  IndexType num_buffers = n["num_buffers"].value();
+  IndexType num_buffers_referenced = n["num_buffers_referenced"].value();
+  IndexType num_buffers_detached = n["num_buffers_detached"].value();
+  IndexType num_bytes_allocated = n["num_bytes_allocated"].value();
+
+The variables have the following values:
+
+  * ``num_buffers`` : Total number of buffer objects in the datastore.
+  * ``num_buffers_referenced`` : Number of buffers referenced by a view (i.e., attached to a view.
+  * ``num_buffers_detached`` : Number of buffers not referenced by a view. Note:
+ ``num_buffers_detached`` = ``num_buffers`` - ``num_buffers_referenced``.
+  * ``num_bytes_allocated`` : Total number of bytes allocated in all buffers.
+
+--------------------
+Group Subtree Query
+--------------------
+
+A group can be queried for information about the data associated with it, or
+with the entire group subtree rooted at the group. For example::
+
+  Group* group = ...;
+
+  bool recursive = false; 
+
+  // get information about a single group
+  conduit::Node n;
+  group->getDataInfo(n, recursive);
+
+  // get information about entire subtree rooted at group
+  recursive = true;
+  conduit::Node n1;
+  group->getDataInfo(n1, recursive);
+
+Similar to the ``Datastore::getBufferInfo`` method described above, the 
+``Group::getDataInfo`` method inserts fields into the given Conduit Node
+that have numeric values accessible as type axom::IndexType.  For example::
+
+  IndexType num_groups = n["num_groups"].value();
+  IndexType num_views = n["num_views"].value();
+  IndexType num_views_empty = n["num_views_empty"].value();
+  IndexType num_views_buffer = n["num_views_buffer"].value();
+  IndexType num_views_external = n["num_views_external"].value();
+  IndexType num_views_scalar = n["num_views_scalar"].value();
+  IndexType num_views_string = n["num_views_string"].value();
+  IndexType num_bytes_assoc_with_views = n["num_bytes_assoc_with_views"].value();
+  IndexType num_bytes_external = n["num_bytes_external"].value();
+  IndexType num_bytes_in_buffers = n["num_bytes_in_buffers"].value();
+
+The variables have the following values describing the single group or
+entire group subtree:
+
+  * ``num_groups`` : Total number of groups.
+  * ``num_views`` : Total number of views.
+  * ``num_views_empty`` : Number of views with no associated buffer or data (may or may not be described).
+  * ``num_views_buffer`` : Number of views associated with a buffer.
+  * ``num_views_external`` : Number of views associated with external data.
+  * ``num_views_scalar`` : Number of views associated with a single scalar data item.
+  * ``num_views_string`` : Number of views associated with string data.
+  * ``num_bytes_assoc_with_views`` : Total number of bytes associated with views (buffer, string, and scalar). Note that this may be an over-count if two or more views share a buffer and their data overlap, for example.
+  * ``num_bytes_external`` : Total number of bytes described by external views. Note that this may be an over-count if two or more views share an external allocation and their data overlaps, for example.
+  * ``num_bytes_in_buffers`` : Total number of bytes allocated in buffers that are attached to views. Each buffer is counted exactly once if attached to multiple views.
+
+.. important:: ``num_bytes_assoc_with_views`` and ``num_bytes_external`` may over-count the actual data that exists. For example, if two or more views share a buffer or if two or more views share an external allocation and the view data overlaps in either case.

--- a/src/axom/sidre/docs/sphinx/query_data.rst
+++ b/src/axom/sidre/docs/sphinx/query_data.rst
@@ -39,8 +39,7 @@ The variables have the following values:
 
   * ``num_buffers`` : Total number of buffer objects in the datastore.
   * ``num_buffers_referenced`` : Number of buffers referenced by a view (i.e., attached to a view.
-  * ``num_buffers_detached`` : Number of buffers not referenced by a view. Note:
- ``num_buffers_detached`` = ``num_buffers`` - ``num_buffers_referenced``.
+  * ``num_buffers_detached`` : Number of buffers not referenced by a view. Note: ``num_buffers_detached`` = ``num_buffers`` - ``num_buffers_referenced``.
   * ``num_bytes_allocated`` : Total number of bytes allocated in all buffers.
 
 --------------------

--- a/src/axom/sidre/tests/sidre_datastore.cpp
+++ b/src/axom/sidre/tests/sidre_datastore.cpp
@@ -15,6 +15,8 @@ using axom::sidre::IndexType;
 using axom::sidre::INT_ID;
 using axom::sidre::DOUBLE_ID;
 
+#include <iostream>
+
 //------------------------------------------------------------------------------
 
 TEST(sidre_datastore, destroy_buffer)
@@ -45,13 +47,36 @@ TEST(sidre_datastore, destroy_buffer)
 }
 
 TEST(sidre_datastore, buffer_info)
-{
+{ 
+  IndexType num_buffers_chk = 0;
   IndexType num_buffers_referenced_chk = 0;
   IndexType num_buffers_detached_chk = 0;
   IndexType num_bytes_allocated_chk = 0;
 
   DataStore* ds = new DataStore();
 
+  //
+  // Ha-ha check
+  //
+  conduit::Node n0;
+  ds->getBufferInfo(n0);
+
+  IndexType num_buffers = n0["num_buffers"].value();
+  IndexType num_buffers_referenced = n0["num_buffers_referenced"].value();
+  IndexType num_buffers_detached = n0["num_buffers_detached"].value();
+  IndexType num_bytes_allocated = n0["num_bytes_allocated"].value();
+
+  num_buffers_detached_chk = ds->getNumBuffers() - num_buffers_referenced_chk;
+
+  EXPECT_EQ(num_buffers_chk, ds->getNumBuffers());
+  EXPECT_EQ(num_buffers_referenced_chk, num_buffers_referenced);
+  EXPECT_EQ(num_buffers_detached_chk, num_buffers_detached);
+  EXPECT_EQ(num_bytes_allocated_chk, num_bytes_allocated);
+
+
+  //
+  // More complex checks...
+  //
   ds->createBuffer(INT_ID, 5);
   num_bytes_allocated_chk += 0;
 
@@ -76,10 +101,10 @@ TEST(sidre_datastore, buffer_info)
   conduit::Node n;
   ds->getBufferInfo(n);
 
-  IndexType num_buffers = n["num_buffers"].value(); 
-  IndexType num_buffers_referenced = n["num_buffers_referenced"].value();
-  IndexType num_buffers_detached = n["num_buffers_detached"].value();
-  IndexType num_bytes_allocated = n["num_bytes_allocated"].value();
+  num_buffers = n["num_buffers"].value(); 
+  num_buffers_referenced = n["num_buffers_referenced"].value();
+  num_buffers_detached = n["num_buffers_detached"].value();
+  num_bytes_allocated = n["num_bytes_allocated"].value();
 
   num_buffers_detached_chk = ds->getNumBuffers() - num_buffers_referenced_chk;
 

--- a/src/axom/sidre/tests/sidre_datastore.cpp
+++ b/src/axom/sidre/tests/sidre_datastore.cpp
@@ -6,9 +6,14 @@
 #include "gtest/gtest.h"
 #include "axom/sidre.hpp"
 
-using axom::sidre::Buffer;
 using axom::sidre::DataStore;
+using axom::sidre::Buffer;
+using axom::sidre::Group;
+using axom::sidre::View;
+
 using axom::sidre::IndexType;
+using axom::sidre::INT_ID;
+using axom::sidre::DOUBLE_ID;
 
 //------------------------------------------------------------------------------
 
@@ -35,6 +40,53 @@ TEST(sidre_datastore, destroy_buffer)
   // check error condition
   IndexType badBufferIndex = 9999;
   ds->destroyBuffer(badBufferIndex);
+
+  delete ds;
+}
+
+TEST(sidre_datastore, buffer_info)
+{
+  IndexType num_buffers_referenced_chk = 0;
+  IndexType num_buffers_detached_chk = 0;
+  IndexType num_bytes_allocated_chk = 0;
+
+  DataStore* ds = new DataStore();
+
+  ds->createBuffer(INT_ID, 5);
+  num_bytes_allocated_chk += 0;
+
+  Buffer* buff1 = ds->createBuffer(INT_ID, 10)->allocate();
+  num_bytes_allocated_chk += buff1->getTotalBytes();
+
+  Buffer* buff2 = ds->createBuffer(DOUBLE_ID, 10)->allocate();
+  num_bytes_allocated_chk += buff2->getTotalBytes();
+
+  Group* root = ds->getRoot();
+  Group* group_a = root->createGroup("a");
+  Group* group_b = root->createGroup("b");
+
+  View* view_a = group_a->createViewAndAllocate("fielda", INT_ID, 5);
+  num_buffers_referenced_chk++;
+  num_bytes_allocated_chk += view_a->getTotalBytes();
+
+  View* view_b = group_b->createView("fieldb");
+  view_b->attachBuffer(DOUBLE_ID, 5, buff2);
+  num_buffers_referenced_chk++;
+
+  conduit::Node n;
+  ds->getBufferInfo(n);
+
+  IndexType num_buffers = n["num_buffers"].value(); 
+  IndexType num_buffers_referenced = n["num_buffers_referenced"].value();
+  IndexType num_buffers_detached = n["num_buffers_detached"].value();
+  IndexType num_bytes_allocated = n["num_bytes_allocated"].value();
+
+  num_buffers_detached_chk = ds->getNumBuffers() - num_buffers_referenced_chk;
+
+  EXPECT_EQ(num_buffers, ds->getNumBuffers());
+  EXPECT_EQ(num_buffers_referenced_chk, num_buffers_referenced);
+  EXPECT_EQ(num_buffers_detached_chk, num_buffers_detached);
+  EXPECT_EQ(num_bytes_allocated_chk, num_bytes_allocated);
 
   delete ds;
 }

--- a/src/axom/sidre/tests/sidre_datastore.cpp
+++ b/src/axom/sidre/tests/sidre_datastore.cpp
@@ -6,14 +6,14 @@
 #include "gtest/gtest.h"
 #include "axom/sidre.hpp"
 
-using axom::sidre::DataStore;
 using axom::sidre::Buffer;
+using axom::sidre::DataStore;
 using axom::sidre::Group;
 using axom::sidre::View;
 
+using axom::sidre::DOUBLE_ID;
 using axom::sidre::IndexType;
 using axom::sidre::INT_ID;
-using axom::sidre::DOUBLE_ID;
 
 #include <iostream>
 
@@ -47,7 +47,7 @@ TEST(sidre_datastore, destroy_buffer)
 }
 
 TEST(sidre_datastore, buffer_info)
-{ 
+{
   IndexType num_buffers_chk = 0;
   IndexType num_buffers_referenced_chk = 0;
   IndexType num_buffers_detached_chk = 0;
@@ -72,7 +72,6 @@ TEST(sidre_datastore, buffer_info)
   EXPECT_EQ(num_buffers_referenced_chk, num_buffers_referenced);
   EXPECT_EQ(num_buffers_detached_chk, num_buffers_detached);
   EXPECT_EQ(num_bytes_allocated_chk, num_bytes_allocated);
-
 
   //
   // More complex checks...
@@ -101,7 +100,7 @@ TEST(sidre_datastore, buffer_info)
   conduit::Node n;
   ds->getBufferInfo(n);
 
-  num_buffers = n["num_buffers"].value(); 
+  num_buffers = n["num_buffers"].value();
   num_buffers_referenced = n["num_buffers_referenced"].value();
   num_buffers_detached = n["num_buffers_detached"].value();
   num_bytes_allocated = n["num_bytes_allocated"].value();

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -3026,7 +3026,7 @@ IndexType num_views_buffer_chk = 0;
 IndexType num_views_external_chk = 0;
 IndexType num_views_scalar_chk = 0;
 IndexType num_views_string_chk = 0;
-IndexType num_bytes_allocated_chk = 0;
+IndexType num_bytes_assoc_with_views_chk = 0;
 IndexType num_bytes_external_chk = 0;
 
 // Variables used to pull test values from Conduit node
@@ -3037,7 +3037,7 @@ IndexType num_views_buffer = 0;
 IndexType num_views_external = 0;
 IndexType num_views_scalar = 0;
 IndexType num_views_string = 0;
-IndexType num_bytes_allocated = 0;
+IndexType num_bytes_assoc_with_views = 0;
 IndexType num_bytes_external = 0;
 
 void resetChkVals()
@@ -3049,7 +3049,7 @@ void resetChkVals()
   num_views_external_chk = 0;
   num_views_scalar_chk = 0;
   num_views_string_chk = 0;
-  num_bytes_allocated_chk = 0;
+  num_bytes_assoc_with_views_chk = 0;
   num_bytes_external_chk = 0;
 }
 
@@ -3062,7 +3062,7 @@ void pullTestVals(const conduit::Node& n)
   num_views_external = n["num_views_external"].value();
   num_views_scalar = n["num_views_scalar"].value();
   num_views_string = n["num_views_string"].value();
-  num_bytes_allocated = n["num_bytes_allocated"].value();
+  num_bytes_assoc_with_views = n["num_bytes_assoc_with_views"].value();
   num_bytes_external = n["num_bytes_external"].value();
 }
 
@@ -3091,7 +3091,7 @@ TEST(sidre_group, get_data_info)
   EXPECT_EQ(num_views_external, num_views_external_chk);
   EXPECT_EQ(num_views_scalar, num_views_scalar_chk);
   EXPECT_EQ(num_views_string, num_views_string_chk);
-  EXPECT_EQ(num_bytes_allocated, num_bytes_allocated_chk);
+  EXPECT_EQ(num_bytes_assoc_with_views, num_bytes_assoc_with_views_chk);
   EXPECT_EQ(num_bytes_external, num_bytes_external_chk);
 
   //
@@ -3128,7 +3128,7 @@ TEST(sidre_group, get_data_info)
   EXPECT_EQ(num_views_external, num_views_external_chk);
   EXPECT_EQ(num_views_scalar, num_views_scalar_chk);
   EXPECT_EQ(num_views_string, num_views_string_chk);
-  EXPECT_EQ(num_bytes_allocated, num_bytes_allocated_chk);
+  EXPECT_EQ(num_bytes_assoc_with_views, num_bytes_assoc_with_views_chk);
   EXPECT_EQ(num_bytes_external, num_bytes_external_chk);
 
   //
@@ -3142,8 +3142,8 @@ TEST(sidre_group, get_data_info)
   num_groups_chk += 1;
   num_views_chk = 3;         // "dat_A1", "dat_A2", "ext_A3" Views
   num_views_buffer_chk = 2;  // "dat_A1", "dat_A2" Views
-  num_bytes_allocated_chk += view_A1->getTotalBytes();
-  num_bytes_allocated_chk += view_A2->getTotalBytes();
+  num_bytes_assoc_with_views_chk += view_A1->getTotalBytes();
+  num_bytes_assoc_with_views_chk += view_A2->getTotalBytes();
   num_views_external_chk = 1;  // "ext_A3" View
   num_bytes_external_chk += view_A3->getTotalBytes();
 
@@ -3159,7 +3159,7 @@ TEST(sidre_group, get_data_info)
   EXPECT_EQ(num_views_external, num_views_external_chk);
   EXPECT_EQ(num_views_scalar, num_views_scalar_chk);
   EXPECT_EQ(num_views_string, num_views_string_chk);
-  EXPECT_EQ(num_bytes_allocated, num_bytes_allocated_chk);
+  EXPECT_EQ(num_bytes_assoc_with_views, num_bytes_assoc_with_views_chk);
   EXPECT_EQ(num_bytes_external, num_bytes_external_chk);
 
   //
@@ -3176,13 +3176,13 @@ TEST(sidre_group, get_data_info)
   View* view_B1 = gp_B->createViewAndAllocate("dat_B1", INT_ID, 5);
   num_views_chk += 1;
   num_views_buffer_chk += 1;
-  num_bytes_allocated_chk += view_B1->getTotalBytes();
+  num_bytes_assoc_with_views_chk += view_B1->getTotalBytes();
 
   View* view_B2 =
     gp_B->createView("dat_B2")->attachBuffer(buff2)->apply(DOUBLE_ID, 5, 5);
   num_views_chk += 1;
   num_views_buffer_chk += 1;
-  num_bytes_allocated_chk += view_B2->getTotalBytes();
+  num_bytes_assoc_with_views_chk += view_B2->getTotalBytes();
 
   // "C" Group and Views
   Group* gp_C = gp_B->createGroup("C");
@@ -3191,12 +3191,12 @@ TEST(sidre_group, get_data_info)
   View* view_C1 = gp_C->createViewScalar("val_C1", 3);
   num_views_chk += 1;
   num_views_scalar_chk += 1;
-  num_bytes_allocated_chk += view_C1->getTotalBytes();
+  num_bytes_assoc_with_views_chk += view_C1->getTotalBytes();
 
   View* view_C2 = gp_C->createViewString("val_C2", "Homer");
   num_views_chk += 1;
   num_views_string_chk += 1;
-  num_bytes_allocated_chk += view_C2->getTotalBytes();
+  num_bytes_assoc_with_views_chk += view_C2->getTotalBytes();
 
   // "D" Group and Views
   Group* gp_D = gp_C->createGroup("D");
@@ -3223,7 +3223,7 @@ TEST(sidre_group, get_data_info)
   EXPECT_EQ(num_views_external, num_views_external_chk);
   EXPECT_EQ(num_views_scalar, num_views_scalar_chk);
   EXPECT_EQ(num_views_string, num_views_string_chk);
-  EXPECT_EQ(num_bytes_allocated, num_bytes_allocated_chk);
+  EXPECT_EQ(num_bytes_assoc_with_views, num_bytes_assoc_with_views_chk);
   EXPECT_EQ(num_bytes_external, num_bytes_external_chk);
 
   //
@@ -3237,8 +3237,8 @@ TEST(sidre_group, get_data_info)
   num_groups_chk += 1;        // "A" Group
   num_views_chk += 3;         // "dat_A1", "dat_A2", "ext_A3" Views
   num_views_buffer_chk += 2;  // "dat_A1", "dat_A2" Views
-  num_bytes_allocated_chk += view_A1->getTotalBytes();
-  num_bytes_allocated_chk += view_A2->getTotalBytes();
+  num_bytes_assoc_with_views_chk += view_A1->getTotalBytes();
+  num_bytes_assoc_with_views_chk += view_A2->getTotalBytes();
   num_views_external_chk += 1;  // "ext_A3" View
   num_bytes_external_chk += view_A3->getTotalBytes();
 
@@ -3246,16 +3246,16 @@ TEST(sidre_group, get_data_info)
   num_groups_chk += 1;
   num_views_chk += 2;         // "dat_B1", "dat_B2" Views
   num_views_buffer_chk += 2;  // "dat_B1", "dat_B2" Views
-  num_bytes_allocated_chk += view_B1->getTotalBytes();
-  num_bytes_allocated_chk += view_B2->getTotalBytes();
+  num_bytes_assoc_with_views_chk += view_B1->getTotalBytes();
+  num_bytes_assoc_with_views_chk += view_B2->getTotalBytes();
 
   // "C" Group and Views
   num_groups_chk += 1;
   num_views_chk += 2;         // "val_C1", "val_C2" Views
   num_views_scalar_chk += 1;  // "val_C1" View
   num_views_string_chk += 1;  // "val_C2" View
-  num_bytes_allocated_chk += view_C1->getTotalBytes();
-  num_bytes_allocated_chk += view_C2->getTotalBytes();
+  num_bytes_assoc_with_views_chk += view_C1->getTotalBytes();
+  num_bytes_assoc_with_views_chk += view_C2->getTotalBytes();
 
   // "D" Group and Views
   num_groups_chk += 1;
@@ -3276,7 +3276,7 @@ TEST(sidre_group, get_data_info)
   EXPECT_EQ(num_views_external, num_views_external_chk);
   EXPECT_EQ(num_views_scalar, num_views_scalar_chk);
   EXPECT_EQ(num_views_string, num_views_string_chk);
-  EXPECT_EQ(num_bytes_allocated, num_bytes_allocated_chk);
+  EXPECT_EQ(num_bytes_assoc_with_views, num_bytes_assoc_with_views_chk);
   EXPECT_EQ(num_bytes_external, num_bytes_external_chk);
 
   delete ds;

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -3358,7 +3358,7 @@ TEST(sidre_group, get_data_info)
   num_views_external_chk = 1;  // "ext_A3" View
   num_bytes_external_chk += view_A3->getTotalBytes();
   num_bytes_in_buffers_chk += view_A1->getTotalBytes();
-  num_bytes_in_buffers_chk += buff2->getTotalBytes(); // "dat_A2" View
+  num_bytes_in_buffers_chk += buff2->getTotalBytes();  // "dat_A2" View
 
   conduit::Node n2;
   root->getDataInfo(n2);
@@ -3459,7 +3459,7 @@ TEST(sidre_group, get_data_info)
   num_views_external_chk += 1;  // "ext_A3" View
   num_bytes_external_chk += view_A3->getTotalBytes();
   num_bytes_in_buffers_chk += view_A1->getTotalBytes();
-  num_bytes_in_buffers_chk += buff2->getTotalBytes(); // "dat_A2" View
+  num_bytes_in_buffers_chk += buff2->getTotalBytes();  // "dat_A2" View
 
   // "B" Group and Views
   num_groups_chk += 1;

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -15,12 +15,12 @@
 using axom::sidre::Buffer;
 using axom::sidre::DataStore;
 using axom::sidre::DataType;
+using axom::sidre::DOUBLE_ID;
 using axom::sidre::FLOAT64_ID;
 using axom::sidre::Group;
 using axom::sidre::indexIsValid;
 using axom::sidre::IndexType;
 using axom::sidre::INT_ID;
-using axom::sidre::DOUBLE_ID;
 using axom::sidre::InvalidIndex;
 using axom::sidre::nameIsValid;
 using axom::sidre::TypeID;
@@ -3018,56 +3018,55 @@ TEST(sidre_group, import_conduit_lists)
 // Local variables and methods to avoid redundant code
 namespace
 {
+// Variables used to set check values
+IndexType num_groups_chk = 0;
+IndexType num_views_chk = 0;
+IndexType num_views_empty_chk = 0;
+IndexType num_views_buffer_chk = 0;
+IndexType num_views_external_chk = 0;
+IndexType num_views_scalar_chk = 0;
+IndexType num_views_string_chk = 0;
+IndexType num_bytes_allocated_chk = 0;
+IndexType num_bytes_external_chk = 0;
 
-  // Variables used to set check values
-  IndexType num_groups_chk = 0;
-  IndexType num_views_chk = 0;
-  IndexType num_views_empty_chk = 0;
-  IndexType num_views_buffer_chk = 0;
-  IndexType num_views_external_chk = 0;
-  IndexType num_views_scalar_chk = 0;
-  IndexType num_views_string_chk = 0;
-  IndexType num_bytes_allocated_chk = 0;
-  IndexType num_bytes_external_chk = 0;
+// Variables used to pull test values from Conduit node
+IndexType num_groups = 0;
+IndexType num_views = 0;
+IndexType num_views_empty = 0;
+IndexType num_views_buffer = 0;
+IndexType num_views_external = 0;
+IndexType num_views_scalar = 0;
+IndexType num_views_string = 0;
+IndexType num_bytes_allocated = 0;
+IndexType num_bytes_external = 0;
 
-  // Variables used to pull test values from Conduit node
-  IndexType num_groups = 0;
-  IndexType num_views = 0;
-  IndexType num_views_empty = 0;
-  IndexType num_views_buffer = 0;
-  IndexType num_views_external = 0;
-  IndexType num_views_scalar = 0;
-  IndexType num_views_string = 0;
-  IndexType num_bytes_allocated = 0; 
-  IndexType num_bytes_external = 0;
+void resetChkVals()
+{
+  num_groups_chk = 0;
+  num_views_chk = 0;
+  num_views_empty_chk = 0;
+  num_views_buffer_chk = 0;
+  num_views_external_chk = 0;
+  num_views_scalar_chk = 0;
+  num_views_string_chk = 0;
+  num_bytes_allocated_chk = 0;
+  num_bytes_external_chk = 0;
+}
 
-  void resetChkVals()
-  {
-    num_groups_chk = 0;
-    num_views_chk = 0;
-    num_views_empty_chk = 0;
-    num_views_buffer_chk = 0;
-    num_views_external_chk = 0;
-    num_views_scalar_chk = 0;
-    num_views_string_chk = 0;
-    num_bytes_allocated_chk = 0;
-    num_bytes_external_chk = 0;
-  }
+void pullTestVals(const conduit::Node& n)
+{
+  num_groups = n["num_groups"].value();
+  num_views = n["num_views"].value();
+  num_views_empty = n["num_views_empty"].value();
+  num_views_buffer = n["num_views_buffer"].value();
+  num_views_external = n["num_views_external"].value();
+  num_views_scalar = n["num_views_scalar"].value();
+  num_views_string = n["num_views_string"].value();
+  num_bytes_allocated = n["num_bytes_allocated"].value();
+  num_bytes_external = n["num_bytes_external"].value();
+}
 
-  void pullTestVals(const conduit::Node& n)
-  {
-    num_groups = n["num_groups"].value();
-    num_views = n["num_views"].value();
-    num_views_empty = n["num_views_empty"].value();
-    num_views_buffer = n["num_views_buffer"].value();
-    num_views_external = n["num_views_external"].value();
-    num_views_scalar = n["num_views_scalar"].value();
-    num_views_string = n["num_views_string"].value();
-    num_bytes_allocated = n["num_bytes_allocated"].value();
-    num_bytes_external = n["num_bytes_external"].value();
-  } 
-
-} // end anonymous namespace
+}  // end anonymous namespace
 
 TEST(sidre_group, get_data_info)
 {
@@ -3076,7 +3075,7 @@ TEST(sidre_group, get_data_info)
   //
   DataStore* ds = new DataStore();
   Group* root = ds->getRoot();
- 
+
   conduit::Node n0;
   root->getDataInfo(n0);
 
@@ -3094,17 +3093,15 @@ TEST(sidre_group, get_data_info)
   EXPECT_EQ(num_views_string, num_views_string_chk);
   EXPECT_EQ(num_bytes_allocated, num_bytes_allocated_chk);
   EXPECT_EQ(num_bytes_external, num_bytes_external_chk);
-  
-
 
   //
-  // Check 1: Add "A" Group with Views. Then, non-recursive check from root 
+  // Check 1: Add "A" Group with Views. Then, non-recursive check from root
   //          Group; i.e., don't count "A" Group
   //
 
   // Add some buffers, 'cause it's fun....
-  ds->createBuffer(INT_ID, 10)->allocate();   // NOTE: Buffer unused 
-                                              // in this scope
+  ds->createBuffer(INT_ID, 10)->allocate();  // NOTE: Buffer unused
+                                             // in this scope
   Buffer* buff2 = ds->createBuffer(DOUBLE_ID, 10)->allocate();
 
   // array for external views
@@ -3134,7 +3131,6 @@ TEST(sidre_group, get_data_info)
   EXPECT_EQ(num_bytes_allocated, num_bytes_allocated_chk);
   EXPECT_EQ(num_bytes_external, num_bytes_external_chk);
 
-
   //
   // Check 2: Recursive from root Group. Count "A" Group this time.
   //
@@ -3144,7 +3140,7 @@ TEST(sidre_group, get_data_info)
 
   // "A" Group and Views
   num_groups_chk += 1;
-  num_views_chk = 3;   // "dat_A1", "dat_A2", "ext_A3" Views
+  num_views_chk = 3;         // "dat_A1", "dat_A2", "ext_A3" Views
   num_views_buffer_chk = 2;  // "dat_A1", "dat_A2" Views
   num_bytes_allocated_chk += view_A1->getTotalBytes();
   num_bytes_allocated_chk += view_A2->getTotalBytes();
@@ -3166,9 +3162,8 @@ TEST(sidre_group, get_data_info)
   EXPECT_EQ(num_bytes_allocated, num_bytes_allocated_chk);
   EXPECT_EQ(num_bytes_external, num_bytes_external_chk);
 
-
   //
-  // Check 3: Add "B" and "C" Groups. Recursive check from "B" Group, 
+  // Check 3: Add "B" and "C" Groups. Recursive check from "B" Group,
   //          counting "B" and "C" Groups
   //
 
@@ -3183,8 +3178,8 @@ TEST(sidre_group, get_data_info)
   num_views_buffer_chk += 1;
   num_bytes_allocated_chk += view_B1->getTotalBytes();
 
-  View* view_B2 = gp_B->createView("dat_B2")->attachBuffer(buff2)->
-                                              apply(DOUBLE_ID, 5, 5);
+  View* view_B2 =
+    gp_B->createView("dat_B2")->attachBuffer(buff2)->apply(DOUBLE_ID, 5, 5);
   num_views_chk += 1;
   num_views_buffer_chk += 1;
   num_bytes_allocated_chk += view_B2->getTotalBytes();
@@ -3207,12 +3202,12 @@ TEST(sidre_group, get_data_info)
   Group* gp_D = gp_C->createGroup("D");
   num_groups_chk += 1;
 
-  View* view_D1 = gp_D->createView("ext_D1", INT_ID, 10, &extdata+10);
+  View* view_D1 = gp_D->createView("ext_D1", INT_ID, 10, &extdata + 10);
   num_views_chk += 1;
   num_views_external_chk += 1;
   num_bytes_external_chk += view_D1->getTotalBytes();
 
-  gp_D->createView("dat_D2");   // NOTE: View unused in this scope
+  gp_D->createView("dat_D2");  // NOTE: View unused in this scope
   num_views_chk += 1;
   num_views_empty_chk += 1;
 
@@ -3231,7 +3226,6 @@ TEST(sidre_group, get_data_info)
   EXPECT_EQ(num_bytes_allocated, num_bytes_allocated_chk);
   EXPECT_EQ(num_bytes_external, num_bytes_external_chk);
 
-
   //
   // Check 4: Recursive check from root Group. Count entire Group hierarchy
   //
@@ -3240,8 +3234,8 @@ TEST(sidre_group, get_data_info)
   num_groups_chk += 1;  // count root Group
 
   // "A" Group and Views
-  num_groups_chk += 1;  // "A" Group
-  num_views_chk += 3;   // "dat_A1", "dat_A2", "ext_A3" Views
+  num_groups_chk += 1;        // "A" Group
+  num_views_chk += 3;         // "dat_A1", "dat_A2", "ext_A3" Views
   num_views_buffer_chk += 2;  // "dat_A1", "dat_A2" Views
   num_bytes_allocated_chk += view_A1->getTotalBytes();
   num_bytes_allocated_chk += view_A2->getTotalBytes();
@@ -3249,15 +3243,15 @@ TEST(sidre_group, get_data_info)
   num_bytes_external_chk += view_A3->getTotalBytes();
 
   // "B" Group and Views
-  num_groups_chk += 1; 
-  num_views_chk += 2;   // "dat_B1", "dat_B2" Views    
-  num_views_buffer_chk += 2;  // "dat_B1", "dat_B2" Views 
+  num_groups_chk += 1;
+  num_views_chk += 2;         // "dat_B1", "dat_B2" Views
+  num_views_buffer_chk += 2;  // "dat_B1", "dat_B2" Views
   num_bytes_allocated_chk += view_B1->getTotalBytes();
   num_bytes_allocated_chk += view_B2->getTotalBytes();
 
   // "C" Group and Views
   num_groups_chk += 1;
-  num_views_chk += 2;   // "val_C1", "val_C2" Views
+  num_views_chk += 2;         // "val_C1", "val_C2" Views
   num_views_scalar_chk += 1;  // "val_C1" View
   num_views_string_chk += 1;  // "val_C2" View
   num_bytes_allocated_chk += view_C1->getTotalBytes();
@@ -3265,9 +3259,9 @@ TEST(sidre_group, get_data_info)
 
   // "D" Group and Views
   num_groups_chk += 1;
-  num_views_chk += 2;   // "ext_D1", "dat_D2" Views
+  num_views_chk += 2;           // "ext_D1", "dat_D2" Views
   num_views_external_chk += 1;  // "ext_D1" View
-  num_views_empty_chk += 1;  // "dat_D2" View
+  num_views_empty_chk += 1;     // "dat_D2" View
   num_bytes_external_chk += view_D1->getTotalBytes();
 
   conduit::Node n4;
@@ -3284,7 +3278,7 @@ TEST(sidre_group, get_data_info)
   EXPECT_EQ(num_views_string, num_views_string_chk);
   EXPECT_EQ(num_bytes_allocated, num_bytes_allocated_chk);
   EXPECT_EQ(num_bytes_external, num_bytes_external_chk);
-  
+
   delete ds;
 }
 


### PR DESCRIPTION
# Summary

- This PR adds methods to get info about Sidre contents in a conduit Node
- Specifically, adds method to DataStore class to get Buffer info and adds method to Group class to get info about a Group subtree
- Tests of methods re included.

User docs added: https://axom.readthedocs.io/en/task-sidre-data-info/axom/sidre/docs/sphinx/query_data.html

Addresses https://github.com/LLNL/axom/issues/297