### PR TITLE
AWS tutorial Docker image update

### DIFF
--- a/scripts/docker/dockerfile_gcc-9_cuda-11
+++ b/scripts/docker/dockerfile_gcc-9_cuda-11
@@ -30,7 +30,7 @@ WORKDIR ${HOME}
 USER ${USER}
 
 # Install CMake
-RUN wget -q --no-check-certificate https://cmake.org/files/v3.21/cmake-3.21.7-linux-x86_64.tar.gz && \
+RUN sudo wget -q --no-check-certificate https://cmake.org/files/v3.21/cmake-3.21.7-linux-x86_64.tar.gz && \
     tar -xzf cmake-3.21.7-linux-x86_64.tar.gz && \
     rm -r cmake-3.21.7-linux-x86_64/share/vim/vimfiles && \
     cp -fR cmake-3.21.7-linux-x86_64/* /usr && \

--- a/scripts/docker/dockerfile_gcc-9_cuda-11
+++ b/scripts/docker/dockerfile_gcc-9_cuda-11
@@ -29,6 +29,14 @@ RUN tar xzf openvscode-server-v1.69.1-linux-x64.tar.gz && chown -R ${USER}:${USE
 WORKDIR ${HOME}
 USER ${USER}
 
+# Install CMake
+RUN wget -q --no-check-certificate https://cmake.org/files/v3.21/cmake-3.21.7-linux-x86_64.tar.gz && \
+    tar -xzf cmake-3.21.7-linux-x86_64.tar.gz && \
+    rm -r cmake-3.21.7-linux-x86_64/share/vim/vimfiles && \
+    cp -fR cmake-3.21.7-linux-x86_64/* /usr && \
+    rm -rf cmake-3.21.7-linux-x86_64 && \
+    rm cmake-3.21.7-linux-x86_64.tar.gz
+
 # Clone axom at axom_repo directory
 RUN git clone --recursive --branch $branch https://github.com/LLNL/axom.git axom_repo
 

--- a/scripts/docker/dockerfile_gcc-9_cuda-11
+++ b/scripts/docker/dockerfile_gcc-9_cuda-11
@@ -21,14 +21,6 @@ RUN sudo apt-get install -y supervisor
 RUN sudo useradd --create-home --shell /bin/bash ${USER}
 RUN sudo apt-get install doxygen elfutils gfortran graphviz language-pack-en-base less libopenblas-dev libomp-dev mpich python3-sphinx ssh texlive-full tree -fy
 
-WORKDIR /opt/archives
-RUN curl -L https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v1.69.1/openvscode-server-v1.69.1-linux-x64.tar.gz > \
-    /opt/archives/openvscode-server-v1.69.1-linux-x64.tar.gz
-RUN tar xzf openvscode-server-v1.69.1-linux-x64.tar.gz && chown -R ${USER}:${USER} openvscode-server-v1.69.1-linux-x64
-
-WORKDIR ${HOME}
-USER ${USER}
-
 # Install CMake
 RUN sudo wget -q --no-check-certificate https://cmake.org/files/v3.21/cmake-3.21.7-linux-x86_64.tar.gz && \
     tar -xzf cmake-3.21.7-linux-x86_64.tar.gz && \
@@ -36,6 +28,14 @@ RUN sudo wget -q --no-check-certificate https://cmake.org/files/v3.21/cmake-3.21
     cp -fR cmake-3.21.7-linux-x86_64/* /usr && \
     rm -rf cmake-3.21.7-linux-x86_64 && \
     rm cmake-3.21.7-linux-x86_64.tar.gz
+
+WORKDIR /opt/archives
+RUN curl -L https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v1.69.1/openvscode-server-v1.69.1-linux-x64.tar.gz > \
+    /opt/archives/openvscode-server-v1.69.1-linux-x64.tar.gz
+RUN tar xzf openvscode-server-v1.69.1-linux-x64.tar.gz && chown -R ${USER}:${USER} openvscode-server-v1.69.1-linux-x64
+
+WORKDIR ${HOME}
+USER ${USER}
 
 # Clone axom at axom_repo directory
 RUN git clone --recursive --branch $branch https://github.com/LLNL/axom.git axom_repo

--- a/scripts/docker/dockerfile_gcc-9_cuda-11
+++ b/scripts/docker/dockerfile_gcc-9_cuda-11
@@ -22,7 +22,7 @@ RUN sudo useradd --create-home --shell /bin/bash ${USER}
 RUN sudo apt-get install doxygen elfutils gfortran graphviz language-pack-en-base less libopenblas-dev libomp-dev mpich python3-sphinx ssh texlive-full tree -fy
 
 # Install CMake
-RUN sudo wget -q --no-check-certificate https://cmake.org/files/v3.21/cmake-3.21.7-linux-x86_64.tar.gz && \
+RUN wget -q --no-check-certificate https://cmake.org/files/v3.21/cmake-3.21.7-linux-x86_64.tar.gz && \
     tar -xzf cmake-3.21.7-linux-x86_64.tar.gz && \
     rm -r cmake-3.21.7-linux-x86_64/share/vim/vimfiles && \
     cp -fR cmake-3.21.7-linux-x86_64/* /usr && \

--- a/scripts/spack/configs/docker/ubuntu20_cuda/spack.yaml
+++ b/scripts/spack/configs/docker/ubuntu20_cuda/spack.yaml
@@ -166,22 +166,22 @@ spack:
     caliper:
       require: "@2.10.0~kokkos"
     camp:
-      require: "@2023.06.0"
+      require: "@2024.02.0"
     conduit:
-      require: "@0.8.8~shared~test~examples~utilities"
+      require: "@0.9.1~shared~test~examples~utilities"
     hdf5:
       variants: ~shared~mpi
     hypre:
       version: [2.24.0]
     # do shared mfem to allow PIC flag in mfem
     mfem:
-      require: "@4.5.2+shared~static"
+      require: "@4.6.0"
     raja:
-      require: "@2023.06.0~shared~examples~exercises"
+      require: "@2024.02.0~shared~examples~exercises"
     scr:
-      require: "@develop~shared"
+      require: "@3.0.1~shared~tests~examples"
     umpire:
-      require: "@2023.06.0~shared~examples"
+      require: "@2024.02.0~shared~examples~werror"
 
     # Globally lock in version of devtools
     cmake:

--- a/scripts/spack/configs/docker/ubuntu20_cuda/spack.yaml
+++ b/scripts/spack/configs/docker/ubuntu20_cuda/spack.yaml
@@ -185,11 +185,11 @@ spack:
 
     # Globally lock in version of devtools
     cmake:
-      version: [3.20.4]
+      version: [3.21.7]
       buildable: false
       externals:
-      - spec: cmake@3.20.4
-        prefix: /opt/view
+      - spec: cmake@3.21.7
+        prefix: /usr
     doxygen:
       version: [1.8.17]
       buildable: false


### PR DESCRIPTION
This PR:
- Updates the CUDA AWS Tutorial image for 2024
- Verified image works in an AWS instance, and axom tests and executables were able to run in the instance.
- AWS Setup instructions were also updated: https://lc.llnl.gov/confluence/display/ASCT/AWS+Setup+Working+Notes
- The updated Docker image can be found here: https://hub.docker.com/r/han12/axom-tutorial/tags

A follow-up PR will likely be necessary once #1171 is merged.