### PR TITLE
Bugfix for intermittent failure of quest_inout_interface Fortran example

### DIFF
--- a/src/axom/quest/examples/quest_inout_interface.F
+++ b/src/axom/quest/examples/quest_inout_interface.F
@@ -76,7 +76,7 @@ contains
     real(C_DOUBLE)  :: x, y, z
     real(C_DOUBLE)  :: EPS = 1E-7
     real(C_DOUBLE) :: mesh_bb_min(3), mesh_bb_max(3), mesh_center_of_mass(3)
-    character(LEN=40) :: Format = "(I4, F8.2, F8.2, F8.2, L3)"
+    character(LEN=60) :: Format = "(I4, I4, F8.2, F8.2, F8.2, L3)"
 
     !...set parameters for the inout query
     rc = quest_inout_set_verbose(is_verbose)
@@ -109,7 +109,7 @@ contains
 
     if (rank == 0) then
       write(*,*) "** Running containment queries using quest fortran interface"
-      write(*,*) "[rank, (  x,  y,  z),   inside?]"
+      write(*,*) "[rank, id, (  x,  y,  z),   inside?]"
     end if
 
     !...run the inout query at some fixed and random points
@@ -126,7 +126,7 @@ contains
 
       ins = quest_inout_evaluate(x,y,z)
 
-      write(*,Format) rank, x, y, z, ins
+      write(*,Format) rank, i-1, x, y, z, ins
     end do
 
     !...finalize quest_inout query

--- a/src/axom/quest/interface/inout.cpp
+++ b/src/axom/quest/interface/inout.cpp
@@ -58,7 +58,7 @@ struct InOutHelper
     void setDefault() { *this = State {}; }
   };
 
-  InOutHelper() : m_surfaceMesh(nullptr), m_inoutTree(nullptr)
+  InOutHelper()
   {
     m_params.setDefault();
     m_state.setDefault();
@@ -214,14 +214,14 @@ struct InOutHelper
     // deal with spatial index
     if(m_inoutTree != nullptr)
     {
-      delete(m_inoutTree);
+      delete m_inoutTree;
       m_inoutTree = nullptr;
     }
 
     // deal with mesh
     if(m_state.m_should_delete_mesh)
     {
-      delete(m_surfaceMesh);
+      delete m_surfaceMesh;
     }
     m_surfaceMesh = nullptr;
 
@@ -294,8 +294,8 @@ struct InOutHelper
   }
 
 private:
-  mint::Mesh* m_surfaceMesh;
-  InOutOctree<DIM>* m_inoutTree;
+  mint::Mesh* m_surfaceMesh {nullptr};
+  InOutOctree<DIM>* m_inoutTree {nullptr};
   GeometricBoundingBox m_meshBoundingBox;
   SpacePt m_meshCenterOfMass;
 
@@ -401,13 +401,21 @@ int inout_init(mint::Mesh*& mesh, MPI_Comm comm)
 int inout_finalize()
 {
   const int dim = inout_get_dimension();
+  SLIC_ASSERT(dim == 2 || dim == 3);
 
-  // Finalize the 2D and 3D structures and reset the params
-  int rc2 = s_inoutHelper2D.finalize();
-  int rc3 = s_inoutHelper3D.finalize();
+  // Finalize the inout structures and reset the params
+  int rc = QUEST_INOUT_FAILED;
+  if(dim == 2)
+  {
+    rc = s_inoutHelper2D.finalize();
+  }
+  else  // dim == 3
+  {
+    rc = s_inoutHelper3D.finalize();
+  }
   s_inoutParams.setDefault();
 
-  return (dim == 2) ? rc2 : rc3;
+  return rc;
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/quest/interface/inout.hpp
+++ b/src/axom/quest/interface/inout.hpp
@@ -7,13 +7,13 @@
 #define QUEST_INOUT_INTERFACE_HPP_
 
 // Axom includes
-#include "axom/config.hpp"  // for compile-time configuration options
+#include "axom/config.hpp"
 
 // Quest includes
-#include "axom/quest/interface/internal/mpicomm_wrapper.hpp"  // MPI_COMM_SELF
+#include "axom/quest/interface/internal/mpicomm_wrapper.hpp"
 
 // C/C++ includes
-#include <string>  // for std::string
+#include <string>
 
 /*!
  * \file inout.hpp


### PR DESCRIPTION
# Summary

- This PR is a bugfix for intermittent failure in our gcc@11 CI `quest_inout_interface` Fortran test
- It only calls the `finalize()` function for the dimension (2 or 3) that was initialized