### PR TITLE
Use Blueprint-specified coordset name, instead of assuming one

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,14 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ## [Unreleased] - Release date yyyy-mm-dd
 
+### Changed
+- `MarchingCubes` and `DistributedClosestPoint` classes changed from requiring the Blueprint
+  coordset name to requiring the Blueprint topology name.  The changed interface methods are:
+  - `DistributedClosestPoint::setObjectMesh`
+  - `DistributedClosestPoint::computeClosestPoints`
+  - `MarchingCubes::MarchingCubes`
+  - `MarchingCubesSingleDomain::MarchingCubesSingleDomain`
+
 ## [Version 0.8.1] - Release date 2023-08-16
 
 ### Changed

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -193,8 +193,8 @@ namespace mpi
  * \param [in] tag tag for MPI message
  * \param [in] comm MPI communicator to use
  * \param [in] request object holding state for the sent data
- * \note Adapted from conduit's relay::mpi's \a send_using_schema and \a isend to use
- * non-blocking \a MPI_Isend instead of blocking \a MPI_Send
+ * \note Adapted from conduit's relay::mpi's \a send_using_schema and \a isend
+ * to use non-blocking \a MPI_Isend instead of blocking \a MPI_Send
  */
 inline int isend_using_schema(conduit::Node& node,
                               int dest,
@@ -424,11 +424,11 @@ public:
    * Import object mesh points from the object blueprint mesh into internal memory.
    *
    * \param [in] mdMeshNode The blueprint mesh containing the object points.
-   * \param [in] valuesPath The path to the mesh points.
+   * \param [in] topologyName Name of the blueprint topology in \a mdMeshNode.
    * \note This function currently supports mesh blueprints with the "point" topology
    */
   void importObjectPoints(const conduit::Node& mdMeshNode,
-                          const std::string& valuesPath)
+                          const std::string& topologyName)
   {
     // TODO: See if some of the copies in this method can be optimized out.
 
@@ -438,6 +438,13 @@ public:
     int ptCount = 0;
     for(const conduit::Node& domain : mdMeshNode.children())
     {
+      const std::string coordsetName =
+        domain
+          .fetch_existing(
+            axom::fmt::format("topologies/{}/coordset", topologyName))
+          .as_string();
+      const std::string valuesPath =
+        axom::fmt::format("coordsets/{}/values", coordsetName);
       auto& values = domain.fetch_existing(valuesPath);
       const int N = internal::extractSize(values);
       ptCount += N;
@@ -451,6 +458,13 @@ public:
     for(conduit::index_t d = 0; d < mdMeshNode.number_of_children(); ++d)
     {
       const conduit::Node& domain = mdMeshNode.child(d);
+      const std::string coordsetName =
+        domain
+          .fetch_existing(
+            axom::fmt::format("topologies/{}/coordset", topologyName))
+          .as_string();
+      const std::string valuesPath =
+        axom::fmt::format("coordsets/{}/values", coordsetName);
 
       auto& values = domain.fetch_existing(valuesPath);
 
@@ -663,7 +677,7 @@ public:
    */
   void node_copy_query_to_xfer(conduit::Node& queryNode,
                                conduit::Node& xferNode,
-                               const std::string& coordset) const
+                               const std::string& topologyName) const
   {
     xferNode["homeRank"] = m_rank;
     xferNode["is_first"] = 1;
@@ -671,11 +685,16 @@ public:
     conduit::Node& xferDoms = xferNode["xferDoms"];
     for(auto& queryDom : queryNode.children())
     {
+      const std::string coordsetName =
+        queryDom
+          .fetch_existing(
+            axom::fmt::format("topologies/{}/coordset", topologyName))
+          .as_string();
       const std::string& domName = queryDom.name();
       conduit::Node& xferDom = xferDoms[domName];
       conduit::Node& fields = queryDom.fetch_existing("fields");
       conduit::Node& queryCoords =
-        queryDom.fetch_existing(fmt::format("coordsets/{}", coordset));
+        queryDom.fetch_existing(fmt::format("coordsets/{}", coordsetName));
       conduit::Node& queryCoordsValues = queryCoords.fetch_existing("values");
 
       // clang-format off
@@ -819,10 +838,10 @@ public:
    *
    * \param queryMesh The root node of a mesh blueprint for the query points
    * Can be empty if there are no query points for the calling rank
-   * \param coordset The coordinate set for the query points
+   * \param topologyName The topology name identifying the query points
    *
-   * When the query mesh contains query points, it uses the \a coordset coordinate set
-   * of the provided blueprint mesh and  contains the following fields:
+   * The named topology is used to identify the points in the query mesh.
+   * On completion, the query mesh contains the following fields:
    *   - cp_rank: Will hold the rank of the object point containing the closest point
    *   - cp_domain_index: will hold the index of the object domain containing
    *     the closest points.
@@ -844,7 +863,7 @@ public:
    * using check_send_requests().
    */
   void computeClosestPoints(conduit::Node& queryMesh_,
-                            const std::string& coordset) const
+                            const std::string& topologyName) const
   {
     SLIC_ASSERT_MSG(
       isBVHTreeInitialized(),
@@ -868,7 +887,7 @@ public:
     {
       xferNodes[m_rank] = std::make_shared<conduit::Node>();
       conduit::Node& xferNode = *xferNodes[m_rank];
-      node_copy_query_to_xfer(queryMesh, xferNode, coordset);
+      node_copy_query_to_xfer(queryMesh, xferNode, topologyName);
       xferNode["homeRank"] = m_rank;
     }
 
@@ -1598,12 +1617,13 @@ public:
    * \brief Sets the object mesh for the query
    *
    * \param [in] meshNode Conduit node for the object mesh
-   * \param [in] coordset The name of the coordset for the object mesh's coordinates
+   * \param [in] topologyName The name of the topology for the object mesh
    *
    * \pre \a meshNode must follow the mesh blueprint convention.
    * \pre Dimension of the mesh must be 2D or 3D
    */
-  void setObjectMesh(const conduit::Node& meshNode, const std::string& coordset)
+  void setObjectMesh(const conduit::Node& meshNode,
+                     const std::string& topologyName)
   {
     SLIC_ASSERT(this->isValidBlueprint(meshNode));
 
@@ -1620,7 +1640,6 @@ public:
     const conduit::Node& mdMeshNode(isMultidomain ? meshNode : *tmpNode);
 
     auto domainCount = conduit::blueprint::mesh::number_of_domains(mdMeshNode);
-    const std::string valuesPath = fmt::format("coordsets/{}/values", coordset);
 
     // Extract the dimension from the coordinate values group
     // use allreduce since some ranks might be empty
@@ -1628,10 +1647,15 @@ public:
       int localDim = -1;
       if(domainCount > 0)
       {
-        const conduit::Node& domain0(mdMeshNode[0]);
-        SLIC_ASSERT(domain0.has_path(valuesPath));
-        auto& values = domain0.fetch_existing(valuesPath);
-        localDim = internal::extractDimension(values);
+        const conduit::Node& domain0 = mdMeshNode.child(0);
+        const conduit::Node& topology =
+          domain0.fetch_existing("topologies/" + topologyName);
+        const std::string coordsetName =
+          topology.fetch_existing("coordset").as_string();
+        const conduit::Node& coordset =
+          domain0.fetch_existing("coordsets/" + coordsetName);
+        const conduit::Node& coordsetValues = coordset.fetch_existing("values");
+        localDim = internal::extractDimension(coordsetValues);
       }
       int dim = -1;
       MPI_Allreduce(&localDim, &dim, 1, MPI_INT, MPI_MAX, m_mpiComm);
@@ -1643,10 +1667,10 @@ public:
     switch(m_dimension)
     {
     case 2:
-      m_dcp_2->importObjectPoints(mdMeshNode, valuesPath);
+      m_dcp_2->importObjectPoints(mdMeshNode, topologyName);
       break;
     case 3:
-      m_dcp_3->importObjectPoints(mdMeshNode, valuesPath);
+      m_dcp_3->importObjectPoints(mdMeshNode, topologyName);
       break;
     }
 

--- a/src/axom/quest/MarchingCubes.cpp
+++ b/src/axom/quest/MarchingCubes.cpp
@@ -15,11 +15,11 @@ namespace quest
 {
 MarchingCubes::MarchingCubes(RuntimePolicy runtimePolicy,
                              const conduit::Node& bpMesh,
-                             const std::string& coordsetName,
+                             const std::string& topologyName,
                              const std::string& maskField)
   : m_runtimePolicy(runtimePolicy)
   , m_singles()
-  , m_coordsetPath("coordsets/" + coordsetName)
+  , m_topologyName(topologyName)
   , m_fcnPath()
   , m_maskPath(maskField.empty() ? std::string() : "fields/" + maskField)
 {
@@ -31,8 +31,10 @@ MarchingCubes::MarchingCubes(RuntimePolicy runtimePolicy,
   m_singles.reserve(conduit::blueprint::mesh::number_of_domains(bpMesh));
   for(auto& dom : bpMesh.children())
   {
-    m_singles.emplace_back(
-      new MarchingCubesSingleDomain(m_runtimePolicy, dom, coordsetName, maskField));
+    m_singles.emplace_back(new MarchingCubesSingleDomain(m_runtimePolicy,
+                                                         dom,
+                                                         m_topologyName,
+                                                         maskField));
   }
 }
 
@@ -131,12 +133,12 @@ void MarchingCubes::populateContourMesh(
 
 MarchingCubesSingleDomain::MarchingCubesSingleDomain(RuntimePolicy runtimePolicy,
                                                      const conduit::Node& dom,
-                                                     const std::string& coordsetName,
+                                                     const std::string& topologyName,
                                                      const std::string& maskField)
   : m_runtimePolicy(runtimePolicy)
   , m_dom(nullptr)
   , m_ndim(0)
-  , m_coordsetPath("coordsets/" + coordsetName)
+  , m_topologyName(topologyName)
   , m_fcnPath()
   , m_maskPath(maskField.empty() ? std::string() : "fields/" + maskField)
 {
@@ -153,9 +155,13 @@ void MarchingCubesSingleDomain::setDomain(const conduit::Node& dom)
   SLIC_ASSERT_MSG(
     !conduit::blueprint::mesh::is_multi_domain(dom),
     "MarchingCubesSingleDomain is single-domain only.  Try MarchingCubes.");
+  SLIC_ASSERT(
+    dom.fetch_existing("topologies/" + m_topologyName + "/type").as_string() ==
+    "structured");
 
-  SLIC_ASSERT(dom.has_path(m_coordsetPath));
-  SLIC_ASSERT(dom["topologies/mesh/type"].as_string() == "structured");
+  const std::string coordsetPath = "coordsets/" +
+    dom.fetch_existing("topologies/" + m_topologyName + "/coordset").as_string();
+  SLIC_ASSERT(dom.has_path(coordsetPath));
 
   if(!m_maskPath.empty())
   {
@@ -164,14 +170,12 @@ void MarchingCubesSingleDomain::setDomain(const conduit::Node& dom)
 
   m_dom = &dom;
 
-  const conduit::Node& dimsNode =
-    m_dom->fetch_existing("topologies/mesh/elements/dims");
-
-  m_ndim = dimsNode.number_of_children();
-
+  m_ndim = conduit::blueprint::mesh::coordset::dims(
+    dom.fetch_existing("coordsets/coords"));
   SLIC_ASSERT(m_ndim >= 2 && m_ndim <= 3);
 
-  const conduit::Node& coordsValues = dom[m_coordsetPath + "/values"];
+  const conduit::Node& coordsValues =
+    dom.fetch_existing(coordsetPath + "/values");
   bool isInterleaved = conduit::blueprint::mcarray::is_interleaved(coordsValues);
   SLIC_ASSERT_MSG(
     !isInterleaved,
@@ -193,7 +197,9 @@ void MarchingCubesSingleDomain::computeIsocontour(double contourVal)
                   "You must call setFunctionField before computeIsocontour.");
 
   allocateImpl();
-  m_impl->initialize(*m_dom, m_coordsetPath, m_fcnPath, m_maskPath);
+  const std::string coordsetPath = "coordsets/" +
+    m_dom->fetch_existing("topologies/" + m_topologyName + "/coordset").as_string();
+  m_impl->initialize(*m_dom, coordsetPath, m_fcnPath, m_maskPath);
   m_impl->setContourValue(contourVal);
   m_impl->markCrossings();
   m_impl->scanCrossings();

--- a/src/axom/quest/MarchingCubes.hpp
+++ b/src/axom/quest/MarchingCubes.hpp
@@ -119,7 +119,7 @@ public:
    *             The simplest policy is RuntimePolicy::seq, which specifies
    *             running sequentially on the CPU.
    * \param [in] bpMesh Blueprint multi-domain mesh containing scalar field.
-   * \param [in] coordsetName Name of blueprint point coordinate set.
+   * \param [in] topologyName Name of Blueprint topology to use in \a bpMesh.
    * \param [in] maskField Cell-based std::int32_t mask field.  If provided,
    *             cells where this field evaluates to false are skipped.
    *
@@ -137,7 +137,7 @@ public:
    */
   MarchingCubes(RuntimePolicy runtimePolicy,
                 const conduit::Node &bpMesh,
-                const std::string &coordsetName,
+                const std::string &topologyName,
                 const std::string &maskField = {});
 
   /*!
@@ -178,7 +178,7 @@ private:
 
   //! @brief Single-domain implementations.
   axom::Array<std::unique_ptr<MarchingCubesSingleDomain>> m_singles;
-  const std::string m_coordsetPath;
+  const std::string m_topologyName;
   std::string m_fcnPath;
   std::string m_maskPath;
 
@@ -206,7 +206,7 @@ public:
    *             The simplest policy is RuntimePolicy::seq, which specifies
    *             running sequentially on the CPU.
    * \param [in] dom Blueprint single-domain mesh containing scalar field.
-   * \param [in] coordsetName Name of blueprint point coordinate set.
+   * \param [in] topologyName Name of Blueprint topology to use in \a dom
    * \param [in] maskField Cell-based std::int32_t mask field.  If provided,
    *             cells where this field evaluates to false are skipped.
    *
@@ -225,7 +225,7 @@ public:
    */
   MarchingCubesSingleDomain(RuntimePolicy runtimePolicy,
                             const conduit::Node &dom,
-                            const std::string &coordsetName,
+                            const std::string &topologyName,
                             const std::string &maskfield);
 
   /*!
@@ -319,8 +319,8 @@ private:
   const conduit::Node *m_dom;
   int m_ndim;
 
-  //!@brief Path to coordinate set in m_dom.
-  const std::string m_coordsetPath;
+  //!@brief Name of Blueprint topology in m_dom.
+  const std::string m_topologyName;
 
   //!@brief Path to nodal scalar function in m_dom.
   std::string m_fcnPath;
@@ -339,7 +339,7 @@ private:
   {
     //!@brief Prepare internal data for operating on the given domain.
     virtual void initialize(const conduit::Node &dom,
-                            const std::string &coordsetPath,
+                            const std::string &topologyName,
                             const std::string &fcnPath,
                             const std::string &maskPath) = 0;
     //!@brief Set the contour value

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -256,7 +256,7 @@ public:
     return m_fieldsGroups[groupIdx];
   }
 
-  const std::string& get_topology_name() const { return m_topologyName; }
+  const std::string& getTopologyName() const { return m_topologyName; }
   const std::string& getCoordsetName() const { return m_coordsetName; }
 
   /// Gets the MPI rank for this mesh
@@ -305,7 +305,7 @@ public:
   int dimension() const { return m_dimension; }
 
   /*!
-    @brief Read a blueprint mesh.
+    @brief Read a blueprint mesh and store it internally in m_group.
   */
   void read_blueprint_mesh(const std::string& meshFilename)
   {
@@ -589,7 +589,6 @@ public:
         slic::flushStreams();
         return false;
       }
-      // info.print();
     }
     return true;
   }
@@ -682,6 +681,7 @@ public:
   /// Get a pointer to the root group for this mesh
   sidre::Group* getBlueprintGroup() const { return m_objectMesh.root_group(); }
 
+  std::string getTopologyName() const { return m_objectMesh.getTopologyName(); }
   std::string getCoordsetName() const { return m_objectMesh.getCoordsetName(); }
 
   void setVerbosity(bool verbose) { m_verbose = verbose; }
@@ -856,6 +856,7 @@ public:
 
   sidre::Group* getBlueprintGroup() const { return m_queryMesh.root_group(); }
 
+  std::string getTopologyName() const { return m_queryMesh.getTopologyName(); }
   std::string getCoordsetName() const { return m_queryMesh.getCoordsetName(); }
 
   /// Returns an array containing the positions of the mesh vertices
@@ -989,7 +990,7 @@ public:
       assert(m_queryMesh.topo_group(di) ==
              m_queryMesh.domain_group(di)
                ->getGroup("topologies")
-               ->getGroup(m_queryMesh.get_topology_name()));
+               ->getGroup(m_queryMesh.getTopologyName()));
       assert(m_queryMesh.fields_group(di) ==
              m_queryMesh.domain_group(di)->getGroup("fields"));
     }
@@ -1423,7 +1424,7 @@ int main(int argc, char** argv)
   // To test support for single-domain format, use single-domain when possible.
   query.setObjectMesh(
     objectMeshNode.number_of_children() == 1 ? objectMeshNode[0] : objectMeshNode,
-    objectMeshWrapper.getCoordsetName());
+    objectMeshWrapper.getTopologyName());
 
   // Build the spatial index over the object on each rank
   SLIC_INFO(init_str);
@@ -1438,7 +1439,7 @@ int main(int argc, char** argv)
   queryTimer.start();
   query.computeClosestPoints(
     queryMeshNode.number_of_children() == 1 ? queryMeshNode[0] : queryMeshNode,
-    queryMeshWrapper.getCoordsetName());
+    queryMeshWrapper.getTopologyName());
   queryTimer.stop();
 
   auto getDoubleMinMax =

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -653,7 +653,7 @@ private:
 #else
     conduit::relay::io::blueprint::load_mesh(meshFilename, _mdMesh);
 #endif
-    assert(conduit::blueprint::mesh::is_multi_domain(_mdMesh));
+    SLIC_ASSERT(conduit::blueprint::mesh::is_multi_domain(_mdMesh));
     _domCount = conduit::blueprint::mesh::number_of_domains(_mdMesh);
 
     if(_domCount > 0)
@@ -1479,7 +1479,7 @@ int testNdimInstance(BlueprintStructuredMesh& computationalMesh)
   // Create marching cubes algorithm object and set some parameters
   quest::MarchingCubes mc(params.policy,
                           computationalMesh.asConduitNode(),
-                          "coords");
+                          "mesh");
 
   //---------------------------------------------------------------------------
   // params specify which tests to run.


### PR DESCRIPTION
The Blueprint coordset name is specified in the topology group, but I had been assuming a coordset name when I wrote the code (because I didn't know it could be different).  The assumed name may not necessarily match the topology-specified name.  This PR removes the assumption.

A topology specifies one coordset, and a coordset may be used by many topologies.

This change is needed by concurrent work, where we have to access both the topology and its coordset.  By specifying the topology, we have both.  If we specify coordset, we can't get to the topology.

# Summary

- This PR is a refactoring.
- It does the following:
  - Modifies the `DistributedClosestPoint` and `MarchingCubes` classes so that they use the Blueprint coordset name specified by the topology.
  - Changes a few public interfaces that were using coordset names.  They now use topology names.
  - Updates `RELEASE-NOTES.md` to show the interface change.