### PR TITLE
Fix a link issue with Clang 16 + CUDA

### DIFF
--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -1038,7 +1038,7 @@ AXOM_HOST_DEVICE Array<T, DIM, SPACE>::Array(const Array& other)
     "Use axom::ArrayView for value captures instead.\n");
   #endif
   #if defined(__CUDA_ARCH__)
-    assert(false);
+  assert(false);
   #endif
 #else
   initialize(other.size(), other.capacity());

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -1038,7 +1038,7 @@ AXOM_HOST_DEVICE Array<T, DIM, SPACE>::Array(const Array& other)
     "Use axom::ArrayView for value captures instead.\n");
   #endif
   #if defined(__CUDA_ARCH__)
-  __trap();
+    assert(false);
   #endif
 #else
   initialize(other.size(), other.capacity());
@@ -1539,7 +1539,7 @@ AXOM_DEVICE inline IndexType Array<T, DIM, SPACE>::reserveForDeviceInsert(IndexT
       "on the device.\n");
   #endif
   #ifdef AXOM_USE_CUDA
-    __trap();
+    assert(false);
   #elif defined(AXOM_USE_HIP)
     abort();
   #endif

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -66,7 +66,8 @@ using MyTypes = ::testing::Types<
 TYPED_TEST_SUITE(core_array_for_all, MyTypes);
 
 //------------------------------------------------------------------------------
-#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE) && defined(AXOM_DEBUG)
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && \
+  defined(AXOM_USE_UMPIRE) && defined(AXOM_DEBUG)
 AXOM_CUDA_TEST(core_array_for_all, capture_test)
 {
   using ExecSpace = axom::CUDA_EXEC<256>;

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -66,7 +66,7 @@ using MyTypes = ::testing::Types<
 TYPED_TEST_SUITE(core_array_for_all, MyTypes);
 
 //------------------------------------------------------------------------------
-#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE) && defined(AXOM_DEBUG)
 AXOM_CUDA_TEST(core_array_for_all, capture_test)
 {
   using ExecSpace = axom::CUDA_EXEC<256>;


### PR DESCRIPTION
A user is seeing an issue with a "missing `__ppc_trap()` symbol" link error when using Clang 16 + CUDA 11.2. Replace this with `assert(false)`, which should serve a similar purpose in a debug build.