### PR TITLE
FlatMap: add Umpire support

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,6 +43,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Exposed primal clip operations for clipping various shapes with a plane.
 - Adds ``axom::mir::utilities::blueprint::MakePointMesh`` class that creates a new Blueprint mesh
   consisting of points located at the zone centers of the input mesh.
+- Adds support for custom allocators to `axom::FlatMap`.
 
 ###  Changed
 - Fixed `Timer::elapsed*()` methods so they properly report the sum of all start/stop cycles

--- a/src/axom/core/CMakeLists.txt
+++ b/src/axom/core/CMakeLists.txt
@@ -50,6 +50,7 @@ set(core_headers
 
     ## detail
     detail/FlatTable.hpp
+    detail/FlatMapOps.hpp
 
     ## core
     AnnotationMacros.hpp

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -119,7 +119,11 @@ public:
    *
    * \param other the FlatMap to move data from
    */
-  FlatMap& operator=(FlatMap&& other) { swap(other); }
+  FlatMap& operator=(FlatMap&& other)
+  {
+    swap(other);
+    return *this;
+  }
 
   /*!
    * \brief Copy constructor for a FlatMap instance.

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -575,6 +575,11 @@ public:
   double max_load_factor() const { return MAX_LOAD_FACTOR; }
 
   /*!
+   * \brief Returns the allocator ID the FlatMap is allocated with.
+   */
+  int getAllocatorID() const { return m_allocator.get(); }
+
+  /*!
    * \brief Explicitly rehash the FlatMap with a given number of buckets.
    *
    * \param count the minimum number of buckets to allocate for the rehash

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -94,7 +94,7 @@ public:
    */
   template <typename InputIt>
   FlatMap(InputIt first, InputIt last, IndexType bucket_count = -1)
-    : FlatMap(std::distance(first, last), first, last, bucket_count)
+    : FlatMap(std::distance(first, last), first, last, bucket_count, Allocator {})
   { }
 
   /*!
@@ -581,7 +581,11 @@ public:
    */
   void rehash(IndexType count)
   {
-    FlatMap rehashed(m_size, std::make_move_iterator(begin()), std::make_move_iterator(end()), count);
+    FlatMap rehashed(m_size,
+                     std::make_move_iterator(begin()),
+                     std::make_move_iterator(end()),
+                     count,
+                     m_allocator);
     this->swap(rehashed);
   }
 
@@ -595,7 +599,7 @@ public:
 
 private:
   template <typename InputIt>
-  FlatMap(IndexType num_elems, InputIt first, InputIt last, IndexType bucket_count);
+  FlatMap(IndexType num_elems, InputIt first, InputIt last, IndexType bucket_count, Allocator allocator);
 
   std::pair<iterator, bool> getEmplacePos(const KeyType& key);
 
@@ -715,8 +719,9 @@ template <typename InputIt>
 FlatMap<KeyType, ValueType, Hash>::FlatMap(IndexType num_elems,
                                            InputIt first,
                                            InputIt last,
-                                           IndexType bucket_count)
-  : FlatMap(std::max(num_elems, bucket_count))
+                                           IndexType bucket_count,
+                                           Allocator allocator)
+  : FlatMap(std::max(num_elems, bucket_count), allocator)
 {
   insert(first, last);
 }

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -191,8 +191,8 @@ public:
     : m_allocator(allocator)
     , m_numGroups2(other.m_numGroups2)
     , m_size(other.m_size)
-    , m_metadata(other.m_metadata, m_allocator.get())
-    , m_buckets(other.m_buckets.size(), m_allocator.get())
+    , m_metadata(other.m_metadata, m_allocator.getID())
+    , m_buckets(other.m_buckets.size(), m_allocator.getID())
     , m_loadCount(other.m_loadCount)
   {
     // Copy all elements.
@@ -563,7 +563,7 @@ public:
   /*!
    * \brief Returns the allocator ID the FlatMap is allocated with.
    */
-  int getAllocatorID() const { return m_allocator.get(); }
+  Allocator getAllocator() const { return m_allocator; }
 
   /*!
    * \brief Explicitly rehash the FlatMap with a given number of buckets.
@@ -708,9 +708,9 @@ FlatMap<KeyType, ValueType, Hash>::FlatMap(IndexType bucket_count, Allocator all
   IndexType numBuckets = numGroupsRounded * BucketsPerGroup - 1;
 
   using BucketType = detail::flat_map::GroupBucket;
-  m_metadata = axom::Array<BucketType>(numGroupsRounded, numGroupsRounded, m_allocator.get());
+  m_metadata = axom::Array<BucketType>(numGroupsRounded, numGroupsRounded, m_allocator.getID());
   detail::flat_map::setSentinel(m_metadata);
-  m_buckets = axom::Array<PairStorage>(numBuckets, numBuckets, m_allocator.get());
+  m_buckets = axom::Array<PairStorage>(numBuckets, numBuckets, m_allocator.getID());
 }
 
 template <typename KeyType, typename ValueType, typename Hash>

--- a/src/axom/core/detail/FlatMapOps.hpp
+++ b/src/axom/core/detail/FlatMapOps.hpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef Axom_Core_Detail_FlatMapOps_Hpp
+#define Axom_Core_Detail_FlatMapOps_Hpp
+
+#include "axom/core/detail/FlatTable.hpp"
+
+namespace axom
+{
+namespace detail
+{
+namespace flat_map
+{
+
+inline void setSentinel(axom::ArrayView<GroupBucket> metadata)
+{
+#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA)
+  MemorySpace space = getAllocatorSpace(metadata.getAllocatorID());
+  using DeviceExec = axom::CUDA_EXEC<256>;
+  if(space == MemorySpace::Device)
+  {
+    for_all<DeviceExec>(
+      1,
+      AXOM_LAMBDA(IndexType) { metadata[metadata.size() - 1].setSentinel(); });
+    return;
+  }
+#endif
+  metadata[metadata.size() - 1].setSentinel();
+}
+
+template <typename KVPair, typename LookupPolicy, typename StoragePair = TypeErasedStorage<KVPair>>
+inline void destroyBuckets(axom::ArrayView<GroupBucket> metadata, axom::ArrayView<StoragePair> buckets)
+{
+  if(std::is_trivially_destructible<KVPair>::value)
+  {
+    // Nothing to do.
+    return;
+  }
+
+#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA)
+  MemorySpace space = getAllocatorSpace(metadata.getAllocatorID());
+  using DeviceExec = axom::CUDA_EXEC<256>;
+  // CUDA-only: buckets located in device-only memory and non-trivially
+  // destructible. We'll need to "relocate" the objects to the host to
+  // destroy.
+  //
+  // This presumes the objects are "trivially relocatable." (See a similar
+  // requirement in axom::Array for device allocations on CUDA)
+  axom::Array<StoragePair> buckets_host;
+  axom::Array<GroupBucket> metadata_host;
+  if(space == MemorySpace::Device)
+  {
+    int host_allocator_id = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+    metadata_host = axom::Array<GroupBucket>(metadata, host_allocator_id);
+    buckets_host = axom::Array<StoragePair>(buckets, host_allocator_id);
+    metadata = metadata_host.view();
+    buckets = buckets_host.view();
+  }
+#endif
+  IndexType index = LookupPolicy {}.nextValidIndex(metadata, LookupPolicy::NO_MATCH);
+  while(index < buckets.size())
+  {
+    buckets[index].get().~KVPair();
+    index = LookupPolicy {}.nextValidIndex(metadata, index);
+  }
+}
+
+template <typename KVPair, typename LookupPolicy, typename StoragePair = TypeErasedStorage<KVPair>>
+inline void copyBuckets(axom::ArrayView<const GroupBucket> metadata,
+                        axom::ArrayView<const StoragePair> from_buckets,
+                        axom::ArrayView<StoragePair> to_buckets)
+{
+  if(std::is_trivially_copyable<KVPair>::value)
+  {
+    axom::copy(to_buckets.data(), from_buckets.data(), sizeof(StoragePair) * from_buckets.size());
+    return;
+  }
+
+  axom::ArrayView<StoragePair> to_buckets_stage = to_buckets;
+#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA)
+  // Non-trivially copyable:
+  // "Relocate" to the host to call host-based copy constructor.
+  MemorySpace meta_space = getAllocatorSpace(metadata.getAllocatorID());
+  axom::Array<GroupBucket> metadata_host;
+  if(meta_space == MemorySpace::Device)
+  {
+    int host_allocator_id = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+    metadata_host = axom::Array<GroupBucket>(metadata, host_allocator_id);
+    metadata = metadata_host.view();
+  }
+  MemorySpace from_space = getAllocatorSpace(from_buckets.getAllocatorID());
+  axom::Array<StoragePair> from_buckets_host;
+  if(from_space == MemorySpace::Device)
+  {
+    int host_allocator_id = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+    from_buckets_host = axom::Array<StoragePair>(from_buckets, host_allocator_id);
+    from_buckets = from_buckets_host.view();
+  }
+
+  MemorySpace to_space = getAllocatorSpace(to_buckets.getAllocatorID());
+  axom::Array<StoragePair> to_buckets_host;
+  if(to_space == MemorySpace::Device)
+  {
+    int host_allocator_id = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+    to_buckets_host = axom::Array<StoragePair>(to_buckets, host_allocator_id);
+    to_buckets_stage = to_buckets_host.view();
+  }
+#endif
+  // Copy all elements.
+  IndexType index = LookupPolicy {}.nextValidIndex(metadata, LookupPolicy::NO_MATCH);
+  while(index < from_buckets.size())
+  {
+    new(&to_buckets_stage[index].data) KVPair(from_buckets[index].get());
+    index = LookupPolicy {}.nextValidIndex(metadata, index);
+  }
+
+#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA)
+  if(to_space == MemorySpace::Device)
+  {
+    // We created new elements in a host staging buffer, relocate them to
+    // our desired buffer.
+    axom::copy(to_buckets.data(), to_buckets_stage.data(), sizeof(StoragePair) * to_buckets.size());
+  }
+#endif
+}
+
+}  // namespace flat_map
+}  // namespace detail
+}  // namespace axom
+
+#endif

--- a/src/axom/core/detail/FlatMapOps.hpp
+++ b/src/axom/core/detail/FlatMapOps.hpp
@@ -17,7 +17,7 @@ namespace flat_map
 
 inline void setSentinel(axom::ArrayView<GroupBucket> metadata)
 {
-#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA)
+#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA) && defined(AXOM_GPUCC)
   // Note: HIP can access device memory from the host and does not need special
   // handling - we just defer to the host path in all cases.
   MemorySpace space = getAllocatorSpace(metadata.getAllocatorID());
@@ -42,7 +42,7 @@ inline void destroyBuckets(axom::ArrayView<GroupBucket> metadata, axom::ArrayVie
     return;
   }
 
-#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA)
+#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA) && defined(AXOM_GPUCC)
   // Note: HIP can access device memory from the host and does not need special
   // handling - we just defer to the host path in all cases.
   MemorySpace space = getAllocatorSpace(metadata.getAllocatorID());

--- a/src/axom/core/detail/FlatMapOps.hpp
+++ b/src/axom/core/detail/FlatMapOps.hpp
@@ -18,6 +18,8 @@ namespace flat_map
 inline void setSentinel(axom::ArrayView<GroupBucket> metadata)
 {
 #if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA)
+  // Note: HIP can access device memory from the host and does not need special
+  // handling - we just defer to the host path in all cases.
   MemorySpace space = getAllocatorSpace(metadata.getAllocatorID());
   using DeviceExec = axom::CUDA_EXEC<256>;
   if(space == MemorySpace::Device)
@@ -41,6 +43,8 @@ inline void destroyBuckets(axom::ArrayView<GroupBucket> metadata, axom::ArrayVie
   }
 
 #if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA)
+  // Note: HIP can access device memory from the host and does not need special
+  // handling - we just defer to the host path in all cases.
   MemorySpace space = getAllocatorSpace(metadata.getAllocatorID());
   using DeviceExec = axom::CUDA_EXEC<256>;
   // CUDA-only: buckets located in device-only memory and non-trivially
@@ -81,6 +85,9 @@ inline void copyBuckets(axom::ArrayView<const GroupBucket> metadata,
 
   axom::ArrayView<StoragePair> to_buckets_stage = to_buckets;
 #if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA)
+  // Note: HIP can access device memory from the host and does not need special
+  // handling - we just defer to the host path in all cases.
+
   // Non-trivially copyable:
   // "Relocate" to the host to call host-based copy constructor.
   MemorySpace meta_space = getAllocatorSpace(metadata.getAllocatorID());

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -135,7 +135,7 @@ struct GroupBucket
 
   bool hasSentinel() const { return metadata.buckets[Size - 1] == Sentinel; }
 
-  void setSentinel() { metadata.buckets[Size - 1] = Sentinel; }
+  AXOM_HOST_DEVICE void setSentinel() { metadata.buckets[Size - 1] = Sentinel; }
 
   // We need to map hashes in the range [0, 255] to [2, 255], since 0 and 1
   // are taken by the "empty" and "sentinel" values respectively.

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -208,11 +208,18 @@ inline void copy(void* dst, const void* src, std::size_t numbytes) noexcept;
 /// @}
 // _memory_management_routines_end
 
+/*!
+ * \brief Wrapper type representing an Umpire allocator ID.
+ *
+ *  This type is intended for use in function and constructor arguments, in
+ *  order to avoid ambiguities in overload resolution.
+ */
 struct Allocator
 {
 public:
   explicit Allocator(int alloc_id = axom::getDefaultAllocatorID()) : m_id {alloc_id} { }
 
+  /// \brief Returns the allocator ID.
   int get() const { return m_id; }
 
 private:

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -208,6 +208,17 @@ inline void copy(void* dst, const void* src, std::size_t numbytes) noexcept;
 /// @}
 // _memory_management_routines_end
 
+struct Allocator
+{
+public:
+  explicit Allocator(int alloc_id = axom::getDefaultAllocatorID()) : m_id {alloc_id} { }
+
+  int get() const { return m_id; }
+
+private:
+  int m_id {0};
+};
+
 //------------------------------------------------------------------------------
 //                        IMPLEMENTATION
 //------------------------------------------------------------------------------

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -220,10 +220,10 @@ public:
   explicit Allocator(int alloc_id = axom::getDefaultAllocatorID()) : m_id {alloc_id} { }
 
   /// \brief Returns the allocator ID.
-  int get() const { return m_id; }
+  int getID() const { return m_id; }
 
 private:
-  int m_id {0};
+  int m_id;
 };
 
 //------------------------------------------------------------------------------

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -707,7 +707,7 @@ AXOM_TYPED_TEST(core_flatmap, copy_host_device)
   MapType test_map_device = MapType(test_map, axom::Allocator {device_alloc_id});
 
   // Check that maps are equivalent with a different allocator ID.
-  EXPECT_EQ(test_map_device.getAllocatorID(), device_alloc_id);
+  EXPECT_EQ(test_map_device.getAllocator().getID(), device_alloc_id);
   EXPECT_EQ(test_map_device.bucket_count(), test_map.bucket_count());
   EXPECT_EQ(test_map_device.size(), test_map.size());
 
@@ -715,7 +715,7 @@ AXOM_TYPED_TEST(core_flatmap, copy_host_device)
   MapType test_map_host = MapType(test_map_device, axom::Allocator {host_alloc_id});
 
   // Check that maps are equivalent with the same allocator ID.
-  EXPECT_EQ(test_map_host.getAllocatorID(), host_alloc_id);
+  EXPECT_EQ(test_map_host.getAllocator().getID(), host_alloc_id);
   EXPECT_EQ(test_map_host.bucket_count(), test_map.bucket_count());
   EXPECT_EQ(test_map_host.size(), test_map.size());
 


### PR DESCRIPTION
# Summary

- Adds an `Allocator` wrapper class to disambiguate between integer arguments and allocator ID
  
  This is a speculative change, and I'd like to hear feedback from others: my biggest complaint/regret about the `Array` constructor interface is that we aren't fully drop-in compatible with the `std::vector` constructor interface, as we've sprinkled in `allocator_id` function arguments haphazardly. I'm hoping this might provide an alternative path forward that we can test out in `FlatMap` for now, and maybe bring it over into `Array` proper once fleshed out.
- Adds initial Umpire allocation support for `FlatMap`, supporting the following operations:
  - Creating a `FlatMap` within a custom Umpire allocator
  - Copying `FlatMap` between two different allocators, including device-based allocators
  - Destroying `FlatMap` created within a Umpire device-based allocator.
- Fix move assignment operator by returning reference to current instance