### PR TITLE
Upgrade upload-artifact action to v4

### DIFF
--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Run uberenv (${{ matrix.triplet }})
       run: python3 ./scripts/uberenv/uberenv.py --triplet ${{ matrix.triplet }}
     - name: Save Uberenv logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
         name: uberenv_artifacts_${{ matrix.triplet }}_${{ matrix.cfg }}.zip
@@ -73,7 +73,7 @@ jobs:
         ls
         ctest -C ${{ matrix.cfg }} --no-compress-output -T Test 
     - name: Save CTest logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
         name: ctest_artifacts_${{ matrix.triplet }}_${{ matrix.cfg }}.zip

--- a/.github/workflows/test_windows_tpls.yml
+++ b/.github/workflows/test_windows_tpls.yml
@@ -29,14 +29,14 @@ jobs:
 
     steps:
     - name: Checkout repo w/ submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
         
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.10'
         
     - name: List path and files
       run: ls


### PR DESCRIPTION
Previous versions were deprecated.

See:
* https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/
* https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md