### PR TITLE
Array: improve support for unified memory

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -34,6 +34,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Primal: Adds a `closest_point` operator for finding the closest point on a `Segment`
 - Primal: Adds a `reflectPoint` method to the `Plane` primitive
 - Primal: Makes several primitive methods available in device code
+- Improves support for `axom::Array` allocated in unified and pinned memory on GPU platforms.
+  Use of GPU-based operations for Arrays allocated in a unified memory space is controlled with
+  a new method, `Array::setDevicePreference()`.
 
 ### Changed
 - `quest::ArrayIndexer` is now `axom::MDMapping`, adopting conventional terminology
@@ -47,6 +50,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   from axom's default dependencies on Windows due to incompatibility between umpire's
   external `fmt` and axom's vendored copy.
 - Turn off CMake finding dependencies on system paths.
+- `axom::Array`: trivially-copyable types with a non-trivial constructor are now initialized on the GPU.
 
 ### Removed
 - Removes config option `AXOM_ENABLE_ANNOTATIONS`. Annotations are now provided by `caliper` 

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -822,6 +822,16 @@ public:
   int getAllocatorID() const { return m_allocator_id; }
 
   /*!
+   * \brief Sets the preferred space where operations on this array should be
+   *  performed.
+   *
+   *  This option only has an effect for memory which is both accessible on the
+   *  CPU and the GPU. For CUDA this is the Unified and Pinned memory spaces,
+   *  while for HIP this is the Unified, Pinned, and Device memory spaces.
+   */
+  void setDevicePreference(bool on_device) { m_executeOnGPU = on_device; }
+
+  /*!
    * \brief Returns a view of the array
    * \sa ArrayView
    */
@@ -934,6 +944,7 @@ protected:
   IndexType m_capacity = 0;
   double m_resize_ratio = DEFAULT_RESIZE_RATIO;
   int m_allocator_id;
+  bool m_executeOnGPU;
 };
 
 /// \brief Helper alias for multi-component arrays

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -299,7 +299,7 @@ public:
       }
       OpHelper {m_allocator_id, m_executeOnGPU}.fill_range(m_data,
                                                            0,
-                                                           m_num_elements,
+                                                           other.size(),
                                                            other.data(),
                                                            srcSpace);
       updateNumElements(other.size());
@@ -1575,7 +1575,7 @@ inline void Array<T, DIM, SPACE>::initialize_from_other(
   // element.
   OpHelper {m_allocator_id, m_executeOnGPU}.fill_range(m_data,
                                                        0,
-                                                       m_num_elements,
+                                                       num_elements,
                                                        other_data,
                                                        other_data_space);
   this->updateNumElements(num_elements);

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -1448,6 +1448,16 @@ struct MemSpaceToOpSpace<MemorySpace::Device>
 {
   static constexpr OperationSpace value = OperationSpace::Device;
 };
+template <>
+struct MemSpaceToOpSpace<MemorySpace::Pinned>
+{
+  static constexpr OperationSpace value = OperationSpace::Unified_Device;
+};
+template <>
+struct MemSpaceToOpSpace<MemorySpace::Unified>
+{
+  static constexpr OperationSpace value = OperationSpace::Unified_Device;
+};
 #endif
 
 template <typename T, MemorySpace SPACE>
@@ -1531,6 +1541,8 @@ private:
   using Base = ArrayOpsBase<T, OperationSpace::Host>;
 #if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
   using BaseDevice = ArrayOpsBase<T, OperationSpace::Device>;
+  // Works with unified and pinned memory.
+  using BaseUM = ArrayOpsBase<T, OperationSpace::Unified_Device>;
 #endif
 
 public:
@@ -1542,6 +1554,11 @@ public:
     if(space == MemorySpace::Device)
     {
       BaseDevice::init(array, begin, nelems);
+      return;
+    }
+    else if(space == MemorySpace::Unified || space == MemorySpace::Pinned)
+    {
+      BaseUM::init(array, begin, nelems);
       return;
     }
 #else
@@ -1562,6 +1579,11 @@ public:
     if(space == MemorySpace::Device)
     {
       BaseDevice::fill(array, begin, nelems, value);
+      return;
+    }
+    else if(space == MemorySpace::Unified || space == MemorySpace::Pinned)
+    {
+      BaseUM::fill(array, begin, nelems, value);
       return;
     }
 #else
@@ -1585,6 +1607,11 @@ public:
       BaseDevice::fill_range(array, begin, nelems, values, valueSpace);
       return;
     }
+    else if(space == MemorySpace::Unified || space == MemorySpace::Pinned)
+    {
+      BaseUM::fill_range(array, begin, nelems, values, valueSpace);
+      return;
+    }
 #else
     AXOM_UNUSED_VAR(allocId);
 #endif
@@ -1604,6 +1631,11 @@ public:
     if(space == MemorySpace::Device)
     {
       BaseDevice::destroy(array, begin, nelems);
+      return;
+    }
+    else if(space == MemorySpace::Unified || space == MemorySpace::Pinned)
+    {
+      BaseUM::destroy(array, begin, nelems);
       return;
     }
 #else
@@ -1630,6 +1662,11 @@ public:
       BaseDevice::move(array, src_begin, src_end, dst);
       return;
     }
+    else if(space == MemorySpace::Unified || space == MemorySpace::Pinned)
+    {
+      BaseUM::move(array, src_begin, src_end, dst);
+      return;
+    }
 #else
     AXOM_UNUSED_VAR(allocId);
 #endif
@@ -1644,6 +1681,11 @@ public:
     if(space == MemorySpace::Device)
     {
       BaseDevice::realloc_move(array, nelems, values);
+      return;
+    }
+    else if(space == MemorySpace::Unified || space == MemorySpace::Pinned)
+    {
+      BaseUM::realloc_move(array, nelems, values);
       return;
     }
 #else
@@ -1661,6 +1703,11 @@ public:
     if(space == MemorySpace::Device)
     {
       BaseDevice::emplace(array, dst, std::forward<Args>(args)...);
+      return;
+    }
+    else if(space == MemorySpace::Unified || space == MemorySpace::Pinned)
+    {
+      BaseUM::emplace(array, dst, std::forward<Args>(args)...);
       return;
     }
 #else

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -1489,36 +1489,29 @@ private:
   using Base = ArrayOpsBase<T, OpSpace>;
 
 public:
-  static void init(T* array, IndexType begin, IndexType nelems, int allocId)
+  ArrayOps(int allocId) { AXOM_UNUSED_VAR(allocId); }
+
+  void init(T* array, IndexType begin, IndexType nelems)
   {
-    AXOM_UNUSED_VAR(allocId);
     Base::init(array, begin, nelems);
   }
 
-  static void fill(T* array,
-                   IndexType begin,
-                   IndexType nelems,
-                   int allocId,
-                   const T& value)
+  void fill(T* array, IndexType begin, IndexType nelems, const T& value)
   {
-    AXOM_UNUSED_VAR(allocId);
     Base::fill(array, begin, nelems, value);
   }
 
-  static void fill_range(T* array,
-                         IndexType begin,
-                         IndexType nelems,
-                         int allocId,
-                         const T* values,
-                         MemorySpace space)
+  void fill_range(T* array,
+                  IndexType begin,
+                  IndexType nelems,
+                  const T* values,
+                  MemorySpace space)
   {
-    AXOM_UNUSED_VAR(allocId);
     Base::fill_range(array, begin, nelems, values, space);
   }
 
-  static void destroy(T* array, IndexType begin, IndexType nelems, int allocId)
+  void destroy(T* array, IndexType begin, IndexType nelems)
   {
-    AXOM_UNUSED_VAR(allocId);
     if(nelems == 0)
     {
       return;
@@ -1526,13 +1519,8 @@ public:
     Base::destroy(array, begin, nelems);
   }
 
-  static void move(T* array,
-                   IndexType src_begin,
-                   IndexType src_end,
-                   IndexType dst,
-                   int allocId)
+  void move(T* array, IndexType src_begin, IndexType src_end, IndexType dst)
   {
-    AXOM_UNUSED_VAR(allocId);
     if(src_begin >= src_end)
     {
       return;
@@ -1540,16 +1528,14 @@ public:
     Base::move(array, src_begin, src_end, dst);
   }
 
-  static void realloc_move(T* array, IndexType nelems, T* values, int allocId)
+  void realloc_move(T* array, IndexType nelems, T* values)
   {
-    AXOM_UNUSED_VAR(allocId);
     Base::realloc_move(array, nelems, values);
   }
 
   template <typename... Args>
-  static void emplace(T* array, IndexType dst, IndexType allocId, Args&&... args)
+  void emplace(T* array, IndexType dst, Args&&... args)
   {
-    AXOM_UNUSED_VAR(allocId);
     Base::emplace(array, dst, std::forward<Args>(args)...);
   }
 };
@@ -1563,14 +1549,21 @@ private:
   using BaseDevice = ArrayOpsBase<T, OperationSpace::Device>;
   // Works with unified and pinned memory.
   using BaseUM = ArrayOpsBase<T, OperationSpace::Unified_Device>;
+
+  MemorySpace space {MemorySpace::Dynamic};
 #endif
 
 public:
-  static void init(T* array, IndexType begin, IndexType nelems, int allocId)
+  ArrayOps(int allocId)
   {
 #if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
-    MemorySpace space = getAllocatorSpace(allocId);
+    space = getAllocatorSpace(allocId);
+#endif
+  }
 
+  void init(T* array, IndexType begin, IndexType nelems)
+  {
+#if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
     if(space == MemorySpace::Device)
     {
       BaseDevice::init(array, begin, nelems);
@@ -1581,21 +1574,13 @@ public:
       BaseUM::init(array, begin, nelems);
       return;
     }
-#else
-    AXOM_UNUSED_VAR(allocId);
 #endif
     Base::init(array, begin, nelems);
   }
 
-  static void fill(T* array,
-                   IndexType begin,
-                   IndexType nelems,
-                   int allocId,
-                   const T& value)
+  void fill(T* array, IndexType begin, IndexType nelems, const T& value)
   {
 #if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
-    MemorySpace space = getAllocatorSpace(allocId);
-
     if(space == MemorySpace::Device)
     {
       BaseDevice::fill(array, begin, nelems, value);
@@ -1606,22 +1591,17 @@ public:
       BaseUM::fill(array, begin, nelems, value);
       return;
     }
-#else
-    AXOM_UNUSED_VAR(allocId);
 #endif
     Base::fill(array, begin, nelems, value);
   }
 
-  static void fill_range(T* array,
-                         IndexType begin,
-                         IndexType nelems,
-                         int allocId,
-                         const T* values,
-                         MemorySpace valueSpace)
+  void fill_range(T* array,
+                  IndexType begin,
+                  IndexType nelems,
+                  const T* values,
+                  MemorySpace valueSpace)
   {
 #if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
-    MemorySpace space = getAllocatorSpace(allocId);
-
     if(space == MemorySpace::Device)
     {
       BaseDevice::fill_range(array, begin, nelems, values, valueSpace);
@@ -1632,22 +1612,17 @@ public:
       BaseUM::fill_range(array, begin, nelems, values, valueSpace);
       return;
     }
-#else
-    AXOM_UNUSED_VAR(allocId);
 #endif
-    AXOM_UNUSED_VAR(allocId);
     Base::fill_range(array, begin, nelems, values, valueSpace);
   }
 
-  static void destroy(T* array, IndexType begin, IndexType nelems, int allocId)
+  void destroy(T* array, IndexType begin, IndexType nelems)
   {
     if(nelems == 0)
     {
       return;
     }
 #if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
-    MemorySpace space = getAllocatorSpace(allocId);
-
     if(space == MemorySpace::Device)
     {
       BaseDevice::destroy(array, begin, nelems);
@@ -1658,25 +1633,17 @@ public:
       BaseUM::destroy(array, begin, nelems);
       return;
     }
-#else
-    AXOM_UNUSED_VAR(allocId);
 #endif
     Base::destroy(array, begin, nelems);
   }
 
-  static void move(T* array,
-                   IndexType src_begin,
-                   IndexType src_end,
-                   IndexType dst,
-                   int allocId)
+  void move(T* array, IndexType src_begin, IndexType src_end, IndexType dst)
   {
     if(src_begin >= src_end)
     {
       return;
     }
 #if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
-    MemorySpace space = getAllocatorSpace(allocId);
-
     if(space == MemorySpace::Device)
     {
       BaseDevice::move(array, src_begin, src_end, dst);
@@ -1687,17 +1654,13 @@ public:
       BaseUM::move(array, src_begin, src_end, dst);
       return;
     }
-#else
-    AXOM_UNUSED_VAR(allocId);
 #endif
     Base::move(array, src_begin, src_end, dst);
   }
 
-  static void realloc_move(T* array, IndexType nelems, T* values, int allocId)
+  void realloc_move(T* array, IndexType nelems, T* values)
   {
 #if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
-    MemorySpace space = getAllocatorSpace(allocId);
-
     if(space == MemorySpace::Device)
     {
       BaseDevice::realloc_move(array, nelems, values);
@@ -1708,18 +1671,14 @@ public:
       BaseUM::realloc_move(array, nelems, values);
       return;
     }
-#else
-    AXOM_UNUSED_VAR(allocId);
 #endif
     Base::realloc_move(array, nelems, values);
   }
 
   template <typename... Args>
-  static void emplace(T* array, IndexType dst, IndexType allocId, Args&&... args)
+  void emplace(T* array, IndexType dst, Args&&... args)
   {
 #if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
-    MemorySpace space = getAllocatorSpace(allocId);
-
     if(space == MemorySpace::Device)
     {
       BaseDevice::emplace(array, dst, std::forward<Args>(args)...);
@@ -1730,8 +1689,6 @@ public:
       BaseUM::emplace(array, dst, std::forward<Args>(args)...);
       return;
     }
-#else
-    AXOM_UNUSED_VAR(allocId);
 #endif
     Base::emplace(array, dst, std::forward<Args>(args)...);
   }

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -1597,6 +1597,9 @@ public:
     {
       space = MemorySpace::Host;
     }
+#else
+    AXOM_UNUSED_VAR(allocId);
+    AXOM_UNUSED_VAR(preferDevice);
 #endif
   }
 

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -1446,8 +1446,17 @@ struct MemSpaceToOpSpace
 template <>
 struct MemSpaceToOpSpace<MemorySpace::Device>
 {
+  #if defined(AXOM_USE_CUDA)
+  // On CUDA platforms, device memory allocated with cudaMalloc can only be
+  // touched from a device kernel.
   static constexpr OperationSpace value = OperationSpace::Device;
+  #elif defined(AXOM_USE_HIP)
+  // On HIP platforms, device memory allocated with hipMalloc is accessible from
+  // the host.
+  static constexpr OperationSpace value = OperationSpace::Unified_Device;
+  #endif
 };
+
 template <>
 struct MemSpaceToOpSpace<MemorySpace::Pinned>
 {

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -50,6 +50,11 @@ public:
   using DynamicArray = axom::Array<int, 1, axom::MemorySpace::Dynamic>;
   using KernelArray = axom::Array<int, 1, exec_space_memory>;
   using KernelArrayView = axom::ArrayView<int, 1, exec_space_memory>;
+
+  static int getKernelAllocatorID()
+  {
+    return axom::detail::getAllocatorID<exec_space_memory>();
+  }
 };
 
 // Generate a list of available execution types
@@ -261,7 +266,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array)
   using DynamicArray = typename TestFixture::DynamicArray;
   using HostArray = typename TestFixture::HostArray;
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
+  int kernelAllocID = TestFixture::getKernelAllocatorID();
   int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   // Create an array of N items using default MemorySpace for ExecSpace
@@ -307,14 +312,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_insert)
   using HostArray = typename TestFixture::HostArray;
   using ExecSpace = typename TestFixture::ExecSpace;
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-  if(axom::execution_space<ExecSpace>::onDevice())
-  {
-    kernelAllocID = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Device);
-  }
-#endif
+  int kernelAllocID = TestFixture::getKernelAllocatorID();
 
   constexpr axom::IndexType N = 374;
   DynamicArray arr(N, N, kernelAllocID);
@@ -380,14 +378,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_range_insert)
   using HostArray = typename TestFixture::HostArray;
   using ExecSpace = typename TestFixture::ExecSpace;
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-  if(axom::execution_space<ExecSpace>::onDevice())
-  {
-    kernelAllocID = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Device);
-  }
-#endif
+  int kernelAllocID = TestFixture::getKernelAllocatorID();
 
   constexpr axom::IndexType N = 374;
   DynamicArray arr(N, N, kernelAllocID);
@@ -454,14 +445,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_range_set)
   using HostArray = typename TestFixture::HostArray;
   using ExecSpace = typename TestFixture::ExecSpace;
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-  if(axom::execution_space<ExecSpace>::onDevice())
-  {
-    kernelAllocID = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Device);
-  }
-#endif
+  int kernelAllocID = TestFixture::getKernelAllocatorID();
 
   constexpr axom::IndexType N = 374;
   DynamicArray arr(N, N, kernelAllocID);
@@ -510,14 +494,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_initializer_list)
   using HostArray = typename TestFixture::HostArray;
   using ExecSpace = typename TestFixture::ExecSpace;
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-  if(axom::execution_space<ExecSpace>::onDevice())
-  {
-    kernelAllocID = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Device);
-  }
-#endif
+  int kernelAllocID = TestFixture::getKernelAllocatorID();
 
   // Construct array with an initializer list
   {
@@ -561,14 +538,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_resize)
   using HostArray = typename TestFixture::HostArray;
   using ExecSpace = typename TestFixture::ExecSpace;
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-  if(axom::execution_space<ExecSpace>::onDevice())
-  {
-    kernelAllocID = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Device);
-  }
-#endif
+  int kernelAllocID = TestFixture::getKernelAllocatorID();
 
   constexpr axom::IndexType N = 10;
   DynamicArray arr(N, N, kernelAllocID);
@@ -578,6 +548,12 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_resize)
   axom::for_all<ExecSpace>(
     N,
     AXOM_LAMBDA(axom::IndexType idx) { arr_v[idx] = idx; });
+
+  // handles synchronization, if necessary
+  if(axom::execution_space<ExecSpace>::async())
+  {
+    axom::synchronize<ExecSpace>();
+  }
 
   // Call resize without a default value. New elements in array should be set
   // to 0.
@@ -645,14 +621,7 @@ AXOM_TYPED_TEST(core_array_for_all, dynamic_array_of_arrays)
   using HostArrayOfArrays =
     typename TestFixture::template HostTArray<DynamicArray>;
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-  if(axom::execution_space<ExecSpace>::onDevice())
-  {
-    kernelAllocID = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Device);
-  }
-#endif
+  int kernelAllocID = TestFixture::getKernelAllocatorID();
 
   constexpr axom::IndexType N = 5;
   ArrayOfArrays arr_2d(0, N, kernelAllocID);
@@ -738,14 +707,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_default_ctor_obj)
   using HostArray =
     typename TestFixture::template HostTArray<NonTrivialDefaultCtor>;
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-  if(axom::execution_space<ExecSpace>::onDevice())
-  {
-    kernelAllocID = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Device);
-  }
-#endif
+  int kernelAllocID = TestFixture::getKernelAllocatorID();
   int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   // Create an array of N items using default MemorySpace for ExecSpace
@@ -815,14 +777,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_ctor_obj)
     typename TestFixture::template DynamicTArray<NonTrivialCtor>;
   using HostArray = typename TestFixture::template HostTArray<NonTrivialCtor>;
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-  if(axom::execution_space<ExecSpace>::onDevice())
-  {
-    kernelAllocID = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Device);
-  }
-#endif
+  int kernelAllocID = TestFixture::getKernelAllocatorID();
   int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   // Create an array of N items using default MemorySpace for ExecSpace
@@ -885,14 +840,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_dtor_obj)
     typename TestFixture::template DynamicTArray<NonTrivialDtor>;
   using HostArray = typename TestFixture::template HostTArray<NonTrivialDtor>;
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-  if(axom::execution_space<ExecSpace>::onDevice())
-  {
-    kernelAllocID = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Device);
-  }
-#endif
+  int kernelAllocID = TestFixture::getKernelAllocatorID();
   int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   NonTrivialDtor::dtor_calls = 0;
@@ -973,14 +921,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_copy_ctor_obj)
   using IntArray = typename TestFixture::DynamicArray;
   using IntHostArray = typename TestFixture::HostArray;
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-  if(axom::execution_space<ExecSpace>::onDevice())
-  {
-    kernelAllocID = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Device);
-  }
-#endif
+  int kernelAllocID = TestFixture::getKernelAllocatorID();
   int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   // Helper function to check all values in the array for consistency
@@ -1092,14 +1033,7 @@ AXOM_TYPED_TEST(core_array_for_all, nontrivial_emplace)
   using IntArray = typename TestFixture::DynamicArray;
   using HostIntArray = typename TestFixture::HostArray;
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-  if(axom::execution_space<ExecSpace>::onDevice())
-  {
-    kernelAllocID = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Device);
-  }
-#endif
+  int kernelAllocID = TestFixture::getKernelAllocatorID();
 
   // Helper function to copy device values to a host array
   auto convert_to_host_array = [=](const DynamicArray& arr) -> HostIntArray {
@@ -1215,17 +1149,18 @@ AXOM_TYPED_TEST(core_array_for_all, device_insert)
   using DynamicArrayOfArrays =
     typename TestFixture::template DynamicTArray<DynamicArray>;
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
+  int kernelAllocID = TestFixture::getKernelAllocatorID();
 #if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   // Use unified memory for frequent movement between device operations
   // and value checking on host
-  kernelAllocID = axom::getUmpireResourceAllocatorID(
+  int umAllocID = axom::getUmpireResourceAllocatorID(
     umpire::resource::MemoryResourceType::Unified);
 #endif
+  int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   constexpr axom::IndexType N = 374;
 
-  DynamicArrayOfArrays arr_container(1, 1, kernelAllocID);
+  DynamicArrayOfArrays arr_container(1, 1, umAllocID);
   arr_container[0] = DynamicArray(0, N, kernelAllocID);
   const auto arr_v = arr_container.view();
 
@@ -1262,24 +1197,27 @@ AXOM_TYPED_TEST(core_array_for_all, device_insert)
   EXPECT_EQ(arr_container[0].size(), N);
   EXPECT_EQ(arr_container[0].capacity(), N);
 
+  // Copy array to host.
+  DynamicArray arr_host(arr_container[0], hostAllocID);
+
   // Device-side inserts may occur in any order.
   // Sort them before we check the inserted values.
-  std::sort(arr_container[0].begin(),
-            arr_container[0].end(),
+  std::sort(arr_host.begin(),
+            arr_host.end(),
             [](const DeviceInsert& a, const DeviceInsert& b) -> bool {
               return a.m_value < b.m_value;
             });
 
   for(int i = 0; i < N; i++)
   {
-    EXPECT_EQ(arr_container[0][i].m_value, 3 * i + 5);
+    EXPECT_EQ(arr_host[i].m_value, 3 * i + 5);
     if(axom::execution_space<ExecSpace>::onDevice())
     {
-      EXPECT_EQ(arr_container[0][i].m_host_or_device, INSERT_ON_DEVICE);
+      EXPECT_EQ(arr_host[i].m_host_or_device, INSERT_ON_DEVICE);
     }
     else
     {
-      EXPECT_EQ(arr_container[0][i].m_host_or_device, INSERT_ON_HOST);
+      EXPECT_EQ(arr_host[i].m_host_or_device, INSERT_ON_HOST);
     }
   }
 }

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -1150,10 +1150,11 @@ AXOM_TYPED_TEST(core_array_for_all, device_insert)
     typename TestFixture::template DynamicTArray<DynamicArray>;
 
   int kernelAllocID = TestFixture::getKernelAllocatorID();
+  int umAllocID = kernelAllocID;
 #if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   // Use unified memory for frequent movement between device operations
   // and value checking on host
-  int umAllocID = axom::getUmpireResourceAllocatorID(
+  umAllocID = axom::getUmpireResourceAllocatorID(
     umpire::resource::MemoryResourceType::Unified);
 #endif
   int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -78,6 +78,9 @@ using MyTypes = ::testing::Types<
   ArrayTestParams<axom::HIP_EXEC<256, axom::ASYNC>, axom::MemorySpace::Unified>,
   ArrayTestParams<axom::HIP_EXEC<256, axom::ASYNC>, axom::MemorySpace::Pinned>,
 #endif
+#if defined(AXOM_USE_UMPIRE)
+  ArrayTestParams<axom::SEQ_EXEC, axom::MemorySpace::Host>,
+#endif
   ArrayTestParams<axom::SEQ_EXEC>>;
 
 TYPED_TEST_SUITE(core_array_for_all, MyTypes);


### PR DESCRIPTION
# Summary

- Adds GPU-side `ArrayOps` operations for unified and pinned memory.

  As with the operations for device memory, unified and pinned memory operations try to use Umpire operations when the type is trivially-copyable, and instantiate a GPU kernel for fill operations when the type is trivially-constructible. This potentially avoids unwanted memory motion between the CPU and GPU.

  In the case where the type isn't trivially-copyable or trivially-constructible, the corresponding operation needs to be performed on the device in order to correctly call the required constructor. However, since unified and pinned memory are accessible on the device, we can just do that operation in-place instead of allocating a temporary buffer.
