### PR TITLE
Fix `MFEMSidreDataCollection::LoadExternalData` and add test cases for various `LoadExternalData` functions

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,6 +35,7 @@ to use Open Cascade's file I/O capabilities in support of Quest applications.
 - ItemCollection and its child classes MapCollection, ListCollection, and IndexedCollection were moved from Sidre
   to core.  The namespace prefix for these classes is now `axom::` instead of `axom::sidre`.  The internal usage of
   these types within Sidre Datastore and Group is unchanged.
+- `MFEMSidreDataCollection::LoadExternalData` now takes an optional `Group` parameter and will only load external data from the given `Group` or from the `MFEMSidreDataCollection` instead of the entire `DataStore`. This is instead of a file path that the class already knows.
 
 ###  Deprecated
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,8 +36,8 @@ to use Open Cascade's file I/O capabilities in support of Quest applications.
   to core.  The namespace prefix for these classes is now `axom::` instead of `axom::sidre`.  The internal usage of
   these types within Sidre Datastore and Group is unchanged.
 - `MFEMSidreDataCollection::LoadExternalData` now takes two optional string parameters, one that is a
-  filename (defaults to the `name` member variable) and the other is a Group path relative to the base of
-  the Data Collection itself (defaults to the whole Data Collection).
+  filename (defaults to the `name` member variable) and the other is a `Group` path relative to the base of
+  the Data Collection itself (defaults to the root of the `DataStore`).
 
 ###  Deprecated
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,9 @@ to use Open Cascade's file I/O capabilities in support of Quest applications.
 - ItemCollection and its child classes MapCollection, ListCollection, and IndexedCollection were moved from Sidre
   to core.  The namespace prefix for these classes is now `axom::` instead of `axom::sidre`.  The internal usage of
   these types within Sidre Datastore and Group is unchanged.
-- `MFEMSidreDataCollection::LoadExternalData` now takes an optional `Group` parameter and will only load external data from the given `Group` or from the `MFEMSidreDataCollection` instead of the entire `DataStore`. This is instead of a file path that the class already knows.
+- `MFEMSidreDataCollection::LoadExternalData` now takes two optional string parameters, one that is a
+  filename (defaults to the `name` member variable) and the other is a Group path relative to the base of
+  the Data Collection itself (defaults to the whole Data Collection).
 
 ###  Deprecated
 

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -957,9 +957,16 @@ void MFEMSidreDataCollection::LoadExternalData(const std::string& filename,
                                                const std::string& group_name)
 {
   // Use the user-provided group name or the DataCollection's base group
-  Group* grp = m_bp_grp;
+  Group* grp = m_bp_grp->getDataStore()->getRoot();
   if(!group_name.empty())
   {
+    #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
+    if(m_comm != MPI_COMM_NULL)
+    {
+      SLIC_ERROR("Loading external data with a group name is not supported in parallel.");
+    }
+    #endif
+
     SLIC_ERROR_IF(!m_bp_grp->hasGroup(group_name),
                   axom::fmt::format(
                     "MFEMSidreDataCollection does not have a Sidre Group '{}'",
@@ -982,7 +989,6 @@ void MFEMSidreDataCollection::LoadExternalData(const std::string& filename,
     // suffix, but the IOManager does not, so it gets added here
     using axom::utilities::string::endsWith;
     std::string suffixedPath = endsWith(path, ".root") ? path : path + ".root";
-
     IOManager reader(m_comm);
     reader.loadExternalData(grp, suffixedPath);
   }

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -953,14 +953,17 @@ void MFEMSidreDataCollection::Load(const std::string& path,
   }
 }
 
-void MFEMSidreDataCollection::LoadExternalData(const std::string& filename, const std::string& group_name)
+void MFEMSidreDataCollection::LoadExternalData(const std::string& filename,
+                                               const std::string& group_name)
 {
   // Use the user-provided group name or the DataCollection's base group
   Group* grp = m_bp_grp;
   if(!group_name.empty())
   {
     SLIC_ERROR_IF(!m_bp_grp->hasGroup(group_name),
-                  axom::fmt::format("MFEMSidreDataCollection does not have a Sidre Group '{}'", group_name));
+                  axom::fmt::format(
+                    "MFEMSidreDataCollection does not have a Sidre Group '{}'",
+                    group_name));
     grp = m_bp_grp->getGroup(group_name);
   }
 

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -953,18 +953,23 @@ void MFEMSidreDataCollection::Load(const std::string& path,
   }
 }
 
-void MFEMSidreDataCollection::LoadExternalData(const std::string& path)
+void MFEMSidreDataCollection::LoadExternalData(Group* grp)
 {
   #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
   if(m_comm != MPI_COMM_NULL)
   {
+    if(grp == nullptr)
+    {
+      grp = m_bp_grp;
+    }
+
     IOManager reader(m_comm);
-    reader.loadExternalData(m_bp_grp->getDataStore()->getRoot(), path);
+    reader.loadExternalData(grp, get_file_path(name));
   }
   else
   #endif
   {
-    m_bp_grp->loadExternalData(path);
+    m_bp_grp->loadExternalData(get_file_path(name));
   }
 }
 

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -960,12 +960,14 @@ void MFEMSidreDataCollection::LoadExternalData(const std::string& filename,
   Group* grp = m_bp_grp->getDataStore()->getRoot();
   if(!group_name.empty())
   {
-    #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
+  #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
     if(m_comm != MPI_COMM_NULL)
     {
-      SLIC_ERROR("Loading external data with a group name is not supported in parallel.");
+      SLIC_ERROR(
+        "Loading external data with a group name is not supported in "
+        "parallel.");
     }
-    #endif
+  #endif
 
     SLIC_ERROR_IF(!m_bp_grp->hasGroup(group_name),
                   axom::fmt::format(

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -476,9 +476,13 @@ public:
     Load(get_file_path(name), "sidre_hdf5");
   }
 
-  /// Load external data for the whole MFEMDataCollection unless a specific group is given.
-  /// @note This must happen after registering externally owned fields.
-  void LoadExternalData(Group* grp = nullptr);
+  /** @brief Load external data for the whole MFEMSidreDataCollection unless a specific group name is given.
+   *  @note This must happen after registering externally owned fields.
+   *
+   *  @param filename Optional base filename to be loaded, function will add prefix path and cycle
+   *  @param group_name Optional group name to load external data, relative to base of MFEMSidreDataCollection
+   **/
+  void LoadExternalData(const std::string& filename = "", const std::string& group_name = "");
 
   /** @brief Updates the DataCollection's cycle, time, and time-step variables
       with the values from the data store. */

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -482,7 +482,8 @@ public:
    *  @param filename Optional base filename to be loaded, function will add prefix path and cycle
    *  @param group_name Optional group name to load external data, relative to base of MFEMSidreDataCollection
    **/
-  void LoadExternalData(const std::string& filename = "", const std::string& group_name = "");
+  void LoadExternalData(const std::string& filename = "",
+                        const std::string& group_name = "");
 
   /** @brief Updates the DataCollection's cycle, time, and time-step variables
       with the values from the data store. */

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -476,8 +476,9 @@ public:
     Load(get_file_path(name), "sidre_hdf5");
   }
 
-  /// Load external data after registering externally owned fields.
-  void LoadExternalData(const std::string& path);
+  /// Load external data for the whole MFEMDataCollection unless a specific group is given.
+  /// @note This must happen after registering externally owned fields.
+  void LoadExternalData(Group* grp = nullptr);
 
   /** @brief Updates the DataCollection's cycle, time, and time-step variables
       with the values from the data store. */

--- a/src/axom/sidre/tests/CMakeLists.txt
+++ b/src/axom/sidre/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(gtest_sidre_tests
    sidre_native_layout.cpp
    sidre_attribute.cpp
    sidre_mcarray.cpp
+   sidre_read_write_userdefined_data.cpp
    )
 
 set(gtest_sidre_C_tests

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -256,6 +256,56 @@ TEST(sidre_datacollection, dc_reload_gf_vdim)
   EXPECT_TRUE(sdc_reader.verifyMeshBlueprint());
 }
 
+TEST(sidre_datacollection, dc_reload_externaldata)
+{
+  const std::string view_name = "external_data";
+
+  // Create DC
+  auto mesh = mfem::Mesh::MakeCartesian1D(10);
+  const bool owns_mesh_data = true;
+  MFEMSidreDataCollection sdc_writer(testName(), &mesh, owns_mesh_data);
+#if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
+  sdc_writer.SetComm(MPI_COMM_WORLD);
+#endif
+  sdc_writer.SetCycle(0);
+
+  // Create external buffer and add it to DC
+  axom::Array<int64_t> writer_data {1, 2, 3, 4};
+  axom::sidre::Group* writer_bp_group = sdc_writer.GetBPGroup();
+  axom::sidre::View* writer_external_view = writer_bp_group->createView(view_name);
+  writer_external_view->setExternalDataPtr(axom::sidre::INT64_ID,
+                                           writer_data.size(),
+                                           writer_data.data());
+  EXPECT_TRUE(writer_bp_group->hasView(view_name));
+
+  sdc_writer.Save();
+
+  // Load DC from file
+  MFEMSidreDataCollection sdc_reader(testName());
+#if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
+  sdc_reader.SetComm(MPI_COMM_WORLD);
+#endif
+  // Note: this will recreate the external view but not load the external data yet
+  sdc_reader.Load();
+  axom::sidre::Group* reader_bp_group = sdc_reader.GetBPGroup();
+  EXPECT_TRUE(reader_bp_group->hasView(view_name));
+  axom::sidre::View* reader_external_view = reader_bp_group->getView(view_name);
+
+  // Create external buffer with wrong data and load previously saved data into it
+  axom::Array<int64_t> reader_data {5, 6, 7, 8};
+  reader_external_view->setExternalDataPtr(reader_data.data());
+  sdc_reader.LoadExternalData();
+
+  EXPECT_TRUE(writer_data.size() == reader_data.size());
+  SLIC_INFO(axom::fmt::format("~~~~ {}", writer_data.size()));
+  for(int i = 0; i < reader_data.size(); ++i)
+  {
+    SLIC_INFO(axom::fmt::format("~~~~ {} == {}", reader_data[i], writer_data[i]));
+    EXPECT_TRUE(reader_data[i] == writer_data[i]);
+  }
+  SLIC_INFO("~~~ END");
+}
+
 TEST(sidre_datacollection, dc_reload_mesh)
 {
   const std::string field_name = "test_field";

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -264,6 +264,8 @@ TEST(sidre_datacollection, dc_reload_externaldata)
   auto mesh = mfem::Mesh::MakeCartesian1D(10);
   const bool owns_mesh_data = true;
   MFEMSidreDataCollection sdc_writer(testName(), &mesh, owns_mesh_data);
+  // After creation set owning to false so data doesn't get double free'd by reader and writer
+  sdc_writer.SetOwnData(false);
 #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
   sdc_writer.SetComm(MPI_COMM_WORLD);
 #endif

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -274,7 +274,8 @@ TEST(sidre_datacollection, dc_reload_externaldata)
   // Create external buffer and add it to DC
   axom::Array<int64_t> writer_data {1, 2, 3, 4};
   axom::sidre::Group* writer_bp_group = sdc_writer.GetBPGroup();
-  axom::sidre::View* writer_external_view = writer_bp_group->createView(view_name);
+  axom::sidre::View* writer_external_view =
+    writer_bp_group->createView(view_name);
   writer_external_view->setExternalDataPtr(axom::sidre::INT64_ID,
                                            writer_data.size(),
                                            writer_data.data());

--- a/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
+++ b/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
@@ -90,7 +90,6 @@ private:
 template <>
 bool check(const double& state, double value)
 {
-  SLIC_INFO(axom::fmt::format("{} == {}", state, value));
   return state == value;
 }
 
@@ -110,7 +109,6 @@ struct StateOne
 template <>
 bool check(const StateOne& state, double value)
 {
-  SLIC_INFO(axom::fmt::format("{} == {}", state.x, value));
   return state.x == value;
 }
 
@@ -265,7 +263,7 @@ void test_external_user_defined_data()
   auto num_states = static_cast<IndexType>(states.size());
   auto state_size = static_cast<IndexType>(sizeof(states[0]));
   auto total_size = num_states * state_size;
-  auto num_uint8s = total_size / sizeof(axom::sidre::UINT8_ID);
+  auto num_uint8s = total_size / sizeof(std::uint8_t);
 
   // write shape
   qd_group->createViewScalar("num_states", num_states);

--- a/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
+++ b/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
@@ -196,7 +196,8 @@ struct StateTensorSmall
 template <>
 bool check(const StateTensorSmall& state, double value)
 {
-  return (state.t(0) == value) && (state.t(1) == (value + 1)) && (state.x == (value + 4));
+  return (state.t(0) == value) && (state.t(1) == (value + 1)) &&
+    (state.x == (value + 4));
 }
 
 template <>
@@ -226,10 +227,10 @@ bool check(const StateTensorLarge& state, double value)
 template <>
 void fill(StateTensorLarge& state, double value)
 {
-  state.t(0,0) = value;
-  state.t(0,1) = value + 1;
-  state.t(1,0) = value + 2;
-  state.t(1,1) = value + 3;
+  state.t(0, 0) = value;
+  state.t(0, 1) = value + 1;
+  state.t(1, 0) = value + 2;
+  state.t(1, 1) = value + 3;
   state.x = value + 4;
 }
 
@@ -300,8 +301,8 @@ void test_user_defined_data()
   SLIC_INFO(axom::fmt::format("Num of States={}", num_states));
   SLIC_INFO(axom::fmt::format("State Size={}", state_size));
   SLIC_INFO(axom::fmt::format("Total Size={}", total_size));
-  SLIC_INFO(axom::fmt::format("Total Size/State Size={}",
-                              total_size / state_size));
+  SLIC_INFO(
+    axom::fmt::format("Total Size/State Size={}", total_size / state_size));
 
   // write shape
   root->createViewScalar("num_states", num_states);
@@ -345,8 +346,8 @@ void test_external_user_defined_data()
   SLIC_INFO(axom::fmt::format("Num of States={}", num_states));
   SLIC_INFO(axom::fmt::format("State Size={}", state_size));
   SLIC_INFO(axom::fmt::format("Total Size={}", total_size));
-  SLIC_INFO(axom::fmt::format("Total Size/State Size={}",
-                              total_size / state_size));
+  SLIC_INFO(
+    axom::fmt::format("Total Size/State Size={}", total_size / state_size));
   SLIC_INFO(axom::fmt::format("Num of uint8={}", num_uint8s));
 
   // write shape
@@ -384,57 +385,123 @@ void test_external_user_defined_data()
 
 TEST(sidre, OneD_double_readandwrite) { test_user_defined_data<double, 1>(); }
 
-TEST(sidre, OneD_StateOne_readandwrite) { test_user_defined_data<StateOne, 1>(); }
+TEST(sidre, OneD_StateOne_readandwrite)
+{
+  test_user_defined_data<StateOne, 1>();
+}
 
-TEST(sidre, OneD_StateTwo_readandwrite) { test_user_defined_data<StateTwo, 1>(); }
+TEST(sidre, OneD_StateTwo_readandwrite)
+{
+  test_user_defined_data<StateTwo, 1>();
+}
 
-TEST(sidre, OneD_StateThree_readandwrite) { test_user_defined_data<StateThree, 1>(); }
+TEST(sidre, OneD_StateThree_readandwrite)
+{
+  test_user_defined_data<StateThree, 1>();
+}
 
-TEST(sidre, OneD_StateTensorSmall_readandwrite) { test_user_defined_data<StateTensorSmall, 1>(); }
+TEST(sidre, OneD_StateTensorSmall_readandwrite)
+{
+  test_user_defined_data<StateTensorSmall, 1>();
+}
 
-TEST(sidre, OneD_StateTensorLarge_readandwrite) { test_user_defined_data<StateTensorLarge, 1>(); }
+TEST(sidre, OneD_StateTensorLarge_readandwrite)
+{
+  test_user_defined_data<StateTensorLarge, 1>();
+}
 
 //-------------------------
 
 TEST(sidre, TwoD_double_readandwrite) { test_user_defined_data<double, 2>(); }
 
-TEST(sidre, TwoD_StateOne_readandwrite) { test_user_defined_data<StateOne, 2>(); }
+TEST(sidre, TwoD_StateOne_readandwrite)
+{
+  test_user_defined_data<StateOne, 2>();
+}
 
-TEST(sidre, TwoD_StateTwo_readandwrite) { test_user_defined_data<StateTwo, 2>(); }
+TEST(sidre, TwoD_StateTwo_readandwrite)
+{
+  test_user_defined_data<StateTwo, 2>();
+}
 
-TEST(sidre, TwoD_StateThree_readandwrite) { test_user_defined_data<StateThree, 2>(); }
+TEST(sidre, TwoD_StateThree_readandwrite)
+{
+  test_user_defined_data<StateThree, 2>();
+}
 
-TEST(sidre, TwoD_StateTensorSmall_readandwrite) { test_user_defined_data<StateTensorSmall, 2>(); }
+TEST(sidre, TwoD_StateTensorSmall_readandwrite)
+{
+  test_user_defined_data<StateTensorSmall, 2>();
+}
 
-TEST(sidre, TwoD_StateTensorLarge_readandwrite) { test_user_defined_data<StateTensorLarge, 2>(); }
+TEST(sidre, TwoD_StateTensorLarge_readandwrite)
+{
+  test_user_defined_data<StateTensorLarge, 2>();
+}
 
 //------------------------------------------------------------------------------
 
-TEST(sidre, OneD_double_external_readandwrite) { test_external_user_defined_data<double, 1>(); }
+TEST(sidre, OneD_double_external_readandwrite)
+{
+  test_external_user_defined_data<double, 1>();
+}
 
-TEST(sidre, OneD_StateOne_external_readandwrite) { test_external_user_defined_data<StateOne, 1>(); }
+TEST(sidre, OneD_StateOne_external_readandwrite)
+{
+  test_external_user_defined_data<StateOne, 1>();
+}
 
-TEST(sidre, OneD_StateTwo_external_readandwrite) { test_external_user_defined_data<StateTwo, 1>(); }
+TEST(sidre, OneD_StateTwo_external_readandwrite)
+{
+  test_external_user_defined_data<StateTwo, 1>();
+}
 
-TEST(sidre, OneD_StateThree_external_readandwrite) { test_external_user_defined_data<StateThree, 1>(); }
+TEST(sidre, OneD_StateThree_external_readandwrite)
+{
+  test_external_user_defined_data<StateThree, 1>();
+}
 
-TEST(sidre, OneD_StateTensorSmall_external_readandwrite) { test_external_user_defined_data<StateTensorSmall, 1>(); }
+TEST(sidre, OneD_StateTensorSmall_external_readandwrite)
+{
+  test_external_user_defined_data<StateTensorSmall, 1>();
+}
 
-TEST(sidre, OneD_StateTensorLarge_external_readandwrite) { test_external_user_defined_data<StateTensorLarge, 1>(); }
+TEST(sidre, OneD_StateTensorLarge_external_readandwrite)
+{
+  test_external_user_defined_data<StateTensorLarge, 1>();
+}
 
 //-------------------------
 
-TEST(sidre, TwoD_double_external_readandwrite) { test_external_user_defined_data<double, 2>(); }
+TEST(sidre, TwoD_double_external_readandwrite)
+{
+  test_external_user_defined_data<double, 2>();
+}
 
-TEST(sidre, TwoD_StateOne_external_readandwrite) { test_external_user_defined_data<StateOne, 2>(); }
+TEST(sidre, TwoD_StateOne_external_readandwrite)
+{
+  test_external_user_defined_data<StateOne, 2>();
+}
 
-TEST(sidre, TwoD_StateTwo_external_readandwrite) { test_external_user_defined_data<StateTwo, 2>(); }
+TEST(sidre, TwoD_StateTwo_external_readandwrite)
+{
+  test_external_user_defined_data<StateTwo, 2>();
+}
 
-TEST(sidre, TwoD_StateThree_external_readandwrite) { test_external_user_defined_data<StateThree, 2>(); }
+TEST(sidre, TwoD_StateThree_external_readandwrite)
+{
+  test_external_user_defined_data<StateThree, 2>();
+}
 
-TEST(sidre, TwoD_StateTensorSmall_external_readandwrite) { test_external_user_defined_data<StateTensorSmall, 2>(); }
+TEST(sidre, TwoD_StateTensorSmall_external_readandwrite)
+{
+  test_external_user_defined_data<StateTensorSmall, 2>();
+}
 
-TEST(sidre, TwoD_StateTensorLarge_external_readandwrite) { test_external_user_defined_data<StateTensorLarge, 2>(); }
+TEST(sidre, TwoD_StateTensorLarge_external_readandwrite)
+{
+  test_external_user_defined_data<StateTensorLarge, 2>();
+}
 
 //----------------------------------------------------------------------
 int main(int argc, char* argv[])

--- a/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
+++ b/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
@@ -13,6 +13,79 @@ using axom::sidre::View;
 
 //-----Mock Serac Structs------------------------------------------------------
 
+/**
+ * @brief Arbitrary-rank tensor class
+ * @tparam T The type stored at each index
+ * @tparam n The dimensions of the tensor
+ */
+template <typename T, int... n>
+struct tensor;
+
+template <typename T, int m, int... n>
+struct tensor<T, m, n...>
+{
+  template <typename i_type>
+  constexpr auto& operator()(i_type i)
+  {
+    return data[i];
+  }
+  template <typename i_type>
+  constexpr auto& operator()(i_type i) const
+  {
+    return data[i];
+  }
+  template <typename i_type, typename... jklm_type>
+  constexpr auto& operator()(i_type i, jklm_type... jklm)
+  {
+    return data[i](jklm...);
+  }
+  template <typename i_type, typename... jklm_type>
+  constexpr auto& operator()(i_type i, jklm_type... jklm) const
+  {
+    return data[i](jklm...);
+  }
+
+  constexpr auto& operator[](int i) { return data[i]; }
+  constexpr const auto& operator[](int i) const { return data[i]; }
+
+  tensor<T, n...> data[m];
+};
+
+template <typename T, int m>
+struct tensor<T, m>
+{
+  template <typename i_type>
+  constexpr auto& operator()(i_type i)
+  {
+    return data[i];
+  }
+  template <typename i_type>
+  constexpr auto& operator()(i_type i) const
+  {
+    return data[i];
+  }
+  constexpr auto& operator[](int i) { return data[i]; }
+  constexpr const auto& operator[](int i) const { return data[i]; }
+
+  template <int last_dimension = m,
+            typename = typename std::enable_if<last_dimension == 1>::type>
+  constexpr operator T()
+  {
+    return data[0];
+  }
+
+  template <int last_dimension = m,
+            typename = typename std::enable_if<last_dimension == 1>::type>
+  constexpr operator T() const
+  {
+    return data[0];
+  }
+
+  T data[m];
+};
+
+//---------------------
+
 template <typename T>
 bool check(const T&, double)
 {
@@ -25,65 +98,6 @@ void fill(T&, double)
 {
   SLIC_ERROR("You didn't implement a specialization for fill");
 }
-
-//---------------------
-
-template <typename T, std::size_t Rows, std::size_t Cols>
-class Tensor
-{
-public:
-  // Constructor to initialize all elements to a specific value
-  Tensor(const T& value = T())
-  {
-    for(auto& row : data)
-    {
-      row.fill(value);
-    }
-  }
-
-  // Constructor to initialize from an initializer list
-  Tensor(std::initializer_list<std::initializer_list<T>> init)
-  {
-    size_t row = 0;
-    for(auto& rowData : init)
-    {
-      size_t col = 0;
-      for(auto& element : rowData)
-      {
-        data[row][col++] = element;
-      }
-      row++;
-    }
-  }
-
-  // Accessor for elements (read/write)
-  T& at(size_t row, size_t col) { return data[row][col]; }
-
-  // Const accessor for elements (read-only)
-  const T& at(size_t row, size_t col) const { return data[row][col]; }
-
-  // Get tensor dimensions
-  std::pair<size_t, size_t> dimensions() const { return {Rows, Cols}; }
-
-  // Function to return a string representation of the tensor
-  std::string to_string() const
-  {
-    std::ostringstream oss;
-    for(const auto& row : data)
-    {
-      oss << "[ ";
-      for(const auto& elem : row)
-      {
-        oss << elem << " ";
-      }
-      oss << "]\n";
-    }
-    return oss.str();
-  }
-
-private:
-  std::array<std::array<T, Cols>, Rows> data;
-};
 
 //---------------------
 
@@ -167,45 +181,98 @@ void fill(StateThree& state, double value)
 
 struct StateTensor
 {
-  Tensor<double, 2, 2> t;
+  //tensor<double, 2, 2> t;
+  tensor<double, 2> t;
   double x;
 };
 
 template <>
 bool check(const StateTensor& state, double value)
 {
-  return (state.t.at(0, 0) == value) && (state.t.at(0, 1) == (value + 1)) &&
-    (state.t.at(1, 0) == (value + 2)) && (state.t.at(1, 1) == (value + 3)) &&
+  // SLIC_INFO(axom::fmt::format("check({}, {}, {}, {}), {}",
+  //                             state.t(0, 0),
+  //                             state.t(0, 1),
+  //                             state.t(1, 0),
+  //                             state.t(1, 1),
+  //                             state.x));
+
+  // return (state.t(0, 0) == value) && (state.t(0, 1) == (value + 1)) &&
+  //   (state.t(1, 0) == (value + 2)) && (state.t(1, 1) == (value + 3)) &&
+  //   (state.x == (value + 4));
+
+  SLIC_INFO(
+    axom::fmt::format("check({}, {}), {}", state.t(0), state.t(1), state.x));
+
+  return (state.t(0) == value) && (state.t(1) == (value + 1)) &&
     (state.x == (value + 4));
 }
 
 template <>
 void fill(StateTensor& state, double value)
 {
-  state.t = {{value, value + 1}, {value + 2, value + 3}};
+  // state.t(0,0) = value;
+  // state.t(0,1) = value + 1;
+  // state.t(1,0) = value + 2;
+  // state.t(1,1) = value + 3;
+  state.t(0) = value;
+  state.t(1) = value + 1;
   state.x = value + 4;
 }
 
 //---------------------
 
-template <typename T>
-using QuadratureData1D = axom::Array<T, 1>;
-template <typename T>
-using QuadratureData2D = axom::Array<T, 2>;
+template <typename T, int DIM>
+void fill_array(T, int, bool)
+{
+  SLIC_ERROR("You didn't implement the fill array of this type.");
+}
+
+template <typename T, int DIM>
+void check_array(T)
+{
+  SLIC_ERROR("You didn't implement the check array of this type.");
+}
+
+template <typename T, int DIM>
+void fill_array(axom::Array<T, DIM>& states, double fill_value, bool increment)
+{
+  int count = 0;
+  for(auto& state : states)
+  {
+    fill(state, fill_value);
+    if(increment)
+    {
+      fill_value++;
+    }
+    count++;
+  }
+  SLIC_INFO(
+    axom::fmt::format("filled {} states with end value {}", count, fill_value));
+}
+
+template <typename T, int DIM>
+void check_array(axom::Array<T, DIM> states)
+{
+  int count = 0;
+  double check_value = 0;
+  for(auto& state : states)
+  {
+    EXPECT_TRUE(check(state, check_value++));
+    count++;
+  }
+  SLIC_INFO(
+    axom::fmt::format("checked {} states with end value {}", count, check_value));
+}
 
 //------------------------------------------------------------------------------
 
-template <typename T>
+template <typename T, int DIM>
 void test_user_defined_data()
 {
   // populate data
   constexpr IndexType size = 10;
-  QuadratureData1D<T> states(size, size);
-  IndexType i = 0;
-  for(auto& state : states)
-  {
-    fill(state, i++);
-  }
+  axom::Array<T, DIM> states(size, size);
+  fill_array(states, 0, true);
 
   // Create datastore
   DataStore ds;
@@ -220,6 +287,12 @@ void test_user_defined_data()
   qd_group->createViewScalar("num_states", num_states);
   qd_group->createViewScalar("state_size", state_size);
   qd_group->createViewScalar("total_size", total_size);
+  SLIC_INFO(axom::fmt::format("Num of States={}", num_states));
+  SLIC_INFO(axom::fmt::format("State Size={}", state_size));
+  SLIC_INFO(axom::fmt::format("Total Size={}", total_size));
+  SLIC_INFO(axom::fmt::format("Double Size={}", sizeof(double)));
+  SLIC_INFO(axom::fmt::format("Total Size/Double Size={}",
+                              total_size / sizeof(double)));
 
   // write data to datastore as bytes
   View* data_view =
@@ -228,32 +301,22 @@ void test_user_defined_data()
   memcpy(sidre_state_data, states.data(), static_cast<std::size_t>(total_size));
 
   // mess with data before overriding it back to original in sidre
-  fill(states[0], 123);
-  fill(states[size / 2], 456);
-  fill(states[size - 1], 789);
+  fill_array(states, -1, false);
 
   // Copy original data back over local data
   memcpy(states.data(), sidre_state_data, static_cast<std::size_t>(total_size));
 
   // Test data is back to original
-  i = 0;
-  for(auto& state : states)
-  {
-    EXPECT_TRUE(check(state, i++));
-  }
+  check_array(states);
 }
 
-template <typename T>
+template <typename T, int DIM>
 void test_external_user_defined_data()
 {
   // populate data
   constexpr IndexType size = 10;
-  QuadratureData1D<T> states(size, size);
-  IndexType i = 0;
-  for(auto& state : states)
-  {
-    fill(state, i++);
-  }
+  axom::Array<T, DIM> states(size, size);
+  fill_array(states, 0, true);
 
   // Create datastore
   DataStore ds;
@@ -281,11 +344,8 @@ void test_external_user_defined_data()
   qd_group->save(filename);
 
   // Create new array to fill with saved data
-  QuadratureData1D<T> saved_states(size, size);
-  for(auto& state : saved_states)
-  {
-    fill(state, -1);
-  }
+  axom::Array<T, DIM> saved_states(size, size);
+  fill_array(saved_states, -1, false);
 
   // Load data into new array
   Group* new_qd_group = ds.getRoot()->createGroup("new_quadraturedata");
@@ -295,43 +355,48 @@ void test_external_user_defined_data()
   new_states_view->setExternalDataPtr(saved_states.data());
   new_qd_group->loadExternalData(filename);
 
-  // Test data is back to original
-  i = 0;
-  for(auto& state : saved_states)
-  {
-    EXPECT_TRUE(check(state, i++));
-  }
+  // Test data was read into the new location and overwrote the bad data
+  check_array(saved_states);
 }
 
 //------------------------------------------------------------------------------
 
-TEST(sidre, QD_double_readandwrite) { test_user_defined_data<double>(); }
+TEST(sidre, OneD_double_readandwrite) { test_user_defined_data<double, 1>(); }
 
-TEST(sidre, QD_StateOne_readandwrite) { test_user_defined_data<StateOne>(); }
+// TEST(sidre, OneD_StateOne_readandwrite) { test_user_defined_data<StateOne, 1>(); }
 
-TEST(sidre, QD_StateTwo_readandwrite) { test_user_defined_data<StateTwo>(); }
+// TEST(sidre, OneD_StateTwo_readandwrite) { test_user_defined_data<StateTwo, 1>(); }
 
-TEST(sidre, QD_StateThree_readandwrite)
+// TEST(sidre, OneD_StateThree_readandwrite) { test_user_defined_data<StateThree, 1>(); }
+
+// TEST(sidre, OneD_StateTensor_readandwrite) { test_user_defined_data<StateTensor, 1>(); }
+
+// //-------------------------
+
+// TEST(sidre, TwoD_double_readandwrite) { test_user_defined_data<double, 2>(); }
+
+// TEST(sidre, TwoD_StateOne_readandwrite) { test_user_defined_data<StateOne, 2>(); }
+
+// TEST(sidre, TwoD_StateTwo_readandwrite) { test_user_defined_data<StateTwo, 2>(); }
+
+// TEST(sidre, TwoD_StateThree_readandwrite) { test_user_defined_data<StateThree, 2>(); }
+
+TEST(sidre, TwoD_StateTensor_readandwrite)
 {
-  test_user_defined_data<StateThree>();
-}
-
-TEST(sidre, QD_StateTensor_readandwrite)
-{
-  test_user_defined_data<StateTensor>();
+  test_user_defined_data<StateTensor, 2>();
 }
 
 //------------------------------------------------------------------------------
 
-TEST(sidre, QD_double_external_readandwrite)
-{
-  test_external_user_defined_data<double>();
-}
+// TEST(sidre, OneD_double_external_readandwrite) { test_external_user_defined_data<double, 1>(); }
 
-TEST(sidre, QD_StateOne_external_readandwrite)
-{
-  test_external_user_defined_data<StateOne>();
-}
+// TEST(sidre, OneD_StateOne_external_readandwrite) { test_external_user_defined_data<StateOne, 1>(); }
+
+// TEST(sidre, OneD_StateTwo_external_readandwrite) { test_external_user_defined_data<StateTwo, 1>(); }
+
+// TEST(sidre, OneD_StateThree_external_readandwrite) { test_external_user_defined_data<StateThree, 1>(); }
+
+// TEST(sidre, OneD_StateTensor_external_readandwrite) { test_external_user_defined_data<StateTensor, 1>(); }
 
 //----------------------------------------------------------------------
 int main(int argc, char* argv[])

--- a/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
+++ b/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
@@ -11,6 +11,14 @@ using axom::sidre::Group;
 using axom::sidre::IndexType;
 using axom::sidre::View;
 
+// This test is meant to mock how Serac stores and loads Quadrature Data.
+// The data is stored in Axom Array's of material states and are a user defined
+// structure of POD types.
+//
+// There are two types of tests, one is where the data is managed by Sidre and
+// the other is where the data is external to sidre and is saved and loaded to
+// disk. The latter is what Serac is doing.
+
 //-----Mock Serac Structs------------------------------------------------------
 
 /**

--- a/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
+++ b/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
@@ -365,7 +365,7 @@ void test_external_user_defined_data()
                                   num_uint8s,
                                   states.data());
 
-  // Save the array data in to a file
+  // Save the array data into a file
   std::string filename = "sidre_external_states";
   root->save(filename);
 
@@ -446,7 +446,7 @@ void test_MFEMSidreDataCollection_user_defined_data()
                                   num_uint8s,
                                   states.data());
 
-  // Save the array data in to a file
+  // Save the array data into a file
   #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
   sdc_writer.SetComm(MPI_COMM_WORLD);
   #endif

--- a/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
+++ b/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
@@ -1,0 +1,346 @@
+// Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "gtest/gtest.h"
+#include "axom/sidre.hpp"
+
+using axom::sidre::DataStore;
+using axom::sidre::Group;
+using axom::sidre::View;
+using axom::sidre::indexIsValid;
+using axom::sidre::IndexType;
+using axom::sidre::InvalidIndex;
+using axom::sidre::InvalidName;
+using axom::sidre::nameIsValid;
+
+//-----Mock Serac Structs------------------------------------------------------
+
+template <typename T>
+bool check(const T&, double)
+{
+  SLIC_ERROR("You didn't implement a specialization for check");
+  return false;
+}
+
+template <typename T>
+void fill(T&, double)
+{
+  SLIC_ERROR("You didn't implement a specialization for fill");
+}
+
+//---------------------
+
+template <typename T, std::size_t Rows, std::size_t Cols>
+class Tensor {
+public:
+    // Constructor to initialize all elements to a specific value
+    Tensor(const T& value = T()) {
+        for (auto& row : data) {
+            row.fill(value);
+        }
+    }
+
+    // Constructor to initialize from an initializer list
+    Tensor(std::initializer_list<std::initializer_list<T>> init) {
+        size_t row = 0;
+        for (auto& rowData : init) {
+            size_t col = 0;
+            for (auto& element : rowData) {
+                data[row][col++] = element;
+            }
+            row++;
+        }
+    }
+
+    // Accessor for elements (read/write)
+    T& at(size_t row, size_t col) {
+        return data[row][col];
+    }
+
+    // Const accessor for elements (read-only)
+    const T& at(size_t row, size_t col) const {
+        return data[row][col];
+    }
+
+    // Get tensor dimensions
+    std::pair<size_t, size_t> dimensions() const {
+        return {Rows, Cols};
+    }
+
+    // Print the tensor for demonstration purposes
+    void print() const {
+        for (const auto& row : data) {
+            for (const auto& element : row) {
+                std::cout << element << " ";
+            }
+            std::cout << "\n";
+        }
+    }
+
+private:
+    std::array<std::array<T, Cols>, Rows> data;
+};
+
+//---------------------
+
+template <>
+bool check(const double& state, double value)
+{
+  SLIC_INFO(axom::fmt::format("{} == {}", state, value));
+  return state == value;
+}
+
+template <>
+void fill(double& state, double value)
+{
+  state = value;
+}
+
+//---------------------
+
+struct StateOne {
+  double x;
+};
+
+template <>
+bool check(const StateOne& state, double value)
+{
+  SLIC_INFO(axom::fmt::format("{} == {}", state.x, value));
+  return state.x == value;
+}
+
+template <>
+void fill(StateOne& state, double value)
+{
+  state.x = value;
+}
+
+//---------------------
+
+struct StateTwo {
+  double x;
+  double y;
+};
+
+template <>
+bool check(const StateTwo& state, double value)
+{
+  return (state.x == value) && (state.y == (value + 1));
+}
+
+template <>
+void fill(StateTwo& state, double value)
+{
+  state.x = value;
+  state.y = value + 1;
+}
+
+//---------------------
+
+struct StateThree {
+  double x;
+  double y;
+  double z;
+};
+
+template <>
+bool check(const StateThree& state, double value)
+{
+  return (state.x == value) && (state.y == (value + 1)) && (state.z == (value + 2));
+}
+
+template <>
+void fill(StateThree& state, double value)
+{
+  state.x = value;
+  state.y = value + 1;
+  state.z = value + 2;
+}
+
+//---------------------
+
+struct StateTensor {
+  Tensor<double, 2, 2> t;
+  double x;
+};
+
+template <>
+bool check(const StateTensor& state, double value)
+{
+  return (state.t.at(0,0) == value) && (state.t.at(0,1) == (value + 1)) &&
+         (state.t.at(1,0) == (value + 2)) && (state.t.at(1,1) == (value + 3)) &&
+         (state.x == (value + 4));
+}
+
+template <>
+void fill(StateTensor& state, double value)
+{
+  state.t = {{value, value + 1}, {value + 2, value + 3}};
+  state.x = value + 4;
+}
+
+//---------------------
+
+template <typename T>
+using QuadratureData1D = axom::Array<T, 1>;
+template <typename T>
+using QuadratureData2D = axom::Array<T, 2>;
+
+//------------------------------------------------------------------------------
+
+template <typename T>
+void test_user_defined_data()
+{
+  // populate data
+  constexpr IndexType size = 10;
+  QuadratureData1D<T> states(size, size);
+  IndexType i = 0;
+  for(auto& state: states){
+    fill(state, i++);
+  }
+
+  // Create datastore
+  DataStore ds;
+  Group* qd_group = ds.getRoot()->createGroup("quadraturedata");
+
+  // get size
+  auto num_states = static_cast<IndexType>(states.size());
+  auto state_size = static_cast<IndexType>(sizeof(states[0]));
+  auto total_size = num_states * state_size;
+
+  // write shape
+  qd_group->createViewScalar("num_states", num_states);
+  qd_group->createViewScalar("state_size", state_size);
+  qd_group->createViewScalar("total_size", total_size);
+
+  // write data to datastore as bytes
+  View* data_view = qd_group->createViewAndAllocate("states",
+                                                    axom::sidre::UINT8_ID,
+                                                    total_size);
+  std::uint8_t* sidre_state_data = data_view->getData();
+  memcpy(sidre_state_data, states.data(), static_cast<std::size_t>(total_size));
+
+  // mess with data before overriding it back to original in sidre
+  fill(states[0], 123);
+  fill(states[size/2], 456);
+  fill(states[size-1], 789);
+
+  // Copy original data back over local data
+  memcpy(states.data(), sidre_state_data, static_cast<std::size_t>(total_size));
+
+  // Test data is back to original
+  i = 0;
+  for(auto& state: states){
+    EXPECT_TRUE(check(state, i++));
+  }
+}
+
+template <typename T>
+void test_external_user_defined_data()
+{
+  // populate data
+  constexpr IndexType size = 10;
+  QuadratureData1D<T> states(size, size);
+  IndexType i = 0;
+  for(auto& state: states){
+    fill(state, i++);
+  }
+
+  // Create datastore
+  DataStore ds;
+  Group* qd_group = ds.getRoot()->createGroup("quadraturedata");
+
+  // get size
+  auto num_states = static_cast<IndexType>(states.size());
+  auto state_size = static_cast<IndexType>(sizeof(states[0]));
+  auto total_size = num_states * state_size;
+  auto num_uint8s = total_size / sizeof(axom::sidre::UINT8_ID);
+
+  // write shape
+  qd_group->createViewScalar("num_states", num_states);
+  qd_group->createViewScalar("state_size", state_size);
+  qd_group->createViewScalar("total_size", total_size);
+
+  // Add states as an external buffer
+  View* states_view = qd_group->createView("states");
+  states_view->setExternalDataPtr(axom::sidre::UINT8_ID, num_uint8s, states.data());
+
+  // Save the array data in to a file
+  std::string filename = "sidre_external_quadraturedata";
+  qd_group->save(filename);
+
+  // Create new array to fill with saved data
+  QuadratureData1D<T> saved_states(size, size);
+  for(auto& state: saved_states){
+    fill(state, -1);
+  }
+
+  // Load data into new array
+  Group* new_qd_group = ds.getRoot()->createGroup("new_quadraturedata");
+  new_qd_group->load(filename);
+  EXPECT_TRUE(new_qd_group->hasView("states"));
+  View* new_states_view = new_qd_group->getView("states");
+  new_states_view->setExternalDataPtr(saved_states.data());
+  new_qd_group->loadExternalData(filename);
+
+  // Test data is back to original
+  i = 0;
+  for(auto& state: saved_states){
+    EXPECT_TRUE(check(state, i++));
+  }
+}
+
+//------------------------------------------------------------------------------
+
+TEST(sidre, QD_double_readandwrite)
+{
+  test_user_defined_data<double>();
+}
+
+TEST(sidre, QD_StateOne_readandwrite)
+{
+  test_user_defined_data<StateOne>();
+}
+
+TEST(sidre, QD_StateTwo_readandwrite)
+{
+  test_user_defined_data<StateTwo>();
+}
+
+TEST(sidre, QD_StateThree_readandwrite)
+{
+  test_user_defined_data<StateThree>();
+}
+
+TEST(sidre, QD_StateTensor_readandwrite)
+{
+  test_user_defined_data<StateTensor>();
+}
+
+//------------------------------------------------------------------------------
+
+TEST(sidre, QD_double_external_readandwrite)
+{
+  test_external_user_defined_data<double>();
+}
+
+TEST(sidre, QD_StateOne_external_readandwrite)
+{
+  test_external_user_defined_data<StateOne>();
+}
+
+//----------------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+  int result = 0;
+
+  ::testing::InitGoogleTest(&argc, argv);
+  axom::slic::SimpleLogger logger;
+
+  result = RUN_ALL_TESTS();
+
+  return result;
+}
+

--- a/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
+++ b/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
@@ -624,7 +624,7 @@ TEST(sidre, OneD_double_MFEMSidreDataCollection_readandwrite)
 {
   test_MFEMSidreDataCollection_user_defined_data<double, 1>();
 }
-/*
+
 TEST(sidre, OneD_StateOne_MFEMSidreDataCollection_readandwrite)
 {
   test_MFEMSidreDataCollection_user_defined_data<StateOne, 1>();
@@ -681,7 +681,7 @@ TEST(sidre, TwoD_StateTensorLarge_MFEMSidreDataCollection_readandwrite)
 {
   test_MFEMSidreDataCollection_user_defined_data<StateTensorLarge, 2>();
 }
-*/
+
 #endif  // AXOM_USE_MFEM
 
 //----------------------------------------------------------------------

--- a/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
+++ b/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
@@ -8,8 +8,8 @@
 
 using axom::sidre::DataStore;
 using axom::sidre::Group;
-using axom::sidre::View;
 using axom::sidre::IndexType;
+using axom::sidre::View;
 
 //-----Mock Serac Structs------------------------------------------------------
 
@@ -29,54 +29,60 @@ void fill(T&, double)
 //---------------------
 
 template <typename T, std::size_t Rows, std::size_t Cols>
-class Tensor {
+class Tensor
+{
 public:
-    // Constructor to initialize all elements to a specific value
-    Tensor(const T& value = T()) {
-        for (auto& row : data) {
-            row.fill(value);
-        }
+  // Constructor to initialize all elements to a specific value
+  Tensor(const T& value = T())
+  {
+    for(auto& row : data)
+    {
+      row.fill(value);
     }
+  }
 
-    // Constructor to initialize from an initializer list
-    Tensor(std::initializer_list<std::initializer_list<T>> init) {
-        size_t row = 0;
-        for (auto& rowData : init) {
-            size_t col = 0;
-            for (auto& element : rowData) {
-                data[row][col++] = element;
-            }
-            row++;
-        }
+  // Constructor to initialize from an initializer list
+  Tensor(std::initializer_list<std::initializer_list<T>> init)
+  {
+    size_t row = 0;
+    for(auto& rowData : init)
+    {
+      size_t col = 0;
+      for(auto& element : rowData)
+      {
+        data[row][col++] = element;
+      }
+      row++;
     }
+  }
 
-    // Accessor for elements (read/write)
-    T& at(size_t row, size_t col) {
-        return data[row][col];
-    }
+  // Accessor for elements (read/write)
+  T& at(size_t row, size_t col) { return data[row][col]; }
 
-    // Const accessor for elements (read-only)
-    const T& at(size_t row, size_t col) const {
-        return data[row][col];
-    }
+  // Const accessor for elements (read-only)
+  const T& at(size_t row, size_t col) const { return data[row][col]; }
 
-    // Get tensor dimensions
-    std::pair<size_t, size_t> dimensions() const {
-        return {Rows, Cols};
-    }
+  // Get tensor dimensions
+  std::pair<size_t, size_t> dimensions() const { return {Rows, Cols}; }
 
-    // Print the tensor for demonstration purposes
-    void print() const {
-        for (const auto& row : data) {
-            for (const auto& element : row) {
-                std::cout << element << " ";
-            }
-            std::cout << "\n";
-        }
+  // Function to return a string representation of the tensor
+  std::string to_string() const
+  {
+    std::ostringstream oss;
+    for(const auto& row : data)
+    {
+      oss << "[ ";
+      for(const auto& elem : row)
+      {
+        oss << elem << " ";
+      }
+      oss << "]\n";
     }
+    return oss.str();
+  }
 
 private:
-    std::array<std::array<T, Cols>, Rows> data;
+  std::array<std::array<T, Cols>, Rows> data;
 };
 
 //---------------------
@@ -96,7 +102,8 @@ void fill(double& state, double value)
 
 //---------------------
 
-struct StateOne {
+struct StateOne
+{
   double x;
 };
 
@@ -115,7 +122,8 @@ void fill(StateOne& state, double value)
 
 //---------------------
 
-struct StateTwo {
+struct StateTwo
+{
   double x;
   double y;
 };
@@ -135,7 +143,8 @@ void fill(StateTwo& state, double value)
 
 //---------------------
 
-struct StateThree {
+struct StateThree
+{
   double x;
   double y;
   double z;
@@ -144,7 +153,8 @@ struct StateThree {
 template <>
 bool check(const StateThree& state, double value)
 {
-  return (state.x == value) && (state.y == (value + 1)) && (state.z == (value + 2));
+  return (state.x == value) && (state.y == (value + 1)) &&
+    (state.z == (value + 2));
 }
 
 template <>
@@ -157,7 +167,8 @@ void fill(StateThree& state, double value)
 
 //---------------------
 
-struct StateTensor {
+struct StateTensor
+{
   Tensor<double, 2, 2> t;
   double x;
 };
@@ -165,9 +176,9 @@ struct StateTensor {
 template <>
 bool check(const StateTensor& state, double value)
 {
-  return (state.t.at(0,0) == value) && (state.t.at(0,1) == (value + 1)) &&
-         (state.t.at(1,0) == (value + 2)) && (state.t.at(1,1) == (value + 3)) &&
-         (state.x == (value + 4));
+  return (state.t.at(0, 0) == value) && (state.t.at(0, 1) == (value + 1)) &&
+    (state.t.at(1, 0) == (value + 2)) && (state.t.at(1, 1) == (value + 3)) &&
+    (state.x == (value + 4));
 }
 
 template <>
@@ -193,7 +204,8 @@ void test_user_defined_data()
   constexpr IndexType size = 10;
   QuadratureData1D<T> states(size, size);
   IndexType i = 0;
-  for(auto& state: states){
+  for(auto& state : states)
+  {
     fill(state, i++);
   }
 
@@ -212,23 +224,23 @@ void test_user_defined_data()
   qd_group->createViewScalar("total_size", total_size);
 
   // write data to datastore as bytes
-  View* data_view = qd_group->createViewAndAllocate("states",
-                                                    axom::sidre::UINT8_ID,
-                                                    total_size);
+  View* data_view =
+    qd_group->createViewAndAllocate("states", axom::sidre::UINT8_ID, total_size);
   std::uint8_t* sidre_state_data = data_view->getData();
   memcpy(sidre_state_data, states.data(), static_cast<std::size_t>(total_size));
 
   // mess with data before overriding it back to original in sidre
   fill(states[0], 123);
-  fill(states[size/2], 456);
-  fill(states[size-1], 789);
+  fill(states[size / 2], 456);
+  fill(states[size - 1], 789);
 
   // Copy original data back over local data
   memcpy(states.data(), sidre_state_data, static_cast<std::size_t>(total_size));
 
   // Test data is back to original
   i = 0;
-  for(auto& state: states){
+  for(auto& state : states)
+  {
     EXPECT_TRUE(check(state, i++));
   }
 }
@@ -240,7 +252,8 @@ void test_external_user_defined_data()
   constexpr IndexType size = 10;
   QuadratureData1D<T> states(size, size);
   IndexType i = 0;
-  for(auto& state: states){
+  for(auto& state : states)
+  {
     fill(state, i++);
   }
 
@@ -261,7 +274,9 @@ void test_external_user_defined_data()
 
   // Add states as an external buffer
   View* states_view = qd_group->createView("states");
-  states_view->setExternalDataPtr(axom::sidre::UINT8_ID, num_uint8s, states.data());
+  states_view->setExternalDataPtr(axom::sidre::UINT8_ID,
+                                  num_uint8s,
+                                  states.data());
 
   // Save the array data in to a file
   std::string filename = "sidre_external_quadraturedata";
@@ -269,7 +284,8 @@ void test_external_user_defined_data()
 
   // Create new array to fill with saved data
   QuadratureData1D<T> saved_states(size, size);
-  for(auto& state: saved_states){
+  for(auto& state : saved_states)
+  {
     fill(state, -1);
   }
 
@@ -283,27 +299,19 @@ void test_external_user_defined_data()
 
   // Test data is back to original
   i = 0;
-  for(auto& state: saved_states){
+  for(auto& state : saved_states)
+  {
     EXPECT_TRUE(check(state, i++));
   }
 }
 
 //------------------------------------------------------------------------------
 
-TEST(sidre, QD_double_readandwrite)
-{
-  test_user_defined_data<double>();
-}
+TEST(sidre, QD_double_readandwrite) { test_user_defined_data<double>(); }
 
-TEST(sidre, QD_StateOne_readandwrite)
-{
-  test_user_defined_data<StateOne>();
-}
+TEST(sidre, QD_StateOne_readandwrite) { test_user_defined_data<StateOne>(); }
 
-TEST(sidre, QD_StateTwo_readandwrite)
-{
-  test_user_defined_data<StateTwo>();
-}
+TEST(sidre, QD_StateTwo_readandwrite) { test_user_defined_data<StateTwo>(); }
 
 TEST(sidre, QD_StateThree_readandwrite)
 {
@@ -339,4 +347,3 @@ int main(int argc, char* argv[])
 
   return result;
 }
-

--- a/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
+++ b/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
@@ -9,11 +9,7 @@
 using axom::sidre::DataStore;
 using axom::sidre::Group;
 using axom::sidre::View;
-using axom::sidre::indexIsValid;
 using axom::sidre::IndexType;
-using axom::sidre::InvalidIndex;
-using axom::sidre::InvalidName;
-using axom::sidre::nameIsValid;
 
 //-----Mock Serac Structs------------------------------------------------------
 

--- a/src/axom/sidre/tests/spio/spio_parallel.hpp
+++ b/src/axom/sidre/tests/spio/spio_parallel.hpp
@@ -495,7 +495,7 @@ TEST(spio_parallel, external_piecemeal_writeread)
 
   // Swap these two sections to show lack of piecemeal loading
 
-  // Section 1: (Works) Load all external arrays
+  // Section 1: (Works) Load all external arrays at a single time
   EXPECT_TRUE(root2->hasGroup("fields1"));
   flds1 = root2->getGroup("fields1");
   EXPECT_TRUE(flds1->hasView("external_array"));

--- a/src/axom/sidre/tests/spio/spio_parallel.hpp
+++ b/src/axom/sidre/tests/spio/spio_parallel.hpp
@@ -493,24 +493,38 @@ TEST(spio_parallel, external_piecemeal_writeread)
 
   reader.read(root2, file_name + ROOT_EXT);
 
-  reader.read(root2->getGroup("fields1"), file_name + ROOT_EXT);
-  EXPECT_TRUE(root2->hasGroup("fields1"));
-  View* view1 = root2->getView("fields1/external_array");
-  view1->setExternalDataPtr(restored_vals1);
-  reader.loadExternalData(root2->getGroup("fields1"), file_name + ROOT_EXT);
-
-  // Swap these two sections to show error
+  // Swap these two sections to show lack of piecemeal loading
 
   // Section 1: (Works) Load all external arrays
-  //reader.loadExternalData(root2, file_name + ROOT_EXT);
+  EXPECT_TRUE(root2->hasGroup("fields1"));
+  flds1 = root2->getGroup("fields1");
+  EXPECT_TRUE(flds1->hasView("external_array"));
+  View* view1 = flds1->getView("external_array");
+  view1->setExternalDataPtr(restored_vals1);
 
-  // Section 2: (Doesn't work) Load external arrays one at a time
-
-  reader.read(root2->getGroup("fields2"), file_name + ROOT_EXT);
   EXPECT_TRUE(root2->hasGroup("fields2"));
-  View* view2 = root2->getView("fields2/external_array");
+  flds2 = root2->getGroup("fields2");
+  EXPECT_TRUE(flds2->hasView("external_array"));
+  View* view2 = flds2->getView("external_array");
   view2->setExternalDataPtr(restored_vals2);
-  reader.loadExternalData(root2->getGroup("fields2"), file_name + ROOT_EXT);
+
+  reader.loadExternalData(root2, file_name + ROOT_EXT);
+
+  // TODO: convert test to this when functionality works
+  // Section 2: (Doesn't work) Load external arrays one at a time
+  // EXPECT_TRUE(root2->hasGroup("fields1"));
+  // flds1 = root2->getGroup("fields1");
+  // EXPECT_TRUE(flds1->hasView("external_array"));
+  // View* view1 = flds1->getView("external_array");
+  // view1->setExternalDataPtr(restored_vals1);
+  // reader.loadExternalData(flds1, file_name + ROOT_EXT);
+
+  // EXPECT_TRUE(root2->hasGroup("fields2"));
+  // flds2 = root2->getGroup("fields2");
+  // EXPECT_TRUE(flds2->hasView("external_array"));
+  // View* view2 = flds2->getView("external_array");
+  // view2->setExternalDataPtr(restored_vals2);
+  // reader.loadExternalData(flds2, file_name + ROOT_EXT);
 
   enum SpioTestResult
   {

--- a/src/axom/sidre/tests/spio/spio_parallel.hpp
+++ b/src/axom/sidre/tests/spio/spio_parallel.hpp
@@ -514,7 +514,6 @@ TEST(spio_parallel, external_piecemeal_writeread)
     SPIO_TEST_SUCCESS = 0,
     HIERARCHY_ERROR = 1 << 0,
     EXT_ARRAY_ERROR = 1 << 1,
-    EXT_UNDESC_ERROR = 1 << 2
   };
   int result = SPIO_TEST_SUCCESS;
 

--- a/src/axom/sidre/tests/spio/spio_parallel.hpp
+++ b/src/axom/sidre/tests/spio/spio_parallel.hpp
@@ -506,7 +506,6 @@ TEST(spio_parallel, external_piecemeal_writeread)
 
   // Section 2: (Doesn't work) Load external arrays one at a time
 
-
   reader.read(root2->getGroup("fields2"), file_name + ROOT_EXT);
   EXPECT_TRUE(root2->hasGroup("fields2"));
   View* view2 = root2->getView("fields2/external_array");


### PR DESCRIPTION
* Fixes `MFEMSidreDataCollection::LoadExternalData` to work on the root of the `DataStore` when in parallel because it is currently required, see #1479 
* Add tests/examples on how to work with external data in the `DataStore`, `IOManager` and `MFEMSidreDataCollection` classes

Enables https://github.com/LLNL/serac/pull/1258