### PR TITLE
Add BezierPatch class to primal/geometry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ _axom_build_and_test_*
 tpl_dirs_summary.json
 *.swp
 *.vscode*
-*.vs
+.vs/*
 uberenv_libs
 *_build*
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ _axom_build_and_test_*
 tpl_dirs_summary.json
 *.swp
 *.vscode*
+*.vs
 uberenv_libs
 *_build*
 .idea

--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -21,6 +21,7 @@ set( primal_headers
 
     ## geometry
     geometry/BezierCurve.hpp
+    geometry/BezierPatch.hpp
     geometry/BoundingBox.hpp
     geometry/CurvedPolygon.hpp
     geometry/Hexahedron.hpp

--- a/src/axom/primal/geometry/BezierCurve.hpp
+++ b/src/axom/primal/geometry/BezierCurve.hpp
@@ -62,7 +62,6 @@ class BezierCurve
 public:
   using PointType = Point<T, NDIMS>;
   using VectorType = Vector<T, NDIMS>;
-  using NumArrayType = NumericArray<T, NDIMS>;
   using SegmentType = Segment<T, NDIMS>;
   using CoordsVec = axom::Array<PointType>;
   using BoundingBoxType = BoundingBox<T, NDIMS>;
@@ -85,7 +84,7 @@ public:
   explicit BezierCurve(int ord = -1)
   {
     SLIC_ASSERT(ord >= -1);
-    const int sz = utilities::max(-1, ord + 1);
+    const int sz = utilities::max(0, ord + 1);
     m_controlPoints.resize(sz);
 
     makeNonrational();
@@ -529,10 +528,10 @@ public:
           }
 
           c2.setWeight(k, temp_weight);
-
-          c1[p] = c2[0];
-          c1.setWeight(p, c2.getWeight(0));
         }
+
+        c1[p] = c2[0];
+        c1.setWeight(p, c2.getWeight(0));
       }
     }
     else  // Code can be simpler if not rational Bezier curves

--- a/src/axom/primal/geometry/BezierCurve.hpp
+++ b/src/axom/primal/geometry/BezierCurve.hpp
@@ -62,6 +62,7 @@ class BezierCurve
 public:
   using PointType = Point<T, NDIMS>;
   using VectorType = Vector<T, NDIMS>;
+  using NumArrayType = NumericArray<T, NDIMS>;
   using SegmentType = Segment<T, NDIMS>;
   using CoordsVec = axom::Array<PointType>;
   using BoundingBoxType = BoundingBox<T, NDIMS>;
@@ -84,7 +85,7 @@ public:
   explicit BezierCurve(int ord = -1)
   {
     SLIC_ASSERT(ord >= -1);
-    const int sz = utilities::max(0, ord + 1);
+    const int sz = utilities::max(-1, ord + 1);
     m_controlPoints.resize(sz);
 
     makeNonrational();
@@ -528,10 +529,10 @@ public:
           }
 
           c2.setWeight(k, temp_weight);
-        }
 
-        c1[p] = c2[0];
-        c1.setWeight(p, c2.getWeight(0));
+          c1[p] = c2[0];
+          c1.setWeight(p, c2.getWeight(0));
+        }
       }
     }
     else  // Code can be simpler if not rational Bezier curves

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -85,73 +85,39 @@ public:
    * \param [in] order the order of the resulting Bezier curve
    * \pre order is greater than or equal to -1.
    */
-  BezierPatch(int ord_t = -1, int ord_s = -1)
+  BezierPatch(int ord_u = -1, int ord_v = -1)
   {
-    SLIC_ASSERT(ord_t >= -1, ord_s >= -1);
+    SLIC_ASSERT(ord_u >= -1, ord_v >= -1);
 
-    const int sz_t = utilities::max(0, ord_t + 1);
-    const int sz_s = utilities::max(0, ord_s + 1);
+    const int sz_u = utilities::max(0, ord_u + 1);
+    const int sz_v = utilities::max(0, ord_v + 1);
 
-    m_controlPoints.resize(sz_t, sz_s);
+    m_controlPoints.resize(sz_u, sz_v);
 
     makeNonrational();
   }
 
   /*!
-   * TODO: Make this constructor work 
-   * (or more likely, don't. That's so many points to initialize in an array...)
-   * \brief Constructor for an order \a ord= n Bezier curve
-   * from a list of coordinates:
-   * \verbatim {x_0, x_1, x_2,...,x_n,
-   *            y_0, y_1, y_2,...,y_n,
-   *            z_0, z_1, z_2,...,z_n}
-   *
-   * \param [in] pts an array with (p+1)*NDIMS entries, ordered by coordinate
-   * then by polynomial order
-   * \param [in] ord Polynomial order of the curve
-   * \pre order is greater than or equal to zero
-   */
-  //BezierCurve(T* pts, int ord)
-  //{
-  //  SLIC_ASSERT(pts != nullptr);
-  //  SLIC_ASSERT(ord >= 0);
-
-  //  const int sz = utilities::max(0, ord + 1);
-  //  m_controlPoints.resize(sz);
-
-  //  for(int p = 0; p <= ord; p++)
-  //  {
-  //    auto& pt = m_controlPoints[p];
-  //    for(int j = 0; j < NDIMS; j++)
-  //    {
-  //      pt[j] = pts[j * (ord + 1) + p];
-  //    }
-  //  }
-
-  //  makeNonrational();
-  //}
-
-  /*!
    * \brief Constructor for a Bezier Patch from a 2D array of coordinates
    *
-   * \param [in] pts an array with ord_t+1 arrays with ord_m+1 control points
-   * \param [in] ord_t The patches's polynomial order in p
-   * \param [in] ord_s The patches's polynomial order in q
+   * \param [in] pts an array with ord_u+1 arrays with ord_m+1 control points
+   * \param [in] ord_u The patches's polynomial order on the first axis
+   * \param [in] ord_v The patches's polynomial order on the second axis
    * \pre order in both directions is greater than or equal to zero
    *
    */
-  BezierPatch(PointType* pts, int ord_t, int ord_s)
+  BezierPatch(PointType* pts, int ord_u, int ord_v)
   {
     SLIC_ASSERT(pts != nullptr);
-    SLIC_ASSERT(ord_t >= 0, ord_s >= 0);
+    SLIC_ASSERT(ord_u >= 0, ord_v >= 0);
 
-    const int sz_t = utilities::max(0, ord_t + 1);
-    const int sz_s = utilities::max(0, ord_s + 1);
+    const int sz_u = utilities::max(0, ord_u + 1);
+    const int sz_v = utilities::max(0, ord_v + 1);
 
-    m_controlPoints.resize(sz_t, sz_s);
+    m_controlPoints.resize(sz_u, sz_v);
 
-    for(int t = 0; t < sz_t * sz_s; ++t)
-      m_controlPoints(t / sz_s, t % sz_s) = pts[t];
+    for(int t = 0; t < sz_u * sz_v; ++t)
+      m_controlPoints(t / sz_v, t % sz_v) = pts[t];
 
     makeNonrational();
   }
@@ -159,25 +125,25 @@ public:
   /*!
    * \brief Constructor for a Rational Bezier Path from an array of coordinates and weights
    *
-   * \param [in] pts a matrix with (ord_t+1) * (ord_s+1) control points
-   * \param [in] weights a matrix with (ord_t+1) * (ord_s+1) positive weights
-   * \param [in] ord_t The patches's polynomial order in p
-   * \param [in] ord_s The patches's polynomial order in q
+   * \param [in] pts a matrix with (ord_u+1) * (ord_v+1) control points
+   * \param [in] weights a matrix with (ord_u+1) * (ord_v+1) positive weights
+   * \param [in] ord_u The patches's polynomial order on the first axis
+   * \param [in] ord_v The patches's polynomial order on the second axis
    * \pre order is greater than or equal to zero in each direction
    *
    */
-  BezierPatch(PointType* pts, T* weights, int ord_t, int ord_s)
+  BezierPatch(PointType* pts, T* weights, int ord_u, int ord_v)
   {
     SLIC_ASSERT(pts != nullptr);
-    SLIC_ASSERT(ord_t >= 0, ord_s >= 0);
+    SLIC_ASSERT(ord_u >= 0, ord_v >= 0);
 
-    const int sz_t = utilities::max(0, ord_t + 1);
-    const int sz_s = utilities::max(0, ord_s + 1);
+    const int sz_u = utilities::max(0, ord_u + 1);
+    const int sz_v = utilities::max(0, ord_v + 1);
 
-    m_controlPoints.resize(sz_t, sz_s);
+    m_controlPoints.resize(sz_u, sz_v);
 
-    for(int t = 0; t < sz_t * sz_s; ++t)
-      m_controlPoints(t / sz_s, t % sz_s) = pts[t];
+    for(int t = 0; t < sz_u * sz_v; ++t)
+      m_controlPoints(t / sz_v, t % sz_v) = pts[t];
 
     if(weights == nullptr)
     {
@@ -185,10 +151,10 @@ public:
     }
     else
     {
-      m_weights.resize(sz_t, sz_s);
+      m_weights.resize(sz_u, sz_v);
 
-      for(int t = 0; t < sz_t * sz_s; ++t)
-        m_weights(t / sz_s, t % sz_s) = weights[t];
+      for(int t = 0; t < sz_u * sz_v; ++t)
+        m_weights(t / sz_v, t % sz_v) = weights[t];
 
       SLIC_ASSERT(isValidRational());
     }
@@ -197,20 +163,20 @@ public:
   /*!
    * \brief Constructor for a Bezier Patch from an matrix of coordinates
    *
-   * \param [in] pts a vector with (ord_t+1) * (ord_s+1) control points
-   * \param [in] ord_t The patch's polynomial order in p
-   * \param [in] ord_s The patch's polynomial order in q
+   * \param [in] pts a vector with (ord_u+1) * (ord_v+1) control points
+   * \param [in] ord_u The patch's polynomial order on the first axis
+   * \param [in] ord_v The patch's polynomial order on the second axis
    * \pre order is greater than or equal to zero in each direction
    *
    */
-  BezierPatch(const CoordsMat& pts, int ord_t, int ord_s)
+  BezierPatch(const CoordsMat& pts, int ord_u, int ord_v)
   {
-    SLIC_ASSERT((ord_t >= 0) && (ord_s >= 0));
+    SLIC_ASSERT((ord_u >= 0) && (ord_v >= 0));
 
-    const int sz_t = utilities::max(0, ord_t + 1);
-    const int sz_s = utilities::max(0, ord_s + 1);
+    const int sz_u = utilities::max(0, ord_u + 1);
+    const int sz_v = utilities::max(0, ord_v + 1);
 
-    m_controlPoints.resize(sz_t, sz_s);
+    m_controlPoints.resize(sz_u, sz_v);
     m_controlPoints = pts;
 
     makeNonrational();
@@ -220,48 +186,46 @@ public:
    * \brief Constructor for a Rational Bezier Patch from a matrix
    * of coordinates and weights
    *
-   * \param [in] pts a vector with (ord_t+1) * (ord_s+1) control points
-   * \param [in] ord_t The patch's polynomial order in p
-   * \param [in] ord_s The patch's polynomial order in q
+   * \param [in] pts a vector with (ord_u+1) * (ord_v+1) control points
+   * \param [in] ord_u The patch's polynomial order on the first axis
+   * \param [in] ord_v The patch's polynomial order on the second axis
    * \pre order is greater than or equal to zero in each direction
-   *
-   * TODO: Can we just do this entire thing with initalizer lists? 
    */
   BezierPatch(const CoordsMat& pts,
               const axom::Array<axom::Array<T>>& weights,
-              int ord_t,
-              int ord_s)
+              int ord_u,
+              int ord_v)
   {
     SLIC_ASSERT(ord >= 0);
     SLIC_ASSERT(pts.shape()[0] == weights.shape()[0]);
     SLIC_ASSERT(pts.shape()[1] == weights.shape()[1]);
 
-    const int sz_t = utilities::max(0, ord_t + 1);
-    const int sz_s = utilities::max(0, ord_s + 1);
+    const int sz_u = utilities::max(0, ord_u + 1);
+    const int sz_v = utilities::max(0, ord_v + 1);
 
-    m_controlPoints.resize(sz_t, sz_s);
+    m_controlPoints.resize(sz_u, sz_v);
     m_controlPoints = pts;
 
-    m_weights.resize(sz_t, sz_s);
+    m_weights.resize(sz_u, sz_v);
     m_weights = weights;
 
     SLIC_ASSERT(isValidRational());
   }
 
   /// Sets the order of the Bezier Curve
-  void setOrder(int ord_t, int ord_s)
+  void setOrder(int ord_u, int ord_v)
   {
-    m_controlPoints.resize(ord_t + 1, ord_s + 1);
+    m_controlPoints.resize(ord_u + 1, ord_v + 1);
   }
 
   /// Returns the order of the Bezier Curve on the first axis
-  int getOrder_t() const
+  int getOrder_u() const
   {
     return static_cast<int>(m_controlPoints.shape()[0]) - 1;
   }
 
   /// Returns the order of the Bezier Curve
-  int getOrder_s() const
+  int getOrder_v() const
   {
     return static_cast<int>(m_controlPoints.shape()[1]) - 1;
   }
@@ -271,13 +235,13 @@ public:
   {
     if(!isRational())
     {
-      const int ord_t = getOrder_t();
-      const int ord_s = getOrder_s();
+      const int ord_u = getOrder_u();
+      const int ord_v = getOrder_v();
 
-      m_weights.resize(ord_t + 1, ord_s + 1);
+      m_weights.resize(ord_u + 1, ord_v + 1);
 
-      for(int i = 0; i <= ord_t; ++i)
-        for(int j = 0; j <= ord_s; ++j) m_weights[i][j] = 1.0;
+      for(int i = 0; i <= ord_u; ++i)
+        for(int j = 0; j <= ord_v; ++j) m_weights[i][j] = 1.0;
     }
   }
 
@@ -290,55 +254,52 @@ public:
   /// Clears the list of control points, make nonrational
   void clear()
   {
-    const int ord_t = getOrder_t();
-    const int ord_s = getOrder_s();
+    const int ord_u = getOrder_u();
+    const int ord_v = getOrder_v();
 
-    for(int p = 0; p <= ord; ++p)
-      for(int q = 0; q <= getOrder_s; ++q) m_controlPoints(p, q) = PointType();
+    for(int p = 0; p <= ord_u; ++p)
+      for(int q = 0; q <= ord_v(); ++q) m_controlPoints(p, q) = PointType();
 
     makeNonrational();
   }
 
   /// Retrieves the control point at index \a (idx_p, idx_q)
-  PointType& operator()(int idx_p, int idx_q)
-  {
-    return m_controlPoints(idx_p, idx_q);
-  }
+  PointType& operator()(int ui, int vi) { return m_controlPoints(ui, vi); }
 
   /// Retrieves the vector of control points at index \a idx
-  const PointType& operator()(int idx_p, int idx_q) const
+  const PointType& operator()(int ui, int vi) const
   {
-    return m_controlPoints(idx_p, idx_q);
+    return m_controlPoints(ui, vi);
   }
 
   /*!
    * \brief Get a specific weight
    *
-   * \param [in] idx_p The index of the weight in p
-   * \param [in] idx_q The index of the weight in q
+   * \param [in] ui The index of the weight on the first axis
+   * \param [in] vi The index of the weight on the second axis
    * \pre Requires that the surface be rational
    */
-  const T& getWeight(int idx_p, int idx_q) const
+  const T& getWeight(int ui, int vi) const
   {
     SLIC_ASSERT(isRational());
-    return m_weights(idx_p, idx_q);
+    return m_weights(ui, vi);
   }
 
   /*!
    * \brief Set the weight at a specific index
    *
-   * \param [in] idx_p The index of the weight in p
-   * \param [in] idx_q The index of the weight in q
+   * \param [in] ui The index of the weight in on the first axis
+   * \param [in] vi The index of the weight in on the second axis
    * \param [in] weight The updated value of the weight
    * \pre Requires that the surface be rational
    * \pre Requires that the weight be positive
    */
-  void setWeight(int idx_p, int idx_q, T weight)
+  void setWeight(int ui, int vi, T weight)
   {
     SLIC_ASSERT(isRational());
     SLIC_ASSERT(weight > 0);
 
-    m_weights(idx_p, idx_q) = weight;
+    m_weights(ui, vi) = weight;
   };
 
   /// Checks equality of two Bezier Patches
@@ -379,23 +340,23 @@ public:
   }
 
   /*!
-   * \brief Evaluates a slice Bezier patch for a fixed parameter value of \a t or \a s
+   * \brief Evaluates a slice Bezier patch for a fixed parameter value of \a u or \a v
    *
-   * \param [in] t parameter value at which to evaluate
-   * \param [in] s parameter value at which to evaluate
-   * \param [in] axis orientation of curve. 0 for fixed t, 1 for fixed s
-   * \return p the value of the Bezier patch at (t, s)
+   * \param [in] u parameter value at which to evaluate the first axis
+   * \param [in] v parameter value at which to evaluate the second axis
+   * \param [in] axis orientation of curve. 0 for fixed u, 1 for fixed v
+   * \return p the value of the Bezier patch at (u, v)
    *
-   * \note We typically evaluate the curve at \a t or \a s between 0 and 1
+   * \note We typically evaluate the curve at \a u or \a v between 0 and 1
    */
-  BezierCurveType slice(T ts, int axis = 0) const
+  BezierCurveType isocurve(T uv, int axis = 0) const
   {
     SLIC_ASSERT((axis == 0) || (axis == 1));
 
     using axom::utilities::lerp;
 
-    const int ord_t = getOrder_t();
-    const int ord_s = getOrder_s();
+    const int ord_u = getOrder_u();
+    const int ord_v = getOrder_v();
 
     BezierCurveType c(-1);
 
@@ -403,29 +364,29 @@ public:
     {
       if(axis == 0)  // Keeping a fixed value of t
       {
-        c.setOrder(ord_s);
+        c.setOrder(ord_v);
         c.makeRational();
 
-        axom::Array<T> dCarray(ord_t + 1);
-        axom::Array<T> dWarray(ord_t + 1);
+        axom::Array<T> dCarray(ord_u + 1);
+        axom::Array<T> dWarray(ord_u + 1);
 
         // Run de Casteljau algorithm on each row of control nodes and each dimension
-        for(int q = 0; q <= ord_s; ++q)
+        for(int q = 0; q <= ord_v; ++q)
           for(int i = 0; i < NDIMS; ++i)
           {
-            for(int p = 0; p <= ord_t; ++p)
+            for(int p = 0; p <= ord_u; ++p)
             {
               dCarray[p] = m_controlPoints(p, q)[i] * m_weights(p, q);
               dWarray[p] = m_weights(p, q);
             }
 
-            for(int p = 1; p <= ord_t; ++p)
+            for(int p = 1; p <= ord_u; ++p)
             {
-              const int end = ord_t - p;
+              const int end = ord_u - p;
               for(int k = 0; k <= end; ++k)
               {
-                dCarray[k] = lerp(dCarray[k], dCarray[k + 1], ts);
-                dWarray[k] = lerp(dWarray[k], dWarray[k + 1], ts);
+                dCarray[k] = lerp(dCarray[k], dCarray[k + 1], uv);
+                dWarray[k] = lerp(dWarray[k], dWarray[k + 1], uv);
               }
             }
 
@@ -436,28 +397,28 @@ public:
       // Run de Casteljau algorithm on each column of control nodes and each dimension
       else  // Keeping a fixed value of s
       {
-        c.setOrder(ord_t);
+        c.setOrder(ord_u);
         c.makeRational();
 
-        axom::Array<T> dCarray(ord_s + 1);
-        axom::Array<T> dWarray(ord_s + 1);
+        axom::Array<T> dCarray(ord_v + 1);
+        axom::Array<T> dWarray(ord_v + 1);
 
-        for(int p = 0; p <= ord_t; ++p)
+        for(int p = 0; p <= ord_u; ++p)
           for(int i = 0; i < NDIMS; ++i)
           {
-            for(int q = 0; q <= ord_s; ++q)
+            for(int q = 0; q <= ord_v; ++q)
             {
               dCarray[q] = m_controlPoints(p, q)[i] * m_weights(p, q);
               dWarray[q] = m_weights(p, q);
             }
 
-            for(int q = 1; q <= ord_s; ++q)
+            for(int q = 1; q <= ord_v; ++q)
             {
-              const int end = ord_s - q;
+              const int end = ord_v - q;
               for(int k = 0; k <= end; ++k)
               {
-                dCarray[k] = lerp(dCarray[k], dCarray[k + 1], ts);
-                dWarray[k] = lerp(dWarray[k], dWarray[k + 1], ts);
+                dCarray[k] = lerp(dCarray[k], dCarray[k + 1], uv);
+                dWarray[k] = lerp(dWarray[k], dWarray[k + 1], uv);
               }
             }
             c[p][i] = dCarray[0] / dWarray[0];
@@ -469,21 +430,21 @@ public:
     {
       if(axis == 0)  // Keeping a fixed value of t
       {
-        c.setOrder(ord_s);
-        axom::Array<T> dCarray(ord_t + 1);  // Temp array
+        c.setOrder(ord_v);
+        axom::Array<T> dCarray(ord_u + 1);  // Temp array
 
         // Run de Casteljau algorithm on each row of control nodes and each dimension
-        for(int q = 0; q <= ord_s; ++q)
+        for(int q = 0; q <= ord_v; ++q)
           for(int i = 0; i < NDIMS; ++i)
           {
-            for(int p = 0; p <= ord_t; ++p)
+            for(int p = 0; p <= ord_u; ++p)
               dCarray[p] = m_controlPoints(p, q)[i];
 
-            for(int p = 1; p <= ord_t; ++p)
+            for(int p = 1; p <= ord_u; ++p)
             {
-              const int end = ord_t - p;
+              const int end = ord_u - p;
               for(int k = 0; k <= end; ++k)
-                dCarray[k] = lerp(dCarray[k], dCarray[k + 1], ts);
+                dCarray[k] = lerp(dCarray[k], dCarray[k + 1], uv);
             }
             c[q][i] = dCarray[0];
           }
@@ -491,21 +452,21 @@ public:
       // Run de Casteljau algorithm on each column of control nodes and each dimension
       else  // Keeping a fixed value of s
       {
-        c.setOrder(ord_t);
-        axom::Array<T> dCarray(ord_s + 1);  // Temp array
+        c.setOrder(ord_u);
+        axom::Array<T> dCarray(ord_v + 1);  // Temp array
 
-        for(int p = 0; p <= ord_t; ++p)
+        for(int p = 0; p <= ord_u; ++p)
           for(int i = 0; i < NDIMS; ++i)
           {
-            for(int q = 0; q <= ord_s; ++q)
+            for(int q = 0; q <= ord_v; ++q)
               dCarray[q] = m_controlPoints(p, q)[i];
 
-            for(int q = 1; q <= ord_s; ++q)
+            for(int q = 1; q <= ord_v; ++q)
             {
-              const int end = ord_s - q;
+              const int end = ord_v - q;
               for(int k = 0; k <= end; ++k)
               {
-                dCarray[k] = lerp(dCarray[k], dCarray[k + 1], ts);
+                dCarray[k] = lerp(dCarray[k], dCarray[k + 1], uv);
               }
             }
             c[p][i] = dCarray[0];
@@ -517,103 +478,109 @@ public:
   }
 
   /*!
-   * \brief Evaluates a Bezier patch at a particular parameter value (\a t, \a s)
+   * \brief Evaluates a Bezier patch at a particular parameter value (\a u, \a v)
    *
-   * \param [in] t parameter value at which to evaluate
-   * \param [in] s parameter value at which to evaluate
-   * \return p the value of the Bezier patch at (t, s)
+   * \param [in] u parameter value at which to evaluate on the first axis
+   * \param [in] v parameter value at which to evaluate on the second axis
+   * \return p the value of the Bezier patch at (u, v)
    *
-   * \note We typically evaluate the curve at \a t and \a s between 0 and 1
+   * \note We typically evaluate the curve at \a u and \a v between 0 and 1
    */
-  PointType evaluate(T t, T s) const { return slice(t).evaluate(s); }
-
-  /*!
-   * \brief Computes a tangent of a Bezier patch at a particular parameter value (\a t, \a s) oriented in \a axis
-   *
-   * \param [in] t parameter value at which to evaluate
-   * \param [in] s parameter value at which to evaluate
-   * \param [in] axis orientation of vector. 0 for fixed t, 1 for fixed s
-   * \return v a tangent vector of the Bezier curve at (t, s)
-   *
-   * \note We typically find the tangent of the curve at \a t and \a s between 0 and 1
-   */
-  VectorType dt(T t, T s, int axis) const
+  PointType evaluate(T u, T v) const
   {
-    SLIC_ASSERT((axis == 0) || (axis == 1));
-    if(axis == 0)  // Get slice at fixed s
-      return slice(s, 1).dt(t);
-    else  // Get slice at fixed t
-      return slice(t, 0).dt(s);
+    if(getOrder_u() >= getOrder_v())
+      return isocurve(u, 0).evaluate(v);
+    else
+      return isocurve(v, 1).evaluate(u);
   }
 
   /*!
-   * \brief Computes the normal vector of a Bezier patch at a particular parameter value (\a t, \a s)
+   * \brief Computes a tangent of a Bezier patch at a particular parameter value (\a u, \a v) along \a axis
    *
-   * \param [in] t parameter value at which to evaluate
-   * \param [in] s parameter value at which to evaluate
-   * \return v the normal vector of the Bezier curve at (t, s)
+   * \param [in] u parameter value at which to evaluate on the first axis
+   * \param [in] v parameter value at which to evaluate on the second axis
+   * \param [in] axis orientation of vector. 0 for fixed u, 1 for fixed v
+   * \return v a tangent vector of the Bezier curve at (u, v)
    *
-   * \note We typically find the normal of the curve at \a t and \a s between 0 and 1
+   * \note We typically find the tangent of the curve at \a u and \a v between 0 and 1
    */
-  VectorType normal(T t, T s) const
+  VectorType dt(T u, T v, int axis) const
   {
-    VectorType tangent_t = dt(t, s, 0);
-    VectorType tangent_s = dt(t, s, 1);
+    SLIC_ASSERT((axis == 0) || (axis == 1));
+    if(axis == 0)  // Get isocurve at fixed v
+      return isocurve(v, 1).dt(u);
+    else  // Get isocurve at fixed u
+      return isocurve(u, 0).dt(v);
+  }
+
+  /*!
+   * \brief Computes the normal vector of a Bezier patch at a particular parameter value (\a u, \a v)
+   *
+   * \param [in] u parameter value at which to evaluate on the first axis
+   * \param [in] v parameter value at which to evaluate on the second axis
+   * \return vec the normal vector of the Bezier curve at (u, v)
+   *
+   * \note We typically find the normal of the curve at \a u and \a v between 0 and 1
+   */
+  VectorType normal(T u, T v) const
+  {
+    VectorType tangent_t = dt(u, v, 0);
+    VectorType tangent_s = dt(u, v, 1);
     return VectorType::cross_product(tangent_t, tangent_s);
   }
 
   /*!
    * \brief Splits a Bezier patch into two Bezier patches
    *
-   * \param [in] ts parameter value between 0 and 1 at which to bisect the patch
-   * \param [in] axis orientation of split. 0 for fixed t, 1 for fixed s
+   * \param [in] uv parameter value between 0 and 1 at which to bisect the patch
+   * \param [in] axis orientation of split. 0 for fixed u, 1 for fixed v
    * \param [out] p1 First output Bezier patch
    * \param [out] p2 Second output Bezier patch
    *
-   * \pre Parameter \a ts must be between 0 and 1
+   * \pre Parameter \a uv must be between 0 and 1
    */
-  void split(T ts, int axis, BezierPatch& p1, BezierPatch& p2) const
+  void split(T uv, int axis, BezierPatch& p1, BezierPatch& p2) const
   {
     SLIC_ASSERT((axis == 0) || (axis == 1));
 
     using axom::utilities::lerp;
 
-    const int ord_t = getOrder_t();
-    const int ord_s = getOrder_s();
+    const int ord_u = getOrder_u();
+    const int ord_v = getOrder_v();
 
-    SLIC_ASSERT((ord_t >= 0) && (ord_s >= 0));
+    SLIC_ASSERT((ord_u >= 0) && (ord_v >= 0));
 
     // Note: The second patch's control points are computed inline
     //       as we find the first patch's control points
     p2 = *this;
 
-    p1.setOrder(ord_t, ord_s);
+    p1.setOrder(ord_u, ord_v);
     if(isRational())
     {
       p1.makeRational();  // p2 already rational
       if(axis == 0)       // Split across a fixed value of t
       {
         // Run algorithm across each row of control nodes
-        for(int q = 0; q <= ord_s; ++q)
+        for(int q = 0; q <= ord_v; ++q)
         {
           // Do the rational de Casteljau algorithm
           p1(0, q) = p2(0, q);
           p1.setWeight(0, q, p2.getWeight(0, q));
 
-          for(int p = 1; p <= ord_t; ++p)
+          for(int p = 1; p <= ord_u; ++p)
           {
-            const int end = ord_t - p;
+            const int end = ord_u - p;
 
             for(int k = 0; k <= end; ++k)
             {
               double temp_weight =
-                lerp(p2.getWeight(k, q), p2.getWeight(k + 1, q), ts);
+                lerp(p2.getWeight(k, q), p2.getWeight(k + 1, q), uv);
 
               for(int i = 0; i < NDIMS; ++i)
               {
                 p2(k, q)[i] = lerp(p2.getWeight(k, q) * p2(k, q)[i],
                                    p2.getWeight(k + 1, q) * p2(k + 1, q)[i],
-                                   ts) /
+                                   uv) /
                   temp_weight;
               }
 
@@ -628,26 +595,26 @@ public:
       else
       {
         // Run algorithm across each column of control nodes
-        for(int p = 0; p <= ord_t; ++p)
+        for(int p = 0; p <= ord_u; ++p)
         {
           // Do the rational de Casteljau algorithm
           p1(p, 0) = p2(p, 0);
           p1.setWeight(p, 0, p2.getWeight(p, 0));
 
-          for(int q = 1; q <= ord_s; ++q)
+          for(int q = 1; q <= ord_v; ++q)
           {
-            const int end = ord_s - q;
+            const int end = ord_v - q;
 
             for(int k = 0; k <= end; ++k)
             {
               double temp_weight =
-                lerp(p2.getWeight(p, k), p2.getWeight(p, k + 1), ts);
+                lerp(p2.getWeight(p, k), p2.getWeight(p, k + 1), uv);
 
               for(int i = 0; i < NDIMS; ++i)
               {
                 p2(p, k)[i] = lerp(p2.getWeight(p, k) * p2(p, k)[i],
                                    p2.getWeight(p, k + 1) * p2(p, k + 1)[i],
-                                   ts) /
+                                   uv) /
                   temp_weight;
               }
 
@@ -665,16 +632,16 @@ public:
       if(axis == 0)  // Split across a fixed value of t
       {
         // Do the split for each row of control nodes
-        for(int q = 0; q <= ord_s; ++q)
+        for(int q = 0; q <= ord_v; ++q)
         {
           p1(0, q) = m_controlPoints(0, q);
 
           for(int i = 0; i < NDIMS; ++i)
-            for(int p = 1; p <= ord_t; ++p)
+            for(int p = 1; p <= ord_u; ++p)
             {
-              const int end = ord_t - p;
+              const int end = ord_u - p;
               for(int k = 0; k <= end; ++k)
-                p2(k, q)[i] = lerp(p2(k, q)[i], p2(k + 1, q)[i], ts);
+                p2(k, q)[i] = lerp(p2(k, q)[i], p2(k + 1, q)[i], uv);
 
               p1(p, q)[i] = p2(0, q)[i];
             }
@@ -683,16 +650,16 @@ public:
       else
       {
         // Do the split for each column of control nodes
-        for(int p = 0; p <= ord_t; ++p)
+        for(int p = 0; p <= ord_u; ++p)
         {
           p1(p, 0) = m_controlPoints(p, 0);
 
           for(int i = 0; i < NDIMS; ++i)
-            for(int q = 1; q <= ord_s; ++q)
+            for(int q = 1; q <= ord_v; ++q)
             {
-              const int end = ord_s - q;
+              const int end = ord_v - q;
               for(int k = 0; k <= end; ++k)
-                p2(p, k)[i] = lerp(p2(p, k)[i], p2(p, k + 1)[i], ts);
+                p2(p, k)[i] = lerp(p2(p, k)[i], p2(p, k + 1)[i], uv);
 
               p1(p, q)[i] = p2(p, 0)[i];
             }
@@ -704,42 +671,42 @@ public:
   /*!
    * \brief Splits a Bezier patch into four Bezier patches
    *
-   * \param [in] t parameter value between 0 and 1 at which to bisect the patch in t
-   * \param [in] s parameter value between 0 and 1 at which to bisect the patch in s
+   * \param [in] u parameter value between 0 and 1 at which to bisect on the first axis
+   * \param [in] v parameter value between 0 and 1 at which to bisect on the second axis
    * \param [out] p1 First output Bezier patch
    * \param [out] p2 Second output Bezier patch
    * \param [out] p3 Third output Bezier patch
    * \param [out] p4 Fourth output Bezier patch
    *
-   *   s = 1
+   *   v = 1
    *   ----------------------
    *   |         |          |
    *   |   p3    |    p4    |
    *   |         |          |
-   *   --------(t,s)---------
+   *   --------(u,v)---------
    *   |         |          |
    *   |   p1    |    p2    |
    *   |         |          |
-   *   ---------------------- t = 1
+   *   ---------------------- u = 1
    *
-   * \pre Parameter \a t and \a s must be between 0 and 1
+   * \pre Parameter \a u and \a v must be between 0 and 1
    */
-  void split(T t,
-             T s,
+  void split(T u,
+             T v,
              BezierPatch& p1,
              BezierPatch& p2,
              BezierPatch& p3,
              BezierPatch& p4) const
   {
-    // Bisect the patch along the t direction
-    split(t, 0, p1, p2);
+    // Bisect the patch along the u direction
+    split(u, 0, p1, p2);
 
     // Temporarily store the result in each half and split again
     BezierPatch p0(p1);
-    p0.split(s, 1, p1, p3);
+    p0.split(v, 1, p1, p3);
 
     p0 = p2;
-    p0.split(s, 1, p2, p4);
+    p0.split(v, 1, p2, p4);
   }
 
   /*!
@@ -753,22 +720,26 @@ public:
    */
   bool isPlanar(double tol = 1E-8) const
   {
-    const int ord_t = getOrder_t();
-    const int ord_s = getOrder_s();
+    const int ord_u = getOrder_u();
+    const int ord_v = getOrder_v();
 
-    if(ord_t <= 1 && ord_s <= 1) return true;
+    if(ord_u <= 0 && ord_v <= 0) return true;
+    if(ord_u == 1 && ord_v == 0) return true;
+    if(ord_u == 0 && ord_v == 1) return true;
 
-    SegmentType the_plane =
-      make_plane(m_controlPoints[0][0],
-                 m_controlPoints[0][ord_s] m_controlPoints[ord_t][0]);
+    PlaneType the_plane = make_plane(m_controlPoints(0, 0),
+                                     m_controlPoints(0, ord_v),
+                                     m_controlPoints(ord_u, 0));
 
     double sqDist = 0.0;
 
     // Check all control points for simplicity
-    for(int p = 1; p < ord_t && sqDist <= tol; ++p)
-      for(int q = 1; p < ord_s && sqDist <= tol; ++q)
-        sqDist += squared_distance(m_controlPoints(p, q), the_plane);
-
+    for(int p = 0; p <= ord_u && sqDist <= tol; ++p)
+      for(int q = 0; q <= ord_v && sqDist <= tol; ++q)
+      {
+        double signedDist = the_plane.signedDistance(m_controlPoints(p, q));
+        sqDist += signedDist * signedDist;
+      }
     return (sqDist <= tol);
   }
 
@@ -780,21 +751,21 @@ public:
    */
   std::ostream& print(std::ostream& os) const
   {
-    const int ord_t = getOrder_t();
-    const int ord_s = getOrder_s();
+    const int ord_u = getOrder_u();
+    const int ord_v = getOrder_v();
 
-    os << "{ order (" << ord_t << ',' << ord_s << ") Bezier Patch ";
+    os << "{ order (" << ord_u << ',' << ord_v << ") Bezier Patch ";
 
-    for(int p = 0; p <= ord_t; ++p)
-      for(int q = 0; q <= ord_s; ++q)
-        os << m_controlPoints(p, q) << ((p < ord_t || q < ord_s) ? "," : "");
+    for(int p = 0; p <= ord_u; ++p)
+      for(int q = 0; q <= ord_v; ++q)
+        os << m_controlPoints(p, q) << ((p < ord_u || q < ord_v) ? "," : "");
 
     if(isRational())
     {
       os << ", weights [";
-      for(int p = 0; p <= ord_t; ++p)
-        for(int q = 0; q <= ord_s; ++q)
-          os << m_weights(p, q) << ((p < ord_t || q < ord_s) ? "," : "");
+      for(int p = 0; p <= ord_u; ++p)
+        for(int q = 0; q <= ord_v; ++q)
+          os << m_weights(p, q) << ((p < ord_u || q < ord_v) ? "," : "");
     }
     os << "}";
 
@@ -808,14 +779,14 @@ private:
   {
     if(!isRational()) return true;
 
-    const int ord_t = getOrder_t();
-    const int ord_s = getOrder_s();
+    const int ord_u = getOrder_u();
+    const int ord_v = getOrder_v();
 
-    if(m_weights.shape()[0] != (ord_t + 1) || m_weights.shape()[1] != (ord_s + 1))
+    if(m_weights.shape()[0] != (ord_u + 1) || m_weights.shape()[1] != (ord_v + 1))
       return false;
 
-    for(int p = 0; p <= ord_t; ++p)
-      for(int q = 0; q <= ord_s; ++q)
+    for(int p = 0; p <= ord_u; ++p)
+      for(int q = 0; q <= ord_v; ++q)
         if(m_weights(p, q) <= 0) return false;
 
     return true;

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -87,7 +87,7 @@ public:
    */
   BezierPatch(int ord_u = -1, int ord_v = -1)
   {
-    SLIC_ASSERT(ord_u >= -1, ord_v >= -1);
+    SLIC_ASSERT(ord_u >= -1 && ord_v >= -1);
 
     const int sz_u = utilities::max(0, ord_u + 1);
     const int sz_v = utilities::max(0, ord_v + 1);
@@ -109,7 +109,7 @@ public:
   BezierPatch(PointType* pts, int ord_u, int ord_v)
   {
     SLIC_ASSERT(pts != nullptr);
-    SLIC_ASSERT(ord_u >= 0, ord_v >= 0);
+    SLIC_ASSERT(ord_u >= 0 && ord_v >= 0);
 
     const int sz_u = utilities::max(0, ord_u + 1);
     const int sz_v = utilities::max(0, ord_v + 1);
@@ -135,7 +135,7 @@ public:
   BezierPatch(PointType* pts, T* weights, int ord_u, int ord_v)
   {
     SLIC_ASSERT(pts != nullptr);
-    SLIC_ASSERT(ord_u >= 0, ord_v >= 0);
+    SLIC_ASSERT(ord_u >= 0 && ord_v >= 0);
 
     const int sz_u = utilities::max(0, ord_u + 1);
     const int sz_v = utilities::max(0, ord_v + 1);
@@ -196,7 +196,7 @@ public:
               int ord_u,
               int ord_v)
   {
-    SLIC_ASSERT(ord >= 0);
+    SLIC_ASSERT(ord_u >= 0 && ord_v >= 0);
     SLIC_ASSERT(pts.shape()[0] == weights.shape()[0]);
     SLIC_ASSERT(pts.shape()[1] == weights.shape()[1]);
 
@@ -258,7 +258,7 @@ public:
     const int ord_v = getOrder_v();
 
     for(int p = 0; p <= ord_u; ++p)
-      for(int q = 0; q <= ord_v(); ++q) m_controlPoints(p, q) = PointType();
+      for(int q = 0; q <= ord_v; ++q) m_controlPoints(p, q) = PointType();
 
     makeNonrational();
   }

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -1,0 +1,841 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ * \file BezierPatch.hpp
+ *
+ * \brief A BezierPatch primitive
+ */
+
+#ifndef AXOM_PRIMAL_BEZIERPATCH_HPP_
+#define AXOM_PRIMAL_BEZIERPATCH_HPP_
+
+#include "axom/core.hpp"
+#include "axom/slic.hpp"
+
+#include "axom/primal/geometry/NumericArray.hpp"
+#include "axom/primal/geometry/Point.hpp"
+#include "axom/primal/geometry/Vector.hpp"
+#include "axom/primal/geometry/Segment.hpp"
+#include "axom/primal/geometry/BezierCurve.hpp"
+#include "axom/primal/geometry/BoundingBox.hpp"
+#include "axom/primal/geometry/OrientedBoundingBox.hpp"
+
+#include "axom/primal/operators/squared_distance.hpp"
+
+#include <vector>
+#include <ostream>
+
+namespace axom
+{
+namespace primal
+{
+// Forward declare the templated classes and operator functions
+template <typename T, int NDIMS>
+class BezierPatch;
+
+/*! \brief Overloaded output operator for Bezier Patches*/
+template <typename T, int NDIMS>
+std::ostream& operator<<(std::ostream& os, const BezierPatch<T, NDIMS>& bCurve);
+
+/*!
+ * \class BezierPatch
+ *
+ * \brief Represents a 3D Bezier patch defined by a 2D array of control points
+ * \tparam T the coordinate type, e.g., double, float, etc.
+ * \tparam NDIMS the number of dimensions
+ *
+ * The order of a Bezier patch with (N+1)(M+1) control points is (N, M).
+ * The patch is approximated by the control points,
+ * parametrized from t=0 to t=1 and s=0 to s=1.
+ * 
+ * Contains a 2D array of positive weights to represent a rational Bezier patch.
+ * Nonrational Bezier patches are identified by an empty weights array.
+ * Algorithms for Rational Bezier curves derived from 
+ * < Not yet known. Probably the same Farin book? >
+ */
+template <typename T, int NDIMS = 3>
+class BezierPatch
+{
+public:
+  using PointType = Point<T, NDIMS>;
+  using VectorType = Vector<T, NDIMS>;
+  using NumArrayType = NumericArray<T, NDIMS>;
+  using PlaneType = Plane<T, NDIMS>;
+  using CoordsVec = axom::Array<PointType>;
+  using CoordsMat = axom::Array<PointType, 2>;
+  using BoundingBoxType = BoundingBox<T, NDIMS>;
+  using OrientedBoundingBoxType = OrientedBoundingBox<T, NDIMS>;
+  using BezierCurveType = primal::BezierCurve<T, NDIMS>;
+
+  // TODO: Unsure if this behavior is captured by the templating statement above
+  AXOM_STATIC_ASSERT_MSG(NDIMS == 3,
+                         "A Bezier Patch object must be defined in 3-D");
+  AXOM_STATIC_ASSERT_MSG(
+    std::is_arithmetic<T>::value,
+    "A Bezier Curve must be defined using an arithmetic type");
+
+public:
+  /*!
+   * \brief Constructor for a Bezier Patch that reserves space for
+   *  the given order of the surface
+   *
+   * \param [in] order the order of the resulting Bezier curve
+   * \pre order is greater than or equal to -1.
+   */
+  BezierPatch(int ord_t = -1, int ord_s = -1)
+  {
+    SLIC_ASSERT(ord_t >= -1, ord_s >= -1);
+
+    const int sz_t = utilities::max(0, ord_t + 1);
+    const int sz_s = utilities::max(0, ord_s + 1);
+
+    m_controlPoints.resize(sz_t, sz_s);
+
+    makeNonrational();
+  }
+
+  /*!
+   * TODO: Make this constructor work 
+   * (or more likely, don't. That's so many points to initialize in an array...)
+   * \brief Constructor for an order \a ord= n Bezier curve
+   * from a list of coordinates:
+   * \verbatim {x_0, x_1, x_2,...,x_n,
+   *            y_0, y_1, y_2,...,y_n,
+   *            z_0, z_1, z_2,...,z_n}
+   *
+   * \param [in] pts an array with (p+1)*NDIMS entries, ordered by coordinate
+   * then by polynomial order
+   * \param [in] ord Polynomial order of the curve
+   * \pre order is greater than or equal to zero
+   */
+  //BezierCurve(T* pts, int ord)
+  //{
+  //  SLIC_ASSERT(pts != nullptr);
+  //  SLIC_ASSERT(ord >= 0);
+
+  //  const int sz = utilities::max(0, ord + 1);
+  //  m_controlPoints.resize(sz);
+
+  //  for(int p = 0; p <= ord; p++)
+  //  {
+  //    auto& pt = m_controlPoints[p];
+  //    for(int j = 0; j < NDIMS; j++)
+  //    {
+  //      pt[j] = pts[j * (ord + 1) + p];
+  //    }
+  //  }
+
+  //  makeNonrational();
+  //}
+
+  /*!
+   * \brief Constructor for a Bezier Patch from a 2D array of coordinates
+   *
+   * \param [in] pts an array with ord_t+1 arrays with ord_m+1 control points
+   * \param [in] ord_t The patches's polynomial order in p
+   * \param [in] ord_s The patches's polynomial order in q
+   * \pre order in both directions is greater than or equal to zero
+   *
+   */
+  BezierPatch(PointType* pts, int ord_t, int ord_s)
+  {
+    SLIC_ASSERT(pts != nullptr);
+    SLIC_ASSERT(ord_t >= 0, ord_s >= 0);
+
+    const int sz_t = utilities::max(0, ord_t + 1);
+    const int sz_s = utilities::max(0, ord_s + 1);
+
+    m_controlPoints.resize(sz_t, sz_s);
+
+    for(int t = 0; t < sz_t * sz_s; ++t)
+      m_controlPoints(t / sz_s, t % sz_s) = pts[t];
+
+    makeNonrational();
+  }
+
+  /*!
+   * \brief Constructor for a Rational Bezier Path from an array of coordinates and weights
+   *
+   * \param [in] pts a matrix with (ord_t+1) * (ord_s+1) control points
+   * \param [in] weights a matrix with (ord_t+1) * (ord_s+1) positive weights
+   * \param [in] ord_t The patches's polynomial order in p
+   * \param [in] ord_s The patches's polynomial order in q
+   * \pre order is greater than or equal to zero in each direction
+   *
+   */
+  BezierPatch(PointType* pts, T* weights, int ord_t, int ord_s)
+  {
+    SLIC_ASSERT(pts != nullptr);
+    SLIC_ASSERT(ord_t >= 0, ord_s >= 0);
+
+    const int sz_t = utilities::max(0, ord_t + 1);
+    const int sz_s = utilities::max(0, ord_s + 1);
+
+    m_controlPoints.resize(sz_t, sz_s);
+
+    for(int t = 0; t < sz_t * sz_s; ++t)
+      m_controlPoints(t / sz_s, t % sz_s) = pts[t];
+
+    if(weights == nullptr)
+    {
+      m_weights.resize(0, 0);
+    }
+    else
+    {
+      m_weights.resize(sz_t, sz_s);
+
+      for(int t = 0; t < sz_t * sz_s; ++t)
+        m_weights(t / sz_s, t % sz_s) = weights[t];
+
+      SLIC_ASSERT(isValidRational());
+    }
+  }
+
+  /*!
+   * \brief Constructor for a Bezier Patch from an matrix of coordinates
+   *
+   * \param [in] pts a vector with (ord_t+1) * (ord_s+1) control points
+   * \param [in] ord_t The patch's polynomial order in p
+   * \param [in] ord_s The patch's polynomial order in q
+   * \pre order is greater than or equal to zero in each direction
+   *
+   */
+  BezierPatch(const CoordsMat& pts, int ord_t, int ord_s)
+  {
+    SLIC_ASSERT((ord_t >= 0) && (ord_s >= 0));
+
+    const int sz_t = utilities::max(0, ord_t + 1);
+    const int sz_s = utilities::max(0, ord_s + 1);
+
+    m_controlPoints.resize(sz_t, sz_s);
+    m_controlPoints = pts;
+
+    makeNonrational();
+  }
+
+  /*!
+   * \brief Constructor for a Rational Bezier Patch from a matrix
+   * of coordinates and weights
+   *
+   * \param [in] pts a vector with (ord_t+1) * (ord_s+1) control points
+   * \param [in] ord_t The patch's polynomial order in p
+   * \param [in] ord_s The patch's polynomial order in q
+   * \pre order is greater than or equal to zero in each direction
+   *
+   * TODO: Can we just do this entire thing with initalizer lists? 
+   */
+  BezierPatch(const CoordsMat& pts,
+              const axom::Array<axom::Array<T>>& weights,
+              int ord_t,
+              int ord_s)
+  {
+    SLIC_ASSERT(ord >= 0);
+    SLIC_ASSERT(pts.shape()[0] == weights.shape()[0]);
+    SLIC_ASSERT(pts.shape()[1] == weights.shape()[1]);
+
+    const int sz_t = utilities::max(0, ord_t + 1);
+    const int sz_s = utilities::max(0, ord_s + 1);
+
+    m_controlPoints.resize(sz_t, sz_s);
+    m_controlPoints = pts;
+
+    m_weights.resize(sz_t, sz_s);
+    m_weights = weights;
+
+    SLIC_ASSERT(isValidRational());
+  }
+
+  /// Sets the order of the Bezier Curve
+  void setOrder(int ord_t, int ord_s)
+  {
+    m_controlPoints.resize(ord_t + 1, ord_s + 1);
+  }
+
+  /// Returns the order of the Bezier Curve on the first axis
+  int getOrder_t() const
+  {
+    return static_cast<int>(m_controlPoints.shape()[0]) - 1;
+  }
+
+  /// Returns the order of the Bezier Curve
+  int getOrder_s() const
+  {
+    return static_cast<int>(m_controlPoints.shape()[1]) - 1;
+  }
+
+  /// Make trivially rational. If already rational, do nothing
+  void makeRational()
+  {
+    if(!isRational())
+    {
+      const int ord_t = getOrder_t();
+      const int ord_s = getOrder_s();
+
+      m_weights.resize(ord_t + 1, ord_s + 1);
+
+      for(int i = 0; i <= ord_t; ++i)
+        for(int j = 0; j <= ord_s; ++j) m_weights[i][j] = 1.0;
+    }
+  }
+
+  /// Make nonrational by shrinking array of weights
+  void makeNonrational() { m_weights.resize(0, 0); }
+
+  /// Use array size as flag for rationality
+  bool isRational() const { return (m_weights.size() != 0); }
+
+  /// Clears the list of control points, make nonrational
+  void clear()
+  {
+    const int ord_t = getOrder_t();
+    const int ord_s = getOrder_s();
+
+    for(int p = 0; p <= ord; ++p)
+      for(int q = 0; q <= getOrder_s; ++q) m_controlPoints(p, q) = PointType();
+
+    makeNonrational();
+  }
+
+  /// Retrieves the control point at index \a (idx_p, idx_q)
+  PointType& operator()(int idx_p, int idx_q)
+  {
+    return m_controlPoints(idx_p, idx_q);
+  }
+
+  /// Retrieves the vector of control points at index \a idx
+  const PointType& operator()(int idx_p, int idx_q) const
+  {
+    return m_controlPoints(idx_p, idx_q);
+  }
+
+  /*!
+   * \brief Get a specific weight
+   *
+   * \param [in] idx_p The index of the weight in p
+   * \param [in] idx_q The index of the weight in q
+   * \pre Requires that the surface be rational
+   */
+  const T& getWeight(int idx_p, int idx_q) const
+  {
+    SLIC_ASSERT(isRational());
+    return m_weights(idx_p, idx_q);
+  }
+
+  /*!
+   * \brief Set the weight at a specific index
+   *
+   * \param [in] idx_p The index of the weight in p
+   * \param [in] idx_q The index of the weight in q
+   * \param [in] weight The updated value of the weight
+   * \pre Requires that the surface be rational
+   * \pre Requires that the weight be positive
+   */
+  void setWeight(int idx_p, int idx_q, T weight)
+  {
+    SLIC_ASSERT(isRational());
+    SLIC_ASSERT(weight > 0);
+
+    m_weights(idx_p, idx_q) = weight;
+  };
+
+  /// Checks equality of two Bezier Patches
+  friend inline bool operator==(const BezierPatch<T, NDIMS>& lhs,
+                                const BezierPatch<T, NDIMS>& rhs)
+  {
+    return (lhs.m_controlPoints == rhs.m_controlPoints) &&
+      (lhs.m_weights == rhs.m_weights);
+  }
+
+  friend inline bool operator!=(const BezierPatch<T, NDIMS>& lhs,
+                                const BezierPatch<T, NDIMS>& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+  /// Returns a copy of the Bezier curve's control points
+  CoordsMat getControlPoints() const { return m_controlPoints; }
+
+  /// Returns a copy of the Bezier curve's weights
+  axom::Array<T, 2> getWeights() const { return m_weights; }
+
+  /// Reverses the order of the Bezier curve's control points and weights
+  // void reverseOrientation() {}
+
+  /// Returns an axis-aligned bounding box containing the Bezier curve
+  BoundingBoxType boundingBox() const
+  {
+    return BoundingBoxType(m_controlPoints.data(),
+                           static_cast<int>(m_controlPoints.size()));
+  }
+
+  /// Returns an oriented bounding box containing the Bezier curve
+  OrientedBoundingBoxType orientedBoundingBox() const
+  {
+    return OrientedBoundingBoxType(m_controlPoints.data(),
+                                   static_cast<int>(m_controlPoints.size()));
+  }
+
+  /*!
+   * \brief Evaluates a slice Bezier patch for a fixed parameter value of \a t or \a s
+   *
+   * \param [in] t parameter value at which to evaluate
+   * \param [in] s parameter value at which to evaluate
+   * \param [in] axis orientation of curve. 0 for fixed t, 1 for fixed s
+   * \return p the value of the Bezier patch at (t, s)
+   *
+   * \note We typically evaluate the curve at \a t or \a s between 0 and 1
+   */
+  BezierCurveType slice(T ts, int axis = 0) const
+  {
+    SLIC_ASSERT((axis == 0) || (axis == 1));
+
+    using axom::utilities::lerp;
+
+    const int ord_t = getOrder_t();
+    const int ord_s = getOrder_s();
+
+    BezierCurveType c(-1);
+
+    if(isRational())
+    {
+      if(axis == 0)  // Keeping a fixed value of t
+      {
+        c.setOrder(ord_s);
+        c.makeRational();
+
+        axom::Array<T> dCarray(ord_t + 1);
+        axom::Array<T> dWarray(ord_t + 1);
+
+        // Run de Casteljau algorithm on each row of control nodes and each dimension
+        for(int q = 0; q <= ord_s; ++q)
+          for(int i = 0; i < NDIMS; ++i)
+          {
+            for(int p = 0; p <= ord_t; ++p)
+            {
+              dCarray[p] = m_controlPoints(p, q)[i] * m_weights(p, q);
+              dWarray[p] = m_weights(p, q);
+            }
+
+            for(int p = 1; p <= ord_t; ++p)
+            {
+              const int end = ord_t - p;
+              for(int k = 0; k <= end; ++k)
+              {
+                dCarray[k] = lerp(dCarray[k], dCarray[k + 1], ts);
+                dWarray[k] = lerp(dWarray[k], dWarray[k + 1], ts);
+              }
+            }
+
+            c[q][i] = dCarray[0] / dWarray[0];
+            c.setWeight(q, dWarray[0]);
+          }
+      }
+      // Run de Casteljau algorithm on each column of control nodes and each dimension
+      else  // Keeping a fixed value of s
+      {
+        c.setOrder(ord_t);
+        c.makeRational();
+
+        axom::Array<T> dCarray(ord_s + 1);
+        axom::Array<T> dWarray(ord_s + 1);
+
+        for(int p = 0; p <= ord_t; ++p)
+          for(int i = 0; i < NDIMS; ++i)
+          {
+            for(int q = 0; q <= ord_s; ++q)
+            {
+              dCarray[q] = m_controlPoints(p, q)[i] * m_weights(p, q);
+              dWarray[q] = m_weights(p, q);
+            }
+
+            for(int q = 1; q <= ord_s; ++q)
+            {
+              const int end = ord_s - q;
+              for(int k = 0; k <= end; ++k)
+              {
+                dCarray[k] = lerp(dCarray[k], dCarray[k + 1], ts);
+                dWarray[k] = lerp(dWarray[k], dWarray[k + 1], ts);
+              }
+            }
+            c[p][i] = dCarray[0] / dWarray[0];
+            c.setWeight(p, dWarray[0]);
+          }
+      }
+    }
+    else
+    {
+      if(axis == 0)  // Keeping a fixed value of t
+      {
+        c.setOrder(ord_s);
+        axom::Array<T> dCarray(ord_t + 1);  // Temp array
+
+        // Run de Casteljau algorithm on each row of control nodes and each dimension
+        for(int q = 0; q <= ord_s; ++q)
+          for(int i = 0; i < NDIMS; ++i)
+          {
+            for(int p = 0; p <= ord_t; ++p)
+              dCarray[p] = m_controlPoints(p, q)[i];
+
+            for(int p = 1; p <= ord_t; ++p)
+            {
+              const int end = ord_t - p;
+              for(int k = 0; k <= end; ++k)
+                dCarray[k] = lerp(dCarray[k], dCarray[k + 1], ts);
+            }
+            c[q][i] = dCarray[0];
+          }
+      }
+      // Run de Casteljau algorithm on each column of control nodes and each dimension
+      else  // Keeping a fixed value of s
+      {
+        c.setOrder(ord_t);
+        axom::Array<T> dCarray(ord_s + 1);  // Temp array
+
+        for(int p = 0; p <= ord_t; ++p)
+          for(int i = 0; i < NDIMS; ++i)
+          {
+            for(int q = 0; q <= ord_s; ++q)
+              dCarray[q] = m_controlPoints(p, q)[i];
+
+            for(int q = 1; q <= ord_s; ++q)
+            {
+              const int end = ord_s - q;
+              for(int k = 0; k <= end; ++k)
+              {
+                dCarray[k] = lerp(dCarray[k], dCarray[k + 1], ts);
+              }
+            }
+            c[p][i] = dCarray[0];
+          }
+      }
+    }
+
+    return c;
+  }
+
+  /*!
+   * \brief Evaluates a Bezier patch at a particular parameter value (\a t, \a s)
+   *
+   * \param [in] t parameter value at which to evaluate
+   * \param [in] s parameter value at which to evaluate
+   * \return p the value of the Bezier patch at (t, s)
+   *
+   * \note We typically evaluate the curve at \a t and \a s between 0 and 1
+   */
+  PointType evaluate(T t, T s) const { return slice(t).evaluate(s); }
+
+  /*!
+   * \brief Computes a tangent of a Bezier patch at a particular parameter value (\a t, \a s) oriented in \a axis
+   *
+   * \param [in] t parameter value at which to evaluate
+   * \param [in] s parameter value at which to evaluate
+   * \param [in] axis orientation of vector. 0 for fixed t, 1 for fixed s
+   * \return v a tangent vector of the Bezier curve at (t, s)
+   *
+   * \note We typically find the tangent of the curve at \a t and \a s between 0 and 1
+   */
+  VectorType dt(T t, T s, int axis) const
+  {
+    SLIC_ASSERT((axis == 0) || (axis == 1));
+    if(axis == 0)  // Get slice at fixed s
+      return slice(s, 1).dt(t);
+    else  // Get slice at fixed t
+      return slice(t, 0).dt(s);
+  }
+
+  /*!
+   * \brief Computes the normal vector of a Bezier patch at a particular parameter value (\a t, \a s)
+   *
+   * \param [in] t parameter value at which to evaluate
+   * \param [in] s parameter value at which to evaluate
+   * \return v the normal vector of the Bezier curve at (t, s)
+   *
+   * \note We typically find the normal of the curve at \a t and \a s between 0 and 1
+   */
+  VectorType normal(T t, T s) const
+  {
+    VectorType tangent_t = dt(t, s, 0);
+    VectorType tangent_s = dt(t, s, 1);
+    return VectorType::cross_product(tangent_t, tangent_s);
+  }
+
+  /*!
+   * \brief Splits a Bezier patch into two Bezier patches
+   *
+   * \param [in] ts parameter value between 0 and 1 at which to bisect the patch
+   * \param [in] axis orientation of split. 0 for fixed t, 1 for fixed s
+   * \param [out] p1 First output Bezier patch
+   * \param [out] p2 Second output Bezier patch
+   *
+   * \pre Parameter \a ts must be between 0 and 1
+   */
+  void split(T ts, int axis, BezierPatch& p1, BezierPatch& p2) const
+  {
+    SLIC_ASSERT((axis == 0) || (axis == 1));
+
+    using axom::utilities::lerp;
+
+    const int ord_t = getOrder_t();
+    const int ord_s = getOrder_s();
+
+    SLIC_ASSERT((ord_t >= 0) && (ord_s >= 0));
+
+    // Note: The second patch's control points are computed inline
+    //       as we find the first patch's control points
+    p2 = *this;
+
+    p1.setOrder(ord_t, ord_s);
+    if(isRational())
+    {
+      p1.makeRational();  // p2 already rational
+      if(axis == 0)       // Split across a fixed value of t
+      {
+        // Run algorithm across each row of control nodes
+        for(int q = 0; q <= ord_s; ++q)
+        {
+          // Do the rational de Casteljau algorithm
+          p1(0, q) = p2(0, q);
+          p1.setWeight(0, q, p2.getWeight(0, q));
+
+          for(int p = 1; p <= ord_t; ++p)
+          {
+            const int end = ord_t - p;
+
+            for(int k = 0; k <= end; ++k)
+            {
+              double temp_weight =
+                lerp(p2.getWeight(k, q), p2.getWeight(k + 1, q), ts);
+
+              for(int i = 0; i < NDIMS; ++i)
+              {
+                p2(k, q)[i] = lerp(p2.getWeight(k, q) * p2(k, q)[i],
+                                   p2.getWeight(k + 1, q) * p2(k + 1, q)[i],
+                                   ts) /
+                  temp_weight;
+              }
+
+              p2.setWeight(k, q, temp_weight);
+            }
+
+            p1(p, q) = p2(0, q);
+            p1.setWeight(p, q, p2.getWeight(0, q));
+          }
+        }
+      }
+      else
+      {
+        // Run algorithm across each column of control nodes
+        for(int p = 0; p <= ord_t; ++p)
+        {
+          // Do the rational de Casteljau algorithm
+          p1(p, 0) = p2(p, 0);
+          p1.setWeight(p, 0, p2.getWeight(p, 0));
+
+          for(int q = 1; q <= ord_s; ++q)
+          {
+            const int end = ord_s - q;
+
+            for(int k = 0; k <= end; ++k)
+            {
+              double temp_weight =
+                lerp(p2.getWeight(p, k), p2.getWeight(p, k + 1), ts);
+
+              for(int i = 0; i < NDIMS; ++i)
+              {
+                p2(p, k)[i] = lerp(p2.getWeight(p, k) * p2(p, k)[i],
+                                   p2.getWeight(p, k + 1) * p2(p, k + 1)[i],
+                                   ts) /
+                  temp_weight;
+              }
+
+              p2.setWeight(p, k, temp_weight);
+            }
+
+            p1(p, q) = p2(p, 0);
+            p1.setWeight(p, q, p2.getWeight(p, 0));
+          }
+        }
+      }
+    }
+    else
+    {
+      if(axis == 0)  // Split across a fixed value of t
+      {
+        // Do the split for each row of control nodes
+        for(int q = 0; q <= ord_s; ++q)
+        {
+          p1(0, q) = m_controlPoints(0, q);
+
+          for(int i = 0; i < NDIMS; ++i)
+            for(int p = 1; p <= ord_t; ++p)
+            {
+              const int end = ord_t - p;
+              for(int k = 0; k <= end; ++k)
+                p2(k, q)[i] = lerp(p2(k, q)[i], p2(k + 1, q)[i], ts);
+
+              p1(p, q)[i] = p2(0, q)[i];
+            }
+        }
+      }
+      else
+      {
+        // Do the split for each column of control nodes
+        for(int p = 0; p <= ord_t; ++p)
+        {
+          p1(p, 0) = m_controlPoints(p, 0);
+
+          for(int i = 0; i < NDIMS; ++i)
+            for(int q = 1; q <= ord_s; ++q)
+            {
+              const int end = ord_s - q;
+              for(int k = 0; k <= end; ++k)
+                p2(p, k)[i] = lerp(p2(p, k)[i], p2(p, k + 1)[i], ts);
+
+              p1(p, q)[i] = p2(p, 0)[i];
+            }
+        }
+      }
+    }
+  }
+
+  /*!
+   * \brief Splits a Bezier patch into four Bezier patches
+   *
+   * \param [in] t parameter value between 0 and 1 at which to bisect the patch in t
+   * \param [in] s parameter value between 0 and 1 at which to bisect the patch in s
+   * \param [out] p1 First output Bezier patch
+   * \param [out] p2 Second output Bezier patch
+   * \param [out] p3 Third output Bezier patch
+   * \param [out] p4 Fourth output Bezier patch
+   *
+   *   s = 1
+   *   ----------------------
+   *   |         |          |
+   *   |   p3    |    p4    |
+   *   |         |          |
+   *   --------(t,s)---------
+   *   |         |          |
+   *   |   p1    |    p2    |
+   *   |         |          |
+   *   ---------------------- t = 1
+   *
+   * \pre Parameter \a t and \a s must be between 0 and 1
+   */
+  void split(T t,
+             T s,
+             BezierPatch& p1,
+             BezierPatch& p2,
+             BezierPatch& p3,
+             BezierPatch& p4) const
+  {
+    // Bisect the patch along the t direction
+    split(t, 0, p1, p2);
+
+    // Temporarily store the result in each half and split again
+    BezierPatch p0(p1);
+    p0.split(s, 1, p1, p3);
+
+    p0 = p2;
+    p0.split(s, 1, p2, p4);
+  }
+
+  /*!
+   * \brief Predicate to check if the Bezier patch is approximately planar
+   *
+   * This function checks if all control points of the BezierPatch
+   * are approximately on the plane defined by its four corners
+   *
+   * \param [in] tol Threshold for sum of squared distances
+   * \return True if c1 is near-planar
+   */
+  bool isPlanar(double tol = 1E-8) const
+  {
+    const int ord_t = getOrder_t();
+    const int ord_s = getOrder_s();
+
+    if(ord_t <= 1 && ord_s <= 1) return true;
+
+    SegmentType the_plane =
+      make_plane(m_controlPoints[0][0],
+                 m_controlPoints[0][ord_s] m_controlPoints[ord_t][0]);
+
+    double sqDist = 0.0;
+
+    // Check all control points for simplicity
+    for(int p = 1; p < ord_t && sqDist <= tol; ++p)
+      for(int q = 1; p < ord_s && sqDist <= tol; ++q)
+        sqDist += squared_distance(m_controlPoints(p, q), the_plane);
+
+    return (sqDist <= tol);
+  }
+
+  /*!
+   * \brief Simple formatted print of a Bezier Curve instance
+   *
+   * \param os The output stream to write to
+   * \return A reference to the modified ostream
+   */
+  std::ostream& print(std::ostream& os) const
+  {
+    const int ord_t = getOrder_t();
+    const int ord_s = getOrder_s();
+
+    os << "{ order (" << ord_t << ',' << ord_s << ") Bezier Patch ";
+
+    for(int p = 0; p <= ord_t; ++p)
+      for(int q = 0; q <= ord_s; ++q)
+        os << m_controlPoints(p, q) << ((p < ord_t || q < ord_s) ? "," : "");
+
+    if(isRational())
+    {
+      os << ", weights [";
+      for(int p = 0; p <= ord_t; ++p)
+        for(int q = 0; q <= ord_s; ++q)
+          os << m_weights(p, q) << ((p < ord_t || q < ord_s) ? "," : "");
+    }
+    os << "}";
+
+    return os;
+  }
+
+private:
+  /// Check that the weights used are positive, and
+  ///  that there is one for each control node
+  bool isValidRational() const
+  {
+    if(!isRational()) return true;
+
+    const int ord_t = getOrder_t();
+    const int ord_s = getOrder_s();
+
+    if(m_weights.shape()[0] != (ord_t + 1) || m_weights.shape()[1] != (ord_s + 1))
+      return false;
+
+    for(int p = 0; p <= ord_t; ++p)
+      for(int q = 0; q <= ord_s; ++q)
+        if(m_weights(p, q) <= 0) return false;
+
+    return true;
+  }
+
+  CoordsMat m_controlPoints;
+  axom::Array<T, 2> m_weights;
+};
+
+//------------------------------------------------------------------------------
+/// Free functions related to BezierCurve
+//------------------------------------------------------------------------------
+template <typename T, int NDIMS>
+std::ostream& operator<<(std::ostream& os, const BezierPatch<T, NDIMS>& bPatch)
+{
+  bPatch.print(os);
+  return os;
+}
+
+}  // namespace primal
+}  // namespace axom
+
+#endif  // AXOM_PRIMAL_BEZIERPATCH_HPP_

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -321,9 +321,6 @@ public:
   /// Clears the list of control points, make nonrational
   void clear()
   {
-    const int ord_u = getOrder_u();
-    const int ord_v = getOrder_v();
-
     m_controlPoints.clear();
     makeNonrational();
   }

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -33,12 +33,12 @@ namespace axom
 namespace primal
 {
 // Forward declare the templated classes and operator functions
-template <typename T, int NDIMS>
+template <typename T>
 class BezierPatch;
 
 /*! \brief Overloaded output operator for Bezier Patches*/
-template <typename T, int NDIMS>
-std::ostream& operator<<(std::ostream& os, const BezierPatch<T, NDIMS>& bPatch);
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const BezierPatch<T>& bPatch);
 
 /*!
  * \class BezierPatch
@@ -57,24 +57,21 @@ std::ostream& operator<<(std::ostream& os, const BezierPatch<T, NDIMS>& bPatch);
  * Gerald Farin, "Algorithms for rational Bezier curves"
  * Computer-Aided Design, Volume 15, Number 2, 1983,
  */
-template <typename T, int NDIMS = 3>
+template <typename T>
 class BezierPatch
 {
 public:
-  using PointType = Point<T, NDIMS>;
-  using VectorType = Vector<T, NDIMS>;
-  using PlaneType = Plane<T, NDIMS>;
+  using PointType = Point<T, 3>;
+  using VectorType = Vector<T, 3>;
+  using PlaneType = Plane<T, 3>;
 
   using CoordsMat = axom::Array<PointType, 2>;
   using NumsMat = axom::Array<T, 2>;
 
-  using BoundingBoxType = BoundingBox<T, NDIMS>;
-  using OrientedBoundingBoxType = OrientedBoundingBox<T, NDIMS>;
-  using BezierCurveType = primal::BezierCurve<T, NDIMS>;
+  using BoundingBoxType = BoundingBox<T, 3>;
+  using OrientedBoundingBoxType = OrientedBoundingBox<T, 3>;
+  using BezierCurveType = primal::BezierCurve<T, 3>;
 
-  // TODO: Unsure if this behavior is captured by the templating statement above
-  AXOM_STATIC_ASSERT_MSG(NDIMS == 3,
-                         "A Bezier Patch object must be defined in 3-D");
   AXOM_STATIC_ASSERT_MSG(
     std::is_arithmetic<T>::value,
     "A Bezier Patch must be defined using an arithmetic type");
@@ -308,15 +305,15 @@ public:
   };
 
   /// Checks equality of two Bezier Patches
-  friend inline bool operator==(const BezierPatch<T, NDIMS>& lhs,
-                                const BezierPatch<T, NDIMS>& rhs)
+  friend inline bool operator==(const BezierPatch<T>& lhs,
+                                const BezierPatch<T>& rhs)
   {
     return (lhs.m_controlPoints == rhs.m_controlPoints) &&
       (lhs.m_weights == rhs.m_weights);
   }
 
-  friend inline bool operator!=(const BezierPatch<T, NDIMS>& lhs,
-                                const BezierPatch<T, NDIMS>& rhs)
+  friend inline bool operator!=(const BezierPatch<T>& lhs,
+                                const BezierPatch<T>& rhs)
   {
     return !(lhs == rhs);
   }
@@ -455,7 +452,7 @@ public:
       axom::Array<T> dWarray(ord_u + 1);
 
       for(int q = 0; q <= ord_v; ++q)
-        for(int i = 0; i < NDIMS; ++i)
+        for(int i = 0; i < 3; ++i)
         {
           for(int p = 0; p <= ord_u; ++p)
           {
@@ -480,7 +477,7 @@ public:
     else
     {
       for(int q = 0; q <= ord_v; ++q)
-        for(int i = 0; i < NDIMS; ++i)
+        for(int i = 0; i < 3; ++i)
         {
           for(int p = 0; p <= ord_u; ++p) dCarray[p] = m_controlPoints(p, q)[i];
 
@@ -514,7 +511,7 @@ public:
       axom::Array<T> dWarray(ord_v + 1);
 
       for(int p = 0; p <= ord_u; ++p)
-        for(int i = 0; i < NDIMS; ++i)
+        for(int i = 0; i < 3; ++i)
         {
           for(int q = 0; q <= ord_v; ++q)
           {
@@ -538,7 +535,7 @@ public:
     else
     {
       for(int p = 0; p <= ord_u; ++p)
-        for(int i = 0; i < NDIMS; ++i)
+        for(int i = 0; i < 3; ++i)
         {
           for(int q = 0; q <= ord_v; ++q) dCarray[q] = m_controlPoints(p, q)[i];
 
@@ -666,7 +663,7 @@ public:
             double temp_weight =
               lerp(p2.getWeight(k, q), p2.getWeight(k + 1, q), u);
 
-            for(int i = 0; i < NDIMS; ++i)
+            for(int i = 0; i < 3; ++i)
             {
               p2(k, q)[i] = lerp(p2.getWeight(k, q) * p2(k, q)[i],
                                  p2.getWeight(k + 1, q) * p2(k + 1, q)[i],
@@ -688,7 +685,7 @@ public:
       {
         p1(0, q) = m_controlPoints(0, q);
 
-        for(int i = 0; i < NDIMS; ++i)
+        for(int i = 0; i < 3; ++i)
           for(int p = 1; p <= ord_u; ++p)
           {
             const int end = ord_u - p;
@@ -733,7 +730,7 @@ public:
             double temp_weight =
               lerp(p2.getWeight(p, k), p2.getWeight(p, k + 1), v);
 
-            for(int i = 0; i < NDIMS; ++i)
+            for(int i = 0; i < 3; ++i)
             {
               p2(p, k)[i] = lerp(p2.getWeight(p, k) * p2(p, k)[i],
                                  p2.getWeight(p, k + 1) * p2(p, k + 1)[i],
@@ -755,7 +752,7 @@ public:
       {
         p1(p, 0) = m_controlPoints(p, 0);
 
-        for(int i = 0; i < NDIMS; ++i)
+        for(int i = 0; i < 3; ++i)
           for(int q = 1; q <= ord_v; ++q)
           {
             const int end = ord_v - q;
@@ -900,7 +897,7 @@ private:
 /// Free functions related to BezierPatch
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-std::ostream& operator<<(std::ostream& os, const BezierPatch<T, NDIMS>& bPatch)
+std::ostream& operator<<(std::ostream& os, const BezierPatch<T>& bPatch)
 {
   bPatch.print(os);
   return os;

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -322,8 +322,70 @@ public:
   /// Returns a copy of the Bezier curve's weights
   axom::Array<T, 2> getWeights() const { return m_weights; }
 
-  /// Reverses the order of the Bezier curve's control points and weights
-  // void reverseOrientation() {}
+  /*!
+   * \brief Reverses the order of one direction of the Bezier patch's control points and weights
+   *
+   * \param [in] axis orientation of curve. 0 to reverse in u, 1 for reverse in v
+   */
+  void reverseOrientation(int axis)
+  {
+    const int ord_u = getOrder_u();
+    const int mid_u = (ord_u + 1) / 2;
+
+    const int ord_v = getOrder_v();
+    const int mid_v = (ord_v + 1) / 2;
+
+    if(axis == 0)
+    {
+      for(int q = 0; q <= ord_v; ++q)
+      {
+        for(int i = 0; i < mid_u; ++i)
+          axom::utilities::swap(m_controlPoints(i, q),
+                                m_controlPoints(ord_u - i, q));
+
+        if(isRational())
+          for(int i = 0; i < mid_u; ++i)
+            axom::utilities::swap(m_weights(i, q), m_weights(ord_u - i, q));
+      }
+    }
+    else
+    {
+      for(int p = 0; p <= ord_u; ++p)
+      {
+        for(int i = 0; i < mid_v; ++i)
+          axom::utilities::swap(m_controlPoints(p, i),
+                                m_controlPoints(p, ord_v - i));
+
+        if(isRational())
+          for(int i = 0; i < mid_v; ++i)
+            axom::utilities::swap(m_weights(p, i), m_weights(p, ord_v - i));
+      }
+    }
+  }
+
+  /// Swap the axes such that s(u, v) becomes s(v, u)
+  void swapAxes()
+  {
+    const int ord_u = getOrder_u();
+    const int ord_v = getOrder_v();
+
+    CoordsMat new_controlPoints(ord_v + 1, ord_u + 1);
+
+    for(int p = 0; p <= ord_u; ++p)
+      for(int q = 0; q <= ord_v; ++q)
+        new_controlPoints(q, p) = m_controlPoints(p, q);
+
+    m_controlPoints = new_controlPoints;
+
+    if(isRational())
+    {
+      axom::Array<T, 2> new_weights(ord_v + 1, ord_u + 1);
+      for(int p = 0; p <= ord_u; ++p)
+        for(int q = 0; q <= ord_v; ++q) new_weights(q, p) = m_weights(p, q);
+
+      m_weights = new_weights;
+    }
+  }
 
   /// Returns an axis-aligned bounding box containing the Bezier curve
   BoundingBoxType boundingBox() const

--- a/src/axom/primal/tests/CMakeLists.txt
+++ b/src/axom/primal/tests/CMakeLists.txt
@@ -9,6 +9,7 @@
 set( primal_tests
     primal_bezier_curve.cpp
     primal_bezier_intersect.cpp
+    primal_bezier_patch.cpp
     primal_boundingbox.cpp
     primal_bounding_box_intersect.cpp
     primal_clip.cpp

--- a/src/axom/primal/tests/primal_bezier_patch.cpp
+++ b/src/axom/primal/tests/primal_bezier_patch.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*! 
+ * \file primal_bezier_patch.cpp
+ * \brief This file tests primal's Bezier patch functionality
+ */
+
+#include "gtest/gtest.h"
+
+#include "axom/slic.hpp"
+
+#include "axom/primal/geometry/BezierCurve.hpp"
+#include "axom/primal/geometry/BezierPatch.hpp"
+#include "axom/primal/operators/squared_distance.hpp"
+
+namespace primal = axom::primal;
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, initial_test)
+{
+  const int DIM = 3;
+  using CoordType = double;
+  using BezierCurveType = primal::BezierCurve<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using CoordsVec = BezierPatchType::CoordsVec;
+  using CoordsMat = BezierPatchType::CoordsMat;
+  using PointType = primal::Point<CoordType, DIM>;
+
+  /* clang-format off */
+  PointType PatchNodes[4 * 3] = {PointType {0, 0, 0}, PointType {0, 4,  0}, PointType {0, 8, -3},
+                                 PointType {2, 0, 6}, PointType {2, 4,  0}, PointType {2, 8,  0}, 
+                                 PointType {4, 0, 0}, PointType {4, 4,  0}, PointType {4, 8,  3},
+                                 PointType {6, 0, 0}, PointType {6, 4, -3}, PointType {6, 8,  0}};
+  
+  double PatchWeights[4 * 3] = {1.0, 2.0, 3.0,
+                                2.0, 3.0, 4.0,
+                                3.0, 4.0, 5.0,
+                                4.0, 5.0, 6.0};
+  /* clang-format on */
+
+  BezierPatchType bPatch(PatchNodes, PatchWeights, 3, 2);
+  BezierPatchType bPatch1(3, 2), bPatch2(3, 2), bPatch3(3, 2), bPatch4(3, 2);
+
+  double t = 0.25, s = 0.75;
+
+  bPatch.split(t, s, bPatch1, bPatch2, bPatch3, bPatch4);
+
+  std::cout << bPatch.evaluate(t, s) << std::endl;
+  std::cout << bPatch1 << std::endl;
+  std::cout << bPatch2 << std::endl;
+  std::cout << bPatch3 << std::endl;
+  std::cout << bPatch4 << std::endl;
+}
+
+//------------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+  int result = 0;
+
+  ::testing::InitGoogleTest(&argc, argv);
+
+  axom::slic::SimpleLogger logger;
+
+  result = RUN_ALL_TESTS();
+
+  return result;
+}

--- a/src/axom/primal/tests/primal_bezier_patch.cpp
+++ b/src/axom/primal/tests/primal_bezier_patch.cpp
@@ -21,9 +21,8 @@ namespace primal = axom::primal;
 //------------------------------------------------------------------------------
 TEST(primal_bezierpatch, constructor)
 {
-  const int DIM = 3;
   using CoordType = double;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
   using CoordsMat = BezierPatchType::CoordsMat;
 
   {
@@ -61,7 +60,7 @@ TEST(primal_bezierpatch, set_order)
   const int DIM = 3;
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   SLIC_INFO("Test adding control points to an empty Bezier patch");
 
@@ -101,7 +100,7 @@ TEST(primal_bezierpatch, point_array_constructor)
   const int DIM = 3;
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   SLIC_INFO("Testing point array constructor");
 
@@ -132,7 +131,7 @@ TEST(primal_bezierpatch, make_rational)
   const int DIM = 3;
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   const int order_u = 1;
   const int order_v = 1;
@@ -180,7 +179,7 @@ TEST(primal_bezierpatch, evaluate)
   const int DIM = 3;
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   const int order_u = 3;
   const int order_v = 2;
@@ -245,7 +244,7 @@ TEST(primal_bezierpatch, evaluate_tall)
   const int DIM = 3;
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   const int order_u = 2;
   const int order_v = 3;
@@ -291,7 +290,7 @@ TEST(primal_bezierpatch, evaluation_degenerate)
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
   using BezierCurveType = primal::BezierCurve<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   const int order = 3;
   PointType data[order + 1] = {PointType {0.6, 1.2, 1.0},
@@ -320,7 +319,7 @@ TEST(primal_bezierpatch, tangent)
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
   using VectorType = primal::Vector<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   const int order_u = 3;
   const int order_v = 2;
@@ -372,7 +371,7 @@ TEST(primal_bezierpatch, normal)
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
   using VectorType = primal::Vector<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   const int order_u = 3;
   const int order_v = 2;
@@ -410,7 +409,7 @@ TEST(primal_bezierpatch, split_degenerate)
   const int DIM = 3;
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   const int order_u = 0;
   const int order_v = 0;
@@ -442,7 +441,7 @@ TEST(primal_bezierpatch, split_curve)
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
   using BezierCurveType = primal::BezierCurve<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   const int order = 3;
   PointType data[order + 1] = {PointType {0.6, 1.2, 1.0},
@@ -482,7 +481,7 @@ TEST(primal_bezierpatch, split_plane)
   const int DIM = 3;
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   const int order_u = 1;
   const int order_v = 1;
@@ -515,7 +514,7 @@ TEST(primal_bezierpatch, split_patch)
   const int DIM = 3;
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   const int order_u = 3;
   const int order_v = 2;
@@ -555,7 +554,7 @@ TEST(primal_bezierpatch, isPlanar)
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
   using VectorType = primal::Vector<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   // order (0, 0) -- always true
   {
@@ -635,7 +634,7 @@ TEST(primal_bezierpatch, reverse_orientation)
   const int DIM = 3;
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   SLIC_INFO("Testing reverseOrientation(axis) on Bezier patches");
 
@@ -708,7 +707,7 @@ TEST(primal_bezierpatch, rational_evaluation_split)
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
   using VectorType = primal::Vector<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType>;
 
   const int ord_u = 3;
   const int ord_v = 3;

--- a/src/axom/primal/tests/primal_bezier_patch.cpp
+++ b/src/axom/primal/tests/primal_bezier_patch.cpp
@@ -19,43 +19,663 @@
 namespace primal = axom::primal;
 
 //------------------------------------------------------------------------------
-TEST(primal_bezierpatch, initial_test)
+TEST(primal_bezierpatch, constructor)
 {
   const int DIM = 3;
   using CoordType = double;
-  using BezierCurveType = primal::BezierCurve<CoordType, DIM>;
   using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
-  using CoordsVec = BezierPatchType::CoordsVec;
   using CoordsMat = BezierPatchType::CoordsMat;
-  using PointType = primal::Point<CoordType, DIM>;
 
-  /* clang-format off */
-  PointType PatchNodes[4 * 3] = {PointType {0, 0, 0}, PointType {0, 4,  0}, PointType {0, 8, -3},
-                                 PointType {2, 0, 6}, PointType {2, 4,  0}, PointType {2, 8,  0}, 
-                                 PointType {4, 0, 0}, PointType {4, 4,  0}, PointType {4, 8,  3},
-                                 PointType {6, 0, 0}, PointType {6, 4, -3}, PointType {6, 8,  0}};
-  
-  double PatchWeights[4 * 3] = {1.0, 2.0, 3.0,
-                                2.0, 3.0, 4.0,
-                                3.0, 4.0, 5.0,
-                                4.0, 5.0, 6.0};
-  /* clang-format on */
+  {
+    SLIC_INFO("Testing default BezierPatch constructor ");
+    BezierPatchType bPatch;
+    EXPECT_FALSE(bPatch.isRational());
 
-  BezierPatchType bPatch(PatchNodes, PatchWeights, 3, 2);
-  BezierPatchType bPatch1(3, 2), bPatch2(3, 2), bPatch3(3, 2), bPatch4(3, 2);
+    int expOrder_u = -1, expOrder_v = -1;
+    EXPECT_EQ(expOrder_u, bPatch.getOrder_u());
+    EXPECT_EQ(expOrder_v, bPatch.getOrder_v());
 
-  double t = 0.25, s = 0.75;
+    EXPECT_EQ(expOrder_u + 1, bPatch.getControlPoints().shape()[0]);
+    EXPECT_EQ(expOrder_v + 1, bPatch.getControlPoints().shape()[1]);
 
-  bPatch.split(t, s, bPatch1, bPatch2, bPatch3, bPatch4);
+    EXPECT_EQ(CoordsMat(), bPatch.getControlPoints());
+  }
 
-  std::cout << bPatch.evaluate(t, s) << std::endl;
-  std::cout << bPatch1 << std::endl;
-  std::cout << bPatch2 << std::endl;
-  std::cout << bPatch3 << std::endl;
-  std::cout << bPatch4 << std::endl;
+  {
+    SLIC_INFO("Testing BezierPatch order constructor ");
+    BezierPatchType bPatch(1, 1);
+    EXPECT_FALSE(bPatch.isRational());
+
+    int expOrder_u = 1, expOrder_v = 1;
+    EXPECT_EQ(expOrder_u, bPatch.getOrder_u());
+    EXPECT_EQ(expOrder_v, bPatch.getOrder_v());
+
+    EXPECT_EQ(expOrder_u + 1, bPatch.getControlPoints().shape()[0]);
+    EXPECT_EQ(expOrder_v + 1, bPatch.getControlPoints().shape()[1]);
+  }
 }
 
 //------------------------------------------------------------------------------
+TEST(primal_bezierpatch, set_order)
+{
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  SLIC_INFO("Test adding control points to an empty Bezier patch");
+
+  BezierPatchType bPatch;
+  EXPECT_EQ(bPatch.getOrder_u(), -1);
+  EXPECT_EQ(bPatch.getOrder_v(), -1);
+
+  const int order_u = 1;
+  const int order_v = 1;
+
+  bPatch.setOrder(order_u, order_v);
+  EXPECT_EQ(bPatch.getOrder_u(), order_u);
+  EXPECT_EQ(bPatch.getOrder_v(), order_v);
+
+  PointType controlPoints[4] = {PointType {0.0, 0.0, 1.0},
+                                PointType {0.0, 1.0, 0.0},
+                                PointType {1.0, 0.0, 0.0},
+                                PointType {1.0, 1.0, -1.0}};
+
+  bPatch(0, 0) = controlPoints[0];
+  bPatch(0, 1) = controlPoints[1];
+  bPatch(1, 0) = controlPoints[2];
+  bPatch(1, 1) = controlPoints[3];
+
+  for(int p = 0; p <= bPatch.getOrder_u(); ++p)
+    for(int q = 0; q <= bPatch.getOrder_v(); ++q)
+    {
+      auto& pt = bPatch(p, q);
+      for(int i = 0; i < DIM; ++i)
+        EXPECT_DOUBLE_EQ(controlPoints[p * (order_u + 1) + q][i], pt[i]);
+    }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, point_array_constructor)
+{
+  SLIC_INFO("Testing point array constructor");
+
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  const int order_u = 1;
+  const int order_v = 1;
+
+  PointType controlPoints[4] = {PointType {0.0, 0.0, 1.0},
+                                PointType {0.0, 1.0, 0.0},
+                                PointType {1.0, 0.0, 0.0},
+                                PointType {1.0, 1.0, -1.0}};
+
+  BezierPatchType bPatch(controlPoints, order_u, order_v);
+  EXPECT_EQ(bPatch.getOrder_u(), order_u);
+  EXPECT_EQ(bPatch.getOrder_v(), order_v);
+
+  for(int p = 0; p <= bPatch.getOrder_u(); ++p)
+    for(int q = 0; q <= bPatch.getOrder_v(); ++q)
+    {
+      auto& pt = bPatch(p, q);
+      for(int i = 0; i < DIM; ++i)
+        EXPECT_DOUBLE_EQ(controlPoints[p * (order_u + 1) + q][i], pt[i]);
+    }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, make_rational)
+{
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  const int order_u = 1;
+  const int order_v = 1;
+
+  SLIC_INFO("Test settings and unsetting rational property");
+
+  PointType controlPoints[4] = {PointType {0.0, 0.0, 1.0},
+                                PointType {0.0, 1.0, 0.0},
+                                PointType {1.0, 0.0, 0.0},
+                                PointType {1.0, 1.0, -1.0}};
+
+  BezierPatchType bPatch(controlPoints, order_u, order_v);
+  BezierPatchType rPatch(controlPoints, order_u, order_v);
+
+  EXPECT_FALSE(rPatch.isRational());
+  EXPECT_EQ(rPatch.getWeights().size(), 0);
+
+  rPatch.makeRational();
+  EXPECT_TRUE(rPatch.isRational());
+  EXPECT_EQ(rPatch.getWeights().shape(), rPatch.getControlPoints().shape());
+
+  // makeRational should set all weights to 1, keeping surface the same
+  for(int p = 0; p <= order_u; ++p)
+    for(int q = 0; q <= order_v; ++q)
+      EXPECT_DOUBLE_EQ(rPatch.getWeight(p, q), 1.0);
+
+  for(double u = 0; u <= 1.0; u += 0.1)
+    for(double v = 0; v <= 1.0; v += 0.1)
+    {
+      auto pt1 = rPatch.evaluate(u, v);
+      auto pt2 = bPatch.evaluate(u, v);
+      for(int i = 0; i < DIM; ++i) EXPECT_NEAR(pt1[i], pt2[i], 1e-10);
+    }
+
+  rPatch.makeNonrational();
+  EXPECT_FALSE(rPatch.isRational());
+  EXPECT_EQ(rPatch.getWeights().size(), 0);
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, evaluate_wide)
+{
+  SLIC_INFO("Testing bezier Patch evaluation");
+
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  const int order_u = 3;
+  const int order_v = 2;
+
+  // clang-format off
+  PointType controlPoints[(order_u + 1) * (order_v + 1)] = {
+    PointType {0, 0, 0}, PointType {0, 4,  0}, PointType {0, 8, -3},
+    PointType {2, 0, 6}, PointType {2, 4,  0}, PointType {2, 8,  0},
+    PointType {4, 0, 0}, PointType {4, 4,  0}, PointType {4, 8,  3},
+    PointType {6, 0, 0}, PointType {6, 4, -3}, PointType {6, 8,  0}};
+  // clang-format on
+
+  BezierPatchType bPatch(controlPoints, order_u, order_v);
+
+  // Evaluate the patch at each of the four corners, where the patch interpolates
+  for(int i = 0; i < DIM; ++i)
+  {
+    EXPECT_DOUBLE_EQ(bPatch.evaluate(0, 0)[i], controlPoints[0][i]);
+    EXPECT_DOUBLE_EQ(bPatch.evaluate(0, 1)[i], controlPoints[2][i]);
+    EXPECT_DOUBLE_EQ(bPatch.evaluate(1, 0)[i], controlPoints[9][i]);
+    EXPECT_DOUBLE_EQ(bPatch.evaluate(1, 1)[i], controlPoints[11][i]);
+  }
+
+  // Evaluate the patch at some interior points
+  PointType interior_1 {3.0, 4.0, 0.5625};
+  PointType interior_2 {1.5, 6.0, -171.0 / 512.0};
+  PointType interior_3 {4.5, 2.0, 39.0 / 512.0};
+
+  for(int i = 0; i < DIM; ++i)
+  {
+    EXPECT_DOUBLE_EQ(bPatch.evaluate(0.5, 0.5)[i], interior_1[i]);
+    EXPECT_DOUBLE_EQ(bPatch.evaluate(0.25, 0.75)[i], interior_2[i]);
+    EXPECT_DOUBLE_EQ(bPatch.evaluate(0.75, 0.25)[i], interior_3[i]);
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, evaluate_tall)
+{
+  SLIC_INFO("Testing bezier Patch evaluation with axes swapped");
+
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  const int order_u = 2;
+  const int order_v = 3;
+
+  // clang-format off
+  PointType controlPoints[(order_u + 1) * (order_v + 1)] = {
+    PointType {0, 0,  0}, PointType {2, 0, 6}, PointType {4, 0, 0}, PointType {6, 0, 0},
+    PointType {0, 4,  0}, PointType {2, 4, 0}, PointType {4, 4, 0}, PointType {6, 4, -3},
+    PointType {0, 8, -3}, PointType {2, 8, 0}, PointType {4, 8, 3}, PointType {6, 8,  0}};
+  // clang-format on
+
+  BezierPatchType bPatch(controlPoints, order_u, order_v);
+
+  // Evaluate the patch at each of the four corners, where the patch interpolates
+  for(int i = 0; i < DIM; ++i)
+  {
+    EXPECT_DOUBLE_EQ(bPatch.evaluate(0, 0)[i], controlPoints[0][i]);
+    EXPECT_DOUBLE_EQ(bPatch.evaluate(0, 1)[i], controlPoints[3][i]);
+    EXPECT_DOUBLE_EQ(bPatch.evaluate(1, 0)[i], controlPoints[8][i]);
+    EXPECT_DOUBLE_EQ(bPatch.evaluate(1, 1)[i], controlPoints[11][i]);
+  }
+
+  // Evaluate the patch at some interior points
+  PointType interior_1 {3.0, 4.0, 0.5625};          // (0.5, 0.5)
+  PointType interior_2 {1.5, 6.0, -171.0 / 512.0};  // (0.75, 0.25)
+  PointType interior_3 {4.5, 2.0, 39.0 / 512.0};    // (0.25, 0.75)
+
+  for(int i = 0; i < DIM; ++i)
+  {
+    EXPECT_DOUBLE_EQ(bPatch.evaluate(0.5, 0.5)[i], interior_1[i]);
+    EXPECT_DOUBLE_EQ(bPatch.evaluate(0.75, 0.25)[i], interior_2[i]);
+    EXPECT_DOUBLE_EQ(bPatch.evaluate(0.25, 0.75)[i], interior_3[i]);
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, evaluation_degenerate)
+{
+  SLIC_INFO("Testing Bezier patch evaluation with one degenerate axis");
+  // Should reduce to a Bezier curve along the nonempty dimension
+
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using BezierCurveType = primal::BezierCurve<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  const int order = 3;
+  PointType data[order + 1] = {PointType {0.6, 1.2, 1.0},
+                               PointType {1.3, 1.6, 1.8},
+                               PointType {2.9, 2.4, 2.3},
+                               PointType {3.2, 3.5, 3.0}};
+
+  BezierCurveType bCurve(data, order);
+  BezierPatchType bPatch(data, order, 0);
+
+  for(double t = 0; t <= 1; t += 0.01)
+    for(int i = 0; i < DIM; ++i)
+    {
+      EXPECT_NEAR(bCurve.evaluate(t)[i], bPatch.evaluate(t, 0)[i], 1e-10);
+      EXPECT_NEAR(bCurve.evaluate(t)[i], bPatch.evaluate(t, 0.5)[i], 1e-10);
+      EXPECT_NEAR(bCurve.evaluate(t)[i], bPatch.evaluate(t, 1.0)[i], 1e-10);
+    }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, tangent)
+{
+  SLIC_INFO("Testing bezier Patch tangent calculation");
+
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using VectorType = primal::Vector<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  const int order_u = 3;
+  const int order_v = 2;
+
+  // clang-format off
+  PointType controlPoints[(order_u + 1) * (order_v + 1)] = {
+    PointType {0, 0, 0}, PointType {0, 4,  0}, PointType {0, 8, -3},
+    PointType {2, 0, 6}, PointType {2, 4,  0}, PointType {2, 8,  0},
+    PointType {4, 0, 0}, PointType {4, 4,  0}, PointType {4, 8,  3},
+    PointType {6, 0, 0}, PointType {6, 4, -3}, PointType {6, 8,  0}};
+  // clang-format on
+
+  BezierPatchType bPatch(controlPoints, order_u, order_v);
+
+  // Evaluate the tangent at the lower corfour corners,
+  //  where the tangents are defined by the control nodes
+  VectorType node00_u = VectorType(controlPoints[0], controlPoints[3]);
+  VectorType node00_v = VectorType(controlPoints[0], controlPoints[1]);
+
+  for(int i = 0; i < DIM; ++i)
+  {
+    EXPECT_NEAR(order_u * node00_u[i], bPatch.dt(0, 0, 0)[i], 1e-10);
+    EXPECT_NEAR(order_v * node00_v[i], bPatch.dt(0, 0, 1)[i], 1e-10);
+  }
+
+  // Evaluate the tangent at some interior nodes
+  VectorType interior1_u = {6.0, 0.0, 567.0 / 128.0};
+  VectorType interior1_v = {0.0, 8.0, -159.0 / 64.0};
+
+  VectorType interior2_u = {6.0, 0.0, -657.0 / 128.0};
+  VectorType interior2_v = {0.0, 8.0, -123.0 / 64.0};
+
+  for(int i = 0; i < DIM; ++i)
+  {
+    EXPECT_NEAR(interior1_u[i], bPatch.dt(0.25, 0.75, 0)[i], 1e-10);
+    EXPECT_NEAR(interior1_v[i], bPatch.dt(0.25, 0.75, 1)[i], 1e-10);
+
+    EXPECT_NEAR(interior2_u[i], bPatch.dt(0.75, 0.25, 0)[i], 1e-10);
+    EXPECT_NEAR(interior2_v[i], bPatch.dt(0.75, 0.25, 1)[i], 1e-10);
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, normal)
+{
+  SLIC_INFO("Testing bezier Patch normal calculation");
+
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using VectorType = primal::Vector<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  const int order_u = 3;
+  const int order_v = 2;
+
+  // clang-format off
+  PointType controlPoints[(order_u + 1) * (order_v + 1)] = {
+    PointType {0, 0, 0}, PointType {0, 4,  0}, PointType {0, 8, -3},
+    PointType {2, 0, 6}, PointType {2, 4,  0}, PointType {2, 8,  0},
+    PointType {4, 0, 0}, PointType {4, 4,  0}, PointType {4, 8,  3},
+    PointType {6, 0, 0}, PointType {6, 4, -3}, PointType {6, 8,  0}};
+  // clang-format on
+
+  BezierPatchType bPatch(controlPoints, order_u, order_v);
+
+  // Test on some interior nodes
+  VectorType interior_1 = {-279.0 / 16.0, 819.0 / 32.0, 48.0};  // (0.25, 0.25)
+  VectorType interior_2 = {-567.0 / 16.0, 477.0 / 32.0, 48.0};  // (0.25, 0.75)
+  VectorType interior_3 = {657.0 / 16.0, 369.0 / 32.0, 48.0};   // (0.75, 0.25)
+  VectorType interior_4 = {369.0 / 16.0, -513.0 / 32.0, 48.0};  // (0.75, 0.75)
+
+  for(int i = 0; i < DIM; ++i)
+  {
+    EXPECT_NEAR(interior_1[i], bPatch.normal(0.25, 0.25)[i], 1e-10);
+    EXPECT_NEAR(interior_2[i], bPatch.normal(0.25, 0.75)[i], 1e-10);
+    EXPECT_NEAR(interior_3[i], bPatch.normal(0.75, 0.25)[i], 1e-10);
+    EXPECT_NEAR(interior_4[i], bPatch.normal(0.75, 0.75)[i], 1e-10);
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, split_degenerate)
+{
+  SLIC_INFO("Testing bezier Patch splitting for order 0 surface");
+
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  const int order_u = 0;
+  const int order_v = 0;
+
+  PointType data[(order_u + 1) * (order_v + 1)] = {
+    PointType::make_point(0.6, 1.2, 0.2)};
+
+  BezierPatchType p(data, 0, 0);
+
+  BezierPatchType p1, p2, p3, p4;
+
+  p.split(0.5, 0.5, p1, p2, p3, p4);
+
+  for(int i = 0; i < DIM; i++)
+  {
+    EXPECT_DOUBLE_EQ(data[0][i], p1(0, 0)[i]);
+    EXPECT_DOUBLE_EQ(data[0][i], p2(0, 0)[i]);
+    EXPECT_DOUBLE_EQ(data[0][i], p3(0, 0)[i]);
+    EXPECT_DOUBLE_EQ(data[0][i], p4(0, 0)[i]);
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, split_curve)
+{
+  SLIC_INFO("Testing Bezier patch split with one degenerate axis");
+
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using BezierCurveType = primal::BezierCurve<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  const int order = 3;
+  PointType data[order + 1] = {PointType {0.6, 1.2, 1.0},
+                               PointType {1.3, 1.6, 1.8},
+                               PointType {2.9, 2.4, 2.3},
+                               PointType {3.2, 3.5, 3.0}};
+
+  BezierCurveType bCurve(data, order);
+  BezierPatchType bPatch(data, order, 0);
+
+  BezierCurveType c1, c2;
+  BezierPatchType p1, p2, p3, p4;
+
+  bCurve.split(0.5, c1, c2);
+  bPatch.split(0.5, 0.5, p1, p2, p3, p4);
+
+  // Components split along the u-axis p1/p3 vs p2/p4 should equal curves
+  // Components split along the v-axis p1/p2 vs p3/p4 should equal each other
+  for(double u = 0; u <= 1; u += 0.1)
+    for(double v = 0; v <= 1; v += 0.1)
+      for(int i = 0; i < DIM; ++i)
+      {
+        EXPECT_NEAR(c1.evaluate(u)[i], p1.evaluate(u, v)[i], 1e-10);
+        EXPECT_NEAR(c1.evaluate(u)[i], p3.evaluate(u, v)[i], 1e-10);
+
+        EXPECT_NEAR(c2.evaluate(u)[i], p2.evaluate(u, v)[i], 1e-10);
+        EXPECT_NEAR(c2.evaluate(u)[i], p4.evaluate(u, v)[i], 1e-10);
+      }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, split_plane)
+{
+  SLIC_INFO("Testing Bezier patch evaluation with one degenerate axis");
+  // Should reduce to a Bezier curve along the nonempty dimension
+
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  const int order_u = 1;
+  const int order_v = 1;
+
+  // clang-format off
+  PointType controlPoints[(order_u + 1) * (order_v + 1)] = {
+    PointType {1.0, 0.0, 0.0}, PointType {0.0, 1.0, 0.0},
+    PointType {0.0, 0.0, 1.0}, PointType {0.0, 0.0, 1.0}};
+  // clang-format on
+
+  BezierPatchType p0(controlPoints, order_u, order_v), p_arr[4];
+
+  p0.split(0.5, 0.5, p_arr[0], p_arr[1], p_arr[2], p_arr[3]);
+
+  // Ensure that after splitting, each point remains on the same hyperplane
+  for(double u = 0.0; u <= 1.0; u += 0.1)
+    for(double v = 0.0; v <= 1.0; v += 0.1)
+      for(int n = 0; n < 4; ++n)
+      {
+        auto pt = p_arr[n].evaluate(u, v);
+        EXPECT_NEAR(pt[0] + pt[1] + pt[2], 1.0, 1e-10);
+      }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, split_patch)
+{
+  SLIC_INFO("Testing Bezier patch evaluation with one degenerate axis");
+
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  const int order_u = 3;
+  const int order_v = 2;
+
+  // clang-format off
+  PointType controlPoints[(order_u + 1) * (order_v + 1)] = {
+    PointType {0, 0, 0}, PointType {0, 4,  0}, PointType {0, 8, -3},
+    PointType {2, 0, 6}, PointType {2, 4,  0}, PointType {2, 8,  0},
+    PointType {4, 0, 0}, PointType {4, 4,  0}, PointType {4, 8,  3},
+    PointType {6, 0, 0}, PointType {6, 4, -3}, PointType {6, 8,  0}};
+  // clang-format on
+
+  BezierPatchType p0(controlPoints, order_u, order_v), p1, p2, p3, p4;
+  p0.split(0.5, 0.5, p1, p2, p3, p4);
+
+  // Check that evaluation the appropriate edges line up
+  for(double t = 0; t <= 1; t += 0.1)
+  {
+    for(int i = 0; i < DIM; i++)
+    {
+      EXPECT_NEAR(p1.evaluate(1, t)[i], p2.evaluate(0, t)[i], 1e-10);
+      EXPECT_NEAR(p3.evaluate(1, t)[i], p4.evaluate(0, t)[i], 1e-10);
+
+      EXPECT_NEAR(p1.evaluate(t, 1)[i], p3.evaluate(t, 0)[i], 1e-10);
+      EXPECT_NEAR(p2.evaluate(t, 1)[i], p4.evaluate(t, 0)[i], 1e-10);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, isPlanar)
+{
+  SLIC_INFO("Testing Bezier patch evaluation with one degenerate axis");
+  // Should reduce to a Bezier curve along the nonempty dimension
+
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using VectorType = primal::Vector<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  // order (0, 0) -- always true
+  {
+    const int order_u = 0;
+    const int order_v = 0;
+    BezierPatchType patch(order_u, order_v);
+    EXPECT_TRUE(patch.isPlanar());
+
+    patch(0, 0) = PointType::make_point(1.0, 1.0, 1.0);
+    EXPECT_TRUE(patch.isPlanar());
+  }
+
+  // order (0, 1), (1, 0) -- always true
+  {
+    PointType data[2] = {PointType {0.0, 1.0, 2.0}, PointType {2.0, 1.0, 0.0}};
+    BezierPatchType patch1(data, 0, 1), patch2(data, 1, 0);
+
+    EXPECT_TRUE(patch1.isPlanar());
+    EXPECT_TRUE(patch2.isPlanar());
+  }
+
+  // order (1, 1) -- sometimes true
+  {
+    // clang-format off
+    PointType data_planar[4] = {
+      PointType {1.0, 0.0, 0.0}, PointType {0.0, 1.0, 0.0},
+      PointType {0.0, 0.0, 1.0}, PointType {-1.0, 1.0, 1.0}};
+
+    PointType data_nonplanar[4] = {
+      PointType {1.0, 0.0, 0.0}, PointType {0.0, 1.0, 0.0},
+      PointType {0.0, 0.0, 1.0}, PointType {0.0, 0.0, 2.0}};
+    // clang-format on
+
+    EXPECT_TRUE(BezierPatchType(data_planar, 1, 1).isPlanar());
+    EXPECT_FALSE(BezierPatchType(data_nonplanar, 1, 1).isPlanar());
+  }
+
+  // order (2, 2)
+  {
+    // clang-format off
+    PointType data[9] = {
+      PointType {-1.0, -1.0, 0.0}, PointType {-1.0, 0.0, 0.0}, PointType {-1.0, 1.0, 0.0},  
+      PointType { 0.0, -1.0, 0.0}, PointType { 0.0, 0.0, 0.0}, PointType { 0.0, 1.0, 0.0},
+      PointType { 1.0, -1.0, 0.0}, PointType { 1.0, 0.0, 0.0}, PointType { 1.0, 1.0, 0.0}};
+    // clang-format on
+
+    const int ord_u = 2;
+    const int ord_v = 2;
+
+    BezierPatchType patch(data, ord_u, ord_v);
+
+    // Begins as planar
+    EXPECT_TRUE(patch.isPlanar());
+
+    // Move middle point and check linearity with diffrent tolerances
+    patch(1, 1).array() += 0.005 * VectorType({0.0, 0.0, 1.0}).array();
+
+    // Linear for a coarse tolerance
+    {
+      const double tol = 0.01;
+      const double tol_sq = tol * tol;
+      EXPECT_TRUE(patch.isPlanar(tol_sq));
+    }
+
+    // Non-Linear for a finer tolerance
+    {
+      const double tol = 0.001;
+      const double tol_sq = tol * tol;
+      EXPECT_FALSE(patch.isPlanar(tol_sq));
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, rational_evaluation_split)
+{
+  // Test behavior with a spherical Bezier patch
+  SLIC_INFO("Testing Bezier patch evaluation wirh rational weights");
+
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using VectorType = primal::Vector<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  const int ord_u = 3;
+  const int ord_v = 3;
+
+  // clang-format off
+  PointType data[16] = {  
+    PointType {0, 0,  1}, PointType {0, 0,  1}, PointType { 0, 0,  1}, PointType { 0, 0,  1},
+    PointType {2, 0,  1}, PointType {2, 4,  1}, PointType {-2, 4,  1}, PointType {-2, 0,  1},
+    PointType {2, 0, -1}, PointType {2, 4, -1}, PointType {-2, 4, -1}, PointType {-2, 0, -1},
+    PointType {0, 0, -1}, PointType {0, 0, -1}, PointType { 0, 0, -1}, PointType { 0, 0, -1}};
+
+  double weights[16] = {1.0,     1.0/3.0, 1.0/3.0, 1.0,
+                        1.0/3.0, 1.0/9.0, 1.0/9.0, 1.0/3.0,
+                        1.0/3.0, 1.0/9.0, 1.0/9.0, 1.0/3.0,
+                        1.0,     1.0/3.0, 1.0/3.0, 1.0};
+  // clang-format on
+
+  BezierPatchType hemisphere(data, weights, ord_u, ord_v);
+
+  // Verify that evaluation points are on the sphere
+  for(double u = 0; u <= 1.0; u += 0.1)
+    for(double v = 0; v <= 1.0; v += 0.1)
+    {
+      PointType pt = hemisphere.evaluate(u, v);
+      EXPECT_NEAR(pt[0] * pt[0] + pt[1] * pt[1] + pt[2] * pt[2], 1.0, 1e-10);
+    }
+
+  BezierPatchType patches[4];
+  hemisphere.split(0.5, 0.5, patches[0], patches[1], patches[2], patches[3]);
+
+  // Verify that evaluation points are on still on the sphere for each subpatch
+  for(double u = 0; u <= 1.0; u += 0.1)
+    for(double v = 0; v <= 1.0; v += 0.1)
+      for(int n = 0; n < 4; ++n)
+      {
+        PointType pt = patches[n].evaluate(u, v);
+        EXPECT_NEAR(pt[0] * pt[0] + pt[1] * pt[1] + pt[2] * pt[2], 1.0, 1e-10);
+      }
+
+  // Do it again
+  BezierPatchType sub_patches[4];
+  patches[0].split(0.5,
+                   0.5,
+                   sub_patches[0],
+                   sub_patches[1],
+                   sub_patches[2],
+                   sub_patches[3]);
+
+  for(double u = 0; u <= 1.0; u += 0.1)
+    for(double v = 0; v <= 1.0; v += 0.1)
+      for(int n = 0; n < 4; ++n)
+      {
+        PointType pt = sub_patches[n].evaluate(u, v);
+        EXPECT_NEAR(pt[0] * pt[0] + pt[1] * pt[1] + pt[2] * pt[2], 1.0, 1e-10);
+      }
+}
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following:
  - Adds a `BezierPatch` class that implements a (possibly rational) tensor product Bezier surface. Methods for `BezierPatch` follow conventions of `BezierCurve`, with most having an additional `axis` parameter.
  - Adds a number of tests for the above `BezierPatch` class
  - Adds a Visual Studio configuration folder `.vs/` to the `.gitignore`
