### PR TITLE
Test and documentation for save/load of external Sidre views.

### DIFF
--- a/src/axom/sidre/docs/sphinx/file_io.rst
+++ b/src/axom/sidre/docs/sphinx/file_io.rst
@@ -60,13 +60,16 @@ was originally saved.  This requires a three step process.
    :language: C++
 
 The first step is to call ``load()`` as before.  This will load the entire
-Sidre hierarchy stored in the file, including all ``View`` descriptions,
-but it will *not* allocate storage or load data values for the views with
-external data.  Second, the calling code must provide each external ``View``
-a pointer to valid storage that will hold the external data, using
-``setExternalDataPtr()``.  Finally, ``loadExternalData()`` is called,
-reading the file again to load data values into the provided external data
-locations.
+Sidre hierarchy of groups and views stored in the file.  For views with
+external data, it will load their descriptions that were saved but it will
+*not* allocate storage or load data values for the views with external data.
+Second, the calling code must provide each external ``View`` a pointer to
+valid storage that will hold the external data, using
+``setExternalDataPtr()``.  It is the responsibility of the calling code to
+ensure that the provided external data pointer points to memory that is
+properly allocated and of the correct size.  Finally, ``loadExternalData()``
+is called, reading the file again to load data values into the provided
+external data locations.
 
 Overloads of the ``save()`` and ``load()`` methods that take HDF5 handles and 
 the ``loadExternalData()`` method are used to implement parallel I/O through 

--- a/src/axom/sidre/docs/sphinx/file_io.rst
+++ b/src/axom/sidre/docs/sphinx/file_io.rst
@@ -62,14 +62,13 @@ was originally saved.  This requires a three step process.
 The first step is to call ``load()`` as before.  This will load the entire
 Sidre hierarchy of groups and views stored in the file.  For views with
 external data, it will load their descriptions that were saved but it will
-*not* allocate storage or load data values for the views with external data.
-Second, the calling code must provide each external ``View`` a pointer to
-valid storage that will hold the external data, using
-``setExternalDataPtr()``.  It is the responsibility of the calling code to
-ensure that the provided external data pointer points to memory that is
-properly allocated and of the correct size.  Finally, ``loadExternalData()``
-is called, reading the file again to load data values into the provided
-external data locations.
+*not* allocate storage or load data values for these views.  Second, the
+calling code must provide each external ``View`` a pointer to valid
+storage that will hold the external data, using ``setExternalDataPtr()``.
+It is the responsibility of the calling code to ensure that the provided
+external data pointer points to memory that is properly allocated and of
+the correct size.  Finally, ``loadExternalData()`` is called, reading the
+file again to load data values into the provided external data locations.
 
 Overloads of the ``save()`` and ``load()`` methods that take HDF5 handles and 
 the ``loadExternalData()`` method are used to implement parallel I/O through 

--- a/src/axom/sidre/docs/sphinx/file_io.rst
+++ b/src/axom/sidre/docs/sphinx/file_io.rst
@@ -47,7 +47,7 @@ which omits error-checking and recovery for brevity and clarity.
    :end-before: _serial_io_save_end
    :language: C++
 
-The ``loadExternalData()`` method is used to read "external" data from an HDF5 
+The ``loadExternalData()`` method is used to read external data from an HDF5 
 file created with the ``sidre_hdf5`` protocol.  This is data referred to by 
 *external* views. Such views refer to data that is not stored in Sidre buffers 
 but in an external data allocation.  ``loadExternalData()`` enables the

--- a/src/axom/sidre/docs/sphinx/file_io.rst
+++ b/src/axom/sidre/docs/sphinx/file_io.rst
@@ -50,7 +50,23 @@ which omits error-checking and recovery for brevity and clarity.
 The ``loadExternalData()`` method is used to read "external" data from an HDF5 
 file created with the ``sidre_hdf5`` protocol.  This is data referred to by 
 *external* views. Such views refer to data that is not stored in Sidre buffers 
-but in an external data allocation.
+but in an external data allocation.  ``loadExternalData()`` enables the
+loading of a ``DataStore`` with external data that preserves the state that
+was originally saved.  This requires a three step process.
+
+.. literalinclude:: ../../tests/sidre_external.cpp
+   :start-after: _external_save_load_start
+   :end-before: _external_save_load_end
+   :language: C++
+
+The first step is to call ``load()`` as before.  This will load the entire
+Sidre hierarchy stored in the file, including all ``View`` descriptions,
+but it will *not* allocate storage or load data values for the views with
+external data.  Second, the calling code must provide each external ``View``
+a pointer to valid storage that will hold the external data, using
+``setExternalDataPtr()``.  Finally, ``loadExternalData()`` is called,
+reading the file again to load data values into the provided external data
+locations.
 
 Overloads of the ``save()`` and ``load()`` methods that take HDF5 handles and 
 the ``loadExternalData()`` method are used to implement parallel I/O through 

--- a/src/axom/sidre/tests/sidre_external.cpp
+++ b/src/axom/sidre/tests/sidre_external.cpp
@@ -278,7 +278,7 @@ TEST(sidre_external, verify_external_layout)
   }
 }
 
-#if 0
+#if 1
 //------------------------------------------------------------------------------
 // Test Group::save(), Group::load() with described external views
 // TODO - The save/load functionality needs to be fixed.
@@ -299,37 +299,34 @@ TEST(sidre_external, save_load_external_view)
     ddata[ii] = idata[ii] * 2.0;
   }
 
-  View* iview = root->createView("idata", idata)->apply(INT_ID, len);
-  View* dview = root->createView("ddata", ddata)->apply(DOUBLE_ID, len);
+  root->createView("idata", idata)->apply(INT_ID, len);
+  root->createView("ddata", ddata)->apply(DOUBLE_ID, len);
   EXPECT_EQ(root->getNumViews(), 2u);
 
-//  iview->print();
-//  dview->print();
-
   ds->getRoot()->save("out_sidre_external_save_restore_external_view",
-                      "conduit");
-
-//  ds->print();
-
+                      "sidre_hdf5");
 
   DataStore* ds2 = new DataStore();
-
-  ds2->getRoot()->load("out_sidre_external_save_restore_external_view",
-                       "conduit");
-
-//  ds2->print();
-
   Group* root2 = ds2->getRoot();
+
+  root2->load("out_sidre_external_save_restore_external_view");
+
+  int* new_idata = new int[len];
+  double* new_ddata = new double[len];
+
+  root2->getView("idata")->setExternalDataPtr(new_idata);
+  root2->getView("ddata")->setExternalDataPtr(new_ddata);
+  root2->loadExternalData("out_sidre_external_save_restore_external_view");
 
   EXPECT_EQ(root2->getNumViews(), 2u);
 
-  int* idata_chk = iview->getData();
+  int* idata_chk = root2->getView("idata")->getData();
   for (int ii = 0 ; ii < len ; ++ii)
   {
     EXPECT_EQ(idata_chk[ii], idata[ii]);
   }
 
-  double* ddata_chk = dview->getData();
+  double* ddata_chk = root2->getView("ddata")->getData();
   for (int ii = 0 ; ii < len ; ++ii)
   {
     EXPECT_EQ(ddata_chk[ii], ddata[ii]);
@@ -339,5 +336,7 @@ TEST(sidre_external, save_load_external_view)
   delete ds2;
   delete [] idata;
   delete [] ddata;
+  delete [] new_idata;
+  delete [] new_ddata;
 }
 #endif

--- a/src/axom/sidre/tests/sidre_external.cpp
+++ b/src/axom/sidre/tests/sidre_external.cpp
@@ -19,10 +19,10 @@ using axom::sidre::INT_ID;
 using axom::sidre::View;
 
 /* This test code contains snippets used in the Sidre Sphinx documentation.
- * They begin and end with comments
+ * They begin and end with comments.
  *
- * _external_save_load_start
- * _external_save_load_end
+ * external_save_load_start
+ * external_save_load_end
  */
 
 //------------------------------------------------------------------------------

--- a/src/axom/sidre/tests/sidre_external.cpp
+++ b/src/axom/sidre/tests/sidre_external.cpp
@@ -314,6 +314,12 @@ TEST(sidre_external, save_load_external_view)
   int* new_idata = new int[len];
   double* new_ddata = new double[len];
 
+    for (int ii = 0 ; ii < len ; ++ii)
+  {
+    idata[ii] = -1;
+    ddata[ii] = -2.0;
+  }
+
   root2->getView("idata")->setExternalDataPtr(new_idata);
   root2->getView("ddata")->setExternalDataPtr(new_ddata);
   root2->loadExternalData("out_sidre_external_save_restore_external_view");

--- a/src/axom/sidre/tests/sidre_external.cpp
+++ b/src/axom/sidre/tests/sidre_external.cpp
@@ -290,7 +290,7 @@ TEST(sidre_external, verify_external_layout)
 //------------------------------------------------------------------------------
 TEST(sidre_external, save_load_external_view)
 {
-  DataStore* ds   = new DataStore();
+  DataStore* ds = new DataStore();
   Group* root = ds->getRoot();
 
   constexpr IndexType len = 11;
@@ -298,7 +298,7 @@ TEST(sidre_external, save_load_external_view)
   std::array<int, len> idata;
   std::array<double, len> ddata;
 
-  for (int ii = 0 ; ii < len ; ++ii)
+  for(int ii = 0; ii < len; ++ii)
   {
     idata[ii] = ii;
     ddata[ii] = idata[ii] * 2.0;
@@ -308,8 +308,7 @@ TEST(sidre_external, save_load_external_view)
   root->createView("ddata", ddata.data())->apply(DOUBLE_ID, len);
   EXPECT_EQ(root->getNumViews(), 2u);
 
-  ds->getRoot()->save("sidre_external_save_load_external_view",
-                      "sidre_hdf5");
+  ds->getRoot()->save("sidre_external_save_load_external_view", "sidre_hdf5");
 
   DataStore* ds2 = new DataStore();
   Group* load_group = ds2->getRoot();
@@ -325,8 +324,8 @@ TEST(sidre_external, save_load_external_view)
   // These Views do not yet have valid data.
   EXPECT_TRUE(load_group->hasView("idata"));
   EXPECT_TRUE(load_group->hasView("ddata"));
-  View* load_idata = load_group->getView("idata"); 
-  View* load_ddata = load_group->getView("ddata"); 
+  View* load_idata = load_group->getView("idata");
+  View* load_ddata = load_group->getView("ddata");
   EXPECT_TRUE(load_idata->isExternal());
   EXPECT_TRUE(load_ddata->isExternal());
   EXPECT_TRUE(load_idata->getNumElements() == len);
@@ -335,8 +334,8 @@ TEST(sidre_external, save_load_external_view)
   EXPECT_TRUE(load_ddata->getTypeID() == DOUBLE_ID);
 
   // Create arrays that will serve as locations for external data
-  std::array<int,len> new_idata;
-  std::array<double,len> new_ddata;
+  std::array<int, len> new_idata;
+  std::array<double, len> new_ddata;
 
   // Set the new arrays' pointers into the Views
   load_idata->setExternalDataPtr(new_idata.data());
@@ -346,26 +345,25 @@ TEST(sidre_external, save_load_external_view)
   // the storage identified by the external pointers.
   load_group->loadExternalData("sidre_external_save_load_external_view");
   // _external_save_load_end
- 
+
   // The pointer retrieved from each View is the same address as the raw array
   int* idata_chk = load_group->getView("idata")->getData();
   EXPECT_EQ(idata_chk, new_idata.data());
 
   // idata_chk has been loaded with the values from the file, which must
   // be the same of the original idata array that was saved
-  for (int ii = 0 ; ii < len ; ++ii)
+  for(int ii = 0; ii < len; ++ii)
   {
     EXPECT_EQ(idata_chk[ii], idata[ii]);
   }
 
   double* ddata_chk = load_group->getView("ddata")->getData();
   EXPECT_EQ(ddata_chk, new_ddata.data());
-  for (int ii = 0 ; ii < len ; ++ii)
+  for(int ii = 0; ii < len; ++ii)
   {
     EXPECT_EQ(ddata_chk[ii], ddata[ii]);
   }
 
   delete ds;
   delete ds2;
-
 }

--- a/src/axom/sidre/tests/sidre_external.cpp
+++ b/src/axom/sidre/tests/sidre_external.cpp
@@ -346,12 +346,13 @@ TEST(sidre_external, save_load_external_view)
   load_group->loadExternalData("sidre_external_save_load_external_view");
   // _external_save_load_end
 
-  // The pointer retrieved from each View is the same address as the raw array
+  // The pointer retrieved from each View is the same address as the new
+  // std::arrays.
   int* idata_chk = load_group->getView("idata")->getData();
   EXPECT_EQ(idata_chk, new_idata.data());
 
   // idata_chk has been loaded with the values from the file, which must
-  // be the same of the original idata array that was saved
+  // be the same as the original idata array that was saved
   for(int ii = 0; ii < len; ++ii)
   {
     EXPECT_EQ(idata_chk[ii], idata[ii]);


### PR DESCRIPTION
# Summary

- This PR is an addition of a test and documentation of the relevant feature.
- It does the following (modify list as needed):
  - Restores a test for serial save/load of Sidre views with external data.  A broken test was present in the code in an `#if 0` block.  Here this test is fixed to do the right thing and includes a section to be used as a snippet in the sphinx docs.
  - Add sphinx documentation of the process required to save and load external views in a way that restores the external state that was saved.

Based on recent conversations I realized that the process to save and load views with external data lacked sufficient documentation, and had no active test code for the serial case (i.e. not using SPIO).  The process takes three steps and is not obvious.  I found the inactive test code and revised it so that it works, and added an explanation to the sphinx docs.