### PR TITLE
Use domain_id for identification if provided in DistributedClosestPoint.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -30,6 +30,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   negative, resulting in the signed volume becoming positive.
 
 ### Changed
+- `MarchingCubes` and `DistributedClosestPoint` classes identify domains by their
+  `state/domain_id` parameters if provided, or the local iteration index if not.
 - `MarchingCubes` and `DistributedClosestPoint` classes changed from requiring the Blueprint
   coordset name to requiring the Blueprint topology name.  The changed interface methods are:
   - `DistributedClosestPoint::setObjectMesh`

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -341,6 +341,16 @@ private:
   };
 
 public:
+  /*!
+    @brief Constructor
+
+    @param [i] runtimePolicy Indicates where local computations
+      are done.  See axom::runtime_policy.
+    @param [i] Allocator ID, which must be compatible with
+      @c runtimePolicy.  See axom::allocate and axom::reallocate.
+      Also see setAllocatorID().
+    @param [i[ isVerbose
+  */
   DistributedClosestPointImpl(RuntimePolicy runtimePolicy,
                               int allocatorID,
                               bool isVerbose)
@@ -389,6 +399,19 @@ public:
     SLIC_ASSERT(allocatorID != axom::INVALID_ALLOCATOR_ID);
     // TODO: If appropriate, how to check for compatibility with runtime policy?
     m_allocatorID = allocatorID;
+  }
+
+  void setOutputSwitches(bool outputRank,
+                         bool outputIndex,
+                         bool outputDistance,
+                         bool outputCoords,
+                         bool outputDomainIndex)
+  {
+    m_outputRank = outputRank;
+    m_outputIndex = outputIndex;
+    m_outputDistance = outputDistance;
+    m_outputCoords = outputCoords;
+    m_outputDomainIndex = outputDomainIndex;
   }
 
 public:
@@ -644,9 +667,15 @@ public:
     xferNode["homeRank"] = m_rank;
     xferNode["is_first"] = 1;
 
+    const bool isMultidomain =
+      conduit::blueprint::mesh::is_multi_domain(queryNode);
+    const auto domainCount =
+      conduit::blueprint::mesh::number_of_domains(queryNode);
     conduit::Node& xferDoms = xferNode["xferDoms"];
-    for(auto& queryDom : queryNode.children())
+    for(conduit::index_t domainNum = 0; domainNum < domainCount; ++domainNum)
     {
+      auto& queryDom = isMultidomain ? queryNode.child(domainNum) : queryNode;
+
       const std::string coordsetName =
         queryDom
           .fetch_existing(
@@ -654,84 +683,89 @@ public:
           .as_string();
       const std::string& domName = queryDom.name();
       conduit::Node& xferDom = xferDoms[domName];
-      conduit::Node& fields = queryDom.fetch_existing("fields");
       conduit::Node& queryCoords =
         queryDom.fetch_existing(fmt::format("coordsets/{}", coordsetName));
       conduit::Node& queryCoordsValues = queryCoords.fetch_existing("values");
-
-      // clang-format off
-      copy_components_to_interleaved(queryCoordsValues, xferDom["coords"]);
-
-      xferDom["cp_index"].set_external(fields.fetch_existing("cp_index/values"));
-      xferDom["cp_rank"].set_external(fields.fetch_existing("cp_rank/values"));
-      copy_components_to_interleaved(fields.fetch_existing("cp_coords/values"),
-                                     xferDom["cp_coords"]);
-      xferDom["cp_domain_index"].set_external(fields.fetch_existing("cp_domain_index/values"));
-
-      if(fields.has_path("cp_distance"))
-      {
-        xferDom["debug/cp_distance"].set_external(fields.fetch_existing("cp_distance/values"));
-      }
-      // clang-format on
 
       const int dim = internal::extractDimension(queryCoordsValues);
       const int qPtCount = internal::extractSize(queryCoordsValues);
       xferDom["qPtCount"] = qPtCount;
       xferDom["dim"] = dim;
+
+      copy_components_to_interleaved(queryCoordsValues, xferDom["coords"]);
+
+      constexpr bool isInt32 = std::is_same<axom::IndexType, std::int32_t>::value;
+      auto dtype =
+        isInt32 ? conduit::DataType::int32() : conduit::DataType::int64();
+      dtype.set_number_of_elements(qPtCount);
+      xferDom["cp_index"].set_dtype(dtype);
+      xferDom["cp_rank"].set_dtype(dtype);
+      xferDom["cp_domain_index"].set_dtype(dtype);
+      xferDom["debug/cp_distance"].set_dtype(conduit::DataType::float64(qPtCount));
+      xferDom["cp_coords"].set_dtype(conduit::DataType::float64(dim * qPtCount));
     }
   }
 
   /// Copy xferNode back to query mesh partition.
-  void node_copy_xfer_to_query(const conduit::Node& xferNode,
-                               conduit::Node& queryNode) const
+  void node_copy_xfer_to_query(conduit::Node& xferNode,
+                               conduit::Node& queryNode,
+                               const std::string& topologyName) const
   {
-    const conduit::Node& xferDoms = xferNode.fetch_existing("xferDoms");
-    conduit::index_t childCount = queryNode.number_of_children();
-    SLIC_ASSERT(xferDoms.number_of_children() == childCount);
-    for(conduit::index_t ci = 0; ci < childCount; ++ci)
+    const bool isMultidomain =
+      conduit::blueprint::mesh::is_multi_domain(queryNode);
+    const auto domainCount =
+      conduit::blueprint::mesh::number_of_domains(queryNode);
+    conduit::Node& xferDoms = xferNode.fetch_existing("xferDoms");
+    SLIC_ASSERT(xferDoms.number_of_children() == domainCount);
+    for(conduit::index_t domainNum = 0; domainNum < domainCount; ++domainNum)
     {
-      const conduit::Node& xferDom = xferDoms.child(ci);
-      conduit::Node& queryDom = queryNode.child(ci);
+      auto& queryDom = isMultidomain ? queryNode.child(domainNum) : queryNode;
+      conduit::Node& xferDom = xferDoms.child(domainNum);
       conduit::Node& fields = queryDom.fetch_existing("fields");
 
+      conduit::Node genericHeaders;
+      genericHeaders["association"] = "vertex";
+      genericHeaders["topology"] = topologyName;
+
+      if(m_outputRank)
       {
         auto& src = xferDom.fetch_existing("cp_rank");
-        auto& dst = fields.fetch_existing("cp_rank/values");
-        if(dst.data_ptr() != src.data_ptr())
-        {
-          dst.update_compatible(src);
-        }
+        auto& dst = fields["cp_rank"];
+        dst.set_node(genericHeaders);
+        dst["values"].move(src);
       }
 
+      if(m_outputIndex)
       {
         auto& src = xferDom.fetch_existing("cp_index");
-        auto& dst = fields.fetch_existing("cp_index/values");
-        if(dst.data_ptr() != src.data_ptr())
-        {
-          dst.update_compatible(src);
-        }
+        auto& dst = fields["cp_index"];
+        dst.set_node(genericHeaders);
+        dst["values"].move(src);
       }
 
+      if(m_outputDomainIndex)
       {
         auto& src = xferDom.fetch_existing("cp_domain_index");
-        auto& dst = fields.fetch_existing("cp_domain_index/values");
-        if(dst.data_ptr() != src.data_ptr())
-        {
-          dst.update_compatible(src);
-        }
+        auto& dst = fields["cp_domain_index"];
+        dst.set_node(genericHeaders);
+        dst["values"].move(src);
       }
 
-      copy_interleaved_to_components(xferDom.fetch_existing("cp_coords"),
-                                     fields.fetch_existing("cp_coords/values"));
-
-      if(xferDom.has_path("debug/cp_distance"))
+      if(m_outputDistance)
       {
         auto& src = xferDom.fetch_existing("debug/cp_distance");
-        auto& dst = fields.fetch_existing("cp_distance/values");
-        if(dst.data_ptr() != src.data_ptr())
-        {
-          dst.update_compatible(src);
-        }
+        auto& dst = fields["cp_distance"];
+        dst.set_node(genericHeaders);
+        dst["values"].move(src);
+      }
+
+      if(m_outputCoords)
+      {
+        auto& dst = fields["cp_coords"];
+        dst.set_node(genericHeaders);
+        auto& dstValues = dst["values"];
+        copy_interleaved_to_components(xferDom.fetch_existing("cp_coords"),
+                                       dstValues);
       }
     }
   }
@@ -777,19 +811,18 @@ public:
   void copy_interleaved_to_components(const conduit::Node& interleaved,
                                       conduit::Node& components) const
   {
-    if(interleaved.data_ptr() != components.child(0).data_ptr())
+    const int qPtCount = interleaved.dtype().number_of_elements() / NDIMS;
+    components.reset();
+    // Copy from 1D-interleaved src to component-wise dst.
+    for(int d = 0; d < NDIMS; ++d)
     {
-      const int dim = internal::extractDimension(components);
-      const int qPtCount = internal::extractSize(components);
-      // Copy from 1D-interleaved src to component-wise dst.
-      for(int d = 0; d < dim; ++d)
+      const double* src = interleaved.as_float64_ptr() + d;
+      auto& dstNode = components.append();
+      dstNode.set_dtype(conduit::DataType(interleaved.dtype().id(), qPtCount));
+      double* dst = dstNode.as_float64_ptr();
+      for(int i = 0; i < qPtCount; ++i)
       {
-        const double* src = interleaved.as_float64_ptr() + d;
-        auto dst = components.child(d).as_float64_array();
-        for(int i = 0; i < qPtCount; ++i)
-        {
-          dst[i] = src[i * dim];
-        }
+        dst[i] = src[i * NDIMS];
       }
     }
   }
@@ -801,6 +834,9 @@ public:
    * \param queryMesh The root node of a mesh blueprint for the query points
    * Can be empty if there are no query points for the calling rank
    * \param topologyName The topology name identifying the query points
+   *
+   * @c queryMesh should have data on the host, regardless of the runtime
+   * policy setting.  Data will be copied to device as needed.
    *
    * The named topology is used to identify the points in the query mesh.
    * On completion, the query mesh contains the following fields:
@@ -824,23 +860,12 @@ public:
    * buffer usage, we occasionally check the sends for completion,
    * using check_send_requests().
    */
-  void computeClosestPoints(conduit::Node& queryMesh_,
+  void computeClosestPoints(conduit::Node& queryMesh,
                             const std::string& topologyName) const
   {
     SLIC_ASSERT_MSG(
       isBVHTreeInitialized(),
       "BVH tree must be initialized before calling 'computeClosestPoints");
-
-    // If query mesh isn't multidomain, create a temporary multidomain representation.
-    const bool qmIsMultidomain =
-      conduit::blueprint::mesh::is_multi_domain(queryMesh_);
-    std::shared_ptr<conduit::Node> tmpNode;
-    if(!qmIsMultidomain)
-    {
-      tmpNode = std::make_shared<conduit::Node>();
-      conduit::blueprint::mesh::to_multi_domain(queryMesh_, *tmpNode);
-    }
-    conduit::Node& queryMesh = qmIsMultidomain ? queryMesh_ : *tmpNode;
 
     std::map<int, std::shared_ptr<conduit::Node>> xferNodes;
 
@@ -899,7 +924,7 @@ public:
       if(firstRecipForMyQuery == -1)
       {
         // No need to send anywhere.  Put computed data back into queryMesh.
-        node_copy_xfer_to_query(*xferNodes[m_rank], queryMesh);
+        node_copy_xfer_to_query(*xferNodes[m_rank], queryMesh, topologyName);
         xferNodes.erase(m_rank);
       }
       else
@@ -936,7 +961,7 @@ public:
 
       if(homeRank == m_rank)
       {
-        node_copy_xfer_to_query(xferNode, queryMesh);
+        node_copy_xfer_to_query(xferNode, queryMesh, topologyName);
       }
       else
       {
@@ -1141,7 +1166,6 @@ public:
     {
       return;
     }
-
     conduit::Node& xferDoms = xferNode["xferDoms"];
     for(conduit::Node& xferDom : xferDoms.children())
     {
@@ -1337,6 +1361,12 @@ private:
   int m_rank;
   int m_nranks;
 
+  bool m_outputRank = true;
+  bool m_outputIndex = true;
+  bool m_outputDistance = true;
+  bool m_outputCoords = true;
+  bool m_outputDomainIndex = true;
+
   /*!
     @brief Object point coordindates array.
 
@@ -1421,7 +1451,11 @@ public:
     }
   }
 
-  /// Set the runtime execution policy for the query
+  /*!
+    @brief Set runtime execution policy for local queries
+
+    See axom::runtime_policy.
+  */
   void setRuntimePolicy(RuntimePolicy policy) { m_runtimePolicy = policy; }
 
   /*!  @brief Sets the allocator ID to the default associated with the
@@ -1533,6 +1567,35 @@ public:
   {
     SLIC_ERROR_IF(threshold < 0.0, "Distance threshold must be non-negative.");
     m_sqDistanceThreshold = threshold * threshold;
+  }
+
+  /*!
+    @brief Set what fields to output.
+
+    @param [i] field Must be one of these:
+      "cp_rank", "cp_index", "cp_distance", "cp_coords", "cp_domain_index".
+    @param [i] on Whether to enable outputing @c field.
+
+    By default, all are on.
+  */
+  void setOutput(const std::string& field, bool on)
+  {
+    // clang-format off
+    bool* f
+      = field == "cp_rank" ? &m_outputRank
+      : field == "cp_index" ? &m_outputIndex
+      : field == "cp_distance" ? &m_outputDistance
+      : field == "cp_coords" ? &m_outputCoords
+      : field == "cp_domain_index" ? &m_outputDomainIndex
+      : nullptr;
+    // clang-format on
+    SLIC_ERROR_IF(
+      f == nullptr,
+      axom::fmt::format(
+        "Invald field '{}' should be one of these: "
+        "cp_rank, cp_index, cp_distance, cp_coords, cp_domain_index",
+        field));
+    *f = on;
   }
 
   /// Sets the logging verbosity of the query. By default the query is not verbose
@@ -1652,11 +1715,21 @@ public:
     case 2:
       m_dcp_2->setSquaredDistanceThreshold(m_sqDistanceThreshold);
       m_dcp_2->setMpiCommunicator(m_mpiComm);
+      m_dcp_2->setOutputSwitches(m_outputRank,
+                                 m_outputIndex,
+                                 m_outputDistance,
+                                 m_outputCoords,
+                                 m_outputDomainIndex);
       m_dcp_2->computeClosestPoints(query_node, coordset);
       break;
     case 3:
       m_dcp_3->setSquaredDistanceThreshold(m_sqDistanceThreshold);
       m_dcp_3->setMpiCommunicator(m_mpiComm);
+      m_dcp_2->setOutputSwitches(m_outputRank,
+                                 m_outputIndex,
+                                 m_outputDistance,
+                                 m_outputCoords,
+                                 m_outputDomainIndex);
       m_dcp_3->computeClosestPoints(query_node, coordset);
       break;
     }
@@ -1738,6 +1811,12 @@ private:
   double m_sqDistanceThreshold {std::numeric_limits<double>::max()};
 
   bool m_objectMeshCreated {false};
+
+  bool m_outputRank = true;
+  bool m_outputIndex = true;
+  bool m_outputDistance = true;
+  bool m_outputCoords = true;
+  bool m_outputDomainIndex = true;
 
   // One instance per dimension
   std::unique_ptr<internal::DistributedClosestPointImpl<2>> m_dcp_2;

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -455,9 +455,16 @@ public:
     axom::Array<axom::IndexType> domIds(ptCount, ptCount);
     std::size_t copiedCount = 0;
     conduit::Node tmpValues;
-    for(conduit::index_t d = 0; d < mdMeshNode.number_of_children(); ++d)
+    for(axom::IndexType d = 0; d < mdMeshNode.number_of_children(); ++d)
     {
       const conduit::Node& domain = mdMeshNode.child(d);
+
+      axom::IndexType domainId = d;
+      if(domain.has_path("state/domain_id"))
+      {
+        domainId = domain.fetch_existing("state/domain_id").to_int32();
+      }
+
       const std::string coordsetName =
         domain
           .fetch_existing(
@@ -483,7 +490,7 @@ public:
                  nBytes);
       tmpValues.reset();
 
-      domIds.fill(d, copiedCount, N);
+      domIds.fill(domainId, N, copiedCount);
 
       copiedCount += N;
     }

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -9,8 +9,6 @@
 #include "axom/config.hpp"
 #include "axom/core.hpp"
 #include "axom/slic.hpp"
-#include "axom/slam.hpp"
-#include "axom/sidre.hpp"
 #include "axom/primal.hpp"
 #include "axom/spin.hpp"
 #include "axom/core/execution/runtime_policy.hpp"

--- a/src/axom/quest/MeshViewUtil.hpp
+++ b/src/axom/quest/MeshViewUtil.hpp
@@ -372,7 +372,7 @@ public:
   }
 
   //! @brief Return the real (ghost-free) extents of mesh data.
-  MdIndices getRealExtents(const std::string& association)
+  const MdIndices& getRealExtents(const std::string& association)
   {
     if(association == "vertex")
     {
@@ -388,7 +388,7 @@ public:
                         "association for now, not '{}'.",
                         association));
 
-    return MdIndices {};
+    return m_cellShape;
   }
   //@}
 
@@ -640,7 +640,8 @@ public:
   //!@name Creating data
 
   /*!
-    @brief Create a new scalar nodal data field.
+    @brief Create a new scalar nodal data field with specified
+    strides and offsets.
 
     @param [in] fieldName
     @param [in] association "vertex" or "element"
@@ -657,7 +658,7 @@ public:
     for matching the strides and offsets of existing data.  It's more
     natural to create the field based on ghost layer thickness and
     index advancement order (row-major, column-major or some other).
-    That is easy to do, but we don't have a use case yet.
+    Use createFieldPadded() for this.
   */
   void createField(const std::string& fieldName,
                    const std::string& association,
@@ -673,7 +674,7 @@ public:
       association != "vertex" && association != "element",
       axom::fmt::format("Not yet supporting association '{}'.", association));
 
-    const auto& realShape = association == "element" ? m_cellShape : m_nodeShape;
+    const auto& realShape = getRealExtents(association);
     MdIndices loPads, hiPads, paddedShape, strideOrder;
     axom::quest::internal::stridesAndOffsetsToShapes(realShape,
                                                      offsets,
@@ -691,8 +692,6 @@ public:
                                       paddedShape));
     }
 
-    auto realExtents = getRealExtents(association);
-
     conduit::Node& fieldNode = m_dom->fetch("fields/" + fieldName);
     fieldNode["association"] = association;
     fieldNode["topology"] = m_topologyName;
@@ -707,7 +706,7 @@ public:
 
     axom::IndexType slowDir = strideOrder[DIM - 1];
     auto extras = dtype.number_of_elements() -
-      strides[slowDir] * (offsets[slowDir] + realExtents[slowDir]);
+      strides[slowDir] * (offsets[slowDir] + realShape[slowDir]);
     if(extras < 0)
     {
       SLIC_ERROR(
@@ -716,6 +715,72 @@ public:
     }
 
     fieldNode["values"].set(dtype);
+  }
+
+  /*!
+    @brief Create a new scalar nodal data field with specified
+    ghost paddings.
+
+    @param [in] fieldName
+    @param [in] association "vertex" or "element"
+    @param [in] dtype Conduit data type to put in the field.
+      If dtype has too few elements, the minimum sufficient
+      size will be allocated.
+    @param loPads [i] Ghost padding amount on low side.
+    @param hiPads [i] Ghost padding amount ont high side.
+    @param strideOrder [i] Fastest-to-slowest advancing
+      index directions.
+
+    Field data allocation is done by Conduit, so the data lives in
+    host memory.  Conduit currently doesn't provide a means to allocate
+    the array in device memory.
+  */
+  void createField(const std::string& fieldName,
+                   const std::string& association,
+                   const conduit::DataType& dtype,
+                   const MdIndices& loPads,
+                   const MdIndices& hiPads,
+                   const MdIndices& strideOrder)
+  {
+    SLIC_ERROR_IF(
+      m_dom->has_path("fields/" + fieldName),
+      axom::fmt::format("Cannot create field {}.  It already exists.", fieldName));
+
+    SLIC_ERROR_IF(
+      association != "vertex" && association != "element",
+      axom::fmt::format("Not yet supporting association '{}'.", association));
+
+    axom::StackArray<axom::IndexType, DIM> offsets;
+    axom::StackArray<axom::IndexType, DIM> strides;
+    axom::IndexType valuesCount;
+    const auto& realShape = getRealExtents(association);
+    axom::quest::internal::shapesToStridesAndOffsets(realShape,
+                                                     loPads,
+                                                     hiPads,
+                                                     strideOrder,
+                                                     1,
+                                                     offsets,
+                                                     strides,
+                                                     valuesCount);
+
+    conduit::Node& fieldNode = m_dom->fetch("fields/" + fieldName);
+    fieldNode["association"] = association;
+    fieldNode["topology"] = m_topologyName;
+
+    constexpr bool isInt32 = std::is_same<axom::IndexType, std::int32_t>::value;
+    const conduit::DataType conduitDtype =
+      isInt32 ? conduit::DataType::int32(DIM) : conduit::DataType::int64(DIM);
+    // Make temporary non-const copies for the "set" methods.
+    auto tmpStrides = strides, tmpOffsets = offsets;
+    fieldNode["strides"].set(conduitDtype, &tmpStrides[0]);
+    fieldNode["offsets"].set(conduitDtype, &tmpOffsets[0]);
+
+    conduit::DataType bumpedDtype = dtype;
+    if(bumpedDtype.number_of_elements() < valuesCount)
+    {
+      bumpedDtype.set_number_of_elements(valuesCount);
+    }
+    fieldNode["values"].set(bumpedDtype);
   }
   //@}
 

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -689,8 +689,6 @@ private:
 
     auto* fieldsGroup = domainGroup->createGroup("fields");
 
-    // domainGroup->createViewScalar<std::int64_t>("state/domain_id", m_rank);
-
     m_domainGroups.push_back(domainGroup);
     m_coordsGroups.push_back(coordsGroup);
     m_topoGroups.push_back(topoGroup);


### PR DESCRIPTION
If not provided, use local domain's iteration index. Fix error setting domain.

# Summary

- This PR is a feature
- It does the following (modify list as needed):
  - Modifies `DistributedClosestPoint` to use the blueprint `state/domain_id` field to identify mesh domain, if the field is given.
  - Fixes https://github.com/LLNL/axom/issues/1197
  - Documents this change in the release notes.

Issue https://github.com/LLNL/axom/issues/1197 also requires the same change in `MarchingCubes`, and that change occurred in a separate, merged PR.

This PR and related comments led to issue https://github.com/LLNL/axom/issues/1236, on being bit width compatibility of blueprint data.