### PR TITLE
Add a library required by FreeBSD

### DIFF
--- a/src/axom/slic/CMakeLists.txt
+++ b/src/axom/slic/CMakeLists.txt
@@ -67,6 +67,9 @@ set(slic_depends core)
 
 blt_list_append( TO slic_depends ELEMENTS lumberjack IF ${AXOM_ENABLE_LUMBERJACK} )
 blt_list_append( TO slic_depends ELEMENTS dbghelp IF ${WIN32} )
+if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  list( APPEND slic_depends execinfo )
+endif()
 
 axom_add_library(NAME        slic
                  SOURCES     ${slic_sources}


### PR DESCRIPTION
# Summary

- This PR is a portability bugfix.
- It does the following:
  - Adds a link library to slic on FreeBSD hosts.  On Linux, `backtrace()` and `backtrace_symbols()` come from glibc.  On FreeBSD, those functions come from libexecinfo.
