### PR TITLE
Replace `std::random_shuffle` with `std::shuffle`

### DIFF
--- a/src/axom/sidre/examples/sidre_stressgroups.cpp
+++ b/src/axom/sidre/examples/sidre_stressgroups.cpp
@@ -11,6 +11,7 @@
 #include "axom/sidre.hpp"
 
 #include <algorithm>
+#include <random>
 #include <set>
 
 using axom::sidre::DataStore;
@@ -77,7 +78,9 @@ int main(int argc, char* argv[])
        names[i] = sstr.str();;
     }
  */
-  std::random_shuffle(names.begin(), names.end());
+  std::random_device rd;
+  std::mt19937 g(rd());
+  std::shuffle(names.begin(), names.end(), g);
 
   axom::utilities::Timer create_timer(true);
   for(size_t i = 0; i < num_groups; ++i)
@@ -87,7 +90,7 @@ int main(int argc, char* argv[])
   create_timer.stop();
   std::cout << "Create time " << create_timer.elapsed() << ".\n";
 
-  std::random_shuffle(names.begin(), names.end());
+  std::shuffle(names.begin(), names.end(), g);
 
   axom::utilities::Timer query_timer(true);
   for(size_t i = 0; i < num_groups; ++i)
@@ -100,7 +103,7 @@ int main(int argc, char* argv[])
   query_timer.stop();
   std::cout << "Query time " << query_timer.elapsed() << ".\n";
 
-  std::random_shuffle(names.begin(), names.end());
+  std::shuffle(names.begin(), names.end(), g);
 
   axom::utilities::Timer destroy_timer(true);
   for(size_t i = 0; i < num_groups; ++i)
@@ -117,7 +120,7 @@ int main(int argc, char* argv[])
     int num_shuffles = num_groups / 100;
     for(int j = 0; j < num_shuffles; ++j)
     {
-      std::random_shuffle(names.begin(), names.end());
+      std::shuffle(names.begin(), names.end(), g);
 
       mixed_timer.start();
       for(int i = 0; i < 100; ++i)


### PR DESCRIPTION
# Summary

- This PR is a refactor
- It replaces std::random_shuffle, which has been removed in c++17, with std::shuffle

Resolves https://github.com/LLNL/axom/issues/1000