### PR TITLE
Fixed OpenMP and CUDA guards

### DIFF
--- a/src/axom/quest/interface/signed_distance.cpp
+++ b/src/axom/quest/interface/signed_distance.cpp
@@ -342,14 +342,14 @@ void signed_distance_set_execution_space(SignedDistExec exec_space)
     signed_distance_initialized(),
     "signed distance query already initialized; setting option has no effect!");
 
-#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
+#if !defined(AXOM_USE_OPENMP) && !defined(AXOM_USE_RAJA)
   if(exec_space == SignedDistExec::OpenMP)
   {
     SLIC_ERROR("Signed distance query not compiled with OpenMP support");
   }
 #endif
 
-#if defined(AXOM_USE_GPU) && defined(AXOM_USE_RAJA)
+#if !defined(AXOM_USE_GPU) && !defined(AXOM_USE_RAJA)
   if(exec_space == SignedDistExec::GPU)
   {
     SLIC_ERROR("Signed distance query not compiled with GPU support");


### PR DESCRIPTION
Fixes inadvertent change to OpenMP and CUDA guards inside signed_distance_set_execution_space, from commit 
 c7d27a1 - switched the guards from #ifndef to #ifdef
