### PR TITLE
Multimat: GPU porting and acceleration

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -55,6 +55,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Multimat: adds an overload of `MultiMat::setCellMatRel()` that supports setting a
   multi-material relation in a compressed sparse-row (CSR) representation.
 - Quest: Adds ability to import volume fractions into `SamplingShaper` before processing `Klee` input
+- Slam: adds a `slam::MappedVariableCardinality` policy to accelerate mapping flat indices
+  back to first-set indices when used in a `StaticRelation`
 
 ### Changed
 - Fixed bug in `mint::mesh::UnstructuredMesh` constructors, affecting capacity.
@@ -97,6 +99,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   of full copies of field data.
 - Multimat: `MultiMat::addField()` and `MultiMat::setVolfracField()` API now use `axom::ArrayView`
   to accept data.
+- Multimat: Ported field data/sparsity layout conversion methods to GPU.
+- Multimat: `MultiMat::makeOtherRelation()` now runs on the GPU with an appropriately-set allocator ID.
+- Multimat: `MultiMat::setCellMatRel(counts, indices)` now runs on the GPU, and accepts GPU-side data.
 
 ###  Fixed
 - Fixed issues with CUDA build in CMake versions 3.14.5 and above. Now require CMake 3.18+

--- a/src/axom/multimat/CMakeLists.txt
+++ b/src/axom/multimat/CMakeLists.txt
@@ -26,18 +26,23 @@ set(multimat_sources
     )
 
 #------------------------------------------------------------------------------
+# Specify multimat dependencies
+#------------------------------------------------------------------------------
+set(multimat_depends_on slam)
+
+blt_list_append( TO multimat_depends_on ELEMENTS RAJA IF RAJA_FOUND )
+blt_list_append( TO multimat_depends_on ELEMENTS umpire IF UMPIRE_FOUND )
+
+#------------------------------------------------------------------------------
 # Build and install the library
 #------------------------------------------------------------------------------
 axom_add_library(
     NAME        multimat
     SOURCES     ${multimat_sources}
     HEADERS     ${multimat_headers}
-    DEPENDS_ON  slam
+    DEPENDS_ON  ${multimat_depends_on}
     FOLDER      axom/multimat
     )
-
-# Set file back to C++ due to nvcc compiler error
-set_source_files_properties(multimat.cpp PROPERTIES LANGUAGE CXX)
 
 axom_write_unified_header(NAME    multimat
                           HEADERS ${multimat_headers}

--- a/src/axom/multimat/multimat.cpp
+++ b/src/axom/multimat/multimat.cpp
@@ -1289,19 +1289,20 @@ axom::Array<DataType> ConvertToDenseImpl(
   const MultiMat::ProductSetType* prodSet,
   int allocatorId)
 {
-  const auto* relationSet = oldField.set();
   int stride = oldField.stride();
   int denseSize = prodSet->size() * stride;
   axom::Array<DataType> denseField(denseSize, denseSize, allocatorId);
   const auto denseFieldView = denseField.view();
+  const auto* relationSetHost = oldField.set();
 
   ExecLambdaForMemory(
-    relationSet->totalSize() * stride,
+    relationSetHost->totalSize() * stride,
     allocatorId,
     AXOM_LAMBDA(int index) {
       int flatIdx = index / stride;
       int comp = index % stride;
 
+      const auto* relationSet = oldField.set();
       auto firstIdx = relationSet->flatToFirstIndex(flatIdx);
       auto secondIdx = relationSet->flatToSecondIndex(flatIdx);
 

--- a/src/axom/multimat/multimat.cpp
+++ b/src/axom/multimat/multimat.cpp
@@ -509,7 +509,8 @@ void ScanRelationOffsetsRAJA(const axom::ArrayView<const IndexType> counts,
       }
     });
 #else
-  SLIC_ASSERT_MSG(false,
+  SLIC_ASSERT_MSG(
+    false,
     "Calling ScanRelationOffsetsRAJA requires support for RAJA and Umpire.");
 #endif
 }

--- a/src/axom/multimat/multimat.cpp
+++ b/src/axom/multimat/multimat.cpp
@@ -851,6 +851,8 @@ bool MultiMat::removeEntry(int cell_id, int mat_id)
 using GPU_Exec = axom::CUDA_EXEC<256>;
   #elif defined(AXOM_USE_HIP)
 using GPU_Exec = axom::HIP_EXEC<256>;
+  #else
+using GPU_Exec = axom::SEQ_EXEC;
   #endif
 #endif
 

--- a/src/axom/multimat/multimat.cpp
+++ b/src/axom/multimat/multimat.cpp
@@ -32,14 +32,13 @@ using namespace axom::multimat;
 
 namespace
 {
-#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
-  #if defined(AXOM_USE_CUDA)
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA)
 using GPU_Exec = axom::CUDA_EXEC<256>;
-  #elif defined(AXOM_USE_HIP)
+#elif defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE) && \
+  defined(AXOM_USE_HIP)
 using GPU_Exec = axom::HIP_EXEC<256>;
-  #else
+#else
 using GPU_Exec = axom::SEQ_EXEC;
-  #endif
 #endif
 
 bool AllocatorOnDevice(int allocatorId)

--- a/src/axom/multimat/multimat.cpp
+++ b/src/axom/multimat/multimat.cpp
@@ -1322,11 +1322,7 @@ void MultiMat::transposeField_helper(int field_idx)
   //Skip if no volume fraction array is set-up
   if(field_idx == 0 && m_fieldBackingVec[0] == nullptr) return;
 
-  Field2D<DataType> old_map = get2dFieldImpl<DataType>(field_idx);
-  int stride = old_map.stride();
-
   DataLayout oldDataLayout = getFieldDataLayout(field_idx);
-  StaticVariableRelationType& oldRel = relStatic(oldDataLayout);
   DataLayout new_layout;
   if(oldDataLayout == DataLayout::CELL_DOM)
   {
@@ -1341,12 +1337,6 @@ void MultiMat::transposeField_helper(int field_idx)
   {
     makeOtherRelation(new_layout);
   }
-
-  auto& set1 = *(oldRel.fromSet());
-  auto& set2 = *(oldRel.toSet());
-
-  int set1Size = set1.size();
-  int set2Size = set2.size();
 
   axom::Array<DataType> arr_data;
   RelationSetType* fromRelSet = &relSparseSet(m_fieldDataLayoutVec[field_idx]);
@@ -1378,10 +1368,7 @@ void MultiMat::transposeField_helper(int field_idx)
       TransposeDenseImpl<axom::SEQ_EXEC>(oldField, fromRelSet, m_fieldAllocatorId);
   }
 
-  if(arr_data.getAllocatorID() != m_fieldAllocatorId)
-  {
-    arr_data = axom::Array<DataType>(arr_data, m_fieldAllocatorId);
-  }
+  SLIC_ASSERT(arr_data.getAllocatorID() == m_fieldAllocatorId);
 
   if(m_fieldBackingVec[field_idx]->isOwned())
   {

--- a/src/axom/multimat/multimat.cpp
+++ b/src/axom/multimat/multimat.cpp
@@ -8,9 +8,11 @@
  *
  * \brief Implementation of the MultiMat class
  */
+#include "axom/config.hpp"
+#include "axom/core/execution/execution_space.hpp"
+#include "axom/core/execution/for_all.hpp"
 
 #include "axom/multimat/multimat.hpp"
-#include "axom/core/execution/for_all.hpp"
 #include "axom/slic.hpp"
 
 #include <iostream>

--- a/src/axom/multimat/multimat.cpp
+++ b/src/axom/multimat/multimat.cpp
@@ -1378,10 +1378,9 @@ void MultiMat::transposeField_helper(int field_idx)
   {
     // We don't own the underlying buffer, just copy the data.
     const auto old_view = m_fieldBackingVec[field_idx]->getArrayView<DataType>();
-    for(IndexType flat_idx = 0; flat_idx < old_view.size(); flat_idx++)
-    {
-      old_view[flat_idx] = arr_data[flat_idx];
-    }
+    axom::copy(old_view.data(),
+               arr_data.data(),
+               old_view.size() * sizeof(DataType));
   }
   m_fieldDataLayoutVec[field_idx] = new_layout;
 }

--- a/src/axom/multimat/multimat.hpp
+++ b/src/axom/multimat/multimat.hpp
@@ -84,7 +84,7 @@ private:
   using IndViewPolicy = slam::policies::ArrayViewIndirection<SetPosType, T>;
 
   using VariableCardinality =
-    slam::policies::VariableCardinality<SetPosType, IndViewPolicy<SetElemType>>;
+    slam::policies::MappedVariableCardinality<SetPosType, IndViewPolicy<SetElemType>>;
   using StaticVariableRelationType =
     slam::StaticRelation<SetPosType,
                          SetElemType,
@@ -681,6 +681,14 @@ private:  //private functions
   IndBufferType& relIndVec(DataLayout layout);
 
   /*!
+   * \brief Returns a reference to the corresponding array of indices for
+   *        a static relation corresponding to a layout.
+   *
+   * \param layout The layout type of the relation (cell- or mat-dominant)
+   */
+  IndBufferType& relFirstIndVec(DataLayout layout);
+
+  /*!
    * \brief Returns a reference to the static relation corresponding to a
    *        layout.
    *
@@ -780,9 +788,11 @@ private:
   //cell to mat relation data
   IndBufferType m_cellMatRel_beginsVec;
   IndBufferType m_cellMatRel_indicesVec;
+  IndBufferType m_cellMatRel_firstIndicesVec;
   //mat to cell relation data
   IndBufferType m_matCellRel_beginsVec;
   IndBufferType m_matCellRel_indicesVec;
+  IndBufferType m_matCellRel_firstIndicesVec;
   //relation objects stored in unified memory
   axom::Array<StaticVariableRelationType> m_staticRelations;
   axom::Array<DynamicVariableRelationType> m_dynamicRelations;

--- a/src/axom/multimat/multimat.hpp
+++ b/src/axom/multimat/multimat.hpp
@@ -802,6 +802,11 @@ private:
   // dense layout bivariate sets
   axom::Array<ProductSetType> m_denseBivarSet;
 
+  // Transposition maps for sparse conversions of data layout
+  // These map flat indices between cell-dominant and material-dominant layouts
+  IndBufferType m_flatCellToMatIndexMap;
+  IndBufferType m_flatMatToCellIndexMap;
+
   struct FieldBacking
   {
   private:

--- a/src/axom/multimat/multimat.hpp
+++ b/src/axom/multimat/multimat.hpp
@@ -283,6 +283,8 @@ public:
    *
    * \pre The number of materials and cell must be set prior to calling this
    *  function with setNumberOfMaterials(int) and setNumberOfCells(int)
+   * \pre If m_slamAllocatorID points to device-accessible memory, cardinality
+   *  and indices must be device accessible.
    */
   void setCellMatRel(axom::ArrayView<const SetPosType> cardinality,
                      axom::ArrayView<const SetPosType> indices,

--- a/src/axom/slam/RelationSet.hpp
+++ b/src/axom/slam/RelationSet.hpp
@@ -191,15 +191,7 @@ public:
     {
       SLIC_ASSERT("Flat index out of bounds of the relation set.");
     }
-    for(PositionType firstIdx = 0; firstIdx < this->firstSetSize(); firstIdx++)
-    {
-      // keep looping until the first subset after flatIndex
-      if((*m_relation)[firstIdx].offset() > flatIndex)
-      {
-        return firstIdx - 1;
-      }
-    }
-    return this->firstSetSize() - 1;
+    return m_relation->firstIndex(flatIndex);
   }
 
   AXOM_HOST_DEVICE RangeSetType elementRangeSet(PositionType pos1) const

--- a/src/axom/slam/policies/CardinalityPolicies.hpp
+++ b/src/axom/slam/policies/CardinalityPolicies.hpp
@@ -28,6 +28,9 @@
  *  * offset(ElementType idx) : const ElementType
  *     -- returns the offset to the first element of the ToSet for element
  *        with index idx of the FromSet
+ *  * firstIndex(ElementType offset) : const ElementType
+ *     -- returns the element index in the FromSet given an offset into the
+ *        relation
  *  * totalSize(): int
  *     -- returns the total number of elements in this relation.
  *        That is, the sum of size(idx) for each element (with index idx)
@@ -104,6 +107,11 @@ struct ConstantCardinality
     return m_begins[fromPos];
   }
 
+  AXOM_HOST_DEVICE ElementType firstIndex(ElementType offset) const
+  {
+    return offset / m_begins.stride();
+  }
+
   IndirectionPtrType offsetData() { return m_begins.ptr(); }
 
   const IndirectionPtrType offsetData() const { return m_begins.ptr(); }
@@ -171,6 +179,18 @@ struct VariableCardinality
   AXOM_HOST_DEVICE ElementType offset(ElementType fromPos) const
   {
     return m_begins[fromPos];
+  }
+
+  AXOM_HOST_DEVICE ElementType firstIndex(ElementType relationOffset) const
+  {
+    for(ElementType firstIdx = 0; firstIdx < m_begins.size() - 1; firstIdx++)
+    {
+      if(offset(firstIdx + 1) > relationOffset)
+      {
+        return firstIdx;
+      }
+    }
+    return -1;
   }
 
   IndirectionPtrType offsetData() { return m_begins.data(); }

--- a/src/axom/slam/policies/CardinalityPolicies.hpp
+++ b/src/axom/slam/policies/CardinalityPolicies.hpp
@@ -61,6 +61,15 @@ namespace slam
 {
 namespace policies
 {
+
+/*!
+ * \class ConstantCardinality
+ * \brief Represents a mapping between two sets, where each element in the
+ *  first set maps to a fixed number of elements in the second set
+ *
+ * \tparam ElementType the index data type
+ * \tparam StridePolicy policy for number of elements being mapped
+ */
 template <typename ElementType = int, typename StridePolicy = RuntimeStride<ElementType>>
 struct ConstantCardinality
 {
@@ -133,6 +142,14 @@ struct ConstantCardinality
   BeginsSet m_begins;
 };
 
+/*!
+ * \class VariableCardinality
+ * \brief Represents a mapping between two sets, where each element in the
+ *  first set maps to an arbitrary number of elements in the second set.
+ *
+ * \tparam ElementType the index data type
+ * \tparam IndirectionPolicy the policy to use for storing offsets and indices
+ */
 template <typename ElementType = int,
           typename IndirectionPolicy = STLVectorIndirection<ElementType, ElementType>>
 struct VariableCardinality
@@ -215,8 +232,19 @@ struct VariableCardinality
   BeginsSet m_begins;
 };
 
+/*!
+ * \class MappedVariableCardinality
+ * \brief Represents a mapping between two sets, where each element in the
+ *  first set maps to an arbitrary number of elements in the second set.
+ *
+ *  MappedVariableCardinality extends VariableCardinality to map "flat" indices
+ *  in the associated RelationSet to first set indices.
+ *
+ * \tparam ElementType the index data type
+ * \tparam IndirectionPolicy the policy to use for storing offsets and indices
+ */
 template <typename ElementType = int,
-          typename IndirectionPolicy = STLVectorIndirection<ElementType, ElementType>>
+          typename IndirectionPolicy = ArrayIndirection<ElementType, ElementType>>
 struct MappedVariableCardinality
 {
   using BeginsSizePolicy = RuntimeSize<ElementType>;

--- a/src/axom/slam/policies/CardinalityPolicies.hpp
+++ b/src/axom/slam/policies/CardinalityPolicies.hpp
@@ -61,7 +61,6 @@ namespace slam
 {
 namespace policies
 {
-
 /*!
  * \class ConstantCardinality
  * \brief Represents a mapping between two sets, where each element in the


### PR DESCRIPTION
# Summary

## Slam
- Moves `RelationSet::flatToFirstIndex()` logic into CardinalityPolicy
- Adds a `MappedVariableCardinality` policy which holds an extra indirection buffer for mapping flat relation offsets to the first set index
  - This allows for constant-time `flatToFirstIndex()` lookups for variable cardinality, at the cost of extra space

## Multimat
- Use `MappedVariableCardinality` for static relations to accelerate transposition operations
- Ports transposition of field data between cell-dominant/material-dominant and sparse/dense layouts
- Ports `MultiMat::makeOtherRelation()` to GPU
- Ports `MultiMat::setCellMatRel(counts, indices)` overload to GPU
  - `counts` and `indices` must be in GPU-accessible space if `slamAllocatorID` is a GPU-accessible allocator