### PR TITLE
ArrayView: multi-dim subspans, non-row-major striding

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -58,6 +58,10 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Quest: Adds ability to import volume fractions into `SamplingShaper` before processing `Klee` input
 - Slam: adds a `slam::MappedVariableCardinality` policy to accelerate mapping flat indices
   back to first-set indices when used in a `StaticRelation`
+- Adds an `ArrayView(data, shape, strides)` constructor to support column-major and custom
+  striding layouts.
+- Adds an `ArrayView::subspan()` overload for multi-dimensional subspans
+- Adds an `axom::utilities::insertionSort()` method.
 
 ### Changed
 - Fixed bug in `mint::mesh::UnstructuredMesh` constructors, affecting capacity.
@@ -103,6 +107,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Multimat: Ported field data/sparsity layout conversion methods to GPU.
 - Multimat: `MultiMat::makeOtherRelation()` now runs on the GPU with an appropriately-set allocator ID.
 - Multimat: `MultiMat::setCellMatRel(counts, indices)` now runs on the GPU, and accepts GPU-side data.
+- Renames `ArrayView::spacing()` to `ArrayView::minStride()`.
 
 ###  Fixed
 - Fixed issues with CUDA build in CMake versions 3.14.5 and above. Now require CMake 3.18+

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -344,11 +344,6 @@ public:
 
   /// @}
 
-  /*!
-    \brief Returns spacing between adjacent items.
-  */
-  AXOM_HOST_DEVICE IndexType spacing() const { return 1; }
-
   /// @}
 
   /// \name Array methods to modify the data.

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -334,10 +334,8 @@ public:
   }
 
   /*!
-    \brief Returns the logical strides of the Array.
-
-    Note: Memory stride is logical stride times spacing.
-  */
+   * \brief Returns the memory strides of the Array.
+   */
   AXOM_HOST_DEVICE const StackArray<IndexType, DIM>& strides() const
   {
     return m_strides;
@@ -404,27 +402,23 @@ private:
     return static_cast<const ArrayType&>(*this);
   }
 
-  /*!
-    \brief Logical offset to get to the given multidimensional index.
-
-    To get from logical offset to memory offset, multiply by spacing().
-  */
+  //// \brief Memory offset to get to the given multidimensional index.
   AXOM_HOST_DEVICE IndexType offset(const StackArray<IndexType, DIM>& idx) const
   {
     return numerics::dot_product((const IndexType*)idx, m_strides.begin(), DIM);
   }
 
   /*!
-   * \brief Returns the logical number of elements.
+   * \brief Returns the number of elements in memory.
    *
    *  offset() will return a value between [0, logicalSize()).
    */
-  AXOM_HOST_DEVICE IndexType logicalSize() const
+  AXOM_HOST_DEVICE IndexType memorySize() const
   {
     return m_strides[0] * m_shape[0];
   }
 
-  /// Logical offset to a slice at the given lower-dimensional index.
+  /// \brief Memory offset to a slice at the given lower-dimensional index.
   template <int UDim>
   AXOM_HOST_DEVICE IndexType offset(const StackArray<IndexType, UDim>& idx) const
   {
@@ -439,7 +433,7 @@ private:
   /*! \brief Test if idx is within bounds */
   AXOM_HOST_DEVICE inline bool inBounds(IndexType idx) const
   {
-    return idx >= 0 && idx < logicalSize();
+    return idx >= 0 && idx < memorySize();
   }
   /// @}
 
@@ -614,12 +608,8 @@ private:
   /// \name Internal bounds-checking routines
   /// @{
 
-  /*!
-   * \brief Returns the logical number of elements.
-   *
-   *  offset() will return a value between [0, logicalSize()).
-   */
-  AXOM_HOST_DEVICE IndexType logicalSize() const
+  /// \brief Returns the number of elements in memory.
+  AXOM_HOST_DEVICE IndexType memorySize() const
   {
     return m_stride * shape()[0];
   }
@@ -627,7 +617,7 @@ private:
   /*! \brief Test if idx is within bounds */
   AXOM_HOST_DEVICE inline bool inBounds(IndexType idx) const
   {
-    return idx >= 0 && idx < logicalSize();
+    return idx >= 0 && idx < memorySize();
   }
   /// @}
 

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -443,9 +443,10 @@ private:
   }
 
   /*!
-   * \brief Returns the number of elements in memory.
+   * \brief Returns the size of the range of memory in which elements are
+   *  located. This is equivalent to size() * minStride().
    *
-   *  offset() will return a value between [0, logicalSize()).
+   *  offset() will return a value between [0, memorySize()).
    */
   AXOM_HOST_DEVICE IndexType memorySize() const
   {
@@ -679,7 +680,10 @@ private:
   /// \name Internal bounds-checking routines
   /// @{
 
-  /// \brief Returns the number of elements in memory.
+  /*!
+   * \brief Returns the size of the range of memory in which elements are
+   *  located. This is equivalent to size() * minStride().
+   */
   AXOM_HOST_DEVICE IndexType memorySize() const
   {
     return m_stride * shape()[0];

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -560,6 +560,11 @@ public:
     : m_stride(spacing)
   { }
 
+  AXOM_HOST_DEVICE ArrayBase(const StackArray<IndexType, 1>&,
+                             const StackArray<IndexType, 1>& stride)
+    : m_stride(stride[0])
+  { }
+
   // Empty implementation because no member data
   template <typename OtherArrayType>
   ArrayBase(const ArrayBase<typename std::remove_const<T>::type, 1, OtherArrayType>&)

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -344,7 +344,15 @@ public:
   /*!
    * \brief Returns the spacing between adjacent items.
    */
-  AXOM_HOST_DEVICE IndexType spacing() const { return m_strides[DIM - 1]; }
+  AXOM_HOST_DEVICE IndexType spacing() const
+  {
+    IndexType minStride = m_strides[0];
+    for(int dim = 1; dim < DIM; dim++)
+    {
+      minStride = axom::utilities::min(minStride, m_strides[dim]);
+    }
+    return minStride;
+  }
 
 protected:
   /// \brief Set the shape
@@ -1475,7 +1483,8 @@ class ArraySubslice
 public:
   AXOM_HOST_DEVICE ArraySubslice(BaseArray* array,
                                  const StackArray<IndexType, NumIndices>& idxs)
-    : BaseClass(detail::takeLastElems<SliceDim>(array->shape()), array->spacing())
+    : BaseClass(detail::takeLastElems<SliceDim>(array->shape()),
+                detail::takeLastElems<SliceDim>(array->strides()))
     , m_array(array)
     , m_inds(idxs)
   { }

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -313,20 +313,6 @@ public:
     std::swap(m_strides, other.m_strides);
   }
 
-  /// \brief Set the shape
-  AXOM_HOST_DEVICE void setShape(const StackArray<IndexType, DIM>& shape_)
-  {
-#ifndef NDEBUG
-    for(auto s : shape_)
-    {
-      assert(s >= 0);
-    }
-#endif
-
-    m_shape = shape_;
-    updateStrides();
-  }
-
   /// \brief Returns the dimensions of the Array
   AXOM_HOST_DEVICE const StackArray<IndexType, DIM>& shape() const
   {
@@ -347,6 +333,20 @@ public:
   AXOM_HOST_DEVICE IndexType spacing() const { return m_strides[DIM - 1]; }
 
 protected:
+  /// \brief Set the shape
+  AXOM_HOST_DEVICE void setShape(const StackArray<IndexType, DIM>& shape_)
+  {
+#ifndef NDEBUG
+    for(auto s : shape_)
+    {
+      assert(s >= 0);
+    }
+#endif
+
+    m_shape = shape_;
+    updateStrides();
+  }
+
   /*!
    * \brief Returns the minimum "chunk size" that should be allocated
    * For example, 2 would be the chunk size of a 2D array whose second dimension is of size 2.

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -177,6 +177,20 @@ public:
   }
 
   /*!
+   * \brief Parameterized constructor that sets up the array shape and stride.
+   *
+   * \param [in] shape Array size in each direction.
+   * \param [in] stride Array stride for each direction.
+   */
+  AXOM_HOST_DEVICE ArrayBase(const StackArray<IndexType, DIM>& shape,
+                             const StackArray<IndexType, DIM>& stride)
+    : m_shape {shape}
+    , m_strides {stride}
+  {
+    validateShapeAndStride(shape, stride);
+  }
+
+  /*!
    * \brief Copy constructor for arrays of different type
    * Because the element type (T) and dimension (DIM) are still locked down,
    * this function is nominally used for copying ArrayBase metadata from

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -487,11 +487,11 @@ private:
       sorted_dims[dim] = dim;
     }
     // Sort the dimensions by stride.
-    axom::utilities::insertion_sort(sorted_dims,
-                                    DIM,
-                                    [&](int dim_a, int dim_b) -> bool {
-                                      return stride[dim_a] < stride[dim_b];
-                                    });
+    axom::utilities::insertionSort(sorted_dims,
+                                   DIM,
+                                   [&](int dim_a, int dim_b) -> bool {
+                                     return stride[dim_a] < stride[dim_b];
+                                   });
     // Work from the smallest-strided dimension to the largest-strided.
     for(int dim = 0; dim < DIM - 1; dim++)
     {

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -352,11 +352,7 @@ protected:
                                           const StackArray<IndexType, DIM>& stride)
   {
 #ifdef AXOM_DEBUG
-    for(int dim = DIM - 1; dim > 0; dim--)
-    {
-      assert(stride[dim - 1] >= stride[dim] * shape[dim]);
-      assert(stride[dim - 1] % stride[dim] == 0);
-    }
+    validateShapeAndStride(shape, stride);
 #endif
     m_shape = shape;
     m_strides = stride;
@@ -430,7 +426,12 @@ private:
    */
   AXOM_HOST_DEVICE IndexType memorySize() const
   {
-    return m_strides[0] * m_shape[0];
+    IndexType maxSize = 0;
+    for(int dim = 0; dim < DIM; dim++)
+    {
+      maxSize = axom::utilities::max(maxSize, m_strides[dim] * m_shape[dim]);
+    }
+    return maxSize;
   }
 
   /// \brief Memory offset to a slice at the given lower-dimensional index.
@@ -450,6 +451,33 @@ private:
   {
     return idx >= 0 && idx < memorySize();
   }
+
+  /// \brief Checks a shape and stride array for correct bounds.
+  AXOM_HOST_DEVICE inline void validateShapeAndStride(
+    const StackArray<IndexType, DIM>& shape,
+    const StackArray<IndexType, DIM>& stride)
+  {
+    int sorted_dims[DIM];
+    for(int dim = 0; dim < DIM; dim++)
+    {
+      sorted_dims[dim] = dim;
+    }
+    // Sort the dimensions by stride.
+    axom::utilities::insertion_sort(sorted_dims,
+                                    DIM,
+                                    [&](int dim_a, int dim_b) -> bool {
+                                      return stride[dim_a] < stride[dim_b];
+                                    });
+    // Work from the smallest-strided dimension to the largest-strided.
+    for(int dim = 0; dim < DIM - 1; dim++)
+    {
+      int minor_dim = sorted_dims[dim];
+      int major_dim = sorted_dims[dim + 1];
+      assert(stride[major_dim] >= stride[minor_dim] * shape[minor_dim]);
+      assert(stride[major_dim] % stride[minor_dim] == 0);
+    }
+  }
+
   /// @}
 
   /// \name Internal subarray slicing methods

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -347,6 +347,21 @@ protected:
     updateStrides();
   }
 
+  /// \brief Set the shape and stride
+  AXOM_HOST_DEVICE void setShapeAndStride(const StackArray<IndexType, DIM>& shape,
+                                          const StackArray<IndexType, DIM>& stride)
+  {
+#ifdef AXOM_DEBUG
+    for(int dim = DIM - 1; dim > 0; dim--)
+    {
+      assert(stride[dim - 1] >= stride[dim] * shape[dim]);
+      assert(stride[dim - 1] % stride[dim] == 0);
+    }
+#endif
+    m_shape = shape;
+    m_strides = stride;
+  }
+
   /*!
    * \brief Returns the minimum "chunk size" that should be allocated
    * For example, 2 would be the chunk size of a 2D array whose second dimension is of size 2.

--- a/src/axom/core/ArrayView.hpp
+++ b/src/axom/core/ArrayView.hpp
@@ -60,12 +60,14 @@ public:
   /*!
    * \brief Generic constructor for an ArrayView of arbitrary dimension with external data
    *
+   *  This constructor assumes that the data is laid out in a dense row-major
+   *  layout; that is, elements are laid out contiguously with respect to the
+   *  last (DIM-1) dimension.
+   *
    * \param [in] data the external data this ArrayView will wrap.
    * \param [in] args The parameter pack containing the "shape" of the ArrayView
    *
    * \pre sizeof...(Args) == DIM
-   *
-   * This constructor doesn't support non-unit spacing.
    */
   template <
     typename... Args,
@@ -76,15 +78,18 @@ public:
   /*!
    * \brief Generic constructor for an ArrayView of arbitrary dimension with external data
    *
+   *  This constructor assumes that the data is laid out in a row-major layout,
+   *  but accepts a min_stride parameter for the stride between consecutive
+   *  elements in the last dimension.
+   *
    * \param [in] data the external data this ArrayView will wrap.
    * \param [in] shape Array size in each dimension.
-   * \param [in] spacing_ Spacing between consecutive items.
-   *
-   * This constructor supports non-unit spacing.
+   * \param [in] min_stride Minimum stride between consecutive items in the
+   *  last dimension
    */
   AXOM_HOST_DEVICE ArrayView(T* data,
                              const StackArray<IndexType, DIM>& shape,
-                             IndexType spacing_ = 1);
+                             IndexType min_stride = 1);
 
   /*!
    * \brief Generic constructor for an ArrayView of arbitrary dimension with external data
@@ -239,8 +244,8 @@ template <typename T, int DIM, MemorySpace SPACE>
 AXOM_HOST_DEVICE ArrayView<T, DIM, SPACE>::ArrayView(
   T* data,
   const StackArray<IndexType, DIM>& shape,
-  IndexType spacing)
-  : ArrayBase<T, DIM, ArrayView<T, DIM, SPACE>>(shape, spacing)
+  IndexType min_stride)
+  : ArrayBase<T, DIM, ArrayView<T, DIM, SPACE>>(shape, min_stride)
   , m_data(data)
 #ifndef AXOM_DEVICE_CODE
   , m_allocator_id(axom::detail::getAllocatorID<SPACE>())

--- a/src/axom/core/ArrayView.hpp
+++ b/src/axom/core/ArrayView.hpp
@@ -138,13 +138,6 @@ public:
   /// @}
 
   /*!
-    \brief Returns spacing between adjacent items.
-
-    Spacing is set by constructor and cannot change.
-  */
-  AXOM_HOST_DEVICE IndexType spacing() const { return m_spacing; }
-
-  /*!
    * \brief Get the ID for the umpire allocator
    */
   int getAllocatorID() const { return m_allocator_id; }
@@ -189,7 +182,6 @@ private:
   /// \brief The full number of elements in the array
   ///  i.e., 3 for a 1D Array of size 3, 9 for a 3x3 2D array, etc
   IndexType m_num_elements = 0;
-  IndexType m_spacing = 1;
   /// \brief The allocator ID for the memory space in which m_data was allocated
   int m_allocator_id;
 };
@@ -217,10 +209,9 @@ template <typename T, int DIM, MemorySpace SPACE>
 AXOM_HOST_DEVICE ArrayView<T, DIM, SPACE>::ArrayView(
   T* data,
   const StackArray<IndexType, DIM>& shape,
-  IndexType spacing_)
-  : ArrayBase<T, DIM, ArrayView<T, DIM, SPACE>>(shape)
+  IndexType spacing)
+  : ArrayBase<T, DIM, ArrayView<T, DIM, SPACE>>(shape, spacing)
   , m_data(data)
-  , m_spacing(spacing_)
 #ifndef AXOM_DEVICE_CODE
   , m_allocator_id(axom::detail::getAllocatorID<SPACE>())
 #endif
@@ -269,7 +260,6 @@ ArrayView<T, DIM, SPACE>::ArrayView(ArrayBase<T, DIM, OtherArrayType>& other)
   : ArrayBase<T, DIM, ArrayView<T, DIM, SPACE>>(other)
   , m_data(static_cast<OtherArrayType&>(other).data())
   , m_num_elements(static_cast<OtherArrayType&>(other).size())
-  , m_spacing(static_cast<OtherArrayType&>(other).spacing())
   , m_allocator_id(static_cast<OtherArrayType&>(other).getAllocatorID())
 {
 #ifdef AXOM_DEBUG
@@ -293,7 +283,6 @@ ArrayView<T, DIM, SPACE>::ArrayView(
   : ArrayBase<T, DIM, ArrayView<T, DIM, SPACE>>(other)
   , m_data(static_cast<const OtherArrayType&>(other).data())
   , m_num_elements(static_cast<const OtherArrayType&>(other).size())
-  , m_spacing(static_cast<const OtherArrayType&>(other).spacing())
   , m_allocator_id(static_cast<const OtherArrayType&>(other).getAllocatorID())
 {
   static_assert(

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(core_serial_tests
     core_about.hpp
     core_array.hpp
     core_array_for_all.hpp
+    core_utilities.hpp
     core_bit_utilities.hpp
     core_execution_for_all.hpp
     core_execution_space.hpp

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1738,7 +1738,7 @@ TEST(core_array, check_multidimensional_view_subspan_colmaj)
                                    {I_STRIDE, J_STRIDE, K_STRIDE});
 
   EXPECT_EQ(double_view.size(), 4 * 5 * 6);
-  EXPECT_EQ(double_view.spacing(), 1);
+  EXPECT_EQ(double_view.minStride(), 1);
   EXPECT_EQ(double_view.strides()[0], I_STRIDE);
   EXPECT_EQ(double_view.strides()[1], J_STRIDE);
   EXPECT_EQ(double_view.strides()[2], K_STRIDE);
@@ -1806,7 +1806,7 @@ TEST(core_array, check_multidimensional_view_subspan_stride)
                                    {I_STRIDE, J_STRIDE, K_STRIDE});
 
   EXPECT_EQ(double_view.size(), 4 * 5 * 6);
-  EXPECT_EQ(double_view.spacing(), 1);
+  EXPECT_EQ(double_view.minStride(), 1);
   EXPECT_EQ(double_view.strides()[0], I_STRIDE);
   EXPECT_EQ(double_view.strides()[1], J_STRIDE);
   EXPECT_EQ(double_view.strides()[2], K_STRIDE);

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1685,6 +1685,10 @@ TEST(core_array, check_multidimensional_view_spacing)
         EXPECT_EQ(windOnly(i, j, k), pvalue + .2);
         EXPECT_EQ(fireOnly(i, j, k), pvalue + .3);
 
+        EXPECT_EQ(earthOnly[i][j][k], pvalue + .1);
+        EXPECT_EQ(windOnly[i][j][k], pvalue + .2);
+        EXPECT_EQ(fireOnly[i][j][k], pvalue + .3);
+
         EXPECT_EQ(&earthOnly(i, j, k), &mdElemArray(i, j, k).earth);
         EXPECT_EQ(&windOnly(i, j, k), &mdElemArray(i, j, k).wind);
         EXPECT_EQ(&fireOnly(i, j, k), &mdElemArray(i, j, k).fire);

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1704,6 +1704,142 @@ TEST(core_array, check_multidimensional_view_subspan)
   }
 }
 
+//------------------------------------------------------------------------------
+TEST(core_array, check_multidimensional_view_subspan_colmaj)
+{
+  constexpr double GHOST_DOUBLE = -1.0;
+
+  // Create a block of 2 * 3 * 4 doubles wrapped by a layer of -1s, representing
+  // a layer of "ghost zones."
+  double v_double_arr[4 * 5 * 6];
+  std::fill_n(v_double_arr, 4 * 5 * 6, GHOST_DOUBLE);
+
+  // For the non-ghost values, fill them with unique values.
+  constexpr int I_STRIDE = 1;
+  constexpr int J_STRIDE = 4;
+  constexpr int K_STRIDE = 4 * 5;
+  for(int i = 1; i < 3; i++)
+  {
+    for(int j = 1; j < 4; j++)
+    {
+      for(int k = 1; k < 5; k++)
+      {
+        double i_comp = (i - 1) * 0.1;
+        double j_comp = (j - 1) * 1.0;
+        double k_comp = (k - 1) * 10.0;
+        double value = i_comp + j_comp + k_comp;
+        v_double_arr[i * I_STRIDE + j * J_STRIDE + k * K_STRIDE] = value;
+      }
+    }
+  }
+
+  ArrayView<double, 3> double_view(v_double_arr,
+                                   {4, 5, 6},
+                                   {I_STRIDE, J_STRIDE, K_STRIDE});
+
+  EXPECT_EQ(double_view.size(), 4 * 5 * 6);
+  EXPECT_EQ(double_view.spacing(), 1);
+  EXPECT_EQ(double_view.strides()[0], I_STRIDE);
+  EXPECT_EQ(double_view.strides()[1], J_STRIDE);
+  EXPECT_EQ(double_view.strides()[2], K_STRIDE);
+
+  // Construct a subspan view starting at (1, 1, 1) and spanning 2 x 3 x 4
+  // elements.
+  ArrayView<double, 3> double_view_real =
+    double_view.subspan({1, 1, 1}, {2, 3, 4});
+
+  EXPECT_EQ(double_view_real.size(), 2 * 3 * 4);
+  EXPECT_EQ(double_view_real.shape()[0], 2);
+  EXPECT_EQ(double_view_real.shape()[1], 3);
+  EXPECT_EQ(double_view_real.shape()[2], 4);
+  EXPECT_EQ(double_view_real.strides(), double_view.strides());
+
+  // Iterate over logical indexes and check for validity.
+  for(int i = 0; i < 2; i++)
+  {
+    for(int j = 0; j < 3; j++)
+    {
+      for(int k = 0; k < 4; k++)
+      {
+        double i_comp = i * 0.1;
+        double j_comp = j * 1.0;
+        double k_comp = k * 10.0;
+        double value = i_comp + j_comp + k_comp;
+        EXPECT_EQ(double_view_real(i, j, k), value);
+        EXPECT_EQ(double_view_real[i][j][k], value);
+      }
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(core_array, check_multidimensional_view_subspan_stride)
+{
+  constexpr double GHOST_DOUBLE = -1.0;
+
+  // Create a block of 2 * 3 * 4 doubles wrapped by a layer of -1s, representing
+  // a layer of "ghost zones."
+  double v_double_arr[4 * 5 * 6];
+  std::fill_n(v_double_arr, 4 * 5 * 6, GHOST_DOUBLE);
+
+  // For the non-ghost values, fill them with unique values.
+  constexpr int I_STRIDE = 5 * 6;
+  constexpr int J_STRIDE = 1;
+  constexpr int K_STRIDE = 5;
+  for(int i = 1; i < 3; i++)
+  {
+    for(int j = 1; j < 4; j++)
+    {
+      for(int k = 1; k < 5; k++)
+      {
+        double i_comp = (i - 1) * 0.1;
+        double j_comp = (j - 1) * 1.0;
+        double k_comp = (k - 1) * 10.0;
+        double value = i_comp + j_comp + k_comp;
+        v_double_arr[i * I_STRIDE + j * J_STRIDE + k * K_STRIDE] = value;
+      }
+    }
+  }
+
+  ArrayView<double, 3> double_view(v_double_arr,
+                                   {4, 5, 6},
+                                   {I_STRIDE, J_STRIDE, K_STRIDE});
+
+  EXPECT_EQ(double_view.size(), 4 * 5 * 6);
+  EXPECT_EQ(double_view.spacing(), 1);
+  EXPECT_EQ(double_view.strides()[0], I_STRIDE);
+  EXPECT_EQ(double_view.strides()[1], J_STRIDE);
+  EXPECT_EQ(double_view.strides()[2], K_STRIDE);
+
+  // Construct a subspan view starting at (1, 1, 1) and spanning 2 x 3 x 4
+  // elements.
+  ArrayView<double, 3> double_view_real =
+    double_view.subspan({1, 1, 1}, {2, 3, 4});
+
+  EXPECT_EQ(double_view_real.size(), 2 * 3 * 4);
+  EXPECT_EQ(double_view_real.shape()[0], 2);
+  EXPECT_EQ(double_view_real.shape()[1], 3);
+  EXPECT_EQ(double_view_real.shape()[2], 4);
+  EXPECT_EQ(double_view_real.strides(), double_view.strides());
+
+  // Iterate over logical indexes and check for validity.
+  for(int i = 0; i < 2; i++)
+  {
+    for(int j = 0; j < 3; j++)
+    {
+      for(int k = 0; k < 4; k++)
+      {
+        double i_comp = i * 0.1;
+        double j_comp = j * 1.0;
+        double k_comp = k * 10.0;
+        double value = i_comp + j_comp + k_comp;
+        EXPECT_EQ(double_view_real(i, j, k), value);
+        EXPECT_EQ(double_view_real[i][j][k], value);
+      }
+    }
+  }
+}
+
 struct Elem
 {
   double earth, wind, fire;

--- a/src/axom/core/tests/core_serial_main.cpp
+++ b/src/axom/core/tests/core_serial_main.cpp
@@ -10,6 +10,7 @@
 #include "core_about.hpp"
 #include "core_array.hpp"
 #include "core_array_for_all.hpp"
+#include "core_utilities.hpp"
 #include "core_bit_utilities.hpp"
 #include "core_execution_for_all.hpp"
 #include "core_execution_space.hpp"

--- a/src/axom/core/tests/core_utilities.hpp
+++ b/src/axom/core/tests/core_utilities.hpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "gtest/gtest.h"
+
+#include "axom/config.hpp"
+#include "axom/core/utilities/Utilities.hpp"
+
+#include <algorithm>
+#include <random>
+#include <numeric>
+
+TEST(core_utilities, insertion_sort_int)
+{
+  constexpr int NUM_ITERS = 100;
+  constexpr int NUM_INTS = 32;
+  // Create some RNG state used by std::shuffle
+  std::random_device rd;
+  std::mt19937 mersenne_twister(rd());
+
+  // Run this for a few iterations to test that sorting works on different
+  // random shuffles.
+  for(int iter = 0; iter < NUM_ITERS; iter++)
+  {
+    // Create an array of 32 integers
+    int data[NUM_INTS];
+
+    // Fill it with uniform numbers from 0...31
+    std::iota(data, data + NUM_INTS, 1);
+
+    // Randomly shuffle the data.
+    std::shuffle(data, data + NUM_INTS, mersenne_twister);
+
+    // Sort the data.
+    axom::utilities::insertion_sort(data, NUM_INTS);
+
+    // The result should be our ordered range 0...31
+    for(int i = 0; i < NUM_INTS; i++)
+    {
+      ASSERT_EQ(data[i], i + 1);
+    }
+  }
+}
+
+TEST(core_utilities, insertion_sort_doubles)
+{
+  constexpr int NUM_ITERS = 100;
+  constexpr int NUM_DBLS = 64;
+  // Create some RNG state used by std::shuffle
+  std::random_device rd;
+  std::mt19937 mersenne_twister(rd());
+
+  // Run this for a few iterations to test that sorting works on different
+  // random shuffles.
+  for(int iter = 0; iter < NUM_ITERS; iter++)
+  {
+    // Create an array of 64 doubles
+    int data[NUM_DBLS];
+
+    // Fill it with random doubles in the range of [0, 1024)
+    std::generate_n(data, NUM_DBLS, []() -> double {
+      return axom::utilities::random_real(0.0, 1024.0);
+    });
+
+    // Randomly shuffle the data.
+    std::shuffle(data, data + NUM_DBLS, mersenne_twister);
+
+    // Sort the data.
+    axom::utilities::insertion_sort(data, NUM_DBLS);
+
+    // Check that the range is now sorted.
+    for(int i = 0; i < NUM_DBLS - 1; i++)
+    {
+      ASSERT_LE(data[i], data[i + 1]);
+    }
+  }
+}

--- a/src/axom/core/tests/core_utilities.hpp
+++ b/src/axom/core/tests/core_utilities.hpp
@@ -34,7 +34,7 @@ TEST(core_utilities, insertion_sort_int)
     std::shuffle(data, data + NUM_INTS, mersenne_twister);
 
     // Sort the data.
-    axom::utilities::insertion_sort(data, NUM_INTS);
+    axom::utilities::insertionSort(data, NUM_INTS);
 
     // The result should be our ordered range 0...31
     for(int i = 0; i < NUM_INTS; i++)
@@ -68,7 +68,7 @@ TEST(core_utilities, insertion_sort_doubles)
     std::shuffle(data, data + NUM_DBLS, mersenne_twister);
 
     // Sort the data.
-    axom::utilities::insertion_sort(data, NUM_DBLS);
+    axom::utilities::insertionSort(data, NUM_DBLS);
 
     // Check that the range is now sorted.
     for(int i = 0; i < NUM_DBLS - 1; i++)

--- a/src/axom/core/utilities/Utilities.hpp
+++ b/src/axom/core/utilities/Utilities.hpp
@@ -347,6 +347,31 @@ inline AXOM_HOST_DEVICE bool isNearlyEqualRelative(RealType a,
 }
 
 /*!
+ * \brief Insertion sort of an array.
+ * \accelerated
+ * \param [in] array The array to sort.
+ * \param [in] n The number of entries in the array.
+ * \param [in] cmp The comparator to use for comparing elements; "less than"
+ *  by default.
+ */
+template <typename DataType, typename Predicate = std::less<DataType>>
+inline AXOM_HOST_DEVICE void insertion_sort(DataType* array,
+                                            IndexType n,
+                                            Predicate cmp = {})
+{
+  for(int i = 1; i < n; i++)
+  {
+    int j = i;
+    // Keep swapping elements until we're not out-of-order.
+    while(j > 0 && cmp(array[j], array[j - 1]))
+    {
+      axom::utilities::swap(array[j], array[j - 1]);
+      j--;
+    }
+  }
+}
+
+/*!
  * \brief Compares std::vector< T > in lexicographic order
  *
  * \note T must support > and < operators.

--- a/src/axom/core/utilities/Utilities.hpp
+++ b/src/axom/core/utilities/Utilities.hpp
@@ -355,9 +355,9 @@ inline AXOM_HOST_DEVICE bool isNearlyEqualRelative(RealType a,
  *  by default.
  */
 template <typename DataType, typename Predicate = std::less<DataType>>
-inline AXOM_HOST_DEVICE void insertion_sort(DataType* array,
-                                            IndexType n,
-                                            Predicate cmp = {})
+inline AXOM_HOST_DEVICE void insertionSort(DataType* array,
+                                           IndexType n,
+                                           Predicate cmp = {})
 {
   for(int i = 1; i < n; i++)
   {


### PR DESCRIPTION
# Summary

- Adds `ArrayView` constructor with user-defined striding parameter
  - User-defined strides can include column-major or arbitrary striding
- Adds `ArrayView::subspan()` overload for multi-dimensional ArrayViews
- Moves spacing field into `ArrayBase::m_strides`