### PR TITLE
Add int64 variant to `package.py`

### DIFF
--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -109,6 +109,8 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     variant("raja", default=True, description="Build with raja")
 
+    variant("int64", default=False, description="Use 64bit integers for IndexType")
+
     varmsg = "Build development tools (such as Sphinx, Doxygen, etc...)"
     variant("devtools", default=False, description=varmsg)
 
@@ -630,6 +632,8 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
         options.append(self.define_from_variant("AXOM_ENABLE_TOOLS", "tools"))
         if self.spec.satisfies("~raja") or self.spec.satisfies("+umpire"):
             options.append("-DAXOM_ENABLE_MIR:BOOL=OFF")
+
+        options.append(self.define_from_variant("AXOM_USE_64BIT_INDEXTYPE", "int64"))
 
         return options
 


### PR DESCRIPTION
# Summary

- This PR is a small addition to the axom spack recipe.
- It does the following:
  - Enables setting `AXOM_USE_64BIT_INDEXTYPE` through the spack variant `int64`

# Context

Recently, we've been running large problems in [Tribol](https://github.com/LLNL/Tribol) which have needed this option.  Exposing it to the spack recipe will simplify enabling this in our TPL builds.