### PR TITLE
Refactor getValidIOProtocols

### DIFF
--- a/src/axom/sidre/core/DataStore.hpp
+++ b/src/axom/sidre/core/DataStore.hpp
@@ -501,6 +501,30 @@ public:
                               const std::string& index_path);
 #endif
 
+  /*!
+   * \brief Get valid protocols for I/O of objects in DataStore.
+   *
+   * Only protocols that work for both input and output are returned.
+   */
+  const std::vector<std::string>& getValidIOProtocols()
+  {
+    if(m_io_protocols.empty())
+    {
+      m_io_protocols = {
+#ifdef AXOM_USE_HDF5
+        "sidre_hdf5",
+        "conduit_hdf5",
+#endif
+        "sidre_json",
+        "sidre_conduit_json",
+        "conduit_bin",
+        "conduit_json",
+        "json"};
+    }
+
+    return m_io_protocols;
+  }
+
   //----------------
 
   /*!
@@ -555,6 +579,9 @@ private:
 
   /// Flag indicating whether SLIC logging environment was initialized in ctor.
   bool m_need_to_finalize_slic;
+
+  /// The valid I/O protocols for objects in the DataStore.
+  std::vector<std::string> m_io_protocols;
 
   /// Details of the most recent Conduit error.  Length > 0 indicates an error occurred.
   mutable std::string m_conduit_errors;

--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -37,18 +37,6 @@ namespace sidre
 // support path syntax.
 const char Group::s_path_delimiter = '/';
 
-// Initialization of static members holding I/O protocol strings
-const std::vector<std::string> Group::s_io_protocols = {
-#ifdef AXOM_USE_HDF5
-  "sidre_hdf5",
-  "conduit_hdf5",
-#endif
-  "sidre_json",
-  "sidre_conduit_json",
-  "conduit_bin",
-  "conduit_json",
-  "json"};
-
 ///////////////////////////////////////////////////////////////////////////////
 //
 // Private utility functions to cast ItemCollections to (named) MapCollections.

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -150,16 +150,6 @@ public:
   char getPathDelimiter() const { return s_path_delimiter; }
 
   /*!
-   * \brief static method to get valid protocols for Group I/O methods.
-   *
-   * Only protocols that work for both input and output are returned.
-   */
-  static const std::vector<std::string>& getValidIOProtocols()
-  {
-    return s_io_protocols;
-  }
-
-  /*!
    * \brief static method to get the default I/O protocol.
    */
   static std::string getDefaultIOProtocol()
@@ -1928,9 +1918,6 @@ private:
 #ifdef AXOM_USE_UMPIRE
   int m_default_allocator_id;
 #endif
-
-  // Collection of the valid I/O protocols for save and load.
-  AXOM_SIDRE_EXPORT static const std::vector<std::string> s_io_protocols;
 };
 
 } /* end namespace sidre */

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -1806,7 +1806,7 @@ TEST(sidre_group, save_restore_empty_datastore)
   const std::string file_path_base("sidre_empty_datastore_");
   DataStore* ds1 = new DataStore();
 
-  const std::vector<std::string>& protocols = Group::getValidIOProtocols();
+  const std::vector<std::string>& protocols = ds1->getValidIOProtocols();
   for(const auto& protocol : protocols)
   {
     const std::string file_path = file_path_base + protocol;
@@ -1914,7 +1914,7 @@ TEST(sidre_group, save_root_restore_as_child)
   }
 
   // Save the DataStore's root
-  const std::vector<std::string>& protocols = Group::getValidIOProtocols();
+  const std::vector<std::string>& protocols = ds->getValidIOProtocols();
   for(const auto& protocol : protocols)
   {
     const std::string file_path = file_path_base + protocol;
@@ -1997,7 +1997,7 @@ TEST(sidre_group, save_child_restore_as_root)
   }
 
   // Save the Group in question (child1) into an archive
-  const std::vector<std::string>& protocols = Group::getValidIOProtocols();
+  const std::vector<std::string>& protocols = ds->getValidIOProtocols();
   for(const auto& protocol : protocols)
   {
     const std::string file_path = file_path_base + protocol;
@@ -2048,7 +2048,7 @@ TEST(sidre_group, save_restore_api)
   // No group provided, defaults to root group
   EXPECT_TRUE(root1->save("sidre_save_fulltree_conduit", "json"));
 
-  const std::vector<std::string>& protocols = Group::getValidIOProtocols();
+  const std::vector<std::string>& protocols = ds1->getValidIOProtocols();
   for(const auto& protocol : protocols)
   {
     const std::string file_path = file_path_base + protocol;
@@ -2160,7 +2160,7 @@ TEST(sidre_group, save_restore_scalars_and_strings)
   root1->createViewScalar<double>("d0", 10.0);
   root1->createViewString("s0", "I am a string");
 
-  const std::vector<std::string>& protocols = Group::getValidIOProtocols();
+  const std::vector<std::string>& protocols = ds1->getValidIOProtocols();
   for(const auto& protocol : protocols)
   {
     //      if ( protocol == "conduit_hdf5")
@@ -2259,7 +2259,7 @@ TEST(sidre_group, save_restore_name_change)
   EXPECT_FALSE(child1->hasView("s0"));
   EXPECT_TRUE(child1->hasView("s0_renamed"));
 
-  const std::vector<std::string>& protocols = Group::getValidIOProtocols();
+  const std::vector<std::string>& protocols = ds1->getValidIOProtocols();
   for(const auto& protocol : protocols)
   {
     //      if ( protocol == "conduit_hdf5")
@@ -2338,7 +2338,7 @@ TEST(sidre_group, save_restore_external_data)
   root1->createView("external_undescribed")->setExternalDataPtr(foo4);
   root1->createViewWithShape("int2d", INT_ID, 2, shape, int2d1);
 
-  const std::vector<std::string>& protocols = Group::getValidIOProtocols();
+  std::vector<std::string> protocols = ds1->getValidIOProtocols();
   for(const auto& protocol : protocols)
   {
     const std::string file_path = file_path_base + protocol;
@@ -2571,7 +2571,7 @@ TEST(sidre_group, save_restore_buffer)
 
   save_restore_buffer_association("original datastore", ds1);
 
-  const std::vector<std::string>& protocols = Group::getValidIOProtocols();
+  const std::vector<std::string>& protocols = ds1->getValidIOProtocols();
   for(const auto& protocol : protocols)
   {
     const std::string file_path = file_path_base + protocol;
@@ -2633,7 +2633,7 @@ TEST(sidre_group, save_restore_other)
     }
   }
 
-  const std::vector<std::string>& protocols = Group::getValidIOProtocols();
+  std::vector<std::string> protocols = ds1->getValidIOProtocols();
   for(const auto& protocol : protocols)
   {
     const std::string file_path = file_path_base + protocol;
@@ -2719,7 +2719,7 @@ TEST(sidre_group, save_restore_complex)
     data_ptr[i] = i;
   }
 
-  const std::vector<std::string>& protocols = Group::getValidIOProtocols();
+  const std::vector<std::string>& protocols = ds1->getValidIOProtocols();
   for(const auto& protocol : protocols)
   {
     const std::string file_path = file_path_base + protocol;
@@ -2860,7 +2860,7 @@ TEST(sidre_group, save_load_all_protocols)
   //
   // test all protocols
   //
-  const std::vector<std::string>& protocols = Group::getValidIOProtocols();
+  const std::vector<std::string>& protocols = ds.getValidIOProtocols();
   for(const auto& protocol : protocols)
   {
     SLIC_INFO("Testing protocol: " << protocol);
@@ -2942,7 +2942,7 @@ TEST(sidre_group, fail_save_all_protocols)
   //
   // test all protocols
   //
-  const std::vector<std::string>& protocols = Group::getValidIOProtocols();
+  const std::vector<std::string>& protocols = ds.getValidIOProtocols();
   for(const auto& protocol : protocols)
   {
     SLIC_INFO("Testing fail to save or load protocol: " << protocol);
@@ -2997,7 +2997,7 @@ TEST(sidre_group, save_load_preserve_contents)
     data_ptr[i] = (conduit::int64)i;
   }
 
-  const std::vector<std::string>& protocols = Group::getValidIOProtocols();
+  const std::vector<std::string>& protocols = ds.getValidIOProtocols();
   std::string groupname;
   for(const auto& protocol : protocols)
   {


### PR DESCRIPTION
# Summary

- This PR is a refactoring
- It does the following:
  - Refactors a getValidIOProtocols method, moving it from Group to DataStore, making it a regular public member of DataStore that doesn't use static data.
  - Fixes #1408

The vector holding the valid protocols is filled on the first call and stored inside the DataStore object.