### PR TITLE
2D polygon robustness

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -53,6 +53,7 @@ to use Open Cascade's file I/O capabilities in support of Quest applications.
 This required a [RAJA fix to avoid 64-bit intrinsics](https://github.com/LLNL/RAJA/pull/1746), 
 as well as support for 32-bit `Word`s in Slam's `BitSet` class.
 - Fixes a memory leak in `axom::Array` copy constructor.
+- Fixes robustness issue with the `axom::primal::clip` overload for clipping a 2D polygon against another 2D polygon.
 
 ## [Version 0.10.1] - Release date 2024-10-22
 

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -763,7 +763,13 @@ AXOM_HOST_DEVICE Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clipPolygonPolygon(
   for(int i = 0; i < outputList.numVertices(); i++)
   {
     int prevIndex = ((i - 1) == -1) ? (outputList.numVertices() - 1) : (i - 1);
-    if(outputList[i] != outputList[prevIndex])
+
+    if(!axom::utilities::isNearlyEqual(outputList[i][0],
+                                       outputList[prevIndex][0],
+                                       eps) ||
+       !axom::utilities::isNearlyEqual(outputList[i][1],
+                                       outputList[prevIndex][1],
+                                       eps))
     {
       uniqueList.addVertex(outputList[i]);
     }

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -732,7 +732,7 @@ AXOM_HOST_DEVICE Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clipPolygonPolygon(
       PointType intersecting_point;
       SegmentType subject_edge(prev_point, current_point);
 
-      if(intersect(plane, subject_edge, seg_param))
+      if(intersect(plane, subject_edge, seg_param, eps))
       {
         intersecting_point = subject_edge.at(seg_param);
       }
@@ -742,13 +742,7 @@ AXOM_HOST_DEVICE Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clipPolygonPolygon(
 
       if(cur_p_orientation == ON_POSITIVE_SIDE)
       {
-        // Handles the edge case of 3 consecutive vertices with orientations
-        // ON_POSITIVE_SIDE, ON_BOUNDARY, ON_POSITIVE. Default algorithm
-        // check (prev_p_orientation != ON_POSITIVE_SIDE) results in the
-        // vertex on the boundary being added twice.
-        if(prev_p_orientation == ON_NEGATIVE_SIDE ||
-           (prev_p_orientation == ON_BOUNDARY &&
-            intersecting_point != outputList[outputList.numVertices() - 1]))
+        if(prev_p_orientation != ON_POSITIVE_SIDE)
         {
           outputList.addVertex(intersecting_point);
         }
@@ -761,7 +755,22 @@ AXOM_HOST_DEVICE Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clipPolygonPolygon(
     }
   }  // end of iteration through edges of clip polygon
 
-  return outputList;
+  // Remove duplicate points.
+  // Handles edge cases such as 3 consecutive vertices with orientations
+  // ON_POSITIVE_SIDE, ON_BOUNDARY, ON_POSITIVE where point on the boundary
+  // is added twice.
+  PolygonType uniqueList;
+  for(int i = 0; i < outputList.numVertices(); i++)
+  {
+    int prevIndex = ((i - 1) == -1) ? (outputList.numVertices() - 1) : (i - 1);
+    if(outputList[i] == outputList[prevIndex])
+    {
+      continue;
+    }
+    uniqueList.addVertex(outputList[i]);
+  }
+
+  return uniqueList;
 }
 
 }  // namespace detail

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -763,11 +763,10 @@ AXOM_HOST_DEVICE Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clipPolygonPolygon(
   for(int i = 0; i < outputList.numVertices(); i++)
   {
     int prevIndex = ((i - 1) == -1) ? (outputList.numVertices() - 1) : (i - 1);
-    if(outputList[i] == outputList[prevIndex])
+    if(outputList[i] != outputList[prevIndex])
     {
-      continue;
+      uniqueList.addVertex(outputList[i]);
     }
-    uniqueList.addVertex(outputList[i]);
   }
 
   return uniqueList;

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -1102,8 +1102,7 @@ AXOM_HOST_DEVICE bool intersect_plane_bbox(const Plane<T, 3>& p,
  * \param [in] seg A segment
  * \param [out] t Intersection point of plane and seg, w.r.t. 
  *   parametrization of seg
- * \param [in] EPS tolerance parameter for determining if \a t
- *             is just within 0.0 <= t <= 1.0 .
+ * \param [in] EPS tolerance parameter for determining if 0.0 <= t <= 1.0
  * \return true iff plane intersects with segment, otherwise, false.
  */
 template <typename T, int DIM>

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -1102,12 +1102,15 @@ AXOM_HOST_DEVICE bool intersect_plane_bbox(const Plane<T, 3>& p,
  * \param [in] seg A segment
  * \param [out] t Intersection point of plane and seg, w.r.t. 
  *   parametrization of seg
+ * \param [in] EPS tolerance parameter for determining if \a t
+ *             is just within 0.0 <= t <= 1.0 .
  * \return true iff plane intersects with segment, otherwise, false.
  */
 template <typename T, int DIM>
 AXOM_HOST_DEVICE bool intersect_plane_seg(const Plane<T, DIM>& plane,
                                           const Segment<T, DIM>& seg,
-                                          T& t)
+                                          T& t,
+                                          double EPS = 1E-12)
 {
   using VectorType = Vector<T, DIM>;
 
@@ -1117,7 +1120,7 @@ AXOM_HOST_DEVICE bool intersect_plane_seg(const Plane<T, DIM>& plane,
   t = (plane.getOffset() - normal.dot(VectorType(seg.source()))) /
     (normal.dot(ab));
 
-  if(t >= 0.0 && t <= 1.0)
+  if(isGeq(t, 0.0, EPS) && isLeq(t, 1.0, EPS))
   {
     return true;
   }

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -575,6 +575,8 @@ AXOM_HOST_DEVICE bool intersect(const Plane<T, 3>& p,
  * \param [in] seg A line segment
  * \param [out] t Intersection point of plane and seg, w.r.t. seg's
  *  parametrization
+ * \param [in] EPS tolerance parameter for determining if \a t
+ *             is just within 0.0 <= t <= 1.0
  * \note If there is an intersection, the intersection point pt is:
  *                     pt = seg.at(t)
  * \return true iff plane intersects with seg, otherwise, false.
@@ -586,9 +588,10 @@ AXOM_HOST_DEVICE bool intersect(const Plane<T, 3>& p,
 template <typename T, int DIM>
 AXOM_HOST_DEVICE bool intersect(const Plane<T, DIM>& plane,
                                 const Segment<T, DIM>& seg,
-                                T& t)
+                                T& t,
+                                const double& EPS = 1e-8)
 {
-  return detail::intersect_plane_seg(plane, seg, t);
+  return detail::intersect_plane_seg(plane, seg, t, EPS);
 }
 
 /*!

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -575,8 +575,7 @@ AXOM_HOST_DEVICE bool intersect(const Plane<T, 3>& p,
  * \param [in] seg A line segment
  * \param [out] t Intersection point of plane and seg, w.r.t. seg's
  *  parametrization
- * \param [in] EPS tolerance parameter for determining if \a t
- *             is just within 0.0 <= t <= 1.0
+ * \param [in] EPS tolerance parameter for determining if 0.0 <= t <= 1.0
  * \note If there is an intersection, the intersection point pt is:
  *                     pt = seg.at(t)
  * \return true iff plane intersects with seg, otherwise, false.
@@ -589,7 +588,7 @@ template <typename T, int DIM>
 AXOM_HOST_DEVICE bool intersect(const Plane<T, DIM>& plane,
                                 const Segment<T, DIM>& seg,
                                 T& t,
-                                const double& EPS = 1e-8)
+                                const double& EPS = 1e-12)
 {
   return detail::intersect_plane_seg(plane, seg, t, EPS);
 }

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -2044,7 +2044,7 @@ TEST(primal_clip, polygon_intersect_robustness)
 
   for(int p : std::vector<int> {0, 1, 2, 3, 4, 6})
   {
-    // Clip clipLower with fine quad
+    // Clip clipLower with overlapping fine quad
     const auto overlapPoly = axom::primal::clip(clipLower, fine[p], EPS);
     EXPECT_TRUE(overlapPoly.isValid());
 
@@ -2055,9 +2055,17 @@ TEST(primal_clip, polygon_intersect_robustness)
     }
   }
 
+  for(int p : std::vector<int> {5, 7, 8})
+  {
+    // Clip clipLower with non-intersecting fine quad
+    const auto overlapPoly = axom::primal::clip(clipLower, fine[p], EPS);
+    EXPECT_FALSE(overlapPoly.isValid());
+    EXPECT_EQ(overlapPoly.numVertices(), 0);
+  }
+
   for(int p : std::vector<int> {2, 4, 5, 6, 7, 8})
   {
-    // Clip clipUpper with fine quad
+    // Clip clipUpper with overlapping fine quad
     const auto overlapPoly = axom::primal::clip(clipUpper, fine[p], EPS);
     EXPECT_TRUE(overlapPoly.isValid());
 
@@ -2066,6 +2074,14 @@ TEST(primal_clip, polygon_intersect_robustness)
       const double vf = overlapPoly.area() / fine_area;
       EXPECT_NEAR(vf, upper_vf[p], EPS);
     }
+  }
+
+  for(int p : std::vector<int> {0, 1, 3})
+  {
+    // Clip clipUpper with non-intersecting fine quad
+    const auto overlapPoly = axom::primal::clip(clipUpper, fine[p], EPS);
+    EXPECT_FALSE(overlapPoly.isValid());
+    EXPECT_EQ(overlapPoly.numVertices(), 0);
   }
 }
 

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -2040,6 +2040,7 @@ TEST(primal_clip, polygon_intersect_robustness)
   const double lower_vf[] = {1., 1., 0.5, 1., 0.5, 0., 0.5, 0., 0.};
   const double upper_vf[] = {0., 0., 0.5, 0., 0.5, 1., 0.5, 1., 1.};
 
+  // Each quad has an area of 1/9 (3x3 quads in the unit square).
   constexpr double fine_area = (1. / 3.) * (1. / 3.);
 
   for(int p : std::vector<int> {0, 1, 2, 3, 4, 6})
@@ -2050,6 +2051,8 @@ TEST(primal_clip, polygon_intersect_robustness)
 
     if(overlapPoly.isValid())
     {
+      // Area of overlapped polygon is some fraction of 1/9.
+      // Divide by 1/9 to get a volume fraction.
       const double vf = overlapPoly.area() / fine_area;
       EXPECT_NEAR(vf, lower_vf[p], EPS);
     }
@@ -2071,6 +2074,8 @@ TEST(primal_clip, polygon_intersect_robustness)
 
     if(overlapPoly.isValid())
     {
+      // Area of overlapped polygon is some fraction of 1/9.
+      // Divide by 1/9 to get a volume fraction.
       const double vf = overlapPoly.area() / fine_area;
       EXPECT_NEAR(vf, upper_vf[p], EPS);
     }

--- a/src/axom/primal/tests/primal_clip.cpp
+++ b/src/axom/primal/tests/primal_clip.cpp
@@ -1952,6 +1952,45 @@ TEST(primal_clip, polygon_intersects_polygon)
     EXPECT_NEAR(poly[9][0], 100, EPS);
     EXPECT_NEAR(poly[9][1], 250, EPS);
   }
+
+  /*
+   * Edge case where polygons overlap along diagonal of one polygon,
+   * and the edge of the other:
+   *    +-----------+
+   *   /| \         |
+   *  / |  \        |
+   * +  |   +       |
+   *  \ |  /        |
+   *   \| /         |
+   *    +-----------+
+   */
+  {
+    Polygon2D subjectPolygon;
+    subjectPolygon.addVertex(Point2D {0., 0.});
+    subjectPolygon.addVertex(Point2D {1., 0.});
+    subjectPolygon.addVertex(Point2D {1., 1.});
+    subjectPolygon.addVertex(Point2D {0., 1.});
+
+    Polygon2D clipPolygon;
+    clipPolygon.addVertex(Point2D {0., 0.});
+    clipPolygon.addVertex(Point2D {0.3, 0.3});
+    clipPolygon.addVertex(Point2D {0., 1.});
+    clipPolygon.addVertex(Point2D {-0.3, 0.7});
+
+    Polygon2D poly = axom::primal::clip(subjectPolygon, clipPolygon, EPS);
+    EXPECT_NEAR(poly.signedArea(), 0.15, EPS);
+    EXPECT_EQ(poly.numVertices(), 3);
+
+    // Check vertices
+    EXPECT_NEAR(poly[0][0], 0, EPS);
+    EXPECT_NEAR(poly[0][1], 1, EPS);
+
+    EXPECT_NEAR(poly[1][0], 0, EPS);
+    EXPECT_NEAR(poly[1][1], 0, EPS);
+
+    EXPECT_NEAR(poly[2][0], 0.3, EPS);
+    EXPECT_NEAR(poly[2][1], 0.3, EPS);
+  }
 }
 
 /*


### PR DESCRIPTION
This PR:
- Adds robustness example to unit tests from #1481 
- Fixes robustness issue with 2D polygon clipping by:
  - Adding missing tolerance parameter to `intersect` overload   between plane and segment
  - Generalizing, simplifying logic to handle duplicate vertices in Sutherland–Hodgman algorithm by performing a pass at the end to remove duplicates.

Closes #1481 