### PR TITLE
Polyhedron centroid

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,6 +39,10 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   a new method, `Array::setDevicePreference()`.
 
 ### Changed
+- Primal: `Polyhedron::centroid()` function changed to return center of mass
+  of the polyhedron. `Polyhedron::vertexMean()` added to return average of
+  polyhedron's vertices. `Polyhedron::moments()` returns the volume and centroid
+  of the polyhedron, the 0th and 1st moments respectively.
 - `quest::ArrayIndexer` is now `axom::MDMapping`, adopting conventional terminology
   and moving out of `quest`.
 - `mint::structured_exec` is now `axom::nested_for_exec`, to support nested for loops

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -521,6 +521,9 @@ public:
     VectorType centroid_vector;
     PointType centroid_point;
 
+    VectorType centroid_vector_squared;
+    PointType centroid_point_squared;
+
     if(!isValid() || hasDuplicateVertices())
     {
       return retVol;
@@ -557,15 +560,36 @@ public:
 
           retVol += curVol;
           centroid_vector += (v0 + v1 + v2) * curVol;
+
+          VectorType n = VectorType::cross_product(v1 - v0, v2 - v0);
+          for(int z = 0; z < 3; z++)
+          {
+            centroid_vector_squared[z] += n[z] *
+              (((v0[z] + v1[z]) * (v0[z] + v1[z])) +
+               ((v1[z] + v2[z]) * (v1[z] + v2[z])) +
+               ((v2[z] + v0[z]) * (v2[z] + v0[z])));
+          }
         }
       }
 
       retVol /= 6.;
       // SLIC_INFO("retVol is " << retVol);
-      double tempVol = (retVol != 0.0) ? (24.0 * retVol) : 1e-12;
+      double tempVol =
+        (retVol != 0.0) ? (24.0 * retVol) : axom::primal::PRIMAL_TINY;
       centroid_vector /= tempVol;
       centroid_point = centroid_vector + origin;
-      // SLIC_INFO(centroid_point);
+      printf("PolyClipper's centroid point is \t (%f, %f, %f)\n",
+             centroid_point[0],
+             centroid_point[1],
+             centroid_point[2]);
+
+      centroid_vector_squared /=
+        (retVol != 0.0) ? (tempVol * 2.0) : axom::primal::PRIMAL_TINY;
+      centroid_point_squared = centroid_vector_squared + origin;
+      printf("Nurnberg's centroid point is \t\t (%f, %f, %f)\n\n",
+             centroid_point_squared[0],
+             centroid_point_squared[1],
+             centroid_point_squared[2]);
     }
 
     return retVol;

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -518,6 +518,9 @@ public:
   {
     double retVol = 0.0;
 
+    VectorType centroid_vector;
+    PointType centroid_point;
+
     if(!isValid() || hasDuplicateVertices())
     {
       return retVol;
@@ -548,15 +551,24 @@ public:
 
         for(int j = 1, k = 2; j < N - 1; ++j, ++k)
         {
-          retVol += VectorType::scalar_triple_product(
-            v0,
-            m_vertices[faces[i_offset + j]] - origin,
-            m_vertices[faces[i_offset + k]] - origin);
+          VectorType v1 = m_vertices[faces[i_offset + j]] - origin;
+          VectorType v2 = m_vertices[faces[i_offset + k]] - origin;
+          double curVol = VectorType::scalar_triple_product(v0, v1, v2);
+
+          retVol += curVol;
+          centroid_vector += (v0 + v1 + v2) * curVol;
         }
       }
+
+      retVol /= 6.;
+      // SLIC_INFO("retVol is " << retVol);
+      double tempVol = (retVol != 0.0) ? (24.0 * retVol) : 1e-12;
+      centroid_vector /= tempVol;
+      centroid_point = centroid_vector + origin;
+      // SLIC_INFO(centroid_point);
     }
 
-    return retVol / 6.;
+    return retVol;
   }
 
   /*!

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -522,10 +522,6 @@ public:
     volume = 0.0;
 
     VectorType centroid_vector;
-    // PointType centroid_point;
-
-    VectorType centroid_vector_squared;
-    PointType centroid_point_squared;
 
     if(!isValid() || hasDuplicateVertices())
     {
@@ -563,36 +559,14 @@ public:
 
           volume += curVol;
           centroid_vector += (v0 + v1 + v2) * curVol;
-
-          VectorType n = VectorType::cross_product(v1 - v0, v2 - v0);
-          for(int z = 0; z < 3; z++)
-          {
-            centroid_vector_squared[z] += n[z] *
-              (((v0[z] + v1[z]) * (v0[z] + v1[z])) +
-               ((v1[z] + v2[z]) * (v1[z] + v2[z])) +
-               ((v2[z] + v0[z]) * (v2[z] + v0[z])));
-          }
         }
       }
 
       volume /= 6.;
-      // SLIC_INFO("volume is " << volume);
-      double tempVol =
-        (volume != 0.0) ? (24.0 * volume) : axom::primal::PRIMAL_TINY;
-      centroid_vector /= tempVol;
-      centroid = centroid_vector + origin;
-      printf("PolyClipper's centroid point is \t (%f, %f, %f)\n",
-             centroid[0],
-             centroid[1],
-             centroid[2]);
 
-      centroid_vector_squared /=
-        (volume != 0.0) ? (tempVol * 2.0) : axom::primal::PRIMAL_TINY;
-      centroid_point_squared = centroid_vector_squared + origin;
-      printf("Nurnberg's centroid point is \t\t (%f, %f, %f)\n\n",
-             centroid_point_squared[0],
-             centroid_point_squared[1],
-             centroid_point_squared[2]);
+      centroid_vector /=
+        (volume != 0.0) ? (24.0 * volume) : axom::primal::PRIMAL_TINY;
+      centroid = centroid_vector + origin;
     }
   }
 

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -529,7 +529,8 @@ public:
     }
 
     // Computes the signed volume of tetrahedra formed from vertices of the
-    // Polyhedron faces and an arbitrary origin (the first vertex)
+    // Polyhedron faces and an arbitrary origin (the first vertex), as well
+    // as the centroid of the Polyhedron.
     else
     {
       SLIC_CHECK_MSG(

--- a/src/axom/primal/geometry/Polyhedron.hpp
+++ b/src/axom/primal/geometry/Polyhedron.hpp
@@ -508,6 +508,8 @@ public:
    *
    * \param [out] volume The volume of the polyhedron (0th moment)
    * \param [out] centroid The centroid of the polyhedron (1st moment)
+   * \param [in]  should_compute_centroid If true, computes the centroid
+   *              of the polyhedron. Default is true.
    *
    * \note Function is based off moments() in Mike Owen's PolyClipper.
    *
@@ -517,7 +519,9 @@ public:
    * \sa centroid()
    */
   AXOM_HOST_DEVICE
-  void moments(double& volume, PointType& centroid) const
+  void moments(double& volume,
+               PointType& centroid,
+               bool should_compute_centroid = true) const
   {
     volume = 0.0;
 
@@ -559,15 +563,21 @@ public:
           double curVol = VectorType::scalar_triple_product(v0, v1, v2);
 
           volume += curVol;
-          centroid_vector += (v0 + v1 + v2) * curVol;
+          if(should_compute_centroid)
+          {
+            centroid_vector += (v0 + v1 + v2) * curVol;
+          }
         }
       }
 
       volume /= 6.;
 
-      centroid_vector /=
-        (volume != 0.0) ? (24.0 * volume) : axom::primal::PRIMAL_TINY;
-      centroid = centroid_vector + origin;
+      if(should_compute_centroid)
+      {
+        centroid_vector /=
+          (volume != 0.0) ? (24.0 * volume) : axom::primal::PRIMAL_TINY;
+        centroid = centroid_vector + origin;
+      }
     }
   }
 
@@ -585,7 +595,7 @@ public:
   {
     double volume;
     PointType centroid;
-    moments(volume, centroid);
+    moments(volume, centroid, false);
     return volume;
   }
 

--- a/src/axom/primal/tests/primal_polyhedron.cpp
+++ b/src/axom/primal/tests/primal_polyhedron.cpp
@@ -395,7 +395,7 @@ TEST(primal_polyhedron, polyhedron_decomposition)
   poly.addNeighbors(poly[7], {4, 6, 3});
 
   // Hex center (hc)
-  PointType hc = poly.centroid();
+  PointType hc = poly.vertexMean();
 
   //Face means (fm)
   PointType fm1 = PointType::midpoint(PointType::midpoint(poly[0], poly[1]),

--- a/src/axom/primal/tests/primal_polyhedron.cpp
+++ b/src/axom/primal/tests/primal_polyhedron.cpp
@@ -835,7 +835,7 @@ TEST(primal_polyhedron, polyhedron_moments)
   using PolyhedronType = primal::Polyhedron<double, 3>;
   using TransformMatrix = axom::numerics::Matrix<double>;
 
-  constexpr double EPS = 1e-10;
+  double EPS = 1e-10;
 
   // Rolling volume and centroid
   double volume;
@@ -873,10 +873,10 @@ TEST(primal_polyhedron, polyhedron_moments)
   EXPECT_NEAR(0.25, centroid[2], EPS);
 
   // lambda to generate an affine transformation matrix for 3D points
-  auto generateTransformMatrix3D = [](const PointType& scale,
-                                      const PointType& translate,
-                                      const VectorType& axis,
-                                      double angle) {
+  auto generateTransformMatrix3D = [&EPS](const PointType& scale,
+                                          const PointType& translate,
+                                          const VectorType& axis,
+                                          double angle) {
     // create scaling matrix
     auto sc_matx = TransformMatrix::identity(4);
     {
@@ -948,8 +948,8 @@ TEST(primal_polyhedron, polyhedron_moments)
   };
 
   // lambda to transform the polyhedron
-  auto transformedPolyhedron = [transformPoint](const PolyhedronType& poly,
-                                                const TransformMatrix& matx) {
+  auto transformedPolyhedron = [&transformPoint](const PolyhedronType& poly,
+                                                 const TransformMatrix& matx) {
     PolyhedronType xformed;
     for(int i = 0; i < poly.numVertices(); ++i)
     {

--- a/src/axom/primal/tests/primal_polyhedron.cpp
+++ b/src/axom/primal/tests/primal_polyhedron.cpp
@@ -312,7 +312,7 @@ void check_volume()
   using PolyhedronType = primal::Polyhedron<double, DIM>;
   using PointType = primal::Point<double, 3>;
 
-  constexpr double EPS = 1e-4;
+  constexpr double EPS = 1e-10;
 
   // Get ids of necessary allocators
   const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();


### PR DESCRIPTION
This PR:
- Changes `Polyhedron::centroid()` function to return center of mass of the polyhedron.
- Adds `Polyhedron::vertexMean()`, returns average of polyhedron's vertices (previous `centroid` functionality).
- Adds `Polyhedron::moments()`, returns the volume and centroid of the polyhedron, the 0th and 1st moments respectively.
  - Based on PolyClipper's [moments ](https://github.com/LLNL/PolyClipper/blob/3091a15aba5ad685afdaf19016a79673b58308da/src/polyclipper3dImpl.hh#L183-L231)function. 
  - `centroid()` and `signedVolume()` delegate to `moments()`.

Resolves #1348 