### PR TITLE
Fix marching cubes loops on GPUs

### DIFF
--- a/src/axom/primal/geometry/Sphere.hpp
+++ b/src/axom/primal/geometry/Sphere.hpp
@@ -125,7 +125,7 @@ public:
    *   <li> zero on the boundary </li>
    *  </ul>
    */
-  inline T computeSignedDistance(const PointType& q) const
+  AXOM_HOST_DEVICE inline T computeSignedDistance(const PointType& q) const
   {
     return VectorType(m_center, q).norm() - m_radius;
   }

--- a/src/axom/quest/MarchingCubes.cpp
+++ b/src/axom/quest/MarchingCubes.cpp
@@ -206,31 +206,39 @@ void MarchingCubesSingleDomain::allocateImpl()
   if(m_runtimePolicy == RuntimePolicy::seq)
   {
     m_impl = m_ndim == 2
-      ? std::unique_ptr<ImplBase>(new MarchingCubesImpl<2, axom::SEQ_EXEC>)
-      : std::unique_ptr<ImplBase>(new MarchingCubesImpl<3, axom::SEQ_EXEC>);
+      ? std::unique_ptr<ImplBase>(
+          new MarchingCubesImpl<2, axom::SEQ_EXEC, RAJA::seq_exec>)
+      : std::unique_ptr<ImplBase>(
+          new MarchingCubesImpl<3, axom::SEQ_EXEC, RAJA::seq_exec>);
   }
 #ifdef _AXOM_MC_USE_OPENMP
   else if(m_runtimePolicy == RuntimePolicy::omp)
   {
     m_impl = m_ndim == 2
-      ? std::unique_ptr<ImplBase>(new MarchingCubesImpl<2, axom::OMP_EXEC>)
-      : std::unique_ptr<ImplBase>(new MarchingCubesImpl<3, axom::OMP_EXEC>);
+      ? std::unique_ptr<ImplBase>(
+          new MarchingCubesImpl<2, axom::OMP_EXEC, RAJA::seq_exec>)
+      : std::unique_ptr<ImplBase>(
+          new MarchingCubesImpl<3, axom::OMP_EXEC, RAJA::seq_exec>);
   }
 #endif
 #ifdef _AXOM_MC_USE_CUDA
   else if(m_runtimePolicy == RuntimePolicy::cuda)
   {
     m_impl = m_ndim == 2
-      ? std::unique_ptr<ImplBase>(new MarchingCubesImpl<2, axom::CUDA_EXEC<256>>)
-      : std::unique_ptr<ImplBase>(new MarchingCubesImpl<3, axom::CUDA_EXEC<256>>);
+      ? std::unique_ptr<ImplBase>(
+          new MarchingCubesImpl<2, axom::CUDA_EXEC<256>, RAJA::cuda_exec<1>>)
+      : std::unique_ptr<ImplBase>(
+          new MarchingCubesImpl<3, axom::CUDA_EXEC<256>, RAJA::cuda_exec<1>>);
   }
 #endif
 #ifdef _AXOM_MC_USE_HIP
   else if(m_runtimePolicy == RuntimePolicy::hip)
   {
     m_impl = m_ndim == 2
-      ? std::unique_ptr<ImplBase>(new MarchingCubesImpl<2, axom::HIP_EXEC<256>>)
-      : std::unique_ptr<ImplBase>(new MarchingCubesImpl<3, axom::HIP_EXEC<256>>);
+      ? std::unique_ptr<ImplBase>(
+          new MarchingCubesImpl<2, axom::HIP_EXEC<256>, RAJA::hip_exec<1>>)
+      : std::unique_ptr<ImplBase>(
+          new MarchingCubesImpl<3, axom::HIP_EXEC<256>, RAJA::hip_exec<1>>);
   }
 #endif
   else

--- a/src/axom/quest/MarchingCubes.cpp
+++ b/src/axom/quest/MarchingCubes.cpp
@@ -207,13 +207,9 @@ void MarchingCubesSingleDomain::allocateImpl()
   {
     m_impl = m_ndim == 2
       ? std::unique_ptr<ImplBase>(
-          new MarchingCubesImpl<2,
-                                axom::SEQ_EXEC,
-                                axom::SEQ_EXEC>)
+          new MarchingCubesImpl<2, axom::SEQ_EXEC, axom::SEQ_EXEC>)
       : std::unique_ptr<ImplBase>(
-          new MarchingCubesImpl<3,
-                                axom::SEQ_EXEC,
-                                axom::SEQ_EXEC>);
+          new MarchingCubesImpl<3, axom::SEQ_EXEC, axom::SEQ_EXEC>);
   }
 #ifdef _AXOM_MC_USE_OPENMP
   else if(m_runtimePolicy == RuntimePolicy::omp)

--- a/src/axom/quest/MarchingCubes.cpp
+++ b/src/axom/quest/MarchingCubes.cpp
@@ -207,9 +207,13 @@ void MarchingCubesSingleDomain::allocateImpl()
   {
     m_impl = m_ndim == 2
       ? std::unique_ptr<ImplBase>(
-          new MarchingCubesImpl<2, axom::SEQ_EXEC, RAJA::seq_exec>)
+          new MarchingCubesImpl<2,
+                                axom::SEQ_EXEC,
+                                axom::execution_space<axom::SEQ_EXEC>::loop_policy>)
       : std::unique_ptr<ImplBase>(
-          new MarchingCubesImpl<3, axom::SEQ_EXEC, RAJA::seq_exec>);
+          new MarchingCubesImpl<3,
+                                axom::SEQ_EXEC,
+                                axom::execution_space<axom::SEQ_EXEC>::loop_policy>);
   }
 #ifdef _AXOM_MC_USE_OPENMP
   else if(m_runtimePolicy == RuntimePolicy::omp)

--- a/src/axom/quest/MarchingCubes.cpp
+++ b/src/axom/quest/MarchingCubes.cpp
@@ -209,20 +209,20 @@ void MarchingCubesSingleDomain::allocateImpl()
       ? std::unique_ptr<ImplBase>(
           new MarchingCubesImpl<2,
                                 axom::SEQ_EXEC,
-                                axom::execution_space<axom::SEQ_EXEC>::loop_policy>)
+                                axom::SEQ_EXEC>)
       : std::unique_ptr<ImplBase>(
           new MarchingCubesImpl<3,
                                 axom::SEQ_EXEC,
-                                axom::execution_space<axom::SEQ_EXEC>::loop_policy>);
+                                axom::SEQ_EXEC>);
   }
 #ifdef _AXOM_MC_USE_OPENMP
   else if(m_runtimePolicy == RuntimePolicy::omp)
   {
     m_impl = m_ndim == 2
       ? std::unique_ptr<ImplBase>(
-          new MarchingCubesImpl<2, axom::OMP_EXEC, RAJA::seq_exec>)
+          new MarchingCubesImpl<2, axom::OMP_EXEC, axom::SEQ_EXEC>)
       : std::unique_ptr<ImplBase>(
-          new MarchingCubesImpl<3, axom::OMP_EXEC, RAJA::seq_exec>);
+          new MarchingCubesImpl<3, axom::OMP_EXEC, axom::SEQ_EXEC>);
   }
 #endif
 #ifdef _AXOM_MC_USE_CUDA
@@ -230,9 +230,9 @@ void MarchingCubesSingleDomain::allocateImpl()
   {
     m_impl = m_ndim == 2
       ? std::unique_ptr<ImplBase>(
-          new MarchingCubesImpl<2, axom::CUDA_EXEC<256>, RAJA::cuda_exec<1>>)
+          new MarchingCubesImpl<2, axom::CUDA_EXEC<256>, axom::CUDA_EXEC<1>>)
       : std::unique_ptr<ImplBase>(
-          new MarchingCubesImpl<3, axom::CUDA_EXEC<256>, RAJA::cuda_exec<1>>);
+          new MarchingCubesImpl<3, axom::CUDA_EXEC<256>, axom::CUDA_EXEC<1>>);
   }
 #endif
 #ifdef _AXOM_MC_USE_HIP
@@ -240,9 +240,9 @@ void MarchingCubesSingleDomain::allocateImpl()
   {
     m_impl = m_ndim == 2
       ? std::unique_ptr<ImplBase>(
-          new MarchingCubesImpl<2, axom::HIP_EXEC<256>, RAJA::hip_exec<1>>)
+          new MarchingCubesImpl<2, axom::HIP_EXEC<256>, axom::HIP_EXEC<1>>)
       : std::unique_ptr<ImplBase>(
-          new MarchingCubesImpl<3, axom::HIP_EXEC<256>, RAJA::hip_exec<1>>);
+          new MarchingCubesImpl<3, axom::HIP_EXEC<256>, axom::HIP_EXEC<1>>);
   }
 #endif
   else

--- a/src/axom/quest/MarchingCubes.hpp
+++ b/src/axom/quest/MarchingCubes.hpp
@@ -64,7 +64,7 @@ namespace detail
 {
 namespace marching_cubes
 {
-template <int DIM, typename ExecSpace>
+template <int DIM, typename ExecSpace, typename SequentialLoopPolicy>
 class MarchingCubesImpl;
 }
 }  // namespace detail
@@ -184,7 +184,7 @@ private:
  */
 class MarchingCubesSingleDomain
 {
-  template <int DIM, typename ExecSpace>
+  template <int DIM, typename ExecSpace, typename SequentialLoopPolicy>
   friend class detail::marching_cubes::MarchingCubesImpl;
 
 public:

--- a/src/axom/quest/detail/MarchingCubesImpl.hpp
+++ b/src/axom/quest/detail/MarchingCubesImpl.hpp
@@ -402,7 +402,7 @@ public:
     }
 #endif
 
-    // Cata from the last crossing tells us how many contour cells there are.
+    // Data from the last crossing tells us how many contour cells there are.
     if(m_crossings.empty())
     {
       m_contourCellCount = 0;
@@ -417,22 +417,6 @@ public:
         back.firstSurfaceCellId + num_contour_cells(back.caseNum);
     }
   }
-
-  /*!
-    @brief Info for a parent cell intersecting the contour surface.
-  */
-  struct CrossingInfo
-  {
-    CrossingInfo() { }
-    CrossingInfo(axom::IndexType parentCellNum_, std::uint16_t caseNum_)
-      : parentCellNum(parentCellNum_)
-      , caseNum(caseNum_)
-      , firstSurfaceCellId(std::numeric_limits<axom::IndexType>::max())
-    { }
-    axom::IndexType parentCellNum;       //!< @brief Flat index of parent cell.
-    std::uint16_t caseNum;               //!< @brief Index in cases2D or cases3D
-    axom::IndexType firstSurfaceCellId;  //!< @brief First index for generated cells.
-  };
 
   /*!
     @brief Implementation used by MarchingCubesImpl::computeContour().
@@ -881,6 +865,22 @@ public:
     , m_contourCellCorners(0, 0)
     , m_contourCellParents(0, 0)
   { }
+
+  /*!
+    @brief Info for a parent cell intersecting the contour surface.
+  */
+  struct CrossingInfo
+  {
+    CrossingInfo() { }
+    CrossingInfo(axom::IndexType parentCellNum_, std::uint16_t caseNum_)
+      : parentCellNum(parentCellNum_)
+      , caseNum(caseNum_)
+      , firstSurfaceCellId(std::numeric_limits<axom::IndexType>::max())
+    { }
+    axom::IndexType parentCellNum;       //!< @brief Flat index of parent cell.
+    std::uint16_t caseNum;               //!< @brief Index in cases2D or cases3D
+    axom::IndexType firstSurfaceCellId;  //!< @brief First index for generated cells.
+  };
 
 private:
   const int m_allocatorID;  //!< @brief ExecSpace-based allocator ID for all internal data

--- a/src/axom/quest/detail/MarchingCubesImpl.hpp
+++ b/src/axom/quest/detail/MarchingCubesImpl.hpp
@@ -66,6 +66,9 @@ public:
 
     Set up views to domain data and allocate other data to work on the
     given domain.
+
+    The above data from the domain MUST be in a memory space
+    compatible with ExecSpace.
   */
   AXOM_HOST void initialize(const conduit::Node& dom,
                             const std::string& coordsetPath,
@@ -103,7 +106,9 @@ public:
       {
         const double* coordsPtr = coordValues[d].as_double_ptr();
         m_coordsViews[d] =
-          axom::ArrayView<const double, DIM>(coordsPtr, m_pShape, coordSp);
+          axom::ArrayView<const double, DIM, MemorySpace>(coordsPtr,
+                                                          m_pShape,
+                                                          coordSp);
       }
     }
 
@@ -111,7 +116,8 @@ public:
     {
       auto& fcnValues = dom.fetch_existing(fcnPath + "/values");
       const double* fcnPtr = fcnValues.as_double_ptr();
-      m_fcnView = axom::ArrayView<const double, DIM>(fcnPtr, m_pShape);
+      m_fcnView =
+        axom::ArrayView<const double, DIM, MemorySpace>(fcnPtr, m_pShape);
     }
 
     // Mask
@@ -124,13 +130,18 @@ public:
       }
       if(maskPtr)
       {
-        m_maskView = axom::ArrayView<const int, DIM>(maskPtr, m_cShape);
+        m_maskView =
+          axom::ArrayView<const int, DIM, MemorySpace>(maskPtr, m_cShape);
       }
     }
 
-    m_caseIds = axom::Array<std::uint16_t, DIM>(
-      m_cShape,
-      axom::execution_space<ExecSpace>::allocatorID());
+    m_caseIds = axom::Array<std::uint16_t, DIM, MemorySpace>(m_cShape);
+  }
+
+  //!@brief Set a value to find the contour for.
+  void setContourValue(double contourVal) override
+  {
+    m_contourVal = contourVal;
   }
 
   /*!
@@ -145,38 +156,26 @@ public:
   template <int TDIM = DIM>
   typename std::enable_if<TDIM == 2>::type markCrossings_dim()
   {
-    auto caseIdsView = m_caseIds.view();
+    m_caseIds.fill(0);
 
-    auto loopBody = AXOM_LAMBDA(axom::IndexType i, axom::IndexType j)
-    {
-      const bool skipZone = !m_maskView.empty() && bool(m_maskView(j, i));
-      if(!skipZone)
-      {
-        // clang-format off
-          double nodalValues[CELL_CORNER_COUNT] =
-            {m_fcnView(j    , i    ),
-             m_fcnView(j    , i + 1),
-             m_fcnView(j + 1, i + 1),
-             m_fcnView(j + 1, i    )};
-        // clang-format on
-
-        auto crossingCase = compute_crossing_case(nodalValues);
-        caseIdsView(j, i) = crossingCase;
-      }
-    };
+    MarkCrossings_Util mcu(m_caseIds, m_fcnView, m_maskView, m_contourVal);
 
 #if defined(AXOM_USE_RAJA)
     RAJA::RangeSegment jRange(0, m_cShape[0]);
     RAJA::RangeSegment iRange(0, m_cShape[1]);
     using EXEC_POL =
       typename axom::mint::internal::structured_exec<ExecSpace>::loop2d_policy;
-    RAJA::kernel<EXEC_POL>(RAJA::make_tuple(iRange, jRange), loopBody);
+    RAJA::kernel<EXEC_POL>(
+      RAJA::make_tuple(iRange, jRange),
+      AXOM_LAMBDA(axom::IndexType i, axom::IndexType j) {
+        mcu.computeCaseId(i, j);
+      });
 #else
     for(int j = 0; j < m_cShape[0]; ++j)
     {
       for(int i = 0; i < m_cShape[1]; ++i)
       {
-        loopBody(i, j);
+        mcu.computeCaseId(i, j);
       }
     }
 #endif
@@ -186,30 +185,9 @@ public:
   template <int TDIM = DIM>
   typename std::enable_if<TDIM == 3>::type markCrossings_dim()
   {
-    auto caseIdsView = m_caseIds.view();
+    m_caseIds.fill(0);
 
-    auto loopBody =
-      AXOM_LAMBDA(axom::IndexType i, axom::IndexType j, axom::IndexType k)
-    {
-      const bool skipZone = !m_maskView.empty() && bool(m_maskView(k, j, i));
-      if(!skipZone)
-      {
-        // clang-format off
-          double nodalValues[CELL_CORNER_COUNT] =
-            {m_fcnView(k    , j    , i + 1),
-             m_fcnView(k    , j + 1, i + 1),
-             m_fcnView(k    , j + 1, i    ),
-             m_fcnView(k    , j    , i    ),
-             m_fcnView(k + 1, j    , i + 1),
-             m_fcnView(k + 1, j + 1, i + 1),
-             m_fcnView(k + 1, j + 1, i    ),
-             m_fcnView(k + 1, j    , i    )};
-        // clang-format on
-
-        auto crossingCase = compute_crossing_case(nodalValues);
-        caseIdsView(k, j, i) = crossingCase;
-      }
-    };
+    MarkCrossings_Util mcu(m_caseIds, m_fcnView, m_maskView, m_contourVal);
 
 #if defined(AXOM_USE_RAJA)
     RAJA::RangeSegment kRange(0, m_cShape[0]);
@@ -217,7 +195,11 @@ public:
     RAJA::RangeSegment iRange(0, m_cShape[2]);
     using EXEC_POL =
       typename axom::mint::internal::structured_exec<ExecSpace>::loop3d_policy;
-    RAJA::kernel<EXEC_POL>(RAJA::make_tuple(iRange, jRange, kRange), loopBody);
+    RAJA::kernel<EXEC_POL>(
+      RAJA::make_tuple(iRange, jRange, kRange),
+      AXOM_LAMBDA(axom::IndexType i, axom::IndexType j, axom::IndexType k) {
+        mcu.computeCaseId(i, j, k);
+      });
 #else
     for(int k = 0; k < m_cShape[0]; ++k)
     {
@@ -225,12 +207,90 @@ public:
       {
         for(int i = 0; i < m_cShape[2]; ++i)
         {
-          loopBody(i, j, k);
+          mcu.computeCaseId(i, j, k);
         }
       }
     }
 #endif
   }
+
+  /*!
+    @brief Implementation used by MarchingCubesImpl::markCrossings_dim()
+    containing just the objects needed for that part, to be made available
+    on devices.
+  */
+  struct MarkCrossings_Util
+  {
+    axom::ArrayView<std::uint16_t, DIM, MemorySpace> caseIdsView;
+    axom::ArrayView<const double, DIM, MemorySpace> fcnView;
+    axom::ArrayView<const int, DIM, MemorySpace> maskView;
+    double contourVal;
+    MarkCrossings_Util(axom::Array<std::uint16_t, DIM, MemorySpace>& caseIds,
+                       axom::ArrayView<const double, DIM, MemorySpace>& fcnView_,
+                       axom::ArrayView<const int, DIM, MemorySpace>& maskView_,
+                       double contourVal_)
+      : caseIdsView(caseIds.view())
+      , fcnView(fcnView_)
+      , maskView(maskView_)
+      , contourVal(contourVal_)
+    { }
+
+    //!@brief Compute the case index into cases2D or cases3D.
+    AXOM_HOST_DEVICE inline int computeCrossingCase(const double* f) const
+    {
+      int index = 0;
+      for(int n = 0; n < CELL_CORNER_COUNT; ++n)
+      {
+        if(f[n] >= contourVal)
+        {
+          const int bit = (1 << n);
+          index |= bit;
+        }
+      }
+      return index;
+    }
+
+    template <int TDIM = DIM>
+    AXOM_HOST_DEVICE inline typename std::enable_if<TDIM == 2>::type
+    computeCaseId(axom::IndexType i, axom::IndexType j) const
+    {
+      const bool skipZone = !maskView.empty() && bool(maskView(j, i));
+      if(!skipZone)
+      {
+        // clang-format off
+          double nodalValues[CELL_CORNER_COUNT] =
+            {fcnView(j    , i    ),
+             fcnView(j    , i + 1),
+             fcnView(j + 1, i + 1),
+             fcnView(j + 1, i    )};
+        // clang-format on
+        caseIdsView(j, i) = computeCrossingCase(nodalValues);
+      }
+    }
+
+    //!@brief Populate m_caseIds with crossing indices.
+    template <int TDIM = DIM>
+    AXOM_HOST_DEVICE inline typename std::enable_if<TDIM == 3>::type
+    computeCaseId(axom::IndexType i, axom::IndexType j, axom::IndexType k) const
+    {
+      const bool skipZone = !maskView.empty() && bool(maskView(k, j, i));
+      if(!skipZone)
+      {
+        // clang-format off
+          double nodalValues[CELL_CORNER_COUNT] =
+            {fcnView(k    , j    , i + 1),
+             fcnView(k    , j + 1, i + 1),
+             fcnView(k    , j + 1, i    ),
+             fcnView(k    , j    , i    ),
+             fcnView(k + 1, j    , i + 1),
+             fcnView(k + 1, j + 1, i + 1),
+             fcnView(k + 1, j + 1, i    ),
+             fcnView(k + 1, j    , i    )};
+        // clang-format on
+        caseIdsView(k, j, i) = computeCrossingCase(nodalValues);
+      }
+    }
+  };  // MarkCrossings_Util
 
   /*!
     @brief Populate the 1D m_crossings array, one entry for each
@@ -243,7 +303,6 @@ public:
   {
     const axom::IndexType parentCellCount = m_caseIds.size();
     auto caseIdsView = m_caseIds.view();
-
 #if defined(AXOM_USE_RAJA)
     RAJA::ReduceSum<ReducePolicy, axom::IndexType> vsum(0);
     RAJA::forall<LoopPolicy>(
@@ -262,17 +321,15 @@ public:
 #endif
 
     m_crossings.resize(m_crossingCount, {0, 0});
-    axom::ArrayView<CrossingInfo> crossingsView = m_crossings.view();
+    axom::ArrayView<CrossingInfo, 1, MemorySpace> crossingsView =
+      m_crossings.view();
 
-    axom::Array<int> addCells(m_crossingCount,
-                              m_crossingCount,
-                              m_crossings.getAllocatorID());
-    const axom::ArrayView<int> addCellsView = addCells.view();
+    axom::Array<int, 1, MemorySpace> addCells(m_crossingCount, m_crossingCount);
+    const axom::ArrayView<int, 1, MemorySpace> addCellsView = addCells.view();
 
     axom::IndexType* crossingId = axom::allocate<axom::IndexType>(
       1,
-      axom::detail::getAllocatorID<MemorySpace::Dynamic>());
-    *crossingId = 0;
+      axom::detail::getAllocatorID<MemorySpace>());
 
     auto loopBody = AXOM_LAMBDA(axom::IndexType n)
     {
@@ -281,8 +338,8 @@ public:
       if(ccc != 0)
       {
         addCellsView[*crossingId] = ccc;
-        m_crossings[*crossingId].caseNum = caseId;
-        m_crossings[*crossingId].parentCellNum = n;
+        crossingsView[*crossingId].caseNum = caseId;
+        crossingsView[*crossingId].parentCellNum = n;
         ++(*crossingId);
       }
     };
@@ -290,31 +347,34 @@ public:
 #if defined(AXOM_USE_RAJA)
     /*
       The m_crossings filling loop isn't data-parallel and shouldn't
-      be parallelized.  The contrived RAJA::forall forces it to run
+      be parallelized.  This contrived RAJA::forall forces it to run
       sequentially.
     */
     RAJA::forall<SequentialLoopPolicy>(
       RAJA::RangeSegment(0, 1),
       [=] AXOM_HOST_DEVICE(int /* i */) {
+        *crossingId = 0;
         for(axom::IndexType n = 0; n < parentCellCount; ++n)
         {
           loopBody(n);
         }
+        // assert(*crossingId == m_crossingCount);
       });
 #else
+    *crossingId = 0;
     for(axom::IndexType n = 0; n < parentCellCount; ++n)
     {
       loopBody(n);
     }
+    SLIC_ASSERT(*crossingId == m_crossingCount);
 #endif
 
-    SLIC_ASSERT(*crossingId == m_crossingCount);
     axom::deallocate(crossingId);
 
-    axom::Array<axom::IndexType> prefixSum(m_crossingCount,
-                                           m_crossingCount,
-                                           m_crossings.getAllocatorID());
-    const axom::ArrayView<axom::IndexType> prefixSumView = prefixSum.view();
+    axom::Array<axom::IndexType, 1, MemorySpace> prefixSum(m_crossingCount,
+                                                           m_crossingCount);
+    const axom::ArrayView<axom::IndexType, 1, MemorySpace> prefixSumView =
+      prefixSum.view();
 
     auto copyFirstSurfaceCellId = AXOM_LAMBDA(axom::IndexType n)
     {
@@ -342,11 +402,234 @@ public:
     }
 #endif
 
-    m_contourCellCount = m_crossings.empty()
-      ? 0
-      : m_crossings.back().firstSurfaceCellId +
-        num_contour_cells(m_crossings.back().caseNum);
+    // Cata from the last crossing tells us how many contour cells there are.
+    if(m_crossings.empty())
+    {
+      m_contourCellCount = 0;
+    }
+    else
+    {
+      CrossingInfo back;
+      axom::copy(&back,
+                 m_crossings.data() + m_crossings.size() - 1,
+                 sizeof(CrossingInfo));
+      m_contourCellCount =
+        back.firstSurfaceCellId + num_contour_cells(back.caseNum);
+    }
   }
+
+  /*!
+    @brief Info for a parent cell intersecting the contour surface.
+  */
+  struct CrossingInfo
+  {
+    CrossingInfo() { }
+    CrossingInfo(axom::IndexType parentCellNum_, std::uint16_t caseNum_)
+      : parentCellNum(parentCellNum_)
+      , caseNum(caseNum_)
+      , firstSurfaceCellId(std::numeric_limits<axom::IndexType>::max())
+    { }
+    axom::IndexType parentCellNum;       //!< @brief Flat index of parent cell.
+    std::uint16_t caseNum;               //!< @brief Index in cases2D or cases3D
+    axom::IndexType firstSurfaceCellId;  //!< @brief First index for generated cells.
+  };
+
+  /*!
+    @brief Implementation used by MarchingCubesImpl::computeContour().
+    containing just the objects needed for that part, to be made available
+    on devices.
+  */
+  struct ComputeContour_Util
+  {
+    double contourVal;
+    MIdx bStrides;
+    axom::ArrayView<const double, DIM, MemorySpace> fcnView;
+    axom::StackArray<axom::ArrayView<const double, DIM, MemorySpace>, DIM> coordsViews;
+    ComputeContour_Util(
+      double contourVal_,
+      const MIdx& bStrides_,
+      const axom::ArrayView<const double, DIM, MemorySpace>& fcnView_,
+      const axom::StackArray<axom::ArrayView<const double, DIM, MemorySpace>, DIM>
+        coordsViews_)
+      : contourVal(contourVal_)
+      , bStrides(bStrides_)
+      , fcnView(fcnView_)
+      , coordsViews(coordsViews_)
+    { }
+
+    template <int TDIM = DIM>
+    AXOM_HOST_DEVICE typename std::enable_if<TDIM == 2>::type
+    get_corner_coords_and_values(IndexType cellNum,
+                                 Point cornerCoords[],
+                                 double cornerValues[]) const
+    {
+      const auto& x = coordsViews[0];
+      const auto& y = coordsViews[1];
+
+      const auto c = multidim_cell_index(cellNum);
+      const auto& i = c[0];
+      const auto& j = c[1];
+
+      // clang-format off
+      cornerCoords[0] = { x(j    , i    ), y(j    , i    ) };
+      cornerCoords[1] = { x(j    , i + 1), y(j    , i + 1) };
+      cornerCoords[2] = { x(j + 1, i + 1), y(j + 1, i + 1) };
+      cornerCoords[3] = { x(j + 1, i    ), y(j + 1, i    ) };
+
+      cornerValues[0] = fcnView(j    , i    );
+      cornerValues[1] = fcnView(j    , i + 1);
+      cornerValues[2] = fcnView(j + 1, i + 1);
+      cornerValues[3] = fcnView(j + 1, i    );
+      // clang-format on
+    }
+    template <int TDIM = DIM>
+    AXOM_HOST_DEVICE typename std::enable_if<TDIM == 3>::type
+    get_corner_coords_and_values(IndexType cellNum,
+                                 Point cornerCoords[],
+                                 double cornerValues[]) const
+    {
+      const auto& x = coordsViews[0];
+      const auto& y = coordsViews[1];
+      const auto& z = coordsViews[2];
+
+      const auto c = multidim_cell_index(cellNum);
+      const auto& i = c[0];
+      const auto& j = c[1];
+      const auto& k = c[2];
+
+      // clang-format off
+      cornerCoords[0] = { x(k  , j  , i+1), y(k  , j  , i+1), z(k  , j  , i+1) };
+      cornerCoords[1] = { x(k  , j+1, i+1), y(k  , j+1, i+1), z(k  , j+1, i+1) };
+      cornerCoords[2] = { x(k  , j+1, i  ), y(k  , j+1, i  ), z(k  , j+1, i  ) };
+      cornerCoords[3] = { x(k  , j  , i  ), y(k  , j  , i  ), z(k  , j  , i  ) };
+      cornerCoords[4] = { x(k+1, j  , i+1), y(k+1, j  , i+1), z(k+1, j  , i+1) };
+      cornerCoords[5] = { x(k+1, j+1, i+1), y(k+1, j+1, i+1), z(k+1, j+1, i+1) };
+      cornerCoords[6] = { x(k+1, j+1, i  ), y(k+1, j+1, i  ), z(k+1, j+1, i  ) };
+      cornerCoords[7] = { x(k+1, j  , i  ), y(k+1, j  , i  ), z(k+1, j  , i  ) };
+
+      cornerValues[0] = fcnView(k  , j  , i+1);
+      cornerValues[1] = fcnView(k  , j+1, i+1);
+      cornerValues[2] = fcnView(k  , j+1, i  );
+      cornerValues[3] = fcnView(k  , j  , i  );
+      cornerValues[4] = fcnView(k+1, j  , i+1);
+      cornerValues[5] = fcnView(k+1, j+1, i+1);
+      cornerValues[6] = fcnView(k+1, j+1, i  );
+      cornerValues[7] = fcnView(k+1, j  , i  );
+      // clang-format on
+    }
+
+    //!@brief Interpolate for the contour location crossing a parent edge.
+    template <int TDIM = DIM>
+    AXOM_HOST_DEVICE typename std::enable_if<TDIM == 2>::type linear_interp(
+      int edgeIdx,
+      const Point cornerCoords[4],
+      const double nodeValues[4],
+      Point& crossingPt) const
+    {
+      // STEP 0: get the edge node indices
+      // 2 nodes define the edge.  n1 and n2 are the indices of
+      // the nodes w.r.t. the square or cubic zone.  There is a
+      // agreed-on ordering of these indices in the arrays xx, yy,
+      // zz, nodeValues, crossingPt.
+      int n1 = edgeIdx;
+      int n2 = (edgeIdx == 3) ? 0 : edgeIdx + 1;
+
+      // STEP 1: get the fields and coordinates from the two points
+      const double f1 = nodeValues[n1];
+      const double f2 = nodeValues[n2];
+
+      const Point& p1 = cornerCoords[n1];
+      const Point& p2 = cornerCoords[n2];
+
+      // STEP 2: check whether the interpolated point is at one of the two corners.
+      if(axom::utilities::isNearlyEqual(contourVal, f1) ||
+         axom::utilities::isNearlyEqual(f1, f2))
+      {
+        crossingPt = p1;
+        return;
+      }
+
+      if(axom::utilities::isNearlyEqual(contourVal, f2))
+      {
+        crossingPt = p2;
+        return;
+      }
+
+      // STEP 3: point is in between the edge points, interpolate its position
+      constexpr double ptiny = axom::primal::PRIMAL_TINY;
+      const double df = f2 - f1 + ptiny;  //add ptiny to avoid division by zero
+      const double w = (contourVal - f1) / df;
+      for(int d = 0; d < DIM; ++d)
+      {
+        crossingPt[d] = p1[d] + w * (p2[d] - p1[d]);
+      }
+    }
+
+    //!@brief Interpolate for the contour location crossing a parent edge.
+    template <int TDIM = DIM>
+    AXOM_HOST_DEVICE typename std::enable_if<TDIM == 3>::type linear_interp(
+      int edgeIdx,
+      const Point cornerCoords[8],
+      const double nodeValues[8],
+      Point& crossingPt) const
+    {
+      // STEP 0: get the edge node indices
+      // 2 nodes define the edge.  n1 and n2 are the indices of
+      // the nodes w.r.t. the square or cubic zone.  There is a
+      // agreed-on ordering of these indices in the arrays
+      // cornerCoords, nodeValues, hex_edge_table.
+      const int hex_edge_table[] = {
+        0, 1, 1, 2, 2, 3, 3, 0,  // base
+        4, 5, 5, 6, 6, 7, 7, 4,  // top
+        0, 4, 1, 5, 2, 6, 3, 7   // vertical
+      };
+
+      int n1 = hex_edge_table[edgeIdx * 2];
+      int n2 = hex_edge_table[edgeIdx * 2 + 1];
+
+      // STEP 1: get the fields and coordinates from the two points
+      const double f1 = nodeValues[n1];
+      const double f2 = nodeValues[n2];
+
+      const Point& p1 = cornerCoords[n1];
+      const Point& p2 = cornerCoords[n2];
+
+      // STEP 2: check whether the interpolated point is at one of the two corners.
+      if(axom::utilities::isNearlyEqual(contourVal, f1) ||
+         axom::utilities::isNearlyEqual(f1, f2))
+      {
+        crossingPt = p1;
+        return;
+      }
+
+      if(axom::utilities::isNearlyEqual(contourVal, f2))
+      {
+        crossingPt = p2;
+        return;
+      }
+
+      // STEP 3: point is not at corner; interpolate its position
+      constexpr double ptiny = axom::primal::PRIMAL_TINY;
+      const double df = f2 - f1 + ptiny;  //add ptiny to avoid division by zero
+      const double w = (contourVal - f1) / df;
+      for(int d = 0; d < DIM; ++d)
+      {
+        crossingPt[d] = p1[d] + w * (p2[d] - p1[d]);
+      }
+    }
+
+    AXOM_HOST_DEVICE inline axom::StackArray<axom::IndexType, DIM>
+    multidim_cell_index(axom::IndexType flatId) const
+    {
+      axom::StackArray<axom::IndexType, DIM> rval;
+      for(int d = DIM - 1; d >= 0; --d)
+      {
+        rval[d] = flatId / bStrides[d];
+        flatId -= rval[d] * bStrides[d];
+      }
+      return rval;
+    }
+  };  // ComputeContour_Util
 
   void computeContour() override
   {
@@ -361,6 +644,12 @@ public:
     m_contourCellCorners.resize(m_contourCellCount);
     m_contourCellParents.resize(m_contourCellCount);
 
+    auto nodeCoordsView = m_contourNodeCoords.view();
+    auto cellCornersView = m_contourCellCorners.view();
+    auto cellParentsView = m_contourCellParents.view();
+
+    ComputeContour_Util ccu(m_contourVal, m_bStrides, m_fcnView, m_coordsViews);
+
     auto loopBody = AXOM_LAMBDA(axom::IndexType iCrossing)
     {
       const auto& crossingInfo = crossingsView[iCrossing];
@@ -370,9 +659,9 @@ public:
       // Parent cell data for interpolating new node coordinates.
       Point cornerCoords[CELL_CORNER_COUNT];
       double cornerValues[CELL_CORNER_COUNT];
-      get_corner_coords_and_values(crossingInfo.parentCellNum,
-                                   cornerCoords,
-                                   cornerValues);
+      ccu.get_corner_coords_and_values(crossingInfo.parentCellNum,
+                                       cornerCoords,
+                                       cornerValues);
 
       /*
         Create the new cell and its DIM nodes.  New nodes are on
@@ -386,29 +675,30 @@ public:
       for(int iCell = 0; iCell < crossingCellCount; ++iCell)
       {
         IndexType contourCellId = crossingInfo.firstSurfaceCellId + iCell;
-        m_contourCellParents[contourCellId] = crossingInfo.parentCellNum;
+        cellParentsView[contourCellId] = crossingInfo.parentCellNum;
         for(int d = 0; d < DIM; ++d)
         {
           IndexType contourNodeId = contourCellId * DIM + d;
-          m_contourCellCorners[contourCellId][d] = contourNodeId;
+          cellCornersView[contourCellId][d] = contourNodeId;
 
           const int edge = cases_table(crossingInfo.caseNum, iCell * DIM + d);
-          linear_interp(edge,
-                        cornerCoords,
-                        cornerValues,
-                        m_contourNodeCoords[contourNodeId]);
+          ccu.linear_interp(edge,
+                            cornerCoords,
+                            cornerValues,
+                            nodeCoordsView[contourNodeId]);
         }
       }
     };
     axom::for_all<ExecSpace>(0, m_crossingCount, loopBody);
   }
 
-  // These 4 functions provides access to the look-up table
+  // These 4 functions provide access to the look-up table
   // whether on host or device.  Is there a more elegant way
   // to put static 1D and 2D arrays on both host and device?  BTNG.
+
   template <int TDIM = DIM>
-  AXOM_HOST_DEVICE typename std::enable_if<TDIM == 2, int>::type num_contour_cells(
-    int iCase) const
+  AXOM_HOST_DEVICE inline typename std::enable_if<TDIM == 2, int>::type
+  num_contour_cells(int iCase) const
   {
 #define _MC_LOOKUP_NUM_SEGMENTS
 #include "marching_cubes_lookup.hpp"
@@ -418,9 +708,8 @@ public:
   }
 
   template <int TDIM = DIM>
-  AXOM_HOST_DEVICE typename std::enable_if<TDIM == 2, int>::type cases_table(
-    int iCase,
-    int iEdge) const
+  AXOM_HOST_DEVICE inline typename std::enable_if<TDIM == 2, int>::type
+  cases_table(int iCase, int iEdge) const
   {
 #define _MC_LOOKUP_CASES2D
 #include "marching_cubes_lookup.hpp"
@@ -430,8 +719,8 @@ public:
   }
 
   template <int TDIM = DIM>
-  AXOM_HOST_DEVICE typename std::enable_if<TDIM == 3, int>::type num_contour_cells(
-    int iCase) const
+  AXOM_HOST_DEVICE inline typename std::enable_if<TDIM == 3, int>::type
+  num_contour_cells(int iCase) const
   {
 #define _MC_LOOKUP_NUM_TRIANGLES
 #include "marching_cubes_lookup.hpp"
@@ -441,9 +730,8 @@ public:
   }
 
   template <int TDIM = DIM>
-  AXOM_HOST_DEVICE typename std::enable_if<TDIM == 3, int>::type cases_table(
-    int iCase,
-    int iEdge) const
+  AXOM_HOST_DEVICE inline typename std::enable_if<TDIM == 3, int>::type
+  cases_table(int iCase, int iEdge) const
   {
 #define _MC_LOOKUP_CASES3D
 #include "marching_cubes_lookup.hpp"
@@ -456,8 +744,8 @@ public:
     @brief Compute multidimensional index from flat cell index
     in domain data.
   */
-  AXOM_HOST_DEVICE axom::StackArray<axom::IndexType, DIM> multidim_cell_index(
-    axom::IndexType flatId) const
+  AXOM_HOST_DEVICE inline axom::StackArray<axom::IndexType, DIM>
+  multidim_cell_index(axom::IndexType flatId) const
   {
     axom::StackArray<axom::IndexType, DIM> rval;
     for(int d = DIM - 1; d >= 0; --d)
@@ -468,71 +756,52 @@ public:
     return rval;
   }
 
-  template <int TDIM = DIM>
-  AXOM_HOST_DEVICE typename std::enable_if<TDIM == 2>::type
-  get_corner_coords_and_values(IndexType cellNum,
-                               Point cornerCoords[],
-                               double cornerValues[])
-  {
-    const auto c = multidim_cell_index(cellNum);
-    const auto& i = c[0];
-    const auto& j = c[1];
+  /*!
+    @brief Output contour mesh to a mint::UnstructuredMesh object.
 
-    const auto& x = m_coordsViews[0];
-    const auto& y = m_coordsViews[1];
-
-    // clang-format off
-    cornerCoords[0] = { x(j    , i    ), y(j    , i    ) };
-    cornerCoords[1] = { x(j    , i + 1), y(j    , i + 1) };
-    cornerCoords[2] = { x(j + 1, i + 1), y(j + 1, i + 1) };
-    cornerCoords[3] = { x(j + 1, i    ), y(j + 1, i    ) };
-
-    cornerValues[0] = m_fcnView(j    , i    );
-    cornerValues[1] = m_fcnView(j    , i + 1);
-    cornerValues[2] = m_fcnView(j + 1, i + 1);
-    cornerValues[3] = m_fcnView(j + 1, i    );
-    // clang-format on
-  }
-  template <int TDIM = DIM>
-  AXOM_HOST_DEVICE typename std::enable_if<TDIM == 3>::type
-  get_corner_coords_and_values(IndexType cellNum,
-                               Point cornerCoords[],
-                               double cornerValues[])
-  {
-    const auto c = multidim_cell_index(cellNum);
-    const auto& i = c[0];
-    const auto& j = c[1];
-    const auto& k = c[2];
-
-    const auto& x = m_coordsViews[0];
-    const auto& y = m_coordsViews[1];
-    const auto& z = m_coordsViews[2];
-
-    // clang-format off
-    cornerCoords[0] = { x(k  , j  , i+1), y(k  , j  , i+1), z(k  , j  , i+1) };
-    cornerCoords[1] = { x(k  , j+1, i+1), y(k  , j+1, i+1), z(k  , j+1, i+1) };
-    cornerCoords[2] = { x(k  , j+1, i  ), y(k  , j+1, i  ), z(k  , j+1, i  ) };
-    cornerCoords[3] = { x(k  , j  , i  ), y(k  , j  , i  ), z(k  , j  , i  ) };
-    cornerCoords[4] = { x(k+1, j  , i+1), y(k+1, j  , i+1), z(k+1, j  , i+1) };
-    cornerCoords[5] = { x(k+1, j+1, i+1), y(k+1, j+1, i+1), z(k+1, j+1, i+1) };
-    cornerCoords[6] = { x(k+1, j+1, i  ), y(k+1, j+1, i  ), z(k+1, j+1, i  ) };
-    cornerCoords[7] = { x(k+1, j  , i  ), y(k+1, j  , i  ), z(k+1, j  , i  ) };
-
-    cornerValues[0] = m_fcnView(k  , j  , i+1);
-    cornerValues[1] = m_fcnView(k  , j+1, i+1);
-    cornerValues[2] = m_fcnView(k  , j+1, i  );
-    cornerValues[3] = m_fcnView(k  , j  , i  );
-    cornerValues[4] = m_fcnView(k+1, j  , i+1);
-    cornerValues[5] = m_fcnView(k+1, j+1, i+1);
-    cornerValues[6] = m_fcnView(k+1, j+1, i  );
-    cornerValues[7] = m_fcnView(k+1, j  , i  );
-    // clang-format on
-  }
-
-  //!@brief Output contour mesh to a mint::UnstructuredMesh object.
+    mint uses host memory.  If internal memory isn't on the host,
+    make a temporary copy of it on the host.
+  */
   void populateContourMesh(
     axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE>& mesh,
     const std::string& cellIdField) const override
+  {
+    auto internalAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
+    auto hostAllocatorID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+    if(internalAllocatorID == hostAllocatorID)
+    {
+      populateContourMesh(mesh,
+                          cellIdField,
+                          m_contourNodeCoords,
+                          m_contourCellCorners,
+                          m_contourCellParents);
+    }
+    else
+    {
+      axom::Array<Point, 1, MemorySpace::Dynamic> contourNodeCoords(
+        m_contourNodeCoords,
+        hostAllocatorID);
+      axom::Array<MIdx, 1, MemorySpace::Dynamic> contourCellCorners(
+        m_contourCellCorners,
+        hostAllocatorID);
+      axom::Array<IndexType, 1, MemorySpace::Dynamic> contourCellParents(
+        m_contourCellParents,
+        hostAllocatorID);
+
+      populateContourMesh(mesh,
+                          cellIdField,
+                          contourNodeCoords,
+                          contourCellCorners,
+                          contourCellParents);
+    }
+  }
+
+  void populateContourMesh(
+    axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE>& mesh,
+    const std::string& cellIdField,
+    axom::Array<Point, 1, MemorySpace::Dynamic> contourNodeCoords,
+    axom::Array<MIdx, 1, MemorySpace::Dynamic> contourCellCorners,
+    axom::Array<IndexType, 1, MemorySpace::Dynamic> contourCellParents) const
   {
     if(!cellIdField.empty() &&
        !mesh.hasField(cellIdField, axom::mint::CELL_CENTERED))
@@ -542,8 +811,8 @@ public:
                                         DIM);
     }
 
-    const axom::IndexType addedCellCount = m_contourCellCorners.size();
-    const axom::IndexType addedNodeCount = m_contourNodeCoords.size();
+    const axom::IndexType addedCellCount = contourCellCorners.size();
+    const axom::IndexType addedNodeCount = contourNodeCoords.size();
     if(addedCellCount != 0)
     {
       const axom::IndexType priorCellCount = mesh.getNumberOfCells();
@@ -551,11 +820,11 @@ public:
       mesh.reserveNodes(priorNodeCount + addedNodeCount);
       mesh.reserveCells(priorCellCount + addedCellCount);
 
-      mesh.appendNodes((double*)m_contourNodeCoords.data(),
-                       m_contourNodeCoords.size());
+      mesh.appendNodes((double*)contourNodeCoords.data(),
+                       contourNodeCoords.size());
       for(int n = 0; n < addedCellCount; ++n)
       {
-        MIdx cornerIds = m_contourCellCorners[n];
+        MIdx cornerIds = contourCellCorners[n];
         add_to_StackArray(cornerIds, priorNodeCount);
         mesh.appendCell(cornerIds);
       }
@@ -565,125 +834,20 @@ public:
                                           axom::mint::CELL_CENTERED,
                                           numComponents);
       SLIC_ASSERT(numComponents == DIM);
+      // Bump corner indices by priorCellCount to avoid indices
+      // used by other parents domains.
       axom::ArrayView<axom::StackArray<axom::IndexType, DIM>> dstView(
         (axom::StackArray<axom::IndexType, DIM>*)dstPtr,
         priorCellCount + addedCellCount);
       for(axom::IndexType i = 0; i < addedCellCount; ++i)
       {
-        dstView[priorCellCount + i] =
-          multidim_cell_index(m_contourCellParents[i]);
+        dstView[priorCellCount + i] = multidim_cell_index(contourCellParents[i]);
       }
     }
   }
 
-  //!@brief Interpolate for the contour location crossing a parent edge.
-  template <int TDIM = DIM>
-  AXOM_HOST_DEVICE typename std::enable_if<TDIM == 2>::type linear_interp(
-    int edgeIdx,
-    const Point cornerCoords[4],
-    const double nodeValues[4],
-    Point& crossingPt)
-  {
-    // STEP 0: get the edge node indices
-    // 2 nodes define the edge.  n1 and n2 are the indices of
-    // the nodes w.r.t. the square or cubic zone.  There is a
-    // agreed-on ordering of these indices in the arrays xx, yy,
-    // zz, nodeValues, crossingPt.
-    int n1 = edgeIdx;
-    int n2 = (edgeIdx == 3) ? 0 : edgeIdx + 1;
-
-    // STEP 1: get the fields and coordinates from the two points
-    const double f1 = nodeValues[n1];
-    const double f2 = nodeValues[n2];
-
-    const Point& p1 = cornerCoords[n1];
-    const Point& p2 = cornerCoords[n2];
-
-    // STEP 2: check whether the interpolated point is at one of the two corners.
-    if(axom::utilities::isNearlyEqual(m_contourVal, f1) ||
-       axom::utilities::isNearlyEqual(f1, f2))
-    {
-      crossingPt = p1;  // memcpy(crossingPt, p1, DIM * sizeof(double));
-      return;
-    }
-
-    if(axom::utilities::isNearlyEqual(m_contourVal, f2))
-    {
-      crossingPt = p2;  // memcpy(crossingPt, p2, DIM * sizeof(double));
-      return;
-    }
-
-    // STEP 3: point is in between the edge points, interpolate its position
-    constexpr double ptiny = axom::primal::PRIMAL_TINY;
-    const double df = f2 - f1 + ptiny;  //add ptiny to avoid division by zero
-    const double w = (m_contourVal - f1) / df;
-    for(int d = 0; d < DIM; ++d)
-    {
-      crossingPt[d] = p1[d] + w * (p2[d] - p1[d]);
-    }
-  }
-
-  //!@brief Interpolate for the contour location crossing a parent edge.
-  template <int TDIM = DIM>
-  AXOM_HOST_DEVICE typename std::enable_if<TDIM == 3>::type linear_interp(
-    int edgeIdx,
-    const Point cornerCoords[8],
-    const double nodeValues[8],
-    Point& crossingPt)
-  {
-    // STEP 0: get the edge node indices
-    // 2 nodes define the edge.  n1 and n2 are the indices of
-    // the nodes w.r.t. the square or cubic zone.  There is a
-    // agreed-on ordering of these indices in the arrays
-    // cornerCoords, nodeValues, hex_edge_table.
-    const int hex_edge_table[] = {
-      0, 1, 1, 2, 2, 3, 3, 0,  // base
-      4, 5, 5, 6, 6, 7, 7, 4,  // top
-      0, 4, 1, 5, 2, 6, 3, 7   // vertical
-    };
-
-    int n1 = hex_edge_table[edgeIdx * 2];
-    int n2 = hex_edge_table[edgeIdx * 2 + 1];
-
-    // STEP 1: get the fields and coordinates from the two points
-    const double f1 = nodeValues[n1];
-    const double f2 = nodeValues[n2];
-
-    const Point& p1 = cornerCoords[n1];
-    const Point& p2 = cornerCoords[n2];
-
-    // STEP 2: check whether the interpolated point is at one of the two corners.
-    if(axom::utilities::isNearlyEqual(m_contourVal, f1) ||
-       axom::utilities::isNearlyEqual(f1, f2))
-    {
-      crossingPt = p1;
-      return;
-    }
-
-    if(axom::utilities::isNearlyEqual(m_contourVal, f2))
-    {
-      crossingPt = p2;
-      return;
-    }
-
-    // STEP 3: point is not at corner; interpolate its position
-    constexpr double ptiny = axom::primal::PRIMAL_TINY;
-    const double df = f2 - f1 + ptiny;  //add ptiny to avoid division by zero
-    const double w = (m_contourVal - f1) / df;
-    for(int d = 0; d < DIM; ++d)
-    {
-      crossingPt[d] = p1[d] + w * (p2[d] - p1[d]);
-    }
-  }
-
-  //!@brief Set a value to find the contour for.
-  void setContourValue(double contourVal) override
-  {
-    m_contourVal = contourVal;
-  }
-
   //!@brief Compute the case index into cases2D or cases3D.
-  AXOM_HOST_DEVICE int compute_crossing_case(const double* f)
+  AXOM_HOST_DEVICE inline int compute_crossing_case(const double* f) const
   {
     int index = 0;
     for(int n = 0; n < CELL_CORNER_COUNT; ++n)
@@ -711,43 +875,33 @@ public:
     @brief Constructor.
   */
   MarchingCubesImpl()
-    : m_crossings(0, 0, execution_space<ExecSpace>::allocatorID())
-    , m_contourNodeCoords(0, 0, execution_space<ExecSpace>::allocatorID())
-    , m_contourCellCorners(0, 0, execution_space<ExecSpace>::allocatorID())
-    , m_contourCellParents(0, 0, execution_space<ExecSpace>::allocatorID())
+    : m_allocatorID(execution_space<ExecSpace>::allocatorID())
+    , m_crossings(0, 0)
+    , m_contourNodeCoords(0, 0)
+    , m_contourCellCorners(0, 0)
+    , m_contourCellParents(0, 0)
   { }
 
-  /*!
-    @brief Info for a parent cell intersecting the contour surface.
-  */
-  struct CrossingInfo
-  {
-    CrossingInfo(axom::IndexType parentCellNum_, std::uint16_t caseNum_)
-      : parentCellNum(parentCellNum_)
-      , caseNum(caseNum_)
-      , firstSurfaceCellId(std::numeric_limits<axom::IndexType>::max())
-    { }
-    axom::IndexType parentCellNum;       //!< @brief Flat index of parent cell.
-    std::uint16_t caseNum;               //!< @brief Index in cases2D or cases3D
-    axom::IndexType firstSurfaceCellId;  //!< @brief First index for generated cells.
-  };
-
 private:
-  MIdx m_bShape;  //!< @brief Blueprint cell data shape.
-  MIdx m_cShape;  //!< @brief Cell-centered array shape for ArrayViews.
-  MIdx m_pShape;  //!< @brief Node-centered array shape for ArrayViews.
-  axom::IndexType m_bStrides[DIM];  //!< @brief Strides for m_bShape arrays.
+  const int m_allocatorID;  //!< @brief ExecSpace-based allocator ID for all internal data
+  MIdx m_bShape;            //!< @brief Blueprint cell data shape.
+  MIdx m_cShape;    //!< @brief Cell-centered array shape for ArrayViews.
+  MIdx m_pShape;    //!< @brief Node-centered array shape for ArrayViews.
+  MIdx m_bStrides;  //!< @brief Strides for m_bShape arrays.
 
   // Views of parent domain data.
-  axom::ArrayView<const double, DIM> m_coordsViews[DIM];
-  axom::ArrayView<const double, DIM> m_fcnView;
-  axom::ArrayView<const int, DIM> m_maskView;
+  // DIM coordinate components, each on a DIM-dimensional mesh.
+  using CoordViews =
+    axom::StackArray<axom::ArrayView<const double, DIM, MemorySpace>, DIM>;
+  CoordViews m_coordsViews;
+  axom::ArrayView<const double, DIM, MemorySpace> m_fcnView;
+  axom::ArrayView<const int, DIM, MemorySpace> m_maskView;
 
   //!@brief Crossing case for each computational mesh cell.
   axom::Array<std::uint16_t, DIM, MemorySpace> m_caseIds;
 
   //!@brief Info on every parent cell that crosses the contour surface.
-  axom::Array<CrossingInfo> m_crossings;
+  axom::Array<CrossingInfo, 1, MemorySpace> m_crossings;
 
   //!@brief Number of parent cells crossing the contour surface.
   axom::IndexType m_crossingCount = 0;
@@ -764,13 +918,13 @@ private:
   //!@name Internal representation of generated contour mesh.
   //@{
   //!@brief Coordinates of generated surface mesh nodes.
-  axom::Array<Point> m_contourNodeCoords;
+  axom::Array<Point, 1, MemorySpace> m_contourNodeCoords;
 
   //!@brief Corners (index into m_contourNodeCoords) of generated contour cells.
-  axom::Array<MIdx> m_contourCellCorners;
+  axom::Array<MIdx, 1, MemorySpace> m_contourCellCorners;
 
   //!@brief Flat index of computational cell crossing the contour cell.
-  axom::Array<IndexType> m_contourCellParents;
+  axom::Array<IndexType, 1, MemorySpace> m_contourCellParents;
   //@}
 
   double m_contourVal = 0.0;

--- a/src/axom/quest/detail/MarchingCubesImpl.hpp
+++ b/src/axom/quest/detail/MarchingCubesImpl.hpp
@@ -56,7 +56,8 @@ public:
   using MIdx = axom::StackArray<axom::IndexType, DIM>;
   using LoopPolicy = typename execution_space<ExecSpace>::loop_policy;
   using ReducePolicy = typename execution_space<ExecSpace>::reduce_policy;
-  using SequentialLoopPolicy = typename execution_space<SequentialExecSpace>::loop_policy;
+  using SequentialLoopPolicy =
+    typename execution_space<SequentialExecSpace>::loop_policy;
   static constexpr auto MemorySpace = execution_space<ExecSpace>::memory_space;
   /*!
     @brief Initialize data to a blueprint domain.

--- a/src/axom/quest/detail/MarchingCubesImpl.hpp
+++ b/src/axom/quest/detail/MarchingCubesImpl.hpp
@@ -44,11 +44,11 @@ static void reverse(axom::StackArray<T, DIM>& a)
   classes MarchCubes and MarchingCubesSingleDomain.
 
   ExecSpace is the general execution space, like axom::SEQ_EXEC and
-  axom::CUDA_EXEC<256>.  SequentialLoopPolicy is used for loops that
-  cannot be parallelized.  Use something like RAJA::seq_exec or
-  RAJA::cuda_exec<1>.
+  axom::CUDA_EXEC<256>.  SequentialExecSpace is used for loops that
+  cannot be parallelized but must access data allocated for ExecSpace.
+  Use something like axom::SEQ_EXEC or axom::CUDA_EXEC<1>.
 */
-template <int DIM, typename ExecSpace, typename SequentialLoopPolicy>
+template <int DIM, typename ExecSpace, typename SequentialExecSpace>
 class MarchingCubesImpl : public MarchingCubesSingleDomain::ImplBase
 {
 public:
@@ -56,6 +56,7 @@ public:
   using MIdx = axom::StackArray<axom::IndexType, DIM>;
   using LoopPolicy = typename execution_space<ExecSpace>::loop_policy;
   using ReducePolicy = typename execution_space<ExecSpace>::reduce_policy;
+  using SequentialLoopPolicy = typename execution_space<SequentialExecSpace>::loop_policy;
   static constexpr auto MemorySpace = execution_space<ExecSpace>::memory_space;
   /*!
     @brief Initialize data to a blueprint domain.

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -106,12 +106,13 @@ if(CONDUIT_FOUND)
             set(_nranks 3)
         endif()
 
-        # Run the distributed closest point example on N ranks for each enabled policy
+        # Run the marching cubes example on N ranks for each enabled policy
         set(_policies "seq")
-        blt_list_append(TO _policies ELEMENTS "omp" IF ENABLE_OPENMP)
-        # Temporarily disable all execution policies the example doesn't yet support.
-        blt_list_append(TO _policies ELEMENTS "cuda" IF ENABLE_CUDA)
-        blt_list_append(TO _policies ELEMENTS "hip" IF ENABLE_HIP)
+        if(RAJA_FOUND)
+            blt_list_append(TO _policies ELEMENTS "omp" IF AXOM_ENABLE_OPENMP)
+            blt_list_append(TO _policies ELEMENTS "cuda" IF AXOM_ENABLE_CUDA)
+            blt_list_append(TO _policies ELEMENTS "hip" IF AXOM_ENABLE_HIP)
+        endif()
 
         # Non-zero empty-rank probability tests domain underloading case
         set(_meshes "mdmesh.2x1" "mdmesh.2x3" "mdmesh.2x2x1")

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -138,6 +138,7 @@ if(CONDUIT_FOUND)
                 axom_add_test(
                     NAME    ${_test}
                     COMMAND quest_marching_cubes_ex
+                                --policy ${_pol}
                                 --mesh-file ${quest_data_dir}/${_mesh}.root
                                 --fields-file ${_test}.field
                                 --dir ${_dir}

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -1267,12 +1267,10 @@ struct RoundContourTest : public ContourTestBase<DIM, ExecSpace>
 {
   RoundContourTest(const axom::primal::Point<double, DIM>& pt)
     : ContourTestBase<DIM, ExecSpace>()
-    , _center(pt)
-    , _sphere(_center, 0.0)
+    , _sphere(pt, 0.0)
     , _errTol(1e-3)
   { }
   virtual ~RoundContourTest() { }
-  const axom::primal::Point<double, DIM> _center;
   const axom::primal::Sphere<double, DIM> _sphere;
   double _errTol;
 
@@ -1336,13 +1334,9 @@ struct PlanarContourTest : public ContourTestBase<DIM, ExecSpace>
   PlanarContourTest(const axom::primal::Point<double, DIM>& inPlane,
                     const axom::primal::Vector<double, DIM>& perpDir)
     : ContourTestBase<DIM, ExecSpace>()
-    , _inPlane(inPlane)
-    , _normal(perpDir.unitVector())
-    , _plane(_normal, _inPlane)
+    , _plane(perpDir.unitVector(), inPlane)
   { }
   virtual ~PlanarContourTest() { }
-  const axom::primal::Point<double, DIM> _inPlane;
-  const axom::primal::Vector<double, DIM> _normal;
   const axom::primal::Plane<double, DIM> _plane;
 
   virtual std::string name() const override { return std::string("planar"); }

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -214,6 +214,68 @@ public:
   }
 };
 
+//!@brief Our allocatorId, based on execution policy.
+static int allocatorId = axom::INVALID_ALLOCATOR_ID;  // Set in main.
+static int allocatorIdForPolicy(quest::MarchingCubesRuntimePolicy policy)
+{
+  //---------------------------------------------------------------------------
+  // Set default allocator for possibly testing on devices
+  //---------------------------------------------------------------------------
+  int aid = axom::INVALID_ALLOCATOR_ID;
+
+  // clang-format off
+  if(policy == axom::quest::MarchingCubesRuntimePolicy::seq)
+  {
+    aid = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  }
+#if defined(AXOM_USE_RAJA)
+#ifdef _AXOM_MC_USE_OPENMP
+  else if(policy == axom::quest::MarchingCubesRuntimePolicy::omp)
+  {
+    aid = axom::execution_space<axom::OMP_EXEC>::allocatorID();
+  }
+#endif
+#ifdef _AXOM_MC_USE_CUDA
+  else if(policy == axom::quest::MarchingCubesRuntimePolicy::cuda)
+  {
+    aid = axom::execution_space<axom::CUDA_EXEC<256>>::allocatorID();
+  }
+#endif
+#ifdef _AXOM_MC_USE_HIP
+  else if(policy == axom::quest::MarchingCubesRuntimePolicy::hip)
+  {
+    aid = axom::execution_space<axom::HIP_EXEC<256>>::allocatorID();
+  }
+#endif
+#endif
+  // clang-format on
+
+  SLIC_ERROR_IF(
+    aid == axom::INVALID_ALLOCATOR_ID,
+    axom::fmt::format("Cannot find allocator id for policy '{}'", policy));
+  return aid;
+}
+
+//!@brief Put a conduit::Node array data into the specified memory space.
+template <typename T>
+void putConduitDataInNewMemorySpace(conduit::Node& node,
+                                    const std::string& path,
+                                    int allocId)
+{
+  SLIC_ASSERT(node.has_path(path));
+  conduit::Node& dataNode = node[path];
+  SLIC_ASSERT(!dataNode.dtype().is_empty() && !dataNode.dtype().is_object() &&
+              !dataNode.dtype().is_list());
+
+  std::size_t count = dataNode.dtype().number_of_elements();
+  // dataNode.print();
+  T* oldPtr = static_cast<T*>(dataNode.data_ptr());
+  T* newPtr = axom::allocate<T>(count, allocId);
+  axom::copy(newPtr, oldPtr, count * sizeof(T));
+  dataNode.set_external(newPtr, count);
+  dataNode.print();
+}
+
 Input params;
 
 int myRank = -1, numRanks = -1;  // MPI stuff, set in main().
@@ -243,6 +305,16 @@ public:
     if(_ndims == 3)
     {
       checkMeshStorage<3>();
+    }
+
+    _maxSpacing = maxSpacing();
+
+    putMeshDataInNewMemorySpace<double>(_coordsetPath + "/values/x", allocatorId);
+    putMeshDataInNewMemorySpace<double>(_coordsetPath + "/values/y", allocatorId);
+    if(_ndims == 3)
+    {
+      putMeshDataInNewMemorySpace<double>(_coordsetPath + "/values/z",
+                                          allocatorId);
     }
   }
 
@@ -347,9 +419,18 @@ public:
 
   /*!
     @return largest mesh spacing.
+
+    Compute only once, because after that, coordinates data may be
+    moved to devices.
   */
   double maxSpacing() const
   {
+    if(_maxSpacing >= 0)
+    {
+      // Max spacing has been computed and cached.
+      return _maxSpacing;
+    }
+
     double localRval = 0.0;
     for(axom::IndexType domId = 0; domId < domainCount(); ++domId)
     {
@@ -530,12 +611,29 @@ public:
     }
   }
 
+  /*!
+    @param[in] path Path to existing data in the blueprint mesh,
+    relative to each domain in the mesh.
+    @param[in] allocId Allocator id for the new memory space.
+    @tparam Type of data being moved.  Should be something Conduit
+    supports, i.e., not custom user data.
+  */
+  template <typename T>
+  void putMeshDataInNewMemorySpace(const std::string& path, int allocId)
+  {
+    for(auto& dom : _mdMesh.children())
+    {
+      putConduitDataInNewMemorySpace<T>(dom, path, allocId);
+    }
+  }
+
 private:
   int _ndims {-1};
   conduit::Node _mdMesh;
   axom::IndexType _domCount;
   const std::string _coordsetPath;
   const std::string _topologyPath;
+  double _maxSpacing = -1.0;
 
   /*!
     @brief Read a blueprint mesh.
@@ -565,8 +663,7 @@ private:
 #endif
     SLIC_ASSERT(_ndims > 0);
 
-    bool valid = isValid();
-    SLIC_ASSERT(valid);
+    SLIC_ASSERT(isValid());
   }
 };  // BlueprintStructuredMesh
 
@@ -693,7 +790,7 @@ axom::StackArray<axom::IndexType, DIM> flatToMultidimIndex(
   return rval;
 }
 
-template <int DIM>
+template <int DIM, typename ExecSpace>
 struct ContourTestBase
 {
   ContourTestBase()
@@ -709,10 +806,16 @@ struct ContourTestBase
   virtual std::string functionName() const = 0;
 
   //!@brief Return function value at a point.
-  virtual double value(const axom::primal::Point<double, DIM>& pt) const = 0;
+  virtual AXOM_HOST_DEVICE double value(
+    const axom::primal::Point<double, DIM>& pt) const = 0;
 
   //!@brief Return error tolerance for contour mesh accuracy check.
   virtual double errorTolerance() const = 0;
+
+  //!@brief Set nodal distances given nodal coordinates.
+  virtual void fillNodalValuesFromCoords(
+    axom::ArrayView<double, DIM> coordsViews[DIM],
+    axom::ArrayView<double, DIM>& fieldView) const = 0;
 
   const std::string m_parentCellIdField;
   const std::string m_domainIdField;
@@ -795,9 +898,6 @@ struct ContourTestBase
         coordsPtrs[d] = coordsValues[d].as_double_ptr();
         coordsViews[d] = axom::ArrayView<double, DIM>(coordsPtrs[d], shape);
       }
-      axom::ArrayView<axom::primal::Point<double, DIM>, DIM> coordsView(
-        (axom::primal::Point<double, DIM>*)coordsValues.data_ptr(),
-        shape);
 
       // Create the nodal function data.
       conduit::Node& fieldNode = dom["fields"][functionName()];
@@ -805,21 +905,11 @@ struct ContourTestBase
       fieldNode["topology"] = "mesh";
       fieldNode["volume_dependent"] = "false";
       fieldNode["values"].set(conduit::DataType::float64(pointCount));
+      putConduitDataInNewMemorySpace<double>(fieldNode, "values", allocatorId);
       double* d = fieldNode["values"].value();
       axom::ArrayView<double, DIM> fieldView(d, shape);
 
-      // Set the function value at the nodes.
-      // value(pt) is the virtual function defining the
-      // distance in a derived class.
-      for(int n = 0; n < pointCount; ++n)
-      {
-        axom::primal::Point<double, DIM> pt;
-        for(int d = 0; d < DIM; ++d)
-        {
-          pt[d] = coordsViews[d].flatIndex(n);
-        }
-        fieldView.flatIndex(n) = value(pt);
-      }
+      fillNodalValuesFromCoords(coordsViews, fieldView);
     }
   }
 
@@ -1172,16 +1262,18 @@ struct ContourTestBase
 /*!
   @brief Function providing distance from a point.
 */
-template <int DIM>
-struct RoundContourTest : public ContourTestBase<DIM>
+template <int DIM, typename ExecSpace>
+struct RoundContourTest : public ContourTestBase<DIM, ExecSpace>
 {
   RoundContourTest(const axom::primal::Point<double, DIM>& pt)
-    : ContourTestBase<DIM>()
+    : ContourTestBase<DIM, ExecSpace>()
     , _center(pt)
+    , _sphere(_center, 0.0)
     , _errTol(1e-3)
   { }
   virtual ~RoundContourTest() { }
   const axom::primal::Point<double, DIM> _center;
+  const axom::primal::Sphere<double, DIM> _sphere;
   double _errTol;
 
   virtual std::string name() const override { return std::string("round"); }
@@ -1191,11 +1283,9 @@ struct RoundContourTest : public ContourTestBase<DIM>
     return std::string("dist_to_center");
   }
 
-  double value(const axom::primal::Point<double, DIM>& pt) const override
+  AXOM_HOST_DEVICE double value(const axom::primal::Point<double, DIM>& pt) const override
   {
-    double dist = primal::squared_distance(_center, pt);
-    dist = sqrt(dist);
-    return dist;
+    return _sphere.computeSignedDistance(pt);
   }
 
   double errorTolerance() const override { return _errTol; }
@@ -1205,13 +1295,37 @@ struct RoundContourTest : public ContourTestBase<DIM>
     double maxSpacing = bsm.maxSpacing();
     _errTol = 0.1 * maxSpacing;
   }
+
+  void fillNodalValuesFromCoords(axom::ArrayView<double, DIM> coordsViews_[DIM],
+                                 axom::ArrayView<double, DIM>& fieldView) const override
+  {
+    const axom::IndexType pointCount = fieldView.size();
+
+    axom::ArrayView<double, DIM> coordsViews[DIM];
+    for(int d = 0; d < DIM; ++d) coordsViews[d] = coordsViews_[d];
+
+    // Duplicate member data so devices don't have to use the this pointer.
+    const auto sphere = _sphere;
+
+    auto loopBody = AXOM_LAMBDA(int n)
+    {
+      axom::primal::Point<double, DIM> pt;
+      for(int d = 0; d < DIM; ++d)
+      {
+        pt[d] = coordsViews[d].flatIndex(n);
+      }
+      fieldView.flatIndex(n) = sphere.computeSignedDistance(pt);
+    };
+
+    axom::for_all<ExecSpace>(0, pointCount, loopBody);
+  }
 };
 
 /*!
   @brief Function providing signed distance from a plane.
 */
-template <int DIM>
-struct PlanarContourTest : public ContourTestBase<DIM>
+template <int DIM, typename ExecSpace>
+struct PlanarContourTest : public ContourTestBase<DIM, ExecSpace>
 {
   /*!
     @brief Constructor.
@@ -1221,13 +1335,15 @@ struct PlanarContourTest : public ContourTestBase<DIM>
   */
   PlanarContourTest(const axom::primal::Point<double, DIM>& inPlane,
                     const axom::primal::Vector<double, DIM>& perpDir)
-    : ContourTestBase<DIM>()
+    : ContourTestBase<DIM, ExecSpace>()
     , _inPlane(inPlane)
     , _normal(perpDir.unitVector())
+    , _plane(_normal, _inPlane)
   { }
   virtual ~PlanarContourTest() { }
   const axom::primal::Point<double, DIM> _inPlane;
   const axom::primal::Vector<double, DIM> _normal;
+  const axom::primal::Plane<double, DIM> _plane;
 
   virtual std::string name() const override { return std::string("planar"); }
 
@@ -1236,14 +1352,36 @@ struct PlanarContourTest : public ContourTestBase<DIM>
     return std::string("dist_to_plane");
   }
 
-  double value(const axom::primal::Point<double, DIM>& pt) const override
+  AXOM_HOST_DEVICE double value(const axom::primal::Point<double, DIM>& pt) const override
   {
-    axom::primal::Vector<double, DIM> r(_inPlane, pt);
-    double dist = r.dot(_normal);
-    return dist;
+    return _plane.signedDistance(pt);
   }
 
   double errorTolerance() const override { return 1e-15; }
+
+  void fillNodalValuesFromCoords(axom::ArrayView<double, DIM> coordsViews_[DIM],
+                                 axom::ArrayView<double, DIM>& fieldView) const override
+  {
+    const axom::IndexType pointCount = fieldView.size();
+
+    axom::ArrayView<double, DIM> coordsViews[DIM];
+    for(int d = 0; d < DIM; ++d) coordsViews[d] = coordsViews_[d];
+
+    // Duplicate member data so devices don't have to use the this pointer.
+    const auto plane = _plane;
+
+    auto loopBody = AXOM_LAMBDA(int n)
+    {
+      axom::primal::Point<double, DIM> pt;
+      for(int d = 0; d < DIM; ++d)
+      {
+        pt[d] = coordsViews[d].flatIndex(n);
+      }
+      fieldView.flatIndex(n) = plane.signedDistance(pt);
+    };
+
+    axom::for_all<ExecSpace>(0, pointCount, loopBody);
+  }
 };
 
 /// Utility function to transform blueprint node storage.
@@ -1306,7 +1444,7 @@ void finalizeLogger()
 /*!
   All the test code that depends on DIM to instantiate.
 */
-template <int DIM>
+template <int DIM, typename ExecSpace>
 int testNdimInstance(BlueprintStructuredMesh& computationalMesh)
 {
   // Create marching cubes algorithm object and set some parameters
@@ -1318,23 +1456,24 @@ int testNdimInstance(BlueprintStructuredMesh& computationalMesh)
   // params specify which tests to run.
   //---------------------------------------------------------------------------
 
-  std::shared_ptr<RoundContourTest<DIM>> roundTest;
-  std::shared_ptr<PlanarContourTest<DIM>> planarTest;
+  std::shared_ptr<RoundContourTest<DIM, ExecSpace>> roundTest;
+  std::shared_ptr<PlanarContourTest<DIM, ExecSpace>> planarTest;
 
   if(params.usingRound)
   {
-    roundTest =
-      std::make_shared<RoundContourTest<DIM>>(params.roundContourCenter<DIM>());
+    roundTest = std::make_shared<RoundContourTest<DIM, ExecSpace>>(
+      params.roundContourCenter<DIM>());
     roundTest->setToleranceByLongestEdge(computationalMesh);
     roundTest->computeNodalDistance(computationalMesh);
   }
   if(params.usingPlanar)
   {
-    planarTest =
-      std::make_shared<PlanarContourTest<DIM>>(params.inplanePoint<DIM>(),
-                                               params.planeNormal<DIM>());
+    planarTest = std::make_shared<PlanarContourTest<DIM, ExecSpace>>(
+      params.inplanePoint<DIM>(),
+      params.planeNormal<DIM>());
     planarTest->computeNodalDistance(computationalMesh);
   }
+  computationalMesh.printMeshInfo();
 
   // Write computational mesh with contour functions.
   saveMesh(computationalMesh.asConduitNode(), params.fieldsFile);
@@ -1421,11 +1560,12 @@ int main(int argc, char** argv)
     exit(retval);
   }
 
+  allocatorId = allocatorIdForPolicy(params.policy);
+
   //---------------------------------------------------------------------------
   // Load computational mesh.
   //---------------------------------------------------------------------------
   BlueprintStructuredMesh computationalMesh(params.meshFile);
-  // computationalMesh.printMeshInfo();
 
   SLIC_INFO_IF(
     params.isVerbose(),
@@ -1470,15 +1610,62 @@ int main(int argc, char** argv)
 
   slic::flushStreams();
 
+  //---------------------------------------------------------------------------
+  // Run test in the execution space set by command line.
+  //---------------------------------------------------------------------------
   int errCount = 0;
-  if(params.ndim == 2)
+  if(params.policy == quest::MarchingCubesRuntimePolicy::seq)
   {
-    errCount = testNdimInstance<2>(computationalMesh);
+    if(params.ndim == 2)
+    {
+      errCount = testNdimInstance<2, axom::SEQ_EXEC>(computationalMesh);
+    }
+    else if(params.ndim == 3)
+    {
+      errCount = testNdimInstance<3, axom::SEQ_EXEC>(computationalMesh);
+    }
   }
-  else if(params.ndim == 3)
+#if defined(AXOM_USE_RAJA)
+  #ifdef AXOM_USE_OPENMP
+  else if(params.policy == quest::MarchingCubesRuntimePolicy::omp)
   {
-    errCount = testNdimInstance<3>(computationalMesh);
+    if(params.ndim == 2)
+    {
+      errCount = testNdimInstance<2, axom::OMP_EXEC>(computationalMesh);
+    }
+    else if(params.ndim == 3)
+    {
+      errCount = testNdimInstance<3, axom::OMP_EXEC>(computationalMesh);
+    }
   }
+  #endif
+  #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+  else if(params.policy == quest::MarchingCubesRuntimePolicy::cuda)
+  {
+    if(params.ndim == 2)
+    {
+      errCount = testNdimInstance<2, axom::CUDA_EXEC<256>>(computationalMesh);
+    }
+    else if(params.ndim == 3)
+    {
+      errCount = testNdimInstance<3, axom::CUDA_EXEC<256>>(computationalMesh);
+    }
+  }
+  #endif
+  #if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
+  else if(params.policy == quest::MarchingCubesRuntimePolicy::hip)
+  {
+    if(params.ndim == 2)
+    {
+      errCount = testNdimInstance<2, axom::HIP_EXEC<256>>(computationalMesh);
+    }
+    else if(params.ndim == 3)
+    {
+      errCount = testNdimInstance<3, axom::HIP_EXEC<256>>(computationalMesh);
+    }
+  }
+  #endif
+#endif
 
   finalizeLogger();
 #ifdef AXOM_USE_MPI


### PR DESCRIPTION
# Fix marching cubes loops on GPUs

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fix a loop that was parallelized but is not data-parallel so should not have been.
  - Fix a test rule that allowed this bug to slip through
  - Fix the marching cubes test code so that it puts mesh data on the GPU.
  - Fix `MarchingCubesImpl` where it was unintentionally trying to use host data on the GPU.

I added template parameter `SequentialLoopPolicy` for use with loops that should not be parallelized.  An unconventional RAJA construct is used to run loops sequentially.

There was some systemic problem running on GPUs, problems that was hidden by the automatic address translation services.  One of the needed changes was to factor out some functionalities into smaller classes whose light-weight objects can be automatically copied into GPU memory for the lambda expressions.  `MarkCrossings_Util` and `ComputeContour_Util` are the two smaller classes.  `MarchingCubesImpl` was too big to warrant copying into GPU memory every time we entered a GPU loop.