### PR TITLE
Use new CI queue

### DIFF
--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -22,14 +22,14 @@
 .src_build_on_lassen:
   stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 25 -q pwdev -G wdev -alloc_flags atsdisable"
+    ALLOC_COMMAND: "lalloc 1 -W 25 -q pci -alloc_flags atsdisable"
   extends: [.src_build_script, .on_lassen, .src_workflow]
   needs: []
 
 .full_build_on_lassen:
   stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 45 -q pwdev -G wdev -alloc_flags atsdisable"
+    ALLOC_COMMAND: "lalloc 1 -W 45 -q pci -alloc_flags atsdisable"
   extends: [.full_build_script, .on_lassen, .full_workflow]
   needs: []
 

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -46,8 +46,6 @@ quartz_release:
 .src_build_on_quartz:
   stage: build
   variables:
-    # Use when ellastic ci is on quartz or we go back to ruby
-    # ALLOC_COMMAND: "srun --reservation=ci --qos=ci_ruby -t 60 -N 1 "
     ALLOC_COMMAND: "srun -t 60 -N 1 -p pdebug"
   extends: [.src_build_script, .on_quartz, .src_workflow]
   needs: [quartz_allocate]
@@ -55,8 +53,6 @@ quartz_release:
 .full_build_on_quartz:
   stage: build
   variables:
-    # Use when ellastic ci is on quartz or we go back to ruby
-    # ALLOC_COMMAND: "srun --reservation=ci --qos=ci_ruby -t 60 -N 1 "
     ALLOC_COMMAND: "srun -t 60 -N 1 -p pdebug"
   extends: [.full_build_script, .on_quartz, .full_workflow]
   needs: []

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -26,7 +26,7 @@ quartz_allocate:
   extends: [.on_quartz, .src_workflow]
   stage: allocate
   script:
-    - salloc -N 1 -c 36 -t 60 -p pdebug --res=ci --no-shell --job-name=${PROJECT_ALLOC_NAME}
+    - salloc -N 1 -c 36 -t 60 --res=ci --no-shell --job-name=${PROJECT_ALLOC_NAME}
   needs: []
 
 ####

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -10,7 +10,7 @@
     - shell
     - quartz
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_RUBY == "OFF"' #run except if ...
+    - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_QUARTZ == "OFF"' #run except if ...
       when: never
     - if: '$CI_JOB_NAME =~ /quartz_release/'
       when: always
@@ -26,9 +26,7 @@ quartz_allocate:
   extends: [.on_quartz, .src_workflow]
   stage: allocate
   script:
-    # Use when ellastic ci is on quartz or we go back to ruby
-    #- salloc --reservation=ci --qos=ci_ruby -N 1 -c 36 -t 60 --no-shell --job-name=${PROJECT_ALLOC_NAME}
-    - salloc -N 1 -c 36 -t 60 -p pdebug --no-shell --job-name=${PROJECT_ALLOC_NAME}
+    - salloc -N 1 -c 36 -t 60 -p pdebug --res=ci --no-shell --job-name=${PROJECT_ALLOC_NAME}
   needs: []
 
 ####

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -21,14 +21,14 @@
 .src_build_on_tioga:
   stage: build
   variables:
-    ALLOC_COMMAND: "flux mini run --exclusive --time-limit=30m --nodes=1"
+    ALLOC_COMMAND: "flux run --exclusive --time-limit=30m --nodes=1"
   extends: [.src_build_script, .on_tioga, .src_workflow]
   needs: []
 
 .full_build_on_tioga:
   stage: build
   variables:
-    ALLOC_COMMAND: "flux mini run --exclusive --time-limit=60m --nodes=1"
+    ALLOC_COMMAND: "flux run --exclusive --time-limit=60m --nodes=1"
   extends: [.full_build_script, .on_tioga, .full_workflow]
   needs: []
 


### PR DESCRIPTION
* Moves us to the new CI queue: https://lc.llnl.gov/confluence/display/GITLAB/Special+partitions+for+CI+batch+jobs
* Moves away from deprecated `flux mini` command