### PR TITLE
Checks that we can use both `c2c` and `stl` in the same sample-based shaping deck

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -27,6 +27,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   - `MarchingCubes::MarchingCubes`
   - `MarchingCubesSingleDomain::MarchingCubesSingleDomain`
 
+### Fixed
+- quest's `SamplingShaper` now properly handles material names containing underscores
+
 ## [Version 0.8.1] - Release date 2023-08-16
 
 ### Changed

--- a/src/axom/quest/SamplingShaper.hpp
+++ b/src/axom/quest/SamplingShaper.hpp
@@ -464,8 +464,6 @@ public:
 
   void applyReplacementRules(const klee::Shape& shape) override
   {
-    using axom::utilities::string::rsplitN;
-
     internal::ScopedLogLevelChanger logLevelChanger(
       this->isVerbose() ? slic::message::Debug : slic::message::Warning);
 

--- a/src/axom/quest/SamplingShaper.hpp
+++ b/src/axom/quest/SamplingShaper.hpp
@@ -657,71 +657,36 @@ public:
   /// This function is intended to help with debugging
   void printRegisteredFieldNames(const std::string& initialMessage)
   {
+    // helper lambda to extract the keys of a map<string,*> as a vector of strings
+    auto extractKeys = [](const auto& map) {
+      std::vector<std::string> keys;
+      for(const auto& kv : map)
+      {
+        keys.push_back(kv.first);
+      }
+      return keys;
+    };
+
     std::stringstream sstr;
     sstr << "List of registered fields in the SamplingShaper " << initialMessage
-         << std::endl;
-    {
-      std::vector<std::string> names;
-      for(auto kv : m_dc->GetFieldMap())
-      {
-        names.push_back(kv.first);
-      }
-      sstr << fmt::format("\t* Data collection grid funcs: {}",
-                          fmt::join(names, ", "))
-           << std::endl;
-    }
-    {
-      std::vector<std::string> names;
-      for(auto kv : m_dc->GetQFieldMap())
-      {
-        names.push_back(kv.first);
-      }
-      sstr << fmt::format("\t* Data collection qfuncs: {}",
-                          fmt::join(names, ", "))
-           << std::endl;
-    }
-
-    {
-      std::vector<std::string> names;
-      for(auto name : m_knownMaterials)
-      {
-        names.push_back(name);
-      }
-      sstr << fmt::format("\t* Known materials: {}", fmt::join(names, ", "))
-           << std::endl;
-    }
+         << fmt::format("\n\t* Data collection grid funcs: {}",
+                        fmt::join(extractKeys(m_dc->GetFieldMap()), ", "))
+         << fmt::format("\n\t* Data collection qfuncs: {}",
+                        fmt::join(extractKeys(m_dc->GetQFieldMap()), ", "))
+         << fmt::format("\n\t* Known materials: {}",
+                        fmt::join(m_knownMaterials, ", "));
 
     if(m_vfSampling == shaping::VolFracSampling::SAMPLE_AT_QPTS)
     {
-      {
-        std::vector<std::string> names;
-        for(auto kv : m_inoutShapeQFuncs)
-        {
-          names.push_back(kv.first);
-        }
-        sstr << fmt::format("\t* Shape qfuncs: {}", fmt::join(names, ", "))
-             << std::endl;
-      }
-      {
-        std::vector<std::string> names;
-        for(auto kv : m_inoutMaterialQFuncs)
-        {
-          names.push_back(kv.first);
-        }
-        sstr << fmt::format("\t* Mat qfuncs: {}", fmt::join(names, ", "))
-             << std::endl;
-      }
+      sstr << fmt::format("\n\t* Shape qfuncs: {}",
+                          fmt::join(extractKeys(m_inoutShapeQFuncs), ", "))
+           << fmt::format("\n\t* Mat qfuncs: {}",
+                          fmt::join(extractKeys(m_inoutMaterialQFuncs), ", "));
     }
     else if(m_vfSampling == shaping::VolFracSampling::SAMPLE_AT_DOFS)
     {
-      std::vector<std::string> names;
-      for(auto kv : m_inoutDofs)
-      {
-        names.push_back(kv.first);
-      }
-      sstr << fmt::format("\t* Shape samples at DOFs: {}",
-                          fmt::join(names, ", "))
-           << std::endl;
+      sstr << fmt::format("\n\t* Shape samples at DOFs: {}",
+                          fmt::join(extractKeys(m_inoutDofs), ", "));
     }
     SLIC_INFO(sstr.str());
   }

--- a/src/axom/quest/SamplingShaper.hpp
+++ b/src/axom/quest/SamplingShaper.hpp
@@ -511,7 +511,7 @@ public:
       }
 
       const bool shouldReplace = shape.replaces(otherMatName);
-      SLIC_DEBUG(axom::fmt::format(
+      SLIC_INFO(axom::fmt::format(
         "Should we replace material '{}' with shape '{}' of material '{}'? {}",
         otherMatName,
         shapeName,

--- a/src/axom/quest/detail/shaping/shaping_helpers.cpp
+++ b/src/axom/quest/detail/shaping/shaping_helpers.cpp
@@ -145,10 +145,9 @@ void computeVolumeFractions(const std::string& matField,
                             QFunctionCollection& inoutQFuncs,
                             int outputOrder)
 {
-  using axom::utilities::string::rsplitN;
+  SLIC_ASSERT(axom::utilities::string::startsWith(matField, "mat_inout_"));
 
-  auto matName = rsplitN(matField, 2, '_')[1];
-  auto volFracName = axom::fmt::format("vol_frac_{}", matName);
+  const auto volFracName = axom::fmt::format("vol_frac_{}", matField.substr(10));
 
   // Grab a pointer to the inout samples QFunc
   mfem::QuadratureFunction* inout = inoutQFuncs.Get(matField);

--- a/src/axom/quest/tests/quest_sampling_shaper.cpp
+++ b/src/axom/quest/tests/quest_sampling_shaper.cpp
@@ -166,13 +166,27 @@ public:
     EXPECT_NE(nullptr, m_shaper)
       << "Shaper needs to be initialized via initializeShaping()";
 
-    const auto shapeDim = m_shapeSet->getDimensions();
+    // Define lambda to override default dimensions, when necessary
+    auto getShapeDim = [defaultDim =
+                          m_shapeSet->getDimensions()](const auto& shape) {
+      static std::map<std::string, klee::Dimensions> format_dim = {
+        {"c2c", klee::Dimensions::Two},
+        {"stl", klee::Dimensions::Three}};
+
+      const auto& format_str = shape.getGeometry().getFormat();
+      return format_dim.find(format_str) != format_dim.end()
+        ? format_dim[format_str]
+        : defaultDim;
+    };
+
     for(const auto& shape : m_shapeSet->getShapes())
     {
       SLIC_INFO_IF(very_verbose_output,
                    axom::fmt::format("\tshape {} -> material {}",
                                      shape.getName(),
                                      shape.getMaterial()));
+
+      const auto shapeDim = getShapeDim(shape);
 
       m_shaper->loadShape(shape);
       m_shaper->prepareShapeQuery(shapeDim, shape);
@@ -1132,6 +1146,110 @@ shapes:
   }
 }
 
+TEST_F(SamplingShaperTest2D, contour_and_stl_2D)
+{
+  using Point2D = primal::Point<double, 2>;
+  using Point3D = primal::Point<double, 3>;
+
+  const auto& testname =
+    ::testing::UnitTest::GetInstance()->current_test_info()->name();
+
+  constexpr double radius = 1.5;
+
+  const std::string shape_template = R"(
+dimensions: 2
+
+shapes:
+# preshape a background material; dimension should be default
+- name: background
+  material: {3}
+  geometry:
+    format: none
+# shape in a revolved sphere given as a c2c contour
+- name: circle_shape
+  material: {4}
+  geometry:
+    format: c2c
+    path: {0}
+    units: cm
+    operators:
+      - scale: {2}
+# shape in a sphere given as an stl surface mesh
+- name: sphere_shape
+  material: {5}
+  geometry:
+    format: stl
+    path: {1}
+    units: cm
+)";
+
+  const std::string background_material = "luminiferous_ether";
+  const std::string circle_material = "steel";
+  const std::string sphere_material = "vaccum";
+  const std::string sphere_path =
+    axom::fmt::format("{}/quest/unit_sphere.stl", AXOM_DATA_DIR);
+
+  ScopedTemporaryFile contour_file(axom::fmt::format("{}.contour", testname),
+                                   unit_circle_contour);
+
+  ScopedTemporaryFile shape_file(axom::fmt::format("{}.yaml", testname),
+                                 axom::fmt::format(shape_template,
+                                                   contour_file.getFileName(),
+                                                   sphere_path,
+                                                   radius,
+                                                   background_material,
+                                                   circle_material,
+                                                   sphere_material));
+
+  if(very_verbose_output)
+  {
+    SLIC_INFO("Contour file: \n" << contour_file.getFileContents());
+    SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
+  }
+
+  // Create an initial background material set to 1 everywhere
+  std::map<std::string, mfem::GridFunction*> initialGridFunctions;
+  {
+    auto* vf = this->registerVolFracGridFunction("init_vf_bg");
+    this->initializeVolFracGridFunction<2>(
+      vf,
+      [](int, const Point2D&, int) -> double { return 1.; });
+    initialGridFunctions[background_material] = vf;
+  }
+
+  this->validateShapeFile(shape_file.getFileName());
+  this->initializeShaping(shape_file.getFileName(), initialGridFunctions);
+
+  // set projector from 2D mesh points to 3D query points within STL
+  this->m_shaper->setPointProjector([](Point2D pt) {
+    return Point3D {pt[0], pt[1], 0.};
+  });
+
+  this->m_shaper->setQuadratureOrder(8);
+
+  this->runShaping();
+
+  // Check that the result has a volume fraction field associated with circle and sphere materials
+  constexpr double exp_volume_contour = M_PI * radius * radius;
+  constexpr double exp_volume_sphere = M_PI * 1. * 1.;
+  this->checkExpectedVolumeFractions(circle_material,
+                                     exp_volume_contour - exp_volume_sphere,
+                                     3e-2);
+  this->checkExpectedVolumeFractions(sphere_material, exp_volume_sphere, 3e-2);
+
+  for(const auto& vf_name :
+      {background_material, circle_material, sphere_material})
+  {
+    EXPECT_TRUE(this->getDC().HasField(axom::fmt::format("vol_frac_{}", vf_name)));
+  }
+
+  // Save meshes and fields
+  if(very_verbose_output)
+  {
+    this->getDC().Save(testname, axom::sidre::Group::getDefaultIOProtocol());
+  }
+}
+
 //-----------------------------------------------------------------------------
 
 TEST_F(SamplingShaperTest3D, basic_tet)
@@ -1591,10 +1709,94 @@ shapes:
 
   this->runShaping();
 
-  // Check that the result has a volume fraction field associated with the tetrahedron material
-  // Scaling by a factor of 1/2 in each dimension should multiply the total volume by a factor of 8
+  // Check that the result has a volume fraction field associated with the circle material
   constexpr double exp_volume = 4. / 3. * M_PI * radius * radius * radius;
   this->checkExpectedVolumeFractions(circle_material, exp_volume, 3e-2);
+
+  // Save meshes and fields
+  if(very_verbose_output)
+  {
+    this->getDC().Save(testname, axom::sidre::Group::getDefaultIOProtocol());
+  }
+}
+
+TEST_F(SamplingShaperTest3D, contour_and_stl_3D)
+{
+  using Point2D = primal::Point<double, 2>;
+  using Point3D = primal::Point<double, 3>;
+
+  const auto& testname =
+    ::testing::UnitTest::GetInstance()->current_test_info()->name();
+
+  constexpr double radius = 1.5;
+
+  const std::string shape_template = R"(
+dimensions: 2
+
+shapes:
+# shape in a revolved sphere given as a c2c contour
+- name: circle_shape
+  material: {3}
+  geometry:
+    format: c2c
+    path: {0}
+    units: cm
+    operators:
+      - scale: {2}
+# shape in a sphere given as an stl surface mesh
+- name: sphere_shape
+  material: {4}
+  geometry:
+    format: stl
+    path: {1}
+    units: cm
+)";
+
+  const std::string circle_material = "steel";
+  const std::string sphere_material = "void";
+  const std::string sphere_path =
+    axom::fmt::format("{}/quest/unit_sphere.stl", AXOM_DATA_DIR);
+
+  ScopedTemporaryFile contour_file(axom::fmt::format("{}.contour", testname),
+                                   unit_semicircle_contour);
+
+  ScopedTemporaryFile shape_file(axom::fmt::format("{}.yaml", testname),
+                                 axom::fmt::format(shape_template,
+                                                   contour_file.getFileName(),
+                                                   sphere_path,
+                                                   radius,
+                                                   circle_material,
+                                                   sphere_material));
+
+  if(very_verbose_output)
+  {
+    SLIC_INFO("Contour file: \n" << contour_file.getFileContents());
+    SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
+  }
+
+  this->validateShapeFile(shape_file.getFileName());
+  this->initializeShaping(shape_file.getFileName());
+
+  // set projector from 3D points to axisymmetric plane
+  this->m_shaper->setPointProjector([](Point3D pt) {
+    const double& x = pt[0];
+    const double& y = pt[1];
+    const double& z = pt[2];
+    return Point2D {z, sqrt(x * x + y * y)};
+  });
+
+  // we need a higher quadrature order to resolve this shape at the (low) testing resolution
+  this->m_shaper->setQuadratureOrder(8);
+
+  this->runShaping();
+
+  // Check that the result has a volume fraction field associated with sphere and circle materials
+  constexpr double exp_volume_contour = 4. / 3. * M_PI * radius * radius * radius;
+  constexpr double exp_volume_sphere = 4. / 3. * M_PI * 1. * 1. * 1.;
+  this->checkExpectedVolumeFractions(circle_material,
+                                     exp_volume_contour - exp_volume_sphere,
+                                     3e-2);
+  this->checkExpectedVolumeFractions(sphere_material, exp_volume_sphere, 3e-2);
 
   // Save meshes and fields
   if(very_verbose_output)


### PR DESCRIPTION
# Summary

- This PR is a proof of concept that we can use `stl` meshes and `c2c` contours in the same shaping deck for sample-based shaping
   - Resolve #1135 
- It also has some minor bugfixes/maintenance:
  - Resolves #1143  -- we can now have materials with underscores in the name, e.g. `a_material_name`
  - Changes the logging level of a log message related to replacement rules from `DEBUG` to `INFO`, since it can be useful to check that replacement rules act as expected, even from release builds.
  - Refactor/clean up a debugging function in the `SamplingShaper`
  - Improves testing for sample-based shaping

#### TODO:
- [x] Update RELEASE_NOTES