### PR TITLE
Remove redundant check and use of out-dated hard-wired value.

### DIFF
--- a/src/axom/core/execution/internal/cuda_exec.hpp
+++ b/src/axom/core/execution/internal/cuda_exec.hpp
@@ -117,8 +117,7 @@ struct execution_space<CUDA_EXEC<BLOCK_SIZE, ASYNC>>
   }
   static bool usesAllocId(int allocId) noexcept
   {
-    return allocId == 0 ||
-      usesMemorySpace(axom::detail::getAllocatorSpace(allocId));
+    return usesMemorySpace(axom::detail::getAllocatorSpace(allocId));
   }
 };
 }  // namespace axom

--- a/src/axom/core/execution/internal/hip_exec.hpp
+++ b/src/axom/core/execution/internal/hip_exec.hpp
@@ -73,8 +73,7 @@ struct execution_space<HIP_EXEC<BLOCK_SIZE, SYNCHRONOUS>>
   }
   static bool usesAllocId(int allocId) noexcept
   {
-    return allocId == 0 ||
-      usesMemorySpace(axom::detail::getAllocatorSpace(allocId));
+    return usesMemorySpace(axom::detail::getAllocatorSpace(allocId));
   }
 };
 


### PR DESCRIPTION
This fixes a couple of things I missed in the PR for blueprint support in shaping.  There were two similar changes needed in each of the device execution headers, and I only got one.