### PR TITLE
Set default allocator id to device instead of unified for CUDA and HIP execution policies

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -32,6 +32,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Primal: Makes several primitive methods available in device code
 
 ### Changed
+- Set default Umpire allocator id to device instead of unified for CUDA and HIP execution policies.
 - Upgrades `vcpkg` usage for axom's automated Windows builds to its
   [2024.03.19 release](https://github.com/microsoft/vcpkg/releases/tag/2024.03.19).
   Also updates vcpkg port versions for axom dependencies. Temporarily removes `umpire`

--- a/src/axom/core/examples/core_acceleration.cpp
+++ b/src/axom/core/examples/core_acceleration.cpp
@@ -182,8 +182,7 @@ void demoAxomExecution()
   //_gpu_atomic_start
   using atomic_pol = typename axom::execution_space<ExecSpace>::atomic_policy;
 
-  int *sum =
-    axom::allocate<int>(1, axom::execution_space<ExecSpace>::allocatorID());
+  int *sum = axom::allocate<int>(1, allocator_id);
   *sum = 0;
 
   // Increment sum 100 times
@@ -193,6 +192,8 @@ void demoAxomExecution()
 
   std::cout << "\nTotal Atomic Sum (" << axom::execution_space<ExecSpace>::name()
             << ") :" << sum[0] << std::endl;
+
+  axom::deallocate(sum);
   //_gpu_atomic_end
 
 #endif

--- a/src/axom/core/execution/internal/cuda_exec.hpp
+++ b/src/axom/core/execution/internal/cuda_exec.hpp
@@ -63,7 +63,7 @@ struct execution_space<CUDA_EXEC<BLOCK_SIZE, SYNCHRONOUS>>
   static constexpr char* name() noexcept { return (char*)"[CUDA_EXEC]"; }
   static int allocatorID() noexcept
   {
-    return axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+    return axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   }
 };
 
@@ -93,7 +93,7 @@ struct execution_space<CUDA_EXEC<BLOCK_SIZE, ASYNC>>
   }
   static int allocatorID() noexcept
   {
-    return axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+    return axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   }
 };
 }  // namespace axom

--- a/src/axom/core/execution/internal/hip_exec.hpp
+++ b/src/axom/core/execution/internal/hip_exec.hpp
@@ -61,7 +61,7 @@ struct execution_space<HIP_EXEC<BLOCK_SIZE, SYNCHRONOUS>>
   static constexpr char* name() noexcept { return (char*)"[HIP_EXEC]"; }
   static int allocatorID() noexcept
   {
-    return axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+    return axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   }
 };
 
@@ -88,7 +88,7 @@ struct execution_space<HIP_EXEC<BLOCK_SIZE, ASYNC>>
   static constexpr char* name() noexcept { return (char*)"[HIP_EXEC] (async)"; }
   static int allocatorID() noexcept
   {
-    return axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+    return axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   }
 };
 }  // namespace axom

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -1205,7 +1205,8 @@ AXOM_TYPED_TEST(core_array_for_all, device_insert)
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
 #if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-  // Use unified memory
+  // Use unified memory for frequent movement between device operations
+  // and value checking on host
   if(axom::execution_space<ExecSpace>::onDevice())
   {
     kernelAllocID = axom::getUmpireResourceAllocatorID(

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -1203,13 +1203,15 @@ AXOM_TYPED_TEST(core_array_for_all, device_insert)
   using DynamicArrayOfArrays =
     typename TestFixture::template DynamicTArray<DynamicArray>;
 
+  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   // Use unified memory
-  constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
-  int kernelAllocID = on_device
-    ? axom::getUmpireResourceAllocatorID(
-        umpire::resource::MemoryResourceType::Unified)
-    : axom::getUmpireResourceAllocatorID(
-        umpire::resource::MemoryResourceType::Host);
+  if(axom::execution_space<ExecSpace>::onDevice())
+  {
+    kernelAllocID = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
+  }
+#endif
 
   constexpr axom::IndexType N = 374;
 

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -1203,7 +1203,9 @@ AXOM_TYPED_TEST(core_array_for_all, device_insert)
   using DynamicArrayOfArrays =
     typename TestFixture::template DynamicTArray<DynamicArray>;
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
+  // Use unified memory
+  int kernelAllocID = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
 
   constexpr axom::IndexType N = 374;
 

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -1204,8 +1204,12 @@ AXOM_TYPED_TEST(core_array_for_all, device_insert)
     typename TestFixture::template DynamicTArray<DynamicArray>;
 
   // Use unified memory
-  int kernelAllocID = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
+  constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
+  int kernelAllocID = on_device
+    ? axom::getUmpireResourceAllocatorID(
+        umpire::resource::MemoryResourceType::Unified)
+    : axom::getUmpireResourceAllocatorID(
+        umpire::resource::MemoryResourceType::Host);
 
   constexpr axom::IndexType N = 374;
 

--- a/src/axom/core/tests/core_array_for_all.hpp
+++ b/src/axom/core/tests/core_array_for_all.hpp
@@ -1207,11 +1207,8 @@ AXOM_TYPED_TEST(core_array_for_all, device_insert)
 #if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   // Use unified memory for frequent movement between device operations
   // and value checking on host
-  if(axom::execution_space<ExecSpace>::onDevice())
-  {
-    kernelAllocID = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-  }
+  kernelAllocID = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
 #endif
 
   constexpr axom::IndexType N = 374;

--- a/src/axom/core/tests/core_execution_for_all.hpp
+++ b/src/axom/core/tests/core_execution_for_all.hpp
@@ -31,7 +31,6 @@ void check_for_all()
   constexpr int VALUE_1 = -42;
   constexpr int VALUE_2 = 42;
   constexpr int N = 256;
-  const int HOST_ID = axom::getUmpireResourceAllocatorID(umpire::resource::Host);
 
   // STEP 1: set default allocator for the execution space
   const int currentAllocatorID = axom::getDefaultAllocatorID();
@@ -51,7 +50,7 @@ void check_for_all()
   }
 
   // STEP 2: check array
-  int* a_host = axom::allocate<int>(N, HOST_ID);
+  int* a_host = axom::allocate<int>(N, currentAllocatorID);
   axom::copy(a_host, a, N * sizeof(int));
 
   for(int i = 0; i < N; ++i)

--- a/src/axom/core/tests/core_execution_for_all.hpp
+++ b/src/axom/core/tests/core_execution_for_all.hpp
@@ -31,6 +31,7 @@ void check_for_all()
   constexpr int VALUE_1 = -42;
   constexpr int VALUE_2 = 42;
   constexpr int N = 256;
+  const int HOST_ID = axom::getUmpireResourceAllocatorID(umpire::resource::Host);
 
   // STEP 1: set default allocator for the execution space
   const int currentAllocatorID = axom::getDefaultAllocatorID();
@@ -50,9 +51,12 @@ void check_for_all()
   }
 
   // STEP 2: check array
+  int* a_host = axom::allocate<int>(N, HOST_ID);
+  axom::copy(a_host, a, N * sizeof(int));
+
   for(int i = 0; i < N; ++i)
   {
-    EXPECT_EQ(a[i], VALUE_1);
+    EXPECT_EQ(a_host[i], VALUE_1);
   }
 
   // STEP 3: add VALUE_2 to all entries resulting to zero
@@ -67,13 +71,16 @@ void check_for_all()
   }
 
   // STEP 4: check result
+  axom::copy(a_host, a, N * sizeof(int));
+
   for(int i = 0; i < N; ++i)
   {
-    EXPECT_EQ(a[i], 0);
+    EXPECT_EQ(a_host[i], 0);
   }
 
   // STEP 5: cleanup
   axom::deallocate(a);
+  axom::deallocate(a_host);
 
   axom::setDefaultAllocator(currentAllocatorID);
 }

--- a/src/axom/core/tests/core_execution_for_all.hpp
+++ b/src/axom/core/tests/core_execution_for_all.hpp
@@ -32,12 +32,12 @@ void check_for_all()
   constexpr int VALUE_2 = 42;
   constexpr int N = 256;
 
-  // STEP 1: set default allocator for the execution space
-  const int currentAllocatorID = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+  // STEP 1: set allocators for the execution spaces
+  const int hostID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int allocID = axom::execution_space<ExecSpace>::allocatorID();
 
   // STEP 0: allocate buffer
-  int* a = axom::allocate<int>(N);
+  int* a = axom::allocate<int>(N, allocID);
 
   // STEP 1: initialize to VALUE_1
   axom::for_all<ExecSpace>(
@@ -50,7 +50,7 @@ void check_for_all()
   }
 
   // STEP 2: check array
-  int* a_host = axom::allocate<int>(N, currentAllocatorID);
+  int* a_host = axom::allocate<int>(N, hostID);
   axom::copy(a_host, a, N * sizeof(int));
 
   for(int i = 0; i < N; ++i)
@@ -80,8 +80,6 @@ void check_for_all()
   // STEP 5: cleanup
   axom::deallocate(a);
   axom::deallocate(a_host);
-
-  axom::setDefaultAllocator(currentAllocatorID);
 }
 
 } /* end anonymous namespace */

--- a/src/axom/core/tests/core_execution_space.hpp
+++ b/src/axom/core/tests/core_execution_space.hpp
@@ -183,8 +183,7 @@ TEST(core_execution_space, check_cuda_exec)
   constexpr bool IS_ASYNC = false;
   constexpr bool ON_DEVICE = true;
 
-  int allocator_id =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  int allocator_id = axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   check_execution_mappings<axom::CUDA_EXEC<BLOCK_SIZE>,
                            RAJA::cuda_exec<BLOCK_SIZE>,
                            RAJA::cuda_reduce,
@@ -204,8 +203,7 @@ TEST(core_execution_space, check_cuda_exec_async)
   constexpr bool IS_ASYNC = true;
   constexpr bool ON_DEVICE = true;
 
-  int allocator_id =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  int allocator_id = axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   check_execution_mappings<axom::CUDA_EXEC<BLOCK_SIZE, axom::ASYNC>,
                            RAJA::cuda_exec_async<BLOCK_SIZE>,
                            RAJA::cuda_reduce,
@@ -228,8 +226,7 @@ TEST(core_execution_space, check_hip_exec)
   constexpr bool IS_ASYNC = false;
   constexpr bool ON_DEVICE = true;
 
-  int allocator_id =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  int allocator_id = axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   check_execution_mappings<axom::HIP_EXEC<BLOCK_SIZE>,
                            RAJA::hip_exec<BLOCK_SIZE>,
                            RAJA::hip_reduce,
@@ -249,8 +246,7 @@ TEST(core_execution_space, check_hip_exec_async)
   constexpr bool IS_ASYNC = true;
   constexpr bool ON_DEVICE = true;
 
-  int allocator_id =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  int allocator_id = axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   check_execution_mappings<axom::HIP_EXEC<BLOCK_SIZE, axom::ASYNC>,
                            RAJA::hip_exec_async<BLOCK_SIZE>,
                            RAJA::hip_reduce,

--- a/src/axom/mint/tests/mint_execution_cell_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_cell_traversals.cpp
@@ -378,7 +378,9 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_nodeids)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -396,7 +398,9 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_nodeids)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -441,7 +445,9 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_coords)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -459,7 +465,9 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_coords)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -504,7 +512,9 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_faceids)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -522,7 +532,9 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_faceids)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -561,7 +573,9 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_ij)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
   const int prev_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator(exec_space_id);
 
@@ -577,7 +591,9 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_ij)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
   const int prev_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator(exec_space_id);
 
@@ -612,7 +628,9 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_ijk)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
   const int prev_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator(exec_space_id);
 
@@ -628,7 +646,9 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_ijk)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
   const int prev_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator(exec_space_id);
 
@@ -670,7 +690,9 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_index)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -688,7 +710,10 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_index)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
+
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 

--- a/src/axom/mint/tests/mint_execution_cell_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_cell_traversals.cpp
@@ -30,6 +30,22 @@ namespace mint
 //------------------------------------------------------------------------------
 namespace
 {
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE) &&   \
+  ((defined(AXOM_USE_CUDA) && defined(RAJA_ENABLE_CUDA)) || \
+   (defined(AXOM_USE_HIP) && defined(RAJA_ENABLE_HIP)))
+
+int set_um_memory_return_previous_allocator()
+{
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
+  const int prev_allocator = axom::getDefaultAllocatorID();
+  axom::setDefaultAllocator(exec_space_id);
+  return prev_allocator;
+}
+
+#endif
+
 template <typename ExecPolicy, int MeshType, int Topology = SINGLE_SHAPE>
 void check_for_all_cells_idx(int dimension)
 {
@@ -378,11 +394,7 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_nodeids)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_cell_nodes<cuda_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cell_nodes<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(i);
@@ -398,11 +410,7 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_nodeids)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_cell_nodes<hip_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cell_nodes<hip_exec, STRUCTURED_CURVILINEAR_MESH>(i);
@@ -445,11 +453,7 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_coords)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_cell_coords<cuda_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cell_coords<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(i);
@@ -465,11 +469,7 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_coords)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_cell_coords<hip_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cell_coords<hip_exec, STRUCTURED_CURVILINEAR_MESH>(i);
@@ -512,11 +512,7 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_faceids)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_cell_faces<cuda_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cell_faces<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(i);
@@ -532,11 +528,7 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_faceids)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_cell_faces<hip_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cell_faces<hip_exec, STRUCTURED_CURVILINEAR_MESH>(i);
@@ -573,11 +565,7 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_ij)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
+  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_cells_ij<cuda_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_cells_ij<cuda_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -591,11 +579,7 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_ij)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
+  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_cells_ij<hip_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_cells_ij<hip_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -628,11 +612,7 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_ijk)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
+  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_cells_ijk<cuda_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_cells_ijk<cuda_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -646,11 +626,7 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_ijk)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
+  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_cells_ijk<hip_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_cells_ijk<hip_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -690,11 +666,7 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_index)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_cells_idx<cuda_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cells_idx<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(i);
@@ -710,12 +682,7 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_index)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_cells_idx<hip_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cells_idx<hip_exec, STRUCTURED_CURVILINEAR_MESH>(i);

--- a/src/axom/mint/tests/mint_execution_face_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_face_traversals.cpp
@@ -273,7 +273,9 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_nodeids)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -291,7 +293,9 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_nodeids)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -335,7 +339,9 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_coords)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -353,7 +359,9 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_coords)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -397,7 +405,9 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_cellids)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -415,7 +425,9 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_cellids)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -460,7 +472,9 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_faces_index)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -478,7 +492,9 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_faces_index)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 

--- a/src/axom/mint/tests/mint_execution_face_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_face_traversals.cpp
@@ -28,6 +28,22 @@ namespace mint
 //------------------------------------------------------------------------------
 namespace
 {
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE) &&   \
+  ((defined(AXOM_USE_CUDA) && defined(RAJA_ENABLE_CUDA)) || \
+   (defined(AXOM_USE_HIP) && defined(RAJA_ENABLE_HIP)))
+
+int set_um_memory_return_previous_allocator()
+{
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
+  const int prev_allocator = axom::getDefaultAllocatorID();
+  axom::setDefaultAllocator(exec_space_id);
+  return prev_allocator;
+}
+
+#endif
+
 template <typename ExecPolicy, int MeshType, int Topology = SINGLE_SHAPE>
 void check_for_all_faces(int dimension)
 {
@@ -273,11 +289,7 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_nodeids)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_face_nodes<cuda_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_face_nodes<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
@@ -293,11 +305,7 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_nodeids)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_face_nodes<hip_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_face_nodes<hip_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
@@ -339,11 +347,7 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_coords)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_face_coords<cuda_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_face_coords<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
@@ -359,11 +363,7 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_coords)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_face_coords<hip_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_face_coords<hip_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
@@ -405,11 +405,7 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_cellids)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_face_cells<cuda_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_face_cells<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
@@ -425,11 +421,7 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_cellids)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_face_cells<hip_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_face_cells<hip_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
@@ -472,11 +464,7 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_faces_index)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_faces<cuda_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_faces<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
@@ -492,11 +480,7 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_faces_index)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_faces<hip_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_faces<hip_exec, STRUCTURED_CURVILINEAR_MESH>(dim);

--- a/src/axom/mint/tests/mint_execution_node_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_node_traversals.cpp
@@ -29,6 +29,22 @@ namespace mint
 //------------------------------------------------------------------------------
 namespace
 {
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE) &&   \
+  ((defined(AXOM_USE_CUDA) && defined(RAJA_ENABLE_CUDA)) || \
+   (defined(AXOM_USE_HIP) && defined(RAJA_ENABLE_HIP)))
+
+int set_um_memory_return_previous_allocator()
+{
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
+  const int prev_allocator = axom::getDefaultAllocatorID();
+  axom::setDefaultAllocator(exec_space_id);
+  return prev_allocator;
+}
+
+#endif
+
 template <typename ExecPolicy, int MeshType, int Topology = SINGLE_SHAPE>
 void check_for_all_nodes_idx(int dimension)
 {
@@ -350,11 +366,7 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_xyz)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
+  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_nodes_xyz<cuda_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_xyz<cuda_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -371,11 +383,7 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_xyz)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
+  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_nodes_xyz<hip_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_xyz<hip_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -417,11 +425,7 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_xy)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
+  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_nodes_xy<cuda_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_xy<cuda_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -438,11 +442,7 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_xy)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
+  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_nodes_xy<hip_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_xy<hip_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -484,11 +484,7 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_x)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
+  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_nodes_x<cuda_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_x<cuda_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -505,11 +501,7 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_x)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
+  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_nodes_x<hip_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_x<hip_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -545,11 +537,7 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_ijk)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
+  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_nodes_ijk<cuda_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_ijk<cuda_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -563,11 +551,7 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_ijk)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
+  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_nodes_ijk<hip_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_ijk<hip_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -600,11 +584,7 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_ij)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
+  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_nodes_ij<cuda_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_ij<cuda_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -618,11 +598,7 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_ij)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
+  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_nodes_ij<hip_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_ij<hip_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -664,11 +640,7 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_index)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_nodes_idx<cuda_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_nodes_idx<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(i);
@@ -685,11 +657,7 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_index)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    // Use unified memory
-    const int exec_space_id = axom::getUmpireResourceAllocatorID(
-      umpire::resource::MemoryResourceType::Unified);
-    const int prev_allocator = axom::getDefaultAllocatorID();
-    axom::setDefaultAllocator(exec_space_id);
+    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_nodes_idx<hip_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_nodes_idx<hip_exec, STRUCTURED_CURVILINEAR_MESH>(i);

--- a/src/axom/mint/tests/mint_execution_node_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_node_traversals.cpp
@@ -350,7 +350,9 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_xyz)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
   const int prev_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator(exec_space_id);
 
@@ -369,7 +371,9 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_xyz)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
   const int prev_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator(exec_space_id);
 
@@ -413,7 +417,9 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_xy)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
   const int prev_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator(exec_space_id);
 
@@ -432,7 +438,9 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_xy)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
   const int prev_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator(exec_space_id);
 
@@ -476,7 +484,9 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_x)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
   const int prev_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator(exec_space_id);
 
@@ -495,7 +505,9 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_x)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
   const int prev_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator(exec_space_id);
 
@@ -533,7 +545,9 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_ijk)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
   const int prev_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator(exec_space_id);
 
@@ -549,7 +563,9 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_ijk)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
   const int prev_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator(exec_space_id);
 
@@ -584,7 +600,9 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_ij)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
   const int prev_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator(exec_space_id);
 
@@ -600,7 +618,9 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_ij)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+  // Use unified memory
+  const int exec_space_id = axom::getUmpireResourceAllocatorID(
+    umpire::resource::MemoryResourceType::Unified);
   const int prev_allocator = axom::getDefaultAllocatorID();
   axom::setDefaultAllocator(exec_space_id);
 
@@ -644,7 +664,9 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_index)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<cuda_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 
@@ -663,7 +685,9 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_index)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int exec_space_id = axom::execution_space<hip_exec>::allocatorID();
+    // Use unified memory
+    const int exec_space_id = axom::getUmpireResourceAllocatorID(
+      umpire::resource::MemoryResourceType::Unified);
     const int prev_allocator = axom::getDefaultAllocatorID();
     axom::setDefaultAllocator(exec_space_id);
 

--- a/src/axom/primal/tests/primal_boundingbox.cpp
+++ b/src/axom/primal/tests/primal_boundingbox.cpp
@@ -21,6 +21,7 @@ template <typename ExecSpace>
 void check_bb_policy()
 {
   const int DIM = 3;
+  const int HOST_ID = axom::getUmpireResourceAllocatorID(umpire::resource::Host);
   using BoundingBoxType = primal::BoundingBox<double, DIM>;
   using PointType = primal::Point<double, DIM>;
   using VectorType = primal::Vector<double, DIM>;
@@ -40,9 +41,13 @@ void check_bb_policy()
       box[i].isValid();
     });
 
-  EXPECT_EQ(box[0], BoundingBoxType(PointType(0.0), PointType(10.0)));
+  BoundingBoxType* box_host = axom::allocate<BoundingBoxType>(1, HOST_ID);
+  axom::copy(box_host, box, sizeof(BoundingBoxType));
+
+  EXPECT_EQ(box_host[0], BoundingBoxType(PointType(0.0), PointType(10.0)));
 
   axom::deallocate(box);
+  axom::deallocate(box_host);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_boundingbox.cpp
+++ b/src/axom/primal/tests/primal_boundingbox.cpp
@@ -21,7 +21,6 @@ template <typename ExecSpace>
 void check_bb_policy()
 {
   const int DIM = 3;
-  const int HOST_ID = axom::getUmpireResourceAllocatorID(umpire::resource::Host);
   using BoundingBoxType = primal::BoundingBox<double, DIM>;
   using PointType = primal::Point<double, DIM>;
   using VectorType = primal::Vector<double, DIM>;
@@ -41,13 +40,12 @@ void check_bb_policy()
       box[i].isValid();
     });
 
-  BoundingBoxType* box_host = axom::allocate<BoundingBoxType>(1, HOST_ID);
-  axom::copy(box_host, box, sizeof(BoundingBoxType));
+  BoundingBoxType box_host;
+  axom::copy(&box_host, box, sizeof(BoundingBoxType));
 
-  EXPECT_EQ(box_host[0], BoundingBoxType(PointType(0.0), PointType(10.0)));
+  EXPECT_EQ(box_host, BoundingBoxType(PointType(0.0), PointType(10.0)));
 
   axom::deallocate(box);
-  axom::deallocate(box_host);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_numeric_array.cpp
+++ b/src/axom/primal/tests/primal_numeric_array.cpp
@@ -21,6 +21,8 @@ void check_numeric_array_policy()
   double* coords =
     axom::allocate<double>(DIM, axom::execution_space<ExecSpace>::allocatorID());
 
+  double coords_host[DIM];
+
   axom::for_all<ExecSpace>(
     1,
     AXOM_LAMBDA(int /*i*/) {
@@ -28,7 +30,9 @@ void check_numeric_array_policy()
       ones.to_array(coords);
     });
 
-  EXPECT_EQ(NumericArrayType(coords), NumericArrayType(1));
+  axom::copy(&coords_host, coords, DIM * sizeof(double));
+
+  EXPECT_EQ(NumericArrayType(coords_host), NumericArrayType(1));
   axom::deallocate(coords);
 }
 

--- a/src/axom/primal/tests/primal_point.cpp
+++ b/src/axom/primal/tests/primal_point.cpp
@@ -22,6 +22,8 @@ void check_point_policy()
   double* coords =
     axom::allocate<double>(DIM, axom::execution_space<ExecSpace>::allocatorID());
 
+  double coords_host[DIM];
+
   axom::for_all<ExecSpace>(
     1,
     AXOM_LAMBDA(int /*i*/) {
@@ -29,7 +31,9 @@ void check_point_policy()
       ones.to_array(coords);
     });
 
-  EXPECT_EQ(PointType(coords), PointType::ones());
+  axom::copy(&coords_host, coords, DIM * sizeof(double));
+
+  EXPECT_EQ(PointType(coords_host), PointType::ones());
   axom::deallocate(coords);
 }
 

--- a/src/axom/primal/tests/primal_polyhedron.cpp
+++ b/src/axom/primal/tests/primal_polyhedron.cpp
@@ -298,10 +298,10 @@ void check_volume()
   axom::setDefaultAllocator(allocator.getId());
 
   // Initialize volume
-  double* res = axom::allocate<double>(1);
+  double* volume = axom::allocate<double>(1);
 
   // Volume on host (for CUDA or HIP)
-  double res_host;
+  double volume_host;
 
   axom::for_all<ExecSpace>(
     1,
@@ -325,14 +325,14 @@ void check_volume()
       poly.addNeighbors(6, {2, 7, 5});
       poly.addNeighbors(7, {4, 6, 3});
 
-      res[i] = poly.volume();
+      volume[i] = poly.volume();
     });
 
-  axom::copy(&res_host, res, sizeof(double));
+  axom::copy(&volume_host, volume, sizeof(double));
 
-  EXPECT_EQ(res_host, 1);
+  EXPECT_EQ(volume_host, 1);
 
-  axom::deallocate(res);
+  axom::deallocate(volume);
 
   axom::setDefaultAllocator(current_allocator);
 }

--- a/src/axom/primal/tests/primal_vector.cpp
+++ b/src/axom/primal/tests/primal_vector.cpp
@@ -27,6 +27,8 @@ void check_vector_policy()
     axom::allocate<VectorType>(1,
                                axom::execution_space<ExecSpace>::allocatorID());
 
+  VectorType vec_host;
+
   axom::for_all<ExecSpace>(
     1,
     AXOM_LAMBDA(int /*i*/) {
@@ -34,7 +36,9 @@ void check_vector_policy()
       vec[0].negate();
     });
 
-  EXPECT_EQ(vec[0], VectorType(1));
+  axom::copy(&vec_host, vec, sizeof(VectorType));
+
+  EXPECT_EQ(vec_host, VectorType(1));
   axom::deallocate(vec);
 }
 

--- a/src/axom/primal/tests/primal_zip.cpp
+++ b/src/axom/primal/tests/primal_zip.cpp
@@ -45,6 +45,7 @@ void check_zip_points_3d()
   double* z = axom::allocate<double>(N);
 
   bool* valid = axom::allocate<bool>(N);
+  bool valid_host[N];
 
   axom::for_all<ExecSpace>(
     0,
@@ -64,9 +65,11 @@ void check_zip_points_3d()
       valid[idx] = (it[idx] == PrimitiveType {x[idx], y[idx], z[idx]});
     });
 
+  axom::copy(&valid_host, valid, N * sizeof(bool));
+
   for(int i = 0; i < N; i++)
   {
-    EXPECT_TRUE(valid[i]);
+    EXPECT_TRUE(valid_host[i]);
   }
 
   axom::deallocate(x);
@@ -92,6 +95,7 @@ void check_zip_points_2d_from_3d()
   double* z = nullptr;
 
   bool* valid = axom::allocate<bool>(N);
+  bool valid_host[N];
 
   axom::for_all<ExecSpace>(
     0,
@@ -110,9 +114,11 @@ void check_zip_points_2d_from_3d()
       valid[idx] = (it[idx] == PointType {x[idx], y[idx]});
     });
 
+  axom::copy(&valid_host, valid, N * sizeof(bool));
+
   for(int i = 0; i < N; i++)
   {
-    EXPECT_TRUE(valid[i]);
+    EXPECT_TRUE(valid_host[i]);
   }
 
   axom::deallocate(x);
@@ -137,6 +143,7 @@ void check_zip_vectors_2d_from_3d()
   double* z = nullptr;
 
   bool* valid = axom::allocate<bool>(N);
+  bool valid_host[N];
 
   axom::for_all<ExecSpace>(
     0,
@@ -155,9 +162,11 @@ void check_zip_vectors_2d_from_3d()
       valid[idx] = (it[idx] == PointType {x[idx], y[idx]});
     });
 
+  axom::copy(&valid_host, valid, N * sizeof(bool));
+
   for(int i = 0; i < N; i++)
   {
-    EXPECT_TRUE(valid[i]);
+    EXPECT_TRUE(valid_host[i]);
   }
 
   axom::deallocate(x);
@@ -187,6 +196,7 @@ void check_zip_bbs_3d()
   double* zmax = axom::allocate<double>(N);
 
   bool* valid = axom::allocate<bool>(N);
+  bool valid_host[N];
 
   axom::for_all<ExecSpace>(
     0,
@@ -213,9 +223,11 @@ void check_zip_bbs_3d()
       valid[idx] = (it[idx] == actual);
     });
 
+  axom::copy(&valid_host, valid, N * sizeof(bool));
+
   for(int i = 0; i < N; i++)
   {
-    EXPECT_TRUE(valid[i]);
+    EXPECT_TRUE(valid_host[i]);
   }
 
   axom::deallocate(xmin);
@@ -251,6 +263,7 @@ void check_zip_bbs_2d_from_3d()
   double* zmax = nullptr;
 
   bool* valid = axom::allocate<bool>(N);
+  bool valid_host[N];
 
   axom::for_all<ExecSpace>(
     0,
@@ -275,9 +288,11 @@ void check_zip_bbs_2d_from_3d()
       valid[idx] = (it[idx] == actual);
     });
 
+  axom::copy(&valid_host, valid, N * sizeof(bool));
+
   for(int i = 0; i < N; i++)
   {
-    EXPECT_TRUE(valid[i]);
+    EXPECT_TRUE(valid_host[i]);
   }
 
   axom::deallocate(xmin);
@@ -312,6 +327,7 @@ void check_zip_rays_3d()
   double* zd = axom::allocate<double>(N);
 
   bool* valid = axom::allocate<bool>(N);
+  bool valid_host[N];
 
   axom::for_all<ExecSpace>(
     0,
@@ -349,9 +365,11 @@ void check_zip_rays_3d()
         (it[idx].direction() == actual.direction());
     });
 
+  axom::copy(&valid_host, valid, N * sizeof(bool));
+
   for(int i = 0; i < N; i++)
   {
-    EXPECT_TRUE(valid[i]);
+    EXPECT_TRUE(valid_host[i]);
   }
 
   axom::deallocate(xo);
@@ -388,6 +406,7 @@ void check_zip_rays_2d_from_3d()
   double* zd = nullptr;
 
   bool* valid = axom::allocate<bool>(N);
+  bool valid_host[N];
 
   axom::for_all<ExecSpace>(
     0,
@@ -425,9 +444,11 @@ void check_zip_rays_2d_from_3d()
         (it[idx].direction() == actual.direction());
     });
 
+  axom::copy(&valid_host, valid, N * sizeof(bool));
+
   for(int i = 0; i < N; i++)
   {
-    EXPECT_TRUE(valid[i]);
+    EXPECT_TRUE(valid_host[i]);
   }
 
   axom::deallocate(xo);

--- a/src/axom/quest/DistributedClosestPoint.cpp
+++ b/src/axom/quest/DistributedClosestPoint.cpp
@@ -70,16 +70,21 @@ void DistributedClosestPoint::setDefaultAllocatorID()
 #ifdef __CUDACC__
   #ifdef AXOM_RUNTIME_POLICY_USE_CUDA
   case RuntimePolicy::cuda:
+
+    // Use unified memory
     defaultAllocatorID =
-      axom::execution_space<axom::CUDA_EXEC<256>>::allocatorID();
+      axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
     break;
   #endif
 #endif
 
 #ifdef AXOM_RUNTIME_POLICY_USE_HIP
   case RuntimePolicy::hip:
+
+    // Use unified memory
     defaultAllocatorID =
-      axom::execution_space<axom::HIP_EXEC<256>>::allocatorID();
+      axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+
     break;
 #endif
   }

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -162,7 +162,10 @@ private:
     m_hostData = hostPtr;
     m_numElements = nElem;
     m_needResult = _needResult;
-    int execSpaceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
+    constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
+    int execSpaceAllocatorID = on_device
+      ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
+      : axom::execution_space<ExecSpace>::allocatorID();
     auto dataSize = sizeof(double) * m_numElements;
     m_deviceData = axom::allocate<double>(dataSize, execSpaceAllocatorID);
     axom::copy(m_deviceData, m_hostData, dataSize);
@@ -579,7 +582,11 @@ public:
 
     // Determine new allocator (for CUDA/HIP policy, set to Unified)
     // Set new default to device
-    axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+    constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
+    int allocator_id = on_device
+      ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
+      : axom::execution_space<ExecSpace>::allocatorID();
+    axom::setDefaultAllocator(allocator_id);
 
     const auto& shapeName = shape.getName();
     AXOM_UNUSED_VAR(shapeDimension);
@@ -625,7 +632,11 @@ public:
 
     // Determine new allocator (for CUDA/HIP policy, set to Unified)
     // Set new default to device
-    axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+    constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
+    int allocator_id = on_device
+      ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
+      : axom::execution_space<ExecSpace>::allocatorID();
+    axom::setDefaultAllocator(allocator_id);
 
     SLIC_INFO(axom::fmt::format("{:-^80}",
                                 " Inserting shapes' bounding boxes into BVH "));
@@ -1191,7 +1202,10 @@ public:
     SLIC_ASSERT(shapeVolFrac != nullptr);
 
     // Allocate some memory for the replacement rule data arrays.
-    int execSpaceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
+    constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
+    int execSpaceAllocatorID = on_device
+      ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
+      : axom::execution_space<ExecSpace>::allocatorID();
     Array<double> vf_subtract_array(dataSize, dataSize, execSpaceAllocatorID);
     Array<double> vf_writable_array(dataSize, dataSize, execSpaceAllocatorID);
     ArrayView<double> vf_subtract(vf_subtract_array);

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -66,6 +66,29 @@
 #endif
 // clang-format on
 
+namespace
+{
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+
+/*!
+   *
+   * \brief Helper function that returns the Umpire allocator id for device
+   *        (for CUDA/HIP policy, set to Unified)
+   * \return The Umpire allocator id for device
+   */
+
+template <typename ExecSpace>
+int getUmpireDeviceId()
+{
+  constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
+  int allocator_id = on_device
+    ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
+    : axom::execution_space<ExecSpace>::allocatorID();
+  return allocator_id;
+}
+#endif
+}  // namespace
+
 namespace axom
 {
 namespace quest
@@ -162,10 +185,8 @@ private:
     m_hostData = hostPtr;
     m_numElements = nElem;
     m_needResult = _needResult;
-    constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
-    int execSpaceAllocatorID = on_device
-      ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
-      : axom::execution_space<ExecSpace>::allocatorID();
+    int execSpaceAllocatorID = ::getUmpireDeviceId<ExecSpace>();
+
     auto dataSize = sizeof(double) * m_numElements;
     m_deviceData = axom::allocate<double>(dataSize, execSpaceAllocatorID);
     axom::copy(m_deviceData, m_hostData, dataSize);
@@ -582,11 +603,7 @@ public:
 
     // Determine new allocator (for CUDA/HIP policy, set to Unified)
     // Set new default to device
-    constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
-    int allocator_id = on_device
-      ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
-      : axom::execution_space<ExecSpace>::allocatorID();
-    axom::setDefaultAllocator(allocator_id);
+    axom::setDefaultAllocator(::getUmpireDeviceId<ExecSpace>());
 
     const auto& shapeName = shape.getName();
     AXOM_UNUSED_VAR(shapeDimension);
@@ -632,11 +649,7 @@ public:
 
     // Determine new allocator (for CUDA/HIP policy, set to Unified)
     // Set new default to device
-    constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
-    int allocator_id = on_device
-      ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
-      : axom::execution_space<ExecSpace>::allocatorID();
-    axom::setDefaultAllocator(allocator_id);
+    axom::setDefaultAllocator(::getUmpireDeviceId<ExecSpace>());
 
     SLIC_INFO(axom::fmt::format("{:-^80}",
                                 " Inserting shapes' bounding boxes into BVH "));
@@ -1202,10 +1215,8 @@ public:
     SLIC_ASSERT(shapeVolFrac != nullptr);
 
     // Allocate some memory for the replacement rule data arrays.
-    constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
-    int execSpaceAllocatorID = on_device
-      ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
-      : axom::execution_space<ExecSpace>::allocatorID();
+    int execSpaceAllocatorID = ::getUmpireDeviceId<ExecSpace>();
+
     Array<double> vf_subtract_array(dataSize, dataSize, execSpaceAllocatorID);
     Array<double> vf_writable_array(dataSize, dataSize, execSpaceAllocatorID);
     ArrayView<double> vf_subtract(vf_subtract_array);

--- a/src/axom/quest/detail/Discretize_detail.hpp
+++ b/src/axom/quest/detail/Discretize_detail.hpp
@@ -154,6 +154,8 @@ int discrSeg(const Point2D &a,
              axom::ArrayView<OctType> &out,
              int idx)
 {
+  int hostAllocID = axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+
   // Assert input assumptions
   SLIC_ASSERT(b[0] - a[0] >= 0);
   SLIC_ASSERT(a[1] >= 0);
@@ -174,7 +176,11 @@ int discrSeg(const Point2D &a,
   // Establish a prism (in an octahedron record) with one triangular
   // end lying on the circle described by rotating point a around the
   // x-axis and the other lying on circle from rotating b.
-  out[idx + 0] = from_segment(a, b);
+  OctType *oct_from_seg = axom::allocate<OctType>(1, hostAllocID);
+  oct_from_seg[0] = from_segment(a, b);
+
+  axom::copy(out.data() + idx + 0, oct_from_seg, sizeof(OctType));
+  axom::deallocate(oct_from_seg);
 
   // curr_lvl indexes to the first prism in the level we're currently refining
   int curr_lvl = idx;

--- a/src/axom/quest/detail/Discretize_detail.hpp
+++ b/src/axom/quest/detail/Discretize_detail.hpp
@@ -154,7 +154,7 @@ int discrSeg(const Point2D &a,
              axom::ArrayView<OctType> &out,
              int idx)
 {
-  int hostAllocID = axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   // Assert input assumptions
   SLIC_ASSERT(b[0] - a[0] >= 0);

--- a/src/axom/quest/detail/DistributedClosestPointImpl.hpp
+++ b/src/axom/quest/detail/DistributedClosestPointImpl.hpp
@@ -1136,9 +1136,7 @@ public:
         auto it = bvh->getTraverser();
         const int rank = m_rank;
 
-        double* sqDistThresh = axom::allocate<double>(
-          1,
-          axom::execution_space<ExecSpace>::allocatorID());
+        double* sqDistThresh = axom::allocate<double>(1, m_allocatorID);
         *sqDistThresh = m_sqDistanceThreshold;
 
         auto ptCoordsView = m_objectPtCoords.view();

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -1331,10 +1331,10 @@ int main(int argc, char** argv)
   #if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
     params.policy == RuntimePolicy::omp ? "HOST" :
   #endif
-  #if defined(UMPIRE_ENABLE_DEVICE)
-                                        "DEVICE"
-  #elif defined(UMPIRE_ENABLE_UM)
-    "UM"
+  #if defined(UMPIRE_ENABLE_UM)
+                                        "UM"
+  #elif defined(UMPIRE_ENABLE_DEVICE)
+    "DEVICE"
   #elif defined(UMPIRE_ENABLE_PINNED)
     "PINNED"
   #else

--- a/src/axom/quest/tests/quest_discretize.cpp
+++ b/src/axom/quest/tests/quest_discretize.cpp
@@ -195,10 +195,15 @@ void run_degen_segment_tests()
   // We don't know what order they'll be in, but we do know how many octahedra
   // will be in each generation.
 
-  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
-  int allocID = on_device
-    ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
-    : axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  int allocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+
+  //Use unified memory on device
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
+  if(axom::execution_space<ExecPolicy>::onDevice())
+  {
+    allocID = axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  }
+#endif
 
   axom::Array<Point2D> polyline(2, 2, allocID);
 
@@ -230,7 +235,7 @@ void run_degen_segment_tests()
 template <typename ExecPolicy>
 void segment_test(const char* label, axom::Array<Point2D>& polyline, int len)
 {
-  int hostAllocID = axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   SCOPED_TRACE(label);
 
@@ -284,10 +289,15 @@ void segment_test(const char* label, axom::Array<Point2D>& polyline, int len)
 template <typename ExecPolicy>
 void run_single_segment_tests()
 {
-  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
-  int allocID = on_device
-    ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
-    : axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  int allocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+
+  //Use unified memory on device
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
+  if(axom::execution_space<ExecPolicy>::onDevice())
+  {
+    allocID = axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  }
+#endif
 
   axom::Array<Point2D> polyline(2, 2, allocID);
 
@@ -317,7 +327,7 @@ void multi_segment_test(const char* label, axom::Array<Point2D>& polyline, int l
 {
   SCOPED_TRACE(label);
 
-  int hostAllocID = axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   // Test each of the three generations.
   constexpr int generations = 2;
@@ -385,10 +395,15 @@ void multi_segment_test(const char* label, axom::Array<Point2D>& polyline, int l
 template <typename ExecPolicy>
 void run_multi_segment_tests()
 {
-  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
-  int allocID = on_device
-    ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
-    : axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  int allocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+
+  //Use unified memory on device
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
+  if(axom::execution_space<ExecPolicy>::onDevice())
+  {
+    allocID = axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  }
+#endif
 
   constexpr int pointcount = 5;
   axom::Array<Point2D> polyline(pointcount, pointcount, allocID);

--- a/src/axom/quest/tests/quest_discretize.cpp
+++ b/src/axom/quest/tests/quest_discretize.cpp
@@ -195,10 +195,12 @@ void run_degen_segment_tests()
   // We don't know what order they'll be in, but we do know how many octahedra
   // will be in each generation.
 
-  int unifiedAllocatorID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
+  int allocID = on_device
+    ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
+    : axom::getUmpireResourceAllocatorID(umpire::resource::Host);
 
-  axom::Array<Point2D> polyline(2, 2, unifiedAllocatorID);
+  axom::Array<Point2D> polyline(2, 2, allocID);
 
   polyline[0] = {0., 0.};
   polyline[1] = {0., 0.};
@@ -282,10 +284,12 @@ void segment_test(const char* label, axom::Array<Point2D>& polyline, int len)
 template <typename ExecPolicy>
 void run_single_segment_tests()
 {
-  int unifiedAllocatorID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
+  int allocID = on_device
+    ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
+    : axom::getUmpireResourceAllocatorID(umpire::resource::Host);
 
-  axom::Array<Point2D> polyline(2, 2, unifiedAllocatorID);
+  axom::Array<Point2D> polyline(2, 2, allocID);
 
   polyline[0] = Point2D {0.5, 0.};
   polyline[1] = Point2D {1.8, 0.8};
@@ -381,11 +385,13 @@ void multi_segment_test(const char* label, axom::Array<Point2D>& polyline, int l
 template <typename ExecPolicy>
 void run_multi_segment_tests()
 {
-  int unifiedAllocatorID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
+  int allocID = on_device
+    ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
+    : axom::getUmpireResourceAllocatorID(umpire::resource::Host);
 
   constexpr int pointcount = 5;
-  axom::Array<Point2D> polyline(pointcount, pointcount, unifiedAllocatorID);
+  axom::Array<Point2D> polyline(pointcount, pointcount, allocID);
 
   polyline[0] = Point2D {1.0, 0.5};
   polyline[1] = Point2D {1.6, 0.3};

--- a/src/axom/quest/tests/quest_discretize.cpp
+++ b/src/axom/quest/tests/quest_discretize.cpp
@@ -197,7 +197,8 @@ void run_degen_segment_tests()
 
   int allocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
-  //Use unified memory on device
+  // Use unified memory for frequent movement between device operations
+  // and value checking on host
 #if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecPolicy>::onDevice())
   {
@@ -291,7 +292,8 @@ void run_single_segment_tests()
 {
   int allocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
-  //Use unified memory on device
+  // Use unified memory for frequent movement between device operations
+  // and value checking on host
 #if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecPolicy>::onDevice())
   {
@@ -397,7 +399,8 @@ void run_multi_segment_tests()
 {
   int allocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
-  //Use unified memory on device
+  //Use unified memory for frequent movement between device operations
+  // and value checking on host
 #if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   if(axom::execution_space<ExecPolicy>::onDevice())
   {

--- a/src/axom/quest/tests/quest_signed_distance.cpp
+++ b/src/axom/quest/tests/quest_signed_distance.cpp
@@ -311,13 +311,18 @@ void run_vectorized_sphere_test()
 {
   using PointType = primal::Point<double, 3>;
 
-  int host_allocator = axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  int kernel_allocator = axom::execution_space<ExecSpace>::allocatorID();
 
   //Use unified memory on device
-  constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
-  const int kernel_allocator = on_device
-    ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
-    : axom::execution_space<ExecSpace>::allocatorID();
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
+  if(axom::execution_space<ExecSpace>::onDevice())
+  {
+    kernel_allocator =
+      axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  }
+#endif
+
   axom::setDefaultAllocator(kernel_allocator);
 
   constexpr double l1norm_expected = 6.7051997372579715;

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -209,7 +209,7 @@ void check_build_bvh2d()
   using PointType = typename primal::Point<FloatType, NDIMS>;
 
   const int hostAllocatorID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+    axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   axom::Array<BoxType> boxes(2, 2, hostAllocatorID);
@@ -252,7 +252,7 @@ void check_build_bvh3d()
   using PointType = typename primal::Point<FloatType, NDIMS>;
 
   const int hostAllocatorID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+    axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   axom::Array<BoxType> boxes(2, 2, hostAllocatorID);
@@ -290,7 +290,7 @@ void check_find_bounding_boxes3d()
   using PointType = typename primal::Point<FloatType, NDIMS>;
 
   const int hostAllocatorID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+    axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   // setup query bounding boxes: both boxes have lower left min at
@@ -424,7 +424,7 @@ void check_find_bounding_boxes2d()
   using PointType = typename primal::Point<FloatType, NDIMS>;
 
   const int hostAllocatorID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+    axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   // setup query bounding boxes: both boxes are source at (-1.0,-1.0) but have
@@ -543,7 +543,7 @@ void check_find_rays3d()
   using VectorType = typename primal::Vector<FloatType, NDIMS>;
 
   const int hostAllocatorID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+    axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   // setup query rays: both rays are source at (-1.0,-1.0) but point in
@@ -678,7 +678,7 @@ void check_find_rays2d()
   using VectorType = typename primal::Vector<FloatType, NDIMS>;
 
   const int hostAllocatorID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+    axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   // setup query rays: both rays are source at (-1.0,-1.0) but point in
@@ -817,7 +817,7 @@ void check_find_points3d()
   constexpr IndexType N = 4;
 
   const int hostAllocatorID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+    axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   using BoxType = typename primal::BoundingBox<FloatType, NDIMS>;
@@ -945,7 +945,7 @@ void check_find_points2d()
   constexpr IndexType N = 4;
 
   const int hostAllocatorID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+    axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   using BoxType = typename primal::BoundingBox<FloatType, NDIMS>;
@@ -1067,7 +1067,7 @@ void check_single_box2d()
   using PointType = primal::Point<FloatType, NDIMS>;
 
   const int hostAllocatorID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+    axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   // single bounding box in [0,1] x [0,1]
@@ -1160,7 +1160,7 @@ void check_single_box3d()
   using PointType = primal::Point<FloatType, NDIMS>;
 
   const int hostAllocatorID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+    axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   // single bounding box in [0,1] x [0,1] x [0,1]
@@ -1528,7 +1528,7 @@ void bvh_compute_point_distances_2d(BVHType& bvh,
   constexpr int FIRST_ELEMENT_INDEX = 0;
 
   const int hostAllocatorID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+    axom::execution_space<axom::SEQ_EXEC>::allocatorID();
   const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   // Borrowed from DistibutedClosestPoint.

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -96,8 +96,6 @@ void generate_aabbs(const mint::Mesh* mesh,
   // sanity check
   EXPECT_EQ(NDIMS, mesh->getDimension());
 
-  using BoxType = typename primal::BoundingBox<FloatType, NDIMS>;
-
   // calculate some constants
   constexpr int nodes_per_dim = 1 << NDIMS;
 
@@ -159,7 +157,6 @@ void generate_aabbs_and_centroids(
   EXPECT_EQ(NDIMS, mesh->getDimension());
 
   // initialize output arrays
-  const IndexType ncells = mesh->getNumberOfCells();
 
   using exec_policy = axom::SEQ_EXEC;
   mint::for_all_cells<exec_policy, xargs::coords>(
@@ -348,7 +345,6 @@ void check_find_bounding_boxes3d()
   auto offsets_view = offsets_device.view();
   auto counts_view = counts_device.view();
   auto query_boxes_view = query_boxes_device.view();
-  auto candidates_view = candidates_device.view();
 
   bvh.findBoundingBoxes(offsets_view,
                         counts_view,
@@ -484,7 +480,6 @@ void check_find_bounding_boxes2d()
   auto offsets_view = offsets_device.view();
   auto counts_view = counts_device.view();
   auto query_boxes_view = query_boxes_device.view();
-  auto candidates_view = candidates_device.view();
 
   bvh.findBoundingBoxes(offsets_view,
                         counts_view,
@@ -607,7 +602,6 @@ void check_find_rays3d()
   auto offsets_view = offsets_device.view();
   auto counts_view = counts_device.view();
   auto query_rays_view = query_rays_device.view();
-  auto candidates_view = candidates_device.view();
 
   bvh.findRays(offsets_view, counts_view, candidates_device, N, query_rays_view);
 
@@ -752,7 +746,6 @@ void check_find_rays2d()
   auto offsets_view = offsets_device.view();
   auto counts_view = counts_device.view();
   auto query_rays_view = query_rays_device.view();
-  auto candidates_view = candidates_device.view();
 
   bvh.findRays(offsets_view, counts_view, candidates_device, N, query_rays_view);
 
@@ -878,7 +871,6 @@ void check_find_points3d()
   // Create views of device arrays
   auto offsets_view = offsets_device.view();
   auto counts_view = counts_device.view();
-  auto candidates_view = candidates_device.view();
 
   bvh.findPoints(offsets_view,
                  counts_view,
@@ -1005,7 +997,6 @@ void check_find_points2d()
   // Create views of device arrays
   auto offsets_view = offsets_device.view();
   auto counts_view = counts_device.view();
-  auto candidates_view = candidates_device.view();
 
   bvh.findPoints(offsets_view,
                  counts_view,
@@ -1116,7 +1107,6 @@ void check_single_box2d()
   // Create views of device arrays
   auto offsets_view = offsets_device.view();
   auto counts_view = counts_device.view();
-  auto candidates_view = candidates_device.view();
 
   bvh.findPoints(offsets_view,
                  counts_view,
@@ -1210,7 +1200,6 @@ void check_single_box3d()
   // Create views of device arrays
   auto offsets_view = offsets_device.view();
   auto counts_view = counts_device.view();
-  auto candidates_view = candidates_device.view();
 
   bvh.findPoints(offsets_view,
                  counts_view,

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -83,23 +83,17 @@ void dump_ray(const std::string& file,
  *  a corresponding centroid.
  *
  * \param [in]  mesh pointer to the mesh object.
- * \param [out] aabbs array of bounding boxes
+ * \param [out] aabbs ArrayView of bounding boxes
  *
  * \note The intent of this method is to generate synthetic input test data
  *  to test the functionality of the BVH.
  *
- * \warning This method allocates aabbs internally. The caller is responsible
- *  for properly deallocating aabbs.
- *
- * \pre aabbs == nullptr
- * \post aabbs != nullptr
  */
 template <typename FloatType, int NDIMS>
 void generate_aabbs(const mint::Mesh* mesh,
-                    primal::BoundingBox<FloatType, NDIMS>*& aabbs)
+                    axom::ArrayView<primal::BoundingBox<FloatType, NDIMS>> aabbs)
 {
-  // sanity checks
-  EXPECT_TRUE(aabbs == nullptr);
+  // sanity check
   EXPECT_EQ(NDIMS, mesh->getDimension());
 
   using BoxType = typename primal::BoundingBox<FloatType, NDIMS>;
@@ -109,7 +103,7 @@ void generate_aabbs(const mint::Mesh* mesh,
 
   // allocate output arrays
   const IndexType ncells = mesh->getNumberOfCells();
-  aabbs = axom::allocate<BoxType>(ncells);
+  EXPECT_TRUE(aabbs.size() == ncells);
 
   using exec_policy = axom::SEQ_EXEC;
   mint::for_all_cells<exec_policy, xargs::coords>(
@@ -129,9 +123,6 @@ void generate_aabbs(const mint::Mesh* mesh,
       aabbs[cellIdx].clear();
       aabbs[cellIdx].addBox(range);
     });
-
-  // post-condition sanity checks
-  EXPECT_TRUE(aabbs != nullptr);
 }
 
 //------------------------------------------------------------------------------
@@ -142,27 +133,21 @@ void generate_aabbs(const mint::Mesh* mesh,
  *  a corresponding centroid.
  *
  * \param [in]  mesh pointer to the mesh object.
- * \param [out] aabbs array of bounding boxes
+ * \param [out] aabbs ArrayView of bounding boxes
  * \param [out] c buffer to store the cell centroids
  *
  * \note The intent of this method is to generate synthetic input test data
  *  to test the functionality of the BVH.
  *
- * \warning This method allocates aabbs internally. The caller is responsible
- *  for properly deallocating aabbs.
- *
- * \pre aabbs == nullptr
  * \pre c != nullptr
- *
- * \post aabbs != nullptr
  */
 template <typename FloatType, int NDIMS>
-void generate_aabbs_and_centroids(const mint::Mesh* mesh,
-                                  primal::BoundingBox<FloatType, NDIMS>*& aabbs,
-                                  primal::Point<FloatType, NDIMS>* c)
+void generate_aabbs_and_centroids(
+  const mint::Mesh* mesh,
+  axom::ArrayView<primal::BoundingBox<FloatType, NDIMS>> aabbs,
+  primal::Point<FloatType, NDIMS>* c)
 {
-  // sanity checks
-  EXPECT_TRUE(aabbs == nullptr);
+  // sanity check
   EXPECT_TRUE(c != nullptr);
 
   // calculate some constants
@@ -173,9 +158,8 @@ void generate_aabbs_and_centroids(const mint::Mesh* mesh,
 
   EXPECT_EQ(NDIMS, mesh->getDimension());
 
-  // allocate output arrays
+  // initialize output arrays
   const IndexType ncells = mesh->getNumberOfCells();
-  aabbs = axom::allocate<BoxType>(ncells);
 
   using exec_policy = axom::SEQ_EXEC;
   mint::for_all_cells<exec_policy, xargs::coords>(
@@ -210,9 +194,6 @@ void generate_aabbs_and_centroids(const mint::Mesh* mesh,
 
       aabbs[cellIdx] = range;
     });
-
-  // post-condition sanity checks
-  EXPECT_TRUE(aabbs != nullptr);
 }
 
 //------------------------------------------------------------------------------
@@ -230,17 +211,21 @@ void check_build_bvh2d()
   using BoxType = typename primal::BoundingBox<FloatType, NDIMS>;
   using PointType = typename primal::Point<FloatType, NDIMS>;
 
-  const int current_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+  const int hostAllocatorID =
+    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
-  BoxType* boxes = axom::allocate<BoxType>(2);
+  axom::Array<BoxType> boxes(2, 2, hostAllocatorID);
   boxes[0] = BoxType {PointType(0.), PointType(1.)};
   boxes[1] = BoxType {PointType(1.), PointType(2.)};
 
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;
 
+  // Copy boxes to device
+  axom::Array<BoxType> boxesDevice(boxes, deviceAllocatorID);
+
   bvh.setScaleFactor(1.0);  // i.e., no scaling
-  bvh.initialize(boxes, NUM_BOXES);
+  bvh.initialize(boxesDevice.view(), NUM_BOXES);
 
   int allocatorID = bvh.getAllocatorID();
   EXPECT_EQ(allocatorID, axom::execution_space<ExecSpace>::allocatorID());
@@ -252,9 +237,6 @@ void check_build_bvh2d()
     EXPECT_NEAR(bounds.getMin()[idim], 0.0, EPS);
     EXPECT_NEAR(bounds.getMax()[idim], 2.0, EPS);
   }
-
-  axom::deallocate(boxes);
-  axom::setDefaultAllocator(current_allocator);
 }
 
 //------------------------------------------------------------------------------
@@ -272,17 +254,21 @@ void check_build_bvh3d()
   using BoxType = typename primal::BoundingBox<FloatType, NDIMS>;
   using PointType = typename primal::Point<FloatType, NDIMS>;
 
-  const int current_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+  const int hostAllocatorID =
+    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
-  BoxType* boxes = axom::allocate<BoxType>(2);
+  axom::Array<BoxType> boxes(2, 2, hostAllocatorID);
   boxes[0] = BoxType {PointType(0.), PointType(1.)};
   boxes[1] = BoxType {PointType(1.), PointType(2.)};
 
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;
 
+  // Copy boxes to device
+  axom::Array<BoxType> boxesDevice(boxes, deviceAllocatorID);
+
   bvh.setScaleFactor(1.0);  // i.e., no scaling
-  bvh.initialize(boxes, NUM_BOXES);
+  bvh.initialize(boxesDevice.view(), NUM_BOXES);
 
   int allocatorID = bvh.getAllocatorID();
   EXPECT_EQ(allocatorID, axom::execution_space<ExecSpace>::allocatorID());
@@ -294,9 +280,6 @@ void check_build_bvh3d()
     EXPECT_NEAR(bounds.getMin()[idim], 0.0, EPS);
     EXPECT_NEAR(bounds.getMax()[idim], 2.0, EPS);
   }
-
-  axom::deallocate(boxes);
-  axom::setDefaultAllocator(current_allocator);
 }
 
 //------------------------------------------------------------------------------
@@ -309,14 +292,15 @@ void check_find_bounding_boxes3d()
   using BoxType = typename primal::BoundingBox<FloatType, NDIMS>;
   using PointType = typename primal::Point<FloatType, NDIMS>;
 
-  const int current_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+  const int hostAllocatorID =
+    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   // setup query bounding boxes: both boxes have lower left min at
   // (-1.0,-1.0,-1.0) but different upper right max.
   // The first bounding box is setup such that it intersects
   // 18 bounding boxes of the mesh.
-  BoxType* query_boxes = axom::allocate<BoxType>(N);
+  axom::Array<BoxType> query_boxes(N, N, hostAllocatorID);
   query_boxes[0].clear();
   query_boxes[1].clear();
 
@@ -331,14 +315,18 @@ void check_find_bounding_boxes3d()
   double hi[NDIMS] = {3.0, 3.0, 3.0};
   mint::UniformMesh mesh(lo, hi, 4, 4, 4);
   const IndexType ncells = mesh.getNumberOfCells();
-  BoxType* aabbs = nullptr;
-  generate_aabbs(&mesh, aabbs);
-  EXPECT_TRUE(aabbs != nullptr);
+  axom::Array<BoxType> aabbs(ncells, ncells, hostAllocatorID);
+  generate_aabbs(&mesh, aabbs.view());
+  EXPECT_TRUE(aabbs.data() != nullptr);
+
+  // Move aabbs to device
+  axom::Array<BoxType> aabbs_device =
+    axom::Array<BoxType>(aabbs, deviceAllocatorID);
 
   // construct the BVH
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;
   bvh.setScaleFactor(1.0);  // i.e., no scaling
-  bvh.initialize(aabbs, ncells);
+  bvh.initialize(aabbs_device.view(), ncells);
 
   // check BVH bounding box
   BoxType bounds = bvh.getBounds();
@@ -350,10 +338,31 @@ void check_find_bounding_boxes3d()
   }
 
   // traverse the BVH to find the candidates for all the bounding boxes
-  axom::Array<IndexType> offsets(N);
-  axom::Array<IndexType> counts(N);
-  axom::Array<IndexType> candidates;
-  bvh.findBoundingBoxes(offsets, counts, candidates, N, query_boxes);
+  axom::Array<IndexType> offsets_device(N, N, deviceAllocatorID);
+  axom::Array<IndexType> counts_device(N, N, deviceAllocatorID);
+  axom::Array<IndexType> candidates_device(0, 0, deviceAllocatorID);
+  axom::Array<BoxType> query_boxes_device =
+    axom::Array<BoxType>(query_boxes, deviceAllocatorID);
+
+  // Create views of device arrays
+  auto offsets_view = offsets_device.view();
+  auto counts_view = counts_device.view();
+  auto query_boxes_view = query_boxes_device.view();
+  auto candidates_view = candidates_device.view();
+
+  bvh.findBoundingBoxes(offsets_view,
+                        counts_view,
+                        candidates_device,
+                        N,
+                        query_boxes_view);
+
+  // Copy back to host
+  axom::Array<IndexType> counts =
+    axom::Array<IndexType>(counts_device, hostAllocatorID);
+  axom::Array<IndexType> offsets =
+    axom::Array<IndexType>(offsets_device, hostAllocatorID);
+  axom::Array<IndexType> candidates =
+    axom::Array<IndexType>(candidates_device, hostAllocatorID);
 
   // flag cells that are found by the bounding box ID
   int* iblank = mesh.createField<int>("iblank", mint::CELL_CENTERED);
@@ -407,13 +416,6 @@ void check_find_bounding_boxes3d()
       EXPECT_EQ(iblank[i], DOES_NOT_INTERSECT_BB);
     }
   }  // END for all mesh cells
-
-  // deallocate
-  axom::deallocate(aabbs);
-
-  axom::deallocate(query_boxes);
-
-  axom::setDefaultAllocator(current_allocator);
 }
 
 //------------------------------------------------------------------------------
@@ -427,13 +429,14 @@ void check_find_bounding_boxes2d()
   using BoxType = typename primal::BoundingBox<FloatType, NDIMS>;
   using PointType = typename primal::Point<FloatType, NDIMS>;
 
-  const int current_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+  const int hostAllocatorID =
+    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   // setup query bounding boxes: both boxes are source at (-1.0,-1.0) but have
   // different max (upper right). The first box is setup to intersect six
   // bounding boxes of the mesh.
-  BoxType* query_boxes = axom::allocate<BoxType>(N);
+  axom::Array<BoxType> query_boxes(N, N, hostAllocatorID);
   query_boxes[0].clear();
   query_boxes[1].clear();
 
@@ -448,14 +451,18 @@ void check_find_bounding_boxes2d()
   double hi[NDIMS] = {3.0, 3.0};
   mint::UniformMesh mesh(lo, hi, 4, 4);
   const IndexType ncells = mesh.getNumberOfCells();
-  BoxType* aabbs = nullptr;
-  generate_aabbs(&mesh, aabbs);
-  EXPECT_TRUE(aabbs != nullptr);
+  axom::Array<BoxType> aabbs(ncells, ncells, hostAllocatorID);
+  generate_aabbs(&mesh, aabbs.view());
+  EXPECT_TRUE(aabbs.data() != nullptr);
+
+  // Move aabbs to device
+  axom::Array<BoxType> aabbs_device =
+    axom::Array<BoxType>(aabbs, deviceAllocatorID);
 
   // construct the BVH
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;
   bvh.setScaleFactor(1.0);  // i.e., no scaling
-  bvh.initialize(aabbs, ncells);
+  bvh.initialize(aabbs_device.view(), ncells);
 
   // check BVH bounding box
   BoxType bounds = bvh.getBounds();
@@ -467,10 +474,31 @@ void check_find_bounding_boxes2d()
   }
 
   // traverse the BVH to find the candidates for all the bounding boxes
-  axom::Array<IndexType> offsets(N);
-  axom::Array<IndexType> counts(N);
-  axom::Array<IndexType> candidates;
-  bvh.findBoundingBoxes(offsets, counts, candidates, N, query_boxes);
+  axom::Array<IndexType> offsets_device(N, N, deviceAllocatorID);
+  axom::Array<IndexType> counts_device(N, N, deviceAllocatorID);
+  axom::Array<IndexType> candidates_device(0, 0, deviceAllocatorID);
+  axom::Array<BoxType> query_boxes_device =
+    axom::Array<BoxType>(query_boxes, deviceAllocatorID);
+
+  // Create views of device arrays
+  auto offsets_view = offsets_device.view();
+  auto counts_view = counts_device.view();
+  auto query_boxes_view = query_boxes_device.view();
+  auto candidates_view = candidates_device.view();
+
+  bvh.findBoundingBoxes(offsets_view,
+                        counts_view,
+                        candidates_device,
+                        N,
+                        query_boxes_view);
+
+  // Copy back to host
+  axom::Array<IndexType> counts =
+    axom::Array<IndexType>(counts_device, hostAllocatorID);
+  axom::Array<IndexType> offsets =
+    axom::Array<IndexType>(offsets_device, hostAllocatorID);
+  axom::Array<IndexType> candidates =
+    axom::Array<IndexType>(candidates_device, hostAllocatorID);
 
   // flag cells that are found by the bounding box ID
   int* iblank = mesh.createField<int>("iblank", mint::CELL_CENTERED);
@@ -508,16 +536,9 @@ void check_find_bounding_boxes2d()
     }
 
   }  // END for all mesh cells
-
-  // deallocate
-  axom::deallocate(aabbs);
-
-  axom::deallocate(query_boxes);
-
-  axom::setDefaultAllocator(current_allocator);
 }
 
-//------------------------------------------------------------------------------
+// //------------------------------------------------------------------------------
 template <typename ExecSpace, typename FloatType>
 void check_find_rays3d()
 {
@@ -529,13 +550,14 @@ void check_find_rays3d()
   using PointType = typename primal::Point<FloatType, NDIMS>;
   using VectorType = typename primal::Vector<FloatType, NDIMS>;
 
-  const int current_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+  const int hostAllocatorID =
+    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   // setup query rays: both rays are source at (-1.0,-1.0) but point in
   // opposite directions. The first ray is setup such that it intersects
   // three bounding boxes of the mesh.
-  RayType* query_rays = axom::allocate<RayType>(N);
+  axom::Array<RayType> query_rays(N, N, hostAllocatorID);
   query_rays[0] =
     RayType {PointType {-1.0, -1.0, -1.0}, VectorType {1.0, 1.0, 1.0}};
   query_rays[1] =
@@ -552,14 +574,18 @@ void check_find_rays3d()
   double hi[NDIMS] = {3.0, 3.0, 3.0};
   mint::UniformMesh mesh(lo, hi, 4, 4, 4);
   const IndexType ncells = mesh.getNumberOfCells();
-  BoxType* aabbs = nullptr;
-  generate_aabbs(&mesh, aabbs);
-  EXPECT_TRUE(aabbs != nullptr);
+  axom::Array<BoxType> aabbs(ncells, ncells, hostAllocatorID);
+  generate_aabbs(&mesh, aabbs.view());
+  EXPECT_TRUE(aabbs.data() != nullptr);
+
+  // Move aabbs to device
+  axom::Array<BoxType> aabbs_device =
+    axom::Array<BoxType>(aabbs, deviceAllocatorID);
 
   // construct the BVH
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;
   bvh.setScaleFactor(1.0);  // i.e., no scaling
-  bvh.initialize(aabbs, ncells);
+  bvh.initialize(aabbs_device.view(), ncells);
 
   // check BVH bounding box
   BoxType bounds = bvh.getBounds();
@@ -570,11 +596,28 @@ void check_find_rays3d()
     EXPECT_NEAR(bounds.getMax()[idim], hi[idim], EPS);
   }
 
-  // traverse the BVH to find the candidates for all the centroids
-  axom::Array<IndexType> offsets(N);
-  axom::Array<IndexType> counts(N);
-  axom::Array<IndexType> candidates;
-  bvh.findRays(offsets, counts, candidates, N, query_rays);
+  // traverse the BVH to find the candidates for all the bounding boxes
+  axom::Array<IndexType> offsets_device(N, N, deviceAllocatorID);
+  axom::Array<IndexType> counts_device(N, N, deviceAllocatorID);
+  axom::Array<IndexType> candidates_device(0, 0, deviceAllocatorID);
+  axom::Array<RayType> query_rays_device =
+    axom::Array<RayType>(query_rays, deviceAllocatorID);
+
+  // Create views of device arrays
+  auto offsets_view = offsets_device.view();
+  auto counts_view = counts_device.view();
+  auto query_rays_view = query_rays_device.view();
+  auto candidates_view = candidates_device.view();
+
+  bvh.findRays(offsets_view, counts_view, candidates_device, N, query_rays_view);
+
+  // Copy back to host
+  axom::Array<IndexType> counts =
+    axom::Array<IndexType>(counts_device, hostAllocatorID);
+  axom::Array<IndexType> offsets =
+    axom::Array<IndexType>(offsets_device, hostAllocatorID);
+  axom::Array<IndexType> candidates =
+    axom::Array<IndexType>(candidates_device, hostAllocatorID);
 
   // flag cells that are found by the ray ID
   int* iblank = mesh.createField<int>("iblank", mint::CELL_CENTERED);
@@ -629,16 +672,9 @@ void check_find_rays3d()
       EXPECT_EQ(iblank[i], DOES_NOT_INTERSECT_RAY);
     }
   }  // END for all mesh cells
-
-  // deallocate
-  axom::deallocate(aabbs);
-
-  axom::deallocate(query_rays);
-
-  axom::setDefaultAllocator(current_allocator);
 }
 
-//------------------------------------------------------------------------------
+// //------------------------------------------------------------------------------
 
 template <typename ExecSpace, typename FloatType>
 void check_find_rays2d()
@@ -651,13 +687,14 @@ void check_find_rays2d()
   using PointType = typename primal::Point<FloatType, NDIMS>;
   using VectorType = typename primal::Vector<FloatType, NDIMS>;
 
-  const int current_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+  const int hostAllocatorID =
+    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   // setup query rays: both rays are source at (-1.0,-1.0) but point in
   // opposite directions. The first ray is setup such that it intersects
   // seven bounding boxes of the mesh.
-  RayType* query_rays = axom::allocate<RayType>(N);
+  axom::Array<RayType> query_rays(N, N, hostAllocatorID);
   query_rays[0] = RayType {PointType {-1.0, -1.0}, VectorType {1.0, 1.0}};
   query_rays[1] = RayType {PointType {-1.0, -1.0}, VectorType {-1.0, -1.0}};
 
@@ -682,14 +719,18 @@ void check_find_rays2d()
   double hi[NDIMS] = {3.0, 3.0};
   mint::UniformMesh mesh(lo, hi, 4, 4);
   const IndexType ncells = mesh.getNumberOfCells();
-  BoxType* aabbs = nullptr;
-  generate_aabbs(&mesh, aabbs);
-  EXPECT_TRUE(aabbs != nullptr);
+  axom::Array<BoxType> aabbs(ncells, ncells, hostAllocatorID);
+  generate_aabbs(&mesh, aabbs.view());
+  EXPECT_TRUE(aabbs.data() != nullptr);
+
+  // Move aabbs to device
+  axom::Array<BoxType> aabbs_device =
+    axom::Array<BoxType>(aabbs, deviceAllocatorID);
 
   // construct the BVH
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;
   bvh.setScaleFactor(1.0);  // i.e., no scaling
-  bvh.initialize(aabbs, ncells);
+  bvh.initialize(aabbs_device.view(), ncells);
 
   // check BVH bounding box
   BoxType bounds = bvh.getBounds();
@@ -700,11 +741,28 @@ void check_find_rays2d()
     EXPECT_NEAR(bounds.getMax()[idim], hi[idim], EPS);
   }
 
-  // traverse the BVH to find the candidates for all the centroids
-  axom::Array<IndexType> offsets(N);
-  axom::Array<IndexType> counts(N);
-  axom::Array<IndexType> candidates;
-  bvh.findRays(offsets, counts, candidates, N, query_rays);
+  // traverse the BVH to find the candidates for all the bounding boxes
+  axom::Array<IndexType> offsets_device(N, N, deviceAllocatorID);
+  axom::Array<IndexType> counts_device(N, N, deviceAllocatorID);
+  axom::Array<IndexType> candidates_device(0, 0, deviceAllocatorID);
+  axom::Array<RayType> query_rays_device =
+    axom::Array<RayType>(query_rays, deviceAllocatorID);
+
+  // Create views of device arrays
+  auto offsets_view = offsets_device.view();
+  auto counts_view = counts_device.view();
+  auto query_rays_view = query_rays_device.view();
+  auto candidates_view = candidates_device.view();
+
+  bvh.findRays(offsets_view, counts_view, candidates_device, N, query_rays_view);
+
+  // Copy back to host
+  axom::Array<IndexType> counts =
+    axom::Array<IndexType>(counts_device, hostAllocatorID);
+  axom::Array<IndexType> offsets =
+    axom::Array<IndexType>(offsets_device, hostAllocatorID);
+  axom::Array<IndexType> candidates =
+    axom::Array<IndexType>(candidates_device, hostAllocatorID);
 
   // flag cells that are found by the ray ID
   int* iblank = mesh.createField<int>("iblank", mint::CELL_CENTERED);
@@ -746,13 +804,6 @@ void check_find_rays2d()
     }
 
   }  // END for all mesh cells
-
-  // deallocate
-  axom::deallocate(aabbs);
-
-  axom::deallocate(query_rays);
-
-  axom::setDefaultAllocator(current_allocator);
 }
 
 //------------------------------------------------------------------------------
@@ -777,8 +828,9 @@ void check_find_points3d()
   constexpr int NDIMS = 3;
   constexpr IndexType N = 4;
 
-  const int current_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+  const int hostAllocatorID =
+    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   using BoxType = typename primal::BoundingBox<FloatType, NDIMS>;
   using PointType = primal::Point<FloatType, NDIMS>;
@@ -794,13 +846,18 @@ void check_find_points3d()
   PointType* centroids = reinterpret_cast<PointType*>(centroids_raw);
   const IndexType ncells = mesh.getNumberOfCells();
 
-  BoxType* aabbs = nullptr;
-  generate_aabbs_and_centroids(&mesh, aabbs, centroids);
+  axom::Array<BoxType> aabbs(ncells, ncells, hostAllocatorID);
+  generate_aabbs_and_centroids(&mesh, aabbs.view(), centroids);
+  EXPECT_TRUE(aabbs.data() != nullptr);
+
+  // Move aabbs to device
+  axom::Array<BoxType> aabbs_device =
+    axom::Array<BoxType>(aabbs, deviceAllocatorID);
 
   // construct the BVH
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;
   bvh.setScaleFactor(1.0);  // i.e., no scaling
-  bvh.initialize(aabbs, ncells);
+  bvh.initialize(aabbs_device.view(), ncells);
 
   BoxType bounds = bvh.getBounds();
 
@@ -810,11 +867,32 @@ void check_find_points3d()
     EXPECT_NEAR(bounds.getMax()[idim], hi[idim], EPS);
   }
 
-  // traverse the BVH to find the candidates for all the centroids
-  axom::Array<IndexType> offsets(ncells);
-  axom::Array<IndexType> counts(ncells);
-  axom::Array<IndexType> candidates;
-  bvh.findPoints(offsets, counts, candidates, ncells, centroids);
+  // traverse the BVH to find the candidates for all the bounding boxes
+  axom::Array<IndexType> offsets_device(ncells, ncells, deviceAllocatorID);
+  axom::Array<IndexType> counts_device(ncells, ncells, deviceAllocatorID);
+  axom::Array<IndexType> candidates_device(0, 0, deviceAllocatorID);
+  PointType* centroids_device =
+    axom::allocate<PointType>(ncells, deviceAllocatorID);
+  axom::copy(centroids_device, centroids, ncells * sizeof(PointType));
+
+  // Create views of device arrays
+  auto offsets_view = offsets_device.view();
+  auto counts_view = counts_device.view();
+  auto candidates_view = candidates_device.view();
+
+  bvh.findPoints(offsets_view,
+                 counts_view,
+                 candidates_device,
+                 ncells,
+                 centroids_device);
+
+  // Copy back to host
+  axom::Array<IndexType> counts =
+    axom::Array<IndexType>(counts_device, hostAllocatorID);
+  axom::Array<IndexType> offsets =
+    axom::Array<IndexType>(offsets_device, hostAllocatorID);
+  axom::Array<IndexType> candidates =
+    axom::Array<IndexType>(candidates_device, hostAllocatorID);
 
   spin::UniformGrid<IndexType, NDIMS> ug(lo, hi, res);
 
@@ -835,16 +913,24 @@ void check_find_points3d()
     centroids[i][2] += OFFSET;
   }
 
-  bvh.findPoints(offsets, counts, candidates, ncells, centroids);
+  // Reallocate modified centroids on device
+  axom::copy(centroids_device, centroids, ncells * sizeof(PointType));
+
+  bvh.findPoints(offsets_view,
+                 counts_view,
+                 candidates_device,
+                 ncells,
+                 centroids_device);
+
+  // Copy back to host
+  counts = axom::Array<IndexType>(counts_device, hostAllocatorID);
 
   for(IndexType i = 0; i < ncells; ++i)
   {
     EXPECT_EQ(counts[i], 0);
   }
 
-  axom::deallocate(aabbs);
-
-  axom::setDefaultAllocator(current_allocator);
+  axom::deallocate(centroids_device);
 }
 
 //------------------------------------------------------------------------------
@@ -869,8 +955,9 @@ void check_find_points2d()
   constexpr int NDIMS = 2;
   constexpr IndexType N = 4;
 
-  const int current_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+  const int hostAllocatorID =
+    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   using BoxType = typename primal::BoundingBox<FloatType, NDIMS>;
   using PointType = primal::Point<FloatType, NDIMS>;
@@ -886,13 +973,18 @@ void check_find_points2d()
   PointType* centroids = reinterpret_cast<PointType*>(centroids_raw);
   const IndexType ncells = mesh.getNumberOfCells();
 
-  BoxType* aabbs = nullptr;
-  generate_aabbs_and_centroids(&mesh, aabbs, centroids);
+  axom::Array<BoxType> aabbs(ncells, ncells, hostAllocatorID);
+  generate_aabbs_and_centroids(&mesh, aabbs.view(), centroids);
+  EXPECT_TRUE(aabbs.data() != nullptr);
+
+  // Move aabbs to device
+  axom::Array<BoxType> aabbs_device =
+    axom::Array<BoxType>(aabbs, deviceAllocatorID);
 
   // construct the BVH
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;
   bvh.setScaleFactor(1.0);  // i.e., no scaling
-  bvh.initialize(aabbs, ncells);
+  bvh.initialize(aabbs_device.view(), ncells);
 
   BoxType bounds = bvh.getBounds();
 
@@ -902,11 +994,32 @@ void check_find_points2d()
     EXPECT_NEAR(bounds.getMax()[idim], hi[idim], EPS);
   }
 
-  // traverse the BVH to find the candidates for all the centroids
-  axom::Array<IndexType> offsets(ncells);
-  axom::Array<IndexType> counts(ncells);
-  axom::Array<IndexType> candidates;
-  bvh.findPoints(offsets, counts, candidates, ncells, centroids);
+  // traverse the BVH to find the candidates for all the bounding boxes
+  axom::Array<IndexType> offsets_device(ncells, ncells, deviceAllocatorID);
+  axom::Array<IndexType> counts_device(ncells, ncells, deviceAllocatorID);
+  axom::Array<IndexType> candidates_device(0, 0, deviceAllocatorID);
+  PointType* centroids_device =
+    axom::allocate<PointType>(ncells, deviceAllocatorID);
+  axom::copy(centroids_device, centroids, ncells * sizeof(PointType));
+
+  // Create views of device arrays
+  auto offsets_view = offsets_device.view();
+  auto counts_view = counts_device.view();
+  auto candidates_view = candidates_device.view();
+
+  bvh.findPoints(offsets_view,
+                 counts_view,
+                 candidates_device,
+                 ncells,
+                 centroids_device);
+
+  // Copy back to host
+  axom::Array<IndexType> counts =
+    axom::Array<IndexType>(counts_device, hostAllocatorID);
+  axom::Array<IndexType> offsets =
+    axom::Array<IndexType>(offsets_device, hostAllocatorID);
+  axom::Array<IndexType> candidates =
+    axom::Array<IndexType>(candidates_device, hostAllocatorID);
 
   spin::UniformGrid<IndexType, NDIMS> ug(lo, hi, res);
 
@@ -926,16 +1039,24 @@ void check_find_points2d()
     centroids[i][1] += OFFSET;
   }
 
-  bvh.findPoints(offsets, counts, candidates, ncells, centroids);
+  // Reallocate modified centroids on device
+  axom::copy(centroids_device, centroids, ncells * sizeof(PointType));
+
+  bvh.findPoints(offsets_view,
+                 counts_view,
+                 candidates_device,
+                 ncells,
+                 centroids_device);
+
+  // Copy back to host
+  counts = axom::Array<IndexType>(counts_device, hostAllocatorID);
 
   for(IndexType i = 0; i < ncells; ++i)
   {
     EXPECT_EQ(counts[i], 0);
   }
 
-  axom::deallocate(aabbs);
-
-  axom::setDefaultAllocator(current_allocator);
+  axom::deallocate(centroids_device);
 }
 
 //------------------------------------------------------------------------------
@@ -955,17 +1076,22 @@ void check_single_box2d()
   using BoxType = typename primal::BoundingBox<FloatType, NDIMS>;
   using PointType = primal::Point<FloatType, NDIMS>;
 
-  const int current_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+  const int hostAllocatorID =
+    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   // single bounding box in [0,1] x [0,1]
-  BoxType* boxes = axom::allocate<BoxType>(2);
+  axom::Array<BoxType> boxes(2, 2, hostAllocatorID);
   boxes[0] = BoxType {PointType(0.), PointType(1.)};
 
-  // construct a BVH with a single box
+  // Move box to device
+  axom::Array<BoxType> boxes_device =
+    axom::Array<BoxType>(boxes, deviceAllocatorID);
+
+  // construct the BVH with a single box
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;
   bvh.setScaleFactor(1.0);  // i.e., no scaling
-  bvh.initialize(boxes, NUM_BOXES);
+  bvh.initialize(boxes_device.view(), NUM_BOXES);
 
   // check the bounds -- should match the bounds of the input bounding box
   BoxType bounds = bvh.getBounds();
@@ -980,13 +1106,32 @@ void check_single_box2d()
   // Should return one and only one candidate that corresponds to the
   // single bounding box.
   PointType centroid {0.5, 0.5};
-  PointType* centroid_device = axom::allocate<PointType>(1);
+  PointType* centroid_device = axom::allocate<PointType>(1, deviceAllocatorID);
   axom::copy(centroid_device, &centroid, sizeof(PointType));
 
-  axom::Array<IndexType> offsets(NUM_BOXES);
-  axom::Array<IndexType> counts(NUM_BOXES);
-  axom::Array<IndexType> candidates;
-  bvh.findPoints(offsets, counts, candidates, NUM_BOXES, centroid_device);
+  axom::Array<IndexType> offsets_device(NUM_BOXES, NUM_BOXES, deviceAllocatorID);
+  axom::Array<IndexType> counts_device(NUM_BOXES, NUM_BOXES, deviceAllocatorID);
+  axom::Array<IndexType> candidates_device(0, 0, deviceAllocatorID);
+
+  // Create views of device arrays
+  auto offsets_view = offsets_device.view();
+  auto counts_view = counts_device.view();
+  auto candidates_view = candidates_device.view();
+
+  bvh.findPoints(offsets_view,
+                 counts_view,
+                 candidates_device,
+                 NUM_BOXES,
+                 centroid_device);
+
+  // Copy back to host
+  axom::Array<IndexType> counts =
+    axom::Array<IndexType>(counts_device, hostAllocatorID);
+  axom::Array<IndexType> offsets =
+    axom::Array<IndexType>(offsets_device, hostAllocatorID);
+  axom::Array<IndexType> candidates =
+    axom::Array<IndexType>(candidates_device, hostAllocatorID);
+
   EXPECT_EQ(counts[0], 1);
   EXPECT_EQ(0, candidates[offsets[0]]);
 
@@ -994,14 +1139,18 @@ void check_single_box2d()
   centroid[0] += 10.0;
   centroid[1] += 10.0;
   axom::copy(centroid_device, &centroid, sizeof(PointType));
-  bvh.findPoints(offsets, counts, candidates, NUM_BOXES, centroid_device);
+  bvh.findPoints(offsets_view,
+                 counts_view,
+                 candidates_device,
+                 NUM_BOXES,
+                 centroid_device);
+
+  // Copy back to host
+  counts = axom::Array<IndexType>(counts_device, hostAllocatorID);
 
   EXPECT_EQ(counts[0], 0);
 
   axom::deallocate(centroid_device);
-  axom::deallocate(boxes);
-
-  axom::setDefaultAllocator(current_allocator);
 }
 
 //------------------------------------------------------------------------------
@@ -1021,17 +1170,22 @@ void check_single_box3d()
   using BoxType = typename primal::BoundingBox<FloatType, NDIMS>;
   using PointType = primal::Point<FloatType, NDIMS>;
 
-  const int current_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(axom::execution_space<ExecSpace>::allocatorID());
+  const int hostAllocatorID =
+    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
 
   // single bounding box in [0,1] x [0,1] x [0,1]
-  BoxType* boxes = axom::allocate<BoxType>(2);
+  axom::Array<BoxType> boxes(2, 2, hostAllocatorID);
   boxes[0] = BoxType {PointType(0.), PointType(1.)};
 
-  // construct a BVH with a single box
+  // Move box to device
+  axom::Array<BoxType> boxes_device =
+    axom::Array<BoxType>(boxes, deviceAllocatorID);
+
+  // construct the BVH with a single box
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;
   bvh.setScaleFactor(1.0);  // i.e., no scaling
-  bvh.initialize(boxes, NUM_BOXES);
+  bvh.initialize(boxes_device.view(), NUM_BOXES);
 
   // check the bounds -- should match the bounds of the input bounding box
   BoxType bounds = bvh.getBounds();
@@ -1046,13 +1200,31 @@ void check_single_box3d()
   // Should return one and only one candidate that corresponds to the
   // single bounding box.
   PointType centroid {0.5, 0.5, 0.5};
-  PointType* centroid_device = axom::allocate<PointType>(1);
+  PointType* centroid_device = axom::allocate<PointType>(1, deviceAllocatorID);
   axom::copy(centroid_device, &centroid, sizeof(PointType));
 
-  axom::Array<IndexType> offsets(NUM_BOXES);
-  axom::Array<IndexType> counts(NUM_BOXES);
-  axom::Array<IndexType> candidates;
-  bvh.findPoints(offsets, counts, candidates, NUM_BOXES, centroid_device);
+  axom::Array<IndexType> offsets_device(NUM_BOXES, NUM_BOXES, deviceAllocatorID);
+  axom::Array<IndexType> counts_device(NUM_BOXES, NUM_BOXES, deviceAllocatorID);
+  axom::Array<IndexType> candidates_device(0, 0, deviceAllocatorID);
+
+  // Create views of device arrays
+  auto offsets_view = offsets_device.view();
+  auto counts_view = counts_device.view();
+  auto candidates_view = candidates_device.view();
+
+  bvh.findPoints(offsets_view,
+                 counts_view,
+                 candidates_device,
+                 NUM_BOXES,
+                 centroid_device);
+
+  // Copy back to host
+  axom::Array<IndexType> counts =
+    axom::Array<IndexType>(counts_device, hostAllocatorID);
+  axom::Array<IndexType> offsets =
+    axom::Array<IndexType>(offsets_device, hostAllocatorID);
+  axom::Array<IndexType> candidates =
+    axom::Array<IndexType>(candidates_device, hostAllocatorID);
 
   EXPECT_EQ(counts[0], 1);
   EXPECT_EQ(0, candidates[offsets[0]]);
@@ -1061,14 +1233,18 @@ void check_single_box3d()
   centroid[0] += 10.0;
   centroid[1] += 10.0;
   axom::copy(centroid_device, &centroid, sizeof(PointType));
-  bvh.findPoints(offsets, counts, candidates, NUM_BOXES, centroid_device);
+  bvh.findPoints(offsets_view,
+                 counts_view,
+                 candidates_device,
+                 NUM_BOXES,
+                 centroid_device);
+
+  // Copy back to host
+  counts = axom::Array<IndexType>(counts_device, hostAllocatorID);
 
   EXPECT_EQ(counts[0], 0);
 
   axom::deallocate(centroid_device);
-  axom::deallocate(boxes);
-
-  axom::setDefaultAllocator(current_allocator);
 }
 
 //------------------------------------------------------------------------------
@@ -1170,8 +1346,8 @@ void check_find_points_zip3d()
   PointType* centroids = reinterpret_cast<PointType*>(centroids_raw);
   const IndexType ncells = mesh.getNumberOfCells();
 
-  BoxType* aabbs = nullptr;
-  generate_aabbs_and_centroids(&mesh, aabbs, centroids);
+  axom::Array<BoxType> aabbs(ncells, ncells, current_allocator);
+  generate_aabbs_and_centroids(&mesh, aabbs.view(), centroids);
 
   axom::Array<FloatType> xs(ncells, ncells);
   axom::Array<FloatType> ys(ncells, ncells);
@@ -1215,8 +1391,6 @@ void check_find_points_zip3d()
     EXPECT_EQ(donorCellIdx, candidates[offsets[i]]);
   }
 
-  axom::deallocate(aabbs);
-
   axom::setDefaultAllocator(current_allocator);
 }
 
@@ -1259,8 +1433,8 @@ void check_find_points_zip2d()
   PointType* centroids = reinterpret_cast<PointType*>(centroids_raw);
   const IndexType ncells = mesh.getNumberOfCells();
 
-  BoxType* aabbs = nullptr;
-  generate_aabbs_and_centroids(&mesh, aabbs, centroids);
+  axom::Array<BoxType> aabbs(ncells, ncells, current_allocator);
+  generate_aabbs_and_centroids(&mesh, aabbs.view(), centroids);
 
   axom::Array<FloatType> xs(ncells, ncells);
   axom::Array<FloatType> ys(ncells, ncells);
@@ -1302,8 +1476,6 @@ void check_find_points_zip2d()
     EXPECT_EQ(counts[i], 1);
     EXPECT_EQ(donorCellIdx, candidates[offsets[i]]);
   }  // END for all cell centroids
-
-  axom::deallocate(aabbs);
 
   axom::setDefaultAllocator(current_allocator);
 }
@@ -1365,6 +1537,10 @@ void bvh_compute_point_distances_2d(BVHType& bvh,
   constexpr int INVALID_ELEMENT_INDEX = -1;
   constexpr int FIRST_ELEMENT_INDEX = 0;
 
+  const int hostAllocatorID =
+    axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  const int deviceAllocatorID = axom::execution_space<ExecSpace>::allocatorID();
+
   // Borrowed from DistibutedClosestPoint.
   struct MinCandidate
   {
@@ -1376,37 +1552,49 @@ void bvh_compute_point_distances_2d(BVHType& bvh,
 
   // Initialize the BVH with the points.
   axom::IndexType npts = none ? 0 : points.size();
-  BoxType* bboxes =
-    axom::allocate<BoxType>(npts ? npts : 1,  // do not allocate 0 elements
-                            axom::execution_space<ExecSpace>::allocatorID());
+  // do not allocate 0 elements
+  axom::Array<BoxType> bboxes = npts
+    ? axom::Array<BoxType>(npts, npts, hostAllocatorID)
+    : axom::Array<BoxType>(1, 1, hostAllocatorID);
   for(axom::IndexType i = 0; i < npts; i++)
   {
     bboxes[i] = BoxType(points[i]);
   }
-  bvh.initialize(bboxes, npts);
+
+  // Copy boxes to device
+  axom::Array<BoxType> bboxes_device =
+    axom::Array<BoxType>(bboxes, deviceAllocatorID);
+
+  bvh.initialize(bboxes_device.view(), npts);
 
   // Call the BVH like the DistributedClosestPoint does.
   auto it = bvh.getTraverser();
 
   // Make a results array to contain the data values we read.
-  axom::Array<int> results(query_pts.size());
-  axom::ArrayView<int> results_view(results.data(), results.size());
+  axom::Array<int> results_device(query_pts.size(),
+                                  query_pts.size(),
+                                  deviceAllocatorID);
+  axom::ArrayView<int> results_view = results_device.view();
 
   // Loop over the query points.
-  axom::ArrayView<PointType> pointsView(points.data(), points.size());
-  axom::ArrayView<PointType> query_pts_view(query_pts.data(), query_pts.size());
+  axom::Array<PointType> points_device =
+    axom::Array<PointType>(points, deviceAllocatorID);
+  axom::ArrayView<PointType> points_device_view = points_device.view();
+  axom::Array<PointType> query_pts_device =
+    axom::Array<PointType>(query_pts, deviceAllocatorID);
+  axom::ArrayView<PointType> query_pts_device_view = query_pts_device.view();
   npts = query_pts.size();
   axom::for_all<ExecSpace>(
     npts,
     AXOM_LAMBDA(std::int32_t idx) mutable {
       // Get the current query point.
-      auto qpt = query_pts_view[idx];
+      auto qpt = query_pts_device_view[idx];
       MinCandidate curr_min;
 
       auto checkMinDist = [&](std::int32_t current_node,
                               const std::int32_t* leaf_nodes) {
         int candidate_idx = leaf_nodes[current_node];
-        const PointType candidate_pt = pointsView[candidate_idx];
+        const PointType candidate_pt = points_device_view[candidate_idx];
         const double sq_dist = squared_distance(qpt, candidate_pt);
 
         if(sq_dist < curr_min.minSqDist)
@@ -1429,25 +1617,21 @@ void bvh_compute_point_distances_2d(BVHType& bvh,
       results_view[idx] = curr_min.minElem;
     });
 
+  // Copy results back to host
+  axom::Array<int> results = axom::Array<int>(results_device, hostAllocatorID);
+
   // Make sure all of the indices we found are the expected value.
   int expected_idx = none ? INVALID_ELEMENT_INDEX : FIRST_ELEMENT_INDEX;
   for(axom::IndexType i = 0; i < results.size(); i++)
   {
     EXPECT_EQ(expected_idx, results[i]);
   }
-
-  axom::deallocate(bboxes);
 }
 
 //------------------------------------------------------------------------------
 template <typename ExecType, typename FloatType>
 void check_0_or_1_bbox_2d()
 {
-  // Temporarily force the allocator for the ExecType so the query points as
-  // well as any other important allocations are available in that space.
-  const int current_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(axom::execution_space<ExecType>::allocatorID());
-
   // Make a 1 element array that we'll access from a BVH callback lambda.
   using PointType = axom::primal::Point<FloatType, 2>;
   axom::Array<PointType> src_pts;
@@ -1464,8 +1648,6 @@ void check_0_or_1_bbox_2d()
   // 0 src points
   spin::BVH<2, ExecType, FloatType> bvh2;
   bvh_compute_point_distances_2d(bvh2, src_pts, query_pts, true);
-
-  axom::setDefaultAllocator(current_allocator);
 }
 
 } /* end unnamed namespace */

--- a/src/axom/spin/tests/spin_implicit_grid.cpp
+++ b/src/axom/spin/tests/spin_implicit_grid.cpp
@@ -487,13 +487,14 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_pt_vectorized)
 
   GridT grid(bbox, &res, maxElts);
 
-  axom::Array<BBox> objBox1(1, 1, kernelAllocID);
+  axom::Array<BBox> objBox1(1, 1, hostAllocID);
   objBox1[0] = BBox {SpacePt {.15, .25, .05}, SpacePt {.45, .25, .35}};
 
-  grid.insert(objBox1[0], 1);
+  axom::Array<BBox> objBox1_device = axom::Array<BBox>(objBox1, kernelAllocID);
+  grid.insert(objBox1_device[0], 1);
 
   {
-    axom::Array<SpacePt> queryPts(9, 9, kernelAllocID);
+    axom::Array<SpacePt> queryPts(9, 9, hostAllocID);
 
     // First three query points inside only obj1
     queryPts[0] = objBox1[0].getMin();
@@ -512,13 +513,15 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_pt_vectorized)
 
     axom::Array<int> count, offset, candidates;
     {
+      axom::Array<SpacePt> queryPtsDevice =
+        axom::Array<SpacePt>(queryPts, kernelAllocID);
       axom::Array<int> countDevice(9, 9, kernelAllocID);
       axom::Array<int> offsetDevice(9, 9, kernelAllocID);
       axom::Array<int> candidatesDevice;
 
       // Run query against implicit grid
       grid.getCandidatesAsArray(9,
-                                queryPts.data(),
+                                queryPtsDevice.data(),
                                 offsetDevice,
                                 countDevice,
                                 candidatesDevice);
@@ -528,8 +531,6 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_pt_vectorized)
       offset = axom::Array<int>(offsetDevice, hostAllocID);
       candidates = axom::Array<int>(candidatesDevice, hostAllocID);
     }
-
-    // Copy results back to the host
 
     // Test some points that are expected to match
     for(int i = 0; i < 5; ++i)
@@ -546,16 +547,18 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_pt_vectorized)
     }
   }
 
-  axom::Array<BBox> objBox2(1, 1, kernelAllocID);
+  axom::Array<BBox> objBox2(1, 1, hostAllocID);
   objBox2[0] = BBox {SpacePt {.75, .85, .85}, SpacePt(.85)};
-  grid.insert(objBox2[0], 2);
+  axom::Array<BBox> objBox2_device = axom::Array<BBox>(objBox2, kernelAllocID);
+  grid.insert(objBox2_device[0], 2);
 
-  axom::Array<BBox> objBox3(1, 1, kernelAllocID);
+  axom::Array<BBox> objBox3(1, 1, hostAllocID);
   objBox3[0] = BBox {SpacePt {.85, .85, .75}, SpacePt(.95)};
-  grid.insert(objBox3[0], 3);
+  axom::Array<BBox> objBox3_device = axom::Array<BBox>(objBox3, kernelAllocID);
+  grid.insert(objBox3_device[0], 3);
 
   {
-    axom::Array<SpacePt> queryPts(3, 3, kernelAllocID);
+    axom::Array<SpacePt> queryPts(3, 3, hostAllocID);
 
     // Should only be inside obj2
     queryPts[0] = SpacePt {.75, .85, .85};
@@ -566,12 +569,14 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_pt_vectorized)
 
     axom::Array<int> count, offset, candidates;
     {
+      axom::Array<SpacePt> queryPtsDevice =
+        axom::Array<SpacePt>(queryPts, kernelAllocID);
       axom::Array<int> countDevice(3, 3, kernelAllocID);
       axom::Array<int> offsetDevice(3, 3, kernelAllocID);
       axom::Array<int> candidatesDevice;
       // Run query against implicit grid
       grid.getCandidatesAsArray(3,
-                                queryPts.data(),
+                                queryPtsDevice.data(),
                                 offsetDevice,
                                 countDevice,
                                 candidatesDevice);
@@ -786,6 +791,8 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_box_vectorized)
             << " execution space for boxes in " << DIM << "D");
 
   int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
+  int unifiedAllocID =
+    axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
   int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
 
   // Note: A 10 x 10 x 10 implicit grid in the unit cube.
@@ -794,13 +801,15 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_box_vectorized)
   BBox bbox(SpacePt(0.), SpacePt(1.));
   const int maxElts = 30;
 
-  GridT grid(bbox, &res, maxElts);
+  // Initialize Implicit Grid in unified memory.
+  // getCandidates() function not yet __host __device__ decorated
+  GridT grid(bbox, &res, maxElts, unifiedAllocID);
   const int i_max = DIM >= 1 ? grid.gridResolution()[0] : 1;
   const int j_max = DIM >= 2 ? grid.gridResolution()[1] : 1;
   const int k_max = DIM >= 3 ? grid.gridResolution()[2] : 1;
 
-  axom::Array<BBox> BBoxes(maxElts, maxElts, kernelAllocID);
-  axom::Array<SpacePt> queryPt(1, 1, kernelAllocID);
+  axom::Array<BBox> BBoxes(maxElts, maxElts, hostAllocID);
+  axom::Array<SpacePt> queryPt(1, 1, hostAllocID);
 
   // Add some boxes to the spatial index
   {
@@ -835,8 +844,10 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_box_vectorized)
       }
     }
 
-    grid.insert(10 * DIM, BBoxes.data(), 0);
+    // Copy boxes to unified memory (for getCandidates() call)
+    axom::Array<BBox> BBoxesDevice = axom::Array<BBox>(BBoxes, unifiedAllocID);
 
+    grid.insert(10 * DIM, BBoxesDevice.data(), 0);
     // Check that each grid cell contains DIM objects
     for(int i = 0; i < i_max; ++i)
     {
@@ -845,7 +856,9 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_box_vectorized)
         for(int k = 0; k < k_max; ++k)
         {
           queryPt[0] = SpacePt {i * .1 + .05, j * .1 + .05, k * .1 + .05};
-          EXPECT_EQ(DIM, grid.getCandidates(queryPt[0]).count());
+          axom::Array<SpacePt> queryPtDevice =
+            axom::Array<SpacePt>(queryPt, unifiedAllocID);
+          EXPECT_EQ(DIM, grid.getCandidates(queryPtDevice[0]).count());
         }
       }
     }
@@ -853,7 +866,7 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_box_vectorized)
 
   //// Run some queries
   constexpr int N_QUERIES = 8;
-  axom::Array<BBox> queryBoxes(N_QUERIES, N_QUERIES, kernelAllocID);
+  axom::Array<BBox> queryBoxes(N_QUERIES, N_QUERIES, hostAllocID);
 
   // Empty box -- covers no objects
   queryBoxes[0] = BBox {};
@@ -883,13 +896,15 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_box_vectorized)
 
   axom::Array<int> offset, count, candidates;
   {
+    axom::Array<BBox> queryBoxesDevice =
+      axom::Array<BBox>(queryBoxes, kernelAllocID);
     axom::Array<int> countDevice(N_QUERIES, N_QUERIES, kernelAllocID);
     axom::Array<int> offsetDevice(N_QUERIES, N_QUERIES, kernelAllocID);
     axom::Array<int> candidatesDevice;
 
     // Run query against implicit grid
     grid.getCandidatesAsArray(N_QUERIES,
-                              queryBoxes.data(),
+                              queryBoxesDevice.data(),
                               offsetDevice,
                               countDevice,
                               candidatesDevice);

--- a/src/axom/spin/tests/spin_implicit_grid.cpp
+++ b/src/axom/spin/tests/spin_implicit_grid.cpp
@@ -790,10 +790,14 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_box_vectorized)
             << axom::execution_space<ExecSpace>::name()
             << " execution space for boxes in " << DIM << "D");
 
-  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
-  int unifiedAllocID =
-    axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
-  int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
+  int kernelAllocID = on_device
+    ? axom::getUmpireResourceAllocatorID(umpire::resource::Device)
+    : axom::execution_space<ExecSpace>::allocatorID();
+  int unifiedAllocID = on_device
+    ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
+    : axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  int hostAllocID = axom::getUmpireResourceAllocatorID(umpire::resource::Host);
 
   // Note: A 10 x 10 x 10 implicit grid in the unit cube.
   //       Grid cells have a spacing of .1 along each dimension

--- a/src/axom/spin/tests/spin_implicit_grid.cpp
+++ b/src/axom/spin/tests/spin_implicit_grid.cpp
@@ -790,14 +790,18 @@ TYPED_TEST(ImplicitGridExecTest, get_candidates_box_vectorized)
             << axom::execution_space<ExecSpace>::name()
             << " execution space for boxes in " << DIM << "D");
 
-  constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
-  int kernelAllocID = on_device
-    ? axom::getUmpireResourceAllocatorID(umpire::resource::Device)
-    : axom::execution_space<ExecSpace>::allocatorID();
-  int unifiedAllocID = on_device
-    ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
-    : axom::getUmpireResourceAllocatorID(umpire::resource::Host);
-  int hostAllocID = axom::getUmpireResourceAllocatorID(umpire::resource::Host);
+  int hostAllocID = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  int kernelAllocID = axom::execution_space<ExecSpace>::allocatorID();
+  int unifiedAllocID = axom::execution_space<ExecSpace>::allocatorID();
+
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
+  if(axom::execution_space<ExecSpace>::onDevice())
+  {
+    kernelAllocID = axom::getUmpireResourceAllocatorID(umpire::resource::Device);
+    unifiedAllocID =
+      axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  }
+#endif
 
   // Note: A 10 x 10 x 10 implicit grid in the unit cube.
   //       Grid cells have a spacing of .1 along each dimension

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -412,10 +412,14 @@ std::vector<std::pair<int, int>> naiveIntersectionAlgorithm(
   const int current_allocator = axom::getDefaultAllocatorID();
 
   // Use unified memory if on device
-  constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
-  int allocatorID = on_device
-    ? axom::getUmpireResourceAllocatorID(umpire::resource::Unified)
-    : axom::execution_space<ExecSpace>::allocatorID();
+  int allocatorID = axom::execution_space<ExecSpace>::allocatorID();
+  #if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
+  if(axom::execution_space<ExecPolicy>::onDevice())
+  {
+    allocatorID = axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+  }
+  #endif
+
   axom::setDefaultAllocator(allocatorID);
 
   std::vector<std::pair<int, int>> retval;

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -414,7 +414,7 @@ std::vector<std::pair<int, int>> naiveIntersectionAlgorithm(
   // Use unified memory if on device
   int allocatorID = axom::execution_space<ExecSpace>::allocatorID();
   #if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-  if(axom::execution_space<ExecPolicy>::onDevice())
+  if(axom::execution_space<ExecSpace>::onDevice())
   {
     allocatorID = axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
   }


### PR DESCRIPTION
This PR:
- Makes device the default Umpire allocator id instead of unified for CUDA and HIP execution policies.
- Adjusts unit tests and examples to reflect device memory as the new default.
  - For tests and examples where device id for memory allocation did not work, unified id is used instead.

Follow-up work is required to revisit tests and examples that still require unified memory, and adjust the source implementation.  These are captured in https://github.com/LLNL/axom/issues/1339