### PR TITLE
change to tag number to fix warning

### DIFF
--- a/src/axom/lumberjack/MPIUtility.cpp
+++ b/src/axom/lumberjack/MPIUtility.cpp
@@ -21,7 +21,7 @@ namespace axom
 {
 namespace lumberjack
 {
-constexpr int LJ_TAG = 55432;
+constexpr int LJ_TAG = 32766;
 
 const char* mpiBlockingReceiveMessages(MPI_Comm comm)
 {


### PR DESCRIPTION
# Summary

This fixes a warning that I saw when running mpi mustrun /collab/usr/global/tools/tce4/opt/must-1.9.2/bin/mustrun --must:mpiexec srun --must:np -n -n 4 executable -inputs

```
Argument 5 (tag) is a tag that is larger than 32767 and may thus only be supported by some MPI implementations. This implementation supports tags up to 268435455. For portability reasons you sh...
```
there were a few other warnings but this seemed to be the most important.

Also, intel documentation (see https://www.intel.com/content/www/us/en/developer/articles/technical/large-mpi-tags-with-the-intel-mpi.html ) says that a tag value exceeding 32767 or 15 bits may not be portable.

 
