### PR TITLE
Bugfix - guard 2D STL intersection shaper test

### DIFF
--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -216,19 +216,21 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
             set_tests_properties(${_testname} PROPERTIES 
                 PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 6[89][0-9].")
 
-            # Tests 2D stl mesh
-            set(_testname quest_shaping_driver_ex_star_stl_2d)
-            axom_add_test(
-                NAME ${_testname}
-                COMMAND  quest_shaping_driver_ex
-                        -i ${shaping_data_dir}/flat_star.yaml
-                        --method intersection
-                        inline_mesh --min 0 0 --max 1 1 --res 4 4 -d 2
-                NUM_MPI_TASKS ${_nranks})
-            # steel triangle: star composed of 16 right triangles with
-            # leg length 0.25 has analytic volume 0.5
-            set_tests_properties(${_testname} PROPERTIES
-                PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 0.5")
+            if (UMPIRE_FOUND AND RAJA_FOUND)
+                # Tests 2D stl mesh with intersection-based shaper
+                set(_testname quest_shaping_driver_ex_star_stl_2d)
+                axom_add_test(
+                    NAME ${_testname}
+                    COMMAND  quest_shaping_driver_ex
+                            -i ${shaping_data_dir}/flat_star.yaml
+                            --method intersection
+                            inline_mesh --min 0 0 --max 1 1 --res 4 4 -d 2
+                    NUM_MPI_TASKS ${_nranks})
+                # steel triangle: star composed of 16 right triangles with
+                # leg length 0.25 has analytic volume 0.5
+                set_tests_properties(${_testname} PROPERTIES
+                    PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 0.5")
+            endif()
         endif()
 
         # 3D shaping tests

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -215,22 +215,22 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
             # steel ball: cirle of radius 5.5 has analytic volume ~696.91
             set_tests_properties(${_testname} PROPERTIES 
                 PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 6[89][0-9].")
+        endif()
 
-            if (UMPIRE_FOUND AND RAJA_FOUND)
-                # Tests 2D stl mesh with intersection-based shaper
-                set(_testname quest_shaping_driver_ex_star_stl_2d)
-                axom_add_test(
-                    NAME ${_testname}
-                    COMMAND  quest_shaping_driver_ex
-                            -i ${shaping_data_dir}/flat_star.yaml
-                            --method intersection
-                            inline_mesh --min 0 0 --max 1 1 --res 4 4 -d 2
-                    NUM_MPI_TASKS ${_nranks})
-                # steel triangle: star composed of 16 right triangles with
-                # leg length 0.25 has analytic volume 0.5
-                set_tests_properties(${_testname} PROPERTIES
-                    PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 0.5")
-            endif()
+        if (UMPIRE_FOUND AND RAJA_FOUND)
+            # Tests 2D stl mesh with intersection-based shaper
+            set(_testname quest_shaping_driver_ex_star_stl_2d)
+            axom_add_test(
+                NAME ${_testname}
+                COMMAND  quest_shaping_driver_ex
+                        -i ${shaping_data_dir}/flat_star.yaml
+                        --method intersection
+                        inline_mesh --min 0 0 --max 1 1 --res 4 4 -d 2
+                NUM_MPI_TASKS ${_nranks})
+            # steel triangle: star composed of 16 right triangles with
+            # leg length 0.25 has analytic volume 0.5
+            set_tests_properties(${_testname} PROPERTIES
+                PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 0.5")
         endif()
 
         # 3D shaping tests

--- a/src/axom/quest/examples/shaping_driver.cpp
+++ b/src/axom/quest/examples/shaping_driver.cpp
@@ -504,13 +504,6 @@ int main(int argc, char** argv)
 
   const klee::Dimensions shapeDim = params.shapeSet.getDimensions();
 
-  // Apply error checking
-#ifndef AXOM_USE_C2C
-  SLIC_ERROR_IF(shapeDim == klee::Dimensions::Two,
-                "Shaping with contour files requires an Axom configured with "
-                "the C2C library");
-#endif
-
   AXOM_ANNOTATE_BEGIN("load mesh");
   //---------------------------------------------------------------------------
   // Load the computational mesh
@@ -656,6 +649,13 @@ int main(int argc, char** argv)
                                           shape.getName(),
                                           shape.getMaterial(),
                                           shapeFormat)));
+
+    // Apply error checking
+#ifndef AXOM_USE_C2C
+    SLIC_ERROR_IF(shapeDim == klee::Dimensions::Two && shapeFormat == "c2c",
+                  "Shaping with contour files requires an Axom configured with "
+                  "the C2C library");
+#endif
 
     // Load the shape from file. This also applies any transformations.
     shaper->loadShape(shape);


### PR DESCRIPTION
This PR: 
- Guards 2D STL intersection shaper unit test to only be compiled/run when Axom is built with RAJA and Umpire (IntersectionShaper class is only enabled with RAJA and Umpire).