### PR TITLE
Update ROCM_PATH

### DIFF
--- a/scripts/spack/configs/toss_4_x86_64_ib_cray/spack.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib_cray/spack.yaml
@@ -161,9 +161,9 @@ spack:
       - spec: hip@5.7.1
         prefix: /opt/rocm-5.7.1/hip
       - spec: hip@6.1.2
-        prefix: /opt/rocm-6.1.2/hip
+        prefix: /opt/rocm-6.1.2
       - spec: hip@6.2.1
-        prefix: /opt/rocm-6.2.1/hip
+        prefix: /opt/rocm-6.2.1
 
     llvm-amdgpu:
       version: [5.2.3, 5.4.3, 5.6.0, 5.7.1, 6.1.2, 6.2.1]

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -327,7 +327,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
             entries.append(cmake_cache_option("ENABLE_HIP", True))
 
-            rocm_root = os.path.dirname(spec["hip"].prefix)
+            rocm_root = os.path.dirname(spec["llvm-amdgpu"].prefix)
             entries.append(cmake_cache_path("ROCM_PATH", rocm_root))
 
             hip_link_flags = ""


### PR DESCRIPTION
This PR:
- Updates `ROCM_PATH` to derive its path from `llvm-amdgpu` instead of `hip` dependency
- Updates radiuss-spack-configs that also makes the change

Does not require a rebuild of TPLs, as no paths have changed, just how they are derived.

Closes #1461
