### PR TITLE
Intersection-based Primal improvements

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,11 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ## [Unreleased] - Release date yyyy-mm-dd
 
+### Added
+- Primal: Adds a `checkAndFixOrientation()` function to `primal::Tetrahedron`
+  that swaps the order of vertices if the signed volume of the Tetrahedron is
+  negative, resulting in the signed volume becoming positive.
+
 ### Changed
 - `MarchingCubes` and `DistributedClosestPoint` classes changed from requiring the Blueprint
   coordset name to requiring the Blueprint topology name.  The changed interface methods are:

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,6 +20,11 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ## [Unreleased] - Release date yyyy-mm-dd
 
 ### Added
+- Primal: Adds a `Quadrilateral` primitive
+- Primal: Adds a `compute_bounding_box()` operator for computing the bounding
+  box of a `Quadrilateral`
+- Primal: Adds a `clip()` operator for clipping a tetrahedron against the
+  half-space defined by a plane
 - Primal: Adds a `checkAndFixOrientation()` function to `primal::Tetrahedron`
   that swaps the order of vertices if the signed volume of the Tetrahedron is
   negative, resulting in the signed volume becoming positive.
@@ -36,11 +41,6 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   returns the signed volume.
 - Primal: `intersection_volume()` operators changed from returning a signed
   volume to an unsigned volume.
-- Primal: Adds a `Quadrilateral` primitive
-- Primal: Adds a `compute_bounding_box()` operator for computing the bounding
-  box of a `Quadrilateral`
-- Primal: Adds a `clip()` operator for clipping a tetrahedron against the
-  half-space defined by a plane
 
 ### Fixed
 - quest's `SamplingShaper` now properly handles material names containing underscores

--- a/src/axom/primal/examples/hex_tet_volume.cpp
+++ b/src/axom/primal/examples/hex_tet_volume.cpp
@@ -239,7 +239,7 @@ void check_intersection_volumes(const Input& params)
   // reduce the number of operations.
   RAJA::ReduceSum<REDUCE_POL, double> total_intersect_vol(0.0);
   constexpr double EPS = 1e-10;
-  constexpr bool checkSign = true;
+  constexpr bool tryFixOrientation = true;
 
   // The lower of the two sizes (NUM_HEXES, NUM_TETS) is used to factor out
   // every pair of hexahedron and tetrahedron indices.
@@ -251,7 +251,7 @@ void check_intersection_volumes(const Input& params)
         total_intersect_vol += intersection_volume(hexes_view[i / NUM_TETS],
                                                    tets_view[i % NUM_TETS],
                                                    EPS,
-                                                   checkSign);
+                                                   tryFixOrientation);
       });
   }
   else
@@ -262,7 +262,7 @@ void check_intersection_volumes(const Input& params)
         total_intersect_vol += intersection_volume(hexes_view[i % NUM_HEXES],
                                                    tets_view[i / NUM_HEXES],
                                                    EPS,
-                                                   checkSign);
+                                                   tryFixOrientation);
       });
   }
 

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -672,12 +672,10 @@ public:
    * \brief Creates a Polyhedron from a given Hexahedron's vertices.
    *
    * \param [in] hex The hexahedron
-   * \param [in] checkSign If true (default is false), checks if the
-   *             signed volume of the Polyhedron is positive. If signed volume
-   *             is negative, order of some vertices will be swapped to try to
-   *             obtain a positive volume for the Polyhedron. Otherwise, if the
-   *             signed volume is negative and the vertices are not swapped,
-   *             the returned Polyhedron will have a non-positive volume.
+   * \param [in] tryFixOrientation If true, checks if the signed volume of the
+   *             Polyhedron is positive and swaps the order of some vertices
+   *             in that shape to try to obtain a nonnegative signed volume.
+   *             Defaults to false.
    *
    * \return A Polyhedron with the Hexahedron's vertices and added
    *         vertex neighbors
@@ -699,15 +697,20 @@ public:
    *       The Polyhedron's vertex neighbors are created assuming this vertex
    *       ordering.
    *
-   * \warning checkSign flag does not guarantee the Polyhedron's vertex order
+   * \warning tryFixOrientation flag does not guarantee the Polyhedron's vertex order
    *          will be valid. It is the responsiblity of the caller to pass
    *          a Hexahedron with a valid vertex order. Otherwise, if the
    *          Hexahedron has an invalid vertex order, the returned Polyhedron
    *          will have a non-positive and/or unexpected volume.
+   *
+   * \warning If tryFixOrientation flag is false and some of the shapes have
+   *          a negative signed volume, the returned Polyhedron
+   *          will have a non-positive and/or unexpected volume.
+   *
    */
   AXOM_HOST_DEVICE
   static Polyhedron from_primitive(const Hexahedron<T, NDIMS>& hex,
-                                   bool checkSign = false)
+                                   bool tryFixOrientation = false)
   {
     // Initialize our polyhedron to return
     Polyhedron<T, NDIMS> poly;
@@ -731,7 +734,7 @@ public:
     poly.addNeighbors(7, {3, 4, 6});
 
     // Reverses order of vertices 1,3 and 5,7 if signed volume is negative
-    if(checkSign)
+    if(tryFixOrientation)
     {
       if(poly.signedVolume() < 0)
       {
@@ -747,12 +750,10 @@ public:
    * \brief Creates a Polyhedron from a given Octahedron's vertices.
    *
    * \param [in] oct The octahedron
-   * \param [in] checkSign If true (default is false), checks if the
-   *             signed volume of the Polyhedron is positive. If signed volume
-   *             is negative, order of some vertices will be swapped to try to
-   *             obtain a positive volume for the Polyhedron. Otherwise, if the
-   *             signed volume is negative and the vertices are not swapped,
-   *             the returned Polyhedron will have a non-positive volume.
+   * \param [in] tryFixOrientation If true, checks if the signed volume of the
+   *             Polyhedron is positive and swaps the order of some vertices
+   *             in that shape to try to obtain a nonnegative signed volume.
+   *             Defaults to false.
    *
    * \return A Polyhedron with the Octahedron's vertices and added
    *         vertex neighbors
@@ -776,16 +777,20 @@ public:
    *       The Polyhedron's vertex neighbors are created assuming this vertex
    *       ordering.
    *
-   * \warning checkSign flag does not guarantee the Polyhedron's vertex order
+   * \warning tryFixOrientation flag does not guarantee the Polyhedron's vertex order
    *          will be valid. It is the responsiblity of the caller to pass
    *          an Octahedron with a valid vertex order. Otherwise, if the
    *          Octahedron has an invalid vertex order, the returned Polyhedron
    *          will have a non-positive and/or unexpected volume.
    *
+   * \warning If tryFixOrientation flag is false and some of the shapes have
+   *          a negative signed volume, the returned Polyhedron
+   *          will have a non-positive and/or unexpected volume.
+   *
    */
   AXOM_HOST_DEVICE
   static Polyhedron from_primitive(const Octahedron<T, NDIMS>& oct,
-                                   bool checkSign = false)
+                                   bool tryFixOrientation = false)
   {
     // Initialize our polyhedron to return
     Polyhedron<T, NDIMS> poly;
@@ -805,7 +810,7 @@ public:
     poly.addNeighbors(5, {0, 1, 3, 4});
 
     // Reverses order of vertices 1,2 and 4,5 if volume is negative.
-    if(checkSign)
+    if(tryFixOrientation)
     {
       if(poly.signedVolume() < 0)
       {
@@ -821,12 +826,10 @@ public:
    * \brief Creates a Polyhedron from a given Tetrahedron's vertices.
    *
    * \param [in] tet The tetrahedron
-   * \param [in] checkSign If true (default is false), checks if the
-   *             signed volume of the Polyhedron is positive. If signed volume
-   *             is negative, order of some vertices will be swapped to try to
-   *             obtain a positive volume for the Polyhedron. Otherwise, if the
-   *             signed volume is negative and the vertices are not swapped,
-   *             the returned Polyhedron will have a non-positive volume.
+   * \param [in] tryFixOrientation If true, checks if the signed volume of the
+   *             Polyhedron is positive and swaps the order of some vertices
+   *             in that shape to try to obtain a nonnegative signed volume.
+   *             Defaults to false.
    *
    * \return A Polyhedron with the Tetrahedron's vertices and added
    *         vertex neighbors
@@ -849,16 +852,20 @@ public:
    *       The Polyhedron's vertex neighbors are created assuming this vertex
    *       ordering.
    *
-   * \warning checkSign flag does not guarantee the Polyhedron's vertex order
-   *          will be valid. It is the responsiblity of the caller to pass
-   *          a Tetrahedron with a valid vertex order. Otherwise, if the
+   * \warning tryFixOrientation flag does not guarantee the Polyhedron's vertex
+   *          order will be valid. It is the responsiblity of the caller to
+   *          pass a Tetrahedron with a valid vertex order. Otherwise, if the
    *          Tetrahedron has an invalid vertex order, the returned Polyhedron
+   *          will have a non-positive and/or unexpected volume.
+   *
+   * \warning If tryFixOrientation flag is false and some of the shapes have
+   *          a negative signed volume, the returned Polyhedron
    *          will have a non-positive and/or unexpected volume.
    *
    */
   AXOM_HOST_DEVICE
   static Polyhedron from_primitive(const Tetrahedron<T, NDIMS>& tet,
-                                   bool checkSign = false)
+                                   bool tryFixOrientation = false)
   {
     // Initialize our polyhedron to return
     Polyhedron<T, NDIMS> poly;
@@ -874,7 +881,7 @@ public:
     poly.addNeighbors(3, {0, 1, 2});
 
     // Reverses order of vertices 1 and 2 if signed volume is negative
-    if(checkSign)
+    if(tryFixOrientation)
     {
       if(tet.signedVolume() < 0)
       {

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -673,7 +673,7 @@ public:
    *
    * \param [in] hex The hexahedron
    * \param [in] tryFixOrientation If true, checks if the signed volume of the
-   *             Polyhedron is positive and swaps the order of some vertices
+   *             Polyhedron is negative and swaps the order of some vertices
    *             in that shape to try to obtain a nonnegative signed volume.
    *             Defaults to false.
    *
@@ -751,7 +751,7 @@ public:
    *
    * \param [in] oct The octahedron
    * \param [in] tryFixOrientation If true, checks if the signed volume of the
-   *             Polyhedron is positive and swaps the order of some vertices
+   *             Polyhedron is negative and swaps the order of some vertices
    *             in that shape to try to obtain a nonnegative signed volume.
    *             Defaults to false.
    *
@@ -827,7 +827,7 @@ public:
    *
    * \param [in] tet The tetrahedron
    * \param [in] tryFixOrientation If true, checks if the signed volume of the
-   *             Polyhedron is positive and swaps the order of some vertices
+   *             Polyhedron is negative and swaps the order of some vertices
    *             in that shape to try to obtain a nonnegative signed volume.
    *             Defaults to false.
    *

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -675,8 +675,9 @@ public:
    * \param [in] checkSign If true (default is false), checks if the
    *             signed volume of the Polyhedron is positive. If signed volume
    *             is negative, order of some vertices will be swapped to try to
-   *             obtain a positive volume for the Polyhedron. Otherwise, the
-   *             returned Polyhedron will have a non-positive volume.
+   *             obtain a positive volume for the Polyhedron. Otherwise, if the
+   *             signed volume is negative and the vertices are not swapped,
+   *             the returned Polyhedron will have a non-positive volume.
    *
    * \return A Polyhedron with the Hexahedron's vertices and added
    *         vertex neighbors
@@ -700,9 +701,9 @@ public:
    *
    * \warning checkSign flag does not guarantee the Polyhedron's vertex order
    *          will be valid. It is the responsiblity of the caller to pass
-   *          a Hexahedron with a valid vertex order. Otherwise, the
-   *          Polyhedron will have a non-positive volume with an
-   *          invalid vertex order.
+   *          a Hexahedron with a valid vertex order. Otherwise, if the
+   *          Hexahedron has an invalid vertex order, the returned Polyhedron
+   *          will have a non-positive and/or unexpected volume.
    */
   AXOM_HOST_DEVICE
   static Polyhedron from_primitive(const Hexahedron<T, NDIMS>& hex,
@@ -749,8 +750,9 @@ public:
    * \param [in] checkSign If true (default is false), checks if the
    *             signed volume of the Polyhedron is positive. If signed volume
    *             is negative, order of some vertices will be swapped to try to
-   *             obtain a positive volume for the Polyhedron. Otherwise, the
-   *             returned Polyhedron will have a non-positive volume.
+   *             obtain a positive volume for the Polyhedron. Otherwise, if the
+   *             signed volume is negative and the vertices are not swapped,
+   *             the returned Polyhedron will have a non-positive volume.
    *
    * \return A Polyhedron with the Octahedron's vertices and added
    *         vertex neighbors
@@ -776,9 +778,10 @@ public:
    *
    * \warning checkSign flag does not guarantee the Polyhedron's vertex order
    *          will be valid. It is the responsiblity of the caller to pass
-   *          an Octahedron with a valid vertex order. Otherwise, the
-   *          Polyhedron will have a non-positive volume with an
-   *          invalid vertex order.
+   *          an Octahedron with a valid vertex order. Otherwise, if the
+   *          Octahedron has an invalid vertex order, the returned Polyhedron
+   *          will have a non-positive and/or unexpected volume.
+   *
    */
   AXOM_HOST_DEVICE
   static Polyhedron from_primitive(const Octahedron<T, NDIMS>& oct,
@@ -821,8 +824,9 @@ public:
    * \param [in] checkSign If true (default is false), checks if the
    *             signed volume of the Polyhedron is positive. If signed volume
    *             is negative, order of some vertices will be swapped to try to
-   *             obtain a positive volume for the Polyhedron. Otherwise, the
-   *             returned Polyhedron will have a non-positive volume.
+   *             obtain a positive volume for the Polyhedron. Otherwise, if the
+   *             signed volume is negative and the vertices are not swapped,
+   *             the returned Polyhedron will have a non-positive volume.
    *
    * \return A Polyhedron with the Tetrahedron's vertices and added
    *         vertex neighbors
@@ -847,9 +851,9 @@ public:
    *
    * \warning checkSign flag does not guarantee the Polyhedron's vertex order
    *          will be valid. It is the responsiblity of the caller to pass
-   *          a Tetrahedron with a valid vertex order. Otherwise, the
-   *          Polyhedron will have a non-positive volume with an
-   *          invalid vertex order.
+   *          a Tetrahedron with a valid vertex order. Otherwise, if the
+   *          Tetrahedron has an invalid vertex order, the returned Polyhedron
+   *          will have a non-positive and/or unexpected volume.
    *
    */
   AXOM_HOST_DEVICE

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -669,37 +669,41 @@ public:
   }
 
   /*!
- * \brief Creates a Polyhedron from a given Hexahedron's vertices.
- *
- * \param [in] hex The hexahedron
- * \param [in] checkSign If true (default is false), checks if the
- *             signed volume of the Polyhedron is positive. If signed volume
- *             is negative, order of some vertices will be swapped.
- *
- * \return A Polyhedron with the Hexahedron's vertices and added
- *         vertex neighbors
- *
- * \note The Hexahedron is assumed to have a specific vertex order:
- * \verbatim
- *
- *          4--------7          +z
- *         /|       /|               +y
- *        / |      / |           ^  >
- *       5--------6  |           | /
- *       |  0-----|--3           |/
- *       | /      | /            -----> +x
- *       |/       |/
- *       1--------2
- *
- * \endverbatim
- *
- *       The Polyhedron's vertex neighbors are created assuming this vertex
- *       ordering.
- *
- * \note checkSign flag does not guarantee the Polyhedron's vertex order
- *       will be valid. It is the responsiblity of the caller to pass
- *       a Hexahedron with a valid vertex order.
- */
+   * \brief Creates a Polyhedron from a given Hexahedron's vertices.
+   *
+   * \param [in] hex The hexahedron
+   * \param [in] checkSign If true (default is false), checks if the
+   *             signed volume of the Polyhedron is positive. If signed volume
+   *             is negative, order of some vertices will be swapped to try to
+   *             obtain a positive volume for the Polyhedron. Otherwise, the
+   *             returned Polyhedron will have a non-positive volume.
+   *
+   * \return A Polyhedron with the Hexahedron's vertices and added
+   *         vertex neighbors
+   *
+   * \note The Hexahedron is assumed to have a specific vertex order:
+   * \verbatim
+   *
+   *          4--------7          +z
+   *         /|       /|               +y
+   *        / |      / |           ^  >
+   *       5--------6  |           | /
+   *       |  0-----|--3           |/
+   *       | /      | /            -----> +x
+   *       |/       |/
+   *       1--------2
+   *
+   * \endverbatim
+   *
+   *       The Polyhedron's vertex neighbors are created assuming this vertex
+   *       ordering.
+   *
+   * \warning checkSign flag does not guarantee the Polyhedron's vertex order
+   *          will be valid. It is the responsiblity of the caller to pass
+   *          a Hexahedron with a valid vertex order. Otherwise, the
+   *          Polyhedron will have a non-positive volume with an
+   *          invalid vertex order.
+   */
   AXOM_HOST_DEVICE
   static Polyhedron from_primitive(const Hexahedron<T, NDIMS>& hex,
                                    bool checkSign = false)
@@ -739,39 +743,43 @@ public:
   }
 
   /*!
- * \brief Creates a Polyhedron from a given Octahedron's vertices.
- *
- * \param [in] oct The octahedron
- * \param [in] checkSign If true (default is false), checks if the
- *             signed volume of the Polyhedron is positive. If signed volume
- *             is negative, order of some vertices will be swapped.
- *
- * \return A Polyhedron with the Octahedron's vertices and added
- *         vertex neighbors
- *
- * \note The Octahedron is assumed to have a specific vertex order:
- *       (view looking down from +z axis):
- *
- * \verbatim
- *
- *            4                +z
- *            /\                    +y
- *       0 --/  \-- 2           ^  >
- *         \/    \ /            | /
- *         /      \             |/
- *       5 -------- 3           -----> +x
- *            \/
- *            1
- *
- * \endverbatim
- *
- *       The Polyhedron's vertex neighbors are created assuming this vertex
- *       ordering.
- *
- * \note checkSign flag does not guarantee the Polyhedron's vertex order
- *       will be valid. It is the responsiblity of the caller to pass
- *       a Octahedron with a valid vertex order.
- */
+   * \brief Creates a Polyhedron from a given Octahedron's vertices.
+   *
+   * \param [in] oct The octahedron
+   * \param [in] checkSign If true (default is false), checks if the
+   *             signed volume of the Polyhedron is positive. If signed volume
+   *             is negative, order of some vertices will be swapped to try to
+   *             obtain a positive volume for the Polyhedron. Otherwise, the
+   *             returned Polyhedron will have a non-positive volume.
+   *
+   * \return A Polyhedron with the Octahedron's vertices and added
+   *         vertex neighbors
+   *
+   * \note The Octahedron is assumed to have a specific vertex order:
+   *       (view looking down from +z axis):
+   *
+   * \verbatim
+   *
+   *            4                +z
+   *            /\                    +y
+   *       0 --/  \-- 2           ^  >
+   *         \/    \ /            | /
+   *         /      \             |/
+   *       5 -------- 3           -----> +x
+   *            \/
+   *            1
+   *
+   * \endverbatim
+   *
+   *       The Polyhedron's vertex neighbors are created assuming this vertex
+   *       ordering.
+   *
+   * \warning checkSign flag does not guarantee the Polyhedron's vertex order
+   *          will be valid. It is the responsiblity of the caller to pass
+   *          an Octahedron with a valid vertex order. Otherwise, the
+   *          Polyhedron will have a non-positive volume with an
+   *          invalid vertex order.
+   */
   AXOM_HOST_DEVICE
   static Polyhedron from_primitive(const Octahedron<T, NDIMS>& oct,
                                    bool checkSign = false)
@@ -807,38 +815,43 @@ public:
   }
 
   /*!
- * \brief Creates a Polyhedron from a given Tetrahedron's vertices.
- *
- * \param [in] tet The tetrahedron
- * \param [in] checkSign If true (default is false), checks if the
- *             signed volume of the Polyhedron is positive. If signed volume
- *             is negative, order of some vertices will be swapped.
- *
- * \return A Polyhedron with the Tetrahedron's vertices and added
- *         vertex neighbors
- *
- * \note The Tetrahedron is assumed to have a specific vertex order:
- * \verbatim
- *
- *              3                    +z
- *             / \\                       +y
- *            /   \ \                 ^  >
- *           /     \  \               | /
- *          /       \   \             |/
- *         /         \    2           -----> +x
- *        /           \  /
- *       /_____________\/
- *      0               1
- *
- * \endverbatim
- *
- *       The Polyhedron's vertex neighbors are created assuming this vertex
- *       ordering.
- *
- * \note checkSign flag does not guarantee the Polyhedron's vertex order
- *       will be valid. It is the responsiblity of the caller to pass
- *       a Tetrahedron with a valid vertex order.
- */
+   * \brief Creates a Polyhedron from a given Tetrahedron's vertices.
+   *
+   * \param [in] tet The tetrahedron
+   * \param [in] checkSign If true (default is false), checks if the
+   *             signed volume of the Polyhedron is positive. If signed volume
+   *             is negative, order of some vertices will be swapped to try to
+   *             obtain a positive volume for the Polyhedron. Otherwise, the
+   *             returned Polyhedron will have a non-positive volume.
+   *
+   * \return A Polyhedron with the Tetrahedron's vertices and added
+   *         vertex neighbors
+   *
+   * \note The Tetrahedron is assumed to have a specific vertex order:
+   * \verbatim
+   *
+   *              3                    +z
+   *             / \\                       +y
+   *            /   \ \                 ^  >
+   *           /     \  \               | /
+   *          /       \   \             |/
+   *         /         \    2           -----> +x
+   *        /           \  /
+   *       /_____________\/
+   *      0               1
+   *
+   * \endverbatim
+   *
+   *       The Polyhedron's vertex neighbors are created assuming this vertex
+   *       ordering.
+   *
+   * \warning checkSign flag does not guarantee the Polyhedron's vertex order
+   *          will be valid. It is the responsiblity of the caller to pass
+   *          a Tetrahedron with a valid vertex order. Otherwise, the
+   *          Polyhedron will have a non-positive volume with an
+   *          invalid vertex order.
+   *
+   */
   AXOM_HOST_DEVICE
   static Polyhedron from_primitive(const Tetrahedron<T, NDIMS>& tet,
                                    bool checkSign = false)

--- a/src/axom/primal/geometry/Tetrahedron.hpp
+++ b/src/axom/primal/geometry/Tetrahedron.hpp
@@ -259,6 +259,20 @@ public:
   AXOM_HOST_DEVICE
   double volume() const { return axom::utilities::abs(signedVolume()); }
 
+  /*!
+   * \brief Swaps the order of vertices if the signed volume of the
+   *        tetrahedron is negative. Signed volume will become positive.
+   * \sa signedVolume()
+   */
+  AXOM_HOST_DEVICE
+  void checkAndFixOrientation()
+  {
+    if(signedVolume() < 0)
+    {
+      axom::utilities::swap<PointType>(m_points[1], m_points[2]);
+    }
+  }
+
   /**
    * \brief Returns the circumsphere (circumscribing sphere) of the tetrahedron
    *

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -121,8 +121,9 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
  *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, the returned polyhedron
- *             will have a non-positive volume.
+ *             for that shape. Otherwise, if the
+ *             signed volume is negative and the vertices are not swapped, the
+ *             returned Polyhedron will have a non-positive volume.
  *
  * \return A polyhedron of the hexahedron clipped against the tetrahedron.
  *
@@ -130,8 +131,9 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
  *
  * \warning checkSign flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
- *          shapes with a valid vertex order. Otherwise, returned polyhedron
- *          will have a non-positive volume with invalid vertex orders.
+ *          shapes with a valid vertex order. Otherwise, if the shapes have
+ *          invalid vertex orders, the returned Polyhedron
+ *          will have a non-positive and/or unexpected volume.
  *
  */
 template <typename T>
@@ -165,8 +167,9 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Hexahedron<T, 3>& hex,
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
  *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, the returned polyhedron
- *             will have a non-positive volume.
+ *             for that shape. Otherwise, if the
+ *             signed volume is negative and the vertices are not swapped, the
+ *             returned Polyhedron will have a non-positive volume.
  *
  * \return A polyhedron of the hexahedron clipped against the tetrahedron.
  *
@@ -174,8 +177,9 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Hexahedron<T, 3>& hex,
  *
  * \warning checkSign flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
- *          shapes with a valid vertex order. Otherwise, returned polyhedron
- *          will have a non-positive volume with invalid vertex orders.
+ *          shapes with a valid vertex order. Otherwise, if the shapes have
+ *          invalid vertex orders, the returned Polyhedron
+ *          will have a non-positive and/or unexpected volume.
  *
  */
 template <typename T>
@@ -209,8 +213,9 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet,
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
  *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, the returned polyhedron
- *             will have a non-positive volume.
+ *             for that shape. Otherwise, if the
+ *             signed volume is negative and the vertices are not swapped, the
+ *             returned Polyhedron will have a non-positive volume.
  *
  * \return A polyhedron of the octahedron clipped against the tetrahedron.
  *
@@ -218,8 +223,9 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet,
  *
  * \warning checkSign flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
- *          shapes with a valid vertex order. Otherwise, returned polyhedron
- *          will have a non-positive volume with invalid vertex orders.
+ *          shapes with a valid vertex order. Otherwise, if the shapes have
+ *          invalid vertex orders, the returned Polyhedron
+ *          will have a non-positive and/or unexpected volume.
  *
  */
 template <typename T>
@@ -254,8 +260,9 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Octahedron<T, 3>& oct,
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
  *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, the returned polyhedron
- *             will have a non-positive volume.
+ *             for that shape. Otherwise, if the
+ *             signed volume is negative and the vertices are not swapped, the
+ *             returned Polyhedron will have a non-positive volume.
  *
  * \return A polyhedron of the octahedron clipped against the tetrahedron.
  *
@@ -263,8 +270,9 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Octahedron<T, 3>& oct,
  *
  * \warning checkSign flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
- *          shapes with a valid vertex order. Otherwise, returned polyhedron
- *          will have a non-positive volume with invalid vertex orders.
+ *          shapes with a valid vertex order. Otherwise, if the shapes have
+ *          invalid vertex orders, the returned Polyhedron
+ *          will have a non-positive and/or unexpected volume.
  *
  */
 template <typename T>
@@ -297,8 +305,9 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet,
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
  *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, the returned polyhedron
- *             will have a non-positive volume.
+ *             for that shape. Otherwise, if the
+ *             signed volume is negative and the vertices are not swapped, the
+ *             returned Polyhedron will have a non-positive volume.
  *
  * \return A polyhedron of the tetrahedron clipped against
  *         the other tetrahedron.
@@ -307,8 +316,9 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet,
  *
  * \warning checkSign flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
- *          shapes with a valid vertex order. Otherwise, returned polyhedron
- *          will have a non-positive volume with invalid vertex orders.
+ *          shapes with a valid vertex order. Otherwise, if the shapes have
+ *          invalid vertex orders, the returned Polyhedron
+ *          will have a non-positive and/or unexpected volume.
  *
  */
 template <typename T>

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -120,15 +120,18 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
  * \param [in] checkSign If true (default is false), checks if the
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
- *             swapped for that shape.
+ *             swapped to try to obtain a positive volume
+ *             for that shape. Otherwise, the returned polyhedron
+ *             will have a non-positive volume.
  *
  * \return A polyhedron of the hexahedron clipped against the tetrahedron.
  *
  * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
  *
- * \note checkSign flag does not guarantee the shapes' vertex orders
- *       will be valid. It is the responsiblity of the caller to pass
- *       shapes with a valid vertex order.
+ * \warning checkSign flag does not guarantee the shapes' vertex orders
+ *          will be valid. It is the responsiblity of the caller to pass
+ *          shapes with a valid vertex order. Otherwise, returned polyhedron
+ *          will have a non-positive volume with invalid vertex orders.
  *
  */
 template <typename T>
@@ -161,15 +164,18 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Hexahedron<T, 3>& hex,
  * \param [in] checkSign If true (default is false), checks if the
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
- *             swapped for that shape.
+ *             swapped to try to obtain a positive volume
+ *             for that shape. Otherwise, the returned polyhedron
+ *             will have a non-positive volume.
  *
  * \return A polyhedron of the hexahedron clipped against the tetrahedron.
  *
  * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
  *
- * \note checkSign flag does not guarantee the shapes' vertex orders
- *       will be valid. It is the responsiblity of the caller to pass
- *       shapes with a valid vertex order.
+ * \warning checkSign flag does not guarantee the shapes' vertex orders
+ *          will be valid. It is the responsiblity of the caller to pass
+ *          shapes with a valid vertex order. Otherwise, returned polyhedron
+ *          will have a non-positive volume with invalid vertex orders.
  *
  */
 template <typename T>
@@ -202,15 +208,18 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet,
  * \param [in] checkSign If true (default is false), checks if the
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
- *             swapped for that shape.
+ *             swapped to try to obtain a positive volume
+ *             for that shape. Otherwise, the returned polyhedron
+ *             will have a non-positive volume.
  *
  * \return A polyhedron of the octahedron clipped against the tetrahedron.
  *
  * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
  *
- * \note checkSign flag does not guarantee the shapes' vertex orders
- *       will be valid. It is the responsiblity of the caller to pass
- *       shapes with a valid vertex order.
+ * \warning checkSign flag does not guarantee the shapes' vertex orders
+ *          will be valid. It is the responsiblity of the caller to pass
+ *          shapes with a valid vertex order. Otherwise, returned polyhedron
+ *          will have a non-positive volume with invalid vertex orders.
  *
  */
 template <typename T>
@@ -244,15 +253,18 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Octahedron<T, 3>& oct,
  * \param [in] checkSign If true (default is false), checks if the
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
- *             swapped for that shape.
+ *             swapped to try to obtain a positive volume
+ *             for that shape. Otherwise, the returned polyhedron
+ *             will have a non-positive volume.
  *
  * \return A polyhedron of the octahedron clipped against the tetrahedron.
  *
  * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
  *
- * \note checkSign flag does not guarantee the shapes' vertex orders
- *       will be valid. It is the responsiblity of the caller to pass
- *       shapes with a valid vertex order.
+ * \warning checkSign flag does not guarantee the shapes' vertex orders
+ *          will be valid. It is the responsiblity of the caller to pass
+ *          shapes with a valid vertex order. Otherwise, returned polyhedron
+ *          will have a non-positive volume with invalid vertex orders.
  *
  */
 template <typename T>
@@ -284,16 +296,20 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet,
  * \param [in] checkSign If true (default is false), checks if the
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
- *             swapped for that shape.
+ *             swapped to try to obtain a positive volume
+ *             for that shape. Otherwise, the returned polyhedron
+ *             will have a non-positive volume.
  *
  * \return A polyhedron of the tetrahedron clipped against
  *         the other tetrahedron.
  *
  * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
  *
- * \note checkSign flag does not guarantee the shapes' vertex orders
- *       will be valid. It is the responsiblity of the caller to pass
- *       shapes with a valid vertex order.
+ * \warning checkSign flag does not guarantee the shapes' vertex orders
+ *          will be valid. It is the responsiblity of the caller to pass
+ *          shapes with a valid vertex order. Otherwise, returned polyhedron
+ *          will have a non-positive volume with invalid vertex orders.
+ *
  */
 template <typename T>
 AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet1,

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -117,22 +117,23 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
  * \param [in] hex The hexahedron to clip
  * \param [in] tet The tetrahedron to clip against
  * \param [in] eps The epsilon value
- * \param [in] checkSign If true (default is false), checks if the
- *             signed volume of each shape is positive. If the signed volume
- *             of that shape is negative, order of some vertices will be
- *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, if the
- *             signed volume is negative and the vertices are not swapped, the
- *             returned Polyhedron will have a non-positive volume.
+ * \param [in] tryFixOrientation If true, takes each shape with a negative
+ *             signed volume and swaps the order of some vertices in that
+ *             shape to try to obtain a nonnegative signed volume.
+ *             Defaults to false.
  *
  * \return A polyhedron of the hexahedron clipped against the tetrahedron.
  *
  * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
  *
- * \warning checkSign flag does not guarantee the shapes' vertex orders
+ * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
  *          shapes with a valid vertex order. Otherwise, if the shapes have
  *          invalid vertex orders, the returned Polyhedron
+ *          will have a non-positive and/or unexpected volume.
+ *
+ * \warning If tryFixOrientation flag is false and some of the shapes have
+ *          a negative signed volume, the returned Polyhedron
  *          will have a non-positive and/or unexpected volume.
  *
  */
@@ -140,9 +141,9 @@ template <typename T>
 AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Hexahedron<T, 3>& hex,
                                        const Tetrahedron<T, 3>& tet,
                                        double eps = 1.e-10,
-                                       bool checkSign = false)
+                                       bool tryFixOrientation = false)
 {
-  return detail::clipHexahedron(hex, tet, eps, checkSign);
+  return detail::clipHexahedron(hex, tet, eps, tryFixOrientation);
 }
 
 /*!
@@ -163,22 +164,23 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Hexahedron<T, 3>& hex,
  * \param [in] tet The tetrahedron to clip against
  * \param [in] hex The hexahedron to clip
  * \param [in] eps The epsilon value
- * \param [in] checkSign If true (default is false), checks if the
- *             signed volume of each shape is positive. If the signed volume
- *             of that shape is negative, order of some vertices will be
- *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, if the
- *             signed volume is negative and the vertices are not swapped, the
- *             returned Polyhedron will have a non-positive volume.
+ * \param [in] tryFixOrientation If true, takes each shape with a negative
+ *             signed volume and swaps the order of some vertices in that
+ *             shape to try to obtain a nonnegative signed volume.
+ *             Defaults to false.
  *
  * \return A polyhedron of the hexahedron clipped against the tetrahedron.
  *
  * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
  *
- * \warning checkSign flag does not guarantee the shapes' vertex orders
+ * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
  *          shapes with a valid vertex order. Otherwise, if the shapes have
  *          invalid vertex orders, the returned Polyhedron
+ *          will have a non-positive and/or unexpected volume.
+ *
+ * \warning If tryFixOrientation flag is false and some of the shapes have
+ *          a negative signed volume, the returned Polyhedron
  *          will have a non-positive and/or unexpected volume.
  *
  */
@@ -186,9 +188,9 @@ template <typename T>
 AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet,
                                        const Hexahedron<T, 3>& hex,
                                        double eps = 1.e-10,
-                                       bool checkSign = false)
+                                       bool tryFixOrientation = false)
 {
-  return clip(hex, tet, eps, checkSign);
+  return clip(hex, tet, eps, tryFixOrientation);
 }
 
 /*!
@@ -209,22 +211,23 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet,
  * \param [in] oct The octahedron to clip
  * \param [in] tet The tetrahedron to clip against
  * \param [in] eps The epsilon value
- * \param [in] checkSign If true (default is false), checks if the
- *             signed volume of each shape is positive. If the signed volume
- *             of that shape is negative, order of some vertices will be
- *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, if the
- *             signed volume is negative and the vertices are not swapped, the
- *             returned Polyhedron will have a non-positive volume.
+ * \param [in] tryFixOrientation If true, takes each shape with a negative
+ *             signed volume and swaps the order of some vertices in that
+ *             shape to try to obtain a nonnegative signed volume.
+ *             Defaults to false.
  *
  * \return A polyhedron of the octahedron clipped against the tetrahedron.
  *
  * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
  *
- * \warning checkSign flag does not guarantee the shapes' vertex orders
+ * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
  *          shapes with a valid vertex order. Otherwise, if the shapes have
  *          invalid vertex orders, the returned Polyhedron
+ *          will have a non-positive and/or unexpected volume.
+ *
+ * \warning If tryFixOrientation flag is false and some of the shapes have
+ *          a negative signed volume, the returned Polyhedron
  *          will have a non-positive and/or unexpected volume.
  *
  */
@@ -232,9 +235,9 @@ template <typename T>
 AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Octahedron<T, 3>& oct,
                                        const Tetrahedron<T, 3>& tet,
                                        double eps = 1.e-10,
-                                       bool checkSign = false)
+                                       bool tryFixOrientation = false)
 {
-  return detail::clipOctahedron(oct, tet, eps, checkSign);
+  return detail::clipOctahedron(oct, tet, eps, tryFixOrientation);
 }
 
 /*!
@@ -256,22 +259,23 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Octahedron<T, 3>& oct,
  * \param [in] oct The octahedron to clip
  * \param [in] tet The tetrahedron to clip against
  * \param [in] eps The epsilon value
- * \param [in] checkSign If true (default is false), checks if the
- *             signed volume of each shape is positive. If the signed volume
- *             of that shape is negative, order of some vertices will be
- *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, if the
- *             signed volume is negative and the vertices are not swapped, the
- *             returned Polyhedron will have a non-positive volume.
+ * \param [in] tryFixOrientation If true, takes each shape with a negative
+ *             signed volume and swaps the order of some vertices in that
+ *             shape to try to obtain a nonnegative signed volume.
+ *             Defaults to false.
  *
  * \return A polyhedron of the octahedron clipped against the tetrahedron.
  *
  * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
  *
- * \warning checkSign flag does not guarantee the shapes' vertex orders
+ * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
  *          shapes with a valid vertex order. Otherwise, if the shapes have
  *          invalid vertex orders, the returned Polyhedron
+ *          will have a non-positive and/or unexpected volume.
+ *
+ * \warning If tryFixOrientation flag is false and some of the shapes have
+ *          a negative signed volume, the returned Polyhedron
  *          will have a non-positive and/or unexpected volume.
  *
  */
@@ -279,9 +283,9 @@ template <typename T>
 AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet,
                                        const Octahedron<T, 3>& oct,
                                        double eps = 1.e-10,
-                                       bool checkSign = false)
+                                       bool tryFixOrientation = false)
 {
-  return clip(oct, tet, eps, checkSign);
+  return clip(oct, tet, eps, tryFixOrientation);
 }
 
 /*!
@@ -301,23 +305,24 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet,
  * \param [in] tet1 The tetrahedron to clip
  * \param [in] tet2 The tetrahedron to clip against
  * \param [in] eps The epsilon value
- * \param [in] checkSign If true (default is false), checks if the
- *             signed volume of each shape is positive. If the signed volume
- *             of that shape is negative, order of some vertices will be
- *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, if the
- *             signed volume is negative and the vertices are not swapped, the
- *             returned Polyhedron will have a non-positive volume.
+ * \param [in] tryFixOrientation If true, takes each shape with a negative
+ *             signed volume and swaps the order of some vertices in that
+ *             shape to try to obtain a nonnegative signed volume.
+ *             Defaults to false.
  *
  * \return A polyhedron of the tetrahedron clipped against
  *         the other tetrahedron.
  *
  * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
  *
- * \warning checkSign flag does not guarantee the shapes' vertex orders
+ * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
  *          shapes with a valid vertex order. Otherwise, if the shapes have
  *          invalid vertex orders, the returned Polyhedron
+ *          will have a non-positive and/or unexpected volume.
+ *
+ * \warning If tryFixOrientation flag is false and some of the shapes have
+ *          a negative signed volume, the returned Polyhedron
  *          will have a non-positive and/or unexpected volume.
  *
  */
@@ -325,9 +330,9 @@ template <typename T>
 AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet1,
                                        const Tetrahedron<T, 3>& tet2,
                                        double eps = 1.e-10,
-                                       bool checkSign = false)
+                                       bool tryFixOrientation = false)
 {
-  return detail::clipTetrahedron(tet1, tet2, eps, checkSign);
+  return detail::clipTetrahedron(tet1, tet2, eps, tryFixOrientation);
 }
 
 /*!

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -493,7 +493,7 @@ AXOM_HOST_DEVICE void clipPolyhedron(Polyhedron<T, NDIMS>& poly,
  * \param [in] hex The hexahedron
  * \param [in] tet The tetrahedron
  * \param [in] eps The tolerance for plane point orientation.
- * \param [in] checkSign Check if the signed volume of each shape is positive.
+ * \param [in] tryFixOrientation Check if the signed volume of each shape is positive.
  * \return The Polyhedron formed from clipping the hexahedron with a tetrahedron.
  *
  */
@@ -502,13 +502,13 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipHexahedron(
   const Hexahedron<T, NDIMS>& hex,
   const Tetrahedron<T, NDIMS>& tet,
   double eps,
-  bool checkSign)
+  bool tryFixOrientation)
 {
   using PlaneType = Plane<T, NDIMS>;
   using PolyhedronType = Polyhedron<T, NDIMS>;
 
   // Initialize our polyhedron to return
-  PolyhedronType poly = PolyhedronType::from_primitive(hex, checkSign);
+  PolyhedronType poly = PolyhedronType::from_primitive(hex, tryFixOrientation);
 
   // Initialize planes from tetrahedron vertices
   // (Ordering here matters to get the correct winding)
@@ -518,9 +518,10 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipHexahedron(
                          make_plane(tet[0], tet[1], tet[2])};
 
   // Adjusts planes in case tetrahedron signed volume is negative
-  if(checkSign)
+  if(tryFixOrientation)
   {
-    PolyhedronType tet_poly = PolyhedronType::from_primitive(tet, checkSign);
+    PolyhedronType tet_poly =
+      PolyhedronType::from_primitive(tet, tryFixOrientation);
     planes[0] = make_plane(tet_poly[1], tet_poly[3], tet_poly[2]);
     planes[1] = make_plane(tet_poly[0], tet_poly[2], tet_poly[3]);
     planes[2] = make_plane(tet_poly[0], tet_poly[3], tet_poly[1]);
@@ -541,7 +542,7 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipHexahedron(
  * \param [in] oct The octahedron
  * \param [in] tet The tetrahedron
  * \param [in] eps The tolerance for plane point orientation.
- * \param [in] checkSign Check if the signed volume of each shape is positive.
+ * \param [in] tryFixOrientation Check if the signed volume of each shape is positive.
  * \return The Polyhedron formed from clipping the octahedron with a tetrahedron.
  *
  */
@@ -550,13 +551,13 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipOctahedron(
   const Octahedron<T, NDIMS>& oct,
   const Tetrahedron<T, NDIMS>& tet,
   double eps,
-  bool checkSign)
+  bool tryFixOrientation)
 {
   using PlaneType = Plane<T, NDIMS>;
   using PolyhedronType = Polyhedron<T, NDIMS>;
 
   // Initialize our polyhedron to return
-  PolyhedronType poly = PolyhedronType::from_primitive(oct, checkSign);
+  PolyhedronType poly = PolyhedronType::from_primitive(oct, tryFixOrientation);
 
   // Initialize planes from tetrahedron vertices
   // (Ordering here matters to get the correct winding)
@@ -566,9 +567,10 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipOctahedron(
                          make_plane(tet[0], tet[1], tet[2])};
 
   // Adjusts planes in case tetrahedron signed volume is negative
-  if(checkSign)
+  if(tryFixOrientation)
   {
-    PolyhedronType tet_poly = PolyhedronType::from_primitive(tet, checkSign);
+    PolyhedronType tet_poly =
+      PolyhedronType::from_primitive(tet, tryFixOrientation);
     planes[0] = make_plane(tet_poly[1], tet_poly[3], tet_poly[2]);
     planes[1] = make_plane(tet_poly[0], tet_poly[2], tet_poly[3]);
     planes[2] = make_plane(tet_poly[0], tet_poly[3], tet_poly[1]);
@@ -589,7 +591,7 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipOctahedron(
  * \param [in] tet1 The tetrahedron to clip
  * \param [in] tet2 The tetrahedron to clip against
  * \param [in] eps The tolerance for plane point orientation.
- * \param [in] checkSign Check if the signed volume of each shape is positive.
+ * \param [in] tryFixOrientation Check if the signed volume of each shape is positive.
  * \return The Polyhedron formed from clipping the tetrahedron with a tetrahedron.
  *
  */
@@ -598,13 +600,13 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
   const Tetrahedron<T, NDIMS>& tet1,
   const Tetrahedron<T, NDIMS>& tet2,
   double eps,
-  bool checkSign)
+  bool tryFixOrientation)
 {
   using PlaneType = Plane<T, NDIMS>;
   using PolyhedronType = Polyhedron<T, NDIMS>;
 
   // Initialize our polyhedron to return
-  PolyhedronType poly = PolyhedronType::from_primitive(tet1, checkSign);
+  PolyhedronType poly = PolyhedronType::from_primitive(tet1, tryFixOrientation);
 
   // Initialize planes from tetrahedron vertices
   // (Ordering here matters to get the correct winding)
@@ -614,9 +616,10 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
                          make_plane(tet2[0], tet2[1], tet2[2])};
 
   // Adjusts planes in case tetrahedron signed volume is negative
-  if(checkSign)
+  if(tryFixOrientation)
   {
-    PolyhedronType tet_poly = PolyhedronType::from_primitive(tet2, checkSign);
+    PolyhedronType tet_poly =
+      PolyhedronType::from_primitive(tet2, tryFixOrientation);
     planes[0] = make_plane(tet_poly[1], tet_poly[3], tet_poly[2]);
     planes[1] = make_plane(tet_poly[0], tet_poly[2], tet_poly[3]);
     planes[2] = make_plane(tet_poly[0], tet_poly[3], tet_poly[1]);

--- a/src/axom/primal/operators/intersection_volume.hpp
+++ b/src/axom/primal/operators/intersection_volume.hpp
@@ -32,30 +32,31 @@ namespace primal
  * \param [in] hex The hexahedron
  * \param [in] tet The tetrahedron
  * \param [in] eps The tolerance for determining the intersection
- * \param [in] checkSign If true (default is false), checks if the
- *             signed volume of each shape is positive. If the signed volume
- *             of that shape is negative, order of some vertices will be
- *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, if the
- *             signed volume is negative and the vertices are not swapped,
- *             the returned volume may be zero and/or unexpected.
+ * \param [in] tryFixOrientation If true, takes each shape with a negative
+ *             signed volume and swaps the order of some vertices in that
+ *             shape to try to obtain a nonnegative signed volume.
+ *             Defaults to false.
  *
  * \return Intersection volume between the hexahedron and tetrahedron
  *
- * \warning checkSign flag does not guarantee the shapes' vertex orders
+ * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
  *          shapes with a valid vertex order. Otherwise, if the shapes have
  *          invalid vertex orders, the returned volume may be zero
  *          and/or unexpected.
+ *
+ * \warning If tryFixOrientation flag is false and some of the shapes have
+ *          a negative signed volume, the returned volume of intersection
+ *          may be zero and/or unexpected.
  *
  */
 template <typename T>
 AXOM_HOST_DEVICE T intersection_volume(const Hexahedron<T, 3>& hex,
                                        const Tetrahedron<T, 3>& tet,
                                        double eps = 1.e-10,
-                                       bool checkSign = false)
+                                       bool tryFixOrientation = false)
 {
-  return clip(hex, tet, eps, checkSign).volume();
+  return clip(hex, tet, eps, tryFixOrientation).volume();
 }
 
 /*!
@@ -65,30 +66,31 @@ AXOM_HOST_DEVICE T intersection_volume(const Hexahedron<T, 3>& hex,
  * \param [in] hex The tetrahedron
  * \param [in] tet The hexahedron
  * \param [in] eps The tolerance for determining the intersection
- * \param [in] checkSign If true (default is false), checks if the
- *             signed volume of each shape is positive. If the signed volume
- *             of that shape is negative, order of some vertices will be
- *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, if the
- *             signed volume is negative and the vertices are not swapped,
- *             the returned volume may be zero and/or unexpected.
+ * \param [in] tryFixOrientation If true, takes each shape with a negative
+ *             signed volume and swaps the order of some vertices in that
+ *             shape to try to obtain a nonnegative signed volume.
+ *             Defaults to false.
  *
  * \return Intersection volume between the tetrahedron and hexahedron
  *
- * \warning checkSign flag does not guarantee the shapes' vertex orders
+ * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
  *          shapes with a valid vertex order. Otherwise, if the shapes have
  *          invalid vertex orders, the returned volume may be zero
  *          and/or unexpected.
+ *
+ * \warning If tryFixOrientation flag is false and some of the shapes have
+ *          a negative signed volume, the returned volume of intersection
+ *          may be zero and/or unexpected.
  *
  */
 template <typename T>
 AXOM_HOST_DEVICE T intersection_volume(const Tetrahedron<T, 3>& tet,
                                        const Hexahedron<T, 3>& hex,
                                        double eps = 1.e-10,
-                                       bool checkSign = false)
+                                       bool tryFixOrientation = false)
 {
-  return intersection_volume(hex, tet, eps, checkSign);
+  return intersection_volume(hex, tet, eps, tryFixOrientation);
 }
 
 /*!
@@ -98,30 +100,31 @@ AXOM_HOST_DEVICE T intersection_volume(const Tetrahedron<T, 3>& tet,
  * \param [in] oct The octahedron
  * \param [in] tet The tetrahedron
  * \param [in] eps The tolerance for determining the intersection
- * \param [in] checkSign If true (default is false), checks if the
- *             signed volume of each shape is positive. If the signed volume
- *             of that shape is negative, order of some vertices will be
- *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, if the
- *             signed volume is negative and the vertices are not swapped,
- *             the returned volume may be zero and/or unexpected.
+ * \param [in] tryFixOrientation If true, takes each shape with a negative
+ *             signed volume and swaps the order of some vertices in that
+ *             shape to try to obtain a nonnegative signed volume.
+ *             Defaults to false.
  *
  * \return Intersection volume between the octahedron and tetrahedron
  *
- * \warning checkSign flag does not guarantee the shapes' vertex orders
+ * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
  *          shapes with a valid vertex order. Otherwise, if the shapes have
  *          invalid vertex orders, the returned volume may be zero
  *          and/or unexpected.
+ *
+ * \warning If tryFixOrientation flag is false and some of the shapes have
+ *          a negative signed volume, the returned volume of intersection
+ *          may be zero and/or unexpected.
  *
  */
 template <typename T>
 AXOM_HOST_DEVICE T intersection_volume(const Octahedron<T, 3>& oct,
                                        const Tetrahedron<T, 3>& tet,
                                        double eps = 1.e-10,
-                                       bool checkSign = false)
+                                       bool tryFixOrientation = false)
 {
-  return clip(oct, tet, eps, checkSign).volume();
+  return clip(oct, tet, eps, tryFixOrientation).volume();
 }
 
 /*!
@@ -131,30 +134,31 @@ AXOM_HOST_DEVICE T intersection_volume(const Octahedron<T, 3>& oct,
  * \param [in] oct The tetrahedron
  * \param [in] tet The octahedron
  * \param [in] eps The tolerance for determining the intersection
- * \param [in] checkSign If true (default is false), checks if the
- *             signed volume of each shape is positive. If the signed volume
- *             of that shape is negative, order of some vertices will be
- *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, if the
- *             signed volume is negative and the vertices are not swapped,
- *             the returned volume may be zero and/or unexpected.
+ * \param [in] tryFixOrientation If true, takes each shape with a negative
+ *             signed volume and swaps the order of some vertices in that
+ *             shape to try to obtain a nonnegative signed volume.
+ *             Defaults to false.
  *
  * \return Intersection volume between the tetrahedron and octahedron
  *
- * \warning checkSign flag does not guarantee the shapes' vertex orders
+ * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
  *          shapes with a valid vertex order. Otherwise, if the shapes have
  *          invalid vertex orders, the returned volume may be zero
  *          and/or unexpected.
+ *
+ * \warning If tryFixOrientation flag is false and some of the shapes have
+ *          a negative signed volume, the returned volume of intersection
+ *          may be zero and/or unexpected.
  *
  */
 template <typename T>
 AXOM_HOST_DEVICE T intersection_volume(const Tetrahedron<T, 3>& tet,
                                        const Octahedron<T, 3>& oct,
                                        double eps = 1.e-10,
-                                       bool checkSign = false)
+                                       bool tryFixOrientation = false)
 {
-  return intersection_volume(oct, tet, eps, checkSign);
+  return intersection_volume(oct, tet, eps, tryFixOrientation);
 }
 
 /*!
@@ -164,30 +168,31 @@ AXOM_HOST_DEVICE T intersection_volume(const Tetrahedron<T, 3>& tet,
  * \param [in] tet1 The tetrahedron
  * \param [in] tet2 The other tetrahedron
  * \param [in] eps The tolerance for determining the intersection
- * \param [in] checkSign If true (default is false), checks if the
- *             signed volume of each shape is positive. If the signed volume
- *             of that shape is negative, order of some vertices will be
- *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, if the
- *             signed volume is negative and the vertices are not swapped,
- *             the returned volume may be zero and/or unexpected.
+ * \param [in] tryFixOrientation If true, takes each shape with a negative
+ *             signed volume and swaps the order of some vertices in that
+ *             shape to try to obtain a nonnegative signed volume.
+ *             Defaults to false.
  *
  * \return Intersection volume between the tetrahedra
  *
- * \warning checkSign flag does not guarantee the shapes' vertex orders
+ * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
  *          shapes with a valid vertex order. Otherwise, if the shapes have
  *          invalid vertex orders, the returned volume may be zero
  *          and/or unexpected.
+ *
+ * \warning If tryFixOrientation flag is false and some of the shapes have
+ *          a negative signed volume, the returned volume of intersection
+ *          may be zero and/or unexpected.
  *
  */
 template <typename T>
 AXOM_HOST_DEVICE T intersection_volume(const Tetrahedron<T, 3>& tet1,
                                        const Tetrahedron<T, 3>& tet2,
                                        double eps = 1.e-10,
-                                       bool checkSign = false)
+                                       bool tryFixOrientation = false)
 {
-  return clip(tet1, tet2, eps, checkSign).volume();
+  return clip(tet1, tet2, eps, tryFixOrientation).volume();
 }
 
 }  // namespace primal

--- a/src/axom/primal/operators/intersection_volume.hpp
+++ b/src/axom/primal/operators/intersection_volume.hpp
@@ -35,13 +35,16 @@ namespace primal
  * \param [in] checkSign If true (default is false), checks if the
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
- *             swapped for that shape.
+ *             swapped to try to obtain a positive volume
+ *             for that shape. Otherwise, the returned volume
+ *             may be zero.
 
  * \return Intersection volume between the hexahedron and tetrahedron
  *
- * \note checkSign flag does not guarantee the shapes' vertex orders
- *       will be valid. It is the responsiblity of the caller to pass
- *       shapes with a valid vertex order.
+ * \warning checkSign flag does not guarantee the shapes' vertex orders
+ *          will be valid. It is the responsiblity of the caller to pass
+ *          shapes with a valid vertex order. Otherwise, the returned
+ *          volume may be zero.
  *
  */
 template <typename T>
@@ -63,13 +66,16 @@ AXOM_HOST_DEVICE T intersection_volume(const Hexahedron<T, 3>& hex,
  * \param [in] checkSign If true (default is false), checks if the
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
- *             swapped for that shape.
+ *             swapped to try to obtain a positive volume
+ *             for that shape. Otherwise, the returned volume
+ *             may be zero.
  *
  * \return Intersection volume between the tetrahedron and hexahedron
  *
- * \note checkSign flag does not guarantee the shapes' vertex orders
- *       will be valid. It is the responsiblity of the caller to pass
- *       shapes with a valid vertex order.
+ * \warning checkSign flag does not guarantee the shapes' vertex orders
+ *          will be valid. It is the responsiblity of the caller to pass
+ *          shapes with a valid vertex order. Otherwise, the returned
+ *          volume may be zero.
  *
  */
 template <typename T>
@@ -91,13 +97,16 @@ AXOM_HOST_DEVICE T intersection_volume(const Tetrahedron<T, 3>& tet,
  * \param [in] checkSign If true (default is false), checks if the
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
- *             swapped for that shape.
+ *             swapped to try to obtain a positive volume
+ *             for that shape. Otherwise, the returned volume
+ *             may be zero.
  *
  * \return Intersection volume between the octahedron and tetrahedron
  *
- * \note checkSign flag does not guarantee the shapes' vertex orders
- *       will be valid. It is the responsiblity of the caller to pass
- *       shapes with a valid vertex order.
+ * \warning checkSign flag does not guarantee the shapes' vertex orders
+ *          will be valid. It is the responsiblity of the caller to pass
+ *          shapes with a valid vertex order. Otherwise, the returned
+ *          volume may be zero.
  *
  */
 template <typename T>
@@ -119,13 +128,16 @@ AXOM_HOST_DEVICE T intersection_volume(const Octahedron<T, 3>& oct,
  * \param [in] checkSign If true (default is false), checks if the
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
- *             swapped for that shape.
+ *             swapped to try to obtain a positive volume
+ *             for that shape. Otherwise, the returned volume
+ *             may be zero.
  *
  * \return Intersection volume between the tetrahedron and octahedron
  *
- * \note checkSign flag does not guarantee the shapes' vertex orders
- *       will be valid. It is the responsiblity of the caller to pass
- *       shapes with a valid vertex order.
+ * \warning checkSign flag does not guarantee the shapes' vertex orders
+ *          will be valid. It is the responsiblity of the caller to pass
+ *          shapes with a valid vertex order. Otherwise, the returned
+ *          volume may be zero.
  *
  */
 template <typename T>
@@ -147,13 +159,16 @@ AXOM_HOST_DEVICE T intersection_volume(const Tetrahedron<T, 3>& tet,
  * \param [in] checkSign If true (default is false), checks if the
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
- *             swapped for that shape.
+ *             swapped to try to obtain a positive volume
+ *             for that shape. Otherwise, the returned volume
+ *             may be zero.
  *
  * \return Intersection volume between the tetrahedra
  *
- * \note checkSign flag does not guarantee the shapes' vertex orders
- *       will be valid. It is the responsiblity of the caller to pass
- *       shapes with a valid vertex order.
+ * \warning checkSign flag does not guarantee the shapes' vertex orders
+ *          will be valid. It is the responsiblity of the caller to pass
+ *          shapes with a valid vertex order. Otherwise, the returned
+ *          volume may be zero.
  *
  */
 template <typename T>

--- a/src/axom/primal/operators/intersection_volume.hpp
+++ b/src/axom/primal/operators/intersection_volume.hpp
@@ -36,15 +36,17 @@ namespace primal
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
  *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, the returned volume
- *             may be zero.
-
+ *             for that shape. Otherwise, if the
+ *             signed volume is negative and the vertices are not swapped,
+ *             the returned volume may be zero and/or unexpected.
+ *
  * \return Intersection volume between the hexahedron and tetrahedron
  *
  * \warning checkSign flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
- *          shapes with a valid vertex order. Otherwise, the returned
- *          volume may be zero.
+ *          shapes with a valid vertex order. Otherwise, if the shapes have
+ *          invalid vertex orders, the returned volume may be zero
+ *          and/or unexpected.
  *
  */
 template <typename T>
@@ -67,15 +69,17 @@ AXOM_HOST_DEVICE T intersection_volume(const Hexahedron<T, 3>& hex,
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
  *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, the returned volume
- *             may be zero.
+ *             for that shape. Otherwise, if the
+ *             signed volume is negative and the vertices are not swapped,
+ *             the returned volume may be zero and/or unexpected.
  *
  * \return Intersection volume between the tetrahedron and hexahedron
  *
  * \warning checkSign flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
- *          shapes with a valid vertex order. Otherwise, the returned
- *          volume may be zero.
+ *          shapes with a valid vertex order. Otherwise, if the shapes have
+ *          invalid vertex orders, the returned volume may be zero
+ *          and/or unexpected.
  *
  */
 template <typename T>
@@ -98,15 +102,17 @@ AXOM_HOST_DEVICE T intersection_volume(const Tetrahedron<T, 3>& tet,
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
  *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, the returned volume
- *             may be zero.
+ *             for that shape. Otherwise, if the
+ *             signed volume is negative and the vertices are not swapped,
+ *             the returned volume may be zero and/or unexpected.
  *
  * \return Intersection volume between the octahedron and tetrahedron
  *
  * \warning checkSign flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
- *          shapes with a valid vertex order. Otherwise, the returned
- *          volume may be zero.
+ *          shapes with a valid vertex order. Otherwise, if the shapes have
+ *          invalid vertex orders, the returned volume may be zero
+ *          and/or unexpected.
  *
  */
 template <typename T>
@@ -129,15 +135,17 @@ AXOM_HOST_DEVICE T intersection_volume(const Octahedron<T, 3>& oct,
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
  *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, the returned volume
- *             may be zero.
+ *             for that shape. Otherwise, if the
+ *             signed volume is negative and the vertices are not swapped,
+ *             the returned volume may be zero and/or unexpected.
  *
  * \return Intersection volume between the tetrahedron and octahedron
  *
  * \warning checkSign flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
- *          shapes with a valid vertex order. Otherwise, the returned
- *          volume may be zero.
+ *          shapes with a valid vertex order. Otherwise, if the shapes have
+ *          invalid vertex orders, the returned volume may be zero
+ *          and/or unexpected.
  *
  */
 template <typename T>
@@ -160,15 +168,17 @@ AXOM_HOST_DEVICE T intersection_volume(const Tetrahedron<T, 3>& tet,
  *             signed volume of each shape is positive. If the signed volume
  *             of that shape is negative, order of some vertices will be
  *             swapped to try to obtain a positive volume
- *             for that shape. Otherwise, the returned volume
- *             may be zero.
+ *             for that shape. Otherwise, if the
+ *             signed volume is negative and the vertices are not swapped,
+ *             the returned volume may be zero and/or unexpected.
  *
  * \return Intersection volume between the tetrahedra
  *
  * \warning checkSign flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
- *          shapes with a valid vertex order. Otherwise, the returned
- *          volume may be zero.
+ *          shapes with a valid vertex order. Otherwise, if the shapes have
+ *          invalid vertex orders, the returned volume may be zero
+ *          and/or unexpected.
  *
  */
 template <typename T>

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -366,7 +366,7 @@ void check_hex_tet_clip(double EPS)
 {
   using namespace Primal3D;
 
-  constexpr bool CHECK_SIGN = true;
+  constexpr bool CHECK_ORIENTATION = true;
 
   // Save current/default allocator
   const int current_allocator = axom::getDefaultAllocatorID();
@@ -401,7 +401,7 @@ void check_hex_tet_clip(double EPS)
               axom::primal::intersection_volume<double>(hex[0], tet[0]),
               EPS);
 
-  // Test checkSign optional parameter using shapes with negative volumes
+  // Test tryFixOrientation optional parameter using shapes with negative volumes
   axom::utilities::swap<PointType>(tet[0][1], tet[0][2]);
   axom::utilities::swap<PointType>(hex[0][1], hex[0][3]);
   axom::utilities::swap<PointType>(hex[0][5], hex[0][7]);
@@ -412,14 +412,16 @@ void check_hex_tet_clip(double EPS)
   axom::for_all<ExecPolicy>(
     1,
     AXOM_LAMBDA(int i) {
-      res[i] = axom::primal::clip(hex[i], tet[i], EPS, CHECK_SIGN);
+      res[i] = axom::primal::clip(hex[i], tet[i], EPS, CHECK_ORIENTATION);
     });
 
   EXPECT_NEAR(0.1666, res[0].volume(), EPS);
-  EXPECT_NEAR(
-    0.1666,
-    axom::primal::intersection_volume<double>(hex[0], tet[0], EPS, CHECK_SIGN),
-    EPS);
+  EXPECT_NEAR(0.1666,
+              axom::primal::intersection_volume<double>(hex[0],
+                                                        tet[0],
+                                                        EPS,
+                                                        CHECK_ORIENTATION),
+              EPS);
 
   axom::deallocate(tet);
   axom::deallocate(hex);
@@ -433,7 +435,7 @@ void check_oct_tet_clip(double EPS)
 {
   using namespace Primal3D;
 
-  constexpr bool CHECK_SIGN = true;
+  constexpr bool CHECK_ORIENTATION = true;
 
   // Save current/default allocator
   const int current_allocator = axom::getDefaultAllocatorID();
@@ -467,7 +469,7 @@ void check_oct_tet_clip(double EPS)
               axom::primal::intersection_volume<double>(oct[0], tet[0]),
               EPS);
 
-  // Test checkSign optional parameter using shapes with negative volumes
+  // Test tryFixOrientation optional parameter using shapes with negative volumes
   axom::utilities::swap<PointType>(tet[0][1], tet[0][2]);
   axom::utilities::swap<PointType>(oct[0][1], oct[0][2]);
   axom::utilities::swap<PointType>(oct[0][4], oct[0][5]);
@@ -477,14 +479,16 @@ void check_oct_tet_clip(double EPS)
   axom::for_all<ExecPolicy>(
     1,
     AXOM_LAMBDA(int i) {
-      res[i] = axom::primal::clip(oct[i], tet[i], EPS, CHECK_SIGN);
+      res[i] = axom::primal::clip(oct[i], tet[i], EPS, CHECK_ORIENTATION);
     });
 
   EXPECT_NEAR(0.1666, res[0].volume(), EPS);
-  EXPECT_NEAR(
-    0.1666,
-    axom::primal::intersection_volume<double>(oct[0], tet[0], EPS, CHECK_SIGN),
-    EPS);
+  EXPECT_NEAR(0.1666,
+              axom::primal::intersection_volume<double>(oct[0],
+                                                        tet[0],
+                                                        EPS,
+                                                        CHECK_ORIENTATION),
+              EPS);
 
   axom::deallocate(tet);
   axom::deallocate(oct);
@@ -498,7 +502,7 @@ void check_tet_tet_clip(double EPS)
 {
   using namespace Primal3D;
 
-  constexpr bool CHECK_SIGN = true;
+  constexpr bool CHECK_ORIENTATION = true;
 
   // Save current/default allocator
   const int current_allocator = axom::getDefaultAllocatorID();
@@ -530,7 +534,7 @@ void check_tet_tet_clip(double EPS)
               axom::primal::intersection_volume<double>(tet1[0], tet2[0]),
               EPS);
 
-  // Test checkSign optional parameter using shapes with negative volumes
+  // Test tryFixOrientation optional parameter using shapes with negative volumes
   axom::utilities::swap<PointType>(tet1[0][1], tet1[0][2]);
   axom::utilities::swap<PointType>(tet2[0][1], tet2[0][2]);
 
@@ -540,14 +544,16 @@ void check_tet_tet_clip(double EPS)
   axom::for_all<ExecPolicy>(
     1,
     AXOM_LAMBDA(int i) {
-      res[i] = axom::primal::clip(tet1[i], tet2[i], EPS, CHECK_SIGN);
+      res[i] = axom::primal::clip(tet1[i], tet2[i], EPS, CHECK_ORIENTATION);
     });
 
   EXPECT_NEAR(0.0833, res[0].volume(), EPS);
-  EXPECT_NEAR(
-    0.0833,
-    axom::primal::intersection_volume<double>(tet1[0], tet2[0], EPS, CHECK_SIGN),
-    EPS);
+  EXPECT_NEAR(0.0833,
+              axom::primal::intersection_volume<double>(tet1[0],
+                                                        tet2[0],
+                                                        EPS,
+                                                        CHECK_ORIENTATION),
+              EPS);
 
   axom::deallocate(tet1);
   axom::deallocate(tet2);
@@ -970,7 +976,7 @@ TEST(primal_clip, oct_tet_clip_special_case_1)
 {
   using namespace Primal3D;
   constexpr double EPS = 1e-4;
-  constexpr bool CHECK_SIGN = true;
+  constexpr bool CHECK_ORIENTATION = true;
 
   TetrahedronType tet(PointType {0.5, 0.5, 0.5},
                       PointType {1, 1, 0},
@@ -1003,18 +1009,18 @@ TEST(primal_clip, oct_tet_clip_special_case_1)
 
   EXPECT_NEAR(0.0251, octPoly.volume(), EPS);
 
-  PolyhedronType poly = axom::primal::clip(oct, tet, EPS, CHECK_SIGN);
+  PolyhedronType poly = axom::primal::clip(oct, tet, EPS, CHECK_ORIENTATION);
 
   EXPECT_NEAR(0.0041, poly.volume(), EPS);
   EXPECT_NEAR(
     0.0041,
-    axom::primal::intersection_volume<double>(oct, tet, EPS, CHECK_SIGN),
+    axom::primal::intersection_volume<double>(oct, tet, EPS, CHECK_ORIENTATION),
     EPS);
   EXPECT_NEAR(
     0.0041,
-    axom::primal::intersection_volume<double>(tet, oct, EPS, CHECK_SIGN),
+    axom::primal::intersection_volume<double>(tet, oct, EPS, CHECK_ORIENTATION),
     EPS);
-  EXPECT_NEAR(axom::primal::clip(tet, oct, EPS, CHECK_SIGN).volume(),
+  EXPECT_NEAR(axom::primal::clip(tet, oct, EPS, CHECK_ORIENTATION).volume(),
               poly.volume(),
               EPS);
 }
@@ -1023,7 +1029,7 @@ TEST(primal_clip, oct_tet_clip_special_case_2)
 {
   using namespace Primal3D;
   constexpr double EPS = 1e-4;
-  constexpr bool CHECK_SIGN = true;
+  constexpr bool CHECK_ORIENTATION = true;
 
   TetrahedronType tet(PointType {0.5, 0.5, 0.5},
                       PointType {0, 1, 0},
@@ -1056,18 +1062,18 @@ TEST(primal_clip, oct_tet_clip_special_case_2)
 
   EXPECT_NEAR(0.0251, octPoly.volume(), EPS);
 
-  PolyhedronType poly = axom::primal::clip(oct, tet, EPS, CHECK_SIGN);
+  PolyhedronType poly = axom::primal::clip(oct, tet, EPS, CHECK_ORIENTATION);
 
   EXPECT_NEAR(0.0041, poly.volume(), EPS);
   EXPECT_NEAR(
     0.0041,
-    axom::primal::intersection_volume<double>(oct, tet, EPS, CHECK_SIGN),
+    axom::primal::intersection_volume<double>(oct, tet, EPS, CHECK_ORIENTATION),
     EPS);
   EXPECT_NEAR(
     0.0041,
-    axom::primal::intersection_volume<double>(tet, oct, EPS, CHECK_SIGN),
+    axom::primal::intersection_volume<double>(tet, oct, EPS, CHECK_ORIENTATION),
     EPS);
-  EXPECT_NEAR(axom::primal::clip(tet, oct, EPS, CHECK_SIGN).volume(),
+  EXPECT_NEAR(axom::primal::clip(tet, oct, EPS, CHECK_ORIENTATION).volume(),
               poly.volume(),
               EPS);
 }
@@ -1227,7 +1233,7 @@ TEST(primal_clip, tet_tet_clip_split)
 {
   using namespace Primal3D;
   constexpr double EPS = 1e-4;
-  constexpr bool CHECK_SIGN = true;
+  constexpr bool CHECK_ORIENTATION = true;
 
   TetrahedronType tet(PointType {0.5, 0.5, 2},
                       PointType {2, -1, 0},
@@ -1257,7 +1263,7 @@ TEST(primal_clip, tet_tet_clip_split)
   for(int i = 0; i < split_tets.size(); i++)
   {
     tet_volumes +=
-      (axom::primal::clip(split_tets[i], tet, EPS, CHECK_SIGN)).volume();
+      (axom::primal::clip(split_tets[i], tet, EPS, CHECK_ORIENTATION)).volume();
   }
 
   // Expected result should still be 0.3333
@@ -1268,7 +1274,7 @@ TEST(primal_clip, tet_tet_clip_special_case_1)
 {
   using namespace Primal3D;
   constexpr double EPS = 1e-10;
-  constexpr bool CHECK_SIGN = true;
+  constexpr bool CHECK_ORIENTATION = true;
 
   // Tets do not intersect, but share a face
   TetrahedronType tet1(PointType {0.5, 0.5, -0.125},
@@ -1281,16 +1287,16 @@ TEST(primal_clip, tet_tet_clip_special_case_1)
                        PointType {0.125, 0, -0.25},
                        PointType {0.125, 0.0625, -0.234375});
 
-  PolyhedronType poly = axom::primal::clip(tet1, tet2, EPS, CHECK_SIGN);
+  PolyhedronType poly = axom::primal::clip(tet1, tet2, EPS, CHECK_ORIENTATION);
 
   EXPECT_NEAR(0.00, poly.volume(), EPS);
   EXPECT_NEAR(
     0.00,
-    axom::primal::intersection_volume<double>(tet2, tet1, EPS, CHECK_SIGN),
+    axom::primal::intersection_volume<double>(tet2, tet1, EPS, CHECK_ORIENTATION),
     EPS);
   EXPECT_NEAR(
     0.00,
-    axom::primal::intersection_volume<double>(tet1, tet2, EPS, CHECK_SIGN),
+    axom::primal::intersection_volume<double>(tet1, tet2, EPS, CHECK_ORIENTATION),
     EPS);
 }
 

--- a/src/axom/primal/tests/primal_hexahedron.cpp
+++ b/src/axom/primal/tests/primal_hexahedron.cpp
@@ -17,7 +17,7 @@ namespace primal = axom::primal;
 
 namespace
 {
-double volume_tet_decomp(primal::Hexahedron<double, 3> hex)
+double signed_volume_tet_decomp(primal::Hexahedron<double, 3> hex)
 {
   double retVol = 0.0;
   axom::StackArray<primal::Tetrahedron<double, 3>, 24> tets;
@@ -26,7 +26,8 @@ double volume_tet_decomp(primal::Hexahedron<double, 3> hex)
 
   for(int i = 0; i < 24; i++)
   {
-    retVol += tets[i].volume();
+    // Get the signed volumes
+    retVol += tets[i].signedVolume();
   }
 
   return retVol;
@@ -270,13 +271,16 @@ TEST_F(HexahedronTest, volume)
   EXPECT_DOUBLE_EQ(hex6.volume(), 1.5625);
 
   // Check hexahedron volume against 24-tetrahedron subvolumes
-  EXPECT_DOUBLE_EQ(hex0.volume(), volume_tet_decomp(hex0));
-  EXPECT_DOUBLE_EQ(hex1.volume(), volume_tet_decomp(hex1));
-  EXPECT_DOUBLE_EQ(hex2.volume(), volume_tet_decomp(hex2));
-  EXPECT_DOUBLE_EQ(hex3.volume(), volume_tet_decomp(hex3));
-  EXPECT_DOUBLE_EQ(hex4.volume(), volume_tet_decomp(hex4));
-  EXPECT_DOUBLE_EQ(hex5.volume(), volume_tet_decomp(hex5));
-  EXPECT_DOUBLE_EQ(hex6.volume(), volume_tet_decomp(hex6));
+  EXPECT_DOUBLE_EQ(hex0.volume(), signed_volume_tet_decomp(hex0));
+  EXPECT_DOUBLE_EQ(hex1.volume(), signed_volume_tet_decomp(hex1));
+  EXPECT_DOUBLE_EQ(hex2.volume(), signed_volume_tet_decomp(hex2));
+
+  // Negative volume expected
+  EXPECT_DOUBLE_EQ(hex3.signedVolume(), signed_volume_tet_decomp(hex3));
+
+  EXPECT_DOUBLE_EQ(hex4.volume(), signed_volume_tet_decomp(hex4));
+  EXPECT_DOUBLE_EQ(hex5.volume(), signed_volume_tet_decomp(hex5));
+  EXPECT_DOUBLE_EQ(hex6.volume(), signed_volume_tet_decomp(hex6));
 }
 
 TEST_F(HexahedronTest, equals)

--- a/src/axom/primal/tests/primal_tetrahedron.cpp
+++ b/src/axom/primal/tests/primal_tetrahedron.cpp
@@ -642,8 +642,17 @@ TEST_F(TetrahedronTest, checkSign)
     {
       QTet tetPermuted =
         QTet(tet[indices[0]], tet[indices[1]], tet[indices[2]], tet[indices[3]]);
+
+      double preCheckVolume = tetPermuted.volume();
+
       tetPermuted.checkAndFixOrientation();
       EXPECT_NEAR(expVolume, tetPermuted.signedVolume(), this->EPS);
+
+      // Verify absolute value of volume is still the same
+      EXPECT_NEAR(axom::utilities::abs(preCheckVolume),
+                  tetPermuted.signedVolume(),
+                  this->EPS);
+
     } while(std::next_permutation(indices, indices + QTet::NUM_VERTS));
   }
 }

--- a/src/axom/primal/tests/primal_tetrahedron.cpp
+++ b/src/axom/primal/tests/primal_tetrahedron.cpp
@@ -625,7 +625,7 @@ TEST_F(TetrahedronTest, regularTetrahedron)
   }
 }
 
-TEST_F(TetrahedronTest, checkSign)
+TEST_F(TetrahedronTest, checkAndFixOrientation)
 {
   using QPoint = TetrahedronTest::QPoint;
   using QTet = TetrahedronTest::QTet;
@@ -643,15 +643,16 @@ TEST_F(TetrahedronTest, checkSign)
       QTet tetPermuted =
         QTet(tet[indices[0]], tet[indices[1]], tet[indices[2]], tet[indices[3]]);
 
-      double preCheckVolume = tetPermuted.volume();
+      double preCheckAbsoluteVolume = tetPermuted.volume();
 
       tetPermuted.checkAndFixOrientation();
-      EXPECT_NEAR(expVolume, tetPermuted.signedVolume(), this->EPS);
+
+      double postCheckAbsoluteVolume = tetPermuted.volume();
+
+      EXPECT_NEAR(expVolume, postCheckAbsoluteVolume, this->EPS);
 
       // Verify absolute value of volume is still the same
-      EXPECT_NEAR(axom::utilities::abs(preCheckVolume),
-                  tetPermuted.signedVolume(),
-                  this->EPS);
+      EXPECT_NEAR(preCheckAbsoluteVolume, postCheckAbsoluteVolume, this->EPS);
 
     } while(std::next_permutation(indices, indices + QTet::NUM_VERTS));
   }

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -912,7 +912,7 @@ public:
       " Calculating element overlap volume from each tet-shape pair "));
 
     constexpr double EPS = 1e-10;
-    constexpr bool checkSign = true;
+    constexpr bool tryFixOrientation = true;
 
     AXOM_PERF_MARK_SECTION(
       "tet_shape_volume",
@@ -926,7 +926,7 @@ public:
           PolyhedronType poly = primal::clip(shapes_view[shapeIndex],
                                              tets_from_hexes_view[tetIndex],
                                              EPS,
-                                             checkSign);
+                                             tryFixOrientation);
 
           // Poly is valid
           if(poly.numVertices() >= 4)


### PR DESCRIPTION
This PR:
- Adds a `checkAndFixOrientation()` function to the `Tetrahedron` class that swaps vertex order if the signed volume is negative to get a positive volume.
- Adds detail to the `checkSign` flag documentation
- Adjusts unit test for `triangulate()` function of the `Hexahedron` class to check total _signed_ volume of the tetrahedron subvolumes.

Addresses #1206 