### PR TITLE
Fixes some Sina configuration variables

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -64,6 +64,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   with GPU support. Instances where this occurs will now trigger a static assertion during compile time.
 - Fixes build with `ninja` generator
 - Primal: Fixes a `BoundingBox` constructor with zero (or fewer) points
+- Sina: Fixes configuration variables related of inclusion of `AdiakWriter.hpp` and hdf5 support in `sina_fortran_interface.f`
 
 ###  Deprecated
 - Primal: Deprecates `Triangle::checkInTriangle(pt)`. Use `Triangle::contains(pt)` instead.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -64,7 +64,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   with GPU support. Instances where this occurs will now trigger a static assertion during compile time.
 - Fixes build with `ninja` generator
 - Primal: Fixes a `BoundingBox` constructor with zero (or fewer) points
-- Sina: Fixes configuration variables related of inclusion of `AdiakWriter.hpp` and hdf5 support in `sina_fortran_interface.f`
+- Sina: Fixes configuration variables related to inclusion of `AdiakWriter.hpp` and to hdf5 support in `sina_fortran_interface.f`
 
 ###  Deprecated
 - Primal: Deprecates `Triangle::checkInTriangle(pt)`. Use `Triangle::contains(pt)` instead.

--- a/src/axom/sina/CMakeLists.txt
+++ b/src/axom/sina/CMakeLists.txt
@@ -45,19 +45,18 @@ set(sina_sources
     core/Run.cpp
     )
 
-
 # Add Adiak header and source
-blt_list_append( TO sina_headers ELEMENTS core/AdiakWriter.hpp IF AXOM_USE_ADIAK )
-blt_list_append( TO sina_sources ELEMENTS core/AdiakWriter.cpp IF AXOM_USE_ADIAK )
+blt_list_append( TO sina_headers ELEMENTS core/AdiakWriter.hpp IF ADIAK_FOUND )
+blt_list_append( TO sina_sources ELEMENTS core/AdiakWriter.cpp IF ADIAK_FOUND )
 
 # Add fortran interface for Sina
-if(AXOM_USE_HDF5 AND ENABLE_FORTRAN)
-  set(AXOM_USE_HDF5_FORTRAN ".true.")
-else()
-  set(AXOM_USE_HDF5_FORTRAN ".false.")
-endif()
-
 if (ENABLE_FORTRAN)
+  if(HDF5_FOUND)
+    set(AXOM_USE_HDF5_FORTRAN ".true.")
+  else()
+    set(AXOM_USE_HDF5_FORTRAN ".false.")
+  endif()
+
   axom_configure_file(
       interface/sina_fortran_interface.f.in
       ${CMAKE_CURRENT_BINARY_DIR}/interface/sina_fortran_interface.f)
@@ -77,7 +76,7 @@ set(sina_depends
     conduit::conduit
     )
 
-blt_list_append( TO sina_depends ELEMENTS adiak::adiak IF AXOM_USE_ADIAK )
+blt_list_append( TO sina_depends ELEMENTS adiak::adiak IF ADIAK_FOUND )
 
 axom_add_library(NAME       sina
                  SOURCES    ${sina_sources}


### PR DESCRIPTION
# Summary

- This PR is a bugfix for some configuration variables in Sina
- It fixes the inclusion/export of some Adiak-related source files 
- It also fixes hdf5 support in sina's Fortran interface.
- Note: `AXOM_USE_<FOO>` variables are not yet available within the Axom components.
