### PR TITLE
Bugfix for `axom::utilities::locale`

### DIFF
--- a/src/axom/core/utilities/System.cpp
+++ b/src/axom/core/utilities/System.cpp
@@ -97,7 +97,7 @@ std::locale locale(const std::string& name)
   }
   catch(std::runtime_error&)
   {
-    loc = std::locale(loc, "", std::locale::ctype);
+    loc = std::locale(loc, "C", std::locale::ctype);
   }
 
   return loc;


### PR DESCRIPTION
Some systems throw an error on `std::locale("")` if there is no user-defined locale. 
Use `std::locale("C")` instead. 

#### Additional details:
* We originally encountered this inside a docker image.
* A user reported the problem w/ axom@0.8.1
* Cherry-picked commit from https://github.com/LLNL/axom/pull/1171

