### PR TITLE
FlatMap: add method for batched GPU construction

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,6 +40,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - 2D and 3D implementations for `axom::for_all` were added.
 - Adds `axom::FlatMapView`, a helper class associated with `axom::FlatMap` to support queries from
   within a GPU kernel.
+- Adds an `axom::FlatMap::create()` method to support constructing a hash map over a batch of keys
+  and values on the GPU or with OpenMP.
 - Adds support for custom allocators to `axom::FlatMap`.
 - Primal: Adds ability to perform sample-based shaping on tetrahedral shapes.
 - Improves efficiency of volume fraction computation from quadrature samples during sample-based shaping.

--- a/src/axom/core/CMakeLists.txt
+++ b/src/axom/core/CMakeLists.txt
@@ -68,6 +68,7 @@ set(core_headers
     MapCollection.hpp
     FlatMap.hpp
     FlatMapView.hpp
+    FlatMapUtil.hpp
     DeviceHash.hpp
     NumericArray.hpp
     NumericLimits.hpp

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -726,7 +726,7 @@ FlatMap<KeyType, ValueType, Hash>::FlatMap(IndexType bucket_count, Allocator all
   // TODO: we should add a countl_zero overload for 64-bit integers
   {
     std::int32_t numGroups = std::ceil((bucket_count + 1) / (double)BucketsPerGroup);
-    m_numGroups2 = 31 - (axom::utilities::countl_zero(numGroups));
+    m_numGroups2 = 32 - (axom::utilities::countl_zero(numGroups));
   }
 
   IndexType numGroupsRounded = 1 << m_numGroups2;

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -613,6 +613,11 @@ public:
   ConstView view() const;
   /// }@
 
+  template <typename ExecSpace>
+  static FlatMap create(axom::ArrayView<KeyType> keys,
+                        axom::ArrayView<ValueType> values,
+                        Allocator allocator = Allocator {});
+
 private:
   friend class FlatMapView<KeyType, ValueType, false, Hash>;
   friend class FlatMapView<KeyType, ValueType, true, Hash>;
@@ -859,5 +864,7 @@ auto FlatMap<KeyType, ValueType, Hash>::erase(const_iterator pos) -> iterator
 }
 
 }  // namespace axom
+
+#include "FlatMapUtil.hpp"
 
 #endif  // Axom_Core_FlatMap_HPP

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -613,6 +613,25 @@ public:
   ConstView view() const;
   /// }@
 
+  /*!
+   * \brief Constructs and returns a FlatMap given a set of key-value pairs.
+   *
+   *  Duplicate keys are handled by selecting the last value in the values
+   *  array corresponding to the equivalent key.
+   *
+   * \param keys   [in] array of keys for the pairs to insert
+   * \param values [in] array of values for the pairs to insert
+   * \param allocator [in] allocator to use for the constructed FlatMap
+   *
+   * \tparam ExecSpace the execution space in which to perform the batched
+   *                   construction
+   *
+   * \return the constructed FlatMap
+   *
+   * \pre keys.size() == values.size()
+   * \pre {keys, values}.getAllocatorID() is accessible from ExecSpace
+   * \pre allocator is accessible from ExecSpace
+   */
   template <typename ExecSpace>
   static FlatMap create(axom::ArrayView<KeyType> keys,
                         axom::ArrayView<ValueType> values,

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -602,7 +602,7 @@ public:
    *
    * \param count the number of elements to fit without a rehash
    */
-  void reserve(IndexType count) { rehash(std::ceil(count / MAX_LOAD_FACTOR)); }
+  void reserve(IndexType count) { rehash(count); }
 
   /*!
    * \brief Returns a read-only view of the FlatMap.
@@ -739,13 +739,13 @@ FlatMap<KeyType, ValueType, Hash>::FlatMap(IndexType bucket_count, Allocator all
   , m_loadCount(0)
 {
   IndexType minBuckets = MIN_NUM_BUCKETS;
-  bucket_count = axom::utilities::max(minBuckets, bucket_count);
+  bucket_count = axom::utilities::max<IndexType>(minBuckets, bucket_count / MAX_LOAD_FACTOR);
   // Get the smallest power-of-two number of groups satisfying:
   // N * GroupSize - 1 >= minBuckets
   // TODO: we should add a countl_zero overload for 64-bit integers
   {
     std::int32_t numGroups = std::ceil((bucket_count + 1) / (double)BucketsPerGroup);
-    m_numGroups2 = 32 - (axom::utilities::countl_zero(numGroups));
+    m_numGroups2 = 32 - (axom::utilities::countl_zero(numGroups - 1));
   }
 
   IndexType numGroupsRounded = 1 << m_numGroups2;

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
 // other Axom Project Developers. See the top-level COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -1,0 +1,189 @@
+// Copyright (c) 2017-2024, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef Axom_Core_FlatMap_Util_HPP
+#define Axom_Core_FlatMap_Util_HPP
+
+#include "axom/config.hpp"
+#include "axom/core/FlatMap.hpp"
+
+namespace axom
+{
+namespace detail
+{
+
+struct SpinLock
+{
+  int value {0};
+
+  AXOM_HOST_DEVICE bool tryLock()
+  {
+    int still_locked = 0;
+#if defined(__HIP_DEVICE_COMPILE__)
+    still_locked = __hip_atomic_exchange(&value, 1, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT);
+#elif defined(AXOM_USE_RAJA) && defined(__CUDA_ARCH__)
+    still_locked = RAJA::atomicExchange<RAJA::cuda_atomic>(&value, 1);
+    // We really want an acquire-fenced atomic here
+    __threadfence();
+#elif defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP)
+    still_locked = RAJA::atomicExchange<RAJA::omp_atomic>(&value, 1);
+    std::atomic_thread_fence(std::memory_order_acquire);
+#endif
+    return !still_locked;
+  }
+
+  AXOM_HOST_DEVICE void unlock()
+  {
+#if defined(__HIP_DEVICE_COMPILE__)
+    __hip_atomic_exchange(&value, 0, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_AGENT);
+#elif defined(AXOM_USE_RAJA) && defined(__CUDA_ARCH__)
+    // We really want a release-fenced atomic here
+    __threadfence();
+    RAJA::atomicExchange<RAJA::cuda_atomic>(&value, 0);
+#elif defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP)
+    std::atomic_thread_fence(std::memory_order_release);
+    RAJA::atomicExchange<RAJA::omp_atomic>(&value, 0);
+#else
+    value = 0;
+#endif
+  }
+};
+
+}  // namespace detail
+
+template <typename KeyType, typename ValueType, typename Hash>
+template <typename ExecSpace>
+auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
+                                               ArrayView<ValueType> values,
+                                               Allocator allocator) -> FlatMap
+{
+  assert(keys.size() == values.size());
+
+  IndexType num_elems = keys.size();
+
+  FlatMap new_map(allocator);
+  new_map.reserve(num_elems);
+
+  using RajaReduce = typename axom::execution_space<ExecSpace>::reduce_policy;
+  using HashResult = typename Hash::result_type;
+  using GroupBucket = detail::flat_map::GroupBucket;
+
+  // Grab some needed internal fields from the flat map.
+  // We're going to be constructing metadata and the K-V pairs directly
+  // in-place.
+  int ngroups_pow_2 = new_map.m_numGroups2;
+  const auto meta_group = new_map.m_metadata.view();
+  const auto buckets = new_map.m_buckets.view();
+
+  // Construct an array of locks per-group. This guards metadata updates for
+  // each insertion.
+  IndexType num_groups = 1 << ngroups_pow_2;
+  Array<detail::SpinLock> lock_vec(num_groups, num_groups, allocator.get());
+  const auto group_locks = lock_vec.view();
+
+  // Add a counter for failed inserts.
+#ifdef AXOM_USE_RAJA
+  RAJA::ReduceSum<RajaReduce, int> num_failed_inserts(0);
+#else
+  int num_failed_inserts = 0;
+#endif
+
+  for_all<ExecSpace>(
+    keys.size(),
+    AXOM_LAMBDA(IndexType idx) {
+      // Hash keys.
+      auto hash = Hash {}(keys[idx]);
+
+      // We use the k MSBs of the hash as the initial group probe point,
+      // where ngroups = 2^k.
+      int bitshift_right = ((CHAR_BIT * sizeof(HashResult)) - ngroups_pow_2);
+      HashResult curr_group = hash >> bitshift_right;
+      curr_group &= ((1 << ngroups_pow_2) - 1);
+
+      std::uint8_t hash_8 = static_cast<std::uint8_t>(hash);
+
+      int group_index = -1;
+      int slot_index = -1;
+      int iteration = 0;
+      while(iteration < meta_group.size())
+      {
+        // Get the overflow state for the current group.
+        bool overflow_group = meta_group[curr_group].template getMaybeOverflowed<true>(hash_8);
+        bool group_locked = false;
+
+        // Try to lock the group if we haven't overflowed.
+        if(!overflow_group)
+        {
+          group_locked = group_locks[curr_group].tryLock();
+        }
+
+        if(group_locked)
+        {
+          // Re-check overflow state now that we've locked the group.
+          // Other threads may have updated the overflow state before
+          // actaully taking the lock.
+          overflow_group = meta_group[curr_group].template getMaybeOverflowed<true>(hash_8);
+          if(!overflow_group)
+          {
+            slot_index = meta_group[curr_group].getEmptyBucket();
+            if(slot_index != GroupBucket::InvalidSlot)
+            {
+              // We have an empty slot in this group. Place an element.
+              group_index = curr_group;
+              meta_group[curr_group].template setBucket<true>(slot_index, hash_8);
+            }
+            else
+            {
+              // Group is full. Set overflow bit for the group.
+              meta_group[curr_group].template setOverflow<true>(hash_8);
+            }
+          }
+          // Unlock group once we're done.
+          group_locks[curr_group].unlock();
+        }
+
+        // Either we got an empty slot to insert in, or we overflowed
+        // on a group we waited on.
+        if(group_index != -1)
+        {
+          // We have an empty slot. Exit.
+          break;
+        }
+        else if(overflow_group)
+        {
+          // Move to next group.
+          curr_group = (curr_group + LookupPolicy {}.getNext(iteration)) % meta_group.size();
+          iteration++;
+        }
+      }
+
+      if(group_index != -1)
+      {
+        IndexType bucket_index = group_index * GroupBucket::Size + slot_index;
+        new(&buckets[bucket_index]) KeyValuePair(keys[idx], values[idx]);
+      }
+      else
+      {
+        // TODO: Is this even possible?
+        num_failed_inserts += 1;
+      }
+    });
+
+  new_map.m_size = keys.size();
+  new_map.m_loadCount = keys.size();
+
+#ifdef AXOM_DEBUG
+  if(num_failed_inserts > 0)
+  {
+    axom::fmt::print("FlatMap::create: {} elements failed to insert\n");
+  }
+#endif
+
+  return new_map;
+}
+
+}  // namespace axom
+
+#endif

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -196,10 +196,21 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
     AXOM_LAMBDA(IndexType kv_idx) {
       IndexType bucket_idx = key_index_to_bucket[kv_idx];
       IndexType winning_idx = key_index_dedup[bucket_idx];
+      // Place k-v pair at bucket_idx.
       if(kv_idx == winning_idx)
       {
-        // Place k-v pair at bucket_idx.
+#if defined(__CUDA_ARCH__)
+        // HACK: std::pair constructor is not host-device annotated, but CUDA
+        // requires passing in --expt-relaxed-constexpr for it to work.
+        // Instead of requiring this flag, construct each member of the pair
+        // individually.
+        KeyType& key_dst = const_cast<KeyType&>(buckets[bucket_idx].get().first);
+        ValueType& value_dst = buckets[bucket_idx].get().second;
+        new(&key_dst) KeyType {keys[kv_idx]};
+        new(&value_dst) ValueType {values[kv_idx]};
+#else
         new(&buckets[bucket_idx]) KeyValuePair(keys[kv_idx], values[kv_idx]);
+#endif
 #ifdef AXOM_USE_RAJA
         total_inserts += 1;
 #else

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -66,6 +66,7 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
   FlatMap new_map(allocator);
   new_map.reserve(num_elems);
 
+  using RajaAtomic = typename axom::execution_space<ExecSpace>::atomic_policy;
   using RajaReduce = typename axom::execution_space<ExecSpace>::reduce_policy;
   using HashResult = typename Hash::result_type;
   using GroupBucket = detail::flat_map::GroupBucket;
@@ -83,12 +84,10 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
   Array<detail::SpinLock> lock_vec(num_groups, num_groups, allocator.get());
   const auto group_locks = lock_vec.view();
 
-  // Add a counter for failed inserts.
-#ifdef AXOM_USE_RAJA
-  RAJA::ReduceSum<RajaReduce, int> num_failed_inserts(0);
-#else
-  int num_failed_inserts = 0;
-#endif
+  // Track assignment of key indices to bucket slots.
+  Array<IndexType> key_index_dedup_vec(0, 0, allocator.get());
+  key_index_dedup_vec.resize(num_groups * GroupBucket::Size, -1);
+  const auto key_index_dedup = key_index_dedup_vec.view();
 
   for_all<ExecSpace>(
     keys.size(),
@@ -104,80 +103,104 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
 
       std::uint8_t hash_8 = static_cast<std::uint8_t>(hash);
 
-      int group_index = -1;
-      int slot_index = -1;
+      IndexType duplicate_bucket_index = -1;
+      IndexType empty_bucket_index = -1;
       int iteration = 0;
       while(iteration < meta_group.size())
       {
-        // Get the overflow state for the current group.
-        bool overflow_group = meta_group[curr_group].template getMaybeOverflowed<true>(hash_8);
-        bool group_locked = false;
-
-        // Try to lock the group if we haven't overflowed.
-        if(!overflow_group)
-        {
-          group_locked = group_locks[curr_group].tryLock();
-        }
+        // Try to lock the group. We do this in a non-blocking manner to avoid
+        // intra-warp progress hazards.
+        bool group_locked = group_locks[curr_group].tryLock();
 
         if(group_locked)
         {
-          // Re-check overflow state now that we've locked the group.
-          // Other threads may have updated the overflow state before
-          // actaully taking the lock.
-          overflow_group = meta_group[curr_group].template getMaybeOverflowed<true>(hash_8);
-          if(!overflow_group)
+          // Every bucket visit - check prior filled buckets for duplicate
+          // keys.
+          int empty_slot_index =
+            meta_group[curr_group].visitHashOrEmptyBucket(hash_8, [&](int matching_slot) {
+              IndexType bucket_index = curr_group * GroupBucket::Size + matching_slot;
+
+              if(key_index_dedup[bucket_index] != -1 &&
+                 keys[key_index_dedup[bucket_index]] == keys[idx])
+              {
+#if defined(AXOM_USE_RAJA)
+                // Highest-indexed kv pair wins.
+                RAJA::atomicMax<RajaAtomic>(&key_index_dedup[bucket_index], idx);
+#else
+                if(key_index_dedup[bucket_index] < idx)
+                {
+                  key_index_dedup[bucket_index] = idx;
+                }
+#endif
+                duplicate_bucket_index = bucket_index;
+              }
+            });
+
+          if(duplicate_bucket_index == -1)
           {
-            slot_index = meta_group[curr_group].getEmptyBucket();
-            if(slot_index != GroupBucket::InvalidSlot)
-            {
-              // We have an empty slot in this group. Place an element.
-              group_index = curr_group;
-              meta_group[curr_group].template setBucket<true>(slot_index, hash_8);
-            }
-            else
+            if(empty_slot_index == GroupBucket::InvalidSlot)
             {
               // Group is full. Set overflow bit for the group.
               meta_group[curr_group].template setOverflow<true>(hash_8);
             }
+            else
+            {
+              // Got to end of probe sequence without a duplicate.
+              // Update empty bucket index.
+              empty_bucket_index = curr_group * GroupBucket::Size + empty_slot_index;
+              meta_group[curr_group].template setBucket<true>(empty_slot_index, hash_8);
+              key_index_dedup[empty_bucket_index] = idx;
+            }
           }
           // Unlock group once we're done.
           group_locks[curr_group].unlock();
-        }
 
-        // Either we got an empty slot to insert in, or we overflowed
-        // on a group we waited on.
-        if(group_index != -1)
-        {
-          // We have an empty slot. Exit.
-          break;
+          if(duplicate_bucket_index != -1 || empty_bucket_index != -1)
+          {
+            // We've found an empty slot or a duplicate key to place the
+            // value at. Empty slots should only occur at the end of the
+            // probe sequence, since we're only inserting.
+            break;
+          }
+          else
+          {
+            // Move to next group.
+            curr_group = (curr_group + LookupPolicy {}.getNext(iteration)) % meta_group.size();
+            iteration++;
+          }
         }
-        else if(overflow_group)
-        {
-          // Move to next group.
-          curr_group = (curr_group + LookupPolicy {}.getNext(iteration)) % meta_group.size();
-          iteration++;
-        }
-      }
-
-      if(group_index != -1)
-      {
-        IndexType bucket_index = group_index * GroupBucket::Size + slot_index;
-        new(&buckets[bucket_index]) KeyValuePair(keys[idx], values[idx]);
-      }
-      else
-      {
-        // TODO: Is this even possible?
-        num_failed_inserts += 1;
       }
     });
 
-  new_map.m_size = keys.size();
-  new_map.m_loadCount = keys.size();
+  // Add a counter for duplicated inserts.
+#ifdef AXOM_USE_RAJA
+  RAJA::ReduceSum<RajaReduce, int> total_inserts(0);
+#else
+  int total_inserts = 0;
+#endif
+
+  // Using key-deduplication map, assign unique k-v pairs to buckets.
+  for_all<ExecSpace>(
+    num_groups * GroupBucket::Size,
+    AXOM_LAMBDA(IndexType bucket_idx) {
+      IndexType kv_idx = key_index_dedup[bucket_idx];
+      if(kv_idx != -1)
+      {
+        // Place k-v pair at bucket_idx.
+        new(&buckets[bucket_idx]) KeyValuePair(keys[kv_idx], values[kv_idx]);
+        total_inserts += 1;
+      }
+    });
+
+  new_map.m_size = total_inserts.get();
+  new_map.m_loadCount = total_inserts.get();
 
 #ifdef AXOM_DEBUG
-  if(num_failed_inserts > 0)
+  if(keys.size() > new_map.size())
   {
-    axom::fmt::print("FlatMap::create: {} elements failed to insert\n");
+    axom::fmt::print("FlatMap::create: inserted {} elements from input of {} pairs\n",
+                     new_map.size(),
+                     keys.size());
   }
 #endif
 

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -83,18 +83,18 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
   // Construct an array of locks per-group. This guards metadata updates for
   // each insertion.
   IndexType num_groups = 1 << ngroups_pow_2;
-  Array<detail::SpinLock> lock_vec(num_groups, num_groups, allocator.get());
+  Array<detail::SpinLock> lock_vec(num_groups, num_groups, allocator.getID());
   const auto group_locks = lock_vec.view();
 
   // Map bucket slots to k-v pair indices. This is used to deduplicate pairs
   // with the same key value.
-  Array<IndexType> key_index_dedup_vec(0, 0, allocator.get());
+  Array<IndexType> key_index_dedup_vec(0, 0, allocator.getID());
   key_index_dedup_vec.resize(num_groups * GroupBucket::Size, -1);
   const auto key_index_dedup = key_index_dedup_vec.view();
 
   // Map k-v pair indices to bucket slots. This is essentially the inverse of
   // the above mapping.
-  Array<IndexType> key_index_to_bucket_vec(num_elems, num_elems, allocator.get());
+  Array<IndexType> key_index_to_bucket_vec(num_elems, num_elems, allocator.getID());
   const auto key_index_to_bucket = key_index_to_bucket_vec.view();
 
   for_all<ExecSpace>(

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -62,7 +62,7 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
 {
   assert(keys.size() == values.size());
 
-  IndexType num_elems = keys.size();
+  const IndexType num_elems = keys.size();
 
   FlatMap new_map(allocator);
   new_map.reserve(num_elems);
@@ -73,13 +73,13 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
   // Grab some needed internal fields from the flat map.
   // We're going to be constructing metadata and the K-V pairs directly
   // in-place.
-  int ngroups_pow_2 = new_map.m_numGroups2;
+  const int ngroups_pow_2 = new_map.m_numGroups2;
   const auto meta_group = new_map.m_metadata.view();
   const auto buckets = new_map.m_buckets.view();
 
   // Construct an array of locks per-group. This guards metadata updates for
   // each insertion.
-  IndexType num_groups = 1 << ngroups_pow_2;
+  const IndexType num_groups = 1 << ngroups_pow_2;
   Array<detail::SpinLock> lock_vec(num_groups, num_groups, allocator.getID());
   const auto group_locks = lock_vec.view();
 
@@ -95,7 +95,7 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
   const auto key_index_to_bucket = key_index_to_bucket_vec.view();
 
   for_all<ExecSpace>(
-    keys.size(),
+    num_elems,
     AXOM_LAMBDA(IndexType idx) {
       // Hash keys.
       auto hash = Hash {}(keys[idx]);

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -203,15 +203,6 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
   new_map.m_size = total_inserts.get();
   new_map.m_loadCount = total_inserts.get();
 
-#ifdef AXOM_DEBUG
-  if(keys.size() > new_map.size())
-  {
-    axom::fmt::print("FlatMap::create: inserted {} elements from input of {} pairs\n",
-                     new_map.size(),
-                     keys.size());
-  }
-#endif
-
   return new_map;
 }
 

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -8,6 +8,7 @@
 
 #include "axom/config.hpp"
 #include "axom/core/FlatMap.hpp"
+#include "axom/core/execution/reductions.hpp"
 
 namespace axom
 {
@@ -66,10 +67,6 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
   FlatMap new_map(allocator);
   new_map.reserve(num_elems);
 
-#ifdef AXOM_USE_RAJA
-  using RajaAtomic = typename axom::execution_space<ExecSpace>::atomic_policy;
-  using RajaReduce = typename axom::execution_space<ExecSpace>::reduce_policy;
-#endif
   using HashResult = typename Hash::result_type;
   using GroupBucket = detail::flat_map::GroupBucket;
 
@@ -130,15 +127,8 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
 
               if(keys[key_index_dedup[bucket_index]] == keys[idx])
               {
-#if defined(AXOM_USE_RAJA)
                 // Highest-indexed kv pair wins.
-                RAJA::atomicMax<RajaAtomic>(&key_index_dedup[bucket_index], idx);
-#else
-                if(key_index_dedup[bucket_index] < idx)
-                {
-                  key_index_dedup[bucket_index] = idx;
-                }
-#endif
+                axom::atomicMax<ExecSpace>(&key_index_dedup[bucket_index], idx);
                 key_index_to_bucket[idx] = bucket_index;
                 duplicate_bucket_index = bucket_index;
               }
@@ -182,13 +172,7 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
     });
 
   // Add a counter for duplicated inserts.
-#ifdef AXOM_USE_RAJA
-  RAJA::ReduceSum<RajaReduce, IndexType> total_inserts(0);
-#else
-  axom::Array<IndexType> total_inserts_vec(1);
-  const auto total_inserts = total_inserts_vec.view();
-  total_inserts[0] = 0;
-#endif
+  axom::ReduceSum<ExecSpace, IndexType> total_inserts(0);
 
   // Using key-deduplication map, assign unique k-v pairs to buckets.
   for_all<ExecSpace>(
@@ -211,21 +195,12 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
 #else
         new(&buckets[bucket_idx]) KeyValuePair(keys[kv_idx], values[kv_idx]);
 #endif
-#ifdef AXOM_USE_RAJA
         total_inserts += 1;
-#else
-        total_inserts[0]++;
-#endif
       }
     });
 
-#ifdef AXOM_USE_RAJA
   new_map.m_size = total_inserts.get();
   new_map.m_loadCount = total_inserts.get();
-#else
-  new_map.m_size = total_inserts[0];
-  new_map.m_loadCount = total_inserts[0];
-#endif
 
   return new_map;
 }

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -84,10 +84,16 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
   Array<detail::SpinLock> lock_vec(num_groups, num_groups, allocator.get());
   const auto group_locks = lock_vec.view();
 
-  // Track assignment of key indices to bucket slots.
+  // Map bucket slots to k-v pair indices. This is used to deduplicate pairs
+  // with the same key value.
   Array<IndexType> key_index_dedup_vec(0, 0, allocator.get());
   key_index_dedup_vec.resize(num_groups * GroupBucket::Size, -1);
   const auto key_index_dedup = key_index_dedup_vec.view();
+
+  // Map k-v pair indices to bucket slots. This is essentially the inverse of
+  // the above mapping.
+  Array<IndexType> key_index_to_bucket_vec(num_elems, num_elems, allocator.get());
+  const auto key_index_to_bucket = key_index_to_bucket_vec.view();
 
   for_all<ExecSpace>(
     keys.size(),
@@ -120,8 +126,7 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
             meta_group[curr_group].visitHashOrEmptyBucket(hash_8, [&](int matching_slot) {
               IndexType bucket_index = curr_group * GroupBucket::Size + matching_slot;
 
-              if(key_index_dedup[bucket_index] != -1 &&
-                 keys[key_index_dedup[bucket_index]] == keys[idx])
+              if(keys[key_index_dedup[bucket_index]] == keys[idx])
               {
 #if defined(AXOM_USE_RAJA)
                 // Highest-indexed kv pair wins.
@@ -132,6 +137,7 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
                   key_index_dedup[bucket_index] = idx;
                 }
 #endif
+                key_index_to_bucket[idx] = bucket_index;
                 duplicate_bucket_index = bucket_index;
               }
             });
@@ -150,6 +156,7 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
               empty_bucket_index = curr_group * GroupBucket::Size + empty_slot_index;
               meta_group[curr_group].template setBucket<true>(empty_slot_index, hash_8);
               key_index_dedup[empty_bucket_index] = idx;
+              key_index_to_bucket[idx] = empty_bucket_index;
             }
           }
           // Unlock group once we're done.
@@ -181,10 +188,11 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
 
   // Using key-deduplication map, assign unique k-v pairs to buckets.
   for_all<ExecSpace>(
-    num_groups * GroupBucket::Size,
-    AXOM_LAMBDA(IndexType bucket_idx) {
-      IndexType kv_idx = key_index_dedup[bucket_idx];
-      if(kv_idx != -1)
+    num_elems,
+    AXOM_LAMBDA(IndexType kv_idx) {
+      IndexType bucket_idx = key_index_to_bucket[kv_idx];
+      IndexType winning_idx = key_index_dedup[bucket_idx];
+      if(kv_idx == winning_idx)
       {
         // Place k-v pair at bucket_idx.
         new(&buckets[bucket_idx]) KeyValuePair(keys[kv_idx], values[kv_idx]);

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -66,8 +66,10 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
   FlatMap new_map(allocator);
   new_map.reserve(num_elems);
 
+#ifdef AXOM_USE_RAJA
   using RajaAtomic = typename axom::execution_space<ExecSpace>::atomic_policy;
   using RajaReduce = typename axom::execution_space<ExecSpace>::reduce_policy;
+#endif
   using HashResult = typename Hash::result_type;
   using GroupBucket = detail::flat_map::GroupBucket;
 
@@ -181,9 +183,11 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
 
   // Add a counter for duplicated inserts.
 #ifdef AXOM_USE_RAJA
-  RAJA::ReduceSum<RajaReduce, int> total_inserts(0);
+  RAJA::ReduceSum<RajaReduce, IndexType> total_inserts(0);
 #else
-  int total_inserts = 0;
+  axom::Array<IndexType> total_inserts_vec(1);
+  const auto total_inserts = total_inserts_vec.view();
+  total_inserts[0] = 0;
 #endif
 
   // Using key-deduplication map, assign unique k-v pairs to buckets.
@@ -196,12 +200,21 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
       {
         // Place k-v pair at bucket_idx.
         new(&buckets[bucket_idx]) KeyValuePair(keys[kv_idx], values[kv_idx]);
+#ifdef AXOM_USE_RAJA
         total_inserts += 1;
+#else
+        total_inserts[0]++;
+#endif
       }
     });
 
+#ifdef AXOM_USE_RAJA
   new_map.m_size = total_inserts.get();
   new_map.m_loadCount = total_inserts.get();
+#else
+  new_map.m_size = total_inserts[0];
+  new_map.m_loadCount = total_inserts[0];
+#endif
 
   return new_map;
 }

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -175,6 +175,24 @@ struct GroupBucket
     return InvalidSlot;
   }
 
+  template <typename Func>
+  AXOM_HOST_DEVICE int visitHashOrEmptyBucket(std::uint8_t hash, Func&& visitor) const
+  {
+    std::uint8_t reducedHash = reduceHash(hash);
+    for(int i = 0; i < Size; i++)
+    {
+      if(metadata.buckets[i] == reducedHash)
+      {
+        visitor(i);
+      }
+      else if(metadata.buckets[i] == GroupBucket::Empty)
+      {
+        return i;
+      }
+    }
+    return InvalidSlot;
+  }
+
   template <bool Atomic = false>
   AXOM_HOST_DEVICE void setBucket(int index, std::uint8_t hash)
   {

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -175,6 +175,19 @@ struct GroupBucket
     return InvalidSlot;
   }
 
+  /*!
+   * \brief Visits matching hash buckets until an empty bucket is encountered.
+   *
+   *  This is used when performing batched insertion: since elements are only
+   *  inserted, not deleted, an empty bucket will always be encountered only at
+   *  the very end of a given probe sequence.
+   *  The visitor function is used to allow for detecting duplicate keys.
+   *
+   * \param [in] hash reduced hash to search for
+   * \param [in] visitor functor to call for each matching bucket slot
+   *
+   * \return the first empty slot found, or InvalidSlot
+   */
   template <typename Func>
   AXOM_HOST_DEVICE int visitHashOrEmptyBucket(std::uint8_t hash, Func&& visitor) const
   {

--- a/src/axom/core/examples/CMakeLists.txt
+++ b/src/axom/core/examples/CMakeLists.txt
@@ -96,3 +96,10 @@ if(AXOM_ENABLE_TESTS)
         endif()
     endforeach()
 endif()
+
+axom_add_executable(
+    NAME        core_flatmap_perf_ex
+    SOURCES     core_flatmap_perf.cpp
+    OUTPUT_DIR  ${EXAMPLE_OUTPUT_DIRECTORY}
+    DEPENDS_ON  core
+    FOLDER      axom/core/examples )

--- a/src/axom/core/examples/core_flatmap_perf.cpp
+++ b/src/axom/core/examples/core_flatmap_perf.cpp
@@ -1,0 +1,183 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/core/Array.hpp"
+#include "axom/core/FlatMap.hpp"
+#include "axom/core/FlatMapView.hpp"
+#include "axom/core/execution/for_all.hpp"
+#include "axom/core/execution/runtime_policy.hpp"
+#include "axom/core/utilities/Timer.hpp"
+
+#include "axom/fmt.hpp"
+#include "axom/CLI11.hpp"
+
+struct InputParams
+{
+  using RuntimePolicy = axom::runtime_policy::Policy;
+
+  axom::IndexType num_elems = 10000;
+  RuntimePolicy runtime_policy = RuntimePolicy::seq;
+  axom::IndexType rep_count = 100;
+
+public:
+  void parse(int argc, char** argv, axom::CLI::App& app)
+  {
+    app.add_option("-n, --numElems", num_elems)->description("Number of elements to insert");
+
+    app.add_option("-p, --policy", runtime_policy)
+      ->description("Set runtime policy for test")
+      ->capture_default_str()
+      ->transform(axom::CLI::CheckedTransformer(axom::runtime_policy::s_nameToPolicy));
+
+    app.add_option("-r, --repCount", rep_count)->description("Number of repetitions to run");
+
+    app.get_formatter()->column_width(60);
+
+    app.parse(argc, argv);
+  }
+};
+
+/*!
+ * \brief Sample an RNG with lookahead.
+ *  Based on PCG implementation: https://www.pcg-random.org
+ */
+AXOM_HOST_DEVICE uint64_t SampleRNG(uint64_t seed, int distance)
+{
+  uint64_t a = 6364136223846793005ULL;
+  uint64_t output = seed;
+
+  // LCG recurrence relation:
+  //  x_n+1 = a*x_n mod m (m is just size of integer seed, i.e. 2^64)
+  // Closed-form solution is:
+  //  x_n+1 = a^n*x_0 mod m
+
+  // Compute modular exponent a^n mod 2^64
+  if(distance > 0)
+  {
+    uint64_t a_n = 1;
+    int n = distance;
+    while(n > 0)
+    {
+      if(n % 2 == 1)
+      {
+        a_n *= a;
+      }
+      a = a * a;
+      n /= 2;
+    }
+    output *= a_n;
+  }
+
+  uint32_t xorshifted = ((output >> 18u) ^ output) >> 27u;
+  uint32_t rot = output >> 59u;
+  return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
+}
+
+template <typename ExecPolicy, typename T>
+void test_flatmap_init_and_query(axom::IndexType num_elems, axom::IndexType rep_count)
+{
+  int allocatorID = axom::execution_space<ExecPolicy>::allocatorID();
+
+  axom::utilities::Timer initTimer(false);
+  axom::utilities::Timer findTimer(false);
+  std::random_device rnd_dev {};
+  for(int i = 0; i < rep_count; i++)
+  {
+    axom::Array<T> keys_vec(num_elems, num_elems, allocatorID);
+    axom::Array<T> values_vec(num_elems, num_elems, allocatorID);
+    const auto keys = keys_vec.view();
+    const auto values = values_vec.view();
+
+    // Get a random seed
+    uint64_t rnd = rand();
+    rnd <<= 32;
+    rnd += rand();
+
+    // Generate random keys and values
+    axom::for_all<ExecPolicy>(
+      num_elems,
+      AXOM_LAMBDA(axom::IndexType index) {
+        keys[index] = SampleRNG(rnd, 2 * index);
+        values[index] = SampleRNG(rnd, 2 * index + 1);
+      });
+
+    // Construct a flat map in a single batch.
+    initTimer.start();
+    auto new_map =
+      axom::FlatMap<T, T>::template create<ExecPolicy>(keys, values, axom::Allocator {allocatorID});
+    initTimer.stop();
+
+    // Get a view of the map.
+    auto map_view = new_map.view();
+
+    findTimer.start();
+    // Test use of FlatMap::find() within a kernel.
+    axom::for_all<ExecPolicy>(
+      num_elems,
+      AXOM_LAMBDA(axom::IndexType index) {
+        auto it = map_view.find(keys[index]);
+        if(it != map_view.end())
+        {
+          T value = it->second;
+          values[index] = value * 2;
+        }
+      });
+    findTimer.stop();
+  }
+
+  axom::fmt::print(" - Average construction time: {:.8f} seconds\n",
+                   initTimer.elapsedTimeInSec() / rep_count);
+  axom::fmt::print(" - Average construction throughput: {:.3f} keys/s\n",
+                   (num_elems * rep_count) / initTimer.elapsedTimeInSec());
+  axom::fmt::print(" - Average query time: {:.8f} seconds\n",
+                   findTimer.elapsedTimeInSec() / rep_count);
+  axom::fmt::print(" - Average query throughput: {:.3f} keys/s\n",
+                   (num_elems * rep_count) / findTimer.elapsedTimeInSec());
+}
+
+int main(int argc, char** argv)
+{
+  axom::CLI::App app {"Driver for flat-map performance tests"};
+
+  InputParams params;
+  try
+  {
+    params.parse(argc, argv, app);
+  }
+  catch(const axom::CLI::ParseError& e)
+  {
+    auto retval = app.exit(e);
+    exit(retval);
+  }
+
+  axom::fmt::print("Runtime policy: {}\n", axom::runtime_policy::policyToName(params.runtime_policy));
+  axom::fmt::print("Number of key-value pairs: {}\n", params.num_elems);
+  axom::fmt::print("Repetition count: {}\n", params.rep_count);
+
+  using RuntimePolicy = axom::runtime_policy::Policy;
+
+  if(params.runtime_policy == RuntimePolicy::seq)
+  {
+    test_flatmap_init_and_query<axom::SEQ_EXEC, int>(params.num_elems, params.rep_count);
+  }
+#ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
+  else if(params.runtime_policy == RuntimePolicy::omp)
+  {
+    test_flatmap_init_and_query<axom::OMP_EXEC, int>(params.num_elems, params.rep_count);
+  }
+#endif
+#ifdef AXOM_RUNTIME_POLICY_USE_CUDA
+  else if(params.runtime_policy == RuntimePolicy::cuda)
+  {
+    test_flatmap_init_and_query<axom::CUDA_EXEC<256>, int>(params.num_elems, params.rep_count);
+  }
+#endif
+#ifdef AXOM_RUNTIME_POLICY_USE_HIP
+  else if(params.runtime_policy == RuntimePolicy::hip)
+  {
+    test_flatmap_init_and_query<axom::HIP_EXEC<256>, int>(params.num_elems, params.rep_count);
+  }
+#endif
+}

--- a/src/axom/core/examples/core_flatmap_perf.cpp
+++ b/src/axom/core/examples/core_flatmap_perf.cpp
@@ -3,6 +3,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+/*! \file core_flatmap_perf.cpp
+ *  \brief This example measures performance of the FlatMap batched construction
+ *   interface and FlatMapView, demonstrating portability between CPU, GPU, and OpenMP.
+ */
+
 #include "axom/core/Array.hpp"
 #include "axom/core/FlatMap.hpp"
 #include "axom/core/FlatMapView.hpp"

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -124,7 +124,7 @@ AXOM_TYPED_TEST(core_flatmap, prealloc_buckets)
   {
     MapType test_map(size);
     EXPECT_EQ(0, test_map.size());
-    EXPECT_LE(size, test_map.bucket_count());
+    EXPECT_LE(size, test_map.bucket_count() * test_map.max_load_factor());
   }
 }
 

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -114,6 +114,20 @@ AXOM_TYPED_TEST(core_flatmap, default_init)
   EXPECT_EQ(true, test_map.empty());
 }
 
+AXOM_TYPED_TEST(core_flatmap, prealloc_buckets)
+{
+  using MapType = typename TestFixture::MapType;
+
+  const std::vector<int> sizes = {100, 400, 1000, 4000, 10000};
+
+  for(int size : sizes)
+  {
+    MapType test_map(size);
+    EXPECT_EQ(0, test_map.size());
+    EXPECT_LE(size, test_map.bucket_count());
+  }
+}
+
 AXOM_TYPED_TEST(core_flatmap, insert_only)
 {
   using MapType = typename TestFixture::MapType;

--- a/src/axom/core/tests/core_flatmap_for_all.hpp
+++ b/src/axom/core/tests/core_flatmap_for_all.hpp
@@ -304,8 +304,10 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_with_dups)
     auto expected_val1 = this->getValue(i * 10.0 + 5.0);
     auto expected_val2 = this->getValue(i * 10.0 + 7.0);
     EXPECT_EQ(1, test_map.count(expected_key));
-    EXPECT_TRUE((test_map.at(expected_key) == expected_val1) ||
-                (test_map.at(expected_key) == expected_val2));
+    // Second key-value pair in batch-order should overwrite first pair with
+    // same key.
+    EXPECT_EQ(expected_val2, test_map.at(expected_key));
+    EXPECT_NE(expected_val1, test_map.at(expected_key));
   }
 
   // Check that we only have one instance of every key in the map
@@ -329,7 +331,8 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_with_dups)
     auto expected_val1 = this->getValue(i * 10.0 + 5.0);
     auto expected_val2 = this->getValue(i * 10.0 + 7.0);
     EXPECT_EQ(kv_out[i].first, expected_key);
-    EXPECT_TRUE((kv_out[i].second == expected_val1) || (kv_out[i].second == expected_val2));
+    EXPECT_EQ(expected_val2, test_map.at(expected_key));
+    EXPECT_NE(expected_val1, test_map.at(expected_key));
   }
 }
 

--- a/src/axom/core/tests/core_flatmap_for_all.hpp
+++ b/src/axom/core/tests/core_flatmap_for_all.hpp
@@ -212,8 +212,6 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batched)
   using MapType = typename TestFixture::MapType;
   using ExecSpace = typename TestFixture::ExecSpace;
 
-  MapType test_map;
-
   const int NUM_ELEMS = 100;
 
   axom::Array<int> keys_vec(NUM_ELEMS);
@@ -228,8 +226,18 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batched)
     values_vec[i] = value;
   }
 
+  // Copy keys and values to GPU space.
+  axom::Array<int> keys_gpu(keys_vec, this->getKernelAllocatorID());
+  axom::Array<double> values_gpu(values_vec, this->getKernelAllocatorID());
+
   // Construct a flat map with the key-value pairs.
-  test_map = MapType::template create<ExecSpace>(keys_vec, values_vec);
+  MapType test_map_gpu =
+    MapType::template create<ExecSpace>(keys_gpu,
+                                        values_gpu,
+                                        axom::Allocator {this->getKernelAllocatorID()});
+
+  // Copy back flat map to host for testing.
+  MapType test_map(test_map_gpu, axom::Allocator {this->getHostAllocatorID()});
 
   // Check contents on the host
   EXPECT_EQ(NUM_ELEMS, test_map.size());
@@ -248,8 +256,6 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_with_dups)
 {
   using MapType = typename TestFixture::MapType;
   using ExecSpace = typename TestFixture::ExecSpace;
-
-  MapType test_map;
 
   const int NUM_ELEMS = 100;
 
@@ -275,8 +281,18 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_with_dups)
     values_vec[i + NUM_ELEMS] = value;
   }
 
+  // Copy keys and values to GPU space.
+  axom::Array<int> keys_gpu(keys_vec, this->getKernelAllocatorID());
+  axom::Array<double> values_gpu(values_vec, this->getKernelAllocatorID());
+
   // Construct a flat map with the key-value pairs.
-  test_map = MapType::template create<ExecSpace>(keys_vec, values_vec);
+  MapType test_map_gpu =
+    MapType::template create<ExecSpace>(keys_gpu,
+                                        values_gpu,
+                                        axom::Allocator {this->getKernelAllocatorID()});
+
+  // Copy back flat map to host for testing.
+  MapType test_map(test_map_gpu, axom::Allocator {this->getHostAllocatorID()});
 
   // Check contents on the host. Only one of the duplicate keys should remain.
   EXPECT_EQ(NUM_ELEMS, test_map.size());
@@ -348,8 +364,18 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_constant_hash)
     values_vec[i] = value;
   }
 
+  // Copy keys and values to GPU space.
+  axom::Array<int> keys_gpu(keys_vec, this->getKernelAllocatorID());
+  axom::Array<double> values_gpu(values_vec, this->getKernelAllocatorID());
+
   // Construct a flat map with the key-value pairs.
-  MapType test_map = MapType::template create<ExecSpace>(keys_vec, values_vec);
+  MapType test_map_gpu =
+    MapType::template create<ExecSpace>(keys_gpu,
+                                        values_gpu,
+                                        axom::Allocator {this->getKernelAllocatorID()});
+
+  // Copy back flat map to host for testing.
+  MapType test_map(test_map_gpu, axom::Allocator {this->getHostAllocatorID()});
 
   // Check contents on the host
   EXPECT_EQ(NUM_ELEMS, test_map.size());

--- a/src/axom/core/tests/core_flatmap_for_all.hpp
+++ b/src/axom/core/tests/core_flatmap_for_all.hpp
@@ -243,3 +243,76 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batched)
     EXPECT_EQ(expected_val, test_map.at(expected_key));
   }
 }
+
+AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_with_dups)
+{
+  using MapType = typename TestFixture::MapType;
+  using ExecSpace = typename TestFixture::ExecSpace;
+
+  MapType test_map;
+
+  const int NUM_ELEMS = 100;
+
+  axom::Array<int> keys_vec(NUM_ELEMS * 2);
+  axom::Array<double> values_vec(NUM_ELEMS * 2);
+  // Create batch of array elements
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 5.0);
+
+    keys_vec[i] = key;
+    values_vec[i] = value;
+  }
+
+  // Add some duplicate key values
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 7.0);
+
+    keys_vec[i + NUM_ELEMS] = key;
+    values_vec[i + NUM_ELEMS] = value;
+  }
+
+  // Construct a flat map with the key-value pairs.
+  test_map = MapType::template create<ExecSpace>(keys_vec, values_vec);
+
+  // Check contents on the host. Only one of the duplicate keys should remain.
+  EXPECT_EQ(NUM_ELEMS, test_map.size());
+
+  // Check that every element we inserted is in the map
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto expected_key = this->getKey(i);
+    auto expected_val1 = this->getValue(i * 10.0 + 5.0);
+    auto expected_val2 = this->getValue(i * 10.0 + 7.0);
+    EXPECT_EQ(1, test_map.count(expected_key));
+    EXPECT_TRUE((test_map.at(expected_key) == expected_val1) ||
+                (test_map.at(expected_key) == expected_val2));
+  }
+
+  // Check that we only have one instance of every key in the map
+  axom::Array<std::pair<int, double>> kv_out(NUM_ELEMS);
+  int index = 0;
+  for(auto &pair : test_map)
+  {
+    EXPECT_LT(index, NUM_ELEMS);
+    kv_out[index++] = {pair.first, pair.second};
+  }
+
+  std::sort(kv_out.begin(),
+            kv_out.end(),
+            [](const std::pair<int, double> &first, const std::pair<int, double> &second) -> bool {
+              return first.first < second.first;
+            });
+
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto expected_key = this->getKey(i);
+    auto expected_val1 = this->getValue(i * 10.0 + 5.0);
+    auto expected_val2 = this->getValue(i * 10.0 + 7.0);
+    EXPECT_EQ(kv_out[i].first, expected_key);
+    EXPECT_TRUE((kv_out[i].second == expected_val1) || (kv_out[i].second == expected_val2));
+  }
+}

--- a/src/axom/core/tests/core_flatmap_for_all.hpp
+++ b/src/axom/core/tests/core_flatmap_for_all.hpp
@@ -345,6 +345,11 @@ struct ConstantHash
   AXOM_HOST_DEVICE axom::IndexType operator()(KeyType) const { return 0; }
 };
 
+/**
+ * Test hash map with a hash that returns the same value for all elements.
+ * Even with worst-case hash collision behavior, the FlatMap should
+ * nevertheless be correctly constructible and queryable.
+ */
 AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_constant_hash)
 {
   using ExecSpace = typename TestFixture::ExecSpace;

--- a/src/axom/core/tests/core_flatmap_for_all.hpp
+++ b/src/axom/core/tests/core_flatmap_for_all.hpp
@@ -206,3 +206,40 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_and_modify)
     EXPECT_EQ(test_map.count(i), false);
   }
 }
+
+AXOM_TYPED_TEST(core_flatmap_forall, insert_batched)
+{
+  using MapType = typename TestFixture::MapType;
+  using ExecSpace = typename TestFixture::ExecSpace;
+
+  MapType test_map;
+
+  const int NUM_ELEMS = 100;
+
+  axom::Array<int> keys_vec(NUM_ELEMS);
+  axom::Array<double> values_vec(NUM_ELEMS);
+  // Create batch of array elements
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 5.0);
+
+    keys_vec[i] = key;
+    values_vec[i] = value;
+  }
+
+  // Construct a flat map with the key-value pairs.
+  test_map = MapType::template create<ExecSpace>(keys_vec, values_vec);
+
+  // Check contents on the host
+  EXPECT_EQ(NUM_ELEMS, test_map.size());
+
+  // Check that every element we inserted is in the map
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto expected_key = this->getKey(i);
+    auto expected_val = this->getValue(i * 10.0 + 5.0);
+    EXPECT_EQ(1, test_map.count(expected_key));
+    EXPECT_EQ(expected_val, test_map.at(expected_key));
+  }
+}

--- a/src/axom/core/tests/core_flatmap_for_all.hpp
+++ b/src/axom/core/tests/core_flatmap_for_all.hpp
@@ -316,3 +316,50 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_with_dups)
     EXPECT_TRUE((kv_out[i].second == expected_val1) || (kv_out[i].second == expected_val2));
   }
 }
+
+template <typename KeyType>
+struct ConstantHash
+{
+  using argument_type = KeyType;
+  using result_type = axom::IndexType;
+
+  AXOM_HOST_DEVICE axom::IndexType operator()(KeyType) const { return 0; }
+};
+
+AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_constant_hash)
+{
+  using ExecSpace = typename TestFixture::ExecSpace;
+  using KeyType = typename TestFixture::KeyType;
+  using ValueType = typename TestFixture::ValueType;
+
+  using MapType = axom::FlatMap<KeyType, ValueType, ConstantHash<KeyType>>;
+
+  const int NUM_ELEMS = 100;
+
+  axom::Array<int> keys_vec(NUM_ELEMS);
+  axom::Array<double> values_vec(NUM_ELEMS);
+  // Create batch of array elements
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 5.0);
+
+    keys_vec[i] = key;
+    values_vec[i] = value;
+  }
+
+  // Construct a flat map with the key-value pairs.
+  MapType test_map = MapType::template create<ExecSpace>(keys_vec, values_vec);
+
+  // Check contents on the host
+  EXPECT_EQ(NUM_ELEMS, test_map.size());
+
+  // Check that every element we inserted is in the map
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto expected_key = this->getKey(i);
+    auto expected_val = this->getValue(i * 10.0 + 5.0);
+    EXPECT_EQ(1, test_map.count(expected_key));
+    EXPECT_EQ(expected_val, test_map.at(expected_key));
+  }
+}


### PR DESCRIPTION
# Summary

Adds a method `FlatMap::create()` for constructing a flat hash map over a batch of corresponding key-value pairs.
  - A template parameter `ExecSpace` is used to specify whether the batched construction happens on the CPU, GPU, or over multiple threads via OpenMP. The passed-in `allocator` argument must be accessible from the specified execution space.
  - If two equivalent keys are inserted, the key-value pair with the higher index is selected.

Also adds a benchmark example for `FlatMap`, which tests the performance of both batched insertion and lookups.