### PR TITLE
Adds missing preprocessor guard to quest marching cubes example

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -17,6 +17,20 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 
 The Axom project release numbers follow [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - Release date yyyy-mm-dd
+
+###  Added
+
+###  Changed
+
+###  Deprecated
+
+###  Removed
+
+###  Fixed
+- Added a guard for sidre-related mint API usage in a quest example
+
+
 ## [Version 0.10.0] - Release date 2024-09-27
 
 ### Added

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -954,6 +954,7 @@ struct ContourTestBase
         checkCellsContainingContour(computationalMesh, contourMesh);
     }
 
+#ifdef AXOM_MINT_USE_SIDRE
     if(contourMesh.hasSidreGroup())
     {
       assert(contourMesh.getSidreGroup() == meshGroup);
@@ -962,6 +963,7 @@ struct ContourTestBase
       saveMesh(*contourMesh.getSidreGroup(), outputName);
       SLIC_INFO(axom::fmt::format("Wrote contour mesh to {}", outputName));
     }
+#endif
     AXOM_ANNOTATE_END("error checking");
 
     objectDS.getRoot()->destroyGroupAndData(sidreGroupName);


### PR DESCRIPTION
# Summary

- This bugfix PR guards `sidre`-related `mint` API calls in the `quest` marching cubes example
- These are only available when the code is configured with `AXOM_MINT_USE_SIDRE`
- Resolves #1435 
