### PR TITLE
Feature/gunney/conduit import memory space

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,6 +22,10 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ###  Added
 
 ###  Changed
+- Importing Conduit array data into `sidre::View` now allocates destination
+  data using the `View`'s parent's allocator ID, insteading of always using
+  host memory.  This is consistent with the behavior of deep-copying data
+  from Sidre.
 
 ###  Deprecated
 

--- a/src/axom/sidre/core/View.cpp
+++ b/src/axom/sidre/core/View.cpp
@@ -1494,7 +1494,7 @@ void View::importFrom(conduit::Node& data_holder,
  *
  *************************************************************************
  */
-View* View::importArrayNode(const Node& array)
+View* View::importArrayNode(const Node& array, int allocID)
 {
   conduit::DataType array_dtype = array.dtype();
 
@@ -1511,14 +1511,15 @@ View* View::importArrayNode(const Node& array)
       conduit::index_t num_ele = array_dtype.number_of_elements();
       conduit::index_t ele_bytes = DataType::default_bytes(array_dtype.id());
 
-      buff->allocate((TypeID)array_dtype.id(), num_ele);
+      allocID = getValidAllocatorID(allocID);
+      buff->allocate((TypeID)array_dtype.id(), num_ele, allocID);
 
       // copy the data in a way that matches
       // to compact representation of the buffer
       conduit::uint8* data_ptr = (conduit::uint8*)buff->getVoidPtr();
       for(conduit::index_t i = 0; i < num_ele; i++)
       {
-        memcpy(data_ptr, array.element_ptr(i), ele_bytes);
+        axom::copy(data_ptr, array.element_ptr(i), ele_bytes);
         data_ptr += ele_bytes;
       }
 

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -677,6 +677,7 @@ public:
 
   /*
  * \brief set the View to hold an array in a Buffer
+ * \param allocID Allocator id for array data allocation.
  *
  * This takes a Node that holds an array of data and sets up the View to
  * hold a copy of that data in an attached Buffer.
@@ -692,7 +693,7 @@ public:
  *
  * \return pointer to this View object
  */
-  View* importArrayNode(const Node& array);
+  View* importArrayNode(const Node& array, int allocID = INVALID_ALLOCATOR_ID);
 
   //
   // RDH -- Add an overload of the following that takes a const char *.


### PR DESCRIPTION
# Summary

- This PR is a feature
- It does the following:
  - Changes where destination data is allocated when importing array from Conduit.  Currently, data is allocated on host.  New, data is allocated using the allocator of the parent `Group`.
  - Fixes issue https://github.com/LLNL/axom/issues/1458
  - Updates RELEASE-NOTES.

Without this change, it is still possible to re-allocate data after the import, but that would require walking a `Group` hierarchy to look for `View`'s with data and re-allocating them individually.  The new behavior is consistent with the behavior when deep-copying from a Sidre source.

# Motivation
This change was needed in the work to support Blueprint meshes in shaping, https://github.com/LLNL/axom/issues/1452.  I wanted to separate it to keep that PR as clean as possible.