### PR TITLE
Add missing bump macro in config.hpp

### DIFF
--- a/src/axom/config.hpp.in
+++ b/src/axom/config.hpp.in
@@ -96,6 +96,7 @@
 /*
  * Compiler defines for Axom components
  */
+#cmakedefine AXOM_USE_BUMP
 #cmakedefine AXOM_USE_INLET
 #cmakedefine AXOM_USE_KLEE
 #cmakedefine AXOM_USE_LUMBERJACK


### PR DESCRIPTION
I noticed that config.hpp was missing a define for AXOM_USE_BUMP. Oops. I added one.

