### PR TITLE
Support multiple start/stop cycles in Timer

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,6 +20,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ## [Unreleased] - Release date yyyy-mm-dd
 
 ###  Added
+- New `Timer::summed()` method reports the sum of all start/stop cycles since the last `reset()`.
 - New `axom::MALLOC_ALLOCATOR_ID` is for using malloc and free
   even when axom is con figured with Umpire support.
 

--- a/src/axom/core/tests/utils_Timer.hpp
+++ b/src/axom/core/tests/utils_Timer.hpp
@@ -71,13 +71,13 @@ TEST(utils_Timer, timer_check_sum)
     t2.stop();
   }
 
-  std::cout << "t1 measured: " << t1.summed() << "s in " << t1.periodCount() << " periods" << std::endl;
-  std::cout << "t2 measured: " << t2.summed() << "s in " << t2.periodCount() << " periods" << std::endl;
+  std::cout << "t1 measured: " << t1.summed() << "s in " << t1.cycleCount() << " cycles" << std::endl;
+  std::cout << "t2 measured: " << t2.summed() << "s in " << t2.cycleCount() << " cycles" << std::endl;
 
-  EXPECT_EQ(t1.periodCount(), N);
-  EXPECT_EQ(t2.periodCount(), N);
+  EXPECT_EQ(t1.cycleCount(), N);
+  EXPECT_EQ(t2.cycleCount(), N);
 
-  // Estimated inaccuracy per start-stop period.
+  // Estimated inaccuracy per start-stop cycle.
   // from the C++ code, function call, etc.
   const double tol = 1.4e-4;
 

--- a/src/axom/core/tests/utils_Timer.hpp
+++ b/src/axom/core/tests/utils_Timer.hpp
@@ -58,7 +58,7 @@ TEST(utils_Timer, timer_check_duration)
 
 TEST(utils_Timer, timer_check_sum)
 {
-  const int N = 3;
+  const int N = 10;
   axom::utilities::Timer t1(false);
   axom::utilities::Timer t2(false);
   for(int n = 0; n < N; ++n)
@@ -79,7 +79,7 @@ TEST(utils_Timer, timer_check_sum)
 
   // Estimated inaccuracy per start-stop cycle.
   // from the C++ code, function call, etc.
-  const double tol = 1.4e-4;
+  const double tol = 1.0e-3;
 
   EXPECT_GE(t1.summed() / N, 1 - tol);
   EXPECT_LE(t1.summed() / N, 1 + tol);

--- a/src/axom/core/tests/utils_Timer.hpp
+++ b/src/axom/core/tests/utils_Timer.hpp
@@ -58,7 +58,7 @@ TEST(utils_Timer, timer_check_duration)
 
 TEST(utils_Timer, timer_check_sum)
 {
-  const int N = 10;
+  const int N = 3;
   axom::utilities::Timer t1(false);
   axom::utilities::Timer t2(false);
   for(int n = 0; n < N; ++n)
@@ -79,7 +79,7 @@ TEST(utils_Timer, timer_check_sum)
 
   // Estimated inaccuracy per start-stop cycle.
   // from the C++ code, function call, etc.
-  const double tol = 1.0e-3;
+  const double tol = 1.4e-4;
 
   EXPECT_GE(t1.summed() / N, 1 - tol);
   EXPECT_LE(t1.summed() / N, 1 + tol);

--- a/src/axom/core/tests/utils_Timer.hpp
+++ b/src/axom/core/tests/utils_Timer.hpp
@@ -55,3 +55,34 @@ TEST(utils_Timer, timer_check_duration)
   EXPECT_GE(e, 1.0);
   EXPECT_LT(e, 2.0);
 }
+
+TEST(utils_Timer, timer_check_sum)
+{
+  const int N = 3;
+  axom::utilities::Timer t1(false);
+  axom::utilities::Timer t2(false);
+  for(int n = 0; n < N; ++n)
+  {
+    t2.start();
+    t1.start();
+    sleep(1);
+    t1.stop();
+    sleep(1);
+    t2.stop();
+  }
+
+  std::cout << "t1 measured: " << t1.summed() << "s in " << t1.periodCount() << " periods" << std::endl;
+  std::cout << "t2 measured: " << t2.summed() << "s in " << t2.periodCount() << " periods" << std::endl;
+
+  EXPECT_EQ(t1.periodCount(), N);
+  EXPECT_EQ(t2.periodCount(), N);
+
+  // Estimated inaccuracy per start-stop period.
+  // from the C++ code, function call, etc.
+  const double tol = 1.4e-4;
+
+  EXPECT_GE(t1.summed()/N, 1 - tol);
+  EXPECT_LE(t1.summed()/N, 1 + tol);
+  EXPECT_GE(t2.summed()/N, 2 - tol);
+  EXPECT_LE(t2.summed()/N, 2 + tol);
+}

--- a/src/axom/core/tests/utils_Timer.hpp
+++ b/src/axom/core/tests/utils_Timer.hpp
@@ -81,8 +81,8 @@ TEST(utils_Timer, timer_check_sum)
   // from the C++ code, function call, etc.
   const double tol = 1.4e-4;
 
-  EXPECT_GE(t1.summed()/N, 1 - tol);
-  EXPECT_LE(t1.summed()/N, 1 + tol);
-  EXPECT_GE(t2.summed()/N, 2 - tol);
-  EXPECT_LE(t2.summed()/N, 2 + tol);
+  EXPECT_GE(t1.summed() / N, 1 - tol);
+  EXPECT_LE(t1.summed() / N, 1 + tol);
+  EXPECT_GE(t2.summed() / N, 2 - tol);
+  EXPECT_LE(t2.summed() / N, 2 + tol);
 }

--- a/src/axom/core/utilities/Timer.hpp
+++ b/src/axom/core/utilities/Timer.hpp
@@ -75,7 +75,7 @@ public:
   Timer(bool startRunning = false)
     : m_running(startRunning)
     , m_summedTime(0)
-    , m_periodCount(0)
+    , m_cycleCount(0)
   {
     if(m_running)
     {
@@ -100,7 +100,7 @@ public:
     m_stopTime = ClockType::now();
     m_running = false;
     m_summedTime = m_summedTime + m_stopTime - m_startTime;
-    ++m_periodCount;
+    ++m_cycleCount;
   }
 
   /*!
@@ -150,14 +150,14 @@ public:
 
   /*!
    * @brief Returns the time in seconds summed across
-   * all start-stop periods since the last reset().
+   * all start-stop cycles since the last reset().
    * \return the summed time in seconds.
    */
   double summed() { return summedTimeInSec(); }
 
   /*!
    * @brief Returns the time in seconds summed across
-   * all start-stop periods since the last reset().
+   * all start-stop cycles since the last reset().
    * \return the summed time in seconds.
    */
   double summedTimeInSec()
@@ -170,26 +170,26 @@ public:
   }
 
   /*!
-   * @brief Returns number of start-stop periods since the last reset().
-   * \return the number of start-stop periods.
+   * @brief Returns number of start/stop cycles since the last reset().
+   * \return the number of start-stop cycles.
    */
-  size_t periodCount()
+  size_t cycleCount()
   {
-    return m_periodCount;
+    return m_cycleCount;
   }
 
   /*!
    * \brief Resets the timer.
    * \post this->elapsed()==0.0
    * \post this->summedTimeInSec()==0.0
-   * \post this->periodCount()==0
+   * \post this->cycleCount()==0
    */
   void reset()
   {
     m_running = false;
     m_startTime = m_stopTime = TimeStruct();
     m_summedTime = TimeDiff(0);
-    m_periodCount = 0;
+    m_cycleCount = 0;
   }
 
 private:
@@ -200,7 +200,7 @@ private:
   TimeStruct m_stopTime;
   bool m_running;
   TimeDiff m_summedTime;
-  size_t m_periodCount;
+  size_t m_cycleCount;
 };
 
 }  // namespace utilities

--- a/src/axom/core/utilities/Timer.hpp
+++ b/src/axom/core/utilities/Timer.hpp
@@ -96,7 +96,7 @@ public:
   {
     m_stopTime = ClockType::now();
     m_running = false;
-    m_summedTime = m_summedTime + m_stopTime - m_startTime;
+    m_summedTime += m_stopTime - m_startTime;
     ++m_cycleCount;
   }
 

--- a/src/axom/core/utilities/Timer.hpp
+++ b/src/axom/core/utilities/Timer.hpp
@@ -72,7 +72,10 @@ public:
    * \param startRunning Indicates whether to start the timer
    *        during construction (default is false)
    */
-  Timer(bool startRunning = false) : m_running(startRunning)
+  Timer(bool startRunning = false)
+    : m_running(startRunning)
+    , m_summedTime(0)
+    , m_periodCount(0)
   {
     if(m_running)
     {
@@ -96,6 +99,8 @@ public:
   {
     m_stopTime = ClockType::now();
     m_running = false;
+    m_summedTime = m_summedTime + m_stopTime - m_startTime;
+    ++m_periodCount;
   }
 
   /*!
@@ -144,13 +149,47 @@ public:
   }
 
   /*!
+   * @brief Returns the time in seconds summed across
+   * all start-stop periods since the last reset().
+   * \return the summed time in seconds.
+   */
+  double summed() { return summedTimeInSec(); }
+
+  /*!
+   * @brief Returns the time in seconds summed across
+   * all start-stop periods since the last reset().
+   * \return the summed time in seconds.
+   */
+  double summedTimeInSec()
+  {
+    if(m_running)
+    {
+      stop();
+    }
+    return m_summedTime.count();
+  }
+
+  /*!
+   * @brief Returns number of start-stop periods since the last reset().
+   * \return the number of start-stop periods.
+   */
+  size_t periodCount()
+  {
+    return m_periodCount;
+  }
+
+  /*!
    * \brief Resets the timer.
    * \post this->elapsed()==0.0
+   * \post this->summedTimeInSec()==0.0
+   * \post this->periodCount()==0
    */
   void reset()
   {
     m_running = false;
     m_startTime = m_stopTime = TimeStruct();
+    m_summedTime = TimeDiff(0);
+    m_periodCount = 0;
   }
 
 private:
@@ -160,6 +199,8 @@ private:
   TimeStruct m_startTime;
   TimeStruct m_stopTime;
   bool m_running;
+  TimeDiff m_summedTime;
+  size_t m_periodCount;
 };
 
 }  // namespace utilities

--- a/src/axom/core/utilities/Timer.hpp
+++ b/src/axom/core/utilities/Timer.hpp
@@ -72,10 +72,7 @@ public:
    * \param startRunning Indicates whether to start the timer
    *        during construction (default is false)
    */
-  Timer(bool startRunning = false)
-    : m_running(startRunning)
-    , m_summedTime(0)
-    , m_cycleCount(0)
+  Timer(bool startRunning = false) : m_running(startRunning), m_summedTime(0), m_cycleCount(0)
   {
     if(m_running)
     {
@@ -173,10 +170,7 @@ public:
    * @brief Returns number of start/stop cycles since the last reset().
    * \return the number of start-stop cycles.
    */
-  size_t cycleCount()
-  {
-    return m_cycleCount;
-  }
+  size_t cycleCount() { return m_cycleCount; }
 
   /*!
    * \brief Resets the timer.

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -613,12 +613,13 @@ void printTimingStats(axom::utilities::Timer& t, const std::string& description)
     const auto count = t.cycleCount();
     if(count > 1)
     {
-      SLIC_INFO(axom::fmt::format("'{}' took {{avg:{}, min:{}, max:{}}} seconds (avg of {} samples)",
-                                  description,
-                                  sumCompute/count / numRanks,
-                                  minCompute/count,
-                                  maxCompute/count,
-                                  count));
+      SLIC_INFO(
+        axom::fmt::format("'{}' took {{avg:{}, min:{}, max:{}}} seconds (avg of {} samples)",
+                          description,
+                          sumCompute / count / numRanks,
+                          minCompute / count,
+                          maxCompute / count,
+                          count));
     }
     else
     {
@@ -839,9 +840,8 @@ struct ContourTestBase
       {
         AXOM_ANNOTATE_SCOPE("MCInit");
         initializationTimer.start();
-        mcPtr = std::make_unique<quest::MarchingCubes>(params.policy,
-                                                       s_allocatorId,
-                                                       params.dataParallelism);
+        mcPtr =
+          std::make_unique<quest::MarchingCubes>(params.policy, s_allocatorId, params.dataParallelism);
         mcPtr->setMesh(computationalMesh.asConduitNode(), "mesh", "mask");
         initializationTimer.stop();
       }
@@ -873,15 +873,28 @@ struct ContourTestBase
           for(int iMask = 0; iMask < params.maskCount; ++iMask)
           {
             mc.setMaskValue(iMask);
-            if(i == 0) { contourTimerM.start(); } else { contourTimer.start(); }
+            if(i == 0)
+            {
+              contourTimerM.start();
+            }
+            else
+            {
+              contourTimer.start();
+            }
             mc.computeIsocontour(params.contourVal);
-            if(i == 0) { contourTimerM.stop(); } else { contourTimer.stop(); }
+            if(i == 0)
+            {
+              contourTimerM.stop();
+            }
+            else
+            {
+              contourTimer.stop();
+            }
           }
           m_strategyFacetPrefixSum.push_back(mc.getContourFacetCount());
         }
       }
       contourGenLoopTimer.stop();
-
     }
     objectRepLoopTimer.stop();
     AXOM_ANNOTATE_END(objectLoopName);
@@ -1778,8 +1791,7 @@ int main(int argc, char** argv)
     exit(retval);
   }
 
-  axom::utilities::raii::AnnotationsWrapper annotation_raii_wrapper(
-    params.annotationMode);
+  axom::utilities::raii::AnnotationsWrapper annotation_raii_wrapper(params.annotationMode);
   axom::utilities::Timer questMarchingCubesExample(false);
   questMarchingCubesExample.start();
   AXOM_ANNOTATE_SCOPE("quest marching cubes example");

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -610,7 +610,7 @@ void printTimingStats(axom::utilities::Timer& t, const std::string& description)
     double minCompute, maxCompute, sumCompute;
     getDoubleMinMax(t.summedTimeInSec(), minCompute, maxCompute, sumCompute);
 
-    const auto count = t.periodCount();
+    const auto count = t.cycleCount();
     if(count > 1)
     {
       SLIC_INFO(axom::fmt::format("'{}' took {{avg:{}, min:{}, max:{}}} seconds (avg of {} samples)",

--- a/src/axom/quest/examples/quest_marching_cubes_example.cpp
+++ b/src/axom/quest/examples/quest_marching_cubes_example.cpp
@@ -608,13 +608,27 @@ void printTimingStats(axom::utilities::Timer& t, const std::string& description)
 
   {
     double minCompute, maxCompute, sumCompute;
-    getDoubleMinMax(t.elapsedTimeInSec(), minCompute, maxCompute, sumCompute);
+    getDoubleMinMax(t.summedTimeInSec(), minCompute, maxCompute, sumCompute);
 
-    SLIC_INFO(axom::fmt::format("'{}' took {{avg:{}, min:{}, max:{}}} seconds",
-                                description,
-                                sumCompute / numRanks,
-                                minCompute,
-                                maxCompute));
+    const auto count = t.periodCount();
+    if(count > 1)
+    {
+      SLIC_INFO(axom::fmt::format("'{}' took {{avg:{}, min:{}, max:{}}} seconds (avg of {} samples)",
+                                  description,
+                                  sumCompute/count / numRanks,
+                                  minCompute/count,
+                                  maxCompute/count,
+                                  count));
+    }
+    else
+    {
+      SLIC_INFO(axom::fmt::format("'{}' took {{avg:{}, min:{}, max:{}}} seconds",
+                                  description,
+                                  sumCompute / numRanks,
+                                  minCompute,
+                                  maxCompute,
+                                  count));
+    }
   }
 }
 
@@ -797,24 +811,52 @@ struct ContourTestBase
     }
 #endif
 
+    // One-time initializations
+    axom::utilities::Timer initializationTimer(false);
+
+    // Entire objectRepCount loop.
+    axom::utilities::Timer objectRepLoopTimer(false);
+
+    // All contourGenCount loops.
+    axom::utilities::Timer contourGenLoopTimer(false);
+
+    // params.objectRepCount setMesh calls
+    axom::utilities::Timer setMeshTimer(false);
+
+    // Time steady-state computeIsocontour calls
+    axom::utilities::Timer contourTimer(false);
+
+    // Time first contourIsocontour call after setMesh
+    axom::utilities::Timer contourTimerM(false);
+
     std::unique_ptr<quest::MarchingCubes> mcPtr;
-    axom::utilities::Timer repsTimer(false);
-    repsTimer.start();
+    const auto objectLoopName = axom::fmt::format("objectRepLoop {}", params.objectRepCount);
+    AXOM_ANNOTATE_BEGIN(objectLoopName);
+    objectRepLoopTimer.start();
     for(int j = 0; j < params.objectRepCount; ++j)
     {
       if(!mcPtr)
       {
-        mcPtr =
-          std::make_unique<quest::MarchingCubes>(params.policy, s_allocatorId, params.dataParallelism);
+        AXOM_ANNOTATE_SCOPE("MCInit");
+        initializationTimer.start();
+        mcPtr = std::make_unique<quest::MarchingCubes>(params.policy,
+                                                       s_allocatorId,
+                                                       params.dataParallelism);
+        mcPtr->setMesh(computationalMesh.asConduitNode(), "mesh", "mask");
+        initializationTimer.stop();
       }
       auto& mc = *mcPtr;
 
       // Clear and set MarchingCubes object for a "new" mesh.
+      setMeshTimer.start();
       mc.setMesh(computationalMesh.asConduitNode(), "mesh", "mask");
+      setMeshTimer.stop();
 
 #ifdef AXOM_USE_MPI
       MPI_Barrier(MPI_COMM_WORLD);
 #endif
+
+      contourGenLoopTimer.start();
       for(int i = 0; i < params.contourGenCount; ++i)
       {
         SLIC_DEBUG(axom::fmt::format("MarchingCubes object rep {} of {}, contour run {} of {}:",
@@ -831,17 +873,28 @@ struct ContourTestBase
           for(int iMask = 0; iMask < params.maskCount; ++iMask)
           {
             mc.setMaskValue(iMask);
+            if(i == 0) { contourTimerM.start(); } else { contourTimer.start(); }
             mc.computeIsocontour(params.contourVal);
+            if(i == 0) { contourTimerM.stop(); } else { contourTimer.stop(); }
           }
           m_strategyFacetPrefixSum.push_back(mc.getContourFacetCount());
         }
       }
+      contourGenLoopTimer.stop();
+
     }
-    repsTimer.stop();
+    objectRepLoopTimer.stop();
+    AXOM_ANNOTATE_END(objectLoopName);
     SLIC_INFO(axom::fmt::format("Finished {} object reps x {} contour reps",
                                 params.objectRepCount,
                                 params.contourGenCount));
-    printTimingStats(repsTimer, "contour");
+    printTimingStats(initializationTimer, axom::fmt::format("init"));
+    printTimingStats(contourTimerM, axom::fmt::format("setMeshContour"));
+    printTimingStats(setMeshTimer, axom::fmt::format("setMesh"));
+    printTimingStats(contourTimer, axom::fmt::format("steady-contour"));
+    printTimingStats(contourTimerM, axom::fmt::format("first-contour"));
+    printTimingStats(contourGenLoopTimer, axom::fmt::format("contourGenLoop"));
+    printTimingStats(objectRepLoopTimer, axom::fmt::format("objectRepLoop"));
 
     auto& mc = *mcPtr;
     printRunStats(mc);
@@ -1725,7 +1778,10 @@ int main(int argc, char** argv)
     exit(retval);
   }
 
-  axom::utilities::raii::AnnotationsWrapper annotation_raii_wrapper(params.annotationMode);
+  axom::utilities::raii::AnnotationsWrapper annotation_raii_wrapper(
+    params.annotationMode);
+  axom::utilities::Timer questMarchingCubesExample(false);
+  questMarchingCubesExample.start();
   AXOM_ANNOTATE_SCOPE("quest marching cubes example");
 
   s_allocatorId = allocatorIdToTest(params.policy);
@@ -1822,6 +1878,8 @@ int main(int argc, char** argv)
   #endif
 #endif
 
+  questMarchingCubesExample.stop();
+  printTimingStats(questMarchingCubesExample, "questMarchingCubesExample");
   finalizeLogger();
 
   return errCount != 0;


### PR DESCRIPTION
# Summary

- Currently, `Timer` may be started and stopped multiple times, but the elapsed time it reports ignores all but the last start/stop.  For timing repeated events, it would be nice for the timer to sum up the start/stop cycles.
- This PR allows `Timer` to sum up times from multiple start/stop cycles
- It does the following:
  - Stores a running sum of all start/stop cycles since the last `reset()` call.
  - Returns the running sum in new method `summed()`, analogous to `elapsed()` method that reports only the last start/stop cycle.
  - Adds a test for multiple start/stop cycles.