### PR TITLE
Add a FlatMap container

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,6 +28,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Primal: Adds a `checkAndFixOrientation()` function to `primal::Tetrahedron`
   that swaps the order of vertices if the signed volume of the Tetrahedron is
   negative, resulting in the signed volume becoming positive.
+- Adds `FlatMap`, a generic key-value store which aims for drop-in compatibility
+  with `std::unordered_map`, but utilizes an open-addressing design.
 
 ### Changed
 - `MarchingCubes` and `DistributedClosestPoint` classes identify domains by their

--- a/src/axom/core/CMakeLists.txt
+++ b/src/axom/core/CMakeLists.txt
@@ -59,6 +59,7 @@ set(core_headers
     IteratorBase.hpp
     Macros.hpp
     Map.hpp
+    FlatMap.hpp
     Path.hpp
     StackArray.hpp
     Types.hpp

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -63,17 +63,17 @@ public:
   // Iterators
   iterator begin()
   {
-    IndexType firstBucketIndex = this->nextValidIndex(m_metadata, 0);
+    IndexType firstBucketIndex = this->nextValidIndex(m_metadata, NO_MATCH);
     return iterator(this, firstBucketIndex);
   }
   const_iterator begin() const
   {
-    IndexType firstBucketIndex = this->nextValidIndex(m_metadata, 0);
+    IndexType firstBucketIndex = this->nextValidIndex(m_metadata, NO_MATCH);
     return const_iterator(this, firstBucketIndex);
   }
   const_iterator cbegin() const
   {
-    IndexType firstBucketIndex = this->nextValidIndex(m_metadata, 0);
+    IndexType firstBucketIndex = this->nextValidIndex(m_metadata, NO_MATCH);
     return const_iterator(this, firstBucketIndex);
   }
 
@@ -238,7 +238,7 @@ public:
   IteratorImpl operator++(int)
   {
     IteratorImpl next = *this;
-    ++next;
+    ++(*this);
     return next;
   }
 

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -263,18 +263,14 @@ auto FlatMap<KeyType, ValueType, Hash>::emplaceImpl(bool assign_on_existence,
     return true;
   };
 
-  auto InsertEmptyBucket = [&, this](IndexType bucket_index) {
-    if(!keyExistsAlready)
-    {
-      foundBucketIndex = bucket_index;
-    }
-  };
-
-  this->probeEmptyIndex(m_numGroups2,
-                        m_metadata,
-                        hash,
-                        FindExistingElem,
-                        InsertEmptyBucket);
+  IndexType newBucket =
+    this->probeEmptyIndex(m_numGroups2, m_metadata, hash, FindExistingElem);
+  if(!keyExistsAlready)
+  {
+    foundBucketIndex = newBucket;
+    // Add a hash to the corresponding bucket slot.
+    this->setBucketHash(m_metadata, newBucket, hash);
+  }
   iterator keyIterator = iterator(this, foundBucketIndex);
   if(!keyExistsAlready)
   {

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -220,7 +220,9 @@ public:
   IteratorImpl(MapConstType* map, IndexType internalIdx)
     : m_map(map)
     , m_internalIdx(internalIdx)
-  { }
+  {
+    assert(m_internalIdx >= 0 && m_internalIdx < m_map->size());
+  }
 
   friend bool operator==(const IteratorImpl& lhs, const IteratorImpl& rhs)
   {
@@ -374,6 +376,7 @@ auto FlatMap<KeyType, ValueType, Hash>::emplaceImpl(bool assign_on_existence,
     foundBucketIndex = newBucket;
     // Add a hash to the corresponding bucket slot.
     this->setBucketHash(m_metadata, newBucket, hash);
+    m_size++;
     m_loadCount++;
   }
   iterator keyIterator = iterator(this, foundBucketIndex);

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -387,6 +387,24 @@ public:
   }
   /// @}
 
+  /*!
+   * \brief Inserts a key-value pair into the FlatMap.
+   *
+   *  If the key already exists in the FlatMap, insertion is skipped.
+   *  Otherwise, the key-value mapping is inserted into the FlatMap.
+   *
+   *  Compared to emplace(), this method only moves-from the value arguments
+   *  if the key does not exist; otherwise, the input arguments are left as-is.
+   *
+   * \param [in] key the key to insert or assign
+   * \param [in] args arguments to construct the value with.
+   *
+   * \return A pair consisting of:
+   *   - an iterator pointing to either the existing key-value pair, or the
+   *     newly-inserted pair
+   *   - true if a new pair was inserted, false otherwise
+   */
+  /// {@
   template <typename... Args>
   std::pair<iterator, bool> try_emplace(const KeyType& key, Args&&... args)
   {
@@ -409,6 +427,7 @@ public:
                 std::forward_as_tuple(std::forward<Args>(args)...));
     return emplace_pos;
   }
+  /// @}
 
   iterator erase(iterator pos) { erase(const_iterator {pos}); }
   iterator erase(const_iterator pos);

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -52,6 +52,14 @@ public:
   explicit FlatMap(std::initializer_list<value_type> init,
                    IndexType bucket_count = -1);
 
+  void swap(FlatMap& other)
+  {
+    axom::utilities::swap(m_numGroups2, other.m_numGroups2);
+    axom::utilities::swap(m_size, other.m_size);
+    axom::utilities::swap(m_metadata, other.m_metadata);
+    axom::utilities::swap(m_buckets, other.m_buckets);
+  }
+
   // Iterators
   iterator begin()
   {

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -36,6 +36,8 @@ private:
   using MixedHash = detail::flat_map::HashMixer64<KeyType, Hash>;
 
 public:
+  using key_type = KeyType;
+  using mapped_type = ValueType;
   using size_type = IndexType;
   using value_type = KeyValuePair;
   using iterator = IteratorImpl<false>;

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -42,7 +42,7 @@ public:
   using const_iterator = IteratorImpl<true>;
 
   // Constructors
-  FlatMap();
+  FlatMap() : FlatMap(MIN_NUM_BUCKETS) { }
 
   explicit FlatMap(IndexType bucket_count);
 
@@ -174,6 +174,8 @@ private:
                                         KeyType&& key,
                                         Args&&... args);
 
+  constexpr static IndexType MIN_NUM_BUCKETS = 16;
+
   IndexType m_numGroups2;  // Number of groups of 15 buckets, expressed as a power of 2
   IndexType m_size;
   axom::Array<detail::flat_map::GroupBucket> m_metadata;
@@ -244,6 +246,7 @@ FlatMap<KeyType, ValueType, Hash>::FlatMap(IndexType bucket_count)
   : m_size(0)
   , m_loadCount(0)
 {
+  bucket_count = std::min(MIN_NUM_BUCKETS, bucket_count);
   // Get the smallest power-of-two number of groups satisfying:
   // N * GroupSize - 1 >= minBuckets
   // TODO: we should add a leadingZeros overload for 64-bit integers

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -177,10 +177,23 @@ public:
   iterator find(const KeyType& key);
   const_iterator find(const KeyType& key) const;
 
-  ValueType& at(const KeyType& key) { return this->find(key)->second; }
+  ValueType& at(const KeyType& key)
+  {
+    auto it = this->find(key);
+    if(it == end())
+    {
+      throw std::out_of_range {"axom::FlatMap::find(): key not found"};
+    }
+    return it->second;
+  }
   const ValueType& at(const KeyType& key) const
   {
-    return this->find(key)->second;
+    auto it = this->find(key);
+    if(it == end())
+    {
+      throw std::out_of_range {"axom::FlatMap::find(): key not found"};
+    }
+    return it->second;
   }
 
   ValueType& operator[](const KeyType& key)

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -429,8 +429,27 @@ public:
   }
   /// @}
 
+  /*!
+   * \brief Remove a key-value pair from the FlatMap, specified by iterator.
+   *
+   * \param pos the iterator pointing to the key-value pair to remove
+   *
+   * \return an iterator to the next valid entry after the removed entry
+   */
+  /// {@
   iterator erase(iterator pos) { return erase(const_iterator {pos}); }
   iterator erase(const_iterator pos);
+  /// @}
+
+  /*!
+   * \brief Remove a key-value pair from the FlatMap, specified by key.
+   *
+   *  If the key doesn't exist in the FlatMap, does nothing.
+   *
+   * \param key the key to remove
+   *
+   * \return 1 if an entry was removed, 0 otherwise
+   */
   IndexType erase(const KeyType& key)
   {
     const_iterator it = find(key);
@@ -442,10 +461,29 @@ public:
     return 0;
   }
 
-  // Hashing
+  /*!
+   * \brief Returns the number of buckets allocated in the FlatMap.
+   *
+   *  The maximum number of elements that can be stored in the FlatMap without
+   *  resizing and rehashing is bucket_count() * max_load_factor().
+   */
   IndexType bucket_count() const { return m_buckets.size(); }
+
+  /*!
+   * \brief Returns the current load factor of the FlatMap.
+   */
   double load_factor() const { return ((double)m_loadCount) / bucket_count(); }
+
+  /*!
+   * \brief Returns the maximum load factor of the FlatMap.
+   */
   double max_load_factor() const { return MAX_LOAD_FACTOR; }
+
+  /*!
+   * \brief Explicitly rehash the FlatMap with a given number of buckets.
+   *
+   * \param count the minimum number of buckets to allocate for the rehash
+   */
   void rehash(IndexType count)
   {
     FlatMap rehashed(m_size,
@@ -454,6 +492,13 @@ public:
                      count);
     this->swap(rehashed);
   }
+
+  /*!
+   * \brief Reallocate and rehash the FlatMap, such that up to the specified
+   *  number of elements may be inserted without a rehash.
+   *
+   * \param count the number of elements to fit without a rehash
+   */
   void reserve(IndexType count) { rehash(std::ceil(count / MAX_LOAD_FACTOR)); }
 
 private:

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -283,6 +283,7 @@ FlatMap<KeyType, ValueType, Hash>::FlatMap(IndexType bucket_count)
   IndexType numGroupsRounded = 1 << m_numGroups2;
   IndexType numBuckets = numGroupsRounded * BucketsPerGroup - 1;
   m_metadata.resize(numGroupsRounded);
+  m_metadata[numGroupsRounded - 1].setSentinel();
   m_buckets.resize(numBuckets);
 }
 

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -58,6 +58,7 @@ public:
     axom::utilities::swap(m_size, other.m_size);
     axom::utilities::swap(m_metadata, other.m_metadata);
     axom::utilities::swap(m_buckets, other.m_buckets);
+    axom::utilities::swap(m_loadCount, other.m_loadCount);
   }
 
   // Iterators
@@ -161,6 +162,7 @@ public:
   }
 
   // Hashing
+  IndexType bucket_count() const { return m_buckets.size(); }
   double load_factor() const
   {
     return ((double)m_loadCount) / m_buckets.size();
@@ -182,7 +184,7 @@ private:
                                         UKeyType&& key,
                                         Args&&... args);
 
-  constexpr static IndexType MIN_NUM_BUCKETS {16};
+  constexpr static IndexType MIN_NUM_BUCKETS {29};
 
   IndexType m_numGroups2;  // Number of groups of 15 buckets, expressed as a power of 2
   IndexType m_size;
@@ -257,14 +259,14 @@ FlatMap<KeyType, ValueType, Hash>::FlatMap(IndexType bucket_count)
   , m_loadCount(0)
 {
   int minBuckets = MIN_NUM_BUCKETS;
-  bucket_count = std::min(minBuckets, bucket_count);
+  bucket_count = std::max(minBuckets, bucket_count);
   // Get the smallest power-of-two number of groups satisfying:
   // N * GroupSize - 1 >= minBuckets
   // TODO: we should add a leadingZeros overload for 64-bit integers
   {
     std::int32_t numGroups =
       std::ceil((bucket_count + 1) / (double)BucketsPerGroup);
-    m_numGroups2 = 32 - axom::utilities::leadingZeros(numGroups);
+    m_numGroups2 = 31 - (axom::utilities::leadingZeros(numGroups));
   }
 
   IndexType numGroupsRounded = 1 << m_numGroups2;

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -16,10 +16,30 @@ template <typename KeyType, typename ValueType, typename Hash = std::hash<KeyTyp
 class FlatMap
   : detail::flat_map::SequentialLookupPolicy<typename Hash::result_type>
 {
+private:
+  using LookupPolicy =
+    detail::flat_map::SequentialLookupPolicy<typename Hash::result_type>;
+  using LookupPolicy::NO_MATCH;
+
+  constexpr static int BucketsPerGroup = detail::flat_map::GroupBucket::Size;
+
+  template <bool Const>
+  class IteratorImpl;
+
+  struct KeyValuePair
+  {
+    const KeyType first;
+    ValueType second;
+  };
+
+  template <bool Const>
+  friend class IteratorImpl;
+
+public:
   using size_type = IndexType;
-  using value_type = std::pair<const KeyType, ValueType>;
-  using iterator = void;
-  using const_iterator = void;
+  using value_type = KeyValuePair;
+  using iterator = IteratorImpl<false>;
+  using const_iterator = IteratorImpl<true>;
 
   // Constructors
   FlatMap();
@@ -42,21 +62,24 @@ class FlatMap
   const_iterator cend() const;
 
   // Capacity
-  bool empty() const;
-  IndexType size() const;
+  bool empty() const { return m_size == 0; }
+  IndexType size() const { return m_size; }
 
   // Lookup
   iterator find(const KeyType& key);
   const_iterator find(const KeyType& key) const;
 
-  ValueType& at(const KeyType& key);
-  const ValueType& at(const KeyType& key) const;
+  ValueType& at(const KeyType& key) { return this->find(key)->second; }
+  const ValueType& at(const KeyType& key) const
+  {
+    return this->find(key)->second;
+  }
 
-  ValueType& operator[](const KeyType& key);
-  const ValueType& operator[](const KeyType& key) const;
+  ValueType& operator[](const KeyType& key) { return at(key); }
+  const ValueType& operator[](const KeyType& key) const { return at(key); }
 
-  IndexType count(const KeyType& key) const;
-  bool contains(const KeyType& key) const;
+  IndexType count(const KeyType& key) const { return (find(key) != end()); }
+  bool contains(const KeyType& key) const { return (find(key) != end()); }
 
   // Modifiers
   void clear();
@@ -69,13 +92,122 @@ class FlatMap
   template <typename InputIt>
   void insert(InputIt first, InputIt last);
 
+  template <typename... Args>
+  std::pair<iterator, bool> insert_or_assign(const KeyType& key, Args&&... args);
+  template <typename... Args>
+  std::pair<iterator, bool> insert_or_assign(KeyType&& key, Args&&... args);
+
+  template <typename... Args>
+  std::pair<iterator, bool> try_emplace(const KeyType& key, Args&&... args);
+  template <typename... Args>
+  std::pair<iterator, bool> try_emplace(KeyType&& key, Args&&... args);
+
   // Hashing
   IndexType bucket_count() const;
   double load_factor() const;
   double max_load_factor() const;
   void rehash(IndexType count);
   void reserve(IndexType count);
+
+private:
+  IndexType m_numGroups2;  // Number of groups of 15 buckets, expressed as a power of 2
+  IndexType m_size;
+  axom::Array<detail::flat_map::GroupBucket> m_metadata;
+  axom::Array<KeyValuePair> m_buckets;
 };
+
+template <typename KeyType, typename ValueType, typename Hash>
+template <bool Const>
+class FlatMap<KeyType, ValueType, Hash>::IteratorImpl
+{
+private:
+  using MapType = FlatMap<KeyType, ValueType, Hash>;
+
+public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = MapType::value_type;
+  using difference_type = IndexType;
+
+  using DataType = std::conditional_t<Const, const value_type, value_type>;
+  using MapConstType = std::conditional_t<Const, const MapType, MapType>;
+  using pointer = DataType*;
+  using reference = DataType&;
+
+public:
+  IteratorImpl(MapConstType* map, IndexType internalIdx)
+    : m_map(map)
+    , m_internalIdx(internalIdx)
+  { }
+
+  friend bool operator==(const IteratorImpl& lhs, const IteratorImpl& rhs)
+  {
+    return lhs.m_internalIdx == rhs.m_internalIdx;
+  }
+
+  friend bool operator!=(const IteratorImpl& lhs, const IteratorImpl& rhs)
+  {
+    return lhs.m_internalIdx != rhs.m_internalIdx;
+  }
+
+  IteratorImpl& operator++()
+  {
+    // TODO
+  }
+
+  IteratorImpl operator++(int)
+  {
+    // TODO
+  }
+
+  reference operator*() const { return m_map->m_buckets[m_internalIdx]; }
+
+  pointer operator->() const { return &(m_map->m_buckets[m_internalIdx]); }
+
+private:
+  MapConstType* m_map;
+  IndexType m_internalIdx;
+};
+
+template <typename KeyType, typename ValueType, typename Hash>
+auto FlatMap<KeyType, ValueType, Hash>::find(const KeyType& key) -> iterator
+{
+  auto hash = Hash {}(key);
+  iterator found_iter = end();
+  this->probeIndex(m_numGroups2,
+                   m_metadata,
+                   hash,
+                   [&](IndexType bucket_index) -> bool {
+                     if(this->m_buckets[bucket_index].first == key)
+                     {
+                       found_iter = iterator(this, bucket_index);
+                       // Stop tracking.
+                       return false;
+                     }
+                     return true;
+                   });
+  return found_iter;
+}
+
+template <typename KeyType, typename ValueType, typename Hash>
+auto FlatMap<KeyType, ValueType, Hash>::find(const KeyType& key) const
+  -> const_iterator
+{
+  auto hash = Hash {}(key);
+  iterator found_iter = end();
+  this->probeIndex(m_numGroups2,
+                   m_metadata,
+                   hash,
+                   [&](IndexType bucket_index) -> bool {
+                     if(this->m_buckets[bucket_index].first == key)
+                     {
+                       found_iter = iterator(this, bucket_index);
+                       // Stop tracking.
+                       return false;
+                     }
+                     return true;
+                   });
+  return found_iter;
+}
 
 }  // namespace axom
 

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -105,7 +105,26 @@ public:
   bool contains(const KeyType& key) const { return (find(key) != end()); }
 
   // Modifiers
-  void clear();
+  void clear()
+  {
+    // Destroy all elements.
+    IndexType index = this->nextValidIndex(m_metadata, NO_MATCH);
+    while(index < bucket_count())
+    {
+      m_buckets[index].get().~KeyValuePair();
+      index = this->nextValidIndex(m_metadata, index);
+    }
+
+    // Also reset metadata.
+    for(int group_index = 0; group_index < m_metadata.size(); group_index++)
+    {
+      m_metadata[group_index] = detail::flat_map::GroupBucket {};
+    }
+    m_metadata[m_metadata.size() - 1].setSentinel();
+    m_size = 0;
+    m_loadCount = 0;
+  }
+
   std::pair<iterator, bool> insert(const value_type& value)
   {
     return emplaceImpl(false, value.first, value.second);

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -41,24 +41,60 @@ public:
   using iterator = IteratorImpl<false>;
   using const_iterator = IteratorImpl<true>;
 
-  // Constructors
+  /*!
+   * \brief Constructs a FlatMap with no elements.
+   */
   FlatMap() : FlatMap(MIN_NUM_BUCKETS) { }
 
+  /*!
+   * \brief Constructs a FlatMap with at least a given number of buckets.
+   *
+   * \param [in] bucket_count the minimum number of buckets to allocate
+   */
   explicit FlatMap(IndexType bucket_count);
 
+  /*!
+   * \brief Constructs a FlatMap with a range of elements.
+   *
+   * \param [in] first iterator pointing to the beginning of the range
+   * \param [in] last iterator pointing to the end of the range
+   * \param [in] bucket_count minimum number of buckets to allocate (optional)
+   */
   template <typename InputIt>
   FlatMap(InputIt first, InputIt last, IndexType bucket_count = -1)
     : FlatMap(std::distance(first, last), first, last, bucket_count)
   { }
 
+  /*!
+   * \brief Constructs a FlatMap with a range of elements.
+   *
+   * \param [in] init a list of pairs to initialize the map with
+   * \param [in] bucket_count minimum number of buckets to allocate (optional)
+   */
   explicit FlatMap(std::initializer_list<value_type> init,
                    IndexType bucket_count = -1)
     : FlatMap(init.begin(), init.end(), bucket_count)
   { }
 
+  /*!
+   * \brief Move constructor for a FlatMap instance.
+   *
+   * \param other the FlatMap to move data from
+   */
   FlatMap(FlatMap&& other) : FlatMap() { swap(other); }
+
+  /*!
+   * \brief Move assignment operator for a FlatMap instance.
+   *
+   * \param other the FlatMap to move data from
+   */
   FlatMap& operator=(FlatMap&& other) { swap(other); }
 
+  /*!
+   * \brief Copy constructor for a FlatMap instance.
+   *
+   * \param other the FlatMap to copy data from
+   */
   FlatMap(const FlatMap& other)
     : m_numGroups2(other.m_numGroups2)
     , m_size(other.m_size)
@@ -74,6 +110,12 @@ public:
       index = this->nextValidIndex(m_metadata, index);
     }
   }
+
+  /*!
+   * \brief Copy assignment operator for a FlatMap instance.
+   *
+   * \param other the FlatMap to copy data from
+   */
   FlatMap& operator=(const FlatMap& other)
   {
     if(*this != other)
@@ -83,6 +125,7 @@ public:
     }
   }
 
+  /// \brief Destructor for a FlatMap instance.
   ~FlatMap()
   {
     // Destroy all elements.

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -80,9 +80,9 @@ public:
     return const_iterator(this, firstBucketIndex);
   }
 
-  iterator end() { return iterator(this, m_buckets.size()); }
-  const_iterator end() const { return const_iterator(this, m_buckets.size()); }
-  const_iterator cend() const { return const_iterator(this, m_buckets.size()); }
+  iterator end() { return iterator(this, bucket_count()); }
+  const_iterator end() const { return const_iterator(this, bucket_count()); }
+  const_iterator cend() const { return const_iterator(this, bucket_count()); }
 
   // Capacity
   bool empty() const { return m_size == 0; }
@@ -165,10 +165,7 @@ public:
 
   // Hashing
   IndexType bucket_count() const { return m_buckets.size(); }
-  double load_factor() const
-  {
-    return ((double)m_loadCount) / m_buckets.size();
-  }
+  double load_factor() const { return ((double)m_loadCount) / bucket_count(); }
   double max_load_factor() const { return MAX_LOAD_FACTOR; }
   void rehash(IndexType count)
   {
@@ -225,7 +222,7 @@ public:
     : m_map(map)
     , m_internalIdx(internalIdx)
   {
-    assert(m_internalIdx >= 0 && m_internalIdx <= m_map->m_buckets.size());
+    assert(m_internalIdx >= 0 && m_internalIdx <= m_map->bucket_count());
   }
 
   template <bool UConst = Const, typename Enable = std::enable_if_t<UConst>>
@@ -364,7 +361,7 @@ auto FlatMap<KeyType, ValueType, Hash>::emplaceImpl(bool assign_on_existence,
   auto hash = MixedHash {}(key);
   // Resize to double the number of bucket groups if insertion would put us
   // above the maximum load factor.
-  if(((m_loadCount + 1) / (double)m_buckets.size()) >= MAX_LOAD_FACTOR)
+  if(((m_loadCount + 1) / (double)bucket_count()) >= MAX_LOAD_FACTOR)
   {
     IndexType newNumGroups = m_metadata.size() * 2;
     rehash(newNumGroups * BucketsPerGroup - 1);

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -53,13 +53,25 @@ public:
                    IndexType bucket_count = -1);
 
   // Iterators
-  iterator begin();
-  const_iterator begin() const;
-  const_iterator cbegin() const;
+  iterator begin()
+  {
+    IndexType firstBucketIndex = this->nextValidIndex(m_metadata, 0);
+    return iterator(this, firstBucketIndex);
+  }
+  const_iterator begin() const
+  {
+    IndexType firstBucketIndex = this->nextValidIndex(m_metadata, 0);
+    return const_iterator(this, firstBucketIndex);
+  }
+  const_iterator cbegin() const
+  {
+    IndexType firstBucketIndex = this->nextValidIndex(m_metadata, 0);
+    return const_iterator(this, firstBucketIndex);
+  }
 
-  iterator end();
-  const_iterator end() const;
-  const_iterator cend() const;
+  iterator end() { return iterator(this, m_buckets.size()); }
+  const_iterator end() const { return const_iterator(this, m_buckets.size()); }
+  const_iterator cend() const { return const_iterator(this, m_buckets.size()); }
 
   // Capacity
   bool empty() const { return m_size == 0; }
@@ -182,12 +194,15 @@ public:
 
   IteratorImpl& operator++()
   {
-    // TODO
+    m_internalIdx = m_map->nextValidIndex(m_map->m_buckets, m_internalIdx);
+    return *this;
   }
 
   IteratorImpl operator++(int)
   {
-    // TODO
+    IteratorImpl next = *this;
+    next++;
+    return next;
   }
 
   reference operator*() const { return m_map->m_buckets[m_internalIdx]; }

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -143,11 +143,12 @@ public:
                   "Cannot copy an axom::FlatMap when value type is not "
                   "copy-constructible.");
     // Copy all elements.
-    IndexType index = this->nextValidIndex(m_metadata, NO_MATCH);
+    const auto metadata = m_metadata.view();
+    IndexType index = this->nextValidIndex(metadata, NO_MATCH);
     while(index < bucket_count())
     {
       new(&m_buckets[index].data) KeyValuePair(other.m_buckets[index].get());
-      index = this->nextValidIndex(m_metadata, index);
+      index = this->nextValidIndex(metadata, index);
     }
   }
 
@@ -178,11 +179,12 @@ public:
   ~FlatMap()
   {
     // Destroy all elements.
-    IndexType index = this->nextValidIndex(m_metadata, NO_MATCH);
+    const auto metadata = m_metadata.view();
+    IndexType index = this->nextValidIndex(metadata, NO_MATCH);
     while(index < bucket_count())
     {
       m_buckets[index].get().~KeyValuePair();
-      index = this->nextValidIndex(m_metadata, index);
+      index = this->nextValidIndex(metadata, index);
     }
 
     // Unlike in clear() we don't need to reset metadata here.

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -312,6 +312,17 @@ auto FlatMap<KeyType, ValueType, Hash>::find(const KeyType& key) const
 }
 
 template <typename KeyType, typename ValueType, typename Hash>
+template <typename InputIt>
+void FlatMap<KeyType, ValueType, Hash>::insert(InputIt first, InputIt last)
+{
+  while(first != last)
+  {
+    insert(*first);
+    first++;
+  }
+}
+
+template <typename KeyType, typename ValueType, typename Hash>
 template <typename... InputArgs>
 auto FlatMap<KeyType, ValueType, Hash>::emplaceImpl(bool assign_on_existence,
                                                     KeyType&& key,

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -579,18 +579,7 @@ private:
   axom::Array<detail::flat_map::GroupBucket> m_metadata;
 
   // Storage details:
-  struct alignas(KeyValuePair) PairStorage
-  {
-    unsigned char data[sizeof(KeyValuePair)];
-
-    const KeyValuePair& get() const
-    {
-      return *(reinterpret_cast<const KeyValuePair*>(&data));
-    }
-
-    KeyValuePair& get() { return *(reinterpret_cast<KeyValuePair*>(&data)); }
-  };
-
+  using PairStorage = detail::flat_map::TypeErasedStorage<KeyValuePair>;
   axom::Array<PairStorage> m_buckets;
 
   // Boost flat_unordered_map uses a fixed load factor.

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -31,6 +31,8 @@ private:
   template <bool Const>
   friend class IteratorImpl;
 
+  using MixedHash = detail::flat_map::HashMixer64<KeyType, Hash>;
+
 public:
   using size_type = IndexType;
   using value_type = KeyValuePair;
@@ -301,7 +303,7 @@ FlatMap<KeyType, ValueType, Hash>::FlatMap(IndexType num_elems,
 template <typename KeyType, typename ValueType, typename Hash>
 auto FlatMap<KeyType, ValueType, Hash>::find(const KeyType& key) -> iterator
 {
-  auto hash = Hash {}(key);
+  auto hash = MixedHash {}(key);
   iterator found_iter = end();
   this->probeIndex(m_numGroups2,
                    m_metadata,
@@ -322,7 +324,7 @@ template <typename KeyType, typename ValueType, typename Hash>
 auto FlatMap<KeyType, ValueType, Hash>::find(const KeyType& key) const
   -> const_iterator
 {
-  auto hash = Hash {}(key);
+  auto hash = MixedHash {}(key);
   const_iterator found_iter = end();
   this->probeIndex(m_numGroups2,
                    m_metadata,
@@ -359,7 +361,7 @@ auto FlatMap<KeyType, ValueType, Hash>::emplaceImpl(bool assign_on_existence,
 {
   static_assert(std::is_convertible<UKeyType, KeyType>::value,
                 "UKeyType -> KeyType not convertible");
-  auto hash = Hash {}(key);
+  auto hash = MixedHash {}(key);
   // Resize to double the number of bucket groups if insertion would put us
   // above the maximum load factor.
   if(((m_loadCount + 1) / (double)m_buckets.size()) >= MAX_LOAD_FACTOR)
@@ -409,7 +411,7 @@ template <typename KeyType, typename ValueType, typename Hash>
 auto FlatMap<KeyType, ValueType, Hash>::erase(const_iterator pos) -> iterator
 {
   assert(pos != end());
-  auto hash = Hash {}(pos->first);
+  auto hash = MixedHash {}(pos->first);
 
   bool midSequence = this->clearBucket(m_metadata, pos.m_internalIdx, hash);
   pos->~KeyValuePair();

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -663,7 +663,7 @@ FlatMap<KeyType, ValueType, Hash>::FlatMap(IndexType bucket_count)
   : m_size(0)
   , m_loadCount(0)
 {
-  int minBuckets = MIN_NUM_BUCKETS;
+  IndexType minBuckets = MIN_NUM_BUCKETS;
   bucket_count = axom::utilities::max(minBuckets, bucket_count);
   // Get the smallest power-of-two number of groups satisfying:
   // N * GroupSize - 1 >= minBuckets

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -551,7 +551,7 @@ FlatMap<KeyType, ValueType, Hash>::FlatMap(IndexType bucket_count)
   , m_loadCount(0)
 {
   int minBuckets = MIN_NUM_BUCKETS;
-  bucket_count = std::max(minBuckets, bucket_count);
+  bucket_count = axom::utilities::max(minBuckets, bucket_count);
   // Get the smallest power-of-two number of groups satisfying:
   // N * GroupSize - 1 >= minBuckets
   // TODO: we should add a leadingZeros overload for 64-bit integers

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -429,7 +429,7 @@ public:
   }
   /// @}
 
-  iterator erase(iterator pos) { erase(const_iterator {pos}); }
+  iterator erase(iterator pos) { return erase(const_iterator {pos}); }
   iterator erase(const_iterator pos);
   IndexType erase(const KeyType& key)
   {

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef Axom_Core_FlatMap_HPP
+#define Axom_Core_FlatMap_HPP
+
+#include "axom/config.hpp"
+#include "axom/core/Macros.hpp"
+#include "axom/core/detail/FlatTable.hpp"
+
+namespace axom
+{
+template <typename KeyType, typename ValueType, typename Hash = std::hash<KeyType>>
+class FlatMap
+  : detail::flat_map::SequentialLookupPolicy<typename Hash::result_type>
+{
+  using size_type = IndexType;
+  using value_type = std::pair<const KeyType, ValueType>;
+  using iterator = void;
+  using const_iterator = void;
+
+  // Constructors
+  FlatMap();
+
+  explicit FlatMap(IndexType bucket_count);
+
+  template <typename InputIt>
+  FlatMap(InputIt first, InputIt last, IndexType bucket_count = -1);
+
+  explicit FlatMap(std::initializer_list<value_type> init,
+                   IndexType bucket_count = -1);
+
+  // Iterators
+  iterator begin();
+  const_iterator begin() const;
+  const_iterator cbegin() const;
+
+  iterator end();
+  const_iterator end() const;
+  const_iterator cend() const;
+
+  // Capacity
+  bool empty() const;
+  IndexType size() const;
+
+  // Lookup
+  iterator find(const KeyType& key);
+  const_iterator find(const KeyType& key) const;
+
+  ValueType& at(const KeyType& key);
+  const ValueType& at(const KeyType& key) const;
+
+  ValueType& operator[](const KeyType& key);
+  const ValueType& operator[](const KeyType& key) const;
+
+  IndexType count(const KeyType& key) const;
+  bool contains(const KeyType& key) const;
+
+  // Modifiers
+  void clear();
+  std::pair<iterator, bool> insert(const value_type& value);
+  std::pair<iterator, bool> insert(value_type&& value);
+  template <typename InputPair>
+  std::pair<iterator, bool> insert(InputPair&& pair);
+  template <typename InputPair>
+  std::pair<iterator, bool> emplace(InputPair&& pair);
+  template <typename InputIt>
+  void insert(InputIt first, InputIt last);
+
+  // Hashing
+  IndexType bucket_count() const;
+  double load_factor() const;
+  double max_load_factor() const;
+  void rehash(IndexType count);
+  void reserve(IndexType count);
+};
+
+}  // namespace axom
+
+#endif  // Axom_Core_FlatMap_HPP

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -320,7 +320,10 @@ public:
    *
    * \param [in] key the key to search for
    */
-  IndexType count(const KeyType& key) const { return (find(key) != end()); }
+  IndexType count(const KeyType& key) const
+  {
+    return contains(key) ? IndexType {1} : IndexType {0};
+  }
 
   /*!
    * \brief Return true if the FlatMap contains a key, false otherwise.

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -375,9 +375,9 @@ auto FlatMap<KeyType, ValueType, Hash>::emplaceImpl(bool assign_on_existence,
       keyExistsAlready = true;
       foundBucketIndex = bucket_index;
       // Exit out of probing, we can't insert if the key already exists.
-      return false;
+      return true;
     }
-    return true;
+    return false;
   };
 
   IndexType newBucket =

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -148,8 +148,8 @@ public:
   {
     axom::utilities::swap(m_numGroups2, other.m_numGroups2);
     axom::utilities::swap(m_size, other.m_size);
-    axom::utilities::swap(m_metadata, other.m_metadata);
-    axom::utilities::swap(m_buckets, other.m_buckets);
+    m_metadata.swap(other.m_metadata);
+    m_buckets.swap(other.m_buckets);
     axom::utilities::swap(m_loadCount, other.m_loadCount);
   }
 

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -168,7 +168,7 @@ struct SequentialLookupPolicy
     int empty_group = NO_MATCH;
     int empty_bucket = NO_MATCH;
 
-    std::uint8_t hash_8 {hash};
+    std::uint8_t hash_8 = static_cast<std::uint8_t>(hash);
     int iteration = 0;
     bool keep_going = true;
     while(keep_going)
@@ -229,7 +229,7 @@ struct SequentialLookupPolicy
     int group_divisor = 1 << ((CHAR_BIT * sizeof(HashType)) - ngroups_pow_2);
     int curr_group = hash / group_divisor;
 
-    std::uint8_t hash_8 {hash};
+    std::uint8_t hash_8 = static_cast<std::uint8_t>(hash);
     int iteration = 0;
     bool keep_going = true;
     while(keep_going)
@@ -276,7 +276,8 @@ struct SequentialLookupPolicy
     return groups[group_index].getMaybeOverflowed(hash);
   }
 
-  IndexType nextValidIndex(ArrayView<const GroupBucket> groups, int last_bucket)
+  IndexType nextValidIndex(ArrayView<const GroupBucket> groups,
+                           int last_bucket) const
   {
     if(last_bucket >= groups.size() * GroupBucket::Size - 1)
     {

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -317,6 +317,16 @@ struct SequentialLookupPolicy
   }
 };
 
+template <typename T>
+struct alignas(T) TypeErasedStorage
+{
+  unsigned char data[sizeof(T)];
+
+  const T& get() const { return *(reinterpret_cast<const T*>(&data)); }
+
+  T& get() { return *(reinterpret_cast<T*>(&data)); }
+};
+
 }  // namespace flat_map
 }  // namespace detail
 }  // namespace axom

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -140,12 +140,11 @@ struct SequentialLookupPolicy
    * \param [in] groups the array of metadata for the groups in the hash map
    * \param [in] hash the hash to insert
    */
-  template <typename FoundIndex, typename InsertIndex>
-  bool probeEmptyIndex(int ngroups_pow_2,
-                       ArrayView<GroupBucket> groups,
-                       HashType hash,
-                       FoundIndex&& on_hash_found,
-                       InsertIndex&& on_empty_insert) const
+  template <typename FoundIndex>
+  IndexType probeEmptyIndex(int ngroups_pow_2,
+                            ArrayView<GroupBucket> groups,
+                            HashType hash,
+                            FoundIndex&& on_hash_found) const
   {
     // We use the k MSBs of the hash as the initial group probe point,
     // where ngroups = 2^k.
@@ -187,12 +186,11 @@ struct SequentialLookupPolicy
         iteration++;
       }
     }
-    // Call the function for the empty bucket index.
     if(empty_group != NO_MATCH)
     {
-      on_empty_insert(empty_group * GroupBucket::Size + empty_bucket);
+      return empty_group * GroupBucket::Size + empty_bucket;
     }
-    return empty_group != NO_MATCH;
+    return NO_MATCH;
   }
 
   /*!
@@ -241,6 +239,14 @@ struct SequentialLookupPolicy
         iteration++;
       }
     }
+  }
+
+  void setBucketHash(ArrayView<GroupBucket> groups, IndexType bucket, HashType hash)
+  {
+    int group_index = bucket / GroupBucket::Size;
+    int slot_index = bucket % GroupBucket::Size;
+
+    groups[group_index].setBucket(slot_index, hash);
   }
 };
 

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -264,6 +264,18 @@ struct SequentialLookupPolicy
     groups[group_index].setBucket(slot_index, hash);
   }
 
+  bool clearBucket(ArrayView<GroupBucket> groups, IndexType bucket, HashType hash)
+  {
+    int group_index = bucket / GroupBucket::Size;
+    int slot_index = bucket % GroupBucket::Size;
+
+    groups[group_index].setBucket(slot_index, GroupBucket::Empty);
+
+    // Return if the overflow bit is set on the bucket. That indicates whether
+    // we are deleting an element in the middle of a probing sequence.
+    return groups[group_index].getMaybeOverflowed(hash);
+  }
+
   IndexType nextValidIndex(ArrayView<const GroupBucket> groups, int last_bucket)
   {
     if(last_bucket >= groups.size() * GroupBucket::Size - 1)

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -42,7 +42,7 @@ struct HashMixer64
   uint64_t operator()(const KeyType& key) const
   {
     uint64_t hash = HashFunc {}(key);
-	hash *= 0xbf58476d1ce4e5b9ULL;
+    hash *= 0xbf58476d1ce4e5b9ULL;
     hash ^= hash >> 32;
     hash *= 0x94d049bb133111ebULL;
     hash ^= hash >> 32;

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -155,18 +155,17 @@ struct GroupBucket
       std::uint8_t buckets[Size];
     } metadata;
     std::uint64_t data[2];
-    static_assert(
-      sizeof(metadata) == sizeof(data),
-      "FlatMap::SwissTable::Bucket: sizeof(data_bytes) != sizeof(data)");
+    static_assert(sizeof(metadata) == sizeof(data),
+                  "flat_map::GroupBucket: sizeof(data_bytes) != sizeof(data)");
   };
 };
 
 static_assert(sizeof(GroupBucket) == 16,
-              "FlatMap::SwissTable::Bucket: size != 16 bytes");
+              "flat_map::GroupBucket: size != 16 bytes");
 static_assert(std::alignment_of<GroupBucket>::value == 16,
-              "FlatMap::SwissTable::Bucket: alignment != 16 bytes");
+              "flat_map::GroupBucket: alignment != 16 bytes");
 static_assert(std::is_standard_layout<GroupBucket>::value,
-              "FlatMap::SwissTable::Bucket: not standard layout");
+              "flat_map::GroupBucket: not standard layout");
 
 template <typename HashType, typename ProbePolicy = QuadraticProbing>
 struct SequentialLookupPolicy
@@ -233,8 +232,8 @@ struct SequentialLookupPolicy
    * \param [in] ngroups_pow_2 the number of groups, expressed as a power of 2
    * \param [in] groups the array of metadata for the groups in the hash map
    * \param [in] hash the hash to insert
-   *
-   * \return the first bucket with an empty space, if probing for insertion.
+   * \param [in] on_hash_found functor to call for a bucket index with a
+   *  matching hash
    */
   template <typename FoundIndex>
   void probeIndex(int ngroups_pow_2,

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -168,7 +168,7 @@ static_assert(std::is_standard_layout<GroupBucket>::value,
               "flat_map::GroupBucket: not standard layout");
 
 template <typename HashType, typename ProbePolicy = QuadraticProbing>
-struct SequentialLookupPolicy
+struct SequentialLookupPolicy : ProbePolicy
 {
   constexpr static int NO_MATCH = -1;
 
@@ -215,8 +215,7 @@ struct SequentialLookupPolicy
         // Set the overflow bit and continue probing.
         metadata[curr_group].setOverflow(hash_8);
       }
-      curr_group =
-        (curr_group + ProbePolicy {}.getNext(iteration)) % metadata.size();
+      curr_group = (curr_group + this->getNext(iteration)) % metadata.size();
     }
     if(empty_group != NO_MATCH)
     {
@@ -267,8 +266,7 @@ struct SequentialLookupPolicy
         break;
       }
       // Probe the next bucket.
-      curr_group =
-        (curr_group + ProbePolicy {}.getNext(iteration)) % metadata.size();
+      curr_group = (curr_group + this->getNext(iteration)) % metadata.size();
     }
   }
 

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -47,6 +47,8 @@ struct GroupBucket
   constexpr static std::uint8_t Sentinel = 1;
   constexpr static int InvalidSlot = -1;
 
+  constexpr static int Size = 15;
+
   GroupBucket() : data {0ULL, 0ULL} { }
 
   int getEmptyBucket() const

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -6,6 +6,8 @@
 #ifndef Axom_Core_Detail_FlatTable_Hpp
 #define Axom_Core_Detail_FlatTable_Hpp
 
+#include <climits>
+
 #include "axom/core/Array.hpp"
 #include "axom/core/ArrayView.hpp"
 #include "axom/core/utilities/BitUtilities.hpp"

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -192,7 +192,7 @@ struct SequentialLookupPolicy
         // contain the hash. Stop probing.
         keep_going = false;
       }
-      else
+      else if(empty_group == NO_MATCH)
       {
         // Set the overflow bit and continue probing.
         groups[curr_group].setOverflow(hash_8);

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -99,6 +99,8 @@ struct GroupBucket
     metadata.buckets[index] = reduceHash(hash);
   }
 
+  void clearBucket(int index) { metadata.buckets[index] = Empty; }
+
   void setOverflow(std::uint8_t hash)
   {
     std::uint8_t hashOfwBit = 1 << (hash % 8);
@@ -267,7 +269,7 @@ struct SequentialLookupPolicy
     int group_index = bucket / GroupBucket::Size;
     int slot_index = bucket % GroupBucket::Size;
 
-    groups[group_index].setBucket(slot_index, GroupBucket::Empty);
+    groups[group_index].clearBucket(slot_index);
 
     // Return if the overflow bit is set on the bucket. That indicates whether
     // we are deleting an element in the middle of a probing sequence.

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -66,7 +66,7 @@ struct GroupBucket
 
   int nextFilledBucket(int start_index) const
   {
-    for(int i = start_index; i < 15; i++)
+    for(int i = start_index + 1; i < 15; i++)
     {
       // We intentionally don't check for the sentinel here. This gives us the
       // index of the sentinel bucket at the end, which is needed as a "stop"
@@ -286,15 +286,16 @@ struct SequentialLookupPolicy
     int group_index = last_bucket / GroupBucket::Size;
     int slot_index = last_bucket % GroupBucket::Size;
 
-    while(slot_index != GroupBucket::InvalidSlot && group_index < groups.size())
+    do
     {
-      slot_index = groups[group_index].nextFilledBucket(slot_index + 1);
+      slot_index = groups[group_index].nextFilledBucket(slot_index);
       if(slot_index == GroupBucket::InvalidSlot)
       {
         group_index++;
-        slot_index = 0;
+        slot_index = -1;
       }
-    }
+    } while(slot_index == GroupBucket::InvalidSlot && group_index < groups.size());
+
     return group_index * GroupBucket::Size + slot_index;
   }
 };

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(core_serial_tests
     core_execution_for_all.hpp
     core_execution_space.hpp
     core_map.hpp
+    core_flatmap.hpp
     core_memory_management.hpp
     core_Path.hpp
     core_stack_array.hpp

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -179,6 +179,31 @@ TEST(core_flatmap, init_and_move)
   }
 }
 
+TEST(core_flatmap, init_and_move_moveonly)
+{
+  axom::FlatMap<int, std::unique_ptr<double>> int_to_dbl;
+  int NUM_ELEMS = 40;
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    int_to_dbl.emplace(i, new double {i + 10.0});
+  }
+
+  axom::FlatMap<int, std::unique_ptr<double>> int_to_dbl_move =
+    std::move(int_to_dbl);
+
+  EXPECT_EQ(int_to_dbl.size(), 0);
+  EXPECT_EQ(int_to_dbl.load_factor(), 0);
+  EXPECT_EQ(int_to_dbl_move.size(), NUM_ELEMS);
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    EXPECT_EQ(*(int_to_dbl_move[i]), i + 10.0);
+
+    auto old_it = int_to_dbl.find(i);
+    EXPECT_EQ(old_it, int_to_dbl.end());
+  }
+}
+
 TEST(core_flatmap, init_and_copy)
 {
   axom::FlatMap<int, double> int_to_dbl;

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -11,41 +11,96 @@
 // gtest includes
 #include "gtest/gtest.h"
 
-TEST(core_flatmap, default_init)
+inline void flatmap_get_value(double key, std::string& out)
 {
-  axom::FlatMap<int, std::string> int_to_dbl;
+  out = std::to_string(key);
+}
+
+inline void flatmap_get_value(int key, std::string& out)
+{
+  out = std::to_string(key);
+}
+
+template <typename T, typename U>
+inline void flatmap_get_value(T key, U& out)
+{
+  out = key;
+}
+
+template <typename FlatMapType>
+class core_flatmap : public ::testing::Test
+{
+public:
+  using MapType = FlatMapType;
+  using KeyType = typename FlatMapType::key_type;
+  using ValueType = typename FlatMapType::mapped_type;
+
+  template <typename T>
+  KeyType getKey(T input)
+  {
+    KeyType key;
+    flatmap_get_value(input, key);
+    return key;
+  }
+
+  template <typename T>
+  ValueType getValue(T input)
+  {
+    ValueType val;
+    flatmap_get_value(input, val);
+    return val;
+  }
+
+  ValueType getDefaultValue() { return ValueType(); }
+};
+
+using MyTypes = ::testing::Types<axom::FlatMap<int, double>,
+                                 axom::FlatMap<int, std::string>,
+                                 axom::FlatMap<std::string, double>,
+                                 axom::FlatMap<std::string, std::string>>;
+
+TYPED_TEST_SUITE(core_flatmap, MyTypes);
+
+AXOM_TYPED_TEST(core_flatmap, default_init)
+{
+  using MapType = typename TestFixture::MapType;
+  MapType int_to_dbl;
   EXPECT_EQ(0, int_to_dbl.size());
   EXPECT_EQ(true, int_to_dbl.empty());
 }
 
-TEST(core_flatmap, insert_only)
+AXOM_TYPED_TEST(core_flatmap, insert_only)
 {
-  axom::FlatMap<int, double> int_to_dbl;
+  using MapType = typename TestFixture::MapType;
+  MapType int_to_dbl;
 
   const int NUM_ELEMS = 100;
 
   for(int i = 0; i < NUM_ELEMS; i++)
   {
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 5.0);
     // Initial insertion of a given key should succeed.
-    auto initial_insert = int_to_dbl.insert({i, i * 10.0 + 5.0});
+    auto initial_insert = int_to_dbl.insert({key, value});
     EXPECT_EQ(int_to_dbl.size(), i + 1);
-    EXPECT_EQ(initial_insert.first, int_to_dbl.find(i));
-    EXPECT_EQ(i * 10.0 + 5.0, int_to_dbl.at(i));
+    EXPECT_EQ(initial_insert.first, int_to_dbl.find(key));
+    EXPECT_EQ(value, int_to_dbl.at(key));
     EXPECT_TRUE(initial_insert.second);
 
     int current_bucket_capacity = int_to_dbl.bucket_count();
 
     // Inserting a duplicate key should not change the value.
-    auto duplicate_insert = int_to_dbl.insert({i, i * 10.0 + 7.0});
+    auto value_dup = this->getValue(i * 10.0 + 5.0);
+    auto duplicate_insert = int_to_dbl.insert({key, value_dup});
     EXPECT_EQ(int_to_dbl.size(), i + 1);
-    EXPECT_EQ(duplicate_insert.first, int_to_dbl.find(i));
-    EXPECT_EQ(i * 10.0 + 5.0, int_to_dbl.at(i));
+    EXPECT_EQ(duplicate_insert.first, int_to_dbl.find(key));
+    EXPECT_EQ(value, int_to_dbl.at(key));
     EXPECT_FALSE(duplicate_insert.second);
 
     // Using operator[] with an already-existing key should return the
     // existing value and not add a value.
-    double value = int_to_dbl[i];
-    EXPECT_EQ(i * 10.0 + 5.0, value);
+    auto value_indexed = int_to_dbl[key];
+    EXPECT_EQ(value_indexed, value);
     EXPECT_EQ(int_to_dbl.size(), i + 1);
 
     // Check that a rehash didn't occur on the second insertion.
@@ -54,83 +109,40 @@ TEST(core_flatmap, insert_only)
   }
 }
 
-TEST(core_flatmap_str, insert_only)
+AXOM_TYPED_TEST(core_flatmap, insert_or_assign)
 {
-  axom::FlatMap<std::string, std::string> int_to_dbl;
+  using MapType = typename TestFixture::MapType;
+  MapType int_to_dbl;
 
-  int_to_dbl.insert({std::to_string(0), std::to_string(10.0)});
-  EXPECT_EQ(1, int_to_dbl.size());
-
-  int_to_dbl.insert({std::to_string(1), std::to_string(20.0)});
-  EXPECT_EQ(2, int_to_dbl.size());
-
-  int_to_dbl.insert({std::to_string(2), std::to_string(30.0)});
-  EXPECT_EQ(3, int_to_dbl.size());
-
-  // Check consistency of added values.
-  const double expected_str[3] {10.0, 20.0, 30.0};
-  for(int i = 0; i < 3; i++)
-  {
-    std::string key = std::to_string(i);
-    std::string expected_value = std::to_string(expected_str[i]);
-    auto iterator = int_to_dbl.find(key);
-    EXPECT_NE(iterator, int_to_dbl.end());
-    EXPECT_EQ(iterator->first, key);
-    EXPECT_EQ(iterator->second, expected_value);
-
-    // Using operator[] with an already-existing key should return the
-    // existing value and not add a value.
-    std::string value = int_to_dbl[key];
-    EXPECT_EQ(value, expected_value);
-    EXPECT_EQ(int_to_dbl.size(), 3);
-  }
-}
-
-TEST(core_flatmap, insert_or_assign)
-{
-  axom::FlatMap<int, double> int_to_dbl;
+  const int NUM_ELEMS = 100;
 
   // Test insert behavior of FlatMap::insert_or_assign.
+  for(int i = 0; i < NUM_ELEMS; i++)
   {
-    auto res_0 = int_to_dbl.insert_or_assign(0, 10.0);
-    EXPECT_EQ(1, int_to_dbl.size());
-    EXPECT_EQ(10.0, int_to_dbl.at(0));
-    EXPECT_EQ(res_0.first, int_to_dbl.find(0));
-    EXPECT_TRUE(res_0.second);
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 5.0);
 
-    auto res_1 = int_to_dbl.insert_or_assign(1, 20.0);
-    EXPECT_EQ(2, int_to_dbl.size());
-    EXPECT_EQ(20.0, int_to_dbl.at(1));
-    EXPECT_EQ(res_1.first, int_to_dbl.find(1));
-    EXPECT_TRUE(res_1.second);
-
-    auto res_2 = int_to_dbl.insert_or_assign(2, 30.0);
-    EXPECT_EQ(3, int_to_dbl.size());
-    EXPECT_EQ(30.0, int_to_dbl.at(2));
-    EXPECT_EQ(res_2.first, int_to_dbl.find(2));
-    EXPECT_TRUE(res_2.second);
+    auto result = int_to_dbl.insert_or_assign(key, value);
+    EXPECT_EQ(i + 1, int_to_dbl.size());
+    EXPECT_EQ(value, int_to_dbl.at(key));
+    EXPECT_EQ(result.first, int_to_dbl.find(key));
+    EXPECT_TRUE(result.second);
   }
 
   // Test assign behavior of FlatMap::insert_or_assign.
+  for(int i = 0; i < NUM_ELEMS; i++)
   {
-    auto res_0 = int_to_dbl.insert_or_assign(0, 20.0);
-    EXPECT_EQ(20.0, int_to_dbl.at(0));
-    EXPECT_EQ(res_0.first, int_to_dbl.find(0));
-    EXPECT_FALSE(res_0.second);
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 7.0);
 
-    auto res_1 = int_to_dbl.insert_or_assign(1, 40.0);
-    EXPECT_EQ(40.0, int_to_dbl.at(1));
-    EXPECT_EQ(res_1.first, int_to_dbl.find(1));
-    EXPECT_FALSE(res_1.second);
-
-    auto res_2 = int_to_dbl.insert_or_assign(2, 60.0);
-    EXPECT_EQ(60.0, int_to_dbl.at(2));
-    EXPECT_EQ(res_2.first, int_to_dbl.find(2));
-    EXPECT_FALSE(res_2.second);
-
-    // Assignments should not change size of FlatMap.
-    EXPECT_EQ(3, int_to_dbl.size());
+    auto result = int_to_dbl.insert_or_assign(key, value);
+    EXPECT_EQ(value, int_to_dbl.at(key));
+    EXPECT_EQ(result.first, int_to_dbl.find(key));
+    EXPECT_FALSE(result.second);
   }
+
+  // Assignments should not change size of FlatMap.
+  EXPECT_EQ(NUM_ELEMS, int_to_dbl.size());
 }
 
 TEST(core_flatmap_moveonly, try_emplace)
@@ -165,9 +177,12 @@ TEST(core_flatmap_moveonly, try_emplace)
   }
 }
 
-TEST(core_flatmap, initializer_list)
+AXOM_TYPED_TEST(core_flatmap, initializer_list)
 {
-  axom::FlatMap<int, double> int_to_dbl {{0, 10.0}, {1, 20.0}, {2, 30.0}};
+  using MapType = typename TestFixture::MapType;
+  MapType int_to_dbl {{this->getKey(0), this->getValue(10.0)},
+                      {this->getKey(1), this->getValue(20.0)},
+                      {this->getKey(2), this->getValue(30.0)}};
 
   EXPECT_EQ(3, int_to_dbl.size());
 
@@ -175,53 +190,69 @@ TEST(core_flatmap, initializer_list)
   const double expected_str[3] {10.0, 20.0, 30.0};
   for(int i = 0; i < 3; i++)
   {
-    auto iterator = int_to_dbl.find(i);
+    auto key = this->getKey(i);
+    auto value = this->getValue(expected_str[i]);
+
+    auto iterator = int_to_dbl.find(key);
     EXPECT_NE(iterator, int_to_dbl.end());
-    EXPECT_EQ(iterator->first, i);
-    EXPECT_EQ(iterator->second, expected_str[i]);
+    EXPECT_EQ(iterator->first, key);
+    EXPECT_EQ(iterator->second, value);
 
     // Using operator[] with an already-existing key should return the
     // existing value and not add a value.
-    double value = int_to_dbl[i];
-    EXPECT_EQ(value, expected_str[i]);
+    auto indexed_value = int_to_dbl[key];
+    EXPECT_EQ(indexed_value, value);
     EXPECT_EQ(int_to_dbl.size(), 3);
   }
 }
 
-TEST(core_flatmap, index_operator_default)
+AXOM_TYPED_TEST(core_flatmap, index_operator_default)
 {
-  axom::FlatMap<int, double> int_to_dbl;
+  using MapType = typename TestFixture::MapType;
+  MapType int_to_dbl;
 
-  int NUM_ELEMS = 10;
+  const int NUM_ELEMS = 100;
 
+  auto expected_default_value = this->getDefaultValue();
   for(int i = 0; i < NUM_ELEMS; i++)
   {
-    double default_value = int_to_dbl[i];
-    EXPECT_EQ(default_value, 0);
-    int_to_dbl[i] = i + 10.0;
+    auto key = this->getKey(i);
+    auto default_value = int_to_dbl[key];
+
+    EXPECT_EQ(default_value, expected_default_value);
+
+    auto new_value = this->getValue(i * 10.0 + 5.0);
+    int_to_dbl[key] = new_value;
   }
 
   EXPECT_EQ(NUM_ELEMS, int_to_dbl.size());
 
   for(int i = 0; i < NUM_ELEMS; i++)
   {
-    auto iterator = int_to_dbl.find(i);
-    EXPECT_EQ(iterator->second, i + 10.0);
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 5.0);
+
+    auto iterator = int_to_dbl.find(key);
+    EXPECT_EQ(iterator->second, value);
   }
 }
 
-TEST(core_flatmap, init_and_clear)
+AXOM_TYPED_TEST(core_flatmap, init_and_clear)
 {
-  axom::FlatMap<int, double> int_to_dbl;
+  using MapType = typename TestFixture::MapType;
+  MapType int_to_dbl;
 
   // Insert enough elements to trigger a resize of the buckets.
   // This allows us to test that a clear() doesn't reset the allocated buckets.
-  int NUM_ELEMS_RESIZE = 40;
+  int NUM_ELEMS_RESIZE = 100;
   EXPECT_GT(NUM_ELEMS_RESIZE, int_to_dbl.bucket_count());
 
   for(int i = 0; i < NUM_ELEMS_RESIZE; i++)
   {
-    int_to_dbl[i] = i + 10.0;
+    auto key = this->getKey(i);
+    auto value = this->getValue(i + 10.0);
+
+    int_to_dbl[key] = value;
   }
 
   EXPECT_EQ(NUM_ELEMS_RESIZE, int_to_dbl.size());
@@ -233,38 +264,45 @@ TEST(core_flatmap, init_and_clear)
   EXPECT_EQ(int_to_dbl.size(), 0);
   EXPECT_EQ(int_to_dbl.load_factor(), 0.0);
   EXPECT_EQ(int_to_dbl.bucket_count(), buckets_before_clear);
-  for(int i = 0; i < 3; i++)
+  for(int i = 0; i < NUM_ELEMS_RESIZE; i++)
   {
-    auto iterator = int_to_dbl.find(i);
+    auto key = this->getKey(i);
+    auto iterator = int_to_dbl.find(key);
     EXPECT_EQ(iterator, int_to_dbl.end());
   }
 }
 
-TEST(core_flatmap, init_and_move)
+AXOM_TYPED_TEST(core_flatmap, init_and_move)
 {
-  axom::FlatMap<int, double> int_to_dbl;
+  using MapType = typename TestFixture::MapType;
+  MapType int_to_dbl;
   int NUM_ELEMS = 40;
 
   for(int i = 0; i < NUM_ELEMS; i++)
   {
-    int_to_dbl[i] = i + 10.0;
+    auto key = this->getKey(i);
+    auto value = this->getValue(i + 10.0);
+
+    int_to_dbl[key] = value;
   }
 
-  axom::FlatMap<int, double> moved_to_map = std::move(int_to_dbl);
+  MapType moved_to_map = std::move(int_to_dbl);
 
   EXPECT_EQ(int_to_dbl.size(), 0);
   EXPECT_EQ(int_to_dbl.load_factor(), 0);
   EXPECT_EQ(moved_to_map.size(), NUM_ELEMS);
   for(int i = 0; i < NUM_ELEMS; i++)
   {
-    EXPECT_EQ(moved_to_map[i], i + 10.0);
+    auto key = this->getKey(i);
+    auto value = this->getValue(i + 10.0);
+    EXPECT_EQ(moved_to_map[key], value);
 
-    auto old_it = int_to_dbl.find(i);
+    auto old_it = int_to_dbl.find(key);
     EXPECT_EQ(old_it, int_to_dbl.end());
   }
 }
 
-TEST(core_flatmap, init_and_move_moveonly)
+TEST(core_flatmap_moveonly, init_and_move_moveonly)
 {
   axom::FlatMap<int, std::unique_ptr<double>> int_to_dbl;
   int NUM_ELEMS = 40;
@@ -289,19 +327,23 @@ TEST(core_flatmap, init_and_move_moveonly)
   }
 }
 
-TEST(core_flatmap, init_and_copy)
+AXOM_TYPED_TEST(core_flatmap, init_and_copy)
 {
-  axom::FlatMap<int, double> int_to_dbl;
+  using MapType = typename TestFixture::MapType;
+  MapType int_to_dbl;
   int NUM_ELEMS = 40;
 
   for(int i = 0; i < NUM_ELEMS; i++)
   {
-    int_to_dbl[i] = i + 10.0;
+    auto key = this->getKey(i);
+    auto value = this->getValue(i + 10.0);
+
+    int_to_dbl[key] = value;
   }
 
   int expected_buckets = int_to_dbl.bucket_count();
 
-  axom::FlatMap<int, double> int_to_dbl_copy = int_to_dbl;
+  MapType int_to_dbl_copy = int_to_dbl;
 
   EXPECT_EQ(int_to_dbl.size(), NUM_ELEMS);
   EXPECT_EQ(int_to_dbl.bucket_count(), expected_buckets);
@@ -309,14 +351,18 @@ TEST(core_flatmap, init_and_copy)
   EXPECT_EQ(int_to_dbl_copy.bucket_count(), expected_buckets);
   for(int i = 0; i < NUM_ELEMS; i++)
   {
-    EXPECT_EQ(int_to_dbl[i], i + 10.0);
-    EXPECT_EQ(int_to_dbl_copy[i], i + 10.0);
+    auto key = this->getKey(i);
+    auto value = this->getValue(i + 10.0);
+
+    EXPECT_EQ(int_to_dbl[key], value);
+    EXPECT_EQ(int_to_dbl_copy[key], value);
   }
 }
 
-TEST(core_flatmap, insert_until_rehash)
+AXOM_TYPED_TEST(core_flatmap, insert_until_rehash)
 {
-  axom::FlatMap<int, double> int_to_dbl;
+  using MapType = typename TestFixture::MapType;
+  MapType int_to_dbl;
 
   const int INIT_CAPACITY = int_to_dbl.bucket_count();
   const double LOAD_FACTOR = int_to_dbl.max_load_factor();
@@ -324,29 +370,41 @@ TEST(core_flatmap, insert_until_rehash)
 
   for(int i = 0; i < SIZE_NO_REHASH; i++)
   {
-    int_to_dbl.insert({i, 2. * i + 1});
+    auto key = this->getKey(i);
+    auto value = this->getValue(2. * i + 1);
+
+    int_to_dbl.insert({key, value});
   }
   EXPECT_EQ(int_to_dbl.bucket_count(), INIT_CAPACITY);
   EXPECT_EQ(int_to_dbl.size(), SIZE_NO_REHASH);
 
   // Next insert should trigger a rehash.
-  int_to_dbl.insert({SIZE_NO_REHASH, 2. * SIZE_NO_REHASH + 1});
+  {
+    auto key_rehash = this->getKey(SIZE_NO_REHASH);
+    auto value_rehash = this->getValue(2. * SIZE_NO_REHASH + 1);
+
+    int_to_dbl.insert({key_rehash, value_rehash});
+  }
   EXPECT_GT(int_to_dbl.bucket_count(), INIT_CAPACITY);
   EXPECT_EQ(int_to_dbl.size(), SIZE_NO_REHASH + 1);
 
   // Check consistency of values.
   for(int i = 0; i < SIZE_NO_REHASH + 1; i++)
   {
-    auto iterator = int_to_dbl.find(i);
+    auto key = this->getKey(i);
+    auto value = this->getValue(2. * i + 1);
+
+    auto iterator = int_to_dbl.find(key);
     EXPECT_NE(iterator, int_to_dbl.end());
-    EXPECT_EQ(iterator->first, i);
-    EXPECT_EQ(iterator->second, 2. * i + 1);
+    EXPECT_EQ(iterator->first, key);
+    EXPECT_EQ(iterator->second, value);
   }
 }
 
-TEST(core_flatmap, insert_then_delete)
+AXOM_TYPED_TEST(core_flatmap, insert_then_delete)
 {
-  axom::FlatMap<int, double> int_to_dbl;
+  using MapType = typename TestFixture::MapType;
+  MapType int_to_dbl;
 
   const int INIT_CAPACITY = int_to_dbl.bucket_count();
   const double LOAD_FACTOR = int_to_dbl.max_load_factor();
@@ -354,14 +412,19 @@ TEST(core_flatmap, insert_then_delete)
 
   for(int i = 0; i < NUM_INSERTS; i++)
   {
-    int_to_dbl.insert({i, 2. * i + 1});
+    auto key = this->getKey(i);
+    auto value = this->getValue(2. * i + 1);
+
+    int_to_dbl.insert({key, value});
   }
   EXPECT_EQ(int_to_dbl.size(), NUM_INSERTS);
   EXPECT_GE(int_to_dbl.bucket_count(), NUM_INSERTS);
 
   for(int i = 0; i < NUM_INSERTS; i += 3)
   {
-    auto iterator_to_remove = int_to_dbl.find(i);
+    auto key = this->getKey(i);
+
+    auto iterator_to_remove = int_to_dbl.find(key);
     auto one_after_elem = iterator_to_remove;
     one_after_elem++;
     // Delete every third entry starting from 0, inclusive.
@@ -374,20 +437,23 @@ TEST(core_flatmap, insert_then_delete)
   // Check consistency of values.
   for(int i = 0; i < NUM_INSERTS; i++)
   {
-    auto iterator = int_to_dbl.find(i);
+    auto key = this->getKey(i);
+    auto value = this->getValue(2. * i + 1);
+
+    auto iterator = int_to_dbl.find(key);
     if(i % 3 == 0)
     {
       EXPECT_EQ(iterator, int_to_dbl.end());
-      EXPECT_EQ(0, int_to_dbl.count(i));
-      EXPECT_EQ(false, int_to_dbl.contains(i));
+      EXPECT_EQ(0, int_to_dbl.count(key));
+      EXPECT_EQ(false, int_to_dbl.contains(key));
     }
     else
     {
       EXPECT_NE(iterator, int_to_dbl.end());
-      EXPECT_EQ(iterator->first, i);
-      EXPECT_EQ(iterator->second, 2. * i + 1);
-      EXPECT_EQ(1, int_to_dbl.count(i));
-      EXPECT_EQ(true, int_to_dbl.contains(i));
+      EXPECT_EQ(iterator->first, key);
+      EXPECT_EQ(iterator->second, value);
+      EXPECT_EQ(1, int_to_dbl.count(key));
+      EXPECT_EQ(true, int_to_dbl.contains(key));
     }
   }
 }

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -87,6 +87,53 @@ TEST(core_flatmap_str, insert_only)
   }
 }
 
+TEST(core_flatmap, insert_or_assign)
+{
+  axom::FlatMap<int, double> int_to_dbl;
+
+  // Test insert behavior of FlatMap::insert_or_assign.
+  {
+    auto res_0 = int_to_dbl.insert_or_assign(0, 10.0);
+    EXPECT_EQ(1, int_to_dbl.size());
+    EXPECT_EQ(10.0, int_to_dbl.at(0));
+    EXPECT_EQ(res_0.first, int_to_dbl.find(0));
+    EXPECT_TRUE(res_0.second);
+
+    auto res_1 = int_to_dbl.insert_or_assign(1, 20.0);
+    EXPECT_EQ(2, int_to_dbl.size());
+    EXPECT_EQ(20.0, int_to_dbl.at(1));
+    EXPECT_EQ(res_1.first, int_to_dbl.find(1));
+    EXPECT_TRUE(res_1.second);
+
+    auto res_2 = int_to_dbl.insert_or_assign(2, 30.0);
+    EXPECT_EQ(3, int_to_dbl.size());
+    EXPECT_EQ(30.0, int_to_dbl.at(2));
+    EXPECT_EQ(res_2.first, int_to_dbl.find(2));
+    EXPECT_TRUE(res_2.second);
+  }
+
+  // Test assign behavior of FlatMap::insert_or_assign.
+  {
+    auto res_0 = int_to_dbl.insert_or_assign(0, 20.0);
+    EXPECT_EQ(20.0, int_to_dbl.at(0));
+    EXPECT_EQ(res_0.first, int_to_dbl.find(0));
+    EXPECT_FALSE(res_0.second);
+
+    auto res_1 = int_to_dbl.insert_or_assign(1, 40.0);
+    EXPECT_EQ(40.0, int_to_dbl.at(1));
+    EXPECT_EQ(res_1.first, int_to_dbl.find(1));
+    EXPECT_FALSE(res_1.second);
+
+    auto res_2 = int_to_dbl.insert_or_assign(2, 60.0);
+    EXPECT_EQ(60.0, int_to_dbl.at(2));
+    EXPECT_EQ(res_2.first, int_to_dbl.find(2));
+    EXPECT_FALSE(res_2.second);
+
+    // Assignments should not change size of FlatMap.
+    EXPECT_EQ(3, int_to_dbl.size());
+  }
+}
+
 TEST(core_flatmap, initializer_list)
 {
   axom::FlatMap<int, double> int_to_dbl {{0, 10.0}, {1, 20.0}, {2, 30.0}};

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -522,3 +522,41 @@ AXOM_TYPED_TEST(core_flatmap, iterator_loop)
     EXPECT_EQ(have_iterator[i], 1);
   }
 }
+
+AXOM_TYPED_TEST(core_flatmap, iterator_loop_write)
+{
+  using MapType = typename TestFixture::MapType;
+  MapType test_map;
+
+  const int NUM_ELEMS = 100;
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 5.0);
+
+    test_map.insert({key, value});
+  }
+
+  // Test mutable iteration
+  for(typename MapType::iterator it = test_map.begin(); it != test_map.end(); ++it)
+  {
+    auto pair = *it;
+    auto iter_key = pair.first;
+
+    // Get the original integer value of the key.
+    int iter_key_int;
+    flatmap_get_value(iter_key, iter_key_int);
+
+    // Modify the stored value.
+    it->second = this->getValue(iter_key_int * 10.0 + 7.0);
+  }
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    // All values should be set to the new value.
+    const auto key = this->getKey(i);
+    const auto expected_value = this->getValue(i * 10.0 + 7.0);
+    EXPECT_EQ(test_map[key], expected_value);
+  }
+}

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -47,3 +47,33 @@ TEST(core_flatmap, insert_only)
     EXPECT_EQ(int_to_dbl.size(), 3);
   }
 }
+
+TEST(core_flatmap, insert_until_rehash)
+{
+  axom::FlatMap<int, double> int_to_dbl;
+
+  const int INIT_CAPACITY = int_to_dbl.bucket_count();
+  const double LOAD_FACTOR = int_to_dbl.max_load_factor();
+  const int SIZE_NO_REHASH = LOAD_FACTOR * INIT_CAPACITY;
+
+  for(int i = 0; i < SIZE_NO_REHASH; i++)
+  {
+    int_to_dbl.insert({i, 2. * i + 1});
+  }
+  EXPECT_EQ(int_to_dbl.bucket_count(), INIT_CAPACITY);
+  EXPECT_EQ(int_to_dbl.size(), SIZE_NO_REHASH);
+
+  // Next insert should trigger a rehash.
+  int_to_dbl.insert({SIZE_NO_REHASH, 2. * SIZE_NO_REHASH + 1});
+  EXPECT_GT(int_to_dbl.bucket_count(), INIT_CAPACITY);
+  EXPECT_EQ(int_to_dbl.size(), SIZE_NO_REHASH + 1);
+
+  // Check consistency of values.
+  for(int i = 0; i < SIZE_NO_REHASH + 1; i++)
+  {
+    auto iterator = int_to_dbl.find(i);
+    EXPECT_NE(iterator, int_to_dbl.end());
+    EXPECT_EQ(iterator->first, i);
+    EXPECT_EQ(iterator->second, 2. * i + 1);
+  }
+}

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -127,14 +127,27 @@ TEST(core_flatmap, index_operator_default)
 
 TEST(core_flatmap, init_and_clear)
 {
-  axom::FlatMap<int, double> int_to_dbl {{0, 10.0}, {1, 20.0}, {2, 30.0}};
+  axom::FlatMap<int, double> int_to_dbl;
 
-  EXPECT_EQ(3, int_to_dbl.size());
+  // Insert enough elements to trigger a resize of the buckets.
+  // This allows us to test that a clear() doesn't reset the allocated buckets.
+  int NUM_ELEMS_RESIZE = 40;
+  EXPECT_GT(NUM_ELEMS_RESIZE, int_to_dbl.bucket_count());
+
+  for(int i = 0; i < NUM_ELEMS_RESIZE; i++)
+  {
+    int_to_dbl[i] = i + 10.0;
+  }
+
+  EXPECT_EQ(NUM_ELEMS_RESIZE, int_to_dbl.size());
+
+  int buckets_before_clear = int_to_dbl.bucket_count();
 
   int_to_dbl.clear();
 
   EXPECT_EQ(int_to_dbl.size(), 0);
   EXPECT_EQ(int_to_dbl.load_factor(), 0.0);
+  EXPECT_EQ(int_to_dbl.bucket_count(), buckets_before_clear);
   for(int i = 0; i < 3; i++)
   {
     auto iterator = int_to_dbl.find(i);

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -80,9 +80,10 @@ AXOM_TYPED_TEST(core_flatmap, insert_only)
   {
     auto key = this->getKey(i);
     auto value = this->getValue(i * 10.0 + 5.0);
+    const auto expected_size = i + 1;
     // Initial insertion of a given key should succeed.
     auto initial_insert = test_map.insert({key, value});
-    EXPECT_EQ(test_map.size(), i + 1);
+    EXPECT_EQ(test_map.size(), expected_size);
     EXPECT_EQ(initial_insert.first, test_map.find(key));
     EXPECT_EQ(value, test_map.at(key));
     EXPECT_TRUE(initial_insert.second);
@@ -92,7 +93,7 @@ AXOM_TYPED_TEST(core_flatmap, insert_only)
     // Inserting a duplicate key should not change the value.
     auto value_dup = this->getValue(i * 10.0 + 5.0);
     auto duplicate_insert = test_map.insert({key, value_dup});
-    EXPECT_EQ(test_map.size(), i + 1);
+    EXPECT_EQ(test_map.size(), expected_size);
     EXPECT_EQ(duplicate_insert.first, test_map.find(key));
     EXPECT_EQ(value, test_map.at(key));
     EXPECT_FALSE(duplicate_insert.second);
@@ -101,7 +102,7 @@ AXOM_TYPED_TEST(core_flatmap, insert_only)
     // existing value and not add a value.
     auto value_indexed = test_map[key];
     EXPECT_EQ(value_indexed, value);
-    EXPECT_EQ(test_map.size(), i + 1);
+    EXPECT_EQ(test_map.size(), expected_size);
 
     // Check that a rehash didn't occur on the second insertion.
     EXPECT_EQ(duplicate_insert.first, initial_insert.first);

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -103,6 +103,23 @@ TEST(core_flatmap, initializer_list)
   }
 }
 
+TEST(core_flatmap, init_and_clear)
+{
+  axom::FlatMap<int, double> int_to_dbl {{0, 10.0}, {1, 20.0}, {2, 30.0}};
+
+  EXPECT_EQ(3, int_to_dbl.size());
+
+  int_to_dbl.clear();
+
+  EXPECT_EQ(int_to_dbl.size(), 0);
+  EXPECT_EQ(int_to_dbl.load_factor(), 0.0);
+  for(int i = 0; i < 3; i++)
+  {
+    auto iterator = int_to_dbl.find(i);
+    EXPECT_EQ(iterator, int_to_dbl.end());
+  }
+}
+
 TEST(core_flatmap, insert_until_rehash)
 {
   axom::FlatMap<int, double> int_to_dbl;

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -31,6 +31,13 @@ TEST(core_flatmap, insert_only)
   int_to_dbl.insert({2, 30.0});
   EXPECT_EQ(3, int_to_dbl.size());
 
+  // Inserting a duplicate key should not change the value.
+  auto duplicate_key = int_to_dbl.insert({2, 40.0});
+  EXPECT_EQ(3, int_to_dbl.size());
+  EXPECT_FALSE(duplicate_key.second);
+  EXPECT_EQ(duplicate_key.first, int_to_dbl.find(2));
+  EXPECT_EQ(duplicate_key.first->second, 30.0);
+
   // Check consistency of added values.
   const double expected_str[3] {10.0, 20.0, 30.0};
   for(int i = 0; i < 3; i++)

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -361,9 +361,14 @@ TEST(core_flatmap, insert_then_delete)
 
   for(int i = 0; i < NUM_INSERTS; i += 3)
   {
+    auto iterator_to_remove = int_to_dbl.find(i);
+    auto one_after_elem = iterator_to_remove;
+    one_after_elem++;
     // Delete every third entry starting from 0, inclusive.
     // (i.e. keys 0, 3, 6, ...)
-    int_to_dbl.erase(i);
+    auto deleted_iterator = int_to_dbl.erase(iterator_to_remove);
+
+    EXPECT_EQ(deleted_iterator, one_after_elem);
   }
 
   // Check consistency of values.

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -80,6 +80,29 @@ TEST(core_flatmap_str, insert_only)
   }
 }
 
+TEST(core_flatmap, initializer_list)
+{
+  axom::FlatMap<int, double> int_to_dbl {{0, 10.0}, {1, 20.0}, {2, 30.0}};
+
+  EXPECT_EQ(3, int_to_dbl.size());
+
+  // Check consistency of added values.
+  const double expected_str[3] {10.0, 20.0, 30.0};
+  for(int i = 0; i < 3; i++)
+  {
+    auto iterator = int_to_dbl.find(i);
+    EXPECT_NE(iterator, int_to_dbl.end());
+    EXPECT_EQ(iterator->first, i);
+    EXPECT_EQ(iterator->second, expected_str[i]);
+
+    // Using operator[] with an already-existing key should return the
+    // existing value and not add a value.
+    double value = int_to_dbl[i];
+    EXPECT_EQ(value, expected_str[i]);
+    EXPECT_EQ(int_to_dbl.size(), 3);
+  }
+}
+
 TEST(core_flatmap, insert_until_rehash)
 {
   axom::FlatMap<int, double> int_to_dbl;

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -11,6 +11,43 @@
 // gtest includes
 #include "gtest/gtest.h"
 
+// Unit test for QuadraticProbing
+TEST(core_flatmap_unit, quadratic_probing)
+{
+  axom::detail::flat_map::QuadraticProbing instance {};
+  for(int array_size = 4; array_size <= 8192; array_size *= 2)
+  {
+    // Generate probe indices.
+    std::vector<int> probe_index(array_size);
+    std::vector<int> probe_index_mod(array_size);
+    int curr_offset = 0;
+    // Compute probe indices for an array of size N.
+    for(int i = 0; i < array_size; i++)
+    {
+      probe_index[i] = curr_offset;
+      probe_index_mod[i] = curr_offset % array_size;
+      curr_offset += instance.getNext(i);
+    }
+
+    for(int i = 0; i < array_size; i++)
+    {
+      // Each probe index should match the formula:
+      // H(i) = H_0 + i/2 + i^2/2 mod m.
+      int expected_probe_index = i * (i + 1) / 2;
+      EXPECT_EQ(probe_index[i], expected_probe_index);
+      EXPECT_EQ(probe_index_mod[i], expected_probe_index % array_size);
+    }
+
+    // Probe indices should be a permutation of the range [0, array_size - 1).
+    std::vector<int> expected_permutation(array_size);
+    std::iota(expected_permutation.begin(), expected_permutation.end(), 0);
+
+    // Sort the modular probe indexes and compare.
+    std::sort(probe_index_mod.begin(), probe_index_mod.end());
+    EXPECT_EQ(probe_index_mod, expected_permutation);
+  }
+}
+
 inline void flatmap_get_value(double key, std::string& out)
 {
   out = std::to_string(key);

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -560,3 +560,91 @@ AXOM_TYPED_TEST(core_flatmap, iterator_loop_write)
     EXPECT_EQ(test_map[key], expected_value);
   }
 }
+
+AXOM_TYPED_TEST(core_flatmap, range_for_loop)
+{
+  using MapType = typename TestFixture::MapType;
+  MapType test_map;
+
+  const int NUM_ELEMS = 100;
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 5.0);
+
+    test_map.insert({key, value});
+  }
+
+  std::vector<int> have_key(NUM_ELEMS, 0);
+
+  int iter_count = 0;
+  // Test constant iteration
+  for(const auto& pair : test_map)
+  {
+    auto iter_key = pair.first;
+    auto iter_value = pair.second;
+
+    // Get the original integer value of the key.
+    int iter_key_int;
+    flatmap_get_value(iter_key, iter_key_int);
+
+    // Check that the key value is in range.
+    EXPECT_GE(iter_key_int, 0);
+    EXPECT_LT(iter_key_int, NUM_ELEMS);
+
+    // Count the key that we got.
+    have_key[iter_key_int]++;
+
+    // Check that the value is what we expect for the given key..
+    auto expected_value = this->getValue(iter_key_int * 10.0 + 5.0);
+    EXPECT_EQ(iter_value, expected_value);
+
+    // Count the number of iterations.
+    iter_count++;
+  }
+  EXPECT_EQ(iter_count, NUM_ELEMS);
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    // We should have iterated through every index exactly once.
+    EXPECT_EQ(have_key[i], 1);
+  }
+}
+
+AXOM_TYPED_TEST(core_flatmap, range_for_loop_write)
+{
+  using MapType = typename TestFixture::MapType;
+  MapType test_map;
+
+  const int NUM_ELEMS = 100;
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 5.0);
+
+    test_map.insert({key, value});
+  }
+
+  // Test mutable iteration
+  for(auto& pair : test_map)
+  {
+    auto iter_key = pair.first;
+
+    // Get the original integer value of the key.
+    int iter_key_int;
+    flatmap_get_value(iter_key, iter_key_int);
+
+    // Modify the stored value.
+    pair.second = this->getValue(iter_key_int * 10.0 + 7.0);
+  }
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    // All values should be set to the new value.
+    const auto key = this->getKey(i);
+    const auto expected_value = this->getValue(i * 10.0 + 7.0);
+    EXPECT_EQ(test_map[key], expected_value);
+  }
+}

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -155,6 +155,55 @@ TEST(core_flatmap, init_and_clear)
   }
 }
 
+TEST(core_flatmap, init_and_move)
+{
+  axom::FlatMap<int, double> int_to_dbl;
+  int NUM_ELEMS = 40;
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    int_to_dbl[i] = i + 10.0;
+  }
+
+  axom::FlatMap<int, double> moved_to_map = std::move(int_to_dbl);
+
+  EXPECT_EQ(int_to_dbl.size(), 0);
+  EXPECT_EQ(int_to_dbl.load_factor(), 0);
+  EXPECT_EQ(moved_to_map.size(), NUM_ELEMS);
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    EXPECT_EQ(moved_to_map[i], i + 10.0);
+
+    auto old_it = int_to_dbl.find(i);
+    EXPECT_EQ(old_it, int_to_dbl.end());
+  }
+}
+
+TEST(core_flatmap, init_and_copy)
+{
+  axom::FlatMap<int, double> int_to_dbl;
+  int NUM_ELEMS = 40;
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    int_to_dbl[i] = i + 10.0;
+  }
+
+  int expected_buckets = int_to_dbl.bucket_count();
+
+  axom::FlatMap<int, double> int_to_dbl_copy = int_to_dbl;
+
+  EXPECT_EQ(int_to_dbl.size(), NUM_ELEMS);
+  EXPECT_EQ(int_to_dbl.bucket_count(), expected_buckets);
+  EXPECT_EQ(int_to_dbl_copy.size(), NUM_ELEMS);
+  EXPECT_EQ(int_to_dbl_copy.bucket_count(), expected_buckets);
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    EXPECT_EQ(int_to_dbl[i], i + 10.0);
+    EXPECT_EQ(int_to_dbl_copy[i], i + 10.0);
+  }
+}
+
 TEST(core_flatmap, insert_until_rehash)
 {
   axom::FlatMap<int, double> int_to_dbl;

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -103,6 +103,28 @@ TEST(core_flatmap, initializer_list)
   }
 }
 
+TEST(core_flatmap, index_operator_default)
+{
+  axom::FlatMap<int, double> int_to_dbl;
+
+  int NUM_ELEMS = 10;
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    double default_value = int_to_dbl[i];
+    EXPECT_EQ(default_value, 0);
+    int_to_dbl[i] = i + 10.0;
+  }
+
+  EXPECT_EQ(NUM_ELEMS, int_to_dbl.size());
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto iterator = int_to_dbl.find(i);
+    EXPECT_EQ(iterator->second, i + 10.0);
+  }
+}
+
 TEST(core_flatmap, init_and_clear)
 {
   axom::FlatMap<int, double> int_to_dbl {{0, 10.0}, {1, 20.0}, {2, 30.0}};

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -48,6 +48,38 @@ TEST(core_flatmap, insert_only)
   }
 }
 
+TEST(core_flatmap_str, insert_only)
+{
+  axom::FlatMap<std::string, std::string> int_to_dbl;
+
+  int_to_dbl.insert({std::to_string(0), std::to_string(10.0)});
+  EXPECT_EQ(1, int_to_dbl.size());
+
+  int_to_dbl.insert({std::to_string(1), std::to_string(20.0)});
+  EXPECT_EQ(2, int_to_dbl.size());
+
+  int_to_dbl.insert({std::to_string(2), std::to_string(30.0)});
+  EXPECT_EQ(3, int_to_dbl.size());
+
+  // Check consistency of added values.
+  const double expected_str[3] {10.0, 20.0, 30.0};
+  for(int i = 0; i < 3; i++)
+  {
+    std::string key = std::to_string(i);
+    std::string expected_value = std::to_string(expected_str[i]);
+    auto iterator = int_to_dbl.find(key);
+    EXPECT_NE(iterator, int_to_dbl.end());
+    EXPECT_EQ(iterator->first, key);
+    EXPECT_EQ(iterator->second, expected_value);
+
+    // Using operator[] with an already-existing key should return the
+    // existing value and not add a value.
+    std::string value = int_to_dbl[key];
+    EXPECT_EQ(value, expected_value);
+    EXPECT_EQ(int_to_dbl.size(), 3);
+  }
+}
+
 TEST(core_flatmap, insert_until_rehash)
 {
   axom::FlatMap<int, double> int_to_dbl;

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+// Axom includes
+#include "axom/config.hpp"
+#include "axom/core/Macros.hpp"
+#include "axom/core/FlatMap.hpp"
+
+// gtest includes
+#include "gtest/gtest.h"
+
+TEST(core_flatmap, default_init)
+{
+  axom::FlatMap<int, std::string> int_to_dbl;
+  EXPECT_EQ(0, int_to_dbl.size());
+  EXPECT_EQ(true, int_to_dbl.empty());
+}
+
+TEST(core_flatmap, insert_only)
+{
+  axom::FlatMap<int, double> int_to_dbl;
+
+  int_to_dbl.insert({0, 10.0});
+  EXPECT_EQ(1, int_to_dbl.size());
+
+  int_to_dbl.insert({1, 20.0});
+  EXPECT_EQ(2, int_to_dbl.size());
+
+  int_to_dbl.insert({2, 30.0});
+  EXPECT_EQ(3, int_to_dbl.size());
+
+  // Check consistency of added values.
+  const double expected_str[3] {10.0, 20.0, 30.0};
+  for(int i = 0; i < 3; i++)
+  {
+    auto iterator = int_to_dbl.find(i);
+    EXPECT_NE(iterator, int_to_dbl.end());
+    EXPECT_EQ(iterator->first, i);
+    EXPECT_EQ(iterator->second, expected_str[i]);
+
+    // Using operator[] with an already-existing key should return the
+    // existing value and not add a value.
+    double value = int_to_dbl[i];
+    EXPECT_EQ(value, expected_str[i]);
+    EXPECT_EQ(int_to_dbl.size(), 3);
+  }
+}

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -64,15 +64,15 @@ TYPED_TEST_SUITE(core_flatmap, MyTypes);
 AXOM_TYPED_TEST(core_flatmap, default_init)
 {
   using MapType = typename TestFixture::MapType;
-  MapType int_to_dbl;
-  EXPECT_EQ(0, int_to_dbl.size());
-  EXPECT_EQ(true, int_to_dbl.empty());
+  MapType test_map;
+  EXPECT_EQ(0, test_map.size());
+  EXPECT_EQ(true, test_map.empty());
 }
 
 AXOM_TYPED_TEST(core_flatmap, insert_only)
 {
   using MapType = typename TestFixture::MapType;
-  MapType int_to_dbl;
+  MapType test_map;
 
   const int NUM_ELEMS = 100;
 
@@ -81,38 +81,38 @@ AXOM_TYPED_TEST(core_flatmap, insert_only)
     auto key = this->getKey(i);
     auto value = this->getValue(i * 10.0 + 5.0);
     // Initial insertion of a given key should succeed.
-    auto initial_insert = int_to_dbl.insert({key, value});
-    EXPECT_EQ(int_to_dbl.size(), i + 1);
-    EXPECT_EQ(initial_insert.first, int_to_dbl.find(key));
-    EXPECT_EQ(value, int_to_dbl.at(key));
+    auto initial_insert = test_map.insert({key, value});
+    EXPECT_EQ(test_map.size(), i + 1);
+    EXPECT_EQ(initial_insert.first, test_map.find(key));
+    EXPECT_EQ(value, test_map.at(key));
     EXPECT_TRUE(initial_insert.second);
 
-    int current_bucket_capacity = int_to_dbl.bucket_count();
+    int current_bucket_capacity = test_map.bucket_count();
 
     // Inserting a duplicate key should not change the value.
     auto value_dup = this->getValue(i * 10.0 + 5.0);
-    auto duplicate_insert = int_to_dbl.insert({key, value_dup});
-    EXPECT_EQ(int_to_dbl.size(), i + 1);
-    EXPECT_EQ(duplicate_insert.first, int_to_dbl.find(key));
-    EXPECT_EQ(value, int_to_dbl.at(key));
+    auto duplicate_insert = test_map.insert({key, value_dup});
+    EXPECT_EQ(test_map.size(), i + 1);
+    EXPECT_EQ(duplicate_insert.first, test_map.find(key));
+    EXPECT_EQ(value, test_map.at(key));
     EXPECT_FALSE(duplicate_insert.second);
 
     // Using operator[] with an already-existing key should return the
     // existing value and not add a value.
-    auto value_indexed = int_to_dbl[key];
+    auto value_indexed = test_map[key];
     EXPECT_EQ(value_indexed, value);
-    EXPECT_EQ(int_to_dbl.size(), i + 1);
+    EXPECT_EQ(test_map.size(), i + 1);
 
     // Check that a rehash didn't occur on the second insertion.
     EXPECT_EQ(duplicate_insert.first, initial_insert.first);
-    EXPECT_EQ(current_bucket_capacity, int_to_dbl.bucket_count());
+    EXPECT_EQ(current_bucket_capacity, test_map.bucket_count());
   }
 }
 
 AXOM_TYPED_TEST(core_flatmap, insert_or_assign)
 {
   using MapType = typename TestFixture::MapType;
-  MapType int_to_dbl;
+  MapType test_map;
 
   const int NUM_ELEMS = 100;
 
@@ -122,10 +122,10 @@ AXOM_TYPED_TEST(core_flatmap, insert_or_assign)
     auto key = this->getKey(i);
     auto value = this->getValue(i * 10.0 + 5.0);
 
-    auto result = int_to_dbl.insert_or_assign(key, value);
-    EXPECT_EQ(i + 1, int_to_dbl.size());
-    EXPECT_EQ(value, int_to_dbl.at(key));
-    EXPECT_EQ(result.first, int_to_dbl.find(key));
+    auto result = test_map.insert_or_assign(key, value);
+    EXPECT_EQ(i + 1, test_map.size());
+    EXPECT_EQ(value, test_map.at(key));
+    EXPECT_EQ(result.first, test_map.find(key));
     EXPECT_TRUE(result.second);
   }
 
@@ -135,19 +135,19 @@ AXOM_TYPED_TEST(core_flatmap, insert_or_assign)
     auto key = this->getKey(i);
     auto value = this->getValue(i * 10.0 + 7.0);
 
-    auto result = int_to_dbl.insert_or_assign(key, value);
-    EXPECT_EQ(value, int_to_dbl.at(key));
-    EXPECT_EQ(result.first, int_to_dbl.find(key));
+    auto result = test_map.insert_or_assign(key, value);
+    EXPECT_EQ(value, test_map.at(key));
+    EXPECT_EQ(result.first, test_map.find(key));
     EXPECT_FALSE(result.second);
   }
 
   // Assignments should not change size of FlatMap.
-  EXPECT_EQ(NUM_ELEMS, int_to_dbl.size());
+  EXPECT_EQ(NUM_ELEMS, test_map.size());
 }
 
 TEST(core_flatmap_moveonly, try_emplace)
 {
-  axom::FlatMap<int, std::unique_ptr<double>> int_to_dbl;
+  axom::FlatMap<int, std::unique_ptr<double>> test_map;
 
   const int NUM_ELEMS = 40;
 
@@ -155,9 +155,9 @@ TEST(core_flatmap_moveonly, try_emplace)
   for(int i = 0; i < NUM_ELEMS; i++)
   {
     std::unique_ptr<double> value {new double {i + 10.0}};
-    auto result = int_to_dbl.try_emplace(i, std::move(value));
-    EXPECT_EQ(*(int_to_dbl[i]), i + 10.0);
-    EXPECT_EQ(result.first, int_to_dbl.find(i));
+    auto result = test_map.try_emplace(i, std::move(value));
+    EXPECT_EQ(*(test_map[i]), i + 10.0);
+    EXPECT_EQ(result.first, test_map.find(i));
     EXPECT_TRUE(result.second);
     // Value should have been moved.
     EXPECT_EQ(value.get(), nullptr);
@@ -167,9 +167,9 @@ TEST(core_flatmap_moveonly, try_emplace)
   for(int i = 0; i < NUM_ELEMS; i++)
   {
     std::unique_ptr<double> value {new double {i + 20.0}};
-    auto result = int_to_dbl.try_emplace(i, std::move(value));
-    EXPECT_EQ(*(int_to_dbl[i]), i + 10.0);
-    EXPECT_EQ(result.first, int_to_dbl.find(i));
+    auto result = test_map.try_emplace(i, std::move(value));
+    EXPECT_EQ(*(test_map[i]), i + 10.0);
+    EXPECT_EQ(result.first, test_map.find(i));
     EXPECT_FALSE(result.second);
     // Since key already exists, value should NOT be moved.
     EXPECT_NE(value.get(), nullptr);
@@ -180,11 +180,11 @@ TEST(core_flatmap_moveonly, try_emplace)
 AXOM_TYPED_TEST(core_flatmap, initializer_list)
 {
   using MapType = typename TestFixture::MapType;
-  MapType int_to_dbl {{this->getKey(0), this->getValue(10.0)},
-                      {this->getKey(1), this->getValue(20.0)},
-                      {this->getKey(2), this->getValue(30.0)}};
+  MapType test_map {{this->getKey(0), this->getValue(10.0)},
+                    {this->getKey(1), this->getValue(20.0)},
+                    {this->getKey(2), this->getValue(30.0)}};
 
-  EXPECT_EQ(3, int_to_dbl.size());
+  EXPECT_EQ(3, test_map.size());
 
   // Check consistency of added values.
   const double expected_str[3] {10.0, 20.0, 30.0};
@@ -193,23 +193,23 @@ AXOM_TYPED_TEST(core_flatmap, initializer_list)
     auto key = this->getKey(i);
     auto value = this->getValue(expected_str[i]);
 
-    auto iterator = int_to_dbl.find(key);
-    EXPECT_NE(iterator, int_to_dbl.end());
+    auto iterator = test_map.find(key);
+    EXPECT_NE(iterator, test_map.end());
     EXPECT_EQ(iterator->first, key);
     EXPECT_EQ(iterator->second, value);
 
     // Using operator[] with an already-existing key should return the
     // existing value and not add a value.
-    auto indexed_value = int_to_dbl[key];
+    auto indexed_value = test_map[key];
     EXPECT_EQ(indexed_value, value);
-    EXPECT_EQ(int_to_dbl.size(), 3);
+    EXPECT_EQ(test_map.size(), 3);
   }
 }
 
 AXOM_TYPED_TEST(core_flatmap, index_operator_default)
 {
   using MapType = typename TestFixture::MapType;
-  MapType int_to_dbl;
+  MapType test_map;
 
   const int NUM_ELEMS = 100;
 
@@ -217,22 +217,22 @@ AXOM_TYPED_TEST(core_flatmap, index_operator_default)
   for(int i = 0; i < NUM_ELEMS; i++)
   {
     auto key = this->getKey(i);
-    auto default_value = int_to_dbl[key];
+    auto default_value = test_map[key];
 
     EXPECT_EQ(default_value, expected_default_value);
 
     auto new_value = this->getValue(i * 10.0 + 5.0);
-    int_to_dbl[key] = new_value;
+    test_map[key] = new_value;
   }
 
-  EXPECT_EQ(NUM_ELEMS, int_to_dbl.size());
+  EXPECT_EQ(NUM_ELEMS, test_map.size());
 
   for(int i = 0; i < NUM_ELEMS; i++)
   {
     auto key = this->getKey(i);
     auto value = this->getValue(i * 10.0 + 5.0);
 
-    auto iterator = int_to_dbl.find(key);
+    auto iterator = test_map.find(key);
     EXPECT_EQ(iterator->second, value);
   }
 }
@@ -240,42 +240,42 @@ AXOM_TYPED_TEST(core_flatmap, index_operator_default)
 AXOM_TYPED_TEST(core_flatmap, init_and_clear)
 {
   using MapType = typename TestFixture::MapType;
-  MapType int_to_dbl;
+  MapType test_map;
 
   // Insert enough elements to trigger a resize of the buckets.
   // This allows us to test that a clear() doesn't reset the allocated buckets.
   int NUM_ELEMS_RESIZE = 100;
-  EXPECT_GT(NUM_ELEMS_RESIZE, int_to_dbl.bucket_count());
+  EXPECT_GT(NUM_ELEMS_RESIZE, test_map.bucket_count());
 
   for(int i = 0; i < NUM_ELEMS_RESIZE; i++)
   {
     auto key = this->getKey(i);
     auto value = this->getValue(i + 10.0);
 
-    int_to_dbl[key] = value;
+    test_map[key] = value;
   }
 
-  EXPECT_EQ(NUM_ELEMS_RESIZE, int_to_dbl.size());
+  EXPECT_EQ(NUM_ELEMS_RESIZE, test_map.size());
 
-  int buckets_before_clear = int_to_dbl.bucket_count();
+  int buckets_before_clear = test_map.bucket_count();
 
-  int_to_dbl.clear();
+  test_map.clear();
 
-  EXPECT_EQ(int_to_dbl.size(), 0);
-  EXPECT_EQ(int_to_dbl.load_factor(), 0.0);
-  EXPECT_EQ(int_to_dbl.bucket_count(), buckets_before_clear);
+  EXPECT_EQ(test_map.size(), 0);
+  EXPECT_EQ(test_map.load_factor(), 0.0);
+  EXPECT_EQ(test_map.bucket_count(), buckets_before_clear);
   for(int i = 0; i < NUM_ELEMS_RESIZE; i++)
   {
     auto key = this->getKey(i);
-    auto iterator = int_to_dbl.find(key);
-    EXPECT_EQ(iterator, int_to_dbl.end());
+    auto iterator = test_map.find(key);
+    EXPECT_EQ(iterator, test_map.end());
   }
 }
 
 AXOM_TYPED_TEST(core_flatmap, init_and_move)
 {
   using MapType = typename TestFixture::MapType;
-  MapType int_to_dbl;
+  MapType test_map;
   int NUM_ELEMS = 40;
 
   for(int i = 0; i < NUM_ELEMS; i++)
@@ -283,13 +283,13 @@ AXOM_TYPED_TEST(core_flatmap, init_and_move)
     auto key = this->getKey(i);
     auto value = this->getValue(i + 10.0);
 
-    int_to_dbl[key] = value;
+    test_map[key] = value;
   }
 
-  MapType moved_to_map = std::move(int_to_dbl);
+  MapType moved_to_map = std::move(test_map);
 
-  EXPECT_EQ(int_to_dbl.size(), 0);
-  EXPECT_EQ(int_to_dbl.load_factor(), 0);
+  EXPECT_EQ(test_map.size(), 0);
+  EXPECT_EQ(test_map.load_factor(), 0);
   EXPECT_EQ(moved_to_map.size(), NUM_ELEMS);
   for(int i = 0; i < NUM_ELEMS; i++)
   {
@@ -297,40 +297,40 @@ AXOM_TYPED_TEST(core_flatmap, init_and_move)
     auto value = this->getValue(i + 10.0);
     EXPECT_EQ(moved_to_map[key], value);
 
-    auto old_it = int_to_dbl.find(key);
-    EXPECT_EQ(old_it, int_to_dbl.end());
+    auto old_it = test_map.find(key);
+    EXPECT_EQ(old_it, test_map.end());
   }
 }
 
 TEST(core_flatmap_moveonly, init_and_move_moveonly)
 {
-  axom::FlatMap<int, std::unique_ptr<double>> int_to_dbl;
+  axom::FlatMap<int, std::unique_ptr<double>> test_map;
   int NUM_ELEMS = 40;
 
   for(int i = 0; i < NUM_ELEMS; i++)
   {
-    int_to_dbl.emplace(i, new double {i + 10.0});
+    test_map.emplace(i, new double {i + 10.0});
   }
 
   axom::FlatMap<int, std::unique_ptr<double>> int_to_dbl_move =
-    std::move(int_to_dbl);
+    std::move(test_map);
 
-  EXPECT_EQ(int_to_dbl.size(), 0);
-  EXPECT_EQ(int_to_dbl.load_factor(), 0);
+  EXPECT_EQ(test_map.size(), 0);
+  EXPECT_EQ(test_map.load_factor(), 0);
   EXPECT_EQ(int_to_dbl_move.size(), NUM_ELEMS);
   for(int i = 0; i < NUM_ELEMS; i++)
   {
     EXPECT_EQ(*(int_to_dbl_move[i]), i + 10.0);
 
-    auto old_it = int_to_dbl.find(i);
-    EXPECT_EQ(old_it, int_to_dbl.end());
+    auto old_it = test_map.find(i);
+    EXPECT_EQ(old_it, test_map.end());
   }
 }
 
 AXOM_TYPED_TEST(core_flatmap, init_and_copy)
 {
   using MapType = typename TestFixture::MapType;
-  MapType int_to_dbl;
+  MapType test_map;
   int NUM_ELEMS = 40;
 
   for(int i = 0; i < NUM_ELEMS; i++)
@@ -338,15 +338,15 @@ AXOM_TYPED_TEST(core_flatmap, init_and_copy)
     auto key = this->getKey(i);
     auto value = this->getValue(i + 10.0);
 
-    int_to_dbl[key] = value;
+    test_map[key] = value;
   }
 
-  int expected_buckets = int_to_dbl.bucket_count();
+  int expected_buckets = test_map.bucket_count();
 
-  MapType int_to_dbl_copy = int_to_dbl;
+  MapType int_to_dbl_copy = test_map;
 
-  EXPECT_EQ(int_to_dbl.size(), NUM_ELEMS);
-  EXPECT_EQ(int_to_dbl.bucket_count(), expected_buckets);
+  EXPECT_EQ(test_map.size(), NUM_ELEMS);
+  EXPECT_EQ(test_map.bucket_count(), expected_buckets);
   EXPECT_EQ(int_to_dbl_copy.size(), NUM_ELEMS);
   EXPECT_EQ(int_to_dbl_copy.bucket_count(), expected_buckets);
   for(int i = 0; i < NUM_ELEMS; i++)
@@ -354,7 +354,7 @@ AXOM_TYPED_TEST(core_flatmap, init_and_copy)
     auto key = this->getKey(i);
     auto value = this->getValue(i + 10.0);
 
-    EXPECT_EQ(int_to_dbl[key], value);
+    EXPECT_EQ(test_map[key], value);
     EXPECT_EQ(int_to_dbl_copy[key], value);
   }
 }
@@ -362,10 +362,10 @@ AXOM_TYPED_TEST(core_flatmap, init_and_copy)
 AXOM_TYPED_TEST(core_flatmap, insert_until_rehash)
 {
   using MapType = typename TestFixture::MapType;
-  MapType int_to_dbl;
+  MapType test_map;
 
-  const int INIT_CAPACITY = int_to_dbl.bucket_count();
-  const double LOAD_FACTOR = int_to_dbl.max_load_factor();
+  const int INIT_CAPACITY = test_map.bucket_count();
+  const double LOAD_FACTOR = test_map.max_load_factor();
   const int SIZE_NO_REHASH = LOAD_FACTOR * INIT_CAPACITY;
 
   for(int i = 0; i < SIZE_NO_REHASH; i++)
@@ -373,20 +373,20 @@ AXOM_TYPED_TEST(core_flatmap, insert_until_rehash)
     auto key = this->getKey(i);
     auto value = this->getValue(2. * i + 1);
 
-    int_to_dbl.insert({key, value});
+    test_map.insert({key, value});
   }
-  EXPECT_EQ(int_to_dbl.bucket_count(), INIT_CAPACITY);
-  EXPECT_EQ(int_to_dbl.size(), SIZE_NO_REHASH);
+  EXPECT_EQ(test_map.bucket_count(), INIT_CAPACITY);
+  EXPECT_EQ(test_map.size(), SIZE_NO_REHASH);
 
   // Next insert should trigger a rehash.
   {
     auto key_rehash = this->getKey(SIZE_NO_REHASH);
     auto value_rehash = this->getValue(2. * SIZE_NO_REHASH + 1);
 
-    int_to_dbl.insert({key_rehash, value_rehash});
+    test_map.insert({key_rehash, value_rehash});
   }
-  EXPECT_GT(int_to_dbl.bucket_count(), INIT_CAPACITY);
-  EXPECT_EQ(int_to_dbl.size(), SIZE_NO_REHASH + 1);
+  EXPECT_GT(test_map.bucket_count(), INIT_CAPACITY);
+  EXPECT_EQ(test_map.size(), SIZE_NO_REHASH + 1);
 
   // Check consistency of values.
   for(int i = 0; i < SIZE_NO_REHASH + 1; i++)
@@ -394,8 +394,8 @@ AXOM_TYPED_TEST(core_flatmap, insert_until_rehash)
     auto key = this->getKey(i);
     auto value = this->getValue(2. * i + 1);
 
-    auto iterator = int_to_dbl.find(key);
-    EXPECT_NE(iterator, int_to_dbl.end());
+    auto iterator = test_map.find(key);
+    EXPECT_NE(iterator, test_map.end());
     EXPECT_EQ(iterator->first, key);
     EXPECT_EQ(iterator->second, value);
   }
@@ -404,10 +404,10 @@ AXOM_TYPED_TEST(core_flatmap, insert_until_rehash)
 AXOM_TYPED_TEST(core_flatmap, insert_then_delete)
 {
   using MapType = typename TestFixture::MapType;
-  MapType int_to_dbl;
+  MapType test_map;
 
-  const int INIT_CAPACITY = int_to_dbl.bucket_count();
-  const double LOAD_FACTOR = int_to_dbl.max_load_factor();
+  const int INIT_CAPACITY = test_map.bucket_count();
+  const double LOAD_FACTOR = test_map.max_load_factor();
   const int NUM_INSERTS = LOAD_FACTOR * INIT_CAPACITY * 4;
 
   for(int i = 0; i < NUM_INSERTS; i++)
@@ -415,21 +415,21 @@ AXOM_TYPED_TEST(core_flatmap, insert_then_delete)
     auto key = this->getKey(i);
     auto value = this->getValue(2. * i + 1);
 
-    int_to_dbl.insert({key, value});
+    test_map.insert({key, value});
   }
-  EXPECT_EQ(int_to_dbl.size(), NUM_INSERTS);
-  EXPECT_GE(int_to_dbl.bucket_count(), NUM_INSERTS);
+  EXPECT_EQ(test_map.size(), NUM_INSERTS);
+  EXPECT_GE(test_map.bucket_count(), NUM_INSERTS);
 
   for(int i = 0; i < NUM_INSERTS; i += 3)
   {
     auto key = this->getKey(i);
 
-    auto iterator_to_remove = int_to_dbl.find(key);
+    auto iterator_to_remove = test_map.find(key);
     auto one_after_elem = iterator_to_remove;
     one_after_elem++;
     // Delete every third entry starting from 0, inclusive.
     // (i.e. keys 0, 3, 6, ...)
-    auto deleted_iterator = int_to_dbl.erase(iterator_to_remove);
+    auto deleted_iterator = test_map.erase(iterator_to_remove);
 
     EXPECT_EQ(deleted_iterator, one_after_elem);
   }
@@ -440,20 +440,20 @@ AXOM_TYPED_TEST(core_flatmap, insert_then_delete)
     auto key = this->getKey(i);
     auto value = this->getValue(2. * i + 1);
 
-    auto iterator = int_to_dbl.find(key);
+    auto iterator = test_map.find(key);
     if(i % 3 == 0)
     {
-      EXPECT_EQ(iterator, int_to_dbl.end());
-      EXPECT_EQ(0, int_to_dbl.count(key));
-      EXPECT_EQ(false, int_to_dbl.contains(key));
+      EXPECT_EQ(iterator, test_map.end());
+      EXPECT_EQ(0, test_map.count(key));
+      EXPECT_EQ(false, test_map.contains(key));
     }
     else
     {
-      EXPECT_NE(iterator, int_to_dbl.end());
+      EXPECT_NE(iterator, test_map.end());
       EXPECT_EQ(iterator->first, key);
       EXPECT_EQ(iterator->second, value);
-      EXPECT_EQ(1, int_to_dbl.count(key));
-      EXPECT_EQ(true, int_to_dbl.contains(key));
+      EXPECT_EQ(1, test_map.count(key));
+      EXPECT_EQ(true, test_map.contains(key));
     }
   }
 }

--- a/src/axom/core/tests/core_serial_main.cpp
+++ b/src/axom/core/tests/core_serial_main.cpp
@@ -15,6 +15,7 @@
 #include "core_execution_for_all.hpp"
 #include "core_execution_space.hpp"
 #include "core_map.hpp"
+#include "core_flatmap.hpp"
 #include "core_memory_management.hpp"
 #include "core_Path.hpp"
 #include "core_stack_array.hpp"


### PR DESCRIPTION
# Summary

Adds `axom::FlatMap`, an initial implementation of a hash map container as a mostly drop-in replacement for `std::unordered_map`. The eventual goal is to enable the use of hash maps on the GPU.

## Design

FlatMap is largely based on Boost's `unordered_flat_map` design, described [here](https://bannalia.blogspot.com/2022/11/inside-boostunorderedflatmap.html). Pertinent design points are:
- Open-addressing as opposed to `std::unordered_map`'s closed-addressing model.
- Non-relocating quadratic probing to resolve hash collisions.
- The hash map is split into groups of 15 "buckets":
  - Each group is represented by a 128-bit chunk of metadata, consisting of an "overflow" byte and one byte for each bucket in the group.
  - The "overflow" byte is used as a Bloom filter to test if the next group should be probed during lookups. This avoids the use of tombstones when performing quadratic probing.
  - Each "bucket" byte is 0 if the bucket is empty, 1 if it's at the end of the array, or a reduced hash of `[2,256)` for a filled bucket.

## API goals

Drop-in compatibility with `std::unordered_map` is aimed for as much as possible, with the exception of any methods that take in iterator "hints," e.g. for insertion.