### PR TITLE
Log an explanatory message for quest_point_in_cell_mfem

### DIFF
--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -9,7 +9,7 @@
 "spack_packages_path": ["scripts/spack/radiuss-spack-configs/packages", "scripts/spack/packages"],
 "spack_concretizer": "clingo",
 "vcpkg_url": "https://github.com/microsoft/vcpkg",
-"vcpkg_commit": "52b52b4588b916152ff662f97842e03db83fa5d1",
+"vcpkg_commit": "c8696863d371ab7f46e213d8f5ca923c4aef2a00",
 "vcpkg_triplet": "x64-windows",
 "vcpkg_ports_path": "scripts/vcpkg_ports"
 }

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -9,7 +9,7 @@
 "spack_packages_path": ["scripts/spack/radiuss-spack-configs/packages", "scripts/spack/packages"],
 "spack_concretizer": "clingo",
 "vcpkg_url": "https://github.com/microsoft/vcpkg",
-"vcpkg_commit": "6f7ffeb18f99796233b958aaaf14ec7bd4fb64b2",
+"vcpkg_commit": "52b52b4588b916152ff662f97842e03db83fa5d1",
 "vcpkg_triplet": "x64-windows",
 "vcpkg_ports_path": "scripts/vcpkg_ports"
 }

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -49,6 +49,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ### Fixed
 - quest's `SamplingShaper` now properly handles material names containing underscores
 - quest's `SamplingShaper` can now be used with an mfem that is configured for (GPU) devices
+- Build system: updated to current version of vcpkg to successfully build TPLs on Windows
 
 ## [Version 0.8.1] - Release date 2023-08-16
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -55,7 +55,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - quest's `SamplingShaper` now properly handles material names containing underscores
 - quest's `SamplingShaper` can now be used with an mfem that is configured for (GPU) devices
 - primal's `Polygon` area computation in 3D previously only worked when the polygon was aligned with the XY-plane. It now works for arbitrary polygons.
-- Build system: updated to current version of vcpkg to successfully build TPLs on Windows
+- Upgrades our `vcpkg` usage for automated Windows builds of our TPLs to its [2023.12.12 release](https://github.com/microsoft/vcpkg/releases/tag/2023.12.12)
 
 ## [Version 0.8.1] - Release date 2023-08-16
 

--- a/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
+++ b/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
@@ -1679,13 +1679,17 @@ TYPED_TEST(PointInCell3DTest, pic_curved_refined_hex_jittered)
 void printSummary()
 {
 #ifdef AXOM_DEBUG
-    const std::string buildtype{ "DEBUG" };
+  const std::string buildtype {"DEBUG"};
 #else
-    const std::string buildtype{ "RELEASE" };
+  const std::string buildtype {"RELEASE"};
 #endif
-    SLIC_INFO(axom::fmt::format(
-        "{} build; running {} test points with {} refinements; grid resolution factor {}",
-        buildtype, NUM_TEST_PTS, NREFINE, TEST_GRID_RES));
+  SLIC_INFO(
+    axom::fmt::format("{} build; running {} test points with {} refinements; "
+                      "grid resolution factor {}",
+                      buildtype,
+                      NUM_TEST_PTS,
+                      NREFINE,
+                      TEST_GRID_RES));
 }
 
 int main(int argc, char* argv[])

--- a/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
+++ b/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
@@ -1676,6 +1676,18 @@ TYPED_TEST(PointInCell3DTest, pic_curved_refined_hex_jittered)
   this->testIsoGridPointsOnMesh(meshTypeStr);
 }
 
+void printSummary()
+{
+#ifdef AXOM_DEBUG
+    const std::string buildtype{ "DEBUG" };
+#else
+    const std::string buildtype{ "RELEASE" };
+#endif
+    SLIC_INFO(axom::fmt::format(
+        "{} build; running {} test points with {} refinements; grid resolution factor {}",
+        buildtype, NUM_TEST_PTS, NREFINE, TEST_GRID_RES));
+}
+
 int main(int argc, char* argv[])
 {
   int result = 0;
@@ -1685,6 +1697,9 @@ int main(int argc, char* argv[])
 
   std::srand(SRAND_SEED);
 
+  printSummary();
   result = RUN_ALL_TESTS();
+  printSummary();
+
   return result;
 }


### PR DESCRIPTION
# Summary

- This PR is a feature.
- It does the following:
  - Modifies/refactors test quest_point_in_cell_mfem to print out the size of the test.
  - Fixes #1222 
  - Updates vcpkg to the current state of their master branch, fixing a problem with downloading a now-missing TPL of vcpkg

# Design review

On 18 Dec 2023, we reviewed the issue linked, which is that the quest_point_in_cell_mfem test takes much longer when running release than debug.  @kennyweiss pointed out that the release build tests 10x more points and twice as many refinement steps than the debug build.  That explained the difference in runtime.   The message in this PR is an attempt to alert future developers to the different problem size between debug and release.
