### PR TITLE
Klee: Adds an optional per-shape `dimensions` field to a shape's geometry specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # <img src="/share/axom/logo/axom_logo_transparent.png?raw=true" width="250" valign="middle" alt="Axom"/>
 
-[![Azure Pipelines Build Status](https://dev.azure.com/axom/axom/_apis/build/status/LLNL.axom?branchName=develop)](https://dev.azure.com/axom/axom/_build/latest?definitionId=1&branchName=develop)
+[![Build Status](https://github.com/LLNL/axom/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/LLNL/axom/actions/workflows/ci-tests.yml)
 [![Documentation Status](https://readthedocs.org/projects/axom/badge/?version=develop)](https://axom.readthedocs.io/en/develop/?badge=develop)
 [![License](https://img.shields.io/github/license/LLNL/axom.svg?color=blue&label=License)](https://github.com/LLNL/axom/blob/develop/LICENSE)
 [![GitHub release](https://img.shields.io/github/release/LLNL/axom.svg)](https://github.com/LLNL/axom/releases/latest)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,9 +47,12 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Added a new `quest::STLWriter` class that writes mint meshes to STL format.
 - Adds `assign` methods to `axom::Array`.
 - Adds `assign`, `fill`, `set` methods to `axom::ArrayView`.
+- Klee: We now support optional specification of a per-shape `dimensions` field for the 
+  geometry of a shape. These can be used to override the global `dimensions` 
+  of a Klee input file.
 
 ###  Changed
-- Axom now requires C++17 and will default to that if not specified via `BLT_CXX_STD`.
+- Axom now requires `C++17` and will default to that if not specified via `BLT_CXX_STD`.
 - Fixed `Timer::elapsed*()` methods so they properly report the sum of all start/stop cycles
   since the last `reset()`.
 - Adds support for allocations using `malloc` and `free` even when Axom is configured with Umpire support.
@@ -64,6 +67,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Spin: Uses `axom::FlatMap` in `SparseOctreeLevel` implementation. We have observed a performance regression
   of about 20% during InOutOctree construction and queries over STL surface meshes relative to the previous sparsehash
   implementation. Please reach out to Axom developers if this affects you while we work on fixes for these.
+- Klee: Moves source files related to IO into a new `io` subdirectory in the Klee component
 
 ###  Fixed
 - Core: prevent incorrect instantiations of `axom::Array` from a host-only compile, when Axom is compiled

--- a/src/axom/klee/CMakeLists.txt
+++ b/src/axom/klee/CMakeLists.txt
@@ -12,28 +12,28 @@ set(klee_headers
     Dimensions.hpp
     Geometry.hpp
     GeometryOperators.hpp
-    IO.hpp
     Shape.hpp
     ShapeSet.hpp
     Units.hpp
     KleeError.hpp
+    io/IO.hpp
     )
 
 set(klee_internal_headers
-    GeometryOperatorsIO.hpp
-    IOUtil.hpp
+    io/GeometryOperatorsIO.hpp
+    io/IOUtil.hpp
     )
 
 set(klee_sources
     Geometry.cpp
     GeometryOperators.cpp
-    GeometryOperatorsIO.cpp
     KleeError.cpp
-    IO.cpp
-    IOUtil.cpp
     Shape.cpp
     ShapeSet.cpp
     Units.cpp
+    io/GeometryOperatorsIO.cpp
+    io/IO.cpp
+    io/IOUtil.cpp
     )
 
 #------------------------------------------------------------------------------

--- a/src/axom/klee/Dimensions.hpp
+++ b/src/axom/klee/Dimensions.hpp
@@ -2,8 +2,8 @@
 // other Axom Project Developers. See the top-level COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-#ifndef AXOM_DIMENSIONS_HPP
-#define AXOM_DIMENSIONS_HPP
+#ifndef AXOM_KLEE_DIMENSIONS_HPP_
+#define AXOM_KLEE_DIMENSIONS_HPP_
 
 namespace axom
 {
@@ -21,4 +21,4 @@ enum class Dimensions : int
 }  // namespace klee
 }  // namespace axom
 
-#endif  //AXOM_DIMENSIONS_HPP
+#endif  // AXOM_KLEE_DIMENSIONS_HPP_

--- a/src/axom/klee/Dimensions.hpp
+++ b/src/axom/klee/Dimensions.hpp
@@ -9,13 +9,12 @@ namespace axom
 {
 namespace klee
 {
-/**
- * The dimensions that are supported for specifying operations in Klee.
- */
+/// The dimensions that are supported for specifying operations in Klee.
 enum class Dimensions : int
 {
   Two = 2,
   Three = 3,
+  Unspecified = -1
 };
 
 }  // namespace klee

--- a/src/axom/klee/Geometry.cpp
+++ b/src/axom/klee/Geometry.cpp
@@ -4,8 +4,8 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "axom/klee/Geometry.hpp"
-
 #include "axom/klee/GeometryOperators.hpp"
+
 #include "conduit_blueprint_mesh.hpp"
 
 #include <utility>

--- a/src/axom/klee/Geometry.cpp
+++ b/src/axom/klee/Geometry.cpp
@@ -117,8 +117,9 @@ Geometry::Geometry(const TransformableGeometryProperties& startProperties,
 
 bool Geometry::hasGeometry() const
 {
-  bool isInMemory = m_format == "blueprint-tets" || m_format == "sphere3D" || m_format == "tet3D" ||
-    m_format == "hex3D" || m_format == "plane3D" || m_format == "cone3D" || m_format == "cylinder3D";
+  bool isInMemory = (m_format == "blueprint-tets" || m_format == "sphere3D" ||
+                     m_format == "tet3D" || m_format == "hex3D" || m_format == "plane3D" ||
+                     m_format == "cone3D" || m_format == "cylinder3D");
   if(isInMemory)
   {
     return true;
@@ -128,11 +129,7 @@ bool Geometry::hasGeometry() const
 
 TransformableGeometryProperties Geometry::getEndProperties() const
 {
-  if(m_operator)
-  {
-    return m_operator->getEndProperties();
-  }
-  return m_startProperties;
+  return m_operator ? m_operator->getEndProperties() : m_startProperties;
 }
 
 const axom::sidre::Group* Geometry::getBlueprintMesh() const

--- a/src/axom/klee/Geometry.cpp
+++ b/src/axom/klee/Geometry.cpp
@@ -26,7 +26,6 @@ Geometry::Geometry(const TransformableGeometryProperties& startProperties,
   : m_startProperties(startProperties)
   , m_format(std::move(format))
   , m_path(std::move(path))
-  , m_levelOfRefinement(0)
   , m_operator(std::move(operator_))
 { }
 
@@ -36,10 +35,8 @@ Geometry::Geometry(const TransformableGeometryProperties& startProperties,
                    std::shared_ptr<GeometryOperator const> operator_)
   : m_startProperties(startProperties)
   , m_format("blueprint-tets")
-  , m_path()
   , m_meshGroup(simplexMeshGroup)
   , m_topology(topology)
-  , m_levelOfRefinement(0)
   , m_operator(std::move(operator_))
 { }
 
@@ -48,11 +45,7 @@ Geometry::Geometry(const TransformableGeometryProperties& startProperties,
                    std::shared_ptr<GeometryOperator const> operator_)
   : m_startProperties(startProperties)
   , m_format("tet3D")
-  , m_path()
-  , m_meshGroup(nullptr)
-  , m_topology()
   , m_tet(tet)
-  , m_levelOfRefinement(0)
   , m_operator(std::move(operator_))
 { }
 
@@ -61,11 +54,7 @@ Geometry::Geometry(const TransformableGeometryProperties& startProperties,
                    std::shared_ptr<GeometryOperator const> operator_)
   : m_startProperties(startProperties)
   , m_format("hex3D")
-  , m_path()
-  , m_meshGroup(nullptr)
-  , m_topology()
   , m_hex(hex)
-  , m_levelOfRefinement(0)
   , m_operator(std::move(operator_))
 { }
 
@@ -75,9 +64,6 @@ Geometry::Geometry(const TransformableGeometryProperties& startProperties,
                    std::shared_ptr<GeometryOperator const> operator_)
   : m_startProperties(startProperties)
   , m_format("sphere3D")
-  , m_path()
-  , m_meshGroup(nullptr)
-  , m_topology()
   , m_sphere(sphere)
   , m_levelOfRefinement(levelOfRefinement)
   , m_operator(std::move(operator_))
@@ -91,10 +77,6 @@ Geometry::Geometry(const TransformableGeometryProperties& startProperties,
                    std::shared_ptr<GeometryOperator const> operator_)
   : m_startProperties(startProperties)
   , m_format("sor3D")
-  , m_path()
-  , m_meshGroup(nullptr)
-  , m_topology()
-  , m_sphere()
   , m_discreteFunction(discreteFunction)
   , m_sorBase(sorBase)
   , m_sorDirection(sorDirection)
@@ -107,11 +89,7 @@ Geometry::Geometry(const TransformableGeometryProperties& startProperties,
                    std::shared_ptr<GeometryOperator const> operator_)
   : m_startProperties(startProperties)
   , m_format("plane3D")
-  , m_path()
-  , m_meshGroup(nullptr)
-  , m_topology()
   , m_plane(plane)
-  , m_levelOfRefinement(0)
   , m_operator(std::move(operator_))
 { }
 

--- a/src/axom/klee/Geometry.hpp
+++ b/src/axom/klee/Geometry.hpp
@@ -3,16 +3,17 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#ifndef AXOM_KLEE_GEOMETRY_HPP
-#define AXOM_KLEE_GEOMETRY_HPP
-
-#include <memory>
-#include <string>
+#ifndef AXOM_KLEE_GEOMETRY_HPP_
+#define AXOM_KLEE_GEOMETRY_HPP_
 
 #include "axom/klee/Dimensions.hpp"
 #include "axom/klee/Units.hpp"
+
 #include "axom/primal.hpp"
 #include "axom/sidre.hpp"
+
+#include <memory>
+#include <string>
 
 namespace axom
 {
@@ -343,4 +344,4 @@ private:
 }  // namespace klee
 }  // namespace axom
 
-#endif  //AXOM_KLEE_GEOMETRY_HPP
+#endif  // AXOM_KLEE_GEOMETRY_HPP_

--- a/src/axom/klee/Geometry.hpp
+++ b/src/axom/klee/Geometry.hpp
@@ -21,9 +21,7 @@ namespace klee
 {
 class GeometryOperator;
 
-/**
- * Properties of a geometric object which can be transformed by operators
- */
+/// Properties of a geometric object which can be transformed by operators
 struct TransformableGeometryProperties
 {
   Dimensions dimensions;
@@ -51,9 +49,7 @@ inline bool operator!=(const TransformableGeometryProperties &lhs,
   return !(lhs == rhs);
 }
 
-/**
- * Represents the geometry specified in a Shape.
- */
+/// Represents the geometry specified in a Shape.
 class Geometry
 {
 public:
@@ -67,8 +63,7 @@ public:
   /**
    * Create a Geometry object based on a file representation.
    *
-   * \param startProperties the transformable properties before any
-   * operators are applied
+   * \param startProperties the transformable properties before any operators are applied
    * \param format the format of the file
    * \param path the path of the file
    * \param operator_ a possibly null operator to apply to the geometry.
@@ -81,8 +76,7 @@ public:
   /**
    * Create a Geometry object based on a blueprint tetrahedral mesh.
    *
-   * \param startProperties the transformable properties before any
-   * operators are applied
+   * \param startProperties the transformable properties before any operators are applied
    * \param simplexMeshGroup the geometry in blueprint format.
    *   The elements should be segments, triangles or tetrahedra.
    * \param topology The blueprint topology to use.
@@ -96,8 +90,7 @@ public:
   /**
    * Create a tetrahedron Geometry object.
    *
-   * \param startProperties the transformable properties before any
-   * operators are applied
+   * \param startProperties the transformable properties before any operators are applied
    * \param tet Tetrahedron
    * \param operator_ a possibly null operator to apply to the geometry.
    */
@@ -108,8 +101,7 @@ public:
   /**
    * Create a hexahedron Geometry object.
    *
-   * \param startProperties the transformable properties before any
-   * operators are applied
+   * \param startProperties the transformable properties before any operators are applied
    * \param hex Hexahedron
    * \param operator_ a possibly null operator to apply to the geometry.
    */
@@ -120,11 +112,9 @@ public:
   /**
    * Create a sphere Geometry object.
    *
-   * \param startProperties the transformable properties before any
-   * operators are applied
+   * \param startProperties the transformable properties before any operators are applied
    * \param sphere Analytical sphere specifications
-   * \param levelOfRefinement Number of refinement levels to use for
-   *        discretizing the sphere.
+   * \param levelOfRefinement Number of refinement levels to use for discretizing the sphere.
    * \param operator_ a possibly null operator to apply to the geometry.
    */
   Geometry(const TransformableGeometryProperties &startProperties,
@@ -135,14 +125,11 @@ public:
   /**
    * Create a surface-of-revolution (SOR) Geometry object.
    *
-   * \param startProperties the transformable properties before any
-   * operators are applied
-   * \param discreteFunction Discrete function describing the surface
-   *        of revolution.
+   * \param startProperties the transformable properties before any operators are applied
+   * \param discreteFunction Discrete function describing the surface of revolution.
    * \param sorBase Coordinates of the base of the SOR.
    * \param sorDirection SOR axis, in the direction of increasing z.
-   * \param levelOfRefinement Number of refinement levels to use for
-   *        discretizing the SOR.
+   * \param levelOfRefinement Number of refinement levels to use for discretizing the SOR.
    * \param operator_ a possibly null operator to apply to the geometry.
    *
    * The \c discreteFunction should be an Nx2 array, interpreted as
@@ -160,20 +147,18 @@ public:
   /**
    * Create a planar Geometry object.
    *
-   * \param startProperties the transformable properties before any
-   * operators are applied
+   * \param startProperties the transformable properties before any operators are applied
    * \param tet Tetrahedron
    * \param operator_ a possibly null operator to apply to the geometry.
    *
-   * The space on the positive normal side of the plane is considered
-   * "inside the shape".
+   * The space on the positive normal side of the plane is considered "inside the shape".
    */
   Geometry(const TransformableGeometryProperties &startProperties,
            const axom::primal::Plane<double, 3> &plane,
            std::shared_ptr<GeometryOperator const> operator_);
 
   /**
-   * @brief Get the format in which the geometry was specified.
+   * \brief Get the format in which the geometry was specified.
    *
    * The format is determined by the constructor used.
    * Values are:
@@ -191,8 +176,7 @@ public:
    * \return the format of the shape
    *
    * TODO: Depending on the specified geometry, some members are not
-   * used.  It may clarify if we make each supported geometry a
-   * subclass.
+   * used.  It may clarify if we make each supported geometry a subclass.
    */
   const std::string &getFormat() const { return m_format; }
 
@@ -205,36 +189,32 @@ public:
   const std::string &getPath() const { return m_path; }
 
   /**
-   * @brief Return the blueprint mesh, for formats that are specified
+   * \brief Return the blueprint mesh, for formats that are specified
    * by a blueprint mesh or have been converted to a blueprint mesh.
    */
   const axom::sidre::Group *getBlueprintMesh() const;
 
   /**
-   * @brief Return the blueprint mesh topology, for formats that are specified
+   * \brief Return the blueprint mesh topology, for formats that are specified
    * by a blueprint mesh or have been converted to a blueprint mesh.
    */
   const std::string &getBlueprintTopology() const;
 
-  /**
-     @brief Return the SOR axis direction.
-  */
+  /// \brief Return the SOR axis direction.
   const Vector3D getSorDirection() const { return m_sorDirection; }
 
-  /**
-     @brief Return the 3D coordinates of the SOR base.
-  */
+  /// \brief Return the 3D coordinates of the SOR base.
   const Point3D getSorBaseCoords() const { return m_sorBase; }
 
-  /*! @brief Predicate that returns true when the shape has an associated geometry
-
-    A false means that this is set up to determine volume fractions without
-    computing on the geometry.
-
-    TODO: We should just create a new format to represent getting
-    volume fractions without geometries.  Or move this logic into
-    Shape, because it's confusing to have a Geometry that has no
-    geometry.
+  /**
+   *  \brief Predicate that returns true when the shape has an associated geometry
+   *
+   *  A false means that this is set up to determine volume fractions without
+   *  computing on the geometry.
+   *
+   *  TODO: We should just create a new format to represent getting
+   *  volume fractions without geometries.  Or move this logic into
+   *  Shape, because it's confusing to have a Geometry that has no geometry.
   */
   bool hasGeometry() const;
 
@@ -253,90 +233,72 @@ public:
   const TransformableGeometryProperties &getStartProperties() const { return m_startProperties; }
 
   /**
-   * Get the final transformable properties of this geometry after
-   * operators are applied
+   * Get the final transformable properties of this geometry after operators are applied
    *
    * \return the initial transformable properties of this geometry
    */
   TransformableGeometryProperties getEndProperties() const;
 
   /**
-   @brief Return the number of levels of refinement for discretization
-   of analytical curves.
-
-   This number is unused for geometries that are specified in discrete
-   form.
-  */
+   * \brief Return the number of levels of refinement for discretization of analytical curves.
+   * 
+   * This number is unused for geometries that are specified in discrete form.
+   */
   axom::IndexType getLevelOfRefinement() const { return m_levelOfRefinement; }
 
-  /**
-   @brief Return the tet geometry, when the Geometry
-   represents a tetrahedron.
-  */
+  /// \brief Return the tet geometry, when the Geometry represents a tetrahedron.
   const axom::primal::Tetrahedron<double, 3> &getTet() const { return m_tet; }
 
-  /**
-   @brief Return the hex geometry, when the Geometry
-   represents a hexahedron.
-  */
+  /// \brief Return the hex geometry, when the Geometry represents a hexahedron
   const axom::primal::Hexahedron<double, 3> &getHex() const { return m_hex; }
 
-  /**
-   @brief Return the sphere geometry, when the Geometry
-   represents an alalytical sphere.
-  */
+  /// \brief Return the sphere geometry, when the Geometry represents an alalytical sphere.
   const axom::primal::Sphere<double, 3> &getSphere() const { return m_sphere; }
 
-  /**
-   @brief Return the plane geometry, when the Geometry
-   represents a plane.
-  */
+  /// \brief Return the plane geometry, when the Geometry represents a plane.
   const axom::primal::Plane<double, 3> &getPlane() const { return m_plane; }
 
-  /**
-   @brief Get the discrete function used in surfaces of revolution.
-  */
+  /// \brief Get the discrete function used in surfaces of revolution.
   axom::ArrayView<const double, 2> getDiscreteFunction() const { return m_discreteFunction.view(); }
 
 private:
   TransformableGeometryProperties m_startProperties;
 
-  //!@brief Geometry format.
+  /// \brief Geometry format.
   std::string m_format;
 
-  //!@brief Geometry file path, if it's file-based.
+  /// \brief Geometry file path, if it's file-based.
   std::string m_path;
 
-  //!@brief Geometry blueprint simplex mesh, when/if it's in memory.
-  const axom::sidre::Group *m_meshGroup;
+  /// \brief Geometry blueprint simplex mesh, when/if it's in memory.
+  const axom::sidre::Group *m_meshGroup {nullptr};
 
-  //!@brief Topology of the blueprint simplex mesh, if it's in memory.
+  /// \brief Topology of the blueprint simplex mesh, if it's in memory.
   std::string m_topology;
 
-  //!@brief The tetrahedron, if used.
+  /// \brief The tetrahedron, if used.
   Tet3D m_tet;
 
-  //!@brief The hexahedron, if used.
+  /// \brief The hexahedron, if used.
   Hex3D m_hex;
 
-  //!@brief The plane, if used.
+  /// \brief The plane, if used.
   Plane3D m_plane;
 
-  //!@brief The analytical sphere, if used.
+  /// \brief The analytical sphere, if used.
   Sphere3D m_sphere;
 
-  //! @brief The discrete 2D function, as an Nx2 array, if used.
+  /// \brief The discrete 2D function, as an Nx2 array, if used.
   axom::Array<double, 2> m_discreteFunction;
 
-  //!@brief The point corresponding to z=0 on the SOR axis.
+  /// \brief The point corresponding to z=0 on the SOR axis.
   Point3D m_sorBase;
 
-  //!@brief SOR axis in the direction of increasing z.
+  /// \brief SOR axis in the direction of increasing z.
   Vector3D m_sorDirection;
 
-  //!@brief Level of refinement for discretizing curved
-  // analytical shapes and surfaces of revolutions.
-  axom::IndexType m_levelOfRefinement = 0;
+  /// \brief Level of refinement for discretizing curved analytical shapes and surfaces of revolutions.
+  axom::IndexType m_levelOfRefinement {0};
 
   std::shared_ptr<const GeometryOperator> m_operator;
 };

--- a/src/axom/klee/Geometry.hpp
+++ b/src/axom/klee/Geometry.hpp
@@ -189,6 +189,16 @@ public:
   const std::string &getPath() const { return m_path; }
 
   /**
+   * Returns the dimensions of the geometry before applying operators
+   * 
+   * For file-based inputs, this is the dimension of the input mesh
+   */
+  Dimensions getInputDimensions() const { return getStartProperties().dimensions; }
+
+  /// Returns the dimensions of the geometry after applying operators
+  Dimensions getOutputDimensions() const { return getEndProperties().dimensions; }
+
+  /**
    * \brief Return the blueprint mesh, for formats that are specified
    * by a blueprint mesh or have been converted to a blueprint mesh.
    */

--- a/src/axom/klee/GeometryOperators.cpp
+++ b/src/axom/klee/GeometryOperators.cpp
@@ -3,12 +3,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/klee/GeometryOperators.hpp"
-
 #include "axom/core/numerics/matvecops.hpp"
+
+#include "axom/klee/GeometryOperators.hpp"
 #include "axom/klee/Units.hpp"
 
-// C/C++ includes
 #include <cmath>
 #include <stdexcept>
 

--- a/src/axom/klee/GeometryOperators.hpp
+++ b/src/axom/klee/GeometryOperators.hpp
@@ -26,8 +26,7 @@ namespace klee
 class GeometryOperatorVisitor;
 
 /**
- * A GeometryOperator describes an operation to perform on the Geometry
- * of a Shape.
+ * \brief A GeometryOperator describes an operation to perform on the Geometry of a Shape
  *
  * There is a subclass of GeometryOperator for each operator defined in
  * the format specification. You can figure out which one you're working
@@ -58,8 +57,7 @@ public:
    */
   virtual TransformableGeometryProperties getEndProperties() const
   {
-    // Be default, end properties are the same as start properties, so
-    // this is correct.
+    // By default, end properties are the same as start properties, so this is correct.
     return m_startProperties;
   }
 
@@ -92,10 +90,7 @@ public:
   virtual numerics::Matrix<double> toMatrix() const = 0;
 };
 
-/**
- * A CompositeOperator is a GeometryOperator which consists of a list of
- * other operators.
- */
+/// A CompositeOperator contains a list of GeometryOperators that are applied in order
 class CompositeOperator : public GeometryOperator
 {
 public:
@@ -106,8 +101,7 @@ public:
   void accept(GeometryOperatorVisitor &visitor) const override;
 
   /**
-   * Add the given operator to the end of the list of operators in this
-   * composite.
+   * Add the given operator to the end of the list of operators in this composite.
    *
    * \param op the operator to add
    */
@@ -126,9 +120,7 @@ private:
   std::vector<OpPtr> m_operators;
 };
 
-/**
- * A Translation is a GeometryOperator which translates points.
- */
+/// A Translation is a GeometryOperator which translates points.
 class Translation : public MatrixOperator
 {
 public:
@@ -136,9 +128,8 @@ public:
    * Create a Translation.
    *
    * \param offset the amount by which to offset points
-   * \param startProperties the initial properties, as in the parent
-   * class. If the number of dimensions is 2, the 3rd entry in the offset
-   * should be zero, but this is not checked.
+   * \param startProperties the initial properties, as in the parent class. 
+   * If the number of dimensions is 2, the 3rd entry in the offset should be zero, but this is not checked.
    */
   Translation(const primal::Vector3D &offset, const TransformableGeometryProperties &startProperties);
 
@@ -157,23 +148,18 @@ private:
   primal::Vector3D m_offset;
 };
 
-/**
- * A Rotation is a GeometryOperator which rotates points about a given
- * axis.
- */
+/// A Rotation is a GeometryOperator which rotates points about a given axis.
 class Rotation : public MatrixOperator
 {
 public:
   /**
    * Create a Rotation.
    *
-   * \param angle the angle, in degrees, by which to rotate. Rotations are
-   * counter-clockwise.
+   * \param angle the angle, in degrees, by which to rotate. Rotations are counter-clockwise.
    * \param center the center of rotation
    * \param axis the axis about which to rotate points
-   * \param startProperties the initial properties, as in the parent
-   * class. If the number of dimensions is 2, the axis should be
-   * [0, 0, 1], but this is not checked.
+   * \param startProperties the initial properties, as in the parent class. 
+   * If the number of dimensions is 2, the axis should be [0, 0, 1], but this is not checked.
    */
   Rotation(double angle,
            const primal::Point3D &center,
@@ -198,8 +184,7 @@ public:
   /**
    * The direction of the axis of rotation.
    *
-   * \return the vector, which when combined with the center, defines the
-   * axis of rotation.
+   * \return the vector, which when combined with the center, defines the axis of rotation.
    */
   const primal::Vector3D &getAxis() const { return m_axis; }
 
@@ -213,9 +198,7 @@ private:
   primal::Vector3D m_axis;
 };
 
-/**
- * A GeometryOperator for scaling shapes.
- */
+/// A GeometryOperator for scaling shapes
 class Scale : public MatrixOperator
 {
 public:
@@ -225,9 +208,8 @@ public:
    * \param xFactor the amount by which to scale in the x direction
    * \param yFactor the amount by which to scale in the y direction
    * \param zFactor the amount by which to scale in the z direction
-   * \param startProperties the initial properties, as in the parent
-   * class. If the number of dimensions is 2, zFactor should be 1.0,
-   * but this is not enforced.
+   * \param startProperties the initial properties, as in the parent class. 
+   * If the number of dimensions is 2, zFactor should be 1.0, but this is not enforced.
    */
   Scale(double xFactor,
         double yFactor,
@@ -265,17 +247,14 @@ private:
   double m_zFactor;
 };
 
-/**
- * A Converter for converting units.
- */
+/// An operator for converting units
 class UnitConverter : public MatrixOperator
 {
 public:
   /**
-   * Convert from the units specified in the start properties to the
-   * given end units
-   * @param endUnits the units at the end of the operation
-   * @param startProperties the properties before the operation
+   * Convert from the units specified in the start properties to the given end units
+   * \param endUnits the units at the end of the operation
+   * \param startProperties the properties before the operation
    */
   UnitConverter(LengthUnit endUnits, const TransformableGeometryProperties &startProperties);
 
@@ -286,9 +265,8 @@ public:
   void accept(GeometryOperatorVisitor &visitor) const override;
 
   /**
-   * Get the conversion factor used to convert from the start units to the
-   * end units
-   * @return the unit conversion factor
+   * Get the conversion factor used to convert from the start units to the end units
+   * \return the unit conversion factor
    */
   double getConversionFactor() const;
 
@@ -298,8 +276,7 @@ private:
 
 /**
  * A SliceOperator takes a 3D shape and makes it 2D by defining a cut plane.
- * This plane is augmented with an origin and an "up" direction to orient
- * the slice to the x-y plane.
+ * This plane is augmented with an origin and an "up" direction to orient the slice to the x-y plane.
  */
 class SliceOperator : public MatrixOperator
 {
@@ -308,12 +285,10 @@ public:
    * Create a new Slice.
    *
    * \param origin the origin of the coordinate system
-   * \param normal a vector normal to the slice plane. Cannot be a zero
-   * vector.
-   * \param up the direction of the positive Y axis. Must be normal to
-   * the "normal" vector.
-   * \param startProperties the initial properties, as in the parent
-   * class. The number of dimensions should be 3, though this is not checked.
+   * \param normal a vector normal to the slice plane. Cannot be a zero vector.
+   * \param up the direction of the positive Y axis. Must be normal to the "normal" vector.
+   * \param startProperties the initial properties, as in the parent class. 
+   * The number of dimensions should be 3, though this is not checked.
    */
   SliceOperator(const primal::Point3D &origin,
                 const primal::Vector3D &normal,
@@ -362,7 +337,6 @@ private:
  * instances of GeometryOperator. It defines a "visit()" method for each
  * type of operator that a user can specify in the input file, as well
  * as one for CompositeOperator to work with a whole list of operators.
- *
  */
 class GeometryOperatorVisitor
 {

--- a/src/axom/klee/GeometryOperators.hpp
+++ b/src/axom/klee/GeometryOperators.hpp
@@ -3,14 +3,16 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#ifndef AXOM_KLEE_GEOMETRYOPERATOR_HPP
-#define AXOM_KLEE_GEOMETRYOPERATOR_HPP
+#ifndef AXOM_KLEE_GEOMETRYOPERATOR_HPP_
+#define AXOM_KLEE_GEOMETRYOPERATOR_HPP_
 
 #include "axom/config.hpp"
 #include "axom/core/numerics/Matrix.hpp"
+
 #include "axom/klee/Dimensions.hpp"
 #include "axom/klee/Geometry.hpp"
 #include "axom/klee/Units.hpp"
+
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
 
@@ -383,4 +385,4 @@ public:
 }  // namespace klee
 }  // namespace axom
 
-#endif  //AXOM_KLEE_GEOMETRYOPERATOR_HPP
+#endif  // AXOM_KLEE_GEOMETRYOPERATOR_HPP_

--- a/src/axom/klee/KleeError.hpp
+++ b/src/axom/klee/KleeError.hpp
@@ -3,13 +3,14 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#ifndef AXOM_KLEEERROR_HPP
-#define AXOM_KLEEERROR_HPP
+#ifndef AXOM_KLEE_ERROR_HPP_
+#define AXOM_KLEE_ERROR_HPP_
+
+
+#include "axom/inlet/inlet_utils.hpp"
 
 #include <exception>
 #include <vector>
-
-#include "axom/inlet/inlet_utils.hpp"
 
 namespace axom
 {
@@ -54,4 +55,4 @@ private:
 }  // namespace klee
 }  // namespace axom
 
-#endif  //AXOM_KLEEERROR_HPP
+#endif  // AXOM_KLEE_ERROR_HPP_

--- a/src/axom/klee/KleeError.hpp
+++ b/src/axom/klee/KleeError.hpp
@@ -6,7 +6,6 @@
 #ifndef AXOM_KLEE_ERROR_HPP_
 #define AXOM_KLEE_ERROR_HPP_
 
-
 #include "axom/inlet/inlet_utils.hpp"
 
 #include <exception>

--- a/src/axom/klee/Shape.cpp
+++ b/src/axom/klee/Shape.cpp
@@ -26,10 +26,8 @@ namespace
 template <typename Container>
 bool contains(const Container &container, const typename Container::value_type &value)
 {
-  using std::begin;
-  using std::end;
-  auto endIter = end(container);
-  return std::find(begin(container), endIter, value) != endIter;
+  auto endIter = std::end(container);
+  return std::find(std::begin(container), endIter, value) != endIter;
 }
 }  // unnamed namespace
 

--- a/src/axom/klee/Shape.hpp
+++ b/src/axom/klee/Shape.hpp
@@ -3,13 +3,14 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#ifndef AXOM_KLEE_SHAPE_HPP
-#define AXOM_KLEE_SHAPE_HPP
+#ifndef AXOM_KLEE_SHAPE_HPP_
+#define AXOM_KLEE_SHAPE_HPP_
+
+
+#include "axom/klee/Geometry.hpp"
 
 #include <string>
 #include <vector>
-
-#include "axom/klee/Geometry.hpp"
 
 namespace axom
 {
@@ -92,4 +93,4 @@ private:
 }  // namespace klee
 }  // namespace axom
 
-#endif
+#endif // AXOM_KLEE_SHAPE_HPP_

--- a/src/axom/klee/Shape.hpp
+++ b/src/axom/klee/Shape.hpp
@@ -33,8 +33,7 @@ public:
    * \param materialsNotReplaced the materials which cannot be replaced. If
    * empty, all materials can be replaced unless materialsReplaced is set.
    * \param geometry the geometric properties of this shape
-   * \throws std::logic_error if both materialsReplaced and
-   * materialsNotReplaced have entries.
+   * \throws std::logic_error if both materialsReplaced and materialsNotReplaced have entries.
    */
   Shape(std::string name,
         std::string material,

--- a/src/axom/klee/Shape.hpp
+++ b/src/axom/klee/Shape.hpp
@@ -6,7 +6,6 @@
 #ifndef AXOM_KLEE_SHAPE_HPP_
 #define AXOM_KLEE_SHAPE_HPP_
 
-
 #include "axom/klee/Geometry.hpp"
 
 #include <string>
@@ -92,4 +91,4 @@ private:
 }  // namespace klee
 }  // namespace axom
 
-#endif // AXOM_KLEE_SHAPE_HPP_
+#endif  // AXOM_KLEE_SHAPE_HPP_

--- a/src/axom/klee/ShapeSet.cpp
+++ b/src/axom/klee/ShapeSet.cpp
@@ -10,7 +10,6 @@
 #include <utility>
 #include <stdexcept>
 
-
 namespace axom
 {
 namespace klee

--- a/src/axom/klee/ShapeSet.cpp
+++ b/src/axom/klee/ShapeSet.cpp
@@ -20,15 +20,19 @@ void ShapeSet::setPath(const std::string &path) { m_path = path; }
 
 void ShapeSet::setDimensions(Dimensions dimensions)
 {
+  if(dimensions != Dimensions::Two && dimensions != Dimensions::Three)
+  {
+    throw std::logic_error(
+      "Invalid ShapeSet dimensions. Must be Dimensions::Two or Dimensions::Three");
+  }
   m_dimensions = dimensions;
-  m_dimensionsHaveBeenSet = true;
 }
 
 Dimensions ShapeSet::getDimensions() const
 {
-  if(!m_dimensionsHaveBeenSet)
+  if(m_dimensions == Dimensions::Unspecified)
   {
-    throw std::logic_error("Can only query the ShapeSet dimensions after calling setShapes()");
+    throw std::logic_error("ShapeSet dimensions have not been set yet");
   }
 
   return m_dimensions;

--- a/src/axom/klee/ShapeSet.cpp
+++ b/src/axom/klee/ShapeSet.cpp
@@ -3,12 +3,13 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+#include "axom/core/utilities/FileUtilities.hpp"
+
 #include "axom/klee/ShapeSet.hpp"
 
 #include <utility>
 #include <stdexcept>
 
-#include "axom/core/utilities/FileUtilities.hpp"
 
 namespace axom
 {

--- a/src/axom/klee/ShapeSet.hpp
+++ b/src/axom/klee/ShapeSet.hpp
@@ -3,14 +3,15 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#ifndef AXOM_KLEE_SHAPE_SET_HPP
-#define AXOM_KLEE_SHAPE_SET_HPP
+#ifndef AXOM_KLEE_SHAPESET_HPP_
+#define AXOM_KLEE_SHAPESET_HPP_
 
-#include <string>
-#include <vector>
 
 #include "axom/klee/Dimensions.hpp"
 #include "axom/klee/Shape.hpp"
+
+#include <string>
+#include <vector>
 
 namespace axom
 {
@@ -77,4 +78,4 @@ private:
 }  // namespace klee
 }  // namespace axom
 
-#endif  //AXOM_KLEE_SHAPE_SET_HPP
+#endif  // AXOM_KLEE_SHAPESET_HPP_

--- a/src/axom/klee/ShapeSet.hpp
+++ b/src/axom/klee/ShapeSet.hpp
@@ -6,7 +6,6 @@
 #ifndef AXOM_KLEE_SHAPESET_HPP_
 #define AXOM_KLEE_SHAPESET_HPP_
 
-
 #include "axom/klee/Dimensions.hpp"
 #include "axom/klee/Shape.hpp"
 
@@ -17,9 +16,7 @@ namespace axom
 {
 namespace klee
 {
-/**
- * A ShapeSet represents a document in the common shape format.
- */
+/// A ShapeSet represents a document in the common shape format.
 class ShapeSet
 {
 public:

--- a/src/axom/klee/ShapeSet.hpp
+++ b/src/axom/klee/ShapeSet.hpp
@@ -68,8 +68,7 @@ public:
 private:
   std::vector<Shape> m_shapes;
   std::string m_path;
-  bool m_dimensionsHaveBeenSet {false};
-  Dimensions m_dimensions;
+  Dimensions m_dimensions {Dimensions::Unspecified};
 };
 
 }  // namespace klee

--- a/src/axom/klee/Units.cpp
+++ b/src/axom/klee/Units.cpp
@@ -3,9 +3,9 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/klee/Units.hpp"
-
 #include "axom/inlet/Proxy.hpp"
+
+#include "axom/klee/Units.hpp"
 #include "axom/klee/KleeError.hpp"
 
 #include <stdexcept>

--- a/src/axom/klee/Units.hpp
+++ b/src/axom/klee/Units.hpp
@@ -2,8 +2,8 @@
 // other Axom Project Developers. See the top-level COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-#ifndef AXOM_UNITS_HPP
-#define AXOM_UNITS_HPP
+#ifndef AXOM_KLEE_UNITS_HPP
+#define AXOM_KLEE_UNITS_HPP
 
 #include <string>
 
@@ -100,4 +100,4 @@ void convertAll(T &values, LengthUnit sourceUnits, LengthUnit targetUnits)
 
 }  // namespace klee
 }  // namespace axom
-#endif  //AXOM_UNITS_HPP
+#endif  // AXOM_KLEE_UNITS_HPP

--- a/src/axom/klee/Units.hpp
+++ b/src/axom/klee/Units.hpp
@@ -53,14 +53,12 @@ LengthUnit parseLengthUnits(const std::string &unitsAsString, const std::string 
  *
  * \param unitsAsProxy the units as a proxy
  * \return the parsed units
- * \throws KleeError if the string does not represent known
- * units
+ * \throws KleeError if the string does not represent known units
  */
 LengthUnit parseLengthUnits(const inlet::Proxy &unitsAsProxy);
 
 /**
- * Get the conversion factor to convert from the given source units to the
- * target units.
+ * Get the conversion factor to convert from the given source units to the target units.
  *
  * \param sourceUnits the original units
  * \param targetUnits the units to convert to

--- a/src/axom/klee/docs/sphinx/specifying_shapes.rst
+++ b/src/axom/klee/docs/sphinx/specifying_shapes.rst
@@ -65,11 +65,37 @@ different paths would be specified.
 
 Changing Dimensions on a Per-Shape Basis
 ****************************************
-Sometimes it is useful to bring in a geometry file in a different
-dimensionality than the one you are working in. For example, you may be
-working in 2D, but may want to bring in a 3D file and then slice it
-(slices are described below). To do this, you need to specify the
+Some problem setups can require operating on shapes of different dimensions.
+
+In addition to the global :code:`dimensions` field, Klee provides a per-shape override 
+mechanism for the dimension of a shape via the :code:`geometry/dimensions` field
+
+.. code-block:: yaml
+
+    dimensions: 2
+
+    shapes:
+      - name: wheel
+        material: steel
+        geometry:
+          format: stl
+          path: wheel.stl
+          dimensions: 3
+          units: cm
+
+In the above snippet, the overall dimension of the problem is `2`, but the `wheel`
+shape is 3-dimensional.
+In such cases, the user code is responsible for conversions between
+the shape dimension (e.g. the dimension in the specified file format) and the problem dimension
+(i.e. the dimension of the computational mesh).
+
+Alternatively, some :code:`operators` (described below), can handle the conversion 
+from the shape's dimension and the problem dimension.
+For example, the input to the :code:`slice`` operator is a three-dimensional shape
+and the output is a two-dimensional shape. This is specified via the 
 :code:`start_dimensions` field on the :code:`geometry` of a :code:`shape`.
+After the `operators` have been applied, the (end) dimension of the shape
+will match that of the (global or per-shape) `dimensions`.
 
 .. code-block:: yaml
 
@@ -86,6 +112,7 @@ working in 2D, but may want to bring in a 3D file and then slice it
           operators:
             - slice:
                 x: 10
+
 
 Overlay Rules
 -------------

--- a/src/axom/klee/io/GeometryOperatorsIO.cpp
+++ b/src/axom/klee/io/GeometryOperatorsIO.cpp
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-
 #include "GeometryOperatorsIO.hpp"
 #include "IOUtil.hpp"
 
@@ -11,6 +10,7 @@
 #include "axom/klee/GeometryOperators.hpp"
 #include "axom/klee/KleeError.hpp"
 
+#include "axom/fmt.hpp"
 
 #include <functional>
 #include <string>
@@ -118,12 +118,9 @@ void verifyObjectFields(const inlet::Container &containerToTest,
   {
     if(!containerToTest.contains(requiredField))
     {
-      std::string message = "Missing required parameter \"";
-      message += requiredField;
-      message += "\" for operator \"";
-      message += name;
-      message += '"';
-      throw KleeError({containerToTest.name(), message});
+      throw KleeError(
+        {containerToTest.name(),
+         axom::fmt::format("Missing required parameter '{}' for operator '{}'", requiredField, name)});
     }
   }
 
@@ -138,12 +135,8 @@ void verifyObjectFields(const inlet::Container &containerToTest,
       continue;
     }
 
-    std::string message = "Unexpected parameter for operator \"";
-    message += name;
-    message += "\": \"";
-    message += child;
-    message += '"';
-    throw KleeError({containerToTest.name(), message});
+    throw KleeError({containerToTest.name(),
+                     axom::fmt::format("Unexpected parameter '{}' for operator '{}'", name, child)});
   }
 }
 
@@ -172,7 +165,9 @@ OpPtr parseTranslate(const inlet::Container &opContainer,
 OpPtr parseRotate(const inlet::Container &opContainer,
                   const TransformableGeometryProperties &startProperties)
 {
-  if(startProperties.dimensions == Dimensions::Two)
+  switch(startProperties.dimensions)
+  {
+  case Dimensions::Two:
   {
     verifyObjectFields(opContainer, "rotate", FieldSet {}, {"center"});
     Vector3D axis {0, 0, 1};
@@ -182,7 +177,8 @@ OpPtr parseRotate(const inlet::Container &opContainer,
       axis,
       startProperties);
   }
-  else
+  break;
+  case Dimensions::Three:
   {
     verifyObjectFields(opContainer, "rotate", {"axis"}, {"center"});
     return std::make_shared<Rotation>(
@@ -190,6 +186,10 @@ OpPtr parseRotate(const inlet::Container &opContainer,
       toPoint(opContainer, "center", Dimensions::Three, Point3D {0, 0, 0}),
       toVector(opContainer, "axis", Dimensions::Three),
       startProperties);
+  }
+  break;
+  case Dimensions::Unspecified:
+    throw KleeError({opContainer.name(), "Rotations can only be applied to 2D or 3D shapes"});
   }
 }
 
@@ -214,7 +214,7 @@ OpPtr makeCheckedSlice(Point3D origin,
   {
     throw KleeError({path, "The 'normal' vector must not be a zero vector"});
   }
-  if(!utilities::isNearlyEqual(normal.dot(up), 0.0))
+  if(!utilities::isNearlyEqual(normal.dot(up), 0.))
   {
     throw KleeError({path, "The 'normal' and 'up' vectors must be perpendicular"});
   }
@@ -289,8 +289,7 @@ primal::Vector3D getPerpendicularSliceNormal(const inlet::Container &sliceContai
  *
  * \param sliceContainer the Container describing the slice
  * \param planeName the name of the plane ("x", "y", or "z")
- * \param defaultNormal the default normal vector for the type of plane
- *  being parsed
+ * \param defaultNormal the default normal vector for the type of plane being parsed
  * \param defaultUp the default up vector for the plane being parsed
  * \param startProperties the properties prior to this operator
  * \return the parsed plane
@@ -393,8 +392,7 @@ OpPtr parseConvertUnits(const inlet::Container &opContainer,
  *
  * \param opContainer the Container from which to read the operator
  * \param startProperties the properties before the "ref" command
- * \param namedOperators a map of named operators from which to get
- * referenced operators
+ * \param namedOperators a map of named operators from which to get referenced operators
  * \return the created operator
  */
 OpPtr parseRef(const inlet::Container &opContainer,
@@ -441,8 +439,7 @@ OpPtr parseRef(const inlet::Container &opContainer,
  *
  * \param data the data from which to convert the operator
  * \param startProperties the properties before the operator
- * \param namedOperators a map of named operators from which to get
- * referenced operators
+ * \param namedOperators a map of named operators from which to get referenced operators
  * \return the created operator
  */
 OpPtr convertOperator(SingleOperatorData const &data,

--- a/src/axom/klee/io/GeometryOperatorsIO.cpp
+++ b/src/axom/klee/io/GeometryOperatorsIO.cpp
@@ -3,12 +3,14 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/klee/GeometryOperatorsIO.hpp"
+
+#include "GeometryOperatorsIO.hpp"
+#include "IOUtil.hpp"
 
 #include "axom/klee/Geometry.hpp"
 #include "axom/klee/GeometryOperators.hpp"
-#include "axom/klee/IOUtil.hpp"
 #include "axom/klee/KleeError.hpp"
+
 
 #include <functional>
 #include <string>

--- a/src/axom/klee/io/GeometryOperatorsIO.hpp
+++ b/src/axom/klee/io/GeometryOperatorsIO.hpp
@@ -2,16 +2,17 @@
 // other Axom Project Developers. See the top-level COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-#ifndef AXOM_KLEE_GEOMETRYOPERATORSIO_HPP
-#define AXOM_KLEE_GEOMETRYOPERATORSIO_HPP
+#ifndef AXOM_KLEE_GEOMETRYOPERATORSIO_HPP_
+#define AXOM_KLEE_GEOMETRYOPERATORSIO_HPP_
 
-#include <memory>
-#include <string>
-#include <unordered_map>
 
 #include "axom/inlet.hpp"
 #include "axom/klee/Dimensions.hpp"
 #include "axom/klee/Units.hpp"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
 
 namespace axom
 {
@@ -171,4 +172,4 @@ struct FromInlet<axom::klee::internal::NamedOperatorMapData>
   axom::klee::internal::NamedOperatorMapData operator()(const axom::inlet::Container &base);
 };
 
-#endif  //AXOM_KLEE_GEOMETRYOPERATORSIO_HPP
+#endif  // AXOM_KLEE_GEOMETRYOPERATORSIO_HPP_

--- a/src/axom/klee/io/GeometryOperatorsIO.hpp
+++ b/src/axom/klee/io/GeometryOperatorsIO.hpp
@@ -5,7 +5,6 @@
 #ifndef AXOM_KLEE_GEOMETRYOPERATORSIO_HPP_
 #define AXOM_KLEE_GEOMETRYOPERATORSIO_HPP_
 
-
 #include "axom/inlet.hpp"
 #include "axom/klee/Dimensions.hpp"
 #include "axom/klee/Units.hpp"
@@ -73,8 +72,7 @@ public:
      * Make an operator describing the transformation to apply to the geomtry.
      * May be null.
      *
-     * @param startProperties properties of the geometry before the first
-     * operator
+     * @param startProperties properties of the geometry before the first operator
      * @param namedOperators a map of any named operators
      * @return the (possibly null) operator
      */
@@ -132,8 +130,7 @@ struct NamedOperatorMapData
   /**
      * Convert the data to a NamedOperatorMap.
      *
-     * @param fileDimensions the dimensions that shapes should be in in this
-     * file.
+     * @param fileDimensions the dimensions that shapes should be in in this file.
      * @return the name of converted operators
      */
   NamedOperatorMap makeNamedOperatorMap(Dimensions fileDimensions) const;

--- a/src/axom/klee/io/GeometryOperatorsIO.hpp
+++ b/src/axom/klee/io/GeometryOperatorsIO.hpp
@@ -24,58 +24,51 @@ namespace internal
 {
 using NamedOperatorMap = std::unordered_map<std::string, std::shared_ptr<const GeometryOperator>>;
 
-/**
- * The data for a single operator.
- */
+/// The data for a single operator.
 struct SingleOperatorData
 {
   const inlet::Container *m_container;
 };
 
-/**
- * The data for the "operator" component of "geometry" objects.
- */
+/// The data for the "operator" component of "geometry" objects.
 class GeometryOperatorData
 {
 public:
-  /**
-     * Construct a GeometryOperatorData with no operators.
-     */
+  /// Construct a GeometryOperatorData with no operators.
   GeometryOperatorData() = default;
 
   /**
-     * Construct a GeometryOperatorData with no operators.
-     * @param path the path where the operators were defined
-     */
+   * Construct a GeometryOperatorData with no operators.
+   * @param path the path where the operators were defined
+   */
   explicit GeometryOperatorData(const Path &path);
 
   /**
-     * Construct a GeometryOperatorData for the given list of operators
-     * @param path the path where the operators were defined
-     * @param singleOperatorData the data for the individual operators
-     */
+   * Construct a GeometryOperatorData for the given list of operators
+   * @param path the path where the operators were defined
+   * @param singleOperatorData the data for the individual operators
+   */
   explicit GeometryOperatorData(const Path &path,
                                 std::vector<SingleOperatorData> &&singleOperatorData);
 
   /**
-     * Define the schema for geometry operators
-     * @param parent the parent container
-     * @param fieldName the name of the field
-     * @param description a description of the field
-     * @return the Container for the new item
-     */
+   * Define the schema for geometry operators
+   * @param parent the parent container
+   * @param fieldName the name of the field
+   * @param description a description of the field
+   * @return the Container for the new item
+   */
   static inlet::Container &defineSchema(inlet::Container &parent,
                                         const std::string &fieldName,
                                         const std::string &description);
 
   /**
-     * Make an operator describing the transformation to apply to the geomtry.
-     * May be null.
-     *
-     * @param startProperties properties of the geometry before the first operator
-     * @param namedOperators a map of any named operators
-     * @return the (possibly null) operator
-     */
+   * Make a (possibly null) operator describing the transformation to apply to the geometry
+   *
+   * @param startProperties properties of the geometry before the first operator
+   * @param namedOperators a map of any named operators
+   * @return the (possibly null) operator
+   */
   std::shared_ptr<GeometryOperator> makeOperator(const TransformableGeometryProperties &startProperties,
                                                  const NamedOperatorMap &namedOperators) const;
 
@@ -90,9 +83,7 @@ private:
   std::vector<SingleOperatorData> m_singleOperatorData;
 };
 
-/**
- * Data for a named operator.
- */
+/// Data for a named operator.
 struct NamedOperatorData
 {
   std::string name;
@@ -103,44 +94,40 @@ struct NamedOperatorData
   GeometryOperatorData value;
 
   /**
-     * Define the schema for a named operator.
-     *
-     * @param container the container in which to describe a single named operator
-     */
+   * Define the schema for a named operator.
+   *
+   * @param container the container in which to describe a single named operator
+   */
   static void defineSchema(inlet::Container &container);
 };
 
-/**
- * Data for all a collection of named operators
- */
+/// Data for all a collection of named operators
 struct NamedOperatorMapData
 {
-  /**
-     * Create a NamedOperatorMapData with no operators.
-     */
+  /// Create a NamedOperatorMapData with no operators.
   NamedOperatorMapData() = default;
 
   /**
-     * Create a NamedOperatorMapData with the given list of operators.
-     *
-     * @param operatorData the data for all the named operators in this map
-     */
+   * Create a NamedOperatorMapData with the given list of operators.
+   *
+   * @param operatorData the data for all the named operators in this map
+   */
   explicit NamedOperatorMapData(std::vector<NamedOperatorData> &&operatorData);
 
   /**
-     * Convert the data to a NamedOperatorMap.
-     *
-     * @param fileDimensions the dimensions that shapes should be in in this file.
-     * @return the name of converted operators
-     */
+   * Convert the data to a NamedOperatorMap.
+   *
+   * @param fileDimensions the dimensions that shapes should be in in this file.
+   * @return the name of converted operators
+   */
   NamedOperatorMap makeNamedOperatorMap(Dimensions fileDimensions) const;
 
   /**
-     * Define the schema for a collection of named operators.
-     *
-     * @param parent the parent object in which to define the operator map
-     * @param name the name of the map
-     */
+   * Define the schema for a collection of named operators.
+   *
+   * @param parent the parent object in which to define the operator map
+   * @param name the name of the map
+   */
   static void defineSchema(inlet::Container &parent, const std::string &name);
 
 private:

--- a/src/axom/klee/io/IO.cpp
+++ b/src/axom/klee/io/IO.cpp
@@ -36,7 +36,7 @@ struct GeometryData
   LengthUnit startUnits {LengthUnit::unspecified};
   LengthUnit endUnits {LengthUnit::unspecified};
   Dimensions startDimensions {Dimensions::Unspecified};
-  bool dimensionsSet {false};
+  Dimensions explicitDimensions {Dimensions::Unspecified};
   internal::GeometryOperatorData operatorData;
   Path pathInFile;
 };
@@ -77,16 +77,13 @@ struct FromInlet<axom::klee::GeometryData>
     data.path = base.contains("path") ? base.get<std::string>("path") : "";
     data.operatorData = base["operators"].get<axom::klee::internal::GeometryOperatorData>();
 
-    if(base.contains("start_dimensions"))
-    {
-      data.startDimensions = axom::klee::internal::toDimensions(base["start_dimensions"]);
-      data.dimensionsSet = true;
-    }
-    else
-    {
-      data.startDimensions = axom::klee::Dimensions::Unspecified;
-      data.dimensionsSet = false;
-    }
+    data.startDimensions = base.contains("start_dimensions")
+      ? axom::klee::internal::toDimensions(base["start_dimensions"])
+      : axom::klee::Dimensions::Unspecified;
+
+    data.explicitDimensions = base.contains("dimensions")
+      ? axom::klee::internal::toDimensions(base["dimensions"])
+      : axom::klee::Dimensions::Unspecified;
 
     std::tie(data.startUnits, data.endUnits) =
       axom::klee::internal::getOptionalStartAndEndUnits(base);
@@ -118,6 +115,10 @@ void defineGeometry(inlet::Container &geometry)
   internal::defineDimensionsField(geometry,
                                   "start_dimensions",
                                   "The initial dimensions of the geometry file");
+  internal::defineDimensionsField(geometry,
+                                  "dimensions",
+                                  "An explicit (final) dimension for the shape."
+                                  "This overrides the global 'dimensions' field for this shape.");
   internal::defineUnitsSchema(geometry,
                               "The units in which the geometry file is expressed if the units "
                               "are not embedded. These will also be the units of the operators "
@@ -137,12 +138,14 @@ void defineGeometry(inlet::Container &geometry)
 void defineShapeList(inlet::Inlet &document)
 {
   inlet::Container &shapeList = document.addStructArray("shapes", "The list of shapes");
+
   shapeList.addString("name", "The shape's name").required();
   shapeList.addString("material", "The shape's material").required();
   shapeList.addStringArray("replaces", "The list of materials this shape replaces");
   shapeList.addStringArray("does_not_replace", "The list of materials this shape does not replace");
   auto &geometry =
     shapeList.addStruct("geometry", "Contains information about the shape's geometry");
+
   defineGeometry(geometry);
 
   // Verify syntax here, semantics later!!!
@@ -161,12 +164,12 @@ void defineShapeList(inlet::Inlet &document)
         const auto geom = shape.get<GeometryData>("geometry");
         if(geom.path.empty() && geom.format != "none")
         {
-          INLET_VERIFICATION_WARNING(shape.name(),
-                                     axom::fmt::format("'geometry/path' field required unless "
-                                                       "'geometry/format' is 'none'. "
-                                                       "Provided format was '{}'",
-                                                       geom.format),
-                                     errors);
+          INLET_VERIFICATION_WARNING(  //
+            shape.name(),
+            axom::fmt::format("'geometry/path' field required unless 'geometry/format' is 'none'. "
+                              "Provided format was '{}'",
+                              geom.format),
+            errors);
           return false;
         }
       }
@@ -199,11 +202,18 @@ Geometry convert(GeometryData const &data,
                  Dimensions fileDimensions,
                  internal::NamedOperatorMap const &namedOperators)
 {
+  const bool has_start_dims = data.startDimensions != Dimensions::Unspecified;
+  const bool has_explicit_dims = data.explicitDimensions != Dimensions::Unspecified;
+
   TransformableGeometryProperties startProperties;
   startProperties.units = data.startUnits;
-  if(data.dimensionsSet)
+  if(has_start_dims)
   {
     startProperties.dimensions = data.startDimensions;
+  }
+  else if(has_explicit_dims)
+  {
+    startProperties.dimensions = data.explicitDimensions;
   }
   else
   {
@@ -215,11 +225,17 @@ Geometry convert(GeometryData const &data,
                      data.path,
                      data.operatorData.makeOperator(startProperties, namedOperators)};
 
-  if(geometry.getEndProperties().dimensions != fileDimensions)
+  const auto computed_end_dims = geometry.getEndProperties().dimensions;
+  const auto expected_end_dims = has_explicit_dims ? data.explicitDimensions : fileDimensions;
+  if(computed_end_dims != expected_end_dims)
   {
-    throw KleeError(
-      {data.pathInFile, "Did not end up in the number of dimensions specified by the file"});
+    throw KleeError({data.pathInFile,
+                     axom::fmt::format("Did not end up with the expected number of dimensions. "
+                                       "Expected: {}, but got: {}",
+                                       expected_end_dims == Dimensions::Two ? 2 : 3,
+                                       computed_end_dims == Dimensions::Two ? 2 : 3)});
   }
+
   return geometry;
 }
 
@@ -227,8 +243,7 @@ Geometry convert(GeometryData const &data,
  * Create a Shape from its raw data representation
  *
  * \param data the data read from Inlet
- * \param fileDimensions the number of dimensions the file expects shapes to
- * have
+ * \param fileDimensions the number of dimensions the file expects shapes to have
  * \param namedOperators any named operators that were parsed from the file
  * \return the shape as a Shape object
  */
@@ -266,6 +281,7 @@ std::vector<Shape> convert(std::vector<ShapeData> const &shapeData,
 
 /**
  * Get all named geometry operators from the file
+ * 
  * \param doc the inlet document containing the file
  * \param startDimensions the number of dimensions that operators should
  * start at unless otherwise specified

--- a/src/axom/klee/io/IO.cpp
+++ b/src/axom/klee/io/IO.cpp
@@ -27,16 +27,16 @@ namespace
 // Because we can't have context-aware validation when extracting the
 // data from Inlet, we need a set of structs that parallels the real
 // classes. These are used to do some basic validation, and then we convert
-// the to the real classes, doing more thorough validation.
+// them to the real classes, doing more thorough validation.
 
 struct GeometryData
 {
   std::string format;
   std::string path;
-  LengthUnit startUnits;
-  LengthUnit endUnits;
-  Dimensions startDimensions;
-  bool dimensionsSet;
+  LengthUnit startUnits {LengthUnit::unspecified};
+  LengthUnit endUnits {LengthUnit::unspecified};
+  Dimensions startDimensions {Dimensions::Unspecified};
+  bool dimensionsSet {false};
   internal::GeometryOperatorData operatorData;
   Path pathInFile;
 };
@@ -84,6 +84,7 @@ struct FromInlet<axom::klee::GeometryData>
     }
     else
     {
+      data.startDimensions = axom::klee::Dimensions::Unspecified;
       data.dimensionsSet = false;
     }
 
@@ -111,7 +112,7 @@ using inlet::Inlet;
  *
  * @param geometry the Container representing a "geometry" object.
  */
-void defineGeometry(Container &geometry)
+void defineGeometry(inlet::Container &geometry)
 {
   geometry.addString("format", "The format of the input file").required();
   geometry.addString("path",
@@ -138,7 +139,7 @@ void defineGeometry(Container &geometry)
  */
 void defineShapeList(Inlet &document)
 {
-  Container &shapeList = document.addStructArray("shapes", "The list of shapes");
+  inlet::Container &shapeList = document.addStructArray("shapes", "The list of shapes");
   shapeList.addString("name", "The shape's name").required();
   shapeList.addString("material", "The shape's material").required();
   shapeList.addStringArray("replaces", "The list of materials this shape replaces");
@@ -164,10 +165,10 @@ void defineShapeList(Inlet &document)
         if(geom.path.empty() && geom.format != "none")
         {
           INLET_VERIFICATION_WARNING(shape.name(),
-                                     fmt::format("'geometry/path' field required unless "
-                                                 "'geometry/format' is 'none'. "
-                                                 "Provided format was '{}'",
-                                                 geom.format),
+                                     axom::fmt::format("'geometry/path' field required unless "
+                                                       "'geometry/format' is 'none'. "
+                                                       "Provided format was '{}'",
+                                                       geom.format),
                                      errors);
           return false;
         }
@@ -193,8 +194,7 @@ void defineKleeSchema(Inlet &document)
  * Create a Shape's Geometry from its raw data
  *
  * \param data the data read from inlet
- * \param fileDimensions the number of dimensions the file expects shapes to
- * have
+ * \param fileDimensions the number of dimensions the file expects shapes to have
  * \param namedOperators any named operators that were parsed from the file
  * \return the geometry description for the shape
  */
@@ -250,8 +250,7 @@ Shape convert(ShapeData const &data,
  * Create a list of Shapes from their raw data representation
  *
  * \param shapeData the data read from Inlet
- * \param fileDimensions the number of dimensions the file expects shapes to
- * have
+ * \param fileDimensions the number of dimensions the file expects shapes to have
  * \param namedOperators any named operators that were parsed from the file
  * \return the shape as a Shape object
  */

--- a/src/axom/klee/io/IO.cpp
+++ b/src/axom/klee/io/IO.cpp
@@ -103,9 +103,6 @@ namespace klee
 {
 namespace
 {
-using inlet::Container;
-using inlet::Field;
-using inlet::Inlet;
 
 /**
  * Define the schema for the "geometry" member of shapes
@@ -137,7 +134,7 @@ void defineGeometry(inlet::Container &geometry)
  *
  * @param document the Inlet document for which to define the schema
  */
-void defineShapeList(Inlet &document)
+void defineShapeList(inlet::Inlet &document)
 {
   inlet::Container &shapeList = document.addStructArray("shapes", "The list of shapes");
   shapeList.addString("name", "The shape's name").required();
@@ -150,7 +147,7 @@ void defineShapeList(Inlet &document)
 
   // Verify syntax here, semantics later!!!
   shapeList.registerVerifier(
-    [](const Container &shape, std::vector<inlet::VerificationError> *errors) -> bool {
+    [](const inlet::Container &shape, std::vector<inlet::VerificationError> *errors) -> bool {
       if(shape.contains("replaces") && shape.contains("does_not_replace"))
       {
         INLET_VERIFICATION_WARNING(shape.name(),
@@ -183,7 +180,7 @@ void defineShapeList(Inlet &document)
  *
  * @param document the Inlet document for which to define the schema
  */
-void defineKleeSchema(Inlet &document)
+void defineKleeSchema(inlet::Inlet &document)
 {
   internal::defineDimensionsField(document.getGlobalContainer(), "dimensions").required();
   defineShapeList(document);
@@ -293,7 +290,7 @@ ShapeSet readShapeSet(std::istream &stream)
   reader->parseString(contents);
 
   sidre::DataStore dataStore;
-  Inlet doc(std::move(reader), dataStore.getRoot());
+  inlet::Inlet doc(std::move(reader), dataStore.getRoot());
   defineKleeSchema(doc);
   std::vector<inlet::VerificationError> errors;
   if(!doc.verify(&errors))

--- a/src/axom/klee/io/IO.cpp
+++ b/src/axom/klee/io/IO.cpp
@@ -3,19 +3,20 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/klee/IO.hpp"
+#include "IO.hpp"
+#include "IOUtil.hpp"
+#include "GeometryOperatorsIO.hpp"
+
+#include "axom/klee/GeometryOperators.hpp"
+#include "axom/klee/KleeError.hpp"
+
+#include "axom/inlet.hpp"
 
 #include <fstream>
 #include <functional>
 #include <iterator>
 #include <string>
 #include <tuple>
-
-#include "axom/inlet.hpp"
-#include "axom/klee/GeometryOperators.hpp"
-#include "axom/klee/GeometryOperatorsIO.hpp"
-#include "axom/klee/IOUtil.hpp"
-#include "axom/klee/KleeError.hpp"
 
 namespace axom
 {

--- a/src/axom/klee/io/IO.hpp
+++ b/src/axom/klee/io/IO.hpp
@@ -3,13 +3,14 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#ifndef AXOM_KLEE_IO_HPP
-#define AXOM_KLEE_IO_HPP
+#ifndef AXOM_KLEE_IO_HPP_
+#define AXOM_KLEE_IO_HPP_
+
+
+#include "axom/klee/ShapeSet.hpp"
 
 #include <string>
 #include <istream>
-
-#include "axom/klee/ShapeSet.hpp"
 
 namespace axom
 {
@@ -35,4 +36,4 @@ ShapeSet readShapeSet(const std::string &filePath);
 }  // namespace klee
 }  // namespace axom
 
-#endif  //AXOM_KLEE_IO_HPP
+#endif  // AXOM_KLEE_IO_HPP_

--- a/src/axom/klee/io/IO.hpp
+++ b/src/axom/klee/io/IO.hpp
@@ -6,7 +6,6 @@
 #ifndef AXOM_KLEE_IO_HPP_
 #define AXOM_KLEE_IO_HPP_
 
-
 #include "axom/klee/ShapeSet.hpp"
 
 #include <string>

--- a/src/axom/klee/io/IOUtil.cpp
+++ b/src/axom/klee/io/IOUtil.cpp
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/klee/IOUtil.hpp"
+#include "IOUtil.hpp"
 
 #include "axom/inlet.hpp"
 #include "axom/klee/KleeError.hpp"

--- a/src/axom/klee/io/IOUtil.hpp
+++ b/src/axom/klee/io/IOUtil.hpp
@@ -53,8 +53,7 @@ primal::Point3D toPoint(inlet::Container const &parent, char const *fieldName, D
 
 /**
  * Convert the specified field to a Point3D, ensuring that it
- * has the expected number of entries. If the field is not present, the
- * default value is used.
+ * has the expected number of entries. If the field is not present, the default value is used.
  *
  * @param parent the parent of the field
  * @param fieldName the name of the field

--- a/src/axom/klee/io/IOUtil.hpp
+++ b/src/axom/klee/io/IOUtil.hpp
@@ -2,16 +2,17 @@
 // other Axom Project Developers. See the top-level COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-#ifndef AXOM_KLEE_IO_UTIL_HPP
-#define AXOM_KLEE_IO_UTIL_HPP
-
-#include <tuple>
-#include <vector>
+#ifndef AXOM_KLEE_IO_UTIL_HPP_
+#define AXOM_KLEE_IO_UTIL_HPP_
 
 #include "axom/klee/Dimensions.hpp"
 #include "axom/klee/Units.hpp"
+
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
+
+#include <tuple>
+#include <vector>
 
 namespace axom
 {
@@ -162,4 +163,4 @@ Dimensions toDimensions(const inlet::Proxy &dimProxy);
 }  // namespace klee
 }  // namespace axom
 
-#endif  //AXOM_KLEE_IO_UTIL_HPP
+#endif  // AXOM_KLEE_IO_UTIL_HPP_

--- a/src/axom/klee/tests/KleeMatchers.hpp
+++ b/src/axom/klee/tests/KleeMatchers.hpp
@@ -2,11 +2,12 @@
 // other Axom Project Developers. See the top-level COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-#ifndef AXOM_KLEEMATCHERS_HPP
-#define AXOM_KLEEMATCHERS_HPP
+#ifndef AXOM_KLEE_MATCHERS_HPP_
+#define AXOM_KLEE_MATCHERS_HPP_
 
 #include "axom/core.hpp"
 #include "axom/primal.hpp"
+
 #include "axom/klee/GeometryOperators.hpp"
 
 #include "gmock/gmock.h"
@@ -170,4 +171,4 @@ inline auto AlmostEqSlice(const klee::SliceOperator& slice) { return AlmostEqSli
 }  // namespace klee
 }  // namespace axom
 
-#endif  //AXOM_KLEEMATCHERS_HPP
+#endif  // AXOM_KLEE_MATCHERS_HPP_

--- a/src/axom/klee/tests/KleeTestUtils.hpp
+++ b/src/axom/klee/tests/KleeTestUtils.hpp
@@ -3,17 +3,18 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#ifndef AXOM_KLEETESTUTILS_HPP
-#define AXOM_KLEETESTUTILS_HPP
+#ifndef AXOM_KLEE_TESTUTILS_HPP_
+#define AXOM_KLEE_TESTUTILS_HPP_
 
-#include <array>
+#include "axom/klee/GeometryOperators.hpp"
 
 #include "axom/core/numerics/Matrix.hpp"
-#include "axom/klee/GeometryOperators.hpp"
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
 
 #include "gmock/gmock.h"
+
+#include <array>
 
 namespace axom
 {
@@ -45,4 +46,4 @@ public:
 }  // namespace klee
 }  // namespace axom
 
-#endif  //AXOM_KLEETESTUTILS_HPP
+#endif  // AXOM_KLEE_TESTUTILS_HPP_

--- a/src/axom/klee/tests/klee_geometry.cpp
+++ b/src/axom/klee/tests/klee_geometry.cpp
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "axom/klee/Geometry.hpp"
-
 #include "axom/klee/tests/KleeTestUtils.hpp"
 
 #include "gtest/gtest.h"

--- a/src/axom/klee/tests/klee_geometry.cpp
+++ b/src/axom/klee/tests/klee_geometry.cpp
@@ -25,6 +25,9 @@ TEST(GeometryTest, dimensions_noOperators)
   EXPECT_EQ(startProperties, geometry.getEndProperties());
 
   EXPECT_TRUE(geometry.hasGeometry());
+
+  EXPECT_EQ(startProperties.dimensions, geometry.getInputDimensions());
+  EXPECT_EQ(startProperties.dimensions, geometry.getOutputDimensions());
 }
 
 TEST(GeometryTest, dimensions_dimensionPreservingOperator)
@@ -37,8 +40,8 @@ TEST(GeometryTest, dimensions_dimensionPreservingOperator)
   ON_CALL(*mockOperator, getEndProperties()).WillByDefault(Return(endProperties));
   EXPECT_CALL(*mockOperator, getEndProperties());
 
-  EXPECT_EQ(startProperties, geometry.getStartProperties());
-  EXPECT_EQ(endProperties, geometry.getEndProperties());
+  EXPECT_EQ(startProperties.dimensions, geometry.getInputDimensions());
+  EXPECT_EQ(endProperties.dimensions, geometry.getOutputDimensions());
 }
 
 TEST(GeometryTest, emptyPath)

--- a/src/axom/klee/tests/klee_geometry_operators_io.cpp
+++ b/src/axom/klee/tests/klee_geometry_operators_io.cpp
@@ -3,12 +3,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/slic/core/SimpleLogger.hpp"
+#include "axom/slic.hpp"
 #include "axom/inlet.hpp"
 
 #include "axom/klee/GeometryOperators.hpp"
-#include "axom/klee/GeometryOperatorsIO.hpp"
 #include "axom/klee/KleeError.hpp"
+#include "axom/klee/io/GeometryOperatorsIO.hpp"
 
 #include "KleeMatchers.hpp"
 

--- a/src/axom/klee/tests/klee_geometry_operators_io.cpp
+++ b/src/axom/klee/tests/klee_geometry_operators_io.cpp
@@ -96,8 +96,7 @@ NamedOperatorMap readNamedOperators(Dimensions startingDimensions, const std::st
  * Copy an operator from a pointer.
  *
  * \tparam T the expected type of the operator
- * \param ptr the pointer to the operator. Must not be null after
- * a dynamic_cast to T.
+ * \param ptr the pointer to the operator. Must not be null after a dynamic_cast to T.
  * \return a copy of the operator
  * \throws std::logic error if the pointer is of the wrong type
  */
@@ -116,8 +115,7 @@ T copyOperator(const OperatorPointer &ptr)
  * Get a single operator from a CompositeOperator.
  *
  * \tparam T the expected type of the operator
- * \param ptr the pointer to the operator. Must not be null after
- * a dynamic_cast to CompositeOperator.
+ * \param ptr the pointer to the operator. Must not be null after a dynamic_cast to CompositeOperator.
  * \return a copy of the operator
  * \throws std::logic error if the pointer is of the wrong type
  */

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -42,6 +42,7 @@ TEST(IOTest, readShapeSet_noShapes)
   EXPECT_TRUE(shapeSet.getShapes().empty());
   EXPECT_EQ(Dimensions::Two, shapeSet.getDimensions());
   EXPECT_NE(Dimensions::Three, shapeSet.getDimensions());
+  EXPECT_NE(Dimensions::Unspecified, shapeSet.getDimensions());
 }
 
 TEST(IOTest, readShapeSet_invalidDimensions)
@@ -73,11 +74,13 @@ TEST(IOTest, readShapeSet_shapeWithNoReplacementLists)
 
   auto &shapes = shapeSet.getShapes();
   ASSERT_EQ(1u, shapes.size());
+
   auto &shape = shapes[0];
   EXPECT_TRUE(shape.replaces("mat1"));
   EXPECT_TRUE(shape.replaces("mat2"));
   EXPECT_EQ("wheel", shape.getName());
   EXPECT_EQ("steel", shape.getMaterial());
+
   auto &geometry = shape.getGeometry();
   EXPECT_EQ("test_format", geometry.getFormat());
   EXPECT_EQ("path/to/file.format", geometry.getPath());
@@ -99,6 +102,7 @@ TEST(IOTest, readShapeSet_shapeWithReplacesList)
 
   auto &shapes = shapeSet.getShapes();
   ASSERT_EQ(1u, shapes.size());
+
   auto &shape = shapes[0];
   EXPECT_TRUE(shape.replaces("mat1"));
   EXPECT_TRUE(shape.replaces("mat2"));
@@ -120,6 +124,7 @@ TEST(IOTest, readShapeSet_shapeWithDoesNotReplaceList)
 
   auto &shapes = shapeSet.getShapes();
   ASSERT_EQ(1u, shapes.size());
+
   auto &shape = shapes[0];
   EXPECT_FALSE(shape.replaces("mat1"));
   EXPECT_FALSE(shape.replaces("mat2"));
@@ -315,7 +320,13 @@ TEST(IOTest, readShapeSet_geometryOperators)
   ASSERT_TRUE(geometryOperator);
   auto composite = std::dynamic_pointer_cast<const CompositeOperator>(geometryOperator);
   ASSERT_TRUE(composite);
+
   EXPECT_EQ(2u, composite->getOperators().size());
+
+  auto rotation = dynamic_cast<const Rotation *>(composite->getOperators()[0].get());
+  ASSERT_NE(rotation, nullptr);
+  EXPECT_EQ(rotation->getAngle(), 90);
+
   auto translation = dynamic_cast<const Translation *>(composite->getOperators()[1].get());
   ASSERT_NE(translation, nullptr);
   EXPECT_THAT(translation->getOffset(), AlmostEqVector(Vector3D {10, 20, 0}));

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -85,6 +85,9 @@ TEST(IOTest, readShapeSet_shapeWithNoReplacementLists)
   EXPECT_EQ("test_format", geometry.getFormat());
   EXPECT_EQ("path/to/file.format", geometry.getPath());
   EXPECT_FALSE(geometry.getGeometryOperator());
+
+  EXPECT_EQ(geometry.getInputDimensions(), Dimensions::Two);
+  EXPECT_EQ(geometry.getOutputDimensions(), Dimensions::Two);
 }
 
 TEST(IOTest, readShapeSet_shapeWithReplacesList)
@@ -466,44 +469,44 @@ TEST(IOTest, readShapeSet_explicitDimensions)
     auto &shapes = shapeSet.getShapes();
     ASSERT_EQ(4u, shapes.size());
 
-    Dimensions exp_global_dims {Dimensions::Two};
+    const Dimensions exp_global_dims {Dimensions::Two};
     EXPECT_EQ(shapeSet.getDimensions(), exp_global_dims);
 
     // no_explicit_dims -- should be same as global dims
     {
       auto &geometry = shapes[0].getGeometry();
-      TransformableGeometryProperties exp_start_props {Dimensions::Two, LengthUnit::cm};
-      TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
-      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
-      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
-      EXPECT_EQ(geometry.getEndProperties().dimensions, exp_global_dims);
+      const Dimensions exp_start_dims {Dimensions::Two};
+      const Dimensions exp_end_dims {Dimensions::Two};
+      EXPECT_EQ(exp_start_dims, geometry.getInputDimensions());
+      EXPECT_EQ(exp_end_dims, geometry.getOutputDimensions());
+      EXPECT_EQ(geometry.getOutputDimensions(), exp_global_dims);
     }
 
     // explicit_dims_same_as_global -- should be same as global dims
     {
       auto &geometry = shapes[1].getGeometry();
-      TransformableGeometryProperties exp_start_props {Dimensions::Two, LengthUnit::cm};
-      TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
-      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
-      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+      const Dimensions exp_start_dims {Dimensions::Two};
+      const Dimensions exp_end_dims {Dimensions::Two};
+      EXPECT_EQ(exp_start_dims, geometry.getInputDimensions());
+      EXPECT_EQ(exp_end_dims, geometry.getOutputDimensions());
     }
 
     // explicit_dims_different_from_global -- differs from global dims
     {
       auto &geometry = shapes[2].getGeometry();
-      TransformableGeometryProperties exp_start_props {Dimensions::Three, LengthUnit::cm};
-      TransformableGeometryProperties exp_end_props {Dimensions::Three, LengthUnit::cm};
-      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
-      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+      const Dimensions exp_start_dims {Dimensions::Three};
+      const Dimensions exp_end_dims {Dimensions::Three};
+      EXPECT_EQ(exp_start_dims, geometry.getInputDimensions());
+      EXPECT_EQ(exp_end_dims, geometry.getOutputDimensions());
     }
 
     // explicit_dims_with_start_dim -- changes dimension
     {
       auto &geometry = shapes[3].getGeometry();
-      TransformableGeometryProperties exp_start_props {Dimensions::Three, LengthUnit::cm};
-      TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
-      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
-      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+      const Dimensions exp_start_dims {Dimensions::Three};
+      const Dimensions exp_end_dims {Dimensions::Two};
+      EXPECT_EQ(exp_start_dims, geometry.getInputDimensions());
+      EXPECT_EQ(exp_end_dims, geometry.getOutputDimensions());
     }
   }
 
@@ -548,44 +551,44 @@ TEST(IOTest, readShapeSet_explicitDimensions)
     auto &shapes = shapeSet.getShapes();
     ASSERT_EQ(4u, shapes.size());
 
-    Dimensions exp_global_dims {Dimensions::Three};
+    const Dimensions exp_global_dims {Dimensions::Three};
     EXPECT_EQ(shapeSet.getDimensions(), exp_global_dims);
 
     // no_explicit_dims -- should be same as global dims
     {
       auto &geometry = shapes[0].getGeometry();
-      TransformableGeometryProperties exp_start_props {Dimensions::Three, LengthUnit::cm};
-      TransformableGeometryProperties exp_end_props {Dimensions::Three, LengthUnit::cm};
-      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
-      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
-      EXPECT_EQ(geometry.getEndProperties().dimensions, exp_global_dims);
+      const Dimensions exp_start_dims {Dimensions::Three};
+      const Dimensions exp_end_dims {Dimensions::Three};
+      EXPECT_EQ(exp_start_dims, geometry.getInputDimensions());
+      EXPECT_EQ(exp_end_dims, geometry.getOutputDimensions());
+      EXPECT_EQ(geometry.getOutputDimensions(), exp_global_dims);
     }
 
     // explicit_dims_same_as_global -- should be same as global dims
     {
       auto &geometry = shapes[1].getGeometry();
-      TransformableGeometryProperties exp_start_props {Dimensions::Three, LengthUnit::cm};
-      TransformableGeometryProperties exp_end_props {Dimensions::Three, LengthUnit::cm};
-      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
-      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+      const Dimensions exp_start_dims {Dimensions::Three};
+      const Dimensions exp_end_dims {Dimensions::Three};
+      EXPECT_EQ(exp_start_dims, geometry.getInputDimensions());
+      EXPECT_EQ(exp_end_dims, geometry.getOutputDimensions());
     }
 
     // explicit_dims_different_from_global -- differs from global dims
     {
       auto &geometry = shapes[2].getGeometry();
-      TransformableGeometryProperties exp_start_props {Dimensions::Two, LengthUnit::cm};
-      TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
-      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
-      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+      const Dimensions exp_start_dims {Dimensions::Two};
+      const Dimensions exp_end_dims {Dimensions::Two};
+      EXPECT_EQ(exp_start_dims, geometry.getInputDimensions());
+      EXPECT_EQ(exp_end_dims, geometry.getOutputDimensions());
     }
 
     // explicit_dims_with_start_dim -- changes dimension
     {
       auto &geometry = shapes[3].getGeometry();
-      TransformableGeometryProperties exp_start_props {Dimensions::Three, LengthUnit::cm};
-      TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
-      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
-      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+      const Dimensions exp_start_dims {Dimensions::Three};
+      const Dimensions exp_end_dims {Dimensions::Two};
+      EXPECT_EQ(exp_start_dims, geometry.getInputDimensions());
+      EXPECT_EQ(exp_end_dims, geometry.getOutputDimensions());
     }
   }
 }

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -421,6 +421,88 @@ TEST(IOTest, readShapeSet_differentDimensions)
   EXPECT_TRUE(slice);
 }
 
+TEST(IOTest, readShapeSet_explicitDimensions)
+{
+  auto shapeSet = readShapeSetFromString(R"(
+      dimensions: 2
+      shapes:
+        - name: no_explicit_dims
+          material: mat0
+          geometry:
+            format: test_format
+            path: path/to/file0.format
+            units: cm
+        - name: explicit_dims_same_as_global
+          material: mat1
+          geometry:
+            format: test_format
+            path: path/to/file1.format
+            units: cm
+            dimensions: 2
+        - name: explicit_dims_different_from_global
+          material: mat2
+          geometry:
+            format: test_format
+            path: path/to/file2.format
+            units: cm
+            dimensions: 3
+        - name: explicit_dims_with_start_dim
+          material: mat3
+          geometry:
+            format: test_format
+            path: path/to/file3.format
+            units: cm
+            start_dimensions: 3
+            dimensions: 2
+            operators:
+              - slice:
+                 x: 10
+    )");
+
+  auto &shapes = shapeSet.getShapes();
+  ASSERT_EQ(4u, shapes.size());
+
+  Dimensions exp_global_dims {Dimensions::Two};
+  EXPECT_EQ(shapeSet.getDimensions(), exp_global_dims);
+
+  // no_explicit_dims -- should be same as global dims
+  {
+    auto &geometry = shapes[0].getGeometry();
+    TransformableGeometryProperties exp_start_props {Dimensions::Two, LengthUnit::cm};
+    TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
+    EXPECT_EQ(exp_start_props, geometry.getStartProperties());
+    EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+    EXPECT_EQ(geometry.getEndProperties().dimensions, exp_global_dims);
+  }
+
+  // explicit_dims_same_as_global -- should be same as global dims
+  {
+    auto &geometry = shapes[1].getGeometry();
+    TransformableGeometryProperties exp_start_props {Dimensions::Two, LengthUnit::cm};
+    TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
+    EXPECT_EQ(exp_start_props, geometry.getStartProperties());
+    EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+  }
+
+  // explicit_dims_different_from_global -- differs from global dims
+  {
+    auto &geometry = shapes[2].getGeometry();
+    TransformableGeometryProperties exp_start_props {Dimensions::Three, LengthUnit::cm};
+    TransformableGeometryProperties exp_end_props {Dimensions::Three, LengthUnit::cm};
+    EXPECT_EQ(exp_start_props, geometry.getStartProperties());
+    EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+  }
+
+  // explicit_dims_with_start_dim -- changes dimension
+  {
+    auto &geometry = shapes[3].getGeometry();
+    TransformableGeometryProperties exp_start_props {Dimensions::Three, LengthUnit::cm};
+    TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
+    EXPECT_EQ(exp_start_props, geometry.getStartProperties());
+    EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+  }
+}
+
 TEST(IOTest, readShapeSet_wrongEndDimensions)
 {
   try

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -3,17 +3,18 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/klee/IO.hpp"
+#include "axom/slic.hpp"
 
-#include <fstream>
-#include <sstream>
+#include "axom/klee/io/IO.hpp"
+#include "axom/klee/GeometryOperators.hpp"
+#include "axom/klee/KleeError.hpp"
+
+#include "KleeMatchers.hpp"
 
 #include "gtest/gtest.h"
 
-#include "axom/klee/GeometryOperators.hpp"
-#include "axom/klee/KleeError.hpp"
-#include "axom/slic/core/SimpleLogger.hpp"
-#include "KleeMatchers.hpp"
+#include <fstream>
+#include <sstream>
 
 namespace axom
 {

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -376,11 +376,13 @@ TEST(IOTest, readShapeSet_geometryOperatorsWithUnits)
     )");
   auto &shapes = shapeSet.getShapes();
   ASSERT_EQ(1u, shapes.size());
-  auto &shape = shapes[0];
-  auto &geometryOperator = shape.getGeometry().getGeometryOperator();
+
+  auto &geometryOperator = shapes[0].getGeometry().getGeometryOperator();
   ASSERT_TRUE(geometryOperator);
+
   auto composite = std::dynamic_pointer_cast<const CompositeOperator>(geometryOperator);
   ASSERT_TRUE(composite);
+
   EXPECT_EQ(2u, composite->getOperators().size());
   auto translation = dynamic_cast<const Translation *>(composite->getOperators()[1].get());
   ASSERT_NE(translation, nullptr);
@@ -423,7 +425,9 @@ TEST(IOTest, readShapeSet_differentDimensions)
 
 TEST(IOTest, readShapeSet_explicitDimensions)
 {
-  auto shapeSet = readShapeSetFromString(R"(
+  // let's start w/ a global dimension of 2
+  {
+    auto shapeSet = readShapeSetFromString(R"(
       dimensions: 2
       shapes:
         - name: no_explicit_dims
@@ -459,47 +463,130 @@ TEST(IOTest, readShapeSet_explicitDimensions)
                  x: 10
     )");
 
-  auto &shapes = shapeSet.getShapes();
-  ASSERT_EQ(4u, shapes.size());
+    auto &shapes = shapeSet.getShapes();
+    ASSERT_EQ(4u, shapes.size());
 
-  Dimensions exp_global_dims {Dimensions::Two};
-  EXPECT_EQ(shapeSet.getDimensions(), exp_global_dims);
+    Dimensions exp_global_dims {Dimensions::Two};
+    EXPECT_EQ(shapeSet.getDimensions(), exp_global_dims);
 
-  // no_explicit_dims -- should be same as global dims
-  {
-    auto &geometry = shapes[0].getGeometry();
-    TransformableGeometryProperties exp_start_props {Dimensions::Two, LengthUnit::cm};
-    TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
-    EXPECT_EQ(exp_start_props, geometry.getStartProperties());
-    EXPECT_EQ(exp_end_props, geometry.getEndProperties());
-    EXPECT_EQ(geometry.getEndProperties().dimensions, exp_global_dims);
+    // no_explicit_dims -- should be same as global dims
+    {
+      auto &geometry = shapes[0].getGeometry();
+      TransformableGeometryProperties exp_start_props {Dimensions::Two, LengthUnit::cm};
+      TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
+      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
+      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+      EXPECT_EQ(geometry.getEndProperties().dimensions, exp_global_dims);
+    }
+
+    // explicit_dims_same_as_global -- should be same as global dims
+    {
+      auto &geometry = shapes[1].getGeometry();
+      TransformableGeometryProperties exp_start_props {Dimensions::Two, LengthUnit::cm};
+      TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
+      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
+      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+    }
+
+    // explicit_dims_different_from_global -- differs from global dims
+    {
+      auto &geometry = shapes[2].getGeometry();
+      TransformableGeometryProperties exp_start_props {Dimensions::Three, LengthUnit::cm};
+      TransformableGeometryProperties exp_end_props {Dimensions::Three, LengthUnit::cm};
+      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
+      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+    }
+
+    // explicit_dims_with_start_dim -- changes dimension
+    {
+      auto &geometry = shapes[3].getGeometry();
+      TransformableGeometryProperties exp_start_props {Dimensions::Three, LengthUnit::cm};
+      TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
+      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
+      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+    }
   }
 
-  // explicit_dims_same_as_global -- should be same as global dims
+  // next, we'll test a global dimension of 3
   {
-    auto &geometry = shapes[1].getGeometry();
-    TransformableGeometryProperties exp_start_props {Dimensions::Two, LengthUnit::cm};
-    TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
-    EXPECT_EQ(exp_start_props, geometry.getStartProperties());
-    EXPECT_EQ(exp_end_props, geometry.getEndProperties());
-  }
+    auto shapeSet = readShapeSetFromString(R"(
+      dimensions: 3
+      shapes:
+        - name: no_explicit_dims
+          material: mat0
+          geometry:
+            format: test_format
+            path: path/to/file0.format
+            units: cm
+        - name: explicit_dims_same_as_global
+          material: mat1
+          geometry:
+            format: test_format
+            path: path/to/file1.format
+            units: cm
+            dimensions: 3
+        - name: explicit_dims_different_from_global
+          material: mat2
+          geometry:
+            format: test_format
+            path: path/to/file2.format
+            units: cm
+            dimensions: 2
+        - name: explicit_dims_with_start_dim
+          material: mat3
+          geometry:
+            format: test_format
+            path: path/to/file3.format
+            units: cm
+            start_dimensions: 3
+            dimensions: 2
+            operators:
+              - slice:
+                 x: 10
+    )");
 
-  // explicit_dims_different_from_global -- differs from global dims
-  {
-    auto &geometry = shapes[2].getGeometry();
-    TransformableGeometryProperties exp_start_props {Dimensions::Three, LengthUnit::cm};
-    TransformableGeometryProperties exp_end_props {Dimensions::Three, LengthUnit::cm};
-    EXPECT_EQ(exp_start_props, geometry.getStartProperties());
-    EXPECT_EQ(exp_end_props, geometry.getEndProperties());
-  }
+    auto &shapes = shapeSet.getShapes();
+    ASSERT_EQ(4u, shapes.size());
 
-  // explicit_dims_with_start_dim -- changes dimension
-  {
-    auto &geometry = shapes[3].getGeometry();
-    TransformableGeometryProperties exp_start_props {Dimensions::Three, LengthUnit::cm};
-    TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
-    EXPECT_EQ(exp_start_props, geometry.getStartProperties());
-    EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+    Dimensions exp_global_dims {Dimensions::Three};
+    EXPECT_EQ(shapeSet.getDimensions(), exp_global_dims);
+
+    // no_explicit_dims -- should be same as global dims
+    {
+      auto &geometry = shapes[0].getGeometry();
+      TransformableGeometryProperties exp_start_props {Dimensions::Three, LengthUnit::cm};
+      TransformableGeometryProperties exp_end_props {Dimensions::Three, LengthUnit::cm};
+      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
+      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+      EXPECT_EQ(geometry.getEndProperties().dimensions, exp_global_dims);
+    }
+
+    // explicit_dims_same_as_global -- should be same as global dims
+    {
+      auto &geometry = shapes[1].getGeometry();
+      TransformableGeometryProperties exp_start_props {Dimensions::Three, LengthUnit::cm};
+      TransformableGeometryProperties exp_end_props {Dimensions::Three, LengthUnit::cm};
+      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
+      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+    }
+
+    // explicit_dims_different_from_global -- differs from global dims
+    {
+      auto &geometry = shapes[2].getGeometry();
+      TransformableGeometryProperties exp_start_props {Dimensions::Two, LengthUnit::cm};
+      TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
+      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
+      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+    }
+
+    // explicit_dims_with_start_dim -- changes dimension
+    {
+      auto &geometry = shapes[3].getGeometry();
+      TransformableGeometryProperties exp_start_props {Dimensions::Three, LengthUnit::cm};
+      TransformableGeometryProperties exp_end_props {Dimensions::Two, LengthUnit::cm};
+      EXPECT_EQ(exp_start_props, geometry.getStartProperties());
+      EXPECT_EQ(exp_end_props, geometry.getEndProperties());
+    }
   }
 }
 

--- a/src/axom/klee/tests/klee_io_util.cpp
+++ b/src/axom/klee/tests/klee_io_util.cpp
@@ -22,7 +22,6 @@ namespace klee
 {
 namespace internal
 {
-using inlet::Container;
 using primal::Point3D;
 using primal::Vector3D;
 
@@ -70,7 +69,7 @@ std::vector<double> parseDoubleVector(const std::string &vectorInput, Dimensions
 {
   std::string fullInput = "values: ";
   fullInput += vectorInput;
-  InletTestData data {fullInput, [](Container &c) { c.addDoubleArray("values"); }};
+  InletTestData data {fullInput, [](inlet::Container &c) { c.addDoubleArray("values"); }};
   return toDoubleVector(data.doc["values"], dims, "values");
 }
 
@@ -86,8 +85,9 @@ Dimensions defineAndParseDimension(const char *input)
 {
   std::string fullInput = "dims: ";
   fullInput += input;
-  InletTestData data {fullInput,
-                      [](Container &c) { defineDimensionsField(c, "dims", "some description"); }};
+  InletTestData data {fullInput, [](inlet::Container &c) {
+                        defineDimensionsField(c, "dims", "some description");
+                      }};
   return toDimensions(data.doc["dims"]);
 }
 
@@ -104,7 +104,7 @@ TEST(io_util, defineAndConvertDimensions)
  *
  * @param container the Container on which to define the units fields
  */
-void defineUnitsSchemaWithDefaults(Container &container) { defineUnitsSchema(container); }
+void defineUnitsSchemaWithDefaults(inlet::Container &container) { defineUnitsSchema(container); }
 
 TEST(io_util, getOptionalStartAndEndUnits_nothingSpecified)
 {
@@ -174,7 +174,7 @@ T parseArray(const char *value, Dimensions dims, Op op)
 {
   std::string input = "value: ";
   input += value;
-  InletTestData data {input, [](Container &c) { c.addDoubleArray("value"); }};
+  InletTestData data {input, [](inlet::Container &c) { c.addDoubleArray("value"); }};
   return op(data.doc.getGlobalContainer(), "value", dims);
 }
 
@@ -192,7 +192,7 @@ T parseArray(const char *value, Dimensions dims, const T &defaultValue, Op op)
     // avoid warning about empty input
     input = "foo: bar";
   }
-  InletTestData data {input, [](Container &c) { c.addDoubleArray("value"); }};
+  InletTestData data {input, [](inlet::Container &c) { c.addDoubleArray("value"); }};
   return op(data.doc.getGlobalContainer(), "value", dims, defaultValue);
 }
 

--- a/src/axom/klee/tests/klee_io_util.cpp
+++ b/src/axom/klee/tests/klee_io_util.cpp
@@ -3,16 +3,16 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/klee/IOUtil.hpp"
+#include "axom/slic.hpp"
+#include "axom/inlet.hpp"
+
+#include "axom/klee/io/IOUtil.hpp"
+#include "axom/klee/KleeError.hpp"
+
+#include "KleeMatchers.hpp"
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
-
-#include "axom/inlet.hpp"
-#include "axom/klee/KleeError.hpp"
-#include "axom/slic/core/SimpleLogger.hpp"
-
-#include "KleeMatchers.hpp"
 
 #include <memory>
 

--- a/src/axom/klee/tests/klee_shape_set.cpp
+++ b/src/axom/klee/tests/klee_shape_set.cpp
@@ -5,9 +5,9 @@
 
 #include "axom/klee/ShapeSet.hpp"
 
-#include <stdexcept>
-
 #include "gtest/gtest.h"
+
+#include <stdexcept>
 
 namespace axom
 {

--- a/src/axom/klee/tests/klee_units.cpp
+++ b/src/axom/klee/tests/klee_units.cpp
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "axom/klee/Units.hpp"
-
 #include "axom/klee/KleeError.hpp"
 
 #include "gtest/gtest.h"

--- a/src/axom/primal/tests/primal_boundingbox.cpp
+++ b/src/axom/primal/tests/primal_boundingbox.cpp
@@ -63,7 +63,7 @@ TEST(primal_boundingBox, bb_default_constructor)
 }
 
 //------------------------------------------------------------------------------
-TEST(primal_boundingBox, bb_ctor_from_zerPt)
+TEST(primal_boundingBox, bb_ctor_from_no_points)
 {
   constexpr int DIM = 3;
   using CoordType = double;

--- a/src/axom/quest/SamplingShaper.hpp
+++ b/src/axom/quest/SamplingShaper.hpp
@@ -283,6 +283,9 @@ public:
         }
       }
       break;
+    case klee::Dimensions::Unspecified:
+      SLIC_ERROR("Unsupported PrimitiveSampler3D requires a 2D or 3D shape");
+      break;
     }
   }
 

--- a/src/axom/quest/examples/quest_shape_in_memory.cpp
+++ b/src/axom/quest/examples/quest_shape_in_memory.cpp
@@ -855,8 +855,7 @@ axom::klee::Shape createShape_Plane()
                                                   prop);
   }
 
-  // Create a plane crossing center of mesh.  No matter the normal,
-  // it cuts the mesh in half.
+  // Create a plane crossing center of mesh.  No matter the normal, it cuts the mesh in half.
   Point3D center {0.5 *
                   (axom::NumericArray<double, 3>(params.boxMins.data()) +
                    axom::NumericArray<double, 3>(params.boxMaxs.data()))};
@@ -933,13 +932,13 @@ double areaOfTriMesh(const axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE
 
 #if defined(AXOM_USE_MFEM)
 /*!
-  @brief Return the element volumes as a sidre::View.
-
-  If it doesn't exist, allocate and compute it.
-  \post The volume data is in \c dc->GetNamedBuffer(volFieldName).
-
-  Most of this is lifted from IntersectionShaper::runShapeQueryImpl.
-*/
+ *  @brief Return the element volumes as a sidre::View.
+ *
+ *  If it doesn't exist, allocate and compute it.
+ *  \post The volume data is in \c dc->GetNamedBuffer(volFieldName).
+ *
+ *  Most of this is lifted from IntersectionShaper::runShapeQueryImpl.
+ */
 template <typename ExecSpace>
 axom::sidre::View* getElementVolumes(
   sidre::MFEMSidreDataCollection* dc,
@@ -1076,14 +1075,13 @@ axom::sidre::View* getElementVolumes(
 #endif
 
 /*!
-  @brief Return the element volumes as a sidre::View containing
-  the volumes in an array.
-
-  If it doesn't exist, allocate and compute it.
-  \post The volume data is in the blueprint field \c volFieldName.
-
-  Most of this is lifted from IntersectionShaper::runShapeQueryImpl.
-*/
+ *  @brief Return the element volumes as a sidre::View containing the volumes in an array
+ *
+ *  If it doesn't exist, allocate and compute it.
+ *  \post The volume data is in the blueprint field \c volFieldName.
+ *
+ *  Most of this is lifted from IntersectionShaper::runShapeQueryImpl.
+ */
 template <typename ExecSpace>
 axom::sidre::View* getElementVolumes(
   sidre::Group* meshGrp,

--- a/src/axom/quest/examples/shaping_driver.cpp
+++ b/src/axom/quest/examples/shaping_driver.cpp
@@ -497,7 +497,7 @@ int main(int argc, char** argv)
     exit(1);
   }
 
-  const klee::Dimensions shapeDim = params.shapeSet.getDimensions();
+  //const klee::Dimensions defaultShapeDim = params.shapeSet.getDimensions();
 
   AXOM_ANNOTATE_BEGIN("load mesh");
   //---------------------------------------------------------------------------
@@ -565,14 +565,22 @@ int main(int argc, char** argv)
     samplingShaper->setQuadratureOrder(params.quadratureOrder);
     samplingShaper->setVolumeFractionOrder(params.outputOrder);
 
-    // register a point projector
-    if(shapingDC.GetMesh()->Dimension() == 3 && shapeDim == klee::Dimensions::Two)
+    // register point projectors
+    if(shapingDC.GetMesh()->Dimension() == 3)
     {
       samplingShaper->setPointProjector32([](primal::Point<double, 3> pt) {
         const double& x = pt[0];
         const double& y = pt[1];
         const double& z = pt[2];
         return primal::Point<double, 2> {z, sqrt(x * x + y * y)};
+      });
+    }
+    else if(shapingDC.GetMesh()->Dimension() == 2)
+    {
+      samplingShaper->setPointProjector23([](primal::Point<double, 2> pt) {
+        const double& x = pt[0];
+        const double& y = pt[1];
+        return primal::Point<double, 3> {x, y, 0.};
       });
     }
   }
@@ -641,6 +649,8 @@ int main(int argc, char** argv)
                                           shape.getName(),
                                           shape.getMaterial(),
                                           shapeFormat)));
+
+    const klee::Dimensions shapeDim = shape.getGeometry().getInputDimensions();
 
     // Apply error checking
 #ifndef AXOM_USE_C2C

--- a/src/axom/quest/tests/quest_intersection_shaper_utils.hpp
+++ b/src/axom/quest/tests/quest_intersection_shaper_utils.hpp
@@ -167,8 +167,7 @@ void loadVisIt(mfem::VisItDataCollection &vdc, sidre::MFEMSidreDataCollection &d
   }
 }
 
-// Turn a MFEMSidreDataCollection's fields into a simple Conduit node so
-// I/O is not so problematic.
+// Turn a MFEMSidreDataCollection's fields into a simple Conduit node so I/O is not so problematic.
 void dcToConduit(sidre::MFEMSidreDataCollection &dc, conduit::Node &n)
 {
   for(auto it : dc.GetFieldMap())
@@ -231,8 +230,7 @@ bool loadBaseline(const std::string &filename, conduit::Node &n)
   bool loaded = false;
   std::string file_with_ext(filename + ".yaml");
   SLIC_INFO(axom::fmt::format("Load baseline {}", file_with_ext));
-  // Check before we read because Sidre installs a conduit error handler
-  // that terminates.
+  // Check before we read because Sidre installs a conduit error handler that terminates.
   if(axom::utilities::filesystem::pathExists(file_with_ext))
   {
     conduit::relay::io::load(file_with_ext, "yaml", n);
@@ -248,8 +246,7 @@ void replacementRuleTest(const std::string &shapeFile,
                          bool initialMats = false)
 {
   // Make potential baseline filenames for this test. Make a policy-specific
-  // baseline that we can check first. If it is not present, the next baseline
-  // is tried.
+  // baseline that we can check first. If it is not present, the next baseline is tried.
   std::string baselineName(yamlRoot(shapeFile));
   if(initialMats)
   {
@@ -276,8 +273,7 @@ void replacementRuleTest(const std::string &shapeFile,
 #ifdef AXOM_USE_MPI
   // This has to happen here because the shaper gets its communicator from it.
   // If we do it before the mfem mesh is added to the data collection then the
-  // data collection communicator gets set to MPI_COMM_NULL, which is bad for
-  // the C2C reader.
+  // data collection communicator gets set to MPI_COMM_NULL, which is bad for the C2C reader.
   dc.SetComm(MPI_COMM_WORLD);
 #endif
   quest::IntersectionShaper shaper(policy, axom::INVALID_ALLOCATOR_ID, shapeSet, &dc);
@@ -408,8 +404,7 @@ void IntersectionWithErrorTolerances(const std::string &filebase,
 #ifdef AXOM_USE_MPI
   // This has to happen here because the shaper gets its communicator from it.
   // If we do it before the mfem mesh is added to the data collection then the
-  // data collection communicator gets set to MPI_COMM_NULL, which is bad for
-  // the C2C reader.
+  // data collection communicator gets set to MPI_COMM_NULL, which is bad for the C2C reader.
   dc.SetComm(MPI_COMM_WORLD);
 #endif
   quest::IntersectionShaper shaper(policy, axom::INVALID_ALLOCATOR_ID, shapeSet, &dc);
@@ -432,8 +427,7 @@ void IntersectionWithErrorTolerances(const std::string &filebase,
     slic::flushStreams();
 
     // NOTE: We do not actually run the query. We're mainly interested
-    //       in how the shape was refined and whether we hit the percent
-    //       error.
+    //       in how the shape was refined and whether we hit the percent error.
 
     // Now check the analytical revolved volume vs the value we expect. This makes
     // sure the quadrature-computed value is "close enough".
@@ -462,23 +456,17 @@ class ShapingTestApplication
 {
 public:
   static constexpr int AnyCase = 0;
-  /*!
-   * \brief Constructor.
-   */
+  /// \brief Constructor
   ShapingTestApplication()
     : m_app()
     , m_annotationMode("none")
     , m_policy()
     , m_caseNumber(AnyCase) { }
 
-  /*!
-   * \brief Destructor
-   */
+  /// \brief Destructor
   ~ShapingTestApplication() { }
 
-  /*!
-   * \brief Parse the command line and run the tests.
-   */
+  /// \brief Parse the command line and run the tests
   int execute(int argc, char *argv[])
   {
     int result = 0;

--- a/src/axom/quest/tests/quest_sampling_shaper.cpp
+++ b/src/axom/quest/tests/quest_sampling_shaper.cpp
@@ -233,12 +233,13 @@ public:
     EXPECT_NE(nullptr, m_shaper) << "Shaper needs to be initialized via initializeShaping()";
 
     // Define lambda to override default dimensions, when necessary
-    auto getShapeDim = [defaultDim = m_shapeSet->getDimensions()](const auto& shape) {
+    auto getShapeDim = [](const auto& shape) {
       static std::map<std::string, klee::Dimensions> format_dim = {{"c2c", klee::Dimensions::Two},
                                                                    {"stl", klee::Dimensions::Three}};
 
+      const auto& shape_dim = shape.getGeometry().getInputDimensions();
       const auto& format_str = shape.getGeometry().getFormat();
-      return format_dim.find(format_str) != format_dim.end() ? format_dim[format_str] : defaultDim;
+      return format_dim.find(format_str) != format_dim.end() ? format_dim[format_str] : shape_dim;
     };
 
     for(const auto& shape : m_shapeSet->getShapes())


### PR DESCRIPTION
# Summary

- This feature PR adds an optional per-shape `dimensions` specification to the geometry of a shape in a Klee file
  - This can be used to override the global dimension
  - Among other use-cases, I'm planing to use it to enhance the flexibility of our STL mesh loader, to allow user bring in STL meshes modeling planar geometry (see #1393) in addition to current 3D boundary representations
- While working through this PR, I reorganized the Klee source directory -- moving files related to IO into the `klee/io` directory -- and cleaned up some doxygen comments in the Klee source files
- Minor: I also fixed one of the badges in the README file to point to our github actions instead of Azure CI

#### API changes
* Klee's `Dimensions` enum now has an `Unspecified` value
* I added helper functions `getInputDimensions()` and `getOuputDimensions()` to Klee's `Geometry` class to get the dimension of the shape before and after applying operators, respectively.