### PR TITLE
Fixes build and tests on Windows

### DIFF
--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -9,7 +9,7 @@
 "spack_packages_path": ["scripts/spack/radiuss-spack-configs/packages", "scripts/spack/packages"],
 "spack_concretizer": "clingo",
 "vcpkg_url": "https://github.com/microsoft/vcpkg",
-"vcpkg_commit": "898b728edc5e0d12b50015f9cd18247c4257a3eb",
+"vcpkg_commit": "d5ec528843d29e3a52d745a64b469f810b2cedbf",
 "vcpkg_triplet": "x64-windows",
 "vcpkg_ports_path": "scripts/vcpkg_ports"
 }

--- a/host-configs/tioga-toss_4_x86_64_ib_cray-cce@18.0.0_hip.cmake
+++ b/host-configs/tioga-toss_4_x86_64_ib_cray-cce@18.0.0_hip.cmake
@@ -134,7 +134,7 @@ set(CAMP_DIR "${TPL_ROOT}/camp-2024.07.0-6plzos2py72y3ns2y72j3ksqdc3qrfqo" CACHE
 
 set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2024_10_28_13_16_23/._view/duoudtvvq736czrjvwlncemhjhg3agix" CACHE PATH "")
 
-set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/rocmcc/rocmcc-5.2.3-magic/llvm/bin/clang-format" CACHE PATH "")
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/rocmcc/rocmcc-6.2.1-magic/llvm/bin/clang-format" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2024_10_28_13_16_23/gcc-10.3.1/python-3.12.5-khbdgeaypdfyrrvyywvvqt47x66jd5ol/bin/python3.12" CACHE PATH "")
 

--- a/host-configs/tioga-toss_4_x86_64_ib_cray-rocmcc@6.1.2_hip.cmake
+++ b/host-configs/tioga-toss_4_x86_64_ib_cray-rocmcc@6.1.2_hip.cmake
@@ -132,7 +132,7 @@ set(CAMP_DIR "${TPL_ROOT}/camp-2024.07.0-hcbpird6z6buwcx5sd5t3aqho4yxqv6z" CACHE
 
 set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2024_10_28_13_16_23/._view/duoudtvvq736czrjvwlncemhjhg3agix" CACHE PATH "")
 
-set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/rocmcc/rocmcc-5.2.3-magic/llvm/bin/clang-format" CACHE PATH "")
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/rocmcc/rocmcc-6.2.1-magic/llvm/bin/clang-format" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2024_10_28_13_16_23/gcc-10.3.1/python-3.12.5-khbdgeaypdfyrrvyywvvqt47x66jd5ol/bin/python3.12" CACHE PATH "")
 

--- a/host-configs/tioga-toss_4_x86_64_ib_cray-rocmcc@6.2.1_hip.cmake
+++ b/host-configs/tioga-toss_4_x86_64_ib_cray-rocmcc@6.2.1_hip.cmake
@@ -132,7 +132,7 @@ set(CAMP_DIR "${TPL_ROOT}/camp-2024.07.0-vnqw3c4b6ivlgf4k2oevxu3jg3b4vbjm" CACHE
 
 set(DEVTOOLS_ROOT "/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2024_10_28_13_16_23/._view/duoudtvvq736czrjvwlncemhjhg3agix" CACHE PATH "")
 
-set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/rocmcc/rocmcc-5.2.3-magic/llvm/bin/clang-format" CACHE PATH "")
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/rocmcc/rocmcc-6.2.1-magic/llvm/bin/clang-format" CACHE PATH "")
 
 set(PYTHON_EXECUTABLE "/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2024_10_28_13_16_23/gcc-10.3.1/python-3.12.5-khbdgeaypdfyrrvyywvvqt47x66jd5ol/bin/python3.12" CACHE PATH "")
 

--- a/scripts/vcpkg_ports/umpire/portfile.cmake
+++ b/scripts/vcpkg_ports/umpire/portfile.cmake
@@ -4,7 +4,9 @@ vcpkg_from_github(
     REF v2024.07.0
     SHA512 c29c39b74641485e81bfaebc9eb2c36a2404e7866848d50f4dc6c576f03bf0ec3989d21ee0f8c573e40c11ad6c279054feefaf50ff7dcc2eb617c4ac60b8520d
     HEAD_REF develop
+    PATCHES v2024.07.0-chrono-include.patch
 )
+
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES

--- a/scripts/vcpkg_ports/umpire/v2024.07.0-chrono-include.patch
+++ b/scripts/vcpkg_ports/umpire/v2024.07.0-chrono-include.patch
@@ -1,0 +1,12 @@
+diff --git a/src/umpire/event/event.hpp b/src/umpire/event/event.hpp
+index 03f0d37..db84c1c 100644
+--- a/src/umpire/event/event.hpp
++++ b/src/umpire/event/event.hpp
+@@ -7,6 +7,7 @@
+ #ifndef UMPIRE_event_HPP
+ #define UMPIRE_event_HPP
+ 
++#include <chrono>
+ #include <cstdint>
+ #include <map>
+ #include <sstream>

--- a/src/axom/config.hpp.in
+++ b/src/axom/config.hpp.in
@@ -28,9 +28,9 @@
 /*
  * Axom source location
  */
-#define AXOM_SRC_DIR "@AXOM_SRC_DIR@"
-#define AXOM_BIN_DIR "@AXOM_BIN_DIR@"
-#cmakedefine AXOM_DATA_DIR "@AXOM_DATA_DIR@"
+#define AXOM_SRC_DIR "@AXOM_SRC_DIR_NATIVE@"
+#define AXOM_BIN_DIR "@AXOM_BIN_DIR_NATIVE@"
+#cmakedefine AXOM_DATA_DIR "@AXOM_DATA_DIR_NATIVE@"
 
 /*
  * Platform specific definitions

--- a/src/axom/core/Macros.hpp
+++ b/src/axom/core/Macros.hpp
@@ -140,8 +140,12 @@
  * \brief Macro used to silence UndefinedBehaviorSanitizer errors
  *  when compiling and linking with -fsanitize=undefined
  */
-#if __has_attribute(no_sanitize_undefined)
-  #define AXOM_SUPPRESS_UBSAN __attribute__((no_sanitize_undefined))
+#if defined(__has_attribute)
+  #if __has_attribute(no_sanitize_undefined)
+    #define AXOM_SUPPRESS_UBSAN __attribute__((no_sanitize_undefined))
+  #else
+    #define AXOM_SUPPRESS_UBSAN
+  #endif
 #else
   #define AXOM_SUPPRESS_UBSAN
 #endif

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -353,6 +353,8 @@ inline MemorySpace getAllocatorSpace(int allocatorId)
   default:
     return MemorySpace::Dynamic;
   }
+#else
+  return MemorySpace::Dynamic;
 #endif
 }
 

--- a/src/axom/core/tests/core_utilities.hpp
+++ b/src/axom/core/tests/core_utilities.hpp
@@ -96,7 +96,7 @@ TEST(core_utilities, qsort_sort_double)
       std::generate_n(vec.data(), n, []() -> double {
         return axom::utilities::random_real(0., 1024.);
       });
-      
+
       // sort the first two iterations in descending/ascending order
       if(iter == 0)
       {
@@ -106,7 +106,7 @@ TEST(core_utilities, qsort_sort_double)
       {
         std::sort(vec.begin(), vec.end(), [](int a, int b) { return a < b; });
       }
-      
+
       axom::utilities::Sorting<double, MAX_SIZE>::qsort(vec.data(), n);
     }
 

--- a/src/axom/core/tests/core_utilities.hpp
+++ b/src/axom/core/tests/core_utilities.hpp
@@ -7,6 +7,7 @@
 
 #include "axom/config.hpp"
 #include "axom/core/utilities/Utilities.hpp"
+#include "axom/core/utilities/Sorting.hpp"
 
 #include <algorithm>
 #include <random>
@@ -74,6 +75,45 @@ TEST(core_utilities, insertion_sort_doubles)
     for(int i = 0; i < NUM_DBLS - 1; i++)
     {
       ASSERT_LE(data[i], data[i + 1]);
+    }
+  }
+}
+
+TEST(core_utilities, qsort_sort_double)
+{
+  constexpr int NUM_ITERS = 1000;
+  constexpr int MAX_SIZE = 100;
+
+  // Run this for a few iterations to test that sorting works on different random shuffles.
+  for(int n = 1; n < MAX_SIZE; ++n)
+  {
+    std::vector<double> vec;
+    vec.resize(n);
+
+    for(int iter = 0; iter < NUM_ITERS; iter++)
+    {
+      // Fill it with random doubles in the range of [0, 1024)
+      std::generate_n(vec.data(), n, []() -> double {
+        return axom::utilities::random_real(0., 1024.);
+      });
+      
+      // sort the first two iterations in descending/ascending order
+      if(iter == 0)
+      {
+        std::sort(vec.begin(), vec.end(), [](int a, int b) { return a > b; });
+      }
+      else if(iter == 1)
+      {
+        std::sort(vec.begin(), vec.end(), [](int a, int b) { return a < b; });
+      }
+      
+      axom::utilities::Sorting<double, MAX_SIZE>::qsort(vec.data(), n);
+    }
+
+    // Check that the results are sorted
+    for(int i = 1; i < n; i++)
+    {
+      EXPECT_TRUE(vec[i - 1] <= vec[i]) << "data not sorted!";
     }
   }
 }

--- a/src/axom/core/utilities/Sorting.hpp
+++ b/src/axom/core/utilities/Sorting.hpp
@@ -80,7 +80,7 @@ struct Sorting
 
       if(low < high)
       {
-        int pivot_index = partition(values, low, high);
+        const int pivot_index = partition(values, low, high);
 
         stack[stack_count][0] = low;
         stack[stack_count][1] = pivot_index - 1;
@@ -105,6 +105,26 @@ struct Sorting
   AXOM_HOST_DEVICE
   static int partition(T *values, int low, int high)
   {
+    // Median-of-three pivot selection
+    const int mid = low + (high - low) / 2;
+
+    // Find the median of values[low], values[mid], values[high]
+    if(values[low] > values[mid])
+    {
+      axom::utilities::swap(values[low], values[mid]);
+    }
+    if(values[low] > values[high])
+    {
+      axom::utilities::swap(values[low], values[high]);
+    }
+    if(values[mid] > values[high])
+    {
+      axom::utilities::swap(values[mid], values[high]);
+    }
+
+    // Use the median as the pivot
+    axom::utilities::swap(values[mid], values[high]);
+
     const T pivot = values[high];
     int i = low - 1;
     for(int j = low; j < high; j++)

--- a/src/axom/mir/clipping/ClipCases.h
+++ b/src/axom/mir/clipping/ClipCases.h
@@ -7,9 +7,11 @@
 //---------------------------------------------------------------------------
 // Axom modifications
 // NOTE: The values for EA-EL and N0-N3 were reduced.
+// NOTE: We're using AXOM_MIR_EXPORT instead of VISIT_VTK_LIGHT_API througout
 // clang-format off
-//#include <visit_vtk_light_exports.h>
-#define VISIT_VTK_LIGHT_API
+
+#include "axom/export/mir.h"
+
 #include <cstdlib>
 namespace axom {
 namespace mir {
@@ -88,87 +90,87 @@ namespace visit {
 #define NOCOLOR 122
 
 // Tables
-extern VISIT_VTK_LIGHT_API int numClipCasesHex;
-extern VISIT_VTK_LIGHT_API int numClipShapesHex[256];
-extern VISIT_VTK_LIGHT_API int startClipShapesHex[256];
-extern VISIT_VTK_LIGHT_API unsigned char clipShapesHex[];
+extern AXOM_MIR_EXPORT int numClipCasesHex;
+extern AXOM_MIR_EXPORT int numClipShapesHex[256];
+extern AXOM_MIR_EXPORT int startClipShapesHex[256];
+extern AXOM_MIR_EXPORT unsigned char clipShapesHex[];
 
-extern VISIT_VTK_LIGHT_API int numClipCasesVox;
-extern VISIT_VTK_LIGHT_API int numClipShapesVox[256];
-extern VISIT_VTK_LIGHT_API int startClipShapesVox[256];
-extern VISIT_VTK_LIGHT_API unsigned char clipShapesVox[];
+extern AXOM_MIR_EXPORT int numClipCasesVox;
+extern AXOM_MIR_EXPORT int numClipShapesVox[256];
+extern AXOM_MIR_EXPORT int startClipShapesVox[256];
+extern AXOM_MIR_EXPORT unsigned char clipShapesVox[];
 
-extern VISIT_VTK_LIGHT_API int numClipCasesWdg;
-extern VISIT_VTK_LIGHT_API int numClipShapesWdg[64];
-extern VISIT_VTK_LIGHT_API int startClipShapesWdg[64];
-extern VISIT_VTK_LIGHT_API unsigned char clipShapesWdg[];
+extern AXOM_MIR_EXPORT int numClipCasesWdg;
+extern AXOM_MIR_EXPORT int numClipShapesWdg[64];
+extern AXOM_MIR_EXPORT int startClipShapesWdg[64];
+extern AXOM_MIR_EXPORT unsigned char clipShapesWdg[];
 
-extern VISIT_VTK_LIGHT_API int numClipCasesPyr;
-extern VISIT_VTK_LIGHT_API int numClipShapesPyr[32];
-extern VISIT_VTK_LIGHT_API int startClipShapesPyr[32];
-extern VISIT_VTK_LIGHT_API unsigned char clipShapesPyr[];
+extern AXOM_MIR_EXPORT int numClipCasesPyr;
+extern AXOM_MIR_EXPORT int numClipShapesPyr[32];
+extern AXOM_MIR_EXPORT int startClipShapesPyr[32];
+extern AXOM_MIR_EXPORT unsigned char clipShapesPyr[];
 
-extern VISIT_VTK_LIGHT_API int numClipCasesTet;
-extern VISIT_VTK_LIGHT_API int numClipShapesTet[16];
-extern VISIT_VTK_LIGHT_API int startClipShapesTet[16];
-extern VISIT_VTK_LIGHT_API unsigned char clipShapesTet[];
+extern AXOM_MIR_EXPORT int numClipCasesTet;
+extern AXOM_MIR_EXPORT int numClipShapesTet[16];
+extern AXOM_MIR_EXPORT int startClipShapesTet[16];
+extern AXOM_MIR_EXPORT unsigned char clipShapesTet[];
 
-extern VISIT_VTK_LIGHT_API int numClipCasesQua;
-extern VISIT_VTK_LIGHT_API int numClipShapesQua[16];
-extern VISIT_VTK_LIGHT_API int startClipShapesQua[16];
-extern VISIT_VTK_LIGHT_API unsigned char clipShapesQua[];
+extern AXOM_MIR_EXPORT int numClipCasesQua;
+extern AXOM_MIR_EXPORT int numClipShapesQua[16];
+extern AXOM_MIR_EXPORT int startClipShapesQua[16];
+extern AXOM_MIR_EXPORT unsigned char clipShapesQua[];
 
-extern VISIT_VTK_LIGHT_API int numClipCasesPix;
-extern VISIT_VTK_LIGHT_API int numClipShapesPix[16];
-extern VISIT_VTK_LIGHT_API int startClipShapesPix[16];
-extern VISIT_VTK_LIGHT_API unsigned char clipShapesPix[];
+extern AXOM_MIR_EXPORT int numClipCasesPix;
+extern AXOM_MIR_EXPORT int numClipShapesPix[16];
+extern AXOM_MIR_EXPORT int startClipShapesPix[16];
+extern AXOM_MIR_EXPORT unsigned char clipShapesPix[];
 
-extern VISIT_VTK_LIGHT_API int numClipCasesTri;
-extern VISIT_VTK_LIGHT_API int numClipShapesTri[8];
-extern VISIT_VTK_LIGHT_API int startClipShapesTri[8];
-extern VISIT_VTK_LIGHT_API unsigned char clipShapesTri[];
+extern AXOM_MIR_EXPORT int numClipCasesTri;
+extern AXOM_MIR_EXPORT int numClipShapesTri[8];
+extern AXOM_MIR_EXPORT int startClipShapesTri[8];
+extern AXOM_MIR_EXPORT unsigned char clipShapesTri[];
 
-extern VISIT_VTK_LIGHT_API int numClipCasesLin;
-extern VISIT_VTK_LIGHT_API int numClipShapesLin[4];
-extern VISIT_VTK_LIGHT_API int startClipShapesLin[4];
-extern VISIT_VTK_LIGHT_API unsigned char clipShapesLin[];
+extern AXOM_MIR_EXPORT int numClipCasesLin;
+extern AXOM_MIR_EXPORT int numClipShapesLin[4];
+extern AXOM_MIR_EXPORT int startClipShapesLin[4];
+extern AXOM_MIR_EXPORT unsigned char clipShapesLin[];
 
-extern VISIT_VTK_LIGHT_API int numClipCasesVtx;
-extern VISIT_VTK_LIGHT_API int numClipShapesVtx[2];
-extern VISIT_VTK_LIGHT_API int startClipShapesVtx[2];
-extern VISIT_VTK_LIGHT_API unsigned char clipShapesVtx[];
+extern AXOM_MIR_EXPORT int numClipCasesVtx;
+extern AXOM_MIR_EXPORT int numClipShapesVtx[2];
+extern AXOM_MIR_EXPORT int startClipShapesVtx[2];
+extern AXOM_MIR_EXPORT unsigned char clipShapesVtx[];
 
-extern VISIT_VTK_LIGHT_API int numClipCasesPoly5;
-extern VISIT_VTK_LIGHT_API int numClipShapesPoly5[32];
-extern VISIT_VTK_LIGHT_API int startClipShapesPoly5[32];
-extern VISIT_VTK_LIGHT_API unsigned char clipShapesPoly5[];
+extern AXOM_MIR_EXPORT int numClipCasesPoly5;
+extern AXOM_MIR_EXPORT int numClipShapesPoly5[32];
+extern AXOM_MIR_EXPORT int startClipShapesPoly5[32];
+extern AXOM_MIR_EXPORT unsigned char clipShapesPoly5[];
 
-extern VISIT_VTK_LIGHT_API int numClipCasesPoly6;
-extern VISIT_VTK_LIGHT_API int numClipShapesPoly6[64];
-extern VISIT_VTK_LIGHT_API int startClipShapesPoly6[64];
-extern VISIT_VTK_LIGHT_API unsigned char clipShapesPoly6[];
+extern AXOM_MIR_EXPORT int numClipCasesPoly6;
+extern AXOM_MIR_EXPORT int numClipShapesPoly6[64];
+extern AXOM_MIR_EXPORT int startClipShapesPoly6[64];
+extern AXOM_MIR_EXPORT unsigned char clipShapesPoly6[];
 
-extern VISIT_VTK_LIGHT_API int numClipCasesPoly7;
-extern VISIT_VTK_LIGHT_API int numClipShapesPoly7[128];
-extern VISIT_VTK_LIGHT_API int startClipShapesPoly7[128];
-extern VISIT_VTK_LIGHT_API unsigned char clipShapesPoly7[];
+extern AXOM_MIR_EXPORT int numClipCasesPoly7;
+extern AXOM_MIR_EXPORT int numClipShapesPoly7[128];
+extern AXOM_MIR_EXPORT int startClipShapesPoly7[128];
+extern AXOM_MIR_EXPORT unsigned char clipShapesPoly7[];
 
-extern VISIT_VTK_LIGHT_API int numClipCasesPoly8;
-extern VISIT_VTK_LIGHT_API int numClipShapesPoly8[256];
-extern VISIT_VTK_LIGHT_API int startClipShapesPoly8[256];
-extern VISIT_VTK_LIGHT_API unsigned char clipShapesPoly8[];
+extern AXOM_MIR_EXPORT int numClipCasesPoly8;
+extern AXOM_MIR_EXPORT int numClipShapesPoly8[256];
+extern AXOM_MIR_EXPORT int startClipShapesPoly8[256];
+extern AXOM_MIR_EXPORT unsigned char clipShapesPoly8[];
 
 //---------------------------------------------------------------------------
 // Axom modifications
 #define ST_MIN ST_TET
 #define ST_MAX (ST_PNT + 1)
-#undef VISIT_VTK_LIGHT_API
-extern const size_t clipShapesTriSize;
-extern const size_t clipShapesQuaSize;
-extern const size_t clipShapesTetSize;
-extern const size_t clipShapesPyrSize;
-extern const size_t clipShapesWdgSize;
-extern const size_t clipShapesHexSize;
+
+extern AXOM_MIR_EXPORT const size_t clipShapesTriSize;
+extern AXOM_MIR_EXPORT const size_t clipShapesQuaSize;
+extern AXOM_MIR_EXPORT const size_t clipShapesTetSize;
+extern AXOM_MIR_EXPORT const size_t clipShapesPyrSize;
+extern AXOM_MIR_EXPORT const size_t clipShapesWdgSize;
+extern AXOM_MIR_EXPORT const size_t clipShapesHexSize;
 } // namespace visit
 } // namespace clipping
 } // namespace mir

--- a/src/axom/mir/tests/mir_clipfield.cpp
+++ b/src/axom/mir/tests/mir_clipfield.cpp
@@ -273,7 +273,7 @@ std::vector<int> permute(const std::vector<int> &input)
   std::iota(indices.begin(), indices.end(), 0);
   for(size_t i = 0; i < input.size(); i++)
   {
-    order[i] = drand48();
+    order[i] = axom::utilities::random_real(0.,1.);
   }
   std::sort(indices.begin(), indices.end(), [&](int a, int b) {
     return order[a] < order[b];
@@ -292,12 +292,12 @@ std::vector<int> makeUnsortedArray(int n)
 
 std::vector<int> makeRandomArray(int n)
 {
-  constexpr int largestId = 1 << 28;
+  constexpr double largestId = static_cast<double>(1 << 28);
   std::vector<int> values;
   values.resize(n);
   for(int i = 0; i < n; i++)
   {
-    values[i] = static_cast<int>(largestId * drand48());
+    values[i] = static_cast<int>(axom::utilities::random_real(0., largestId));
   }
   return permute(values);
 }

--- a/src/axom/mir/tests/mir_clipfield.cpp
+++ b/src/axom/mir/tests/mir_clipfield.cpp
@@ -273,7 +273,7 @@ std::vector<int> permute(const std::vector<int> &input)
   std::iota(indices.begin(), indices.end(), 0);
   for(size_t i = 0; i < input.size(); i++)
   {
-    order[i] = axom::utilities::random_real(0.,1.);
+    order[i] = axom::utilities::random_real(0., 1.);
   }
   std::sort(indices.begin(), indices.end(), [&](int a, int b) {
     return order[a] < order[b];

--- a/src/axom/mir/tests/mir_views.cpp
+++ b/src/axom/mir/tests/mir_views.cpp
@@ -34,26 +34,26 @@ std::string baselineDirectory()
 
 TEST(mir_views, shape2conduitName)
 {
-  EXPECT_EQ(axom::mir::views::LineShape<int>::name(), "line");
-  EXPECT_EQ(axom::mir::views::LineShape<long>::name(), "line");
+  EXPECT_STREQ(axom::mir::views::LineShape<int>::name(), "line");
+  EXPECT_STREQ(axom::mir::views::LineShape<long>::name(), "line");
+  
+  EXPECT_STREQ(axom::mir::views::TriShape<int>::name(), "tri");
+  EXPECT_STREQ(axom::mir::views::TriShape<long>::name(), "tri");
 
-  EXPECT_EQ(axom::mir::views::TriShape<int>::name(), "tri");
-  EXPECT_EQ(axom::mir::views::TriShape<long>::name(), "tri");
+  EXPECT_STREQ(axom::mir::views::QuadShape<int>::name(), "quad");
+  EXPECT_STREQ(axom::mir::views::QuadShape<long>::name(), "quad");
 
-  EXPECT_EQ(axom::mir::views::QuadShape<int>::name(), "quad");
-  EXPECT_EQ(axom::mir::views::QuadShape<long>::name(), "quad");
+  EXPECT_STREQ(axom::mir::views::TetShape<int>::name(), "tet");
+  EXPECT_STREQ(axom::mir::views::TetShape<long>::name(), "tet");
 
-  EXPECT_EQ(axom::mir::views::TetShape<int>::name(), "tet");
-  EXPECT_EQ(axom::mir::views::TetShape<long>::name(), "tet");
+  EXPECT_STREQ(axom::mir::views::PyramidShape<int>::name(), "pyramid");
+  EXPECT_STREQ(axom::mir::views::PyramidShape<long>::name(), "pyramid");
 
-  EXPECT_EQ(axom::mir::views::PyramidShape<int>::name(), "pyramid");
-  EXPECT_EQ(axom::mir::views::PyramidShape<long>::name(), "pyramid");
+  EXPECT_STREQ(axom::mir::views::WedgeShape<int>::name(), "wedge");
+  EXPECT_STREQ(axom::mir::views::WedgeShape<long>::name(), "wedge");
 
-  EXPECT_EQ(axom::mir::views::WedgeShape<int>::name(), "wedge");
-  EXPECT_EQ(axom::mir::views::WedgeShape<long>::name(), "wedge");
-
-  EXPECT_EQ(axom::mir::views::HexShape<int>::name(), "hex");
-  EXPECT_EQ(axom::mir::views::HexShape<long>::name(), "hex");
+  EXPECT_STREQ(axom::mir::views::HexShape<int>::name(), "hex");
+  EXPECT_STREQ(axom::mir::views::HexShape<long>::name(), "hex");
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/mir/tests/mir_views.cpp
+++ b/src/axom/mir/tests/mir_views.cpp
@@ -36,7 +36,7 @@ TEST(mir_views, shape2conduitName)
 {
   EXPECT_STREQ(axom::mir::views::LineShape<int>::name(), "line");
   EXPECT_STREQ(axom::mir::views::LineShape<long>::name(), "line");
-  
+
   EXPECT_STREQ(axom::mir::views::TriShape<int>::name(), "tri");
   EXPECT_STREQ(axom::mir::views::TriShape<long>::name(), "tri");
 

--- a/src/axom/mir/utilities/blueprint_utilities.hpp
+++ b/src/axom/mir/utilities/blueprint_utilities.hpp
@@ -12,6 +12,7 @@
 #include "axom/core/NumericLimits.hpp"
 #include "axom/core/memory_management.hpp"
 #include "axom/mir/views/NodeArrayView.hpp"
+#include "axom/export/mir.h"
 
 #include <conduit/conduit.hpp>
 #include <conduit/conduit_blueprint.hpp>
@@ -46,7 +47,7 @@ struct cpp2conduit<conduit::int8>
 {
   using type = conduit::int8;
   static constexpr conduit::index_t id = conduit::DataType::INT8_ID;
-  static const char *name;
+  AXOM_MIR_EXPORT static const char *name;
 };
 
 template <>
@@ -54,7 +55,7 @@ struct cpp2conduit<conduit::int16>
 {
   using type = conduit::int16;
   static constexpr conduit::index_t id = conduit::DataType::INT16_ID;
-  static const char *name;
+  AXOM_MIR_EXPORT static const char *name;
 };
 
 template <>
@@ -62,7 +63,7 @@ struct cpp2conduit<conduit::int32>
 {
   using type = conduit::int32;
   static constexpr conduit::index_t id = conduit::DataType::INT32_ID;
-  static const char *name;
+  AXOM_MIR_EXPORT static const char *name;
 };
 
 template <>
@@ -70,7 +71,7 @@ struct cpp2conduit<conduit::int64>
 {
   using type = conduit::int64;
   static constexpr conduit::index_t id = conduit::DataType::INT64_ID;
-  static const char *name;
+  AXOM_MIR_EXPORT static const char *name;
 };
 
 template <>
@@ -78,7 +79,7 @@ struct cpp2conduit<conduit::uint8>
 {
   using type = conduit::uint8;
   static constexpr conduit::index_t id = conduit::DataType::UINT8_ID;
-  static const char *name;
+  AXOM_MIR_EXPORT static const char *name;
 };
 
 template <>
@@ -86,7 +87,7 @@ struct cpp2conduit<conduit::uint16>
 {
   using type = conduit::uint16;
   static constexpr conduit::index_t id = conduit::DataType::UINT16_ID;
-  static const char *name;
+  AXOM_MIR_EXPORT static const char *name;
 };
 
 template <>
@@ -94,7 +95,7 @@ struct cpp2conduit<conduit::uint32>
 {
   using type = conduit::uint32;
   static constexpr conduit::index_t id = conduit::DataType::UINT32_ID;
-  static const char *name;
+  AXOM_MIR_EXPORT static const char *name;
 };
 
 template <>
@@ -102,7 +103,7 @@ struct cpp2conduit<conduit::uint64>
 {
   using type = conduit::uint64;
   static constexpr conduit::index_t id = conduit::DataType::UINT64_ID;
-  static const char *name;
+  AXOM_MIR_EXPORT static const char *name;
 };
 
 template <>
@@ -110,7 +111,7 @@ struct cpp2conduit<conduit::float32>
 {
   using type = conduit::float32;
   static constexpr conduit::index_t id = conduit::DataType::FLOAT32_ID;
-  static const char *name;
+  AXOM_MIR_EXPORT static const char *name;
 };
 
 template <>
@@ -118,7 +119,7 @@ struct cpp2conduit<conduit::float64>
 {
   using type = conduit::float64;
   static constexpr conduit::index_t id = conduit::DataType::FLOAT64_ID;
-  static const char *name;
+  AXOM_MIR_EXPORT static const char *name;
 };
 
 //------------------------------------------------------------------------------

--- a/src/axom/mir/views/view_traits.hpp
+++ b/src/axom/mir/views/view_traits.hpp
@@ -106,15 +106,14 @@ struct array_view_traits
     }                                                   \
   };
 
-AXOM_MAKE_TRAIT(signed char)
-AXOM_MAKE_TRAIT(char)
-AXOM_MAKE_TRAIT(short)
-AXOM_MAKE_TRAIT(long)
-AXOM_MAKE_TRAIT(int)
-AXOM_MAKE_TRAIT(unsigned char)
-AXOM_MAKE_TRAIT(unsigned short)
-AXOM_MAKE_TRAIT(unsigned long)
-AXOM_MAKE_TRAIT(unsigned int)
+AXOM_MAKE_TRAIT(std::uint8_t)
+AXOM_MAKE_TRAIT(std::uint16_t)
+AXOM_MAKE_TRAIT(std::uint32_t)
+AXOM_MAKE_TRAIT(std::uint64_t)
+AXOM_MAKE_TRAIT(std::int8_t)
+AXOM_MAKE_TRAIT(std::int16_t)
+AXOM_MAKE_TRAIT(std::int32_t)
+AXOM_MAKE_TRAIT(std::int64_t)
 AXOM_MAKE_TRAIT(float)
 AXOM_MAKE_TRAIT(double)
 #undef AXOM_MAKE_TRAIT

--- a/src/axom/quest/DiscreteShape.cpp
+++ b/src/axom/quest/DiscreteShape.cpp
@@ -172,7 +172,11 @@ std::shared_ptr<mint::Mesh> DiscreteShape::createMeshRepresentation()
       axom::fmt::format(" '{}' format requires .stl file type", file_format));
 
     axom::mint::Mesh* meshRep = nullptr;
+#ifdef AXOM_USE_MPI
     quest::internal::read_stl_mesh(shapePath, meshRep, m_comm);
+#else
+    quest::internal::read_stl_mesh(shapePath, meshRep);
+#endif
     m_meshRep.reset(meshRep);
     // Transform the coordinates of the linearized mesh.
     applyTransforms();
@@ -184,7 +188,11 @@ std::shared_ptr<mint::Mesh> DiscreteShape::createMeshRepresentation()
       axom::fmt::format(" '{}' format requires .proe file type", file_format));
 
     axom::mint::Mesh* meshRep = nullptr;
+#ifdef AXOM_USE_MPI
     quest::internal::read_pro_e_mesh(shapePath, meshRep, m_comm);
+#else
+    quest::internal::read_pro_e_mesh(shapePath, meshRep);
+#endif
     m_meshRep.reset(meshRep);
   }
 #ifdef AXOM_USE_C2C
@@ -486,8 +494,10 @@ void DiscreteShape::createRepresentationOfSphere()
   int octCount = 0;
   axom::quest::discretize(sphere, geometry.getLevelOfRefinement(), octs, octCount);
 
-  constexpr int TETS_PER_OCT = 8;
-  constexpr int NODES_PER_TET = 4;
+  // Note: MSVC required `static` to pass TETS_PER_OCT to the axom::for_all w/ C++14
+  // this restriction might be lifted w/ C++17
+  static constexpr int TETS_PER_OCT = 8;
+  static constexpr int NODES_PER_TET = 4;
   const axom::IndexType tetCount = octCount * TETS_PER_OCT;
   const axom::IndexType nodeCount = tetCount * NODES_PER_TET;
 

--- a/src/axom/quest/Shaper.cpp
+++ b/src/axom/quest/Shaper.cpp
@@ -70,7 +70,9 @@ Shaper::Shaper(RuntimePolicy execPolicy,
   , m_bpNodeExt(nullptr)
   , m_bpNodeInt()
 #endif
+#if defined(AXOM_USE_MPI)
   , m_comm(MPI_COMM_WORLD)
+#endif
 {
   SLIC_ASSERT(m_bpTopo != sidre::InvalidName);
 
@@ -106,7 +108,9 @@ Shaper::Shaper(RuntimePolicy execPolicy,
   , m_bpNodeExt(&bpNode)
   , m_bpNodeInt()
 #endif
+#if defined(AXOM_USE_MPI)
   , m_comm(MPI_COMM_WORLD)
+#endif
 {
   AXOM_ANNOTATE_SCOPE("Shaper::Shaper_Node");
   m_bpGrp = m_dataStore.getRoot()->createGroup("internalGrp");

--- a/src/axom/quest/util/mesh_helpers.cpp
+++ b/src/axom/quest/util/mesh_helpers.cpp
@@ -376,7 +376,9 @@ void convert_blueprint_structured_explicit_to_unstructured_impl_3d(
   const std::string& topoName)
 {
   AXOM_ANNOTATE_SCOPE("convert_to_unstructured");
-  constexpr int DIM = 3;
+  // Note: MSVC required `static` to pass DIM to the axom::for_all w/ C++14
+  // this restriction might be lifted w/ C++17
+  static constexpr int DIM = 3;
 
   const std::string& coordsetName =
     meshGrp->getView("topologies/" + topoName + "/coordset")->getString();

--- a/src/axom/quest/util/mesh_helpers.cpp
+++ b/src/axom/quest/util/mesh_helpers.cpp
@@ -516,8 +516,8 @@ void convert_blueprint_structured_explicit_to_unstructured_impl_2d(
   const std::string& topoName)
 {
   AXOM_ANNOTATE_SCOPE("convert_to_unstructured");
-  constexpr int DIM = 2;
-  constexpr int NUM_VERTS_PER_QUAD = 4;
+  static constexpr int DIM = 2;
+  static constexpr int NUM_VERTS_PER_QUAD = 4;
 
   const std::string& coordsetName =
     meshGrp->getView("topologies/" + topoName + "/coordset")->getString();

--- a/src/axom/sidre/core/Group.cpp
+++ b/src/axom/sidre/core/Group.cpp
@@ -21,6 +21,8 @@
 #include "Buffer.hpp"
 #include "DataStore.hpp"
 
+#include "axom/fmt.hpp"
+
 namespace axom
 {
 namespace sidre
@@ -1453,33 +1455,27 @@ bool Group::createNativeLayout(Node& n, const Attribute* attr) const
   bool hasSavedViews = false;
 
   // Dump the group's views
-  IndexType vidx = getFirstValidViewIndex();
-  while(indexIsValid(vidx))
+  for(const auto& view : this->views())
   {
-    const View* view = getView(vidx);
-
     // Check that the view's name is not also a child group name
-    SLIC_CHECK_MSG(m_is_list || !hasChildGroup(view->getName()),
-                   SIDRE_GROUP_LOG_PREPEND
-                     << "'" << view->getName()
-                     << "' is the name of both a group and a view.");
+    SLIC_CHECK_MSG(m_is_list || !hasChildGroup(view.getName()),
+                   SIDRE_GROUP_LOG_PREPEND << axom::fmt::format(
+                     "'{}' is the name of both a group and a view",
+                     view.getName()));
 
-    if(attr == nullptr || view->hasAttributeValue(attr))
+    if(attr == nullptr || view.hasAttributeValue(attr))
     {
-      conduit::Node& child_node = m_is_list ? n.append() : n[view->getName()];
-      view->createNativeLayout(child_node);
+      conduit::Node& child_node = m_is_list ? n.append() : n[view.getName()];
+      view.createNativeLayout(child_node);
       hasSavedViews = true;
     }
-    vidx = getNextValidViewIndex(vidx);
   }
 
   // Recursively dump the child groups
-  IndexType gidx = getFirstValidGroupIndex();
-  while(indexIsValid(gidx))
+  for(const auto& group : this->groups())
   {
-    const Group* group = getGroup(gidx);
-    conduit::Node& child_node = m_is_list ? n.append() : n[group->getName()];
-    if(group->createNativeLayout(child_node, attr))
+    conduit::Node& child_node = m_is_list ? n.append() : n[group.getName()];
+    if(group.createNativeLayout(child_node, attr))
     {
       hasSavedViews = true;
     }
@@ -1487,14 +1483,13 @@ bool Group::createNativeLayout(Node& n, const Attribute* attr) const
     {
       if(m_is_list)
       {
-        n.remove(group->getName());
+        n.remove(group.getName());
       }
       else
       {
         n.remove(n.number_of_children() - 1);
       }
     }
-    gidx = getNextValidGroupIndex(gidx);
   }
 
   return hasSavedViews;
@@ -1518,9 +1513,9 @@ void Group::createNoDataLayout(Node& n, const Attribute* attr) const
   {
     // Check that the view's name is not also a child group name
     SLIC_CHECK_MSG(m_is_list || !hasChildGroup(view.getName()),
-                   SIDRE_GROUP_LOG_PREPEND
-                     << "'" << view.getName()
-                     << "' is the name of both a group and a view.");
+                   SIDRE_GROUP_LOG_PREPEND << axom::fmt::format(
+                     "'{}' is the name of both a group and a view",
+                     view.getName()));
 
     if(attr == nullptr || view.hasAttributeValue(attr))
     {
@@ -1553,41 +1548,32 @@ bool Group::createExternalLayout(Node& n, const Attribute* attr) const
   bool hasExternalViews = false;
 
   // Dump the group's views
-  IndexType vidx = getFirstValidViewIndex();
-  while(indexIsValid(vidx))
+  for(const auto& view : this->views())
   {
-    const View* view = getView(vidx);
-
     // Check that the view's name is not also a child group name
-    SLIC_CHECK_MSG(m_is_list || !hasChildGroup(view->getName()),
-                   SIDRE_GROUP_LOG_PREPEND
-                     << "'" << view->getName()
-                     << "' is the name of both a group and a view.");
+    SLIC_CHECK_MSG(m_is_list || !hasChildGroup(view.getName()),
+                   SIDRE_GROUP_LOG_PREPEND << axom::fmt::format(
+                     "'{}' is the name of both a group and a view.",
+                     view.getName()));
 
-    if(attr == nullptr || view->hasAttributeValue(attr))
+    if(attr == nullptr || view.hasAttributeValue(attr))
     {
-      if(view->isExternal())
+      if(view.isExternal())
       {
-        if(view->isDescribed())
+        if(view.isDescribed())
         {
-          conduit::Node& vnode = m_is_list ? n.append() : n[view->getName()];
-          view->createNativeLayout(vnode);
+          conduit::Node& vnode = m_is_list ? n.append() : n[view.getName()];
+          view.createNativeLayout(vnode);
         }
         hasExternalViews = true;
       }
     }
-
-    vidx = getNextValidViewIndex(vidx);
   }
 
-  // Recursively dump the child groups
-  IndexType gidx = getFirstValidGroupIndex();
-  while(indexIsValid(gidx))
+  for(const auto& group : this->groups())
   {
-    const Group* group = getGroup(gidx);
-
-    conduit::Node& gnode = m_is_list ? n.append() : n[group->getName()];
-    if(group->createExternalLayout(gnode, attr))
+    conduit::Node& gnode = m_is_list ? n.append() : n[group.getName()];
+    if(group.createExternalLayout(gnode, attr))
     {
       hasExternalViews = true;
     }
@@ -1600,11 +1586,9 @@ bool Group::createExternalLayout(Node& n, const Attribute* attr) const
       }
       else
       {
-        n.remove(group->getName());
+        n.remove(group.getName());
       }
     }
-
-    gidx = getNextValidGroupIndex(gidx);
   }
 
   return hasExternalViews;
@@ -1636,41 +1620,25 @@ void Group::print(std::ostream& os) const
 /*
  *************************************************************************
  *
- * Print given number of levels of Group sub-tree rooted at this
- * Group to stdout.
+ * Print sub-tree rooted at this Group to stdout, with level-based padding.
  *
  *************************************************************************
  */
 void Group::printTree(const int nlevels, std::ostream& os) const
 {
-  for(int i = 0; i < nlevels; ++i)
+  // lambda to generate the proper number of padding spaces
+  auto pad = [](int n) { return axom::fmt::format("{:>{}}", "", 4 * n); };
+
+  os << axom::fmt::format("{}Group {}\n", pad(nlevels), this->getName());
+
+  for(const auto& view : this->views())
   {
-    os << "    ";
-  }
-  os << "Group " << this->getName() << std::endl;
-
-  IndexType vidx = getFirstValidViewIndex();
-  while(indexIsValid(vidx))
-  {
-    const View* view = getView(vidx);
-
-    for(int i = 0; i < nlevels + 1; ++i)
-    {
-      os << "    ";
-    }
-    os << "View " << view->getName() << std::endl;
-
-    vidx = getNextValidViewIndex(vidx);
+    os << axom::fmt::format("{}View {}\n", pad(nlevels + 1), view.getName());
   }
 
-  IndexType gidx = getFirstValidGroupIndex();
-  while(indexIsValid(gidx))
+  for(const auto& group : this->groups())
   {
-    const Group* group = getGroup(gidx);
-
-    group->printTree(nlevels + 1, os);
-
-    gidx = getNextValidGroupIndex(gidx);
+    group.printTree(nlevels + 1, os);
   }
 }
 
@@ -1685,38 +1653,18 @@ void Group::copyToConduitNode(Node& n) const
 {
   n["name"] = m_name;
 
-  IndexType vidx = getFirstValidViewIndex();
-  while(indexIsValid(vidx))
+  for(const auto& view : this->views())
   {
-    const View* view = getView(vidx);
-    if(isUsingMap())
-    {
-      Node& v = n["views"].fetch(view->getName());
-      view->copyToConduitNode(v);
-    }
-    else
-    {
-      Node& v = n["views"].append();
-      view->copyToConduitNode(v);
-    }
-    vidx = getNextValidViewIndex(vidx);
+    Node& v =
+      isUsingMap() ? n["views"].fetch(view.getName()) : n["views"].append();
+    view.copyToConduitNode(v);
   }
 
-  IndexType gidx = getFirstValidGroupIndex();
-  while(indexIsValid(gidx))
+  for(const auto& group : this->groups())
   {
-    const Group* group = getGroup(gidx);
-    if(isUsingMap())
-    {
-      Node& g = n["groups"].fetch(group->getName());
-      group->copyToConduitNode(g);
-    }
-    else
-    {
-      Node& g = n["groups"].append();
-      group->copyToConduitNode(g);
-    }
-    gidx = getNextValidGroupIndex(gidx);
+    Node& g =
+      isUsingMap() ? n["groups"].fetch(group.getName()) : n["groups"].append();
+    group.copyToConduitNode(g);
   }
 }
 
@@ -1730,48 +1678,34 @@ void Group::copyToConduitNode(Node& n) const
 bool Group::isEquivalentTo(const Group* other, bool checkName) const
 {
   // Equality of names
-  bool is_equiv = true;
-  if(checkName)
-  {
-    is_equiv = (m_name == other->m_name);
-  }
+  bool is_equiv = checkName ? m_name == other->m_name : true;
 
   // Sizes of collections of child items must be equal
-  if(is_equiv)
-  {
-    is_equiv = (m_view_coll->getNumItems() == other->m_view_coll->getNumItems()) &&
-      (m_group_coll->getNumItems() == other->m_group_coll->getNumItems());
-  }
+  is_equiv = is_equiv &&
+    (m_view_coll->getNumItems() == other->m_view_coll->getNumItems()) &&
+    (m_group_coll->getNumItems() == other->m_group_coll->getNumItems());
 
   // Test equivalence of Views
   if(is_equiv)
   {
-    IndexType vidx = getFirstValidViewIndex();
-    while(is_equiv && indexIsValid(vidx))
+    for(const auto& view : this->views())
     {
-      const View* view = getView(vidx);
-      const std::string& name = view->getName();
+      const std::string& name = view.getName();
 
-      is_equiv =
-        other->hasChildView(name) && view->isEquivalentTo(other->getView(name));
-
-      vidx = getNextValidViewIndex(vidx);
+      is_equiv = is_equiv && other->hasChildView(name) &&
+        view.isEquivalentTo(other->getView(name));
     }
   }
 
   // Recursively call this method to test equivalence of child Groups
   if(is_equiv)
   {
-    IndexType gidx = getFirstValidGroupIndex();
-    while(is_equiv && indexIsValid(gidx))
+    for(const auto& group : this->groups())
     {
-      const Group* group = getGroup(gidx);
-      const std::string& name = group->getName();
+      const std::string& name = group.getName();
 
-      is_equiv = other->hasChildGroup(name) &&
-        group->isEquivalentTo(other->getGroup(name));
-
-      gidx = getNextValidGroupIndex(gidx);
+      is_equiv = is_equiv && other->hasChildGroup(name) &&
+        group.isEquivalentTo(other->getGroup(name));
     }
   }
 
@@ -2590,22 +2524,19 @@ bool Group::exportTo(conduit::Node& result,
                      std::set<IndexType>& buffer_indices) const
 {
   result.set(DataType::object());
-  bool hasSavedViews = false;
 
+  bool hasSavedViews = false;
   if(getNumViews() > 0)
   {
     Node& vnode = result["views"];
-    IndexType vidx = getFirstValidViewIndex();
-    while(indexIsValid(vidx))
+    for(const auto& view : this->views())
     {
-      const View* view = getView(vidx);
-      if(attr == nullptr || view->hasAttributeValue(attr))
+      if(attr == nullptr || view.hasAttributeValue(attr))
       {
-        Node& n_view = m_is_list ? vnode.append() : vnode.fetch(view->getName());
-        view->exportTo(n_view, buffer_indices);
+        Node& n_view = m_is_list ? vnode.append() : vnode.fetch(view.getName());
+        view.exportTo(n_view, buffer_indices);
         hasSavedViews = true;
       }
-      vidx = getNextValidViewIndex(vidx);
     }
     if(!hasSavedViews)
     {
@@ -2617,16 +2548,12 @@ bool Group::exportTo(conduit::Node& result,
   if(getNumGroups() > 0)
   {
     Node& gnode = result["groups"];
-    IndexType gidx = getFirstValidGroupIndex();
-    while(indexIsValid(gidx))
+    for(const auto& group : this->groups())
     {
-      const Group* group = getGroup(gidx);
-      Node& n_group = m_is_list ? gnode.append() : gnode.fetch(group->getName());
-      bool hsv = group->exportTo(n_group, attr, buffer_indices);
+      Node& n_group = m_is_list ? gnode.append() : gnode.fetch(group.getName());
+      bool hsv = group.exportTo(n_group, attr, buffer_indices);
       hasSavedViews = hasSavedViews || hsv;
       hasSavedGroups = true;
-
-      gidx = getNextValidGroupIndex(gidx);
     }
     if(!hasSavedGroups)
     {

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -1362,15 +1362,12 @@ public:
   /*!
    * \brief Copy Group's native layout to given Conduit node.
    *
-   * The native layout is a Conduit Node hierarchy that maps the Conduit Node
-   * data
+   * The native layout is a Conduit Node hierarchy that maps the Conduit Node data
    * externally to the Sidre View data so that it can be filled in from the data
-   * in the file (independent of file format) and can be accessed as a Conduit
-   * tree.
+   * in the file (independent of file format) and can be accessed as a Conduit tree.
    *
    * \return True if the Group or any of its children were added to the Node,
    * false otherwise.
-   *
    */
   bool createNativeLayout(Node& n, const Attribute* attr = nullptr) const;
 

--- a/src/axom/sidre/core/MFEMSidreDataCollection.cpp
+++ b/src/axom/sidre/core/MFEMSidreDataCollection.cpp
@@ -997,7 +997,14 @@ void MFEMSidreDataCollection::LoadExternalData(const std::string& filename,
   else
   #endif
   {
-    grp->loadExternalData(path);
+    if(!group_name.empty())
+    {
+      grp->loadExternalData(path);
+    }
+    else
+    {
+      m_bp_grp->loadExternalData(path);
+    }
   }
 }
 

--- a/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
+++ b/src/axom/sidre/tests/sidre_mfem_datacollection.cpp
@@ -281,45 +281,51 @@ TEST(sidre_datacollection, dc_reload_externaldata)
 #endif
 
   const std::string view_name = "external_data";
+  const bool owns_mesh_data = true;
+
+  // Create external arrays for writer and reader
+  axom::Array<int64_t> writer_data {1, 2, 3, 4};
+  axom::Array<int64_t> reader_data {5, 6, 7, 8};
 
   // Create DC
-  auto mesh = mfem::Mesh::MakeCartesian1D(10);
-  const bool owns_mesh_data = true;
-  MFEMSidreDataCollection sdc_writer(testName(), &mesh, owns_mesh_data);
-  // After creation set owning to false so data doesn't get double free'd by reader and writer
-  sdc_writer.SetOwnData(false);
+  {
+    auto mesh = mfem::Mesh::MakeCartesian1D(10);
+    MFEMSidreDataCollection sdc_writer(testName(), &mesh, owns_mesh_data);
+    // After creation set owning to false so data doesn't get double free'd by reader and writer
+    sdc_writer.SetOwnData(false);
 #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
-  sdc_writer.SetComm(MPI_COMM_WORLD);
+    sdc_writer.SetComm(MPI_COMM_WORLD);
 #endif
-  sdc_writer.SetCycle(0);
+    sdc_writer.SetCycle(0);
 
-  // Create external buffer and add it to DC
-  axom::Array<int64_t> writer_data {1, 2, 3, 4};
-  axom::sidre::Group* writer_bp_group = sdc_writer.GetBPGroup();
-  axom::sidre::View* writer_external_view =
-    writer_bp_group->createView(view_name);
-  writer_external_view->setExternalDataPtr(axom::sidre::INT64_ID,
-                                           writer_data.size(),
-                                           writer_data.data());
-  EXPECT_TRUE(writer_bp_group->hasView(view_name));
+    axom::sidre::Group* writer_bp_group = sdc_writer.GetBPGroup();
+    axom::sidre::View* writer_external_view =
+      writer_bp_group->createView(view_name);
+    writer_external_view->setExternalDataPtr(axom::sidre::INT64_ID,
+                                             writer_data.size(),
+                                             writer_data.data());
+    EXPECT_TRUE(writer_bp_group->hasView(view_name));
 
-  sdc_writer.Save();
+    sdc_writer.Save();
+  }
 
   // Load DC from file
-  MFEMSidreDataCollection sdc_reader(testName());
+  {
+    MFEMSidreDataCollection sdc_reader(testName());
 #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
-  sdc_reader.SetComm(MPI_COMM_WORLD);
+    sdc_reader.SetComm(MPI_COMM_WORLD);
 #endif
-  // Note: this will recreate the external view but not load the external data yet
-  sdc_reader.Load();
-  axom::sidre::Group* reader_bp_group = sdc_reader.GetBPGroup();
-  EXPECT_TRUE(reader_bp_group->hasView(view_name));
-  axom::sidre::View* reader_external_view = reader_bp_group->getView(view_name);
+    // Note: this will recreate the external view but not load the external data yet
+    sdc_reader.Load();
+    axom::sidre::Group* reader_bp_group = sdc_reader.GetBPGroup();
+    EXPECT_TRUE(reader_bp_group->hasView(view_name));
+    axom::sidre::View* reader_external_view = reader_bp_group->getView(view_name);
 
-  // Create external buffer with wrong data and load previously saved data into it
-  axom::Array<int64_t> reader_data {5, 6, 7, 8};
-  reader_external_view->setExternalDataPtr(reader_data.data());
-  sdc_reader.LoadExternalData();
+    // Create external buffer with wrong data and load previously saved data into it
+    reader_external_view->setExternalDataPtr(reader_data.data());
+
+    sdc_reader.LoadExternalData();
+  }
 
   EXPECT_TRUE(writer_data.size() == reader_data.size());
   SLIC_INFO(axom::fmt::format("~~~~ {}", writer_data.size()));

--- a/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
+++ b/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
@@ -406,8 +406,7 @@ void test_external_user_defined_data()
     EXPECT_EQ(total_size, loaded_total_size);
 
     EXPECT_TRUE(loaded_group->hasView("states"));
-    auto loaded_states_size =
-      loaded_group->getView("states")->getNumElements();
+    auto loaded_states_size = loaded_group->getView("states")->getNumElements();
     EXPECT_EQ(num_uint8s, loaded_states_size);
 
     // Create new array to fill with loaded data

--- a/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
+++ b/src/axom/sidre/tests/sidre_read_write_userdefined_data.cpp
@@ -340,75 +340,88 @@ void test_external_user_defined_data()
   return;
 #endif
 
-  // populate data
   constexpr IndexType size = 10;
-  axom::Array<T, DIM> states(size, size);
-  fill_array(states, 0, true);
+  IndexType num_states {0};
+  IndexType state_size {0};
+  IndexType total_size {0};
+  IndexType num_uint8s {0};
 
-  // Create datastore
   DataStore ds;
   Group* root = ds.getRoot();
 
-  // get size
-  auto num_states = static_cast<IndexType>(states.size());
-  auto state_size = static_cast<IndexType>(sizeof(*(states.begin())));
-  auto total_size = num_states * state_size;
-  auto num_uint8s = total_size / sizeof(std::uint8_t);
+  const std::string filename = "sidre_external_states";
 
-  SLIC_INFO(axom::fmt::format("Num of States={}", num_states));
-  SLIC_INFO(axom::fmt::format("State Size={}", state_size));
-  SLIC_INFO(axom::fmt::format("Total Size={}", total_size));
-  SLIC_INFO(
-    axom::fmt::format("Total Size/State Size={}", total_size / state_size));
-  SLIC_INFO(axom::fmt::format("Num of uint8={}", num_uint8s));
+  // populate data
+  {
+    axom::Array<T, DIM> states(size, size);
+    fill_array(states, 0, true);
 
-  // write shape
-  root->createViewScalar("num_states", num_states);
-  root->createViewScalar("state_size", state_size);
-  root->createViewScalar("total_size", total_size);
+    // get size
+    num_states = static_cast<IndexType>(states.size());
+    state_size = static_cast<IndexType>(sizeof(*(states.begin())));
+    total_size = num_states * state_size;
+    num_uint8s = total_size / sizeof(std::uint8_t);
 
-  // Add states as an external buffer
-  View* states_view = root->createView("states");
-  states_view->setExternalDataPtr(axom::sidre::UINT8_ID,
-                                  num_uint8s,
-                                  states.data());
+    SLIC_INFO(axom::fmt::format("Num of States={}", num_states));
+    SLIC_INFO(axom::fmt::format("State Size={}", state_size));
+    SLIC_INFO(axom::fmt::format("Total Size={}", total_size));
+    SLIC_INFO(
+      axom::fmt::format("Total Size/State Size={}", total_size / state_size));
+    SLIC_INFO(axom::fmt::format("Num of uint8={}", num_uint8s));
 
-  // Save the array data into a file
-  std::string filename = "sidre_external_states";
-  root->save(filename);
+    // write shape
+    root->createViewScalar("num_states", num_states);
+    root->createViewScalar("state_size", state_size);
+    root->createViewScalar("total_size", total_size);
+
+    // Add states as an external buffer
+    View* states_view = root->createView("states");
+    states_view->setExternalDataPtr(axom::sidre::UINT8_ID,
+                                    num_uint8s,
+                                    states.data());
+
+    // Save the array data into a file
+    root->save(filename);
+  }
 
   // Load data into new array
-  Group* loaded_group = root->createGroup("loaded_data");
-  loaded_group->load(filename);
+  {
+    Group* loaded_group = root->createGroup("loaded_data");
+    loaded_group->load(filename);
 
-  // Verify size correctness
-  EXPECT_TRUE(loaded_group->hasView("num_states"));
-  auto loaded_num_states =
-    loaded_group->getView("num_states")->getData<axom::IndexType>();
-  EXPECT_TRUE(num_states == loaded_num_states);
+    // Verify size correctness
+    EXPECT_TRUE(loaded_group->hasView("num_states"));
+    auto loaded_num_states =
+      loaded_group->getView("num_states")->getData<axom::IndexType>();
+    EXPECT_EQ(num_states, loaded_num_states);
 
-  EXPECT_TRUE(loaded_group->hasView("state_size"));
-  auto loaded_state_size =
-    loaded_group->getView("state_size")->getData<axom::IndexType>();
-  EXPECT_TRUE(state_size == loaded_state_size);
+    EXPECT_TRUE(loaded_group->hasView("state_size"));
+    auto loaded_state_size =
+      loaded_group->getView("state_size")->getData<axom::IndexType>();
+    EXPECT_EQ(state_size, loaded_state_size);
 
-  EXPECT_TRUE(loaded_group->hasView("total_size"));
-  auto loaded_total_size =
-    loaded_group->getView("total_size")->getData<axom::IndexType>();
-  EXPECT_TRUE(total_size == loaded_total_size);
+    EXPECT_TRUE(loaded_group->hasView("total_size"));
+    auto loaded_total_size =
+      loaded_group->getView("total_size")->getData<axom::IndexType>();
+    EXPECT_EQ(total_size, loaded_total_size);
 
-  // Create new array to fill with loaded data
-  axom::Array<T, DIM> loaded_states(size, size);
-  fill_array(loaded_states, -1, false);
+    EXPECT_TRUE(loaded_group->hasView("states"));
+    auto loaded_states_size =
+      loaded_group->getView("states")->getNumElements();
+    EXPECT_EQ(num_uint8s, loaded_states_size);
 
-  // Load external data
-  EXPECT_TRUE(loaded_group->hasView("states"));
-  View* loaded_states_view = loaded_group->getView("states");
-  loaded_states_view->setExternalDataPtr(loaded_states.data());
-  loaded_group->loadExternalData(filename);
+    // Create new array to fill with loaded data
+    axom::Array<T, DIM> loaded_states(size, size);
+    fill_array(loaded_states, -1, false);
 
-  // Test data was read into the new location and overwrote the bad data
-  check_array(loaded_states);
+    // Load external data
+    View* loaded_states_view = loaded_group->getView("states");
+    loaded_states_view->setExternalDataPtr(loaded_states.data());
+    loaded_group->loadExternalData(filename);
+
+    // Test data was read into the new location and overwrote the bad data
+    check_array(loaded_states);
+  }
 }
 
 #if defined(AXOM_USE_MFEM) && defined(AXOM_USE_HDF5)
@@ -419,85 +432,99 @@ void test_MFEMSidreDataCollection_user_defined_data()
   std::string test_name =
     ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
-  // populate data
   constexpr IndexType size = 10;
-  axom::Array<T, DIM> states(size, size);
-  fill_array(states, 0, true);
+  IndexType num_states {0};
+  IndexType state_size {0};
+  IndexType total_size {0};
+  IndexType num_uint8s {0};
 
-  // Create MFEMSidreDataCollection
-  auto* mesh = new mfem::Mesh(mfem::Mesh::MakeCartesian1D(10));
-  const bool owns_mesh_data = true;
-  MFEMSidreDataCollection sdc_writer(test_name, mesh, owns_mesh_data);
-  Group* bp_group = sdc_writer.GetBPGroup();
+  // populate data into Data Collection and save
+  {
+    axom::Array<T, DIM> states(size, size);
+    fill_array(states, 0, true);
 
-  // get size
-  auto num_states = static_cast<IndexType>(states.size());
-  auto state_size = static_cast<IndexType>(sizeof(*(states.begin())));
-  auto total_size = num_states * state_size;
-  auto num_uint8s = total_size / sizeof(std::uint8_t);
+    // Create MFEMSidreDataCollection
+    auto* mesh = new mfem::Mesh(mfem::Mesh::MakeCartesian1D(10));
+    const bool owns_mesh_data = true;
+    MFEMSidreDataCollection sdc_writer(test_name, mesh, owns_mesh_data);
+    Group* bp_group = sdc_writer.GetBPGroup();
 
-  SLIC_INFO(axom::fmt::format("Num of States={}", num_states));
-  SLIC_INFO(axom::fmt::format("State Size={}", state_size));
-  SLIC_INFO(axom::fmt::format("Total Size={}", total_size));
-  SLIC_INFO(
-    axom::fmt::format("Total Size/State Size={}", total_size / state_size));
-  SLIC_INFO(axom::fmt::format("Num of uint8={}", num_uint8s));
+    // get size
+    num_states = static_cast<IndexType>(states.size());
+    state_size = static_cast<IndexType>(sizeof(*(states.begin())));
+    total_size = num_states * state_size;
+    num_uint8s = total_size / sizeof(std::uint8_t);
 
-  // write shape
-  bp_group->createViewScalar("num_states", num_states);
-  bp_group->createViewScalar("state_size", state_size);
-  bp_group->createViewScalar("total_size", total_size);
+    SLIC_INFO(axom::fmt::format("Num of States={}", num_states));
+    SLIC_INFO(axom::fmt::format("State Size={}", state_size));
+    SLIC_INFO(axom::fmt::format("Total Size={}", total_size));
+    SLIC_INFO(
+      axom::fmt::format("Total Size/State Size={}", total_size / state_size));
+    SLIC_INFO(axom::fmt::format("Num of uint8={}", num_uint8s));
 
-  // Add states as an external buffer
-  View* states_view = bp_group->createView("states");
-  states_view->setExternalDataPtr(axom::sidre::UINT8_ID,
-                                  num_uint8s,
-                                  states.data());
+    // write shape
+    bp_group->createViewScalar("num_states", num_states);
+    bp_group->createViewScalar("state_size", state_size);
+    bp_group->createViewScalar("total_size", total_size);
+
+    // Add states as an external buffer
+    View* states_view = bp_group->createView("states");
+    states_view->setExternalDataPtr(axom::sidre::UINT8_ID,
+                                    num_uint8s,
+                                    states.data());
 
   // Save the array data into a file
   #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
-  sdc_writer.SetComm(MPI_COMM_WORLD);
+    sdc_writer.SetComm(MPI_COMM_WORLD);
   #endif
-  sdc_writer.SetCycle(0);
-  sdc_writer.Save();
+    sdc_writer.SetCycle(0);
+    sdc_writer.Save();
+  }
 
   // Load data into new Data Collection
-  MFEMSidreDataCollection sdc_reader(test_name);
+  {
+    MFEMSidreDataCollection sdc_reader(test_name);
   #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
-  sdc_reader.SetComm(MPI_COMM_WORLD);
+    sdc_reader.SetComm(MPI_COMM_WORLD);
   #endif
-  sdc_reader.Load();
+    sdc_reader.Load();
 
-  Group* loaded_bp_group = sdc_reader.GetBPGroup();
+    Group* loaded_bp_group = sdc_reader.GetBPGroup();
 
-  // Verify size correctness
-  EXPECT_TRUE(loaded_bp_group->hasView("num_states"));
-  auto loaded_num_states =
-    loaded_bp_group->getView("num_states")->getData<axom::IndexType>();
-  EXPECT_TRUE(num_states == loaded_num_states);
+    // Verify size correctness
+    EXPECT_TRUE(loaded_bp_group->hasView("num_states"));
+    auto loaded_num_states =
+      loaded_bp_group->getView("num_states")->getData<axom::IndexType>();
+    EXPECT_EQ(num_states, loaded_num_states);
 
-  EXPECT_TRUE(loaded_bp_group->hasView("state_size"));
-  auto loaded_state_size =
-    loaded_bp_group->getView("state_size")->getData<axom::IndexType>();
-  EXPECT_TRUE(state_size == loaded_state_size);
+    EXPECT_TRUE(loaded_bp_group->hasView("state_size"));
+    auto loaded_state_size =
+      loaded_bp_group->getView("state_size")->getData<axom::IndexType>();
+    EXPECT_EQ(state_size, loaded_state_size);
 
-  EXPECT_TRUE(loaded_bp_group->hasView("total_size"));
-  auto loaded_total_size =
-    loaded_bp_group->getView("total_size")->getData<axom::IndexType>();
-  EXPECT_TRUE(total_size == loaded_total_size);
+    EXPECT_TRUE(loaded_bp_group->hasView("total_size"));
+    auto loaded_total_size =
+      loaded_bp_group->getView("total_size")->getData<axom::IndexType>();
+    EXPECT_EQ(total_size, loaded_total_size);
 
-  // Create new array to fill with loaded data
-  axom::Array<T, DIM> loaded_states(size, size);
-  fill_array(loaded_states, -1, false);
+    EXPECT_TRUE(loaded_bp_group->hasView("states"));
+    auto loaded_states_size =
+      loaded_bp_group->getView("states")->getNumElements();
+    EXPECT_EQ(num_uint8s, loaded_states_size);
 
-  // Load external data
-  EXPECT_TRUE(loaded_bp_group->hasView("states"));
-  View* loaded_states_view = loaded_bp_group->getView("states");
-  loaded_states_view->setExternalDataPtr(loaded_states.data());
-  sdc_reader.LoadExternalData();
+    // Create new array to fill with loaded data
+    axom::Array<T, DIM> loaded_states(size, size);
+    fill_array(loaded_states, -1, false);
 
-  // Test data was read into the new location and overwrote the bad data
-  check_array(loaded_states);
+    // Load external data
+    EXPECT_TRUE(loaded_bp_group->hasView("states"));
+    View* loaded_states_view = loaded_bp_group->getView("states");
+    loaded_states_view->setExternalDataPtr(loaded_states.data());
+    sdc_reader.LoadExternalData();
+
+    // Test data was read into the new location and overwrote the bad data
+    check_array(loaded_states);
+  }
 }
 
 #endif  // defined(AXOM_USE_MFEM) && defined(AXOM_USE_HDF5)

--- a/src/axom/sina/core/Document.cpp
+++ b/src/axom/sina/core/Document.cpp
@@ -145,7 +145,6 @@ void saveDocument(Document const &document, std::string const &fileName)
   fout << asJson;
   fout.close();
 
-
   // windows doesn't let you rename to a destination that already exists
   axom::utilities::filesystem::removeFile(fileName);
 

--- a/src/axom/sina/core/Document.cpp
+++ b/src/axom/sina/core/Document.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "axom/sina/core/Document.hpp"
+#include "axom/core.hpp"
 
 #include <cstdio>
 #include <fstream>
@@ -136,14 +137,17 @@ void saveDocument(Document const &document, std::string const &fileName)
   // that if a write fails, the old file is left intact. For this reason,
   // we write to a temporary file first and then move the file. The temporary
   // file is in the same directory to ensure that it is part of the same
-  // file system as the destination file so that the move operation is
-  // atomic.
+  // file system as the destination file so that the move operation is atomic.
   std::string tmpFileName = fileName + SAVE_TMP_FILE_EXTENSION;
   auto asJson = document.toJson();
   std::ofstream fout {tmpFileName};
   fout.exceptions(std::ostream::failbit | std::ostream::badbit);
   fout << asJson;
   fout.close();
+
+
+  // windows doesn't let you rename to a destination that already exists
+  axom::utilities::filesystem::removeFile(fileName);
 
   if(rename(tmpFileName.c_str(), fileName.c_str()) != 0)
   {

--- a/src/axom/sina/core/ID.cpp
+++ b/src/axom/sina/core/ID.cpp
@@ -65,10 +65,11 @@ IDField::IDField(ID value_, std::string localName_, std::string globalName_)
 IDField::IDField(conduit::Node const &parentObject,
                  std::string localName_,
                  std::string globalName_)
-  : IDField {extractIDFromObject(parentObject, localName_, globalName_),
-             std::move(localName_),
-             std::move(globalName_)}
-{ }
+  : value(extractIDFromObject(parentObject, localName_, globalName_))
+{ 
+  std::swap(localName, localName_);
+  std::swap(globalName, globalName_);
+}
 
 void IDField::addTo(conduit::Node &object) const
 {

--- a/src/axom/sina/core/ID.cpp
+++ b/src/axom/sina/core/ID.cpp
@@ -66,7 +66,7 @@ IDField::IDField(conduit::Node const &parentObject,
                  std::string localName_,
                  std::string globalName_)
   : value(extractIDFromObject(parentObject, localName_, globalName_))
-{ 
+{
   std::swap(localName, localName_);
   std::swap(globalName, globalName_);
 }

--- a/src/cmake/AxomConfig.cmake
+++ b/src/cmake/AxomConfig.cmake
@@ -43,9 +43,12 @@ foreach(option MPI3)
     endif()
 endforeach()
 
-convert_to_native_escaped_file_path(${PROJECT_SOURCE_DIR} AXOM_SRC_DIR)
-convert_to_native_escaped_file_path(${PROJECT_BINARY_DIR} AXOM_BIN_DIR)
-
+# Handle paths
+convert_to_native_escaped_file_path(${PROJECT_SOURCE_DIR} AXOM_SRC_DIR_NATIVE)
+convert_to_native_escaped_file_path(${PROJECT_BINARY_DIR} AXOM_BIN_DIR_NATIVE)
+if(AXOM_DATA_DIR)
+  convert_to_native_escaped_file_path(${AXOM_DATA_DIR} AXOM_DATA_DIR_NATIVE)
+endif()
 
 #------------------------------------------------------------------------------
 # Compiler and language related configuration variables

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -318,7 +318,7 @@ endmacro(axom_assert_find_succeeded)
 ## convert_to_native_escaped_file_path( path output )
 ##
 ## This macro converts a cmake path to a platform specific string literal
-## usable in C++.  (For example, on windows C:/Path will be come C:\\Path)
+## usable in C++.  (For example, on windows C:/Path will become C:\\Path)
 ##------------------------------------------------------------------------------
 
 macro(convert_to_native_escaped_file_path path output)


### PR DESCRIPTION
# Summary

- This PR is a bugfix for the build on Windows
- It fixes:
   -  the MIR build, which required some exports for static members
    - MIR tests that depend on the compile time path to the data directory
    - A bug with the quicksort algorithm for some data orderings and adds a unit test
    - Some quest tests when mfem does not have MPI
    - Some quest lambdas that take a constexpr -- MSVC appears to require `static constexpr` w/ c++14. This might be relaxed in c++17
 - I also cleaned up/updated some sidre::Group implementations to use the iterator interface while working on sidre test bugfixes
 - **Update:** Passes all builds and tests in our Windows TPL CI -- https://github.com/LLNL/axom/actions/runs/13846008225
  
#### Status:
- The code + tests + examples currently build w/ our msvc configuration
- The following tests are still currently failing (checked when fixed):
  - [x] 85 - sina_Document (Failed)
  - [x] 86 - sina_ID (Failed)
  - [x] 87 - sina_Record (Failed)
  - [x] 88 - sina_Relationship (Failed)
  - [x] 89 - sina_Run (Failed)
  - [x] 170 - sidre_read_write_userdefined_data (Failed)
  - [x] 171 - sidre_mfem_datacollection (Failed)
  - Update: All fixed!
- The sina failures appear to be related to data that is moved. I will try to fix w/ `ubsan`
  - Update: Fixed. There was also an error related to trying to rename a tmp file. Windows does not allow this if the destination already exists.
- The sidre failures appear to be related to `MFEMSidreDataCollection::LoadExternalData()`. Perhaps related to changes from: 
    - https://github.com/LLNL/axom/pull/1473
    - https://github.com/LLNL/axom/issues/1479
    - https://github.com/LLNL/axom/pull/1494
    - Update: The sidre failures were due to loading external data into the wrong group when not going through spio