### PR TITLE
Add unit testing for Slic ranks and rank counts

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -29,6 +29,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ###  Fixed
 - Added a guard for sidre-related mint API usage in a quest example
+- Removed `std::ends` usage from `SLIC_ASSERT`,`SLIC_ASSERT_MSG`,`SLIC_CHECK`,
+  and `SLIC_CHECK_MSG` macros that prevented Lumberjack from combining
+  messages.
 
 
 ## [Version 0.10.0] - Release date 2024-09-27

--- a/src/axom/core/utilities/FileUtilities.hpp
+++ b/src/axom/core/utilities/FileUtilities.hpp
@@ -88,6 +88,11 @@ void getDirName(std::string& dir, const std::string& path);
  * \param filename The name of the file.
  * \return 0 on success, -1 on failure. errno can obtain more information
  *         about the failure.
+ *
+ * \note On Windows, this function calls _unlink() and will fail if there are
+ *       any open file handles to the specified file.
+ *       On Linux, this function calls unlink() and will succeed even if
+ *       there are open file handles to the specified file.
  */
 int removeFile(const std::string& filename);
 

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -339,7 +339,7 @@
       if(!(EXP))                                                      \
       {                                                               \
         std::ostringstream __oss;                                     \
-        __oss << "Failed Assert: " << #EXP << std::ends;              \
+        __oss << "Failed Assert: " << #EXP;                           \
         axom::slic::logErrorMessage(__oss.str(), __FILE__, __LINE__); \
         if(axom::slic::isAbortOnErrorsEnabled())                      \
         {                                                             \
@@ -371,7 +371,7 @@
       if(!(EXP))                                                             \
       {                                                                      \
         std::ostringstream __oss;                                            \
-        __oss << "Failed Assert: " << #EXP << std::endl << msg << std::ends; \
+        __oss << "Failed Assert: " << #EXP << std::endl << msg;              \
         axom::slic::logErrorMessage(__oss.str(), __FILE__, __LINE__);        \
         if(axom::slic::isAbortOnErrorsEnabled())                             \
         {                                                                    \
@@ -427,7 +427,7 @@
       if(!(EXP))                                                          \
       {                                                                   \
         std::ostringstream __oss;                                         \
-        __oss << "Failed Check: " << #EXP << std::ends;                   \
+        __oss << "Failed Check: " << #EXP;                                \
         if(axom::slic::debug::checksAreErrors)                            \
         {                                                                 \
           axom::slic::logErrorMessage(__oss.str(), __FILE__, __LINE__);   \
@@ -469,7 +469,7 @@
       if(!(EXP))                                                            \
       {                                                                     \
         std::ostringstream __oss;                                           \
-        __oss << "Failed Check: " << #EXP << std::endl << msg << std::ends; \
+        __oss << "Failed Check: " << #EXP << std::endl << msg;              \
         if(axom::slic::debug::checksAreErrors)                              \
         {                                                                   \
           axom::slic::logErrorMessage(__oss.str(), __FILE__, __LINE__);     \

--- a/src/axom/slic/interface/slic_macros.hpp
+++ b/src/axom/slic/interface/slic_macros.hpp
@@ -365,19 +365,19 @@
  * \endcode
  *
  */
-  #define SLIC_ASSERT_MSG(EXP, msg)                                          \
-    do                                                                       \
-    {                                                                        \
-      if(!(EXP))                                                             \
-      {                                                                      \
-        std::ostringstream __oss;                                            \
-        __oss << "Failed Assert: " << #EXP << std::endl << msg;              \
-        axom::slic::logErrorMessage(__oss.str(), __FILE__, __LINE__);        \
-        if(axom::slic::isAbortOnErrorsEnabled())                             \
-        {                                                                    \
-          axom::slic::abort();                                               \
-        }                                                                    \
-      }                                                                      \
+  #define SLIC_ASSERT_MSG(EXP, msg)                                   \
+    do                                                                \
+    {                                                                 \
+      if(!(EXP))                                                      \
+      {                                                               \
+        std::ostringstream __oss;                                     \
+        __oss << "Failed Assert: " << #EXP << std::endl << msg;       \
+        axom::slic::logErrorMessage(__oss.str(), __FILE__, __LINE__); \
+        if(axom::slic::isAbortOnErrorsEnabled())                      \
+        {                                                             \
+          axom::slic::abort();                                        \
+        }                                                             \
+      }                                                               \
     } while(axom::slic::detail::false_value)
 
   ///@}
@@ -463,30 +463,30 @@
  * \endcode
  *
  */
-  #define SLIC_CHECK_MSG(EXP, msg)                                          \
-    do                                                                      \
-    {                                                                       \
-      if(!(EXP))                                                            \
-      {                                                                     \
-        std::ostringstream __oss;                                           \
-        __oss << "Failed Check: " << #EXP << std::endl << msg;              \
-        if(axom::slic::debug::checksAreErrors)                              \
-        {                                                                   \
-          axom::slic::logErrorMessage(__oss.str(), __FILE__, __LINE__);     \
-          if(axom::slic::isAbortOnErrorsEnabled())                          \
-          {                                                                 \
-            axom::slic::abort();                                            \
-          }                                                                 \
-        }                                                                   \
-        else                                                                \
-        {                                                                   \
-          axom::slic::logWarningMessage(__oss.str(), __FILE__, __LINE__);   \
-          if(axom::slic::isAbortOnWarningsEnabled())                        \
-          {                                                                 \
-            axom::slic::abort();                                            \
-          }                                                                 \
-        }                                                                   \
-      }                                                                     \
+  #define SLIC_CHECK_MSG(EXP, msg)                                        \
+    do                                                                    \
+    {                                                                     \
+      if(!(EXP))                                                          \
+      {                                                                   \
+        std::ostringstream __oss;                                         \
+        __oss << "Failed Check: " << #EXP << std::endl << msg;            \
+        if(axom::slic::debug::checksAreErrors)                            \
+        {                                                                 \
+          axom::slic::logErrorMessage(__oss.str(), __FILE__, __LINE__);   \
+          if(axom::slic::isAbortOnErrorsEnabled())                        \
+          {                                                               \
+            axom::slic::abort();                                          \
+          }                                                               \
+        }                                                                 \
+        else                                                              \
+        {                                                                 \
+          axom::slic::logWarningMessage(__oss.str(), __FILE__, __LINE__); \
+          if(axom::slic::isAbortOnWarningsEnabled())                      \
+          {                                                               \
+            axom::slic::abort();                                          \
+          }                                                               \
+        }                                                                 \
+      }                                                                   \
     } while(axom::slic::detail::false_value)
 
 /// @}

--- a/src/axom/slic/tests/slic_macros.cpp
+++ b/src/axom/slic/tests/slic_macros.cpp
@@ -456,7 +456,7 @@ TEST(slic_macros, test_macros_file_output)
   std::string no_fmt_expected;
   no_fmt_expected += "*****\n[INFO]\n\n Test \n\n ";
   no_fmt_expected += __FILE__;
-  no_fmt_expected += "\n440\n****\n";
+  no_fmt_expected += "\n" + std::to_string(__LINE__ - 19) + "\n****\n";
 
   EXPECT_EQ(no_fmt_buffer.str(), no_fmt_expected);
 

--- a/src/axom/slic/tests/slic_macros.cpp
+++ b/src/axom/slic/tests/slic_macros.cpp
@@ -101,6 +101,8 @@ void check_line(const std::string& msg, int expected_line)
   size_t start = msg.rfind("@@") + 2;
   std::string l = msg.substr(start);
   const int line = std::stoi(l);
+
+  // expected value is the line number of the SLIC message
   EXPECT_EQ(line, expected_line);
 }
 
@@ -122,24 +124,28 @@ void check_tag(const std::string& msg, const std::string& expected_tag)
 //------------------------------------------------------------------------------
 TEST(slic_macros, test_error_macros)
 {
+  int expected_line_number;
+
   EXPECT_TRUE(slic::internal::is_stream_empty());
   SLIC_ERROR("test error message");
+  expected_line_number = __LINE__ - 1;
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "ERROR");
   check_msg(slic::internal::test_stream.str(), "test error message");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), (__LINE__ - 5));
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 
   SLIC_ERROR_IF(false, "this message should not be logged!");
   EXPECT_TRUE(slic::internal::is_stream_empty());
 
   SLIC_ERROR_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "ERROR");
   check_msg(slic::internal::test_stream.str(), "this message is logged!");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), (__LINE__ - 5));
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 
   // Check selective filtering based on root == false
@@ -150,11 +156,12 @@ TEST(slic_macros, test_error_macros)
   // Check selective filter based on root == true
   axom::slic::setIsRoot(true);
   SLIC_ERROR_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "ERROR");
   check_msg(slic::internal::test_stream.str(), "this message is logged!");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), (__LINE__ - 5));
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 
   // is root, but conditional is false -> no message
@@ -171,24 +178,28 @@ TEST(slic_macros, test_error_macros)
 //------------------------------------------------------------------------------
 TEST(slic_macros, test_warning_macros)
 {
+  int expected_line_number;
+
   EXPECT_TRUE(slic::internal::is_stream_empty());
   SLIC_WARNING("test warning message");
+  expected_line_number = __LINE__ - 1;
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "WARNING");
   check_msg(slic::internal::test_stream.str(), "test warning message");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), (__LINE__ - 5));
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 
   SLIC_WARNING_IF(false, "this message should not be logged!");
   EXPECT_TRUE(slic::internal::is_stream_empty());
 
   SLIC_WARNING_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "WARNING");
   check_msg(slic::internal::test_stream.str(), "this message is logged!");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), (__LINE__ - 5));
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 
   // Check selective filtering based on root == false
@@ -199,11 +210,12 @@ TEST(slic_macros, test_warning_macros)
   // Check selective filter based on root == true
   axom::slic::setIsRoot(true);
   SLIC_WARNING_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "WARNING");
   check_msg(slic::internal::test_stream.str(), "this message is logged!");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), (__LINE__ - 5));
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 
   // is root, but conditional is false -> no message
@@ -220,24 +232,28 @@ TEST(slic_macros, test_warning_macros)
 //------------------------------------------------------------------------------
 TEST(slic_macros, test_info_macros)
 {
+  int expected_line_number;
+
   EXPECT_TRUE(slic::internal::is_stream_empty());
   SLIC_INFO("test info message");
+  expected_line_number = __LINE__ - 1;
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "INFO");
   check_msg(slic::internal::test_stream.str(), "test info message");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), __LINE__ - 5);
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 
   SLIC_INFO_IF(false, "this message should not be logged!");
   EXPECT_TRUE(slic::internal::is_stream_empty());
 
   SLIC_INFO_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "INFO");
   check_msg(slic::internal::test_stream.str(), "this message is logged!");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), (__LINE__ - 5));
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 
   // is root, but conditional is false -> no message
@@ -254,14 +270,17 @@ TEST(slic_macros, test_info_macros)
 //------------------------------------------------------------------------------
 TEST(slic_macros, test_debug_macros)
 {
+  int expected_line_number;
+
   EXPECT_TRUE(slic::internal::is_stream_empty());
   SLIC_DEBUG("test debug message");
+  expected_line_number = __LINE__ - 1;
 #ifdef AXOM_DEBUG
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "DEBUG");
   check_msg(slic::internal::test_stream.str(), "test debug message");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), (__LINE__ - 6));
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 #else
   // SLIC_DEBUG macros only log messages when AXOM_DEBUG is defined
@@ -272,12 +291,13 @@ TEST(slic_macros, test_debug_macros)
   EXPECT_TRUE(slic::internal::is_stream_empty());
 
   SLIC_DEBUG_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
 #ifdef AXOM_DEBUG
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "DEBUG");
   check_msg(slic::internal::test_stream.str(), "this message is logged!");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), (__LINE__ - 6));
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 #else
   // SLIC_DEBUG macros only log messages when AXOM_DEBUG is defined
@@ -292,12 +312,13 @@ TEST(slic_macros, test_debug_macros)
   // Check selective filter based on root == true
   axom::slic::setIsRoot(true);
   SLIC_DEBUG_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
 #ifdef AXOM_DEBUG
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "DEBUG");
   check_msg(slic::internal::test_stream.str(), "this message is logged!");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), (__LINE__ - 6));
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 #else
   // SLIC_DEBUG macros only log messages when AXOM_DEBUG is defined
@@ -318,16 +339,18 @@ TEST(slic_macros, test_debug_macros)
 //------------------------------------------------------------------------------
 TEST(slic_macros, test_assert_macros)
 {
+  int expected_line_number;
   EXPECT_TRUE(slic::internal::is_stream_empty());
 
   constexpr int val = 42;
   SLIC_ASSERT(val < 0);
+  expected_line_number = __LINE__ - 1;
 #if defined(AXOM_DEBUG) && !defined(AXOM_DEVICE_CODE)
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "ERROR");
   check_msg(slic::internal::test_stream.str(), "Failed Assert: val < 0");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), (__LINE__ - 6));
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 #else
   // SLIC_ASSERT macros only log messages when AXOM_DEBUG is defined
@@ -339,13 +362,14 @@ TEST(slic_macros, test_assert_macros)
   EXPECT_TRUE(slic::internal::is_stream_empty());
 
   SLIC_ASSERT_MSG(val < 0, "val should be negative!");
+  expected_line_number = __LINE__ - 1;
 #if defined(AXOM_DEBUG) && !defined(AXOM_DEVICE_CODE)
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "ERROR");
   check_msg(slic::internal::test_stream.str(),
             "Failed Assert: val < 0\nval should be negative!");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), (__LINE__ - 7));
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 #else
   // SLIC_ASSERT macros only log messages when AXOM_DEBUG is defined
@@ -357,16 +381,18 @@ TEST(slic_macros, test_assert_macros)
 //------------------------------------------------------------------------------
 TEST(slic_macros, test_check_macros)
 {
+  int expected_line_number;
   EXPECT_TRUE(slic::internal::is_stream_empty());
 
   constexpr int val = 42;
   SLIC_CHECK(val < 0);
+  expected_line_number = __LINE__ - 1;
 #if defined(AXOM_DEBUG) && !defined(AXOM_DEVICE_CODE)
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "WARNING");
   check_msg(slic::internal::test_stream.str(), "Failed Check: val < 0");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), (__LINE__ - 6));
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 #else
   // SLIC_CHECK macros only log messages when AXOM_DEBUG is defined
@@ -378,13 +404,14 @@ TEST(slic_macros, test_check_macros)
   EXPECT_TRUE(slic::internal::is_stream_empty());
 
   SLIC_CHECK_MSG(val < 0, "val should be negative!");
+  expected_line_number = __LINE__ - 1;
 #if defined(AXOM_DEBUG) && !defined(AXOM_DEVICE_CODE)
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "WARNING");
   check_msg(slic::internal::test_stream.str(),
             "Failed Check: val < 0\nval should be negative!");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), (__LINE__ - 7));
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   slic::internal::clear();
 #else
   // SLIC_CHECK macros only log messages when AXOM_DEBUG is defined
@@ -396,13 +423,16 @@ TEST(slic_macros, test_check_macros)
 //------------------------------------------------------------------------------
 TEST(slic_macros, test_tagged_macros)
 {
+  int expected_line_number;
+
   EXPECT_TRUE(slic::internal::is_stream_empty());
   SLIC_INFO_TAGGED("test tagged info message", "myTag");
+  expected_line_number = __LINE__ - 1;
   EXPECT_FALSE(slic::internal::is_stream_empty());
   check_level(slic::internal::test_stream.str(), "INFO");
   check_msg(slic::internal::test_stream.str(), "test tagged info message");
   check_file(slic::internal::test_stream.str());
-  check_line(slic::internal::test_stream.str(), __LINE__ - 5);
+  check_line(slic::internal::test_stream.str(), expected_line_number);
   check_tag(slic::internal::test_stream.str(), "myTag");
   slic::internal::clear();
 
@@ -416,6 +446,8 @@ TEST(slic_macros, test_tagged_macros)
 //------------------------------------------------------------------------------
 TEST(slic_macros, test_macros_file_output)
 {
+  int expected_line_number;
+
   std::string msgfmt = "<MESSAGE>";
 
   // GenericOutputStream(std::string stream) and
@@ -438,6 +470,7 @@ TEST(slic_macros, test_macros_file_output)
 
   // message is buffered but not yet flushed, no files created
   SLIC_INFO("Test");
+  expected_line_number = __LINE__ - 1;
 
   EXPECT_FALSE(axom::utilities::filesystem::pathExists(no_fmt));
   EXPECT_FALSE(axom::utilities::filesystem::pathExists(with_fmt));
@@ -456,7 +489,8 @@ TEST(slic_macros, test_macros_file_output)
   std::string no_fmt_expected;
   no_fmt_expected += "*****\n[INFO]\n\n Test \n\n ";
   no_fmt_expected += __FILE__;
-  no_fmt_expected += "\n" + std::to_string(__LINE__ - 19) + "\n****\n";
+  no_fmt_expected += "\n" + std::to_string(expected_line_number);
+  no_fmt_expected += "\n****\n";
 
   EXPECT_EQ(no_fmt_buffer.str(), no_fmt_expected);
 

--- a/src/axom/slic/tests/slic_macros_parallel.cpp
+++ b/src/axom/slic/tests/slic_macros_parallel.cpp
@@ -85,6 +85,18 @@ void check_msg(const std::string& msg, const std::string& expected_message)
 {
   EXPECT_FALSE(msg.empty());
 
+  // message is output only once (combining successful for LumberjackStream)
+  int count = 0;
+  size_t pos = 0;
+
+  while((pos = msg.find(expected_message, pos)) != std::string::npos)
+  {
+    count++;
+    pos += expected_message.length();
+  }
+
+  EXPECT_EQ(count, 1);
+
   // extract message
   size_t start = msg.find(";;") + 2;
   size_t end = expected_message.length();

--- a/src/axom/slic/tests/slic_macros_parallel.cpp
+++ b/src/axom/slic/tests/slic_macros_parallel.cpp
@@ -131,6 +131,8 @@ void check_line(const std::string& msg, int expected_line)
   size_t start = msg.rfind("@@") + 2;
   std::string l = msg.substr(start);
   const int line = std::stoi(l);
+
+  // expected value is the line number of the SLIC message
   EXPECT_EQ(line, expected_line);
 }
 
@@ -270,8 +272,11 @@ public:
 //------------------------------------------------------------------------------
 TEST_P(SlicMacrosParallel, test_error_macros)
 {
+  int expected_line_number;
+
   EXPECT_TRUE(slic::internal::are_all_streams_empty());
   SLIC_ERROR("test error message");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
   {
@@ -279,7 +284,7 @@ TEST_P(SlicMacrosParallel, test_error_macros)
     check_level(slic::internal::test_stream.str(), "ERROR");
     check_msg(slic::internal::test_stream.str(), "test error message");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -297,6 +302,7 @@ TEST_P(SlicMacrosParallel, test_error_macros)
   EXPECT_TRUE(slic::internal::are_all_streams_empty());
 
   SLIC_ERROR_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
   {
@@ -304,7 +310,7 @@ TEST_P(SlicMacrosParallel, test_error_macros)
     check_level(slic::internal::test_stream.str(), "ERROR");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -326,6 +332,7 @@ TEST_P(SlicMacrosParallel, test_error_macros)
   // Check selective filter based on root == true
   axom::slic::setIsRoot(true);
   SLIC_ERROR_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
   {
@@ -333,7 +340,7 @@ TEST_P(SlicMacrosParallel, test_error_macros)
     check_level(slic::internal::test_stream.str(), "ERROR");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -361,6 +368,7 @@ TEST_P(SlicMacrosParallel, test_error_macros)
   // Check for one rank being root
   axom::slic::setIsRoot(rank == 0);
   SLIC_ERROR_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(rank == 0)
   {
@@ -368,7 +376,7 @@ TEST_P(SlicMacrosParallel, test_error_macros)
     check_level(slic::internal::test_stream.str(), "ERROR");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     check_rank(slic::internal::test_stream.str(), rank);
     check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
   }
@@ -381,6 +389,7 @@ TEST_P(SlicMacrosParallel, test_error_macros)
   // Check for more than one rank being root for SynchronizedStream
   axom::slic::setIsRoot((rank % 2) == 0);
   SLIC_ERROR_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(((rank % 2) == 0 && GetParam() == "Synchronized") ||
      (rank == 0 && GetParam() == "Lumberjack"))
@@ -389,7 +398,7 @@ TEST_P(SlicMacrosParallel, test_error_macros)
     check_level(slic::internal::test_stream.str(), "ERROR");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -415,8 +424,11 @@ TEST_P(SlicMacrosParallel, test_error_macros)
 //------------------------------------------------------------------------------
 TEST_P(SlicMacrosParallel, test_warning_macros)
 {
+  int expected_line_number;
+
   EXPECT_TRUE(slic::internal::are_all_streams_empty());
   SLIC_WARNING("test warning message");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
   {
@@ -424,7 +436,7 @@ TEST_P(SlicMacrosParallel, test_warning_macros)
     check_level(slic::internal::test_stream.str(), "WARNING");
     check_msg(slic::internal::test_stream.str(), "test warning message");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -442,6 +454,7 @@ TEST_P(SlicMacrosParallel, test_warning_macros)
   EXPECT_TRUE(slic::internal::are_all_streams_empty());
 
   SLIC_WARNING_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
   {
@@ -449,7 +462,7 @@ TEST_P(SlicMacrosParallel, test_warning_macros)
     check_level(slic::internal::test_stream.str(), "WARNING");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -471,6 +484,7 @@ TEST_P(SlicMacrosParallel, test_warning_macros)
   // Check selective filter based on root == true
   axom::slic::setIsRoot(true);
   SLIC_WARNING_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
   {
@@ -478,7 +492,7 @@ TEST_P(SlicMacrosParallel, test_warning_macros)
     check_level(slic::internal::test_stream.str(), "WARNING");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -506,6 +520,7 @@ TEST_P(SlicMacrosParallel, test_warning_macros)
   // Check for one rank being root
   axom::slic::setIsRoot(rank == 0);
   SLIC_WARNING_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(rank == 0)
   {
@@ -513,7 +528,7 @@ TEST_P(SlicMacrosParallel, test_warning_macros)
     check_level(slic::internal::test_stream.str(), "WARNING");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     check_rank(slic::internal::test_stream.str(), rank);
     check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
   }
@@ -526,6 +541,7 @@ TEST_P(SlicMacrosParallel, test_warning_macros)
   // Check for more than one rank being root for SynchronizedStream
   axom::slic::setIsRoot((rank % 2) == 0);
   SLIC_WARNING_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(((rank % 2) == 0 && GetParam() == "Synchronized") ||
      (rank == 0 && GetParam() == "Lumberjack"))
@@ -534,7 +550,7 @@ TEST_P(SlicMacrosParallel, test_warning_macros)
     check_level(slic::internal::test_stream.str(), "WARNING");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -560,8 +576,12 @@ TEST_P(SlicMacrosParallel, test_warning_macros)
 //------------------------------------------------------------------------------
 TEST_P(SlicMacrosParallel, test_info_macros)
 {
+  int expected_line_number;
+  int expected_tag_number;
+
   EXPECT_TRUE(slic::internal::are_all_streams_empty());
   SLIC_INFO("test info message");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
   {
@@ -569,7 +589,7 @@ TEST_P(SlicMacrosParallel, test_info_macros)
     check_level(slic::internal::test_stream.str(), "INFO");
     check_msg(slic::internal::test_stream.str(), "test info message");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), __LINE__ - 8);
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -583,6 +603,7 @@ TEST_P(SlicMacrosParallel, test_info_macros)
   slic::internal::clear_streams();
 
   SLIC_INFO_TAGGED("test tagged info message", "myTag");
+  expected_tag_number = __LINE__ - 1;
   slic::flushStreams();
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
   {
@@ -590,7 +611,7 @@ TEST_P(SlicMacrosParallel, test_info_macros)
     check_level(slic::internal::test_tag_stream.str(), "INFO");
     check_msg(slic::internal::test_tag_stream.str(), "test tagged info message");
     check_file(slic::internal::test_tag_stream.str());
-    check_line(slic::internal::test_tag_stream.str(), __LINE__ - 8);
+    check_line(slic::internal::test_tag_stream.str(), expected_tag_number);
     check_tag(slic::internal::test_tag_stream.str(), "myTag");
     if(GetParam() == "Synchronized")
     {
@@ -606,7 +627,9 @@ TEST_P(SlicMacrosParallel, test_info_macros)
   slic::internal::clear_streams();
 
   SLIC_INFO("test info message only for normal message-level stream");
+  expected_line_number = __LINE__ - 1;
   SLIC_INFO_TAGGED("test tagged info message only for tagged stream", "myTag");
+  expected_tag_number = __LINE__ - 1;
   slic::flushStreams();
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
   {
@@ -615,7 +638,7 @@ TEST_P(SlicMacrosParallel, test_info_macros)
     check_msg(slic::internal::test_stream.str(),
               "test info message only for normal message-level stream");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), __LINE__ - 10);
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -631,7 +654,7 @@ TEST_P(SlicMacrosParallel, test_info_macros)
     check_msg(slic::internal::test_tag_stream.str(),
               "test tagged info message only for tagged stream");
     check_file(slic::internal::test_tag_stream.str());
-    check_line(slic::internal::test_tag_stream.str(), __LINE__ - 25);
+    check_line(slic::internal::test_tag_stream.str(), expected_tag_number);
     check_tag(slic::internal::test_tag_stream.str(), "myTag");
     if(GetParam() == "Synchronized")
     {
@@ -658,6 +681,7 @@ TEST_P(SlicMacrosParallel, test_info_macros)
   EXPECT_TRUE(slic::internal::are_all_streams_empty());
 
   SLIC_INFO_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
   {
@@ -665,7 +689,7 @@ TEST_P(SlicMacrosParallel, test_info_macros)
     check_level(slic::internal::test_stream.str(), "INFO");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -687,6 +711,7 @@ TEST_P(SlicMacrosParallel, test_info_macros)
   // Check selective filter based on root == true
   axom::slic::setIsRoot(true);
   SLIC_INFO_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
   {
@@ -694,7 +719,7 @@ TEST_P(SlicMacrosParallel, test_info_macros)
     check_level(slic::internal::test_stream.str(), "INFO");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -722,6 +747,7 @@ TEST_P(SlicMacrosParallel, test_info_macros)
   // Check for one rank being root
   axom::slic::setIsRoot(rank == 0);
   SLIC_INFO_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(rank == 0)
   {
@@ -729,7 +755,7 @@ TEST_P(SlicMacrosParallel, test_info_macros)
     check_level(slic::internal::test_stream.str(), "INFO");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     check_rank(slic::internal::test_stream.str(), rank);
     check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
   }
@@ -742,6 +768,7 @@ TEST_P(SlicMacrosParallel, test_info_macros)
   // Check for more than one rank being root
   axom::slic::setIsRoot((rank % 2) == 0);
   SLIC_INFO_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
   if(((rank % 2) == 0 && GetParam() == "Synchronized") ||
      (rank == 0 && GetParam() == "Lumberjack"))
@@ -750,7 +777,7 @@ TEST_P(SlicMacrosParallel, test_info_macros)
     check_level(slic::internal::test_stream.str(), "INFO");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -776,8 +803,11 @@ TEST_P(SlicMacrosParallel, test_info_macros)
 //------------------------------------------------------------------------------
 TEST_P(SlicMacrosParallel, test_debug_macros)
 {
+  int expected_line_number;
+
   EXPECT_TRUE(slic::internal::are_all_streams_empty());
   SLIC_DEBUG("test debug message");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
 #ifdef AXOM_DEBUG
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
@@ -786,7 +816,7 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
     check_level(slic::internal::test_stream.str(), "DEBUG");
     check_msg(slic::internal::test_stream.str(), "test debug message");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -808,6 +838,7 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
   EXPECT_TRUE(slic::internal::are_all_streams_empty());
 
   SLIC_DEBUG_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
 #ifdef AXOM_DEBUG
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
@@ -816,7 +847,7 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
     check_level(slic::internal::test_stream.str(), "DEBUG");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -842,6 +873,7 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
   // Check selective filter based on root == true
   axom::slic::setIsRoot(true);
   SLIC_DEBUG_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
 #ifdef AXOM_DEBUG
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
@@ -850,7 +882,7 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
     check_level(slic::internal::test_stream.str(), "DEBUG");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -882,6 +914,7 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
   // Check for one rank being root
   axom::slic::setIsRoot(rank == 0);
   SLIC_DEBUG_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
 #ifdef AXOM_DEBUG
   if(rank == 0)
@@ -890,7 +923,7 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
     check_level(slic::internal::test_stream.str(), "DEBUG");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     check_rank(slic::internal::test_stream.str(), rank);
     check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
   }
@@ -907,6 +940,7 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
   // Check for more than one rank being root
   axom::slic::setIsRoot((rank % 2) == 0);
   SLIC_DEBUG_ROOT_IF(true, "this message is logged!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
 #ifdef AXOM_DEBUG
   if(((rank % 2) == 0 && GetParam() == "Synchronized") ||
@@ -916,7 +950,7 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
     check_level(slic::internal::test_stream.str(), "DEBUG");
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 10));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -945,6 +979,8 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
 
 TEST_P(SlicMacrosParallel, test_abort_error_macros)
 {
+  int expected_line_number;
+
   const int NUM_ABORT_STATES = 2;
 
   slic::enableAbortOnError(); /* enable abort for testing purposes */
@@ -976,19 +1012,21 @@ TEST_P(SlicMacrosParallel, test_abort_error_macros)
       if(rank == i)
       {
         SLIC_ERROR("SLIC_ERROR message is logged!");
+        expected_line_number = __LINE__ - 1;
         slic::outputLocalMessages();
         EXPECT_EQ(has_aborted, abort_enabled);
         check_level(slic::internal::test_stream.str(), "ERROR");
         check_msg(slic::internal::test_stream.str(),
                   "SLIC_ERROR message is logged!");
         check_file(slic::internal::test_stream.str());
-        check_line(slic::internal::test_stream.str(), (__LINE__ - 7));
+        check_line(slic::internal::test_stream.str(), expected_line_number);
         check_rank(slic::internal::test_stream.str(), rank);
         check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
         reset_state();
 
         int val = rank == i ? 42 : -42;
         SLIC_ERROR_IF(val == 42, "SLIC_ERROR_IF message is logged!");
+        expected_line_number = __LINE__ - 1;
         slic::outputLocalMessages();
         EXPECT_EQ(has_aborted, abort_enabled);
         EXPECT_FALSE(slic::internal::are_all_streams_empty());
@@ -996,12 +1034,13 @@ TEST_P(SlicMacrosParallel, test_abort_error_macros)
         check_msg(slic::internal::test_stream.str(),
                   "SLIC_ERROR_IF message is logged!");
         check_file(slic::internal::test_stream.str());
-        check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+        check_line(slic::internal::test_stream.str(), expected_line_number);
         check_rank(slic::internal::test_stream.str(), rank);
         check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
         reset_state();
 
         SLIC_ERROR_ROOT("SLIC_ERROR_ROOT message is logged!");
+        expected_line_number = __LINE__ - 1;
         slic::outputLocalMessages();
         EXPECT_EQ(has_aborted, abort_enabled);
         EXPECT_FALSE(slic::internal::are_all_streams_empty());
@@ -1009,12 +1048,13 @@ TEST_P(SlicMacrosParallel, test_abort_error_macros)
         check_msg(slic::internal::test_stream.str(),
                   "SLIC_ERROR_ROOT message is logged!");
         check_file(slic::internal::test_stream.str());
-        check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+        check_line(slic::internal::test_stream.str(), expected_line_number);
         check_rank(slic::internal::test_stream.str(), rank);
         check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
         reset_state();
 
         SLIC_ERROR_ROOT_IF(val == 42, "SLIC_ERROR_ROOT_IF message is logged!");
+        expected_line_number = __LINE__ - 1;
         slic::outputLocalMessages();
         EXPECT_EQ(has_aborted, abort_enabled);
         EXPECT_FALSE(slic::internal::are_all_streams_empty());
@@ -1022,24 +1062,26 @@ TEST_P(SlicMacrosParallel, test_abort_error_macros)
         check_msg(slic::internal::test_stream.str(),
                   "SLIC_ERROR_ROOT_IF message is logged!");
         check_file(slic::internal::test_stream.str());
-        check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+        check_line(slic::internal::test_stream.str(), expected_line_number);
         check_rank(slic::internal::test_stream.str(), rank);
         check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
         reset_state();
 
         SLIC_ASSERT(val < 0);
+        expected_line_number = __LINE__ - 1;
         slic::outputLocalMessages();
         EXPECT_EQ(has_aborted, abort_enabled);
         EXPECT_FALSE(slic::internal::are_all_streams_empty());
         check_level(slic::internal::test_stream.str(), "ERROR");
         check_msg(slic::internal::test_stream.str(), "Failed Assert: val < 0");
         check_file(slic::internal::test_stream.str());
-        check_line(slic::internal::test_stream.str(), (__LINE__ - 7));
+        check_line(slic::internal::test_stream.str(), expected_line_number);
         check_rank(slic::internal::test_stream.str(), rank);
         check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
         reset_state();
 
         SLIC_ASSERT_MSG(val < 0, "val should be negative!");
+        expected_line_number = __LINE__ - 1;
         slic::outputLocalMessages();
         EXPECT_EQ(has_aborted, abort_enabled);
         EXPECT_FALSE(slic::internal::are_all_streams_empty());
@@ -1047,7 +1089,7 @@ TEST_P(SlicMacrosParallel, test_abort_error_macros)
         check_msg(slic::internal::test_stream.str(),
                   "Failed Assert: val < 0\nval should be negative!");
         check_file(slic::internal::test_stream.str());
-        check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+        check_line(slic::internal::test_stream.str(), expected_line_number);
         check_rank(slic::internal::test_stream.str(), rank);
         check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
         reset_state();
@@ -1073,6 +1115,8 @@ TEST_P(SlicMacrosParallel, test_abort_error_macros)
 //------------------------------------------------------------------------------
 TEST_P(SlicMacrosParallel, test_abort_warning_macros)
 {
+  int expected_line_number;
+
   const int NUM_ABORT_STATES = 2;
 
   slic::enableAbortOnWarning(); /* enable abort for testing purposes */
@@ -1104,6 +1148,7 @@ TEST_P(SlicMacrosParallel, test_abort_warning_macros)
       if(rank == i)
       {
         SLIC_WARNING("SLIC_WARNING message is logged!");
+        expected_line_number = __LINE__ - 1;
         slic::outputLocalMessages();
         EXPECT_EQ(has_aborted, abort_enabled);
         EXPECT_FALSE(slic::internal::are_all_streams_empty());
@@ -1111,13 +1156,14 @@ TEST_P(SlicMacrosParallel, test_abort_warning_macros)
         check_msg(slic::internal::test_stream.str(),
                   "SLIC_WARNING message is logged!");
         check_file(slic::internal::test_stream.str());
-        check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+        check_line(slic::internal::test_stream.str(), expected_line_number);
         check_rank(slic::internal::test_stream.str(), rank);
         check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
         reset_state();
 
         int val = rank == i ? 42 : -42;
         SLIC_WARNING_IF(val == 42, "SLIC_WARNING_IF message is logged!");
+        expected_line_number = __LINE__ - 1;
         slic::outputLocalMessages();
         EXPECT_EQ(has_aborted, abort_enabled);
         EXPECT_FALSE(slic::internal::are_all_streams_empty());
@@ -1125,12 +1171,13 @@ TEST_P(SlicMacrosParallel, test_abort_warning_macros)
         check_msg(slic::internal::test_stream.str(),
                   "SLIC_WARNING_IF message is logged!");
         check_file(slic::internal::test_stream.str());
-        check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+        check_line(slic::internal::test_stream.str(), expected_line_number);
         check_rank(slic::internal::test_stream.str(), rank);
         check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
         reset_state();
 
         SLIC_WARNING_ROOT("SLIC_WARNING_ROOT message is logged!");
+        expected_line_number = __LINE__ - 1;
         slic::outputLocalMessages();
         EXPECT_EQ(has_aborted, abort_enabled);
         EXPECT_FALSE(slic::internal::are_all_streams_empty());
@@ -1138,12 +1185,13 @@ TEST_P(SlicMacrosParallel, test_abort_warning_macros)
         check_msg(slic::internal::test_stream.str(),
                   "SLIC_WARNING_ROOT message is logged!");
         check_file(slic::internal::test_stream.str());
-        check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+        check_line(slic::internal::test_stream.str(), expected_line_number);
         check_rank(slic::internal::test_stream.str(), rank);
         check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
         reset_state();
 
         SLIC_WARNING_ROOT_IF(val == 42, "SLIC_WARNING_ROOT_IF msg logged!");
+        expected_line_number = __LINE__ - 1;
         slic::outputLocalMessages();
         EXPECT_EQ(has_aborted, abort_enabled);
         EXPECT_FALSE(slic::internal::are_all_streams_empty());
@@ -1151,24 +1199,26 @@ TEST_P(SlicMacrosParallel, test_abort_warning_macros)
         check_msg(slic::internal::test_stream.str(),
                   "SLIC_WARNING_ROOT_IF msg logged!");
         check_file(slic::internal::test_stream.str());
-        check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+        check_line(slic::internal::test_stream.str(), expected_line_number);
         check_rank(slic::internal::test_stream.str(), rank);
         check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
         reset_state();
 
         SLIC_CHECK(val < 0);
+        expected_line_number = __LINE__ - 1;
         slic::outputLocalMessages();
         EXPECT_EQ(has_aborted, abort_enabled);
         EXPECT_FALSE(slic::internal::are_all_streams_empty());
         check_level(slic::internal::test_stream.str(), "WARNING");
         check_msg(slic::internal::test_stream.str(), "Failed Check: val < 0");
         check_file(slic::internal::test_stream.str());
-        check_line(slic::internal::test_stream.str(), (__LINE__ - 7));
+        check_line(slic::internal::test_stream.str(), expected_line_number);
         check_rank(slic::internal::test_stream.str(), rank);
         check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
         reset_state();
 
         SLIC_CHECK_MSG(val < 0, "val should be negative!");
+        expected_line_number = __LINE__ - 1;
         slic::outputLocalMessages();
         EXPECT_EQ(has_aborted, abort_enabled);
         EXPECT_FALSE(slic::internal::are_all_streams_empty());
@@ -1176,7 +1226,7 @@ TEST_P(SlicMacrosParallel, test_abort_warning_macros)
         check_msg(slic::internal::test_stream.str(),
                   "Failed Check: val < 0\nval should be negative!");
         check_file(slic::internal::test_stream.str());
-        check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
+        check_line(slic::internal::test_stream.str(), expected_line_number);
         check_rank(slic::internal::test_stream.str(), rank);
         check_rank_count(slic::internal::test_stream.str(), GetParam(), 1);
         reset_state();
@@ -1199,11 +1249,14 @@ TEST_P(SlicMacrosParallel, test_abort_warning_macros)
 //------------------------------------------------------------------------------
 TEST_P(SlicMacrosParallel, test_assert_macros)
 {
+  int expected_line_number;
+
   slic::internal::clear_streams();
   EXPECT_TRUE(slic::internal::are_all_streams_empty());
 
   constexpr int val = 42;
   SLIC_ASSERT(val < 0);
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
 #if defined(AXOM_DEBUG) && !defined(AXOM_DEVICE_CODE)
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
@@ -1212,7 +1265,7 @@ TEST_P(SlicMacrosParallel, test_assert_macros)
     check_level(slic::internal::test_stream.str(), "ERROR");
     check_msg(slic::internal::test_stream.str(), "Failed Assert: val < 0");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -1235,6 +1288,7 @@ TEST_P(SlicMacrosParallel, test_assert_macros)
   EXPECT_TRUE(slic::internal::are_all_streams_empty());
 
   SLIC_ASSERT_MSG(val < 0, "val should be negative!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
 #if defined(AXOM_DEBUG) && !defined(AXOM_DEVICE_CODE)
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
@@ -1244,7 +1298,7 @@ TEST_P(SlicMacrosParallel, test_assert_macros)
     check_msg(slic::internal::test_stream.str(),
               "Failed Assert: val < 0\nval should be negative!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 10));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -1266,10 +1320,13 @@ TEST_P(SlicMacrosParallel, test_assert_macros)
 // ------------------------------------------------------------------------------
 TEST_P(SlicMacrosParallel, test_check_macros)
 {
+  int expected_line_number;
+
   EXPECT_TRUE(slic::internal::are_all_streams_empty());
 
   constexpr int val = 42;
   SLIC_CHECK(val < 0);
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
 #if defined(AXOM_DEBUG) && !defined(AXOM_DEVICE_CODE)
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
@@ -1278,7 +1335,7 @@ TEST_P(SlicMacrosParallel, test_check_macros)
     check_level(slic::internal::test_stream.str(), "WARNING");
     check_msg(slic::internal::test_stream.str(), "Failed Check: val < 0");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -1301,6 +1358,7 @@ TEST_P(SlicMacrosParallel, test_check_macros)
   EXPECT_TRUE(slic::internal::are_all_streams_empty());
 
   SLIC_CHECK_MSG(val < 0, "val should be negative!");
+  expected_line_number = __LINE__ - 1;
   slic::flushStreams();
 #if defined(AXOM_DEBUG) && !defined(AXOM_DEVICE_CODE)
   if(GetParam() == "Synchronized" || (GetParam() == "Lumberjack" && rank == 0))
@@ -1310,7 +1368,7 @@ TEST_P(SlicMacrosParallel, test_check_macros)
     check_msg(slic::internal::test_stream.str(),
               "Failed Check: val < 0\nval should be negative!");
     check_file(slic::internal::test_stream.str());
-    check_line(slic::internal::test_stream.str(), (__LINE__ - 10));
+    check_line(slic::internal::test_stream.str(), expected_line_number);
     if(GetParam() == "Synchronized")
     {
       check_rank(slic::internal::test_stream.str(), rank);
@@ -1381,6 +1439,7 @@ TEST_P(SlicMacrosParallel, test_macros_file_output)
 
   // message is buffered but not yet flushed, no files created
   SLIC_INFO("Test");
+  int expected_line_number_flush = __LINE__ - 1;
 
   EXPECT_FALSE(axom::utilities::filesystem::pathExists(no_fmt));
   EXPECT_FALSE(axom::utilities::filesystem::pathExists(with_fmt));
@@ -1402,7 +1461,8 @@ TEST_P(SlicMacrosParallel, test_macros_file_output)
     std::string no_fmt_expected;
     no_fmt_expected += "*****\n[INFO]\n\n Test \n\n ";
     no_fmt_expected += __FILE__;
-    no_fmt_expected += "\n" + std::to_string(__LINE__ - 22) + "\n****\n";
+    no_fmt_expected += "\n" + std::to_string(expected_line_number_flush);
+    no_fmt_expected += "\n****\n";
 
     EXPECT_EQ(no_fmt_buffer.str(), no_fmt_expected);
 
@@ -1414,7 +1474,7 @@ TEST_P(SlicMacrosParallel, test_macros_file_output)
     check_level(with_fmt_buffer.str(), "INFO");
     check_msg(with_fmt_buffer.str(), "Test");
     check_file(with_fmt_buffer.str());
-    check_line(with_fmt_buffer.str(), (__LINE__ - 34));
+    check_line(with_fmt_buffer.str(), expected_line_number_flush);
     if(GetParam() == "Synchronized")
     {
       check_rank(with_fmt_buffer.str(), rank);
@@ -1437,6 +1497,7 @@ TEST_P(SlicMacrosParallel, test_macros_file_output)
   // Expect non-output Lumberjack ranks to create files if possible
   // (cannot guarantee all ranks will output before non-collective MPI Abort)
   SLIC_INFO("Test outputLocalMessages()");
+  int expected_line_number_local = __LINE__ - 1;
   slic::outputLocalMessages();
 
   EXPECT_TRUE(axom::utilities::filesystem::pathExists(no_fmt));
@@ -1453,11 +1514,13 @@ TEST_P(SlicMacrosParallel, test_macros_file_output)
     std::string no_fmt_output_expected;
     no_fmt_output_expected += "*****\n[INFO]\n\n Test \n\n ";
     no_fmt_output_expected += __FILE__;
-    no_fmt_output_expected += "\n" + std::to_string(__LINE__ - 73) + "\n****\n";
+    no_fmt_output_expected += "\n" + std::to_string(expected_line_number_flush);
+    no_fmt_output_expected += "\n****\n";
     no_fmt_output_expected +=
       "*****\n[INFO]\n\n Test outputLocalMessages() \n\n ";
     no_fmt_output_expected += __FILE__;
-    no_fmt_output_expected += "\n" + std::to_string(__LINE__ - 21) + "\n****\n";
+    no_fmt_output_expected += "\n" + std::to_string(expected_line_number_local);
+    no_fmt_output_expected += "\n****\n";
 
     EXPECT_EQ(no_fmt_out_buf.str(), no_fmt_output_expected);
 
@@ -1472,7 +1535,7 @@ TEST_P(SlicMacrosParallel, test_macros_file_output)
     check_level(next_msg, "INFO");
     check_msg(next_msg, "Test outputLocalMessages()");
     check_file(next_msg);
-    check_line(next_msg, (__LINE__ - 36));
+    check_line(next_msg, (expected_line_number_local));
 
     // For outputLocalMessages(), only current rank and rank count of 1
     // output for LumberjackStreams. Behaves like SynchronizedStream.
@@ -1492,7 +1555,8 @@ TEST_P(SlicMacrosParallel, test_macros_file_output)
     no_fmt_output_expected +=
       "*****\n[INFO]\n\n Test outputLocalMessages() \n\n ";
     no_fmt_output_expected += __FILE__;
-    no_fmt_output_expected += "\n" + std::to_string(__LINE__ - 56) + "\n****\n";
+    no_fmt_output_expected += "\n" + std::to_string(expected_line_number_local);
+    no_fmt_output_expected += "\n****\n";
 
     EXPECT_EQ(no_fmt_out_buf.str(), no_fmt_output_expected);
 
@@ -1504,7 +1568,7 @@ TEST_P(SlicMacrosParallel, test_macros_file_output)
     check_level(with_fmt_out_buf.str(), "INFO");
     check_msg(with_fmt_out_buf.str(), "Test outputLocalMessages()");
     check_file(with_fmt_out_buf.str());
-    check_line(with_fmt_out_buf.str(), (__LINE__ - 68));
+    check_line(with_fmt_out_buf.str(), expected_line_number_local);
 
     // For outputLocalMessages(), only current rank and rank count of 1
     // output for LumberjackStreams. Behaves like SynchronizedStream.

--- a/src/axom/slic/tests/slic_macros_parallel.cpp
+++ b/src/axom/slic/tests/slic_macros_parallel.cpp
@@ -20,8 +20,6 @@
 
 #include "mpi.h"
 
-#include <iostream>
-
 // namespace alias
 namespace slic = axom::slic;
 

--- a/src/axom/slic/tests/slic_macros_parallel.cpp
+++ b/src/axom/slic/tests/slic_macros_parallel.cpp
@@ -1098,8 +1098,6 @@ TEST_P(SlicMacrosParallel, test_check_macros)
     check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
     check_rank(slic::internal::test_stream.str(), rank);
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
-    std::cout << " ******* \n"
-              << slic::internal::test_stream.str() << "\n ******* " << std::endl;
   }
   slic::internal::clear_streams();
 #else
@@ -1208,7 +1206,7 @@ TEST_P(SlicMacrosParallel, test_macros_file_output)
     std::string no_fmt_expected;
     no_fmt_expected += "*****\n[INFO]\n\n Test \n\n ";
     no_fmt_expected += __FILE__;
-    no_fmt_expected += "\n1065\n****\n";
+    no_fmt_expected += "\n1187\n****\n";
 
     EXPECT_EQ(no_fmt_buffer.str(), no_fmt_expected);
 
@@ -1247,11 +1245,11 @@ TEST_P(SlicMacrosParallel, test_macros_file_output)
     std::string no_fmt_output_expected;
     no_fmt_output_expected += "*****\n[INFO]\n\n Test \n\n ";
     no_fmt_output_expected += __FILE__;
-    no_fmt_output_expected += "\n1065\n****\n";
+    no_fmt_output_expected += "\n1187\n****\n";
     no_fmt_output_expected +=
       "*****\n[INFO]\n\n Test outputLocalMessages() \n\n ";
     no_fmt_output_expected += __FILE__;
-    no_fmt_output_expected += "\n1109\n****\n";
+    no_fmt_output_expected += "\n1231\n****\n";
 
     EXPECT_EQ(no_fmt_out_buf.str(), no_fmt_output_expected);
 
@@ -1275,7 +1273,7 @@ TEST_P(SlicMacrosParallel, test_macros_file_output)
     no_fmt_output_expected +=
       "*****\n[INFO]\n\n Test outputLocalMessages() \n\n ";
     no_fmt_output_expected += __FILE__;
-    no_fmt_output_expected += "\n1109\n****\n";
+    no_fmt_output_expected += "\n1231\n****\n";
 
     EXPECT_EQ(no_fmt_out_buf.str(), no_fmt_output_expected);
 
@@ -1314,8 +1312,8 @@ int main(int argc, char* argv[])
   ::testing::InitGoogleTest(&argc, argv);
 
   // Run specifically one of these tests
-  ::testing::GTEST_FLAG(filter) =
-    "core_memory_management/SlicMacrosParallel.test_check_macros*";
+  // ::testing::GTEST_FLAG(filter) =
+  //   "core_memory_management/SlicMacrosParallel.test_check_macros*";
 
   MPI_Init(&argc, &argv);
 

--- a/src/axom/slic/tests/slic_macros_parallel.cpp
+++ b/src/axom/slic/tests/slic_macros_parallel.cpp
@@ -140,9 +140,21 @@ void check_rank(const std::string& msg, int expected_rank)
 
   // extract rank
   size_t start = msg.rfind("$$") + 2;
-  std::string r = msg.substr(start);
-  const int rank = std::stoi(r);
-  EXPECT_EQ(rank, expected_rank);
+  size_t end = msg.rfind("&&");
+  std::string ranks_string = msg.substr(start, end - start);
+
+  EXPECT_TRUE(ranks_string.find(std::to_string(expected_rank)) !=
+              std::string::npos);
+}
+
+//------------------------------------------------------------------------------
+void check_ranks(const std::string& msg, int expected_ranks)
+{
+  // Check all ranks from [0, expected_ranks) are in message
+  for(int i = 0; i < expected_ranks; i++)
+  {
+    check_rank(msg, i);
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -256,7 +268,14 @@ TEST_P(SlicMacrosParallel, test_error_macros)
     check_msg(slic::internal::test_stream.str(), "test error message");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -274,7 +293,14 @@ TEST_P(SlicMacrosParallel, test_error_macros)
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -296,7 +322,14 @@ TEST_P(SlicMacrosParallel, test_error_macros)
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -345,7 +378,17 @@ TEST_P(SlicMacrosParallel, test_error_macros)
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      for(int i = 0; i < nranks; i += 2)
+      {
+        check_rank(slic::internal::test_stream.str(), i);
+      }
+    }
     check_rank_count(slic::internal::test_stream.str(),
                      GetParam(),
                      (nranks / 2) + (nranks % 2));
@@ -370,7 +413,14 @@ TEST_P(SlicMacrosParallel, test_warning_macros)
     check_msg(slic::internal::test_stream.str(), "test warning message");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -388,7 +438,14 @@ TEST_P(SlicMacrosParallel, test_warning_macros)
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -410,7 +467,14 @@ TEST_P(SlicMacrosParallel, test_warning_macros)
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -459,7 +523,17 @@ TEST_P(SlicMacrosParallel, test_warning_macros)
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      for(int i = 0; i < nranks; i += 2)
+      {
+        check_rank(slic::internal::test_stream.str(), i);
+      }
+    }
     check_rank_count(slic::internal::test_stream.str(),
                      GetParam(),
                      (nranks / 2) + (nranks % 2));
@@ -484,7 +558,14 @@ TEST_P(SlicMacrosParallel, test_info_macros)
     check_msg(slic::internal::test_stream.str(), "test info message");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), __LINE__ - 8);
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -499,7 +580,14 @@ TEST_P(SlicMacrosParallel, test_info_macros)
     check_file(slic::internal::test_tag_stream.str());
     check_line(slic::internal::test_tag_stream.str(), __LINE__ - 8);
     check_tag(slic::internal::test_tag_stream.str(), "myTag");
-    check_rank(slic::internal::test_tag_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_tag_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_tag_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_tag_stream.str(), GetParam(), nranks);
     EXPECT_TRUE(slic::internal::is_stream_empty());
   }
@@ -516,7 +604,14 @@ TEST_P(SlicMacrosParallel, test_info_macros)
               "test info message only for normal message-level stream");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), __LINE__ - 10);
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
 
     EXPECT_FALSE(slic::internal::is_tag_stream_empty());
@@ -524,9 +619,16 @@ TEST_P(SlicMacrosParallel, test_info_macros)
     check_msg(slic::internal::test_tag_stream.str(),
               "test tagged info message only for tagged stream");
     check_file(slic::internal::test_tag_stream.str());
-    check_line(slic::internal::test_tag_stream.str(), __LINE__ - 18);
+    check_line(slic::internal::test_tag_stream.str(), __LINE__ - 25);
     check_tag(slic::internal::test_tag_stream.str(), "myTag");
-    check_rank(slic::internal::test_tag_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_tag_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_tag_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_tag_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -552,7 +654,14 @@ TEST_P(SlicMacrosParallel, test_info_macros)
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -574,7 +683,14 @@ TEST_P(SlicMacrosParallel, test_info_macros)
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 8));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -623,7 +739,17 @@ TEST_P(SlicMacrosParallel, test_info_macros)
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      for(int i = 0; i < nranks; i += 2)
+      {
+        check_rank(slic::internal::test_stream.str(), i);
+      }
+    }
     check_rank_count(slic::internal::test_stream.str(),
                      GetParam(),
                      (nranks / 2) + (nranks % 2));
@@ -649,7 +775,14 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
     check_msg(slic::internal::test_stream.str(), "test debug message");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -672,7 +805,14 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -699,7 +839,14 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -758,7 +905,17 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
     check_msg(slic::internal::test_stream.str(), "this message is logged!");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 10));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      for(int i = 0; i < nranks; i += 2)
+      {
+        check_rank(slic::internal::test_stream.str(), i);
+      }
+    }
     check_rank_count(slic::internal::test_stream.str(),
                      GetParam(),
                      (nranks / 2) + (nranks % 2));
@@ -1044,7 +1201,14 @@ TEST_P(SlicMacrosParallel, test_assert_macros)
     check_msg(slic::internal::test_stream.str(), "Failed Assert: val < 0");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -1069,7 +1233,14 @@ TEST_P(SlicMacrosParallel, test_assert_macros)
               "Failed Assert: val < 0\nval should be negative!");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 10));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -1096,7 +1267,14 @@ TEST_P(SlicMacrosParallel, test_check_macros)
     check_msg(slic::internal::test_stream.str(), "Failed Check: val < 0");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 9));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -1121,7 +1299,14 @@ TEST_P(SlicMacrosParallel, test_check_macros)
               "Failed Check: val < 0\nval should be negative!");
     check_file(slic::internal::test_stream.str());
     check_line(slic::internal::test_stream.str(), (__LINE__ - 10));
-    check_rank(slic::internal::test_stream.str(), rank);
+    if(GetParam() == "Synchronized")
+    {
+      check_rank(slic::internal::test_stream.str(), rank);
+    }
+    else
+    {
+      check_ranks(slic::internal::test_stream.str(), nranks);
+    }
     check_rank_count(slic::internal::test_stream.str(), GetParam(), nranks);
   }
   slic::internal::clear_streams();
@@ -1206,7 +1391,7 @@ TEST_P(SlicMacrosParallel, test_macros_file_output)
     std::string no_fmt_expected;
     no_fmt_expected += "*****\n[INFO]\n\n Test \n\n ";
     no_fmt_expected += __FILE__;
-    no_fmt_expected += "\n1187\n****\n";
+    no_fmt_expected += "\n" + std::to_string(__LINE__ - 22) + "\n****\n";
 
     EXPECT_EQ(no_fmt_buffer.str(), no_fmt_expected);
 
@@ -1245,11 +1430,11 @@ TEST_P(SlicMacrosParallel, test_macros_file_output)
     std::string no_fmt_output_expected;
     no_fmt_output_expected += "*****\n[INFO]\n\n Test \n\n ";
     no_fmt_output_expected += __FILE__;
-    no_fmt_output_expected += "\n1187\n****\n";
+    no_fmt_output_expected += "\n" + std::to_string(__LINE__ - 61) + "\n****\n";
     no_fmt_output_expected +=
       "*****\n[INFO]\n\n Test outputLocalMessages() \n\n ";
     no_fmt_output_expected += __FILE__;
-    no_fmt_output_expected += "\n1231\n****\n";
+    no_fmt_output_expected += "\n" + std::to_string(__LINE__ - 21) + "\n****\n";
 
     EXPECT_EQ(no_fmt_out_buf.str(), no_fmt_output_expected);
 
@@ -1273,7 +1458,7 @@ TEST_P(SlicMacrosParallel, test_macros_file_output)
     no_fmt_output_expected +=
       "*****\n[INFO]\n\n Test outputLocalMessages() \n\n ";
     no_fmt_output_expected += __FILE__;
-    no_fmt_output_expected += "\n1231\n****\n";
+    no_fmt_output_expected += "\n" + std::to_string(__LINE__ - 45) + "\n****\n";
 
     EXPECT_EQ(no_fmt_out_buf.str(), no_fmt_output_expected);
 
@@ -1310,10 +1495,6 @@ int main(int argc, char* argv[])
   int result = 0;
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  // Run specifically one of these tests
-  // ::testing::GTEST_FLAG(filter) =
-  //   "core_memory_management/SlicMacrosParallel.test_check_macros*";
 
   MPI_Init(&argc, &argv);
 


### PR DESCRIPTION
This PR:
- Adds testing for ranks and rank counts information in `slic_macros_parallel` unit tests.
- Remove `std::ends` from `SLIC_ASSERT`/`SLIC_ASSERT_MSG`/`SLIC_CHECK`/`SLIC_CHECK_MSG` macros that prevented Lumberjack from combining messages. When packing/unpacking messages for combining, `std::ends` does not play nice in std::string --> C-style string conversions. Trailing `std::ends` null character does not get included in the conversion, so output/rank Node's message (with `std::ends` null character) will always be different from the other nodes (no`std::ends` null character), and as such no combining would take place.
  - Added check that messages are unique/combined for LumberjackStreams in unit tests.
  - Example Reproducer of behavior: https://godbolt.org/z/of9Y74sxz

Relates to #1410 