### PR TITLE
Added LineFileTagCombiner

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -41,6 +41,7 @@ to use Open Cascade's file I/O capabilities in support of Quest applications.
 - Adds a piecewise method to load external data using `sidre::IOManager`.  This adds new overloaded methods
   of `loadExternalData` in `sidre::IOManager` and `sidre::Group`.
 - Adds intersection routines between `primal::Ray` objects and `primal::NURBSCurve`/`primal::NURBSPatch` objects.
+- Adds LineFileTagCombiner to Lumberjack to allow combining messages if line number, file, and tag are equal.
 
 ###  Changed
 - `primal::NumericArray` has been moved to `core`.  The header is `core/NumericArray.hpp`.

--- a/src/axom/lumberjack/LineFileTagCombiner.hpp
+++ b/src/axom/lumberjack/LineFileTagCombiner.hpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ *******************************************************************************
+ * \file LineFileTagCombiner.hpp
+ *
+ * \brief This file contains the class implementation of the
+ * LineFileTagCombiner.
+ *******************************************************************************
+ */
+
+#ifndef LINEFILETAGCOMBINER_HPP
+#define LINEFILETAGCOMBINER_HPP
+
+#include "axom/lumberjack/Combiner.hpp"
+#include "axom/lumberjack/Message.hpp"
+
+#include <string>
+
+namespace axom
+{
+namespace lumberjack
+{
+/*!
+ *******************************************************************************
+ * \class LineFileTagCombiner
+ *
+ * \brief Combines Message classes if their Message::fileName, 
+ *        Message::lineNumer, and Message::tag are equal.
+ *
+ *******************************************************************************
+ */
+class LineFileTagCombiner : public axom::lumberjack::Combiner
+{
+public:
+  LineFileTagCombiner() { }
+
+  /*!
+   *****************************************************************************
+   * \brief Returns the unique string identifier for this combiner. Used by
+   *  Lumberjack to differentiate between other combiners.
+   *****************************************************************************
+   */
+  const std::string id() { return m_id; }
+
+  /*!
+   *****************************************************************************
+   * \brief Function used by Lumberjack to indicate whether two messages should
+   *  be combined.
+   *
+   * They are not actually combined by this function. Message classes are
+   * triggered for combination if Message::fileName, Message::lineNumer, 
+   * and Message::tag are equal.
+   *
+   * \param [in] leftMessage One of the Messages to be compared.
+   * \param [in] rightMessage One of the Messages to be compared.
+   *****************************************************************************
+   */
+  bool shouldMessagesBeCombined(const axom::lumberjack::Message& leftMessage,
+                                const axom::lumberjack::Message& rightMessage)
+  {
+    return ((leftMessage.lineNumber() == rightMessage.lineNumber()) &&
+            leftMessage.fileName().compare(rightMessage.fileName()) == 0 &&
+            leftMessage.tag().compare(rightMessage.tag()) == 0);
+  }
+
+  /*!
+   *****************************************************************************
+   * \brief Combines the combinee into the combined Message.
+   *
+   * The only thing truly combined in this Combiner is the ranks from combinee
+   * to combined.  The text will not be combined, even if it is not equal.  
+   * Only text from the first message will be saved.
+   *
+   * \param [in,out] combined the Message that will be modified.
+   * \param [in] combinee the Message that is combined into the other.
+   * \param [in] ranksLimit The limit on how many individual ranks are tracked
+   *  in the combined Message. Message::rankCount is always incremented.
+   *
+   * \pre shouldMessagesBeCombined(combined, combinee) must be true
+   *****************************************************************************
+   */
+  void combine(axom::lumberjack::Message& combined,
+               const axom::lumberjack::Message& combinee,
+               const int ranksLimit)
+  {
+    combined.addRanks(combinee.ranks(), combinee.count(), ranksLimit);
+  }
+
+private:
+  const std::string m_id = "LineFileTagCombiner";
+};
+
+}  // end namespace lumberjack
+}  // end namespace axom
+
+#endif

--- a/src/axom/lumberjack/docs/sphinx/combiner_class.rst
+++ b/src/axom/lumberjack/docs/sphinx/combiner_class.rst
@@ -46,3 +46,15 @@ the ranksLimit) and incrementing the Message's count as well.  This is handled b
 Message.addRanks().
 
 .. note:: You can add this Combiner by calling Lumberjack::addCombiner(new TextEqualityCombiner).
+
+.. _linefiletagcombiner_class_label:
+
+LineFileTagCombiner
+^^^^^^^^^^^^^^^^^^^
+
+This Combiner combines the two given Messages if the Message line number, file name,
+and tag are equal.  It does so by adding the second Message's ranks to the first
+Message (if not past the ranksLimit) and incrementing the Message's count as well.
+This is handled by Message.addRanks().
+
+.. note:: You can add this Combiner by calling Lumberjack::addCombiner(new LineFileTagCombiner).  The combiner does not compare the text of the two messages passed in.  Therefore, the message texts do not get combined, and the first message text remains unchanged.

--- a/src/axom/lumberjack/tests/CMakeLists.txt
+++ b/src/axom/lumberjack/tests/CMakeLists.txt
@@ -13,7 +13,8 @@ set(lumberjack_serial_tests
     lumberjack_Lumberjack.hpp
     lumberjack_Message.hpp
     lumberjack_TextEqualityCombiner.hpp
-    lumberjack_TextTagCombiner.hpp )
+    lumberjack_TextTagCombiner.hpp
+    lumberjack_LineFileTagCombiner.hpp )
 
 axom_add_executable(NAME       lumberjack_serial_tests
                     SOURCES    lumberjack_serial_main.cpp

--- a/src/axom/lumberjack/tests/lumberjack_LineFileTagCombiner.hpp
+++ b/src/axom/lumberjack/tests/lumberjack_LineFileTagCombiner.hpp
@@ -45,14 +45,14 @@ inline void verifyMessage(const axom::lumberjack::Message& message,
 // Struct to hold test parameters
 struct TestParams
 {
-  std::string caseName;
-  int lineNumber1;
-  int lineNumber2;
-  std::string fileName1;
-  std::string fileName2;
-  std::string tag1;
-  std::string tag2;
-  bool shouldCombine;
+  std::string caseName{""};
+  int lineNumber1{-1};
+  int lineNumber2{-1};
+  std::string fileName1{""};
+  std::string fileName2{""};
+  std::string tag1{""};
+  std::string tag2{""};
+  bool shouldCombine{false};
 };
 
 // Parameterized Test Fixture

--- a/src/axom/lumberjack/tests/lumberjack_LineFileTagCombiner.hpp
+++ b/src/axom/lumberjack/tests/lumberjack_LineFileTagCombiner.hpp
@@ -1,0 +1,401 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "gtest/gtest.h"
+
+#include "axom/lumberjack/LineFileTagCombiner.hpp"
+
+TEST(lumberjack_LineFileTagCombiner, case01)
+{
+  //Test positive case: two equal line numbers, filenames, and tags
+  std::string text1 =
+    "This message does not matter because we do not filter by text";
+  axom::lumberjack::Message m1;
+  m1.text(text1);
+  m1.addRank(13, 5);
+  m1.fileName("foo.cpp");
+  m1.lineNumber(154);
+  m1.tag("myTag");
+
+  std::string text2 =
+    "This message ALSO does not matter because we do not filter by text";
+  axom::lumberjack::Message m2;
+  m2.text(text2);
+  m2.addRank(14, 5);
+  m2.fileName("foo.cpp");
+  m2.lineNumber(154);
+  m2.tag("myTag");
+
+  axom::lumberjack::LineFileTagCombiner c;
+
+  bool shouldMessagesBeCombined = c.shouldMessagesBeCombined(m1, m2);
+
+  if(shouldMessagesBeCombined == true)
+  {
+    c.combine(m1, m2, 5);
+  }
+
+  EXPECT_EQ(shouldMessagesBeCombined, true);
+
+  EXPECT_EQ(m1.lineNumber(), 154);
+  EXPECT_EQ(m1.fileName().compare("foo.cpp"), 0);
+  EXPECT_EQ(m1.text().compare(text1), 0);
+  EXPECT_EQ(m1.count(), 2);
+  EXPECT_EQ(m1.ranks().size(), 2);
+  EXPECT_EQ(m1.ranks()[0], 13);
+  EXPECT_EQ(m1.ranks()[1], 14);
+  EXPECT_EQ(m1.tag().compare("myTag"), 0);
+
+  EXPECT_EQ(m2.lineNumber(), 154);
+  EXPECT_EQ(m2.fileName().compare("foo.cpp"), 0);
+  EXPECT_EQ(m2.text().compare(text2), 0);
+  EXPECT_EQ(m2.count(), 1);
+  EXPECT_EQ(m2.ranks().size(), 1);
+  EXPECT_EQ(m2.ranks()[0], 14);
+  EXPECT_EQ(m2.tag().compare("myTag"), 0);
+}
+
+TEST(lumberjack_LineFileTagCombiner, case02)
+{
+  //Test negative case: two not equal line numbers, equal filenames, and equal tags
+  std::string text1 =
+    "This message does not matter because we do not filter by text";
+  axom::lumberjack::Message m1;
+  m1.text(text1);
+  m1.addRank(13, 5);
+  m1.fileName("foo.cpp");
+  m1.lineNumber(12000);
+  m1.tag("myTag");
+
+  std::string text2 =
+    "This message ALSO does not matter because we do not filter by text";
+  axom::lumberjack::Message m2;
+  m2.text(text2);
+  m2.addRank(14, 5);
+  m2.fileName("foo.cpp");
+  m2.lineNumber(154);
+  m2.tag("myTag");
+
+  axom::lumberjack::LineFileTagCombiner c;
+
+  bool shouldMessagesBeCombined = c.shouldMessagesBeCombined(m1, m2);
+
+  if(shouldMessagesBeCombined == true)
+  {
+    c.combine(m1, m2, 5);
+  }
+
+  EXPECT_EQ(shouldMessagesBeCombined, false);
+
+  EXPECT_EQ(m1.lineNumber(), 12000);
+  EXPECT_EQ(m1.fileName().compare("foo.cpp"), 0);
+  EXPECT_EQ(m1.text().compare(text1), 0);
+  EXPECT_EQ(m1.count(), 1);
+  EXPECT_EQ(m1.ranks().size(), 1);
+  EXPECT_EQ(m1.ranks()[0], 13);
+  EXPECT_EQ(m1.tag().compare("myTag"), 0);
+
+  EXPECT_EQ(m2.lineNumber(), 154);
+  EXPECT_EQ(m2.fileName().compare("foo.cpp"), 0);
+  EXPECT_EQ(m2.text().compare(text2), 0);
+  EXPECT_EQ(m2.count(), 1);
+  EXPECT_EQ(m2.ranks().size(), 1);
+  EXPECT_EQ(m2.ranks()[0], 14);
+  EXPECT_EQ(m2.tag().compare("myTag"), 0);
+}
+
+TEST(lumberjack_LineFileTagCombiner, case03)
+{
+  //Test negative case: two equal line numbers, not equal filenames, and equal tags
+  std::string text1 =
+    "This message does not matter because we do not filter by text";
+  axom::lumberjack::Message m1;
+  m1.text(text1);
+  m1.addRank(13, 5);
+  m1.fileName("foo.cpp");
+  m1.lineNumber(154);
+  m1.tag("myTag");
+
+  std::string text2 =
+    "This message ALSO does not matter because we do not filter by text";
+  axom::lumberjack::Message m2;
+  m2.text(text2);
+  m2.addRank(14, 5);
+  m2.fileName("bar.cpp");
+  m2.lineNumber(154);
+  m2.tag("myTag");
+
+  axom::lumberjack::LineFileTagCombiner c;
+
+  bool shouldMessagesBeCombined = c.shouldMessagesBeCombined(m1, m2);
+
+  if(shouldMessagesBeCombined == true)
+  {
+    c.combine(m1, m2, 5);
+  }
+
+  EXPECT_EQ(shouldMessagesBeCombined, false);
+
+  EXPECT_EQ(m1.lineNumber(), 154);
+  EXPECT_EQ(m1.fileName().compare("foo.cpp"), 0);
+  EXPECT_EQ(m1.text().compare(text1), 0);
+  EXPECT_EQ(m1.count(), 1);
+  EXPECT_EQ(m1.ranks().size(), 1);
+  EXPECT_EQ(m1.ranks()[0], 13);
+  EXPECT_EQ(m1.tag().compare("myTag"), 0);
+
+  EXPECT_EQ(m2.lineNumber(), 154);
+  EXPECT_EQ(m2.fileName().compare("bar.cpp"), 0);
+  EXPECT_EQ(m2.text().compare(text2), 0);
+  EXPECT_EQ(m2.count(), 1);
+  EXPECT_EQ(m2.ranks().size(), 1);
+  EXPECT_EQ(m2.ranks()[0], 14);
+  EXPECT_EQ(m2.tag().compare("myTag"), 0);
+}
+
+TEST(lumberjack_LineFileTagCombiner, case04)
+{
+  //Test negative case: two equal line numbers, equal filenames, and not equal tags
+  std::string text1 =
+    "This message does not matter because we do not filter by text";
+  axom::lumberjack::Message m1;
+  m1.text(text1);
+  m1.addRank(13, 5);
+  m1.fileName("foo.cpp");
+  m1.lineNumber(154);
+  m1.tag("myTag");
+
+  std::string text2 =
+    "This message ALSO does not matter because we do not filter by text";
+  axom::lumberjack::Message m2;
+  m2.text(text2);
+  m2.addRank(14, 5);
+  m2.fileName("foo.cpp");
+  m2.lineNumber(154);
+  m2.tag("myOtherTag");
+
+  axom::lumberjack::LineFileTagCombiner c;
+
+  bool shouldMessagesBeCombined = c.shouldMessagesBeCombined(m1, m2);
+
+  if(shouldMessagesBeCombined == true)
+  {
+    c.combine(m1, m2, 5);
+  }
+
+  EXPECT_EQ(shouldMessagesBeCombined, false);
+
+  EXPECT_EQ(m1.lineNumber(), 154);
+  EXPECT_EQ(m1.fileName().compare("foo.cpp"), 0);
+  EXPECT_EQ(m1.text().compare(text1), 0);
+  EXPECT_EQ(m1.count(), 1);
+  EXPECT_EQ(m1.ranks().size(), 1);
+  EXPECT_EQ(m1.ranks()[0], 13);
+  EXPECT_EQ(m1.tag().compare("myTag"), 0);
+
+  EXPECT_EQ(m2.lineNumber(), 154);
+  EXPECT_EQ(m2.fileName().compare("foo.cpp"), 0);
+  EXPECT_EQ(m2.text().compare(text2), 0);
+  EXPECT_EQ(m2.count(), 1);
+  EXPECT_EQ(m2.ranks().size(), 1);
+  EXPECT_EQ(m2.ranks()[0], 14);
+  EXPECT_EQ(m2.tag().compare("myOtherTag"), 0);
+}
+
+TEST(lumberjack_LineFileTagCombiner, case05)
+{
+  //Test negative case: two not equal line numbers, not equal filenames, and equal tags
+  std::string text1 =
+    "This message does not matter because we do not filter by text";
+  axom::lumberjack::Message m1;
+  m1.text(text1);
+  m1.addRank(13, 5);
+  m1.fileName("foo.cpp");
+  m1.lineNumber(12000);
+  m1.tag("myTag");
+
+  std::string text2 =
+    "This message ALSO does not matter because we do not filter by text";
+  axom::lumberjack::Message m2;
+  m2.text(text2);
+  m2.addRank(14, 5);
+  m2.fileName("bar.cpp");
+  m2.lineNumber(154);
+  m2.tag("myTag");
+
+  axom::lumberjack::LineFileTagCombiner c;
+
+  bool shouldMessagesBeCombined = c.shouldMessagesBeCombined(m1, m2);
+
+  if(shouldMessagesBeCombined == true)
+  {
+    c.combine(m1, m2, 5);
+  }
+
+  EXPECT_EQ(shouldMessagesBeCombined, false);
+
+  EXPECT_EQ(m1.lineNumber(), 12000);
+  EXPECT_EQ(m1.fileName().compare("foo.cpp"), 0);
+  EXPECT_EQ(m1.text().compare(text1), 0);
+  EXPECT_EQ(m1.count(), 1);
+  EXPECT_EQ(m1.ranks().size(), 1);
+  EXPECT_EQ(m1.ranks()[0], 13);
+  EXPECT_EQ(m1.tag().compare("myTag"), 0);
+
+  EXPECT_EQ(m2.lineNumber(), 154);
+  EXPECT_EQ(m2.fileName().compare("bar.cpp"), 0);
+  EXPECT_EQ(m2.text().compare(text2), 0);
+  EXPECT_EQ(m2.count(), 1);
+  EXPECT_EQ(m2.ranks().size(), 1);
+  EXPECT_EQ(m2.ranks()[0], 14);
+  EXPECT_EQ(m2.tag().compare("myTag"), 0);
+}
+
+TEST(lumberjack_LineFileTagCombiner, case06)
+{
+  //Test negative case: two not equal line numbers, equal filenames, and not equal tags
+  std::string text1 =
+    "This message does not matter because we do not filter by text";
+  axom::lumberjack::Message m1;
+  m1.text(text1);
+  m1.addRank(13, 5);
+  m1.fileName("foo.cpp");
+  m1.lineNumber(12000);
+  m1.tag("myTag");
+
+  std::string text2 =
+    "This message ALSO does not matter because we do not filter by text";
+  axom::lumberjack::Message m2;
+  m2.text(text2);
+  m2.addRank(14, 5);
+  m2.fileName("foo.cpp");
+  m2.lineNumber(154);
+  m2.tag("myOtherTag");
+
+  axom::lumberjack::LineFileTagCombiner c;
+
+  bool shouldMessagesBeCombined = c.shouldMessagesBeCombined(m1, m2);
+
+  if(shouldMessagesBeCombined == true)
+  {
+    c.combine(m1, m2, 5);
+  }
+
+  EXPECT_EQ(shouldMessagesBeCombined, false);
+
+  EXPECT_EQ(m1.lineNumber(), 12000);
+  EXPECT_EQ(m1.fileName().compare("foo.cpp"), 0);
+  EXPECT_EQ(m1.text().compare(text1), 0);
+  EXPECT_EQ(m1.count(), 1);
+  EXPECT_EQ(m1.ranks().size(), 1);
+  EXPECT_EQ(m1.ranks()[0], 13);
+  EXPECT_EQ(m1.tag().compare("myTag"), 0);
+
+  EXPECT_EQ(m2.lineNumber(), 154);
+  EXPECT_EQ(m2.fileName().compare("foo.cpp"), 0);
+  EXPECT_EQ(m2.text().compare(text2), 0);
+  EXPECT_EQ(m2.count(), 1);
+  EXPECT_EQ(m2.ranks().size(), 1);
+  EXPECT_EQ(m2.ranks()[0], 14);
+  EXPECT_EQ(m2.tag().compare("myOtherTag"), 0);
+}
+
+TEST(lumberjack_LineFileTagCombiner, case07)
+{
+  //Test negative case: two equal line numbers, not equal filenames, and not equal tags
+  std::string text1 =
+    "This message does not matter because we do not filter by text";
+  axom::lumberjack::Message m1;
+  m1.text(text1);
+  m1.addRank(13, 5);
+  m1.fileName("foo.cpp");
+  m1.lineNumber(154);
+  m1.tag("myTag");
+
+  std::string text2 =
+    "This message ALSO does not matter because we do not filter by text";
+  axom::lumberjack::Message m2;
+  m2.text(text2);
+  m2.addRank(14, 5);
+  m2.fileName("bar.cpp");
+  m2.lineNumber(154);
+  m2.tag("myOtherTag");
+
+  axom::lumberjack::LineFileTagCombiner c;
+
+  bool shouldMessagesBeCombined = c.shouldMessagesBeCombined(m1, m2);
+
+  if(shouldMessagesBeCombined == true)
+  {
+    c.combine(m1, m2, 5);
+  }
+
+  EXPECT_EQ(shouldMessagesBeCombined, false);
+
+  EXPECT_EQ(m1.lineNumber(), 154);
+  EXPECT_EQ(m1.fileName().compare("foo.cpp"), 0);
+  EXPECT_EQ(m1.text().compare(text1), 0);
+  EXPECT_EQ(m1.count(), 1);
+  EXPECT_EQ(m1.ranks().size(), 1);
+  EXPECT_EQ(m1.ranks()[0], 13);
+  EXPECT_EQ(m1.tag().compare("myTag"), 0);
+
+  EXPECT_EQ(m2.lineNumber(), 154);
+  EXPECT_EQ(m2.fileName().compare("bar.cpp"), 0);
+  EXPECT_EQ(m2.text().compare(text2), 0);
+  EXPECT_EQ(m2.count(), 1);
+  EXPECT_EQ(m2.ranks().size(), 1);
+  EXPECT_EQ(m2.ranks()[0], 14);
+  EXPECT_EQ(m2.tag().compare("myOtherTag"), 0);
+}
+
+TEST(lumberjack_LineFileTagCombiner, case08)
+{
+  //Test negative case: two not equal line numbers, not equal filenames, and not equal tags
+  std::string text1 =
+    "This message does not matter because we do not filter by text";
+  axom::lumberjack::Message m1;
+  m1.text(text1);
+  m1.addRank(13, 5);
+  m1.fileName("foo.cpp");
+  m1.lineNumber(12000);
+  m1.tag("myTag");
+
+  std::string text2 =
+    "This message ALSO does not matter because we do not filter by text";
+  axom::lumberjack::Message m2;
+  m2.text(text2);
+  m2.addRank(14, 5);
+  m2.fileName("bar.cpp");
+  m2.lineNumber(154);
+  m2.tag("myOtherTag");
+
+  axom::lumberjack::LineFileTagCombiner c;
+
+  bool shouldMessagesBeCombined = c.shouldMessagesBeCombined(m1, m2);
+
+  if(shouldMessagesBeCombined == true)
+  {
+    c.combine(m1, m2, 5);
+  }
+
+  EXPECT_EQ(shouldMessagesBeCombined, false);
+
+  EXPECT_EQ(m1.lineNumber(), 12000);
+  EXPECT_EQ(m1.fileName().compare("foo.cpp"), 0);
+  EXPECT_EQ(m1.text().compare(text1), 0);
+  EXPECT_EQ(m1.count(), 1);
+  EXPECT_EQ(m1.ranks().size(), 1);
+  EXPECT_EQ(m1.ranks()[0], 13);
+  EXPECT_EQ(m1.tag().compare("myTag"), 0);
+
+  EXPECT_EQ(m2.lineNumber(), 154);
+  EXPECT_EQ(m2.fileName().compare("bar.cpp"), 0);
+  EXPECT_EQ(m2.text().compare(text2), 0);
+  EXPECT_EQ(m2.count(), 1);
+  EXPECT_EQ(m2.ranks().size(), 1);
+  EXPECT_EQ(m2.ranks()[0], 14);
+  EXPECT_EQ(m2.tag().compare("myOtherTag"), 0);
+}

--- a/src/axom/lumberjack/tests/lumberjack_LineFileTagCombiner.hpp
+++ b/src/axom/lumberjack/tests/lumberjack_LineFileTagCombiner.hpp
@@ -45,14 +45,14 @@ inline void verifyMessage(const axom::lumberjack::Message& message,
 // Struct to hold test parameters
 struct TestParams
 {
-  std::string caseName{""};
-  int lineNumber1{-1};
-  int lineNumber2{-1};
-  std::string fileName1{""};
-  std::string fileName2{""};
-  std::string tag1{""};
-  std::string tag2{""};
-  bool shouldCombine{false};
+  std::string caseName {""};
+  int lineNumber1 {-1};
+  int lineNumber2 {-1};
+  std::string fileName1 {""};
+  std::string fileName2 {""};
+  std::string tag1 {""};
+  std::string tag2 {""};
+  bool shouldCombine {false};
 };
 
 // Parameterized Test Fixture

--- a/src/axom/lumberjack/tests/lumberjack_serial_main.cpp
+++ b/src/axom/lumberjack/tests/lumberjack_serial_main.cpp
@@ -9,6 +9,7 @@
 #include "lumberjack_Message.hpp"
 #include "lumberjack_TextEqualityCombiner.hpp"
 #include "lumberjack_TextTagCombiner.hpp"
+#include "lumberjack_LineFileTagCombiner.hpp"
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
# Summary

- This PR is a feature
- Adds a Lumberjack combiner that combines messages only when the line number, file name, and tag are equal.  If texts are not equal, only one text message will remain after being combined.  This can be useful in some circumstances where we have a similar message that is emitted many times from the same source code location, but may be slightly different in its text content (e.g. if it includes the rank in the message).  In some of these cases, the user may want to just see one message, even if the content is slightly different.