### PR TITLE
2D Polygon Intersection

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,6 +20,11 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ## [Unreleased] - Release date yyyy-mm-dd
 
 ### Added
+- Primal: Adds a `clip()` operator overload for clipping a 2D polygon against
+  another 2D polygon.
+- Primal: Adds `Polygon::reverseOrientation()` to reverse orientation of
+  a polygon in-place.
+- Adds `StaticArray`, a wrapper for `StackArray` with a size member variable.
 - Multidimenional `core::Array` supports column-major and arbitrary stride ordering,
   in addition to the default row-major ordering.
 - Adds new `PolygonArray` and `MAX_VERTS` template parameters to `primal::Polygon` for dynamic

--- a/src/axom/core/CMakeLists.txt
+++ b/src/axom/core/CMakeLists.txt
@@ -63,6 +63,7 @@ set(core_headers
     Path.hpp
     RangeAdapter.hpp
     StackArray.hpp
+    StaticArray.hpp
     Types.hpp
     memory_management.hpp
 

--- a/src/axom/core/StaticArray.hpp
+++ b/src/axom/core/StaticArray.hpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_STATICARRAY_HPP_
+#define AXOM_STATICARRAY_HPP_
+
+#include "axom/config.hpp"           // for compile-time defines
+#include "axom/core/Macros.hpp"      // for axom macros
+#include "axom/core/StackArray.hpp"  // for StackArray
+#include "axom/core/Types.hpp"       // for axom types
+
+namespace axom
+{
+/*!
+ * \accelerated
+ * \class StaticArray
+ *
+ * \brief Provides a wrapper for a StackArray with an additional size member.
+ *
+ * \tparam T the type of the values to hold.
+ * \tparam N the number of values in the array.
+ */
+template <typename T, int N>
+struct StaticArray : public StackArray<T, N>
+{
+  AXOM_HOST_DEVICE int size() const { return m_size; }
+  AXOM_HOST_DEVICE void push_back(const T& obj)
+  {
+    assert(m_size < N);
+    if(m_size < N)
+    {
+      StackArray<T, N>::m_data[m_size++] = obj;
+    }
+  }
+
+  AXOM_HOST_DEVICE void clear()
+  {
+    for(T& datum : StackArray<T, N>::m_data)
+    {
+      datum = T();
+    }
+    m_size = 0;
+  }
+
+private:
+  int m_size {0};
+};
+
+} /* namespace axom */
+
+#endif /* AXOM_STATICARRAY_HPP_ */

--- a/src/axom/core/StaticArray.hpp
+++ b/src/axom/core/StaticArray.hpp
@@ -20,6 +20,9 @@ namespace axom
  *
  * \tparam T the type of the values to hold.
  * \tparam N the number of values in the array.
+ *
+ * \note Type \a T must be default-constructible on device for device
+ *       execution.
  */
 template <typename T, int N>
 struct StaticArray : public StackArray<T, N>

--- a/src/axom/core/StaticArray.hpp
+++ b/src/axom/core/StaticArray.hpp
@@ -9,7 +9,6 @@
 #include "axom/config.hpp"           // for compile-time defines
 #include "axom/core/Macros.hpp"      // for axom macros
 #include "axom/core/StackArray.hpp"  // for StackArray
-#include "axom/core/Types.hpp"       // for axom types
 
 namespace axom
 {
@@ -25,7 +24,24 @@ namespace axom
 template <typename T, int N>
 struct StaticArray : public StackArray<T, N>
 {
+  /*!
+   * \brief Returns the size of the static array
+   *
+   * \return The size of the static array
+   */
   AXOM_HOST_DEVICE int size() const { return m_size; }
+
+  /*!
+   * \brief Pushes an object to the back of the static array
+   *
+   * \param [in] obj the object to be added to the back.
+   *
+   * \note The number of push_backs must not exceed N,
+   *       the max number of values in the array.
+   *
+   * \note If the static array is full, push_back
+   *       will not modify the static array.
+   */
   AXOM_HOST_DEVICE void push_back(const T& obj)
   {
     assert(m_size < N);
@@ -35,6 +51,9 @@ struct StaticArray : public StackArray<T, N>
     }
   }
 
+  /*!
+   * \brief Clears the data from the static array
+   */
   AXOM_HOST_DEVICE void clear()
   {
     for(T& datum : StackArray<T, N>::m_data)

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(core_serial_tests
     core_memory_management.hpp
     core_Path.hpp
     core_stack_array.hpp
+    core_static_array.hpp
 
     numerics_determinants.hpp
     numerics_eigen_solve.hpp

--- a/src/axom/core/tests/core_serial_main.cpp
+++ b/src/axom/core/tests/core_serial_main.cpp
@@ -20,6 +20,7 @@
 #include "core_memory_management.hpp"
 #include "core_Path.hpp"
 #include "core_stack_array.hpp"
+#include "core_static_array.hpp"
 
 #ifndef AXOM_USE_MPI
   #include "core_types.hpp"

--- a/src/axom/core/tests/core_static_array.hpp
+++ b/src/axom/core/tests/core_static_array.hpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/config.hpp"  // for compile time definitions
+
+#include "axom/core/StaticArray.hpp"
+
+// for gtest macros
+#include "gtest/gtest.h"
+
+//------------------------------------------------------------------------------
+//  HELPER METHOD
+//------------------------------------------------------------------------------
+namespace
+{
+template <typename ExecSpace>
+void check_static_array_policy()
+{
+  const int MAX_SIZE = 10;
+  using StaticArrayType = axom::StaticArray<int, MAX_SIZE>;
+
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int kernel_allocator = axom::execution_space<ExecSpace>::allocatorID();
+
+  axom::Array<StaticArrayType> s_arrays_device(MAX_SIZE,
+                                               MAX_SIZE,
+                                               kernel_allocator);
+  auto s_arrays_view = s_arrays_device.view();
+
+  axom::Array<StaticArrayType> sizes_device(1, 1, kernel_allocator);
+  auto sizes_view = sizes_device.view();
+
+  axom::for_all<ExecSpace>(
+    MAX_SIZE,
+    AXOM_LAMBDA(int i) {
+      // Sanity check - function is callable on device
+      s_arrays_view[i].clear();
+
+      for(int idx = 0; idx <= i; idx++)
+      {
+        s_arrays_view[i].push_back(idx);
+      }
+
+      sizes_view[0][i] = s_arrays_view[i].size();
+    });
+
+  // Copy static arrays and their sizes back to host
+  axom::Array<StaticArrayType> s_arrays_host =
+    axom::Array<StaticArrayType>(s_arrays_device, host_allocator);
+  axom::Array<StaticArrayType> sizes_host =
+    axom::Array<StaticArrayType>(sizes_device, host_allocator);
+
+  // Verify values
+  for(int i = 0; i < MAX_SIZE; i++)
+  {
+    EXPECT_EQ(sizes_host[0][i], i + 1);
+    for(int j = 0; j <= i; j++)
+    {
+      EXPECT_EQ(s_arrays_host[i][j], j);
+    }
+  }
+}
+
+} /* end anonymous namespace */
+
+//------------------------------------------------------------------------------
+//  UNIT TESTS
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+TEST(core_static_array, check_static_array_seq)
+{
+  check_static_array_policy<axom::SEQ_EXEC>();
+}
+
+#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
+TEST(core_static_array, check_static_array_omp)
+{
+  check_static_array_policy<axom::OMP_EXEC>();
+}
+#endif
+
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+TEST(core_static_array, check_static_array_cuda)
+{
+  check_static_array_policy<axom::CUDA_EXEC<256>>();
+  check_static_array_policy<axom::CUDA_EXEC<256, axom::ASYNC>>();
+}
+#endif
+
+#if defined(AXOM_USE_HIP) && defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+TEST(core_static_array, check_static_array_hip)
+{
+  check_static_array_policy<axom::HIP_EXEC<256>>();
+  check_static_array_policy<axom::HIP_EXEC<256, axom::ASYNC>>();
+}
+#endif

--- a/src/axom/primal/geometry/Point.hpp
+++ b/src/axom/primal/geometry/Point.hpp
@@ -174,6 +174,7 @@ public:
   /*!
    * \brief Inequality operator for points
    */
+  AXOM_HOST_DEVICE
   friend inline bool operator!=(const Point& lhs, const Point& rhs)
   {
     return !(lhs == rhs);

--- a/src/axom/primal/geometry/Polygon.hpp
+++ b/src/axom/primal/geometry/Polygon.hpp
@@ -123,6 +123,164 @@ public:
   AXOM_HOST_DEVICE Polygon()
   { }
 
+  /// Default destructor for an empty polygon (dynamic array specialization).
+  /// Specializations are necessary to remove __host__ __device__ warning for
+  /// axom::Array usage with the dynamic array type.
+  // template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
+  //           std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Dynamic, int> = 0>
+  // ~Polygon()
+  // { }
+
+  /// Default destructor for an empty polygon (static array specialization)
+
+  /***************************************************************************/
+
+  //  Throws warnings because not host device decorated (works)
+  // (Nothing)
+
+  // Same as doing (Nothing), because C++ generating for us (works)
+  // ~Polygon() = default;
+
+  // Decoration is ignored (works)
+  // AXOM_HOST_DEVICE
+  // ~Polygon() = default;
+
+  // This doesn't work on device, runtime failure (because not compiled for it)
+  // ~Polygon()
+  // { m_vertices.clear(); }
+
+  // This throws a bunch of warnings for axom::Array, but works
+  // AXOM_HOST_DEVICE
+  // ~Polygon()
+  // { m_vertices.clear(); }
+
+  // This the above but silences the axom::Array warnings, works.
+  // This does what we want (no warnings + works), but is ugly.
+  // Either it's this, or you live with the default constructed warnings (only 2)
+  AXOM_SUPPRESS_HD_WARN
+  AXOM_HOST_DEVICE
+  ~Polygon() { m_vertices.clear(); }
+
+  // This not allowed, you cannot do this SFINAE stuff, doesn't compile
+  // template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
+  //           std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Dynamic, int> = 0>
+  // ~Polygon()
+  // { }
+
+  // /// Default constructor for an empty polygon (static array specialization)
+  // template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
+  //           std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Static, int> = 0>
+  // AXOM_HOST_DEVICE ~Polygon()
+  // { }
+
+  /***************************************************************************/
+  // Copy assignment operator
+
+  // (Nothing)
+
+  // Same as doing (Nothing), because C++ generating for us (works)
+  // Polygon& operator=(const Polygon& other) = default;
+
+  // This doesn't work on device, runtime failure (because not compiled for it)
+  // Polygon& operator=(const Polygon& other)
+  // {
+  //   if (this == &other)
+  //   {
+  //     return *this;
+  //   }
+
+  //   m_vertices = other.m_vertices;
+  //   return *this;
+  // }
+
+  // This throws a bunch of warnings for axom::Array, but works
+  // AXOM_HOST_DEVICE
+  // Polygon& operator=(const Polygon& other)
+  // {
+  //   if (this == &other)
+  //   {
+  //     return *this;
+  //   }
+
+  //   m_vertices = other.m_vertices;
+  //   return *this;
+  // }
+
+  // This the above but silences the axom::Array warnings, works.
+  // This does what we want (no warnings + works), but is ugly.
+  // Either it's this, or you live with the default constructed warnings (only 2)
+  AXOM_SUPPRESS_HD_WARN
+  AXOM_HOST_DEVICE
+  Polygon& operator=(const Polygon& other)
+  {
+    if(this == &other)
+    {
+      return *this;
+    }
+
+    m_vertices = other.m_vertices;
+    return *this;
+  }
+
+  // Huh, still get the warning...
+  // template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
+  //           std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Dynamic, int> = 0>
+  // Polygon& operator=(const Polygon& other)
+  // {
+  //   if (this == &other)
+  //   {
+  //     return *this;
+  //   }
+
+  //   m_vertices = other.m_vertices;
+  //   return *this;
+  // }
+
+  // // Copy assignment(static array specialization)
+  // template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
+  //           std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Static, int> = 0>
+  // AXOM_HOST_DEVICE
+  // Polygon& operator=(const Polygon& other)
+  // {
+  //   if (this == &other)
+  //   {
+  //     return *this;
+  //   }
+
+  //   m_vertices = other.m_vertices;
+  //   return *this;
+  // }
+
+  /***************************************************************************/
+  // Copy constructor - Huh, doesn't throw a warning, maybe not necessary?
+
+  // (Nothing)
+
+  // Same as doing (Nothing), because C++ generating for us (works)
+  // Polygon(const Polygon& other) = default;
+
+  // This doesn't work on device, runtime failure (because not compiled for it)
+  // Polygon(const Polygon& other) : m_vertices(other.m_vertices)
+  // {}
+
+  // AXOM_HOST_DEVICE
+  // Polygon(const Polygon& other) : m_vertices(other.m_vertices)
+  // {}
+
+  // Oh, this works. Okay then.
+  // template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
+  //           std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Dynamic, int> = 0>
+  // Polygon(const Polygon& other) : m_vertices(other.m_vertices)
+  // {}
+
+  // template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
+  //           std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Static, int> = 0>
+  // AXOM_HOST_DEVICE
+  // Polygon(const Polygon& other) : m_vertices(other.m_vertices)
+  // {}
+
+  /***************************************************************************/
+
   /*!
    * \brief Constructor for an empty polygon that reserves space for
    *  the given number of vertices. Only available for dynamic arrays.

--- a/src/axom/primal/geometry/Polygon.hpp
+++ b/src/axom/primal/geometry/Polygon.hpp
@@ -123,92 +123,18 @@ public:
   AXOM_HOST_DEVICE Polygon()
   { }
 
-  /// Default destructor for an empty polygon (dynamic array specialization).
-  /// Specializations are necessary to remove __host__ __device__ warning for
-  /// axom::Array usage with the dynamic array type.
-  // template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
-  //           std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Dynamic, int> = 0>
-  // ~Polygon()
-  // { }
-
-  /// Default destructor for an empty polygon (static array specialization)
-
-  /***************************************************************************/
-
-  //  Throws warnings because not host device decorated (works)
-  // (Nothing)
-
-  // Same as doing (Nothing), because C++ generating for us (works)
-  // ~Polygon() = default;
-
-  // Decoration is ignored (works)
-  // AXOM_HOST_DEVICE
-  // ~Polygon() = default;
-
-  // This doesn't work on device, runtime failure (because not compiled for it)
-  // ~Polygon()
-  // { m_vertices.clear(); }
-
-  // This throws a bunch of warnings for axom::Array, but works
-  // AXOM_HOST_DEVICE
-  // ~Polygon()
-  // { m_vertices.clear(); }
-
-  // This the above but silences the axom::Array warnings, works.
-  // This does what we want (no warnings + works), but is ugly.
-  // Either it's this, or you live with the default constructed warnings (only 2)
+  /*!
+   * \brief Destructor for Polygon. Suppress CUDA warnings for
+   *        dynamic axom::Array.
+   */
   AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE
   ~Polygon() { m_vertices.clear(); }
 
-  // This not allowed, you cannot do this SFINAE stuff, doesn't compile
-  // template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
-  //           std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Dynamic, int> = 0>
-  // ~Polygon()
-  // { }
-
-  // /// Default constructor for an empty polygon (static array specialization)
-  // template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
-  //           std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Static, int> = 0>
-  // AXOM_HOST_DEVICE ~Polygon()
-  // { }
-
-  /***************************************************************************/
-  // Copy assignment operator
-
-  // (Nothing)
-
-  // Same as doing (Nothing), because C++ generating for us (works)
-  // Polygon& operator=(const Polygon& other) = default;
-
-  // This doesn't work on device, runtime failure (because not compiled for it)
-  // Polygon& operator=(const Polygon& other)
-  // {
-  //   if (this == &other)
-  //   {
-  //     return *this;
-  //   }
-
-  //   m_vertices = other.m_vertices;
-  //   return *this;
-  // }
-
-  // This throws a bunch of warnings for axom::Array, but works
-  // AXOM_HOST_DEVICE
-  // Polygon& operator=(const Polygon& other)
-  // {
-  //   if (this == &other)
-  //   {
-  //     return *this;
-  //   }
-
-  //   m_vertices = other.m_vertices;
-  //   return *this;
-  // }
-
-  // This the above but silences the axom::Array warnings, works.
-  // This does what we want (no warnings + works), but is ugly.
-  // Either it's this, or you live with the default constructed warnings (only 2)
+  /*!
+   * \brief Copy assignment operator for Polygon. Suppress CUDA warnings for
+   *        dynamic axom::Array.
+   */
   AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE
   Polygon& operator=(const Polygon& other)
@@ -222,64 +148,19 @@ public:
     return *this;
   }
 
-  // Huh, still get the warning...
-  // template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
-  //           std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Dynamic, int> = 0>
-  // Polygon& operator=(const Polygon& other)
-  // {
-  //   if (this == &other)
-  //   {
-  //     return *this;
-  //   }
+  /// Copy constructor for Polygon. Specializations are necessary to
+  /// remove __host__ __device__ warning for axom::Array usage with
+  /// the dynamic array type.
+  template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
+            std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Dynamic, int> = 0>
+  Polygon(const Polygon& other) : m_vertices(other.m_vertices)
+  { }
 
-  //   m_vertices = other.m_vertices;
-  //   return *this;
-  // }
-
-  // // Copy assignment(static array specialization)
-  // template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
-  //           std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Static, int> = 0>
-  // AXOM_HOST_DEVICE
-  // Polygon& operator=(const Polygon& other)
-  // {
-  //   if (this == &other)
-  //   {
-  //     return *this;
-  //   }
-
-  //   m_vertices = other.m_vertices;
-  //   return *this;
-  // }
-
-  /***************************************************************************/
-  // Copy constructor - Huh, doesn't throw a warning, maybe not necessary?
-
-  // (Nothing)
-
-  // Same as doing (Nothing), because C++ generating for us (works)
-  // Polygon(const Polygon& other) = default;
-
-  // This doesn't work on device, runtime failure (because not compiled for it)
-  // Polygon(const Polygon& other) : m_vertices(other.m_vertices)
-  // {}
-
-  // AXOM_HOST_DEVICE
-  // Polygon(const Polygon& other) : m_vertices(other.m_vertices)
-  // {}
-
-  // Oh, this works. Okay then.
-  // template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
-  //           std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Dynamic, int> = 0>
-  // Polygon(const Polygon& other) : m_vertices(other.m_vertices)
-  // {}
-
-  // template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
-  //           std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Static, int> = 0>
-  // AXOM_HOST_DEVICE
-  // Polygon(const Polygon& other) : m_vertices(other.m_vertices)
-  // {}
-
-  /***************************************************************************/
+  /// Copy constructor for Polygon (static array specialization)
+  template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
+            std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Static, int> = 0>
+  AXOM_HOST_DEVICE Polygon(const Polygon& other) : m_vertices(other.m_vertices)
+  { }
 
   /*!
    * \brief Constructor for an empty polygon that reserves space for

--- a/src/axom/primal/geometry/Polygon.hpp
+++ b/src/axom/primal/geometry/Polygon.hpp
@@ -13,6 +13,7 @@
 #define AXOM_PRIMAL_POLYGON_HPP_
 
 #include "axom/core/Array.hpp"
+#include "axom/core/StaticArray.hpp"
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
 
@@ -25,39 +26,6 @@ namespace primal
 namespace
 {
 static constexpr int DEFAULT_MAX_NUM_VERTICES = 8;
-
-/*!
- * \brief A helper class for the Polygon class
- *
- * This class helps define a StackArray with a current size and additional
- * functions to mirror axom::Array.
- */
-template <typename T, int N>
-struct StaticArray : public StackArray<T, N>
-{
-  AXOM_HOST_DEVICE int size() const { return m_size; }
-  AXOM_HOST_DEVICE void push_back(const T& obj)
-  {
-    assert(m_size < N);
-    if(m_size < N)
-    {
-      StackArray<T, N>::m_data[m_size++] = obj;
-    }
-  }
-
-  AXOM_HOST_DEVICE void clear()
-  {
-    for(T& datum : StackArray<T, N>::m_data)
-    {
-      datum = T();
-    }
-    m_size = 0;
-  }
-
-private:
-  int m_size {0};
-};
-
 } /* end anonymous namespace */
 
 /**
@@ -106,7 +74,7 @@ public:
   // axom::Array for dynamic array type, StaticArray for static array type
   using ArrayType = std::conditional_t<ARRAY_TYPE == PolygonArray::Dynamic,
                                        axom::Array<PointType>,
-                                       StaticArray<PointType, MAX_VERTS>>;
+                                       axom::StaticArray<PointType, MAX_VERTS>>;
 
 public:
   /// Default constructor for an empty polygon (dynamic array specialization).

--- a/src/axom/primal/geometry/Polygon.hpp
+++ b/src/axom/primal/geometry/Polygon.hpp
@@ -182,7 +182,17 @@ public:
   AXOM_HOST_DEVICE
   int numVertices() const { return static_cast<int>(m_vertices.size()); }
 
-  /// Appends a vertex to the list of vertices
+  /*!
+   * \brief Appends a vertex to the list of vertices
+   *
+   * \param [in] pt the point to be appended to the list of vertices
+   *
+   * \note If the array type is static and the list of vertices is full,
+   *       addVertex will not modify the list of vertices.
+   *
+   * \sa axom::StaticArray::push_back() for behavior when array type is static
+   *     and the list of vertices is full.
+   */
   AXOM_HOST_DEVICE
   void addVertex(const PointType& pt) { m_vertices.push_back(pt); }
 

--- a/src/axom/primal/geometry/Polygon.hpp
+++ b/src/axom/primal/geometry/Polygon.hpp
@@ -248,6 +248,22 @@ public:
     return normal;
   }
 
+  /// \brief Reverses orientation of the polygon in-place
+  AXOM_HOST_DEVICE
+  void reverseOrientation()
+  {
+    const int nverts = numVertices();
+    const int mid = nverts >> 1;
+
+    // Swap leftmost/rightmost vertices, midpoint unchanged
+    for(int i = 0; i < mid; ++i)
+    {
+      const int left = i;
+      const int right = nverts - i - 1;
+      axom::utilities::swap(m_vertices[left], m_vertices[right]);
+    }
+  }
+
   /*!
    * \brief Computes the average of the polygon's vertex positions
    *

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -96,6 +96,55 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
 }
 
 /*!
+ * \brief Clips a 2D subject polygon against a clip polygon in 2D, returning
+ *        the geometric intersection of the subject polygon and the
+ *        clip polygon as a polygon
+ *
+ *  This function clips the subject polygon by the planes obtained from the
+ *  clip polygon's edges (normals point inward). Clipping the
+ *  subject polygon by each plane gives the polygon above that plane.
+ *  Clipping the polygon by a plane involves
+ *  finding new vertices at the intersection of the polygon edges and
+ *  the plane, and removing vertices from the polygon that are below the
+ *  plane.
+ *
+ *
+ * \param [in] subjectPolygon The subject polygon
+ * \param [in] clipPolygon The clip polygon
+ * \param [in] eps The epsilon value
+ * \param [in] tryFixOrientation If true, takes each shape with a negative
+ *             signed area and swaps the order of some vertices in that
+ *             shape to try to obtain a nonnegative signed area.
+ *             Defaults to false.
+ *
+ * \return A polygon of the subject polygon clipped against the clip polygon.
+ *
+ * \note Function is based off the Sutherland–Hodgman algorithm.
+ *
+ * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
+ *          will be valid. It is the responsiblity of the caller to pass
+ *          shapes with a valid vertex order. Otherwise, if the shapes have
+ *          invalid vertex orders, the returned Polygon
+ *          will have a non-positive and/or unexpected area.
+ *
+ * \warning If tryFixOrientation flag is false and some of the shapes have
+ *          a negative signed area, the returned Polygon
+ *          will have a non-positive and/or unexpected area.
+ *
+ */
+template <typename T>
+Polygon<T, 2> clip(const Polygon<T, 2>& subjectPolygon,
+                   const Polygon<T, 2>& clipPolygon,
+                   double eps = 1.e-10,
+                   bool tryFixOrientation = false)
+{
+  return detail::clipPolygonPolygon(subjectPolygon,
+                                    clipPolygon,
+                                    eps,
+                                    tryFixOrientation);
+}
+
+/*!
  * \brief Clips a 3D hexahedron against a tetrahedron in 3D, returning
  *        the geometric intersection of the hexahedron and the tetrahedron
  *        as a polyhedron

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -111,7 +111,8 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
  *
  * \param [in] subjectPolygon The subject polygon
  * \param [in] clipPolygon The clip polygon
- * \param [in] eps The epsilon value
+ * \param [in] eps The tolerance for plane point orientation.
+ *                 Defaults to 1.e-10.
  * \param [in] tryFixOrientation If true, takes each shape with a negative
  *             signed area and swaps the order of some vertices in that
  *             shape to try to obtain a nonnegative signed area.

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -121,6 +121,11 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
  *
  * \note Function is based off the Sutherland–Hodgman algorithm.
  *
+ * \warning Polygons with static array types must have enough vertices
+ *          preallocated for the output polygon. It is recommended that
+ *          MAX_VERTS >= subjectPolygon.numVertices() + clipPolygon.numVertices()
+ *          for the output polygon with the largest possible vertex count.
+ *
  * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
  *          shapes with a valid vertex order. Otherwise, if the shapes have
@@ -132,11 +137,12 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
  *          will have a non-positive and/or unexpected area.
  *
  */
-template <typename T>
-Polygon<T, 2> clip(const Polygon<T, 2>& subjectPolygon,
-                   const Polygon<T, 2>& clipPolygon,
-                   double eps = 1.e-10,
-                   bool tryFixOrientation = false)
+template <typename T, axom::primal::PolygonArray ARRAY_TYPE, int MAX_VERTS>
+Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clip(
+  const Polygon<T, 2, ARRAY_TYPE, MAX_VERTS>& subjectPolygon,
+  const Polygon<T, 2, ARRAY_TYPE, MAX_VERTS>& clipPolygon,
+  double eps = 1.e-10,
+  bool tryFixOrientation = false)
 {
   return detail::clipPolygonPolygon(subjectPolygon,
                                     clipPolygon,

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -137,6 +137,7 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
  *          will have a non-positive and/or unexpected area.
  *
  */
+AXOM_SUPPRESS_HD_WARN
 template <typename T, axom::primal::PolygonArray ARRAY_TYPE, int MAX_VERTS>
 AXOM_HOST_DEVICE Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clip(
   const Polygon<T, 2, ARRAY_TYPE, MAX_VERTS>& subjectPolygon,

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -138,7 +138,7 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
  *
  */
 template <typename T, axom::primal::PolygonArray ARRAY_TYPE, int MAX_VERTS>
-Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clip(
+AXOM_HOST_DEVICE Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clip(
   const Polygon<T, 2, ARRAY_TYPE, MAX_VERTS>& subjectPolygon,
   const Polygon<T, 2, ARRAY_TYPE, MAX_VERTS>& clipPolygon,
   double eps = 1.e-10,

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -97,8 +97,7 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
 
 /*!
  * \brief Clips a 2D subject polygon against a clip polygon in 2D, returning
- *        the geometric intersection of the subject polygon and the
- *        clip polygon as a polygon
+ *        their geometric intersection as a polygon
  *
  *  This function clips the subject polygon by the planes obtained from the
  *  clip polygon's edges (normals point inward). Clipping the

--- a/src/axom/primal/operators/clip.hpp
+++ b/src/axom/primal/operators/clip.hpp
@@ -122,9 +122,14 @@ Polygon<T, 3> clip(const Triangle<T, 3>& tri, const BoundingBox<T, 3>& bbox)
  * \note Function is based off the Sutherland–Hodgman algorithm.
  *
  * \warning Polygons with static array types must have enough vertices
- *          preallocated for the output polygon. It is recommended that
+ *          preallocated for the output polygon. It is mandatory that
  *          MAX_VERTS >= subjectPolygon.numVertices() + clipPolygon.numVertices()
  *          for the output polygon with the largest possible vertex count.
+ *          Otherwise, if there is not enough preallocated vertices, output
+ *          polygon will have missing vertices.
+ *
+ * \sa axom::primal::Polygon::addVertex(), axom::StaticArray::push_back()
+ *     for behavior when there is not enough preallocated vertices.
  *
  * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -673,7 +673,7 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
 
 /*!
  * \brief Clips a subject polygon against a clip polygon and returns the
- *        resultign polygon
+ *        resulting polygon
  *
  * \param [in] subjectPolygon The subject polygon
  * \param [in] clipPolygon The clip polygon
@@ -766,7 +766,7 @@ Polygon<T, 2> clipPolygonPolygon(const Polygon<T, 2>& subjectPolygon,
 
       if(cur_p_orientation == ON_POSITIVE_SIDE)
       {
-        if(prev_p_orientation == ON_NEGATIVE_SIDE)
+        if(prev_p_orientation != ON_POSITIVE_SIDE)
         {
           outputList.addVertex(intersecting_point);
         }
@@ -775,10 +775,6 @@ Polygon<T, 2> clipPolygonPolygon(const Polygon<T, 2>& subjectPolygon,
       else if(prev_p_orientation == ON_POSITIVE_SIDE)
       {
         outputList.addVertex(intersecting_point);
-      }
-      else if(cur_p_orientation == ON_BOUNDARY)
-      {
-        outputList.addVertex(current_point);
       }
     }
   }  // end of iteration through edges of clip polygon

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -703,7 +703,7 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
  *          will have a non-positive and/or unexpected area.
  */
 template <typename T, axom::primal::PolygonArray ARRAY_TYPE, int MAX_VERTS>
-Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clipPolygonPolygon(
+AXOM_HOST_DEVICE Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clipPolygonPolygon(
   const Polygon<T, 2, ARRAY_TYPE, MAX_VERTS>& subjectPolygon,
   const Polygon<T, 2, ARRAY_TYPE, MAX_VERTS>& clipPolygon,
   double eps = 1.e-10,
@@ -773,7 +773,13 @@ Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clipPolygonPolygon(
 
       if(cur_p_orientation == ON_POSITIVE_SIDE)
       {
-        if(prev_p_orientation != ON_POSITIVE_SIDE)
+        // Handles the edge case of 3 consecutive vertices with orientations
+        // ON_POSITIVE_SIDE, ON_BOUNDARY, ON_POSITIVE. Default algorithm
+        // check (prev_p_orientation != ON_POSITIVE_SIDE) results in the
+        // vertex on the boundary being added twice.
+        if(prev_p_orientation == ON_NEGATIVE_SIDE ||
+           (prev_p_orientation == ON_BOUNDARY &&
+            intersecting_point != outputList[outputList.numVertices() - 1]))
         {
           outputList.addVertex(intersecting_point);
         }

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -736,15 +736,13 @@ Polygon<T, 2> clipPolygonPolygon(const Polygon<T, 2>& subjectPolygon,
   }
 
   int numClipEdges = planePoints.numVertices();
-  PlaneType planes[numClipEdges];
-  for(int i = 0; i < numClipEdges; i++)
-  {
-    planes[i] = make_plane(planePoints[i], planePoints[(i + 1) % numClipEdges]);
-  }
 
   // Iterate through edges of clip polygon, represented as planes
-  for(PlaneType plane : planes)
+  for(int i = 0; i < numClipEdges; i++)
   {
+    PlaneType plane =
+      make_plane(planePoints[i], planePoints[(i + 1) % numClipEdges]);
+
     Polygon<T, 2> inputList = outputList;
     outputList.clear();
 

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -687,6 +687,11 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
  *
  * \note Function is based off the Sutherland–Hodgman algorithm.
  *
+ * \warning Polygons with static array types must have enough vertices
+ *          preallocated for the output polygon. It is recommended that
+ *          MAX_VERTS >= subjectPolygon.numVertices() + clipPolygon.numVertices()
+ *          for the output polygon with the largest possible vertex count.
+ *
  * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
  *          will be valid. It is the responsiblity of the caller to pass
  *          shapes with a valid vertex order. Otherwise, if the shapes have
@@ -697,22 +702,24 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
  *          a negative signed area, the returned Polygon
  *          will have a non-positive and/or unexpected area.
  */
-template <typename T>
-Polygon<T, 2> clipPolygonPolygon(const Polygon<T, 2>& subjectPolygon,
-                                 const Polygon<T, 2>& clipPolygon,
-                                 double eps = 1.e-10,
-                                 bool tryFixOrientation = false)
+template <typename T, axom::primal::PolygonArray ARRAY_TYPE, int MAX_VERTS>
+Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clipPolygonPolygon(
+  const Polygon<T, 2, ARRAY_TYPE, MAX_VERTS>& subjectPolygon,
+  const Polygon<T, 2, ARRAY_TYPE, MAX_VERTS>& clipPolygon,
+  double eps = 1.e-10,
+  bool tryFixOrientation = false)
 {
   using PlaneType = Plane<T, 2>;
   using PointType = Point<T, 2>;
   using SegmentType = Segment<T, 2>;
+  using PolygonType = Polygon<T, 2, ARRAY_TYPE, MAX_VERTS>;
 
-  Polygon<T, 2> outputList = subjectPolygon;
-  Polygon<T, 2> planePoints = clipPolygon;
+  PolygonType outputList = subjectPolygon;
+  PolygonType planePoints = clipPolygon;
 
   if(tryFixOrientation)
   {
-    Polygon<T, 2> tempPolygon;
+    PolygonType tempPolygon;
     if(subjectPolygon.signedArea() < 0)
     {
       for(int i = 0; i < subjectPolygon.numVertices(); i++)
@@ -743,7 +750,7 @@ Polygon<T, 2> clipPolygonPolygon(const Polygon<T, 2>& subjectPolygon,
     PlaneType plane =
       make_plane(planePoints[i], planePoints[(i + 1) % numClipEdges]);
 
-    Polygon<T, 2> inputList = outputList;
+    PolygonType inputList = outputList;
     outputList.clear();
 
     for(int i = 0; i < inputList.numVertices(); i++)

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -677,7 +677,7 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
  *
  * \param [in] subjectPolygon The subject polygon
  * \param [in] clipPolygon The clip polygon
- * \param [in] eps The epsilon value
+ * \param [in] eps The tolerance for plane point orientation
  * \param [in] tryFixOrientation If true, takes each shape with a negative
  *             signed area and swaps the order of some vertices in that
  *             shape to try to obtain a nonnegative signed area.

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -702,6 +702,7 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
  *          a negative signed area, the returned Polygon
  *          will have a non-positive and/or unexpected area.
  */
+AXOM_SUPPRESS_HD_WARN
 template <typename T, axom::primal::PolygonArray ARRAY_TYPE, int MAX_VERTS>
 AXOM_HOST_DEVICE Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clipPolygonPolygon(
   const Polygon<T, 2, ARRAY_TYPE, MAX_VERTS>& subjectPolygon,

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -685,6 +685,11 @@ AXOM_HOST_DEVICE Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clipPolygonPolygon(
   double eps = 1.e-10,
   bool tryFixOrientation = false)
 {
+  SLIC_ASSERT(
+    ARRAY_TYPE == axom::primal::PolygonArray::Dynamic ||
+    (ARRAY_TYPE == axom::primal::PolygonArray::Static &&
+     MAX_VERTS >= (subjectPolygon.numVertices() + clipPolygon.numVertices())));
+
   using PlaneType = Plane<T, 2>;
   using PointType = Point<T, 2>;
   using SegmentType = Segment<T, 2>;

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -672,35 +672,10 @@ AXOM_HOST_DEVICE Polyhedron<T, NDIMS> clipTetrahedron(
 }
 
 /*!
- * \brief Clips a subject polygon against a clip polygon and returns the
- *        resulting polygon
+ * \brief Clips a 2D subject polygon against a clip polygon in 2D, returning
+ *        their geometric intersection as a polygon.
  *
- * \param [in] subjectPolygon The subject polygon
- * \param [in] clipPolygon The clip polygon
- * \param [in] eps The tolerance for plane point orientation
- * \param [in] tryFixOrientation If true, takes each shape with a negative
- *             signed area and swaps the order of some vertices in that
- *             shape to try to obtain a nonnegative signed area.
- *             Defaults to false.
- *
- * \return A polygon of the subject polygon clipped against the clip polygon.
- *
- * \note Function is based off the Sutherland–Hodgman algorithm.
- *
- * \warning Polygons with static array types must have enough vertices
- *          preallocated for the output polygon. It is recommended that
- *          MAX_VERTS >= subjectPolygon.numVertices() + clipPolygon.numVertices()
- *          for the output polygon with the largest possible vertex count.
- *
- * \warning tryFixOrientation flag does not guarantee the shapes' vertex orders
- *          will be valid. It is the responsiblity of the caller to pass
- *          shapes with a valid vertex order. Otherwise, if the shapes have
- *          invalid vertex orders, the returned Polygon
- *          will have a non-positive and/or unexpected area.
- *
- * \warning If tryFixOrientation flag is false and some of the shapes have
- *          a negative signed area, the returned Polygon
- *          will have a non-positive and/or unexpected area.
+ * \sa axom::primal::clip()
  */
 AXOM_SUPPRESS_HD_WARN
 template <typename T, axom::primal::PolygonArray ARRAY_TYPE, int MAX_VERTS>

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -700,26 +700,14 @@ AXOM_HOST_DEVICE Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clipPolygonPolygon(
 
   if(tryFixOrientation)
   {
-    PolygonType tempPolygon;
-    if(subjectPolygon.signedArea() < 0)
+    if(outputList.signedArea() < 0)
     {
-      for(int i = 0; i < subjectPolygon.numVertices(); i++)
-      {
-        tempPolygon.addVertex(
-          subjectPolygon[subjectPolygon.numVertices() - i - 1]);
-      }
-      outputList = tempPolygon;
-      tempPolygon.clear();
+      outputList.reverseOrientation();
     }
 
-    if(clipPolygon.signedArea() < 0)
+    if(planePoints.signedArea() < 0)
     {
-      for(int i = 0; i < clipPolygon.numVertices(); i++)
-      {
-        tempPolygon.addVertex(clipPolygon[clipPolygon.numVertices() - i - 1]);
-      }
-      planePoints = tempPolygon;
-      tempPolygon.clear();
+      planePoints.reverseOrientation();
     }
   }
 

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -743,7 +743,7 @@ AXOM_HOST_DEVICE Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clipPolygonPolygon(
     }
   }
 
-  int numClipEdges = planePoints.numVertices();
+  const int numClipEdges = planePoints.numVertices();
 
   // Iterate through edges of clip polygon, represented as planes
   for(int i = 0; i < numClipEdges; i++)

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -1098,8 +1098,8 @@ AXOM_HOST_DEVICE bool intersect_plane_bbox(const Plane<T, 3>& p,
 
 /*!
  * \brief Determines if a plane intersects a segment.
- * \param [in] b1 A plane
- * \param [in] b2 A segment
+ * \param [in] plane A plane
+ * \param [in] seg A segment
  * \param [out] t Intersection point of plane and seg, w.r.t. 
  *   parametrization of seg
  * \return true iff plane intersects with segment, otherwise, false.

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -1097,19 +1097,19 @@ AXOM_HOST_DEVICE bool intersect_plane_bbox(const Plane<T, 3>& p,
 }
 
 /*!
- * \brief Determines if a 3D plane intersects a 3D segment.
- * \param [in] b1 A 3D plane
- * \param [in] b2 A 3D segment
+ * \brief Determines if a plane intersects a segment.
+ * \param [in] b1 A plane
+ * \param [in] b2 A segment
  * \param [out] t Intersection point of plane and seg, w.r.t. 
  *   parametrization of seg
  * \return true iff plane intersects with segment, otherwise, false.
  */
-template <typename T>
-AXOM_HOST_DEVICE bool intersect_plane_seg(const Plane<T, 3>& plane,
-                                          const Segment<T, 3>& seg,
+template <typename T, int DIM>
+AXOM_HOST_DEVICE bool intersect_plane_seg(const Plane<T, DIM>& plane,
+                                          const Segment<T, DIM>& seg,
                                           T& t)
 {
-  using VectorType = Vector<T, 3>;
+  using VectorType = Vector<T, DIM>;
 
   VectorType ab(seg.source(), seg.target());
   VectorType normal = plane.getNormal();

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -570,9 +570,9 @@ AXOM_HOST_DEVICE bool intersect(const Plane<T, 3>& p,
 }
 
 /*!
- * \brief Determines if a 3D plane intersects a 3D segment.
- * \param [in] plane A 3D plane
- * \param [in] seg A 3D line segment
+ * \brief Determines if a plane intersects a segment.
+ * \param [in] plane A plane
+ * \param [in] seg A line segment
  * \param [out] t Intersection point of plane and seg, w.r.t. seg's
  *  parametrization
  * \note If there is an intersection, the intersection point pt is:
@@ -583,9 +583,9 @@ AXOM_HOST_DEVICE bool intersect(const Plane<T, 3>& p,
  * \note Uses method from pg 176 of 
  *       Real Time Collision Detection by Christer Ericson.
  */
-template <typename T>
-AXOM_HOST_DEVICE bool intersect(const Plane<T, 3>& plane,
-                                const Segment<T, 3>& seg,
+template <typename T, int DIM>
+AXOM_HOST_DEVICE bool intersect(const Plane<T, DIM>& plane,
+                                const Segment<T, DIM>& seg,
                                 T& t)
 {
   return detail::intersect_plane_seg(plane, seg, t);

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -1643,7 +1643,7 @@ TEST(primal_clip, tet_plane_intersect_four_edges)
   EXPECT_NEAR(tet.signedVolume() / 2.0, poly.signedVolume(), EPS);
 }
 
-TEST(primal_clip, empty_polygon)
+TEST(primal_clip, empty_polygons)
 {
   using Polygon2D = axom::primal::Polygon<double, 2>;
 
@@ -1656,7 +1656,7 @@ TEST(primal_clip, empty_polygon)
   EXPECT_EQ(poly.isValid(), false);
 }
 
-TEST(primal_clip, rectangles)
+TEST(primal_clip, polygon_intersects_polygon)
 {
   using Polygon2D = axom::primal::Polygon<double, 2>;
   using Point2D = axom::primal::Point<double, 2>;
@@ -1708,6 +1708,72 @@ TEST(primal_clip, rectangles)
 
     // Positive area with tryFixOrientation flag enabled
     EXPECT_NEAR(poly_fix_orientation.signedArea(), 0.5, EPS);
+  }
+
+  // Non-clipping - polygons intersect at a line
+  {
+    Polygon2D subjectPolygon;
+    subjectPolygon.addVertex(Point2D {0, 0});
+    subjectPolygon.addVertex(Point2D {1, 0});
+    subjectPolygon.addVertex(Point2D {1, 1});
+    subjectPolygon.addVertex(Point2D {0, 1});
+
+    Polygon2D clipPolygon;
+    clipPolygon.addVertex(Point2D {-1, 0});
+    clipPolygon.addVertex(Point2D {0, 0});
+    clipPolygon.addVertex(Point2D {0, 1});
+    clipPolygon.addVertex(Point2D {-1, 1});
+
+    Polygon2D poly =
+      axom::primal::clip(subjectPolygon, clipPolygon, EPS, CHECK_SIGN);
+
+    EXPECT_EQ(poly.isValid(), false);
+    EXPECT_EQ(poly.numVertices(), 0);
+  }
+
+  // Non-clipping - polygons intersect at a point
+  {
+    Polygon2D subjectPolygon;
+    subjectPolygon.addVertex(Point2D {0, 0});
+    subjectPolygon.addVertex(Point2D {1, 0});
+    subjectPolygon.addVertex(Point2D {1, 1});
+    subjectPolygon.addVertex(Point2D {0, 1});
+
+    Polygon2D clipPolygon;
+    clipPolygon.addVertex(Point2D {-1, -1});
+    clipPolygon.addVertex(Point2D {0, -1});
+    clipPolygon.addVertex(Point2D {0, 0});
+    clipPolygon.addVertex(Point2D {-1, 0});
+
+    Polygon2D poly =
+      axom::primal::clip(subjectPolygon, clipPolygon, EPS, CHECK_SIGN);
+
+    EXPECT_EQ(poly.isValid(), false);
+    EXPECT_EQ(poly.numVertices(), 0);
+  }
+
+  // Rosetta Code example
+  {
+    Polygon2D subjectPolygon;
+    subjectPolygon.addVertex(Point2D {50, 150});
+    subjectPolygon.addVertex(Point2D {200, 50});
+    subjectPolygon.addVertex(Point2D {350, 150});
+    subjectPolygon.addVertex(Point2D {350, 300});
+    subjectPolygon.addVertex(Point2D {250, 300});
+    subjectPolygon.addVertex(Point2D {200, 250});
+    subjectPolygon.addVertex(Point2D {150, 350});
+    subjectPolygon.addVertex(Point2D {100, 250});
+    subjectPolygon.addVertex(Point2D {100, 200});
+
+    Polygon2D clipPolygon;
+    clipPolygon.addVertex(Point2D {100, 100});
+    clipPolygon.addVertex(Point2D {300, 100});
+    clipPolygon.addVertex(Point2D {300, 300});
+    clipPolygon.addVertex(Point2D {100, 300});
+
+    Polygon2D poly = axom::primal::clip(subjectPolygon, clipPolygon, EPS);
+    EXPECT_NEAR(poly.signedArea(), 37083.3333333333, EPS);
+    SLIC_INFO(poly);
   }
 }
 

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -1659,6 +1659,8 @@ TEST(primal_clip, empty_polygons)
 TEST(primal_clip, polygon_intersects_polygon)
 {
   using Polygon2D = axom::primal::Polygon<double, 2>;
+  using PolygonStatic2D =
+    axom::primal::Polygon<double, 2, axom::primal::PolygonArray::Static>;
   using Point2D = axom::primal::Point<double, 2>;
   constexpr double EPS = 1e-10;
   constexpr bool CHECK_SIGN = true;
@@ -1678,6 +1680,27 @@ TEST(primal_clip, polygon_intersects_polygon)
     clipPolygon.addVertex(Point2D {0.5, 2});
 
     Polygon2D poly = axom::primal::clip(subjectPolygon, clipPolygon, EPS);
+
+    EXPECT_NEAR(subjectPolygon.signedArea(), 1.0, EPS);
+    EXPECT_NEAR(clipPolygon.signedArea(), 3.0, EPS);
+    EXPECT_NEAR(poly.signedArea(), 0.5, EPS);
+  }
+
+  // Same polygons with static arrays
+  {
+    PolygonStatic2D subjectPolygon;
+    subjectPolygon.addVertex(Point2D {0, 0});
+    subjectPolygon.addVertex(Point2D {1, 0});
+    subjectPolygon.addVertex(Point2D {1, 1});
+    subjectPolygon.addVertex(Point2D {0, 1});
+
+    PolygonStatic2D clipPolygon;
+    clipPolygon.addVertex(Point2D {0.5, -1});
+    clipPolygon.addVertex(Point2D {1.5, -1});
+    clipPolygon.addVertex(Point2D {1.5, 2});
+    clipPolygon.addVertex(Point2D {0.5, 2});
+
+    PolygonStatic2D poly = axom::primal::clip(subjectPolygon, clipPolygon, EPS);
 
     EXPECT_NEAR(subjectPolygon.signedArea(), 1.0, EPS);
     EXPECT_NEAR(clipPolygon.signedArea(), 3.0, EPS);
@@ -1773,7 +1796,6 @@ TEST(primal_clip, polygon_intersects_polygon)
 
     Polygon2D poly = axom::primal::clip(subjectPolygon, clipPolygon, EPS);
     EXPECT_NEAR(poly.signedArea(), 37083.3333333333, EPS);
-    SLIC_INFO(poly);
   }
 }
 

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -1920,6 +1920,37 @@ TEST(primal_clip, polygon_intersects_polygon)
     Polygon2D poly = axom::primal::clip(subjectPolygon, clipPolygon, EPS);
     EXPECT_NEAR(poly.signedArea(), 37083.3333333333, EPS);
     EXPECT_EQ(poly.numVertices(), 10);
+
+    // Check vertices
+    EXPECT_NEAR(poly[0][0], 100, EPS);
+    EXPECT_NEAR(poly[0][1], 116.6666666666, EPS);
+
+    EXPECT_NEAR(poly[1][0], 125, EPS);
+    EXPECT_NEAR(poly[1][1], 100, EPS);
+
+    EXPECT_NEAR(poly[2][0], 275, EPS);
+    EXPECT_NEAR(poly[2][1], 100, EPS);
+
+    EXPECT_NEAR(poly[3][0], 300, EPS);
+    EXPECT_NEAR(poly[3][1], 116.6666666666, EPS);
+
+    EXPECT_NEAR(poly[4][0], 300, EPS);
+    EXPECT_NEAR(poly[4][1], 300, EPS);
+
+    EXPECT_NEAR(poly[5][0], 250, EPS);
+    EXPECT_NEAR(poly[5][1], 300, EPS);
+
+    EXPECT_NEAR(poly[6][0], 200, EPS);
+    EXPECT_NEAR(poly[6][1], 250, EPS);
+
+    EXPECT_NEAR(poly[7][0], 175, EPS);
+    EXPECT_NEAR(poly[7][1], 300, EPS);
+
+    EXPECT_NEAR(poly[8][0], 125, EPS);
+    EXPECT_NEAR(poly[8][1], 300, EPS);
+
+    EXPECT_NEAR(poly[9][0], 100, EPS);
+    EXPECT_NEAR(poly[9][1], 250, EPS);
   }
 }
 

--- a/src/axom/primal/tests/primal_intersect.cpp
+++ b/src/axom/primal/tests/primal_intersect.cpp
@@ -2178,47 +2178,93 @@ TEST(primal_intersect, plane_bb_test_intersection)
 TEST(primal_intersect, plane_seg_test_intersection)
 {
   double t1, t2, t3;
-  const int DIM = 3;
-  using PointType = primal::Point<double, DIM>;
-  using PlaneType = primal::Plane<double, DIM>;
-  using SegmentType = primal::Segment<double, DIM>;
-  using VectorType = primal::Vector<double, DIM>;
+  using Point3D = primal::Point<double, 3>;
+  using Plane3D = primal::Plane<double, 3>;
+  using Segment3D = primal::Segment<double, 3>;
+  using Vector3D = primal::Vector<double, 3>;
 
-  // Line segment goes from (0,0,0) to (1,1,1)
-  PointType A(0.);
-  PointType B(1.);
-  SegmentType s(A, B);
+  using Point2D = primal::Point<double, 2>;
+  using Plane2D = primal::Plane<double, 2>;
+  using Segment2D = primal::Segment<double, 2>;
+  using Vector2D = primal::Vector<double, 2>;
 
-  // Line segment parallel to plane (non-intersect)
-  PointType A_p {-1, -1, 0};
-  PointType B_p {1, -1, 0};
-  SegmentType s_p(A_p, B_p);
+  // 3D Tests
+  {
+    // Line segment goes from (0,0,0) to (1,1,1)
+    Point3D A(0.);
+    Point3D B(1.);
+    Segment3D s(A, B);
 
-  // intersect A
-  VectorType normal1 {0.0, 1.0, 0.0};
-  double offset1 = 0.0;
-  PlaneType p1(normal1, offset1);
+    // Line segment parallel to plane (non-intersect)
+    Point3D A_p {-1, -1, 0};
+    Point3D B_p {1, -1, 0};
+    Segment3D s_p(A_p, B_p);
 
-  // intersect midpoint
-  VectorType normal2 {0.0, 1.0, 0.0};
-  double offset2 = 0.5;
-  PlaneType p2(normal2, offset2);
+    // intersect A
+    Vector3D normal1 {0.0, 1.0, 0.0};
+    double offset1 = 0.0;
+    Plane3D p1(normal1, offset1);
 
-  // intersect B
-  VectorType normal3 {0.0, 1.0, 0.0};
-  double offset3 = 1.0;
-  PlaneType p3(normal3, offset3);
+    // intersect midpoint
+    Vector3D normal2 {0.0, 1.0, 0.0};
+    double offset2 = 0.5;
+    Plane3D p2(normal2, offset2);
 
-  EXPECT_TRUE(axom::primal::intersect(p1, s, t1));
-  EXPECT_EQ(s.at(t1), PointType({0.0, 0.0, 0.0}));
+    // intersect B
+    Vector3D normal3 {0.0, 1.0, 0.0};
+    double offset3 = 1.0;
+    Plane3D p3(normal3, offset3);
 
-  EXPECT_TRUE(axom::primal::intersect(p2, s, t2));
-  EXPECT_EQ(s.at(t2), PointType({0.5, 0.5, 0.5}));
+    EXPECT_TRUE(axom::primal::intersect(p1, s, t1));
+    EXPECT_EQ(s.at(t1), Point3D({0.0, 0.0, 0.0}));
 
-  EXPECT_TRUE(axom::primal::intersect(p3, s, t3));
-  EXPECT_EQ(s.at(t3), PointType({1.0, 1.0, 1.0}));
+    EXPECT_TRUE(axom::primal::intersect(p2, s, t2));
+    EXPECT_EQ(s.at(t2), Point3D({0.5, 0.5, 0.5}));
 
-  EXPECT_FALSE(axom::primal::intersect(p1, s_p, t1));
+    EXPECT_TRUE(axom::primal::intersect(p3, s, t3));
+    EXPECT_EQ(s.at(t3), Point3D({1.0, 1.0, 1.0}));
+
+    EXPECT_FALSE(axom::primal::intersect(p1, s_p, t1));
+  }
+
+  // 2D Tests
+  {
+    // Line segment goes from (0,0) to (1,1)
+    Point2D A(0.);
+    Point2D B(1.);
+    Segment2D s(A, B);
+
+    // Line segment parallel to plane (non-intersect)
+    Point2D A_p {-1, -1};
+    Point2D B_p {1, -1};
+    Segment2D s_p(A_p, B_p);
+
+    // intersect A
+    Vector2D normal1 {0.0, 1.0};
+    double offset1 = 0.0;
+    Plane2D p1(normal1, offset1);
+
+    // intersect midpoint
+    Vector2D normal2 {0.0, 1.0};
+    double offset2 = 0.5;
+    Plane2D p2(normal2, offset2);
+
+    // intersect B
+    Vector2D normal3 {0.0, 1.0};
+    double offset3 = 1.0;
+    Plane2D p3(normal3, offset3);
+
+    EXPECT_TRUE(axom::primal::intersect(p1, s, t1));
+    EXPECT_EQ(s.at(t1), Point2D({0.0, 0.0}));
+
+    EXPECT_TRUE(axom::primal::intersect(p2, s, t2));
+    EXPECT_EQ(s.at(t2), Point2D({0.5, 0.5}));
+
+    EXPECT_TRUE(axom::primal::intersect(p3, s, t3));
+    EXPECT_EQ(s.at(t3), Point2D({1.0, 1.0}));
+
+    EXPECT_FALSE(axom::primal::intersect(p1, s_p, t1));
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_polygon.cpp
+++ b/src/axom/primal/tests/primal_polygon.cpp
@@ -720,6 +720,47 @@ TEST(primal_polygon, normal)
   }
 }
 
+//------------------------------------------------------------------------------
+TEST(primal_polygon, reverseOrientation)
+{
+  using Polygon2D = axom::primal::Polygon<double, 2>;
+  using Point2D = axom::primal::Point<double, 2>;
+
+  // Test an odd number of vertices
+  {
+    Polygon2D poly({Point2D {0, 0}, Point2D {1, 0}, Point2D {1, 1}});
+    poly.reverseOrientation();
+
+    EXPECT_NEAR(poly[0][0], 1, EPS);
+    EXPECT_NEAR(poly[0][1], 1, EPS);
+
+    EXPECT_NEAR(poly[1][0], 1, EPS);
+    EXPECT_NEAR(poly[1][1], 0, EPS);
+
+    EXPECT_NEAR(poly[2][0], 0, EPS);
+    EXPECT_NEAR(poly[2][1], 0, EPS);
+  }
+
+  // Test an even number of vertices
+  {
+    Polygon2D poly(
+      {Point2D {0, 0}, Point2D {1, 0}, Point2D {1, 1}, Point2D {0, 1}});
+    poly.reverseOrientation();
+
+    EXPECT_NEAR(poly[0][0], 0, EPS);
+    EXPECT_NEAR(poly[0][1], 1, EPS);
+
+    EXPECT_NEAR(poly[1][0], 1, EPS);
+    EXPECT_NEAR(poly[1][1], 1, EPS);
+
+    EXPECT_NEAR(poly[2][0], 1, EPS);
+    EXPECT_NEAR(poly[2][1], 0, EPS);
+
+    EXPECT_NEAR(poly[3][0], 0, EPS);
+    EXPECT_NEAR(poly[3][1], 0, EPS);
+  }
+}
+
 template <typename ExecPolicy>
 void check_polygon_policy()
 {
@@ -788,6 +829,11 @@ void check_polygon_policy()
       poly_3d_view[i].isValid();
       poly_2d_view[i].numVertices();
       poly_2d_view[i].isValid();
+
+      poly_2d_view[i].reverseOrientation();
+      poly_2d_view[i].reverseOrientation();
+      poly_3d_view[i].reverseOrientation();
+      poly_3d_view[i].reverseOrientation();
     });
 
   // Copy polygons and data back to host


### PR DESCRIPTION
This PR:
- Implements an overload `clip()` for 2D polygons using the Sutherland–Hodgman algorithm.
  - host-device decorated to run on device. 
- Generalizes `intersect(plane, segment)` for 2D.
- Moved `StaticArray` from Polygon class into core.