### PR TITLE
Bugfix/whitlock/1024 investigate compiler warnings

### DIFF
--- a/src/axom/core/examples/core_acceleration.cpp
+++ b/src/axom/core/examples/core_acceleration.cpp
@@ -189,7 +189,7 @@ void demoAxomExecution()
   // Increment sum 100 times
   axom::for_all<ExecSpace>(
     100,
-    AXOM_LAMBDA(axom::IndexType i) { RAJA::atomicAdd<atomic_pol>(sum, 1); });
+    AXOM_LAMBDA(axom::IndexType) { RAJA::atomicAdd<atomic_pol>(sum, 1); });
 
   std::cout << "\nTotal Atomic Sum (" << axom::execution_space<ExecSpace>::name()
             << ") :" << sum[0] << std::endl;

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1286,8 +1286,6 @@ void checkIteratorDeviceImpl()
   axom::Array<int, 1, axom::MemorySpace::Host> v_int_host(SIZE);
   axom::Array<int, 1, axom::MemorySpace::Device> v_int(SIZE);
 
-  //auto v_int_view = v_int.view();
-
   /* Push 0...999 elements */
   for(int i = 0; i < SIZE; i++)
   {

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -825,7 +825,7 @@ void check_device(Array<T, DIM, SPACE>& v)
 template <typename T>
 __global__ void assign_raw_2d(T* data, int M, int N)
 {
-  for(int i = 0; i < N; i++)
+  for(int i = 0; i < M; i++)
   {
     for(int j = 0; j < N; j++)
     {
@@ -1286,7 +1286,7 @@ void checkIteratorDeviceImpl()
   axom::Array<int, 1, axom::MemorySpace::Host> v_int_host(SIZE);
   axom::Array<int, 1, axom::MemorySpace::Device> v_int(SIZE);
 
-  auto v_int_view = v_int.view();
+  //auto v_int_view = v_int.view();
 
   /* Push 0...999 elements */
   for(int i = 0; i < SIZE; i++)

--- a/src/axom/multimat/tests/multimat_test.cpp
+++ b/src/axom/multimat/tests/multimat_test.cpp
@@ -301,7 +301,7 @@ void check_values(MultiMat& mm, std::string arr_name, MM_test_data<DataType>& da
   EXPECT_EQ(data.stride, map.stride());
 
   //check via findValue(...)
-  int sparse_idx = 0;
+  // int sparse_idx = 0;
   for(int ci = 0; ci < data.num_cells; ++ci)
   {
     for(int mi = 0; mi < data.num_mats; ++mi)
@@ -328,7 +328,7 @@ void check_values(MultiMat& mm, std::string arr_name, MM_test_data<DataType>& da
           {
             EXPECT_NE(d, nullptr);
             EXPECT_EQ(*d, data.cellmat_dense_arr[dense_idx * data.stride + s]);
-            if(s == data.stride - 1) sparse_idx += 1;
+            // if(s == data.stride - 1) sparse_idx += 1;
           }
           else
           {

--- a/src/axom/multimat/tests/multimat_test.cpp
+++ b/src/axom/multimat/tests/multimat_test.cpp
@@ -301,7 +301,6 @@ void check_values(MultiMat& mm, std::string arr_name, MM_test_data<DataType>& da
   EXPECT_EQ(data.stride, map.stride());
 
   //check via findValue(...)
-  // int sparse_idx = 0;
   for(int ci = 0; ci < data.num_cells; ++ci)
   {
     for(int mi = 0; mi < data.num_mats; ++mi)
@@ -328,7 +327,6 @@ void check_values(MultiMat& mm, std::string arr_name, MM_test_data<DataType>& da
           {
             EXPECT_NE(d, nullptr);
             EXPECT_EQ(*d, data.cellmat_dense_arr[dense_idx * data.stride + s]);
-            // if(s == data.stride - 1) sparse_idx += 1;
           }
           else
           {

--- a/src/axom/primal/geometry/Octahedron.hpp
+++ b/src/axom/primal/geometry/Octahedron.hpp
@@ -218,6 +218,28 @@ public:
   }
 
   /*!
+   * \brief Determines whether the octahedron has duplicate vertices.
+   * \return True if there are duplicate vertices; False otherwise.
+   */
+  AXOM_HOST_DEVICE
+  bool has_duplicate_vertices() const
+  {
+    for(int i = 0; i < 6; i++)
+    {
+      for(int j = i + 1; j < NUM_OCT_VERTS; j++)
+      {
+        // operator= for Point does not want to play nice...
+        if(m_points[i][0] == m_points[j][0] && m_points[i][1] == m_points[j][1] &&
+           m_points[i][2] == m_points[j][2])
+        {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /*!
    * \brief Simple formatted print of an octahedron instance
    * \param os The output stream to write to
    * \return A reference to the modified ostream

--- a/src/axom/primal/geometry/Octahedron.hpp
+++ b/src/axom/primal/geometry/Octahedron.hpp
@@ -229,8 +229,8 @@ public:
       for(int j = i + 1; j < NUM_OCT_VERTS; j++)
       {
         // operator= for Point does not want to play nice...
-        if(m_points[i][0] == m_points[j][0] && m_points[i][1] == m_points[j][1] &&
-           m_points[i][2] == m_points[j][2])
+        if(m_points[i][0] == m_points[j][0] &&
+           m_points[i][1] == m_points[j][1] && m_points[i][2] == m_points[j][2])
         {
           return true;
         }

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -318,32 +318,6 @@ public:
   void setExecPolicy(int policy) { m_execPolicy = (ExecPolicy)policy; }
   //@}
 
-private:
-  /**
-   * \brief Helper method to check if an Octahedron has duplicate
-   *        vertices
-   *
-   * \param poly [in] The Octahedron to check for duplicate vertices
-   * \return True if duplicate vertices found, false otherwise
-   */
-  AXOM_HOST_DEVICE
-  bool oct_has_duplicate_verts(const OctahedronType& oct) const
-  {
-    for(int i = 0; i < 6; i++)
-    {
-      for(int j = i + 1; j < OctahedronType::NUM_OCT_VERTS; j++)
-      {
-        // operator= for Point does not want to play nice...
-        if(oct[i][0] == oct[j][0] && oct[i][1] == oct[j][1] &&
-           oct[i][2] == oct[j][2])
-        {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
 public:
 //@{
 //!  @name Functions related to the stages for a given shape
@@ -831,7 +805,8 @@ public:
           for(int j = 0; j < counts_v[i]; j++)
           {
             int octIdx = candidates_v[offsets_v[i] + j];
-            if(!oct_has_duplicate_verts(local_octs[octIdx]))
+
+            if(!local_octs[octIdx].has_duplicate_vertices())
             {
               for(int k = 0; k < NUM_TETS_PER_HEX; k++)
               {

--- a/src/axom/slam/policies/IndirectionPolicies.hpp
+++ b/src/axom/slam/policies/IndirectionPolicies.hpp
@@ -106,9 +106,9 @@ struct IndexedIndirection : public BasePolicy
   #elif defined(__HIP_DEVICE_COMPILE__)
     abort();
   #endif
-#else
-    return buf[pos];
 #endif
+    // Always return a value.
+    return buf[pos];
   }
 
   template <bool DeviceEnable = BasePolicy::DeviceAccessible>
@@ -127,9 +127,9 @@ struct IndexedIndirection : public BasePolicy
   #elif defined(__HIP_DEVICE_COMPILE__)
     abort();
   #endif
-#else
-    return buf[pos];
 #endif
+    // Always return a value.
+    return buf[pos];
   }
 
   AXOM_HOST_DEVICE inline ConstIndirectionResult indirection(PositionType pos) const

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -499,30 +499,49 @@
     #define SLIC_CHECK(EXP) assert(EXP)
     #define SLIC_CHECK_MSG(EXP, msg) assert(EXP)
   #else
-    // AXOM_DEBUG is defined so the expression and message cannot be ignored
-    // as they probably contain parameters that were decorated with AXOM_UNUSED_PARAM
-    // which will require the expression and message to be used to avoid warnings.
-    // Here we use them in a way that will not really have a runtime effect.
-    // The msg code block may contain << operators so we need a stream-like object
-    // but we enclose it in "if(false)" so it never executes.
-    namespace axom
-    {
-    namespace slic
-    {
-    namespace internal
-    {
-      class blackhole {};
-      // Write an object to a blackhole.
-      template <typename T>
-      AXOM_HOST_DEVICE
-      inline blackhole &operator << (blackhole &bh, T) { return bh; }
-    }
-    }
-    }
+// AXOM_DEBUG is defined so the expression and message cannot be ignored
+// as they probably contain parameters that were decorated with AXOM_UNUSED_PARAM
+// which will require the expression and message to be used to avoid warnings.
+// Here we use them in a way that will not really have a runtime effect.
+// The msg code block may contain << operators so we need a stream-like object
+// but we enclose it in "if(false)" so it never executes.
+namespace axom
+{
+namespace slic
+{
+namespace internal
+{
+class blackhole
+{ };
+// Write an object to a blackhole.
+template <typename T>
+AXOM_HOST_DEVICE inline blackhole &operator<<(blackhole &bh, T)
+{
+  return bh;
+}
+}  // namespace internal
+}  // namespace slic
+}  // namespace axom
     #define SLIC_ASSERT(EXP) ((void)(EXP))
-    #define SLIC_ASSERT_MSG(EXP, msg) {((void)(EXP)); if(false){axom::slic::internal::blackhole __oss; __oss << msg;}}
+    #define SLIC_ASSERT_MSG(EXP, msg)            \
+      {                                          \
+        ((void)(EXP));                           \
+        if(false)                                \
+        {                                        \
+          axom::slic::internal::blackhole __oss; \
+          __oss << msg;                          \
+        }                                        \
+      }
     #define SLIC_CHECK(EXP) ((void)(EXP))
-    #define SLIC_CHECK_MSG(EXP, msg) {((void)(EXP)); if(false){axom::slic::internal::blackhole __oss; __oss << msg;}}
+    #define SLIC_CHECK_MSG(EXP, msg)             \
+      {                                          \
+        ((void)(EXP));                           \
+        if(false)                                \
+        {                                        \
+          axom::slic::internal::blackhole __oss; \
+          __oss << msg;                          \
+        }                                        \
+      }
   #endif
 #else  // turn off debug macros and asserts
 

--- a/src/axom/spin/UniformGrid.hpp
+++ b/src/axom/spin/UniformGrid.hpp
@@ -797,11 +797,11 @@ void UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::getCandidatesAsArray(
     for_all<ExecSpace>(
       qsize,
       AXOM_LAMBDA(IndexType i) {
-        int startIdx = offsets_view[i];
         int count = counts_view[i];
         if(count > 0)
         {
   #ifndef AXOM_DEVICE_CODE
+          int startIdx = offsets_view[i];
           std::sort(candidates_view.begin() + startIdx,
                     candidates_view.begin() + startIdx + count);
   #endif


### PR DESCRIPTION
# Summary

- This PR addresses compilation warnings in issue #1024 .
- It does the following:
  - Moves a method for detecting duplicate vertices from IntersectionShaper to Octahedron to remove a warning about the data being in the wrong place (cpu vs gpu). Previously, the code was capturing a host this pointer.
  - Some unused variables were removed.
  - SLIC macros for building using clang+HIP in debug mode were changed so expressions and messages are referenced, which references any AXOM_DEBUG_PARAM() arguments that were complained about previously. This is done by adding alternate no-op code that references the expression or message in a way that should be optimized away. The upside is that no additional macro decoration is needed back in the code where the SLIC macros are called. This change lets the code build quite cleanly.
  - I ran the build on rzvernal.

