### PR TITLE
Add intersect function for plane/tet that returns polygon output.

### DIFF
--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -1625,7 +1625,7 @@ AXOM_HOST_DEVICE bool intersect_plane_tet3d(const Plane<T, 3>& p,
   distances[2] = p.signedDistance(tet[2]);
   distances[3] = p.signedDistance(tet[3]);
 
-  constexpr T zero{0};
+  constexpr T zero {0};
   int gt[4];
   gt[0] = distances[0] > zero;
   gt[1] = distances[1] > zero;
@@ -1646,6 +1646,7 @@ AXOM_HOST_DEVICE bool intersect_plane_tet3d(const Plane<T, 3>& p,
     caseNumber = (~((lt[3] << 3) | (lt[2] << 2) | (lt[1] << 1) | lt[0])) & 0xf;
   }
 
+  // clang-format off
   // Edge lookup (pairs of point ids)
   const std::uint8_t edges[] = {
    /* 0 */ // None
@@ -1666,9 +1667,12 @@ AXOM_HOST_DEVICE bool intersect_plane_tet3d(const Plane<T, 3>& p,
    /* 15 */ // None
   };
   const std::uint8_t edges_offsets[] = {0, 0, 6, 12, 20, 26, 34, 42, 48, 54, 62, 70, 76, 84, 90, 96, 96};
+  // clang-format on
 
   // Add new vertices to the polygon according to the case.
-  const int n = static_cast<int>(edges_offsets[caseNumber + 1] - edges_offsets[caseNumber]) >> 1;
+  const int n =
+    static_cast<int>(edges_offsets[caseNumber + 1] - edges_offsets[caseNumber]) >>
+    1;
   for(int i = 0; i < n; i++)
   {
     const auto eOffset = static_cast<int>(edges_offsets[caseNumber]) + (i << 1);

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -22,9 +22,11 @@
 #include "axom/primal/geometry/OrientedBoundingBox.hpp"
 #include "axom/primal/geometry/Plane.hpp"
 #include "axom/primal/geometry/Point.hpp"
+#include "axom/primal/geometry/Polygon.hpp"
 #include "axom/primal/geometry/Ray.hpp"
 #include "axom/primal/geometry/Segment.hpp"
 #include "axom/primal/geometry/Triangle.hpp"
+#include "axom/primal/geometry/Tetrahedron.hpp"
 
 namespace axom
 {
@@ -1608,6 +1610,79 @@ inline bool intervalsDisjoint(double d0, double d1, double d2, double r)
   SLIC_ASSERT(d1 >= d0 && d1 >= d2);
 
   return d1 < -r || d0 > r;
+}
+
+template <typename T>
+AXOM_HOST_DEVICE bool intersect_plane_tet3d(const Plane<T, 3>& p,
+                                            const Tetrahedron<T, 3>& tet,
+                                            Polygon<T, 3>& intersection)
+{
+  intersection.clear();
+
+  T distances[4];
+  distances[0] = p.signedDistance(tet[0]);
+  distances[1] = p.signedDistance(tet[1]);
+  distances[2] = p.signedDistance(tet[2]);
+  distances[3] = p.signedDistance(tet[3]);
+
+  constexpr T zero{0};
+  int gt[4];
+  gt[0] = distances[0] > zero;
+  gt[1] = distances[1] > zero;
+  gt[2] = distances[2] > zero;
+  gt[3] = distances[3] > zero;
+  int caseNumber = (gt[3] << 3) | (gt[2] << 2) | (gt[1] << 1) | gt[0];
+
+  // Cases 0, 15 indicate all points were on one side of the zero. That would
+  // normally not produce geometry. We may have zeroes and some bigger negatives
+  // so try picking a better case.
+  if(caseNumber == 0 || caseNumber == 15)
+  {
+    int lt[4];
+    lt[0] = distances[0] < zero;
+    lt[1] = distances[1] < zero;
+    lt[2] = distances[2] < zero;
+    lt[3] = distances[3] < zero;
+    caseNumber = (~((lt[3] << 3) | (lt[2] << 2) | (lt[1] << 1) | lt[0])) & 0xf;
+  }
+
+  // Edge lookup (pairs of point ids)
+  const std::uint8_t edges[] = {
+   /* 0 */ // None
+   /* 1 */ 0, 2, 0, 1, 0, 3,
+   /* 2 */ 0, 1, 1, 2, 1, 3,
+   /* 3 */ 0, 2, 1, 2, 1, 3, 0, 3,
+   /* 4 */ 1, 2, 0, 2, 2, 3,
+   /* 5 */ 1, 2, 0, 1, 0, 3, 2, 3,
+   /* 6 */ 0, 1, 0, 2, 2, 3, 1, 3,
+   /* 7 */ 2, 3, 1, 3, 0, 3,
+   /* 8 */ 0, 3, 1, 3, 2, 3,
+   /* 9 */ 0, 2, 0, 1, 1, 3, 2, 3,
+   /* 10 */ 0, 1, 1, 2, 2, 3, 0, 3,
+   /* 11 */ 0, 2, 1, 2, 2, 3,
+   /* 12 */ 1, 2, 0, 2, 0, 3, 1, 3,
+   /* 13 */ 1, 2, 0, 1, 1, 3,
+   /* 14 */ 0, 1, 0, 2, 0, 3,
+   /* 15 */ // None
+  };
+  const std::uint8_t edges_offsets[] = {0, 0, 6, 12, 20, 26, 34, 42, 48, 54, 62, 70, 76, 84, 90, 96, 96};
+
+  // Add new vertices to the polygon according to the case.
+  const int n = static_cast<int>(edges_offsets[caseNumber + 1] - edges_offsets[caseNumber]) >> 1;
+  for(int i = 0; i < n; i++)
+  {
+    const auto eOffset = static_cast<int>(edges_offsets[caseNumber]) + (i << 1);
+    const auto p0 = static_cast<int>(edges[eOffset]);
+    const auto p1 = static_cast<int>(edges[eOffset + 1]);
+
+    const double d0 = (distances[p0] < 0.) ? -distances[p0] : distances[p0];
+    const double d1 = (distances[p1] < 0.) ? -distances[p1] : distances[p1];
+
+    const auto t = d0 / (d0 + d1);
+    intersection.addVertex(Point<T, 3>::lerp(tet[p0], tet[p1], t));
+  }
+
+  return caseNumber > 0 && caseNumber < 15;
 }
 
 }  // end namespace detail

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -607,7 +607,7 @@ AXOM_HOST_DEVICE bool intersect(const Plane<T, 3>& plane,
 template <typename T>
 AXOM_HOST_DEVICE bool intersect(const Plane<T, 3>& p,
                                 const Tetrahedron<T, 3>& tet,
-                                Polygon<T, 3> &intersection)
+                                Polygon<T, 3>& intersection)
 {
   return detail::intersect_plane_tet3d(p, tet, intersection);
 }

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -21,9 +21,11 @@
 #include "axom/primal/geometry/OrientedBoundingBox.hpp"
 #include "axom/primal/geometry/Plane.hpp"
 #include "axom/primal/geometry/Point.hpp"
+#include "axom/primal/geometry/Polygon.hpp"
 #include "axom/primal/geometry/Ray.hpp"
 #include "axom/primal/geometry/Segment.hpp"
 #include "axom/primal/geometry/Sphere.hpp"
+#include "axom/primal/geometry/Tetrahedron.hpp"
 #include "axom/primal/geometry/Triangle.hpp"
 #include "axom/primal/geometry/BezierCurve.hpp"
 
@@ -587,6 +589,27 @@ AXOM_HOST_DEVICE bool intersect(const Plane<T, 3>& plane,
                                 T& t)
 {
   return detail::intersect_plane_seg(plane, seg, t);
+}
+
+/*!
+ * \brief Determines if a 3D plane intersects a tetrahedron.
+ *
+ * \param [in] p A 3D plane
+ * \param [in] tet A 3D tetrahedron
+ * \param [out] intersection A polygon containing the intersection.
+ *
+ * \return true if plane intersects with tetrahedron, otherwise, false.
+ *
+ * \note If no intersection is found, the output polygon will be empty.
+ *       If the plane intersects at a tetrahedron vertex, the polygon
+ *       will contain duplicated points.
+ */
+template <typename T>
+AXOM_HOST_DEVICE bool intersect(const Plane<T, 3>& p,
+                                const Tetrahedron<T, 3>& tet,
+                                Polygon<T, 3> &intersection)
+{
+  return detail::intersect_plane_tet3d(p, tet, intersection);
 }
 
 /// @}

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -2220,6 +2220,290 @@ TEST(primal_intersect, plane_seg_test_intersection)
 
   EXPECT_FALSE(axom::primal::intersect(p1, s_p, t1));
 }
+
+//------------------------------------------------------------------------------
+TEST(primal_intersect, plane_tet_test_intersection)
+{
+  const int DIM = 3;
+  using PointType = primal::Point<double, DIM>;
+  using PlaneType = primal::Plane<double, DIM>;
+  using TetType = primal::Tetrahedron<double, DIM>;
+  using VectorType = primal::Vector<double, DIM>;
+  using PolygonType = primal::Polygon<double, DIM>;
+
+  PointType A{0., 0., 1.};
+  PointType B{1., 0., 0.};
+  PointType C{0., 0., 0.};
+  PointType D{0., 1., 0.};
+
+  PointType origin{0., 0., 0.};
+
+  PointType ABmid(PointType::lerp(A, B, 0.5));
+  PointType ACmid(PointType::lerp(A, C, 0.5));
+  PointType ADmid(PointType::lerp(A, D, 0.5));
+  PointType BCmid(PointType::lerp(B, C, 0.5));
+  PointType BDmid(PointType::lerp(B, D, 0.5));
+  PointType CDmid(PointType::lerp(C, D, 0.5));
+
+  TetType T{A, B, C, D};
+
+  PolygonType poly;
+
+  // ---------------------------------------------------------------------------
+  // Not even close
+  EXPECT_FALSE(axom::primal::intersect(PlaneType(VectorType{0.,0.,1.}, PointType{0.,0.,-10.}), T, poly));
+  EXPECT_EQ(poly.numVertices(), 0);
+
+  // ---------------------------------------------------------------------------
+  // Tests along X axis
+
+  // Plane hits only at point B.
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{1.,0.,0.}, B), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], B);
+  EXPECT_EQ(poly[1], B);
+  EXPECT_EQ(poly[2], B);
+
+  // Plane hits only at point B.
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,0.,0.}, B), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], B);
+  EXPECT_EQ(poly[1], B);
+  EXPECT_EQ(poly[2], B);
+
+  // Plane misses near point B.
+  EXPECT_FALSE(axom::primal::intersect(PlaneType(VectorType{1.,0.,0.}, PointType{1.5, 0., 0.}), T, poly));
+  EXPECT_EQ(poly.numVertices(), 0);
+
+  // Plane slices at x=0.5
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{1.,0.,0.}, PointType{0.5, 0., 0.}), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], PointType::lerp(A, B, 0.5));
+  EXPECT_EQ(poly[1], PointType::lerp(B, C, 0.5));
+  EXPECT_EQ(poly[2], PointType::lerp(B, D, 0.5));
+
+  // Plane slices at x=0.5
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,0.,0.}, PointType{0.5, 0., 0.}), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], PointType::lerp(B, C, 0.5));
+  EXPECT_EQ(poly[1], PointType::lerp(A, B, 0.5));
+  EXPECT_EQ(poly[2], PointType::lerp(B, D, 0.5));
+
+  // Slice at x=0
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{1.,0.,0.}, origin), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], A);
+  EXPECT_EQ(poly[1], C);
+  EXPECT_EQ(poly[2], D);
+
+  // Slice at x=0
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,0.,0.}, origin), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], C);
+  EXPECT_EQ(poly[1], A);
+  EXPECT_EQ(poly[2], D);
+
+  // ---------------------------------------------------------------------------
+  // Tests along Y axis
+
+  // Plane hits only at point D.
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,1.,0.}, D), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], D);
+  EXPECT_EQ(poly[1], D);
+  EXPECT_EQ(poly[2], D);
+
+  // Plane hits only at point D.
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,-1.,0.}, D), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], D);
+  EXPECT_EQ(poly[1], D);
+  EXPECT_EQ(poly[2], D);
+
+  // Plane misses near point D.
+  EXPECT_FALSE(axom::primal::intersect(PlaneType(VectorType{0.,1.,0.}, PointType{0., 1.5, 0.}), T, poly));
+  EXPECT_EQ(poly.numVertices(), 0);
+
+  // Plane slices at y=0.5
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,1.,0.}, PointType{0., 0.5, 0.}), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], PointType::lerp(A, D, 0.5));
+  EXPECT_EQ(poly[1], PointType::lerp(B, D, 0.5));
+  EXPECT_EQ(poly[2], PointType::lerp(C, D, 0.5));
+
+  // Plane slices at y=0.5
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,-1.,0.}, PointType{0., 0.5, 0.}), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], PointType::lerp(C, D, 0.5));
+  EXPECT_EQ(poly[1], PointType::lerp(B, D, 0.5));
+  EXPECT_EQ(poly[2], PointType::lerp(A, D, 0.5));
+
+  // Slice at y=0
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,1.,0.}, origin), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], A);
+  EXPECT_EQ(poly[1], B);
+  EXPECT_EQ(poly[2], C);
+
+  // Slice at y=0
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,-1.,0.}, origin), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], C);
+  EXPECT_EQ(poly[1], B);
+  EXPECT_EQ(poly[2], A);
+
+  // ---------------------------------------------------------------------------
+  // Tests along Z axis
+
+  // Plane hits only at point A.
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,0.,1.}, A), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], A);
+  EXPECT_EQ(poly[1], A);
+  EXPECT_EQ(poly[2], A);
+
+  // Plane hits only at point A.
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,0.,-1.}, A), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], A);
+  EXPECT_EQ(poly[1], A);
+  EXPECT_EQ(poly[2], A);
+
+  // Plane misses near point A.
+  EXPECT_FALSE(axom::primal::intersect(PlaneType(VectorType{0.,0.,-1.}, PointType{0., 0., 1.5}), T, poly));
+  EXPECT_EQ(poly.numVertices(), 0);
+
+  // Plane slices at z=0.5
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,0.,1.}, PointType{0., 0., 0.5}), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], PointType::lerp(A, C, 0.5));
+  EXPECT_EQ(poly[1], PointType::lerp(A, B, 0.5));
+  EXPECT_EQ(poly[2], PointType::lerp(A, D, 0.5));
+
+  // Plane slices at z=0.5
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,0.,-1.}, PointType{0., 0., 0.5}), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], PointType::lerp(A, B, 0.5));
+  EXPECT_EQ(poly[1], PointType::lerp(A, C, 0.5));
+  EXPECT_EQ(poly[2], PointType::lerp(A, D, 0.5));
+
+  // Slice at z=0
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,0.,1.}, origin), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], C);
+  EXPECT_EQ(poly[1], B);
+  EXPECT_EQ(poly[2], D);
+
+  // Slice at z=0
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,0.,-1.}, origin), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], B);
+  EXPECT_EQ(poly[1], C);
+  EXPECT_EQ(poly[2], D);
+
+  // ---------------------------------------------------------------------------
+  // Tests along normal (1,1,1) from point C
+
+  // Plane hits only at point C.
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{1.,1.,1.}, C), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], C);
+  EXPECT_EQ(poly[1], C);
+  EXPECT_EQ(poly[2], C);
+
+  // Plane hits only at point C.
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,-1.,-1.}, C), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], C);
+  EXPECT_EQ(poly[1], C);
+  EXPECT_EQ(poly[2], C);
+
+  // Plane misses near point C.
+  EXPECT_FALSE(axom::primal::intersect(PlaneType(VectorType{1.,1.,1.}, PointType{-0.1, -0.1, -0.1}), T, poly));
+  EXPECT_EQ(poly.numVertices(), 0);
+
+  // Plane slices at ACmid
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{1.,1.,1.}, ACmid), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], ACmid);
+  EXPECT_EQ(poly[1], BCmid);
+  EXPECT_EQ(poly[2], CDmid);
+
+  // Plane slices at ACmid
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,-1.,-1.}, ACmid), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], BCmid);
+  EXPECT_EQ(poly[1], ACmid);
+  EXPECT_EQ(poly[2], CDmid);
+
+  // Slice at face ABD
+  EXPECT_TRUE(axom::primal::intersect(make_plane(A, B, D), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], A);
+  EXPECT_EQ(poly[1], B);
+  EXPECT_EQ(poly[2], D);
+
+  // ---------------------------------------------------------------------------
+  // Tests along normal (1,0,1) from point ACmid
+
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{1.,0.,1.}, ACmid), T, poly));
+  EXPECT_EQ(poly.numVertices(), 4);
+  EXPECT_EQ(poly[0], ACmid);
+  EXPECT_EQ(poly[1], BCmid);
+  EXPECT_EQ(poly[2], BDmid);
+  EXPECT_EQ(poly[3], ADmid);
+
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,0.,-1.}, ACmid), T, poly));
+  EXPECT_EQ(poly.numVertices(), 4);
+  EXPECT_EQ(poly[0], BCmid);
+  EXPECT_EQ(poly[1], ACmid);
+  EXPECT_EQ(poly[2], ADmid);
+  EXPECT_EQ(poly[3], BDmid);
+
+  // ---------------------------------------------------------------------------
+  // Tests along normal (1,1,0) from point BCmid
+
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{1.,1.,0.}, BCmid), T, poly));
+  EXPECT_EQ(poly.numVertices(), 4);
+  EXPECT_EQ(poly[0], ABmid);
+  EXPECT_EQ(poly[1], BCmid);
+  EXPECT_EQ(poly[2], CDmid);
+  EXPECT_EQ(poly[3], ADmid);
+
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,-1.,0.}, BCmid), T, poly));
+  EXPECT_EQ(poly.numVertices(), 4);
+  EXPECT_EQ(poly[0], BCmid);
+  EXPECT_EQ(poly[1], ABmid);
+  EXPECT_EQ(poly[2], ADmid);
+  EXPECT_EQ(poly[3], CDmid);
+
+  // ---------------------------------------------------------------------------
+  // Tests along normal (0,1,1) from point ACmid
+
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,1.,1.}, ACmid), T, poly));
+  EXPECT_EQ(poly.numVertices(), 4);
+  EXPECT_EQ(poly[0], ACmid);
+  EXPECT_EQ(poly[1], ABmid);
+  EXPECT_EQ(poly[2], BDmid);
+  EXPECT_EQ(poly[3], CDmid);
+
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,-1.,-1.}, ACmid), T, poly));
+  EXPECT_EQ(poly.numVertices(), 4);
+  EXPECT_EQ(poly[0], ABmid);
+  EXPECT_EQ(poly[1], ACmid);
+  EXPECT_EQ(poly[2], CDmid);
+  EXPECT_EQ(poly[3], BDmid);
+
+  // ---------------------------------------------------------------------------
+  // Cut in half through CD segment
+
+  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,0.,1.}, C), T, poly));
+  EXPECT_EQ(poly.numVertices(), 3);
+  EXPECT_EQ(poly[0], C);
+  EXPECT_EQ(poly[1], ABmid);
+  EXPECT_EQ(poly[2], D);
+}
+
 //------------------------------------------------------------------------------
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
 

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -2231,12 +2231,12 @@ TEST(primal_intersect, plane_tet_test_intersection)
   using VectorType = primal::Vector<double, DIM>;
   using PolygonType = primal::Polygon<double, DIM>;
 
-  PointType A{0., 0., 1.};
-  PointType B{1., 0., 0.};
-  PointType C{0., 0., 0.};
-  PointType D{0., 1., 0.};
+  PointType A {0., 0., 1.};
+  PointType B {1., 0., 0.};
+  PointType C {0., 0., 0.};
+  PointType D {0., 1., 0.};
 
-  PointType origin{0., 0., 0.};
+  PointType origin {0., 0., 0.};
 
   PointType ABmid(PointType::lerp(A, B, 0.5));
   PointType ACmid(PointType::lerp(A, C, 0.5));
@@ -2245,59 +2245,75 @@ TEST(primal_intersect, plane_tet_test_intersection)
   PointType BDmid(PointType::lerp(B, D, 0.5));
   PointType CDmid(PointType::lerp(C, D, 0.5));
 
-  TetType T{A, B, C, D};
+  TetType T {A, B, C, D};
 
   PolygonType poly;
 
   // ---------------------------------------------------------------------------
   // Not even close
-  EXPECT_FALSE(axom::primal::intersect(PlaneType(VectorType{0.,0.,1.}, PointType{0.,0.,-10.}), T, poly));
+  EXPECT_FALSE(axom::primal::intersect(
+    PlaneType(VectorType {0., 0., 1.}, PointType {0., 0., -10.}),
+    T,
+    poly));
   EXPECT_EQ(poly.numVertices(), 0);
 
   // ---------------------------------------------------------------------------
   // Tests along X axis
 
   // Plane hits only at point B.
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{1.,0.,0.}, B), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {1., 0., 0.}, B), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], B);
   EXPECT_EQ(poly[1], B);
   EXPECT_EQ(poly[2], B);
 
   // Plane hits only at point B.
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,0.,0.}, B), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {-1., 0., 0.}, B), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], B);
   EXPECT_EQ(poly[1], B);
   EXPECT_EQ(poly[2], B);
 
   // Plane misses near point B.
-  EXPECT_FALSE(axom::primal::intersect(PlaneType(VectorType{1.,0.,0.}, PointType{1.5, 0., 0.}), T, poly));
+  EXPECT_FALSE(axom::primal::intersect(
+    PlaneType(VectorType {1., 0., 0.}, PointType {1.5, 0., 0.}),
+    T,
+    poly));
   EXPECT_EQ(poly.numVertices(), 0);
 
   // Plane slices at x=0.5
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{1.,0.,0.}, PointType{0.5, 0., 0.}), T, poly));
+  EXPECT_TRUE(axom::primal::intersect(
+    PlaneType(VectorType {1., 0., 0.}, PointType {0.5, 0., 0.}),
+    T,
+    poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], PointType::lerp(A, B, 0.5));
   EXPECT_EQ(poly[1], PointType::lerp(B, C, 0.5));
   EXPECT_EQ(poly[2], PointType::lerp(B, D, 0.5));
 
   // Plane slices at x=0.5
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,0.,0.}, PointType{0.5, 0., 0.}), T, poly));
+  EXPECT_TRUE(axom::primal::intersect(
+    PlaneType(VectorType {-1., 0., 0.}, PointType {0.5, 0., 0.}),
+    T,
+    poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], PointType::lerp(B, C, 0.5));
   EXPECT_EQ(poly[1], PointType::lerp(A, B, 0.5));
   EXPECT_EQ(poly[2], PointType::lerp(B, D, 0.5));
 
   // Slice at x=0
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{1.,0.,0.}, origin), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {1., 0., 0.}, origin), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], A);
   EXPECT_EQ(poly[1], C);
   EXPECT_EQ(poly[2], D);
 
   // Slice at x=0
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,0.,0.}, origin), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {-1., 0., 0.}, origin), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], C);
   EXPECT_EQ(poly[1], A);
@@ -2307,46 +2323,59 @@ TEST(primal_intersect, plane_tet_test_intersection)
   // Tests along Y axis
 
   // Plane hits only at point D.
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,1.,0.}, D), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {0., 1., 0.}, D), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], D);
   EXPECT_EQ(poly[1], D);
   EXPECT_EQ(poly[2], D);
 
   // Plane hits only at point D.
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,-1.,0.}, D), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {0., -1., 0.}, D), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], D);
   EXPECT_EQ(poly[1], D);
   EXPECT_EQ(poly[2], D);
 
   // Plane misses near point D.
-  EXPECT_FALSE(axom::primal::intersect(PlaneType(VectorType{0.,1.,0.}, PointType{0., 1.5, 0.}), T, poly));
+  EXPECT_FALSE(axom::primal::intersect(
+    PlaneType(VectorType {0., 1., 0.}, PointType {0., 1.5, 0.}),
+    T,
+    poly));
   EXPECT_EQ(poly.numVertices(), 0);
 
   // Plane slices at y=0.5
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,1.,0.}, PointType{0., 0.5, 0.}), T, poly));
+  EXPECT_TRUE(axom::primal::intersect(
+    PlaneType(VectorType {0., 1., 0.}, PointType {0., 0.5, 0.}),
+    T,
+    poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], PointType::lerp(A, D, 0.5));
   EXPECT_EQ(poly[1], PointType::lerp(B, D, 0.5));
   EXPECT_EQ(poly[2], PointType::lerp(C, D, 0.5));
 
   // Plane slices at y=0.5
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,-1.,0.}, PointType{0., 0.5, 0.}), T, poly));
+  EXPECT_TRUE(axom::primal::intersect(
+    PlaneType(VectorType {0., -1., 0.}, PointType {0., 0.5, 0.}),
+    T,
+    poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], PointType::lerp(C, D, 0.5));
   EXPECT_EQ(poly[1], PointType::lerp(B, D, 0.5));
   EXPECT_EQ(poly[2], PointType::lerp(A, D, 0.5));
 
   // Slice at y=0
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,1.,0.}, origin), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {0., 1., 0.}, origin), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], A);
   EXPECT_EQ(poly[1], B);
   EXPECT_EQ(poly[2], C);
 
   // Slice at y=0
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,-1.,0.}, origin), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {0., -1., 0.}, origin), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], C);
   EXPECT_EQ(poly[1], B);
@@ -2356,46 +2385,59 @@ TEST(primal_intersect, plane_tet_test_intersection)
   // Tests along Z axis
 
   // Plane hits only at point A.
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,0.,1.}, A), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {0., 0., 1.}, A), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], A);
   EXPECT_EQ(poly[1], A);
   EXPECT_EQ(poly[2], A);
 
   // Plane hits only at point A.
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,0.,-1.}, A), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {0., 0., -1.}, A), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], A);
   EXPECT_EQ(poly[1], A);
   EXPECT_EQ(poly[2], A);
 
   // Plane misses near point A.
-  EXPECT_FALSE(axom::primal::intersect(PlaneType(VectorType{0.,0.,-1.}, PointType{0., 0., 1.5}), T, poly));
+  EXPECT_FALSE(axom::primal::intersect(
+    PlaneType(VectorType {0., 0., -1.}, PointType {0., 0., 1.5}),
+    T,
+    poly));
   EXPECT_EQ(poly.numVertices(), 0);
 
   // Plane slices at z=0.5
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,0.,1.}, PointType{0., 0., 0.5}), T, poly));
+  EXPECT_TRUE(axom::primal::intersect(
+    PlaneType(VectorType {0., 0., 1.}, PointType {0., 0., 0.5}),
+    T,
+    poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], PointType::lerp(A, C, 0.5));
   EXPECT_EQ(poly[1], PointType::lerp(A, B, 0.5));
   EXPECT_EQ(poly[2], PointType::lerp(A, D, 0.5));
 
   // Plane slices at z=0.5
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,0.,-1.}, PointType{0., 0., 0.5}), T, poly));
+  EXPECT_TRUE(axom::primal::intersect(
+    PlaneType(VectorType {0., 0., -1.}, PointType {0., 0., 0.5}),
+    T,
+    poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], PointType::lerp(A, B, 0.5));
   EXPECT_EQ(poly[1], PointType::lerp(A, C, 0.5));
   EXPECT_EQ(poly[2], PointType::lerp(A, D, 0.5));
 
   // Slice at z=0
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,0.,1.}, origin), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {0., 0., 1.}, origin), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], C);
   EXPECT_EQ(poly[1], B);
   EXPECT_EQ(poly[2], D);
 
   // Slice at z=0
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,0.,-1.}, origin), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {0., 0., -1.}, origin), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], B);
   EXPECT_EQ(poly[1], C);
@@ -2405,32 +2447,39 @@ TEST(primal_intersect, plane_tet_test_intersection)
   // Tests along normal (1,1,1) from point C
 
   // Plane hits only at point C.
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{1.,1.,1.}, C), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {1., 1., 1.}, C), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], C);
   EXPECT_EQ(poly[1], C);
   EXPECT_EQ(poly[2], C);
 
   // Plane hits only at point C.
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,-1.,-1.}, C), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {-1., -1., -1.}, C), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], C);
   EXPECT_EQ(poly[1], C);
   EXPECT_EQ(poly[2], C);
 
   // Plane misses near point C.
-  EXPECT_FALSE(axom::primal::intersect(PlaneType(VectorType{1.,1.,1.}, PointType{-0.1, -0.1, -0.1}), T, poly));
+  EXPECT_FALSE(axom::primal::intersect(
+    PlaneType(VectorType {1., 1., 1.}, PointType {-0.1, -0.1, -0.1}),
+    T,
+    poly));
   EXPECT_EQ(poly.numVertices(), 0);
 
   // Plane slices at ACmid
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{1.,1.,1.}, ACmid), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {1., 1., 1.}, ACmid), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], ACmid);
   EXPECT_EQ(poly[1], BCmid);
   EXPECT_EQ(poly[2], CDmid);
 
   // Plane slices at ACmid
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,-1.,-1.}, ACmid), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {-1., -1., -1.}, ACmid), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], BCmid);
   EXPECT_EQ(poly[1], ACmid);
@@ -2446,14 +2495,16 @@ TEST(primal_intersect, plane_tet_test_intersection)
   // ---------------------------------------------------------------------------
   // Tests along normal (1,0,1) from point ACmid
 
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{1.,0.,1.}, ACmid), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {1., 0., 1.}, ACmid), T, poly));
   EXPECT_EQ(poly.numVertices(), 4);
   EXPECT_EQ(poly[0], ACmid);
   EXPECT_EQ(poly[1], BCmid);
   EXPECT_EQ(poly[2], BDmid);
   EXPECT_EQ(poly[3], ADmid);
 
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,0.,-1.}, ACmid), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {-1., 0., -1.}, ACmid), T, poly));
   EXPECT_EQ(poly.numVertices(), 4);
   EXPECT_EQ(poly[0], BCmid);
   EXPECT_EQ(poly[1], ACmid);
@@ -2463,14 +2514,16 @@ TEST(primal_intersect, plane_tet_test_intersection)
   // ---------------------------------------------------------------------------
   // Tests along normal (1,1,0) from point BCmid
 
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{1.,1.,0.}, BCmid), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {1., 1., 0.}, BCmid), T, poly));
   EXPECT_EQ(poly.numVertices(), 4);
   EXPECT_EQ(poly[0], ABmid);
   EXPECT_EQ(poly[1], BCmid);
   EXPECT_EQ(poly[2], CDmid);
   EXPECT_EQ(poly[3], ADmid);
 
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,-1.,0.}, BCmid), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {-1., -1., 0.}, BCmid), T, poly));
   EXPECT_EQ(poly.numVertices(), 4);
   EXPECT_EQ(poly[0], BCmid);
   EXPECT_EQ(poly[1], ABmid);
@@ -2480,14 +2533,16 @@ TEST(primal_intersect, plane_tet_test_intersection)
   // ---------------------------------------------------------------------------
   // Tests along normal (0,1,1) from point ACmid
 
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,1.,1.}, ACmid), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {0., 1., 1.}, ACmid), T, poly));
   EXPECT_EQ(poly.numVertices(), 4);
   EXPECT_EQ(poly[0], ACmid);
   EXPECT_EQ(poly[1], ABmid);
   EXPECT_EQ(poly[2], BDmid);
   EXPECT_EQ(poly[3], CDmid);
 
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{0.,-1.,-1.}, ACmid), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {0., -1., -1.}, ACmid), T, poly));
   EXPECT_EQ(poly.numVertices(), 4);
   EXPECT_EQ(poly[0], ABmid);
   EXPECT_EQ(poly[1], ACmid);
@@ -2497,7 +2552,8 @@ TEST(primal_intersect, plane_tet_test_intersection)
   // ---------------------------------------------------------------------------
   // Cut in half through CD segment
 
-  EXPECT_TRUE(axom::primal::intersect(PlaneType(VectorType{-1.,0.,1.}, C), T, poly));
+  EXPECT_TRUE(
+    axom::primal::intersect(PlaneType(VectorType {-1., 0., 1.}, C), T, poly));
   EXPECT_EQ(poly.numVertices(), 3);
   EXPECT_EQ(poly[0], C);
   EXPECT_EQ(poly[1], ABmid);


### PR DESCRIPTION
# Summary

This PR adds an _intersect_ function in primal that lets the user slice a tetrahedron with plane and if there is an intersection, return the intersection polygon. There are existing _intersect_ functions for other primal primitives. This new function follows the established pattern. A new CI test was added.

This resolves #1324, which was requested by @adayton1.

