### PR TITLE
Refactor/gunney/runtime policy

### DIFF
--- a/src/axom/core/CMakeLists.txt
+++ b/src/axom/core/CMakeLists.txt
@@ -64,6 +64,7 @@ set(core_headers
     ## execution
     execution/execution_space.hpp
     execution/for_all.hpp
+    execution/runtime_policy.hpp
     execution/synchronize.hpp
 
     execution/internal/seq_exec.hpp

--- a/src/axom/core/execution/execution_space.hpp
+++ b/src/axom/core/execution/execution_space.hpp
@@ -56,6 +56,8 @@
  *
  * The execution spaces bind the corresponding RAJA execution policies and
  * default memory space.
+ *
+ * @see runtime_policy.hpp
  */
 
 namespace axom

--- a/src/axom/core/execution/runtime_policy.hpp
+++ b/src/axom/core/execution/runtime_policy.hpp
@@ -11,9 +11,37 @@
 
 #include <map>
 
+/*!
+  @file runtime_policy.hpp
+
+  @brief Define runtime policies symbols for selecting.
+
+  The policies are enums corresponding to
+  \a axom::execution_space template parameters.
+  The difference is that runtime policies are selected at
+  run time while \a axom::execution_space is specialized
+  at build time.
+  @see execution_space.hpp.
+
+  The possible runtime parameters are
+  - @c seq: sequential execution on the host
+  - @c omp: OpenMP execution
+  - @c cuda: GPU execution via CUDA
+  - @c hip: GPU execution via HIP
+
+  The available policies depend on how Axom is configured.
+  RAJA is required for using OpenMP, CUDA and HIP.
+  UMPIRE is required for using CUDA and HIP.
+  Sequential execution on host is always available.
+
+  These macros are defined to indicate available non-sequential
+  policies.
+  - @c AXOM_RUNTIME_POLICY_USE_OPENMP
+  - @c AXOM_RUNTIME_POLICY_USE_CUDA
+  - @c AXOM_RUNTIME_POLICY_USE_HIP
+*/
+
 // Helper preprocessor defines for using OPENMP, CUDA, and HIP policies.
-// RAJA is required for using OpenMP, CUDA and HIP.
-// UMPIRE is required for using CUDA and HIP.
 #if defined(AXOM_USE_RAJA)
   #ifdef AXOM_USE_OPENMP
     #define AXOM_RUNTIME_POLICY_USE_OPENMP
@@ -30,7 +58,7 @@ namespace axom
 {
 namespace runtime_policy
 {
-/// Execution policies supported by Axom's configuration.
+/// Execution policies.  The supported set depends on Axom's configuration.
 enum class Policy
 {
   seq = 0

--- a/src/axom/core/execution/runtime_policy.hpp
+++ b/src/axom/core/execution/runtime_policy.hpp
@@ -6,10 +6,25 @@
 #ifndef AXOM_CORE_EXECUTION_RUNTIME_POLICY_HPP_
 #define AXOM_CORE_EXECUTION_RUNTIME_POLICY_HPP_
 
-#include "axom/config.hpp"                         /* for compile time defs. */
-#include "axom/fmt/format.h"                       /* for axom::fmt */
-#include "axom/core/Macros.hpp"                    /* for AXOM_STATIC_ASSERT */
-#include "axom/core/execution/execution_space.hpp" /* execution_space traits */
+#include "axom/config.hpp"   /* for compile time defs. */
+#include "axom/fmt/format.h" /* for axom::fmt */
+
+#include <map>
+
+// Helper preprocessor defines for using OPENMP, CUDA, and HIP policies.
+// RAJA is required for using OpenMP, CUDA and HIP.
+// UMPIRE is required for using CUDA and HIP.
+#if defined(AXOM_USE_RAJA)
+  #ifdef AXOM_USE_OPENMP
+    #define AXOM_RUNTIME_POLICY_USE_OPENMP
+  #endif
+  #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+    #define AXOM_RUNTIME_POLICY_USE_CUDA
+  #endif
+  #if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
+    #define AXOM_RUNTIME_POLICY_USE_HIP
+  #endif
+#endif
 
 namespace axom
 {
@@ -17,23 +32,21 @@ namespace core
 {
 namespace runtime_policy
 {
-/// Execution policies supported by configuration.
+/// Execution policies supported by Axom's configuration.
 enum class Policy
 {
   seq = 0
-#if defined(AXOM_USE_RAJA)
-  #ifdef AXOM_USE_OPENMP
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
   ,
   omp = 1
-  #endif
-  #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
   ,
   cuda = 2
-  #endif
-  #if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
   ,
   hip = 3
-  #endif
 #endif
 };
 
@@ -42,16 +55,14 @@ enum class Policy
   static const std::map<std::string, Policy> s_nameToPolicy
   {
     {"seq", Policy::seq}
-#if defined(AXOM_USE_RAJA)
-#ifdef AXOM_USE_OPENMP
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
     , {"omp", Policy::omp}
 #endif
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
     , {"cuda", Policy::cuda}
 #endif
-#if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
     , {"hip", Policy::hip}
-#endif
 #endif
   };
 
@@ -59,16 +70,14 @@ enum class Policy
   static const std::map<Policy, std::string> s_policyToName
   {
     {Policy::seq, "seq"}
-#if defined(AXOM_USE_RAJA)
-#ifdef AXOM_USE_OPENMP
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
     , {Policy::omp, "omp"}
 #endif
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
     , {Policy::cuda, "cuda"}
 #endif
-#if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
     , {Policy::hip, "hip"}
-#endif
 #endif
   };
 // clang-format on

--- a/src/axom/core/execution/runtime_policy.hpp
+++ b/src/axom/core/execution/runtime_policy.hpp
@@ -17,25 +17,28 @@ namespace core
 {
 namespace runtime_policy
 {
-  /// Execution policies supported by configuration.
-  enum class Policy
-  {
-    seq = 0
+/// Execution policies supported by configuration.
+enum class Policy
+{
+  seq = 0
 #if defined(AXOM_USE_RAJA)
-#ifdef AXOM_USE_OPENMP
-    , omp = 1
+  #ifdef AXOM_USE_OPENMP
+  ,
+  omp = 1
+  #endif
+  #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+  ,
+  cuda = 2
+  #endif
+  #if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
+  ,
+  hip = 3
+  #endif
 #endif
-#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
-    , cuda = 2
-#endif
-#if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
-    , hip = 3
-#endif
-#endif
-  };
+};
 
-  //! @brief Mapping from policy name to policy enum.
-  // clang-format off
+//! @brief Mapping from policy name to policy enum.
+// clang-format off
   static const std::map<std::string, Policy> s_nameToPolicy
   {
     {"seq", Policy::seq}
@@ -68,13 +71,10 @@ namespace runtime_policy
 #endif
 #endif
   };
-  // clang-format on
+// clang-format on
 
-  /// Utility function to allow formating a Policy
-  static inline auto format_as(Policy pol)
-  {
-    return axom::fmt::underlying(pol);
-  }
+/// Utility function to allow formating a Policy
+static inline auto format_as(Policy pol) { return axom::fmt::underlying(pol); }
 
 }  // end namespace runtime_policy
 }  // end namespace core

--- a/src/axom/core/execution/runtime_policy.hpp
+++ b/src/axom/core/execution/runtime_policy.hpp
@@ -28,8 +28,6 @@
 
 namespace axom
 {
-namespace core
-{
 namespace runtime_policy
 {
 /// Execution policies supported by Axom's configuration.
@@ -86,7 +84,6 @@ enum class Policy
 static inline auto format_as(Policy pol) { return axom::fmt::underlying(pol); }
 
 }  // end namespace runtime_policy
-}  // end namespace core
 }  // end namespace axom
 
 #endif /* AXOM_CORE_EXECUTION_RUNTIME_POLICY_HPP_ */

--- a/src/axom/core/execution/runtime_policy.hpp
+++ b/src/axom/core/execution/runtime_policy.hpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_CORE_EXECUTION_RUNTIME_POLICY_HPP_
+#define AXOM_CORE_EXECUTION_RUNTIME_POLICY_HPP_
+
+#include "axom/config.hpp"                         /* for compile time defs. */
+#include "axom/fmt/format.h"                       /* for axom::fmt */
+#include "axom/core/Macros.hpp"                    /* for AXOM_STATIC_ASSERT */
+#include "axom/core/execution/execution_space.hpp" /* execution_space traits */
+
+namespace axom
+{
+namespace core
+{
+namespace runtime_policy
+{
+  /// Execution policies supported by configuration.
+  enum class Policy
+  {
+    seq = 0
+#if defined(AXOM_USE_RAJA)
+#ifdef AXOM_USE_OPENMP
+    , omp = 1
+#endif
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+    , cuda = 2
+#endif
+#if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
+    , hip = 3
+#endif
+#endif
+  };
+
+  //! @brief Mapping from policy name to policy enum.
+  // clang-format off
+  static const std::map<std::string, Policy> s_nameToPolicy
+  {
+    {"seq", Policy::seq}
+#if defined(AXOM_USE_RAJA)
+#ifdef AXOM_USE_OPENMP
+    , {"omp", Policy::omp}
+#endif
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+    , {"cuda", Policy::cuda}
+#endif
+#if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
+    , {"hip", Policy::hip}
+#endif
+#endif
+  };
+
+  //! @brief Mapping from policy enum to policy name.
+  static const std::map<Policy, std::string> s_policyToName
+  {
+    {Policy::seq, "seq"}
+#if defined(AXOM_USE_RAJA)
+#ifdef AXOM_USE_OPENMP
+    , {Policy::omp, "omp"}
+#endif
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+    , {Policy::cuda, "cuda"}
+#endif
+#if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
+    , {Policy::hip, "hip"}
+#endif
+#endif
+  };
+  // clang-format on
+
+  /// Utility function to allow formating a Policy
+  static inline auto format_as(Policy pol)
+  {
+    return axom::fmt::underlying(pol);
+  }
+
+}  // end namespace runtime_policy
+}  // end namespace core
+}  // end namespace axom
+
+#endif /* AXOM_CORE_EXECUTION_RUNTIME_POLICY_HPP_ */

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -1429,10 +1429,7 @@ public:
   }
 
   /// Set the runtime execution policy for the query
-  void setRuntimePolicy(RuntimePolicy policy)
-  {
-    m_runtimePolicy = policy;
-  }
+  void setRuntimePolicy(RuntimePolicy policy) { m_runtimePolicy = policy; }
 
   /*!  @brief Sets the allocator ID to the default associated with the
     execution policy

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -34,20 +34,6 @@
 #endif
 #include "mpi.h"
 
-// Add some helper preprocessor defines for using OPENMP, CUDA, and HIP policies
-// within the distributed closest point query.
-#if defined(AXOM_USE_RAJA)
-  #ifdef AXOM_USE_OPENMP
-    #define _AXOM_DCP_USE_OPENMP
-  #endif
-  #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
-    #define _AXOM_DCP_USE_CUDA
-  #endif
-  #if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
-    #define _AXOM_DCP_USE_HIP
-  #endif
-#endif
-
 namespace axom
 {
 namespace quest
@@ -331,13 +317,13 @@ public:
   using BoxArray = axom::Array<BoxType>;
 
   using SeqBVHTree = spin::BVH<DIM, axom::SEQ_EXEC>;
-#ifdef _AXOM_DCP_USE_OPENMP
+#ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
   using OmpBVHTree = spin::BVH<DIM, axom::OMP_EXEC>;
 #endif
-#ifdef _AXOM_DCP_USE_CUDA
+#ifdef AXOM_RUNTIME_POLICY_USE_CUDA
   using CudaBVHTree = spin::BVH<DIM, axom::CUDA_EXEC<256>>;
 #endif
-#ifdef _AXOM_DCP_USE_HIP
+#ifdef AXOM_RUNTIME_POLICY_USE_HIP
   using HipBVHTree = spin::BVH<DIM, axom::HIP_EXEC<256>>;
 #endif
 
@@ -486,17 +472,17 @@ public:
     case RuntimePolicy::seq:
       return m_bvh_seq.get() != nullptr;
 
-#ifdef _AXOM_DCP_USE_OPENMP
+#ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
     case RuntimePolicy::omp:
       return m_bvh_omp.get() != nullptr;
 #endif
 
-#ifdef _AXOM_DCP_USE_CUDA
+#ifdef AXOM_RUNTIME_POLICY_USE_CUDA
     case RuntimePolicy::cuda:
       return m_bvh_cuda.get() != nullptr;
 #endif
 
-#ifdef _AXOM_DCP_USE_HIP
+#ifdef AXOM_RUNTIME_POLICY_USE_HIP
     case RuntimePolicy::hip:
       return m_bvh_hip.get() != nullptr;
 #endif
@@ -527,19 +513,19 @@ public:
       m_bvh_seq = std::make_unique<SeqBVHTree>();
       return generateBVHTreeImpl<SeqBVHTree>(m_bvh_seq.get());
 
-#ifdef _AXOM_DCP_USE_OPENMP
+#ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
     case RuntimePolicy::omp:
       m_bvh_omp = std::make_unique<OmpBVHTree>();
       return generateBVHTreeImpl<OmpBVHTree>(m_bvh_omp.get());
 #endif
 
-#ifdef _AXOM_DCP_USE_CUDA
+#ifdef AXOM_RUNTIME_POLICY_USE_CUDA
     case RuntimePolicy::cuda:
       m_bvh_cuda = std::make_unique<CudaBVHTree>();
       return generateBVHTreeImpl<CudaBVHTree>(m_bvh_cuda.get());
 #endif
 
-#ifdef _AXOM_DCP_USE_HIP
+#ifdef AXOM_RUNTIME_POLICY_USE_HIP
     case RuntimePolicy::hip:
       m_bvh_hip = std::make_unique<HipBVHTree>();
       return generateBVHTreeImpl<HipBVHTree>(m_bvh_hip.get());
@@ -566,19 +552,19 @@ public:
       local_bb = m_bvh_seq->getBounds();
       break;
 
-#ifdef _AXOM_DCP_USE_OPENMP
+#ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
     case RuntimePolicy::omp:
       local_bb = m_bvh_omp->getBounds();
       break;
 #endif
 
-#ifdef _AXOM_DCP_USE_CUDA
+#ifdef AXOM_RUNTIME_POLICY_USE_CUDA
     case RuntimePolicy::cuda:
       local_bb = m_bvh_cuda->getBounds();
       break;
 #endif
 
-#ifdef _AXOM_DCP_USE_HIP
+#ifdef AXOM_RUNTIME_POLICY_USE_HIP
     case RuntimePolicy::hip:
       local_bb = m_bvh_hip->getBounds();
       break;
@@ -985,19 +971,19 @@ private:
       computeLocalClosestPoints<SeqBVHTree>(m_bvh_seq.get(), xferNode);
       break;
 
-#ifdef _AXOM_DCP_USE_OPENMP
+#ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
     case RuntimePolicy::omp:
       computeLocalClosestPoints<OmpBVHTree>(m_bvh_omp.get(), xferNode);
 #endif
       break;
 
-#ifdef _AXOM_DCP_USE_CUDA
+#ifdef AXOM_RUNTIME_POLICY_USE_CUDA
     case RuntimePolicy::cuda:
       computeLocalClosestPoints<CudaBVHTree>(m_bvh_cuda.get(), xferNode);
 #endif
       break;
 
-#ifdef _AXOM_DCP_USE_HIP
+#ifdef AXOM_RUNTIME_POLICY_USE_HIP
     case RuntimePolicy::hip:
       computeLocalClosestPoints<HipBVHTree>(m_bvh_hip.get(), xferNode);
 #endif
@@ -1360,15 +1346,15 @@ private:
 
   std::unique_ptr<SeqBVHTree> m_bvh_seq;
 
-#ifdef _AXOM_DCP_USE_OPENMP
+#ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
   std::unique_ptr<OmpBVHTree> m_bvh_omp;
 #endif
 
-#ifdef _AXOM_DCP_USE_CUDA
+#ifdef AXOM_RUNTIME_POLICY_USE_CUDA
   std::unique_ptr<CudaBVHTree> m_bvh_cuda;
 #endif
 
-#ifdef _AXOM_DCP_USE_HIP
+#ifdef AXOM_RUNTIME_POLICY_USE_HIP
   std::unique_ptr<HipBVHTree> m_bvh_hip;
 #endif
 };  // DistributedClosestPointImpl
@@ -1443,20 +1429,20 @@ public:
       defaultAllocatorID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
       break;
 
-#ifdef _AXOM_DCP_USE_OPENMP
+#ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
     case RuntimePolicy::omp:
       defaultAllocatorID = axom::execution_space<axom::OMP_EXEC>::allocatorID();
       break;
 #endif
 
-#ifdef _AXOM_DCP_USE_CUDA
+#ifdef AXOM_RUNTIME_POLICY_USE_CUDA
     case RuntimePolicy::cuda:
       defaultAllocatorID =
         axom::execution_space<axom::CUDA_EXEC<256>>::allocatorID();
       break;
 #endif
 
-#ifdef _AXOM_DCP_USE_HIP
+#ifdef AXOM_RUNTIME_POLICY_USE_HIP
     case RuntimePolicy::hip:
       defaultAllocatorID =
         axom::execution_space<axom::HIP_EXEC<256>>::allocatorID();
@@ -1753,10 +1739,5 @@ private:
 
 }  // end namespace quest
 }  // end namespace axom
-
-// Cleanup local #defines
-#undef _AXOM_DCP_USE_OPENMP
-#undef _AXOM_DCP_USE_CUDA
-#undef _AXOM_DCP_USE_HIP
 
 #endif  //  QUEST_DISTRIBUTED_CLOSEST_POINT_H_

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -310,7 +310,7 @@ class DistributedClosestPointImpl
 {
 public:
   static constexpr int DIM = NDIMS;
-  using RuntimePolicy = axom::core::runtime_policy::Policy;
+  using RuntimePolicy = axom::runtime_policy::Policy;
   using PointType = primal::Point<double, DIM>;
   using BoxType = primal::BoundingBox<double, DIM>;
   using PointArray = axom::Array<PointType>;
@@ -1390,7 +1390,7 @@ private:
 class DistributedClosestPoint
 {
 public:
-  using RuntimePolicy = axom::core::runtime_policy::Policy;
+  using RuntimePolicy = axom::runtime_policy::Policy;
 
 public:
   DistributedClosestPoint()

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -294,14 +294,7 @@ public:
   using TetrahedronType = primal::Tetrahedron<double, 3>;
   using SegmentMesh = mint::UnstructuredMesh<mint::SINGLE_SHAPE>;
 
-  /// Choose runtime policy for RAJA
-  enum ExecPolicy
-  {
-    seq = 0,
-    omp = 1,
-    cuda = 2,
-    hip = 3
-  };
+  using RuntimePolicy = axom::runtime_policy::Policy;
 
   static constexpr int DEFAULT_CIRCLE_REFINEMENT_LEVEL {7};
   static constexpr double DEFAULT_REVOLVED_VOLUME {0.};
@@ -319,7 +312,7 @@ public:
 
   void setLevel(int level) { m_level = level; }
 
-  void setExecPolicy(int policy) { m_execPolicy = (ExecPolicy)policy; }
+  void setExecPolicy(RuntimePolicy policy) { m_execPolicy = policy; }
 
   /*!
    * \brief Set the name of the material used to account for free volume fractions.
@@ -1368,30 +1361,27 @@ public:
     switch(m_execPolicy)
     {
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
-    case seq:
+    case RuntimePolicy::seq:
       applyReplacementRulesImpl<seq_exec>(shape);
       break;
   #if defined(AXOM_USE_OPENMP)
-    case omp:
+    case RuntimePolicy::omp:
       applyReplacementRulesImpl<omp_exec>(shape);
       break;
   #endif  // AXOM_USE_OPENMP
   #if defined(AXOM_USE_CUDA)
-    case cuda:
+    case RuntimePolicy::cuda:
       applyReplacementRulesImpl<cuda_exec>(shape);
       break;
   #endif  // AXOM_USE_CUDA
   #if defined(AXOM_USE_HIP)
-    case hip:
+    case RuntimePolicy::hip:
       applyReplacementRulesImpl<hip_exec>(shape);
       break;
   #endif  // AXOM_USE_HIP
 #endif    // AXOM_USE_RAJA && AXOM_USE_UMPIRE
-    default:
-      AXOM_UNUSED_VAR(shape);
-      SLIC_ERROR("Unhandled runtime policy case " << m_execPolicy);
-      break;
     }
+    AXOM_UNUSED_VAR(shape);
   }
 
   void finalizeShapeQuery() override
@@ -1426,31 +1416,28 @@ public:
     switch(m_execPolicy)
     {
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
-    case seq:
+    case RuntimePolicy::seq:
       prepareShapeQueryImpl<seq_exec>(shapeDimension, shape);
       break;
   #if defined(AXOM_USE_OPENMP)
-    case omp:
+    case RuntimePolicy::omp:
       prepareShapeQueryImpl<omp_exec>(shapeDimension, shape);
       break;
   #endif  // AXOM_USE_OPENMP
   #if defined(AXOM_USE_CUDA)
-    case cuda:
+    case RuntimePolicy::cuda:
       prepareShapeQueryImpl<cuda_exec>(shapeDimension, shape);
       break;
   #endif  // AXOM_USE_CUDA
   #if defined(AXOM_USE_HIP)
-    case hip:
+    case RuntimePolicy::hip:
       prepareShapeQueryImpl<hip_exec>(shapeDimension, shape);
       break;
   #endif  // AXOM_USE_HIP
 #endif    // AXOM_USE_RAJA && AXOM_USE_UMPIRE
-    default:
-      AXOM_UNUSED_VAR(shapeDimension);
-      AXOM_UNUSED_VAR(shape);
-      SLIC_ERROR("Unhandled runtime policy case " << m_execPolicy);
-      break;
     }
+    AXOM_UNUSED_VAR(shapeDimension);
+    AXOM_UNUSED_VAR(shape);
 
     // Restore m_percentError, m_level in case refineShape changed them.
     m_percentError = saved_percentError;
@@ -1469,29 +1456,25 @@ public:
       switch(m_execPolicy)
       {
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
-      case seq:
+      case RuntimePolicy::seq:
         runShapeQueryImpl<seq_exec, TetrahedronType>(shape, m_tets, m_tetcount);
         break;
   #if defined(AXOM_USE_OPENMP)
-      case omp:
+      case RuntimePolicy::omp:
         runShapeQueryImpl<omp_exec, TetrahedronType>(shape, m_tets, m_tetcount);
         break;
   #endif  // AXOM_USE_OPENMP
   #if defined(AXOM_USE_CUDA)
-      case cuda:
+      case RuntimePolicy::cuda:
         runShapeQueryImpl<cuda_exec, TetrahedronType>(shape, m_tets, m_tetcount);
         break;
   #endif  // AXOM_USE_CUDA
   #if defined(AXOM_USE_HIP)
-      case hip:
+      case RuntimePolicy::hip:
         runShapeQueryImpl<hip_exec, TetrahedronType>(shape, m_tets, m_tetcount);
         break;
   #endif  // AXOM_USE_HIP
 #endif    // AXOM_USE_RAJA && AXOM_USE_UMPIRE
-      default:
-        AXOM_UNUSED_VAR(shape);
-        SLIC_ERROR("Unhandled runtime policy case " << m_execPolicy);
-        break;
       }
     }
     else if(shapeFormat == "c2c")
@@ -1499,29 +1482,25 @@ public:
       switch(m_execPolicy)
       {
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
-      case seq:
+      case RuntimePolicy::seq:
         runShapeQueryImpl<seq_exec, OctahedronType>(shape, m_octs, m_octcount);
         break;
   #if defined(AXOM_USE_OPENMP)
-      case omp:
+      case RuntimePolicy::omp:
         runShapeQueryImpl<omp_exec, OctahedronType>(shape, m_octs, m_octcount);
         break;
   #endif  // AXOM_USE_OPENMP
   #if defined(AXOM_USE_CUDA)
-      case cuda:
+      case RuntimePolicy::cuda:
         runShapeQueryImpl<cuda_exec, OctahedronType>(shape, m_octs, m_octcount);
         break;
   #endif  // AXOM_USE_CUDA
   #if defined(AXOM_USE_HIP)
-      case hip:
+      case RuntimePolicy::hip:
         runShapeQueryImpl<hip_exec, OctahedronType>(shape, m_octs, m_octcount);
         break;
   #endif  // AXOM_USE_HIP
 #endif    // AXOM_USE_RAJA && AXOM_USE_UMPIRE
-      default:
-        AXOM_UNUSED_VAR(shape);
-        SLIC_ERROR("Unhandled runtime policy case " << m_execPolicy);
-        break;
       }
     }
     else
@@ -2009,7 +1988,7 @@ private:
   }
 
 private:
-  ExecPolicy m_execPolicy {seq};
+  RuntimePolicy m_execPolicy {RuntimePolicy::seq};
   int m_level {DEFAULT_CIRCLE_REFINEMENT_LEVEL};
   double m_revolvedVolume {DEFAULT_REVOLVED_VOLUME};
   int m_num_elements {0};

--- a/src/axom/quest/MarchingCubes.cpp
+++ b/src/axom/quest/MarchingCubes.cpp
@@ -234,7 +234,7 @@ void MarchingCubesSingleDomain::allocateImpl()
       : std::unique_ptr<ImplBase>(
           new MarchingCubesImpl<3, axom::SEQ_EXEC, axom::SEQ_EXEC>);
   }
-  #ifdef _AXOM_MARCHINGCUBES_USE_OPENMP
+  #ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
   else if(m_runtimePolicy == RuntimePolicy::omp)
   {
     m_impl = m_ndim == 2
@@ -244,7 +244,7 @@ void MarchingCubesSingleDomain::allocateImpl()
           new MarchingCubesImpl<3, axom::OMP_EXEC, axom::SEQ_EXEC>);
   }
   #endif
-  #ifdef _AXOM_MARCHINGCUBES_USE_CUDA
+  #ifdef AXOM_RUNTIME_POLICY_USE_CUDA
   else if(m_runtimePolicy == RuntimePolicy::cuda)
   {
     m_impl = m_ndim == 2
@@ -254,7 +254,7 @@ void MarchingCubesSingleDomain::allocateImpl()
           new MarchingCubesImpl<3, axom::CUDA_EXEC<256>, axom::CUDA_EXEC<1>>);
   }
   #endif
-  #ifdef _AXOM_MARCHINGCUBES_USE_HIP
+  #ifdef AXOM_RUNTIME_POLICY_USE_HIP
   else if(m_runtimePolicy == RuntimePolicy::hip)
   {
     m_impl = m_ndim == 2

--- a/src/axom/quest/MarchingCubes.cpp
+++ b/src/axom/quest/MarchingCubes.cpp
@@ -154,10 +154,6 @@ MarchingCubesSingleDomain::MarchingCubesSingleDomain(RuntimePolicy runtimePolicy
   , m_maskFieldName(maskField)
   , m_maskPath(maskField.empty() ? std::string() : "fields/" + maskField)
 {
-  SLIC_ASSERT_MSG(
-    isValidRuntimePolicy(runtimePolicy),
-    fmt::format("Policy '{}' is not a valid runtime policy", runtimePolicy));
-
   setDomain(dom);
   return;
 }

--- a/src/axom/quest/MarchingCubes.hpp
+++ b/src/axom/quest/MarchingCubes.hpp
@@ -28,20 +28,6 @@
   // C++ includes
   #include <string>
 
-  // Add some helper preprocessor defines for using OPENMP, CUDA, and HIP policies
-  // within the marching cubes implementation.
-  #if defined(AXOM_USE_RAJA)
-    #ifdef AXOM_USE_OPENMP
-      #define _AXOM_MARCHINGCUBES_USE_OPENMP
-    #endif
-    #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
-      #define _AXOM_MARCHINGCUBES_USE_CUDA
-    #endif
-    #if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
-      #define _AXOM_MARCHINGCUBES_USE_HIP
-    #endif
-  #endif
-
 namespace axom
 {
 namespace quest

--- a/src/axom/quest/MarchingCubes.hpp
+++ b/src/axom/quest/MarchingCubes.hpp
@@ -82,7 +82,7 @@ class MarchingCubesSingleDomain;
 class MarchingCubes
 {
 public:
-  using RuntimePolicy = axom::core::runtime_policy::Policy;
+  using RuntimePolicy = axom::runtime_policy::Policy;
   /*!
    * \brief Constructor sets up computational mesh and data for running the
    * marching cubes algorithm.
@@ -176,7 +176,7 @@ class MarchingCubesSingleDomain
   friend class detail::marching_cubes::MarchingCubesImpl;
 
 public:
-  using RuntimePolicy = axom::core::runtime_policy::Policy;
+  using RuntimePolicy = axom::runtime_policy::Policy;
   /*!
    * \brief Constructor for applying algorithm in a single domain.
    * See MarchingCubes for the multi-domain implementation.

--- a/src/axom/quest/MarchingCubes.hpp
+++ b/src/axom/quest/MarchingCubes.hpp
@@ -19,6 +19,7 @@
 #ifdef AXOM_USE_CONDUIT
 
   // Axom includes
+  #include "axom/core/execution/runtime_policy.hpp"
   #include "axom/mint/mesh/UnstructuredMesh.hpp"
 
   // Conduit includes
@@ -45,25 +46,6 @@ namespace axom
 {
 namespace quest
 {
-/*!
-  @brief Enum for runtime execution policy
-
-  The policy implicitly selects the execution space and allocator id.
-*/
-enum class MarchingCubesRuntimePolicy
-{
-  seq = 0,
-  omp = 1,
-  cuda = 2,
-  hip = 3
-};
-
-/// Utility function to allow formating a MarchingCubesRuntimePolicy
-inline auto format_as(MarchingCubesRuntimePolicy pol)
-{
-  return fmt::underlying(pol);
-}
-
 namespace detail
 {
 namespace marching_cubes
@@ -114,12 +96,12 @@ class MarchingCubesSingleDomain;
 class MarchingCubes
 {
 public:
-  using RuntimePolicy = MarchingCubesRuntimePolicy;
+  using RuntimePolicy = axom::core::runtime_policy::Policy;
   /*!
    * \brief Constructor sets up computational mesh and data for running the
    * marching cubes algorithm.
    *
-   * \param [in] runtimePolicy A value from MarchingCubesRuntimePolicy.
+   * \param [in] runtimePolicy A value from RuntimePolicy.
    *             The simplest policy is RuntimePolicy::seq, which specifies
    *             running sequentially on the CPU.
    * \param [in] bpMesh Blueprint multi-domain mesh containing scalar field.
@@ -183,7 +165,7 @@ public:
     const std::string &domainIdField = {});
 
 private:
-  MarchingCubesRuntimePolicy m_runtimePolicy;
+  RuntimePolicy m_runtimePolicy;
 
   //! @brief Single-domain implementations.
   axom::Array<std::unique_ptr<MarchingCubesSingleDomain>> m_singles;
@@ -208,12 +190,12 @@ class MarchingCubesSingleDomain
   friend class detail::marching_cubes::MarchingCubesImpl;
 
 public:
-  using RuntimePolicy = MarchingCubesRuntimePolicy;
+  using RuntimePolicy = axom::core::runtime_policy::Policy;
   /*!
    * \brief Constructor for applying algorithm in a single domain.
    * See MarchingCubes for the multi-domain implementation.
    *
-   * \param [in] runtimePolicy A value from MarchingCubesRuntimePolicy.
+   * \param [in] runtimePolicy A value from RuntimePolicy.
    *             The simplest policy is RuntimePolicy::seq, which specifies
    *             running sequentially on the CPU.
    * \param [in] dom Blueprint single-domain mesh containing scalar field.
@@ -293,43 +275,8 @@ public:
     m_impl->populateContourMesh(mesh, cellIdField);
   }
 
-  /*!
-    @brief Determine whether a given \a MarchingCubesRuntimePolicy is
-    valid for the Axom build configuration.
-  */
-  inline bool isValidRuntimePolicy(MarchingCubesRuntimePolicy policy) const
-  {
-    switch(policy)
-    {
-    case MarchingCubesRuntimePolicy::seq:
-      return true;
-
-    case MarchingCubesRuntimePolicy::omp:
-  #ifdef _AXOM_MARCHINGCUBES_USE_OPENMP
-      return true;
-  #else
-      return false;
-  #endif
-
-    case MarchingCubesRuntimePolicy::cuda:
-  #ifdef _AXOM_MARCHINGCUBES_USE_CUDA
-      return true;
-  #else
-      return false;
-  #endif
-    case MarchingCubesRuntimePolicy::hip:
-  #ifdef _AXOM_MARCHINGCUBES_USE_HIP
-      return true;
-  #else
-      return false;
-  #endif
-    }
-
-    return false;
-  }
-
 private:
-  MarchingCubesRuntimePolicy m_runtimePolicy;
+  RuntimePolicy m_runtimePolicy;
   /*!
     \brief Computational mesh as a conduit::Node.
   */

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -1288,9 +1288,10 @@ int main(int argc, char** argv)
   // Memory resource.  For testing, choose device memory if appropriate.
   //---------------------------------------------------------------------------
   const std::string umpireResourceName =
-    params.policy == RuntimePolicy::seq || params.policy == RuntimePolicy::omp
-    ? "HOST"
-    :
+    params.policy == RuntimePolicy::seq ? "HOST" :
+  #ifdef AXOM_USE_OPENMP
+    params.policy == RuntimePolicy::omp ? "HOST" :
+  #endif
   #if defined(UMPIRE_ENABLE_DEVICE)
     "DEVICE"
   #elif defined(UMPIRE_ENABLE_UM)

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -168,8 +168,8 @@ public:
     app.add_option("-p, --policy", policy)
       ->description("Set runtime policy for point query method")
       ->capture_default_str()
-      ->transform(axom::CLI::CheckedTransformer(
-        axom::runtime_policy::s_nameToPolicy));
+      ->transform(
+        axom::CLI::CheckedTransformer(axom::runtime_policy::s_nameToPolicy));
 
     app.add_flag("-c,--check-results,!--no-check-results", checkResults)
       ->description(

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -168,7 +168,8 @@ public:
     app.add_option("-p, --policy", policy)
       ->description("Set runtime policy for point query method")
       ->capture_default_str()
-      ->transform(axom::CLI::CheckedTransformer(axom::core::runtime_policy::s_nameToPolicy));
+      ->transform(axom::CLI::CheckedTransformer(
+        axom::core::runtime_policy::s_nameToPolicy));
 
     app.add_flag("-c,--check-results,!--no-check-results", checkResults)
       ->description(
@@ -1287,13 +1288,14 @@ int main(int argc, char** argv)
   //---------------------------------------------------------------------------
   // Memory resource.  For testing, choose device memory if appropriate.
   //---------------------------------------------------------------------------
-  const std::string umpireResourceName =
-    params.policy == RuntimePolicy::seq ? "HOST" :
+  const std::string umpireResourceName = params.policy == RuntimePolicy::seq
+    ? "HOST"
+    :
   #ifdef AXOM_USE_OPENMP
     params.policy == RuntimePolicy::omp ? "HOST" :
   #endif
   #if defined(UMPIRE_ENABLE_DEVICE)
-    "DEVICE"
+                                        "DEVICE"
   #elif defined(UMPIRE_ENABLE_UM)
     "UM"
   #elif defined(UMPIRE_ENABLE_PINNED)

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -1291,7 +1291,7 @@ int main(int argc, char** argv)
   const std::string umpireResourceName = params.policy == RuntimePolicy::seq
     ? "HOST"
     :
-  #ifdef AXOM_USE_OPENMP
+  #if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
     params.policy == RuntimePolicy::omp ? "HOST" :
   #endif
   #if defined(UMPIRE_ENABLE_DEVICE)

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -49,7 +49,7 @@ namespace primal = axom::primal;
 namespace mint = axom::mint;
 namespace numerics = axom::numerics;
 
-using RuntimePolicy = axom::quest::DistributedClosestPoint::RuntimePolicy;
+using RuntimePolicy = axom::core::runtime_policy::Policy;
 
 // converts the input string into an 80 character string
 // padded on both sides with '=' symbols
@@ -83,24 +83,6 @@ public:
 private:
   bool m_verboseOutput {false};
   double m_emptyRankProbability {0.};
-
-  // clang-format off
-  const std::map<std::string, RuntimePolicy> s_validPolicies
-  {
-      {"seq", RuntimePolicy::seq}
-#if defined(AXOM_USE_RAJA)
-  #ifdef AXOM_USE_OPENMP
-    , {"omp", RuntimePolicy::omp}
-  #endif
-  #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
-    , {"cuda", RuntimePolicy::cuda}
-  #endif
-  #if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
-    , {"hip", RuntimePolicy::hip}
-  #endif
-#endif
-  };
-  // clang-format on
 
 public:
   bool isVerbose() const { return m_verboseOutput; }
@@ -186,7 +168,7 @@ public:
     app.add_option("-p, --policy", policy)
       ->description("Set runtime policy for point query method")
       ->capture_default_str()
-      ->transform(axom::CLI::CheckedTransformer(s_validPolicies));
+      ->transform(axom::CLI::CheckedTransformer(axom::core::runtime_policy::s_nameToPolicy));
 
     app.add_flag("-c,--check-results,!--no-check-results", checkResults)
       ->description(

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -49,7 +49,7 @@ namespace primal = axom::primal;
 namespace mint = axom::mint;
 namespace numerics = axom::numerics;
 
-using RuntimePolicy = axom::core::runtime_policy::Policy;
+using RuntimePolicy = axom::runtime_policy::Policy;
 
 // converts the input string into an 80 character string
 // padded on both sides with '=' symbols
@@ -169,7 +169,7 @@ public:
       ->description("Set runtime policy for point query method")
       ->capture_default_str()
       ->transform(axom::CLI::CheckedTransformer(
-        axom::core::runtime_policy::s_nameToPolicy));
+        axom::runtime_policy::s_nameToPolicy));
 
     app.add_flag("-c,--check-results,!--no-check-results", checkResults)
       ->description(

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -104,7 +104,8 @@ public:
     app.add_option("-p, --policy", policy)
       ->description("Set runtime policy for point query method")
       ->capture_default_str()
-      ->transform(axom::CLI::CheckedTransformer(axom::core::runtime_policy::s_nameToPolicy));
+      ->transform(axom::CLI::CheckedTransformer(
+        axom::core::runtime_policy::s_nameToPolicy));
 
     app.add_option("-m,--mesh-file", meshFile)
       ->description(
@@ -716,12 +717,12 @@ struct ContourTestBase
       {
         SLIC_ASSERT(resourceName == "HOST");
       }
-#ifdef AXOM_USE_OPENMP
+    #ifdef AXOM_USE_OPENMP
       else if(params.policy == axom::core::runtime_policy::Policy::omp)
       {
         SLIC_ASSERT(resourceName == "HOST");
       }
-#endif
+    #endif
       else
       {
         SLIC_ASSERT(resourceName == "DEVICE");

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -215,7 +215,6 @@ static int allocatorIdForPolicy(axom::core::runtime_policy::Policy policy)
   {
     aid = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   }
-#if defined(AXOM_USE_RAJA)
 #ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
   else if(policy == axom::core::runtime_policy::Policy::omp)
   {
@@ -235,7 +234,6 @@ static int allocatorIdForPolicy(axom::core::runtime_policy::Policy policy)
     // aid = axom::execution_space<axom::HIP_EXEC<256>>::allocatorID();
     aid = axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   }
-#endif
 #endif
   // clang-format on
 

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -90,8 +90,7 @@ public:
 
   bool checkResults {false};
 
-  axom::runtime_policy::Policy policy {
-    axom::runtime_policy::Policy::seq};
+  axom::runtime_policy::Policy policy {axom::runtime_policy::Policy::seq};
 
 private:
   bool _verboseOutput {false};
@@ -104,8 +103,8 @@ public:
     app.add_option("-p, --policy", policy)
       ->description("Set runtime policy for point query method")
       ->capture_default_str()
-      ->transform(axom::CLI::CheckedTransformer(
-        axom::runtime_policy::s_nameToPolicy));
+      ->transform(
+        axom::CLI::CheckedTransformer(axom::runtime_policy::s_nameToPolicy));
 
     app.add_option("-m,--mesh-file", meshFile)
       ->description(

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -90,8 +90,8 @@ public:
 
   bool checkResults {false};
 
-  axom::core::runtime_policy::Policy policy {
-    axom::core::runtime_policy::Policy::seq};
+  axom::runtime_policy::Policy policy {
+    axom::runtime_policy::Policy::seq};
 
 private:
   bool _verboseOutput {false};
@@ -105,7 +105,7 @@ public:
       ->description("Set runtime policy for point query method")
       ->capture_default_str()
       ->transform(axom::CLI::CheckedTransformer(
-        axom::core::runtime_policy::s_nameToPolicy));
+        axom::runtime_policy::s_nameToPolicy));
 
     app.add_option("-m,--mesh-file", meshFile)
       ->description(
@@ -203,7 +203,7 @@ public:
 
 //!@brief Our allocator id, based on execution policy.
 static int s_allocatorId = axom::INVALID_ALLOCATOR_ID;  // Set in main.
-static int allocatorIdForPolicy(axom::core::runtime_policy::Policy policy)
+static int allocatorIdForPolicy(axom::runtime_policy::Policy policy)
 {
   //---------------------------------------------------------------------------
   // Set default allocator for possibly testing on devices
@@ -211,25 +211,25 @@ static int allocatorIdForPolicy(axom::core::runtime_policy::Policy policy)
   int aid = axom::INVALID_ALLOCATOR_ID;
 
   // clang-format off
-  if(policy == axom::core::runtime_policy::Policy::seq)
+  if(policy == axom::runtime_policy::Policy::seq)
   {
     aid = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   }
 #ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
-  else if(policy == axom::core::runtime_policy::Policy::omp)
+  else if(policy == axom::runtime_policy::Policy::omp)
   {
     aid = axom::execution_space<axom::OMP_EXEC>::allocatorID();
   }
 #endif
 #ifdef AXOM_RUNTIME_POLICY_USE_CUDA
-  else if(policy == axom::core::runtime_policy::Policy::cuda)
+  else if(policy == axom::runtime_policy::Policy::cuda)
   {
     // aid = axom::execution_space<axom::CUDA_EXEC<256>>::allocatorID();
     aid = axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   }
 #endif
 #ifdef AXOM_RUNTIME_POLICY_USE_HIP
-  else if(policy == axom::core::runtime_policy::Policy::hip)
+  else if(policy == axom::runtime_policy::Policy::hip)
   {
     // aid = axom::execution_space<axom::HIP_EXEC<256>>::allocatorID();
     aid = axom::getUmpireResourceAllocatorID(umpire::resource::Device);
@@ -711,12 +711,12 @@ struct ContourTestBase
         axom::fmt::format("Testing with policy {} and function data on {}",
                           params.policy,
                           resourceName));
-      if(params.policy == axom::core::runtime_policy::Policy::seq)
+      if(params.policy == axom::runtime_policy::Policy::seq)
       {
         SLIC_ASSERT(resourceName == "HOST");
       }
     #if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
-      else if(params.policy == axom::core::runtime_policy::Policy::omp)
+      else if(params.policy == axom::runtime_policy::Policy::omp)
       {
         SLIC_ASSERT(resourceName == "HOST");
       }
@@ -1569,7 +1569,7 @@ int main(int argc, char** argv)
   // Run test in the execution space set by command line.
   //---------------------------------------------------------------------------
   int errCount = 0;
-  if(params.policy == axom::core::runtime_policy::Policy::seq)
+  if(params.policy == axom::runtime_policy::Policy::seq)
   {
     if(params.ndim == 2)
     {
@@ -1582,7 +1582,7 @@ int main(int argc, char** argv)
   }
   #if defined(AXOM_USE_RAJA)
     #ifdef AXOM_USE_OPENMP
-  else if(params.policy == axom::core::runtime_policy::Policy::omp)
+  else if(params.policy == axom::runtime_policy::Policy::omp)
   {
     if(params.ndim == 2)
     {
@@ -1595,7 +1595,7 @@ int main(int argc, char** argv)
   }
     #endif
     #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
-  else if(params.policy == axom::core::runtime_policy::Policy::cuda)
+  else if(params.policy == axom::runtime_policy::Policy::cuda)
   {
     if(params.ndim == 2)
     {
@@ -1608,7 +1608,7 @@ int main(int argc, char** argv)
   }
     #endif
     #if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
-  else if(params.policy == axom::core::runtime_policy::Policy::hip)
+  else if(params.policy == axom::runtime_policy::Policy::hip)
   {
     if(params.ndim == 2)
     {

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -59,6 +59,8 @@ namespace primal = axom::primal;
 namespace mint = axom::mint;
 namespace numerics = axom::numerics;
 
+using RuntimePolicy = axom::runtime_policy::Policy;
+
 ///////////////////////////////////////////////////////////////
 // converts the input string into an 80 character string
 // padded on both sides with '=' symbols
@@ -90,7 +92,7 @@ public:
 
   bool checkResults {false};
 
-  axom::runtime_policy::Policy policy {axom::runtime_policy::Policy::seq};
+  RuntimePolicy policy {RuntimePolicy::seq};
 
 private:
   bool _verboseOutput {false};

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -90,29 +90,11 @@ public:
 
   bool checkResults {false};
 
-  quest::MarchingCubesRuntimePolicy policy {
-    quest::MarchingCubesRuntimePolicy::seq};
+  axom::core::runtime_policy::Policy policy {
+    axom::core::runtime_policy::Policy::seq};
 
 private:
   bool _verboseOutput {false};
-
-  // clang-format off
-  const std::map<std::string, quest::MarchingCubesRuntimePolicy> s_validPolicies
-  {
-      {"seq", quest::MarchingCubesRuntimePolicy::seq}
-#if defined(AXOM_USE_RAJA)
-  #ifdef AXOM_USE_OPENMP
-    , {"omp", quest::MarchingCubesRuntimePolicy::omp}
-  #endif
-  #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
-    , {"cuda", quest::MarchingCubesRuntimePolicy::cuda}
-  #endif
-  #if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
-    , {"hip", quest::MarchingCubesRuntimePolicy::hip}
-  #endif
-#endif
-  };
-  // clang-format on
 
 public:
   bool isVerbose() const { return _verboseOutput; }
@@ -122,7 +104,7 @@ public:
     app.add_option("-p, --policy", policy)
       ->description("Set runtime policy for point query method")
       ->capture_default_str()
-      ->transform(axom::CLI::CheckedTransformer(s_validPolicies));
+      ->transform(axom::CLI::CheckedTransformer(axom::core::runtime_policy::s_nameToPolicy));
 
     app.add_option("-m,--mesh-file", meshFile)
       ->description(
@@ -220,7 +202,7 @@ public:
 
 //!@brief Our allocator id, based on execution policy.
 static int s_allocatorId = axom::INVALID_ALLOCATOR_ID;  // Set in main.
-static int allocatorIdForPolicy(quest::MarchingCubesRuntimePolicy policy)
+static int allocatorIdForPolicy(axom::core::runtime_policy::Policy policy)
 {
   //---------------------------------------------------------------------------
   // Set default allocator for possibly testing on devices
@@ -228,26 +210,26 @@ static int allocatorIdForPolicy(quest::MarchingCubesRuntimePolicy policy)
   int aid = axom::INVALID_ALLOCATOR_ID;
 
   // clang-format off
-  if(policy == axom::quest::MarchingCubesRuntimePolicy::seq)
+  if(policy == axom::core::runtime_policy::Policy::seq)
   {
     aid = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   }
 #if defined(AXOM_USE_RAJA)
 #ifdef _AXOM_MARCHINGCUBES_USE_OPENMP
-  else if(policy == axom::quest::MarchingCubesRuntimePolicy::omp)
+  else if(policy == axom::core::runtime_policy::Policy::omp)
   {
     aid = axom::execution_space<axom::OMP_EXEC>::allocatorID();
   }
 #endif
 #ifdef _AXOM_MARCHINGCUBES_USE_CUDA
-  else if(policy == axom::quest::MarchingCubesRuntimePolicy::cuda)
+  else if(policy == axom::core::runtime_policy::Policy::cuda)
   {
     // aid = axom::execution_space<axom::CUDA_EXEC<256>>::allocatorID();
     aid = axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   }
 #endif
 #ifdef _AXOM_MARCHINGCUBES_USE_HIP
-  else if(policy == axom::quest::MarchingCubesRuntimePolicy::hip)
+  else if(policy == axom::core::runtime_policy::Policy::hip)
   {
     // aid = axom::execution_space<axom::HIP_EXEC<256>>::allocatorID();
     aid = axom::getUmpireResourceAllocatorID(umpire::resource::Device);
@@ -730,8 +712,8 @@ struct ContourTestBase
         axom::fmt::format("Testing with policy {} and function data on {}",
                           params.policy,
                           resourceName));
-      if(params.policy == quest::MarchingCubesRuntimePolicy::seq ||
-         params.policy == quest::MarchingCubesRuntimePolicy::omp)
+      if(params.policy == axom::core::runtime_policy::Policy::seq ||
+         params.policy == axom::core::runtime_policy::Policy::omp)
       {
         SLIC_ASSERT(resourceName == "HOST");
       }
@@ -1583,7 +1565,7 @@ int main(int argc, char** argv)
   // Run test in the execution space set by command line.
   //---------------------------------------------------------------------------
   int errCount = 0;
-  if(params.policy == quest::MarchingCubesRuntimePolicy::seq)
+  if(params.policy == axom::core::runtime_policy::Policy::seq)
   {
     if(params.ndim == 2)
     {
@@ -1596,7 +1578,7 @@ int main(int argc, char** argv)
   }
   #if defined(AXOM_USE_RAJA)
     #ifdef AXOM_USE_OPENMP
-  else if(params.policy == quest::MarchingCubesRuntimePolicy::omp)
+  else if(params.policy == axom::core::runtime_policy::Policy::omp)
   {
     if(params.ndim == 2)
     {
@@ -1609,7 +1591,7 @@ int main(int argc, char** argv)
   }
     #endif
     #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
-  else if(params.policy == quest::MarchingCubesRuntimePolicy::cuda)
+  else if(params.policy == axom::core::runtime_policy::Policy::cuda)
   {
     if(params.ndim == 2)
     {
@@ -1622,7 +1604,7 @@ int main(int argc, char** argv)
   }
     #endif
     #if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
-  else if(params.policy == quest::MarchingCubesRuntimePolicy::hip)
+  else if(params.policy == axom::core::runtime_policy::Policy::hip)
   {
     if(params.ndim == 2)
     {

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -712,11 +712,16 @@ struct ContourTestBase
         axom::fmt::format("Testing with policy {} and function data on {}",
                           params.policy,
                           resourceName));
-      if(params.policy == axom::core::runtime_policy::Policy::seq ||
-         params.policy == axom::core::runtime_policy::Policy::omp)
+      if(params.policy == axom::core::runtime_policy::Policy::seq)
       {
         SLIC_ASSERT(resourceName == "HOST");
       }
+#ifdef AXOM_USE_OPENMP
+      else if(params.policy == axom::core::runtime_policy::Policy::omp)
+      {
+        SLIC_ASSERT(resourceName == "HOST");
+      }
+#endif
       else
       {
         SLIC_ASSERT(resourceName == "DEVICE");

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -216,20 +216,20 @@ static int allocatorIdForPolicy(axom::core::runtime_policy::Policy policy)
     aid = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   }
 #if defined(AXOM_USE_RAJA)
-#ifdef _AXOM_MARCHINGCUBES_USE_OPENMP
+#ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
   else if(policy == axom::core::runtime_policy::Policy::omp)
   {
     aid = axom::execution_space<axom::OMP_EXEC>::allocatorID();
   }
 #endif
-#ifdef _AXOM_MARCHINGCUBES_USE_CUDA
+#ifdef AXOM_RUNTIME_POLICY_USE_CUDA
   else if(policy == axom::core::runtime_policy::Policy::cuda)
   {
     // aid = axom::execution_space<axom::CUDA_EXEC<256>>::allocatorID();
     aid = axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   }
 #endif
-#ifdef _AXOM_MARCHINGCUBES_USE_HIP
+#ifdef AXOM_RUNTIME_POLICY_USE_HIP
   else if(policy == axom::core::runtime_policy::Policy::hip)
   {
     // aid = axom::execution_space<axom::HIP_EXEC<256>>::allocatorID();
@@ -717,7 +717,7 @@ struct ContourTestBase
       {
         SLIC_ASSERT(resourceName == "HOST");
       }
-    #ifdef AXOM_USE_OPENMP
+    #if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
       else if(params.policy == axom::core::runtime_policy::Policy::omp)
       {
         SLIC_ASSERT(resourceName == "HOST");

--- a/src/axom/quest/examples/shaping_driver.cpp
+++ b/src/axom/quest/examples/shaping_driver.cpp
@@ -59,14 +59,7 @@ enum class ShapingMethod : int
   Intersection
 };
 
-/// Choose runtime policy for RAJA
-enum RuntimePolicy
-{
-  seq = 0,
-  omp = 1,
-  cuda = 2,
-  hip = 3
-};
+using RuntimePolicy = axom::runtime_policy::Policy;
 
 /// Struct to parse and store the input parameters
 struct Input
@@ -84,7 +77,7 @@ public:
   klee::ShapeSet shapeSet;
 
   ShapingMethod shapingMethod {ShapingMethod::Sampling};
-  RuntimePolicy policy {seq};
+  RuntimePolicy policy {RuntimePolicy::seq};
   int quadratureOrder {5};
   int outputOrder {2};
   int samplesPerKnotSpan {25};
@@ -98,23 +91,6 @@ public:
 
 private:
   bool m_verboseOutput {false};
-
-  // clang-format off
-  const std::map<std::string, RuntimePolicy> s_validPolicies{
-    #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
-      {"seq", seq}
-      #ifdef AXOM_USE_OPENMP
-    , {"omp", omp}
-      #endif
-      #ifdef AXOM_USE_CUDA
-    , {"cuda", cuda}
-      #endif
-      #ifdef AXOM_USE_HIP
-    , {"hip", hip}
-      #endif
-    #endif
-  };
-  // clang-format on
 
 public:
   bool isVerbose() const { return m_verboseOutput; }
@@ -348,7 +324,8 @@ public:
 
       intersection_options->add_option("-p, --policy", policy, pol_sstr.str())
         ->capture_default_str()
-        ->transform(axom::CLI::CheckedTransformer(s_validPolicies));
+        ->transform(
+          axom::CLI::CheckedTransformer(axom::runtime_policy::s_nameToPolicy));
     }
     app.get_formatter()->column_width(50);
 

--- a/src/axom/quest/tests/quest_intersection_shaper.cpp
+++ b/src/axom/quest/tests/quest_intersection_shaper.cpp
@@ -73,6 +73,8 @@ namespace quest = axom::quest;
 namespace sidre = axom::sidre;
 namespace slic = axom::slic;
 
+using RuntimePolicy = axom::runtime_policy::Policy;
+
 std::string pjoin(const std::string &path, const std::string &filename)
 {
   return axom::utilities::filesystem::joinPath(path, filename);
@@ -283,7 +285,7 @@ bool loadBaseline(const std::string &filename, conduit::Node &n)
 
 void replacementRuleTest(const std::string &shapeFile,
                          const std::string &policyName,
-                         int policy,
+                         RuntimePolicy policy,
                          double tolerance,
                          bool initialMats = false)
 {
@@ -401,7 +403,7 @@ void replacementRuleTest(const std::string &shapeFile,
 
 void replacementRuleTestSet(const std::vector<std::string> &cases,
                             const std::string &policyName,
-                            int policy,
+                            RuntimePolicy policy,
                             double tolerance,
                             bool initialMats = false)
 {
@@ -418,7 +420,7 @@ void IntersectionWithErrorTolerances(const std::string &filebase,
                                      int refinementLevel,
                                      double targetPercentError,
                                      const std::string &policyName,
-                                     int policy,
+                                     RuntimePolicy policy,
                                      double revolvedVolumeEPS = 1.e-4)
 {
   SLIC_INFO(axom::fmt::format("Testing {} with {}", filebase, policyName));
@@ -504,7 +506,8 @@ void IntersectionWithErrorTolerances(const std::string &filebase,
 }
 
 //---------------------------------------------------------------------------
-void dynamicRefinementTest_Line(const std::string &policyName, int policy)
+void dynamicRefinementTest_Line(const std::string &policyName,
+                                RuntimePolicy policy)
 {
   const std::string contour = R"(piece = line(start=(2cm,0cm), end=(2cm,2cm))
 )";
@@ -538,7 +541,8 @@ shapes:
 }
 
 //---------------------------------------------------------------------------
-void dynamicRefinementTest_Cone(const std::string &policyName, int policy)
+void dynamicRefinementTest_Cone(const std::string &policyName,
+                                RuntimePolicy policy)
 {
   const std::string contour = R"(piece = line(start=(2cm,0cm), end=(3cm,2cm))
 )";
@@ -572,7 +576,8 @@ shapes:
 }
 
 //---------------------------------------------------------------------------
-void dynamicRefinementTest_Spline(const std::string &policyName, int policy)
+void dynamicRefinementTest_Spline(const std::string &policyName,
+                                  RuntimePolicy policy)
 {
   const std::string contour = R"(piece = rz(units=cm,
   rz=2 0
@@ -611,7 +616,8 @@ shapes:
 }
 
 //---------------------------------------------------------------------------
-void dynamicRefinementTest_Circle(const std::string &policyName, int policy)
+void dynamicRefinementTest_Circle(const std::string &policyName,
+                                  RuntimePolicy policy)
 {
   const std::string contour =
     R"(piece = circle(origin=(0cm,0cm), radius=8cm, start=0deg, end=180deg)
@@ -647,7 +653,8 @@ shapes:
 }
 
 //---------------------------------------------------------------------------
-void dynamicRefinementTest_LineTranslate(const std::string &policyName, int policy)
+void dynamicRefinementTest_LineTranslate(const std::string &policyName,
+                                         RuntimePolicy policy)
 {
   const std::string contour = R"(piece = line(start=(2cm,0cm), end=(2cm,2cm))
 )";
@@ -685,7 +692,8 @@ shapes:
 }
 
 //---------------------------------------------------------------------------
-void dynamicRefinementTest_LineScale(const std::string &policyName, int policy)
+void dynamicRefinementTest_LineScale(const std::string &policyName,
+                                     RuntimePolicy policy)
 {
   const std::string contour = R"(piece = line(start=(2cm,0cm), end=(2cm,2cm))
 )";
@@ -723,7 +731,8 @@ shapes:
 }
 
 //---------------------------------------------------------------------------
-void dynamicRefinementTest_LineRotate(const std::string &policyName, int policy)
+void dynamicRefinementTest_LineRotate(const std::string &policyName,
+                                      RuntimePolicy policy)
 {
   const std::string contour = R"(piece = line(start=(2cm,0cm), end=(2cm,2cm))
 )";
@@ -769,35 +778,31 @@ shapes:
 TEST(IntersectionShaperTest, case1_seq)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case1, "seq", quest::IntersectionShaper::seq, tolerance);
+  replacementRuleTestSet(case1, "seq", RuntimePolicy::seq, tolerance);
 }
   #endif
   #if defined(AXOM_USE_OPENMP)
 TEST(IntersectionShaperTest, case1_omp)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case1, "omp", quest::IntersectionShaper::omp, tolerance);
+  replacementRuleTestSet(case1, "omp", RuntimePolicy::omp, tolerance);
 
   // Include a version that has some initial materials.
-  replacementRuleTestSet(case1,
-                         "omp",
-                         quest::IntersectionShaper::omp,
-                         tolerance,
-                         true);
+  replacementRuleTestSet(case1, "omp", RuntimePolicy::omp, tolerance, true);
 }
   #endif
   #if defined(AXOM_USE_CUDA)
 TEST(IntersectionShaperTest, case1_cuda)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case1, "cuda", quest::IntersectionShaper::cuda, tolerance);
+  replacementRuleTestSet(case1, "cuda", RuntimePolicy::cuda, tolerance);
 }
   #endif
   #if defined(AXOM_USE_HIP)
 TEST(IntersectionShaperTest, case1_hip)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case1, "hip", quest::IntersectionShaper::hip, tolerance);
+  replacementRuleTestSet(case1, "hip", RuntimePolicy::hip, tolerance);
 }
   #endif
 #endif
@@ -808,28 +813,28 @@ TEST(IntersectionShaperTest, case1_hip)
 TEST(IntersectionShaperTest, case2_seq)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case2, "seq", quest::IntersectionShaper::seq, tolerance);
+  replacementRuleTestSet(case2, "seq", RuntimePolicy::seq, tolerance);
 }
   #endif
   #if defined(AXOM_USE_OPENMP)
 TEST(IntersectionShaperTest, case2_omp)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case2, "omp", quest::IntersectionShaper::omp, tolerance);
+  replacementRuleTestSet(case2, "omp", RuntimePolicy::omp, tolerance);
 }
   #endif
   #if defined(AXOM_USE_CUDA)
 TEST(IntersectionShaperTest, case2_cuda)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case2, "cuda", quest::IntersectionShaper::cuda, tolerance);
+  replacementRuleTestSet(case2, "cuda", RuntimePolicy::cuda, tolerance);
 }
   #endif
   #if defined(AXOM_USE_HIP)
 TEST(IntersectionShaperTest, case2_hip)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case2, "hip", quest::IntersectionShaper::hip, tolerance);
+  replacementRuleTestSet(case2, "hip", RuntimePolicy::hip, tolerance);
 }
   #endif
 #endif
@@ -840,28 +845,28 @@ TEST(IntersectionShaperTest, case2_hip)
 TEST(IntersectionShaperTest, case3_seq)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case3, "seq", quest::IntersectionShaper::seq, tolerance);
+  replacementRuleTestSet(case3, "seq", RuntimePolicy::seq, tolerance);
 }
   #endif
   #if defined(AXOM_USE_OPENMP)
 TEST(IntersectionShaperTest, case3_omp)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case3, "omp", quest::IntersectionShaper::omp, tolerance);
+  replacementRuleTestSet(case3, "omp", RuntimePolicy::omp, tolerance);
 }
   #endif
   #if defined(AXOM_USE_CUDA)
 TEST(IntersectionShaperTest, case3_cuda)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case3, "cuda", quest::IntersectionShaper::cuda, tolerance);
+  replacementRuleTestSet(case3, "cuda", RuntimePolicy::cuda, tolerance);
 }
   #endif
   #if defined(AXOM_USE_HIP)
 TEST(IntersectionShaperTest, case3_hip)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case3, "hip", quest::IntersectionShaper::hip, tolerance);
+  replacementRuleTestSet(case3, "hip", RuntimePolicy::hip, tolerance);
 }
   #endif
 #endif
@@ -872,28 +877,28 @@ TEST(IntersectionShaperTest, case3_hip)
 TEST(IntersectionShaperTest, case4_seq)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case4, "seq", quest::IntersectionShaper::seq, tolerance);
+  replacementRuleTestSet(case4, "seq", RuntimePolicy::seq, tolerance);
 }
   #endif
   #if defined(AXOM_USE_OPENMP)
 TEST(IntersectionShaperTest, case4_omp)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case4, "omp", quest::IntersectionShaper::omp, tolerance);
+  replacementRuleTestSet(case4, "omp", RuntimePolicy::omp, tolerance);
 }
   #endif
   #if defined(AXOM_USE_CUDA)
 TEST(IntersectionShaperTest, case4_cuda)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case4, "cuda", quest::IntersectionShaper::cuda, tolerance);
+  replacementRuleTestSet(case4, "cuda", RuntimePolicy::cuda, tolerance);
 }
   #endif
   #if defined(AXOM_USE_HIP)
 TEST(IntersectionShaperTest, case4_hip)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(case4, "hip", quest::IntersectionShaper::hip, tolerance);
+  replacementRuleTestSet(case4, "hip", RuntimePolicy::hip, tolerance);
 }
   #endif
 #endif
@@ -904,31 +909,28 @@ TEST(IntersectionShaperTest, case4_hip)
 TEST(IntersectionShaperTest, proeCase_seq)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(proeCase, "seq", quest::IntersectionShaper::seq, tolerance);
+  replacementRuleTestSet(proeCase, "seq", RuntimePolicy::seq, tolerance);
 }
   #endif
   #if defined(AXOM_USE_OPENMP)
 TEST(IntersectionShaperTest, proeCase_omp)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(proeCase, "omp", quest::IntersectionShaper::omp, tolerance);
+  replacementRuleTestSet(proeCase, "omp", RuntimePolicy::omp, tolerance);
 }
   #endif
   #if defined(AXOM_USE_CUDA)
 TEST(IntersectionShaperTest, proeCase_cuda)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(proeCase,
-                         "cuda",
-                         quest::IntersectionShaper::cuda,
-                         tolerance);
+  replacementRuleTestSet(proeCase, "cuda", RuntimePolicy::cuda, tolerance);
 }
   #endif
   #if defined(AXOM_USE_HIP)
 TEST(IntersectionShaperTest, proeCase_hip)
 {
   constexpr double tolerance = 1.e-10;
-  replacementRuleTestSet(proeCase, "hip", quest::IntersectionShaper::hip, tolerance);
+  replacementRuleTestSet(proeCase, "hip", RuntimePolicy::hip, tolerance);
 }
   #endif
 #endif
@@ -939,25 +941,25 @@ TEST(IntersectionShaperTest, proeCase_hip)
   #if defined(RUN_AXOM_SEQ_TESTS)
 TEST(IntersectionShaperTest, line_seq)
 {
-  dynamicRefinementTest_Line("seq", quest::IntersectionShaper::seq);
+  dynamicRefinementTest_Line("seq", RuntimePolicy::seq);
 }
   #endif
   #if defined(AXOM_USE_OPENMP)
 TEST(IntersectionShaperTest, line_omp)
 {
-  dynamicRefinementTest_Line("omp", quest::IntersectionShaper::omp);
+  dynamicRefinementTest_Line("omp", RuntimePolicy::omp);
 }
   #endif
   #if defined(AXOM_USE_CUDA)
 TEST(IntersectionShaperTest, line_cuda)
 {
-  dynamicRefinementTest_Line("cuda", quest::IntersectionShaper::cuda);
+  dynamicRefinementTest_Line("cuda", RuntimePolicy::cuda);
 }
   #endif
   #if defined(AXOM_USE_HIP)
 TEST(IntersectionShaperTest, line_hip)
 {
-  dynamicRefinementTest_Line("hip", quest::IntersectionShaper::hip);
+  dynamicRefinementTest_Line("hip", RuntimePolicy::hip);
 }
   #endif
 #endif
@@ -968,25 +970,25 @@ TEST(IntersectionShaperTest, line_hip)
   #if defined(RUN_AXOM_SEQ_TESTS)
 TEST(IntersectionShaperTest, cone_seq)
 {
-  dynamicRefinementTest_Cone("seq", quest::IntersectionShaper::seq);
+  dynamicRefinementTest_Cone("seq", RuntimePolicy::seq);
 }
   #endif
   #if defined(AXOM_USE_OPENMP)
 TEST(IntersectionShaperTest, cone_omp)
 {
-  dynamicRefinementTest_Cone("omp", quest::IntersectionShaper::omp);
+  dynamicRefinementTest_Cone("omp", RuntimePolicy::omp);
 }
   #endif
   #if defined(AXOM_USE_CUDA)
 TEST(IntersectionShaperTest, cone_cuda)
 {
-  dynamicRefinementTest_Cone("cuda", quest::IntersectionShaper::cuda);
+  dynamicRefinementTest_Cone("cuda", RuntimePolicy::cuda);
 }
   #endif
   #if defined(AXOM_USE_HIP)
 TEST(IntersectionShaperTest, cone_hip)
 {
-  dynamicRefinementTest_Cone("hip", quest::IntersectionShaper::hip);
+  dynamicRefinementTest_Cone("hip", RuntimePolicy::hip);
 }
   #endif
 #endif
@@ -997,25 +999,25 @@ TEST(IntersectionShaperTest, cone_hip)
   #if defined(RUN_AXOM_SEQ_TESTS)
 TEST(IntersectionShaperTest, spline_seq)
 {
-  dynamicRefinementTest_Spline("seq", quest::IntersectionShaper::seq);
+  dynamicRefinementTest_Spline("seq", RuntimePolicy::seq);
 }
   #endif
   #if defined(AXOM_USE_OPENMP)
 TEST(IntersectionShaperTest, spline_omp)
 {
-  dynamicRefinementTest_Spline("omp", quest::IntersectionShaper::omp);
+  dynamicRefinementTest_Spline("omp", RuntimePolicy::omp);
 }
   #endif
   #if defined(AXOM_USE_CUDA)
 TEST(IntersectionShaperTest, spline_cuda)
 {
-  dynamicRefinementTest_Spline("cuda", quest::IntersectionShaper::cuda);
+  dynamicRefinementTest_Spline("cuda", RuntimePolicy::cuda);
 }
   #endif
   #if defined(AXOM_USE_HIP)
 TEST(IntersectionShaperTest, spline_hip)
 {
-  dynamicRefinementTest_Spline("hip", quest::IntersectionShaper::hip);
+  dynamicRefinementTest_Spline("hip", RuntimePolicy::hip);
 }
   #endif
 #endif
@@ -1026,25 +1028,25 @@ TEST(IntersectionShaperTest, spline_hip)
   #if defined(RUN_AXOM_SEQ_TESTS)
 TEST(IntersectionShaperTest, circle_seq)
 {
-  dynamicRefinementTest_Circle("seq", quest::IntersectionShaper::seq);
+  dynamicRefinementTest_Circle("seq", RuntimePolicy::seq);
 }
   #endif
   #if defined(AXOM_USE_OPENMP)
 TEST(IntersectionShaperTest, circle_omp)
 {
-  dynamicRefinementTest_Circle("omp", quest::IntersectionShaper::omp);
+  dynamicRefinementTest_Circle("omp", RuntimePolicy::omp);
 }
   #endif
   #if defined(AXOM_USE_CUDA)
 TEST(IntersectionShaperTest, circle_cuda)
 {
-  dynamicRefinementTest_Circle("cuda", quest::IntersectionShaper::cuda);
+  dynamicRefinementTest_Circle("cuda", RuntimePolicy::cuda);
 }
   #endif
   #if defined(AXOM_USE_HIP)
 TEST(IntersectionShaperTest, circle_hip)
 {
-  dynamicRefinementTest_Circle("hip", quest::IntersectionShaper::hip);
+  dynamicRefinementTest_Circle("hip", RuntimePolicy::hip);
 }
   #endif
 #endif
@@ -1055,25 +1057,25 @@ TEST(IntersectionShaperTest, circle_hip)
   #if defined(RUN_AXOM_SEQ_TESTS)
 TEST(IntersectionShaperTest, line_translate_seq)
 {
-  dynamicRefinementTest_LineTranslate("seq", quest::IntersectionShaper::seq);
+  dynamicRefinementTest_LineTranslate("seq", RuntimePolicy::seq);
 }
   #endif
   #if defined(AXOM_USE_OPENMP)
 TEST(IntersectionShaperTest, line_translate_omp)
 {
-  dynamicRefinementTest_LineTranslate("omp", quest::IntersectionShaper::omp);
+  dynamicRefinementTest_LineTranslate("omp", RuntimePolicy::omp);
 }
   #endif
   #if defined(AXOM_USE_CUDA)
 TEST(IntersectionShaperTest, line_translate_cuda)
 {
-  dynamicRefinementTest_LineTranslate("cuda", quest::IntersectionShaper::cuda);
+  dynamicRefinementTest_LineTranslate("cuda", RuntimePolicy::cuda);
 }
   #endif
   #if defined(AXOM_USE_HIP)
 TEST(IntersectionShaperTest, line_translate_hip)
 {
-  dynamicRefinementTest_LineTranslate("hip", quest::IntersectionShaper::hip);
+  dynamicRefinementTest_LineTranslate("hip", RuntimePolicy::hip);
 }
   #endif
 #endif
@@ -1084,25 +1086,25 @@ TEST(IntersectionShaperTest, line_translate_hip)
   #if defined(RUN_AXOM_SEQ_TESTS)
 TEST(IntersectionShaperTest, line_scale_seq)
 {
-  dynamicRefinementTest_LineScale("seq", quest::IntersectionShaper::seq);
+  dynamicRefinementTest_LineScale("seq", RuntimePolicy::seq);
 }
   #endif
   #if defined(AXOM_USE_OPENMP)
 TEST(IntersectionShaperTest, line_scale_omp)
 {
-  dynamicRefinementTest_LineScale("omp", quest::IntersectionShaper::omp);
+  dynamicRefinementTest_LineScale("omp", RuntimePolicy::omp);
 }
   #endif
   #if defined(AXOM_USE_CUDA)
 TEST(IntersectionShaperTest, line_scale_cuda)
 {
-  dynamicRefinementTest_LineScale("cuda", quest::IntersectionShaper::cuda);
+  dynamicRefinementTest_LineScale("cuda", RuntimePolicy::cuda);
 }
   #endif
   #if defined(AXOM_USE_HIP)
 TEST(IntersectionShaperTest, line_scale_hip)
 {
-  dynamicRefinementTest_LineScale("hip", quest::IntersectionShaper::hip);
+  dynamicRefinementTest_LineScale("hip", RuntimePolicy::hip);
 }
   #endif
 #endif
@@ -1113,25 +1115,25 @@ TEST(IntersectionShaperTest, line_scale_hip)
   #if defined(RUN_AXOM_SEQ_TESTS)
 TEST(IntersectionShaperTest, line_rotate_seq)
 {
-  dynamicRefinementTest_LineRotate("seq", quest::IntersectionShaper::seq);
+  dynamicRefinementTest_LineRotate("seq", RuntimePolicy::seq);
 }
   #endif
   #if defined(AXOM_USE_OPENMP)
 TEST(IntersectionShaperTest, line_rotate_omp)
 {
-  dynamicRefinementTest_LineRotate("omp", quest::IntersectionShaper::omp);
+  dynamicRefinementTest_LineRotate("omp", RuntimePolicy::omp);
 }
   #endif
   #if defined(AXOM_USE_CUDA)
 TEST(IntersectionShaperTest, line_rotate_cuda)
 {
-  dynamicRefinementTest_LineRotate("cuda", quest::IntersectionShaper::cuda);
+  dynamicRefinementTest_LineRotate("cuda", RuntimePolicy::cuda);
 }
   #endif
   #if defined(AXOM_USE_HIP)
 TEST(IntersectionShaperTest, line_rotate_hip)
 {
-  dynamicRefinementTest_LineRotate("hip", quest::IntersectionShaper::hip);
+  dynamicRefinementTest_LineRotate("hip", RuntimePolicy::hip);
 }
   #endif
 #endif

--- a/src/docs/doxygen/Doxyfile.in
+++ b/src/docs/doxygen/Doxyfile.in
@@ -2067,7 +2067,10 @@ INCLUDE_FILE_PATTERNS  =
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED             = MINT_USE_SIDRE \
-                         AXOM_DEBUG
+                         AXOM_DEBUG \
+                         AXOM_RUNTIME_POLICY_USE_OPENMP \
+                         AXOM_RUNTIME_POLICY_USE_CUDA \
+                         AXOM_RUNTIME_POLICY_USE_HIP
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
# Refactor runtime policy selection code
We suport sequential, OpenMP, CUDA and HIP runtime policies and have examples that choose one at run time.
The motivation for this refactor are:
1. The code to define and specify policies is currently duplicated in two algorithms and their examples.
2. We can anticipate more library, example and test codes requiring this code.
3. Applications need this code, in the way the examples need it.

- This PR is a refactoring.
- It does the following:
  - Factor out `DistributedClosestPointRuntimePolicy` and `MarchingCubesRuntimePolicy` enums.
  - Add header `src/axom/core/execution/runtime_policy.hpp` where the factored code is moved.
  - Addresses issue https://github.com/LLNL/axom/issues/1193
  - Addresses application developer's request for factoring this out.