### PR TITLE
Move to service user and new bank on lassen

### DIFF
--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -24,14 +24,14 @@
 .src_build_on_lassen:
   stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 25 -q pdebug -alloc_flags atsdisable"
+    ALLOC_COMMAND: "lalloc 1 -W 25 -q pwdev -G wdev -alloc_flags atsdisable"
   extends: [.src_build_script, .on_lassen, .src_workflow]
   needs: []
 
 .full_build_on_lassen:
   stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 45 -q pdebug -alloc_flags atsdisable"
+    ALLOC_COMMAND: "lalloc 1 -W 45 -q pwdev -G wdev -alloc_flags atsdisable"
   extends: [.full_build_script, .on_lassen, .full_workflow]
   needs: []
 

--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -7,6 +7,7 @@
 # This is the share configuration of jobs for lassen
 .on_lassen:
   variables:
+    LLNL_SERVICE_USER: atk
   tags:
     - shell
     - lassen

--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -6,8 +6,6 @@
 ####
 # This is the share configuration of jobs for lassen
 .on_lassen:
-  variables:
-    LLNL_SERVICE_USER: atk
   tags:
     - shell
     - lassen

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -6,8 +6,6 @@
 ####
 # This is the shared configuration of jobs for quartz
 .on_quartz:
-  variables:
-    LLNL_SERVICE_USER: atk
   tags:
     - shell
     - quartz

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -6,6 +6,8 @@
 ####
 # This is the shared configuration of jobs for quartz
 .on_quartz:
+  variables:
+    LLNL_SERVICE_USER: atk
   tags:
     - shell
     - quartz

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -6,8 +6,6 @@
 ####
 # This is the shared configuration of jobs for tioga
 .on_tioga:
-  variables:
-    LLNL_SERVICE_USER: atk
   tags:
     - shell
     - tioga

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -6,6 +6,8 @@
 ####
 # This is the shared configuration of jobs for tioga
 .on_tioga:
+  variables:
+    LLNL_SERVICE_USER: atk
   tags:
     - shell
     - tioga

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -39,14 +39,12 @@ tioga-clang_16_0_0_hip_5_6_0-src:
     COMPILER: "clang@16.0.0_hip"
     HOST_CONFIG: "tioga-toss_4_x86_64_ib_cray-${COMPILER}.cmake"
   extends: .src_build_on_tioga
-  allow_failure: true
 
 tioga-cce_15_0_1_hip_5_4_3-src:
   variables:
     COMPILER: "cce@15.0.1_hip"
     HOST_CONFIG: "tioga-toss_4_x86_64_ib_cray-${COMPILER}.cmake"
   extends: .src_build_on_tioga
-  allow_failure: true
 
 ####
 # Full Build jobs
@@ -56,7 +54,6 @@ tioga-clang_16_0_0_hip_5_6_0-full:
     SPEC: "%${COMPILER}~openmp+rocm+mfem+c2c"
     EXTRASPEC: "amdgpu_target=gfx90a ^hip@5.6.0 ^hsa-rocr-dev@5.6.0 ^llvm-amdgpu@5.6.0 ^raja~openmp+rocm ^umpire~openmp+rocm ^hdf5 cflags=-Wno-int-conversion"
   extends: .full_build_on_tioga
-  allow_failure: true
 
 tioga-cce_15_0_1_hip_5_4_3-full:
   variables:
@@ -64,4 +61,3 @@ tioga-cce_15_0_1_hip_5_4_3-full:
     SPEC: "%${COMPILER}~openmp+rocm+mfem+c2c"
     EXTRASPEC: "amdgpu_target=gfx90a ^hip@5.4.3 ^hsa-rocr-dev@5.4.3 ^llvm-amdgpu@5.4.3 ^raja~openmp+rocm ^umpire~openmp+rocm ^hdf5 cflags=-Wno-int-conversion"
   extends: .full_build_on_tioga
-  allow_failure: true


### PR DESCRIPTION
Move all CI to `atk` and move to the `wdev` bank on Lassen.

The `LLNL_SERVICE_USER` variable was already in `.gitlab-ci.yml`, so I just had to turn on the Gitlab setting to allow us to use the service user.