### PR TITLE
Fixed unused variables in builds without HDF5

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -17,6 +17,7 @@ Benjamin Curtice Corbett <corbett5@llnl.gov>    Ben Corbett <32752943+corbett5@u
 Brad J. Whitlock <whitlock2@llnl.gov>           Brad Whitlock <whitlock2@llnl.gov>
 Brian Manh Hien Han <han12@llnl.gov>            Brian Han <han12@llnl.gov>          
 Brian Manh Hien Han <han12@llnl.gov>            Brian Manh Hien Han <han12@rzansel19.coral.llnl.gov>
+Brian Gunnarson <brianfunnarson14@gmail.com>    Brian Gunnarson <49216024+bgunnar5@users.noreply.github.com>
 Brian T.N. Gunney <gunney1@llnl.gov>            Brian Gunney <45609916+gunney1@users.noreply.github.com>
 Chris White <white238@llnl.gov>                 Christopher A. White <white238@llnl.gov>
 Cyrus D. Harrison <harrison37@llnl.gov>         Cyrus Harrison <cyrush@llnl.gov>
@@ -38,6 +39,7 @@ Kae Suarez <suarez29@llnl.gov>                  Kae S <31679808+ksuarez1423@user
 Kenneth Weiss <weiss27@llnl.gov>                Kenneth Weiss <kweiss@llnl.gov>
 Kenneth Weiss <weiss27@llnl.gov>                Kenny Weiss <kennyweiss@users.noreply.github.com>
 Kenneth Weiss <weiss27@llnl.gov>                Kenny Weiss <kenny@kennyweiss.com>
+Kenneth Weiss <weiss27@llnl.gov>                Kenneth Weiss <kenny@kennyweiss.com>
 Keith Edward Healy <healy22@llnl.gov>           keithhealy <50376825+keithhealy@users.noreply.github.com>
 Keith Edward Healy <healy22@llnl.gov>           Keith Edward Healy <healy22@borax5.llnl.gov>
 Lee A. Taylor <taylor16@llnl.gov>               Lee A. Taylor <taylor@cab688.llnl.gov>

--- a/src/axom/sidre/spio/IOManager.cpp
+++ b/src/axom/sidre/spio/IOManager.cpp
@@ -612,7 +612,8 @@ void IOManager::loadExternalData(sidre::Group* parent_group,
   }
 
 #else
-  AXOM_UNUSED_VAR(datagroup);
+  AXOM_UNUSED_VAR(parent_group);
+  AXOM_UNUSED_VAR(load_group);
   SLIC_WARNING("Loading external data only only available "
                << "when Axom is configured with hdf5");
 #endif /* AXOM_USE_HDF5 */


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Fixes unused variables in `IOManager::loadExternalData()` for builds without HDF5
