### PR TITLE
Flush parallel logStreams

### DIFF
--- a/src/axom/slic/streams/LumberjackStream.cpp
+++ b/src/axom/slic/streams/LumberjackStream.cpp
@@ -155,6 +155,7 @@ void LumberjackStream::write(bool local)
         messages[i]->lineNumber());
     }
 
+    m_stream->flush();
     m_lj->clearMessages();
   }
 }

--- a/src/axom/slic/streams/SynchronizedStream.cpp
+++ b/src/axom/slic/streams/SynchronizedStream.cpp
@@ -38,6 +38,7 @@ struct SynchronizedStream::MessageCache
       (*stream) << messages[i];
     }  // END for all messages
 
+    stream->flush();
     messages.clear();
   }
 };


### PR DESCRIPTION
This PR:
- Adds missing ostream call to `flush()` for parallel LogStreams (LumberjackStream and SynchronizedStream)

Related to #1140 