### PR TITLE
Suppress compiler warnings: calling host func from host-device func

### DIFF
--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -1440,6 +1440,7 @@ AXOM_HOST_DEVICE inline void Array<T, DIM, SPACE>::push_back(T&& value)
 }
 
 //------------------------------------------------------------------------------
+AXOM_SUPPRESS_HD_WARN
 template <typename T, int DIM, MemorySpace SPACE>
 template <typename... Args>
 AXOM_HOST_DEVICE inline void Array<T, DIM, SPACE>::emplace_back(Args&&... args)

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -158,6 +158,7 @@ public:
   constexpr static int Dims = DIM;
 
   //! @brief Construct row-major, unitnitialized array.
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE ArrayBase() : m_shape(), m_mapping(ArrayStrideOrder::ROW)
   {
     updateStrides();
@@ -170,6 +171,7 @@ public:
    * \param [in] min_stride The minimum stride between two consecutive
    *  elements in row-major order.
    */
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE ArrayBase(const StackArray<IndexType, DIM>& shape,
                              int min_stride = 1)
     : m_shape {shape}
@@ -188,6 +190,7 @@ public:
    * The object is constructed with the given shape,
    * not the partial shape information in \c mapping.
    */
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE ArrayBase(const StackArray<IndexType, DIM>& shape,
                              const MDMapping<DIM>& mapping)
     : m_shape {shape}
@@ -388,6 +391,7 @@ protected:
   }
 
   /// \brief Set the shape and stride
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE void setShapeAndStride(const StackArray<IndexType, DIM>& shape,
                                           const StackArray<IndexType, DIM>& stride)
   {
@@ -631,6 +635,7 @@ public:
   }
 
   /// \brief Returns the multidimensional mapping for the Array
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE MDMapping<1> mapping() const
   {
     return MDMapping<1> {{m_stride}};

--- a/src/axom/core/ArrayView.hpp
+++ b/src/axom/core/ArrayView.hpp
@@ -387,6 +387,7 @@ ArrayView<T, DIM, SPACE>::ArrayView(
 }
 
 //------------------------------------------------------------------------------
+AXOM_SUPPRESS_HD_WARN
 template <typename T, int DIM, MemorySpace SPACE>
 AXOM_HOST_DEVICE ArrayView<T, DIM, SPACE> ArrayView<T, DIM, SPACE>::subspan(
   const StackArray<IndexType, DIM>& offsets,

--- a/src/axom/core/IteratorBase.hpp
+++ b/src/axom/core/IteratorBase.hpp
@@ -63,7 +63,8 @@ private:
   struct accessor : IterType
   {
     AXOM_HOST_DEVICE accessor(const IterType& base) : IterType(base) { }
-
+   
+    AXOM_SUPPRESS_HD_WARN
     AXOM_HOST_DEVICE
     static void adv(IterType& instance, PosType n)
     {
@@ -126,6 +127,7 @@ public:
   /// \{
 
   /// Pre-increment operator
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE
   IterType& operator++()
   {

--- a/src/axom/core/MDMapping.hpp
+++ b/src/axom/core/MDMapping.hpp
@@ -11,6 +11,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <type_traits>
 
 namespace axom
 {
@@ -219,6 +220,7 @@ public:
     @param [i] strides Strides.  Values must be unique.
       If not unique, use one of the other initializers.
   */
+  AXOM_SUPPRESS_HD_WARN
   inline AXOM_HOST_DEVICE void initializeStrides(
     const axom::StackArray<T, DIM>& strides)
   {
@@ -253,6 +255,7 @@ public:
       ArrayStrideOrder::COLUMN, to use where strides
       are non-unique.
   */
+  AXOM_SUPPRESS_HD_WARN
   inline AXOM_HOST_DEVICE void initializeStrides(
     const axom::StackArray<T, DIM>& strides,
     ArrayStrideOrder orderPref)

--- a/src/axom/core/tests/core_openmp_map.hpp
+++ b/src/axom/core/tests/core_openmp_map.hpp
@@ -32,7 +32,7 @@ void test_storage(experimental::Map<Key, T, Hash, Policy> &test)
   axom::for_all<Policy>(
     0,
     test.max_size(),
-    AXOM_LAMBDA(IndexType idx) {
+    [=](IndexType idx) {
       Key key = idx;
       T value = key * 27;
       auto ret_test = test2->insert(key, value);
@@ -42,7 +42,7 @@ void test_storage(experimental::Map<Key, T, Hash, Policy> &test)
   axom::for_all<Policy>(
     0,
     test.max_size(),
-    AXOM_LAMBDA(IndexType idx) {
+    [=](IndexType idx) {
       Key key = idx;
       EXPECT_EQ(key * 27, test2->find(key).value);
     });
@@ -58,7 +58,7 @@ void test_subscript(experimental::Map<Key, T, Hash, Policy> &test)
   axom::for_all<Policy>(
     0,
     test.size(),
-    AXOM_LAMBDA(IndexType idx) {
+    [=](IndexType idx) {
       Key key = idx;
       EXPECT_EQ(key * 27, (*test2)[key]);
     });
@@ -71,7 +71,7 @@ void test_insert_assign(experimental::Map<Key, T, Hash, Policy> &test)
   axom::for_all<Policy>(
     0,
     test.max_size(),
-    AXOM_LAMBDA(IndexType idx) {
+    [=](IndexType idx) {
       Key key = idx;
       T value = key * 27;
       auto ret_test = test2->insert_or_assign(key, value);
@@ -82,7 +82,7 @@ void test_insert_assign(experimental::Map<Key, T, Hash, Policy> &test)
   axom::for_all<Policy>(
     0,
     test.max_size(),
-    AXOM_LAMBDA(IndexType idx) {
+    [=](IndexType idx) {
       Key key = idx;
       EXPECT_EQ(key * 27, test2->find(key).value);
     });
@@ -90,7 +90,7 @@ void test_insert_assign(experimental::Map<Key, T, Hash, Policy> &test)
   axom::for_all<Policy>(
     0,
     test.max_size(),
-    AXOM_LAMBDA(IndexType idx) {
+    [=](IndexType idx) {
       Key key = idx;
       T value = key * 28;
       auto ret_test = test2->insert_or_assign(key, value);
@@ -102,7 +102,7 @@ void test_insert_assign(experimental::Map<Key, T, Hash, Policy> &test)
   axom::for_all<Policy>(
     0,
     test.max_size(),
-    AXOM_LAMBDA(IndexType idx) {
+    [=](IndexType idx) {
       Key key = idx;
       EXPECT_EQ(key * 28, test2->find(key).value);
     });
@@ -117,7 +117,7 @@ void test_remove(experimental::Map<Key, T, Hash, Policy> &test)
   axom::for_all<Policy>(
     0,
     to_erase,
-    AXOM_LAMBDA(IndexType idx) {
+    [=](IndexType idx) {
       Key key = (Key)idx;
       bool erased = test2->erase(key);
       EXPECT_EQ(erased, true);
@@ -140,7 +140,7 @@ void test_rehash(experimental::Map<Key, T, Hash, Policy> &test, int num, int fac
   axom::for_all<Policy>(
     0,
     original_size,
-    AXOM_LAMBDA(IndexType idx) {
+    [=](IndexType idx) {
       Key key = idx;
       EXPECT_EQ(key * 27, test2->find(key).value);
     });
@@ -148,7 +148,7 @@ void test_rehash(experimental::Map<Key, T, Hash, Policy> &test, int num, int fac
   axom::for_all<Policy>(
     original_size,
     test.max_size(),
-    AXOM_LAMBDA(IndexType idx) {
+    [=](IndexType idx) {
       Key key = idx;
       T value = key * 27;
       auto ret_test = test2->insert(key, value);
@@ -158,7 +158,7 @@ void test_rehash(experimental::Map<Key, T, Hash, Policy> &test, int num, int fac
   axom::for_all<Policy>(
     original_size,
     test.max_size(),
-    AXOM_LAMBDA(IndexType idx) {
+    [=](IndexType idx) {
       Key key = idx;
       EXPECT_EQ(key * 27, test2->find(key).value);
     });

--- a/src/axom/core/utilities/Utilities.hpp
+++ b/src/axom/core/utilities/Utilities.hpp
@@ -354,6 +354,7 @@ inline AXOM_HOST_DEVICE bool isNearlyEqualRelative(RealType a,
  * \param [in] cmp The comparator to use for comparing elements; "less than"
  *  by default.
  */
+AXOM_SUPPRESS_HD_WARN
 template <typename DataType, typename Predicate = std::less<DataType>>
 inline AXOM_HOST_DEVICE void insertionSort(DataType* array,
                                            IndexType n,

--- a/src/axom/multimat/mmsubfield.hpp
+++ b/src/axom/multimat/mmsubfield.hpp
@@ -33,6 +33,7 @@ public:
   MMSubField2D() : SubMapType(), m_superfield(nullptr), firstSetIndex(-1) {};
 
   // Constructor
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE MMSubField2D(Field2DType* superfield,
                                 int firstIndex,
                                 bool indicesHaveIndirection = true)

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -1609,6 +1609,7 @@ inline bool intervalsDisjoint(double d0, double d1, double d2, double r)
   return d1 < -r || d0 > r;
 }
 
+AXOM_SUPPRESS_HD_WARN
 template <typename T>
 AXOM_HOST_DEVICE bool intersect_plane_tet3d(const Plane<T, 3>& p,
                                             const Tetrahedron<T, 3>& tet,

--- a/src/axom/quest/examples/quest_bvh_two_pass.cpp
+++ b/src/axom/quest/examples/quest_bvh_two_pass.cpp
@@ -176,6 +176,7 @@ void find_collisions_broadphase(const mint::Mesh* mesh,
   // First pass: get number of bounding box collisions for each surface element
   axom::for_all<ExecSpace>(
     ncells,
+    AXOM_SUPPRESS_HD_WARN
     AXOM_LAMBDA(IndexType icell) {
       IndexType count = 0;
 

--- a/src/axom/slam/BivariateMap.hpp
+++ b/src/axom/slam/BivariateMap.hpp
@@ -327,6 +327,7 @@ public:
     return ConstSubMapType(this, s, hasInd);
   }
 
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE SubMapType operator()(SetPosition firstIdx)
   {
 #ifndef AXOM_DEVICE_CODE
@@ -480,31 +481,44 @@ protected:
 
 public:
   /** BivariateMap iterator functions */
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE iterator begin() { return iterator(this, 0); }
+
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE iterator end()
   {
     return iterator(this, totalSize() * numComp());
   }
+
   AXOM_HOST_DEVICE const_iterator begin() const
   {
     return const_iterator(this, 0);
   }
+
   AXOM_HOST_DEVICE const_iterator end() const
   {
     return const_iterator(this, totalSize() * numComp());
   }
+
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE range_iterator set_begin()
   {
     return range_iterator(this, 0);
   }
+
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE range_iterator set_end()
   {
     return range_iterator(this, totalSize());
   }
+
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE const_range_iterator set_begin() const
   {
     return const_range_iterator(this, 0);
   }
+
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE const_range_iterator set_end() const
   {
     return const_range_iterator(this, totalSize());
@@ -512,35 +526,45 @@ public:
 
   /** Iterator via Submap */
   AXOM_HOST_DEVICE SubMapIterator begin(int i) { return (*this)(i).begin(); }
+
   AXOM_HOST_DEVICE SubMapIterator end(int i) { return (*this)(i).end(); }
+
   AXOM_HOST_DEVICE ConstSubMapIterator begin(int i) const
   {
     return (*this)(i).begin();
   }
+
   AXOM_HOST_DEVICE ConstSubMapIterator end(int i) const
   {
     return (*this)(i).end();
   }
+
   AXOM_HOST_DEVICE SubMapRangeIterator set_begin(int i)
   {
     return (*this)(i).set_begin();
   }
+
   AXOM_HOST_DEVICE SubMapRangeIterator set_end(int i)
   {
     return (*this)(i).set_end();
   }
+
   AXOM_HOST_DEVICE ConstSubMapRangeIterator set_begin(int i) const
   {
     return (*this)(i).set_begin();
   }
+
   AXOM_HOST_DEVICE ConstSubMapRangeIterator set_end(int i) const
   {
     return (*this)(i).set_end();
   }
 
 public:
+
   AXOM_HOST_DEVICE const BivariateSetType* set() const { return m_bset.get(); }
+
   const MapType* getMap() const { return &m_map; }
+
   MapType* getMap() { return &m_map; }
 
   bool isValid(bool verboseOutput = false) const
@@ -553,18 +577,23 @@ public:
   ///
 
   /** \brief Returns the BivariateSet size. */
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE SetPosition size() const { return set()->size(); }
+
   /** \brief Returns the BivariateSet size. */
   SetPosition totalSize() const { return set()->size(); }
 
   SetPosition firstSetSize() const { return set()->firstSetSize(); }
+
   AXOM_HOST_DEVICE SetPosition secondSetSize() const
   {
     return set()->secondSetSize();
   }
+
   /** \brief Returns the number of the BivariateSet ordered pairs with
    *         the given first set index. */
   SetPosition size(SetPosition s) const { return set()->size(s); }
+
   /** \brief Return the number of components of the map  */
   SetPosition numComp() const { return StrPol::stride(); }
 
@@ -663,6 +692,7 @@ public:
   /**
      * \brief Returns the current map element pointed to by the iterator.
      */
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE DataRefType operator*() const
   {
     return m_map->flatValue(m_bsetIterator.flatIndex(), compIndex());
@@ -685,9 +715,11 @@ public:
   PositionType compIndex() const { return this->m_pos % numComp(); }
 
   /** \brief Returns the number of components per element in the map. */
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE PositionType numComp() const { return m_map->numComp(); }
 
 protected:
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE void advance(IndexType n)
   {
     this->m_pos += n;
@@ -763,6 +795,7 @@ public:
    * \pre `sizeof(compIdx) == StridePolicy::NumDims`
    * \pre `0 <= compIdx[idim] < shape()[idim]`
    */
+  AXOM_SUPPRESS_HD_WARN
   template <typename... ComponentIndex>
   AXOM_HOST_DEVICE DataRefType operator()(ComponentIndex... comp_idx) const
   {
@@ -802,6 +835,7 @@ public:
   PositionType numComp() const { return m_map->numComp(); }
 
 protected:
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE void advance(IndexType n)
   {
     this->m_pos += n;

--- a/src/axom/slam/BivariateSet.hpp
+++ b/src/axom/slam/BivariateSet.hpp
@@ -213,7 +213,9 @@ public:
   {
     return getSize<FirstSetType>(m_set1);
   }
+
   /** \brief Size of the second set.   */
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE inline PositionType secondSetSize() const
   {
     return getSize<SecondSetType>(m_set2);
@@ -221,6 +223,7 @@ public:
 
   /** \brief Returns pointer to the first set.   */
   const FirstSetType* getFirstSet() const { return m_set1; }
+
   /** \brief Returns pointer to the second set.   */
   const SecondSetType* getSecondSet() const { return m_set2; }
 
@@ -253,6 +256,7 @@ public:
 private:
   virtual void verifyPosition(PositionType s1, PositionType s2) const = 0;
 
+  AXOM_SUPPRESS_HD_WARN
   template <typename SetType>
   AXOM_HOST_DEVICE
     typename std::enable_if<std::is_abstract<SetType>::value, PositionType>::type
@@ -371,6 +375,7 @@ public:
     return PositionType();
   }
 
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE PositionType findElementFlatIndex(PositionType s1,
                                                      PositionType s2) const override
   {
@@ -393,6 +398,7 @@ public:
     return PositionType();
   }
 
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE RangeSetType elementRangeSet(PositionType) const override
   {
     return RangeSetType();

--- a/src/axom/slam/Map.hpp
+++ b/src/axom/slam/Map.hpp
@@ -374,6 +374,7 @@ public:
    *
    * The total storage size for the map's values is `size() * numComp()`
    */
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE SetPosition size() const
   {
     return !policies::EmptySetTraits<SetType>::isEmpty(m_set.get())
@@ -654,6 +655,7 @@ public:
 
   protected:
     /** Implementation of advance() as required by IteratorBase */
+    AXOM_SUPPRESS_HD_WARN
     AXOM_HOST_DEVICE void advance(PositionType n)
     {
       this->m_pos += n;

--- a/src/axom/slam/MapBase.hpp
+++ b/src/axom/slam/MapBase.hpp
@@ -39,6 +39,7 @@ public:
   using SetPosition = SetPositionType;
 
 public:
+  AXOM_HOST_DEVICE
   virtual ~MapBase() {};
 
   /**

--- a/src/axom/slam/OrderedSet.hpp
+++ b/src/axom/slam/OrderedSet.hpp
@@ -406,9 +406,11 @@ public:
 
   protected:
     /** Implementation of advance() as required by IteratorBase */
+    AXOM_SUPPRESS_HD_WARN
     AXOM_HOST_DEVICE void advance(PositionType n) { m_pos += n * stride(); }
 
   private:
+    AXOM_SUPPRESS_HD_WARN
     AXOM_HOST_DEVICE inline const PositionType stride() const
     {
       return m_orderedSet.StrideType::stride();
@@ -480,6 +482,8 @@ public:
   {
     return SizePolicyType::size();
   }
+  
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE inline bool empty() const { return SizePolicyType::empty(); }
 
   bool isValid(bool verboseOutput = false) const;

--- a/src/axom/slam/RelationSet.hpp
+++ b/src/axom/slam/RelationSet.hpp
@@ -179,6 +179,7 @@ public:
    *
    * \return pos2  The to-set index.
    */
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE PositionType flatToSecondIndex(PositionType flatIndex) const
   {
     if(flatIndex < 0 || flatIndex > size())
@@ -221,6 +222,7 @@ public:
    */
   SubsetType getElements(PositionType s1) const { return (*m_relation)[s1]; }
 
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE ElementType at(PositionType pos) const
   {
 #ifndef AXOM_DEVICE_CODE
@@ -280,6 +282,7 @@ public:
   //but still implemented due to the function being virtual
   //(and can be called from base ptr)
   // KW -- made this public to use from BivariateMap
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE PositionType size() const
   {
     return PositionType(m_relation->relationData().size());

--- a/src/axom/slam/SubMap.hpp
+++ b/src/axom/slam/SubMap.hpp
@@ -123,6 +123,7 @@ public:
    *         element, where `setIndex = i * numComp() + j`.
    * \pre    0 <= idx < size() * numComp()
    */
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE DataRefType operator[](IndexType idx) const
   {
 #ifndef AXOM_DEVICE_CODE
@@ -170,6 +171,7 @@ public:
   /**
    * \brief Return the set element in the SuperMap at the given subset index
    */
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE IndexType index(IndexType idx) const
   {
     return m_indicesHaveIndirection ? m_superMap->set()->at(m_subsetIdx[idx])
@@ -183,6 +185,7 @@ public:
   ///
 
   /** \brief returns the size of the SubMap  */
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE axom::IndexType size() const { return m_subsetIdx.size(); }
 
   /** \brief returns the number of components (aka. stride) of the SubMap  */
@@ -475,6 +478,8 @@ public:
   }
 
 public:
+
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE RangeIterator(PositionType pos, SubMap sMap)
     : IterBase(pos)
     , m_submap(sMap)
@@ -491,6 +496,8 @@ public:
   {
     return m_mapIter(comp_idx...);
   }
+
+  AXOM_SUPPRESS_HD_WARN
   template <typename... ComponentIndex>
   AXOM_HOST_DEVICE DataRefType value(ComponentIndex... comp_idx) const
   {
@@ -515,7 +522,9 @@ public:
   PositionType numComp() const { return m_mapIter.numComp(); }
 
 protected:
+
   /** Implementation of advance() as required by IteratorBase */
+  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE void advance(PositionType n)
   {
     PositionType currIndex = m_mapIter.flatIndex();

--- a/src/axom/slam/policies/IndirectionPolicies.hpp
+++ b/src/axom/slam/policies/IndirectionPolicies.hpp
@@ -90,6 +90,7 @@ struct IndexedIndirection : public BasePolicy
     return buf[pos];
   }
 
+  AXOM_SUPPRESS_HD_WARN
   template <bool DeviceEnable = BasePolicy::DeviceAccessible>
   AXOM_HOST_DEVICE static inline std::enable_if_t<!DeviceEnable, IndirectionResult>
   getIndirection(IndirectionRefType buf, PositionType pos)
@@ -111,6 +112,7 @@ struct IndexedIndirection : public BasePolicy
     return buf[pos];
   }
 
+  AXOM_SUPPRESS_HD_WARN
   template <bool DeviceEnable = BasePolicy::DeviceAccessible>
   AXOM_HOST_DEVICE static inline std::enable_if_t<!DeviceEnable, ConstIndirectionResult>
   getConstIndirection(IndirectionConstRefType buf, PositionType pos)

--- a/src/axom/spin/UniformGrid.hpp
+++ b/src/axom/spin/UniformGrid.hpp
@@ -336,6 +336,7 @@ public:
     return sumOfBinSizes;
   }
 
+  AXOM_SUPPRESS_HD_WARN
   template <typename Func>
   AXOM_HOST_DEVICE void visitCandidates(const BoxType& bbox, Func&& evalFn) const
   {


### PR DESCRIPTION
# Summary

- This PR suppresses a bunch of compiler warnings about calling a ``__host__`` function from a ``__host__ __device__`` function.
- There are many other warnings that will require some thought and code refactoring to squash. 