### PR TITLE
Add clip operator for a tet and plane

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -34,6 +34,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Primal: Adds a `Quadrilateral` primitive
 - Primal: Adds a `compute_bounding_box()` operator for computing the bounding
   box of a `Quadrilateral`
+- Primal: Adds a `clip()` operator for clipping a tetrahedron against the
+  half-space defined by a plane
 
 ### Fixed
 - quest's `SamplingShaper` now properly handles material names containing underscores

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -304,6 +304,82 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet1,
   return detail::clipTetrahedron(tet1, tet2, eps, checkSign);
 }
 
+/*!
+ * \brief Clips a 3D tetrahedron against a plane in 3D, returning
+ *        the geometric intersection as a polyhedron
+ *
+ *  This function clips the tetrahedron against the given plane. This
+ *  involves finding new vertices at the intersection of the polyhedron
+ *  edges and the plane, removing vertices from the polyhedron that are
+ *  below the plane, and redefining the neighbors for each vertex (a
+ *  vertex is a neighbor of another vertex if there is an edge between
+ *  them).
+ *
+ * \param [in] tet The tetrahedron to clip
+ * \param [in] plane The plane used to clip the tetrahedron
+ * \param [in] eps The tolerance used when computing on which side of the
+ *             plane a point lies
+ * \param [in] checkSign If true (default is false), checks if the signed
+ *             volume of the tetrahedron is positive. If the signed volume
+ *             of the tetrahedron is negative, the order of some vertices
+ *             will be swapped in order to obtain a positive signed volume.
+ *
+ * \return The polyhedron obtained from clipping the tetrahedron against
+ *         the plane.
+ *
+ * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
+ *
+ * \note checkSign flag does not guarantee the shapes' vertex orders
+ *       will be valid. It is the responsiblity of the caller to pass
+ *       shapes with a valid vertex order.
+ */
+template <typename T>
+AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet,
+                                       const Plane<T, 3>& plane,
+                                       double eps = 1.e-10,
+                                       bool checkSign = false)
+{
+  return detail::clipTetrahedron(tet, plane, eps, checkSign);
+}
+
+/*!
+ * \brief Clips a 3D tetrahedron against a plane in 3D, returning
+ *        the geometric intersection as a polyhedron
+ *
+ *  This function clips the tetrahedron against the given plane. This
+ *  involves finding new vertices at the intersection of the polyhedron
+ *  edges and the plane, removing vertices from the polyhedron that are
+ *  below the plane, and redefining the neighbors for each vertex (a
+ *  vertex is a neighbor of another vertex if there is an edge between
+ *  them).
+ *
+ * \param [in] plane The plane used to clip the tetrahedron
+ * \param [in] tet The tetrahedron to clip
+ * \param [in] eps The tolerance used when computing on which side of the
+ *             plane a point lies
+ * \param [in] checkSign If true (default is false), checks if the signed
+ *             volume of the tetrahedron is positive. If the signed volume
+ *             of the tetrahedron is negative, the order of some vertices
+ *             will be swapped in order to obtain a positive signed volume.
+ *
+ * \return The polyhedron obtained from clipping the tetrahedron against
+ *         the plane.
+ *
+ * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
+ *
+ * \note checkSign flag does not guarantee the shapes' vertex orders
+ *       will be valid. It is the responsiblity of the caller to pass
+ *       shapes with a valid vertex order.
+ */
+template <typename T>
+AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Plane<T, 3>& plane,
+                                       const Tetrahedron<T, 3>& tet,
+                                       double eps = 1.e-10,
+                                       bool checkSign = false)
+{
+  return clip(tet, plane, eps, checkSign);
+}
+
 }  // namespace primal
 }  // namespace axom
 

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -305,79 +305,87 @@ AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet1,
 }
 
 /*!
- * \brief Clips a 3D tetrahedron against a plane in 3D, returning
- *        the geometric intersection as a polyhedron
+ * \brief Clips a 3D tetrahedron against the half-space defined by a plane
+ *        and returns the resulting polyhedron
  *
- *  This function clips the tetrahedron against the given plane. This
- *  involves finding new vertices at the intersection of the polyhedron
- *  edges and the plane, removing vertices from the polyhedron that are
- *  below the plane, and redefining the neighbors for each vertex (a
- *  vertex is a neighbor of another vertex if there is an edge between
+ *  This function clips a tetrahedron against the half-space defined by a
+ *  plane. This involves finding new vertices at the intersection of the
+ *  polyhedron edges and the plane, removing vertices from the polyhedron
+ *  that are below the plane, and redefining the neighbors for each vertex
+ *  (a vertex is a neighbor of another vertex if there is an edge between
  *  them).
  *
  * \param [in] tet The tetrahedron to clip
- * \param [in] plane The plane used to clip the tetrahedron
- * \param [in] eps The tolerance used when computing on which side of the
- *             plane a point lies
- * \param [in] checkSign If true (default is false), checks if the signed
- *             volume of the tetrahedron is positive. If the signed volume
- *             of the tetrahedron is negative, the order of some vertices
- *             will be swapped in order to obtain a positive signed volume.
+ * \param [in] plane The plane defining the half-space used to clip the tetrahedron
+ * \param [in] eps The tolerance for plane point orientation
+ * \param [in] tryFixOrientation If true and the tetrahedron has a negative
+ *             signed volume, swaps the order of some vertices in the
+ *             tetrathedron to try to obtain a nonnegative signed volume.
+ *             Defaults to false.
  *
- * \return The polyhedron obtained from clipping the tetrahedron against
- *         the plane.
+ * \return The polyhedron obtained from clipping a tetrahedron against
+ *         the half-space defined by a plane.
  *
  * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
  *
- * \note checkSign flag does not guarantee the shapes' vertex orders
- *       will be valid. It is the responsiblity of the caller to pass
- *       shapes with a valid vertex order.
+ * \warning tryFixOrientation flag does not guarantee the tetrahedron's vertex
+ *          order will be valid. It is the responsiblity of the caller to pass
+ *          a tetrahedron with a valid vertex order. Otherwise, the returned
+ *          polyhedron will have a non-positive and/or unexpected volume.
+ *
+ * \warning If the tryFixOrientation flag is false and the tetrahedron has
+ *          a negative signed volume, the returned polyhedron will have a
+ *          non-positive and/or unexpected volume.
  */
 template <typename T>
 AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Tetrahedron<T, 3>& tet,
                                        const Plane<T, 3>& plane,
                                        double eps = 1.e-10,
-                                       bool checkSign = false)
+                                       bool tryFixOrientation = false)
 {
-  return detail::clipTetrahedron(tet, plane, eps, checkSign);
+  return detail::clipTetrahedron(tet, plane, eps, tryFixOrientation);
 }
 
 /*!
- * \brief Clips a 3D tetrahedron against a plane in 3D, returning
- *        the geometric intersection as a polyhedron
+ * \brief Clips a 3D tetrahedron against the half-space defined by a plane
+ *        and returns the resulting polyhedron
  *
- *  This function clips the tetrahedron against the given plane. This
- *  involves finding new vertices at the intersection of the polyhedron
- *  edges and the plane, removing vertices from the polyhedron that are
- *  below the plane, and redefining the neighbors for each vertex (a
- *  vertex is a neighbor of another vertex if there is an edge between
+ *  This function clips a tetrahedron against the half-space defined by a
+ *  plane. This involves finding new vertices at the intersection of the
+ *  polyhedron edges and the plane, removing vertices from the polyhedron
+ *  that are below the plane, and redefining the neighbors for each vertex
+ *  (a vertex is a neighbor of another vertex if there is an edge between
  *  them).
  *
- * \param [in] plane The plane used to clip the tetrahedron
+ * \param [in] plane The plane defining the half-space used to clip the tetrahedron
  * \param [in] tet The tetrahedron to clip
- * \param [in] eps The tolerance used when computing on which side of the
- *             plane a point lies
- * \param [in] checkSign If true (default is false), checks if the signed
- *             volume of the tetrahedron is positive. If the signed volume
- *             of the tetrahedron is negative, the order of some vertices
- *             will be swapped in order to obtain a positive signed volume.
+ * \param [in] eps The tolerance for plane point orientation
+ * \param [in] tryFixOrientation If true and the tetrahedron has a negative
+ *             signed volume, swaps the order of some vertices in the
+ *             tetrathedron to try to obtain a nonnegative signed volume.
+ *             Defaults to false.
  *
- * \return The polyhedron obtained from clipping the tetrahedron against
- *         the plane.
+ * \return The polyhedron obtained from clipping a tetrahedron against
+ *         the half-space defined by a plane.
  *
  * \note Function is based off clipPolyhedron() in Mike Owen's PolyClipper.
  *
- * \note checkSign flag does not guarantee the shapes' vertex orders
- *       will be valid. It is the responsiblity of the caller to pass
- *       shapes with a valid vertex order.
+ * \warning tryFixOrientation flag does not guarantee the tetrahedron's vertex
+ *          order will be valid. It is the responsiblity of the caller to pass
+ *          a tetrahedron with a valid vertex order. Otherwise, the returned
+ *          polyhedron will have a non-positive and/or unexpected volume.
+ *
+ * \warning If the tryFixOrientation flag is false and the tetrahedron has
+ *          a negative signed volume, the returned polyhedron will have a
+ *          non-positive and/or unexpected volume.
  */
 template <typename T>
 AXOM_HOST_DEVICE Polyhedron<T, 3> clip(const Plane<T, 3>& plane,
                                        const Tetrahedron<T, 3>& tet,
                                        double eps = 1.e-10,
-                                       bool checkSign = false)
+                                       bool tryFixOrientation = false)
 {
-  return clip(tet, plane, eps, checkSign);
+  return clip(tet, plane, eps, tryFixOrientation);
 }
 
 }  // namespace primal

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -409,15 +409,14 @@ AXOM_HOST_DEVICE void poly_clip_reindex(Polyhedron<T, NDIMS>& poly,
  * \return The polyhedron formed from clipping the input polyhedron with a plane
  */
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(
-  Polyhedron<T, NDIMS>& poly,
-  const Plane<T, NDIMS>& plane,
-  double eps)
+AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(Polyhedron<T, NDIMS>& poly,
+                                                     const Plane<T, NDIMS>& plane,
+                                                     double eps)
 {
   using BoxType = BoundingBox<T, NDIMS>;
 
   // Check that plane intersects Polyhedron
-  if (intersect(plane, BoxType(&poly[0], poly.numVertices()), true, eps))
+  if(intersect(plane, BoxType(&poly[0], poly.numVertices()), true, eps))
   {
     int numVerts = poly.numVertices();
 
@@ -443,16 +442,16 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(
   {
     bool completeClip = true;
 
-    for (int i = 0; i < poly.numVertices(); i++)
+    for(int i = 0; i < poly.numVertices(); i++)
     {
-      if (plane.getOrientation(poly[i], eps) == ON_POSITIVE_SIDE)
+      if(plane.getOrientation(poly[i], eps) == ON_POSITIVE_SIDE)
       {
         completeClip = false;
         break;
       }
     }
 
-    if (completeClip)
+    if(completeClip)
     {
       poly.clear();
     }
@@ -481,7 +480,7 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(
   using PlaneType = Plane<T, NDIMS>;
 
   // Clip Polyhedron by each plane
-  for (const PlaneType& plane : planes)
+  for(const PlaneType& plane : planes)
   {
     clipPolyhedron(poly, plane, eps);
   }

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -402,7 +402,7 @@ AXOM_HOST_DEVICE void poly_clip_reindex(Polyhedron<T, NDIMS>& poly,
 /*!
  * \brief Clips a polyhedron against a half-space defined by a plane
  *
- * \param [in/out] poly The polyhedron to clip
+ * \param [inout] poly The polyhedron to clip
  * \param [in] plane The plane defining the half-space used to clip the polyhedron
  * \param [in] eps The tolerance for plane point orientation
  */
@@ -461,7 +461,7 @@ AXOM_HOST_DEVICE void clipPolyhedron(Polyhedron<T, NDIMS>& poly,
 /*!
  * \brief Clips a polyhedron against an array of planes
  *
- * \param [in/out] poly The polyhedron to clip
+ * \param [inout] poly The polyhedron to clip
  * \param [in] planes The array of planes
  * \param [in] eps The tolerance for plane point orientation
  */

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -478,64 +478,12 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(
   axom::ArrayView<Plane<T, NDIMS>> planes,
   double eps)
 {
-  using PointType = Point<T, NDIMS>;
-  using BoxType = BoundingBox<T, NDIMS>;
   using PlaneType = Plane<T, NDIMS>;
 
-  //Bounding Box of Polyhedron
-  BoxType polyBox(&poly[0], poly.numVertices());
-
-  //Clip Polyhedron by each plane
-  for(PlaneType plane : planes)
+  // Clip Polyhedron by each plane
+  for (const PlaneType& plane : planes)
   {
-    // Check that plane intersects Polyhedron
-    if(intersect(plane, polyBox, true, eps))
-    {
-      int numVerts = poly.numVertices();
-
-      // Each bit value indicates if that Polyhedron vertex is formed from
-      // Polyhedron clipping with a plane.
-      unsigned int clipped = 0;
-
-      // Clip polyhedron against current plane, generating extra vertices
-      // where edges meet the plane.
-      poly_clip_vertices(poly, plane, eps, clipped);
-
-      // Adjust connectivity to link up newly-generated vertices.
-      poly_clip_fix_nbrs(poly, plane, numVerts, eps, clipped);
-
-      // Reindex polyhedron connectivity by removing vertices on the negative
-      // side of the plane.
-      poly_clip_reindex(poly, clipped);
-
-      // Generate new bounding box for polyhedron
-      polyBox = BoxType();
-
-      for(int i = 0; i < poly.numVertices(); i++)
-      {
-        polyBox.addPoint(PointType(poly[i]));
-      }
-    }
-
-    // If entire polyhedron is below a plane (points can be on the plane), it is completely removed.
-    else
-    {
-      bool completeClip = true;
-      for(int i = 0; i < poly.numVertices(); i++)
-      {
-        if(plane.getOrientation(poly[i], eps) == ON_POSITIVE_SIDE)
-        {
-          completeClip = false;
-          break;
-        }
-      }
-
-      if(completeClip)
-      {
-        poly.clear();
-        return poly;
-      }
-    }
+    clipPolyhedron(poly, plane, eps);
   }
 
   return poly;

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -400,18 +400,16 @@ AXOM_HOST_DEVICE void poly_clip_reindex(Polyhedron<T, NDIMS>& poly,
 }
 
 /*!
- * \brief Finds the polyhedron formed from clipping a polyhedron with a plane
+ * \brief Clips a polyhedron against a half-space defined by a plane
  *
- * \param [in] poly The polyhedron to clip
- * \param [in] plane The plane used to clip the polyhedron
+ * \param [in/out] poly The polyhedron to clip
+ * \param [in] plane The plane defining the half-space used to clip the polyhedron
  * \param [in] eps The tolerance for plane point orientation
- *
- * \return The polyhedron formed from clipping the input polyhedron with a plane
  */
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(Polyhedron<T, NDIMS>& poly,
-                                                     const Plane<T, NDIMS>& plane,
-                                                     double eps)
+AXOM_HOST_DEVICE void clipPolyhedron(Polyhedron<T, NDIMS>& poly,
+                                     const Plane<T, NDIMS>& plane,
+                                     double eps)
 {
   using BoxType = BoundingBox<T, NDIMS>;
 
@@ -457,25 +455,20 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(Polyhedron<T, NDIMS>& poly,
     }
   }
 
-  return poly;
+  return;
 }
 
 /*!
- * \brief Finds the clipped intersection Polyhedron between Polyhedron
- *        poly and an array of Planes.
+ * \brief Clips a polyhedron against an array of planes
  *
- * \param [in] poly The polyhedron
+ * \param [in/out] poly The polyhedron to clip
  * \param [in] planes The array of planes
- * \param [in] eps The tolerance for plane point orientation.
- *
- * \return The Polyhedron formed from clipping the polyhedron with a set of planes.
- *
+ * \param [in] eps The tolerance for plane point orientation
  */
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(
-  Polyhedron<T, NDIMS>& poly,
-  axom::ArrayView<Plane<T, NDIMS>> planes,
-  double eps)
+AXOM_HOST_DEVICE void clipPolyhedron(Polyhedron<T, NDIMS>& poly,
+                                     axom::ArrayView<Plane<T, NDIMS>> planes,
+                                     double eps)
 {
   using PlaneType = Plane<T, NDIMS>;
 
@@ -483,9 +476,14 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipPolyhedron(
   for(const PlaneType& plane : planes)
   {
     clipPolyhedron(poly, plane, eps);
+
+    if(poly.numVertices() == 0)
+    {
+      return;
+    }
   }
 
-  return poly;
+  return;
 }
 
 /*!
@@ -532,7 +530,8 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipHexahedron(
   axom::StackArray<IndexType, 1> planeSize = {4};
   axom::ArrayView<PlaneType> planesView(planes, planeSize);
 
-  return clipPolyhedron(poly, planesView, eps);
+  clipPolyhedron(poly, planesView, eps);
+  return poly;
 }
 
 /*!
@@ -579,7 +578,8 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipOctahedron(
   axom::StackArray<IndexType, 1> planeSize = {4};
   axom::ArrayView<PlaneType> planesView(planes, planeSize);
 
-  return clipPolyhedron(poly, planesView, eps);
+  clipPolyhedron(poly, planesView, eps);
+  return poly;
 }
 
 /*!
@@ -626,7 +626,8 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
   axom::StackArray<IndexType, 1> planeSize = {4};
   axom::ArrayView<PlaneType> planesView(planes, planeSize);
 
-  return clipPolyhedron(poly, planesView, eps);
+  clipPolyhedron(poly, planesView, eps);
+  return poly;
 }
 
 /*!
@@ -651,7 +652,8 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
   // Initialize our polyhedron to return
   PolyhedronType poly = PolyhedronType::from_primitive(tet, checkSign);
 
-  return clipPolyhedron(poly, plane, eps);
+  clipPolyhedron(poly, plane, eps);
+  return poly;
 }
 
 }  // namespace detail

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -631,27 +631,38 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
 }
 
 /*!
- * \brief Finds the polyhedron formed from clipping a tetrahedron by a plane.
+ * \brief Clips a tetrahedron against the half-space defined by a plane
+ *        and returns the resulting polyhedron
  *
  * \param [in] tet The tetrahedron to clip
- * \param [in] plane The plane used to clip the tetrahedron
+ * \param [in] plane The plane defining the half-space used to clip the tetrahedron
  * \param [in] eps The tolerance for plane point orientation
- * \param [in] checkSign Check if the signed volume of each shape is positive
+ * \param [in] tryFixOrientation If true and the tetrahedron has a negative
+ *             signed volume, swaps the order of some vertices in the
+ *             tetrathedron to try to obtain a nonnegative signed volume.
+ *             Defaults to false.
  *
- * \return The polyhedron formed from clipping a tetrahedron by a plane
+ * \return The polyhedron obtained from clipping a tetrahedron against
+ *         the half-space defined a plane
+ *
+ * \warning tryFixOrientation flag does not guarantee the tetrahedron's vertex
+ *          order will be valid. It is the responsiblity of the caller to pass
+ *          a tetrahedron with a valid vertex order. Otherwise, the returned
+ *          polyhedron will have a non-positive and/or unexpected volume.
+ *
+ * \warning If the tryFixOrientation flag is false and the tetrahedron has
+ *          a negative signed volume, the returned polyhedron will have a
+ *          non-positive and/or unexpected volume.
  */
 template <typename T, int NDIMS>
 AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
   const Tetrahedron<T, NDIMS>& tet,
   const Plane<T, NDIMS>& plane,
   double eps,
-  bool checkSign)
+  bool tryFixOrientation)
 {
   using PolyhedronType = Polyhedron<T, NDIMS>;
-
-  // Initialize our polyhedron to return
-  PolyhedronType poly = PolyhedronType::from_primitive(tet, checkSign);
-
+  PolyhedronType poly = PolyhedronType::from_primitive(tet, tryFixOrientation);
   clipPolyhedron(poly, plane, eps);
   return poly;
 }

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -1465,7 +1465,24 @@ TEST(primal_clip, tet_plane_intersect_three_edges)
   EXPECT_NEAR(tet.signedVolume() / 2.0, poly.signedVolume(), EPS);
 }
 
-// TODO: Add a test for a plane that intersects four edges of a tet
+TEST(primal_clip, tet_plane_intersect_four_edges)
+{
+  using namespace Primal3D;
+  constexpr double EPS = 1e-10;
+  constexpr bool CHECK_SIGN = true;
+
+  // Plane intersects four edges of tet
+  TetrahedronType tet(PointType {0.0, 0.0, 0.0},
+                      PointType {1.0, 1.0, 0.0},
+                      PointType {0.0, 1.0, 1.0},
+                      PointType {1.0, 0.0, 1.0});
+
+  PlaneType plane(VectorType {0.0, 0.0, 1.0}, 0.5);
+
+  PolyhedronType poly = axom::primal::clip(plane, tet, EPS, CHECK_SIGN);
+
+  EXPECT_NEAR(tet.signedVolume() / 2.0, poly.signedVolume(), EPS);
+}
 
 //------------------------------------------------------------------------------
 int main(int argc, char* argv[])

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -1310,7 +1310,7 @@ TEST(primal_clip, tet_plane_intersect_none_below)
 
   PolyhedronType poly = axom::primal::clip(tet, plane, EPS, CHECK_SIGN);
 
-  EXPECT_NEAR(0.0, poly.volume(), EPS);
+  EXPECT_NEAR(0.0, poly.signedVolume(), EPS);
 }
 
 TEST(primal_clip, tet_plane_intersect_none_above)
@@ -1329,7 +1329,7 @@ TEST(primal_clip, tet_plane_intersect_none_above)
 
   PolyhedronType poly = axom::primal::clip(tet, plane, EPS, CHECK_SIGN);
 
-  EXPECT_NEAR(tet.volume(), poly.volume(), EPS);
+  EXPECT_NEAR(tet.signedVolume(), poly.signedVolume(), EPS);
 }
 
 TEST(primal_clip, tet_plane_border_vertex_below)
@@ -1348,7 +1348,7 @@ TEST(primal_clip, tet_plane_border_vertex_below)
 
   PolyhedronType poly = axom::primal::clip(tet, plane, EPS, CHECK_SIGN);
 
-  EXPECT_NEAR(0.0, poly.volume(), EPS);
+  EXPECT_NEAR(0.0, poly.signedVolume(), EPS);
 }
 
 TEST(primal_clip, tet_plane_border_vertex_above)
@@ -1367,7 +1367,7 @@ TEST(primal_clip, tet_plane_border_vertex_above)
 
   PolyhedronType poly = axom::primal::clip(tet, plane, EPS, CHECK_SIGN);
 
-  EXPECT_NEAR(tet.volume(), poly.volume(), EPS);
+  EXPECT_NEAR(tet.signedVolume(), poly.signedVolume(), EPS);
 }
 
 TEST(primal_clip, tet_plane_border_edge_below)
@@ -1386,7 +1386,7 @@ TEST(primal_clip, tet_plane_border_edge_below)
 
   PolyhedronType poly = axom::primal::clip(tet, plane, EPS, CHECK_SIGN);
 
-  EXPECT_NEAR(0.0, poly.volume(), EPS);
+  EXPECT_NEAR(0.0, poly.signedVolume(), EPS);
 }
 
 TEST(primal_clip, tet_plane_border_edge_above)
@@ -1405,7 +1405,7 @@ TEST(primal_clip, tet_plane_border_edge_above)
 
   PolyhedronType poly = axom::primal::clip(tet, plane, EPS, CHECK_SIGN);
 
-  EXPECT_NEAR(tet.volume(), poly.volume(), EPS);
+  EXPECT_NEAR(tet.signedVolume(), poly.signedVolume(), EPS);
 }
 
 TEST(primal_clip, tet_plane_border_face_below)
@@ -1424,7 +1424,7 @@ TEST(primal_clip, tet_plane_border_face_below)
 
   PolyhedronType poly = axom::primal::clip(plane, tet, EPS, CHECK_SIGN);
 
-  EXPECT_NEAR(0.0, poly.volume(), EPS);
+  EXPECT_NEAR(0.0, poly.signedVolume(), EPS);
 }
 
 TEST(primal_clip, tet_plane_border_face_above)
@@ -1443,7 +1443,7 @@ TEST(primal_clip, tet_plane_border_face_above)
 
   PolyhedronType poly = axom::primal::clip(plane, tet, EPS, CHECK_SIGN);
 
-  EXPECT_NEAR(tet.volume(), poly.volume(), EPS);
+  EXPECT_NEAR(tet.signedVolume(), poly.signedVolume(), EPS);
 }
 
 TEST(primal_clip, tet_plane_intersect_three_edges)
@@ -1462,7 +1462,7 @@ TEST(primal_clip, tet_plane_intersect_three_edges)
 
   PolyhedronType poly = axom::primal::clip(plane, tet, EPS, CHECK_SIGN);
 
-  EXPECT_NEAR(tet.volume() / 2.0, poly.volume(), EPS);
+  EXPECT_NEAR(tet.signedVolume() / 2.0, poly.signedVolume(), EPS);
 }
 
 // TODO: Add a test for a plane that intersects four edges of a tet

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -1294,6 +1294,124 @@ TEST(primal_clip, tet_tet_clip_special_case_1)
     EPS);
 }
 
+TEST(primal_clip, tet_plane_no_intersect_below)
+{
+  using namespace Primal3D;
+  constexpr double EPS = 1e-10;
+  constexpr bool CHECK_SIGN = true;
+
+  // Tet and plane do not intersect
+  TetrahedronType tet(PointType {0.0, 0.0, 0.0},
+                      PointType {1.0, 0.0, 0.0},
+                      PointType {0.0, 1.0, 0.0},
+                      PointType {0.0, 0.0, 1.0});
+
+  PlaneType plane(VectorType {0.0, 0.0, -1.0}, PointType {0.0, 0.0, -0.5});
+
+  PolyhedronType poly = axom::primal::clip(tet, plane, EPS, CHECK_SIGN);
+
+  EXPECT_NEAR(0.0, poly.volume(), EPS);
+}
+
+TEST(primal_clip, tet_plane_no_intersect_above)
+{
+  using namespace Primal3D;
+  constexpr double EPS = 1e-10;
+  constexpr bool CHECK_SIGN = true;
+
+  // Tet and plane do not intersect
+  TetrahedronType tet(PointType {0.0, 0.0, 0.0},
+                      PointType {1.0, 0.0, 0.0},
+                      PointType {0.0, 1.0, 0.0},
+                      PointType {0.0, 0.0, 1.0});
+
+  PlaneType plane(VectorType {0.0, 0.0, 1.0}, PointType {0.0, 0.0, -0.5});
+
+  PolyhedronType poly = axom::primal::clip(tet, plane, EPS, CHECK_SIGN);
+
+  EXPECT_NEAR(tet.volume(), poly.volume(), EPS);
+}
+
+TEST(primal_clip, tet_plane_borders_face_below)
+{
+  using namespace Primal3D;
+  constexpr double EPS = 1e-10;
+  constexpr bool CHECK_SIGN = true;
+
+  // Tet and plane do not intersect, but border each other
+  TetrahedronType tet(PointType {0.0, 0.0, 0.0},
+                      PointType {1.0, 0.0, 0.0},
+                      PointType {0.0, 1.0, 0.0},
+                      PointType {0.0, 0.0, 1.0});
+
+  constexpr double planeOffset = 0.0;
+  PlaneType plane(VectorType {0.0, 0.0, -1.0}, planeOffset);
+
+  PolyhedronType poly = axom::primal::clip(plane, tet, EPS, CHECK_SIGN);
+
+  EXPECT_NEAR(0.0, poly.volume(), EPS);
+}
+
+TEST(primal_clip, tet_plane_borders_face_above)
+{
+  using namespace Primal3D;
+  constexpr double EPS = 1e-10;
+  constexpr bool CHECK_SIGN = true;
+
+  // Tet and plane do not intersect, but border each other
+  TetrahedronType tet(PointType {0.0, 0.0, 0.0},
+                      PointType {1.0, 0.0, 0.0},
+                      PointType {0.0, 1.0, 0.0},
+                      PointType {0.0, 0.0, 1.0});
+
+  constexpr double planeOffset = 0.0;
+  PlaneType plane(VectorType {0.0, 0.0, 1.0}, planeOffset);
+
+  PolyhedronType poly = axom::primal::clip(plane, tet, EPS, CHECK_SIGN);
+
+  EXPECT_NEAR(tet.volume(), poly.volume(), EPS);
+}
+
+TEST(primal_clip, tet_plane_intersects_two_faces)
+{
+  using namespace Primal3D;
+  constexpr double EPS = 1e-10;
+  constexpr bool CHECK_SIGN = true;
+
+  // Tet and plane do not intersect, but border each other
+  TetrahedronType tet(PointType {0.0, 0.0, 0.0},
+                      PointType {1.0, 0.0, 0.0},
+                      PointType {0.0, 1.0, 0.0},
+                      PointType {0.0, 0.0, 1.0});
+
+  constexpr double planeOffset = 0.5;
+  PlaneType plane(VectorType {0.5, 0.5, -0.5}, planeOffset);
+
+  PolyhedronType poly = axom::primal::clip(plane, tet, EPS, CHECK_SIGN);
+
+  EXPECT_NEAR(tet.volume()/2.0, poly.volume(), EPS);
+}
+
+TEST(primal_clip, tet_plane_intersects_three_faces)
+{
+  using namespace Primal3D;
+  constexpr double EPS = 1e-10;
+  constexpr bool CHECK_SIGN = true;
+
+  // Tet and plane do not intersect, but border each other
+  TetrahedronType tet(PointType {0.0, 0.0, 0.0},
+                      PointType {1.0, 0.0, 0.0},
+                      PointType {0.0, 1.0, 0.0},
+                      PointType {0.0, 0.0, 1.0});
+
+  constexpr double planeOffset = 0.5;
+  PlaneType plane(VectorType {0.0, 0.0, -1.0}, planeOffset);
+
+  PolyhedronType poly = axom::primal::clip(plane, tet, EPS, CHECK_SIGN);
+
+  EXPECT_NEAR(0.125, poly.volume(), EPS);
+}
+
 //------------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -1294,13 +1294,13 @@ TEST(primal_clip, tet_tet_clip_special_case_1)
     EPS);
 }
 
-TEST(primal_clip, tet_plane_no_intersect_below)
+TEST(primal_clip, tet_plane_intersect_none_below)
 {
   using namespace Primal3D;
   constexpr double EPS = 1e-10;
   constexpr bool CHECK_SIGN = true;
 
-  // Tet and plane do not intersect
+  // Plane intersects one vertex of tet
   TetrahedronType tet(PointType {0.0, 0.0, 0.0},
                       PointType {1.0, 0.0, 0.0},
                       PointType {0.0, 1.0, 0.0},
@@ -1313,13 +1313,13 @@ TEST(primal_clip, tet_plane_no_intersect_below)
   EXPECT_NEAR(0.0, poly.volume(), EPS);
 }
 
-TEST(primal_clip, tet_plane_no_intersect_above)
+TEST(primal_clip, tet_plane_intersect_none_above)
 {
   using namespace Primal3D;
   constexpr double EPS = 1e-10;
   constexpr bool CHECK_SIGN = true;
 
-  // Tet and plane do not intersect
+  // Plane intersects one vertex of tet
   TetrahedronType tet(PointType {0.0, 0.0, 0.0},
                       PointType {1.0, 0.0, 0.0},
                       PointType {0.0, 1.0, 0.0},
@@ -1332,7 +1332,83 @@ TEST(primal_clip, tet_plane_no_intersect_above)
   EXPECT_NEAR(tet.volume(), poly.volume(), EPS);
 }
 
-TEST(primal_clip, tet_plane_borders_face_below)
+TEST(primal_clip, tet_plane_border_vertex_below)
+{
+  using namespace Primal3D;
+  constexpr double EPS = 1e-10;
+  constexpr bool CHECK_SIGN = true;
+
+  // Plane intersects one vertex of tet
+  TetrahedronType tet(PointType {0.0, 0.0, 0.0},
+                      PointType {1.0, 0.0, 0.0},
+                      PointType {0.0, 1.0, 0.0},
+                      PointType {0.0, 0.0, 1.0});
+
+  PlaneType plane(VectorType {0.0, 0.0, 1.0}, PointType {0.0, 0.0, 1.0});
+
+  PolyhedronType poly = axom::primal::clip(tet, plane, EPS, CHECK_SIGN);
+
+  EXPECT_NEAR(0.0, poly.volume(), EPS);
+}
+
+TEST(primal_clip, tet_plane_border_vertex_above)
+{
+  using namespace Primal3D;
+  constexpr double EPS = 1e-10;
+  constexpr bool CHECK_SIGN = true;
+
+  // Plane intersects one vertex of tet
+  TetrahedronType tet(PointType {0.0, 0.0, 0.0},
+                      PointType {1.0, 0.0, 0.0},
+                      PointType {0.0, 1.0, 0.0},
+                      PointType {0.0, 0.0, 1.0});
+
+  PlaneType plane(VectorType {0.0, 0.0, -1.0}, PointType {0.0, 0.0, 1.0});
+
+  PolyhedronType poly = axom::primal::clip(tet, plane, EPS, CHECK_SIGN);
+
+  EXPECT_NEAR(tet.volume(), poly.volume(), EPS);
+}
+
+TEST(primal_clip, tet_plane_border_edge_below)
+{
+  using namespace Primal3D;
+  constexpr double EPS = 1e-10;
+  constexpr bool CHECK_SIGN = true;
+
+  // Plane intersects one edge of tet
+  TetrahedronType tet(PointType {0.0, 0.0, 0.0},
+                      PointType {1.0, 0.0, 0.0},
+                      PointType {0.0, 1.0, 0.0},
+                      PointType {0.0, 0.0, 1.0});
+
+  PlaneType plane(VectorType {0.0, -1.0, -1.0}, 0.0);
+
+  PolyhedronType poly = axom::primal::clip(tet, plane, EPS, CHECK_SIGN);
+
+  EXPECT_NEAR(0.0, poly.volume(), EPS);
+}
+
+TEST(primal_clip, tet_plane_border_edge_above)
+{
+  using namespace Primal3D;
+  constexpr double EPS = 1e-10;
+  constexpr bool CHECK_SIGN = true;
+
+  // Plane intersects one edge of tet
+  TetrahedronType tet(PointType {0.0, 0.0, 0.0},
+                      PointType {1.0, 0.0, 0.0},
+                      PointType {0.0, 1.0, 0.0},
+                      PointType {0.0, 0.0, 1.0});
+
+  PlaneType plane(VectorType {0.0, 1.0, 1.0}, 0.0);
+
+  PolyhedronType poly = axom::primal::clip(tet, plane, EPS, CHECK_SIGN);
+
+  EXPECT_NEAR(tet.volume(), poly.volume(), EPS);
+}
+
+TEST(primal_clip, tet_plane_border_face_below)
 {
   using namespace Primal3D;
   constexpr double EPS = 1e-10;
@@ -1344,15 +1420,14 @@ TEST(primal_clip, tet_plane_borders_face_below)
                       PointType {0.0, 1.0, 0.0},
                       PointType {0.0, 0.0, 1.0});
 
-  constexpr double planeOffset = 0.0;
-  PlaneType plane(VectorType {0.0, 0.0, -1.0}, planeOffset);
+  PlaneType plane(VectorType {0.0, 0.0, -1.0}, 0.0);
 
   PolyhedronType poly = axom::primal::clip(plane, tet, EPS, CHECK_SIGN);
 
   EXPECT_NEAR(0.0, poly.volume(), EPS);
 }
 
-TEST(primal_clip, tet_plane_borders_face_above)
+TEST(primal_clip, tet_plane_border_face_above)
 {
   using namespace Primal3D;
   constexpr double EPS = 1e-10;
@@ -1364,15 +1439,14 @@ TEST(primal_clip, tet_plane_borders_face_above)
                       PointType {0.0, 1.0, 0.0},
                       PointType {0.0, 0.0, 1.0});
 
-  constexpr double planeOffset = 0.0;
-  PlaneType plane(VectorType {0.0, 0.0, 1.0}, planeOffset);
+  PlaneType plane(VectorType {0.0, 0.0, 1.0}, 0.0);
 
   PolyhedronType poly = axom::primal::clip(plane, tet, EPS, CHECK_SIGN);
 
   EXPECT_NEAR(tet.volume(), poly.volume(), EPS);
 }
 
-TEST(primal_clip, tet_plane_intersects_two_faces)
+TEST(primal_clip, tet_plane_intersect_triangle)
 {
   using namespace Primal3D;
   constexpr double EPS = 1e-10;
@@ -1384,15 +1458,14 @@ TEST(primal_clip, tet_plane_intersects_two_faces)
                       PointType {0.0, 1.0, 0.0},
                       PointType {0.0, 0.0, 1.0});
 
-  constexpr double planeOffset = 0.5;
-  PlaneType plane(VectorType {0.5, 0.5, -0.5}, planeOffset);
+  PlaneType plane(VectorType {-1.0, 0.0, 1.0}, 0.0);
 
   PolyhedronType poly = axom::primal::clip(plane, tet, EPS, CHECK_SIGN);
 
   EXPECT_NEAR(tet.volume()/2.0, poly.volume(), EPS);
 }
 
-TEST(primal_clip, tet_plane_intersects_three_faces)
+TEST(primal_clip, tet_plane_intersect_quadrilateral)
 {
   using namespace Primal3D;
   constexpr double EPS = 1e-10;

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -1446,13 +1446,13 @@ TEST(primal_clip, tet_plane_border_face_above)
   EXPECT_NEAR(tet.volume(), poly.volume(), EPS);
 }
 
-TEST(primal_clip, tet_plane_intersect_triangle)
+TEST(primal_clip, tet_plane_intersect_three_edges)
 {
   using namespace Primal3D;
   constexpr double EPS = 1e-10;
   constexpr bool CHECK_SIGN = true;
 
-  // Plane intersects three edges of tet, forming a triangle
+  // Plane intersects three edges of tet
   TetrahedronType tet(PointType {0.0, 0.0, 0.0},
                       PointType {1.0, 0.0, 0.0},
                       PointType {0.0, 1.0, 0.0},
@@ -1465,24 +1465,7 @@ TEST(primal_clip, tet_plane_intersect_triangle)
   EXPECT_NEAR(tet.volume()/2.0, poly.volume(), EPS);
 }
 
-TEST(primal_clip, tet_plane_intersect_quadrilateral)
-{
-  using namespace Primal3D;
-  constexpr double EPS = 1e-10;
-  constexpr bool CHECK_SIGN = true;
-
-  // Plane intersects four edges of tet, forming a quadrilateral
-  TetrahedronType tet(PointType {0.0, 0.0, 0.0},
-                      PointType {1.0, 0.0, 0.0},
-                      PointType {0.0, 1.0, 0.0},
-                      PointType {0.0, 0.0, 1.0});
-
-  PlaneType plane(VectorType {0.25, 0.25, 0.0}, PointType {0.5, 0.0, 0.0});
-
-  PolyhedronType poly = axom::primal::clip(plane, tet, EPS, CHECK_SIGN);
-
-  EXPECT_NEAR(0.5*sqrt(0.5), poly.volume(), EPS);
-}
+// TODO: Add a test for a plane that intersects four edges of a tet
 
 //------------------------------------------------------------------------------
 int main(int argc, char* argv[])

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -1452,7 +1452,7 @@ TEST(primal_clip, tet_plane_intersect_triangle)
   constexpr double EPS = 1e-10;
   constexpr bool CHECK_SIGN = true;
 
-  // Tet and plane do not intersect, but border each other
+  // Plane intersects three edges of tet, forming a triangle
   TetrahedronType tet(PointType {0.0, 0.0, 0.0},
                       PointType {1.0, 0.0, 0.0},
                       PointType {0.0, 1.0, 0.0},
@@ -1471,18 +1471,17 @@ TEST(primal_clip, tet_plane_intersect_quadrilateral)
   constexpr double EPS = 1e-10;
   constexpr bool CHECK_SIGN = true;
 
-  // Tet and plane do not intersect, but border each other
+  // Plane intersects four edges of tet, forming a quadrilateral
   TetrahedronType tet(PointType {0.0, 0.0, 0.0},
                       PointType {1.0, 0.0, 0.0},
                       PointType {0.0, 1.0, 0.0},
                       PointType {0.0, 0.0, 1.0});
 
-  constexpr double planeOffset = 0.5;
-  PlaneType plane(VectorType {0.0, 0.0, -1.0}, planeOffset);
+  PlaneType plane(VectorType {0.25, 0.25, 0.0}, PointType {0.5, 0.0, 0.0});
 
   PolyhedronType poly = axom::primal::clip(plane, tet, EPS, CHECK_SIGN);
 
-  EXPECT_NEAR(0.125, poly.volume(), EPS);
+  EXPECT_NEAR(0.5*sqrt(0.5), poly.volume(), EPS);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -1462,7 +1462,7 @@ TEST(primal_clip, tet_plane_intersect_three_edges)
 
   PolyhedronType poly = axom::primal::clip(plane, tet, EPS, CHECK_SIGN);
 
-  EXPECT_NEAR(tet.volume()/2.0, poly.volume(), EPS);
+  EXPECT_NEAR(tet.volume() / 2.0, poly.volume(), EPS);
 }
 
 // TODO: Add a test for a plane that intersects four edges of a tet


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following:
  - Adds a clip operator for a tet and plane
  - Refactors internal code for clipping a polyhedron by a set of planes
