### PR TITLE
Use new RTD dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ Axom provides robust, flexible software infrastructure for the development of mu
 Documentation
 -------------
 
-Latest docs on Develop branch: https://axom.readthedocs.io
-
-To access docs for other versions: https://readthedocs.org/projects/axom/
+To access the latest docs for Axom as well as those for specific versions:
+https://app.readthedocs.org/projects/axom/
 
 Getting Involved
 ----------------

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Axom provides robust, flexible software infrastructure for the development of mu
 Documentation
 -------------
 
-To access the latest docs for Axom as well as those for specific versions:
-https://app.readthedocs.org/projects/axom/
+To access the latest docs for Axom: https://axom.readthedocs.io/en/develop/
+
+To access Axom docs for specific versions: https://app.readthedocs.org/projects/axom/
 
 Getting Involved
 ----------------

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Documentation
 
 To access the latest docs for Axom: https://axom.readthedocs.io/en/develop/
 
-To access Axom docs for specific versions: https://app.readthedocs.org/projects/axom/
+To access another version of Axom docs, please expand the sub-window on the lower right of any Axom Document page.
 
 Getting Involved
 ----------------


### PR DESCRIPTION
# Summary

- This PR changes the link to our documentation on our main project to the new RTD dashboard.
- The current legacy dashboard is going away in March 2025.
- Why wait until the last minute?!?