### PR TITLE
Fill _IMPORT_ROOT in the CMake target.

### DIFF
--- a/src/cmake/axom-config.cmake.in
+++ b/src/cmake/axom-config.cmake.in
@@ -156,6 +156,15 @@ if(NOT AXOM_FOUND)
   # Include targets exported by cmake
   #----------------------------------------------------------------------------
   get_filename_component(AXOM_CMAKE_CONFIG_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+  get_filename_component(_IMPORT_PREFIX "${AXOM_CMAKE_CONFIG_DIR}" PATH)
+
+  if(_IMPORT_PREFIX STREQUAL "/")
+    set(_IMPORT_PREFIX "")
+  endif()
+
+  # we want the import root, which is right above the "lib" prefix
+  get_filename_component(_IMPORT_ROOT "${_IMPORT_PREFIX}" PATH)
+
   include(${AXOM_CMAKE_CONFIG_DIR}/axom-targets.cmake)
 
   # Create convenience target that bundles all Axom targets (axom)


### PR DESCRIPTION
# Summary

- This PR is a bugfix to the CMake target.  It defines a variable to allow us to refer to files with relative paths.