### PR TITLE
Use compile-time strings as the format argument to fmt functions (fixes to support C++20)

### DIFF
--- a/src/axom/mint/utils/vtk_utils.cpp
+++ b/src/axom/mint/utils/vtk_utils.cpp
@@ -240,7 +240,7 @@ void write_scalar_helper(const std::string& type, const Field* field, std::ofstr
   SLIC_ASSERT(data_ptr != nullptr);
 
   fmt::print(file, "SCALARS {} ", field->getName());
-  fmt::print(file, fmt::format("{}\n", type));
+  fmt::print(file, "{}\n", type);
   fmt::print(file, "LOOKUP_TABLE default\n");
   const IndexType num_values = field->getNumTuples();
   fmt::print(file, "{}\n", fmt::join(data_ptr, data_ptr + num_values, "\n"));
@@ -292,7 +292,7 @@ void write_vector_helper(const std::string& type, const Field* field, std::ofstr
   SLIC_ASSERT(data_ptr != nullptr);
 
   fmt::print(file, "VECTORS {} ", field->getName());
-  fmt::print(file, fmt::format("{}\n", type));
+  fmt::print(file, "{}\n", type);
 
   const int num_components = field->getNumComponents();
   const IndexType num_values = field->getNumTuples();

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -1367,9 +1367,7 @@ private:
    */
   std::string materialNameToFieldName(const std::string& materialName) const
   {
-    const std::string vol_frac_fmt("vol_frac_{}");
-    auto name = axom::fmt::format(vol_frac_fmt, materialName);
-    return name;
+    return axom::fmt::format("vol_frac_{}", materialName);
   }
 
   /*!


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Uses compile-time strings as the format string argument to fmt functions (required in C++20)
  - The alternative is to wrap runtime format strings in axom::fmt::runtime