### PR TITLE
Add option to allow Lumberjack to own communicator

### DIFF
--- a/src/axom/lumberjack/Lumberjack.cpp
+++ b/src/axom/lumberjack/Lumberjack.cpp
@@ -19,15 +19,22 @@ namespace axom
 {
 namespace lumberjack
 {
-void Lumberjack::initialize(Communicator* communicator, int ranksLimit)
+void Lumberjack::initialize(Communicator* communicator,
+                            int ranksLimit,
+                            bool isCommunicatorOwned)
 {
   m_communicator = communicator;
+  m_isCommunicatorOwned = isCommunicatorOwned;
   m_ranksLimit = ranksLimit;
   m_combiners.push_back(new TextTagCombiner);
 }
 
 void Lumberjack::finalize()
 {
+  if(m_isCommunicatorOwned)
+  {
+    delete m_communicator;
+  }
   m_communicator = nullptr;
   clearCombiners();
   clearMessages();

--- a/src/axom/lumberjack/Lumberjack.hpp
+++ b/src/axom/lumberjack/Lumberjack.hpp
@@ -55,9 +55,13 @@ public:
    * messages
    * \param [in] ranksLimit Limit on how many ranks are individually tracker per
    * Message.
+   * \param [in] isCommunicatorOwned When set to true, Lumberjack will be 
+   * responsible for freeing communication object when finalize() is called.
    *****************************************************************************
    */
-  void initialize(Communicator* communicator, int ranksLimit);
+  void initialize(Communicator* communicator,
+                  int ranksLimit,
+                  bool isCommunicatorOwned = false);
 
   /*!
    *****************************************************************************
@@ -239,6 +243,7 @@ private:
   void combineMessages();
 
   Communicator* m_communicator;
+  bool m_isCommunicatorOwned;
   int m_ranksLimit;
   std::vector<Combiner*> m_combiners;
   std::vector<Message*> m_messages;


### PR DESCRIPTION
# Summary

- This PR is a feature
- This PR adds the ability for Lumberjack to directly own a Communicator object.  When this case is true, Lumberjack will call delete on the communicator object when finalize() is called.
