### PR TITLE
Allow device policy execution for more tests and examples

### DIFF
--- a/src/axom/mint/execution/internal/for_all_cells.hpp
+++ b/src/axom/mint/execution/internal/for_all_cells.hpp
@@ -665,7 +665,7 @@ inline void for_all_cells_impl(xargs::coords,
   {
     SLIC_ASSERT(dimension == 3);
 
-    // Extract xy coordinate values into an axom::ArrayView
+    // Extract yz coordinate values into an axom::ArrayView
     auto y_vals_h =
       axom::ArrayView<const double>(m.getCoordinateArray(Y_COORDINATE),
                                     m.getNodeResolution(Y_COORDINATE));
@@ -673,7 +673,7 @@ inline void for_all_cells_impl(xargs::coords,
       axom::ArrayView<const double>(m.getCoordinateArray(Z_COORDINATE),
                                     m.getNodeResolution(Z_COORDINATE));
 
-    // Move xy values onto device
+    // Move yz values onto device
     axom::Array<double> y_vals_d = on_device
       ? axom::Array<double>(y_vals_h, device_allocator)
       : axom::Array<double>();

--- a/src/axom/mint/execution/internal/for_all_faces.hpp
+++ b/src/axom/mint/execution/internal/for_all_faces.hpp
@@ -409,14 +409,27 @@ inline void for_all_faces_impl(xargs::nodeids,
                 "No faces in the mesh, perhaps you meant to call "
                   << "UnstructuredMesh::initializeFaceConnectivity first.");
 
-  const IndexType* faces_to_nodes = m.getFaceNodesArray();
+  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
+  auto faces_to_nodes_h =
+    axom::ArrayView<const IndexType>(m.getFaceNodesArray(), m.getFaceNodesSize());
+
+  // Move faces to nodes onto device
+  axom::Array<IndexType> faces_to_nodes_d = on_device
+    ? axom::Array<IndexType>(faces_to_nodes_h, device_allocator)
+    : axom::Array<IndexType>();
+
+  auto faces_to_nodes_view =
+    on_device ? faces_to_nodes_d.view() : faces_to_nodes_h;
+
   const IndexType num_nodes = m.getNumberOfFaceNodes();
 
   for_all_faces_impl<ExecPolicy>(
     xargs::index(),
     m,
     AXOM_LAMBDA(IndexType faceID) {
-      kernel(faceID, faces_to_nodes + faceID * num_nodes, num_nodes);
+      kernel(faceID, faces_to_nodes_view.data() + faceID * num_nodes, num_nodes);
     });
 }
 
@@ -430,15 +443,32 @@ inline void for_all_faces_impl(xargs::nodeids,
                 "No faces in the mesh, perhaps you meant to call "
                   << "UnstructuredMesh::initializeFaceConnectivity first.");
 
-  const IndexType* faces_to_nodes = m.getFaceNodesArray();
-  const IndexType* offsets = m.getFaceNodesOffsetsArray();
+  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
+  auto faces_to_nodes_h =
+    axom::ArrayView<const IndexType>(m.getFaceNodesArray(), m.getFaceNodesSize());
+  auto offsets_h = axom::ArrayView<const IndexType>(m.getFaceNodesOffsetsArray(),
+                                                    m.getNumberOfFaces() + 1);
+
+  // Move faces to nodes and offsets onto device
+  axom::Array<IndexType> faces_to_nodes_d = on_device
+    ? axom::Array<IndexType>(faces_to_nodes_h, device_allocator)
+    : axom::Array<IndexType>();
+  axom::Array<IndexType> offsets_d = on_device
+    ? axom::Array<IndexType>(offsets_h, device_allocator)
+    : axom::Array<IndexType>();
+
+  auto faces_to_nodes_view =
+    on_device ? faces_to_nodes_d.view() : faces_to_nodes_h;
+  auto offsets_view = on_device ? offsets_d.view() : offsets_h;
 
   for_all_faces_impl<ExecPolicy>(
     xargs::index(),
     m,
     AXOM_LAMBDA(IndexType faceID) {
-      const IndexType num_nodes = offsets[faceID + 1] - offsets[faceID];
-      kernel(faceID, faces_to_nodes + offsets[faceID], num_nodes);
+      const IndexType num_nodes = offsets_view[faceID + 1] - offsets_view[faceID];
+      kernel(faceID, faces_to_nodes_view.data() + offsets_view[faceID], num_nodes);
     });
 }
 
@@ -601,14 +631,27 @@ inline void for_all_faces_impl(xargs::cellids,
                 "No faces in the mesh, perhaps you meant to call "
                   << "UnstructuredMesh::initializeFaceConnectivity first.");
 
-  const IndexType* faces_to_cells = m.getFaceCellsArray();
+  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
+  auto faces_to_cells_h =
+    axom::ArrayView<const IndexType>(m.getFaceCellsArray(),
+                                     2 * m.getNumberOfFaces());
+
+  // Move faces to cells onto device
+  axom::Array<IndexType> faces_to_cells_d = on_device
+    ? axom::Array<IndexType>(faces_to_cells_h, device_allocator)
+    : axom::Array<IndexType>();
+
+  auto faces_to_cells_view =
+    on_device ? faces_to_cells_d.view() : faces_to_cells_h;
 
   for_all_faces_impl<ExecPolicy>(
     xargs::index(),
     m,
     AXOM_LAMBDA(IndexType faceID) {
       const IndexType offset = 2 * faceID;
-      kernel(faceID, faces_to_cells[offset], faces_to_cells[offset + 1]);
+      kernel(faceID, faces_to_cells_view[offset], faces_to_cells_view[offset + 1]);
     });
 }
 
@@ -791,11 +834,30 @@ inline void for_all_faces_impl(xargs::coords,
 
   SLIC_ASSERT(m.getDimension() > 1 && m.getDimension() <= 3);
 
+  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
   const int dimension = m.getDimension();
   const IndexType nodeJp = m.nodeJp();
   const IndexType nodeKp = m.nodeKp();
-  const double* x = m.getCoordinateArray(X_COORDINATE);
-  const double* y = m.getCoordinateArray(Y_COORDINATE);
+
+  auto x_vals_h =
+    axom::ArrayView<const double>(m.getCoordinateArray(X_COORDINATE),
+                                  m.getNodeResolution(X_COORDINATE));
+  auto y_vals_h =
+    axom::ArrayView<const double>(m.getCoordinateArray(Y_COORDINATE),
+                                  m.getNodeResolution(Y_COORDINATE));
+
+  // Move xy values onto device
+  axom::Array<double> x_vals_d = on_device
+    ? axom::Array<double>(x_vals_h, device_allocator)
+    : axom::Array<double>();
+  axom::Array<double> y_vals_d = on_device
+    ? axom::Array<double>(y_vals_h, device_allocator)
+    : axom::Array<double>();
+
+  auto x_vals_view = on_device ? x_vals_d.view() : x_vals_h;
+  auto y_vals_view = on_device ? y_vals_d.view() : y_vals_h;
 
   if(dimension == 2)
   {
@@ -806,7 +868,10 @@ inline void for_all_faces_impl(xargs::coords,
         const IndexType n0 = i + j * nodeJp;
         const IndexType nodeIDs[2] = {n0, n0 + nodeJp};
 
-        double coords[4] = {x[i], y[j], x[i], y[j + 1]};
+        double coords[4] = {x_vals_view[i],
+                            y_vals_view[j],
+                            x_vals_view[i],
+                            y_vals_view[j + 1]};
 
         numerics::Matrix<double> coordsMatrix(dimension, 2, coords, NO_COPY);
         kernel(faceID, coordsMatrix, nodeIDs);
@@ -819,7 +884,10 @@ inline void for_all_faces_impl(xargs::coords,
         const IndexType n0 = i + j * nodeJp;
         const IndexType nodeIDs[2] = {n0, n0 + 1};
 
-        double coords[4] = {x[i], y[j], x[i + 1], y[j]};
+        double coords[4] = {x_vals_view[i],
+                            y_vals_view[j],
+                            x_vals_view[i + 1],
+                            y_vals_view[j]};
 
         numerics::Matrix<double> coordsMatrix(dimension, 2, coords, NO_COPY);
         kernel(faceID, coordsMatrix, nodeIDs);
@@ -827,7 +895,17 @@ inline void for_all_faces_impl(xargs::coords,
   }
   else
   {
-    const double* z = m.getCoordinateArray(Z_COORDINATE);
+    auto z_vals_h =
+      axom::ArrayView<const double>(m.getCoordinateArray(Z_COORDINATE),
+                                    m.getNodeResolution(Z_COORDINATE));
+
+    // Move z values onto device
+    axom::Array<double> z_vals_d = on_device
+      ? axom::Array<double>(z_vals_h, device_allocator)
+      : axom::Array<double>();
+
+    auto z_vals_view = on_device ? z_vals_d.view() : z_vals_h;
+
     helpers::for_all_I_faces<ExecPolicy>(
       xargs::ijk(),
       m,
@@ -838,18 +916,18 @@ inline void for_all_faces_impl(xargs::coords,
                                       n0 + nodeJp + nodeKp,
                                       n0 + nodeJp};
 
-        double coords[12] = {x[i],
-                             y[j],
-                             z[k],
-                             x[i],
-                             y[j],
-                             z[k + 1],
-                             x[i],
-                             y[j + 1],
-                             z[k + 1],
-                             x[i],
-                             y[j + 1],
-                             z[k]};
+        double coords[12] = {x_vals_view[i],
+                             y_vals_view[j],
+                             z_vals_view[k],
+                             x_vals_view[i],
+                             y_vals_view[j],
+                             z_vals_view[k + 1],
+                             x_vals_view[i],
+                             y_vals_view[j + 1],
+                             z_vals_view[k + 1],
+                             x_vals_view[i],
+                             y_vals_view[j + 1],
+                             z_vals_view[k]};
 
         numerics::Matrix<double> coordsMatrix(dimension, 4, coords, NO_COPY);
         kernel(faceID, coordsMatrix, nodeIDs);
@@ -862,18 +940,18 @@ inline void for_all_faces_impl(xargs::coords,
         const IndexType n0 = i + j * nodeJp + k * nodeKp;
         const IndexType nodeIDs[4] = {n0, n0 + 1, n0 + 1 + nodeKp, n0 + nodeKp};
 
-        double coords[12] = {x[i],
-                             y[j],
-                             z[k],
-                             x[i + 1],
-                             y[j],
-                             z[k],
-                             x[i + 1],
-                             y[j],
-                             z[k + 1],
-                             x[i],
-                             y[j],
-                             z[k + 1]};
+        double coords[12] = {x_vals_view[i],
+                             y_vals_view[j],
+                             z_vals_view[k],
+                             x_vals_view[i + 1],
+                             y_vals_view[j],
+                             z_vals_view[k],
+                             x_vals_view[i + 1],
+                             y_vals_view[j],
+                             z_vals_view[k + 1],
+                             x_vals_view[i],
+                             y_vals_view[j],
+                             z_vals_view[k + 1]};
 
         numerics::Matrix<double> coordsMatrix(dimension, 4, coords, NO_COPY);
         kernel(faceID, coordsMatrix, nodeIDs);
@@ -886,18 +964,18 @@ inline void for_all_faces_impl(xargs::coords,
         const IndexType n0 = i + j * nodeJp + k * nodeKp;
         const IndexType nodeIDs[4] = {n0, n0 + 1, n0 + 1 + nodeJp, n0 + nodeJp};
 
-        double coords[12] = {x[i],
-                             y[j],
-                             z[k],
-                             x[i + 1],
-                             y[j],
-                             z[k],
-                             x[i + 1],
-                             y[j + 1],
-                             z[k],
-                             x[i],
-                             y[j + 1],
-                             z[k]};
+        double coords[12] = {x_vals_view[i],
+                             y_vals_view[j],
+                             z_vals_view[k],
+                             x_vals_view[i + 1],
+                             y_vals_view[j],
+                             z_vals_view[k],
+                             x_vals_view[i + 1],
+                             y_vals_view[j + 1],
+                             z_vals_view[k],
+                             x_vals_view[i],
+                             y_vals_view[j + 1],
+                             z_vals_view[k]};
 
         numerics::Matrix<double> coordsMatrix(dimension, 4, coords, NO_COPY);
         kernel(faceID, coordsMatrix, nodeIDs);
@@ -955,9 +1033,30 @@ inline void for_all_faces_impl(xargs::coords,
 
   SLIC_ASSERT(m.getDimension() > 1 && m.getDimension() <= 3);
 
+  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
   const int dimension = m.getDimension();
-  const double* x = m.getCoordinateArray(X_COORDINATE);
-  const double* y = m.getCoordinateArray(Y_COORDINATE);
+
+  IndexType coordinate_size = m.getNumberOfNodes();
+
+  auto x_vals_h =
+    axom::ArrayView<const double>(m.getCoordinateArray(X_COORDINATE),
+                                  coordinate_size);
+  auto y_vals_h =
+    axom::ArrayView<const double>(m.getCoordinateArray(Y_COORDINATE),
+                                  coordinate_size);
+
+  // Move xy values onto device
+  axom::Array<double> x_vals_d = on_device
+    ? axom::Array<double>(x_vals_h, device_allocator)
+    : axom::Array<double>();
+  axom::Array<double> y_vals_d = on_device
+    ? axom::Array<double>(y_vals_h, device_allocator)
+    : axom::Array<double>();
+
+  auto x_vals_view = on_device ? x_vals_d.view() : x_vals_h;
+  auto y_vals_view = on_device ? y_vals_d.view() : y_vals_h;
 
   if(dimension == 2)
   {
@@ -969,8 +1068,8 @@ inline void for_all_faces_impl(xargs::coords,
         for(int i = 0; i < numNodes; ++i)
         {
           const IndexType nodeID = nodeIDs[i];
-          coords[2 * i] = x[nodeID];
-          coords[2 * i + 1] = y[nodeID];
+          coords[2 * i] = x_vals_view[nodeID];
+          coords[2 * i + 1] = y_vals_view[nodeID];
         }
 
         numerics::Matrix<double> coordsMatrix(dimension, 2, coords, NO_COPY);
@@ -979,7 +1078,17 @@ inline void for_all_faces_impl(xargs::coords,
   }
   else
   {
-    const double* z = m.getCoordinateArray(Z_COORDINATE);
+    auto z_vals_h =
+      axom::ArrayView<const double>(m.getCoordinateArray(Z_COORDINATE),
+                                    coordinate_size);
+
+    // Move z values onto device
+    axom::Array<double> z_vals_d = on_device
+      ? axom::Array<double>(z_vals_h, device_allocator)
+      : axom::Array<double>();
+
+    auto z_vals_view = on_device ? z_vals_d.view() : z_vals_h;
+
     for_all_faces_impl<ExecPolicy>(
       xargs::nodeids(),
       m,
@@ -988,9 +1097,9 @@ inline void for_all_faces_impl(xargs::coords,
         for(int i = 0; i < numNodes; ++i)
         {
           const IndexType nodeID = nodeIDs[i];
-          coords[3 * i] = x[nodeID];
-          coords[3 * i + 1] = y[nodeID];
-          coords[3 * i + 2] = z[nodeID];
+          coords[3 * i] = x_vals_view[nodeID];
+          coords[3 * i + 1] = y_vals_view[nodeID];
+          coords[3 * i + 2] = z_vals_view[nodeID];
         }
 
         numerics::Matrix<double> coordsMatrix(dimension, numNodes, coords, NO_COPY);

--- a/src/axom/mint/execution/internal/for_all_nodes.hpp
+++ b/src/axom/mint/execution/internal/for_all_nodes.hpp
@@ -199,14 +199,27 @@ inline void for_all_nodes_impl(xargs::x, const Mesh& m, KernelType&& kernel)
   SLIC_ERROR_IF(m.getDimension() != 1, "xargs::x is only valid for 1D meshes");
   SLIC_ERROR_IF(m.getMeshType() == STRUCTURED_UNIFORM_MESH,
                 "Not valid for UniformMesh.");
+  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+  IndexType coordinate_size = m.getNumberOfNodes();
 
-  const double* x = m.getCoordinateArray(X_COORDINATE);
-  SLIC_ASSERT(x != nullptr);
+  // extract coordinate values into an axom::Array
+  auto x_vals_h =
+    axom::ArrayView<const double>(m.getCoordinateArray(X_COORDINATE),
+                                  coordinate_size);
+
+  SLIC_ASSERT(x_vals_h.data() != nullptr);
+
+  // Move x values onto device
+  axom::Array<double> x_vals_d = on_device
+    ? axom::Array<double>(x_vals_h, device_allocator)
+    : axom::Array<double>();
+  auto x_vals_view = on_device ? x_vals_d.view() : x_vals_h;
 
   for_all_nodes_impl<ExecPolicy>(
     xargs::index(),
     m,
-    AXOM_LAMBDA(IndexType nodeID) { kernel(nodeID, x[nodeID]); });
+    AXOM_LAMBDA(IndexType nodeID) { kernel(nodeID, x_vals_view[nodeID]); });
 }
 
 //------------------------------------------------------------------------------
@@ -236,16 +249,30 @@ template <typename ExecPolicy, typename KernelType>
 inline void for_all_nodes_impl(xargs::xy, const UniformMesh& m, KernelType&& kernel)
 {
   SLIC_ERROR_IF(m.getDimension() != 2, "xargs::xy is only valid for 2D meshes");
+  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
 
-  const StackArray<double, 3>& origin = m.getOrigin();
-  const StackArray<double, 3>& spacing = m.getSpacing();
+  // extract origin and spacing into an axom::Array
+  auto origin_h = axom::ArrayView<const double>(m.getOrigin().begin(), 3);
+  auto spacing_h = axom::ArrayView<const double>(m.getSpacing().begin(), 3);
+
+  // Move origin and spacing values onto device
+  axom::Array<double> origin_d = on_device
+    ? axom::Array<double>(origin_h, device_allocator)
+    : axom::Array<double>();
+  auto origin_view = on_device ? origin_d.view() : origin_h;
+
+  axom::Array<double> spacing_d = on_device
+    ? axom::Array<double>(spacing_h, device_allocator)
+    : axom::Array<double>();
+  auto spacing_view = on_device ? spacing_d.view() : spacing_h;
 
   for_all_nodes_impl<ExecPolicy>(
     xargs::ij(),
     m,
     AXOM_LAMBDA(IndexType nodeID, IndexType i, IndexType j) {
-      const double x = origin[0] + i * spacing[0];
-      const double y = origin[1] + j * spacing[1];
+      const double x = origin_view[0] + i * spacing_view[0];
+      const double y = origin_view[1] + j * spacing_view[1];
       kernel(nodeID, x, y);
     });
 }
@@ -258,16 +285,36 @@ inline void for_all_nodes_impl(xargs::xy,
 {
   SLIC_ERROR_IF(m.getDimension() != 2, "xargs::xy is only valid for 2D meshes");
 
-  const double* x = m.getCoordinateArray(X_COORDINATE);
-  const double* y = m.getCoordinateArray(Y_COORDINATE);
-  SLIC_ASSERT(x != nullptr);
-  SLIC_ASSERT(y != nullptr);
+  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
+  // extract coordinate values into an axom::Array
+  auto x_vals_h =
+    axom::ArrayView<const double>(m.getCoordinateArray(X_COORDINATE),
+                                  m.getNodeResolution(X_COORDINATE));
+  auto y_vals_h =
+    axom::ArrayView<const double>(m.getCoordinateArray(Y_COORDINATE),
+                                  m.getNodeResolution(Y_COORDINATE));
+
+  SLIC_ASSERT(x_vals_h.data() != nullptr);
+  SLIC_ASSERT(y_vals_h.data() != nullptr);
+
+  // Move xy values onto device
+  axom::Array<double> x_vals_d = on_device
+    ? axom::Array<double>(x_vals_h, device_allocator)
+    : axom::Array<double>();
+  auto x_vals_view = on_device ? x_vals_d.view() : x_vals_h;
+
+  axom::Array<double> y_vals_d = on_device
+    ? axom::Array<double>(y_vals_h, device_allocator)
+    : axom::Array<double>();
+  auto y_vals_view = on_device ? y_vals_d.view() : y_vals_h;
 
   for_all_nodes_impl<ExecPolicy>(
     xargs::ij(),
     m,
     AXOM_LAMBDA(IndexType nodeID, IndexType i, IndexType j) {
-      kernel(nodeID, x[i], y[j]);
+      kernel(nodeID, x_vals_view[i], y_vals_view[j]);
     });
 }
 
@@ -281,15 +328,38 @@ inline void for_all_nodes_impl(xargs::xy, const Mesh& m, KernelType&& kernel)
   SLIC_ERROR_IF(m.getMeshType() == STRUCTURED_RECTILINEAR_MESH,
                 "Not valid for RectilinearMesh.");
 
-  const double* x = m.getCoordinateArray(X_COORDINATE);
-  const double* y = m.getCoordinateArray(Y_COORDINATE);
-  SLIC_ASSERT(x != nullptr);
-  SLIC_ASSERT(y != nullptr);
+  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+  IndexType coordinate_size = m.getNumberOfNodes();
+
+  // extract coordinate values into an axom::Array
+  auto x_vals_h =
+    axom::ArrayView<const double>(m.getCoordinateArray(X_COORDINATE),
+                                  coordinate_size);
+  auto y_vals_h =
+    axom::ArrayView<const double>(m.getCoordinateArray(Y_COORDINATE),
+                                  coordinate_size);
+
+  SLIC_ASSERT(x_vals_h.data() != nullptr);
+  SLIC_ASSERT(y_vals_h.data() != nullptr);
+
+  // Move xy values onto device
+  axom::Array<double> x_vals_d = on_device
+    ? axom::Array<double>(x_vals_h, device_allocator)
+    : axom::Array<double>();
+  auto x_vals_view = on_device ? x_vals_d.view() : x_vals_h;
+
+  axom::Array<double> y_vals_d = on_device
+    ? axom::Array<double>(y_vals_h, device_allocator)
+    : axom::Array<double>();
+  auto y_vals_view = on_device ? y_vals_d.view() : y_vals_h;
 
   for_all_nodes_impl<ExecPolicy>(
     xargs::index(),
     m,
-    AXOM_LAMBDA(IndexType nodeID) { kernel(nodeID, x[nodeID], y[nodeID]); });
+    AXOM_LAMBDA(IndexType nodeID) {
+      kernel(nodeID, x_vals_view[nodeID], y_vals_view[nodeID]);
+    });
 }
 
 //------------------------------------------------------------------------------
@@ -326,17 +396,31 @@ template <typename ExecPolicy, typename KernelType>
 inline void for_all_nodes_impl(xargs::xyz, const UniformMesh& m, KernelType&& kernel)
 {
   SLIC_ERROR_IF(m.getDimension() != 3, "xargs::xyz is only valid for 3D meshes");
+  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
 
-  const StackArray<double, 3> origin = m.getOrigin();
-  const StackArray<double, 3> spacing = m.getSpacing();
+  // extract origin and spacing into an axom::Array
+  auto origin_h = axom::ArrayView<const double>(m.getOrigin().begin(), 3);
+  auto spacing_h = axom::ArrayView<const double>(m.getSpacing().begin(), 3);
+
+  // Move origin and spacing values onto device
+  axom::Array<double> origin_d = on_device
+    ? axom::Array<double>(origin_h, device_allocator)
+    : axom::Array<double>();
+  auto origin_view = on_device ? origin_d.view() : origin_h;
+
+  axom::Array<double> spacing_d = on_device
+    ? axom::Array<double>(spacing_h, device_allocator)
+    : axom::Array<double>();
+  auto spacing_view = on_device ? spacing_d.view() : spacing_h;
 
   for_all_nodes_impl<ExecPolicy>(
     xargs::ijk(),
     m,
     AXOM_LAMBDA(IndexType nodeID, IndexType i, IndexType j, IndexType k) {
-      const double x = origin[0] + i * spacing[0];
-      const double y = origin[1] + j * spacing[1];
-      const double z = origin[2] + k * spacing[2];
+      const double x = origin_view[0] + i * spacing_view[0];
+      const double y = origin_view[1] + j * spacing_view[1];
+      const double z = origin_view[2] + k * spacing_view[2];
       kernel(nodeID, x, y, z);
     });
 }
@@ -348,15 +432,41 @@ inline void for_all_nodes_impl(xargs::xyz,
                                KernelType&& kernel)
 {
   SLIC_ERROR_IF(m.getDimension() != 3, "xargs::xyz is only valid for 3D meshes");
-  const double* x = m.getCoordinateArray(X_COORDINATE);
-  const double* y = m.getCoordinateArray(Y_COORDINATE);
-  const double* z = m.getCoordinateArray(Z_COORDINATE);
+  constexpr bool on_device = axom::execution_space<ExecPolicy>::onDevice();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
+  // extract coordinate values into an axom::Array
+  auto x_vals_h =
+    axom::ArrayView<const double>(m.getCoordinateArray(X_COORDINATE),
+                                  m.getNodeResolution(X_COORDINATE));
+  auto y_vals_h =
+    axom::ArrayView<const double>(m.getCoordinateArray(Y_COORDINATE),
+                                  m.getNodeResolution(Y_COORDINATE));
+  auto z_vals_h =
+    axom::ArrayView<const double>(m.getCoordinateArray(Z_COORDINATE),
+                                  m.getNodeResolution(Z_COORDINATE));
+
+  // Move xyz values onto device
+  axom::Array<double> x_vals_d = on_device
+    ? axom::Array<double>(x_vals_h, device_allocator)
+    : axom::Array<double>();
+  auto x_vals_view = on_device ? x_vals_d.view() : x_vals_h;
+
+  axom::Array<double> y_vals_d = on_device
+    ? axom::Array<double>(y_vals_h, device_allocator)
+    : axom::Array<double>();
+  auto y_vals_view = on_device ? y_vals_d.view() : y_vals_h;
+
+  axom::Array<double> z_vals_d = on_device
+    ? axom::Array<double>(z_vals_h, device_allocator)
+    : axom::Array<double>();
+  auto z_vals_view = on_device ? z_vals_d.view() : z_vals_h;
 
   for_all_nodes_impl<ExecPolicy>(
     xargs::ijk(),
     m,
     AXOM_LAMBDA(IndexType nodeID, IndexType i, IndexType j, IndexType k) {
-      kernel(nodeID, x[i], y[j], z[k]);
+      kernel(nodeID, x_vals_view[i], y_vals_view[j], z_vals_view[k]);
     });
 }
 

--- a/src/axom/mint/execution/internal/for_all_nodes.hpp
+++ b/src/axom/mint/execution/internal/for_all_nodes.hpp
@@ -385,9 +385,6 @@ inline void for_all_nodes_impl(xargs::xyz, const Mesh& m, KernelType&& kernel)
     axom::ArrayView<const double>(m.getCoordinateArray(Z_COORDINATE),
                                   coordinate_size);
 
-  // const double* x = m.getCoordinateArray(X_COORDINATE);
-  // const double* y = m.getCoordinateArray(Y_COORDINATE);
-  // const double* z = m.getCoordinateArray(Z_COORDINATE);
   SLIC_ASSERT(x_vals_h.data() != nullptr);
   SLIC_ASSERT(y_vals_h.data() != nullptr);
   SLIC_ASSERT(z_vals_h.data() != nullptr);

--- a/src/axom/mint/execution/internal/helpers.hpp
+++ b/src/axom/mint/execution/internal/helpers.hpp
@@ -37,6 +37,7 @@ namespace internal
  *  the number of nodes.
  * \param [in] m the Mesh to iterate over.
  * \param [in] kernel the kernel to call on each object.
+ *
  */
 
 template <typename ExecPolicy,
@@ -49,6 +50,11 @@ inline void for_all_coords(const FOR_ALL_FUNCTOR& for_all_nodes,
                            const MeshType& m,
                            KernelType&& kernel)
 {
+  SLIC_ERROR_IF(m.getMeshType() == STRUCTURED_UNIFORM_MESH,
+                "Not valid for UniformMesh.");
+  SLIC_ERROR_IF(m.getMeshType() == STRUCTURED_RECTILINEAR_MESH,
+                "Not valid for RectilinearMesh.");
+
   AXOM_STATIC_ASSERT_MSG(NDIM >= 1 && NDIM <= 3,
                          "NDIM must be a valid dimension.");
   AXOM_STATIC_ASSERT_MSG(NNODES > 0, "NNODES must be greater than zero.");
@@ -58,12 +64,38 @@ inline void for_all_coords(const FOR_ALL_FUNCTOR& for_all_nodes,
 
   SLIC_ERROR_IF(m.getDimension() != NDIM, "Dimension mismatch!");
 
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
   constexpr bool NO_COPY = true;
 
-  const StackArray<const double*, 3> coords = {
-    {m.getCoordinateArray(X_COORDINATE),
-     (NDIM > 1) ? m.getCoordinateArray(Y_COORDINATE) : nullptr,
-     (NDIM > 2) ? m.getCoordinateArray(Z_COORDINATE) : nullptr}};
+  IndexType coordinate_size = m.getNumberOfNodes();
+
+  // Extract coordinate values into an axom::ArrayView
+  auto x_vals_h =
+    axom::ArrayView<const double>(m.getCoordinateArray(X_COORDINATE),
+                                  coordinate_size);
+  auto y_vals_h = (NDIM > 1)
+    ? axom::ArrayView<const double>(m.getCoordinateArray(Y_COORDINATE),
+                                    coordinate_size)
+    : axom::ArrayView<const double>();
+  auto z_vals_h = (NDIM > 2)
+    ? axom::ArrayView<const double>(m.getCoordinateArray(Z_COORDINATE),
+                                    coordinate_size)
+    : axom::ArrayView<const double>();
+
+  // Move xyz values onto device
+  axom::Array<double> x_vals_d = axom::Array<double>(x_vals_h, device_allocator);
+  auto x_vals_view = x_vals_d.view();
+
+  axom::Array<double> y_vals_d = (NDIM > 1)
+    ? axom::Array<double>(y_vals_h, device_allocator)
+    : axom::Array<double>();
+  auto y_vals_view = (NDIM > 1) ? y_vals_d.view() : y_vals_h;
+
+  axom::Array<double> z_vals_d = (NDIM > 2)
+    ? axom::Array<double>(z_vals_h, device_allocator)
+    : axom::Array<double>();
+  auto z_vals_view = (NDIM > 2) ? z_vals_d.view() : z_vals_h;
 
   for_all_nodes(
     ExecPolicy(),
@@ -76,9 +108,15 @@ inline void for_all_coords(const FOR_ALL_FUNCTOR& for_all_nodes,
       for(int i = 0; i < NNODES; ++i)
       {
         const int i_offset = NDIM * i;
-        for(int dim = 0; dim < NDIM; ++dim)
+
+        localCoords[i_offset] = x_vals_view[nodeIDs[i]];
+        if(NDIM > 1)
         {
-          localCoords[i_offset + dim] = coords[dim][nodeIDs[i]];
+          localCoords[i_offset + 1] = y_vals_view[nodeIDs[i]];
+        }
+        if(NDIM > 2)
+        {
+          localCoords[i_offset + 2] = z_vals_view[nodeIDs[i]];
         }
       }
 

--- a/src/axom/mint/tests/mint_execution_cell_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_cell_traversals.cpp
@@ -424,10 +424,6 @@ void check_for_all_cell_faces(int dimension)
   EXPECT_TRUE(test_mesh != nullptr);
 
   const IndexType numCells = test_mesh->getNumberOfCells();
-  // IndexType* cellFaces =
-  //   test_mesh->template createField<IndexType>("cellFaces",
-  //                                              CELL_CENTERED,
-  //                                              MAX_CELL_FACES);
   axom::Array<IndexType> cell_faces_d(numCells * MAX_CELL_FACES,
                                       numCells * MAX_CELL_FACES,
                                       device_allocator);

--- a/src/axom/mint/tests/mint_execution_cell_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_cell_traversals.cpp
@@ -30,21 +30,6 @@ namespace mint
 //------------------------------------------------------------------------------
 namespace
 {
-#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE) &&   \
-  ((defined(AXOM_USE_CUDA) && defined(RAJA_ENABLE_CUDA)) || \
-   (defined(AXOM_USE_HIP) && defined(RAJA_ENABLE_HIP)))
-
-int set_um_memory_return_previous_allocator()
-{
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
-  return prev_allocator;
-}
-
-#endif
 
 template <typename ExecPolicy, int MeshType, int Topology = SINGLE_SHAPE>
 void check_for_all_cells_idx(int dimension)
@@ -53,6 +38,10 @@ void check_for_all_cells_idx(int dimension)
   SLIC_INFO("dimension=" << dimension
                          << ", policy=" << execution_space<ExecPolicy>::name()
                          << ", mesh_type=" << mesh_name);
+
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
 
   const IndexType Ni = 20;
   const IndexType Nj = (dimension >= 2) ? Ni : -1;
@@ -67,17 +56,29 @@ void check_for_all_cells_idx(int dimension)
     dynamic_cast<MESH*>(internal::create_mesh<MeshType, Topology>(uniform_mesh));
   EXPECT_TRUE(test_mesh != nullptr);
 
-  IndexType* field =
-    test_mesh->template createField<IndexType>("c1", CELL_CENTERED);
+  const IndexType numCells = test_mesh->getNumberOfCells();
+
+  axom::Array<IndexType> field_d(numCells, numCells, device_allocator);
+
+  auto field_v = field_d.view();
 
   for_all_cells<ExecPolicy>(
     test_mesh,
-    AXOM_LAMBDA(IndexType cellID) { field[cellID] = cellID; });
+    AXOM_LAMBDA(IndexType cellID) { field_v[cellID] = cellID; });
 
-  const IndexType numCells = test_mesh->getNumberOfCells();
+  // Copy field back to host
+  axom::Array<IndexType> field_h =
+    axom::Array<IndexType>(field_d, host_allocator);
+
+  // Create mesh field from buffer
+  IndexType* c1_field =
+    test_mesh->template createField<IndexType>("c1",
+                                               CELL_CENTERED,
+                                               field_h.data());
+
   for(IndexType cellID = 0; cellID < numCells; ++cellID)
   {
-    EXPECT_EQ(field[cellID], cellID);
+    EXPECT_EQ(c1_field[cellID], cellID);
   }
 
   delete test_mesh;
@@ -91,6 +92,10 @@ void check_for_all_cells_ij()
   SLIC_INFO("policy=" << execution_space<ExecPolicy>::name() << ", mesh_type="
                       << internal::mesh_type<MeshType>::name());
 
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
   constexpr IndexType N = 20;
   const double lo[] = {-10, -10};
   const double hi[] = {10, 10};
@@ -102,25 +107,42 @@ void check_for_all_cells_ij()
     dynamic_cast<MESH*>(internal::create_mesh<MeshType>(uniform_mesh));
   EXPECT_TRUE(test_mesh != nullptr);
 
-  IndexType* icoords =
-    test_mesh->template createField<IndexType>("i", CELL_CENTERED);
-  IndexType* jcoords =
-    test_mesh->template createField<IndexType>("j", CELL_CENTERED);
+  axom::Array<IndexType> icoords_d(N * N, N * N, device_allocator);
+  axom::Array<IndexType> jcoords_d(N * N, N * N, device_allocator);
+
+  auto icoords_v = icoords_d.view();
+  auto jcoords_v = jcoords_d.view();
 
   for_all_cells<ExecPolicy, xargs::ij>(
     test_mesh,
     AXOM_LAMBDA(IndexType cellIdx, IndexType i, IndexType j) {
-      icoords[cellIdx] = i;
-      jcoords[cellIdx] = j;
+      icoords_v[cellIdx] = i;
+      jcoords_v[cellIdx] = j;
     });
+
+  // Copy data back to host
+  axom::Array<IndexType> icoords_h =
+    axom::Array<IndexType>(icoords_d, host_allocator);
+  axom::Array<IndexType> jcoords_h =
+    axom::Array<IndexType>(jcoords_d, host_allocator);
+
+  // Create mesh fields from buffers
+  IndexType* i_field =
+    test_mesh->template createField<IndexType>("i",
+                                               CELL_CENTERED,
+                                               icoords_h.data());
+  IndexType* j_field =
+    test_mesh->template createField<IndexType>("j",
+                                               CELL_CENTERED,
+                                               jcoords_h.data());
 
   IndexType icell = 0;
   for(IndexType j = 0; j < (N - 1); ++j)
   {
     for(IndexType i = 0; i < (N - 1); ++i)
     {
-      EXPECT_EQ(icoords[icell], i);
-      EXPECT_EQ(jcoords[icell], j);
+      EXPECT_EQ(i_field[icell], i);
+      EXPECT_EQ(j_field[icell], j);
       ++icell;
     }  // END for all i
   }    // END for all j
@@ -133,6 +155,10 @@ void check_for_all_cells_ij()
 template <typename ExecPolicy, int MeshType>
 void check_for_all_cells_ijk()
 {
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
   SLIC_INFO("policy=" << execution_space<ExecPolicy>::name() << ", mesh_type="
                       << internal::mesh_type<MeshType>::name());
 
@@ -147,20 +173,45 @@ void check_for_all_cells_ijk()
     dynamic_cast<MESH*>(internal::create_mesh<MeshType>(uniform_mesh));
   EXPECT_TRUE(test_mesh != nullptr);
 
-  IndexType* icoords =
-    test_mesh->template createField<IndexType>("i", CELL_CENTERED);
-  IndexType* jcoords =
-    test_mesh->template createField<IndexType>("j", CELL_CENTERED);
-  IndexType* kcoords =
-    test_mesh->template createField<IndexType>("k", CELL_CENTERED);
+  const int size = N * N * N;
+  axom::Array<IndexType> icoords_d(size, size, device_allocator);
+  axom::Array<IndexType> jcoords_d(size, size, device_allocator);
+  axom::Array<IndexType> kcoords_d(size, size, device_allocator);
+
+  auto icoords_v = icoords_d.view();
+  auto jcoords_v = jcoords_d.view();
+  auto kcoords_v = kcoords_d.view();
 
   for_all_cells<ExecPolicy, xargs::ijk>(
     test_mesh,
     AXOM_LAMBDA(IndexType cellIdx, IndexType i, IndexType j, IndexType k) {
-      icoords[cellIdx] = i;
-      jcoords[cellIdx] = j;
-      kcoords[cellIdx] = k;
+      icoords_v[cellIdx] = i;
+      jcoords_v[cellIdx] = j;
+      kcoords_v[cellIdx] = k;
     });
+
+  // Copy data back to host
+  axom::Array<IndexType> icoords_h =
+    axom::Array<IndexType>(icoords_d, host_allocator);
+  axom::Array<IndexType> jcoords_h =
+    axom::Array<IndexType>(jcoords_d, host_allocator);
+  axom::Array<IndexType> kcoords_h =
+    axom::Array<IndexType>(kcoords_d, host_allocator);
+
+  // Create mesh fields from buffers
+  IndexType* i_field =
+    test_mesh->template createField<IndexType>("i",
+                                               CELL_CENTERED,
+                                               icoords_h.data());
+  IndexType* j_field =
+    test_mesh->template createField<IndexType>("j",
+                                               CELL_CENTERED,
+                                               jcoords_h.data());
+
+  IndexType* k_field =
+    test_mesh->template createField<IndexType>("k",
+                                               CELL_CENTERED,
+                                               kcoords_h.data());
 
   IndexType icell = 0;
   for(IndexType k = 0; k < (N - 1); ++k)
@@ -169,9 +220,9 @@ void check_for_all_cells_ijk()
     {
       for(IndexType i = 0; i < (N - 1); ++i)
       {
-        EXPECT_EQ(icoords[icell], i);
-        EXPECT_EQ(jcoords[icell], j);
-        EXPECT_EQ(kcoords[icell], k);
+        EXPECT_EQ(i_field[icell], i);
+        EXPECT_EQ(j_field[icell], j);
+        EXPECT_EQ(k_field[icell], k);
         ++icell;
       }  // END for all i
     }    // END for all j
@@ -190,6 +241,10 @@ void check_for_all_cell_nodes(int dimension)
                          << ", policy=" << execution_space<ExecPolicy>::name()
                          << ", mesh_type=" << mesh_name);
 
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
   const IndexType Ni = 20;
   const IndexType Nj = (dimension >= 2) ? Ni : -1;
   const IndexType Nk = (dimension == 3) ? Ni : -1;
@@ -204,18 +259,31 @@ void check_for_all_cell_nodes(int dimension)
   EXPECT_TRUE(test_mesh != nullptr);
 
   const IndexType numCells = test_mesh->getNumberOfCells();
-  IndexType* conn = test_mesh->template createField<IndexType>("conn",
-                                                               CELL_CENTERED,
-                                                               MAX_CELL_NODES);
+
+  axom::Array<IndexType> conn_d(numCells * MAX_CELL_NODES,
+                                numCells * MAX_CELL_NODES,
+                                device_allocator);
+
+  auto conn_v = conn_d.view();
 
   for_all_cells<ExecPolicy, xargs::nodeids>(
     test_mesh,
     AXOM_LAMBDA(IndexType cellID, const IndexType* nodes, IndexType N) {
       for(int i = 0; i < N; ++i)
       {
-        conn[cellID * MAX_CELL_NODES + i] = nodes[i];
+        conn_v[cellID * MAX_CELL_NODES + i] = nodes[i];
       }  // END for all cell nodes
     });
+
+  // Copy data back to host
+  axom::Array<IndexType> conn_h = axom::Array<IndexType>(conn_d, host_allocator);
+
+  // Create mesh field from buffer
+  IndexType* conn_field =
+    test_mesh->template createField<IndexType>("conn",
+                                               CELL_CENTERED,
+                                               conn_h.data(),
+                                               MAX_CELL_NODES);
 
   IndexType cellNodes[MAX_CELL_NODES];
   for(IndexType cellID = 0; cellID < numCells; ++cellID)
@@ -223,7 +291,7 @@ void check_for_all_cell_nodes(int dimension)
     const IndexType N = test_mesh->getCellNodeIDs(cellID, cellNodes);
     for(int i = 0; i < N; ++i)
     {
-      EXPECT_EQ(conn[cellID * MAX_CELL_NODES + i], cellNodes[i]);
+      EXPECT_EQ(conn_field[cellID * MAX_CELL_NODES + i], cellNodes[i]);
     }
   }  // END for all cells
 
@@ -241,6 +309,10 @@ void check_for_all_cell_coords(int dimension)
                          << ", policy=" << execution_space<ExecPolicy>::name()
                          << ", mesh_type=" << mesh_name);
 
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
   const IndexType Ni = 20;
   const IndexType Nj = (dimension >= 2) ? Ni : -1;
   const IndexType Nk = (dimension == 3) ? Ni : -1;
@@ -255,13 +327,16 @@ void check_for_all_cell_coords(int dimension)
   EXPECT_TRUE(test_mesh != nullptr);
 
   const IndexType numCells = test_mesh->getNumberOfCells();
-  IndexType* conn = test_mesh->template createField<IndexType>("conn",
-                                                               CELL_CENTERED,
-                                                               MAX_CELL_NODES);
-  double* coords =
-    test_mesh->template createField<double>("coords",
-                                            CELL_CENTERED,
-                                            dimension * MAX_CELL_NODES);
+
+  axom::Array<IndexType> conn_d(numCells * MAX_CELL_NODES,
+                                numCells * MAX_CELL_NODES,
+                                device_allocator);
+  axom::Array<double> coords_d(numCells * dimension * MAX_CELL_NODES,
+                               numCells * dimension * MAX_CELL_NODES,
+                               device_allocator);
+
+  auto conn_v = conn_d.view();
+  auto coords_v = coords_d.view();
 
   for_all_cells<ExecPolicy, xargs::coords>(
     test_mesh,
@@ -271,15 +346,31 @@ void check_for_all_cell_coords(int dimension)
       const IndexType numNodes = coordsMatrix.getNumColumns();
       for(int i = 0; i < numNodes; ++i)
       {
-        conn[cellID * MAX_CELL_NODES + i] = nodes[i];
+        conn_v[cellID * MAX_CELL_NODES + i] = nodes[i];
 
         for(int dim = 0; dim < dimension; ++dim)
         {
-          coords[cellID * dimension * MAX_CELL_NODES + i * dimension + dim] =
+          coords_v[cellID * dimension * MAX_CELL_NODES + i * dimension + dim] =
             coordsMatrix(dim, i);
         }
       }  // END for all cell nodes
     });
+
+  // Copy data back to host
+  axom::Array<IndexType> conn_h = axom::Array<IndexType>(conn_d, host_allocator);
+  axom::Array<double> coords_h = axom::Array<double>(coords_d, host_allocator);
+
+  // Create mesh fields from buffers
+  IndexType* conn_field =
+    test_mesh->template createField<IndexType>("conn",
+                                               CELL_CENTERED,
+                                               conn_h.data(),
+                                               MAX_CELL_NODES);
+  double* coords_field =
+    test_mesh->template createField<double>("coords",
+                                            CELL_CENTERED,
+                                            coords_h.data(),
+                                            dimension * MAX_CELL_NODES);
 
   double nodeCoords[3];
   IndexType cellNodes[MAX_CELL_NODES];
@@ -288,13 +379,13 @@ void check_for_all_cell_coords(int dimension)
     const IndexType numNodes = test_mesh->getCellNodeIDs(cellID, cellNodes);
     for(int i = 0; i < numNodes; ++i)
     {
-      EXPECT_EQ(conn[cellID * MAX_CELL_NODES + i], cellNodes[i]);
+      EXPECT_EQ(conn_field[cellID * MAX_CELL_NODES + i], cellNodes[i]);
 
       for(int dim = 0; dim < dimension; ++dim)
       {
         test_mesh->getNode(cellNodes[i], nodeCoords);
         EXPECT_NEAR(
-          coords[cellID * dimension * MAX_CELL_NODES + i * dimension + dim],
+          coords_field[cellID * dimension * MAX_CELL_NODES + i * dimension + dim],
           nodeCoords[dim],
           1e-8);
       }
@@ -315,6 +406,10 @@ void check_for_all_cell_faces(int dimension)
                          << ", policy=" << execution_space<ExecPolicy>::name()
                          << ", mesh_type=" << mesh_name);
 
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
   const IndexType Ni = 20;
   const IndexType Nj = (dimension >= 2) ? Ni : -1;
   const IndexType Nk = (dimension == 3) ? Ni : -1;
@@ -329,19 +424,35 @@ void check_for_all_cell_faces(int dimension)
   EXPECT_TRUE(test_mesh != nullptr);
 
   const IndexType numCells = test_mesh->getNumberOfCells();
-  IndexType* cellFaces =
-    test_mesh->template createField<IndexType>("cellFaces",
-                                               CELL_CENTERED,
-                                               MAX_CELL_FACES);
+  // IndexType* cellFaces =
+  //   test_mesh->template createField<IndexType>("cellFaces",
+  //                                              CELL_CENTERED,
+  //                                              MAX_CELL_FACES);
+  axom::Array<IndexType> cell_faces_d(numCells * MAX_CELL_FACES,
+                                      numCells * MAX_CELL_FACES,
+                                      device_allocator);
+
+  auto cell_faces_v = cell_faces_d.view();
 
   for_all_cells<ExecPolicy, xargs::faceids>(
     test_mesh,
     AXOM_LAMBDA(IndexType cellID, const IndexType* faces, IndexType N) {
       for(int i = 0; i < N; ++i)
       {
-        cellFaces[cellID * MAX_CELL_FACES + i] = faces[i];
+        cell_faces_v[cellID * MAX_CELL_FACES + i] = faces[i];
       }
     });
+
+  // Copy data back to host
+  axom::Array<IndexType> cell_faces_h =
+    axom::Array<IndexType>(cell_faces_d, host_allocator);
+
+  // Create mesh fields from buffers
+  IndexType* cell_faces_field =
+    test_mesh->template createField<IndexType>("cellFaces",
+                                               CELL_CENTERED,
+                                               cell_faces_h.data(),
+                                               MAX_CELL_NODES);
 
   IndexType faces[MAX_CELL_FACES];
   for(IndexType cellID = 0; cellID < numCells; ++cellID)
@@ -350,7 +461,7 @@ void check_for_all_cell_faces(int dimension)
 
     for(IndexType i = 0; i < N; ++i)
     {
-      EXPECT_EQ(cellFaces[cellID * MAX_CELL_FACES + i], faces[i]);
+      EXPECT_EQ(cell_faces_field[cellID * MAX_CELL_FACES + i], faces[i]);
     }
   }
 
@@ -394,15 +505,12 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_nodeids)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_cell_nodes<cuda_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cell_nodes<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(i);
     check_for_all_cell_nodes<cuda_exec, STRUCTURED_RECTILINEAR_MESH>(i);
     check_for_all_cell_nodes<cuda_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(i);
     check_for_all_cell_nodes<cuda_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(i);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
@@ -410,15 +518,12 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_nodeids)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_cell_nodes<hip_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cell_nodes<hip_exec, STRUCTURED_CURVILINEAR_MESH>(i);
     check_for_all_cell_nodes<hip_exec, STRUCTURED_RECTILINEAR_MESH>(i);
     check_for_all_cell_nodes<hip_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(i);
     check_for_all_cell_nodes<hip_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(i);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
   }  // END for all dimensions
@@ -453,15 +558,12 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_coords)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_cell_coords<cuda_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cell_coords<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(i);
     check_for_all_cell_coords<cuda_exec, STRUCTURED_RECTILINEAR_MESH>(i);
     check_for_all_cell_coords<cuda_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(i);
     check_for_all_cell_coords<cuda_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(i);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
@@ -469,15 +571,12 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_coords)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_cell_coords<hip_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cell_coords<hip_exec, STRUCTURED_CURVILINEAR_MESH>(i);
     check_for_all_cell_coords<hip_exec, STRUCTURED_RECTILINEAR_MESH>(i);
     check_for_all_cell_coords<hip_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(i);
     check_for_all_cell_coords<hip_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(i);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
   }  // END for all dimensions
@@ -512,15 +611,12 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_faceids)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_cell_faces<cuda_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cell_faces<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(i);
     check_for_all_cell_faces<cuda_exec, STRUCTURED_RECTILINEAR_MESH>(i);
     check_for_all_cell_faces<seq_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(i);
     check_for_all_cell_faces<seq_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(i);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
@@ -528,15 +624,12 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_faceids)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_cell_faces<hip_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cell_faces<hip_exec, STRUCTURED_CURVILINEAR_MESH>(i);
     check_for_all_cell_faces<hip_exec, STRUCTURED_RECTILINEAR_MESH>(i);
     check_for_all_cell_faces<hip_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(i);
     check_for_all_cell_faces<hip_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(i);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
   }  // END for all dimensions
@@ -565,13 +658,10 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_ij)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  const int prev_allocator = set_um_memory_return_previous_allocator();
-
   check_for_all_cells_ij<cuda_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_cells_ij<cuda_exec, STRUCTURED_CURVILINEAR_MESH>();
   check_for_all_cells_ij<cuda_exec, STRUCTURED_RECTILINEAR_MESH>();
 
-  setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
@@ -579,13 +669,10 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_ij)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  const int prev_allocator = set_um_memory_return_previous_allocator();
-
   check_for_all_cells_ij<hip_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_cells_ij<hip_exec, STRUCTURED_CURVILINEAR_MESH>();
   check_for_all_cells_ij<hip_exec, STRUCTURED_RECTILINEAR_MESH>();
 
-  setDefaultAllocator(prev_allocator);
 #endif
 }
 
@@ -612,13 +699,10 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_ijk)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  const int prev_allocator = set_um_memory_return_previous_allocator();
-
   check_for_all_cells_ijk<cuda_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_cells_ijk<cuda_exec, STRUCTURED_CURVILINEAR_MESH>();
   check_for_all_cells_ijk<cuda_exec, STRUCTURED_RECTILINEAR_MESH>();
 
-  setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
@@ -626,13 +710,10 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_ijk)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  const int prev_allocator = set_um_memory_return_previous_allocator();
-
   check_for_all_cells_ijk<hip_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_cells_ijk<hip_exec, STRUCTURED_CURVILINEAR_MESH>();
   check_for_all_cells_ijk<hip_exec, STRUCTURED_RECTILINEAR_MESH>();
 
-  setDefaultAllocator(prev_allocator);
 #endif
 }
 
@@ -666,15 +747,11 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_index)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_cells_idx<cuda_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cells_idx<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(i);
     check_for_all_cells_idx<cuda_exec, STRUCTURED_RECTILINEAR_MESH>(i);
     check_for_all_cells_idx<cuda_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(i);
     check_for_all_cells_idx<cuda_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(i);
-
-    setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
@@ -682,15 +759,11 @@ AXOM_CUDA_TEST(mint_execution_cell_traversals, for_all_cells_index)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_cells_idx<hip_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_cells_idx<hip_exec, STRUCTURED_CURVILINEAR_MESH>(i);
     check_for_all_cells_idx<hip_exec, STRUCTURED_RECTILINEAR_MESH>(i);
     check_for_all_cells_idx<hip_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(i);
     check_for_all_cells_idx<hip_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(i);
-
-    setDefaultAllocator(prev_allocator);
 #endif
 
   }  // END for all dimensions

--- a/src/axom/mint/tests/mint_execution_face_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_face_traversals.cpp
@@ -28,21 +28,6 @@ namespace mint
 //------------------------------------------------------------------------------
 namespace
 {
-#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE) &&   \
-  ((defined(AXOM_USE_CUDA) && defined(RAJA_ENABLE_CUDA)) || \
-   (defined(AXOM_USE_HIP) && defined(RAJA_ENABLE_HIP)))
-
-int set_um_memory_return_previous_allocator()
-{
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
-  return prev_allocator;
-}
-
-#endif
 
 template <typename ExecPolicy, int MeshType, int Topology = SINGLE_SHAPE>
 void check_for_all_faces(int dimension)
@@ -51,6 +36,10 @@ void check_for_all_faces(int dimension)
   SLIC_INFO("dimension=" << dimension
                          << ", policy=" << execution_space<ExecPolicy>::name()
                          << ", mesh_type=" << mesh_name);
+
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
 
   const IndexType Ni = 20;
   const IndexType Nj = (dimension >= 2) ? Ni : -1;
@@ -67,16 +56,27 @@ void check_for_all_faces(int dimension)
 
   const IndexType numFaces = test_mesh->getNumberOfFaces();
 
-  IndexType* field =
-    test_mesh->template createField<IndexType>("f1", FACE_CENTERED);
+  axom::Array<IndexType> field_d(numFaces, numFaces, device_allocator);
+
+  auto field_v = field_d.view();
 
   for_all_faces<ExecPolicy>(
     test_mesh,
-    AXOM_LAMBDA(IndexType faceID) { field[faceID] = faceID; });
+    AXOM_LAMBDA(IndexType faceID) { field_v[faceID] = faceID; });
+
+  // Copy field back to host
+  axom::Array<IndexType> field_h =
+    axom::Array<IndexType>(field_d, host_allocator);
+
+  // Create mesh field from buffer
+  IndexType* f1_field =
+    test_mesh->template createField<IndexType>("f1",
+                                               FACE_CENTERED,
+                                               field_h.data());
 
   for(IndexType faceID = 0; faceID < numFaces; ++faceID)
   {
-    EXPECT_EQ(field[faceID], faceID);
+    EXPECT_EQ(f1_field[faceID], faceID);
   }
 
   delete test_mesh;
@@ -92,6 +92,10 @@ void check_for_all_face_nodes(int dimension)
                          << ", policy=" << execution_space<ExecPolicy>::name()
                          << ", mesh_type=" << mesh_name);
 
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
   const IndexType Ni = 20;
   const IndexType Nj = (dimension >= 2) ? Ni : -1;
   const IndexType Nk = (dimension == 3) ? Ni : -1;
@@ -106,18 +110,28 @@ void check_for_all_face_nodes(int dimension)
   EXPECT_TRUE(test_mesh != nullptr);
 
   const IndexType numFaces = test_mesh->getNumberOfFaces();
-  IndexType* conn = test_mesh->template createField<IndexType>("f1",
-                                                               FACE_CENTERED,
-                                                               MAX_FACE_NODES);
+
+  axom::Array<IndexType> conn_d(numFaces * MAX_FACE_NODES,
+                                numFaces * MAX_FACE_NODES,
+                                device_allocator);
+
+  auto conn_v = conn_d.view();
 
   for_all_faces<ExecPolicy, xargs::nodeids>(
     test_mesh,
     AXOM_LAMBDA(IndexType faceID, const IndexType* nodes, IndexType N) {
       for(int i = 0; i < N; ++i)
       {
-        conn[faceID * MAX_FACE_NODES + i] = nodes[i];
+        conn_v[faceID * MAX_FACE_NODES + i] = nodes[i];
       }  // END for all face nodes
     });
+
+  // Copy field back to host
+  axom::Array<IndexType> conn_h = axom::Array<IndexType>(conn_d, host_allocator);
+
+  // Create mesh field from buffer
+  IndexType* conn_field =
+    test_mesh->template createField<IndexType>("f1", FACE_CENTERED, conn_h.data());
 
   IndexType faceNodes[MAX_FACE_NODES];
   for(IndexType faceID = 0; faceID < numFaces; ++faceID)
@@ -125,7 +139,7 @@ void check_for_all_face_nodes(int dimension)
     const IndexType N = test_mesh->getFaceNodeIDs(faceID, faceNodes);
     for(int i = 0; i < N; ++i)
     {
-      EXPECT_EQ(conn[faceID * MAX_FACE_NODES + i], faceNodes[i]);
+      EXPECT_EQ(conn_field[faceID * MAX_FACE_NODES + i], faceNodes[i]);
     }
   }  // END for all cells
 
@@ -143,6 +157,10 @@ void check_for_all_face_coords(int dimension)
                          << ", policy=" << execution_space<ExecPolicy>::name()
                          << ", mesh_type=" << mesh_name);
 
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
   const IndexType Ni = 20;
   const IndexType Nj = (dimension >= 2) ? Ni : -1;
   const IndexType Nk = (dimension == 3) ? Ni : -1;
@@ -157,13 +175,15 @@ void check_for_all_face_coords(int dimension)
   EXPECT_TRUE(test_mesh != nullptr);
 
   const IndexType numFaces = test_mesh->getNumberOfFaces();
-  IndexType* conn = test_mesh->template createField<IndexType>("conn",
-                                                               FACE_CENTERED,
-                                                               MAX_FACE_NODES);
-  double* coords =
-    test_mesh->template createField<double>("coords",
-                                            FACE_CENTERED,
-                                            dimension * MAX_FACE_NODES);
+  axom::Array<IndexType> conn_d(numFaces * MAX_FACE_NODES,
+                                numFaces * MAX_FACE_NODES,
+                                device_allocator);
+  axom::Array<double> coords_d(numFaces * dimension * MAX_FACE_NODES,
+                               numFaces * dimension * MAX_FACE_NODES,
+                               device_allocator);
+
+  auto conn_v = conn_d.view();
+  auto coords_v = coords_d.view();
 
   for_all_faces<ExecPolicy, xargs::coords>(
     test_mesh,
@@ -173,15 +193,31 @@ void check_for_all_face_coords(int dimension)
       const IndexType numNodes = coordsMatrix.getNumColumns();
       for(int i = 0; i < numNodes; ++i)
       {
-        conn[faceID * MAX_FACE_NODES + i] = nodes[i];
+        conn_v[faceID * MAX_FACE_NODES + i] = nodes[i];
 
         for(int dim = 0; dim < dimension; ++dim)
         {
-          coords[faceID * dimension * MAX_FACE_NODES + i * dimension + dim] =
+          coords_v[faceID * dimension * MAX_FACE_NODES + i * dimension + dim] =
             coordsMatrix(dim, i);
         }
       }  // END for all face nodes
     });
+
+  // Copy data back to host
+  axom::Array<IndexType> conn_h = axom::Array<IndexType>(conn_d, host_allocator);
+  axom::Array<double> coords_h = axom::Array<double>(coords_d, host_allocator);
+
+  // Create mesh fields from buffers
+  IndexType* conn_field =
+    test_mesh->template createField<IndexType>("conn",
+                                               FACE_CENTERED,
+                                               conn_h.data(),
+                                               MAX_FACE_NODES);
+  double* coords_field =
+    test_mesh->template createField<double>("coords",
+                                            FACE_CENTERED,
+                                            coords_h.data(),
+                                            dimension * MAX_FACE_NODES);
 
   double nodeCoords[3];
   IndexType faceNodes[MAX_FACE_NODES];
@@ -190,13 +226,13 @@ void check_for_all_face_coords(int dimension)
     const IndexType numNodes = test_mesh->getFaceNodeIDs(faceID, faceNodes);
     for(int i = 0; i < numNodes; ++i)
     {
-      EXPECT_EQ(conn[faceID * MAX_FACE_NODES + i], faceNodes[i]);
+      EXPECT_EQ(conn_field[faceID * MAX_FACE_NODES + i], faceNodes[i]);
 
       for(int dim = 0; dim < dimension; ++dim)
       {
         test_mesh->getNode(faceNodes[i], nodeCoords);
         EXPECT_NEAR(
-          coords[faceID * dimension * MAX_FACE_NODES + i * dimension + dim],
+          coords_field[faceID * dimension * MAX_FACE_NODES + i * dimension + dim],
           nodeCoords[dim],
           1e-8);
       }
@@ -217,6 +253,10 @@ void check_for_all_face_cells(int dimension)
                          << ", policy=" << execution_space<ExecPolicy>::name()
                          << ", mesh_type=" << mesh_name);
 
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
   const IndexType Ni = 20;
   const IndexType Nj = (dimension >= 2) ? Ni : -1;
   const IndexType Nk = (dimension == 3) ? Ni : -1;
@@ -231,23 +271,35 @@ void check_for_all_face_cells(int dimension)
   EXPECT_TRUE(test_mesh != nullptr);
 
   const IndexType numFaces = test_mesh->getNumberOfFaces();
-  IndexType* faceCells =
-    test_mesh->template createField<IndexType>("f1", FACE_CENTERED, 2);
+  axom::Array<IndexType> face_cells_d(numFaces * 2, numFaces * 2, device_allocator);
+
+  auto face_cells_v = face_cells_d.view();
 
   for_all_faces<ExecPolicy, xargs::cellids>(
     test_mesh,
     AXOM_LAMBDA(IndexType faceID, IndexType cellIDOne, IndexType cellIDTwo) {
-      faceCells[2 * faceID + 0] = cellIDOne;
-      faceCells[2 * faceID + 1] = cellIDTwo;
+      face_cells_v[2 * faceID + 0] = cellIDOne;
+      face_cells_v[2 * faceID + 1] = cellIDTwo;
     });
+
+  // Copy field back to host
+  axom::Array<IndexType> face_cells_h =
+    axom::Array<IndexType>(face_cells_d, host_allocator);
+
+  // Create mesh field from buffer
+  IndexType* face_cells_field =
+    test_mesh->template createField<IndexType>("f1",
+                                               FACE_CENTERED,
+                                               face_cells_h.data(),
+                                               2);
 
   for(IndexType faceID = 0; faceID < numFaces; ++faceID)
   {
     IndexType cellIDOne, cellIDTwo;
     test_mesh->getFaceCellIDs(faceID, cellIDOne, cellIDTwo);
 
-    EXPECT_EQ(faceCells[2 * faceID + 0], cellIDOne);
-    EXPECT_EQ(faceCells[2 * faceID + 1], cellIDTwo);
+    EXPECT_EQ(face_cells_field[2 * faceID + 0], cellIDOne);
+    EXPECT_EQ(face_cells_field[2 * faceID + 1], cellIDTwo);
   }
 
   /* clean up */
@@ -289,15 +341,12 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_nodeids)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_face_nodes<cuda_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_face_nodes<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
     check_for_all_face_nodes<cuda_exec, STRUCTURED_RECTILINEAR_MESH>(dim);
     check_for_all_face_nodes<cuda_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(dim);
     check_for_all_face_nodes<cuda_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(dim);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
@@ -305,15 +354,12 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_nodeids)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_face_nodes<hip_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_face_nodes<hip_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
     check_for_all_face_nodes<hip_exec, STRUCTURED_RECTILINEAR_MESH>(dim);
     check_for_all_face_nodes<hip_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(dim);
     check_for_all_face_nodes<hip_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(dim);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
   }  // END for all dimensions
@@ -347,15 +393,12 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_coords)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_face_coords<cuda_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_face_coords<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
     check_for_all_face_coords<cuda_exec, STRUCTURED_RECTILINEAR_MESH>(dim);
     check_for_all_face_coords<cuda_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(dim);
     check_for_all_face_coords<cuda_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(dim);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
@@ -363,15 +406,12 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_coords)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_face_coords<hip_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_face_coords<hip_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
     check_for_all_face_coords<hip_exec, STRUCTURED_RECTILINEAR_MESH>(dim);
     check_for_all_face_coords<hip_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(dim);
     check_for_all_face_coords<hip_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(dim);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
   }  // END for all dimensions
@@ -405,15 +445,12 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_cellids)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_face_cells<cuda_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_face_cells<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
     check_for_all_face_cells<cuda_exec, STRUCTURED_RECTILINEAR_MESH>(dim);
     check_for_all_face_nodes<cuda_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(dim);
     check_for_all_face_nodes<cuda_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(dim);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
@@ -421,15 +458,12 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_face_cellids)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_face_cells<hip_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_face_cells<hip_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
     check_for_all_face_cells<hip_exec, STRUCTURED_RECTILINEAR_MESH>(dim);
     check_for_all_face_nodes<hip_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(dim);
     check_for_all_face_nodes<hip_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(dim);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
   }  // END for all dimensions
@@ -464,15 +498,12 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_faces_index)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_faces<cuda_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_faces<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
     check_for_all_faces<cuda_exec, STRUCTURED_RECTILINEAR_MESH>(dim);
     check_for_all_faces<cuda_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(dim);
     check_for_all_faces<cuda_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(dim);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
@@ -480,15 +511,12 @@ AXOM_CUDA_TEST(mint_execution_face_traversals, for_all_faces_index)
 
     using hip_exec = axom::HIP_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_faces<hip_exec, STRUCTURED_UNIFORM_MESH>(dim);
     check_for_all_faces<hip_exec, STRUCTURED_CURVILINEAR_MESH>(dim);
     check_for_all_faces<hip_exec, STRUCTURED_RECTILINEAR_MESH>(dim);
     check_for_all_faces<hip_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(dim);
     check_for_all_faces<hip_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(dim);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
   }  // END for all dimensions

--- a/src/axom/mint/tests/mint_execution_node_traversals.cpp
+++ b/src/axom/mint/tests/mint_execution_node_traversals.cpp
@@ -29,21 +29,6 @@ namespace mint
 //------------------------------------------------------------------------------
 namespace
 {
-#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE) &&   \
-  ((defined(AXOM_USE_CUDA) && defined(RAJA_ENABLE_CUDA)) || \
-   (defined(AXOM_USE_HIP) && defined(RAJA_ENABLE_HIP)))
-
-int set_um_memory_return_previous_allocator()
-{
-  // Use unified memory
-  const int exec_space_id = axom::getUmpireResourceAllocatorID(
-    umpire::resource::MemoryResourceType::Unified);
-  const int prev_allocator = axom::getDefaultAllocatorID();
-  axom::setDefaultAllocator(exec_space_id);
-  return prev_allocator;
-}
-
-#endif
 
 template <typename ExecPolicy, int MeshType, int Topology = SINGLE_SHAPE>
 void check_for_all_nodes_idx(int dimension)
@@ -52,6 +37,10 @@ void check_for_all_nodes_idx(int dimension)
   SLIC_INFO("dimension=" << dimension
                          << ", policy=" << execution_space<ExecPolicy>::name()
                          << ", mesh_type=" << mesh_name);
+
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
 
   constexpr int MAGIC_VAL = 42;
 
@@ -68,16 +57,25 @@ void check_for_all_nodes_idx(int dimension)
     dynamic_cast<MESH*>(internal::create_mesh<MeshType, Topology>(uniform_mesh));
   EXPECT_TRUE(test_mesh != nullptr);
 
-  int* field = test_mesh->template createField<int>("n1", NODE_CENTERED);
+  const IndexType numNodes = test_mesh->getNumberOfNodes();
+  axom::Array<int> field_d(numNodes, numNodes, device_allocator);
+
+  auto field_v = field_d.view();
 
   for_all_nodes<ExecPolicy>(
     test_mesh,
-    AXOM_LAMBDA(IndexType nodeIdx) { field[nodeIdx] = MAGIC_VAL; });
+    AXOM_LAMBDA(IndexType nodeIdx) { field_v[nodeIdx] = MAGIC_VAL; });
 
-  const IndexType numNodes = test_mesh->getNumberOfNodes();
+  // Copy data back to host
+  axom::Array<int> field_h = axom::Array<int>(field_d, host_allocator);
+
+  // Create mesh field from buffer
+  int* n1_field =
+    test_mesh->template createField<int>("n1", NODE_CENTERED, field_h.data());
+
   for(IndexType inode = 0; inode < numNodes; ++inode)
   {
-    EXPECT_EQ(field[inode], MAGIC_VAL);
+    EXPECT_EQ(n1_field[inode], MAGIC_VAL);
   }
 
   delete test_mesh;
@@ -91,6 +89,10 @@ void check_for_all_nodes_ij()
   SLIC_INFO("policy=" << execution_space<ExecPolicy>::name() << ", mesh_type="
                       << internal::mesh_type<MeshType>::name());
 
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
   constexpr IndexType N = 20;
   const double lo[] = {-10, -10};
   const double hi[] = {10, 10};
@@ -104,23 +106,32 @@ void check_for_all_nodes_ij()
 
   const IndexType numNodes = test_mesh->getNumberOfNodes();
 
-  IndexType* icoords = axom::allocate<IndexType>(numNodes);
-  IndexType* jcoords = axom::allocate<IndexType>(numNodes);
+  axom::Array<IndexType> icoords_d(numNodes, numNodes, device_allocator);
+  axom::Array<IndexType> jcoords_d(numNodes, numNodes, device_allocator);
+
+  auto icoords_v = icoords_d.view();
+  auto jcoords_v = jcoords_d.view();
 
   for_all_nodes<ExecPolicy, xargs::ij>(
     test_mesh,
     AXOM_LAMBDA(IndexType nodeIdx, IndexType i, IndexType j) {
-      icoords[nodeIdx] = i;
-      jcoords[nodeIdx] = j;
+      icoords_v[nodeIdx] = i;
+      jcoords_v[nodeIdx] = j;
     });
+
+  // Copy data back to host
+  axom::Array<IndexType> icoords_h =
+    axom::Array<IndexType>(icoords_d, host_allocator);
+  axom::Array<IndexType> jcoords_h =
+    axom::Array<IndexType>(jcoords_d, host_allocator);
 
   IndexType inode = 0;
   for(IndexType j = 0; j < N; ++j)
   {
     for(IndexType i = 0; i < N; ++i)
     {
-      EXPECT_EQ(icoords[inode], i);
-      EXPECT_EQ(jcoords[inode], j);
+      EXPECT_EQ(icoords_h[inode], i);
+      EXPECT_EQ(jcoords_h[inode], j);
       ++inode;
 
     }  // END for all i
@@ -128,9 +139,6 @@ void check_for_all_nodes_ij()
 
   delete test_mesh;
   test_mesh = nullptr;
-
-  axom::deallocate(icoords);
-  axom::deallocate(jcoords);
 }
 
 //------------------------------------------------------------------------------
@@ -139,6 +147,10 @@ void check_for_all_nodes_ijk()
 {
   SLIC_INFO("policy=" << execution_space<ExecPolicy>::name() << ", mesh_type="
                       << internal::mesh_type<MeshType>::name());
+
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
 
   constexpr IndexType N = 20;
   const double lo[] = {-10, -10, -10};
@@ -153,17 +165,29 @@ void check_for_all_nodes_ijk()
 
   const IndexType numNodes = test_mesh->getNumberOfNodes();
 
-  IndexType* icoords = axom::allocate<IndexType>(numNodes);
-  IndexType* jcoords = axom::allocate<IndexType>(numNodes);
-  IndexType* kcoords = axom::allocate<IndexType>(numNodes);
+  axom::Array<IndexType> icoords_d(numNodes, numNodes, device_allocator);
+  axom::Array<IndexType> jcoords_d(numNodes, numNodes, device_allocator);
+  axom::Array<IndexType> kcoords_d(numNodes, numNodes, device_allocator);
+
+  auto icoords_v = icoords_d.view();
+  auto jcoords_v = jcoords_d.view();
+  auto kcoords_v = kcoords_d.view();
 
   for_all_nodes<ExecPolicy, xargs::ijk>(
     test_mesh,
     AXOM_LAMBDA(IndexType nodeIdx, IndexType i, IndexType j, IndexType k) {
-      icoords[nodeIdx] = i;
-      jcoords[nodeIdx] = j;
-      kcoords[nodeIdx] = k;
+      icoords_v[nodeIdx] = i;
+      jcoords_v[nodeIdx] = j;
+      kcoords_v[nodeIdx] = k;
     });
+
+  // Copy data back to host
+  axom::Array<IndexType> icoords_h =
+    axom::Array<IndexType>(icoords_d, host_allocator);
+  axom::Array<IndexType> jcoords_h =
+    axom::Array<IndexType>(jcoords_d, host_allocator);
+  axom::Array<IndexType> kcoords_h =
+    axom::Array<IndexType>(kcoords_d, host_allocator);
 
   IndexType inode = 0;
   for(IndexType k = 0; k < N; ++k)
@@ -172,9 +196,9 @@ void check_for_all_nodes_ijk()
     {
       for(IndexType i = 0; i < N; ++i)
       {
-        EXPECT_EQ(icoords[inode], i);
-        EXPECT_EQ(jcoords[inode], j);
-        EXPECT_EQ(kcoords[inode], k);
+        EXPECT_EQ(icoords_h[inode], i);
+        EXPECT_EQ(jcoords_h[inode], j);
+        EXPECT_EQ(kcoords_h[inode], k);
         ++inode;
 
       }  // END for all i
@@ -183,10 +207,6 @@ void check_for_all_nodes_ijk()
 
   delete test_mesh;
   test_mesh = nullptr;
-
-  axom::deallocate(icoords);
-  axom::deallocate(jcoords);
-  axom::deallocate(kcoords);
 }
 
 //------------------------------------------------------------------------------
@@ -197,6 +217,10 @@ void check_for_all_nodes_xyz()
   SLIC_INFO("policy=" << execution_space<ExecPolicy>::name()
                       << ", mesh_type=" << mesh_name);
 
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
+
   constexpr IndexType N = 20;
   const double lo[] = {-10, -10, -10};
   const double hi[] = {10, 10, 10};
@@ -210,34 +234,41 @@ void check_for_all_nodes_xyz()
 
   // STEP 1: generate test coordinate arrays
   const IndexType numNodes = test_mesh->getNumberOfNodes();
-  double* x = axom::allocate<double>(numNodes);
-  double* y = axom::allocate<double>(numNodes);
-  double* z = axom::allocate<double>(numNodes);
+
+  axom::Array<double> x_d(numNodes, numNodes, device_allocator);
+  axom::Array<double> y_d(numNodes, numNodes, device_allocator);
+  axom::Array<double> z_d(numNodes, numNodes, device_allocator);
+
+  auto x_v = x_d.view();
+  auto y_v = y_d.view();
+  auto z_v = z_d.view();
+
   for_all_nodes<ExecPolicy, xargs::xyz>(
     test_mesh,
     AXOM_LAMBDA(IndexType idx, double xx, double yy, double zz) {
-      x[idx] = xx;
-      y[idx] = yy;
-      z[idx] = zz;
+      x_v[idx] = xx;
+      y_v[idx] = yy;
+      z_v[idx] = zz;
     });
+
+  // Copy data back to host
+  axom::Array<double> x_h = axom::Array<double>(x_d, host_allocator);
+  axom::Array<double> y_h = axom::Array<double>(y_d, host_allocator);
+  axom::Array<double> z_h = axom::Array<double>(z_d, host_allocator);
 
   // STEP 2:check coordinate arrays
   for(int inode = 0; inode < numNodes; ++inode)
   {
     double node[3];
     test_mesh->getNode(inode, node);
-    EXPECT_DOUBLE_EQ(x[inode], node[X_COORDINATE]);
-    EXPECT_DOUBLE_EQ(y[inode], node[Y_COORDINATE]);
-    EXPECT_DOUBLE_EQ(z[inode], node[Z_COORDINATE]);
+    EXPECT_DOUBLE_EQ(x_h[inode], node[X_COORDINATE]);
+    EXPECT_DOUBLE_EQ(y_h[inode], node[Y_COORDINATE]);
+    EXPECT_DOUBLE_EQ(z_h[inode], node[Z_COORDINATE]);
   }  // END for all nodes
 
   // STEP 3: clean up
   delete test_mesh;
   test_mesh = nullptr;
-
-  axom::deallocate(x);
-  axom::deallocate(y);
-  axom::deallocate(z);
 }
 
 //------------------------------------------------------------------------------
@@ -247,6 +278,10 @@ void check_for_all_nodes_xy()
   constexpr char* mesh_name = internal::mesh_type<MeshType, Topology>::name();
   SLIC_INFO("policy=" << execution_space<ExecPolicy>::name()
                       << ", mesh_type=" << mesh_name);
+
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
 
   constexpr IndexType N = 20;
   const double lo[] = {-10, -10};
@@ -261,30 +296,36 @@ void check_for_all_nodes_xy()
 
   // STEP 1: generate test coordinate arrays
   const IndexType numNodes = test_mesh->getNumberOfNodes();
-  double* x = axom::allocate<double>(numNodes);
-  double* y = axom::allocate<double>(numNodes);
+
+  axom::Array<double> x_d(numNodes, numNodes, device_allocator);
+  axom::Array<double> y_d(numNodes, numNodes, device_allocator);
+
+  auto x_v = x_d.view();
+  auto y_v = y_d.view();
+
   for_all_nodes<ExecPolicy, xargs::xy>(
     test_mesh,
     AXOM_LAMBDA(IndexType idx, double xx, double yy) {
-      x[idx] = xx;
-      y[idx] = yy;
+      x_v[idx] = xx;
+      y_v[idx] = yy;
     });
+
+  // Copy data back to host
+  axom::Array<double> x_h = axom::Array<double>(x_d, host_allocator);
+  axom::Array<double> y_h = axom::Array<double>(y_d, host_allocator);
 
   // STEP 2:check coordinate arrays
   for(int inode = 0; inode < numNodes; ++inode)
   {
     double node[2];
     test_mesh->getNode(inode, node);
-    EXPECT_DOUBLE_EQ(x[inode], node[X_COORDINATE]);
-    EXPECT_DOUBLE_EQ(y[inode], node[Y_COORDINATE]);
+    EXPECT_DOUBLE_EQ(x_h[inode], node[X_COORDINATE]);
+    EXPECT_DOUBLE_EQ(y_h[inode], node[Y_COORDINATE]);
   }  // END for all nodes
 
   // STEP 3: clean up
   delete test_mesh;
   test_mesh = nullptr;
-
-  axom::deallocate(x);
-  axom::deallocate(y);
 }
 
 //------------------------------------------------------------------------------
@@ -294,6 +335,10 @@ void check_for_all_nodes_x()
   constexpr char* mesh_name = internal::mesh_type<MeshType, Topology>::name();
   SLIC_INFO("policy=" << execution_space<ExecPolicy>::name()
                       << ", mesh_type=" << mesh_name);
+
+  // Get ids of necessary allocators
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecPolicy>::allocatorID();
 
   constexpr IndexType Ni = 20;
   const double lo[] = {-10};
@@ -313,23 +358,28 @@ void check_for_all_nodes_x()
 
   // STEP 1: generate test coordinate arrays
   const IndexType numNodes = uniform_mesh.getNumberOfNodes();
-  double* x = axom::allocate<double>(numNodes);
+
+  axom::Array<double> x_d(numNodes, numNodes, device_allocator);
+  auto x_v = x_d.view();
+
   for_all_nodes<ExecPolicy, xargs::x>(
     test_mesh,
-    AXOM_LAMBDA(IndexType idx, double xx) { x[idx] = xx; });
+    AXOM_LAMBDA(IndexType idx, double xx) { x_v[idx] = xx; });
+
+  // Copy data back to host
+  axom::Array<double> x_h = axom::Array<double>(x_d, host_allocator);
 
   // STEP 2:check coordinate arrays
   for(int inode = 0; inode < numNodes; ++inode)
   {
     double node[1];
     uniform_mesh.getNode(inode, node);
-    EXPECT_DOUBLE_EQ(x[inode], node[X_COORDINATE]);
+    EXPECT_DOUBLE_EQ(x_h[inode], node[X_COORDINATE]);
   }  // END for all nodes
 
   // STEP 3: clean up
   delete test_mesh;
   test_mesh = nullptr;
-  axom::deallocate(x);
 }
 
 } /* end anonymous namespace */
@@ -366,8 +416,6 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_xyz)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  const int prev_allocator = set_um_memory_return_previous_allocator();
-
   check_for_all_nodes_xyz<cuda_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_xyz<cuda_exec, STRUCTURED_CURVILINEAR_MESH>();
   check_for_all_nodes_xyz<cuda_exec, STRUCTURED_RECTILINEAR_MESH>();
@@ -375,15 +423,12 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_xyz)
   check_for_all_nodes_xyz<cuda_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>();
   check_for_all_nodes_xyz<cuda_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>();
 
-  setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
   defined(RAJA_ENABLE_HIP) && defined(AXOM_USE_UMPIRE)
 
   using hip_exec = axom::HIP_EXEC<512>;
-
-  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_nodes_xyz<hip_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_xyz<hip_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -392,7 +437,6 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_xyz)
   check_for_all_nodes_xyz<hip_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>();
   check_for_all_nodes_xyz<hip_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>();
 
-  setDefaultAllocator(prev_allocator);
 #endif
 }
 
@@ -425,8 +469,6 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_xy)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  const int prev_allocator = set_um_memory_return_previous_allocator();
-
   check_for_all_nodes_xy<cuda_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_xy<cuda_exec, STRUCTURED_CURVILINEAR_MESH>();
   check_for_all_nodes_xy<cuda_exec, STRUCTURED_RECTILINEAR_MESH>();
@@ -434,15 +476,12 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_xy)
   check_for_all_nodes_xy<cuda_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>();
   check_for_all_nodes_xy<cuda_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>();
 
-  setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
   defined(RAJA_ENABLE_HIP) && defined(AXOM_USE_UMPIRE)
 
   using hip_exec = axom::HIP_EXEC<512>;
-
-  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_nodes_xy<hip_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_xy<hip_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -451,7 +490,6 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_xy)
   check_for_all_nodes_xy<hip_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>();
   check_for_all_nodes_xy<hip_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>();
 
-  setDefaultAllocator(prev_allocator);
 #endif
 }
 
@@ -484,8 +522,6 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_x)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  const int prev_allocator = set_um_memory_return_previous_allocator();
-
   check_for_all_nodes_x<cuda_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_x<cuda_exec, STRUCTURED_CURVILINEAR_MESH>();
   check_for_all_nodes_x<cuda_exec, STRUCTURED_RECTILINEAR_MESH>();
@@ -493,15 +529,12 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_x)
   check_for_all_nodes_x<cuda_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>();
   check_for_all_nodes_x<cuda_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>();
 
-  setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
   defined(RAJA_ENABLE_HIP) && defined(AXOM_USE_UMPIRE)
 
   using hip_exec = axom::HIP_EXEC<512>;
-
-  const int prev_allocator = set_um_memory_return_previous_allocator();
 
   check_for_all_nodes_x<hip_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_x<hip_exec, STRUCTURED_CURVILINEAR_MESH>();
@@ -510,7 +543,6 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_x)
   check_for_all_nodes_x<hip_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>();
   check_for_all_nodes_x<hip_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>();
 
-  setDefaultAllocator(prev_allocator);
 #endif
 }
 
@@ -537,13 +569,10 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_ijk)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  const int prev_allocator = set_um_memory_return_previous_allocator();
-
   check_for_all_nodes_ijk<cuda_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_ijk<cuda_exec, STRUCTURED_CURVILINEAR_MESH>();
   check_for_all_nodes_ijk<cuda_exec, STRUCTURED_RECTILINEAR_MESH>();
 
-  setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
@@ -551,13 +580,10 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_ijk)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  const int prev_allocator = set_um_memory_return_previous_allocator();
-
   check_for_all_nodes_ijk<hip_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_ijk<hip_exec, STRUCTURED_CURVILINEAR_MESH>();
   check_for_all_nodes_ijk<hip_exec, STRUCTURED_RECTILINEAR_MESH>();
 
-  setDefaultAllocator(prev_allocator);
 #endif
 }
 
@@ -584,13 +610,10 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_ij)
 
   using cuda_exec = axom::CUDA_EXEC<512>;
 
-  const int prev_allocator = set_um_memory_return_previous_allocator();
-
   check_for_all_nodes_ij<cuda_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_ij<cuda_exec, STRUCTURED_CURVILINEAR_MESH>();
   check_for_all_nodes_ij<cuda_exec, STRUCTURED_RECTILINEAR_MESH>();
 
-  setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
@@ -598,13 +621,10 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_ij)
 
   using hip_exec = axom::HIP_EXEC<512>;
 
-  const int prev_allocator = set_um_memory_return_previous_allocator();
-
   check_for_all_nodes_ij<hip_exec, STRUCTURED_UNIFORM_MESH>();
   check_for_all_nodes_ij<hip_exec, STRUCTURED_CURVILINEAR_MESH>();
   check_for_all_nodes_ij<hip_exec, STRUCTURED_RECTILINEAR_MESH>();
 
-  setDefaultAllocator(prev_allocator);
 #endif
 }
 
@@ -640,8 +660,6 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_index)
 
     using cuda_exec = axom::CUDA_EXEC<512>;
 
-    const int prev_allocator = set_um_memory_return_previous_allocator();
-
     check_for_all_nodes_idx<cuda_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_nodes_idx<cuda_exec, STRUCTURED_CURVILINEAR_MESH>(i);
     check_for_all_nodes_idx<cuda_exec, STRUCTURED_RECTILINEAR_MESH>(i);
@@ -649,15 +667,12 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_index)
     check_for_all_nodes_idx<cuda_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(i);
     check_for_all_nodes_idx<cuda_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(i);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && \
   defined(RAJA_ENABLE_HIP) && defined(AXOM_USE_UMPIRE)
 
     using hip_exec = axom::HIP_EXEC<512>;
-
-    const int prev_allocator = set_um_memory_return_previous_allocator();
 
     check_for_all_nodes_idx<hip_exec, STRUCTURED_UNIFORM_MESH>(i);
     check_for_all_nodes_idx<hip_exec, STRUCTURED_CURVILINEAR_MESH>(i);
@@ -666,7 +681,6 @@ AXOM_CUDA_TEST(mint_execution_node_traversals, for_all_nodes_index)
     check_for_all_nodes_idx<hip_exec, UNSTRUCTURED_MESH, SINGLE_SHAPE>(i);
     check_for_all_nodes_idx<hip_exec, UNSTRUCTURED_MESH, MIXED_SHAPE>(i);
 
-    setDefaultAllocator(prev_allocator);
 #endif
 
   }  // END for all dimensions

--- a/src/axom/primal/examples/CMakeLists.txt
+++ b/src/axom/primal/examples/CMakeLists.txt
@@ -39,4 +39,28 @@ if (RAJA_FOUND AND UMPIRE_FOUND)
         FOLDER      axom/primal/examples
         )
 
+    # Add unit tests
+    if(AXOM_ENABLE_TESTS)
+
+        # Run the hex_tet_volume_ex example with different raja policies
+        # to check for completion
+
+        set (_policies "seq")
+        blt_list_append(TO _policies ELEMENTS "omp" IF AXOM_ENABLE_OPENMP)
+        blt_list_append(TO _policies ELEMENTS "cuda" IF AXOM_ENABLE_CUDA)
+        blt_list_append(TO _policies ELEMENTS "hip" IF AXOM_ENABLE_HIP)
+
+        foreach(_policy ${_policies})
+
+            set(_testname "primal_hex_tet_volume_ex_${_policy}")
+            axom_add_test(
+              NAME ${_testname}
+              COMMAND hex_tet_volume_ex
+                      --policy ${_policy}
+            )
+
+            set_tests_properties(${_testname} PROPERTIES
+                PASS_REGULAR_EXPRESSION  "Difference between sums")
+        endforeach()
+    endif()
 endif()

--- a/src/axom/quest/DistributedClosestPoint.cpp
+++ b/src/axom/quest/DistributedClosestPoint.cpp
@@ -69,21 +69,16 @@ void DistributedClosestPoint::setDefaultAllocatorID()
 #ifdef __CUDACC__
   #ifdef AXOM_RUNTIME_POLICY_USE_CUDA
   case RuntimePolicy::cuda:
-
-    // Use unified memory
     defaultAllocatorID =
-      axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
+      axom::execution_space<axom::CUDA_EXEC<256>>::allocatorID();
     break;
   #endif
 #endif
 
 #ifdef AXOM_RUNTIME_POLICY_USE_HIP
   case RuntimePolicy::hip:
-
-    // Use unified memory
     defaultAllocatorID =
-      axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
-
+      axom::execution_space<axom::HIP_EXEC<256>>::allocatorID();
     break;
 #endif
   }

--- a/src/axom/quest/detail/MeshTester_detail.hpp
+++ b/src/axom/quest/detail/MeshTester_detail.hpp
@@ -160,6 +160,8 @@ protected:
 template <typename ExecSpace, typename FloatType>
 void CandidateFinderBase<ExecSpace, FloatType>::initialize()
 {
+  int allocatorID = axom::execution_space<ExecSpace>::allocatorID();
+
   const int ncells = m_surfaceMesh->getNumberOfCells();
 
   m_tris.resize(ncells);
@@ -186,7 +188,7 @@ void CandidateFinderBase<ExecSpace, FloatType>::initialize()
 
       for(IndexType inode = 0; inode < 3; ++inode)
       {
-        const double* node = coords.getColumn(inode);
+        double* node = coords.getColumn(inode);
         tri[inode] = PointType {node[mint::X_COORDINATE],
                                 node[mint::Y_COORDINATE],
                                 node[mint::Z_COORDINATE]};

--- a/src/axom/quest/detail/MeshTester_detail.hpp
+++ b/src/axom/quest/detail/MeshTester_detail.hpp
@@ -188,7 +188,7 @@ void CandidateFinderBase<ExecSpace, FloatType>::initialize()
 
       for(IndexType inode = 0; inode < 3; ++inode)
       {
-        double* node = coords.getColumn(inode);
+        const double* node = coords.getColumn(inode);
         tri[inode] = PointType {node[mint::X_COORDINATE],
                                 node[mint::Y_COORDINATE],
                                 node[mint::Z_COORDINATE]};

--- a/src/axom/quest/detail/MeshTester_detail.hpp
+++ b/src/axom/quest/detail/MeshTester_detail.hpp
@@ -160,8 +160,6 @@ protected:
 template <typename ExecSpace, typename FloatType>
 void CandidateFinderBase<ExecSpace, FloatType>::initialize()
 {
-  int allocatorID = axom::execution_space<ExecSpace>::allocatorID();
-
   const int ncells = m_surfaceMesh->getNumberOfCells();
 
   m_tris.resize(ncells);

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -49,6 +49,33 @@ if (RAJA_FOUND AND UMPIRE_FOUND)
         DEPENDS_ON  ${quest_example_depends}
         FOLDER      axom/quest/examples
         )
+
+    # Add unit tests
+    if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR)
+
+        # Run the quest_bvh_two_pass example with different raja policies
+
+        set(input_file "${AXOM_DATA_DIR}/quest/unit_cube.stl")
+
+        set (_policies "seq")
+        blt_list_append(TO _policies ELEMENTS "omp" IF AXOM_ENABLE_OPENMP)
+        blt_list_append(TO _policies ELEMENTS "cuda" IF AXOM_ENABLE_CUDA)
+        blt_list_append(TO _policies ELEMENTS "hip" IF AXOM_ENABLE_HIP)
+
+        foreach(_policy ${_policies})
+
+            set(_testname "quest_bvh_two_pass_example_${_policy}")
+            axom_add_test(
+              NAME ${_testname}
+              COMMAND quest_bvh_two_pass_ex
+                      --file ${input_file}
+                      --exec_space ${_policy}
+            )
+
+            set_tests_properties(${_testname} PROPERTIES
+                PASS_REGULAR_EXPRESSION  "Found 4 actual collisions")
+        endforeach()
+    endif()
 endif()
 
 # Read ProE example -----------------------------------------------------------

--- a/src/axom/quest/examples/quest_bvh_two_pass.cpp
+++ b/src/axom/quest/examples/quest_bvh_two_pass.cpp
@@ -123,8 +123,6 @@ void find_collisions_broadphase(const mint::Mesh* mesh,
   const auto v_aabbs = aabbs.view();
 
   // Initialize the bounding box for each cell
-  axom::utilities::Timer timer(true);
-
   mint::for_all_cells<ExecSpace, mint::xargs::coords>(
     mesh,
     AXOM_LAMBDA(IndexType cellIdx,
@@ -140,7 +138,6 @@ void find_collisions_broadphase(const mint::Mesh* mesh,
         PointType vtx {node[mint::X_COORDINATE],
                        node[mint::Y_COORDINATE],
                        node[mint::Z_COORDINATE]};
-        // PointType vtx {0, 1, 2};
         aabb.addPoint(vtx);
       }  // END for all cells nodes
 
@@ -275,7 +272,6 @@ void find_collisions_narrowphase(const mint::Mesh* mesh,
   const auto v_triangles = triangles.view();
 
   // Create an array with our surface mesh's triangles
-  axom::utilities::Timer timer(true);
   mint::for_all_cells<ExecSpace, mint::xargs::coords>(
     mesh,
     AXOM_LAMBDA(IndexType cellIdx,

--- a/src/axom/quest/examples/quest_bvh_two_pass.cpp
+++ b/src/axom/quest/examples/quest_bvh_two_pass.cpp
@@ -123,6 +123,8 @@ void find_collisions_broadphase(const mint::Mesh* mesh,
   const auto v_aabbs = aabbs.view();
 
   // Initialize the bounding box for each cell
+  axom::utilities::Timer timer(true);
+
   mint::for_all_cells<ExecSpace, mint::xargs::coords>(
     mesh,
     AXOM_LAMBDA(IndexType cellIdx,
@@ -138,6 +140,7 @@ void find_collisions_broadphase(const mint::Mesh* mesh,
         PointType vtx {node[mint::X_COORDINATE],
                        node[mint::Y_COORDINATE],
                        node[mint::Z_COORDINATE]};
+        // PointType vtx {0, 1, 2};
         aabb.addPoint(vtx);
       }  // END for all cells nodes
 
@@ -272,6 +275,7 @@ void find_collisions_narrowphase(const mint::Mesh* mesh,
   const auto v_triangles = triangles.view();
 
   // Create an array with our surface mesh's triangles
+  axom::utilities::Timer timer(true);
   mint::for_all_cells<ExecSpace, mint::xargs::coords>(
     mesh,
     AXOM_LAMBDA(IndexType cellIdx,
@@ -390,21 +394,6 @@ int main(int argc, char** argv)
     finalize_logger();
     return retval;
   }
-#ifdef AXOM_USE_CUDA
-  if(args.exec_space == ExecPolicy::CUDA)
-  {
-    using GPUExec = axom::CUDA_EXEC<256>;
-    axom::setDefaultAllocator(axom::execution_space<GPUExec>::allocatorID());
-  }
-#endif
-#ifdef AXOM_USE_HIP
-  if(args.exec_space == ExecPolicy::HIP)
-  {
-    using GPUExec = axom::HIP_EXEC<256>;
-    axom::setDefaultAllocator(axom::execution_space<GPUExec>::allocatorID());
-  }
-#endif
-
   std::unique_ptr<UMesh> surface_mesh;
 
   // Read file

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -484,8 +484,6 @@ std::vector<std::pair<int, int>> naiveIntersectionAlgorithm(
   axom::deallocate(intersections);
   axom::deallocate(counter);
 
-  // axom::setDefaultAllocator(current_allocator);
-
   return retval;
 }
 #endif  // defined(AXOM_USE_RAJA)

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -410,17 +410,7 @@ std::vector<std::pair<int, int>> naiveIntersectionAlgorithm(
 
   // Get allocator
   const int current_allocator = axom::getDefaultAllocatorID();
-
-  // Use unified memory if on device
   int allocatorID = axom::execution_space<ExecSpace>::allocatorID();
-  #if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-  if(axom::execution_space<ExecSpace>::onDevice())
-  {
-    allocatorID = axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
-  }
-  #endif
-
-  axom::setDefaultAllocator(allocatorID);
 
   std::vector<std::pair<int, int>> retval;
 
@@ -494,7 +484,7 @@ std::vector<std::pair<int, int>> naiveIntersectionAlgorithm(
   axom::deallocate(intersections);
   axom::deallocate(counter);
 
-  axom::setDefaultAllocator(current_allocator);
+  // axom::setDefaultAllocator(current_allocator);
 
   return retval;
 }
@@ -626,26 +616,6 @@ int main(int argc, char** argv)
   {
     return app.exit(e);
   }
-
-#ifdef AXOM_USE_CUDA
-  if(params.policy == raja_cuda)
-  {
-    // Use unified memory on device
-    int unified_id =
-      axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
-    axom::setDefaultAllocator(unified_id);
-  }
-#endif
-
-#if defined(AXOM_USE_HIP) && defined(NDEBUG)
-  if(params.policy == raja_hip)
-  {
-    // Use unified memory on device
-    int unified_id =
-      axom::getUmpireResourceAllocatorID(umpire::resource::Unified);
-    axom::setDefaultAllocator(unified_id);
-  }
-#endif
 
   // _read_stl_file_start
   // Read file

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -408,22 +408,23 @@ std::vector<std::pair<int, int>> naiveIntersectionAlgorithm(
             << " in execution Space: "
             << axom::execution_space<ExecSpace>::name());
 
-  // Get allocator
-  const int current_allocator = axom::getDefaultAllocatorID();
-  int allocatorID = axom::execution_space<ExecSpace>::allocatorID();
+  // Get allocators
+  constexpr bool on_device = axom::execution_space<ExecSpace>::onDevice();
+  const int host_allocator = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  const int device_allocator = axom::execution_space<ExecSpace>::allocatorID();
 
   std::vector<std::pair<int, int>> retval;
 
   const int ncells = surface_mesh->getNumberOfCells();
   SLIC_INFO("Checking mesh with a total of " << ncells << " cells.");
 
-  Triangle3* tris = axom::allocate<Triangle3>(ncells);
+  axom::Array<Triangle3> tris_h(ncells, ncells, host_allocator);
 
   // Get each triangle in the mesh and check for degeneracies
   for(int i = 0; i < ncells; i++)
   {
-    tris[i] = getMeshTriangle(i, surface_mesh);
-    if(tris[i].degenerate())
+    tris_h[i] = getMeshTriangle(i, surface_mesh);
+    if(tris_h[i].degenerate())
     {
       degenerate.push_back(i);
     }
@@ -439,13 +440,20 @@ std::vector<std::pair<int, int>> naiveIntersectionAlgorithm(
 
   RAJA::ReduceSum<REDUCE_POL, int> numIntersect(0);
 
+  // Copy triangles to device
+  axom::Array<Triangle3> tris_d = on_device
+    ? axom::Array<Triangle3>(tris_h, device_allocator)
+    : axom::Array<Triangle3>();
+
+  auto tris_v = on_device ? tris_d.view() : tris_h.view();
+
   // Compute the number of intersections
   RAJA::kernel<KERNEL_POL>(
     RAJA::make_tuple(col_range, row_range),
     AXOM_LAMBDA(int col, int row) {
       if(row > col)
       {
-        if(checkTT(tris[row], tris[col], EPS))
+        if(checkTT(tris_v[row], tris_v[col], EPS))
         {
           numIntersect += 1;
         }
@@ -453,10 +461,17 @@ std::vector<std::pair<int, int>> naiveIntersectionAlgorithm(
     });
 
   // Allocation to hold intersection pairs and counter to know where to store
-  int* intersections = axom::allocate<int>(numIntersect.get() * 2);
-  int* counter = axom::allocate<int>(1);
+  axom::Array<int> intersections_d(numIntersect.get() * 2,
+                                   numIntersect.get() * 2,
+                                   device_allocator);
+  axom::Array<int> counter_h(1, 1, host_allocator);
+  counter_h[0] = 0;
+  axom::Array<int> counter_d = on_device
+    ? axom::Array<int>(counter_h, device_allocator)
+    : axom::Array<int>();
 
-  counter[0] = 0;
+  auto intersections_v = intersections_d.view();
+  auto counter_v = on_device ? counter_d.view() : counter_h.view();
 
   // RAJA loop to populate with intersections
   RAJA::kernel<KERNEL_POL>(
@@ -464,25 +479,25 @@ std::vector<std::pair<int, int>> naiveIntersectionAlgorithm(
     AXOM_LAMBDA(int col, int row) {
       if(row > col)
       {
-        if(checkTT(tris[row], tris[col], EPS))
+        if(checkTT(tris_v[row], tris_v[col], EPS))
         {
-          auto idx = RAJA::atomicAdd<ATOMIC_POL>(counter, 2);
-          intersections[idx] = row;
-          intersections[idx + 1] = col;
+          auto idx = RAJA::atomicAdd<ATOMIC_POL>(counter_v.data(), 2);
+          intersections_v[idx] = row;
+          intersections_v[idx + 1] = col;
         }
       }
     });
 
+  // Copy intersections to host
+  axom::Array<int> intersections_h = on_device
+    ? axom::Array<int>(intersections_d, host_allocator)
+    : std::move(intersections_d);
+
   // Initialize pairs of clashes
   for(auto i = 0; i < numIntersect.get() * 2; i += 2)
   {
-    retval.push_back(std::make_pair(intersections[i], intersections[i + 1]));
+    retval.push_back(std::make_pair(intersections_h[i], intersections_h[i + 1]));
   }
-
-  // Deallocate
-  axom::deallocate(tris);
-  axom::deallocate(intersections);
-  axom::deallocate(counter);
 
   return retval;
 }


### PR DESCRIPTION
This PR:

- Contains work related to issue https://github.com/LLNL/axom/issues/1339
- Refactors several examples and tests to allow for execution with a device policy (previously required unified policy to run on device), notably:
  - mint `for_all_*` execution loops
  - `mesh_tester`
  - `point_in_cell_benchmark`