### PR TITLE
Bugfix: Early exit in `eigen_solve` method

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -49,7 +49,6 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Quest: Adds an example to query winding numbers on an MFEM NURBS mesh
 
 ### Changed
-- `numerics::eigen_solve()` has been corrected to avoid an early return with error state.
 - `axom::CLI::ExitCodes::Success` has been changed to `axom::CLI::ExitCodes::CLI11_Success`
   to avoid conflict when X11 `#define`s `Success`.
 - `MarchingCubes` masking now uses the mask field's integer values instead of
@@ -79,6 +78,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   (and `adiak` for metadata) and are available when axom is configured with `CALIPER_DIR` and `ADIAK_DIR` 
   config variables.
 - Removes caching of `{PACKAGE}_FOUND` variables in `SetupAxomThirdParty.cmake`
+
+### Fixed
+- `numerics::eigen_solve()` has been corrected to avoid an early return with error state.
 
 ## [Version 0.9.0] - Release date 2024-03-19
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -46,6 +46,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Quest: Adds an example to query winding numbers on an MFEM NURBS mesh
 
 ### Changed
+- `numerics::eigen_solve()` has been corrected to avoid an early return with error state.
 - `axom::CLI::ExitCodes::Success` has been changed to `axom::CLI::ExitCodes::CLI11_Success`
   to avoid conflict when X11 `#define`s `Success`.
 - `MarchingCubes` masking now uses the mask field's integer values instead of

--- a/src/axom/core/numerics/eigen_solve.hpp
+++ b/src/axom/core/numerics/eigen_solve.hpp
@@ -119,7 +119,7 @@ int eigen_solve(Matrix<T>& A, int k, T* u, T* lambdas, int numIterations)
 
     bool res = normalize<T>(vec, N);
 
-    // something went wrong, likely because `vec` is
+    // something went wrong, likely because `vec` is (numerically)
     //  in the span of the previous eigenvectors. Try again!
     if(!res)
     {

--- a/src/axom/core/numerics/eigen_solve.hpp
+++ b/src/axom/core/numerics/eigen_solve.hpp
@@ -119,9 +119,9 @@ int eigen_solve(Matrix<T>& A, int k, T* u, T* lambdas, int numIterations)
 
     bool res = normalize<T>(vec, N);
 
-    // something went wrong, likely because `vec` is 
+    // something went wrong, likely because `vec` is
     //  in the span of the previous eigenvectors. Try again!
-    if(!res)  
+    if(!res)
     {
       i--;
       continue;

--- a/src/axom/core/numerics/eigen_solve.hpp
+++ b/src/axom/core/numerics/eigen_solve.hpp
@@ -119,9 +119,12 @@ int eigen_solve(Matrix<T>& A, int k, T* u, T* lambdas, int numIterations)
 
     bool res = normalize<T>(vec, N);
 
-    if(!res)  // something went wrong
+    // something went wrong, likely because `vec` is 
+    //  in the span of the previous eigenvectors. Try again!
+    if(!res)  
     {
-      return 0;
+      i--;
+      continue;
     }
 
     // 3: run depth iterations of power method; note that a loop invariant

--- a/src/axom/core/numerics/eigen_solve.hpp
+++ b/src/axom/core/numerics/eigen_solve.hpp
@@ -38,7 +38,7 @@ namespace numerics
  * \param [in] A a square input matrix
  * \param [in] k number of eigenvalue-eigenvectors to find
  * \param [out] u pointer to k eigenvectors in order by magnitude of eigenvalue
- * \param [out] lambdas pointer to k eigenvales in order by size
+ * \param [out] lambdas pointer to k eigenvalues in order by size
  * \param [in] numIterations optional number of iterations for the power method
  * \note if k <= 0, the solve is declared successful
  * \return rc return value, nonzero if the solve is successful.

--- a/src/axom/primal/geometry/OrientedBoundingBox.hpp
+++ b/src/axom/primal/geometry/OrientedBoundingBox.hpp
@@ -424,12 +424,7 @@ OrientedBoundingBox<T, NDIMS>::OrientedBoundingBox(const PointType* pts, int n)
   T u[NDIMS * NDIMS];
   T lambdas[NDIMS];
 
-  int eigen_res = 0;
-  while( !eigen_res )
-  {
-    eigen_res = numerics::eigen_solve<T>(covar, NDIMS, u, lambdas);
-  } 
-  
+  int eigen_res = numerics::eigen_solve<T>(covar, NDIMS, u, lambdas);
   AXOM_UNUSED_VAR(eigen_res);
   SLIC_ASSERT(eigen_res);
 

--- a/src/axom/primal/geometry/OrientedBoundingBox.hpp
+++ b/src/axom/primal/geometry/OrientedBoundingBox.hpp
@@ -424,7 +424,12 @@ OrientedBoundingBox<T, NDIMS>::OrientedBoundingBox(const PointType* pts, int n)
   T u[NDIMS * NDIMS];
   T lambdas[NDIMS];
 
-  int eigen_res = numerics::eigen_solve<T>(covar, NDIMS, u, lambdas);
+  int eigen_res = 0;
+  while( !eigen_res )
+  {
+    eigen_res = numerics::eigen_solve<T>(covar, NDIMS, u, lambdas);
+  } 
+  
   AXOM_UNUSED_VAR(eigen_res);
   SLIC_ASSERT(eigen_res);
 

--- a/src/axom/primal/tests/primal_orientedboundingbox.cpp
+++ b/src/axom/primal/tests/primal_orientedboundingbox.cpp
@@ -130,6 +130,7 @@ TEST(primal_OBBox, obb_ctor_from_point_array)
   using QVector = primal::Vector<CoordType, DIM>;
   using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
+
   QPoint pt1;  // origin
   QPoint pt2({1.0, 0.0, 0.0});
   QPoint pt3({0.0, 1.0, 0.0});
@@ -139,19 +140,64 @@ TEST(primal_OBBox, obb_ctor_from_point_array)
   QPoint pt7({0.0, 1.0, 1.0});
   QPoint pt8({1.0, 1.0, 1.0});
 
-  QPoint pts[] = {pt1, pt2, pt3, pt4, pt5, pt6, pt7, pt8};
+  /* -1D OBB */
+  QPoint *pts_00 = nullptr;
+  QOBBox obbox00(pts_00, 0);
+  
+  EXPECT_FALSE(obbox00.isValid());
 
-  QOBBox obbox1(pts, 8);
+  /* 0D OBB */
+  QPoint pts_0d[] = {pt1};
+  QOBBox obbox0(pts_0d, 1);
 
-  // check containments
+  EXPECT_TRUE(obbox0.isValid());
+  EXPECT_TRUE(obbox0.contains(pt1));
+
+  EXPECT_NEAR( obbox0.getCentroid()[0], 0.0, 1e-6 );
+  EXPECT_NEAR( obbox0.getCentroid()[1], 0.0, 1e-6 );
+  EXPECT_NEAR( obbox0.getCentroid()[2], 0.0, 1e-6 );
+  
+  /* 1D OBB */
+  QPoint pts_1d[] = {pt1, pt2};
+  QOBBox obbox1(pts_1d, 2);
+
   EXPECT_TRUE(obbox1.isValid());
+  EXPECT_TRUE(obbox1.contains(pt1));
+  EXPECT_TRUE(obbox1.contains(pt2));
+
+  EXPECT_NEAR( obbox1.getCentroid()[0], 0.5, 1e-6 );
+  EXPECT_NEAR( obbox1.getCentroid()[1], 0.0, 1e-6 );
+  EXPECT_NEAR( obbox1.getCentroid()[2], 0.0, 1e-6 );
+
+  /* 2D OBB */  
+  QPoint pts_2d[] = {pt1, pt2, pt3, pt5};
+  QOBBox obbox2(pts_2d, 4);
+
+  std::cout << obbox2 << std::endl;
+  
+  EXPECT_TRUE(obbox2.isValid());
+  EXPECT_TRUE(obbox2.contains(pt1));
+  EXPECT_TRUE(obbox2.contains(pt2));
+  EXPECT_TRUE(obbox2.contains(pt3));
+  EXPECT_TRUE(obbox2.contains(pt5));
+
+  EXPECT_NEAR( obbox2.getCentroid()[0], 0.5, 1e-6 );
+  EXPECT_NEAR( obbox2.getCentroid()[1], 0.5, 1e-6 );
+  EXPECT_NEAR( obbox2.getCentroid()[2], 0.0, 1e-6 );
+
+  /* 3D OBB */
+  QPoint pts_3d[] = {pt1, pt2, pt3, pt4, pt5, pt6, pt7, pt8};
+  QOBBox obbox3(pts_3d, 8);
+  
+  // check containments
+  EXPECT_TRUE(obbox3.isValid());
   for(int i = 0; i < 8; i++)
   {
-    EXPECT_TRUE(obbox1.contains(pts[i]));
+    EXPECT_TRUE(obbox3.contains(pts_3d[i]));
   }
 
   // check settings
-  EXPECT_TRUE(obbox1.getCentroid() == QPoint(0.5));
+  EXPECT_TRUE(obbox3.getCentroid() == QPoint(0.5));
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_orientedboundingbox.cpp
+++ b/src/axom/primal/tests/primal_orientedboundingbox.cpp
@@ -130,7 +130,6 @@ TEST(primal_OBBox, obb_ctor_from_point_array)
   using QVector = primal::Vector<CoordType, DIM>;
   using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
-
   QPoint pt1;  // origin
   QPoint pt2({1.0, 0.0, 0.0});
   QPoint pt3({0.0, 1.0, 0.0});
@@ -141,9 +140,9 @@ TEST(primal_OBBox, obb_ctor_from_point_array)
   QPoint pt8({1.0, 1.0, 1.0});
 
   /* -1D OBB */
-  QPoint *pts_00 = nullptr;
+  QPoint* pts_00 = nullptr;
   QOBBox obbox00(pts_00, 0);
-  
+
   EXPECT_FALSE(obbox00.isValid());
 
   /* 0D OBB */
@@ -153,10 +152,10 @@ TEST(primal_OBBox, obb_ctor_from_point_array)
   EXPECT_TRUE(obbox0.isValid());
   EXPECT_TRUE(obbox0.contains(pt1));
 
-  EXPECT_NEAR( obbox0.getCentroid()[0], 0.0, 1e-6 );
-  EXPECT_NEAR( obbox0.getCentroid()[1], 0.0, 1e-6 );
-  EXPECT_NEAR( obbox0.getCentroid()[2], 0.0, 1e-6 );
-  
+  EXPECT_NEAR(obbox0.getCentroid()[0], 0.0, 1e-6);
+  EXPECT_NEAR(obbox0.getCentroid()[1], 0.0, 1e-6);
+  EXPECT_NEAR(obbox0.getCentroid()[2], 0.0, 1e-6);
+
   /* 1D OBB */
   QPoint pts_1d[] = {pt1, pt2};
   QOBBox obbox1(pts_1d, 2);
@@ -165,11 +164,11 @@ TEST(primal_OBBox, obb_ctor_from_point_array)
   EXPECT_TRUE(obbox1.contains(pt1));
   EXPECT_TRUE(obbox1.contains(pt2));
 
-  EXPECT_NEAR( obbox1.getCentroid()[0], 0.5, 1e-6 );
-  EXPECT_NEAR( obbox1.getCentroid()[1], 0.0, 1e-6 );
-  EXPECT_NEAR( obbox1.getCentroid()[2], 0.0, 1e-6 );
+  EXPECT_NEAR(obbox1.getCentroid()[0], 0.5, 1e-6);
+  EXPECT_NEAR(obbox1.getCentroid()[1], 0.0, 1e-6);
+  EXPECT_NEAR(obbox1.getCentroid()[2], 0.0, 1e-6);
 
-  /* 2D OBB */  
+  /* 2D OBB */
   QPoint pts_2d[] = {pt1, pt2, pt3, pt5};
   QOBBox obbox2(pts_2d, 4);
 
@@ -179,14 +178,14 @@ TEST(primal_OBBox, obb_ctor_from_point_array)
   EXPECT_TRUE(obbox2.contains(pt3));
   EXPECT_TRUE(obbox2.contains(pt5));
 
-  EXPECT_NEAR( obbox2.getCentroid()[0], 0.5, 1e-6 );
-  EXPECT_NEAR( obbox2.getCentroid()[1], 0.5, 1e-6 );
-  EXPECT_NEAR( obbox2.getCentroid()[2], 0.0, 1e-6 );
+  EXPECT_NEAR(obbox2.getCentroid()[0], 0.5, 1e-6);
+  EXPECT_NEAR(obbox2.getCentroid()[1], 0.5, 1e-6);
+  EXPECT_NEAR(obbox2.getCentroid()[2], 0.0, 1e-6);
 
   /* 3D OBB */
   QPoint pts_3d[] = {pt1, pt2, pt3, pt4, pt5, pt6, pt7, pt8};
   QOBBox obbox3(pts_3d, 8);
-  
+
   // check containments
   EXPECT_TRUE(obbox3.isValid());
   for(int i = 0; i < 8; i++)

--- a/src/axom/primal/tests/primal_orientedboundingbox.cpp
+++ b/src/axom/primal/tests/primal_orientedboundingbox.cpp
@@ -130,14 +130,14 @@ TEST(primal_OBBox, obb_ctor_from_point_array)
   using QVector = primal::Vector<CoordType, DIM>;
   using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
-  QPoint pt1;      // origin
-  QPoint pt2( {1.0, 0.0, 0.0} );
-  QPoint pt3( {0.0, 1.0, 0.0} );
-  QPoint pt4( {0.0, 0.0, 1.0} );
-  QPoint pt5( {1.0, 1.0, 0.0} );
-  QPoint pt6( {1.0, 0.0, 1.0} );
-  QPoint pt7( {0.0, 1.0, 1.0} );
-  QPoint pt8( {1.0, 1.0, 1.0} );
+  QPoint pt1;  // origin
+  QPoint pt2({1.0, 0.0, 0.0});
+  QPoint pt3({0.0, 1.0, 0.0});
+  QPoint pt4({0.0, 0.0, 1.0});
+  QPoint pt5({1.0, 1.0, 0.0});
+  QPoint pt6({1.0, 0.0, 1.0});
+  QPoint pt7({0.0, 1.0, 1.0});
+  QPoint pt8({1.0, 1.0, 1.0});
 
   QPoint pts[] = {pt1, pt2, pt3, pt4, pt5, pt6, pt7, pt8};
 

--- a/src/axom/primal/tests/primal_orientedboundingbox.cpp
+++ b/src/axom/primal/tests/primal_orientedboundingbox.cpp
@@ -124,37 +124,38 @@ TEST(primal_OBBox, obb_ctor_from_data)
 //------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_ctor_from_point_array)
 {
-    constexpr int DIM = 3;
-    using CoordType = double;
-    using QPoint = primal::Point<CoordType, DIM>;
-    using QVector = primal::Vector<CoordType, DIM>;
-    using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
-    
-    QPoint pt0( {0.0, 0.0, 0.0} );
-    QPoint pt1( {1.0, 0.0, 0.0} );
-    QPoint pt2( {0.0, 1.0, 0.0} );
-    QPoint pt3( {0.0, 0.0, 1.0} );
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using QPoint = primal::Point<CoordType, DIM>;
+  using QVector = primal::Vector<CoordType, DIM>;
+  using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
-    QPoint pts[4] = {pt0, pt1, pt2, pt3};
+  QPoint pts[5 * 5 * 5];
 
-    for(int i = 0; i < 1e6; ++i)
-    { 
-        srand(4000000 + i);
+  // Orthonomal axes
+  QVector v1({-0.87097929, -0.2000536, -0.44874674});
+  QVector v2({0.35391955, 0.37804987, -0.85546434});
+  QVector v3({-0.34078737, 0.90391197, 0.25847073});
 
-        QOBBox obbox1(pts, 4);
-    
-        // check containments
-        EXPECT_TRUE(obbox1.isValid());
-        EXPECT_TRUE(obbox1.contains(pt0));
-        EXPECT_TRUE(obbox1.contains(pt1));
-        EXPECT_TRUE(obbox1.contains(pt2));
-        EXPECT_TRUE(obbox1.contains(pt3));
-
-        // check settings
-        EXPECT_NEAR( obbox1.getCentroid()[0], 0.25, 1.e-6 );
-        EXPECT_NEAR( obbox1.getCentroid()[1], 0.25, 1.e-6 );
-        EXPECT_NEAR( obbox1.getCentroid()[2], 0.25, 1.e-6 );
+  // Create a 5x5x5 grid of points
+  for(int i = 0; i < 5; ++i)
+  {
+    for(int j = 0; j < 5; ++j)
+    {
+      for(int k = 0; k < 5; ++k)
+      {
+        auto new_vec = double(i) * v1 + double(j) * v2 + double(k) * v3;
+        pts[i + 5 * j + 25 * k] = QPoint( new_vec.array() );
+      }
     }
+  }
+
+  for(int i = 0; i < 1e6; ++i)
+  {
+    // srand(i);
+
+    QOBBox obbox1(pts, 5 * 5 * 5);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_orientedboundingbox.cpp
+++ b/src/axom/primal/tests/primal_orientedboundingbox.cpp
@@ -127,7 +127,6 @@ TEST(primal_OBBox, obb_ctor_from_point_array)
   constexpr int DIM = 3;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
-  using QVector = primal::Vector<CoordType, DIM>;
   using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
   QPoint pt1;  // origin

--- a/src/axom/primal/tests/primal_orientedboundingbox.cpp
+++ b/src/axom/primal/tests/primal_orientedboundingbox.cpp
@@ -173,8 +173,6 @@ TEST(primal_OBBox, obb_ctor_from_point_array)
   QPoint pts_2d[] = {pt1, pt2, pt3, pt5};
   QOBBox obbox2(pts_2d, 4);
 
-  std::cout << obbox2 << std::endl;
-  
   EXPECT_TRUE(obbox2.isValid());
   EXPECT_TRUE(obbox2.contains(pt1));
   EXPECT_TRUE(obbox2.contains(pt2));

--- a/src/axom/primal/tests/primal_orientedboundingbox.cpp
+++ b/src/axom/primal/tests/primal_orientedboundingbox.cpp
@@ -130,32 +130,18 @@ TEST(primal_OBBox, obb_ctor_from_point_array)
   using QVector = primal::Vector<CoordType, DIM>;
   using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
-  QPoint pts[5 * 5 * 5];
+  srand(17382);
 
-  // Orthonomal axes
-  QVector v1({-0.87097929, -0.2000536, -0.44874674});
-  QVector v2({0.35391955, 0.37804987, -0.85546434});
-  QVector v3({-0.34078737, 0.90391197, 0.25847073});
+  // Data pulled from the relevant winding_number test
+  QPoint array[25] = {
+    QPoint {0.57735, 0.57735, 0.57735}, QPoint {0.709587, 0.312876, 0.709587}, QPoint {0.754021, 0, 0.754021}, QPoint {0.709587, -0.312876, 0.709587}, QPoint {0.57735, -0.57735, 0.57735},
+    QPoint {0.312876, 0.709587, 0.709587}, QPoint {0.413364, 0.413364, 1}, QPoint {0.457304, 0, 1.12005}, QPoint {0.413364, -0.413364, 1}, QPoint {0.312876, -0.709587, 0.709587},
+    QPoint {0, 0.754021, 0.754021}, QPoint {0, 0.457304, 1.12005}, QPoint {0, 0, 1.27983}, QPoint {0, -0.457304, 1.12005}, QPoint {0, -0.754021, 0.754021},
+    QPoint {-0.312876, 0.709587, 0.709587}, QPoint {-0.413364, 0.413364, 1}, QPoint {-0.457304, 0, 1.12005}, QPoint {-0.413364, -0.413364, 1}, QPoint {-0.312876, -0.709587, 0.709587},
+    QPoint {-0.57735, 0.57735, 0.57735}, QPoint {-0.709587, 0.312876, 0.709587}, QPoint {-0.754021, 0, 0.754021}, QPoint {-0.709587, -0.312876, 0.709587}, QPoint {-0.57735, -0.57735, 0.57735}
+  };
 
-  // Create a 5x5x5 grid of points
-  for(int i = 0; i < 5; ++i)
-  {
-    for(int j = 0; j < 5; ++j)
-    {
-      for(int k = 0; k < 5; ++k)
-      {
-        auto new_vec = double(i) * v1 + double(j) * v2 + double(k) * v3;
-        pts[i + 5 * j + 25 * k] = QPoint( new_vec.array() );
-      }
-    }
-  }
-
-  for(int i = 0; i < 1e6; ++i)
-  {
-    // srand(i);
-
-    QOBBox obbox1(pts, 5 * 5 * 5);
-  }
+  primal::OrientedBoundingBox<double, 3> obb( array, 25 );
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_orientedboundingbox.cpp
+++ b/src/axom/primal/tests/primal_orientedboundingbox.cpp
@@ -122,6 +122,42 @@ TEST(primal_OBBox, obb_ctor_from_data)
 }
 
 //------------------------------------------------------------------------------
+TEST(primal_OBBox, obb_ctor_from_point_array)
+{
+    constexpr int DIM = 3;
+    using CoordType = double;
+    using QPoint = primal::Point<CoordType, DIM>;
+    using QVector = primal::Vector<CoordType, DIM>;
+    using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
+    
+    QPoint pt0( {0.0, 0.0, 0.0} );
+    QPoint pt1( {1.0, 0.0, 0.0} );
+    QPoint pt2( {0.0, 1.0, 0.0} );
+    QPoint pt3( {0.0, 0.0, 1.0} );
+
+    QPoint pts[4] = {pt0, pt1, pt2, pt3};
+
+    for(int i = 0; i < 1e6; ++i)
+    { 
+        srand(4000000 + i);
+
+        QOBBox obbox1(pts, 4);
+    
+        // check containments
+        EXPECT_TRUE(obbox1.isValid());
+        EXPECT_TRUE(obbox1.contains(pt0));
+        EXPECT_TRUE(obbox1.contains(pt1));
+        EXPECT_TRUE(obbox1.contains(pt2));
+        EXPECT_TRUE(obbox1.contains(pt3));
+
+        // check settings
+        EXPECT_NEAR( obbox1.getCentroid()[0], 0.25, 1.e-6 );
+        EXPECT_NEAR( obbox1.getCentroid()[1], 0.25, 1.e-6 );
+        EXPECT_NEAR( obbox1.getCentroid()[2], 0.25, 1.e-6 );
+    }
+}
+
+//------------------------------------------------------------------------------
 TEST(primal_OBBox, obb_test_clear)
 {
   constexpr int DIM = 3;

--- a/src/axom/primal/tests/primal_orientedboundingbox.cpp
+++ b/src/axom/primal/tests/primal_orientedboundingbox.cpp
@@ -130,18 +130,28 @@ TEST(primal_OBBox, obb_ctor_from_point_array)
   using QVector = primal::Vector<CoordType, DIM>;
   using QOBBox = primal::OrientedBoundingBox<CoordType, DIM>;
 
-  srand(17382);
+  QPoint pt1;      // origin
+  QPoint pt2( {1.0, 0.0, 0.0} );
+  QPoint pt3( {0.0, 1.0, 0.0} );
+  QPoint pt4( {0.0, 0.0, 1.0} );
+  QPoint pt5( {1.0, 1.0, 0.0} );
+  QPoint pt6( {1.0, 0.0, 1.0} );
+  QPoint pt7( {0.0, 1.0, 1.0} );
+  QPoint pt8( {1.0, 1.0, 1.0} );
 
-  // Data pulled from the relevant winding_number test
-  QPoint array[25] = {
-    QPoint {0.57735, 0.57735, 0.57735}, QPoint {0.709587, 0.312876, 0.709587}, QPoint {0.754021, 0, 0.754021}, QPoint {0.709587, -0.312876, 0.709587}, QPoint {0.57735, -0.57735, 0.57735},
-    QPoint {0.312876, 0.709587, 0.709587}, QPoint {0.413364, 0.413364, 1}, QPoint {0.457304, 0, 1.12005}, QPoint {0.413364, -0.413364, 1}, QPoint {0.312876, -0.709587, 0.709587},
-    QPoint {0, 0.754021, 0.754021}, QPoint {0, 0.457304, 1.12005}, QPoint {0, 0, 1.27983}, QPoint {0, -0.457304, 1.12005}, QPoint {0, -0.754021, 0.754021},
-    QPoint {-0.312876, 0.709587, 0.709587}, QPoint {-0.413364, 0.413364, 1}, QPoint {-0.457304, 0, 1.12005}, QPoint {-0.413364, -0.413364, 1}, QPoint {-0.312876, -0.709587, 0.709587},
-    QPoint {-0.57735, 0.57735, 0.57735}, QPoint {-0.709587, 0.312876, 0.709587}, QPoint {-0.754021, 0, 0.754021}, QPoint {-0.709587, -0.312876, 0.709587}, QPoint {-0.57735, -0.57735, 0.57735}
-  };
+  QPoint pts[] = {pt1, pt2, pt3, pt4, pt5, pt6, pt7, pt8};
 
-  primal::OrientedBoundingBox<double, 3> obb( array, 25 );
+  QOBBox obbox1(pts, 8);
+
+  // check containments
+  EXPECT_TRUE(obbox1.isValid());
+  for(int i = 0; i < 8; i++)
+  {
+    EXPECT_TRUE(obbox1.contains(pts[i]));
+  }
+
+  // check settings
+  EXPECT_TRUE(obbox1.getCentroid() == QPoint(0.5));
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

- This PR is a bugfix. It removes an unnecessary early termination criterion in the `numerics::eigen_solve` method.
- A test for the `primal::OrientedBoundingBox( const PointType* pts )` constructor has been added, which utilizes this method.

The `numerics::eigen_solve` method uses the power method to find eigenvalues and eigenvectors for an NxN matrix. At each step, a random vector is created and then made orthonormal to previously found eigenvectors. If this randomly created vector is (numerically) already in the span of previously found eigenvectors, it has zero magnitude, and the algorithm will terminate early with an error status.

While this event has mathematically zero chance of occurring, it occurs numerically in roughly 0.05% of runs of the existing `numerics_eigen_solve` test, resulting in a fail state.

This behavior has been modified so that if the resulting vector has (near-) zero magnitude, it is instead discarded and a new one is generated.

## Discussion

This behavior was originally observed through repeated calls to the `primal::OrientedBoundingBox( const PointType* pts )` constructor as a part of a winding number algorithm, which would occasionally return erroneous results on Release or terminate entirely on Debug. Further investigation revealed that no test in the OBB testing suite used this constructor. Although the actual likelihood of failing such a test in this way is very low, as was the case with the existing `numerics_eigen_solve` tests, a test has been added. 