### PR TITLE
No more object libraries

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ stages:
   artifacts:
     paths:
       - ${FULL_BUILD_ROOT}/${SYS_TYPE}/*/_axom_build_and_test_*/output.log*.txt
-      - ${FULL_BUILD_ROOT}}/${SYS_TYPE}/*/_axom_build_and_test_*/build-*/output.log*.txt
+      - ${FULL_BUILD_ROOT}/${SYS_TYPE}/*/_axom_build_and_test_*/build-*/output.log*.txt
     reports:
       junit: ${FULL_BUILD_ROOT}/${SYS_TYPE}/*/_axom_build_and_test_*/build-*/junit.xml
 

--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -14,13 +14,9 @@
     - if: '$CI_COMMIT_BRANCH =~ /_lnone/ || $ON_LASSEN == "OFF"' #run except if ...
       when: never
     - when: on_success
-
-####
-# Load required CUDA module
-.with_cuda:
   before_script:
     - module load cuda/11.2.0
-    - module load cmake/3.21.1
+    - module load cmake/3.18.0
 
 ####
 # Template
@@ -50,7 +46,7 @@ lassen-clang_10_0_1_cuda-src:
   variables:
     COMPILER: "clang@10.0.1.2_cuda"
     HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}.cmake"
-  extends: [.src_build_on_lassen, .with_cuda]
+  extends: [.src_build_on_lassen]
 
 lassen-gcc_8_3_1-src:
   variables:
@@ -62,7 +58,7 @@ lassen-gcc_8_3_1_cuda-src:
   variables:
     COMPILER: "gcc@8.3.1.2_cuda"
     HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}.cmake"
-  extends: [.src_build_on_lassen, .with_cuda]
+  extends: [.src_build_on_lassen]
 
 lassen-xl_16_1_1-src:
   variables:
@@ -74,7 +70,7 @@ lassen-xl_16_1_1_cuda-src:
   variables:
     COMPILER: "xl@16.1.1.2_cuda"
     HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}.cmake"
-  extends: [.src_build_on_lassen, .with_cuda]
+  extends: [.src_build_on_lassen]
 
 ####
 # Full Build jobs
@@ -89,7 +85,7 @@ lassen-clang_10_0_1_cuda-full:
     COMPILER: "clang@10.0.1.2"
     SPEC: "%${COMPILER}+mfem+cuda~openmp"
     EXTRA_SPEC: "cuda_arch=70"
-  extends: [.full_build_on_lassen, .with_cuda]
+  extends: [.full_build_on_lassen]
 
 lassen-gcc_8_3_1-full:
   variables:
@@ -102,7 +98,7 @@ lassen-gcc_8_3_1_cuda-full:
     COMPILER: "gcc@8.3.1.2"
     SPEC: "%${COMPILER}~mfem+cuda"
     EXTRA_SPEC: "cuda_arch=70"
-  extends: [.full_build_on_lassen, .with_cuda]
+  extends: [.full_build_on_lassen]
 
 lassen-xl_16_1_1-full:
   variables:
@@ -115,4 +111,4 @@ lassen-xl_16_1_1_cuda-full:
     COMPILER: "xl@16.1.1.2"
     SPEC: "%${COMPILER}+mfem+cuda~openmp~cpp14"
     EXTRA_SPEC: "cuda_arch=70"
-  extends: [.full_build_on_lassen, .with_cuda]
+  extends: [.full_build_on_lassen]

--- a/.gitlab/build_ruby.yml
+++ b/.gitlab/build_ruby.yml
@@ -15,6 +15,8 @@
     - if: '$CI_JOB_NAME =~ /ruby_release/'
       when: always
     - when: on_success
+  before_script:
+    - module load cmake/3.18.0
 
 ####
 # In pre-build phase, allocate a node for builds

--- a/.gitlab/build_rzansel.yml
+++ b/.gitlab/build_rzansel.yml
@@ -11,13 +11,8 @@
     - shell
     - rzansel
   before_script:
-    - module load cmake/3.14.5
-
-####
-# Load required CUDA module
-.with_cuda:
-  before_script:
     - module load cuda/11.2.0
+    - module load cmake/3.18.0
 
 ####
 # Template
@@ -47,7 +42,7 @@ rzansel-clang_10_0_1_cuda-src:
   variables:
     COMPILER: "clang@10.0.1.2_cuda"
     HOST_CONFIG: "rzansel-blueos_3_ppc64le_ib_p9-${COMPILER}.cmake"
-  extends: [.src_build_on_rzansel, .with_cuda]
+  extends: [.src_build_on_rzansel]
 
 rzansel-gcc_8_3_1-src:
   variables:
@@ -59,7 +54,7 @@ rzansel-gcc_8_3_1_cuda-src:
   variables:
     COMPILER: "gcc@8.3.1.2_cuda"
     HOST_CONFIG: "rzansel-blueos_3_ppc64le_ib_p9-${COMPILER}.cmake"
-  extends: [.src_build_on_rzansel, .with_cuda]
+  extends: [.src_build_on_rzansel]
 
 rzansel-xl_16_1_1-src:
   variables:
@@ -71,7 +66,7 @@ rzansel-xl_16_1_1_cuda-src:
   variables:
     COMPILER: "xl@16.1.1.2_cuda"
     HOST_CONFIG: "rzansel-blueos_3_ppc64le_ib_p9-${COMPILER}.cmake"
-  extends: [.src_build_on_rzansel, .with_cuda]
+  extends: [.src_build_on_rzansel]
 
 ####
 # Full Build jobs
@@ -86,7 +81,7 @@ rzansel-clang_10_0_1_cuda-full:
     COMPILER: "clang@10.0.1.2"
     SPEC: "%${COMPILER}+mfem+cuda~openmp"
     EXTRA_SPEC: "cuda_arch=70"
-  extends: [.full_build_on_rzansel, .with_cuda]
+  extends: [.full_build_on_rzansel]
 
 rzansel-gcc_8_3_1-full:
   variables:
@@ -99,7 +94,7 @@ rzansel-gcc_8_3_1_cuda-full:
     COMPILER: "gcc@8.3.1.2"
     SPEC: "%${COMPILER}~mfem+cuda"
     EXTRA_SPEC: "cuda_arch=70"
-  extends: [.full_build_on_rzansel, .with_cuda]
+  extends: [.full_build_on_rzansel]
 
 rzansel-xl_16_1_1-full:
   variables:
@@ -112,4 +107,4 @@ rzansel-xl_16_1_1_cuda-full:
     COMPILER: "xl@16.1.1.2"
     SPEC: "%${COMPILER}+mfem+cuda~openmp~cpp14"
     EXTRA_SPEC: "cuda_arch=70"
-  extends: [.full_build_on_rzansel, .with_cuda]
+  extends: [.full_build_on_rzansel]

--- a/.gitlab/build_rzgenie.yml
+++ b/.gitlab/build_rzgenie.yml
@@ -10,7 +10,7 @@
     - shell
     - rzgenie
   before_script:
-    - module load cmake/3.14.5
+    - module load cmake/3.18.0
 
 
 ####

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -13,6 +13,8 @@
     - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_TIOGA == "OFF"' #run except if ...
       when: never
     - when: on_success
+  before_script:
+    - module load cmake/3.21.1
 
 ####
 # Template

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -48,8 +48,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ### Changed
 - The Axom library has been broken down into its component libraries (prefixed with `axom_`).
   This change requires no change to downstream CMake users who import our targets.
-  The exported CMake target `axom` includes all components, but others will need to create the link line
-  themselves. The following replacement can be used:
+  The exported CMake target `axom` includes all components, but users who do not import our targets
+  will need to create the link line themselves. The following replacement can be used:
   `-laxom` -> `-laxom_quest -laxom_multimat -laxom_slam -laxom_mint -laxom_klee -laxom_inlet -laxom_sidre -laxom_slic -laxom_lumberjack -laxom_core`
   If you only need a subset of the components, you can now use those targets directly, ie. `axom::inlet`.
 - `IntersectionShaper` now implements material replacement rules.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -46,6 +46,12 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   and by calling `Shaper::setPercentError()` to set a refinement error percentage.
 
 ### Changed
+- The Axom library has been broken down into its component libraries (prefixed with `axom_`).
+  This change requires no change to downstream CMake users who import our targets.
+  The exported CMake target `axom` includes all components, but others will need to create the link line
+  themselves. The following replacement can be used:
+  `-laxom` -> `-laxom_quest -laxom_multimat -laxom_slam -laxom_mint -laxom_klee -laxom_inlet -laxom_sidre -laxom_slic -laxom_lumberjack -laxom_core`
+  If you only need a subset of the components, you can now use those targets directly, ie. `axom::inlet`.
 - `IntersectionShaper` now implements material replacement rules.
 - `axom::Array` move constructors are now `noexcept`.
 - Exported CMake targets, `cli11`, `fmt`, `sol`, and `sparsehash`, have been prefixed with `axom::`

--- a/src/axom/Axom.cpp
+++ b/src/axom/Axom.cpp
@@ -1,7 +1,0 @@
-// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
-// other Axom Project Developers. See the top-level LICENSE file for details.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-
-// This file is left intentionally blank because CMake requires
-// a source file for compiling libraries

--- a/src/axom/CMakeLists.txt
+++ b/src/axom/CMakeLists.txt
@@ -57,7 +57,7 @@ generate_export_header(core
 if(WIN32)
     foreach(_component ${AXOM_COMPONENTS_ENABLED})
         # Skip header only libraries
-        get_property(_targetType TARGET ${arg_TARGET} PROPERTY TYPE)
+        get_property(_targetType TARGET ${_component} PROPERTY TYPE)
         if(${_targetType} STREQUAL "INTERFACE_LIBRARY")
             continue()
         endif()

--- a/src/axom/CMakeLists.txt
+++ b/src/axom/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 # Core is an essential part of Axom and cannot be turned off
 axom_add_component(COMPONENT_NAME core DEFAULT_STATE ON)
-if(NOT AXOM_ENABLE_CORE)
+if(DEFINED AXOM_ENABLE_CORE)
     message(FATAL_ERROR "Core is an essential part of Axom and cannot be turned off")
 endif()
 
@@ -73,8 +73,7 @@ endif()
 # Output some information about the configuration
 #------------------------------------------------------------------------------
 foreach(_component ${AXOM_COMPONENTS_FULL})
-    string(TOUPPER ${_component} COMPONENT_NAME_UPPERCASE)
-    if(AXOM_ENABLE_${COMPONENT_NAME_UPPERCASE})
+    if(${_component} IN_LIST AXOM_COMPONENTS_ENABLED)
         message(STATUS "Axom component ${_component} is ON")
     else()
         message(STATUS "Axom component ${_component} is OFF")

--- a/src/axom/CMakeLists.txt
+++ b/src/axom/CMakeLists.txt
@@ -10,17 +10,16 @@
 #------------------------------------------------------------------------------
 
 # Core is an essential part of Axom and cannot be turned off
-add_subdirectory(core)
-set(AXOM_ENABLE_CORE ON CACHE BOOL "" FORCE)
-set(AXOM_COMPONENTS_FULL core CACHE STRING "List of all components in Axom" FORCE)
-set(AXOM_COMPONENTS_ENABLED core
-    CACHE STRING "List of all enabled components in Axom" FORCE)
+axom_add_component(COMPONENT_NAME core DEFAULT_STATE ON)
+if(NOT AXOM_ENABLE_CORE)
+    message(FATAL_ERROR "Core is an essential part of Axom and cannot be turned off")
+endif()
 
 # Lumberjack is a parallel message filtering and reduction library. It can be used
 # by itself or as a SLIC Log Stream. It is not meant for serial (non-mpi) executables.
 if(AXOM_ENABLE_MPI)
-    axom_add_component( COMPONENT_NAME lumberjack
-                        DEFAULT_STATE  ${AXOM_ENABLE_ALL_COMPONENTS})
+    axom_add_component(COMPONENT_NAME lumberjack
+                       DEFAULT_STATE  ${AXOM_ENABLE_ALL_COMPONENTS})
 else()
     message(STATUS "Axom Component Lumberjack turned off due to AXOM_ENABLE_MPI=OFF")
     set(AXOM_ENABLE_LUMBERJACK OFF CACHE BOOL "")
@@ -39,32 +38,31 @@ axom_add_component(COMPONENT_NAME klee   DEFAULT_STATE ${AXOM_ENABLE_ALL_COMPONE
 axom_add_component(COMPONENT_NAME quest  DEFAULT_STATE ${AXOM_ENABLE_ALL_COMPONENTS})
 axom_add_component(COMPONENT_NAME multimat DEFAULT_STATE ${AXOM_ENABLE_ALL_COMPONENTS})
 
-# Combine all component object libraries into a unified library
-blt_add_library(NAME       axom
-                SOURCES    Axom.cpp
-                DEPENDS_ON ${AXOM_COMPONENTS_ENABLED})
-
-install(TARGETS              axom
+install(TARGETS              ${AXOM_COMPONENTS_ENABLED}
         EXPORT               axom-targets
         DESTINATION          lib)
-install(EXPORT axom-targets DESTINATION lib/cmake)
+install(EXPORT               axom-targets 
+        NAMESPACE            axom::
+        DESTINATION          lib/cmake)
 
 #------------------------------------------------------------------------------
 # Generate export symbols
 #------------------------------------------------------------------------------
 include(GenerateExportHeader)
 set(_export_header ${PROJECT_BINARY_DIR}/axom_export_symbols)
-generate_export_header(axom  EXPORT_FILE_NAME ${_export_header})
+generate_export_header(core
+                       BASE_NAME axom
+                       EXPORT_FILE_NAME ${_export_header})
 
 #------------------------------------------------------------------------------
 # Output some information about the configuration
 #------------------------------------------------------------------------------
-foreach(comp ${AXOM_COMPONENTS_FULL})
-    string(TOUPPER ${comp} COMPONENT_NAME_UPPERCASE)
+foreach(_component ${AXOM_COMPONENTS_FULL})
+    string(TOUPPER ${_component} COMPONENT_NAME_UPPERCASE)
     if(AXOM_ENABLE_${COMPONENT_NAME_UPPERCASE})
-        message(STATUS "Axom component ${comp} is ON")
+        message(STATUS "Axom component ${_component} is ON")
     else()
-        message(STATUS "Axom component ${comp} is OFF")
+        message(STATUS "Axom component ${_component} is OFF")
     endif()
 endforeach()
 
@@ -99,9 +97,9 @@ endif()
 # Each axom component needs to have 'axom_EXPORTS' defined when building
 #------------------------------------------------------------------------------
 if(WIN32)
-    foreach(c ${AXOM_COMPONENTS_ENABLED})
+    foreach(_component ${AXOM_COMPONENTS_ENABLED})
         blt_add_target_definitions(
-            TO                 ${c}
+            TO                 ${_component}
             SCOPE              PRIVATE
             TARGET_DEFINITIONS "axom_EXPORTS")
     endforeach()

--- a/src/axom/CMakeLists.txt
+++ b/src/axom/CMakeLists.txt
@@ -54,6 +54,21 @@ generate_export_header(core
                        BASE_NAME axom
                        EXPORT_FILE_NAME ${_export_header})
 
+if(WIN32)
+    foreach(_component ${AXOM_COMPONENTS_ENABLED})
+        # Skip header only libraries
+        get_property(_targetType TARGET ${arg_TARGET} PROPERTY TYPE)
+        if(${_targetType} STREQUAL "INTERFACE_LIBRARY")
+            continue()
+        endif()
+
+        blt_add_target_definitions(
+            TO                 ${_component}
+            SCOPE              PRIVATE
+            TARGET_DEFINITIONS "axom_EXPORTS")
+    endforeach()
+endif()
+
 #------------------------------------------------------------------------------
 # Output some information about the configuration
 #------------------------------------------------------------------------------
@@ -75,10 +90,6 @@ endif()
 #------------------------------------------------------------------------------
 # Fix FOLDER property for some targets
 #------------------------------------------------------------------------------
-if(TARGET axom)
-    set_target_properties(axom PROPERTIES FOLDER "axom")
-endif()
-
 # If Axom is the main project, set FOLDER property for top-level check targets
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
     set(_code_check_targets "docs" "doxygen_docs"
@@ -88,19 +99,5 @@ if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
         if(TARGET ${_tgt})
             set_target_properties(${_tgt} PROPERTIES FOLDER "axom/code_checks")
         endif()
-    endforeach()
-endif()
-
-
-#------------------------------------------------------------------------------
-# Bugfix for dllimport/dllexport functionality in msvc with object libraries
-# Each axom component needs to have 'axom_EXPORTS' defined when building
-#------------------------------------------------------------------------------
-if(WIN32)
-    foreach(_component ${AXOM_COMPONENTS_ENABLED})
-        blt_add_target_definitions(
-            TO                 ${_component}
-            SCOPE              PRIVATE
-            TARGET_DEFINITIONS "axom_EXPORTS")
     endforeach()
 endif()

--- a/src/axom/core/CMakeLists.txt
+++ b/src/axom/core/CMakeLists.txt
@@ -97,10 +97,7 @@ set( core_depends fmt )
 blt_list_append( TO core_depends ELEMENTS camp IF CAMP_FOUND )
 blt_list_append( TO core_depends ELEMENTS umpire IF UMPIRE_FOUND )
 blt_list_append( TO core_depends ELEMENTS RAJA IF RAJA_FOUND )
-list(APPEND core_depends ${axom_device_depends})
 blt_list_append( TO core_depends ELEMENTS nvToolsExt IF AXOM_ENABLE_CUDA )
-
-blt_list_append( TO core_depends ELEMENTS openmp IF AXOM_ENABLE_OPENMP)
 blt_list_append( TO core_depends ELEMENTS mpi IF AXOM_ENABLE_MPI )
 
 # HACK: RAJA's dependencies are not getting added to core due to a bug in
@@ -113,12 +110,11 @@ endif()
 # Make/Install the library
 #------------------------------------------------------------------------------
 
-blt_add_library( NAME        core
+axom_add_library(NAME        core
                  SOURCES     ${core_sources}
                  HEADERS     ${core_headers}
                  DEPENDS_ON  ${core_depends}
                  FOLDER      axom/core
-                 OBJECT      TRUE
                  )
 
 # Basic includes that should be inherited to all Axom targets

--- a/src/axom/core/examples/CMakeLists.txt
+++ b/src/axom/core/examples/CMakeLists.txt
@@ -14,18 +14,16 @@ set(example_sources
     core_containers.cpp 
     core_acceleration.cpp)
 
-set( core_examples_depends axom ${axom_device_depends})
-
 #------------------------------------------------------------------------------
 # Add targets and tests for serial examples
 #------------------------------------------------------------------------------
 foreach(example_source ${example_sources})
     get_filename_component(exe_name ${example_source} NAME_WE)
-    blt_add_executable(
+    axom_add_executable(
         NAME        ${exe_name}_ex
         SOURCES     ${example_source}
         OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
-        DEPENDS_ON  ${core_examples_depends}
+        DEPENDS_ON  core
         FOLDER      axom/core/examples )
 
     if(AXOM_ENABLE_TESTS)
@@ -36,26 +34,26 @@ foreach(example_source ${example_sources})
 endforeach()
 
 if(AXOM_ENABLE_CUDA)
-    blt_add_executable(
+    axom_add_executable(
           NAME        core_acceleration_cuda_on_ex
           SOURCES     core_acceleration.cpp
           OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
-          DEPENDS_ON  ${core_examples_depends}
+          DEPENDS_ON  core
           FOLDER      axom/core/examples )
 
-    blt_add_executable(
+    axom_add_executable(
           NAME        core_containers_cuda_on_ex
           SOURCES     core_containers.cpp
           OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
-          DEPENDS_ON  ${core_examples_depends}
+          DEPENDS_ON  core
           FOLDER      axom/core/examples )
 endif()
 
-blt_add_executable(
+axom_add_executable(
     NAME        core_utilities_ex
     SOURCES     core_utilities.cpp
     OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
-    DEPENDS_ON  ${core_examples_depends}
+    DEPENDS_ON  core
     FOLDER      axom/core/examples )
 
 if(AXOM_ENABLE_TESTS)

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -47,8 +47,7 @@ set(core_serial_tests
     )
 
 set(core_test_depends
-    axom
-    ${axom_device_depends}
+    core
     gtest
     )
 
@@ -61,7 +60,7 @@ if (NOT AXOM_ENABLE_MPI)
   list(APPEND core_serial_tests core_types.hpp)
 endif()
 
-blt_add_executable( NAME       core_serial_tests
+axom_add_executable(NAME       core_serial_tests
                     SOURCES    core_serial_main.cpp
                     HEADERS    ${core_serial_tests}
                     OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
@@ -82,7 +81,7 @@ if (AXOM_ENABLE_MPI)
        core_types.hpp
        )
 
-  blt_add_executable( NAME       core_mpi_tests
+  axom_add_executable(NAME       core_mpi_tests
                       SOURCES    core_mpi_main.cpp
                       HEADERS    ${core_mpi_tests}
                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
@@ -105,11 +104,11 @@ if (AXOM_ENABLE_OPENMP AND AXOM_USE_RAJA)
        core_openmp_map.hpp
        )
 
-  blt_add_executable( NAME       core_openmp_tests
+  axom_add_executable(NAME       core_openmp_tests
                       SOURCES    core_openmp_main.cpp
                       HEADERS    ${core_mpi_tests}
                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                      DEPENDS_ON ${core_test_depends} openmp
+                      DEPENDS_ON ${core_test_depends}
                       FOLDER     axom/core/tests )
 
   foreach( test_suite ${core_openmp_tests} )
@@ -123,11 +122,11 @@ endif()
 #------------------------------------------------------------------------------
 # Add a test to query properties of the configuration
 #------------------------------------------------------------------------------
-set(utils_config_test_depends core ${axom_device_depends} gtest )
+set(utils_config_test_depends core gtest )
 
 blt_list_append( TO utils_config_test_depends ELEMENTS mfem IF MFEM_FOUND )
 
-blt_add_executable( NAME       utils_config_test
+axom_add_executable(NAME       utils_config_test
                     SOURCES    utils_config.cpp
                     OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                     DEPENDS_ON ${utils_config_test_depends}

--- a/src/axom/inlet/CMakeLists.txt
+++ b/src/axom/inlet/CMakeLists.txt
@@ -53,16 +53,15 @@ blt_list_append(TO inlet_sources ELEMENTS LuaReader.cpp IF SOL_FOUND)
 #------------------------------------------------------------------------------
 # Make/Install the library
 #------------------------------------------------------------------------------
-set(inlet_depends sidre slic core ${axom_device_depends} fmt)
+set(inlet_depends sidre fmt)
 
 blt_list_append(TO inlet_depends ELEMENTS sol lua IF SOL_FOUND)
 
-blt_add_library( NAME        inlet
+axom_add_library(NAME        inlet
                  SOURCES     ${inlet_sources}
                  HEADERS     ${inlet_headers}
                  DEPENDS_ON  ${inlet_depends}
-                 FOLDER      axom/inlet
-                 OBJECT      TRUE )
+                 FOLDER      axom/inlet )
 
 # Set file back to C++ due to nvcc compiler error
 set_source_files_properties(LuaReader.cpp PROPERTIES LANGUAGE CXX)
@@ -84,7 +83,7 @@ endif()
 #------------------------------------------------------------------------------
 # Add tests
 #------------------------------------------------------------------------------
-if (AXOM_ENABLE_TESTS AND ENABLE_GMOCK)
+if (AXOM_ENABLE_TESTS)
   add_subdirectory(tests)
 endif()
 

--- a/src/axom/inlet/examples/CMakeLists.txt
+++ b/src/axom/inlet/examples/CMakeLists.txt
@@ -34,10 +34,10 @@ blt_list_append(
 
 foreach(example ${inlet_examples})
     get_filename_component( ex_name ${example} NAME_WE )
-    blt_add_executable( NAME       inlet_${ex_name}_ex
+    axom_add_executable(NAME       inlet_${ex_name}_ex
                         SOURCES    ${example}
                         OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-                        DEPENDS_ON axom ${axom_device_depends}
+                        DEPENDS_ON inlet
                         FOLDER     axom/inlet/examples )
 endforeach()
 
@@ -47,10 +47,10 @@ if (SOL_FOUND)
 endif()
 
 if (SOL_FOUND AND MFEM_FOUND)
-    blt_add_executable( NAME       inlet_mfem_coefficient_ex
+    axom_add_executable(NAME       inlet_mfem_coefficient_ex
                         SOURCES    mfem_coefficient.cpp
                         OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-                        DEPENDS_ON axom ${axom_device_depends} mfem
+                        DEPENDS_ON inlet
                         FOLDER     axom/inlet/examples )
 endif()
 

--- a/src/axom/inlet/tests/CMakeLists.txt
+++ b/src/axom/inlet/tests/CMakeLists.txt
@@ -10,29 +10,27 @@
 # Specify list of tests
 #------------------------------------------------------------------------------
 
+axom_add_library(NAME        inlet_test_utils
+                 SOURCES     inlet_test_utils.cpp
+                 HEADERS     inlet_test_utils.hpp
+                 DEPENDS_ON  inlet gtest
+                 FOLDER      axom/inlet/tests )
+
 # Add Serial GTests based tests
 set(gtest_inlet_tests
     inlet_Reader.cpp
     inlet_jsonschema_writer.cpp
-    inlet_Inlet.cpp 
-    inlet_object.cpp
     inlet_restart.cpp
     inlet_errors.cpp )
 
 blt_list_append(TO gtest_inlet_tests ELEMENTS inlet_function.cpp IF SOL_FOUND)
 
-blt_add_library(NAME        inlet_test_utils
-                SOURCES     inlet_test_utils.cpp
-                HEADERS     inlet_test_utils.hpp
-                DEPENDS_ON  axom ${axom_device_depends} gtest gmock
-                FOLDER      axom/inlet/tests )
-
 foreach(test ${gtest_inlet_tests})
     get_filename_component( test_name ${test} NAME_WE )
-    blt_add_executable( NAME       ${test_name}_test
+    axom_add_executable(NAME       ${test_name}_test
                         SOURCES    ${test}
                         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                        DEPENDS_ON gtest inlet_test_utils ${axom_device_depends}
+                        DEPENDS_ON inlet_test_utils
                         FOLDER     axom/inlet/tests )
     axom_add_test( NAME    ${test_name} 
                    COMMAND ${test_name}_test )
@@ -41,4 +39,22 @@ endforeach()
 if(SOL_FOUND)
     # Set file back to C++ due to nvcc compiler error
     set_source_files_properties(inlet_function.cpp PROPERTIES LANGUAGE CXX)
+endif()
+
+if(ENABLE_GMOCK)
+    # Add Serial GMock based tests
+    set(gmock_inlet_tests
+        inlet_Inlet.cpp 
+        inlet_object.cpp )
+
+    foreach(test ${gmock_inlet_tests})
+        get_filename_component( test_name ${test} NAME_WE )
+        axom_add_executable(NAME       ${test_name}_test
+                            SOURCES    ${test}
+                            OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                            DEPENDS_ON inlet_test_utils gmock
+                            FOLDER     axom/inlet/tests )
+        axom_add_test( NAME    ${test_name} 
+                       COMMAND ${test_name}_test )
+    endforeach()
 endif()

--- a/src/axom/klee/CMakeLists.txt
+++ b/src/axom/klee/CMakeLists.txt
@@ -39,15 +39,12 @@ set(klee_sources
 #------------------------------------------------------------------------------
 # Make/Install the library
 #------------------------------------------------------------------------------
-set(klee_depends core primal slic sidre inlet ${axom_device_depends} fmt)
-
-blt_add_library(NAME        klee
-                SOURCES     ${klee_sources}
-                HEADERS     ${klee_headers} ${klee_internal_headers}
-                DEPENDS_ON  ${klee_depends}
-                FOLDER      axom/klee
-                OBJECT      TRUE
-                )
+axom_add_library(NAME        klee
+                 SOURCES     ${klee_sources}
+                 HEADERS     ${klee_headers} ${klee_internal_headers}
+                 DEPENDS_ON  inlet
+                 FOLDER      axom/klee
+                 )
 
 axom_write_unified_header( NAME klee
                            HEADERS ${klee_headers}
@@ -57,13 +54,6 @@ axom_install_component( NAME    klee
                         HEADERS ${klee_headers}
                         )
 
-
-#------------------------------------------------------------------------------
-# Add examples
-#------------------------------------------------------------------------------
-#if (AXOM_ENABLE_EXAMPLES)
-#  add_subdirectory(examples)
-#endif()
 
 #------------------------------------------------------------------------------
 # Add tests

--- a/src/axom/klee/tests/CMakeLists.txt
+++ b/src/axom/klee/tests/CMakeLists.txt
@@ -22,11 +22,11 @@ set(gtest_klee_tests
     klee_units.cpp
    )
 
-blt_add_library(
+axom_add_library(
         NAME        klee_test_utils
         SOURCES     KleeTestUtils.cpp
         HEADERS     KleeTestUtils.hpp KleeMatchers.hpp
-        DEPENDS_ON  axom ${axom_device_depends} gtest gmock
+        DEPENDS_ON  klee gtest gmock
         FOLDER      axom/klee/tests)
 
 #
@@ -34,10 +34,10 @@ blt_add_library(
 #
 foreach(test ${gtest_klee_tests})
     get_filename_component( test_name ${test} NAME_WE )
-    blt_add_executable( NAME ${test_name}_test
-                        SOURCES ${test}
-                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                        DEPENDS_ON gtest klee_test_utils ${axom_device_depends}
+    axom_add_executable(NAME        ${test_name}_test
+                        SOURCES     ${test}
+                        OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
+                        DEPENDS_ON  klee_test_utils
                         FOLDER      axom/klee/tests )
     blt_add_test( NAME ${test_name}
                   COMMAND ${test_name}_test )

--- a/src/axom/lumberjack/CMakeLists.txt
+++ b/src/axom/lumberjack/CMakeLists.txt
@@ -32,12 +32,11 @@ set(lumberjack_sources
 #------------------------------------------------------------------------------
 # Make/Install the library
 #------------------------------------------------------------------------------
-blt_add_library( NAME        lumberjack
+axom_add_library(NAME        lumberjack
                  SOURCES     ${lumberjack_sources}
                  HEADERS     ${lumberjack_headers}
                  DEPENDS_ON  core mpi
                  FOLDER      axom/lumberjack
-                 OBJECT      TRUE
                  )
 
 axom_write_unified_header(NAME    lumberjack

--- a/src/axom/lumberjack/examples/CMakeLists.txt
+++ b/src/axom/lumberjack/examples/CMakeLists.txt
@@ -6,9 +6,8 @@
 # Examples for Lumberjack component
 #------------------------------------------------------------------------------
 
-blt_add_executable(NAME lumberjack_basic_ex
-                   SOURCES basicExample.cpp
-                   OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-                   DEPENDS_ON axom 
-                   FOLDER axom/lumberjack/examples )
-
+axom_add_executable(NAME lumberjack_basic_ex
+                    SOURCES basicExample.cpp
+                    OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
+                    DEPENDS_ON lumberjack 
+                    FOLDER axom/lumberjack/examples )

--- a/src/axom/lumberjack/tests/CMakeLists.txt
+++ b/src/axom/lumberjack/tests/CMakeLists.txt
@@ -14,12 +14,12 @@ set(lumberjack_serial_tests
     lumberjack_Message.hpp
     lumberjack_TextEqualityCombiner.hpp )
 
-blt_add_executable(NAME       lumberjack_serial_tests
-                   SOURCES    lumberjack_serial_main.cpp
-                   HEADERS    ${lumberjack_serial_tests}
-                   OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                   DEPENDS_ON axom gtest 
-                   FOLDER     axom/lumberjack/tests )
+axom_add_executable(NAME       lumberjack_serial_tests
+                    SOURCES    lumberjack_serial_main.cpp
+                    HEADERS    ${lumberjack_serial_tests}
+                    OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                    DEPENDS_ON lumberjack gtest 
+                    FOLDER     axom/lumberjack/tests )
 
 foreach(test_suite ${lumberjack_serial_tests})
     get_filename_component(test_suite ${test_suite} NAME_WE)
@@ -35,12 +35,12 @@ set(lumberjack_mpi_tests
     lumberjack_BinaryCommunicator.hpp
     lumberjack_RootCommunicator.hpp )
 
-blt_add_executable(NAME       lumberjack_mpi_tests
-                   SOURCES    lumberjack_mpi_main.cpp
-                   HEADERS    ${lumberjack_mpi_tests}
-                   OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                   DEPENDS_ON axom gtest 
-                   FOLDER     axom/lumberjack/tests )
+axom_add_executable(NAME       lumberjack_mpi_tests
+                    SOURCES    lumberjack_mpi_main.cpp
+                    HEADERS    ${lumberjack_mpi_tests}
+                    OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                    DEPENDS_ON lumberjack gtest 
+                    FOLDER     axom/lumberjack/tests )
 
 foreach(test_suite ${lumberjack_mpi_tests})
     get_filename_component( test_suite ${test_suite} NAME_WE )
@@ -54,11 +54,11 @@ endforeach()
 #------------------------------------------------------------------------------
 # Single source file tests
 #------------------------------------------------------------------------------
-blt_add_executable(NAME       lumberjack_speed_test
-                   SOURCES    lumberjack_speedTest.cpp
-                   OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                   DEPENDS_ON axom
-                   FOLDER     axom/lumberjack/tests )
+axom_add_executable(NAME       lumberjack_speed_test
+                    SOURCES    lumberjack_speedTest.cpp
+                    OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                    DEPENDS_ON lumberjack
+                    FOLDER     axom/lumberjack/tests )
 
 set(lumberjack_sample_input_dir ${PROJECT_SOURCE_DIR}/axom/lumberjack/tests/sampleInput)
 axom_add_test(NAME          lumberjack_speedTest_binary

--- a/src/axom/mint/CMakeLists.txt
+++ b/src/axom/mint/CMakeLists.txt
@@ -120,25 +120,22 @@ set( mint_sources
 # Make/Install the library
 #------------------------------------------------------------------------------
 set( mint_dependencies
-     core
      slic
-     ${axom_device_depends}
      )
 
 if (AXOM_MINT_USE_SIDRE)
-   list( APPEND mint_dependencies sidre conduit::conduit )
+   list( APPEND mint_dependencies sidre)
    blt_list_append( TO mint_dependencies ELEMENTS hdf5 IF HDF5_FOUND )
 endif()
 
 blt_list_append( TO mint_dependencies ELEMENTS RAJA IF RAJA_FOUND )
 
-blt_add_library(
+axom_add_library(
     NAME       mint
     SOURCES    ${mint_sources}
     HEADERS    ${mint_headers}
     DEPENDS_ON ${mint_dependencies}
     FOLDER     axom/mint
-    OBJECT     TRUE
    )
 
 axom_write_unified_header(NAME    mint

--- a/src/axom/mint/examples/CMakeLists.txt
+++ b/src/axom/mint/examples/CMakeLists.txt
@@ -20,17 +20,15 @@ set( mint_examples
      user_guide/mint_getting_started.cpp
    )
 
-set( mint_example_dependencies axom ${axom_device_depends})
-
 foreach( example ${mint_examples} )
 
    get_filename_component( example_name ${example} NAME_WE )
 
-   blt_add_executable(
+   axom_add_executable(
         NAME       ${example_name}_ex
         SOURCES    ${example}
         OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-        DEPENDS_ON ${mint_example_dependencies}
+        DEPENDS_ON mint
         FOLDER     axom/mint/examples
         )
 

--- a/src/axom/mint/tests/CMakeLists.txt
+++ b/src/axom/mint/tests/CMakeLists.txt
@@ -43,17 +43,15 @@ set( mint_tests
      mint_deprecated_mcarray.cpp
    )
 
-set( mint_test_dependencies axom ${axom_device_depends})
-
 foreach( test ${mint_tests} )
 
    get_filename_component( test_name ${test} NAME_WE )
 
-   blt_add_executable(
+   axom_add_executable(
         NAME       ${test_name}_test
         SOURCES    ${test}
         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-        DEPENDS_ON ${mint_test_dependencies} gtest
+        DEPENDS_ON mint gtest
         FOLDER     axom/mint/tests
         )
 

--- a/src/axom/multimat/CMakeLists.txt
+++ b/src/axom/multimat/CMakeLists.txt
@@ -28,15 +28,12 @@ set(multimat_sources
 #------------------------------------------------------------------------------
 # Build and install the library
 #------------------------------------------------------------------------------
-set(multimat_depends_on core slam slic ${axom_device_depends})
-
-blt_add_library(
+axom_add_library(
     NAME        multimat
     SOURCES     ${multimat_sources}
     HEADERS     ${multimat_headers}
-    DEPENDS_ON  ${multimat_depends_on}
+    DEPENDS_ON  slam
     FOLDER      axom/multimat
-    OBJECT      TRUE
     )
 
 # Set file back to C++ due to nvcc compiler error

--- a/src/axom/multimat/examples/CMakeLists.txt
+++ b/src/axom/multimat/examples/CMakeLists.txt
@@ -16,16 +16,14 @@ set(multimat_example_sources
     calculate.cpp
     traversal.cpp )
 
-set(multimat_tests_depends_on slic slam multimat ${axom_device_depends})
-
 foreach(example_source ${multimat_example_sources})
     get_filename_component(example_name ${example_source} NAME_WE)
-    blt_add_executable(
-        NAME        "multimat_${example_name}_ex"
+    axom_add_executable(
+        NAME        multimat_${example_name}_ex
         HEADERS     ${multimat_example_headers}
         SOURCES     ${example_source}
         OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
-        DEPENDS_ON  ${multimat_tests_depends_on}
+        DEPENDS_ON  multimat
         FOLDER      axom/multimat/examples
         )
 

--- a/src/axom/multimat/tests/CMakeLists.txt
+++ b/src/axom/multimat/tests/CMakeLists.txt
@@ -14,18 +14,16 @@ set(gtest_multimat_tests
     multimat_test.cpp
     )
 
-set(multimat_tests_depends_on core slic slam multimat ${axom_device_depends} gtest)
-
 #------------------------------------------------------------------------------
 # Add gtest based tests
 #------------------------------------------------------------------------------
 foreach(test ${gtest_multimat_tests})
     get_filename_component( test_name ${test} NAME_WE )
-    blt_add_executable( NAME ${test_name}_test
-                        SOURCES ${test}
+    axom_add_executable(NAME       ${test_name}_test
+                        SOURCES    ${test}
                         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                        DEPENDS_ON ${multimat_tests_depends_on} 
-                        FOLDER axom/multimat/tests )
+                        DEPENDS_ON multimat gtest
+                        FOLDER     axom/multimat/tests )
     blt_add_test( NAME ${test_name}
                   COMMAND ${test_name}_test )
 endforeach()

--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -88,19 +88,16 @@ blt_list_append(
 #------------------------------------------------------------------------------
 set( primal_dependencies
      slic
-     core
-     ${axom_device_depends}
      )
 
 blt_list_append( TO primal_dependencies ELEMENTS mfem IF MFEM_FOUND )
 
-blt_add_library(
+axom_add_library(
     NAME                  primal
     SOURCES               ${primal_sources}
     HEADERS               ${primal_headers}
     FOLDER                axom/primal
     DEPENDS_ON            ${primal_dependencies}
-    OBJECT                TRUE
     )
 
 axom_write_unified_header(NAME    primal

--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -70,12 +70,6 @@ set( primal_headers
     utils/ZipVector.hpp
    )
 
-set( primal_sources
-
-     ## Empty source file
-     dummy.cpp
-   )
-
 blt_list_append(
     TO       primal_headers 
     ELEMENTS operators/evaluate_integral.hpp
@@ -94,7 +88,6 @@ blt_list_append( TO primal_dependencies ELEMENTS mfem IF MFEM_FOUND )
 
 axom_add_library(
     NAME                  primal
-    SOURCES               ${primal_sources}
     HEADERS               ${primal_headers}
     FOLDER                axom/primal
     DEPENDS_ON            ${primal_dependencies}

--- a/src/axom/primal/dummy.cpp
+++ b/src/axom/primal/dummy.cpp
@@ -1,6 +1,0 @@
-// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
-// other Axom Project Developers. See the top-level COPYRIGHT file for details.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-
-// Dummy source for primal

--- a/src/axom/primal/examples/CMakeLists.txt
+++ b/src/axom/primal/examples/CMakeLists.txt
@@ -6,21 +6,20 @@
 # Primal examples
 #------------------------------------------------------------------------------
 
-set( primal_examples 
+set(primal_examples 
     primal_introduction.cpp
-   )
+    )
 
 set(primal_example_depends
-        axom
-        ${axom_device_depends}
-        fmt
-        )
+    primal
+    fmt
+    )
 
 foreach ( example ${primal_examples} )
 
     get_filename_component( example_name ${example} NAME_WE )
 
-    blt_add_executable(
+    axom_add_executable(
         NAME        ${example_name}_ex
         SOURCES     ${example}
         OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
@@ -30,9 +29,9 @@ foreach ( example ${primal_examples} )
 
 endforeach()
 
-if (AXOM_ENABLE_PRIMAL AND RAJA_FOUND AND UMPIRE_FOUND)
+if (RAJA_FOUND AND UMPIRE_FOUND)
 
-    blt_add_executable(
+    axom_add_executable(
         NAME        hex_tet_volume_ex
         SOURCES     hex_tet_volume.cpp
         OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}

--- a/src/axom/primal/tests/CMakeLists.txt
+++ b/src/axom/primal/tests/CMakeLists.txt
@@ -47,15 +47,13 @@ blt_list_append(
     IF       MFEM_FOUND 
                )
 
-set(primal_test_depends axom ${axom_device_depends} fmt gtest)
-
-blt_list_append( TO primal_test_depends ELEMENTS openmp IF AXOM_ENABLE_OPENMP )
+set(primal_test_depends primal fmt gtest)
 
 foreach ( test ${primal_tests} )
 
    get_filename_component( test_name ${test} NAME_WE )
 
-   blt_add_executable(
+   axom_add_executable(
         NAME       ${test_name}_test
         SOURCES    ${test}
         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}

--- a/src/axom/quest/CMakeLists.txt
+++ b/src/axom/quest/CMakeLists.txt
@@ -86,13 +86,8 @@ set( quest_sources
 
 
 set( quest_depends_on
-    core
-    slic
-    mint
-    slam
     spin
-    primal
-    ${axom_device_depends}
+    mint
     fmt
     )
 
@@ -117,6 +112,7 @@ if(MFEM_FOUND AND AXOM_ENABLE_KLEE AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_MFEM_SI
                               detail/shaping/shaping_helpers.hpp)
     list(APPEND quest_sources Shaper.cpp
                               detail/shaping/shaping_helpers.cpp)
+    list(APPEND quest_depends_on klee)
 endif()
 
 if(C2C_FOUND)
@@ -133,8 +129,6 @@ if (AXOM_ENABLE_MPI)
     list(APPEND quest_sources readers/PSTLReader.cpp
                               readers/PProEReader.cpp)
     blt_list_append(TO quest_sources IF C2C_FOUND ELEMENTS readers/PC2CReader.cpp)
-    
-    list(APPEND quest_depends_on mpi)
 endif()
 
 if (SHROUD_FOUND)
@@ -160,13 +154,12 @@ endif()
 #------------------------------------------------------------------------------
 # Make and install the library
 #------------------------------------------------------------------------------
-blt_add_library(
+axom_add_library(
     NAME        quest
     SOURCES     ${quest_sources}
     HEADERS     ${quest_headers}
     DEPENDS_ON  ${quest_depends_on}
     FOLDER      axom/quest
-    OBJECT      TRUE
     )
 
 axom_write_unified_header(NAME    quest

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -6,14 +6,14 @@
 # Quest examples
 #------------------------------------------------------------------------------
 
-set(quest_example_depends axom ${axom_device_depends} fmt cli11)
+set(quest_example_depends quest fmt cli11)
 
 blt_list_append(TO quest_example_depends ELEMENTS RAJA IF RAJA_FOUND)
 
 set(quest_data_dir  ${AXOM_DATA_DIR}/quest)
 
 # In/out octree containment example -------------------------------------------
-blt_add_executable(
+axom_add_executable(
     NAME        quest_containment_driver_ex
     SOURCES     containment_driver.cpp
     OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
@@ -25,7 +25,7 @@ blt_add_executable(
 if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                    AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION
                    AND AXOM_ENABLE_KLEE)
-    blt_add_executable(
+    axom_add_executable(
         NAME        quest_shaping_driver_ex
         SOURCES     shaping_driver.cpp
         OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
@@ -36,7 +36,7 @@ endif()
 
 # Distributed closest point example -------------------------------------------
 if(AXOM_ENABLE_MPI AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_HDF5)
-    blt_add_executable(
+    axom_add_executable(
             NAME        quest_distributed_distance_query_ex
             SOURCES     quest_distributed_distance_query_example.cpp
             OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
@@ -93,7 +93,7 @@ endif()
 
 # Point in cell example -------------------------------------------------------
 if(MFEM_FOUND)
-    blt_add_executable(
+    axom_add_executable(
         NAME        quest_point_in_cell_benchmark_ex
         SOURCES     point_in_cell_benchmark.cpp
         OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
@@ -103,7 +103,7 @@ if(MFEM_FOUND)
 endif()
 
 # Delaunay triangulation example ----------------------------------------------
-blt_add_executable(
+axom_add_executable(
     NAME        quest_delaunay_triangulation_ex
     SOURCES     delaunay_triangulation.cpp
     OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
@@ -122,7 +122,7 @@ endif()
 
 # Scattered interpolation example --------------------------------------------
 if(AXOM_ENABLE_SIDRE)
-    blt_add_executable(
+    axom_add_executable(
         NAME        quest_scattered_interpolation_ex
         SOURCES     scattered_interpolation.cpp
         OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
@@ -143,7 +143,7 @@ endif()
 
 # Quest signed distance and inout interface examples (C++ and Fortran) --------
 
-blt_add_executable(
+axom_add_executable(
     NAME       quest_signed_distance_interface_ex
     SOURCES    quest_signed_distance_interface.cpp
     OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
@@ -151,7 +151,7 @@ blt_add_executable(
     FOLDER      axom/quest/examples
     )
 
-blt_add_executable(
+axom_add_executable(
     NAME        quest_inout_interface_ex
     SOURCES     quest_inout_interface.cpp
     OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
@@ -202,7 +202,7 @@ if (ENABLE_FORTRAN)
 
     foreach(_t ${quest_fortran_examples})
         set(_example_name "${_t}_F_ex")
-        blt_add_executable(
+        axom_add_executable(
             NAME       ${_example_name}
             SOURCES    ${_t}.F
             OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}

--- a/src/axom/quest/tests/CMakeLists.txt
+++ b/src/axom/quest/tests/CMakeLists.txt
@@ -27,21 +27,19 @@ blt_list_append(TO       quest_tests
                 ELEMENTS quest_meshtester.cpp)
 
 set(quest_tests_depends
-    axom
-    ${axom_device_depends}
-    fmt
+    quest
     gtest
    )
 
 foreach(test ${quest_tests})
     get_filename_component( test_name ${test} NAME_WE )
 
-    blt_add_executable(
-        NAME ${test_name}_test
-        SOURCES ${test}
+    axom_add_executable(
+        NAME       ${test_name}_test
+        SOURCES    ${test}
         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
         DEPENDS_ON ${quest_tests_depends}
-        FOLDER axom/quest/tests
+        FOLDER     axom/quest/tests
         )
 
     axom_add_test(
@@ -63,12 +61,12 @@ endif()
 
 if(MFEM_FOUND)
     set(test_name quest_point_in_cell_mfem)
-    blt_add_executable(
-        NAME ${test_name}
-        SOURCES ${test_name}.cpp
+    axom_add_executable(
+        NAME       ${test_name}
+        SOURCES    ${test_name}.cpp
         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
         DEPENDS_ON ${quest_tests_depends} mfem
-        FOLDER axom/quest/tests
+        FOLDER      axom/quest/tests
         )
 
     string(STRIP "${AXOM_DISABLE_UNUSED_PARAMETER_WARNINGS}" MFEM_COMPILE_FLAGS)
@@ -108,12 +106,12 @@ blt_list_append(TO       quest_mpi_tests
 
 foreach(test ${quest_mpi_tests})
     get_filename_component( test_name ${test} NAME_WE )
-    blt_add_executable(
-        NAME ${test_name}_test
-        SOURCES ${test_name}.cpp
+    axom_add_executable(
+        NAME       ${test_name}_test
+        SOURCES    ${test_name}.cpp
         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
         DEPENDS_ON ${quest_tests_depends}
-        FOLDER axom/quest/tests
+        FOLDER     axom/quest/tests
     )
 
     set(_numMPITasks 4)
@@ -150,11 +148,11 @@ if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
        )
     foreach(test ${quest_mpi_mfem_c2c_data_tests})
         get_filename_component( test_name ${test} NAME_WE )
-        blt_add_executable(
+        axom_add_executable(
             NAME ${test_name}_test
             SOURCES ${test_name}.cpp
             OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-            DEPENDS_ON ${quest_tests_depends} mfem mpi
+            DEPENDS_ON ${quest_tests_depends} mfem
             FOLDER axom/quest/tests
         )
 
@@ -193,12 +191,12 @@ if (AXOM_ENABLE_MPI AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_HDF5)
 
     set(test_name quest_regression_test)
 
-    blt_add_executable(
-        NAME ${test_name}
-        SOURCES quest_regression.cpp
+    axom_add_executable(
+        NAME       ${test_name}
+        SOURCES    quest_regression.cpp
         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
         DEPENDS_ON ${quest_regression_depends}
-        FOLDER axom/quest/tests
+        FOLDER     axom/quest/tests
         )
 
     if ( NOT AXOM_ENABLE_OPENMP )

--- a/src/axom/sidre/CMakeLists.txt
+++ b/src/axom/sidre/CMakeLists.txt
@@ -101,9 +101,9 @@ endif()
 # Build and install the library
 #------------------------------------------------------------------------------
 set(sidre_depends
-    core
+    slic
     conduit::conduit
-    slic)
+    )
 
 blt_list_append(TO sidre_depends ELEMENTS hdf5 IF HDF5_FOUND)
 blt_list_append(TO sidre_depends ELEMENTS sparsehash IF SPARSEHASH_FOUND)
@@ -114,18 +114,16 @@ endif()
 
 # Include additional dependencies for spio when MPI is available
 if(AXOM_ENABLE_MPI)
-    list(APPEND sidre_depends fmt mpi)
-    blt_list_append(TO sidre_depends ELEMENTS conduit::conduit_mpi IF AXOM_ENABLE_MPI)
+    list(APPEND sidre_depends conduit::conduit_mpi fmt)
     blt_list_append(TO sidre_depends ELEMENTS scr IF SCR_FOUND)
 endif()
 
 
-blt_add_library( NAME       sidre
+axom_add_library(NAME       sidre
                  SOURCES    ${sidre_sources}
                  HEADERS    ${sidre_headers}
                  DEPENDS_ON ${sidre_depends}
-                 FOLDER     axom/sidre
-                 OBJECT     TRUE )
+                 FOLDER     axom/sidre)
 
 axom_write_unified_header(NAME    sidre
                           HEADERS ${sidre_headers})

--- a/src/axom/sidre/examples/CMakeLists.txt
+++ b/src/axom/sidre/examples/CMakeLists.txt
@@ -35,19 +35,17 @@ elseif(UNIX)
     set(EXTRA_LIBS rt)
 endif()
 
-list(APPEND EXTRA_LIBS ${axom_device_depends} )
-
 #------------------------------------------------------------------------------
 # Add targets and tests for serial examples
 #------------------------------------------------------------------------------
 foreach(example_source ${example_sources})
     get_filename_component(exe_name ${example_source} NAME_WE)
-    blt_add_executable(
-        NAME ${exe_name}_ex
-        SOURCES ${example_source}
+    axom_add_executable(
+        NAME       ${exe_name}_ex
+        SOURCES    ${example_source}
         OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-        DEPENDS_ON  axom ${EXTRA_LIBS}
-        FOLDER axom/sidre/examples )
+        DEPENDS_ON  sidre ${EXTRA_LIBS}
+        FOLDER      axom/sidre/examples )
 
     if(AXOM_ENABLE_TESTS)
         axom_add_test(
@@ -62,11 +60,11 @@ endforeach()
 if(AXOM_ENABLE_MPI)
     foreach(example_source ${example_parallel_sources})
         get_filename_component(exe_name ${example_source} NAME_WE)
-        blt_add_executable(
-            NAME ${exe_name}_ex
-            SOURCES ${example_source}
+        axom_add_executable(
+            NAME       ${exe_name}_ex
+            SOURCES    ${example_source}
             OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-            DEPENDS_ON  axom ${EXTRA_LIBS} mpi
+            DEPENDS_ON sidre ${EXTRA_LIBS}
             FOLDER axom/sidre/examples)
 
         if(AXOM_ENABLE_TESTS)
@@ -98,16 +96,14 @@ if(MFEM_FOUND AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION)
         sidre_mfem_datacollection_restart.cpp
         sidre_mfem_datacollection_vis.cpp)
 
-    set(_mfem_dc_test_depends axom mfem ${EXTRA_LIBS})
-
     foreach(example_source ${_mfem_dc_tests})
         get_filename_component(exe_name ${example_source} NAME_WE)
-        blt_add_executable(
-            NAME ${exe_name}_ex
-            SOURCES ${example_source}
-            OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-            DEPENDS_ON  ${_mfem_dc_test_depends}
-            FOLDER axom/sidre/examples)
+        axom_add_executable(
+            NAME        ${exe_name}_ex
+            SOURCES     ${example_source}
+            OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
+            DEPENDS_ON  sidre ${EXTRA_LIBS}
+            FOLDER      axom/sidre/examples)
 
         if(AXOM_ENABLE_TESTS)
             if(AXOM_ENABLE_MPI)
@@ -135,7 +131,7 @@ endif()
 if(ENABLE_FORTRAN)
     foreach(example_source ${F_example_sources})
         get_filename_component(exe_name ${example_source} NAME_WE)
-        blt_add_executable(
+        axom_add_executable(
             NAME ${exe_name}_ex
             SOURCES ${example_source}
             OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}

--- a/src/axom/sidre/examples/lulesh2/CMakeLists.txt
+++ b/src/axom/sidre/examples/lulesh2/CMakeLists.txt
@@ -17,21 +17,13 @@ set(lulesh_sources
     lulesh-util.cc
     lulesh-viz.cc )
 
-set(lulesh_depends
-    sidre
-    slic
-    core
-    ${axom_device_depends} )
-
-blt_list_append( TO lulesh_depends ELEMENTS hdf5   IF HDF5_FOUND )
-
-blt_add_executable(
-    NAME sidre_lulesh2_ex
-    SOURCES ${lulesh_sources}
-    HEADERS ${lulesh_headers}
+axom_add_executable(
+    NAME       sidre_lulesh2_ex
+    SOURCES    ${lulesh_sources}
+    HEADERS    ${lulesh_headers}
     OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-    DEPENDS_ON ${lulesh_depends}
-    FOLDER axom/sidre/examples )
+    DEPENDS_ON sidre
+    FOLDER     axom/sidre/examples )
 
 if(AXOM_ENABLE_TESTS)
     if(AXOM_ENABLE_MPI)

--- a/src/axom/sidre/examples/spio/CMakeLists.txt
+++ b/src/axom/sidre/examples/spio/CMakeLists.txt
@@ -14,16 +14,14 @@ set(spio_example_sources
     IOWrite.cpp
     )
 
-set(spio_example_depends axom ${EXTRA_LIBS})
-blt_list_append(TO spio_example_depends ELEMENTS hdf5 IF HDF5_FOUND)
-blt_list_append(TO spio_example_depends ELEMENTS scr  IF SCR_FOUND)
+set(spio_example_depends sidre ${EXTRA_LIBS})
 
 #------------------------------------------------------------------------------
 # Add targets and tests for spio examples
 #------------------------------------------------------------------------------
 foreach(src ${spio_example_sources})
     get_filename_component(exe_name ${src} NAME_WE)
-    blt_add_executable(
+    axom_add_executable(
         NAME       spio_${exe_name}_ex
         SOURCES    ${src}
         OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
@@ -35,11 +33,11 @@ endforeach()
 if(SCR_FOUND AND AXOM_ENABLE_TESTS)
     # Note: This example is a combination of a test and an example due
     # inability to run two SCR executables at the same time
-    blt_add_executable(
+    axom_add_executable(
         NAME       spio_IO_SCR_Checkpoint_ex
         SOURCES    IO_SCR_Checkpoint.cpp
         OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-        DEPENDS_ON ${spio_example_depends} scr gtest
+        DEPENDS_ON ${spio_example_depends} gtest
         FOLDER     axom/sidre/examples
         )
 

--- a/src/axom/sidre/tests/CMakeLists.txt
+++ b/src/axom/sidre/tests/CMakeLists.txt
@@ -47,14 +47,14 @@ set(fruit_sidre_tests
    sidre_allocatable_F.f
    )
 
-set(sidre_gtests_depends_on axom ${axom_device_depends} fmt gtest)
+set(sidre_gtests_depends_on sidre fmt gtest)
 
 #------------------------------------------------------------------------------
 # Add gtest C++ tests
 #------------------------------------------------------------------------------
 foreach(test ${gtest_sidre_tests})
     get_filename_component( test_name ${test} NAME_WE )
-    blt_add_executable( NAME ${test_name}_test
+    axom_add_executable(NAME ${test_name}_test
                         SOURCES ${test}
                         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                         DEPENDS_ON ${sidre_gtests_depends_on}
@@ -73,10 +73,10 @@ if (ENABLE_FORTRAN)
     # Sidre's C API is only built to provide a Fortran interface.
     foreach(test ${gtest_sidre_C_tests})
         get_filename_component( test_name ${test} NAME_WE )
-        blt_add_executable( NAME ${test_name}_test
+        axom_add_executable(NAME ${test_name}_test
                             SOURCES ${test}
                             OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                            DEPENDS_ON sidre ${axom_device_depends} gtest
+                            DEPENDS_ON sidre gtest
                             FOLDER axom/sidre/tests
                             )
         axom_add_test( NAME    ${test_name}
@@ -91,10 +91,10 @@ endif()
 if (ENABLE_FORTRAN)
     foreach(test ${fruit_sidre_tests})
         get_filename_component( test_name ${test} NAME_WE )
-        blt_add_executable( NAME ${test_name}_test
+        axom_add_executable(NAME ${test_name}_test
                             SOURCES ${test}
                             OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                            DEPENDS_ON sidre ${axom_device_depends} fruit
+                            DEPENDS_ON sidre fruit
                             FOLDER axom/sidre/tests
                             )
         axom_add_test( NAME    ${test_name}
@@ -107,12 +107,10 @@ endif()
 # Add MFEMSidreDataCollection tests
 #------------------------------------------------------------------------------
 if (MFEM_FOUND AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION)
-    set(_sidre_mfem_dc_depends axom ${axom_device_depends} gtest)
-
-    blt_add_executable( NAME sidre_mfem_datacollection_test
+    axom_add_executable(NAME sidre_mfem_datacollection_test
                         SOURCES sidre_mfem_datacollection.cpp
                         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                        DEPENDS_ON ${_sidre_mfem_dc_depends}
+                        DEPENDS_ON sidre gtest
                         FOLDER axom/sidre/tests
                         )
     if (AXOM_ENABLE_MPI)

--- a/src/axom/sidre/tests/spio/CMakeLists.txt
+++ b/src/axom/sidre/tests/spio/CMakeLists.txt
@@ -23,11 +23,11 @@ set(gtest_spio_parallel_tests
 #------------------------------------------------------------------------------
 # Add gtest C++ tests
 #------------------------------------------------------------------------------
-blt_add_executable( NAME       spio_tests
+axom_add_executable(NAME       spio_tests
                     SOURCES    spio_main.cpp
                     HEADERS    ${gtest_spio_parallel_tests} ${gtest_spio_serial_tests}
                     OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                    DEPENDS_ON axom ${axom_device_depends} gtest
+                    DEPENDS_ON sidre gtest
                     FOLDER     axom/sidre/tests
                     )
 
@@ -60,13 +60,13 @@ if(ENABLE_FORTRAN)
     foreach(test ${spio_one_fortran_tests})
         get_filename_component( test_name ${test} NAME_WE )
         string(SUBSTRING "${test_name}" 2 -1 test_name) # remove F_
-        blt_add_executable( NAME       ${test_name}_F_test
+        axom_add_executable(NAME       ${test_name}_F_test
                             SOURCES    ${test}
                             OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                            DEPENDS_ON sidre ${axom_device_depends}
+                            DEPENDS_ON sidre
                             FOLDER     axom/sidre/tests
                             )
-        axom_add_test( NAME    ${test_name}_F
+        axom_add_test(NAME    ${test_name}_F
                       COMMAND ${test_name}_F_test
                       NUM_MPI_TASKS 1
                       )
@@ -82,10 +82,10 @@ if(ENABLE_FORTRAN)
     foreach(test ${spio_four_fortran_tests})
         get_filename_component( test_name ${test} NAME_WE )
         string(SUBSTRING "${test_name}" 2 -1 test_name) # remove F_
-        blt_add_executable( NAME       ${test_name}_F_test
+        axom_add_executable(NAME       ${test_name}_F_test
                             SOURCES    ${test}
                             OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                            DEPENDS_ON sidre ${axom_device_depends}
+                            DEPENDS_ON sidre
                             FOLDER     axom/sidre/tests
                             )
         axom_add_test( NAME    ${test_name}_F
@@ -102,10 +102,10 @@ if(ENABLE_FORTRAN)
     foreach(test ${spio_fruit_tests})
         get_filename_component( test_name ${test} NAME_WE )
         string(SUBSTRING "${test_name}" 2 -1 test_name) # remove F_
-        blt_add_executable( NAME       ${test_name}_F_test
+        axom_add_executable(NAME       ${test_name}_F_test
                             SOURCES    ${test}
                             OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                            DEPENDS_ON sidre ${axom_device_depends} fruit
+                            DEPENDS_ON sidre fruit
                             FOLDER     axom/sidre/tests
                             )
         axom_add_test( NAME    ${test_name}_F

--- a/src/axom/slam/CMakeLists.txt
+++ b/src/axom/slam/CMakeLists.txt
@@ -86,15 +86,12 @@ set(slam_sources
 #------------------------------------------------------------------------------
 # Build and install the library
 #------------------------------------------------------------------------------
-set(slam_depends_on core slic ${axom_device_depends})
-
-blt_add_library(
+axom_add_library(
     NAME        slam
     SOURCES     ${slam_sources}
     HEADERS     ${slam_headers}
-    DEPENDS_ON  ${slam_depends_on}
-    FOLDER      axom/slam
-    OBJECT      TRUE )
+    DEPENDS_ON  slic
+    FOLDER      axom/slam )
 
 axom_write_unified_header(NAME    slam
                           HEADERS ${slam_headers} )

--- a/src/axom/slam/benchmarks/CMakeLists.txt
+++ b/src/axom/slam/benchmarks/CMakeLists.txt
@@ -16,11 +16,11 @@ if (ENABLE_BENCHMARKS)
         get_filename_component( test_name ${test} NAME_WE )
         set(test_name "${test_name}_benchmark")
         
-        blt_add_executable(
+        axom_add_executable(
             NAME        ${test_name}
             SOURCES     ${test}
             OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-            DEPENDS_ON  slic slam ${axom_device_depends} gbenchmark
+            DEPENDS_ON  slam gbenchmark
             FOLDER      axom/slam/benchmarks
             )
 

--- a/src/axom/slam/examples/CMakeLists.txt
+++ b/src/axom/slam/examples/CMakeLists.txt
@@ -23,11 +23,11 @@ set(example_sources
 
 foreach(example_source ${example_sources})
     get_filename_component(example_name ${example_source} NAME_WE)
-    blt_add_executable(
-        NAME        "slam_${example_name}_ex"
+    axom_add_executable(
+        NAME        slam_${example_name}_ex
         SOURCES     ${example_source}
         OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
-        DEPENDS_ON  axom ${axom_device_depends}
+        DEPENDS_ON  slam
         FOLDER      axom/slam/examples )
 
     if(AXOM_ENABLE_TESTS)
@@ -47,11 +47,11 @@ add_subdirectory(tinyHydro)
 #------------------------------------------------------------------------------
 # Unstructured hexahedral mesh example
 #------------------------------------------------------------------------------
-blt_add_executable(
+axom_add_executable(
     NAME        slam_unstructMesh_ex
     SOURCES     UnstructMeshField.cpp
     OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
-    DEPENDS_ON  axom ${axom_device_depends} fmt
+    DEPENDS_ON  slam fmt
     FOLDER      axom/slam/examples )
 
 if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR)

--- a/src/axom/slam/examples/lulesh2.0.3/CMakeLists.txt
+++ b/src/axom/slam/examples/lulesh2.0.3/CMakeLists.txt
@@ -27,14 +27,12 @@ if ( NOT AXOM_ENABLE_OPENMP )
         PROPERTIES COMPILE_FLAGS "${AXOM_DISABLE_OMP_PRAGMA_WARNINGS}" )
 endif()
 
-set(slam_tests_depends_on core slic slam ${axom_device_depends})
-
-blt_add_executable(
+axom_add_executable(
     NAME        slam_lulesh_ex
     SOURCES     ${lulesh_sources}
     HEADERS     ${lulesh_headers}
     OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
-    DEPENDS_ON  ${slam_tests_depends_on}
+    DEPENDS_ON  slam
     FOLDER      axom/slam/examples )
 
 if(AXOM_ENABLE_TESTS)

--- a/src/axom/slam/examples/lulesh2.0.3_orig/CMakeLists.txt
+++ b/src/axom/slam/examples/lulesh2.0.3_orig/CMakeLists.txt
@@ -20,20 +20,19 @@ set(lulesh_sources
 
 # Add some extra configuration flags for MPI, OpenMP and allowing unused
 # parameters (in 3rd party source code)
-set(lulesh_depends_on ${axom_device_depends})
 set(luleshExtraCompileFlags ${AXOM_DISABLE_UNUSED_PARAMETER_WARNINGS})
 if (NOT AXOM_ENABLE_OPENMP )
     set(luleshExtraCompileFlags "${luleshExtraCompileFlags} ${AXOM_DISABLE_OMP_PRAGMA_WARNINGS}")
 endif()
 
+set(lulesh_depends_on)
 blt_list_append(TO lulesh_depends_on ELEMENTS mpi IF AXOM_ENABLE_MPI)
-blt_list_append(TO lulesh_depends_on ELEMENTS openmp IF AXOM_ENABLE_OPENMP)
 
 set_source_files_properties(${lulesh_sources} ${lulesh_headers}
     PROPERTIES COMPILE_FLAGS " ${luleshExtraCompileFlags} " )
 
 if ( lulesh_depends_on )
-    blt_add_executable(
+    axom_add_executable(
         NAME        slam_lulesh_orig_ex
         SOURCES     ${lulesh_sources}
         HEADERS     ${lulesh_headers}
@@ -41,7 +40,7 @@ if ( lulesh_depends_on )
         DEPENDS_ON  ${lulesh_depends_on}
         FOLDER      axom/slam/examples )
 else()
-    blt_add_executable(
+    axom_add_executable(
         NAME        slam_lulesh_orig_ex
         SOURCES     ${lulesh_sources}
         HEADERS     ${lulesh_headers}

--- a/src/axom/slam/examples/tinyHydro/CMakeLists.txt
+++ b/src/axom/slam/examples/tinyHydro/CMakeLists.txt
@@ -24,12 +24,12 @@ set(tinyHydro_lib_sources
     )
 
 
-set(slam_tiny_hydro_lib_depends_on core slam slic ${axom_device_depends} fmt)
+set(slam_tiny_hydro_lib_depends_on slam fmt)
 
 #------------------------------------------------------------------------------
 # Build the tinyHydro library
 #------------------------------------------------------------------------------
-blt_add_library(
+axom_add_library(
     NAME        slam_tinyHydro_ex
     SOURCES     ${tinyHydro_lib_sources}
                 ${tinyHydro_lib_headers}
@@ -37,17 +37,15 @@ blt_add_library(
     FOLDER      axom/slam/examples 
     OBJECT      TRUE )
 
-list(APPEND slam_tiny_hydro_tests_depends_on slam_tinyHydro_ex ${axom_device_depends})
-
 #------------------------------------------------------------------------------
 # Add gtest based tests for tinyHydro
 #------------------------------------------------------------------------------
 if(AXOM_ENABLE_TESTS)
-    blt_add_executable(
+    axom_add_executable(
         NAME        slam_tinyHydro_unitTests_ex
         SOURCES     tests/slam_tinyHydro_unitTests.cpp
         OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-        DEPENDS_ON  ${slam_tiny_hydro_tests_depends_on} gtest
+        DEPENDS_ON  slam_tinyHydro_ex gtest
         FOLDER      axom/slam/examples )
 
     axom_add_test(
@@ -58,11 +56,11 @@ endif()
 #------------------------------------------------------------------------------
 # Add the standalone executables for the sod example
 #------------------------------------------------------------------------------
-blt_add_executable(
+axom_add_executable(
     NAME        slam_tinyHydro_sod_ex
     SOURCES     tests/slam_tinyHydro_sod1DTwoPart.cpp
     OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
-    DEPENDS_ON  ${slam_tiny_hydro_tests_depends_on} 
+    DEPENDS_ON  slam_tinyHydro_ex 
     FOLDER      axom/slam/examples )
 
 if(AXOM_ENABLE_TESTS)
@@ -75,10 +73,10 @@ endif()
 # Add the standalone executables for the sedov example
 # Note: Not a test since the runtime is a bit high in debug mode (~40s)
 #------------------------------------------------------------------------------
-blt_add_executable(
+axom_add_executable(
     NAME        slam_tinyHydro_sedov_ex
     SOURCES     tests/slam_tinyHydro_sedovTwoPart.cpp
     OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
-    DEPENDS_ON  ${slam_tiny_hydro_tests_depends_on}
+    DEPENDS_ON  slam_tinyHydro_ex
     FOLDER      axom/slam/examples )
 

--- a/src/axom/slam/tests/CMakeLists.txt
+++ b/src/axom/slam/tests/CMakeLists.txt
@@ -45,18 +45,16 @@ set(gtest_slam_tests
     )
 
 
-set(slam_tests_depends_on axom ${axom_device_depends} gtest)
-
 #------------------------------------------------------------------------------
 # Add gtest based tests
 #------------------------------------------------------------------------------
 foreach(test ${gtest_slam_tests})
     get_filename_component( test_name ${test} NAME_WE )
-    blt_add_executable( NAME ${test_name}_test
-                        SOURCES ${test}
+    axom_add_executable(NAME       ${test_name}_test
+                        SOURCES    ${test}
                         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                        DEPENDS_ON ${slam_tests_depends_on}
-                        FOLDER axom/slam/tests )
+                        DEPENDS_ON slam gtest
+                        FOLDER     axom/slam/tests )
     axom_add_test( NAME ${test_name}
                    COMMAND ${test_name}_test )
 endforeach()

--- a/src/axom/slic/CMakeLists.txt
+++ b/src/axom/slic/CMakeLists.txt
@@ -63,18 +63,17 @@ endif()
 #------------------------------------------------------------------------------
 # Make/Install the library
 #------------------------------------------------------------------------------
-set(slic_depends core ${axom_device_depends})
+set(slic_depends core)
 
 blt_list_append( TO slic_depends ELEMENTS lumberjack IF ${AXOM_ENABLE_LUMBERJACK} )
 blt_list_append( TO slic_depends ELEMENTS dbghelp IF ${WIN32} )
 
-blt_add_library(NAME        slic
-                SOURCES     ${slic_sources}
-                HEADERS     ${slic_headers}
-                DEPENDS_ON  ${slic_depends}
-                FOLDER      axom/slic
-                OBJECT      TRUE
-                )
+axom_add_library(NAME        slic
+                 SOURCES     ${slic_sources}
+                 HEADERS     ${slic_headers}
+                 DEPENDS_ON  ${slic_depends}
+                 FOLDER      axom/slic
+                 )
 
 axom_write_unified_header( NAME slic
                            HEADERS ${slic_headers}

--- a/src/axom/slic/examples/CMakeLists.txt
+++ b/src/axom/slic/examples/CMakeLists.txt
@@ -21,19 +21,17 @@ set(mpi_example_sources
 set(F_example_sources
     basic/logging_F.f
     basic/flogger.f
-)
+    )
 
 if (AXOM_ENABLE_LUMBERJACK)
     list(APPEND mpi_example_sources basic/lumberjack_logging.cpp )
 endif()
 
-set( slic_examples_depends axom ${axom_device_depends})
-
 foreach( example_source ${example_sources} )
     get_filename_component( example_name ${example_source} NAME_WE )
-    blt_add_executable( NAME       slic_${example_name}_ex
+    axom_add_executable(NAME       slic_${example_name}_ex
                         SOURCES    ${example_source} 
-                        DEPENDS_ON ${slic_examples_depends}
+                        DEPENDS_ON slic
                         OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
                         FOLDER     axom/slic/examples )
 
@@ -44,13 +42,13 @@ foreach( example_source ${example_sources} )
 endforeach()
 
 
-if ( AXOM_ENABLE_MPI )
+if (AXOM_ENABLE_MPI)
     foreach( example_source ${mpi_example_sources} )
         get_filename_component( example_name ${example_source} NAME_WE )
-        blt_add_executable( NAME       slic_mpi_${example_name}_ex
+        axom_add_executable(NAME       slic_mpi_${example_name}_ex
                             SOURCES    ${example_source}
                             OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-                            DEPENDS_ON ${slic_examples_depends}
+                            DEPENDS_ON slic
                             FOLDER     axom/slic/examples )
 
         if(AXOM_ENABLE_TESTS)
@@ -62,14 +60,12 @@ if ( AXOM_ENABLE_MPI )
 endif()
 
 if(ENABLE_FORTRAN)
-    set( slic_fortran_examples_depends slic ${axom_device_depends})
-
     foreach(example_source ${F_example_sources})
         get_filename_component(exe_name ${example_source} NAME_WE)
-        blt_add_executable( NAME slic_${exe_name}_ex
+        axom_add_executable(NAME slic_${exe_name}_ex
                             SOURCES ${example_source}
                             OUTPUT_DIR ${EXAMPLE_OUTPUT_DIRECTORY}
-                            DEPENDS_ON ${slic_fortran_examples_depends}
+                            DEPENDS_ON slic
                             FOLDER axom/slic/examples )
 
         if(AXOM_ENABLE_TESTS)

--- a/src/axom/slic/tests/CMakeLists.txt
+++ b/src/axom/slic/tests/CMakeLists.txt
@@ -16,15 +16,15 @@ set(serial_slic_tests
     slic_macros.cpp
     slic_uninit.cpp )
 
-set(slic_tests_depends axom ${axom_device_depends} gtest fmt)
+set(slic_tests_depends slic gtest fmt)
 
 foreach(test ${serial_slic_tests})
     get_filename_component( test_name ${test} NAME_WE )
-    blt_add_executable(NAME       ${test_name}_test
-                       SOURCES    ${test}
-                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON ${slic_tests_depends}
-                       FOLDER     axom/slic/tests )
+    axom_add_executable(NAME       ${test_name}_test
+                        SOURCES    ${test}
+                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                        DEPENDS_ON ${slic_tests_depends}
+                        FOLDER     axom/slic/tests )
     axom_add_test(NAME    ${test_name}
                   COMMAND ${test_name}_test )
 endforeach()
@@ -39,11 +39,11 @@ if (AXOM_ENABLE_MPI AND AXOM_ENABLE_LUMBERJACK)
 
     foreach(test ${parallel_slic_tests})
         get_filename_component( test_name ${test} NAME_WE )
-        blt_add_executable(NAME       ${test_name}_test
-                           SOURCES    ${test}
-                           OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON ${slic_tests_depends}
-                           FOLDER     axom/slic/tests )
+        axom_add_executable(NAME       ${test_name}_test
+                            SOURCES    ${test}
+                            OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                            DEPENDS_ON ${slic_tests_depends}
+                            FOLDER     axom/slic/tests )
         axom_add_test(NAME          ${test_name}
                       COMMAND       ${test_name}_test 
                       NUM_MPI_TASKS 4)
@@ -61,11 +61,11 @@ if (ENABLE_BENCHMARKS)
     foreach(test ${slic_benchmarks})
         get_filename_component( test_name ${test} NAME_WE )
 
-        blt_add_executable(NAME       ${test_name}
-                           SOURCES    ${test}
-                           OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON axom gbenchmark
-                           FOLDER     axom/slic/benchmarks )
+        axom_add_executable(NAME       ${test_name}
+                            SOURCES    ${test}
+                            OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                            DEPENDS_ON slic gbenchmark
+                            FOLDER     axom/slic/benchmarks )
 
         blt_add_benchmark(
             NAME    ${test_name}
@@ -83,11 +83,11 @@ if (ENABLE_FORTRAN)
 
     foreach(test ${fruit_slic_tests})
         get_filename_component( test_name ${test} NAME_WE )
-        blt_add_executable(NAME ${test_name}_test
-                           SOURCES ${test}
-                           OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON slic ${axom_device_depends} fruit
-                           FOLDER axom/slic/tests )
+        axom_add_executable(NAME ${test_name}_test
+                            SOURCES ${test}
+                            OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                            DEPENDS_ON slic fruit
+                            FOLDER axom/slic/tests )
         axom_add_test(NAME    ${test_name}
                       COMMAND ${test_name}_test )
     endforeach()

--- a/src/axom/spin/CMakeLists.txt
+++ b/src/axom/spin/CMakeLists.txt
@@ -40,10 +40,6 @@ set( spin_headers
      policy/UniformGridStorage.hpp
    )
 
-set( spin_sources
-     dummy.cpp
-   )
-
 #------------------------------------------------------------------------------
 # Specify spin dependencies
 #------------------------------------------------------------------------------
@@ -60,7 +56,6 @@ blt_list_append( TO spin_depends_on ELEMENTS umpire IF UMPIRE_FOUND )
 #------------------------------------------------------------------------------
 axom_add_library(
     NAME                  spin
-    SOURCES               ${spin_sources}
     HEADERS               ${spin_headers}
     FOLDER                axom/spin
     DEPENDS_ON            ${spin_depends_on})

--- a/src/axom/spin/CMakeLists.txt
+++ b/src/axom/spin/CMakeLists.txt
@@ -41,14 +41,15 @@ set( spin_headers
    )
 
 set( spin_sources
-     ../Axom.cpp
+     dummy.cpp
    )
 
 #------------------------------------------------------------------------------
 # Specify spin dependencies
 #------------------------------------------------------------------------------
 set( spin_depends_on
-     core slic primal slam ${axom_device_depends})
+     primal 
+     slam)
 
 blt_list_append( TO spin_depends_on ELEMENTS sparsehash IF SPARSEHASH_FOUND )
 blt_list_append( TO spin_depends_on ELEMENTS RAJA IF RAJA_FOUND )
@@ -57,13 +58,12 @@ blt_list_append( TO spin_depends_on ELEMENTS umpire IF UMPIRE_FOUND )
 #------------------------------------------------------------------------------
 # Make/Install the library
 #------------------------------------------------------------------------------
-blt_add_library(
+axom_add_library(
     NAME                  spin
     SOURCES               ${spin_sources}
     HEADERS               ${spin_headers}
     FOLDER                axom/spin
-    DEPENDS_ON            ${spin_depends_on}
-    OBJECT                TRUE )
+    DEPENDS_ON            ${spin_depends_on})
 
 axom_write_unified_header(NAME    spin
                           HEADERS ${spin_headers})

--- a/src/axom/spin/dummy.cpp
+++ b/src/axom/spin/dummy.cpp
@@ -1,6 +1,0 @@
-// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
-// other Axom Project Developers. See the top-level COPYRIGHT file for details.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-
-// Dummy source for spin

--- a/src/axom/spin/dummy.cpp
+++ b/src/axom/spin/dummy.cpp
@@ -1,0 +1,6 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+// Dummy source for spin

--- a/src/axom/spin/examples/CMakeLists.txt
+++ b/src/axom/spin/examples/CMakeLists.txt
@@ -7,12 +7,11 @@
 #------------------------------------------------------------------------------
 
 set(spin_example_depends
-        axom
-        ${axom_device_depends}
+        spin
         fmt
         )
 
-blt_add_executable(
+axom_add_executable(
     NAME        spin_introduction_ex
     SOURCES     spin_introduction.cpp
     OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
@@ -22,13 +21,13 @@ blt_add_executable(
 
 # Note: The following example uses quest to read in an STL file
 #       and mint for meshing
-if (AXOM_ENABLE_MINT AND AXOM_ENABLE_QUEST AND RAJA_FOUND AND UMPIRE_FOUND)
+if (AXOM_ENABLE_QUEST AND RAJA_FOUND AND UMPIRE_FOUND)
 
     blt_add_executable(
         NAME        spin_bvh_two_pass_ex
         SOURCES     spin_bvh_two_pass.cpp
         OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
-        DEPENDS_ON  ${spin_example_depends}
+        DEPENDS_ON  quest
         FOLDER      axom/spin/examples
         )
 

--- a/src/axom/spin/examples/CMakeLists.txt
+++ b/src/axom/spin/examples/CMakeLists.txt
@@ -23,7 +23,7 @@ axom_add_executable(
 #       and mint for meshing
 if (AXOM_ENABLE_QUEST AND RAJA_FOUND AND UMPIRE_FOUND)
 
-    blt_add_executable(
+    axom_add_executable(
         NAME        spin_bvh_two_pass_ex
         SOURCES     spin_bvh_two_pass.cpp
         OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}

--- a/src/axom/spin/tests/CMakeLists.txt
+++ b/src/axom/spin/tests/CMakeLists.txt
@@ -16,8 +16,7 @@ set(spin_tests
    )
 
 set(spin_tests_depends
-    axom
-    ${axom_device_depends}
+    spin
     gtest
     fmt
     )
@@ -26,7 +25,7 @@ foreach ( test ${spin_tests} )
 
     get_filename_component( test_name ${test} NAME_WE )
 
-    blt_add_executable(
+    axom_add_executable(
       NAME       ${test_name}_test
       SOURCES    ${test}
       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
@@ -43,11 +42,11 @@ endforeach()
 
 if (AXOM_ENABLE_MINT)
 
-    blt_add_executable(
+    axom_add_executable(
       NAME       spin_bvh_test
       SOURCES    spin_bvh.cpp
       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-      DEPENDS_ON ${spin_tests_depends}
+      DEPENDS_ON ${spin_tests_depends} mint
       FOLDER     axom/spin/tests
       )
 

--- a/src/cmake/AxomConfig.cmake
+++ b/src/cmake/AxomConfig.cmake
@@ -156,7 +156,7 @@ install(
 #------------------------------------------------------------------------------
 
 # Add it to a temporary list before creating the cache variable to use list(APPEND)
-set(_axom_exported_targets axom)
+set(_axom_exported_targets ${AXOM_COMPONENTS_ENABLED})
 
 blt_list_append(TO _axom_exported_targets ELEMENTS cuda cuda_runtime IF AXOM_ENABLE_CUDA)
 blt_list_append(TO _axom_exported_targets ELEMENTS hip hip_runtime IF AXOM_ENABLE_HIP)

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -141,7 +141,7 @@ macro(axom_add_executable)
 
     # Blanket add openmp as a dependency to get around not propagating
     # openmp to fortran dependencies
-    blt_list_append(TO arg_DEPENDS_ON ELEMENTS openmp IF ENABLE_OPENMP)
+    blt_list_append(TO arg_DEPENDS_ON ELEMENTS openmp IF AXOM_ENABLE_OPENMP)
 
     blt_add_executable(NAME        ${arg_NAME}
                        SOURCES     ${arg_SOURCES}

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -97,14 +97,16 @@ macro(axom_add_component)
     string(TOUPPER ${arg_COMPONENT_NAME} COMPONENT_NAME_CAPITALIZED)
     string(TOLOWER ${arg_COMPONENT_NAME} COMPONENT_NAME_LOWERED)
 
-    option( AXOM_ENABLE_${COMPONENT_NAME_CAPITALIZED}
-            "Enables ${arg_COMPONENT_NAME}"
-            ${arg_DEFAULT_STATE})
+    if(NOT "${COMPONENT_NAME_LOWERED}" STREQUAL "core")
+        option(AXOM_ENABLE_${COMPONENT_NAME_CAPITALIZED}
+              "Enables ${arg_COMPONENT_NAME}"
+              ${arg_DEFAULT_STATE})
+    endif()
 
     set(AXOM_COMPONENTS_FULL ${AXOM_COMPONENTS_FULL} ${COMPONENT_NAME_LOWERED}
         CACHE STRING "List of all components in Axom" FORCE)
 
-    if ( AXOM_ENABLE_${COMPONENT_NAME_CAPITALIZED} )
+    if ( AXOM_ENABLE_${COMPONENT_NAME_CAPITALIZED} OR "${COMPONENT_NAME_LOWERED}" STREQUAL "core")
         set(AXOM_COMPONENTS_ENABLED ${AXOM_COMPONENTS_ENABLED} ${COMPONENT_NAME_LOWERED}
             CACHE STRING "List of all enabled components in Axom" FORCE)
         add_subdirectory( ${arg_COMPONENT_NAME} )

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -187,6 +187,15 @@ macro(axom_add_library)
         message(FATAL_ERROR "Do not add 'openmp' to Axom libraries to avoid propegation. It is handled automatically.")
     endif()
 
+    # Prefix the output name with "axom_" for component libraries
+    if(DEFINED arg_OUTPUT_NAME)
+        set(_output_name "${arg_OUTPUT_NAME}")
+    elseif(${arg_NAME} IN_LIST AXOM_COMPONENTS_FULL)
+        set(_output_name "axom_${arg_NAME}")
+    else()
+        set(_output_name "${arg_NAME}")
+    endif()
+
     blt_add_library(NAME        ${arg_NAME}
                     SOURCES     ${arg_SOURCES}
                     HEADERS     ${arg_HEADERS}
@@ -194,7 +203,7 @@ macro(axom_add_library)
                     DEFINES     ${arg_DEFINES}
                     DEPENDS_ON  ${arg_DEPENDS_ON} ${axom_device_depends}
                     OUTPUT_DIR  ${arg_OUTPUT_DIR}
-                    OUTPUT_NAME ${arg_OUTPUT_NAME}
+                    OUTPUT_NAME ${_output_name}
                     FOLDER      ${arg_FOLDER})
 
     if(AXOM_ENABLE_OPENMP AND (NOT "${arg_SOURCES}" STREQUAL ""))

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -197,7 +197,7 @@ macro(axom_add_library)
                     OUTPUT_NAME ${arg_OUTPUT_NAME}
                     FOLDER      ${arg_FOLDER})
 
-    if(ENABLE_OPENMP AND (NOT "${arg_SOURCES}" STREQUAL ""))
+    if(AXOM_ENABLE_OPENMP AND (NOT "${arg_SOURCES}" STREQUAL ""))
         # Do not propegate OpenMP due to generator expressions evaluating early
         target_link_libraries(${arg_NAME} PRIVATE openmp)
     endif()

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -187,10 +187,13 @@ macro(axom_add_library)
         message(FATAL_ERROR "Do not add 'openmp' to Axom libraries to avoid propegation. It is handled automatically.")
     endif()
 
-    # Prefix the output name with "axom_" for component libraries
     if(DEFINED arg_OUTPUT_NAME)
         set(_output_name "${arg_OUTPUT_NAME}")
+    elseif(NOT DEFINED arg_SOURCES)
+        # Can't set OUTPUT_NAME on header only libraries
+        set(_output_NAME)
     elseif(${arg_NAME} IN_LIST AXOM_COMPONENTS_FULL)
+        # Prefix the output name with "axom_" for component libraries
         set(_output_name "axom_${arg_NAME}")
     else()
         set(_output_name "${arg_NAME}")

--- a/src/cmake/axom-config.cmake.in
+++ b/src/cmake/axom-config.cmake.in
@@ -166,14 +166,9 @@ if(NOT AXOM_FOUND)
   endforeach()
 
   # HACK: Clear INTERFACE_COMPILE_OPTIONS to avoid requiring OpenMP in user code
-  # This can (hopefully) be removed when we fix axom/blt's treatment of OpenMP
-  if(AXOM_USE_OPENMP)
-    set(_fix_tgts axom)
-    if(AXOM_USE_RAJA)
-      list(APPEND _fix_tgts RAJA)
-    endif()
-    set_target_properties(${_fix_tgts} PROPERTIES INTERFACE_COMPILE_OPTIONS "")
-    unset(_fix_tgts)
+  # This can (hopefully) be removed when we fix blt's treatment of OpenMP
+  if(TARGET RAJA AND AXOM_USE_OPENMP)
+    set_target_properties(RAJA PROPERTIES INTERFACE_COMPILE_OPTIONS "")
   endif()
 
   #----------------------------------------------------------------------------

--- a/src/cmake/axom-config.cmake.in
+++ b/src/cmake/axom-config.cmake.in
@@ -36,6 +36,8 @@ if(NOT AXOM_FOUND)
   set(AXOM_USE_OPENMP         "@AXOM_USE_OPENMP@")
 
   # Axom components
+  set(AXOM_COMPONENTS_ENABLED @AXOM_COMPONENTS_ENABLED@)
+
   set(AXOM_ENABLE_INLET       "@AXOM_ENABLE_INLET@")
   set(AXOM_ENABLE_KLEE        "@AXOM_ENABLE_KLEE@")
   set(AXOM_ENABLE_LUMBERJACK  "@AXOM_ENABLE_LUMBERJACK@")
@@ -149,6 +151,19 @@ if(NOT AXOM_FOUND)
   #----------------------------------------------------------------------------
   get_filename_component(AXOM_CMAKE_CONFIG_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
   include(${AXOM_CMAKE_CONFIG_DIR}/axom-targets.cmake)
+
+  # Create convenience target that bundles all Axom targets (axom)
+  add_library(axom INTERFACE IMPORTED)
+
+  set_property(TARGET axom
+               APPEND PROPERTY
+               INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_ROOT}/include/")
+
+  foreach(_component ${AXOM_COMPONENTS_ENABLED})
+    set_property(TARGET axom
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                 axom::${_component})
+  endforeach()
 
   # HACK: Clear INTERFACE_COMPILE_OPTIONS to avoid requiring OpenMP in user code
   # This can (hopefully) be removed when we fix axom/blt's treatment of OpenMP

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -352,7 +352,5 @@ foreach(dep ${TPL_DEPS})
         install(TARGETS              ${dep}
                 EXPORT               axom-targets
                 DESTINATION          lib)
-        # Namespace target to avoid conflicts
-        set_target_properties(${dep} PROPERTIES EXPORT_NAME axom::${dep})
     endif()
 endforeach()

--- a/src/docs/sphinx/dev_guide/component_org.rst
+++ b/src/docs/sphinx/dev_guide/component_org.rst
@@ -205,13 +205,13 @@ This file also adds source subdirectories as needed (using the CMake
 adds target definitions for dependencies. For example, the command to 
 add *sidre* as a library is::
 
-  blt_add_library( NAME
+  axom_add_library( NAME
                        sidre
                    SOURCES
-                       "${sidre_sources}"
-                       "${sidre_fortran_sources}"
+                       ${sidre_sources}
+                       ${sidre_fortran_sources}
                    HEADERS
-                       "${sidre_headers}"
+                       ${sidre_headers}
                    DEPENDS_ON
                        ${sidre_depends}
                    )

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -10,13 +10,28 @@
 #------------------------------------------------------------------------------
 
 #------------------------------------------------------------------------------
-# install 'using-with-make' example (no configuration, so just copy files)
+# install 'using-with-make' example
 #------------------------------------------------------------------------------
+# Create a link line string that has all the component libraries in the proper order
+# This list is ordered by hand, then we only add components that are enabled
+set(_ordered_component_list quest multimat slam mint klee inlet sidre slic lumberjack core)
+set(AXOM_ORDERED_LIBS)
+foreach(_component ${_ordered_component_list})
+  if(_component IN_LIST AXOM_COMPONENTS_ENABLED)
+    set(AXOM_ORDERED_LIBS "${AXOM_ORDERED_LIBS} -l${_component}")
+  endif()
+endforeach()
+
+configure_file(
+    using-with-make/Makefile.in
+    ${PROJECT_BINARY_DIR}/examples/using-with-make/Makefile)
+
 install(
-    DIRECTORY 
-        using-with-make
+    FILES
+        ${PROJECT_BINARY_DIR}/examples/using-with-make/Makefile
+        using-with-make/example.cpp
     DESTINATION 
-        examples/axom
+        examples/axom/using-with-make
 )
 
 #------------------------------------------------------------------------------

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -18,7 +18,7 @@ set(_ordered_component_list quest multimat slam mint klee inlet sidre slic lumbe
 set(AXOM_ORDERED_LIBS)
 foreach(_component ${_ordered_component_list})
   if(_component IN_LIST AXOM_COMPONENTS_ENABLED)
-    set(AXOM_ORDERED_LIBS "${AXOM_ORDERED_LIBS} -l${_component}")
+    set(AXOM_ORDERED_LIBS "${AXOM_ORDERED_LIBS} -laxom_${_component}")
   endif()
 endforeach()
 

--- a/src/examples/using-with-blt/CMakeLists.txt
+++ b/src/examples/using-with-blt/CMakeLists.txt
@@ -47,9 +47,9 @@ if(NOT DEFINED AXOM_DIR OR NOT EXISTS ${AXOM_DIR}/lib/cmake/axom-config.cmake)
     message(FATAL_ERROR "Missing required 'AXOM_DIR' variable pointing to an installed axom")
 endif()
 
-find_package(axom REQUIRED
-             NO_DEFAULT_PATH 
-             PATHS ${AXOM_DIR}/lib/cmake)
+find_dependency(axom REQUIRED
+                NO_DEFAULT_PATH 
+                PATHS ${AXOM_DIR}/lib/cmake)
 
 #------------------------------------------------------------------------------
 # Set up example target that depends on axom

--- a/src/examples/using-with-blt/CMakeLists.txt
+++ b/src/examples/using-with-blt/CMakeLists.txt
@@ -47,6 +47,8 @@ if(NOT DEFINED AXOM_DIR OR NOT EXISTS ${AXOM_DIR}/lib/cmake/axom-config.cmake)
     message(FATAL_ERROR "Missing required 'AXOM_DIR' variable pointing to an installed axom")
 endif()
 
+include(CMakeFindDependencyMacro)
+
 find_dependency(axom REQUIRED
                 NO_DEFAULT_PATH 
                 PATHS ${AXOM_DIR}/lib/cmake)

--- a/src/examples/using-with-cmake/CMakeLists.txt
+++ b/src/examples/using-with-cmake/CMakeLists.txt
@@ -53,27 +53,9 @@ if (ENABLE_HIP)
     find_package(hip REQUIRED CONFIG PATHS ${ROCM_PATH})
 endif()
 
-# Required to create Conduit's MPI dependencies
-if (ENABLE_MPI)
-    find_package(MPI REQUIRED)
-    
-    if(NOT TARGET mpi AND TARGET MPI::MPI_CXX)
-        add_library(mpi INTERFACE)
-        target_link_libraries(mpi INTERFACE MPI::MPI_CXX)
-    endif()
-endif()
-
-find_package(axom REQUIRED
-             NO_DEFAULT_PATH 
-             PATHS ${AXOM_DIR}/lib/cmake)
-
-# BEGIN FIXME:
-# Create fake empty target, this stops CMake from adding -lcuda_runtime to the link line
-add_library(cuda_runtime INTERFACE)
-
-# Create fake empty target, this stops CMake from adding -lblt_hip_runtime to the link line
-add_library(blt_hip_runtime INTERFACE)
-# END FIXME
+find_dependency(axom REQUIRED
+                NO_DEFAULT_PATH 
+                PATHS ${AXOM_DIR}/lib/cmake)
 
 # Remove implicitly added link directories added by CMake that are problematic when
 # the default system libraries are older than the ones used by the compiler

--- a/src/examples/using-with-cmake/CMakeLists.txt
+++ b/src/examples/using-with-cmake/CMakeLists.txt
@@ -53,6 +53,8 @@ if (ENABLE_HIP)
     find_package(hip REQUIRED CONFIG PATHS ${ROCM_PATH})
 endif()
 
+include(CMakeFindDependencyMacro)
+
 find_dependency(axom REQUIRED
                 NO_DEFAULT_PATH 
                 PATHS ${AXOM_DIR}/lib/cmake)

--- a/src/examples/using-with-make/Makefile.in
+++ b/src/examples/using-with-make/Makefile.in
@@ -7,20 +7,33 @@
 # based build system.
 #
 # To build:
-#  env AXOM_DIR={axom install path} make
+#  make AXOM_DIR={Axom install path}
+#  ./example
+#
+# From within an Axom install:
+#  make 
+#  ./example
+#
+# Which corresponds to:
+#
+#  make AXOM_DIR=../../../ 
 #  ./example
 #
 # Note:
 #  If you use features that leverage external third party libraries 
 #  (ex: hdf5 features), you may need to pass additional include 
-#   and linking flags. 
+#  and linking flags. 
 #------------------------------------------------------------------------------
 
+AXOM_DIR ?= ../../..
 
+CXX=@CMAKE_CXX_COMPILER@
+CXX_FLAGS=@CMAKE_CXX_FLAGS@ -std=c++@CMAKE_CXX_STANDARD@
 INC_FLAGS=-I$(AXOM_DIR)/include/
-LINK_FLAGS=-L$(AXOM_DIR)/lib/ -laxom
+LINK_FLAGS=-L$(AXOM_DIR)/lib/ @AXOM_ORDERED_LIBS@
 
 main:
 	$(CXX) $(INC_FLAGS) example.cpp $(LINK_FLAGS) -o example
 
-
+clean:
+	rm -f example

--- a/src/index.rst
+++ b/src/index.rst
@@ -170,7 +170,7 @@ of our email lists:
 Chat Room
 ---------
 
-We also have the 'Axom' chat room on the LLNL Microsoft Teams server. This 
+We also have the 'Axom Users' chat room on the LLNL Microsoft Teams server. This 
 is open to anyone with access to the LLNL network. Just log onto Teams and 
 join the room.
 

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -18,8 +18,6 @@ if (LUA_FOUND)
   target_include_directories(sol SYSTEM INTERFACE
               $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/thirdparty>)
 
-  set_target_properties(sol PROPERTIES EXPORT_NAME axom::sol)
-
   install(TARGETS              sol
           EXPORT               axom-targets
           INCLUDES DESTINATION include)
@@ -45,8 +43,6 @@ blt_add_library(NAME    cli11
 
 target_include_directories(cli11 SYSTEM INTERFACE
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/thirdparty>)
-
-set_target_properties(cli11 PROPERTIES EXPORT_NAME axom::cli11)
 
 install(TARGETS              cli11
         EXPORT               axom-targets
@@ -104,8 +100,6 @@ target_include_directories(fmt INTERFACE
 # Setup some variables for fmt in Axom's config.hpp
 set(AXOM_FMT_EXCEPTIONS FALSE PARENT_SCOPE)
 set(AXOM_FMT_HEADER_ONLY TRUE PARENT_SCOPE)
-
-set_target_properties(fmt PROPERTIES EXPORT_NAME axom::fmt)
 
 install(TARGETS              fmt
         EXPORT               axom-targets
@@ -177,8 +171,6 @@ if (AXOM_ENABLE_SPARSEHASH)
         blt_add_target_compile_flags(TO sparsehash FLAGS
             $<$<AND:$<CXX_COMPILER_ID:GNU>,$<COMPILE_LANGUAGE:CXX>>:-Wno-class-memaccess>)
     endif()
-
-    set_target_properties(sparsehash PROPERTIES EXPORT_NAME axom::sparsehash)
 
     install(TARGETS              sparsehash
             EXPORT               axom-targets

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -24,7 +24,6 @@ if (LUA_FOUND)
   install(FILES        ${PROJECT_SOURCE_DIR}/thirdparty/axom/sol.hpp
                        ${PROJECT_SOURCE_DIR}/thirdparty/axom/sol_forward.hpp
           DESTINATION include/axom )
-  install(EXPORT axom-targets DESTINATION lib/cmake)
 
   set(SOL_FOUND TRUE CACHE INTERNAL "")
 else()
@@ -49,7 +48,6 @@ install(TARGETS              cli11
         INCLUDES DESTINATION include)
 install(FILES       ${PROJECT_SOURCE_DIR}/thirdparty/axom/CLI11.hpp
         DESTINATION include/axom )
-install(EXPORT axom-targets DESTINATION lib/cmake)
 
 set(CLI11_FOUND TRUE CACHE INTERNAL "")
 mark_as_advanced(CLI11_FOUND)
@@ -112,7 +110,6 @@ install(FILES   ${axom_fmt_headers}
 install(DIRECTORY   ${PROJECT_SOURCE_DIR}/thirdparty/axom/fmt
         DESTINATION include/axom
         )
-install(EXPORT axom-targets DESTINATION lib/cmake)
 
 set(FMT_FOUND TRUE CACHE INTERNAL "")
 mark_as_advanced(FMT_FOUND)
@@ -178,8 +175,6 @@ if (AXOM_ENABLE_SPARSEHASH)
 
     install(DIRECTORY   ${PROJECT_SOURCE_DIR}/thirdparty/axom/sparsehash
             DESTINATION include/axom)
-
-    install(EXPORT axom-targets DESTINATION lib/cmake)
 endif()
 
 #------------------------------------------------------------------------------

--- a/src/thirdparty/tests/CMakeLists.txt
+++ b/src/thirdparty/tests/CMakeLists.txt
@@ -184,6 +184,11 @@ if (SOL_FOUND)
         DEPENDS_ON sol lua gtest
         FOLDER     axom/thirdparty/tests )
 
+    if (SOL_FOUND)
+        # Set file back to C++ due to nvcc compiler error
+        set_source_files_properties(sol_smoke.cpp PROPERTIES LANGUAGE CXX)
+    endif()
+
     axom_add_test(NAME    sol_smoke
                   COMMAND sol_smoke_test)
 endif()

--- a/src/thirdparty/tests/CMakeLists.txt
+++ b/src/thirdparty/tests/CMakeLists.txt
@@ -148,6 +148,9 @@ axom_add_executable(
     DEPENDS_ON cli11
     FOLDER     axom/thirdparty/tests )
 
+# Set file back to C++ due to nvcc compiler error
+set_source_files_properties(cli11_smoke.cpp PROPERTIES LANGUAGE CXX)
+
 axom_add_test(
     NAME cli11_smoke_help
     COMMAND cli11_smoke_test --help)
@@ -184,10 +187,8 @@ if (SOL_FOUND)
         DEPENDS_ON sol lua gtest
         FOLDER     axom/thirdparty/tests )
 
-    if (SOL_FOUND)
-        # Set file back to C++ due to nvcc compiler error
-        set_source_files_properties(sol_smoke.cpp PROPERTIES LANGUAGE CXX)
-    endif()
+    # Set file back to C++ due to nvcc compiler error
+    set_source_files_properties(sol_smoke.cpp PROPERTIES LANGUAGE CXX)
 
     axom_add_test(NAME    sol_smoke
                   COMMAND sol_smoke_test)

--- a/src/thirdparty/tests/CMakeLists.txt
+++ b/src/thirdparty/tests/CMakeLists.txt
@@ -14,11 +14,11 @@ axom_add_code_checks(PREFIX thirdparty_tests)
 #------------------------------------------------------------------------------
 if ( UMPIRE_FOUND )
 
-  set( umpire_smoke_dependencies umpire ${axom_device_depends} gtest )
+  set( umpire_smoke_dependencies umpire gtest )
 
   blt_list_append( TO umpire_smoke_dependencies ELEMENTS mpi IF AXOM_ENABLE_MPI)
 
-  blt_add_executable( NAME umpire_smoke_test
+  axom_add_executable(NAME umpire_smoke_test
                       SOURCES umpire_smoke.cpp
                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                       DEPENDS_ON ${umpire_smoke_dependencies}
@@ -34,13 +34,12 @@ endif()
 #------------------------------------------------------------------------------
 if ( RAJA_FOUND )
 
-  set( raja_smoke_dependencies RAJA ${axom_device_depends} gtest )
+  set( raja_smoke_dependencies RAJA gtest )
 
-  blt_list_append( TO raja_smoke_dependencies ELEMENTS openmp IF AXOM_ENABLE_OPENMP)
   blt_list_append( TO raja_smoke_dependencies ELEMENTS umpire IF UMPIRE_FOUND)
   blt_list_append( TO raja_smoke_dependencies ELEMENTS mpi    IF AXOM_ENABLE_MPI)
 
-  blt_add_executable( NAME raja_smoke_test
+  axom_add_executable(NAME raja_smoke_test
                       SOURCES raja_smoke.cpp
                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                       DEPENDS_ON ${raja_smoke_dependencies}
@@ -65,14 +64,13 @@ if( HDF5_FOUND AND CONDUIT_FOUND)
 
     blt_list_append( TO hdf5_smoke_dependencies ELEMENTS mpi IF AXOM_ENABLE_MPI)
 
-    blt_add_executable(NAME hdf5_smoke_test
-                       SOURCES hdf5_smoke.cpp
-                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON ${hdf5_smoke_dependencies}
-                       FOLDER axom/thirdparty/tests )
+    axom_add_executable(NAME       hdf5_smoke_test
+                        SOURCES    hdf5_smoke.cpp
+                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                        DEPENDS_ON ${hdf5_smoke_dependencies}
+                        FOLDER     axom/thirdparty/tests )
 
     target_include_directories(hdf5_smoke_test PUBLIC 
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include> )
 
     axom_add_test(NAME hdf5_smoke
@@ -83,17 +81,17 @@ endif()
 # Smoke test for conduit third party library
 #------------------------------------------------------------------------------
 if (CONDUIT_FOUND)
-    blt_add_executable(NAME       conduit_smoke_test
-                       SOURCES    conduit_smoke.cpp
-                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON conduit::conduit gtest
-                       FOLDER     axom/thirdparty/tests )
+    axom_add_executable(NAME       conduit_smoke_test
+                        SOURCES    conduit_smoke.cpp
+                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                        DEPENDS_ON conduit::conduit gtest
+                        FOLDER     axom/thirdparty/tests )
 
     axom_add_test(NAME conduit_smoke
                  COMMAND conduit_smoke_test)
 
     if (ENABLE_FORTRAN)
-        blt_add_executable(NAME       conduit_smoke_F_test
+        axom_add_executable(NAME       conduit_smoke_F_test
                            SOURCES    f_conduit_smoke.f
                            OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                            DEPENDS_ON conduit::conduit fruit
@@ -110,11 +108,11 @@ endif()
 if (MFEM_FOUND)
     set( mfem_smoke_dependencies mfem gtest )
     blt_list_append( TO mfem_smoke_dependencies ELEMENTS mpi IF AXOM_ENABLE_MPI)
-    blt_add_executable(NAME mfem_smoke_test
-                       SOURCES mfem_smoke.cpp
-                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON ${mfem_smoke_dependencies}
-                       FOLDER axom/thirdparty/tests )
+    axom_add_executable(NAME       mfem_smoke_test
+                        SOURCES    mfem_smoke.cpp
+                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                        DEPENDS_ON ${mfem_smoke_dependencies}
+                        FOLDER     axom/thirdparty/tests )
     set_property(
         TARGET mfem_smoke_test
         APPEND_STRING PROPERTY COMPILE_FLAGS "${AXOM_DISABLE_UNUSED_PARAMETER_WARNINGS}")
@@ -130,12 +128,12 @@ endif()
 set(fmt_smoke_dependencies fmt gtest)
 blt_list_append( TO fmt_smoke_dependencies ELEMENTS cuda IF AXOM_ENABLE_CUDA)
 
-blt_add_executable(
-    NAME fmt_smoke_test
-    SOURCES fmt_smoke.cpp
+axom_add_executable(
+    NAME       fmt_smoke_test
+    SOURCES    fmt_smoke.cpp
     OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
     DEPENDS_ON ${fmt_smoke_dependencies}
-    FOLDER axom/thirdparty/tests )
+    FOLDER     axom/thirdparty/tests )
     
 axom_add_test(NAME    fmt_smoke
               COMMAND fmt_smoke_test)
@@ -143,12 +141,12 @@ axom_add_test(NAME    fmt_smoke
 #------------------------------------------------------------------------------
 # Smoke test for CLI11 third party library
 #------------------------------------------------------------------------------
-blt_add_executable(
-    NAME cli11_smoke_test
-    SOURCES cli11_smoke.cpp
+axom_add_executable(
+    NAME       cli11_smoke_test
+    SOURCES    cli11_smoke.cpp
     OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
     DEPENDS_ON cli11
-    FOLDER axom/thirdparty/tests )
+    FOLDER     axom/thirdparty/tests )
 
 axom_add_test(
     NAME cli11_smoke_help
@@ -163,12 +161,12 @@ axom_add_test(
 #------------------------------------------------------------------------------
 
 if (SPARSEHASH_FOUND)
-  blt_add_executable(
-    NAME sparsehash_smoke_test
-    SOURCES sparsehash_smoke.cpp
+  axom_add_executable(
+    NAME       sparsehash_smoke_test
+    SOURCES    sparsehash_smoke.cpp
     OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
     DEPENDS_ON sparsehash gtest
-    FOLDER axom/thirdparty/tests )
+    FOLDER     axom/thirdparty/tests )
 
   axom_add_test(NAME    sparsehash_smoke
                 COMMAND sparsehash_smoke_test)
@@ -179,7 +177,7 @@ endif()
 #------------------------------------------------------------------------------
 
 if (SOL_FOUND)
-    blt_add_executable(
+    axom_add_executable(
         NAME       sol_smoke_test
         SOURCES    sol_smoke.cpp
         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
@@ -195,7 +193,7 @@ endif()
 #------------------------------------------------------------------------------
 
 if (C2C_FOUND)
-    blt_add_executable(
+    axom_add_executable(
         NAME       c2c_smoke_test
         SOURCES    c2c_smoke.cpp
         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
@@ -232,12 +230,11 @@ endif()
 
 foreach(test ${BLT_SMOKE_TESTS})
     get_filename_component( test_name ${test} NAME_WE )
-    blt_add_executable(
-        NAME ${test_name}_test
-        SOURCES ${test}
+    axom_add_executable(
+        NAME       ${test_name}_test
+        SOURCES    ${test}
         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-        USE_OPENMP False
-        FOLDER axom/thirdparty/tests)
+        FOLDER     axom/thirdparty/tests)
 
     axom_add_test(
         NAME ${test_name}

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -20,15 +20,14 @@ if( AXOM_ENABLE_SLAM AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_MPI AND HDF5_FOUND )
         convert_sidre_protocol.cpp
     )
     set(datastore_converter_depends
-        axom
-        ${axom_device_depends}
-        mpi
+        slam
+        sidre
         cli11
         fmt)
 
     blt_list_append(TO datastore_converter_depends ELEMENTS scr IF SCR_FOUND)
 
-    blt_add_executable(
+    axom_add_executable(
         NAME       convert_sidre_protocol
         SOURCES    ${datastore_converter_sources}
         OUTPUT_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
@@ -43,19 +42,18 @@ endif()
 #------------------------------------------------------------------------------
 # mesh_tester is a utility that tests a mesh for a variety of problems.
 #------------------------------------------------------------------------------
-set(mesh_tester_sources
-    mesh_tester.cpp
-)
-set(mesh_tester_depends
-    axom
-    ${axom_device_depends}
-    )
-
-blt_list_append(TO mesh_tester_depends ELEMENTS umpire IF UMPIRE_FOUND)
-blt_list_append(TO mesh_tester_depends ELEMENTS RAJA IF RAJA_FOUND)
-
 if(AXOM_ENABLE_QUEST)
-    blt_add_executable(
+    set(mesh_tester_sources
+        mesh_tester.cpp
+    )
+    set(mesh_tester_depends
+        quest
+        )
+
+    blt_list_append(TO mesh_tester_depends ELEMENTS umpire IF UMPIRE_FOUND)
+    blt_list_append(TO mesh_tester_depends ELEMENTS RAJA IF RAJA_FOUND)
+
+    axom_add_executable(
         NAME        mesh_tester
         SOURCES     ${mesh_tester_sources}
         OUTPUT_DIR  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
@@ -84,16 +82,15 @@ if( AXOM_ENABLE_SIDRE AND AXOM_ENABLE_PRIMAL AND
         data_collection_util.cpp
     )
     set(data_collection_util_depends
-        axom
-        ${axom_device_depends}
-        mfem
+        sidre
+        primal
         cli11
         fmt
         )
 
     blt_list_append(TO data_collection_util_depends ELEMENTS mpi IF AXOM_ENABLE_MPI)
 
-    blt_add_executable(
+    axom_add_executable(
         NAME        data_collection_util
         SOURCES     ${data_collection_util}
         OUTPUT_DIR  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}


### PR DESCRIPTION
This removes all of our CMake object library usage. This caused numerous problems.

Basically instead of having all the components being linked into a single `axom` library, we now have individual CMake targets and libraries for each component. There is also a new helper CMake target, named `axom`, created in the exported `axom-config.cmake`. Downstream users should not have to change anything in their CMake usage.

Important changes to point out:

- `axom` target is now an interface target that depends on all our underlying targets. It also only exists in the exported targets from `AxomConfig.cmake`. It does not exist in our internal build.
- All underlying targets are now namespaced with `axom::`, eg. `inlet` is now `axom::inlet`. Downstream users can now depend on these individual targets to minimize what they bring into their projects
- Our library file, `libaxom.a` or `libaxom.so`, no longer exists. There is a now a library for each component (except primal and spin, which are header only) and they are prefixed with `axom_`, eg. `libaxom_inlet.a`, `libaxom_core.a`.