### PR TITLE
Some bugfixes for axom's installation

### DIFF
--- a/src/axom/CMakeLists.txt
+++ b/src/axom/CMakeLists.txt
@@ -60,9 +60,9 @@ foreach(_component ${AXOM_COMPONENTS_ENABLED})
     set(_export_header ${PROJECT_BINARY_DIR}/include/axom/export/${_component}.h)
     generate_export_header( ${_component} 
                             PREFIX_NAME AXOM_
-                            EXPORT_FILE_NAME ${_export_header}
-                            )
-
+                            EXPORT_FILE_NAME ${_export_header})
+    install(FILES ${_export_header} 
+            DESTINATION include/axom/export )
 endforeach()
 
 #------------------------------------------------------------------------------

--- a/src/axom/multimat/examples/calculate_gpu.cpp
+++ b/src/axom/multimat/examples/calculate_gpu.cpp
@@ -117,7 +117,6 @@ void avgDensityCompactFlat(mmat::MultiMat& mm)
 {
   axom::fmt::print("Running average density compact - flat\n");
   int ncells = mm.getNumberOfCells();
-  // int nmats = mm.getNumberOfMaterials();
 
   auto* relationSet = mm.getSparse2dFieldSet(mmat::DataLayout::CELL_DOM);
   int nthreads = relationSet->totalSize();
@@ -134,7 +133,6 @@ void avgDensityCompactFlat(mmat::MultiMat& mm)
     nthreads,
     AXOM_LAMBDA(int flatid) {
       int cell_id = relationSet->flatToFirstIndex(flatid);
-      // int mat_id = relationSet->flatToSecondIndex(flatid);
 
       double density_avg_slot = density[flatid] * vf[flatid];
 
@@ -153,7 +151,6 @@ void avgDensityCompactSubmap(mmat::MultiMat& mm)
 {
   axom::fmt::print("Running average density compact - submap\n");
   int ncells = mm.getNumberOfCells();
-  // int nmats = mm.getNumberOfMaterials();
 
   const auto density = mm.getSparse2dField<double>("Densityfrac");
   const auto vf = mm.getSparse2dField<double>("Volfrac");
@@ -241,7 +238,6 @@ void avgDensityIter(mmat::MultiMat& mm)
 {
   axom::fmt::print("Running average density - iterators\n");
   int ncells = mm.getNumberOfCells();
-  // int nmats = mm.getNumberOfMaterials();
 
   const auto density = mm.getDense2dField<double>("Densityfrac");
   const auto vf = mm.getDense2dField<double>("Volfrac");

--- a/src/axom/multimat/examples/calculate_gpu.cpp
+++ b/src/axom/multimat/examples/calculate_gpu.cpp
@@ -117,7 +117,7 @@ void avgDensityCompactFlat(mmat::MultiMat& mm)
 {
   axom::fmt::print("Running average density compact - flat\n");
   int ncells = mm.getNumberOfCells();
-  int nmats = mm.getNumberOfMaterials();
+  // int nmats = mm.getNumberOfMaterials();
 
   auto* relationSet = mm.getSparse2dFieldSet(mmat::DataLayout::CELL_DOM);
   int nthreads = relationSet->totalSize();
@@ -134,7 +134,7 @@ void avgDensityCompactFlat(mmat::MultiMat& mm)
     nthreads,
     AXOM_LAMBDA(int flatid) {
       int cell_id = relationSet->flatToFirstIndex(flatid);
-      int mat_id = relationSet->flatToSecondIndex(flatid);
+      // int mat_id = relationSet->flatToSecondIndex(flatid);
 
       double density_avg_slot = density[flatid] * vf[flatid];
 
@@ -153,7 +153,7 @@ void avgDensityCompactSubmap(mmat::MultiMat& mm)
 {
   axom::fmt::print("Running average density compact - submap\n");
   int ncells = mm.getNumberOfCells();
-  int nmats = mm.getNumberOfMaterials();
+  // int nmats = mm.getNumberOfMaterials();
 
   const auto density = mm.getSparse2dField<double>("Densityfrac");
   const auto vf = mm.getSparse2dField<double>("Volfrac");
@@ -241,7 +241,7 @@ void avgDensityIter(mmat::MultiMat& mm)
 {
   axom::fmt::print("Running average density - iterators\n");
   int ncells = mm.getNumberOfCells();
-  int nmats = mm.getNumberOfMaterials();
+  // int nmats = mm.getNumberOfMaterials();
 
   const auto density = mm.getDense2dField<double>("Densityfrac");
   const auto vf = mm.getDense2dField<double>("Volfrac");

--- a/src/axom/multimat/examples/helper.hpp
+++ b/src/axom/multimat/examples/helper.hpp
@@ -68,7 +68,7 @@ struct Value_Checker
     }
     else
     {
-      if(values.size() != vec.size())
+      if(static_cast<axom::IndexType>(values.size()) != vec.size())
       {
         SLIC_ERROR(
           axom::fmt::format("Sizes of arrays are different. 'values' has {} "

--- a/src/axom/multimat/examples/traversal.cpp
+++ b/src/axom/multimat/examples/traversal.cpp
@@ -83,7 +83,7 @@ void various_traversal_methods(int nmats,
   axom::Array<double> cellmat_arr;
   cellmat_arr.resize((use_sparse ? nfilled : nmats * ncells) * ncomp);
   double x_sum = 0;
-  for(unsigned int i = 0; i < cellmat_arr.size() / ncomp; i++)
+  for(axom::IndexType i = 0; i < cellmat_arr.size() / ncomp; i++)
   {
     if(use_sparse || cellMatRel[i])
     {

--- a/src/axom/multimat/multimat.cpp
+++ b/src/axom/multimat/multimat.cpp
@@ -516,7 +516,7 @@ int MultiMat::getFieldIdx(const std::string& field_name) const
 
 std::string MultiMat::getFieldName(int field_idx) const
 {
-  if(field_idx < 0 || field_idx >= m_fieldNameVec.size())
+  if(field_idx < 0 || field_idx >= static_cast<int>(m_fieldNameVec.size()))
   {
     return "";
   }
@@ -832,7 +832,7 @@ void MultiMat::makeOtherRelation(DataLayout layout)
 
   //add them to make this the end index
   {
-    unsigned int i;
+    axom::IndexType i;
     for(i = 1; i < newBeginVec.size() - 1; i++)
     {
       newBeginVec[i] += newBeginVec[i - 1];

--- a/src/cmake/axom-config.cmake.in
+++ b/src/cmake/axom-config.cmake.in
@@ -162,7 +162,8 @@ if(NOT AXOM_FOUND)
   foreach(_component ${AXOM_COMPONENTS_ENABLED})
     set_property(TARGET axom
                  PROPERTY INTERFACE_LINK_LIBRARIES
-                 axom::${_component})
+                 axom::${_component}
+                 APPEND)
   endforeach()
 
   # HACK: Clear INTERFACE_COMPILE_OPTIONS to avoid requiring OpenMP in user code

--- a/src/examples/using-with-cmake/CMakeLists.txt
+++ b/src/examples/using-with-cmake/CMakeLists.txt
@@ -70,6 +70,14 @@ if(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE)
                      ${BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE})
 endif()
 
+# HACK: Define the `mpi` target as an alias to `axom::mpi` if/when necessary
+# Details: An axom dependency has a link dependency to `mpi`, but it might
+# not be a target. Need to mark axom::mpi as global to use it for an alias.
+if(NOT TARGET mpi AND TARGET axom::mpi)
+    set_target_properties(axom::mpi PROPERTIES IMPORTED_GLOBAL TRUE)
+    add_library(mpi ALIAS axom::mpi)
+endif()
+
 #------------------------------------------------------------------------------
 # Set up example target that depends on axom
 #------------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

- This PR is a bugfix for some errors in axom's installation
  - It installs the new export headers
  - It makes the `axom` target depend on all axom components, not just the last one (using `APPEND`)
  - It fixes a bug in the `using-with-cmake` example for configs that depend on mpi
  - It fixes some warnings in multimat