### PR TITLE
Fixes/improvements for closest_point to Segment operator

### DIFF
--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -81,9 +81,10 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
 
       return B;
     }
-    else if(isLeq(squaredNormAB, ZERO, EPS))
+    else if(utilities::isNearlyEqual(squaredNormAB, ZERO, EPS))
     {
-      // Segment is degenerate, so can pick either endpoint. We pick A.
+      // Segment is degenerate (A and B are collocated),
+      // so we can pick either end point. We pick A.
       if(loc)
       {
         *loc = ZERO;

--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -83,7 +83,7 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
     }
     else if(isLeq(squaredNormAB, ZERO, EPS))
     {
-      // Segment is degenerate
+      // Segment is degenerate, so can pick either endpoint. We pick A.
       if(loc)
       {
         *loc = ZERO;

--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -61,7 +61,8 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
 
   if(isLeq(t, ZERO, EPS))
   {
-    if(loc) {
+    if(loc)
+    {
       *loc = ZERO;
     }
 
@@ -73,7 +74,8 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
 
     if(isGeq(t, squaredNormAB, EPS))
     {
-      if(loc) {
+      if(loc)
+      {
         *loc = ONE;
       }
 
@@ -82,7 +84,8 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
     else if(isLeq(squaredNormAB, ZERO, EPS))
     {
       // Segment is degenerate
-      if(loc) {
+      if(loc)
+      {
         *loc = ZERO;
       }
 
@@ -93,7 +96,8 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
       // Normalize t
       t /= squaredNormAB;
 
-      if(loc) {
+      if(loc)
+      {
         *loc = t;
       }
 

--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -55,14 +55,6 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
   const PointType& B = seg[1];
 
   const VectorType AB(A, B);
-  const T squaredNormAB = AB.squared_norm();
-
-  // Check if segment is degenerate
-  if(isLeq(squaredNormAB, ZERO, EPS))
-  {
-    t = ZERO;
-    return A;
-  }
 
   // Compute length of the projection of AP onto AB
   t = VectorType(A, P).dot(AB);
@@ -72,16 +64,27 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
     t = ZERO;
     return A;
   }
-  else if(isGeq(t, squaredNormAB, EPS))
-  {
-    t = ONE;
-    return B;
-  }
   else
   {
-    // Normalize t
-    t /= squaredNormAB;
-    return A + AB * t;
+    const T squaredNormAB = AB.squared_norm();
+
+    if(isGeq(t, squaredNormAB, EPS))
+    {
+      t = ONE;
+      return B;
+    }
+    else if(isLeq(squaredNormAB, ZERO, EPS))
+    {
+      // Segment is degenerate
+      t = ZERO;
+      return A;
+    }
+    else
+    {
+      // Normalize t
+      t /= squaredNormAB;
+      return A + AB * t;
+    }
   }
 }
 

--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -29,17 +29,17 @@ namespace primal
  *
  * \param [in] P the query point
  * \param [in] seg user-supplied segment
- * \param [out] t location along the line segment
+ * \param [out] loc location along the line segment
  * \param [in] EPS fuzz factor for equality comparisons
  * \return cp the closest point from a point P and a segment
  *
- * \note t \f$ \in [0, 1] \f% represents the fraction of the way from A to B,
+ * \note loc \f$ \in [0, 1] \f% represents the fraction of the way from A to B,
  *  with 0 corresponding to A and 1 corresponding to B.
  */
 template <typename T, int NDIMS>
 AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
                                                       const Segment<T, NDIMS>& seg,
-                                                      T& t,
+                                                      T* loc,
                                                       double EPS = 1E-12)
 {
   using PointType = Point<T, NDIMS>;
@@ -57,11 +57,14 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
   const VectorType AB(A, B);
 
   // Compute length of the projection of AP onto AB
-  t = VectorType(A, P).dot(AB);
+  T t = VectorType(A, P).dot(AB);
 
   if(isLeq(t, ZERO, EPS))
   {
-    t = ZERO;
+    if(loc) {
+      *loc = ZERO;
+    }
+
     return A;
   }
   else
@@ -70,39 +73,33 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
 
     if(isGeq(t, squaredNormAB, EPS))
     {
-      t = ONE;
+      if(loc) {
+        *loc = ONE;
+      }
+
       return B;
     }
     else if(isLeq(squaredNormAB, ZERO, EPS))
     {
       // Segment is degenerate
-      t = ZERO;
+      if(loc) {
+        *loc = ZERO;
+      }
+
       return A;
     }
     else
     {
       // Normalize t
       t /= squaredNormAB;
+
+      if(loc) {
+        *loc = t;
+      }
+
       return A + AB * t;
     }
   }
-}
-
-/*!
- * \brief Computes the closest point from a point, P, to a given segment.
- *
- * \param [in] P the query point
- * \param [in] seg user-supplied segment
- * \param [in] EPS fuzz factor for equality comparisons
- * \return cp the closest point from a point P and a segment
- */
-template <typename T, int NDIMS>
-AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
-                                                      const Segment<T, NDIMS>& seg,
-                                                      double EPS = 1E-12)
-{
-  T t;
-  return closest_point(P, seg, t, EPS);
 }
 
 /*!

--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -103,6 +103,23 @@ AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
 }
 
 /*!
+ * \brief Computes the closest point from a point, P, to a given segment.
+ *
+ * \param [in] P the query point
+ * \param [in] seg user-supplied segment
+ * \param [in] EPS fuzz factor for equality comparisons
+ * \return cp the closest point from a point P and a segment
+ */
+template <typename T, int NDIMS>
+AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
+                                                      const Segment<T, NDIMS>& seg,
+                                                      double EPS = PRIMAL_TINY)
+{
+  T* loc = nullptr;
+  return closest_point(P, seg, loc, EPS);
+}
+
+/*!
  * \brief Computes the closest point from a point, P, to a given triangle.
  *
  * \param [in] P the query point

--- a/src/axom/primal/operators/closest_point.hpp
+++ b/src/axom/primal/operators/closest_point.hpp
@@ -40,7 +40,7 @@ template <typename T, int NDIMS>
 AXOM_HOST_DEVICE inline Point<T, NDIMS> closest_point(const Point<T, NDIMS>& P,
                                                       const Segment<T, NDIMS>& seg,
                                                       T* loc,
-                                                      double EPS = 1E-12)
+                                                      double EPS = PRIMAL_TINY)
 {
   using PointType = Point<T, NDIMS>;
   using VectorType = Vector<T, NDIMS>;

--- a/src/axom/primal/operators/squared_distance.hpp
+++ b/src/axom/primal/operators/squared_distance.hpp
@@ -145,31 +145,7 @@ template <typename T, int NDIMS>
 inline double squared_distance(const Point<T, NDIMS>& P,
                                const Segment<T, NDIMS>& S)
 {
-  Vector<T, NDIMS> ab(S.source(), S.target());
-  Vector<T, NDIMS> ac(S.source(), P);
-
-  const T e = Vector<T, NDIMS>::dot_product(ac, ab);
-
-  // outside segment, on the side of a
-  // Testing if closest point is A
-  if(e <= 0.0f)
-  {
-    return ac.squared_norm();
-  }
-
-  // outside segment, on the side of b
-  // Testing if closest point is B
-  const T f = ab.squared_norm();
-  if(e >= f)
-  {
-    Vector<T, NDIMS> bc(S.target(), P);
-    return bc.squared_norm();
-  }
-
-  // P projects onto the segment
-  // Otherwise, we are in between A,B, therefore we project inside A,B.
-  const T dist = ac.squared_norm() - (e * e / f);
-  return dist;
+  return squared_distance(P, closest_point(P, S));
 }
 
 /*!
@@ -183,8 +159,7 @@ template <typename T, int NDIMS>
 inline double squared_distance(const Point<T, NDIMS>& P,
                                const Triangle<T, NDIMS>& tri)
 {
-  Point<T, NDIMS> cpt = closest_point(P, tri);
-  return squared_distance(P, cpt);
+  return squared_distance(P, closest_point(P, tri));
 }
 
 }  // namespace primal

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -45,7 +45,8 @@ TEST(primal_closest_point, seg_test_degenerate)
   EXPECT_NEAR(t, 0.0, EPS);
 
   // Query point is anywhere else
-  EXPECT_TRUE(primal::closest_point(QPoint({2.2, 2.2, 2.2}), S_reverse, &t, EPS) == B);
+  EXPECT_TRUE(
+    primal::closest_point(QPoint({2.2, 2.2, 2.2}), S_reverse, &t, EPS) == B);
   EXPECT_NEAR(t, 0.0, EPS);
 }
 
@@ -244,9 +245,8 @@ TEST(primal_closest_point, seg_test_closest_point_interior)
   EXPECT_NEAR(t, 0.75, EPS);
 
   // Test without loc argument
-  EXPECT_TRUE(
-    primal::closest_point(QPoint({0.25, 0.75, 0.75}), S_reverse, EPS) ==
-    QPoint::lerp(A, B, 0.25));
+  EXPECT_TRUE(primal::closest_point(QPoint({0.25, 0.75, 0.75}), S_reverse, EPS) ==
+              QPoint::lerp(A, B, 0.25));
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -27,19 +27,19 @@ TEST(primal_closest_point, seg_test_degenerate)
   double t;
 
   // Query point is on the midpoint of AB
-  EXPECT_TRUE(primal::closest_point(QPoint({0.5e-10, 0.0, 0.0}), S, t, EPS) == A);
+  EXPECT_TRUE(primal::closest_point(QPoint({0.5e-10, 0.0, 0.0}), S, &t, EPS) == A);
   EXPECT_NEAR(t, 0.0, EPS);
 
   // Query point is on the line perpendicular to AB running through the midpoint
-  EXPECT_TRUE(primal::closest_point(QPoint({0.5e-10, 1.0, 0.0}), S, t, EPS) == A);
+  EXPECT_TRUE(primal::closest_point(QPoint({0.5e-10, 1.0, 0.0}), S, &t, EPS) == A);
   EXPECT_NEAR(t, 0.0, EPS);
 
   // Query point is equal to A
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 0.0}), S, t, EPS) == A);
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 0.0}), S, &t, EPS) == A);
   EXPECT_NEAR(t, 0.0, EPS);
 
   // Query point is equal to B (for a degenerate segment, A is always returned)
-  EXPECT_TRUE(primal::closest_point(QPoint({1.0e-9, 0.0, 0.0}), S, t, EPS) == A);
+  EXPECT_TRUE(primal::closest_point(QPoint({1.0e-9, 0.0, 0.0}), S, &t, EPS) == A);
   EXPECT_NEAR(t, 0.0, EPS);
 
   //
@@ -49,22 +49,22 @@ TEST(primal_closest_point, seg_test_degenerate)
 
   // Query point is on the midpoint of AB
   EXPECT_TRUE(
-    primal::closest_point(QPoint({0.5e-10, 0.0, 0.0}), S_reverse, t, EPS) == B);
+    primal::closest_point(QPoint({0.5e-10, 0.0, 0.0}), S_reverse, &t, EPS) == B);
   EXPECT_NEAR(t, 0.0, EPS);
 
   // Query point is on the line perpendicular to AB running through the midpoint
   EXPECT_TRUE(
-    primal::closest_point(QPoint({0.5e-10, 1.0, 0.0}), S_reverse, t, EPS) == B);
+    primal::closest_point(QPoint({0.5e-10, 1.0, 0.0}), S_reverse, &t, EPS) == B);
   EXPECT_NEAR(t, 0.0, EPS);
 
   // Query point is equal to A
   EXPECT_TRUE(
-    primal::closest_point(QPoint({0.0, 0.0, 0.0}), S_reverse, t, EPS) == B);
+    primal::closest_point(QPoint({0.0, 0.0, 0.0}), S_reverse, &t, EPS) == B);
   EXPECT_NEAR(t, 0.0, EPS);
 
   // Query point is equal to B (for a degenerate segment, A is always returned)
   EXPECT_TRUE(
-    primal::closest_point(QPoint({1.0e-9, 0.0, 0.0}), S_reverse, t, EPS) == B);
+    primal::closest_point(QPoint({1.0e-9, 0.0, 0.0}), S_reverse, &t, EPS) == B);
   EXPECT_NEAR(t, 0.0, EPS);
 }
 
@@ -84,15 +84,15 @@ TEST(primal_closest_point, seg_test_closest_point_vertex_0)
   double t;
 
   // Query point is on the line extended past point A
-  EXPECT_TRUE(primal::closest_point(QPoint({-1.0, 2.0, 2.0}), S, t, EPS) == A);
+  EXPECT_TRUE(primal::closest_point(QPoint({-1.0, 2.0, 2.0}), S, &t, EPS) == A);
   EXPECT_NEAR(t, 0.0, EPS);
 
   // Query point is on the line perpendicular to AB running through point A
-  EXPECT_TRUE(primal::closest_point(QPoint({-1.0, 0.0, 2.0}), S, t, EPS) == A);
+  EXPECT_TRUE(primal::closest_point(QPoint({-1.0, 0.0, 2.0}), S, &t, EPS) == A);
   EXPECT_NEAR(t, 0.0, EPS);
 
   // Query point is equal to A
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 1.0, 1.0}), S, t, EPS) == A);
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 1.0, 1.0}), S, &t, EPS) == A);
   EXPECT_NEAR(t, 0.0, EPS);
 
   //
@@ -102,17 +102,17 @@ TEST(primal_closest_point, seg_test_closest_point_vertex_0)
 
   // Query point is on the line extended past point A
   EXPECT_TRUE(
-    primal::closest_point(QPoint({-1.0, 2.0, 2.0}), S_reverse, t, EPS) == A);
+    primal::closest_point(QPoint({-1.0, 2.0, 2.0}), S_reverse, &t, EPS) == A);
   EXPECT_NEAR(t, 1.0, EPS);
 
   // Query point is on the line perpendicular to AB running through point A
   EXPECT_TRUE(
-    primal::closest_point(QPoint({-1.0, 0.0, 2.0}), S_reverse, t, EPS) == A);
+    primal::closest_point(QPoint({-1.0, 0.0, 2.0}), S_reverse, &t, EPS) == A);
   EXPECT_NEAR(t, 1.0, EPS);
 
   // Query point is equal to A
   EXPECT_TRUE(
-    primal::closest_point(QPoint({0.0, 1.0, 1.0}), S_reverse, t, EPS) == A);
+    primal::closest_point(QPoint({0.0, 1.0, 1.0}), S_reverse, &t, EPS) == A);
   EXPECT_NEAR(t, 1.0, EPS);
 }
 
@@ -132,15 +132,15 @@ TEST(primal_closest_point, seg_test_closest_point_vertex_1)
   double t;
 
   // Query point is on the line extended past point B
-  EXPECT_TRUE(primal::closest_point(QPoint({2.0, -1.0, 1.0}), S, t, EPS) == B);
+  EXPECT_TRUE(primal::closest_point(QPoint({2.0, -1.0, 1.0}), S, &t, EPS) == B);
   EXPECT_NEAR(t, 1.0, EPS);
 
   // Query point is on the line perpendicular to AB running through point B
-  EXPECT_TRUE(primal::closest_point(QPoint({2.0, 1.0, -1.0}), S, t, EPS) == B);
+  EXPECT_TRUE(primal::closest_point(QPoint({2.0, 1.0, -1.0}), S, &t, EPS) == B);
   EXPECT_NEAR(t, 1.0, EPS);
 
   // Query point is equal to B
-  EXPECT_TRUE(primal::closest_point(QPoint({1.0, 0.0, 0.0}), S, t, EPS) == B);
+  EXPECT_TRUE(primal::closest_point(QPoint({1.0, 0.0, 0.0}), S, &t, EPS) == B);
   EXPECT_NEAR(t, 1.0, EPS);
 
   //
@@ -150,17 +150,17 @@ TEST(primal_closest_point, seg_test_closest_point_vertex_1)
 
   // Query point is on the line extended past point B
   EXPECT_TRUE(
-    primal::closest_point(QPoint({2.0, -1.0, 1.0}), S_reverse, t, EPS) == B);
+    primal::closest_point(QPoint({2.0, -1.0, 1.0}), S_reverse, &t, EPS) == B);
   EXPECT_NEAR(t, 0.0, EPS);
 
   // Query point is on the line perpendicular to AB running through point B
   EXPECT_TRUE(
-    primal::closest_point(QPoint({2.0, 1.0, -1.0}), S_reverse, t, EPS) == B);
+    primal::closest_point(QPoint({2.0, 1.0, -1.0}), S_reverse, &t, EPS) == B);
   EXPECT_NEAR(t, 0.0, EPS);
 
   // Query point is equal to B
   EXPECT_TRUE(
-    primal::closest_point(QPoint({1.0, 0.0, 0.0}), S_reverse, t, EPS) == B);
+    primal::closest_point(QPoint({1.0, 0.0, 0.0}), S_reverse, &t, EPS) == B);
   EXPECT_NEAR(t, 0.0, EPS);
 }
 
@@ -180,12 +180,12 @@ TEST(primal_closest_point, seg_test_closest_point_interior)
   double t;
 
   // Query point is perpendicular to the midpoint of AB
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 0.5}), S, t, EPS) ==
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 0.5}), S, &t, EPS) ==
               QPoint::lerp(A, B, 0.5));
   EXPECT_NEAR(t, 0.5, EPS);
 
   // Query point is a quarter of the way to B from A
-  EXPECT_TRUE(primal::closest_point(QPoint({0.25, 0.75, 0.75}), S, t, EPS) ==
+  EXPECT_TRUE(primal::closest_point(QPoint({0.25, 0.75, 0.75}), S, &t, EPS) ==
               QPoint::lerp(A, B, 0.25));
   EXPECT_NEAR(t, 0.25, EPS);
 
@@ -195,13 +195,13 @@ TEST(primal_closest_point, seg_test_closest_point_interior)
   QSegment S_reverse(B, A);
 
   // Query point is perpendicular to the midpoint of AB
-  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 0.5}), S_reverse, t, EPS) ==
+  EXPECT_TRUE(primal::closest_point(QPoint({0.0, 0.0, 0.5}), S_reverse, &t, EPS) ==
               QPoint::lerp(A, B, 0.5));
   EXPECT_NEAR(t, 0.5, EPS);
 
   // Query point is a quarter of the way to B from A
   EXPECT_TRUE(
-    primal::closest_point(QPoint({0.25, 0.75, 0.75}), S_reverse, t, EPS) ==
+    primal::closest_point(QPoint({0.25, 0.75, 0.75}), S_reverse, &t, EPS) ==
     QPoint::lerp(A, B, 0.25));
   EXPECT_NEAR(t, 0.75, EPS);
 }

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -242,6 +242,11 @@ TEST(primal_closest_point, seg_test_closest_point_interior)
     primal::closest_point(QPoint({0.25, 0.75, 0.75}), S_reverse, &t, EPS) ==
     QPoint::lerp(A, B, 0.25));
   EXPECT_NEAR(t, 0.75, EPS);
+
+  // Test without loc argument
+  EXPECT_TRUE(
+    primal::closest_point(QPoint({0.25, 0.75, 0.75}), S_reverse, EPS) ==
+    QPoint::lerp(A, B, 0.25));
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_closest_point.cpp
+++ b/src/axom/primal/tests/primal_closest_point.cpp
@@ -14,6 +14,44 @@ namespace primal = axom::primal;
 //------------------------------------------------------------------------------
 TEST(primal_closest_point, seg_test_degenerate)
 {
+  constexpr double EPS = primal::PRIMAL_TINY;
+
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QSegment = primal::Segment<CoordType, DIM>;
+
+  QPoint A({1.1, 1.1, 1.1});
+  QPoint B({1.1, 1.1, 1.1});
+  QSegment S(A, B);
+  double t;
+
+  // Query point is on A/B
+  EXPECT_TRUE(primal::closest_point(QPoint({1.1, 1.1, 1.1}), S, &t, EPS) == A);
+  EXPECT_NEAR(t, 0.0, EPS);
+
+  // Query point is anywhere else
+  EXPECT_TRUE(primal::closest_point(QPoint({2.2, 2.2, 2.2}), S, &t, EPS) == A);
+  EXPECT_NEAR(t, 0.0, EPS);
+
+  //
+  // Now let's reverse the segment
+  //
+  QSegment S_reverse(B, A);
+
+  // Query point is on A/B
+  EXPECT_TRUE(
+    primal::closest_point(QPoint({1.1, 1.1, 1.1}), S_reverse, &t, EPS) == B);
+  EXPECT_NEAR(t, 0.0, EPS);
+
+  // Query point is anywhere else
+  EXPECT_TRUE(primal::closest_point(QPoint({2.2, 2.2, 2.2}), S_reverse, &t, EPS) == B);
+  EXPECT_NEAR(t, 0.0, EPS);
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_closest_point, seg_test_tiny)
+{
   constexpr double EPS = 1e-12;
 
   constexpr int DIM = 3;


### PR DESCRIPTION
# Summary

- This PR is a refactoring and bugfix
- It does the following:
  - Removes ambiguous overload of closest_point to Segment operator
  - Updates default tolerance for closest_point to Segment operator (1e-12 -> PRIMAL_TINY = 1.0e-50)
  - Refactors closest_point to Segment operator to only punt if it needs to
  - Uses closest_point to Segment operator in squared_distance to Segment operator
  - Adds actual degenerate test case for closest_point to Segment operator