### PR TITLE
Use pdebug queue for quartz allocation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,5 +81,5 @@ stages:
 # This is where jobs are included
 include:
   - local: .gitlab/build_quartz.yml
-  - local: .gitlab/build_lassen.yml
-  - local: .gitlab/build_tioga.yml
+  #- local: .gitlab/build_lassen.yml
+  #- local: .gitlab/build_tioga.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,10 +29,25 @@ stages:
 .src_build_script:
   script:
     # Use pre-existing allocation if any
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - echo "Hostname before calling build_src.py command is:"
+    - hostname
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - echo +++++++++++++++
     - JOBID=$(if [[ "$SYS_TYPE" == "toss_3_x86_64_ib" ]]; then squeue -h --name=${PROJECT_ALLOC_NAME} --format=%A; fi)
     - ASSIGN_ID=$(if [[ -n "${JOBID}" ]]; then echo "--jobid=${JOBID}"; fi)
     # BUILD + TEST
     - echo -e "\e[0Ksection_start:$(date +%s):src_build_and_test\r\e[0KSource Build and Test ${CI_PROJECT_NAME}"
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - ${ALLOC_COMMAND} ${ASSIGN_ID} hostname
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - echo +++++++++++++++
     - ${ALLOC_COMMAND} ${ASSIGN_ID} python3 scripts/llnl_scripts/build_src.py -v --host-config ${HOST_CONFIG} --extra-cmake-options '-DENABLE_DOCS=OFF ${EXTRA_CMAKE_OPTIONS}' --build-type ${BUILD_TYPE:-Debug} ${EXTRA_OPTIONS}
     - echo -e "\e[0Ksection_end:$(date +%s):src_build_and_test\r\e[0K"
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ stages:
     - echo +++++++++++++++
     - echo +++++++++++++++
     - echo +++++++++++++++
-    - JOBID=$(if [[ "$SYS_TYPE" == "toss_3_x86_64_ib" ]]; then squeue -h --name=${PROJECT_ALLOC_NAME} --format=%A; fi)
+    - export JOBID=$(if [[ "$SYS_TYPE" == "toss_3_x86_64_ib" ]]; then squeue -h --name=${PROJECT_ALLOC_NAME} --format=%A; fi)
     - echo +++++++++++++++
     - echo +++++++++++++++
     - echo +++++++++++++++

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,34 +29,10 @@ stages:
 .src_build_script:
   script:
     # Use pre-existing allocation if any
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - echo "Hostname before calling build_src.py command is:"
-    - hostname
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - echo +++++++++++++++
     - export JOBID=$(if [[ "$SYS_TYPE" == "toss_4_x86_64_ib" ]]; then squeue -h --name=${PROJECT_ALLOC_NAME} --format=%A; fi)
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - echo "JOBID is:"
-    - printenv JOBID
-    - echo "--jobid=${JOBID}"
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - echo +++++++++++++++
     - ASSIGN_ID=$(if [[ -n "${JOBID}" ]]; then echo "--jobid=${JOBID}"; fi)
     # BUILD + TEST
     - echo -e "\e[0Ksection_start:$(date +%s):src_build_and_test\r\e[0KSource Build and Test ${CI_PROJECT_NAME}"
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - ${ALLOC_COMMAND} ${ASSIGN_ID} hostname
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - echo +++++++++++++++
     - ${ALLOC_COMMAND} ${ASSIGN_ID} python3 scripts/llnl_scripts/build_src.py -v --host-config ${HOST_CONFIG} --extra-cmake-options '-DENABLE_DOCS=OFF ${EXTRA_CMAKE_OPTIONS}' --build-type ${BUILD_TYPE:-Debug} ${EXTRA_OPTIONS}
     - echo -e "\e[0Ksection_end:$(date +%s):src_build_and_test\r\e[0K"
   artifacts:
@@ -81,5 +57,5 @@ stages:
 # This is where jobs are included
 include:
   - local: .gitlab/build_quartz.yml
-  #- local: .gitlab/build_lassen.yml
-  #- local: .gitlab/build_tioga.yml
+  - local: .gitlab/build_lassen.yml
+  - local: .gitlab/build_tioga.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ stages:
     - echo +++++++++++++++
     - echo +++++++++++++++
     - echo "JOBID is:"
-    - JOBID
+    - printenv JOBID
     - echo "--jobid=${JOBID}"
     - echo +++++++++++++++
     - echo +++++++++++++++

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,15 @@ stages:
     - echo +++++++++++++++
     - echo +++++++++++++++
     - JOBID=$(if [[ "$SYS_TYPE" == "toss_3_x86_64_ib" ]]; then squeue -h --name=${PROJECT_ALLOC_NAME} --format=%A; fi)
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - echo "JOBID is:"
+    - JOBID
+    - echo "--jobid=${JOBID}"
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - echo +++++++++++++++
     - ASSIGN_ID=$(if [[ -n "${JOBID}" ]]; then echo "--jobid=${JOBID}"; fi)
     # BUILD + TEST
     - echo -e "\e[0Ksection_start:$(date +%s):src_build_and_test\r\e[0KSource Build and Test ${CI_PROJECT_NAME}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ stages:
     - echo +++++++++++++++
     - echo +++++++++++++++
     - echo +++++++++++++++
-    - export JOBID=$(if [[ "$SYS_TYPE" == "toss_3_x86_64_ib" ]]; then squeue -h --name=${PROJECT_ALLOC_NAME} --format=%A; fi)
+    - export JOBID=$(if [[ "$SYS_TYPE" == "toss_4_x86_64_ib" ]]; then squeue -h --name=${PROJECT_ALLOC_NAME} --format=%A; fi)
     - echo +++++++++++++++
     - echo +++++++++++++++
     - echo +++++++++++++++

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -28,7 +28,23 @@ quartz_allocate:
   script:
     # Use when ellastic ci is on quartz or we go back to ruby
     #- salloc --reservation=ci --qos=ci_ruby -N 1 -c 36 -t 60 --no-shell --job-name=${PROJECT_ALLOC_NAME}
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - echo "Hostname before salloc command is:"
+    - hostname
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - echo +++++++++++++++
     - salloc -N 1 -c 36 -t 60 -p pdebug --no-shell --job-name=${PROJECT_ALLOC_NAME}
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - echo "Hostname after salloc command is:"
+    - hostname
+    - echo +++++++++++++++
+    - echo +++++++++++++++
+    - echo +++++++++++++++
   needs: []
 
 ####

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -50,7 +50,7 @@ quartz_release:
   variables:
     # Use when ellastic ci is on quartz or we go back to ruby
     # ALLOC_COMMAND: "srun --reservation=ci --qos=ci_ruby -t 60 -N 1 "
-    ALLOC_COMMAND: "srun -t 60 -N 1 "
+    ALLOC_COMMAND: "srun -t 60 -N 1 -p pdebug"
   extends: [.src_build_script, .on_quartz, .src_workflow]
   needs: [quartz_allocate]
 
@@ -59,7 +59,7 @@ quartz_release:
   variables:
     # Use when ellastic ci is on quartz or we go back to ruby
     # ALLOC_COMMAND: "srun --reservation=ci --qos=ci_ruby -t 60 -N 1 "
-    ALLOC_COMMAND: "srun -t 60 -N 1 "
+    ALLOC_COMMAND: "srun -t 60 -N 1 -p pdebug"
   extends: [.full_build_script, .on_quartz, .full_workflow]
   needs: []
 

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -28,23 +28,7 @@ quartz_allocate:
   script:
     # Use when ellastic ci is on quartz or we go back to ruby
     #- salloc --reservation=ci --qos=ci_ruby -N 1 -c 36 -t 60 --no-shell --job-name=${PROJECT_ALLOC_NAME}
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - echo "Hostname before salloc command is:"
-    - hostname
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - echo +++++++++++++++
     - salloc -N 1 -c 36 -t 60 -p pdebug --no-shell --job-name=${PROJECT_ALLOC_NAME}
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - echo "Hostname after salloc command is:"
-    - hostname
-    - echo +++++++++++++++
-    - echo +++++++++++++++
-    - echo +++++++++++++++
   needs: []
 
 ####

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -28,7 +28,7 @@ quartz_allocate:
   script:
     # Use when ellastic ci is on quartz or we go back to ruby
     #- salloc --reservation=ci --qos=ci_ruby -N 1 -c 36 -t 60 --no-shell --job-name=${PROJECT_ALLOC_NAME}
-    - salloc -N 1 -c 36 -t 60 --no-shell --job-name=${PROJECT_ALLOC_NAME}
+    - salloc -N 1 -c 36 -t 60 -p pdebug --no-shell --job-name=${PROJECT_ALLOC_NAME}
   needs: []
 
 ####

--- a/scripts/llnl_scripts/build_src.py
+++ b/scripts/llnl_scripts/build_src.py
@@ -152,6 +152,10 @@ def main():
                         print("[ERROR: Could not find any host-configs in any known path. Try giving fully qualified path.]")
                         return 1
 
+            print("[build info]")
+            binfo_str = json.dumps(build_info(),indent=2)
+            print(binfo_str)
+
             test_root = get_build_and_test_root(repo_dir, timestamp)
             test_root = "{0}_{1}".format(test_root, hostconfig.replace(".cmake", "").replace("@","_"))
             os.mkdir(test_root)

--- a/scripts/llnl_scripts/llnl_lc_build_tools.py
+++ b/scripts/llnl_scripts/llnl_lc_build_tools.py
@@ -71,6 +71,7 @@ def build_info():
     res["built_from_branch"] = "unknown"
     res["built_from_sha1"]   = "unknown"
     res["platform"] = get_platform()
+    res["hostname"] = os.environ["HOSTNAME"]
     rc, out = sexe('git branch -a | grep \"*\"',ret_output=True,error_prefix="WARNING:")
     out = out.strip()
     if rc == 0 and out != "":

--- a/scripts/llnl_scripts/llnl_lc_build_tools.py
+++ b/scripts/llnl_scripts/llnl_lc_build_tools.py
@@ -71,7 +71,7 @@ def build_info():
     res["built_from_branch"] = "unknown"
     res["built_from_sha1"]   = "unknown"
     res["platform"] = get_platform()
-    res["hostname"] = os.environ["HOSTNAME"]
+    res["hostname"] = sexe('hostname',ret_output=True,error_prefix="WARNING:")
     rc, out = sexe('git branch -a | grep \"*\"',ret_output=True,error_prefix="WARNING:")
     out = out.strip()
     if rc == 0 and out != "":

--- a/scripts/llnl_scripts/llnl_lc_build_tools.py
+++ b/scripts/llnl_scripts/llnl_lc_build_tools.py
@@ -71,7 +71,7 @@ def build_info():
     res["built_from_branch"] = "unknown"
     res["built_from_sha1"]   = "unknown"
     res["platform"] = get_platform()
-    res["hostname"] = sexe('hostname',ret_output=True,error_prefix="WARNING:")
+    res["hostname"] = "unknown"
     rc, out = sexe('git branch -a | grep \"*\"',ret_output=True,error_prefix="WARNING:")
     out = out.strip()
     if rc == 0 and out != "":
@@ -80,6 +80,10 @@ def build_info():
     out = out.strip()
     if rc == 0 and out != "":
         res["built_from_sha1"] = out
+    rc, out = sexe('hostname',ret_output=True,error_prefix="WARNING:")
+    out = out.strip()
+    if rc == 0 and out != "":
+        res["hostname"] = out
     return res
 
 


### PR DESCRIPTION
This PR:
- Targets pdebug queue for quartz. pbatch is rather popular.
- Fixes quartz not re-using `salloc` allocation
- `build_src.py` script now prints the name of the running node (hostname) for easier debugging in the future (Thanks @white238 for the suggestion!)