### PR TITLE
Add deep copy methods for Group and View

### DIFF
--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -975,8 +975,10 @@ View* Group::copyView(View* view)
  *
  *************************************************************************
  */
-View* Group::deepCopyView(View* view)
+View* Group::deepCopyView(View* view, int allocID)
 {
+  allocID = getValidAllocatorID(allocID);
+
   if(view == nullptr || hasChildView(view->getName()))
   {
     SLIC_CHECK_MSG(
@@ -995,7 +997,7 @@ View* Group::deepCopyView(View* view)
   }
 
   View* copy = createView(view->getName());
-  view->deepCopyView(copy);
+  view->deepCopyView(copy, allocID);
   return copy;
 }
 
@@ -1388,19 +1390,15 @@ Group* Group::copyGroup(Group* group)
   Group* res = createGroup(group->getName());
 
   // copy child Groups to new Group
-  IndexType gidx = group->getFirstValidGroupIndex();
-  while(indexIsValid(gidx))
+  for(auto& grp : group->groups())
   {
-    res->copyGroup(group->getGroup(gidx));
-    gidx = group->getNextValidGroupIndex(gidx);
+    res->copyGroup(&grp);
   }
 
   // copy Views to new Group
-  IndexType vidx = group->getFirstValidViewIndex();
-  while(indexIsValid(vidx))
+  for(auto& view : group->views())
   {
-    res->copyView(group->getView(vidx));
-    vidx = group->getNextValidViewIndex(vidx);
+    res->copyView(&view);
   }
 
   return res;
@@ -1416,8 +1414,10 @@ Group* Group::copyGroup(Group* group)
  *
  *************************************************************************
  */
-Group* Group::deepCopyGroup(Group* group)
+Group* Group::deepCopyGroup(Group* group, int allocID)
 {
+  allocID = getValidAllocatorID(allocID);
+
   if(group == nullptr || hasChildGroup(group->getName()))
   {
     SLIC_CHECK_MSG(
@@ -1438,19 +1438,15 @@ Group* Group::deepCopyGroup(Group* group)
   Group* res = createGroup(group->getName());
 
   // copy child Groups to new Group
-  IndexType gidx = group->getFirstValidGroupIndex();
-  while(indexIsValid(gidx))
+  for(auto& grp : group->groups())
   {
-    res->deepCopyGroup(group->getGroup(gidx));
-    gidx = group->getNextValidGroupIndex(gidx);
+    res->deepCopyGroup(&grp, allocID);
   }
 
   // copy Views to new Group
-  IndexType vidx = group->getFirstValidViewIndex();
-  while(indexIsValid(vidx))
+  for(auto& view : group->views())
   {
-    res->deepCopyView(group->getView(vidx));
-    vidx = group->getNextValidViewIndex(vidx);
+    res->deepCopyView(&view, allocID);
   }
 
   return res;

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -899,8 +899,8 @@ public:
    * If given View pointer is null or Group already has a View with
    * same name as given View, method is a no-op.
    *
-   * \return pointer to given argument View object or nullptr if View
-   * is not copied into this Group.
+   * \return pointer to the new copied View object or nullptr if a View
+   * is not successfully copied into this Group.
    */
   View* copyView(View* view);
 
@@ -919,7 +919,7 @@ public:
    * If given View pointer is null or Group already has a View with
    * same name as given View, method is a no-op.
    *
-   * \return pointer to given argument Group object or nullptr if View
+   * \return pointer to the new copied View object or nullptr if a View
    * is not copied into this Group.
    */
   View* deepCopyView(View* view);
@@ -1261,7 +1261,7 @@ public:
    * If given Group pointer is null or Group already has a child Group with
    * same name as given Group, method is a no-op.
    *
-   * \return pointer to given argument Group object or nullptr if Group
+   * \return pointer to the new copied Group object or nullptr if a Group
    * is not copied into this Group.
    */
   Group* copyGroup(Group* group);
@@ -1280,7 +1280,7 @@ public:
    * If given Group pointer is null or Group already has a child Group with
    * same name as given Group, method is a no-op.
    *
-   * \return pointer to given argument Group object or nullptr if Group
+   * \return pointer to the new copied Group object or nullptr if a Group
    * is not copied into this Group.
    */
   Group* deepCopyGroup(Group* group);

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -896,13 +896,33 @@ public:
    * the View is not copied. The new View object is associated with
    * the same data as the original.
    *
-   * If given Group pointer is null or Group already has a child Group with
-   * same name as given Group, method is a no-op.
+   * If given View pointer is null or Group already has a View with
+   * same name as given View, method is a no-op.
    *
-   * \return pointer to given argument Group object or nullptr if Group
-   * is not moved into this Group.
+   * \return pointer to given argument View object or nullptr if View
+   * is not copied into this Group.
    */
   View* copyView(View* view);
+
+  /*!
+   * \brief Create a deep copy of given View object and add it to this Group.
+   *
+   * Note that for Views that use sidre Buffers or external data, the
+   * deep copy performs a copy of the data described by the View
+   * into a new Buffer attached to the destination View. If the source View
+   * describes only part of a Buffer or part of an external array, due to
+   * strides and or offsets into the data, only the values seen by the 
+   * description will be copied into the new View. The new View will have
+   * a Buffer that is the exact size of the number of values that are copied,
+   * with an offset of zero and a stride of one.
+   *
+   * If given View pointer is null or Group already has a View with
+   * same name as given View, method is a no-op.
+   *
+   * \return pointer to given argument Group object or nullptr if View
+   * is not copied into this Group.
+   */
+  View* deepCopyView(View* view);
 
   //@}
 
@@ -1242,9 +1262,28 @@ public:
    * same name as given Group, method is a no-op.
    *
    * \return pointer to given argument Group object or nullptr if Group
-   * is not moved into this Group.
+   * is not copied into this Group.
    */
   Group* copyGroup(Group* group);
+
+  /*!
+   * \brief Create a deep copy of Group hierarchy rooted at given Group and
+   *        make it a child of this Group.
+   *
+   * Note that all Views in the Group hierarchy are deep copied as well.
+   *
+   * The deep copy of the Group creates a duplicate of the entire Group
+   * hierarchy and performs a deep copy of the data described by the Views
+   * in the hierarchy. The Views in the new Group hierarchy will all allocate
+   * and use new Buffers to hold their copied data.
+   *
+   * If given Group pointer is null or Group already has a child Group with
+   * same name as given Group, method is a no-op.
+   *
+   * \return pointer to given argument Group object or nullptr if Group
+   * is not copied into this Group.
+   */
+  Group* deepCopyGroup(Group* group);
 
   //@}
 

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -890,7 +890,8 @@ public:
   View* moveView(View* view);
 
   /*!
-   * \brief Create a copy of given View object and add it to this Group.
+   * \brief Create a (shallow) copy of given View object and add it to this
+   *        Group.
    *
    * Note that View copying is a "shallow" copy; the data associated with
    * the View is not copied. The new View object is associated with
@@ -898,6 +899,8 @@ public:
    *
    * If given View pointer is null or Group already has a View with
    * same name as given View, method is a no-op.
+   *
+   * \sa deepCopyView
    *
    * \return pointer to the new copied View object or nullptr if a View
    * is not successfully copied into this Group.
@@ -922,7 +925,7 @@ public:
    * \return pointer to the new copied View object or nullptr if a View
    * is not copied into this Group.
    */
-  View* deepCopyView(View* view);
+  View* deepCopyView(View* view, int allocID = INVALID_ALLOCATOR_ID);
 
   //@}
 
@@ -1248,8 +1251,8 @@ public:
   Group* moveGroup(Group* group);
 
   /*!
-   * \brief Create a copy of Group hierarchy rooted at given Group and make it
-   *        a child of this Group.
+   * \brief Create a (shallow) copy of Group hierarchy rooted at given
+   *        Group and make it a child of this Group.
    *
    * Note that all Views in the Group hierarchy are copied as well.
    *
@@ -1260,6 +1263,8 @@ public:
    *
    * If given Group pointer is null or Group already has a child Group with
    * same name as given Group, method is a no-op.
+   *
+   * \sa deepCopyGroup
    *
    * \return pointer to the new copied Group object or nullptr if a Group
    * is not copied into this Group.
@@ -1274,16 +1279,22 @@ public:
    *
    * The deep copy of the Group creates a duplicate of the entire Group
    * hierarchy and performs a deep copy of the data described by the Views
-   * in the hierarchy. The Views in the new Group hierarchy will all allocate
-   * and use new Buffers to hold their copied data.
+   * in the hierarchy.
+   *
+   * The Views in the new Group hierarchy will each allocate and use
+   * new Buffers to hold their copied data. Each Buffer will be sized to
+   * receive only the data values seen by the description of the original
+   * View and will have zero offset and a strid of one.
    *
    * If given Group pointer is null or Group already has a child Group with
    * same name as given Group, method is a no-op.
    *
+   * \sa deepCopyGroup
+   *
    * \return pointer to the new copied Group object or nullptr if a Group
    * is not copied into this Group.
    */
-  Group* deepCopyGroup(Group* group);
+  Group* deepCopyGroup(Group* group, int allocID = INVALID_ALLOCATOR_ID);
 
   //@}
 

--- a/src/axom/sidre/core/View.cpp
+++ b/src/axom/sidre/core/View.cpp
@@ -1040,6 +1040,103 @@ void View::copyView(View* copy) const
 /*
  *************************************************************************
  *
+ * PRIVATE method copy the contents of this into a undescribed EMPTY view.
+ *
+ *************************************************************************
+ */
+void View::deepCopyView(View* copy) const
+{
+  SLIC_ASSERT_MSG(copy->m_state == EMPTY && !copy->isDescribed(),
+                  SIDRE_VIEW_LOG_PREPEND
+                    << "deepCopyView can only copy into undescribed view "
+                    << "with empty state.");
+#if 1
+  if(isDescribed())
+  {
+    copy->describe(m_schema.dtype());
+    if(hasBuffer() || m_state == EXTERNAL)
+    {
+      copy->allocate(getTypeID(), getNumElements());
+    }
+  }
+
+  switch(m_state)
+  {
+  case EMPTY:
+    // Nothing more to do
+    break;
+  case STRING:
+  case SCALAR:
+    copy->m_node = m_node;
+    copy->m_state = m_state;
+    copy->m_is_applied = true;
+    break;
+  case EXTERNAL:
+    if(!copy->isAllocated())
+    {
+      copy->allocate();
+    }
+    if(isApplied())
+    {
+      copy->apply();
+    }
+    {
+      IndexType stride = getStride();
+      IndexType src_offset = getOffset();
+      IndexType dst_offset = copy->getOffset();
+      IndexType num_bytes = getBytesPerElement();
+      IndexType j = 0;
+      for(IndexType i = 0; i < getNumElements(); ++i)
+      {
+        char* copy_dst =
+          static_cast<char*>(copy->getVoidPtr()) + (dst_offset + i) * num_bytes;
+        const char* copy_src =
+          static_cast<const char*>(getVoidPtr()) + (src_offset + j) * num_bytes;
+        axom::copy(copy_dst, copy_src, num_bytes);
+
+        j += stride;
+      }
+    }
+    break;
+  case BUFFER:
+    if(isAllocated() && !copy->isAllocated())
+    {
+      copy->allocate();
+    }
+    if(isApplied())
+    {
+      copy->apply();
+    }
+    if(hasBuffer())
+    {
+      IndexType stride = getStride();
+      IndexType src_offset = getOffset();
+      IndexType dst_offset = copy->getOffset();
+      IndexType num_bytes = getBytesPerElement();
+      IndexType j = 0;
+      for(IndexType i = 0; i < getNumElements(); ++i)
+      {
+        char* copy_dst =
+          static_cast<char*>(copy->getVoidPtr()) + (dst_offset + i) * num_bytes;
+        const char* copy_src =
+          static_cast<const char*>(getVoidPtr()) + (src_offset + j) * num_bytes;
+        axom::copy(copy_dst, copy_src, num_bytes);
+
+        j += stride;
+      }
+    }
+    break;
+  default:
+    SLIC_ASSERT_MSG(false,
+                    SIDRE_VIEW_LOG_PREPEND << "View is in unexpected state: "
+                                           << getStateStringName(m_state));
+  }
+#endif
+}
+
+/*
+ *************************************************************************
+ *
  * PRIVATE method returns true if view can allocate data; else false.
  *
  * This method does not need to emit the view state as part of it's

--- a/src/axom/sidre/core/View.cpp
+++ b/src/axom/sidre/core/View.cpp
@@ -1044,7 +1044,7 @@ void View::copyView(View* copy) const
  *
  *************************************************************************
  */
-void View::deepCopyView(View* copy) const
+void View::deepCopyView(View* copy, int allocID) const
 {
   SLIC_ASSERT_MSG(copy->m_state == EMPTY && !copy->isDescribed(),
                   SIDRE_VIEW_LOG_PREPEND
@@ -1056,7 +1056,7 @@ void View::deepCopyView(View* copy) const
     copy->describe(m_schema.dtype());
     if(hasBuffer() || m_state == EXTERNAL)
     {
-      copy->allocate(getTypeID(), getNumElements());
+      copy->allocate(getTypeID(), getNumElements(), allocID);
     }
   }
 
@@ -1074,7 +1074,7 @@ void View::deepCopyView(View* copy) const
   case EXTERNAL:
     if(!copy->isAllocated())
     {
-      copy->allocate();
+      copy->allocate(allocID);
     }
     if(isApplied())
     {
@@ -1101,7 +1101,7 @@ void View::deepCopyView(View* copy) const
   case BUFFER:
     if(isAllocated() && !copy->isAllocated())
     {
-      copy->allocate();
+      copy->allocate(allocID);
     }
     if(isApplied())
     {

--- a/src/axom/sidre/core/View.cpp
+++ b/src/axom/sidre/core/View.cpp
@@ -1050,7 +1050,7 @@ void View::deepCopyView(View* copy) const
                   SIDRE_VIEW_LOG_PREPEND
                     << "deepCopyView can only copy into undescribed view "
                     << "with empty state.");
-#if 1
+
   if(isDescribed())
   {
     copy->describe(m_schema.dtype());
@@ -1131,7 +1131,6 @@ void View::deepCopyView(View* copy) const
                     SIDRE_VIEW_LOG_PREPEND << "View is in unexpected state: "
                                            << getStateStringName(m_state));
   }
-#endif
 }
 
 /*

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -1371,6 +1371,18 @@ private:
   void copyView(View* copy) const;
 
   /*!
+   * \brief Deep copy view contents into an undescribed EMPTY view.
+   *
+   * For SCALAR and STRING the data is copied and the state is preserved.
+   * For BUFFER and EXTERNAL, the data described by this View is copied into a
+   * new Buffer that is of the size needed to hold the copied data. Any
+   * parts of the source Buffer or external array that are not seen due
+   * to offsets and strides in the description will not be copied. The copied
+   * View will have BUFFER state with zero offset and a stride of one.
+   */
+  void deepCopyView(View* copy) const;
+
+  /*!
    * \brief Add view description and references to it's data to a conduit tree.
    */
   void exportTo(conduit::Node& data_holder,

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -1363,7 +1363,7 @@ private:
   }
 
   /*!
-   * \brief Copy view contents into an undescribed EMPTY view.
+   * \brief Copy contents of this View contents into an undescribed EMPTY View.
    *
    * For SCALAR and STRING the data is copied; EXTERNAL,
    * data pointer is copied; BUFFER attaches the buffer.
@@ -1371,7 +1371,8 @@ private:
   void copyView(View* copy) const;
 
   /*!
-   * \brief Deep copy view contents into an undescribed EMPTY view.
+   * \brief Deep copy contents of this View contents into an undescribed
+   * EMPTY View.
    *
    * For SCALAR and STRING the data is copied and the state is preserved.
    * For BUFFER and EXTERNAL, the data described by this View is copied into a

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -1381,7 +1381,7 @@ private:
    * to offsets and strides in the description will not be copied. The copied
    * View will have BUFFER state with zero offset and a stride of one.
    */
-  void deepCopyView(View* copy) const;
+  void deepCopyView(View* copy, int allocID = INVALID_ALLOCATOR_ID) const;
 
   /*!
    * \brief Add view description and references to it's data to a conduit tree.


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following (modify list as needed):
  - Adds deep copy methods for Group and View
  - Addresses #769 

The actual deep copy of buffer data occurs on the Views, with the deep copy of a Group copying the entire hierarchy with deep copies of all Views.

All deep copies of Views with Buffer or external data are copied into a new sidre Buffer attached to the new View.  If the source View's description sees only a part of its Buffer or external array due to offsets or strides, only the elements that are seen by the description will be copied, and the Buffer for the new View will be sized to receive the exact number of elements that are copied.