### PR TITLE
Host execution space can use more than just its default and unified m…

### DIFF
--- a/src/axom/core/execution/internal/omp_exec.hpp
+++ b/src/axom/core/execution/internal/omp_exec.hpp
@@ -66,8 +66,9 @@ struct execution_space<OMP_EXEC>
   }
   static bool usesMemorySpace(axom::MemorySpace m) noexcept
   {
-    return m == memory_space
+    return m == MemorySpace::Dynamic
 #ifdef AXOM_USE_UMPIRE
+      || m == MemorySpace::Host
       || m == MemorySpace::Unified
 #endif
       ;

--- a/src/axom/core/execution/internal/omp_exec.hpp
+++ b/src/axom/core/execution/internal/omp_exec.hpp
@@ -68,8 +68,7 @@ struct execution_space<OMP_EXEC>
   {
     return m == MemorySpace::Dynamic
 #ifdef AXOM_USE_UMPIRE
-      || m == MemorySpace::Host
-      || m == MemorySpace::Unified
+      || m == MemorySpace::Host || m == MemorySpace::Unified
 #endif
       ;
   }

--- a/src/axom/core/execution/internal/seq_exec.hpp
+++ b/src/axom/core/execution/internal/seq_exec.hpp
@@ -75,8 +75,9 @@ struct execution_space<SEQ_EXEC>
   }
   static bool usesMemorySpace(axom::MemorySpace m) noexcept
   {
-    return m == memory_space
+    return m == MemorySpace::Dynamic
 #ifdef AXOM_USE_UMPIRE
+      || m == MemorySpace::Host
       || m == MemorySpace::Unified
 #endif
       ;

--- a/src/axom/core/execution/internal/seq_exec.hpp
+++ b/src/axom/core/execution/internal/seq_exec.hpp
@@ -77,8 +77,7 @@ struct execution_space<SEQ_EXEC>
   {
     return m == MemorySpace::Dynamic
 #ifdef AXOM_USE_UMPIRE
-      || m == MemorySpace::Host
-      || m == MemorySpace::Unified
+      || m == MemorySpace::Host || m == MemorySpace::Unified
 #endif
       ;
   }


### PR DESCRIPTION
Fix what memory spaces SEQ_EXEC and OMP_EXEC claim to be able to use.  They could use Dynamic _and_ Host, not just their default memory space.