### PR TITLE
GPU-related ODR fixes for Array and FlatMap

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -55,6 +55,10 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - The `primal::BoundingBox` class' `expand()` and `shift()` methods were modified so they do
   nothing when called on invalid bounding boxes.
 
+###  Fixed
+- Core: prevent incorrect instantiations of `axom::Array` from a host-only compile, when Axom is compiled
+  with GPU support. Instances where this occurs will now trigger a static assertion during compile time.
+
 ###  Deprecated
 - Primal: Deprecates `Triangle::checkInTriangle(pt)`. Use `Triangle::contains(pt)` instead.
 

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -914,7 +914,7 @@ struct ArrayOpsBase<T, OperationSpace::Host>
    */
   static void fill_range(T* array, IndexType begin, IndexType nelems, const T* values, MemorySpace space)
   {
-#if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
     if(std::is_trivially_copyable<T>::value)
     {
       axom::copy(array + begin, values, sizeof(T) * nelems);
@@ -1020,7 +1020,7 @@ struct ArrayOpsBase<T, OperationSpace::Host>
   }
 };
 
-#if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
 /*!
  * \name Tag types for device initialization
  */
@@ -1143,7 +1143,21 @@ struct DeviceStagingBuffer<T, OperationSpace::Unified_Device>
 template <typename T, OperationSpace SPACE>
 struct ArrayOpsBase
 {
-  #if defined(__CUDACC__)
+  #if !defined(AXOM_GPUCC)
+  // To avoid an ODR issue, we error out here to ensure that axom::Array
+  // device-aware operations are not instantiated within a host-compiler.
+  // See:
+  // - https://github.com/LLNL/axom/issues/1182
+  // - https://github.com/LLNL/axom/issues/1440
+  static_assert(SPACE != OperationSpace::Device,
+                "Cannot instantiate Array operations -- file is being compiled "
+                "with a host-only compiler, but Axom was configured and built "
+                "with a CUDA/HIP compiler.");
+
+  // Placeholder to ensure that the code compiles, even if we aren't
+  // instantiating this class.
+  using ExecSpace = axom::SEQ_EXEC;
+  #elif defined(AXOM_USE_CUDA)
   using ExecSpace = axom::CUDA_EXEC<256>;
   #else
   using ExecSpace = axom::HIP_EXEC<256>;
@@ -1380,7 +1394,7 @@ struct MemSpaceTraits
   static constexpr bool IsUVMAccessible = false;
 };
 
-#if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
 template <>
 struct MemSpaceTraits<MemorySpace::Device>
 {
@@ -1482,7 +1496,7 @@ struct ArrayOps<T, SPACE, true>
 {
 private:
   using Base = ArrayOpsBase<T, OperationSpace::Host>;
-#if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
   using BaseDevice = ArrayOpsBase<T, OperationSpace::Device>;
   // Works with unified and pinned memory.
   using BaseUM = ArrayOpsBase<T, OperationSpace::Unified_Device>;
@@ -1493,7 +1507,7 @@ private:
 public:
   ArrayOps(int allocId, bool preferDevice)
   {
-#if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
     if(SPACE == MemorySpace::Dynamic)
     {
       space = getAllocatorSpace(allocId);
@@ -1520,7 +1534,7 @@ public:
 
   void init(T* array, IndexType begin, IndexType nelems)
   {
-#if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
     if(space == MemorySpace::Device)
     {
       BaseDevice::init(array, begin, nelems);
@@ -1537,7 +1551,7 @@ public:
 
   void fill(T* array, IndexType begin, IndexType nelems, const T& value)
   {
-#if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
     if(space == MemorySpace::Device)
     {
       BaseDevice::fill(array, begin, nelems, value);
@@ -1554,7 +1568,7 @@ public:
 
   void fill_range(T* array, IndexType begin, IndexType nelems, const T* values, MemorySpace valueSpace)
   {
-#if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
     if(space == MemorySpace::Device)
     {
       BaseDevice::fill_range(array, begin, nelems, values, valueSpace);
@@ -1575,7 +1589,7 @@ public:
     {
       return;
     }
-#if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
     if(space == MemorySpace::Device)
     {
       BaseDevice::destroy(array, begin, nelems);
@@ -1596,7 +1610,7 @@ public:
     {
       return;
     }
-#if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
     if(space == MemorySpace::Device)
     {
       BaseDevice::move(array, src_begin, src_end, dst);
@@ -1613,7 +1627,7 @@ public:
 
   void realloc_move(T* array, IndexType nelems, T* values)
   {
-#if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
     if(space == MemorySpace::Device)
     {
       BaseDevice::realloc_move(array, nelems, values);
@@ -1631,7 +1645,7 @@ public:
   template <typename... Args>
   void emplace(T* array, IndexType dst, Args&&... args)
   {
-#if defined(AXOM_USE_GPU) && defined(AXOM_GPUCC) && defined(AXOM_USE_UMPIRE)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
     if(space == MemorySpace::Device)
     {
       BaseDevice::emplace(array, dst, std::forward<Args>(args)...);

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -1150,9 +1150,9 @@ struct ArrayOpsBase
   // - https://github.com/LLNL/axom/issues/1182
   // - https://github.com/LLNL/axom/issues/1440
   static_assert(SPACE != OperationSpace::Device && SPACE != OperationSpace::Unified_Device,
-                "Cannot instantiate Array operations -- file is being compiled "
-                "with a host-only compiler, but Axom was configured and built "
-                "with a CUDA/HIP compiler.");
+                "Cannot instantiate device-aware Array operations when file is compiled "
+                "with a host-only compiler. Axom was built with GPU support, so you should "
+                "build all source files using axom::Array with a CUDA/HIP compiler.");
 
   // Placeholder to ensure that the code compiles, even if we aren't
   // instantiating this class.

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -1149,7 +1149,7 @@ struct ArrayOpsBase
   // See:
   // - https://github.com/LLNL/axom/issues/1182
   // - https://github.com/LLNL/axom/issues/1440
-  static_assert(SPACE != OperationSpace::Device,
+  static_assert(SPACE != OperationSpace::Device && SPACE != OperationSpace::Unified_Device,
                 "Cannot instantiate Array operations -- file is being compiled "
                 "with a host-only compiler, but Axom was configured and built "
                 "with a CUDA/HIP compiler.");

--- a/src/axom/core/detail/FlatMapOps.hpp
+++ b/src/axom/core/detail/FlatMapOps.hpp
@@ -21,7 +21,6 @@ inline void setSentinel(axom::ArrayView<GroupBucket> metadata)
   // Note: HIP can access device memory from the host and does not need special
   // handling - we just defer to the host path in all cases.
   MemorySpace space = getAllocatorSpace(metadata.getAllocatorID());
-  using DeviceExec = axom::CUDA_EXEC<256>;
   if(space == MemorySpace::Device)
   {
     GroupBucket last_bucket;

--- a/src/axom/core/detail/FlatMapOps.hpp
+++ b/src/axom/core/detail/FlatMapOps.hpp
@@ -17,16 +17,17 @@ namespace flat_map
 
 inline void setSentinel(axom::ArrayView<GroupBucket> metadata)
 {
-#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA) && defined(AXOM_GPUCC)
+#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA)
   // Note: HIP can access device memory from the host and does not need special
   // handling - we just defer to the host path in all cases.
   MemorySpace space = getAllocatorSpace(metadata.getAllocatorID());
   using DeviceExec = axom::CUDA_EXEC<256>;
   if(space == MemorySpace::Device)
   {
-    for_all<DeviceExec>(
-      1,
-      AXOM_LAMBDA(IndexType) { metadata[metadata.size() - 1].setSentinel(); });
+    GroupBucket last_bucket;
+    axom::copy(&last_bucket, metadata.data() + metadata.size() - 1, sizeof(GroupBucket));
+    last_bucket.setSentinel();
+    axom::copy(metadata.data() + metadata.size() - 1, &last_bucket, sizeof(GroupBucket));
     return;
   }
 #endif
@@ -42,11 +43,10 @@ inline void destroyBuckets(axom::ArrayView<GroupBucket> metadata, axom::ArrayVie
     return;
   }
 
-#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA) && defined(AXOM_GPUCC)
+#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA)
   // Note: HIP can access device memory from the host and does not need special
   // handling - we just defer to the host path in all cases.
   MemorySpace space = getAllocatorSpace(metadata.getAllocatorID());
-  using DeviceExec = axom::CUDA_EXEC<256>;
   // CUDA-only: buckets located in device-only memory and non-trivially
   // destructible. We'll need to "relocate" the objects to the host to
   // destroy.


### PR DESCRIPTION
# Summary

Resolves potential ODR-related issues in `axom::Array` and `axom::FlatMap` when compiling a host-only source file against a GPU-enabled Axom library.
  - For `axom::Array`, preprocessor guards on `AXOM_GPUCC` are removed; instead, a static assertion is added within the device-side specialization of `ArrayOpsBase`.
 
     This allows for host-compiled code which does not use or instantiate `axom::Array` to include `axom/Array.hpp` without issue, while blocking an inadvertent and potentially-conflicting instantiation of the device code path within a host-only compilation. [^1]

  - For `axom::FlatMap`, replaces a kernel launch with an `axom::copy`.

Resolves the issues https://github.com/LLNL/axom/issues/1182 and https://github.com/LLNL/axom/issues/1440

[^1]: I think the implementation of `ArrayOpsBase` for the device still technically violates ODR (different tokens between a host and device compile), but it only gets correctly instantiated in a device compile so I think it's okay.