### PR TITLE
Fixes build and tests when not using `hdf5`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -24,6 +24,7 @@ Cyrus D. Harrison <harrison37@llnl.gov>         Cyrus Harrison <cyrush@llnl.gov>
 Cyrus D. Harrison <harrison37@llnl.gov>         Cyrus Harrison <harrison37@llnl.gov>
 Cyrus D. Harrison <harrison37@llnl.gov>         Cyrus <cyrush@llnl.gov>
 Daniel Taller <taller1@llnl.gov>                Danny Taller <66029857+dtaller@users.noreply.github.com>
+Eric B. Chin <chin23@llnl.gov>                  E. B. Chin <ebchin@gmail.com>
 Esteban Pauli <pauli2@llnl.gov>                 Esteban Pauli <40901502+estebanpauli@users.noreply.github.com>
 Evan Taylor Desantola <desantola1@llnl.gov>     Evan Taylor DeSantola <desantola1@llnl.gov>
 format-robot <no-reply@llnl.gov>                format-robot <axom-dev@llnl.gov>
@@ -67,6 +68,8 @@ Robert Carson <rac428@cornell.edu>              Robert <rac428@cornell.edu>
 Robert Carson <rac428@cornell.edu>              rcarson3 <rac428@cornell.edu>
 Robert Cohn <robert.s.cohn@intel.com>           rscohn2 <rscohn2@gmail.com>
 Samuel P. Mish <mish2@llnl.gov>                 samuelpmishLLNL <61714427+samuelpmishLLNL@users.noreply.github.com>
+Sterbentz <stermark@isu.edu>                    Sterbentz <sterbentz3@lonestarr.llnl.gov>
+
 
 Axom Shared User <axom-dev@llnl.gov>            Asctoolkit Shared User <axom-dev@llnl.gov>
 Axom Shared User <axom-dev@llnl.gov>            Asctoolkit Shared User <atk@cab687.llnl.gov>

--- a/src/axom/primal/tests/primal_surface_intersect.cpp
+++ b/src/axom/primal/tests/primal_surface_intersect.cpp
@@ -90,7 +90,7 @@ void checkIntersections(const primal::Ray<CoordType, 3>& ray,
          << "\n\t" << ray << "\n\t" << patch;
 
     sstr << "\ns (" << u.size() << "): ";
-    for(auto i = 0u; i < u.size(); ++i)
+    for(auto i = 0; i < u.size(); ++i)
     {
       sstr << std::setprecision(16) << "(" << u[i] << "," << v[i] << "),";
     }

--- a/src/axom/quest/detail/PointInCellMeshWrapper_mfem.hpp
+++ b/src/axom/quest/detail/PointInCellMeshWrapper_mfem.hpp
@@ -408,12 +408,13 @@ private:
     }
 
     // Output some information
-    SLIC_DEBUG("Mesh nodes fec -- "
-               << nodalFEColl->Name() << " with ordering "
-               << nodalFESpace->GetOrdering()
-               << "\n\t -- Positive nodes are fec -- "
-               << positiveNodes->FESpace()->FEColl()->Name()
-               << " with ordering " << positiveNodes->FESpace()->GetOrdering());
+    SLIC_DEBUG_ROOT("Mesh nodes fec -- "
+                    << nodalFEColl->Name() << " with ordering "
+                    << nodalFESpace->GetOrdering()
+                    << "\n\t -- Positive nodes are fec -- "
+                    << positiveNodes->FESpace()->FEColl()->Name()
+                    << " with ordering "
+                    << positiveNodes->FESpace()->GetOrdering());
 
     /// For each element, compute bounding box, and overall mesh bbox
     mfem::Array<int> dofIndices;

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -97,11 +97,10 @@ if (CONDUIT_FOUND AND RAJA_FOUND AND UMPIRE_FOUND)
         FOLDER      axom/quest/examples
         )
 
-    # Add unit tests
-    if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR)
+    # Add unit tests; the (current) input meshes are in the hdf5 format
+    if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR AND HDF5_FOUND)
 
-        # Run the candidates example with the different spatial indices
-        # and raja policies
+        # Run the candidates example with the different spatial indices and raja policies
 
         # Use same file for input and query
         set(input_file "${AXOM_DATA_DIR}/quest/ucart10.cycle_000000.root")
@@ -423,7 +422,8 @@ if(CONDUIT_FOUND)
             )
 
     # These examples currently segfault on windows without MPI when loading the test data into conduit
-    if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR AND NOT WIN32)
+    # Also, the input files are hdf5
+    if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR AND NOT WIN32 AND HDF5_FOUND)
         if (ENABLE_MPI)
             set(_nranks 3)
         endif()

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -1220,7 +1220,7 @@ void MFEMSidreDataCollection::Save(const std::string& filename,
       // Root file support only available in hdf5.
       else
       {
-        writer.write(blueprint_indicies_grp, 1, file_path + ".root", protocol);
+        blueprint_indicies_grp->save(file_path + ".root", protocol);
       }
     }
   }

--- a/src/axom/sidre/core/MFEMSidreDataCollection.hpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.hpp
@@ -472,6 +472,12 @@ public:
    */
   virtual void Load(int cycle_ = 0)
   {
+  #ifndef AXOM_USE_HDF5
+    SLIC_ERROR(
+      "MFEMSidreDataCollection::Load(<cycle>) is only implemented for the "
+      "'sidre_hdf5' protocol");
+  #endif
+
     SetCycle(cycle_);
     Load(get_file_path(name), "sidre_hdf5");
   }

--- a/src/axom/sidre/examples/spio/CMakeLists.txt
+++ b/src/axom/sidre/examples/spio/CMakeLists.txt
@@ -30,9 +30,13 @@ foreach(src ${spio_example_sources})
         )
 endforeach()
 
-if(SCR_FOUND AND AXOM_ENABLE_TESTS)
-    # Note: This example is a combination of a test and an example due
-    # inability to run two SCR executables at the same time
+if(SCR_FOUND AND AXOM_ENABLE_TESTS AND HDF5_FOUND)
+    # Note: This example is a combination of a test and an example
+    # since we're unable to run two SCR executables at the same time
+    #
+    # The test was written against the sidre_hdf5 protocol, so disable it
+    # in configurations that do not include hdf5
+    
     axom_add_executable(
         NAME       spio_IO_SCR_Checkpoint_ex
         SOURCES    IO_SCR_Checkpoint.cpp

--- a/src/axom/sidre/spio/IOManager.cpp
+++ b/src/axom/sidre/spio/IOManager.cpp
@@ -177,10 +177,13 @@ void IOManager::write(sidre::Group* datagroup,
 
   std::string test_file_base(broadcastString(file_base, m_mpi_comm, m_my_rank));
 
-  SLIC_WARNING_IF(test_file_base != file_base,
-                  "IOManager::write() file_base argument is not identical "
-                    << "on all ranks. This may cause the output files to be "
-                    << "incompatible with a call to IOManager::read().");
+  SLIC_WARNING_IF(
+    test_file_base != file_base,
+    "IOManager::write() file_base argument is not identical "
+      << "on all ranks. This may cause the output files to be "
+      << "incompatible with a call to IOManager::read()."
+      << axom::fmt::format("\n\tfile_base: '{}'", file_base)
+      << axom::fmt::format("\n\ttest_file_base: '{}'", test_file_base));
 
   std::string output_base =
     createRootFile(file_base, num_files, protocol, tree_pattern);

--- a/src/axom/sidre/tests/sidre_external.cpp
+++ b/src/axom/sidre/tests/sidre_external.cpp
@@ -3,13 +3,13 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "gtest/gtest.h"
-
-#include <vector>
-
 #include "axom/config.hpp"
 #include "axom/core/Types.hpp"
 #include "axom/sidre.hpp"
+
+#include "gtest/gtest.h"
+
+#include <vector>
 
 using axom::sidre::DataStore;
 using axom::sidre::DOUBLE_ID;
@@ -292,6 +292,12 @@ TEST(sidre_external, verify_external_layout)
 //------------------------------------------------------------------------------
 TEST(sidre_external, save_load_external_view)
 {
+#ifndef AXOM_USE_HDF5
+  SUCCEED() << "sidre::Group::loadExternalData() is only implemented "
+               "for the 'sidre_hdf5' protocol";
+  return;
+#endif
+
   DataStore* ds = new DataStore();
   Group* root = ds->getRoot();
 

--- a/src/axom/sidre/tests/sidre_group.cpp
+++ b/src/axom/sidre/tests/sidre_group.cpp
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/config.hpp"  // for AXOM_USE_HDF5
+#include "axom/config.hpp"
 #include "axom/core.hpp"
 #include "axom/sidre.hpp"
 

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -256,8 +256,16 @@ TEST(sidre_datacollection, dc_reload_gf_vdim)
   EXPECT_TRUE(sdc_reader.verifyMeshBlueprint());
 }
 
+// Note: This test use Group::loadExternalData(), which is only valid (implemented)
+// for sidre_hdf5 protocol. Let's skip the test in configs w/o hdf5
 TEST(sidre_datacollection, dc_reload_externaldata)
 {
+#ifndef AXOM_USE_HDF5
+  SUCCEED() << "sidre::Group::loadExternalData() is only implemented "
+               "for the 'sidre_hdf5' protocol";
+  return;
+#endif
+
   const std::string view_name = "external_data";
 
   // Create DC

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -184,6 +184,13 @@ TEST(sidre_datacollection, dc_reload_gf)
   sdc_writer.SetCycle(0);
   sdc_writer.Save();
 
+#ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+#endif
+
   // No mesh is used here
   MFEMSidreDataCollection sdc_reader(testName());
 
@@ -235,6 +242,13 @@ TEST(sidre_datacollection, dc_reload_gf_vdim)
 
   sdc_writer.SetCycle(0);
   sdc_writer.Save();
+
+#ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+#endif
 
   // No mesh is used here
   MFEMSidreDataCollection sdc_reader(testName());
@@ -344,6 +358,13 @@ TEST(sidre_datacollection, dc_reload_mesh)
   sdc_writer.SetCycle(0);
   sdc_writer.Save();
 
+#ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+#endif
+
   // No mesh is used here to construct as it will be read in
   MFEMSidreDataCollection sdc_reader(testName());
 #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
@@ -407,6 +428,13 @@ TEST(sidre_datacollection, dc_reload_qf)
   sdc_writer.SetCycle(5);
   sdc_writer.SetTime(8.0);
   sdc_writer.Save();
+
+#ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+#endif
 
   MFEMSidreDataCollection sdc_reader(testName());
 #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
@@ -901,6 +929,13 @@ TEST(sidre_datacollection, dc_par_reload_gf)
   sdc_writer.SetCycle(0);
   sdc_writer.Save();
 
+  #ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+  #endif
+
   MFEMSidreDataCollection sdc_reader(testName());
 
   // Needs to be set "manually" in order for everything to be loaded in properly
@@ -971,6 +1006,13 @@ TEST(sidre_datacollection, dc_par_reload_gf_ordering)
 
   sdc_writer.SetCycle(0);
   sdc_writer.Save();
+
+  #ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+  #endif
 
   MFEMSidreDataCollection sdc_reader(testName());
 
@@ -1071,6 +1113,13 @@ TEST(sidre_datacollection, dc_par_reload_multi_datastore)
   second_sdc_writer.SetCycle(0);
   second_sdc_writer.Save();
 
+  #ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+  #endif
+
   axom::sidre::DataStore ds_read;
 
   first_global_grp = ds_read.getRoot()->createGroup(first_coll_name + "_global");
@@ -1135,6 +1184,13 @@ TEST(sidre_datacollection, dc_par_reload_multi_datastore)
 
 TEST(sidre_datacollection, dc_par_reload_mesh_1D_small)
 {
+  #ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+  #endif
+
   // 1D mesh divided into segments
   auto mesh = mfem::Mesh::MakeCartesian1D(10);
   testParallelMeshReloadAllPartitionings(mesh);
@@ -1142,6 +1198,13 @@ TEST(sidre_datacollection, dc_par_reload_mesh_1D_small)
 
 TEST(sidre_datacollection, dc_par_reload_mesh_2D_small)
 {
+  #ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+  #endif
+
   // 2D mesh divided into triangles
   auto mesh = mfem::Mesh::MakeCartesian2D(10, 10, mfem::Element::TRIANGLE);
   testParallelMeshReloadAllPartitionings(mesh);
@@ -1149,6 +1212,13 @@ TEST(sidre_datacollection, dc_par_reload_mesh_2D_small)
 
 TEST(sidre_datacollection, dc_par_reload_mesh_2D_large)
 {
+  #ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+  #endif
+
   // 2D mesh divided into triangles
   auto mesh = mfem::Mesh::MakeCartesian2D(100, 100, mfem::Element::TRIANGLE);
   testParallelMeshReloadAllPartitionings(mesh);
@@ -1158,6 +1228,13 @@ TEST(sidre_datacollection, dc_par_reload_mesh_2D_large)
   #if(MFEM_VERSION >= 40300)
 TEST(sidre_datacollection, dc_par_reload_mesh_2D_periodic)
 {
+    #ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+    #endif
+
   // periodic 2D mesh divided into triangles
   auto base_mesh = mfem::Mesh::MakeCartesian2D(10,
                                                10,
@@ -1175,6 +1252,13 @@ TEST(sidre_datacollection, dc_par_reload_mesh_2D_periodic)
 
 TEST(sidre_datacollection, dc_par_reload_mesh_3D_small_tet)
 {
+  #ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+  #endif
+
   // 3D mesh divided into tetrahedra
   auto mesh = mfem::Mesh::MakeCartesian3D(2, 2, 2, mfem::Element::TETRAHEDRON);
   testParallelMeshReloadAllPartitionings(mesh);
@@ -1182,6 +1266,13 @@ TEST(sidre_datacollection, dc_par_reload_mesh_3D_small_tet)
 
 TEST(sidre_datacollection, dc_par_reload_mesh_3D_medium_tet)
 {
+  #ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+  #endif
+
   // 3D mesh divided into tetrahedra
   auto mesh = mfem::Mesh::MakeCartesian3D(10, 10, 10, mfem::Element::TETRAHEDRON);
   testParallelMeshReloadAllPartitionings(mesh);
@@ -1189,6 +1280,13 @@ TEST(sidre_datacollection, dc_par_reload_mesh_3D_medium_tet)
 
 TEST(sidre_datacollection, dc_par_reload_mesh_3D_small_hex)
 {
+  #ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+  #endif
+
   // 3D mesh divided into hexahedra
   auto mesh = mfem::Mesh::MakeCartesian3D(3, 3, 3, mfem::Element::HEXAHEDRON);
   testParallelMeshReloadAllPartitionings(mesh);
@@ -1196,6 +1294,13 @@ TEST(sidre_datacollection, dc_par_reload_mesh_3D_small_hex)
 
 TEST(sidre_datacollection, dc_par_reload_mesh_3D_medium_hex)
 {
+  #ifndef AXOM_USE_HDF5
+  SUCCEED()
+    << "sidre::MFEMSidreDataCollection::load(<cycle>) is only implemented "
+       "for the 'sidre_hdf5' protocol";
+  return;
+  #endif
+
   // 3D mesh divided into hexahedra
   auto mesh = mfem::Mesh::MakeCartesian3D(10, 10, 10, mfem::Element::HEXAHEDRON);
   testParallelMeshReloadAllPartitionings(mesh);

--- a/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
+++ b/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
@@ -3,8 +3,10 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "gtest/gtest.h"
+#include "axom/config.hpp"
 #include "axom/sidre.hpp"
+
+#include "gtest/gtest.h"
 
 using axom::sidre::DataStore;
 using axom::sidre::Group;
@@ -332,6 +334,12 @@ void test_user_defined_data()
 template <typename T, int DIM>
 void test_external_user_defined_data()
 {
+#ifndef AXOM_USE_HDF5
+  SUCCEED() << "sidre::Group::loadExternalData() is only implemented "
+               "for the 'sidre_hdf5' protocol";
+  return;
+#endif
+
   // populate data
   constexpr IndexType size = 10;
   axom::Array<T, DIM> states(size, size);

--- a/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
+++ b/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
@@ -411,7 +411,7 @@ void test_external_user_defined_data()
   check_array(loaded_states);
 }
 
-#ifdef AXOM_USE_MFEM
+#if defined(AXOM_USE_MFEM) && defined(AXOM_USE_HDF5)
 
 template <typename T, int DIM>
 void test_MFEMSidreDataCollection_user_defined_data()
@@ -500,7 +500,7 @@ void test_MFEMSidreDataCollection_user_defined_data()
   check_array(loaded_states);
 }
 
-#endif  // AXOM_USE_MFEM
+#endif  // defined(AXOM_USE_MFEM) && defined(AXOM_USE_HDF5)
 
 //------------------------------------------------------------------------------
 
@@ -626,7 +626,7 @@ TEST(sidre, TwoD_StateTensorLarge_external_readandwrite)
 
 //-------------------------
 
-#ifdef AXOM_USE_MFEM
+#if defined(AXOM_USE_MFEM) && defined(AXOM_USE_HDF5)
 
 TEST(sidre, OneD_double_MFEMSidreDataCollection_readandwrite)
 {
@@ -690,7 +690,7 @@ TEST(sidre, TwoD_StateTensorLarge_MFEMSidreDataCollection_readandwrite)
   test_MFEMSidreDataCollection_user_defined_data<StateTensorLarge, 2>();
 }
 
-#endif  // AXOM_USE_MFEM
+#endif  // defined(AXOM_USE_MFEM) && defined(AXOM_USE_HDF5)
 
 //----------------------------------------------------------------------
 int main(int argc, char* argv[])

--- a/src/cmake/AxomConfig.cmake
+++ b/src/cmake/AxomConfig.cmake
@@ -13,7 +13,7 @@ message(STATUS "Configuring Axom version ${AXOM_VERSION_FULL}")
 ## Add a definition to the generated config file for each library dependency
 ## (optional and built-in) that we might need to know about in the code. We
 ## check for vars of the form <DEP>_FOUND or ENABLE_<DEP>
-set(TPL_DEPS ADIAK C2C CALIPER CAMP CLI11 CONDUIT CUDA FMT HIP HDF5 LUA MFEM MPI OPENMP OPENCASCADE RAJA SCR SOL SPARSEHASH UMPIRE )
+set(TPL_DEPS ADIAK C2C CALIPER CAMP CLI11 CONDUIT CUDA FMT HIP HDF5 LUA MFEM MPI OPENMP OPENCASCADE RAJA SCR SOL SPARSEHASH UMPIRE ZLIB)
 foreach(dep ${TPL_DEPS})
     if( ${dep}_FOUND OR ENABLE_${dep} )
         set(AXOM_USE_${dep} TRUE  )

--- a/src/cmake/axom-config.cmake.in
+++ b/src/cmake/axom-config.cmake.in
@@ -70,6 +70,7 @@ if(NOT AXOM_FOUND)
   set(AXOM_USE_RAJA           "@AXOM_USE_RAJA@")
   set(AXOM_USE_SCR            "@AXOM_USE_SCR@")
   set(AXOM_USE_UMPIRE         "@AXOM_USE_UMPIRE@")
+  set(AXOM_USE_ZLIB           "@AXOM_USE_ZLIB@")
 
   # Configration for Axom compiler defines
   set(AXOM_DEBUG_DEFINE         "@AXOM_DEBUG_DEFINE@")
@@ -158,6 +159,18 @@ if(NOT AXOM_FOUND)
                     PATHS "${CONDUIT_DIR}"
                           "${CONDUIT_DIR}/lib/cmake/conduit"
                     NO_SYSTEM_ENVIRONMENT_PATH)
+  endif()
+
+  # zlib
+  if(AXOM_USE_ZLIB)
+    set(AXOM_ZLIB_DIR  "@ZLIB_DIR@")
+    if(NOT ZLIB_DIR) 
+      set(ZLIB_DIR ${AXOM_ZLIB_DIR}) 
+    endif()
+    if(ZLIB_DIR)
+        set(ZLIB_ROOT ${ZLIB_DIR})
+    endif()
+    find_package(ZLIB REQUIRED)
   endif()
 
   # hdf5

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -257,12 +257,20 @@ endif()
 # SCR
 #------------------------------------------------------------------------------
 if (SCR_DIR)
+    # SCR depends on zlib, but this can be masked by hdf5's zlib dependency
+    if(NOT TARGET ZLIB::ZLIB)
+        if(ZLIB_DIR)
+            set(ZLIB_ROOT ${ZLIB_DIR})
+        endif()
+        find_package(ZLIB REQUIRED) # creates ZLIB::ZLIB target
+    endif()
+
     axom_assert_is_directory(DIR_VARIABLE SCR_DIR)
 
     include(cmake/thirdparty/FindSCR.cmake)
     blt_import_library( NAME       scr
                         INCLUDES   ${SCR_INCLUDE_DIRS}
-                        LIBRARIES  ${SCR_LIBRARIES}
+                        LIBRARIES  ${SCR_LIBRARIES} ZLIB::ZLIB
                         TREAT_INCLUDES_AS_SYSTEM ON
                         EXPORTABLE ON)
     blt_list_append(TO TPL_DEPS ELEMENTS scr)


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It fixes the build and tests in configurations without `hdf5`
- I also discovered and fixed an unknown dependency for `scr` on `zlib`

I noted in #1480 that Axom supports configurations without `hdf5`. We don't currently have CI for this, and when I configured the code without `hdf5`, I found several tests that did not work. This branch fixes them. 

Since non-`hdf5` configs require a `conduit` without `hdf5` (i.e. a new library set), I'm not sure that we need a CI that tests this -- it might be enough to just manually run the code and fix it every so often. Perhaps we should have a manually run github-action that does this, similar to our manual Windows TPL build?

### Details:
I configured the code with a host-config generated by running the following uberenv command:
```
> ./scripts/uberenv/uberenv.py --spec "%clang@14.0.6+devtools~hdf5+c2c+mfem+scr+profiling  ^conduit~hdf5"
```