### PR TITLE
spack v1.0 support: `%foo +bar` -> `+bar %foo`

### DIFF
--- a/scripts/spack/configs/toss_4_x86_64_ib/spack.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib/spack.yaml
@@ -121,11 +121,11 @@ spack:
     mvapich2:
       buildable: false
       externals:
-      - spec: mvapich2@2.3.6%clang@14.0.6~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto process_managers=slurm threads=multiple
+      - spec: mvapich2@2.3.6~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto process_managers=slurm threads=multiple %clang@14.0.6
         prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.6-clang-14.0.6
-      - spec: mvapich2@2.3.6%gcc@10.3.1~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto process_managers=slurm threads=multiple
+      - spec: mvapich2@2.3.6~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto process_managers=slurm threads=multiple %gcc@10.3.1
         prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1
-      - spec: mvapich2@2.3.6%intel@2022.1.0~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto process_managers=slurm threads=multiple
+      - spec: mvapich2@2.3.6~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto process_managers=slurm threads=multiple %intel@2022.1.0
         prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.6-intel-2022.1.0
 
     netlib-lapack:

--- a/scripts/spack/configs/toss_4_x86_64_ib_cray/spack.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib_cray/spack.yaml
@@ -273,21 +273,21 @@ spack:
     cray-mpich:
       buildable: false
       externals:
-      - spec: cray-mpich@8.1.16%clang@14.0.0+slurm
+      - spec: cray-mpich@8.1.16+slurm %clang@14.0.0
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.2.3/
-      - spec: cray-mpich@8.1.25%clang@15.0.0+slurm
+      - spec: cray-mpich@8.1.25+slurm %clang@15.0.0
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.25-rocmcc-5.4.3/
-      - spec: cray-mpich@8.1.25%clang@16.0.0+slurm
+      - spec: cray-mpich@8.1.25+slurm %clang@16.0.0
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.25-rocmcc-5.6.0/
-      - spec: cray-mpich@8.1.27%rocmcc@5.7.1+slurm
+      - spec: cray-mpich@8.1.27+slurm %rocmcc@5.7.1
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.27-rocmcc-5.7.1/
-      - spec: cray-mpich@8.1.29%rocmcc@6.1.2+slurm
+      - spec: cray-mpich@8.1.29+slurm %rocmcc@6.1.2
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2/
-      - spec: cray-mpich@8.1.29%rocmcc@6.2.1+slurm
+      - spec: cray-mpich@8.1.29+slurm %rocmcc@6.2.1
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.2.1/
-      - spec: cray-mpich@8.1.25%cce@15.0.1+slurm
+      - spec: cray-mpich@8.1.25+slurm %cce@15.0.1
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.25-rocmcc-5.4.3-cce-15.0.1/
-      - spec: cray-mpich@8.1.29%cce@18.0.0+slurm
+      - spec: cray-mpich@8.1.29+slurm %cce@18.0.0
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.1.2-cce-18.0.0/
 
     # blas is a bit more complicated because its a virtual package so fake it with

--- a/scripts/spack/devtools_configs/toss_4_x86_64_ib/spack.yaml
+++ b/scripts/spack/devtools_configs/toss_4_x86_64_ib/spack.yaml
@@ -72,7 +72,7 @@ spack:
     mvapich2:
       buildable: false
       externals:
-      - spec: mvapich2@2.3.6%gcc@10.3.1 process_managers=slurm arch=linux-rhel8-ivybridge
+      - spec: mvapich2@2.3.6 process_managers=slurm arch=linux-rhel8-ivybridge %gcc@10.3.1
         prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.6-gcc-10.3.1
 
     netlib-lapack:

--- a/scripts/spack/devtools_configs/toss_4_x86_64_ib_cray/spack.yaml
+++ b/scripts/spack/devtools_configs/toss_4_x86_64_ib_cray/spack.yaml
@@ -104,7 +104,7 @@ spack:
     cray-mpich:
       buildable: false
       externals:
-      - spec: cray-mpich@8.1.29%gcc@10.3.1+slurm
+      - spec: cray-mpich@8.1.29+slurm %gcc@10.3.1
         prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-gcc-10.3.1/
 
     # blas is a bit more complicated because its a virtual package so fake it with


### PR DESCRIPTION
# Summary

Spack v1.0 will parse `pkg %gcc +foo` as "pkg with direct dependency gcc
with variant foo enabled" instead of "pkg with variant foo enabled and compiler
gcc". Reorder as `pkg +foo %gcc` to be compatible with Spack v0.x and
v1.0.
