### PR TITLE
Fix `/style` functionality

### DIFF
--- a/.github/actions/apply-style/entrypoint.sh
+++ b/.github/actions/apply-style/entrypoint.sh
@@ -56,7 +56,7 @@ git checkout $branch
 git submodule update --init --recursive
 
 mkdir build && cd build 
-cmake $CMAKE_ARGS ..
+cmake $CMAKE_ARGS ../src
 make style
 cd ..
 

--- a/.mailmap
+++ b/.mailmap
@@ -25,6 +25,7 @@ Cyrus D. Harrison <harrison37@llnl.gov>         Cyrus <cyrush@llnl.gov>
 Daniel Taller <taller1@llnl.gov>                Danny Taller <66029857+dtaller@users.noreply.github.com>
 Esteban Pauli <pauli2@llnl.gov>                 Esteban Pauli <40901502+estebanpauli@users.noreply.github.com>
 Evan Taylor Desantola <desantola1@llnl.gov>     Evan Taylor DeSantola <desantola1@llnl.gov>
+format-robot <no-reply@llnl.gov>                format-robot <axom-dev@llnl.gov>
 George Zagaris <zagaris2@llnl.gov>              George Zagaris <george.zagaris@gmail.com>
 Jacob Spainhour <Jacob.Spainhour@colorado.edu>  jcs15c <Jacob.Spainhour@colorado.edu>
 Jacob Spainhour <Jacob.Spainhour@colorado.edu>  Jacob Spainhour <jcs15c@my.fsu.edu>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,6 +129,8 @@ if(AXOM_ENABLE_CUDA AND ${CMAKE_VERSION} VERSION_LESS 3.18.0)
     message(FATAL_ERROR "Axom requires CMake version 3.18.0+ when CUDA is enabled.")
 endif()
 
+axom_add_code_checks()
+
 #------------------------------------------------------------------------------
 # Add source directories
 #------------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,6 +129,11 @@ if(AXOM_ENABLE_CUDA AND ${CMAKE_VERSION} VERSION_LESS 3.18.0)
     message(FATAL_ERROR "Axom requires CMake version 3.18.0+ when CUDA is enabled.")
 endif()
 
+# Add extra file extensions for code styling
+# Note: Add them also to axom_add_code_checks in src/cmake/AxomMacros.cmake
+# Configured C++ files
+list(APPEND BLT_C_FILE_EXTS ".cpp.in" ".hpp.in")
+
 axom_add_code_checks()
 
 #------------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,11 +129,6 @@ if(AXOM_ENABLE_CUDA AND ${CMAKE_VERSION} VERSION_LESS 3.18.0)
     message(FATAL_ERROR "Axom requires CMake version 3.18.0+ when CUDA is enabled.")
 endif()
 
-# Add extra file extensions for code styling
-# Note: Add them also to axom_add_code_checks in src/cmake/AxomMacros.cmake
-# Configured C++ files
-list(APPEND BLT_C_FILE_EXTS ".cpp.in" ".hpp.in")
-
 axom_add_code_checks()
 
 #------------------------------------------------------------------------------

--- a/src/axom/config.hpp.in
+++ b/src/axom/config.hpp.in
@@ -40,7 +40,7 @@
 #cmakedefine AXOM_NO_INT64_T
 
 #ifndef AXOM_NO_INT64_T
-  #cmakedefine AXOM_USE_64BIT_INDEXTYPE
+#cmakedefine AXOM_USE_64BIT_INDEXTYPE
 #endif
 
 /*
@@ -87,9 +87,9 @@
  * Windows GDI geometry classes (NOGDI).
  */
 #ifdef WIN32
-  #define _USE_MATH_DEFINES
-  #define NOGDI
-  #define NOMINMAX
+#define _USE_MATH_DEFINES
+#define NOGDI
+#define NOMINMAX
 #endif
 
 /*

--- a/src/axom/config.hpp.in
+++ b/src/axom/config.hpp.in
@@ -16,12 +16,10 @@
 /*
  * Axom Version Information
  */
-// clang-format off
 #define AXOM_VERSION_MAJOR @AXOM_VERSION_MAJOR@
 #define AXOM_VERSION_MINOR @AXOM_VERSION_MINOR@
 #define AXOM_VERSION_PATCH @AXOM_VERSION_PATCH@
 #define AXOM_VERSION_FULL "@AXOM_VERSION_FULL@"
-// clang-format on
 /*NOTE: Do not add AXOM_GIT_SHA here.  This will force
  * full rebuild on all local changes. It is added in axom::getVersion()
  * and axom::about(), as well as accessible from axom::gitSha().
@@ -114,9 +112,7 @@
  * allow silently, and -1 to disallow.  Corresponds to cmake variable
  * AXOM_DEPRECATED_TYPES values of WARN, ALLOW and ERROR.
  */
-// clang-format off
 #cmakedefine AXOM_DEPRECATED_TYPES_N @AXOM_DEPRECATED_TYPES_N@
-// clang-format on
 
 /*
  * Compiler defines to configure the built-in fmt library
@@ -127,7 +123,6 @@
 /*
  * Compiler defines to configure the built-in sparsehash library
  */
-// clang-format off
 #cmakedefine SPARSEHASH_HASHFUN_HEADER @SPARSEHASH_HASHFUN_HEADER@
 #cmakedefine SPARSEHASH_HASHFUN_NAMESPACE @SPARSEHASH_HASHFUN_NAMESPACE@
 
@@ -135,6 +130,5 @@
  * Disable some MSVC warnings related to shared libraries, if applicable
  */
 @AXOM_MSVC_PRAGMAS@
-// clang-format on
 
 #endif /* AXOM_COMMON_CONFIG_HPP */

--- a/src/axom/config.hpp.in
+++ b/src/axom/config.hpp.in
@@ -16,10 +16,12 @@
 /*
  * Axom Version Information
  */
-#define AXOM_VERSION_MAJOR @AXOM_VERSION_MAJOR @
-#define AXOM_VERSION_MINOR @AXOM_VERSION_MINOR @
-#define AXOM_VERSION_PATCH @AXOM_VERSION_PATCH @
+// clang-format off
+#define AXOM_VERSION_MAJOR @AXOM_VERSION_MAJOR@
+#define AXOM_VERSION_MINOR @AXOM_VERSION_MINOR@
+#define AXOM_VERSION_PATCH @AXOM_VERSION_PATCH@
 #define AXOM_VERSION_FULL "@AXOM_VERSION_FULL@"
+// clang-format on
 /*NOTE: Do not add AXOM_GIT_SHA here.  This will force
  * full rebuild on all local changes. It is added in axom::getVersion()
  * and axom::about(), as well as accessible from axom::gitSha().
@@ -112,7 +114,9 @@
  * allow silently, and -1 to disallow.  Corresponds to cmake variable
  * AXOM_DEPRECATED_TYPES values of WARN, ALLOW and ERROR.
  */
-#cmakedefine AXOM_DEPRECATED_TYPES_N @AXOM_DEPRECATED_TYPES_N @
+// clang-format off
+#cmakedefine AXOM_DEPRECATED_TYPES_N @AXOM_DEPRECATED_TYPES_N@
+// clang-format on
 
 /*
  * Compiler defines to configure the built-in fmt library
@@ -123,12 +127,14 @@
 /*
  * Compiler defines to configure the built-in sparsehash library
  */
-#cmakedefine SPARSEHASH_HASHFUN_HEADER @SPARSEHASH_HASHFUN_HEADER @
-#cmakedefine SPARSEHASH_HASHFUN_NAMESPACE @SPARSEHASH_HASHFUN_NAMESPACE @
+// clang-format off
+#cmakedefine SPARSEHASH_HASHFUN_HEADER @SPARSEHASH_HASHFUN_HEADER@
+#cmakedefine SPARSEHASH_HASHFUN_NAMESPACE @SPARSEHASH_HASHFUN_NAMESPACE@
 
 /*
  * Disable some MSVC warnings related to shared libraries, if applicable
  */
-@AXOM_MSVC_PRAGMAS @
+@AXOM_MSVC_PRAGMAS@
+// clang-format on
 
 #endif /* AXOM_COMMON_CONFIG_HPP */

--- a/src/axom/config.hpp.in
+++ b/src/axom/config.hpp.in
@@ -13,19 +13,17 @@
  *       since it might be included from a C file
  */
 
-
 /*
  * Axom Version Information
  */
-#define AXOM_VERSION_MAJOR @AXOM_VERSION_MAJOR@
-#define AXOM_VERSION_MINOR @AXOM_VERSION_MINOR@
-#define AXOM_VERSION_PATCH @AXOM_VERSION_PATCH@
-#define AXOM_VERSION_FULL  "@AXOM_VERSION_FULL@"
+#define AXOM_VERSION_MAJOR @AXOM_VERSION_MAJOR @
+#define AXOM_VERSION_MINOR @AXOM_VERSION_MINOR @
+#define AXOM_VERSION_PATCH @AXOM_VERSION_PATCH @
+#define AXOM_VERSION_FULL "@AXOM_VERSION_FULL@"
 /*NOTE: Do not add AXOM_GIT_SHA here.  This will force
  * full rebuild on all local changes. It is added in axom::getVersion()
  * and axom::about(), as well as accessible from axom::gitSha().
  */
-
 
 /*
  * Axom source location
@@ -33,7 +31,6 @@
 #define AXOM_SRC_DIR "@AXOM_SRC_DIR@"
 #define AXOM_BIN_DIR "@AXOM_BIN_DIR@"
 #cmakedefine AXOM_DATA_DIR "@AXOM_DATA_DIR@"
-
 
 /*
  * Platform specific definitions
@@ -43,9 +40,8 @@
 #cmakedefine AXOM_NO_INT64_T
 
 #ifndef AXOM_NO_INT64_T
-#cmakedefine AXOM_USE_64BIT_INDEXTYPE
+  #cmakedefine AXOM_USE_64BIT_INDEXTYPE
 #endif
-
 
 /*
  * Compiler tests
@@ -61,7 +57,6 @@
 #cmakedefine AXOM_USE_MPI3
 #cmakedefine AXOM_USE_MPIF_HEADER
 #cmakedefine AXOM_USE_OPENMP
-
 
 /*
  * Compiler defines for libraries (built-in and third party)
@@ -92,11 +87,10 @@
  * Windows GDI geometry classes (NOGDI).
  */
 #ifdef WIN32
-#define _USE_MATH_DEFINES
-#define NOGDI
-#define NOMINMAX
+  #define _USE_MATH_DEFINES
+  #define NOGDI
+  #define NOMINMAX
 #endif
-
 
 /*
  * Compiler defines for Axom components
@@ -118,8 +112,7 @@
  * allow silently, and -1 to disallow.  Corresponds to cmake variable
  * AXOM_DEPRECATED_TYPES values of WARN, ALLOW and ERROR.
  */
-#cmakedefine AXOM_DEPRECATED_TYPES_N @AXOM_DEPRECATED_TYPES_N@
-
+#cmakedefine AXOM_DEPRECATED_TYPES_N @AXOM_DEPRECATED_TYPES_N @
 
 /*
  * Compiler defines to configure the built-in fmt library
@@ -130,14 +123,12 @@
 /*
  * Compiler defines to configure the built-in sparsehash library
  */
-#cmakedefine SPARSEHASH_HASHFUN_HEADER @SPARSEHASH_HASHFUN_HEADER@
-#cmakedefine SPARSEHASH_HASHFUN_NAMESPACE @SPARSEHASH_HASHFUN_NAMESPACE@
-
+#cmakedefine SPARSEHASH_HASHFUN_HEADER @SPARSEHASH_HASHFUN_HEADER @
+#cmakedefine SPARSEHASH_HASHFUN_NAMESPACE @SPARSEHASH_HASHFUN_NAMESPACE @
 
 /*
  * Disable some MSVC warnings related to shared libraries, if applicable
  */
-@AXOM_MSVC_PRAGMAS@
+@AXOM_MSVC_PRAGMAS @
 
-
-#endif  /* AXOM_COMMON_CONFIG_HPP */
+#endif /* AXOM_COMMON_CONFIG_HPP */

--- a/src/axom/core/CMakeLists.txt
+++ b/src/axom/core/CMakeLists.txt
@@ -158,8 +158,3 @@ endif()
 if(AXOM_ENABLE_EXAMPLES)
   add_subdirectory(examples)
 endif()
-
-#------------------------------------------------------------------------------
-# Add code checks
-#------------------------------------------------------------------------------
-axom_add_code_checks(PREFIX core)

--- a/src/axom/inlet/CMakeLists.txt
+++ b/src/axom/inlet/CMakeLists.txt
@@ -86,8 +86,3 @@ endif()
 if (AXOM_ENABLE_TESTS)
   add_subdirectory(tests)
 endif()
-
-#------------------------------------------------------------------------------
-# Add code checks
-#------------------------------------------------------------------------------
-axom_add_code_checks(PREFIX inlet)

--- a/src/axom/inlet/Field.cpp
+++ b/src/axom/inlet/Field.cpp
@@ -45,8 +45,7 @@ void Field::setDefaultValue(T value)
     if(m_docEnabled)
     {
       m_sidreGroup->createViewScalar("defaultValue", value);
-    }
-    if(!m_sidreGroup->hasView("value"))
+    }if(!m_sidreGroup->hasView("value"))
     {
       m_sidreGroup->createViewScalar("value", value);
     }

--- a/src/axom/inlet/Field.cpp
+++ b/src/axom/inlet/Field.cpp
@@ -45,7 +45,8 @@ void Field::setDefaultValue(T value)
     if(m_docEnabled)
     {
       m_sidreGroup->createViewScalar("defaultValue", value);
-    }if(!m_sidreGroup->hasView("value"))
+    }
+    if(!m_sidreGroup->hasView("value"))
     {
       m_sidreGroup->createViewScalar("value", value);
     }

--- a/src/axom/klee/CMakeLists.txt
+++ b/src/axom/klee/CMakeLists.txt
@@ -61,9 +61,3 @@ axom_install_component( NAME    klee
 if (AXOM_ENABLE_TESTS AND ENABLE_GMOCK)
   add_subdirectory(tests)
 endif()
-
-#------------------------------------------------------------------------------
-# Add code checks
-#------------------------------------------------------------------------------
-axom_add_code_checks(PREFIX klee)
-

--- a/src/axom/lumberjack/CMakeLists.txt
+++ b/src/axom/lumberjack/CMakeLists.txt
@@ -61,8 +61,3 @@ endif()
 if (AXOM_ENABLE_TESTS)
   add_subdirectory(tests)
 endif()
-
-#------------------------------------------------------------------------------
-# Add code checks
-#------------------------------------------------------------------------------
-axom_add_code_checks(PREFIX lumberjack)

--- a/src/axom/mint/CMakeLists.txt
+++ b/src/axom/mint/CMakeLists.txt
@@ -161,8 +161,3 @@ endif()
 if (AXOM_ENABLE_TESTS)
   add_subdirectory(tests)
 endif()
-
-#------------------------------------------------------------------------------
-# Add code checks
-#------------------------------------------------------------------------------
-axom_add_code_checks(PREFIX mint)

--- a/src/axom/mint/core/config.hpp.in
+++ b/src/axom/mint/core/config.hpp.in
@@ -6,8 +6,8 @@
 #ifndef MINT_CONFIG_HPP_
 #define MINT_CONFIG_HPP_
 
-#include "axom/config.hpp"// for compile-time definitions
-#include "axom/core/Types.hpp" // for fixed-width types
+#include "axom/config.hpp"      // for compile-time definitions
+#include "axom/core/Types.hpp"  // for fixed-width types
 
 #cmakedefine AXOM_MINT_USE_SIDRE
 
@@ -21,7 +21,5 @@ using int64 = std::int64_t;
 
 } /* end namespace mint */
 } /* end namespace axom */
-
-
 
 #endif /* MINT_CONFIG_HPP_ */

--- a/src/axom/multimat/CMakeLists.txt
+++ b/src/axom/multimat/CMakeLists.txt
@@ -62,11 +62,3 @@ endif()
 if (AXOM_ENABLE_EXAMPLES)
   add_subdirectory(examples)
 endif()
-
-
-#------------------------------------------------------------------------------
-# Add docs and code checks
-#------------------------------------------------------------------------------
-axom_add_code_checks(
-        PREFIX multimat
-        )

--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -115,8 +115,3 @@ endif()
 if (AXOM_ENABLE_TESTS)
   add_subdirectory(tests)
 endif()
-
-#------------------------------------------------------------------------------
-# Add code checks
-#------------------------------------------------------------------------------
-axom_add_code_checks(PREFIX primal)

--- a/src/axom/quest/CMakeLists.txt
+++ b/src/axom/quest/CMakeLists.txt
@@ -205,5 +205,3 @@ endif()
 if (AXOM_ENABLE_TESTS)
     add_subdirectory(tests)
 endif()
-
-axom_add_code_checks(PREFIX quest)

--- a/src/axom/sidre/CMakeLists.txt
+++ b/src/axom/sidre/CMakeLists.txt
@@ -146,9 +146,3 @@ endif()
 if(AXOM_ENABLE_EXAMPLES)
   add_subdirectory(examples)
 endif()
-
-#------------------------------------------------------------------------------
-# Add code checks
-#------------------------------------------------------------------------------
-axom_add_code_checks(PREFIX   sidre
-                     EXCLUDES sidre/examples/lulesh2)

--- a/src/axom/slam/CMakeLists.txt
+++ b/src/axom/slam/CMakeLists.txt
@@ -112,14 +112,3 @@ endif()
 if (AXOM_ENABLE_EXAMPLES)
   add_subdirectory(examples)
 endif()
-
-
-#------------------------------------------------------------------------------
-# Add code checks
-#------------------------------------------------------------------------------
-axom_add_code_checks(
-        PREFIX slam
-        EXCLUDES
-            slam/examples/lulesh2.0.3
-            slam/examples/tinyHydro )
-

--- a/src/axom/slic/CMakeLists.txt
+++ b/src/axom/slic/CMakeLists.txt
@@ -100,8 +100,3 @@ endif()
 if (AXOM_ENABLE_TESTS)
   add_subdirectory(tests)
 endif()
-
-#------------------------------------------------------------------------------
-# Add code checks
-#------------------------------------------------------------------------------
-axom_add_code_checks(PREFIX slic)

--- a/src/axom/spin/CMakeLists.txt
+++ b/src/axom/spin/CMakeLists.txt
@@ -80,8 +80,3 @@ endif()
 if (AXOM_ENABLE_TESTS)
   add_subdirectory(tests)
 endif()
-
-#------------------------------------------------------------------------------
-# Add code checks
-#------------------------------------------------------------------------------
-axom_add_code_checks(PREFIX spin)

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -6,7 +6,7 @@
 ##------------------------------------------------------------------------------
 ## axom_add_code_checks()
 ##
-## Adds code checks for all cpp/hpp files recursively under the current directory.
+## Adds code checks for all source files recursively in the Axom repository.
 ## 
 ## This creates the following parent build targets:
 ##  check - Runs a non file changing style check and CppCheck

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -30,9 +30,11 @@ macro(axom_add_code_checks)
     # another project
     if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
         # Create file globbing expressions that only include directories that contain source
-        set(_base_dirs "axom" "examples" "thirdparty/tests/" "tools")
-        # Note: any extensions added here should also be added to BLT's lists in CMakeLists.txt
-        set(_ext_expressions "*.cpp" "*.hpp" "*.inl" "*.cuh" "*.cu" "*.cpp.in" "*.hpp.in"
+        set(_base_dirs "axom" "examples" "thirdparty/tests" "tools")
+
+        # Note: any extensions added here should also be added to BLT's lists
+        # in src/CMakeLists.txt
+        set(_ext_expressions "*.cpp" "*.hpp" "*.inl" "*.cpp.in" "*.hpp.in"
                              "*.cxx" "*.hxx" "*.cc" "*.c" "*.h" "*.hh"
                              "*.F" "*.f" "*.f90" "*.F90")
 

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -31,10 +31,7 @@ macro(axom_add_code_checks)
     if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
         # Create file globbing expressions that only include directories that contain source
         set(_base_dirs "axom" "examples" "thirdparty/tests" "tools")
-
-        # Note: any extensions added here should also be added to BLT's lists
-        # in src/CMakeLists.txt
-        set(_ext_expressions "*.cpp" "*.hpp" "*.inl" "*.cpp.in" "*.hpp.in"
+        set(_ext_expressions "*.cpp" "*.hpp" "*.inl"
                              "*.cxx" "*.hxx" "*.cc" "*.c" "*.h" "*.hh"
                              "*.F" "*.f" "*.f90" "*.F90")
 

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -4,23 +4,23 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 
 ##------------------------------------------------------------------------------
-## axom_add_code_checks( PREFIX     <Prefix used for created targets>
-##                       EXCLUDES   [path1 [path2 ...]])
+## axom_add_code_checks()
 ##
-## Adds code checks to all source files under this directory.
+## Adds code checks for all cpp/hpp files recursively under the current directory.
+## 
+## This creates the following parent build targets:
+##  check - Runs a non file changing style check and CppCheck
+##  style - In-place code formatting
 ##
-## PREFIX is used in the creation of all the underlying targets. For example:
-## <PREFIX>_clangformat_check.
-##
-## EXCLUDES is used to exclude any files from the code checks. It is done with
-## a simple CMake reg exp MATCHES check.
-##
+## Creates various child build targets that follow this pattern:
+##  axom_<check|style>
+##  axom_<cppcheck|clangformat>_<check|style>
 ##------------------------------------------------------------------------------
 macro(axom_add_code_checks)
 
     set(options)
-    set(singleValueArgs PREFIX )
-    set(multiValueArgs EXCLUDES )
+    set(singleValueArgs)
+    set(multiValueArgs)
 
     # Parse the arguments to the macro
     cmake_parse_arguments(arg
@@ -29,34 +29,37 @@ macro(axom_add_code_checks)
     # Only do code checks if building Axom by itself and not included in
     # another project
     if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
-        set(_all_sources)
-        file(GLOB_RECURSE _all_sources
-             "*.cpp" "*.hpp" "*.cxx" "*.hxx" "*.cc" "*.c" "*.h" "*.hh"
-             "*.F" "*.f" "*.f90" "*.F90")
+        # Create file globbing expressions that only include directories that contain source
+        set(_base_dirs "axom" "examples" "thirdparty/tests/" "tools")
+        # Note: any extensions added here should also be added to BLT's lists in CMakeLists.txt
+        set(_ext_expressions "*.cpp" "*.hpp" "*.inl" "*.cuh" "*.cu" "*.cpp.in" "*.hpp.in"
+                             "*.cxx" "*.hxx" "*.cc" "*.c" "*.h" "*.hh"
+                             "*.F" "*.f" "*.f90" "*.F90")
 
-        # Check for excludes
-        if (NOT DEFINED arg_EXCLUDES)
-            set(_sources ${_all_sources})
-        else()
-            set(_sources)
-            foreach(_source ${_all_sources})
-                set(_to_be_excluded FALSE)
-                foreach(_exclude ${arg_EXCLUDES})
-                    if (${_source} MATCHES ${_exclude})
-                        set(_to_be_excluded TRUE)
-                        break()
-                    endif()
-                endforeach()
-
-                if (NOT ${_to_be_excluded})
-                    list(APPEND _sources ${_source})
-                endif()
+        set(_glob_expressions)
+        foreach(_exp ${_ext_expressions})
+            foreach(_base_dir ${_base_dirs})
+                list(APPEND _glob_expressions "${PROJECT_SOURCE_DIR}/${_base_dir}/${_exp}")
             endforeach()
-        endif()
+        endforeach()
 
-        blt_add_code_checks(PREFIX    ${arg_PREFIX}
-                            SOURCES   ${_sources}
-                            CLANGFORMAT_CFG_FILE ${PROJECT_SOURCE_DIR}/.clang-format)
+        # Glob for list of files to run code checks on
+        set(_sources)
+        file(GLOB_RECURSE _sources ${_glob_expressions})
+
+        # Filter out exclusions
+        set(_exclude_expressions
+            "${PROJECT_SOURCE_DIR}/axom/sidre/examples/lulesh2/*"
+            "${PROJECT_SOURCE_DIR}/axom/slam/examples/lulesh2.0.3/*"
+            "${PROJECT_SOURCE_DIR}/axom/slam/examples/tinyHydro/*")
+        foreach(_exp ${_exclude_expressions})
+            list(FILTER _sources EXCLUDE REGEX ${_exp})
+        endforeach()
+
+        blt_add_code_checks(PREFIX          axom
+                            SOURCES         ${_sources}
+                            CLANGFORMAT_CFG_FILE ${PROJECT_SOURCE_DIR}/.clang-format
+                            CPPCHECK_FLAGS  --enable=all --inconclusive)
 
         # Set FOLDER property for code check targets
         foreach(_suffix clangformat_check clangformat_style clang_tidy_check clang_tidy_style)

--- a/src/docs/sphinx/dev_guide/component_org.rst
+++ b/src/docs/sphinx/dev_guide/component_org.rst
@@ -169,20 +169,9 @@ The top-level component directory contains a ``CMakeLists.txt``, e.g.,
 
        install(EXPORT <component name>-targets DESTINATION lib/cmake)
 
-  #. Code formatting and static analysis targets; e.g.,::
-
-       axom_add_code_checks(BASE_NAME <component name>)
-
-
-
-.. note:: Each Axom component should use the common ``clang-format``
-          configuration file defined for the project at ``src/.clang-format``. 
-          The file is used to define source code formatting options that are
-          applied when the *clang-format* tool is run on the code.
-
 
 Component src directory
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``CMakeLists.txt`` file in the component ``src`` directory defines:
 

--- a/src/examples/using-with-blt/example.cpp
+++ b/src/examples/using-with-blt/example.cpp
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-
 //-----------------------------------------------------------------------------
 ///
 /// file: example.cpp
@@ -17,14 +16,15 @@
 
 int main()
 {
-   // Using fmt library exported by axom
-   std::cout << axom::fmt::format(
-        "Example of using an installed version of Axom {}",
-        axom::getVersion()) << std::endl << std::endl;
+  // Using fmt library exported by axom
+  std::cout << axom::fmt::format(
+                 "Example of using an installed version of Axom {}",
+                 axom::getVersion())
+            << std::endl
+            << std::endl;
 
-   // Uses installed axom library
-   axom::about();
+  // Uses installed axom library
+  axom::about();
 
-   return 0;
+  return 0;
 }
-

--- a/src/examples/using-with-cmake/example.cpp
+++ b/src/examples/using-with-cmake/example.cpp
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-
 //-----------------------------------------------------------------------------
 ///
 /// file: example.cpp
@@ -17,14 +16,15 @@
 
 int main()
 {
-   // Using fmt library exported by axom
-   std::cout << axom::fmt::format(
-        "Example of using an installed version of Axom {}",
-        axom::getVersion()) << std::endl << std::endl;
+  // Using fmt library exported by axom
+  std::cout << axom::fmt::format(
+                 "Example of using an installed version of Axom {}",
+                 axom::getVersion())
+            << std::endl
+            << std::endl;
 
-   // Uses installed axom library
-   axom::about();
+  // Uses installed axom library
+  axom::about();
 
-   return 0;
+  return 0;
 }
-

--- a/src/examples/using-with-make/example.cpp
+++ b/src/examples/using-with-make/example.cpp
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-
 //-----------------------------------------------------------------------------
 ///
 /// file: example.cpp
@@ -14,8 +13,4 @@
 
 #include "axom/core.hpp"
 
-int main()
-{
-   axom::about();
-}
-
+int main() { axom::about(); }

--- a/src/thirdparty/tests/CMakeLists.txt
+++ b/src/thirdparty/tests/CMakeLists.txt
@@ -6,9 +6,6 @@
 # Collection of tests for axom's built-in third party libraries
 #------------------------------------------------------------------------------
 
-# Create cmake targets for running the tests through axom's code checks
-axom_add_code_checks(PREFIX thirdparty_tests)
-
 #------------------------------------------------------------------------------
 # Smoke test for Umpire third party library
 #------------------------------------------------------------------------------

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -173,8 +173,3 @@ if( AXOM_ENABLE_SIDRE AND AXOM_ENABLE_PRIMAL AND
             )
 
 endif()
-
-#------------------------------------------------------------------------------
-# Add code checks
-#------------------------------------------------------------------------------
-axom_add_code_checks(PREFIX tools)


### PR DESCRIPTION
Couldn't test this until it was in the default branch. This does the following:

* Removes component based code checks
* Simplifies `axom_add_code_checks` macro
* Run style on more files that are included due to previous bullet point