### PR TITLE
Bugfix when loading group with attributes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -59,6 +59,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - primal's `Polygon` area computation in 3D previously only worked when the polygon was aligned with the XY-plane. It now works for arbitrary polygons.
 - Upgrades our `vcpkg` usage for automated Windows builds of our TPLs to its [2023.12.12 release](https://github.com/microsoft/vcpkg/releases/tag/2023.12.12)
 - Fixed a bug in the bounds checks for `primal::clip(Triangle, BoundingBox)`
+- Fixed a bug when loading Sidre groups with attributes that already exist
 
 ## [Version 0.8.1] - Release date 2023-08-16
 

--- a/src/axom/sidre/core/AttrValues.cpp
+++ b/src/axom/sidre/core/AttrValues.cpp
@@ -35,33 +35,21 @@ namespace sidre
  */
 bool AttrValues::hasValue(const Attribute* attr) const
 {
-  if(attr == nullptr)
+  // check for empty values
+  if(attr == nullptr || m_values == nullptr)
   {
     return false;
   }
 
-  if(m_values == nullptr)
-  {
-    // No attributes have been set in this View.
-    return false;
-  }
-
-  IndexType iattr = attr->getIndex();
-
-  if((size_t)iattr >= m_values->size())
+  const auto iattr = static_cast<std::size_t>(attr->getIndex());
+  if(iattr >= m_values->size())
   {
     // This attribute has not been set for this View.
     return false;
   }
 
   Node& value = (*m_values)[iattr];
-
-  if(isEmpty(value))
-  {
-    return false;
-  }
-
-  return true;
+  return !isEmpty(value);
 }
 
 /*
@@ -87,9 +75,8 @@ bool AttrValues::setToDefault(const Attribute* attr)
     return true;
   }
 
-  IndexType iattr = attr->getIndex();
-
-  if((size_t)iattr >= m_values->size())
+  const auto iattr = static_cast<std::size_t>(attr->getIndex());
+  if(iattr >= m_values->size())
   {
     // This attribute has not been set for this View, already default.
     return true;
@@ -117,13 +104,13 @@ bool AttrValues::createNode(IndexType iattr)
     m_values = new(std::nothrow) Values();
   }
 
-  if((size_t)iattr >= m_values->size())
+  if(static_cast<std::size_t>(iattr) >= m_values->size())
   {
     // Create all attributes up to iattr, push back empty Nodes
     m_values->reserve(iattr + 1);
     for(int n = m_values->size(); n < iattr + 1; ++n)
     {
-      m_values->push_back(Node());
+      m_values->emplace_back(Node());
     }
   }
 
@@ -192,9 +179,8 @@ const Node& AttrValues::getValueNodeRef(const Attribute* attr) const
     return attr->getDefaultNodeRef();
   }
 
-  IndexType iattr = attr->getIndex();
-
-  if((size_t)iattr >= m_values->size())
+  const auto iattr = static_cast<std::size_t>(attr->getIndex());
+  if(iattr >= m_values->size())
   {
     // This attribute has not been set for this View
     return attr->getDefaultNodeRef();

--- a/src/axom/sidre/core/AttrValues.hpp
+++ b/src/axom/sidre/core/AttrValues.hpp
@@ -58,16 +58,12 @@ class View;
  * avoid multiple messages for the same error.  For example, if the
  * index cannot be converted to an Attribute pointer in the View
  * class, an error message will be printing and then a NULL pointer
- * passed to the AttrValues class which will not print another
- * message.
+ * passed to the AttrValues class which will not print another message.
  */
 class AttrValues
 {
 public:
-  /*!
-   * Friend declarations to constrain usage via controlled access to
-   * private members.
-   */
+  /// Friend declarations to constrain usage via controlled access to private members.
   friend class View;
 
 private:
@@ -106,7 +102,7 @@ private:
   template <typename ScalarType>
   bool setScalar(const Attribute* attr, ScalarType value)
   {
-    DataTypeId arg_id = detail::SidreTT<ScalarType>::id;
+    const DataTypeId arg_id = detail::SidreTT<ScalarType>::id;
     if(arg_id != attr->getTypeID())
     {
       SLIC_CHECK_MSG(arg_id == attr->getTypeID(),
@@ -117,8 +113,8 @@ private:
       return false;
     }
 
-    IndexType iattr = attr->getIndex();
-    bool ok = createNode(iattr);
+    const IndexType iattr = attr->getIndex();
+    const bool ok = createNode(iattr);
     if(ok)
     {
       (*m_values)[iattr] = value;
@@ -131,7 +127,7 @@ private:
    */
   bool setString(const Attribute* attr, const std::string& value)
   {
-    DataTypeId arg_id = CHAR8_STR_ID;
+    const DataTypeId arg_id = CHAR8_STR_ID;
     if(arg_id != attr->getTypeID())
     {
       SLIC_CHECK_MSG(arg_id == attr->getTypeID(),
@@ -142,8 +138,8 @@ private:
       return false;
     }
 
-    IndexType iattr = attr->getIndex();
-    bool ok = createNode(iattr);
+    const IndexType iattr = attr->getIndex();
+    const bool ok = createNode(iattr);
     if(ok)
     {
       (*m_values)[iattr] = value;
@@ -159,8 +155,8 @@ private:
    */
   bool setNode(const Attribute* attr, const Node& node)
   {
-    IndexType iattr = attr->getIndex();
-    bool ok = createNode(iattr);
+    const IndexType iattr = attr->getIndex();
+    const bool ok = createNode(iattr);
     if(ok)
     {
       (*m_values)[iattr] = node;

--- a/src/axom/sidre/core/DataStore.cpp
+++ b/src/axom/sidre/core/DataStore.cpp
@@ -637,14 +637,9 @@ bool DataStore::saveAttributeLayout(Node& node) const
 
   bool hasAttributes = false;
 
-  IndexType aidx = getFirstValidAttributeIndex();
-  while(indexIsValid(aidx))
+  for(const auto& attr : attributes())
   {
-    const Attribute* attr = getAttribute(aidx);
-
-    node[attr->getName()] = attr->getDefaultNodeRef();
-
-    aidx = getNextValidAttributeIndex(aidx);
+    node[attr.getName()] = attr.getDefaultNodeRef();
     hasAttributes = true;
   }
 
@@ -670,7 +665,9 @@ void DataStore::loadAttributeLayout(Node& node)
       Node& n_attr = attrs_itr.next();
       std::string attr_name = attrs_itr.name();
 
-      Attribute* attr = createAttributeEmpty(attr_name);
+      auto* attr = !hasAttribute(attr_name) ? createAttributeEmpty(attr_name)
+                                            : getAttribute(attr_name);
+
       attr->setDefaultNodeRef(n_attr);
     }
   }

--- a/src/axom/sidre/core/DataStore.hpp
+++ b/src/axom/sidre/core/DataStore.hpp
@@ -391,9 +391,7 @@ public:
    */
   bool saveAttributeLayout(Node& node) const;
 
-  /*!
-   * \brief Create attributes from name/value pairs in node["attribute"].
-   */
+  /// \brief Create attributes from name/value pairs in node["attribute"].
   void loadAttributeLayout(Node& node);
 
   //@}

--- a/src/axom/sidre/core/DataStore.hpp
+++ b/src/axom/sidre/core/DataStore.hpp
@@ -279,7 +279,7 @@ public:
   IndexType getNumAttributes() const;
 
   /*!
-   * \brief Create a Attribute object with a default scalar value.
+   * \brief Create an Attribute object with a default scalar value.
    *
    *        The Attribute object is assigned a unique index when created and the
    *        Attribute object is owned by the DataStore object.
@@ -297,7 +297,7 @@ public:
   }
 
   /*!
-   * \brief Create a Attribute object with a default string value.
+   * \brief Create an Attribute object with a default string value.
    *
    *        The Attribute object is assigned a unique index when created and the
    *        Attribute object is owned by the DataStore object.
@@ -313,20 +313,14 @@ public:
     return new_attribute;
   }
 
-  /*!
-   * \brief Return true if DataStore has created attribute name; else false.
-   */
+  /// \brief Return true if DataStore has created attribute name, else false
   bool hasAttribute(const std::string& name) const;
 
-  /*!
-   * \brief Return true if DataStore has created attribute with index; else
-   * false.
-   */
+  /// \brief Return true if DataStore has created attribute with index, else false
   bool hasAttribute(IndexType idx) const;
 
   /*!
-   * \brief Remove Attribute from the DataStore and destroy it and
-   *        its data.
+   * \brief Remove Attribute from the DataStore and destroy it and its data.
    *
    * \note Destruction of an Attribute detaches it from all Views to
    *       which it is attached.
@@ -343,8 +337,7 @@ public:
   void destroyAttribute(IndexType idx);
 
   /*!
-   * \brief Remove Attribute from the DataStore and destroy it and
-   *        its data.
+   * \brief Remove Attribute from the DataStore and destroy it and its data.
    *
    * \note Destruction of an Attribute detaches it from all Views to
    *       which it is attached.
@@ -352,8 +345,7 @@ public:
   void destroyAttribute(Attribute* attr);
 
   /*!
-   * \brief Remove all Attributes from the DataStore and destroy them
-   *        and their data.
+   * \brief Remove all Attributes from the DataStore and destroy them and their data.
    *
    * \note Destruction of an Attribute detaches it from all Views to
    *       which it is attached.
@@ -434,8 +426,7 @@ public:
 
   /*!
    * \brief Return next valid Attribute index in DataStore object after given
-   * index (i.e., smallest index over all Attribute indices larger than given
-   * one).
+   * index (i.e., smallest index over all Attribute indices larger than given one).
    *
    * sidre::InvalidIndex is returned if there is no valid index greater
    * than given one.

--- a/src/axom/sidre/tests/sidre_attribute.cpp
+++ b/src/axom/sidre/tests/sidre_attribute.cpp
@@ -16,6 +16,8 @@ using axom::sidre::DataStore;
 using axom::sidre::DOUBLE_ID;
 using axom::sidre::Group;
 using axom::sidre::IndexType;
+using axom::sidre::INT32_ID;
+using axom::sidre::INT64_ID;
 using axom::sidre::INT_ID;
 using axom::sidre::InvalidIndex;
 using axom::sidre::Node;
@@ -61,6 +63,8 @@ const std::string g_protocols[] = {"sidre_json", "json"};
 //
 TEST(sidre_attribute, create_attr)
 {
+  SLIC_INFO("Some warnings are expected in the 'create_attr' test");
+
   bool ok;
 
   DataStore* ds = new DataStore();
@@ -162,6 +166,8 @@ TEST(sidre_attribute, create_attr)
 
 TEST(sidre_attribute, view_attr)
 {
+  SLIC_INFO("Some warnings are expected in the 'view_attr' test");
+
   // Note: This test relies on re-wiring conduit error handlers
   DataStore::setConduitSLICMessageHandlers();
 
@@ -302,6 +308,8 @@ TEST(sidre_attribute, view_attr)
 
 TEST(sidre_attribute, view_int_and_double)
 {
+  SLIC_INFO("Some warnings are expected in the 'view_int_and_double' test");
+
   // Note: This test relies on re-wiring conduit error handlers
   DataStore::setConduitSLICMessageHandlers();
 
@@ -377,6 +385,8 @@ TEST(sidre_attribute, view_int_and_double)
 
 TEST(sidre_attribute, set_default)
 {
+  SLIC_INFO("Some warnings are expected in the 'set_default' test");
+
   bool ok;
 
   DataStore* ds = new DataStore();
@@ -436,6 +446,8 @@ TEST(sidre_attribute, set_default)
 
 TEST(sidre_attribute, as_node)
 {
+  SLIC_INFO("Some warnings are expected in the 'as_node' test");
+
   bool ok;
 
   DataStore* ds = new DataStore();
@@ -475,6 +487,8 @@ TEST(sidre_attribute, as_node)
 
 TEST(sidre_attribute, overloads)
 {
+  SLIC_INFO("Some warnings are expected in the 'overloads' test");
+
   // Note: This test relies on re-wiring conduit error handlers
   DataStore::setConduitSLICMessageHandlers();
 
@@ -969,4 +983,163 @@ TEST(sidre_attribute, save_by_attribute)
 
     delete ds2;
   }
+}
+
+TEST(sidre_attribute, save_load_group_with_attributes_new_ds)
+{
+  const std::string protocol = "sidre_json";
+  const std::string filename = "saveFile.json";
+
+  axom::sidre::DataStore ds1;
+  axom::sidre::DataStore ds2;
+
+  // set up first datastore and save to disk
+  {
+    ds1.createAttributeScalar("attr", 10);
+    ds1.createAttributeString(g_name_color, g_color_none);  // create the attribute
+
+    auto* gr = ds1.getRoot()->createGroup("gr");
+    gr->createViewScalar("scalar1", 1);
+    gr->createViewScalar("scalar2", 2)->setAttributeString(g_name_color, g_color_red);
+    gr->createViewScalar("scalar3", 3)->setAttributeString(g_name_color, g_color_blue);
+
+    EXPECT_EQ(2, ds1.getNumAttributes());
+    EXPECT_TRUE(INT32_ID == ds1.getAttribute("attr")->getTypeID() ||
+                INT64_ID == ds1.getAttribute("attr")->getTypeID());
+    EXPECT_EQ(CHAR8_STR_ID, ds1.getAttribute(g_name_color)->getTypeID());
+
+    EXPECT_FALSE(gr->getView("scalar1")->hasAttributeValue(g_name_color));
+
+    EXPECT_TRUE(gr->getView("scalar2")->hasAttributeValue(g_name_color));
+    EXPECT_EQ(g_color_red,
+              gr->getView("scalar2")->getAttributeString(g_name_color));
+
+    EXPECT_TRUE(gr->getView("scalar3")->hasAttributeValue(g_name_color));
+    EXPECT_EQ(g_color_blue,
+              gr->getView("scalar3")->getAttributeString(g_name_color));
+
+    gr->save(filename, protocol);
+  }
+
+  // load second datastore from saved data
+  {
+    auto* gr = ds2.getRoot()->createGroup("gr");
+    gr->load(filename, protocol);
+
+    EXPECT_EQ(2, ds2.getNumAttributes());
+    EXPECT_TRUE(INT32_ID == ds2.getAttribute("attr")->getTypeID() ||
+                INT64_ID == ds2.getAttribute("attr")->getTypeID());
+
+    EXPECT_EQ(CHAR8_STR_ID, ds2.getAttribute(g_name_color)->getTypeID());
+
+    EXPECT_TRUE(gr->hasView("scalar1"));
+    EXPECT_FALSE(gr->getView("scalar1")->hasAttributeValue(g_name_color));
+
+    EXPECT_TRUE(gr->hasView("scalar2"));
+    EXPECT_TRUE(gr->getView("scalar2")->hasAttributeValue(g_name_color));
+    EXPECT_EQ(g_color_red,
+              gr->getView("scalar2")->getAttributeString(g_name_color));
+
+    EXPECT_TRUE(gr->hasView("scalar3"));
+    EXPECT_TRUE(gr->getView("scalar3")->hasAttributeValue(g_name_color));
+    EXPECT_EQ(g_color_blue,
+              gr->getView("scalar3")->getAttributeString(g_name_color));
+  }
+
+  EXPECT_EQ(ds1.getNumAttributes(), ds2.getNumAttributes());
+  EXPECT_EQ(ds1.getAttribute(g_name_color)->getName(),
+            ds2.getAttribute(g_name_color)->getName());
+  EXPECT_EQ(ds1.getAttribute(g_name_color)->getTypeID(),
+            ds2.getAttribute(g_name_color)->getTypeID());
+  EXPECT_EQ(ds1.getAttribute(g_name_color)->getDefaultNodeRef().to_string(),
+            ds2.getAttribute(g_name_color)->getDefaultNodeRef().to_string());
+}
+
+TEST(sidre_attribute, save_load_group_with_attributes_same_ds)
+{
+  const std::string protocol = "sidre_json";
+  const std::string filename = "saveFile.json";
+
+  axom::sidre::DataStore ds;
+
+  // create the attributes
+  ds.createAttributeScalar("attr", 10);
+  ds.createAttributeString(g_name_color, g_color_none);
+
+  // attach some attributes to views
+  auto* gr = ds.getRoot()->createGroup("gr");
+  gr->createViewScalar("scalar1", 1);
+  gr->createViewScalar("scalar2", 2)->setAttributeString(g_name_color, g_color_red);
+  gr->createViewScalar("scalar3", 3)->setAttributeString(g_name_color, g_color_blue);
+
+  EXPECT_EQ(2, ds.getNumAttributes());
+
+  EXPECT_FALSE(gr->getView("scalar1")->hasAttributeValue(g_name_color));
+
+  EXPECT_TRUE(gr->getView("scalar2")->hasAttributeValue(g_name_color));
+  EXPECT_EQ(g_color_red,
+            gr->getView("scalar2")->getAttributeString(g_name_color));
+
+  EXPECT_TRUE(gr->getView("scalar3")->hasAttributeValue(g_name_color));
+  EXPECT_EQ(g_color_blue,
+            gr->getView("scalar3")->getAttributeString(g_name_color));
+
+  gr->save(filename, protocol);
+
+  {
+    gr->load(filename, protocol);
+
+    // Check that things are still as expected after loading
+    EXPECT_EQ(2, ds.getNumAttributes());
+
+    EXPECT_FALSE(gr->getView("scalar1")->hasAttributeValue(g_name_color));
+
+    EXPECT_TRUE(gr->getView("scalar2")->hasAttributeValue(g_name_color));
+    EXPECT_EQ(g_color_red,
+              gr->getView("scalar2")->getAttributeString(g_name_color));
+
+    EXPECT_TRUE(gr->getView("scalar3")->hasAttributeValue(g_name_color));
+    EXPECT_EQ(g_color_blue,
+              gr->getView("scalar3")->getAttributeString(g_name_color));
+  }
+
+  // check that changes to attributes get overwritten when loading
+  {
+    // modify/remove some attributes before loading
+    ds.destroyAttribute("attr");
+    gr->getView("scalar1")->setAttributeString(g_name_color, g_color_red);
+    gr->getView("scalar2")->setAttributeToDefault(g_name_color);
+    gr->getView("scalar3")->setAttributeString(g_name_color, g_color_red);
+
+    EXPECT_EQ(1, ds.getNumAttributes());
+
+    // reload group from file; this should revert changes
+    gr->load(filename, protocol);
+
+    // Check that things are reverted after loading
+    EXPECT_EQ(2, ds.getNumAttributes());
+
+    EXPECT_FALSE(gr->getView("scalar1")->hasAttributeValue(g_name_color));
+
+    EXPECT_TRUE(gr->getView("scalar2")->hasAttributeValue(g_name_color));
+    EXPECT_EQ(g_color_red,
+              gr->getView("scalar2")->getAttributeString(g_name_color));
+
+    EXPECT_TRUE(gr->getView("scalar3")->hasAttributeValue(g_name_color));
+    EXPECT_EQ(g_color_blue,
+              gr->getView("scalar3")->getAttributeString(g_name_color));
+  }
+}
+
+//------------------------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+  int result = 0;
+
+  ::testing::InitGoogleTest(&argc, argv);
+  axom::slic::SimpleLogger logger;
+
+  result = RUN_ALL_TESTS();
+
+  return result;
 }

--- a/src/axom/sidre/tests/sidre_attribute.cpp
+++ b/src/axom/sidre/tests/sidre_attribute.cpp
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/config.hpp"  // for AXOM_USE_HDF5
+#include "axom/config.hpp"
 #include "axom/sidre.hpp"
 
 #include "axom/fmt.hpp"
@@ -916,8 +916,7 @@ TEST(sidre_attribute, save_by_attribute)
   // Create a deep path with and without attribute
   root1->createViewScalar("grp1a/grp1b/view3", 3);
 
-  root1->createViewScalar("grp2a/view4", 4);  // make sure empty "views" not
-                                              // saved
+  root1->createViewScalar("grp2a/view4", 4);  // make sure empty "views" not saved
   root1->createViewScalar("grp2a/grp2b/view5", 5)
     ->setAttributeScalar(dump, g_dump_yes);
 

--- a/src/axom/sidre/tests/sidre_attribute.cpp
+++ b/src/axom/sidre/tests/sidre_attribute.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "axom/config.hpp"
+#include "axom/core.hpp"
 #include "axom/sidre.hpp"
 
 #include "axom/fmt.hpp"
@@ -57,6 +58,11 @@ const std::string g_protocols[] = {"sidre_json", "sidre_hdf5", "json"};
 const int g_nprotocols = 2;
 const std::string g_protocols[] = {"sidre_json", "json"};
 #endif
+
+const std::set<std::string> g_protocol_saves_attributes {"sidre_hdf5",
+                                                         "sidre_conduit_json",
+                                                         "sidre_json",
+                                                         "sidre_layout_json"};
 
 //------------------------------------------------------------------------------
 // Create attribute in a Datastore
@@ -987,26 +993,126 @@ TEST(sidre_attribute, save_by_attribute)
 
 TEST(sidre_attribute, save_load_group_with_attributes_new_ds)
 {
-  const std::string protocol = "sidre_json";
-  const std::string filename = "saveFile.json";
+  using axom::utilities::string::endsWith;
 
-  axom::sidre::DataStore ds1;
-  axom::sidre::DataStore ds2;
-
-  // set up first datastore and save to disk
+  for(const auto& protocol : g_protocols)
   {
-    ds1.createAttributeScalar("attr", 10);
-    ds1.createAttributeString(g_name_color, g_color_none);  // create the attribute
+    axom::sidre::DataStore ds1, ds2;
 
-    auto* gr = ds1.getRoot()->createGroup("gr");
+    const std::string ext = endsWith(protocol, "hdf5") ? "hdf5" : "json";
+    const std::string filename =
+      axom::fmt::format("saveFile_{}.{}", protocol, ext);
+
+    SLIC_INFO(axom::fmt::format(
+      "Checking attribute save/load w/ protocol '{}' using file '{}'",
+      protocol,
+      filename));
+
+    // set up first datastore and save to disk
+    {
+      // create the attributes
+      ds1.createAttributeScalar("attr", 10);
+      ds1.createAttributeString(g_name_color, g_color_none);
+
+      // create groups/views and attach attributes
+      auto* gr = ds1.getRoot()->createGroup("gr");
+      gr->createViewScalar("scalar1", 1);
+      gr->createViewScalar("scalar2", 2)
+        ->setAttributeString(g_name_color, g_color_red);
+      gr->createViewScalar("scalar3", 3)
+        ->setAttributeString(g_name_color, g_color_blue);
+
+      EXPECT_EQ(2, ds1.getNumAttributes());
+      EXPECT_TRUE(INT32_ID == ds1.getAttribute("attr")->getTypeID() ||
+                  INT64_ID == ds1.getAttribute("attr")->getTypeID());
+      EXPECT_EQ(CHAR8_STR_ID, ds1.getAttribute(g_name_color)->getTypeID());
+
+      EXPECT_FALSE(gr->getView("scalar1")->hasAttributeValue(g_name_color));
+
+      EXPECT_TRUE(gr->getView("scalar2")->hasAttributeValue(g_name_color));
+      EXPECT_EQ(g_color_red,
+                gr->getView("scalar2")->getAttributeString(g_name_color));
+
+      EXPECT_TRUE(gr->getView("scalar3")->hasAttributeValue(g_name_color));
+      EXPECT_EQ(g_color_blue,
+                gr->getView("scalar3")->getAttributeString(g_name_color));
+
+      gr->save(filename, protocol);
+    }
+
+    if(g_protocol_saves_attributes.find(protocol) ==
+       g_protocol_saves_attributes.end())
+    {
+      SLIC_INFO(
+        axom::fmt::format("Skipping attribute load tests for protocol '{}' -- "
+                          "it doesn't support saving attributes",
+                          protocol));
+      continue;
+    }
+
+    // load second datastore from saved data
+    {
+      auto* gr = ds2.getRoot()->createGroup("gr");
+      gr->load(filename, protocol);
+
+      EXPECT_EQ(2, ds2.getNumAttributes());
+      EXPECT_TRUE(INT32_ID == ds2.getAttribute("attr")->getTypeID() ||
+                  INT64_ID == ds2.getAttribute("attr")->getTypeID());
+
+      EXPECT_EQ(CHAR8_STR_ID, ds2.getAttribute(g_name_color)->getTypeID());
+
+      EXPECT_TRUE(gr->hasView("scalar1"));
+      EXPECT_FALSE(gr->getView("scalar1")->hasAttributeValue(g_name_color));
+
+      EXPECT_TRUE(gr->hasView("scalar2"));
+      EXPECT_TRUE(gr->getView("scalar2")->hasAttributeValue(g_name_color));
+      EXPECT_EQ(g_color_red,
+                gr->getView("scalar2")->getAttributeString(g_name_color));
+
+      EXPECT_TRUE(gr->hasView("scalar3"));
+      EXPECT_TRUE(gr->getView("scalar3")->hasAttributeValue(g_name_color));
+      EXPECT_EQ(g_color_blue,
+                gr->getView("scalar3")->getAttributeString(g_name_color));
+    }
+
+    EXPECT_EQ(ds1.getNumAttributes(), ds2.getNumAttributes());
+    EXPECT_EQ(ds1.getAttribute(g_name_color)->getName(),
+              ds2.getAttribute(g_name_color)->getName());
+    EXPECT_EQ(ds1.getAttribute(g_name_color)->getTypeID(),
+              ds2.getAttribute(g_name_color)->getTypeID());
+    EXPECT_EQ(ds1.getAttribute(g_name_color)->getDefaultNodeRef().to_string(),
+              ds2.getAttribute(g_name_color)->getDefaultNodeRef().to_string());
+  }
+}
+
+TEST(sidre_attribute, save_load_group_with_attributes_same_ds)
+{
+  using axom::utilities::string::endsWith;
+
+  for(const auto& protocol : g_protocols)
+  {
+    axom::sidre::DataStore ds;
+
+    const std::string ext = endsWith(protocol, "hdf5") ? "hdf5" : "json";
+    const std::string filename =
+      axom::fmt::format("saveFile_{}.{}", protocol, ext);
+
+    SLIC_INFO(axom::fmt::format(
+      "Checking attribute save/load w/ protocol '{}' using file '{}'",
+      protocol,
+      filename));
+
+    // create the attributes
+    ds.createAttributeScalar("attr", 10);
+    ds.createAttributeString(g_name_color, g_color_none);
+
+    // attach some attributes to views
+    auto* gr = ds.getRoot()->createGroup("gr");
     gr->createViewScalar("scalar1", 1);
     gr->createViewScalar("scalar2", 2)->setAttributeString(g_name_color, g_color_red);
     gr->createViewScalar("scalar3", 3)->setAttributeString(g_name_color, g_color_blue);
 
-    EXPECT_EQ(2, ds1.getNumAttributes());
-    EXPECT_TRUE(INT32_ID == ds1.getAttribute("attr")->getTypeID() ||
-                INT64_ID == ds1.getAttribute("attr")->getTypeID());
-    EXPECT_EQ(CHAR8_STR_ID, ds1.getAttribute(g_name_color)->getTypeID());
+    EXPECT_EQ(2, ds.getNumAttributes());
 
     EXPECT_FALSE(gr->getView("scalar1")->hasAttributeValue(g_name_color));
 
@@ -1019,115 +1125,60 @@ TEST(sidre_attribute, save_load_group_with_attributes_new_ds)
               gr->getView("scalar3")->getAttributeString(g_name_color));
 
     gr->save(filename, protocol);
-  }
 
-  // load second datastore from saved data
-  {
-    auto* gr = ds2.getRoot()->createGroup("gr");
-    gr->load(filename, protocol);
+    if(g_protocol_saves_attributes.find(protocol) ==
+       g_protocol_saves_attributes.end())
+    {
+      SLIC_INFO(
+        axom::fmt::format("Skipping attribute load tests for protocol '{}' -- "
+                          "it doesn't support saving attributes",
+                          protocol));
+      continue;
+    }
 
-    EXPECT_EQ(2, ds2.getNumAttributes());
-    EXPECT_TRUE(INT32_ID == ds2.getAttribute("attr")->getTypeID() ||
-                INT64_ID == ds2.getAttribute("attr")->getTypeID());
+    {
+      gr->load(filename, protocol);
 
-    EXPECT_EQ(CHAR8_STR_ID, ds2.getAttribute(g_name_color)->getTypeID());
+      // Check that things are still as expected after loading
+      EXPECT_EQ(2, ds.getNumAttributes());
 
-    EXPECT_TRUE(gr->hasView("scalar1"));
-    EXPECT_FALSE(gr->getView("scalar1")->hasAttributeValue(g_name_color));
+      EXPECT_FALSE(gr->getView("scalar1")->hasAttributeValue(g_name_color));
 
-    EXPECT_TRUE(gr->hasView("scalar2"));
-    EXPECT_TRUE(gr->getView("scalar2")->hasAttributeValue(g_name_color));
-    EXPECT_EQ(g_color_red,
-              gr->getView("scalar2")->getAttributeString(g_name_color));
+      EXPECT_TRUE(gr->getView("scalar2")->hasAttributeValue(g_name_color));
+      EXPECT_EQ(g_color_red,
+                gr->getView("scalar2")->getAttributeString(g_name_color));
 
-    EXPECT_TRUE(gr->hasView("scalar3"));
-    EXPECT_TRUE(gr->getView("scalar3")->hasAttributeValue(g_name_color));
-    EXPECT_EQ(g_color_blue,
-              gr->getView("scalar3")->getAttributeString(g_name_color));
-  }
+      EXPECT_TRUE(gr->getView("scalar3")->hasAttributeValue(g_name_color));
+      EXPECT_EQ(g_color_blue,
+                gr->getView("scalar3")->getAttributeString(g_name_color));
+    }
 
-  EXPECT_EQ(ds1.getNumAttributes(), ds2.getNumAttributes());
-  EXPECT_EQ(ds1.getAttribute(g_name_color)->getName(),
-            ds2.getAttribute(g_name_color)->getName());
-  EXPECT_EQ(ds1.getAttribute(g_name_color)->getTypeID(),
-            ds2.getAttribute(g_name_color)->getTypeID());
-  EXPECT_EQ(ds1.getAttribute(g_name_color)->getDefaultNodeRef().to_string(),
-            ds2.getAttribute(g_name_color)->getDefaultNodeRef().to_string());
-}
+    // check that changes to attributes get overwritten when loading
+    {
+      // modify/remove some attributes before loading
+      ds.destroyAttribute("attr");
+      gr->getView("scalar1")->setAttributeString(g_name_color, g_color_red);
+      gr->getView("scalar2")->setAttributeToDefault(g_name_color);
+      gr->getView("scalar3")->setAttributeString(g_name_color, g_color_red);
 
-TEST(sidre_attribute, save_load_group_with_attributes_same_ds)
-{
-  const std::string protocol = "sidre_json";
-  const std::string filename = "saveFile.json";
+      EXPECT_EQ(1, ds.getNumAttributes());
 
-  axom::sidre::DataStore ds;
+      // reload group from file; this should revert changes
+      gr->load(filename, protocol);
 
-  // create the attributes
-  ds.createAttributeScalar("attr", 10);
-  ds.createAttributeString(g_name_color, g_color_none);
+      // Check that things are reverted after loading
+      EXPECT_EQ(2, ds.getNumAttributes());
 
-  // attach some attributes to views
-  auto* gr = ds.getRoot()->createGroup("gr");
-  gr->createViewScalar("scalar1", 1);
-  gr->createViewScalar("scalar2", 2)->setAttributeString(g_name_color, g_color_red);
-  gr->createViewScalar("scalar3", 3)->setAttributeString(g_name_color, g_color_blue);
+      EXPECT_FALSE(gr->getView("scalar1")->hasAttributeValue(g_name_color));
 
-  EXPECT_EQ(2, ds.getNumAttributes());
+      EXPECT_TRUE(gr->getView("scalar2")->hasAttributeValue(g_name_color));
+      EXPECT_EQ(g_color_red,
+                gr->getView("scalar2")->getAttributeString(g_name_color));
 
-  EXPECT_FALSE(gr->getView("scalar1")->hasAttributeValue(g_name_color));
-
-  EXPECT_TRUE(gr->getView("scalar2")->hasAttributeValue(g_name_color));
-  EXPECT_EQ(g_color_red,
-            gr->getView("scalar2")->getAttributeString(g_name_color));
-
-  EXPECT_TRUE(gr->getView("scalar3")->hasAttributeValue(g_name_color));
-  EXPECT_EQ(g_color_blue,
-            gr->getView("scalar3")->getAttributeString(g_name_color));
-
-  gr->save(filename, protocol);
-
-  {
-    gr->load(filename, protocol);
-
-    // Check that things are still as expected after loading
-    EXPECT_EQ(2, ds.getNumAttributes());
-
-    EXPECT_FALSE(gr->getView("scalar1")->hasAttributeValue(g_name_color));
-
-    EXPECT_TRUE(gr->getView("scalar2")->hasAttributeValue(g_name_color));
-    EXPECT_EQ(g_color_red,
-              gr->getView("scalar2")->getAttributeString(g_name_color));
-
-    EXPECT_TRUE(gr->getView("scalar3")->hasAttributeValue(g_name_color));
-    EXPECT_EQ(g_color_blue,
-              gr->getView("scalar3")->getAttributeString(g_name_color));
-  }
-
-  // check that changes to attributes get overwritten when loading
-  {
-    // modify/remove some attributes before loading
-    ds.destroyAttribute("attr");
-    gr->getView("scalar1")->setAttributeString(g_name_color, g_color_red);
-    gr->getView("scalar2")->setAttributeToDefault(g_name_color);
-    gr->getView("scalar3")->setAttributeString(g_name_color, g_color_red);
-
-    EXPECT_EQ(1, ds.getNumAttributes());
-
-    // reload group from file; this should revert changes
-    gr->load(filename, protocol);
-
-    // Check that things are reverted after loading
-    EXPECT_EQ(2, ds.getNumAttributes());
-
-    EXPECT_FALSE(gr->getView("scalar1")->hasAttributeValue(g_name_color));
-
-    EXPECT_TRUE(gr->getView("scalar2")->hasAttributeValue(g_name_color));
-    EXPECT_EQ(g_color_red,
-              gr->getView("scalar2")->getAttributeString(g_name_color));
-
-    EXPECT_TRUE(gr->getView("scalar3")->hasAttributeValue(g_name_color));
-    EXPECT_EQ(g_color_blue,
-              gr->getView("scalar3")->getAttributeString(g_name_color));
+      EXPECT_TRUE(gr->getView("scalar3")->hasAttributeValue(g_name_color));
+      EXPECT_EQ(g_color_blue,
+                gr->getView("scalar3")->getAttributeString(g_name_color));
+    }
   }
 }
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It allows loading a group with attributes into a datastore that already has that attribute
- When loading, only create the attribute if it doesn't already exist, but use the default value from the file
- Includes some minor code cleanup
- Fixes https://github.com/LLNL/axom/issues/67