### PR TITLE
More warnings cleanup

### DIFF
--- a/src/axom/core/MDMapping.hpp
+++ b/src/axom/core/MDMapping.hpp
@@ -324,22 +324,16 @@ public:
     const axom::StackArray<DirectionType, DIM>& v) const
   {
     // v is a permutation if all its values are unique and in [0, DIM).
-    axom::StackArray<bool, DIM> found;
-    for(int d = 0; d < DIM; ++d)
+    axom::StackArray<DirectionType, DIM> values_sorted = v;
+
+    // After sorting, the values should be the sequence {0, 1, ... DIM - 1}.
+    axom::utilities::insertionSort(&values_sorted[0], DIM);
+    for(int d = 0; d < DIM; d++)
     {
-      found[d] = false;
-    }
-    for(int d = 0; d < DIM; ++d)
-    {
-      if(v[d] < 0 || v[d] >= DIM)
+      if(values_sorted[d] != d)
       {
-        return false;  // Out of range.
+        return false;
       }
-      if(found[v[d]] == true)
-      {
-        return false;  // Repeated index.
-      }
-      found[v[d]] = true;
     }
     return true;
   }

--- a/src/axom/slam/BivariateMap.hpp
+++ b/src/axom/slam/BivariateMap.hpp
@@ -802,7 +802,7 @@ public:
    *  index. Same as operator()
    */
   template <typename... ComponentIndex>
-  DataRefType value(ComponentIndex... comp) const
+  AXOM_HOST_DEVICE DataRefType value(ComponentIndex... comp) const
   {
     return m_mapIterator(comp...);
   }


### PR DESCRIPTION
# Summary

- Modifies `MDMapping::isPermutation` to avoid warning about unsigned integer comparison
- Add `AXOM_HOST_DEVICE` annotation to `BivariateMap::iterator::value()`