### PR TITLE
Separate templated and non-template code in DistributedClosestPointImpl

### DIFF
--- a/src/axom/quest/DistributedClosestPoint.cpp
+++ b/src/axom/quest/DistributedClosestPoint.cpp
@@ -103,7 +103,10 @@ void DistributedClosestPoint::setAllocatorID(int allocatorID)
                   "Invalid allocator id.");
   m_allocatorID = allocatorID;
 
-  if (m_impl) { m_impl->setAllocatorID(m_allocatorID); }
+  if(m_impl)
+  {
+    m_impl->setAllocatorID(m_allocatorID);
+  }
 }
 
 void DistributedClosestPoint::setMpiCommunicator(MPI_Comm mpiComm, bool duplicate)
@@ -159,7 +162,7 @@ void DistributedClosestPoint::setOutput(const std::string& field, bool on)
 void DistributedClosestPoint::setObjectMesh(const conduit::Node& meshNode,
                                             const std::string& topologyName)
 {
-  if (m_impl)
+  if(m_impl)
   {
     SLIC_ERROR("Object mesh already created.");
   }
@@ -240,30 +243,30 @@ void DistributedClosestPoint::allocateQueryInstance()
   case RuntimePolicy::seq:
     m_impl = m_dimension == 2
       ? std::unique_ptr<internal::DistributedClosestPointImpl>(
-        new internal::DistributedClosestPointExec<2, axom::SEQ_EXEC>(
-          m_runtimePolicy,
-          m_allocatorID,
-          m_isVerbose))
+          new internal::DistributedClosestPointExec<2, axom::SEQ_EXEC>(
+            m_runtimePolicy,
+            m_allocatorID,
+            m_isVerbose))
       : std::unique_ptr<internal::DistributedClosestPointImpl>(
-        new internal::DistributedClosestPointExec<3, axom::SEQ_EXEC>(
-          m_runtimePolicy,
-          m_allocatorID,
-          m_isVerbose));
+          new internal::DistributedClosestPointExec<3, axom::SEQ_EXEC>(
+            m_runtimePolicy,
+            m_allocatorID,
+            m_isVerbose));
     break;
 
 #ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
   case RuntimePolicy::omp:
     m_impl = m_dimension == 2
       ? std::unique_ptr<internal::DistributedClosestPointImpl>(
-        new internal::DistributedClosestPointExec<2, axom::OMP_EXEC>(
-          m_runtimePolicy,
-          m_allocatorID,
-          m_isVerbose))
+          new internal::DistributedClosestPointExec<2, axom::OMP_EXEC>(
+            m_runtimePolicy,
+            m_allocatorID,
+            m_isVerbose))
       : std::unique_ptr<internal::DistributedClosestPointImpl>(
-        new internal::DistributedClosestPointExec<3, axom::OMP_EXEC>(
-          m_runtimePolicy,
-          m_allocatorID,
-          m_isVerbose));
+          new internal::DistributedClosestPointExec<3, axom::OMP_EXEC>(
+            m_runtimePolicy,
+            m_allocatorID,
+            m_isVerbose));
     break;
 #endif
 
@@ -271,15 +274,15 @@ void DistributedClosestPoint::allocateQueryInstance()
   case RuntimePolicy::cuda:
     m_impl = m_dimension == 2
       ? std::unique_ptr<internal::DistributedClosestPointImpl>(
-        new internal::DistributedClosestPointExec<2, axom::CUDA_EXEC<256>>(
-          m_runtimePolicy,
-          m_allocatorID,
-          m_isVerbose))
+          new internal::DistributedClosestPointExec<2, axom::CUDA_EXEC<256>>(
+            m_runtimePolicy,
+            m_allocatorID,
+            m_isVerbose))
       : std::unique_ptr<internal::DistributedClosestPointImpl>(
-        new internal::DistributedClosestPointExec<3, axom::CUDA_EXEC<256>>(
-          m_runtimePolicy,
-          m_allocatorID,
-          m_isVerbose));
+          new internal::DistributedClosestPointExec<3, axom::CUDA_EXEC<256>>(
+            m_runtimePolicy,
+            m_allocatorID,
+            m_isVerbose));
     break;
 #endif
 
@@ -287,15 +290,15 @@ void DistributedClosestPoint::allocateQueryInstance()
   case RuntimePolicy::hip:
     m_impl = m_dimension == 2
       ? std::unique_ptr<internal::DistributedClosestPointImpl>(
-        new internal::DistributedClosestPointExec<2, axom::HIP_EXEC<256>>(
-          m_runtimePolicy,
-          m_allocatorID,
-          m_isVerbose))
+          new internal::DistributedClosestPointExec<2, axom::HIP_EXEC<256>>(
+            m_runtimePolicy,
+            m_allocatorID,
+            m_isVerbose))
       : std::unique_ptr<internal::DistributedClosestPointImpl>(
-        new internal::DistributedClosestPointExec<3, axom::HIP_EXEC<256>>(
-          m_runtimePolicy,
-          m_allocatorID,
-          m_isVerbose));
+          new internal::DistributedClosestPointExec<3, axom::HIP_EXEC<256>>(
+            m_runtimePolicy,
+            m_allocatorID,
+            m_isVerbose));
     break;
 #endif
 

--- a/src/axom/quest/DistributedClosestPoint.cpp
+++ b/src/axom/quest/DistributedClosestPoint.cpp
@@ -103,14 +103,7 @@ void DistributedClosestPoint::setAllocatorID(int allocatorID)
                   "Invalid allocator id.");
   m_allocatorID = allocatorID;
 
-  if(m_dcp_2 != nullptr)
-  {
-    m_dcp_2->setAllocatorID(m_allocatorID);
-  }
-  if(m_dcp_3 != nullptr)
-  {
-    m_dcp_3->setAllocatorID(m_allocatorID);
-  }
+  if (m_impl) { m_impl->setAllocatorID(m_allocatorID); }
 }
 
 void DistributedClosestPoint::setMpiCommunicator(MPI_Comm mpiComm, bool duplicate)
@@ -166,7 +159,10 @@ void DistributedClosestPoint::setOutput(const std::string& field, bool on)
 void DistributedClosestPoint::setObjectMesh(const conduit::Node& meshNode,
                                             const std::string& topologyName)
 {
-  SLIC_ASSERT(this->isValidBlueprint(meshNode));
+  if (m_impl)
+  {
+    SLIC_ERROR("Object mesh already created.");
+  }
 
   const bool isMultidomain = conduit::blueprint::mesh::is_multi_domain(meshNode);
 
@@ -205,99 +201,110 @@ void DistributedClosestPoint::setObjectMesh(const conduit::Node& meshNode,
 
   allocateQueryInstance();
 
-  switch(m_dimension)
-  {
-  case 2:
-    m_dcp_2->importObjectPoints(mdMeshNode, topologyName);
-    break;
-  case 3:
-    m_dcp_3->importObjectPoints(mdMeshNode, topologyName);
-    break;
-  }
+  m_impl->importObjectPoints(mdMeshNode, topologyName);
 
   return;
 }
 
 bool DistributedClosestPoint::generateBVHTree()
 {
-  SLIC_ASSERT_MSG(m_objectMeshCreated,
+  SLIC_ASSERT_MSG(m_impl,
                   "Must call 'setObjectMesh' before calling generateBVHTree");
 
-  bool success = false;
-
-  // dispatch to implementation class over dimension
-  switch(m_dimension)
-  {
-  case 2:
-    success = m_dcp_2->generateBVHTree();
-    break;
-  case 3:
-    success = m_dcp_3->generateBVHTree();
-    break;
-  }
-
+  bool success = m_impl->generateBVHTree();
   return success;
 }
 
 void DistributedClosestPoint::computeClosestPoints(conduit::Node& query_node,
                                                    const std::string& topology)
 {
-  SLIC_ASSERT_MSG(m_objectMeshCreated,
+  SLIC_ASSERT_MSG(m_impl,
                   "Must call 'setObjectMesh' before calling generateBVHTree");
 
   SLIC_ASSERT(this->isValidBlueprint(query_node));
 
-  // dispatch to implementation class over dimension
-  switch(m_dimension)
-  {
-  case 2:
-    m_dcp_2->setSquaredDistanceThreshold(m_sqDistanceThreshold);
-    m_dcp_2->setMpiCommunicator(m_mpiComm);
-    m_dcp_2->setOutputSwitches(m_outputRank,
-                               m_outputIndex,
-                               m_outputDistance,
-                               m_outputCoords,
-                               m_outputDomainIndex);
-    m_dcp_2->computeClosestPoints(query_node, topology);
-    break;
-  case 3:
-    m_dcp_3->setSquaredDistanceThreshold(m_sqDistanceThreshold);
-    m_dcp_3->setMpiCommunicator(m_mpiComm);
-    m_dcp_3->setOutputSwitches(m_outputRank,
-                               m_outputIndex,
-                               m_outputDistance,
-                               m_outputCoords,
-                               m_outputDomainIndex);
-    m_dcp_3->computeClosestPoints(query_node, topology);
-    break;
-  }
+  m_impl->setSquaredDistanceThreshold(m_sqDistanceThreshold);
+  m_impl->setMpiCommunicator(m_mpiComm);
+  m_impl->setOutputSwitches(m_outputRank,
+                            m_outputIndex,
+                            m_outputDistance,
+                            m_outputCoords,
+                            m_outputDomainIndex);
+  m_impl->computeClosestPoints(query_node, topology);
 }
 
 void DistributedClosestPoint::allocateQueryInstance()
 {
-  SLIC_ASSERT_MSG(m_objectMeshCreated == false, "Object mesh already created");
-
-  switch(m_dimension)
+  switch(m_runtimePolicy)
   {
-  case 2:
-    m_dcp_2 =
-      std::make_unique<internal::DistributedClosestPointImpl<2>>(m_runtimePolicy,
-                                                                 m_allocatorID,
-                                                                 m_isVerbose);
-    m_objectMeshCreated = true;
+  case RuntimePolicy::seq:
+    m_impl = m_dimension == 2
+      ? std::unique_ptr<internal::DistributedClosestPointImpl>(
+        new internal::DistributedClosestPointExec<2, axom::SEQ_EXEC>(
+          m_runtimePolicy,
+          m_allocatorID,
+          m_isVerbose))
+      : std::unique_ptr<internal::DistributedClosestPointImpl>(
+        new internal::DistributedClosestPointExec<3, axom::SEQ_EXEC>(
+          m_runtimePolicy,
+          m_allocatorID,
+          m_isVerbose));
     break;
-  case 3:
-    m_dcp_3 =
-      std::make_unique<internal::DistributedClosestPointImpl<3>>(m_runtimePolicy,
-                                                                 m_allocatorID,
-                                                                 m_isVerbose);
-    m_objectMeshCreated = true;
-    break;
-  }
 
-  SLIC_ASSERT_MSG(
-    m_objectMeshCreated,
-    "Called allocateQueryInstance, but did not create an instance");
+#ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
+  case RuntimePolicy::omp:
+    m_impl = m_dimension == 2
+      ? std::unique_ptr<internal::DistributedClosestPointImpl>(
+        new internal::DistributedClosestPointExec<2, axom::OMP_EXEC>(
+          m_runtimePolicy,
+          m_allocatorID,
+          m_isVerbose))
+      : std::unique_ptr<internal::DistributedClosestPointImpl>(
+        new internal::DistributedClosestPointExec<3, axom::OMP_EXEC>(
+          m_runtimePolicy,
+          m_allocatorID,
+          m_isVerbose));
+    break;
+#endif
+
+#ifdef AXOM_RUNTIME_POLICY_USE_CUDA
+  case RuntimePolicy::cuda:
+    m_impl = m_dimension == 2
+      ? std::unique_ptr<internal::DistributedClosestPointImpl>(
+        new internal::DistributedClosestPointExec<2, axom::CUDA_EXEC<256>>(
+          m_runtimePolicy,
+          m_allocatorID,
+          m_isVerbose))
+      : std::unique_ptr<internal::DistributedClosestPointImpl>(
+        new internal::DistributedClosestPointExec<3, axom::CUDA_EXEC<256>>(
+          m_runtimePolicy,
+          m_allocatorID,
+          m_isVerbose));
+    break;
+#endif
+
+#ifdef AXOM_RUNTIME_POLICY_USE_HIP
+  case RuntimePolicy::hip:
+    m_impl = m_dimension == 2
+      ? std::unique_ptr<internal::DistributedClosestPointImpl>(
+        new internal::DistributedClosestPointExec<2, axom::HIP_EXEC<256>>(
+          m_runtimePolicy,
+          m_allocatorID,
+          m_isVerbose))
+      : std::unique_ptr<internal::DistributedClosestPointImpl>(
+        new internal::DistributedClosestPointExec<3, axom::HIP_EXEC<256>>(
+          m_runtimePolicy,
+          m_allocatorID,
+          m_isVerbose));
+    break;
+#endif
+
+  default:
+    SLIC_ERROR(axom::fmt::format(
+      "DistriburedClosestPoint: axom was not built for runtime policy {}."
+      "  Please select another policy.",
+      axom::runtime_policy::s_policyToName.at(m_runtimePolicy)));
+  }
 }
 
 bool DistributedClosestPoint::isValidBlueprint(const conduit::Node& mesh_node) const

--- a/src/axom/quest/DistributedClosestPoint.cpp
+++ b/src/axom/quest/DistributedClosestPoint.cpp
@@ -241,56 +241,28 @@ void DistributedClosestPoint::allocateQueryInstance()
   switch(m_runtimePolicy)
   {
   case RuntimePolicy::seq:
-    m_impl = m_dimension == 2
-      ? std::unique_ptr<internal::DistributedClosestPointImpl>(
-          new internal::DistributedClosestPointExec<2, axom::SEQ_EXEC>(
-            m_allocatorID,
-            m_isVerbose))
-      : std::unique_ptr<internal::DistributedClosestPointImpl>(
-          new internal::DistributedClosestPointExec<3, axom::SEQ_EXEC>(
-            m_allocatorID,
-            m_isVerbose));
+    m_dimension == 2 ? allocateQueryInstance<2, axom::SEQ_EXEC>()
+                     : allocateQueryInstance<3, axom::SEQ_EXEC>();
     break;
 
 #ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
   case RuntimePolicy::omp:
-    m_impl = m_dimension == 2
-      ? std::unique_ptr<internal::DistributedClosestPointImpl>(
-          new internal::DistributedClosestPointExec<2, axom::OMP_EXEC>(
-            m_allocatorID,
-            m_isVerbose))
-      : std::unique_ptr<internal::DistributedClosestPointImpl>(
-          new internal::DistributedClosestPointExec<3, axom::OMP_EXEC>(
-            m_allocatorID,
-            m_isVerbose));
+    m_dimension == 2 ? allocateQueryInstance<2, axom::OMP_EXEC>()
+                     : allocateQueryInstance<3, axom::OMP_EXEC>();
     break;
 #endif
 
 #ifdef AXOM_RUNTIME_POLICY_USE_CUDA
   case RuntimePolicy::cuda:
-    m_impl = m_dimension == 2
-      ? std::unique_ptr<internal::DistributedClosestPointImpl>(
-          new internal::DistributedClosestPointExec<2, axom::CUDA_EXEC<256>>(
-            m_allocatorID,
-            m_isVerbose))
-      : std::unique_ptr<internal::DistributedClosestPointImpl>(
-          new internal::DistributedClosestPointExec<3, axom::CUDA_EXEC<256>>(
-            m_allocatorID,
-            m_isVerbose));
+    m_dimension == 2 ? allocateQueryInstance<2, axom::CUDA_EXEC<256>>()
+                     : allocateQueryInstance<3, axom::CUDA_EXEC<256>>();
     break;
 #endif
 
 #ifdef AXOM_RUNTIME_POLICY_USE_HIP
   case RuntimePolicy::hip:
-    m_impl = m_dimension == 2
-      ? std::unique_ptr<internal::DistributedClosestPointImpl>(
-          new internal::DistributedClosestPointExec<2, axom::HIP_EXEC<256>>(
-            m_allocatorID,
-            m_isVerbose))
-      : std::unique_ptr<internal::DistributedClosestPointImpl>(
-          new internal::DistributedClosestPointExec<3, axom::HIP_EXEC<256>>(
-            m_allocatorID,
-            m_isVerbose));
+    m_dimension == 2 ? allocateQueryInstance<2, axom::HIP_EXEC<256>>()
+                     : allocateQueryInstance<3, axom::HIP_EXEC<256>>();
     break;
 #endif
 
@@ -300,6 +272,15 @@ void DistributedClosestPoint::allocateQueryInstance()
       "  Please select another policy.",
       axom::runtime_policy::s_policyToName.at(m_runtimePolicy)));
   }
+}
+
+template <int DIM, typename ExecSpace>
+void DistributedClosestPoint::allocateQueryInstance()
+{
+  m_impl =
+    std::make_unique<internal::DistributedClosestPointExec<DIM, ExecSpace>>(
+      m_allocatorID,
+      m_isVerbose);
 }
 
 bool DistributedClosestPoint::isValidBlueprint(const conduit::Node& mesh_node) const

--- a/src/axom/quest/DistributedClosestPoint.cpp
+++ b/src/axom/quest/DistributedClosestPoint.cpp
@@ -244,12 +244,10 @@ void DistributedClosestPoint::allocateQueryInstance()
     m_impl = m_dimension == 2
       ? std::unique_ptr<internal::DistributedClosestPointImpl>(
           new internal::DistributedClosestPointExec<2, axom::SEQ_EXEC>(
-            m_runtimePolicy,
             m_allocatorID,
             m_isVerbose))
       : std::unique_ptr<internal::DistributedClosestPointImpl>(
           new internal::DistributedClosestPointExec<3, axom::SEQ_EXEC>(
-            m_runtimePolicy,
             m_allocatorID,
             m_isVerbose));
     break;
@@ -259,12 +257,10 @@ void DistributedClosestPoint::allocateQueryInstance()
     m_impl = m_dimension == 2
       ? std::unique_ptr<internal::DistributedClosestPointImpl>(
           new internal::DistributedClosestPointExec<2, axom::OMP_EXEC>(
-            m_runtimePolicy,
             m_allocatorID,
             m_isVerbose))
       : std::unique_ptr<internal::DistributedClosestPointImpl>(
           new internal::DistributedClosestPointExec<3, axom::OMP_EXEC>(
-            m_runtimePolicy,
             m_allocatorID,
             m_isVerbose));
     break;
@@ -275,12 +271,10 @@ void DistributedClosestPoint::allocateQueryInstance()
     m_impl = m_dimension == 2
       ? std::unique_ptr<internal::DistributedClosestPointImpl>(
           new internal::DistributedClosestPointExec<2, axom::CUDA_EXEC<256>>(
-            m_runtimePolicy,
             m_allocatorID,
             m_isVerbose))
       : std::unique_ptr<internal::DistributedClosestPointImpl>(
           new internal::DistributedClosestPointExec<3, axom::CUDA_EXEC<256>>(
-            m_runtimePolicy,
             m_allocatorID,
             m_isVerbose));
     break;
@@ -291,12 +285,10 @@ void DistributedClosestPoint::allocateQueryInstance()
     m_impl = m_dimension == 2
       ? std::unique_ptr<internal::DistributedClosestPointImpl>(
           new internal::DistributedClosestPointExec<2, axom::HIP_EXEC<256>>(
-            m_runtimePolicy,
             m_allocatorID,
             m_isVerbose))
       : std::unique_ptr<internal::DistributedClosestPointImpl>(
           new internal::DistributedClosestPointExec<3, axom::HIP_EXEC<256>>(
-            m_runtimePolicy,
             m_allocatorID,
             m_isVerbose));
     break;

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -175,13 +175,14 @@ public:
 
 private:
   /*!
-    @brief Allocate the templated the implementation object.
+    @brief Allocate the DistributedClosestPointImpl object, which actually does the work.
 
-    \post The problem dimension and runtime policy are a part of the
-    implementation object, so changes to them are disallowed.
+    \post The implementation object is for a specific dimension and runtime policy,
+    so changes to those are disallowed.
   */
   void allocateQueryInstance();
 
+  //!@brief Allocate the DistributedClosestPointImpl for compile-time dimension and execution space.
   template <int DIM, typename ExecSpace>
   void allocateQueryInstance();
 

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -182,6 +182,9 @@ private:
   */
   void allocateQueryInstance();
 
+  template <int DIM, typename ExecSpace>
+  void allocateQueryInstance();
+
   /// Check validity of blueprint group
   bool isValidBlueprint(const conduit::Node& mesh_node) const;
 

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -67,8 +67,10 @@ public:
 
     See axom::runtime_policy.
   */
-  void setRuntimePolicy(RuntimePolicy policy) {
-    SLIC_ASSERT_MSG(!m_impl, "Runtime policy may not change after setObjectMesh()");
+  void setRuntimePolicy(RuntimePolicy policy)
+  {
+    SLIC_ASSERT_MSG(!m_impl,
+                    "Runtime policy may not change after setObjectMesh()");
     m_runtimePolicy = policy;
   }
 

--- a/src/axom/quest/detail/DistributedClosestPointImpl.hpp
+++ b/src/axom/quest/detail/DistributedClosestPointImpl.hpp
@@ -248,12 +248,8 @@ inline int isend_using_schema(conduit::Node& node,
 class DistributedClosestPointImpl
 {
 public:
-  using RuntimePolicy = axom::runtime_policy::Policy;
-  DistributedClosestPointImpl(RuntimePolicy runtimePolicy,
-                              int allocatorID,
-                              bool isVerbose)
-    : m_runtimePolicy(runtimePolicy)
-    , m_allocatorID(allocatorID)
+  DistributedClosestPointImpl(int allocatorID, bool isVerbose)
+    : m_allocatorID(allocatorID)
     , m_isVerbose(isVerbose)
     , m_mpiComm(MPI_COMM_NULL)
     , m_rank(-1)
@@ -547,7 +543,6 @@ public:
                                     const std::string& topologyName) const = 0;
 
 protected:
-  RuntimePolicy m_runtimePolicy;
   int m_allocatorID;
   bool m_isVerbose;
 
@@ -603,17 +598,13 @@ public:
   /*!
     @brief Constructor
 
-    @param [i] runtimePolicy Indicates where local computations
-      are done.  See axom::runtime_policy.
     @param [i] allocatorID Allocator ID, which must be compatible with
-      @c runtimePolicy.  See axom::allocate and axom::reallocate.
+      @c ExecSpace.  See axom::allocate and axom::reallocate.
       Also see setAllocatorID().
     @param [i[ isVerbose
   */
-  DistributedClosestPointExec(RuntimePolicy runtimePolicy,
-                              int allocatorID,
-                              bool isVerbose)
-    : DistributedClosestPointImpl(runtimePolicy, allocatorID, isVerbose)
+  DistributedClosestPointExec(int allocatorID, bool isVerbose)
+    : DistributedClosestPointImpl(allocatorID, isVerbose)
     , m_objectPtCoords(0, 0, allocatorID)
     , m_objectPtDomainIds(0, 0, allocatorID)
   {

--- a/src/axom/quest/detail/DistributedClosestPointImpl.hpp
+++ b/src/axom/quest/detail/DistributedClosestPointImpl.hpp
@@ -235,7 +235,6 @@ inline int isend_using_schema(conduit::Node& node,
 }  // namespace mpi
 }  // namespace relay
 
-
 /*!
   @brief Non-templated base class for the distributed closest point
   implementation.
@@ -253,16 +252,16 @@ public:
   DistributedClosestPointImpl(RuntimePolicy runtimePolicy,
                               int allocatorID,
                               bool isVerbose)
-  : m_runtimePolicy(runtimePolicy)
-  , m_allocatorID(allocatorID)
-  , m_isVerbose(isVerbose)
-  , m_mpiComm(MPI_COMM_NULL)
-  , m_rank(-1)
-  , m_nranks(-1)
-  , m_sqDistanceThreshold(std::numeric_limits<double>::max())
-  {}
+    : m_runtimePolicy(runtimePolicy)
+    , m_allocatorID(allocatorID)
+    , m_isVerbose(isVerbose)
+    , m_mpiComm(MPI_COMM_NULL)
+    , m_rank(-1)
+    , m_nranks(-1)
+    , m_sqDistanceThreshold(std::numeric_limits<double>::max())
+  { }
 
-  virtual ~DistributedClosestPointImpl() {}
+  virtual ~DistributedClosestPointImpl() { }
 
   virtual int getDimension() const = 0;
 
@@ -326,7 +325,6 @@ public:
     m_outputCoords = outputCoords;
     m_outputDomainIndex = outputDomainIndex;
   }
-
 
   /*!
    * Copy parts of query mesh partition to a conduit::Node for
@@ -922,7 +920,6 @@ public:
   }
 
 private:
-
   /**
     Determine the next rank (in ring order) with an object partition
     close to the query points in xferNode.  The intent is to send
@@ -949,7 +946,6 @@ private:
     }
     return -1;
   }
-
 
   // Note: following should be private, but nvcc complains about lambdas in private scope
 public:

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -292,7 +292,7 @@ if(AXOM_ENABLE_MPI AND AXOM_ENABLE_SIDRE AND HDF5_FOUND)
                                 --no-random-spacing
                                 --check-results
                                 --policy ${_pol}
-                                --object-file dcp_object_mesh_2d_${_pol}_${_mesh}
+                                --object-file dcp_object_mesh_${_ndim}d_${_pol}_${_mesh}
                                 --distance-file dcp_closest_point_2d_${_pol}_${_mesh}
                     NUM_MPI_TASKS ${_nranks})
                 if(${_pol} STREQUAL "omp")

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -767,7 +767,7 @@ public:
   void saveMesh(const std::string& filename = "object_mesh")
   {
     SLIC_INFO(
-      banner(axom::fmt::format("Saving particle mesh '{}' to disk", filename)));
+      banner(axom::fmt::format("Saving object mesh '{}' to disk", filename)));
 
     m_objectMesh.saveMesh(filename);
   }
@@ -1489,13 +1489,13 @@ int main(int argc, char** argv)
 
     SLIC_INFO(axom::fmt::format(
       "Initialization with policy {} took {{avg:{}, min:{}, max:{}}} seconds",
-      params.policy,
+      axom::runtime_policy::s_policyToName.at(params.policy),
       sumInit / num_ranks,
       minInit,
       maxInit));
     SLIC_INFO(axom::fmt::format(
       "Query with policy {} took {{avg:{}, min:{}, max:{}}} seconds",
-      params.policy,
+      axom::runtime_policy::s_policyToName.at(params.policy),
       sumQuery / num_ranks,
       minQuery,
       maxQuery));


### PR DESCRIPTION
# Separate templated and non-template code in DistributedClostetPointImpl

- This PR is a refactoring
- It does the following:
  - Break up `DistributedClosestPointImpl` into a non-templated base class and the derived class `DistributedClosestPointExec` templated on `DIM` and `ExecSpace`.
  - Makes minor fixes to the CMake test set-up.

The refactoring simplifies the code and follows the separation of template and non-template code used in the marching cubes implementation.  It helps the optimization I'm implementing in `DistributedClosestPointImpl`.

## Motivation

Before this re-factoring, `DistributedClosestPointImpl` is templated on `DIM` and has BVH objects that are templated on DIM and `ExecSpace`.  We had separate pointers for all possible dimensions and execution spaces.  There was a lot of trivial-yet-clunky code to pick the correct pointers.

After the refactoring, `DistributedClosestPointImpl` contains no templated code.  Its template code has been pushed down to the new class `DistributedClosestPointExec`, which is templated on dimension and execution space.  The templated class has just one BVH, which is instantiated for the same dimension and execution space.  We don't need separate pointers for all the cases--just a pointer to the base class `DistributedClosesePointImpl`.  We only look at the dimension and execution space when allocating the `DistributedClosestPointExec` object.