### PR TITLE
Harden CMake find_*

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -37,6 +37,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   Also updates vcpkg port versions for axom dependencies. Temporarily removes `umpire`
   from axom's default dependencies on Windows due to incompatibility between umpire's
   external `fmt` and axom's vendored copy.
+- Turn off CMake finding dependencies on system paths.
 
 ### Removed
 - Removes config option `AXOM_ENABLE_ANNOTATIONS`. Annotations are now provided by `caliper` 

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -260,28 +260,57 @@ endmacro(axom_add_test)
 
 
 #------------------------------------------------------------------------------
-# Asserts that the given VARIABLE_NAME's value is a directory and exists.
+# axom_assert_is_directory(DIR_VARIABLE <variable that holds the prefix>)
+#
+# Asserts that the given DIR_VARIABLE's value is a directory and exists.
 # Fails with a helpful message when it doesn't.
 #------------------------------------------------------------------------------
 macro(axom_assert_is_directory)
 
     set(options)
-    set(singleValueArgs VARIABLE_NAME)
+    set(singleValueArgs DIR_VARIABLE)
     set(multiValueArgs)
 
     # Parse the arguments to the macro
     cmake_parse_arguments(arg
          "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    if (NOT EXISTS "${${arg_VARIABLE_NAME}}")
-        message(FATAL_ERROR "Given ${arg_VARIABLE_NAME} does not exist: ${${arg_VARIABLE_NAME}}")
+    if (NOT EXISTS "${${arg_DIR_VARIABLE}}")
+        message(FATAL_ERROR "Given ${arg_DIR_VARIABLE} does not exist: ${${arg_DIR_VARIABLE}}")
     endif()
 
-    if (NOT IS_DIRECTORY "${${arg_VARIABLE_NAME}}")
-        message(FATAL_ERROR "Given ${arg_VARIABLE_NAME} is not a directory: ${${arg_VARIABLE_NAME}}")
+    if (NOT IS_DIRECTORY "${${arg_DIR_VARIABLE}}")
+        message(FATAL_ERROR "Given ${arg_DIR_VARIABLE} is not a directory: ${${arg_DIR_VARIABLE}}")
     endif()
 
 endmacro(axom_assert_is_directory)
+
+#------------------------------------------------------------------------------
+# axom_assert_find_succeeded(PROJECT_NAME <project name>
+#                             TARGET       <found target>
+#                             DIR_VARIABLE <variable that holds the prefix>)
+#
+# Asserts that the given PROJECT_NAME's TARGET exists.
+# Fails with a helpful message when it doesn't.
+#------------------------------------------------------------------------------
+macro(axom_assert_find_succeeded)
+
+    set(options)
+    set(singleValueArgs DIR_VARIABLE PROJECT_NAME TARGET)
+    set(multiValueArgs)
+
+    # Parse the arguments to the macro
+    cmake_parse_arguments(arg
+         "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    message(STATUS "Checking for expected ${arg_PROJECT_NAME} target '${arg_TARGET}'")
+    if (NOT TARGET ${arg_TARGET})
+        message(FATAL_ERROR "${arg_PROJECT_NAME} failed to load: ${${arg_DIR_VARIABLE}}")
+    else()
+        message(STATUS "${arg_PROJECT_NAME} loaded: ${${arg_DIR_VARIABLE}}")
+    endif()
+
+endmacro(axom_assert_find_succeeded)
 
 ##------------------------------------------------------------------------------
 ## convert_to_native_escaped_file_path( path output )

--- a/src/cmake/axom-config.cmake.in
+++ b/src/cmake/axom-config.cmake.in
@@ -90,7 +90,8 @@ if(NOT AXOM_FOUND)
     endif()
     find_dependency(adiak REQUIRED 
                     PATHS "${ADIAK_DIR}"
-                          "${ADIAK_DIR}/lib/cmake/adiak")
+                          "${ADIAK_DIR}/lib/cmake/adiak"
+                    NO_SYSTEM_ENVIRONMENT_PATH)
   endif()
 
   # c2c
@@ -107,7 +108,8 @@ if(NOT AXOM_FOUND)
     endif()
     find_dependency(caliper REQUIRED 
                     PATHS "${CALIPER_DIR}"
-                          "${CALIPER_DIR}/share/cmake/caliper")
+                          "${CALIPER_DIR}/share/cmake/caliper"
+                    NO_SYSTEM_ENVIRONMENT_PATH)
   endif()
 
   # camp
@@ -116,7 +118,7 @@ if(NOT AXOM_FOUND)
     if(NOT CAMP_DIR)
       set(CAMP_DIR ${AXOM_CAMP_DIR})
     endif()
-    find_dependency(camp REQUIRED PATHS "${CAMP_DIR}")
+    find_dependency(camp REQUIRED PATHS "${CAMP_DIR}" NO_SYSTEM_ENVIRONMENT_PATH)
   endif()
 
   # umpire
@@ -125,7 +127,7 @@ if(NOT AXOM_FOUND)
     if(NOT UMPIRE_DIR)
       set(UMPIRE_DIR ${AXOM_UMPIRE_DIR})
     endif()
-    find_dependency(umpire REQUIRED PATHS "${UMPIRE_DIR}")
+    find_dependency(umpire REQUIRED PATHS "${UMPIRE_DIR}" NO_SYSTEM_ENVIRONMENT_PATH)
   endif()
 
   # raja
@@ -134,7 +136,7 @@ if(NOT AXOM_FOUND)
     if(NOT RAJA_DIR)
       set(RAJA_DIR ${AXOM_RAJA_DIR})
     endif()
-    find_dependency(RAJA REQUIRED PATHS "${RAJA_DIR}")
+    find_dependency(RAJA REQUIRED PATHS "${RAJA_DIR}" NO_SYSTEM_ENVIRONMENT_PATH)
   endif()
 
   # conduit
@@ -151,7 +153,8 @@ if(NOT AXOM_FOUND)
 
     find_dependency(Conduit REQUIRED
                     PATHS "${CONDUIT_DIR}"
-                          "${CONDUIT_DIR}/lib/cmake/conduit")
+                          "${CONDUIT_DIR}/lib/cmake/conduit"
+                    NO_SYSTEM_ENVIRONMENT_PATH)
   endif()
 
   # hdf5

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -35,8 +35,11 @@ if ((RAJA_DIR OR UMPIRE_DIR) AND NOT CAMP_DIR)
 endif()
 
 if(CAMP_DIR)
-    axom_assert_is_directory(VARIABLE_NAME CAMP_DIR)
+    axom_assert_is_directory(DIR_VARIABLE CAMP_DIR)
     find_dependency(camp REQUIRED PATHS "${CAMP_DIR}")
+    axom_assert_find_succeeded(PROJECT_NAME Camp
+                               TARGET       camp
+                               DIR_VARIABLE CAMP_DIR)
     set(CAMP_FOUND TRUE)
 else()
     set(CAMP_FOUND FALSE)
@@ -46,14 +49,11 @@ endif()
 # UMPIRE
 #------------------------------------------------------------------------------
 if (UMPIRE_DIR)
-    axom_assert_is_directory(VARIABLE_NAME UMPIRE_DIR)
+    axom_assert_is_directory(DIR_VARIABLE UMPIRE_DIR)
     find_dependency(umpire REQUIRED PATHS "${UMPIRE_DIR}")
-
-    message(STATUS "Checking for expected Umpire target 'umpire'")
-    if (NOT TARGET umpire)
-        message(FATAL_ERROR "Umpire failed to load: ${UMPIRE_DIR}")
-    endif()
-    message(STATUS "Umpire loaded: ${UMPIRE_DIR}")
+    axom_assert_find_succeeded(PROJECT_NAME Umpire
+                               TARGET       umpire
+                               DIR_VARIABLE UMPIRE_DIR)
     set(UMPIRE_FOUND TRUE)
 
     blt_convert_to_system_includes(TARGET umpire)
@@ -67,14 +67,11 @@ endif()
 # RAJA
 #------------------------------------------------------------------------------
 if (RAJA_DIR)
-    axom_assert_is_directory(VARIABLE_NAME RAJA_DIR)
+    axom_assert_is_directory(DIR_VARIABLE RAJA_DIR)
     find_dependency(raja REQUIRED PATHS "${RAJA_DIR}")
-
-    message(STATUS "Checking for expected RAJA target 'RAJA'")
-    if (NOT TARGET RAJA)
-        message(FATAL_ERROR "RAJA failed to load: ${RAJA_DIR}")
-    endif()
-    message(STATUS "RAJA loaded: ${RAJA_DIR}")
+    axom_assert_find_succeeded(PROJECT_NAME RAJA
+                               TARGET       RAJA
+                               DIR_VARIABLE RAJA_DIR)
     set(RAJA_FOUND TRUE)
 else()
     message(STATUS "RAJA support is OFF" )
@@ -87,17 +84,14 @@ endif()
 # Find Conduit first, then find HDF5 to fix "Could NOT find HDF5" issue with
 # newer CMake versions
 if (CONDUIT_DIR)
-    axom_assert_is_directory(VARIABLE_NAME CONDUIT_DIR)
+    axom_assert_is_directory(DIR_VARIABLE CONDUIT_DIR)
 
     find_dependency(Conduit REQUIRED
                     PATHS "${CONDUIT_DIR}"
                           "${CONDUIT_DIR}/lib/cmake/conduit")
-
-    message(STATUS "Checking for expected Conduit target 'conduit::conduit'")
-    if (NOT TARGET conduit::conduit)
-        message(FATAL_ERROR "Conduit failed to load: ${CONDUIT_DIR}")
-    endif()
-    message(STATUS "Conduit loaded: ${CONDUIT_DIR}")
+    axom_assert_find_succeeded(PROJECT_NAME Conduit
+                               TARGET       conduit::conduit
+                               DIR_VARIABLE CONDUIT_DIR)
     set(CONDUIT_FOUND TRUE)
 
     blt_convert_to_system_includes(TARGET conduit::conduit)
@@ -109,8 +103,11 @@ endif()
 # HDF5
 #------------------------------------------------------------------------------
 if (HDF5_DIR)
-    axom_assert_is_directory(VARIABLE_NAME HDF5_DIR)
+    axom_assert_is_directory(DIR_VARIABLE HDF5_DIR)
     include(cmake/thirdparty/SetupHDF5.cmake)
+    axom_assert_find_succeeded(PROJECT_NAME HDF5
+                               TARGET       hdf5
+                               DIR_VARIABLE HDF5_DIR)
     blt_list_append(TO TPL_DEPS ELEMENTS hdf5)
 else()
     message(STATUS "HDF5 support is OFF")
@@ -136,7 +133,7 @@ if (TARGET mfem)
 
     set(MFEM_FOUND TRUE)
 elseif (MFEM_DIR)
-    axom_assert_is_directory(VARIABLE_NAME MFEM_DIR)
+    axom_assert_is_directory(DIR_VARIABLE MFEM_DIR)
     include(cmake/thirdparty/FindMFEM.cmake)
     # If the CMake build system was used, a CMake target for mfem already exists
     if (NOT TARGET mfem)
@@ -191,15 +188,13 @@ endif()
 # Adiak
 #------------------------------------------------------------------------------
 if(ADIAK_DIR)
-    axom_assert_is_directory(VARIABLE_NAME ADIAK_DIR)
+    axom_assert_is_directory(DIR_VARIABLE ADIAK_DIR)
     find_dependency(adiak REQUIRED 
                     PATHS "${ADIAK_DIR}"
                           "${ADIAK_DIR}/lib/cmake/adiak")
-
-    message(STATUS "Checking for expected adiak target 'adiak::adiak'")
-    if (NOT TARGET adiak::adiak)
-        message(FATAL_ERROR "adiak failed to load: ${ADIAK_DIR}")
-    endif()
+    axom_assert_find_succeeded(PROJECT_NAME Adiak
+                               TARGET       adiak::adiak
+                               DIR_VARIABLE ADIAK_DIR)
 
     # Apply patch for adiak's missing `-ldl' for mpi when built statically
     get_target_property(_target_type adiak::adiak TYPE)
@@ -207,10 +202,9 @@ if(ADIAK_DIR)
         blt_patch_target(NAME adiak::mpi DEPENDS_ON dl)
     endif()
 
-    message(STATUS "adiak loaded: ${ADIAK_DIR}")
     set(ADIAK_FOUND TRUE)
 else()
-    message(STATUS "adiak support is OFF")
+    message(STATUS "Adiak support is OFF")
     set(ADIAK_FOUND FALSE)
 endif()
 
@@ -223,20 +217,17 @@ if(CALIPER_DIR)
         find_package(CUDAToolkit REQUIRED)
     endif()
 
-    axom_assert_is_directory(VARIABLE_NAME CALIPER_DIR)
+    axom_assert_is_directory(DIR_VARIABLE CALIPER_DIR)
     find_dependency(caliper REQUIRED 
                     PATHS "${CALIPER_DIR}" 
                           "${CALIPER_DIR}/share/cmake/caliper")
+    axom_assert_find_succeeded(PROJECT_NAME Caliper
+                               TARGET       caliper
+                               DIR_VARIABLE CALIPER_DIR)
 
-    message(STATUS "Checking for expected caliper target 'caliper'")
-    if (NOT TARGET caliper)
-        message(FATAL_ERROR "caliper failed to load: ${CALIPER_DIR}")
-    endif()
-    
-    message(STATUS "caliper loaded: ${CALIPER_DIR}")
     set(CALIPER_FOUND TRUE)
 else()
-    message(STATUS "caliper support is OFF")
+    message(STATUS "Caliper support is OFF")
     set(CALIPER_FOUND FALSE)
 endif()
 
@@ -263,7 +254,7 @@ endif()
 # SCR
 #------------------------------------------------------------------------------
 if (SCR_DIR)
-    axom_assert_is_directory(VARIABLE_NAME SCR_DIR)
+    axom_assert_is_directory(DIR_VARIABLE SCR_DIR)
 
     include(cmake/thirdparty/FindSCR.cmake)
     blt_import_library( NAME       scr
@@ -282,7 +273,7 @@ endif()
 # LUA
 #------------------------------------------------------------------------------
 if (LUA_DIR)
-    axom_assert_is_directory(VARIABLE_NAME LUA_DIR)
+    axom_assert_is_directory(DIR_VARIABLE LUA_DIR)
     include(cmake/thirdparty/FindLUA.cmake)
     if(NOT TARGET lua)
         blt_import_library( NAME        lua
@@ -303,7 +294,7 @@ endif()
 # C2C
 #------------------------------------------------------------------------------
 if (C2C_DIR)
-    axom_assert_is_directory(VARIABLE_NAME C2C_DIR)
+    axom_assert_is_directory(DIR_VARIABLE C2C_DIR)
     include(cmake/thirdparty/FindC2C.cmake)
     blt_import_library(
         NAME          c2c

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -36,7 +36,7 @@ endif()
 
 if(CAMP_DIR)
     axom_assert_is_directory(DIR_VARIABLE CAMP_DIR)
-    find_dependency(camp REQUIRED PATHS "${CAMP_DIR}")
+    find_dependency(camp REQUIRED PATHS "${CAMP_DIR}" NO_SYSTEM_ENVIRONMENT_PATH)
     axom_assert_find_succeeded(PROJECT_NAME Camp
                                TARGET       camp
                                DIR_VARIABLE CAMP_DIR)
@@ -50,7 +50,7 @@ endif()
 #------------------------------------------------------------------------------
 if (UMPIRE_DIR)
     axom_assert_is_directory(DIR_VARIABLE UMPIRE_DIR)
-    find_dependency(umpire REQUIRED PATHS "${UMPIRE_DIR}")
+    find_dependency(umpire REQUIRED PATHS "${UMPIRE_DIR}" NO_SYSTEM_ENVIRONMENT_PATH)
     axom_assert_find_succeeded(PROJECT_NAME Umpire
                                TARGET       umpire
                                DIR_VARIABLE UMPIRE_DIR)
@@ -68,7 +68,7 @@ endif()
 #------------------------------------------------------------------------------
 if (RAJA_DIR)
     axom_assert_is_directory(DIR_VARIABLE RAJA_DIR)
-    find_dependency(raja REQUIRED PATHS "${RAJA_DIR}")
+    find_dependency(raja REQUIRED PATHS "${RAJA_DIR}" NO_SYSTEM_ENVIRONMENT_PATH)
     axom_assert_find_succeeded(PROJECT_NAME RAJA
                                TARGET       RAJA
                                DIR_VARIABLE RAJA_DIR)
@@ -88,7 +88,8 @@ if (CONDUIT_DIR)
 
     find_dependency(Conduit REQUIRED
                     PATHS "${CONDUIT_DIR}"
-                          "${CONDUIT_DIR}/lib/cmake/conduit")
+                          "${CONDUIT_DIR}/lib/cmake/conduit"
+                    NO_SYSTEM_ENVIRONMENT_PATH)
     axom_assert_find_succeeded(PROJECT_NAME Conduit
                                TARGET       conduit::conduit
                                DIR_VARIABLE CONDUIT_DIR)
@@ -191,7 +192,8 @@ if(ADIAK_DIR)
     axom_assert_is_directory(DIR_VARIABLE ADIAK_DIR)
     find_dependency(adiak REQUIRED 
                     PATHS "${ADIAK_DIR}"
-                          "${ADIAK_DIR}/lib/cmake/adiak")
+                          "${ADIAK_DIR}/lib/cmake/adiak"
+                    NO_SYSTEM_ENVIRONMENT_PATH)
     axom_assert_find_succeeded(PROJECT_NAME Adiak
                                TARGET       adiak::adiak
                                DIR_VARIABLE ADIAK_DIR)
@@ -220,7 +222,8 @@ if(CALIPER_DIR)
     axom_assert_is_directory(DIR_VARIABLE CALIPER_DIR)
     find_dependency(caliper REQUIRED 
                     PATHS "${CALIPER_DIR}" 
-                          "${CALIPER_DIR}/share/cmake/caliper")
+                          "${CALIPER_DIR}/share/cmake/caliper"
+                    NO_SYSTEM_ENVIRONMENT_PATH)
     axom_assert_find_succeeded(PROJECT_NAME Caliper
                                TARGET       caliper
                                DIR_VARIABLE CALIPER_DIR)


### PR DESCRIPTION
A user submitted a problem where our finding of Conduit was defaulting to a Conduit installed in a system installed Python installation over the specified `CONDUIT_DIR`.  This turns off that.

It also adds a new macro to ensure the target that we expect to come out of the find calls is present afterwards.