### PR TITLE
Fix bug crashing MarchingCubes.

### DIFF
--- a/src/axom/quest/MarchingCubes.cpp
+++ b/src/axom/quest/MarchingCubes.cpp
@@ -86,6 +86,10 @@ void MarchingCubes::setMesh(const conduit::Node& bpMesh,
     const auto& dom = bpMesh.child(d);
     m_singles[d]->setDomain(dom, m_topologyName, maskField);
   }
+  for(int d = newDomainCount; d < m_singles.size(); ++d)
+  {
+    m_singles[d]->getImpl().clearDomain();
+  }
 
   m_domainCount = newDomainCount;
 }
@@ -94,9 +98,9 @@ void MarchingCubes::setFunctionField(const std::string& fcnField)
 {
   m_fcnFieldName = fcnField;
   m_fcnPath = "fields/" + fcnField;
-  for(auto& s : m_singles)
+  for(axom::IndexType d = 0; d < m_domainCount; ++d)
   {
-    s->setFunctionField(fcnField);
+    m_singles[d]->setFunctionField(fcnField);
   }
 }
 
@@ -107,7 +111,7 @@ void MarchingCubes::computeIsocontour(double contourVal)
   // Mark and scan domains while adding up their
   // facet counts to get the total facet counts.
   m_facetIndexOffsets.resize(m_singles.size());
-  for(axom::IndexType d = 0; d < m_singles.size(); ++d)
+  for(axom::IndexType d = 0; d < m_domainCount; ++d)
   {
     auto& single = *m_singles[d];
     single.setContourValue(contourVal);
@@ -123,7 +127,7 @@ void MarchingCubes::computeIsocontour(double contourVal)
   auto facetNodeIdsView = m_facetNodeIds.view();
   auto facetNodeCoordsView = m_facetNodeCoords.view();
   auto facetParentIdsView = m_facetParentIds.view();
-  for(axom::IndexType d = 0; d < m_singles.size(); ++d)
+  for(axom::IndexType d = 0; d < m_domainCount; ++d)
   {
     m_singles[d]->getImpl().setOutputBuffers(facetNodeIdsView,
                                              facetNodeCoordsView,
@@ -131,16 +135,16 @@ void MarchingCubes::computeIsocontour(double contourVal)
                                              m_facetIndexOffsets[d]);
   }
 
-  for(axom::IndexType d = 0; d < m_singles.size(); ++d)
+  for(axom::IndexType d = 0; d < m_domainCount; ++d)
   {
     m_singles[d]->computeFacets();
   }
 
-  for(axom::IndexType d = 0; d < m_singles.size(); ++d)
+  for(axom::IndexType d = 0; d < m_domainCount; ++d)
   {
     const auto domainId = m_singles[d]->getDomainId(d);
     const auto domainFacetCount =
-      (d < m_singles.size() - 1 ? m_facetIndexOffsets[d + 1] : m_facetCount) -
+      (d < m_domainCount - 1 ? m_facetIndexOffsets[d + 1] : m_facetCount) -
       m_facetIndexOffsets[d];
     m_facetDomainIds.fill(domainId, domainFacetCount, m_facetIndexOffsets[d]);
   }
@@ -149,7 +153,7 @@ void MarchingCubes::computeIsocontour(double contourVal)
 axom::IndexType MarchingCubes::getContourNodeCount() const
 {
   axom::IndexType contourNodeCount =
-    m_singles.empty() ? 0 : m_facetCount * m_singles[0]->spatialDimension();
+    !m_domainCount ? 0 : m_facetCount * m_singles[0]->spatialDimension();
   return contourNodeCount;
 }
 

--- a/src/axom/quest/MarchingCubes.cpp
+++ b/src/axom/quest/MarchingCubes.cpp
@@ -56,8 +56,6 @@ void MarchingCubes::setMesh(const conduit::Node& bpMesh,
     conduit::blueprint::mesh::is_multi_domain(bpMesh),
     "MarchingCubes class input mesh must be in multidomain format.");
 
-  clearMesh();
-
   m_topologyName = topologyName;
   m_maskFieldName = maskField;
 
@@ -155,18 +153,6 @@ axom::IndexType MarchingCubes::getContourNodeCount() const
   axom::IndexType contourNodeCount =
     !m_domainCount ? 0 : m_facetCount * m_singles[0]->spatialDimension();
   return contourNodeCount;
-}
-
-void MarchingCubes::clearMesh()
-{
-  for(int d = 0; d < m_singles.size(); ++d)
-  {
-    m_singles[d]->getImpl().clearDomain();
-  }
-  m_domainCount = 0;
-  m_facetNodeIds.clear();
-  m_facetNodeCoords.clear();
-  m_facetParentIds.clear();
 }
 
 void MarchingCubes::clearOutput()

--- a/src/axom/quest/MarchingCubes.cpp
+++ b/src/axom/quest/MarchingCubes.cpp
@@ -151,7 +151,7 @@ void MarchingCubes::computeIsocontour(double contourVal)
 axom::IndexType MarchingCubes::getContourNodeCount() const
 {
   axom::IndexType contourNodeCount =
-    !m_domainCount ? 0 : m_facetCount * m_singles[0]->spatialDimension();
+    (m_domainCount > 0) ? m_facetCount * m_singles[0]->spatialDimension() : 0;
   return contourNodeCount;
 }
 

--- a/src/axom/quest/MarchingCubes.hpp
+++ b/src/axom/quest/MarchingCubes.hpp
@@ -137,8 +137,6 @@ public:
 
     Some metadata from \a bpMesh may be cached.  Any change to it
     after setMesh() leads to undefined behavior.
-
-    @see clearMesh()
   */
   void setMesh(const conduit::Node &bpMesh,
                const std::string &topologyName,
@@ -275,19 +273,6 @@ public:
     facetDomainIds.swap(m_facetDomainIds);
   }
   //@}
-
-  /*!
-    @brief Clear the input mesh data.
-
-    The contour mesh is *not* cleared.  See clearOutput() for this.
-
-    After clearing, you have to call setMesh() as if it was a new
-    object.
-
-    @internal For good GPU performance, memory is not deallocated.  To
-    really deallocate memory, destruct this object and use another.
-  */
-  void clearMesh();
 
   /*!
     @brief Clear the computed contour mesh.


### PR DESCRIPTION
The bug was triggered when generating the contour from multiple meshes (such as SAMR levels), and the number of domains decrease.  When this happens, the memory-use optimization leaves all single-domain objects, but keeps track of the count separately.  Loops through domains should use the separately maintained count, not the number of items allocated.
