### PR TITLE
Add a DeviceHash class for GPU hashing

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -51,6 +51,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Adds support for custom allocators to `axom::FlatMap`.
 - Primal: Adds ability to perform sample-based shaping on tetrahedral shapes.
 - Improves efficiency of volume fraction computation from quadrature samples during sample-based shaping.
+- Adds a `axom::DeviceHash` type as a GPU-enabled version of the `std::hash` interface.
 
 ###  Changed
 - Fixed `Timer::elapsed*()` methods so they properly report the sum of all start/stop cycles

--- a/src/axom/core/CMakeLists.txt
+++ b/src/axom/core/CMakeLists.txt
@@ -67,6 +67,7 @@ set(core_headers
     Map.hpp
     MapCollection.hpp
     FlatMap.hpp
+    DeviceHash.hpp
     NumericArray.hpp
     NumericLimits.hpp
     Path.hpp

--- a/src/axom/core/DeviceHash.hpp
+++ b/src/axom/core/DeviceHash.hpp
@@ -65,7 +65,7 @@ struct DeviceHashHelper<T*, void>
   using result_type = axom::IndexType;
   AXOM_HOST_DEVICE axom::IndexType operator()(T* ptr) const
   {
-    return static_cast<axom::IndexType>(ptr);
+    return reinterpret_cast<axom::IndexType>(ptr);
   }
 };
 

--- a/src/axom/core/DeviceHash.hpp
+++ b/src/axom/core/DeviceHash.hpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef Axom_Core_DeviceHash_Hpp
+#define Axom_Core_DeviceHash_Hpp
+
+#include "axom/config.hpp"
+#include "axom/core/Types.hpp"
+
+#include <type_traits>
+
+namespace axom
+{
+namespace detail
+{
+template <typename T, typename Enable = void>
+struct DeviceHashHelper;
+
+/// \brief Specialization for integral types
+template <typename T>
+struct DeviceHashHelper<T, std::enable_if_t<std::is_integral<T>::value>>
+{
+  using argument_type = T;
+  using result_type = axom::IndexType;
+  axom::IndexType operator()(T value) const { return value; }
+};
+
+/// \brief Specialization for floating-point types
+template <typename T>
+struct DeviceHashHelper<T, std::enable_if_t<std::is_floating_point<T>::value>>
+{
+  using argument_type = T;
+  using result_type = axom::IndexType;
+  axom::IndexType operator()(T value) const
+  {
+    // Special case: -0.0 and 0.0 compare equal but have different byte representations.
+    if(value == T {0.})
+    {
+      return 0;
+    }
+    return value;
+  }
+};
+
+/// \brief SFINAE specialization for enum types
+template <typename T>
+struct DeviceHashHelper<T, std::enable_if_t<std::is_enum<T>::value>>
+{
+  using argument_type = T;
+  using result_type = axom::IndexType;
+  axom::IndexType operator()(T value) const
+  {
+    return static_cast<axom::IndexType>(value);
+  }
+};
+
+/// \brief Specialization for pointer types
+template <typename T>
+struct DeviceHashHelper<T*, void>
+{
+  using argument_type = T*;
+  using result_type = axom::IndexType;
+  axom::IndexType operator()(T* ptr) const
+  {
+    return static_cast<axom::IndexType>(ptr);
+  }
+};
+
+/// \brief Default catch-all specialization. Passes through to std::hash.
+template <typename T, typename Enable>
+struct DeviceHashHelper
+{
+  using argument_type = T;
+  using result_type = axom::IndexType;
+  axom::IndexType operator()(const T& object) const
+  {
+    return static_cast<axom::IndexType>(std::hash<T> {}(object));
+  }
+};
+
+}  // namespace detail
+
+/*!
+ * \class DeviceHash
+ *
+ * \brief Implements a host/device-callable hash function for supported types,
+ *  and passes through to std::hash otherwise.
+ */
+template <typename T>
+struct DeviceHash : public detail::DeviceHashHelper<T>
+{
+  using typename detail::DeviceHashHelper<T>::argument_type;
+  using typename detail::DeviceHashHelper<T>::result_type;
+};
+
+}  // namespace axom
+
+#endif

--- a/src/axom/core/DeviceHash.hpp
+++ b/src/axom/core/DeviceHash.hpp
@@ -7,6 +7,7 @@
 #define Axom_Core_DeviceHash_Hpp
 
 #include "axom/config.hpp"
+#include "axom/core/Macros.hpp"
 #include "axom/core/Types.hpp"
 
 #include <type_traits>
@@ -24,7 +25,7 @@ struct DeviceHashHelper<T, std::enable_if_t<std::is_integral<T>::value>>
 {
   using argument_type = T;
   using result_type = axom::IndexType;
-  axom::IndexType operator()(T value) const { return value; }
+  AXOM_HOST_DEVICE axom::IndexType operator()(T value) const { return value; }
 };
 
 /// \brief Specialization for floating-point types
@@ -33,7 +34,7 @@ struct DeviceHashHelper<T, std::enable_if_t<std::is_floating_point<T>::value>>
 {
   using argument_type = T;
   using result_type = axom::IndexType;
-  axom::IndexType operator()(T value) const
+  AXOM_HOST_DEVICE axom::IndexType operator()(T value) const
   {
     // Special case: -0.0 and 0.0 compare equal but have different byte representations.
     if(value == T {0.})
@@ -50,7 +51,7 @@ struct DeviceHashHelper<T, std::enable_if_t<std::is_enum<T>::value>>
 {
   using argument_type = T;
   using result_type = axom::IndexType;
-  axom::IndexType operator()(T value) const
+  AXOM_HOST_DEVICE axom::IndexType operator()(T value) const
   {
     return static_cast<axom::IndexType>(value);
   }
@@ -62,7 +63,7 @@ struct DeviceHashHelper<T*, void>
 {
   using argument_type = T*;
   using result_type = axom::IndexType;
-  axom::IndexType operator()(T* ptr) const
+  AXOM_HOST_DEVICE axom::IndexType operator()(T* ptr) const
   {
     return static_cast<axom::IndexType>(ptr);
   }

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -13,6 +13,7 @@
 #include "axom/core/Macros.hpp"
 #include "axom/core/detail/FlatTable.hpp"
 #include "axom/core/detail/FlatMapOps.hpp"
+#include "axom/core/DeviceHash.hpp"
 
 namespace axom
 {
@@ -44,7 +45,7 @@ namespace axom
  * \pre Hash is invocable with an instance of KeyType, and returns an integer
  *  value (32- or 64-bit)
  */
-template <typename KeyType, typename ValueType, typename Hash = std::hash<KeyType>>
+template <typename KeyType, typename ValueType, typename Hash = DeviceHash<KeyType>>
 class FlatMap : detail::flat_map::SequentialLookupPolicy<typename Hash::result_type>
 {
 private:

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -45,7 +45,7 @@ namespace axom
  * \pre Hash is invocable with an instance of KeyType, and returns an integer
  *  value (32- or 64-bit)
  */
-template <typename KeyType, typename ValueType, typename Hash = DeviceHash<KeyType>>
+template <typename KeyType, typename ValueType, typename Hash = detail::flat_map::HashMixer64<KeyType, DeviceHash>>
 class FlatMap : detail::flat_map::SequentialLookupPolicy<typename Hash::result_type>
 {
 private:
@@ -61,8 +61,6 @@ private:
 
   template <bool Const>
   friend class IteratorImpl;
-
-  using MixedHash = detail::flat_map::HashMixer64<KeyType, Hash>;
 
 public:
   using key_type = KeyType;
@@ -729,7 +727,7 @@ FlatMap<KeyType, ValueType, Hash>::FlatMap(IndexType num_elems,
 template <typename KeyType, typename ValueType, typename Hash>
 auto FlatMap<KeyType, ValueType, Hash>::find(const KeyType& key) -> iterator
 {
-  auto hash = MixedHash {}(key);
+  auto hash = Hash {}(key);
   iterator found_iter = end();
   this->probeIndex(m_numGroups2, m_metadata, hash, [&](IndexType bucket_index) -> bool {
     if(this->m_buckets[bucket_index].get().first == key)
@@ -746,7 +744,7 @@ auto FlatMap<KeyType, ValueType, Hash>::find(const KeyType& key) -> iterator
 template <typename KeyType, typename ValueType, typename Hash>
 auto FlatMap<KeyType, ValueType, Hash>::find(const KeyType& key) const -> const_iterator
 {
-  auto hash = MixedHash {}(key);
+  auto hash = Hash {}(key);
   const_iterator found_iter = end();
   this->probeIndex(m_numGroups2, m_metadata, hash, [&](IndexType bucket_index) -> bool {
     if(this->m_buckets[bucket_index].get().first == key)
@@ -775,7 +773,7 @@ template <typename KeyType, typename ValueType, typename Hash>
 auto FlatMap<KeyType, ValueType, Hash>::getEmplacePos(const KeyType& key)
   -> std::pair<iterator, bool>
 {
-  auto hash = MixedHash {}(key);
+  auto hash = Hash {}(key);
 
   // If the key already exists, return the existing iterator.
   iterator existing_elem = this->find(key);
@@ -828,7 +826,7 @@ template <typename KeyType, typename ValueType, typename Hash>
 auto FlatMap<KeyType, ValueType, Hash>::erase(const_iterator pos) -> iterator
 {
   assert(pos != end());
-  auto hash = MixedHash {}(pos->first);
+  auto hash = Hash {}(pos->first);
 
   bool midSequence = this->clearBucket(m_metadata, pos.m_internalIdx, hash);
   pos->~KeyValuePair();

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -38,12 +38,15 @@ struct QuadraticProbing
  *  Uses the "mxmxm" function described here:
  *  https://jonkagstrom.com/bit-mixer-construction/index.html
  */
-template <typename KeyType, typename HashFunc>
+template <typename KeyType, template <typename> class HashFunc>
 struct HashMixer64
 {
+  using argument_type = typename HashFunc<KeyType>::argument_type;
+  using result_type = typename HashFunc<KeyType>::result_type;
+
   uint64_t operator()(const KeyType& key) const
   {
-    uint64_t hash = HashFunc {}(key);
+    uint64_t hash = HashFunc<KeyType> {}(key);
     hash *= 0xbf58476d1ce4e5b9ULL;
     hash ^= hash >> 32;
     hash *= 0x94d049bb133111ebULL;

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(core_serial_tests
     core_array_for_all.hpp
     core_utilities.hpp
     core_bit_utilities.hpp
+    core_device_hash.hpp
     core_execution_for_all.hpp
     core_execution_space.hpp
     core_map.hpp

--- a/src/axom/core/tests/core_device_hash.hpp
+++ b/src/axom/core/tests/core_device_hash.hpp
@@ -1,0 +1,142 @@
+// Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+// Axom includes
+#include "axom/config.hpp"
+#include "axom/core/Macros.hpp"
+#include "axom/core/DeviceHash.hpp"
+
+// gtest includes
+#include "gtest/gtest.h"
+
+TEST(core_device_hash, hash_int)
+{
+  axom::DeviceHash<int> device_hasher;
+
+  constexpr int NUM_HASHES = 4;
+
+  int things_to_hash[NUM_HASHES] {0, 1, 37, 1100};
+
+  axom::IndexType computed_hashes[NUM_HASHES];
+
+  // Compute hashes.
+  for(int i = 0; i < NUM_HASHES; i++)
+  {
+    computed_hashes[i] = device_hasher(things_to_hash[i]);
+  }
+
+  for(int i = 0; i < NUM_HASHES; i++)
+  {
+    // Invocations of the hash function should be idempotent.
+    EXPECT_EQ(computed_hashes[i], device_hasher(things_to_hash[i]));
+
+    // Check that we don't have hash collisions with other values.
+    for(int j = i + 1; j < NUM_HASHES; j++)
+    {
+      EXPECT_NE(computed_hashes[i], computed_hashes[j]);
+    }
+  }
+}
+
+TEST(core_device_hash, hash_float)
+{
+  axom::DeviceHash<float> device_hasher;
+
+  constexpr int NUM_HASHES = 4;
+
+  float things_to_hash[NUM_HASHES] {0.f, 1.f, 37.f, 1100.f};
+
+  axom::IndexType computed_hashes[NUM_HASHES];
+
+  // Compute hashes.
+  for(int i = 0; i < NUM_HASHES; i++)
+  {
+    computed_hashes[i] = device_hasher(things_to_hash[i]);
+  }
+
+  for(int i = 0; i < NUM_HASHES; i++)
+  {
+    // Invocations of the hash function should be idempotent.
+    EXPECT_EQ(computed_hashes[i], device_hasher(things_to_hash[i]));
+
+    // Check that we don't have hash collisions with other values.
+    for(int j = i + 1; j < NUM_HASHES; j++)
+    {
+      EXPECT_NE(computed_hashes[i], computed_hashes[j]);
+    }
+  }
+
+  // Since 0.0f == -0.0f, they should hash to the same value.
+  EXPECT_EQ(device_hasher(0.0f), device_hasher(-0.0f));
+}
+
+TEST(core_device_hash, hash_string)
+{
+  axom::DeviceHash<std::string> device_hasher;
+
+  constexpr int NUM_HASHES = 4;
+
+  std::string things_to_hash[NUM_HASHES] {"0", "1", "37", "1100"};
+
+  axom::IndexType computed_hashes[NUM_HASHES];
+
+  // Compute hashes.
+  for(int i = 0; i < NUM_HASHES; i++)
+  {
+    computed_hashes[i] = device_hasher(things_to_hash[i]);
+  }
+
+  for(int i = 0; i < NUM_HASHES; i++)
+  {
+    // Invocations of the hash function should be idempotent.
+    EXPECT_EQ(computed_hashes[i], device_hasher(things_to_hash[i]));
+
+    // Check that we don't have hash collisions with other values.
+    for(int j = i + 1; j < NUM_HASHES; j++)
+    {
+      EXPECT_NE(computed_hashes[i], computed_hashes[j]);
+    }
+  }
+}
+
+enum class TestEnumHash
+{
+  Zero,
+  One,
+  Two,
+  Three
+};
+
+TEST(core_device_hash, hash_enum)
+{
+  axom::DeviceHash<TestEnumHash> device_hasher;
+
+  constexpr int NUM_HASHES = 4;
+
+  TestEnumHash things_to_hash[NUM_HASHES] {TestEnumHash::Zero,
+                                           TestEnumHash::One,
+                                           TestEnumHash::Two,
+                                           TestEnumHash::Three};
+
+  axom::IndexType computed_hashes[NUM_HASHES];
+
+  // Compute hashes.
+  for(int i = 0; i < NUM_HASHES; i++)
+  {
+    computed_hashes[i] = device_hasher(things_to_hash[i]);
+  }
+
+  for(int i = 0; i < NUM_HASHES; i++)
+  {
+    // Invocations of the hash function should be idempotent.
+    EXPECT_EQ(computed_hashes[i], device_hasher(things_to_hash[i]));
+
+    // Check that we don't have hash collisions with other values.
+    for(int j = i + 1; j < NUM_HASHES; j++)
+    {
+      EXPECT_NE(computed_hashes[i], computed_hashes[j]);
+    }
+  }
+}

--- a/src/axom/core/tests/core_device_hash.hpp
+++ b/src/axom/core/tests/core_device_hash.hpp
@@ -11,60 +11,98 @@
 // gtest includes
 #include "gtest/gtest.h"
 
-TEST(core_device_hash, hash_int)
+template <typename TheExecSpace>
+class core_device_hash : public ::testing::Test
 {
+public:
+  using ExecSpace = TheExecSpace;
+};
+
+using HashTestTypes = ::testing::Types<
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+  axom::CUDA_EXEC<256>,
+#endif
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
+  axom::HIP_EXEC<256>,
+#endif
+  axom::SEQ_EXEC>;
+
+TYPED_TEST_SUITE(core_device_hash, HashTestTypes);
+
+AXOM_TYPED_TEST(core_device_hash, hash_int)
+{
+  using ExecSpace = typename TestFixture::ExecSpace;
+
   axom::DeviceHash<int> device_hasher;
 
   constexpr int NUM_HASHES = 4;
 
   int things_to_hash[NUM_HASHES] {0, 1, 37, 1100};
 
-  axom::IndexType computed_hashes[NUM_HASHES];
+  // Allocate space for hash results.
+  int allocatorID = axom::execution_space<ExecSpace>::allocatorID();
+  axom::IndexType *computed_hashes =
+    axom::allocate<axom::IndexType>(NUM_HASHES, allocatorID);
 
   // Compute hashes.
-  for(int i = 0; i < NUM_HASHES; i++)
-  {
-    computed_hashes[i] = device_hasher(things_to_hash[i]);
-  }
+  axom::for_all<ExecSpace>(
+    NUM_HASHES,
+    AXOM_LAMBDA(int i) { computed_hashes[i] = device_hasher(things_to_hash[i]); });
+
+  // Copy back to host.
+  axom::IndexType computed_hashes_host[NUM_HASHES];
+  axom::copy(computed_hashes_host,
+             computed_hashes,
+             sizeof(axom::IndexType) * NUM_HASHES);
 
   for(int i = 0; i < NUM_HASHES; i++)
   {
     // Invocations of the hash function should be idempotent.
-    EXPECT_EQ(computed_hashes[i], device_hasher(things_to_hash[i]));
+    EXPECT_EQ(computed_hashes_host[i], device_hasher(things_to_hash[i]));
 
     // Check that we don't have hash collisions with other values.
     for(int j = i + 1; j < NUM_HASHES; j++)
     {
-      EXPECT_NE(computed_hashes[i], computed_hashes[j]);
+      EXPECT_NE(computed_hashes_host[i], computed_hashes[j]);
     }
   }
 }
 
-TEST(core_device_hash, hash_float)
+AXOM_TYPED_TEST(core_device_hash, hash_float)
 {
+  using ExecSpace = typename TestFixture::ExecSpace;
+
   axom::DeviceHash<float> device_hasher;
 
   constexpr int NUM_HASHES = 4;
 
   float things_to_hash[NUM_HASHES] {0.f, 1.f, 37.f, 1100.f};
 
-  axom::IndexType computed_hashes[NUM_HASHES];
+  // Allocate space for hash results.
+  int allocatorID = axom::execution_space<ExecSpace>::allocatorID();
+  axom::IndexType *computed_hashes =
+    axom::allocate<axom::IndexType>(NUM_HASHES, allocatorID);
 
   // Compute hashes.
-  for(int i = 0; i < NUM_HASHES; i++)
-  {
-    computed_hashes[i] = device_hasher(things_to_hash[i]);
-  }
+  axom::for_all<ExecSpace>(
+    NUM_HASHES,
+    AXOM_LAMBDA(int i) { computed_hashes[i] = device_hasher(things_to_hash[i]); });
+
+  // Copy back to host.
+  axom::IndexType computed_hashes_host[NUM_HASHES];
+  axom::copy(computed_hashes_host,
+             computed_hashes,
+             sizeof(axom::IndexType) * NUM_HASHES);
 
   for(int i = 0; i < NUM_HASHES; i++)
   {
     // Invocations of the hash function should be idempotent.
-    EXPECT_EQ(computed_hashes[i], device_hasher(things_to_hash[i]));
+    EXPECT_EQ(computed_hashes_host[i], device_hasher(things_to_hash[i]));
 
     // Check that we don't have hash collisions with other values.
     for(int j = i + 1; j < NUM_HASHES; j++)
     {
-      EXPECT_NE(computed_hashes[i], computed_hashes[j]);
+      EXPECT_NE(computed_hashes_host[i], computed_hashes_host[j]);
     }
   }
 
@@ -109,8 +147,10 @@ enum class TestEnumHash
   Three
 };
 
-TEST(core_device_hash, hash_enum)
+AXOM_TYPED_TEST(core_device_hash, hash_enum)
 {
+  using ExecSpace = typename TestFixture::ExecSpace;
+
   axom::DeviceHash<TestEnumHash> device_hasher;
 
   constexpr int NUM_HASHES = 4;
@@ -120,23 +160,31 @@ TEST(core_device_hash, hash_enum)
                                            TestEnumHash::Two,
                                            TestEnumHash::Three};
 
-  axom::IndexType computed_hashes[NUM_HASHES];
+  // Allocate space for hash results.
+  int allocatorID = axom::execution_space<ExecSpace>::allocatorID();
+  axom::IndexType *computed_hashes =
+    axom::allocate<axom::IndexType>(NUM_HASHES, allocatorID);
 
   // Compute hashes.
-  for(int i = 0; i < NUM_HASHES; i++)
-  {
-    computed_hashes[i] = device_hasher(things_to_hash[i]);
-  }
+  axom::for_all<ExecSpace>(
+    NUM_HASHES,
+    AXOM_LAMBDA(int i) { computed_hashes[i] = device_hasher(things_to_hash[i]); });
+
+  // Copy back to host.
+  axom::IndexType computed_hashes_host[NUM_HASHES];
+  axom::copy(computed_hashes_host,
+             computed_hashes,
+             sizeof(axom::IndexType) * NUM_HASHES);
 
   for(int i = 0; i < NUM_HASHES; i++)
   {
     // Invocations of the hash function should be idempotent.
-    EXPECT_EQ(computed_hashes[i], device_hasher(things_to_hash[i]));
+    EXPECT_EQ(computed_hashes_host[i], device_hasher(things_to_hash[i]));
 
     // Check that we don't have hash collisions with other values.
     for(int j = i + 1; j < NUM_HASHES; j++)
     {
-      EXPECT_NE(computed_hashes[i], computed_hashes[j]);
+      EXPECT_NE(computed_hashes_host[i], computed_hashes_host[j]);
     }
   }
 }

--- a/src/axom/core/tests/core_device_hash.hpp
+++ b/src/axom/core/tests/core_device_hash.hpp
@@ -41,8 +41,7 @@ AXOM_TYPED_TEST(core_device_hash, hash_int)
 
   // Allocate space for hash results.
   int allocatorID = axom::execution_space<ExecSpace>::allocatorID();
-  axom::IndexType *computed_hashes =
-    axom::allocate<axom::IndexType>(NUM_HASHES, allocatorID);
+  axom::IndexType *computed_hashes = axom::allocate<axom::IndexType>(NUM_HASHES, allocatorID);
 
   // Compute hashes.
   axom::for_all<ExecSpace>(
@@ -51,9 +50,8 @@ AXOM_TYPED_TEST(core_device_hash, hash_int)
 
   // Copy back to host.
   axom::IndexType computed_hashes_host[NUM_HASHES];
-  axom::copy(computed_hashes_host,
-             computed_hashes,
-             sizeof(axom::IndexType) * NUM_HASHES);
+  axom::copy(computed_hashes_host, computed_hashes, sizeof(axom::IndexType) * NUM_HASHES);
+  axom::deallocate(computed_hashes);
 
   for(int i = 0; i < NUM_HASHES; i++)
   {
@@ -63,7 +61,7 @@ AXOM_TYPED_TEST(core_device_hash, hash_int)
     // Check that we don't have hash collisions with other values.
     for(int j = i + 1; j < NUM_HASHES; j++)
     {
-      EXPECT_NE(computed_hashes_host[i], computed_hashes[j]);
+      EXPECT_NE(computed_hashes_host[i], computed_hashes_host[j]);
     }
   }
 }
@@ -80,8 +78,7 @@ AXOM_TYPED_TEST(core_device_hash, hash_float)
 
   // Allocate space for hash results.
   int allocatorID = axom::execution_space<ExecSpace>::allocatorID();
-  axom::IndexType *computed_hashes =
-    axom::allocate<axom::IndexType>(NUM_HASHES, allocatorID);
+  axom::IndexType *computed_hashes = axom::allocate<axom::IndexType>(NUM_HASHES, allocatorID);
 
   // Compute hashes.
   axom::for_all<ExecSpace>(
@@ -90,9 +87,8 @@ AXOM_TYPED_TEST(core_device_hash, hash_float)
 
   // Copy back to host.
   axom::IndexType computed_hashes_host[NUM_HASHES];
-  axom::copy(computed_hashes_host,
-             computed_hashes,
-             sizeof(axom::IndexType) * NUM_HASHES);
+  axom::copy(computed_hashes_host, computed_hashes, sizeof(axom::IndexType) * NUM_HASHES);
+  axom::deallocate(computed_hashes);
 
   for(int i = 0; i < NUM_HASHES; i++)
   {
@@ -162,8 +158,7 @@ AXOM_TYPED_TEST(core_device_hash, hash_enum)
 
   // Allocate space for hash results.
   int allocatorID = axom::execution_space<ExecSpace>::allocatorID();
-  axom::IndexType *computed_hashes =
-    axom::allocate<axom::IndexType>(NUM_HASHES, allocatorID);
+  axom::IndexType *computed_hashes = axom::allocate<axom::IndexType>(NUM_HASHES, allocatorID);
 
   // Compute hashes.
   axom::for_all<ExecSpace>(
@@ -172,9 +167,83 @@ AXOM_TYPED_TEST(core_device_hash, hash_enum)
 
   // Copy back to host.
   axom::IndexType computed_hashes_host[NUM_HASHES];
-  axom::copy(computed_hashes_host,
-             computed_hashes,
-             sizeof(axom::IndexType) * NUM_HASHES);
+  axom::copy(computed_hashes_host, computed_hashes, sizeof(axom::IndexType) * NUM_HASHES);
+  axom::deallocate(computed_hashes);
+
+  for(int i = 0; i < NUM_HASHES; i++)
+  {
+    // Invocations of the hash function should be idempotent.
+    EXPECT_EQ(computed_hashes_host[i], device_hasher(things_to_hash[i]));
+
+    // Check that we don't have hash collisions with other values.
+    for(int j = i + 1; j < NUM_HASHES; j++)
+    {
+      EXPECT_NE(computed_hashes_host[i], computed_hashes_host[j]);
+    }
+  }
+}
+
+namespace
+{
+template <typename T>
+struct UserVector
+{
+  T x, y, z;
+};
+}  // namespace
+
+// Test that we can correctly specialize a device hash for a user-defined type.
+namespace axom
+{
+template <typename T>
+struct DeviceHash<UserVector<T>>
+{
+  using argument_type = UserVector<T>;
+  using result_type = axom::IndexType;
+
+  AXOM_HOST_DEVICE axom::IndexType operator()(UserVector<T> value) const
+  {
+    // Copy byte representation over
+    constexpr int NWORDS = sizeof(UserVector<T>) / sizeof(int);
+    alignas(UserVector<T>) int bytes[NWORDS];
+    *reinterpret_cast<UserVector<T> *>(bytes) = value;
+
+    axom::IndexType hash_result {};
+    for(int i = 0; i < NWORDS; i++)
+    {
+      hash_result ^= (bytes[i] + 0x853c49e6);
+    }
+    return hash_result;
+  }
+};
+}  // namespace axom
+
+AXOM_TYPED_TEST(core_device_hash, hash_user_defined)
+{
+  using ExecSpace = typename TestFixture::ExecSpace;
+
+  axom::DeviceHash<UserVector<float>> device_hasher;
+
+  constexpr int NUM_HASHES = 4;
+
+  UserVector<float> things_to_hash[NUM_HASHES] = {{0.0, 0.0, 0.0},
+                                                  {1.0, 3.0, 5.0},
+                                                  {2.0, 5.0, 8.0},
+                                                  {10.0, 20.0, 30.0}};
+
+  // Allocate space for hash results.
+  int allocatorID = axom::execution_space<ExecSpace>::allocatorID();
+  axom::IndexType *computed_hashes = axom::allocate<axom::IndexType>(NUM_HASHES, allocatorID);
+
+  // Compute hashes.
+  axom::for_all<ExecSpace>(
+    NUM_HASHES,
+    AXOM_LAMBDA(int i) { computed_hashes[i] = device_hasher(things_to_hash[i]); });
+
+  // Copy back to host.
+  axom::IndexType computed_hashes_host[NUM_HASHES];
+  axom::copy(computed_hashes_host, computed_hashes, sizeof(axom::IndexType) * NUM_HASHES);
+  axom::deallocate(computed_hashes);
 
   for(int i = 0; i < NUM_HASHES; i++)
   {

--- a/src/axom/core/tests/core_serial_main.cpp
+++ b/src/axom/core/tests/core_serial_main.cpp
@@ -13,6 +13,7 @@
 #include "core_array_mapping.hpp"
 #include "core_utilities.hpp"
 #include "core_bit_utilities.hpp"
+#include "core_device_hash.hpp"
 #include "core_execution_for_all.hpp"
 #include "core_execution_space.hpp"
 #include "core_map.hpp"


### PR DESCRIPTION
# Summary

- Adds `axom::DeviceHash` for supporting hashing certain primitive types (integers, floating points, enums) on the GPU
  - Mimics the libc++ behavior for `std::hash`, which is to return the identity of the hashed value (casted to `axom::IndexType`)
  - For unsupported types, just wraps a call to `std::hash::operator ()`