### PR TITLE
Fix `ConnectivityArray` setting bad capacity in constructor.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -57,6 +57,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Quest: Adds ability to import volume fractions into `SamplingShaper` before processing `Klee` input
 
 ### Changed
+- Fixed bug in `mint::mesh::UnstructuredMesh` constructors, affecting capacity.
+  A mising factor was added.  If you worked around this by adding the factor yourself,
+  you may want to undo that work-around.
 - Updates blt submodule to HEAD of develop on 24Jan2023
 - Updates uberenv submodule to HEAD of main on 12May2023
 - Updates to [conduit version 0.8.6](https://github.com/LLNL/conduit/compare/v0.8.3...v0.8.6)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -58,7 +58,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ### Changed
 - Fixed bug in `mint::mesh::UnstructuredMesh` constructors, affecting capacity.
-  A mising factor was added.  If you worked around this by adding the factor yourself,
+  A missing factor was added.  If you worked around this by adding the factor yourself,
   you may want to undo that work-around.
 - Updates blt submodule to HEAD of develop on 24Jan2023
 - Updates uberenv submodule to HEAD of main on 12May2023

--- a/src/axom/mint/mesh/ConnectivityArray.hpp
+++ b/src/axom/mint/mesh/ConnectivityArray.hpp
@@ -340,10 +340,12 @@ public:
     SLIC_ASSERT(elems_group != nullptr);
 
     sidre::View* connec_view = elems_group->getView("connectivity");
+    axom::IndexType element_capacity =
+      ID_capacity == USE_DEFAULT ? USE_DEFAULT : ID_capacity * m_stride;
     m_values = std::make_unique<sidre::MCArray<IndexType>>(connec_view,
                                                            0,
                                                            m_stride,
-                                                           ID_capacity);
+                                                           element_capacity);
     SLIC_ASSERT(m_values != nullptr);
   }
 
@@ -381,10 +383,12 @@ public:
     SLIC_ASSERT(elems_group != nullptr);
 
     sidre::View* connec_view = elems_group->getView("connectivity");
+    axom::IndexType element_capacity =
+      ID_capacity == USE_DEFAULT ? USE_DEFAULT : ID_capacity * m_stride;
     m_values = std::make_unique<sidre::MCArray<IndexType>>(connec_view,
                                                            0,
                                                            m_stride,
-                                                           ID_capacity);
+                                                           element_capacity);
   }
 
 #endif
@@ -420,7 +424,8 @@ public:
    * \param [in] ID_capacity the number of IDs to reserve space for.
    * \param [in] value_capacity not used, does not need to be specified.
    *
-   * \post getIDCapacity() >= n_IDs
+   * If current getIDCapacity() >= ID_capacity, do nothing.
+   * \post getIDCapacity() >= ID_capacity
    */
   void reserve(IndexType ID_capacity,
                IndexType AXOM_UNUSED_PARAM(value_capacity) = 0)

--- a/src/axom/sidre/core/Array.hpp
+++ b/src/axom/sidre/core/Array.hpp
@@ -335,8 +335,7 @@ protected:
   /*!
    * \brief Allocates space within the Array's View.
    *
-   * \param [in] new_num_tuples the number of tuples which exceeds the current
-   *  capacity.
+   * \param [in] new_capacity the number of elements to allocate.
    */
   void reallocViewData(IndexType new_capacity);
 


### PR DESCRIPTION
# Fixed capacity set by `ConnectivityArray` constructors

- This PR is a bugfix
- It does the following:
  - Multiplies the tuple size (nodes per cell) with the number of tuples (cells) to get the capacity.  The number of tuples had been omitted.
  - Add this change to the `RELEASE-NOTES.md` file.
  - Updates some outdated doxygen comments.

The errors caused this behavior.  You want a capacity for N cells.  You get N/2 in 2D and N/3 in 3D.

The capacity set by the constructors are now correct and consistent with the capacity set using the `reserve` method.

There was probably some confusion because capacity meant different things to high-level `ConnectivityArray` vs low-level `Array` containers.  The `ConnectivityArray` only looks at the first dimension, because it considers the second dimension to be fixed even as the container grows.  `Array` looks at all dimensions.