### PR TITLE
Enable area computation for planar polygons with arbitrary orientation

### DIFF
--- a/src/axom/primal/geometry/Polygon.hpp
+++ b/src/axom/primal/geometry/Polygon.hpp
@@ -14,6 +14,7 @@
 
 #include "axom/core/Array.hpp"
 #include "axom/primal/geometry/Point.hpp"
+#include "axom/primal/geometry/Vector.hpp"
 
 #include <ostream>
 
@@ -142,27 +143,25 @@ public:
   typename std::enable_if<TDIM == 3, double>::type area() const
   {
     const int nVerts = numVertices();
-    double sum = 0.;
 
     // check for early return
     if(nVerts < 3)
     {
-      return sum;
+      return 0.0;
     }
 
     // Add up areas of triangles connecting polygon edges the vertex average
+    VectorType sum;
     const auto O = vertexMean();  // 'O' for (local) origin
     for(int curr = 0, prev = nVerts - 1; curr < nVerts; prev = curr++)
     {
-      const auto& P = m_vertices[prev];
-      const auto& C = m_vertices[curr];
-      // clang-format off
-      sum += axom::numerics::determinant(P[0] - O[0], C[0] - O[0],
-                                         P[1] - O[1], C[1] - O[1]);
-      // clang-format on
+      const VectorType v0(O, m_vertices[prev]);
+      const VectorType v1(O, m_vertices[curr]);
+
+      sum += VectorType::cross_product(v0, v1);
     }
 
-    return axom::utilities::abs(0.5 * sum);
+    return axom::utilities::abs(0.5 * sum.norm());
   }
 
   /**

--- a/src/axom/primal/tests/primal_polygon.cpp
+++ b/src/axom/primal/tests/primal_polygon.cpp
@@ -362,16 +362,21 @@ TEST(primal_polygon, area_2d_3d)
   using Point3D = axom::primal::Point<double, 3>;
 
   // test a simple right triangle
-  // use same xy-data in 2D and 3D
   {
     Polygon2D poly2D({Point2D {0, 0}, Point2D {1, 0}, Point2D {1, 1}});
     EXPECT_DOUBLE_EQ(.5, poly2D.area());
 
+    // in xy-plane
     Polygon3D poly3Da({Point3D {0, 0, 0}, Point3D {1, 0, 0}, Point3D {1, 1, 0}});
     EXPECT_DOUBLE_EQ(.5, poly3Da.area());
 
-    Polygon3D poly3Db({Point3D {0, 0, 1}, Point3D {1, 0, 1}, Point3D {1, 1, 1}});
+    // in xz-plane
+    Polygon3D poly3Db({Point3D {0, 0, 0}, Point3D {1, 0, 0}, Point3D {1, 0, 1}});
     EXPECT_DOUBLE_EQ(.5, poly3Db.area());
+
+    // in yz-plane
+    Polygon3D poly3Dc({Point3D {0, 0, 0}, Point3D {0, 1, 0}, Point3D {0, 1, 1}});
+    EXPECT_DOUBLE_EQ(.5, poly3Dc.area());
   }
 
   // test regular polygons


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Fixes the area computation for planar 3d polygons that are not parallel to the xy-plane 
