### PR TITLE
Fix instantiation of Array::resize

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -110,6 +110,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   and triangles before using the geometry.
 - Improves import logic for `lua` dependency
 - Improves import logic for `mfem` dependency in device builds when `mfem` is configured with `caliper`
+- Fixes ambiguity when calling `Array::resize(size, value)` for `Array<bool>`
 
 ### Deprecated
 - Integer types in `src/axom/core/Types.hpp` are deprecated because `c++11` supports their equivalents.

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -716,7 +716,7 @@ public:
                   "constructible. Use Array<T>::reserve() and emplace_back()"
                   "instead.");
     const StackArray<IndexType, DIM> dims {static_cast<IndexType>(args)...};
-    resize(dims, true);
+    resizeImpl(dims, true);
   }
 
   /// \overload
@@ -724,18 +724,18 @@ public:
   void resize(ArrayOptions::Uninitialized, Args... args)
   {
     const StackArray<IndexType, DIM> dims {static_cast<IndexType>(args)...};
-    resize(dims, false);
+    resizeImpl(dims, false);
   }
 
   template <int Dims = DIM, typename Enable = std::enable_if_t<Dims == 1>>
   void resize(IndexType size, const T& value)
   {
-    resize({size}, true, &value);
+    resizeImpl({size}, true, &value);
   }
 
   void resize(const StackArray<IndexType, DIM>& size, const T& value)
   {
-    resize(size, true, &value);
+    resizeImpl(size, true, &value);
   }
 
   /*!
@@ -818,9 +818,9 @@ protected:
    * \param [in] value pointer to the value to fill new elements in the array
    *             with. If null, will default-construct elements in place.
    */
-  void resize(const StackArray<IndexType, DIM>& dims,
-              bool construct_with_values,
-              const T* value = nullptr);
+  void resizeImpl(const StackArray<IndexType, DIM>& dims,
+                  bool construct_with_values,
+                  const T* value = nullptr);
 
   /*!
    * \brief Make space for a subsequent insertion into the array.
@@ -1295,9 +1295,9 @@ inline void Array<T, DIM, SPACE>::emplace_back(Args&&... args)
 
 //------------------------------------------------------------------------------
 template <typename T, int DIM, MemorySpace SPACE>
-inline void Array<T, DIM, SPACE>::resize(const StackArray<IndexType, DIM>& dims,
-                                         bool construct_with_values,
-                                         const T* value)
+inline void Array<T, DIM, SPACE>::resizeImpl(const StackArray<IndexType, DIM>& dims,
+                                             bool construct_with_values,
+                                             const T* value)
 {
   assert(detail::allNonNegative(dims.m_data));
   const auto new_num_elements = detail::packProduct(dims.m_data);

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -2006,4 +2006,50 @@ TEST(core_array, check_subspan_range)
   EXPECT_EQ(&arrv3[arrv3.size() - 1], &arr[n + l - 1]);
 }
 
+//------------------------------------------------------------------------------
+
+template <typename DataType>
+void test_resize_with_stackarray(DataType value)
+{
+  const int I_DIMS = 3;
+  const int J_DIMS = 5;
+  const int K_DIMS = 7;
+  Array<DataType, 2> arr2;
+
+  StackArray<axom::IndexType, 2> dims2 = {I_DIMS, J_DIMS};
+  arr2.resize(dims2, value);
+  EXPECT_EQ(arr2.size(), I_DIMS * J_DIMS);
+  EXPECT_EQ(arr2.shape()[0], I_DIMS);
+  EXPECT_EQ(arr2.shape()[1], J_DIMS);
+  for(int i = 0; i < I_DIMS; i++)
+  {
+    for(int j = 0; j < J_DIMS; j++)
+    {
+      EXPECT_EQ(arr2[i][j], value);
+    }
+  }
+
+  Array<DataType, 3> arr3;
+
+  StackArray<axom::IndexType, 3> dims3 = {I_DIMS, J_DIMS, K_DIMS};
+  arr3.resize(dims3, value);
+  EXPECT_EQ(arr3.size(), I_DIMS * J_DIMS * K_DIMS);
+  EXPECT_EQ(arr3.shape()[0], I_DIMS);
+  EXPECT_EQ(arr3.shape()[1], J_DIMS);
+  EXPECT_EQ(arr3.shape()[2], K_DIMS);
+  for(int i = 0; i < I_DIMS; i++)
+  {
+    for(int j = 0; j < J_DIMS; j++)
+    {
+      for(int k = 0; k < K_DIMS; k++) EXPECT_EQ(arr3[i][j][k], value);
+    }
+  }
+}
+
+TEST(core_array, resize_stackarray)
+{
+  test_resize_with_stackarray<bool>(false);
+  test_resize_with_stackarray<int>(-1);
+}
+
 } /* end namespace axom */

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -2041,7 +2041,10 @@ void test_resize_with_stackarray(DataType value)
   {
     for(int j = 0; j < J_DIMS; j++)
     {
-      for(int k = 0; k < K_DIMS; k++) EXPECT_EQ(arr3[i][j][k], value);
+      for(int k = 0; k < K_DIMS; k++)
+      {
+        EXPECT_EQ(arr3[i][j][k], value);
+      }
     }
   }
 }


### PR DESCRIPTION
# Summary

- Fixes an ambiguous call to `Array::resize()` for `axom::Array`s of type `bool`.
  The underlying problem was a protected overload of `resize()` used by the public-facing resize methods; we just rename this to `resizeImpl()` to avoid the ambiguity.

Resolves #1082.