### PR TITLE
Addresses some odds and ends

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,3 +1,7 @@
+# Adds some checks to the code
+# the following might also be useful: 
+#    modernize-use-nullptr
+#    readability-static-definition-in-anonymous-namespace
 Checks:          '-*,readability-braces-around-statements,modernize-use-using'
 WarningsAsErrors: ''
 HeaderFilterRegex: "^.*.hpp$|^.*.cpp$"

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,4 +1,4 @@
-Checks:          '-*,readability-braces-around-statements'
+Checks:          '-*,readability-braces-around-statements,modernize-use-using'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,6 +1,6 @@
 Checks:          '-*,readability-braces-around-statements,modernize-use-using'
 WarningsAsErrors: ''
-HeaderFilterRegex: '.*'
+HeaderFilterRegex: "^.*.hpp$|^.*.cpp$"
 AnalyzeTemporaryDtors: false
 FormatStyle: none
 CheckOptions:

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -730,7 +730,7 @@ public:
                   "Cannot call Array<T>::resize() when T is non-trivially-"
                   "constructible. Use Array<T>::reserve() and emplace_back()"
                   "instead.");
-    const StackArray<IndexType, DIM> dims {static_cast<IndexType>(args)...};
+    const StackArray<IndexType, DIM> dims {{static_cast<IndexType>(args)...}};
     resizeImpl(dims, true);
   }
 
@@ -738,14 +738,14 @@ public:
   template <typename... Args, typename Enable = std::enable_if_t<sizeof...(Args) == DIM>>
   void resize(ArrayOptions::Uninitialized, Args... args)
   {
-    const StackArray<IndexType, DIM> dims {static_cast<IndexType>(args)...};
+    const StackArray<IndexType, DIM> dims {{static_cast<IndexType>(args)...}};
     resizeImpl(dims, false);
   }
 
   template <int Dims = DIM, typename Enable = std::enable_if_t<Dims == 1>>
   void resize(IndexType size, const T& value)
   {
-    resizeImpl({size}, true, &value);
+    resizeImpl({{size}}, true, &value);
   }
 
   void resize(const StackArray<IndexType, DIM>& size, const T& value)
@@ -911,7 +911,7 @@ template <typename T, int DIM, MemorySpace SPACE>
 template <typename... Args, typename Enable>
 Array<T, DIM, SPACE>::Array(Args... args)
   : ArrayBase<T, DIM, Array<T, DIM, SPACE>>(
-      StackArray<IndexType, DIM> {static_cast<IndexType>(args)...})
+      StackArray<IndexType, DIM> {{static_cast<IndexType>(args)...}})
   , m_allocator_id(axom::detail::getAllocatorID<SPACE>())
 {
   static_assert(sizeof...(Args) == DIM,
@@ -927,7 +927,7 @@ template <typename T, int DIM, MemorySpace SPACE>
 template <typename... Args, typename Enable>
 Array<T, DIM, SPACE>::Array(ArrayOptions::Uninitialized, Args... args)
   : ArrayBase<T, DIM, Array<T, DIM, SPACE>>(
-      StackArray<IndexType, DIM> {static_cast<IndexType>(args)...})
+      StackArray<IndexType, DIM> {{static_cast<IndexType>(args)...}})
   , m_allocator_id(axom::detail::getAllocatorID<SPACE>())
 {
   static_assert(sizeof...(Args) == DIM,

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -231,7 +231,7 @@ public:
     static_assert(sizeof...(Args) <= DIM,
                   "Index dimensions different from array dimensions");
     constexpr int UDim = sizeof...(Args);
-    const StackArray<IndexType, UDim> indices {static_cast<IndexType>(args)...};
+    const StackArray<IndexType, UDim> indices {{static_cast<IndexType>(args)...}};
     return (*this)[indices];
   }
   /// \overload
@@ -255,14 +255,14 @@ public:
    */
   AXOM_HOST_DEVICE SliceType<1> operator[](const IndexType idx)
   {
-    const StackArray<IndexType, 1> slice {idx};
+    const StackArray<IndexType, 1> slice {{idx}};
     return (*this)[slice];
   }
 
   /// \overload
   AXOM_HOST_DEVICE ConstSliceType<1> operator[](const IndexType idx) const
   {
-    const StackArray<IndexType, 1> slice {idx};
+    const StackArray<IndexType, 1> slice {{idx}};
     return (*this)[slice];
   }
 

--- a/src/axom/core/ArrayView.hpp
+++ b/src/axom/core/ArrayView.hpp
@@ -233,7 +233,8 @@ using MCArrayView = ArrayView<T, 2>;
 template <typename T, int DIM, MemorySpace SPACE>
 template <typename... Args, typename Enable>
 ArrayView<T, DIM, SPACE>::ArrayView(T* data, Args... args)
-  : ArrayView(data, StackArray<IndexType, DIM> {static_cast<IndexType>(args)...})
+  : ArrayView(data,
+              StackArray<IndexType, DIM> {{static_cast<IndexType>(args)...}})
 {
   static_assert(sizeof...(Args) == DIM,
                 "Array size must match number of dimensions");

--- a/src/axom/core/examples/core_numerics.cpp
+++ b/src/axom/core/examples/core_numerics.cpp
@@ -192,7 +192,7 @@ void demoMatrix()
   // _eigs_start
   // Solve for eigenvectors and values using the power method
   // The power method calls rand(), so we need to initialize it with srand().
-  std::srand(std::time(0));
+  std::srand(std::time(nullptr));
   double eigvec[nrows * ncols];
   double eigval[nrows];
   int res = numerics::eigen_solve(A, nrows, eigvec, eigval);

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -2219,7 +2219,7 @@ void test_resize_with_stackarray(DataType value)
   const int K_DIMS = 7;
   axom::Array<DataType, 2> arr2;
 
-  axom::StackArray<axom::IndexType, 2> dims2 = {I_DIMS, J_DIMS};
+  axom::StackArray<axom::IndexType, 2> dims2 = {{I_DIMS, J_DIMS}};
   arr2.resize(dims2, value);
   EXPECT_EQ(arr2.size(), I_DIMS * J_DIMS);
   EXPECT_EQ(arr2.shape()[0], I_DIMS);
@@ -2234,7 +2234,7 @@ void test_resize_with_stackarray(DataType value)
 
   axom::Array<DataType, 3> arr3;
 
-  axom::StackArray<axom::IndexType, 3> dims3 = {I_DIMS, J_DIMS, K_DIMS};
+  axom::StackArray<axom::IndexType, 3> dims3 = {{I_DIMS, J_DIMS, K_DIMS}};
   arr3.resize(dims3, value);
   EXPECT_EQ(arr3.size(), I_DIMS * J_DIMS * K_DIMS);
   EXPECT_EQ(arr3.shape()[0], I_DIMS);

--- a/src/axom/core/utilities/nvtx/interface.hpp
+++ b/src/axom/core/utilities/nvtx/interface.hpp
@@ -12,10 +12,8 @@ namespace axom
 {
 namespace nvtx
 {
-/*!
- * \brief Predefined set of NVTX colors to use with NVTXRange.
- */
-enum class Color : uint32_t
+/// \brief Predefined set of NVTX colors to use with NVTXRange
+enum class Color : std::uint32_t
 {
   BLACK = 0x00000000,
   GREEN = 0x0000FF00,

--- a/src/axom/mint/examples/mint_heat_equation.cpp
+++ b/src/axom/mint/examples/mint_heat_equation.cpp
@@ -363,10 +363,8 @@ const std::string help_string =
   "-d INT, -dumpPeriod INT\n"
   "\tThe number of cycles to wait between writing a dump file.\n";
 
-/*!
- * \brief A structure that holds the command line arguments.
- */
-using Arguments = struct
+/// A structure that holds the command line arguments.
+struct Arguments
 {
   double h;
   double lower_bound[2];

--- a/src/axom/mint/examples/mint_heat_equation.cpp
+++ b/src/axom/mint/examples/mint_heat_equation.cpp
@@ -366,7 +366,7 @@ const std::string help_string =
 /*!
  * \brief A structure that holds the command line arguments.
  */
-typedef struct
+using Arguments = struct
 {
   double h;
   double lower_bound[2];
@@ -379,7 +379,7 @@ typedef struct
   double t_max;
   int period;
   std::string path;
-} Arguments;
+};
 
 /*!
  * \brief Parses and validates the command line arguments.

--- a/src/axom/mint/fem/FiniteElement.hpp
+++ b/src/axom/mint/fem/FiniteElement.hpp
@@ -499,7 +499,7 @@ private:
   /// \name Reference Element Attributes
   /// @{
 
-  typedef void (*ShapeFunctionPtr)(const double* lc, double* phi);
+  using ShapeFunctionPtr = void (*)(const double* lc, double* phi);
   ShapeFunctionPtr m_shapeFunction;            /*! shape function functor */
   ShapeFunctionPtr m_shapeFunctionDerivatives; /*! derivatives functor */
 
@@ -517,7 +517,7 @@ private:
   DISABLE_MOVE_AND_ASSIGNMENT(FiniteElement);
 };
 
-} /* namespace mint */
+}  // namespace mint
 }  // namespace axom
 
 //------------------------------------------------------------------------------
@@ -534,8 +534,8 @@ void bind_basis(FiniteElement& fe)
   SLIC_ASSERT(fe.m_reference_center != nullptr);
   SLIC_ASSERT(fe.m_reference_coords != nullptr);
 
-  typedef mint::FEBasis<BasisType, CELLTYPE> FEBasisType;
-  typedef typename FEBasisType::ShapeFunctionType ShapeType;
+  using FEBasisType = mint::FEBasis<BasisType, CELLTYPE>;
+  using ShapeType = typename FEBasisType::ShapeFunctionType;
 
   if(CELLTYPE != fe.getCellType())
   {

--- a/src/axom/mint/mesh/CellTypes.hpp
+++ b/src/axom/mint/mesh/CellTypes.hpp
@@ -108,7 +108,7 @@ constexpr int NUM_CELL_TYPES = static_cast<int>(CellType::NUM_CELL_TYPES);
  *
  * \brief Holds information associated with a given cell type.
  */
-typedef struct
+using CellInfo = struct
 {
   CellType cell_type;         /*!< cell type, e.g. mint::QUAD, mint::HEX */
   const char* name;           /*!< the name associated with the cell */
@@ -119,7 +119,7 @@ typedef struct
   int face_nodecount[MAX_CELL_FACES]; /*!< number of nodes for each of cell's faces */
   CellType face_types[MAX_CELL_FACES]; /*!< face type, e.g. mint::SEGMENT, mint::QUAD */
   IndexType face_nodes[MAX_ALL_FACES_NODES]; /*!< nodes for each of cell's faces */
-} CellInfo;
+};
 
 // This construct lets us pass literal arrays to function-like macros.
 // AR stands for ARray.

--- a/src/axom/mint/mesh/CellTypes.hpp
+++ b/src/axom/mint/mesh/CellTypes.hpp
@@ -108,7 +108,7 @@ constexpr int NUM_CELL_TYPES = static_cast<int>(CellType::NUM_CELL_TYPES);
  *
  * \brief Holds information associated with a given cell type.
  */
-using CellInfo = struct
+struct CellInfo
 {
   CellType cell_type;         /*!< cell type, e.g. mint::QUAD, mint::HEX */
   const char* name;           /*!< the name associated with the cell */

--- a/src/axom/mint/mesh/internal/MeshHelpers.cpp
+++ b/src/axom/mint/mesh/internal/MeshHelpers.cpp
@@ -195,7 +195,8 @@ bool initFaces(Mesh* mesh,
   f2noffsets[facecount] = faceNodeOffset;
 
   // Step 4. Now that we have face IDs, record cell-to-face relation.
-  typedef std::unordered_map<IndexType, std::vector<IndexType>> CellFaceBuilderType;
+  using CellFaceBuilderType =
+    std::unordered_map<IndexType, std::vector<IndexType>>;
 
   CellFaceBuilderType cell_to_face;
   int cellFaceCount = 0;

--- a/src/axom/mint/tests/mint_fem_shape_functions.cpp
+++ b/src/axom/mint/tests/mint_fem_shape_functions.cpp
@@ -34,8 +34,8 @@ namespace
 template <int BasisType, mint::CellType CELLTYPE>
 void reference_element(double TOL = std::numeric_limits<double>::epsilon())
 {
-  typedef typename mint::FEBasis<BasisType, CELLTYPE> FEMType;
-  typedef typename FEMType::ShapeFunctionType ShapeFunctionType;
+  using FEMType = typename mint::FEBasis<BasisType, CELLTYPE>;
+  using ShapeFunctionType = typename FEMType::ShapeFunctionType;
   ShapeFunctionType sf;
 
   SLIC_INFO("checking " << mint::basis_name[BasisType] << " / "
@@ -84,8 +84,8 @@ void reference_element(double TOL = std::numeric_limits<double>::epsilon())
 template <int BasisType, mint::CellType CELLTYPE>
 void kronecker_delta()
 {
-  typedef typename mint::FEBasis<BasisType, CELLTYPE> FEMType;
-  typedef typename FEMType::ShapeFunctionType ShapeFunctionType;
+  using FEMType = typename mint::FEBasis<BasisType, CELLTYPE>;
+  using ShapeFunctionType = typename FEMType::ShapeFunctionType;
   ShapeFunctionType sf;
 
   SLIC_INFO("checking " << mint::basis_name[BasisType] << " / "
@@ -122,8 +122,8 @@ void kronecker_delta()
 template <int BasisType, mint::CellType CELLTYPE>
 void partition_of_unity()
 {
-  typedef typename mint::FEBasis<BasisType, CELLTYPE> FEMType;
-  typedef typename FEMType::ShapeFunctionType ShapeFunctionType;
+  using FEMType = typename mint::FEBasis<BasisType, CELLTYPE>;
+  using ShapeFunctionType = typename FEMType::ShapeFunctionType;
   ShapeFunctionType sf;
 
   SLIC_INFO("checking " << mint::basis_name[BasisType] << " / "

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -1896,14 +1896,20 @@ public:
          VectorType::scalar_triple_product(v1, v2, v3),
          0.0,
          tol))
+    {
       return false;
+    }
 
     // Find three points that produce a nonzero normal
     Vector3D plane_normal = VectorType::cross_product(v1, v2);
     if(axom::utilities::isNearlyEqual(plane_normal.norm(), 0.0, tol))
+    {
       plane_normal = VectorType::cross_product(v1, v3);
+    }
     if(axom::utilities::isNearlyEqual(plane_normal.norm(), 0.0, tol))
+    {
       plane_normal = VectorType::cross_product(v2, v3);
+    }
     plane_normal = plane_normal.unitVector();
 
     double sqDist = 0.0;
@@ -1936,18 +1942,42 @@ public:
     const int ord_u = getOrder_u();
     const int ord_v = getOrder_v();
 
-    if(ord_u <= 0 && ord_v <= 0) return true;
-    if(ord_u == 1 && ord_v == 0) return true;
-    if(ord_u == 0 && ord_v == 1) return true;
+    if(ord_u <= 0 && ord_v <= 0)
+    {
+      return true;
+    }
+    if(ord_u == 1 && ord_v == 0)
+    {
+      return true;
+    }
+    if(ord_u == 0 && ord_v == 1)
+    {
+      return true;
+    }
 
     // Check if the patch is planar
-    if(!isPlanar(tol)) return false;
+    if(!isPlanar(tol))
+    {
+      return false;
+    }
 
     // Check if each bounding curve is linear
-    if(!isocurve_u(0).isLinear(tol)) return false;
-    if(!isocurve_v(0).isLinear(tol)) return false;
-    if(!isocurve_u(1).isLinear(tol)) return false;
-    if(!isocurve_v(1).isLinear(tol)) return false;
+    if(!isocurve_u(0).isLinear(tol))
+    {
+      return false;
+    }
+    if(!isocurve_v(0).isLinear(tol))
+    {
+      return false;
+    }
+    if(!isocurve_u(1).isLinear(tol))
+    {
+      return false;
+    }
+    if(!isocurve_v(1).isLinear(tol))
+    {
+      return false;
+    }
 
     return true;
   }

--- a/src/axom/primal/geometry/NumericArray.hpp
+++ b/src/axom/primal/geometry/NumericArray.hpp
@@ -150,21 +150,21 @@ std::ostream& operator<<(std::ostream& os, const NumericArray<T, SIZE>& arr);
 template <typename T>
 struct NonChar
 {
-  typedef T type; /** The non-char type to return */
+  using type = T;  // The non-char type to return
 };
 
 template <>
 struct NonChar<char>
 {
   /** A non-char signed type to which we can cast a char for output */
-  typedef int type;
+  using type = int;
 };
 
 template <>
 struct NonChar<unsigned char>
 {
   /** A non-char unsigned type to which we can cast a char for output */
-  typedef unsigned int type;
+  using type = unsigned int;
 };
 
 /*!

--- a/src/axom/primal/geometry/OrientedBoundingBox.hpp
+++ b/src/axom/primal/geometry/OrientedBoundingBox.hpp
@@ -77,11 +77,11 @@ template <typename T, int NDIMS>
 class OrientedBoundingBox
 {
 public:
-  typedef T CoordType;
-  typedef Point<T, NDIMS> PointType;
-  typedef Vector<T, NDIMS> VectorType;
-  typedef OrientedBoundingBox<T, NDIMS> OrientedBoxType;
-  typedef BoundingBox<T, NDIMS> BoxType;
+  using CoordType = T;
+  using PointType = Point<T, NDIMS>;
+  using VectorType = Vector<T, NDIMS>;
+  using OrientedBoxType = OrientedBoundingBox<T, NDIMS>;
+  using BoxType = BoundingBox<T, NDIMS>;
 
 public:
   /*!

--- a/src/axom/primal/geometry/Point.hpp
+++ b/src/axom/primal/geometry/Point.hpp
@@ -250,8 +250,8 @@ private:
 /// \name Pre-defined point types
 /// @{
 
-typedef Point<double, 2> Point2D;
-typedef Point<double, 3> Point3D;
+using Point2D = Point<double, 2>;
+using Point3D = Point<double, 3>;
 
 /// @}
 

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -422,8 +422,8 @@ private:
 /// \name Pre-defined Vector types
 /// @{
 
-typedef Vector<double, 2> Vector2D;
-typedef Vector<double, 3> Vector3D;
+using Vector2D = Vector<double, 2>;
+using Vector3D = Vector<double, 3>;
 
 /// @}
 

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -158,7 +158,7 @@ AXOM_HOST_DEVICE bool intersect_tri3D_tri3D(const Triangle<T, 3>& t1,
                                             bool includeBoundary,
                                             double EPS)
 {
-  typedef primal::Vector<T, 3> Vector3;
+  using Vector3 = primal::Vector<T, 3>;
 
   SLIC_CHECK_MSG(!t1.degenerate(),
                  "\n\n WARNING \n\n Triangle " << t1 << " is degenerate");
@@ -762,7 +762,7 @@ bool intersect_tri_ray(const Triangle<T, 3>& tri,
   // I (Arlie Capps, Jan. 2017) don't understand the motivation at this
   // point, but I'll accept this for now.
 
-  typedef NumericArray<T, 3> NumArray;
+  using NumArray = NumericArray<T, 3>;
   const T zero = T();
 
   //find out dimension where ray direction is maximal
@@ -874,7 +874,7 @@ bool intersect_tri_segment(const Triangle<T, 3>& tri,
                            T& t,
                            Point<double, 3>& p)
 {
-  typedef Vector<T, 3> Vector3;
+  using Vector3 = Vector<T, 3>;
   Ray<T, 3> r(S.source(), Vector3(S.source(), S.target()));
 
   //Ray-triangle intersection does not check endpoints, so we explicitly check

--- a/src/axom/primal/operators/winding_number.hpp
+++ b/src/axom/primal/operators/winding_number.hpp
@@ -657,9 +657,13 @@ double winding_number(const Point<T, 3>& query,
     // Find the direction of a ray perpendicular to that
     Vector<T, 3> v1;
     if(axom::utilities::isNearlyEqual(v0[0], v0[1], EPS))
+    {
       v1 = Vector<T, 3>({v0[2], v0[2], -v0[0] - v0[1]}).unitVector();
+    }
     else
+    {
       v1 = Vector<T, 3>({-v0[1] - v0[2], v0[0], v0[0]}).unitVector();
+    }
 
     // Rotate v0 around v1 until it is perpendicular to the plane spanned by k and v1
     double ang = (v0[2] < 0 ? 1.0 : -1.0) *

--- a/src/axom/primal/tests/primal_octahedron.cpp
+++ b/src/axom/primal/tests/primal_octahedron.cpp
@@ -23,9 +23,9 @@ class OctahedronTest : public ::testing::Test
 public:
   static const int DIM = 3;
 
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
-  typedef primal::Octahedron<CoordType, DIM> QOct;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QOct = primal::Octahedron<CoordType, DIM>;
 
 protected:
   virtual void SetUp()
@@ -94,8 +94,8 @@ protected:
 //------------------------------------------------------------------------------
 TEST_F(OctahedronTest, defaultConstructor)
 {
-  typedef OctahedronTest::QPoint QPoint;
-  typedef OctahedronTest::QOct QOct;
+  using QPoint = OctahedronTest::QPoint;
+  using QOct = OctahedronTest::QOct;
 
   const QOct oct;
 
@@ -113,8 +113,8 @@ TEST_F(OctahedronTest, defaultConstructor)
 
 TEST_F(OctahedronTest, constructFromPoints)
 {
-  typedef OctahedronTest::QPoint QPoint;
-  typedef OctahedronTest::QOct QOct;
+  using QPoint = OctahedronTest::QPoint;
+  using QOct = OctahedronTest::QOct;
 
   // Access the test data
   const QPoint* pt = this->qData0;
@@ -167,8 +167,8 @@ TEST_F(OctahedronTest, constructFromPoints)
 
 TEST_F(OctahedronTest, equals)
 {
-  typedef OctahedronTest::QPoint QPoint;
-  typedef OctahedronTest::QOct QOct;
+  using QPoint = OctahedronTest::QPoint;
+  using QOct = OctahedronTest::QOct;
 
   // Access the test data
   const QPoint* pt0 = this->qData0;

--- a/src/axom/primal/tests/primal_point.cpp
+++ b/src/axom/primal/tests/primal_point.cpp
@@ -37,8 +37,8 @@ void check_point_policy()
 TEST(primal_point, point_default_constructor)
 {
   static const int DIM = 2;
-  typedef double CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
 
   QPoint pt;
 
@@ -50,8 +50,8 @@ TEST(primal_point, point_default_constructor)
 TEST(primal_point, point_singleVal_constructor)
 {
   static const int DIM = 5;
-  typedef int CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
+  using CoordType = int;
+  using QPoint = primal::Point<CoordType, DIM>;
   const int singleVal = 10;
 
   //
@@ -103,8 +103,8 @@ TEST(primal_point, point_singleVal_constructor)
 TEST(primal_point, point_array_constructor)
 {
   static const int DIM = 5;
-  typedef int CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
+  using CoordType = int;
+  using QPoint = primal::Point<CoordType, DIM>;
 
   // Set elt i of input array to i
   CoordType arr[DIM];
@@ -167,9 +167,9 @@ TEST(primal_point, point_array_constructor)
 TEST(primal_point, point_numericArray_constructor)
 {
   static const int DIM = 5;
-  typedef int CoordType;
-  typedef primal::NumericArray<CoordType, DIM> QArray;
-  typedef primal::Point<CoordType, DIM> QPoint;
+  using CoordType = int;
+  using QArray = primal::NumericArray<CoordType, DIM>;
+  using QPoint = primal::Point<CoordType, DIM>;
 
   // Set elt i of input array to i
   CoordType arr[DIM];
@@ -226,8 +226,8 @@ TEST(primal_point, point_initializerList_constructor)
 TEST(primal_point, point_copy_and_assignment)
 {
   static const int DIM = 5;
-  typedef int CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
+  using CoordType = int;
+  using QPoint = primal::Point<CoordType, DIM>;
 
   // Set elt i of input array to i
   CoordType arr[DIM];
@@ -262,8 +262,8 @@ TEST(primal_point, point_copy_and_assignment)
 TEST(primal_point, point_equality)
 {
   static const int DIM = 5;
-  typedef int CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
+  using CoordType = int;
+  using QPoint = primal::Point<CoordType, DIM>;
 
   // Set elt i of input array to i
   CoordType arr[DIM];
@@ -297,8 +297,8 @@ TEST(primal_point, point_equality)
 TEST(primal_point, point_to_array)
 {
   static const int DIM = 5;
-  typedef int CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
+  using CoordType = int;
+  using QPoint = primal::Point<CoordType, DIM>;
 
   // Set elt i of input array to i
   CoordType arr[DIM];
@@ -321,8 +321,8 @@ TEST(primal_point, point_to_array)
 TEST(primal_point, point_make_point)
 {
   static const int DIM = 3;
-  typedef int CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
+  using CoordType = int;
+  using QPoint = primal::Point<CoordType, DIM>;
 
   const int x = 10;
   const int y = 20;
@@ -346,8 +346,8 @@ TEST(primal_point, point_make_point)
 TEST(primal_point, point_midpoint)
 {
   static const int DIM = 3;
-  typedef int CoordType;
-  typedef primal::Point<CoordType, DIM> QPoint;
+  using CoordType = int;
+  using QPoint = primal::Point<CoordType, DIM>;
 
   QPoint p10(10);
   QPoint p30(30);

--- a/src/axom/primal/tests/primal_solid_angle.cpp
+++ b/src/axom/primal/tests/primal_solid_angle.cpp
@@ -582,7 +582,9 @@ TEST(primal_integral, bezierpatch_sphere)
     {
       const int idx = 5 * i + j;
       for(int n = 0; n < 6; ++n)
+      {
         sphere_faces[n].setWeight(i, j, weight_data[idx]);
+      }
 
       // Set up each face by rotating one of the patch faces
       sphere_faces[0](i, j)[0] = node_data[idx][1];

--- a/src/axom/quest/AllNearestNeighbors.cpp
+++ b/src/axom/quest/AllNearestNeighbors.cpp
@@ -31,10 +31,10 @@ void all_nearest_neighbors(const double* x,
   // points in this and neighboring UniformGrid bins (out to distance limit)
   // and report result.
 
-  typedef spin::UniformGrid<int, 3> GridType;
-  typedef GridType::BoxType BoxType;
-  typedef GridType::PointType PointType;
-  typedef BoxType::VectorType VectorType;
+  using GridType = spin::UniformGrid<int, 3>;
+  using BoxType = GridType::BoxType;
+  using PointType = GridType::PointType;
+  using VectorType = BoxType::VectorType;
 
   double sqlimit = limit * limit;
 

--- a/src/axom/quest/Shaper.hpp
+++ b/src/axom/quest/Shaper.hpp
@@ -48,11 +48,7 @@ public:
   static constexpr double DEFAULT_VERTEX_WELD_THRESHOLD {1e-9};
 
   /// Refinement type.
-  typedef enum
-  {
-    RefinementUniformSegments,
-    RefinementDynamic
-  } RefinementType;
+  using RefinementType = enum { RefinementUniformSegments, RefinementDynamic };
 
   //@{
   //!  @name Functions to get and set shaping parameters

--- a/src/axom/quest/tests/quest_c2c_reader.cpp
+++ b/src/axom/quest/tests/quest_c2c_reader.cpp
@@ -32,10 +32,10 @@ namespace quest = axom::quest;
 
 namespace
 {
-static const std::string C2C_LINE_FILENAME = "test_line.contour";
-static const std::string C2C_CIRCLE_FILENAME = "test_circle.contour";
-static const std::string C2C_SQUARE_FILENAME = "test_square.contour";
-static const std::string C2C_SPLINE_FILENAME = "test_spline.contour";
+const std::string C2C_LINE_FILENAME = "test_line.contour";
+const std::string C2C_CIRCLE_FILENAME = "test_circle.contour";
+const std::string C2C_SQUARE_FILENAME = "test_square.contour";
+const std::string C2C_SPLINE_FILENAME = "test_spline.contour";
 }  // end anonymous namespace
 
 /// Writes out a c2c file for a circle

--- a/src/axom/quest/tests/quest_vertex_weld.cpp
+++ b/src/axom/quest/tests/quest_vertex_weld.cpp
@@ -13,11 +13,11 @@
 
 namespace
 {
-static const int DIM = 3;
-static const double EPS = 1e-6;
+constexpr int DIM = 3;
+constexpr double EPS = 1e-6;
 
-typedef axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE> UMesh;
-typedef axom::primal::Point<double, 3> Point3;
+using UMesh = axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE>;
+using Point3 = axom::primal::Point<double, 3>;
 
 /*! Insert a vertex with coordinates (x,y,z) into \a mesh  */
 void insertVertex(UMesh* mesh, double x, double y, double z)

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -979,7 +979,7 @@ void MFEMSidreDataCollection::UpdateStateFromDS()
 void MFEMSidreDataCollection::UpdateStateToDS()
 {
   SLIC_ASSERT_MSG(
-    mesh != NULL,
+    mesh != nullptr,
     "Need to set mesh before updating state in MFEMSidreDataCollection.");
 
   m_bp_grp->getView("state/cycle")->setScalar(GetCycle());

--- a/src/axom/sidre/core/View.cpp
+++ b/src/axom/sidre/core/View.cpp
@@ -1239,7 +1239,7 @@ bool View::isApplyValid() const
  */
 char const* View::getStateStringName(State state)
 {
-  char const* ret_string = NULL;
+  char const* ret_string = nullptr;
 
   switch(state)
   {

--- a/src/axom/sidre/examples/sidre_shocktube.cpp
+++ b/src/axom/sidre/examples/sidre_shocktube.cpp
@@ -503,7 +503,7 @@ void DumpUltra(Group* const prob)
 
   sprintf(tail, "_%04d.ult", prob->getView("cycle")->getData<int>());
 
-  if((fp = fopen(fname, "w")) == NULL)
+  if((fp = fopen(fname, "w")) == nullptr)
   {
     printf("Could not open file %s. Aborting.\n", fname);
     exit(-1);

--- a/src/axom/sidre/tests/sidre_buffer.cpp
+++ b/src/axom/sidre/tests/sidre_buffer.cpp
@@ -298,18 +298,18 @@ TEST(sidre_buffer, with_multiple_views)
   EXPECT_EQ(dbuff->getNumViews(), 2);
 
   // Detach buffer from first view will not detach from datastore.
-  dv1->attachBuffer(NULL);
+  dv1->attachBuffer(nullptr);
   EXPECT_FALSE(dv1->hasBuffer());
   EXPECT_EQ(ds->getNumBuffers(), 1u);
   EXPECT_EQ(dbuff->getNumViews(), 1);
 
   // Detach buffer from second view will detach from datastore.
-  dv2->attachBuffer(NULL);
+  dv2->attachBuffer(nullptr);
   EXPECT_FALSE(dv2->hasBuffer());
   EXPECT_EQ(ds->getNumBuffers(), 0u);
 
   // Buffer has been destroyed since there are no more attached views
-  EXPECT_TRUE(ds->getBuffer(idx) == NULL);
+  EXPECT_TRUE(ds->getBuffer(idx) == nullptr);
 
   delete ds;
 }

--- a/src/axom/sidre/tests/sidre_external.cpp
+++ b/src/axom/sidre/tests/sidre_external.cpp
@@ -171,7 +171,7 @@ TEST(sidre_external, transition_external_view_to_empty)
   EXPECT_EQ(idata, view->getVoidPtr());
 
   // Transition from EXTERNAL to EMPTY
-  view->setExternalDataPtr(NULL);
+  view->setExternalDataPtr(nullptr);
 
   EXPECT_TRUE(view->isDescribed());
   EXPECT_FALSE(view->isAllocated());

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -1024,7 +1024,7 @@ TEST(sidre_group, create_destroy_has_view)
   IndexType indx = group->getFirstValidViewIndex();
   IndexType bindx = group->getView(indx)->getBuffer()->getIndex();
   group->destroyViewAndData(indx);
-  EXPECT_TRUE(ds->getBuffer(bindx) == NULL);
+  EXPECT_TRUE(ds->getBuffer(bindx) == nullptr);
 
   // Destroy view but not the buffer
   view = group->createViewAndAllocate("viewWithLength2", INT_ID, 50);
@@ -2323,7 +2323,7 @@ TEST(sidre_group, save_restore_external_data)
     int2d1[i] = i;
     int2d2[i] = 0;
   }
-  foo3 = NULL;
+  foo3 = nullptr;
 
   DataStore* ds1 = new DataStore();
   Group* root1 = ds1->getRoot();

--- a/src/axom/sidre/tests/sidre_opaque_C.cpp
+++ b/src/axom/sidre/tests/sidre_opaque_C.cpp
@@ -25,7 +25,7 @@ enum DType
   _UnknownType_
 };
 
-using AA_extent = struct
+struct AA_extent
 {
   int ilo;
   int ihi;
@@ -60,7 +60,7 @@ int AA_get_num_pts(AA_extent* self, Centering cent)
   return retval;
 }
 
-using AA_meshvar = struct
+struct AA_meshvar
 {
   Centering cent;
   DType type;

--- a/src/axom/sidre/tests/sidre_opaque_C.cpp
+++ b/src/axom/sidre/tests/sidre_opaque_C.cpp
@@ -25,11 +25,11 @@ enum DType
   _UnknownType_
 };
 
-typedef struct
+using AA_extent = struct
 {
   int ilo;
   int ihi;
-} AA_extent;
+};
 
 AA_extent* AA_extent_new(int lo, int hi)
 {
@@ -60,12 +60,12 @@ int AA_get_num_pts(AA_extent* self, Centering cent)
   return retval;
 }
 
-typedef struct
+using AA_meshvar = struct
 {
   Centering cent;
   DType type;
   int depth;
-} AA_meshvar;
+};
 
 AA_meshvar* AA_meshvar_new(Centering cent, DType type, int depth)
 {

--- a/src/axom/sidre/tests/sidre_view.cpp
+++ b/src/axom/sidre/tests/sidre_view.cpp
@@ -1180,7 +1180,7 @@ TEST(sidre_view, view_offset_and_stride)
   //          string, scalar, empty, opaque
   Group* othersGroup = root->createGroup("others");
 
-  typedef std::vector<View*> ViewVec;
+  using ViewVec = std::vector<View*>;
   ViewVec views;
   std::uint8_t ui8 = 3;
   std::uint16_t ui16 = 4;

--- a/src/axom/sidre/tests/spio/spio_basic.hpp
+++ b/src/axom/sidre/tests/spio/spio_basic.hpp
@@ -29,7 +29,7 @@ TEST(spio_basic, root_name)
   protocolMap["json"] = "json";
   protocolMap["sidre_conduit_json"] = "conduit_json";
 
-  typedef std::map<std::string, std::string>::const_iterator MapIt;
+  using MapIt = std::map<std::string, std::string>::const_iterator;
   for(MapIt it = protocolMap.begin(); it != protocolMap.end(); ++it)
   {
     const std::string& sidreProtocol = it->first;

--- a/src/axom/slam/tests/slam_map_BivariateMap.cpp
+++ b/src/axom/slam/tests/slam_map_BivariateMap.cpp
@@ -51,12 +51,12 @@ using RelationSetType = slam::RelationSet<RelationType>;
 template <typename T, typename B, typename I, typename S>
 using BivariateMapType = slam::BivariateMap<T, B, I, S>;
 
-static const SetPosition MAX_SET_SIZE1 = 10;
-static const SetPosition MAX_SET_SIZE2 = 15;
+constexpr SetPosition MAX_SET_SIZE1 = 10;
+constexpr SetPosition MAX_SET_SIZE2 = 15;
 
-static double const multFac3 = 0000.1;
-static double const multFac1 = 1000.0;
-static double const multFac2 = 0010.0;
+constexpr double multFac3 = 0000.1;
+constexpr double multFac1 = 1000.0;
+constexpr double multFac2 = 0010.0;
 
 }  // end anonymous namespace
 

--- a/src/axom/slam/tests/slam_map_DynamicMap.cpp
+++ b/src/axom/slam/tests/slam_map_DynamicMap.cpp
@@ -26,7 +26,7 @@ using SetPosition = slam::DefaultPositionType;
 using SetElement = slam::DefaultElementType;
 using SetType = slam::DynamicSet<SetPosition, SetElement>;
 
-static const SetPosition MAX_SET_SIZE = 10;
+constexpr SetPosition MAX_SET_SIZE = 10;
 
 using IntMap = slam::DynamicMap<SetType, int>;
 using RealMap = slam::DynamicMap<SetType, double>;

--- a/src/axom/slam/tests/slam_map_Map.cpp
+++ b/src/axom/slam/tests/slam_map_Map.cpp
@@ -31,7 +31,7 @@ using RealMap = slam::Map<double, BaseSet>;
 template <typename T>
 using VecIndirection = policies::STLVectorIndirection<SetPosition, T>;
 
-static SetPosition const MAX_SET_SIZE = 10;
+constexpr SetPosition MAX_SET_SIZE = 10;
 
 template <int S>
 using CompileTimeStrideType = policies::CompileTimeStride<int, S>;

--- a/src/axom/slam/tests/slam_map_SubMap.cpp
+++ b/src/axom/slam/tests/slam_map_SubMap.cpp
@@ -41,9 +41,9 @@ using OrderedSetType = axom::slam::OrderedSet<
   slam::policies::StrideOne<PositionType>,
   slam::policies::STLVectorIndirection<PositionType, ElementType>>;
 
-static const double multFac = 1.0001;
+constexpr double multFac = 1.0001;
 
-static PositionType const MAX_SET_SIZE = 10;
+PositionType const MAX_SET_SIZE = 10;
 
 template <typename T>
 T getValue(int idx)

--- a/src/axom/slam/tests/slam_set_BivariateSet.cpp
+++ b/src/axom/slam/tests/slam_set_BivariateSet.cpp
@@ -26,11 +26,11 @@ namespace policies = axom::slam::policies;
 
 namespace
 {
-static const int SET_SIZE_1 = 5;
-static const int SET_SIZE_2 = 16;
+constexpr int SET_SIZE_1 = 5;
+constexpr int SET_SIZE_2 = 16;
 
-static const int SET_OFFSET_1 = 3;
-static const int SET_OFFSET_2 = 2;
+constexpr int SET_OFFSET_1 = 3;
+constexpr int SET_OFFSET_2 = 2;
 
 // Template aliases to simplify specifying some sets and relations
 template <typename P, typename E, typename FromSet, typename ToSet>

--- a/src/axom/slam/tests/slam_set_IndirectionSet.cpp
+++ b/src/axom/slam/tests/slam_set_IndirectionSet.cpp
@@ -24,7 +24,7 @@ namespace slam = axom::slam;
 
 namespace
 {
-static const int MAX_SET_SIZE = 10;
+constexpr int MAX_SET_SIZE = 10;
 }
 
 /**

--- a/src/axom/slam/tests/slam_set_Iterator.cpp
+++ b/src/axom/slam/tests/slam_set_Iterator.cpp
@@ -41,7 +41,7 @@ using RangeSet = slam::RangeSet<SetPosition, SetElement>;
 using VectorSet = slam::VectorIndirectionSet<SetPosition, SetElement>;
 using CArraySet = slam::CArrayIndirectionSet<SetPosition, SetElement>;
 
-static const int SET_SIZE = 10;
+constexpr int SET_SIZE = 10;
 
 /// Utility function to initialize a set for the test data
 /// Specialized for each set type

--- a/src/axom/slam/tests/slam_set_PositionSet.cpp
+++ b/src/axom/slam/tests/slam_set_PositionSet.cpp
@@ -27,7 +27,7 @@ using SetType = axom::slam::PositionSet<>;
 using SetPosition = SetType::PositionType;
 using SetElement = SetType::ElementType;
 
-static const SetPosition MAX_SET_SIZE = 10;
+constexpr SetPosition MAX_SET_SIZE = 10;
 
 }  // end anonymous namespace
 

--- a/src/axom/slam/tests/slam_set_RangeSet.cpp
+++ b/src/axom/slam/tests/slam_set_RangeSet.cpp
@@ -32,10 +32,10 @@ using SetType = axom::slam::RangeSet<>;
 using SetPosition = SetType::PositionType;
 using SetElement = SetType::ElementType;
 
-static const SetPosition MAX_SIZE = 20;
-static const SetElement lowerIndex = static_cast<SetElement>(.3 * MAX_SIZE);
-static const SetElement upperIndex = static_cast<SetElement>(.7 * MAX_SIZE);
-static const SetElement range = upperIndex - lowerIndex;
+constexpr SetPosition MAX_SIZE = 20;
+constexpr SetElement lowerIndex = static_cast<SetElement>(.3 * MAX_SIZE);
+constexpr SetElement upperIndex = static_cast<SetElement>(.7 * MAX_SIZE);
+constexpr SetElement range = upperIndex - lowerIndex;
 
 }  // end anonymous namespace
 

--- a/src/axom/slam/tests/slam_set_Set.cpp
+++ b/src/axom/slam/tests/slam_set_Set.cpp
@@ -14,7 +14,7 @@
 
 namespace
 {
-static int const NUM_ELEMS = 5;
+constexpr int NUM_ELEMS = 5;
 
 namespace slam = axom::slam;
 using RangeSetType = slam::RangeSet<>;

--- a/src/axom/spin/tests/spin_morton.cpp
+++ b/src/axom/spin/tests/spin_morton.cpp
@@ -26,7 +26,7 @@ using axom::primal::Point;
 
 namespace
 {
-static const int MAX_ITER = 10000;
+constexpr int MAX_ITER = 10000;
 
 // Generate a random integer in the range [beg, end)
 template <typename CoordType>

--- a/src/thirdparty/tests/compiler_flag_strict_aliasing.cpp
+++ b/src/thirdparty/tests/compiler_flag_strict_aliasing.cpp
@@ -29,7 +29,7 @@ struct Bar
 
 int main()
 {
-  Foo foo = {1, NULL};
+  Foo foo = {1, nullptr};
   ((Bar*)(&foo))->i++;  // violates strict aliasing
 
   std::cout << " foo.i: " << foo.i << std::endl;

--- a/src/thirdparty/tests/compiler_flag_unused_local_typedef.cpp
+++ b/src/thirdparty/tests/compiler_flag_unused_local_typedef.cpp
@@ -14,7 +14,9 @@
 
 int main()
 {
-  using IntT = int;
+  // NOLINTBEGIN
+  typedef int IntT;
+  // NOLINTEND
 
   std::cout << "I have defined type IntT, but am not using it." << std::endl;
   return 0;

--- a/src/thirdparty/tests/compiler_flag_unused_local_typedef.cpp
+++ b/src/thirdparty/tests/compiler_flag_unused_local_typedef.cpp
@@ -14,7 +14,7 @@
 
 int main()
 {
-  typedef int IntT;
+  using IntT = int;
 
   std::cout << "I have defined type IntT, but am not using it." << std::endl;
   return 0;

--- a/src/thirdparty/tests/hdf5_smoke.cpp
+++ b/src/thirdparty/tests/hdf5_smoke.cpp
@@ -59,7 +59,7 @@ TEST(hdf5_smoke, create_dset)
   // Create the data space for the dataset.
   dims[0] = 4;
   dims[1] = 6;
-  dataspace_id = H5Screate_simple(2, dims, NULL);
+  dataspace_id = H5Screate_simple(2, dims, nullptr);
   EXPECT_GE(dataspace_id, 0);
 
   // Create the dataset.

--- a/src/thirdparty/tests/sparsehash_smoke.cpp
+++ b/src/thirdparty/tests/sparsehash_smoke.cpp
@@ -17,7 +17,7 @@
 //-----------------------------------------------------------------------------
 TEST(sparsehash_smoke, basic_use)
 {
-  typedef axom::google::dense_hash_map<std::string, double> MapType;
+  using MapType = axom::google::dense_hash_map<std::string, double>;
 
   const std::string deletedKey = "DELETED";
   const std::string emptyKey = "EMPTY";


### PR DESCRIPTION
# Summary

- This PR resolves some minor issues/warnings and applies clang-tidy rules to the code
- Resolves https://github.com/LLNL/axom/issues/1223
- Resolves https://github.com/LLNL/axom/issues/1248
   -  I couldn't reproduce the issue exactly, but I think the change should resolve it based on the description
- It also (partially) applies the following clang-tidy rules. In some cases, I had to revert clang-tidy changes, e.g. when it modified the auto-generated shroud files:
   - readability-braces-around-statements
   - modernize-use-using
   - readability-static-definition-in-anonymous-namespace
   - modernize-use-nullptr