### PR TITLE
Move I/O protocol vector into static method

### DIFF
--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -37,18 +37,6 @@ namespace sidre
 // support path syntax.
 const char Group::s_path_delimiter = '/';
 
-// Initialization of static members holding I/O protocol strings
-const std::vector<std::string> Group::s_io_protocols = {
-#ifdef AXOM_USE_HDF5
-  "sidre_hdf5",
-  "conduit_hdf5",
-#endif
-  "sidre_json",
-  "sidre_conduit_json",
-  "conduit_bin",
-  "conduit_json",
-  "json"};
-
 ///////////////////////////////////////////////////////////////////////////////
 //
 // Private utility functions to cast ItemCollections to (named) MapCollections.

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -156,6 +156,17 @@ public:
    */
   static const std::vector<std::string>& getValidIOProtocols()
   {
+    static const std::vector<std::string> s_io_protocols = {
+#ifdef AXOM_USE_HDF5
+      "sidre_hdf5",
+      "conduit_hdf5",
+#endif
+      "sidre_json",
+      "sidre_conduit_json",
+      "conduit_bin",
+      "conduit_json",
+      "json"};
+
     return s_io_protocols;
   }
 
@@ -1928,9 +1939,6 @@ private:
 #ifdef AXOM_USE_UMPIRE
   int m_default_allocator_id;
 #endif
-
-  // Collection of the valid I/O protocols for save and load.
-  AXOM_SIDRE_EXPORT static const std::vector<std::string> s_io_protocols;
 };
 
 } /* end namespace sidre */


### PR DESCRIPTION
# Summary

- This PR is a refactoring
- It does the following:
  - Moves the declaration and initialization of the static vector containing all valid I/O protocol strings into the static method that uses it.
  - Fixes #1408