### PR TITLE
Substitute PR for resolving X11-CLI11 conflict

### DIFF
--- a/src/thirdparty/axom/CLI11.hpp
+++ b/src/thirdparty/axom/CLI11.hpp
@@ -552,7 +552,7 @@ namespace CLI {
 /// These codes are part of every error in CLI. They can be obtained from e using e.exit_code or as a quick shortcut,
 /// int values from e.get_error_code().
 enum class ExitCodes {
-  CLI11_Success = 0 /* Formerly Success, changed to work around X11 #defining Success */,
+    CLI11_Success = 0 /* Formerly Success, changed to work around X11 #defining Success */,
     IncorrectConstruction = 100,
     BadNameString,
     OptionAlreadyAdded,


### PR DESCRIPTION
Somehow, I broke the association between the branch and the pull request for resolving the X11-CLI11 conflict.  This is a new pull request to take place of the one that was already approved by @rhornung67 and @agcapps.  While removing some white spaces as suggested by @agcapps, I broke the association.