### PR TITLE
Adds a Quadrilateral primitive

### DIFF
--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -38,6 +38,7 @@ set( primal_headers
     geometry/Tetrahedron.hpp
     geometry/Octahedron.hpp
     geometry/Triangle.hpp
+    geometry/Quadrilateral.hpp
     geometry/Vector.hpp
 
     ## operators

--- a/src/axom/primal/docs/sphinx/primitive.rst
+++ b/src/axom/primal/docs/sphinx/primitive.rst
@@ -6,8 +6,10 @@ Primal includes the following primitives:
 - Point
 - Segment, Ray, Vector
 - Plane, Triangle, Polygon
+- Quadrilateral
 - Sphere
 - Tetrahedron
+- Hexahedron
 - BoundingBox, OrientedBoundingBox
 
 Primal also provides the NumericArray class, which implements arithmetic

--- a/src/axom/primal/geometry/BoundingBox.hpp
+++ b/src/axom/primal/geometry/BoundingBox.hpp
@@ -264,9 +264,9 @@ public:
    *  type. This should work as long as the two Ts are comparable with
    *  operator<().
    */
-  template <typename OtherType>
+  template <typename OtherType, int OtherDims>
   AXOM_HOST_DEVICE bool intersectsWith(
-    const BoundingBox<OtherType, NDIMS>& otherBB) const;
+    const BoundingBox<OtherType, OtherDims>& otherBB) const;
 
   /*!
    * \brief Checks that we have a valid bounding box.
@@ -453,14 +453,16 @@ bool BoundingBox<T, NDIMS>::contains(const BoundingBox<OtherT, NDIMS>& otherBB) 
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-template <typename OtherType>
+template <typename OtherType, int OtherDims>
 AXOM_HOST_DEVICE bool BoundingBox<T, NDIMS>::intersectsWith(
-  const BoundingBox<OtherType, NDIMS>& otherBB) const
+  const BoundingBox<OtherType, OtherDims>& otherBB) const
 {
   bool status = true;
 
   // AABBs cannot intersect if they are separated along any dimension
-  for(int i = 0; i < NDIMS; ++i)
+  constexpr int MinDims = NDIMS < OtherDims ? NDIMS : OtherDims;
+
+  for(int i = 0; i < MinDims; ++i)
   {
     status &= detail::intersect_bbox_bbox(m_min[i],
                                           m_max[i],

--- a/src/axom/primal/geometry/BoundingBox.hpp
+++ b/src/axom/primal/geometry/BoundingBox.hpp
@@ -92,6 +92,15 @@ public:
   explicit BoundingBox(const PointType& pt) : m_min(pt), m_max(pt) { }
 
   /*!
+   * \brief Constructor. Creates a bounding box containing the
+   * initializer list of points.
+   *
+   * \param [in] pts an initializer list containing points
+   */
+  AXOM_HOST_DEVICE
+  explicit BoundingBox(std::initializer_list<PointType> pts);
+
+  /*!
    * \brief Constructor. Creates a bounding box containing the collection of
    * points.
    * \pre pt must point to at least n valid point
@@ -401,6 +410,18 @@ AXOM_HOST_DEVICE bool BoundingBox<T, NDIMS>::contains(
   }
 
   return true;
+}
+
+//------------------------------------------------------------------------------
+template <typename T, int NDIMS>
+AXOM_HOST_DEVICE BoundingBox<T, NDIMS>::BoundingBox(std::initializer_list<PointType> pts)
+{
+  clear();
+
+  for(const auto& pt : pts)
+  {
+    this->addPoint(pt);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/geometry/Quadrilateral.hpp
+++ b/src/axom/primal/geometry/Quadrilateral.hpp
@@ -1,0 +1,260 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_PRIMAL_QUADRILATERAL_HPP_
+#define AXOM_PRIMAL_QUADRILATERAL_HPP_
+
+#include "axom/config.hpp"
+#include "axom/core.hpp"
+#include "axom/slic/interface/slic.hpp"
+#include "axom/fmt.hpp"
+
+#include "axom/primal/constants.hpp"
+#include "axom/primal/geometry/Point.hpp"
+#include "axom/primal/geometry/Triangle.hpp"
+
+#include <cmath>
+#include <ostream>
+
+namespace axom
+{
+namespace primal
+{
+// Forward declare the templated classes and operator functions
+template <typename T, int NDIMS>
+class Quadrilateral;
+
+/**
+ * \brief Overloaded output operator for quadrilaterals
+ */
+template <typename T, int NDIMS>
+std::ostream& operator<<(std::ostream& os, const Quadrilateral<T, NDIMS>& quad);
+
+/*!
+ * \accelerated
+ * \class Quadrilateral
+ *
+ * \brief Represents a quadrilateral geometric shape defined by four points.
+ *
+ * \accelerated
+ *
+ * \tparam T the coordinate type, e.g., double, float, etc.
+ * \tparam NDIMS the number of dimensions
+ *
+ * There are four vertices in the quadrilateral, labeled P through S as the
+ * constructor's arguments.  They are accessible using the square-brackets
+ * operator, with P being index 0, Q index 1, R index 2, and S index 3.
+ *
+ * Here's a diagram showing a square with the labeled vertices.
+ *
+ * \verbatim
+ *
+ * Q +---------+ R       +y
+ *   |         |         
+ *   |         |          ^
+ *   |         |          |
+ *   |         |          |
+ * P +---------+ S        -----> +x
+ *
+ * \endverbatim
+ */
+template <typename T, int NDIMS>
+class Quadrilateral
+{
+public:
+  using PointType = Point<T, NDIMS>;
+  using TriangleType = Triangle<T, NDIMS>;
+
+  static constexpr int DIM = NDIMS;
+  static constexpr int NUM_QUAD_VERTS = 4;
+
+public:
+  /// \brief Default constructor. Creates a degenerate quadrilateral.
+  AXOM_HOST_DEVICE
+  Quadrilateral() = default;
+
+  /*!
+   * \brief Custom Constructor. Creates a quadrilateral from the 4 points p, q, r, s.
+   * \param [in] p point instance corresponding to vertex P of the quadrilateral.
+   * \param [in] q point instance corresponding to vertex Q of the quadrilateral.
+   * \param [in] r point instance corresponding to vertex R of the quadrilateral.
+   * \param [in] s point instance corresponding to vertex S of the quadrilateral.
+   */
+  AXOM_HOST_DEVICE
+  Quadrilateral(const PointType& p,
+                const PointType& q,
+                const PointType& r,
+                const PointType& s)
+    : m_points {p, q, r, s}
+  { }
+
+  /*!
+   * \brief Quadrilateral constructor from an array of Points
+   *
+   * \param [in] pts An array containing at least 4 Points.
+   *
+   * \note It is the responsiblity of the caller to pass
+   *       an array with at least 4 Points
+   */
+  AXOM_HOST_DEVICE
+  explicit Quadrilateral(const PointType* pts)
+  {
+    for (int i = 0; i < NUM_QUAD_VERTS; i++)
+    {
+      m_points[i] = pts[i];
+    }
+  }
+
+  /*!
+   * \brief Quadrilateral constructor from an Array of Points.
+   *
+   * \param [in] pts An ArrayView containing 4 Points.
+   */
+  AXOM_HOST_DEVICE
+  explicit Quadrilateral(const axom::ArrayView<PointType> pts)
+  {
+    SLIC_ASSERT(pts.size() == NUM_QUAD_VERTS);
+
+    for(int i = 0; i < NUM_QUAD_VERTS; i++)
+    {
+      m_points[i] = pts[i];
+    }
+  }
+
+  /*!
+   * \brief Quadrilateral constructor from an initializer list of Points
+   *
+   * \param [in] pts an initializer list containing 4 Points
+   */
+  AXOM_HOST_DEVICE
+  explicit Quadrilateral(std::initializer_list<PointType> pts)
+  {
+    SLIC_ASSERT(pts.size() == NUM_QUAD_VERTS);
+
+    int i = 0;
+    for(const auto& pt : pts)
+    {
+      m_points[i] = pt;
+      i++;
+    }
+  }
+
+  /*!
+   * \brief Index operator to get the i^th vertex
+   * \param idx The index of the desired vertex
+   * \pre idx is 0, 1 or 2
+   */
+  AXOM_HOST_DEVICE
+  PointType& operator[](int idx)
+  {
+    SLIC_ASSERT(idx >= 0 && idx < NUM_QUAD_VERTS);
+    return m_points[idx];
+  }
+
+  /*!
+   * \brief Index operator to get the i^th vertex
+   * \param idx The index of the desired vertex
+   * \pre idx is 0, 1 or 2
+   */
+  AXOM_HOST_DEVICE
+  const PointType& operator[](int idx) const
+  {
+    SLIC_ASSERT(idx >= 0 && idx < NUM_QUAD_VERTS);
+    return m_points[idx];
+  }
+
+  /// \brief Returns the area of the quadrilateral (2D specialization)
+  template <int TDIM = NDIMS>
+  AXOM_HOST_DEVICE typename std::enable_if<TDIM == 2, double>::type area() const
+  {
+    return axom::utilities::abs(signedArea());
+  }
+
+  /**
+   * \brief Returns the signed area of a 2D quadrilateral
+   *
+   * The area is positive when the vertices are oriented counter-clockwise.
+   * \note This function is only available for quadrilaterals in 2D since
+   * signed areas don't make sense for 3D quadrilaterals
+   *
+   * Compute the signed area by dividing the quadrilateral into two triangles
+   * as shown below and summing their signed area
+   *
+   * \verbatim
+   *
+   * q +----+ r       +y
+   *   |   /|         
+   *   |  / |          ^
+   *   | /  |          |
+   *   |/   |          |
+   * p +----+ s        -----> +x
+   *
+   * \endverbatim
+   */
+  template <int TDIM = NDIMS>
+  AXOM_HOST_DEVICE typename std::enable_if<TDIM == 2, double>::type signedArea() const
+  {
+    const PointType& p = m_points[0];
+    const PointType& q = m_points[1];
+    const PointType& r = m_points[2];
+    const PointType& s = m_points[3];
+
+    // clang-format off
+    return TriangleType{p, q, r}.signedArea() +
+           TriangleType{r, s, p}.signedArea();
+    // clang-format on
+  }
+
+  /*!
+   * \brief Returns the volume of the quadrilateral (synonym for area())
+   * \sa area()
+   */
+  AXOM_HOST_DEVICE double volume() const { return area(); }
+
+  /*!
+   * \brief Returns the signed volume of a 2D quadrilateral (synonym for signedArea())
+   * \sa signedArea()
+   */
+  template <int TDIM = NDIMS>
+  AXOM_HOST_DEVICE typename std::enable_if<TDIM == 2, double>::type signedVolume() const
+  {
+    return signedArea();
+  }
+
+  /*!
+   * \brief Simple formatted print of a triangle instance
+   * \param os The output stream to write to
+   * \return A reference to the modified ostream
+   */
+  std::ostream& print(std::ostream& os) const
+  {
+    os << "{" << m_points[0] << " " << m_points[1] << " " << m_points[2] << " " << m_points[3] << "}";
+
+    return os;
+  }
+
+private:
+  PointType m_points[NUM_QUAD_VERTS];
+};
+
+//------------------------------------------------------------------------------
+/// Free functions implementing Quadrilateral's operators
+//------------------------------------------------------------------------------
+template <typename T, int NDIMS>
+std::ostream& operator<<(std::ostream& os, const Quadrilateral<T, NDIMS>& quad)
+{
+  quad.print(os);
+  return os;
+}
+
+}  // namespace primal
+}  // namespace axom
+
+/// Overload to format a primal::Quadrilateral using fmt
+template <typename T, int NDIMS>
+struct axom::fmt::formatter<axom::primal::Quadrilateral<T, NDIMS>> : ostream_formatter
+{ };
+
+#endif  // AXOM_PRIMAL_QUADRILATERAL_HPP_

--- a/src/axom/primal/operators/compute_bounding_box.hpp
+++ b/src/axom/primal/operators/compute_bounding_box.hpp
@@ -21,6 +21,7 @@
 #include "axom/primal/geometry/Hexahedron.hpp"
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Triangle.hpp"
+#include "axom/primal/geometry/Quadrilateral.hpp"
 #include "axom/primal/geometry/Vector.hpp"
 #include "axom/primal/geometry/OrientedBoundingBox.hpp"
 
@@ -119,6 +120,18 @@ AXOM_HOST_DEVICE BoundingBox<T, NDIMS> compute_bounding_box(
     res.addPoint(tri[i]);
   }
   return res;
+}
+
+/*!
+ * \brief Creates a bounding box around a Quadrilateral
+ * \accelerated
+ * \param [in] quad The Quadrilateral
+ */
+template <typename T, int NDIMS>
+AXOM_HOST_DEVICE BoundingBox<T, NDIMS> compute_bounding_box(
+  const Quadrilateral<T, NDIMS> &quad)
+{
+  return BoundingBox<T, NDIMS>{quad[0], quad[1], quad[2], quad[3]};
 }
 
 /*!

--- a/src/axom/primal/tests/CMakeLists.txt
+++ b/src/axom/primal/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set( primal_tests
     primal_tetrahedron.cpp
     primal_octahedron.cpp
     primal_triangle.cpp
+    primal_quadrilateral.cpp
     primal_vector.cpp
     primal_winding_number.cpp
     primal_zip.cpp

--- a/src/axom/primal/tests/primal_compute_bounding_box.cpp
+++ b/src/axom/primal/tests/primal_compute_bounding_box.cpp
@@ -129,6 +129,30 @@ TEST(primal_compute_bounding_box, merge_aligned_box_test)
   EXPECT_TRUE(bbox5.contains(bbox4));
 }
 
+TEST(primal_compute_bounding_box, compute_quad_2d_box_test)
+{
+  constexpr int DIM = 2;
+  using CoordinateType = double;
+  using PointType = primal::Point<CoordinateType, DIM>;
+  using BoundingBoxType = primal::BoundingBox<CoordinateType, DIM>;
+  using QuadrilateralType = primal::Octahedron<CoordinateType, DIM>;
+
+  PointType p{-1.0, 0.1};
+  PointType q{ 0.0, 1.0};
+  PointType r{ 2.0, 0.0};
+  PointType s{-0.1, 0.5};
+
+  QuadrilateralType quad{p, q, r, s};
+  BoundingBoxType box = primal::compute_bounding_box<CoordinateType, DIM>(quad);
+
+  EXPECT_TRUE(box.contains(p));
+  EXPECT_TRUE(box.contains(q));
+  EXPECT_TRUE(box.contains(r));
+  EXPECT_TRUE(box.contains(s));
+  EXPECT_EQ(box.getMin(), (PointType{-1.0, 0.0}));
+  EXPECT_EQ(box.getMax(), (PointType{2.0, 1.0}));
+}
+
 TEST(primal_compute_bounding_box, compute_oct_box_test)
 {
   static const int DIM = 3;

--- a/src/axom/primal/tests/primal_quadrilateral.cpp
+++ b/src/axom/primal/tests/primal_quadrilateral.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/config.hpp"
+#include "axom/slic.hpp"
+#include "axom/primal.hpp"
+
+#include "gtest/gtest.h"
+
+namespace primal = axom::primal;
+
+TEST(primal_quadrilateral, area_2D)
+{
+  constexpr int DIM = 2;
+  constexpr double EPS = 1e-12;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using QuadrilateralType = primal::Quadrilateral<CoordType, DIM>;
+
+  // This is a concave quadrilateral
+  QuadrilateralType quad{Point{-1.0, 0.1},
+                         Point{ 0.0, 1.0},
+                         Point{ 2.0, 0.0},
+                         Point{-0.1, 0.5}};
+
+  EXPECT_NEAR(0.755, quad.area(), EPS);
+}
+
+//----------------------------------------------------------------------
+//----------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  axom::slic::SimpleLogger logger(axom::slic::message::Info);
+
+  int result = RUN_ALL_TESTS();
+  return result;
+}

--- a/src/axom/primal/tests/primal_quadrilateral.cpp
+++ b/src/axom/primal/tests/primal_quadrilateral.cpp
@@ -20,12 +20,16 @@ TEST(primal_quadrilateral, area_2D)
   using QuadrilateralType = primal::Quadrilateral<CoordType, DIM>;
 
   // This is a concave quadrilateral
-  QuadrilateralType quad{Point{-1.0, 0.1},
-                         Point{ 0.0, 1.0},
-                         Point{ 2.0, 0.0},
-                         Point{-0.1, 0.5}};
+  QuadrilateralType quad{PointType{-1.0, 0.1},
+                         PointType{ 0.0, 1.0},
+                         PointType{ 2.0, 0.0},
+                         PointType{-0.1, 0.5}};
 
-  EXPECT_NEAR(0.755, quad.area(), EPS);
+  const CoordType signedArea = quad.signedArea();
+  const CoordType area = quad.area();
+
+  EXPECT_NEAR(-0.755, signedArea, EPS);
+  EXPECT_NEAR(0.755, area, EPS);
 }
 
 //----------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_quadrilateral.cpp
+++ b/src/axom/primal/tests/primal_quadrilateral.cpp
@@ -15,9 +15,9 @@ TEST(primal_quadrilateral, area_2D)
 {
   constexpr int DIM = 2;
   constexpr double EPS = 1e-12;
-  using CoordType = double;
-  using PointType = primal::Point<CoordType, DIM>;
-  using QuadrilateralType = primal::Quadrilateral<CoordType, DIM>;
+  using CoordinateType = double;
+  using PointType = primal::Point<CoordinateType, DIM>;
+  using QuadrilateralType = primal::Quadrilateral<CoordinateType, DIM>;
 
   // This is a concave quadrilateral
   QuadrilateralType quad{PointType{-1.0, 0.1},
@@ -25,8 +25,8 @@ TEST(primal_quadrilateral, area_2D)
                          PointType{ 2.0, 0.0},
                          PointType{-0.1, 0.5}};
 
-  const CoordType signedArea = quad.signedArea();
-  const CoordType area = quad.area();
+  const CoordinateType signedArea = quad.signedArea();
+  const CoordinateType area = quad.area();
 
   EXPECT_NEAR(-0.755, signedArea, EPS);
   EXPECT_NEAR(0.755, area, EPS);


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following:
  - Adds Quadrilateral primitive
  - Adds BoundingBox constructor that takes an initializer list
  - Extends BoundingBox::intersectsWith to work with a bounding box of a different dimension
  - Adds compute_bounding_box operator for Quadrilateral