### PR TITLE
Improvements to annotations API

### DIFF
--- a/src/axom/core/CMakeLists.txt
+++ b/src/axom/core/CMakeLists.txt
@@ -24,6 +24,7 @@ set(core_headers
     utilities/About.hpp
     utilities/Annotations.hpp
     utilities/BitUtilities.hpp
+    utilities/CommandLineUtilities.hpp
     utilities/FileUtilities.hpp
     utilities/RAII.hpp
     utilities/StringUtilities.hpp

--- a/src/axom/core/utilities/Annotations.cpp
+++ b/src/axom/core/utilities/Annotations.cpp
@@ -18,13 +18,6 @@
 
 #include <set>
 
-#ifdef AXOM_USE_CALIPER
-namespace cali
-{
-extern Attribute region_attr;
-}
-#endif
-
 namespace axom
 {
 namespace utilities
@@ -403,18 +396,18 @@ void finalize()
 void begin(const std::string &name)
 {
 #ifdef AXOM_USE_CALIPER
-  cali::Caliper().begin(
-    cali::region_attr,
-    cali::Variant(CALI_TYPE_STRING, name.c_str(), name.length()));
+  cali_begin_region(name.c_str());
 #else
   AXOM_UNUSED_VAR(name);
 #endif
 }
 
-void end(const std::string & /*name*/)
+void end(const std::string &name)
 {
 #ifdef AXOM_USE_CALIPER
-  cali::Caliper().end(cali::region_attr);
+  cali_end_region(name.c_str());
+#else
+  AXOM_UNUSED_VAR(name);
 #endif
 }
 

--- a/src/axom/core/utilities/Annotations.cpp
+++ b/src/axom/core/utilities/Annotations.cpp
@@ -295,6 +295,8 @@ static std::string adiak_value_as_string(adiak_value_t *val, adiak_datatype_t *t
     return axom::fmt::format(
       "({})",
       axom::fmt::join(get_vals_array(t, val, adiak_num_subvals(t)), ", "));
+  default:
+    return std::string("<unknown type>");
   }
 }
 

--- a/src/axom/core/utilities/Annotations.cpp
+++ b/src/axom/core/utilities/Annotations.cpp
@@ -93,11 +93,6 @@ void initialize_caliper(const std::string &mode)
 {
 #ifdef AXOM_USE_CALIPER
   cali::ConfigManager::argmap_t app_args;
-
-  #ifdef AXOM_USE_MPI
-  cali_mpi_init();
-  #endif
-
   cali_mgr = new cali::ConfigManager();
   cali_mgr->add(mode.c_str(), app_args);
 

--- a/src/axom/core/utilities/Annotations.hpp
+++ b/src/axom/core/utilities/Annotations.hpp
@@ -49,7 +49,7 @@ void initialize_adiak();
 #endif
 
 /// \note Intended to be called from within the axom::utilities::annotations API
-void initialize_caliper(const std::string& mode, int num_ranks);
+void initialize_caliper(const std::string& mode);
 
 // Checks if the provided annotation mode is valid
 bool is_mode_valid(const std::string& mode);

--- a/src/axom/core/utilities/CommandLineUtilities.hpp
+++ b/src/axom/core/utilities/CommandLineUtilities.hpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ * \file CommandLineUtilities.hpp
+ *
+ * \brief Defines utilities in support of validating command line input
+ */
+
+#ifndef AXOM_CORE_COMMANDLINE_UTILITIES_HPP_
+#define AXOM_CORE_COMMANDLINE_UTILITIES_HPP_
+
+#include "axom/config.hpp"
+#include "axom/core/utilities/Annotations.hpp"
+
+#ifdef AXOM_USE_CLI11
+  #include "axom/CLI11.hpp"
+#endif
+#include "axom/fmt.hpp"
+
+#include <string>
+
+namespace axom
+{
+namespace utilities
+{
+#if defined(AXOM_USE_CLI11) && defined(AXOM_USE_CALIPER)
+/// Helper class for CLI11 to validate a caliper \a mode string passed into an axom app
+struct CaliperModeValidator : public axom::CLI::Validator
+{
+  CaliperModeValidator()
+  {
+    name_ = "MODE";
+    func_ = [](const std::string &str) {
+      if(str == "help")
+      {
+        return axom::fmt::format(
+          "Valid caliper modes are:\n{}\n",
+          axom::utilities::annotations::detail::mode_help_string());
+      }
+      return axom::utilities::annotations::detail::is_mode_valid(str)
+        ? std::string("")
+        : axom::fmt::format(
+            "'{}' invalid caliper mode. "
+            "Run with '--caliper help' to see all valid options",
+            str);
+    };
+  }
+};
+
+const static CaliperModeValidator ValidCaliperMode;
+#endif  // defined(AXOM_USE_CLI11) && defined(AXOM_USE_CALIPER)
+
+}  // namespace utilities
+}  // namespace axom
+
+#endif  // AXOM_CORE_COMMANDLINE_UTILITIES_HPP_

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -23,12 +23,20 @@ axom_add_executable(
     )
 
 if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR AND CALIPER_FOUND)
-    set(input_file "${AXOM_DATA_DIR}/quest/sphere_binary.stl")
+    set(_input_file "${AXOM_DATA_DIR}/quest/sphere_binary.stl")
+    
+    if(AXOM_ENABLE_MPI)     # this test requires MPI when available
+        set(_num_ranks 1)   # (but only 1 rank)
+    else()                  # but can otherwise be run without MPI
+        unset(_num_ranks)
+    endif()
+    
     axom_add_test(
         NAME    quest_containment_sphere_ex
         COMMAND quest_containment_driver_ex
-                --input ${input_file}
+                --input ${_input_file}
                 --caliper report
+        NUM_MPI_TASKS ${_num_ranks}
     )
 endif()
 

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -22,6 +22,16 @@ axom_add_executable(
     FOLDER      axom/quest/examples
     )
 
+if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR AND CALIPER_FOUND)
+    set(input_file "${AXOM_DATA_DIR}/quest/sphere_binary.stl")
+    axom_add_test(
+        NAME    quest_containment_sphere_ex
+        COMMAND quest_containment_driver_ex
+                --input ${input_file}
+                --caliper report
+    )
+endif()
+
 # BVH two pass example --------------------------------------------------------
 if (RAJA_FOUND AND UMPIRE_FOUND)
     axom_add_executable(

--- a/src/axom/quest/examples/containment_driver.cpp
+++ b/src/axom/quest/examples/containment_driver.cpp
@@ -585,23 +585,10 @@ public:
         "caliper annotation mode. Valid options include 'none' and 'report'. "
         "Use 'help' to see full list.")
       ->capture_default_str()
-      ->check([](const std::string& mode) -> std::string {
-        if(mode == "help")
-        {
-          std::cerr << "Valid caliper modes are:\n"
-                    << axom::utilities::annotations::detail::mode_help_string()
-                    << std::endl;
-        }
-        return axom::utilities::annotations::detail::is_mode_valid(mode)
-          ? ""
-          : axom::fmt::format(
-              "'{}' invalid caliper mode. "
-              "Run with '--caliper help' to see all valid options",
-              mode);
-      });
+      ->check(axom::utilities::ValidCaliperMode);
 #endif
 
-    app.get_formatter()->column_width(45);
+    app.get_formatter()->column_width(48);
 
     // could throw an exception
     app.parse(argc, argv);

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -212,20 +212,7 @@ public:
         "caliper annotation mode. Valid options include 'none' and 'report'. "
         "Use 'help' to see full list.")
       ->capture_default_str()
-      ->check([](const std::string& mode) -> std::string {
-        if(mode == "help")
-        {
-          std::cerr << "Valid caliper modes are:\n"
-                    << axom::utilities::annotations::detail::mode_help_string()
-                    << std::endl;
-        }
-        return axom::utilities::annotations::detail::is_mode_valid(mode)
-          ? ""
-          : fmt::format(
-              "'{}' invalid caliper mode. "
-              "Run with '--caliper help' to see all valid options",
-              mode);
-      });
+      ->check(axom::utilities::ValidCaliperMode);
 #endif
 
     app.get_formatter()->column_width(60);

--- a/src/axom/quest/examples/shaping_driver.cpp
+++ b/src/axom/quest/examples/shaping_driver.cpp
@@ -230,20 +230,7 @@ public:
         "caliper annotation mode. Valid options include 'none' and 'report'. "
         "Use 'help' to see full list.")
       ->capture_default_str()
-      ->check([](const std::string& mode) -> std::string {
-        if(mode == "help")
-        {
-          std::cerr << "Valid caliper modes are:\n"
-                    << axom::utilities::annotations::detail::mode_help_string()
-                    << std::endl;
-        }
-        return axom::utilities::annotations::detail::is_mode_valid(mode)
-          ? ""
-          : axom::fmt::format(
-              "'{}' invalid caliper mode. "
-              "Run with '--caliper help' to see all valid options",
-              mode);
-      });
+      ->check(axom::utilities::ValidCaliperMode);
 #endif
 
     // use either an input mesh file or a simple inline Cartesian mesh


### PR DESCRIPTION
# Summary

- This PR is a feature/enhancement
- It improves our usage of `caliper` and `adiak` in the annotations API based on an offline code review of #1312 from @daboehme (Thanks!)
- Fixes #1314 by adding a custom CLI Validator for caliper modes
- Fixes #1315 by using a caliper function call that uses the `name` passed to `axom::utility::annotations::end(name)`