### PR TITLE
Renames some bit/byte operations to match newer C++ standards

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -59,6 +59,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Primal: `intersection_volume()` operators changed from returning a signed
   volume to an unsigned volume.
 - Primal's `BoundingBox::contains(BoundingBox)`  now returns `true` when the input is empty
+- Renamed axom's bit utility functions to conform to `C++20` standard: `popCount() -> popcount()`, 
+  `trailingZeros() -> countr_zero()` and `leadingZeros() -> countl_zero()`
+- Renamed `axom::utilities::swapEndian() -> byteswap()` to conform to `C++23` standard
 
 ### Fixed
 - quest's `SamplingShaper` now properly handles material names containing underscores

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -669,11 +669,11 @@ FlatMap<KeyType, ValueType, Hash>::FlatMap(IndexType bucket_count)
   bucket_count = axom::utilities::max(minBuckets, bucket_count);
   // Get the smallest power-of-two number of groups satisfying:
   // N * GroupSize - 1 >= minBuckets
-  // TODO: we should add a leadingZeros overload for 64-bit integers
+  // TODO: we should add a countl_zero overload for 64-bit integers
   {
     std::int32_t numGroups =
       std::ceil((bucket_count + 1) / (double)BucketsPerGroup);
-    m_numGroups2 = 31 - (axom::utilities::leadingZeros(numGroups));
+    m_numGroups2 = 31 - (axom::utilities::countl_zero(numGroups));
   }
 
   IndexType numGroupsRounded = 1 << m_numGroups2;

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ set(core_serial_tests
 set(core_test_depends
     core
     gtest
+    fmt
     )
 
 #------------------------------------------------------------------------------

--- a/src/axom/core/tests/core_bit_utilities.hpp
+++ b/src/axom/core/tests/core_bit_utilities.hpp
@@ -77,7 +77,7 @@ TEST(core_bit_utilities, trailingZeroes)
   }
 }
 
-TEST(core_bit_utilities, popCount)
+TEST(core_bit_utilities, popcount)
 {
   constexpr std::uint64_t ZERO = std::uint64_t(0);
   constexpr int BITS = axom::utilities::BitTraits<std::uint64_t>::BITS_PER_WORD;
@@ -85,16 +85,16 @@ TEST(core_bit_utilities, popCount)
 
   // Test pop count when zero bits are set
   {
-    EXPECT_EQ(0, axom::utilities::popCount(ZERO));
-    EXPECT_EQ(BITS, axom::utilities::popCount(~ZERO));
+    EXPECT_EQ(0, axom::utilities::popcount(ZERO));
+    EXPECT_EQ(BITS, axom::utilities::popcount(~ZERO));
   }
 
   // Test pop count when one bit is set
   for(int i = 0; i < BITS; ++i)
   {
     std::uint64_t val = ::shifted(i);
-    EXPECT_EQ(1, axom::utilities::popCount(val));
-    EXPECT_EQ(BITS - 1, axom::utilities::popCount(~val));
+    EXPECT_EQ(1, axom::utilities::popcount(val));
+    EXPECT_EQ(BITS - 1, axom::utilities::popcount(~val));
   }
 
   // Test pop count when two bits are set
@@ -103,8 +103,8 @@ TEST(core_bit_utilities, popCount)
     for(int j = 0; j < i; ++j)
     {
       std::uint64_t val = shifted(i) + shifted(j);
-      EXPECT_EQ(2, axom::utilities::popCount(val));
-      EXPECT_EQ(BITS - 2, axom::utilities::popCount(~val));
+      EXPECT_EQ(2, axom::utilities::popcount(val));
+      EXPECT_EQ(BITS - 2, axom::utilities::popcount(~val));
     }
   }
 
@@ -116,8 +116,8 @@ TEST(core_bit_utilities, popCount)
       for(int k = 0; k < j; ++k)
       {
         std::uint64_t val = shifted(i) + shifted(j) + shifted(k);
-        EXPECT_EQ(3, axom::utilities::popCount(val));
-        EXPECT_EQ(BITS - 3, axom::utilities::popCount(~val));
+        EXPECT_EQ(3, axom::utilities::popcount(val));
+        EXPECT_EQ(BITS - 3, axom::utilities::popcount(~val));
       }
     }
   }
@@ -136,7 +136,7 @@ TEST(core_bit_utilities, popCount)
       }
     }
 
-    EXPECT_EQ(bits, axom::utilities::popCount(val));
+    EXPECT_EQ(bits, axom::utilities::popcount(val));
   }
 }
 

--- a/src/axom/core/tests/core_bit_utilities.hpp
+++ b/src/axom/core/tests/core_bit_utilities.hpp
@@ -140,26 +140,26 @@ TEST(core_bit_utilities, popcount)
   }
 }
 
-TEST(core_bit_utilities, leadingZeros)
+TEST(core_bit_utilities, countl_zero)
 {
   constexpr std::int32_t ZERO = std::int32_t(0);
   constexpr int BITS = axom::utilities::BitTraits<std::uint32_t>::BITS_PER_WORD;
   ASSERT_EQ(32, BITS);
 
-  // Axom's leadingZeros will return 32 when given 0
-  EXPECT_EQ(BITS, axom::utilities::leadingZeros(ZERO));
+  // Axom's countl_zero will return 32 when given 0
+  EXPECT_EQ(BITS, axom::utilities::countl_zero(ZERO));
 
   for(int i = 0; i < BITS; ++i)
   {
     std::int32_t val = ::shifted(i);
-    EXPECT_EQ(BITS - i - 1, axom::utilities::leadingZeros(val));
+    EXPECT_EQ(BITS - i - 1, axom::utilities::countl_zero(val));
 
     // Value doesn't change if you set bits to right of leading zero
     for(int j = 0; j < i; ++j)
     {
       std::int32_t val2 = ::shifted(i) + ::shifted(j);
-      EXPECT_EQ(axom::utilities::leadingZeros(val),
-                axom::utilities::leadingZeros(val2));
+      EXPECT_EQ(axom::utilities::countl_zero(val),
+                axom::utilities::countl_zero(val2));
     }
   }
 
@@ -177,6 +177,6 @@ TEST(core_bit_utilities, leadingZeros)
         break;
       }
     }
-    EXPECT_EQ(bit, axom::utilities::leadingZeros(rand_val));
+    EXPECT_EQ(bit, axom::utilities::countl_zero(rand_val));
   }
 }

--- a/src/axom/core/tests/core_bit_utilities.hpp
+++ b/src/axom/core/tests/core_bit_utilities.hpp
@@ -39,23 +39,23 @@ TEST(core_bit_utilities, trailingZeroes)
   constexpr int BITS = axom::utilities::BitTraits<std::uint64_t>::BITS_PER_WORD;
   ASSERT_EQ(64, BITS);
 
-  // Axom's trailingZeros will return 64 when given 0
+  // Axom's countr_zero will return 64 when given 0
   {
-    EXPECT_EQ(BITS, axom::utilities::trailingZeros(ZERO));
+    EXPECT_EQ(BITS, axom::utilities::countr_zero(ZERO));
   }
 
   // Test with a known trailing bit
   for(int i = 0; i < BITS; ++i)
   {
     std::uint64_t val = ::shifted(i);
-    EXPECT_EQ(i, axom::utilities::trailingZeros(val));
+    EXPECT_EQ(i, axom::utilities::countr_zero(val));
 
     // Value doesn't change when you set bits to left of trailing bit
     for(int j = i + 1; j < BITS; ++j)
     {
       std::uint64_t val2 = ::shifted(i) + ::shifted(j);
-      EXPECT_EQ(axom::utilities::trailingZeros(val),
-                axom::utilities::trailingZeros(val2));
+      EXPECT_EQ(axom::utilities::countr_zero(val),
+                axom::utilities::countr_zero(val2));
     }
   }
 
@@ -73,7 +73,7 @@ TEST(core_bit_utilities, trailingZeroes)
         break;
       }
     }
-    EXPECT_EQ(bit, axom::utilities::trailingZeros(rand_val));
+    EXPECT_EQ(bit, axom::utilities::countr_zero(rand_val));
   }
 }
 

--- a/src/axom/core/tests/utils_endianness.hpp
+++ b/src/axom/core/tests/utils_endianness.hpp
@@ -8,6 +8,8 @@
 #include "axom/config.hpp"
 #include "axom/core/utilities/Utilities.hpp"
 
+#include "axom/fmt.hpp"
+
 #include <limits>
 #include <iostream>
 
@@ -19,6 +21,62 @@ TEST(utils_endianness, print_endianness)
 
   std::cout << "System is " << (isLittleEndian ? "little" : "big") << " endian."
             << std::endl;
+}
+
+TEST(utils_endianness, basic)
+{
+  // compare and print the hex value and that of its swapped bytes
+  auto compare_and_dump = [](auto type, auto val) {
+    const auto rev = axom::utilities::byteswap(val);
+    const auto revrev = axom::utilities::byteswap(rev);
+    EXPECT_EQ(val, revrev);
+
+    std::cout << axom::fmt::format("[{}], orig: '0x{:X}'; swapped '0x{:X}'\n",
+                                   type,
+                                   val,
+                                   rev);
+  };
+
+  {
+    constexpr auto orig = std::uint8_t(0xa);
+    compare_and_dump("U8", orig);
+    EXPECT_EQ(orig, axom::utilities::byteswap(orig));
+  }
+
+  {
+    constexpr auto orig = std::uint16_t(0xCAFE);
+    compare_and_dump("U16", orig);
+    EXPECT_NE(orig, axom::utilities::byteswap(orig));
+  }
+
+  {
+    constexpr auto orig = std::uint32_t(0xDEADBEEFu);
+    compare_and_dump("U32", orig);
+    EXPECT_NE(orig, axom::utilities::byteswap(orig));
+  }
+
+  {
+    constexpr auto orig = std::uint64_t {0x0123456789ABCDEFull};
+    compare_and_dump("U64", orig);
+    EXPECT_NE(orig, axom::utilities::byteswap(orig));
+  }
+}
+
+TEST(utils_endianness, endianness_8)
+{
+  {
+    std::int8_t v1 = 5;
+    std::int8_t v2 = axom::utilities::byteswap(v1);
+
+    EXPECT_EQ(v1, v2);
+  }
+
+  {
+    std::uint8_t v1 = 5;
+    std::uint8_t v2 = axom::utilities::byteswap(v1);
+
+    EXPECT_EQ(v1, v2);
+  }
 }
 
 TEST(utils_endianness, endianness_16)
@@ -38,8 +96,8 @@ TEST(utils_endianness, endianness_16)
   // Test short
   {
     short v1 = valOrig.short_val;
-    short v2 = axom::utilities::swapEndian(v1);
-    short v3 = axom::utilities::swapEndian(v2);
+    short v2 = axom::utilities::byteswap(v1);
+    short v3 = axom::utilities::byteswap(v2);
 
     EXPECT_EQ(valOrig.short_val, v1);
     EXPECT_EQ(valSwap.short_val, v2);
@@ -49,8 +107,8 @@ TEST(utils_endianness, endianness_16)
   // Test unsigned short
   {
     unsigned short v1 = valOrig.ushort_val;
-    unsigned short v2 = axom::utilities::swapEndian(v1);
-    unsigned short v3 = axom::utilities::swapEndian(v2);
+    unsigned short v2 = axom::utilities::byteswap(v1);
+    unsigned short v3 = axom::utilities::byteswap(v2);
 
     EXPECT_EQ(valOrig.ushort_val, v1);
     EXPECT_EQ(valSwap.ushort_val, v2);
@@ -60,8 +118,8 @@ TEST(utils_endianness, endianness_16)
   // Test int16
   {
     std::int16_t v1 = valOrig.i_val;
-    std::int16_t v2 = axom::utilities::swapEndian(v1);
-    std::int16_t v3 = axom::utilities::swapEndian(v2);
+    std::int16_t v2 = axom::utilities::byteswap(v1);
+    std::int16_t v3 = axom::utilities::byteswap(v2);
 
     EXPECT_EQ(valOrig.i_val, v1);
     EXPECT_EQ(valSwap.i_val, v2);
@@ -71,8 +129,8 @@ TEST(utils_endianness, endianness_16)
   // Test uint16
   {
     std::uint16_t v1 = valOrig.i_val;
-    std::uint16_t v2 = axom::utilities::swapEndian(v1);
-    std::uint16_t v3 = axom::utilities::swapEndian(v2);
+    std::uint16_t v2 = axom::utilities::byteswap(v1);
+    std::uint16_t v3 = axom::utilities::byteswap(v2);
 
     EXPECT_EQ(valOrig.ui_val, v1);
     EXPECT_EQ(valSwap.ui_val, v2);
@@ -98,8 +156,8 @@ TEST(utils_endianness, endianness_32)
   // Test int
   {
     int v1 = valOrig.int_val;
-    int v2 = axom::utilities::swapEndian(v1);
-    int v3 = axom::utilities::swapEndian(v2);
+    int v2 = axom::utilities::byteswap(v1);
+    int v3 = axom::utilities::byteswap(v2);
 
     EXPECT_EQ(valOrig.int_val, v1);
     EXPECT_EQ(valSwap.int_val, v2);
@@ -109,8 +167,8 @@ TEST(utils_endianness, endianness_32)
   // Test unsigned int
   {
     unsigned int v1 = valOrig.uint_val;
-    unsigned int v2 = axom::utilities::swapEndian(v1);
-    unsigned int v3 = axom::utilities::swapEndian(v2);
+    unsigned int v2 = axom::utilities::byteswap(v1);
+    unsigned int v3 = axom::utilities::byteswap(v2);
 
     EXPECT_EQ(valOrig.uint_val, v1);
     EXPECT_EQ(valSwap.uint_val, v2);
@@ -120,8 +178,8 @@ TEST(utils_endianness, endianness_32)
   // Test int32
   {
     std::int32_t v1 = valOrig.i_val;
-    std::int32_t v2 = axom::utilities::swapEndian(v1);
-    std::int32_t v3 = axom::utilities::swapEndian(v2);
+    std::int32_t v2 = axom::utilities::byteswap(v1);
+    std::int32_t v3 = axom::utilities::byteswap(v2);
 
     EXPECT_EQ(valOrig.i_val, v1);
     EXPECT_EQ(valSwap.i_val, v2);
@@ -131,8 +189,8 @@ TEST(utils_endianness, endianness_32)
   // Test uint32
   {
     std::uint32_t v1 = valOrig.i_val;
-    std::uint32_t v2 = axom::utilities::swapEndian(v1);
-    std::uint32_t v3 = axom::utilities::swapEndian(v2);
+    std::uint32_t v2 = axom::utilities::byteswap(v1);
+    std::uint32_t v3 = axom::utilities::byteswap(v2);
 
     EXPECT_EQ(valOrig.ui_val, v1);
     EXPECT_EQ(valSwap.ui_val, v2);
@@ -142,8 +200,8 @@ TEST(utils_endianness, endianness_32)
   // Test float
   {
     float v1 = valOrig.f_val;
-    float v2 = axom::utilities::swapEndian(v1);
-    float v3 = axom::utilities::swapEndian(v2);
+    float v2 = axom::utilities::byteswap(v1);
+    float v3 = axom::utilities::byteswap(v2);
 
     EXPECT_EQ(valOrig.f_val, v1);
     EXPECT_EQ(valSwap.f_val, v2);
@@ -170,8 +228,8 @@ TEST(utils_endianness, endianness_64)
   // Test int64
   {
     std::int64_t v1 = valOrig.i_val;
-    std::int64_t v2 = axom::utilities::swapEndian(v1);
-    std::int64_t v3 = axom::utilities::swapEndian(v2);
+    std::int64_t v2 = axom::utilities::byteswap(v1);
+    std::int64_t v3 = axom::utilities::byteswap(v2);
 
     EXPECT_EQ(valOrig.i_val, v1);
     EXPECT_EQ(valSwap.i_val, v2);
@@ -181,8 +239,8 @@ TEST(utils_endianness, endianness_64)
   // Test uint64
   {
     std::uint64_t v1 = valOrig.i_val;
-    std::uint64_t v2 = axom::utilities::swapEndian(v1);
-    std::uint64_t v3 = axom::utilities::swapEndian(v2);
+    std::uint64_t v2 = axom::utilities::byteswap(v1);
+    std::uint64_t v3 = axom::utilities::byteswap(v2);
 
     EXPECT_EQ(valOrig.ui_val, v1);
     EXPECT_EQ(valSwap.ui_val, v2);
@@ -193,8 +251,8 @@ TEST(utils_endianness, endianness_64)
   // Test double
   {
     double v1 = valOrig.d_val;
-    double v2 = axom::utilities::swapEndian(v1);
-    double v3 = axom::utilities::swapEndian(v2);
+    double v2 = axom::utilities::byteswap(v1);
+    double v3 = axom::utilities::byteswap(v2);
 
     EXPECT_EQ(valOrig.d_val, v1);
     EXPECT_EQ(valSwap.d_val, v2);
@@ -203,28 +261,7 @@ TEST(utils_endianness, endianness_64)
 }
 
 #if 0
-// Note: Checks that swapEndian static_asserts for types within invalid sizes.
-//       Commented out since it should lead to a compile error
-TEST(utils_endianness,invalid_byte_width)
-{
-  {
-    std::int8_t v1 = 5;
-    std::int8_t v2 = axom::utilities::swapEndian(v1);
-
-    EXPECT_EQ(v1, v2);
-  }
-
-  {
-    std::uint8_t v1 = 5;
-    std::uint8_t v2 = axom::utilities::swapEndian(v1);
-
-    EXPECT_EQ(v1, v2);
-  }
-}
-#endif
-
-#if 0
-// Note: Checks that swapEndian static_asserts for non-native types.
+// Note: Checks that byteswap static_asserts for non-native types.
 //       Commented out since it should lead to a compile error.
 TEST(utils_endianness,invalid_non_native_types)
 {
@@ -238,7 +275,7 @@ TEST(utils_endianness,invalid_non_native_types)
   v1.a = 5;
   v1.b = 12;
 
-  AxomUtilsTestsNonNative v2 = axom::utilities::swapEndian(v1);
+  AxomUtilsTestsNonNative v2 = axom::utilities::byteswap(v1);
 
   EXPECT_NE(v1.a, v2.a);
   EXPECT_NE(v1.b, v2.b);

--- a/src/axom/core/utilities/BitUtilities.hpp
+++ b/src/axom/core/utilities/BitUtilities.hpp
@@ -84,7 +84,7 @@ struct BitTraits<std::uint8_t>
  * \return The number of zeros to the right of the first set bit in \word,
  * starting with the least significant bit, or 64 if \a word == 0.
  */
-AXOM_HOST_DEVICE inline int trailingZeros(std::uint64_t word)
+AXOM_HOST_DEVICE inline constexpr int countr_zero(std::uint64_t word) noexcept
 {
   /* clang-format off */
 #if defined(__CUDA_ARCH__) && defined(AXOM_USE_CUDA)

--- a/src/axom/core/utilities/BitUtilities.hpp
+++ b/src/axom/core/utilities/BitUtilities.hpp
@@ -160,7 +160,7 @@ AXOM_HOST_DEVICE inline constexpr int popcount(std::uint64_t word) noexcept
  * \return The number of zeros to the left of the first set bit in \word,
  * starting with the least significant bit.
  */
-AXOM_HOST_DEVICE inline std::int32_t leadingZeros(std::int32_t word)
+AXOM_HOST_DEVICE inline constexpr std::int32_t countl_zero(std::int32_t word) noexcept
 {
   /* clang-format off */
 #if defined(__CUDA_ARCH__) && defined(AXOM_USE_CUDA)

--- a/src/axom/core/utilities/BitUtilities.hpp
+++ b/src/axom/core/utilities/BitUtilities.hpp
@@ -121,7 +121,7 @@ AXOM_HOST_DEVICE inline int trailingZeros(std::uint64_t word)
  * \accelerated
  * \return number of bits in \a word that are set to 1
  */
-AXOM_HOST_DEVICE inline int popCount(std::uint64_t word)
+AXOM_HOST_DEVICE inline constexpr int popcount(std::uint64_t word) noexcept
 {
   /* clang-format off */
 #if defined(__CUDA_ARCH__) && defined(AXOM_USE_CUDA)

--- a/src/axom/core/utilities/BitUtilities.hpp
+++ b/src/axom/core/utilities/BitUtilities.hpp
@@ -84,7 +84,7 @@ struct BitTraits<std::uint8_t>
  * \return The number of zeros to the right of the first set bit in \word,
  * starting with the least significant bit, or 64 if \a word == 0.
  */
-AXOM_HOST_DEVICE inline constexpr int countr_zero(std::uint64_t word) noexcept
+AXOM_HOST_DEVICE inline int countr_zero(std::uint64_t word) noexcept
 {
   /* clang-format off */
 #if defined(__CUDA_ARCH__) && defined(AXOM_USE_CUDA)
@@ -121,7 +121,7 @@ AXOM_HOST_DEVICE inline constexpr int countr_zero(std::uint64_t word) noexcept
  * \accelerated
  * \return number of bits in \a word that are set to 1
  */
-AXOM_HOST_DEVICE inline constexpr int popcount(std::uint64_t word) noexcept
+AXOM_HOST_DEVICE inline int popcount(std::uint64_t word) noexcept
 {
   /* clang-format off */
 #if defined(__CUDA_ARCH__) && defined(AXOM_USE_CUDA)
@@ -160,7 +160,7 @@ AXOM_HOST_DEVICE inline constexpr int popcount(std::uint64_t word) noexcept
  * \return The number of zeros to the left of the first set bit in \word,
  * starting with the least significant bit.
  */
-AXOM_HOST_DEVICE inline constexpr std::int32_t countl_zero(std::int32_t word) noexcept
+AXOM_HOST_DEVICE inline std::int32_t countl_zero(std::int32_t word) noexcept
 {
   /* clang-format off */
 #if defined(__CUDA_ARCH__) && defined(AXOM_USE_CUDA)
@@ -172,7 +172,7 @@ AXOM_HOST_DEVICE inline constexpr std::int32_t countl_zero(std::int32_t word) no
 #elif defined(_AXOM_CORE_USE_INTRINSICS_GCC) || defined(_AXOM_CORE_USE_INTRINSICS_PPC)
   return word != std::int32_t(0) ? __builtin_clz(word) : 32;
 #else
-  std::int32_t y;
+  std::int32_t y {};
   std::int32_t n = 32;
   y = word >> 16; if(y != 0) { n -= 16; word = y;}
   y = word >>  8; if(y != 0) { n -=  8; word = y;}

--- a/src/axom/core/utilities/Utilities.hpp
+++ b/src/axom/core/utilities/Utilities.hpp
@@ -265,24 +265,24 @@ inline bool isLittleEndian()
 }
 
 /*!
- * \brief Swaps the endianness of the input value.
- * \param [in] val The input value.
- * \return The value with endianness swapped.
+ * \brief Reverses the bytes of the input value.
+ * \param [in] val The input value
+ * \return The value with swapped bytes
  * \note Assumes endianness is either little or big (not PDP).
  * \pre T is a native arithmetic type (i.e. integral or floating point).
- * \pre sizeof(T) must be 2, 4, or 8 bytes.
+ * \pre sizeof(T) must be 1, 2, 4, or 8 bytes.
  */
 template <typename T>
-T swapEndian(T val)
+constexpr T byteswap(T val) noexcept
 {
-  const int NBYTES = sizeof(T);
+  constexpr int NBYTES = sizeof(T);
 
   AXOM_STATIC_ASSERT_MSG(
-    NBYTES == 2 || NBYTES == 4 || NBYTES == 8,
-    "swapEndian only valid for types of size 2, 4 or 8 bytes.");
+    NBYTES == 1 || NBYTES == 2 || NBYTES == 4 || NBYTES == 8,
+    "byteswap only valid for types of size 1, 2, 4 or 8 bytes.");
 
   AXOM_STATIC_ASSERT_MSG(std::is_arithmetic<T>::value,
-                         "swapEndian only valid for native arithmetic types");
+                         "byteswap only valid for native arithmetic types");
 
   union
   {

--- a/src/axom/lumberjack/TextTagCombiner.hpp
+++ b/src/axom/lumberjack/TextTagCombiner.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
 // other Axom Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)

--- a/src/axom/lumberjack/tests/lumberjack_TextTagCombiner.hpp
+++ b/src/axom/lumberjack/tests/lumberjack_TextTagCombiner.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
 // other Axom Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)

--- a/src/axom/quest/examples/quest_proe_bbox.cpp
+++ b/src/axom/quest/examples/quest_proe_bbox.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023, Lawrence Livermore National Security, LLC and
+// Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
 // other Axom Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)

--- a/src/axom/quest/readers/STLReader.cpp
+++ b/src/axom/quest/readers/STLReader.cpp
@@ -74,7 +74,7 @@ bool STLReader::isAsciiFormat() const
 
   if(!utilities::isLittleEndian())
   {
-    numTris = utilities::swapEndian(numTris);
+    numTris = utilities::byteswap(numTris);
   }
 
   // Check if the size matches our expectation
@@ -166,7 +166,7 @@ int STLReader::readBinarySTL()
 
   if(!isLittleEndian)
   {
-    m_num_faces = utilities::swapEndian(m_num_faces);
+    m_num_faces = utilities::byteswap(m_num_faces);
   }
 
   m_num_nodes = m_num_faces * 3;
@@ -180,7 +180,7 @@ int STLReader::readBinarySTL()
     for(int j = 0; j < 9; ++j)
     {
       float coord = isLittleEndian ? tri.data.vert[j]
-                                   : utilities::swapEndian(tri.data.vert[j]);
+                                   : utilities::byteswap(tri.data.vert[j]);
 
       m_nodes.push_back(static_cast<double>(coord));
     }

--- a/src/axom/slam/BitSet.cpp
+++ b/src/axom/slam/BitSet.cpp
@@ -130,7 +130,7 @@ BitSet::Index BitSet::find_next(Index idx) const
     if(startWord != Word(0))
     {
       return (startWordIdx * BitsPerWord) +
-        axom::utilities::trailingZeros(startWord << startOffset);
+        axom::utilities::countr_zero(startWord << startOffset);
     }
 
     ++startWordIdx;
@@ -142,7 +142,7 @@ BitSet::Index BitSet::find_next(Index idx) const
     const Word& w = m_data[i];
     if(w != Word(0))
     {
-      return (i * BitsPerWord) + axom::utilities::trailingZeros(w);
+      return (i * BitsPerWord) + axom::utilities::countr_zero(w);
     }
   }
   return BitSet::npos;

--- a/src/axom/slam/BitSet.cpp
+++ b/src/axom/slam/BitSet.cpp
@@ -59,7 +59,7 @@ int BitSet::count() const
 
   for(int i = 0; i < m_data.size(); ++i)
   {
-    ctr += axom::utilities::popCount(m_data[i]);
+    ctr += axom::utilities::popcount(m_data[i]);
   }
   return ctr;
 }

--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -1058,8 +1058,7 @@ ImplicitGrid<NDIMS, ExecSpace, IndexType>::QueryObject::visitCandidates(
     {
       continue;
     }
-    // currWord now contains the resulting candidacy information
-    // for our given point
+    // currWord now contains the resulting candidacy information for our given point
     int numBits = axom::utilities::min(bitsPerWord, nbits - (iword * 64));
     int currBit = axom::utilities::countr_zero(currWord);
     while(currBit < numBits)

--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -1061,13 +1061,13 @@ ImplicitGrid<NDIMS, ExecSpace, IndexType>::QueryObject::visitCandidates(
     // currWord now contains the resulting candidacy information
     // for our given point
     int numBits = axom::utilities::min(bitsPerWord, nbits - (iword * 64));
-    int currBit = axom::utilities::trailingZeros(currWord);
+    int currBit = axom::utilities::countr_zero(currWord);
     while(currBit < numBits)
     {
       bool found = getVisitResult(candidatePredicate,
                                   iword * BitsetType::BitsPerWord + currBit);
       currBit++;
-      currBit += axom::utilities::trailingZeros(currWord >> currBit);
+      currBit += axom::utilities::countr_zero(currWord >> currBit);
       if(found)
       {
         return;
@@ -1131,13 +1131,13 @@ ImplicitGrid<NDIMS, ExecSpace, IndexType>::QueryObject::visitCandidates(
     // currWord now contains the resulting candidacy information
     // for our given point
     int numBits = axom::utilities::min(bitsPerWord, nbits - (iword * 64));
-    int currBit = axom::utilities::trailingZeros(currWord);
+    int currBit = axom::utilities::countr_zero(currWord);
     while(currBit < numBits)
     {
       bool found = getVisitResult(candidatePredicate,
                                   iword * BitsetType::BitsPerWord + currBit);
       currBit++;
-      currBit += axom::utilities::trailingZeros(currWord >> currBit);
+      currBit += axom::utilities::countr_zero(currWord >> currBit);
       if(found)
       {
         return;

--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -7,13 +7,13 @@
 #define AXOM_SPIN_IMPLICIT_GRID__HPP_
 
 #include "axom/config.hpp"
-#include "axom/core.hpp"  // for clamp functions
+#include "axom/core.hpp"
 #include "axom/slic.hpp"
 #include "axom/slam.hpp"
 
-#include "axom/core/execution/execution_space.hpp"  // for execution spaces
-#include "axom/core/memory_management.hpp"          // for setDefaultAllocator()
-#include "axom/core/utilities/BitUtilities.hpp"     // for popCount()
+#include "axom/core/execution/execution_space.hpp"
+#include "axom/core/memory_management.hpp"
+#include "axom/core/utilities/BitUtilities.hpp"
 
 #include "axom/primal/geometry/BoundingBox.hpp"
 #include "axom/primal/geometry/Point.hpp"
@@ -953,9 +953,8 @@ ImplicitGrid<NDIMS, ExecSpace, IndexType>::QueryObject::countCandidates(
     {
       continue;
     }
-    // currWord now contains the resulting candidacy information
-    // for our given point
-    ncandidates += axom::utilities::popCount(currWord);
+    // currWord now contains the resulting candidacy information for our given point
+    ncandidates += axom::utilities::popcount(currWord);
   }
   return ncandidates;
 }
@@ -1009,9 +1008,8 @@ ImplicitGrid<NDIMS, ExecSpace, IndexType>::QueryObject::countCandidates(
     {
       continue;
     }
-    // currWord now contains the resulting candidacy information
-    // for our given point
-    ncandidates += axom::utilities::popCount(currWord);
+    // currWord now contains the resulting candidacy information for our given point
+    ncandidates += axom::utilities::popcount(currWord);
   }
   return ncandidates;
 }

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -6,12 +6,12 @@
 #ifndef AXOM_SPIN_BUILD_RADIX_TREE_H_
 #define AXOM_SPIN_BUILD_RADIX_TREE_H_
 
-#include "axom/config.hpp"  // for axom compile-time definitions
+#include "axom/config.hpp"
 
 #include "axom/core/execution/execution_space.hpp"
 #include "axom/core/execution/for_all.hpp"
 
-#include "axom/core/utilities/AnnotationMacros.hpp"  // for annotations
+#include "axom/core/utilities/AnnotationMacros.hpp"
 
 #include "axom/primal/geometry/BoundingBox.hpp"
 #include "axom/primal/geometry/Point.hpp"
@@ -20,16 +20,16 @@
 
 #include "axom/spin/MortonIndex.hpp"
 
-#include "axom/core/utilities/Utilities.hpp"     // for isNearlyEqual()
-#include "axom/core/utilities/BitUtilities.hpp"  // for leadingZeros()
-#include "axom/slic/interface/slic.hpp"          // for slic
+#include "axom/core/utilities/Utilities.hpp"
+#include "axom/core/utilities/BitUtilities.hpp"
+#include "axom/slic/interface/slic.hpp"
 
 #if defined(AXOM_USE_RAJA)
   // RAJA includes
   #include "RAJA/RAJA.hpp"
 #endif
 
-#include <atomic>  // For std::atomic_thread_fence
+#include <atomic>
 
 #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA)
   // NOTE: uses the cub installation that is  bundled with RAJA
@@ -300,7 +300,7 @@ AXOM_HOST_DEVICE IntType delta(const IntType& a,
   tie = (exor == 0);
   //break the tie, a and b must always differ
   exor = tie ? std::uint32_t(a) ^ std::uint32_t(bb) : exor;
-  std::int32_t count = axom::utilities::leadingZeros(exor);
+  std::int32_t count = axom::utilities::countl_zero(exor);
   if(tie)
   {
     count += 32;


### PR DESCRIPTION
# Summary

- This is a maintenance PR
- It renames several functions in the `axom::utilities` namespace that have recently been added to the `c++20` and `c++23` standards
- Specifically
  - `popCount() -> popcount()`
  - `trailingZeros() -> countr_zero()` 
  - `leadingZeros() -> countl_zero()`
  - `swapEndian() -> byteswap()`

- Resolves #762