### PR TITLE
Build configs with +scr

### DIFF
--- a/host-configs/quartz-toss_4_x86_64_ib-clang@14.0.6.cmake
+++ b/host-configs/quartz-toss_4_x86_64_ib-clang@14.0.6.cmake
@@ -4,7 +4,7 @@
 # CMake executable path: /usr/tce/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/clang-14.0.6/umpire-2023.06.0-ubadmsj3l2zavunhkkt7nxevkpmssdvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/clang-14.0.6/raja-2023.06.0-55ypap77cpmjgq24vaquanhsshjm3gqh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/clang-14.0.6/camp-2023.06.0-e6mknahsrmbbifbfv3umemetvqzoh3he;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/clang-14.0.6/mfem-4.5.2-lwet4c3edrdvipij3r4itukmse2jklvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/clang-14.0.6/hypre-2.24.0-bwh42bebp4hiuwzlwcthpgkawape6dp3;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/clang-14.0.6/conduit-0.8.8-inqrhwboacvngevqbvavhpisx4aeqpvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/clang-14.0.6/parmetis-4.0.3-jthqwflsj5bpe6onwsb5r2zi5wbx6pq4;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/clang-14.0.6/metis-5.1.0-imzig3eih3itpztvvk4yildzgq6aeelo;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/clang-14.0.6/hdf5-1.8.22-5mfm2r7fo5krpj7vvmayz24qksnluryl;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/clang-14.0.6/c2c-1.8.0-5smd5ktj7yjc2egeyum4t5vlwmw3jktt;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/clang-14.0.6/gmake-4.4.1-6lgy76r7dbvqm6mbwb2jkpcuycf7tb27;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/clang-14.0.6/blt-0.5.3-xa3bmu75nkolqiewb5ftk5tp2jpzw57n;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-clang-14.0.6;/usr/tce;/usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6;/usr/tce/packages/clang/clang-14.0.6" CACHE PATH "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/umpire-2023.06.0-ubadmsj3l2zavunhkkt7nxevkpmssdvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/scr-3.0.1-5edtc4k2wstti2dh4kp2tno7rmwr3lyd;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/spath-0.2.0-gvlnzegcdph7ien3w4tjcxevblf2xe4r;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/libyogrt-1.33-3joihut3xh67qmtalrqadzujfzxwpodj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/er-0.2.0-befo66qsdjjulpnhaxvhk4uil45ynd6u;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/shuffile-0.2.0-j5blkpa2h3keb562qb5pdnfiuzyaecfd;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/redset-0.2.0-tllpyzklkik7oa32us3tigl7vdvil42o;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/rankstr-0.1.0-jkgwo3kyvegaapdtm67mg4aknu44foyn;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/dtcmp-1.1.4-u376uqcnt3y7ebu5ocfvk7bovkr2febv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/lwgrp-1.0.5-am6sfml4trdhzlds365vbepezgdvdocz;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/axl-0.7.1-t7yboywzjziqb3hbgidynhbk5vd33jc7;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/kvtree-1.3.0-4zcbvvaqpbkdt7xc4pbu7urlkdywjjd7;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/raja-2023.06.0-55ypap77cpmjgq24vaquanhsshjm3gqh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/camp-2023.06.0-e6mknahsrmbbifbfv3umemetvqzoh3he;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/mfem-4.5.2-lwet4c3edrdvipij3r4itukmse2jklvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/hypre-2.24.0-bwh42bebp4hiuwzlwcthpgkawape6dp3;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/conduit-0.8.8-inqrhwboacvngevqbvavhpisx4aeqpvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/parmetis-4.0.3-jthqwflsj5bpe6onwsb5r2zi5wbx6pq4;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/metis-5.1.0-imzig3eih3itpztvvk4yildzgq6aeelo;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/hdf5-1.8.22-5mfm2r7fo5krpj7vvmayz24qksnluryl;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/c2c-1.8.0-5smd5ktj7yjc2egeyum4t5vlwmw3jktt;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/gmake-4.4.1-6lgy76r7dbvqm6mbwb2jkpcuycf7tb27;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6/blt-0.5.3-xa3bmu75nkolqiewb5ftk5tp2jpzw57n;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-clang-14.0.6;/usr/tce;/usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6;/usr/tce/packages/clang/clang-14.0.6" CACHE PATH "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -15,11 +15,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
 
 else()
 
@@ -69,7 +69,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_50_23/clang-14.0.6" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/clang-14.0.6" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.8-inqrhwboacvngevqbvavhpisx4aeqpvy" CACHE PATH "")
 
@@ -87,7 +87,27 @@ set(UMPIRE_DIR "${TPL_ROOT}/umpire-2023.06.0-ubadmsj3l2zavunhkkt7nxevkpmssdvy" C
 
 set(CAMP_DIR "${TPL_ROOT}/camp-2023.06.0-e6mknahsrmbbifbfv3umemetvqzoh3he" CACHE PATH "")
 
-# scr not built
+set(SCR_DIR "${TPL_ROOT}/scr-3.0.1-5edtc4k2wstti2dh4kp2tno7rmwr3lyd" CACHE PATH "")
+
+set(KVTREE_DIR "${TPL_ROOT}/kvtree-1.3.0-4zcbvvaqpbkdt7xc4pbu7urlkdywjjd7" CACHE PATH "")
+
+set(DTCMP_DIR "${TPL_ROOT}/dtcmp-1.1.4-u376uqcnt3y7ebu5ocfvk7bovkr2febv" CACHE PATH "")
+
+set(SPATH_DIR "${TPL_ROOT}/spath-0.2.0-gvlnzegcdph7ien3w4tjcxevblf2xe4r" CACHE PATH "")
+
+set(AXL_DIR "${TPL_ROOT}/axl-0.7.1-t7yboywzjziqb3hbgidynhbk5vd33jc7" CACHE PATH "")
+
+set(LWGRP_DIR "${TPL_ROOT}/lwgrp-1.0.5-am6sfml4trdhzlds365vbepezgdvdocz" CACHE PATH "")
+
+set(ER_DIR "${TPL_ROOT}/er-0.2.0-befo66qsdjjulpnhaxvhk4uil45ynd6u" CACHE PATH "")
+
+set(RANKSTR_DIR "${TPL_ROOT}/rankstr-0.1.0-jkgwo3kyvegaapdtm67mg4aknu44foyn" CACHE PATH "")
+
+set(REDSET_DIR "${TPL_ROOT}/redset-0.2.0-tllpyzklkik7oa32us3tigl7vdvil42o" CACHE PATH "")
+
+set(SHUFFILE_DIR "${TPL_ROOT}/shuffile-0.2.0-j5blkpa2h3keb562qb5pdnfiuzyaecfd" CACHE PATH "")
+
+set(LIBYOGRT_DIR "${TPL_ROOT}/libyogrt-1.33-3joihut3xh67qmtalrqadzujfzxwpodj" CACHE PATH "")
 
 #------------------------------------------------------------------------------
 # Devtools

--- a/host-configs/quartz-toss_4_x86_64_ib-gcc@10.3.1.cmake
+++ b/host-configs/quartz-toss_4_x86_64_ib-gcc@10.3.1.cmake
@@ -4,7 +4,7 @@
 # CMake executable path: /usr/tce/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/gcc-10.3.1/umpire-2023.06.0-z2ts74flz56i67azbbp5zyiwvwgwucrr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/gcc-10.3.1/raja-2023.06.0-ca64lzglcihqwwjcmxuzfdvg7bhsd5rq;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/gcc-10.3.1/camp-2023.06.0-k4v6kc3zhnika36o2jvhncwiwcaifxqp;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/gcc-10.3.1/mfem-4.5.2-uyempb4k6nefxh36lxnbfb2dynpyaezr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/gcc-10.3.1/hypre-2.24.0-lof7hdy7wsyuei436d6uhilprsgmr3ik;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/gcc-10.3.1/conduit-0.8.8-wngwwhpllk2gjewlizsk4plakvdu4beu;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/gcc-10.3.1/parmetis-4.0.3-lq6aryhur6qn3trc2qxizvz4nae5ngzf;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/gcc-10.3.1/metis-5.1.0-pyrzcrzqvl6q27kk637o2nwi3j7ibseb;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/gcc-10.3.1/hdf5-1.8.22-wikz2sxdo4zf76fdfl5do4mekkixf4yv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/gcc-10.3.1/c2c-1.8.0-bsohtsh5a73tmmxlndgjuhzz6lzoif5j;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/gcc-10.3.1/gmake-4.4.1-y2kaxrqjbg3dcwo7dzfphztusfjqoowq;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/gcc-10.3.1/blt-0.5.3-iljv7wrfi4r5i4drs4yf65rgsuunaxjn;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1;/usr/tce;/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1" CACHE PATH "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/umpire-2023.06.0-z2ts74flz56i67azbbp5zyiwvwgwucrr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/scr-3.0.1-znr5hvdmrpg2wwtcrepv3bzh32visddj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/spath-0.2.0-scp7lun3jtdgorfmd4mzhtieqkjko57q;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/libyogrt-1.33-riegwpsbfjywz6pumvit2eadroiosowy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/er-0.2.0-m7mypt2brwrodmfun3ya2cwpkuwpccnv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/shuffile-0.2.0-74ysb2qi6xkrx7u5vsa2jnmcqof3q4je;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/redset-0.2.0-7bhg5tua2jns5ob7r6stbgitzlfggdax;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/rankstr-0.1.0-yuunbkeetjd4y563p4dzxp23rsdcc6tr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/dtcmp-1.1.4-bk55ioptacxzxnpxcgu27vwk2nacb35s;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/lwgrp-1.0.5-zhpxnopjtpr5cchaqufivi2sn4crkgwn;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/axl-0.7.1-b3zz33f7lmeal5thbfyuc6cmbdfek2vv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/kvtree-1.3.0-oeqjobwdjxemywgc77pfuv4nnpxk6buj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/raja-2023.06.0-ca64lzglcihqwwjcmxuzfdvg7bhsd5rq;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/camp-2023.06.0-k4v6kc3zhnika36o2jvhncwiwcaifxqp;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/mfem-4.5.2-uyempb4k6nefxh36lxnbfb2dynpyaezr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/hypre-2.24.0-lof7hdy7wsyuei436d6uhilprsgmr3ik;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/conduit-0.8.8-wngwwhpllk2gjewlizsk4plakvdu4beu;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/parmetis-4.0.3-lq6aryhur6qn3trc2qxizvz4nae5ngzf;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/metis-5.1.0-pyrzcrzqvl6q27kk637o2nwi3j7ibseb;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/hdf5-1.8.22-wikz2sxdo4zf76fdfl5do4mekkixf4yv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/c2c-1.8.0-bsohtsh5a73tmmxlndgjuhzz6lzoif5j;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/gmake-4.4.1-y2kaxrqjbg3dcwo7dzfphztusfjqoowq;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1/blt-0.5.3-iljv7wrfi4r5i4drs4yf65rgsuunaxjn;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1;/usr/tce;/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1" CACHE PATH "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -15,11 +15,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/spack/lib/spack/env/gcc/g++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
 
 else()
 
@@ -67,7 +67,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_13_04_53/gcc-10.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/gcc-10.3.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.8-wngwwhpllk2gjewlizsk4plakvdu4beu" CACHE PATH "")
 
@@ -85,7 +85,27 @@ set(UMPIRE_DIR "${TPL_ROOT}/umpire-2023.06.0-z2ts74flz56i67azbbp5zyiwvwgwucrr" C
 
 set(CAMP_DIR "${TPL_ROOT}/camp-2023.06.0-k4v6kc3zhnika36o2jvhncwiwcaifxqp" CACHE PATH "")
 
-# scr not built
+set(SCR_DIR "${TPL_ROOT}/scr-3.0.1-znr5hvdmrpg2wwtcrepv3bzh32visddj" CACHE PATH "")
+
+set(KVTREE_DIR "${TPL_ROOT}/kvtree-1.3.0-oeqjobwdjxemywgc77pfuv4nnpxk6buj" CACHE PATH "")
+
+set(DTCMP_DIR "${TPL_ROOT}/dtcmp-1.1.4-bk55ioptacxzxnpxcgu27vwk2nacb35s" CACHE PATH "")
+
+set(SPATH_DIR "${TPL_ROOT}/spath-0.2.0-scp7lun3jtdgorfmd4mzhtieqkjko57q" CACHE PATH "")
+
+set(AXL_DIR "${TPL_ROOT}/axl-0.7.1-b3zz33f7lmeal5thbfyuc6cmbdfek2vv" CACHE PATH "")
+
+set(LWGRP_DIR "${TPL_ROOT}/lwgrp-1.0.5-zhpxnopjtpr5cchaqufivi2sn4crkgwn" CACHE PATH "")
+
+set(ER_DIR "${TPL_ROOT}/er-0.2.0-m7mypt2brwrodmfun3ya2cwpkuwpccnv" CACHE PATH "")
+
+set(RANKSTR_DIR "${TPL_ROOT}/rankstr-0.1.0-yuunbkeetjd4y563p4dzxp23rsdcc6tr" CACHE PATH "")
+
+set(REDSET_DIR "${TPL_ROOT}/redset-0.2.0-7bhg5tua2jns5ob7r6stbgitzlfggdax" CACHE PATH "")
+
+set(SHUFFILE_DIR "${TPL_ROOT}/shuffile-0.2.0-74ysb2qi6xkrx7u5vsa2jnmcqof3q4je" CACHE PATH "")
+
+set(LIBYOGRT_DIR "${TPL_ROOT}/libyogrt-1.33-riegwpsbfjywz6pumvit2eadroiosowy" CACHE PATH "")
 
 #------------------------------------------------------------------------------
 # Devtools

--- a/host-configs/quartz-toss_4_x86_64_ib-intel@2022.1.0.cmake
+++ b/host-configs/quartz-toss_4_x86_64_ib-intel@2022.1.0.cmake
@@ -4,7 +4,7 @@
 # CMake executable path: /usr/tce/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/intel-2022.1.0/umpire-2023.06.0-6wmifjy5c2er4kkfqw7m5s4in7esiln5;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/intel-2022.1.0/raja-2023.06.0-urtfojwbjummyvyev7k4zn2oix53f4up;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/intel-2022.1.0/camp-2023.06.0-ovewmmz43udq34jrdlokh2zuzgkzrum4;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/intel-2022.1.0/mfem-4.5.2-dbvjel6jhwnwf6wzm76w6ghbjpy3v4gj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/intel-2022.1.0/hypre-2.24.0-qdjyl5ibcpl4nxb6t5godfgvi5bb6hac;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/intel-2022.1.0/conduit-0.8.8-22refnw4twba4zznewcuczky2udimj7i;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/intel-2022.1.0/parmetis-4.0.3-nqxoj5gqogj32hfo5ognkcb6vg24zdlc;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/intel-2022.1.0/metis-5.1.0-tb5bijmooj2d6d2npjpajcj4fyu4yd4y;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/intel-2022.1.0/hdf5-1.8.22-6oeginq7kyyix35utjgsfxeghcnujtpg;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/intel-2022.1.0/c2c-1.8.0-gvlftgplgmtput3k4fy2nssecldmmlsa;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/intel-2022.1.0/gmake-4.4.1-e3r4ry6vgi7zp4mbwfokypkutqwpctek;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/intel-2022.1.0/blt-0.5.3-i7qltms7ksyz4xltznzbtsafywrykq7b;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-intel-2022.1.0;/usr/tce" CACHE PATH "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/intel-2022.1.0/umpire-2023.06.0-6wmifjy5c2er4kkfqw7m5s4in7esiln5;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/intel-2022.1.0/raja-2023.06.0-urtfojwbjummyvyev7k4zn2oix53f4up;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/intel-2022.1.0/camp-2023.06.0-ovewmmz43udq34jrdlokh2zuzgkzrum4;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/intel-2022.1.0/mfem-4.5.2-dbvjel6jhwnwf6wzm76w6ghbjpy3v4gj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/intel-2022.1.0/hypre-2.24.0-qdjyl5ibcpl4nxb6t5godfgvi5bb6hac;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/intel-2022.1.0/conduit-0.8.8-22refnw4twba4zznewcuczky2udimj7i;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/intel-2022.1.0/parmetis-4.0.3-nqxoj5gqogj32hfo5ognkcb6vg24zdlc;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/intel-2022.1.0/metis-5.1.0-tb5bijmooj2d6d2npjpajcj4fyu4yd4y;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/intel-2022.1.0/hdf5-1.8.22-6oeginq7kyyix35utjgsfxeghcnujtpg;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/intel-2022.1.0/c2c-1.8.0-gvlftgplgmtput3k4fy2nssecldmmlsa;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/intel-2022.1.0/gmake-4.4.1-e3r4ry6vgi7zp4mbwfokypkutqwpctek;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/intel-2022.1.0/blt-0.5.3-i7qltms7ksyz4xltznzbtsafywrykq7b;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-intel-2022.1.0;/usr/tce" CACHE PATH "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -15,11 +15,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/spack/lib/spack/env/intel/icc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/spack/lib/spack/env/intel/icc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/spack/lib/spack/env/intel/icpc" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/spack/lib/spack/env/intel/icpc" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/spack/lib/spack/env/intel/ifort" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/spack/lib/spack/env/intel/ifort" CACHE PATH "")
 
 else()
 
@@ -67,7 +67,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_14_27_32/intel-2022.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_31_08_54_50/intel-2022.1.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.8-22refnw4twba4zznewcuczky2udimj7i" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_4_x86_64_ib-clang@14.0.6.cmake
+++ b/host-configs/rzgenie-toss_4_x86_64_ib-clang@14.0.6.cmake
@@ -4,7 +4,7 @@
 # CMake executable path: /usr/tce/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/clang-14.0.6/umpire-2023.06.0-ubadmsj3l2zavunhkkt7nxevkpmssdvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/clang-14.0.6/raja-2023.06.0-55ypap77cpmjgq24vaquanhsshjm3gqh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/clang-14.0.6/camp-2023.06.0-e6mknahsrmbbifbfv3umemetvqzoh3he;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/clang-14.0.6/mfem-4.5.2-lwet4c3edrdvipij3r4itukmse2jklvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/clang-14.0.6/hypre-2.24.0-bwh42bebp4hiuwzlwcthpgkawape6dp3;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/clang-14.0.6/conduit-0.8.8-inqrhwboacvngevqbvavhpisx4aeqpvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/clang-14.0.6/parmetis-4.0.3-jthqwflsj5bpe6onwsb5r2zi5wbx6pq4;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/clang-14.0.6/metis-5.1.0-imzig3eih3itpztvvk4yildzgq6aeelo;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/clang-14.0.6/hdf5-1.8.22-5mfm2r7fo5krpj7vvmayz24qksnluryl;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/clang-14.0.6/c2c-1.8.0-5smd5ktj7yjc2egeyum4t5vlwmw3jktt;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/clang-14.0.6/gmake-4.4.1-6lgy76r7dbvqm6mbwb2jkpcuycf7tb27;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/clang-14.0.6/blt-0.5.3-xa3bmu75nkolqiewb5ftk5tp2jpzw57n;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-clang-14.0.6;/usr/tce;/usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6;/usr/tce/packages/clang/clang-14.0.6" CACHE PATH "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/umpire-2023.06.0-ubadmsj3l2zavunhkkt7nxevkpmssdvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/scr-3.0.1-5edtc4k2wstti2dh4kp2tno7rmwr3lyd;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/spath-0.2.0-gvlnzegcdph7ien3w4tjcxevblf2xe4r;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/libyogrt-1.33-3joihut3xh67qmtalrqadzujfzxwpodj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/er-0.2.0-befo66qsdjjulpnhaxvhk4uil45ynd6u;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/shuffile-0.2.0-j5blkpa2h3keb562qb5pdnfiuzyaecfd;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/redset-0.2.0-tllpyzklkik7oa32us3tigl7vdvil42o;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/rankstr-0.1.0-jkgwo3kyvegaapdtm67mg4aknu44foyn;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/dtcmp-1.1.4-u376uqcnt3y7ebu5ocfvk7bovkr2febv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/lwgrp-1.0.5-am6sfml4trdhzlds365vbepezgdvdocz;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/axl-0.7.1-t7yboywzjziqb3hbgidynhbk5vd33jc7;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/kvtree-1.3.0-4zcbvvaqpbkdt7xc4pbu7urlkdywjjd7;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/raja-2023.06.0-55ypap77cpmjgq24vaquanhsshjm3gqh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/camp-2023.06.0-e6mknahsrmbbifbfv3umemetvqzoh3he;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/mfem-4.5.2-lwet4c3edrdvipij3r4itukmse2jklvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/hypre-2.24.0-bwh42bebp4hiuwzlwcthpgkawape6dp3;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/conduit-0.8.8-inqrhwboacvngevqbvavhpisx4aeqpvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/parmetis-4.0.3-jthqwflsj5bpe6onwsb5r2zi5wbx6pq4;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/metis-5.1.0-imzig3eih3itpztvvk4yildzgq6aeelo;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/hdf5-1.8.22-5mfm2r7fo5krpj7vvmayz24qksnluryl;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/c2c-1.8.0-5smd5ktj7yjc2egeyum4t5vlwmw3jktt;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/gmake-4.4.1-6lgy76r7dbvqm6mbwb2jkpcuycf7tb27;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6/blt-0.5.3-xa3bmu75nkolqiewb5ftk5tp2jpzw57n;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-clang-14.0.6;/usr/tce;/usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6;/usr/tce/packages/clang/clang-14.0.6" CACHE PATH "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -15,11 +15,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
 
 else()
 
@@ -69,7 +69,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/clang-14.0.6" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/clang-14.0.6" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.8-inqrhwboacvngevqbvavhpisx4aeqpvy" CACHE PATH "")
 
@@ -87,7 +87,27 @@ set(UMPIRE_DIR "${TPL_ROOT}/umpire-2023.06.0-ubadmsj3l2zavunhkkt7nxevkpmssdvy" C
 
 set(CAMP_DIR "${TPL_ROOT}/camp-2023.06.0-e6mknahsrmbbifbfv3umemetvqzoh3he" CACHE PATH "")
 
-# scr not built
+set(SCR_DIR "${TPL_ROOT}/scr-3.0.1-5edtc4k2wstti2dh4kp2tno7rmwr3lyd" CACHE PATH "")
+
+set(KVTREE_DIR "${TPL_ROOT}/kvtree-1.3.0-4zcbvvaqpbkdt7xc4pbu7urlkdywjjd7" CACHE PATH "")
+
+set(DTCMP_DIR "${TPL_ROOT}/dtcmp-1.1.4-u376uqcnt3y7ebu5ocfvk7bovkr2febv" CACHE PATH "")
+
+set(SPATH_DIR "${TPL_ROOT}/spath-0.2.0-gvlnzegcdph7ien3w4tjcxevblf2xe4r" CACHE PATH "")
+
+set(AXL_DIR "${TPL_ROOT}/axl-0.7.1-t7yboywzjziqb3hbgidynhbk5vd33jc7" CACHE PATH "")
+
+set(LWGRP_DIR "${TPL_ROOT}/lwgrp-1.0.5-am6sfml4trdhzlds365vbepezgdvdocz" CACHE PATH "")
+
+set(ER_DIR "${TPL_ROOT}/er-0.2.0-befo66qsdjjulpnhaxvhk4uil45ynd6u" CACHE PATH "")
+
+set(RANKSTR_DIR "${TPL_ROOT}/rankstr-0.1.0-jkgwo3kyvegaapdtm67mg4aknu44foyn" CACHE PATH "")
+
+set(REDSET_DIR "${TPL_ROOT}/redset-0.2.0-tllpyzklkik7oa32us3tigl7vdvil42o" CACHE PATH "")
+
+set(SHUFFILE_DIR "${TPL_ROOT}/shuffile-0.2.0-j5blkpa2h3keb562qb5pdnfiuzyaecfd" CACHE PATH "")
+
+set(LIBYOGRT_DIR "${TPL_ROOT}/libyogrt-1.33-3joihut3xh67qmtalrqadzujfzxwpodj" CACHE PATH "")
 
 #------------------------------------------------------------------------------
 # Devtools

--- a/host-configs/rzgenie-toss_4_x86_64_ib-gcc@10.3.1.cmake
+++ b/host-configs/rzgenie-toss_4_x86_64_ib-gcc@10.3.1.cmake
@@ -4,7 +4,7 @@
 # CMake executable path: /usr/tce/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/gcc-10.3.1/umpire-2023.06.0-z2ts74flz56i67azbbp5zyiwvwgwucrr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/gcc-10.3.1/raja-2023.06.0-ca64lzglcihqwwjcmxuzfdvg7bhsd5rq;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/gcc-10.3.1/camp-2023.06.0-k4v6kc3zhnika36o2jvhncwiwcaifxqp;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/gcc-10.3.1/mfem-4.5.2-uyempb4k6nefxh36lxnbfb2dynpyaezr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/gcc-10.3.1/hypre-2.24.0-lof7hdy7wsyuei436d6uhilprsgmr3ik;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/gcc-10.3.1/conduit-0.8.8-wngwwhpllk2gjewlizsk4plakvdu4beu;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/gcc-10.3.1/parmetis-4.0.3-lq6aryhur6qn3trc2qxizvz4nae5ngzf;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/gcc-10.3.1/metis-5.1.0-pyrzcrzqvl6q27kk637o2nwi3j7ibseb;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/gcc-10.3.1/hdf5-1.8.22-wikz2sxdo4zf76fdfl5do4mekkixf4yv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/gcc-10.3.1/c2c-1.8.0-bsohtsh5a73tmmxlndgjuhzz6lzoif5j;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/gcc-10.3.1/gmake-4.4.1-y2kaxrqjbg3dcwo7dzfphztusfjqoowq;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/gcc-10.3.1/blt-0.5.3-iljv7wrfi4r5i4drs4yf65rgsuunaxjn;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1;/usr/tce;/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1" CACHE PATH "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/umpire-2023.06.0-z2ts74flz56i67azbbp5zyiwvwgwucrr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/scr-3.0.1-znr5hvdmrpg2wwtcrepv3bzh32visddj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/spath-0.2.0-scp7lun3jtdgorfmd4mzhtieqkjko57q;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/libyogrt-1.33-riegwpsbfjywz6pumvit2eadroiosowy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/er-0.2.0-m7mypt2brwrodmfun3ya2cwpkuwpccnv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/shuffile-0.2.0-74ysb2qi6xkrx7u5vsa2jnmcqof3q4je;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/redset-0.2.0-7bhg5tua2jns5ob7r6stbgitzlfggdax;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/rankstr-0.1.0-yuunbkeetjd4y563p4dzxp23rsdcc6tr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/dtcmp-1.1.4-bk55ioptacxzxnpxcgu27vwk2nacb35s;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/lwgrp-1.0.5-zhpxnopjtpr5cchaqufivi2sn4crkgwn;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/axl-0.7.1-b3zz33f7lmeal5thbfyuc6cmbdfek2vv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/kvtree-1.3.0-oeqjobwdjxemywgc77pfuv4nnpxk6buj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/raja-2023.06.0-ca64lzglcihqwwjcmxuzfdvg7bhsd5rq;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/camp-2023.06.0-k4v6kc3zhnika36o2jvhncwiwcaifxqp;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/mfem-4.5.2-uyempb4k6nefxh36lxnbfb2dynpyaezr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/hypre-2.24.0-lof7hdy7wsyuei436d6uhilprsgmr3ik;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/conduit-0.8.8-wngwwhpllk2gjewlizsk4plakvdu4beu;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/parmetis-4.0.3-lq6aryhur6qn3trc2qxizvz4nae5ngzf;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/metis-5.1.0-pyrzcrzqvl6q27kk637o2nwi3j7ibseb;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/hdf5-1.8.22-wikz2sxdo4zf76fdfl5do4mekkixf4yv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/c2c-1.8.0-bsohtsh5a73tmmxlndgjuhzz6lzoif5j;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/gmake-4.4.1-y2kaxrqjbg3dcwo7dzfphztusfjqoowq;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1/blt-0.5.3-iljv7wrfi4r5i4drs4yf65rgsuunaxjn;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1;/usr/tce;/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1" CACHE PATH "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -15,11 +15,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/spack/lib/spack/env/gcc/g++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
 
 else()
 
@@ -67,7 +67,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/gcc-10.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/gcc-10.3.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.8-wngwwhpllk2gjewlizsk4plakvdu4beu" CACHE PATH "")
 
@@ -85,7 +85,27 @@ set(UMPIRE_DIR "${TPL_ROOT}/umpire-2023.06.0-z2ts74flz56i67azbbp5zyiwvwgwucrr" C
 
 set(CAMP_DIR "${TPL_ROOT}/camp-2023.06.0-k4v6kc3zhnika36o2jvhncwiwcaifxqp" CACHE PATH "")
 
-# scr not built
+set(SCR_DIR "${TPL_ROOT}/scr-3.0.1-znr5hvdmrpg2wwtcrepv3bzh32visddj" CACHE PATH "")
+
+set(KVTREE_DIR "${TPL_ROOT}/kvtree-1.3.0-oeqjobwdjxemywgc77pfuv4nnpxk6buj" CACHE PATH "")
+
+set(DTCMP_DIR "${TPL_ROOT}/dtcmp-1.1.4-bk55ioptacxzxnpxcgu27vwk2nacb35s" CACHE PATH "")
+
+set(SPATH_DIR "${TPL_ROOT}/spath-0.2.0-scp7lun3jtdgorfmd4mzhtieqkjko57q" CACHE PATH "")
+
+set(AXL_DIR "${TPL_ROOT}/axl-0.7.1-b3zz33f7lmeal5thbfyuc6cmbdfek2vv" CACHE PATH "")
+
+set(LWGRP_DIR "${TPL_ROOT}/lwgrp-1.0.5-zhpxnopjtpr5cchaqufivi2sn4crkgwn" CACHE PATH "")
+
+set(ER_DIR "${TPL_ROOT}/er-0.2.0-m7mypt2brwrodmfun3ya2cwpkuwpccnv" CACHE PATH "")
+
+set(RANKSTR_DIR "${TPL_ROOT}/rankstr-0.1.0-yuunbkeetjd4y563p4dzxp23rsdcc6tr" CACHE PATH "")
+
+set(REDSET_DIR "${TPL_ROOT}/redset-0.2.0-7bhg5tua2jns5ob7r6stbgitzlfggdax" CACHE PATH "")
+
+set(SHUFFILE_DIR "${TPL_ROOT}/shuffile-0.2.0-74ysb2qi6xkrx7u5vsa2jnmcqof3q4je" CACHE PATH "")
+
+set(LIBYOGRT_DIR "${TPL_ROOT}/libyogrt-1.33-riegwpsbfjywz6pumvit2eadroiosowy" CACHE PATH "")
 
 #------------------------------------------------------------------------------
 # Devtools

--- a/host-configs/rzgenie-toss_4_x86_64_ib-intel@2022.1.0.cmake
+++ b/host-configs/rzgenie-toss_4_x86_64_ib-intel@2022.1.0.cmake
@@ -4,7 +4,7 @@
 # CMake executable path: /usr/tce/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/intel-2022.1.0/umpire-2023.06.0-6wmifjy5c2er4kkfqw7m5s4in7esiln5;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/intel-2022.1.0/raja-2023.06.0-urtfojwbjummyvyev7k4zn2oix53f4up;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/intel-2022.1.0/camp-2023.06.0-ovewmmz43udq34jrdlokh2zuzgkzrum4;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/intel-2022.1.0/mfem-4.5.2-dbvjel6jhwnwf6wzm76w6ghbjpy3v4gj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/intel-2022.1.0/hypre-2.24.0-qdjyl5ibcpl4nxb6t5godfgvi5bb6hac;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/intel-2022.1.0/conduit-0.8.8-32edlc6hrwpchrywdw5xdhcrhiqqjg6n;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/intel-2022.1.0/parmetis-4.0.3-nqxoj5gqogj32hfo5ognkcb6vg24zdlc;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/intel-2022.1.0/metis-5.1.0-tb5bijmooj2d6d2npjpajcj4fyu4yd4y;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/intel-2022.1.0/hdf5-1.8.22-e7opxg2skchlv6z6hd4pre35bd6pqv22;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/intel-2022.1.0/c2c-1.8.0-gvlftgplgmtput3k4fy2nssecldmmlsa;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/intel-2022.1.0/gmake-4.4.1-e3r4ry6vgi7zp4mbwfokypkutqwpctek;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/intel-2022.1.0/blt-0.5.3-i7qltms7ksyz4xltznzbtsafywrykq7b;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-intel-2022.1.0;/usr/tce" CACHE PATH "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/intel-2022.1.0/umpire-2023.06.0-6wmifjy5c2er4kkfqw7m5s4in7esiln5;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/intel-2022.1.0/raja-2023.06.0-urtfojwbjummyvyev7k4zn2oix53f4up;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/intel-2022.1.0/camp-2023.06.0-ovewmmz43udq34jrdlokh2zuzgkzrum4;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/intel-2022.1.0/mfem-4.5.2-dbvjel6jhwnwf6wzm76w6ghbjpy3v4gj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/intel-2022.1.0/hypre-2.24.0-qdjyl5ibcpl4nxb6t5godfgvi5bb6hac;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/intel-2022.1.0/conduit-0.8.8-22refnw4twba4zznewcuczky2udimj7i;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/intel-2022.1.0/parmetis-4.0.3-nqxoj5gqogj32hfo5ognkcb6vg24zdlc;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/intel-2022.1.0/metis-5.1.0-tb5bijmooj2d6d2npjpajcj4fyu4yd4y;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/intel-2022.1.0/hdf5-1.8.22-6oeginq7kyyix35utjgsfxeghcnujtpg;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/intel-2022.1.0/c2c-1.8.0-gvlftgplgmtput3k4fy2nssecldmmlsa;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/intel-2022.1.0/gmake-4.4.1-e3r4ry6vgi7zp4mbwfokypkutqwpctek;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/intel-2022.1.0/blt-0.5.3-i7qltms7ksyz4xltznzbtsafywrykq7b;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-intel-2022.1.0;/usr/tce" CACHE PATH "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -15,11 +15,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/spack/lib/spack/env/intel/icc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/spack/lib/spack/env/intel/icc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/spack/lib/spack/env/intel/icpc" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/spack/lib/spack/env/intel/icpc" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/spack/lib/spack/env/intel/ifort" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/spack/lib/spack/env/intel/ifort" CACHE PATH "")
 
 else()
 
@@ -67,15 +67,15 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_23_09_45_05/intel-2022.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_13_06_22/intel-2022.1.0" CACHE PATH "")
 
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.8-32edlc6hrwpchrywdw5xdhcrhiqqjg6n" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.8-22refnw4twba4zznewcuczky2udimj7i" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-gvlftgplgmtput3k4fy2nssecldmmlsa" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.5.2-dbvjel6jhwnwf6wzm76w6ghbjpy3v4gj" CACHE PATH "")
 
-set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22-e7opxg2skchlv6z6hd4pre35bd6pqv22" CACHE PATH "")
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.22-6oeginq7kyyix35utjgsfxeghcnujtpg" CACHE PATH "")
 
 set(LUA_DIR "/usr" CACHE PATH "")
 

--- a/host-configs/rzwhippet-toss_4_x86_64_ib-clang@14.0.6.cmake
+++ b/host-configs/rzwhippet-toss_4_x86_64_ib-clang@14.0.6.cmake
@@ -4,7 +4,7 @@
 # CMake executable path: /usr/tce/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/clang-14.0.6/umpire-2023.06.0-ubadmsj3l2zavunhkkt7nxevkpmssdvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/clang-14.0.6/raja-2023.06.0-55ypap77cpmjgq24vaquanhsshjm3gqh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/clang-14.0.6/camp-2023.06.0-e6mknahsrmbbifbfv3umemetvqzoh3he;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/clang-14.0.6/mfem-4.5.2-lwet4c3edrdvipij3r4itukmse2jklvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/clang-14.0.6/hypre-2.24.0-bwh42bebp4hiuwzlwcthpgkawape6dp3;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/clang-14.0.6/conduit-0.8.8-inqrhwboacvngevqbvavhpisx4aeqpvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/clang-14.0.6/parmetis-4.0.3-jthqwflsj5bpe6onwsb5r2zi5wbx6pq4;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/clang-14.0.6/metis-5.1.0-imzig3eih3itpztvvk4yildzgq6aeelo;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/clang-14.0.6/hdf5-1.8.22-5mfm2r7fo5krpj7vvmayz24qksnluryl;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/clang-14.0.6/c2c-1.8.0-5smd5ktj7yjc2egeyum4t5vlwmw3jktt;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/clang-14.0.6/gmake-4.4.1-6lgy76r7dbvqm6mbwb2jkpcuycf7tb27;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/clang-14.0.6/blt-0.5.3-xa3bmu75nkolqiewb5ftk5tp2jpzw57n;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-clang-14.0.6;/usr/tce;/usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6;/usr/tce/packages/clang/clang-14.0.6" CACHE PATH "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/umpire-2023.06.0-ubadmsj3l2zavunhkkt7nxevkpmssdvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/scr-3.0.1-5edtc4k2wstti2dh4kp2tno7rmwr3lyd;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/spath-0.2.0-gvlnzegcdph7ien3w4tjcxevblf2xe4r;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/libyogrt-1.33-3joihut3xh67qmtalrqadzujfzxwpodj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/er-0.2.0-befo66qsdjjulpnhaxvhk4uil45ynd6u;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/shuffile-0.2.0-j5blkpa2h3keb562qb5pdnfiuzyaecfd;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/redset-0.2.0-tllpyzklkik7oa32us3tigl7vdvil42o;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/rankstr-0.1.0-jkgwo3kyvegaapdtm67mg4aknu44foyn;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/dtcmp-1.1.4-u376uqcnt3y7ebu5ocfvk7bovkr2febv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/lwgrp-1.0.5-am6sfml4trdhzlds365vbepezgdvdocz;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/axl-0.7.1-t7yboywzjziqb3hbgidynhbk5vd33jc7;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/kvtree-1.3.0-4zcbvvaqpbkdt7xc4pbu7urlkdywjjd7;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/raja-2023.06.0-55ypap77cpmjgq24vaquanhsshjm3gqh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/camp-2023.06.0-e6mknahsrmbbifbfv3umemetvqzoh3he;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/mfem-4.5.2-lwet4c3edrdvipij3r4itukmse2jklvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/hypre-2.24.0-bwh42bebp4hiuwzlwcthpgkawape6dp3;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/conduit-0.8.8-inqrhwboacvngevqbvavhpisx4aeqpvy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/parmetis-4.0.3-jthqwflsj5bpe6onwsb5r2zi5wbx6pq4;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/metis-5.1.0-imzig3eih3itpztvvk4yildzgq6aeelo;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/hdf5-1.8.22-5mfm2r7fo5krpj7vvmayz24qksnluryl;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/c2c-1.8.0-5smd5ktj7yjc2egeyum4t5vlwmw3jktt;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/gmake-4.4.1-6lgy76r7dbvqm6mbwb2jkpcuycf7tb27;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6/blt-0.5.3-xa3bmu75nkolqiewb5ftk5tp2jpzw57n;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-clang-14.0.6;/usr/tce;/usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6;/usr/tce/packages/clang/clang-14.0.6" CACHE PATH "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -15,11 +15,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
 
 else()
 
@@ -69,7 +69,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/clang-14.0.6" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/clang-14.0.6" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.8-inqrhwboacvngevqbvavhpisx4aeqpvy" CACHE PATH "")
 
@@ -87,7 +87,27 @@ set(UMPIRE_DIR "${TPL_ROOT}/umpire-2023.06.0-ubadmsj3l2zavunhkkt7nxevkpmssdvy" C
 
 set(CAMP_DIR "${TPL_ROOT}/camp-2023.06.0-e6mknahsrmbbifbfv3umemetvqzoh3he" CACHE PATH "")
 
-# scr not built
+set(SCR_DIR "${TPL_ROOT}/scr-3.0.1-5edtc4k2wstti2dh4kp2tno7rmwr3lyd" CACHE PATH "")
+
+set(KVTREE_DIR "${TPL_ROOT}/kvtree-1.3.0-4zcbvvaqpbkdt7xc4pbu7urlkdywjjd7" CACHE PATH "")
+
+set(DTCMP_DIR "${TPL_ROOT}/dtcmp-1.1.4-u376uqcnt3y7ebu5ocfvk7bovkr2febv" CACHE PATH "")
+
+set(SPATH_DIR "${TPL_ROOT}/spath-0.2.0-gvlnzegcdph7ien3w4tjcxevblf2xe4r" CACHE PATH "")
+
+set(AXL_DIR "${TPL_ROOT}/axl-0.7.1-t7yboywzjziqb3hbgidynhbk5vd33jc7" CACHE PATH "")
+
+set(LWGRP_DIR "${TPL_ROOT}/lwgrp-1.0.5-am6sfml4trdhzlds365vbepezgdvdocz" CACHE PATH "")
+
+set(ER_DIR "${TPL_ROOT}/er-0.2.0-befo66qsdjjulpnhaxvhk4uil45ynd6u" CACHE PATH "")
+
+set(RANKSTR_DIR "${TPL_ROOT}/rankstr-0.1.0-jkgwo3kyvegaapdtm67mg4aknu44foyn" CACHE PATH "")
+
+set(REDSET_DIR "${TPL_ROOT}/redset-0.2.0-tllpyzklkik7oa32us3tigl7vdvil42o" CACHE PATH "")
+
+set(SHUFFILE_DIR "${TPL_ROOT}/shuffile-0.2.0-j5blkpa2h3keb562qb5pdnfiuzyaecfd" CACHE PATH "")
+
+set(LIBYOGRT_DIR "${TPL_ROOT}/libyogrt-1.33-3joihut3xh67qmtalrqadzujfzxwpodj" CACHE PATH "")
 
 #------------------------------------------------------------------------------
 # Devtools

--- a/host-configs/rzwhippet-toss_4_x86_64_ib-gcc@10.3.1.cmake
+++ b/host-configs/rzwhippet-toss_4_x86_64_ib-gcc@10.3.1.cmake
@@ -4,7 +4,7 @@
 # CMake executable path: /usr/tce/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/gcc-10.3.1/umpire-2023.06.0-z2ts74flz56i67azbbp5zyiwvwgwucrr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/gcc-10.3.1/raja-2023.06.0-ca64lzglcihqwwjcmxuzfdvg7bhsd5rq;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/gcc-10.3.1/camp-2023.06.0-k4v6kc3zhnika36o2jvhncwiwcaifxqp;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/gcc-10.3.1/mfem-4.5.2-uyempb4k6nefxh36lxnbfb2dynpyaezr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/gcc-10.3.1/hypre-2.24.0-lof7hdy7wsyuei436d6uhilprsgmr3ik;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/gcc-10.3.1/conduit-0.8.8-wngwwhpllk2gjewlizsk4plakvdu4beu;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/gcc-10.3.1/parmetis-4.0.3-lq6aryhur6qn3trc2qxizvz4nae5ngzf;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/gcc-10.3.1/metis-5.1.0-pyrzcrzqvl6q27kk637o2nwi3j7ibseb;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/gcc-10.3.1/hdf5-1.8.22-wikz2sxdo4zf76fdfl5do4mekkixf4yv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/gcc-10.3.1/c2c-1.8.0-bsohtsh5a73tmmxlndgjuhzz6lzoif5j;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/gcc-10.3.1/gmake-4.4.1-y2kaxrqjbg3dcwo7dzfphztusfjqoowq;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/gcc-10.3.1/blt-0.5.3-iljv7wrfi4r5i4drs4yf65rgsuunaxjn;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1;/usr/tce;/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1" CACHE PATH "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/umpire-2023.06.0-z2ts74flz56i67azbbp5zyiwvwgwucrr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/scr-3.0.1-znr5hvdmrpg2wwtcrepv3bzh32visddj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/spath-0.2.0-scp7lun3jtdgorfmd4mzhtieqkjko57q;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/libyogrt-1.33-riegwpsbfjywz6pumvit2eadroiosowy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/er-0.2.0-m7mypt2brwrodmfun3ya2cwpkuwpccnv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/shuffile-0.2.0-74ysb2qi6xkrx7u5vsa2jnmcqof3q4je;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/redset-0.2.0-7bhg5tua2jns5ob7r6stbgitzlfggdax;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/rankstr-0.1.0-yuunbkeetjd4y563p4dzxp23rsdcc6tr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/dtcmp-1.1.4-bk55ioptacxzxnpxcgu27vwk2nacb35s;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/lwgrp-1.0.5-zhpxnopjtpr5cchaqufivi2sn4crkgwn;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/axl-0.7.1-b3zz33f7lmeal5thbfyuc6cmbdfek2vv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/kvtree-1.3.0-oeqjobwdjxemywgc77pfuv4nnpxk6buj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/raja-2023.06.0-ca64lzglcihqwwjcmxuzfdvg7bhsd5rq;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/camp-2023.06.0-k4v6kc3zhnika36o2jvhncwiwcaifxqp;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/mfem-4.5.2-uyempb4k6nefxh36lxnbfb2dynpyaezr;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/hypre-2.24.0-lof7hdy7wsyuei436d6uhilprsgmr3ik;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/conduit-0.8.8-wngwwhpllk2gjewlizsk4plakvdu4beu;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/parmetis-4.0.3-lq6aryhur6qn3trc2qxizvz4nae5ngzf;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/metis-5.1.0-pyrzcrzqvl6q27kk637o2nwi3j7ibseb;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/hdf5-1.8.22-wikz2sxdo4zf76fdfl5do4mekkixf4yv;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/c2c-1.8.0-bsohtsh5a73tmmxlndgjuhzz6lzoif5j;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/gmake-4.4.1-y2kaxrqjbg3dcwo7dzfphztusfjqoowq;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1/blt-0.5.3-iljv7wrfi4r5i4drs4yf65rgsuunaxjn;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1;/usr/tce;/usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1" CACHE PATH "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -15,11 +15,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/spack/lib/spack/env/gcc/gcc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/spack/lib/spack/env/gcc/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/spack/lib/spack/env/gcc/g++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/spack/lib/spack/env/gcc/gfortran" CACHE PATH "")
 
 else()
 
@@ -67,7 +67,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/gcc-10.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/gcc-10.3.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.8-wngwwhpllk2gjewlizsk4plakvdu4beu" CACHE PATH "")
 
@@ -85,7 +85,27 @@ set(UMPIRE_DIR "${TPL_ROOT}/umpire-2023.06.0-z2ts74flz56i67azbbp5zyiwvwgwucrr" C
 
 set(CAMP_DIR "${TPL_ROOT}/camp-2023.06.0-k4v6kc3zhnika36o2jvhncwiwcaifxqp" CACHE PATH "")
 
-# scr not built
+set(SCR_DIR "${TPL_ROOT}/scr-3.0.1-znr5hvdmrpg2wwtcrepv3bzh32visddj" CACHE PATH "")
+
+set(KVTREE_DIR "${TPL_ROOT}/kvtree-1.3.0-oeqjobwdjxemywgc77pfuv4nnpxk6buj" CACHE PATH "")
+
+set(DTCMP_DIR "${TPL_ROOT}/dtcmp-1.1.4-bk55ioptacxzxnpxcgu27vwk2nacb35s" CACHE PATH "")
+
+set(SPATH_DIR "${TPL_ROOT}/spath-0.2.0-scp7lun3jtdgorfmd4mzhtieqkjko57q" CACHE PATH "")
+
+set(AXL_DIR "${TPL_ROOT}/axl-0.7.1-b3zz33f7lmeal5thbfyuc6cmbdfek2vv" CACHE PATH "")
+
+set(LWGRP_DIR "${TPL_ROOT}/lwgrp-1.0.5-zhpxnopjtpr5cchaqufivi2sn4crkgwn" CACHE PATH "")
+
+set(ER_DIR "${TPL_ROOT}/er-0.2.0-m7mypt2brwrodmfun3ya2cwpkuwpccnv" CACHE PATH "")
+
+set(RANKSTR_DIR "${TPL_ROOT}/rankstr-0.1.0-yuunbkeetjd4y563p4dzxp23rsdcc6tr" CACHE PATH "")
+
+set(REDSET_DIR "${TPL_ROOT}/redset-0.2.0-7bhg5tua2jns5ob7r6stbgitzlfggdax" CACHE PATH "")
+
+set(SHUFFILE_DIR "${TPL_ROOT}/shuffile-0.2.0-74ysb2qi6xkrx7u5vsa2jnmcqof3q4je" CACHE PATH "")
+
+set(LIBYOGRT_DIR "${TPL_ROOT}/libyogrt-1.33-riegwpsbfjywz6pumvit2eadroiosowy" CACHE PATH "")
 
 #------------------------------------------------------------------------------
 # Devtools

--- a/host-configs/rzwhippet-toss_4_x86_64_ib-intel@2022.1.0.cmake
+++ b/host-configs/rzwhippet-toss_4_x86_64_ib-intel@2022.1.0.cmake
@@ -4,7 +4,7 @@
 # CMake executable path: /usr/tce/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/intel-2022.1.0/umpire-2023.06.0-6wmifjy5c2er4kkfqw7m5s4in7esiln5;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/intel-2022.1.0/raja-2023.06.0-urtfojwbjummyvyev7k4zn2oix53f4up;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/intel-2022.1.0/camp-2023.06.0-ovewmmz43udq34jrdlokh2zuzgkzrum4;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/intel-2022.1.0/mfem-4.5.2-dbvjel6jhwnwf6wzm76w6ghbjpy3v4gj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/intel-2022.1.0/hypre-2.24.0-qdjyl5ibcpl4nxb6t5godfgvi5bb6hac;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/intel-2022.1.0/conduit-0.8.8-22refnw4twba4zznewcuczky2udimj7i;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/intel-2022.1.0/parmetis-4.0.3-nqxoj5gqogj32hfo5ognkcb6vg24zdlc;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/intel-2022.1.0/metis-5.1.0-tb5bijmooj2d6d2npjpajcj4fyu4yd4y;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/intel-2022.1.0/hdf5-1.8.22-6oeginq7kyyix35utjgsfxeghcnujtpg;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/intel-2022.1.0/c2c-1.8.0-gvlftgplgmtput3k4fy2nssecldmmlsa;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/intel-2022.1.0/gmake-4.4.1-e3r4ry6vgi7zp4mbwfokypkutqwpctek;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/intel-2022.1.0/blt-0.5.3-i7qltms7ksyz4xltznzbtsafywrykq7b;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-intel-2022.1.0;/usr/tce" CACHE PATH "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/intel-2022.1.0/umpire-2023.06.0-6wmifjy5c2er4kkfqw7m5s4in7esiln5;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/intel-2022.1.0/raja-2023.06.0-urtfojwbjummyvyev7k4zn2oix53f4up;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/intel-2022.1.0/camp-2023.06.0-ovewmmz43udq34jrdlokh2zuzgkzrum4;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/intel-2022.1.0/mfem-4.5.2-dbvjel6jhwnwf6wzm76w6ghbjpy3v4gj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/intel-2022.1.0/hypre-2.24.0-qdjyl5ibcpl4nxb6t5godfgvi5bb6hac;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/intel-2022.1.0/conduit-0.8.8-22refnw4twba4zznewcuczky2udimj7i;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/intel-2022.1.0/parmetis-4.0.3-nqxoj5gqogj32hfo5ognkcb6vg24zdlc;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/intel-2022.1.0/metis-5.1.0-tb5bijmooj2d6d2npjpajcj4fyu4yd4y;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/intel-2022.1.0/hdf5-1.8.22-6oeginq7kyyix35utjgsfxeghcnujtpg;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/intel-2022.1.0/c2c-1.8.0-gvlftgplgmtput3k4fy2nssecldmmlsa;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/intel-2022.1.0/gmake-4.4.1-e3r4ry6vgi7zp4mbwfokypkutqwpctek;/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/intel-2022.1.0/blt-0.5.3-i7qltms7ksyz4xltznzbtsafywrykq7b;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/doxygen-1.9.6;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/cppcheck-2.9;/usr/tce/packages/mvapich2/mvapich2-2.3.6-intel-2022.1.0;/usr/tce" CACHE PATH "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -15,11 +15,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/spack/lib/spack/env/intel/icc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/spack/lib/spack/env/intel/icc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/spack/lib/spack/env/intel/icpc" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/spack/lib/spack/env/intel/icpc" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/spack/lib/spack/env/intel/ifort" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/spack/lib/spack/env/intel/ifort" CACHE PATH "")
 
 else()
 
@@ -67,7 +67,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_18_08_27_25/intel-2022.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2023_10_30_15_05_41/intel-2022.1.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.8.8-22refnw4twba4zznewcuczky2udimj7i" CACHE PATH "")
 

--- a/scripts/llnl_scripts/build_devtools.py
+++ b/scripts/llnl_scripts/build_devtools.py
@@ -50,6 +50,9 @@ def main():
         if not os.path.exists(build_dir):
             os.makedirs(build_dir)
     else:
+        if getpass.getuser() != "atk":
+            print("ERROR: Only shared user 'atk' can install into shared directory. Use -d option.")
+            return 1
         build_dir = get_shared_devtool_dir()
     build_dir = os.path.abspath(build_dir)
 

--- a/scripts/llnl_scripts/build_devtools.py
+++ b/scripts/llnl_scripts/build_devtools.py
@@ -50,9 +50,6 @@ def main():
         if not os.path.exists(build_dir):
             os.makedirs(build_dir)
     else:
-        if getpass.getuser() != "atk":
-            print("ERROR: Only shared user 'atk' can install into shared directory. Use -d option.")
-            return 1
         build_dir = get_shared_devtool_dir()
     build_dir = os.path.abspath(build_dir)
 

--- a/scripts/spack/specs.json
+++ b/scripts/spack/specs.json
@@ -21,8 +21,8 @@
       "intel@19.0.4~openmp+devtools+mfem+c2c" ],
 
     "toss_4_x86_64_ib":
-    [ "gcc@10.3.1+devtools+hdf5+mfem+c2c",
-      "clang@14.0.6+devtools+hdf5+mfem+c2c",
+    [ "gcc@10.3.1+devtools+hdf5+mfem+c2c+scr",
+      "clang@14.0.6+devtools+hdf5+mfem+c2c+scr",
       "intel@2022.1.0+devtools+hdf5+mfem+c2c" ],
 
     "__comment__":"# Use amdgpu_target=gfx90a for tioga/rzvernal; and gfx908 for rznevada",

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -234,6 +234,7 @@ if (SCR_DIR)
                         TREAT_INCLUDES_AS_SYSTEM ON
                         EXPORTABLE ON)
     blt_list_append(TO TPL_DEPS ELEMENTS scr)
+    set(SCR_FOUND ON CACHE BOOL "")
 else()
     message(STATUS "SCR support is OFF")
 endif()


### PR DESCRIPTION
This PR:

- Adds back +scr to some toss4 configs (previous scr built only with some toss3 configs)
- ~~Edits `build_devtools` script to allow non-atk users to build to shared directory~~