### PR TITLE
using-with-cmake example cmake version 

### DIFF
--- a/.gitlab/build_rzansel.yml
+++ b/.gitlab/build_rzansel.yml
@@ -12,7 +12,7 @@
     - rzansel
   before_script:
     - module load cuda/11.2.0
-    - module load cmake/3.18.0
+    - module load cmake/3.21.1
 
 ####
 # Template

--- a/src/examples/using-with-cmake/CMakeLists.txt
+++ b/src/examples/using-with-cmake/CMakeLists.txt
@@ -20,7 +20,7 @@
 #
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.20)
 
 project(using_with_cmake)
 

--- a/src/examples/using-with-cmake/CMakeLists.txt
+++ b/src/examples/using-with-cmake/CMakeLists.txt
@@ -20,7 +20,7 @@
 #
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.18)
 
 project(using_with_cmake)
 
@@ -68,14 +68,6 @@ if(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE)
                      ${BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE})
     list(REMOVE_ITEM CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES
                      ${BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE})
-endif()
-
-# HACK: Define the `mpi` target as an alias to `axom::mpi` if/when necessary
-# Details: An axom dependency has a link dependency to `mpi`, but it might
-# not be a target. Need to mark axom::mpi as global to use it for an alias.
-if(NOT TARGET mpi AND TARGET axom::mpi)
-    set_target_properties(axom::mpi PROPERTIES IMPORTED_GLOBAL TRUE)
-    add_library(mpi ALIAS axom::mpi)
 endif()
 
 #------------------------------------------------------------------------------

--- a/src/examples/using-with-cmake/CMakeLists.txt
+++ b/src/examples/using-with-cmake/CMakeLists.txt
@@ -20,7 +20,11 @@
 #
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.20)
+if (ENABLE_HIP OR AXOM_ENABLE_HIP OR ENABLE_CUDA OR AXOM_ENABLE_CUDA)
+    cmake_minimum_required(VERSION 3.21)
+else()
+    cmake_minimum_required(VERSION 3.18)
+endif()
 
 project(using_with_cmake)
 


### PR DESCRIPTION
This PR:
- Bumps up the `cmake_minimum_required` version for the using-with-cmake examples.