### PR TITLE
Add missing device functions to primal

### DIFF
--- a/src/axom/primal/geometry/Point.hpp
+++ b/src/axom/primal/geometry/Point.hpp
@@ -37,7 +37,8 @@ AXOM_HOST_DEVICE bool operator==(const Point<T, NDIMS>& lhs,
  * \brief Inequality comparison operator for points
  */
 template <typename T, int NDIMS>
-bool operator!=(const Point<T, NDIMS>& lhs, const Point<T, NDIMS>& rhs);
+AXOM_HOST_DEVICE bool operator!=(const Point<T, NDIMS>& lhs,
+                                 const Point<T, NDIMS>& rhs);
 
 /*!
  * \brief Overloaded output operator for points
@@ -113,7 +114,8 @@ public:
    * \return d the dimension of the point.
    * \post d >= 1.
    */
-  static int dimension() { return NDIMS; };
+  AXOM_HOST_DEVICE
+  static constexpr int dimension() { return NDIMS; };
 
   /// \name Overloaded [] operator methods
   ///@{

--- a/src/axom/primal/geometry/Segment.hpp
+++ b/src/axom/primal/geometry/Segment.hpp
@@ -143,8 +143,7 @@ public:
    * \note Only available in 2D
    */
   template <int TDIM = NDIMS>
-  AXOM_HOST_DEVICE
-  typename std::enable_if<TDIM == 2, VectorType>::type normal() const
+  AXOM_HOST_DEVICE typename std::enable_if<TDIM == 2, VectorType>::type normal() const
   {
     return VectorType {m_target[1] - m_source[1], m_source[0] - m_target[0]};
   }

--- a/src/axom/primal/geometry/Segment.hpp
+++ b/src/axom/primal/geometry/Segment.hpp
@@ -28,13 +28,15 @@ class Segment;
  * \brief Equality comparison operator for Segment
  */
 template <typename T, int NDIMS>
-bool operator==(const Segment<T, NDIMS>& lhs, const Segment<T, NDIMS>& rhs);
+AXOM_HOST_DEVICE bool operator==(const Segment<T, NDIMS>& lhs,
+                                 const Segment<T, NDIMS>& rhs);
 
 /*!
  * \brief Inequality comparison operator for Segment
  */
 template <typename T, int NDIMS>
-bool operator!=(const Segment<T, NDIMS>& lhs, const Segment<T, NDIMS>& rhs);
+AXOM_HOST_DEVICE bool operator!=(const Segment<T, NDIMS>& lhs,
+                                 const Segment<T, NDIMS>& rhs);
 
 /*!
  * \brief Overloaded output operator for Segment
@@ -130,7 +132,10 @@ public:
   /*!
    * \brief Returns the length of the segment
    */
-  double length() const { return VectorType(m_source, m_target).norm(); }
+  AXOM_HOST_DEVICE double length() const
+  {
+    return VectorType(m_source, m_target).norm();
+  }
 
   /*!
    * \brief Returns a vector normal to the segment
@@ -138,6 +143,7 @@ public:
    * \note Only available in 2D
    */
   template <int TDIM = NDIMS>
+  AXOM_HOST_DEVICE
   typename std::enable_if<TDIM == 2, VectorType>::type normal() const
   {
     return VectorType {m_target[1] - m_source[1], m_source[0] - m_target[0]};
@@ -146,6 +152,7 @@ public:
   /*!
    * \brief Equality comparison operator for segments
    */
+  AXOM_HOST_DEVICE
   friend inline bool operator==(const Segment& lhs, const Segment& rhs)
   {
     return lhs.m_source == rhs.m_source && lhs.m_target == rhs.m_target;
@@ -154,6 +161,7 @@ public:
   /*!
    * \brief Inequality operator for segments
    */
+  AXOM_HOST_DEVICE
   friend inline bool operator!=(const Segment& lhs, const Segment& rhs)
   {
     return !(lhs == rhs);

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -101,7 +101,7 @@ AXOM_HOST_DEVICE Vector<T, NDIMS> operator-(const Point<T, NDIMS>& h,
  * \return C resulting vector from unary negation.
  */
 template <typename T, int NDIMS>
-Vector<T, NDIMS> operator-(const Vector<T, NDIMS>& vec1);
+AXOM_HOST_DEVICE Vector<T, NDIMS> operator-(const Vector<T, NDIMS>& vec1);
 
 /*!
  * \brief Scalar multiplication of vector; Scalar on rhs.
@@ -131,7 +131,8 @@ AXOM_HOST_DEVICE Vector<T, NDIMS> operator*(const T scalar,
  * \pre scalar != 0.0
  */
 template <typename T, int NDIMS>
-Vector<T, NDIMS> operator/(const Vector<T, NDIMS>& vec, const T scalar);
+AXOM_HOST_DEVICE Vector<T, NDIMS> operator/(const Vector<T, NDIMS>& vec,
+                                            const T scalar);
 
 /*!
  * \brief Overloaded output operator for vectors
@@ -229,7 +230,7 @@ public:
    * \post d >= 1.
    */
   AXOM_HOST_DEVICE
-  int dimension() const { return NDIMS; };
+  static constexpr int dimension() const { return NDIMS; };
 
   /*!
    * \brief Access operator for individual components.
@@ -273,6 +274,7 @@ public:
   /*!
    * \brief Inequality operator for points
    */
+  AXOM_HOST_DEVICE
   friend bool operator!=(const Vector& lhs, const Vector& rhs)
   {
     return !(lhs == rhs);
@@ -413,6 +415,7 @@ public:
    * \param [in] z the z--coordinate of the vector. Default is 0.0.
    * \return v a Vector instance with the given coordinates.
    */
+  AXOM_HOST_DEVICE
   static Vector make_vector(const T& x, const T& y, const T& z = 0.0);
 
 private:
@@ -656,7 +659,8 @@ AXOM_HOST_DEVICE Point<T, NDIMS> operator-(const Point<T, NDIMS>& P,
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-inline Vector<T, NDIMS> operator/(const Vector<T, NDIMS>& vec, const T scalar)
+AXOM_HOST_DEVICE inline Vector<T, NDIMS> operator/(const Vector<T, NDIMS>& vec,
+                                                   const T scalar)
 {
   Vector<T, NDIMS> result(vec);
   result /= scalar;
@@ -683,7 +687,7 @@ AXOM_HOST_DEVICE Vector<T, NDIMS> operator-(const Point<T, NDIMS>& h,
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-inline Vector<T, NDIMS> operator-(const Vector<T, NDIMS>& vec1)
+AXOM_HOST_DEVICE inline Vector<T, NDIMS> operator-(const Vector<T, NDIMS>& vec1)
 {
   Vector<T, NDIMS> result(vec1);
   result.negate();
@@ -700,7 +704,7 @@ std::ostream& operator<<(std::ostream& os, const Vector<T, NDIMS>& vec)
 
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
-inline Vector<T, NDIMS> Vector<T, NDIMS>::make_vector(const T& x,
+AXOM_HOST_DEVICE inline Vector<T, NDIMS> Vector<T, NDIMS>::make_vector(const T& x,
                                                       const T& y,
                                                       const T& z)
 {

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -230,7 +230,7 @@ public:
    * \post d >= 1.
    */
   AXOM_HOST_DEVICE
-  static constexpr int dimension() const { return NDIMS; };
+  static constexpr int dimension() { return NDIMS; };
 
   /*!
    * \brief Access operator for individual components.

--- a/src/axom/primal/geometry/Vector.hpp
+++ b/src/axom/primal/geometry/Vector.hpp
@@ -705,8 +705,8 @@ std::ostream& operator<<(std::ostream& os, const Vector<T, NDIMS>& vec)
 //------------------------------------------------------------------------------
 template <typename T, int NDIMS>
 AXOM_HOST_DEVICE inline Vector<T, NDIMS> Vector<T, NDIMS>::make_vector(const T& x,
-                                                      const T& y,
-                                                      const T& z)
+                                                                       const T& y,
+                                                                       const T& z)
 {
   T tmp_array[3] = {x, y, z};
   return Vector(tmp_array, NDIMS);


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following:
  - Adds missing device functions to Point, Segment, and Vector at the request of myself