### PR TITLE
Change to fix intersection shaper unit tests with HIP

### DIFF
--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -522,7 +522,11 @@ AXOM_HOST_DEVICE inline blackhole &operator<<(blackhole &bh, T)
 }  // namespace internal
 }  // namespace slic
 }  // namespace axom
-    #define SLIC_ASSERT(EXP) ((void)(EXP))
+
+    // Bug: Causes intersection shaper unit tests to hang with HIP
+    // #define SLIC_ASSERT(EXP) ((void)(EXP))
+
+    #define SLIC_ASSERT(EXP) ((void)(0))
     #define SLIC_ASSERT_MSG(EXP, msg)            \
       {                                          \
         if(false)                                \


### PR DESCRIPTION
This PR:
- Makes a small reversion to PR #1079 to get intersection shaper unit tests running on rzvernal and tioga.
  -  NOTE: This reintroduces the HIP-related unused variable warnings that were previously ignored by `SLIC_ASSERT`

Closes  #1089 