### PR TITLE
Feature/taylor/shroud 0.13.0

### DIFF
--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1.1.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1.1.cmake
@@ -113,7 +113,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/blueos_3_ppc64le_ib_p9/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1.2_cuda.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1.2_cuda.cmake
@@ -141,7 +141,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/blueos_3_ppc64le_ib_p9/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-gcc@8.3.1.1.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-gcc@8.3.1.1.cmake
@@ -105,7 +105,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/blueos_3_ppc64le_ib_p9/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-gcc@8.3.1.2_cuda.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-gcc@8.3.1.2_cuda.cmake
@@ -133,7 +133,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/blueos_3_ppc64le_ib_p9/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1.1.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1.1.cmake
@@ -117,7 +117,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/blueos_3_ppc64le_ib_p9/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1.2_cuda.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-xl@16.1.1.2_cuda.cmake
@@ -145,7 +145,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/blueos_3_ppc64le_ib_p9/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/quartz-toss_4_x86_64_ib-clang@14.0.6.cmake
+++ b/host-configs/quartz-toss_4_x86_64_ib-clang@14.0.6.cmake
@@ -123,7 +123,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/quartz-toss_4_x86_64_ib-gcc@10.3.1.cmake
+++ b/host-configs/quartz-toss_4_x86_64_ib-gcc@10.3.1.cmake
@@ -121,7 +121,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/quartz-toss_4_x86_64_ib-intel@2022.1.0.cmake
+++ b/host-configs/quartz-toss_4_x86_64_ib-intel@2022.1.0.cmake
@@ -101,7 +101,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@10.0.1.1.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@10.0.1.1.cmake
@@ -113,7 +113,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/blueos_3_ppc64le_ib_p9/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@10.0.1.2_cuda.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@10.0.1.2_cuda.cmake
@@ -141,7 +141,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/blueos_3_ppc64le_ib_p9/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@8.3.1.1.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@8.3.1.1.cmake
@@ -105,7 +105,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/blueos_3_ppc64le_ib_p9/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@8.3.1.2_cuda.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-gcc@8.3.1.2_cuda.cmake
@@ -133,7 +133,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/blueos_3_ppc64le_ib_p9/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1.1.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1.1.cmake
@@ -117,7 +117,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/blueos_3_ppc64le_ib_p9/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1.2_cuda.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-xl@16.1.1.2_cuda.cmake
@@ -145,7 +145,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/blueos_3_ppc64le_ib_p9/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_4_x86_64_ib-clang@14.0.6.cmake
+++ b/host-configs/rzgenie-toss_4_x86_64_ib-clang@14.0.6.cmake
@@ -123,7 +123,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_4_x86_64_ib-gcc@10.3.1.cmake
+++ b/host-configs/rzgenie-toss_4_x86_64_ib-gcc@10.3.1.cmake
@@ -121,7 +121,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_4_x86_64_ib-intel@2022.1.0.cmake
+++ b/host-configs/rzgenie-toss_4_x86_64_ib-intel@2022.1.0.cmake
@@ -101,7 +101,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzwhippet-toss_4_x86_64_ib-clang@14.0.6.cmake
+++ b/host-configs/rzwhippet-toss_4_x86_64_ib-clang@14.0.6.cmake
@@ -123,7 +123,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzwhippet-toss_4_x86_64_ib-gcc@10.3.1.cmake
+++ b/host-configs/rzwhippet-toss_4_x86_64_ib-gcc@10.3.1.cmake
@@ -121,7 +121,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzwhippet-toss_4_x86_64_ib-intel@2022.1.0.cmake
+++ b/host-configs/rzwhippet-toss_4_x86_64_ib-intel@2022.1.0.cmake
@@ -101,7 +101,7 @@ set(ENABLE_DOCS ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/sphinx-build" CACHE PATH "")
 
-set(SHROUD_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.10.10/bin/shroud" CACHE PATH "")
+set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0.13.0/bin/shroud" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.9/bin/cppcheck" CACHE PATH "")
 

--- a/scripts/spack/configs/blueos_3_ppc64le_ib_p9/spack.yaml
+++ b/scripts/spack/configs/blueos_3_ppc64le_ib_p9/spack.yaml
@@ -358,11 +358,11 @@ spack:
       - spec: python@3.10.10
         prefix: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/latest/python-3.10.10
     py-shroud:
-      version: [0.12.2]
+      version: [0.13.0]
       buildable: false
       externals:
-      - spec: py-shroud@0.12.2
-        prefix: /collab/usr/gapps/axom/devtools/blueos_3_ppc64le_ib_p9/latest/python-3.10.10
+      - spec: py-shroud@0.13.0
+        prefix: /collab/usr/gapps/shroud/public/blueos_3_ppc64le_ib_p9/shroud-0.13.0
     py-sphinx:
       version: [6.1.3]
       buildable: false

--- a/scripts/spack/configs/toss_4_x86_64_ib/spack.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib/spack.yaml
@@ -311,11 +311,11 @@ spack:
       - spec: llvm+clang@10.0.0
         prefix: /collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/llvm-10.0.0
     py-shroud:
-      version: [0.12.2]
+      version: [0.13.0]
       buildable: false
       externals:
-      - spec: py-shroud@0.12.2
-        prefix: /collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/latest/python-3.10.10
+      - spec: py-shroud@0.13.0
+        prefix: /collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0.13.0
     py-sphinx:
       version: [4.4.0]
       buildable: false

--- a/scripts/spack/configs/toss_4_x86_64_ib_cray/spack.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib_cray/spack.yaml
@@ -352,3 +352,10 @@ spack:
       require: "@3.0.1~shared~tests~examples"
     umpire:
       require: "@2023.06.0~shared~examples"
+
+    py-shroud:
+      version: [0.13.0]
+      buildable: false
+      externals:
+      - spec: py-shroud@0.13.0
+        prefix: /collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.13.0

--- a/scripts/spack/devtools_configs/toss_4_x86_64_ib/spack.yaml
+++ b/scripts/spack/devtools_configs/toss_4_x86_64_ib/spack.yaml
@@ -17,7 +17,7 @@ spack:
   view:
     default:
       root: ../view
-      select: [llvm, cppcheck, doxygen, py-shroud, py-sphinx, python, ^python]
+      select: [llvm, cppcheck, doxygen, py-sphinx, python, ^python]
       projections:
         all: '{name}-{version}'
 

--- a/scripts/spack/packages/py-shroud/package.py
+++ b/scripts/spack/packages/py-shroud/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyShroud(PythonPackage):
+    """Create Fortran wrappers for a C++ library."""
+
+    homepage = "https://github.com/LLNL/shroud"
+    git = "https://github.com/LLNL/shroud.git"
+    tags = ["radiuss"]
+
+    license("BSD-3-Clause")
+
+    version("develop", branch="develop")
+    version("master", branch="master")
+    version("0.13.0", tag="v0.13.0", commit="4388ff1b689bbe450ba7d1b9bc4e1fe2563a4101")
+    version("0.12.2", tag="v0.12.2", commit="939ba0a3e8b5a885da3ddaebb92bf93cb12b0401")
+    version("0.12.1", tag="v0.12.1", commit="c09344655371885a42783f8c0ac8a31f2bbffc9f")
+    version("0.11.0", tag="v0.11.0", commit="503b852796d549199c5ab94b14e59ebd62988870")
+    version("0.10.1", tag="v0.10.1", commit="13a3c70bc5190e0e8531e17925928fbd7154acb5")
+    version("0.9.0", tag="v0.9.0", commit="94aa2831290d10b604df16cb87ee17aa722fb998")
+    version("0.8.0", tag="v0.8.0", commit="b58ac35f41514428d08849a578c45ad444bfddc9")
+
+    depends_on("py-setuptools", type=("build", "run"))
+    depends_on("py-pyyaml@4.2:", type=("build", "run"))


### PR DESCRIPTION
# Update devtools to use Shroud 0.13.0

- This PR is a devtool update
- It does the following:
  - Part of #1258
  - Removes Shroud as part of the `build_devtools.py` scripts. Instead it uses a version installed at `/collab/usr/gapps/shroud/public/$SYS_TYPE`.
  - Changes the host-configs files to use this version.
  - Adds `py-shroud/package.py` file. This should be upstreamed into spack.
  
A future PR will regenerate the Fortran and C wrappers using this version.

The current hash of spack used in `scripts/spack/devtools.json` only supplies 0.12.1, while we were requesting 0.12.2.