### PR TITLE
Use srun flux wrapper path for toss 4 cray machines

### DIFF
--- a/host-configs/rzvernal-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
+++ b/host-configs/rzvernal-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
@@ -41,7 +41,7 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-
 
 set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.2.3/bin/mpif90" CACHE PATH "")
 
-set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
+set(MPIEXEC_EXECUTABLE "srun" CACHE PATH "")
 
 set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
 

--- a/host-configs/tioga-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
+++ b/host-configs/tioga-toss_4_x86_64_ib_cray-clang@14.0.0_hip.cmake
@@ -41,7 +41,7 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-
 
 set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.2.3/bin/mpif90" CACHE PATH "")
 
-set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
+set(MPIEXEC_EXECUTABLE "srun" CACHE PATH "")
 
 set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
 


### PR DESCRIPTION
This PR:
- Changes unit tests to use srun flux wrapper instead of slurm srun.

This change will require modifying the spack recipe for axom to make it automated and not manual, which can be done in a follow-up PR (#1122 will modify the spack recipe)