### PR TITLE
Adds initial benchmarking for axom::Array vs. std::vector

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,9 +119,9 @@ jobs:
     condition: eq( variables['Agent.OS'], 'Darwin')
     displayName: 'Darwin Test ($(TEST_TARGET))'
   - script:  |
-      echo " -e $TEST_TARGET -e $COMPILER -e $DO_BUILD -e $DO_TEST -e $CMAKE_EXTRA_FLAGS $(Compiler_ImageName) ./scripts/azure-pipelines/linux-build_and_test.sh"
+      echo " -e TEST_TARGET=$TEST_TARGET -e COMPILER=$COMPILER -e DO_BUILD=$DO_BUILD -e DO_TEST=$DO_TEST -e DO_BENCHMARKS=$DO_BENCHMARKS -e $CMAKE_EXTRA_FLAGS $(Compiler_ImageName) ./scripts/azure-pipelines/linux-build_and_test.sh"
       docker run --rm --user='root' -v `pwd`:/home/axom/axom $(Compiler_ImageName) chown -R axom /home/axom
-      docker run --rm -v `pwd`:/home/axom/axom -e TEST_TARGET -e COMPILER -e DO_BUILD -e DO_TEST -e DO_CLEAN -e HOST_CONFIG -e CMAKE_EXTRA_FLAGS -e BUILD_TYPE $(Compiler_ImageName) ./axom/scripts/azure-pipelines/linux-build_and_test.sh
+      docker run --rm -v `pwd`:/home/axom/axom -e TEST_TARGET -e COMPILER -e DO_BUILD -e DO_TEST -e DO_CLEAN -e DO_BENCHMARKS -e HOST_CONFIG -e CMAKE_EXTRA_FLAGS -e BUILD_TYPE $(Compiler_ImageName) ./axom/scripts/azure-pipelines/linux-build_and_test.sh
 
     condition: eq( variables['Agent.OS'], 'Linux')
     displayName: 'Linux Build & Test ($(TEST_TARGET))'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ variables:
   DO_BUILD: 'yes'
   DO_TEST: 'yes'
   DO_CLEAN: 'no'
+  DO_BENCHMARKS: 'no'
   CLANG14_IMAGENAME: 'axom/tpls:clang-14_10-10-24_01h-31m'
   GCC13_IMAGENAME: 'axom/tpls:gcc-13_10-10-24_01h-31m'
   system.debug: false
@@ -37,11 +38,12 @@ jobs:
       linux_clang14:
         VM_ImageName: 'ubuntu-22.04'
         Compiler_ImageName: '$(CLANG14_IMAGENAME)'
-        CMAKE_EXTRA_FLAGS: '-DBUILD_SHARED_LIBS=ON -DAXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS:BOOL=ON'
+        CMAKE_EXTRA_FLAGS: '-DBUILD_SHARED_LIBS=ON -DAXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS:BOOL=ON -DENABLE_BENCHMARKS:BOOL=ON'
         BUILD_TYPE: 'Release'
         COMPILER: 'clang++'
         TEST_TARGET: 'linux_clang14'
         HOST_CONFIG: 'clang@14.0.0'
+        DO_BENCHMARKS: 'yes'  
       linux_clang14_noraja:
         VM_ImageName: 'ubuntu-22.04'
         Compiler_ImageName: '$(CLANG14_IMAGENAME)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,10 +24,11 @@ jobs:
       linux_gcc13:
         VM_ImageName: 'ubuntu-22.04'
         Compiler_ImageName: '$(GCC13_IMAGENAME)'
-        CMAKE_EXTRA_FLAGS: '-DBUILD_SHARED_LIBS=ON -DAXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION:BOOL=ON'
+        CMAKE_EXTRA_FLAGS: '-DBUILD_SHARED_LIBS=ON -DAXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION:BOOL=ON -DENABLE_BENCHMARKS:BOOL=ON'
         COMPILER: 'g++'
         TEST_TARGET: 'linux_gcc13'
         HOST_CONFIG: 'gcc@13.1.0'
+        DO_BENCHMARKS: 'yes'  
       linux_gcc13_64bit:
         VM_ImageName: 'ubuntu-22.04'
         Compiler_ImageName: '$(GCC13_IMAGENAME)'

--- a/scripts/azure-pipelines/linux-build_and_test.sh
+++ b/scripts/azure-pipelines/linux-build_and_test.sh
@@ -41,6 +41,10 @@ if [[ "$DO_BUILD" == "yes" ]] ; then
         echo "~~~~~~ RUNNING TESTS ~~~~~~~~"
         make CTEST_OUTPUT_ON_FAILURE=1 test ARGS='-T Test -VV -j8'
     fi
+    if [[ "${DO_BENCHMARKS}" == "yes" ]] ; then
+        echo "~~~~~~ RUNNING BENCHMARKS ~~~~~~~~"
+        make CTEST_OUTPUT_ON_FAILURE=1 run_benchmarks
+    fi
     if [[ "${DO_MEMCHECK}" == "yes" ]] ; then
         echo "~~~~~~ RUNNING MEMCHECK ~~~~~~~~"
         or_die ctest -T memcheck

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -385,6 +385,7 @@ inline bool isDeviceAllocator(int allocator_id)
   return axom::detail::getAllocatorSpace(allocator_id) ==
     axom::MemorySpace::Device;
 #else
+  AXOM_UNUSED_VAR(allocator_id);
   return false;
 #endif
 }

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -204,7 +204,7 @@ if (ENABLE_BENCHMARKS)
     axom_add_executable(NAME       ${test_name}
                         SOURCES    ${test}
                         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                        DEPENDS_ON fmt core slic gbenchmark
+                        DEPENDS_ON fmt core slic gbenchmark cli11
                         FOLDER     axom/core/benchmarks)
 
     blt_add_benchmark(NAME    ${test_name}

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -190,3 +190,25 @@ foreach(_mode none report counts gputx)
                APPEND PROPERTY ENVIRONMENT  "CALI_LOG_VERBOSITY=2")
 endforeach()
 
+#------------------------------------------------------------------------------
+# Benchmarks
+#------------------------------------------------------------------------------
+if (ENABLE_BENCHMARKS)
+
+  set(core_benchmarks
+      core_benchmark_array.cpp )
+
+  foreach(test ${core_benchmarks})
+    get_filename_component(test_name ${test} NAME_WE)
+
+    axom_add_executable(NAME       ${test_name}
+                        SOURCES    ${test}
+                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                        DEPENDS_ON fmt core slic gbenchmark
+                        FOLDER     axom/core/benchmarks)
+
+    blt_add_benchmark(NAME    ${test_name}
+                      COMMAND ${test_name} --benchmark_min_time=0.0001s)
+  endforeach()
+endif()
+

--- a/src/axom/core/tests/core_benchmark_array.cpp
+++ b/src/axom/core/tests/core_benchmark_array.cpp
@@ -7,12 +7,94 @@
 #include "axom/config.hpp"
 #include "axom/core.hpp"
 #include "axom/slic.hpp"
+
 #include "axom/fmt.hpp"
+#include "axom/CLI11.hpp"
 
 #include <tuple>
 #include <vector>
 #include <type_traits>
 #include <cstdint>
+
+namespace
+{
+
+enum class ArrayFeatureBenchmarks
+{
+  None = 0,
+  Constructors = 1 << 0,
+  Insertion = 1 << 1,
+  Iterators = 1 << 2,
+
+  All = Constructors | Insertion | Iterators
+};
+
+inline ArrayFeatureBenchmarks operator|(ArrayFeatureBenchmarks lhs,
+                                        ArrayFeatureBenchmarks rhs)
+{
+  using T = std::underlying_type_t<ArrayFeatureBenchmarks>;
+  return static_cast<ArrayFeatureBenchmarks>(static_cast<T>(lhs) |
+                                             static_cast<T>(rhs));
+}
+
+inline ArrayFeatureBenchmarks& operator|=(ArrayFeatureBenchmarks& lhs,
+                                          ArrayFeatureBenchmarks rhs)
+{
+  lhs = lhs | rhs;
+  return lhs;
+}
+
+inline ArrayFeatureBenchmarks operator&(ArrayFeatureBenchmarks lhs,
+                                        ArrayFeatureBenchmarks rhs)
+{
+  using T = std::underlying_type_t<ArrayFeatureBenchmarks>;
+  return static_cast<ArrayFeatureBenchmarks>(static_cast<T>(lhs) &
+                                             static_cast<T>(rhs));
+}
+
+std::vector<int> args_benchmark_sizes;
+ArrayFeatureBenchmarks args_benchmark_features {ArrayFeatureBenchmarks::None};
+}  // namespace
+
+// Custom fmt formatter for ArrayFeatureBenchmarks
+template <>
+struct axom::fmt::formatter<ArrayFeatureBenchmarks>
+{
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx)
+  {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(ArrayFeatureBenchmarks feature, FormatContext& ctx)
+  {
+    static const std::map<ArrayFeatureBenchmarks, std::string> feature_map = {
+      {ArrayFeatureBenchmarks::Constructors, "Constructors"},
+      {ArrayFeatureBenchmarks::Insertion, "Insertion"},
+      {ArrayFeatureBenchmarks::Iterators, "Iterators"}};
+
+    if(feature == ArrayFeatureBenchmarks::None)
+    {
+      return axom::fmt::format_to(ctx.out(), "None");
+    }
+    else if(feature == ArrayFeatureBenchmarks::All)
+    {
+      return axom::fmt::format_to(ctx.out(), "All");
+    }
+
+    std::string name;
+    for(const auto& kv : feature_map)
+    {
+      if((feature & kv.first) != ArrayFeatureBenchmarks::None)
+      {
+        name += name.empty() ? kv.second : "|" + kv.second;
+      }
+    }
+
+    return axom::fmt::format_to(ctx.out(), "{}", name);
+  }
+};
 
 //-----------------------------------------------------------------------------
 // Arguments and types to test
@@ -20,10 +102,10 @@
 
 void CustomArgs(benchmark::internal::Benchmark* b)
 {
-  // b->Arg(1 << 3);   // small
-  b->Arg(1 << 16);  // larger than  32K L1 cache
-  // b->Arg(1 << 19);  // larger than 256K L2 cache
-  // b->Arg(1 << 25);  // larger than  25M L3 cache
+  for(int sz : ::args_benchmark_sizes)
+  {
+    b->Arg(sz);
+  }
 }
 
 template <typename T>
@@ -304,23 +386,32 @@ void RegisterBenchmark()
   };
 
   // clang-format off
-  benchmark::RegisterBenchmark(tname("Array::ctor"), &ctor<axom::Array<T>>)->Apply(CustomArgs);
-  benchmark::RegisterBenchmark(tname("vector::ctor"), &ctor<std::vector<T>>)->Apply(CustomArgs);
+  if((args_benchmark_features & ArrayFeatureBenchmarks::Constructors) != ArrayFeatureBenchmarks::None)
+  {
+    benchmark::RegisterBenchmark(tname("Array::ctor"), &ctor<axom::Array<T>>)->Apply(CustomArgs);
+    benchmark::RegisterBenchmark(tname("vector::ctor"), &ctor<std::vector<T>>)->Apply(CustomArgs);
+  }
 
-  benchmark::RegisterBenchmark(tname("Array::push_back_startEmpty"), &push_back_startEmpty<axom::Array<T>>)->Apply(CustomArgs);
-  benchmark::RegisterBenchmark(tname("Array::emplace_back_startEmpty"), &emplace_back_startEmpty<axom::Array<T>>)->Apply(CustomArgs);
-  benchmark::RegisterBenchmark(tname("Array::push_back_initialReserve"), &push_back_initialReserve<axom::Array<T>>)->Apply(CustomArgs);
-  benchmark::RegisterBenchmark(tname("Array::emplace_back_initialReserve"), &emplace_back_initialReserve<axom::Array<T>>)->Apply(CustomArgs);
+  if((args_benchmark_features & ArrayFeatureBenchmarks::Insertion) != ArrayFeatureBenchmarks::None)
+  {
+    benchmark::RegisterBenchmark(tname("Array::push_back_startEmpty"), &push_back_startEmpty<axom::Array<T>>)->Apply(CustomArgs);
+    benchmark::RegisterBenchmark(tname("Array::emplace_back_startEmpty"), &emplace_back_startEmpty<axom::Array<T>>)->Apply(CustomArgs);
+    benchmark::RegisterBenchmark(tname("Array::push_back_initialReserve"), & push_back_initialReserve<axom::Array<T>>)->Apply(CustomArgs);
+    benchmark::RegisterBenchmark(tname("Array::emplace_back_initialReserve"), &emplace_back_initialReserve<axom::Array<T>>)->Apply(CustomArgs);
 
-  benchmark::RegisterBenchmark(tname("vector::push_back_startEmpty"), &push_back_startEmpty<std::vector<T>>)->Apply(CustomArgs);
-  benchmark::RegisterBenchmark(tname("vector::emplace_back_startEmpty"), &emplace_back_startEmpty<std::vector<T>>)->Apply(CustomArgs);
-  benchmark::RegisterBenchmark(tname("vector::push_back_initialReserve"), &push_back_initialReserve<std::vector<T>>)->Apply(CustomArgs);
-  benchmark::RegisterBenchmark(tname("vector::emplace_back_initialReserve"), &emplace_back_initialReserve<std::vector<T>>)->Apply(CustomArgs);
+    benchmark::RegisterBenchmark(tname("vector::push_back_startEmpty"), &push_back_startEmpty<std::vector<T>>)->Apply(CustomArgs);
+    benchmark::RegisterBenchmark(tname("vector::emplace_back_startEmpty"), &emplace_back_startEmpty<std::vector<T>>)->Apply(CustomArgs);
+    benchmark::RegisterBenchmark(tname("vector::push_back_initialReserve"), &push_back_initialReserve<std::vector<T>>)->Apply(CustomArgs);
+    benchmark::RegisterBenchmark(tname("vector::emplace_back_initialReserve"), &emplace_back_initialReserve<std::vector<T>>)->Apply(CustomArgs);
+  }
 
-  benchmark::RegisterBenchmark(tname("Array::iterate_range"), &iterate_range<axom::Array<T>>)->Apply(CustomArgs);
-  benchmark::RegisterBenchmark(tname("Array::iterate_direct"), &iterate_direct<axom::Array<T>>)->Apply(CustomArgs);
-  benchmark::RegisterBenchmark(tname("vector::iterate_range"), &iterate_range<std::vector<T>>)->Apply(CustomArgs);
-  benchmark::RegisterBenchmark(tname("vector::iterate_direct"), &iterate_direct<std::vector<T>>)->Apply(CustomArgs);
+  if((args_benchmark_features & ArrayFeatureBenchmarks::Iterators) != ArrayFeatureBenchmarks::None)
+  {
+    benchmark::RegisterBenchmark(tname("Array::iterate_range"), &iterate_range<axom::Array<T>>)->Apply(CustomArgs);
+    benchmark::RegisterBenchmark(tname("Array::iterate_direct"), &iterate_direct<axom::Array<T>>)->Apply(CustomArgs);
+    benchmark::RegisterBenchmark(tname("vector::iterate_range"), &iterate_range<std::vector<T>>)->Apply(CustomArgs);
+    benchmark::RegisterBenchmark(tname("vector::iterate_direct"), &iterate_direct<std::vector<T>>)->Apply(CustomArgs);
+  }
   // clang-format on
 }
 
@@ -349,8 +440,88 @@ void RegisterBenchmarks()
 
 int main(int argc, char* argv[])
 {
+  // Parse command line args for array benchmarks
+  std::vector<int> local_test_sizes;
+  ArrayFeatureBenchmarks local_benchmark_features {ArrayFeatureBenchmarks::None};
+
+  axom::CLI::App app {"Axom array benchmarks"};
+  app.add_option("-s,--custom_sizes", local_test_sizes)
+    ->description(
+      "Adds custom array sizes to benchmark (positive numbers only)")
+    ->expected(-1)
+    ->default_val(std::vector<int> {1 << 16})
+    ->each([](const std::string& num_str) {
+      int num = std::stoi(num_str);
+      if(num < 0)
+      {
+        throw axom::CLI::ValidationError("Negative numbers are not allowed");
+      }
+    });
+  app
+    .add_flag_callback(
+      "--use_cache_related_sizes",
+      [&local_test_sizes]() {
+        local_test_sizes.push_back(1 << 3);   // small
+        local_test_sizes.push_back(1 << 16);  // larger than  32K L1 cache
+        local_test_sizes.push_back(1 << 19);  // larger than 256K L2 cache
+        local_test_sizes.push_back(1 << 25);  // larger than  25M L3 cache
+      })
+    ->description("Test array sizes related to typical cache sizes");
+
+  std::vector<std::string> feature_strings;
+  auto feature_opt =
+    app.add_option("-f,--features", feature_strings)
+      ->description(
+        "Features to benchmark (Constructors, Insertion, Iterators, All); "
+        "default is 'All'")
+      ->expected(-1)
+      ->each([&local_benchmark_features](const std::string& feature) {
+        static const std::map<std::string, ArrayFeatureBenchmarks> feature_map = {
+          {"constructors", ArrayFeatureBenchmarks::Constructors},
+          {"insertion", ArrayFeatureBenchmarks::Insertion},
+          {"iterators", ArrayFeatureBenchmarks::Iterators},
+          {"all", ArrayFeatureBenchmarks::All}};
+
+        std::string lower_feature = feature;
+        std::transform(lower_feature.begin(),
+                       lower_feature.end(),
+                       lower_feature.begin(),
+                       ::tolower);
+        auto it = feature_map.find(lower_feature);
+        if(it == feature_map.end())
+        {
+          throw axom::CLI::ValidationError("Invalid feature: " + feature);
+        }
+
+        local_benchmark_features |= it->second;
+      });
+
+  app.allow_extras();  // pass additional args to gbenchmark
+  CLI11_PARSE(app, argc, argv);
+
   ::benchmark::Initialize(&argc, argv);
   axom::slic::SimpleLogger logger;
+
+  // process input into global variables
+  {
+    // copy list of Features to test into global array; by default, test everything
+    ::args_benchmark_features = feature_opt->count() > 0
+      ? local_benchmark_features
+      : ArrayFeatureBenchmarks::All;
+
+    // sort and unique-ify the input sizes and copy into the global array variable
+    std::sort(local_test_sizes.begin(), local_test_sizes.end());
+    auto last = std::unique(local_test_sizes.begin(), local_test_sizes.end());
+    local_test_sizes.erase(last, local_test_sizes.end());
+    std::swap(::args_benchmark_sizes, local_test_sizes);
+
+    SLIC_INFO("Parsed and processed command line arguments:");
+    SLIC_INFO(axom::fmt::format("- Array sizes: {}",
+                                axom::fmt::join(::args_benchmark_sizes, ",")));
+    SLIC_INFO(axom::fmt::format("- Array features to test: {}",
+                                ::args_benchmark_features));
+  }
+
   RegisterBenchmarks<Types>();
   ::benchmark::RunSpecifiedBenchmarks();
   return 0;

--- a/src/axom/core/tests/core_benchmark_array.cpp
+++ b/src/axom/core/tests/core_benchmark_array.cpp
@@ -107,7 +107,7 @@ std::string get_type_name<std::string>()
 template <typename Arr>
 void assert_size_and_capacity(const Arr& arr, int exp_size, int exp_capacity)
 {
-#ifdef NDEBUG
+#if defined(NDEBUG)
   AXOM_UNUSED_VAR(arr);
   AXOM_UNUSED_VAR(exp_size);
   AXOM_UNUSED_VAR(exp_capacity);
@@ -120,7 +120,7 @@ void assert_size_and_capacity(const Arr& arr, int exp_size, int exp_capacity)
 template <typename Arr>
 void assert_size_and_strict_capacity(const Arr& arr, int exp_size, int exp_capacity)
 {
-#ifdef NDEBUG
+#if defined(NDEBUG)
   AXOM_UNUSED_VAR(arr);
   AXOM_UNUSED_VAR(exp_size);
   AXOM_UNUSED_VAR(exp_capacity);

--- a/src/axom/core/tests/core_benchmark_array.cpp
+++ b/src/axom/core/tests/core_benchmark_array.cpp
@@ -1,0 +1,278 @@
+// Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "benchmark/benchmark.h"
+#include "axom/config.hpp"
+#include "axom/core.hpp"
+#include "axom/slic.hpp"
+#include "axom/fmt.hpp"
+
+#include <tuple>
+#include <vector>
+#include <type_traits>
+#include <cstdint>
+
+//-----------------------------------------------------------------------------
+// Arguments and types to test
+//-----------------------------------------------------------------------------
+
+void CustomArgs(benchmark::internal::Benchmark* b)
+{
+  b->Arg(1 << 3);   // small
+  b->Arg(1 << 16);  // larger than  32K L1 cache
+  b->Arg(1 << 19);  // larger than 256K L2 cache
+  b->Arg(1 << 25);  // larger than  25M L3 cache
+}
+
+// TODO: Test w/ custom structs
+using Types = std::tuple<int>;  //, double, std::int64_t>;
+
+//-----------------------------------------------------------------------------
+// Benchmarks for array and vector construction
+//-----------------------------------------------------------------------------
+template <typename T>
+static void Array_ctor(benchmark::State& state)
+{
+  const int size = state.range(0);
+  for(auto _ : state)
+  {
+    axom::Array<T> arr(size);
+    assert(arr.size() == size);
+    assert(arr.capacity() >= size);
+    benchmark::DoNotOptimize(arr);
+  }
+}
+
+template <typename T>
+static void Vector_ctor(benchmark::State& state)
+{
+  const int size = state.range(0);
+  for(auto _ : state)
+  {
+    std::vector<T> arr(size);
+    assert(static_cast<int>(arr.size()) == size);
+    assert(static_cast<int>(arr.capacity()) >= size);
+    benchmark::DoNotOptimize(arr);
+  }
+}
+
+//-----------------------------------------------------------------------------
+// Benchmarks for array and vector push_back and emplace_back
+//-----------------------------------------------------------------------------
+template <typename T>
+void Array_push_back_initialSize(benchmark::State& state)
+{
+  const int size = state.range(0);
+  for(auto _ : state)
+  {
+    axom::Array<T> arr(0, size);
+    assert(static_cast<int>(arr.size()) == 0);
+    assert(static_cast<int>(arr.capacity()) == size);
+
+    for(int i = 0; i < size; ++i)
+    {
+      arr.push_back(static_cast<T>(i));
+    }
+    assert(static_cast<int>(arr.size()) == size);
+    assert(static_cast<int>(arr.capacity()) == size);
+    benchmark::DoNotOptimize(arr);
+  }
+}
+
+template <typename T>
+void Array_emplace_back_initialSize(benchmark::State& state)
+{
+  const int size = state.range(0);
+  for(auto _ : state)
+  {
+    axom::Array<T> arr(0, size);
+    assert(static_cast<int>(arr.size()) == 0);
+    assert(static_cast<int>(arr.capacity()) == size);
+
+    for(int i = 0; i < size; ++i)
+    {
+      arr.emplace_back(static_cast<T>(i));
+    }
+    assert(static_cast<int>(arr.size()) == size);
+    assert(static_cast<int>(arr.capacity()) == size);
+    benchmark::DoNotOptimize(arr);
+  }
+}
+
+template <typename T>
+void Array_push_back_startEmpty(benchmark::State& state)
+{
+  const int size = state.range(0);
+  for(auto _ : state)
+  {
+    axom::Array<T> arr;
+    assert(static_cast<int>(arr.size()) == 0);
+    assert(static_cast<int>(arr.capacity()) == 0);
+
+    for(int i = 0; i < size; ++i)
+    {
+      arr.push_back(static_cast<T>(i));
+    }
+    assert(static_cast<int>(arr.size()) == size);
+    assert(static_cast<int>(arr.capacity()) >= size);
+    benchmark::DoNotOptimize(arr);
+  }
+}
+
+template <typename T>
+void Array_emplace_back_startEmpty(benchmark::State& state)
+{
+  const int size = state.range(0);
+  for(auto _ : state)
+  {
+    axom::Array<T> arr;
+    assert(static_cast<int>(arr.size()) == 0);
+    assert(static_cast<int>(arr.capacity()) == 0);
+    for(int i = 0; i < size; ++i)
+    {
+      arr.emplace_back(static_cast<T>(i));
+    }
+    assert(static_cast<int>(arr.size()) == size);
+    assert(static_cast<int>(arr.capacity()) >= size);
+    benchmark::DoNotOptimize(arr);
+  }
+}
+
+template <typename T>
+void Vector_push_back_initialSize(benchmark::State& state)
+{
+  const int size = state.range(0);
+  for(auto _ : state)
+  {
+    std::vector<T> arr;
+    arr.reserve(size);
+    assert(static_cast<int>(arr.size()) == 0);
+    assert(static_cast<int>(arr.capacity()) == size);
+    for(int i = 0; i < size; ++i)
+    {
+      arr.push_back(static_cast<T>(i));
+    }
+    assert(static_cast<int>(arr.size()) == size);
+    assert(static_cast<int>(arr.capacity()) == size);
+    benchmark::DoNotOptimize(arr);
+  }
+}
+
+template <typename T>
+void Vector_emplace_back_initialSize(benchmark::State& state)
+{
+  const int size = state.range(0);
+  for(auto _ : state)
+  {
+    std::vector<T> arr;
+    arr.reserve(size);
+    assert(static_cast<int>(arr.size()) == 0);
+    assert(static_cast<int>(arr.capacity()) == size);
+    for(int i = 0; i < size; ++i)
+    {
+      arr.emplace_back(static_cast<T>(i));
+    }
+    assert(static_cast<int>(arr.size()) == size);
+    assert(static_cast<int>(arr.capacity()) == size);
+    benchmark::DoNotOptimize(arr);
+  }
+}
+
+template <typename T>
+void Vector_push_back_startEmpty(benchmark::State& state)
+{
+  const int size = state.range(0);
+  for(auto _ : state)
+  {
+    std::vector<T> arr;
+    assert(static_cast<int>(arr.size()) == 0);
+    assert(static_cast<int>(arr.capacity()) == 0);
+    for(int i = 0; i < size; ++i)
+    {
+      arr.push_back(static_cast<T>(i));
+    }
+    assert(static_cast<int>(arr.size()) == size);
+    assert(static_cast<int>(arr.capacity()) >= size);
+    benchmark::DoNotOptimize(arr);
+  }
+}
+
+template <typename T>
+void Vector_emplace_back_startEmpty(benchmark::State& state)
+{
+  const int size = state.range(0);
+  for(auto _ : state)
+  {
+    std::vector<T> arr;
+    assert(static_cast<int>(arr.size()) == 0);
+    assert(static_cast<int>(arr.capacity()) == 0);
+    for(int i = 0; i < size; ++i)
+    {
+      arr.emplace_back(static_cast<T>(i));
+    }
+    assert(static_cast<int>(arr.size()) == size);
+    assert(static_cast<int>(arr.capacity()) >= size);
+    benchmark::DoNotOptimize(arr);
+  }
+}
+//-----------------------------------------------------------------------------
+// Register all the tests
+//-----------------------------------------------------------------------------
+
+template <typename T>
+void RegisterBenchmark()
+{
+  auto tname = [](const std::string& n) {
+    return axom::fmt::format("{}<{}>", n, typeid(T).name());
+  };
+
+  // clang-format off
+  benchmark::RegisterBenchmark(tname("Array::ctor"), &Array_ctor<T>)->Apply(CustomArgs);
+  benchmark::RegisterBenchmark(tname("vector::ctor"), &Vector_ctor<T>)->Apply(CustomArgs);
+
+
+  benchmark::RegisterBenchmark(tname("Array::push_back_startEmpty"), &Array_push_back_startEmpty<T>)->Apply(CustomArgs);
+  benchmark::RegisterBenchmark(tname("Array::emplace_back_startEmpty"), &Array_emplace_back_startEmpty<T>)->Apply(CustomArgs);
+  benchmark::RegisterBenchmark(tname("Array::push_back_initialSize"), &Array_push_back_initialSize<T>)->Apply(CustomArgs);
+  benchmark::RegisterBenchmark(tname("Array::emplace_back_initialSize"), &Array_emplace_back_initialSize<T>)->Apply(CustomArgs);
+
+  benchmark::RegisterBenchmark(tname("vector::push_back_startEmpty"), &Array_push_back_startEmpty<T>)->Apply(CustomArgs);
+  benchmark::RegisterBenchmark(tname("vector::emplace_back_startEmpty"), &Array_emplace_back_startEmpty<T>)->Apply(CustomArgs);
+  benchmark::RegisterBenchmark(tname("vector::push_back_initialSize"), &Array_push_back_initialSize<T>)->Apply(CustomArgs);
+  benchmark::RegisterBenchmark(tname("vector::emplace_back_initialSize"), &Array_emplace_back_initialSize<T>)->Apply(CustomArgs);
+  // clang-format on
+}
+
+//-----------------------------------------------------------------------------
+// Main and helper functions to consistently register templated test types
+//
+// Note: This can likely be simplified/streamlined a bit when we move to C++17,
+// e.g. using std::apply and paraeter pack fold expressions
+//-----------------------------------------------------------------------------
+
+template <typename Tuple, std::size_t... Is>
+void RegisterBenchmarksImpl(std::index_sequence<Is...>)
+{
+  using expander = int[];
+  (void)expander {
+    0,
+    (RegisterBenchmark<typename std::tuple_element<Is, Tuple>::type>(), 0)...};
+}
+
+template <typename Tuple>
+void RegisterBenchmarks()
+{
+  RegisterBenchmarksImpl<Tuple>(
+    std::make_index_sequence<std::tuple_size<Tuple>::value> {});
+}
+
+int main(int argc, char* argv[])
+{
+  ::benchmark::Initialize(&argc, argv);
+  axom::slic::SimpleLogger logger;
+  RegisterBenchmarks<Types>();
+  ::benchmark::RunSpecifiedBenchmarks();
+  return 0;
+}

--- a/src/axom/core/tests/core_benchmark_array.cpp
+++ b/src/axom/core/tests/core_benchmark_array.cpp
@@ -419,7 +419,7 @@ void RegisterBenchmark()
 // Main and helper functions to consistently register templated test types
 //
 // Note: This can likely be simplified/streamlined a bit when we move to C++17,
-// e.g. using std::apply and paraeter pack fold expressions
+// e.g. using std::apply and parameter pack fold expressions
 //-----------------------------------------------------------------------------
 
 template <typename Tuple, std::size_t... Is>

--- a/src/axom/core/tests/core_benchmark_array.cpp
+++ b/src/axom/core/tests/core_benchmark_array.cpp
@@ -112,8 +112,8 @@ void assert_size_and_capacity(const Arr& arr, int exp_size, int exp_capacity)
   AXOM_UNUSED_VAR(exp_size);
   AXOM_UNUSED_VAR(exp_capacity);
 #else
-  assert(arr.size() == exp_size);
-  assert(arr.capacity() >= exp_capacity);
+  assert(static_cast<int>(arr.size()) == exp_size);
+  assert(static_cast<int>(arr.capacity()) >= exp_capacity);
 #endif
 }
 
@@ -125,8 +125,8 @@ void assert_size_and_strict_capacity(const Arr& arr, int exp_size, int exp_capac
   AXOM_UNUSED_VAR(exp_size);
   AXOM_UNUSED_VAR(exp_capacity);
 #else
-  assert(arr.size() == exp_size);
-  assert(arr.capacity() == exp_capacity);
+  assert(static_cast<int>(arr.size()) == exp_size);
+  assert(static_cast<int>(arr.capacity()) == exp_capacity);
 #endif
 }
 
@@ -253,10 +253,10 @@ void iterate_range(benchmark::State& state)
   const int size = state.range(0);
   ArrFixture<Container> fixture(size);
 
-  int count = 0;
-  const T element = get_value<T>(state.range(0) / 2);
+  const T element = get_value<T>(size / 2);
   for(auto _ : state)
   {
+    int count = 0;
     for(const T& item : fixture.data)
     {
       if(item == element)
@@ -276,10 +276,10 @@ void iterate_direct(benchmark::State& state)
   const int size = state.range(0);
   ArrFixture<Container> fixture(size);
 
-  int count = 0;
-  const T element = get_value<T>(state.range(0) / 2);
+  const T element = get_value<T>(size / 2);
   for(auto _ : state)
   {
+    int count = 0;
     for(auto it = fixture.data.begin(); it != fixture.data.end(); ++it)
     {
       if(*it == element)

--- a/src/axom/core/tests/core_benchmark_array.cpp
+++ b/src/axom/core/tests/core_benchmark_array.cpp
@@ -318,11 +318,12 @@ public:
 
   ArrFixture(int size)
   {
-    data.resize(size);
+    data.reserve(size);
     for(int i = 0; i < size; ++i)
     {
       data.emplace_back(get_value<T>(i));
     }
+    assert_size_and_capacity(data, size, size);
   }
 
   Container data;

--- a/src/axom/primal/tests/primal_nurbs_curve.cpp
+++ b/src/axom/primal/tests/primal_nurbs_curve.cpp
@@ -218,7 +218,6 @@ TEST(primal_nurbscurve, evaluate)
 {
   SLIC_INFO("Testing NURBS evaluation");
 
-  const int MAX_DIM = 3;
   using CoordType = double;
   using Point1D = primal::Point<CoordType, 1>;
   using Point2D = primal::Point<CoordType, 2>;

--- a/src/axom/quest/Shaper.cpp
+++ b/src/axom/quest/Shaper.cpp
@@ -161,6 +161,7 @@ void Shaper::loadShapeInternal(const klee::Shape& shape,
                                double& revolvedVolume)
 {
   using axom::utilities::string::endsWith;
+  AXOM_UNUSED_VAR(percentError);  // only currently used with C2C
 
   internal::ScopedLogLevelChanger logLevelChanger(
     this->isVerbose() ? slic::message::Debug : slic::message::Warning);

--- a/src/axom/quest/interface/inout.cpp
+++ b/src/axom/quest/interface/inout.cpp
@@ -110,6 +110,7 @@ struct InOutHelper
                                            revolvedVolume,
                                            comm);
 #else
+      AXOM_UNUSED_VAR(revolvedVolume);
       SLIC_WARNING(fmt::format(
         "Cannot read contour file: C2C not enabled in this configuration.",
         file));

--- a/src/axom/sina/examples/sina_check_datum_type.cpp
+++ b/src/axom/sina/examples/sina_check_datum_type.cpp
@@ -9,13 +9,17 @@
 using ValueTypeUnderlying =
   typename std::underlying_type<axom::sina::ValueType>::type;
 
-void printType(axom::sina::Datum datum, std::string datumName, std::string errMsg)
+void printType(axom::sina::Datum datum,
+               std::string datumName,
+               const std::string& errMsg)
 {
   auto datumType = static_cast<ValueTypeUnderlying>(datum.getType());
   SLIC_ASSERT_MSG(
     static_cast<bool>(
       std::is_same<decltype(datumType), ValueTypeUnderlying>::value),
     errMsg);
+  AXOM_UNUSED_VAR(errMsg);
+
   std::cout << datumName << " type: " << datumType << std::endl;
 }
 

--- a/src/axom/sina/tests/sina_Record.cpp
+++ b/src/axom/sina/tests/sina_Record.cpp
@@ -454,8 +454,14 @@ TEST(RecordLoader, load_missingLoader)
   asNode[EXPECTED_GLOBAL_ID_KEY] = "the ID";
   asNode[EXPECTED_TYPE_KEY] = "unknownType";
   auto loaded = loader.load(asNode);
-  auto &actualType = typeid(*loaded);
-  EXPECT_EQ(typeid(Record), actualType) << "Type was " << actualType.name();
+
+  EXPECT_NE(loaded.get(), nullptr);
+  if(loaded)
+  {
+    auto &loadedRef = *loaded;
+    EXPECT_EQ(typeid(Record), typeid(loadedRef))
+      << "Type was " << typeid(loadedRef).name();
+  }
 }
 
 TEST(RecordLoader, load_loaderPresent)

--- a/src/axom/slam/benchmarks/CMakeLists.txt
+++ b/src/axom/slam/benchmarks/CMakeLists.txt
@@ -26,7 +26,7 @@ if (ENABLE_BENCHMARKS)
 
         blt_add_benchmark( 
             NAME        ${test_name} 
-            COMMAND     ${test_name}
+            COMMAND     ${test_name} --benchmark_min_time=0.0001s
             )
     endforeach()
 endif()

--- a/src/axom/slam/benchmarks/slam_array.cpp
+++ b/src/axom/slam/benchmarks/slam_array.cpp
@@ -8,7 +8,7 @@
 
 #include <iostream>
 
-#include "benchmark/benchmark_api.h"
+#include "benchmark/benchmark.h"
 #include "axom/slic.hpp"
 
 //------------------------------------------------------------------------------
@@ -77,7 +77,7 @@ DataArray generateRandomDataField(int sz)
 class SetFixture : public ::benchmark::Fixture
 {
 public:
-  void SetUp()
+  void SetUp(const ::benchmark::State& /*state*/) override
   {
     volatile int str_vol = STRIDE;  // pass through volatile variable so the
     str = str_vol;                  // number is not a compile time constant
@@ -89,7 +89,7 @@ public:
     data = nullptr;
   }
 
-  void TearDown()
+  void TearDown(const ::benchmark::State& /*state*/) override
   {
     if(ind != nullptr)
     {
@@ -160,7 +160,7 @@ BENCHMARK_TEMPLATE(contig_sequence_compileTimeSize, S3);
 
 BENCHMARK_DEFINE_F(SetFixture, contig_sequence)(benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   while(state.KeepRunning())
   {
@@ -176,7 +176,7 @@ BENCHMARK_REGISTER_F(SetFixture, contig_sequence)->Apply(CustomArgs);
 
 BENCHMARK_DEFINE_F(SetFixture, strided_sequence)(benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   while(state.KeepRunning())
   {
@@ -192,7 +192,7 @@ BENCHMARK_REGISTER_F(SetFixture, strided_sequence)->Apply(CustomArgs);
 
 BENCHMARK_DEFINE_F(SetFixture, offset_sequence)(benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   while(state.KeepRunning())
   {
@@ -208,7 +208,7 @@ BENCHMARK_REGISTER_F(SetFixture, offset_sequence)->Apply(CustomArgs);
 
 BENCHMARK_DEFINE_F(SetFixture, offset_strided_sequence)(benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   while(state.KeepRunning())
   {
@@ -225,7 +225,7 @@ BENCHMARK_REGISTER_F(SetFixture, offset_strided_sequence)->Apply(CustomArgs);
 BENCHMARK_DEFINE_F(SetFixture, indirection_sequence_ordered)
 (benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   ind = generateRandomPermutationArray(maxIndex(sz), false);
 
@@ -245,7 +245,7 @@ BENCHMARK_REGISTER_F(SetFixture, indirection_sequence_ordered)->Apply(CustomArgs
 BENCHMARK_DEFINE_F(SetFixture, indirection_sequence_ordered_strided)
 (benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   ind = generateRandomPermutationArray(maxIndex(sz), false);
 
@@ -266,7 +266,7 @@ BENCHMARK_REGISTER_F(SetFixture, indirection_sequence_ordered_strided)
 BENCHMARK_DEFINE_F(SetFixture, indirection_sequence_ordered_offset)
 (benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   ind = generateRandomPermutationArray(maxIndex(sz), false);
 
@@ -287,7 +287,7 @@ BENCHMARK_REGISTER_F(SetFixture, indirection_sequence_ordered_offset)
 BENCHMARK_DEFINE_F(SetFixture, indirection_sequence_ordered_strided_offset)
 (benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   ind = generateRandomPermutationArray(maxIndex(sz), false);
 
@@ -308,7 +308,7 @@ BENCHMARK_REGISTER_F(SetFixture, indirection_sequence_ordered_strided_offset)
 BENCHMARK_DEFINE_F(SetFixture, indirection_sequence_permuted)
 (benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   ind = generateRandomPermutationArray(maxIndex(sz), true);
 
@@ -328,7 +328,7 @@ BENCHMARK_REGISTER_F(SetFixture, indirection_sequence_permuted)->Apply(CustomArg
 BENCHMARK_DEFINE_F(SetFixture, indirection_sequence_permuted_strided)
 (benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   ind = generateRandomPermutationArray(maxIndex(sz), true);
 
@@ -349,7 +349,7 @@ BENCHMARK_REGISTER_F(SetFixture, indirection_sequence_permuted_strided)
 BENCHMARK_DEFINE_F(SetFixture, indirection_sequence_permuted_offset)
 (benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   ind = generateRandomPermutationArray(maxIndex(sz), true);
 
@@ -370,7 +370,7 @@ BENCHMARK_REGISTER_F(SetFixture, indirection_sequence_permuted_offset)
 BENCHMARK_DEFINE_F(SetFixture, indirection_sequence_permuted_strided_offset)
 (benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   ind = generateRandomPermutationArray(maxIndex(sz), true);
 
@@ -391,7 +391,7 @@ BENCHMARK_REGISTER_F(SetFixture, indirection_sequence_permuted_strided_offset)
 /// --------------------  Benchmarks for array indexing ---------------------
 BENCHMARK_DEFINE_F(SetFixture, contig_sequence_field)(benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   data = generateRandomDataField(maxIndex(sz));
 
@@ -409,7 +409,7 @@ BENCHMARK_REGISTER_F(SetFixture, contig_sequence_field)->Apply(CustomArgs);
 
 BENCHMARK_DEFINE_F(SetFixture, strided_sequence_field)(benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   data = generateRandomDataField(maxIndex(sz));
 
@@ -427,7 +427,7 @@ BENCHMARK_REGISTER_F(SetFixture, strided_sequence_field)->Apply(CustomArgs);
 
 BENCHMARK_DEFINE_F(SetFixture, offset_sequence_field)(benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   data = generateRandomDataField(maxIndex(sz));
 
@@ -446,7 +446,7 @@ BENCHMARK_REGISTER_F(SetFixture, offset_sequence_field)->Apply(CustomArgs);
 BENCHMARK_DEFINE_F(SetFixture, offset_strided_sequence_field)
 (benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   data = generateRandomDataField(maxIndex(sz));
 
@@ -465,7 +465,7 @@ BENCHMARK_REGISTER_F(SetFixture, offset_strided_sequence_field)->Apply(CustomArg
 BENCHMARK_DEFINE_F(SetFixture, indirection_sequence_ordered_field)
 (benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   ind = generateRandomPermutationArray(sz, false);
   data = generateRandomDataField(maxIndex(sz));
@@ -495,7 +495,7 @@ BENCHMARK_REGISTER_F(SetFixture, indirection_sequence_ordered_field)
 BENCHMARK_DEFINE_F(SetFixture, indirection_sequence_permuted_field)
 (benchmark::State& state)
 {
-  const int sz = state.range_x();
+  const int sz = state.range(0);
 
   ind = generateRandomPermutationArray(sz, true);
   data = generateRandomDataField(maxIndex(sz));

--- a/src/axom/slam/benchmarks/slam_array.cpp
+++ b/src/axom/slam/benchmarks/slam_array.cpp
@@ -11,11 +11,14 @@
 #include "benchmark/benchmark.h"
 #include "axom/slic.hpp"
 
+// Uncomment the following line to enable larger test sizes
+// #define SLAM_BENCHMARK_LARGE_SIZES
+
 //------------------------------------------------------------------------------
 namespace
 {
-const int STRIDE = 7;
-const int OFFSET = 12;
+constexpr int STRIDE = 7;
+constexpr int OFFSET = 12;
 
 using IndexType = int;
 using IndexArray = IndexType*;
@@ -124,8 +127,11 @@ enum ArrSizes
 {
   S0 = 1 << 3,   // small
   S1 = 1 << 16,  // larger than  32K L1 cache
-  S2 = 1 << 19,  // Larger than 256K L2 cache
-  S3 = 1 << 25   // Larger than  25M L3 cache
+  S2 = 1 << 19   // Larger than 256K L2 cache
+#if defined(SLAM_BENCHMARK_LARGE_SIZES)
+  ,
+  S3 = 1 << 25  // Larger than  25M L3 cache
+#endif
 };
 
 void CustomArgs(benchmark::internal::Benchmark* b)
@@ -133,7 +139,9 @@ void CustomArgs(benchmark::internal::Benchmark* b)
   b->Arg(S0);
   b->Arg(S1);
   b->Arg(S2);
+#if defined(SLAM_BENCHMARK_LARGE_SIZES)
   b->Arg(S3);
+#endif
 }
 
 }  // namespace
@@ -156,7 +164,9 @@ void contig_sequence_compileTimeSize(benchmark::State& state)
 BENCHMARK_TEMPLATE(contig_sequence_compileTimeSize, S0);
 BENCHMARK_TEMPLATE(contig_sequence_compileTimeSize, S1);
 BENCHMARK_TEMPLATE(contig_sequence_compileTimeSize, S2);
+#if defined(SLAM_BENCHMARK_LARGE_SIZES)
 BENCHMARK_TEMPLATE(contig_sequence_compileTimeSize, S3);
+#endif
 
 BENCHMARK_DEFINE_F(SetFixture, contig_sequence)(benchmark::State& state)
 {

--- a/src/axom/slam/benchmarks/slam_array.cpp
+++ b/src/axom/slam/benchmarks/slam_array.cpp
@@ -529,7 +529,7 @@ int main(int argc, char* argv[])
   std::srand(std::time(NULL));
 
   ::benchmark::Initialize(&argc, argv);
-  axom::slic::SimpleLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;
 
   ::benchmark::RunSpecifiedBenchmarks();
 

--- a/src/axom/slam/benchmarks/slam_sets.cpp
+++ b/src/axom/slam/benchmarks/slam_sets.cpp
@@ -8,7 +8,7 @@
 
 #include <iostream>
 
-#include "benchmark/benchmark_api.h"
+#include "benchmark/benchmark.h"
 #include "axom/slic.hpp"
 
 #include "axom/slam/policies/SizePolicies.hpp"
@@ -19,8 +19,8 @@ namespace
 {
 namespace slam = axom::slam;
 
-const int STRIDE = 7;
-const int OFFSET = 12;
+// constexpr int STRIDE = 7;
+// constexpr int OFFSET = 12;
 
 using IndexType = int;
 using IndexArray = IndexType*;
@@ -131,7 +131,7 @@ template <int SZ>
 void positionSet_compileTimeSize(benchmark::State& state)
 {
   using StaticSetSize = slam::policies::CompileTimeSize<int, SZ>;
-  using SetType = slam::OrderedSet<StaticSetSize>;
+  using SetType = slam::OrderedSet<int, int, StaticSetSize>;
   SetType set(SZ);
 
   while(state.KeepRunning())
@@ -173,7 +173,7 @@ BENCHMARK_TEMPLATE(positionSet_runtimeTimeSize_template, S3);
 void positionSet_runtimeTimeSize_function(benchmark::State& state)
 {
   using SetType = slam::OrderedSet<>;
-  SetType set(state.range_x());
+  SetType set(state.range(0));
 
   while(state.KeepRunning())
   {
@@ -190,7 +190,7 @@ BENCHMARK(positionSet_runtimeTimeSize_function)->Apply(CustomArgs);
 void positionSet_runtimeTimeSize_function_sizeOutside(benchmark::State& state)
 {
   using SetType = slam::OrderedSet<>;
-  SetType set(state.range_x());
+  SetType set(state.range(0));
 
   const int sz = set.size();
   while(state.KeepRunning())
@@ -208,7 +208,7 @@ BENCHMARK(positionSet_runtimeTimeSize_function_sizeOutside)->Apply(CustomArgs);
 void positionSet_runtimeTimeSize_function_volatileSizeOutside(benchmark::State& state)
 {
   using SetType = slam::OrderedSet<>;
-  SetType set(state.range_x());
+  SetType set(state.range(0));
 
   volatile int sz = set.size();
   while(state.KeepRunning())
@@ -227,7 +227,7 @@ void positionSet_runtimeTimeSize_iter(benchmark::State& state)
 {
   using SetType = slam::OrderedSet<>;
   using SetIter = SetType::iterator;
-  SetType set(state.range_x());
+  SetType set(state.range(0));
 
   while(state.KeepRunning())
   {

--- a/src/axom/slic/tests/CMakeLists.txt
+++ b/src/axom/slic/tests/CMakeLists.txt
@@ -69,7 +69,7 @@ if (ENABLE_BENCHMARKS)
 
         blt_add_benchmark(
             NAME    ${test_name}
-            COMMAND ${test_name} --benchmark_min_time=0.0001s )
+            COMMAND ${test_name} )
     endforeach()
 endif()
 

--- a/src/axom/slic/tests/CMakeLists.txt
+++ b/src/axom/slic/tests/CMakeLists.txt
@@ -69,7 +69,7 @@ if (ENABLE_BENCHMARKS)
 
         blt_add_benchmark(
             NAME    ${test_name}
-            COMMAND ${test_name} --benchmark_min_time=0.0001 )
+            COMMAND ${test_name} --benchmark_min_time=0.0001s )
     endforeach()
 endif()
 

--- a/src/axom/slic/tests/slic_benchmark_asserts.cpp
+++ b/src/axom/slic/tests/slic_benchmark_asserts.cpp
@@ -3,41 +3,43 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "benchmark/benchmark_api.h"
+#include "benchmark/benchmark.h"
 #include "axom/slic/interface/slic.hpp"
 #include "axom/slic/core/SimpleLogger.hpp"
 
 /*!
  * \file
  *
- * A series of tests of SLIC logging macros (SLIC_WARNING to avoid killing the
- * program) in the TPL benchmark framework.
+ * A series of tests of SLIC logging macros (using SLIC_WARNING to avoid 
+ * killing the program) in the TPL benchmark framework.
  *
  * These tests were written to see why SLIC macros was not being logged
  * when called from a benchmark fixture's destructor.
  * It turns out that the fixtures are destructed after main exits,
  * so SLIC is already finalized.
- *
  */
 
 namespace
 {
-static const bool IS_VALID = true;
-static const bool SHOULD_PRINT = false;
+static constexpr bool IS_VALID = true;
+static constexpr bool SHOULD_PRINT = false;
 
 void printMsg(std::string const& str, bool override = false)
 {
-  if(SHOULD_PRINT || override) std::cout << str << std::endl;
+  if(SHOULD_PRINT || override)
+  {
+    std::cout << str << std::endl;
+  }
 }
 
 struct AssertCtor
 {
-  AssertCtor() { SLIC_WARNING_IF(IS_VALID, "Testing warning in .ctor"); }
-};
+  AssertCtor() { SLIC_WARNING_IF(IS_VALID, "Testing warning in .ctor"); };
 
-struct AssertMethod
-{
-  void foo() { SLIC_WARNING_IF(IS_VALID, "Testing warning in class method"); }
+  struct AssertMethod
+  {
+    void foo() { SLIC_WARNING_IF(IS_VALID, "Testing warning in class method"); }
+  };
 };
 
 struct AssertDtor
@@ -50,24 +52,36 @@ class SetFixtureC : public ::benchmark::Fixture
 public:
   SetFixtureC()
   {
-    SLIC_WARNING_IF(IS_VALID, "Testing warning in .ctor");
-    printMsg(
-      "*** Note: the slic log is not printed for SetFixtureC/assertCtor since "
-      "it is called before slic::initialize() ***",
-      true);
+    static bool override_once = true;
+    if(override_once)
+    {
+      std::cout
+        << "*** Note: cannot use slic macros in fixture constructors since "
+           "they're called before main (i.e. before slic::initialize()) ***"
+        << std::endl;
+      override_once = false;
+    }
+
+    //SLIC_WARNING_IF(IS_VALID, "Testing warning in .ctor");
   }
 };
 
 class SetFixtureS : public ::benchmark::Fixture
 {
 public:
-  void SetUp() { SLIC_WARNING_IF(IS_VALID, "Testing warning in setup"); }
+  void SetUp(const ::benchmark::State& /*state*/) override
+  {
+    SLIC_WARNING_IF(IS_VALID, "Testing warning in setup");
+  }
 };
 
 class SetFixtureT : public ::benchmark::Fixture
 {
 public:
-  void TearDown() { SLIC_WARNING_IF(IS_VALID, "Testing warning in teardown"); }
+  void TearDown(const ::benchmark::State& /*state*/) override
+  {
+    SLIC_WARNING_IF(IS_VALID, "Testing warning in teardown");
+  }
 };
 
 class SetFixtureD : public ::benchmark::Fixture
@@ -75,50 +89,81 @@ class SetFixtureD : public ::benchmark::Fixture
 public:
   ~SetFixtureD()
   {
-    SLIC_WARNING_IF(IS_VALID, "Testing warning in .dtor");
-    printMsg(
-      "*** Note: the slic log is not printed for SetFixtureD/assertDtor since "
-      "it is called after slic::finalize() ***",
-      true);
+    static bool override_once = true;
+    if(override_once)
+    {
+      std::cout
+        << "*** Note: cannot use slic macros in fixture destructors since "
+           "they're called after main (i.e. after slic::finalize()) ***"
+        << std::endl;
+      override_once = false;
+    }
+
+    //SLIC_WARNING_IF(IS_VALID, "Testing warning in .dtor");
   }
 };
 
 class SetFixtureOutput : public ::benchmark::Fixture
 {
 public:
-  SetFixtureOutput() { printMsg("  fixure .ctor"); }
-  void SetUp() { printMsg("  fixure SetUp"); }
-  void TearDown() { printMsg("  fixure TearDown"); }
-  ~SetFixtureOutput() { printMsg("  fixure ~.dtor"); }
+  SetFixtureOutput() { printMsg("  fixure .ctor (called before main)"); }
+  void SetUp(const ::benchmark::State& /*state*/) override
+  {
+    printMsg("  fixure SetUp");
+  }
+  void TearDown(const ::benchmark::State& /*state*/) override
+  {
+    printMsg("  fixure TearDown");
+  }
+  ~SetFixtureOutput() { printMsg("  fixure ~.dtor (called after main)"); }
 };
 
 static void BM_AssertBefore(benchmark::State& state)
 {
   SLIC_WARNING_IF(IS_VALID, "Testing warning before running benchmark");
-  while(state.KeepRunning()) benchmark::DoNotOptimize(0);
+  while(state.KeepRunning())
+  {
+    std::int64_t x = 0;
+    benchmark::DoNotOptimize(x);
+  }
 }
 
 static void BM_AssertAfter(benchmark::State& state)
 {
-  while(state.KeepRunning()) benchmark::DoNotOptimize(0);
+  while(state.KeepRunning())
+  {
+    std::int64_t x = 0;
+    benchmark::DoNotOptimize(x);
+  }
   SLIC_WARNING_IF(IS_VALID, "Testing warning after running benchmark");
 }
 
 static void BM_CallAssertCtorBefore(benchmark::State& state)
 {
   AssertCtor();
-  while(state.KeepRunning()) benchmark::DoNotOptimize(0);
+  while(state.KeepRunning())
+  {
+    std::int64_t x = 0;
+    benchmark::DoNotOptimize(x);
+  }
 }
 
 static void BM_CallAssertDtorBefore(benchmark::State& state)
 {
   AssertDtor();
-  while(state.KeepRunning()) benchmark::DoNotOptimize(0);
+  while(state.KeepRunning())
+  {
+    std::int64_t x = 0;
+    benchmark::DoNotOptimize(x);
+  }
 }
 
 static void BM_CallAssertDtorDuring(benchmark::State& state)
 {
-  while(state.KeepRunning()) AssertDtor();
+  while(state.KeepRunning())
+  {
+    AssertDtor();
+  }
 }
 
 }  // namespace
@@ -133,41 +178,45 @@ BENCHMARK_F(SetFixtureC, assertCtor)(benchmark::State& state)
 {
   while(state.KeepRunning())
   {
-    benchmark::DoNotOptimize(0);
+    std::int64_t x = 0;
+    benchmark::DoNotOptimize(x);
   }
 }
 BENCHMARK_F(SetFixtureS, assertSetup)(benchmark::State& state)
 {
   while(state.KeepRunning())
   {
-    benchmark::DoNotOptimize(0);
+    std::int64_t x = 0;
+    benchmark::DoNotOptimize(x);
   }
 }
 BENCHMARK_F(SetFixtureT, assertTeardown)(benchmark::State& state)
 {
   while(state.KeepRunning())
   {
-    benchmark::DoNotOptimize(0);
+    std::int64_t x = 0;
+    benchmark::DoNotOptimize(x);
   }
 }
 BENCHMARK_F(SetFixtureD, assertDtor)(benchmark::State& state)
 {
   while(state.KeepRunning())
   {
-    benchmark::DoNotOptimize(0);
+    std::int64_t x = 0;
+    benchmark::DoNotOptimize(x);
   }
 }
 
 // The following two benchmarks are here to show the order of construction,
 // setup, teardown and destruction of benchmarks fixtures.
-// Note: Need to enable printing (by setting SHOULD_PRINT above to true) to see
-// this.
+// Note: Need to enable printing (by setting SHOULD_PRINT above to true) to see this.
 BENCHMARK_F(SetFixtureOutput, process1)(benchmark::State& state)
 {
   printMsg("   P1 (before)");
   while(state.KeepRunning())
   {
-    benchmark::DoNotOptimize(0);
+    std::int64_t x = 0;
+    benchmark::DoNotOptimize(x);
   }
   printMsg("   P1 (after)");
 }
@@ -176,7 +225,8 @@ BENCHMARK_F(SetFixtureOutput, process2)(benchmark::State& state)
   printMsg("   P2 (before)");
   while(state.KeepRunning())
   {
-    benchmark::DoNotOptimize(0);
+    std::int64_t x = 0;
+    benchmark::DoNotOptimize(x);
   }
   printMsg("   P2 (after)");
 }
@@ -190,7 +240,6 @@ int main(int argc, char* argv[])
   printMsg(" After init logger");
 
   printMsg(" Before init benchmark");
-
   ::benchmark::Initialize(&argc, argv);
   printMsg(" after init benchmark");
 

--- a/src/axom/slic/tests/slic_benchmark_asserts.cpp
+++ b/src/axom/slic/tests/slic_benchmark_asserts.cpp
@@ -7,6 +7,9 @@
 #include "axom/slic/interface/slic.hpp"
 #include "axom/slic/core/SimpleLogger.hpp"
 
+#include <cstdint>
+#include <iostream>
+
 /*!
  * \file
  *
@@ -24,9 +27,9 @@ namespace
 static constexpr bool IS_VALID = true;
 static constexpr bool SHOULD_PRINT = false;
 
-void printMsg(std::string const& str, bool override = false)
+void printMsg(std::string const& str, bool always_print = false)
 {
-  if(SHOULD_PRINT || override)
+  if(SHOULD_PRINT || always_print)
   {
     std::cout << str << std::endl;
   }
@@ -168,11 +171,11 @@ static void BM_CallAssertDtorDuring(benchmark::State& state)
 
 }  // namespace
 
-BENCHMARK(BM_AssertBefore);
-BENCHMARK(BM_AssertAfter);
-BENCHMARK(BM_CallAssertCtorBefore);
-BENCHMARK(BM_CallAssertDtorBefore);
-BENCHMARK(BM_CallAssertDtorDuring);
+BENCHMARK(BM_AssertBefore)->Iterations(1);
+BENCHMARK(BM_AssertAfter)->Iterations(1);
+BENCHMARK(BM_CallAssertCtorBefore)->Iterations(1);
+BENCHMARK(BM_CallAssertDtorBefore)->Iterations(1);
+BENCHMARK(BM_CallAssertDtorDuring)->Iterations(1);
 
 BENCHMARK_F(SetFixtureC, assertCtor)(benchmark::State& state)
 {
@@ -182,6 +185,8 @@ BENCHMARK_F(SetFixtureC, assertCtor)(benchmark::State& state)
     benchmark::DoNotOptimize(x);
   }
 }
+BENCHMARK_REGISTER_F(SetFixtureC, assertCtor)->Iterations(1);
+
 BENCHMARK_F(SetFixtureS, assertSetup)(benchmark::State& state)
 {
   while(state.KeepRunning())
@@ -190,6 +195,8 @@ BENCHMARK_F(SetFixtureS, assertSetup)(benchmark::State& state)
     benchmark::DoNotOptimize(x);
   }
 }
+BENCHMARK_REGISTER_F(SetFixtureS, assertSetup)->Iterations(1);
+
 BENCHMARK_F(SetFixtureT, assertTeardown)(benchmark::State& state)
 {
   while(state.KeepRunning())
@@ -198,6 +205,8 @@ BENCHMARK_F(SetFixtureT, assertTeardown)(benchmark::State& state)
     benchmark::DoNotOptimize(x);
   }
 }
+BENCHMARK_REGISTER_F(SetFixtureT, assertTeardown)->Iterations(1);
+
 BENCHMARK_F(SetFixtureD, assertDtor)(benchmark::State& state)
 {
   while(state.KeepRunning())
@@ -206,6 +215,7 @@ BENCHMARK_F(SetFixtureD, assertDtor)(benchmark::State& state)
     benchmark::DoNotOptimize(x);
   }
 }
+BENCHMARK_REGISTER_F(SetFixtureD, assertDtor)->Iterations(1);
 
 // The following two benchmarks are here to show the order of construction,
 // setup, teardown and destruction of benchmarks fixtures.
@@ -220,6 +230,8 @@ BENCHMARK_F(SetFixtureOutput, process1)(benchmark::State& state)
   }
   printMsg("   P1 (after)");
 }
+BENCHMARK_REGISTER_F(SetFixtureOutput, process1)->Iterations(1);
+
 BENCHMARK_F(SetFixtureOutput, process2)(benchmark::State& state)
 {
   printMsg("   P2 (before)");
@@ -230,13 +242,14 @@ BENCHMARK_F(SetFixtureOutput, process2)(benchmark::State& state)
   }
   printMsg("   P2 (after)");
 }
+BENCHMARK_REGISTER_F(SetFixtureOutput, process2)->Iterations(1);
 
 int main(int argc, char* argv[])
 {
   printMsg("at start of main");
 
   printMsg(" Before init logger");
-  axom::slic::SimpleLogger logger;  // create & initialize test logger,
+  axom::slic::SimpleLogger logger;
   printMsg(" After init logger");
 
   printMsg(" Before init benchmark");

--- a/src/axom/slic/tests/slic_macros.cpp
+++ b/src/axom/slic/tests/slic_macros.cpp
@@ -323,6 +323,7 @@ TEST(slic_macros, test_debug_macros)
 #else
   // SLIC_DEBUG macros only log messages when AXOM_DEBUG is defined
   EXPECT_TRUE(slic::internal::is_stream_empty());
+  AXOM_UNUSED_VAR(expected_line_number);
 #endif
 
   // is root, but conditional is false -> no message

--- a/src/axom/slic/tests/slic_macros_parallel.cpp
+++ b/src/axom/slic/tests/slic_macros_parallel.cpp
@@ -973,6 +973,7 @@ TEST_P(SlicMacrosParallel, test_debug_macros)
 #else
   // SLIC_DEBUG macros only log messages when AXOM_DEBUG is defined
   EXPECT_TRUE(slic::internal::are_all_streams_empty());
+  AXOM_UNUSED_VAR(expected_line_number);
 #endif
 }
 


### PR DESCRIPTION
# Summary

- This PR is progress towards #287  
  (see also #922)
- It adds initial benchmarking of `axom::Array` vs. `std::vector`
   - Specifically, it compares construction times, performance of `push_back` and `emplace_back` and some iterator operations.
   - I decided to stop here in this first attempt before the testing got too involved
- This PR also updates BLT to get a bugfix related to running benchmarks (https://github.com/LLNL/blt/pull/698) and fixes our existing gbenchmark tests for `slic` and `slam`
- It also adds `ENABLE_BENCHMARKS` to a debug and a release config CI job and runs the benchmarks as part of the testing

#### Details
Here are the initial results for a Release Clang config on an LC CTS-2 cluster comparing `axom::Array` vs. `std::vector` templates on several types:
* `int`
* `std::pair<int,int>`
* `Wrapper<int>` --  a struct that wraps an `int`
* `std::string`

For simplicity, these results only use a single array size -- $2^{16} == 65,536$ elements, although it's easy to test other sizes and/or types.

```
>./tests/core_benchmark_array 

Running ./tests/core_benchmark_array
Run on (224 X 3800.68 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x112)
  L1 Instruction 32 KiB (x112)
  L2 Unified 2048 KiB (x112)
  L3 Unified 107520 KiB (x2)
Load Average: 0.00, 0.00, 0.33
---------------------------------------------------------------------------------------------------------
Benchmark                                                               Time             CPU   Iterations
---------------------------------------------------------------------------------------------------------
Array::ctor<int>/65536                                               4558 ns         4553 ns       153089
vector::ctor<int>/65536                                              4297 ns         4293 ns       163069
Array::push_back_startEmpty<int>/65536                             243490 ns       243157 ns         3180
Array::emplace_back_startEmpty<int>/65536                          247124 ns       246788 ns         2834
Array::push_back_initialReserve<int>/65536                         129280 ns       129155 ns         5419
Array::emplace_back_initialReserve<int>/65536                      136120 ns       135991 ns         5137
vector::push_back_startEmpty<int>/65536                            143477 ns       143213 ns         4886
vector::emplace_back_startEmpty<int>/65536                         143364 ns       143085 ns         4892
vector::push_back_initialReserve<int>/65536                         40123 ns        40085 ns        17463
vector::emplace_back_initialReserve<int>/65536                      40122 ns        40087 ns        17461
Array::iterate_range<int>/65536                                     31360 ns        31328 ns        22596
Array::iterate_direct<int>/65536                                    32914 ns        32881 ns        22270
vector::iterate_range<int>/65536                                    34642 ns        34611 ns        20225
vector::iterate_direct<int>/65536                                   34669 ns        34636 ns        20224
Array::ctor<std::pair<int, int>>/65536                               8809 ns         8800 ns        79545
vector::ctor<std::pair<int, int>>/65536                              8554 ns         8545 ns        81923
Array::push_back_startEmpty<std::pair<int, int>>/65536             390602 ns       389792 ns         1794
Array::emplace_back_startEmpty<std::pair<int, int>>/65536          385204 ns       384419 ns         1820
Array::push_back_initialReserve<std::pair<int, int>>/65536         135640 ns       135499 ns         5165
Array::emplace_back_initialReserve<std::pair<int, int>>/65536      130796 ns       130653 ns         5355
vector::push_back_startEmpty<std::pair<int, int>>/65536            350294 ns       349552 ns         2004
vector::emplace_back_startEmpty<std::pair<int, int>>/65536         355547 ns       354832 ns         1972
vector::push_back_initialReserve<std::pair<int, int>>/65536         66364 ns        66296 ns        10087
vector::emplace_back_initialReserve<std::pair<int, int>>/65536      63207 ns        63139 ns        11517
Array::iterate_range<std::pair<int, int>>/65536                     51925 ns        51877 ns        13492
Array::iterate_direct<std::pair<int, int>>/65536                    31522 ns        31494 ns        22959
vector::iterate_range<std::pair<int, int>>/65536                    34649 ns        34616 ns        20223
vector::iterate_direct<std::pair<int, int>>/65536                   34650 ns        34614 ns        20222
Array::ctor<Wrapper<int>>/65536                                      4548 ns         4543 ns       154093
vector::ctor<Wrapper<int>>/65536                                    17349 ns        17333 ns        40383
Array::push_back_startEmpty<Wrapper<int>>/65536                    146199 ns       146058 ns         4796
Array::emplace_back_startEmpty<Wrapper<int>>/65536                 146684 ns       146531 ns         4762
Array::push_back_initialReserve<Wrapper<int>>/65536                129391 ns       129263 ns         5412
Array::emplace_back_initialReserve<Wrapper<int>>/65536             135634 ns       135504 ns         5193
vector::push_back_startEmpty<Wrapper<int>>/65536                    46341 ns        46297 ns        15124
vector::emplace_back_startEmpty<Wrapper<int>>/65536                 46343 ns        46297 ns        15120
vector::push_back_initialReserve<Wrapper<int>>/65536                40126 ns        40086 ns        17463
vector::emplace_back_initialReserve<Wrapper<int>>/65536             40123 ns        40087 ns        17461
Array::iterate_range<Wrapper<int>>/65536                            35463 ns        35428 ns        20013
Array::iterate_direct<Wrapper<int>>/65536                           30262 ns        30233 ns        21990
vector::iterate_range<Wrapper<int>>/65536                           34650 ns        34616 ns        20222
vector::iterate_direct<Wrapper<int>>/65536                          34644 ns        34612 ns        20224
Array::ctor<std::string>/65536                                      88505 ns        88357 ns         7923
vector::ctor<std::string>/65536                                     82147 ns        82016 ns         8534
Array::push_back_startEmpty<std::string>/65536                    4404390 ns      4395382 ns          159
Array::emplace_back_startEmpty<std::string>/65536                 4472433 ns      4463544 ns          157
Array::push_back_initialReserve<std::string>/65536                4277672 ns      4269434 ns          164
Array::emplace_back_initialReserve<std::string>/65536             4290957 ns      4283060 ns          164
vector::push_back_startEmpty<std::string>/65536                   4237623 ns      4229098 ns          165
vector::emplace_back_startEmpty<std::string>/65536                4220593 ns      4211613 ns          166
vector::push_back_initialReserve<std::string>/65536               4175780 ns      4167776 ns          168
vector::emplace_back_initialReserve<std::string>/65536            4164180 ns      4156289 ns          168
Array::iterate_range<std::string>/65536                            212227 ns       211870 ns         3301
Array::iterate_direct<std::string>/65536                           212656 ns       212243 ns         3292
vector::iterate_range<std::string>/65536                           217987 ns       217601 ns         3209
vector::iterate_direct<std::string>/65536                          220336 ns       219948 ns         3192
```

My quick read is that `std::vector` can be several times faster than `axom::Array` for `push_back` and `emplace_back` on simple types, even when we reserve storage ahead of time (compare e.g. the lines with `push_back_initialReserve`)