### PR TITLE
Support replacement rules for preshaped geometry

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -109,6 +109,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Multimat: `MultiMat::makeOtherRelation()` now runs on the GPU with an appropriately-set allocator ID.
 - Multimat: `MultiMat::setCellMatRel(counts, indices)` now runs on the GPU, and accepts GPU-side data.
 - Renames `ArrayView::spacing()` to `ArrayView::minStride()`.
+- Klee: A shape's geometry no longer needs a `path` field when its `format` is "none"
+- Quest: Shapes without geometry can participate in replacement rules for sample-based shaping. Volume
+fractions for the associated materials must be supplied before shaping.
 
 ###  Fixed
 - Fixed issues with CUDA build in CMake versions 3.14.5 and above. Now require CMake 3.18+

--- a/src/axom/klee/Geometry.hpp
+++ b/src/axom/klee/Geometry.hpp
@@ -82,6 +82,9 @@ public:
    */
   const std::string &getPath() const { return m_path; }
 
+  /// Predicate that returns true when the geometry has a path
+  bool hasPath() const { return !m_path.empty(); }
+
   /**
    * Get a GeometryOperator to apply to this geometry. Can be null.
    *

--- a/src/axom/klee/Geometry.hpp
+++ b/src/axom/klee/Geometry.hpp
@@ -82,8 +82,8 @@ public:
    */
   const std::string &getPath() const { return m_path; }
 
-  /// Predicate that returns true when the geometry has a path
-  bool hasPath() const { return !m_path.empty(); }
+  /// Predicate that returns true when the shape has an associated geometry
+  bool hasGeometry() const { return !m_path.empty(); }
 
   /**
    * Get a GeometryOperator to apply to this geometry. Can be null.

--- a/src/axom/klee/tests/klee_geometry.cpp
+++ b/src/axom/klee/tests/klee_geometry.cpp
@@ -26,7 +26,7 @@ TEST(GeometryTest, dimensions_noOperators)
   EXPECT_EQ(startProperties, geometry.getStartProperties());
   EXPECT_EQ(startProperties, geometry.getEndProperties());
 
-  EXPECT_TRUE(geometry.hasPath());
+  EXPECT_TRUE(geometry.hasGeometry());
 }
 
 TEST(GeometryTest, dimensions_dimensionPreservingOperator)
@@ -51,7 +51,7 @@ TEST(GeometryTest, emptyPath)
                                                    LengthUnit::mils};
   Geometry geometry {startProperties, "none", "", nullptr};
 
-  EXPECT_FALSE(geometry.hasPath());
+  EXPECT_FALSE(geometry.hasGeometry());
 }
 
 }  // namespace klee

--- a/src/axom/klee/tests/klee_geometry.cpp
+++ b/src/axom/klee/tests/klee_geometry.cpp
@@ -25,6 +25,8 @@ TEST(GeometryTest, dimensions_noOperators)
   Geometry geometry {startProperties, "test format", "test path", nullptr};
   EXPECT_EQ(startProperties, geometry.getStartProperties());
   EXPECT_EQ(startProperties, geometry.getEndProperties());
+
+  EXPECT_TRUE(geometry.hasPath());
 }
 
 TEST(GeometryTest, dimensions_dimensionPreservingOperator)
@@ -41,6 +43,15 @@ TEST(GeometryTest, dimensions_dimensionPreservingOperator)
 
   EXPECT_EQ(startProperties, geometry.getStartProperties());
   EXPECT_EQ(endProperties, geometry.getEndProperties());
+}
+
+TEST(GeometryTest, emptyPath)
+{
+  TransformableGeometryProperties startProperties {Dimensions::Three,
+                                                   LengthUnit::mils};
+  Geometry geometry {startProperties, "none", "", nullptr};
+
+  EXPECT_FALSE(geometry.hasPath());
 }
 
 }  // namespace klee

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -216,7 +216,7 @@ TEST(IOTest, readShapeSet_missingGeometryPath)
     }
     catch(const KleeError &err)
     {
-      FAIL() << "Should not have thrown";
+      FAIL() << "Should not have thrown. Error message: " << err.what();
     }
   }
 }

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -173,24 +173,51 @@ TEST(IOTest, readShapeSet_missingMaterial)
 
 TEST(IOTest, readShapeSet_missingGeometryPath)
 {
-  auto input = R"(
-    dimensions: 2
-
-    shapes:
-      - name: wheel
-        material: steel
-        geometry:
-          format: test_format
-  )";
-
-  try
+  // Expect a validation error when 'geometry/path' is missing
+  // and 'geometry/format' is not "none"
   {
-    readShapeSetFromString(input);
-    FAIL() << "Should have thrown";
+    auto input = R"(
+      dimensions: 2
+
+      shapes:
+        - name: wheel
+          material: steel
+          geometry:
+            format: test_format
+    )";
+
+    try
+    {
+      readShapeSetFromString(input);
+      FAIL() << "Should have thrown";
+    }
+    catch(const KleeError &err)
+    {
+      EXPECT_THAT(err.what(), HasSubstr("Provided format"));
+    }
   }
-  catch(const KleeError &err)
+
+  // Valid when 'geometry/path' is missing and 'geometry/format' is none
   {
-    EXPECT_THAT(err.what(), HasSubstr("path"));
+    auto input = R"(
+      dimensions: 2
+
+      shapes:
+        - name: wheel
+          material: steel
+          geometry:
+            format: none
+    )";
+
+    try
+    {
+      readShapeSetFromString(input);
+      SUCCEED();
+    }
+    catch(const KleeError &err)
+    {
+      FAIL() << "Should not have thrown";
+    }
   }
 }
 

--- a/src/axom/multimat/multimat.cpp
+++ b/src/axom/multimat/multimat.cpp
@@ -488,7 +488,6 @@ void ScanRelationOffsetsRAJA(const axom::ArrayView<const IndexType> counts,
                              const axom::ArrayView<IndexType> firstIndices)
 {
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
-  using AtomicPolicy = typename axom::execution_space<ExecSpace>::atomic_policy;
   using LoopPolicy = typename axom::execution_space<ExecSpace>::loop_policy;
 
   // The begins array has one more element than the counts array. The last

--- a/src/axom/primal/tests/primal_bezier_patch.cpp
+++ b/src/axom/primal/tests/primal_bezier_patch.cpp
@@ -824,7 +824,6 @@ TEST(primal_bezierpatch, rational_evaluation_split)
   const int DIM = 3;
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
-  using VectorType = primal::Vector<CoordType, DIM>;
   using BezierPatchType = primal::BezierPatch<CoordType>;
 
   const int ord_u = 3;

--- a/src/axom/primal/tests/primal_solid_angle.cpp
+++ b/src/axom/primal/tests/primal_solid_angle.cpp
@@ -22,7 +22,6 @@ namespace primal = axom::primal;
 TEST(primal_solid_angle, triangle)
 {
   using Point3D = primal::Point<double, 3>;
-  using Vector3D = primal::Vector<double, 3>;
   using Triangle = primal::Triangle<double, 3>;
 
   Point3D origin {0.0, 0.0, 0.0};
@@ -207,7 +206,6 @@ TEST(primal_solid_angle, degenerate_polygon)
 {
   using Point3D = primal::Point<double, 3>;
   using Vector3D = primal::Vector<double, 3>;
-  using Triangle = primal::Triangle<double, 3>;
   using Polygon = primal::Polygon<double, 3>;
 
   Vector3D v1 = Vector3D({0.0, 1.0, 2.0}).unitVector();
@@ -282,7 +280,6 @@ TEST(primal_solid_angle, selfintersecting_star)
 {
   using Point3D = primal::Point<double, 3>;
   using Vector3D = primal::Vector<double, 3>;
-  using Triangle = primal::Triangle<double, 3>;
   using Polygon = primal::Polygon<double, 3>;
 
   Point3D single_query {1, 2, 3};
@@ -383,7 +380,6 @@ TEST(primal_solid_angle, selfintersecting_star)
 TEST(primal_solid_angle, selfintersecting_quadrilateral)
 {
   using Point3D = primal::Point<double, 3>;
-  using Vector3D = primal::Vector<double, 3>;
   using Triangle = primal::Triangle<double, 3>;
   using Polygon = primal::Polygon<double, 3>;
 

--- a/src/axom/quest/SamplingShaper.hpp
+++ b/src/axom/quest/SamplingShaper.hpp
@@ -459,7 +459,10 @@ public:
         matQFunc != nullptr,
         axom::fmt::format("Missing inout samples for material '{}'", thisMatName));
 
-      quest::shaping::copyShapeIntoMaterial(shapeQFuncCopy, matQFunc);
+      const bool reuseExisting = shape.getGeometry().hasGeometry();
+      quest::shaping::copyShapeIntoMaterial(shapeQFuncCopy,
+                                            matQFunc,
+                                            reuseExisting);
 
       delete shapeQFuncCopy;
       shapeQFuncCopy = nullptr;

--- a/src/axom/quest/Shaper.cpp
+++ b/src/axom/quest/Shaper.cpp
@@ -143,7 +143,8 @@ void Shaper::setRefinementType(Shaper::RefinementType t)
 
 bool Shaper::isValidFormat(const std::string& format) const
 {
-  return (format == "stl" || format == "proe" || format == "c2c");
+  return (format == "stl" || format == "proe" || format == "c2c" ||
+          format == "none");
 }
 
 void Shaper::loadShape(const klee::Shape& shape)
@@ -166,11 +167,19 @@ void Shaper::loadShapeInternal(const klee::Shape& shape,
     "{:-^80}",
     axom::fmt::format(" Loading shape '{}' ", shape.getName())));
 
-  std::string file_format = shape.getGeometry().getFormat();
-
+  const std::string& file_format = shape.getGeometry().getFormat();
   SLIC_ASSERT_MSG(
     this->isValidFormat(file_format),
     axom::fmt::format("Shape has unsupported format: '{}", file_format));
+
+  if(!shape.getGeometry().hasGeometry())
+  {
+    SLIC_DEBUG(
+      fmt::format("Current shape '{}' of material '{}' has no geometry",
+                  shape.getName(),
+                  shape.getMaterial()));
+    return;
+  }
 
   std::string shapePath = m_shapeSet.resolvePath(shape.getGeometry().getPath());
   SLIC_INFO("Reading file: " << shapePath << "...");
@@ -239,8 +248,9 @@ void Shaper::loadShapeInternal(const klee::Shape& shape,
   {
     SLIC_ERROR(
       axom::fmt::format("Unsupported filetype for this Axom configuration. "
-                        "Provided file was '{}'",
-                        shapePath));
+                        "Provided file was '{}', with format '{}'",
+                        shapePath,
+                        file_format));
   }
 }
 

--- a/src/axom/quest/detail/shaping/shaping_helpers.cpp
+++ b/src/axom/quest/detail/shaping/shaping_helpers.cpp
@@ -53,7 +53,8 @@ void replaceMaterial(mfem::QuadratureFunction* shapeQFunc,
 
 /// Utility function to copy in_out quadrature samples from one QFunc to another
 void copyShapeIntoMaterial(const mfem::QuadratureFunction* shapeQFunc,
-                           mfem::QuadratureFunction* materialQFunc)
+                           mfem::QuadratureFunction* materialQFunc,
+                           bool reuseExisting)
 {
   SLIC_ASSERT(shapeQFunc != nullptr);
   SLIC_ASSERT(materialQFunc != nullptr);
@@ -63,9 +64,20 @@ void copyShapeIntoMaterial(const mfem::QuadratureFunction* shapeQFunc,
   double* mData = materialQFunc->GetData();
   const double* sData = shapeQFunc->GetData();
 
-  for(int j = 0; j < SZ; ++j)
+  // When reuseExisting, don't reset material values; otherwise, just copy values over
+  if(reuseExisting)
   {
-    mData[j] = sData[j] > 0 ? 1 : mData[j];
+    for(int j = 0; j < SZ; ++j)
+    {
+      mData[j] = sData[j] > 0 ? 1 : mData[j];
+    }
+  }
+  else
+  {
+    for(int j = 0; j < SZ; ++j)
+    {
+      mData[j] = sData[j];
+    }
   }
 }
 

--- a/src/axom/quest/detail/shaping/shaping_helpers.hpp
+++ b/src/axom/quest/detail/shaping/shaping_helpers.hpp
@@ -45,9 +45,17 @@ void replaceMaterial(mfem::QuadratureFunction* shapeQFunc,
                      mfem::QuadratureFunction* materialQFunc,
                      bool shouldReplace);
 
-/// Utility function to copy inout quadrature point values from \a shapeQFunc to \a materialQFunc
+/**
+ * \brief Utility function to copy inout quadrature point values from \a shapeQFunc to \a materialQFunc
+ *
+ * \param shapeQFunc The inout samples for the current shape
+ * \param materialQFunc The inout samples for the material we're writing into
+ * \param reuseExisting When a value is not set in \a shapeQFunc, should we retain existing values 
+ * from \a materialQFunc or overwrite them based on \a shapeQFunc. The default is to retain values
+ */
 void copyShapeIntoMaterial(const mfem::QuadratureFunction* shapeQFunc,
-                           mfem::QuadratureFunction* materialQFunc);
+                           mfem::QuadratureFunction* materialQFunc,
+                           bool reuseExisting = true);
 
 /// Generates a quadrature function corresponding to the mesh positions
 void generatePositionsQFunction(mfem::Mesh* mesh,

--- a/src/axom/quest/examples/shaping_driver.cpp
+++ b/src/axom/quest/examples/shaping_driver.cpp
@@ -580,6 +580,29 @@ int main(int argc, char** argv)
   shaper->adjustVolumeFractions();
 
   //---------------------------------------------------------------------------
+  // Compute and print volumes of each material's volume fraction
+  //---------------------------------------------------------------------------
+  using axom::utilities::string::startsWith;
+  for(auto& kv : shaper->getDC()->GetFieldMap())
+  {
+    if(startsWith(kv.first, "vol_frac_"))
+    {
+      const auto mat_name = kv.first.substr(9);
+      auto* gf = kv.second;
+
+      mfem::ConstantCoefficient one(1.0);
+      mfem::LinearForm vol_form(gf->FESpace());
+      vol_form.AddDomainIntegrator(new mfem::DomainLFIntegrator(one));
+      vol_form.Assemble();
+
+      const double volume = *gf * vol_form;
+
+      SLIC_INFO(
+        axom::fmt::format("Volume of material '{}' is {}", mat_name, volume));
+    }
+  }
+
+  //---------------------------------------------------------------------------
   // Save meshes and fields
   //---------------------------------------------------------------------------
 #ifdef MFEM_USE_MPI

--- a/src/axom/quest/tests/CMakeLists.txt
+++ b/src/axom/quest/tests/CMakeLists.txt
@@ -145,6 +145,7 @@ if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
               AND C2C_FOUND)
     set(quest_mpi_mfem_c2c_data_tests
         quest_intersection_shaper.cpp
+        quest_sampling_shaper.cpp
        )
     foreach(test ${quest_mpi_mfem_c2c_data_tests})
         get_filename_component( test_name ${test} NAME_WE )

--- a/src/axom/quest/tests/quest_sampling_shaper.cpp
+++ b/src/axom/quest/tests/quest_sampling_shaper.cpp
@@ -255,8 +255,8 @@ public:
   {
     mfem::GridFunction* gf = m_dc.GetField(name);
 
-    mfem::LinearForm vol_form(gf->FESpace());
     mfem::ConstantCoefficient one(1.0);
+    mfem::LinearForm vol_form(gf->FESpace());
     vol_form.AddDomainIntegrator(new mfem::DomainLFIntegrator(one));
     vol_form.Assemble();
 

--- a/src/axom/quest/tests/quest_sampling_shaper.cpp
+++ b/src/axom/quest/tests/quest_sampling_shaper.cpp
@@ -1,0 +1,327 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ * \brief Unit tests for quest's SamplingShaper class and associated replacement rules.
+ */
+
+#include "gtest/gtest.h"
+
+#include "axom/config.hpp"
+#include "axom/core.hpp"
+#include "axom/klee.hpp"
+#include "axom/primal.hpp"
+#include "axom/quest.hpp"
+#include "axom/sidre.hpp"
+#include "axom/slic.hpp"
+#include "axom/quest/SamplingShaper.hpp"
+
+#ifndef AXOM_USE_MFEM
+  #error "Quest's SamplingShaper tests on mfem meshes require mfem library."
+#else
+  #include "mfem.hpp"
+#endif
+
+#ifdef AXOM_USE_MPI
+  #include <mpi.h>
+#endif
+
+#include <cmath>
+#include <string>
+#include <iostream>
+
+namespace klee = axom::klee;
+namespace slic = axom::slic;
+namespace sidre = axom::sidre;
+namespace quest = axom::quest;
+
+namespace
+{
+/// RAII utility class to write a file at construction time and remove it
+/// once the instance is out of scope
+class ScopedTemporaryFile
+{
+public:
+  ScopedTemporaryFile(const std::string& filename, const std::string& contents)
+    : m_filename(filename)
+  {
+    std::ofstream ofs(m_filename.c_str(), std::ios::out);
+    ofs << contents;
+  }
+
+  ~ScopedTemporaryFile()
+  {
+    axom::utilities::filesystem::removeFile(m_filename);
+  }
+
+  const std::string& getFileName() const { return m_filename; }
+
+  std::string getFileContents() const
+  {
+    std::ifstream ifs(m_filename.c_str(), std::ios::in);
+    std::stringstream buffer;
+    buffer << ifs.rdbuf();
+
+    return buffer.str();
+  }
+
+private:
+  const std::string m_filename;
+};
+}  // namespace
+
+/// Test fixture for SamplingShaper tests on MFEM meshes
+class SamplingShaperTest : public ::testing::Test
+{
+public:
+  SamplingShaperTest() : m_dc("test", nullptr, true) { }
+
+  virtual ~SamplingShaperTest() { }
+
+  virtual void SetUp()
+  {
+    const int dim = 2;
+    const int polynomialOrder = 2;
+    const double lo[] = {-2., -2.};
+    const double hi[] = {2., 2.};
+    const int celldims[] = {64, 64};
+
+    // memory for mesh will be managed by data collection
+    auto mesh =
+      new mfem::Mesh(mfem::Mesh::MakeCartesian2D(celldims[0],
+                                                 celldims[1],
+                                                 mfem::Element::QUADRILATERAL,
+                                                 true,
+                                                 hi[0] - lo[0],
+                                                 hi[1] - lo[1]));
+
+    // Offset the mesh to lie w/in the bounding box
+    for(int i = 0; i < mesh->GetNV(); ++i)
+    {
+      double* v = mesh->GetVertex(i);
+      for(int d = 0; d < dim; ++d)
+      {
+        v[d] += lo[d];
+      }
+    }
+
+    mesh->SetCurvature(polynomialOrder);
+
+    m_dc.SetOwnData(true);
+    m_dc.SetMeshNodesName("positions");
+    m_dc.SetMesh(mesh);
+
+#ifdef AXOM_USE_MPI
+    m_dc.SetComm(MPI_COMM_WORLD);
+#endif
+  }
+
+  sidre::MFEMSidreDataCollection& getDC() { return m_dc; }
+  mfem::Mesh& getMesh() { return *m_dc.GetMesh(); }
+
+  // parse and validate the Klee shapefile; fail the test if invalid
+  void validateShapeFile(const std::string& shapefile)
+  {
+    axom::klee::ShapeSet shapeSet;
+
+    try
+    {
+      shapeSet = axom::klee::readShapeSet(shapefile);
+    }
+    catch(axom::klee::KleeError& error)
+    {
+      std::vector<std::string> errs;
+      for(auto verificationError : error.getErrors())
+      {
+        errs.push_back(
+          axom::fmt::format(" - '{}': {}",
+                            static_cast<std::string>(verificationError.path),
+                            verificationError.message));
+      }
+
+      if(!errs.empty())
+      {
+        SLIC_WARNING(
+          axom::fmt::format("Error during parsing klee input file '{}'. "
+                            "Found the following errors:\n{}",
+                            shapefile,
+                            axom::fmt::join(errs, "\n")));
+        FAIL();
+      }
+    }
+  }
+
+  void runShaping(const std::string& shapefile)
+  {
+    SLIC_INFO(axom::fmt::format("Reading shape set from {}", shapefile));
+    klee::ShapeSet shapeSet(klee::readShapeSet(shapefile));
+
+    SLIC_INFO(axom::fmt::format("Shaping materials..."));
+    quest::SamplingShaper shaper(shapeSet, &m_dc);
+    shaper.setVerbosity(true);
+
+    const auto shapeDim = shapeSet.getDimensions();
+    for(const auto& shape : shapeSet.getShapes())
+    {
+      SLIC_INFO(axom::fmt::format("\tshape {} -> material {}",
+                                  shape.getName(),
+                                  shape.getMaterial()));
+
+      shaper.loadShape(shape);
+      shaper.prepareShapeQuery(shapeDim, shape);
+      shaper.runShapeQuery(shape);
+      shaper.applyReplacementRules(shape);
+      shaper.finalizeShapeQuery();
+    }
+
+    shaper.adjustVolumeFractions();
+  }
+
+  // Computes the total volume of the associated volume fraction grid function
+  double gridFunctionVolume(const std::string& name)
+  {
+    mfem::GridFunction* gf = m_dc.GetField(name);
+
+    mfem::LinearForm vol_form(gf->FESpace());
+    mfem::ConstantCoefficient one(1.0);
+    vol_form.AddDomainIntegrator(new mfem::DomainLFIntegrator(one));
+    vol_form.Assemble();
+
+    return *gf * vol_form;
+  }
+
+protected:
+  sidre::MFEMSidreDataCollection m_dc;
+};
+
+//-----------------------------------------------------------------------------
+
+TEST(ScopedTemporaryFile, basic)
+{
+  using axom::utilities::filesystem::pathExists;
+
+  const std::string filename = "previously_nonexistent.file";
+  const std::string contents = "file contents!";
+
+  // File does not exist before entering scope
+  EXPECT_FALSE(pathExists(filename));
+
+  // File is created and exists within the scope
+  {
+    ScopedTemporaryFile test_file(filename, contents);
+
+    EXPECT_EQ(test_file.getFileName(), filename);
+    ASSERT_TRUE(pathExists(test_file.getFileName()));
+
+    // check contents
+    EXPECT_EQ(contents, test_file.getFileContents());
+  }
+
+  // File no longer exists outside the scope
+  EXPECT_FALSE(pathExists(filename));
+}
+
+TEST_F(SamplingShaperTest, check_mesh)
+{
+  auto& mesh = this->getMesh();
+
+  const int NE = mesh.GetNE();
+  SLIC_INFO(axom::fmt::format("The mesh has {} elements", NE));
+  EXPECT_GT(NE, 0);
+
+  const int NV = mesh.GetNV();
+  SLIC_INFO(axom::fmt::format("The mesh has {} vertices", NV));
+  EXPECT_GT(NV, 0);
+
+  mfem::Vector mn, mx;
+  mesh.GetBoundingBox(mn, mx);
+  SLIC_INFO(
+    axom::fmt::format("The mesh bounding box is:  {{min: {}, {}, max: {},{}}}",
+                      mn[0],
+                      mn[1],
+                      mx[0],
+                      mx[1]));
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_F(SamplingShaperTest, basic_circle)
+{
+  const auto& testname =
+    ::testing::UnitTest::GetInstance()->current_test_info()->name();
+
+  const std::string contour_contents =
+    "piece = circle(origin=(0cm, 0cm), radius=1cm, start=0deg, end=360deg)";
+
+  const std::string shape_template = R"(
+dimensions: 2
+
+shapes:
+- name: circle_shape
+  material: {}
+  geometry:
+    format: c2c
+    path: {}
+)";
+
+  const std::string circle_material = "circleMat";
+
+  ScopedTemporaryFile contour_file(axom::fmt::format("{}.contour", testname),
+                                   contour_contents);
+
+  ScopedTemporaryFile shape_file(axom::fmt::format("{}.yaml", testname),
+                                 axom::fmt::format(shape_template,
+                                                   circle_material,
+                                                   contour_file.getFileName()));
+
+  {
+    SLIC_INFO("Contour file: \n" << contour_file.getFileContents());
+    SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
+  }
+
+  this->validateShapeFile(shape_file.getFileName());
+
+  this->runShaping(shape_file.getFileName());
+
+  // check that the result has a volume fraction field associated with the circle material
+  auto& dc = this->getDC();
+  const std::string vf_name = axom::fmt::format("vol_frac_{}", circle_material);
+  EXPECT_TRUE(dc.HasField(vf_name))
+    << "Did not have material '" << vf_name << "'";
+
+  // check shaped-in volume fraction of unit circle -- should be around PI
+  SLIC_INFO("Shaped volume fraction of unit circle is "
+            << this->gridFunctionVolume(vf_name));
+
+  EXPECT_NEAR(M_PI, this->gridFunctionVolume(vf_name), 1e-2);
+
+  //---------------------------------------------------------------------------
+  // Save meshes and fields
+  //---------------------------------------------------------------------------
+  dc.Save();
+}
+
+//-----------------------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+  int result = 0;
+#ifdef AXOM_USE_MPI
+  // This is needed because of Axom's c2c reader.
+  MPI_Init(&argc, &argv);
+  // See if this aborts right away.
+  int my_rank, num_ranks;
+  MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
+#endif
+
+  ::testing::InitGoogleTest(&argc, argv);
+  slic::SimpleLogger logger(slic::message::Info);
+
+  result = RUN_ALL_TESTS();
+#ifdef AXOM_USE_MPI
+  MPI_Finalize();
+#endif
+  return result;
+}


### PR DESCRIPTION
# Summary

- This PR is a feature related to quest's shaping application of klee input decks
- It allows "preshaped" materials (e.g. where the volume fractions are generated prior to invoking axom's shaping pipeline) to participate in replacement rules.
- It adds support in Klee for a shape to have no geometric data. This is specified with `geometry/format: none`. If so, it will not have a `geometry/path` entry.
- It also adds unit tests for quest's `SamplingShaper` class
- Resolves #1104 

#### TODO
- [x] Update `RELEASE-NOTES`
- Update klee/shaping files in `axom_data` repo, as necessary

_Update:_ I'll update the `axom_data` repo in a follow-up PR since it will involve non-trivial changes to the shaping example