### PR TITLE
Convert Python scripts to use argparse

### DIFF
--- a/scripts/llnl_scripts/archive_job.py
+++ b/scripts/llnl_scripts/archive_job.py
@@ -1,5 +1,5 @@
 #!/bin/sh
-"exec" "python" "-u" "-B" "$0" "$@"
+"exec" "python3" "-u" "-B" "$0" "$@"
 
 # Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
 # other Axom Project Developers. See the top-level LICENSE file for details.
@@ -26,35 +26,35 @@ import os
 import sys
 
 from llnl_lc_build_tools import *
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 
 def parse_args():
     "Parses args from command line"
-    parser = OptionParser()
+    parser = ArgumentParser()
     
-    parser.add_option("-e", "--exitcode",
-                      type="int",
-                      dest="exitcode",
-                      default="0",
-                      help="Exit code to be returned from this script (Defaults to 0)")
+    parser.add_argument("-e", "--exitcode",
+                        type=int,
+                        dest="exitcode",
+                        default="0",
+                        help="Exit code to be returned from this script (Defaults to 0)")
 
-    parser.add_option("-n", "--name",
-                      dest="name",
-                      default="",
-                      help="Archive build results under given name")
+    parser.add_argument("-n", "--name",
+                        dest="name",
+                        default="",
+                        help="Archive build results under given name")
 
-    parser.add_option("-f", "--files",
-                      dest="files",
-                      default="",
-                      help="Files to be archived (comma delimited)")
+    parser.add_argument("-f", "--files",
+                        dest="files",
+                        default="",
+                        help="Files to be archived (comma delimited)")
 
     ###############
     # parse args
     ###############
-    opts, extras = parser.parse_args()
+    opts = parser.parse_args()
     # we want a dict b/c the values could 
-    # be passed without using optparse
+    # be passed without using argparse
     opts = vars(opts)
     return opts
 
@@ -68,9 +68,9 @@ def main():
 
     cwd = os.getcwd()
 
-    print "[Starting Archiving]"
-    print "[  Archive Dir: %s]" % archive_dir
-    print "[  Job Dir: %s]" % cwd
+    print("[Starting Archiving]")
+    print(f"[  Archive Dir: {archive_dir}]")
+    print(f"[  Job Dir: {cwd}]")
 
     # Create a success/failure file if not already created by the job
     if (opts["exitcode"] != 0) and not os.path.exists("failed.json"):

--- a/scripts/llnl_scripts/build_devtools.py
+++ b/scripts/llnl_scripts/build_devtools.py
@@ -16,7 +16,7 @@
 
 from llnl_lc_build_tools import *
 
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 import getpass
 import os
@@ -24,19 +24,19 @@ import os
 
 def parse_args():
     "Parses args from command line"
-    parser = OptionParser()
+    parser = ArgumentParser()
     # Location of source directory to build
-    parser.add_option("-d", "--directory",
-                      dest="directory",
-                      default="",
-                      help="Location to build all TPL's, timestamp directory will be created (Defaults to shared location)")
+    parser.add_argument("-d", "--directory",
+                        dest="directory",
+                        default="",
+                        help="Location to build all TPL's, timestamp directory will be created (Defaults to shared location)")
 
     ###############
     # parse args
     ###############
-    opts, extras = parser.parse_args()
+    opts = parser.parse_args()
     # we want a dict b/c the values could 
-    # be passed without using optparse
+    # be passed without using argparse
     opts = vars(opts)
     return opts
 

--- a/scripts/llnl_scripts/build_src.py
+++ b/scripts/llnl_scripts/build_src.py
@@ -16,55 +16,55 @@
 
 from llnl_lc_build_tools import *
 
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 
 def parse_args():
     "Parses args from command line"
-    parser = OptionParser()
+    parser = ArgumentParser()
     # Location of source directory to build
-    parser.add_option("-d", "--directory",
-                      dest="directory",
-                      default="",
-                      help="Directory of source to be built (Defaults to current)")
+    parser.add_argument("-d", "--directory",
+                        dest="directory",
+                        default="",
+                        help="Directory of source to be built (Defaults to current)")
     # Whether to build a specific hostconfig
-    parser.add_option("--host-config",
-                      dest="hostconfig",
-                      default="",
-                      help="Specific host-config file to build (Tries multiple known paths to locate given file)")
+    parser.add_argument("--host-config",
+                        dest="hostconfig",
+                        default="",
+                        help="Specific host-config file to build (Tries multiple known paths to locate given file)")
     # Build type for the configuration
-    parser.add_option("--build-type",
-                      dest="buildtype",
-                      default="Debug",
-                      choices = ("Debug", "RelWithDebInfo", "Release", "MinSizeRel"),
-                      help="The CMake build type to use")
+    parser.add_argument("--build-type",
+                        dest="buildtype",
+                        default="Debug",
+                        choices = ("Debug", "RelWithDebInfo", "Release", "MinSizeRel"),
+                        help="The CMake build type to use")
     # Run unit tests serially (MPI Bug on El Capitan)
-    parser.add_option("--test-serial",
-                      action="store_true",
-                      dest="testserial",
-                      default=False,
-                      help="Run unit tests serially")
+    parser.add_argument("--test-serial",
+                        action="store_true",
+                        dest="testserial",
+                        default=False,
+                        help="Run unit tests serially")
     # Extra cmake options to pass to config build
-    parser.add_option("--extra-cmake-options",
-                      dest="extra_cmake_options",
-                      default="",
-                      help="Extra cmake options to add to the cmake configure line")
-    parser.add_option("--automation-mode",
-                      action="store_true",
-                      dest="automation",
-                      default=False,
-                      help="Toggle automation mode which uses env $HOST_CONFIG then $SYS_TYPE/$COMPILER if found")
-    parser.add_option("-v", "--verbose",
-                      action="store_true",
-                      dest="verbose",
-                      default=False,
-                      help="Output logs to screen as well as to files")
+    parser.add_argument("--extra-cmake-options",
+                        dest="extra_cmake_options",
+                        default="",
+                        help="Extra cmake options to add to the cmake configure line")
+    parser.add_argument("--automation-mode",
+                        action="store_true",
+                        dest="automation",
+                        default=False,
+                        help="Toggle automation mode which uses env $HOST_CONFIG then $SYS_TYPE/$COMPILER if found")
+    parser.add_argument("-v", "--verbose",
+                        action="store_true",
+                        dest="verbose",
+                        default=False,
+                        help="Output logs to screen as well as to files")
     ###############
     # parse args
     ###############
-    opts, extras = parser.parse_args()
+    opts = parser.parse_args()
     # we want a dict b/c the values could
-    # be passed without using optparse
+    # be passed without using argparse
     opts = vars(opts)
 
     # Ensure correctness

--- a/scripts/llnl_scripts/build_tpls.py
+++ b/scripts/llnl_scripts/build_tpls.py
@@ -17,40 +17,40 @@
 
 from llnl_lc_build_tools import *
 
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 import os
 
 
 def parse_args():
     "Parses args from command line"
-    parser = OptionParser()
+    parser = ArgumentParser()
     # Directory to do all the building
-    parser.add_option("-d", "--directory",
-                      dest="directory",
-                      default="",
-                      help="Location to build all TPL's, timestamp directory will be created (Defaults to shared location)")
+    parser.add_argument("-d", "--directory",
+                        dest="directory",
+                        default="",
+                        help="Location to build all TPL's, timestamp directory will be created (Defaults to shared location)")
     # Spack spec to use for the build
-    parser.add_option("-s", "--spec",
-                      dest="spec",
-                      default="",
-                      help="Spack spec to build (defaults to all available on SYS_TYPE)")
-    parser.add_option("-v", "--verbose",
-                      action="store_true",
-                      dest="verbose",
-                      default=False,
-                      help="Output logs to screen as well as to files")
-    parser.add_option("-m", "--mirror",
-                      dest="mirror",
-                      default="",
-                      help="Mirror location to use (defaults to shared location)")
+    parser.add_argument("-s", "--spec",
+                        dest="spec",
+                        default="",
+                        help="Spack spec to build (defaults to all available on SYS_TYPE)")
+    parser.add_argument("-v", "--verbose",
+                        action="store_true",
+                        dest="verbose",
+                        default=False,
+                        help="Output logs to screen as well as to files")
+    parser.add_argument("-m", "--mirror",
+                        dest="mirror",
+                        default="",
+                        help="Mirror location to use (defaults to shared location)")
 
     ###############
     # parse args
     ###############
-    opts, _ = parser.parse_args()
+    opts = parser.parse_args()
     # we want a dict b/c the values could 
-    # be passed without using optparse
+    # be passed without using argparse
     opts = vars(opts)
     return opts
 

--- a/scripts/llnl_scripts/report.py
+++ b/scripts/llnl_scripts/report.py
@@ -1,5 +1,5 @@
 #!/bin/sh
-"exec" "python" "-u" "-B" "$0" "$@"
+"exec" "python3" "-u" "-B" "$0" "$@"
 
 # Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
 # other Axom Project Developers. See the top-level LICENSE file for details.
@@ -26,9 +26,9 @@ try:
 except ImportError:
     import xml.etree.ElementTree as ET
 
-from optparse import OptionParser
+from argparse import ArgumentParser
 from smtplib import SMTP
-from email.MIMEText import MIMEText
+from email.mime.text import MIMEText
 from dateutil.parser import parse
 from llnl_lc_build_tools import *
 
@@ -61,32 +61,32 @@ class SpecInfo(object):
 
 def parse_args():
     "Parses args from command line"
-    parser = OptionParser()
+    parser = ArgumentParser()
     
-    parser.add_option("--clean",
-                      dest="clean",
-                      action="store_true",
-                      default=False,
-                      help="!!DESTRUCTIVE!! This option cleans old archived jobs (leaves 20 jobs)")
+    parser.add_argument("--clean",
+                        dest="clean",
+                        action="store_true",
+                        default=False,
+                        help="!!DESTRUCTIVE!! This option cleans old archived jobs (leaves 20 jobs)")
 
-    parser.add_option("-e", "--email",
-                      type="string",
-                      dest="email",
-                      default="axom-dev@llnl.gov",
-                      help="Email address to send report (Defaults to 'axom-dev@llnl.gov')")
+    parser.add_argument("-e", "--email",
+                        type=str,
+                        dest="email",
+                        default="axom-dev@llnl.gov",
+                        help="Email address to send report (Defaults to 'axom-dev@llnl.gov')")
 
-    parser.add_option("--html",
-                      type="string",
-                      dest="html",
-                      default="status.html",
-                      help="File name for saving generated html status file (Defaults to 'status.html')")
+    parser.add_argument("--html",
+                        type=str,
+                        dest="html",
+                        default="status.html",
+                        help="File name for saving generated html status file (Defaults to 'status.html')")
 
     ###############
     # parse args
     ###############
-    opts, extras = parser.parse_args()
+    opts = parser.parse_args()
     # we want a dict b/c the values could 
-    # be passed without using optparse
+    # be passed without using argparse
     opts = vars(opts)
     return opts
 
@@ -109,17 +109,17 @@ def main():
         cleanOldArchives(archive_dir)
 
     #Generate build email and send
-    print "Reading archived job information..."
+    print("Reading archived job information...")
     basicJobInfos, srcJobInfos, tplJobInfos = generateJobInfos(archive_dir)
 
-    print "Generating email content..."
+    print("Generating email content...")
     emailContent = generateEmailContent(basicJobInfos, srcJobInfos, tplJobInfos)
     
-    print "Saving html file '{}'".format( opts["html"] )
+    print("Saving html file '{}'".format( opts["html"] ))
     with open(opts["html"], 'w') as f:
         f.write(emailContent)
 
-    print "Sending email to {}...".format(opts["email"])
+    print("Sending email to {}...".format(opts["email"]))
     return sendEmail(emailContent, emailSubject, sender, receiver, emailServer)
 
 
@@ -128,7 +128,7 @@ def getAllDirectoryNames(path):
 
 
 def cleanOldArchives(archive_dir):
-    print "Deleting old archive directories..."    
+    print("Deleting old archive directories...")
 
     # Remove only the individual jobs not any of the directory structure
     # Directory structure = <archive base>/<sys_type>/<job name>/<datetime>
@@ -147,7 +147,7 @@ def cleanOldArchives(archive_dir):
                 datetime_dir = pjoin(jobName_dir, datetime)
                 shutil.rmtree(datetime_dir)
 
-    print "Done deleting."
+    print("Done deleting.")
 
 
 def determineSuccessState(path):
@@ -209,7 +209,7 @@ def generateJobInfos(archive_dir):
 
                 populateTests(currSpecInfo, spec_dir)
                 if currJobInfo.specInfos.has_key(currSpecInfo.name):
-                    print "Warning: duplicate spec ({0}) found in job: {1}".format(spec, currJobInfo.name)
+                    print("Warning: duplicate spec ({0}) found in job: {1}".format(spec, currJobInfo.name))
                 currJobInfo.specInfos[spec] = currSpecInfo
 
                 currJobInfo.success = True
@@ -254,14 +254,14 @@ def populateTests(specInfo, path):
                 name = child_elem.text
                 break
         if name == "":
-            print "Error: {0}: Unknown to find test name".format(test_xml_path)
+            print("Error: {0}: Unknown to find test name".format(test_xml_path))
 
         if test_elem.attrib["Status"] == "passed":
             specInfo.passed.append(name)
         elif test_elem.attrib["Status"] == "failed":
             specInfo.failed.append(name)
         else:
-            print "Error: {0}: Unknown test status ({1})".format(test_xml_path, test_elem.attrib["Status"])
+            print("Error: {0}: Unknown test status ({1})".format(test_xml_path, test_elem.attrib["Status"]))
 
 
 def generateEmailContent(basicJobInfos, srcJobInfos, tplJobInfos):
@@ -424,9 +424,9 @@ def sendEmail(content, subject, sender, receiver, emailServer):
         finally:
             conn.close()
     except Exception as e:
-        print "Failed to send email:\n {0}".format(str(e))
+        print("Failed to send email:\n {0}".format(str(e)))
         return False
-    print "Sent."
+    print("Sent.")
 
     return True
 


### PR DESCRIPTION
# Convert Python scripts to use argparse

- This PR is a Python module update
- It does the following:
  - Replaces deprecated module optparse with argparse.
  - Fixes #1268

