### PR TITLE
Do not inherit from std::iterator

### DIFF
--- a/src/axom/slam/Map.hpp
+++ b/src/axom/slam/Map.hpp
@@ -575,14 +575,14 @@ public:
     using difference_type = SetPosition;
 
   private:
-    static StackArray<IndexType, Dims + 1> fetchDims(StrideIndexType shape)
+    static StackArray<axom::IndexType, Dims + 1> fetchDims(StrideIndexType shape)
     {
       return {0, shape};
     }
-    static StackArray<IndexType, Dims + 1> fetchDims(
+    static StackArray<axom::IndexType, Dims + 1> fetchDims(
       const StackArray<StrideIndexType, Dims> shape)
     {
-      StackArray<IndexType, Dims + 1> dims;
+      StackArray<axom::IndexType, Dims + 1> dims;
       for(int idim = 0; idim < Dims; idim++)
       {
         dims[idim + 1] = shape[idim];
@@ -595,7 +595,7 @@ public:
       : IterBase(pos)
       , m_map(oMap)
     {
-      StackArray<IndexType, Dims + 1> dataDims = fetchDims(oMap->shape());
+      StackArray<axom::IndexType, Dims + 1> dataDims = fetchDims(oMap->shape());
       dataDims[0] = m_map->size();
       m_mapData =
         axom::ArrayView<DataType, Dims + 1>(m_map->data().data(), dataDims);

--- a/src/axom/slam/SubMap.hpp
+++ b/src/axom/slam/SubMap.hpp
@@ -183,7 +183,7 @@ public:
   ///
 
   /** \brief returns the size of the SubMap  */
-  AXOM_HOST_DEVICE IndexType size() const { return m_subsetIdx.size(); }
+  AXOM_HOST_DEVICE axom::IndexType size() const { return m_subsetIdx.size(); }
 
   /** \brief returns the number of components (aka. stride) of the SubMap  */
   AXOM_HOST_DEVICE IndexType numComp() const

--- a/src/axom/spin/OctreeLevel.hpp
+++ b/src/axom/spin/OctreeLevel.hpp
@@ -201,11 +201,21 @@ public:
    *   \a increment(), \a equal() \a update(), \a pt() and \a data()
    */
   template <typename OctreeLevel, typename IterHelper, typename DataType>
-  class BlockIterator : public std::iterator<std::forward_iterator_tag, DataType>
+  class BlockIterator
   {
   public:
     using GridPt = typename OctreeLevel::GridPt;
     using iter = BlockIterator<OctreeLevel, IterHelper, DataType>;
+
+    // In C++17, inheriting from std::iterator was deprecated.
+    // We provide these typedefs for class BlockIterator to avoid inheriting
+    // from std::iterator and causing warnings for those compiling to C++17
+    // or newer.
+    using value_type = DataType;
+    using difference_type = std::ptrdiff_t;
+    using pointer = DataType*;
+    using reference = DataType&;
+    using iterator_category = std::forward_iterator_tag;
 
     BlockIterator(OctreeLevel* octLevel, bool begin = false)
       : m_octLevel(octLevel)


### PR DESCRIPTION
# Summary

- This PR bugfix.
- It does the following:
  - Fixes #1244 (reported from a build of serac, also showing up in another host code build)
  - Fixes #1320 (showed up when I tried to start working on 1244).  As @publixsubfan noted, this issue may come from a mismatch between `axom::IndexType` and whatever `IndexType` is visible from within slam.
