### PR TITLE
Fix some host device warnings.

### DIFF
--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -1631,7 +1631,9 @@ inline bool intersect_line_bilinear_patch(const Line<double, 3>& line,
   double bu = Vector3::scalar_triple_product(q10, line.direction(), e11) - au - cu;
 
   // Rescale the coefficients to avoid (some) numerical issues
-  double su = axom::utilities::max(axom::utilities::abs(au), axom::utilities::max(axom::utilities::abs(bu), axom::utilities::abs(cu)));
+  double su =
+    axom::utilities::max(axom::utilities::abs(au),
+                         axom::utilities::max(axom::utilities::abs(bu), axom::utilities::abs(cu)));
   au /= su;
   bu /= su;
   cu /= su;
@@ -1759,7 +1761,9 @@ inline bool intersect_line_bilinear_patch(const Line<double, 3>& line,
     double cv = Vector3::dot_product(qm, line.direction());
     double bv = Vector3::scalar_triple_product(q01, line.direction(), e01) - av - cv;
 
-    double sv = axom::utilities::max(axom::utilities::abs(av), axom::utilities::max(axom::utilities::abs(bv), axom::utilities::abs(cv)));
+    double sv =
+      axom::utilities::max(axom::utilities::abs(av),
+                           axom::utilities::max(axom::utilities::abs(bv), axom::utilities::abs(cv)));
     av /= sv;
     bv /= sv;
     cv /= sv;

--- a/src/axom/primal/operators/detail/intersect_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_impl.hpp
@@ -1610,9 +1610,9 @@ inline bool intersect_line_bilinear_patch(const Line<double, 3>& line,
                                           const Point3& p10,
                                           const Point3& p11,
                                           const Point3& p01,
-                                          axom::Array<double>& t,
-                                          axom::Array<double>& u,
-                                          axom::Array<double>& v,
+                                          axom::StaticArray<double, 2>& t,
+                                          axom::StaticArray<double, 2>& u,
+                                          axom::StaticArray<double, 2>& v,
                                           double EPS = 1e-8,
                                           bool isRay = false)
 {
@@ -1631,7 +1631,7 @@ inline bool intersect_line_bilinear_patch(const Line<double, 3>& line,
   double bu = Vector3::scalar_triple_product(q10, line.direction(), e11) - au - cu;
 
   // Rescale the coefficients to avoid (some) numerical issues
-  double su = std::max(std::fabs(au), std::max(fabs(bu), fabs(cu)));
+  double su = axom::utilities::max(axom::utilities::abs(au), axom::utilities::max(axom::utilities::abs(bu), axom::utilities::abs(cu)));
   au /= su;
   bu /= su;
   cu /= su;
@@ -1705,7 +1705,7 @@ inline bool intersect_line_bilinear_patch(const Line<double, 3>& line,
           const double t1 = Vector3::dot_product(pa, line.direction());
           const double t2 = Vector3::dot_product(pa + pb, line.direction());
 
-          if(!isRay || std::min(t1, t2) > 0.0)
+          if(!isRay || axom::utilities::min(t1, t2) > 0.0)
           {
             // Always an intersection in this case
             t.push_back(0.5 * (t1 + t2));
@@ -1759,7 +1759,7 @@ inline bool intersect_line_bilinear_patch(const Line<double, 3>& line,
     double cv = Vector3::dot_product(qm, line.direction());
     double bv = Vector3::scalar_triple_product(q01, line.direction(), e01) - av - cv;
 
-    double sv = std::max(std::fabs(av), std::max(fabs(bv), fabs(cv)));
+    double sv = axom::utilities::max(axom::utilities::abs(av), axom::utilities::max(axom::utilities::abs(bv), axom::utilities::abs(cv)));
     av /= sv;
     bv /= sv;
     cv /= sv;
@@ -1839,7 +1839,7 @@ inline bool intersect_line_bilinear_patch(const Line<double, 3>& line,
           const double t1 = Vector3::dot_product(pa, line.direction());
           const double t2 = Vector3::dot_product(pa + pb, line.direction());
 
-          if(!isRay || std::min(t1, t2) > 0.0)
+          if(!isRay || axom::utilities::min(t1, t2) > 0.0)
           {
             // Always an intersection in this case
             t.push_back(0.5 * (t1 + t2));
@@ -1856,7 +1856,7 @@ inline bool intersect_line_bilinear_patch(const Line<double, 3>& line,
             if(t1 == t2)
             {
               t.push_back(0.5 * t1);
-              v.push_back(0.5);
+              u.push_back(0.5);
             }
             else if(t1 < t2)
             {

--- a/src/axom/primal/operators/detail/intersect_patch_impl.hpp
+++ b/src/axom/primal/operators/detail/intersect_patch_impl.hpp
@@ -122,7 +122,7 @@ bool intersect_line_patch(const Line<T, 3> &line,
   if(patch.isBilinear(sq_tol, true))
   {
     // Store candidate intersection points
-    axom::Array<T> tc, uc, vc;
+    axom::StaticArray<T, 2> tc, uc, vc;
 
     detail::intersect_line_bilinear_patch(line,
                                           patch(0, 0),

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -892,9 +892,18 @@ bool intersect(const Ray<T, 3>& ray,
                                           svc,
                                           EPS,
                                           true);
-    for(int i = 0; i < stc.size(); i++) { tc.push_back(stc[i]); }
-    for(int i = 0; i < suc.size(); i++) { uc.push_back(suc[i]); }
-    for(int i = 0; i < svc.size(); i++) { vc.push_back(svc[i]); }
+    for(int i = 0; i < stc.size(); i++)
+    {
+      tc.push_back(stc[i]);
+    }
+    for(int i = 0; i < suc.size(); i++)
+    {
+      uc.push_back(suc[i]);
+    }
+    for(int i = 0; i < svc.size(); i++)
+    {
+      vc.push_back(svc[i]);
+    }
   }
   else
   {

--- a/src/axom/primal/operators/intersect.hpp
+++ b/src/axom/primal/operators/intersect.hpp
@@ -881,16 +881,20 @@ bool intersect(const Ray<T, 3>& ray,
   else if(order_u == 1 && order_v == 1)
   {
     primal::Line<T, 3> line(ray.origin(), ray.direction());
+    StaticArray<T, 2> stc, suc, svc;
     detail::intersect_line_bilinear_patch(line,
                                           patch(0, 0),
                                           patch(order_u, 0),
                                           patch(order_u, order_v),
                                           patch(0, order_v),
-                                          tc,
-                                          uc,
-                                          vc,
+                                          stc,
+                                          suc,
+                                          svc,
                                           EPS,
                                           true);
+    for(int i = 0; i < stc.size(); i++) { tc.push_back(stc[i]); }
+    for(int i = 0; i < suc.size(); i++) { uc.push_back(suc[i]); }
+    for(int i = 0; i < svc.size(); i++) { vc.push_back(svc[i]); }
   }
   else
   {


### PR DESCRIPTION
When building on blueos a lot of warnings are issued due to calling ``host`` functions from ``host device`` functions. This category of warnings were mainly coming from primal. This PR fixes many of these warnings.

* Replaced calls like min,max,fabs with equivalents from Axom utilities.
* Changed some functions to pass axom::StaticArray instead of axom::Array so they can be used in ``host device`` functions.
* Fixed an unrelated line of code that looked like a copy/paste error.
