### PR TITLE
Check for null shapes in `View` methods

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -46,6 +46,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Quest: Adds an example to query winding numbers on an MFEM NURBS mesh
 
 ### Changed
+- `axom::CLI::ExitCodes::Success` has been changed to `axom::CLI::ExitCodes::CLI11_Success`
+  to avoid conflict when X11 `#define`s `Success`.
 - `MarchingCubes` masking now uses the mask field's integer values instead of
   converting them to booleans.  The new behavior lets you select a value to mask for.
   If you want to continue the boolean behavior, use only 0 or 1 in your mask field.

--- a/src/axom/sidre/core/View.cpp
+++ b/src/axom/sidre/core/View.cpp
@@ -983,6 +983,14 @@ void View::describe(TypeID type, IndexType num_elems)
  */
 void View::describe(TypeID type, int ndims, const IndexType* shape)
 {
+  SLIC_CHECK_MSG(shape != nullptr,
+                 SIDRE_VIEW_LOG_PREPEND
+                   << "Could not allocate: specified shape is nullptr.");
+  if(shape == nullptr)
+  {
+    return;
+  }
+
   IndexType num_elems = 0;
   if(ndims > 0)
   {
@@ -1035,6 +1043,14 @@ void View::describeShape()
  */
 void View::describeShape(int ndims, const IndexType* shape)
 {
+  SLIC_CHECK_MSG(shape != nullptr,
+                 SIDRE_VIEW_LOG_PREPEND
+                   << "Could not allocate: specified shape is nullptr.");
+  if(shape == nullptr)
+  {
+    return;
+  }
+
   m_shape.clear();
   for(int i = 0; i < ndims; i++)
   {

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -375,6 +375,8 @@ public:
    *       type is NO_TYPE_ID, or ndims < 0, or shape is nullptr,
    *       or any element of shape < 0, this method does nothing.
    *
+   * If shape is NULL, this is a no-op.
+   *
    * \return pointer to this View object.
    */
   View* allocate(TypeID type, int ndims, const IndexType* shape, int allocID);
@@ -468,10 +470,19 @@ public:
   /*!
    * \brief Describe the data view and attach Buffer object.
    *
+   * If shape is nullptr, this is a no-op.
+   *
    * \return pointer to this View object.
    */
   View* attachBuffer(TypeID type, int ndims, const IndexType* shape, Buffer* buff)
   {
+    SLIC_CHECK_MSG(shape != nullptr,
+                   SIDRE_VIEW_LOG_PREPEND
+                     << "Could not allocate: specified shape is nullptr.");
+    if(shape == nullptr)
+    {
+      return this;
+    }
     describe(type, ndims, shape);
     attachBuffer(buff);
     return this;
@@ -746,6 +757,8 @@ public:
    *
    * If external_ptr is NULL, the view will be EMPTY.
    *
+   * If shape is NULL, this is a no-op.
+   *
    * \return pointer to this View object.
    */
   View* setExternalDataPtr(TypeID type,
@@ -753,6 +766,15 @@ public:
                            const IndexType* shape,
                            void* external_ptr)
   {
+    SLIC_CHECK_MSG(
+      shape != nullptr,
+      SIDRE_VIEW_LOG_PREPEND
+        << "Could not set external data ptr: specified shape is nullptr.");
+    if(shape == nullptr)
+    {
+      return this;
+    }
+
     describe(type, ndims, shape);
     setExternalDataPtr(external_ptr);
     return this;
@@ -1333,13 +1355,14 @@ private:
    * \brief Describe a data view with given type, number of dimensions, and
    *        number of elements per dimension.
    *
-   *
    * \attention If view has been previously described, this operation will
    *            re-describe the view. To have the new description take effect,
    *            the apply() method must be called.
    *
    * If given type of NO_TYPE_ID, or number of dimensions or total
    * number of elements < 0, or view is opaque, method does nothing.
+   *
+   * If shape is nullptr, this is a no-op.
    */
   void describe(TypeID type, int ndims, const IndexType* shape);
 
@@ -1362,6 +1385,8 @@ private:
 
   /*!
    * \brief Set the shape to be a ndims dimensions with shape.
+   *
+   * If shape is NULL, this is a no-op.
    */
   void describeShape(int ndims, const IndexType* shape);
 

--- a/src/thirdparty/axom/CLI11.hpp
+++ b/src/thirdparty/axom/CLI11.hpp
@@ -552,7 +552,7 @@ namespace CLI {
 /// These codes are part of every error in CLI. They can be obtained from e using e.exit_code or as a quick shortcut,
 /// int values from e.get_error_code().
 enum class ExitCodes {
-    CLI11_Success = 0,
+  CLI11_Success = 0 /* Formerly Success, changed to work around X11 #defining Success */,
     IncorrectConstruction = 100,
     BadNameString,
     OptionAlreadyAdded,


### PR DESCRIPTION
Check for null `shape` parameters in all `View` methods and do nothing if the `shape` is null.  This makes the `View` methods consistent across all cases with a `shape` parameter.

This change addresses issue https://github.com/LLNL/axom/issues/1395