### PR TITLE
Add MPI to candidates example

### DIFF
--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -89,12 +89,12 @@ axom_add_executable(
     )
 
 # BVH silo example ------------------------------------------------------------
-if (CONDUIT_FOUND AND UMPIRE_FOUND)
+if (AXOM_ENABLE_MPI AND CONDUIT_FOUND AND UMPIRE_FOUND)
     axom_add_executable(
         NAME        quest_candidates_example_ex
         SOURCES     quest_candidates_example.cpp
         OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
-        DEPENDS_ON  ${quest_example_depends} conduit::conduit umpire
+        DEPENDS_ON  ${quest_example_depends} conduit::conduit conduit::conduit_mpi umpire
         FOLDER      axom/quest/examples
         )
 

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -88,7 +88,7 @@ axom_add_executable(
     FOLDER      axom/quest/examples
     )
 
-# BVH silo example ------------------------------------------------------------
+# BVH Blueprint candidate example -------------------------------------------------
 if (AXOM_ENABLE_MPI AND CONDUIT_FOUND AND UMPIRE_FOUND)
     axom_add_executable(
         NAME        quest_candidates_example_ex
@@ -136,7 +136,7 @@ if (AXOM_ENABLE_MPI AND CONDUIT_FOUND AND UMPIRE_FOUND)
 
                 # Match either one comma or none for portability
                 set_tests_properties(${_testname} PROPERTIES
-                    PASS_REGULAR_EXPRESSION  "Mesh had 6[,]?859 candidates pairs")
+                    PASS_REGULAR_EXPRESSION  "Mesh had 6[,]?859 candidate pairs")
             endforeach()
         endforeach()
     endif()
@@ -789,4 +789,3 @@ if(OPENCASCADE_FOUND)
 
     endif()
 endif()
-

--- a/src/axom/quest/examples/quest_candidates_example.cpp
+++ b/src/axom/quest/examples/quest_candidates_example.cpp
@@ -269,16 +269,6 @@ HexMesh loadBlueprintHexMesh(const std::string& mesh_path, bool verboseOutput = 
   int connectivity_size =
     (n_load[0]["topologies/topo/elements/connectivity"]).dtype().number_of_elements();
 
-  // Sanity check for number of cells
-  int cell_calc_from_nodes = std::round(std::pow(std::pow(num_nodes, 1.0 / 3.0) - 1, 3));
-  int cell_calc_from_connectivity = connectivity_size / HEX_OFFSET;
-  if(cell_calc_from_nodes != cell_calc_from_connectivity)
-  {
-    SLIC_ERROR("Number of cells is not expected!\n"
-               << "First calculation is " << cell_calc_from_nodes << " and second calculation is "
-               << cell_calc_from_connectivity);
-  }
-
   // extract hexes into an axom::Array
   auto x_vals_h = axom::ArrayView<double>(n_load[0]["coordsets/coords/values/x"].value(), num_nodes);
   auto y_vals_h = axom::ArrayView<double>(n_load[0]["coordsets/coords/values/y"].value(), num_nodes);
@@ -298,9 +288,32 @@ HexMesh loadBlueprintHexMesh(const std::string& mesh_path, bool verboseOutput = 
   auto z_vals_view = on_device ? z_vals_d.view() : z_vals_h;
 
   // Move connectivity information onto device
-  auto connectivity_h =
-    axom::ArrayView<int>(n_load[0]["topologies/topo/elements/connectivity"].value(),
-                         connectivity_size);
+
+  int* conn_data = nullptr;
+  axom::Array<int> temp_conn_data;
+  int conn_id = n_load[0]["topologies/topo/elements/connectivity"].dtype().id();
+  if(conn_id == conduit::DataType::INT32_ID)
+  {
+    conn_data = n_load[0]["topologies/topo/elements/connectivity"].as_int32_ptr();
+  }
+  else if(conn_id == conduit::DataType::INT64_ID)
+  {
+    temp_conn_data.resize(connectivity_size);
+    auto conn_int64_data = n_load[0]["topologies/topo/elements/connectivity"].as_int64_ptr();
+    for(int i = 0; i < connectivity_size; ++i)
+    {
+      temp_conn_data[i] = static_cast<int>(conn_int64_data[i]);
+    }
+    conn_data = temp_conn_data.data();
+  }
+  else
+  {
+    SLIC_ERROR("Node connectivity data type "
+               << n_load[0]["topologies/topo/elements/connectivity"].dtype().name()
+               << " is unsupported!");
+  }
+
+  auto connectivity_h = axom::ArrayView<int>(conn_data, connectivity_size);
 
   axom::Array<int> connectivity_d =
     on_device ? axom::Array<int>(connectivity_h, kernel_allocator) : axom::Array<int>();

--- a/src/axom/quest/examples/quest_candidates_example.cpp
+++ b/src/axom/quest/examples/quest_candidates_example.cpp
@@ -24,11 +24,19 @@
   #error This example requires axom to be configured with Umpire support
 #endif
 
+#ifdef AXOM_USE_MPI
+  #include "mpi.h"
+#else
+  #error This example requires axom to be configured with MPI support
+#endif
+
 #ifdef AXOM_USE_CONDUIT
   #include "conduit_relay.hpp"
   #include "conduit_blueprint.hpp"
+  #include "conduit_blueprint_mpi.hpp"
+  #include "conduit_relay_mpi_io_blueprint.hpp"
 #else
-  #error This example requires axom to be configured with Conduit support
+  #error This example requires axom to be configured with Conduit + MPI support
 #endif
 
 #include "axom/mint.hpp"
@@ -48,6 +56,10 @@ using UMesh = axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE>;
 using IndexPair = std::pair<axom::IndexType, axom::IndexType>;
 using RuntimePolicy = axom::runtime_policy::Policy;
 
+// MPI globals, set in main().
+int myRank = -1;
+int numRanks = -1;
+
 //-----------------------------------------------------------------------------
 /// Basic RAII utility class for initializing and finalizing slic logger
 //-----------------------------------------------------------------------------
@@ -56,21 +68,21 @@ struct BasicLogger
   BasicLogger()
   {
     namespace slic = axom::slic;
-
     // Initialize the SLIC logger
     slic::initialize();
-    slic::setLoggingMsgLevel(slic::message::Debug);
+    slic::setLoggingMsgLevel(slic::message::Info);
 
-    // Customize logging levels and formatting
-    const std::string slicFormatStr = "[<LEVEL>] <MESSAGE> \n";
+    slic::LogStream* logStream;
 
-    slic::addStreamToMsgLevel(new slic::GenericOutputStream(&std::cerr), slic::message::Error);
-    slic::addStreamToMsgLevel(new slic::GenericOutputStream(&std::cerr, slicFormatStr),
-                              slic::message::Warning);
+    std::string fmt = "[<RANK>][<LEVEL>]: <MESSAGE>\n";
+#ifdef AXOM_USE_LUMBERJACK
+    const int RLIMIT = 8;
+    logStream = new slic::LumberjackStream(&std::cout, MPI_COMM_WORLD, RLIMIT, fmt);
+#else
+    logStream = new slic::SynchronizedStream(&std::cout, MPI_COMM_WORLD, fmt);
+#endif  // AXOM_USE_MPI
 
-    auto* compactStream = new slic::GenericOutputStream(&std::cout, slicFormatStr);
-    slic::addStreamToMsgLevel(compactStream, slic::message::Info);
-    slic::addStreamToMsgLevel(compactStream, slic::message::Debug);
+    slic::addStreamToAllMsgLevels(logStream);
   }
 
   ~BasicLogger() { axom::slic::finalize(); }
@@ -245,7 +257,23 @@ HexMesh loadBlueprintHexMesh(const std::string& mesh_path, bool verboseOutput = 
 
   // Load Blueprint mesh into Conduit node
   conduit::Node n_load;
+
+  // Read mesh as single domain first; if partitioned, then reset and reload with MPI
   conduit::relay::io::blueprint::read_mesh(mesh_path, n_load);
+
+  if(conduit::blueprint::mesh::number_of_domains(n_load) > 1)
+  {
+    n_load.reset();
+    conduit::relay::mpi::io::blueprint::read_mesh(mesh_path, n_load, MPI_COMM_WORLD);
+  }
+
+  // Requirement that each rank has 1 domain
+  if(conduit::blueprint::mesh::number_of_domains(n_load) != 1)
+  {
+    SLIC_ERROR(axom::fmt::format("Rank {} has {} domains. Must have 1 domain per rank!\n",
+                                 myRank,
+                                 conduit::blueprint::mesh::number_of_domains(n_load)));
+  }
 
   // Check if Blueprint mesh conforms
   conduit::Node n_info;
@@ -391,8 +419,10 @@ HexMesh loadBlueprintHexMesh(const std::string& mesh_path, bool verboseOutput = 
     }
 
     // Write out to vtk for test viewing
-    SLIC_INFO("Writing out Blueprint mesh to test.vtk for debugging...");
-    axom::mint::write_vtk(mesh, "test.vtk");
+    std::string vtk_file_name = "test_" + std::to_string(myRank) + ".vtk";
+    SLIC_INFO(axom::fmt::format("Writing out Blueprint mesh to {} for debugging...", vtk_file_name));
+
+    axom::mint::write_vtk(mesh, vtk_file_name);
 
     delete mesh;
     mesh = nullptr;
@@ -659,6 +689,10 @@ std::vector<IndexPair> findCandidatesImplicit(const HexMesh& insertMesh,
 
 int main(int argc, char** argv)
 {
+  axom::utilities::raii::MPIWrapper mpi_raii_wrapper(argc, argv);
+  myRank = mpi_raii_wrapper.my_rank();
+  numRanks = mpi_raii_wrapper.num_ranks();
+
 #if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
   using omp_exec = axom::OMP_EXEC;
 #endif
@@ -686,7 +720,18 @@ int main(int argc, char** argv)
     }
     catch(const axom::CLI::ParseError& e)
     {
-      return app.exit(e);
+      int retval = -1;
+      if(myRank == 0)
+      {
+        retval = app.exit(e);
+      }
+
+#ifdef AXOM_USE_MPI
+      MPI_Bcast(&retval, 1, MPI_INT, 0, MPI_COMM_WORLD);
+      MPI_Finalize();
+#endif
+
+      exit(retval);
     }
   }
 
@@ -816,6 +861,7 @@ int main(int argc, char** argv)
 
   // print first few pairs
   const int numCandidates = candidatePairs.size();
+
   if(numCandidates > 0 && params.isVerbose())
   {
     constexpr int MAX_PRINT = 20;
@@ -832,8 +878,9 @@ int main(int argc, char** argv)
     }
 
     // Write out candidate pairs
-    SLIC_INFO("Writing out candidate pairs...");
-    std::ofstream outf("candidates.txt");
+    std::string candidates_file_name = "candidates_" + std::to_string(myRank) + ".txt";
+    SLIC_INFO(axom::fmt::format("Writing out candidate pairs to {}...", candidates_file_name));
+    std::ofstream outf(candidates_file_name);
 
     outf << candidatePairs.size() << " candidate pairs:" << std::endl;
     for(unsigned long i = 0; i < candidatePairs.size(); ++i)
@@ -841,6 +888,17 @@ int main(int argc, char** argv)
       outf << candidatePairs[i].first << " " << candidatePairs[i].second << std::endl;
     }
   }
+
+  // Print total number of pairs across all ranks
+  int totalNumCandidates = 0;
+  MPI_Reduce(&numCandidates, &totalNumCandidates, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+  if(myRank == 0)
+  {
+    SLIC_INFO(axom::fmt::format(axom::utilities::locale(),
+                                "Mesh had {:L} a total of candidates pairs across all ranks",
+                                totalNumCandidates));
+  }
+
   AXOM_ANNOTATE_END("find candidates");
 
   return 0;

--- a/src/axom/quest/examples/quest_candidates_example.cpp
+++ b/src/axom/quest/examples/quest_candidates_example.cpp
@@ -353,7 +353,7 @@ HexMesh loadBlueprintHexMesh(const std::string& mesh_path,
   // Move connectivity information onto device
 
   int* conn_data = nullptr;
-  axom::Array<int> temp_conn_data;
+  conduit::Node temp_conn_data;
   int conn_id = n_load[0]["topologies/topo/elements/connectivity"].dtype().id();
   if(conn_id == conduit::DataType::INT32_ID)
   {
@@ -361,13 +361,8 @@ HexMesh loadBlueprintHexMesh(const std::string& mesh_path,
   }
   else if(conn_id == conduit::DataType::INT64_ID)
   {
-    temp_conn_data.resize(connectivity_size);
-    auto conn_int64_data = n_load[0]["topologies/topo/elements/connectivity"].as_int64_ptr();
-    for(int i = 0; i < connectivity_size; ++i)
-    {
-      temp_conn_data[i] = static_cast<int>(conn_int64_data[i]);
-    }
-    conn_data = temp_conn_data.data();
+    n_load[0]["topologies/topo/elements/connectivity"].to_int32_array(temp_conn_data);
+    conn_data = temp_conn_data.as_int32_ptr();
   }
   else
   {

--- a/src/axom/quest/examples/quest_candidates_example.cpp
+++ b/src/axom/quest/examples/quest_candidates_example.cpp
@@ -6,7 +6,7 @@
 
 //-----------------------------------------------------------------------------
 ///
-/// file: quest_candidates_examples.cpp
+/// file: quest_candidates_example.cpp
 ///
 /// This example takes as input two Blueprint unstructured hex meshes, and
 /// finds the candidates of intersection between the meshes using a
@@ -56,9 +56,17 @@ using UMesh = axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE>;
 using IndexPair = std::pair<axom::IndexType, axom::IndexType>;
 using RuntimePolicy = axom::runtime_policy::Policy;
 
+namespace
+{
 // MPI globals, set in main().
 int myRank = -1;
-int numRanks = -1;
+
+enum class MeshLoadPolicy
+{
+  Replicated,
+  OneDomainPerRankOrReplicated
+};
+}  // namespace
 
 //-----------------------------------------------------------------------------
 /// Basic RAII utility class for initializing and finalizing slic logger
@@ -111,12 +119,16 @@ struct Input
 void Input::parse(int argc, char** argv, axom::CLI::App& app)
 {
   app.add_option("-i, --infile", mesh_file_first)
-    ->description("The first input Blueprint mesh file to insert into spatial index")
+    ->description(
+      "The first input Blueprint mesh file to insert into spatial index.\n"
+      "May be single-domain on all ranks or partitioned with one domain per rank.")
     ->required()
     ->check(axom::CLI::ExistingFile);
 
   app.add_option("-q, --queryfile", mesh_file_second)
-    ->description("The second input Blueprint mesh file to query spatial index")
+    ->description(
+      "The second input Blueprint mesh file to query spatial index.\n"
+      "Must be a single-domain mesh on all ranks.")
     ->required()
     ->check(axom::CLI::ExistingFile);
 
@@ -239,7 +251,9 @@ struct HexMesh
 };
 
 template <typename ExecSpace>
-HexMesh loadBlueprintHexMesh(const std::string& mesh_path, bool verboseOutput = false)
+HexMesh loadBlueprintHexMesh(const std::string& mesh_path,
+                             MeshLoadPolicy meshLoadPolicy,
+                             bool verboseOutput = false)
 {
   AXOM_ANNOTATE_SCOPE("load Blueprint hexahedron mesh");
 
@@ -258,21 +272,34 @@ HexMesh loadBlueprintHexMesh(const std::string& mesh_path, bool verboseOutput = 
   // Load Blueprint mesh into Conduit node
   conduit::Node n_load;
 
-  // Read mesh as single domain first; if partitioned, then reset and reload with MPI
+  // Read mesh as a regular Blueprint file first. Meshes that allow
+  // partitioning may then be reloaded with MPI if they are distributed
+  // across ranks.
   conduit::relay::io::blueprint::read_mesh(mesh_path, n_load);
 
-  if(conduit::blueprint::mesh::number_of_domains(n_load) > 1)
+  const auto numDomains = conduit::blueprint::mesh::number_of_domains(n_load);
+  if(numDomains > 1)
   {
+    if(meshLoadPolicy == MeshLoadPolicy::Replicated)
+    {
+      SLIC_ERROR(axom::fmt::format(
+        "Mesh '{}' has {} domains. This mesh must be a single-domain mesh available on all ranks.",
+        mesh_path,
+        numDomains));
+    }
+
     n_load.reset();
     conduit::relay::mpi::io::blueprint::read_mesh(mesh_path, n_load, MPI_COMM_WORLD);
-  }
 
-  // Requirement that each rank has 1 domain
-  if(conduit::blueprint::mesh::number_of_domains(n_load) != 1)
-  {
-    SLIC_ERROR(axom::fmt::format("Rank {} has {} domains. Must have 1 domain per rank!\n",
-                                 myRank,
-                                 conduit::blueprint::mesh::number_of_domains(n_load)));
+    if(conduit::blueprint::mesh::number_of_domains(n_load) != 1)
+    {
+      SLIC_ERROR(
+        axom::fmt::format("Rank {} has {} local domains for '{}'. Partitioned meshes must provide "
+                          "exactly one domain per rank.",
+                          myRank,
+                          conduit::blueprint::mesh::number_of_domains(n_load),
+                          mesh_path));
+    }
   }
 
   // Check if Blueprint mesh conforms
@@ -296,6 +323,14 @@ HexMesh loadBlueprintHexMesh(const std::string& mesh_path, bool verboseOutput = 
 
   int connectivity_size =
     (n_load[0]["topologies/topo/elements/connectivity"]).dtype().number_of_elements();
+
+  if(connectivity_size % HEX_OFFSET != 0)
+  {
+    SLIC_ERROR(
+      axom::fmt::format("Hex connectivity array has {} entries; expected a multiple of {}.",
+                        connectivity_size,
+                        HEX_OFFSET));
+  }
 
   // extract hexes into an axom::Array
   auto x_vals_h = axom::ArrayView<double>(n_load[0]["coordsets/coords/values/x"].value(), num_nodes);
@@ -691,7 +726,6 @@ int main(int argc, char** argv)
 {
   axom::utilities::raii::MPIWrapper mpi_raii_wrapper(argc, argv);
   myRank = mpi_raii_wrapper.my_rank();
-  numRanks = mpi_raii_wrapper.num_ranks();
 
 #if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
   using omp_exec = axom::OMP_EXEC;
@@ -728,10 +762,9 @@ int main(int argc, char** argv)
 
 #ifdef AXOM_USE_MPI
       MPI_Bcast(&retval, 1, MPI_INT, 0, MPI_COMM_WORLD);
-      MPI_Finalize();
 #endif
 
-      exit(retval);
+      return retval;
     }
   }
 
@@ -753,21 +786,29 @@ int main(int argc, char** argv)
   {
 #ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
   case RuntimePolicy::omp:
-    insert_mesh = loadBlueprintHexMesh<omp_exec>(params.mesh_file_first, params.isVerbose());
+    insert_mesh = loadBlueprintHexMesh<omp_exec>(params.mesh_file_first,
+                                                 MeshLoadPolicy::OneDomainPerRankOrReplicated,
+                                                 params.isVerbose());
     break;
 #endif
 #ifdef AXOM_RUNTIME_POLICY_USE_CUDA
   case RuntimePolicy::cuda:
-    insert_mesh = loadBlueprintHexMesh<cuda_exec>(params.mesh_file_first, params.isVerbose());
+    insert_mesh = loadBlueprintHexMesh<cuda_exec>(params.mesh_file_first,
+                                                  MeshLoadPolicy::OneDomainPerRankOrReplicated,
+                                                  params.isVerbose());
     break;
 #endif
 #ifdef AXOM_RUNTIME_POLICY_USE_HIP
   case RuntimePolicy::hip:
-    insert_mesh = loadBlueprintHexMesh<hip_exec>(params.mesh_file_first, params.isVerbose());
+    insert_mesh = loadBlueprintHexMesh<hip_exec>(params.mesh_file_first,
+                                                 MeshLoadPolicy::OneDomainPerRankOrReplicated,
+                                                 params.isVerbose());
     break;
 #endif
   default:  // RuntimePolicy::seq
-    insert_mesh = loadBlueprintHexMesh<seq_exec>(params.mesh_file_first, params.isVerbose());
+    insert_mesh = loadBlueprintHexMesh<seq_exec>(params.mesh_file_first,
+                                                 MeshLoadPolicy::OneDomainPerRankOrReplicated,
+                                                 params.isVerbose());
     break;
   }
 
@@ -780,21 +821,29 @@ int main(int argc, char** argv)
   {
 #ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
   case RuntimePolicy::omp:
-    query_mesh = loadBlueprintHexMesh<omp_exec>(params.mesh_file_second, params.isVerbose());
+    query_mesh = loadBlueprintHexMesh<omp_exec>(params.mesh_file_second,
+                                                MeshLoadPolicy::Replicated,
+                                                params.isVerbose());
     break;
 #endif
 #ifdef AXOM_RUNTIME_POLICY_USE_CUDA
   case RuntimePolicy::cuda:
-    query_mesh = loadBlueprintHexMesh<cuda_exec>(params.mesh_file_second, params.isVerbose());
+    query_mesh = loadBlueprintHexMesh<cuda_exec>(params.mesh_file_second,
+                                                 MeshLoadPolicy::Replicated,
+                                                 params.isVerbose());
     break;
 #endif
 #ifdef AXOM_RUNTIME_POLICY_USE_HIP
   case RuntimePolicy::hip:
-    query_mesh = loadBlueprintHexMesh<hip_exec>(params.mesh_file_second, params.isVerbose());
+    query_mesh = loadBlueprintHexMesh<hip_exec>(params.mesh_file_second,
+                                                MeshLoadPolicy::Replicated,
+                                                params.isVerbose());
     break;
 #endif
   default:  // RuntimePolicy::seq
-    query_mesh = loadBlueprintHexMesh<seq_exec>(params.mesh_file_second, params.isVerbose());
+    query_mesh = loadBlueprintHexMesh<seq_exec>(params.mesh_file_second,
+                                                MeshLoadPolicy::Replicated,
+                                                params.isVerbose());
     break;
   }
 
@@ -856,7 +905,7 @@ int main(int argc, char** argv)
   }
 
   SLIC_INFO(axom::fmt::format(axom::utilities::locale(),
-                              "Mesh had {:L} candidates pairs",
+                              "Mesh had {:L} candidate pairs",
                               candidatePairs.size()));
 
   // print first few pairs
@@ -867,10 +916,11 @@ int main(int argc, char** argv)
     constexpr int MAX_PRINT = 20;
     if(numCandidates > MAX_PRINT)
     {
-      candidatePairs.resize(MAX_PRINT);
+      const std::vector<IndexPair> previewPairs(candidatePairs.begin(),
+                                                candidatePairs.begin() + MAX_PRINT);
       SLIC_INFO(axom::fmt::format("First {} candidate pairs: {} ...\n",
                                   MAX_PRINT,
-                                  axom::fmt::join(candidatePairs, ", ")));
+                                  axom::fmt::join(previewPairs, ", ")));
     }
     else
     {
@@ -882,10 +932,15 @@ int main(int argc, char** argv)
     SLIC_INFO(axom::fmt::format("Writing out candidate pairs to {}...", candidates_file_name));
     std::ofstream outf(candidates_file_name);
 
-    outf << candidatePairs.size() << " candidate pairs:" << std::endl;
-    for(unsigned long i = 0; i < candidatePairs.size(); ++i)
+    if(!outf)
     {
-      outf << candidatePairs[i].first << " " << candidatePairs[i].second << std::endl;
+      SLIC_ERROR(axom::fmt::format("Failed to open '{}' for writing.", candidates_file_name));
+    }
+
+    outf << candidatePairs.size() << " candidate pairs:" << std::endl;
+    for(const auto& candidatePair : candidatePairs)
+    {
+      outf << candidatePair.first << " " << candidatePair.second << '\n';
     }
   }
 
@@ -895,7 +950,7 @@ int main(int argc, char** argv)
   if(myRank == 0)
   {
     SLIC_INFO(axom::fmt::format(axom::utilities::locale(),
-                                "Mesh had {:L} a total of candidates pairs across all ranks",
+                                "Mesh had {:L} candidate pairs total across all ranks",
                                 totalNumCandidates));
   }
 


### PR DESCRIPTION
This PR:

- Adds MPI support to `quest_candidates_examples.cpp`
  - Input mesh (donor) to the spatial index can either be single domain or partitioned with one domain per rank.
  - Query (target) to the spatial index must be single domain.
- Fix issue with potentially loading `int64` or `int32` connectivity data.   