### PR TITLE
Fixes several bugs related to undefined behavior

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -67,6 +67,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Fixes build with `ninja` generator
 - Primal: Fixes a `BoundingBox` constructor with zero (or fewer) points
 - Sina: Fixes configuration variables related to inclusion of `AdiakWriter.hpp` and to hdf5 support in `sina_fortran_interface.f`
+- Spin: Fixes undefined behavior in BVH tree construction associated with using signed indexes
+- Spin: Fixes undefined behavior in UniformGrid construction associated with invalid geometry bounding boxes
+- Core: Fixes undefined behavior in MapCollection when searching empty collections
 
 ###  Deprecated
 - Primal: Deprecates `Triangle::checkInTriangle(pt)`. Use `Triangle::contains(pt)` instead.

--- a/src/axom/core/Macros.hpp
+++ b/src/axom/core/Macros.hpp
@@ -141,8 +141,8 @@
  *  when compiling and linking with -fsanitize=undefined
  */
 #if defined(__has_attribute)
-  #if __has_attribute(no_sanitize_undefined)
-    #define AXOM_SUPPRESS_UBSAN __attribute__((no_sanitize_undefined))
+  #if __has_attribute(no_sanitize)
+    #define AXOM_SUPPRESS_UBSAN __attribute__((no_sanitize("undefined")))
   #else
     #define AXOM_SUPPRESS_UBSAN
   #endif

--- a/src/axom/core/MapCollection.hpp
+++ b/src/axom/core/MapCollection.hpp
@@ -179,8 +179,15 @@ public:
   ///
   bool hasItem(const std::string& name) const
   {
-    typename MapType::const_iterator mit = m_name2idx_map.find(name);
-    return (mit != m_name2idx_map.end() ? true : false);
+    if(m_name2idx_map.empty())
+    {
+      return false;
+    }
+    else
+    {
+      typename MapType::const_iterator mit = m_name2idx_map.find(name);
+      return (mit != m_name2idx_map.end() ? true : false);
+    }
   }
 
   ///
@@ -193,15 +200,29 @@ public:
   ///
   T* getItem(const std::string& name)
   {
-    typename MapType::iterator mit = m_name2idx_map.find(name);
-    return (mit != m_name2idx_map.end() ? m_items[mit->second] : nullptr);
+    if(m_name2idx_map.empty())
+    {
+      return nullptr;
+    }
+    else
+    {
+      typename MapType::iterator mit = m_name2idx_map.find(name);
+      return (mit != m_name2idx_map.end() ? m_items[mit->second] : nullptr);
+    }
   }
 
   ///
   T const* getItem(const std::string& name) const
   {
-    typename MapType::const_iterator mit = m_name2idx_map.find(name);
-    return (mit != m_name2idx_map.end() ? m_items[mit->second] : nullptr);
+    if(m_name2idx_map.empty())
+    {
+      return nullptr;
+    }
+    else
+    {
+      typename MapType::const_iterator mit = m_name2idx_map.find(name);
+      return (mit != m_name2idx_map.end() ? m_items[mit->second] : nullptr);
+    }
   }
 
   ///
@@ -226,8 +247,15 @@ public:
   ///
   IndexType getItemIndex(const std::string& name) const
   {
-    typename MapType::const_iterator mit = m_name2idx_map.find(name);
-    return (mit != m_name2idx_map.end() ? mit->second : InvalidIndex);
+    if(m_name2idx_map.empty())
+    {
+      return InvalidIndex;
+    }
+    else
+    {
+      typename MapType::const_iterator mit = m_name2idx_map.find(name);
+      return (mit != m_name2idx_map.end() ? mit->second : InvalidIndex);
+    }
   }
 
   ///

--- a/src/axom/core/MapCollection.hpp
+++ b/src/axom/core/MapCollection.hpp
@@ -185,7 +185,7 @@ public:
     }
     else
     {
-      typename MapType::const_iterator mit = m_name2idx_map.find(name);
+      const auto mit = m_name2idx_map.find(name);
       return (mit != m_name2idx_map.end() ? true : false);
     }
   }
@@ -193,8 +193,8 @@ public:
   ///
   bool hasItem(IndexType idx) const
   {
-    return (idx >= 0 && static_cast<unsigned>(idx) < m_items.size() &&
-            m_items[static_cast<unsigned>(idx)]);
+    return (idx >= 0 && static_cast<std::size_t>(idx) < m_items.size() &&
+            m_items[static_cast<std::size_t>(idx)]);
   }
 
   ///
@@ -206,7 +206,7 @@ public:
     }
     else
     {
-      typename MapType::iterator mit = m_name2idx_map.find(name);
+      const auto mit = m_name2idx_map.find(name);
       return (mit != m_name2idx_map.end() ? m_items[mit->second] : nullptr);
     }
   }
@@ -220,7 +220,7 @@ public:
     }
     else
     {
-      typename MapType::const_iterator mit = m_name2idx_map.find(name);
+      const auto mit = m_name2idx_map.find(name);
       return (mit != m_name2idx_map.end() ? m_items[mit->second] : nullptr);
     }
   }
@@ -228,19 +228,19 @@ public:
   ///
   T* getItem(IndexType idx)
   {
-    return (hasItem(idx) ? m_items[static_cast<unsigned>(idx)] : nullptr);
+    return (hasItem(idx) ? m_items[static_cast<std::size_t>(idx)] : nullptr);
   }
 
   ///
   T const* getItem(IndexType idx) const
   {
-    return (hasItem(idx) ? m_items[static_cast<unsigned>(idx)] : nullptr);
+    return (hasItem(idx) ? m_items[static_cast<std::size_t>(idx)] : nullptr);
   }
 
   ///
   const std::string& getItemName(IndexType idx) const
   {
-    return (hasItem(idx) ? m_items[static_cast<unsigned>(idx)]->getName()
+    return (hasItem(idx) ? m_items[static_cast<std::size_t>(idx)]->getName()
                          : axom::utilities::string::InvalidName);
   }
 
@@ -253,7 +253,7 @@ public:
     }
     else
     {
-      typename MapType::const_iterator mit = m_name2idx_map.find(name);
+      const auto mit = m_name2idx_map.find(name);
       return (mit != m_name2idx_map.end() ? mit->second : InvalidIndex);
     }
   }
@@ -316,11 +316,12 @@ template <typename T>
 IndexType MapCollection<T>::getFirstValidIndex() const
 {
   IndexType idx = 0;
-  while(static_cast<unsigned>(idx) < m_items.size() && m_items[static_cast<unsigned>(idx)] == nullptr)
+  while(static_cast<std::size_t>(idx) < m_items.size() &&
+        m_items[static_cast<std::size_t>(idx)] == nullptr)
   {
-    idx++;
+    ++idx;
   }
-  return ((static_cast<unsigned>(idx) < m_items.size()) ? idx : InvalidIndex);
+  return ((static_cast<std::size_t>(idx) < m_items.size()) ? idx : InvalidIndex);
 }
 
 template <typename T>
@@ -332,11 +333,12 @@ IndexType MapCollection<T>::getNextValidIndex(IndexType idx) const
   }
 
   idx++;
-  while(static_cast<unsigned>(idx) < m_items.size() && m_items[static_cast<unsigned>(idx)] == nullptr)
+  while(static_cast<std::size_t>(idx) < m_items.size() &&
+        m_items[static_cast<std::size_t>(idx)] == nullptr)
   {
     idx++;
   }
-  return ((static_cast<unsigned>(idx) < m_items.size()) ? idx : InvalidIndex);
+  return ((static_cast<std::size_t>(idx) < m_items.size()) ? idx : InvalidIndex);
 }
 
 template <typename T>
@@ -389,7 +391,7 @@ T* MapCollection<T>::removeItem(const std::string& name)
 {
   T* ret_val = nullptr;
 
-  typename MapType::iterator mit = m_name2idx_map.find(name);
+  auto mit = m_name2idx_map.find(name);
   if(mit != m_name2idx_map.end())
   {
     IndexType idx = mit->second;
@@ -418,6 +420,6 @@ T* MapCollection<T>::removeItem(IndexType idx)
   }
 }
 
-} /* end namespace axom */
+}  // namespace axom
 
-#endif /* AXOM_MAP_COLLECTIONS_HPP_ */
+#endif  // AXOM_MAP_COLLECTIONS_HPP_

--- a/src/axom/core/MapCollection.hpp
+++ b/src/axom/core/MapCollection.hpp
@@ -179,6 +179,10 @@ public:
   ///
   bool hasItem(const std::string& name) const
   {
+    // Implementation note: Sparsehash requires sentinel values for 'empty' and 'deleted'
+    // entries. Our usage in this class only enforces this when we insert or delete
+    // items from the map, so we add explicit checks for empty maps in functions
+    // that do not mutate the map to avoid undefined behavior.
     if(m_name2idx_map.empty())
     {
       return false;
@@ -200,6 +204,7 @@ public:
   ///
   T* getItem(const std::string& name)
   {
+    // Implementation note: This explicit check avoids undefined behavior. See note above.
     if(m_name2idx_map.empty())
     {
       return nullptr;
@@ -214,6 +219,7 @@ public:
   ///
   T const* getItem(const std::string& name) const
   {
+    // Implementation note: This explicit check avoids undefined behavior. See note above.
     if(m_name2idx_map.empty())
     {
       return nullptr;
@@ -247,6 +253,7 @@ public:
   ///
   IndexType getItemIndex(const std::string& name) const
   {
+    // Implementation note: This explicit check avoids undefined behavior. See note above.
     if(m_name2idx_map.empty())
     {
       return InvalidIndex;

--- a/src/axom/core/tests/core_device_hash.hpp
+++ b/src/axom/core/tests/core_device_hash.hpp
@@ -183,30 +183,30 @@ AXOM_TYPED_TEST(core_device_hash, hash_enum)
   }
 }
 
-namespace
+namespace axom_testing
 {
 template <typename T>
 struct UserVector
 {
   T x, y, z;
 };
-}  // namespace
+}  // namespace axom_testing
 
 // Test that we can correctly specialize a device hash for a user-defined type.
 namespace axom
 {
 template <typename T>
-struct DeviceHash<UserVector<T>>
+struct DeviceHash<axom_testing::UserVector<T>>
 {
-  using argument_type = UserVector<T>;
+  using argument_type = axom_testing::UserVector<T>;
   using result_type = axom::IndexType;
 
-  AXOM_HOST_DEVICE axom::IndexType operator()(UserVector<T> value) const
+  AXOM_HOST_DEVICE axom::IndexType operator()(axom_testing::UserVector<T> value) const
   {
     // Copy byte representation over
-    constexpr int NWORDS = sizeof(UserVector<T>) / sizeof(int);
-    alignas(UserVector<T>) int bytes[NWORDS];
-    *reinterpret_cast<UserVector<T> *>(bytes) = value;
+    constexpr int NWORDS = sizeof(axom_testing::UserVector<T>) / sizeof(int);
+    alignas(axom_testing::UserVector<T>) int bytes[NWORDS];
+    *reinterpret_cast<axom_testing::UserVector<T> *>(bytes) = value;
 
     axom::IndexType hash_result {};
     for(int i = 0; i < NWORDS; i++)
@@ -222,14 +222,14 @@ AXOM_TYPED_TEST(core_device_hash, hash_user_defined)
 {
   using ExecSpace = typename TestFixture::ExecSpace;
 
-  axom::DeviceHash<UserVector<float>> device_hasher;
+  axom::DeviceHash<axom_testing::UserVector<float>> device_hasher;
 
   constexpr int NUM_HASHES = 4;
 
-  UserVector<float> things_to_hash[NUM_HASHES] = {{0.0, 0.0, 0.0},
-                                                  {1.0, 3.0, 5.0},
-                                                  {2.0, 5.0, 8.0},
-                                                  {10.0, 20.0, 30.0}};
+  axom_testing::UserVector<float> things_to_hash[NUM_HASHES] = {{0.0, 0.0, 0.0},
+                                                                {1.0, 3.0, 5.0},
+                                                                {2.0, 5.0, 8.0},
+                                                                {10.0, 20.0, 30.0}};
 
   // Allocate space for hash results.
   int allocatorID = axom::execution_space<ExecSpace>::allocatorID();

--- a/src/axom/inlet/Container.hpp
+++ b/src/axom/inlet/Container.hpp
@@ -1227,9 +1227,9 @@ private:
   std::string m_name;
   Reader& m_reader;
   // Inlet's Root Sidre Group
-  axom::sidre::Group* m_sidreRootGroup;
+  axom::sidre::Group* m_sidreRootGroup {nullptr};
   // This Container's Sidre Group
-  axom::sidre::Group* m_sidreGroup;
+  axom::sidre::Group* m_sidreGroup {nullptr};
   // Hold a reference to the global set of unexpected names so it can be updated when
   // things are added to this Container
   std::vector<std::string>& m_unexpectedNames;

--- a/src/axom/quest/MeshTester.cpp
+++ b/src/axom/quest/MeshTester.cpp
@@ -92,7 +92,7 @@ void findTriMeshIntersections(detail::UMesh* surface_mesh,
       triBboxes[i] = compute_bounding_box(t1);
     }
   }
-  detail::UniformGrid3 ugrid(resolutions, triBboxes, triIdxs);
+  detail::UniformGrid3 ugrid(resolutions, triBboxes.view(), triIdxs.view());
 
   // Iterate through triangle indices *idx.
   // Check against each other triangle with index greater than the index *idx that also shares a UniformGrid bin.

--- a/src/axom/slam/OrderedSet.hpp
+++ b/src/axom/slam/OrderedSet.hpp
@@ -262,8 +262,8 @@ public:
         const double str = m_stride.stride();
         const auto diff = (m_rangeUpper - m_rangeLower);
 
-        // size is 0 if upper==lower, or signs of diff and stride differ
-        return (diff == 0 || ((diff > 0) != (str > 0))) ? 0 : ceil(diff / str);
+        // size is 0 if upper==lower, or stride is 0 or signs of diff and stride differ
+        return (diff == 0 || str == 0 || ((diff > 0) != (str > 0))) ? 0 : ceil(diff / str);
       }
       else
       {

--- a/src/axom/slam/policies/StridePolicies.hpp
+++ b/src/axom/slam/policies/StridePolicies.hpp
@@ -15,8 +15,7 @@
  *   * DEFAULT_VALUE is a public static const IntType
  *   * IS_COMPILE_TIME is a public static const bool
  *   * stride() : IntType  -- returns the stride
- *   * isValid() : bool -- indicates whether the Stride policy of the set is
- *     valid
+ *   * isValid() : bool -- indicates whether the Stride policy of the set is valid
  *   * [optional]
  *   * operator(): IntType -- alternate accessor for the stride value
  *

--- a/src/axom/slam/tests/slam_set_RangeSet.cpp
+++ b/src/axom/slam/tests/slam_set_RangeSet.cpp
@@ -396,9 +396,7 @@ TEST(slam_generic_range_set, concrete_parent_set)
     EXPECT_EQ(parentSet[pos], childParSet[pos]);
   }
 
-  // Note: Equality is based on Base class Set
-  //-- it does not differentiate based on whether a set is a subset of another
-  // set
+  // Note: Equality is based on Base class Set -- it does not differentiate based on whether a set is a subset of another set
   EXPECT_EQ(childSet, nonChildSet);
 }
 

--- a/src/axom/spin/MortonIndex.hpp
+++ b/src/axom/spin/MortonIndex.hpp
@@ -126,10 +126,14 @@ template <typename CoordType, typename MortonIndexType, typename Derived>
 struct MortonBase
 {
   // static assert to ensure we only instantiate on integral types
-  AXOM_STATIC_ASSERT_MSG(std::is_integral<CoordType>::value,
-                         "Coordtype must be integral for Morton indexing");
-  AXOM_STATIC_ASSERT_MSG(std::is_integral<MortonIndexType>::value,
-                         "MortonIndexType must be integral for Morton indexing");
+  static_assert(std::is_integral<CoordType>::value,
+                "Coordtype must be integral for Morton indexing");
+  static_assert(std::is_integral<MortonIndexType>::value,
+                "MortonIndexType must be integral for Morton indexing");
+
+  // we get undefined behavior w/ our bit shifts if using signed types
+  static_assert(std::is_unsigned<MortonIndexType>::value,
+                "MortonIndexType must be an unsigned type");
 
 private:
   // Magic numbers for efficient base-2 log-like function -- maxSetBit()
@@ -232,15 +236,12 @@ struct Mortonizer<CoordType, MortonIndexType, 2>
   // Magic numbers in 2D
   AXOM_HOST_DEVICE static MortonIndexType GetB(int i)
   {
-    constexpr MortonIndexType B[] = {static_cast<MortonIndexType>(0x5555555555555555),  // 0101'0101
-                                     static_cast<MortonIndexType>(0x3333333333333333),  // 0011'0011
-                                     static_cast<MortonIndexType>(0x0F0F0F0F0F0F0F0F),  // 0000'1111
-                                     static_cast<MortonIndexType>(0x00FF00FF00FF00FF),  // 0x8
-                                                                                        //  1x8
-                                     static_cast<MortonIndexType>(0x0000FFFF0000FFFF),  // 0x16
-                                                                                        // 1x16
-                                     static_cast<MortonIndexType>(0x00000000FFFFFFFF)};  //  0x32
-                                                                                         // 1x32;
+    constexpr MortonIndexType B[] = {static_cast<MortonIndexType>(0x5555555555555555),   // 0101'0101
+                                     static_cast<MortonIndexType>(0x3333333333333333),   // 0011'0011
+                                     static_cast<MortonIndexType>(0x0F0F0F0F0F0F0F0F),   // 0000'1111
+                                     static_cast<MortonIndexType>(0x00FF00FF00FF00FF),   // 0x8  1x8
+                                     static_cast<MortonIndexType>(0x0000FFFF0000FFFF),   // 0x16 1x16
+                                     static_cast<MortonIndexType>(0x00000000FFFFFFFF)};  // 0x32 1x32;
     return B[i];
   }
 

--- a/src/axom/spin/MortonIndex.hpp
+++ b/src/axom/spin/MortonIndex.hpp
@@ -151,7 +151,6 @@ protected:
    * so, e.g. in 2D, 6 == 0b0110 becomes 0b*0*1*1*0 == 0b00010100 == 20
    */
   AXOM_HOST_DEVICE
-  AXOM_SUPPRESS_UBSAN
   static MortonIndexType expandBits(MortonIndexType x)
   {
     for(int i = Derived::EXPAND_MAX_ITER; i >= 0; --i)
@@ -236,11 +235,11 @@ struct Mortonizer<CoordType, MortonIndexType, 2>
   // Magic numbers in 2D
   AXOM_HOST_DEVICE static MortonIndexType GetB(int i)
   {
-    constexpr MortonIndexType B[] = {static_cast<MortonIndexType>(0x5555555555555555),   // 0101'0101
-                                     static_cast<MortonIndexType>(0x3333333333333333),   // 0011'0011
-                                     static_cast<MortonIndexType>(0x0F0F0F0F0F0F0F0F),   // 0000'1111
-                                     static_cast<MortonIndexType>(0x00FF00FF00FF00FF),   // 0x8  1x8
-                                     static_cast<MortonIndexType>(0x0000FFFF0000FFFF),   // 0x16 1x16
+    constexpr MortonIndexType B[] = {static_cast<MortonIndexType>(0x5555555555555555),  // 0101'0101
+                                     static_cast<MortonIndexType>(0x3333333333333333),  // 0011'0011
+                                     static_cast<MortonIndexType>(0x0F0F0F0F0F0F0F0F),  // 0000'1111
+                                     static_cast<MortonIndexType>(0x00FF00FF00FF00FF),  // 0x8  1x8
+                                     static_cast<MortonIndexType>(0x0000FFFF0000FFFF),  // 0x16 1x16
                                      static_cast<MortonIndexType>(0x00000000FFFFFFFF)};  // 0x32 1x32;
     return B[i];
   }

--- a/src/axom/spin/SparseOctreeLevel.hpp
+++ b/src/axom/spin/SparseOctreeLevel.hpp
@@ -40,13 +40,13 @@ template <typename CoordType, int DIM, typename BroodDataType, typename Represen
 struct BroodRepresentationTraits
 {
   using GridPt = primal::Point<CoordType, DIM>;
-  using PointRepresenationType = RepresentationType;
+  using PointRepresentationType = RepresentationType;
 
-  AXOM_STATIC_ASSERT_MSG(std::is_integral<CoordType>::value, "CoordType must be integral");
-  AXOM_STATIC_ASSERT_MSG(std::is_integral<PointRepresenationType>::value,
-                         "RepresentationType must be integral");
-  AXOM_STATIC_ASSERT_MSG(std::is_unsigned<PointRepresenationType>::value,
-                         "RepresentationType must be unsigned");
+  static_assert(std::is_integral<CoordType>::value, "CoordType must be integral");
+  static_assert(std::is_integral<PointRepresentationType>::value,
+                "RepresentationType must be integral");
+  static_assert(std::is_unsigned<PointRepresentationType>::value,
+                "RepresentationType must be unsigned");
 
   // Requires a uint for RepresentationType with 8-,16-,32-, or 64- bits
 #if defined(AXOM_USE_SPARSEHASH)
@@ -55,10 +55,10 @@ struct BroodRepresentationTraits
   using MapType = std::unordered_map<RepresentationType, BroodDataType>;
 #endif
 
-  using BroodType = Brood<GridPt, PointRepresenationType>;
+  using BroodType = Brood<GridPt, PointRepresentationType>;
 
   /** Simple function to convert a point to its representation type */
-  static PointRepresenationType convertPoint(const GridPt& pt)
+  static PointRepresentationType convertPoint(const GridPt& pt)
   {
     return BroodType::MortonizerType::mortonize(pt);
   }
@@ -71,7 +71,7 @@ struct BroodRepresentationTraits
   static void initializeMap(MapType& map)
   {
 #if defined(AXOM_USE_SPARSEHASH)
-    const PointRepresenationType maxVal = axom::numeric_limits<PointRepresenationType>::max();
+    const PointRepresentationType maxVal = axom::numeric_limits<PointRepresentationType>::max();
     map.set_empty_key(maxVal);
     map.set_deleted_key(maxVal - 1);
 #else
@@ -150,7 +150,7 @@ struct BroodRepresentationTraits<CoordType, DIM, BroodDataType, primal::Point<Co
  *
  *  \see OctreeLevel
  */
-template <int DIM, typename BlockDataType, typename PointRepresenationType>
+template <int DIM, typename BlockDataType, typename PointRepresentationType>
 class SparseOctreeLevel : public OctreeLevel<DIM, BlockDataType>
 {
 public:
@@ -161,7 +161,7 @@ public:
   using ConstBaseBlockIteratorHelper = typename Base::ConstBlockIteratorHelper;
 
   using BroodTraits =
-    BroodRepresentationTraits<typename GridPt::CoordType, GridPt::DIMENSION, BroodData, PointRepresenationType>;
+    BroodRepresentationTraits<typename GridPt::CoordType, GridPt::DIMENSION, BroodData, PointRepresentationType>;
   using MapType = typename BroodTraits::MapType;
   using BroodType = typename BroodTraits::BroodType;
 

--- a/src/axom/spin/UniformGrid.hpp
+++ b/src/axom/spin/UniformGrid.hpp
@@ -447,7 +447,7 @@ void UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::initialize_grid()
   StoragePolicy::setNumBins(numBins);
 
   // scale the bounding box by a little to account for boundaries
-  const double EPS = 1e-12;
+  constexpr double EPS = 1e-12;
   m_boundingBox.scale(1. + EPS);
 
   // set up the bounding box and lattice for point conversions
@@ -501,12 +501,11 @@ void UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::initialize(axom::ArrayView
   // rectangular lattice and uniform grid storage.
   initialize_grid();
 
-  const IndexType numBins = getNumBins();
   // 1. Get number of elements to insert into each bin
+  const IndexType numBins = getNumBins();
   axom::Array<IndexType> binCounts(numBins, numBins, StoragePolicy::getAllocatorID());
-  // TODO: There's an error on operator[] if this isn't const and it only
-  // happens for GCC 8.1.0
-  const axom::ArrayView<IndexType> binCountsView = binCounts;
+  // TODO: There's an error on operator[] if this isn't const and it only happens for GCC 8.1.0
+  const axom::ArrayView<IndexType> binCountsView = binCounts.view();
 
   NumericArray<int, NDIMS> strides = m_strides;
   NumericArray<int, NDIMS> resolution = m_resolution;
@@ -515,9 +514,15 @@ void UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::initialize(axom::ArrayView
   axom::for_all<ExecSpace>(
     bboxes.size(),
     AXOM_LAMBDA(IndexType idx) {
-      const BoxType bbox = bboxes[idx];
+      const BoxType& bbox = bboxes[idx];
+      if(!bbox.isValid())
+      {
+        return;
+      }
+
       const GridCell lowerCell = getClampedGridCell(lattice, resolution, bbox.getMin());
       const GridCell upperCell = getClampedGridCell(lattice, resolution, bbox.getMax());
+
       const int kLower = (NDIMS == 2) ? 0 : lowerCell[2];
       const int kUpper = (NDIMS == 2) ? 0 : upperCell[2];
       const int kStride = (NDIMS == 2) ? 1 : strides[2];
@@ -548,7 +553,12 @@ void UniformGrid<T, NDIMS, ExecSpace, StoragePolicy>::initialize(axom::ArrayView
   axom::for_all<ExecSpace>(
     bboxes.size(),
     AXOM_LAMBDA(IndexType idx) {
-      const BoxType bbox = bboxes[idx];
+      const BoxType& bbox = bboxes[idx];
+      if(!bbox.isValid())
+      {
+        return;
+      }
+
       const GridCell lowerCell = getClampedGridCell(lattice, resolution, bbox.getMin());
       const GridCell upperCell = getClampedGridCell(lattice, resolution, bbox.getMax());
       const int kLower = (NDIMS == 2) ? 0 : lowerCell[2];

--- a/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
+++ b/src/axom/spin/internal/linear_bvh/build_radix_tree.hpp
@@ -47,6 +47,8 @@ namespace linear_bvh
 template <typename FloatType, int Dims>
 static inline AXOM_HOST_DEVICE std::int32_t morton32_encode(const primal::Vector<FloatType, Dims>& point)
 {
+  using PointType = primal::Point<std::int32_t, Dims>;
+
   //for a float, take the first 10 bits. Note, 2^10 = 1024
   constexpr int NUM_BITS_PER_DIM = 32 / Dims;
   constexpr FloatType FLOAT_TO_INT = 1 << NUM_BITS_PER_DIM;
@@ -55,12 +57,11 @@ static inline AXOM_HOST_DEVICE std::int32_t morton32_encode(const primal::Vector
   std::int32_t int_coords[Dims];
   for(int i = 0; i < Dims; i++)
   {
-    int_coords[i] = fmin(fmax(point[i] * FLOAT_TO_INT, (FloatType)0), FLOAT_CEILING);
+    int_coords[i] = static_cast<std::int32_t>(
+      fmin(fmax(point[i] * FLOAT_TO_INT, static_cast<FloatType>(0)), FLOAT_CEILING));
   }
 
-  primal::Point<std::int32_t, Dims> integer_pt(int_coords);
-
-  return convertPointToMorton<std::int32_t>(integer_pt);
+  return static_cast<std::int32_t>(convertPointToMorton<std::uint32_t>(PointType(int_coords)));
 }
 
 //------------------------------------------------------------------------------
@@ -70,15 +71,15 @@ static inline AXOM_HOST_DEVICE std::int64_t morton64_encode(axom::float32 x,
                                                             axom::float32 y,
                                                             axom::float32 z = 0.0)
 {
+  using PointType = primal::Point<std::int64_t, 3>;
+
   //take the first 21 bits. Note, 2^21= 2097152.0f
-  x = fmin(fmax(x * 2097152.0f, 0.0f), 2097151.0f);
-  y = fmin(fmax(y * 2097152.0f, 0.0f), 2097151.0f);
-  z = fmin(fmax(z * 2097152.0f, 0.0f), 2097151.0f);
+  constexpr float F_21 = 2097152.0f;
+  const PointType integer_pt = {static_cast<std::int64_t>(fmin(fmax(x * F_21, 0.0f), F_21)),
+                                static_cast<std::int64_t>(fmin(fmax(y * F_21, 0.0f), F_21)),
+                                static_cast<std::int64_t>(fmin(fmax(z * F_21, 0.0f), F_21))};
 
-  primal::Point<std::int64_t, 3> integer_pt =
-    primal::Point<std::int64_t, 3>::make_point((std::int64_t)x, (std::int64_t)y, (std::int64_t)z);
-
-  return convertPointToMorton<std::int64_t>(integer_pt);
+  return static_cast<std::int64_t>(convertPointToMorton<std::uint64_t>(integer_pt));
 }
 
 template <typename ExecSpace, typename BoxIndexable, typename FloatType, int NDIMS>


### PR DESCRIPTION
# Summary

- This PR is a bugfix associated with undefined behavior as identified by ubsan in our clang configuration
- In particular:
  - It fixes invalid shifts in the BVH construction. The Morton indexing assumed that the `MortonIndexType` was unsigned, but was being passed in a signed integer. I changed this to an unsigned type and added a `static_assert` to `spin::MortonBase`
  - It fixes possible invalid `spin:UniformGrid` initialization when passed geometry with invalid bounding boxes. We now skip those cases
  - It fixes a validity check in `slam::OrderedSet` when presented with a stride of zero. There was previously a divide by zero.
  - It fixes checks on empty `axom::MapCollection` instances when using sparsehash, which expected a sentinel key (even for empty hashtables). We now check if the table is empty before checking for items. This is used heavily by `sidre` and was reporting undefined behavior in user applications.
