### PR TITLE
Slic tags for streams and messages

### DIFF
--- a/src/axom/lumberjack/CMakeLists.txt
+++ b/src/axom/lumberjack/CMakeLists.txt
@@ -18,6 +18,7 @@ set(lumberjack_headers
     MPIUtility.hpp
     RootCommunicator.hpp
     TextEqualityCombiner.hpp
+    TextTagCombiner.hpp
     )
 
 set(lumberjack_sources

--- a/src/axom/lumberjack/Lumberjack.cpp
+++ b/src/axom/lumberjack/Lumberjack.cpp
@@ -23,7 +23,7 @@ void Lumberjack::initialize(Communicator* communicator, int ranksLimit)
 {
   m_communicator = communicator;
   m_ranksLimit = ranksLimit;
-  m_combiners.push_back(new TextEqualityCombiner);
+  m_combiners.push_back(new TextTagCombiner);
 }
 
 void Lumberjack::finalize()

--- a/src/axom/lumberjack/Lumberjack.hpp
+++ b/src/axom/lumberjack/Lumberjack.hpp
@@ -22,7 +22,7 @@
 #include "axom/lumberjack/Combiner.hpp"
 #include "axom/lumberjack/Communicator.hpp"
 #include "axom/lumberjack/Message.hpp"
-#include "axom/lumberjack/TextEqualityCombiner.hpp"
+#include "axom/lumberjack/TextTagCombiner.hpp"
 
 namespace axom
 {

--- a/src/axom/lumberjack/TextEqualityCombiner.hpp
+++ b/src/axom/lumberjack/TextEqualityCombiner.hpp
@@ -34,6 +34,9 @@ namespace lumberjack
  *  you. If you want it removed call Lumberjack::removeCombiner with the string
  * "TextEqualityCombiner" as it's parameter.
  *
+ * \warning Using the TextEqualityCombiner with Message::tag has undefined
+ *          behavior.
+ *
  * \see Combiner Lumberjack
  *******************************************************************************
  */

--- a/src/axom/lumberjack/TextEqualityCombiner.hpp
+++ b/src/axom/lumberjack/TextEqualityCombiner.hpp
@@ -40,7 +40,7 @@ namespace lumberjack
 class TextEqualityCombiner : public Combiner
 {
 public:
-  TextEqualityCombiner() : m_id("TextEqualityCombiner") { }
+  TextEqualityCombiner() { }
 
   /*!
    *****************************************************************************
@@ -65,11 +65,7 @@ public:
   bool shouldMessagesBeCombined(const Message& leftMessage,
                                 const Message& rightMessage)
   {
-    if(leftMessage.text().compare(rightMessage.text()) == 0)
-    {
-      return true;
-    }
-    return false;
+    return (leftMessage.text().compare(rightMessage.text()) == 0);
   }
 
   /*!
@@ -83,6 +79,8 @@ public:
    * \param [in] combinee the Message that is combined into the other.
    * \param [in] ranksLimit The limit on how many individual ranks are tracked
    *  in the combined Message. Message::rankCount is always incremented.
+   *
+   * \pre shouldMessagesBeCombined(combined, combinee) must be true
    *****************************************************************************
    */
   void combine(Message& combined, const Message& combinee, const int ranksLimit)
@@ -91,7 +89,7 @@ public:
   }
 
 private:
-  std::string m_id;
+  const std::string m_id = "TextEqualityCombiner";
 };
 
 }  // end namespace lumberjack

--- a/src/axom/lumberjack/TextTagCombiner.hpp
+++ b/src/axom/lumberjack/TextTagCombiner.hpp
@@ -1,0 +1,102 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ *******************************************************************************
+ * \file TextTagCombiner.hpp
+ *
+ * \brief This file contains the class implementation of the
+ * TextTagCombiner.
+ *******************************************************************************
+ */
+
+#ifndef TEXTTAGCOMBINER_HPP
+#define TEXTTAGCOMBINER_HPP
+
+#include "axom/lumberjack/Combiner.hpp"
+#include "axom/lumberjack/Message.hpp"
+
+#include <string>
+
+namespace axom
+{
+namespace lumberjack
+{
+/*!
+ *******************************************************************************
+ * \class Tex
+ *
+ * \brief Combines Message classes if their Message::text and Message::tag
+ *        are equal.
+ *
+ *  This class instance is automatically added to Lumberjack's Lumberjack for
+ *  you. If you want it removed call Lumberjack::removeCombiner with the string
+ * "TextTagCombiner" as it's parameter.
+ *
+ * \see Combiner Lumberjack
+ *******************************************************************************
+ */
+class TextTagCombiner : public Combiner
+{
+public:
+  TextTagCombiner() : m_id("TextTagCombiner") { }
+
+  /*!
+   *****************************************************************************
+   * \brief Returns the unique string identifier for this combiner. Used by
+   *  Lumberjack to differentiate between other combiners.
+   *****************************************************************************
+   */
+  const std::string id() { return m_id; }
+
+  /*!
+   *****************************************************************************
+   * \brief Function used by Lumberjack to indicate whether two messages should
+   *  be combined.
+   *
+   * They are not actually combined by this function. Message classes are
+   * triggered for combination if both Message::text and Message::tag are equal.
+   *
+   * \param [in] leftMessage One of the Messages to be compared.
+   * \param [in] rightMessage One of the Messages to be compared.
+   *****************************************************************************
+   */
+  bool shouldMessagesBeCombined(const Message& leftMessage,
+                                const Message& rightMessage)
+  {
+    if(leftMessage.text().compare(rightMessage.text()) == 0 &&
+       leftMessage.tag().compare(rightMessage.tag()) == 0)
+    {
+      return true;
+    }
+    return false;
+  }
+
+  /*!
+   *****************************************************************************
+   * \brief Combines the combinee into the combined Message.
+   *
+   * The only thing truly combined in this Combiner is the ranks from combinee
+   * to combined, since text is already equal.
+   *
+   * \param [in,out] combined the Message that will be modified.
+   * \param [in] combinee the Message that is combined into the other.
+   * \param [in] ranksLimit The limit on how many individual ranks are tracked
+   *  in the combined Message. Message::rankCount is always incremented.
+   *****************************************************************************
+   */
+  void combine(Message& combined, const Message& combinee, const int ranksLimit)
+  {
+    combined.addRanks(combinee.ranks(), combinee.count(), ranksLimit);
+  }
+
+private:
+  std::string m_id;
+};
+
+}  // end namespace lumberjack
+}  // end namespace axom
+
+#endif

--- a/src/axom/lumberjack/TextTagCombiner.hpp
+++ b/src/axom/lumberjack/TextTagCombiner.hpp
@@ -26,7 +26,7 @@ namespace lumberjack
 {
 /*!
  *******************************************************************************
- * \class Tex
+ * \class TextTagCombiner
  *
  * \brief Combines Message classes if their Message::text and Message::tag
  *        are equal.

--- a/src/axom/lumberjack/TextTagCombiner.hpp
+++ b/src/axom/lumberjack/TextTagCombiner.hpp
@@ -31,9 +31,9 @@ namespace lumberjack
  * \brief Combines Message classes if their Message::text and Message::tag
  *        are equal.
  *
- *  This class instance is automatically added to Lumberjack's Lumberjack for
- *  you. If you want it removed call Lumberjack::removeCombiner with the string
- * "TextTagCombiner" as it's parameter.
+ *  This class can be added to Lumberjack's Lumberjack by calling
+ *  Lumberjack::addCombiner with a
+ *  TextTagCombiner instance as its parameter.
  *
  * \see Combiner Lumberjack
  *******************************************************************************

--- a/src/axom/lumberjack/TextTagCombiner.hpp
+++ b/src/axom/lumberjack/TextTagCombiner.hpp
@@ -41,7 +41,7 @@ namespace lumberjack
 class TextTagCombiner : public Combiner
 {
 public:
-  TextTagCombiner() : m_id("TextTagCombiner") { }
+  TextTagCombiner() { }
 
   /*!
    *****************************************************************************
@@ -66,12 +66,8 @@ public:
   bool shouldMessagesBeCombined(const Message& leftMessage,
                                 const Message& rightMessage)
   {
-    if(leftMessage.text().compare(rightMessage.text()) == 0 &&
-       leftMessage.tag().compare(rightMessage.tag()) == 0)
-    {
-      return true;
-    }
-    return false;
+    return (leftMessage.text().compare(rightMessage.text()) == 0 &&
+            leftMessage.tag().compare(rightMessage.tag()) == 0);
   }
 
   /*!
@@ -85,6 +81,8 @@ public:
    * \param [in] combinee the Message that is combined into the other.
    * \param [in] ranksLimit The limit on how many individual ranks are tracked
    *  in the combined Message. Message::rankCount is always incremented.
+   *
+   * \pre shouldMessagesBeCombined(combined, combinee) must be true
    *****************************************************************************
    */
   void combine(Message& combined, const Message& combinee, const int ranksLimit)
@@ -93,7 +91,7 @@ public:
   }
 
 private:
-  std::string m_id;
+  const std::string m_id = "TextTagCombiner";
 };
 
 }  // end namespace lumberjack

--- a/src/axom/lumberjack/docs/sphinx/combiner_class.rst
+++ b/src/axom/lumberjack/docs/sphinx/combiner_class.rst
@@ -23,6 +23,18 @@ combine                   Combines the second message into the first.
 Concrete Instances
 ------------------
 
+.. _texttagcombiner_class_label:
+
+TextTagCombiner
+^^^^^^^^^^^^^^^
+
+This Combiner combines the two given Messages if the Message text strings and tag strings are equal.
+It does so by adding the second Message's ranks to the first Message (if not past
+the ranksLimit) and incrementing the Message's count as well.  This is handled by
+Message.addRanks().
+
+.. note:: This is the only Combiner automatically added to Lumberjack for you.  You can remove it by calling Lumberjack::removeCombiner("TextTagCombiner").
+
 .. _textequalitycombiner_class_label:
 
 TextEqualityCombiner
@@ -33,4 +45,4 @@ It does so by adding the second Message's ranks to the first Message (if not pas
 the ranksLimit) and incrementing the Message's count as well.  This is handled by
 Message.addRanks().
 
-.. note:: This is the only Combiner automatically added to Lumberjack for you.  You can remove it by calling Lumberjack::removeCombiner("TextEqualityCombiner").
+.. note:: You can add this Combiner by calling Lumberjack::addCombiner(new TextEqualityCombiner).

--- a/src/axom/lumberjack/docs/sphinx/core_concepts.rst
+++ b/src/axom/lumberjack/docs/sphinx/core_concepts.rst
@@ -16,18 +16,18 @@ your program.  It does so by giving the currently held Messages at the current n
 two at a time, to the Combiner classes that are currently registered to Lumberjack
 when a Push happens.
 
-Lumberjack only provides one Combiner, the TextEqualityCombiner. You can write your own
+Lumberjack provides one Combiner as default, the TextTagCombiner. You can write your own
 Combiners and register them with Lumberjack.  The idea is that each Combiner would have
 its own criteria for whether a Message should be combined and how to combine that specific
 Message with another of the same type.
 
 Combiner's have two main functions, shouldMessagesBeCombined and combine.
 
-The function shouldMessagesBeCombined, returns True if the pair of messages satisfy the associated criteria.  For example in the TextEqualityCombiner,
-if the Text strings are exactly equal, it signals they should be combined.
+The function shouldMessagesBeCombined, returns True if the pair of messages satisfy the associated criteria.  For example in the TextTagCombiner,
+if the Text strings and tag strings are exactly equal, it signals they should be combined.
 
 The function combine, takes two Messages and combines them in the way that is specific
-to that Combiner class.  For example in the TextEqualityCombiner, the only thing
+to that Combiner class.  For example in the TextTagCombiner, the only thing
 that happens is the second Message's ranks gets added to the first and the message count
 is increased.  This is because the text strings were equal.  This may not be the case
 for all Combiners that you write yourself.

--- a/src/axom/lumberjack/docs/sphinx/lumberjack_classes.rst
+++ b/src/axom/lumberjack/docs/sphinx/lumberjack_classes.rst
@@ -15,6 +15,7 @@ Combiners
 Handles Message combination and tests whether Message classes should be combined.
 
 * :ref:`Combiner <combiner_class_label>` - Abstract base class that all Combiners must inherit from.
+* :ref:`TextTagCombiner <texttagcombiner_class_label>` - Combines Message classes that have equal Text and Tag member variables.
 * :ref:`TextEqualityCombiner <textequalitycombiner_class_label>` - Combines Message classes that have equal Text member variables.
 
 

--- a/src/axom/lumberjack/tests/CMakeLists.txt
+++ b/src/axom/lumberjack/tests/CMakeLists.txt
@@ -12,7 +12,8 @@
 set(lumberjack_serial_tests
     lumberjack_Lumberjack.hpp
     lumberjack_Message.hpp
-    lumberjack_TextEqualityCombiner.hpp )
+    lumberjack_TextEqualityCombiner.hpp
+    lumberjack_TextTagCombiner.hpp )
 
 axom_add_executable(NAME       lumberjack_serial_tests
                     SOURCES    lumberjack_serial_main.cpp

--- a/src/axom/lumberjack/tests/lumberjack_TextTagCombiner.hpp
+++ b/src/axom/lumberjack/tests/lumberjack_TextTagCombiner.hpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "gtest/gtest.h"
+
+#include "axom/lumberjack/TextTagCombiner.hpp"
+
+TEST(lumberjack_TextTagCombiner, case01)
+{
+  //Test positive case: two equal texts and tags
+  std::string text = "I never wanted to do this job in the first place!";
+  axom::lumberjack::Message m1;
+  m1.text(text);
+  m1.addRank(13, 5);
+  m1.fileName("foo.cpp");
+  m1.lineNumber(154);
+  m1.tag("myTag");
+
+  axom::lumberjack::Message m2;
+  m2.text(text);
+  m2.addRank(14, 5);
+  m2.fileName("foo.cpp");
+  m2.lineNumber(154);
+  m2.tag("myTag");
+
+  axom::lumberjack::TextTagCombiner c;
+
+  bool shouldMessagesBeCombined = c.shouldMessagesBeCombined(m1, m2);
+
+  c.combine(m1, m2, 5);
+
+  EXPECT_EQ(shouldMessagesBeCombined, true);
+  EXPECT_EQ(m1.text().compare(text), 0);
+  EXPECT_EQ(m1.count(), 2);
+  EXPECT_EQ(m1.ranks()[0], 13);
+  EXPECT_EQ(m1.ranks()[1], 14);
+  EXPECT_EQ(m2.tag().compare("myTag"), 0);
+}
+
+TEST(lumberjack_TextTagCombiner, case02)
+{
+  //Test negative case: two not-equal texts, but equal tags
+  std::string text1 = "I never wanted to do this job in the first place!";
+  axom::lumberjack::Message m1;
+  m1.text(text1);
+  m1.addRank(13, 5);
+  m1.fileName("foo.cpp");
+  m1.lineNumber(154);
+  m1.tag("myTag");
+
+  std::string text2 = "This text is not equal to the first.";
+  axom::lumberjack::Message m2;
+  m2.text(text2);
+  m2.addRank(14, 5);
+  m2.fileName("foo.cpp");
+  m2.lineNumber(154);
+  m2.tag("myTag");
+
+  axom::lumberjack::TextTagCombiner c;
+
+  bool shouldMessagesBeCombined = c.shouldMessagesBeCombined(m1, m2);
+
+  EXPECT_EQ(shouldMessagesBeCombined, false);
+  EXPECT_EQ(m1.text().compare(text1), 0);
+  EXPECT_EQ(m1.count(), 1);
+  EXPECT_EQ(m1.ranks()[0], 13);
+  EXPECT_EQ(m1.tag().compare("myTag"), 0);
+
+  EXPECT_EQ(m2.text().compare(text2), 0);
+  EXPECT_EQ(m2.count(), 1);
+  EXPECT_EQ(m2.ranks()[0], 14);
+  EXPECT_EQ(m2.tag().compare("myTag"), 0);
+}
+
+TEST(lumberjack_TextTagCombiner, case03)
+{
+  //Test negative case: two equal texts, but not-equal tags
+  std::string text = "I never wanted to do this job in the first place!";
+
+  axom::lumberjack::Message m1;
+  m1.text(text);
+  m1.addRank(13, 5);
+  m1.fileName("foo.cpp");
+  m1.lineNumber(154);
+  m1.tag("tag1");
+
+  axom::lumberjack::Message m2;
+  m2.text(text);
+  m2.addRank(14, 5);
+  m2.fileName("foo.cpp");
+  m2.lineNumber(154);
+  m2.tag("tag2");
+
+  axom::lumberjack::TextTagCombiner c;
+
+  bool shouldMessagesBeCombined = c.shouldMessagesBeCombined(m1, m2);
+
+  EXPECT_EQ(shouldMessagesBeCombined, false);
+  EXPECT_EQ(m1.text().compare(text), 0);
+  EXPECT_EQ(m1.count(), 1);
+  EXPECT_EQ(m1.ranks()[0], 13);
+  EXPECT_EQ(m1.tag().compare("tag1"), 0);
+
+  EXPECT_EQ(m2.text().compare(text), 0);
+  EXPECT_EQ(m2.count(), 1);
+  EXPECT_EQ(m2.ranks()[0], 14);
+  EXPECT_EQ(m2.tag().compare("tag2"), 0);
+}

--- a/src/axom/lumberjack/tests/lumberjack_serial_main.cpp
+++ b/src/axom/lumberjack/tests/lumberjack_serial_main.cpp
@@ -8,6 +8,7 @@
 #include "lumberjack_Lumberjack.hpp"
 #include "lumberjack_Message.hpp"
 #include "lumberjack_TextEqualityCombiner.hpp"
+#include "lumberjack_TextTagCombiner.hpp"
 
 int main(int argc, char** argv)
 {

--- a/src/axom/slic/core/LogStream.hpp
+++ b/src/axom/slic/core/LogStream.hpp
@@ -88,6 +88,8 @@ public:
    * \param [in] line the line within the file at which the message is appended.
    * \param [in] filter_duplicates optional parameter that indicates whether
    * duplicate messages resulting from running in parallel will be filtered out.
+   * /param [in] tag_stream_only optional parameter that indicates whether the
+   * message will go only to streams bound to tagName.
    *
    * \note The following wildcards may be used to ignore a particular field:
    * <ul>
@@ -101,7 +103,8 @@ public:
                       const std::string& tagName,
                       const std::string& fileName,
                       int line,
-                      bool filter_duplicates) = 0;
+                      bool filter_duplicates,
+                      bool tag_stream_only) = 0;
 
   /*!
    * \brief Outputs the log stream on the current rank to the console.

--- a/src/axom/slic/core/Logger.cpp
+++ b/src/axom/slic/core/Logger.cpp
@@ -75,6 +75,8 @@ Logger::~Logger()
     m_logStreams[level].clear();
 
   }  // END for all levels
+
+  m_taggedStreams.clear();
 }
 
 //------------------------------------------------------------------------------
@@ -144,6 +146,33 @@ void Logger::addStreamToMsgLevel(LogStream* ls,
 }
 
 //------------------------------------------------------------------------------
+void Logger::addStreamToTag(LogStream* ls,
+                            const std::string& tag,
+                            bool pass_ownership)
+{
+  if(ls == nullptr)
+  {
+    std::cerr << "WARNING: supplied log stream is NULL!\n";
+    return;
+  }
+
+  if(m_taggedStreams.find(tag) == m_taggedStreams.end())
+  {
+    m_taggedStreams[tag] = std::vector<LogStream*> {ls};
+  }
+
+  else
+  {
+    m_taggedStreams[tag].push_back(ls);
+  }
+
+  if(pass_ownership)
+  {
+    m_streamObjectsManager[ls] = ls;
+  }
+}
+
+//------------------------------------------------------------------------------
 void Logger::addStreamToAllMsgLevels(LogStream* ls)
 {
   if(ls == nullptr)
@@ -166,6 +195,17 @@ int Logger::getNumStreamsAtMsgLevel(message::Level level)
 }
 
 //------------------------------------------------------------------------------
+int Logger::getNumStreamsAtTag(const std::string& tag)
+{
+  if(m_taggedStreams.find(tag) == m_taggedStreams.end())
+  {
+    return 0;
+  }
+
+  return static_cast<int>(m_taggedStreams[tag].size());
+}
+
+//------------------------------------------------------------------------------
 LogStream* Logger::getStream(message::Level level, int i)
 {
   if(i < 0 || i >= static_cast<int>(m_logStreams[level].size()))
@@ -178,6 +218,24 @@ LogStream* Logger::getStream(message::Level level, int i)
 }
 
 //------------------------------------------------------------------------------
+LogStream* Logger::getStream(const std::string& tag, int i)
+{
+  if(m_taggedStreams.find(tag) == m_taggedStreams.end())
+  {
+    std::cerr << "ERROR: tag does not exist!\n";
+    return nullptr;
+  }
+
+  if(i < 0 || i >= static_cast<int>(m_taggedStreams[tag].size()))
+  {
+    std::cerr << "ERROR: stream index is out-of-bounds!\n";
+    return nullptr;
+  }
+
+  return m_taggedStreams[tag][i];
+}
+
+//------------------------------------------------------------------------------
 void Logger::logMessage(message::Level level,
                         const std::string& message,
                         bool filter_duplicates)
@@ -187,21 +245,24 @@ void Logger::logMessage(message::Level level,
                    MSG_IGNORE_TAG,
                    MSG_IGNORE_FILE,
                    MSG_IGNORE_LINE,
-                   filter_duplicates);
+                   filter_duplicates,
+                   false);
 }
 
 //------------------------------------------------------------------------------
 void Logger::logMessage(message::Level level,
                         const std::string& message,
                         const std::string& tagName,
-                        bool filter_duplicates)
+                        bool filter_duplicates,
+                        bool tag_stream_only)
 {
   this->logMessage(level,
                    message,
                    tagName,
                    MSG_IGNORE_FILE,
                    MSG_IGNORE_LINE,
-                   filter_duplicates);
+                   filter_duplicates,
+                   tag_stream_only);
 }
 
 //------------------------------------------------------------------------------
@@ -211,7 +272,13 @@ void Logger::logMessage(message::Level level,
                         int line,
                         bool filter_duplicates)
 {
-  this->logMessage(level, message, MSG_IGNORE_TAG, fileName, line, filter_duplicates);
+  this->logMessage(level,
+                   message,
+                   MSG_IGNORE_TAG,
+                   fileName,
+                   line,
+                   filter_duplicates,
+                   false);
 }
 
 //------------------------------------------------------------------------------
@@ -220,24 +287,63 @@ void Logger::logMessage(message::Level level,
                         const std::string& tagName,
                         const std::string& fileName,
                         int line,
-                        bool filter_duplicates)
+                        bool filter_duplicates,
+                        bool tag_stream_only)
 {
-  if(m_isEnabled[level] == false)
+  if(m_isEnabled[level] == false && tag_stream_only == false)
   {
     return;
   }
 
-  unsigned nstreams = static_cast<unsigned>(m_logStreams[level].size());
-  for(unsigned istream = 0; istream < nstreams; ++istream)
+  if(tag_stream_only == true && tagName == MSG_IGNORE_TAG)
   {
-    m_logStreams[level][istream]
-      ->append(level, message, tagName, fileName, line, filter_duplicates);
+    std::cerr << "ERROR: message for tagged streams does not have a tag!\n";
+    return;
+  }
+
+  if(tag_stream_only == true &&
+     m_taggedStreams.find(tagName) == m_taggedStreams.end())
+  {
+    std::cerr << "ERROR: tag does not exist!\n";
+    return;
+  }
+
+  // Message for message levels
+  if(tag_stream_only == false)
+  {
+    unsigned nstreams = static_cast<unsigned>(m_logStreams[level].size());
+    for(unsigned istream = 0; istream < nstreams; ++istream)
+    {
+      m_logStreams[level][istream]->append(level,
+                                           message,
+                                           tagName,
+                                           fileName,
+                                           line,
+                                           filter_duplicates,
+                                           tag_stream_only);
+    }
+  }
+
+  // Message for tagged streams
+  else
+  {
+    for(unsigned int i = 0; i < m_taggedStreams[tagName].size(); i++)
+    {
+      m_taggedStreams[tagName][i]->append(level,
+                                          message,
+                                          tagName,
+                                          fileName,
+                                          line,
+                                          filter_duplicates,
+                                          tag_stream_only);
+    }
   }
 }
 
 //------------------------------------------------------------------------------
 void Logger::outputLocalMessages()
 {
+  //Output for all message levels
   for(int level = message::Error; level < message::Num_Levels; ++level)
   {
     unsigned nstreams = static_cast<unsigned>(m_logStreams[level].size());
@@ -248,11 +354,23 @@ void Logger::outputLocalMessages()
     }  // END for all streams
 
   }  // END for all levels
+
+  // Output for all tagged streams
+  std::map<std::string, std::vector<LogStream*>>::iterator it;
+
+  for(it = m_taggedStreams.begin(); it != m_taggedStreams.end(); it++)
+  {
+    for(unsigned int i = 0; i < it->second.size(); i++)
+    {
+      it->second[i]->outputLocal();
+    }
+  }
 }
 
 //------------------------------------------------------------------------------
 void Logger::flushStreams()
 {
+  //Flush for all message levels
   for(int level = message::Error; level < message::Num_Levels; ++level)
   {
     unsigned nstreams = static_cast<unsigned>(m_logStreams[level].size());
@@ -263,11 +381,23 @@ void Logger::flushStreams()
     }  // END for all streams
 
   }  // END for all levels
+
+  // Flush for all tagged streams
+  std::map<std::string, std::vector<LogStream*>>::iterator it;
+
+  for(it = m_taggedStreams.begin(); it != m_taggedStreams.end(); it++)
+  {
+    for(unsigned int i = 0; i < it->second.size(); i++)
+    {
+      it->second[i]->flush();
+    }
+  }
 }
 
 //------------------------------------------------------------------------------
 void Logger::pushStreams()
 {
+  //Push for all message levels
   for(int level = message::Error; level < message::Num_Levels; ++level)
   {
     unsigned nstreams = static_cast<unsigned>(m_logStreams[level].size());
@@ -278,6 +408,17 @@ void Logger::pushStreams()
     }  // END for all streams
 
   }  // END for all levels
+
+  // Push for all tagged streams
+  std::map<std::string, std::vector<LogStream*>>::iterator it;
+
+  for(it = m_taggedStreams.begin(); it != m_taggedStreams.end(); it++)
+  {
+    for(unsigned int i = 0; i < it->second.size(); i++)
+    {
+      it->second[i]->push();
+    }
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/slic/core/Logger.cpp
+++ b/src/axom/slic/core/Logger.cpp
@@ -189,6 +189,29 @@ void Logger::addStreamToAllMsgLevels(LogStream* ls)
 }
 
 //------------------------------------------------------------------------------
+void Logger::addStreamToAllTags(LogStream* ls)
+{
+  if(ls == nullptr)
+  {
+    std::cerr << "WARNING: supplied log stream is NULL!\n";
+    return;
+  }
+
+  if(ls == nullptr)
+  {
+    std::cerr << "WARNING: no tags are available!\n";
+    return;
+  }
+
+  std::map<std::string, std::vector<LogStream*>>::iterator it;
+
+  for(it = m_taggedStreams.begin(); it != m_taggedStreams.end(); it++)
+  {
+    this->addStreamToTag(ls, it->first);
+  }
+}
+
+//------------------------------------------------------------------------------
 int Logger::getNumStreamsAtMsgLevel(message::Level level)
 {
   return static_cast<int>(m_logStreams[level].size());

--- a/src/axom/slic/core/Logger.cpp
+++ b/src/axom/slic/core/Logger.cpp
@@ -218,7 +218,7 @@ int Logger::getNumStreamsAtMsgLevel(message::Level level)
 }
 
 //------------------------------------------------------------------------------
-int Logger::getNumStreamsAtTag(const std::string& tag)
+int Logger::getNumStreamsWithTag(const std::string& tag)
 {
   if(m_taggedStreams.find(tag) == m_taggedStreams.end())
   {

--- a/src/axom/slic/core/Logger.hpp
+++ b/src/axom/slic/core/Logger.hpp
@@ -216,7 +216,7 @@ public:
    *
    * \param [in] tag the tag in query.
    *
-   * \return N the number of streams at the given level.
+   * \return N the number of streams for the given tag.
    * \post N >= 0
    */
   int getNumStreamsAtTag(const std::string& tag);

--- a/src/axom/slic/core/Logger.hpp
+++ b/src/axom/slic/core/Logger.hpp
@@ -201,6 +201,16 @@ public:
                       bool pass_ownership = true);
 
   /*!
+   * \brief Binds the given stream to all the tags for this Logger instance.
+   *
+   * \param [in] ls pointer to the user-supplied LogStream object.
+   *
+   * \note The Logger takes ownership of the LogStream object.
+   * \pre ls != NULL.
+   */
+  void addStreamToAllTags(LogStream* ls);
+
+  /*!
    * \brief Returns the number of streams for a given tag.
    *        Returns 0 if the tag does not exist.
    *

--- a/src/axom/slic/core/Logger.hpp
+++ b/src/axom/slic/core/Logger.hpp
@@ -219,7 +219,7 @@ public:
    * \return N the number of streams for the given tag.
    * \post N >= 0
    */
-  int getNumStreamsAtTag(const std::string& tag);
+  int getNumStreamsWithTag(const std::string& tag);
 
   /*!
    * \brief Returns the ith stream at the given tag.
@@ -228,7 +228,7 @@ public:
    * \param [in] i the index of the stream in query.
    *
    * \return stream_ptr pointer to the stream.
-   * \pre i >= 0 && i < this->getNumStreamsAtTag( tag )
+   * \pre i >= 0 && i < this->getNumStreamsWithTag( tag )
    * \post stream_ptr != NULL.
    */
   LogStream* getStream(const std::string& tag, int i);

--- a/src/axom/slic/core/Logger.hpp
+++ b/src/axom/slic/core/Logger.hpp
@@ -443,14 +443,13 @@ private:
 
   std::string m_name;
   bool m_abortOnError;
+  std::map<std::string, std::vector<LogStream*>> m_taggedStreams;
   bool m_abortOnWarning;
   void (*m_abortFunction)(void);
 
   bool m_isEnabled[message::Num_Levels];
   std::map<LogStream*, LogStream*> m_streamObjectsManager;
   std::vector<LogStream*> m_logStreams[message::Num_Levels];
-
-  std::map<std::string, std::vector<LogStream*>> m_taggedStreams;
 
   ///@}
 

--- a/src/axom/slic/core/Logger.hpp
+++ b/src/axom/slic/core/Logger.hpp
@@ -185,6 +185,45 @@ public:
   LogStream* getStream(message::Level level, int i);
 
   /*!
+   * \brief Binds the given stream to the given tag for this Logger instance.
+   *
+   * \param [in] ls pointer to the user-supplied LogStream object.
+   * \param [in] tag the tag that this stream will be associated with.
+   * \param [in] pass_ownership flag that indicates whether the given logger
+   *  instance owns the supplied LogStream object. This parameter is optional.
+   *  Default is true.
+   *
+   * \note The Logger takes ownership of the LogStream object.
+   * \pre ls != NULL.
+   */
+  void addStreamToTag(LogStream* ls,
+                      const std::string& tag,
+                      bool pass_ownership = true);
+
+  /*!
+   * \brief Returns the number of streams for a given tag.
+   *        Returns 0 if the tag does not exist.
+   *
+   * \param [in] tag the tag in query.
+   *
+   * \return N the number of streams at the given level.
+   * \post N >= 0
+   */
+  int getNumStreamsAtTag(const std::string& tag);
+
+  /*!
+   * \brief Returns the ith stream at the given tag.
+   *
+   * \param [in] tag the tag in query.
+   * \param [in] i the index of the stream in query.
+   *
+   * \return stream_ptr pointer to the stream.
+   * \pre i >= 0 && i < this->getNumStreamsAtTag( tag )
+   * \post stream_ptr != NULL.
+   */
+  LogStream* getStream(const std::string& tag, int i);
+
+  /*!
    * \brief Logs the given message to all registered streams.
    *
    * \param [in] level the level of the given message.
@@ -206,11 +245,14 @@ public:
    * \param [in] filter_duplicates optional parameter that indicates whether
    * duplicate messages resulting from running in parallel will be filtered out.
    * Default is false.
+   * /param [in] tag_stream_only optional parameter that indicates whether the
+   * message will go only to streams bound to tagName. Default is false.
    */
   void logMessage(message::Level level,
                   const std::string& message,
                   const std::string& tagName,
-                  bool filter_duplicates = false);
+                  bool filter_duplicates = false,
+                  bool tag_stream_only = false);
 
   /*!
    * \brief Logs the given message to all registered streams.
@@ -240,13 +282,16 @@ public:
    * \param [in] filter_duplicates optional parameter that indicates whether
    * duplicate messages resulting from running in parallel will be filtered out.
    * Default is false.
+   * /param [in] tag_stream_only optional parameter that indicates whether the
+   * message will go only to streams bound to tagName. Default is false.
    */
   void logMessage(message::Level level,
                   const std::string& message,
                   const std::string& tagName,
                   const std::string& fileName,
                   int line,
-                  bool filter_duplicates = false);
+                  bool filter_duplicates = false,
+                  bool tag_stream_only = false);
 
   /*!
    * \brief For the current rank, outputs messages from all streams to the
@@ -394,6 +439,8 @@ private:
   bool m_isEnabled[message::Num_Levels];
   std::map<LogStream*, LogStream*> m_streamObjectsManager;
   std::vector<LogStream*> m_logStreams[message::Num_Levels];
+
+  std::map<std::string, std::vector<LogStream*>> m_taggedStreams;
 
   ///@}
 

--- a/src/axom/slic/docs/sphinx/sections/appendix.rst
+++ b/src/axom/slic/docs/sphinx/sections/appendix.rst
@@ -87,6 +87,7 @@ The table below details which SLIC macros are collective:
 | | ``SLIC_INFO_IF``         | |                                                                          |
 | | ``SLIC_INFO_ROOT``       | |                                                                          |
 | | ``SLIC_INFO_ROOT_IF``    | |                                                                          |
+| | ``SLIC_INFO_TAGGED``     | |                                                                          |
 +----------------------------+----------------------------------------------------------------------------+
 | | ``SLIC_ERROR``           | | Collective by default.                                                   |
 | | ``SLIC_ERROR_IF``        | | Collective after calling ``slic::enableAbortOnError()``.                 |

--- a/src/axom/slic/docs/sphinx/sections/getting_started.rst
+++ b/src/axom/slic/docs/sphinx/sections/getting_started.rst
@@ -167,6 +167,24 @@ The :ref:`GenericOutputStream`,  takes two arguments in its constructor:
    Slic maintains ownership of all registered :ref:`LogStream` instances and
    will deallocate them when ``slic::finalize()`` is called.
 
+Step 5.1: Tagged Log Streams
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Slic has limited support for tags, where users can bind streams
+to user-defined tags. The bound streams only output messages with the
+given tag, disregarding the message's :ref:`logMessageLevel`. The tagged
+:ref:`LogStream` can be created by calling ``slic::addStreamToTag()``.
+
+The following code snippet uses the :ref:`GenericOutputStream` object to
+specify ``std::cout`` as the output destination for messages tagged with
+the custom tag ``myTag``.
+
+.. literalinclude:: ../../../examples/basic/logging.cpp
+   :start-after: SPHINX_SLIC_SET_TAGGED_STREAM_BEGIN
+   :end-before: SPHINX_SLIC_SET_TAGGED_STREAM_END
+   :language: C++
+   :linenos:
+
 Step 6: Log Messages
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/axom/slic/examples/basic/logging.cpp
+++ b/src/axom/slic/examples/basic/logging.cpp
@@ -26,8 +26,8 @@ int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
   // SPHINX_SLIC_FORMAT_MSG_BEGIN
 
   std::string format = std::string("<TIMESTAMP>\n") +
-    std::string("[<LEVEL>]: <MESSAGE> \n") + std::string("FILE=<FILE>\n") +
-    std::string("LINE=<LINE>\n\n");
+    std::string("[ <LEVEL> <TAG>]: <MESSAGE> \n") +
+    std::string("FILE=<FILE>\n") + std::string("LINE=<LINE>\n\n");
 
   // SPHINX_SLIC_FORMAT_MSG_END
 
@@ -42,12 +42,20 @@ int main(int AXOM_UNUSED_PARAM(argc), char** AXOM_UNUSED_PARAM(argv))
 
   // SPHINX_SLIC_SET_STREAM_END
 
+  // SPHINX_SLIC_SET_TAGGED_STREAM_BEGIN
+  slic::addStreamToTag(new slic::GenericOutputStream(&std::cout, format),
+                       "myTag");
+
+  // SPHINX_SLIC_SET_TAGGED_STREAM_END
+
   // SPHINX_SLIC_LOG_MESSAGES_BEGIN
 
   SLIC_DEBUG("Here is a debug message!");
   SLIC_INFO("Here is an info mesage!");
   SLIC_WARNING("Here is a warning!");
   SLIC_ERROR("Here is an error message!");
+  SLIC_INFO_TAGGED("Here is a message for tagged streams with tag 'myTag'!",
+                   "myTag");
 
   // SPHINX_SLIC_LOG_MESSAGES_END
 

--- a/src/axom/slic/interface/slic.cpp
+++ b/src/axom/slic/interface/slic.cpp
@@ -179,6 +179,41 @@ void addStreamToAllMsgLevels(GenericOutputStream* ls)
 }
 
 //------------------------------------------------------------------------------
+void addStreamToTag(LogStream* ls, const std::string& tag)
+{
+  ensureInitialized();
+  Logger::getActiveLogger()->addStreamToTag(ls, tag);
+}
+
+//------------------------------------------------------------------------------
+void addStreamToTag(GenericOutputStream* ls, const std::string& tag)
+{
+  ensureInitialized();
+  Logger::getActiveLogger()->addStreamToTag(ls, tag);
+}
+
+//------------------------------------------------------------------------------
+void addStreamToAllTags(LogStream* ls)
+{
+  ensureInitialized();
+  Logger::getActiveLogger()->addStreamToAllTags(ls);
+}
+
+//------------------------------------------------------------------------------
+void addStreamToAllTags(GenericOutputStream* ls)
+{
+  ensureInitialized();
+  Logger::getActiveLogger()->addStreamToAllTags(ls);
+}
+
+//------------------------------------------------------------------------------
+int getNumStreamsAtTag(const std::string& tag)
+{
+  ensureInitialized();
+  return Logger::getActiveLogger()->getNumStreamsAtTag(tag);
+}
+
+//------------------------------------------------------------------------------
 void logMessage(message::Level level,
                 const std::string& message,
                 bool filter_duplicates)
@@ -195,7 +230,11 @@ void logMessage(message::Level level,
                 bool tag_stream_only)
 {
   ensureInitialized();
-  Logger::getActiveLogger()->logMessage(level, message, tag, filter_duplicates);
+  Logger::getActiveLogger()->logMessage(level,
+                                        message,
+                                        tag,
+                                        filter_duplicates,
+                                        tag_stream_only);
 }
 
 //------------------------------------------------------------------------------
@@ -223,8 +262,13 @@ void logMessage(message::Level level,
                 bool tag_stream_only)
 {
   ensureInitialized();
-  Logger::getActiveLogger()
-    ->logMessage(level, message, tag, fileName, line, filter_duplicates);
+  Logger::getActiveLogger()->logMessage(level,
+                                        message,
+                                        tag,
+                                        fileName,
+                                        line,
+                                        filter_duplicates,
+                                        tag_stream_only);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/slic/interface/slic.cpp
+++ b/src/axom/slic/interface/slic.cpp
@@ -207,10 +207,10 @@ void addStreamToAllTags(GenericOutputStream* ls)
 }
 
 //------------------------------------------------------------------------------
-int getNumStreamsAtTag(const std::string& tag)
+int getNumStreamsWithTag(const std::string& tag)
 {
   ensureInitialized();
-  return Logger::getActiveLogger()->getNumStreamsAtTag(tag);
+  return Logger::getActiveLogger()->getNumStreamsWithTag(tag);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/slic/interface/slic.cpp
+++ b/src/axom/slic/interface/slic.cpp
@@ -191,7 +191,8 @@ void logMessage(message::Level level,
 void logMessage(message::Level level,
                 const std::string& message,
                 const std::string& tag,
-                bool filter_duplicates)
+                bool filter_duplicates,
+                bool tag_stream_only)
 {
   ensureInitialized();
   Logger::getActiveLogger()->logMessage(level, message, tag, filter_duplicates);
@@ -218,7 +219,8 @@ void logMessage(message::Level level,
                 const std::string& tag,
                 const std::string& fileName,
                 int line,
-                bool filter_duplicates)
+                bool filter_duplicates,
+                bool tag_stream_only)
 {
   ensureInitialized();
   Logger::getActiveLogger()

--- a/src/axom/slic/interface/slic.hpp
+++ b/src/axom/slic/interface/slic.hpp
@@ -248,11 +248,14 @@ void logMessage(message::Level level,
  * \param [in] filter_duplicates optional parameter that indicates whether
  * duplicate messages resulting from running in parallel will be filtered out.
  * Default is false.
+ * /param [in] tag_stream_only optional parameter that indicates whether the
+ * message will go only to streams bound to tagName. Default is false.
  */
 void logMessage(message::Level level,
                 const std::string& message,
                 const std::string& tag,
-                bool filter_duplicates = false);
+                bool filter_duplicates = false,
+                bool tag_stream_only = false);
 
 /*!
  * \brief Logs the given message to all registered streams.
@@ -282,13 +285,16 @@ void logMessage(message::Level level,
  * \param [in] filter_duplicates optional parameter that indicates whether
  * duplicate messages resulting from running in parallel will be filtered out.
  * Default is false.
+ * /param [in] tag_stream_only optional parameter that indicates whether the
+ * message will go only to streams bound to tagName. Default is false.
  */
 void logMessage(message::Level level,
                 const std::string& message,
                 const std::string& tag,
                 const std::string& fileName,
                 int line,
-                bool filter_duplicates = false);
+                bool filter_duplicates = false,
+                bool tag_stream_only = false);
 
 /*!
  * \brief Convenience method to log an error message.

--- a/src/axom/slic/interface/slic.hpp
+++ b/src/axom/slic/interface/slic.hpp
@@ -273,7 +273,7 @@ void addStreamToAllTags(GenericOutputStream* ls);
 * \return N the number of streams for the given tag.
 * \post N >= 0
 */
-int getNumStreamsAtTag(const std::string& tag);
+int getNumStreamsWithTag(const std::string& tag);
 
 /*!
  * \brief Logs the given message to all registered streams.

--- a/src/axom/slic/interface/slic.hpp
+++ b/src/axom/slic/interface/slic.hpp
@@ -227,6 +227,55 @@ void addStreamToAllMsgLevels(LogStream* ls);
 void addStreamToAllMsgLevels(GenericOutputStream* ls);
 
 /*!
+* \brief Binds the given stream to the given tag.
+*
+* \param [in] ls pointer to the user-supplied LogStream object.
+* \param [in] tag the tag that this stream will be associated with.
+*
+* \pre ls != nullptr.
+*/
+void addStreamToTag(LogStream* ls, const std::string& tag);
+
+/*!
+* \brief Binds the given GenericOutputStream to the given tag.
+*
+* \param [in] ls pointer to the user-supplied GenericOutputStream.
+* \param [in] tag the tag that this stream will be associated with.
+*
+* \pre ls != nullptr.
+*/
+void addStreamToTag(GenericOutputStream* ls, const std::string& tag);
+
+/*!
+* \brief Binds the given stream to all the tags.
+*
+* \param [in] ls pointer to the user-supplied LogStream object.
+*
+* \pre ls != nullptr.
+*/
+void addStreamToAllTags(LogStream* ls);
+
+/*!
+* \brief Binds the given GenericOutputStream to all the tags.
+*
+* \param [in] ls pointer to the user-supplied GenericOutputStream.
+*
+* \pre ls != nullptr.
+*/
+void addStreamToAllTags(GenericOutputStream* ls);
+
+/*!
+* \brief Returns the number of streams for a given tag.
+*        Returns 0 if the tag does not exist.
+*
+* \param [in] tag the tag in query.
+*
+* \return N the number of streams for the given tag.
+* \post N >= 0
+*/
+int getNumStreamsAtTag(const std::string& tag);
+
+/*!
  * \brief Logs the given message to all registered streams.
  *
  * \param [in] level the level of the message being logged.

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -579,6 +579,35 @@ AXOM_HOST_DEVICE inline blackhole &operator<<(blackhole &bh, T)
   } while(axom::slic::detail::false_value)
 
 /*!
+ * \def SLIC_INFO_TAGGED( tag, msg )
+ * \brief Logs an Info message to a tagged stream
+ *
+ * \param [in] tag user-supplied tag
+ * \param [in] msg user-supplied message
+ *
+ * \note The SLIC_INFO macro is always active.
+ *
+ * Usage:
+ * \code
+ *   SLIC_INFO( "tag","informative text goes here" );
+ * \endcode
+ *
+ */
+#define SLIC_INFO_TAGGED(msg, tag)                    \
+  do                                                  \
+  {                                                   \
+    std::ostringstream __oss;                         \
+    __oss << msg;                                     \
+    axom::slic::logMessage(axom::slic::message::Info, \
+                           __oss.str(),               \
+                           tag,                       \
+                           __FILE__,                  \
+                           __LINE__,                  \
+                           false,                     \
+                           true);                     \
+  } while(axom::slic::detail::false_value)
+
+/*!
  * \def SLIC_INFO_IF( EXP, msg )
  * \brief Logs an Info message iff EXP is true
  *

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -579,17 +579,17 @@ AXOM_HOST_DEVICE inline blackhole &operator<<(blackhole &bh, T)
   } while(axom::slic::detail::false_value)
 
 /*!
- * \def SLIC_INFO_TAGGED( tag, msg )
+ * \def SLIC_INFO_TAGGED( msg, tag )
  * \brief Logs an Info message to a tagged stream
  *
- * \param [in] tag user-supplied tag
  * \param [in] msg user-supplied message
+ * \param [in] tag user-supplied tag
  *
- * \note The SLIC_INFO macro is always active.
+ * \note The SLIC_INFO_TAGGED macro is always active.
  *
  * Usage:
  * \code
- *   SLIC_INFO( "tag","informative text goes here" );
+ *   SLIC_INFO_TAGGED("informative text goes here", "tag");
  * \endcode
  *
  */

--- a/src/axom/slic/streams/GenericOutputStream.cpp
+++ b/src/axom/slic/streams/GenericOutputStream.cpp
@@ -61,7 +61,8 @@ void GenericOutputStream::append(message::Level msgLevel,
                                  const std::string& tagName,
                                  const std::string& fileName,
                                  int line,
-                                 bool AXOM_UNUSED_PARAM(filtered_duplicates))
+                                 bool AXOM_UNUSED_PARAM(filtered_duplicates),
+                                 bool AXOM_UNUSED_PARAM(tag_stream_only))
 {
   if(m_stream == nullptr)
   {

--- a/src/axom/slic/streams/GenericOutputStream.hpp
+++ b/src/axom/slic/streams/GenericOutputStream.hpp
@@ -85,7 +85,8 @@ public:
                       const std::string& tagName,
                       const std::string& fileName,
                       int line,
-                      bool filter_duplicates);
+                      bool filter_duplicates,
+                      bool tag_stream_only);
 
   /*!
    * \brief Outputs the log stream to the console.

--- a/src/axom/slic/streams/LumberjackStream.cpp
+++ b/src/axom/slic/streams/LumberjackStream.cpp
@@ -169,7 +169,6 @@ void LumberjackStream::initializeLumberjack(MPI_Comm comm, int ranksLimit)
   m_ljComm->initialize(comm, ranksLimit);
   m_lj = new axom::lumberjack::Lumberjack;
   m_lj->initialize(m_ljComm, ranksLimit);
-  m_lj->addCombiner(new lumberjack::TextTagCombiner);
   m_isLJOwnedBySLIC = true;
 }
 

--- a/src/axom/slic/streams/LumberjackStream.cpp
+++ b/src/axom/slic/streams/LumberjackStream.cpp
@@ -72,7 +72,8 @@ void LumberjackStream::append(message::Level msgLevel,
                               const std::string& tagName,
                               const std::string& fileName,
                               int line,
-                              bool AXOM_UNUSED_PARAM(filter_duplicates))
+                              bool AXOM_UNUSED_PARAM(filter_duplicates),
+                              bool AXOM_UNUSED_PARAM(tag_stream_only))
 {
   if(m_lj == nullptr)
   {

--- a/src/axom/slic/streams/LumberjackStream.cpp
+++ b/src/axom/slic/streams/LumberjackStream.cpp
@@ -11,6 +11,7 @@
 
 #include "axom/lumberjack/BinaryTreeCommunicator.hpp"
 #include "axom/lumberjack/Lumberjack.hpp"
+#include "axom/lumberjack/TextTagCombiner.hpp"
 
 namespace axom
 {
@@ -168,6 +169,7 @@ void LumberjackStream::initializeLumberjack(MPI_Comm comm, int ranksLimit)
   m_ljComm->initialize(comm, ranksLimit);
   m_lj = new axom::lumberjack::Lumberjack;
   m_lj->initialize(m_ljComm, ranksLimit);
+  m_lj->addCombiner(new lumberjack::TextTagCombiner);
   m_isLJOwnedBySLIC = true;
 }
 

--- a/src/axom/slic/streams/LumberjackStream.hpp
+++ b/src/axom/slic/streams/LumberjackStream.hpp
@@ -68,6 +68,8 @@ public:
    * \param [in] line the line within the file at which the message is appended.
    * \param [in] filter_duplicates optional parameter that indicates whether
    * duplicate messages resulting from running in parallel will be filtered out.
+   * /param [in] tag_stream_only optional parameter that indicates whether the
+   * message will go only to streams bound to tagName.
    *
    * \note This method doesn't put anything to the console. Instead the
    *  messages are cached locally to each ranks and are dumped to the console
@@ -78,7 +80,8 @@ public:
                       const std::string& tagName,
                       const std::string& fileName,
                       int line,
-                      bool filter_duplicates);
+                      bool filter_duplicates,
+                      bool tag_stream_only);
 
   /*!
    * \brief Pushes the messages from the current rank directly to the

--- a/src/axom/slic/streams/SynchronizedStream.cpp
+++ b/src/axom/slic/streams/SynchronizedStream.cpp
@@ -74,7 +74,8 @@ void SynchronizedStream::append(message::Level msgLevel,
                                 const std::string& tagName,
                                 const std::string& fileName,
                                 int line,
-                                bool AXOM_UNUSED_PARAM(filter_duplicates))
+                                bool AXOM_UNUSED_PARAM(filter_duplicates),
+                                bool AXOM_UNUSED_PARAM(tag_stream_only))
 {
   if(m_cache == nullptr)
   {

--- a/src/axom/slic/streams/SynchronizedStream.hpp
+++ b/src/axom/slic/streams/SynchronizedStream.hpp
@@ -60,6 +60,8 @@ public:
    * \param [in] line the line within the file at which the message is appended.
    * \param [in] filter_duplicates optional parameter that indicates whether
    * duplicate messages resulting from running in parallel will be filtered out.
+   * /param [in] tag_stream_only optional parameter that indicates whether the
+   * message will go only to streams bound to tagName.
    *
    * \note This method doesn't put anything to the console. Instead the
    *  messages are cached locally to each ranks and are dumped to the console
@@ -70,7 +72,8 @@ public:
                       const std::string& tagName,
                       const std::string& fileName,
                       int line,
-                      bool filter_duplicates);
+                      bool filter_duplicates,
+                      bool tag_stream_only);
 
   /*!
    * \brief Dumps the messages from the current rank directly to the

--- a/src/axom/slic/tests/slic_macros.cpp
+++ b/src/axom/slic/tests/slic_macros.cpp
@@ -103,6 +103,17 @@ void check_line(const std::string& msg, int expected_line)
   EXPECT_EQ(line, expected_line);
 }
 
+//------------------------------------------------------------------------------
+void check_tag(const std::string& msg, const std::string& expected_tag)
+{
+  EXPECT_FALSE(msg.empty());
+
+  // extract tag
+  size_t start = msg.rfind("##") + 2;
+  std::string tag = msg.substr(start, expected_tag.length());
+  EXPECT_EQ(tag, expected_tag);
+}
+
 }  // end anonymous namespace
 
 //------------------------------------------------------------------------------
@@ -382,6 +393,23 @@ TEST(slic_macros, test_check_macros)
 }
 
 //------------------------------------------------------------------------------
+TEST(slic_macros, test_tagged_macros)
+{
+  EXPECT_TRUE(slic::internal::is_stream_empty());
+  SLIC_INFO_TAGGED("test tagged info message", "myTag");
+  EXPECT_FALSE(slic::internal::is_stream_empty());
+  check_level(slic::internal::test_stream.str(), "INFO");
+  check_msg(slic::internal::test_stream.str(), "test tagged info message");
+  check_file(slic::internal::test_stream.str());
+  check_line(slic::internal::test_stream.str(), __LINE__ - 5);
+  check_tag(slic::internal::test_stream.str(), "myTag");
+  slic::internal::clear();
+
+  SLIC_INFO_TAGGED("this message should not be logged!", "tag404");
+  EXPECT_TRUE(slic::internal::is_stream_empty());
+}
+
+//------------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {
   int result = 0;
@@ -397,6 +425,12 @@ int main(int argc, char* argv[])
 
   slic::addStreamToAllMsgLevels(
     new slic::GenericOutputStream(&slic::internal::test_stream, msgfmt));
+
+  std::string msgtagfmt =
+    "[<LEVEL>]:;;<MESSAGE>;;\n##<TAG>\n@@<FILE>\n@@<LINE>";
+  slic::addStreamToTag(
+    new slic::GenericOutputStream(&slic::internal::test_stream, msgtagfmt),
+    "myTag");
 
   // finalized when exiting main scope
   result = RUN_ALL_TESTS();

--- a/src/axom/slic/tests/slic_macros.cpp
+++ b/src/axom/slic/tests/slic_macros.cpp
@@ -405,7 +405,10 @@ TEST(slic_macros, test_tagged_macros)
   check_tag(slic::internal::test_stream.str(), "myTag");
   slic::internal::clear();
 
-  SLIC_INFO_TAGGED("this message should not be logged!", "tag404");
+  SLIC_INFO_TAGGED("this message should not be logged (no tag given)!", "");
+  EXPECT_TRUE(slic::internal::is_stream_empty());
+
+  SLIC_INFO_TAGGED("this message should not be logged (tag DNE)!", "tag404");
   EXPECT_TRUE(slic::internal::is_stream_empty());
 }
 

--- a/src/axom/slic/tests/slic_uninit.cpp
+++ b/src/axom/slic/tests/slic_uninit.cpp
@@ -96,8 +96,8 @@ TEST(slic_uninit, manage_loggers)
     axom::slic::addStreamToAllTags(
       new axom::slic::GenericOutputStream(&std::cout, format));
   });
-  testInit("getNumStreamsAtTag",
-           []() { axom::slic::getNumStreamsAtTag("Test"); });
+  testInit("getNumStreamsWithTag",
+           []() { axom::slic::getNumStreamsWithTag("Test"); });
 }
 
 TEST(slic_uninit, log_methods)

--- a/src/axom/slic/tests/slic_uninit.cpp
+++ b/src/axom/slic/tests/slic_uninit.cpp
@@ -27,6 +27,8 @@ TEST(slic_uninit, log_macro)
            []() { SLIC_DEBUG_IF(true, "debug message should print"); });
 #endif
   testInit("info message", []() { SLIC_INFO("test info message"); });
+  testInit("tagged info message",
+           []() { SLIC_INFO_TAGGED("test info message", "test_tag"); });
   testInit("info_if", []() { SLIC_INFO_IF(true, "info message should print"); });
   testInit("warning message", []() { SLIC_WARNING("test warning message"); });
   testInit("warning_if", []() { SLIC_WARNING_IF(true, "test warning message"); });
@@ -78,11 +80,24 @@ TEST(slic_uninit, manage_loggers)
       new axom::slic::GenericOutputStream(&std::cout, format),
       axom::slic::message::Info);
   });
+  testInit("addStreamToTag", []() {
+    std::string format("[<LEVEL>]: <MESSAGE> <TAG>\n");
+    axom::slic::addStreamToTag(
+      new axom::slic::GenericOutputStream(&std::cout, format),
+      "Test");
+  });
   testInit("addStreamToAllMsgLevels", []() {
     std::string format("[<LEVEL>]: <MESSAGE> \n");
     axom::slic::addStreamToAllMsgLevels(
       new axom::slic::GenericOutputStream(&std::cout, format));
   });
+  testInit("addStreamToAllTags", []() {
+    std::string format("[<LEVEL>]: <MESSAGE> \n");
+    axom::slic::addStreamToAllTags(
+      new axom::slic::GenericOutputStream(&std::cout, format));
+  });
+  testInit("getNumStreamsAtTag",
+           []() { axom::slic::getNumStreamsAtTag("Test"); });
 }
 
 TEST(slic_uninit, log_methods)
@@ -96,11 +111,17 @@ TEST(slic_uninit, log_methods)
   testInit("logMessage_B", [&]() {
     axom::slic::logMessage(lvl, "another info message", "tagB");
   });
+  testInit("logMessage_B_Tagged", [&]() {
+    axom::slic::logMessage(lvl, "another info message", "tagB", false, true);
+  });
   testInit("logMessage_C", [&, fname]() {
     axom::slic::logMessage(lvl, "info msg", fname, line);
   });
   testInit("logMessage_D", [&, fname]() {
     axom::slic::logMessage(lvl, "info msg", "tagD", fname, line);
+  });
+  testInit("logMessage_D_Tagged", [&, fname]() {
+    axom::slic::logMessage(lvl, "info msg", "tagD", fname, line, false, true);
   });
 
   testInit("logErrorMessage", [&, fname]() {


### PR DESCRIPTION
This PR
- Adds the ability to create user-defined tags for tagged streams and messages.
  - Tagged streams only receive messages with the corresponding tag.
- Adds a `TextTagCombiner` Combiner for Lumberjack that combines messages based on message and tag content.

ReadTheDocs link for this branch: https://axom.readthedocs.io/en/feature-han12-slic_tags/axom/slic/docs/sphinx/sections/getting_started.html#step-5-1-tagged-log-streams