### PR TITLE
Updates and bugfixes for blt@0.5.3

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -68,7 +68,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Fixed bug in `mint::mesh::UnstructuredMesh` constructors, affecting capacity.
   A missing factor was added.  If you worked around this by adding the factor yourself,
   you may want to undo that work-around.
-- Updates blt submodule to HEAD of develop on 24Jan2023
+- Updates blt submodule to blt@0.5.3
 - Updates uberenv submodule to HEAD of main on 12May2023
 - Updates to [conduit version 0.8.6](https://github.com/LLNL/conduit/compare/v0.8.3...v0.8.6)
 - Updates to [mfem version 4.5](https://github.com/mfem/mfem/releases/tag/v4.5)

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -11,21 +11,18 @@
 
 #include <algorithm>
 
-namespace axom
-{
-namespace internal
+namespace
 {
 /*!
- * \brief Calculate the new capacity for an Array given an increase in the
- *  size.
+ * \brief Calculate the new capacity for an Array given an increase in the size.
  * \param [in] v, the Array in question.
  * \param [in] increase, the amount the size will increase by
  * \return the new capacity.
  */
 template <typename T>
-IndexType calc_new_capacity(Array<T>& v, IndexType increase)
+axom::IndexType calc_new_capacity(axom::Array<T>& v, axom::IndexType increase)
 {
-  IndexType new_num_elements = v.size() + increase;
+  axom::IndexType new_num_elements = v.size() + increase;
   if(new_num_elements > v.capacity())
   {
     return new_num_elements * v.getResizeRatio() + 0.5;
@@ -41,7 +38,7 @@ IndexType calc_new_capacity(Array<T>& v, IndexType increase)
  * \return the new capacity.
  */
 template <typename T>
-void check_copy(const Array<T>& lhs, const Array<T>& rhs)
+void check_copy(const axom::Array<T>& lhs, const axom::Array<T>& rhs)
 {
   EXPECT_EQ(lhs.size(), rhs.size());
   EXPECT_EQ(lhs.capacity(), rhs.capacity());
@@ -56,12 +53,12 @@ void check_copy(const Array<T>& lhs, const Array<T>& rhs)
  * \param [in] v the Array to check.
  */
 template <typename T>
-void check_storage(Array<T>& v)
+void check_storage(axom::Array<T>& v)
 {
   EXPECT_TRUE(v.empty());
   EXPECT_EQ(v.size(), 0);
 
-  IndexType capacity = v.capacity();
+  axom::IndexType capacity = v.capacity();
   const T* data_ptr = v.data();
 
   /* Push back up to half the capacity. */
@@ -89,20 +86,20 @@ void check_storage(Array<T>& v)
   EXPECT_EQ(v.data(), data_ptr);
 
   /* Check the array data using the [] operator and the raw pointer. */
-  for(IndexType i = 0; i < capacity; ++i)
+  for(axom::IndexType i = 0; i < capacity; ++i)
   {
     EXPECT_EQ(v[i], i);
     EXPECT_EQ(data_ptr[i], i);
   }
 
   /* Set the array data to new values using the [] operator. */
-  for(IndexType i = 0; i < capacity; ++i)
+  for(axom::IndexType i = 0; i < capacity; ++i)
   {
     v[i] = i - 5 * i + 7;
   }
 
   /* Check the array data using the [] operator and the raw pointer. */
-  for(IndexType i = 0; i < capacity; ++i)
+  for(axom::IndexType i = 0; i < capacity; ++i)
   {
     EXPECT_EQ(v[i], i - 5 * i + 7);
     EXPECT_EQ(data_ptr[i], i - 5 * i + 7);
@@ -119,13 +116,13 @@ void check_storage(Array<T>& v)
  * \brief Check that the fill method is working properly.
  * \param [in] v the Array to check.
  */
-template <typename T, int DIM, MemorySpace SPACE>
-void check_fill(Array<T, DIM, SPACE>& v)
+template <typename T, int DIM, axom::MemorySpace SPACE>
+void check_fill(axom::Array<T, DIM, SPACE>& v)
 {
   constexpr T MAGIC_NUM_0 = 55;
   constexpr T MAGIC_NUM_1 = 6834;
-  const IndexType capacity = v.capacity();
-  const IndexType size = v.size();
+  const axom::IndexType capacity = v.capacity();
+  const axom::IndexType size = v.size();
   const double ratio = v.getResizeRatio();
   const T* const data_ptr = v.data();
 
@@ -140,10 +137,10 @@ void check_fill(Array<T, DIM, SPACE>& v)
 
   // To check entries, we copy data to a dynamic array
   int host_alloc_id = axom::getDefaultAllocatorID();
-  Array<T, DIM> v_host(v, host_alloc_id);
+  axom::Array<T, DIM> v_host(v, host_alloc_id);
 
   /* Check that the entries are all MAGIC_NUM_0. */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v_host[i], MAGIC_NUM_0);
   }
@@ -157,10 +154,10 @@ void check_fill(Array<T, DIM, SPACE>& v)
   EXPECT_EQ(ratio, v.getResizeRatio());
   EXPECT_EQ(data_ptr, v.data());
 
-  v_host = Array<T, DIM>(v, host_alloc_id);
+  v_host = axom::Array<T, DIM>(v, host_alloc_id);
 
   /* Check that the entries are all MAGIC_NUM_1. */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v_host[i], MAGIC_NUM_1);
   }
@@ -171,19 +168,18 @@ void check_fill(Array<T, DIM, SPACE>& v)
  * \param [in] v the Array to check.
  */
 template <typename T>
-void check_set(Array<T>& v)
+void check_set(axom::Array<T>& v)
 {
   constexpr T ZERO = 0;
-  const IndexType capacity = v.capacity();
-  const IndexType size = v.size();
+  const axom::IndexType capacity = v.capacity();
+  const axom::IndexType size = v.size();
   const double ratio = v.getResizeRatio();
   const T* const data_ptr = v.data();
 
-  /* Allocate a buffer half the size of the array. Fill it up with sequential
-   * values. */
-  const IndexType buffer_size = size / 2;
-  T* buffer = allocate<T>(buffer_size);
-  for(IndexType i = 0; i < buffer_size; ++i)
+  /* Allocate a buffer half the size of the array. Fill it up with sequential values. */
+  const axom::IndexType buffer_size = size / 2;
+  T* buffer = axom::allocate<T>(buffer_size);
+  for(axom::IndexType i = 0; i < buffer_size; ++i)
   {
     buffer[i] = i;
   }
@@ -191,8 +187,7 @@ void check_set(Array<T>& v)
   /* Set all the values in the array to zero. */
   v.fill(ZERO);
 
-  /* Set the first half of the elements in the array to the sequential values in
-   * buffer. */
+  /* Set the first half of the elements in the array to the sequential values in buffer. */
   v.set(buffer, buffer_size, 0);
 
   /* Check the array metadata. */
@@ -201,27 +196,25 @@ void check_set(Array<T>& v)
   EXPECT_EQ(ratio, v.getResizeRatio());
   EXPECT_EQ(data_ptr, v.data());
 
-  /* Check that the first half of the elements in the array are equivalent to
-   * those in buffer. */
-  for(IndexType i = 0; i < buffer_size; ++i)
+  /* Check that the first half of the elements in the array are equivalent to those in buffer. */
+  for(axom::IndexType i = 0; i < buffer_size; ++i)
   {
     EXPECT_EQ(v[i], buffer[i]);
   }
 
   /* Check that the second half of the elements in the array are all zero. */
-  for(IndexType i = buffer_size; i < size; ++i)
+  for(axom::IndexType i = buffer_size; i < size; ++i)
   {
     EXPECT_EQ(v[i], ZERO);
   }
 
   /* Reset the values in buffer to the next sequential values. */
-  for(IndexType i = 0; i < buffer_size; ++i)
+  for(axom::IndexType i = 0; i < buffer_size; ++i)
   {
     buffer[i] = i + buffer_size;
   }
 
-  /* Set the second half of the elements in the array to the new sequential
-   * values in buffer. */
+  /* Set the second half of the elements in the array to the new sequential values in buffer. */
   v.set(buffer, buffer_size, buffer_size);
 
   /* Check the array metadata. */
@@ -231,37 +224,37 @@ void check_set(Array<T>& v)
   EXPECT_EQ(data_ptr, v.data());
 
   /* Check that all the elements in the array now hold sequential values. */
-  for(IndexType i = 0; i < 2 * buffer_size; ++i)
+  for(axom::IndexType i = 0; i < 2 * buffer_size; ++i)
   {
     EXPECT_EQ(v[i], i);
   }
 
-  deallocate(buffer);
+  axom::deallocate(buffer);
 }
 
 /*!
- * \brief Check that the resizing of an Array is working properly.
+ * \brief Check that the resizing of an array is working properly.
  * \param [in] v the Array to check.
  */
 template <typename T>
-void check_resize(Array<T>& v)
+void check_resize(axom::Array<T>& v)
 {
   /* Resize the array up to the capacity */
-  IndexType capacity = v.capacity();
+  axom::IndexType capacity = v.capacity();
   v.resize(capacity);
-  IndexType size = capacity;
+  axom::IndexType size = capacity;
 
   /* Check that the size equals the capacity. */
   EXPECT_EQ(v.size(), v.capacity());
 
   /* Set the existing data in v */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     v[i] = static_cast<T>(i - 5 * i + 7);
   }
 
   /* Push back a new element, should resize. */
-  IndexType old_capacity = capacity;
+  axom::IndexType old_capacity = capacity;
   capacity = calc_new_capacity(v, 1);
   v.push_back(size - 5 * size + 7);
   size++;
@@ -272,18 +265,18 @@ void check_resize(Array<T>& v)
   EXPECT_EQ(v.size(), size);
 
   /* Check that the data is still intact. */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i - 5 * i + 7);
   }
 
   /* Push back 1000 elements */
-  const IndexType n_elements = 1000;
+  const axom::IndexType n_elements = 1000;
 
-  T* values = allocate<T>(n_elements);
-  for(IndexType i = 0; i < n_elements; ++i)
+  T* values = axom::allocate<T>(n_elements);
+  for(axom::IndexType i = 0; i < n_elements; ++i)
   {
-    IndexType i_real = i + size;
+    axom::IndexType i_real = i + size;
     values[i] = i_real - 5 * i_real + 7;
   }
 
@@ -297,7 +290,7 @@ void check_resize(Array<T>& v)
   EXPECT_EQ(v.size(), size);
 
   /* Check that the data is still intact. */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i - 5 * i + 7);
   }
@@ -313,7 +306,7 @@ void check_resize(Array<T>& v)
   EXPECT_EQ(v.data(), data_address);
 
   /* Check the data. */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i - 5 * i + 7);
   }
@@ -327,7 +320,7 @@ void check_resize(Array<T>& v)
   EXPECT_EQ(v.size(), size);
 
   /* Check that the data is intact. */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i - 5 * i + 7);
   }
@@ -344,14 +337,14 @@ void check_resize(Array<T>& v)
   EXPECT_EQ(v.size(), size);
 
   /* Check that the data is intact. */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i - 5 * i + 7);
   }
 
   /* Reset the data */
   T* data_ptr = v.data();
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     data_ptr[i] = i;
   }
@@ -359,7 +352,7 @@ void check_resize(Array<T>& v)
   /* Push back a bunch of elements to fill in up to the capacity. Resize should
    * not occur. */
   old_capacity = capacity;
-  for(IndexType i = size; i < old_capacity; ++i)
+  for(axom::IndexType i = size; i < old_capacity; ++i)
   {
     v.push_back(i);
     size++;
@@ -381,12 +374,12 @@ void check_resize(Array<T>& v)
   EXPECT_EQ(v.size(), size);
 
   /* Check the data. */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i);
   }
 
-  deallocate(values);
+  axom::deallocate(values);
   values = nullptr;
 }
 
@@ -395,23 +388,23 @@ void check_resize(Array<T>& v)
  * \param [in] v the Array to check.
  */
 template <typename T>
-void check_insert(Array<T>& v)
+void check_insert(axom::Array<T>& v)
 {
   /* Resize the array up to the capacity */
-  IndexType capacity = v.capacity();
+  axom::IndexType capacity = v.capacity();
   v.resize(capacity);
-  IndexType size = capacity;
+  axom::IndexType size = capacity;
 
   EXPECT_EQ(v.size(), v.capacity());
 
   /* Set the existing data in v */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     v[i] = i - 5 * i + 7;
   }
 
   /* Insert a new element, should resize. */
-  IndexType old_capacity = capacity;
+  axom::IndexType old_capacity = capacity;
   capacity = calc_new_capacity(v, 1);
   v.insert(v.size(), 1, size - 5 * size + 7);
   size++;
@@ -420,17 +413,17 @@ void check_insert(Array<T>& v)
   EXPECT_GT(capacity, old_capacity);
   EXPECT_EQ(v.capacity(), capacity);
   EXPECT_EQ(v.size(), size);
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i - 5 * i + 7);
   }
 
   /* Insert 1000 elements */
-  const IndexType n_elements = 1000;
-  T* values = allocate<T>(n_elements);
-  for(IndexType i = 0; i < n_elements; ++i)
+  const axom::IndexType n_elements = 1000;
+  T* values = axom::allocate<T>(n_elements);
+  for(axom::IndexType i = 0; i < n_elements; ++i)
   {
-    IndexType i_real = i + size;
+    axom::IndexType i_real = i + size;
     values[i] = i_real - 5 * i_real + 7;
   }
 
@@ -441,24 +434,24 @@ void check_insert(Array<T>& v)
   /* Check that it resizes properly */
   EXPECT_EQ(v.capacity(), capacity);
   EXPECT_EQ(v.size(), size);
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i - 5 * i + 7);
   }
 
   capacity = size;
   v.shrink();
-  IndexType n_insert_front = 100;
+  axom::IndexType n_insert_front = 100;
 
   /* Reset the data */
   T* data_ptr = v.data();
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     data_ptr[i] = i + n_insert_front;
   }
 
-  /* Insert into the front of the Array. */
-  for(IndexType i = n_insert_front - 1; i >= 0; i--)
+  /* Insert into the front of the array. */
+  for(axom::IndexType i = n_insert_front - 1; i >= 0; i--)
   {
     capacity = calc_new_capacity(v, 1);
     v.insert(0, 1, i);
@@ -468,41 +461,39 @@ void check_insert(Array<T>& v)
   /* Check that the insertion worked as expected */
   EXPECT_EQ(v.capacity(), capacity);
   EXPECT_EQ(v.size(), size);
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i);
   }
 
-  deallocate(values);
+  axom::deallocate(values);
   values = nullptr;
 }
 
 /*!
- * \brief Check that the insertion into an Array is working properly
- *        for iterators.
+ * \brief Check that the insertion into an Array is working properly for iterators.
  * \param [in] v the Array to check.
  */
 template <typename T>
-void check_insert_iterator(Array<T>& v)
+void check_insert_iterator(axom::Array<T>& v)
 {
   /* Resize the array up to the capacity */
-  IndexType capacity = v.capacity();
+  axom::IndexType capacity = v.capacity();
   v.resize(capacity);
-  IndexType size = capacity;
+  axom::IndexType size = capacity;
 
   EXPECT_EQ(v.size(), v.capacity());
 
   /* Set the existing data in v */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     v[i] = i - 5 * i + 7;
   }
 
   /* Insert a new element, should resize. */
-  IndexType old_capacity = capacity;
+  axom::IndexType old_capacity = capacity;
   capacity = calc_new_capacity(v, 1);
-  typename axom::Array<T>::ArrayIterator ret =
-    v.insert(v.end(), 1, size - 5 * size + 7);
+  auto ret = v.insert(v.end(), 1, size - 5 * size + 7);
   size++;
 
   /* Check that it resized properly */
@@ -510,23 +501,22 @@ void check_insert_iterator(Array<T>& v)
   EXPECT_EQ(v.capacity(), capacity);
   EXPECT_EQ(v.size(), size);
   EXPECT_EQ(ret, v.end() - 1);
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i - 5 * i + 7);
   }
 
   /* Insert 1000 elements */
-  const IndexType n_elements = 1000;
-  T* values = allocate<T>(n_elements);
-  for(IndexType i = 0; i < n_elements; ++i)
+  const axom::IndexType n_elements = 1000;
+  T* values = axom::allocate<T>(n_elements);
+  for(axom::IndexType i = 0; i < n_elements; ++i)
   {
-    IndexType i_real = i + size;
+    axom::IndexType i_real = i + size;
     values[i] = i_real - 5 * i_real + 7;
   }
 
   capacity = calc_new_capacity(v, n_elements);
-  typename axom::Array<T>::ArrayIterator ret2 =
-    v.insert(v.end(), n_elements, values);
+  auto ret2 = v.insert(v.end(), n_elements, values);
 
   EXPECT_EQ(ret2, v.begin() + size);
   size += n_elements;
@@ -534,27 +524,27 @@ void check_insert_iterator(Array<T>& v)
   /* Check that it resizes properly */
   EXPECT_EQ(v.capacity(), capacity);
   EXPECT_EQ(v.size(), size);
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i - 5 * i + 7);
   }
 
   capacity = size;
   v.shrink();
-  IndexType n_insert_front = 100;
+  axom::IndexType n_insert_front = 100;
 
   /* Reset the data */
   T* data_ptr = v.data();
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     data_ptr[i] = i + n_insert_front;
   }
 
   /* Insert into the front of the Array. */
-  for(IndexType i = n_insert_front - 1; i >= 0; i--)
+  for(axom::IndexType i = n_insert_front - 1; i >= 0; i--)
   {
     capacity = calc_new_capacity(v, 1);
-    typename axom::Array<T>::ArrayIterator ret3 = v.insert(v.begin(), 1, i);
+    auto ret3 = v.insert(v.begin(), 1, i);
     EXPECT_EQ(ret3, v.begin());
     EXPECT_EQ(i, v.front());
     size++;
@@ -563,12 +553,12 @@ void check_insert_iterator(Array<T>& v)
   /* Check that the insertion worked as expected */
   EXPECT_EQ(v.capacity(), capacity);
   EXPECT_EQ(v.size(), size);
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i);
   }
 
-  deallocate(values);
+  axom::deallocate(values);
   values = nullptr;
 }
 
@@ -577,42 +567,41 @@ void check_insert_iterator(Array<T>& v)
  * \param [in] v the Array to check.
  */
 template <typename T>
-void check_emplace(Array<T>& v)
+void check_emplace(axom::Array<T>& v)
 {
   /* Resize the array up to the capacity */
-  IndexType capacity = v.capacity();
+  axom::IndexType capacity = v.capacity();
   v.resize(capacity);
-  IndexType size = capacity;
+  axom::IndexType size = capacity;
 
   EXPECT_EQ(v.size(), v.capacity());
 
   /* Set the existing data in v */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     v[i] = i - 5 * i + 7;
   }
 
   /* Emplace a new element, should resize. */
-  IndexType old_capacity = capacity;
+  axom::IndexType old_capacity = capacity;
   capacity = calc_new_capacity(v, 1);
-  typename axom::Array<T>::ArrayIterator ret =
-    v.emplace(v.end(), size - 5 * size + 7);
+  auto ret = v.emplace(v.end(), size - 5 * size + 7);
   size++;
 
   /* Check that it resized properly */
   EXPECT_GT(capacity, old_capacity);
   EXPECT_EQ(v.size(), size);
   EXPECT_EQ(ret, v.end() - 1);
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i - 5 * i + 7);
   }
 
   /* Emplace_back 1000 elements */
-  const IndexType n_elements = 1000;
-  for(IndexType i = 0; i < n_elements; ++i)
+  const axom::IndexType n_elements = 1000;
+  for(axom::IndexType i = 0; i < n_elements; ++i)
   {
-    IndexType i_real = i + size;
+    axom::IndexType i_real = i + size;
     v.emplace_back(i_real - 5 * i_real + 7);
   }
 
@@ -620,27 +609,27 @@ void check_emplace(Array<T>& v)
 
   /* Check that it resizes properly */
   EXPECT_EQ(v.size(), size);
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i - 5 * i + 7);
   }
 
   capacity = size;
   v.shrink();
-  IndexType n_insert_front = 100;
+  axom::IndexType n_insert_front = 100;
 
   /* Reset the data */
   T* data_ptr = v.data();
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     data_ptr[i] = i + n_insert_front;
   }
 
   /* Emplace into the front of the Array. */
-  for(IndexType i = n_insert_front - 1; i >= 0; i--)
+  for(axom::IndexType i = n_insert_front - 1; i >= 0; i--)
   {
     capacity = calc_new_capacity(v, 1);
-    typename axom::Array<T>::ArrayIterator ret3 = v.emplace(v.begin(), i);
+    auto ret3 = v.emplace(v.begin(), i);
     EXPECT_EQ(ret3, v.begin());
     EXPECT_EQ(i, v.front());
     size++;
@@ -649,7 +638,7 @@ void check_emplace(Array<T>& v)
   /* Check that the emplace worked as expected */
   EXPECT_EQ(v.capacity(), capacity);
   EXPECT_EQ(v.size(), size);
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i);
   }
@@ -658,15 +647,15 @@ void check_emplace(Array<T>& v)
 // Clumsy implementation of https://numpy.org/doc/stable/reference/generated/numpy.zeros_like.html
 // for testing purposes
 template <typename T, int DIM>
-Array<T, DIM> zeros_like(const Array<T, DIM>& other)
+axom::Array<T, DIM> zeros_like(const axom::Array<T, DIM>& other)
 {
-  Array<T, DIM> zeros(other);
+  axom::Array<T, DIM> zeros(other);
   zeros.fill(T {});
   return zeros;
 }
 
 template <typename T, int DIM>
-void check_swap(Array<T, DIM>& v)
+void check_swap(axom::Array<T, DIM>& v)
 {
   auto v_two = zeros_like(v);
 
@@ -698,7 +687,7 @@ void check_swap(Array<T, DIM>& v)
 }
 
 template <typename T, int DIM, axom::MemorySpace SPACE>
-void check_alloc(Array<T, DIM, SPACE>& v, const int id)
+void check_alloc(axom::Array<T, DIM, SPACE>& v, const int id)
 {
   // Verify allocation
   EXPECT_EQ(v.getAllocatorID(), id);
@@ -717,32 +706,32 @@ void check_alloc(Array<T, DIM, SPACE>& v, const int id)
  * \param [in] v the external array to check.
  */
 template <typename T>
-void check_external_view(ArrayView<T>& v)
+void check_external_view(axom::ArrayView<T>& v)
 {
-  const IndexType size = v.size();
-  const IndexType num_values = size;
+  const axom::IndexType size = v.size();
+  const axom::IndexType num_values = size;
   T* const data_ptr = v.data();
 
   /* Set the elements in the array. */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     v[i] = i;
   }
 
   /* Check the elements using the raw pointer. */
-  for(IndexType i = 0; i < num_values; ++i)
+  for(axom::IndexType i = 0; i < num_values; ++i)
   {
     EXPECT_EQ(data_ptr[i], i);
   }
 
   /* Set the elements using the raw pointer. */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     data_ptr[i] = i * i;
   }
 
   /* Check the elements using the () operator. */
-  for(IndexType i = 0; i < size; ++i)
+  for(axom::IndexType i = 0; i < size; ++i)
   {
     EXPECT_EQ(v[i], i * i);
   }
@@ -763,7 +752,7 @@ __global__ void assign_raw(T* data, int N)
 }
 
 template <typename T, int DIM, axom::MemorySpace SPACE>
-__global__ void assign_view(ArrayView<T, DIM, SPACE> view)
+__global__ void assign_view(axom::ArrayView<T, DIM, SPACE> view)
 {
   for(int i = 0; i < view.size(); i++)
   {
@@ -776,24 +765,24 @@ __global__ void assign_view(ArrayView<T, DIM, SPACE> view)
  * \param [in] v the array to check.
  */
 template <typename T, int DIM, axom::MemorySpace SPACE>
-void check_device(Array<T, DIM, SPACE>& v)
+void check_device(axom::Array<T, DIM, SPACE>& v)
 {
-  const IndexType size = v.size();
+  const axom::IndexType size = v.size();
   // Then assign to it via a raw device pointer
   assign_raw<<<1, 1>>>(v.data(), size);
 
   // Check the contents of the array by assigning to a Dynamic array
   // The Umpire allocator should be Host, so we can access it from the CPU
   int host_alloc_id = axom::getDefaultAllocatorID();
-  Array<T, 1> check_raw_array_dynamic(v, host_alloc_id);
+  axom::Array<T, 1> check_raw_array_dynamic(v, host_alloc_id);
   EXPECT_EQ(check_raw_array_dynamic.size(), size);
   for(int i = 0; i < check_raw_array_dynamic.size(); i++)
   {
     EXPECT_EQ(check_raw_array_dynamic[i], i);
   }
 
-  // Then check the contents by assigning to an explicitly Host array
-  Array<T, 1, axom::MemorySpace::Host> check_raw_array_host = v;
+  // Then check the contents by assigning to an explicitly Host Array
+  axom::Array<T, 1, axom::MemorySpace::Host> check_raw_array_host = v;
   EXPECT_EQ(check_raw_array_host.size(), size);
   for(int i = 0; i < check_raw_array_host.size(); i++)
   {
@@ -801,12 +790,12 @@ void check_device(Array<T, DIM, SPACE>& v)
   }
 
   // Then modify the underlying data via a view
-  ArrayView<T, DIM, SPACE> view(v);
+  axom::ArrayView<T, DIM, SPACE> view(v);
   assign_view<<<1, 1>>>(view);
 
   // Check the contents of the array by assigning to a Dynamic array
   // The Umpire allocator should be Host, so we can access it from the CPU
-  Array<T, 1> check_view_array_dynamic(view, host_alloc_id);
+  axom::Array<T, 1> check_view_array_dynamic(view, host_alloc_id);
   EXPECT_EQ(check_view_array_dynamic.size(), size);
   for(int i = 0; i < check_view_array_dynamic.size(); i++)
   {
@@ -814,7 +803,7 @@ void check_device(Array<T, DIM, SPACE>& v)
   }
 
   // Then check the contents by assigning to an explicitly Host array
-  Array<T, 1, axom::MemorySpace::Host> check_view_array_host = view;
+  axom::Array<T, 1, axom::MemorySpace::Host> check_view_array_host = view;
   EXPECT_EQ(check_view_array_host.size(), size);
   for(int i = 0; i < check_view_array_host.size(); i++)
   {
@@ -835,7 +824,7 @@ __global__ void assign_raw_2d(T* data, int M, int N)
 }
 
 template <typename T, axom::MemorySpace SPACE>
-__global__ void assign_view_2d(ArrayView<T, 2, SPACE> view)
+__global__ void assign_view_2d(axom::ArrayView<T, 2, SPACE> view)
 {
   for(int i = 0; i < view.shape()[0]; i++)
   {
@@ -851,18 +840,18 @@ __global__ void assign_view_2d(ArrayView<T, 2, SPACE> view)
  * \param [in] v the array to check.
  */
 template <typename T, axom::MemorySpace SPACE>
-void check_device_2D(Array<T, 2, SPACE>& v)
+void check_device_2D(axom::Array<T, 2, SPACE>& v)
 {
-  const IndexType size = v.size();
-  const IndexType M = v.shape()[0];
-  const IndexType N = v.shape()[1];
+  const axom::IndexType size = v.size();
+  const axom::IndexType M = v.shape()[0];
+  const axom::IndexType N = v.shape()[1];
   // Then assign to it via a raw device pointer
   assign_raw_2d<<<1, 1>>>(v.data(), M, N);
 
   // Check the contents of the array by assigning to a Dynamic array
   // The Umpire allocator should be Host, so we can access it from the CPU
   int host_alloc_id = axom::getDefaultAllocatorID();
-  Array<T, 2> check_raw_array_dynamic(v, host_alloc_id);
+  axom::Array<T, 2> check_raw_array_dynamic(v, host_alloc_id);
   EXPECT_EQ(check_raw_array_dynamic.size(), size);
   EXPECT_EQ(check_raw_array_dynamic.shape(), v.shape());
 
@@ -875,7 +864,7 @@ void check_device_2D(Array<T, 2, SPACE>& v)
   }
 
   // Then check the contents by assigning to an explicitly Host array
-  Array<T, 2, axom::MemorySpace::Host> check_raw_array_host = v;
+  axom::Array<T, 2, axom::MemorySpace::Host> check_raw_array_host = v;
   EXPECT_EQ(check_raw_array_host.size(), size);
   EXPECT_EQ(check_raw_array_host.shape(), v.shape());
 
@@ -883,17 +872,17 @@ void check_device_2D(Array<T, 2, SPACE>& v)
   {
     for(int j = 0; j < N; j++)
     {
-      EXPECT_EQ(check_raw_array_host(i, j), i * i + j);
+      EXPECT_EQ(check_raw_axom::Array_host(i, j), i * i + j);
     }
   }
 
   // Then modify the underlying data via a view
-  ArrayView<T, 2, SPACE> view(v);
+  axom::ArrayView<T, 2, SPACE> view(v);
   assign_view_2d<<<1, 1>>>(view);
 
   // Check the contents of the array by assigning to a Dynamic array
   // The Umpire allocator should be Host, so we can access it from the CPU
-  Array<T, 2> check_view_array_dynamic(view, host_alloc_id);
+  axom::Array<T, 2> check_view_array_dynamic(view, host_alloc_id);
   EXPECT_EQ(check_view_array_dynamic.size(), size);
   EXPECT_EQ(check_view_array_dynamic.shape(), v.shape());
 
@@ -906,7 +895,7 @@ void check_device_2D(Array<T, 2, SPACE>& v)
   }
 
   // Then check the contents by assigning to an explicitly Host array
-  Array<T, 2, axom::MemorySpace::Host> check_view_array_host = view;
+  axom::Array<T, 2, axom::MemorySpace::Host> check_view_array_host = view;
   EXPECT_EQ(check_view_array_host.size(), size);
   EXPECT_EQ(check_view_array_host.shape(), v.shape());
 
@@ -921,7 +910,7 @@ void check_device_2D(Array<T, 2, SPACE>& v)
 
 #endif  // defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
 
-} /* end namespace internal */
+}  // end anonymous namespace
 
 //------------------------------------------------------------------------------
 // UNIT TESTS
@@ -930,29 +919,29 @@ void check_device_2D(Array<T, 2, SPACE>& v)
 //------------------------------------------------------------------------------
 TEST(core_array, checkStorage)
 {
-  constexpr IndexType ZERO = 0;
+  constexpr axom::IndexType ZERO = 0;
 
-  for(IndexType capacity = 2; capacity < 512; capacity *= 2)
+  for(axom::IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
-    Array<int> v_int(ZERO, capacity);
-    internal::check_storage(v_int);
+    axom::Array<int> v_int(ZERO, capacity);
+    ::check_storage(v_int);
 
-    Array<double> v_double(ZERO, capacity);
-    internal::check_storage(v_double);
+    axom::Array<double> v_double(ZERO, capacity);
+    ::check_storage(v_double);
   }
 }
 
 //------------------------------------------------------------------------------
 TEST(core_array, checkFill)
 {
-  for(IndexType capacity = 2; capacity < 512; capacity *= 2)
+  for(axom::IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
-    IndexType size = capacity / 2;
-    Array<int> v_int(size, capacity);
-    internal::check_fill(v_int);
+    axom::IndexType size = capacity / 2;
+    axom::Array<int> v_int(size, capacity);
+    ::check_fill(v_int);
 
-    Array<double> v_double(size, capacity);
-    internal::check_fill(v_double);
+    axom::Array<double> v_double(size, capacity);
+    ::check_fill(v_double);
   }
 }
 
@@ -960,14 +949,14 @@ TEST(core_array, checkFill)
 #if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
 TEST(core_array, checkFillDevice)
 {
-  for(IndexType capacity = 2; capacity < 512; capacity *= 2)
+  for(axom::IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
-    IndexType size = capacity / 2;
-    Array<int, 1, MemorySpace::Device> v_int(size, capacity);
-    internal::check_fill(v_int);
+    axom::IndexType size = capacity / 2;
+    axom::Array<int, 1, MemorySpace::Device> v_int(size, capacity);
+    ::check_fill(v_int);
 
-    Array<double, 1, MemorySpace::Device> v_double(size, capacity);
-    internal::check_fill(v_double);
+    axom::Array<double, 1, MemorySpace::Device> v_double(size, capacity);
+    ::check_fill(v_double);
   }
 }
 #endif
@@ -975,32 +964,32 @@ TEST(core_array, checkFillDevice)
 //------------------------------------------------------------------------------
 TEST(core_array, checkSet)
 {
-  for(IndexType size = 2; size < 512; size *= 2)
+  for(axom::IndexType size = 2; size < 512; size *= 2)
   {
-    Array<int> v_int(size);
-    internal::check_set(v_int);
+    axom::Array<int> v_int(size);
+    ::check_set(v_int);
 
-    Array<double> v_double(size);
-    internal::check_set(v_double);
+    axom::Array<double> v_double(size);
+    ::check_set(v_double);
   }
 }
 
 //------------------------------------------------------------------------------
 TEST(core_array, checkResize)
 {
-  constexpr IndexType ZERO = 0;
+  constexpr axom::IndexType ZERO = 0;
 
   for(double ratio = 1.0; ratio <= 2.0; ratio += 0.5)
   {
-    for(IndexType capacity = 2; capacity <= 512; capacity *= 2)
+    for(axom::IndexType capacity = 2; capacity <= 512; capacity *= 2)
     {
-      Array<int> v_int(ZERO, capacity);
+      axom::Array<int> v_int(ZERO, capacity);
       v_int.setResizeRatio(ratio);
-      internal::check_resize(v_int);
+      ::check_resize(v_int);
 
-      Array<double> v_double(ZERO, capacity);
+      axom::Array<double> v_double(ZERO, capacity);
       v_double.setResizeRatio(ratio);
-      internal::check_resize(v_double);
+      ::check_resize(v_double);
     }
   }
 }
@@ -1008,31 +997,31 @@ TEST(core_array, checkResize)
 //------------------------------------------------------------------------------
 TEST(core_array_DeathTest, checkResize)
 {
-  constexpr IndexType ZERO = 0;
-  IndexType size = 100;
+  constexpr axom::IndexType ZERO = 0;
+  axom::IndexType size = 100;
 
   /* Resizing isn't allowed with a ratio less than 1.0. */
-  Array<int> v_int(ZERO, size);
+  axom::Array<int> v_int(ZERO, size);
   v_int.setResizeRatio(0.99);
-  EXPECT_DEATH_IF_SUPPORTED(internal::check_resize(v_int), "");
+  EXPECT_DEATH_IF_SUPPORTED(::check_resize(v_int), "");
 }
 
 //------------------------------------------------------------------------------
 TEST(core_array, checkInsert)
 {
-  constexpr IndexType ZERO = 0;
+  constexpr axom::IndexType ZERO = 0;
 
   for(double ratio = 1.0; ratio <= 2.0; ratio += 0.5)
   {
-    for(IndexType capacity = 2; capacity <= 512; capacity *= 2)
+    for(axom::IndexType capacity = 2; capacity <= 512; capacity *= 2)
     {
-      Array<int> v_int(ZERO, capacity);
+      axom::Array<int> v_int(ZERO, capacity);
       v_int.setResizeRatio(ratio);
-      internal::check_insert(v_int);
+      ::check_insert(v_int);
 
-      Array<double> v_double(ZERO, capacity);
+      axom::Array<double> v_double(ZERO, capacity);
       v_double.setResizeRatio(ratio);
-      internal::check_insert(v_double);
+      ::check_insert(v_double);
     }
   }
 }
@@ -1040,19 +1029,19 @@ TEST(core_array, checkInsert)
 //------------------------------------------------------------------------------
 TEST(core_array, checkInsertIterator)
 {
-  constexpr IndexType ZERO = 0;
+  constexpr axom::IndexType ZERO = 0;
 
   for(double ratio = 1.0; ratio <= 2.0; ratio += 0.5)
   {
-    for(IndexType capacity = 10; capacity <= 512; capacity *= 2)
+    for(axom::IndexType capacity = 10; capacity <= 512; capacity *= 2)
     {
-      Array<int> v_int(ZERO, capacity);
+      axom::Array<int> v_int(ZERO, capacity);
       v_int.setResizeRatio(ratio);
-      internal::check_insert_iterator(v_int);
+      ::check_insert_iterator(v_int);
 
-      Array<double> v_double(ZERO, capacity);
+      axom::Array<double> v_double(ZERO, capacity);
       v_double.setResizeRatio(ratio);
-      internal::check_insert_iterator(v_double);
+      ::check_insert_iterator(v_double);
     }
   }
 }
@@ -1060,19 +1049,19 @@ TEST(core_array, checkInsertIterator)
 //------------------------------------------------------------------------------
 TEST(core_array, checkEmplace)
 {
-  constexpr IndexType ZERO = 0;
+  constexpr axom::IndexType ZERO = 0;
 
   for(double ratio = 1.0; ratio <= 2.0; ratio += 0.5)
   {
-    for(IndexType capacity = 10; capacity <= 512; capacity *= 2)
+    for(axom::IndexType capacity = 10; capacity <= 512; capacity *= 2)
     {
-      Array<int> v_int(ZERO, capacity);
+      axom::Array<int> v_int(ZERO, capacity);
       v_int.setResizeRatio(ratio);
-      internal::check_emplace(v_int);
+      ::check_emplace(v_int);
 
-      Array<double> v_double(ZERO, capacity);
+      axom::Array<double> v_double(ZERO, capacity);
       v_double.setResizeRatio(ratio);
-      internal::check_emplace(v_double);
+      ::check_emplace(v_double);
     }
   }
 }
@@ -1080,19 +1069,19 @@ TEST(core_array, checkEmplace)
 //------------------------------------------------------------------------------
 TEST(core_array, checkSwap)
 {
-  for(IndexType size = 10; size <= 512; size *= 2)
+  for(axom::IndexType size = 10; size <= 512; size *= 2)
   {
-    Array<int> v_int(size);
-    internal::check_swap(v_int);
+    axom::Array<int> v_int(size);
+    ::check_swap(v_int);
 
-    Array<double> v_double(size);
-    internal::check_swap(v_double);
+    axom::Array<double> v_double(size);
+    ::check_swap(v_double);
 
-    Array<int, 2> v_int_2d(size, size);
-    internal::check_swap(v_int_2d);
+    axom::Array<int, 2> v_int_2d(size, size);
+    ::check_swap(v_int_2d);
 
-    Array<double, 2> v_double_2d(size, size);
-    internal::check_swap(v_double);
+    axom::Array<double, 2> v_double_2d(size, size);
+    ::check_swap(v_double);
   }
 }
 
@@ -1124,64 +1113,68 @@ TEST(core_array, checkAlloc)
 
   for(double ratio = 1.0; ratio <= 2.0; ratio += 0.5)
   {
-    for(IndexType capacity = 4; capacity <= 512; capacity *= 2)
+    for(axom::IndexType capacity = 4; capacity <= 512; capacity *= 2)
     {
       // First use the dynamic option
       for(int id : memory_locations)
       {
-        Array<int, 1, axom::MemorySpace::Dynamic> v_int(capacity, capacity, id);
-        internal::check_alloc(v_int, id);
-
-        Array<double, 1, axom::MemorySpace::Dynamic> v_double(capacity,
+        axom::Array<int, 1, axom::MemorySpace::Dynamic> v_int(capacity,
                                                               capacity,
                                                               id);
-        internal::check_alloc(v_double, id);
+        ::check_alloc(v_int, id);
+
+        axom::Array<double, 1, axom::MemorySpace::Dynamic> v_double(capacity,
+                                                                    capacity,
+                                                                    id);
+        ::check_alloc(v_double, id);
       }
 // Then, if Umpire is available, we can use the space as an explicit template parameter
 #ifdef AXOM_USE_UMPIRE
   #ifdef UMPIRE_ENABLE_DEVICE
-      Array<int, 1, axom::MemorySpace::Device> v_int_device(capacity, capacity);
-      internal::check_alloc(
-        v_int_device,
-        axom::getUmpireResourceAllocatorID(umpire::resource::Device));
-      Array<double, 1, axom::MemorySpace::Device> v_double_device(capacity,
+      axom::Array<int, 1, axom::MemorySpace::Device> v_int_device(capacity,
                                                                   capacity);
-      internal::check_alloc(
-        v_double_device,
-        axom::getUmpireResourceAllocatorID(umpire::resource::Device));
+      ::check_alloc(v_int_device,
+                    axom::getUmpireResourceAllocatorID(umpire::resource::Device));
+      axom::Array<double, 1, axom::MemorySpace::Device> v_double_device(capacity,
+                                                                        capacity);
+      ::check_alloc(v_double_device,
+                    axom::getUmpireResourceAllocatorID(umpire::resource::Device));
   #endif
   #ifdef UMPIRE_ENABLE_UM
-      Array<int, 1, axom::MemorySpace::Unified> v_int_unified(capacity, capacity);
-      internal::check_alloc(
+      axom::Array<int, 1, axom::MemorySpace::Unified> v_int_unified(capacity,
+                                                                    capacity);
+      ::check_alloc(
         v_int_unified,
         axom::getUmpireResourceAllocatorID(umpire::resource::Unified));
-      Array<double, 1, axom::MemorySpace::Unified> v_double_unified(capacity,
-                                                                    capacity);
-      internal::check_alloc(
+      axom::Array<double, 1, axom::MemorySpace::Unified> v_double_unified(
+        capacity,
+        capacity);
+      ::check_alloc(
         v_double_unified,
         axom::getUmpireResourceAllocatorID(umpire::resource::Unified));
   #endif
   #ifdef UMPIRE_ENABLE_CONST
-      Array<int, 1, axom::MemorySpace::Constant> v_int_const(capacity, capacity);
-      internal::check_alloc(
+      axom::Array<int, 1, axom::MemorySpace::Constant> v_int_const(capacity,
+                                                                   capacity);
+      ::check_alloc(
         v_int_const,
         axom::getUmpireResourceAllocatorID(umpire::resource::Constant));
-      Array<double, 1, axom::MemorySpace::Constant> v_double_const(capacity,
-                                                                   capacity);
-      internal::check_alloc(
+      axom::Array<double, 1, axom::MemorySpace::Constant> v_double_const(
+        capacity,
+        capacity);
+      ::check_alloc(
         v_double_const,
         axom::getUmpireResourceAllocatorID(umpire::resource::Constant));
   #endif
   #ifdef UMPIRE_ENABLE_PINNED
-      Array<int, 1, axom::MemorySpace::Pinned> v_int_pinned(capacity, capacity);
-      internal::check_alloc(
-        v_int_pinned,
-        axom::getUmpireResourceAllocatorID(umpire::resource::Pinned));
-      Array<double, 1, axom::MemorySpace::Pinned> v_double_pinned(capacity,
+      axom::Array<int, 1, axom::MemorySpace::Pinned> v_int_pinned(capacity,
                                                                   capacity);
-      internal::check_alloc(
-        v_double_pinned,
-        axom::getUmpireResourceAllocatorID(umpire::resource::Pinned));
+      ::check_alloc(v_int_pinned,
+                    axom::getUmpireResourceAllocatorID(umpire::resource::Pinned));
+      axom::Array<double, 1, axom::MemorySpace::Pinned> v_double_pinned(capacity,
+                                                                        capacity);
+      ::check_alloc(v_double_pinned,
+                    axom::getUmpireResourceAllocatorID(umpire::resource::Pinned));
   #endif
 #endif
     }
@@ -1192,8 +1185,8 @@ TEST(core_array, checkAlloc)
 TEST(core_array, checkExternalView)
 {
   constexpr double MAGIC_NUM = 5683578.8;
-  constexpr IndexType MAX_SIZE = 256;
-  constexpr IndexType MAX_VALUES = MAX_SIZE;
+  constexpr axom::IndexType MAX_SIZE = 256;
+  constexpr axom::IndexType MAX_VALUES = MAX_SIZE;
   union DataBuffer
   {
     int ints[MAX_SIZE];
@@ -1203,21 +1196,21 @@ TEST(core_array, checkExternalView)
   DataBuffer buffer;
   std::fill_n(buffer.doubles, MAX_VALUES, MAGIC_NUM);
 
-  for(IndexType size = 16; size <= MAX_SIZE; size *= 2)
+  for(axom::IndexType size = 16; size <= MAX_SIZE; size *= 2)
   {
-    ArrayView<int> v_int_view(buffer.ints, size);
+    axom::ArrayView<int> v_int_view(buffer.ints, size);
     EXPECT_EQ(v_int_view.data(), buffer.ints);
-    internal::check_external_view(v_int_view);
+    ::check_external_view(v_int_view);
 
-    ArrayView<double> v_double_view(buffer.doubles, size);
+    axom::ArrayView<double> v_double_view(buffer.doubles, size);
     EXPECT_EQ(v_double_view.data(), buffer.doubles);
-    internal::check_external_view(v_double_view);
+    ::check_external_view(v_double_view);
 
     /* Set v_double's data to MAGIC_NUM */
     std::fill_n(v_double_view.data(), size, MAGIC_NUM);
 
     /* Check that the data still exists in the buffer */
-    for(IndexType i = 0; i < MAX_VALUES; ++i)
+    for(axom::IndexType i = 0; i < MAX_VALUES; ++i)
     {
       EXPECT_EQ(buffer.doubles[i], MAGIC_NUM);
     }
@@ -1243,15 +1236,13 @@ TEST(core_array, checkIterator)
   EXPECT_EQ(v_int.size(), SIZE);
 
   /* Erase nothing */
-  axom::Array<int>::ArrayIterator ret1 =
-    v_int.erase(v_int.begin() + SIZE / 2, v_int.begin() + SIZE / 2);
+  auto ret1 = v_int.erase(v_int.begin() + SIZE / 2, v_int.begin() + SIZE / 2);
 
   EXPECT_EQ(ret1, v_int.begin() + SIZE / 2);
   EXPECT_EQ(v_int.size(), SIZE);
 
   /* Erase half the elements */
-  axom::Array<int>::ArrayIterator ret2 =
-    v_int.erase(v_int.begin(), v_int.begin() + SIZE / 2);
+  auto ret2 = v_int.erase(v_int.begin(), v_int.begin() + SIZE / 2);
 
   EXPECT_EQ(ret2, v_int.begin());
   EXPECT_EQ(*v_int.begin(), SIZE / 2);
@@ -1261,13 +1252,13 @@ TEST(core_array, checkIterator)
   EXPECT_EQ(v_int.size(), SIZE / 2);
 
   /* Erase first, last elements */
-  axom::Array<int>::ArrayIterator ret3 = v_int.erase(v_int.begin());
+  auto ret3 = v_int.erase(v_int.begin());
 
   EXPECT_EQ(ret3, v_int.begin());
   EXPECT_EQ(*v_int.begin(), SIZE / 2 + 1);
   EXPECT_EQ(v_int.front(), SIZE / 2 + 1);
 
-  axom::Array<int>::ArrayIterator ret4 = v_int.erase(v_int.end() - 1);
+  auto ret4 = v_int.erase(v_int.end() - 1);
 
   EXPECT_EQ(ret4, v_int.end());
   EXPECT_EQ(*(v_int.end() - 1), SIZE - 2);
@@ -1339,41 +1330,41 @@ TEST(core_array, check_move_copy)
   constexpr int MAGIC_INT = 255;
   constexpr double MAGIC_DOUBLE = 5683578.8;
 
-  for(IndexType capacity = 2; capacity < 512; capacity *= 2)
+  for(axom::IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
-    IndexType size = capacity;
+    axom::IndexType size = capacity;
 
-    /* Check copy and move semantics for Array of ints */
-    Array<int> v_int(size, capacity);
+    /* Check copy and move semantics for array of ints */
+    axom::Array<int> v_int(size, capacity);
     v_int.fill(MAGIC_INT);
 
-    Array<int> v_int_copy_ctor(v_int);
-    Array<int> v_int_copy_assign;
+    axom::Array<int> v_int_copy_ctor(v_int);
+    axom::Array<int> v_int_copy_assign;
     v_int_copy_assign = v_int;
     EXPECT_EQ(v_int, v_int_copy_ctor);
     EXPECT_EQ(v_int, v_int_copy_assign);
 
-    Array<int> v_int_move_assign;
+    axom::Array<int> v_int_move_assign;
     v_int_move_assign = std::move(v_int_copy_assign);
-    Array<int> v_int_move_ctor = std::move(v_int_copy_ctor);
+    axom::Array<int> v_int_move_ctor = std::move(v_int_copy_ctor);
     EXPECT_EQ(v_int, v_int_move_assign);
     EXPECT_EQ(v_int, v_int_move_ctor);
     EXPECT_EQ(v_int_copy_assign.data(), nullptr);
     EXPECT_EQ(v_int_copy_ctor.data(), nullptr);
 
-    /* Check copy and move semantics for Array of doubles */
-    Array<double> v_double(size, capacity);
+    /* Check copy and move semantics for array of doubles */
+    axom::Array<double> v_double(size, capacity);
     v_double.fill(MAGIC_DOUBLE);
 
-    Array<double> v_double_copy_ctor(v_double);
-    Array<double> v_double_copy_assign;
+    axom::Array<double> v_double_copy_ctor(v_double);
+    axom::Array<double> v_double_copy_assign;
     v_double_copy_assign = v_double;
     EXPECT_EQ(v_double, v_double_copy_ctor);
     EXPECT_EQ(v_double, v_double_copy_assign);
 
-    Array<double> v_double_move_assign;
+    axom::Array<double> v_double_move_assign;
     v_double_move_assign = std::move(v_double_copy_assign);
-    Array<double> v_double_move_ctor = std::move(v_double_copy_ctor);
+    axom::Array<double> v_double_move_ctor = std::move(v_double_copy_ctor);
     EXPECT_EQ(v_double, v_double_move_assign);
     EXPECT_EQ(v_double, v_double_move_ctor);
     EXPECT_EQ(v_double_copy_assign.data(), nullptr);
@@ -1387,16 +1378,16 @@ TEST(core_array, check_move_copy_multidimensional)
   constexpr int MAGIC_INT = 255;
   constexpr double MAGIC_DOUBLE = 5683578.8;
 
-  for(IndexType capacity = 2; capacity < 512; capacity *= 2)
+  for(axom::IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
-    IndexType size = capacity;
+    axom::IndexType size = capacity;
 
-    /* Check copy and move semantics for Array of ints */
-    Array<int, 2> v_int(size, size);
+    /* Check copy and move semantics for array of ints */
+    axom::Array<int, 2> v_int(size, size);
     v_int.fill(MAGIC_INT);
 
-    Array<int, 2> v_int_copy_ctor(v_int);
-    Array<int, 2> v_int_copy_assign;
+    axom::Array<int, 2> v_int_copy_ctor(v_int);
+    axom::Array<int, 2> v_int_copy_assign;
     v_int_copy_assign = v_int;
     EXPECT_EQ(v_int, v_int_copy_ctor);
     EXPECT_EQ(v_int, v_int_copy_assign);
@@ -1404,9 +1395,9 @@ TEST(core_array, check_move_copy_multidimensional)
     EXPECT_EQ(v_int.strides(), v_int_copy_ctor.strides());
     EXPECT_EQ(v_int.strides(), v_int_copy_assign.strides());
 
-    Array<int, 2> v_int_move_assign;
+    axom::Array<int, 2> v_int_move_assign;
     v_int_move_assign = std::move(v_int_copy_assign);
-    Array<int, 2> v_int_move_ctor = std::move(v_int_copy_ctor);
+    axom::Array<int, 2> v_int_move_ctor = std::move(v_int_copy_ctor);
     EXPECT_EQ(v_int, v_int_move_assign);
     EXPECT_EQ(v_int, v_int_move_ctor);
     EXPECT_EQ(v_int.strides(), v_int_move_assign.strides());
@@ -1414,12 +1405,12 @@ TEST(core_array, check_move_copy_multidimensional)
     EXPECT_EQ(v_int_copy_assign.data(), nullptr);
     EXPECT_EQ(v_int_copy_ctor.data(), nullptr);
 
-    /* Check copy and move semantics for Array of doubles */
-    Array<double, 2> v_double(size, size);
+    /* Check copy and move semantics for array of doubles */
+    axom::Array<double, 2> v_double(size, size);
     v_double.fill(MAGIC_DOUBLE);
 
-    Array<double, 2> v_double_copy_ctor(v_double);
-    Array<double, 2> v_double_copy_assign;
+    axom::Array<double, 2> v_double_copy_ctor(v_double);
+    axom::Array<double, 2> v_double_copy_assign;
     v_double_copy_assign = v_double;
     EXPECT_EQ(v_double, v_double_copy_ctor);
     EXPECT_EQ(v_double, v_double_copy_assign);
@@ -1427,9 +1418,9 @@ TEST(core_array, check_move_copy_multidimensional)
     EXPECT_EQ(v_double.strides(), v_double_copy_ctor.strides());
     EXPECT_EQ(v_double.strides(), v_double_copy_assign.strides());
 
-    Array<double, 2> v_double_move_assign;
+    axom::Array<double, 2> v_double_move_assign;
     v_double_move_assign = std::move(v_double_copy_assign);
-    Array<double, 2> v_double_move_ctor = std::move(v_double_copy_ctor);
+    axom::Array<double, 2> v_double_move_ctor = std::move(v_double_copy_ctor);
     EXPECT_EQ(v_double, v_double_move_assign);
     EXPECT_EQ(v_double, v_double_move_ctor);
     EXPECT_EQ(v_double.strides(), v_double_move_assign.strides());
@@ -1445,26 +1436,26 @@ TEST(core_array, check_view_move_copy)
   constexpr int MAGIC_INT = 255;
   constexpr double MAGIC_DOUBLE = 5683578.8;
 
-  for(IndexType capacity = 2; capacity < 512; capacity *= 2)
+  for(axom::IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
-    IndexType size = capacity;
+    axom::IndexType size = capacity;
 
     /* Check copy and move semantics for ArrayView of ints */
     std::vector<int> ints(size, MAGIC_INT);
-    ArrayView<int> v_int_view(ints.data(), size);
+    axom::ArrayView<int> v_int_view(ints.data(), size);
 
-    ArrayView<int> v_int_view_copy_ctor(v_int_view);
-    ArrayView<int> v_int_view_copy_assign;
+    axom::ArrayView<int> v_int_view_copy_ctor(v_int_view);
+    axom::ArrayView<int> v_int_view_copy_assign;
     v_int_view_copy_assign = v_int_view;
     EXPECT_EQ(v_int_view, v_int_view_copy_ctor);
     EXPECT_EQ(v_int_view, v_int_view_copy_assign);
 
     /* Check copy and move semantics for ArrayView of doubles */
     std::vector<double> doubles(size, MAGIC_DOUBLE);
-    ArrayView<double> v_double_view(doubles.data(), size);
+    axom::ArrayView<double> v_double_view(doubles.data(), size);
 
-    ArrayView<double> v_double_view_copy_ctor(v_double_view);
-    ArrayView<double> v_double_view_copy_assign;
+    axom::ArrayView<double> v_double_view_copy_ctor(v_double_view);
+    axom::ArrayView<double> v_double_view_copy_assign;
     v_double_view_copy_assign = v_double_view;
     EXPECT_EQ(v_double_view, v_double_view_copy_ctor);
     EXPECT_EQ(v_double_view, v_double_view_copy_assign);
@@ -1478,12 +1469,12 @@ TEST(core_array, check_multidimensional)
   constexpr double MAGIC_DOUBLE = 5683578.8;
 
   // First test multidimensional int arrays
-  Array<int, 2> v_int;
+  axom::Array<int, 2> v_int;
   v_int.resize(2, 2);
   v_int.fill(MAGIC_INT);
   // Make sure the number of elements and contents are correct
   EXPECT_EQ(v_int.size(), 2 * 2);
-  StackArray<IndexType, 2> expected_shape = {2, 2};
+  axom::StackArray<axom::IndexType, 2> expected_shape = {2, 2};
   EXPECT_EQ(v_int.shape(), expected_shape);
   for(const auto val : v_int)
   {
@@ -1496,12 +1487,12 @@ TEST(core_array, check_multidimensional)
   v_int(1, 1) = 4;
 
   // FIXME: Should we add a std::initializer_list ctor?
-  Array<int> v_int_flat(4);
+  axom::Array<int> v_int_flat(4);
   v_int_flat[0] = 1;
   v_int_flat[1] = 2;
   v_int_flat[2] = 3;
   v_int_flat[3] = 4;
-  StackArray<IndexType, 1> expected_flat_shape = {4};
+  axom::StackArray<axom::IndexType, 1> expected_flat_shape = {4};
   EXPECT_EQ(v_int_flat.shape(), expected_flat_shape);
 
   for(int i = 0; i < v_int_flat.size(); i++)
@@ -1510,17 +1501,17 @@ TEST(core_array, check_multidimensional)
     EXPECT_EQ(v_int.flatIndex(i), v_int_flat[i]);
   }
 
-  Array<double, 3> v_double(4, 3, 2);
+  axom::Array<double, 3> v_double(4, 3, 2);
   v_double.fill(MAGIC_DOUBLE);
   EXPECT_EQ(v_double.size(), 4 * 3 * 2);
-  StackArray<IndexType, 3> expected_double_shape = {4, 3, 2};
+  axom::StackArray<axom::IndexType, 3> expected_double_shape = {4, 3, 2};
   EXPECT_EQ(v_double.shape(), expected_double_shape);
   for(const auto val : v_double)
   {
     EXPECT_EQ(val, MAGIC_DOUBLE);
   }
 
-  Array<double> v_double_flat(4 * 3 * 2);
+  axom::Array<double> v_double_flat(4 * 3 * 2);
   int double_flat_idx = 0;
   for(int i = 0; i < v_double.shape()[0]; i++)
   {
@@ -1542,10 +1533,10 @@ TEST(core_array, check_multidimensional)
 
   for(int i = 0; i < v_double.shape()[0]; i++)
   {
-    Array<double, 2> v_double_subarray_2d = v_double[i];
+    axom::Array<double, 2> v_double_subarray_2d = v_double[i];
     for(int j = 0; j < v_double.shape()[1]; j++)
     {
-      Array<double> v_double_subarray_1d = v_double(i, j);
+      axom::Array<double> v_double_subarray_1d = v_double(i, j);
       for(int k = 0; k < v_double.shape()[2]; k++)
       {
         EXPECT_EQ(v_double(i, j, k), v_double[i][j][k]);
@@ -1564,10 +1555,10 @@ TEST(core_array, check_multidimensional_view)
 
   // First test multidimensional int arrays
   int v_int_arr[] = {MAGIC_INT, MAGIC_INT, MAGIC_INT, MAGIC_INT};
-  ArrayView<int, 2> v_int_view(v_int_arr, 2, 2);
+  axom::ArrayView<int, 2> v_int_view(v_int_arr, 2, 2);
   // Make sure the number of elements and contents are correct
   EXPECT_EQ(v_int_view.size(), 2 * 2);
-  StackArray<IndexType, 2> expected_shape = {2, 2};
+  axom::StackArray<axom::IndexType, 2> expected_shape = {2, 2};
   EXPECT_EQ(v_int_view.shape(), expected_shape);
   for(const auto val : v_int_view)
   {
@@ -1581,8 +1572,8 @@ TEST(core_array, check_multidimensional_view)
 
   // FIXME: Should we add a std::initializer_list ctor?
   int v_int_flat_arr[] = {1, 2, 3, 4};
-  ArrayView<int> v_int_flat_view(v_int_flat_arr, 4);
-  StackArray<IndexType, 1> expected_flat_shape = {4};
+  axom::ArrayView<int> v_int_flat_view(v_int_flat_arr, 4);
+  axom::StackArray<axom::IndexType, 1> expected_flat_shape = {4};
   EXPECT_EQ(v_int_flat_view.shape(), expected_flat_shape);
 
   for(int i = 0; i < v_int_flat_view.size(); i++)
@@ -1593,9 +1584,9 @@ TEST(core_array, check_multidimensional_view)
 
   double v_double_arr[4 * 3 * 2];
   std::fill_n(v_double_arr, 4 * 3 * 2, MAGIC_DOUBLE);
-  ArrayView<double, 3> v_double_view(v_double_arr, 4, 3, 2);
+  axom::ArrayView<double, 3> v_double_view(v_double_arr, 4, 3, 2);
   EXPECT_EQ(v_double_view.size(), 4 * 3 * 2);
-  StackArray<IndexType, 3> expected_double_shape = {4, 3, 2};
+  axom::StackArray<axom::IndexType, 3> expected_double_shape = {4, 3, 2};
   EXPECT_EQ(v_double_view.shape(), expected_double_shape);
   for(const auto val : v_double_view)
   {
@@ -1603,7 +1594,7 @@ TEST(core_array, check_multidimensional_view)
   }
 
   double v_double_flat_arr[4 * 3 * 2];
-  ArrayView<double> v_double_flat_view(v_double_flat_arr, 4 * 3 * 2);
+  axom::ArrayView<double> v_double_flat_view(v_double_flat_arr, 4 * 3 * 2);
   int double_flat_idx = 0;
   for(int i = 0; i < v_double_view.shape()[0]; i++)
   {
@@ -1625,10 +1616,10 @@ TEST(core_array, check_multidimensional_view)
 
   for(int i = 0; i < v_double_view.shape()[0]; i++)
   {
-    Array<double, 2> v_double_subarray_2d = v_double_view[i];
+    axom::Array<double, 2> v_double_subarray_2d = v_double_view[i];
     for(int j = 0; j < v_double_view.shape()[1]; j++)
     {
-      Array<double> v_double_subarray_1d = v_double_view(i, j);
+      axom::Array<double> v_double_subarray_1d = v_double_view(i, j);
       for(int k = 0; k < v_double_view.shape()[2]; k++)
       {
         EXPECT_EQ(v_double_view(i, j, k), v_double_view[i][j][k]);
@@ -1668,16 +1659,15 @@ TEST(core_array, check_multidimensional_view_subspan)
     }
   }
 
-  ArrayView<double, 3> double_view(v_double_arr, {4, 5, 6});
+  axom::ArrayView<double, 3> double_view(v_double_arr, {4, 5, 6});
 
   EXPECT_EQ(double_view.size(), 4 * 5 * 6);
   EXPECT_EQ(double_view.strides()[0], I_STRIDE);
   EXPECT_EQ(double_view.strides()[1], J_STRIDE);
   EXPECT_EQ(double_view.strides()[2], K_STRIDE);
 
-  // Construct a subspan view starting at (1, 1, 1) and spanning 2 x 3 x 4
-  // elements.
-  ArrayView<double, 3> double_view_real =
+  // Construct a subspan view starting at (1, 1, 1) and spanning 2 x 3 x 4 elements.
+  axom::ArrayView<double, 3> double_view_real =
     double_view.subspan({1, 1, 1}, {2, 3, 4});
 
   EXPECT_EQ(double_view_real.size(), 2 * 3 * 4);
@@ -1733,9 +1723,9 @@ TEST(core_array, check_multidimensional_view_subspan_colmaj)
     }
   }
 
-  ArrayView<double, 3> double_view(v_double_arr,
-                                   {4, 5, 6},
-                                   {I_STRIDE, J_STRIDE, K_STRIDE});
+  axom::ArrayView<double, 3> double_view(v_double_arr,
+                                         {4, 5, 6},
+                                         {I_STRIDE, J_STRIDE, K_STRIDE});
 
   EXPECT_EQ(double_view.size(), 4 * 5 * 6);
   EXPECT_EQ(double_view.minStride(), 1);
@@ -1743,9 +1733,8 @@ TEST(core_array, check_multidimensional_view_subspan_colmaj)
   EXPECT_EQ(double_view.strides()[1], J_STRIDE);
   EXPECT_EQ(double_view.strides()[2], K_STRIDE);
 
-  // Construct a subspan view starting at (1, 1, 1) and spanning 2 x 3 x 4
-  // elements.
-  ArrayView<double, 3> double_view_real =
+  // Construct a subspan view starting at (1, 1, 1) and spanning 2 x 3 x 4 elements
+  axom::ArrayView<double, 3> double_view_real =
     double_view.subspan({1, 1, 1}, {2, 3, 4});
 
   EXPECT_EQ(double_view_real.size(), 2 * 3 * 4);
@@ -1801,9 +1790,9 @@ TEST(core_array, check_multidimensional_view_subspan_stride)
     }
   }
 
-  ArrayView<double, 3> double_view(v_double_arr,
-                                   {4, 5, 6},
-                                   {I_STRIDE, J_STRIDE, K_STRIDE});
+  axom::ArrayView<double, 3> double_view(v_double_arr,
+                                         {4, 5, 6},
+                                         {I_STRIDE, J_STRIDE, K_STRIDE});
 
   EXPECT_EQ(double_view.size(), 4 * 5 * 6);
   EXPECT_EQ(double_view.minStride(), 1);
@@ -1811,9 +1800,8 @@ TEST(core_array, check_multidimensional_view_subspan_stride)
   EXPECT_EQ(double_view.strides()[1], J_STRIDE);
   EXPECT_EQ(double_view.strides()[2], K_STRIDE);
 
-  // Construct a subspan view starting at (1, 1, 1) and spanning 2 x 3 x 4
-  // elements.
-  ArrayView<double, 3> double_view_real =
+  // Construct a subspan view starting at (1, 1, 1) and spanning 2 x 3 x 4 elements.
+  axom::ArrayView<double, 3> double_view_real =
     double_view.subspan({1, 1, 1}, {2, 3, 4});
 
   EXPECT_EQ(double_view_real.size(), 2 * 3 * 4);
@@ -1853,8 +1841,8 @@ TEST(core_array, check_multidimensional_view_spacing)
   constexpr int NUM_DIMS = 3;
 
   // Initialize a multidimensional, multicomponent array.
-  StackArray<IndexType, NUM_DIMS> shape {3, 2, 4};
-  Array<Elem, 3> mdElemArray(shape[0], shape[1], shape[2]);
+  axom::StackArray<axom::IndexType, NUM_DIMS> shape {3, 2, 4};
+  axom::Array<Elem, 3> mdElemArray(shape[0], shape[1], shape[2]);
   for(int i = 0; i < shape[0]; ++i)
   {
     for(int j = 0; j < shape[1]; ++j)
@@ -1869,11 +1857,11 @@ TEST(core_array, check_multidimensional_view_spacing)
     }
   }
 
-  // Verify views of the 3 individual components in mdElemArray.
-  IndexType spacing = NUM_COMPS;
-  ArrayView<double, 3> earthOnly(&mdElemArray(0, 0, 0).earth, shape, spacing);
-  ArrayView<double, 3> windOnly(&mdElemArray(0, 0, 0).wind, shape, spacing);
-  ArrayView<double, 3> fireOnly(&mdElemArray(0, 0, 0).fire, shape, spacing);
+  // Verify views of the 3 individual components in mdElemarray.
+  axom::IndexType spacing = NUM_COMPS;
+  axom::ArrayView<double, 3> earthOnly(&mdElemArray(0, 0, 0).earth, shape, spacing);
+  axom::ArrayView<double, 3> windOnly(&mdElemArray(0, 0, 0).wind, shape, spacing);
+  axom::ArrayView<double, 3> fireOnly(&mdElemArray(0, 0, 0).fire, shape, spacing);
 
   for(int i = 0; i < shape[0]; ++i)
   {
@@ -1906,30 +1894,31 @@ TEST(core_array, checkDevice)
   GTEST_SKIP() << "CUDA or HIP is not available, skipping tests that use Array "
                   "in device code";
 #else
-  for(IndexType capacity = 2; capacity < 512; capacity *= 2)
+  for(axom::IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
     // Allocate a Dynamic array in Device memory
-    Array<int, 1, axom::MemorySpace::Dynamic> v_int_dynamic(
+    axom::Array<int, 1, axom::MemorySpace::Dynamic> v_int_dynamic(
       capacity,
       capacity,
       axom::getUmpireResourceAllocatorID(umpire::resource::Device));
 
-    internal::check_device(v_int_dynamic);
+    ::check_device(v_int_dynamic);
 
-    Array<double, 1, axom::MemorySpace::Dynamic> v_double_dynamic(
+    axom::Array<double, 1, axom::MemorySpace::Dynamic> v_double_dynamic(
       capacity,
       capacity,
       axom::getUmpireResourceAllocatorID(umpire::resource::Device));
 
-    internal::check_device(v_double_dynamic);
+    ::check_device(v_double_dynamic);
 
     // Then allocate an explicitly Device array
-    Array<int, 1, axom::MemorySpace::Device> v_int_device(capacity, capacity);
-    internal::check_device(v_int_device);
-
-    Array<double, 1, axom::MemorySpace::Device> v_double_device(capacity,
+    axom::Array<int, 1, axom::MemorySpace::Device> v_int_device(capacity,
                                                                 capacity);
-    internal::check_device(v_double_device);
+    ::check_device(v_int_device);
+
+    axom::Array<double, 1, axom::MemorySpace::Device> v_double_device(capacity,
+                                                                      capacity);
+    ::check_device(v_double_device);
   }
 #endif
 }
@@ -1942,15 +1931,16 @@ TEST(core_array, checkDevice2D)
   GTEST_SKIP() << "CUDA or HIP is not available, skipping tests that use Array "
                   "in device code";
 #else
-  for(IndexType capacity = 2; capacity < 512; capacity *= 2)
+  for(axom::IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
     // Allocate an explicitly Device array
-    Array<int, 2, axom::MemorySpace::Device> v_int_device(capacity, capacity);
-    internal::check_device_2D(v_int_device);
-
-    Array<double, 2, axom::MemorySpace::Device> v_double_device(capacity,
+    axom::Array<int, 2, axom::MemorySpace::Device> v_int_device(capacity,
                                                                 capacity);
-    internal::check_device_2D(v_double_device);
+    ::check_device_2D(v_int_device);
+
+    axom::Array<double, 2, axom::MemorySpace::Device> v_double_device(capacity,
+                                                                      capacity);
+    ::check_device_2D(v_double_device);
   }
 #endif
 }
@@ -1969,28 +1959,28 @@ struct HasDefault
 TEST(core_array, checkDefaultInitialization)
 {
   constexpr int MAGIC_INT = 255;
-  for(IndexType capacity = 2; capacity < 512; capacity *= 2)
+  for(axom::IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
     // Make sure the array gets zero-initialized
-    Array<int> v_int(capacity);
+    axom::Array<int> v_int(capacity);
     for(const auto ele : v_int)
     {
       EXPECT_EQ(ele, 0);
     }
 
-    Array<int, 2> v_int_2d(capacity, capacity);
+    axom::Array<int, 2> v_int_2d(capacity, capacity);
     for(const auto ele : v_int_2d)
     {
       EXPECT_EQ(ele, 0);
     }
 
-    Array<HasDefault> v_has_default(capacity);
+    axom::Array<HasDefault> v_has_default(capacity);
     for(const auto& ele : v_has_default)
     {
       EXPECT_EQ(ele.member, MAGIC_INT);
     }
 
-    Array<HasDefault, 2> v_has_default_2d(capacity, capacity);
+    axom::Array<HasDefault, 2> v_has_default_2d(capacity, capacity);
     for(const auto& ele : v_has_default_2d)
     {
       EXPECT_EQ(ele.member, MAGIC_INT);
@@ -2007,13 +1997,13 @@ TEST(core_array, checkDefaultInitializationDevice)
                   "in device code";
 #else
   constexpr int MAGIC_INT = 255;
-  for(IndexType capacity = 2; capacity < 512; capacity *= 2)
+  for(axom::IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
     // Allocate an explicitly Device array of ints (zero-initialized)
-    Array<int, 1, axom::MemorySpace::Device> v_int(capacity);
+    axom::Array<int, 1, axom::MemorySpace::Device> v_int(capacity);
 
     // Then copy it to the host
-    Array<int, 1, axom::MemorySpace::Host> v_int_host(v_int);
+    axom::Array<int, 1, axom::MemorySpace::Host> v_int_host(v_int);
 
     for(const auto ele : v_int_host)
     {
@@ -2021,10 +2011,11 @@ TEST(core_array, checkDefaultInitializationDevice)
     }
 
     // Allocate an explicitly Device array of a default-constructible type
-    Array<HasDefault, 1, axom::MemorySpace::Device> v_has_default_device(capacity);
+    axom::Array<HasDefault, 1, axom::MemorySpace::Device> v_has_default_device(
+      capacity);
 
     // Then copy it to the host
-    Array<HasDefault, 1, axom::MemorySpace::Host> v_has_default_host(
+    axom::Array<HasDefault, 1, axom::MemorySpace::Host> v_has_default_host(
       v_has_default_device);
 
     for(const auto& ele : v_has_default_host)
@@ -2055,16 +2046,17 @@ struct FailsOnConstruction
 
 TEST(core_array, checkUninitialized)
 {
-  for(IndexType capacity = 2; capacity < 512; capacity *= 2)
+  for(axom::IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
     // Test uninitialized functionality with 1D Array using FailsOnConstruction type
     {
-      Array<FailsOnConstruction> arr(ArrayOptions::Uninitialized {}, capacity);
+      axom::Array<FailsOnConstruction> arr(axom::ArrayOptions::Uninitialized {},
+                                           capacity);
 
       EXPECT_LE(capacity, arr.capacity());
       EXPECT_EQ(capacity, arr.size());
 
-      arr.resize(ArrayOptions::Uninitialized {}, capacity * 2);
+      arr.resize(axom::ArrayOptions::Uninitialized {}, capacity * 2);
 
       EXPECT_LE(capacity * 2, arr.capacity());
       EXPECT_EQ(capacity * 2, arr.size());
@@ -2074,17 +2066,17 @@ TEST(core_array, checkUninitialized)
     // Note: this test will not fail if HasDefault is copied, but will at least
     // check that the code compiles and that we can copy and assign these arrays
     {
-      Array<HasDefault> arr(ArrayOptions::Uninitialized {}, capacity);
+      axom::Array<HasDefault> arr(axom::ArrayOptions::Uninitialized {}, capacity);
 
       EXPECT_LE(capacity, arr.capacity());
       EXPECT_EQ(capacity, arr.size());
 
-      Array<HasDefault> copied(arr);
+      axom::Array<HasDefault> copied(arr);
       EXPECT_LE(arr.capacity(), copied.capacity());
       EXPECT_EQ(arr.size(), copied.size());
       EXPECT_EQ(arr, copied);
 
-      Array<HasDefault> assigned;
+      axom::Array<HasDefault> assigned;
       assigned = arr;
       EXPECT_LE(arr.capacity(), assigned.capacity());
       EXPECT_EQ(arr.size(), assigned.size());
@@ -2093,14 +2085,15 @@ TEST(core_array, checkUninitialized)
 
     // Tests uninitialized with 2D Array
     {
-      Array<FailsOnConstruction, 2> arr(ArrayOptions::Uninitialized {},
-                                        capacity,
-                                        capacity);
+      axom::Array<FailsOnConstruction, 2> arr(
+        axom::ArrayOptions::Uninitialized {},
+        capacity,
+        capacity);
 
       EXPECT_LE(capacity * capacity, arr.capacity());
       EXPECT_EQ(capacity * capacity, arr.size());
 
-      arr.resize(ArrayOptions::Uninitialized {}, capacity * 2, capacity * 2);
+      arr.resize(axom::ArrayOptions::Uninitialized {}, capacity * 2, capacity * 2);
 
       EXPECT_LE(capacity * capacity * 4, arr.capacity());
       EXPECT_EQ(capacity * capacity * 4, arr.size());
@@ -2108,16 +2101,16 @@ TEST(core_array, checkUninitialized)
 
     // Tests uninitialized with 1D Array with user-supplied allocator
     {
-      Array<FailsOnConstruction> arr(ArrayOptions::Uninitialized {},
-                                     capacity,
-                                     capacity,
-                                     axom::getDefaultAllocatorID());
+      axom::Array<FailsOnConstruction> arr(axom::ArrayOptions::Uninitialized {},
+                                           capacity,
+                                           capacity,
+                                           axom::getDefaultAllocatorID());
 
       EXPECT_EQ(capacity, arr.capacity());
       EXPECT_EQ(capacity, arr.size());
       EXPECT_EQ(axom::getDefaultAllocatorID(), arr.getAllocatorID());
 
-      arr.resize(ArrayOptions::Uninitialized {}, capacity * 2);
+      arr.resize(axom::ArrayOptions::Uninitialized {}, capacity * 2);
 
       EXPECT_LE(capacity * 2, arr.capacity());
       EXPECT_EQ(capacity * 2, arr.size());
@@ -2129,18 +2122,18 @@ TEST(core_array, checkUninitialized)
 //------------------------------------------------------------------------------
 TEST(core_array, checkConstConversion)
 {
-  constexpr IndexType size = 10;
-  Array<int> v_int(size);
+  constexpr axom::IndexType size = 10;
+  axom::Array<int> v_int(size);
   for(int i = 0; i < v_int.size(); i++)
   {
     v_int[i] = i;
   }
-  const Array<int>& v_int_cref = v_int;
-  ArrayView<const int> v_int_view = v_int_cref;
+  const axom::Array<int>& v_int_cref = v_int;
+  axom::ArrayView<const int> v_int_view = v_int_cref;
   EXPECT_EQ(v_int, v_int_view);
-  ArrayView<const int> v_int_view_copy = v_int_view;
+  axom::ArrayView<const int> v_int_view_copy = v_int_view;
   EXPECT_EQ(v_int, v_int_view_copy);
-  // ArrayView<int> v_int_view_copy_non_const = v_int_view; // Fails to compile as it should
+  // axom::ArrayView<int> v_int_view_copy_non_const = v_int_view; // Fails to compile as it should
   // v_int_view[1] = 12; // Fails to compile as it should
 
   // Check begin() const and end() const
@@ -2150,7 +2143,7 @@ TEST(core_array, checkConstConversion)
     EXPECT_EQ(ele, idx++);
   }
 
-  Array<double, 2> v_double_2d(size, size);
+  axom::Array<double, 2> v_double_2d(size, size);
   for(int i = 0; i < size; i++)
   {
     for(int j = 0; j < size; j++)
@@ -2158,10 +2151,10 @@ TEST(core_array, checkConstConversion)
       v_double_2d(i, j) = 7.1 * i + j * 2.3;
     }
   }
-  const Array<double, 2>& v_double_2d_cref = v_double_2d;
-  ArrayView<const double, 2> v_double_2d_view = v_double_2d_cref;
+  const axom::Array<double, 2>& v_double_2d_cref = v_double_2d;
+  axom::ArrayView<const double, 2> v_double_2d_view = v_double_2d_cref;
   EXPECT_EQ(v_double_2d, v_double_2d_view);
-  ArrayView<const double, 2> v_double_2d_view_copy = v_double_2d_view;
+  axom::ArrayView<const double, 2> v_double_2d_view_copy = v_double_2d_view;
   EXPECT_EQ(v_double_2d, v_double_2d_view_copy);
   // v_double_2d_view_copy(0,0) = 1.1; // Fails to compile as it should
 }
@@ -2173,19 +2166,19 @@ TEST(core_array, checkVariadicCtors)
   int i = 5;
   size_t s = 6;
 
-  Array<int, 2> arr1(i, i);
-  Array<int, 2> arr2(i, s);
-  Array<int, 2> arr3(s, i);
-  Array<int, 2> arr4(s, s);
+  axom::Array<int, 2> arr1(i, i);
+  axom::Array<int, 2> arr2(i, s);
+  axom::Array<int, 2> arr3(s, i);
+  axom::Array<int, 2> arr4(s, s);
 
-  Array<int, 3> arr5(i, i, i);
-  Array<int, 3> arr6(i, i, s);
-  Array<int, 3> arr7(i, s, i);
-  Array<int, 3> arr8(i, s, s);
-  Array<int, 3> arr9(s, i, i);
-  Array<int, 3> arr10(s, i, s);
-  Array<int, 3> arr11(s, s, i);
-  Array<int, 3> arr12(s, s, s);
+  axom::Array<int, 3> arr5(i, i, i);
+  axom::Array<int, 3> arr6(i, i, s);
+  axom::Array<int, 3> arr7(i, s, i);
+  axom::Array<int, 3> arr8(i, s, s);
+  axom::Array<int, 3> arr9(s, i, i);
+  axom::Array<int, 3> arr10(s, i, s);
+  axom::Array<int, 3> arr11(s, s, i);
+  axom::Array<int, 3> arr12(s, s, s);
 }
 
 //------------------------------------------------------------------------------
@@ -2195,17 +2188,17 @@ TEST(core_array, check_subspan_range)
   int m = 10;
   int n = 3;
   int l = 5;
-  Array<int> arr(m);
+  axom::Array<int> arr(m);
 
-  ArrayView<int> arrv1(arr);
+  axom::ArrayView<int> arrv1(arr);
   EXPECT_EQ(arrv1.size(), arr.size());
 
-  ArrayView<int> arrv2 = arrv1.subspan(n);
+  axom::ArrayView<int> arrv2 = arrv1.subspan(n);
   EXPECT_EQ(arrv2.size() + n, arrv1.size());
   EXPECT_EQ(&arrv2[0], &arr[n]);
   EXPECT_EQ(&arrv2[arrv2.size() - 1], &arr[arr.size() - 1]);
 
-  ArrayView<int> arrv3 = arrv1.subspan(n, l);
+  axom::ArrayView<int> arrv3 = arrv1.subspan(n, l);
   EXPECT_EQ(arrv3.size(), l);
   EXPECT_EQ(&arrv3[0], &arr[n]);
   EXPECT_EQ(&arrv3[arrv3.size() - 1], &arr[n + l - 1]);
@@ -2219,9 +2212,9 @@ void test_resize_with_stackarray(DataType value)
   const int I_DIMS = 3;
   const int J_DIMS = 5;
   const int K_DIMS = 7;
-  Array<DataType, 2> arr2;
+  axom::Array<DataType, 2> arr2;
 
-  StackArray<axom::IndexType, 2> dims2 = {I_DIMS, J_DIMS};
+  axom::StackArray<axom::IndexType, 2> dims2 = {I_DIMS, J_DIMS};
   arr2.resize(dims2, value);
   EXPECT_EQ(arr2.size(), I_DIMS * J_DIMS);
   EXPECT_EQ(arr2.shape()[0], I_DIMS);
@@ -2234,9 +2227,9 @@ void test_resize_with_stackarray(DataType value)
     }
   }
 
-  Array<DataType, 3> arr3;
+  axom::Array<DataType, 3> arr3;
 
-  StackArray<axom::IndexType, 3> dims3 = {I_DIMS, J_DIMS, K_DIMS};
+  axom::StackArray<axom::IndexType, 3> dims3 = {I_DIMS, J_DIMS, K_DIMS};
   arr3.resize(dims3, value);
   EXPECT_EQ(arr3.size(), I_DIMS * J_DIMS * K_DIMS);
   EXPECT_EQ(arr3.shape()[0], I_DIMS);
@@ -2259,5 +2252,3 @@ TEST(core_array, resize_stackarray)
   test_resize_with_stackarray<bool>(false);
   test_resize_with_stackarray<int>(-1);
 }
-
-} /* end namespace axom */

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -1953,6 +1953,11 @@ struct HasDefault
   {
     return (member == other.member);
   }
+
+  friend std::ostream& operator<<(std::ostream& os, const HasDefault& hd)
+  {
+    return os << hd.member;
+  }
 };
 
 //------------------------------------------------------------------------------

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -872,7 +872,7 @@ void check_device_2D(axom::Array<T, 2, SPACE>& v)
   {
     for(int j = 0; j < N; j++)
     {
-      EXPECT_EQ(check_raw_axom::Array_host(i, j), i * i + j);
+      EXPECT_EQ(check_raw_array_host(i, j), i * i + j);
     }
   }
 
@@ -952,10 +952,10 @@ TEST(core_array, checkFillDevice)
   for(axom::IndexType capacity = 2; capacity < 512; capacity *= 2)
   {
     axom::IndexType size = capacity / 2;
-    axom::Array<int, 1, MemorySpace::Device> v_int(size, capacity);
+    axom::Array<int, 1, axom::MemorySpace::Device> v_int(size, capacity);
     ::check_fill(v_int);
 
-    axom::Array<double, 1, MemorySpace::Device> v_double(size, capacity);
+    axom::Array<double, 1, axom::MemorySpace::Device> v_double(size, capacity);
     ::check_fill(v_double);
   }
 }

--- a/src/axom/klee/tests/klee_geometry_operators.cpp
+++ b/src/axom/klee/tests/klee_geometry_operators.cpp
@@ -3,19 +3,20 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/klee/GeometryOperators.hpp"
-
+#include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
 
-#include <cmath>
+#include "axom/klee/GeometryOperators.hpp"
+
+#include "axom/klee/tests/KleeMatchers.hpp"
+#include "axom/klee/tests/KleeTestUtils.hpp"
+
+#include <math.h>
 #include <stdexcept>
 #include <utility>
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
-
-#include "axom/klee/tests/KleeMatchers.hpp"
-#include "axom/klee/tests/KleeTestUtils.hpp"
 
 namespace axom
 {
@@ -99,14 +100,14 @@ TEST(GeometryOperator, getProperties)
   EXPECT_EQ(constructorProps.units, endProperties.units);
 }
 
-TEST(Tanslation, basics)
+TEST(Translation, basics)
 {
   Vector3D offset {10, 20, 30};
   Translation translation {offset, {Dimensions::Two, LengthUnit::cm}};
   EXPECT_THAT(translation.getOffset(), AlmostEqVector(offset));
 }
 
-TEST(Tanslation, toMatrix)
+TEST(Translation, toMatrix)
 {
   for(Dimensions dims : ALL_DIMS)
   {
@@ -118,7 +119,7 @@ TEST(Tanslation, toMatrix)
   }
 }
 
-TEST(Tanslation, accept)
+TEST(Translation, accept)
 {
   Translation translation {{10, 20, 30}, {Dimensions::Two, LengthUnit::cm}};
   MockVisitor visitor;

--- a/src/axom/klee/tests/klee_geometry_operators_io.cpp
+++ b/src/axom/klee/tests/klee_geometry_operators_io.cpp
@@ -3,18 +3,17 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
+#include "axom/slic/core/SimpleLogger.hpp"
+#include "axom/inlet.hpp"
 
 #include "axom/klee/GeometryOperators.hpp"
 #include "axom/klee/GeometryOperatorsIO.hpp"
 #include "axom/klee/KleeError.hpp"
 
-#include "axom/inlet.hpp"
-
-#include "axom/slic/core/SimpleLogger.hpp"
-
 #include "KleeMatchers.hpp"
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 #include <memory>
 #include <unordered_map>
@@ -31,8 +30,8 @@ using primal::Point3D;
 using primal::Vector3D;
 using test::AlmostEqMatrix;
 using test::AlmostEqPoint;
+using test::AlmostEqSlice;
 using test::AlmostEqVector;
-using test::MatchesSlice;
 
 using ::testing::HasSubstr;
 
@@ -195,22 +194,13 @@ T getSingleNamedOperator(const NamedOperatorMap &operators,
   return getSingleOperatorFromComposite<T>(iter->second);
 }
 
-/**
- * Create a matcher to verify an object is a slice with the expected values
- * \param origin the expected origin
- * \param normal the expected normal vector
- * \param up the expected up vector
- * \param startProperties the expected start properties
- * \return a matcher that verifies a SliceOperator is as specified
- */
-test::MatchesSliceMatcherP<SliceOperator> isSlice(
-  Point3D origin,
-  Vector3D normal,
-  Vector3D up,
-  TransformableGeometryProperties startProperties)
+/// Helper function to create a klee::SliceOperator from its constituent parts
+SliceOperator make_slice(Point3D origin,
+                         Vector3D normal,
+                         Vector3D up,
+                         TransformableGeometryProperties startProperties)
 {
-  SliceOperator op {origin, normal, up, startProperties};
-  return MatchesSlice(op);
+  return SliceOperator {origin, normal, up, startProperties};
 }
 
 TEST(GeometryOperatorsIO, readMultipleOperatorsIncluded)
@@ -438,9 +428,11 @@ TEST(GeometryOperatorsIO, readSlice_specifyAll)
         normal: [4, 5, 6]
         up: [-5, 4, 0]
     )");
-  EXPECT_THAT(
-    slice,
-    isSlice({1, 2, 3}, {4, 5, 6}, {-5, 4, 0}, {Dimensions::Three, LengthUnit::cm}));
+  EXPECT_THAT(slice,
+              AlmostEqSlice(make_slice({1, 2, 3},
+                                       {4, 5, 6},
+                                       {-5, 4, 0},
+                                       {Dimensions::Three, LengthUnit::cm})));
 }
 
 TEST(GeometryOperatorsIO, readSlice_x_defaults)
@@ -450,9 +442,11 @@ TEST(GeometryOperatorsIO, readSlice_x_defaults)
       slice:
         x: 10
     )");
-  EXPECT_THAT(
-    slice,
-    isSlice({10, 0, 0}, {1, 0, 0}, {0, 0, 1}, {Dimensions::Three, LengthUnit::cm}));
+  EXPECT_THAT(slice,
+              AlmostEqSlice(make_slice({10, 0, 0},
+                                       {1, 0, 0},
+                                       {0, 0, 1},
+                                       {Dimensions::Three, LengthUnit::cm})));
 }
 
 TEST(GeometryOperatorsIO, readSlice_x_optionals)
@@ -466,10 +460,10 @@ TEST(GeometryOperatorsIO, readSlice_x_optionals)
         up: [0, -50, 60]
     )");
   EXPECT_THAT(slice,
-              isSlice({10, 20, 30},
-                      {40, 0, 0},
-                      {0, -50, 60},
-                      {Dimensions::Three, LengthUnit::cm}));
+              AlmostEqSlice(make_slice({10, 20, 30},
+                                       {40, 0, 0},
+                                       {0, -50, 60},
+                                       {Dimensions::Three, LengthUnit::cm})));
 }
 
 TEST(GeometryOperatorsIO, readSlice_y_defaults)
@@ -479,9 +473,11 @@ TEST(GeometryOperatorsIO, readSlice_y_defaults)
       slice:
         y: 20
     )");
-  EXPECT_THAT(
-    slice,
-    isSlice({0, 20, 0}, {0, 1, 0}, {1, 0, 0}, {Dimensions::Three, LengthUnit::cm}));
+  EXPECT_THAT(slice,
+              AlmostEqSlice(make_slice({0, 20, 0},
+                                       {0, 1, 0},
+                                       {1, 0, 0},
+                                       {Dimensions::Three, LengthUnit::cm})));
 }
 
 TEST(GeometryOperatorsIO, readSlice_y_optionals)
@@ -495,10 +491,10 @@ TEST(GeometryOperatorsIO, readSlice_y_optionals)
         up: [-50, 0, 60]
     )");
   EXPECT_THAT(slice,
-              isSlice({10, 20, 30},
-                      {0, 40, 0},
-                      {-50, 0, 60},
-                      {Dimensions::Three, LengthUnit::cm}));
+              AlmostEqSlice(make_slice({10, 20, 30},
+                                       {0, 40, 0},
+                                       {-50, 0, 60},
+                                       {Dimensions::Three, LengthUnit::cm})));
 }
 
 TEST(GeometryOperatorsIO, readSlice_z_defaults)
@@ -508,9 +504,11 @@ TEST(GeometryOperatorsIO, readSlice_z_defaults)
       slice:
         z: 30
     )");
-  EXPECT_THAT(
-    slice,
-    isSlice({0, 0, 30}, {0, 0, 1}, {0, 1, 0}, {Dimensions::Three, LengthUnit::cm}));
+  EXPECT_THAT(slice,
+              AlmostEqSlice(make_slice({0, 0, 30},
+                                       {0, 0, 1},
+                                       {0, 1, 0},
+                                       {Dimensions::Three, LengthUnit::cm})));
 }
 
 TEST(GeometryOperatorsIO, readSlice_z_optionals)
@@ -524,10 +522,10 @@ TEST(GeometryOperatorsIO, readSlice_z_optionals)
         up: [-50, 60, 0]
     )");
   EXPECT_THAT(slice,
-              isSlice({10, 20, 30},
-                      {0, 0, 40},
-                      {-50, 60, 0},
-                      {Dimensions::Three, LengthUnit::cm}));
+              AlmostEqSlice(make_slice({10, 20, 30},
+                                       {0, 0, 40},
+                                       {-50, 60, 0},
+                                       {Dimensions::Three, LengthUnit::cm})));
 }
 
 TEST(GeometryOperatorsIO, readSlice_zeroNormal)

--- a/src/axom/klee/tests/klee_io_util.cpp
+++ b/src/axom/klee/tests/klee_io_util.cpp
@@ -26,7 +26,6 @@ using inlet::Container;
 using primal::Point3D;
 using primal::Vector3D;
 
-using test::AlmostEqArray;
 using test::AlmostEqPoint;
 using test::AlmostEqVector;
 using ::testing::ElementsAre;

--- a/src/axom/primal/operators/detail/winding_number_impl.hpp
+++ b/src/axom/primal/operators/detail/winding_number_impl.hpp
@@ -7,7 +7,7 @@
 #define PRIMAL_WINDING_NUMBER_IMPL_HPP_
 
 // Axom includes
-#include "axom/config.hpp"  // for compile-time configuration options
+#include "axom/config.hpp"
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
 #include "axom/primal/geometry/Polygon.hpp"
@@ -17,7 +17,7 @@
 #include "axom/primal/operators/squared_distance.hpp"
 
 // C++ includes
-#include <cmath>
+#include <math.h>
 
 namespace axom
 {

--- a/src/axom/primal/tests/primal_polygon.cpp
+++ b/src/axom/primal/tests/primal_polygon.cpp
@@ -3,10 +3,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "gtest/gtest.h"
-
+#include "axom/config.hpp"
 #include "axom/primal.hpp"
 #include "axom/slic.hpp"
+
+#include <math.h>
+#include "gtest/gtest.h"
 
 //------------------------------------------------------------------------------
 TEST(primal_polygon, empty)

--- a/src/axom/primal/tests/primal_polyhedron.cpp
+++ b/src/axom/primal/tests/primal_polyhedron.cpp
@@ -3,7 +3,8 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "gtest/gtest.h"
+#include "axom/core.hpp"
+#include "axom/slic.hpp"
 
 #include "axom/primal/geometry/Hexahedron.hpp"
 #include "axom/primal/geometry/Octahedron.hpp"
@@ -15,10 +16,8 @@
 #include "axom/primal/operators/in_polyhedron.hpp"
 #include "axom/primal/operators/winding_number.hpp"
 
-#include "axom/core.hpp"
-#include "axom/slic.hpp"
-
-#include <cmath>
+#include <math.h>
+#include "gtest/gtest.h"
 
 namespace primal = axom::primal;
 

--- a/src/axom/quest/tests/quest_signed_distance_interface.cpp
+++ b/src/axom/quest/tests/quest_signed_distance_interface.cpp
@@ -15,19 +15,19 @@
 #include "quest_test_utilities.hpp"
 
 // gtest
+#include "gtest/gtest.h"
+
+// Note: Disable death tests when MPI is enabled since they're not being properly handled
 #ifdef AXOM_USE_MPI
-
-  #ifdef GTEST_HAS_DEATH_TEST
-    #undef GTEST_HAS_DEATH_TEST
-  #endif /* GTEST_HAS_DEATH_TEST */
-
-  #define GTEST_HAS_DEATH_TEST 0
-#endif                    /* AXOM_USE_MPI */
-#include "gtest/gtest.h"  // for gtest macros
+  #define _DEATH_TESTS_LOCALLY_DISABLED 1
+#else
+  #define _DEATH_TESTS_LOCALLY_DISABLED 0
+const char IGNORE_OUTPUT[] = ".*";
+#endif
 
 // C/C++ includes
-#include <fstream>  // for std::ofstream
-#include <sstream>  // for std::ostringstream
+#include <fstream>
+#include <sstream>
 
 // Aliases
 namespace quest = axom::quest;
@@ -36,8 +36,6 @@ namespace primal = axom::primal;
 namespace utilities = axom::utilities;
 
 using UnstructuredMesh = mint::UnstructuredMesh<mint::SINGLE_SHAPE>;
-
-const char IGNORE_OUTPUT[] = ".*";
 
 //#define WRITE_VTK_OUTPUT 1
 #define REMOVE_FILES 1
@@ -247,10 +245,12 @@ TEST(quest_signed_distance_interface_DeathTest, get_mesh_bounds_invalid_calls)
 {
   EXPECT_FALSE(quest::signed_distance_initialized());
 
+#if !_DEATH_TESTS_LOCALLY_DISABLED
   double lo[3];
   double hi[3];
   EXPECT_DEATH_IF_SUPPORTED(quest::signed_distance_get_mesh_bounds(lo, hi),
                             IGNORE_OUTPUT);
+#endif
 
   constexpr int NDIMS = 3;
   constexpr double SPHERE_RADIUS = 0.5;
@@ -267,11 +267,13 @@ TEST(quest_signed_distance_interface_DeathTest, get_mesh_bounds_invalid_calls)
 
   quest::signed_distance_init(surface_mesh);
 
+#if !_DEATH_TESTS_LOCALLY_DISABLED
   EXPECT_DEATH_IF_SUPPORTED(quest::signed_distance_get_mesh_bounds(nullptr, hi),
                             IGNORE_OUTPUT);
 
   EXPECT_DEATH_IF_SUPPORTED(quest::signed_distance_get_mesh_bounds(lo, nullptr),
                             IGNORE_OUTPUT);
+#endif
 
   quest::signed_distance_finalize();
   delete surface_mesh;
@@ -282,9 +284,10 @@ TEST(quest_signed_distance_interface_DeathTest, get_mesh_bounds_invalid_calls)
 TEST(quest_signed_distance_interface_DeathTest, call_evaluate_before_init)
 {
   EXPECT_FALSE(quest::signed_distance_initialized());
+
+#if !_DEATH_TESTS_LOCALLY_DISABLED
   EXPECT_DEATH_IF_SUPPORTED(quest::signed_distance_evaluate(0.0, 0.0),
                             IGNORE_OUTPUT);
-
   double x[2];
   double y[2];
   double z[2];
@@ -292,6 +295,7 @@ TEST(quest_signed_distance_interface_DeathTest, call_evaluate_before_init)
 
   EXPECT_DEATH_IF_SUPPORTED(quest::signed_distance_evaluate(x, y, z, 2, phi),
                             IGNORE_OUTPUT);
+#endif
 }
 
 //------------------------------------------------------------------------------
@@ -316,6 +320,8 @@ TEST(quest_signed_distance_interface_DeathTest, set_params_after_init)
   quest::signed_distance_init(surface_mesh);
 
   // STEP 1: setting parameters after init() should fail
+#if !_DEATH_TESTS_LOCALLY_DISABLED
+
   EXPECT_DEATH_IF_SUPPORTED(quest::signed_distance_set_dimension(3),
                             IGNORE_OUTPUT);
   EXPECT_DEATH_IF_SUPPORTED(quest::signed_distance_set_closed_surface(true),
@@ -327,6 +333,7 @@ TEST(quest_signed_distance_interface_DeathTest, set_params_after_init)
   EXPECT_DEATH_IF_SUPPORTED(
     quest::signed_distance_set_execution_space(quest::SignedDistExec::CPU),
     IGNORE_OUTPUT);
+#endif
 
   // STEP 2: finalize
   quest::signed_distance_finalize();


### PR DESCRIPTION
# Summary

- This PR is maintenance and bugfixes
- It updates the blt submodule to `blt@0.5.3`, which updates the gtest and gmock version
- It fixes a compilation error in the `axom::Array` unit tests -- the templated type requires an `operator<<()` overload and was missing for a type defined in the tests.
   - It also removes some utility functions in the above test from the `axom` namespace
- It also fixes a build error w/ MSVC that has cropped up before. When using defines like `M_PI` from `math.h`, we either have to make sure that we load `<cmath>` after defining `_USE_MATH_DEFINES`, or include `math.h` instead due to a guard in msvc's cmath that prevents it from being loaded a second time. (See also: https://github.com/search?q=repo%3ALLNL%2Faxom+cmath&type=commits)
- It also fixes a compilation issue w/ Klee's gmock testing macros on LLNL's blueos. clang+nvcc was complaining about a missing constructor when using the `MATCHER_P` macros. I expanded these to a simplified version of the underlying classes, which appears to have resolved the problem.

#### TODO: 
- [x] There's an unresolved segfault in a `quest::SignedDistance` test that still needs to be resolved. (Fixed)
- [x] Update RELEASE_NOTES