### PR TITLE
Fix mesh tester example and add tests

### DIFF
--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -101,7 +101,7 @@ endif()
 #------------------------------------------------------------------------------
 # OpenMP GTests
 #------------------------------------------------------------------------------
-if (AXOM_ENABLE_OPENMP AND AXOM_USE_RAJA)
+if (AXOM_ENABLE_OPENMP AND RAJA_FOUND)
   set( core_openmp_tests
        core_openmp_map.hpp
        )

--- a/src/axom/quest/detail/Discretize_detail.hpp
+++ b/src/axom/quest/detail/Discretize_detail.hpp
@@ -219,16 +219,15 @@ int discrSeg(const Point2D &a,
     // with comment "the ends switch each level."
     axom::for_all<ExecSpace>(
       curr_lvl_count,
-      AXOM_LAMBDA(axom::IndexType i) {
-        OctType *out_ptr = out.data();
-        out_ptr[next_lvl + i * lvl_factor + 0] =
-          new_inscribed_prism(out_ptr[curr_lvl + i], Q, T, S, R, pa, pb);
-        out_ptr[next_lvl + i * lvl_factor + 1] =
-          new_inscribed_prism(out_ptr[curr_lvl + i], U, R, Q, P, pa, pb);
+      AXOM_LAMBDA(axom::IndexType i) mutable {
+        out[next_lvl + i * lvl_factor + 0] =
+          new_inscribed_prism(out[curr_lvl + i], Q, T, S, R, pa, pb);
+        out[next_lvl + i * lvl_factor + 1] =
+          new_inscribed_prism(out[curr_lvl + i], U, R, Q, P, pa, pb);
         if(level == 0)
         {
-          out_ptr[next_lvl + i * lvl_factor + 2] =
-            new_inscribed_prism(out_ptr[curr_lvl + i], S, P, U, T, pa, pb);
+          out[next_lvl + i * lvl_factor + 2] =
+            new_inscribed_prism(out[curr_lvl + i], S, P, U, T, pa, pb);
         }
       });
 

--- a/src/axom/quest/detail/Discretize_detail.hpp
+++ b/src/axom/quest/detail/Discretize_detail.hpp
@@ -151,7 +151,7 @@ template <typename ExecSpace>
 int discrSeg(const Point2D &a,
              const Point2D &b,
              int levels,
-             const axom::ArrayView<OctType> &out,
+             axom::ArrayView<OctType> &out,
              int idx)
 {
   // Assert input assumptions

--- a/src/axom/quest/detail/Discretize_detail.hpp
+++ b/src/axom/quest/detail/Discretize_detail.hpp
@@ -220,14 +220,15 @@ int discrSeg(const Point2D &a,
     axom::for_all<ExecSpace>(
       curr_lvl_count,
       AXOM_LAMBDA(axom::IndexType i) {
-        out[next_lvl + i * lvl_factor + 0] =
-          new_inscribed_prism(out[curr_lvl + i], Q, T, S, R, pa, pb);
-        out[next_lvl + i * lvl_factor + 1] =
-          new_inscribed_prism(out[curr_lvl + i], U, R, Q, P, pa, pb);
+        OctType *out_ptr = out.data();
+        out_ptr[next_lvl + i * lvl_factor + 0] =
+          new_inscribed_prism(out_ptr[curr_lvl + i], Q, T, S, R, pa, pb);
+        out_ptr[next_lvl + i * lvl_factor + 1] =
+          new_inscribed_prism(out_ptr[curr_lvl + i], U, R, Q, P, pa, pb);
         if(level == 0)
         {
-          out[next_lvl + i * lvl_factor + 2] =
-            new_inscribed_prism(out[curr_lvl + i], S, P, U, T, pa, pb);
+          out_ptr[next_lvl + i * lvl_factor + 2] =
+            new_inscribed_prism(out_ptr[curr_lvl + i], S, P, U, T, pa, pb);
         }
       });
 

--- a/src/axom/quest/detail/MeshTester_detail.hpp
+++ b/src/axom/quest/detail/MeshTester_detail.hpp
@@ -146,7 +146,7 @@ protected:
    * \note This should be implemented in derived CandidateFinder template
    *  specializations for each supported acceleration data structure.
    */
-  virtual axom::Array<IndexType, 1, Space> getCandidates(
+  virtual axom::ArrayView<IndexType, 1, Space> getCandidates(
     axom::Array<IndexType, 1, Space>& offsets,
     axom::Array<IndexType, 1, Space>& counts) = 0;
 
@@ -219,7 +219,7 @@ void CandidateFinderBase<ExecSpace, FloatType>::findTriMeshIntersections(
 
   // Get CSR arrays for candidate data
   IndexArray offsets, counts;
-  IndexView candidates = getCandidates(offsets, counts).view();
+  IndexView candidates = getCandidates(offsets, counts);
 
   IndexArray indices(candidates.size());
   IndexArray validCandidates(candidates.size());
@@ -328,7 +328,7 @@ struct CandidateFinder<AccelType::BVH, ExecSpace, FloatType>
   using BaseClass::HostSpace;
   using BaseClass::Space;
 
-  virtual axom::Array<IndexType, 1, Space> getCandidates(
+  virtual axom::ArrayView<IndexType, 1, Space> getCandidates(
     axom::Array<IndexType, 1, Space>& offsets,
     axom::Array<IndexType, 1, Space>& counts) override
   {
@@ -417,7 +417,7 @@ struct CandidateFinder<AccelType::ImplicitGrid, ExecSpace, FloatType>
     m_resolutions = axom::primal::Point<IndexType, 3>(spatialIndexResolution);
   }
 
-  virtual axom::Array<IndexType, 1, Space> getCandidates(
+  virtual axom::ArrayView<IndexType, 1, Space> getCandidates(
     axom::Array<IndexType, 1, Space>& offsets,
     axom::Array<IndexType, 1, Space>& counts) override
   {
@@ -471,7 +471,7 @@ struct CandidateFinder<AccelType::UniformGrid, ExecSpace, FloatType>
     m_resolutions = axom::primal::NumericArray<int, 3>(spatialIndexResolution);
   }
 
-  virtual axom::Array<IndexType, 1, Space> getCandidates(
+  virtual axom::ArrayView<IndexType, 1, Space> getCandidates(
     axom::Array<IndexType, 1, Space>& offsets,
     axom::Array<IndexType, 1, Space>& counts) override
   {

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -69,6 +69,39 @@ if(AXOM_ENABLE_QUEST)
         blt_add_target_compile_flags(TO mesh_tester FLAGS "-fgpu-rdc")
         blt_add_target_link_flags(TO mesh_tester FLAGS "-fgpu-rdc")
     endif()
+
+    # Add unit tests
+    if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR AND RAJA_FOUND)
+
+        # Run the mesh_tester with the plane_simp_problems.stl example and
+        # different spatial indexes, raja policies
+
+        set(plane_data_dir ${AXOM_DATA_DIR}/quest/plane_simp_problems.stl)
+
+        set(_methods "bvh" "implicit" "uniform")
+
+        set (_policies "raja_seq")
+        blt_list_append(TO _policies ELEMENTS "raja_omp" IF AXOM_ENABLE_OPENMP)
+        blt_list_append(TO _policies ELEMENTS "raja_cuda" IF AXOM_ENABLE_CUDA)
+
+        foreach(_method ${_methods})
+            foreach(_policy ${_policies})
+
+                set(_testname "mesh_tester_${_method}_${_policy}")
+                axom_add_test(
+                  NAME ${_testname}
+                  COMMAND mesh_tester
+                          --infile ${plane_data_dir}
+                          --method ${_method}
+                          --policy ${_policy}
+                )
+
+                set_tests_properties(${_testname} PROPERTIES
+                    PASS_REGULAR_EXPRESSION  "5 intersecting tri pairs")
+            endforeach()
+        endforeach()
+    endif()
+
 endif()
 
 #------------------------------------------------------------------------------

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -76,7 +76,7 @@ if(AXOM_ENABLE_QUEST)
         # Run the mesh_tester with the plane_simp_problems.stl example and
         # different spatial indexes, raja policies
 
-        set(plane_data_dir ${AXOM_DATA_DIR}/quest/plane_simp_problems.stl)
+        set(plane_data_dir "${AXOM_DATA_DIR}/quest/plane_simp_problems.stl")
 
         set(_methods "bvh" "implicit" "uniform")
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -71,7 +71,7 @@ if(AXOM_ENABLE_QUEST)
     endif()
 
     # Add unit tests
-    if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR AND RAJA_FOUND)
+    if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR AND RAJA_FOUND AND UMPIRE_FOUND)
 
         # Run the mesh_tester with the plane_simp_problems.stl example and
         # different spatial indexes, raja policies


### PR DESCRIPTION
This PR:
- Fixes failing `mesh_tester` executable
  - Bug was introduced by a change made in PR #1111 ([link to exact buggy commit](https://github.com/LLNL/axom/pull/1111/commits/d340e93be55a314853a6609c47b0b16cf21a20c9))
- Adds tests for `mesh_tester` for the different spatial indexes and RAJA policies.
- Re-enable `core_openmp_map` unit test.
  - `AXOM_USE_RAJA` was used of instead of `RAJA_FOUND` to guard test inclusion.