### PR TITLE
Update MacOS Azure agent

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ jobs:
         TEST_TARGET: 'linux_clang10'
         HOST_CONFIG: 'clang@10.0.0'
       osx_gcc:
-        VM_ImageName: 'macos-11'
+        VM_ImageName: 'macos-12'
         CMAKE_EXTRA_FLAGS: '-DAXOM_ENABLE_SIDRE:BOOL=OFF -DAXOM_ENABLE_INLET:BOOL=OFF -DAXOM_ENABLE_KLEE:BOOL=OFF'
         TEST_TARGET: 'osx_gcc'
       windows:


### PR DESCRIPTION
This PR updates the Azure Pipelines MacOS agent to macOS-12.

The current macOS-11 agent is being deprecated as of June 28th:
https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#software