### PR TITLE
Fix `MFEMSidreDataCollection` finite element space bug

### DIFF
--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -2636,7 +2636,7 @@ void MFEMSidreDataCollection::reconstructField(Group* field_grp)
     }
 
     // We cache the FESpaces to avoid reconstructing them when not needed
-    // An FESpace is uniquely identified by the basis of its FEColl, its ordering, and its vdim number
+    // An FESpace is uniquely identified by the basis of its FEColl, ordering, and vdim number
     const std::string fespace_id =
       axom::fmt::format("{0}_{1}_{2}",
                         basis_name,

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -2640,7 +2640,7 @@ void MFEMSidreDataCollection::reconstructField(Group* field_grp)
     const std::string fespace_id =
       axom::fmt::format("{0}_{1}_{2}",
                         basis_name,
-                        (ordering == mfem::Ordering::byVDIM) ? "vdim" : "nodes", 
+                        (ordering == mfem::Ordering::byVDIM) ? "vdim" : "nodes",
                         vdim);
 
     // Only need to create a new FESpace if one doesn't already exist

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -2636,11 +2636,11 @@ void MFEMSidreDataCollection::reconstructField(Group* field_grp)
     }
 
     // We cache the FESpaces to avoid reconstructing them when not needed
-    // An FESpace is uniquely identified by the basis of its FEColl and its ordering
+    // An FESpace is uniquely identified by the basis of its FEColl, its ordering, and its vdim number
     const std::string fespace_id =
-      axom::fmt::format("{0}_{1}",
+      axom::fmt::format("{0}_{1}_{2}",
                         basis_name,
-                        (ordering == mfem::Ordering::byVDIM) ? "nodes" : "vdim");
+                        (ordering == mfem::Ordering::byVDIM) ? "vdim" : "nodes", vdim);
 
     // Only need to create a new FESpace if one doesn't already exist
     if(is_gridfunc && (m_fespaces.count(fespace_id) == 0))

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -2640,7 +2640,8 @@ void MFEMSidreDataCollection::reconstructField(Group* field_grp)
     const std::string fespace_id =
       axom::fmt::format("{0}_{1}_{2}",
                         basis_name,
-                        (ordering == mfem::Ordering::byVDIM) ? "vdim" : "nodes", vdim);
+                        (ordering == mfem::Ordering::byVDIM) ? "vdim" : "nodes", 
+                        vdim);
 
     // Only need to create a new FESpace if one doesn't already exist
     if(is_gridfunc && (m_fespaces.count(fespace_id) == 0))


### PR DESCRIPTION
This short PR fixes two bugs when reading an `mfem::GridFunction` from an `MFEMSidreDataCollection`.

1) It constructs a new `mfem::FiniteElementSpace` when the vdim is different from what is currently stored in Sidre.
2) It correctly determines whether the stored grid function is ordered by nodes or VDIM.
