### PR TITLE
Uses clang-tidy to add braces around one line statements

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,6 +1,6 @@
 Checks:          '-*,readability-braces-around-statements'
 WarningsAsErrors: ''
-HeaderFilterRegex: ''
+HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
 FormatStyle: none
 CheckOptions:

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,0 +1,6 @@
+Checks:          '-*,readability-braces-around-statements'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle: none
+CheckOptions:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,7 +51,6 @@ if (“${PROJECT_SOURCE_DIR}” STREQUAL “${CMAKE_SOURCE_DIR}”)
     # These are not used in Axom, turn them off
     set(_unused_blt_tools
         CLANGQUERY
-        CLANGTIDY
         VALGRIND
         ASTYLE
         CMAKEFORMAT
@@ -65,6 +64,8 @@ if (“${PROJECT_SOURCE_DIR}” STREQUAL “${CMAKE_SOURCE_DIR}”)
     # unless an explicit executable path is given
     set(_used_blt_tools
         CLANGFORMAT
+        CLANGTIDY
+        CLANGAPPLYREPLACEMENTS
         CPPCHECK
         DOXYGEN
         SPHINX)
@@ -77,6 +78,9 @@ if (“${PROJECT_SOURCE_DIR}” STREQUAL “${CMAKE_SOURCE_DIR}”)
     endforeach()
 
     set(BLT_REQUIRED_CLANGFORMAT_VERSION  "10" CACHE STRING "")
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy 
+                   ${CMAKE_CURRENT_BINARY_DIR}/.clang-tidy
+                   COPYONLY)
 
     # If Axom is the top project and AXOM_ENABLE_TESTS is off, force ENABLE_TESTS to off so
     # gtest doesn't build when it's not needed

--- a/src/axom/core/examples/core_numerics.cpp
+++ b/src/axom/core/examples/core_numerics.cpp
@@ -112,7 +112,10 @@ void display_eigs(double* eigvec, double* eigval, int nrows, int i)
             << " = [";
   for(int j = 0; j < nrows; ++j)
   {
-    if(j > 0) std::cout << ", ";
+    if(j > 0)
+    {
+      std::cout << ", ";
+    }
     std::cout << eigvec[i * nrows + j];
   }
   std::cout << "]" << std::endl;

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -201,7 +201,10 @@ inline T* allocate(std::size_t n, int allocID) noexcept
 template <typename T>
 inline void deallocate(T*& pointer) noexcept
 {
-  if(pointer == nullptr) return;
+  if(pointer == nullptr)
+  {
+    return;
+  }
 
 #ifdef AXOM_USE_UMPIRE
 

--- a/src/axom/core/numerics/matvecops.hpp
+++ b/src/axom/core/numerics/matvecops.hpp
@@ -585,13 +585,19 @@ void make_orthogonal(T* u, T* v, int dim, double tol)
 
   double norm = static_cast<double>(dot_product(v, v, dim));
 
-  if(norm < tol) return;
+  if(norm < tol)
+  {
+    return;
+  }
 
   T tnorm = static_cast<T>(norm);
 
   T dot = dot_product(u, v, dim);
 
-  for(int l = 0; l < dim; ++l) u[l] -= ((dot * v[l]) / tnorm);
+  for(int l = 0; l < dim; ++l)
+  {
+    u[l] -= ((dot * v[l]) / tnorm);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/core/tests/core_bit_utilities.hpp
+++ b/src/axom/core/tests/core_bit_utilities.hpp
@@ -68,7 +68,10 @@ TEST(core_bit_utilities, trailingZeroes)
     int bit = 0;
     for(; bit < BITS; ++bit)
     {
-      if(rand_val & shifted(bit)) break;
+      if(rand_val & shifted(bit))
+      {
+        break;
+      }
     }
     EXPECT_EQ(bit, axom::utilities::trailingZeros(rand_val));
   }
@@ -127,7 +130,10 @@ TEST(core_bit_utilities, popCount)
     int bits = 0;
     for(int i = 0; i < BITS; ++i)
     {
-      if(val & shifted(i)) ++bits;
+      if(val & shifted(i))
+      {
+        ++bits;
+      }
     }
 
     EXPECT_EQ(bits, axom::utilities::popCount(val));
@@ -166,7 +172,10 @@ TEST(core_bit_utilities, leadingZeros)
     int bit = 0;
     for(; bit < BITS; ++bit)
     {
-      if(rand_val & shifted(BITS - bit - 1)) break;
+      if(rand_val & shifted(BITS - bit - 1))
+      {
+        break;
+      }
     }
     EXPECT_EQ(bit, axom::utilities::leadingZeros(rand_val));
   }

--- a/src/axom/core/utilities/Timer.hpp
+++ b/src/axom/core/utilities/Timer.hpp
@@ -74,7 +74,10 @@ public:
    */
   Timer(bool startRunning = false) : m_running(startRunning)
   {
-    if(m_running) start();
+    if(m_running)
+    {
+      start();
+    }
   }
 
   /*!
@@ -107,7 +110,10 @@ public:
    */
   double elapsedTimeInSec()
   {
-    if(m_running) stop();
+    if(m_running)
+    {
+      stop();
+    }
     return clockDiff().count();
   }
 
@@ -117,7 +123,10 @@ public:
    */
   double elapsedTimeInMilliSec()
   {
-    if(m_running) stop();
+    if(m_running)
+    {
+      stop();
+    }
     return std::chrono::duration_cast<MilliTimeDiff>(clockDiff()).count();
   }
 
@@ -127,7 +136,10 @@ public:
    */
   double elapsedTimeInMicroSec()
   {
-    if(m_running) stop();
+    if(m_running)
+    {
+      stop();
+    }
     return std::chrono::duration_cast<MicroTimeDiff>(clockDiff()).count();
   }
 

--- a/src/axom/klee/tests/KleeMatchers.hpp
+++ b/src/axom/klee/tests/KleeMatchers.hpp
@@ -34,8 +34,7 @@ public:
     : m_mat(mat)
   { }
 
-  bool MatchAndExplain(const axom::numerics::Matrix<T>& other,
-                       std::ostream* /* listener */) const
+  bool MatchAndExplain(const axom::numerics::Matrix<T>& other, std::ostream*) const
   {
     if(other.getNumRows() != m_mat.getNumRows() ||
        other.getNumColumns() != m_mat.getNumColumns())
@@ -59,8 +58,8 @@ public:
     return true;
   }
 
-  void DescribeTo(std::ostream* os) const { }
-  void DescribeNegationTo(std::ostream* os) const { }
+  void DescribeTo(std::ostream*) const { }
+  void DescribeNegationTo(std::ostream*) const { }
 
 private:
   const axom::numerics::Matrix<T> m_mat;
@@ -85,7 +84,7 @@ public:
 
   explicit AlmostEqArrMatcher(const T& arr) : m_arr(arr) { }
 
-  bool MatchAndExplain(const T& other, std::ostream* /* listener */) const
+  bool MatchAndExplain(const T& other, std::ostream*) const
   {
     for(int i = 0; i < m_arr.dimension(); ++i)
     {
@@ -97,8 +96,8 @@ public:
     return true;
   }
 
-  void DescribeTo(std::ostream* os) const { }
-  void DescribeNegationTo(std::ostream* os) const { }
+  void DescribeTo(std::ostream*) const { }
+  void DescribeNegationTo(std::ostream*) const { }
 
 private:
   const T m_arr;
@@ -130,8 +129,7 @@ public:
     : m_slice(slice)
   { }
 
-  bool MatchAndExplain(const klee::SliceOperator& other,
-                       std::ostream* /* listener */) const
+  bool MatchAndExplain(const klee::SliceOperator& other, std::ostream*) const
   {
     return ::testing::Matches(AlmostEqPoint(m_slice.getOrigin()))(
              other.getOrigin()) &&
@@ -141,8 +139,8 @@ public:
              other.getStartProperties());
   }
 
-  void DescribeTo(std::ostream* os) const { }
-  void DescribeNegationTo(std::ostream* os) const { }
+  void DescribeTo(std::ostream*) const { }
+  void DescribeNegationTo(std::ostream*) const { }
 
 private:
   const klee::SliceOperator m_slice;

--- a/src/axom/multimat/examples/calculate.cpp
+++ b/src/axom/multimat/examples/calculate.cpp
@@ -530,7 +530,10 @@ void average_density_cell_dom_mm_flatiter(MultiMat& mm)
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : Density_average) v = 0.0;
+    for(auto& v : Density_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -584,7 +587,10 @@ void average_density_cell_dom_mm_iter(MultiMat& mm)
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : Density_average) v = 0.0;
+    for(auto& v : Density_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -637,7 +643,10 @@ double average_density_mat_dom_full(Robey_data& data)
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : Density_average) v = 0.0;
+    for(auto& v : Density_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -689,7 +698,10 @@ double average_density_mat_dom_compact(Robey_data& data)
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : Density_average) v = 0.0;
+    for(auto& v : Density_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -750,7 +762,10 @@ void average_density_mat_dom_mm_direct(MultiMat& mm)
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : Density_average) v = 0.0;
+    for(auto& v : Density_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -814,7 +829,10 @@ void average_density_mat_dom_mm_submap(MultiMat& mm)
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : Density_average) v = 0.0;
+    for(auto& v : Density_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -871,7 +889,10 @@ void average_density_mat_dom_mm_idxarray(MultiMat& mm)
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : Density_average) v = 0.0;
+    for(auto& v : Density_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -926,7 +947,10 @@ void average_density_mat_dom_mm_iter(MultiMat& mm)
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : Density_average) v = 0.0;
+    for(auto& v : Density_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -981,7 +1005,10 @@ void average_density_mat_dom_mm_flatiter(MultiMat& mm)
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : Density_average) v = 0.0;
+    for(auto& v : Density_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -1799,7 +1826,10 @@ void average_density_over_nbr_cell_dom_full(Robey_data& data)
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : MatDensity_average) v = 0.0;
+    for(auto& v : MatDensity_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -1829,9 +1859,13 @@ void average_density_over_nbr_cell_dom_full(Robey_data& data)
             }
           }
           if(nnm > 0)
+          {
             MatDensity_average[ic * nmats + m] = den / nnm;
+          }
           else
+          {
             SLIC_ASSERT(MatDensity_average[ic * nmats + m] == 0.0);
+          }
         }
         else
         {
@@ -1876,7 +1910,10 @@ void average_density_over_nbr_cell_dom_compact(Robey_data& data)
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : MatDensity_average) v = 0.0;
+    for(auto& v : MatDensity_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -1911,9 +1948,13 @@ void average_density_over_nbr_cell_dom_compact(Robey_data& data)
         }
 
         if(nnm > 0)
+        {
           MatDensity_average[ii] = den / nnm;
+        }
         else
+        {
           SLIC_ASSERT(MatDensity_average[ii] == 0.0);
+        }
       }
     }
 
@@ -2155,7 +2196,10 @@ void average_density_over_nbr_cell_dom_full_mm_iter(MultiMat& mm, Robey_data& da
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : MatDensity_average) v = 0.0;
+    for(auto& v : MatDensity_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -2168,7 +2212,10 @@ void average_density_over_nbr_cell_dom_full_mm_iter(MultiMat& mm, Robey_data& da
       int cnbrs[8];
       double dsqr[8];
 
-      for(int n = 0; n < nn; ++n) cnbrs[n] = nbrs[ic * 8 + n];
+      for(int n = 0; n < nn; ++n)
+      {
+        cnbrs[n] = nbrs[ic * 8 + n];
+      }
 
       for(int n = 0; n < nn; ++n)
       {
@@ -2200,9 +2247,13 @@ void average_density_over_nbr_cell_dom_full_mm_iter(MultiMat& mm, Robey_data& da
             }
           }
           if(nnm > 0)
+          {
             MatDensity_average[ic * nmats + m] /= nnm;
+          }
           else
+          {
             SLIC_ASSERT(MatDensity_average[ic * nmats + m] == 0.0);
+          }
         }
         else
         {
@@ -2337,7 +2388,10 @@ void average_density_over_nbr_cell_dom_compact_mm_idxarray(MultiMat& mm,
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : MatDensity_average) v = 0.0;
+    for(auto& v : MatDensity_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -2350,7 +2404,10 @@ void average_density_over_nbr_cell_dom_compact_mm_idxarray(MultiMat& mm,
       int cnbrs[8];
       double dsqr[8];
 
-      for(int n = 0; n < nn; ++n) cnbrs[n] = nbrs[ic * 8 + n];
+      for(int n = 0; n < nn; ++n)
+      {
+        cnbrs[n] = nbrs[ic * 8 + n];
+      }
 
       for(int n = 0; n < nn; ++n)
       {
@@ -2387,9 +2444,13 @@ void average_density_over_nbr_cell_dom_compact_mm_idxarray(MultiMat& mm,
           }
         }
         if(nnm > 0)
+        {
           MatDensity_average[ic * nmats + m] /= nnm;
+        }
         else
+        {
           SLIC_ASSERT(MatDensity_average[ic * nmats + m] == 0.0);
+        }
       }
     }
 
@@ -2434,7 +2495,10 @@ void average_density_over_nbr_cell_dom_compact_mm_iter(MultiMat& mm,
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : MatDensity_average) v = 0.0;
+    for(auto& v : MatDensity_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -2447,7 +2511,10 @@ void average_density_over_nbr_cell_dom_compact_mm_iter(MultiMat& mm,
       int cnbrs[8];
       double dsqr[8];
 
-      for(int n = 0; n < nn; ++n) cnbrs[n] = nbrs[ic * 8 + n];
+      for(int n = 0; n < nn; ++n)
+      {
+        cnbrs[n] = nbrs[ic * 8 + n];
+      }
 
       for(int n = 0; n < nn; ++n)
       {
@@ -2482,9 +2549,13 @@ void average_density_over_nbr_cell_dom_compact_mm_iter(MultiMat& mm,
           }
         }
         if(nnm > 0)
+        {
           MatDensity_average[ic * nmats + m] /= nnm;
+        }
         else
+        {
           SLIC_ASSERT(MatDensity_average[ic * nmats + m] == 0.0);
+        }
       }
     }
 
@@ -2526,7 +2597,10 @@ void average_density_over_nbr_mat_dom_full(Robey_data& data)
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : MatDensity_average) v = 0.0;
+    for(auto& v : MatDensity_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -2556,9 +2630,13 @@ void average_density_over_nbr_mat_dom_full(Robey_data& data)
             }
           }
           if(nnm > 0)
+          {
             MatDensity_average[m * ncells + ic] = den / nnm;
+          }
           else
+          {
             SLIC_ASSERT(MatDensity_average[m * ncells + ic] == 0.0);
+          }
         }
         else
         {
@@ -2604,7 +2682,10 @@ void average_density_over_nbr_mat_dom_compact(Robey_data& data)
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : MatDensity_average) v = 0.0;
+    for(auto& v : MatDensity_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -2637,9 +2718,13 @@ void average_density_over_nbr_mat_dom_compact(Robey_data& data)
           }
         }
         if(nnm > 0)
+        {
           MatDensity_average[ii] = den / nnm;
+        }
         else
+        {
           SLIC_ASSERT(MatDensity_average[ii] == 0.0);
+        }
       }
     }
 
@@ -2690,7 +2775,10 @@ void average_density_over_nbr_mat_dom_full_mm_direct(MultiMat& mm,
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : MatDensity_average) v = 0.0;
+    for(auto& v : MatDensity_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -2706,7 +2794,10 @@ void average_density_over_nbr_mat_dom_full_mm_direct(MultiMat& mm,
           int nn = nnbrs[ic];
           int cnbrs[8];
           double dsqr[8];
-          for(int n = 0; n < nn; ++n) cnbrs[n] = nbrs[ic * 8 + n];
+          for(int n = 0; n < nn; ++n)
+          {
+            cnbrs[n] = nbrs[ic * 8 + n];
+          }
           for(int n = 0; n < nn; ++n)
           {
             dsqr[n] = 0.0;
@@ -2728,9 +2819,13 @@ void average_density_over_nbr_mat_dom_full_mm_direct(MultiMat& mm,
             }
           }
           if(nnm > 0)
+          {
             MatDensity_average[m * ncells + ic] /= nnm;
+          }
           else
+          {
             SLIC_ASSERT(MatDensity_average[m * ncells + ic] == 0.0);
+          }
         }
         else
         {
@@ -2870,7 +2965,10 @@ void average_density_over_nbr_mat_dom_full_mm_iter(MultiMat& mm, Robey_data& dat
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : MatDensity_average) v = 0.0;
+    for(auto& v : MatDensity_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -2891,7 +2989,10 @@ void average_density_over_nbr_mat_dom_full_mm_iter(MultiMat& mm, Robey_data& dat
           int nn = nnbrs[ic];
           int cnbrs[8];
           double dsqr[8];
-          for(int n = 0; n < nn; ++n) cnbrs[n] = nbrs[ic * 8 + n];
+          for(int n = 0; n < nn; ++n)
+          {
+            cnbrs[n] = nbrs[ic * 8 + n];
+          }
           for(int n = 0; n < nn; ++n)
           {
             dsqr[n] = 0.0;
@@ -2916,9 +3017,13 @@ void average_density_over_nbr_mat_dom_full_mm_iter(MultiMat& mm, Robey_data& dat
             }
           }
           if(nnm > 0)
+          {
             MatDensity_average[m * ncells + ic] /= nnm;
+          }
           else
+          {
             SLIC_ASSERT(MatDensity_average[m * ncells + ic] == 0.0);
+          }
         }
         else
         {
@@ -3056,7 +3161,10 @@ void average_density_over_nbr_mat_dom_compact_mm_indexarray(MultiMat& mm,
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : MatDensity_average) v = 0.0;
+    for(auto& v : MatDensity_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -3075,7 +3183,10 @@ void average_density_over_nbr_mat_dom_compact_mm_indexarray(MultiMat& mm,
         int nn = nnbrs[ci];
         int cnbrs[9];
         double dsqr[8];
-        for(int n = 0; n < nn; ++n) cnbrs[n] = nbrs[ci * 8 + n];
+        for(int n = 0; n < nn; ++n)
+        {
+          cnbrs[n] = nbrs[ci * 8 + n];
+        }
         for(int n = 0; n < nn; ++n)
         {
           dsqr[n] = 0.0;
@@ -3099,9 +3210,13 @@ void average_density_over_nbr_mat_dom_compact_mm_indexarray(MultiMat& mm,
           }
         }
         if(nnm > 0)
+        {
           MatDensity_average[m * ncells + ci] /= nnm;
+        }
         else
+        {
           SLIC_ASSERT(MatDensity_average[m * ncells + ci] == 0.0);
+        }
       }
     }
 
@@ -3147,7 +3262,10 @@ void average_density_over_nbr_mat_dom_compact_mm_iter(MultiMat& mm,
 
   for(int iter = 0; iter < ITERMAX; ++iter)
   {
-    for(auto& v : MatDensity_average) v = 0.0;
+    for(auto& v : MatDensity_average)
+    {
+      v = 0.0;
+    }
 
     timer.start();
 
@@ -3166,7 +3284,10 @@ void average_density_over_nbr_mat_dom_compact_mm_iter(MultiMat& mm,
         int nn = nnbrs[ci];
         int cnbrs[9];
         double dsqr[8];
-        for(int n = 0; n < nn; ++n) cnbrs[n] = nbrs[ci * 8 + n];
+        for(int n = 0; n < nn; ++n)
+        {
+          cnbrs[n] = nbrs[ci * 8 + n];
+        }
         for(int n = 0; n < nn; ++n)
         {
           dsqr[n] = 0.0;
@@ -3190,9 +3311,13 @@ void average_density_over_nbr_mat_dom_compact_mm_iter(MultiMat& mm,
           }
         }
         if(nnm > 0)
+        {
           MatDensity_average[m * ncells + ci] /= nnm;
+        }
         else
+        {
           SLIC_ASSERT(MatDensity_average[m * ncells + ci] == 0.0);
+        }
       }
     }
 

--- a/src/axom/multimat/examples/helper.hpp
+++ b/src/axom/multimat/examples/helper.hpp
@@ -121,7 +121,10 @@ struct multirun_timer
   double get_median()
   {
     auto sz = time_record.size();
-    if(sz == 0) return 0.;
+    if(sz == 0)
+    {
+      return 0.;
+    }
 
     std::vector<double> sorted(time_record);
     std::sort(sorted.begin(), sorted.end());
@@ -402,12 +405,30 @@ void read_vol_frac_matrix_file(std::string filename,
     {
       pure_frac_count++;
     }
-    if(mat_count == 1) pure_cell_count++;
-    if(mat_count == 1) onematcell++;
-    if(mat_count == 2) twomatcell++;
-    if(mat_count == 3) threematcell++;
-    if(mat_count == 4) fourmatcell++;
-    if(mat_count >= 5) fiveplusmatcell++;
+    if(mat_count == 1)
+    {
+      pure_cell_count++;
+    }
+    if(mat_count == 1)
+    {
+      onematcell++;
+    }
+    if(mat_count == 2)
+    {
+      twomatcell++;
+    }
+    if(mat_count == 3)
+    {
+      threematcell++;
+    }
+    if(mat_count == 4)
+    {
+      fourmatcell++;
+    }
+    if(mat_count >= 5)
+    {
+      fiveplusmatcell++;
+    }
   }
   fclose(fp);
 
@@ -499,7 +520,10 @@ void get_vol_frac_matrix_rand(int& ncells,
   {
     int m1 =
       (int)((float)rand() * (float)nmats / (float)((long long)RAND_MAX + 1));
-    if(m1 > nmats - 1) m1 = nmats - 1;
+    if(m1 > nmats - 1)
+    {
+      m1 = nmats - 1;
+    }
     Volfrac[ic * nmats + m1] = 1.0;
     int mf = mf_rand[ic];
     if(mf < 25)
@@ -525,9 +549,18 @@ void get_vol_frac_matrix_rand(int& ncells,
         m4 =
           (int)((float)rand() * (float)nmats / (float)((long long)RAND_MAX + 1));
       }
-      if(m2 > nmats - 1) m2 = nmats - 1;
-      if(m3 > nmats - 1) m3 = nmats - 1;
-      if(m4 > nmats - 1) m4 = nmats - 1;
+      if(m2 > nmats - 1)
+      {
+        m2 = nmats - 1;
+      }
+      if(m3 > nmats - 1)
+      {
+        m3 = nmats - 1;
+      }
+      if(m4 > nmats - 1)
+      {
+        m4 = nmats - 1;
+      }
       Volfrac[ic * nmats + m1] = 0.4;
       Volfrac[ic * nmats + m2] = 0.3;
       Volfrac[ic * nmats + m3] = 0.2;
@@ -545,8 +578,14 @@ void get_vol_frac_matrix_rand(int& ncells,
       {
         m3 = (float)rand() * (float)nmats / (float)((long long)RAND_MAX + 1);
       }
-      if(m2 > nmats - 1) m2 = nmats - 1;
-      if(m3 > nmats - 1) m3 = nmats - 1;
+      if(m2 > nmats - 1)
+      {
+        m2 = nmats - 1;
+      }
+      if(m3 > nmats - 1)
+      {
+        m3 = nmats - 1;
+      }
       Volfrac[ic * nmats + m1] = 0.5;
       Volfrac[ic * nmats + m2] = 0.3;
       Volfrac[ic * nmats + m3] = 0.2;
@@ -558,7 +597,10 @@ void get_vol_frac_matrix_rand(int& ncells,
       {
         m2 = (float)rand() * (float)nmats / (float)((long long)RAND_MAX + 1);
       }
-      if(m2 > nmats - 1) m2 = nmats - 1;
+      if(m2 > nmats - 1)
+      {
+        m2 = nmats - 1;
+      }
       Volfrac[ic * nmats + m1] = 0.5;
       Volfrac[ic * nmats + m2] = 0.5;
     }
@@ -581,12 +623,30 @@ void get_vol_frac_matrix_rand(int& ncells,
     {
       pure_frac_count++;
     }
-    if(mat_count == 1) pure_cell_count++;
-    if(mat_count == 1) onematcell++;
-    if(mat_count == 2) twomatcell++;
-    if(mat_count == 3) threematcell++;
-    if(mat_count == 4) fourmatcell++;
-    if(mat_count >= 5) fiveplusmatcell++;
+    if(mat_count == 1)
+    {
+      pure_cell_count++;
+    }
+    if(mat_count == 1)
+    {
+      onematcell++;
+    }
+    if(mat_count == 2)
+    {
+      twomatcell++;
+    }
+    if(mat_count == 3)
+    {
+      threematcell++;
+    }
+    if(mat_count == 4)
+    {
+      fourmatcell++;
+    }
+    if(mat_count >= 5)
+    {
+      fiveplusmatcell++;
+    }
   }
 
   printf("Ratios to Full Data Structure\n");
@@ -669,6 +729,7 @@ void get_neighbors(int ncells,
       int jhi = j == ncells1 - 1 ? j : j + 1;
       int n = 0;
       for(int i1 = ilo; i1 <= ihi; i1++)
+      {
         for(int j1 = jlo; j1 <= jhi; j1++)
         {
           int c2 = i1 * ncells1 + j1;
@@ -678,6 +739,7 @@ void get_neighbors(int ncells,
             n++;
           }
         }
+      }
       num_nbrs[c] = n;
     }
   }
@@ -1032,7 +1094,10 @@ struct Result_Store
                << " NRuns: " << ITERMAX << "\n\n";
 
     outputFile << "Methods";
-    for(int i = 0; i < nMethod; i++) outputFile << "," << method_names[i];
+    for(int i = 0; i < nMethod; i++)
+    {
+      outputFile << "," << method_names[i];
+    }
     outputFile << "\n";
 
     for(int i = 0; i < (int)result_vec.size() / nMethod; i++)
@@ -1043,9 +1108,15 @@ struct Result_Store
       bool all_zero = true;
       for(int j = 0; j < nMethod; j++)
       {
-        if(result_vec[idx + j] != 0.0) all_zero = false;
+        if(result_vec[idx + j] != 0.0)
+        {
+          all_zero = false;
+        }
       }
-      if(all_zero) continue;
+      if(all_zero)
+      {
+        continue;
+      }
 
       outputFile << get_algo_name(idx) << ",";
       for(int j = 0; j < nMethod; j++)

--- a/src/axom/multimat/examples/traversal.cpp
+++ b/src/axom/multimat/examples/traversal.cpp
@@ -102,12 +102,17 @@ void various_traversal_methods(int nmats,
     int matcount = 0;
     for(auto m = 0; m < nmats; ++m)
     {
-      if(cellMatRel[i * nmats + m]) matcount += 1;
+      if(cellMatRel[i * nmats + m])
+      {
+        matcount += 1;
+      }
     }
     for(auto m = 0; m < nmats; ++m)
     {
       if(cellMatRel[i * nmats + m])
+      {
         volfrac_arr[i * nmats + m] = 1.0 / (double)matcount;
+      }
     }
   }
 
@@ -215,7 +220,10 @@ void various_traversal_methods(int nmats,
         {
           double* valptr = map.findValue(i, m, c);
           // ^ contains a hidden for-loop for sparse layouts, O(row_size) time
-          if(valptr) sum += *valptr;
+          if(valptr)
+          {
+            sum += *valptr;
+          }
         }
       }
     }
@@ -277,7 +285,9 @@ void various_traversal_methods(int nmats,
         iter++)
     {
       for(int comp = 0; comp < iter.numComp(); ++comp)
+      {
         sum += iter(comp);  //<----
+      }
     }
   }
   timer.stop();
@@ -418,9 +428,13 @@ int main(int argc, char** argv)
     ncomp = std::stoi(argv[3]);
     int sparse = std::stoi(argv[4]);
     if(sparse == 0)
+    {
       use_sparse = false;
+    }
     else if(sparse == 1)
+    {
       use_sparse = true;
+    }
     else
     {
       usage();

--- a/src/axom/multimat/multimat.cpp
+++ b/src/axom/multimat/multimat.cpp
@@ -656,7 +656,10 @@ int MultiMat::getFieldIdx(const std::string& field_name) const
 {
   for(unsigned int i = 0; i < m_fieldNameVec.size(); i++)
   {
-    if(m_fieldNameVec[i] == field_name) return i;
+    if(m_fieldNameVec[i] == field_name)
+    {
+      return i;
+    }
   }
 
   return -1;
@@ -690,9 +693,13 @@ MultiMat::IndexSet MultiMat::getSubfieldIndexingSet(int idx,
                                                     SparsityLayout sparsity) const
 {
   if(layout == DataLayout::CELL_DOM)
+  {
     return getIndexingSetOfCell(idx, sparsity);
+  }
   else
+  {
     return getIndexingSetOfMat(idx, sparsity);
+  }
 }
 
 MultiMat::IndexSet MultiMat::getIndexingSetOfCell(int c,
@@ -781,7 +788,10 @@ void MultiMat::convertToDynamic()
 
 void MultiMat::convertToStatic()
 {
-  if(!m_dynamic_mode) return;
+  if(!m_dynamic_mode)
+  {
+    return;
+  }
 
   // Change dynamicRelation back to staticRelation
   // change the layout to previously stored static layout
@@ -1239,7 +1249,9 @@ void MultiMat::convertFieldLayout(int field_idx,
   SparsityLayout field_sparsity_layout = m_fieldSparsityLayoutVec[field_idx];
 
   if(new_layout == field_data_layout && new_sparsity == field_sparsity_layout)
+  {
     return;
+  }
 
   //sparse/dense conversion
   if(field_sparsity_layout == SparsityLayout::DENSE &&
@@ -1306,7 +1318,9 @@ void MultiMat::convertFieldToSparse(int field_idx)
     convertToSparse_helper<unsigned char>(field_idx);
   }
   else
+  {
     SLIC_ASSERT(false);  //TODO
+  }
 
   m_fieldSparsityLayoutVec[field_idx] = SparsityLayout::SPARSE;
 }
@@ -1349,7 +1363,9 @@ void MultiMat::convertFieldToDense(int field_idx)
     convertToDense_helper<unsigned char>(field_idx);
   }
   else
+  {
     SLIC_ASSERT(false);  //TODO
+  }
 
   m_fieldSparsityLayoutVec[field_idx] = SparsityLayout::DENSE;
 }
@@ -1397,7 +1413,10 @@ void MultiMat::convertToSparse_helper(int map_i)
   SLIC_ASSERT(m_fieldBackingVec[map_i]->isOwned());
 
   //Skip if no volume fraction array is set-up
-  if(map_i == 0 && m_fieldBackingVec[0] == nullptr) return;
+  if(map_i == 0 && m_fieldBackingVec[0] == nullptr)
+  {
+    return;
+  }
 
   const RelationSetType* rel_set = &relSparseSet(m_fieldDataLayoutVec[map_i]);
 
@@ -1457,7 +1476,10 @@ void MultiMat::convertToDense_helper(int map_i)
   SLIC_ASSERT(m_fieldBackingVec[map_i]->isOwned());
 
   //Skip if no volume fraction array is set-up
-  if(map_i == 0 && m_fieldBackingVec[0] == nullptr) return;
+  if(map_i == 0 && m_fieldBackingVec[0] == nullptr)
+  {
+    return;
+  }
 
   ProductSetType* prod_set = &relDenseSet(m_fieldDataLayoutVec[map_i]);
 
@@ -1578,7 +1600,10 @@ void MultiMat::transposeField_helper(int field_idx)
   SLIC_ASSERT(m_fieldMappingVec[field_idx] == FieldMapping::PER_CELL_MAT);
 
   //Skip if no volume fraction array is set-up
-  if(field_idx == 0 && m_fieldBackingVec[0] == nullptr) return;
+  if(field_idx == 0 && m_fieldBackingVec[0] == nullptr)
+  {
+    return;
+  }
 
   DataLayout oldDataLayout = getFieldDataLayout(field_idx);
   DataLayout new_layout;
@@ -1671,7 +1696,10 @@ void MultiMat::transposeField_helper(int field_idx)
 
 void MultiMat::transposeField(int field_idx)
 {
-  if(m_fieldMappingVec[field_idx] != FieldMapping::PER_CELL_MAT) return;
+  if(m_fieldMappingVec[field_idx] != FieldMapping::PER_CELL_MAT)
+  {
+    return;
+  }
 
   switch(m_dataTypeVec[field_idx])
   {
@@ -1713,22 +1741,34 @@ void MultiMat::convertFieldToCellDom(int field_idx)
 std::string MultiMat::getFieldDataLayoutAsString(int field_i) const
 {
   if(m_fieldDataLayoutVec[field_i] == DataLayout::CELL_DOM)
+  {
     return "Cell-Centric";
+  }
   else if(m_fieldDataLayoutVec[field_i] == DataLayout::MAT_DOM)
+  {
     return "Material-Centric";
+  }
   else
+  {
     SLIC_ASSERT(false);
+  }
   return "";
 }
 
 std::string MultiMat::getFieldSparsityLayoutAsString(int field_i) const
 {
   if(m_fieldSparsityLayoutVec[field_i] == SparsityLayout::SPARSE)
+  {
     return "Sparse";
+  }
   else if(m_fieldSparsityLayoutVec[field_i] == SparsityLayout::DENSE)
+  {
     return "Dense";
+  }
   else
+  {
     SLIC_ASSERT(false);
+  }
   return "";
 }
 
@@ -1830,9 +1870,13 @@ bool MultiMat::isValid(bool verboseOutput) const
         for(int j = 0; j < submap.size(); ++j)
         {
           if(volfrac_layout == DataLayout::CELL_DOM)
+          {
             volfrac_sum[i] += submap.value(j);
+          }
           else
+          {
             volfrac_sum[submap.index(j)] += submap.value(j);
+          }
         }
       }
       for(unsigned int i = 0; i < volfrac_sum.size(); ++i)

--- a/src/axom/multimat/multimat.hpp
+++ b/src/axom/multimat/multimat.hpp
@@ -1027,15 +1027,25 @@ int MultiMat::addFieldArray_impl(const std::string& field_name,
   m_fieldStrideVec.push_back(stride);
 
   if(std::is_same<T, int>::value)
+  {
     m_dataTypeVec.push_back(DataTypeSupported::TypeInt);
+  }
   else if(std::is_same<T, double>::value)
+  {
     m_dataTypeVec.push_back(DataTypeSupported::TypeDouble);
+  }
   else if(std::is_same<T, float>::value)
+  {
     m_dataTypeVec.push_back(DataTypeSupported::TypeFloat);
+  }
   else if(std::is_same<T, unsigned char>::value)
+  {
     m_dataTypeVec.push_back(DataTypeSupported::TypeUnsignChar);
+  }
   else
+  {
     m_dataTypeVec.push_back(DataTypeSupported::TypeUnknown);
+  }
 
   SLIC_ASSERT(m_fieldNameVec.size() == m_dataTypeVec.size());
   SLIC_ASSERT(m_fieldNameVec.size() == m_fieldMappingVec.size());
@@ -1071,8 +1081,10 @@ MultiMat::Field1D<T> MultiMat::get1dField(const std::string& field_name)
   int fieldIdx = getFieldIdx(field_name);
 
   if(fieldIdx < 0)
+  {
     SLIC_ERROR("Multimat: No field with the name \"" + field_name +
                "\" was found.");
+  }
 
   return get1dFieldImpl<T>(fieldIdx);
 }
@@ -1083,8 +1095,10 @@ MultiMat::Field1D<const T> MultiMat::get1dField(const std::string& field_name) c
   int fieldIdx = getFieldIdx(field_name);
 
   if(fieldIdx < 0)
+  {
     SLIC_ERROR("Multimat: No field with the name \"" + field_name +
                "\" was found.");
+  }
 
   return get1dFieldImpl<const T>(fieldIdx);
 }
@@ -1095,8 +1109,10 @@ MultiMat::Field2D<T> MultiMat::get2dField(const std::string& field_name)
   int fieldIdx = getFieldIdx(field_name);
 
   if(fieldIdx < 0)
+  {
     SLIC_ERROR("Multimat: No field with the name \"" + field_name +
                "\" was found.");
+  }
 
   return get2dFieldImpl<T>(fieldIdx);
 }
@@ -1107,7 +1123,9 @@ MultiMat::Field2D<const T> MultiMat::get2dField(const std::string& field_name) c
   int fieldIdx = getFieldIdx(field_name);
 
   if(fieldIdx < 0)
+  {
     throw std::invalid_argument("No field with this name is found");
+  }
 
   return get2dFieldImpl<const T>(fieldIdx);
 }
@@ -1160,7 +1178,10 @@ MultiMat::Field2D<T, BSetType> MultiMat::get2dField(const std::string& field_nam
   //create instance of that map
   int fi = getFieldIdx(field_name);
 
-  if(fi < 0) throw std::invalid_argument("No field with this name is found");
+  if(fi < 0)
+  {
+    throw std::invalid_argument("No field with this name is found");
+  }
 
   BSetType bsetValue = getCompatibleBivarSet<BSetType>(fi);
 
@@ -1183,7 +1204,9 @@ MultiMat::DenseField2D<T> MultiMat::getDense2dField(const std::string& field_nam
   int fieldIdx = getFieldIdx(field_name);
 
   if(fieldIdx < 0)
+  {
     throw std::invalid_argument("No field with this name is found");
+  }
 
   SLIC_CHECK_MSG(
     bmap.isDense(),
@@ -1213,7 +1236,9 @@ MultiMat::SparseField2D<T> MultiMat::getSparse2dField(const std::string& field_n
   int fieldIdx = getFieldIdx(field_name);
 
   if(fieldIdx < 0)
+  {
     throw std::invalid_argument("No field with this name is found");
+  }
 
   SLIC_CHECK_MSG(
     bmap.isSparse(),

--- a/src/axom/multimat/tests/multimat_test.cpp
+++ b/src/axom/multimat/tests/multimat_test.cpp
@@ -214,7 +214,12 @@ struct MM_test_data
 
     int sparseidx = 0;
     for(int i = 0; i < mi; i++)
-      if(fillBool_cellcen[ci * num_mats + i]) sparseidx += 1;
+    {
+      if(fillBool_cellcen[ci * num_mats + i])
+      {
+        sparseidx += 1;
+      }
+    }
     if(already_filled && to_be_filled)
     {  //just update
       volfrac_cellcen_sparse[cellmat_beginvecs[ci] + sparseidx] = volfrac_val;
@@ -233,7 +238,10 @@ struct MM_test_data
         cellmat_sparse_arr.erase(cellmat_sparse_arr.begin() +
                                  (cellmat_beginvecs[ci] + sparseidx) * stride);
       }
-      for(int i = ci + 1; i < num_cells; i++) cellmat_beginvecs[i] -= 1;
+      for(int i = ci + 1; i < num_cells; i++)
+      {
+        cellmat_beginvecs[i] -= 1;
+      }
     }
     else if(!already_filled && to_be_filled)
     {  //adding an entry
@@ -247,11 +255,19 @@ struct MM_test_data
             (cellmat_beginvecs[ci] + sparseidx) * stride + si,
           get_val(ci, mi, si));
       }
-      for(int i = ci + 1; i < num_cells; i++) cellmat_beginvecs[i] += 1;
+      for(int i = ci + 1; i < num_cells; i++)
+      {
+        cellmat_beginvecs[i] += 1;
+      }
     }
     sparseidx = 0;
     for(int i = 0; i < ci; i++)
-      if(fillBool_matcen[mi * num_cells + i]) sparseidx += 1;
+    {
+      if(fillBool_matcen[mi * num_cells + i])
+      {
+        sparseidx += 1;
+      }
+    }
     if(already_filled && to_be_filled)
     {  //just update
       volfrac_matcen_sparse[matcell_beginvecs[mi] + sparseidx] = volfrac_val;
@@ -270,7 +286,10 @@ struct MM_test_data
         matcell_sparse_arr.erase(matcell_sparse_arr.begin() +
                                  (matcell_beginvecs[mi] + sparseidx) * stride);
       }
-      for(int i = mi + 1; i < num_mats; i++) matcell_beginvecs[i] -= 1;
+      for(int i = mi + 1; i < num_mats; i++)
+      {
+        matcell_beginvecs[i] -= 1;
+      }
     }
     else if(!already_filled && to_be_filled)
     {  //adding an entry
@@ -284,7 +303,10 @@ struct MM_test_data
             (matcell_beginvecs[mi] + sparseidx) * stride + si,
           get_val(ci, mi, si));
       }
-      for(int i = mi + 1; i < num_mats; i++) matcell_beginvecs[i] += 1;
+      for(int i = mi + 1; i < num_mats; i++)
+      {
+        matcell_beginvecs[i] += 1;
+      }
     }
 
     fillBool_cellcen[cellcen_idx] = to_be_filled;
@@ -310,9 +332,13 @@ void check_values(MultiMat& mm, std::string arr_name, MM_test_data<DataType>& da
       {
         DataType* d;
         if(mm.getFieldDataLayout(map_i) == DataLayout::CELL_DOM)
+        {
           d = map.findValue(ci, mi, s);
+        }
         else
+        {
           d = map.findValue(mi, ci, s);
+        }
         int dense_idx = ci * data.num_mats + mi;
 
         if(mm.getFieldSparsityLayout(map_i) == SparsityLayout::DENSE)
@@ -352,32 +378,44 @@ MultiMat* newMM(MM_test_data<T>& data,
   mm.setNumberOfMaterials(data.num_mats);
 
   if(layout_used == DataLayout::CELL_DOM)
+  {
     mm.setCellMatRel(data.fillBool_cellcen, DataLayout::CELL_DOM);
+  }
   else
+  {
     mm.setCellMatRel(data.fillBool_matcen,
                      DataLayout::MAT_DOM);  //todo change to MatCellRel
+  }
 
   if(layout_used == DataLayout::CELL_DOM)
   {
     if(sparsity_used == SparsityLayout::DENSE)
+    {
       mm.setVolfracField(data.volfrac_cellcen_dense,
                          DataLayout::CELL_DOM,
                          SparsityLayout::DENSE);
+    }
     else
+    {
       mm.setVolfracField(data.volfrac_cellcen_sparse,
                          DataLayout::CELL_DOM,
                          SparsityLayout::SPARSE);
+    }
   }
   else
   {
     if(sparsity_used == SparsityLayout::DENSE)
+    {
       mm.setVolfracField(data.volfrac_matcen_dense,
                          DataLayout::MAT_DOM,
                          SparsityLayout::DENSE);
+    }
     else
+    {
       mm.setVolfracField(data.volfrac_matcen_sparse,
                          DataLayout::MAT_DOM,
                          SparsityLayout::SPARSE);
+    }
   }
 
   EXPECT_TRUE(mm.isValid());
@@ -385,36 +423,44 @@ MultiMat* newMM(MM_test_data<T>& data,
   if(layout_used == DataLayout::CELL_DOM)
   {
     if(sparsity_used == SparsityLayout::DENSE)
+    {
       mm.addField(array_name,
                   FieldMapping::PER_CELL_MAT,
                   layout_used,
                   sparsity_used,
                   data.cellmat_dense_arr.view(),
                   data.stride);
+    }
     else
+    {
       mm.addField(array_name,
                   FieldMapping::PER_CELL_MAT,
                   layout_used,
                   sparsity_used,
                   data.cellmat_sparse_arr.view(),
                   data.stride);
+    }
   }
   else
   {
     if(sparsity_used == SparsityLayout::DENSE)
+    {
       mm.addField(array_name,
                   FieldMapping::PER_CELL_MAT,
                   layout_used,
                   sparsity_used,
                   data.matcell_dense_arr.view(),
                   data.stride);
+    }
     else
+    {
       mm.addField(array_name,
                   FieldMapping::PER_CELL_MAT,
                   layout_used,
                   sparsity_used,
                   data.matcell_sparse_arr.view(),
                   data.stride);
+    }
   }
 
   return mm_ptr;
@@ -839,7 +885,10 @@ TEST(multimat, test_dynamic_multimat_1_array)
 
             EXPECT_TRUE(mm.removeEntry(ci, mi));
             volfrac_field(idx1, idx2) = 0.0;
-            for(int s = 0; s < stride_val; s++) arr(idx1, idx2, s) = 0.0;
+            for(int s = 0; s < stride_val; s++)
+            {
+              arr(idx1, idx2, s) = 0.0;
+            }
           }
         }
       }
@@ -863,8 +912,10 @@ TEST(multimat, test_dynamic_multimat_1_array)
         EXPECT_TRUE(mm.addEntry(ci, 0));
         volfrac_field(idx1, idx2) = 1.0;
         for(int s = 0; s < stride_val; s++)
+        {
           arr(idx1, idx2, s) =
             data.cellmat_dense_arr[ci * data.num_mats * stride_val + s];
+        }
       }
 
       EXPECT_TRUE(mm.isValid(true));

--- a/src/axom/primal/geometry/BezierCurve.hpp
+++ b/src/axom/primal/geometry/BezierCurve.hpp
@@ -592,7 +592,10 @@ private:
   ///  that there is one for each control node
   bool isValidRational() const
   {
-    if(!isRational()) return true;
+    if(!isRational())
+    {
+      return true;
+    }
 
     const int ord = getOrder();
 

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -161,7 +161,9 @@ public:
     }
 
     if(weights == nullptr)
+    {
       makeNonrational();
+    }
     else
     {
       m_weights.resize(sz_u, sz_v);
@@ -961,9 +963,18 @@ public:
     const int ord_u = getOrder_u();
     const int ord_v = getOrder_v();
 
-    if(ord_u <= 0 && ord_v <= 0) return true;
-    if(ord_u == 1 && ord_v == 0) return true;
-    if(ord_u == 0 && ord_v == 1) return true;
+    if(ord_u <= 0 && ord_v <= 0)
+    {
+      return true;
+    }
+    if(ord_u == 1 && ord_v == 0)
+    {
+      return true;
+    }
+    if(ord_u == 0 && ord_v == 1)
+    {
+      return true;
+    }
 
     PlaneType the_plane = make_plane(m_controlPoints(0, 0),
                                      m_controlPoints(0, ord_v),
@@ -1026,7 +1037,10 @@ private:
   ///  that there is one for each control node
   bool isValidRational() const
   {
-    if(!isRational()) return true;
+    if(!isRational())
+    {
+      return true;
+    }
 
     const int ord_u = getOrder_u();
     const int ord_v = getOrder_v();

--- a/src/axom/primal/geometry/NumericArray.hpp
+++ b/src/axom/primal/geometry/NumericArray.hpp
@@ -11,8 +11,8 @@
 #include "axom/slic/interface/slic.hpp"
 
 // C/C++ includes
-#include <algorithm>  // For std:: copy and fill
-#include <ostream>    // For print() and operator <<
+#include <algorithm>
+#include <ostream>
 #include <initializer_list>
 
 namespace axom
@@ -176,11 +176,9 @@ struct NonChar<unsigned char>
  * \tparam SIZE the size of the array
  */
 template <typename T, int SIZE>
-class NumericArray
+class NumericArray  // NOLINT
 {
 public:
-  // -- TODO: Add static_assert that T has numeric type --
-
   /*!
    * \brief Fill the first sz coordinates with val and zeros the rest
    * \param [in] val The value to set the coordinates to. Defaults to zero.
@@ -241,7 +239,6 @@ public:
   T* data();
 
   /*!
-   *
    * \brief Copy the coordinate data to the provided array
    * \param [in] arr The array to which we are copying.
    * \pre The user needs to make sure that the provided array has been allocated
@@ -264,7 +261,7 @@ public:
    * \return A reference to the NumericArray instance after addition.
    */
   AXOM_HOST_DEVICE
-  NumericArray<T, SIZE>& operator+=(const NumericArray<T, SIZE>& arr);
+  NumericArray& operator+=(const NumericArray& arr);
 
   /*!
    * \brief Component-wise subtraction assignment operator.
@@ -273,7 +270,7 @@ public:
    * \return A reference to the NumericArray instance after subtraction.
    */
   AXOM_HOST_DEVICE
-  NumericArray<T, SIZE>& operator-=(const NumericArray<T, SIZE>& arr);
+  NumericArray& operator-=(const NumericArray& arr);
 
   /*!
    * \brief Scalar multiplication on the NumericArray instance.
@@ -283,7 +280,7 @@ public:
    * multiplication.
    */
   AXOM_HOST_DEVICE
-  NumericArray<T, SIZE>& operator*=(double scalar);
+  NumericArray& operator*=(double scalar);
 
   /*!
    * \brief Scalar division on the NumericArray instance.
@@ -293,7 +290,7 @@ public:
    * \return A reference to the NumericArray instance after scalar division.
    */
   AXOM_HOST_DEVICE
-  NumericArray<T, SIZE>& operator/=(double scalar);
+  NumericArray& operator/=(double scalar);
 
   /*!
    * \brief Component-wise multiplication assignment operator.
@@ -303,7 +300,7 @@ public:
    * multiplication.
    */
   AXOM_HOST_DEVICE
-  NumericArray<T, SIZE>& operator*=(const NumericArray<T, SIZE>& arr);
+  NumericArray& operator*=(const NumericArray& arr);
 
   /*!
    * \brief Component-wise division assignment operator.
@@ -312,7 +309,7 @@ public:
    * \pre forall i, arr[i] != 0
    * \return A reference to the NumericArray instance after cwise division.
    */
-  NumericArray<T, SIZE>& operator/=(const NumericArray<T, SIZE>& arr);
+  NumericArray& operator/=(const NumericArray& arr);
 
   /*!
    * \brief Ensures that the highest value of the coordinates is at most
@@ -322,7 +319,7 @@ public:
    * \post forall i, arr[i] <= upperVal
    * \return A reference to the NumericArray instance after clamping upper
    */
-  NumericArray<T, SIZE>& clampUpper(const T& upperVal);
+  NumericArray& clampUpper(const T& upperVal);
 
   /*!
    * \brief Ensures that the lowest value of the coordinates is at least
@@ -334,7 +331,7 @@ public:
    *
    * \return A reference to the NumericArray instance after clamping lower
    */
-  NumericArray<T, SIZE>& clampLower(const T& lowerVal);
+  NumericArray& clampLower(const T& lowerVal);
 
   /*!
    * \brief Ensures that each coordinate's value is in range
@@ -348,7 +345,7 @@ public:
    *
    * \return A reference to the NumericArray instance after clamping
    */
-  NumericArray<T, SIZE>& clamp(const T& lowerVal, const T& upperVal);
+  NumericArray& clamp(const T& lowerVal, const T& upperVal);
 
   /*!
    * \brief Find the max component.
@@ -385,12 +382,11 @@ private:
   }
 
 protected:
-  T m_components[SIZE]; /*! The encapsulated array */
+  T m_components[SIZE];  /// The encapsulated array
 };
 
-} /* namespace primal */
-
-} /* namespace axom */
+}  // namespace primal
+}  // namespace axom
 
 //------------------------------------------------------------------------------
 //  NumericArray implementation

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -193,7 +193,10 @@ public:
       int curr_idx = 0;
       for(int inbr = 0; inbr < num_nbrs[iv]; inbr++)
       {
-        if(nbrs[iv][inbr] == -1) continue;
+        if(nbrs[iv][inbr] == -1)
+        {
+          continue;
+        }
         nbrs[iv][curr_idx] = nbrs[iv][inbr];
         curr_idx++;
       }

--- a/src/axom/primal/operators/detail/intersect_bezier_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_bezier_impl.hpp
@@ -204,14 +204,20 @@ bool intersect_2d_linear(const Point<T, 2> &a,
   const auto area2 = twoDcross(a, b, d);
 
   // early return if both have same orientation, or if d is collinear w/ (a,b)
-  if(area2 == 0. || (area1 * area2) > 0.) return false;
+  if(area2 == 0. || (area1 * area2) > 0.)
+  {
+    return false;
+  }
 
   // compute signed areas of endpoints of segment (a,b) w.r.t. segment (c,d)
   const auto area3 = twoDcross(c, d, a);
   const auto area4 = area3 + area1 - area2;  // equivalent to twoDcross(c,d,b)
 
   // early return if both have same orientation, or if b is collinear w/ (c,d)
-  if(area4 == 0. || (area3 * area4) > 0.) return false;
+  if(area4 == 0. || (area3 * area4) > 0.)
+  {
+    return false;
+  }
 
   // Compute intersection parameters using linear interpolation
   // Divisions are safe due to early return conditions

--- a/src/axom/primal/operators/detail/intersect_ray_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_ray_impl.hpp
@@ -76,8 +76,10 @@ inline bool intersect_ray(const primal::Ray<T, 2>& R,
 
       return ((ray_param >= tlow) && (seg_param >= tlow) && (seg_param <= thigh));
     }
-    else  // Not collinear, no intersection
+    else
+    {  // Not collinear, no intersection
       return false;
+    }
   }
 
   // Solve for the ray_param and seg_param directly using Cramer's rule

--- a/src/axom/primal/operators/detail/winding_number_impl.hpp
+++ b/src/axom/primal/operators/detail/winding_number_impl.hpp
@@ -56,7 +56,9 @@ double linear_winding_number(const Point<T, 2>& q,
 
   // Compute distance from line connecting endpoints to query
   if(tri_area * tri_area <= edge_tol * edge_tol * (V1 - V2).squared_norm())
+  {
     return 0;
+  }
 
   // Compute signed angle between vectors
   double dotprod = axom::utilities::clampVal(
@@ -95,7 +97,10 @@ double convex_endpoint_winding_number(const Point<T, 2>& q,
                                       double EPS)
 {
   const int ord = c.getOrder();
-  if(ord == 1) return 0;
+  if(ord == 1)
+  {
+    return 0;
+  }
 
   double edge_tol_sq = edge_tol * edge_tol;
 
@@ -109,11 +114,21 @@ double convex_endpoint_winding_number(const Point<T, 2>& q,
   // Need to find vectors that subtend the entire curve.
   //   We must ignore duplicate nodes
   for(idx = 0; idx <= ord; ++idx)
-    if(squared_distance(q, c[idx]) > edge_tol_sq) break;
+  {
+    if(squared_distance(q, c[idx]) > edge_tol_sq)
+    {
+      break;
+    }
+  }
   Vector<T, 2> V1(q, c[idx]);
 
   for(idx = ord; idx >= 0; --idx)
-    if(squared_distance(q, c[idx]) > edge_tol_sq) break;
+  {
+    if(squared_distance(q, c[idx]) > edge_tol_sq)
+    {
+      break;
+    }
+  }
   Vector<T, 2> V2(q, c[idx]);
 
   // clang-format off
@@ -138,7 +153,9 @@ double convex_endpoint_winding_number(const Point<T, 2>& q,
 
       // Because we are convex, a single non-collinear vertex tells us the orientation
       if(!axom::utilities::isNearlyEqual(tri_area, 0.0, EPS))
+      {
         return (tri_area > 0) ? 0.5 : -0.5;
+      }
     }
 
     // If all vectors are parallel, the curve is linear and return 0
@@ -182,7 +199,10 @@ double curve_winding_number_recursive(const Point<T, 2>& q,
                                       double EPS = 1e-8)
 {
   const int ord = c.getOrder();
-  if(ord <= 0) return 0.0;  // Catch degenerate cases
+  if(ord <= 0)
+  {
+    return 0.0;  // Catch degenerate cases
+  }
 
   // If q is outside a convex shape that contains the entire curve, the winding
   //   number for the shape connected at the endpoints with straight lines is zero.

--- a/src/axom/primal/operators/evaluate_integral.hpp
+++ b/src/axom/primal/operators/evaluate_integral.hpp
@@ -189,7 +189,10 @@ double evaluate_area_integral(const primal::CurvedPolygon<T, 2> cpoly,
   //  Use the same one for every curve in the polygon
   static mfem::IntegrationRules my_IntRules(0, mfem::Quadrature1D::GaussLegendre);
 
-  if(npts_P <= 0) npts_P = npts_Q;
+  if(npts_P <= 0)
+  {
+    npts_P = npts_Q;
+  }
 
   // Get the quadrature for the line integral.
   //  Quadrature order is equal to 2*N - 1
@@ -201,8 +204,12 @@ double evaluate_area_integral(const primal::CurvedPolygon<T, 2> cpoly,
   // Use minimum y-coord of control nodes as lower bound for integration
   double int_lb = cpoly[0][0][1];
   for(int i = 0; i < cpoly.numEdges(); i++)
+  {
     for(int j = 1; j < cpoly[i].getOrder() + 1; j++)
+    {
       int_lb = std::min(int_lb, cpoly[i][j][1]);
+    }
+  }
 
   // Evaluate the antiderivative line integral along each component
   double total_integral = 0.0;

--- a/src/axom/primal/operators/is_convex.hpp
+++ b/src/axom/primal/operators/is_convex.hpp
@@ -35,7 +35,10 @@ template <typename T>
 bool is_convex(const Polygon<T, 2>& poly, double EPS = 1e-8)
 {
   int n = poly.numVertices() - 1;
-  if(n + 1 < 3) return true;  // Triangles and lines are convex
+  if(n + 1 < 3)
+  {
+    return true;  // Triangles and lines are convex
+  }
 
   for(int i = 1; i < n; i++)
   {
@@ -45,10 +48,16 @@ bool is_convex(const Polygon<T, 2>& poly, double EPS = 1e-8)
     int res1 = orientation(poly[i], seg, EPS);
 
     // Edge case
-    if(res1 == primal::ON_BOUNDARY) continue;
+    if(res1 == primal::ON_BOUNDARY)
+    {
+      continue;
+    }
 
     // Ensure other point to check against isn't adjacent
-    if(res1 == orientation(poly[(i < n / 2) ? n : 0], seg, EPS)) return false;
+    if(res1 == orientation(poly[(i < n / 2) ? n : 0], seg, EPS))
+    {
+      return false;
+    }
   }
 
   return true;

--- a/src/axom/primal/operators/winding_number.hpp
+++ b/src/axom/primal/operators/winding_number.hpp
@@ -270,7 +270,10 @@ double winding_number(const Point<T, 3>& q,
 {
   using Vec3 = Vector<T, 3>;
 
-  if(tri.area() == 0) return 0;
+  if(tri.area() == 0)
+  {
+    return 0;
+  }
 
   const Vec3 a = tri[0] - q;
   const Vec3 b = tri[1] - q;
@@ -281,7 +284,10 @@ double winding_number(const Point<T, 3>& q,
   const double b_norm = b.norm();
   const double c_norm = c.norm();
 
-  if(a_norm < edge_tol || b_norm < edge_tol || c_norm < edge_tol) return 0;
+  if(a_norm < edge_tol || b_norm < edge_tol || c_norm < edge_tol)
+  {
+    return 0;
+  }
 
   const double num = Vec3::scalar_triple_product(a, b, c);
   if(axom::utilities::isNearlyEqual(num, 0.0, EPS))

--- a/src/axom/primal/tests/primal_bezier_intersect.cpp
+++ b/src/axom/primal/tests/primal_bezier_intersect.cpp
@@ -91,11 +91,15 @@ void checkIntersections(const primal::BezierCurve<CoordType, 2>& curve1,
 
     sstr << "\ns (" << s.size() << "): ";
     for(auto i = 0u; i < s.size(); ++i)
+    {
       sstr << std::setprecision(16) << s[i] << ",";
+    }
 
     sstr << "\nt (" << t.size() << "): ";
     for(auto i = 0u; i < t.size(); ++i)
+    {
       sstr << std::setprecision(16) << t[i] << ",";
+    }
 
     SLIC_INFO(sstr.str());
   }

--- a/src/axom/primal/tests/primal_bezier_patch.cpp
+++ b/src/axom/primal/tests/primal_bezier_patch.cpp
@@ -86,12 +86,16 @@ TEST(primal_bezierpatch, set_order)
   bPatch(1, 1) = controlPoints[3];
 
   for(int p = 0; p <= bPatch.getOrder_u(); ++p)
+  {
     for(int q = 0; q <= bPatch.getOrder_v(); ++q)
     {
       auto& pt = bPatch(p, q);
       for(int i = 0; i < DIM; ++i)
+      {
         EXPECT_DOUBLE_EQ(controlPoints[p * (order_u + 1) + q][i], pt[i]);
+      }
     }
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -120,12 +124,16 @@ TEST(primal_bezierpatch, array_constructors)
   EXPECT_FALSE(nonrational_patch.isRational());
 
   for(int p = 0; p <= nonrational_patch.getOrder_u(); ++p)
+  {
     for(int q = 0; q <= nonrational_patch.getOrder_v(); ++q)
     {
       auto& pt = nonrational_patch(p, q);
       for(int i = 0; i < DIM; ++i)
+      {
         EXPECT_DOUBLE_EQ(controlPoints[p * (order_u + 1) + q][i], pt[i]);
+      }
     }
+  }
 
   BezierPatchType nonrational_patch_again(controlPoints, nullptr, order_u, order_v);
   EXPECT_EQ(nonrational_patch_again.getOrder_u(), order_u);
@@ -133,12 +141,16 @@ TEST(primal_bezierpatch, array_constructors)
   EXPECT_FALSE(nonrational_patch_again.isRational());
 
   for(int p = 0; p <= nonrational_patch_again.getOrder_u(); ++p)
+  {
     for(int q = 0; q <= nonrational_patch_again.getOrder_v(); ++q)
     {
       auto& pt = nonrational_patch_again(p, q);
       for(int i = 0; i < DIM; ++i)
+      {
         EXPECT_DOUBLE_EQ(controlPoints[p * (order_u + 1) + q][i], pt[i]);
+      }
     }
+  }
 
   BezierPatchType rational_patch(controlPoints, weights, order_u, order_v);
   EXPECT_EQ(rational_patch.getOrder_u(), order_u);
@@ -146,14 +158,18 @@ TEST(primal_bezierpatch, array_constructors)
   EXPECT_TRUE(rational_patch.isRational());
 
   for(int p = 0; p <= rational_patch.getOrder_u(); ++p)
+  {
     for(int q = 0; q <= rational_patch.getOrder_v(); ++q)
     {
       auto& pt = rational_patch(p, q);
       for(int i = 0; i < DIM; ++i)
+      {
         EXPECT_DOUBLE_EQ(controlPoints[p * (order_u + 1) + q][i], pt[i]);
+      }
       EXPECT_DOUBLE_EQ(weights[p * (order_u + 1) + q],
                        rational_patch.getWeight(p, q));
     }
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -183,12 +199,16 @@ TEST(primal_bezierpatch, axom_array_constructors)
   EXPECT_FALSE(nonrational_patch.isRational());
 
   for(int p = 0; p <= nonrational_patch.getOrder_u(); ++p)
+  {
     for(int q = 0; q <= nonrational_patch.getOrder_v(); ++q)
     {
       auto& pt = nonrational_patch(p, q);
       for(int i = 0; i < DIM; ++i)
+      {
         EXPECT_DOUBLE_EQ(controlPoints[p * (order_u + 1) + q][i], pt[i]);
+      }
     }
+  }
 
   BezierPatchType rational_patch(controlPoints, weights, order_u, order_v);
   EXPECT_EQ(rational_patch.getOrder_u(), order_u);
@@ -196,14 +216,18 @@ TEST(primal_bezierpatch, axom_array_constructors)
   EXPECT_TRUE(rational_patch.isRational());
 
   for(int p = 0; p <= rational_patch.getOrder_u(); ++p)
+  {
     for(int q = 0; q <= rational_patch.getOrder_v(); ++q)
     {
       auto& pt = rational_patch(p, q);
       for(int i = 0; i < DIM; ++i)
+      {
         EXPECT_DOUBLE_EQ(controlPoints[p * (order_u + 1) + q][i], pt[i]);
+      }
       EXPECT_DOUBLE_EQ(weights[p * (order_u + 1) + q],
                        rational_patch.getWeight(p, q));
     }
+  }
 
   // Construct with 2D axom arrays
   axom::Array<PointType, 2> controlPoints_2D(2, 2);
@@ -224,10 +248,16 @@ TEST(primal_bezierpatch, axom_array_constructors)
   EXPECT_FALSE(nonrational_patch_2D.isRational());
 
   for(int p = 0; p <= nonrational_patch_2D.getOrder_u(); ++p)
+  {
     for(int q = 0; q <= nonrational_patch_2D.getOrder_v(); ++q)
+    {
       for(int i = 0; i < DIM; ++i)
+      {
         EXPECT_DOUBLE_EQ(controlPoints_2D(p, q)[i],
                          nonrational_patch_2D(p, q)[i]);
+      }
+    }
+  }
 
   BezierPatchType rational_patch_2D(controlPoints_2D, weights_2D, order_u, order_v);
   EXPECT_EQ(rational_patch_2D.getOrder_u(), order_u);
@@ -235,12 +265,16 @@ TEST(primal_bezierpatch, axom_array_constructors)
   EXPECT_TRUE(rational_patch_2D.isRational());
 
   for(int p = 0; p <= rational_patch_2D.getOrder_u(); ++p)
+  {
     for(int q = 0; q <= rational_patch_2D.getOrder_v(); ++q)
     {
       for(int i = 0; i < DIM; ++i)
+      {
         EXPECT_DOUBLE_EQ(controlPoints_2D(p, q)[i], rational_patch_2D(p, q)[i]);
+      }
       EXPECT_DOUBLE_EQ(weights_2D(p, q), rational_patch_2D.getWeight(p, q));
     }
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -271,18 +305,27 @@ TEST(primal_bezierpatch, make_rational)
 
   // makeRational should set all weights to 1
   for(int p = 0; p <= order_u; ++p)
+  {
     for(int q = 0; q <= order_v; ++q)
+    {
       EXPECT_DOUBLE_EQ(rPatch.getWeight(p, q), 1.0);
+    }
+  }
 
   // With all weights 1, the surface should be the same as if unweighted
   BezierPatchType bPatch(controlPoints, order_u, order_v);
   for(double u = 0; u <= 1.0; u += 0.1)
+  {
     for(double v = 0; v <= 1.0; v += 0.1)
     {
       auto pt1 = rPatch.evaluate(u, v);
       auto pt2 = bPatch.evaluate(u, v);
-      for(int i = 0; i < DIM; ++i) EXPECT_NEAR(pt1[i], pt2[i], 1e-10);
+      for(int i = 0; i < DIM; ++i)
+      {
+        EXPECT_NEAR(pt1[i], pt2[i], 1e-10);
+      }
     }
+  }
 
   rPatch.makeNonrational();
   EXPECT_FALSE(rPatch.isRational());
@@ -420,12 +463,14 @@ TEST(primal_bezierpatch, evaluation_degenerate)
   BezierPatchType bPatch(data, order, 0);
 
   for(double t = 0; t <= 1; t += 0.01)
+  {
     for(int i = 0; i < DIM; ++i)
     {
       EXPECT_NEAR(bCurve.evaluate(t)[i], bPatch.evaluate(t, 0)[i], 1e-10);
       EXPECT_NEAR(bCurve.evaluate(t)[i], bPatch.evaluate(t, 0.5)[i], 1e-10);
       EXPECT_NEAR(bCurve.evaluate(t)[i], bPatch.evaluate(t, 1.0)[i], 1e-10);
     }
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -579,7 +624,9 @@ TEST(primal_bezierpatch, split_curve)
   // Components split along the u-axis p1/p3 vs p2/p4 should equal curves
   // Components split along the v-axis p1/p2 vs p3/p4 should equal each other
   for(double u = 0; u <= 1; u += 0.1)
+  {
     for(double v = 0; v <= 1; v += 0.1)
+    {
       for(int i = 0; i < DIM; ++i)
       {
         EXPECT_NEAR(c1.evaluate(u)[i], p1.evaluate(u, v)[i], 1e-10);
@@ -588,6 +635,8 @@ TEST(primal_bezierpatch, split_curve)
         EXPECT_NEAR(c2.evaluate(u)[i], p2.evaluate(u, v)[i], 1e-10);
         EXPECT_NEAR(c2.evaluate(u)[i], p4.evaluate(u, v)[i], 1e-10);
       }
+    }
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -616,12 +665,16 @@ TEST(primal_bezierpatch, split_plane)
 
   // Ensure that after splitting, each point remains on the same hyperplane
   for(double u = 0.0; u <= 1.0; u += 0.1)
+  {
     for(double v = 0.0; v <= 1.0; v += 0.1)
+    {
       for(int n = 0; n < 4; ++n)
       {
         auto pt = p_arr[n].evaluate(u, v);
         EXPECT_NEAR(pt[0] + pt[1] + pt[2], 1.0, 1e-10);
       }
+    }
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -773,46 +826,66 @@ TEST(primal_bezierpatch, reverse_orientation)
   // Reverse along the u-axis
   reversed.reverseOrientation(0);
   for(double u = 0; u <= 1.0; u += 0.1)
+  {
     for(double v = 0; v <= 1.0; v += 0.1)
     {
       PointType o_pt = original.evaluate(u, v);
       PointType r_pt = reversed.evaluate(1 - u, v);
 
-      for(int i = 0; i < DIM; ++i) EXPECT_NEAR(o_pt[i], r_pt[i], 1e-10);
+      for(int i = 0; i < DIM; ++i)
+      {
+        EXPECT_NEAR(o_pt[i], r_pt[i], 1e-10);
+      }
     }
+  }
 
   // Reverse along the u-axis again, should return to original
   reversed.reverseOrientation(0);
   for(double u = 0; u <= 1.0; u += 0.1)
+  {
     for(double v = 0; v <= 1.0; v += 0.1)
     {
       PointType o_pt = original.evaluate(u, v);
       PointType r_pt = reversed.evaluate(u, v);
 
-      for(int i = 0; i < DIM; ++i) EXPECT_NEAR(o_pt[i], r_pt[i], 1e-10);
+      for(int i = 0; i < DIM; ++i)
+      {
+        EXPECT_NEAR(o_pt[i], r_pt[i], 1e-10);
+      }
     }
+  }
 
   // Reverse along the v-axis
   reversed.reverseOrientation(1);
   for(double u = 0; u <= 1.0; u += 0.1)
+  {
     for(double v = 0; v <= 1.0; v += 0.1)
     {
       PointType o_pt = original.evaluate(u, v);
       PointType r_pt = reversed.evaluate(u, 1 - v);
 
-      for(int i = 0; i < DIM; ++i) EXPECT_NEAR(o_pt[i], r_pt[i], 1e-10);
+      for(int i = 0; i < DIM; ++i)
+      {
+        EXPECT_NEAR(o_pt[i], r_pt[i], 1e-10);
+      }
     }
+  }
 
   // Reverse along the u-axis again
   reversed.reverseOrientation(0);
   for(double u = 0; u <= 1.0; u += 0.1)
+  {
     for(double v = 0; v <= 1.0; v += 0.1)
     {
       PointType o_pt = original.evaluate(u, v);
       PointType r_pt = reversed.evaluate(1 - u, 1 - v);
 
-      for(int i = 0; i < DIM; ++i) EXPECT_NEAR(o_pt[i], r_pt[i], 1e-10);
+      for(int i = 0; i < DIM; ++i)
+      {
+        EXPECT_NEAR(o_pt[i], r_pt[i], 1e-10);
+      }
     }
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -846,23 +919,29 @@ TEST(primal_bezierpatch, rational_evaluation_split)
 
   // Verify that evaluation points are on the sphere
   for(double u = 0; u <= 1.0; u += 0.1)
+  {
     for(double v = 0; v <= 1.0; v += 0.1)
     {
       PointType pt = hemisphere.evaluate(u, v);
       EXPECT_NEAR(pt[0] * pt[0] + pt[1] * pt[1] + pt[2] * pt[2], 1.0, 1e-10);
     }
+  }
 
   BezierPatchType patches[4];
   hemisphere.split(0.5, 0.5, patches[0], patches[1], patches[2], patches[3]);
 
   // Verify that evaluation points are on still on the sphere for each subpatch
   for(double u = 0; u <= 1.0; u += 0.1)
+  {
     for(double v = 0; v <= 1.0; v += 0.1)
+    {
       for(int n = 0; n < 4; ++n)
       {
         PointType pt = patches[n].evaluate(u, v);
         EXPECT_NEAR(pt[0] * pt[0] + pt[1] * pt[1] + pt[2] * pt[2], 1.0, 1e-10);
       }
+    }
+  }
 
   // Do it again
   BezierPatchType sub_patches[4];
@@ -874,12 +953,16 @@ TEST(primal_bezierpatch, rational_evaluation_split)
                    sub_patches[3]);
 
   for(double u = 0; u <= 1.0; u += 0.1)
+  {
     for(double v = 0; v <= 1.0; v += 0.1)
+    {
       for(int n = 0; n < 4; ++n)
       {
         PointType pt = sub_patches[n].evaluate(u, v);
         EXPECT_NEAR(pt[0] * pt[0] + pt[1] * pt[1] + pt[2] * pt[2], 1.0, 1e-10);
       }
+    }
+  }
 }
 
 int main(int argc, char* argv[])

--- a/src/axom/primal/tests/primal_curved_polygon.cpp
+++ b/src/axom/primal/tests/primal_curved_polygon.cpp
@@ -76,7 +76,10 @@ primal::CurvedPolygon<CoordType, DIM> createPolygon(
   for(int j = 0; j < num_edges; ++j)
   {
     axom::Array<PointType> subCP(orders[j] + 1);
-    for(int i = 0; i < orders[j] + 1; i++) subCP[i] = ControlPoints[i + iter];
+    for(int i = 0; i < orders[j] + 1; i++)
+    {
+      subCP[i] = ControlPoints[i + iter];
+    }
 
     BezierCurveType addCurve(subCP, orders[j]);
     bPolygon.addEdge(addCurve);

--- a/src/axom/primal/tests/primal_rational_bezier.cpp
+++ b/src/axom/primal/tests/primal_rational_bezier.cpp
@@ -407,7 +407,9 @@ TEST(primal_beziercurve, isRational)
 
   // Verify that makeRational makes curve trivially rational
   for(int i = 1; i <= order; i++)
+  {
     EXPECT_DOUBLE_EQ(rCurve.getWeight(0), rCurve.getWeight(i));
+  }
 
   // Verify that trivially rational Bezier curve is identical
   //  to polynomial Bezier curve
@@ -450,6 +452,7 @@ TEST(primal_rationalbezier, winding_number)
   quarter_circle.addEdge(leg2);
 
   for(double theta = 0.01; theta < 1.5; theta += 0.05)
+  {
     for(int i = 1; i < 9; i++)
     {
       const double offset = std::pow(10, -i);
@@ -472,6 +475,7 @@ TEST(primal_rationalbezier, winding_number)
         0.0,
         abs_tol);
     }
+  }
 }
 
 TEST(primal_rationalbezier, rational_intersection)

--- a/src/axom/primal/tests/primal_ray_intersect.cpp
+++ b/src/axom/primal/tests/primal_ray_intersect.cpp
@@ -427,7 +427,9 @@ TEST(primal_ray_intersect, ray_segment_edge_cases)
     SegmentType(PointType({1, 3.1}), PointType({-2, -2.9}))};
 
   for(auto& seg : not_intersecting_segs)
+  {
     EXPECT_FALSE(intersect_ray(the_ray, seg, ray_param, seg_param, EPS));
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_solid_angle.cpp
+++ b/src/axom/primal/tests/primal_solid_angle.cpp
@@ -65,15 +65,19 @@ TEST(primal_solid_angle, triangle)
 
     // Get sign from orientation.
     if(primal::orientation(queries[n], tri) == primal::ON_NEGATIVE_SIDE)
+    {
       // Means query point is interior
       EXPECT_NEAR(0.25 * M_1_PI * solid_angle,
                   winding_number(queries[n], tri),
                   1e-10);
+    }
     else
+    {
       // Means query point is exterior
       EXPECT_NEAR(-0.25 * M_1_PI * solid_angle,
                   winding_number(queries[n], tri),
                   1e-10);
+    }
   }
 
   // Test with simple degenerate triangle
@@ -81,7 +85,9 @@ TEST(primal_solid_angle, triangle)
                Point3D {2.0, 3.0, 4.0},
                Point3D {1.0, 2.0, 3.0});
   for(int n = 0; n < 5; ++n)
+  {
     EXPECT_DOUBLE_EQ(0.0, winding_number(queries[n], deg));
+  }
 
   // Test with nondegenerate triangle, zero winding number
   Point3D coplanar {-1.0, 1.0, 1.0};
@@ -137,10 +143,12 @@ TEST(primal_solid_angle, simple_polygon)
   };
 
   for(int n = 0; n < 5; ++n)
+  {
     EXPECT_NEAR(winding_number(queries[n], square),
                 winding_number(queries[n], square_tri1) +
                   winding_number(queries[n], square_tri2),
                 1e-10);
+  }
 
   // Test on coplanar points
   Point3D troubled_queries[5] = {
@@ -152,7 +160,9 @@ TEST(primal_solid_angle, simple_polygon)
   };
 
   for(int n = 0; n < 5; ++n)
+  {
     EXPECT_NEAR(winding_number(troubled_queries[n], square), 0, 1e-10);
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -183,10 +193,12 @@ TEST(primal_solid_angle, nonconvex_polygon)
   };
 
   for(int n = 0; n < 5; ++n)
+  {
     EXPECT_NEAR(winding_number(queries[n], pentagon),
                 winding_number(queries[n], pentagon_tri1) +
                   winding_number(queries[n], pentagon_tri2),
                 1e-10);
+  }
 
   // Test on coplanar points
   Point3D troubled_queries[5] = {
@@ -198,7 +210,9 @@ TEST(primal_solid_angle, nonconvex_polygon)
   };
 
   for(int n = 0; n < 5; ++n)
+  {
     EXPECT_NEAR(winding_number(troubled_queries[n], pentagon), 0, 1e-10);
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -219,10 +233,12 @@ TEST(primal_solid_angle, degenerate_polygon)
 
   // Add vertices to good polygon
   for(int i = 0; i < 5; ++i)
+  {
     good_pentagon.addVertex(
       Point3D {cos(good_angles[i]) * v1[0] + sin(good_angles[i]) * v2[0],
                cos(good_angles[i]) * v1[1] + sin(good_angles[i]) * v2[1],
                cos(good_angles[i]) * v1[2] + sin(good_angles[i]) * v2[2]});
+  }
 
   // Create bad polygon with degeneracies
   // Add point at angle 0
@@ -238,10 +254,12 @@ TEST(primal_solid_angle, degenerate_polygon)
              cos(bad_angles[1]) * v1[2] + sin(bad_angles[1]) * v2[2]}));
   // Add the rest of the vertices
   for(int i = 1; i < 9; ++i)
+  {
     bad_pentagon.addVertex(
       Point3D {cos(bad_angles[i]) * v1[0] + sin(bad_angles[i]) * v2[0],
                cos(bad_angles[i]) * v1[1] + sin(bad_angles[i]) * v2[1],
                cos(bad_angles[i]) * v1[2] + sin(bad_angles[i]) * v2[2]});
+  }
 
   Point3D queries[5] = {
     Point3D {0.0, 4.0, 1.0},
@@ -253,9 +271,11 @@ TEST(primal_solid_angle, degenerate_polygon)
 
   EXPECT_NEAR(good_pentagon.area(), bad_pentagon.area(), 1e-10);
   for(int n = 0; n < 5; ++n)
+  {
     EXPECT_NEAR(winding_number(queries[n], good_pentagon),
                 winding_number(queries[n], bad_pentagon),
                 1e-10);
+  }
 
   // Test with duplicate point at endpoint
   axom::Array<Point3D> good_square_vertices({Point3D {1.0, 0.0, 0.0},
@@ -270,9 +290,11 @@ TEST(primal_solid_angle, degenerate_polygon)
                                             Point3D {0.0, 0.0, 0.0}});
 
   for(int n = 0; n < 5; ++n)
+  {
     EXPECT_NEAR(winding_number(queries[n], Polygon(good_square_vertices)),
                 winding_number(queries[n], Polygon(bad_square_vertices)),
                 1e-10);
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -305,17 +327,21 @@ TEST(primal_solid_angle, selfintersecting_star)
 
   // Add vertices to pentagram
   for(int i = 0; i < 5; ++i)
+  {
     pentagram.addVertex(
       Point3D {cos(outer_angles[i]) * v1[0] + sin(outer_angles[i]) * v2[0],
                cos(outer_angles[i]) * v1[1] + sin(outer_angles[i]) * v2[1],
                cos(outer_angles[i]) * v1[2] + sin(outer_angles[i]) * v2[2]});
+  }
 
   // Construct the inner pentagon
   for(int i = 0; i < 5; ++i)
+  {
     pentagon.addVertex(Point3D {
       r0 * cos(inner_angles[i]) * v1[0] + r0 * sin(inner_angles[i]) * v2[0],
       r0 * cos(inner_angles[i]) * v1[1] + r0 * sin(inner_angles[i]) * v2[1],
       r0 * cos(inner_angles[i]) * v1[2] + r0 * sin(inner_angles[i]) * v2[2]});
+  }
 
   // Construct the stars of the pentagram
   Polygon star_tips[5];
@@ -345,18 +371,24 @@ TEST(primal_solid_angle, selfintersecting_star)
   double star_components = 0;
   star_components += winding_number(single_query, pentagon);
   for(int i = 0; i < 5; ++i)
+  {
     star_components += winding_number(single_query, star_tips[i]);
+  }
 
   // Triangulate the pentagram directly
   Polygon pentagram_tris[5 - 2];
   for(int i = 0; i < 5 - 2; ++i)
+  {
     pentagram_tris[i] = Polygon(
       axom::Array<Point3D>({pentagram[0], pentagram[i + 1], pentagram[i + 2]}));
+  }
 
   // Add up components of the pentagram triangulation
   double pentagram_triangulation = 0;
   for(int i = 0; i < 5 - 2; ++i)
+  {
     pentagram_triangulation += winding_number(single_query, pentagram_tris[i]);
+  }
 
   for(int n = 0; n < 5; ++n)
   {
@@ -414,9 +446,11 @@ TEST(primal_solid_angle, selfintersecting_quadrilateral)
 
   // Area of overlapping square should be twice that of nonoverlapping
   for(int n = 0; n < 5; ++n)
+  {
     EXPECT_NEAR(2 * winding_number(queries[n], square),
                 winding_number(queries[n], squareish),
                 1e-10);
+  }
 
   // Test on non-uniformly oriented hourglass shape
   axom::Array<Point3D> hourglass_vertices({
@@ -436,10 +470,12 @@ TEST(primal_solid_angle, selfintersecting_quadrilateral)
 
   // Area of overlapping square should be twice that of nonoverlapping
   for(int n = 0; n < 5; ++n)
+  {
     EXPECT_NEAR(winding_number(queries[n], top_bulb) +
                   winding_number(queries[n], bot_bulb),
                 winding_number(queries[n], hourglass),
                 1e-10);
+  }
 }
 
 int main(int argc, char** argv)

--- a/src/axom/primal/tests/primal_winding_number.cpp
+++ b/src/axom/primal/tests/primal_winding_number.cpp
@@ -102,9 +102,13 @@ TEST(primal_winding_number, simple_cases)
   {
     auto q = Point2D {0.0, y};
     if(tri.checkInTriangle(q))
+    {
       EXPECT_EQ(winding_number(q, tri, includeBoundary), 1);
+    }
     else
+    {
       EXPECT_EQ(winding_number(q, tri, includeBoundary), 0);
+    }
   }
 
   // Reverse the orientation, which flips the winding number
@@ -113,9 +117,13 @@ TEST(primal_winding_number, simple_cases)
   {
     auto q = Point2D {0.0, y};
     if(tri.checkInTriangle(q))
+    {
       EXPECT_EQ(winding_number(q, tri, includeBoundary), -1);
+    }
     else
+    {
       EXPECT_EQ(winding_number(q, tri, includeBoundary), 0);
+    }
   }
 }
 
@@ -313,9 +321,11 @@ TEST(primal_winding_number, edge_cases)
 
   // At any point on a line, returns 0
   for(double t = 0.1; t < 1; t += 0.1)
+  {
     EXPECT_NEAR(winding_number(Point2D({t, t}), linear, edge_tol, EPS),
                 0.0,
                 abs_tol);
+  }
 
   // Cubic curve, where query is not on an endpoint after any number of bisections
   Point2D cubic_nodes[] = {Point2D {0.0, 0.0},
@@ -400,16 +410,22 @@ TEST(primal_winding_number, degenerate_cases)
                                       Point2D {0.0, 1.0}};
 
   for(auto pt : test_points)
+  {
     EXPECT_NEAR(winding_number(pt, empty_curve, edge_tol, EPS), 0, abs_tol);
+  }
 
   // Check default empty Bezier curves
   Bezier very_empty_curve(-1);
   for(auto pt : test_points)
+  {
     EXPECT_NEAR(winding_number(pt, very_empty_curve, edge_tol, EPS), 0, abs_tol);
+  }
 
   very_empty_curve.setOrder(0);
   for(auto pt : test_points)
+  {
     EXPECT_NEAR(winding_number(pt, very_empty_curve, edge_tol, EPS), 0, abs_tol);
+  }
 
   // Cubic curve with many duplicated endpoints
   Point2D cubic_nodes[] = {Point2D {0.0, 0.0},

--- a/src/axom/quest/Delaunay.hpp
+++ b/src/axom/quest/Delaunay.hpp
@@ -311,7 +311,9 @@ public:
       const int kUpper = (DIM == 2) ? 0 : res;
       const IndexType stride[3] = {1, res, (DIM == 2) ? 0 : res * res};
       for(IndexType k = 0; k < kUpper; ++k)
+      {
         for(IndexType j = 0; j < res; ++j)
+        {
           for(IndexType i = 0; i < res; ++i)
           {
             const IndexType vals[3] = {i, j, k};
@@ -320,6 +322,8 @@ public:
             const auto binValues = implicitGrid.getCandidatesAsArray(cell);
             grid.getBinContents(idx).insert(0, binValues.size(), binValues.data());
           }
+        }
+      }
     }
 
     // for each vertex -- check in_sphere condition for candidate element

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -1049,30 +1049,40 @@ private:
                            bool atLeastOne) const
   {
     std::vector<MPI_Request> reqs;
-    for(auto& isr : isendRequests) reqs.push_back(isr.m_request);
+    for(auto& isr : isendRequests)
+    {
+      reqs.push_back(isr.m_request);
+    }
 
     int inCount = static_cast<int>(reqs.size());
     int outCount = 0;
     std::vector<int> indices(reqs.size(), -1);
     if(atLeastOne)
+    {
       MPI_Waitsome(inCount,
                    reqs.data(),
                    &outCount,
                    indices.data(),
                    MPI_STATUSES_IGNORE);
+    }
     else
+    {
       MPI_Testsome(inCount,
                    reqs.data(),
                    &outCount,
                    indices.data(),
                    MPI_STATUSES_IGNORE);
+    }
     indices.resize(outCount);
 
     auto reqIter = isendRequests.begin();
     int prevIdx = 0;
     for(const int idx : indices)
     {
-      for(; prevIdx < idx; ++prevIdx) ++reqIter;
+      for(; prevIdx < idx; ++prevIdx)
+      {
+        ++reqIter;
+      }
       reqIter = isendRequests.erase(reqIter);
       ++prevIdx;
     }

--- a/src/axom/quest/InOutOctree.hpp
+++ b/src/axom/quest/InOutOctree.hpp
@@ -320,7 +320,10 @@ private:
     for(int i = 0; i < tVerts.size(); ++i)
     {
       // Using the vertex-to-block cache to avoid numerical degeneracies
-      if(blockIndexesVertex(tVerts[i], blk)) return true;
+      if(blockIndexesVertex(tVerts[i], blk))
+      {
+        return true;
+      }
     }
     return false;
   }
@@ -553,7 +556,9 @@ void InOutOctree<DIM>::insertVertex(VertexIndex idx, int startingLevel)
 
     // Update the vertex-to-block map for this vertex
     if(m_generationState >= INOUTOCTREE_MESH_REORDERED)
+    {
       m_vertexToBlockMap[idx] = block;
+    }
   }
   else
   {
@@ -600,7 +605,10 @@ void InOutOctree<DIM>::insertMeshCells()
 
   currentLevelData.push_back(DynamicGrayBlockData());
   DynamicGrayBlockData& dynamicRootData = currentLevelData[0];
-  if(rootData.hasData()) dynamicRootData.setVertex(rootData.dataIndex());
+  if(rootData.hasData())
+  {
+    dynamicRootData.setVertex(rootData.dataIndex());
+  }
   dynamicRootData.setLeafFlag(rootData.isLeaf());
   rootData.setData(0);
 
@@ -633,7 +641,10 @@ void InOutOctree<DIM>::insertMeshCells()
     {
       InOutBlockData& blkData = *it;
 
-      if(!blkData.hasData()) continue;
+      if(!blkData.hasData())
+      {
+        continue;
+      }
 
       BlockIndex blk(it.pt(), lev);
       DynamicGrayBlockData& dynamicLeafData =
@@ -696,7 +707,9 @@ void InOutOctree<DIM>::insertMeshCells()
 
           // Reinsert the vertex into the tree, if vIdx was indexed by blk
           if(blockIndexesVertex(vIdx, blk))
+          {
             insertVertex(vIdx, blk.childLevel());
+          }
         }
         else if(isInternal)
         {
@@ -747,7 +760,9 @@ void InOutOctree<DIM>::insertMeshCells()
         // This ensures that our child data pointers will not be invalidated
         if(nextLevelData.capacity() <
            (nextLevelData.size() + BlockIndex::NUM_CHILDREN))
+        {
           nextLevelData.reserve(nextLevelData.size() * 4);
+        }
 
         // Add all cells to intersecting children blocks
         DynamicGrayBlockData::CellList& parentCells = dynamicLeafData.cells();
@@ -838,8 +853,10 @@ void InOutOctree<DIM>::insertMeshCells()
     nextLevelData.swap(currentLevelData);
 
     if(!levelLeafMap.empty())
+    {
       SLIC_DEBUG("\tInserting cells into level "
                  << lev << " took " << levelTimer.elapsed() << " seconds.");
+    }
   }
 }
 
@@ -865,12 +882,17 @@ void InOutOctree<DIM>::colorOctreeLeaves()
     auto itEnd = levelLeafMap.end();
     for(auto it = levelLeafMap.begin(); it != itEnd; ++it)
     {
-      if(!it->isLeaf()) continue;
+      if(!it->isLeaf())
+      {
+        continue;
+      }
 
       BlockIndex leafBlk(it.pt(), lev);
       InOutBlockData& blockData = *it;
       if(!colorLeafAndNeighbors(leafBlk, blockData))
+      {
         uncoloredBlocks.push_back(leafBlk.pt());
+      }
     }
 
     // Iterate through the uncolored blocks until all have a color
@@ -888,7 +910,9 @@ void InOutOctree<DIM>::colorOctreeLeaves()
       {
         BlockIndex leafBlk(*it, lev);
         if(!colorLeafAndNeighbors(leafBlk, (*this)[leafBlk]))
+        {
           uncoloredBlocks.push_back(*it);
+        }
       }
 
       SLIC_ASSERT_MSG(
@@ -961,9 +985,13 @@ bool InOutOctree<DIM>::colorLeafAndNeighbors(const BlockIndex& leafBlk,
             SpacePt::midpoint(this->blockBoundingBox(leafBlk).getCentroid(),
                               this->blockBoundingBox(neighborBlk).getCentroid());
           if(withinGrayBlock<DIM>(faceCenter, neighborBlk, neighborData))
+          {
             leafData.setBlack();
+          }
           else
+          {
             leafData.setWhite();
+          }
         }
         break;
         case InOutBlockData::Undetermined:
@@ -1025,9 +1053,13 @@ bool InOutOctree<DIM>::colorLeafAndNeighbors(const BlockIndex& leafBlk,
               this->blockBoundingBox(leafBlk.faceNeighbor(i)).getCentroid());
 
             if(withinGrayBlock<DIM>(faceCenter, leafBlk, leafData))
+            {
               neighborData.setBlack();
+            }
             else
+            {
               neighborData.setWhite();
+            }
           }
           break;
           case InOutBlockData::Undetermined:
@@ -1161,7 +1193,10 @@ typename std::enable_if<TDIM == 3, bool>::type InOutOctree<DIM>::withinGrayBlock
     for(int j = 0; j < numTris; ++j)
     {
       CellIndex localIdx = triSet[j];
-      if(localIdx == idx) continue;
+      if(localIdx == idx)
+      {
+        continue;
+      }
 
       if(primal::intersect(m_meshWrapper.cellPositions(localIdx), ray, rayParam))
       {
@@ -1278,7 +1313,10 @@ typename std::enable_if<TDIM == 2, bool>::type InOutOctree<DIM>::withinGrayBlock
     for(int j = 0; j < numSegments; ++j)
     {
       CellIndex localIdx = segmentSet[j];
-      if(localIdx == idx) continue;
+      if(localIdx == idx)
+      {
+        continue;
+      }
 
       if(primal::intersect(ray,
                            m_meshWrapper.cellPositions(localIdx),
@@ -1348,10 +1386,15 @@ void InOutOctree<DIM>::updateSurfaceMeshVertices()
 
     // If the indexed vertex doesn't have a new id, give it one
     if(vertexIndexMap[vInd] == MeshWrapper<DIM>::NO_VERTEX)
+    {
       vertexIndexMap[vInd] = uniqueVertexCounter++;
+    }
 
     // If this is not the indexed vertex of the block, set the new index
-    if(vInd != i) vertexIndexMap[i] = vertexIndexMap[vInd];
+    if(vInd != i)
+    {
+      vertexIndexMap[i] = vertexIndexMap[vInd];
+    }
   }
 
   // Use the index map to reindex the mesh verts and elements
@@ -1426,13 +1469,18 @@ bool InOutOctree<DIM>::allCellsIncidentInCommonVertex(
           if(!m_meshWrapper.incidentInVertex(
                m_meshWrapper.cellVertexIndices(cells[i]),
                commonVert))
+          {
             shareCommonVert = false;
+          }
         }
       }
       break;
     }
 
-    if(shareCommonVert) leafData.setVertex(commonVert);
+    if(shareCommonVert)
+    {
+      leafData.setVertex(commonVert);
+    }
   }
 
   return shareCommonVert;

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -474,7 +474,9 @@ public:
     // The mesh points are filtered like we want. We need only copy
     // them into the polyline array.
     for(int i = 0; i < pointcount; ++i)
+    {
       m_surfaceMesh->getNode(i, polyline[i].data());
+    }
     int polyline_size = pointcount;
 
     // Generate the Octahedra
@@ -1002,7 +1004,9 @@ private:
     const std::string vol_frac_("vol_frac_");
     std::string name;
     if(fieldName.find(vol_frac_) == 0)
+    {
       name = fieldName.substr(vol_frac_.size());
+    }
     return name;
   }
 
@@ -1062,7 +1066,10 @@ private:
     for(auto it : this->getDC()->GetFieldMap())
     {
       std::string materialName = fieldNameToMaterialName(it.first);
-      if(!materialName.empty()) materialNames.emplace_back(materialName);
+      if(!materialName.empty())
+      {
+        materialNames.emplace_back(materialName);
+      }
     }
     // Add any of these existing fields to this class' bookkeeping.
     for(const auto& materialName : materialNames)
@@ -1095,7 +1102,9 @@ public:
     const std::string fieldName(materialNameToFieldName(m_free_mat_name));
     mfem::GridFunction* cfgf = nullptr;
     if(this->getDC()->HasField(fieldName))
+    {
       cfgf = this->getDC()->GetField(fieldName);
+    }
     else
     {
       // Make the new grid function.
@@ -1235,7 +1244,9 @@ public:
             // Do not add the current shape material since it should
             // not end up in updateVFs.
             if(name != shape.getMaterial())
+            {
               gf_order_by_matnumber.emplace_back(getMaterial(name));
+            }
           }
           else
           {

--- a/src/axom/quest/detail/MarchingCubesImpl.hpp
+++ b/src/axom/quest/detail/MarchingCubesImpl.hpp
@@ -23,7 +23,10 @@ namespace marching_cubes
 template <typename T, int DIM, typename U>
 static void add_to_StackArray(axom::StackArray<T, DIM>& a, U b)
 {
-  for(int d = 0; d < DIM; ++d) a[d] += b;
+  for(int d = 0; d < DIM; ++d)
+  {
+    a[d] += b;
+  }
 }
 
 //!@brief Reverse the order of a StackArray.
@@ -85,7 +88,9 @@ public:
 
     m_bStrides[0] = 1;
     for(int d = 1; d < DIM; ++d)
+    {
       m_bStrides[d] = m_bStrides[d - 1] * m_bShape[d - 1];
+    }
 
     // Domain's node coordinates
     {

--- a/src/axom/quest/detail/PointInCellMeshWrapper_mfem.hpp
+++ b/src/axom/quest/detail/PointInCellMeshWrapper_mfem.hpp
@@ -433,7 +433,9 @@ private:
 
         SpacePoint pt;
         for(int j = 0; j < NDIMS; ++j)
+        {
           pt[j] = (*positiveNodes)(fes->DofToVDof(nIdx, j));
+        }
 
         bbox.addPoint(pt);
       }

--- a/src/axom/quest/detail/inout/BlockData.hpp
+++ b/src/axom/quest/detail/inout/BlockData.hpp
@@ -168,7 +168,10 @@ public:  // Other functions
    */
   LeafColor color() const
   {
-    if(hasData()) return Gray;
+    if(hasData())
+    {
+      return Gray;
+    }
 
     switch(m_idx)
     {
@@ -238,9 +241,13 @@ inline std::ostream& operator<<(std::ostream& os, const InOutBlockData& iob)
   {
     os << ", dataIndex: ";
     if(!iob.hasData())
+    {
       os << "<no data>";
+    }
     else
+    {
       os << iob.dataIndex();
+    }
   }
 
   os << "}";
@@ -399,9 +406,13 @@ inline std::ostream& operator<<(std::ostream& os,
 
   os << ", vertex: ";
   if(bData.hasVertex())
+  {
     os << bData.vertexIndex();
+  }
   else
+  {
     os << "<none>";
+  }
 
   os << ", cells: ";
   if(bData.hasCells())
@@ -409,7 +420,9 @@ inline std::ostream& operator<<(std::ostream& os,
     int numCell = bData.numCells();
     os << "(" << numCell << ") {";
     for(int i = 0; i < numCell; ++i)
+    {
       os << bData.cells()[i] << ((i == numCell - 1) ? "} " : ",");
+    }
   }
 
   os << "}";

--- a/src/axom/quest/detail/inout/InOutOctreeMeshDumper.hpp
+++ b/src/axom/quest/detail/inout/InOutOctreeMeshDumper.hpp
@@ -107,7 +107,10 @@ public:
       auto itEnd = levelLeafMap.end();
       for(auto it = levelLeafMap.begin(); it != itEnd; ++it)
       {
-        if(it->isLeaf()) blocks.push_back(BlockIndex(it.pt(), lev));
+        if(it->isLeaf())
+        {
+          blocks.push_back(BlockIndex(it.pt(), lev));
+        }
       }
     }
     SLIC_INFO("Dump vtk:: Octree has " << blocks.size() << " leaves.");
@@ -202,7 +205,10 @@ public:
                             const std::vector<BlockIndex>& blocks,
                             bool shouldLogBlocks = false) const
   {
-    if(blocks.empty()) return;
+    if(blocks.empty())
+    {
+      return;
+    }
 
     // Dump an octree mesh containing all blocks
     std::string fName = fmt::format("{}.vtk", name);
@@ -349,7 +355,10 @@ protected:
       CellVertIndices cv = m_octree.m_meshWrapper.cellVertexIndices(cIdx);
       for(int j = 0; j < cv.size(); ++j)
       {
-        if(cv[j] == vIdx) cells.push_back(cIdx);
+        if(cv[j] == vIdx)
+        {
+          cells.push_back(cIdx);
+        }
       }
     }
 
@@ -828,7 +837,10 @@ public:
     mesh->appendNode(bMin[0], bMax[1], bMax[2]);
 
     axom::IndexType data[8];
-    for(int i = 0; i < 8; ++i) data[i] = vStart + i;
+    for(int i = 0; i < 8; ++i)
+    {
+      data[i] = vStart + i;
+    }
 
     mesh->appendCell(data, mint::HEX);
 

--- a/src/axom/quest/detail/inout/InOutOctreeValidator.hpp
+++ b/src/axom/quest/detail/inout/InOutOctreeValidator.hpp
@@ -74,7 +74,10 @@ public:
     auto itEnd = levelLeafMap.end();
     for(auto it = levelLeafMap.begin(); it != itEnd; ++it)
     {
-      if(!it->isLeaf()) continue;
+      if(!it->isLeaf())
+      {
+        continue;
+      }
 
       SLIC_ASSERT_MSG(
         it->isColored(),
@@ -153,7 +156,10 @@ public:
         CellIndexSet leafCells = m_octree.leafCells(vertBlock, leafData);
         for(int k = 0; !foundCell && k < leafCells.size(); ++k)
         {
-          if(leafCells[k] == cIdx) foundCell = true;
+          if(leafCells[k] == cIdx)
+          {
+            foundCell = true;
+          }
         }
 
         SLIC_ASSERT_MSG(
@@ -301,7 +307,9 @@ public:
   {
     // We are assumed to be valid before we insert the vertices
     if(m_generationState < InOutOctreeType::INOUTOCTREE_VERTICES_INSERTED)
+    {
       return;
+    }
 
     // Iterate through the tree
     // Internal blocks should not have associated vertex data

--- a/src/axom/quest/detail/inout/MeshWrapper.hpp
+++ b/src/axom/quest/detail/inout/MeshWrapper.hpp
@@ -116,18 +116,26 @@ public:
   int numMeshVertices() const
   {
     if(m_meshWasReindexed)
+    {
       return m_vertexSet.size();
+    }
     else
+    {
       return m_surfaceMesh->getNumberOfNodes();
+    }
   }
 
   /** Accessor for the number of elements in the wrapped surface mesh */
   int numMeshCells() const
   {
     if(m_meshWasReindexed)
+    {
       return m_elementSet.size();
+    }
     else
+    {
       return m_surfaceMesh->getNumberOfCells();
+    }
   }
 
   /**
@@ -195,7 +203,12 @@ public:
     CellVertIndices cvRel1 = cellVertexIndices(c1);
 
     for(int i = 0; i < NUM_CELL_VERTS; ++i)
-      if(!incidentInVertex(cvRel0, cvRel1[i])) return cvRel1[i];
+    {
+      if(!incidentInVertex(cvRel0, cvRel1[i]))
+      {
+        return cvRel1[i];
+      }
+    }
 
     SLIC_ASSERT_MSG(
       false,
@@ -410,7 +423,9 @@ public:
 
       // Remap the vertex IDs
       for(int j = 0; j < NUM_EDGE_VERTS; ++j)
+      {
         vertIds[j] = vertexIndexMap[vertIds[j]];
+      }
 
       // Add to relation if not degenerate edge
       // (namely, we need 2 unique vertex IDs)
@@ -559,7 +574,9 @@ public:
 
       // Remap the vertex IDs
       for(int j = 0; j < NUM_TRI_VERTS; ++j)
+      {
         vertIds[j] = vertexIndexMap[vertIds[j]];
+      }
 
       // Add to relation if not degenerate triangles
       // (namely, we need 3 unique vertex IDs)

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -270,7 +270,10 @@ public:
     // return m_coordsGroup != nullptr && m_coordsGroup->hasView("values/x");
     for(auto* cg : m_coordsGroups)
     {
-      if(cg != nullptr && cg->hasView("values/x")) return true;
+      if(cg != nullptr && cg->hasView("values/x"))
+      {
+        return true;
+      }
     }
     return false;
   }

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -463,7 +463,10 @@ public:
   axom::Array<axom::ArrayView<double, DIM>> get_coords_view(int domainNum)
   {
     axom::StackArray<axom::IndexType, DIM> shape = getNodesShape<DIM>(domainNum);
-    for(int d = 0; d < DIM / 2; ++d) std::swap(shape[d], shape[DIM - 1 - d]);
+    for(int d = 0; d < DIM / 2; ++d)
+    {
+      std::swap(shape[d], shape[DIM - 1 - d]);
+    }
 
     conduit::Node& dom = _mdMesh[domainNum];
     conduit::Node& coordsValues = dom.fetch_existing("coordsets/coords/values");
@@ -655,14 +658,20 @@ template <typename T, int DIM>
 T product(const axom::StackArray<T, DIM>& a)
 {
   T rval = a[0];
-  for(int d = 1; d < DIM; ++d) rval *= a[d];
+  for(int d = 1; d < DIM; ++d)
+  {
+    rval *= a[d];
+  }
   return rval;
 }
 
 template <typename T, int DIM, typename U>
 static void addToStackArray(axom::StackArray<T, DIM>& a, U b)
 {
-  for(int d = 0; d < DIM; ++d) a[d] += b;
+  for(int d = 0; d < DIM; ++d)
+  {
+    a[d] += b;
+  }
 }
 
 /*!
@@ -678,7 +687,10 @@ axom::StackArray<axom::IndexType, DIM> flatToMultidimIndex(
   const axom::StackArray<axom::IndexType, DIM>& sizes)
 {
   axom::IndexType strides[DIM] = {1};
-  for(int d = 1; d < DIM; ++d) strides[d] = strides[d - 1] * sizes[d - 1];
+  for(int d = 1; d < DIM; ++d)
+  {
+    strides[d] = strides[d - 1] * sizes[d - 1];
+  }
   if(flatId >= strides[DIM - 1] * sizes[DIM - 1])
   {
     SLIC_ERROR("flatId is too big.");
@@ -1072,7 +1084,12 @@ struct ContourTestBase
         {
           axom::StackArray<axom::IndexType, DIM> cornerIdx = cellIdx;
           for(int d = 0; d < DIM; ++d)
-            if(cornerId & (1 << d)) ++cornerIdx[d];
+          {
+            if(cornerId & (1 << d))
+            {
+              ++cornerIdx[d];
+            }
+          }
 
           reverse(cornerIdx);
           double fcnValue = fcnView[cornerIdx];
@@ -1112,7 +1129,9 @@ struct ContourTestBase
       domain.fetch_existing("topologies/mesh/elements/dims");
     axom::StackArray<axom::IndexType, DIM> coordsViewShape;
     for(int d = 0; d < DIM; ++d)
+    {
       coordsViewShape[d] = 1 + dimsNode[DIM - 1 - d].as_int();
+    }
 
     const conduit::Node& coordValues =
       domain.fetch_existing(coordsetPath + "/values");

--- a/src/axom/quest/readers/C2CReader.cpp
+++ b/src/axom/quest/readers/C2CReader.cpp
@@ -413,8 +413,14 @@ struct NURBSInterpolator
 
     std::vector<BasisVector> ndu(p + 1), a(2);
     BasisVector left(p + 1), right(p + 1);
-    for(int j = 0; j <= p; j++) ndu[j].resize(p + 1);
-    for(int j = 0; j <= n; j++) ders[j].resize(p + 1);
+    for(int j = 0; j <= p; j++)
+    {
+      ndu[j].resize(p + 1);
+    }
+    for(int j = 0; j <= n; j++)
+    {
+      ders[j].resize(p + 1);
+    }
     a[0].resize(p + 1);
     a[1].resize(p + 1);
 
@@ -436,7 +442,10 @@ struct NURBSInterpolator
       ndu[j][j] = saved;
     }
     // Load basis functions
-    for(int j = 0; j <= p; j++) ders[0][j] = ndu[j][p];
+    for(int j = 0; j <= p; j++)
+    {
+      ders[0][j] = ndu[j][p];
+    }
 
     // This section computes the derivatives (Eq. [2.9])
 
@@ -477,7 +486,10 @@ struct NURBSInterpolator
     double r = static_cast<double>(p);
     for(int k = 1; k <= n; k++)
     {
-      for(int j = 0; j <= p; j++) ders[k][j] *= r;
+      for(int j = 0; j <= p; j++)
+      {
+        ders[k][j] *= r;
+      }
       r *= static_cast<double>(p - k);
     }
   }

--- a/src/axom/quest/readers/STLReader.cpp
+++ b/src/axom/quest/readers/STLReader.cpp
@@ -62,7 +62,10 @@ bool STLReader::isAsciiFormat() const
   std::int32_t fileSize = static_cast<std::int32_t>(ifs.tellg());
 
   const int totalHeaderSize = (BINARY_HEADER_SIZE + sizeof(std::int32_t));
-  if(fileSize < totalHeaderSize) return true;
+  if(fileSize < totalHeaderSize)
+  {
+    return true;
+  }
 
   // Find the number of triangles (if the file were binary)
   int numTris = 0;
@@ -105,7 +108,10 @@ int STLReader::readAsciiSTL()
       ifs >> junk;
     } while(ifs.good() && junk != "vertex");
 
-    if(ifs.fail()) break;
+    if(ifs.fail())
+    {
+      break;
+    }
 
     ifs >> x >> y >> z;
     m_nodes.push_back(x);

--- a/src/axom/quest/tests/quest_intersection_shaper.cpp
+++ b/src/axom/quest/tests/quest_intersection_shaper.cpp
@@ -101,9 +101,13 @@ std::string yamlRoot(const std::string &filepath)
   psplit(filepath, path, filename);
   auto idx = filename.rfind(".");
   if(idx != std::string::npos)
+  {
     retval = filename.substr(0, idx);
+  }
   else
+  {
     retval = filename;
+  }
   return retval;
 }
 
@@ -171,7 +175,10 @@ void saveVisIt(const std::string &path,
 {
   // Wrap mesh and grid functions in a VisItDataCollection and save it.
   mfem::VisItDataCollection vdc(filename, dc.GetMesh());
-  if(!path.empty()) vdc.SetPrefixPath(path);
+  if(!path.empty())
+  {
+    vdc.SetPrefixPath(path);
+  }
   vdc.SetOwnData(false);
   vdc.SetFormat(mfem::DataCollection::SERIAL_FORMAT);
   for(auto it : dc.GetFieldMap())
@@ -195,7 +202,9 @@ void loadVisIt(mfem::VisItDataCollection &vdc, sidre::MFEMSidreDataCollection &d
   for(auto it : vdc.GetFieldMap())
   {
     if(it.first.find("vol_frac_") != std::string::npos)
+    {
       dc.RegisterField(it.first, it.second);
+    }
   }
 }
 
@@ -284,7 +293,10 @@ void replacementRuleTest(const std::string &shapeFile,
   // baseline that we can check first. If it is not present, the next baseline
   // is tried.
   std::string baselineName(yamlRoot(shapeFile));
-  if(initialMats) baselineName += "_initial_mats";
+  if(initialMats)
+  {
+    baselineName += "_initial_mats";
+  }
   std::vector<std::string> baselinePaths;
   // Example /path/to/axom/src/quest/tests/baseline/quest_intersection_shaper/cuda
   baselinePaths.push_back(pjoin(baselineDirectory(), policyName));
@@ -488,7 +500,9 @@ void IntersectionWithErrorTolerances(const std::string &filebase,
 
   // Clean up files.
   for(const auto &filename : filenames)
+  {
     axom::utilities::filesystem::removeFile(filename);
+  }
 }
 
 //---------------------------------------------------------------------------

--- a/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
+++ b/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
@@ -162,7 +162,10 @@ public:
     if(outputMeshMFEM)
     {
       mfem::VisItDataCollection dataCol(filename, m_mesh);
-      if(m_mesh->GetNodes()) dataCol.RegisterField("nodes", m_mesh->GetNodes());
+      if(m_mesh->GetNodes())
+      {
+        dataCol.RegisterField("nodes", m_mesh->GetNodes());
+      }
       dataCol.Save();
     }
     if(outputMeshVTK)
@@ -284,7 +287,9 @@ public:
     pts.reserve(sz);
 
     for(int i = 0; i <= res; ++i)
+    {
       for(int j = 0; j <= res; ++j)
+      {
         for(int k = 0; k <= k_max; ++k)
         {
           // Get the corresponding isoparametric value
@@ -293,6 +298,8 @@ public:
                                  static_cast<double>(j) / res,
                                  static_cast<double>(k) / res});
         }
+      }
+    }
 
     return pts;
   }
@@ -700,9 +707,13 @@ public:
     // compose the mesh descriptor string
     {
       if(numRefine > 0)
+      {
         meshDescSstr << "_refined_" << numRefine;
+      }
       else
+      {
         meshDescSstr << "_single";
+      }
 
       if(jitterFactor > 0)
       {
@@ -912,9 +923,13 @@ public:
       meshDescSstr << "_" << DIM << "d";
 
       if(numRefine > 0)
+      {
         meshDescSstr << "_refined_" << numRefine;
+      }
       else
+      {
         meshDescSstr << "_single";
+      }
 
       if(jitterFactor > 0)
       {

--- a/src/axom/quest/tests/quest_regression.cpp
+++ b/src/axom/quest/tests/quest_regression.cpp
@@ -233,7 +233,9 @@ void loadBaselineData(sidre::Group* grp, Input& args)
   {
     sidre::View* view = grp->getView("mesh_bounding_box");
     if(view->getNumElements() != 6)
+    {
       SLIC_ERROR("Bounding box must contain six doubles");
+    }
 
     double* data = view->getData();
     args.meshBoundingBox =
@@ -249,7 +251,9 @@ void loadBaselineData(sidre::Group* grp, Input& args)
   {
     sidre::View* view = grp->getView("query_resolution");
     if(view->getNumElements() != 3)
+    {
       SLIC_ERROR("Query resolution must contain three ints");
+    }
 
     int* data = view->getData();
     args.queryResolution = GridPt(data, 3);
@@ -259,8 +263,10 @@ void loadBaselineData(sidre::Group* grp, Input& args)
   if(args.testContainment)
   {
     if(!grp->hasView("octree_containment"))
+    {
       SLIC_ERROR("Requested containment, but baseline "
                  << "does not have a 'octree_containment' view");
+    }
     else
     {
       SLIC_ASSERT_MSG(

--- a/src/axom/quest/tests/quest_test_utilities.hpp
+++ b/src/axom/quest/tests/quest_test_utilities.hpp
@@ -159,7 +159,10 @@ template <int DIM>
 primal::Point<double, DIM> randomSpacePt(double beg, double end)
 {
   primal::Point<double, DIM> pt;
-  for(int i = 0; i < DIM; ++i) pt[i] = axom::utilities::random_real(beg, end);
+  for(int i = 0; i < DIM; ++i)
+  {
+    pt[i] = axom::utilities::random_real(beg, end);
+  }
 
   return pt;
 }

--- a/src/axom/sidre/examples/sidre_shocktube.cpp
+++ b/src/axom/sidre/examples/sidre_shocktube.cpp
@@ -497,7 +497,9 @@ void DumpUltra(Group* const prob)
 
   /* Skip past the junk */
   for(tail = fname; isalpha(*tail); ++tail)
+  {
     ;
+  }
 
   sprintf(tail, "_%04d.ult", prob->getView("cycle")->getData<int>());
 

--- a/src/axom/sidre/interface/c_fortran/wrapGroup.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapGroup.cpp
@@ -30,10 +30,16 @@ static void ShroudStrCopy(char *dest, int ndest, const char *src, int nsrc)
   }
   else
   {
-    if(nsrc < 0) nsrc = std::strlen(src);
+    if(nsrc < 0)
+    {
+      nsrc = std::strlen(src);
+    }
     int nm = nsrc < ndest ? nsrc : ndest;
     std::memcpy(dest, src, nm);
-    if(ndest > nm) std::memset(dest + nm, ' ', ndest - nm);  // blank fill
+    if(ndest > nm)
+    {
+      std::memset(dest + nm, ' ', ndest - nm);  // blank fill
+    }
   }
 }
 // splicer begin class.Group.C_definitions

--- a/src/axom/sidre/interface/c_fortran/wrapView.cpp
+++ b/src/axom/sidre/interface/c_fortran/wrapView.cpp
@@ -29,10 +29,16 @@ static void ShroudStrCopy(char *dest, int ndest, const char *src, int nsrc)
   }
   else
   {
-    if(nsrc < 0) nsrc = std::strlen(src);
+    if(nsrc < 0)
+    {
+      nsrc = std::strlen(src);
+    }
     int nm = nsrc < ndest ? nsrc : ndest;
     std::memcpy(dest, src, nm);
-    if(ndest > nm) std::memset(dest + nm, ' ', ndest - nm);  // blank fill
+    if(ndest > nm)
+    {
+      std::memset(dest + nm, ' ', ndest - nm);  // blank fill
+    }
   }
 }
 // splicer begin class.View.C_definitions

--- a/src/axom/sidre/tests/sidre_buffer_unit.cpp
+++ b/src/axom/sidre/tests/sidre_buffer_unit.cpp
@@ -32,10 +32,19 @@ int countMismatch(unsigned int elts,
 
   for(unsigned int i = 0; i < elts; ++i)
   {
-    if(standard[i] != undertest[i]) ++retval;
-    if(printTest) std::cout << "  " << undertest[i];
+    if(standard[i] != undertest[i])
+    {
+      ++retval;
+    }
+    if(printTest)
+    {
+      std::cout << "  " << undertest[i];
+    }
   }
-  if(printTest) std::cout << std::endl;
+  if(printTest)
+  {
+    std::cout << std::endl;
+  }
 
   return retval;
 }

--- a/src/axom/sidre/tests/sidre_datastore_unit.cpp
+++ b/src/axom/sidre/tests/sidre_datastore_unit.cpp
@@ -569,7 +569,10 @@ TEST(sidre_datastore, loop_create_delete_buffers_iterate)
       if(delta < 0)
       {
         int rmvcount = abs(delta);
-        if(rmvcount > static_cast<int>(bs.size())) rmvcount = bs.size();
+        if(rmvcount > static_cast<int>(bs.size()))
+        {
+          rmvcount = bs.size();
+        }
 
         for(int i = 0; i < rmvcount; ++i)
         {

--- a/src/axom/sidre/tests/sidre_native_layout.cpp
+++ b/src/axom/sidre/tests/sidre_native_layout.cpp
@@ -47,7 +47,9 @@ template <typename T>
 void setData(T* data, int size, T initVal = T(0), int intDiv = 1, T scaleFac = T(1))
 {
   for(int i = 0; i < size; ++i)
+  {
     data[i] = initVal + ((i + 1) / intDiv) * scaleFac;
+  }
 }
 
 /**

--- a/src/axom/slam/BitSet.cpp
+++ b/src/axom/slam/BitSet.cpp
@@ -84,7 +84,10 @@ bool BitSet::isValid() const
   {
     // check num words vs. num bits
     int expWords = (m_numBits - 1) / BitsPerWord + 1;
-    if(expWords != m_data.size()) valid = false;
+    if(expWords != m_data.size())
+    {
+      valid = false;
+    }
 
     // check that highest bits are not set
     if(!isLastWordFull())

--- a/src/axom/slam/BitSet.hpp
+++ b/src/axom/slam/BitSet.hpp
@@ -370,7 +370,10 @@ private:
   AXOM_HOST_DEVICE
   Word& getWord(Index idx, bool checkIndexValid = true)
   {
-    if(checkIndexValid) checkValidIndex(idx);
+    if(checkIndexValid)
+    {
+      checkValidIndex(idx);
+    }
 
     const Index wIdx = idx / BitsPerWord;
     return m_data[wIdx];
@@ -383,7 +386,10 @@ private:
   AXOM_HOST_DEVICE
   const Word& getWord(Index idx, bool checkIndexValid = true) const
   {
-    if(checkIndexValid) checkValidIndex(idx);
+    if(checkIndexValid)
+    {
+      checkValidIndex(idx);
+    }
 
     const Index wIdx = idx / BitsPerWord;
     return m_data[wIdx];

--- a/src/axom/slam/BivariateMap.hpp
+++ b/src/axom/slam/BivariateMap.hpp
@@ -591,9 +591,13 @@ public:
     {
       const BivariateSetType* set = m_map->set();
       if(idx2 + n < 0)
+      {
         advance_helper(n + (idx2 + 1), idx1 - 1, set->size(idx1 - 1) - 1);
+      }
       else if(idx2 + n >= set->size(idx1))
+      {
         advance_helper(n - (set->size(idx1) - idx2), idx1 + 1, 0);
+      }
       else
       {
         firstIdx = idx1;
@@ -705,7 +709,9 @@ public:
   void copy(const DataType* data_arr)
   {
     for(int i = 0; i < m_map.size() * StrPol::stride(); i++)
+    {
       m_map[i] = data_arr[i];
+    }
   }
 
   /** \brief replace all elements in the Map with the default DataType */

--- a/src/axom/slam/DynamicConstantRelation.hpp
+++ b/src/axom/slam/DynamicConstantRelation.hpp
@@ -306,7 +306,10 @@ public:
       const auto beg_idx = idx * SZ;
       for(auto idx = beg_idx; idx < (beg_idx + SZ); ++idx)
       {
-        if(m_relationsVec[idx] != INVALID_INDEX) return true;
+        if(m_relationsVec[idx] != INVALID_INDEX)
+        {
+          return true;
+        }
       }
     }
     return false;
@@ -374,7 +377,10 @@ public:
   /// \brief Mark all values in entry \a fromSetIndex as invalid.
   void remove(SetPosition fromSetIndex)
   {
-    if(!isValidEntry(fromSetIndex)) return;
+    if(!isValidEntry(fromSetIndex))
+    {
+      return;
+    }
 
     const auto SZ = relationCardinality();
     for(int i = 0; i < SZ; ++i)

--- a/src/axom/slam/DynamicSet.hpp
+++ b/src/axom/slam/DynamicSet.hpp
@@ -296,7 +296,10 @@ public:
     const int sz = size();
     for(int i = 0; i < sz; ++i)
     {
-      if(m_data[i] == e) return i;
+      if(m_data[i] == e)
+      {
+        return i;
+      }
     }
     return INVALID_ENTRY;
   };
@@ -312,7 +315,10 @@ public:
     const int sz = size();
     for(int i = 0; i < sz; ++i)
     {
-      if(m_data[i] == e) return true;
+      if(m_data[i] == e)
+      {
+        return true;
+      }
     }
     return false;
   };
@@ -459,7 +465,10 @@ private:
   /** Fill each entry of the set such that its value is equal to its index. */
   void fill_array_default(PositionType sz)
   {
-    if(sz < 0) return;
+    if(sz < 0)
+    {
+      return;
+    }
 
     m_data.resize(sz);
     for(int i = 0; i < sz; ++i)

--- a/src/axom/slam/DynamicVariableRelation.hpp
+++ b/src/axom/slam/DynamicVariableRelation.hpp
@@ -104,7 +104,10 @@ public:
   SetPosition totalSize() const
   {
     SetPosition sz = 0;
-    for(auto& vec : m_relationsVec) sz += vec.size();
+    for(auto& vec : m_relationsVec)
+    {
+      sz += vec.size();
+    }
     return sz;
   }
 
@@ -228,7 +231,10 @@ bool DynamicVariableRelation<FirstSetType, SecondSetType>::isValid(
   }
   else
   {
-    if(verboseOutput) sstr << "\n\t* Neither set was null";
+    if(verboseOutput)
+    {
+      sstr << "\n\t* Neither set was null";
+    }
 
     // Check that the the relations vector has the right size
     // (should be same as fromSet's size() )
@@ -281,8 +287,13 @@ bool DynamicVariableRelation<FirstSetType, SecondSetType>::isValid(
     }
 
     if(m_fromSet)
+    {
       sstr2 << "\n** fromSet has size " << m_fromSet->size() << ": ";
-    if(m_toSet) sstr2 << "\n** toSet has size " << m_toSet->size() << ": ";
+    }
+    if(m_toSet)
+    {
+      sstr2 << "\n** toSet has size " << m_toSet->size() << ": ";
+    }
 
     if(m_relationsVec.empty())
     {

--- a/src/axom/slam/ModularInt.hpp
+++ b/src/axom/slam/ModularInt.hpp
@@ -221,7 +221,10 @@ private:
     // Straightforward solution -- possibly adds sz to ensure
     // that m_val is non-negative -- which involves a branch
     m_val %= sz;
-    if(m_val < 0) m_val += sz;
+    if(m_val < 0)
+    {
+      m_val += sz;
+    }
 #else  // MODINT_MODLESS
 
     // this version assumes that we are usually only adding

--- a/src/axom/slam/RelationSet.hpp
+++ b/src/axom/slam/RelationSet.hpp
@@ -114,7 +114,10 @@ public:
     RelationSubset ls = (*m_relation)[pos1];
     for(PositionType i = 0; i < ls.size(); i++)
     {
-      if(ls[i] == pos2) return i;
+      if(ls[i] == pos2)
+      {
+        return i;
+      }
     }
     return BaseType::INVALID_POS;
   }
@@ -136,7 +139,10 @@ public:
     RelationSubset ls = (*m_relation)[s1];
     for(PositionType i = 0; i < ls.size(); i++)
     {
-      if(ls[i] == s2) return ls.offset() + i;
+      if(ls[i] == s2)
+      {
+        return ls.offset() + i;
+      }
     }
     return BaseType::INVALID_POS;
   }
@@ -155,7 +161,10 @@ public:
   {
     RelationSubset ls = (*m_relation)[pos1];
 
-    if(ls.size() > 0) return ls.offset();
+    if(ls.size() > 0)
+    {
+      return ls.offset();
+    }
 
     return BaseType::INVALID_POS;
   }

--- a/src/axom/slam/Set.hpp
+++ b/src/axom/slam/Set.hpp
@@ -156,7 +156,10 @@ inline bool operator==(const Set<P1, E1>& set1, const Set<P2, E2>& set2)
   PosType const numElts = set1.size();
 
   // Sets are different if they have a different size
-  if(set2.size() != numElts) return false;
+  if(set2.size() != numElts)
+  {
+    return false;
+  }
 
   // Otherwise, compare the indices element wise
   for(PosType pos = PosType(); pos < numElts; ++pos)

--- a/src/axom/slam/examples/PolicyPrototype.cpp
+++ b/src/axom/slam/examples/PolicyPrototype.cpp
@@ -159,7 +159,10 @@ inline ResType sumSet(const SetType& set)
 {
   ResType sum = 0;
 
-  for(int i = 0; i < set.size(); ++i) sum += set.at(i);
+  for(int i = 0; i < set.size(); ++i)
+  {
+    sum += set.at(i);
+  }
 
   return sum;
 }
@@ -167,7 +170,10 @@ inline ResType sumSet(const SetType& set)
 template <typename SetType>
 inline void copySet(const SetType& set, int* buf)
 {
-  for(int i = 0; i < set.size(); ++i) *buf++ = set.at(i);
+  for(int i = 0; i < set.size(); ++i)
+  {
+    *buf++ = set.at(i);
+  }
 }
 
 int main(int argc, char* argv[])
@@ -186,8 +192,14 @@ int main(int argc, char* argv[])
 
   // allocate and initialize the indirection array elements
   int* pVal = new int[numElts];
-  for(int i = 0; i < numElts; ++i) pVal[i] = i * i;
-  if(numElts > 0) pVal[numElts - 1] = 12345;
+  for(int i = 0; i < numElts; ++i)
+  {
+    pVal[i] = i * i;
+  }
+  if(numElts > 0)
+  {
+    pVal[numElts - 1] = 12345;
+  }
 
   slamTemplateEx::PositionSet pSet(numElts);
   slamTemplateEx::RangeSet rSet(rangeBeginElt, numElts + rangeBeginElt);

--- a/src/axom/slam/examples/ShockTube.cpp
+++ b/src/axom/slam/examples/ShockTube.cpp
@@ -585,10 +585,14 @@ void dumpData(ShockTubeMesh const& mesh)
   {
     ShockTubeMesh::IndexType ind = begSet[i];
     if(i == 0)
+    {
       elemStream << "IN"
                  << "\t";
+    }
     else
+    {
       elemStream << ind << "\t";
+    }
 
     mStream << mass[ind] << "\t";
     pStream << momentum[ind] << "\t";
@@ -606,10 +610,14 @@ void dumpData(ShockTubeMesh const& mesh)
   {
     ShockTubeMesh::IndexType ind = endSet[i];
     if(ind == endSet.parentSet()->size() - 1)
+    {
       elemStream << "OUT"
                  << "\t";
+    }
     else
+    {
       elemStream << ind << "\t";
+    }
 
     mStream << mass[ind] << "\t";
     pStream << momentum[ind] << "\t";

--- a/src/axom/slam/mesh_struct/IA_impl.hpp
+++ b/src/axom/slam/mesh_struct/IA_impl.hpp
@@ -37,7 +37,10 @@ bool is_subset(T v, const IterableT& iterable)
 {
   for(auto item : iterable)
   {
-    if(item == v) return true;
+    if(item == v)
+    {
+      return true;
+    }
   }
   return false;
 }
@@ -506,7 +509,10 @@ typename IAMesh<TDIM, SDIM, P>::IndexType IAMesh<TDIM, SDIM, P>::addElement(
   // If so, modify ee_rel to reflect that.
   for(auto otherElementIdx : elem_list)
   {
-    if(otherElementIdx < 0 || otherElementIdx == element_idx) continue;
+    if(otherElementIdx < 0 || otherElementIdx == element_idx)
+    {
+      continue;
+    }
     for(IndexType s = 0; s < VERTS_PER_ELEM; s++)
     {
       IndexType otherSideIdx = s;

--- a/src/axom/slam/policies/IndirectionPolicies.hpp
+++ b/src/axom/slam/policies/IndirectionPolicies.hpp
@@ -178,7 +178,10 @@ bool IndexedIndirection<BasePolicy>::isValid(PositionType size,
   AXOM_UNUSED_VAR(verboseOutput);
 
   // always valid if set has zero size, even if indirection buffer is null
-  if(size == 0) return true;
+  if(size == 0)
+  {
+    return true;
+  }
 
   bool bValid = true;
 

--- a/src/axom/slam/policies/SubsettingPolicies.hpp
+++ b/src/axom/slam/policies/SubsettingPolicies.hpp
@@ -86,11 +86,17 @@ struct VirtualParentSubset
   bool isValid(OrderedSetIt beg, OrderedSetIt end, bool verboseOutput = false) const
   {
     // We allow parent sets to be null (i.e. the subset feature is deactivated)
-    if(!isSubset() || m_parentSet == nullptr) return true;
+    if(!isSubset() || m_parentSet == nullptr)
+    {
+      return true;
+    }
 
     // Next, check if child is empty -- null set is a subset of all sets
     bool childIsEmpty = (beg == end);
-    if(childIsEmpty) return true;
+    if(childIsEmpty)
+    {
+      return true;
+    }
 
     // Next, since child has at least one element, the parent cannot be empty
     if(verboseOutput)
@@ -108,7 +114,9 @@ struct VirtualParentSubset
     using ElType = typename OrderedSetIt::value_type;
     std::set<ElType> pSet;
     for(auto pos = 0; pos < m_parentSet->size(); ++pos)
+    {
       pSet.insert(m_parentSet->at(pos));
+    }
     for(; beg != end; ++beg)
     {
       if(pSet.find(*beg) == pSet.end())
@@ -149,11 +157,17 @@ struct ConcreteParentSubset
   bool isValid(OrderedSetIt beg, OrderedSetIt end, bool verboseOutput = false) const
   {
     // We allow parent sets to be null (i.e. the subset feature is deactivated)
-    if(!isSubset()) return true;
+    if(!isSubset())
+    {
+      return true;
+    }
 
     // Next, check if child is empty -- null set is a subset of all sets
     bool childIsEmpty = (beg == end);
-    if(childIsEmpty) return true;
+    if(childIsEmpty)
+    {
+      return true;
+    }
 
     // Next, since child has at least one element, the parent cannot be empty
     if(verboseOutput)
@@ -168,7 +182,9 @@ struct ConcreteParentSubset
     // At this point, parent and child are both non-null
     std::set<typename ParentSetType::ElementType> pSet;
     for(auto pos = 0; pos < m_parentSet->size(); ++pos)
+    {
       pSet.insert((*m_parentSet)[pos]);
+    }
     for(; beg != end; ++beg)
     {
       if(pSet.find(*beg) == pSet.end())

--- a/src/axom/slam/tests/slam_IA.cpp
+++ b/src/axom/slam/tests/slam_IA.cpp
@@ -149,7 +149,10 @@ bool isInBoundary(const IAMeshType& ia_mesh, IndexType vert_id, IndexType elem_i
 {
   for(auto bdry : ia_mesh.boundaryVertices(elem_id))
   {
-    if(bdry == vert_id) return true;
+    if(bdry == vert_id)
+    {
+      return true;
+    }
   }
   return false;
 }
@@ -162,7 +165,10 @@ bool isAdjacent(const IAMeshType& ia_mesh, IndexType el_1, IndexType el_2)
 {
   for(auto adj : ia_mesh.adjacentElements(el_1))
   {
-    if(adj == el_2) return true;
+    if(adj == el_2)
+    {
+      return true;
+    }
   }
   return false;
 }

--- a/src/axom/slam/tests/slam_map_BivariateMap.cpp
+++ b/src/axom/slam/tests/slam_map_BivariateMap.cpp
@@ -106,35 +106,45 @@ void constructAndTestCartesianMap(int stride)
   SLIC_INFO("Setting the elements in the map.");
 
   for(auto idx1 = 0; idx1 < m.firstSetSize(); ++idx1)
+  {
     for(auto idx2 = 0; idx2 < m.secondSetSize(); ++idx2)
+    {
       for(auto i = 0; i < stride; i++)
       {
         T* valPtr = m.findValue(idx1, idx2, i);
         EXPECT_NE(valPtr, nullptr);
         *valPtr = getVal<T>(idx1, idx2, i);
       }
+    }
+  }
 
   SLIC_INFO("Checking the elements with findValue().");
   for(auto idx1 = 0; idx1 < m.firstSetSize(); ++idx1)
+  {
     for(auto idx2 = 0; idx2 < m.secondSetSize(); ++idx2)
+    {
       for(auto i = 0; i < stride; i++)
       {
         T* ptr = m.findValue(idx1, idx2, i);
         EXPECT_NE(ptr, nullptr);
         EXPECT_EQ(*ptr, getVal<T>(idx1, idx2, i));
       }
+    }
+  }
 
   SLIC_INFO("Checking the elements with SubMap.");
   for(auto idx1 = 0; idx1 < m.firstSetSize(); ++idx1)
   {
     SubMapType sm = m(idx1);
     for(auto idx2 = 0; idx2 < sm.size(); ++idx2)
+    {
       for(auto i = 0; i < stride; i++)
       {
         T v = sm.value(idx2, i);
         EXPECT_EQ(v, getVal<T>(idx1, idx2, i));
         EXPECT_EQ(sm.index(idx2), idx2);
       }
+    }
   }
 
   EXPECT_TRUE(m.isValid());
@@ -262,7 +272,10 @@ void constructAndTestRelationSetMap(int stride)
           EXPECT_EQ(ptr, nullptr);
         }
       }
-      if(isInRel) rel_idx++;
+      if(isInRel)
+      {
+        rel_idx++;
+      }
     }
   }
 
@@ -345,13 +358,17 @@ void constructAndTestBivariateMapIterator(int stride)
   SLIC_INFO("Setting the elements in the map.");
   //currently can't set value using iterator
   for(auto idx1 = 0; idx1 < m.firstSetSize(); ++idx1)
+  {
     for(auto idx2 = 0; idx2 < m.secondSetSize(); ++idx2)
+    {
       for(auto i = 0; i < stride; i++)
       {
         DataType* valPtr = m.findValue(idx1, idx2, i);
         EXPECT_NE(valPtr, nullptr);
         *valPtr = getVal<DataType>(idx1, idx2, i);
       }
+    }
+  }
 
   SLIC_INFO("Checking the elements with SubMap iterator.");
   for(auto idx1 = 0; idx1 < m.firstSetSize(); ++idx1)
@@ -442,13 +459,17 @@ void testScopedCopyBehavior(int stride)
     SLIC_INFO("Setting the elements in the map.");
 
     for(auto idx1 = 0; idx1 < m_inner.firstSetSize(); ++idx1)
+    {
       for(auto idx2 = 0; idx2 < m_inner.secondSetSize(); ++idx2)
+      {
         for(auto i = 0; i < stride; i++)
         {
           T* valPtr = m_inner.findValue(idx1, idx2, i);
           EXPECT_NE(valPtr, nullptr);
           *valPtr = getVal<T>(idx1, idx2, i);
         }
+      }
+    }
 
     m = m_inner;
   }
@@ -459,13 +480,17 @@ void testScopedCopyBehavior(int stride)
 
   SLIC_INFO("Checking the elements with findValue().");
   for(auto idx1 = 0; idx1 < m.firstSetSize(); ++idx1)
+  {
     for(auto idx2 = 0; idx2 < m.secondSetSize(); ++idx2)
+    {
       for(auto i = 0; i < stride; i++)
       {
         T* ptr = m.findValue(idx1, idx2, i);
         EXPECT_NE(ptr, nullptr);
         EXPECT_EQ(*ptr, getVal<T>(idx1, idx2, i));
       }
+    }
+  }
 }
 
 TEST(slam_bivariate_map, testScopedMapBehavior)
@@ -832,7 +857,10 @@ void slam_bivariate_map_templated<ExecutionSpace>::initializeAndTestRelationMap(
               numIncorrect += (ptr != nullptr);
             }
           }
-          if(inRelation) relIndex++;
+          if(inRelation)
+          {
+            relIndex++;
+          }
         }
       });
 

--- a/src/axom/slam/tests/slam_map_Map.cpp
+++ b/src/axom/slam/tests/slam_map_Map.cpp
@@ -99,7 +99,10 @@ TEST(slam_map, out_of_bounds)
   IntMap m(&s, defaultElt);
 
   SLIC_INFO("Testing Map element access -- in bounds");
-  for(auto idx = 0; idx < m.size(); ++idx) EXPECT_EQ(defaultElt, m[idx]);
+  for(auto idx = 0; idx < m.size(); ++idx)
+  {
+    EXPECT_EQ(defaultElt, m[idx]);
+  }
 
   // Test out of bounds
   SLIC_INFO("Testing Map element access "
@@ -132,13 +135,18 @@ TEST(slam_map, map_builder)
   SetType s(MAX_SET_SIZE);
   std::vector<DataType> data_arr(s.size());
   for(auto i = 0u; i < data_arr.size(); ++i)
+  {
     data_arr[i] = static_cast<DataType>(i * 1.01);
+  }
 
   MapType m2(MapBuilder().set(&s).data(data_arr.data()));
   EXPECT_TRUE(m2.isValid());
   EXPECT_EQ(m2.size(), s.size());
   EXPECT_EQ(m2.stride(), 1);
-  for(auto i = 0u; i < data_arr.size(); ++i) EXPECT_EQ(m2[i], data_arr[i]);
+  for(auto i = 0u; i < data_arr.size(); ++i)
+  {
+    EXPECT_EQ(m2[i], data_arr[i]);
+  }
 }
 
 template <typename T, typename StrideType>

--- a/src/axom/slam/tests/slam_map_SubMap.cpp
+++ b/src/axom/slam/tests/slam_map_SubMap.cpp
@@ -144,7 +144,10 @@ bool constructAndTestSubMap()
 
     SLIC_INFO("Creating Subset 2");
     std::vector<PositionType> subset_indices_data(submapSize);
-    for(int i = 0; i < submapSize; i++) subset_indices_data[i] = i * 2;
+    for(int i = 0; i < submapSize; i++)
+    {
+      subset_indices_data[i] = i * 2;
+    }
     OrderedSetType subset_indices =
       OrderedSetType::SetBuilder().size(5).data(&subset_indices_data);
 
@@ -202,7 +205,9 @@ bool constructBySubMap()
   {
     T val = getValue<T>(idx);
     if(idx >= submapOffset && idx < submapOffset + submapSize)
+    {
       val = -getValue<T>(idx);
+    }
     EXPECT_EQ(m[idx], val);
   }
 

--- a/src/axom/slic/interface/c_fortran/wrapSLIC.cpp
+++ b/src/axom/slic/interface/c_fortran/wrapSLIC.cpp
@@ -30,10 +30,16 @@ static void ShroudStrCopy(char *dest, int ndest, const char *src, int nsrc)
   }
   else
   {
-    if(nsrc < 0) nsrc = std::strlen(src);
+    if(nsrc < 0)
+    {
+      nsrc = std::strlen(src);
+    }
     int nm = nsrc < ndest ? nsrc : ndest;
     std::memcpy(dest, src, nm);
-    if(ndest > nm) std::memset(dest + nm, ' ', ndest - nm);  // blank fill
+    if(ndest > nm)
+    {
+      std::memset(dest + nm, ' ', ndest - nm);  // blank fill
+    }
   }
 }
 // splicer begin C_definitions

--- a/src/axom/spin/Brood.hpp
+++ b/src/axom/spin/Brood.hpp
@@ -116,7 +116,9 @@ struct Brood<GridPt, GridPt>
     // shift and add offset to each coordinate
     GridPt retPt;
     for(int i = 0; i < GridPt::DIMENSION; ++i)
+    {
       retPt[i] = (pt[i] << 1) + (offset & (1 << i) ? 1 : 0);
+    }
 
     return retPt;
   }

--- a/src/axom/spin/DenseOctreeLevel.hpp
+++ b/src/axom/spin/DenseOctreeLevel.hpp
@@ -75,7 +75,10 @@ public:
       m_currentIdx = begin ? 0 : m_endIdx;
 
       // Advance the iterator to point to a valid Block
-      if(begin && !data()->isBlock()) increment();
+      if(begin && !data()->isBlock())
+      {
+        increment();
+      }
     }
 
     /** Increment to next block of the level */
@@ -144,7 +147,10 @@ public:
     {
       const int rowsize = (level > 0) ? 1 << (level - 1) : 1;
       m_broodCapacity = 1;
-      for(int i = 0; i < DIM; ++i) m_broodCapacity *= rowsize;
+      for(int i = 0; i < DIM; ++i)
+      {
+        m_broodCapacity *= rowsize;
+      }
 
       m_data = new BroodData[m_broodCapacity];
     }
@@ -153,7 +159,10 @@ public:
     for(int i = 0; i < m_broodCapacity; ++i)
     {
       BroodData& bd = m_data[i];
-      for(int j = 0; j < Base::BROOD_SIZE; ++j) bd[j].setNonBlock();
+      for(int j = 0; j < Base::BROOD_SIZE; ++j)
+      {
+        bd[j].setNonBlock();
+      }
     }
   }
 
@@ -223,7 +232,10 @@ public:
     // Handle level 0 -- only add the root, mark its 'siblings' as non-blocks
     if(this->level() == 0)
     {
-      for(int j = 1; j < Base::BROOD_SIZE; ++j) m_data[0][j].setNonBlock();
+      for(int j = 1; j < Base::BROOD_SIZE; ++j)
+      {
+        m_data[0][j].setNonBlock();
+      }
       ++m_blockCount;
     }
     else
@@ -274,7 +286,10 @@ public:
   /** \brief Returns the number of leaf blocks in the level */
   int numLeafBlocks() const
   {
-    if(empty()) return 0;
+    if(empty())
+    {
+      return 0;
+    }
 
     int count = 0;
     for(int i = 0; i < m_broodCapacity; ++i)
@@ -282,7 +297,10 @@ public:
       const BroodData& bd = m_data[i];
       for(int j = 0; j < Base::BROOD_SIZE; ++j)
       {
-        if(bd[j].isLeaf()) ++count;
+        if(bd[j].isLeaf())
+        {
+          ++count;
+        }
       }
     }
     return count;
@@ -298,7 +316,10 @@ public:
    */
   TreeBlockStatus blockStatus(const GridPt& pt) const
   {
-    if(!this->inBounds(pt)) return BlockNotInTree;
+    if(!this->inBounds(pt))
+    {
+      return BlockNotInTree;
+    }
 
     const BroodType brood(pt);
     const BlockDataType& blockData = m_data[brood.base()][brood.offset()];

--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -339,7 +339,10 @@ public:
    */
   BitsetType getCandidates(const SpacePoint& pt) const
   {
-    if(!m_initialized || !m_bb.contains(pt)) return BitsetType(0);
+    if(!m_initialized || !m_bb.contains(pt))
+    {
+      return BitsetType(0);
+    }
 
     const GridCell gridCell = m_lattice.gridCell(pt);
 
@@ -368,7 +371,10 @@ public:
   BitsetType getCandidates(const GridCell& gridCell) const
   {
     // Perform some validity checks
-    if(!m_initialized) return BitsetType(0);
+    if(!m_initialized)
+    {
+      return BitsetType(0);
+    }
     for(int i = 0; i < NDIMS; ++i)
     {
       if(gridCell[i] < 0 || gridCell[i] > highestBin(i))
@@ -398,7 +404,10 @@ public:
    */
   BitsetType getCandidates(const SpatialBoundingBox& box) const
   {
-    if(!m_initialized || !m_bb.intersectsWith(box)) return BitsetType(0);
+    if(!m_initialized || !m_bb.intersectsWith(box))
+    {
+      return BitsetType(0);
+    }
 
     const GridCell lowerCell = m_lattice.gridCell(box.getMin());
     const GridCell upperCell = m_lattice.gridCell(box.getMax());
@@ -515,7 +524,10 @@ public:
   {
     bool ret = true;
 
-    if(!m_elementSet.isValidIndex(idx)) ret = false;
+    if(!m_elementSet.isValidIndex(idx))
+    {
+      ret = false;
+    }
 
     for(int i = 0; i < NDIMS; ++i)
     {
@@ -900,7 +912,10 @@ AXOM_HOST_DEVICE IndexType
 ImplicitGrid<NDIMS, ExecSpace, IndexType>::QueryObject::countCandidates(
   const SpacePoint& pt) const
 {
-  if(!m_bb.contains(pt)) return 0;
+  if(!m_bb.contains(pt))
+  {
+    return 0;
+  }
 
   GridCell gridCell = m_lattice.gridCell(pt);
 
@@ -945,7 +960,10 @@ AXOM_HOST_DEVICE IndexType
 ImplicitGrid<NDIMS, ExecSpace, IndexType>::QueryObject::countCandidates(
   const SpatialBoundingBox& bbox) const
 {
-  if(!m_bb.intersectsWith(bbox)) return 0;
+  if(!m_bb.intersectsWith(bbox))
+  {
+    return 0;
+  }
 
   GridCell lowerCell = m_lattice.gridCell(bbox.getMin());
   GridCell upperCell = m_lattice.gridCell(bbox.getMax());
@@ -1000,7 +1018,10 @@ ImplicitGrid<NDIMS, ExecSpace, IndexType>::QueryObject::visitCandidates(
   const SpacePoint& pt,
   FuncType&& candidatePredicate) const
 {
-  if(!m_bb.contains(pt)) return;
+  if(!m_bb.contains(pt))
+  {
+    return;
+  }
 
   GridCell gridCell = m_lattice.gridCell(pt);
 
@@ -1059,7 +1080,10 @@ ImplicitGrid<NDIMS, ExecSpace, IndexType>::QueryObject::visitCandidates(
   const SpatialBoundingBox& bbox,
   FuncType&& candidatePredicate) const
 {
-  if(!m_bb.intersectsWith(bbox)) return;
+  if(!m_bb.intersectsWith(bbox))
+  {
+    return;
+  }
 
   GridCell lowerCell = m_lattice.gridCell(bbox.getMin());
   GridCell upperCell = m_lattice.gridCell(bbox.getMax());

--- a/src/axom/spin/OctreeBase.hpp
+++ b/src/axom/spin/OctreeBase.hpp
@@ -268,7 +268,10 @@ public:
     GridPt neighborPt(const GridPt& offset) const
     {
       GridPt nPoint(m_pt);
-      for(int i = 0; i < DIM; ++i) nPoint[i] += offset[i];
+      for(int i = 0; i < DIM; ++i)
+      {
+        nPoint[i] += offset[i];
+      }
 
       return nPoint;
     }
@@ -322,13 +325,25 @@ public:
 
     bool operator<(const BlockIndex& other) const
     {
-      if(m_lev < other.m_lev) return true;
-      if(m_lev > other.m_lev) return false;
+      if(m_lev < other.m_lev)
+      {
+        return true;
+      }
+      if(m_lev > other.m_lev)
+      {
+        return false;
+      }
 
       for(int i = 0; i < DIM; ++i)
       {
-        if(m_pt[i] < other.m_pt[i]) return true;
-        if(m_pt[i] > other.m_pt[i]) return false;
+        if(m_pt[i] < other.m_pt[i])
+        {
+          return true;
+        }
+        if(m_pt[i] > other.m_pt[i])
+        {
+          return false;
+        }
       }
 
       return false;
@@ -356,7 +371,12 @@ public:
     {
       const CoordType maxVal = (CoordType(1) << m_lev) - CoordType(1);
       for(int i = 0; i < DIM; ++i)
-        if((m_pt[i] < 0) || (m_pt[i] > maxVal)) return false;
+      {
+        if((m_pt[i] < 0) || (m_pt[i] > maxVal))
+        {
+          return false;
+        }
+      }
       return true;
     }
 
@@ -376,10 +396,16 @@ public:
     {
       const int ancestorLevel = ancestor.level();
       const int levelDiff = m_lev - ancestorLevel;
-      if(levelDiff < 0 || m_lev < 0 || ancestorLevel < 0) return false;
+      if(levelDiff < 0 || m_lev < 0 || ancestorLevel < 0)
+      {
+        return false;
+      }
 
       BlockIndex blk(*this);
-      for(int i = 0; i < levelDiff; ++i) blk = blk.parent();
+      for(int i = 0; i < levelDiff; ++i)
+      {
+        blk = blk.parent();
+      }
 
       SLIC_ASSERT(blk.level() == ancestorLevel);
       return blk.pt() == ancestor.pt();
@@ -468,15 +494,25 @@ public:
       // Use point bases SparseOctreeLevel (key is Point<int, DIM>,
       // hashed using a MortonIndex)  when MortonIndex requires more than 64
       if(i <= MAX_DENSE_LEV)
+      {
         m_leavesLevelMap[i] = new DenseOctLevType(i);
+      }
       else if(i <= MAX_SPARSE16_LEV)
+      {
         m_leavesLevelMap[i] = new Sparse16OctLevType(i);
+      }
       else if(i <= MAX_SPARSE32_LEV)
+      {
         m_leavesLevelMap[i] = new Sparse32OctLevType(i);
+      }
       else if(i <= MAX_SPARSE64_LEV)
+      {
         m_leavesLevelMap[i] = new Sparse64OctLevType(i);
+      }
       else
+      {
         m_leavesLevelMap[i] = new SparsePtOctLevType(i);
+      }
     }
 
     // Add the root block to the octree
@@ -877,7 +913,9 @@ public:
   {
     // Check that point is in bounds
     if(checkInBounds && !this->inBounds(blk))
+    {
       return BlockIndex::invalid_index();
+    }
 
     switch(blockStatus(blk))
     {
@@ -885,7 +923,10 @@ public:
                           // a leaf)
     {
       BlockIndex ancBlk = blk.parent();
-      while(!this->hasBlock(ancBlk)) ancBlk = ancBlk.parent();
+      while(!this->hasBlock(ancBlk))
+      {
+        ancBlk = ancBlk.parent();
+      }
 
       SLIC_ASSERT(this->isLeaf(ancBlk));
       return ancBlk;

--- a/src/axom/spin/OctreeLevel.hpp
+++ b/src/axom/spin/OctreeLevel.hpp
@@ -182,7 +182,12 @@ public:
   {
     const CoordType maxVal = maxCoord();
     for(int i = 0; i < DIM; ++i)
-      if(pt[i] < 0 || pt[i] > maxVal) return false;
+    {
+      if(pt[i] < 0 || pt[i] > maxVal)
+      {
+        return false;
+      }
+    }
     return true;
   }
 

--- a/src/axom/spin/SparseOctreeLevel.hpp
+++ b/src/axom/spin/SparseOctreeLevel.hpp
@@ -304,7 +304,10 @@ public:
                                        // (default constructed)
     if(this->level() == 0)
     {
-      for(int j = 1; j < Base::BROOD_SIZE; ++j) bd[j].setNonBlock();
+      for(int j = 1; j < Base::BROOD_SIZE; ++j)
+      {
+        bd[j].setNonBlock();
+      }
     }
   }
 
@@ -352,7 +355,10 @@ public:
   /** \brief Returns the number of blocks (internal and leaf) in the level */
   int numBlocks() const
   {
-    if(empty()) return 0;
+    if(empty())
+    {
+      return 0;
+    }
 
     return ((this->m_level == 0)
               ? 1
@@ -365,7 +371,10 @@ public:
   /** \brief Returns the number of leaf blocks in the level */
   int numLeafBlocks() const
   {
-    if(empty()) return 0;
+    if(empty())
+    {
+      return 0;
+    }
 
     int count = 0;
     for(ConstMapIter it = m_map.begin(), itEnd = m_map.end(); it != itEnd; ++it)
@@ -373,7 +382,10 @@ public:
       const BroodData& bd = it->second;
       for(int i = 0; i < Base::BROOD_SIZE; ++i)
       {
-        if(bd[i].isLeaf()) ++count;
+        if(bd[i].isLeaf())
+        {
+          ++count;
+        }
       }
     }
     return count;

--- a/src/axom/spin/SpatialOctree.hpp
+++ b/src/axom/spin/SpatialOctree.hpp
@@ -57,7 +57,9 @@ public:
       m_deltaLevelMap[lev] = bbRange / static_cast<double>(CoordType(1) << lev);
 
       for(int dim = 0; dim < DIM; ++dim)
+      {
         m_invDeltaLevelMap[lev][dim] = 1. / m_deltaLevelMap[lev][dim];
+      }
     }
   }
 

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -301,7 +301,10 @@ AXOM_HOST_DEVICE IntType delta(const IntType& a,
   //break the tie, a and b must always differ
   exor = tie ? std::uint32_t(a) ^ std::uint32_t(bb) : exor;
   std::int32_t count = axom::utilities::leadingZeros(exor);
-  if(tie) count += 32;
+  if(tie)
+  {
+    count += 32;
+  }
   count = (out_of_range) ? -1 : count;
   return count;
 }
@@ -337,7 +340,9 @@ void build_tree(RadixTree<FloatType, NDIMS>& data)
       std::int32_t min_delta = delta(i, i - d, inner_size, mcodes_ptr);
       std::int32_t lmax = 2;
       while(delta(i, i + lmax * d, inner_size, mcodes_ptr) > min_delta)
+      {
         lmax *= 2;
+      }
 
       //binary search to find the lower bound
       std::int32_t l = 0;
@@ -361,7 +366,10 @@ void build_tree(RadixTree<FloatType, NDIMS>& data)
         {
           s += t;
         }
-        if(t == 1) break;
+        if(t == 1)
+        {
+          break;
+        }
       }
 
       std::int32_t split = i + s * d + utilities::min(d, 0);

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -1382,7 +1382,10 @@ void bvh_compute_point_distances_2d(BVHType& bvh,
   BoxType* bboxes =
     axom::allocate<BoxType>(npts ? npts : 1,  // do not allocate 0 elements
                             axom::execution_space<ExecSpace>::allocatorID());
-  for(axom::IndexType i = 0; i < npts; i++) bboxes[i] = BoxType(points[i]);
+  for(axom::IndexType i = 0; i < npts; i++)
+  {
+    bboxes[i] = BoxType(points[i]);
+  }
   bvh.initialize(bboxes, npts);
 
   // Call the BVH like the DistributedClosestPoint does.

--- a/src/axom/spin/tests/spin_implicit_grid.cpp
+++ b/src/axom/spin/tests/spin_implicit_grid.cpp
@@ -138,7 +138,10 @@ TYPED_TEST(ImplicitGridTest, resolution)
   // Set the number of elements so that the DIM^th root is an integer
   const int dimRes = 8;
   int numElts = 1;
-  for(int i = 0; i < DIM; ++i) numElts *= dimRes;
+  for(int i = 0; i < DIM; ++i)
+  {
+    numElts *= dimRes;
+  }
 
   // Tests explicitly set grid resolution
   {

--- a/src/axom/spin/tests/spin_octree.cpp
+++ b/src/axom/spin/tests/spin_octree.cpp
@@ -159,7 +159,9 @@ TEST(spin_octree, octree_coveringLeafBlocks)
       SLIC_INFO(" Face neighbor " << j << " is " << neighborBlk);
 
       if(octree.coveringLeafBlock(neighborBlk) != BlockIndex::invalid_index())
+      {
         validNeighborCount++;
+      }
     }
     EXPECT_EQ(2, validNeighborCount);
   }

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -59,7 +59,7 @@ macro(axom_add_code_checks)
                             CLANGFORMAT_CFG_FILE ${PROJECT_SOURCE_DIR}/.clang-format)
 
         # Set FOLDER property for code check targets
-        foreach(_suffix clangformat_check clangformat_style)
+        foreach(_suffix clangformat_check clangformat_style clang_tidy_check clang_tidy_style)
             set(_tgt ${arg_PREFIX}_${_suffix})
             if(TARGET ${_tgt}) 
                 set_target_properties(${_tgt} PROPERTIES FOLDER "axom/code_checks")

--- a/src/thirdparty/tests/compiler_flag_omp_pragma.cpp
+++ b/src/thirdparty/tests/compiler_flag_omp_pragma.cpp
@@ -19,7 +19,10 @@ int main()
   int arr[SZ];
 
 #pragma omp parallel for
-  for(int i = 0; i < SZ; ++i) arr[i] = i;
+  for(int i = 0; i < SZ; ++i)
+  {
+    arr[i] = i;
+  }
 
   std::cout << "Value of array element 0 is " << arr[0] << std::endl;
 

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -308,7 +308,10 @@ inline bool pointIsNearlyEqual(Point3& p1, Point3& p2, double EPS = 1.0e-9)
 AXOM_HOST_DEVICE
 bool checkTT(Triangle3& t1, Triangle3& t2, double EPS)
 {
-  if(t2.degenerate()) return false;
+  if(t2.degenerate())
+  {
+    return false;
+  }
 
   const bool includeBoundaries = false;  // only check internal intersections
   if(primal::intersect(t1, t2, includeBoundaries, EPS))


### PR DESCRIPTION
# Summary

- This is a maintenance PR
- It uses `clang-tidy` and `clang-apply-replacements` to wrap one-line statements with curly brackets via the `readability-braces-around-statements` rule.
- It adds a simple clang-tidy config file to axom, which gets copied into our build directory
- It fixes https://github.com/LLNL/axom/issues/1117
  - This is a one time fix which we can apply sporadically, e.g. before releases
- Depends on BLT PR https://github.com/LLNL/blt/pull/644

#### Notes: 
* the changes from `clang-tidy` are not always safe and need to be verified before applying.
* Oddly enough, I had trouble getting this to work with a clang compiler on LLNL's LC, and had to use this with a GCC compiler. The issue related to incorrectly propagating flags for the underlying standard library.
* I locally added the following two CMake config variables to the toss3-gcc@8.3.1 host-config (but did not check these in):
```cmake
set(CLANGTIDY_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.1/bin/clang-tidy" CACHE PATH "")
set(CLANGAPPLYREPLACEMENTS_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.1/bin/clang-apply-replacements" CACHE PATH "")
```
* I didn't set up `clang-tidy` to format the code, so we have to run `clang-format` after applying `clang-tidy`

#### Discussion:
* This PR only applies the `readability-braces-around-statements` clang-tidy rule. Are there other rules that we want to apply, e.g. rules related to modernizing our C++ usage? 

#### TODO:
- [x] Update BLT submodule again after merging https://github.com/LLNL/blt/pull/644