### PR TITLE
rzadams host-configs

### DIFF
--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -34,17 +34,17 @@
 
 ####
 # PR Build jobs
-tioga-clang_16_0_0_hip_5_6_0-src:
+tioga-rocmcc_6_1_2_hip-src:
   variables:
-    COMPILER: "clang@16.0.0_hip"
+    COMPILER: "rocmcc@6.1.2_hip"
     HOST_CONFIG: "tioga-toss_4_x86_64_ib_cray-${COMPILER}.cmake"
   extends: .src_build_on_tioga
 
 ####
 # Full Build jobs
-tioga-clang_16_0_0_hip_5_6_0-full:
+tioga-rocmcc_6_1_2_hip-full:
   variables:
-    COMPILER: "clang@16.0.0_hip"
+    COMPILER: "rocmcc@6.1.2_hip"
     SPEC: "%${COMPILER}~openmp+rocm+mfem+c2c"
-    EXTRASPEC: "amdgpu_target=gfx90a ^hip@5.6.0 ^hsa-rocr-dev@5.6.0 ^llvm-amdgpu@5.6.0 ^raja~openmp+rocm ^umpire~openmp+rocm ^hdf5 cflags=-Wno-int-conversion"
+    EXTRASPEC: "amdgpu_target=gfx90a ^hip@6.1.2 ^hsa-rocr-dev@6.1.2 ^llvm-amdgpu@6.1.2 ^raja~openmp+rocm ^umpire~openmp+rocm ^hdf5 cflags=-Wno-int-conversion"
   extends: .full_build_on_tioga

--- a/host-configs/rzadams-toss_4_x86_64_ib_cray-rocmcc@6.1.2_hip.cmake
+++ b/host-configs/rzadams-toss_4_x86_64_ib_cray-rocmcc@6.1.2_hip.cmake
@@ -1,0 +1,141 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/bin/cmake
+#------------------------------------------------------------------------------
+
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/umpire-2024.07.0-y6avvn5svuidecvjwqa6rltl3rih7os5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/fmt-11.0.2-h3wnomtfs6e3ue5gb7xxtmwn6wkkg672;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/raja-2024.07.0-zto4givqkfssetncw5gimoripw2itwrp;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/camp-2024.07.0-fsc63ixb6psvhxuadifl3wgqywcj2n4i;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/mfem-4.6.0-i2h2aj7bkuuwoltmyhkt6wwlqa3wousu;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/hypre-2.24.0-4kf24mxt6e3l7s6dr3a46rsbmadp6h5g;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/lua-5.4.6-yfdqhf5xfthpi2ewpzvhqe4n2qjgs3v4;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/ncurses-6.5-rb47wua3xmzwsgvn625ashcbhscsvvsa;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/conduit-0.9.2-iuxya57ldj6cpemgbipobqfwtrhixbix;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/parmetis-4.0.3-4xmnxxvzb77ygpj6z44kwrpy3enthqzc;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/metis-5.1.0-wh7uzwbzc5pftivibu2emd5ui5bpk4u7;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/hdf5-1.8.23-ibttonvoeuxviddsvavljlxmccxu3pdf;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/zlib-ng-2.2.1-nc7mdwd672nxjcqsazt7ihzkk7xpg63d;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/caliper-2.10.0-m4iaugyyapjb4k4l2fmy7jss4z7nf764;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/c2c-1.8.0-y7xmpoy6nja6pfq5prxuaqrizs7c4zys;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/blt-0.6.2-npjqsqy32t3xxvdtbn7zo37xdxbee6ti;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/adiak-0.4.0-hgvm7il3azqfwmwudxw7ekf3susnlird;/opt/rocm-6.1.2/llvm;/opt/rocm-6.1.2;/opt/rocm-6.1.2/hip;/opt/rocm-6.1.2;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2;/usr/tce" CACHE STRING "")
+
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
+
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/axom-develop-5lvqzqxuo27xpsrq2vm4irsplewyk63y/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/axom-develop-5lvqzqxuo27xpsrq2vm4irsplewyk63y/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/adiak-0.4.0-hgvm7il3azqfwmwudxw7ekf3susnlird/lib;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/c2c-1.8.0-y7xmpoy6nja6pfq5prxuaqrizs7c4zys/lib;/opt/rocm-6.1.2/lib;/opt/rocm-6.1.2/llvm/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/conduit-0.9.2-iuxya57ldj6cpemgbipobqfwtrhixbix/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/hdf5-1.8.23-ibttonvoeuxviddsvavljlxmccxu3pdf/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/zlib-ng-2.2.1-nc7mdwd672nxjcqsazt7ihzkk7xpg63d/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/metis-5.1.0-wh7uzwbzc5pftivibu2emd5ui5bpk4u7/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/parmetis-4.0.3-4xmnxxvzb77ygpj6z44kwrpy3enthqzc/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/lua-5.4.6-yfdqhf5xfthpi2ewpzvhqe4n2qjgs3v4/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/ncurses-6.5-rb47wua3xmzwsgvn625ashcbhscsvvsa/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/mfem-4.6.0-i2h2aj7bkuuwoltmyhkt6wwlqa3wousu/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/hypre-2.24.0-4kf24mxt6e3l7s6dr3a46rsbmadp6h5g/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/raja-2024.07.0-zto4givqkfssetncw5gimoripw2itwrp/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/camp-2024.07.0-fsc63ixb6psvhxuadifl3wgqywcj2n4i/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/caliper-2.10.0-m4iaugyyapjb4k4l2fmy7jss4z7nf764/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/umpire-2024.07.0-y6avvn5svuidecvjwqa6rltl3rih7os5/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/fmt-11.0.2-h3wnomtfs6e3ue5gb7xxtmwn6wkkg672/lib64;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/axom-develop-5lvqzqxuo27xpsrq2vm4irsplewyk63y/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/axom-develop-5lvqzqxuo27xpsrq2vm4irsplewyk63y/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/adiak-0.4.0-hgvm7il3azqfwmwudxw7ekf3susnlird/lib;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/c2c-1.8.0-y7xmpoy6nja6pfq5prxuaqrizs7c4zys/lib;/opt/rocm-6.1.2/lib;/opt/rocm-6.1.2/llvm/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/conduit-0.9.2-iuxya57ldj6cpemgbipobqfwtrhixbix/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/hdf5-1.8.23-ibttonvoeuxviddsvavljlxmccxu3pdf/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/zlib-ng-2.2.1-nc7mdwd672nxjcqsazt7ihzkk7xpg63d/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/metis-5.1.0-wh7uzwbzc5pftivibu2emd5ui5bpk4u7/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/parmetis-4.0.3-4xmnxxvzb77ygpj6z44kwrpy3enthqzc/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/lua-5.4.6-yfdqhf5xfthpi2ewpzvhqe4n2qjgs3v4/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/ncurses-6.5-rb47wua3xmzwsgvn625ashcbhscsvvsa/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/mfem-4.6.0-i2h2aj7bkuuwoltmyhkt6wwlqa3wousu/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/hypre-2.24.0-4kf24mxt6e3l7s6dr3a46rsbmadp6h5g/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/raja-2024.07.0-zto4givqkfssetncw5gimoripw2itwrp/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/camp-2024.07.0-fsc63ixb6psvhxuadifl3wgqywcj2n4i/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/caliper-2.10.0-m4iaugyyapjb4k4l2fmy7jss4z7nf764/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/umpire-2024.07.0-y6avvn5svuidecvjwqa6rltl3rih7os5/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2/fmt-11.0.2-h3wnomtfs6e3ue5gb7xxtmwn6wkkg672/lib64;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+# Compiler Spec: rocmcc@=6.1.2
+#------------------------------------------------------------------------------
+if(DEFINED ENV{SPACK_CC})
+
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/spack/lib/spack/env/rocmcc/amdclang" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/spack/lib/spack/env/rocmcc/amdclang++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/spack/lib/spack/env/rocmcc/amdflang" CACHE PATH "")
+
+else()
+
+  set(CMAKE_C_COMPILER "/opt/rocm-6.1.2/llvm/bin/amdclang" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/opt/rocm-6.1.2/llvm/bin/amdclang++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/opt/rocm-6.1.2/llvm/bin/amdflang" CACHE PATH "")
+
+endif()
+
+set(CMAKE_Fortran_FLAGS "-Mfreeform" CACHE STRING "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_CXX_FLAGS_DEBUG "-O1 -g -DNDEBUG" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/bin/mpif90" CACHE PATH "")
+
+# Unable to determine MPIEXEC, axom tests may fail
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPIEXEC_EXECUTABLE "/usr/global/tools/flux_wrappers/bin/srun" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Hardware
+#------------------------------------------------------------------------------
+
+#------------------------------------------------
+# ROCm
+#------------------------------------------------
+
+set(HIP_ROOT_DIR "/opt/rocm-6.1.2/hip" CACHE PATH "")
+
+set(CMAKE_HIP_COMPILER "/opt/rocm-6.1.2/llvm/bin/clang++" CACHE FILEPATH "")
+
+set(CMAKE_HIP_ARCHITECTURES "gfx942" CACHE STRING "")
+
+set(AMDGPU_TARGETS "gfx942" CACHE STRING "")
+
+set(GPU_TARGETS "gfx942" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+
+# Axom ROCm specifics
+
+#------------------------------------------------------------------------------
+
+
+set(ENABLE_HIP ON CACHE BOOL "")
+
+set(ROCM_PATH "/opt/rocm-6.1.2" CACHE PATH "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -Wl,--disable-new-dtags -L/opt/rocm-6.1.2/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.1.2/lib/llvm/lib  -L/opt/rocm-6.1.2/lib -Wl,-rpath,/opt/rocm-6.1.2/lib -lpgmath -lflang -lflangrti -lompstub  -L/opt/rocm-6.1.2/lib64 -Wl,-rpath,/opt/rocm-6.1.2/lib64 -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+
+#------------------------------------------------
+# Hardware Specifics
+#------------------------------------------------
+
+set(ENABLE_OPENMP OFF CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.1.2" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.2-iuxya57ldj6cpemgbipobqfwtrhixbix" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-y7xmpoy6nja6pfq5prxuaqrizs7c4zys" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.6.0-i2h2aj7bkuuwoltmyhkt6wwlqa3wousu" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-ibttonvoeuxviddsvavljlxmccxu3pdf" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.4.6-yfdqhf5xfthpi2ewpzvhqe4n2qjgs3v4" CACHE PATH "")
+
+set(RAJA_DIR "${TPL_ROOT}/raja-2024.07.0-zto4givqkfssetncw5gimoripw2itwrp" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2024.07.0-y6avvn5svuidecvjwqa6rltl3rih7os5" CACHE PATH "")
+
+set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-hgvm7il3azqfwmwudxw7ekf3susnlird" CACHE PATH "")
+
+set(CALIPER_DIR "${TPL_ROOT}/caliper-2.10.0-m4iaugyyapjb4k4l2fmy7jss4z7nf764" CACHE PATH "")
+
+set(CAMP_DIR "${TPL_ROOT}/camp-2024.07.0-fsc63ixb6psvhxuadifl3wgqywcj2n4i" CACHE PATH "")
+
+# scr not built
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# ClangFormat disabled due to llvm and devtools not in spec
+
+set(ENABLE_CLANGFORMAT OFF CACHE BOOL "")
+
+set(ENABLE_DOCS OFF CACHE BOOL "")
+
+

--- a/host-configs/rzadams-toss_4_x86_64_ib_cray-rocmcc@6.2.1_hip.cmake
+++ b/host-configs/rzadams-toss_4_x86_64_ib_cray-rocmcc@6.2.1_hip.cmake
@@ -1,0 +1,141 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/bin/cmake
+#------------------------------------------------------------------------------
+
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/umpire-2024.07.0-3qvxundo65b6j5ozpo2kspcj7rvoilah;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/fmt-11.0.2-hwrpzl3jooz7i65odnksfmxnsrf6d6sl;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/raja-2024.07.0-kbmumpmwodscfwfpmpqfedn2ca3aeszw;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/camp-2024.07.0-zwcj7bw62eulxdmlbb6gxc2vvnc5fli7;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/mfem-4.6.0-sh3z33happgc3nnz6jolrisvazlti7k2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/hypre-2.24.0-foz6b27kleqdgmmzsdvpwjigdsoykx4x;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/lua-5.4.6-vxdhu4xjfysss6padqmfzbvugvqywkt4;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/ncurses-6.5-walwjoomb76cgabk7qm7qvtjudtdues7;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/conduit-0.9.2-t62ryin3syopew4tzjoyraejoss223ky;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/parmetis-4.0.3-xd5pbav3ovs6gwvmp7lfey2coi3j36ai;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/metis-5.1.0-f3c7kd5vapvi2wf4nhwfaivxustgbddo;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/hdf5-1.8.23-ngpgvcnflpjtgjo6jjpt4ud22wd6aidc;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/zlib-ng-2.2.1-gcwdngejntz7wrdnxtah6jpn2zljjuo4;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/caliper-2.10.0-aagllvusaojj6wcxiq2xw3ovpiwxoiwm;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/c2c-1.8.0-254byruibds3wjeij7u453vzjk5wc26e;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/blt-0.6.2-4yqzr5jlco2hibawbwglc2g4n2hjatxx;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/adiak-0.4.0-4tg3h7x4k7gkq2pjolovwuuhz4cw25ud;/opt/rocm-6.2.1/llvm;/opt/rocm-6.2.1;/opt/rocm-6.2.1/hip;/opt/rocm-6.2.1;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1;/usr/tce" CACHE STRING "")
+
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
+
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/axom-develop-fzydsrlrcsnkpodjbho6i4dnv3uroiaz/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/axom-develop-fzydsrlrcsnkpodjbho6i4dnv3uroiaz/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/adiak-0.4.0-4tg3h7x4k7gkq2pjolovwuuhz4cw25ud/lib;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/c2c-1.8.0-254byruibds3wjeij7u453vzjk5wc26e/lib;/opt/rocm-6.2.1/lib;/opt/rocm-6.2.1/llvm/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/conduit-0.9.2-t62ryin3syopew4tzjoyraejoss223ky/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/hdf5-1.8.23-ngpgvcnflpjtgjo6jjpt4ud22wd6aidc/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/zlib-ng-2.2.1-gcwdngejntz7wrdnxtah6jpn2zljjuo4/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/metis-5.1.0-f3c7kd5vapvi2wf4nhwfaivxustgbddo/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/parmetis-4.0.3-xd5pbav3ovs6gwvmp7lfey2coi3j36ai/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/lua-5.4.6-vxdhu4xjfysss6padqmfzbvugvqywkt4/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/ncurses-6.5-walwjoomb76cgabk7qm7qvtjudtdues7/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/mfem-4.6.0-sh3z33happgc3nnz6jolrisvazlti7k2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/hypre-2.24.0-foz6b27kleqdgmmzsdvpwjigdsoykx4x/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/raja-2024.07.0-kbmumpmwodscfwfpmpqfedn2ca3aeszw/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/camp-2024.07.0-zwcj7bw62eulxdmlbb6gxc2vvnc5fli7/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/caliper-2.10.0-aagllvusaojj6wcxiq2xw3ovpiwxoiwm/lib64;/opt/rocm-6.2.1/llvm/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/umpire-2024.07.0-3qvxundo65b6j5ozpo2kspcj7rvoilah/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/fmt-11.0.2-hwrpzl3jooz7i65odnksfmxnsrf6d6sl/lib64;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/axom-develop-fzydsrlrcsnkpodjbho6i4dnv3uroiaz/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/axom-develop-fzydsrlrcsnkpodjbho6i4dnv3uroiaz/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/adiak-0.4.0-4tg3h7x4k7gkq2pjolovwuuhz4cw25ud/lib;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/c2c-1.8.0-254byruibds3wjeij7u453vzjk5wc26e/lib;/opt/rocm-6.2.1/lib;/opt/rocm-6.2.1/llvm/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/conduit-0.9.2-t62ryin3syopew4tzjoyraejoss223ky/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/hdf5-1.8.23-ngpgvcnflpjtgjo6jjpt4ud22wd6aidc/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/zlib-ng-2.2.1-gcwdngejntz7wrdnxtah6jpn2zljjuo4/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/metis-5.1.0-f3c7kd5vapvi2wf4nhwfaivxustgbddo/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/parmetis-4.0.3-xd5pbav3ovs6gwvmp7lfey2coi3j36ai/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/lua-5.4.6-vxdhu4xjfysss6padqmfzbvugvqywkt4/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/ncurses-6.5-walwjoomb76cgabk7qm7qvtjudtdues7/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/mfem-4.6.0-sh3z33happgc3nnz6jolrisvazlti7k2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/hypre-2.24.0-foz6b27kleqdgmmzsdvpwjigdsoykx4x/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/raja-2024.07.0-kbmumpmwodscfwfpmpqfedn2ca3aeszw/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/camp-2024.07.0-zwcj7bw62eulxdmlbb6gxc2vvnc5fli7/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/caliper-2.10.0-aagllvusaojj6wcxiq2xw3ovpiwxoiwm/lib64;/opt/rocm-6.2.1/llvm/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/umpire-2024.07.0-3qvxundo65b6j5ozpo2kspcj7rvoilah/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1/fmt-11.0.2-hwrpzl3jooz7i65odnksfmxnsrf6d6sl/lib64;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+# Compiler Spec: rocmcc@=6.2.1
+#------------------------------------------------------------------------------
+if(DEFINED ENV{SPACK_CC})
+
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/spack/lib/spack/env/rocmcc/amdclang" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/spack/lib/spack/env/rocmcc/amdclang++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/spack/lib/spack/env/rocmcc/amdflang" CACHE PATH "")
+
+else()
+
+  set(CMAKE_C_COMPILER "/opt/rocm-6.2.1/llvm/bin/amdclang" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/opt/rocm-6.2.1/llvm/bin/amdclang++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/opt/rocm-6.2.1/llvm/bin/amdflang" CACHE PATH "")
+
+endif()
+
+set(CMAKE_Fortran_FLAGS "-Mfreeform" CACHE STRING "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_CXX_FLAGS_DEBUG "-O1 -g -DNDEBUG" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/bin/mpif90" CACHE PATH "")
+
+# Unable to determine MPIEXEC, axom tests may fail
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPIEXEC_EXECUTABLE "/usr/global/tools/flux_wrappers/bin/srun" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Hardware
+#------------------------------------------------------------------------------
+
+#------------------------------------------------
+# ROCm
+#------------------------------------------------
+
+set(HIP_ROOT_DIR "/opt/rocm-6.2.1/hip" CACHE PATH "")
+
+set(CMAKE_HIP_COMPILER "/opt/rocm-6.2.1/llvm/bin/clang++" CACHE FILEPATH "")
+
+set(CMAKE_HIP_ARCHITECTURES "gfx942" CACHE STRING "")
+
+set(AMDGPU_TARGETS "gfx942" CACHE STRING "")
+
+set(GPU_TARGETS "gfx942" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+
+# Axom ROCm specifics
+
+#------------------------------------------------------------------------------
+
+
+set(ENABLE_HIP ON CACHE BOOL "")
+
+set(ROCM_PATH "/opt/rocm-6.2.1" CACHE PATH "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -Wl,--disable-new-dtags -L/opt/rocm-6.2.1/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.2.1/lib/llvm/lib  -L/opt/rocm-6.2.1/lib -Wl,-rpath,/opt/rocm-6.2.1/lib -lpgmath -lflang -lflangrti -lompstub  -L/opt/rocm-6.2.1/lib64 -Wl,-rpath,/opt/rocm-6.2.1/lib64 -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+
+#------------------------------------------------
+# Hardware Specifics
+#------------------------------------------------
+
+set(ENABLE_OPENMP OFF CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_15_10_09_34/rocmcc-6.2.1" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.2-t62ryin3syopew4tzjoyraejoss223ky" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-254byruibds3wjeij7u453vzjk5wc26e" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.6.0-sh3z33happgc3nnz6jolrisvazlti7k2" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-ngpgvcnflpjtgjo6jjpt4ud22wd6aidc" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.4.6-vxdhu4xjfysss6padqmfzbvugvqywkt4" CACHE PATH "")
+
+set(RAJA_DIR "${TPL_ROOT}/raja-2024.07.0-kbmumpmwodscfwfpmpqfedn2ca3aeszw" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2024.07.0-3qvxundo65b6j5ozpo2kspcj7rvoilah" CACHE PATH "")
+
+set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-4tg3h7x4k7gkq2pjolovwuuhz4cw25ud" CACHE PATH "")
+
+set(CALIPER_DIR "${TPL_ROOT}/caliper-2.10.0-aagllvusaojj6wcxiq2xw3ovpiwxoiwm" CACHE PATH "")
+
+set(CAMP_DIR "${TPL_ROOT}/camp-2024.07.0-zwcj7bw62eulxdmlbb6gxc2vvnc5fli7" CACHE PATH "")
+
+# scr not built
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# ClangFormat disabled due to llvm and devtools not in spec
+
+set(ENABLE_CLANGFORMAT OFF CACHE BOOL "")
+
+set(ENABLE_DOCS OFF CACHE BOOL "")
+
+

--- a/host-configs/rzvernal-toss_4_x86_64_ib_cray-rocmcc@6.1.2_hip.cmake
+++ b/host-configs/rzvernal-toss_4_x86_64_ib_cray-rocmcc@6.1.2_hip.cmake
@@ -1,0 +1,139 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/bin/cmake
+#------------------------------------------------------------------------------
+
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/umpire-2024.07.0-g524h7qg2p4ccmwr32vnajos7s4e2abv;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/fmt-11.0.2-j47ee4t2b4scoqvatm7weqsjcojrhsux;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/raja-2024.07.0-vt66yeqbdjkk45kyiummlrtokg4etx2z;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/camp-2024.07.0-f5m2lmxbhrcdbcc3fldvdlqk6hagamlb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/mfem-4.6.0-7zjrawwz6khla767rcpchm57amn5lig5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/hypre-2.24.0-gher3z34noqrbvn4s3itm2g6oaxcgkip;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/lua-5.4.6-fnels5zgzn5vzxfq6i4kkfxh2ljycii2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/ncurses-6.5-goclmfjdkgozo6wnlnbeqlzbjeis2voe;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/conduit-0.9.2-7xscrsthpqpstlda4vate42qbp3ra54m;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/parmetis-4.0.3-cxwpfxqmlcdenxfkxjqwden6aqp7fe34;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/metis-5.1.0-bcmoajf2xwgehwbuynjhoyy7f542v7nl;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/hdf5-1.8.23-tusfyhpdjwru4fgino3qbdoemuldnqbq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/zlib-ng-2.2.1-zqnkhwl4vptvos26y2hzou6ytcqyuq2q;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/caliper-2.10.0-f7hsj6tib6me2y32l4bfbgolouzifj2m;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/c2c-1.8.0-cazdglwlq5l2p6usy5zpv4pi6szete7a;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/blt-0.6.2-eo77mfvlgtqc4atyuvfdj437lzdh5su2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/adiak-0.4.0-3emvqbq5m6ruzwoajexslmpixs57ouqr;/opt/rocm-6.1.2/llvm;/opt/rocm-6.1.2;/opt/rocm-6.1.2/hip;/opt/rocm-6.1.2;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2;/usr/tce" CACHE STRING "")
+
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
+
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/axom-develop-pvkaodpz7qhyl3n6iqjlcbby665odfj4/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/axom-develop-pvkaodpz7qhyl3n6iqjlcbby665odfj4/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/adiak-0.4.0-3emvqbq5m6ruzwoajexslmpixs57ouqr/lib;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/c2c-1.8.0-cazdglwlq5l2p6usy5zpv4pi6szete7a/lib;/opt/rocm-6.1.2/lib;/opt/rocm-6.1.2/llvm/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/conduit-0.9.2-7xscrsthpqpstlda4vate42qbp3ra54m/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/hdf5-1.8.23-tusfyhpdjwru4fgino3qbdoemuldnqbq/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/zlib-ng-2.2.1-zqnkhwl4vptvos26y2hzou6ytcqyuq2q/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/metis-5.1.0-bcmoajf2xwgehwbuynjhoyy7f542v7nl/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/parmetis-4.0.3-cxwpfxqmlcdenxfkxjqwden6aqp7fe34/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/lua-5.4.6-fnels5zgzn5vzxfq6i4kkfxh2ljycii2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/ncurses-6.5-goclmfjdkgozo6wnlnbeqlzbjeis2voe/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/mfem-4.6.0-7zjrawwz6khla767rcpchm57amn5lig5/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/hypre-2.24.0-gher3z34noqrbvn4s3itm2g6oaxcgkip/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/raja-2024.07.0-vt66yeqbdjkk45kyiummlrtokg4etx2z/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/camp-2024.07.0-f5m2lmxbhrcdbcc3fldvdlqk6hagamlb/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/caliper-2.10.0-f7hsj6tib6me2y32l4bfbgolouzifj2m/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/umpire-2024.07.0-g524h7qg2p4ccmwr32vnajos7s4e2abv/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/fmt-11.0.2-j47ee4t2b4scoqvatm7weqsjcojrhsux/lib64;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/axom-develop-pvkaodpz7qhyl3n6iqjlcbby665odfj4/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/axom-develop-pvkaodpz7qhyl3n6iqjlcbby665odfj4/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/adiak-0.4.0-3emvqbq5m6ruzwoajexslmpixs57ouqr/lib;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/c2c-1.8.0-cazdglwlq5l2p6usy5zpv4pi6szete7a/lib;/opt/rocm-6.1.2/lib;/opt/rocm-6.1.2/llvm/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/conduit-0.9.2-7xscrsthpqpstlda4vate42qbp3ra54m/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/hdf5-1.8.23-tusfyhpdjwru4fgino3qbdoemuldnqbq/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/zlib-ng-2.2.1-zqnkhwl4vptvos26y2hzou6ytcqyuq2q/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/metis-5.1.0-bcmoajf2xwgehwbuynjhoyy7f542v7nl/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/parmetis-4.0.3-cxwpfxqmlcdenxfkxjqwden6aqp7fe34/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/lua-5.4.6-fnels5zgzn5vzxfq6i4kkfxh2ljycii2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/ncurses-6.5-goclmfjdkgozo6wnlnbeqlzbjeis2voe/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/mfem-4.6.0-7zjrawwz6khla767rcpchm57amn5lig5/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/hypre-2.24.0-gher3z34noqrbvn4s3itm2g6oaxcgkip/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/raja-2024.07.0-vt66yeqbdjkk45kyiummlrtokg4etx2z/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/camp-2024.07.0-f5m2lmxbhrcdbcc3fldvdlqk6hagamlb/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/caliper-2.10.0-f7hsj6tib6me2y32l4bfbgolouzifj2m/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/umpire-2024.07.0-g524h7qg2p4ccmwr32vnajos7s4e2abv/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2/fmt-11.0.2-j47ee4t2b4scoqvatm7weqsjcojrhsux/lib64;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+# Compiler Spec: rocmcc@=6.1.2
+#------------------------------------------------------------------------------
+if(DEFINED ENV{SPACK_CC})
+
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/spack/lib/spack/env/rocmcc/amdclang" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/spack/lib/spack/env/rocmcc/amdclang++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/spack/lib/spack/env/rocmcc/amdflang" CACHE PATH "")
+
+else()
+
+  set(CMAKE_C_COMPILER "/opt/rocm-6.1.2/llvm/bin/amdclang" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/opt/rocm-6.1.2/llvm/bin/amdclang++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/opt/rocm-6.1.2/llvm/bin/amdflang" CACHE PATH "")
+
+endif()
+
+set(CMAKE_Fortran_FLAGS "-Mfreeform" CACHE STRING "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_CXX_FLAGS_DEBUG "-O1 -g -DNDEBUG" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPIEXEC_EXECUTABLE "/usr/global/tools/flux_wrappers/bin/srun" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Hardware
+#------------------------------------------------------------------------------
+
+#------------------------------------------------
+# ROCm
+#------------------------------------------------
+
+set(HIP_ROOT_DIR "/opt/rocm-6.1.2/hip" CACHE PATH "")
+
+set(CMAKE_HIP_COMPILER "/opt/rocm-6.1.2/llvm/bin/clang++" CACHE FILEPATH "")
+
+set(CMAKE_HIP_ARCHITECTURES "gfx90a" CACHE STRING "")
+
+set(AMDGPU_TARGETS "gfx90a" CACHE STRING "")
+
+set(GPU_TARGETS "gfx90a" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+
+# Axom ROCm specifics
+
+#------------------------------------------------------------------------------
+
+
+set(ENABLE_HIP ON CACHE BOOL "")
+
+set(ROCM_PATH "/opt/rocm-6.1.2" CACHE PATH "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -Wl,--disable-new-dtags -L/opt/rocm-6.1.2/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.1.2/lib/llvm/lib  -L/opt/rocm-6.1.2/lib -Wl,-rpath,/opt/rocm-6.1.2/lib -lpgmath -lflang -lflangrti -lompstub  -L/opt/rocm-6.1.2/lib64 -Wl,-rpath,/opt/rocm-6.1.2/lib64 -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+
+#------------------------------------------------
+# Hardware Specifics
+#------------------------------------------------
+
+set(ENABLE_OPENMP OFF CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.1.2" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.2-7xscrsthpqpstlda4vate42qbp3ra54m" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-cazdglwlq5l2p6usy5zpv4pi6szete7a" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.6.0-7zjrawwz6khla767rcpchm57amn5lig5" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-tusfyhpdjwru4fgino3qbdoemuldnqbq" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.4.6-fnels5zgzn5vzxfq6i4kkfxh2ljycii2" CACHE PATH "")
+
+set(RAJA_DIR "${TPL_ROOT}/raja-2024.07.0-vt66yeqbdjkk45kyiummlrtokg4etx2z" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2024.07.0-g524h7qg2p4ccmwr32vnajos7s4e2abv" CACHE PATH "")
+
+set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-3emvqbq5m6ruzwoajexslmpixs57ouqr" CACHE PATH "")
+
+set(CALIPER_DIR "${TPL_ROOT}/caliper-2.10.0-f7hsj6tib6me2y32l4bfbgolouzifj2m" CACHE PATH "")
+
+set(CAMP_DIR "${TPL_ROOT}/camp-2024.07.0-f5m2lmxbhrcdbcc3fldvdlqk6hagamlb" CACHE PATH "")
+
+# scr not built
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# ClangFormat disabled due to llvm and devtools not in spec
+
+set(ENABLE_CLANGFORMAT OFF CACHE BOOL "")
+
+set(ENABLE_DOCS OFF CACHE BOOL "")
+
+

--- a/host-configs/rzvernal-toss_4_x86_64_ib_cray-rocmcc@6.2.1_hip.cmake
+++ b/host-configs/rzvernal-toss_4_x86_64_ib_cray-rocmcc@6.2.1_hip.cmake
@@ -1,0 +1,139 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/bin/cmake
+#------------------------------------------------------------------------------
+
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/umpire-2024.07.0-phrz3gjvnrhlrz2c3qkeeuohg3hnppip;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/fmt-11.0.2-bup7224vwsd7cinw6mvxbsrdww5cwhck;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/raja-2024.07.0-jokxpeli25cw2ewwlhdrn4smocy734n7;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/camp-2024.07.0-wpl7d6a5zs6tlu33puxatbyipsoz6ykl;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/mfem-4.6.0-hg4ii6e2lf5t6yytq4bs3ibagvo4xfwf;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/hypre-2.24.0-lqt5cjqiq7fbzp2gicbal2helcssornj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/lua-5.4.6-6hhinarrajn753pr4h4z7n3cusdriekl;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/ncurses-6.5-bpmj4tvujmrgzmkyggvwowu7fnz2di6j;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/conduit-0.9.2-debdb62dkpjhhd7td6fjvnyg3ee5vjpo;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/parmetis-4.0.3-eq7wn2ougghkw2tvur2js6jsc532b2q2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/metis-5.1.0-zvuucjwsesfonjwtk6ix3ausyrwti3aa;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/hdf5-1.8.23-4ls4xukncx5xfqhdca5wnmhzyyrxmuhp;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/zlib-ng-2.2.1-a4lnvcfc55tx7tnrfwx3oamrnumcd6w6;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/caliper-2.10.0-7lxiorowa5xy5dscxytv42ky36zl4tca;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/c2c-1.8.0-gvxdlgkotdfic2kq2wacb5c2dzhasdey;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/blt-0.6.2-gvehddmo22vhtwjpmq2o2donadrs4fzh;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/adiak-0.4.0-3lamdguwrmfcm6jp5yulflpltibwkhjk;/opt/rocm-6.2.1/llvm;/opt/rocm-6.2.1;/opt/rocm-6.2.1/hip;/opt/rocm-6.2.1;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1;/usr/tce" CACHE STRING "")
+
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
+
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/axom-develop-jntuqmtzq7yh4wpvb4xmeknotikqndb2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/axom-develop-jntuqmtzq7yh4wpvb4xmeknotikqndb2/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/adiak-0.4.0-3lamdguwrmfcm6jp5yulflpltibwkhjk/lib;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/c2c-1.8.0-gvxdlgkotdfic2kq2wacb5c2dzhasdey/lib;/opt/rocm-6.2.1/lib;/opt/rocm-6.2.1/llvm/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/conduit-0.9.2-debdb62dkpjhhd7td6fjvnyg3ee5vjpo/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/hdf5-1.8.23-4ls4xukncx5xfqhdca5wnmhzyyrxmuhp/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/zlib-ng-2.2.1-a4lnvcfc55tx7tnrfwx3oamrnumcd6w6/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/metis-5.1.0-zvuucjwsesfonjwtk6ix3ausyrwti3aa/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/parmetis-4.0.3-eq7wn2ougghkw2tvur2js6jsc532b2q2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/lua-5.4.6-6hhinarrajn753pr4h4z7n3cusdriekl/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/ncurses-6.5-bpmj4tvujmrgzmkyggvwowu7fnz2di6j/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/mfem-4.6.0-hg4ii6e2lf5t6yytq4bs3ibagvo4xfwf/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/hypre-2.24.0-lqt5cjqiq7fbzp2gicbal2helcssornj/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/raja-2024.07.0-jokxpeli25cw2ewwlhdrn4smocy734n7/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/camp-2024.07.0-wpl7d6a5zs6tlu33puxatbyipsoz6ykl/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/caliper-2.10.0-7lxiorowa5xy5dscxytv42ky36zl4tca/lib64;/opt/rocm-6.2.1/llvm/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/umpire-2024.07.0-phrz3gjvnrhlrz2c3qkeeuohg3hnppip/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/fmt-11.0.2-bup7224vwsd7cinw6mvxbsrdww5cwhck/lib64;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/axom-develop-jntuqmtzq7yh4wpvb4xmeknotikqndb2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/axom-develop-jntuqmtzq7yh4wpvb4xmeknotikqndb2/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/adiak-0.4.0-3lamdguwrmfcm6jp5yulflpltibwkhjk/lib;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/c2c-1.8.0-gvxdlgkotdfic2kq2wacb5c2dzhasdey/lib;/opt/rocm-6.2.1/lib;/opt/rocm-6.2.1/llvm/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/conduit-0.9.2-debdb62dkpjhhd7td6fjvnyg3ee5vjpo/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/hdf5-1.8.23-4ls4xukncx5xfqhdca5wnmhzyyrxmuhp/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/zlib-ng-2.2.1-a4lnvcfc55tx7tnrfwx3oamrnumcd6w6/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/metis-5.1.0-zvuucjwsesfonjwtk6ix3ausyrwti3aa/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/parmetis-4.0.3-eq7wn2ougghkw2tvur2js6jsc532b2q2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/lua-5.4.6-6hhinarrajn753pr4h4z7n3cusdriekl/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/ncurses-6.5-bpmj4tvujmrgzmkyggvwowu7fnz2di6j/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/mfem-4.6.0-hg4ii6e2lf5t6yytq4bs3ibagvo4xfwf/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/hypre-2.24.0-lqt5cjqiq7fbzp2gicbal2helcssornj/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/raja-2024.07.0-jokxpeli25cw2ewwlhdrn4smocy734n7/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/camp-2024.07.0-wpl7d6a5zs6tlu33puxatbyipsoz6ykl/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/caliper-2.10.0-7lxiorowa5xy5dscxytv42ky36zl4tca/lib64;/opt/rocm-6.2.1/llvm/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/umpire-2024.07.0-phrz3gjvnrhlrz2c3qkeeuohg3hnppip/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1/fmt-11.0.2-bup7224vwsd7cinw6mvxbsrdww5cwhck/lib64;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+# Compiler Spec: rocmcc@=6.2.1
+#------------------------------------------------------------------------------
+if(DEFINED ENV{SPACK_CC})
+
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/spack/lib/spack/env/rocmcc/amdclang" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/spack/lib/spack/env/rocmcc/amdclang++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/spack/lib/spack/env/rocmcc/amdflang" CACHE PATH "")
+
+else()
+
+  set(CMAKE_C_COMPILER "/opt/rocm-6.2.1/llvm/bin/amdclang" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/opt/rocm-6.2.1/llvm/bin/amdclang++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/opt/rocm-6.2.1/llvm/bin/amdflang" CACHE PATH "")
+
+endif()
+
+set(CMAKE_Fortran_FLAGS "-Mfreeform" CACHE STRING "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_CXX_FLAGS_DEBUG "-O1 -g -DNDEBUG" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPIEXEC_EXECUTABLE "/usr/global/tools/flux_wrappers/bin/srun" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Hardware
+#------------------------------------------------------------------------------
+
+#------------------------------------------------
+# ROCm
+#------------------------------------------------
+
+set(HIP_ROOT_DIR "/opt/rocm-6.2.1/hip" CACHE PATH "")
+
+set(CMAKE_HIP_COMPILER "/opt/rocm-6.2.1/llvm/bin/clang++" CACHE FILEPATH "")
+
+set(CMAKE_HIP_ARCHITECTURES "gfx90a" CACHE STRING "")
+
+set(AMDGPU_TARGETS "gfx90a" CACHE STRING "")
+
+set(GPU_TARGETS "gfx90a" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+
+# Axom ROCm specifics
+
+#------------------------------------------------------------------------------
+
+
+set(ENABLE_HIP ON CACHE BOOL "")
+
+set(ROCM_PATH "/opt/rocm-6.2.1" CACHE PATH "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -Wl,--disable-new-dtags -L/opt/rocm-6.2.1/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.2.1/lib/llvm/lib  -L/opt/rocm-6.2.1/lib -Wl,-rpath,/opt/rocm-6.2.1/lib -lpgmath -lflang -lflangrti -lompstub  -L/opt/rocm-6.2.1/lib64 -Wl,-rpath,/opt/rocm-6.2.1/lib64 -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+
+#------------------------------------------------
+# Hardware Specifics
+#------------------------------------------------
+
+set(ENABLE_OPENMP OFF CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_13_28_29/rocmcc-6.2.1" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.2-debdb62dkpjhhd7td6fjvnyg3ee5vjpo" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-gvxdlgkotdfic2kq2wacb5c2dzhasdey" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.6.0-hg4ii6e2lf5t6yytq4bs3ibagvo4xfwf" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-4ls4xukncx5xfqhdca5wnmhzyyrxmuhp" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.4.6-6hhinarrajn753pr4h4z7n3cusdriekl" CACHE PATH "")
+
+set(RAJA_DIR "${TPL_ROOT}/raja-2024.07.0-jokxpeli25cw2ewwlhdrn4smocy734n7" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2024.07.0-phrz3gjvnrhlrz2c3qkeeuohg3hnppip" CACHE PATH "")
+
+set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-3lamdguwrmfcm6jp5yulflpltibwkhjk" CACHE PATH "")
+
+set(CALIPER_DIR "${TPL_ROOT}/caliper-2.10.0-7lxiorowa5xy5dscxytv42ky36zl4tca" CACHE PATH "")
+
+set(CAMP_DIR "${TPL_ROOT}/camp-2024.07.0-wpl7d6a5zs6tlu33puxatbyipsoz6ykl" CACHE PATH "")
+
+# scr not built
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# ClangFormat disabled due to llvm and devtools not in spec
+
+set(ENABLE_CLANGFORMAT OFF CACHE BOOL "")
+
+set(ENABLE_DOCS OFF CACHE BOOL "")
+
+

--- a/host-configs/tioga-toss_4_x86_64_ib_cray-rocmcc@6.1.2_hip.cmake
+++ b/host-configs/tioga-toss_4_x86_64_ib_cray-rocmcc@6.1.2_hip.cmake
@@ -1,0 +1,139 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/bin/cmake
+#------------------------------------------------------------------------------
+
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/umpire-2024.07.0-g524h7qg2p4ccmwr32vnajos7s4e2abv;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/fmt-11.0.2-j47ee4t2b4scoqvatm7weqsjcojrhsux;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/raja-2024.07.0-vt66yeqbdjkk45kyiummlrtokg4etx2z;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/camp-2024.07.0-f5m2lmxbhrcdbcc3fldvdlqk6hagamlb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/mfem-4.6.0-7zjrawwz6khla767rcpchm57amn5lig5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/hypre-2.24.0-gher3z34noqrbvn4s3itm2g6oaxcgkip;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/lua-5.4.6-fnels5zgzn5vzxfq6i4kkfxh2ljycii2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/ncurses-6.5-goclmfjdkgozo6wnlnbeqlzbjeis2voe;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/conduit-0.9.2-7xscrsthpqpstlda4vate42qbp3ra54m;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/parmetis-4.0.3-cxwpfxqmlcdenxfkxjqwden6aqp7fe34;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/metis-5.1.0-bcmoajf2xwgehwbuynjhoyy7f542v7nl;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/hdf5-1.8.23-tusfyhpdjwru4fgino3qbdoemuldnqbq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/zlib-ng-2.2.1-zqnkhwl4vptvos26y2hzou6ytcqyuq2q;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/caliper-2.10.0-f7hsj6tib6me2y32l4bfbgolouzifj2m;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/c2c-1.8.0-cazdglwlq5l2p6usy5zpv4pi6szete7a;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/blt-0.6.2-eo77mfvlgtqc4atyuvfdj437lzdh5su2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/adiak-0.4.0-3emvqbq5m6ruzwoajexslmpixs57ouqr;/opt/rocm-6.1.2/llvm;/opt/rocm-6.1.2;/opt/rocm-6.1.2/hip;/opt/rocm-6.1.2;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2;/usr/tce" CACHE STRING "")
+
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
+
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/axom-develop-pvkaodpz7qhyl3n6iqjlcbby665odfj4/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/axom-develop-pvkaodpz7qhyl3n6iqjlcbby665odfj4/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/adiak-0.4.0-3emvqbq5m6ruzwoajexslmpixs57ouqr/lib;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/c2c-1.8.0-cazdglwlq5l2p6usy5zpv4pi6szete7a/lib;/opt/rocm-6.1.2/lib;/opt/rocm-6.1.2/llvm/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/conduit-0.9.2-7xscrsthpqpstlda4vate42qbp3ra54m/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/hdf5-1.8.23-tusfyhpdjwru4fgino3qbdoemuldnqbq/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/zlib-ng-2.2.1-zqnkhwl4vptvos26y2hzou6ytcqyuq2q/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/metis-5.1.0-bcmoajf2xwgehwbuynjhoyy7f542v7nl/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/parmetis-4.0.3-cxwpfxqmlcdenxfkxjqwden6aqp7fe34/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/lua-5.4.6-fnels5zgzn5vzxfq6i4kkfxh2ljycii2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/ncurses-6.5-goclmfjdkgozo6wnlnbeqlzbjeis2voe/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/mfem-4.6.0-7zjrawwz6khla767rcpchm57amn5lig5/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/hypre-2.24.0-gher3z34noqrbvn4s3itm2g6oaxcgkip/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/raja-2024.07.0-vt66yeqbdjkk45kyiummlrtokg4etx2z/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/camp-2024.07.0-f5m2lmxbhrcdbcc3fldvdlqk6hagamlb/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/caliper-2.10.0-f7hsj6tib6me2y32l4bfbgolouzifj2m/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/umpire-2024.07.0-g524h7qg2p4ccmwr32vnajos7s4e2abv/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/fmt-11.0.2-j47ee4t2b4scoqvatm7weqsjcojrhsux/lib64;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/axom-develop-pvkaodpz7qhyl3n6iqjlcbby665odfj4/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/axom-develop-pvkaodpz7qhyl3n6iqjlcbby665odfj4/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/adiak-0.4.0-3emvqbq5m6ruzwoajexslmpixs57ouqr/lib;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/c2c-1.8.0-cazdglwlq5l2p6usy5zpv4pi6szete7a/lib;/opt/rocm-6.1.2/lib;/opt/rocm-6.1.2/llvm/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/conduit-0.9.2-7xscrsthpqpstlda4vate42qbp3ra54m/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/hdf5-1.8.23-tusfyhpdjwru4fgino3qbdoemuldnqbq/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/zlib-ng-2.2.1-zqnkhwl4vptvos26y2hzou6ytcqyuq2q/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/metis-5.1.0-bcmoajf2xwgehwbuynjhoyy7f542v7nl/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/parmetis-4.0.3-cxwpfxqmlcdenxfkxjqwden6aqp7fe34/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/lua-5.4.6-fnels5zgzn5vzxfq6i4kkfxh2ljycii2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/ncurses-6.5-goclmfjdkgozo6wnlnbeqlzbjeis2voe/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/mfem-4.6.0-7zjrawwz6khla767rcpchm57amn5lig5/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/hypre-2.24.0-gher3z34noqrbvn4s3itm2g6oaxcgkip/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/raja-2024.07.0-vt66yeqbdjkk45kyiummlrtokg4etx2z/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/camp-2024.07.0-f5m2lmxbhrcdbcc3fldvdlqk6hagamlb/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/caliper-2.10.0-f7hsj6tib6me2y32l4bfbgolouzifj2m/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/umpire-2024.07.0-g524h7qg2p4ccmwr32vnajos7s4e2abv/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2/fmt-11.0.2-j47ee4t2b4scoqvatm7weqsjcojrhsux/lib64;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+# Compiler Spec: rocmcc@=6.1.2
+#------------------------------------------------------------------------------
+if(DEFINED ENV{SPACK_CC})
+
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/spack/lib/spack/env/rocmcc/amdclang" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/spack/lib/spack/env/rocmcc/amdclang++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/spack/lib/spack/env/rocmcc/amdflang" CACHE PATH "")
+
+else()
+
+  set(CMAKE_C_COMPILER "/opt/rocm-6.1.2/llvm/bin/amdclang" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/opt/rocm-6.1.2/llvm/bin/amdclang++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/opt/rocm-6.1.2/llvm/bin/amdflang" CACHE PATH "")
+
+endif()
+
+set(CMAKE_Fortran_FLAGS "-Mfreeform" CACHE STRING "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_CXX_FLAGS_DEBUG "-O1 -g -DNDEBUG" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPIEXEC_EXECUTABLE "/usr/global/tools/flux_wrappers/bin/srun" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Hardware
+#------------------------------------------------------------------------------
+
+#------------------------------------------------
+# ROCm
+#------------------------------------------------
+
+set(HIP_ROOT_DIR "/opt/rocm-6.1.2/hip" CACHE PATH "")
+
+set(CMAKE_HIP_COMPILER "/opt/rocm-6.1.2/llvm/bin/clang++" CACHE FILEPATH "")
+
+set(CMAKE_HIP_ARCHITECTURES "gfx90a" CACHE STRING "")
+
+set(AMDGPU_TARGETS "gfx90a" CACHE STRING "")
+
+set(GPU_TARGETS "gfx90a" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+
+# Axom ROCm specifics
+
+#------------------------------------------------------------------------------
+
+
+set(ENABLE_HIP ON CACHE BOOL "")
+
+set(ROCM_PATH "/opt/rocm-6.1.2" CACHE PATH "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -Wl,--disable-new-dtags -L/opt/rocm-6.1.2/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.1.2/lib/llvm/lib  -L/opt/rocm-6.1.2/lib -Wl,-rpath,/opt/rocm-6.1.2/lib -lpgmath -lflang -lflangrti -lompstub  -L/opt/rocm-6.1.2/lib64 -Wl,-rpath,/opt/rocm-6.1.2/lib64 -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+
+#------------------------------------------------
+# Hardware Specifics
+#------------------------------------------------
+
+set(ENABLE_OPENMP OFF CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.1.2" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.2-7xscrsthpqpstlda4vate42qbp3ra54m" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-cazdglwlq5l2p6usy5zpv4pi6szete7a" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.6.0-7zjrawwz6khla767rcpchm57amn5lig5" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-tusfyhpdjwru4fgino3qbdoemuldnqbq" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.4.6-fnels5zgzn5vzxfq6i4kkfxh2ljycii2" CACHE PATH "")
+
+set(RAJA_DIR "${TPL_ROOT}/raja-2024.07.0-vt66yeqbdjkk45kyiummlrtokg4etx2z" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2024.07.0-g524h7qg2p4ccmwr32vnajos7s4e2abv" CACHE PATH "")
+
+set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-3emvqbq5m6ruzwoajexslmpixs57ouqr" CACHE PATH "")
+
+set(CALIPER_DIR "${TPL_ROOT}/caliper-2.10.0-f7hsj6tib6me2y32l4bfbgolouzifj2m" CACHE PATH "")
+
+set(CAMP_DIR "${TPL_ROOT}/camp-2024.07.0-f5m2lmxbhrcdbcc3fldvdlqk6hagamlb" CACHE PATH "")
+
+# scr not built
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# ClangFormat disabled due to llvm and devtools not in spec
+
+set(ENABLE_CLANGFORMAT OFF CACHE BOOL "")
+
+set(ENABLE_DOCS OFF CACHE BOOL "")
+
+

--- a/host-configs/tioga-toss_4_x86_64_ib_cray-rocmcc@6.2.1_hip.cmake
+++ b/host-configs/tioga-toss_4_x86_64_ib_cray-rocmcc@6.2.1_hip.cmake
@@ -1,0 +1,139 @@
+#------------------------------------------------------------------------------
+# !!!! This is a generated file, edit at own risk !!!!
+#------------------------------------------------------------------------------
+# CMake executable path: /usr/tce/bin/cmake
+#------------------------------------------------------------------------------
+
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/umpire-2024.07.0-phrz3gjvnrhlrz2c3qkeeuohg3hnppip;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/fmt-11.0.2-bup7224vwsd7cinw6mvxbsrdww5cwhck;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/raja-2024.07.0-jokxpeli25cw2ewwlhdrn4smocy734n7;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/camp-2024.07.0-wpl7d6a5zs6tlu33puxatbyipsoz6ykl;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/mfem-4.6.0-hg4ii6e2lf5t6yytq4bs3ibagvo4xfwf;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/hypre-2.24.0-lqt5cjqiq7fbzp2gicbal2helcssornj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/lua-5.4.6-6hhinarrajn753pr4h4z7n3cusdriekl;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/ncurses-6.5-bpmj4tvujmrgzmkyggvwowu7fnz2di6j;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/conduit-0.9.2-debdb62dkpjhhd7td6fjvnyg3ee5vjpo;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/parmetis-4.0.3-eq7wn2ougghkw2tvur2js6jsc532b2q2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/metis-5.1.0-zvuucjwsesfonjwtk6ix3ausyrwti3aa;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/hdf5-1.8.23-4ls4xukncx5xfqhdca5wnmhzyyrxmuhp;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/zlib-ng-2.2.1-a4lnvcfc55tx7tnrfwx3oamrnumcd6w6;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/caliper-2.10.0-7lxiorowa5xy5dscxytv42ky36zl4tca;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/c2c-1.8.0-gvxdlgkotdfic2kq2wacb5c2dzhasdey;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/blt-0.6.2-gvehddmo22vhtwjpmq2o2donadrs4fzh;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/adiak-0.4.0-3lamdguwrmfcm6jp5yulflpltibwkhjk;/opt/rocm-6.2.1/llvm;/opt/rocm-6.2.1;/opt/rocm-6.2.1/hip;/opt/rocm-6.2.1;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1;/usr/tce" CACHE STRING "")
+
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
+
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/axom-develop-jntuqmtzq7yh4wpvb4xmeknotikqndb2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/axom-develop-jntuqmtzq7yh4wpvb4xmeknotikqndb2/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/adiak-0.4.0-3lamdguwrmfcm6jp5yulflpltibwkhjk/lib;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/c2c-1.8.0-gvxdlgkotdfic2kq2wacb5c2dzhasdey/lib;/opt/rocm-6.2.1/lib;/opt/rocm-6.2.1/llvm/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/conduit-0.9.2-debdb62dkpjhhd7td6fjvnyg3ee5vjpo/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/hdf5-1.8.23-4ls4xukncx5xfqhdca5wnmhzyyrxmuhp/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/zlib-ng-2.2.1-a4lnvcfc55tx7tnrfwx3oamrnumcd6w6/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/metis-5.1.0-zvuucjwsesfonjwtk6ix3ausyrwti3aa/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/parmetis-4.0.3-eq7wn2ougghkw2tvur2js6jsc532b2q2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/lua-5.4.6-6hhinarrajn753pr4h4z7n3cusdriekl/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/ncurses-6.5-bpmj4tvujmrgzmkyggvwowu7fnz2di6j/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/mfem-4.6.0-hg4ii6e2lf5t6yytq4bs3ibagvo4xfwf/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/hypre-2.24.0-lqt5cjqiq7fbzp2gicbal2helcssornj/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/raja-2024.07.0-jokxpeli25cw2ewwlhdrn4smocy734n7/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/camp-2024.07.0-wpl7d6a5zs6tlu33puxatbyipsoz6ykl/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/caliper-2.10.0-7lxiorowa5xy5dscxytv42ky36zl4tca/lib64;/opt/rocm-6.2.1/llvm/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/umpire-2024.07.0-phrz3gjvnrhlrz2c3qkeeuohg3hnppip/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/fmt-11.0.2-bup7224vwsd7cinw6mvxbsrdww5cwhck/lib64;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/axom-develop-jntuqmtzq7yh4wpvb4xmeknotikqndb2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/axom-develop-jntuqmtzq7yh4wpvb4xmeknotikqndb2/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/adiak-0.4.0-3lamdguwrmfcm6jp5yulflpltibwkhjk/lib;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/c2c-1.8.0-gvxdlgkotdfic2kq2wacb5c2dzhasdey/lib;/opt/rocm-6.2.1/lib;/opt/rocm-6.2.1/llvm/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/conduit-0.9.2-debdb62dkpjhhd7td6fjvnyg3ee5vjpo/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/hdf5-1.8.23-4ls4xukncx5xfqhdca5wnmhzyyrxmuhp/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/zlib-ng-2.2.1-a4lnvcfc55tx7tnrfwx3oamrnumcd6w6/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/metis-5.1.0-zvuucjwsesfonjwtk6ix3ausyrwti3aa/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/parmetis-4.0.3-eq7wn2ougghkw2tvur2js6jsc532b2q2/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/lua-5.4.6-6hhinarrajn753pr4h4z7n3cusdriekl/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/ncurses-6.5-bpmj4tvujmrgzmkyggvwowu7fnz2di6j/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/mfem-4.6.0-hg4ii6e2lf5t6yytq4bs3ibagvo4xfwf/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/hypre-2.24.0-lqt5cjqiq7fbzp2gicbal2helcssornj/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/raja-2024.07.0-jokxpeli25cw2ewwlhdrn4smocy734n7/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/camp-2024.07.0-wpl7d6a5zs6tlu33puxatbyipsoz6ykl/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/caliper-2.10.0-7lxiorowa5xy5dscxytv42ky36zl4tca/lib64;/opt/rocm-6.2.1/llvm/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/umpire-2024.07.0-phrz3gjvnrhlrz2c3qkeeuohg3hnppip/lib64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1/fmt-11.0.2-bup7224vwsd7cinw6mvxbsrdww5cwhck/lib64;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# Compilers
+#------------------------------------------------------------------------------
+# Compiler Spec: rocmcc@=6.2.1
+#------------------------------------------------------------------------------
+if(DEFINED ENV{SPACK_CC})
+
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/spack/lib/spack/env/rocmcc/amdclang" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/spack/lib/spack/env/rocmcc/amdclang++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/spack/lib/spack/env/rocmcc/amdflang" CACHE PATH "")
+
+else()
+
+  set(CMAKE_C_COMPILER "/opt/rocm-6.2.1/llvm/bin/amdclang" CACHE PATH "")
+
+  set(CMAKE_CXX_COMPILER "/opt/rocm-6.2.1/llvm/bin/amdclang++" CACHE PATH "")
+
+  set(CMAKE_Fortran_COMPILER "/opt/rocm-6.2.1/llvm/bin/amdflang" CACHE PATH "")
+
+endif()
+
+set(CMAKE_Fortran_FLAGS "-Mfreeform" CACHE STRING "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_CXX_FLAGS_DEBUG "-O1 -g -DNDEBUG" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+# MPI
+#------------------------------------------------------------------------------
+
+set(MPI_C_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/bin/mpicc" CACHE PATH "")
+
+set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/bin/mpicxx" CACHE PATH "")
+
+set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPIEXEC_EXECUTABLE "/usr/global/tools/flux_wrappers/bin/srun" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# Hardware
+#------------------------------------------------------------------------------
+
+#------------------------------------------------
+# ROCm
+#------------------------------------------------
+
+set(HIP_ROOT_DIR "/opt/rocm-6.2.1/hip" CACHE PATH "")
+
+set(CMAKE_HIP_COMPILER "/opt/rocm-6.2.1/llvm/bin/clang++" CACHE FILEPATH "")
+
+set(CMAKE_HIP_ARCHITECTURES "gfx90a" CACHE STRING "")
+
+set(AMDGPU_TARGETS "gfx90a" CACHE STRING "")
+
+set(GPU_TARGETS "gfx90a" CACHE STRING "")
+
+#------------------------------------------------------------------------------
+
+# Axom ROCm specifics
+
+#------------------------------------------------------------------------------
+
+
+set(ENABLE_HIP ON CACHE BOOL "")
+
+set(ROCM_PATH "/opt/rocm-6.2.1" CACHE PATH "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -Wl,--disable-new-dtags -L/opt/rocm-6.2.1/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.2.1/lib/llvm/lib  -L/opt/rocm-6.2.1/lib -Wl,-rpath,/opt/rocm-6.2.1/lib -lpgmath -lflang -lflangrti -lompstub  -L/opt/rocm-6.2.1/lib64 -Wl,-rpath,/opt/rocm-6.2.1/lib64 -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+
+#------------------------------------------------
+# Hardware Specifics
+#------------------------------------------------
+
+set(ENABLE_OPENMP OFF CACHE BOOL "")
+
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+#------------------------------------------------------------------------------
+# TPLs
+#------------------------------------------------------------------------------
+
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2024_10_14_14_52_45/rocmcc-6.2.1" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.2-debdb62dkpjhhd7td6fjvnyg3ee5vjpo" CACHE PATH "")
+
+set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-gvxdlgkotdfic2kq2wacb5c2dzhasdey" CACHE PATH "")
+
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.6.0-hg4ii6e2lf5t6yytq4bs3ibagvo4xfwf" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-4ls4xukncx5xfqhdca5wnmhzyyrxmuhp" CACHE PATH "")
+
+set(LUA_DIR "${TPL_ROOT}/lua-5.4.6-6hhinarrajn753pr4h4z7n3cusdriekl" CACHE PATH "")
+
+set(RAJA_DIR "${TPL_ROOT}/raja-2024.07.0-jokxpeli25cw2ewwlhdrn4smocy734n7" CACHE PATH "")
+
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2024.07.0-phrz3gjvnrhlrz2c3qkeeuohg3hnppip" CACHE PATH "")
+
+set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-3lamdguwrmfcm6jp5yulflpltibwkhjk" CACHE PATH "")
+
+set(CALIPER_DIR "${TPL_ROOT}/caliper-2.10.0-7lxiorowa5xy5dscxytv42ky36zl4tca" CACHE PATH "")
+
+set(CAMP_DIR "${TPL_ROOT}/camp-2024.07.0-wpl7d6a5zs6tlu33puxatbyipsoz6ykl" CACHE PATH "")
+
+# scr not built
+
+#------------------------------------------------------------------------------
+# Devtools
+#------------------------------------------------------------------------------
+
+# ClangFormat disabled due to llvm and devtools not in spec
+
+set(ENABLE_CLANGFORMAT OFF CACHE BOOL "")
+
+set(ENABLE_DOCS OFF CACHE BOOL "")
+
+

--- a/scripts/spack/configs/toss_4_x86_64_ib_cray/spack.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib_cray/spack.yaml
@@ -259,9 +259,9 @@ spack:
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.25-rocmcc-5.6.0/
       - spec: cray-mpich@8.1.27%rocmcc@5.7.1+slurm
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.27-rocmcc-5.7.1/
-      - spec: cray-mpich@8.1.30%rocmcc@6.1.2+slurm
+      - spec: cray-mpich@8.1.29%rocmcc@6.1.2+slurm
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/
-      - spec: cray-mpich@8.1.30%rocmcc@6.2.1+slurm
+      - spec: cray-mpich@8.1.29%rocmcc@6.2.1+slurm
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/
       - spec: cray-mpich@8.1.25%cce@15.0.1+slurm
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.25-rocmcc-5.4.3-cce-15.0.1/

--- a/scripts/spack/configs/toss_4_x86_64_ib_cray/spack.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib_cray/spack.yaml
@@ -72,7 +72,35 @@ spack:
         cxx: /opt/rocm-5.7.1/llvm/bin/amdclang++
         f77: /opt/rocm-5.7.1/llvm/bin/amdflang
         fc: /opt/rocm-5.7.1/llvm/bin/amdflang
-      spec: clang@17.0.0
+      spec: rocmcc@=5.7.1
+      target: x86_64
+  - compiler:
+      environment: {}
+      extra_rpaths: []
+      flags:
+        fflags: -Mfreeform
+      modules: []
+      operating_system: rhel8
+      paths:
+        cc: /opt/rocm-6.1.2/llvm/bin/amdclang
+        cxx: /opt/rocm-6.1.2/llvm/bin/amdclang++
+        f77: /opt/rocm-6.1.2/llvm/bin/amdflang
+        fc: /opt/rocm-6.1.2/llvm/bin/amdflang
+      spec: rocmcc@=6.1.2
+      target: x86_64
+  - compiler:
+      environment: {}
+      extra_rpaths: []
+      flags:
+        fflags: -Mfreeform
+      modules: []
+      operating_system: rhel8
+      paths:
+        cc: /opt/rocm-6.2.1/llvm/bin/amdclang
+        cxx: /opt/rocm-6.2.1/llvm/bin/amdclang++
+        f77: /opt/rocm-6.2.1/llvm/bin/amdflang
+        fc: /opt/rocm-6.2.1/llvm/bin/amdflang
+      spec: rocmcc@=6.2.1
       target: x86_64
   - compiler:
       environment: {}
@@ -99,7 +127,7 @@ spack:
         mpi: [cray-mpich]
 
     hip:
-      version: [5.2.3, 5.4.3, 5.6.0, 5.7.1]
+      version: [5.2.3, 5.4.3, 5.6.0, 5.7.1, 6.1.2, 6.2.1]
       buildable: false
       externals:
       - spec: hip@5.2.3
@@ -110,9 +138,13 @@ spack:
         prefix: /opt/rocm-5.6.0/hip
       - spec: hip@5.7.1
         prefix: /opt/rocm-5.7.1/hip
+      - spec: hip@6.1.2
+        prefix: /opt/rocm-6.1.2/hip
+      - spec: hip@6.2.1
+        prefix: /opt/rocm-6.2.1/hip
 
     llvm-amdgpu:
-      version: [5.2.3, 5.4.3, 5.6.0, 5.7.1]
+      version: [5.2.3, 5.4.3, 5.6.0, 5.7.1, 6.1.2, 6.2.1]
       buildable: false
       externals:
       - spec: llvm-amdgpu@5.2.3
@@ -123,9 +155,13 @@ spack:
         prefix: /opt/rocm-5.6.0/llvm
       - spec: llvm-amdgpu@5.7.1
         prefix: /opt/rocm-5.7.1/llvm
+      - spec: llvm-amdgpu@6.1.2
+        prefix: /opt/rocm-6.1.2/llvm
+      - spec: llvm-amdgpu@6.2.1
+        prefix: /opt/rocm-6.2.1/llvm
 
     hsa-rocr-dev:
-      version: [5.2.3, 5.4.3, 5.6.0, 5.7.1]
+      version: [5.2.3, 5.4.3, 5.6.0, 5.7.1, 6.1.2, 6.2.1]
       buildable: false
       externals:
       - spec: hsa-rocr-dev@5.2.3
@@ -136,9 +172,13 @@ spack:
         prefix: /opt/rocm-5.6.0/
       - spec: hsa-rocr-dev@5.7.1
         prefix: /opt/rocm-5.7.1/
+      - spec: hsa-rocr-dev@6.1.2
+        prefix: /opt/rocm-6.1.2/
+      - spec: hsa-rocr-dev@6.2.1
+        prefix: /opt/rocm-6.2.1/
 
     rocblas:
-      version: [5.2.3, 5.4.3, 5.6.0, 5.7.1]
+      version: [5.2.3, 5.4.3, 5.6.0, 5.7.1, 6.1.2, 6.2.1]
       buildable: false
       externals:
       - spec: rocblas@5.2.3
@@ -149,9 +189,13 @@ spack:
         prefix: /opt/rocm-5.6.0/
       - spec: rocblas@5.7.1
         prefix: /opt/rocm-5.7.1/
+      - spec: rocblas@6.1.2
+        prefix: /opt/rocm-6.1.2/
+      - spec: rocblas@6.2.1
+        prefix: /opt/rocm-6.2.1/
 
     rocminfo:
-      version: [5.2.3, 5.4.3, 5.6.0, 5.7.1]
+      version: [5.2.3, 5.4.3, 5.6.0, 5.7.1, 6.1.2, 6.2.1]
       buildable: false
       externals:
       - spec: rocminfo@5.2.3
@@ -162,9 +206,13 @@ spack:
         prefix: /opt/rocm-5.6.0/
       - spec: rocminfo@5.7.1
         prefix: /opt/rocm-5.7.1
+      - spec: rocminfo@6.1.2
+        prefix: /opt/rocm-6.1.2
+      - spec: rocminfo@6.2.1
+        prefix: /opt/rocm-6.2.1
 
     rocprim:
-      version: [5.2.3, 5.4.3, 5.6.0, 5.7.1]
+      version: [5.2.3, 5.4.3, 5.6.0, 5.7.1, 6.1.2, 6.2.1]
       buildable: false
       externals:
       - spec: rocprim@5.2.3
@@ -175,9 +223,13 @@ spack:
         prefix: /opt/rocm-5.6.0/
       - spec: rocprim@5.7.1
         prefix: /opt/rocm-5.7.1/
+      - spec: rocprim@6.1.2
+        prefix: /opt/rocm-6.1.2/
+      - spec: rocprim@6.2.1
+        prefix: /opt/rocm-6.2.1/
 
     rocm-device-libs:
-      version: [5.2.3, 5.4.3, 5.6.0, 5.7.1]
+      version: [5.2.3, 5.4.3, 5.6.0, 5.7.1, 6.1.2, 6.2.1]
       buildable: false
       externals:
       - spec: rocm-device-libs@5.2.3
@@ -188,6 +240,10 @@ spack:
         prefix: /opt/rocm-5.6.0/
       - spec: rocm-device-libs@5.7.1
         prefix: /opt/rocm-5.7.1/
+      - spec: rocm-device-libs@6.1.2
+        prefix: /opt/rocm-6.1.2/
+      - spec: rocm-device-libs@6.2.1
+        prefix: /opt/rocm-6.2.1/
 
     # Lock down which MPI we are using
     mpi:
@@ -201,8 +257,12 @@ spack:
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.25-rocmcc-5.4.3/
       - spec: cray-mpich@8.1.25%clang@16.0.0+slurm
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.25-rocmcc-5.6.0/
-      - spec: cray-mpich@8.1.27%clang@17.0.0+slurm
+      - spec: cray-mpich@8.1.27%rocmcc@5.7.1+slurm
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.27-rocmcc-5.7.1/
+      - spec: cray-mpich@8.1.30%rocmcc@6.1.2+slurm
+        prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/
+      - spec: cray-mpich@8.1.30%rocmcc@6.2.1+slurm
+        prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/
       - spec: cray-mpich@8.1.25%cce@15.0.1+slurm
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.25-rocmcc-5.4.3-cce-15.0.1/
 

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -326,6 +326,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_option("ENABLE_HIP", True))
 
             rocm_root = os.path.dirname(spec["hip"].prefix)
+            entries.append(cmake_cache_path("ROCM_PATH", rocm_root))
 
             hip_link_flags = ""
 

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -327,26 +327,16 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
             rocm_root = os.path.dirname(spec["hip"].prefix)
 
-            # Fix blt_hip getting HIP_CLANG_INCLUDE_PATH-NOTFOUND bad include directory
-            # TODO: verify that this is still needed and is indeed specific to LC
-            if (
-                self.spec.satisfies("%cce") or
-                self.spec.satisfies("%clang") or
-                self.spec.satisfies("%rocmcc")
-            ) and "toss_4" in self._get_sys_type(spec):
-                # Set the patch version to 0 if not already
-                clang_version = str(self.compiler.version)[:-1] + "0"
-                hip_clang_include_path = (
-                    rocm_root + "/llvm/lib/clang/" + clang_version + "/include"
-                )
-                if os.path.isdir(hip_clang_include_path):
-                    entries.append(
-                        cmake_cache_path("HIP_CLANG_INCLUDE_PATH", hip_clang_include_path)
-                    )
+            hip_link_flags = ""
+
+            # Recommended MPI flags
+            hip_link_flags += "-lxpmem "
+            hip_link_flags += "-L/opt/cray/pe/mpich/{0}/gtl/lib ".format(spec["mpi"].version)
+            hip_link_flags += "-Wl,-rpath,/opt/cray/pe/mpich/{0}/gtl/lib ".format(spec["mpi"].version)
+            hip_link_flags += "-lmpi_gtl_hsa "
 
             # Fixes for mpi for rocm until wrapper paths are fixed
             # These flags are already part of the wrapped compilers on TOSS4 systems
-            hip_link_flags = ""
             if "+fortran" in spec and self.is_fortran_compiler("amdflang"):
                 hip_link_flags += "-Wl,--disable-new-dtags "
 
@@ -355,7 +345,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
                 else:
                     hip_link_flags += "-L{0}/llvm/lib -Wl,-rpath,{0}/llvm/lib ".format(rocm_root)
                 hip_link_flags += " -L{0}/lib -Wl,-rpath,{0}/lib ".format(rocm_root)
-                hip_link_flags += "-lpgmath -lflang -lflangrti -lompstub -lamdhip64 "
+                hip_link_flags += "-lpgmath -lflang -lflangrti -lompstub "
 
             # Remove extra link library for crayftn
             if "+fortran" in spec and self.is_fortran_compiler("crayftn"):
@@ -365,7 +355,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
             # Additional libraries for TOSS4
             hip_link_flags += " -L{0}/lib64 -Wl,-rpath,{0}/lib64 ".format(rocm_root)
-            hip_link_flags += "-lamd_comgr -lhsa-runtime64 "
+            hip_link_flags += "-lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr "
 
             entries.append(cmake_cache_string("CMAKE_EXE_LINKER_FLAGS", hip_link_flags))
 

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -325,13 +325,14 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
             entries.append(cmake_cache_option("ENABLE_HIP", True))
 
-            hip_root = spec["hip"].prefix
-            rocm_root = hip_root + "/.."
+            rocm_root = os.path.dirname(spec["hip"].prefix)
 
             # Fix blt_hip getting HIP_CLANG_INCLUDE_PATH-NOTFOUND bad include directory
             # TODO: verify that this is still needed and is indeed specific to LC
             if (
-                self.spec.satisfies("%cce") or self.spec.satisfies("%clang")
+                self.spec.satisfies("%cce") or
+                self.spec.satisfies("%clang") or
+                self.spec.satisfies("%rocmcc")
             ) and "toss_4" in self._get_sys_type(spec):
                 # Set the patch version to 0 if not already
                 clang_version = str(self.compiler.version)[:-1] + "0"
@@ -348,8 +349,12 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             hip_link_flags = ""
             if "+fortran" in spec and self.is_fortran_compiler("amdflang"):
                 hip_link_flags += "-Wl,--disable-new-dtags "
-                hip_link_flags += "-L{0}/../llvm/lib -L{0}/lib ".format(hip_root)
-                hip_link_flags += "-Wl,-rpath,{0}/../llvm/lib:{0}/lib ".format(hip_root)
+
+                if spec.satisfies("^hip@6.0.0:"):
+                    hip_link_flags += "-L{0}/lib/llvm/lib -Wl,-rpath,{0}/lib/llvm/lib ".format(rocm_root)
+                else:
+                    hip_link_flags += "-L{0}/llvm/lib -Wl,-rpath,{0}/llvm/lib ".format(rocm_root)
+                hip_link_flags += " -L{0}/lib -Wl,-rpath,{0}/lib ".format(rocm_root)
                 hip_link_flags += "-lpgmath -lflang -lflangrti -lompstub -lamdhip64 "
 
             # Remove extra link library for crayftn
@@ -359,8 +364,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
                 )
 
             # Additional libraries for TOSS4
-            hip_link_flags += " -L{0}/../lib64 -Wl,-rpath,{0}/../lib64 ".format(hip_root)
-            hip_link_flags += " -L{0}/../lib -Wl,-rpath,{0}/../lib ".format(hip_root)
+            hip_link_flags += " -L{0}/lib64 -Wl,-rpath,{0}/lib64 ".format(rocm_root)
             hip_link_flags += "-lamd_comgr -lhsa-runtime64 "
 
             entries.append(cmake_cache_string("CMAKE_EXE_LINKER_FLAGS", hip_link_flags))
@@ -459,7 +463,8 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
                 mpi_exec_index = [
                     index for index, entry in enumerate(entries) if "MPIEXEC_EXECUTABLE" in entry
                 ]
-                del entries[mpi_exec_index[0]]
+                if mpi_exec_index:
+                    del entries[mpi_exec_index[0]]
                 entries.append(cmake_cache_path("MPIEXEC_EXECUTABLE", srun_wrapper))
         else:
             entries.append(cmake_cache_option("ENABLE_MPI", False))

--- a/scripts/spack/specs.json
+++ b/scripts/spack/specs.json
@@ -18,11 +18,13 @@
       "clang@14.0.6+devtools+hdf5+mfem+c2c+scr+profiling",
       "intel@2022.1.0+devtools+hdf5+mfem+c2c+profiling" ],
 
-    "__comment__":"# Use amdgpu_target=gfx90a for tioga/rzvernal; and gfx908 for rznevada",
+    "__comment__":"# Use amdgpu_target=gfx942 for rzadams",
+    "__comment__":"# Use amdgpu_target=gfx90a for tioga/rzvernal",
+    "__comment__":"# Use amdgpu_target=gfx908 for rznevada",
     "__comment__":"# -Wno-int-conversion flag needed for building HDF5",
     "toss_4_x86_64_ib_cray":
-    [ "clang@16.0.0~openmp+mfem+c2c+profiling+rocm amdgpu_target=gfx90a ^hip@5.6.0 ^hsa-rocr-dev@5.6.0 ^llvm-amdgpu@5.6.0 ^rocprim@5.6.0 ^raja~openmp+rocm ^umpire~openmp+rocm ^hdf5 cflags=-Wno-int-conversion",
-      "clang@17.0.0~openmp+mfem+c2c+profiling+rocm amdgpu_target=gfx90a ^hip@5.7.1 ^hsa-rocr-dev@5.7.1 ^llvm-amdgpu@5.7.1 ^rocprim@5.7.1 ^raja~openmp+rocm ^umpire~openmp+rocm ^hdf5 cflags=-Wno-int-conversion" ],
+    [ "rocmcc@6.1.2~openmp+mfem+c2c+profiling+rocm amdgpu_target=gfx942 ^hip@6.1.2 ^hsa-rocr-dev@6.1.2 ^llvm-amdgpu@6.1.2 ^rocprim@6.1.2 ^raja~openmp+rocm ^umpire~openmp+rocm ^hdf5 cflags=-Wno-int-conversion",
+      "rocmcc@6.2.1~openmp+mfem+c2c+profiling+rocm amdgpu_target=gfx942 ^hip@6.2.1 ^hsa-rocr-dev@6.2.1 ^llvm-amdgpu@6.2.1 ^rocprim@6.2.1 ^raja~openmp+rocm ^umpire~openmp+rocm ^hdf5 cflags=-Wno-int-conversion" ],
 
     "__comment__":"# Note: clang-ibm + raja+openmp causes runtime failures, turning it off until there is an alternative",
     "blueos_3_ppc64le_ib_p9":

--- a/src/examples/radiuss_tutorial/host-config.cmake.in
+++ b/src/examples/radiuss_tutorial/host-config.cmake.in
@@ -53,6 +53,7 @@ endif()
 # HIP
 set(ENABLE_HIP                @ENABLE_HIP@                  CACHE BOOL "")
 if(ENABLE_HIP)
+  set(ROCM_PATH                 "@ROCM_PATH@"                 CACHE PATH "")
   set(HIP_ROOT_DIR              "@HIP_ROOT_DIR@"              CACHE PATH "")
   set(HIP_CLANG_PATH            "@HIP_CLANG_PATH@"            CACHE PATH "")
   set(HIP_CXX_COMPILER          "@HIP_CXX_COMPILER@"          CACHE PATH "")

--- a/src/examples/using-with-blt/host-config.cmake.in
+++ b/src/examples/using-with-blt/host-config.cmake.in
@@ -46,6 +46,7 @@ endif()
 set(ENABLE_HIP                @ENABLE_HIP@                  CACHE BOOL "")
 
 if(ENABLE_HIP)
+  set(ROCM_PATH                 "@ROCM_PATH@"                 CACHE PATH "")
   set(HIP_ROOT_DIR              "@HIP_ROOT_DIR@"              CACHE PATH "")
   set(HIP_CLANG_PATH            "@HIP_CLANG_PATH@"            CACHE PATH "")
   set(CMAKE_HIP_ARCHITECTURES   "@CMAKE_HIP_ARCHITECTURES@"   CACHE STRING "")

--- a/src/examples/using-with-cmake/host-config.cmake.in
+++ b/src/examples/using-with-cmake/host-config.cmake.in
@@ -48,6 +48,7 @@ endif()
 set(ENABLE_HIP                @ENABLE_HIP@                  CACHE BOOL "")
 
 if(ENABLE_HIP)
+  set(ROCM_PATH                 "@ROCM_PATH@"                 CACHE PATH "")
   set(HIP_ROOT_DIR              "@HIP_ROOT_DIR@"              CACHE PATH "")
   set(HIP_CLANG_PATH            "@HIP_CLANG_PATH@"            CACHE PATH "")
   set(CMAKE_HIP_ARCHITECTURES   "@CMAKE_HIP_ARCHITECTURES@"   CACHE STRING "")


### PR DESCRIPTION
This PR: 
- Adds host-configs for rzadams
- Updates `toss_4_x86_64_ib_cray` compilers to rocm@6.1.2 (default) and rocm@6.2.1 (latest stable)
  -  Update Gitlab CI to use rocm@6.1.2