### PR TITLE
Add a reflectPoint method to Plane

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,6 +28,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Adds a RAII-based `MPIWrapper` utility class to axom's core component. This can help setup/teardown
   MPI in axom's examples. It can also be used in configurations with MPI.
 - Primal: Adds a `closest_point` operator for finding the closest point on a `Segment`
+- Primal: Adds a `reflectPoint` method to the `Plane` primitive
+- Primal: Makes several primitive methods available in device code
 
 ### Changed
 - Upgrades `vcpkg` usage for axom's automated Windows builds to its

--- a/src/axom/primal/geometry/Plane.hpp
+++ b/src/axom/primal/geometry/Plane.hpp
@@ -178,6 +178,17 @@ public:
   PointType projectPoint(const PointType& x) const;
 
   /*!
+   * \brief Computes the reflection of a given point, x, across this Plane.
+   *
+   * \param [in] x buffer consisting of the coordinates of the point to project.
+   * \return refx the coordinates of the reflected point.
+   *
+   * \post The reflected point will be on the Plane if x is on the Plane,
+   *       otherwise it will be on the opposite side of the Plane from x.
+   */
+  PointType reflectPoint(const PointType& x) const;
+
+  /*!
    * \brief Flips the orientation of the plane.
    */
   inline void flip();
@@ -262,6 +273,16 @@ inline typename Plane<T, NDIMS>::PointType Plane<T, NDIMS>::projectPoint(
 {
   const T signed_distance = this->signedDistance(x);
   return x - signed_distance * m_normal;
+}
+
+//------------------------------------------------------------------------------
+template <typename T, int NDIMS>
+inline typename Plane<T, NDIMS>::PointType Plane<T, NDIMS>::reflectPoint(
+  const PointType& x) const
+{
+  constexpr T TWO {2.};
+  const T signed_distance = this->signedDistance(x);
+  return x - TWO * signed_distance * m_normal;
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/geometry/Plane.hpp
+++ b/src/axom/primal/geometry/Plane.hpp
@@ -139,7 +139,7 @@ public:
    * \return dim the dimension of the Plane.
    * \post (dim==2) || (dim==3)
    */
-  AXOM_HOST_DEVICE static int getDimension() const { return NDIMS; };
+  AXOM_HOST_DEVICE static constexpr int getDimension() { return NDIMS; };
 
   /*!
    * \brief Returns a const pointer to the plane's unit normal.

--- a/src/axom/primal/geometry/Plane.hpp
+++ b/src/axom/primal/geometry/Plane.hpp
@@ -118,8 +118,7 @@ public:
    * \note The supplied normal will be normalized, such that, the Plane's normal
    *  will always be a unit normal.
    */
-  AXOM_HOST_DEVICE
-  Plane(const VectorType& normal, const PointType& x);
+  AXOM_HOST_DEVICE Plane(const VectorType& normal, const PointType& x);
 
   /*!
    * \brief Constructs a plane with a specified normal, \f$ \mathcal{N} \f$,
@@ -131,8 +130,7 @@ public:
    * \note The supplied normal will be normalized, such that, the Plane's normal
    *  will always be a unit normal.
    */
-  AXOM_HOST_DEVICE
-  Plane(const VectorType& normal, T offset);
+  AXOM_HOST_DEVICE Plane(const VectorType& normal, T offset);
 
   /// @}
 
@@ -141,8 +139,7 @@ public:
    * \return dim the dimension of the Plane.
    * \post (dim==2) || (dim==3)
    */
-  AXOM_HOST_DEVICE
-  inline int getDimension() const { return NDIMS; };
+  AXOM_HOST_DEVICE static int getDimension() const { return NDIMS; };
 
   /*!
    * \brief Returns a const pointer to the plane's unit normal.
@@ -175,7 +172,7 @@ public:
    *
    * \post this->getOrientedSide( projx ) == ON_BOUNDARY
    */
-  PointType projectPoint(const PointType& x) const;
+  AXOM_HOST_DEVICE PointType projectPoint(const PointType& x) const;
 
   /*!
    * \brief Computes the reflection of a given point, x, across this Plane.
@@ -186,12 +183,12 @@ public:
    * \post The reflected point will be on the Plane if x is on the Plane,
    *       otherwise it will be on the opposite side of the Plane from x.
    */
-  PointType reflectPoint(const PointType& x) const;
+  AXOM_HOST_DEVICE PointType reflectPoint(const PointType& x) const;
 
   /*!
    * \brief Flips the orientation of the plane.
    */
-  inline void flip();
+  AXOM_HOST_DEVICE void flip();
 
   /*!
    * \brief Computes the orientation of the point with respect to this Plane.
@@ -209,8 +206,8 @@ public:
    *
    * \see OrientationResult
    */
-  AXOM_HOST_DEVICE inline int getOrientation(const PointType& x,
-                                             double TOL = 1.e-9) const;
+  AXOM_HOST_DEVICE int getOrientation(const PointType& x,
+                                      double TOL = 1.e-9) const;
 
   /*!
    * \brief Prints the Plane information in the given output stream.
@@ -227,7 +224,7 @@ private:
    * \param [in] normal pointer to a buffer consisting of the normal
    * \note The supplied buffer must be at least NDIMS long.
    */
-  AXOM_HOST_DEVICE inline void setNormal(const VectorType& normal);
+  AXOM_HOST_DEVICE void setNormal(const VectorType& normal);
 
   VectorType m_normal; /*!< plane unit-normal  */
   T m_offset;          /*!< offset from origin */
@@ -268,7 +265,7 @@ AXOM_HOST_DEVICE Plane<T, NDIMS>::Plane(const VectorType& normal, T offset)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-inline typename Plane<T, NDIMS>::PointType Plane<T, NDIMS>::projectPoint(
+AXOM_HOST_DEVICE typename Plane<T, NDIMS>::PointType Plane<T, NDIMS>::projectPoint(
   const PointType& x) const
 {
   const T signed_distance = this->signedDistance(x);
@@ -277,17 +274,16 @@ inline typename Plane<T, NDIMS>::PointType Plane<T, NDIMS>::projectPoint(
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-inline typename Plane<T, NDIMS>::PointType Plane<T, NDIMS>::reflectPoint(
+AXOM_HOST_DEVICE typename Plane<T, NDIMS>::PointType Plane<T, NDIMS>::reflectPoint(
   const PointType& x) const
 {
-  constexpr T TWO {2.};
   const T signed_distance = this->signedDistance(x);
-  return x - TWO * signed_distance * m_normal;
+  return x - static_cast<T>(2.0) * signed_distance * m_normal;
 }
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-inline void Plane<T, NDIMS>::flip()
+AXOM_HOST_DEVICE void Plane<T, NDIMS>::flip()
 {
   m_normal *= static_cast<T>(-1.0);
   m_offset *= static_cast<T>(-1.0);
@@ -295,8 +291,8 @@ inline void Plane<T, NDIMS>::flip()
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE inline int Plane<T, NDIMS>::getOrientation(const PointType& x,
-                                                            double TOL) const
+AXOM_HOST_DEVICE int Plane<T, NDIMS>::getOrientation(const PointType& x,
+                                                     double TOL) const
 {
   const T signed_distance = this->signedDistance(x);
 
@@ -323,7 +319,7 @@ std::ostream& Plane<T, NDIMS>::print(std::ostream& os) const
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-AXOM_HOST_DEVICE inline void Plane<T, NDIMS>::setNormal(const VectorType& normal)
+AXOM_HOST_DEVICE void Plane<T, NDIMS>::setNormal(const VectorType& normal)
 {
   m_normal = normal.unitVector();
 }

--- a/src/axom/primal/tests/primal_plane.cpp
+++ b/src/axom/primal/tests/primal_plane.cpp
@@ -333,6 +333,74 @@ TEST(primal_plane, project_point)
 }
 
 //------------------------------------------------------------------------------
+TEST(primal_plane, reflect_point)
+{
+  // test 3D
+  {
+    const PointType3 x1 {1.0, 1.0, 3.0};
+    const PointType3 x2 {2.0, 2.0, 3.0};
+    const PointType3 x3 {1.0, 3.0, 3.0};
+    PointType3 q {0.0, 0.0, 0.0};
+    PointType3 qproj;
+
+    PlaneType3 P = primal::make_plane(x1, x2, x3);
+
+    // (a) test reflect point below plane
+    qproj = P.reflectPoint(q);
+    EXPECT_EQ(P.getOrientation(qproj), primal::ON_POSITIVE_SIDE);
+    EXPECT_DOUBLE_EQ(qproj[0], 0.0);
+    EXPECT_DOUBLE_EQ(qproj[1], 0.0);
+    EXPECT_DOUBLE_EQ(qproj[2], 6.0);
+
+    // (b) test reflect point above plane
+    q[2] = 6.0;
+    qproj = P.reflectPoint(q);
+    EXPECT_EQ(P.getOrientation(qproj), primal::ON_NEGATIVE_SIDE);
+    EXPECT_DOUBLE_EQ(qproj[0], 0.0);
+    EXPECT_DOUBLE_EQ(qproj[1], 0.0);
+    EXPECT_DOUBLE_EQ(qproj[2], 0.0);
+
+    // (c) test reflect point (already) on plane
+    q[2] = 3.0;
+    qproj = P.reflectPoint(q);
+    EXPECT_EQ(P.getOrientation(qproj), primal::ON_BOUNDARY);
+    EXPECT_DOUBLE_EQ(qproj[0], q[0]);
+    EXPECT_DOUBLE_EQ(qproj[1], q[1]);
+    EXPECT_DOUBLE_EQ(qproj[2], q[2]);
+  }
+
+  // test 2D
+  {
+    const PointType2 x1 {2.0, -1.0};
+    const PointType2 x2 {2.0, 2.0};
+    PlaneType2 P = primal::make_plane(x1, x2);
+    PointType2 q {0.0, 0.0};
+    PointType2 qproj;
+
+    // (a) test reflect point below plane
+    q[0] = 4.0;
+    qproj = P.reflectPoint(q);
+    EXPECT_EQ(P.getOrientation(qproj), primal::ON_POSITIVE_SIDE);
+    EXPECT_DOUBLE_EQ(qproj[0], 0.0);
+    EXPECT_DOUBLE_EQ(qproj[1], 0.0);
+
+    // (b) test reflect point above plane
+    q[0] = 0.0;
+    qproj = P.reflectPoint(q);
+    EXPECT_EQ(P.getOrientation(qproj), primal::ON_NEGATIVE_SIDE);
+    EXPECT_DOUBLE_EQ(qproj[0], 4.0);
+    EXPECT_DOUBLE_EQ(qproj[1], 0.0);
+
+    // (c) test reflect point (already) on plane
+    q[0] = 2.0;
+    qproj = P.reflectPoint(q);
+    EXPECT_EQ(P.getOrientation(qproj), primal::ON_BOUNDARY);
+    EXPECT_DOUBLE_EQ(qproj[0], q[0]);
+    EXPECT_DOUBLE_EQ(qproj[1], q[1]);
+  }
+}
+
+//------------------------------------------------------------------------------
 TEST(primal_plane, flip)
 {
   // test 3D


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following:
  - Adds reflectPoint method to Plane at the request of myself
  - Makes sure all Plane methods (except I/O) are device accessible
  - Removes redundant (and potentially harmful) "inline" keyword on methods in Plane