### PR TITLE
Add missing SLIC includes

### DIFF
--- a/src/axom/quest/DistributedClosestPoint.cpp
+++ b/src/axom/quest/DistributedClosestPoint.cpp
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "axom/config.hpp"
-#include "axom/slic.hpp"
 #include "axom/core/memory_management.hpp"
 #include "axom/core/execution/execution_space.hpp"
 #include "axom/core/execution/runtime_policy.hpp"

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -8,6 +8,7 @@
 
 #include "axom/config.hpp"
 #include "axom/core/execution/runtime_policy.hpp"
+#include "axom/slic.hpp"
 
 #include "conduit_node.hpp"
 

--- a/src/axom/quest/MeshTester.hpp
+++ b/src/axom/quest/MeshTester.hpp
@@ -10,6 +10,7 @@
 #include "axom/config.hpp"
 #include "axom/core.hpp"
 #include "axom/primal.hpp"
+#include "axom/slic.hpp"
 #include "axom/spin.hpp"
 #include "axom/mint.hpp"
 

--- a/src/axom/quest/MeshViewUtil.hpp
+++ b/src/axom/quest/MeshViewUtil.hpp
@@ -14,6 +14,7 @@
   #include "axom/core.hpp"
   #include "axom/core/NumericLimits.hpp"
   #include "axom/fmt.hpp"
+  #include "axom/slic.hpp"
   #include "conduit_blueprint.hpp"
   #include "conduit_blueprint_mcarray.hpp"
   #ifdef AXOM_USE_MPI

--- a/src/axom/quest/PointInCell.hpp
+++ b/src/axom/quest/PointInCell.hpp
@@ -8,6 +8,7 @@
 
 #include "axom/config.hpp"
 #include "axom/core/Macros.hpp"
+#include "axom/slic.hpp"
 
 #include "axom/primal/geometry/Point.hpp"
 

--- a/src/axom/quest/SignedDistance.hpp
+++ b/src/axom/quest/SignedDistance.hpp
@@ -11,6 +11,7 @@
 #include "axom/core/Macros.hpp"
 #include "axom/core/Types.hpp"
 #include "axom/core/utilities/Utilities.hpp"
+#include "axom/slic.hpp"
 
 // primal includes
 #include "axom/spin/BVH.hpp"


### PR DESCRIPTION
@gberg617

Guy noticed that a compilation error in the new release due to SLIC being used in a header and not including SLIC.  This should fix that and more.