### PR TITLE
Initial 2D intersection shaping

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -42,6 +42,7 @@ to use Open Cascade's file I/O capabilities in support of Quest applications.
   of `loadExternalData` in `sidre::IOManager` and `sidre::Group`.
 - Adds intersection routines between `primal::Ray` objects and `primal::NURBSCurve`/`primal::NURBSPatch` objects.
 - Adds LineFileTagCombiner to Lumberjack to allow combining messages if line number, file, and tag are equal.
+- Adds some support for 2D shaping in `quest::IntersectionShaper`, using STL meshes with zero for z-coordinates or in-memory triangles as input.
 
 ###  Changed
 - `primal::NumericArray` has been moved to `core`.  The header is `core/NumericArray.hpp`.

--- a/src/axom/primal/geometry/Polygon.hpp
+++ b/src/axom/primal/geometry/Polygon.hpp
@@ -100,11 +100,28 @@ public:
   ~Polygon() { m_vertices.clear(); }
 
   /*!
-   * \brief Copy assignment operator for Polygon. Suppress CUDA warnings for
-   *        dynamic axom::Array.
+   * \brief Copy assignment operator for Polygon (static array specialization).
+   *        Specializations are necessary to remove warnings.
    */
-  AXOM_SUPPRESS_HD_WARN
-  AXOM_HOST_DEVICE
+  template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
+            std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Static, int> = 0>
+  AXOM_HOST_DEVICE Polygon& operator=(const Polygon& other)
+  {
+    if(this == &other)
+    {
+      return *this;
+    }
+
+    m_vertices = other.m_vertices;
+    return *this;
+  }
+
+  /*!
+   * \brief Copy assignment operator for Polygon.
+   *        (dynamic array specialization)
+   */
+  template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
+            std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Dynamic, int> = 0>
   Polygon& operator=(const Polygon& other)
   {
     if(this == &other)

--- a/src/axom/primal/tests/primal_point.cpp
+++ b/src/axom/primal/tests/primal_point.cpp
@@ -41,13 +41,15 @@ void check_point_policy()
 //------------------------------------------------------------------------------
 TEST(primal_point, point_default_constructor)
 {
-  static const int DIM = 2;
+  static const int DIM = 3;
   using CoordType = double;
   using QPoint = primal::Point<CoordType, DIM>;
 
   QPoint pt;
 
   EXPECT_EQ(pt[0], CoordType());
+  EXPECT_EQ(pt[1], CoordType());
+  EXPECT_EQ(pt[2], CoordType());
   EXPECT_EQ(pt.dimension(), DIM);
 }
 

--- a/src/axom/primal/tests/primal_surface_intersect.cpp
+++ b/src/axom/primal/tests/primal_surface_intersect.cpp
@@ -90,7 +90,7 @@ void checkIntersections(const primal::Ray<CoordType, 3>& ray,
          << "\n\t" << ray << "\n\t" << patch;
 
     sstr << "\ns (" << u.size() << "): ";
-    for(auto i = 0u; i < u.size(); ++i)
+    for(auto i = 0; i < u.size(); ++i)
     {
       sstr << std::setprecision(16) << "(" << u[i] << "," << v[i] << "),";
     }

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -1231,7 +1231,6 @@ private:
     const int device_allocator = m_allocatorId;
 
     constexpr int NUM_TETS_PER_HEX = 24;
-    constexpr double ZERO_THRESHOLD = 1.e-10;
 
     SLIC_INFO(axom::fmt::format("{:-^80}",
                                 " Inserting shapes' bounding boxes into BVH "));
@@ -1259,11 +1258,6 @@ private:
     SLIC_INFO(axom::fmt::format("{:-^80}", " Querying the BVH tree "));
 
     axom::ArrayView<const BoundingBox3D> hex_bbs_device_view = m_hex_bbs.view();
-
-    // Set shape components to zero if within threshold
-    snapShapeVerticesToZero<ExecSpace, ShapeType>(shapes,
-                                                  shape_count,
-                                                  ZERO_THRESHOLD);
 
     // Find which shape bounding boxes intersect hexahedron bounding boxes
     SLIC_INFO(axom::fmt::format(
@@ -2782,7 +2776,6 @@ public:
 
     m_hexes = axom::Array<HexahedronType>(m_cellCount, m_cellCount, allocId);
     axom::ArrayView<HexahedronType> hexes_device_view = m_hexes.view();
-    constexpr double ZERO_THRESHOLD = 1.e-10;
     axom::for_all<ExecSpace>(
       m_cellCount,
       AXOM_LAMBDA(axom::IndexType i) {
@@ -2796,61 +2789,8 @@ public:
             Point3D({vertCoords_device_view[vertIndex],
                      vertCoords_device_view[vertIndex + 1],
                      vertCoords_device_view[vertIndex + 2]});
-
-          // Set hexahedra components to zero if within threshold
-          if(axom::utilities::isNearlyEqual(hexes_device_view[i][j][0],
-                                            0.0,
-                                            ZERO_THRESHOLD))
-          {
-            hexes_device_view[i][j][0] = 0.0;
-          }
-
-          if(axom::utilities::isNearlyEqual(hexes_device_view[i][j][1],
-                                            0.0,
-                                            ZERO_THRESHOLD))
-          {
-            hexes_device_view[i][j][1] = 0.0;
-          }
-
-          if(axom::utilities::isNearlyEqual(hexes_device_view[i][j][2],
-                                            0.0,
-                                            ZERO_THRESHOLD))
-          {
-            hexes_device_view[i][j][2] = 0.0;
-          }
         }
       });  // end of loop to initialize hexahedral elements and bounding boxes
-  }
-
-  //!\brief Set shape vertices to zero of within threshold.
-  template <typename ExecSpace, typename ShapeType>
-  void snapShapeVerticesToZero(axom::Array<ShapeType>& shapes,
-                               axom::IndexType shapeCount,
-                               double zeroThreshold)
-  {
-    AXOM_ANNOTATE_SCOPE("snapShapeVerticesToZero");
-    axom::ArrayView<ShapeType> shapesView = shapes.view();
-    axom::for_all<ExecSpace>(
-      shapeCount,
-      AXOM_LAMBDA(axom::IndexType i) {
-        for(int j = 0; j < ShapeType::NUM_VERTS; j++)
-        {
-          if(axom::utilities::isNearlyEqual(shapesView[i][j][0], 0.0, zeroThreshold))
-          {
-            shapesView[i][j][0] = 0.0;
-          }
-
-          if(axom::utilities::isNearlyEqual(shapesView[i][j][1], 0.0, zeroThreshold))
-          {
-            shapesView[i][j][1] = 0.0;
-          }
-
-          if(axom::utilities::isNearlyEqual(shapesView[i][j][2], 0.0, zeroThreshold))
-          {
-            shapesView[i][j][2] = 0.0;
-          }
-        }
-      });
   }
 
   #if defined(AXOM_USE_CONDUIT)

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -678,8 +678,10 @@ private:
                                              m_tricount,
                                              host_allocator);
 
-    // Initialize 2D triangles from 3D stl Points (ignore z coordinate)
+    // Initialize 2D triangles from mesh (ignore z coordinate)
     axom::Array<IndexType> nodeIds(3);
+
+    // Buffer is 3D for stl mesh
     axom::Array<Point3D> pts(3);
 
     for(int i = 0; i < m_tricount; i++)
@@ -689,6 +691,14 @@ private:
       m_surfaceMesh->getNode(nodeIds[0], pts[0].data());
       m_surfaceMesh->getNode(nodeIds[1], pts[1].data());
       m_surfaceMesh->getNode(nodeIds[2], pts[2].data());
+
+      // Verify that z-coordinates are unused by the mesh.
+      // (0 for stl mesh, undefined by in-memory triangle mesh)
+      if(pts[0][2] != 0 || pts[1][2] != 0 || pts[2][2] != 0)
+      {
+        SLIC_ERROR(axom::fmt::format(
+          "2D triangles must have undefined or value 0 z-coordinates"));
+      }
 
       Point2D p1({pts[0][0], pts[0][1]});
       Point2D p2({pts[1][0], pts[1][1]});

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -1079,9 +1079,12 @@ private:
       });  // end of loop to initialize hexahedral elements and bounding boxes
 
     printf("\t--> CHECKPOINT 2\n");
-    for(int i = 0; i < NE; i++)
+    if(device_allocator == host_allocator)
     {
-      SLIC_INFO("\t\t--> Quad[" << i << "] is " << quads_device_view[i]);
+      for(int i = 0; i < NE; i++)
+      {
+        SLIC_INFO("\t\t--> Quad[" << i << "] is " << quads_device_view[i]);
+      }
     }
 
     // Set shape components to zero if within threshold

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -668,11 +668,9 @@ private:
     const int host_allocator =
       axom::execution_space<axom::SEQ_EXEC>::allocatorID();
     const int device_allocator = axom::execution_space<ExecSpace>::allocatorID();
-    printf("ooo ooo INSIDE prepareTriCells ooo ooo\n");
 
     // Number of triangles in mesh
     m_tricount = m_surfaceMesh->getNumberOfCells();
-    printf("\t --> m_tricount is %d\n", m_tricount);
 
     axom::Array<PolygonStaticType> tris_host(m_tricount,
                                              m_tricount,
@@ -705,12 +703,6 @@ private:
       Point2D p3({pts[2][0], pts[2][1]});
 
       tris_host[i] = PolygonStaticType({p1, p2, p3});
-
-      SLIC_INFO("\t --> tris_host[" << i << "] is " << tris_host[i]);
-      SLIC_INFO("\t\t --> Full pts[" << 0 << "] is " << pts[0]);
-      SLIC_INFO("\t\t --> Full pts[" << 1 << "] is " << pts[1]);
-      SLIC_INFO("\t\t --> Full pts[" << 2 << "] is " << pts[2]);
-      slic::flushStreams();
     }
 
     // Copy triangles to device
@@ -1027,7 +1019,6 @@ private:
     const int host_allocator =
       axom::execution_space<axom::SEQ_EXEC>::allocatorID();
     const int device_allocator = axom::execution_space<ExecSpace>::allocatorID();
-    printf("xxx xxx INSIDE runShapeQuery2DImpl xxx xxx\n");
 
     SLIC_INFO(axom::fmt::format("{:-^80}",
                                 " Inserting shapes' bounding boxes into BVH "));
@@ -1063,7 +1054,6 @@ private:
 
     SLIC_INFO(axom::fmt::format("{:-^80}", " Querying the BVH tree "));
 
-    printf("\t--> CHECKPOINT 3\n");
     auto quad_bbs_device_view = m_quad_bbs.view();
 
     // Find which shape bounding boxes intersect quadrilateral bounding boxes
@@ -2759,17 +2749,6 @@ public:
                      vertCoords_device_view[vertIndex + 1]}));
         }
       });
-
-    printf("\t--> CHECKPOINT 2\n");
-    if(m_allocatorId ==
-       axom::policyToDefaultAllocatorID(axom::runtime_policy::Policy::seq))
-    {
-      for(int i = 0; i < m_cellCount; i++)
-      {
-        SLIC_INFO("\t\t--> Quad[" << i << "] is " << quads_device_view[i]);
-      }
-    }
-
   }  // end of populateQuadsFromMesh()
 
   template <typename ExecSpace>

--- a/src/axom/quest/Shaper.cpp
+++ b/src/axom/quest/Shaper.cpp
@@ -119,13 +119,31 @@ Shaper::Shaper(RuntimePolicy execPolicy,
                                  .fetch_existing(m_bpTopo)
                                  .fetch_existing("type")
                                  .as_string();
+
   if(topoType == "structured")
   {
     AXOM_ANNOTATE_SCOPE("Shaper::convertStructured");
-    axom::quest::util::convert_blueprint_structured_explicit_to_unstructured(
-      m_bpGrp,
-      m_bpTopo,
-      m_execPolicy);
+    const std::string shapeType =
+      bpNode.fetch_existing("topologies/mesh/elements/shape").as_string();
+
+    if(shapeType == "hex")
+    {
+      axom::quest::util::convert_blueprint_structured_explicit_to_unstructured_3d(
+        m_bpGrp,
+        m_bpTopo,
+        m_execPolicy);
+    }
+    else if(shapeType == "quad")
+    {
+      axom::quest::util::convert_blueprint_structured_explicit_to_unstructured_2d(
+        m_bpGrp,
+        m_bpTopo,
+        m_execPolicy);
+    }
+    else
+    {
+      SLIC_ERROR("Axom Internal error: Unhandled shape type.");
+    }
   }
 
   m_bpGrp->createNativeLayout(m_bpNodeInt);
@@ -274,8 +292,8 @@ bool Shaper::verifyInputMesh(std::string& whyBad) const
     {
       std::string elemShape =
         m_bpNodeInt.fetch("topologies")[m_bpTopo]["elements"]["shape"].as_string();
-      rval = elemShape == "hex";
-      info[0].set_string("Topology elements are not hex.");
+      rval = (elemShape == "hex") || (elemShape == "quad");
+      info[0].set_string("Topology elements are not hex or quad.");
     }
     whyBad = info.to_summary_string();
   }

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -215,7 +215,20 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                 NUM_MPI_TASKS ${_nranks})
             # steel ball: cirle of radius 5.5 has analytic volume ~696.91
             set_tests_properties(${_testname} PROPERTIES 
-                PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 6[89][0-9].")          
+                PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 6[89][0-9].")
+
+            # Tests 2D stl mesh
+            set(_testname quest_shaping_driver_ex_triangle_stl_2d)
+            axom_add_test(
+                NAME ${_testname}
+                COMMAND  quest_shaping_driver_ex
+                        -i ${AXOM_DATA_DIR}/../triangle_2d.yaml
+                        --method intersection
+                        inline_mesh --min 0 0 --max 1 1 --res 3 3 -d 2
+                NUM_MPI_TASKS ${_nranks})
+            # steel triangle: right triangle of leg length 1 has analytic volume 0.5
+            set_tests_properties(${_testname} PROPERTIES
+                PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 0.5")
         endif()
 
         # 3D shaping tests

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -346,6 +346,29 @@ if((CONDUIT_FOUND OR
               endforeach()
             endforeach()
         endforeach()
+
+        # Test 2D Triangle shape
+        set(_testshapes "tri")
+        set(_testMeshTypes "bpConduit" "bpSidre")
+        blt_list_append(TO _testMeshTypes ELEMENTS "mfem" IF MFEM_FOUND)
+        foreach(_policy ${_policies})
+            foreach(_testMeshType ${_testMeshTypes})
+              foreach(_testshape ${_testshapes})
+                set(_testname "quest_shape_in_memory_${_policy}_${_testMeshType}_${_testshape}")
+                axom_add_test(
+                  NAME ${_testname}
+                  COMMAND quest_shape_in_memory_ex
+                             --policy ${_policy}
+                             --testShape ${_testshape}
+                             --refinements 2
+                             --scale 0.75 0.75 0.75
+                             --dir 0.2 0.4 0.8
+                             --meshType ${_testMeshType}
+                             inline_mesh --min -2 -2 --max 2 2 --res 2 2
+                  NUM_MPI_TASKS ${_nranks})
+              endforeach()
+            endforeach()
+        endforeach()
     endif()
 endif()
 

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -218,15 +218,16 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                 PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 6[89][0-9].")
 
             # Tests 2D stl mesh
-            set(_testname quest_shaping_driver_ex_triangle_stl_2d)
+            set(_testname quest_shaping_driver_ex_star_stl_2d)
             axom_add_test(
                 NAME ${_testname}
                 COMMAND  quest_shaping_driver_ex
-                        -i ${AXOM_DATA_DIR}/../triangle_2d.yaml
+                        -i ${shaping_data_dir}/flat_star.yaml
                         --method intersection
-                        inline_mesh --min 0 0 --max 1 1 --res 3 3 -d 2
+                        inline_mesh --min 0 0 --max 1 1 --res 4 4 -d 2
                 NUM_MPI_TASKS ${_nranks})
-            # steel triangle: right triangle of leg length 1 has analytic volume 0.5
+            # steel triangle: star composed of 16 right triangles with
+            # leg length 0.25 has analytic volume 0.5
             set_tests_properties(${_testname} PROPERTIES
                 PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 0.5")
         endif()

--- a/src/axom/quest/examples/quest_shape_in_memory.cpp
+++ b/src/axom/quest/examples/quest_shape_in_memory.cpp
@@ -1078,7 +1078,6 @@ axom::sidre::View* getElementVolumes(
 
       constexpr int NUM_VERTS_PER_HEX = 8;
       constexpr int NUM_COMPS_PER_VERT = 3;
-      constexpr double ZERO_THRESHOLD = 1.e-10;
 
       axom::Array<Point3D> vertCoords(cellCount * NUM_VERTS_PER_HEX,
                                       cellCount * NUM_VERTS_PER_HEX);
@@ -1102,21 +1101,6 @@ axom::sidre::View* getElementVolumes(
           }
         }
       }
-
-      // Set vertex coords to zero if within threshold.
-      // (I don't know why we do this.  I'm following examples.)
-      axom::ArrayView<double> flatCoordsView(
-        (double*)vertCoords.data(),
-        vertCoords.size() * Point3D::dimension());
-      assert(flatCoordsView.size() == cellCount * NUM_VERTS_PER_HEX * 3);
-      axom::for_all<ExecSpace>(
-        cellCount * 3,
-        AXOM_LAMBDA(axom::IndexType i) {
-          if(axom::utilities::isNearlyEqual(flatCoordsView[i], 0.0, ZERO_THRESHOLD))
-          {
-            flatCoordsView[i] = 0.0;
-          }
-        });
 
       // Initialize hexahedral elements.
       axom::Array<HexahedronType> hexes(cellCount, cellCount);
@@ -1308,7 +1292,6 @@ axom::sidre::View* getElementVolumes(
 
       constexpr int NUM_VERTS_PER_HEX = 8;
       constexpr int NUM_COMPS_PER_VERT = 3;
-      constexpr double ZERO_THRESHOLD = 1.e-10;
 
       /*
           Get vertex coordinates.  We use UnstructuredMesh for this,
@@ -1366,21 +1349,6 @@ axom::sidre::View* getElementVolumes(
               vertCoordsView[vertIdx][k] = coordArrays[k][verts[j]];
               // vertCoordsView[vertIdx][k] = mesh.getNodeCoordinate(verts[j], k);
             }
-          }
-        });
-
-      // Set vertex coords to zero if within threshold.
-      // (I don't know why we do this.  I'm following examples.)
-      axom::ArrayView<double> flatCoordsView(
-        (double*)vertCoords.data(),
-        vertCoords.size() * Point3D::dimension());
-      assert(flatCoordsView.size() == cellCount * NUM_VERTS_PER_HEX * 3);
-      axom::for_all<ExecSpace>(
-        cellCount * 3,
-        AXOM_LAMBDA(axom::IndexType i) {
-          if(axom::utilities::isNearlyEqual(flatCoordsView[i], 0.0, ZERO_THRESHOLD))
-          {
-            flatCoordsView[i] = 0.0;
           }
         });
 

--- a/src/axom/quest/examples/quest_shape_in_memory.cpp
+++ b/src/axom/quest/examples/quest_shape_in_memory.cpp
@@ -2017,7 +2017,7 @@ int main(int argc, char** argv)
   }
 
   // For error checking, work on host.
-  using ExecSpace = typename axom::SEQ_EXEC;
+  using ExecSpace = axom::SEQ_EXEC;
   using ReducePolicy = typename axom::execution_space<ExecSpace>::reduce_policy;
 
   //---------------------------------------------------------------------------

--- a/src/axom/quest/examples/shaping_driver.cpp
+++ b/src/axom/quest/examples/shaping_driver.cpp
@@ -569,7 +569,7 @@ int main(int argc, char** argv)
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
     shaper = new quest::IntersectionShaper(
       params.policy,
-      axom::policyToDefaultAllocatorID(axom::runtime_policy::Policy::seq),
+      axom::policyToDefaultAllocatorID(params.policy),
       params.shapeSet,
       &shapingDC);
 #else

--- a/src/axom/quest/util/mesh_helpers.cpp
+++ b/src/axom/quest/util/mesh_helpers.cpp
@@ -94,7 +94,7 @@ mfem::Mesh* make_cartesian_mfem_mesh_3D(const primal::BoundingBox<double, 3>& bb
 
 #if defined(AXOM_USE_SIDRE)
 
-axom::sidre::Group* make_structured_blueprint_box_mesh(
+axom::sidre::Group* make_structured_blueprint_box_mesh_3d(
   axom::sidre::Group* meshGrp,
   const primal::BoundingBox<double, 3>& bbox,
   const NumericArray<int, 3>& res,
@@ -182,7 +182,83 @@ axom::sidre::Group* make_structured_blueprint_box_mesh(
   return meshGrp;
 }
 
-axom::sidre::Group* make_unstructured_blueprint_box_mesh(
+axom::sidre::Group* make_structured_blueprint_box_mesh_2d(
+  axom::sidre::Group* meshGrp,
+  const primal::BoundingBox<double, 2>& bbox,
+  const NumericArray<int, 2>& res,
+  const std::string& topologyName,
+  const std::string& coordsetName,
+  axom::runtime_policy::Policy runtimePolicy)
+{
+  auto* topoGrp = meshGrp->createGroup("topologies")->createGroup(topologyName);
+  SLIC_ERROR_IF(topoGrp == nullptr,
+                "Cannot allocate topology '" + topologyName +
+                  "' in blueprint mesh '" + meshGrp->getName() +
+                  "'.  It already exists.");
+
+  auto* coordsetGrp =
+    meshGrp->createGroup("coordsets")->createGroup(coordsetName);
+  SLIC_ERROR_IF(coordsetGrp == nullptr,
+                "Cannot allocate coordset '" + coordsetName +
+                  "' in blueprint mesh '" + meshGrp->getName() +
+                  "'.  It already exists.");
+
+  topoGrp->createView("type")->setString("structured");
+  topoGrp->createView("coordset")->setString(coordsetName);
+  auto* dimsGrp = topoGrp->createGroup("elements/dims");
+
+  constexpr int DIM = 2;
+
+  auto ni = res[0];
+  auto nj = res[1];
+
+  const axom::StackArray<axom::IndexType, DIM> vertsShape {res[0] + 1,
+                                                           res[1] + 1};
+  const auto numVerts = vertsShape[0] * vertsShape[1];
+
+  dimsGrp->createViewScalar("i", ni);
+  dimsGrp->createViewScalar("j", nj);
+
+  coordsetGrp->createView("type")->setString("explicit");
+  auto* valuesGrp = coordsetGrp->createGroup("values");
+  auto* xVu =
+    valuesGrp->createViewAndAllocate("x",
+                                     axom::sidre::DataTypeId::FLOAT64_ID,
+                                     numVerts);
+  auto* yVu =
+    valuesGrp->createViewAndAllocate("y",
+                                     axom::sidre::DataTypeId::FLOAT64_ID,
+                                     numVerts);
+  #ifdef AXOM_USE_UMPIRE
+  SLIC_ASSERT(axom::getAllocatorIDFromPointer(xVu->getVoidPtr()) ==
+              meshGrp->getDefaultAllocatorID());
+  SLIC_ASSERT(axom::getAllocatorIDFromPointer(yVu->getVoidPtr()) ==
+              meshGrp->getDefaultAllocatorID());
+  #endif
+
+  const axom::MDMapping<DIM> vertMapping(vertsShape,
+                                         axom::ArrayStrideOrder::COLUMN);
+  axom::ArrayView<double, DIM> xView(xVu->getData(),
+                                     vertsShape,
+                                     vertMapping.strides());
+  axom::ArrayView<double, DIM> yView(yVu->getData(),
+                                     vertsShape,
+                                     vertMapping.strides());
+
+  fill_cartesian_coords_2d(runtimePolicy, bbox, xView, yView);
+
+  #if defined(AXOM_DEBUG) && defined(AXOM_USE_CONDUIT)
+  {
+    conduit::Node info;
+    bool isValid = verifyBlueprintMesh(meshGrp, info);
+    SLIC_ASSERT_MSG(isValid, "Internal error: Generated mesh is invalid.");
+  }
+  #endif
+
+  return meshGrp;
+}
+
+axom::sidre::Group* make_unstructured_blueprint_box_mesh_3d(
   axom::sidre::Group* meshGrp,
   const primal::BoundingBox<double, 3>& bbox,
   const NumericArray<int, 3>& res,
@@ -190,33 +266,53 @@ axom::sidre::Group* make_unstructured_blueprint_box_mesh(
   const std::string& coordsetName,
   axom::runtime_policy::Policy runtimePolicy)
 {
-  make_structured_blueprint_box_mesh(meshGrp,
-                                     bbox,
-                                     res,
-                                     topologyName,
-                                     coordsetName,
-                                     runtimePolicy);
-  convert_blueprint_structured_explicit_to_unstructured(meshGrp,
-                                                        topologyName,
-                                                        runtimePolicy);
+  make_structured_blueprint_box_mesh_3d(meshGrp,
+                                        bbox,
+                                        res,
+                                        topologyName,
+                                        coordsetName,
+                                        runtimePolicy);
+  convert_blueprint_structured_explicit_to_unstructured_3d(meshGrp,
+                                                           topologyName,
+                                                           runtimePolicy);
   return meshGrp;
 }
 
-void convert_blueprint_structured_explicit_to_unstructured(
+axom::sidre::Group* make_unstructured_blueprint_box_mesh_2d(
+  axom::sidre::Group* meshGrp,
+  const primal::BoundingBox<double, 2>& bbox,
+  const NumericArray<int, 2>& res,
+  const std::string& topologyName,
+  const std::string& coordsetName,
+  axom::runtime_policy::Policy runtimePolicy)
+{
+  make_structured_blueprint_box_mesh_2d(meshGrp,
+                                        bbox,
+                                        res,
+                                        topologyName,
+                                        coordsetName,
+                                        runtimePolicy);
+  convert_blueprint_structured_explicit_to_unstructured_2d(meshGrp,
+                                                           topologyName,
+                                                           runtimePolicy);
+  return meshGrp;
+}
+
+void convert_blueprint_structured_explicit_to_unstructured_3d(
   axom::sidre::Group* meshGrp,
   const std::string& topoName,
   axom::runtime_policy::Policy runtimePolicy)
 {
   if(runtimePolicy == axom::runtime_policy::Policy::seq)
   {
-    convert_blueprint_structured_explicit_to_unstructured_impl<axom::SEQ_EXEC>(
+    convert_blueprint_structured_explicit_to_unstructured_impl_3d<axom::SEQ_EXEC>(
       meshGrp,
       topoName);
   }
   #if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
   if(runtimePolicy == axom::runtime_policy::Policy::omp)
   {
-    convert_blueprint_structured_explicit_to_unstructured_impl<axom::OMP_EXEC>(
+    convert_blueprint_structured_explicit_to_unstructured_impl_3d<axom::OMP_EXEC>(
       meshGrp,
       topoName);
   }
@@ -224,15 +320,50 @@ void convert_blueprint_structured_explicit_to_unstructured(
   #if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
   if(runtimePolicy == axom::runtime_policy::Policy::cuda)
   {
-    convert_blueprint_structured_explicit_to_unstructured_impl<axom::CUDA_EXEC<256>>(
-      meshGrp,
-      topoName);
+    convert_blueprint_structured_explicit_to_unstructured_impl_3d<
+      axom::CUDA_EXEC<256>>(meshGrp, topoName);
   }
   #endif
   #if defined(AXOM_RUNTIME_POLICY_USE_HIP)
   if(runtimePolicy == axom::runtime_policy::Policy::hip)
   {
-    convert_blueprint_structured_explicit_to_unstructured_impl<axom::HIP_EXEC<256>>(
+    convert_blueprint_structured_explicit_to_unstructured_impl_3d<axom::HIP_EXEC<256>>(
+      meshGrp,
+      topoName);
+  }
+  #endif
+}
+
+void convert_blueprint_structured_explicit_to_unstructured_2d(
+  axom::sidre::Group* meshGrp,
+  const std::string& topoName,
+  axom::runtime_policy::Policy runtimePolicy)
+{
+  if(runtimePolicy == axom::runtime_policy::Policy::seq)
+  {
+    convert_blueprint_structured_explicit_to_unstructured_impl_2d<axom::SEQ_EXEC>(
+      meshGrp,
+      topoName);
+  }
+  #if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
+  if(runtimePolicy == axom::runtime_policy::Policy::omp)
+  {
+    convert_blueprint_structured_explicit_to_unstructured_impl_2d<axom::OMP_EXEC>(
+      meshGrp,
+      topoName);
+  }
+  #endif
+  #if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
+  if(runtimePolicy == axom::runtime_policy::Policy::cuda)
+  {
+    convert_blueprint_structured_explicit_to_unstructured_impl_2d<
+      axom::CUDA_EXEC<256>>(meshGrp, topoName);
+  }
+  #endif
+  #if defined(AXOM_RUNTIME_POLICY_USE_HIP)
+  if(runtimePolicy == axom::runtime_policy::Policy::hip)
+  {
+    convert_blueprint_structured_explicit_to_unstructured_impl_2d<axom::HIP_EXEC<256>>(
       meshGrp,
       topoName);
   }
@@ -240,7 +371,7 @@ void convert_blueprint_structured_explicit_to_unstructured(
 }
 
 template <typename ExecSpace>
-void convert_blueprint_structured_explicit_to_unstructured_impl(
+void convert_blueprint_structured_explicit_to_unstructured_impl_3d(
   axom::sidre::Group* meshGrp,
   const std::string& topoName)
 {
@@ -377,6 +508,138 @@ void convert_blueprint_structured_explicit_to_unstructured_impl(
   return;
 }
 
+template <typename ExecSpace>
+void convert_blueprint_structured_explicit_to_unstructured_impl_2d(
+  axom::sidre::Group* meshGrp,
+  const std::string& topoName)
+{
+  AXOM_ANNOTATE_SCOPE("convert_to_unstructured");
+  constexpr int DIM = 2;
+  constexpr int NUM_VERTS_PER_QUAD = 4;
+
+  const std::string& coordsetName =
+    meshGrp->getView("topologies/" + topoName + "/coordset")->getString();
+
+  sidre::Group* coordsetGrp =
+    meshGrp->getGroup("coordsets")->getGroup(coordsetName);
+  SLIC_ASSERT(std::string(coordsetGrp->getView("type")->getString()) ==
+              "explicit");
+
+  axom::sidre::Group* topoGrp =
+    meshGrp->getGroup("topologies")->getGroup(topoName);
+  axom::sidre::View* topoTypeView = topoGrp->getView("type");
+  SLIC_ASSERT(std::string(topoTypeView->getString()) == "structured");
+  topoTypeView->setString("unstructured");
+  topoGrp->createView("elements/shape")->setString("quad");
+
+  axom::sidre::Group* topoElemGrp = topoGrp->getGroup("elements");
+  axom::sidre::Group* topoDimsGrp = topoElemGrp->getGroup("dims");
+
+  // Assuming no ghost, but we should eventually support ghosts.
+  SLIC_ASSERT(!topoGrp->hasGroup("elements/offsets"));
+  SLIC_ASSERT(!topoGrp->hasGroup("elements/strides"));
+
+  const axom::StackArray<axom::IndexType, DIM> cShape {
+    axom::IndexType(topoDimsGrp->getView("i")->getNode().to_value()),
+    axom::IndexType(topoDimsGrp->getView("j")->getNode().to_value())};
+  const axom::StackArray<axom::IndexType, DIM> vShape {cShape[0] + 1,
+                                                       cShape[1] + 1};
+
+  const axom::IndexType cCount = cShape[0] * cShape[1];
+
+  // 4 vertices per quad cell
+  const axom::StackArray<axom::IndexType, 2> connShape {cCount,
+                                                        NUM_VERTS_PER_QUAD};
+  axom::sidre::View* connView = topoGrp->createViewWithShapeAndAllocate(
+    "elements/connectivity",
+    axom::sidre::detail::SidreTT<axom::IndexType>::id,
+    2,
+    connShape.begin());
+  axom::ArrayView<axom::IndexType, 2> connArrayView(
+    static_cast<axom::IndexType*>(connView->getVoidPtr()),
+    connShape);
+
+  axom::MDMapping<DIM> cIdMapping(cShape, axom::ArrayStrideOrder::COLUMN);
+  axom::MDMapping<DIM> vIdMapping(vShape, axom::ArrayStrideOrder::COLUMN);
+
+  const axom::StackArray<const axom::StackArray<axom::IndexType, DIM>, NUM_VERTS_PER_QUAD>
+    cornerOffsets {{{0, 0}, {1, 0}, {1, 1}, {0, 1}}};
+  axom::for_all<ExecSpace>(
+    cCount,
+    AXOM_LAMBDA(axom::IndexType iCell) {
+      axom::StackArray<axom::IndexType, DIM> cIdx =
+        cIdMapping.toMultiIndex(iCell);
+      for(int n = 0; n < NUM_VERTS_PER_QUAD; ++n)
+      {
+        const auto& cornerOffset = cornerOffsets[n];
+        axom::StackArray<axom::IndexType, DIM> vIdx;
+        for(int d = 0; d < DIM; ++d)
+        {
+          vIdx[d] = cIdx[d] + cornerOffset[d];
+        }
+        axom::IndexType iVert = vIdMapping.toFlatIndex(vIdx);
+        connArrayView(iCell, n) = iVert;
+      }
+    });
+
+  const bool addExtraDataForMint = true;
+  if(addExtraDataForMint)
+  {
+    AXOM_ANNOTATE_BEGIN("add_extra");
+    /*
+      Constructing a mint mesh from meshGrp fails unless we add some
+      extra data.  Blueprint doesn't require this extra data.  (The mesh
+      passes conduit's Blueprint verification.)  This should be fixed,
+      or we should write better blueprint support utilities.
+    */
+    /*
+      Make the coordinate arrays 2D to use mint::Mesh.
+      For some reason, mint::Mesh requires the arrays to be
+      2D, even though the second dimension is always 1.
+    */
+    axom::IndexType curShape[2];
+    int curDim;
+    auto* valuesGrp = coordsetGrp->getGroup("values");
+    curDim = valuesGrp->getView("x")->getShape(2, curShape);
+    assert(curDim == 1);
+    const axom::IndexType vertsShape[2] = {curShape[0], 1};
+    valuesGrp->getView("x")->reshapeArray(2, vertsShape);
+    valuesGrp->getView("y")->reshapeArray(2, vertsShape);
+
+    // Make connectivity array 2D for the same reason.
+    auto* elementsGrp = topoGrp->getGroup("elements");
+    auto* connView = elementsGrp->getView("connectivity");
+    curDim = connView->getShape(2, curShape);
+    SLIC_ASSERT(curDim == 2);
+    // Is this code necessary? Not reached in example, and accesses out-of-bounds index
+    // constexpr axom::IndexType NUM_VERTS_PER_HEX = 8;
+    // if(curDim == 1)
+    // {
+    //   SLIC_ASSERT(curShape[0] % NUM_VERTS_PER_HEX == 0);
+    //   axom::IndexType connShape[2] = {curShape[0] / NUM_VERTS_PER_HEX,
+    //                                   NUM_VERTS_PER_HEX};
+    //   connView->reshapeArray(2, connShape);
+    // }
+
+    // mint::Mesh requires connectivity strides, even though Blueprint doesn't.
+    elementsGrp->createViewScalar("stride", NUM_VERTS_PER_QUAD);
+
+    // mint::Mesh requires field group, even though Blueprint doesn't.
+    meshGrp->createGroup("fields");
+    AXOM_ANNOTATE_END("add_extra");
+  }
+
+  #if defined(AXOM_DEBUG) && defined(AXOM_USE_CONDUIT)
+  AXOM_ANNOTATE_BEGIN("validate_post");
+  conduit::Node info;
+  bool isValid = verifyBlueprintMesh(meshGrp, info);
+  SLIC_ASSERT_MSG(isValid, "Internal error: Generated mesh is invalid.");
+  AXOM_ANNOTATE_END("validate_post");
+  #endif
+
+  return;
+}
+
   #if defined(AXOM_USE_CONDUIT)
 bool verifyBlueprintMesh(const axom::sidre::Group* meshGrp, conduit::Node info)
 {
@@ -422,6 +685,35 @@ void fill_cartesian_coords_3d(axom::runtime_policy::Policy runtimePolicy,
                                                        xView,
                                                        yView,
                                                        zView);
+  }
+#endif
+}
+
+void fill_cartesian_coords_2d(axom::runtime_policy::Policy runtimePolicy,
+                              const primal::BoundingBox<double, 2>& domainBox,
+                              axom::ArrayView<double, 2>& xView,
+                              axom::ArrayView<double, 2>& yView)
+{
+  if(runtimePolicy == axom::runtime_policy::Policy::seq)
+  {
+    fill_cartesian_coords_2d_impl<axom::SEQ_EXEC>(domainBox, xView, yView);
+  }
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
+  if(runtimePolicy == axom::runtime_policy::Policy::omp)
+  {
+    fill_cartesian_coords_2d_impl<axom::OMP_EXEC>(domainBox, xView, yView);
+  }
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
+  if(runtimePolicy == axom::runtime_policy::Policy::cuda)
+  {
+    fill_cartesian_coords_2d_impl<axom::CUDA_EXEC<256>>(domainBox, xView, yView);
+  }
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
+  if(runtimePolicy == axom::runtime_policy::Policy::hip)
+  {
+    fill_cartesian_coords_2d_impl<axom::HIP_EXEC<256>>(domainBox, xView, yView);
   }
 #endif
 }
@@ -500,6 +792,72 @@ void fill_cartesian_coords_3d_impl(const primal::BoundingBox<double, 3>& domainB
         yView(i, j, k) = domainBox.getMin()[1] + j * dy;
         zView(i, j, k) = domainBox.getMin()[2] + k * dz;
       }
+    }
+  }
+#endif
+
+  return;
+}
+
+template <typename ExecSpace>
+void fill_cartesian_coords_2d_impl(const primal::BoundingBox<double, 2>& domainBox,
+                                   axom::ArrayView<double, 2>& xView,
+                                   axom::ArrayView<double, 2>& yView)
+{
+#if defined(AXOM_DEBUG)
+  using XS = axom::execution_space<ExecSpace>;
+  SLIC_ASSERT_MSG(XS::usesAllocId(xView.getAllocatorID()) &&
+                    XS::usesAllocId(yView.getAllocatorID()),
+                  std::string("fill_cartesian_coords_2d_impl: alloc ids ") +
+                    std::to_string(xView.getAllocatorID()) + " and " +
+                    std::to_string(yView.getAllocatorID()) +
+                    " are not all compatible with execution space " + XS::name());
+#endif
+
+  const auto& shape = xView.shape();
+  const auto& mapping = xView.mapping();
+
+  SLIC_ASSERT(shape == yView.shape());
+  SLIC_ASSERT(mapping == yView.mapping());
+
+  // Mesh resolution
+  const axom::NumericArray<axom::IndexType, 2> res {shape[0] - 1, shape[1] - 1};
+
+  // Mesh spacings.
+  double dx = (domainBox.getMax()[0] - domainBox.getMin()[0]) / res[0];
+  double dy = (domainBox.getMax()[1] - domainBox.getMin()[1]) / res[1];
+
+#if defined(AXOM_USE_RAJA)
+  RAJA::RangeSegment jRange(0, shape[1]);
+  RAJA::RangeSegment iRange(0, shape[0]);
+  using EXEC_POL =
+    typename axom::internal::nested_for_exec<ExecSpace>::loop2d_policy;
+  auto order = mapping.getStrideOrder();
+  if(int(order) & int(axom::ArrayStrideOrder::COLUMN))
+  {
+    RAJA::kernel<EXEC_POL>(
+      RAJA::make_tuple(iRange, jRange),
+      AXOM_LAMBDA(axom::IndexType i, axom::IndexType j) {
+        xView(i, j) = domainBox.getMin()[0] + i * dx;
+        yView(i, j) = domainBox.getMin()[1] + j * dy;
+      });
+  }
+  else
+  {
+    RAJA::kernel<EXEC_POL>(
+      RAJA::make_tuple(jRange, iRange),
+      AXOM_LAMBDA(axom::IndexType j, axom::IndexType i) {
+        xView(i, j) = domainBox.getMin()[0] + i * dx;
+        yView(i, j) = domainBox.getMin()[1] + j * dy;
+      });
+  }
+#else
+  for(int j = 0; j < res[1]; ++j)
+  {
+    for(int i = 0; i < res[0]; ++i)
+    {
+      xView(i, j) = domainBox.getMin()[0] + i * dx;
+      yView(i, j) = domainBox.getMin()[1] + j * dy;
     }
   }
 #endif

--- a/src/axom/quest/util/mesh_helpers.cpp
+++ b/src/axom/quest/util/mesh_helpers.cpp
@@ -611,15 +611,6 @@ void convert_blueprint_structured_explicit_to_unstructured_impl_2d(
     auto* connView = elementsGrp->getView("connectivity");
     curDim = connView->getShape(2, curShape);
     SLIC_ASSERT(curDim == 2);
-    // Is this code necessary? Not reached in example, and accesses out-of-bounds index
-    // constexpr axom::IndexType NUM_VERTS_PER_HEX = 8;
-    // if(curDim == 1)
-    // {
-    //   SLIC_ASSERT(curShape[0] % NUM_VERTS_PER_HEX == 0);
-    //   axom::IndexType connShape[2] = {curShape[0] / NUM_VERTS_PER_HEX,
-    //                                   NUM_VERTS_PER_HEX};
-    //   connView->reshapeArray(2, connShape);
-    // }
 
     // mint::Mesh requires connectivity strides, even though Blueprint doesn't.
     constexpr axom::IndexType BIT_SPECIFIC_NUM_VERTS_PER_QUAD = 4;

--- a/src/axom/quest/util/mesh_helpers.cpp
+++ b/src/axom/quest/util/mesh_helpers.cpp
@@ -622,7 +622,8 @@ void convert_blueprint_structured_explicit_to_unstructured_impl_2d(
     // }
 
     // mint::Mesh requires connectivity strides, even though Blueprint doesn't.
-    elementsGrp->createViewScalar("stride", NUM_VERTS_PER_QUAD);
+    constexpr axom::IndexType BIT_SPECIFIC_NUM_VERTS_PER_QUAD = 4;
+    elementsGrp->createViewScalar("stride", BIT_SPECIFIC_NUM_VERTS_PER_QUAD);
 
     // mint::Mesh requires field group, even though Blueprint doesn't.
     meshGrp->createGroup("fields");

--- a/src/axom/quest/util/mesh_helpers.hpp
+++ b/src/axom/quest/util/mesh_helpers.hpp
@@ -65,7 +65,7 @@ mfem::Mesh* make_cartesian_mfem_mesh_3D(const primal::BoundingBox<double, 3>& bb
 
 #if defined(AXOM_USE_SIDRE)
 /*!
-  /brief Creates a 3D Cartesian mfem mesh lying within a given bounding box
+  /brief Creates a 3D Cartesian blueprint mesh lying within a given bounding box
 
   \param meshGrp Put the mesh in this Group
   \param bbox The bounding box for the mesh
@@ -78,7 +78,7 @@ mfem::Mesh* make_cartesian_mfem_mesh_3D(const primal::BoundingBox<double, 3>& bb
 
   \return The meshGrp pointer
 */
-axom::sidre::Group* make_structured_blueprint_box_mesh(
+axom::sidre::Group* make_structured_blueprint_box_mesh_3d(
   axom::sidre::Group* meshGrp,
   const primal::BoundingBox<double, 3>& bbox,
   const NumericArray<int, 3>& res,
@@ -86,10 +86,40 @@ axom::sidre::Group* make_structured_blueprint_box_mesh(
   const std::string& coordsetName = "coords",
   axom::runtime_policy::Policy runtimePolicy = axom::runtime_policy::Policy::seq);
 
-axom::sidre::Group* make_unstructured_blueprint_box_mesh(
+axom::sidre::Group* make_unstructured_blueprint_box_mesh_3d(
   axom::sidre::Group* meshGrp,
   const primal::BoundingBox<double, 3>& bbox,
   const NumericArray<int, 3>& res,
+  const std::string& topologyName = "mesh",
+  const std::string& coordsetName = "coords",
+  axom::runtime_policy::Policy runtimePolicy = axom::runtime_policy::Policy::seq);
+
+/*!
+  /brief Creates a 2D Cartesian blueprint mesh lying within a given bounding box
+
+  \param meshGrp Put the mesh in this Group
+  \param bbox The bounding box for the mesh
+  \param res The resolution of the mesh
+  \param topologyName Name of the blueprint topoloyy to use.
+  \param coordsetName Name of the blueprint coordset to use.
+  \param runtimePolicy Runtime policy, see axom::runtime_policy.
+         Memory in \c meshGrp must be compatible with the
+         specified policy.
+
+  \return The meshGrp pointer
+*/
+axom::sidre::Group* make_structured_blueprint_box_mesh_2d(
+  axom::sidre::Group* meshGrp,
+  const primal::BoundingBox<double, 2>& bbox,
+  const NumericArray<int, 2>& res,
+  const std::string& topologyName = "mesh",
+  const std::string& coordsetName = "coords",
+  axom::runtime_policy::Policy runtimePolicy = axom::runtime_policy::Policy::seq);
+
+axom::sidre::Group* make_unstructured_blueprint_box_mesh_2d(
+  axom::sidre::Group* meshGrp,
+  const primal::BoundingBox<double, 2>& bbox,
+  const NumericArray<int, 2>& res,
   const std::string& topologyName = "mesh",
   const std::string& coordsetName = "coords",
   axom::runtime_policy::Policy runtimePolicy = axom::runtime_policy::Policy::seq);
@@ -107,13 +137,23 @@ axom::sidre::Group* make_unstructured_blueprint_box_mesh(
   the same allocator id, even if the intermediate steps have to
   transfers memory to and from another space.
 */
-void convert_blueprint_structured_explicit_to_unstructured(
+void convert_blueprint_structured_explicit_to_unstructured_3d(
   axom::sidre::Group* meshGrp,
   const std::string& topoName,
   axom::runtime_policy::Policy runtimePolicy);
 
 template <typename ExecSpace>
-void convert_blueprint_structured_explicit_to_unstructured_impl(
+void convert_blueprint_structured_explicit_to_unstructured_impl_3d(
+  axom::sidre::Group* meshGrp,
+  const std::string& topoName);
+
+void convert_blueprint_structured_explicit_to_unstructured_2d(
+  axom::sidre::Group* meshGrp,
+  const std::string& topoName,
+  axom::runtime_policy::Policy runtimePolicy);
+
+template <typename ExecSpace>
+void convert_blueprint_structured_explicit_to_unstructured_impl_2d(
   axom::sidre::Group* meshGrp,
   const std::string& topoName);
 
@@ -127,7 +167,7 @@ bool verifyBlueprintMesh(const axom::sidre::Group* meshGrp, conduit::Node info);
 #endif
 
 /*!
-  @brief Fill in structured mesh cartesian coordinates.
+  @brief Fill in 3D structured mesh cartesian coordinates.
   \param runtimePolicy Runtime execution space selector
   \param xView Vertex x-values array
   \param yView Vertex y-values array
@@ -144,7 +184,22 @@ void fill_cartesian_coords_3d(axom::runtime_policy::Policy runtimePolicy,
                               axom::ArrayView<double, 3>& zView);
 
 /*!
-  @brief Fill in structured mesh cartesian coordinates.
+  @brief Fill in 2D structured mesh cartesian coordinates.
+  \param runtimePolicy Runtime execution space selector
+  \param xView Vertex x-values array
+  \param yView Vertex y-values array
+  \param domainBox Physical domain
+
+  Array data must be in a memory space accessible by the
+  selected \c runtimePolicy.
+*/
+void fill_cartesian_coords_2d(axom::runtime_policy::Policy runtimePolicy,
+                              const primal::BoundingBox<double, 2>& domainBox,
+                              axom::ArrayView<double, 2>& xView,
+                              axom::ArrayView<double, 2>& yView);
+
+/*!
+  @brief Fill in 3D structured mesh cartesian coordinates.
   \tparam ExecSpace Execution space, e.g. \c axom::SEQ_EXEC.
           @see axom::execution_space
   \param xView Vertex x-values array
@@ -157,6 +212,19 @@ void fill_cartesian_coords_3d_impl(const primal::BoundingBox<double, 3>& domainB
                                    axom::ArrayView<double, 3>& xView,
                                    axom::ArrayView<double, 3>& yView,
                                    axom::ArrayView<double, 3>& zView);
+
+/*!
+  @brief Fill in 2D structured mesh cartesian coordinates.
+  \tparam ExecSpace Execution space, e.g. \c axom::SEQ_EXEC.
+          @see axom::execution_space
+  \param xView Vertex x-values array
+  \param yView Vertex y-values array
+  \param domainBox Physical domain
+*/
+template <typename ExecSpace>
+void fill_cartesian_coords_2d_impl(const primal::BoundingBox<double, 2>& domainBox,
+                                   axom::ArrayView<double, 2>& xView,
+                                   axom::ArrayView<double, 2>& yView);
 
 }  // namespace util
 }  // namespace quest

--- a/triangle_2d.yaml
+++ b/triangle_2d.yaml
@@ -1,0 +1,8 @@
+dimensions: 2
+units: cm
+shapes:
+  - name: unit_triangle 
+    material: steel
+    geometry:
+      format: stl 
+      path: ./unit_triangle.stl

--- a/triangle_2d.yaml
+++ b/triangle_2d.yaml
@@ -1,8 +1,0 @@
-dimensions: 2
-units: cm
-shapes:
-  - name: unit_triangle 
-    material: steel
-    geometry:
-      format: stl 
-      path: ./unit_triangle.stl

--- a/unit_triangle.stl
+++ b/unit_triangle.stl
@@ -1,0 +1,9 @@
+solid unit_triangle
+  facet normal 0 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 1 0 0
+      vertex 0 1 0
+    endloop
+  endfacet
+endsolid unit_triangle

--- a/unit_triangle.stl
+++ b/unit_triangle.stl
@@ -1,9 +1,0 @@
-solid unit_triangle
-  facet normal 0 0 0
-    outer loop
-      vertex 0 0 0
-      vertex 1 0 0
-      vertex 0 1 0
-    endloop
-  endfacet
-endsolid unit_triangle


### PR DESCRIPTION
This PR:
 - Adds 2D intersection shaping, accepting as input either a 2D `stl` mesh of triangles (0 for z-coordinates) or a 2D in-memory triangle blueprint mesh.
   - `quest_shape_in_memory.cpp` modified to support a 2D in-memory triangle mesh (`create2DShapeSet`). 
 - Adds additional utility functions to `mesh_helpers` for generation of 2D quad meshes using mfem/sidre/blueprint
 - Related PR LLNL/axom_data#25 adds a 2D `stl` mesh for testing.
 - Fixes bug in `shaping_driver.cpp` where policy used for allocation would always be sequential.
 - Runtime regex output tests added in `src/axom/quest/examples/CMakeLists.txt` for `quest_shaping_driver_ex` and `quest_shape_in_memory_ex` executables.