### PR TITLE
Gitlab batch runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,15 +6,9 @@
 variables:
   LLNL_SERVICE_USER: atk
   GIT_SUBMODULE_STRATEGY: recursive
-  PROJECT_ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   BUILD_ROOT: ${CI_PROJECT_DIR}
   FULL_BUILD_ROOT: ${CI_BUILDS_DIR}/axom/${CI_JOB_NAME}
   SLURM_OVERLAP: 1
-
-stages:
-  - allocate
-  - build
-  - release
 
 .src_workflow:
   rules:
@@ -28,12 +22,8 @@ stages:
 # Template
 .src_build_script:
   script:
-    # Use pre-existing allocation if any
-    - export JOBID=$(if [[ "$SYS_TYPE" == "toss_4_x86_64_ib" ]]; then squeue -h --name=${PROJECT_ALLOC_NAME} --format=%A; fi)
-    - ASSIGN_ID=$(if [[ -n "${JOBID}" ]]; then echo "--jobid=${JOBID}"; fi)
-    # BUILD + TEST
     - echo -e "\e[0Ksection_start:$(date +%s):src_build_and_test\r\e[0KSource Build and Test ${CI_PROJECT_NAME}"
-    - ${ALLOC_COMMAND} ${ASSIGN_ID} python3 scripts/llnl_scripts/build_src.py -v --host-config ${HOST_CONFIG} --extra-cmake-options '-DENABLE_DOCS=OFF ${EXTRA_CMAKE_OPTIONS}' --build-type ${BUILD_TYPE:-Debug} ${EXTRA_OPTIONS}
+    - ${ALLOC_COMMAND} python3 scripts/llnl_scripts/build_src.py -v --host-config ${HOST_CONFIG} --extra-cmake-options '-DENABLE_DOCS=OFF ${EXTRA_CMAKE_OPTIONS}' --build-type ${BUILD_TYPE:-Debug} ${EXTRA_OPTIONS}
     - echo -e "\e[0Ksection_end:$(date +%s):src_build_and_test\r\e[0K"
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -6,8 +6,10 @@
 ####
 # This is the share configuration of jobs for lassen
 .on_lassen:
+  variables:
+    SCHEDULER_PARAMETERS: "-nnodes 1 -W ${ALLOC_TIME} -q pci -alloc_flags atsdisable"
   tags:
-    - shell
+    - batch
     - lassen
   rules:
     - if: '$CI_COMMIT_BRANCH =~ /_lnone/ || $ON_LASSEN == "OFF"' #run except if ...
@@ -20,16 +22,14 @@
 ####
 # Template
 .src_build_on_lassen:
-  stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 25 -q pci -alloc_flags atsdisable"
+    ALLOC_TIME: "25"
   extends: [.src_build_script, .on_lassen, .src_workflow]
   needs: []
 
 .full_build_on_lassen:
-  stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 45 -q pci -alloc_flags atsdisable"
+    ALLOC_TIME: "45"
   extends: [.full_build_script, .on_lassen, .full_workflow]
   needs: []
 

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -6,8 +6,10 @@
 ####
 # This is the shared configuration of jobs for quartz
 .on_quartz:
+  variables:
+    SCHEDULER_PARAMETERS: "--res=ci --exclusive=user --deadline=now+1hour -N1 -t ${ALLOC_TIME}"
   tags:
-    - shell
+    - batch
     - quartz
   rules:
     - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_QUARTZ == "OFF"' #run except if ...
@@ -19,41 +21,16 @@
     - module load cmake/3.19.2
 
 ####
-# In pre-build phase, allocate a node for builds
-quartz_allocate:
-  variables:
-    GIT_STRATEGY: none
-  extends: [.on_quartz, .src_workflow]
-  stage: allocate
-  script:
-    - salloc -N 1 -c 36 -t 60 --res=ci --no-shell --job-name=${PROJECT_ALLOC_NAME}
-  needs: []
-
-####
-# In post-build phase, deallocate resources
-# Note : make sure this is run even on build phase failure
-quartz_release:
-  variables:
-    GIT_STRATEGY: none
-  extends: [.on_quartz, .src_workflow]
-  stage: release
-  script:
-    - export JOBID=$(squeue -h --name=${PROJECT_ALLOC_NAME} --format=%A)
-    - if [[ -n "${JOBID}" ]]; then scancel ${JOBID}; fi
-
-####
 # Template
 .src_build_on_quartz:
-  stage: build
   variables:
-    ALLOC_COMMAND: "srun -t 60 -N 1 -p pdebug"
+    ALLOC_TIME: "30"
   extends: [.src_build_script, .on_quartz, .src_workflow]
-  needs: [quartz_allocate]
+  needs: []
 
 .full_build_on_quartz:
-  stage: build
   variables:
-    ALLOC_COMMAND: "srun -t 60 -N 1 -p pdebug"
+    ALLOC_TIME: "60"
   extends: [.full_build_script, .on_quartz, .full_workflow]
   needs: []
 

--- a/.gitlab/build_rzansel.yml
+++ b/.gitlab/build_rzansel.yml
@@ -6,10 +6,11 @@
 ####
 # This is the share configuration of jobs for rzansel
 .on_rzansel:
-  variables:
   tags:
-    - shell
+    - batch
     - rzansel
+  variables:
+    SCHEDULER_PARAMETERS: "-nnodes 1 -W ${ALLOC_TIME} -alloc_flags atsdisable"
   before_script:
     - module load cuda/11.2.0
     - module load cmake/3.21.1
@@ -17,16 +18,14 @@
 ####
 # Template
 .src_build_on_rzansel:
-  stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 25 -q pdebug"
+    ALLOC_TIME: "25"
   extends: [.src_build_script, .on_rzansel, .src_workflow]
   needs: []
 
 .full_build_on_rzansel:
-  stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 45 -q pdebug"
+    ALLOC_TIME: "45"
   extends: [.full_build_script, .on_rzansel, .full_workflow]
   needs: []
 

--- a/.gitlab/build_rzgenie.yml
+++ b/.gitlab/build_rzgenie.yml
@@ -6,26 +6,25 @@
 ####
 # This is the shared configuration of jobs for rzgenie
 .on_rzgenie:
+  variables:
+    SCHEDULER_PARAMETERS: "--deadline=now+1hour -N1 -t ${ALLOC_TIME}"
   tags:
-    - shell
+    - batch
     - rzgenie
   before_script:
     - module load cmake/3.18.0
 
-
 ####
 # Template
 .src_build_on_rzgenie:
-  stage: build
   variables:
-    ALLOC_COMMAND: "salloc -p pdebug -t 30 -N 1 -n36 srun --interactive -n1"
+    ALLOC_TIME: "30"
   extends: [.src_build_script, .on_rzgenie, .src_workflow]
   needs: []
 
 .full_build_on_rzgenie:
-  stage: build
   variables:
-    ALLOC_COMMAND: "srun -p pdebug -t 60 -N 1 -n 1"
+    ALLOC_TIME: "60"
   extends: [.full_build_script, .on_rzgenie, .full_workflow]
   needs: []
 

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -6,8 +6,10 @@
 ####
 # This is the shared configuration of jobs for tioga
 .on_tioga:
+  variables:
+    SCHEDULER_PARAMETERS: "--queue pci --exclusive --time-limit=${ALLOC_TIME}m --nodes=1"
   tags:
-    - shell
+    - batch
     - tioga
   rules:
     - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_TIOGA == "OFF"' #run except if ...
@@ -19,16 +21,14 @@
 ####
 # Template
 .src_build_on_tioga:
-  stage: build
   variables:
-    ALLOC_COMMAND: "flux run --queue pci --exclusive --time-limit=30m --nodes=1"
+    ALLOC_TIME: "30"
   extends: [.src_build_script, .on_tioga, .src_workflow]
   needs: []
 
 .full_build_on_tioga:
-  stage: build
   variables:
-    ALLOC_COMMAND: "flux run --queue pci --exclusive --time-limit=60m --nodes=1"
+    ALLOC_TIME: "60"
   extends: [.full_build_script, .on_tioga, .full_workflow]
   needs: []
 


### PR DESCRIPTION
Now that the CI queue on LC has been proven to be effective, I feel like it's time that we can reduce the complexity of our gitlab scripts. The two focuses in this PR are: removing the allocate/deallocate stages and moving us to the batch runners instead of the shell runners.