### PR TITLE
Turn host intrinsics back on for bit utilities

### DIFF
--- a/src/axom/core/utilities/BitUtilities.hpp
+++ b/src/axom/core/utilities/BitUtilities.hpp
@@ -23,14 +23,14 @@
 
 // Check for and setup defines for platform-specific intrinsics
 // Note: `__GNUC__` is defined for the gnu, clang and intel compilers
-#if defined(AXOM_USE_CUDA)
-  // Intrinsics included implicitly
-#elif defined(_WIN64) && (_MSC_VER >= 1600)
+#if defined(_WIN64) && (_MSC_VER >= 1600)
   #define _AXOM_CORE_USE_INTRINSICS_MSVC
   #include <intrin.h>
 #elif defined(__x86_64__) && defined(__GNUC__)
   #define _AXOM_CORE_USE_INTRINSICS_GCC
-  #include <x86intrin.h>
+  #if !defined(__CUDACC__)
+    #include <x86intrin.h>
+  #endif
 #elif defined(__powerpc64__) && (defined(__GNUC__) || defined(__ibmxl__))
   #define _AXOM_CORE_USE_INTRINSICS_PPC
 #endif


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Turns host intrinsics back on for bit utilities

Related issues:
[#798](https://github.com/LLNL/axom/issues/798)

Related PRs:
https://github.com/LLNL/axom/pull/1088
https://github.com/LLNL/axom/pull/1180

