### PR TITLE
Fix clipping of 3D triangle against axis-aligned bounding box

### DIFF
--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -82,14 +82,13 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
   {
     // Optimization note: we should be able to save some work based on
     // the clipping plane and the triangle's bounding box
-
-    if(triBox.getMax()[dim] > bbox.getMin()[dim])
+    if(triBox.getMin()[dim] < bbox.getMin()[dim])
     {
       axom::utilities::swap(prevPoly, currentPoly);
       detail::clipAxisPlane(prevPoly, currentPoly, 2 * dim + 0, bbox.getMin()[dim]);
     }
 
-    if(triBox.getMin()[dim] < bbox.getMax()[dim])
+    if(triBox.getMax()[dim] > bbox.getMax()[dim])
     {
       axom::utilities::swap(prevPoly, currentPoly);
       detail::clipAxisPlane(prevPoly, currentPoly, 2 * dim + 1, bbox.getMax()[dim]);

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -57,8 +57,11 @@ TEST(primal_clip, simple_clip)
 
     PointType {0.25, 0.25, 0.5},
     PointType {0.75, 0.25, 0.5},
-    PointType {0.66, 0.5, 0.5},
     PointType {1.5, 0.5, 0.5},
+
+    PointType {2, 1, 0.5},
+    PointType {2, 2, 0.5},
+    PointType {1, 2, 0.5},
   };
 
   {
@@ -94,13 +97,20 @@ TEST(primal_clip, simple_clip)
   }
 
   {
-    TriangleType tri(points[6], points[7], points[9]);
+    TriangleType tri(points[6], points[7], points[8]);
 
     PolygonType poly = axom::primal::clip(tri, bbox);
     EXPECT_EQ(4, poly.numVertices());
 
     SLIC_INFO("Intersection of triangle " << tri << " and bounding box " << bbox
                                           << " is polygon" << poly);
+  }
+
+  {
+    TriangleType tri(points[9], points[10], points[11]);
+
+    PolygonType poly = axom::primal::clip(tri, bbox);
+    EXPECT_EQ(0, poly.numVertices());
   }
 }
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Fixes clipping of 3D triangle against axis-aligned bounding box for cases without intersection (incorrectly returned non-empty polygons)
