### PR TITLE
Initialize Array::m_executeOnGPU

### DIFF
--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -289,8 +289,8 @@ public:
       this->clear();
       static_cast<ArrayBase<T, DIM, Array<T, DIM, SPACE>>&>(*this) = other;
       m_allocator_id = other.m_allocator_id;
-      m_executeOnGPU =
-        axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
+      m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) ==
+        axom::MemorySpace::Device;
       m_resize_ratio = other.m_resize_ratio;
       setCapacity(other.capacity());
       // Use fill_range to ensure that copy constructors are invoked for each element
@@ -330,8 +330,8 @@ public:
       m_capacity = other.m_capacity;
       m_resize_ratio = other.m_resize_ratio;
       m_allocator_id = other.m_allocator_id;
-      m_executeOnGPU =
-        axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
+      m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) ==
+        axom::MemorySpace::Device;
 
       other.m_data = nullptr;
       other.m_num_elements = 0;
@@ -987,7 +987,7 @@ template <typename T, int DIM, MemorySpace SPACE>
 Array<T, DIM, SPACE>::Array()
   : m_allocator_id(axom::detail::getAllocatorID<SPACE>())
   , m_executeOnGPU(axom::detail::getAllocatorSpace(m_allocator_id) ==
-                   MemorySpace::Device)
+                   axom::MemorySpace::Device)
 { }
 
 //------------------------------------------------------------------------------
@@ -1170,8 +1170,8 @@ Array<T, DIM, SPACE>::Array(Array&& other) noexcept
   m_capacity = other.m_capacity;
   m_resize_ratio = other.m_resize_ratio;
   m_allocator_id = other.m_allocator_id;
-  m_executeOnGPU =
-    axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
+  m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) ==
+    axom::MemorySpace::Device;
 
   other.m_data = nullptr;
   other.m_num_elements = 0;
@@ -1593,8 +1593,8 @@ inline void Array<T, DIM, SPACE>::initialize(IndexType num_elements,
     capacity = (num_elements > MIN_DEFAULT_CAPACITY) ? num_elements
                                                      : MIN_DEFAULT_CAPACITY;
   }
-  m_executeOnGPU =
-    axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
+  m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) ==
+    axom::MemorySpace::Device;
   setCapacity(capacity);
   if(default_construct)
   {
@@ -1630,8 +1630,8 @@ inline void Array<T, DIM, SPACE>::initialize_from_other(
 #endif
     m_allocator_id = axom::detail::getAllocatorID<SPACE>();
   }
-  m_executeOnGPU =
-    axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
+  m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) ==
+    axom::MemorySpace::Device;
   this->setCapacity(num_elements);
   // Use fill_range to ensure that copy constructors are invoked for each
   // element.

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -289,6 +289,7 @@ public:
       this->clear();
       static_cast<ArrayBase<T, DIM, Array<T, DIM, SPACE>>&>(*this) = other;
       m_allocator_id = other.m_allocator_id;
+      m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
       m_resize_ratio = other.m_resize_ratio;
       setCapacity(other.capacity());
       // Use fill_range to ensure that copy constructors are invoked for each element
@@ -328,6 +329,7 @@ public:
       m_capacity = other.m_capacity;
       m_resize_ratio = other.m_resize_ratio;
       m_allocator_id = other.m_allocator_id;
+      m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
 
       other.m_data = nullptr;
       other.m_num_elements = 0;
@@ -966,8 +968,8 @@ protected:
   IndexType m_num_elements = 0;
   IndexType m_capacity = 0;
   double m_resize_ratio = DEFAULT_RESIZE_RATIO;
-  int m_allocator_id;
-  bool m_executeOnGPU;
+  int m_allocator_id = INVALID_ALLOCATOR_ID;
+  bool m_executeOnGPU {false};
 };
 
 /// \brief Helper alias for multi-component arrays
@@ -982,6 +984,7 @@ using MCArray = Array<T, 2>;
 template <typename T, int DIM, MemorySpace SPACE>
 Array<T, DIM, SPACE>::Array()
   : m_allocator_id(axom::detail::getAllocatorID<SPACE>())
+  , m_executeOnGPU(axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device)
 { }
 
 //------------------------------------------------------------------------------
@@ -1164,6 +1167,7 @@ Array<T, DIM, SPACE>::Array(Array&& other) noexcept
   m_capacity = other.m_capacity;
   m_resize_ratio = other.m_resize_ratio;
   m_allocator_id = other.m_allocator_id;
+  m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
 
   other.m_data = nullptr;
   other.m_num_elements = 0;
@@ -1585,6 +1589,7 @@ inline void Array<T, DIM, SPACE>::initialize(IndexType num_elements,
     capacity = (num_elements > MIN_DEFAULT_CAPACITY) ? num_elements
                                                      : MIN_DEFAULT_CAPACITY;
   }
+  m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
   setCapacity(capacity);
   if(default_construct)
   {
@@ -1620,6 +1625,7 @@ inline void Array<T, DIM, SPACE>::initialize_from_other(
 #endif
     m_allocator_id = axom::detail::getAllocatorID<SPACE>();
   }
+  m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
   this->setCapacity(num_elements);
   // Use fill_range to ensure that copy constructors are invoked for each
   // element.

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -289,8 +289,7 @@ public:
       this->clear();
       static_cast<ArrayBase<T, DIM, Array<T, DIM, SPACE>>&>(*this) = other;
       m_allocator_id = other.m_allocator_id;
-      m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) ==
-        axom::MemorySpace::Device;
+      m_executeOnGPU = axom::isDeviceAllocator(m_allocator_id);
       m_resize_ratio = other.m_resize_ratio;
       setCapacity(other.capacity());
       // Use fill_range to ensure that copy constructors are invoked for each element
@@ -330,8 +329,7 @@ public:
       m_capacity = other.m_capacity;
       m_resize_ratio = other.m_resize_ratio;
       m_allocator_id = other.m_allocator_id;
-      m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) ==
-        axom::MemorySpace::Device;
+      m_executeOnGPU = axom::isDeviceAllocator(m_allocator_id);
 
       other.m_data = nullptr;
       other.m_num_elements = 0;
@@ -964,6 +962,15 @@ protected:
    */
   virtual void dynamicRealloc(IndexType new_num_elements);
 
+  /*!
+   * \brief Determine the appropriate setting for m_executeOnGPU based on 
+   *        an allocator id.
+   *
+   * \param allocator_id An allocator id.
+   * \return True if device execution should be preferred; false otherwise.
+   */
+  static bool prefersDevice(int allocator_id);
+
   T* m_data = nullptr;
   /// \brief The full number of elements in the array
   ///  i.e., 3 for a 1D Array of size 3, 9 for a 3x3 2D array, etc
@@ -986,8 +993,7 @@ using MCArray = Array<T, 2>;
 template <typename T, int DIM, MemorySpace SPACE>
 Array<T, DIM, SPACE>::Array()
   : m_allocator_id(axom::detail::getAllocatorID<SPACE>())
-  , m_executeOnGPU(axom::detail::getAllocatorSpace(m_allocator_id) ==
-                   axom::MemorySpace::Device)
+  , m_executeOnGPU(axom::isDeviceAllocator(m_allocator_id))
 { }
 
 //------------------------------------------------------------------------------
@@ -1170,8 +1176,7 @@ Array<T, DIM, SPACE>::Array(Array&& other) noexcept
   m_capacity = other.m_capacity;
   m_resize_ratio = other.m_resize_ratio;
   m_allocator_id = other.m_allocator_id;
-  m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) ==
-    axom::MemorySpace::Device;
+  m_executeOnGPU = axom::isDeviceAllocator(m_allocator_id);
 
   other.m_data = nullptr;
   other.m_num_elements = 0;
@@ -1593,8 +1598,7 @@ inline void Array<T, DIM, SPACE>::initialize(IndexType num_elements,
     capacity = (num_elements > MIN_DEFAULT_CAPACITY) ? num_elements
                                                      : MIN_DEFAULT_CAPACITY;
   }
-  m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) ==
-    axom::MemorySpace::Device;
+  m_executeOnGPU = axom::isDeviceAllocator(m_allocator_id);
   setCapacity(capacity);
   if(default_construct)
   {
@@ -1630,8 +1634,7 @@ inline void Array<T, DIM, SPACE>::initialize_from_other(
 #endif
     m_allocator_id = axom::detail::getAllocatorID<SPACE>();
   }
-  m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) ==
-    axom::MemorySpace::Device;
+  m_executeOnGPU = axom::isDeviceAllocator(m_allocator_id);
   this->setCapacity(num_elements);
   // Use fill_range to ensure that copy constructors are invoked for each
   // element.

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -971,7 +971,7 @@ protected:
   IndexType m_capacity = 0;
   double m_resize_ratio = DEFAULT_RESIZE_RATIO;
   int m_allocator_id = INVALID_ALLOCATOR_ID;
-  bool m_executeOnGPU {false};
+  bool m_executeOnGPU = false;
 };
 
 /// \brief Helper alias for multi-component arrays

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -962,15 +962,6 @@ protected:
    */
   virtual void dynamicRealloc(IndexType new_num_elements);
 
-  /*!
-   * \brief Determine the appropriate setting for m_executeOnGPU based on 
-   *        an allocator id.
-   *
-   * \param allocator_id An allocator id.
-   * \return True if device execution should be preferred; false otherwise.
-   */
-  static bool prefersDevice(int allocator_id);
-
   T* m_data = nullptr;
   /// \brief The full number of elements in the array
   ///  i.e., 3 for a 1D Array of size 3, 9 for a 3x3 2D array, etc

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -289,7 +289,8 @@ public:
       this->clear();
       static_cast<ArrayBase<T, DIM, Array<T, DIM, SPACE>>&>(*this) = other;
       m_allocator_id = other.m_allocator_id;
-      m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
+      m_executeOnGPU =
+        axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
       m_resize_ratio = other.m_resize_ratio;
       setCapacity(other.capacity());
       // Use fill_range to ensure that copy constructors are invoked for each element
@@ -329,7 +330,8 @@ public:
       m_capacity = other.m_capacity;
       m_resize_ratio = other.m_resize_ratio;
       m_allocator_id = other.m_allocator_id;
-      m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
+      m_executeOnGPU =
+        axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
 
       other.m_data = nullptr;
       other.m_num_elements = 0;
@@ -984,7 +986,8 @@ using MCArray = Array<T, 2>;
 template <typename T, int DIM, MemorySpace SPACE>
 Array<T, DIM, SPACE>::Array()
   : m_allocator_id(axom::detail::getAllocatorID<SPACE>())
-  , m_executeOnGPU(axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device)
+  , m_executeOnGPU(axom::detail::getAllocatorSpace(m_allocator_id) ==
+                   MemorySpace::Device)
 { }
 
 //------------------------------------------------------------------------------
@@ -1167,7 +1170,8 @@ Array<T, DIM, SPACE>::Array(Array&& other) noexcept
   m_capacity = other.m_capacity;
   m_resize_ratio = other.m_resize_ratio;
   m_allocator_id = other.m_allocator_id;
-  m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
+  m_executeOnGPU =
+    axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
 
   other.m_data = nullptr;
   other.m_num_elements = 0;
@@ -1589,7 +1593,8 @@ inline void Array<T, DIM, SPACE>::initialize(IndexType num_elements,
     capacity = (num_elements > MIN_DEFAULT_CAPACITY) ? num_elements
                                                      : MIN_DEFAULT_CAPACITY;
   }
-  m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
+  m_executeOnGPU =
+    axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
   setCapacity(capacity);
   if(default_construct)
   {
@@ -1625,7 +1630,8 @@ inline void Array<T, DIM, SPACE>::initialize_from_other(
 #endif
     m_allocator_id = axom::detail::getAllocatorID<SPACE>();
   }
-  m_executeOnGPU = axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
+  m_executeOnGPU =
+    axom::detail::getAllocatorSpace(m_allocator_id) == MemorySpace::Device;
   this->setCapacity(num_elements);
   // Use fill_range to ensure that copy constructors are invoked for each
   // element.

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -372,6 +372,23 @@ inline int getAllocatorID<MemorySpace::Constant>()
 
 }  // namespace detail
 
+/*!
+ * \brief Determines whether an allocator id is on device.
+ *
+ * \param allocator_id An allocator id.
+ *
+ * \return True if the allocator id is for a device; false otherwise.
+ */
+inline bool isDeviceAllocator(int allocator_id)
+{
+#if defined(AXOM_USE_UMPIRE)
+  return axom::detail::getAllocatorSpace(m_allocator_id) ==
+    axom::MemorySpace::Device;
+#else
+  return false;
+#endif
+}
+
 }  // namespace axom
 
 #endif /* AXOM_MEMORYMANAGEMENT_HPP_ */

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -382,7 +382,7 @@ inline int getAllocatorID<MemorySpace::Constant>()
 inline bool isDeviceAllocator(int allocator_id)
 {
 #if defined(AXOM_USE_UMPIRE)
-  return axom::detail::getAllocatorSpace(m_allocator_id) ==
+  return axom::detail::getAllocatorSpace(allocator_id) ==
     axom::MemorySpace::Device;
 #else
   return false;

--- a/src/axom/core/tests/core_execution_space.hpp
+++ b/src/axom/core/tests/core_execution_space.hpp
@@ -212,6 +212,40 @@ TEST(core_execution_space, check_cuda_exec_async)
                                                    IS_ASYNC,
                                                    ON_DEVICE);
 }
+//------------------------------------------------------------------------------
+void build(axom::Array<axom::IndexType> &values,
+           axom::Array<axom::IndexType> &ids,
+           int allocatorID)
+{
+  const std::vector<axom::IndexType> data {{0, 1, 2, 3}};
+  const axom::IndexType n = static_cast<axom::IndexType>(data.size());
+
+  values = axom::Array<axom::IndexType>(n, n, allocatorID);
+  ids = axom::Array<axom::IndexType>(n, n, allocatorID);
+
+  axom::copy(values.data(), data.data(), sizeof(axom::IndexType) * n);
+  axom::copy(ids.data(), data.data(), sizeof(axom::IndexType) * n);
+}
+
+template <typename ExecSpace>
+void test_check_cuda_array()
+{
+  int allocatorID = axom::execution_space<ExecSpace>::allocatorID();
+
+  axom::Array<axom::IndexType> values, ids;
+  build(values, ids, allocatorID);
+
+  EXPECT_EQ(values.size(), ids.size());
+  EXPECT_TRUE(axom::isDeviceAllocator(values.getAllocatorID()));
+  EXPECT_TRUE(axom::isDeviceAllocator(ids.getAllocatorID()));
+}
+
+TEST(core_execution_space, check_cuda_array)
+{
+  constexpr int BLOCK_SIZE = 256;
+  using ExecSpace = axom::CUDA_EXEC<BLOCK_SIZE>;
+  test_check_cuda_array<ExecSpace>();
+}
   #endif  // defined(AXOM_USE_CUDA)
 
   //------------------------------------------------------------------------------


### PR DESCRIPTION
# Summary
Lack of Array::m_executeOnGPU initialization played a role in causing host-initialization of device-allocated memory in certain situations. I was not able to create a reproducer on the develop branch but these changes eliminate warnings about uninitialized memory in axom::Array under Valgrind and fix the crashes on my MIR branch when using CUDA-allocated memory.

- This PR is a bugfix and closes #1432.
- It adds some initialization for Array::m_executeOnGPU, a bool that was causing warnings about uninitialized memory. 
