### PR TITLE
Fixes memory leaks in axom

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -66,6 +66,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Fixed a bug when loading Sidre groups with attributes that already exist
 - Fixed `std::locale` error when when compiling `src/axom/core/utilities/System.cpp` using nvcc
 - Include `cstdint` for higher gcc version support (e.g. gcc-13)
+- Fixed several memory leaks in `axom::Array`, `quest::Shaping` and `sidre::MFEMSidreDataCollection`
 
 ## [Version 0.8.1] - Release date 2023-08-16
 

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -257,12 +257,12 @@ public:
   {
     if(this != &other)
     {
+      this->clear();
       static_cast<ArrayBase<T, DIM, Array<T, DIM, SPACE>>&>(*this) = other;
       m_allocator_id = other.m_allocator_id;
       m_resize_ratio = other.m_resize_ratio;
-      initialize(other.size(), other.capacity());
-      // Use fill_range to ensure that copy constructors are invoked for each
-      // element.
+      setCapacity(other.capacity());
+      // Use fill_range to ensure that copy constructors are invoked for each element
       MemorySpace srcSpace = SPACE;
       if(srcSpace == MemorySpace::Dynamic)
       {
@@ -270,10 +270,11 @@ public:
       }
       OpHelper::fill_range(m_data,
                            0,
-                           m_num_elements,
+                           other.size(),
                            m_allocator_id,
                            other.data(),
                            srcSpace);
+      updateNumElements(other.size());
     }
 
     return *this;
@@ -1474,15 +1475,15 @@ inline void Array<T, DIM, SPACE>::initialize_from_other(
 #endif
     m_allocator_id = axom::detail::getAllocatorID<SPACE>();
   }
-  initialize(num_elements, num_elements);
-  // Use fill_range to ensure that copy constructors are invoked for each
-  // element.
+  this->setCapacity(num_elements);
+  // Use fill_range to ensure that copy constructors are invoked for each element
   OpHelper::fill_range(m_data,
                        0,
-                       m_num_elements,
+                       num_elements,
                        m_allocator_id,
                        other_data,
                        other_data_space);
+  this->updateNumElements(num_elements);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -286,6 +286,7 @@ public:
   {
     if(this != &other)
     {
+      this->clear();
       if(m_data != nullptr)
       {
         axom::deallocate(m_data);

--- a/src/axom/core/numerics/Matrix.hpp
+++ b/src/axom/core/numerics/Matrix.hpp
@@ -4,15 +4,15 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "axom/config.hpp"
-#include "axom/core/utilities/Utilities.hpp"  // for utilities::swap()
-#include "axom/core/memory_management.hpp"    // for alloc(), free()
+#include "axom/core/utilities/Utilities.hpp"
+#include "axom/core/memory_management.hpp"
 
 #include "axom/fmt.hpp"
 
 // C/C++ includes
-#include <cassert>   // for assert()
-#include <cstring>   // for memcpy()
-#include <iostream>  // for std::ostream
+#include <cassert>
+#include <cstring>
+#include <iostream>
 
 #ifndef AXOM_MATRIX_HPP_
   #define AXOM_MATRIX_HPP_
@@ -39,6 +39,25 @@ class Matrix;
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const Matrix<T>& A);
 
+/*!
+ * \brief Checks if two matrices are component-wise equal
+ *
+ * \param [in] lhs first matrix
+ * \param [in] rhs second matrix
+ * \return status true if lhs==rhs, otherwise, false.
+ */
+template <typename T>
+bool operator==(const Matrix<T>& lhs, const Matrix<T>& rhs);
+
+/*!
+ * \brief Checks if two matrices are not component-wise equal
+ *
+ * \param [in] lhs first matrix
+ * \param [in] rhs second matrix
+ * \return status true if lhs!=rhs, otherwise, false.
+ */
+template <typename T>
+bool operator!=(const Matrix<T>& lhs, const Matrix<T>& rhs);
 /// @}
 
 /// \name Matrix Operators
@@ -948,6 +967,37 @@ AXOM_HOST_DEVICE void Matrix<T>::clear()
 //-----------------------------------------------------------------------------
 // FREE METHODS
 //-----------------------------------------------------------------------------
+
+template <typename T>
+bool operator==(const Matrix<T>& lhs, const Matrix<T>& rhs)
+{
+  const int R = lhs.getNumRows();
+  const int C = lhs.getNumColumns();
+
+  if(R != rhs.getNumRows() || C != rhs.getNumColumns())
+  {
+    return false;
+  }
+
+  using axom::utilities::isNearlyEqual;
+  constexpr double EPS = 1e-12;
+
+  for(int i = 0; i < R * C; ++i)
+  {
+    if(!isNearlyEqual(lhs.data()[i], rhs.data()[i], EPS))
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+template <typename T>
+bool operator!=(const Matrix<T>& lhs, const Matrix<T>& rhs)
+{
+  return !(lhs == rhs);
+}
 
 //-----------------------------------------------------------------------------
 template <typename T>

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -2359,3 +2359,103 @@ TEST(core_array, reserve_nontrivial_reloc_um)
   }
 }
 #endif
+
+// Regression test for a memory leak in axom::Array's copy/move/initialization
+template <typename T1, typename T2>
+auto make_arr_data(int SZ1, int SZ2)
+  -> std::pair<axom::Array<axom::Array<T1>>, axom::Array<axom::Array<T2>>>
+{
+  using Arr1 = axom::Array<axom::Array<T1>>;
+  using Arr2 = axom::Array<axom::Array<T2>>;
+
+  T1 val1 {};
+  T2 val2 {};
+
+  Arr1 arr1(SZ1, 2 * SZ1);
+  for(int i = 0; i < SZ1; ++i)
+  {
+    arr1[i].resize(i + 10);
+    arr1[i].shrink();
+    arr1[i].push_back(val1);
+  }
+
+  Arr2 arr2(SZ2, 2 * SZ2);
+  for(int i = 0; i < SZ2; ++i)
+  {
+    arr2[i].resize(i + 10);
+    arr2[i].shrink();
+    arr2[i].push_back(val2);
+  }
+  arr2.shrink();
+
+  return {std::move(arr1), std::move(arr2)};
+}
+
+TEST(core_array, regression_array_move)
+{
+  using T1 = int;
+  using Arr1 = axom::Array<axom::Array<T1>>;
+
+  using T2 = NonTriviallyRelocatable;
+  using Arr2 = axom::Array<axom::Array<T2>>;
+
+  using PArrArr = std::pair<Arr1, Arr2>;
+
+  constexpr int SZ1 = 20;
+  constexpr int SZ2 = 30;
+
+  {
+    PArrArr pr;
+    pr = make_arr_data<T1, T2>(SZ1, SZ2);
+
+    EXPECT_EQ(SZ1, pr.first.size());
+    EXPECT_EQ(2 * SZ1, pr.first.capacity());
+
+    EXPECT_EQ(SZ2, pr.second.size());
+    EXPECT_EQ(SZ2, pr.second.capacity());
+  }
+
+  {
+    auto pr = make_arr_data<T1, T2>(SZ1, SZ2);
+
+    EXPECT_EQ(SZ1, pr.first.size());
+    EXPECT_EQ(2 * SZ1, pr.first.capacity());
+
+    EXPECT_EQ(SZ2, pr.second.size());
+    EXPECT_EQ(SZ2, pr.second.capacity());
+  }
+
+  {
+    auto pr = make_arr_data<T1, T2>(SZ1, SZ2);
+    EXPECT_EQ(SZ1, pr.first.size());
+    EXPECT_EQ(2 * SZ1, pr.first.capacity());
+    EXPECT_EQ(SZ2, pr.second.size());
+    EXPECT_EQ(SZ2, pr.second.capacity());
+
+    pr = make_arr_data<T1, T2>(SZ2, SZ1);
+    EXPECT_EQ(SZ2, pr.first.size());
+    EXPECT_EQ(2 * SZ2, pr.first.capacity());
+    EXPECT_EQ(SZ1, pr.second.size());
+    EXPECT_EQ(SZ1, pr.second.capacity());
+  }
+
+  // lots of copy and move assignments and constructions
+  {
+    auto pr = make_arr_data<T1, T2>(SZ1, SZ2);
+    pr = make_arr_data<T1, T2>(5, 7);
+
+    auto pr2 = std::move(pr);
+    auto pr3 = pr2;
+
+    pr2 = make_arr_data<T1, T2>(13, 17);
+
+    auto pr4 {make_arr_data<T1, T2>(33, 44)};
+
+    auto pr5(std::move(pr4));
+
+    EXPECT_EQ(33, pr5.first.size());
+    EXPECT_EQ(66, pr5.first.capacity());
+    EXPECT_EQ(44, pr5.second.size());
+    EXPECT_EQ(44, pr5.second.capacity());
+  }
+}

--- a/src/axom/core/tests/core_map.hpp
+++ b/src/axom/core/tests/core_map.hpp
@@ -396,7 +396,11 @@ TEST(core_map, bucket_return_value)
 
     EXPECT_EQ(0, bucket.get_size());
     EXPECT_EQ(length, bucket.get_capacity());
+
+    // Note: Bucket's not intended to be used on its own; explicitly free the memory
+    axom::deallocate(bucket.m_list);
   }
+
   {
     const int length = 5;
     auto fn = [](Key i) { return i * i; };
@@ -411,6 +415,9 @@ TEST(core_map, bucket_return_value)
       EXPECT_EQ(i, node.key);
       EXPECT_EQ(fn(i), node.value);
     }
+
+    // Note: Bucket's not intended to be used on its own; explicitly free the memory
+    axom::deallocate(bucket.m_list);
   }
 
   {
@@ -427,6 +434,9 @@ TEST(core_map, bucket_return_value)
       EXPECT_EQ(i, node.key);
       EXPECT_EQ(fn(i), node.value);
     }
+
+    // Note: Bucket's not intended to be used on its own; explicitly free the memory
+    axom::deallocate(bucket.m_list);
   }
 }
 

--- a/src/axom/core/tests/numerics_matrix.hpp
+++ b/src/axom/core/tests/numerics_matrix.hpp
@@ -247,6 +247,85 @@ TEST(numerics_matrix, is_square)
 }
 
 //------------------------------------------------------------------------------
+TEST(numerics_matrix, equality)
+{
+  using Mtx = axom::numerics::Matrix<double>;
+  constexpr double val = 2.2;
+
+  {
+    Mtx a, b;
+    EXPECT_EQ(a, b);
+    EXPECT_EQ(b, a);
+  }
+
+  {
+    Mtx a, b(5, 7);
+    EXPECT_NE(a, b);
+
+    EXPECT_NE(b, a);
+  }
+
+  {
+    Mtx a(5, 7, val), b(5, 7, val);
+    EXPECT_EQ(a, b);
+    EXPECT_EQ(b, a);
+
+    a(3, 4) = 1;
+    EXPECT_NE(a, b);
+    EXPECT_NE(b, a);
+  }
+
+  {
+    Mtx a = Mtx::identity(3);
+    Mtx b = Mtx::identity(4);
+    EXPECT_NE(a, b);
+    EXPECT_NE(b, a);
+  }
+
+  {
+    Mtx a = Mtx::identity(3);
+    Mtx b = Mtx::identity(3);
+    EXPECT_EQ(a, b);
+    EXPECT_EQ(b, a);
+  }
+
+  {
+    Mtx a = Mtx::zeros(3, 3);
+    Mtx b = Mtx::ones(3, 3);
+    EXPECT_NE(a, b);
+    EXPECT_NE(b, a);
+  }
+
+  {
+    Mtx a = Mtx::identity(3);
+    Mtx b = Mtx::zeros(3, 3);
+    b(0, 0) = 1.;
+    b(1, 1) = 1.;
+    b(2, 2) = 1.;
+
+    EXPECT_EQ(a, b);
+    EXPECT_EQ(b, a);
+  }
+
+  {
+    Mtx a(7, 5);
+    Mtx b(5, 7);
+    EXPECT_NE(a, b);
+    EXPECT_NE(b, a);
+
+    a(3, 4) = val;
+    b(4, 3) = val;
+    EXPECT_NE(a, b);
+    EXPECT_NE(b, a);
+
+    Mtx a_tr(5, 7);
+    axom::numerics::matrix_transpose(a, a_tr);
+    EXPECT_EQ(a_tr, b);
+    EXPECT_EQ(b, a_tr);
+  }
+}
+
+//------------------------------------------------------------------------------
 TEST(numerics_matrix, random_access_operators)
 {
   const int MROWS = 10;

--- a/src/axom/inlet/VariantKey.hpp
+++ b/src/axom/inlet/VariantKey.hpp
@@ -126,7 +126,7 @@ private:
 
   // Integer and string keys
   // With only two possible types a union is overkill
-  int m_int;
+  int m_int {};
   std::string m_string;
 
   // Active key type

--- a/src/axom/klee/tests/KleeMatchers.hpp
+++ b/src/axom/klee/tests/KleeMatchers.hpp
@@ -61,13 +61,24 @@ public:
   void DescribeTo(std::ostream*) const { }
   void DescribeNegationTo(std::ostream*) const { }
 
+  friend bool operator==(const AlmostEqMatrixMatcher& lhs,
+                         const axom::numerics::Matrix<T>& rhs)
+  {
+    return lhs.MatchAndExplain(rhs, nullptr);
+  }
+
+  friend bool operator==(const axom::numerics::Matrix<T>& lhs,
+                         const AlmostEqMatrixMatcher& rhs)
+  {
+    return rhs == lhs;
+  }
+
 private:
   const axom::numerics::Matrix<T> m_mat;
 };
 
 template <typename T>
-inline ::testing::Matcher<const axom::numerics::Matrix<T>&> AlmostEqMatrix(
-  const axom::numerics::Matrix<T>& mat)
+inline auto AlmostEqMatrix(const axom::numerics::Matrix<T>& mat)
 {
   return AlmostEqMatrixMatcher<T>(mat);
 }
@@ -99,20 +110,30 @@ public:
   void DescribeTo(std::ostream*) const { }
   void DescribeNegationTo(std::ostream*) const { }
 
+  friend bool operator==(const AlmostEqArrMatcher& lhs, const T& rhs)
+  {
+    return lhs.MatchAndExplain(rhs, nullptr);
+  }
+
+  friend bool operator==(const T& lhs, const AlmostEqArrMatcher& rhs)
+  {
+    return rhs == lhs;
+  }
+
+  explicit operator const T() const { return m_arr; }
+
 private:
   const T m_arr;
 };
 
 template <typename T, int DIM>
-inline ::testing::Matcher<const primal::Vector<T, DIM>&> AlmostEqVector(
-  const primal::Vector<T, DIM>& vec)
+inline auto AlmostEqVector(const primal::Vector<T, DIM>& vec)
 {
   return AlmostEqArrMatcher<primal::Vector<T, DIM>>(vec);
 }
 
 template <typename T, int DIM>
-inline ::testing::Matcher<const primal::Point<T, DIM>&> AlmostEqPoint(
-  const primal::Point<T, DIM>& pt)
+inline auto AlmostEqPoint(const primal::Point<T, DIM>& pt)
 {
   return AlmostEqArrMatcher<primal::Point<T, DIM>>(pt);
 }
@@ -142,12 +163,23 @@ public:
   void DescribeTo(std::ostream*) const { }
   void DescribeNegationTo(std::ostream*) const { }
 
+  friend bool operator==(const AlmostEqSliceMatcher& lhs,
+                         const klee::SliceOperator& rhs)
+  {
+    return lhs.MatchAndExplain(rhs, nullptr);
+  }
+
+  friend bool operator==(const klee::SliceOperator& lhs,
+                         const AlmostEqSliceMatcher& rhs)
+  {
+    return rhs == lhs;
+  }
+
 private:
   const klee::SliceOperator m_slice;
 };
 
-inline ::testing::Matcher<const klee::SliceOperator&> AlmostEqSlice(
-  const klee::SliceOperator& slice)
+inline auto AlmostEqSlice(const klee::SliceOperator& slice)
 {
   return AlmostEqSliceMatcher(slice);
 }

--- a/src/axom/lumberjack/Message.cpp
+++ b/src/axom/lumberjack/Message.cpp
@@ -278,8 +278,7 @@ const char* packMessages(const std::vector<Message*>& messages)
 
   int totalSize = 1;  // include size for null terminator
 
-  //Calculate total size of char array after all messages are
-  //  combined.
+  //Calculate total size of char array after all messages are combined.
   std::vector<std::string> packedMessages;
   std::vector<std::string> sizeStrings;
   int currSize = 0;

--- a/src/axom/lumberjack/Message.hpp
+++ b/src/axom/lumberjack/Message.hpp
@@ -315,8 +315,7 @@ private:
 
 /*!
  *****************************************************************************
- * \brief This packs all given Message classes into one const char
- *  buffer.
+ * \brief This packs all given Message classes into one const char buffer
  *
  * The messages are packed into the following format:
  *  <message count>[*<packed message size>*<packed message>]...
@@ -325,6 +324,7 @@ private:
  * \param [in] messages Message classes to be packed for sending
  *
  * \return Packed char array of all given messages
+ * \note It is the caller's responsibility to deallocate the returned buffer
  *****************************************************************************
  */
 const char* packMessages(const std::vector<Message*>& messages);
@@ -339,6 +339,9 @@ const char* packMessages(const std::vector<Message*>& messages);
  * This function only adds to the messages vector and does not alter the
  * packagedMessages parameter.
  *
+ * \note It is the caller's responsibility to deallocate the Message added 
+ * to the \a messages vector
+ * 
  * \param [in,out] messages Vector to append created messages to
  * \param [in]  packedMessages Packed messages to be unpacked
  * \param [in]  ranksLimit Limits how many ranks are tracked per Message.

--- a/src/axom/lumberjack/tests/lumberjack_BinaryCommunicator.hpp
+++ b/src/axom/lumberjack/tests/lumberjack_BinaryCommunicator.hpp
@@ -113,6 +113,13 @@ TEST(lumberjack_BinaryCommunicator, basic)
   c.finalize();
 
   MPI_Barrier(MPI_COMM_WORLD);
+
+  // cleanup allocated memory from received messages
+  for(auto& rm : receivedPackedMessages)
+  {
+    delete rm;
+  }
+  receivedPackedMessages.clear();
 }
 
 TEST(lumberjack_BinaryCommunicator, pushNothing)

--- a/src/axom/lumberjack/tests/lumberjack_Message.hpp
+++ b/src/axom/lumberjack/tests/lumberjack_Message.hpp
@@ -637,6 +637,8 @@ TEST(lumberjack_Message, packMessagesIndividually)
 
     EXPECT_EQ(packedMessage, answer);
 
+    // cleanup
+    delete packedMessage;
     delete m;
     messages.clear();
   }
@@ -664,6 +666,14 @@ TEST(lumberjack_Message, packMessages)
 
   answer = std::to_string((int)testData.size()) + "*" + answer;
   EXPECT_EQ(packedMessages, answer);
+
+  // cleanup
+  delete packedMessages;
+  for(auto* _m : messages)
+  {
+    delete _m;
+  }
+  messages.clear();
 }
 
 TEST(lumberjack_Message, unpackMessagesIndividually)

--- a/src/axom/lumberjack/tests/lumberjack_RootCommunicator.hpp
+++ b/src/axom/lumberjack/tests/lumberjack_RootCommunicator.hpp
@@ -87,6 +87,13 @@ TEST(lumberjack_RootCommunicator, basic)
   c.finalize();
 
   MPI_Barrier(MPI_COMM_WORLD);
+
+  // cleanup allocated memory from received messages
+  for(auto& rm : receivedPackedMessages)
+  {
+    delete rm;
+  }
+  receivedPackedMessages.clear();
 }
 
 TEST(lumberjack_RootCommunicator, pushNothing)

--- a/src/axom/mint/examples/user_guide/mint_getting_started.cpp
+++ b/src/axom/mint/examples/user_guide/mint_getting_started.cpp
@@ -195,7 +195,7 @@ mint::Mesh* getUniformMesh()
   const double lo[] = {-5.0, -5.0};
   const double hi[] = {5.0, 5.0};
   mint::Mesh* m = new mint::UniformMesh(lo, hi, Arguments.res, Arguments.res);
-  return (m);
+  return m;
 }
 // sphinx_tutorial_walkthrough_construct_umesh_end
 
@@ -278,7 +278,7 @@ mint::Mesh* getUnstructuredMesh()
   delete umesh;
   umesh = nullptr;
 
-  return (m);
+  return m;
 }
 
 // sphinx_tutorial_basic_example_end

--- a/src/axom/mint/execution/internal/for_all_cells.hpp
+++ b/src/axom/mint/execution/internal/for_all_cells.hpp
@@ -187,6 +187,9 @@ inline void for_all_cells_impl(xargs::nodeids,
   const IndexType nodeKp = m.nodeKp();
   const StackArray<IndexType, 8>& offsets = m.getCellNodeOffsetsArray();
 
+  // Note: gcc@10.3.1 emits a '-Warray-bounds' warning in callers of this function
+  // about the sizes of nodeIds and coords not matching due to the runtime switch on dimension
+
   if(dimension == 1)
   {
     for_all_cells_impl<ExecPolicy>(
@@ -452,6 +455,9 @@ inline void for_all_cells_impl(xargs::coords,
 
   const double z0 = origin[2];
   const double dz = spacing[2];
+
+  // Note: gcc@10.3.1 emits a '-Warray-bounds' warning in callers of this function
+  // about the sizes of nodeIds and coords not matching due to the runtime switch on dimension
 
   if(dimension == 1)
   {

--- a/src/axom/mint/tests/mint_fem_single_fe.cpp
+++ b/src/axom/mint/tests/mint_fem_single_fe.cpp
@@ -802,6 +802,7 @@ void check_interp(double TOL = 1.e-9)
   // STEP 6: clean up
   delete fe;
   delete[] xc;
+  delete[] f;
   delete[] wgts;
 }
 

--- a/src/axom/mint/tests/mint_mesh_connectivity_array.cpp
+++ b/src/axom/mint/tests/mint_mesh_connectivity_array.cpp
@@ -1399,6 +1399,7 @@ TEST(mint_connectivity_array, IndirectionExternalSet)
   /* Check that the external constructor functions properly. */
   internal::checkExternalConstructor(ext_mixed);
 
+  delete[] initial_values;
   delete[] values;
   delete[] offsets;
   delete[] types;

--- a/src/axom/multimat/multimat.cpp
+++ b/src/axom/multimat/multimat.cpp
@@ -27,7 +27,6 @@
   #include "RAJA/RAJA.hpp"
 #endif
 
-using namespace std;
 using namespace axom::multimat;
 
 namespace
@@ -354,8 +353,9 @@ void MultiMat::setAllocatorID(int alloc_id)
 
 void MultiMat::setSlamAllocatorID(int alloc_id)
 {
-  bool hasCellDomRelation = hasValidStaticRelation(DataLayout::CELL_DOM);
-  bool hasMatDomRelation = hasValidStaticRelation(DataLayout::MAT_DOM);
+  const bool hasCellDomRelation = hasValidStaticRelation(DataLayout::CELL_DOM);
+  const bool hasMatDomRelation = hasValidStaticRelation(DataLayout::MAT_DOM);
+
   m_slamAllocatorId = alloc_id;
   m_sets = axom::Array<RangeSetType>(m_sets, m_slamAllocatorId);
 
@@ -365,6 +365,7 @@ void MultiMat::setSlamAllocatorID(int alloc_id)
     IndBufferType(m_cellMatRel_indicesVec, m_slamAllocatorId);
   m_cellMatRel_firstIndicesVec =
     IndBufferType(m_cellMatRel_firstIndicesVec, m_slamAllocatorId);
+
   m_matCellRel_beginsVec =
     IndBufferType(m_matCellRel_beginsVec, m_slamAllocatorId);
   m_matCellRel_indicesVec =
@@ -433,7 +434,7 @@ void MultiMat::setFieldAllocatorID(int alloc_id)
   }
 }
 
-void MultiMat::setCellMatRel(const vector<bool>& vecarr, DataLayout layout)
+void MultiMat::setCellMatRel(const std::vector<bool>& vecarr, DataLayout layout)
 {
   //Setup the SLAM cell to mat relation
   //This step is necessary if the volfrac field is sparse
@@ -1802,7 +1803,7 @@ void MultiMat::print() const
   }
   sstr << "\n\n";
 
-  cout << sstr.str() << endl;
+  std::cout << sstr.str() << std::endl;
 }
 
 bool MultiMat::isValid(bool verboseOutput) const

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -328,7 +328,7 @@ AXOM_HOST_DEVICE void poly_clip_fix_nbrs(Polyhedron<T, NDIMS>& poly,
             }
             else
             {
-              int offset;
+              int offset {};
               for(int oi = 0; oi < old_nbrs.getNumNeighbors(inext); oi++)
               {
                 if(old_nbrs[inext][oi] == iprev)

--- a/src/axom/primal/tests/primal_curved_polygon.cpp
+++ b/src/axom/primal/tests/primal_curved_polygon.cpp
@@ -81,8 +81,7 @@ primal::CurvedPolygon<CoordType, DIM> createPolygon(
       subCP[i] = ControlPoints[i + iter];
     }
 
-    BezierCurveType addCurve(subCP, orders[j]);
-    bPolygon.addEdge(addCurve);
+    bPolygon.addEdge(BezierCurveType {subCP, orders[j]});
     iter += (orders[j]);
   }
 
@@ -101,7 +100,7 @@ TEST(primal_curvedpolygon, constructor)
     SLIC_INFO("Testing default CurvedPolygon constructor ");
     CurvedPolygonType bPolygon;
 
-    int expNumEdges = 0;
+    const int expNumEdges = 0;
     EXPECT_EQ(expNumEdges, bPolygon.numEdges());
     EXPECT_EQ(expNumEdges, bPolygon.getEdges().size());
     EXPECT_EQ(axom::Array<BezierCurveType>(), bPolygon.getEdges());
@@ -111,7 +110,7 @@ TEST(primal_curvedpolygon, constructor)
     SLIC_INFO("Testing CurvedPolygon numEdges constructor ");
 
     CurvedPolygonType bPolygon(1);
-    int expNumEdges = 1;
+    const int expNumEdges = 1;
     EXPECT_EQ(expNumEdges, bPolygon.numEdges());
     EXPECT_EQ(expNumEdges, static_cast<int>(bPolygon.getEdges().size()));
   }

--- a/src/axom/quest/SamplingShaper.hpp
+++ b/src/axom/quest/SamplingShaper.hpp
@@ -320,6 +320,18 @@ public:
     : Shaper(shapeSet, dc)
   { }
 
+  ~SamplingShaper()
+  {
+    m_inoutShapeQFuncs.DeleteData(true);
+    m_inoutShapeQFuncs.clear();
+
+    m_inoutMaterialQFuncs.DeleteData(true);
+    m_inoutMaterialQFuncs.clear();
+
+    m_inoutDofs.DeleteData(true);
+    m_inoutDofs.clear();
+  }
+
   //@{
   //!  @name Functions to get and set shaping parameters related to sampling; supplements parameters in base class
 

--- a/src/axom/quest/interface/internal/QuestHelpers.hpp
+++ b/src/axom/quest/interface/internal/QuestHelpers.hpp
@@ -57,7 +57,7 @@ public:
   }
 
 private:
-  slic::message::Level m_previousLevel;
+  slic::message::Level m_previousLevel {slic::message::Level::Debug};
 };
 
 /// \name MPI Helper/Wrapper Methods

--- a/src/axom/quest/tests/quest_c2c_reader.cpp
+++ b/src/axom/quest/tests/quest_c2c_reader.cpp
@@ -101,7 +101,7 @@ void writeSpline(const std::string& filename)
 
 TEST(quest_c2c_reader, basic_read)
 {
-  std::string fileName = C2C_CIRCLE_FILENAME;
+  const std::string fileName = C2C_CIRCLE_FILENAME;
   writeSimpleCircle(fileName);
 
   quest::C2CReader reader;
@@ -113,7 +113,7 @@ TEST(quest_c2c_reader, basic_read)
 
 TEST(quest_c2c_reader, interpolate_circle)
 {
-  std::string fileName = C2C_CIRCLE_FILENAME;
+  const std::string fileName = C2C_CIRCLE_FILENAME;
   writeSimpleCircle(fileName);
 
   quest::C2CReader reader;
@@ -122,7 +122,7 @@ TEST(quest_c2c_reader, interpolate_circle)
   reader.read();
   reader.log();
 
-  const int DIM = 2;
+  constexpr int DIM = 2;
   using MeshType = mint::UnstructuredMesh<mint::SINGLE_SHAPE>;
   MeshType* mesh = new MeshType(DIM, mint::SEGMENT);
 
@@ -158,7 +158,7 @@ TEST(quest_c2c_reader, interpolate_circle)
 
 TEST(quest_c2c_reader, interpolate_square)
 {
-  std::string fileName = C2C_SQUARE_FILENAME;
+  const std::string fileName = C2C_SQUARE_FILENAME;
   writeSquare(fileName);
 
   quest::C2CReader reader;
@@ -167,11 +167,11 @@ TEST(quest_c2c_reader, interpolate_square)
   reader.read();
   reader.log();
 
-  const int DIM = 2;
+  constexpr int DIM = 2;
   using MeshType = mint::UnstructuredMesh<mint::SINGLE_SHAPE>;
   MeshType* mesh = new MeshType(DIM, mint::SEGMENT);
 
-  int segmentsPerKnotSpan = 10;
+  const int segmentsPerKnotSpan = 10;
   reader.getLinearMeshUniform(mesh, segmentsPerKnotSpan);
 
   SLIC_INFO(axom::fmt::format("Mesh has {} nodes and {} cells",
@@ -188,11 +188,13 @@ TEST(quest_c2c_reader, interpolate_square)
   EXPECT_EQ(expSegs, mesh->getNumberOfCells());
 
   mint::write_vtk(mesh, "test_square.vtk");
+
+  delete mesh;
 }
 
 TEST(quest_c2c_reader, interpolate_spline)
 {
-  std::string fileName = C2C_SPLINE_FILENAME;
+  const std::string fileName = C2C_SPLINE_FILENAME;
   writeSpline(fileName);
 
   quest::C2CReader reader;
@@ -201,11 +203,11 @@ TEST(quest_c2c_reader, interpolate_spline)
   reader.read();
   reader.log();
 
-  const int DIM = 2;
+  constexpr int DIM = 2;
   using MeshType = mint::UnstructuredMesh<mint::SINGLE_SHAPE>;
   MeshType* mesh = new MeshType(DIM, mint::SEGMENT);
 
-  int segmentsPerKnotSpan = 20;
+  const int segmentsPerKnotSpan = 20;
   reader.getLinearMeshUniform(mesh, segmentsPerKnotSpan);
 
   SLIC_INFO(axom::fmt::format("Mesh has {} nodes and {} cells",
@@ -220,6 +222,8 @@ TEST(quest_c2c_reader, interpolate_spline)
   EXPECT_EQ(expSegs, mesh->getNumberOfCells());
 
   mint::write_vtk(mesh, "test_spline.vtk");
+
+  delete mesh;
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/quest/tests/quest_inout_interface.cpp
+++ b/src/axom/quest/tests/quest_inout_interface.cpp
@@ -137,7 +137,7 @@ TYPED_TEST(InOutInterfaceTest, initialize_from_mesh)
 
   EXPECT_TRUE(axom::utilities::filesystem::pathExists(this->meshfile));
 
-  axom::mint::Mesh* mesh = nullptr;
+  axom::mint::Mesh* mesh {nullptr};
 
   int rc = failCode;
 
@@ -179,6 +179,8 @@ TYPED_TEST(InOutInterfaceTest, initialize_from_mesh)
 
   // InOut should no longer  be initialized
   EXPECT_FALSE(axom::quest::inout_initialized());
+
+  delete mesh;
 }
 
 TYPED_TEST(InOutInterfaceTest, query_properties)

--- a/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
+++ b/src/axom/quest/tests/quest_point_in_cell_mfem.cpp
@@ -1093,11 +1093,11 @@ TYPED_TEST(PointInCell2DTest, pic_flat_single_quad)
 
   // Add a bilinear gridfunction
   mfem::Mesh& mesh = *this->getMesh();
-  mfem::FiniteElementCollection* fec =
-    mfem::FiniteElementCollection::New("Linear");
-  mfem::FiniteElementSpace* fes = new mfem::FiniteElementSpace(&mesh, fec, 1);
+  auto* fec = mfem::FiniteElementCollection::New("Linear");
+  auto* fes = new mfem::FiniteElementSpace(&mesh, fec, 1);
 
   mfem::GridFunction gf(fes);
+  gf.MakeOwner(fec);
   gf(0) = gf(2) = 1.;
   gf(1) = gf(3) = 0.;
 

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -193,9 +193,11 @@ public:
                                   collection (can be nullptr)
       @param[in] owns_mesh_data   Does the SidreDC own the mesh vertices?
 
-      With this constructor, the MFEMSidreDataCollection owns the allocated
-         Sidre
-      DataStore.
+      With this constructor, the MFEMSidreDataCollection owns the allocated Sidre DataStore.
+
+      @note This constructor also sets \a own_data in the base \a mfem::DataCollection
+      class to the value of \a owns_mesh_data. If this is not desired, the former
+      can be reset by calling \a this->SetOwnData(<bool>)
    */
   explicit MFEMSidreDataCollection(const std::string& collection_name,
                                    mfem::Mesh* the_mesh = nullptr,
@@ -212,10 +214,13 @@ public:
                                   see the above schematic
       @param[in] owns_mesh_data   Does the SidreDC own the mesh vertices?
 
-      With this constructor, the MFEMSidreDataCollection does not own the Sidre
-      DataStore.
+      With this constructor, the MFEMSidreDataCollection does not own the Sidre DataStore.
+
       @note No mesh or fields are read from the given Groups. The mesh has
       to be set with SetMesh() and fields registered with RegisterField().
+
+      @note This constructor also sets \a own_data in the base \a mfem::DataCollection class
+      to false. If this is not desired, the former can be reset by calling \a this->SetOwnData(true)
    */
   MFEMSidreDataCollection(const std::string& collection_name,
                           Group* bp_index_grp,
@@ -528,29 +533,25 @@ public:
 
 private:
   // Used if the Sidre data collection is providing the datastore itself.
-  const bool m_owns_datastore;
+  const bool m_owns_datastore {false};
 
-  // TODO - Need to evaluate if this bool member can be combined with own_data
-  // in parent data collection class. m_owns_mesh_data indicates whether the
-  // Sidre dc owns the mesh element data and node positions gf. The DC base
-  // class own_data indicates if the dc owns the mesh object pointer itself and
-  // GF objects. Can we use one flag and just have DC own all objects vs none?
-  const bool m_owns_mesh_data;
+  // Note: m_owns_mesh_data indicates whether the Sidre dc owns
+  // the mesh element data and node positions gf. The DC base class \a own_data
+  // indicates if the dc owns the mesh object pointer itself and GF objects.
+  const bool m_owns_mesh_data {false};
 
-  // Name to be used for registering the mesh nodes in the
-  // MFEMSidreDataCollection.
+  // Name to be used for registering the mesh nodes in the MFEMSidreDataCollection.
   // This name is used by SetMesh() and can be overwritten by the method
-  // SetMeshNodesName().
-  // Default value: "mesh_nodes".
-  std::string m_meshNodesGFName;
+  // SetMeshNodesName(). Default value: "mesh_nodes".
+  std::string m_meshNodesGFName {"mesh_nodes"};
 
   // For Parallel IO, the user can specify a number of files less than or equal to the
   // number of processors.
-  int m_num_files;
+  int m_num_files {-1};
 
   // If the data collection owns the datastore, it will store a pointer to it.
   // Otherwise, this pointer is nullptr.
-  DataStore* m_datastore_ptr;
+  DataStore* m_datastore_ptr {nullptr};
 
 protected:
   Group* named_buffers_grp() const;
@@ -567,11 +568,11 @@ protected:
 private:
   // If the data collection does not own the datastore, it will need pointers
   // to the blueprint and blueprint index group to use.
-  Group* m_bp_grp;
-  Group* m_bp_index_grp;
+  Group* m_bp_grp {nullptr};
+  Group* m_bp_index_grp {nullptr};
 
   // This is stored for convenience.
-  Group* m_named_bufs_grp;
+  Group* m_named_bufs_grp {nullptr};
 
   // Used to retain ownership of components of reconstructed Meshes and GridFuncs
   // Instead of using flags to keep track of ownership between this class
@@ -718,9 +719,6 @@ private:
   /// Before saving the file, add any fields that look like materials to the
   /// blueprint index.
   void addMaterialSetToIndex();
-
-  // /// Verifies that the contents of the mesh blueprint data is valid.
-  // void verifyMeshBlueprint();
 
   // The names for the mesh and boundary topologies in the blueprint group,
   // and the suffix used to store their attributes (as fields)

--- a/src/axom/sidre/examples/lulesh2/lulesh-init.cc
+++ b/src/axom/sidre/examples/lulesh2/lulesh-init.cc
@@ -192,6 +192,23 @@ Domain::Domain(Int_t numRanks, Index_t colLoc,
 
 } // End constructor
 
+Domain::~Domain()
+{
+#ifdef AXOM_USE_MPI   
+  delete [] commDataSend;
+  delete [] commDataRecv;
+#endif
+
+  delete [] m_regElemSize;
+  delete [] m_regNumList;
+
+  for (Index_t i=0 ; i<numReg() ; ++i)
+  {
+    delete [] m_regElemlist[i];
+  }
+  delete [] m_regElemlist;
+
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 void
@@ -438,57 +455,48 @@ Domain::CreateRegionIndexSets(Int_t nr, Int_t balance)
       //Determine the relative weights of all the regions.  This is based off the -b flag.  Balance is the value passed into b.  
       for (Index_t i=0 ; i<numReg() ; ++i) {
          regElemSize(i) = 0;
-	 costDenominator += pow((i+1), balance);  //Total sum of all regions weights
-	 regBinEnd[i] = costDenominator;  //Chance of hitting a given region is (regBinEnd[i] - regBinEdn[i-1])/costDenominator
+         costDenominator += pow((i+1), balance);  //Total sum of all regions weights
+         regBinEnd[i] = costDenominator;  //Chance of hitting a given region is (regBinEnd[i] - regBinEdn[i-1])/costDenominator
       }
       //Until all elements are assigned
       while (nextIndex < numElem()) {
-	 //pick the region
-	 regionVar = rand() % costDenominator;
-	 Index_t i = 0;
+         //pick the region
+         regionVar = rand() % costDenominator;
+         Index_t i = 0;
          while(regionVar >= regBinEnd[i])
-	    i++;
+            i++;
          //rotate the regions based on MPI rank.  Rotation is Rank % NumRegions this makes each domain have a different region with 
          //the highest representation
-	 regionNum = ((i + myRank) % numReg()) + 1;
-	 // make sure we don't pick the same region twice in a row
+         regionNum = ((i + myRank) % numReg()) + 1;
+         // make sure we don't pick the same region twice in a row
          while(regionNum == lastReg) {
-	    regionVar = rand() % costDenominator;
-	    i = 0;
+            regionVar = rand() % costDenominator;
+            i = 0;
             while(regionVar >= regBinEnd[i])
-	       i++;
-	    regionNum = ((i + myRank) % numReg()) + 1;
+	            i++;
+	          regionNum = ((i + myRank) % numReg()) + 1;
          }
-	 //Pick the bin size of the region and determine the number of elements.
+         
+         //Pick the bin size of the region and determine the number of elements.
          binSize = rand() % 1000;
-	 if(binSize < 773) {
-	   elements = rand() % 15 + 1;
-	 }
-	 else if(binSize < 937) {
-	   elements = rand() % 16 + 16;
-	 }
-	 else if(binSize < 970) {
-	   elements = rand() % 32 + 32;
-	 }
-	 else if(binSize < 974) {
-	   elements = rand() % 64 + 64;
-	 } 
-	 else if(binSize < 978) {
-	   elements = rand() % 128 + 128;
-	 }
-	 else if(binSize < 981) {
-	   elements = rand() % 256 + 256;
-	 }
-	 else
-	    elements = rand() % 1537 + 512;
-	 runto = elements + nextIndex;
-	 //Store the elements.  If we hit the end before we run out of elements then just stop.
+         if(binSize < 773) { elements = rand() % 15 + 1; }
+         else if(binSize < 937) { elements = rand() % 16 + 16; }
+         else if(binSize < 970) { elements = rand() % 32 + 32; }
+         else if(binSize < 974) { elements = rand() % 64 + 64; } 
+         else if(binSize < 978) { elements = rand() % 128 + 128; }
+         else if(binSize < 981) { elements = rand() % 256 + 256; }
+         else { elements = rand() % 1537 + 512;}
+
+         runto = elements + nextIndex;
+         //Store the elements.  If we hit the end before we run out of elements then just stop.
          while (nextIndex < runto && nextIndex < numElem()) {
-	    this->regNumList(nextIndex) = regionNum;
-	    nextIndex++;
-	 }
-	 lastReg = regionNum;
+           this->regNumList(nextIndex) = regionNum;
+           nextIndex++;
+         }
+         lastReg = regionNum;
       } 
+
+      delete [] regBinEnd;
    }
    // Convert regNumList to region index sets
    // First, count size of each region 
@@ -507,6 +515,8 @@ Domain::CreateRegionIndexSets(Int_t nr, Int_t balance)
       Index_t regndx = regElemSize(r)++; // Note increment
       regElemlist(r,regndx) = i;
    }
+
+
    
 }
 

--- a/src/axom/sidre/examples/lulesh2/lulesh.cc
+++ b/src/axom/sidre/examples/lulesh2/lulesh.cc
@@ -2776,7 +2776,7 @@ void LagrangeLeapFrog(Domain& domain)
 
 int main(int argc, char *argv[])
 {
-  Domain *locDom ;
+   Domain *locDom ;
    Int_t numRanks ;
    Int_t myRank ;
    struct cmdLineOpts opts;
@@ -2894,6 +2894,8 @@ int main(int argc, char *argv[])
    if ((myRank == 0) && (opts.quiet == 0)) {
       VerifyAndWriteFinalOutput(elapsed_timeG, *locDom, opts.nx, numRanks);
    }
+
+   delete locDom;
 
 #ifdef AXOM_USE_MPI
    MPI_Finalize() ;

--- a/src/axom/sidre/examples/lulesh2/lulesh.h
+++ b/src/axom/sidre/examples/lulesh2/lulesh.h
@@ -166,6 +166,9 @@ public:
          Index_t rowLoc, Index_t planeLoc,
          Index_t nx, Int_t tp, Int_t nr, Int_t balance, Int_t cost);
 
+  // Destructor
+  ~Domain();
+
   //
   // ALLOCATION
   //
@@ -584,8 +587,8 @@ public:
 
 #ifdef AXOM_USE_MPI
   // Communication Work space
-  Real_t * commDataSend;
-  Real_t * commDataRecv;
+  Real_t * commDataSend {nullptr};
+  Real_t * commDataRecv {nullptr};
 
   // Maximum number of block neighbors
   MPI_Request recvRequest[26];   // 6 faces + 12 edges + 8 corners
@@ -639,9 +642,9 @@ private:
   // Region information
   Int_t m_numReg;
   Int_t m_cost;     //imbalance cost
-  Index_t * m_regElemSize;    // Size of region sets
-  Index_t * m_regNumList;     // Region number per domain element
-  Index_t * * m_regElemlist;  // region indexset
+  Index_t * m_regElemSize {nullptr};    // Size of region sets
+  Index_t * m_regNumList {nullptr};     // Region number per domain element
+  Index_t * * m_regElemlist {nullptr};  // region indexset
 
   luleshIndexData m_nodelist;        /* elemToNode connectivity */
 

--- a/src/axom/sidre/examples/sidre_createdatastore.cpp
+++ b/src/axom/sidre/examples/sidre_createdatastore.cpp
@@ -8,8 +8,7 @@
  *  Sidre classes to construct a hierarchical data store and save it to
  *  a file.  (This example does not use the parallel I/O facility.)
  *  This also shows how to use Sidre with Conduit to generate and save a
- *  data store using the Mesh Blueprint, for easy data exchange and
- *  visualization.
+ *  data store using the Mesh Blueprint, for easy data exchange and visualization.
  */
 
 /*
@@ -87,24 +86,23 @@
 #include <cstring>
 
 // "using" directives to simplify code
-using namespace axom;
-using namespace sidre;
+namespace sidre = axom::sidre;
 
-DataStore* create_datastore(int* region)
+std::unique_ptr<sidre::DataStore> create_datastore(int* region)
 {
   // _first_example_creategroups_start
   // Create Sidre datastore object and get root group
-  DataStore* ds = new DataStore();
-  Group* root = ds->getRoot();
+  auto ds = std::unique_ptr<sidre::DataStore> {new sidre::DataStore()};
+  sidre::Group* root = ds->getRoot();
 
   // Create two attributes
   ds->createAttributeScalar("vis", 0);
   ds->createAttributeScalar("restart", 1);
 
   // Create group children of root group
-  Group* state = root->createGroup("state");
-  Group* nodes = root->createGroup("nodes");
-  Group* fields = root->createGroup("fields");
+  sidre::Group* state = root->createGroup("state");
+  sidre::Group* nodes = root->createGroup("nodes");
+  sidre::Group* fields = root->createGroup("fields");
   // _first_example_creategroups_end
 
   // _first_example_state_start
@@ -125,7 +123,8 @@ DataStore* create_datastore(int* region)
   // holds 3 * nodecount doubles.  These views might describe the location of
   // each node in a 16 x 16 x 16 hexahedron mesh.  Each view is described by
   // number of elements, offset, and stride into that data.
-  Buffer* buff = ds->createBuffer(sidre::DOUBLE_ID, 3 * nodecount)->allocate();
+  sidre::Buffer* buff =
+    ds->createBuffer(sidre::DOUBLE_ID, 3 * nodecount)->allocate();
   nodes->createView("x", buff)->apply(sidre::DOUBLE_ID, nodecount, 0, 3);
   nodes->createView("y", buff)->apply(sidre::DOUBLE_ID, nodecount, 1, 3);
   nodes->createView("z", buff)->apply(sidre::DOUBLE_ID, nodecount, 2, 3);
@@ -139,8 +138,10 @@ DataStore* create_datastore(int* region)
   // object.  Likewise with "rho."  Both Views have the default offset (0)
   // and stride (1).  These Views could point to data associated with
   // each of the 15 x 15 x 15 hexahedron elements defined by the nodes above.
-  View* temp = fields->createViewAndAllocate("temp", sidre::DOUBLE_ID, eltcount);
-  View* rho = fields->createViewAndAllocate("rho", sidre::DOUBLE_ID, eltcount);
+  sidre::View* temp =
+    fields->createViewAndAllocate("temp", sidre::DOUBLE_ID, eltcount);
+  sidre::View* rho =
+    fields->createViewAndAllocate("rho", sidre::DOUBLE_ID, eltcount);
 
   // Explicitly set values for the "vis" Attribute on the "temp" and "rho"
   // buffers.
@@ -150,7 +151,7 @@ DataStore* create_datastore(int* region)
   // The "fields" Group also contains a child Group "ext" which holds a pointer
   // to an externally owned integer array.  Although Sidre does not own the
   // data, the data can still be described to Sidre.
-  Group* ext = fields->createGroup("ext");
+  sidre::Group* ext = fields->createGroup("ext");
   // int * region has been passed in as a function argument.  As with "temp"
   // and "rho", view "region" has default offset and stride.
   ext->createView("region", region)->apply(sidre::INT_ID, eltcount);
@@ -159,18 +160,18 @@ DataStore* create_datastore(int* region)
   return ds;
 }
 
-void access_datastore(DataStore* ds)
+void access_datastore(sidre::DataStore* ds)
 {
   // _first_example_access_start
   // Retrieve Group pointers
-  Group* root = ds->getRoot();
-  Group* state = root->getGroup("state");
-  Group* nodes = root->getGroup("nodes");
-  Group* fields = root->getGroup("fields");
+  sidre::Group* root = ds->getRoot();
+  sidre::Group* state = root->getGroup("state");
+  sidre::Group* nodes = root->getGroup("nodes");
+  sidre::Group* fields = root->getGroup("fields");
 
   // Accessing a Group that is not there gives a null pointer
   // Requesting a nonexistent View also gives a null pointer
-  Group* goofy = root->getGroup("goofy");
+  sidre::Group* goofy = root->getGroup("goofy");
   if(goofy == nullptr)
   {
     std::cout << "no such group: goofy" << std::endl;
@@ -206,9 +207,9 @@ void access_datastore(DataStore* ds)
   AXOM_UNUSED_VAR(region);
 }
 
-void iterate_datastore(DataStore* ds)
+void iterate_datastore(sidre::DataStore* ds)
 {
-  const std::string fill_line = fmt::format("{:=^80}", "");
+  const std::string fill_line = axom::fmt::format("{:=^80}", "");
 
   std::cout << fill_line << std::endl;
 
@@ -216,11 +217,12 @@ void iterate_datastore(DataStore* ds)
   std::cout << "The datastore has the following attributes:\n";
   for(auto& attr : ds->attributes())
   {
-    std::cout << fmt::format("  * [{}] '{}' of type {} and default value: {}\n",
-                             attr.getIndex(),
-                             attr.getName(),
-                             conduit::DataType::id_to_name(attr.getTypeID()),
-                             attr.getDefaultNodeRef().to_yaml());
+    std::cout << axom::fmt::format(
+      "  * [{}] '{}' of type {} and default value: {}\n",
+      attr.getIndex(),
+      attr.getName(),
+      conduit::DataType::id_to_name(attr.getTypeID()),
+      attr.getDefaultNodeRef().to_yaml());
   }
 
   std::cout << fill_line << std::endl;
@@ -229,7 +231,7 @@ void iterate_datastore(DataStore* ds)
   std::cout << "The datastore has the following buffers:\n";
   for(auto& buff : ds->buffers())
   {
-    std::cout << fmt::format(
+    std::cout << axom::fmt::format(
       "  * [{}] {} buffer with {} elements of type {} with {} views\n",
       buff.getIndex(),
       buff.isAllocated() ? "Allocated" : "Unallocated",
@@ -244,11 +246,12 @@ void iterate_datastore(DataStore* ds)
   std::cout << "The root group has the following groups:\n";
   for(auto& grp : ds->getRoot()->groups())
   {
-    std::cout << fmt::format("  * [{}] '{}' with {} groups and {} views\n",
-                             grp.getIndex(),
-                             grp.getName(),
-                             grp.getNumGroups(),
-                             grp.getNumViews());
+    std::cout << axom::fmt::format(
+      "  * [{}] '{}' with {} groups and {} views\n",
+      grp.getIndex(),
+      grp.getName(),
+      grp.getNumGroups(),
+      grp.getNumViews());
   }
 
   std::cout << fill_line << std::endl;
@@ -257,7 +260,7 @@ void iterate_datastore(DataStore* ds)
   std::cout << "The 'state' group has the following views:\n";
   for(auto& view : ds->getRoot()->getGroup("state")->views())
   {
-    std::cout << fmt::format(
+    std::cout << axom::fmt::format(
       "  * [{}] '{}' -- {} view of type {} and {} elements\n",
       view.getIndex(),
       view.getName(),
@@ -269,24 +272,27 @@ void iterate_datastore(DataStore* ds)
   std::cout << fill_line << std::endl;
 }
 
-DataStore* create_tiny_datastore()
+std::unique_ptr<sidre::DataStore> create_tiny_datastore()
 {
   // _tiny_create_start
-  DataStore* ds = new DataStore();
+  auto ds = std::unique_ptr<sidre::DataStore> {new sidre::DataStore()};
 
   int nodecount = 12;
   int elementcount = 2;
 
   // Create views and buffers to hold node positions and field values
-  Group* nodes = ds->getRoot()->createGroup("nodes");
-  View* xs = nodes->createViewAndAllocate("xs", sidre::DOUBLE_ID, nodecount);
-  View* ys = nodes->createViewAndAllocate("ys", sidre::DOUBLE_ID, nodecount);
-  View* zs = nodes->createViewAndAllocate("zs", sidre::DOUBLE_ID, nodecount);
+  sidre::Group* nodes = ds->getRoot()->createGroup("nodes");
+  sidre::View* xs =
+    nodes->createViewAndAllocate("xs", sidre::DOUBLE_ID, nodecount);
+  sidre::View* ys =
+    nodes->createViewAndAllocate("ys", sidre::DOUBLE_ID, nodecount);
+  sidre::View* zs =
+    nodes->createViewAndAllocate("zs", sidre::DOUBLE_ID, nodecount);
 
-  Group* fields = ds->getRoot()->createGroup("fields");
-  View* nodefield =
+  sidre::Group* fields = ds->getRoot()->createGroup("fields");
+  sidre::View* nodefield =
     fields->createViewAndAllocate("nodefield", sidre::INT_ID, nodecount);
-  View* eltfield =
+  sidre::View* eltfield =
     fields->createViewAndAllocate("eltfield", sidre::DOUBLE_ID, elementcount);
 
   // Set node position for two adjacent hexahedrons
@@ -316,14 +322,14 @@ DataStore* create_tiny_datastore()
   // _tiny_create_end
 }
 
-void setup_blueprint_coords(DataStore* ds, Group* coords)
+void setup_blueprint_coords(sidre::DataStore* ds, sidre::Group* coords)
 {
   // _blueprint_restructure_coords_start
   // Set up the coordinates as Mesh Blueprint requires
   coords->createViewString("type", "explicit");
   // We use prior knowledge of the layout of the original datastore
-  View* origv = ds->getRoot()->getView("nodes/xs");
-  Group* conduitval = coords->createGroup("values");
+  sidre::View* origv = ds->getRoot()->getView("nodes/xs");
+  sidre::Group* conduitval = coords->createGroup("values");
   conduitval->createView("x",
                          sidre::DOUBLE_ID,
                          origv->getNumElements(),
@@ -341,14 +347,14 @@ void setup_blueprint_coords(DataStore* ds, Group* coords)
   // _blueprint_restructure_coords_end
 }
 
-void setup_blueprint_external_coords(DataStore* ds, Group* coords)
+void setup_blueprint_external_coords(sidre::DataStore* ds, sidre::Group* coords)
 {
   // _blueprint_external_coords_start
   // Set up the coordinates as Mesh Blueprint requires
   coords->createViewString("type", "explicit");
   // We use prior knowledge of the layout of the original datastore
-  View* origv = ds->getRoot()->getView("nodes/xs");
-  Group* conduitval = coords->createGroup("values");
+  sidre::View* origv = ds->getRoot()->getView("nodes/xs");
+  sidre::Group* conduitval = coords->createGroup("values");
   conduitval->createView("x",
                          sidre::DOUBLE_ID,
                          origv->getNumElements(),
@@ -366,18 +372,18 @@ void setup_blueprint_external_coords(DataStore* ds, Group* coords)
   // _blueprint_external_coords_end
 }
 
-void setup_blueprint_topos(DataStore* ds, Group* topos)
+void setup_blueprint_topos(sidre::DataStore* ds, sidre::Group* topos)
 {
   // _blueprint_restructure_topo_start
   // Sew the nodes together into the two hexahedra, using prior knowledge.
-  Group* connmesh = topos->createGroup("mesh");
+  sidre::Group* connmesh = topos->createGroup("mesh");
   connmesh->createViewString("type", "unstructured");
   connmesh->createViewString("coordset", "coords");
-  Group* elts = connmesh->createGroup("elements");
+  sidre::Group* elts = connmesh->createGroup("elements");
   elts->createViewString("shape", "hex");
 
   // We have two eight-node hex elements, so we need 2 * 8 = 16 ints.
-  View* connectivity =
+  sidre::View* connectivity =
     elts->createViewAndAllocate("connectivity", sidre::INT_ID, 16);
 
   // The Mesh Blueprint connectivity array for a hexahedron lists four nodes on
@@ -415,13 +421,13 @@ void setup_blueprint_topos(DataStore* ds, Group* topos)
   AXOM_UNUSED_VAR(ds);
 }
 
-void setup_blueprint_fields(DataStore* ds, Group* fields)
+void setup_blueprint_fields(sidre::DataStore* ds, sidre::Group* fields)
 {
   // _blueprint_restructure_field_start
   // Set up the node-centered field
   // Get the original data
-  View* origv = ds->getRoot()->getView("fields/nodefield");
-  Group* nodefield = fields->createGroup("nodefield");
+  sidre::View* origv = ds->getRoot()->getView("fields/nodefield");
+  sidre::Group* nodefield = fields->createGroup("nodefield");
   nodefield->createViewString("association", "vertex");
   nodefield->createViewString("type", "scalar");
   nodefield->createViewString("topology", "mesh");
@@ -433,7 +439,7 @@ void setup_blueprint_fields(DataStore* ds, Group* fields)
   // Set up the element-centered field
   // Get the original data
   origv = ds->getRoot()->getView("fields/eltfield");
-  Group* eltfield = fields->createGroup("eltfield");
+  sidre::Group* eltfield = fields->createGroup("eltfield");
   eltfield->createViewString("association", "element");
   eltfield->createViewString("type", "scalar");
   eltfield->createViewString("topology", "mesh");
@@ -444,13 +450,13 @@ void setup_blueprint_fields(DataStore* ds, Group* fields)
   // _blueprint_restructure_field_end
 }
 
-void setup_blueprint_external_fields(DataStore* ds, Group* fields)
+void setup_blueprint_external_fields(sidre::DataStore* ds, sidre::Group* fields)
 {
   // _blueprint_external_field_start
   // Set up the node-centered field
   // Get the original data
-  View* origv = ds->getRoot()->getView("fields/nodefield");
-  Group* nodefield = fields->createGroup("nodefield");
+  sidre::View* origv = ds->getRoot()->getView("fields/nodefield");
+  sidre::Group* nodefield = fields->createGroup("nodefield");
   nodefield->createViewString("association", "vertex");
   nodefield->createViewString("type", "scalar");
   nodefield->createViewString("topology", "mesh");
@@ -462,7 +468,7 @@ void setup_blueprint_external_fields(DataStore* ds, Group* fields)
   // Set up the element-centered field
   // Get the original data
   origv = ds->getRoot()->getView("fields/eltfield");
-  Group* eltfield = fields->createGroup("eltfield");
+  sidre::Group* eltfield = fields->createGroup("eltfield");
   eltfield->createViewString("association", "element");
   eltfield->createViewString("type", "scalar");
   eltfield->createViewString("topology", "mesh");
@@ -473,7 +479,7 @@ void setup_blueprint_external_fields(DataStore* ds, Group* fields)
   // _blueprint_external_field_end
 }
 
-void save_as_blueprint(DataStore* ds)
+void save_as_blueprint(sidre::DataStore* ds)
 {
   // _blueprint_restructure_toplevel_start
   // Conduit needs a specific hierarchy.
@@ -482,11 +488,11 @@ void save_as_blueprint(DataStore* ds)
   std::string mesh_name = "tinymesh";
 
   // The Conduit specifies top-level groups:
-  Group* mroot = ds->getRoot()->createGroup(mesh_name);
-  Group* coords = mroot->createGroup("coordsets/coords");
-  Group* topos = mroot->createGroup("topologies");
+  sidre::Group* mroot = ds->getRoot()->createGroup(mesh_name);
+  sidre::Group* coords = mroot->createGroup("coordsets/coords");
+  sidre::Group* topos = mroot->createGroup("topologies");
   // no material sets in this example
-  Group* fields = mroot->createGroup("fields");
+  sidre::Group* fields = mroot->createGroup("fields");
   // no adjacency sets in this (single-domain) example
   // _blueprint_restructure_toplevel_end
 
@@ -532,7 +538,7 @@ void save_as_blueprint(DataStore* ds)
   // _blueprint_restructure_save_end
 }
 
-void generate_blueprint(DataStore* ds)
+void generate_blueprint(sidre::DataStore* ds)
 {
   // _blueprint_generate_toplevel_start
   // Conduit needs a specific hierarchy.
@@ -543,11 +549,11 @@ void generate_blueprint(DataStore* ds)
   std::string mesh_name = "mesh";
   std::string domain_mesh = domain_location + "/" + mesh_name;
 
-  Group* mroot = ds->getRoot()->createGroup(domain_location);
-  Group* coords = mroot->createGroup(mesh_name + "/coordsets/coords");
-  Group* topos = mroot->createGroup(mesh_name + "/topologies");
+  sidre::Group* mroot = ds->getRoot()->createGroup(domain_location);
+  sidre::Group* coords = mroot->createGroup(mesh_name + "/coordsets/coords");
+  sidre::Group* topos = mroot->createGroup(mesh_name + "/topologies");
   // no material sets in this example
-  Group* fields = mroot->createGroup(mesh_name + "/fields");
+  sidre::Group* fields = mroot->createGroup(mesh_name + "/fields");
   // no adjacency sets in this (single-domain) example
   // _blueprint_generate_toplevel_end
 
@@ -567,7 +573,7 @@ void generate_blueprint(DataStore* ds)
 
     ds->generateBlueprintIndex(domain_mesh, mesh_name, bp, 1);
 
-    Group* rootfile_grp = ds->getRoot()->getGroup("rootfile_data");
+    sidre::Group* rootfile_grp = ds->getRoot()->getGroup("rootfile_data");
     rootfile_grp->createViewString("protocol/name", "json");
     rootfile_grp->createViewString("protocol/version", "0.1");
     rootfile_grp->createViewScalar("number_of_files", 1);
@@ -587,7 +593,7 @@ void generate_blueprint(DataStore* ds)
   // _blueprint_generate_save_end
 }
 
-void generate_blueprint_to_path(DataStore* ds)
+void generate_blueprint_to_path(sidre::DataStore* ds)
 {
   // _blueprint_generate_path_start
   // Conduit needs a specific hierarchy.
@@ -598,11 +604,11 @@ void generate_blueprint_to_path(DataStore* ds)
   std::string mesh_name = "pathmesh";
   std::string domain_mesh = domain_location + "/" + mesh_name;
 
-  Group* mroot = ds->getRoot()->createGroup(domain_location);
-  Group* coords = mroot->createGroup(mesh_name + "/coordsets/coords");
-  Group* topos = mroot->createGroup(mesh_name + "/topologies");
+  sidre::Group* mroot = ds->getRoot()->createGroup(domain_location);
+  sidre::Group* coords = mroot->createGroup(mesh_name + "/coordsets/coords");
+  sidre::Group* topos = mroot->createGroup(mesh_name + "/topologies");
   // no material sets in this example
-  Group* fields = mroot->createGroup(mesh_name + "/fields");
+  sidre::Group* fields = mroot->createGroup(mesh_name + "/fields");
   // no adjacency sets in this (single-domain) example
   // _blueprint_generate_path_end
 
@@ -622,7 +628,7 @@ void generate_blueprint_to_path(DataStore* ds)
 
     ds->generateBlueprintIndex(domain_mesh, mesh_name, bp, 1);
 
-    Group* rootfile_grp = ds->getRoot()->getGroup("rootfile_data");
+    sidre::Group* rootfile_grp = ds->getRoot()->getGroup("rootfile_data");
     rootfile_grp->createViewString("protocol/name", "json");
     rootfile_grp->createViewString("protocol/version", "0.1");
     rootfile_grp->createViewScalar("number_of_files", 1);
@@ -643,7 +649,7 @@ void generate_blueprint_to_path(DataStore* ds)
 }
 
 #ifdef AXOM_USE_MPI
-void generate_spio_blueprint(DataStore* ds)
+void generate_spio_blueprint(sidre::DataStore* ds)
 {
   int comm_size;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
@@ -654,11 +660,11 @@ void generate_spio_blueprint(DataStore* ds)
   std::string mesh_name = "mesh";
   std::string domain_mesh = domain_location + "/" + mesh_name;
 
-  Group* mroot = ds->getRoot()->createGroup(domain_location);
-  Group* coords = mroot->createGroup(mesh_name + "/coordsets/coords");
-  Group* topos = mroot->createGroup(mesh_name + "/topologies");
+  sidre::Group* mroot = ds->getRoot()->createGroup(domain_location);
+  sidre::Group* coords = mroot->createGroup(mesh_name + "/coordsets/coords");
+  sidre::Group* topos = mroot->createGroup(mesh_name + "/topologies");
   // no material sets in this example
-  Group* fields = mroot->createGroup(mesh_name + "/fields");
+  sidre::Group* fields = mroot->createGroup(mesh_name + "/fields");
   // no adjacency sets in this (single-domain) example
   // _blueprint_spio_toplevel_end
 
@@ -669,7 +675,7 @@ void generate_spio_blueprint(DataStore* ds)
   setup_blueprint_fields(ds, fields);
 
   // _blueprint_generate_spio_start
-  IOManager writer(MPI_COMM_WORLD);
+  sidre::IOManager writer(MPI_COMM_WORLD);
 
   conduit::Node info, mesh_node, root_node;
   ds->getRoot()->createNativeLayout(mesh_node);
@@ -699,7 +705,7 @@ void generate_spio_blueprint(DataStore* ds)
   // _blueprint_generate_spio_end
 }
 
-void generate_spio_blueprint_to_path(DataStore* ds)
+void generate_spio_blueprint_to_path(sidre::DataStore* ds)
 {
   int comm_size;
   MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
@@ -710,11 +716,11 @@ void generate_spio_blueprint_to_path(DataStore* ds)
   std::string mesh_name = "spiopathmesh";
   std::string domain_mesh = domain_location + "/" + mesh_name;
 
-  Group* mroot = ds->getRoot()->createGroup(domain_location);
-  Group* coords = mroot->createGroup(mesh_name + "/coordsets/coords");
-  Group* topos = mroot->createGroup(mesh_name + "/topologies");
+  sidre::Group* mroot = ds->getRoot()->createGroup(domain_location);
+  sidre::Group* coords = mroot->createGroup(mesh_name + "/coordsets/coords");
+  sidre::Group* topos = mroot->createGroup(mesh_name + "/topologies");
   // no material sets in this example
-  Group* fields = mroot->createGroup(mesh_name + "/fields");
+  sidre::Group* fields = mroot->createGroup(mesh_name + "/fields");
   // no adjacency sets in this (single-domain) example
   // _blueprint_spio_path_end
 
@@ -725,7 +731,7 @@ void generate_spio_blueprint_to_path(DataStore* ds)
   setup_blueprint_external_fields(ds, fields);
 
   // _blueprint_generate_spio_path_start
-  IOManager writer(MPI_COMM_WORLD);
+  sidre::IOManager writer(MPI_COMM_WORLD);
 
   conduit::Node info, mesh_node, root_node;
   ds->getRoot()->createNativeLayout(mesh_node);
@@ -759,7 +765,7 @@ void generate_spio_blueprint_to_path(DataStore* ds)
 }
 #endif
 
-void serial_save_datastore_and_load_copy_lower(DataStore* ds)
+void serial_save_datastore_and_load_copy_lower(sidre::DataStore* ds)
 {
 #if defined(AXOM_USE_HDF5)
   std::string protocol = "sidre_hdf5";
@@ -775,7 +781,7 @@ void serial_save_datastore_and_load_copy_lower(DataStore* ds)
   ds->getRoot()->save(filename, protocol);
   // Delete the data hierarchy under the root, then load it from the file
   ds->getRoot()->load(filename, protocol);
-  Group* additional = ds->getRoot()->createGroup("additional");
+  sidre::Group* additional = ds->getRoot()->createGroup("additional");
   additional->createGroup("yetanother");
   // Load another copy of the data store into the "additional" group
   // without first clearing all its contents
@@ -796,24 +802,24 @@ int main(int argc, char** argv)
   MPI_Init(&argc, &argv);
 #endif
 
-  DataStore* ds = create_datastore(region);
-  access_datastore(ds);
-  iterate_datastore(ds);
+  auto ds = create_datastore(region);
+  access_datastore(ds.get());
+  iterate_datastore(ds.get());
 
-  DataStore* tds = create_tiny_datastore();
-  save_as_blueprint(tds);
+  auto tds = create_tiny_datastore();
+  save_as_blueprint(tds.get());
 
-  DataStore* bds = create_tiny_datastore();
-  generate_blueprint(bds);
+  auto bds = create_tiny_datastore();
+  generate_blueprint(bds.get());
 
-  DataStore* pds = create_tiny_datastore();
-  generate_blueprint_to_path(pds);
+  auto pds = create_tiny_datastore();
+  generate_blueprint_to_path(pds.get());
 
 #ifdef AXOM_USE_MPI
-  DataStore* sds = create_tiny_datastore();
-  DataStore* spds = create_tiny_datastore();
-  generate_spio_blueprint(sds);
-  generate_spio_blueprint_to_path(spds);
+  auto sds = create_tiny_datastore();
+  auto spds = create_tiny_datastore();
+  generate_spio_blueprint(sds.get());
+  generate_spio_blueprint_to_path(spds.get());
   MPI_Finalize();
 #endif
 

--- a/src/axom/sidre/examples/sidre_generateindex.cpp
+++ b/src/axom/sidre/examples/sidre_generateindex.cpp
@@ -46,9 +46,9 @@ namespace sidre = axom::sidre;
 static int cart_nx = 5;  // nodal domain x size for cartesian mesh example
 static int cart_ny = 5;  // nodal domain y size for cartesian mesh example
 
-sidre::DataStore* create_tiny_datastore()
+std::unique_ptr<sidre::DataStore> create_tiny_datastore()
 {
-  sidre::DataStore* ds = new sidre::DataStore();
+  auto ds = std::unique_ptr<sidre::DataStore> {new sidre::DataStore()};
 
   int nodecount = 12;
   int elementcount = 2;
@@ -518,50 +518,60 @@ int main(int argc, char** argv)
   MPI_Init(&argc, &argv);
   MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
 
-  sidre::DataStore* sds = create_tiny_datastore();
-  sidre::DataStore* spds = create_tiny_datastore();
-  generate_spio_blueprint(sds, true);    //dense
-  generate_spio_blueprint(spds, false);  //sparse
+  auto sds = create_tiny_datastore();
+  generate_spio_blueprint(sds.get(), true);  //dense
+
+  auto spds = create_tiny_datastore();
+  generate_spio_blueprint(spds.get(), false);  //sparse
   spds->getRoot()->destroyGroups();
   spds->getRoot()->destroyViews();
+
   spds = create_tiny_datastore();
-  generate_multidomain_blueprint(spds, "multi1", 1, false);
+  generate_multidomain_blueprint(spds.get(), "multi1", 1, false);
   spds->getRoot()->destroyGroups();
   spds->getRoot()->destroyViews();
+
   spds = create_tiny_datastore();
-  generate_multidomain_blueprint(spds, "multi1_list", 1, true);
+  generate_multidomain_blueprint(spds.get(), "multi1_list", 1, true);
   if(num_ranks > 1)
   {
     spds->getRoot()->destroyGroups();
     spds->getRoot()->destroyViews();
+
     spds = create_tiny_datastore();
-    generate_multidomain_blueprint(spds, "multi2", 2, false);
+    generate_multidomain_blueprint(spds.get(), "multi2", 2, false);
     spds->getRoot()->destroyGroups();
     spds->getRoot()->destroyViews();
+
     spds = create_tiny_datastore();
-    generate_multidomain_blueprint(spds, "multi2_list", 2, true);
+    generate_multidomain_blueprint(spds.get(), "multi2_list", 2, true);
     spds->getRoot()->destroyGroups();
     spds->getRoot()->destroyViews();
+
     spds = create_tiny_datastore();
-    generate_multidomain_blueprint(spds, "multi_all", num_ranks, false);
+    generate_multidomain_blueprint(spds.get(), "multi_all", num_ranks, false);
     spds->getRoot()->destroyGroups();
     spds->getRoot()->destroyViews();
+
     spds = create_tiny_datastore();
-    generate_multidomain_blueprint(spds, "multi_all_list", num_ranks, true);
+    generate_multidomain_blueprint(spds.get(), "multi_all_list", num_ranks, true);
   }
   spds->getRoot()->destroyGroups();
   spds->getRoot()->destroyViews();
-  generate_cartesian_blueprint(spds, "cart1", 1);
+
+  generate_cartesian_blueprint(spds.get(), "cart1", 1);
   if(num_ranks > 1)
   {
     spds->getRoot()->destroyGroups();
     spds->getRoot()->destroyViews();
+
     spds = create_tiny_datastore();
-    generate_cartesian_blueprint(spds, "cart2", 2);
+    generate_cartesian_blueprint(spds.get(), "cart2", 2);
     spds->getRoot()->destroyGroups();
     spds->getRoot()->destroyViews();
+
     spds = create_tiny_datastore();
-    generate_cartesian_blueprint(spds, "cart_all", num_ranks);
+    generate_cartesian_blueprint(spds.get(), "cart_all", num_ranks);
   }
 
   MPI_Finalize();

--- a/src/axom/sidre/examples/sidre_mfem_datacollection_restart.cpp
+++ b/src/axom/sidre/examples/sidre_mfem_datacollection_restart.cpp
@@ -198,8 +198,7 @@ int main(int argc, char* argv[])
 #endif
 
   // Initialize the datacollection
-  // Needs to be configured to own the mesh data so all mesh data is saved to datastore/output file
-  const bool owns_mesh_data = true;
+  const bool owns_mesh_data = false;
   axom::sidre::MFEMSidreDataCollection dc("sidre_mfem_datacoll_restart_ex",
                                           nullptr,
                                           owns_mesh_data);

--- a/src/axom/sidre/tests/sidre_collections.cpp
+++ b/src/axom/sidre/tests/sidre_collections.cpp
@@ -934,6 +934,7 @@ TYPED_TEST(IndexedCollectionTest, insertBadIdx)
       if(idx < 0)
       {
         EXPECT_EQ(sidre::InvalidIndex, insertedIdx);
+        delete val;
       }
       else
       {

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -1797,6 +1797,8 @@ TEST(sidre_group, copy_to_conduit_node)
       EXPECT_EQ(chld_views["d1/value"].as_string(), std::string("33.0"));
     }
   }
+
+  delete ds1;
 }
 //------------------------------------------------------------------------------
 TEST(sidre_group, save_restore_empty_datastore)
@@ -3603,7 +3605,7 @@ TEST(sidre_group, get_data_info)
   Group* gp_D = gp_C->createGroup("D");
   num_groups_chk += 1;
 
-  View* view_D1 = gp_D->createView("ext_D1", INT_ID, 10, &extdata + 10);
+  View* view_D1 = gp_D->createView("ext_D1", INT_ID, 10, extdata + 10);
   num_views_chk += 1;
   num_views_external_chk += 1;
   num_bytes_external_chk += view_D1->getTotalBytes();

--- a/src/axom/sidre/tests/sidre_group_C.cpp
+++ b/src/axom/sidre/tests/sidre_group_C.cpp
@@ -791,6 +791,8 @@ TEST(C_sidre_group, rename_group)
   success = SIDRE_Group_rename(child3, "g_b");
   EXPECT_FALSE(success);
   EXPECT_TRUE(strcmp(SIDRE_Group_get_name(child3), "g_c") == 0);
+
+  SIDRE_DataStore_delete(ds);
 }
 
 //------------------------------------------------------------------------------
@@ -850,8 +852,8 @@ TEST(C_sidre_group, save_restore_complex)
   EXPECT_NEAR(SIDRE_View_get_data_double(d0_view), 3000.0, 1e-12);
 
   SIDRE_DataStore_print(ds2);
-
-  SIDRE_DataStore_delete(ds);
-  SIDRE_DataStore_delete(ds2);
 #endif
+
+  SIDRE_DataStore_delete(ds2);
+  SIDRE_DataStore_delete(ds);
 }

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "axom/config.hpp"
+#include "axom/core.hpp"
 #include "axom/slic.hpp"
 #include "axom/sidre.hpp"
 #include "axom/fmt.hpp"
@@ -22,7 +23,7 @@
 using axom::sidre::Group;
 using axom::sidre::MFEMSidreDataCollection;
 
-const double EPSILON = 1.0e-6;
+constexpr double EPSILON = 1.0e-6;
 
 std::string testName()
 {
@@ -38,9 +39,9 @@ TEST(sidre_datacollection, dc_alloc_no_mesh)
 TEST(sidre_datacollection, dc_alloc_owning_mesh)
 {
   // 1D mesh divided into 10 segments
-  auto mesh = mfem::Mesh::MakeCartesian1D(10);
-  bool owns_mesh = true;
-  MFEMSidreDataCollection sdc(testName(), &mesh, owns_mesh);
+  auto* mesh = new mfem::Mesh(mfem::Mesh::MakeCartesian1D(10));
+  const bool owns_mesh_data = true;
+  MFEMSidreDataCollection sdc(testName(), mesh, owns_mesh_data);
   EXPECT_TRUE(sdc.verifyMeshBlueprint());
 }
 
@@ -48,8 +49,8 @@ TEST(sidre_datacollection, dc_alloc_nonowning_mesh)
 {
   // 1D mesh divided into 10 segments
   auto mesh = mfem::Mesh::MakeCartesian1D(10);
-  bool owns_mesh = false;
-  MFEMSidreDataCollection sdc(testName(), &mesh, owns_mesh);
+  const bool owns_mesh_data = false;
+  MFEMSidreDataCollection sdc(testName(), &mesh, owns_mesh_data);
   EXPECT_TRUE(sdc.verifyMeshBlueprint());
 }
 
@@ -155,22 +156,24 @@ TEST(sidre_datacollection, dc_reload_gf)
 {
   const std::string field_name = "test_field";
   // 2D mesh divided into triangles
-  auto mesh = mfem::Mesh::MakeCartesian2D(10, 10, mfem::Element::TRIANGLE);
-  mfem::H1_FECollection fec(1, mesh.Dimension());
-  mfem::FiniteElementSpace fes(&mesh, &fec);
+  auto* mesh =
+    new mfem::Mesh(mfem::Mesh::MakeCartesian2D(10, 10, mfem::Element::TRIANGLE));
+  auto* fec = new mfem::H1_FECollection(1, mesh->Dimension());
+  auto* fes = new mfem::FiniteElementSpace(mesh, fec);
 
   // The mesh and field(s) must be owned by Sidre to properly manage data in case of
   // a simulated restart (save -> load)
-  bool owns_mesh = true;
-  MFEMSidreDataCollection sdc_writer(testName(), &mesh, owns_mesh);
-  mfem::GridFunction gf_write(&fes, nullptr);
+  const bool owns_mesh_data = true;
+  MFEMSidreDataCollection sdc_writer(testName(), mesh, owns_mesh_data);
+  auto* gf_write = new mfem::GridFunction(fes, nullptr);
+  gf_write->MakeOwner(fec);
 
   // Register to allocate storage internally, then write to it
-  sdc_writer.RegisterField(field_name, &gf_write);
+  sdc_writer.RegisterField(field_name, gf_write);
   EXPECT_TRUE(sdc_writer.HasField(field_name));
 
   mfem::ConstantCoefficient three_and_a_half(3.5);
-  gf_write.ProjectCoefficient(three_and_a_half);
+  gf_write->ProjectCoefficient(three_and_a_half);
 
   EXPECT_TRUE(sdc_writer.verifyMeshBlueprint());
 
@@ -192,7 +195,7 @@ TEST(sidre_datacollection, dc_reload_gf)
   EXPECT_TRUE(sdc_reader.HasField(field_name));
 
   // No need to reregister, it already exists
-  auto gf_read = sdc_reader.GetField(field_name);
+  auto* gf_read = sdc_reader.GetField(field_name);
 
   // Make sure the gridfunction was actually read in
   EXPECT_LT(gf_read->ComputeL2Error(three_and_a_half), EPSILON);
@@ -211,8 +214,11 @@ TEST(sidre_datacollection, dc_reload_gf_vdim)
 
   // The mesh and field(s) must be owned by Sidre to properly manage data in case of
   // a simulated restart (save -> load)
-  bool owns_mesh = true;
-  MFEMSidreDataCollection sdc_writer(testName(), &mesh, owns_mesh);
+  const bool owns_mesh_data = true;
+  MFEMSidreDataCollection sdc_writer(testName(), &mesh, owns_mesh_data);
+  // the following prevents mfem::DataCollection from deleting the mesh and gfs
+  // see 'dc_reload_gf' test for a case where the DataCollection also owns the mesh and gf data
+  sdc_writer.SetOwnData(false);
   mfem::GridFunction gf_write(&fes, nullptr);
 
   // Register to allocate storage internally, then write to it
@@ -260,8 +266,9 @@ TEST(sidre_datacollection, dc_reload_mesh)
 
   // The mesh and field(s) must be owned by Sidre to properly manage data in case of
   // a simulated restart (save -> load)
-  bool owns_mesh = true;
-  MFEMSidreDataCollection sdc_writer(testName(), &mesh, owns_mesh);
+  const bool owns_mesh_data = true;
+  MFEMSidreDataCollection sdc_writer(testName(), &mesh, owns_mesh_data);
+  sdc_writer.SetOwnData(false);
 #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
   sdc_writer.SetComm(MPI_COMM_WORLD);
 #endif
@@ -317,8 +324,9 @@ TEST(sidre_datacollection, dc_reload_qf)
 
   // The mesh and field(s) must be owned by Sidre to properly manage data in case of
   // a simulated restart (save -> load)
-  bool owns_mesh = true;
-  MFEMSidreDataCollection sdc_writer(testName(), &mesh, owns_mesh);
+  const bool owns_mesh_data = true;
+  MFEMSidreDataCollection sdc_writer(testName(), &mesh, owns_mesh_data);
+  sdc_writer.SetOwnData(false);
 #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
   sdc_writer.SetComm(MPI_COMM_WORLD);
 #endif
@@ -639,24 +647,49 @@ TEST(sidre_datacollection, create_material_dependent_field_multi_fraction)
 
 #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
 
-TEST(sidre_datacollection, dc_alloc_owning_parmesh)
+TEST(sidre_datacollection, dc_alloc_parmesh)
 {
-  // 1D mesh divided into 10 segments
-  auto mesh = mfem::Mesh::MakeCartesian1D(10);
-  mfem::ParMesh parmesh(MPI_COMM_WORLD, mesh);
-  bool owns_mesh = true;
-  MFEMSidreDataCollection sdc(testName(), &parmesh, owns_mesh);
-  EXPECT_TRUE(sdc.verifyMeshBlueprint());
-}
+  // case 1: serial and parallel mesh are not pointers
+  {
+    constexpr bool owns_mesh_data = true;
 
-TEST(sidre_datacollection, dc_alloc_nonowning_parmesh)
-{
-  // 1D mesh divided into 10 segments
-  auto mesh = mfem::Mesh::MakeCartesian1D(10);
-  mfem::ParMesh parmesh(MPI_COMM_WORLD, mesh);
-  bool owns_mesh = false;
-  MFEMSidreDataCollection sdc(testName(), &parmesh, owns_mesh);
-  EXPECT_TRUE(sdc.verifyMeshBlueprint());
+    // 1D mesh divided into 10 segments
+    auto mesh = mfem::Mesh::MakeCartesian1D(10);
+    mfem::ParMesh parmesh(MPI_COMM_WORLD, mesh);
+    MFEMSidreDataCollection sdc(testName(), &parmesh, owns_mesh_data);
+
+    // Must set this to avoid mfem's DataCollection from deleting the parmesh
+    sdc.SetOwnData(false);
+
+    EXPECT_TRUE(sdc.verifyMeshBlueprint());
+  }
+
+  // case 2: serial and parallel meshes are pointers
+  // data collection owns and deletes parmesh
+  {
+    constexpr bool owns_mesh_data = true;
+
+    // 1D mesh divided into 10 segments
+    auto* mesh = new mfem::Mesh(mfem::Mesh::MakeCartesian1D(10));
+    auto* parmesh = new mfem::ParMesh(MPI_COMM_WORLD, *mesh);
+    delete mesh;
+
+    MFEMSidreDataCollection sdc(testName(), parmesh, owns_mesh_data);
+
+    EXPECT_TRUE(sdc.verifyMeshBlueprint());
+  }
+
+  // case 3: data collection doesn't own mesh/data
+  {
+    constexpr bool owns_mesh_data = false;
+
+    // 1D mesh divided into 10 segments
+    auto mesh = mfem::Mesh::MakeCartesian1D(10);
+    mfem::ParMesh parmesh(MPI_COMM_WORLD, mesh);
+
+    MFEMSidreDataCollection sdc(testName(), &parmesh, owns_mesh_data);
+    EXPECT_TRUE(sdc.verifyMeshBlueprint());
+  }
 }
 
 struct ParMeshGroupData
@@ -705,16 +738,13 @@ static std::vector<ParMeshGroupData> getGroupData(const mfem::ParMesh& parmesh)
 static void testParallelMeshReload(mfem::Mesh& base_mesh,
                                    const int part_method = 1)
 {
-  mfem::ParMesh parmesh(MPI_COMM_WORLD, base_mesh, nullptr, part_method);
-
-  // Use second-order elements to ensure that the nodal gridfunction gets set up properly as well
-  mfem::H1_FECollection fec(2, base_mesh.Dimension());
-  mfem::ParFiniteElementSpace parfes(&parmesh, &fec);
+  auto* parmesh =
+    new mfem::ParMesh(MPI_COMM_WORLD, base_mesh, nullptr, part_method);
 
   // The mesh must be owned by Sidre to properly manage data in case of
   // a simulated restart (save -> load)
-  const bool owns_mesh = true;
-  MFEMSidreDataCollection sdc_writer(testName(), &parmesh, owns_mesh);
+  const bool owns_mesh_data = true;
+  MFEMSidreDataCollection sdc_writer(testName(), parmesh, owns_mesh_data);
 
   // Save some basic info about the mesh
   const int n_verts = sdc_writer.GetMesh()->GetNV();
@@ -730,6 +760,8 @@ static void testParallelMeshReload(mfem::Mesh& base_mesh,
 
   // Group-specific info
   auto writer_group_data = getGroupData(*writer_pmesh);
+
+  EXPECT_TRUE(sdc_writer.verifyMeshBlueprint());
 
   sdc_writer.SetCycle(0);
   sdc_writer.Save();
@@ -772,7 +804,7 @@ static void testParallelMeshReload(mfem::Mesh& base_mesh,
 static void testParallelMeshReloadAllPartitionings(mfem::Mesh& base_mesh)
 {
   // MFEM supports partition methods [0, 5]
-  static constexpr int MAX_PART_METHOD = 5;
+  constexpr int MAX_PART_METHOD = 5;
   for(int part_method = 0; part_method <= MAX_PART_METHOD; part_method++)
   {
     testParallelMeshReload(base_mesh, part_method);
@@ -791,8 +823,9 @@ TEST(sidre_datacollection, dc_par_reload_gf)
 
   // The mesh must be owned by Sidre to properly manage data in case of
   // a simulated restart (save -> load)
-  bool owns_mesh = true;
-  MFEMSidreDataCollection sdc_writer(testName(), &parmesh, owns_mesh);
+  bool owns_mesh_data = true;
+  MFEMSidreDataCollection sdc_writer(testName(), &parmesh, owns_mesh_data);
+  sdc_writer.SetOwnData(false);
 
   // The mesh and field(s) must be owned by Sidre to properly manage data in case of
   // a simulated restart (save -> load)
@@ -848,8 +881,9 @@ TEST(sidre_datacollection, dc_par_reload_gf_ordering)
 
   // The mesh must be owned by Sidre to properly manage data in case of
   // a simulated restart (save -> load)
-  bool owns_mesh = true;
-  MFEMSidreDataCollection sdc_writer(testName(), &parmesh, owns_mesh);
+  bool owns_mesh_data = true;
+  MFEMSidreDataCollection sdc_writer(testName(), &parmesh, owns_mesh_data);
+  sdc_writer.SetOwnData(false);
 
   // The mesh and field(s) must be owned by Sidre to properly manage data in case of
   // a simulated restart (save -> load)
@@ -908,6 +942,7 @@ TEST(sidre_datacollection, dc_par_reload_multi_datastore)
   const std::string second_coll_name = testName() + "second";
   const std::string field_name = "test_field";
   const std::string useless_view_name = "useless_view";
+
   // 3D tet mesh
   auto mesh = mfem::Mesh::MakeCartesian3D(2, 2, 2, mfem::Element::TETRAHEDRON);
   mfem::ParMesh first_parmesh(MPI_COMM_WORLD, mesh);
@@ -937,18 +972,18 @@ TEST(sidre_datacollection, dc_par_reload_multi_datastore)
 
   // The mesh must be owned by Sidre to properly manage data in case of
   // a simulated restart (save -> load)
-  bool owns_mesh = true;
+  bool owns_mesh_data = true;
   MFEMSidreDataCollection first_sdc_writer(first_coll_name,
                                            first_bp_index_grp,
                                            first_domain_grp,
-                                           owns_mesh);
+                                           owns_mesh_data);
   first_sdc_writer.SetComm(MPI_COMM_WORLD);
   first_sdc_writer.SetMesh(&first_parmesh);
 
   MFEMSidreDataCollection second_sdc_writer(second_coll_name,
                                             second_bp_index_grp,
                                             second_domain_grp,
-                                            owns_mesh);
+                                            owns_mesh_data);
   second_sdc_writer.SetComm(MPI_COMM_WORLD);
   second_sdc_writer.SetMesh(&second_parmesh);
 
@@ -991,11 +1026,11 @@ TEST(sidre_datacollection, dc_par_reload_multi_datastore)
   MFEMSidreDataCollection first_sdc_reader(first_coll_name,
                                            first_bp_index_grp,
                                            first_domain_grp,
-                                           owns_mesh);
+                                           owns_mesh_data);
   MFEMSidreDataCollection second_sdc_reader(second_coll_name,
                                             second_bp_index_grp,
                                             second_domain_grp,
-                                            owns_mesh);
+                                            owns_mesh_data);
 
   // Needs to be set "manually" in order for everything to be loaded in properly
   first_sdc_reader.SetComm(MPI_COMM_WORLD);

--- a/src/axom/sidre/tests/sidre_opaque_C.cpp
+++ b/src/axom/sidre/tests/sidre_opaque_C.cpp
@@ -137,6 +137,8 @@ TEST(C_sidre_opaque, basic_inout)
   int test_ihi2 = test_extent2->ihi;
 
   EXPECT_EQ(test_ihi2, 2 * ihi_val);
+
+  AA_extent_delete(ext2);
 #endif
 
   // clean up...

--- a/src/axom/sidre/tests/sidre_view.cpp
+++ b/src/axom/sidre/tests/sidre_view.cpp
@@ -1720,6 +1720,8 @@ TEST(sidre_view, import_array_node)
 
   v4->importArrayNode(n_ints);
   EXPECT_TRUE(v4->isString());
+
+  delete ds;
 }
 
 //------------------------------------------------------------------------------
@@ -1820,6 +1822,8 @@ TEST(sidre_view, clear_view)
     view->clear();
     EXPECT_TRUE(checkViewValues(view, EMPTY, false, false, false, 0));
   }
+
+  delete ds;
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/sidre/tests/spio/spio_basic.hpp
+++ b/src/axom/sidre/tests/spio/spio_basic.hpp
@@ -7,6 +7,7 @@
 
 #include "axom/sidre/spio/IOManager.hpp"
 #include "axom/sidre/spio/IOBaton.hpp"
+#include "axom/fmt.hpp"
 
 #include "mpi.h"
 
@@ -29,13 +30,12 @@ TEST(spio_basic, root_name)
   protocolMap["json"] = "json";
   protocolMap["sidre_conduit_json"] = "conduit_json";
 
-  using MapIt = std::map<std::string, std::string>::const_iterator;
-  for(MapIt it = protocolMap.begin(); it != protocolMap.end(); ++it)
+  for(const auto& kv : protocolMap)
   {
-    const std::string& sidreProtocol = it->first;
-    const std::string& expRelayProtocol = it->second;
+    const std::string& sidreProtocol = kv.first;
+    const std::string& expRelayProtocol = kv.second;
 
-    std::string relayProtocol =
+    const std::string relayProtocol =
       IOManager::correspondingRelayProtocol(sidreProtocol);
 
     EXPECT_EQ(expRelayProtocol, relayProtocol);
@@ -117,11 +117,9 @@ TEST(spio_basic, baton)
   // Test baton for different numbers of files
   for(int nFiles = 1; nFiles <= num_ranks; ++nFiles)
   {
-    std::stringstream sstr;
-    sstr << "Checking baton for " << nFiles << " files "
-         << " with " << num_ranks << " ranks";
-
-    SCOPED_TRACE(sstr.str());
+    SCOPED_TRACE(axom::fmt::format("Checking baton for {} files with {} ranks",
+                                   nFiles,
+                                   num_ranks));
     checkBaton(nFiles, num_ranks, my_rank);
   }
 }

--- a/src/axom/sidre/tests/spio/spio_main.cpp
+++ b/src/axom/sidre/tests/spio/spio_main.cpp
@@ -9,14 +9,11 @@
 
 #include "axom/config.hpp"
 #include "axom/slic.hpp"
+#include "axom/sidre.hpp"
 
 namespace
 {
-#ifdef AXOM_USE_HDF5
-const std::string PROTOCOL = "sidre_hdf5";
-#else
-const std::string PROTOCOL = "sidre_json";
-#endif
+const std::string PROTOCOL = axom::sidre::Group::getDefaultIOProtocol();
 const std::string ROOT_EXT = ".root";
 }  // namespace
 

--- a/src/axom/sidre/tests/spio/spio_parallel.hpp
+++ b/src/axom/sidre/tests/spio/spio_parallel.hpp
@@ -19,12 +19,10 @@
 #include "gtest/gtest.h"
 
 // _parallel_io_headers_start
-#include "axom/config.hpp"  // for AXOM_USE_HDF5
+#include "axom/config.hpp"
 
 #include "conduit_blueprint.hpp"
-
 #include "conduit_relay.hpp"
-
 #ifdef AXOM_USE_HDF5
   #include "conduit_relay_io_hdf5.hpp"
 #endif
@@ -250,10 +248,7 @@ TEST(spio_parallel, write_read_write)
   MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
 
   const int num_files = numOutputFiles(num_ranks);
-
-  std::stringstream sstr;
-  sstr << "out_spio_WRW_" << num_ranks;
-  std::string filename = sstr.str();
+  const std::string filename = axom::fmt::format("out_spio_WRW_{}", num_ranks);
 
   // Initialize a datastore and dump to disk
   DataStore* ds = new DataStore();
@@ -280,6 +275,8 @@ TEST(spio_parallel, write_read_write)
   //      minor: Unable to open file
   IOManager writer_b(MPI_COMM_WORLD);
   writer_b.write(ds_r.getRoot(), num_files, filename, PROTOCOL);
+
+  delete ds;
 }
 
 //------------------------------------------------------------------------------
@@ -329,7 +326,7 @@ TEST(spio_parallel, external_writeread)
   /*
    * Contents of the DataStore written to files with IOManager.
    */
-  int num_files = num_output;
+  const int num_files = num_output;
   IOManager writer(MPI_COMM_WORLD);
 
   const std::string file_name = "out_spio_external_write_read";

--- a/src/axom/sidre/tests/spio/spio_serial.hpp
+++ b/src/axom/sidre/tests/spio/spio_serial.hpp
@@ -5,9 +5,10 @@
 
 #include "gtest/gtest.h"
 
-#include "axom/config.hpp"      // for AXOM_USE_HDF5
-#include "axom/core/Types.hpp"  // for common::std::int64_t
+#include "axom/config.hpp"
 #include "axom/sidre.hpp"
+#include "axom/fmt.hpp"
+
 #include <list>
 
 #include "mpi.h"
@@ -15,8 +16,6 @@
 using axom::sidre::DataStore;
 using axom::sidre::Group;
 using axom::sidre::IOManager;
-
-using std::int64_t;
 
 //------------------------------------------------------------------------------
 
@@ -36,7 +35,7 @@ TEST(spio_serial, basic_writeread)
   ga->createViewScalar<std::int64_t>("i0", 101);
   gb->createViewScalar<std::int64_t>("i1", 404);
 
-  int num_files = 1;
+  const int num_files = 1;
   IOManager writer(MPI_COMM_WORLD);
 
   const std::string file_name = "out_spio_basic_write_read";
@@ -83,12 +82,8 @@ TEST(spio_serial, basic_writeread_protocols)
   protocols.push_back("sidre_conduit_json");
   protocols.push_back("sidre_json");
 
-  for(std::list<std::string>::const_iterator itr = protocols.begin();
-      itr != protocols.end();
-      ++itr)
+  for(const auto& protocol : protocols)
   {
-    const std::string& protocol = *itr;
-
     DataStore* ds1 = new DataStore();
 
     Group* root1 = ds1->getRoot();
@@ -103,7 +98,7 @@ TEST(spio_serial, basic_writeread_protocols)
     ga->createViewScalar<std::int64_t>("i0", 101);
     gb->createViewScalar<std::int64_t>("i1", 404);
 
-    int num_files = 1;
+    const int num_files = 1;
     IOManager writer(MPI_COMM_WORLD);
 
     const std::string file_name = "out_spio_basic_write_read" + protocol;
@@ -144,10 +139,8 @@ TEST(spio_serial, write_read_write)
   MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
   MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
 
-  int num_files = std::max(num_ranks / 2, 1);
-  std::stringstream sstr;
-  sstr << "out_spio_WRW_" << num_ranks;
-  std::string filename = sstr.str();
+  const int num_files = std::max(num_ranks / 2, 1);
+  const std::string filename = axom::fmt::format("out_spio_WRW_{}", num_ranks);
 
   // Initialize a datastore and dump to disk
   DataStore* ds = new DataStore();
@@ -174,6 +167,8 @@ TEST(spio_serial, write_read_write)
   //      minor: Unable to open file
   IOManager writer_b(MPI_COMM_WORLD);
   writer_b.write(ds_r.getRoot(), num_files, filename, PROTOCOL);
+
+  delete ds;
 }
 
 //------------------------------------------------------------------------------
@@ -221,5 +216,7 @@ TEST(spio_serial, rootfile_suffix)
             ds->getRoot()->getView("grp/i")->getData<int>());
   EXPECT_EQ(ds_suffix.getRoot()->getView("grp/i")->getData<int>(),
             ds_nosuffix.getRoot()->getView("grp/i")->getData<int>());
+
+  delete ds;
 }
 #endif  // AXOM_USE_HDF5

--- a/src/axom/slam/examples/lulesh2.0.3/lulesh-init.cpp
+++ b/src/axom/slam/examples/lulesh2.0.3/lulesh-init.cpp
@@ -208,6 +208,14 @@ namespace slamLulesh {
   } // End constructor
 
 
+Domain::~Domain()
+{
+#ifdef AXOM_USE_MPI
+    delete [] commDataSend;
+    delete [] commDataRecv;
+#endif
+}
+
 ////////////////////////////////////////////////////////////////////////////////
   void
   Domain::BuildMesh(Int_t nx, Int_t edgeNodes, Int_t edgeElems)

--- a/src/axom/slam/examples/lulesh2.0.3/lulesh.hpp
+++ b/src/axom/slam/examples/lulesh2.0.3/lulesh.hpp
@@ -205,6 +205,10 @@ namespace slamLulesh {
         Index_t rowLoc, Index_t planeLoc,
         Index_t nx, Int_t tp, Int_t nr, Int_t balance, Int_t cost);
 
+
+    // Destructor
+    ~Domain();
+    
     //
     // ALLOCATION
     //
@@ -497,8 +501,8 @@ namespace slamLulesh {
 
 #ifdef AXOM_USE_MPI
     // Communication Work space
-    Real_t *commDataSend;
-    Real_t *commDataRecv;
+    Real_t *commDataSend {nullptr};
+    Real_t *commDataRecv {nullptr};
 
     // Maximum number of block neighbors
     MPI_Request recvRequest[26]; // 6 faces + 12 edges + 8 corners

--- a/src/axom/slam/mesh_struct/IA_impl.hpp
+++ b/src/axom/slam/mesh_struct/IA_impl.hpp
@@ -667,7 +667,7 @@ void IAMesh<TDIM, SDIM, P>::fixVertexNeighborhood(
       {
         // Add all element-face associations to an array;
         // we'll update the adjacencies outside this loop
-        FaceLinkVerts face_link_verts;
+        FaceLinkVerts face_link_verts {};
         for(int i = 0, idx = 0; i < TDIM; ++i)
         {
           if(i != vert_i &&          // i is a vertex in face_i

--- a/src/axom/slic/core/Logger.hpp
+++ b/src/axom/slic/core/Logger.hpp
@@ -156,11 +156,14 @@ public:
    * \brief Binds the given stream to all the levels for this Logger instance.
    *
    * \param [in] ls pointer to the user-supplied LogStream object.
+   * \param [in] pass_ownership flag that indicates whether the given logger
+   *  instance owns the supplied LogStream object. This parameter is optional.
+   *  Default is true.
    *
    * \note The Logger takes ownership of the LogStream object.
    * \pre ls != NULL.
    */
-  void addStreamToAllMsgLevels(LogStream* ls);
+  void addStreamToAllMsgLevels(LogStream* ls, bool pass_ownership = true);
 
   /*!
    * \brief Returns the number of streams at the given level.
@@ -204,11 +207,14 @@ public:
    * \brief Binds the given stream to all the tags for this Logger instance.
    *
    * \param [in] ls pointer to the user-supplied LogStream object.
+   * \param [in] pass_ownership flag that indicates whether the given logger
+   *  instance owns the supplied LogStream object. This parameter is optional.
+   *  Default is true.
    *
    * \note The Logger takes ownership of the LogStream object.
    * \pre ls != NULL.
    */
-  void addStreamToAllTags(LogStream* ls);
+  void addStreamToAllTags(LogStream* ls, bool pass_ownership = true);
 
   /*!
    * \brief Returns the number of streams for a given tag.

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -1264,6 +1264,7 @@ void check_find_points_zip2d()
 
   axom::Array<FloatType> xs(ncells, ncells);
   axom::Array<FloatType> ys(ncells, ncells);
+  FloatType* zs {nullptr};
 
   for(int icell = 0; icell < ncells; icell++)
   {
@@ -1271,7 +1272,7 @@ void check_find_points_zip2d()
     ys[icell] = centroids[icell][1];
   }
 
-  primal::ZipIndexable<PointType> zip_test {{xs.data(), ys.data(), nullptr}};
+  primal::ZipIndexable<PointType> zip_test {{xs.data(), ys.data(), zs}};
 
   // construct the BVH
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -1173,9 +1173,9 @@ void check_find_points_zip3d()
   BoxType* aabbs = nullptr;
   generate_aabbs_and_centroids(&mesh, aabbs, centroids);
 
-  FloatType* xs = axom::allocate<FloatType>(ncells);
-  FloatType* ys = axom::allocate<FloatType>(ncells);
-  FloatType* zs = axom::allocate<FloatType>(ncells);
+  axom::Array<FloatType> xs(ncells, ncells);
+  axom::Array<FloatType> ys(ncells, ncells);
+  axom::Array<FloatType> zs(ncells, ncells);
 
   for(int icell = 0; icell < ncells; icell++)
   {
@@ -1184,7 +1184,7 @@ void check_find_points_zip3d()
     zs[icell] = centroids[icell][2];
   }
 
-  primal::ZipIndexable<PointType> zip_test {{xs, ys, zs}};
+  primal::ZipIndexable<PointType> zip_test {{xs.data(), ys.data(), zs.data()}};
 
   // construct the BVH
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;
@@ -1213,11 +1213,8 @@ void check_find_points_zip3d()
     const int donorCellIdx = ug.getBinIndex(q);
     EXPECT_EQ(counts[i], 1);
     EXPECT_EQ(donorCellIdx, candidates[offsets[i]]);
-  }  // END for all cell centroids
+  }
 
-  axom::deallocate(xs);
-  axom::deallocate(ys);
-  axom::deallocate(zs);
   axom::deallocate(aabbs);
 
   axom::setDefaultAllocator(current_allocator);
@@ -1265,9 +1262,8 @@ void check_find_points_zip2d()
   BoxType* aabbs = nullptr;
   generate_aabbs_and_centroids(&mesh, aabbs, centroids);
 
-  FloatType* xs = axom::allocate<FloatType>(ncells);
-  FloatType* ys = axom::allocate<FloatType>(ncells);
-  FloatType* zs = nullptr;
+  axom::Array<FloatType> xs(ncells, ncells);
+  axom::Array<FloatType> ys(ncells, ncells);
 
   for(int icell = 0; icell < ncells; icell++)
   {
@@ -1275,7 +1271,7 @@ void check_find_points_zip2d()
     ys[icell] = centroids[icell][1];
   }
 
-  primal::ZipIndexable<PointType> zip_test {{xs, ys, zs}};
+  primal::ZipIndexable<PointType> zip_test {{xs.data(), ys.data(), nullptr}};
 
   // construct the BVH
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;

--- a/src/tools/data_collection_util.cpp
+++ b/src/tools/data_collection_util.cpp
@@ -570,7 +570,7 @@ int main(int argc, char** argv)
   sidre::MFEMSidreDataCollection dc(params.dcName, nullptr, true);
 
   // Create or load the serial mfem mesh
-  mfem::Mesh* mesh = nullptr;
+  mfem::Mesh* mesh {nullptr};
   switch(params.meshForm)
   {
   case MeshForm::Box:


### PR DESCRIPTION
# Summary

- This PR is a bugfix for several memory leaks in axom as reported by `lsan`
   - I compiled the full stack w/ gcc@10.3.1 using the following flags 
   ```
   BLT_CXX_FLAGS =-g -mcmodel=medium -fsanitize=leak -fno-omit-frame-pointer -O3 -std=c++14
    ```
- Most leaks were in Axom tests and examples, but there were some in the code, which I'll point out. Notably:
   - fixes a leak in `sidre::MFEMSidreDataCollection` in cases where the data collection is supposed to deallocate the underlying mfem mesh
   - fixes a leak in axom::Array's move assignment operator. Thanks @publixsubfan for help with the solution!
   - There is still an outstanding leak in `multimat`, presumably related to `axom::Array` due to this line: https://github.com/LLNL/axom/blob/60a3add00eb5b9a261ca683c790a8513f5fe2e23/src/axom/multimat/multimat.cpp#L351
- Includes some minor refactoring

#### TODO

- [x] Update RELEASE-NOTES
- [x] Fix compilation error with gmock in Klee unit tests
- [x] Fix memory leak exposed through multimat's `SetAllocatorID()` function