### PR TITLE
Bugfix for primal's clip(triangle,bbox)

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -50,12 +50,14 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   returns the signed volume.
 - Primal: `intersection_volume()` operators changed from returning a signed
   volume to an unsigned volume.
+- Primal's `BoundingBox::contains(BoundingBox)`  now returns `true` when the input is empty
 
 ### Fixed
 - quest's `SamplingShaper` now properly handles material names containing underscores
 - quest's `SamplingShaper` can now be used with an mfem that is configured for (GPU) devices
 - primal's `Polygon` area computation in 3D previously only worked when the polygon was aligned with the XY-plane. It now works for arbitrary polygons.
 - Upgrades our `vcpkg` usage for automated Windows builds of our TPLs to its [2023.12.12 release](https://github.com/microsoft/vcpkg/releases/tag/2023.12.12)
+- Fixed a bug in the bounds checks for `primal::clip(Triangle, BoundingBox)`
 
 ## [Version 0.8.1] - Release date 2023-08-16
 

--- a/src/axom/mint/mesh/StructuredMesh.cpp
+++ b/src/axom/mint/mesh/StructuredMesh.cpp
@@ -57,6 +57,7 @@ void StructuredMesh::setExtent(int ndims, const int64* extent)
   }
 
   SLIC_ASSERT(numNodes == getNumberOfNodes());
+  AXOM_UNUSED_VAR(numNodes);
 
 #ifdef AXOM_MINT_USE_SIDRE
   if(hasSidreGroup())

--- a/src/axom/multimat/examples/traversal.cpp
+++ b/src/axom/multimat/examples/traversal.cpp
@@ -168,6 +168,8 @@ void various_traversal_methods(int nmats,
   timer.stop();
   SLIC_INFO("  Field1D: " << timer.elapsed() << " sec");
   SLIC_ASSERT(c_sum == sum);
+  AXOM_UNUSED_VAR(c_sum);
+  AXOM_UNUSED_VAR(sum);
 
   sum = 0;
   timer.reset();
@@ -203,6 +205,7 @@ void various_traversal_methods(int nmats,
   timer.stop();
   SLIC_INFO("  Field2D: " << timer.elapsed() << " sec");
   SLIC_ASSERT(x_sum == sum);
+  AXOM_UNUSED_VAR(x_sum);
 
   // ------- Dense Access ----------
   SLIC_INFO("\n -- Dense Access via map-- ");

--- a/src/axom/multimat/multimat.hpp
+++ b/src/axom/multimat/multimat.hpp
@@ -1055,21 +1055,21 @@ int MultiMat::addFieldArray_impl(const std::string& field_name,
   SLIC_ASSERT(m_fieldNameVec.size() == m_fieldSparsityLayoutVec.size());
   SLIC_ASSERT(m_fieldNameVec.size() == m_fieldStrideVec.size());
 
-  axom::IndexType set_size = 0;
+#ifdef AXOM_DEBUG
   if(field_mapping == FieldMapping::PER_CELL_MAT)
   {
     const BivariateSetType* s = get_mapped_biSet(data_layout, sparsity_layout);
     SLIC_ASSERT(s != nullptr);
-    set_size = s->size();
+    SLIC_ASSERT(s->size() * stride == data_arr.size());
   }
   else
   {
     SLIC_ASSERT(field_mapping == FieldMapping::PER_CELL ||
                 field_mapping == FieldMapping::PER_MAT);
     const RangeSetType& s = *getMappedRangeSet(field_mapping);
-    set_size = s.size();
+    SLIC_ASSERT(s.size() * stride == data_arr.size());
   }
-  SLIC_ASSERT(set_size * stride == data_arr.size());
+#endif
 
   m_fieldBackingVec.back() =
     std::make_unique<FieldBacking>(data_arr, owned, m_fieldAllocatorId);

--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -60,6 +60,7 @@ set( primal_headers
 
     operators/detail/clip_impl.hpp
     operators/detail/compute_moments_impl.hpp
+    operators/detail/fuzzy_comparators.hpp
     operators/detail/intersect_bezier_impl.hpp
     operators/detail/intersect_bounding_box_impl.hpp
     operators/detail/intersect_impl.hpp

--- a/src/axom/primal/geometry/BoundingBox.hpp
+++ b/src/axom/primal/geometry/BoundingBox.hpp
@@ -255,6 +255,7 @@ public:
    * \note We are allowing the other bounding box to have a different coordinate
    *  type. This should work as long as the two Ts are comparable with
    *  operator<().
+   * \note If \a otherBB is empty, we return true
    */
   template <typename OtherType>
   bool contains(const BoundingBox<OtherType, NDIMS>& otherBB) const;
@@ -438,7 +439,9 @@ template <typename T, int NDIMS>
 template <typename OtherT>
 bool BoundingBox<T, NDIMS>::contains(const BoundingBox<OtherT, NDIMS>& otherBB) const
 {
-  return this->contains(otherBB.getMin()) && this->contains(otherBB.getMax());
+  return otherBB.isValid()
+    ? this->contains(otherBB.getMin()) && this->contains(otherBB.getMax())
+    : true;
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/geometry/OrientedBoundingBox.hpp
+++ b/src/axom/primal/geometry/OrientedBoundingBox.hpp
@@ -518,19 +518,15 @@ void OrientedBoundingBox<T, NDIMS>::addPoint(Point<T, NDIMS> pt)
 template <typename T, int NDIMS>
 void OrientedBoundingBox<T, NDIMS>::addBox(OrientedBoundingBox<T, NDIMS> obb)
 {
-  SLIC_CHECK_MSG(obb.isValid(), "Passed in OBB is invalid.");
   if(!obb.isValid())
   {
     // don't do anything
     return;
   }
 
-  std::vector<Point<T, NDIMS>> res = obb.vertices();
-  int size = static_cast<int>(res.size());
-
-  for(int i = 0; i < size; i++)
+  for(const auto& vert : obb.vertices())
   {
-    this->addPoint(res[i]);
+    this->addPoint(vert);
   }
 }
 

--- a/src/axom/primal/geometry/OrientedBoundingBox.hpp
+++ b/src/axom/primal/geometry/OrientedBoundingBox.hpp
@@ -181,10 +181,9 @@ public:
   /*!
    * \brief Expands the box so it contains the passed in box.
    * \param obb [in] OBB to add in
-   * \note If obb is invalid, makes this invalid too.
-   * \note Expands the extents so this box contains obb. This loses
-   * optimality of the box; for a better fit use merge_boxes in
-   * primal/compute_bounding_box.
+   * \note If obb is invalid, this is a no-op
+   * \note Expands the extents so this box contains obb. This loses optimality of the box
+   * for a better fit use merge_boxes in primal/compute_bounding_box.
    * \post this->contains(obb) == true
    */
   void addBox(OrientedBoxType obb);

--- a/src/axom/primal/geometry/Ray.hpp
+++ b/src/axom/primal/geometry/Ray.hpp
@@ -162,4 +162,9 @@ std::ostream& operator<<(std::ostream& os, const Ray<T, NDIMS>& ray)
 }  // namespace primal
 }  // namespace axom
 
+/// Overload to format a primal::Ray using fmt
+template <typename T, int NDIMS>
+struct axom::fmt::formatter<axom::primal::Ray<T, NDIMS>> : ostream_formatter
+{ };
+
 #endif  // AXOM_PRIMAL_RAY_HPP_

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -50,16 +50,13 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
   using PolygonType = Polygon<T, 3>;
 
   // Use two polygons with pointers for 'back-buffer'-like swapping
-  const int MAX_VERTS = 6;
+  constexpr int MAX_VERTS = 6;
   PolygonType poly[2] = {PolygonType(MAX_VERTS), PolygonType(MAX_VERTS)};
   PolygonType* currentPoly = &poly[0];
   PolygonType* prevPoly = &poly[1];
 
   // First check if the triangle is contained in the bbox, if not we are empty
-  BoundingBoxType triBox;
-  triBox.addPoint(tri[0]);
-  triBox.addPoint(tri[1]);
-  triBox.addPoint(tri[2]);
+  BoundingBoxType triBox {tri[0], tri[1], tri[2]};
 
   if(!bbox.intersectsWith(triBox))
   {

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -82,14 +82,13 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
   {
     // Optimization note: we should be able to save some work based on
     // the clipping plane and the triangle's bounding box
-
-    if(triBox.getMax()[dim] > bbox.getMin()[dim])
+    if(triBox.getMin()[dim] < bbox.getMin()[dim])
     {
       axom::utilities::swap(prevPoly, currentPoly);
       detail::clipAxisPlane(prevPoly, currentPoly, 2 * dim + 0, bbox.getMin()[dim]);
     }
 
-    if(triBox.getMin()[dim] < bbox.getMax()[dim])
+    if(triBox.getMax()[dim] > bbox.getMax()[dim])
     {
       axom::utilities::swap(prevPoly, currentPoly);
       detail::clipAxisPlane(prevPoly, currentPoly, 2 * dim + 1, bbox.getMax()[dim]);

--- a/src/axom/primal/operators/compute_bounding_box.hpp
+++ b/src/axom/primal/operators/compute_bounding_box.hpp
@@ -22,6 +22,7 @@
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Triangle.hpp"
 #include "axom/primal/geometry/Quadrilateral.hpp"
+#include "axom/primal/geometry/Polygon.hpp"
 #include "axom/primal/geometry/Vector.hpp"
 #include "axom/primal/geometry/OrientedBoundingBox.hpp"
 
@@ -169,8 +170,8 @@ template <typename T, int NDIMS>
 AXOM_HOST_DEVICE BoundingBox<T, NDIMS> compute_bounding_box(
   const Polyhedron<T, NDIMS> &poly)
 {
-  BoundingBox<T, NDIMS> res(poly[0]);
-  for(int i = 1; i < poly.numVertices(); i++)
+  BoundingBox<T, NDIMS> res;
+  for(int i = 0; i < poly.numVertices(); i++)
   {
     res.addPoint(poly[i]);
   }
@@ -180,13 +181,30 @@ AXOM_HOST_DEVICE BoundingBox<T, NDIMS> compute_bounding_box(
 /*!
  * \brief Creates a bounding box around a Tetrahedron
  *
- * \param [in] tet The Tetrahedron
+ * \param [in] tet The tetrahedron
  */
 template <typename T, int NDIMS>
 AXOM_HOST_DEVICE BoundingBox<T, NDIMS> compute_bounding_box(
   const Tetrahedron<T, NDIMS> &tet)
 {
   return BoundingBox<T, NDIMS> {tet[0], tet[1], tet[2], tet[3]};
+}
+
+/*!
+ * \brief Creates a bounding box around a Polygon
+ *
+ * \param [in] poly The polygon
+ */
+template <typename T, int NDIMS>
+AXOM_HOST_DEVICE BoundingBox<T, NDIMS> compute_bounding_box(
+  const Polygon<T, NDIMS> &poly)
+{
+  BoundingBox<T, NDIMS> res;
+  for(int i = 0; i < poly.numVertices(); ++i)
+  {
+    res.addPoint(poly[i]);
+  }
+  return res;
 }
 
 }  // namespace primal

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -106,10 +106,11 @@ Point<T, NDIMS> findIntersectionPoint(const Point<T, NDIMS>& a,
   // * pt = a + t * (b-a)
   // * pt[ index/2]  == val
 
-  T t = (val - a[index / 2]) / (b[index / 2] - a[index / 2]);
+  const int coord = index / 2;
+  const T t = (val - a[coord]) / (b[coord] - a[coord]);
   SLIC_ASSERT(0. <= t && t <= 1.);
 
-  auto ret = PointType::lerp(a, b, t);
+  const auto ret = PointType::lerp(a, b, t);
   SLIC_ASSERT(classifyPointAxisPlane(ret, index, val) == ON_BOUNDARY);
 
   return ret;

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -68,7 +68,7 @@ int classifyPointAxisPlane(const Point<T, NDIMS>& pt,
   // Note: we are exploiting the fact that the planes are axis aligned
   // So the dot product is +/- the given coordinate.
   // In general, we would need to call distance(pt, plane) here
-  T dist = isEven(index) ? val - pt[index / 2] : pt[index / 2] - val;
+  const T dist = isEven(index) ? val - pt[index / 2] : pt[index / 2] - val;
 
   if(dist > eps)
   {
@@ -109,7 +109,7 @@ Point<T, NDIMS> findIntersectionPoint(const Point<T, NDIMS>& a,
   T t = (val - a[index / 2]) / (b[index / 2] - a[index / 2]);
   SLIC_ASSERT(0. <= t && t <= 1.);
 
-  PointType ret = PointType(a.array() + t * (b.array() - a.array()));
+  auto ret = PointType::lerp(a, b, t);
   SLIC_ASSERT(classifyPointAxisPlane(ret, index, val) == ON_BOUNDARY);
 
   return ret;
@@ -142,7 +142,7 @@ void clipAxisPlane(const Polygon<T, NDIMS>* prevPoly,
   using PointType = Point<T, NDIMS>;
 
   currentPoly->clear();
-  int numVerts = prevPoly->numVertices();
+  const int numVerts = prevPoly->numVertices();
 
   if(numVerts == 0)
   {
@@ -156,7 +156,7 @@ void clipAxisPlane(const Polygon<T, NDIMS>* prevPoly,
   for(int i = 0; i < numVerts; ++i)
   {
     const PointType* b = &(*prevPoly)[i];
-    int bSide = classifyPointAxisPlane(*b, index, val);
+    const int bSide = classifyPointAxisPlane(*b, index, val);
 
     switch(bSide)
     {

--- a/src/axom/primal/operators/detail/fuzzy_comparators.hpp
+++ b/src/axom/primal/operators/detail/fuzzy_comparators.hpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ * \file fuzzy_comparators.hpp
+ *
+ * This file provides helper functions for fuzzy comparisons
+ */
+
+#ifndef AXOM_PRIMAL_FUZZY_COMPARATORS_HPP_
+#define AXOM_PRIMAL_FUZZY_COMPARATORS_HPP_
+
+#include "axom/core/Macros.hpp"
+#include "axom/core/utilities/Utilities.hpp"
+
+namespace axom
+{
+namespace primal
+{
+namespace detail
+{
+/// \brief Checks if x > y, within a specified tolerance.
+AXOM_HOST_DEVICE
+inline bool isGt(double x, double y, double EPS = 1e-12)
+{
+  return ((x > y) && !(axom::utilities::isNearlyEqual(x, y, EPS)));
+}
+
+/// \brief Checks if x < y, within a specified tolerance.
+AXOM_HOST_DEVICE
+inline bool isLt(double x, double y, double EPS = 1e-12)
+{
+  return ((x < y) && !(axom::utilities::isNearlyEqual(x, y, EPS)));
+}
+
+/// \brief Checks if x <= y, within a specified tolerance.
+AXOM_HOST_DEVICE
+inline bool isLeq(double x, double y, double EPS = 1e-12)
+{
+  return !(isGt(x, y, EPS));
+}
+
+/// \brief Checks if x >= y, within a specified tolerance.
+AXOM_HOST_DEVICE
+inline bool isGeq(double x, double y, double EPS = 1e-12)
+{
+  return !(isLt(x, y, EPS));
+}
+
+/*!
+ * \brief Checks if x < y, or possibly x == y, within a specified tolerance.
+ *
+ * The check for equality is controlled by parameter includeEqual.  This
+ * lets users specify at compile time whether triangles intersecting only on
+ * border points are reported as intersecting or not.
+ *
+ * Supports checkEdge and checkVertex
+ */
+AXOM_HOST_DEVICE
+inline bool isLpeq(double x, double y, bool includeEqual = false, double EPS = 1e-12)
+{
+  if(includeEqual && axom::utilities::isNearlyEqual(x, y, EPS))
+  {
+    return true;
+  }
+
+  return isLt(x, y, EPS);
+}
+
+/*!
+ * \brief Checks if x > y, or possibly x == y, within a specified tolerance.
+ *
+ * The check for equality is controlled by parameter includeEqual.  This
+ * lets users specify at compile time whether triangles intersecting only on
+ * border points are reported as intersecting or not.
+ *
+ * Supports checkEdge and checkVertex
+ */
+AXOM_HOST_DEVICE
+inline bool isGpeq(double x, double y, bool includeEqual = false, double EPS = 1e-12)
+{
+  if(includeEqual && axom::utilities::isNearlyEqual(x, y, EPS))
+  {
+    return true;
+  }
+
+  return isGt(x, y, EPS);
+}
+
+}  // namespace detail
+}  // namespace primal
+}  // namespace axom
+
+#endif  // AXOM_PRIMAL_FUZZY_COMPARATORS_HPP_

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -17,6 +17,7 @@
 #include "axom/core/numerics/Determinants.hpp"
 #include "axom/core/utilities/Utilities.hpp"
 
+#include "axom/primal/operators/detail/fuzzy_comparators.hpp"
 #include "axom/primal/geometry/BoundingBox.hpp"
 #include "axom/primal/geometry/OrientedBoundingBox.hpp"
 #include "axom/primal/geometry/Plane.hpp"
@@ -38,24 +39,6 @@ using Point3 = primal::Point<double, 3>;
 using Triangle3 = primal::Triangle<double, 3>;
 using Triangle2 = primal::Triangle<double, 2>;
 using Point2 = primal::Point<double, 2>;
-
-AXOM_HOST_DEVICE
-bool isGt(double x, double y, double EPS = 1E-12);
-
-AXOM_HOST_DEVICE
-bool isLt(double x, double y, double EPS = 1E-12);
-
-AXOM_HOST_DEVICE
-bool isLeq(double x, double y, double EPS = 1E-12);
-
-AXOM_HOST_DEVICE
-bool isLpeq(double x, double y, bool includeEqual = false, double EPS = 1E-12);
-
-AXOM_HOST_DEVICE
-bool isGeq(double x, double y, double EPS = 1E-12);
-
-AXOM_HOST_DEVICE
-bool isGpeq(double x, double y, bool includeEqual = false, double EPS = 1E-12);
 
 AXOM_HOST_DEVICE
 bool nonzeroSignMatch(double x, double y, double z, double EPS = 1E-12);
@@ -564,76 +547,6 @@ AXOM_HOST_DEVICE
 inline double twoDcross(const Point2& A, const Point2& B, const Point2& C)
 {
   return (((A[0] - C[0]) * (B[1] - C[1]) - (A[1] - C[1]) * (B[0] - C[0])));
-}
-
-/*!
- * \brief Checks if x > y, within a specified tolerance.
- */
-AXOM_HOST_DEVICE
-inline bool isGt(double x, double y, double EPS)
-{
-  return ((x > y) && !(axom::utilities::isNearlyEqual(x, y, EPS)));
-}
-
-/*!
- * \brief Checks if x < y, within a specified tolerance.
- */
-AXOM_HOST_DEVICE
-inline bool isLt(double x, double y, double EPS)
-{
-  return ((x < y) && !(axom::utilities::isNearlyEqual(x, y, EPS)));
-}
-
-/*!
- * \brief Checks if x <= y, within a specified tolerance.
- */
-AXOM_HOST_DEVICE
-inline bool isLeq(double x, double y, double EPS) { return !(isGt(x, y, EPS)); }
-
-/*!
- * \brief Checks if x < y, or possibly x == y, within a specified tolerance.
- *
- * The check for equality is controlled by parameter includeEqual.  This
- * lets users specify at compile time whether triangles intersecting only on
- * border points are reported as intersecting or not.
- *
- * Supports checkEdge and checkVertex
- */
-AXOM_HOST_DEVICE
-inline bool isLpeq(double x, double y, bool includeEqual, double EPS)
-{
-  if(includeEqual && axom::utilities::isNearlyEqual(x, y, EPS))
-  {
-    return true;
-  }
-
-  return isLt(x, y, EPS);
-}
-
-/*!
- * \brief Checks if x >= y, within a specified tolerance.
- */
-AXOM_HOST_DEVICE
-inline bool isGeq(double x, double y, double EPS) { return !(isLt(x, y, EPS)); }
-
-/*!
- * \brief Checks if x > y, or possibly x == y, within a specified tolerance.
- *
- * The check for equality is controlled by parameter includeEqual.  This
- * lets users specify at compile time whether triangles intersecting only on
- * border points are reported as intersecting or not.
- *
- * Supports checkEdge and checkVertex
- */
-AXOM_HOST_DEVICE
-inline bool isGpeq(double x, double y, bool includeEqual, double EPS)
-{
-  if(includeEqual && axom::utilities::isNearlyEqual(x, y, EPS))
-  {
-    return true;
-  }
-
-  return isGt(x, y, EPS);
 }
 
 /*!

--- a/src/axom/primal/tests/primal_bezier_patch.cpp
+++ b/src/axom/primal/tests/primal_bezier_patch.cpp
@@ -555,14 +555,13 @@ TEST(primal_bezierpatch, normal)
 //------------------------------------------------------------------------------
 TEST(primal_bezierpatch, rational_evaluation)
 {
-  const int DIM = 3;
+  constexpr int DIM = 3;
   using CoordType = double;
   using PointType = primal::Point<CoordType, DIM>;
-  using VectorType = primal::Vector<CoordType, DIM>;
   using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
 
-  const int max_order_u = 3;
-  const int order_v = 4;
+  constexpr int max_order_u = 3;
+  constexpr int order_v = 4;
 
   // clang-format off
   PointType controlPoints[(max_order_u + 1) * (order_v + 1)] = {

--- a/src/axom/primal/tests/primal_boundingbox.cpp
+++ b/src/axom/primal/tests/primal_boundingbox.cpp
@@ -14,7 +14,7 @@
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/BoundingBox.hpp"
 
-using namespace axom;
+namespace primal = axom::primal;
 
 //------------------------------------------------------------------------------
 template <typename ExecSpace>
@@ -48,10 +48,10 @@ void check_bb_policy()
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_default_constructor)
 {
-  static const int DIM = 2;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
+  constexpr int DIM = 2;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
 
   QBBox bbox;
   EXPECT_FALSE(bbox.isValid()) << "Default constructed bounding box is invalid";
@@ -64,10 +64,10 @@ TEST(primal_boundingBox, bb_default_constructor)
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_ctor_from_singlePt)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
 
   QPoint pt1;
   QPoint pt2(2);
@@ -92,10 +92,10 @@ TEST(primal_boundingBox, bb_ctor_from_singlePt)
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_ctor_from_twoPoints)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
 
   QPoint pt1(1);
   QPoint pt2(3);
@@ -129,7 +129,6 @@ TEST(primal_boundingBox, bb_ctor_from_twoPoints)
   const int val = 10;
   QPoint pt101 = QPoint::make_point(val, 0, val);
   QPoint pt010 = QPoint::make_point(0, val, 0);
-  ;
   QPoint midPt2 = QPoint::midpoint(pt101, pt010);
 
   QBBox bbox3(pt101, pt010);
@@ -146,10 +145,10 @@ TEST(primal_boundingBox, bb_ctor_from_twoPoints)
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_ctor_from_many_points)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
 
   // test single point
   QPoint pt1(0.);
@@ -179,10 +178,10 @@ TEST(primal_boundingBox, bb_ctor_from_many_points)
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_addPoint)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
 
   QPoint pt1(1);
   QPoint pt2(3);
@@ -203,8 +202,7 @@ TEST(primal_boundingBox, bb_addPoint)
   bbox1.addPoint(pt10);
   EXPECT_TRUE(bbox1.contains(pt10));
 
-  // Testing that if we add a point, then points outside the bounds remain
-  // outside
+  // Testing that if we add a point, then points outside the bounds remain outside
   EXPECT_FALSE(bbox1.contains(pt30));
   bbox1.addPoint(pt20);  // note: adding 20, but testing 30
   EXPECT_FALSE(bbox1.contains(pt30));
@@ -213,10 +211,10 @@ TEST(primal_boundingBox, bb_addPoint)
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_test_clear)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
 
   QPoint pt1(1);
   QPoint pt2(3);
@@ -242,10 +240,10 @@ TEST(primal_boundingBox, bb_test_clear)
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_copy_and_assignment)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
 
   QPoint pt1(1);
   QPoint pt2(3);
@@ -261,8 +259,7 @@ TEST(primal_boundingBox, bb_copy_and_assignment)
   EXPECT_EQ(bbox1.getMax(), bbox2.getMax());
   EXPECT_TRUE(bbox2.contains(midPt));
 
-  QBBox bbox3(pt2);  // some initialization that we don't care
-                     // about
+  QBBox bbox3(pt2);  // some initialization that we don't care about
   EXPECT_TRUE(bbox3.isValid());
   EXPECT_FALSE(bbox3.contains(pt1));
   bbox3 = bbox1;  // assignment operation
@@ -284,10 +281,10 @@ TEST(primal_boundingBox, bb_copy_and_assignment)
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_test_equality)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
 
   QPoint pt1(1);
   QPoint pt2(3);
@@ -325,10 +322,10 @@ TEST(primal_boundingBox, bb_test_equality)
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_add_box)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
 
   //
   SLIC_INFO("Testing addBox() for two simple bounding boxes");
@@ -395,12 +392,12 @@ TEST(primal_boundingBox, bb_add_box)
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_different_coord_types)
 {
-  static const int DIM = 3;
-  typedef primal::Point<double, DIM> PointD;
-  typedef primal::BoundingBox<double, DIM> BBoxD;
+  constexpr int DIM = 3;
+  using PointD = primal::Point<double, DIM>;
+  using BBoxD = primal::BoundingBox<double, DIM>;
 
-  typedef primal::Point<int, DIM> PointI;
-  typedef primal::BoundingBox<int, DIM> BBoxI;
+  using PointI = primal::Point<int, DIM>;
+  using BBoxI = primal::BoundingBox<int, DIM>;
 
   // checking that an integer point is in the double bounding box
   BBoxD dBox(PointD(1.), PointD(3.));
@@ -429,12 +426,73 @@ TEST(primal_boundingBox, bb_different_coord_types)
 }
 
 //------------------------------------------------------------------------------
+TEST(primal_boundingBox, bb_contains_bb)
+{
+  constexpr int DIM = 3;
+  constexpr double ONE_THIRD = 1. / 3.;
+  constexpr double TWO_THIRDS = 2. / 3.;
+
+  using PointD = primal::Point<double, DIM>;
+  using BBoxD = primal::BoundingBox<double, DIM>;
+
+  BBoxD unit_box;
+  unit_box.addPoint(PointD(0.));
+  unit_box.addPoint(PointD(1.));
+
+  const BBoxD empty_box;
+  const BBoxD empty_box2;
+
+  // check identity
+  {
+    EXPECT_TRUE(unit_box.contains(unit_box));
+  }
+
+  // check contains w/ empty boxes
+  {
+    EXPECT_TRUE(unit_box.contains(empty_box));
+    EXPECT_FALSE(empty_box.contains(unit_box));
+
+    EXPECT_TRUE(empty_box.contains(empty_box2));
+  }
+
+  // check full overlap
+  {
+    BBoxD other_box;
+    other_box.addPoint(PointD(ONE_THIRD));
+    other_box.addPoint(PointD(TWO_THIRDS));
+
+    EXPECT_TRUE(unit_box.contains(other_box));
+    EXPECT_FALSE(other_box.contains(unit_box));
+  }
+
+  // check full overlap, one point at boundary
+  {
+    BBoxD other_box;
+    other_box.addPoint(PointD(ONE_THIRD));
+    other_box.addPoint(PointD(1.));
+
+    EXPECT_TRUE(unit_box.contains(other_box));
+    EXPECT_FALSE(other_box.contains(unit_box));
+  }
+
+  // check partial overlap
+  {
+    BBoxD other_box;
+    other_box.addPoint(PointD(0.5));
+    other_box.addPoint(PointD(1.5));
+
+    EXPECT_FALSE(unit_box.contains(other_box));
+    EXPECT_FALSE(other_box.contains(unit_box));
+  }
+}
+
+//------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_expand)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
 
   //
   SLIC_INFO("Testing bounding box inflate");
@@ -467,10 +525,10 @@ TEST(primal_boundingBox, bb_expand)
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_scale)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
 
   //
   SLIC_INFO("Testing bounding box scale");
@@ -515,11 +573,11 @@ TEST(primal_boundingBox, bb_scale)
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_shift)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
-  typedef primal::Vector<CoordType, DIM> QVec;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
+  using QVec = primal::Vector<CoordType, DIM>;
 
   //
   SLIC_INFO("Testing bounding box shift");
@@ -545,9 +603,7 @@ TEST(primal_boundingBox, bb_shift)
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, highest_lowest_values)
 {
-  using namespace axom::primal;
-
-  static const int DIM = 3;
+  constexpr int DIM = 3;
 
   // Testing that our type trait for highest and lowest values
   // is doing the right thing in our CXX11 and pre-CXX11 compilers
@@ -576,27 +632,24 @@ TEST(primal_boundingBox, highest_lowest_values)
   EXPECT_EQ(maxU, std::numeric_limits<unsigned int>::max());
   EXPECT_EQ(minU, std::numeric_limits<unsigned int>::lowest());
 
-  // Testing that our default constructor for bounding boxes is properly
-  // setting the range.
+  // Testing that our default constructor for bounding boxes is properly setting the range.
 
-  // Note: The bounds are intentionally in the reverse order -- this is how we
-  // ensure
-  // that adding a point to an empty bounding box always updates the bounds
-  // properly
+  // Note: The bounds are intentionally in the reverse order -- this is how we ensure
+  // that adding a point to an empty bounding box always updates the bounds properly
 
-  typedef primal::BoundingBox<double, DIM> BBoxD;
+  using BBoxD = primal::BoundingBox<double, DIM>;
   EXPECT_TRUE(BBoxD().getMin()[0] > 0);
   EXPECT_TRUE(BBoxD().getMax()[0] < 0);
 
-  typedef primal::BoundingBox<float, DIM> BBoxF;
+  using BBoxF = primal::BoundingBox<float, DIM>;
   EXPECT_TRUE(BBoxF().getMin()[0] > 0);
   EXPECT_TRUE(BBoxF().getMax()[0] < 0);
 
-  typedef primal::BoundingBox<int, DIM> BBoxI;
+  using BBoxI = primal::BoundingBox<int, DIM>;
   EXPECT_TRUE(BBoxI().getMin()[0] > 0);
   EXPECT_TRUE(BBoxI().getMax()[0] < 0);
 
-  typedef primal::BoundingBox<unsigned int, DIM> BBoxU;
+  using BBoxU = primal::BoundingBox<unsigned int, DIM>;
   EXPECT_TRUE(BBoxU().getMin()[0] > 0);
   EXPECT_TRUE(BBoxU().getMax()[0] == 0);
 }
@@ -604,19 +657,19 @@ TEST(primal_boundingBox, highest_lowest_values)
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_longest_dimension)
 {
-  typedef primal::Point<double, 2> PointType;
-  typedef primal::BoundingBox<double, 2> BoxType;
+  using PointType = primal::Point<double, 2>;
+  using BoxType = primal::BoundingBox<double, 2>;
 
-  BoxType bbox(PointType::zero(), PointType::make_point(5.0, 10.0));
-  int longest_dimension = bbox.getLongestDimension();
+  const BoxType bbox(PointType::zero(), PointType::make_point(5.0, 10.0));
+  const int longest_dimension = bbox.getLongestDimension();
   EXPECT_EQ(1, longest_dimension);
 }
 
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_bisect)
 {
-  typedef primal::Point<double, 2> PointType;
-  typedef primal::BoundingBox<double, 2> BoxType;
+  using PointType = primal::Point<double, 2>;
+  using BoxType = primal::BoundingBox<double, 2>;
 
   BoxType bbox(PointType::zero(), PointType::ones());
 
@@ -642,8 +695,8 @@ TEST(primal_boundingBox, bb_bisect)
 //------------------------------------------------------------------------------
 TEST(primal_boundingBox, bb_get_centroid)
 {
-  typedef primal::Point<double, 2> PointType;
-  typedef primal::BoundingBox<double, 2> BoxType;
+  using PointType = primal::Point<double, 2>;
+  using BoxType = primal::BoundingBox<double, 2>;
 
   BoxType bbox(PointType::zero(), PointType::ones());
   PointType centroid = bbox.getCentroid();

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -20,6 +20,7 @@
 #include "axom/primal/operators/clip.hpp"
 #include "axom/primal/operators/intersection_volume.hpp"
 #include "axom/primal/operators/split.hpp"
+#include "axom/primal/operators/compute_bounding_box.hpp"
 
 #include <limits>
 
@@ -41,159 +42,120 @@ using PolyhedronType = axom::primal::Polyhedron<double, 3>;
 TEST(primal_clip, simple_clip)
 {
   using namespace Primal3D;
-  constexpr double EPS = 1e-8;
 
   // all checks in this test are against the cube [-1,-1,-1] to [1,1,1]
   BoundingBoxType bbox;
   bbox.addPoint(PointType {-1, -1, -1});
   bbox.addPoint(PointType {1, 1, 1});
 
-  const std::string print_template =
-    "Intersection of triangle {} and bbox {} is polygon {}";
+  // define a slightly inflated bbox for containment tests
+  constexpr double EPS = 1e-8;
+  BoundingBoxType expanded_bbox(bbox);
+  expanded_bbox.expand(EPS);
 
-  // this triangle is clearly outside the reference cube
+  std::vector<std::pair<TriangleType, int>> test_cases;
+
+  // add a bunch of test cases
   {
-    TriangleType tri(PointType {2, 2, 2},
-                     PointType {2, 2, 4},
-                     PointType {2, 4, 2});
+    // this triangle is clearly outside the reference cube
+    test_cases.push_back(std::make_pair(
+      TriangleType {PointType {2, 2, 2}, PointType {2, 2, 4}, PointType {2, 4, 2}},
+      0));
 
-    PolygonType poly = axom::primal::clip(tri, bbox);
-    EXPECT_EQ(0, poly.numVertices());
+    // triangle at z=0 that spans entire cube
+    test_cases.push_back(std::make_pair(TriangleType {PointType {-100, -100, 0.},
+                                                      PointType {-100, 100, 0.},
+                                                      PointType {100, 0, 0.}},
+                                        4));
+
+    // triangle at z=0 w/ two vertices inside unit cube
+    test_cases.push_back(std::make_pair(TriangleType {PointType {0.25, 0.25, 0.},
+                                                      PointType {0.75, 0.25, 0.},
+                                                      PointType {1.5, 0.5, 0.}},
+                                        4));
+
+    // triangle at z=0 w/ vertices aligned w/ bounding box planes
+    test_cases.push_back(std::make_pair(TriangleType {PointType {2, 1, 0.},
+                                                      PointType {2, 2, 0.},
+                                                      PointType {1, 2, 0.}},
+                                        0));
+
+    // triangle at z=0 w/ one vertex coincident w/ cube
+    test_cases.push_back(std::make_pair(TriangleType {PointType {1, 2, 0.},
+                                                      PointType {1, 1, 0.},
+                                                      PointType {2, 1, 0.}},
+                                        0));
+
+    // triangle at z=0 w/ one edge midpoint coincident w/ cube
+    test_cases.push_back(std::make_pair(TriangleType {PointType {0, 2, 0.},
+                                                      PointType {2, 0, 0.},
+                                                      PointType {2, 2, 0.}},
+                                        0));
+
+    // triangle at z=0 w/ one edge coincident w/ unit cube and the other outside
+    test_cases.push_back(std::make_pair(TriangleType {PointType {-10, 1, 0.},
+                                                      PointType {10, 1, 0.},
+                                                      PointType {0, 10, 0.}},
+                                        0));
+
+    // triangle at z=0 w/ one edge coincident w/ unit cube and the last vertex inside
+    test_cases.push_back(std::make_pair(TriangleType {PointType {-10, 1, 0.},
+                                                      PointType {10, 1, 0.},
+                                                      PointType {0, 0, 0.}},
+                                        5));
+
+    // triangle at z=0 w/ one edge coincident w/ unit cube and the last vertex on the other side
+    test_cases.push_back(std::make_pair(TriangleType {PointType {-10, 1, 0.},
+                                                      PointType {10, 1, 0.},
+                                                      PointType {0, -10, 0.}},
+                                        4));
+
+    // triangle at z=1 w/ one edge coincident w/ unit cube and the last vertex on the other side
+    test_cases.push_back(std::make_pair(TriangleType {PointType {-10, 1, 1.},
+                                                      PointType {10, 1, 1.},
+                                                      PointType {0, -10, 1.}},
+                                        4));
+
+    // triangle at z=.5 w/ two vertices inside cube and one to the left
+    test_cases.push_back(std::make_pair(TriangleType {PointType {-2, .25, .5},
+                                                      PointType {.25, .25, .5},
+                                                      PointType {.25, .75, .5}},
+                                        4));
+
+    // triangle at z=.5 w/ two vertices inside cube and one to the left
+    test_cases.push_back(std::make_pair(TriangleType {PointType {-2, .25, .5},
+                                                      PointType {.75, .25, .5},
+                                                      PointType {.75, .75, .5}},
+                                        4));
+
+    // all vertices outside cube, one vertex above, one vertex to the left and one to the top left
+    test_cases.push_back(std::make_pair(TriangleType {PointType {.9, 100, .5},
+                                                      PointType {100, -1, .5},
+                                                      PointType {100, 100, .5}},
+                                        0));
   }
 
-  // triangle at z=0 that spans entire cube
+  // check each test case
+  for(const auto& pair : test_cases)
   {
-    TriangleType tri(PointType {-100, -100, 0.},
-                     PointType {-100, 100, 0.},
-                     PointType {100, 0, 0.});
+    const auto& tri = pair.first;
+    const int expected_verts = pair.second;
 
     PolygonType poly = axom::primal::clip(tri, bbox);
-    EXPECT_EQ(4, poly.numVertices());
 
-    EXPECT_NEAR(0., poly.vertexMean()[0], EPS);
-    EXPECT_NEAR(0., poly.vertexMean()[1], EPS);
-    EXPECT_NEAR(0., poly.vertexMean()[2], EPS);
+    SLIC_INFO(
+      axom::fmt::format("Intersection of triangle {} and bbox {} is polygon {}",
+                        tri,
+                        bbox,
+                        poly));
 
-    SLIC_INFO(axom::fmt::format(print_template, tri, bbox, poly));
-  }
-
-  // triangle at z=0 w/ two vertices inside unit cube
-  {
-    TriangleType tri(PointType {0.25, 0.25, 0.},
-                     PointType {0.75, 0.25, 0.},
-                     PointType {1.5, 0.5, 0.});
-
-    PolygonType poly = axom::primal::clip(tri, bbox);
-    EXPECT_EQ(4, poly.numVertices());
-
-    SLIC_INFO(axom::fmt::format(print_template, tri, bbox, poly));
-  }
-
-  // triangle at z=0 w/ vertices aligned w/ bounding box planes
-  {
-    TriangleType tri(PointType {2, 1, 0.},
-                     PointType {2, 2, 0.},
-                     PointType {1, 2, 0.});
-
-    PolygonType poly = axom::primal::clip(tri, bbox);
-    EXPECT_EQ(0, poly.numVertices());
-  }
-
-  // triangle at z=0 w/ one vertex coincident w/ cube
-  {
-    TriangleType tri(PointType {1, 2, 0.},
-                     PointType {1, 1, 0.},
-                     PointType {2, 1, 0.});
-
-    PolygonType poly = axom::primal::clip(tri, bbox);
-    EXPECT_EQ(0, poly.numVertices());
-  }
-
-  // triangle at z=0 w/ one edge midpoint coincident w/ cube
-  {
-    TriangleType tri(PointType {0, 2, 0.},
-                     PointType {2, 0, 0.},
-                     PointType {2, 2, 0.});
-
-    PolygonType poly = axom::primal::clip(tri, bbox);
-    EXPECT_EQ(0, poly.numVertices());
-  }
-
-  // triangle at z=0 w/ one edge coincident w/ unit cube and the other outside
-  {
-    TriangleType tri(PointType {-10, 1, 0.},
-                     PointType {10, 1, 0.},
-                     PointType {0, 10, 0.});
-
-    PolygonType poly = axom::primal::clip(tri, bbox);
-    EXPECT_EQ(0, poly.numVertices());
-  }
-
-  // triangle at z=0 w/ one edge coincident w/ unit cube and the last vertex inside
-  {
-    TriangleType tri(PointType {-10, 1, 0.},
-                     PointType {10, 1, 0.},
-                     PointType {0, 0, 0.});
-
-    PolygonType poly = axom::primal::clip(tri, bbox);
-    EXPECT_EQ(5, poly.numVertices());
-
-    SLIC_INFO(axom::fmt::format(print_template, tri, bbox, poly));
-  }
-
-  // triangle at z=0 w/ one edge coincident w/ unit cube and the last vertex on the other side
-  {
-    TriangleType tri(PointType {-10, 1, 0.},
-                     PointType {10, 1, 0.},
-                     PointType {0, -10, 0.});
-
-    PolygonType poly = axom::primal::clip(tri, bbox);
-    EXPECT_EQ(4, poly.numVertices());
-
-    SLIC_INFO(axom::fmt::format(print_template, tri, bbox, poly));
-  }
-
-  // triangle at z=1 w/ one edge coincident w/ unit cube and the last vertex on the other side
-  {
-    TriangleType tri(PointType {-10, 1, 1.},
-                     PointType {10, 1, 1.},
-                     PointType {0, -10, 1.});
-
-    PolygonType poly_no_bdry = axom::primal::clip(tri, bbox);
-    EXPECT_EQ(4, poly_no_bdry.numVertices());
-  }
-
-  {
-    TriangleType tri(PointType {-2, .25, .5},
-                     PointType {.25, .25, .5},
-                     PointType {.25, .75, .5});
-
-    PolygonType poly = axom::primal::clip(tri, bbox);
-    EXPECT_EQ(4, poly.numVertices());
-
-    SLIC_INFO(axom::fmt::format(print_template, tri, bbox, poly));
-  }
-
-  {
-    TriangleType tri(PointType {-2, .25, .5},
-                     PointType {.75, .25, .5},
-                     PointType {.75, .75, .5});
-
-    PolygonType poly = axom::primal::clip(tri, bbox);
-    EXPECT_EQ(4, poly.numVertices());
-
-    SLIC_INFO(axom::fmt::format(print_template, tri, bbox, poly));
-  }
-
-  {
-    TriangleType tri(PointType {.9, 100, .5},
-                     PointType {100, -1, .5},
-                     PointType {100, 100, .5});
-
-    PolygonType poly = axom::primal::clip(tri, bbox);
-    EXPECT_EQ(0, poly.numVertices());
-
-    SLIC_INFO(axom::fmt::format(print_template, tri, bbox, poly));
+    // The clipped polygon
+    // ... should have the expected number of vertices
+    EXPECT_EQ(expected_verts, poly.numVertices());
+    // ... should lie inside the bounding box (inflated by EPS to deal w/ boundaries)
+    EXPECT_TRUE(expanded_bbox.contains(axom::primal::compute_bounding_box(poly)));
+    // ... and its area should be at most that of the original triangle
+    EXPECT_GE(tri.area(), poly.area());
   }
 }
 

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -57,8 +57,11 @@ TEST(primal_clip, simple_clip)
 
     PointType {0.25, 0.25, 0.5},
     PointType {0.75, 0.25, 0.5},
-    PointType {0.66, 0.5, 0.5},
     PointType {1.5, 0.5, 0.5},
+
+    PointType {2, 1, 0.5},
+    PointType {2, 2, 0.5},
+    PointType {1, 2, 0.5},
   };
 
   {
@@ -94,13 +97,20 @@ TEST(primal_clip, simple_clip)
   }
 
   {
-    TriangleType tri(points[6], points[7], points[9]);
+    TriangleType tri(points[6], points[7], points[8]);
 
     PolygonType poly = axom::primal::clip(tri, bbox);
     EXPECT_EQ(4, poly.numVertices());
 
     SLIC_INFO("Intersection of triangle " << tri << " and bounding box " << bbox
                                           << " is polygon" << poly);
+  }
+
+  {
+    TriangleType tri(points[9], points[10], points[11]);
+
+    PolygonType poly = axom::primal::clip(tri, bbox);
+    EXPECT_EQ(0, poly.numVertices());
   }
 }
 

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -112,6 +112,42 @@ TEST(primal_clip, simple_clip)
     PolygonType poly = axom::primal::clip(tri, bbox);
     EXPECT_EQ(0, poly.numVertices());
   }
+
+  {
+    TriangleType tri(PointType {-1, .25, .5},
+                     PointType {.25, .25, .5},
+                     PointType {.25, .75, .5});
+
+    PolygonType poly = axom::primal::clip(tri, bbox);
+    EXPECT_EQ(4, poly.numVertices());
+
+    SLIC_INFO("Intersection of triangle " << tri << " and bounding box " << bbox
+                                          << " is polygon" << poly);
+  }
+
+  {
+    TriangleType tri(PointType {-1, .25, .5},
+                     PointType {.75, .25, .5},
+                     PointType {.75, .75, .5});
+
+    PolygonType poly = axom::primal::clip(tri, bbox);
+    EXPECT_EQ(4, poly.numVertices());
+
+    SLIC_INFO("Intersection of triangle " << tri << " and bounding box " << bbox
+                                          << " is polygon" << poly);
+  }
+
+  {
+    TriangleType tri(PointType {.9, 100, .5},
+                     PointType {100, -1, .5},
+                     PointType {100, 100, .5});
+
+    PolygonType poly = axom::primal::clip(tri, bbox);
+    EXPECT_EQ(0, poly.numVertices());
+
+    SLIC_INFO("Intersection of triangle " << tri << " and bounding box " << bbox
+                                          << " is polygon" << poly);
+  }
 }
 
 TEST(primal_clip, unit_simplex)

--- a/src/axom/primal/tests/primal_compute_bounding_box.cpp
+++ b/src/axom/primal/tests/primal_compute_bounding_box.cpp
@@ -12,17 +12,18 @@
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
 #include "axom/primal/geometry/OrientedBoundingBox.hpp"
+#include "axom/primal/geometry/Polygon.hpp"
 #include "axom/primal/operators/compute_bounding_box.hpp"
 
-using namespace axom;
+namespace primal = axom::primal;
 
 TEST(primal_compute_bounding_box, compute_oriented_box_test)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;      // origin
   QVector u[DIM];  // make standard axes
@@ -66,11 +67,11 @@ TEST(primal_compute_bounding_box, compute_oriented_box_test)
 
 TEST(primal_compute_bounding_box, merge_oriented_box_test)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::OrientedBoundingBox<CoordType, DIM> QOBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   const double ONE_OVER_SQRT_TWO = 0.7071;
   QPoint pt1;      // origin
@@ -105,11 +106,11 @@ TEST(primal_compute_bounding_box, merge_oriented_box_test)
 
 TEST(primal_compute_bounding_box, merge_aligned_box_test)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Vector<CoordType, DIM> QVector;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
 
   QPoint pt1(0.);
   QPoint pt2(1.);
@@ -135,7 +136,7 @@ TEST(primal_compute_bounding_box, compute_quad_2d_box_test)
   using CoordinateType = double;
   using PointType = primal::Point<CoordinateType, DIM>;
   using BoundingBoxType = primal::BoundingBox<CoordinateType, DIM>;
-  using QuadrilateralType = primal::Octahedron<CoordinateType, DIM>;
+  using QuadrilateralType = primal::Quadrilateral<CoordinateType, DIM>;
 
   PointType A {-1.0, 0.1};
   PointType B {-0.1, 0.5};
@@ -159,7 +160,7 @@ TEST(primal_compute_bounding_box, compute_quad_3d_box_test)
   using CoordinateType = double;
   using PointType = primal::Point<CoordinateType, DIM>;
   using BoundingBoxType = primal::BoundingBox<CoordinateType, DIM>;
-  using QuadrilateralType = primal::Octahedron<CoordinateType, DIM>;
+  using QuadrilateralType = primal::Quadrilateral<CoordinateType, DIM>;
 
   PointType A {-1.0, 0.1, 0.0};
   PointType B {-0.1, 0.5, 0.0};
@@ -179,11 +180,11 @@ TEST(primal_compute_bounding_box, compute_quad_3d_box_test)
 
 TEST(primal_compute_bounding_box, compute_oct_box_test)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
-  typedef primal::Octahedron<CoordType, DIM> QOct;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
+  using QOct = primal::Octahedron<CoordType, DIM>;
 
   QPoint p1({1, 0, 0});
   QPoint p2({1, 1, 0});
@@ -207,11 +208,11 @@ TEST(primal_compute_bounding_box, compute_oct_box_test)
 
 TEST(primal_compute_bounding_box, compute_poly_box_test)
 {
-  static const int DIM = 3;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::BoundingBox<CoordType, DIM> QBBox;
-  typedef primal::Polyhedron<CoordType, DIM> QPoly;
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
+  using QPoly = primal::Polyhedron<CoordType, DIM>;
 
   QPoly poly;
   QPoint p1({0, 0, 0});
@@ -245,9 +246,52 @@ TEST(primal_compute_bounding_box, compute_poly_box_test)
   EXPECT_EQ(box.getMax(), QPoint::ones());
 }
 
+TEST(primal_compute_bounding_box, compute_polygon_2)
+{
+  constexpr int DIM = 2;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QBBox = primal::BoundingBox<CoordType, DIM>;
+  using QPoly = primal::Polygon<CoordType, DIM>;
+
+  // empty polygon generates an empty (invalid) bounding box
+  {
+    QPoly empty_poly;
+    QBBox box = primal::compute_bounding_box(empty_poly);
+    EXPECT_FALSE(box.isValid());
+  }
+
+  // non-empty polygon generates expected axis-aligned bounding box
+  {
+    QPoint p1({1, 0});
+    QPoint p2({5, 0});
+    QPoint p3({7, 2});
+    QPoint p4({9, 4});
+    QPoint p5({-1, 4});
+
+    QPoly polygon(5);
+    polygon.addVertex(p1);
+    polygon.addVertex(p2);
+    polygon.addVertex(p3);
+    polygon.addVertex(p4);
+    polygon.addVertex(p5);
+
+    QBBox box = primal::compute_bounding_box(polygon);
+    EXPECT_TRUE(box.contains(p1));
+    EXPECT_TRUE(box.contains(p2));
+    EXPECT_TRUE(box.contains(p3));
+    EXPECT_TRUE(box.contains(p4));
+    EXPECT_TRUE(box.contains(p5));
+
+    EXPECT_EQ(box.getMin(), (QPoint {-1., 0.}));
+    EXPECT_EQ(box.getMax(), (QPoint {9., 4.}));
+  }
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
+  axom::slic::SimpleLogger logger;
 
 #ifdef COMPUTE_BOUNDING_BOX_TESTER_SHOULD_SEED
   std::srand(std::time(0));

--- a/src/axom/primal/tests/primal_orientedboundingbox.cpp
+++ b/src/axom/primal/tests/primal_orientedboundingbox.cpp
@@ -9,6 +9,8 @@
 #include "gtest/gtest.h"
 
 #include "axom/config.hpp"
+#include "axom/slic.hpp"
+
 #include "axom/primal/geometry/NumericArray.hpp"
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
@@ -270,7 +272,7 @@ TEST(primal_OBBox, obb_test_add_box)
   obbox3.addBox(obbox4);
   EXPECT_TRUE(obbox3.contains(obbox1));
 
-  // adding invalid box should make it invalid
+  // adding empty/invalid box is a no-op
   QOBBox obbox5;
   obbox3.addBox(obbox5);
   EXPECT_FALSE(obbox5.isValid());
@@ -604,6 +606,7 @@ TEST(primal_OBBox, obb_test_furthest_point)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
+  axom::slic::SimpleLogger logger;
 
 #ifdef ORIENTEDBOUNDINGBOX_TESTER_SHOULD_SEED
   std::srand(std::time(0));

--- a/src/axom/primal/tests/primal_tetrahedron.cpp
+++ b/src/axom/primal/tests/primal_tetrahedron.cpp
@@ -627,7 +627,6 @@ TEST_F(TetrahedronTest, regularTetrahedron)
 
 TEST_F(TetrahedronTest, checkAndFixOrientation)
 {
-  using QPoint = TetrahedronTest::QPoint;
   using QTet = TetrahedronTest::QTet;
 
   int indices[] = {0, 1, 2, 3};

--- a/src/axom/quest/InOutOctree.hpp
+++ b/src/axom/quest/InOutOctree.hpp
@@ -546,7 +546,7 @@ void InOutOctree<DIM>::insertVertex(VertexIndex idx, int startingLevel)
                 "Looking at block {} w/ blockBB {} indexing leaf vertex {}",
                 pt,
                 idx,
-                block,
+                axom::fmt::streamed(block),
                 this->blockBoundingBox(block),
                 blkData.dataIndex()));
 
@@ -579,7 +579,7 @@ void InOutOctree<DIM>::insertVertex(VertexIndex idx, int startingLevel)
     blkData.dataIndex() == DEBUG_VERT_IDX,
     fmt::format("-- vertex {} is indexed in block {}. Leaf vertex is {}",
                 idx,
-                block,
+                axom::fmt::streamed(block),
                 blkData.dataIndex()));
 }
 
@@ -660,7 +660,7 @@ void InOutOctree<DIM>::insertMeshCells()
                     "\n\tDynamic data: {}"
                     "\n\tBlock data: {}"
                     "\n\tAbout to finalize? {}",
-                    blk,
+                    axom::fmt::streamed(blk),
                     dynamicLeafData,
                     blkData,
                     (!isInternal && !isLeafThatMustRefine ? " yes" : "no")));
@@ -688,7 +688,7 @@ void InOutOctree<DIM>::insertMeshCells()
             fmt::format("[Added block {} into tree as a gray leaf]."
                         "\n\tDynamic data: {}"
                         "\n\tBlock data: {}",
-                        blk,
+                        axom::fmt::streamed(blk),
                         dynamicLeafData,
                         blkData));
         }
@@ -788,7 +788,7 @@ void InOutOctree<DIM>::insertMeshCells()
                           tIdx,
                           spaceTri,
                           tBB,
-                          childBlk[j],
+                          axom::fmt::streamed(childBlk[j]),
                           childBB[j],
                           *childDataPtr[j],
                           (shouldAddCell ? " yes" : "no")));
@@ -819,7 +819,7 @@ void InOutOctree<DIM>::insertMeshCells()
                   tIdx,
                   spaceTri,
                   fmt::join(m_meshWrapper.cellVertexIndices(tIdx), ", "),
-                  childBlk[j],
+                  axom::fmt::streamed(childBlk[j]),
                   *(childDataPtr[j])));
             }
           }
@@ -941,9 +941,10 @@ bool InOutOctree<DIM>::colorLeafAndNeighbors(const BlockIndex& leafBlk,
 {
   bool isColored = leafData.isColored();
 
-  QUEST_OCTREE_DEBUG_LOG_IF(
-    leafBlk == DEBUG_BLOCK_1 || leafBlk == DEBUG_BLOCK_2,
-    fmt::format("Trying to color {} with data: {}", leafBlk, leafData));
+  QUEST_OCTREE_DEBUG_LOG_IF(leafBlk == DEBUG_BLOCK_1 || leafBlk == DEBUG_BLOCK_2,
+                            fmt::format("Trying to color {} with data: {}",
+                                        axom::fmt::streamed(leafBlk),
+                                        leafData));
 
   if(!isColored)
   {
@@ -962,11 +963,11 @@ bool InOutOctree<DIM>::colorLeafAndNeighbors(const BlockIndex& leafBlk,
                       "bounding box {} w/ midpoint {}"
                       "\n\t\t from block {} with data {}, "
                       "bounding box {} w/ midpoint {}.",
-                      leafBlk,
+                      axom::fmt::streamed(leafBlk),
                       leafData,
                       this->blockBoundingBox(leafBlk),
                       this->blockBoundingBox(leafBlk).getCentroid(),
-                      neighborBlk,
+                      axom::fmt::streamed(neighborBlk),
                       neighborData,
                       this->blockBoundingBox(neighborBlk),
                       this->blockBoundingBox(neighborBlk).getCentroid()));
@@ -1004,7 +1005,7 @@ bool InOutOctree<DIM>::colorLeafAndNeighbors(const BlockIndex& leafBlk,
           isColored &&
             (DEBUG_BLOCK_1 == neighborBlk || DEBUG_BLOCK_2 == neighborBlk),
           fmt::format("Leaf block was colored -- {} now has data {}",
-                      leafBlk,
+                      axom::fmt::streamed(leafBlk),
                       leafData));
       }
     }
@@ -1028,11 +1029,11 @@ bool InOutOctree<DIM>::colorLeafAndNeighbors(const BlockIndex& leafBlk,
                         "bounding box {} w/ midpoint {}"
                         "\n\t\t to block {} with data {}, "
                         "bounding box {} w/ midpoint {}.",
-                        leafBlk,
+                        axom::fmt::streamed(leafBlk),
                         leafData,
                         this->blockBoundingBox(leafBlk),
                         this->blockBoundingBox(leafBlk).getCentroid(),
-                        neighborBlk,
+                        axom::fmt::streamed(neighborBlk),
                         neighborData,
                         this->blockBoundingBox(neighborBlk),
                         this->blockBoundingBox(neighborBlk).getCentroid()));
@@ -1070,7 +1071,7 @@ bool InOutOctree<DIM>::colorLeafAndNeighbors(const BlockIndex& leafBlk,
             neighborData.isColored() &&
               (DEBUG_BLOCK_1 == neighborBlk || DEBUG_BLOCK_2 == neighborBlk),
             fmt::format("Neighbor block was colored -- {} now has data {}",
-                        neighborBlk,
+                        axom::fmt::streamed(neighborBlk),
                         neighborData));
         }
       }
@@ -1169,7 +1170,7 @@ typename std::enable_if<TDIM == 3, bool>::type InOutOctree<DIM>::withinGrayBlock
       fmt::format("Checking if pt {} is within block {} with data {}, "
                   "ray is {}, triangle point is {} on triangle with index {}.",
                   queryPt,
-                  leafBlk,
+                  axom::fmt::streamed(leafBlk),
                   leafData,
                   ray,
                   triPt,
@@ -1228,8 +1229,8 @@ typename std::enable_if<TDIM == 3, bool>::type InOutOctree<DIM>::withinGrayBlock
     return normal.dot(ray.direction()) > 0.;
   }
 
-  SLIC_DEBUG("Could not determine inside/outside for point "
-             << queryPt << " on block " << leafBlk);
+  // SLIC_DEBUG("Could not determine inside/outside for point "
+  //            << queryPt << " on block " << leafBlk);
 
   return false;  // query points on boundary might get here -- revisit this.
 }
@@ -1285,7 +1286,7 @@ typename std::enable_if<TDIM == 2, bool>::type InOutOctree<DIM>::withinGrayBlock
       fmt::format("Checking if pt {} is within block {} with data {}, "
                   "ray is {}, segment point is {} on segment with index {}.",
                   queryPt,
-                  leafBlk,
+                  axom::fmt::streamed(leafBlk),
                   leafData,
                   ray,
                   segmentPt,

--- a/src/axom/quest/detail/inout/BlockData.hpp
+++ b/src/axom/quest/detail/inout/BlockData.hpp
@@ -438,4 +438,9 @@ template <>
 struct axom::fmt::formatter<axom::quest::InOutBlockData> : ostream_formatter
 { };
 
+/// Overload to format a quest::DynamicGrayBlockData using fmt
+template <>
+struct axom::fmt::formatter<axom::quest::DynamicGrayBlockData> : ostream_formatter
+{ };
+
 #endif  // AXOM_QUEST_INOUT_OCTREE_BLOCKDATA__HPP_

--- a/src/axom/quest/detail/inout/MeshWrapper.hpp
+++ b/src/axom/quest/detail/inout/MeshWrapper.hpp
@@ -26,7 +26,7 @@ namespace axom
 namespace quest
 {
 /**
-   * \brief A utility class that wraps access to the mesh data of and InOutOctree
+   * \brief A utility class that wraps access to the mesh data of an InOutOctree
    *
    * This class helps separate the specifics of accessing the underlying mesh
    * for an InOutOctree. It is customized for unstructured Segment meshes in 2D

--- a/src/axom/quest/tests/quest_regression.cpp
+++ b/src/axom/quest/tests/quest_regression.cpp
@@ -52,13 +52,14 @@
 #endif
 
 // C/C++ includes
-#include <cmath>  // for std::signbit()
+#include <cmath>
 #include <string>
 
-const int DIM = 3;
-const int MAX_RESULTS = 10;         // Max number of disagreeing entries to show
-                                    // when comparing results
-const int DEFAULT_RESOLUTION = 32;  // Default resolution of query grid
+constexpr int DIM = 3;
+// Default resolution of query grid
+constexpr int DEFAULT_RESOLUTION = 32;
+// Max number of disagreeing entries to show when comparing results
+constexpr int MAX_RESULTS = 10;
 
 namespace mint = axom::mint;
 namespace primal = axom::primal;
@@ -71,7 +72,7 @@ using SpacePt = primal::Point<double, DIM>;
 using SpaceVec = primal::Vector<double, DIM>;
 using GridPt = primal::Point<int, DIM>;
 
-/** Simple structure to hold the command line arguments */
+/// Simple structure to hold the command line arguments
 struct Input
 {
   Input() = default;
@@ -104,9 +105,7 @@ struct Input
   bool hasBoundingBox() const { return meshBoundingBox != SpaceBoundingBox(); }
   bool hasQueryMesh() const { return queryMesh != nullptr; }
 
-  /**
- * \brief Parses the command line options
- */
+  /// Parses the command line options
   void parse(int argc, char** argv, axom::CLI::App& app)
   {
     app
@@ -138,8 +137,7 @@ struct Input
       ->check(axom::CLI::ExistingFile);
 #endif
 
-    // user can supply 1 or 3 values for resolution
-    // the following is not quite right
+    // user can supply 1 or 3 values for resolution the following is not quite right
     auto* res = app
                   .add_option("-r,--resolution",
                               m_resolution,
@@ -211,7 +209,7 @@ struct Input
   }
 };
 
-/** Loads the baseline dataset into the given sidre group */
+/// Loads the baseline dataset into the given sidre group
 void loadBaselineData(sidre::Group* grp, Input& args)
 {
   sidre::IOManager reader(MPI_COMM_WORLD);
@@ -587,11 +585,12 @@ bool compareDistanceAndContainment(Input& clargs)
     if(diffCount != 0)
     {
       passed = false;
-      SLIC_INFO("** Disagreement between SignedDistance "
-                << " and InOutOctree containment queries.  "
-                << "\n There were " << diffCount << " differences."
-                << "\n Showing first " << std::min(diffCount, MAX_RESULTS)
-                << " results:" << out.data());
+      SLIC_INFO(axom::fmt::format(
+        "** Disagreement between SignedDistance and InOutOctree queries.\n"
+        "There were {} differences.\n Showing first {} results -- {}",
+        diffCount,
+        std::min(diffCount, MAX_RESULTS),
+        std::string(out.begin(), out.end())));
     }
   }
 
@@ -599,8 +598,7 @@ bool compareDistanceAndContainment(Input& clargs)
 }
 
 /**
- * \brief Function to compare the results from the InOutOctree and
- * SignedDistance queries
+ * \brief Function to compare the results from the InOutOctree and SignedDistance queries
  * \return True if all results agree, False otherwise.
  * \note When there are differences, the first few are logged
  */
@@ -614,19 +612,41 @@ bool compareToBaselineResults(axom::sidre::Group* grp, Input& clargs)
   mint::UniformMesh* umesh = clargs.queryMesh;
   const int nnodes = umesh->getNumberOfNodes();
 
+  int* base_inout_containment = nullptr;
+  int* exp_inout_containment = nullptr;
+  int* base_sd_containment = nullptr;
+  int* exp_sd_containment = nullptr;
+  double* base_sd_distance = nullptr;
+  double* exp_sd_distance = nullptr;
+
+  // grab pointers to data arrays when appropriate
+  if(clargs.testContainment)
+  {
+    base_inout_containment = grp->getView("octree_containment")->getArray();
+    exp_inout_containment =
+      umesh->getFieldPtr<int>("octree_containment", mint::NODE_CENTERED);
+  }
+
+  if(clargs.testDistance)
+  {
+    base_sd_containment = grp->getView("bvh_containment")->getArray();
+    exp_sd_containment =
+      umesh->getFieldPtr<int>("bvh_containment", mint::NODE_CENTERED);
+
+    base_sd_distance = grp->getView("bvh_distance")->getArray();
+    exp_sd_distance =
+      umesh->getFieldPtr<double>("bvh_distance", mint::NODE_CENTERED);
+  }
+
   if(clargs.testContainment)
   {
     int diffCount = 0;
     axom::fmt::memory_buffer out;
 
-    int* exp_containment =
-      umesh->getFieldPtr<int>("octree_containment", mint::NODE_CENTERED);
-    int* base_containment = grp->getView("octree_containment")->getArray();
-
     for(int inode = 0; inode < nnodes; ++inode)
     {
-      const int expected = base_containment[inode];
-      const int actual = exp_containment[inode];
+      const int expected = base_inout_containment[inode];
+      const int actual = exp_inout_containment[inode];
       if(expected != actual)
       {
         if(diffCount < MAX_RESULTS)
@@ -639,8 +659,16 @@ bool compareToBaselineResults(axom::sidre::Group* grp, Input& clargs)
             "\n  Disagreement on sample {} @ {}.  Expected {}, got {}",
             inode,
             pt,
-            expected,
-            actual);
+            expected ? "inside" : "outside",
+            actual ? "inside" : "outside");
+
+          if(clargs.testDistance)
+          {
+            axom::fmt::format_to(
+              std::back_inserter(out),
+              " -- distance from query point to surface is {} ",
+              base_sd_distance[inode]);
+          }
         }
         ++diffCount;
       }
@@ -649,9 +677,12 @@ bool compareToBaselineResults(axom::sidre::Group* grp, Input& clargs)
     if(diffCount != 0)
     {
       passed = false;
-      SLIC_INFO("** Containment test failed.  There were "
-                << diffCount << " differences. Showing first "
-                << std::min(diffCount, MAX_RESULTS) << out.data());
+      SLIC_INFO(axom::fmt::format(
+        "** Containment test failed.  There were {} differences. "
+        "Showing first {} -- {}",
+        diffCount,
+        std::min(diffCount, MAX_RESULTS),
+        std::string(out.begin(), out.end())));
     }
   }
 
@@ -660,20 +691,12 @@ bool compareToBaselineResults(axom::sidre::Group* grp, Input& clargs)
     int diffCount = 0;
     axom::fmt::memory_buffer out;
 
-    int* base_containment = grp->getView("bvh_containment")->getArray();
-    int* exp_containment =
-      umesh->getFieldPtr<int>("bvh_containment", mint::NODE_CENTERED);
-
-    double* base_distance = grp->getView("bvh_distance")->getArray();
-    double* exp_distance =
-      umesh->getFieldPtr<double>("bvh_distance", mint::NODE_CENTERED);
-
     for(int inode = 0; inode < nnodes; ++inode)
     {
-      const int expected_c = base_containment[inode];
-      const int actual_c = exp_containment[inode];
-      const double expected_d = base_distance[inode];
-      const double actual_d = exp_distance[inode];
+      const int expected_c = base_sd_containment[inode];
+      const int actual_c = exp_sd_containment[inode];
+      const double expected_d = base_sd_distance[inode];
+      const double actual_d = exp_sd_distance[inode];
       if(expected_c != actual_c ||
          !utilities::isNearlyEqual(expected_d, actual_d))
       {
@@ -699,9 +722,12 @@ bool compareToBaselineResults(axom::sidre::Group* grp, Input& clargs)
     if(diffCount != 0)
     {
       passed = false;
-      SLIC_INFO("** Distance test failed.  There were "
-                << diffCount << " differences. Showing first "
-                << std::min(diffCount, MAX_RESULTS) << out.data());
+      SLIC_INFO(axom::fmt::format(
+        "** Distance test failed.  There were {} differences. "
+        "Showing first {} -- {}",
+        diffCount,
+        std::min(diffCount, MAX_RESULTS),
+        std::string(out.begin(), out.end())));
     }
   }
 
@@ -784,9 +810,7 @@ void saveBaseline(axom::sidre::Group* grp, Input& clargs)
                       protocol));
 }
 
-/**
- * \brief Runs regression test for quest containment and signed distance queries
- */
+/// Runs regression test for quest containment and signed distance queries
 int main(int argc, char** argv)
 {
   bool allTestsPassed = true;

--- a/src/axom/spin/OctreeBase.hpp
+++ b/src/axom/spin/OctreeBase.hpp
@@ -20,7 +20,7 @@
 #include "axom/spin/OctreeLevel.hpp"
 #include "axom/spin/SparseOctreeLevel.hpp"
 
-#include <ostream>  // for ostream in print
+#include <ostream>
 
 namespace axom
 {


### PR DESCRIPTION
# Summary

- This PR is a bugfix for `primal::clip(Triangle, BoundingBox)` 
   - the core bugfix is from @simonradler in #1239 
   - placed in a new branch for internal testing
- This branch extends the original bugfix with some additional tests and code cleanup including:
   - modified the behavior of `BoundingBox::contains(BoundingBox)` to return true when the latter is empty 
   - added an overload to `primal::compute_bounding_box` for `primal::Polygon`
   - fixed some minor warnings