### PR TITLE
Fix axom::Array reallocation for non-trivially relocatable types

### DIFF
--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -1500,7 +1500,6 @@ inline void Array<T, DIM, SPACE>::setCapacity(IndexType new_capacity)
   OpHelper::realloc_move(new_data, m_num_elements, m_data, m_allocator_id);
 
   // Destroy the original array.
-  OpHelper::destroy(m_data, 0, m_num_elements, m_allocator_id);
   axom::deallocate(m_data);
 
   // Set the pointer and capacity to the new memory.

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -1020,6 +1020,7 @@ struct ArrayOpsBase<T, false>
     std::uninitialized_copy(std::make_move_iterator(values),
                             std::make_move_iterator(values + nelems),
                             array);
+    destroy(values, 0, nelems);
   }
 };
 

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -2308,3 +2308,28 @@ TEST(core_array, reserve_nontrivial_reloc)
     EXPECT_EQ(&(array[i].m_member), array[i].m_localMemberPointer);
   }
 }
+
+TEST(core_array, reserve_nontrivial_reloc_2)
+{
+  const int NUM_ELEMS = 1024;
+  axom::Array<NonTriviallyRelocatable> array(NUM_ELEMS, NUM_ELEMS);
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    // Check initial values.
+    EXPECT_EQ(array[i].m_member, NONTRIVIAL_RELOC_MAGIC);
+    EXPECT_EQ(&(array[i].m_member), array[i].m_localMemberPointer);
+  }
+
+  EXPECT_EQ(array.capacity(), NUM_ELEMS);
+
+  // Emplace to trigger a resize.
+  array.emplace_back(NonTriviallyRelocatable {});
+  EXPECT_GE(array.capacity(), NUM_ELEMS);
+
+  for(int i = 0; i < NUM_ELEMS + 1; i++)
+  {
+    EXPECT_EQ(array[i].m_member, NONTRIVIAL_RELOC_MAGIC);
+    EXPECT_EQ(&(array[i].m_member), array[i].m_localMemberPointer);
+  }
+}

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -2333,3 +2333,29 @@ TEST(core_array, reserve_nontrivial_reloc_2)
     EXPECT_EQ(&(array[i].m_member), array[i].m_localMemberPointer);
   }
 }
+
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
+TEST(core_array, reserve_nontrivial_reloc_um)
+{
+  const int NUM_ELEMS = 1024;
+  axom::Array<NonTriviallyRelocatable, 1, axom::MemorySpace::Unified> array(
+    NUM_ELEMS,
+    NUM_ELEMS);
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    // Check initial values.
+    EXPECT_EQ(array[i].m_member, NONTRIVIAL_RELOC_MAGIC);
+    EXPECT_EQ(&(array[i].m_member), array[i].m_localMemberPointer);
+  }
+
+  // Reallocation should work for non-trivially relocatable types.
+  array.reserve(NUM_ELEMS * 4);
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    EXPECT_EQ(array[i].m_member, NONTRIVIAL_RELOC_MAGIC);
+    EXPECT_EQ(&(array[i].m_member), array[i].m_localMemberPointer);
+  }
+}
+#endif


### PR DESCRIPTION
# Summary

A type is considered "trivially relocatable" if a bitcopy of the object can be treated as a "move-and-destroy" of the original object. Types which are not trivially-relocatable need to call the move or copy constructor in order to correctly construct the destination object.

This is usually the case when a type maintains a pointer/reference to itself; one example of a common type which is not trivially-relocatable is `std::string` in the GCC STL (more examples [here](https://quuxplusone.github.io/blog/2019/02/20/p1144-what-types-are-relocatable/))

This PR improves the handling of these non-trivially relocatable types in `axom::Array`, by ensuring that the move/copy constructor is called on non-trivially copyable types when reallocating the underlying memory.