### PR TITLE
Cleanup a bunch of GPU warnings

### DIFF
--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -842,7 +842,7 @@ public:
   /*!
    * \brief Get the ID for the umpire allocator
    */
-  int getAllocatorID() const { return m_allocator_id; }
+  AXOM_HOST_DEVICE int getAllocatorID() const { return m_allocator_id; }
 
   /*!
    * \brief Sets the preferred space where operations on this array should be

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -221,7 +221,7 @@ public:
    * memory spaces
    */
   template <typename OtherArrayType>
-  ArrayBase(
+  AXOM_HOST_DEVICE ArrayBase(
     const ArrayBase<typename std::remove_const<T>::type, DIM, OtherArrayType>& other)
     : m_shape(other.shape())
     , m_mapping(other.mapping())
@@ -230,7 +230,7 @@ public:
 
   /// \overload
   template <typename OtherArrayType>
-  ArrayBase(
+  AXOM_HOST_DEVICE ArrayBase(
     const ArrayBase<const typename std::remove_const<T>::type, DIM, OtherArrayType>& other)
     : m_shape(other.shape())
     , m_mapping(other.mapping())
@@ -618,12 +618,13 @@ public:
 
   // Empty implementation because no member data
   template <typename OtherArrayType>
-  ArrayBase(const ArrayBase<typename std::remove_const<T>::type, 1, OtherArrayType>&)
+  AXOM_HOST_DEVICE ArrayBase(
+    const ArrayBase<typename std::remove_const<T>::type, 1, OtherArrayType>&)
   { }
 
   // Empty implementation because no member data
   template <typename OtherArrayType>
-  ArrayBase(
+  AXOM_HOST_DEVICE ArrayBase(
     const ArrayBase<const typename std::remove_const<T>::type, 1, OtherArrayType>&)
   { }
 
@@ -1812,7 +1813,10 @@ public:
   /*!
    * \brief Get the ID for the umpire allocator
    */
-  int getAllocatorID() const { return m_array->getAllocatorID(); }
+  AXOM_HOST_DEVICE int getAllocatorID() const
+  {
+    return m_array->getAllocatorID();
+  }
 
 protected:
   friend BaseClass;

--- a/src/axom/core/ArrayView.hpp
+++ b/src/axom/core/ArrayView.hpp
@@ -114,10 +114,10 @@ public:
    * space.
    */
   template <typename OtherArrayType>
-  ArrayView(ArrayBase<T, DIM, OtherArrayType>& other);
+  AXOM_HOST_DEVICE ArrayView(ArrayBase<T, DIM, OtherArrayType>& other);
   /// \overload
   template <typename OtherArrayType>
-  ArrayView(
+  AXOM_HOST_DEVICE ArrayView(
     const ArrayBase<typename std::remove_const<T>::type, DIM, OtherArrayType>& other);
 
   /*!
@@ -156,7 +156,7 @@ public:
   /*!
    * \brief Get the ID for the umpire allocator
    */
-  int getAllocatorID() const { return m_allocator_id; }
+  AXOM_HOST_DEVICE int getAllocatorID() const { return m_allocator_id; }
 
   /*!
    * \brief Returns an ArrayView that is a subspan of the original range of
@@ -341,13 +341,14 @@ AXOM_HOST_DEVICE ArrayView<T, DIM, SPACE>::ArrayView(
 //------------------------------------------------------------------------------
 template <typename T, int DIM, MemorySpace SPACE>
 template <typename OtherArrayType>
-ArrayView<T, DIM, SPACE>::ArrayView(ArrayBase<T, DIM, OtherArrayType>& other)
+AXOM_HOST_DEVICE ArrayView<T, DIM, SPACE>::ArrayView(
+  ArrayBase<T, DIM, OtherArrayType>& other)
   : ArrayBase<T, DIM, ArrayView<T, DIM, SPACE>>(other)
   , m_data(static_cast<OtherArrayType&>(other).data())
   , m_num_elements(static_cast<OtherArrayType&>(other).size())
   , m_allocator_id(static_cast<OtherArrayType&>(other).getAllocatorID())
 {
-#ifdef AXOM_DEBUG
+#if !defined(AXOM_DEVICE_CODE) && defined(AXOM_DEBUG)
   // If it's not dynamic, the allocator ID from the argument array has to match the template param.
   // If that's not the case then things have gone horribly wrong somewhere.
   if(SPACE != MemorySpace::Dynamic &&
@@ -363,7 +364,7 @@ ArrayView<T, DIM, SPACE>::ArrayView(ArrayBase<T, DIM, OtherArrayType>& other)
 //------------------------------------------------------------------------------
 template <typename T, int DIM, MemorySpace SPACE>
 template <typename OtherArrayType>
-ArrayView<T, DIM, SPACE>::ArrayView(
+AXOM_HOST_DEVICE ArrayView<T, DIM, SPACE>::ArrayView(
   const ArrayBase<typename std::remove_const<T>::type, DIM, OtherArrayType>& other)
   : ArrayBase<T, DIM, ArrayView<T, DIM, SPACE>>(other)
   , m_data(static_cast<const OtherArrayType&>(other).data())
@@ -373,7 +374,7 @@ ArrayView<T, DIM, SPACE>::ArrayView(
   static_assert(
     std::is_const<T>::value || detail::ArrayTraits<OtherArrayType>::is_view,
     "Cannot create an ArrayView of non-const type from a const Array");
-#ifdef AXOM_DEBUG
+#if !defined(AXOM_DEVICE_CODE) && defined(AXOM_DEBUG)
   // If it's not dynamic, the allocator ID from the argument array has to match the template param.
   // If that's not the case then things have gone horribly wrong somewhere.
   if(SPACE != MemorySpace::Dynamic &&

--- a/src/axom/core/IteratorBase.hpp
+++ b/src/axom/core/IteratorBase.hpp
@@ -156,6 +156,8 @@ public:
   }
 
   /// Addition-assignment operator
+  AXOM_SUPPRESS_HD_WARN
+  AXOM_HOST_DEVICE
   IterType& operator+=(PosType n)
   {
     adv(getIter(), n);
@@ -169,6 +171,8 @@ public:
   }
 
   /// Addition operator with iterator on left and position on right
+  AXOM_SUPPRESS_HD_WARN
+  AXOM_HOST_DEVICE
   friend IterType operator+(const IterType& it, PosType n)
   {
     IterType ret(it);

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -258,7 +258,6 @@ struct SequentialLookupPolicy : ProbePolicy
       {
         // Stop probing if the "overflow" bit is not set.
         keep_going = false;
-        curr_group = NO_MATCH;
       }
 
       if(!keep_going)

--- a/src/axom/slam/BivariateMap.hpp
+++ b/src/axom/slam/BivariateMap.hpp
@@ -83,7 +83,7 @@ template <typename T,
           typename IndPol =
             policies::STLVectorIndirection<typename BSet::PositionType, T>,
           typename StrPol = policies::StrideOne<typename BSet::PositionType>,
-          typename IfacePol = policies::VirtualInterface>
+          typename IfacePol = policies::ConcreteInterface>
 class BivariateMap
   : public policies::MapInterface<IfacePol, typename BSet::PositionType>,
     public StrPol

--- a/src/axom/slam/BivariateMap.hpp
+++ b/src/axom/slam/BivariateMap.hpp
@@ -481,10 +481,8 @@ protected:
 
 public:
   /** BivariateMap iterator functions */
-  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE iterator begin() { return iterator(this, 0); }
 
-  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE iterator end()
   {
     return iterator(this, totalSize() * numComp());
@@ -500,25 +498,21 @@ public:
     return const_iterator(this, totalSize() * numComp());
   }
 
-  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE range_iterator set_begin()
   {
     return range_iterator(this, 0);
   }
 
-  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE range_iterator set_end()
   {
     return range_iterator(this, totalSize());
   }
 
-  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE const_range_iterator set_begin() const
   {
     return const_range_iterator(this, 0);
   }
 
-  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE const_range_iterator set_end() const
   {
     return const_range_iterator(this, totalSize());
@@ -562,9 +556,9 @@ public:
 public:
   AXOM_HOST_DEVICE const BivariateSetType* set() const { return m_bset.get(); }
 
-  const MapType* getMap() const { return &m_map; }
+  AXOM_HOST_DEVICE const MapType* getMap() const { return &m_map; }
 
-  MapType* getMap() { return &m_map; }
+  AXOM_HOST_DEVICE MapType* getMap() { return &m_map; }
 
   bool isValid(bool verboseOutput = false) const
   {
@@ -576,11 +570,10 @@ public:
   ///
 
   /** \brief Returns the BivariateSet size. */
-  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE SetPosition size() const { return set()->size(); }
 
   /** \brief Returns the BivariateSet size. */
-  SetPosition totalSize() const { return set()->size(); }
+  AXOM_HOST_DEVICE SetPosition totalSize() const { return set()->size(); }
 
   SetPosition firstSetSize() const { return set()->firstSetSize(); }
 
@@ -594,7 +587,7 @@ public:
   SetPosition size(SetPosition s) const { return set()->size(s); }
 
   /** \brief Return the number of components of the map  */
-  SetPosition numComp() const { return StrPol::stride(); }
+  AXOM_HOST_DEVICE SetPosition numComp() const { return StrPol::stride(); }
 
   /// @}
 
@@ -682,7 +675,7 @@ public:
   /**
      * \brief Construct a new BivariateMap Iterator given an ElementFlatIndex
      */
-  FlatIterator(BivariateMapPtr sMap, PositionType pos)
+  AXOM_HOST_DEVICE FlatIterator(BivariateMapPtr sMap, PositionType pos)
     : IterBase(pos)
     , m_map(sMap)
     , m_bsetIterator(m_map->set(), pos / m_map->numComp())
@@ -771,7 +764,7 @@ public:
   /*!
    * \brief Construct a new BivariateMap Iterator given an ElementFlatIndex
    */
-  RangeIterator(BivariateMapPtr sMap, PositionType pos)
+  AXOM_HOST_DEVICE RangeIterator(BivariateMapPtr sMap, PositionType pos)
     : IterBase(pos)
     , m_map(sMap)
     , m_mapIterator(m_map->getMap()->set_begin() + pos)
@@ -828,7 +821,10 @@ public:
   /**
    * \brief Return the current iterator's flat bivariate index.
    */
-  PositionType flatIndex() const { return m_mapIterator.flatIndex(); }
+  AXOM_HOST_DEVICE PositionType flatIndex() const
+  {
+    return m_mapIterator.flatIndex();
+  }
 
   /** \brief Returns the number of components per element in the map. */
   PositionType numComp() const { return m_map->numComp(); }

--- a/src/axom/slam/BivariateSet.hpp
+++ b/src/axom/slam/BivariateSet.hpp
@@ -318,7 +318,8 @@ public:
   using pointer = value_type*;
   using iterator_category = std::forward_iterator_tag;
 
-  BivariateSetIterator(const BivariateSetType* bset, IndexType flatPos = 0)
+  AXOM_HOST_DEVICE BivariateSetIterator(const BivariateSetType* bset,
+                                        IndexType flatPos = 0)
     : BaseType(flatPos)
     , m_bset(bset)
   { }

--- a/src/axom/slam/Map.hpp
+++ b/src/axom/slam/Map.hpp
@@ -259,7 +259,7 @@ public:
 #ifndef AXOM_DEVICE_CODE
     verifyPositionImpl(setIndex);
 #endif
-    return IndirectionPolicy::getConstIndirection(m_data, setIndex);
+    return *IndirectionPolicy::getConstIndirection(m_data, setIndex);
   }
 
   AXOM_HOST_DEVICE ValueType operator[](SetPosition setIndex)
@@ -267,7 +267,7 @@ public:
 #ifndef AXOM_DEVICE_CODE
     verifyPositionImpl(setIndex);
 #endif
-    return IndirectionPolicy::getIndirection(m_data, setIndex);
+    return *IndirectionPolicy::getIndirection(m_data, setIndex);
   }
 
   /**
@@ -341,7 +341,7 @@ public:
 #endif
     SetPosition elemIndex = setIdx * StridePolicyType::stride();
     elemIndex += componentOffset(compIdx...);
-    return IndirectionPolicy::getConstIndirection(m_data, elemIndex);
+    return *IndirectionPolicy::getConstIndirection(m_data, elemIndex);
   }
 
   /// \overload
@@ -359,7 +359,7 @@ public:
 #endif
     SetPosition elemIndex = setIdx * StridePolicyType::stride();
     elemIndex += componentOffset(compIdx...);
-    return IndirectionPolicy::getIndirection(m_data, elemIndex);
+    return *IndirectionPolicy::getIndirection(m_data, elemIndex);
   }
 
   SetElement index(IndexType idx) const { return set()->at(idx); }

--- a/src/axom/slam/Map.hpp
+++ b/src/axom/slam/Map.hpp
@@ -68,7 +68,7 @@ template <typename T,
           typename IndPol =
             policies::STLVectorIndirection<typename S::PositionType, T>,
           typename StrPol = policies::StrideOne<typename S::PositionType>,
-          typename IfacePol = policies::VirtualInterface>
+          typename IfacePol = policies::ConcreteInterface>
 class Map : public StrPol,
             public policies::MapInterface<IfacePol, typename S::PositionType>
 {

--- a/src/axom/slam/Map.hpp
+++ b/src/axom/slam/Map.hpp
@@ -685,13 +685,19 @@ public:  // Functions related to iteration
     return RangeAdapter<iterator> {begin(), end()};
   }
 
-  range_iterator set_begin() { return range_iterator(this, 0); }
-  range_iterator set_end() { return range_iterator(this, size()); }
-  const_range_iterator set_begin() const
+  AXOM_HOST_DEVICE range_iterator set_begin()
+  {
+    return range_iterator(this, 0);
+  }
+  AXOM_HOST_DEVICE range_iterator set_end()
+  {
+    return range_iterator(this, size());
+  }
+  AXOM_HOST_DEVICE const_range_iterator set_begin() const
   {
     return const_range_iterator(this, 0);
   }
-  const_range_iterator set_end() const
+  AXOM_HOST_DEVICE const_range_iterator set_end() const
   {
     return const_range_iterator(this, size());
   }

--- a/src/axom/slam/OrderedSet.hpp
+++ b/src/axom/slam/OrderedSet.hpp
@@ -422,7 +422,7 @@ public:
     }
 
   private:
-    OrderedSet m_orderedSet;
+    OrderedSet::ConcreteSet m_orderedSet;
   };
 
 public:  // Functions related to iteration

--- a/src/axom/slam/SubMap.hpp
+++ b/src/axom/slam/SubMap.hpp
@@ -123,7 +123,6 @@ public:
    *         element, where `setIndex = i * numComp() + j`.
    * \pre    0 <= idx < size() * numComp()
    */
-  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE DataRefType operator[](IndexType idx) const
   {
 #ifndef AXOM_DEVICE_CODE
@@ -185,7 +184,6 @@ public:
   ///
 
   /** \brief returns the size of the SubMap  */
-  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE axom::IndexType size() const { return m_subsetIdx.size(); }
 
   /** \brief returns the number of components (aka. stride) of the SubMap  */
@@ -220,7 +218,7 @@ private:  //helper functions
    * \brief Get the ComponentFlatIndex into the SuperMap given the subset's
    * ComponentFlatIndex. This is used only with bracket [] access
    */
-  IndexType getMapCompFlatIndex(IndexType idx) const
+  AXOM_HOST_DEVICE IndexType getMapCompFlatIndex(IndexType idx) const
   {
     IndexType comp = numComp();
     IndexType s = idx % comp;
@@ -401,7 +399,7 @@ public:
   using iter = Iterator;
   using PositionType = SetPosition;
 
-  AXOM_HOST_DEVICE Iterator(PositionType pos, SubMap sMap)
+  AXOM_HOST_DEVICE Iterator(PositionType pos, const SubMap& sMap)
     : IterBase(pos)
     , m_submap(sMap)
   { }
@@ -465,7 +463,7 @@ public:
   using pointer = typename MapRangeIterator::pointer;
   using difference_type = SetPosition;
 
-  PositionType getParentPosition(PositionType subset_pos)
+  AXOM_HOST_DEVICE PositionType getParentPosition(PositionType subset_pos)
   {
     PositionType subsetEnd = m_submap.m_subsetIdx.size() - 1;
     // End element is one past the last subset element.
@@ -478,8 +476,7 @@ public:
   }
 
 public:
-  AXOM_SUPPRESS_HD_WARN
-  AXOM_HOST_DEVICE RangeIterator(PositionType pos, SubMap sMap)
+  AXOM_HOST_DEVICE RangeIterator(PositionType pos, const SubMap& sMap)
     : IterBase(pos)
     , m_submap(sMap)
     , m_mapIter(m_submap.m_superMap, getParentPosition(pos))
@@ -496,7 +493,6 @@ public:
     return m_mapIter(comp_idx...);
   }
 
-  AXOM_SUPPRESS_HD_WARN
   template <typename... ComponentIndex>
   AXOM_HOST_DEVICE DataRefType value(ComponentIndex... comp_idx) const
   {
@@ -522,7 +518,6 @@ public:
 
 protected:
   /** Implementation of advance() as required by IteratorBase */
-  AXOM_SUPPRESS_HD_WARN
   AXOM_HOST_DEVICE void advance(PositionType n)
   {
     PositionType currIndex = m_mapIter.flatIndex();

--- a/src/axom/slam/SubMap.hpp
+++ b/src/axom/slam/SubMap.hpp
@@ -52,7 +52,7 @@ namespace slam
 
 template <typename SuperMapType,
           typename SubsetType,  //= slam::RangeSet<SetPosition, SetElement>
-          typename InterfacePolicy = policies::VirtualInterface>
+          typename InterfacePolicy = policies::ConcreteInterface>
 class SubMap
   : public policies::MapInterface<InterfacePolicy, typename SubsetType::PositionType>,
     public SuperMapType::StridePolicyType

--- a/src/axom/spin/tests/spin_bvh.cpp
+++ b/src/axom/spin/tests/spin_bvh.cpp
@@ -1354,7 +1354,7 @@ void check_find_points_zip3d()
   // construct the BVH
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;
   bvh.setScaleFactor(1.0);  // i.e., no scaling
-  bvh.initialize(aabbs, ncells);
+  bvh.initialize(aabbs_view, ncells);
 
   BoxType bounds = bvh.getBounds();
 
@@ -1441,7 +1441,7 @@ void check_find_points_zip2d()
   // construct the BVH
   spin::BVH<NDIMS, ExecSpace, FloatType> bvh;
   bvh.setScaleFactor(1.0);  // i.e., no scaling
-  bvh.initialize(aabbs, ncells);
+  bvh.initialize(aabbs_view, ncells);
 
   BoxType bounds = bvh.getBounds();
 


### PR DESCRIPTION
# Summary

Clears up the bulk of Slam/Core-associated host/device usage warnings.

- Most of these were associated with the Slam `IndirectionPolicy` accessing the array value by reference; the interface has been changed to return a pointer-to-value, which allows us to just return `nullptr` for `STLVectorIndirectionPolicy`.
- The remainder were associated with the construction of `Map`, `BivariateMap`, and `SubMap` iterators, and were resolved by adding a bunch of `AXOM_HOST_DEVICE` annotations, and using a concrete interface policy for `Map` types by default.

The other remaining warnings were:
- `FlatMap`: Improperly setting an unsigned hash value with a negative sentinel value. The assignment was extraneous and removed.
- `BVH`: A test passed in an `axom::Array` to `BVH::initialize()`, which is captured by a lambda. This was changed to pass in an `ArrayView` instead.