### PR TITLE
Work-around for ROCM overflowing ints when scan-summing arrays

### DIFF
--- a/src/axom/quest/MarchingCubes.hpp
+++ b/src/axom/quest/MarchingCubes.hpp
@@ -292,6 +292,15 @@ public:
   // Allow single-domain code to share common scratch space.
   friend detail::marching_cubes::MarchingCubesSingleDomain;
 
+  /*
+    TODO: CrossingFlagType can be a boolean value but is wastefully
+    stored in 32 bits because of a ROCM scan implementation that adds
+    them in the input type without promoting them to our 32-bit output
+    type.  When ROCM supports the promotion and RAJA uses it, we can
+    change this type to something more efficient.
+  */
+  using CrossingFlagType = std::uint32_t;
+
 private:
   RuntimePolicy m_runtimePolicy;
   int m_allocatorID = axom::INVALID_ALLOCATOR_ID;
@@ -327,7 +336,8 @@ private:
   //!@name Scratch space from m_allocatorID, shared among singles
   // Memory alloc is slow on CUDA, so this optimizes space AND time.
   axom::Array<std::uint16_t> m_caseIdsFlat;
-  axom::Array<std::uint16_t> m_crossingFlags;
+
+  axom::Array<CrossingFlagType> m_crossingFlags;
   axom::Array<axom::IndexType> m_scannedFlags;
   axom::Array<axom::IndexType> m_facetIncrs;
   //@}

--- a/src/axom/quest/detail/MarchingCubesImpl.hpp
+++ b/src/axom/quest/detail/MarchingCubesImpl.hpp
@@ -47,6 +47,8 @@ public:
   using MIdx = axom::StackArray<axom::IndexType, DIM>;
   using MDMapper = axom::MDMapping<DIM>;
   using FacetIdType = int;
+  using CrossingFlagType = axom::quest::MarchingCubes::CrossingFlagType;
+
   using LoopPolicy = typename execution_space<ExecSpace>::loop_policy;
   using ReducePolicy = typename execution_space<ExecSpace>::reduce_policy;
 #if defined(AXOM_USE_RAJA)
@@ -63,7 +65,7 @@ public:
 
   AXOM_HOST MarchingCubesImpl(int allocatorID,
                               axom::Array<std::uint16_t>& caseIdsFlat,
-                              axom::Array<std::uint16_t>& crossingFlags,
+                              axom::Array<CrossingFlagType>& crossingFlags,
                               axom::Array<axom::IndexType>& scannedFlags,
                               axom::Array<axom::IndexType>& facetIncrs)
     : m_allocatorID(allocatorID)
@@ -963,13 +965,21 @@ private:
   axom::Array<std::uint16_t>& m_caseIdsFlat;
 
   //!@brief Whether a parent cell crosses the contour.
-  axom::Array<std::uint16_t>& m_crossingFlags;
+  axom::Array<CrossingFlagType>& m_crossingFlags;
 
   //!@brief Prefix sum of m_crossingFlags
   axom::Array<axom::IndexType>& m_scannedFlags;
 
+  /*!
+    TODO: Facet increment values lie in [0, 5], but are wastefully
+    stored in 32 bits because of a ROCM scan implementation that adds
+    them in the input type without promoting them to our 32-bit output
+    type.  When ROCM supports the promotion and RAJA uses it, we can
+    change this type to something more efficient.
+  */
+  using FacetIncrsType = std::int32_t;
   //!@brief Number of surface mesh facets added by each crossing.
-  axom::Array<axom::IndexType>& m_facetIncrs;
+  axom::Array<FacetIncrsType>& m_facetIncrs;
 
   //!@brief Number of parent cells crossing the contour surface.
   axom::IndexType m_crossingCount = 0;

--- a/src/axom/quest/detail/MarchingCubesImpl.hpp
+++ b/src/axom/quest/detail/MarchingCubesImpl.hpp
@@ -973,11 +973,11 @@ private:
   /*!
     TODO: Facet increment values lie in [0, 5], but are wastefully
     stored in 32 bits because of a ROCM scan implementation that adds
-    them in the input type without promoting them to our 32-bit output
+    them in the input type without promoting them to the bigger output
     type.  When ROCM supports the promotion and RAJA uses it, we can
     change this type to something more efficient.
   */
-  using FacetIncrsType = std::int32_t;
+  using FacetIncrsType = axom::IndexType;
   //!@brief Number of surface mesh facets added by each crossing.
   axom::Array<FacetIncrsType>& m_facetIncrs;
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix (work-around)
- It does the following:
  - Use a totally inefficient 32-bit int to represent a boolean, to work around a ROCM behavior.
  - Add comment about the same work-around for another array.
  - Add notes on when we can remove the work-around.

We have 2 arrays, one with booleans and with ints in [0,5], but we have to use more bits to represent them for ROCM.  We do sum scans on them and put the output in 32-bit ints.  However, ROCM is doing the sum in the **input** type without promoting to the output type.  This work-around bumps up the input type.

Related to https://github.com/LLNL/RAJA/issues/1631