### PR TITLE
Adds a TempFile utility class to core's file utilities

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,6 +47,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Added a new `quest::STLWriter` class that writes mint meshes to STL format.
 - Adds `assign` methods to `axom::Array`.
 - Adds `assign`, `fill`, `set` methods to `axom::ArrayView`.
+- Core: Adds a `TempFile` class to Axom's FileUtilities to help with generating temp files with unique file
+  names that can be automatically removed when the instance goes out of scope.
 
 ###  Changed
 - Axom now requires C++17 and will default to that if not specified via `BLT_CXX_STD`.
@@ -74,6 +76,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Spin: Fixes undefined behavior in BVH tree construction associated with using signed indexes
 - Spin: Fixes undefined behavior in UniformGrid construction associated with invalid geometry bounding boxes
 - Core: Fixes undefined behavior in MapCollection when searching empty collections
+- Core: Fixes some edge cases in the `joinPath` file utility
 
 ###  Deprecated
 - Primal: Deprecates `Triangle::checkInTriangle(pt)`. Use `Triangle::contains(pt)` instead.

--- a/src/axom/core/tests/utils_fileUtilities.hpp
+++ b/src/axom/core/tests/utils_fileUtilities.hpp
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 #include <fstream>
 #include <exception>
+#include <iterator>
 
 #include "axom/config.hpp"
 #include "axom/core/utilities/FileUtilities.hpp"
@@ -132,36 +133,65 @@ TEST(utils_fileUtilities, getParentPath)
 
 TEST(utils_fileUtilities, TempFile_basic)
 {
-  using namespace axom::utilities::filesystem;
-
   const std::string fname = "foo";
   std::string actual_path;
   {
-    TempFile fooFile(fname);
+    fs::TempFile fooFile(fname);
     actual_path = fooFile.getPath();
     std::cout << "Created temp file: " << actual_path << std::endl;
     fooFile << "some string";
 
-    EXPECT_TRUE(pathExists(actual_path));
+    EXPECT_TRUE(fs::pathExists(actual_path));
   }
   // file is removed once it is out of scope
-  EXPECT_FALSE(pathExists(actual_path));
+  EXPECT_FALSE(fs::pathExists(actual_path));
+}
+
+TEST(utils_fileUtilities, TempFile_delete_during_destruction)
+{
+  const std::string fname = "foo";
+  const std::string file_contents = "some string";
+
+  for(bool should_delete : {true, false})
+  {
+    std::string actual_path;
+    {
+      fs::TempFile fooFile(fname, should_delete);
+      actual_path = fooFile.getPath();
+      fooFile << file_contents;
+
+      EXPECT_TRUE(fs::pathExists(actual_path));
+    }
+
+    if(should_delete)
+    {
+      EXPECT_FALSE(fs::pathExists(actual_path));
+    }
+    else
+    {
+      EXPECT_TRUE(fs::pathExists(actual_path));
+
+      // check that the file contents match what we wrote above
+      std::ifstream infile(actual_path);
+      std::string contents((std::istreambuf_iterator<char>(infile)),
+                           std::istreambuf_iterator<char>());
+      EXPECT_EQ(contents, file_contents);
+    }
+  }
 }
 
 TEST(utils_fileUtilities, TempFile_two)
 {
-  using namespace axom::utilities::filesystem;
-
+  // check that we can create two TempFiles with the same prefix
   const std::string fname = "foo";
-  {
-    TempFile fooFile1(fname);
-    TempFile fooFile2(fname);
 
-    const std::string actual_path1 = fooFile1.getPath();
-    const std::string actual_path2 = fooFile2.getPath();
-    EXPECT_NE(actual_path1, actual_path2);
-    
-    std::cout << "Created temp file 1: " << actual_path1 << std::endl;
-    std::cout << "Created temp file 2: " << actual_path2 << std::endl;
-  }
+  fs::TempFile fooFile1(fname);
+  fs::TempFile fooFile2(fname);
+
+  const std::string actual_path1 = fooFile1.getPath();
+  const std::string actual_path2 = fooFile2.getPath();
+  EXPECT_NE(actual_path1, actual_path2);
+
+  std::cout << "Created temp file 1: " << actual_path1 << std::endl;
+  std::cout << "Created temp file 2: " << actual_path2 << std::endl;
 }

--- a/src/axom/core/tests/utils_fileUtilities.hpp
+++ b/src/axom/core/tests/utils_fileUtilities.hpp
@@ -54,7 +54,7 @@ TEST(utils_fileUtilities, joinPath)
     EXPECT_EQ("abc.def", fs::joinPath("abc.", ".def", "."));
   }
 
-  // test with backslash separator (w/ and w/p raw string literals)
+  // test with backslash separator (w/ and w/o raw string literals)
   {
     EXPECT_EQ("abc\\def", fs::joinPath("abc", "def", "\\"));
     EXPECT_EQ("abc\\def", fs::joinPath("abc\\", "def", "\\"));
@@ -237,10 +237,10 @@ TEST(utils_fileUtilities, TempFile_extension)
   {
     for(const std::string& ext : {"", ".json", "json"})
     {
-      fs::TempFile tmp(nm, ext);
+      fs::TempFile temp(nm, ext);
 
-      std::cout << "Creating tmp file: '" << tmp.getPath() << "' with extension '" << ext << "'\n";
-      EXPECT_TRUE(axom::utilities::string::endsWith(tmp.getPath(), ext));
+      std::cout << "Creating temp file: '" << temp.getPath() << "' with extension '" << ext << "'\n";
+      EXPECT_TRUE(axom::utilities::string::endsWith(temp.getPath(), ext));
     }
   }
 }

--- a/src/axom/core/tests/utils_fileUtilities.hpp
+++ b/src/axom/core/tests/utils_fileUtilities.hpp
@@ -108,27 +108,25 @@ TEST(utils_fileUtilities, changeCWD_smoke)
 
 TEST(utils_fileUtilities, prefixRelativePath)
 {
-  using namespace axom::utilities::filesystem;
-  EXPECT_EQ(prefixRelativePath("rel/path", "/pre/fix"), "/pre/fix/rel/path");
-  EXPECT_EQ(prefixRelativePath("rel/path", ""), "rel/path");
-  EXPECT_THROW(prefixRelativePath("", "/pre/fix"), std::invalid_argument);
+  EXPECT_EQ(fs::prefixRelativePath("rel/path", "/pre/fix"), "/pre/fix/rel/path");
+  EXPECT_EQ(fs::prefixRelativePath("rel/path", ""), "rel/path");
+  EXPECT_THROW(fs::prefixRelativePath("", "/pre/fix"), std::invalid_argument);
 
   // These full paths should not change.
-  EXPECT_EQ(prefixRelativePath("/full/path", "/pre/fix"), "/full/path");
-  EXPECT_EQ(prefixRelativePath("/full/path", ""), "/full/path");
+  EXPECT_EQ(fs::prefixRelativePath("/full/path", "/pre/fix"), "/full/path");
+  EXPECT_EQ(fs::prefixRelativePath("/full/path", ""), "/full/path");
 }
 
 TEST(utils_fileUtilities, getParentPath)
 {
-  using namespace axom::utilities::filesystem;
-  EXPECT_EQ(getParentPath("/full/multi/level/path"), "/full/multi/level");
-  EXPECT_EQ(getParentPath("/full/multi/level"), "/full/multi");
-  EXPECT_EQ(getParentPath("rel/multi/level/path"), "rel/multi/level");
-  EXPECT_EQ(getParentPath("rel/multi/level"), "rel/multi");
-  EXPECT_EQ(getParentPath("level"), "");
-  EXPECT_EQ(getParentPath("/level0/level1"), "/level0");
-  EXPECT_EQ(getParentPath("/level0"), "/");
-  EXPECT_EQ(getParentPath("/"), "");
+  EXPECT_EQ(fs::getParentPath("/full/multi/level/path"), "/full/multi/level");
+  EXPECT_EQ(fs::getParentPath("/full/multi/level"), "/full/multi");
+  EXPECT_EQ(fs::getParentPath("rel/multi/level/path"), "rel/multi/level");
+  EXPECT_EQ(fs::getParentPath("rel/multi/level"), "rel/multi");
+  EXPECT_EQ(fs::getParentPath("level"), "");
+  EXPECT_EQ(fs::getParentPath("/level0/level1"), "/level0");
+  EXPECT_EQ(fs::getParentPath("/level0"), "/");
+  EXPECT_EQ(fs::getParentPath("/"), "");
 }
 
 TEST(utils_fileUtilities, TempFile_basic)

--- a/src/axom/core/tests/utils_fileUtilities.hpp
+++ b/src/axom/core/tests/utils_fileUtilities.hpp
@@ -194,6 +194,9 @@ TEST(utils_fileUtilities, TempFile_delete_during_destruction)
       fooFile.open();
       EXPECT_TRUE(fooFile.is_open());
       fooFile << file_contents;
+      fooFile.close();
+
+      EXPECT_EQ(file_contents, fooFile.getFileContents());
 
       EXPECT_TRUE(fs::pathExists(actual_path));
     }

--- a/src/axom/core/tests/utils_fileUtilities.hpp
+++ b/src/axom/core/tests/utils_fileUtilities.hpp
@@ -10,6 +10,7 @@
 
 #include "axom/config.hpp"
 #include "axom/core/utilities/FileUtilities.hpp"
+#include "axom/core/utilities/StringUtilities.hpp"
 
 namespace fs = axom::utilities::filesystem;
 
@@ -31,18 +32,40 @@ TEST(utils_fileUtilities, joinPath)
 {
   std::cout << "Testing joinPath() function" << std::endl;
 
-  std::string fdir = "abc";
-  std::string fdirWithSlash = "abc/";
-  std::string fname = "def";
+  // test with empty dir or name
+  {
+    EXPECT_EQ("def", fs::joinPath("", "def"));
+    EXPECT_EQ("abc", fs::joinPath("abc", ""));
+  }
 
-  std::string fullfile = "abc/def";
+  // test with default separator
+  {
+    EXPECT_EQ("abc/def", fs::joinPath("abc", "def"));
+    EXPECT_EQ("abc/def", fs::joinPath("abc/", "def"));
+    EXPECT_EQ("abc/def", fs::joinPath("abc", "/def"));
+    EXPECT_EQ("abc/def", fs::joinPath("abc/", "/def"));
+  }
 
-  EXPECT_EQ(fullfile, fs::joinPath(fdir, fname));
+  // test with a different separator
+  {
+    EXPECT_EQ("abc.def", fs::joinPath("abc", "def", "."));
+    EXPECT_EQ("abc.def", fs::joinPath("abc.", "def", "."));
+    EXPECT_EQ("abc.def", fs::joinPath("abc", ".def", "."));
+    EXPECT_EQ("abc.def", fs::joinPath("abc.", ".def", "."));
+  }
 
-  EXPECT_EQ(fullfile, fs::joinPath(fdirWithSlash, fname));
+  // test a string that has the separator in other positions
+  {
+    EXPECT_EQ("abc/def/ghi", fs::joinPath("abc", "def/ghi"));
+    EXPECT_EQ("abc/def/ghi", fs::joinPath("abc/", "def/ghi"));
+    EXPECT_EQ("abc/def/ghi", fs::joinPath("abc", "/def/ghi"));
+    EXPECT_EQ("abc/def/ghi", fs::joinPath("abc/", "/def/ghi"));
 
-  std::string fnameWithSubdir = "def/ghi";
-  EXPECT_EQ("abc/def/ghi", fs::joinPath(fdir, fnameWithSubdir));
+    EXPECT_EQ("abc/def/ghi", fs::joinPath("abc/def", "ghi"));
+    EXPECT_EQ("abc/def/ghi", fs::joinPath("abc/def/", "ghi"));
+    EXPECT_EQ("abc/def/ghi", fs::joinPath("abc/def", "/ghi"));
+    EXPECT_EQ("abc/def/ghi", fs::joinPath("abc/def/", "/ghi"));
+  }
 }
 
 TEST(utils_fileUtilities, pathExists)

--- a/src/axom/core/tests/utils_fileUtilities.hpp
+++ b/src/axom/core/tests/utils_fileUtilities.hpp
@@ -160,8 +160,6 @@ TEST(utils_fileUtilities, TempFile_basic)
     fs::TempFile fooFile(fname);
     actual_path = fooFile.getPath();
     std::cout << "Created temp file: " << actual_path << std::endl;
-    fooFile << "some string";
-
     EXPECT_TRUE(fs::pathExists(actual_path));
   }
   // file is removed once it is out of scope
@@ -179,6 +177,9 @@ TEST(utils_fileUtilities, TempFile_delete_during_destruction)
     {
       fs::TempFile fooFile(fname, should_delete);
       actual_path = fooFile.getPath();
+
+      fooFile.open();
+      EXPECT_TRUE(fooFile.is_open());
       fooFile << file_contents;
 
       EXPECT_TRUE(fs::pathExists(actual_path));
@@ -215,4 +216,18 @@ TEST(utils_fileUtilities, TempFile_two)
 
   std::cout << "Created temp file 1: " << actual_path1 << std::endl;
   std::cout << "Created temp file 2: " << actual_path2 << std::endl;
+}
+
+TEST(utils_fileUtilities, TempFile_extension)
+{
+  for(const std::string nm : {"", "foo"})
+  {
+    for(const std::string ext : {"", ".json", "json"})
+    {
+      fs::TempFile tmp(nm, ext);
+
+      std::cout << "Creating tmp file: '" << tmp.getPath() << "' with extension '" << ext << "'\n";
+      EXPECT_TRUE(axom::utilities::string::endsWith(tmp.getPath(), ext));
+    }
+  }
 }

--- a/src/axom/core/tests/utils_fileUtilities.hpp
+++ b/src/axom/core/tests/utils_fileUtilities.hpp
@@ -12,6 +12,8 @@
 #include "axom/core/utilities/FileUtilities.hpp"
 #include "axom/core/utilities/StringUtilities.hpp"
 
+#include "axom/fmt.hpp"
+
 namespace fs = axom::utilities::filesystem;
 
 TEST(utils_fileUtilities, getCWD_smoke)
@@ -192,11 +194,7 @@ TEST(utils_fileUtilities, TempFile_delete_during_destruction)
       fooFile.retain(should_retain);
       actual_path = fooFile.getPath();
 
-      fooFile.open();
-      EXPECT_TRUE(fooFile.is_open());
-      fooFile << file_contents;
-      fooFile.close();
-
+      fooFile.write(file_contents);
       EXPECT_EQ(file_contents, fooFile.getFileContents());
 
       EXPECT_TRUE(fs::pathExists(actual_path));
@@ -211,10 +209,45 @@ TEST(utils_fileUtilities, TempFile_delete_during_destruction)
       std::string contents((std::istreambuf_iterator<char>(infile)),
                            std::istreambuf_iterator<char>());
       EXPECT_EQ(contents, file_contents);
+
+      fs::removeFile(actual_path);  // clean up
     }
     else
     {
       EXPECT_FALSE(fs::pathExists(actual_path));
+    }
+  }
+}
+
+TEST(utils_fileUtilities, TempFile_write)
+{
+  const std::string fname = "foo";
+  const std::string file_contents = "some string";
+
+  for(bool start_open : {true, false})
+  {
+    for(bool preserve_state : {true, false})
+    {
+      fs::TempFile fooFile(fname);
+
+      if(start_open)
+      {
+        fooFile.open();
+      }
+      EXPECT_EQ(fooFile.is_open(), start_open);
+
+      fooFile.write(file_contents, std::ios::out, preserve_state);
+
+      if(preserve_state)
+      {
+        EXPECT_EQ(fooFile.is_open(), start_open)
+          << axom::fmt::format("start_open {} -- preserve_state {}", start_open, preserve_state);
+      }
+      else
+      {
+        EXPECT_TRUE(fooFile.is_open())
+          << axom::fmt::format("start_open {} -- preserve_state {}", start_open, preserve_state);
+      }
     }
   }
 }

--- a/src/axom/core/tests/utils_fileUtilities.hpp
+++ b/src/axom/core/tests/utils_fileUtilities.hpp
@@ -54,6 +54,19 @@ TEST(utils_fileUtilities, joinPath)
     EXPECT_EQ("abc.def", fs::joinPath("abc.", ".def", "."));
   }
 
+  // test with backslash separator (w/ and w/p raw string literals)
+  {
+    EXPECT_EQ("abc\\def", fs::joinPath("abc", "def", "\\"));
+    EXPECT_EQ("abc\\def", fs::joinPath("abc\\", "def", "\\"));
+    EXPECT_EQ("abc\\def", fs::joinPath("abc", "\\def", "\\"));
+    EXPECT_EQ("abc\\def", fs::joinPath("abc\\", "\\def", "\\"));
+
+    EXPECT_EQ(R"(abc\def)", fs::joinPath(R"(abc)", R"(def)", R"(\)"));
+    EXPECT_EQ(R"(abc\def)", fs::joinPath(R"(abc\)", R"(def)", R"(\)"));
+    EXPECT_EQ(R"(abc\def)", fs::joinPath(R"(abc)", R"(\def)", R"(\)"));
+    EXPECT_EQ(R"(abc\def)", fs::joinPath(R"(abc\)", R"(\def)", R"(\)"));
+  }
+
   // test a string that has the separator in other positions
   {
     EXPECT_EQ("abc/def/ghi", fs::joinPath("abc", "def/ghi"));
@@ -220,9 +233,9 @@ TEST(utils_fileUtilities, TempFile_two)
 
 TEST(utils_fileUtilities, TempFile_extension)
 {
-  for(const std::string nm : {"", "foo"})
+  for(const std::string& nm : {"", "foo"})
   {
-    for(const std::string ext : {"", ".json", "json"})
+    for(const std::string& ext : {"", ".json", "json"})
     {
       fs::TempFile tmp(nm, ext);
 

--- a/src/axom/core/tests/utils_fileUtilities.hpp
+++ b/src/axom/core/tests/utils_fileUtilities.hpp
@@ -129,3 +129,39 @@ TEST(utils_fileUtilities, getParentPath)
   EXPECT_EQ(getParentPath("/level0"), "/");
   EXPECT_EQ(getParentPath("/"), "");
 }
+
+TEST(utils_fileUtilities, TempFile_basic)
+{
+  using namespace axom::utilities::filesystem;
+
+  const std::string fname = "foo";
+  std::string actual_path;
+  {
+    TempFile fooFile(fname);
+    actual_path = fooFile.getPath();
+    std::cout << "Created temp file: " << actual_path << std::endl;
+    fooFile << "some string";
+
+    EXPECT_TRUE(pathExists(actual_path));
+  }
+  // file is removed once it is out of scope
+  EXPECT_FALSE(pathExists(actual_path));
+}
+
+TEST(utils_fileUtilities, TempFile_two)
+{
+  using namespace axom::utilities::filesystem;
+
+  const std::string fname = "foo";
+  {
+    TempFile fooFile1(fname);
+    TempFile fooFile2(fname);
+
+    const std::string actual_path1 = fooFile1.getPath();
+    const std::string actual_path2 = fooFile2.getPath();
+    EXPECT_NE(actual_path1, actual_path2);
+    
+    std::cout << "Created temp file 1: " << actual_path1 << std::endl;
+    std::cout << "Created temp file 2: " << actual_path2 << std::endl;
+  }
+}

--- a/src/axom/core/tests/utils_fileUtilities.hpp
+++ b/src/axom/core/tests/utils_fileUtilities.hpp
@@ -184,11 +184,12 @@ TEST(utils_fileUtilities, TempFile_delete_during_destruction)
   const std::string fname = "foo";
   const std::string file_contents = "some string";
 
-  for(bool should_delete : {true, false})
+  for(bool should_retain : {true, false})
   {
     std::string actual_path;
     {
-      fs::TempFile fooFile(fname, should_delete);
+      fs::TempFile fooFile(fname);
+      fooFile.retain(should_retain);
       actual_path = fooFile.getPath();
 
       fooFile.open();
@@ -201,11 +202,7 @@ TEST(utils_fileUtilities, TempFile_delete_during_destruction)
       EXPECT_TRUE(fs::pathExists(actual_path));
     }
 
-    if(should_delete)
-    {
-      EXPECT_FALSE(fs::pathExists(actual_path));
-    }
-    else
+    if(should_retain)
     {
       EXPECT_TRUE(fs::pathExists(actual_path));
 
@@ -214,6 +211,10 @@ TEST(utils_fileUtilities, TempFile_delete_during_destruction)
       std::string contents((std::istreambuf_iterator<char>(infile)),
                            std::istreambuf_iterator<char>());
       EXPECT_EQ(contents, file_contents);
+    }
+    else
+    {
+      EXPECT_FALSE(fs::pathExists(actual_path));
     }
   }
 }

--- a/src/axom/core/utilities/FileUtilities.cpp
+++ b/src/axom/core/utilities/FileUtilities.cpp
@@ -172,7 +172,8 @@ void getDirName(std::string& dir, const std::string& path)
 int removeFile(const std::string& filename) { return Unlink(filename.c_str()); }
 
 //-----------------------------------------------------------------------------
-TempFile::TempFile(const std::string& file_name)
+TempFile::TempFile(const std::string& file_name, bool delete_during_destruction)
+  : m_delete_during_destruction(delete_during_destruction)
 {
 #ifdef WIN32
   char tempPath[MAX_PATH];
@@ -203,8 +204,15 @@ TempFile::TempFile(const std::string& file_name)
 
 TempFile::~TempFile()
 {
-  m_ofs.close();
-  removeFile(m_path);
+  if(m_ofs.is_open())
+  {
+    m_ofs.close();
+  }
+
+  if(m_delete_during_destruction)
+  {
+    removeFile(m_path);
+  }
 }
 
 }  // end namespace filesystem

--- a/src/axom/core/utilities/FileUtilities.cpp
+++ b/src/axom/core/utilities/FileUtilities.cpp
@@ -5,11 +5,11 @@
 
 #include "axom/core/utilities/FileUtilities.hpp"
 
+#include <vector>
 #include <string>
 #include <fstream>
 #include <sstream>
 #include <cerrno>
-
 #include <cstdio>  // defines FILENAME_MAX
 
 #ifdef WIN32
@@ -170,6 +170,42 @@ void getDirName(std::string& dir, const std::string& path)
 
 //-----------------------------------------------------------------------------
 int removeFile(const std::string& filename) { return Unlink(filename.c_str()); }
+
+//-----------------------------------------------------------------------------
+TempFile::TempFile(const std::string& file_name)
+{
+#ifdef WIN32
+  char tempPath[MAX_PATH];
+  char tempFileName[MAX_PATH];
+  GetTempPathA(MAX_PATH, tempPath);
+  GetTempFileNameA(tempPath, file_name.c_str(), 0, tempFileName);
+  m_path = tempFileName;
+#else
+  std::string tmpl = "/tmp/" + file_name + "XXXXXX";
+  std::vector<char> buf(tmpl.begin(), tmpl.end());
+  buf.push_back('\0');
+
+  int fd = mkstemp(buf.data());
+  if(fd == -1)
+  {
+    throw std::runtime_error("Failed to create temp file");
+  }
+  m_path = buf.data();
+  close(fd);
+#endif
+
+  m_ofs.open(m_path, std::ios::out | std::ios::trunc);
+  if(!m_ofs)
+  {
+    throw std::runtime_error("Failed to open temp file with ofstream");
+  }
+}
+
+TempFile::~TempFile()
+{
+  m_ofs.close();
+  removeFile(m_path);
+}
 
 }  // end namespace filesystem
 }  // end namespace utilities

--- a/src/axom/core/utilities/FileUtilities.cpp
+++ b/src/axom/core/utilities/FileUtilities.cpp
@@ -49,10 +49,7 @@ std::string getCWD()
 
   if(!GetCurrentDir(cCurrentPath, FILENAME_MAX))
   {
-    //Note: Cannot use logging in COMMON component -- topic of JIRA issue
-    // ATK-463
-    //SLIC_WARNING("Common::Could not find cwd");
-
+    //Note: Cannot use slic logging in core component
     return std::string("./");
   }
 
@@ -180,8 +177,7 @@ void getDirName(std::string& dir, const std::string& path)
 int removeFile(const std::string& filename) { return Unlink(filename.c_str()); }
 
 //-----------------------------------------------------------------------------
-TempFile::TempFile(const std::string& file_name, const std::string& ext, bool delete_during_destruction)
-  : m_delete_during_destruction(delete_during_destruction)
+TempFile::TempFile(const std::string& file_name, const std::string& ext)
 {
 #ifdef WIN32
   char temp_dir[MAX_PATH];
@@ -245,7 +241,7 @@ TempFile::~TempFile()
 {
   this->close();
 
-  if(m_delete_during_destruction)
+  if(!m_retain_file)
   {
     removeFile(m_path);
   }

--- a/src/axom/core/utilities/FileUtilities.cpp
+++ b/src/axom/core/utilities/FileUtilities.cpp
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "axom/core/utilities/FileUtilities.hpp"
+#include "axom/core/utilities/StringUtilities.hpp"
+#include "axom/fmt.hpp"
 
 #include <vector>
 #include <string>
@@ -72,14 +74,18 @@ std::string joinPath(const std::string& fileDir,
                      const std::string& fileName,
                      const std::string& separator)
 {
-  // Check if we need to add a separator
-  bool pathNeedsSep = !fileDir.empty() && (fileDir[fileDir.size() - 1] != separator[0]);
+  namespace sutil = axom::utilities::string;
 
-  // Concatenate the path with the fileName to create the full path
-  std::stringstream fullFileNameStream;
-  fullFileNameStream << fileDir << (pathNeedsSep ? separator : "") << fileName;
+  // Check if we need to add or remove a separator
+  const bool has_empties = fileDir.empty() || fileName.empty();
+  const int sep_count = (!fileDir.empty() && sutil::endsWith(fileDir, separator) ? 1 : 0) +
+    (!fileName.empty() && sutil::startsWith(fileName, separator) ? 1 : 0);
 
-  return fullFileNameStream.str();
+  // Concatenate the path with the fileName, adding or removing a separator, as needed
+  return axom::fmt::format("{}{}{}",
+                           (sep_count == 2) ? sutil::removeSuffix(fileDir, separator) : fileDir,
+                           !has_empties && sep_count == 0 ? separator : "",
+                           fileName);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/axom/core/utilities/FileUtilities.cpp
+++ b/src/axom/core/utilities/FileUtilities.cpp
@@ -16,6 +16,7 @@
 #include <cstdlib>
 
 #ifdef WIN32
+  #include <windows.h>
   #include <direct.h>
   #include <sys/stat.h>
 
@@ -183,11 +184,26 @@ TempFile::TempFile(const std::string& file_name, const std::string& ext, bool de
   : m_delete_during_destruction(delete_during_destruction)
 {
 #ifdef WIN32
-  char tempPath[MAX_PATH];
-  char tempFileName[MAX_PATH];
-  GetTempPathA(MAX_PATH, tempPath);
-  GetTempFileNameA(tempPath, file_name.c_str(), 0, tempFileName);
-  m_path = tempFileName;
+  char temp_dir[MAX_PATH];
+  char temp_file_name[MAX_PATH];
+  GetTempPathA(MAX_PATH, temp_dir);
+
+  // Combine file_name and ext for the prefix (max 3 chars for prefix in GetTempFileNameA)
+  GetTempFileNameA(temp_dir, file_name.c_str(), 0, temp_file_name);
+
+  if(!ext.empty())
+  {
+    const std::string new_path = joinPath(temp_file_name, ext, ".");
+    if(std::rename(temp_file_name, new_path.c_str()) != 0)
+    {
+      throw std::ios::failure {"Failed to rename temp file to include extension"};
+    }
+    m_path = new_path;
+  }
+  else
+  {
+    m_path = std::string(temp_file_name);
+  }
 #else
   // create a tmp file with the requested prefix
   // note: mkstemp requires the last six chars to be "XXXXXX"

--- a/src/axom/core/utilities/FileUtilities.cpp
+++ b/src/axom/core/utilities/FileUtilities.cpp
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <cerrno>
 #include <cstdio>  // defines FILENAME_MAX
+#include <cstdlib>
 
 #ifdef WIN32
   #include <direct.h>
@@ -182,11 +183,13 @@ TempFile::TempFile(const std::string& file_name, bool delete_during_destruction)
   GetTempFileNameA(tempPath, file_name.c_str(), 0, tempFileName);
   m_path = tempFileName;
 #else
-  std::string tmpl = "/tmp/" + file_name + "XXXXXX";
-  std::vector<char> buf(tmpl.begin(), tmpl.end());
+  const char* tmpdir = getenv("TMPDIR");
+  const std::string dir = tmpdir ? tmpdir : "/tmp";
+  const std::string tmp_file_name = joinPath(dir, file_name + "XXXXXX");
+  std::vector<char> buf(tmp_file_name.begin(), tmp_file_name.end());
   buf.push_back('\0');
 
-  int fd = mkstemp(buf.data());
+  const int fd = mkstemp(buf.data());
   if(fd == -1)
   {
     throw std::runtime_error("Failed to create temp file");

--- a/src/axom/core/utilities/FileUtilities.cpp
+++ b/src/axom/core/utilities/FileUtilities.cpp
@@ -251,6 +251,19 @@ TempFile::~TempFile()
   }
 }
 
+std::string TempFile::getFileContents() const
+{
+  std::stringstream buffer;
+
+  std::ifstream ifs(m_path.c_str(), std::ios::in);
+  if(ifs.is_open())
+  {
+    buffer << ifs.rdbuf();
+  }
+
+  return buffer.str();
+}
+
 }  // end namespace filesystem
 }  // end namespace utilities
 }  // end namespace axom

--- a/src/axom/core/utilities/FileUtilities.cpp
+++ b/src/axom/core/utilities/FileUtilities.cpp
@@ -179,7 +179,7 @@ void getDirName(std::string& dir, const std::string& path)
 int removeFile(const std::string& filename) { return Unlink(filename.c_str()); }
 
 //-----------------------------------------------------------------------------
-TempFile::TempFile(const std::string& file_name, bool delete_during_destruction)
+TempFile::TempFile(const std::string& file_name, const std::string& ext, bool delete_during_destruction)
   : m_delete_during_destruction(delete_during_destruction)
 {
 #ifdef WIN32
@@ -189,6 +189,8 @@ TempFile::TempFile(const std::string& file_name, bool delete_during_destruction)
   GetTempFileNameA(tempPath, file_name.c_str(), 0, tempFileName);
   m_path = tempFileName;
 #else
+  // create a tmp file with the requested prefix
+  // note: mkstemp requires the last six chars to be "XXXXXX"
   const char* tmpdir = getenv("TMPDIR");
   const std::string dir = tmpdir ? tmpdir : "/tmp";
   const std::string tmp_file_name = joinPath(dir, file_name + "XXXXXX");
@@ -198,25 +200,32 @@ TempFile::TempFile(const std::string& file_name, bool delete_during_destruction)
   const int fd = mkstemp(buf.data());
   if(fd == -1)
   {
-    throw std::runtime_error("Failed to create temp file");
+    throw std::ios::failure {"Failed to create temp file"};
   }
-  m_path = buf.data();
-  close(fd);
-#endif
 
-  m_ofs.open(m_path, std::ios::out | std::ios::trunc);
-  if(!m_ofs)
+  // rename to use the provided extension
+  if(!ext.empty())
   {
-    throw std::runtime_error("Failed to open temp file with ofstream");
+    const std::string new_path = joinPath(buf.data(), ext, ".");
+    if(std::rename(buf.data(), new_path.c_str()) != 0)
+    {
+      ::close(fd);
+
+      throw std::ios::failure {"Failed to rename temp file to include extension"};
+    }
+    m_path = new_path;
   }
+  else
+  {
+    m_path = buf.data();
+  }
+  ::close(fd);
+#endif
 }
 
 TempFile::~TempFile()
 {
-  if(m_ofs.is_open())
-  {
-    m_ofs.close();
-  }
+  this->close();
 
   if(m_delete_during_destruction)
   {

--- a/src/axom/core/utilities/FileUtilities.cpp
+++ b/src/axom/core/utilities/FileUtilities.cpp
@@ -193,7 +193,9 @@ TempFile::TempFile(const std::string& file_name, const std::string& ext, bool de
 
   if(!ext.empty())
   {
-    const std::string new_path = joinPath(temp_file_name, ext, ".");
+    // remove ".tmp" (if present), add the requested extension and rename the file
+    const std::string new_path =
+      joinPath(axom::utilities::string::removeSuffix(temp_file_name, ".tmp"), ext, ".");
     if(std::rename(temp_file_name, new_path.c_str()) != 0)
     {
       throw std::ios::failure {"Failed to rename temp file to include extension"};

--- a/src/axom/core/utilities/FileUtilities.hpp
+++ b/src/axom/core/utilities/FileUtilities.hpp
@@ -134,7 +134,7 @@ class TempFile
 {
 public:
   /**
-   * \brief Creates a tmp file using \a file_name and \a file_ext
+   * \brief Creates a temp file using \a file_name and \a file_ext
    * 
    * \param file_name The name of the temporary file to create without extension
    * \param file_ext An optional extension for the temp file

--- a/src/axom/core/utilities/FileUtilities.hpp
+++ b/src/axom/core/utilities/FileUtilities.hpp
@@ -182,6 +182,36 @@ public:
   }
 
   /**
+   * Writes \a contents to the file
+   * 
+   * Opens the file if it is not already open using \a mode and optionally closes the file
+   * \param content A string to write to the file
+   * \param mode The ios mode to open the file
+   * \param preserve_file_state Controls whether the file should be closed if we had to open it
+   *   If false, the file will be left open. If true, it will be left in its initial state
+   */
+  template <typename StringType>
+  void write(StringType&& content,
+             std::ios::openmode mode = std::ios::out | std::ios::trunc,
+             bool preserve_file_state = true)
+  {
+    bool opened_here = false;
+
+    if(!is_open())
+    {
+      open(mode);
+      opened_here = true;
+    }
+
+    m_ofs << std::forward<StringType>(content);
+
+    if(opened_here && preserve_file_state)
+    {
+      close();
+    }
+  }
+
+  /**
    * \brief Checks if the temporary file is currently open.
    * \return true if the file is open, false otherwise.
    */

--- a/src/axom/core/utilities/FileUtilities.hpp
+++ b/src/axom/core/utilities/FileUtilities.hpp
@@ -121,13 +121,26 @@ void getDirName(std::string& dir, const std::string& path);
 int removeFile(const std::string& filename);
 
 /**
- * Platform-independent RAII utility class to create an temporary file that will be deleted when the
- * instance goes out of scope
+ * /brief Utility class for managing temporary files.
+ *
+ * The TempFile class provides a convenient way to create and manage temporary files.
+ * It ensures that the file is deleted upon destruction, if specified.
+ * The class is non-copyable to prevent accidental duplication of file handles.
+ *
+ * The file is opened for writing upon construction and can be written to using the overloaded << operator.
+ * 
+ * \note The path to the temp file is likely different from the supplied \a file_name
  */
 class TempFile
 {
 public:
-  explicit TempFile(const std::string& file_name);
+  /**
+   * \brief Constructor that takes a \a file_name template, and a flag to control whether the file gets deleted
+   * 
+   * \param file_name The name (or path) of the temporary file to create.
+   * \param delete_during_destruction If true (default), the file will be deleted when the TempFile object is destroyed.
+   */
+  explicit TempFile(const std::string& file_name, bool delete_during_destruction = true);
 
   ~TempFile();
 
@@ -135,6 +148,7 @@ public:
   TempFile(const TempFile&) = delete;
   TempFile& operator=(const TempFile&) = delete;
 
+  /// Returns the path to the temporary file
   std::string getPath() const { return m_path; }
 
   /// Overload the << operator to write data to the file
@@ -148,6 +162,7 @@ public:
 private:
   std::string m_path;
   std::ofstream m_ofs;
+  bool m_delete_during_destruction {true};
 };
 
 }  // end namespace filesystem

--- a/src/axom/core/utilities/FileUtilities.hpp
+++ b/src/axom/core/utilities/FileUtilities.hpp
@@ -191,6 +191,9 @@ public:
   /// Returns the path to the temporary file
   const std::string& getPath() const { return m_path; }
 
+  /// Loads the contents of the file into a string and returns it
+  std::string getFileContents() const;
+
   /// Overload the << operator to write data to the file (for general types)
   template <typename T>
   TempFile& operator<<(const T& data)

--- a/src/axom/core/utilities/FileUtilities.hpp
+++ b/src/axom/core/utilities/FileUtilities.hpp
@@ -127,26 +127,65 @@ int removeFile(const std::string& filename);
  * It ensures that the file is deleted upon destruction, if specified.
  * The class is non-copyable to prevent accidental duplication of file handles.
  *
- * The file is opened for writing upon construction and can be written to using the overloaded << operator.
- * 
  * \note The path to the temp file is likely different from the supplied \a file_name
  */
 class TempFile
 {
 public:
   /**
-   * \brief Constructor that takes a \a file_name template, and a flag to control whether the file gets deleted
+   * \brief Creates a tmp file using \a file_name and \a file_ext
    * 
-   * \param file_name The name (or path) of the temporary file to create.
+   * \param file_name The name of the temporary file to create without extension
+   * \param file_ext An optional extension for the temp file
    * \param delete_during_destruction If true (default), the file will be deleted when the TempFile object is destroyed.
+   * \note When creating the temp file, the name will likely be changed. You can get the actual file name
+   * using the \a getPath() function after the file is created.
    */
-  explicit TempFile(const std::string& file_name, bool delete_during_destruction = true);
+  TempFile(const std::string& file_name,
+           const std::string& file_ext,
+           bool delete_during_destruction = true);
+
+  explicit TempFile(const std::string& file_name, bool delete_during_destruction = true)
+    : TempFile(file_name, "", delete_during_destruction)
+  { }
 
   ~TempFile();
 
   // Non-copyable
   TempFile(const TempFile&) = delete;
+  TempFile(TempFile&&) = delete;
   TempFile& operator=(const TempFile&) = delete;
+  TempFile& operator=(TempFile&&) = delete;
+
+  /**
+   * \brief Opens the temporary file for writing
+   * 
+   * \param mode ios flags for opening the file (not used if file is already open)
+   * \return true if the file was successfully opened, false otherwise.
+   */
+  bool open(std::ios_base::openmode mode = std::ios::out | std::ios::trunc)
+  {
+    if(!m_ofs.is_open())
+    {
+      m_ofs.open(m_path, mode);
+    }
+    return m_ofs.is_open();
+  }
+
+  /// \brief Closes the temporary file if it is open
+  void close()
+  {
+    if(m_ofs.is_open())
+    {
+      m_ofs.close();
+    }
+  }
+
+  /**
+   * \brief Checks if the temporary file is currently open.
+   * \return true if the file is open, false otherwise.
+   */
+  bool is_open() const { return m_ofs.is_open(); }
 
   /// Returns the path to the temporary file
   std::string getPath() const { return m_path; }

--- a/src/axom/core/utilities/FileUtilities.hpp
+++ b/src/axom/core/utilities/FileUtilities.hpp
@@ -125,7 +125,7 @@ int removeFile(const std::string& filename);
  * /brief Utility class for managing temporary files.
  *
  * The TempFile class provides a convenient way to create and manage temporary files.
- * It ensures that the file is deleted upon destruction, if specified.
+ * It ensures that the file is deleted upon destruction, unless the user calls \a retain(true)
  * The class is non-copyable to prevent accidental duplication of file handles.
  *
  * \note The path to the temp file is likely different from the supplied \a file_name
@@ -138,17 +138,10 @@ public:
    * 
    * \param file_name The name of the temporary file to create without extension
    * \param file_ext An optional extension for the temp file
-   * \param delete_during_destruction If true (default), the file will be deleted when the TempFile object is destroyed.
    * \note When creating the temp file, the name will likely be changed. You can get the actual file name
    * using the \a getPath() function after the file is created.
    */
-  TempFile(const std::string& file_name,
-           const std::string& file_ext,
-           bool delete_during_destruction = true);
-
-  explicit TempFile(const std::string& file_name, bool delete_during_destruction = true)
-    : TempFile(file_name, "", delete_during_destruction)
-  { }
+  explicit TempFile(const std::string& file_name, const std::string& file_ext = "");
 
   ~TempFile();
 
@@ -157,6 +150,12 @@ public:
   TempFile(TempFile&&) = delete;
   TempFile& operator=(const TempFile&) = delete;
   TempFile& operator=(TempFile&&) = delete;
+
+  /// If set to true, we will retain the file after the instance is destroyed
+  void retain(bool should_retain) { m_retain_file = should_retain; }
+
+  /// Returns true if the file will be retained after the instance is destroyed, false otherwise (default)
+  bool retain() const { return m_retain_file; }
 
   /**
    * \brief Opens the temporary file for writing
@@ -212,7 +211,7 @@ public:
 private:
   std::string m_path;
   std::ofstream m_ofs;
-  bool m_delete_during_destruction {true};
+  bool m_retain_file {false};  // should the temp file persist after the instance goes out of scope?
 };
 
 }  // end namespace filesystem

--- a/src/axom/core/utilities/FileUtilities.hpp
+++ b/src/axom/core/utilities/FileUtilities.hpp
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <fstream>
+#include <utility>
 
 namespace axom
 {
@@ -190,11 +191,18 @@ public:
   /// Returns the path to the temporary file
   const std::string& getPath() const { return m_path; }
 
-  /// Overload the << operator to write data to the file
+  /// Overload the << operator to write data to the file (for general types)
   template <typename T>
-  TempFile& operator<<(T&& data)
+  TempFile& operator<<(const T& data)
   {
-    m_ofs << std::forward<T>(data);
+    m_ofs << data;
+    return *this;
+  }
+
+  /// Overload the << operator to support manipulators (e.g., std::endl)
+  TempFile& operator<<(std::ostream& (*manip)(std::ostream&))
+  {
+    m_ofs << manip;
     return *this;
   }
 

--- a/src/axom/core/utilities/FileUtilities.hpp
+++ b/src/axom/core/utilities/FileUtilities.hpp
@@ -188,7 +188,7 @@ public:
   bool is_open() const { return m_ofs.is_open(); }
 
   /// Returns the path to the temporary file
-  std::string getPath() const { return m_path; }
+  const std::string& getPath() const { return m_path; }
 
   /// Overload the << operator to write data to the file
   template <typename T>

--- a/src/axom/core/utilities/FileUtilities.hpp
+++ b/src/axom/core/utilities/FileUtilities.hpp
@@ -7,6 +7,7 @@
 #define COMMON_FILE_UTILITIES_H_
 
 #include <string>
+#include <fstream>
 
 namespace axom
 {
@@ -118,6 +119,36 @@ void getDirName(std::string& dir, const std::string& path);
  *       there are open file handles to the specified file.
  */
 int removeFile(const std::string& filename);
+
+/**
+ * Platform-independent RAII utility class to create an temporary file that will be deleted when the
+ * instance goes out of scope
+ */
+class TempFile
+{
+public:
+  explicit TempFile(const std::string& file_name);
+
+  ~TempFile();
+
+  // Non-copyable
+  TempFile(const TempFile&) = delete;
+  TempFile& operator=(const TempFile&) = delete;
+
+  std::string getPath() const { return m_path; }
+
+  /// Overload the << operator to write data to the file
+  template <typename T>
+  TempFile& operator<<(T&& data)
+  {
+    m_ofs << std::forward<T>(data);
+    return *this;
+  }
+
+private:
+  std::string m_path;
+  std::ofstream m_ofs;
+};
 
 }  // end namespace filesystem
 }  // end namespace utilities

--- a/src/axom/mint/tests/mint_su2_io.cpp
+++ b/src/axom/mint/tests/mint_su2_io.cpp
@@ -8,7 +8,8 @@
 #include "axom/mint/mesh/UnstructuredMesh.hpp" /* for UnstructuredMesh */
 #include "axom/mint/utils/su2_utils.hpp"       /* for su2 i/o */
 
-// Slic includes
+// Axom includes
+#include "axom/core.hpp"
 #include "axom/slic.hpp"
 
 // gtest includes
@@ -130,7 +131,8 @@ TEST(mint_su2_io, write_read_mixed_cell_topology_mesh)
   mesh.appendCell(c2, mint::TRIANGLE);
 
   // write an SU2 file
-  const std::string su2File = "mixed_cell_mesh.su2";
+  axom::utilities::filesystem::TempFile tmpfile("mixed_cell_mesh", ".su2");
+  const std::string& su2File = tmpfile.getPath();
   int rc = mint::write_su2(&mesh, su2File);
   EXPECT_EQ(rc, 0);
 
@@ -155,7 +157,6 @@ TEST(mint_su2_io, write_read_mixed_cell_topology_mesh)
 
   // cleanup
   delete test_mesh;
-  EXPECT_EQ(axom::utilities::filesystem::removeFile(su2File), 0);
 }
 
 //------------------------------------------------------------------------------
@@ -187,7 +188,8 @@ TEST(mint_su2_io, write_read_single_cell_topology_mesh)
   mesh.appendCell(c3);
 
   // write an SU2 file
-  const std::string su2File = "simple_mesh.su2";
+  axom::utilities::filesystem::TempFile tmpfile("simple_mesh", ".su2");
+  const std::string& su2File = tmpfile.getPath();
   int rc = mint::write_su2(&mesh, su2File);
   EXPECT_EQ(rc, 0);
 
@@ -212,7 +214,6 @@ TEST(mint_su2_io, write_read_single_cell_topology_mesh)
 
   // cleanup
   delete test_mesh;
-  EXPECT_EQ(axom::utilities::filesystem::removeFile(su2File), 0);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/mint/tests/mint_su2_io.cpp
+++ b/src/axom/mint/tests/mint_su2_io.cpp
@@ -4,9 +4,9 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 // Mint includes
-#include "axom/mint/mesh/UniformMesh.hpp"      /* for UniformMesh */
-#include "axom/mint/mesh/UnstructuredMesh.hpp" /* for UnstructuredMesh */
-#include "axom/mint/utils/su2_utils.hpp"       /* for su2 i/o */
+#include "axom/mint/mesh/UniformMesh.hpp"
+#include "axom/mint/mesh/UnstructuredMesh.hpp"
+#include "axom/mint/utils/su2_utils.hpp"
 
 // Axom includes
 #include "axom/core.hpp"
@@ -188,8 +188,8 @@ TEST(mint_su2_io, write_read_single_cell_topology_mesh)
   mesh.appendCell(c3);
 
   // write an SU2 file
-  axom::utilities::filesystem::TempFile tmpfile("simple_mesh", ".su2");
-  const std::string& su2File = tmpfile.getPath();
+  axom::utilities::filesystem::TempFile tempfile("simple_mesh", ".su2");
+  const std::string& su2File = tempfile.getPath();
   int rc = mint::write_su2(&mesh, su2File);
   EXPECT_EQ(rc, 0);
 

--- a/src/axom/quest/tests/quest_pro_e_reader.cpp
+++ b/src/axom/quest/tests/quest_pro_e_reader.cpp
@@ -24,7 +24,7 @@ namespace
 {
 /*!
  * \brief Generates a Pro/E file consisting of a single tetrahedron
- * \param [in] file the name of the file to generate.
+ * \param [in] file the temp file to generate.
  * \pre file.empty() == false
  */
 void generate_pro_e_file(fs::TempFile& file)
@@ -57,7 +57,7 @@ void generate_pro_e_file(fs::TempFile& file)
 //------------------------------------------------------------------------------
 TEST(quest_pro_e_reader, read_missing_file)
 {
-  const std::string INVALID_FILE = "nonexistant_file.proe";
+  const std::string INVALID_FILE = "nonexistent_file.proe";
   axom::quest::ProEReader reader;
   reader.setFileName(INVALID_FILE);
   int status = reader.read();

--- a/src/axom/quest/tests/quest_pro_e_reader.cpp
+++ b/src/axom/quest/tests/quest_pro_e_reader.cpp
@@ -5,7 +5,7 @@
 
 #include "axom/core/utilities/FileUtilities.hpp"
 #include "axom/core/NumericLimits.hpp"
-#include "axom/mint/utils/vtk_utils.hpp"  // for write_vtk
+#include "axom/mint/utils/vtk_utils.hpp"
 #include "axom/quest/io/ProEReader.hpp"
 #include "axom/slic.hpp"
 
@@ -13,6 +13,9 @@
 #include "gtest/gtest.h"
 
 #include <fstream>
+#include <iostream>
+
+namespace fs = axom::utilities::filesystem;
 
 //------------------------------------------------------------------------------
 // HELPER METHODS
@@ -24,29 +27,29 @@ namespace
  * \param [in] file the name of the file to generate.
  * \pre file.empty() == false
  */
-void generate_pro_e_file(const std::string& file)
+void generate_pro_e_file(fs::TempFile& file)
 {
-  EXPECT_FALSE(file.empty());
+  EXPECT_FALSE(file.getPath().empty());
 
-  std::ofstream ofs(file.c_str());
-  EXPECT_TRUE(ofs.is_open());
+  file.open();
+  EXPECT_TRUE(file.is_open());
 
-  ofs << "# Comment header to ignore" << std::endl;
-  ofs << "# Another comment" << std::endl;
+  file << "# Comment header to ignore" << std::endl;
+  file << "# Another comment" << std::endl;
 
   // Number of nodes followed by number of tetrahedra
-  ofs << "4 1" << std::endl;
+  file << "4 1" << std::endl;
 
   // Node ID followed by xyz coordinates
-  ofs << "1 -1.0 0.0 0.0" << std::endl;
-  ofs << "2 1.0 0.0 0.0" << std::endl;
-  ofs << "3 0.0 1.0 0.0" << std::endl;
-  ofs << "4 0.0 0.0 1.0" << std::endl;
+  file << "1 -1.0 0.0 0.0" << std::endl;
+  file << "2 1.0 0.0 0.0" << std::endl;
+  file << "3 0.0 1.0 0.0" << std::endl;
+  file << "4 0.0 0.0 1.0" << std::endl;
 
   // Tetrahedron ID followed by corresponding Node IDs
-  ofs << "1 1 2 3 4" << std::endl;
+  file << "1 1 2 3 4" << std::endl;
 
-  ofs.close();
+  file.close();
 }
 
 } /* end anonymous namespace */
@@ -54,7 +57,7 @@ void generate_pro_e_file(const std::string& file)
 //------------------------------------------------------------------------------
 TEST(quest_pro_e_reader, read_missing_file)
 {
-  const std::string INVALID_FILE = "foo.proe";
+  const std::string INVALID_FILE = "nonexistant_file.proe";
   axom::quest::ProEReader reader;
   reader.setFileName(INVALID_FILE);
   int status = reader.read();
@@ -65,10 +68,10 @@ TEST(quest_pro_e_reader, read_missing_file)
 TEST(quest_pro_e_reader, read_to_invalid_mesh)
 {
   const char* IGNORE_OUTPUT = ".*";
-  const std::string filename = "tet.proe";
 
   // STEP 0: generate a temporary Pro/E file for testing
-  generate_pro_e_file(filename);
+  fs::TempFile testFile("tet", ".proe");
+  generate_pro_e_file(testFile);
 
   // STEP 1: constructs mesh object to read in the mesh to
   axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE> trimesh(2, axom::mint::TRIANGLE);
@@ -76,7 +79,7 @@ TEST(quest_pro_e_reader, read_to_invalid_mesh)
 
   // STEP 2: read in the Pro/E mesh data
   axom::quest::ProEReader reader;
-  reader.setFileName(filename);
+  reader.setFileName(testFile.getPath());
   int status = reader.read();
   EXPECT_EQ(status, 0);
 
@@ -87,9 +90,6 @@ TEST(quest_pro_e_reader, read_to_invalid_mesh)
 
   // read the Pro/E mesh data to a axom::mint::Mesh that has a different cell type
   EXPECT_DEATH_IF_SUPPORTED(reader.getMesh(&hexmesh), IGNORE_OUTPUT);
-
-  // STEP 4: remove Pro/E file
-  EXPECT_EQ(axom::utilities::filesystem::removeFile(filename), 0);
 }
 
 //------------------------------------------------------------------------------
@@ -99,14 +99,13 @@ TEST(quest_pro_e_reader, read_pro_e)
   const double y_expected[] = {0.0, 0.0, 1.0, 0.0};
   const double z_expected[] = {0.0, 0.0, 0.0, 1.0};
 
-  const std::string filename = "tet.proe";
-
   // STEP 0: generate a temporary Pro/E file for testing
-  generate_pro_e_file(filename);
+  fs::TempFile testFile("tet", ".proe");
+  generate_pro_e_file(testFile);
 
   // STEP 1: create an Pro/E reader and read-in the mesh data
   axom::quest::ProEReader reader;
-  reader.setFileName(filename);
+  reader.setFileName(testFile.getPath());
   int status = reader.read();
   EXPECT_EQ(status, 0);
 
@@ -131,10 +130,7 @@ TEST(quest_pro_e_reader, read_pro_e)
     EXPECT_NEAR(x[inode], x_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(y[inode], y_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(z[inode], z_expected[inode], axom::numeric_limits<double>::epsilon());
-  }  // END for all nodes
-
-  // STEP 4: remove temporary Pro/E file
-  EXPECT_EQ(axom::utilities::filesystem::removeFile(filename), 0);
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -144,17 +140,16 @@ TEST(quest_pro_e_reader, read_pro_e_invbbox)
   const double y_expected[] = {0.0, 0.0, 1.0, 0.0};
   const double z_expected[] = {0.0, 0.0, 0.0, 1.0};
 
-  const std::string filename = "tet.proe";
-
   // STEP 0: generate a temporary Pro/E file for testing
-  generate_pro_e_file(filename);
+  fs::TempFile testFile("tet", ".proe");
+  generate_pro_e_file(testFile);
 
   // STEP 1: create an Pro/E reader and read-in the mesh data
   axom::quest::ProEReader reader;
   // invalid bounding box is the same as no bounding box: keep everything
   axom::quest::ProEReader::BBox3D invbbox;
   reader.setTetPredFromBoundingBox(invbbox, false);
-  reader.setFileName(filename);
+  reader.setFileName(testFile.getPath());
   int status = reader.read();
   EXPECT_EQ(status, 0);
 
@@ -179,10 +174,7 @@ TEST(quest_pro_e_reader, read_pro_e_invbbox)
     EXPECT_NEAR(x[inode], x_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(y[inode], y_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(z[inode], z_expected[inode], axom::numeric_limits<double>::epsilon());
-  }  // END for all nodes
-
-  // STEP 4: remove temporary Pro/E file
-  EXPECT_EQ(axom::utilities::filesystem::removeFile(filename), 0);
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -192,10 +184,9 @@ TEST(quest_pro_e_reader, read_pro_e_bbox_all)
   const double y_expected[] = {0.0, 0.0, 1.0, 0.0};
   const double z_expected[] = {0.0, 0.0, 0.0, 1.0};
 
-  const std::string filename = "tet.proe";
-
   // STEP 0: generate a temporary Pro/E file for testing
-  generate_pro_e_file(filename);
+  fs::TempFile testFile("tet", ".proe");
+  generate_pro_e_file(testFile);
 
   // STEP 1: create an Pro/E reader and read-in the mesh data
   axom::quest::ProEReader reader;
@@ -204,7 +195,7 @@ TEST(quest_pro_e_reader, read_pro_e_bbox_all)
   bbox.addPoint(axom::quest::ProEReader::Point3D {-1.5, -0.5, -0.5});
   bbox.addPoint(axom::quest::ProEReader::Point3D {1.5, 1.5, 1.5});
   reader.setTetPredFromBoundingBox(bbox, false);
-  reader.setFileName(filename);
+  reader.setFileName(testFile.getPath());
   int status = reader.read();
   EXPECT_EQ(status, 0);
 
@@ -229,10 +220,7 @@ TEST(quest_pro_e_reader, read_pro_e_bbox_all)
     EXPECT_NEAR(x[inode], x_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(y[inode], y_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(z[inode], z_expected[inode], axom::numeric_limits<double>::epsilon());
-  }  // END for all nodes
-
-  // STEP 4: remove temporary Pro/E file
-  EXPECT_EQ(axom::utilities::filesystem::removeFile(filename), 0);
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -242,10 +230,9 @@ TEST(quest_pro_e_reader, read_pro_e_bbox_some)
   const double y_expected[] = {0.0, 0.0, 1.0, 0.0};
   const double z_expected[] = {0.0, 0.0, 0.0, 1.0};
 
-  const std::string filename = "tet.proe";
-
   // STEP 0: generate a temporary Pro/E file for testing
-  generate_pro_e_file(filename);
+  fs::TempFile testFile("tet", ".proe");
+  generate_pro_e_file(testFile);
 
   // STEP 1: create an Pro/E reader and read-in the mesh data
   axom::quest::ProEReader reader;
@@ -255,7 +242,7 @@ TEST(quest_pro_e_reader, read_pro_e_bbox_some)
   bbox.addPoint(axom::quest::ProEReader::Point3D {-1.5, -0.5, -0.5});
   bbox.addPoint(axom::quest::ProEReader::Point3D {0, 1.5, 1.5});
   reader.setTetPredFromBoundingBox(bbox, false);
-  reader.setFileName(filename);
+  reader.setFileName(testFile.getPath());
   int status = reader.read();
   EXPECT_EQ(status, 0);
 
@@ -280,10 +267,7 @@ TEST(quest_pro_e_reader, read_pro_e_bbox_some)
     EXPECT_NEAR(x[inode], x_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(y[inode], y_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(z[inode], z_expected[inode], axom::numeric_limits<double>::epsilon());
-  }  // END for all nodes
-
-  // STEP 4: remove temporary Pro/E file
-  EXPECT_EQ(axom::utilities::filesystem::removeFile(filename), 0);
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -293,10 +277,9 @@ TEST(quest_pro_e_reader, read_pro_e_bbox_some_incl)
   const double y_expected[] = {0.0, 0.0, 1.0, 0.0};
   const double z_expected[] = {0.0, 0.0, 0.0, 1.0};
 
-  const std::string filename = "tet.proe";
-
   // STEP 0: generate a temporary Pro/E file for testing
-  generate_pro_e_file(filename);
+  fs::TempFile testFile("tet", ".proe");
+  generate_pro_e_file(testFile);
 
   // STEP 1: create an Pro/E reader and read-in the mesh data
   axom::quest::ProEReader reader;
@@ -306,7 +289,7 @@ TEST(quest_pro_e_reader, read_pro_e_bbox_some_incl)
   bbox.addPoint(axom::quest::ProEReader::Point3D {-1.5, -0.5, -0.5});
   bbox.addPoint(axom::quest::ProEReader::Point3D {0, 1.5, 1.5});
   reader.setTetPredFromBoundingBox(bbox);
-  reader.setFileName(filename);
+  reader.setFileName(testFile.getPath());
   int status = reader.read();
   EXPECT_EQ(status, 0);
 
@@ -331,10 +314,7 @@ TEST(quest_pro_e_reader, read_pro_e_bbox_some_incl)
     EXPECT_NEAR(x[inode], x_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(y[inode], y_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(z[inode], z_expected[inode], axom::numeric_limits<double>::epsilon());
-  }  // END for all nodes
-
-  // STEP 4: remove temporary Pro/E file
-  EXPECT_EQ(axom::utilities::filesystem::removeFile(filename), 0);
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -352,14 +332,13 @@ TEST(quest_pro_e_reader, read_pro_e_external)
 
   axom::IndexType conn[] = {-1, -1, -1, -1};
 
-  const std::string filename = "tet.proe";
-
   // STEP 0: generate a temporary Pro/E file for testing
-  generate_pro_e_file(filename);
+  fs::TempFile testFile("tet", ".proe");
+  generate_pro_e_file(testFile);
 
   // STEP 1: create a Pro/E reader and read-in the mesh data
   axom::quest::ProEReader reader;
-  reader.setFileName(filename);
+  reader.setFileName(testFile.getPath());
   int status = reader.read();
   EXPECT_EQ(status, 0);
 
@@ -384,10 +363,7 @@ TEST(quest_pro_e_reader, read_pro_e_external)
     EXPECT_NEAR(x[inode], x_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(y[inode], y_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(z[inode], z_expected[inode], axom::numeric_limits<double>::epsilon());
-  }  // END for all nodes
-
-  // STEP 4: remove temporary Pro/E file
-  EXPECT_EQ(axom::utilities::filesystem::removeFile(filename), 0);
+  }
 }
 
 #ifdef AXOM_DATA_DIR
@@ -399,7 +375,6 @@ TEST(quest_pro_e_reader, cup_pro_e)
   constexpr double EPS = axom::numeric_limits<double>::epsilon();
 
   // STEP 0: Get Pro/E cup example file for testing
-  namespace fs = axom::utilities::filesystem;
   std::string cup = fs::joinPath(AXOM_DATA_DIR, "quest/cup.proe");
 
   // STEP 1: create a Pro/E reader and read-in the mesh data
@@ -509,7 +484,6 @@ TEST(quest_pro_e_reader, cup_pro_e_some)
   constexpr int NUM_BBOX_TETS = 52;
 
   // STEP 0: Get Pro/E cup example file for testing
-  namespace fs = axom::utilities::filesystem;
   std::string cup = fs::joinPath(AXOM_DATA_DIR, "quest/cup.proe");
 
   // STEP 1: create a Pro/E reader and read-in the mesh data
@@ -544,7 +518,6 @@ TEST(quest_pro_e_reader, cup_pro_e_some_incl)
   constexpr int NUM_BBOX_INCL_TETS = 298;
 
   // STEP 0: Get Pro/E cup example file for testing
-  namespace fs = axom::utilities::filesystem;
   std::string cup = fs::joinPath(AXOM_DATA_DIR, "quest/cup.proe");
 
   // STEP 1: create a Pro/E reader and read-in the mesh data

--- a/src/axom/quest/tests/quest_sampling_shaper.cpp
+++ b/src/axom/quest/tests/quest_sampling_shaper.cpp
@@ -62,27 +62,31 @@ const std::string proe_tet_fmt_str = R"(
 // Set the following to true for verbose output and for saving vis files
 constexpr bool very_verbose_output = false;
 
-/// RAII utility class to write a file at construction time and remove it
-/// once the instance is out of scope
+/// RAII utility class to write a file and remove it when the instance is out of scope
 class ScopedTemporaryFile
 {
+private:
+  // Set this to false to keep the ScopedTemporaryFiles at end of run
+  static constexpr bool s_delete_tmp_files_at_end_of_scope {true};
+
 public:
-  ScopedTemporaryFile(const std::string& filename, const std::string& contents)
-    : m_filename(filename)
+  ScopedTemporaryFile(const std::string& file_name,
+                      const std::string& file_ext,
+                      const std::string& contents)
+    : m_tempFile(file_name, file_ext, s_delete_tmp_files_at_end_of_scope)
   {
-    std::ofstream ofs(m_filename.c_str(), std::ios::out);
-    ofs << contents;
+    m_tempFile.open();
+    m_tempFile << contents;
+    m_tempFile.close();
   }
 
-  ~ScopedTemporaryFile() { EXPECT_EQ(axom::utilities::filesystem::removeFile(m_filename), 0); }
-
-  const std::string& getFileName() const { return m_filename; }
+  const std::string& getFileName() const { return m_tempFile.getPath(); }
 
   std::string getFileContents() const
   {
     std::stringstream buffer;
 
-    std::ifstream ifs(m_filename.c_str(), std::ios::in);
+    std::ifstream ifs(getFileName().c_str(), std::ios::in);
     if(ifs.is_open())
     {
       buffer << ifs.rdbuf();
@@ -92,7 +96,8 @@ public:
   }
 
 private:
-  const std::string m_filename;
+  /// The TempFile class creates the file w/ unique name and removes the file in its destructor
+  axom::utilities::filesystem::TempFile m_tempFile;
 };
 
 // Utility function to slice a tetrahedron along a plane
@@ -558,33 +563,6 @@ public:
 
 //-----------------------------------------------------------------------------
 
-TEST(ScopedTemporaryFile, basic)
-{
-  using axom::utilities::filesystem::pathExists;
-
-  const std::string filename = "previously_nonexistent.file";
-  const std::string contents = "file contents!";
-
-  // File does not exist before entering scope
-  EXPECT_FALSE(pathExists(filename));
-
-  // File is created and exists within the scope
-  {
-    ScopedTemporaryFile test_file(filename, contents);
-
-    EXPECT_EQ(test_file.getFileName(), filename);
-    ASSERT_TRUE(pathExists(test_file.getFileName()));
-
-    // check contents
-    EXPECT_EQ(contents, test_file.getFileContents());
-  }
-
-  // File no longer exists outside the scope
-  EXPECT_FALSE(pathExists(filename));
-}
-
-//-----------------------------------------------------------------------------
-
 TEST_F(SamplingShaperTest2D, check_mesh)
 {
   auto& mesh = this->getMesh();
@@ -621,9 +599,10 @@ shapes:
 
   const std::string circle_material = "circleMat";
 
-  ScopedTemporaryFile contour_file(axom::fmt::format("{}.contour", testname), unit_circle_contour);
+  ScopedTemporaryFile contour_file(testname, ".contour", unit_circle_contour);
 
-  ScopedTemporaryFile shape_file(axom::fmt::format("{}.yaml", testname),
+  ScopedTemporaryFile shape_file(testname,
+                                 ".yaml",
                                  axom::fmt::format(axom::fmt::runtime(shape_template),
                                                    circle_material,
                                                    contour_file.getFileName()));
@@ -669,9 +648,10 @@ shapes:
 
   const std::string circle_material = "circleMat";
 
-  ScopedTemporaryFile contour_file(axom::fmt::format("{}.contour", testname), unit_circle_contour);
+  ScopedTemporaryFile contour_file(testname, ".contour", unit_circle_contour);
 
-  ScopedTemporaryFile shape_file(axom::fmt::format("{}.yaml", testname),
+  ScopedTemporaryFile shape_file(testname,
+                                 ".yaml",
                                  axom::fmt::format(axom::fmt::runtime(shape_template),
                                                    circle_material,
                                                    contour_file.getFileName()));
@@ -721,9 +701,10 @@ shapes:
 
   const std::string circle_material = "circleMat";
 
-  ScopedTemporaryFile contour_file(axom::fmt::format("{}.contour", testname), unit_circle_contour);
+  ScopedTemporaryFile contour_file(testname, ".contour", unit_circle_contour);
 
-  ScopedTemporaryFile shape_file(axom::fmt::format("{}.yaml", testname),
+  ScopedTemporaryFile shape_file(testname,
+                                 ".yaml",
                                  axom::fmt::format(axom::fmt::runtime(shape_template),
                                                    circle_material,
                                                    contour_file.getFileName()));
@@ -782,10 +763,11 @@ shapes:
   const std::string outer_material = "outer";
   const std::string inner_material = "inner";
 
-  ScopedTemporaryFile contour_file(axom::fmt::format("{}.contour", testname), unit_circle_contour);
+  ScopedTemporaryFile contour_file(testname, ".contour", unit_circle_contour);
 
   ScopedTemporaryFile shape_file(
-    axom::fmt::format("{}.yaml", testname),
+    testname,
+    ".yaml",
     axom::fmt::format(axom::fmt::runtime(shape_template), contour_file.getFileName()));
 
   if(very_verbose_output)
@@ -842,11 +824,12 @@ shapes:
       - scale: .5
 )";
 
-  ScopedTemporaryFile contour_file(axom::fmt::format("{}.contour", testname), unit_circle_contour);
+  ScopedTemporaryFile contour_file(testname, ".contour", unit_circle_contour);
 
   // Set background material to 'void' (which is not present elsewhere)
   {
-    ScopedTemporaryFile shape_file(axom::fmt::format("{}.yaml", testname),
+    ScopedTemporaryFile shape_file(testname,
+                                   ".yaml",
                                    axom::fmt::format(axom::fmt::runtime(shape_template),
                                                      contour_file.getFileName(),
                                                      "void",
@@ -885,7 +868,8 @@ shapes:
 
   // Set background and inner hole materials to 'void'
   {
-    ScopedTemporaryFile shape_file(axom::fmt::format("{}.yaml", testname),
+    ScopedTemporaryFile shape_file(testname,
+                                   ".yaml",
                                    axom::fmt::format(axom::fmt::runtime(shape_template),
                                                      contour_file.getFileName(),
                                                      "void",
@@ -949,7 +933,8 @@ shapes:
 )";
 
   ScopedTemporaryFile shape_file(
-    axom::fmt::format("{}.yaml", testname),
+    testname,
+    ".yaml",
     axom::fmt::format(axom::fmt::runtime(shape_template), "void", "left", "odds"));
 
   if(very_verbose_output)
@@ -1044,10 +1029,11 @@ shapes:
   replaces: [void, hole]
 )";
 
-  ScopedTemporaryFile contour_file(axom::fmt::format("{}.contour", testname), unit_circle_contour);
+  ScopedTemporaryFile contour_file(testname, ".contour", unit_circle_contour);
 
   ScopedTemporaryFile shape_file(
-    axom::fmt::format("{}.yaml", testname),
+    testname,
+    ".yaml",
     axom::fmt::format(axom::fmt::runtime(shape_template), contour_file.getFileName()));
 
   if(very_verbose_output)
@@ -1159,10 +1145,10 @@ shapes:
   const std::string double_underscored_shape_name {"double_underscored_shape"};
   const std::string double_underscored_mat_name {"double_underscored_mat"};
 
-  ScopedTemporaryFile contour_file(axom::fmt::format("{}.contour", testname),
-                                   unit_semicircle_contour);
+  ScopedTemporaryFile contour_file(testname, ".contour", unit_semicircle_contour);
 
-  ScopedTemporaryFile shape_file(axom::fmt::format("{}.yaml", testname),
+  ScopedTemporaryFile shape_file(testname,
+                                 ".yaml",
                                  axom::fmt::format(axom::fmt::runtime(shape_template),
                                                    contour_file.getFileName(),
                                                    radius,
@@ -1245,9 +1231,10 @@ shapes:
   const std::string sphere_material = "vaccum";
   const std::string sphere_path = axom::fmt::format("{}/quest/unit_sphere.stl", AXOM_DATA_DIR);
 
-  ScopedTemporaryFile contour_file(axom::fmt::format("{}.contour", testname), unit_circle_contour);
+  ScopedTemporaryFile contour_file(testname, ".contour", unit_circle_contour);
 
-  ScopedTemporaryFile shape_file(axom::fmt::format("{}.yaml", testname),
+  ScopedTemporaryFile shape_file(testname,
+                                 ".yaml",
                                  axom::fmt::format(axom::fmt::runtime(shape_template),
                                                    contour_file.getFileName(),
                                                    sphere_path,
@@ -1319,7 +1306,8 @@ shapes:
   const std::string tet_path = axom::fmt::format("{}/quest/tetrahedron.stl", AXOM_DATA_DIR);
 
   ScopedTemporaryFile shape_file(
-    axom::fmt::format("{}.yaml", testname),
+    testname,
+    ".yaml",
     axom::fmt::format(axom::fmt::runtime(shape_template), tet_material, tet_path));
 
   if(very_verbose_output)
@@ -1396,7 +1384,8 @@ shapes:
   const std::string tet_path = axom::fmt::format("{}/quest/tetrahedron.stl", AXOM_DATA_DIR);
 
   ScopedTemporaryFile shape_file(
-    axom::fmt::format("{}.yaml", testname),
+    testname,
+    ".yaml",
     axom::fmt::format(axom::fmt::runtime(shape_template), tet_material, tet_path));
 
   if(very_verbose_output)
@@ -1509,7 +1498,8 @@ shapes:
 
   const std::string tet_path = axom::fmt::format("{}/quest/tetrahedron.stl", AXOM_DATA_DIR);
 
-  ScopedTemporaryFile shape_file(axom::fmt::format("{}.yaml", testname),
+  ScopedTemporaryFile shape_file(testname,
+                                 ".yaml",
                                  axom::fmt::format(axom::fmt::runtime(shape_template), tet_path));
 
   if(very_verbose_output)
@@ -1585,7 +1575,8 @@ shapes:
   const std::string tet_path = axom::fmt::format("{}/quest/tetrahedron.stl", AXOM_DATA_DIR);
 
   ScopedTemporaryFile shape_file(
-    axom::fmt::format("{}.yaml", testname),
+    testname,
+    ".yaml",
     axom::fmt::format(axom::fmt::runtime(shape_template), tet_material, tet_path));
 
   if(very_verbose_output)
@@ -1642,7 +1633,8 @@ shapes:
   const std::string tet_path = axom::fmt::format("{}/quest/tetrahedron.stl", AXOM_DATA_DIR);
 
   ScopedTemporaryFile shape_file(
-    axom::fmt::format("{}.yaml", testname),
+    testname,
+    ".yaml",
     axom::fmt::format(axom::fmt::runtime(shape_template), tet_material, tet_path));
 
   if(very_verbose_output)
@@ -1700,10 +1692,10 @@ shapes:
 
   const std::string circle_material = "steel";
 
-  ScopedTemporaryFile contour_file(axom::fmt::format("{}.contour", testname),
-                                   unit_semicircle_contour);
+  ScopedTemporaryFile contour_file(testname, ".contour", unit_semicircle_contour);
 
-  ScopedTemporaryFile shape_file(axom::fmt::format("{}.yaml", testname),
+  ScopedTemporaryFile shape_file(testname,
+                                 ".yaml",
                                  axom::fmt::format(axom::fmt::runtime(shape_template),
                                                    circle_material,
                                                    contour_file.getFileName(),
@@ -1777,10 +1769,10 @@ shapes:
   const std::string sphere_material = "void";
   const std::string sphere_path = axom::fmt::format("{}/quest/unit_sphere.stl", AXOM_DATA_DIR);
 
-  ScopedTemporaryFile contour_file(axom::fmt::format("{}.contour", testname),
-                                   unit_semicircle_contour);
+  ScopedTemporaryFile contour_file(testname, ".contour", unit_semicircle_contour);
 
-  ScopedTemporaryFile shape_file(axom::fmt::format("{}.yaml", testname),
+  ScopedTemporaryFile shape_file(testname,
+                                 ".yaml",
                                  axom::fmt::format(axom::fmt::runtime(shape_template),
                                                    contour_file.getFileName(),
                                                    sphere_path,
@@ -1864,10 +1856,11 @@ shapes:
   // clang-format on
 
   const std::string tet_material = "steel";
-  ScopedTemporaryFile tet_file(axom::fmt::format("{}.proe", testname), proe_tet_str);
+  ScopedTemporaryFile tet_file(testname, ".proe", proe_tet_str);
 
   ScopedTemporaryFile shape_file(
-    axom::fmt::format("{}.yaml", testname),
+    testname,
+    ".yaml",
     axom::fmt::format(axom::fmt::runtime(shape_template), tet_file.getFileName(), tet_material));
 
   if(very_verbose_output)
@@ -1973,9 +1966,10 @@ piece = line(end=start)
                         bb.getMax()[0],
                         bb.getMax()[1]);
 
-    ScopedTemporaryFile contour_file(axom::fmt::format("{}.contour", testname), contour_str);
+    ScopedTemporaryFile contour_file(testname, ".contour", contour_str);
 
-    ScopedTemporaryFile shape_file(axom::fmt::format("{}.yaml", testname),
+    ScopedTemporaryFile shape_file(testname,
+                                   ".yaml",
                                    axom::fmt::format(axom::fmt::runtime(shape_template),
                                                      rect_shape,
                                                      rect_material,

--- a/src/axom/quest/tests/quest_sampling_shaper.cpp
+++ b/src/axom/quest/tests/quest_sampling_shaper.cpp
@@ -40,6 +40,7 @@ namespace primal = axom::primal;
 namespace quest = axom::quest;
 namespace sidre = axom::sidre;
 namespace slic = axom::slic;
+namespace fs = axom::utilities::filesystem;
 
 namespace
 {
@@ -61,35 +62,6 @@ const std::string proe_tet_fmt_str = R"(
 
 // Set the following to true for verbose output and for saving vis files
 constexpr bool very_verbose_output = false;
-
-/// RAII utility class to write a file and remove it when the instance is out of scope
-class ScopedTemporaryFile
-{
-private:
-  // Set this to true to keep the temp files at end of run
-  static constexpr bool s_retain_tmp_files_at_end_of_scope {false};
-
-public:
-  ScopedTemporaryFile(const std::string& file_name,
-                      const std::string& file_ext,
-                      const std::string& contents)
-    : m_tempFile(file_name, file_ext)
-  {
-    m_tempFile.retain(s_retain_tmp_files_at_end_of_scope);
-
-    m_tempFile.open();
-    m_tempFile << contents;
-    m_tempFile.close();
-  }
-
-  const std::string& getFileName() const { return m_tempFile.getPath(); }
-
-  std::string getFileContents() const { return m_tempFile.getFileContents(); }
-
-private:
-  /// The TempFile class creates the file w/ unique name and removes the file in its destructor
-  axom::utilities::filesystem::TempFile m_tempFile;
-};
 
 // Utility function to slice a tetrahedron along a plane
 primal::Polygon<double, 3> slice(const primal::Tetrahedron<double, 3>& tet,
@@ -590,13 +562,12 @@ shapes:
 
   const std::string circle_material = "circleMat";
 
-  ScopedTemporaryFile contour_file(testname, ".contour", unit_circle_contour);
+  fs::TempFile contour_file(testname, ".contour");
+  contour_file.write(unit_circle_contour);
 
-  ScopedTemporaryFile shape_file(testname,
-                                 ".yaml",
-                                 axom::fmt::format(axom::fmt::runtime(shape_template),
-                                                   circle_material,
-                                                   contour_file.getFileName()));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(
+    axom::fmt::format(axom::fmt::runtime(shape_template), circle_material, contour_file.getPath()));
 
   if(very_verbose_output)
   {
@@ -604,8 +575,8 @@ shapes:
     SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
   }
 
-  this->validateShapeFile(shape_file.getFileName());
-  this->initializeShaping(shape_file.getFileName());
+  this->validateShapeFile(shape_file.getPath());
+  this->initializeShaping(shape_file.getPath());
   this->runShaping();
 
   // check that the result has a volume fraction field associated with the circle material
@@ -639,16 +610,15 @@ shapes:
 
   const std::string circle_material = "circleMat";
 
-  ScopedTemporaryFile contour_file(testname, ".contour", unit_circle_contour);
+  fs::TempFile contour_file(testname, ".contour");
+  contour_file.write(unit_circle_contour);
 
-  ScopedTemporaryFile shape_file(testname,
-                                 ".yaml",
-                                 axom::fmt::format(axom::fmt::runtime(shape_template),
-                                                   circle_material,
-                                                   contour_file.getFileName()));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(
+    axom::fmt::format(axom::fmt::runtime(shape_template), circle_material, contour_file.getPath()));
 
-  this->validateShapeFile(shape_file.getFileName());
-  this->initializeShaping(shape_file.getFileName());
+  this->validateShapeFile(shape_file.getPath());
+  this->initializeShaping(shape_file.getPath());
 
   // check that we can set several projectors in 2D and 3D
   // uses simplest projectors, e.g. identity in 2D and 3D
@@ -692,16 +662,15 @@ shapes:
 
   const std::string circle_material = "circleMat";
 
-  ScopedTemporaryFile contour_file(testname, ".contour", unit_circle_contour);
+  fs::TempFile contour_file(testname, ".contour");
+  contour_file.write(unit_circle_contour);
 
-  ScopedTemporaryFile shape_file(testname,
-                                 ".yaml",
-                                 axom::fmt::format(axom::fmt::runtime(shape_template),
-                                                   circle_material,
-                                                   contour_file.getFileName()));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(
+    axom::fmt::format(axom::fmt::runtime(shape_template), circle_material, contour_file.getPath()));
 
-  this->validateShapeFile(shape_file.getFileName());
-  this->initializeShaping(shape_file.getFileName());
+  this->validateShapeFile(shape_file.getPath());
+  this->initializeShaping(shape_file.getPath());
 
   // check that we can set several projectors in 2D and 3D
   // creating an ellipse by scaling input x and y by scale_a and scale_b
@@ -754,12 +723,11 @@ shapes:
   const std::string outer_material = "outer";
   const std::string inner_material = "inner";
 
-  ScopedTemporaryFile contour_file(testname, ".contour", unit_circle_contour);
+  fs::TempFile contour_file(testname, ".contour");
+  contour_file.write(unit_circle_contour);
 
-  ScopedTemporaryFile shape_file(
-    testname,
-    ".yaml",
-    axom::fmt::format(axom::fmt::runtime(shape_template), contour_file.getFileName()));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template), contour_file.getPath()));
 
   if(very_verbose_output)
   {
@@ -767,9 +735,9 @@ shapes:
     SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
   }
 
-  this->validateShapeFile(shape_file.getFileName());
+  this->validateShapeFile(shape_file.getPath());
 
-  this->initializeShaping(shape_file.getFileName());
+  this->initializeShaping(shape_file.getPath());
   this->runShaping();
 
   // check that the result has a volume fraction field associated with the circle material
@@ -815,17 +783,17 @@ shapes:
       - scale: .5
 )";
 
-  ScopedTemporaryFile contour_file(testname, ".contour", unit_circle_contour);
+  fs::TempFile contour_file(testname, ".contour");
+  contour_file.write(unit_circle_contour);
 
   // Set background material to 'void' (which is not present elsewhere)
   {
-    ScopedTemporaryFile shape_file(testname,
-                                   ".yaml",
-                                   axom::fmt::format(axom::fmt::runtime(shape_template),
-                                                     contour_file.getFileName(),
-                                                     "void",
-                                                     "disk",
-                                                     "hole"));
+    fs::TempFile shape_file(testname, ".yaml");
+    shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template),
+                                       contour_file.getPath(),
+                                       "void",
+                                       "disk",
+                                       "hole"));
 
     // Create an initial background material set to 1 everywhere
     std::map<std::string, mfem::GridFunction*> initialGridFunctions;
@@ -836,8 +804,8 @@ shapes:
       initialGridFunctions["void"] = vf;
     }
 
-    this->validateShapeFile(shape_file.getFileName());
-    this->initializeShaping(shape_file.getFileName(), initialGridFunctions);
+    this->validateShapeFile(shape_file.getPath());
+    this->initializeShaping(shape_file.getPath(), initialGridFunctions);
     this->runShaping();
 
     // check that the result has a volume fraction field associated with the circle material
@@ -859,13 +827,12 @@ shapes:
 
   // Set background and inner hole materials to 'void'
   {
-    ScopedTemporaryFile shape_file(testname,
-                                   ".yaml",
-                                   axom::fmt::format(axom::fmt::runtime(shape_template),
-                                                     contour_file.getFileName(),
-                                                     "void",
-                                                     "disk",
-                                                     "void"));
+    fs::TempFile shape_file(testname, ".yaml");
+    shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template),
+                                       contour_file.getPath(),
+                                       "void",
+                                       "disk",
+                                       "void"));
 
     // Create an initial background material set to 1 everywhere
     std::map<std::string, mfem::GridFunction*> initialGridFunctions;
@@ -876,8 +843,8 @@ shapes:
       initialGridFunctions["void"] = vf;
     }
 
-    this->validateShapeFile(shape_file.getFileName());
-    this->initializeShaping(shape_file.getFileName(), initialGridFunctions);
+    this->validateShapeFile(shape_file.getPath());
+    this->initializeShaping(shape_file.getPath(), initialGridFunctions);
     this->runShaping();
 
     // check that the result has a volume fraction field associated with the circle material
@@ -923,10 +890,8 @@ shapes:
   does_not_replace: [{1}]
 )";
 
-  ScopedTemporaryFile shape_file(
-    testname,
-    ".yaml",
-    axom::fmt::format(axom::fmt::runtime(shape_template), "void", "left", "odds"));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template), "void", "left", "odds"));
 
   if(very_verbose_output)
   {
@@ -954,8 +919,8 @@ shapes:
     initialGridFunctions["odds"] = vf;
   }
 
-  this->validateShapeFile(shape_file.getFileName());
-  this->initializeShaping(shape_file.getFileName(), initialGridFunctions);
+  this->validateShapeFile(shape_file.getPath());
+  this->initializeShaping(shape_file.getPath(), initialGridFunctions);
   this->runShaping();
 
   // check that the result has a volume fraction field associated with the circle material
@@ -1020,12 +985,11 @@ shapes:
   replaces: [void, hole]
 )";
 
-  ScopedTemporaryFile contour_file(testname, ".contour", unit_circle_contour);
+  fs::TempFile contour_file(testname, ".contour");
+  contour_file.write(unit_circle_contour);
 
-  ScopedTemporaryFile shape_file(
-    testname,
-    ".yaml",
-    axom::fmt::format(axom::fmt::runtime(shape_template), contour_file.getFileName()));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template), contour_file.getPath()));
 
   if(very_verbose_output)
   {
@@ -1063,8 +1027,8 @@ shapes:
   // The interior hole is within radius .5, but is replaced by left and odds
   // The odds material is all cells w/ odd index, but not covering 'left' or 'disk'
   // The end result for the void background is everything that's left
-  this->validateShapeFile(shape_file.getFileName());
-  this->initializeShaping(shape_file.getFileName(), initialGridFunctions);
+  this->validateShapeFile(shape_file.getPath());
+  this->initializeShaping(shape_file.getPath(), initialGridFunctions);
   this->runShaping();
 
   // check that the result has the correct volume fractions
@@ -1136,19 +1100,19 @@ shapes:
   const std::string double_underscored_shape_name {"double_underscored_shape"};
   const std::string double_underscored_mat_name {"double_underscored_mat"};
 
-  ScopedTemporaryFile contour_file(testname, ".contour", unit_semicircle_contour);
+  fs::TempFile contour_file(testname, ".contour");
+  contour_file.write(unit_semicircle_contour);
 
-  ScopedTemporaryFile shape_file(testname,
-                                 ".yaml",
-                                 axom::fmt::format(axom::fmt::runtime(shape_template),
-                                                   contour_file.getFileName(),
-                                                   radius,
-                                                   shape_name,
-                                                   mat_name,
-                                                   underscored_shape_name,
-                                                   underscored_mat_name,
-                                                   double_underscored_shape_name,
-                                                   double_underscored_mat_name));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template),
+                                     contour_file.getPath(),
+                                     radius,
+                                     shape_name,
+                                     mat_name,
+                                     underscored_shape_name,
+                                     underscored_mat_name,
+                                     double_underscored_shape_name,
+                                     double_underscored_mat_name));
 
   if(very_verbose_output)
   {
@@ -1156,8 +1120,8 @@ shapes:
     SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
   }
 
-  this->validateShapeFile(shape_file.getFileName());
-  this->initializeShaping(shape_file.getFileName());
+  this->validateShapeFile(shape_file.getPath());
+  this->initializeShaping(shape_file.getPath());
 
   this->runShaping();
 
@@ -1222,17 +1186,17 @@ shapes:
   const std::string sphere_material = "vaccum";
   const std::string sphere_path = axom::fmt::format("{}/quest/unit_sphere.stl", AXOM_DATA_DIR);
 
-  ScopedTemporaryFile contour_file(testname, ".contour", unit_circle_contour);
+  fs::TempFile contour_file(testname, ".contour");
+  contour_file.write(unit_circle_contour);
 
-  ScopedTemporaryFile shape_file(testname,
-                                 ".yaml",
-                                 axom::fmt::format(axom::fmt::runtime(shape_template),
-                                                   contour_file.getFileName(),
-                                                   sphere_path,
-                                                   radius,
-                                                   background_material,
-                                                   circle_material,
-                                                   sphere_material));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template),
+                                     contour_file.getPath(),
+                                     sphere_path,
+                                     radius,
+                                     background_material,
+                                     circle_material,
+                                     sphere_material));
 
   if(very_verbose_output)
   {
@@ -1248,8 +1212,8 @@ shapes:
     initialGridFunctions[background_material] = vf;
   }
 
-  this->validateShapeFile(shape_file.getFileName());
-  this->initializeShaping(shape_file.getFileName(), initialGridFunctions);
+  this->validateShapeFile(shape_file.getPath());
+  this->initializeShaping(shape_file.getPath(), initialGridFunctions);
 
   // set projector from 2D mesh points to 3D query points within STL
   this->m_shaper->setPointProjector23([](Point2D pt) { return Point3D {pt[0], pt[1], 0.}; });
@@ -1296,10 +1260,8 @@ shapes:
   const std::string tet_material = "steel";
   const std::string tet_path = axom::fmt::format("{}/quest/tetrahedron.stl", AXOM_DATA_DIR);
 
-  ScopedTemporaryFile shape_file(
-    testname,
-    ".yaml",
-    axom::fmt::format(axom::fmt::runtime(shape_template), tet_material, tet_path));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template), tet_material, tet_path));
 
   if(very_verbose_output)
   {
@@ -1307,8 +1269,8 @@ shapes:
     SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
   }
 
-  this->validateShapeFile(shape_file.getFileName());
-  this->initializeShaping(shape_file.getFileName());
+  this->validateShapeFile(shape_file.getPath());
+  this->initializeShaping(shape_file.getPath());
   this->runShaping();
 
   // Check that the result has a volume fraction field associated with the tetrahedron material
@@ -1374,17 +1336,15 @@ shapes:
   const std::string tet_material = "steel";
   const std::string tet_path = axom::fmt::format("{}/quest/tetrahedron.stl", AXOM_DATA_DIR);
 
-  ScopedTemporaryFile shape_file(
-    testname,
-    ".yaml",
-    axom::fmt::format(axom::fmt::runtime(shape_template), tet_material, tet_path));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template), tet_material, tet_path));
 
   if(very_verbose_output)
   {
     SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
   }
 
-  this->validateShapeFile(shape_file.getFileName());
+  this->validateShapeFile(shape_file.getPath());
 
   // Create initial background materials based on octant attributes
   // Octants were offset by one since mfem doesn't allow setting attribute to zero
@@ -1400,7 +1360,7 @@ shapes:
     }
   }
 
-  this->initializeShaping(shape_file.getFileName(), initialGridFunctions);
+  this->initializeShaping(shape_file.getPath(), initialGridFunctions);
   this->runShaping();
 
   // Check that the result has a volume fraction field associated with the tetrahedron material
@@ -1489,16 +1449,15 @@ shapes:
 
   const std::string tet_path = axom::fmt::format("{}/quest/tetrahedron.stl", AXOM_DATA_DIR);
 
-  ScopedTemporaryFile shape_file(testname,
-                                 ".yaml",
-                                 axom::fmt::format(axom::fmt::runtime(shape_template), tet_path));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template), tet_path));
 
   if(very_verbose_output)
   {
     SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
   }
 
-  this->validateShapeFile(shape_file.getFileName());
+  this->validateShapeFile(shape_file.getPath());
 
   // Create initial background materials based on octant attributes
   std::map<std::string, mfem::GridFunction*> initialGridFunctions;
@@ -1513,7 +1472,7 @@ shapes:
     }
   }
 
-  this->initializeShaping(shape_file.getFileName(), initialGridFunctions);
+  this->initializeShaping(shape_file.getPath(), initialGridFunctions);
   this->runShaping();
 
   // Check that the result has a volume fraction field associated with the tetrahedron material
@@ -1565,18 +1524,16 @@ shapes:
   const std::string tet_material = "steel";
   const std::string tet_path = axom::fmt::format("{}/quest/tetrahedron.stl", AXOM_DATA_DIR);
 
-  ScopedTemporaryFile shape_file(
-    testname,
-    ".yaml",
-    axom::fmt::format(axom::fmt::runtime(shape_template), tet_material, tet_path));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template), tet_material, tet_path));
 
   if(very_verbose_output)
   {
     SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
   }
 
-  this->validateShapeFile(shape_file.getFileName());
-  this->initializeShaping(shape_file.getFileName());
+  this->validateShapeFile(shape_file.getPath());
+  this->initializeShaping(shape_file.getPath());
 
   // check that we can set several projectors in 2D and 3D
   // uses simplest projectors, e.g. identity in 2D and 3D
@@ -1623,18 +1580,16 @@ shapes:
   const std::string tet_material = "steel";
   const std::string tet_path = axom::fmt::format("{}/quest/tetrahedron.stl", AXOM_DATA_DIR);
 
-  ScopedTemporaryFile shape_file(
-    testname,
-    ".yaml",
-    axom::fmt::format(axom::fmt::runtime(shape_template), tet_material, tet_path));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template), tet_material, tet_path));
 
   if(very_verbose_output)
   {
     SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
   }
 
-  this->validateShapeFile(shape_file.getFileName());
-  this->initializeShaping(shape_file.getFileName());
+  this->validateShapeFile(shape_file.getPath());
+  this->initializeShaping(shape_file.getPath());
 
   // scale input points by a factor of 1/2 in each dimension
   this->m_shaper->setPointProjector33([](const Point3D& pt) {
@@ -1683,14 +1638,14 @@ shapes:
 
   const std::string circle_material = "steel";
 
-  ScopedTemporaryFile contour_file(testname, ".contour", unit_semicircle_contour);
+  fs::TempFile contour_file(testname, ".contour");
+  contour_file.write(unit_semicircle_contour);
 
-  ScopedTemporaryFile shape_file(testname,
-                                 ".yaml",
-                                 axom::fmt::format(axom::fmt::runtime(shape_template),
-                                                   circle_material,
-                                                   contour_file.getFileName(),
-                                                   radius));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template),
+                                     circle_material,
+                                     contour_file.getPath(),
+                                     radius));
 
   if(very_verbose_output)
   {
@@ -1698,8 +1653,8 @@ shapes:
     SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
   }
 
-  this->validateShapeFile(shape_file.getFileName());
-  this->initializeShaping(shape_file.getFileName());
+  this->validateShapeFile(shape_file.getPath());
+  this->initializeShaping(shape_file.getPath());
 
   // set projector from 3D points to axisymmetric plane
   this->m_shaper->setPointProjector32([](Point3D pt) {
@@ -1760,16 +1715,16 @@ shapes:
   const std::string sphere_material = "void";
   const std::string sphere_path = axom::fmt::format("{}/quest/unit_sphere.stl", AXOM_DATA_DIR);
 
-  ScopedTemporaryFile contour_file(testname, ".contour", unit_semicircle_contour);
+  fs::TempFile contour_file(testname, ".contour");
+  contour_file.write(unit_semicircle_contour);
 
-  ScopedTemporaryFile shape_file(testname,
-                                 ".yaml",
-                                 axom::fmt::format(axom::fmt::runtime(shape_template),
-                                                   contour_file.getFileName(),
-                                                   sphere_path,
-                                                   radius,
-                                                   circle_material,
-                                                   sphere_material));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template),
+                                     contour_file.getPath(),
+                                     sphere_path,
+                                     radius,
+                                     circle_material,
+                                     sphere_material));
 
   if(very_verbose_output)
   {
@@ -1777,8 +1732,8 @@ shapes:
     SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
   }
 
-  this->validateShapeFile(shape_file.getFileName());
-  this->initializeShaping(shape_file.getFileName());
+  this->validateShapeFile(shape_file.getPath());
+  this->initializeShaping(shape_file.getPath());
 
   // set projector from 3D points to axisymmetric plane
   this->m_shaper->setPointProjector32([](Point3D pt) {
@@ -1847,12 +1802,12 @@ shapes:
   // clang-format on
 
   const std::string tet_material = "steel";
-  ScopedTemporaryFile tet_file(testname, ".proe", proe_tet_str);
+  fs::TempFile tet_file(testname, ".proe");
+  tet_file.write(proe_tet_str);
 
-  ScopedTemporaryFile shape_file(
-    testname,
-    ".yaml",
-    axom::fmt::format(axom::fmt::runtime(shape_template), tet_file.getFileName(), tet_material));
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(
+    axom::fmt::format(axom::fmt::runtime(shape_template), tet_file.getPath(), tet_material));
 
   if(very_verbose_output)
   {
@@ -1860,14 +1815,14 @@ shapes:
     SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
   }
 
-  this->validateShapeFile(shape_file.getFileName());
+  this->validateShapeFile(shape_file.getPath());
 
   // exercise the point projector by running at several XY planes
   for(const double z : {-1.2, -.9, -.75, -.1, 0., .25, 1. / 3., .5})
   {
     this->resetShaping();
 
-    this->initializeShaping(shape_file.getFileName());
+    this->initializeShaping(shape_file.getPath());
 
     primal::Plane<double, 3> plane({0, 0, 1}, z);
     const auto polygon = slice(tet, plane);
@@ -1957,14 +1912,14 @@ piece = line(end=start)
                         bb.getMax()[0],
                         bb.getMax()[1]);
 
-    ScopedTemporaryFile contour_file(testname, ".contour", contour_str);
+    fs::TempFile contour_file(testname, ".contour");
+    contour_file.write(contour_str);
 
-    ScopedTemporaryFile shape_file(testname,
-                                   ".yaml",
-                                   axom::fmt::format(axom::fmt::runtime(shape_template),
-                                                     rect_shape,
-                                                     rect_material,
-                                                     contour_file.getFileName()));
+    fs::TempFile shape_file(testname, ".yaml");
+    shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template),
+                                       rect_shape,
+                                       rect_material,
+                                       contour_file.getPath()));
 
     if(very_verbose_output)
     {
@@ -1972,12 +1927,12 @@ piece = line(end=start)
       SLIC_INFO("Shape file: \n" << shape_file.getFileContents());
     }
 
-    this->validateShapeFile(shape_file.getFileName());
+    this->validateShapeFile(shape_file.getPath());
 
     for(int qorder : {3, 4, 5, 6, 7, 8, 9})
     {
       this->resetShaping();
-      this->initializeShaping(shape_file.getFileName());
+      this->initializeShaping(shape_file.getPath());
 
       this->m_shaper->setVolumeFractionOrder(0);
       this->m_shaper->setQuadratureOrder(qorder);

--- a/src/axom/quest/tests/quest_sampling_shaper.cpp
+++ b/src/axom/quest/tests/quest_sampling_shaper.cpp
@@ -66,15 +66,17 @@ constexpr bool very_verbose_output = false;
 class ScopedTemporaryFile
 {
 private:
-  // Set this to false to keep the ScopedTemporaryFiles at end of run
-  static constexpr bool s_delete_tmp_files_at_end_of_scope {true};
+  // Set this to true to keep the temp files at end of run
+  static constexpr bool s_retain_tmp_files_at_end_of_scope {false};
 
 public:
   ScopedTemporaryFile(const std::string& file_name,
                       const std::string& file_ext,
                       const std::string& contents)
-    : m_tempFile(file_name, file_ext, s_delete_tmp_files_at_end_of_scope)
+    : m_tempFile(file_name, file_ext)
   {
+    m_tempFile.retain(s_retain_tmp_files_at_end_of_scope);
+
     m_tempFile.open();
     m_tempFile << contents;
     m_tempFile.close();

--- a/src/axom/quest/tests/quest_sampling_shaper.cpp
+++ b/src/axom/quest/tests/quest_sampling_shaper.cpp
@@ -82,18 +82,7 @@ public:
 
   const std::string& getFileName() const { return m_tempFile.getPath(); }
 
-  std::string getFileContents() const
-  {
-    std::stringstream buffer;
-
-    std::ifstream ifs(getFileName().c_str(), std::ios::in);
-    if(ifs.is_open())
-    {
-      buffer << ifs.rdbuf();
-    }
-
-    return buffer.str();
-  }
+  std::string getFileContents() const { return m_tempFile.getFileContents(); }
 
 private:
   /// The TempFile class creates the file w/ unique name and removes the file in its destructor

--- a/src/axom/quest/tests/quest_stl_reader.cpp
+++ b/src/axom/quest/tests/quest_stl_reader.cpp
@@ -7,6 +7,7 @@
 #include "axom/mint/mesh/UnstructuredMesh.hpp"
 #include "axom/slic.hpp"
 #include "axom/core/NumericLimits.hpp"
+#include "axom/core/utilities/FileUtilities.hpp"
 
 // gtest includes
 #include "gtest/gtest.h"
@@ -19,6 +20,7 @@
 // namespace aliases
 namespace mint = axom::mint;
 namespace quest = axom::quest;
+namespace fs = axom::utilities::filesystem;
 
 //------------------------------------------------------------------------------
 // HELPER METHODS
@@ -27,27 +29,27 @@ namespace
 {
 /*!
  * \brief Generates an STL file consisting of a single triangle on the XY plane
- * \param [in] file the name of the file to generate.
+ * \param [in] file the TempFile instance to write into
  * \pre file.empty() == false
  */
-void generate_stl_file(const std::string& file)
+void generate_stl_file(fs::TempFile& file)
 {
-  EXPECT_FALSE(file.empty());
+  EXPECT_FALSE(file.getPath().empty());
 
-  std::ofstream ofs(file.c_str());
-  EXPECT_TRUE(ofs.is_open());
+  file.open();
+  EXPECT_TRUE(file.is_open());
 
-  ofs << "solid triangle" << std::endl;
-  ofs << "\t facet normal 0.0 0.0 1.0" << std::endl;
-  ofs << "\t\t outer loop" << std::endl;
-  ofs << "\t\t\t vertex 0.0 0.0 0.0" << std::endl;
-  ofs << "\t\t\t vertex 1.0 0.0 0.0" << std::endl;
-  ofs << "\t\t\t vertex 0.0 1.0 0.0" << std::endl;
-  ofs << "\t\t endloop" << std::endl;
-  ofs << "\t endfacet" << std::endl;
-  ofs << "endsolid triangle" << std::endl;
+  file << "solid triangle" << std::endl;
+  file << "\t facet normal 0.0 0.0 1.0" << std::endl;
+  file << "\t\t outer loop" << std::endl;
+  file << "\t\t\t vertex 0.0 0.0 0.0" << std::endl;
+  file << "\t\t\t vertex 1.0 0.0 0.0" << std::endl;
+  file << "\t\t\t vertex 0.0 1.0 0.0" << std::endl;
+  file << "\t\t endloop" << std::endl;
+  file << "\t endfacet" << std::endl;
+  file << "endsolid triangle" << std::endl;
 
-  ofs.close();
+  file.close();
 }
 
 } /* end anonymous namespace */
@@ -58,10 +60,10 @@ void generate_stl_file(const std::string& file)
 TEST(quest_stl_reader_DeathTest, read_to_invalid_mesh)
 {
   const char* IGNORE_OUTPUT = ".*";
-  const std::string filename = "triangle.stl";
 
   // STEP 0: generate a temporary STL file for testing
-  generate_stl_file(filename);
+  fs::TempFile tempFile("triangle", ".stl");
+  generate_stl_file(tempFile);
 
   // STEP 1: constructs mesh object to read in the mesh to
   mint::UnstructuredMesh<mint::SINGLE_SHAPE> trimesh(2, mint::TRIANGLE);
@@ -69,7 +71,7 @@ TEST(quest_stl_reader_DeathTest, read_to_invalid_mesh)
 
   // STEP 2: read in the STL mesh data
   quest::STLReader reader;
-  reader.setFileName(filename);
+  reader.setFileName(tempFile.getPath());
   int status = reader.read();
   EXPECT_EQ(status, 0);
 
@@ -80,15 +82,12 @@ TEST(quest_stl_reader_DeathTest, read_to_invalid_mesh)
 
   // read the STL mesh data to a mint::Mesh that has a different cell type
   EXPECT_DEATH_IF_SUPPORTED(reader.getMesh(&hexmesh), IGNORE_OUTPUT);
-
-  // STEP 4: remove STL file
-  EXPECT_EQ(axom::utilities::filesystem::removeFile(filename), 0);
 }
 
 //------------------------------------------------------------------------------
 TEST(quest_stl_reader, read_missing_file)
 {
-  const std::string INVALID_FILE = "foo.stl";
+  const std::string INVALID_FILE = "nonexistant_file.stl";
   quest::STLReader reader;
   reader.setFileName(INVALID_FILE);
   int status = reader.read();
@@ -102,14 +101,13 @@ TEST(quest_stl_reader, read_stl)
   const double y_expected[] = {0.0, 0.0, 1.0};
   const double z_expected[] = {0.0, 0.0, 0.0};
 
-  const std::string filename = "triangle.stl";
-
   // STEP 0: generate a temporary STL file for testing
-  generate_stl_file(filename);
+  fs::TempFile testFile("triangle", ".stl");
+  generate_stl_file(testFile);
 
   // STEP 1: create an STL reader and read-in the mesh data
   quest::STLReader reader;
-  reader.setFileName(filename);
+  reader.setFileName(testFile.getPath());
   int status = reader.read();
   EXPECT_EQ(status, 0);
 
@@ -134,10 +132,7 @@ TEST(quest_stl_reader, read_stl)
     EXPECT_NEAR(x[inode], x_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(y[inode], y_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(z[inode], z_expected[inode], axom::numeric_limits<double>::epsilon());
-  }  // END for all nodes
-
-  // STEP 4: remove temporary STL file
-  axom::utilities::filesystem::removeFile(filename);
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -155,14 +150,13 @@ TEST(quest_stl_reader, read_stl_external)
 
   axom::IndexType conn[] = {-1, -1, -1};
 
-  const std::string filename = "triangle.stl";
-
   // STEP 0: generate a temporary STL file for testing
-  generate_stl_file(filename);
+  fs::TempFile testFile("triangle", ".stl");
+  generate_stl_file(testFile);
 
   // STEP 1: create an STL reader and read-in the mesh data
   quest::STLReader reader;
-  reader.setFileName(filename);
+  reader.setFileName(testFile.getPath());
   int status = reader.read();
   EXPECT_EQ(status, 0);
 
@@ -186,10 +180,7 @@ TEST(quest_stl_reader, read_stl_external)
     EXPECT_NEAR(x[inode], x_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(y[inode], y_expected[inode], axom::numeric_limits<double>::epsilon());
     EXPECT_NEAR(z[inode], z_expected[inode], axom::numeric_limits<double>::epsilon());
-  }  // END for all nodes
-
-  // STEP 4: remove temporary STL file
-  axom::utilities::filesystem::removeFile(filename);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/quest/tests/quest_stl_reader.cpp
+++ b/src/axom/quest/tests/quest_stl_reader.cpp
@@ -87,7 +87,7 @@ TEST(quest_stl_reader_DeathTest, read_to_invalid_mesh)
 //------------------------------------------------------------------------------
 TEST(quest_stl_reader, read_missing_file)
 {
-  const std::string INVALID_FILE = "nonexistant_file.stl";
+  const std::string INVALID_FILE = "nonexistent_file.stl";
   quest::STLReader reader;
   reader.setFileName(INVALID_FILE);
   int status = reader.read();

--- a/src/axom/quest/tests/quest_stl_writer.cpp
+++ b/src/axom/quest/tests/quest_stl_writer.cpp
@@ -9,6 +9,8 @@
 #include "axom/mint/mesh/UnstructuredMesh.hpp"
 #include "axom/mint/mesh/RectilinearMesh.hpp"
 #include "axom/mint/mesh/CurvilinearMesh.hpp"
+
+#include "axom/core/utilities/FileUtilities.hpp"
 #include "axom/slic.hpp"
 #include "axom/fmt.hpp"
 

--- a/src/axom/sina/tests/sina_Document.cpp
+++ b/src/axom/sina/tests/sina_Document.cpp
@@ -290,50 +290,6 @@ TEST(Document, toNode_relationships)
   }
 }
 
-/**
- * Instances of this class acquire a temporary file name when created
- * and delete the file when destructed.
- *
- * NOTE: This class uses unsafe methods and should only be used for testing
- * purposes. DO NOT move it to the main code!!!!
- */
-class NamedTempFile
-{
-public:
-  NamedTempFile();
-
-  // As a resource-holding class, we don't want this to be copyable
-  // (or movable since there is no reason to return it from a function)
-  NamedTempFile(NamedTempFile const &) = delete;
-
-  NamedTempFile(NamedTempFile &&) = delete;
-
-  NamedTempFile &operator=(NamedTempFile const &) = delete;
-
-  NamedTempFile &operator=(NamedTempFile &&) = delete;
-
-  ~NamedTempFile();
-
-  std::string const &getName() const { return fileName; }
-
-private:
-  std::string fileName;
-};
-
-NamedTempFile::NamedTempFile()
-{
-  std::vector<char> tmpFileName;
-  tmpFileName.resize(L_tmpnam);
-  // tmpnam is not the best way to do this, but it is standard and this is only a test.
-  if(!std::tmpnam(tmpFileName.data()))
-  {
-    throw std::ios::failure {"Could not get temporary file"};
-  }
-  fileName = tmpFileName.data();
-}
-
-NamedTempFile::~NamedTempFile() { axom::utilities::filesystem::removeFile(fileName.data()); }
-
 TEST(Document, create_fromJson_roundtrip_json)
 {
   std::string orig_json =
@@ -371,23 +327,16 @@ TEST(Document, create_fromJson_value_check_json)
 
 TEST(Document, saveDocument_json)
 {
-  NamedTempFile tmpFile;
-
-  // First, write some random stuff to the temp file to make sure it is
-  // overwritten.
-  {
-    std::ofstream fout {tmpFile.getName()};
-    fout << "Initial contents";
-  }
+  axom::utilities::filesystem::TempFile tmpFile("", ".json");
 
   Document document;
   document.add(std::make_unique<Record>(ID {"the id", IDType::Global}, "the type"));
 
-  saveDocument(document, tmpFile.getName() + ".json");
+  saveDocument(document, tmpFile.getPath());
 
   conduit::Node readContents;
   {
-    std::ifstream fin {tmpFile.getName() + ".json"};
+    std::ifstream fin {tmpFile.getPath()};
     std::stringstream f_buf;
     f_buf << fin.rdbuf();
     readContents.parse(f_buf.str(), "json");
@@ -407,11 +356,10 @@ TEST(Document, load_specifiedRecordLoader)
   Document originalDocument;
   originalDocument.add(std::move(originalRecord));
 
-  NamedTempFile file;
-  {
-    std::ofstream fout {file.getName()};
-    fout << originalDocument.toNode().to_json();
-  }
+  axom::utilities::filesystem::TempFile tmpfile("load_specifiedRecordLoader", ".json");
+  tmpfile.open();
+  tmpfile << originalDocument.toNode().to_json();
+  tmpfile.close();
 
   RecordLoader loader;
   loader.addTypeLoader("my type", [](conduit::Node const &asNode) {
@@ -420,7 +368,7 @@ TEST(Document, load_specifiedRecordLoader)
       getRequiredString("type", asNode, "Test type"),
       static_cast<int>(getRequiredField(TEST_RECORD_VALUE_KEY, asNode, "Test type").as_int64()));
   });
-  Document loadedDocument = loadDocument(file.getName(), loader);
+  Document loadedDocument = loadDocument(tmpfile.getPath(), loader);
   ASSERT_EQ(1u, loadedDocument.getRecords().size());
   auto loadedRecord = dynamic_cast<RecordType const *>(loadedDocument.getRecords()[0].get());
   ASSERT_NE(nullptr, loadedRecord);
@@ -434,13 +382,12 @@ TEST(Document, load_defaultRecordLoaders)
   Document originalDocument;
   originalDocument.add(std::move(originalRun));
 
-  NamedTempFile file;
-  {
-    std::ofstream fout {file.getName()};
-    fout << originalDocument.toNode().to_json();
-  }
+  axom::utilities::filesystem::TempFile tmpfile("load_defaultRecordLoaders", ".json");
+  tmpfile.open();
+  tmpfile << originalDocument.toNode().to_json();
+  tmpfile.close();
 
-  Document loadedDocument = loadDocument(file.getName());
+  Document loadedDocument = loadDocument(tmpfile.getPath());
   ASSERT_EQ(1u, loadedDocument.getRecords().size());
   auto loadedRun = dynamic_cast<axom::sina::Run const *>(loadedDocument.getRecords()[0].get());
   EXPECT_NE(nullptr, loadedRun);
@@ -490,22 +437,15 @@ TEST(Document, create_fromJson_value_check_hdf5)
 
 TEST(Document, saveDocument_hdf5)
 {
-  NamedTempFile tmpFile;
-
-  // First, write some random stuff to the temp file to make sure it is
-  // overwritten.
-  {
-    std::ofstream fout {tmpFile.getName()};
-    fout << "Initial contents";
-  }
+  axom::utilities::filesystem::TempFile tmpFile("saveDocument", ".hdf5");
 
   Document document;
   document.add(std::make_unique<Record>(ID {"the id", IDType::Global}, "the type"));
 
-  saveDocument(document, tmpFile.getName() + ".hdf5", Protocol::HDF5);
+  saveDocument(document, tmpFile.getPath(), Protocol::HDF5);
 
   conduit::Node readContents;
-  conduit::relay::io::load(tmpFile.getName() + ".hdf5", "hdf5", readContents);
+  conduit::relay::io::load(tmpFile.getPath(), "hdf5", readContents);
 
   ASSERT_TRUE(readContents[EXPECTED_RECORDS_KEY].dtype().is_list());
   EXPECT_EQ(1, readContents[EXPECTED_RECORDS_KEY].number_of_children());

--- a/src/axom/sina/tests/sina_Document.cpp
+++ b/src/axom/sina/tests/sina_Document.cpp
@@ -327,16 +327,16 @@ TEST(Document, create_fromJson_value_check_json)
 
 TEST(Document, saveDocument_json)
 {
-  axom::utilities::filesystem::TempFile tmpFile("", ".json");
+  axom::utilities::filesystem::TempFile tempFile("", ".json");
 
   Document document;
   document.add(std::make_unique<Record>(ID {"the id", IDType::Global}, "the type"));
 
-  saveDocument(document, tmpFile.getPath());
+  saveDocument(document, tempFile.getPath());
 
   conduit::Node readContents;
   {
-    std::ifstream fin {tmpFile.getPath()};
+    std::ifstream fin {tempFile.getPath()};
     std::stringstream f_buf;
     f_buf << fin.rdbuf();
     readContents.parse(f_buf.str(), "json");
@@ -356,10 +356,10 @@ TEST(Document, load_specifiedRecordLoader)
   Document originalDocument;
   originalDocument.add(std::move(originalRecord));
 
-  axom::utilities::filesystem::TempFile tmpfile("load_specifiedRecordLoader", ".json");
-  tmpfile.open();
-  tmpfile << originalDocument.toNode().to_json();
-  tmpfile.close();
+  axom::utilities::filesystem::TempFile tempfile("load_specifiedRecordLoader", ".json");
+  tempfile.open();
+  tempfile << originalDocument.toNode().to_json();
+  tempfile.close();
 
   RecordLoader loader;
   loader.addTypeLoader("my type", [](conduit::Node const &asNode) {
@@ -368,7 +368,7 @@ TEST(Document, load_specifiedRecordLoader)
       getRequiredString("type", asNode, "Test type"),
       static_cast<int>(getRequiredField(TEST_RECORD_VALUE_KEY, asNode, "Test type").as_int64()));
   });
-  Document loadedDocument = loadDocument(tmpfile.getPath(), loader);
+  Document loadedDocument = loadDocument(tempfile.getPath(), loader);
   ASSERT_EQ(1u, loadedDocument.getRecords().size());
   auto loadedRecord = dynamic_cast<RecordType const *>(loadedDocument.getRecords()[0].get());
   ASSERT_NE(nullptr, loadedRecord);
@@ -382,12 +382,12 @@ TEST(Document, load_defaultRecordLoaders)
   Document originalDocument;
   originalDocument.add(std::move(originalRun));
 
-  axom::utilities::filesystem::TempFile tmpfile("load_defaultRecordLoaders", ".json");
-  tmpfile.open();
-  tmpfile << originalDocument.toNode().to_json();
-  tmpfile.close();
+  axom::utilities::filesystem::TempFile tempfile("load_defaultRecordLoaders", ".json");
+  tempfile.open();
+  tempfile << originalDocument.toNode().to_json();
+  tempfile.close();
 
-  Document loadedDocument = loadDocument(tmpfile.getPath());
+  Document loadedDocument = loadDocument(tempfile.getPath());
   ASSERT_EQ(1u, loadedDocument.getRecords().size());
   auto loadedRun = dynamic_cast<axom::sina::Run const *>(loadedDocument.getRecords()[0].get());
   EXPECT_NE(nullptr, loadedRun);
@@ -437,15 +437,15 @@ TEST(Document, create_fromJson_value_check_hdf5)
 
 TEST(Document, saveDocument_hdf5)
 {
-  axom::utilities::filesystem::TempFile tmpFile("saveDocument", ".hdf5");
+  axom::utilities::filesystem::TempFile tempFile("saveDocument", ".hdf5");
 
   Document document;
   document.add(std::make_unique<Record>(ID {"the id", IDType::Global}, "the type"));
 
-  saveDocument(document, tmpFile.getPath(), Protocol::HDF5);
+  saveDocument(document, tempFile.getPath(), Protocol::HDF5);
 
   conduit::Node readContents;
-  conduit::relay::io::load(tmpFile.getPath(), "hdf5", readContents);
+  conduit::relay::io::load(tempFile.getPath(), "hdf5", readContents);
 
   ASSERT_TRUE(readContents[EXPECTED_RECORDS_KEY].dtype().is_list());
   EXPECT_EQ(1, readContents[EXPECTED_RECORDS_KEY].number_of_children());

--- a/src/axom/sina/tests/sina_Document.cpp
+++ b/src/axom/sina/tests/sina_Document.cpp
@@ -335,12 +335,7 @@ TEST(Document, saveDocument_json)
   saveDocument(document, tempFile.getPath());
 
   conduit::Node readContents;
-  {
-    std::ifstream fin {tempFile.getPath()};
-    std::stringstream f_buf;
-    f_buf << fin.rdbuf();
-    readContents.parse(f_buf.str(), "json");
-  }
+  readContents.parse(tempFile.getFileContents(), "json");
 
   ASSERT_TRUE(readContents[EXPECTED_RECORDS_KEY].dtype().is_list());
   EXPECT_EQ(1, readContents[EXPECTED_RECORDS_KEY].number_of_children());
@@ -357,9 +352,7 @@ TEST(Document, load_specifiedRecordLoader)
   originalDocument.add(std::move(originalRecord));
 
   axom::utilities::filesystem::TempFile tempfile("load_specifiedRecordLoader", ".json");
-  tempfile.open();
-  tempfile << originalDocument.toNode().to_json();
-  tempfile.close();
+  tempfile.write(originalDocument.toNode().to_json());
 
   RecordLoader loader;
   loader.addTypeLoader("my type", [](conduit::Node const &asNode) {
@@ -383,9 +376,7 @@ TEST(Document, load_defaultRecordLoaders)
   originalDocument.add(std::move(originalRun));
 
   axom::utilities::filesystem::TempFile tempfile("load_defaultRecordLoaders", ".json");
-  tempfile.open();
-  tempfile << originalDocument.toNode().to_json();
-  tempfile.close();
+  tempfile.write(originalDocument.toNode().to_json());
 
   Document loadedDocument = loadDocument(tempfile.getPath());
   ASSERT_EQ(1u, loadedDocument.getRecords().size());


### PR DESCRIPTION
# Summary

- This is a feature PR that add a utility class to help with generating temp files with unique names
- By default, TempFile removes the file once it goes out of scope, but the constructor has a flag to keep the file
- It incorporates this `TempFile` class into several of Axom's unit tests.
- It also fixes a warning from Sina's tests about using an unsafe system call (`tmpnam`), and calls the recommended `mkstemp` instead.
   - Removing that warning was the impetus for adding the TempFile class.
- Along the way it also fixes some edge cases in Axom's `joinPath` file utility
- Resolves a subtask of #1467 
