### PR TITLE
Initial 2D intersection shaping for c2c

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -86,6 +86,7 @@ to use Open Cascade's file I/O capabilities in support of Quest applications.
 - Adds some support for 2D shaping in `quest::IntersectionShaper`, using STL meshes with zero for z-coordinates or in-memory triangles as input.
 - Adds ability in Lumberjack to own and set communicators.
 - Adds `NonCollectiveRootCommunicator` to Lumberjack to provide an MPI-based communicator for logging messages non-collectively.
+- Adds initial support for 2D shaping in `quest::IntersectionShaper`, using a c2c contour as input. The contour cannot overlap, and is expected to be entirely above the x-axis.
 
 ###  Changed
 - Updates blt submodule to [BLT version 0.7.0][https://github.com/LLNL/blt/releases/tag/v0.7.0]

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -898,11 +898,18 @@ private:
 
         // Check if any Octahedron are degenerate with all points {0,0,0}
         RAJA::ReduceSum<REDUCE_POL, int> num_degenerate(0);
+
+        const int device_allocator = m_allocatorId;
+        axom::Array<OctahedronType> degenerate_oct_host(1, 1, host_allocator);
+        degenerate_oct_host[0] = OctahedronType();
+        axom::Array<OctahedronType> degenerate_oct_device =
+          axom::Array<OctahedronType>(degenerate_oct_host, device_allocator);
+        auto degenerate_oct_device_view = degenerate_oct_device.view();
+
         axom::for_all<ExecSpace>(
           m_octcount,
           AXOM_LAMBDA(axom::IndexType i) {
-            OctahedronType degenerate_oct;
-            if(octs_device_view[i].equals(degenerate_oct))
+            if(octs_device_view[i].equals(degenerate_oct_device_view[0]))
             {
               num_degenerate += 1;
             }

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -959,18 +959,11 @@ private:
           SLIC_ERROR("2D: Contour with non-negative r values expected");
         }
 
-        SLIC_INFO("Point 0 "
-                  << " is " << pts[0]);
-        SLIC_INFO("Point 1 "
-                  << " is " << pts[1]);
-
         // Right ear of quad
         tris_host[i * 2] = PolygonStaticType({pts[1], pts[0], Point2D {pts[0][0], 0}});
-        SLIC_INFO("Triangle " << i * 2 << " is " << tris_host[i * 2]);
 
         // Left ear of quad
         tris_host[(i * 2) + 1] = PolygonStaticType({pts[1], pts[0], Point2D {pts[1][0], 0}});
-        SLIC_INFO("Triangle " << (i * 2) + 1 << " is " << tris_host[(i * 2) + 1]);
       }
 
       // Copy triangles to device

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -801,7 +801,9 @@ private:
     }  // end of verbose output for Pro/E
   }
 
-  // Prepares the C2C mesh cells for the spatial index
+  // Prepares the C2C mesh cells for the spatial index.
+  // Produced octahedra for the revolved contour in the 3D case,
+  // or triangles for the contour bounded by the x-axis in the 2D case.
   template <typename ExecSpace>
   void prepareC2CCells()
   {
@@ -811,9 +813,6 @@ private:
     int pointcount = getSurfaceMesh()->getNumberOfNodes();
 
     axom::Array<Point2D> polyline(pointcount, pointcount);
-
-    SLIC_INFO(
-      axom::fmt::format("{:-^80}", axom::fmt::format(" Refinement level set to {} ", m_level)));
 
     SLIC_INFO(axom::fmt::format(
       "{:-^80}",
@@ -829,91 +828,159 @@ private:
     }
     int polyline_size = pointcount;
 
-    // Generate the Octahedra
-    // (octahedra m_octs will be on device)
-    const bool disc_status =
-      axom::quest::discretize<ExecSpace>(polyline, polyline_size, m_level, m_octs, m_octcount);
+    int compMeshDim = getCompMeshDim();
 
-    axom::ArrayView<OctahedronType> octs_device_view = m_octs.view();
-
-    AXOM_UNUSED_VAR(disc_status);  // silence warnings in release configs
-    SLIC_ASSERT_MSG(disc_status,
-                    "Discretization of contour has failed. Check that contour is valid");
-
-    SLIC_INFO(axom::fmt::format(axom::utilities::locale(),
-                                "Contour has been discretized into {:L} octahedra ",
-                                m_octcount));
-
-    if(this->isVerbose())
+    // Produce octahedra for revolved contour (3D)
+    if(compMeshDim == 3)
     {
-      // Print out the bounding box containing all the octahedra
-      BoundingBox3D all_oct_bb;
-      axom::Array<OctahedronType> octs_host = axom::Array<OctahedronType>(m_octs, host_allocator);
-      auto octs_host_view = octs_host.view();
-
-      for(int i = 0; i < m_octcount; i++)
-      {
-        all_oct_bb.addBox(primal::compute_bounding_box(octs_host[i]));
-      }
       SLIC_INFO(
-        axom::fmt::format("DEBUG: Bounding box containing all generated octahedra "
-                          "has dimensions:\n\t{}",
-                          all_oct_bb));
+        axom::fmt::format("{:-^80}", axom::fmt::format(" Refinement level set to {} ", m_level)));
 
-      // Print out the total volume of all the octahedra
-      using REDUCE_POL = typename axom::execution_space<ExecSpace>::reduce_policy;
-      RAJA::ReduceSum<REDUCE_POL, double> total_oct_vol(0.0);
-      axom::for_all<ExecSpace>(
-        m_octcount,
-        AXOM_LAMBDA(axom::IndexType i) {
-          // Convert Octahedron into Polyhedrom
-          PolyhedronType octPoly;
+      // Generate the Octahedra
+      // (octahedra m_octs will be on device)
+      const bool disc_status =
+        axom::quest::discretize<ExecSpace>(polyline, polyline_size, m_level, m_octs, m_octcount);
 
-          octPoly.addVertex(octs_device_view[i][0]);
-          octPoly.addVertex(octs_device_view[i][1]);
-          octPoly.addVertex(octs_device_view[i][2]);
-          octPoly.addVertex(octs_device_view[i][3]);
-          octPoly.addVertex(octs_device_view[i][4]);
-          octPoly.addVertex(octs_device_view[i][5]);
+      axom::ArrayView<OctahedronType> octs_device_view = m_octs.view();
 
-          octPoly.addNeighbors(0, {1, 5, 4, 2});
-          octPoly.addNeighbors(1, {0, 2, 3, 5});
-          octPoly.addNeighbors(2, {0, 4, 3, 1});
-          octPoly.addNeighbors(3, {1, 2, 4, 5});
-          octPoly.addNeighbors(4, {0, 5, 3, 2});
-          octPoly.addNeighbors(5, {0, 1, 3, 4});
+      AXOM_UNUSED_VAR(disc_status);  // silence warnings in release configs
+      SLIC_ASSERT_MSG(disc_status,
+                      "Discretization of contour has failed. Check that contour is valid");
 
-          total_oct_vol += octPoly.volume();
-        });
+      SLIC_INFO(axom::fmt::format(axom::utilities::locale(),
+                                  "Contour has been discretized into {:L} octahedra ",
+                                  m_octcount));
 
-      SLIC_INFO(axom::fmt::format("DEBUG: Total volume of all generated octahedra is {}",
-                                  total_oct_vol.get()));
+      if(this->isVerbose())
+      {
+        // Print out the bounding box containing all the octahedra
+        BoundingBox3D all_oct_bb;
+        axom::Array<OctahedronType> octs_host = axom::Array<OctahedronType>(m_octs, host_allocator);
+        auto octs_host_view = octs_host.view();
 
-      // Check if any Octahedron are degenerate with all points {0,0,0}
-      RAJA::ReduceSum<REDUCE_POL, int> num_degenerate(0);
-      axom::for_all<ExecSpace>(
-        m_octcount,
-        AXOM_LAMBDA(axom::IndexType i) {
-          OctahedronType degenerate_oct;
-          if(octs_device_view[i].equals(degenerate_oct))
-          {
-            num_degenerate += 1;
-          }
-        });
+        for(int i = 0; i < m_octcount; i++)
+        {
+          all_oct_bb.addBox(primal::compute_bounding_box(octs_host[i]));
+        }
+        SLIC_INFO(
+          axom::fmt::format("DEBUG: Bounding box containing all generated octahedra "
+                            "has dimensions:\n\t{}",
+                            all_oct_bb));
 
-      SLIC_INFO(axom::fmt::format("DEBUG: {} Octahedron found with all points (0,0,0)",
-                                  num_degenerate.get()));
+        // Print out the total volume of all the octahedra
+        using REDUCE_POL = typename axom::execution_space<ExecSpace>::reduce_policy;
+        RAJA::ReduceSum<REDUCE_POL, double> total_oct_vol(0.0);
+        axom::for_all<ExecSpace>(
+          m_octcount,
+          AXOM_LAMBDA(axom::IndexType i) {
+            // Convert Octahedron into Polyhedrom
+            PolyhedronType octPoly;
 
-      // Dump discretized octs as a tet mesh
-      axom::mint::Mesh* tetmesh;
-      axom::quest::mesh_from_discretized_polyline(octs_host_view,
-                                                  m_octcount,
-                                                  polyline_size - 1,
-                                                  tetmesh);
-      axom::mint::write_vtk(tetmesh, "discretized_surface_of_revolution.vtk");
-      delete tetmesh;
+            octPoly.addVertex(octs_device_view[i][0]);
+            octPoly.addVertex(octs_device_view[i][1]);
+            octPoly.addVertex(octs_device_view[i][2]);
+            octPoly.addVertex(octs_device_view[i][3]);
+            octPoly.addVertex(octs_device_view[i][4]);
+            octPoly.addVertex(octs_device_view[i][5]);
 
-    }  // end of verbose output for contour
+            octPoly.addNeighbors(0, {1, 5, 4, 2});
+            octPoly.addNeighbors(1, {0, 2, 3, 5});
+            octPoly.addNeighbors(2, {0, 4, 3, 1});
+            octPoly.addNeighbors(3, {1, 2, 4, 5});
+            octPoly.addNeighbors(4, {0, 5, 3, 2});
+            octPoly.addNeighbors(5, {0, 1, 3, 4});
+
+            total_oct_vol += octPoly.volume();
+          });
+
+        SLIC_INFO(axom::fmt::format("DEBUG: Total volume of all generated octahedra is {}",
+                                    total_oct_vol.get()));
+
+        // Check if any Octahedron are degenerate with all points {0,0,0}
+        RAJA::ReduceSum<REDUCE_POL, int> num_degenerate(0);
+        axom::for_all<ExecSpace>(
+          m_octcount,
+          AXOM_LAMBDA(axom::IndexType i) {
+            OctahedronType degenerate_oct;
+            if(octs_device_view[i].equals(degenerate_oct))
+            {
+              num_degenerate += 1;
+            }
+          });
+
+        SLIC_INFO(axom::fmt::format("DEBUG: {} Octahedron found with all points (0,0,0)",
+                                    num_degenerate.get()));
+
+        // Dump discretized octs as a tet mesh
+        axom::mint::Mesh* tetmesh;
+        axom::quest::mesh_from_discretized_polyline(octs_host_view,
+                                                    m_octcount,
+                                                    polyline_size - 1,
+                                                    tetmesh);
+        axom::mint::write_vtk(tetmesh, "discretized_surface_of_revolution.vtk");
+        delete tetmesh;
+
+      }  // end of verbose output for contour
+    }    // end of 3D case
+
+    // Produce triangles for contour bounded by x-axis (2D)
+    else
+    {
+      SLIC_INFO(
+        axom::fmt::format("{:-^80}",
+                          axom::fmt::format(axom::utilities::locale(),
+                                            "{:L} linear segments to generate per NURBS knot span",
+                                            m_samplesPerKnotSpan)));
+
+      const int device_allocator = axom::execution_space<ExecSpace>::allocatorID();
+
+      // Number of triangles in mesh (2 triangles per segment/quad cell)
+      m_tricount = m_surfaceMesh->getNumberOfCells() * 2;
+
+      axom::Array<PolygonStaticType> tris_host(m_tricount, m_tricount, host_allocator);
+
+      // Initialize 2D triangles from segment mesh (3rd point is on the x-axis)
+      axom::Array<IndexType> nodeIds(2);
+
+      // Buffer to store 2D points
+      axom::Array<Point2D> pts(2);
+
+      for(int i = 0; i < m_tricount / 2; i++)
+      {
+        m_surfaceMesh->getCellNodeIDs(i, nodeIds.data());
+
+        m_surfaceMesh->getNode(nodeIds[0], pts[0].data());
+        m_surfaceMesh->getNode(nodeIds[1], pts[1].data());
+
+        constexpr double EPS = 1e-10;
+        if(axom::primal::detail::isLt(pts[0][1], 0.0, EPS) ||
+           axom::primal::detail::isLt(pts[1][1], 0.0, EPS))
+        {
+          SLIC_ERROR("2D: Contour with non-negative r values expected");
+        }
+
+        SLIC_INFO("Point 0 "
+                  << " is " << pts[0]);
+        SLIC_INFO("Point 1 "
+                  << " is " << pts[1]);
+
+        // Right ear of quad
+        tris_host[i * 2] = PolygonStaticType({pts[1], pts[0], Point2D {pts[0][0], 0}});
+        SLIC_INFO("Triangle " << i * 2 << " is " << tris_host[i * 2]);
+
+        // Left ear of quad
+        tris_host[(i * 2) + 1] = PolygonStaticType({pts[1], pts[0], Point2D {pts[1][0], 0}});
+        SLIC_INFO("Triangle " << (i * 2) + 1 << " is " << tris_host[(i * 2) + 1]);
+      }
+
+      // Copy triangles to device
+      m_tris = axom::Array<PolygonStaticType>(tris_host, device_allocator);
+
+      SLIC_INFO(axom::fmt::format(axom::utilities::locale(),
+                                  "Contour has been discretized into {:L} triangles ",
+                                  m_tricount));
+
+    }  // end of 2D case
   }
 
   /// Initializes the spatial index for shaping
@@ -1714,9 +1781,6 @@ public:
   */
   void prepareShapeQuery(klee::Dimensions shapeDimension, const klee::Shape& shape) override
   {
-    // TODO
-    SLIC_INFO("Computational mesh dimension is " << getCompMeshDim());
-
     AXOM_ANNOTATE_SCOPE("prepareShapeQuery");
     const std::string shapeFormat = shape.getGeometry().getFormat();
 
@@ -1796,7 +1860,7 @@ public:
   #endif  // AXOM_USE_HIP
       }
     }
-    else if(shapeFormat == "c2c")
+    else if(shapeFormat == "c2c" && getCompMeshDim() == 3)
     {
       switch(m_execPolicy)
       {
@@ -1816,6 +1880,30 @@ public:
   #if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
       case RuntimePolicy::hip:
         runShapeQuery3DImpl<hip_exec, OctahedronType>(shape, m_octs, m_octcount);
+        break;
+  #endif  // AXOM_USE_HIP
+      }
+    }
+    else if(shapeFormat == "c2c" && getCompMeshDim() == 2)
+    {
+      switch(m_execPolicy)
+      {
+      case RuntimePolicy::seq:
+        runShapeQuery2DImpl<seq_exec>(shape, m_tris, m_tricount);
+        break;
+  #if defined(AXOM_USE_OPENMP)
+      case RuntimePolicy::omp:
+        runShapeQuery2DImpl<omp_exec>(shape, m_tris, m_tricount);
+        break;
+  #endif  // AXOM_USE_OPENMP
+  #if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+      case RuntimePolicy::cuda:
+        runShapeQuery2DImpl<cuda_exec>(shape, m_tris, m_tricount);
+        break;
+  #endif  // AXOM_USE_CUDA
+  #if defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
+      case RuntimePolicy::hip:
+        runShapeQuery2DImpl<hip_exec>(shape, m_tris, m_tricount);
         break;
   #endif  // AXOM_USE_HIP
       }

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -296,7 +296,7 @@ AXOM_HOST_DEVICE inline void TempArrayView<hip_exec>::finalize()
  *   mesh first.  Sphere and surfaces-of-revolution discretization uses
  *   the refinement level specified in the \c Geometry.
  *
- * - (2D) For c2c, support is a work-in-progress. Initially support for a
+ * - (2D) For c2c, support is a work-in-progress. Initial support for a
  *   single contour that covers an area from the curve down to the x-axis (z-axis).
  *   The contour cannot overlap, and is expected to be entirely above the x-axis.
  *   The contour is refined into smaller linear segments that form triangles with the
@@ -884,7 +884,7 @@ private:
         axom::for_all<ExecSpace>(
           m_octcount,
           AXOM_LAMBDA(axom::IndexType i) {
-            // Convert Octahedron into Polyhedrom
+            // Convert Octahedron into Polyhedron
             PolyhedronType octPoly;
 
             octPoly.addVertex(octs_device_view[i][0]);

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -1714,6 +1714,9 @@ public:
   */
   void prepareShapeQuery(klee::Dimensions shapeDimension, const klee::Shape& shape) override
   {
+    // TODO
+    SLIC_INFO("Computational mesh dimension is " << getCompMeshDim());
+
     AXOM_ANNOTATE_SCOPE("prepareShapeQuery");
     const std::string shapeFormat = shape.getGeometry().getFormat();
 
@@ -2904,6 +2907,40 @@ private:
     bool isTri = m_surfaceMesh != nullptr && m_surfaceMesh->getDimension() == 2 &&
       !m_surfaceMesh->hasMixedCellTypes() && m_surfaceMesh->getCellType() == mint::TRIANGLE;
     return isTri;
+  }
+
+  /*!
+   * \brief Returns the dimension of the computational mesh
+   * \return dim The dimensions of the mesh (expected is 2 or 3, -1 in case of failure)
+   */
+  int getCompMeshDim()
+  {
+    SLIC_ERROR_IF(m_dc == nullptr && m_bpGrp == nullptr, "Computational mesh is not initialized");
+
+    int dim = -1;
+  #if defined(AXOM_USE_MFEM)
+    if(m_dc != nullptr)
+    {
+      dim = this->getDC()->GetMesh()->SpaceDimension();
+    }
+  #endif
+  #if defined(AXOM_USE_CONDUIT)
+    if(m_bpGrp != nullptr)
+    {
+      std::string mesh_type = m_bpGrp->getView("topologies/mesh/elements/shape")->getString();
+      if(mesh_type == "hex")
+      {
+        dim = 3;
+      }
+      else if(mesh_type == "quad")
+      {
+        dim = 2;
+      }
+    }
+  #endif
+
+    SLIC_ERROR_IF(!(dim == 2 || dim == 3), "Invalid computational mesh dimension");
+    return dim;
   }
 
 private:

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -702,7 +702,7 @@ private:
         all_tris_bb.addBox(primal::compute_bounding_box(tempPoly));
       }
       SLIC_INFO(
-        axom::fmt::format("DEBUG: Bounding box containing all generated triangles "
+        axom::fmt::format("VERBOSE: Bounding box containing all generated triangles "
                           "has dimensions:\n\t{}",
                           all_tris_bb));
 
@@ -715,7 +715,7 @@ private:
         m_tricount,
         AXOM_LAMBDA(axom::IndexType i) { total_tri_area += tri_device_view[i].area(); });
 
-      SLIC_INFO(axom::fmt::format("DEBUG: Total area of all generated triangles is {}",
+      SLIC_INFO(axom::fmt::format("VERBOSE: Total area of all generated triangles is {}",
                                   total_tri_area.get()));
 
       // Check if any Triangles are degenerate with zero area
@@ -729,7 +729,7 @@ private:
           }
         });
 
-      SLIC_INFO(axom::fmt::format("DEBUG: Degenerate {} triangles found with zero area",
+      SLIC_INFO(axom::fmt::format("VERBOSE: Degenerate {} triangles found with zero area",
                                   num_degenerate.get()));
 
     }  // end of verbose output for triangles
@@ -776,7 +776,7 @@ private:
         all_tet_bb.addBox(primal::compute_bounding_box(tets_host[i]));
       }
       SLIC_INFO(
-        axom::fmt::format("DEBUG: Bounding box containing all generated tetrahedra "
+        axom::fmt::format("VERBOSE: Bounding box containing all generated tetrahedra "
                           "has dimensions:\n\t{}",
                           all_tet_bb));
 
@@ -789,7 +789,7 @@ private:
         m_tetcount,
         AXOM_LAMBDA(axom::IndexType i) { total_tet_vol += tets_device_view[i].volume(); });
 
-      SLIC_INFO(axom::fmt::format("DEBUG: Total volume of all generated tetrahedra is {}",
+      SLIC_INFO(axom::fmt::format("VERBOSE: Total volume of all generated tetrahedra is {}",
                                   total_tet_vol.get()));
 
       // Check if any Tetrahedron are degenerate with zero volume
@@ -803,7 +803,7 @@ private:
           }
         });
 
-      SLIC_INFO(axom::fmt::format("DEBUG: Degenerate {} tetrahedra found with zero volume",
+      SLIC_INFO(axom::fmt::format("VERBOSE: Degenerate {} tetrahedra found with zero volume",
                                   num_degenerate.get()));
 
       // Dump tet mesh as a vtk mesh
@@ -874,7 +874,7 @@ private:
           all_oct_bb.addBox(primal::compute_bounding_box(octs_host[i]));
         }
         SLIC_INFO(
-          axom::fmt::format("DEBUG: Bounding box containing all generated octahedra "
+          axom::fmt::format("VERBOSE: Bounding box containing all generated octahedra "
                             "has dimensions:\n\t{}",
                             all_oct_bb));
 
@@ -885,26 +885,12 @@ private:
           m_octcount,
           AXOM_LAMBDA(axom::IndexType i) {
             // Convert Octahedron into Polyhedron
-            PolyhedronType octPoly;
-
-            octPoly.addVertex(octs_device_view[i][0]);
-            octPoly.addVertex(octs_device_view[i][1]);
-            octPoly.addVertex(octs_device_view[i][2]);
-            octPoly.addVertex(octs_device_view[i][3]);
-            octPoly.addVertex(octs_device_view[i][4]);
-            octPoly.addVertex(octs_device_view[i][5]);
-
-            octPoly.addNeighbors(0, {1, 5, 4, 2});
-            octPoly.addNeighbors(1, {0, 2, 3, 5});
-            octPoly.addNeighbors(2, {0, 4, 3, 1});
-            octPoly.addNeighbors(3, {1, 2, 4, 5});
-            octPoly.addNeighbors(4, {0, 5, 3, 2});
-            octPoly.addNeighbors(5, {0, 1, 3, 4});
+            PolyhedronType octPoly = PolyhedronType::from_primitive(octs_device_view[i]);
 
             total_oct_vol += octPoly.volume();
           });
 
-        SLIC_INFO(axom::fmt::format("DEBUG: Total volume of all generated octahedra is {}",
+        SLIC_INFO(axom::fmt::format("VERBOSE: Total volume of all generated octahedra is {}",
                                     total_oct_vol.get()));
 
         // Check if any Octahedron are degenerate with all points {0,0,0}
@@ -926,7 +912,7 @@ private:
             }
           });
 
-        SLIC_INFO(axom::fmt::format("DEBUG: {} Octahedron found with all points (0,0,0)",
+        SLIC_INFO(axom::fmt::format("VERBOSE: {} Octahedron found with all points (0,0,0)",
                                     num_degenerate.get()));
 
         // Dump discretized octs as a tet mesh

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -2915,8 +2915,6 @@ private:
    */
   int getCompMeshDim()
   {
-    SLIC_ERROR_IF(m_dc == nullptr && m_bpGrp == nullptr, "Computational mesh is not initialized");
-
     int dim = -1;
   #if defined(AXOM_USE_MFEM)
     if(m_dc != nullptr)

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -280,7 +280,7 @@ AXOM_HOST_DEVICE inline void TempArrayView<hip_exec>::finalize()
  *
  * The IntersectionShaper generates material volume fractions:
  *
- * - For c2c, an input set of 2D contours and replacement rules. Each contour
+ * - (3D) For c2c, an input set of 2D contours and replacement rules. Each contour
  *   covers an area from the curve down to the axis of revolution about which
  *   the area is revolved to produce a volume. Contours are refined into smaller
  *   linear spans that are revolved to produce a set of truncated cones, which
@@ -288,13 +288,24 @@ AXOM_HOST_DEVICE inline void TempArrayView<hip_exec>::finalize()
  *   intersected with the mesh. The octahedra are intersected with the input
  *   mesh to produce volume fractions.
  *
- * - For tetrahedral mesh (including Pro/E), an input mesh of 3D tetrahedra is loaded in.
+ * - (3D) For tetrahedral mesh (including Pro/E), an input mesh of 3D tetrahedra is loaded in.
  *   Each tetrahedron has its own respective volume. The tetrahedra are
  *   intersected with the input mesh to produce volume fractions.
  *
- * - For analytical geometries, the shapes are discretized into a tetrahedral
+ * - (3D) For analytical geometries, the shapes are discretized into a tetrahedral
  *   mesh first.  Sphere and surfaces-of-revolution discretization uses
  *   the refinement level specified in the \c Geometry.
+ *
+ * - (2D) For c2c, support is a work-in-progress. Initially support for a
+ *   single contour that covers an area from the curve down to the x-axis (z-axis).
+ *   The contour cannot overlap, and is expected to be entirely above the x-axis.
+ *   The contour is refined into smaller linear segments that form triangles with the
+ *   x-axis. The trianges are intersected with the input mesh to product volume fractions.
+ *
+ * - (2D) For triangle mesh, an input STL mesh is loaded in (z-coordinates must be 0).
+ *   Each triangle has its own respective area/volume. The triangles are
+ *   intersected with the input mesh to produce volume fractions.
+ *
  *
  * The input mesh can be an MFEM mesh stored as a \c
  * sidre::MFEMSidreDataCollection or be a Blueprint mesh stored as a

--- a/src/axom/quest/Shaper.cpp
+++ b/src/axom/quest/Shaper.cpp
@@ -242,6 +242,7 @@ void Shaper::loadShapeInternal(const klee::Shape& shape, double percentError, do
 
   // Code for discretizing shapes has been factored into DiscreteShape class.
   DiscreteShape discreteShape(shape, m_dataStore.getRoot(), m_prefixPath);
+  discreteShape.setSamplesPerKnotSpan(m_samplesPerKnotSpan);
   discreteShape.setVertexWeldThreshold(m_vertexWeldThreshold);
   discreteShape.setRefinementType(m_refinementType);
   if(percentError > 0)

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -247,13 +247,13 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                         COMMAND  quest_shaping_driver_ex
                                 -i ${shaping_data_dir}/revolved_circle.yaml
                                 --policy ${_policy}
-                                --segments-per-knot-span 1000
+                                --segments-per-knot-span 50
                                 --method intersection
                                 inline_mesh --min 0 0 --max 3 3 --res 3 3 -d 2
                         NUM_MPI_TASKS ${_nranks})
                     # steel unit semi-circle with an area of pi/2
                     set_tests_properties(${_testname} PROPERTIES
-                        PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 1.57079")
+                        PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 1.57")
                 endforeach()
 
                 unset(_policies)

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -231,6 +231,32 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
             # leg length 0.25 has analytic volume 0.5
             set_tests_properties(${_testname} PROPERTIES
                 PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 0.5")
+
+            # Tests 2D c2c contour
+            set(_policies "seq")
+            if(RAJA_FOUND)
+                blt_list_append(TO _policies ELEMENTS "omp" IF AXOM_ENABLE_OPENMP)
+                blt_list_append(TO _policies ELEMENTS "cuda" IF AXOM_ENABLE_CUDA)
+                blt_list_append(TO _policies ELEMENTS "hip" IF AXOM_ENABLE_HIP)
+            endif()
+            foreach(_policy ${_policies})
+                set(_testname quest_shaping_driver_ex_semi_circle_2d_${_policy})
+
+                axom_add_test(
+                    NAME ${_testname}
+                    COMMAND  quest_shaping_driver_ex
+                            -i ${shaping_data_dir}/revolved_circle.yaml
+                            --policy ${_policy}
+                            --segments-per-knot-span 1000
+                            --method intersection
+                            inline_mesh --min 0 0 --max 3 3 --res 3 3 -d 2
+                    NUM_MPI_TASKS ${_nranks})
+                # steel unit semi-circle with an area of pi/2
+                set_tests_properties(${_testname} PROPERTIES
+                    PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 1.57079")
+            endforeach()
+
+            unset(_policies)
         endif()
 
         # 3D shaping tests

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -233,30 +233,31 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                 PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 0.5")
 
             # Tests 2D c2c contour
-            set(_policies "seq")
-            if(RAJA_FOUND)
+            if(C2C_FOUND)
+                set(_policies "seq")
                 blt_list_append(TO _policies ELEMENTS "omp" IF AXOM_ENABLE_OPENMP)
                 blt_list_append(TO _policies ELEMENTS "cuda" IF AXOM_ENABLE_CUDA)
                 blt_list_append(TO _policies ELEMENTS "hip" IF AXOM_ENABLE_HIP)
+
+                foreach(_policy ${_policies})
+                    set(_testname quest_shaping_driver_ex_semi_circle_2d_${_policy})
+
+                    axom_add_test(
+                        NAME ${_testname}
+                        COMMAND  quest_shaping_driver_ex
+                                -i ${shaping_data_dir}/revolved_circle.yaml
+                                --policy ${_policy}
+                                --segments-per-knot-span 1000
+                                --method intersection
+                                inline_mesh --min 0 0 --max 3 3 --res 3 3 -d 2
+                        NUM_MPI_TASKS ${_nranks})
+                    # steel unit semi-circle with an area of pi/2
+                    set_tests_properties(${_testname} PROPERTIES
+                        PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 1.57079")
+                endforeach()
+
+                unset(_policies)
             endif()
-            foreach(_policy ${_policies})
-                set(_testname quest_shaping_driver_ex_semi_circle_2d_${_policy})
-
-                axom_add_test(
-                    NAME ${_testname}
-                    COMMAND  quest_shaping_driver_ex
-                            -i ${shaping_data_dir}/revolved_circle.yaml
-                            --policy ${_policy}
-                            --segments-per-knot-span 1000
-                            --method intersection
-                            inline_mesh --min 0 0 --max 3 3 --res 3 3 -d 2
-                    NUM_MPI_TASKS ${_nranks})
-                # steel unit semi-circle with an area of pi/2
-                set_tests_properties(${_testname} PROPERTIES
-                    PASS_REGULAR_EXPRESSION  "Volume of material 'steel' is 1.57079")
-            endforeach()
-
-            unset(_policies)
         endif()
 
         # 3D shaping tests

--- a/src/axom/quest/examples/shaping_driver.cpp
+++ b/src/axom/quest/examples/shaping_driver.cpp
@@ -298,7 +298,7 @@ public:
         app.add_option_group("intersection", "Options related to intersection-based queries");
 
       intersection_options->add_option("-r, --refinements", refinementLevel)
-        ->description("Number of refinements to perform for revolved contour")
+        ->description("(3D only) Number of refinements to perform for revolved contour")
         ->capture_default_str()
         ->check(axom::CLI::NonNegativeNumber);
 


### PR DESCRIPTION
This PR:
- Adds initial capability to accept c2c meshes as input to the 2D intersection shaper.
  - Runtime regex output test added in `src/axom/quest/examples/CMakeLists.txt` for `quest_shaping_driver_ex`
- Fixes a bug where `m_samplesPerKnotSpan` was not being propagated.
- Future work is to support 2D shape bounded by multiple c2c contours (current assumption is a single c2c contour is bounded by the z-axis (x-axis))