### PR TITLE
Add tests for closest_point on triangle operator

### DIFF
--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -187,22 +187,6 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
   }
 
   //----------------------------------------------------------------------------
-  // Check if P in edge region of AB
-  const T vc = d1 * d4 - d3 * d2;
-  if(isLeq(vc, T(0), EPS) && isGeq(d1, T(0), EPS) && isLeq(d3, T(0), EPS))
-  {
-    const T v = d1 / (d1 - d3);
-    const VectorType v_ab = ab * v;
-
-    if(loc != nullptr)
-    {
-      *loc = -1;
-    }
-
-    return A + v_ab;
-  }
-
-  //----------------------------------------------------------------------------
   // Check if P in vertex region outside C
   const VectorType cp(C, P);
   const T d5 = VectorType::dot_product(ab, cp);
@@ -216,6 +200,22 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
     }
 
     return C;
+  }
+
+  //----------------------------------------------------------------------------
+  // Check if P in edge region of AB
+  const T vc = d1 * d4 - d3 * d2;
+  if(isLeq(vc, T(0), EPS) && isGeq(d1, T(0), EPS) && isLeq(d3, T(0), EPS) && !utilities::isNearlyEqual(d1, d3, EPS))
+  {
+    const T v = d1 / (d1 - d3);
+    const VectorType v_ab = ab * v;
+
+    if(loc != nullptr)
+    {
+      *loc = -1;
+    }
+
+    return A + v_ab;
   }
 
   //----------------------------------------------------------------------------

--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -141,7 +141,7 @@ template <typename T, int NDIMS>
 AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
                                                       const Triangle<T, NDIMS>& tri,
                                                       int* loc = nullptr,
-                                                      double EPS = 1E-8)
+                                                      double EPS = PRIMAL_TINY)
 {
   using PointType = Point<T, NDIMS>;
   using VectorType = Vector<T, NDIMS>;

--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -187,22 +187,6 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
   }
 
   //----------------------------------------------------------------------------
-  // Check if P in vertex region outside C
-  const VectorType cp(C, P);
-  const T d5 = VectorType::dot_product(ab, cp);
-  const T d6 = VectorType::dot_product(ac, cp);
-  if(isGeq(d6, T(0), EPS) && isLeq(d5, d6, EPS))
-  {
-    // C is the closest point
-    if(loc != nullptr)
-    {
-      *loc = 2;
-    }
-
-    return C;
-  }
-
-  //----------------------------------------------------------------------------
   // Check if P in edge region of AB
   const T vc = d1 * d4 - d3 * d2;
   if(isLeq(vc, T(0), EPS) && isGeq(d1, T(0), EPS) && isLeq(d3, T(0), EPS) && !utilities::isNearlyEqual(d1, d3, EPS))
@@ -216,6 +200,22 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
     }
 
     return A + v_ab;
+  }
+
+  //----------------------------------------------------------------------------
+  // Check if P in vertex region outside C
+  const VectorType cp(C, P);
+  const T d5 = VectorType::dot_product(ab, cp);
+  const T d6 = VectorType::dot_product(ac, cp);
+  if(isGeq(d6, T(0), EPS) && isLeq(d5, d6, EPS))
+  {
+    // C is the closest point
+    if(loc != nullptr)
+    {
+      *loc = 2;
+    }
+
+    return C;
   }
 
   //----------------------------------------------------------------------------

--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -190,7 +190,7 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
   // Check if P in edge region of AB
   const T vc = d1 * d4 - d3 * d2;
   if(isLeq(vc, T(0), EPS) && isGeq(d1, T(0), EPS) && isLeq(d3, T(0), EPS) &&
-     !utilities::isNearlyEqual(d1, d3, EPS)) // Additional check for degenerate triangles
+     !utilities::isNearlyEqual(d1, d3, EPS))  // Additional check for degenerate triangles
   {
     const T v = d1 / (d1 - d3);
     const VectorType v_ab = ab * v;

--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -189,7 +189,8 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
   //----------------------------------------------------------------------------
   // Check if P in edge region of AB
   const T vc = d1 * d4 - d3 * d2;
-  if(isLeq(vc, T(0), EPS) && isGeq(d1, T(0), EPS) && isLeq(d3, T(0), EPS) && !utilities::isNearlyEqual(d1, d3, EPS))
+  if(isLeq(vc, T(0), EPS) && isGeq(d1, T(0), EPS) && isLeq(d3, T(0), EPS) &&
+     !utilities::isNearlyEqual(d1, d3, EPS)) // Additional check for degenerate triangles
   {
     const T v = d1 / (d1 - d3);
     const VectorType v_ab = ab * v;

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -231,15 +231,18 @@ TEST(primal_closest_point, triangle_test_tiny)
   EXPECT_EQ(loc, 0);
 
   // Query point is in the vertex region of A
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, -1.0e-16}), tri, &loc, EPS) == A);
+  EXPECT_TRUE(
+    primal::closest_point(QPoint({0.0, 0.0, -1.0e-16}), tri, &loc, EPS) == A);
   EXPECT_EQ(loc, 0);
 
   // Query point is on vertex B
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 1.0e-16}), tri, &loc, EPS) == B);
+  EXPECT_TRUE(
+    primal::closest_point(QPoint({0.0, 0.0, 1.0e-16}), tri, &loc, EPS) == B);
   EXPECT_EQ(loc, 1);
 
   // Query point is in the vertex region of B
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 1.0e-15}), tri, &loc, EPS) == B);
+  EXPECT_TRUE(
+    primal::closest_point(QPoint({0.0, 0.0, 1.0e-15}), tri, &loc, EPS) == B);
   EXPECT_EQ(loc, 1);
 
   // Query point is on vertex C
@@ -247,14 +250,16 @@ TEST(primal_closest_point, triangle_test_tiny)
   EXPECT_EQ(loc, 2);
 
   // Query point is in the vertex region of C
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 1.0 + 1.0e-16, 0.0}), tri, &loc, EPS) == C);
+  EXPECT_TRUE(
+    primal::closest_point(QPoint({0.0, 1.0 + 1.0e-16, 0.0}), tri, &loc, EPS) == C);
   EXPECT_EQ(loc, 2);
 
   // Query point is on AB
   QPoint queryPoint({0.0, 0.0, 1.0e-17});
   QPoint closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
-  for (int i = 0; i < DIM; ++i) {
+  for(int i = 0; i < DIM; ++i)
+  {
     EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-16);
   }
 
@@ -265,7 +270,8 @@ TEST(primal_closest_point, triangle_test_tiny)
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
   QPoint expectedClosestPoint({0.0, 0.0, 1.0e-17});
 
-  for (int i = 0; i < DIM; ++i) {
+  for(int i = 0; i < DIM; ++i)
+  {
     EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
   }
 
@@ -275,7 +281,8 @@ TEST(primal_closest_point, triangle_test_tiny)
   queryPoint = QPoint({0.0, 0.5, 5.0e-17});
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
-  for (int i = 0; i < DIM; ++i) {
+  for(int i = 0; i < DIM; ++i)
+  {
     EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-16);
   }
 
@@ -286,7 +293,8 @@ TEST(primal_closest_point, triangle_test_tiny)
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
   expectedClosestPoint = QPoint({0.0, 0.5, 5.0e-17});
 
-  for (int i = 0; i < DIM; ++i) {
+  for(int i = 0; i < DIM; ++i)
+  {
     EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
   }
 
@@ -296,7 +304,8 @@ TEST(primal_closest_point, triangle_test_tiny)
   queryPoint = QPoint({0.0, 0.25, 0.0});
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
-  for (int i = 0; i < DIM; ++i) {
+  for(int i = 0; i < DIM; ++i)
+  {
     EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-16);
   }
 
@@ -307,28 +316,31 @@ TEST(primal_closest_point, triangle_test_tiny)
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
   expectedClosestPoint = QPoint({0.0, 0.75, 0.0});
 
-  for (int i = 0; i < DIM; ++i) {
+  for(int i = 0; i < DIM; ++i)
+  {
     EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
   }
 
   EXPECT_EQ(loc, -3);
 
   // Query point is on the interior of the triangle
-  queryPoint = QPoint({0.0, 1.0/3.0, 1.0e-16/3.0});
+  queryPoint = QPoint({0.0, 1.0 / 3.0, 1.0e-16 / 3.0});
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
-  for (int i = 0; i < DIM; ++i) {
+  for(int i = 0; i < DIM; ++i)
+  {
     EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-16);
   }
 
   EXPECT_EQ(loc, 3);
 
   // Query point is in the interior region of the triangle
-  queryPoint = QPoint({-0.5, 1.0/3.0, 1.0e-16/3.0});
+  queryPoint = QPoint({-0.5, 1.0 / 3.0, 1.0e-16 / 3.0});
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
-  expectedClosestPoint = QPoint({0.0, 1.0/3.0, 1.0e-16/3.0});
+  expectedClosestPoint = QPoint({0.0, 1.0 / 3.0, 1.0e-16 / 3.0});
 
-  for (int i = 0; i < DIM; ++i) {
+  for(int i = 0; i < DIM; ++i)
+  {
     EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
   }
 
@@ -345,9 +357,8 @@ TEST(primal_closest_point, triangle_test_degenerate_side_AB)
   using QPoint = primal::Point<CoordType, DIM>;
   using QTriangle = primal::Triangle<CoordType, DIM>;
 
-  QTriangle tri({QPoint({0.0, 0.0, 0.0}),
-                 QPoint({0.0, 0.0, 0.0}),
-                 QPoint({0.0, 1.0, 0.0})});
+  QTriangle tri(
+    {QPoint({0.0, 0.0, 0.0}), QPoint({0.0, 0.0, 0.0}), QPoint({0.0, 1.0, 0.0})});
 
   const QPoint& A = tri[0];
   const QPoint& C = tri[2];
@@ -359,15 +370,18 @@ TEST(primal_closest_point, triangle_test_degenerate_side_AB)
   EXPECT_EQ(loc, 0);
 
   // Query point is in the vertex region of A/B
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, -1.0e-16}), tri, &loc, EPS) == A);
+  EXPECT_TRUE(
+    primal::closest_point(QPoint({0.0, 0.0, -1.0e-16}), tri, &loc, EPS) == A);
   EXPECT_EQ(loc, 0);
 
   // Query point is in the vertex region of A/B
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 1.0e-16}), tri, &loc, EPS) == A);
+  EXPECT_TRUE(
+    primal::closest_point(QPoint({0.0, 0.0, 1.0e-16}), tri, &loc, EPS) == A);
   EXPECT_EQ(loc, 0);
 
   // Query point is in the vertex region of A/B
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, -1.0e-16, 0.0}), tri, &loc, EPS) == A);
+  EXPECT_TRUE(
+    primal::closest_point(QPoint({0.0, -1.0e-16, 0.0}), tri, &loc, EPS) == A);
   EXPECT_EQ(loc, 0);
 
   // Query point is on vertex C
@@ -375,14 +389,16 @@ TEST(primal_closest_point, triangle_test_degenerate_side_AB)
   EXPECT_EQ(loc, 2);
 
   // Query point is in the vertex region of C
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 1.0 + 1.0e-16, 0.0}), tri, &loc, EPS) == C);
+  EXPECT_TRUE(
+    primal::closest_point(QPoint({0.0, 1.0 + 1.0e-16, 0.0}), tri, &loc, EPS) == C);
   EXPECT_EQ(loc, 2);
 
   // Query point is on BC/CA
   QPoint queryPoint({0.0, 0.25, 0.0});
   QPoint closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
-  for (int i = 0; i < DIM; ++i) {
+  for(int i = 0; i < DIM; ++i)
+  {
     EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-16);
   }
 
@@ -393,7 +409,8 @@ TEST(primal_closest_point, triangle_test_degenerate_side_AB)
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
   QPoint expectedClosestPoint({0.0, 0.75, 0.0});
 
-  for (int i = 0; i < DIM; ++i) {
+  for(int i = 0; i < DIM; ++i)
+  {
     EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
   }
 
@@ -410,9 +427,8 @@ TEST(primal_closest_point, triangle_test_degenerate_side_BC)
   using QPoint = primal::Point<CoordType, DIM>;
   using QTriangle = primal::Triangle<CoordType, DIM>;
 
-  QTriangle tri({QPoint({2.0, 0.0, 0.0}),
-                 QPoint({2.0, 1.0, 1.0}),
-                 QPoint({2.0, 1.0, 1.0})});
+  QTriangle tri(
+    {QPoint({2.0, 0.0, 0.0}), QPoint({2.0, 1.0, 1.0}), QPoint({2.0, 1.0, 1.0})});
 
   const QPoint& A = tri[0];
   const QPoint& B = tri[1];
@@ -439,7 +455,8 @@ TEST(primal_closest_point, triangle_test_degenerate_side_BC)
   QPoint queryPoint({2.0, 0.75, 0.75});
   QPoint closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
-  for (int i = 0; i < DIM; ++i) {
+  for(int i = 0; i < DIM; ++i)
+  {
     EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-16);
   }
 
@@ -450,7 +467,8 @@ TEST(primal_closest_point, triangle_test_degenerate_side_BC)
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
   QPoint expectedClosestPoint({2.0, 0.5, 0.5});
 
-  for (int i = 0; i < DIM; ++i) {
+  for(int i = 0; i < DIM; ++i)
+  {
     EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
   }
 
@@ -467,9 +485,8 @@ TEST(primal_closest_point, triangle_test_degenerate_side_CA)
   using QPoint = primal::Point<CoordType, DIM>;
   using QTriangle = primal::Triangle<CoordType, DIM>;
 
-  QTriangle tri({QPoint({1.0, 3.0, 1.0}),
-                 QPoint({2.0, 4.0, 2.0}),
-                 QPoint({1.0, 3.0, 1.0})});
+  QTriangle tri(
+    {QPoint({1.0, 3.0, 1.0}), QPoint({2.0, 4.0, 2.0}), QPoint({1.0, 3.0, 1.0})});
 
   const QPoint& A = tri[0];
   const QPoint& B = tri[1];
@@ -493,10 +510,11 @@ TEST(primal_closest_point, triangle_test_degenerate_side_CA)
   EXPECT_EQ(loc, 1);
 
   // Query point is on AB/BC
-  QPoint queryPoint({4.0/3.0, 10.0/3.0, 4.0/3.0});
+  QPoint queryPoint({4.0 / 3.0, 10.0 / 3.0, 4.0 / 3.0});
   QPoint closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
-  for (int i = 0; i < DIM; ++i) {
+  for(int i = 0; i < DIM; ++i)
+  {
     EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-16);
   }
 
@@ -505,9 +523,10 @@ TEST(primal_closest_point, triangle_test_degenerate_side_CA)
   // Query point is in the edge region of AB/BC
   queryPoint = QPoint({1.0, 4.0, 1.0});
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
-  QPoint expectedClosestPoint({4.0/3.0, 10.0/3.0, 4.0/3.0});
+  QPoint expectedClosestPoint({4.0 / 3.0, 10.0 / 3.0, 4.0 / 3.0});
 
-  for (int i = 0; i < DIM; ++i) {
+  for(int i = 0; i < DIM; ++i)
+  {
     EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
   }
 
@@ -524,9 +543,8 @@ TEST(primal_closest_point, triangle_test_all_sides_degenerate)
   using QPoint = primal::Point<CoordType, DIM>;
   using QTriangle = primal::Triangle<CoordType, DIM>;
 
-  QTriangle tri({QPoint({1.0, 3.0, 1.0}),
-                 QPoint({1.0, 3.0, 1.0}),
-                 QPoint({1.0, 3.0, 1.0})});
+  QTriangle tri(
+    {QPoint({1.0, 3.0, 1.0}), QPoint({1.0, 3.0, 1.0}), QPoint({1.0, 3.0, 1.0})});
 
   const QPoint& A = tri[0];
 

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -312,6 +312,27 @@ TEST(primal_closest_point, triangle_test_degenerate)
   }
 
   EXPECT_EQ(loc, -3);
+
+  // Query point is on the interior of the triangle
+  queryPoint = QPoint({0.0, 1.0/3.0, 1.0e-13/3.0});
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+
+  for (int i = 0; i < DIM; ++i) {
+    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.1e-14);
+  }
+
+  EXPECT_EQ(loc, 3);
+
+  // Query point is in the interior region of the triangle
+  queryPoint = QPoint({-0.5, 1.0/3.0, 1.0e-13/3.0});
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+  expectedClosestPoint = QPoint({0.0, 1.0/3.0, 1.0e-13/3.0});
+
+  for (int i = 0; i < DIM; ++i) {
+    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.1e-14);
+  }
+
+  EXPECT_EQ(loc, 3);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -255,10 +255,63 @@ TEST(primal_closest_point, triangle_test_degenerate)
   QPoint closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
 
   for (int i = 0; i < DIM; ++i) {
-    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-13);
+    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.1e-14);
   }
 
   EXPECT_EQ(loc, -1);
+
+  // Query point is in the edge region of AB
+  queryPoint = QPoint({0.0, -0.1, 1.0e-14});
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+  QPoint expectedClosestPoint({0.0, 0.0, 1.0e-14});
+
+  for (int i = 0; i < DIM; ++i) {
+    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.1e-14);
+  }
+
+  EXPECT_EQ(loc, -1);
+
+  // Query point is on BC
+  queryPoint = QPoint({0.0, 0.5, 5.0e-14});
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+
+  for (int i = 0; i < DIM; ++i) {
+    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.1e-14);
+  }
+
+  EXPECT_EQ(loc, -2);
+
+  // Query point is in the edge region of BC
+  queryPoint = QPoint({0.5, 0.5, 5.0e-14});
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+  expectedClosestPoint = QPoint({0.0, 0.5, 5.0e-14});
+
+  for (int i = 0; i < DIM; ++i) {
+    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.1e-14);
+  }
+
+  EXPECT_EQ(loc, -2);
+
+  // Query point is on CA
+  queryPoint = QPoint({0.0, 0.25, 0.0});
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+
+  for (int i = 0; i < DIM; ++i) {
+    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.1e-14);
+  }
+
+  EXPECT_EQ(loc, -3);
+
+  // Query point is in the edge region of BC
+  queryPoint = QPoint({-0.25, 0.75, -0.25});
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+  expectedClosestPoint = QPoint({0.0, 0.75, 0.0});
+
+  for (int i = 0; i < DIM; ++i) {
+    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.1e-14);
+  }
+
+  EXPECT_EQ(loc, -3);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -217,7 +217,7 @@ TEST(primal_closest_point, triangle_test_tiny)
   using QTriangle = primal::Triangle<CoordType, DIM>;
 
   QTriangle tri({QPoint({0.0, 0.0, 0.0}),
-                 QPoint({0.0, 0.0, 1.0e-13}),
+                 QPoint({0.0, 0.0, 1.0e-16}),
                  QPoint({0.0, 1.0, 0.0})});
 
   const QPoint& A = tri[0];
@@ -231,15 +231,15 @@ TEST(primal_closest_point, triangle_test_tiny)
   EXPECT_EQ(loc, 0);
 
   // Query point is in the vertex region of A
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, -1.0e-11}), tri, &loc, EPS) == A);
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, -1.0e-16}), tri, &loc, EPS) == A);
   EXPECT_EQ(loc, 0);
 
   // Query point is on vertex B
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 1.0e-13}), tri, &loc, EPS) == B);
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 1.0e-16}), tri, &loc, EPS) == B);
   EXPECT_EQ(loc, 1);
 
   // Query point is in the vertex region of B
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 1.0e-11}), tri, &loc, EPS) == B);
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 1.0e-15}), tri, &loc, EPS) == B);
   EXPECT_EQ(loc, 1);
 
   // Query point is on vertex C
@@ -247,11 +247,11 @@ TEST(primal_closest_point, triangle_test_tiny)
   EXPECT_EQ(loc, 2);
 
   // Query point is in the vertex region of C
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 1.00000000001, 0.0}), tri, &loc, EPS) == C);
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 1.0 + 1.0e-16, 0.0}), tri, &loc, EPS) == C);
   EXPECT_EQ(loc, 2);
 
   // Query point is on AB
-  QPoint queryPoint({0.0, 0.0, 1.0e-14});
+  QPoint queryPoint({0.0, 0.0, 1.0e-17});
   QPoint closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
   for (int i = 0; i < DIM; ++i) {
@@ -261,9 +261,9 @@ TEST(primal_closest_point, triangle_test_tiny)
   EXPECT_EQ(loc, -1);
 
   // Query point is in the edge region of AB
-  queryPoint = QPoint({0.0, -0.1, 1.0e-14});
+  queryPoint = QPoint({0.0, -0.1, 1.0e-17});
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
-  QPoint expectedClosestPoint({0.0, 0.0, 1.0e-14});
+  QPoint expectedClosestPoint({0.0, 0.0, 1.0e-17});
 
   for (int i = 0; i < DIM; ++i) {
     EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
@@ -272,7 +272,7 @@ TEST(primal_closest_point, triangle_test_tiny)
   EXPECT_EQ(loc, -1);
 
   // Query point is on BC
-  queryPoint = QPoint({0.0, 0.5, 5.0e-14});
+  queryPoint = QPoint({0.0, 0.5, 5.0e-17});
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
   for (int i = 0; i < DIM; ++i) {
@@ -282,9 +282,9 @@ TEST(primal_closest_point, triangle_test_tiny)
   EXPECT_EQ(loc, -2);
 
   // Query point is in the edge region of BC
-  queryPoint = QPoint({0.5, 0.5, 5.0e-14});
+  queryPoint = QPoint({0.5, 0.5, 5.0e-17});
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
-  expectedClosestPoint = QPoint({0.0, 0.5, 5.0e-14});
+  expectedClosestPoint = QPoint({0.0, 0.5, 5.0e-17});
 
   for (int i = 0; i < DIM; ++i) {
     EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
@@ -314,7 +314,7 @@ TEST(primal_closest_point, triangle_test_tiny)
   EXPECT_EQ(loc, -3);
 
   // Query point is on the interior of the triangle
-  queryPoint = QPoint({0.0, 1.0/3.0, 1.0e-13/3.0});
+  queryPoint = QPoint({0.0, 1.0/3.0, 1.0e-16/3.0});
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
   for (int i = 0; i < DIM; ++i) {
@@ -324,9 +324,9 @@ TEST(primal_closest_point, triangle_test_tiny)
   EXPECT_EQ(loc, 3);
 
   // Query point is in the interior region of the triangle
-  queryPoint = QPoint({-0.5, 1.0/3.0, 1.0e-13/3.0});
+  queryPoint = QPoint({-0.5, 1.0/3.0, 1.0e-16/3.0});
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
-  expectedClosestPoint = QPoint({0.0, 1.0/3.0, 1.0e-13/3.0});
+  expectedClosestPoint = QPoint({0.0, 1.0/3.0, 1.0e-16/3.0});
 
   for (int i = 0; i < DIM; ++i) {
     EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -209,7 +209,7 @@ TEST(primal_closest_point, seg_test_closest_point_interior)
 //------------------------------------------------------------------------------
 TEST(primal_closest_point, triangle_test_degenerate)
 {
-  constexpr double EPS = 1e-12;
+  constexpr double EPS = primal::PRIMAL_TINY;
 
   constexpr int DIM = 3;
   using CoordType = double;
@@ -227,32 +227,32 @@ TEST(primal_closest_point, triangle_test_degenerate)
   int loc;
 
   // Query point is on vertex A
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 0.0}), tri, &loc, 0.0) == A);
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 0.0}), tri, &loc, EPS) == A);
   EXPECT_EQ(loc, 0);
 
   // Query point is in the vertex region of A
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, -1.0e-11}), tri, &loc, 0.0) == A);
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, -1.0e-11}), tri, &loc, EPS) == A);
   EXPECT_EQ(loc, 0);
 
   // Query point is on vertex B
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 1.0e-13}), tri, &loc, 0.0) == B);
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 1.0e-13}), tri, &loc, EPS) == B);
   EXPECT_EQ(loc, 1);
 
   // Query point is in the vertex region of B
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 1.0e-11}), tri, &loc, 0.0) == B);
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 1.0e-11}), tri, &loc, EPS) == B);
   EXPECT_EQ(loc, 1);
 
   // Query point is on vertex C
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 1.0, 0.0}), tri, &loc, 0.0) == C);
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 1.0, 0.0}), tri, &loc, EPS) == C);
   EXPECT_EQ(loc, 2);
 
   // Query point is in the vertex region of C
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 1.00000000001, 0.0}), tri, &loc, 0.0) == C);
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 1.00000000001, 0.0}), tri, &loc, EPS) == C);
   EXPECT_EQ(loc, 2);
 
   // Query point is on AB
   QPoint queryPoint({0.0, 0.0, 1.0e-14});
-  QPoint closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+  QPoint closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
   for (int i = 0; i < DIM; ++i) {
     EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.1e-14);
@@ -262,7 +262,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
 
   // Query point is in the edge region of AB
   queryPoint = QPoint({0.0, -0.1, 1.0e-14});
-  closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
   QPoint expectedClosestPoint({0.0, 0.0, 1.0e-14});
 
   for (int i = 0; i < DIM; ++i) {
@@ -273,7 +273,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
 
   // Query point is on BC
   queryPoint = QPoint({0.0, 0.5, 5.0e-14});
-  closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
   for (int i = 0; i < DIM; ++i) {
     EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.1e-14);
@@ -283,7 +283,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
 
   // Query point is in the edge region of BC
   queryPoint = QPoint({0.5, 0.5, 5.0e-14});
-  closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
   expectedClosestPoint = QPoint({0.0, 0.5, 5.0e-14});
 
   for (int i = 0; i < DIM; ++i) {
@@ -294,7 +294,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
 
   // Query point is on CA
   queryPoint = QPoint({0.0, 0.25, 0.0});
-  closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
   for (int i = 0; i < DIM; ++i) {
     EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.1e-14);
@@ -304,7 +304,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
 
   // Query point is in the edge region of BC
   queryPoint = QPoint({-0.25, 0.75, -0.25});
-  closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
   expectedClosestPoint = QPoint({0.0, 0.75, 0.0});
 
   for (int i = 0; i < DIM; ++i) {
@@ -315,7 +315,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
 
   // Query point is on the interior of the triangle
   queryPoint = QPoint({0.0, 1.0/3.0, 1.0e-13/3.0});
-  closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
   for (int i = 0; i < DIM; ++i) {
     EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.1e-14);
@@ -325,7 +325,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
 
   // Query point is in the interior region of the triangle
   queryPoint = QPoint({-0.5, 1.0/3.0, 1.0e-13/3.0});
-  closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
   expectedClosestPoint = QPoint({0.0, 1.0/3.0, 1.0e-13/3.0});
 
   for (int i = 0; i < DIM; ++i) {

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -207,6 +207,61 @@ TEST(primal_closest_point, seg_test_closest_point_interior)
 }
 
 //------------------------------------------------------------------------------
+TEST(primal_closest_point, triangle_test_degenerate)
+{
+  constexpr double EPS = 1e-12;
+
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QTriangle = primal::Triangle<CoordType, DIM>;
+
+  QTriangle tri({QPoint({0.0, 0.0, 0.0}),
+                 QPoint({0.0, 0.0, 1.0e-13}),
+                 QPoint({0.0, 1.0, 0.0})});
+
+  const QPoint& A = tri[0];
+  const QPoint& B = tri[1];
+  const QPoint& C = tri[2];
+
+  int loc;
+
+  // Query point is on vertex A
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 0.0}), tri, &loc, 0.0) == A);
+  EXPECT_EQ(loc, 0);
+
+  // Query point is in the vertex region of A
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, -1.0e-11}), tri, &loc, 0.0) == A);
+  EXPECT_EQ(loc, 0);
+
+  // Query point is on vertex B
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 1.0e-13}), tri, &loc, 0.0) == B);
+  EXPECT_EQ(loc, 1);
+
+  // Query point is in the vertex region of B
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 1.0e-11}), tri, &loc, 0.0) == B);
+  EXPECT_EQ(loc, 1);
+
+  // Query point is on vertex C
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 1.0, 0.0}), tri, &loc, 0.0) == C);
+  EXPECT_EQ(loc, 2);
+
+  // Query point is in the vertex region of C
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 1.00000000001, 0.0}), tri, &loc, 0.0) == C);
+  EXPECT_EQ(loc, 2);
+
+  // Query point is on AB
+  QPoint queryPoint({0.0, 0.0, 1.0e-14});
+  QPoint closestPoint = primal::closest_point(queryPoint, tri, &loc, 0.0);
+
+  for (int i = 0; i < DIM; ++i) {
+    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-13);
+  }
+
+  EXPECT_EQ(loc, -1);
+}
+
+//------------------------------------------------------------------------------
 TEST(primal_closest_point, obb_test_closest_point_interior)
 {
   constexpr int DIM = 3;

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -515,6 +515,33 @@ TEST(primal_closest_point, triangle_test_degenerate_side_CA)
 }
 
 //------------------------------------------------------------------------------
+TEST(primal_closest_point, triangle_test_all_sides_degenerate)
+{
+  constexpr double EPS = primal::PRIMAL_TINY;
+
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QTriangle = primal::Triangle<CoordType, DIM>;
+
+  QTriangle tri({QPoint({1.0, 3.0, 1.0}),
+                 QPoint({1.0, 3.0, 1.0}),
+                 QPoint({1.0, 3.0, 1.0})});
+
+  const QPoint& A = tri[0];
+
+  int loc;
+
+  // Query point is on vertex A/B/C
+  EXPECT_TRUE(primal::closest_point(QPoint({1.0, 3.0, 1.0}), tri, &loc, EPS) == A);
+  EXPECT_EQ(loc, 0);
+
+  // Query point is in the vertex region of A/B/C
+  EXPECT_TRUE(primal::closest_point(QPoint({2.0, 4.0, 2.0}), tri, &loc, EPS) == A);
+  EXPECT_EQ(loc, 0);
+}
+
+//------------------------------------------------------------------------------
 TEST(primal_closest_point, obb_test_closest_point_interior)
 {
   constexpr int DIM = 3;

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -207,7 +207,7 @@ TEST(primal_closest_point, seg_test_closest_point_interior)
 }
 
 //------------------------------------------------------------------------------
-TEST(primal_closest_point, triangle_test_degenerate)
+TEST(primal_closest_point, triangle_test_tiny)
 {
   constexpr double EPS = primal::PRIMAL_TINY;
 
@@ -333,6 +333,72 @@ TEST(primal_closest_point, triangle_test_degenerate)
   }
 
   EXPECT_EQ(loc, 3);
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_closest_point, triangle_test_degenerate_side_AB)
+{
+  constexpr double EPS = primal::PRIMAL_TINY;
+
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QTriangle = primal::Triangle<CoordType, DIM>;
+
+  QTriangle tri({QPoint({0.0, 0.0, 0.0}),
+                 QPoint({0.0, 0.0, 0.0}),
+                 QPoint({0.0, 1.0, 0.0})});
+
+  const QPoint& A = tri[0];
+  const QPoint& B = tri[1];
+  const QPoint& C = tri[2];
+
+  int loc;
+
+  // Query point is on vertex A/B
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 0.0}), tri, &loc, EPS) == A);
+  EXPECT_EQ(loc, 0);
+
+  // Query point is in the vertex region of A/B
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, -1.0e-16}), tri, &loc, EPS) == A);
+  EXPECT_EQ(loc, 0);
+
+  // Query point is in the vertex region of A/B
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 1.0e-16}), tri, &loc, EPS) == A);
+  EXPECT_EQ(loc, 0);
+
+  // Query point is in the vertex region of A/B
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, -1.0e-16, 0.0}), tri, &loc, EPS) == A);
+  EXPECT_EQ(loc, 0);
+
+  // Query point is on vertex C
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 1.0, 0.0}), tri, &loc, EPS) == C);
+  EXPECT_EQ(loc, 2);
+
+  // Query point is in the vertex region of C
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 1.0 + 1.0e-16, 0.0}), tri, &loc, EPS) == C);
+  EXPECT_EQ(loc, 2);
+
+  // Query point is on BC/CA
+  QPoint queryPoint({0.0, 0.25, 0.0});
+  QPoint closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
+
+  for (int i = 0; i < DIM; ++i) {
+    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-16);
+  }
+
+  EXPECT_EQ(loc, -3);
+
+  // Query point is in the edge region of BC/CA
+  queryPoint = QPoint({-0.25, 0.75, -0.25});
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
+  QPoint expectedClosestPoint({0.0, 0.75, 0.0});
+
+  for (int i = 0; i < DIM; ++i) {
+    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
+  }
+
+  EXPECT_EQ(loc, -3);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -350,7 +350,6 @@ TEST(primal_closest_point, triangle_test_degenerate_side_AB)
                  QPoint({0.0, 1.0, 0.0})});
 
   const QPoint& A = tri[0];
-  const QPoint& B = tri[1];
   const QPoint& C = tri[2];
 
   int loc;
@@ -399,6 +398,120 @@ TEST(primal_closest_point, triangle_test_degenerate_side_AB)
   }
 
   EXPECT_EQ(loc, -3);
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_closest_point, triangle_test_degenerate_side_BC)
+{
+  constexpr double EPS = primal::PRIMAL_TINY;
+
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QTriangle = primal::Triangle<CoordType, DIM>;
+
+  QTriangle tri({QPoint({2.0, 0.0, 0.0}),
+                 QPoint({2.0, 1.0, 1.0}),
+                 QPoint({2.0, 1.0, 1.0})});
+
+  const QPoint& A = tri[0];
+  const QPoint& B = tri[1];
+
+  int loc;
+
+  // Query point is on vertex A
+  EXPECT_TRUE(primal::closest_point(QPoint({2.0, 0.0, 0.0}), tri, &loc, EPS) == A);
+  EXPECT_EQ(loc, 0);
+
+  // Query point is in the vertex region of A
+  EXPECT_TRUE(primal::closest_point(QPoint({2.0, 0.0, 0.0}), tri, &loc, EPS) == A);
+  EXPECT_EQ(loc, 0);
+
+  // Query point is on vertex B/C
+  EXPECT_TRUE(primal::closest_point(QPoint({2.0, 1.0, 1.0}), tri, &loc, EPS) == B);
+  EXPECT_EQ(loc, 1);
+
+  // Query point is in the vertex region of B/C
+  EXPECT_TRUE(primal::closest_point(QPoint({3.0, 2.0, 2.0}), tri, &loc, EPS) == B);
+  EXPECT_EQ(loc, 1);
+
+  // Query point is on AB/CA
+  QPoint queryPoint({2.0, 0.75, 0.75});
+  QPoint closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
+
+  for (int i = 0; i < DIM; ++i) {
+    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-16);
+  }
+
+  EXPECT_EQ(loc, -1);
+
+  // Query point is in the edge region of AB/CA
+  queryPoint = QPoint({2.0, 1.0, 0.0});
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
+  QPoint expectedClosestPoint({2.0, 0.5, 0.5});
+
+  for (int i = 0; i < DIM; ++i) {
+    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
+  }
+
+  EXPECT_EQ(loc, -1);
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_closest_point, triangle_test_degenerate_side_CA)
+{
+  constexpr double EPS = primal::PRIMAL_TINY;
+
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QTriangle = primal::Triangle<CoordType, DIM>;
+
+  QTriangle tri({QPoint({1.0, 3.0, 1.0}),
+                 QPoint({2.0, 4.0, 2.0}),
+                 QPoint({1.0, 3.0, 1.0})});
+
+  const QPoint& A = tri[0];
+  const QPoint& B = tri[1];
+
+  int loc;
+
+  // Query point is on vertex A/C
+  EXPECT_TRUE(primal::closest_point(QPoint({1.0, 3.0, 1.0}), tri, &loc, EPS) == A);
+  EXPECT_EQ(loc, 0);
+
+  // Query point is in the vertex region of A/C
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 0.0}), tri, &loc, EPS) == A);
+  EXPECT_EQ(loc, 0);
+
+  // Query point is on vertex B
+  EXPECT_TRUE(primal::closest_point(QPoint({2.0, 4.0, 2.0}), tri, &loc, EPS) == B);
+  EXPECT_EQ(loc, 1);
+
+  // Query point is in the vertex region of B
+  EXPECT_TRUE(primal::closest_point(QPoint({2.1, 4.1, 2.1}), tri, &loc, EPS) == B);
+  EXPECT_EQ(loc, 1);
+
+  // Query point is on AB/BC
+  QPoint queryPoint({4.0/3.0, 10.0/3.0, 4.0/3.0});
+  QPoint closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
+
+  for (int i = 0; i < DIM; ++i) {
+    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-16);
+  }
+
+  EXPECT_EQ(loc, -1);
+
+  // Query point is in the edge region of AB/BC
+  queryPoint = QPoint({1.0, 4.0, 1.0});
+  closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
+  QPoint expectedClosestPoint({4.0/3.0, 10.0/3.0, 4.0/3.0});
+
+  for (int i = 0; i < DIM; ++i) {
+    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
+  }
+
+  EXPECT_EQ(loc, -1);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -255,7 +255,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
   QPoint closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
   for (int i = 0; i < DIM; ++i) {
-    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.1e-14);
+    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-16);
   }
 
   EXPECT_EQ(loc, -1);
@@ -266,7 +266,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
   QPoint expectedClosestPoint({0.0, 0.0, 1.0e-14});
 
   for (int i = 0; i < DIM; ++i) {
-    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.1e-14);
+    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
   }
 
   EXPECT_EQ(loc, -1);
@@ -276,7 +276,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
   for (int i = 0; i < DIM; ++i) {
-    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.1e-14);
+    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-16);
   }
 
   EXPECT_EQ(loc, -2);
@@ -287,7 +287,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
   expectedClosestPoint = QPoint({0.0, 0.5, 5.0e-14});
 
   for (int i = 0; i < DIM; ++i) {
-    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.1e-14);
+    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
   }
 
   EXPECT_EQ(loc, -2);
@@ -297,7 +297,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
   for (int i = 0; i < DIM; ++i) {
-    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.1e-14);
+    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-16);
   }
 
   EXPECT_EQ(loc, -3);
@@ -308,7 +308,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
   expectedClosestPoint = QPoint({0.0, 0.75, 0.0});
 
   for (int i = 0; i < DIM; ++i) {
-    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.1e-14);
+    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
   }
 
   EXPECT_EQ(loc, -3);
@@ -318,7 +318,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
   closestPoint = primal::closest_point(queryPoint, tri, &loc, EPS);
 
   for (int i = 0; i < DIM; ++i) {
-    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.1e-14);
+    EXPECT_NEAR(closestPoint[i], queryPoint[i], 1.0e-16);
   }
 
   EXPECT_EQ(loc, 3);
@@ -329,7 +329,7 @@ TEST(primal_closest_point, triangle_test_degenerate)
   expectedClosestPoint = QPoint({0.0, 1.0/3.0, 1.0e-13/3.0});
 
   for (int i = 0; i < DIM; ++i) {
-    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.1e-14);
+    EXPECT_NEAR(closestPoint[i], expectedClosestPoint[i], 1.0e-16);
   }
 
   EXPECT_EQ(loc, 3);


### PR DESCRIPTION
# Summary

- This PR is a bugfix:
- It does the following:
  - Modifies closest_point on triangle query to handle degenerate triangles
  - Adds tests for closest_point on triangle query at the request of myself
  - Fixes #1307