### PR TITLE
Consolidates constructor logic for Bezier and NURBS classes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -72,6 +72,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   of about 20% during InOutOctree construction and queries over STL surface meshes relative to the previous sparsehash
   implementation. Please reach out to Axom developers if this affects you while we work on fixes for these.
 - Klee: Moves source files related to IO into a new `io` subdirectory in the Klee component
+- Primal: Consolidates construction logic for `BezierCurve`, `BezierPatch`, `KnotVector`,
+  `NURBSCurve` and `NURBSPatch` classes and add overloads from `axom::ArrayView`
 
 ###  Fixed
 - Core: prevent incorrect instantiations of `axom::Array` from a host-only compile, when Axom is compiled

--- a/src/axom/bump/TopologyMapper.hpp
+++ b/src/axom/bump/TopologyMapper.hpp
@@ -58,7 +58,7 @@ AXOM_HOST_DEVICE double shapeOverlap(const axom::primal::Polygon<T, 2, ARRAY_TYP
  * \param shape2 The clip shape.
  * \return The volume of the overlap between the shapes.
  */
-// @{
+///@{
 
 // Tetrahedron first
 template <typename T>
@@ -236,7 +236,7 @@ AXOM_HOST_DEVICE double shapeOverlap(const axom::bump::PolyhedralFaces<T> &shape
   return clipped.volume();
 }
 
-// @}
+///@}
 
 // VariableShape helpers
 

--- a/src/axom/bump/views/BasicIndexing.hpp
+++ b/src/axom/bump/views/BasicIndexing.hpp
@@ -24,12 +24,12 @@ class BasicIndexing
 {
 public:
   /// Constructors
-  // @{
+  ///@{
   AXOM_HOST_DEVICE
   BasicIndexing() : m_size(0) { }
   AXOM_HOST_DEVICE
   BasicIndexing(axom::IndexType size) : m_size(size) { }
-  // @}
+  ///@}
 
   /*!
    * \brief Return the size

--- a/src/axom/bump/views/dispatch_unstructured_topology.hpp
+++ b/src/axom/bump/views/dispatch_unstructured_topology.hpp
@@ -118,7 +118,7 @@ struct make_unstructured_polyhedral_topology
  * \param topo The node that contains the topology.
  * \param func The function/lambda to call with the topology view.
  */
-// @{
+///@{
 template <typename FuncType>
 void dispatch_unstructured_polyhedral_topology(const conduit::Node &topo, FuncType &&func)
 {
@@ -161,7 +161,7 @@ void typed_dispatch_unstructured_polyhedral_topology(const conduit::Node &topo, 
     func(shape, ugView);
   }
 }
-// @}
+///@}
 
 /*!
  * \brief This function dispatches a Conduit mixed unstructured topology.
@@ -175,7 +175,7 @@ void typed_dispatch_unstructured_polyhedral_topology(const conduit::Node &topo, 
  *       the shape_map within the topology so we can build our own shape map
  *       later in the for_all_zones method.
  */
-// @{
+///@{
 template <typename FuncType>
 void dispatch_unstructured_mixed_topology(const conduit::Node &topo, FuncType &&func)
 {
@@ -238,7 +238,7 @@ void typed_dispatch_unstructured_mixed_topology(const conduit::Node &topo, FuncT
     func(shape, ugView);
   }
 }
-// @}
+///@}
 
 #if __cplusplus >= 201703L
 // C++17 and later.

--- a/src/axom/klee/io/GeometryOperatorsIO.cpp
+++ b/src/axom/klee/io/GeometryOperatorsIO.cpp
@@ -188,6 +188,7 @@ OpPtr parseRotate(const inlet::Container &opContainer,
       startProperties);
   }
   break;
+  default:
   case Dimensions::Unspecified:
     throw KleeError({opContainer.name(), "Rotations can only be applied to 2D or 3D shapes"});
   }

--- a/src/axom/primal/geometry/BezierCurve.hpp
+++ b/src/axom/primal/geometry/BezierCurve.hpp
@@ -133,7 +133,7 @@ public:
     }
   }
 
-  /// Constructs a BezierCurve from arrays of control points and weights.
+  /// Constructor for a Bezier Curve from ArrayViews of (non-const) control points and weights
   BezierCurve(axom::ArrayView<PointType> pts, axom::ArrayView<T> weights, int ord)
     : BezierCurve(axom::ArrayView<const PointType>(pts.data(), pts.size()),
                   axom::ArrayView<const T>(weights.data(), weights.size()),

--- a/src/axom/primal/geometry/BezierCurve.hpp
+++ b/src/axom/primal/geometry/BezierCurve.hpp
@@ -35,7 +35,7 @@ namespace primal
 template <typename T, int NDIMS>
 class BezierCurve;
 
-/*! \brief Overloaded output operator for Bezier Curves*/
+/// \brief Overloaded output operator for Bezier Curves
 template <typename T, int NDIMS>
 std::ostream& operator<<(std::ostream& os, const BezierCurve<T, NDIMS>& bCurve);
 
@@ -47,8 +47,7 @@ std::ostream& operator<<(std::ostream& os, const BezierCurve<T, NDIMS>& bCurve);
  * \tparam NDIMS the number of dimensions
  *
  * The order of a Bezier curve with N+1 control points is N.
- * The curve is approximated by the control points,
- * parametrized from t=0 to t=1.
+ * The curve is approximated by the control points, parametrized from t=0 to t=1.
  * 
  * Contains an array of positive weights to represent a rational Bezier curve.
  * Nonrational Bezier curves are identified by an empty weights array.
@@ -76,58 +75,65 @@ public:
 
 public:
   //@{
-  //!  @name Constructors for polynomial and rational Bezier curves
+  /**  
+   * \name Constructors for polynomial and rational Bezier curves
+   *
+   * The constructors allow for flexible initialization of BezierCurve objects from:
+   * - 1D arrays of control points and weights,
+   * - C-style arrays of control points and weights,
+   * - Specified polynomial orders,
+   * - Rational or polynomial (nonrational) curves, depending on the presence of weights.
+   *
+   * The curve is parametrized from t=0 to t=1. 
+   * 
+   * Rational curves are identified by a non-empty weights array, 
+   * and nonrational curves by an empty weights array.
+   * All weights must be greater than 0 in a rational curve.
+   */
 
   /*!
-   * \brief Constructor for a Bezier Curve from ArrayViews of coordinates and weights
+   * \brief Constructor for a Bezier Curve from ArrayViews of control points and weights
    *
-   * \param [in] pts ArrayView with zero or \a ord+1 control points
+   * \param [in] controlPoints ArrayView with zero or \a ord+1 control points
    * \param [in] weights ArrayView with zero or \a ord+1 positive weights
    * \param [in] ord The Curve's polynomial order
+   * 
+   * If \a controlPoints is empty, we still allocate space for \a ord+1 control points
    * \pre order \a ord is greater than or equal to -1
-   * \pre pts is either empty or has size \a ord+1
+   * \pre controlPoints is either empty or has size \a ord+1
    * \pre weights is either empty or has size \a ord+1
-   * \pre pts cannot be empty if weights are supplied
+   * \pre controlPoints cannot be empty if weights are supplied
    */
-  BezierCurve(axom::ArrayView<const PointType> pts, axom::ArrayView<const T> weights, int ord)
+  BezierCurve(axom::ArrayView<const PointType> controlPoints, axom::ArrayView<const T> weights, int ord)
   {
     SLIC_ASSERT(ord >= -1);
-    const int SZ = ord + 1;
-    SLIC_ASSERT(pts.empty() || pts.size() == SZ);
-    SLIC_ASSERT(pts.empty() || pts.data() != nullptr);
+    const int SZ = utilities::max(0, ord + 1);
 
-    SLIC_ASSERT(weights.empty() || weights.size() == SZ);
-    SLIC_ASSERT(weights.empty() || weights.data() != nullptr);
-
-    SLIC_ASSERT(pts.size() >= weights.size());
+    SLIC_ASSERT(controlPoints.size() >= weights.size());
 
     // note: always allocates space for the control points
-    if(pts.empty())
+    if(controlPoints.empty())
     {
       m_controlPoints.resize(SZ);
     }
     else
     {
-      m_controlPoints = pts;
+      SLIC_ASSERT(controlPoints.size() == SZ);
+      SLIC_ASSERT(controlPoints.data() != nullptr);
+      m_controlPoints = controlPoints;
     }
 
     // note: only allocates when weights are supplied
-    if(weights.empty())
+    if(!weights.empty())
     {
-      m_weights.resize(0);
-      SLIC_ASSERT(!isRational());
-    }
-    else
-    {
+      SLIC_ASSERT(weights.size() == SZ);
+      SLIC_ASSERT(weights.data() != nullptr);
       m_weights = weights;
       SLIC_ASSERT(isRational());
     }
   }
 
-  /**
-   * \brief Constructs a BezierCurve from arrays of control points and weights.
-   * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
-   */
+  /// Constructs a BezierCurve from arrays of control points and weights.
   BezierCurve(axom::ArrayView<PointType> pts, axom::ArrayView<T> weights, int ord)
     : BezierCurve(axom::ArrayView<const PointType>(pts.data(), pts.size()),
                   axom::ArrayView<const T>(weights.data(), weights.size()),
@@ -139,7 +145,6 @@ public:
    *
    * \param [in] order the order of the resulting Bezier curve
    * \pre order is greater than or equal to -1.
-   * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
    */
   explicit BezierCurve(int ord = -1)
     : BezierCurve(axom::ArrayView<PointType>(nullptr, 0), axom::ArrayView<T>(nullptr, 0), ord)
@@ -151,7 +156,6 @@ public:
    * \param [in] pts a vector with ord+1 control points
    * \param [in] ord The Curve's polynomial order
    * \pre order is greater than or equal to zero
-   * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
    */
   BezierCurve(const PointType* pts, int ord)
     : BezierCurve(axom::ArrayView<const PointType>(pts, ord + 1),
@@ -166,7 +170,6 @@ public:
    * \param [in] weights a vector with ord+1 positive weights
    * \param [in] ord The Curve's polynomial order
    * \pre order is greater than or equal to zero
-   * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
    */
   BezierCurve(const PointType* pts, const T* weights, int ord)
     : BezierCurve(axom::ArrayView<const PointType>(pts, ord + 1),
@@ -180,7 +183,6 @@ public:
    * \param [in] pts an array with ord+1 control points
    * \param [in] ord The Curve's polynomial order
    * \pre order is greater than or equal to zero
-   * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
    */
   BezierCurve(const axom::Array<PointType>& pts, int ord)
     : BezierCurve(pts.view(), axom::ArrayView<const T>(nullptr, 0), ord)
@@ -193,7 +195,6 @@ public:
    * \param [in] weights an array with ord+1 positive weights
    * \param [in] ord The Curve's polynomial order
    * \pre order is greater than or equal to zero
-   * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
    */
   BezierCurve(const axom::Array<PointType>& pts, const axom::Array<T>& weights, int ord)
     : BezierCurve(pts.view(), weights.view(), ord)
@@ -205,10 +206,12 @@ public:
   /// Sets the order of the Bezier Curve
   void setOrder(int ord)
   {
-    m_controlPoints.resize(ord + 1);
+    SLIC_ASSERT((ord >= -1));
+    const int SZ = utilities::max(0, ord + 1);
+    m_controlPoints.resize(SZ);
     if(isRational())
     {
-      m_weights.resize(ord + 1);
+      m_weights.resize(SZ);
     }
   }
 
@@ -444,8 +447,7 @@ public:
     //  which requires all first derivatives
     else
     {
-      // Store BezierPatch of projective weights, (wx, wy, wz)
-      //  and BezierPatch of weights (w)
+      // Store BezierCurves of projective weights (wx, wy, wz) and of weights (w)
       BezierCurve<T, NDIMS> projective(ord);
       BezierCurve<T, 1> weights(ord);
 
@@ -529,8 +531,7 @@ public:
     //  which requires all first derivatives
     else
     {
-      // Store BezierPatch of projective weights, (wx, wy, wz)
-      //  and BezierPatch of weights (w)
+      // Store BezierCurves of projective weights (wx, wy, wz) and of weights (w)
       BezierCurve<T, NDIMS> projective(ord);
       BezierCurve<T, 1> weights(ord);
 
@@ -623,8 +624,7 @@ public:
     //  which requires all first derivatives
     else
     {
-      // Store BezierPatch of projective weights, (wx, wy, wz)
-      //  and BezierPatch of weights (w)
+      // Store BezierCurves of projective weights (wx, wy, wz) and of weights (w)
       BezierCurve<T, NDIMS> projective(ord);
       BezierCurve<T, 1> weights(ord);
 
@@ -709,8 +709,7 @@ public:
     //  which requires all first derivatives
     else
     {
-      // Store BezierPatch of projective weights, (wx, wy, wz)
-      //  and BezierPatch of weights (w)
+      // Store BezierCurves of projective weights (wx, wy, wz) and of weights (w)
       BezierCurve<T, NDIMS> projective(ord);
       BezierCurve<T, 1> weights(ord);
 

--- a/src/axom/primal/geometry/BezierCurve.hpp
+++ b/src/axom/primal/geometry/BezierCurve.hpp
@@ -153,8 +153,10 @@ public:
    * \pre order is greater than or equal to zero
    * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
    */
-  BezierCurve(PointType* pts, int ord)
-    : BezierCurve(axom::ArrayView<PointType>(pts, ord + 1), axom::ArrayView<T>(nullptr, 0), ord)
+  BezierCurve(const PointType* pts, int ord)
+    : BezierCurve(axom::ArrayView<const PointType>(pts, ord + 1),
+                  axom::ArrayView<const T>(nullptr, 0),
+                  ord)
   { }
 
   /*!
@@ -166,9 +168,9 @@ public:
    * \pre order is greater than or equal to zero
    * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
    */
-  BezierCurve(PointType* pts, T* weights, int ord)
-    : BezierCurve(axom::ArrayView<PointType>(pts, ord + 1),
-                  axom::ArrayView<T>(weights, weights ? ord + 1 : 0),
+  BezierCurve(const PointType* pts, const T* weights, int ord)
+    : BezierCurve(axom::ArrayView<const PointType>(pts, ord + 1),
+                  axom::ArrayView<const T>(weights, weights ? ord + 1 : 0),
                   ord)
   { }
 
@@ -181,7 +183,7 @@ public:
    * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
    */
   BezierCurve(const axom::Array<PointType>& pts, int ord)
-    : BezierCurve(pts.view(), axom::ArrayView<T>(nullptr, 0), ord)
+    : BezierCurve(pts.view(), axom::ArrayView<const T>(nullptr, 0), ord)
   { }
 
   /*!

--- a/src/axom/primal/geometry/BezierCurve.hpp
+++ b/src/axom/primal/geometry/BezierCurve.hpp
@@ -74,7 +74,7 @@ public:
                          "A Bezier Curve must be defined using an arithmetic type");
 
 public:
-  //@{
+  ///@{
   /**  
    * \name Constructors for polynomial and rational Bezier curves
    *
@@ -200,7 +200,7 @@ public:
     : BezierCurve(pts.view(), weights.view(), ord)
   { }
 
-  //@}
+  ///@}
 
 public:
   /// Sets the order of the Bezier Curve

--- a/src/axom/primal/geometry/BezierCurve.hpp
+++ b/src/axom/primal/geometry/BezierCurve.hpp
@@ -75,126 +75,131 @@ public:
                          "A Bezier Curve must be defined using an arithmetic type");
 
 public:
+  //@{
+  //!  @name Constructors for polynomial and rational Bezier curves
+
   /*!
-   * \brief Constructor for a Bezier Curve that reserves space for
-   *  the given order of the curve
+   * \brief Constructor for a Bezier Curve from ArrayViews of coordinates and weights
    *
-   * \param [in] order the order of the resulting Bezier curve
-   * \pre order is greater than or equal to -1.
+   * \param [in] pts ArrayView with zero or \a ord+1 control points
+   * \param [in] weights ArrayView with zero or \a ord+1 positive weights
+   * \param [in] ord The Curve's polynomial order
+   * \pre order \a ord is greater than or equal to -1
+   * \pre pts is either empty or has size \a ord+1
+   * \pre weights is either empty or has size \a ord+1
+   * \pre pts cannot be empty if weights are supplied
    */
-  explicit BezierCurve(int ord = -1)
+  BezierCurve(axom::ArrayView<const PointType> pts, axom::ArrayView<const T> weights, int ord)
   {
     SLIC_ASSERT(ord >= -1);
-    const int sz = utilities::max(-1, ord + 1);
-    m_controlPoints.resize(sz);
+    const int SZ = ord + 1;
+    SLIC_ASSERT(pts.empty() || pts.size() == SZ);
+    SLIC_ASSERT(pts.empty() || pts.data() != nullptr);
 
-    makeNonrational();
-  }
+    SLIC_ASSERT(weights.empty() || weights.size() == SZ);
+    SLIC_ASSERT(weights.empty() || weights.data() != nullptr);
 
-  /*!
-   * \brief Constructor for a Bezier Curve from an array of coordinates
-   *
-   * \param [in] pts a vector with ord+1 control points
-   * \param [in] ord The Curve's polynomial order
-   * \pre order is greater than or equal to zero
-   *
-   */
-  BezierCurve(PointType* pts, int ord)
-  {
-    SLIC_ASSERT(pts != nullptr);
-    SLIC_ASSERT(ord >= 0);
+    SLIC_ASSERT(pts.size() >= weights.size());
 
-    const int sz = utilities::max(0, ord + 1);
-    m_controlPoints.resize(sz);
-
-    for(int p = 0; p <= ord; ++p)
+    // note: always allocates space for the control points
+    if(pts.empty())
     {
-      m_controlPoints[p] = pts[p];
-    }
-
-    makeNonrational();
-  }
-
-  /*!
-   * \brief Constructor for a Bezier Curve from an array of coordinates
-   *
-   * \param [in] pts a vector with ord+1 control points
-   * \param [in] weights a vector with ord+1 positive weights
-   * \param [in] ord The Curve's polynomial order
-   * \pre order is greater than or equal to zero
-   *
-   */
-  BezierCurve(PointType* pts, T* weights, int ord)
-  {
-    SLIC_ASSERT(pts != nullptr);
-    SLIC_ASSERT(ord >= 0);
-
-    const int sz = utilities::max(0, ord + 1);
-    m_controlPoints.resize(sz);
-    for(int p = 0; p <= ord; ++p)
-    {
-      m_controlPoints[p] = pts[p];
-    }
-
-    if(weights == nullptr)
-    {
-      makeNonrational();
+      m_controlPoints.resize(SZ);
     }
     else
     {
-      m_weights.resize(sz);
-      for(int p = 0; p <= ord; ++p)
-      {
-        m_weights[p] = weights[p];
-      }
-      SLIC_ASSERT(isValidRational());
+      m_controlPoints = pts;
+    }
+
+    // note: only allocates when weights are supplied
+    if(weights.empty())
+    {
+      m_weights.resize(0);
+      SLIC_ASSERT(!isRational());
+    }
+    else
+    {
+      m_weights = weights;
+      SLIC_ASSERT(isRational());
     }
   }
 
+  /**
+   * \brief Constructs a BezierCurve from arrays of control points and weights.
+   * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
+   */
+  BezierCurve(axom::ArrayView<PointType> pts, axom::ArrayView<T> weights, int ord)
+    : BezierCurve(axom::ArrayView<const PointType>(pts.data(), pts.size()),
+                  axom::ArrayView<const T>(weights.data(), weights.size()),
+                  ord)
+  { }
+
   /*!
-   * \brief Constructor for a Bezier Curve from an vector of coordinates
+   * \brief Constructor for a polynomial Bezier Curve that reserves space for the control points
+   *
+   * \param [in] order the order of the resulting Bezier curve
+   * \pre order is greater than or equal to -1.
+   * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
+   */
+  explicit BezierCurve(int ord = -1)
+    : BezierCurve(axom::ArrayView<PointType>(nullptr, 0), axom::ArrayView<T>(nullptr, 0), ord)
+  { }
+
+  /*!
+   * \brief Constructor for a polynomial Bezier Curve from an array of coordinates
    *
    * \param [in] pts a vector with ord+1 control points
    * \param [in] ord The Curve's polynomial order
    * \pre order is greater than or equal to zero
-   *
+   * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
    */
-  BezierCurve(const axom::Array<PointType>& pts, int ord)
-  {
-    SLIC_ASSERT(ord >= 0);
-
-    const int sz = utilities::max(0, ord + 1);
-    m_controlPoints.resize(sz);
-    m_controlPoints = pts;
-
-    makeNonrational();
-  }
+  BezierCurve(PointType* pts, int ord)
+    : BezierCurve(axom::ArrayView<PointType>(pts, ord + 1), axom::ArrayView<T>(nullptr, 0), ord)
+  { }
 
   /*!
-   * \brief Constructor for a Rational Bezier Curve from an vector 
-   * of coordinates and weights
+   * \brief Constructor for a rational Bezier Curve from an array of coordinates and weights
    *
    * \param [in] pts a vector with ord+1 control points
    * \param [in] weights a vector with ord+1 positive weights
    * \param [in] ord The Curve's polynomial order
    * \pre order is greater than or equal to zero
+   * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
+   */
+  BezierCurve(PointType* pts, T* weights, int ord)
+    : BezierCurve(axom::ArrayView<PointType>(pts, ord + 1),
+                  axom::ArrayView<T>(weights, weights ? ord + 1 : 0),
+                  ord)
+  { }
+
+  /*!
+   * \brief Constructor for a Bezier Curve from an array of coordinates
    *
+   * \param [in] pts an array with ord+1 control points
+   * \param [in] ord The Curve's polynomial order
+   * \pre order is greater than or equal to zero
+   * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
+   */
+  BezierCurve(const axom::Array<PointType>& pts, int ord)
+    : BezierCurve(pts.view(), axom::ArrayView<T>(nullptr, 0), ord)
+  { }
+
+  /*!
+   * \brief Constructor for a rational Bezier Curve from arrays of coordinates and weights
+   *
+   * \param [in] pts an array with ord+1 control points
+   * \param [in] weights an array with ord+1 positive weights
+   * \param [in] ord The Curve's polynomial order
+   * \pre order is greater than or equal to zero
+   * \see BezierCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, int)
    */
   BezierCurve(const axom::Array<PointType>& pts, const axom::Array<T>& weights, int ord)
-  {
-    SLIC_ASSERT(ord >= 0);
-    SLIC_ASSERT(pts.size() == weights.size());
+    : BezierCurve(pts.view(), weights.view(), ord)
+  { }
 
-    const int sz = utilities::max(0, ord + 1);
-    m_controlPoints.resize(sz);
-    m_weights.resize(sz);
+  //@}
 
-    m_controlPoints = pts;
-    m_weights = weights;
-
-    SLIC_ASSERT(isValidRational());
-  }
-
+public:
   /// Sets the order of the Bezier Curve
   void setOrder(int ord)
   {
@@ -913,6 +918,7 @@ private:
     return true;
   }
 
+private:
   CoordsVec m_controlPoints;
   WeightsVec m_weights;
 };

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -79,8 +79,9 @@ public:
                          "A Bezier Patch must be defined using an arithmetic type");
 
 public:
-  //@{
-  /** @name Constructors for BezierPatch
+  ///@{
+  /** 
+   * @name Constructors for BezierPatch
    *
    * The constructors allow for flexible initialization of BezierPatch objects from:
    * - 1D or 2D Axom arrays of control points and weights,
@@ -256,7 +257,7 @@ public:
     : BezierPatch(pts.view(), weights.view(), ord_u, ord_v)
   { }
 
-  //@}
+  ///@}
 
   /*!
    * \brief Sets the order of Bezier patch

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -86,7 +86,6 @@ public:
    * - 1D or 2D Axom arrays of control points and weights,
    * - C-style arrays of control points and weights,
    * - Specified polynomial orders in each axis,
-   * - Empty patches with reserved space for a given order,
    * - Rational or polynomial (nonrational) patches, depending on the presence of weights.
    *
    * For 1D arrays, the mapping of control points and weights to the patch is lexicographical, i.e.
@@ -166,13 +165,10 @@ public:
   { }
 
   /*!
-   * \brief Constructor for a nonrational Bezier Patch that reserves 
+   * \brief Constructor for a polynomial (nonrational) Bezier Patch that reserves 
    *  space for the given order of the surface
-   *
-   * Constructs an empty patch by default (no nodes/weights on either axis)
    * 
-   * \param [in] ord_u The patch's polynomial order on the first axis
-   * \param [in] ord_v The patch's polynomial order on the second axis
+   * \param [in] ord_u, ord_v The patch's polynomial orders
    * \pre ord_u, ord_v greater than or equal to -1.
    */
   BezierPatch(int ord_u = -1, int ord_v = -1)
@@ -186,8 +182,7 @@ public:
    * \brief Constructor for a Bezier Patch from an array of coordinates
    *
    * \param [in] pts A 1D C-style array of (ord_u+1)*(ord_v+1) control points
-   * \param [in] ord_u The patch's polynomial order on the first axis
-   * \param [in] ord_v The patch's polynomial order on the second axis
+   * \param [in] ord_u, ord_v The patch's polynomial orders
    * \pre order in both directions is greater than or equal to zero
    */
   BezierPatch(const PointType* pts, int ord_u, int ord_v)
@@ -198,14 +193,12 @@ public:
   { }
 
   /*!
-   * \brief Constructor for a Rational Bezier Patch from arrays of coordinates and weights
+   * \brief Constructor for a rational Bezier Patch from arrays of coordinates and weights
    *
    * \param [in] pts A 1D C-style array of (ord_u+1)*(ord_v+1) control points
    * \param [in] weights A 1D C-style array of (ord_u+1)*(ord_v+1) positive weights
-   * \param [in] ord_u The patch's polynomial order on the first axis
-   * \param [in] ord_v The patch's polynomial order on the second axis
-   * \pre order is greater than or equal to zero in each direction
-   * 
+   * \param [in] ord_u, ord_v The patch's polynomial orders, both greater than or equal to zero
+   *  
    * If \a weights is the null pointer, creates a nonrational curve
    */
   BezierPatch(PointType* pts, T* weights, int ord_u, int ord_v)
@@ -219,9 +212,7 @@ public:
    * \brief Constructor for a Bezier Patch from a 1D Axom array of coordinates
    *
    * \param [in] pts A 1D Axom array of (ord_u+1)*(ord_v+1) control points
-   * \param [in] ord_u The patch's polynomial order on the first axis
-   * \param [in] ord_v The patch's polynomial order on the second axis
-   * \pre order in both directions is greater than or equal to zero
+   * \param [in] ord_u, ord_v The patch's polynomial orders, both greater than or equal to zero
    */
   BezierPatch(const CoordsVec& pts, int ord_u, int ord_v)
     : BezierPatch(axom::ArrayView<const PointType, 2>(pts.data(), {ord_u + 1, ord_v + 1}),
@@ -235,9 +226,7 @@ public:
    *
    * \param [in] pts A 1D Axom array of (ord_u+1)*(ord_v+1) control points
    * \param [in] weights A 1D Axom array of (ord_u+1)*(ord_v+1) positive weights
-   * \param [in] ord_u The patch's polynomial order on the first axis
-   * \param [in] ord_v The patch's polynomial order on the second axis
-   * \pre order is greater than or equal to zero in each direction
+   * \param [in] ord_u, ord_v The patch's polynomial orders, both greater than or equal to zero
    */
   BezierPatch(const CoordsVec& pts, const WeightsVec& weights, int ord_u, int ord_v)
     : BezierPatch(axom::ArrayView<const PointType, 2>(pts.data(), {ord_u + 1, ord_v + 1}),
@@ -250,9 +239,7 @@ public:
    * \brief Constructor for a Bezier Patch from an Axom array of coordinates
    *
    * \param [in] pts A 2D Axom array with (ord_u+1, ord_v+1) control points
-   * \param [in] ord_u The patch's polynomial order on the first axis
-   * \param [in] ord_v The patch's polynomial order on the second axis
-   * \pre order is greater than or equal to zero in each direction
+   * \param [in] ord_u, ord_v The patch's polynomial orders, both greater than or equal to zero
    */
   BezierPatch(const CoordsMat& pts, int ord_u, int ord_v)
     : BezierPatch(pts.view(), axom::ArrayView<const T, 2>(nullptr, {0, 0}), ord_u, ord_v)
@@ -263,9 +250,7 @@ public:
    *
    * \param [in] pts A 2D Axom array with (ord_u+1, ord_v+1) control points
    * \param [in] weights A 2D Axom array with (ord_u+1, ord_v+1) weights
-   * \param [in] ord_u The patch's polynomial order on the first axis
-   * \param [in] ord_v The patch's polynomial order on the second axis
-   * \pre order is greater than or equal to zero in each direction
+   * \param [in] ord_u, ord_v The patch's polynomial orders, both greater than or equal to zero
    */
   BezierPatch(const CoordsMat& pts, const WeightsMat& weights, int ord_u, int ord_v)
     : BezierPatch(pts.view(), weights.view(), ord_u, ord_v)
@@ -276,17 +261,22 @@ public:
   /*!
    * \brief Sets the order of Bezier patch
    *
-   * \param [in] ord_u The patch's polynomial order on the first axis
-   * \param [in] ord_v The patch's polynomial order on the second axis
+   * \param [in] ord_u, ord_v The patch's polynomial orders, 
+   * 
+   * \pre ord_u and ord_v must both be -1 or both greater than or equal to zero
    *
    * \note Will only resize the arrays, and likely make the patch invalid
    */
   void setOrder(int ord_u, int ord_v)
   {
-    m_controlPoints.resize(ord_u + 1, ord_v + 1);
+    SLIC_ASSERT((ord_u == -1 && ord_v == -1) || (ord_u >= 0 && ord_v >= 0));
+    const int SZ_U = utilities::max(0, ord_u + 1);
+    const int SZ_V = utilities::max(0, ord_v + 1);
+
+    m_controlPoints.resize(SZ_U, SZ_V);
     if(isRational())
     {
-      m_weights.resize(ord_u + 1, ord_v + 1);
+      m_weights.resize(SZ_U, SZ_V);
     }
   }
 

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -49,7 +49,8 @@ std::ostream& operator<<(std::ostream& os, const BezierPatch<T, NDIMS>& bPatch);
  * parametrized from u=0 to u=1 and v=0 to v=1.
  * 
  * Contains a 2D array of positive weights to represent a rational Bezier patch.
- * Nonrational Bezier patches are identified by an empty weights array.
+ * Polynomial (nonrational) Bezier patches are identified by an empty weights array.
+ * 
  * Algorithms for Rational Bezier curves derived from 
  * Gerald Farin, "Algorithms for rational Bezier curves"
  * Computer-Aided Design, Volume 15, Number 2, 1983,
@@ -78,6 +79,92 @@ public:
                          "A Bezier Patch must be defined using an arithmetic type");
 
 public:
+  //@{
+  /** @name Constructors for BezierPatch
+   *
+   * The constructors allow for flexible initialization of BezierPatch objects from:
+   * - 1D or 2D Axom arrays of control points and weights,
+   * - C-style arrays of control points and weights,
+   * - Specified polynomial orders in each axis,
+   * - Empty patches with reserved space for a given order,
+   * - Rational or polynomial (nonrational) patches, depending on the presence of weights.
+   *
+   * For 1D arrays, the mapping of control points and weights to the patch is lexicographical, i.e.
+   * pts[0]               -> nodes[0, 0],     ..., pts[ord_v]       -> nodes[0, ord_v]
+   * pts[ord_v+1]         -> nodes[1, 0],     ..., pts[2*ord_v]     -> nodes[1, ord_v]
+   *                                          ...
+   * pts[ord_u*(ord_v-1)] -> nodes[ord_u, 0], ..., pts[ord_u*ord_v] -> nodes[ord_u, ord_v]
+   * 
+   * The patch is parametrized from u=0 to u=1 and v=0 to v=1. 
+   * 
+   * Rational patches are identified by a non-empty weights array, 
+   * and nonrational patches by an empty weights array.
+   * All weights must be greater than 0 in a rational patch.
+   */
+
+  /**
+   * \brief Constructor from an ArrayView over the control points and weights
+   * 
+   * \param [in] controlPoints ArrayView of control points (size: (ord_u+1, ord_v+1) or (0,0))
+   * \param [in] weights ArrayView of weights (size: (ord_u+1, ord_v+1) or (0,0))
+   * \param [in] ord_u The patch's polynomial order on the first axis
+   * \param [in] ord_v The patch's polynomial order on the second axis
+   * 
+   * If \a controlPoints is empty, we still allocate space for (ord_u+1, ord_v+1) control points
+   * \pre ord_u and ord_v must either both be at least 0 for a valid patch, or both must be -1 for an empty patch
+   */
+  BezierPatch(axom::ArrayView<const PointType, 2> controlPoints,
+              axom::ArrayView<const T, 2> weights,
+              int ord_u,
+              int ord_v)
+  {
+    SLIC_ASSERT((ord_u == -1 && ord_v == -1) || (ord_u >= 0 && ord_u >= 0));
+    const int sz_u = utilities::max(0, ord_u + 1);
+    const int sz_v = utilities::max(0, ord_v + 1);
+
+    SLIC_ASSERT(controlPoints.size() >= weights.size());
+
+    // note: always allocate space for control points
+    if(controlPoints.empty())
+    {
+      m_controlPoints.resize(sz_u, sz_v);
+    }
+    else
+    {
+      SLIC_ASSERT(controlPoints.data() != nullptr);
+      SLIC_ASSERT(controlPoints.shape()[0] == sz_u && controlPoints.shape()[1] == sz_v);
+      m_controlPoints = controlPoints;
+    }
+
+    // note: only allocate space for weights when they are supplied
+    if(!weights.empty())
+    {
+      SLIC_ASSERT(weights.data() != nullptr);
+      SLIC_ASSERT(weights.shape()[0] == sz_u && weights.shape()[1] == sz_v);
+      m_weights = weights;
+      SLIC_ASSERT(isValidRational());
+    }
+  }
+
+  /// Constructor for polynomial BezierPatch from ArrayView of control points
+  BezierPatch(axom::ArrayView<PointType, 2> controlPoints, int ord_u, int ord_v)
+    : BezierPatch(axom::ArrayView<const PointType, 2>(controlPoints.data(), controlPoints.shape()),
+                  axom::ArrayView<const T, 2>(nullptr, {0, 0}),
+                  ord_u,
+                  ord_v)
+  { }
+
+  /// Constructor for rational BezierPatch from ArrayView of control points
+  BezierPatch(axom::ArrayView<PointType, 2> controlPoints,
+              axom::ArrayView<T, 2> weights,
+              int ord_u,
+              int ord_v)
+    : BezierPatch(axom::ArrayView<const PointType, 2>(controlPoints.data(), controlPoints.shape()),
+                  axom::ArrayView<const T, 2>(weights.data(), weights.shape()),
+                  ord_u,
+                  ord_v)
+  { }
+
   /*!
    * \brief Constructor for a nonrational Bezier Patch that reserves 
    *  space for the given order of the surface
@@ -89,16 +176,11 @@ public:
    * \pre ord_u, ord_v greater than or equal to -1.
    */
   BezierPatch(int ord_u = -1, int ord_v = -1)
-  {
-    SLIC_ASSERT(ord_u >= -1 && ord_v >= -1);
-
-    const int sz_u = utilities::max(0, ord_u + 1);
-    const int sz_v = utilities::max(0, ord_v + 1);
-
-    m_controlPoints.resize(sz_u, sz_v);
-
-    makeNonrational();
-  }
+    : BezierPatch(axom::ArrayView<const PointType, 2>(nullptr, {0, 0}),
+                  axom::ArrayView<const T, 2>(nullptr, {0, 0}),
+                  ord_u,
+                  ord_v)
+  { }
 
   /*!
    * \brief Constructor for a Bezier Patch from an array of coordinates
@@ -107,31 +189,13 @@ public:
    * \param [in] ord_u The patch's polynomial order on the first axis
    * \param [in] ord_v The patch's polynomial order on the second axis
    * \pre order in both directions is greater than or equal to zero
-   *
-   * Elements of pts[k] are mapped to control nodes (p, q) lexicographically, i.e.
-   * pts[0]               -> nodes[0, 0],     ..., pts[ord_v]       -> nodes[0, ord_v]
-   * pts[ord_v+1]         -> nodes[1, 0],     ..., pts[2*ord_v]     -> nodes[1, ord_v]
-   *                                          ...
-   * pts[ord_u*(ord_v-1)] -> nodes[ord_u, 0], ..., pts[ord_u*ord_v] -> nodes[ord_u, ord_v]
-   * 
    */
-  BezierPatch(PointType* pts, int ord_u, int ord_v)
-  {
-    SLIC_ASSERT(pts != nullptr);
-    SLIC_ASSERT(ord_u >= 0 && ord_v >= 0);
-
-    const int sz_u = utilities::max(0, ord_u + 1);
-    const int sz_v = utilities::max(0, ord_v + 1);
-
-    m_controlPoints.resize(sz_u, sz_v);
-
-    for(int t = 0; t < sz_u * sz_v; ++t)
-    {
-      m_controlPoints.flatIndex(t) = pts[t];
-    }
-
-    makeNonrational();
-  }
+  BezierPatch(const PointType* pts, int ord_u, int ord_v)
+    : BezierPatch(axom::ArrayView<const PointType, 2>(pts, {ord_u + 1, ord_v + 1}),
+                  axom::ArrayView<const T, 2>(nullptr, {0, 0}),
+                  ord_u,
+                  ord_v)
+  { }
 
   /*!
    * \brief Constructor for a Rational Bezier Patch from arrays of coordinates and weights
@@ -142,41 +206,14 @@ public:
    * \param [in] ord_v The patch's polynomial order on the second axis
    * \pre order is greater than or equal to zero in each direction
    * 
-   * Elements of pts and weights are mapped to control nodes (p, q) lexicographically
-   * 
-   * If \p weights is the null pointer, creates a nonrational curve
+   * If \a weights is the null pointer, creates a nonrational curve
    */
   BezierPatch(PointType* pts, T* weights, int ord_u, int ord_v)
-  {
-    SLIC_ASSERT(pts != nullptr);
-    SLIC_ASSERT(ord_u >= 0 && ord_v >= 0);
-
-    const int sz_u = utilities::max(0, ord_u + 1);
-    const int sz_v = utilities::max(0, ord_v + 1);
-
-    m_controlPoints.resize(sz_u, sz_v);
-
-    for(int t = 0; t < sz_u * sz_v; ++t)
-    {
-      m_controlPoints.flatIndex(t) = pts[t];
-    }
-
-    if(weights == nullptr)
-    {
-      makeNonrational();
-    }
-    else
-    {
-      m_weights.resize(sz_u, sz_v);
-
-      for(int t = 0; t < sz_u * sz_v; ++t)
-      {
-        m_weights.flatIndex(t) = weights[t];
-      }
-    }
-
-    SLIC_ASSERT(isValidRational());
-  }
+    : BezierPatch(axom::ArrayView<const PointType, 2>(pts, {ord_u + 1, ord_v + 1}),
+                  axom::ArrayView<const T, 2>(weights, {ord_u + 1, ord_v + 1}),
+                  ord_u,
+                  ord_v)
+  { }
 
   /*!
    * \brief Constructor for a Bezier Patch from a 1D Axom array of coordinates
@@ -185,25 +222,13 @@ public:
    * \param [in] ord_u The patch's polynomial order on the first axis
    * \param [in] ord_v The patch's polynomial order on the second axis
    * \pre order in both directions is greater than or equal to zero
-   * 
-   * Elements of pts are mapped to control nodes (p, q) lexicographically
    */
   BezierPatch(const CoordsVec& pts, int ord_u, int ord_v)
-  {
-    SLIC_ASSERT(ord_u >= 0 && ord_v >= 0);
-
-    const int sz_u = utilities::max(0, ord_u + 1);
-    const int sz_v = utilities::max(0, ord_v + 1);
-
-    m_controlPoints.resize(sz_u, sz_v);
-
-    for(int t = 0; t < sz_u * sz_v; ++t)
-    {
-      m_controlPoints.flatIndex(t) = pts.flatIndex(t);
-    }
-
-    makeNonrational();
-  }
+    : BezierPatch(axom::ArrayView<const PointType, 2>(pts.data(), {ord_u + 1, ord_v + 1}),
+                  axom::ArrayView<const T, 2>(nullptr, {0, 0}),
+                  ord_u,
+                  ord_v)
+  { }
 
   /*!
    * \brief Constructor for a Rational Bezier Patch from 1D Axom arrays of coordinates and weights
@@ -213,31 +238,13 @@ public:
    * \param [in] ord_u The patch's polynomial order on the first axis
    * \param [in] ord_v The patch's polynomial order on the second axis
    * \pre order is greater than or equal to zero in each direction
-   * 
-   * Elements of pts and weights are mapped to control nodes (p, q) lexicographically.
    */
   BezierPatch(const CoordsVec& pts, const WeightsVec& weights, int ord_u, int ord_v)
-  {
-    SLIC_ASSERT(ord_u >= 0 && ord_v >= 0);
-    SLIC_ASSERT(weights.size() == pts.size());
-
-    const int sz_u = utilities::max(0, ord_u + 1);
-    const int sz_v = utilities::max(0, ord_v + 1);
-
-    m_controlPoints.resize(sz_u, sz_v);
-    for(int t = 0; t < sz_u * sz_v; ++t)
-    {
-      m_controlPoints.flatIndex(t) = pts.flatIndex(t);
-    }
-
-    m_weights.resize(sz_u, sz_v);
-    for(int t = 0; t < sz_u * sz_v; ++t)
-    {
-      m_weights.flatIndex(t) = weights.flatIndex(t);
-    }
-
-    SLIC_ASSERT(isValidRational());
-  }
+    : BezierPatch(axom::ArrayView<const PointType, 2>(pts.data(), {ord_u + 1, ord_v + 1}),
+                  axom::ArrayView<const T, 2>(weights.data(), {ord_u + 1, ord_v + 1}),
+                  ord_u,
+                  ord_v)
+  { }
 
   /*!
    * \brief Constructor for a Bezier Patch from an Axom array of coordinates
@@ -246,24 +253,13 @@ public:
    * \param [in] ord_u The patch's polynomial order on the first axis
    * \param [in] ord_v The patch's polynomial order on the second axis
    * \pre order is greater than or equal to zero in each direction
-   *
    */
   BezierPatch(const CoordsMat& pts, int ord_u, int ord_v)
-  {
-    SLIC_ASSERT((ord_u >= 0) && (ord_v >= 0));
-
-    const int sz_u = utilities::max(0, ord_u + 1);
-    const int sz_v = utilities::max(0, ord_v + 1);
-
-    m_controlPoints.resize(sz_u, sz_v);
-    m_controlPoints = pts;
-
-    makeNonrational();
-  }
+    : BezierPatch(pts.view(), axom::ArrayView<const T, 2>(nullptr, {0, 0}), ord_u, ord_v)
+  { }
 
   /*!
-   * \brief Constructor for a rational Bezier Patch from a 2D Axom array 
-   *   of weights and coordinates
+   * \brief Constructor for a rational Bezier Patch from a 2D Axom array  of weights and coordinates
    *
    * \param [in] pts A 2D Axom array with (ord_u+1, ord_v+1) control points
    * \param [in] weights A 2D Axom array with (ord_u+1, ord_v+1) weights
@@ -272,22 +268,10 @@ public:
    * \pre order is greater than or equal to zero in each direction
    */
   BezierPatch(const CoordsMat& pts, const WeightsMat& weights, int ord_u, int ord_v)
-  {
-    SLIC_ASSERT(ord_u >= 0 && ord_v >= 0);
-    SLIC_ASSERT(pts.shape()[0] == weights.shape()[0]);
-    SLIC_ASSERT(pts.shape()[1] == weights.shape()[1]);
+    : BezierPatch(pts.view(), weights.view(), ord_u, ord_v)
+  { }
 
-    const int sz_u = utilities::max(0, ord_u + 1);
-    const int sz_v = utilities::max(0, ord_v + 1);
-
-    m_controlPoints.resize(sz_u, sz_v);
-    m_controlPoints = pts;
-
-    m_weights.resize(sz_u, sz_v);
-    m_weights = weights;
-
-    SLIC_ASSERT(isValidRational());
-  }
+  //@}
 
   /*!
    * \brief Sets the order of Bezier patch
@@ -2112,6 +2096,7 @@ private:
     return true;
   }
 
+private:
   CoordsMat m_controlPoints;
   WeightsMat m_weights;
 };

--- a/src/axom/primal/geometry/KnotVector.hpp
+++ b/src/axom/primal/geometry/KnotVector.hpp
@@ -50,8 +50,41 @@ public:
                          "A knot vector must be defined using an arithmetic type");
 
 public:
+  /*!
+   * \brief Constructor from a user-supplied knot vector (axom::ArrayView<const T>)
+   *
+   * \param [in] knots the knot vector
+   * \param [in] degree the degree of the curve
+   * \pre \a degree >= 1. When degree is less than 0, the KnotVector is invalid
+   * \pre The \a knots can be empty when the degree is -1, otherwise it has knot values
+   *      and knots.data() is not \a nullptr
+   * \sa isValid() tests conditions for a valid knot span instance
+   */
+  KnotVector(axom::ArrayView<const T> knots, int degree) : m_deg(degree)
+  {
+    SLIC_ASSERT(degree >= -1);
+    SLIC_ASSERT(knots.size() >= (degree + 1));
+    SLIC_ASSERT(knots.empty() || knots.data() != nullptr);
+
+    if(!knots.empty())
+    {
+      m_knots = knots;
+    }
+  }
+
+  /*!
+   * \brief Constructor from a user-supplied knot vector (axom::ArrayView<T>)
+   *
+   * \param [in] knots the knot vector
+   * \param degree The degree of the knot vector.
+   * \see KnotVector(axom::ArrayView<const T> knots, int degree)
+   */
+  KnotVector(axom::ArrayView<T> knots, int degree)
+    : KnotVector(axom::ArrayView<const T>(knots.data(), knots.size()), degree)
+  { }
+
   /// \brief Default constructor for an empty (invalid) knot vector
-  KnotVector() : m_deg(-1) { m_knots.resize(0); }
+  KnotVector() : m_deg(-1) { }
 
   /*!
    * \brief Constructor for a normalized, uniform knot vector
@@ -64,26 +97,17 @@ public:
   KnotVector(axom::IndexType npts, int degree) { makeUniform(npts, degree); }
 
   /*!
-   * \brief Constructor from a user-supplied knot vector (C-style)
+   * \brief Constructor from a user-supplied knot vector (C-style array)
    * 
    * \param [in] knots the knot vector
    * \param [in] nkts the length of the knot vector
    * \param [in] degree the degree of the curve
    * 
-   * \pre Assumes that the knot vector is valid
+   * \see KnotVector(axom::ArrayView<const T> knots, int degree)
    */
   KnotVector(const T* knots, axom::IndexType nkts, int degree)
-  {
-    m_knots.resize(nkts);
-    for(int i = 0; i < nkts; ++i)
-    {
-      m_knots[i] = knots[i];
-    }
-
-    m_deg = degree;
-
-    SLIC_ASSERT(isValid());
-  }
+    : KnotVector(axom::ArrayView<const T>(knots, nkts), degree)
+  { }
 
   /*!
    * \brief Constructor from a user-supplied knot vector (axom::Array)
@@ -91,12 +115,9 @@ public:
    * \param [in] knots the knot vector
    * \param [in] degree the degree of the curve
    * 
-   * \pre Assumes that the knot vector is valid
+   * \see KnotVector(axom::ArrayView<const T> knots, int degree)
    */
-  KnotVector(const axom::Array<T>& knots, int degree) : m_deg(degree), m_knots(knots)
-  {
-    SLIC_ASSERT(isValid());
-  }
+  KnotVector(const axom::Array<T>& knots, int degree) : KnotVector(knots.view(), degree) { }
 
   /*!
    * \brief Give the knot vector uniformly spaced internal knots

--- a/src/axom/primal/geometry/KnotVector.hpp
+++ b/src/axom/primal/geometry/KnotVector.hpp
@@ -50,14 +50,28 @@ public:
                          "A knot vector must be defined using an arithmetic type");
 
 public:
+  //@{
+
+  /**
+   * \name Constructors for KnotVector
+   * 
+   * The KnotVector class provides constructors that allow initialization from a user-supplied array of knots
+   * and a specified degree and enforces several conditions to ensure validity: 
+   * - the degree must be at least -1
+   * - the knot array must contain at least (degree + 1) elements, 
+   * - and if the knot array is not empty, its data pointer must not be nullptr.
+   * These checks guarantee that the constructed KnotVector adheres to the requirements for B-Spline/NURBS curves,
+   * such as monotonicity, clamped ends, and appropriate internal knot multiplicity. The isValid() method is used
+   * to verify that the resulting instance meets all necessary criteria for a valid knot span.
+   */
+
   /*!
    * \brief Constructor from a user-supplied knot vector (axom::ArrayView<const T>)
    *
    * \param [in] knots the knot vector
    * \param [in] degree the degree of the curve
    * \pre \a degree >= 1. When degree is less than 0, the KnotVector is invalid
-   * \pre The \a knots can be empty when the degree is -1, otherwise it has knot values
-   *      and knots.data() is not \a nullptr
+   * \pre The \a knots can be empty when the degree is -1, otherwise knots.data() is not \a nullptr
    * \sa isValid() tests conditions for a valid knot span instance
    */
   KnotVector(axom::ArrayView<const T> knots, int degree) : m_deg(degree)
@@ -79,7 +93,7 @@ public:
    *
    * \param [in] knots the knot vector
    * \param degree The degree of the knot vector.
-   * \see KnotVector(axom::ArrayView<const T> knots, int degree)
+   * \overload for ArrayView of non-const T
    */
   KnotVector(axom::ArrayView<T> knots, int degree)
     : KnotVector(axom::ArrayView<const T>(knots.data(), knots.size()), degree)
@@ -120,6 +134,8 @@ public:
    * \see KnotVector(axom::ArrayView<const T> knots, int degree)
    */
   KnotVector(const axom::Array<T>& knots, int degree) : KnotVector(knots.view(), degree) { }
+
+  //@}
 
   /*!
    * \brief Give the knot vector uniformly spaced internal knots

--- a/src/axom/primal/geometry/KnotVector.hpp
+++ b/src/axom/primal/geometry/KnotVector.hpp
@@ -70,6 +70,8 @@ public:
     {
       m_knots = knots;
     }
+
+    SLIC_ASSERT(isValid());
   }
 
   /*!

--- a/src/axom/primal/geometry/KnotVector.hpp
+++ b/src/axom/primal/geometry/KnotVector.hpp
@@ -50,16 +50,16 @@ public:
                          "A knot vector must be defined using an arithmetic type");
 
 public:
-  //@{
-
+  ///@{
   /**
    * \name Constructors for KnotVector
-   * 
+   *  
    * The KnotVector class provides constructors that allow initialization from a user-supplied array of knots
    * and a specified degree and enforces several conditions to ensure validity: 
    * - the degree must be at least -1
-   * - the knot array must contain at least (degree + 1) elements, 
-   * - and if the knot array is not empty, its data pointer must not be nullptr.
+   * - the knot array must contain at least \a (degree + 1) elements, 
+   * - if the knot array is not empty, its data pointer must not be nullptr.
+   * 
    * These checks guarantee that the constructed KnotVector adheres to the requirements for B-Spline/NURBS curves,
    * such as monotonicity, clamped ends, and appropriate internal knot multiplicity. The isValid() method is used
    * to verify that the resulting instance meets all necessary criteria for a valid knot span.
@@ -135,7 +135,7 @@ public:
    */
   KnotVector(const axom::Array<T>& knots, int degree) : KnotVector(knots.view(), degree) { }
 
-  //@}
+  ///@}
 
   /*!
    * \brief Give the knot vector uniformly spaced internal knots

--- a/src/axom/primal/geometry/NURBSCurve.hpp
+++ b/src/axom/primal/geometry/NURBSCurve.hpp
@@ -54,7 +54,7 @@ std::ostream& operator<<(std::ostream& os, const NURBSCurve<T, NDIMS>& bCurve);
  * and a knot vector of length `k+1`. A valid curve has k+1 = n+p+2
  * The curve must be open (clamped on each end) and continuous (unless p = 0)
  * 
- * Nonrational NURBS curves are identified by an empty weights array.
+ * Polynomial (Nonrational) NURBS curves are identified by an empty weights array.
  */
 template <typename T, int NDIMS>
 class NURBSCurve
@@ -77,7 +77,24 @@ public:
 
 public:
   //@{
-  //!  @name Constructors for NURBS curves
+
+  /**
+   * \name Constructors for NURBSCurve
+   * 
+   * The constructors allow for flexible initialization fo NURBSCurve objects from:
+   * - 1D arrays of control points, weights and knots.
+   *   The control points and weight can be provided as C-style arrays with sizes, axom Arrays and axom ArrayViews.
+   *   The knots can be provided as C-style arrays with sizes, axom Arrays and KnotVector instances
+   * - Specified number of points and degree
+   * - Rational or polynomial (nonrational) curves, depending on the presence of weights.
+   * 
+   * All require:
+   * - Degree >= -1. Degree -1 creates an empty/invalid curve.
+   * - For valid curves, npts must be greater than the degree 
+   * - The weights array is optional. The curve is polynomial (non-rational) if weights are not provided
+   * - When weights are provided, their size must match the number of control points
+   * - The knot vector must satisfy continuity and openness conditions
+   */
 
   /*!
    * \brief Constructor for a simple NURBS curve that reserves space for
@@ -86,8 +103,6 @@ public:
    * \param [in] deg the degree of the resulting curve
    * 
    * \note A uniform knot vector is constructed such that the curve is continuous
-   * \note This constructor reserves space for the control points, but does not set them
-   * 
    * \pre degree is greater than or equal to -1
    * \note When the degree is -1, no space is reserved and the NURBS curve is not valid, 
    *       i.e. in this case, \a curve.isValid() will return false
@@ -175,7 +190,6 @@ public:
    * \param[in] pts        ArrayView of control points
    * \param[in] weights    ArrayView of weights
    * \param[in] knotVector Knot vector defining the parameterization of the curve.
-   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(axom::ArrayView<PointType> pts,
              axom::ArrayView<T> weights,
@@ -189,7 +203,6 @@ public:
    * \brief Constructor for a NURBS curve from a Bezier curve
    *
    * \param [in] bezierCurve the Bezier curve to convert to a NURBS curve 
-   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   explicit NURBSCurve(const BezierCurve<T, NDIMS>& bezierCurve)
     : NURBSCurve(bezierCurve.getControlPoints(),
@@ -205,7 +218,6 @@ public:
    * \param [in] degree the degree of the curve
    * 
    * \pre Requires valid pointers, npts > degree, degree >= 0
-   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const PointType* pts, int npts, int degree)
     : NURBSCurve(axom::ArrayView<const PointType>(pts, npts),
@@ -222,7 +234,6 @@ public:
    * \param [in] degree the degree of the curve
    * 
    * \pre Requires valid pointers, npts > degree, npts == nwts, and degree >= 0
-   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const PointType* pts, const T* weights, int npts, int degree)
     : NURBSCurve(axom::ArrayView<const PointType>(pts, npts),
@@ -239,7 +250,6 @@ public:
    * \param [in] nkts the length of the knot vector
    * 
    * \pre Requires valid pointers, a valid knot vector and npts > degree
-   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const PointType* pts, int npts, const T* knots, int nkts)
     : NURBSCurve(axom::ArrayView<const PointType>(pts, npts),
@@ -257,7 +267,6 @@ public:
    * \param [in] nkts the length of the knot vector
    * 
    * \pre Requires valid pointers, a valid knot vector, npts > degree, npts == nwts, wts > 0
-   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const PointType* pts, const T* weights, int npts, const T* knots, int nkts)
     : NURBSCurve(axom::ArrayView<const PointType>(pts, npts),
@@ -272,7 +281,6 @@ public:
    * \param [in] degree the degree of the curve
    * 
    * \pre Requires npts > degree and degree >= 0
-   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const axom::Array<PointType>& pts, int degree)
     : NURBSCurve(pts.view(), axom::ArrayView<const T>(nullptr, 0), KnotVectorType(pts.size(), degree))
@@ -286,7 +294,6 @@ public:
    * \param [in] degree the degree of the curve
    *
    * \pre Requires npts > degree, degree >= 0, and pts.size() == weights.size()
-   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const axom::Array<PointType>& pts, const axom::Array<T>& weights, int degree)
     : NURBSCurve(pts.view(), weights.view(), KnotVectorType(pts.size(), degree))
@@ -299,7 +306,6 @@ public:
    * \param [in] knots the knot vector of the curve
    *
    * \pre Requires a valid knot vector and npts > degree
-   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const axom::Array<PointType>& pts, const axom::Array<T>& knots)
     : NURBSCurve(pts.view(),
@@ -315,7 +321,6 @@ public:
    * \param [in] knots the knot vector of the curve
    *
    * \pre Requires a valid knot vector, npts > degree, npts == nwts, wts > 0
-   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const axom::Array<PointType>& pts,
              const axom::Array<T>& weights,
@@ -330,7 +335,6 @@ public:
    * \param [in] knotVector A KnotVector object
    * 
    * \pre Requires a valid knot vector and npts > degree
-   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const axom::Array<PointType>& pts, const KnotVectorType& knotVector)
     : NURBSCurve(pts.view(), axom::ArrayView<const T>(nullptr, 0), knotVector)
@@ -344,7 +348,6 @@ public:
    * \param [in] knotVector A KnotVector object
    * 
    * \pre Requires a valid knot vector, npts > degree, npts == nwts, wts > 0
-   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const axom::Array<PointType>& pts,
              const axom::Array<T>& weights,

--- a/src/axom/primal/geometry/NURBSCurve.hpp
+++ b/src/axom/primal/geometry/NURBSCurve.hpp
@@ -76,8 +76,7 @@ public:
                 "A NURBS Curve must be defined using an arithmetic type");
 
 public:
-  //@{
-
+  ///@{
   /**
    * \name Constructors for NURBSCurve
    * 
@@ -355,7 +354,7 @@ public:
     : NURBSCurve(pts.view(), weights.view(), knotVector)
   { }
 
-  //@}
+  ///@}
 
   /*!
    * \brief Construct a multi-span, rational, degree 2 NURBS curve from the angles of a circular arc

--- a/src/axom/primal/geometry/NURBSCurve.hpp
+++ b/src/axom/primal/geometry/NURBSCurve.hpp
@@ -80,7 +80,7 @@ public:
   /**
    * \name Constructors for NURBSCurve
    * 
-   * The constructors allow for flexible initialization fo NURBSCurve objects from:
+   * The constructors allow for flexible initialization of NURBSCurve objects from:
    * - 1D arrays of control points, weights and knots.
    *   The control points and weight can be provided as C-style arrays with sizes, axom Arrays and axom ArrayViews.
    *   The knots can be provided as C-style arrays with sizes, axom Arrays and KnotVector instances

--- a/src/axom/primal/geometry/NURBSCurve.hpp
+++ b/src/axom/primal/geometry/NURBSCurve.hpp
@@ -69,43 +69,30 @@ public:
   using BoundingBoxType = BoundingBox<T, NDIMS>;
   using OrientedBoundingBoxType = OrientedBoundingBox<T, NDIMS>;
 
-  AXOM_STATIC_ASSERT_MSG((NDIMS == 1) || (NDIMS == 2) || (NDIMS == 3),
-                         "A NURBS Curve object may be defined in 1-, 2-, or 3-D");
+  static_assert((NDIMS == 1) || (NDIMS == 2) || (NDIMS == 3),
+                "A NURBS Curve object may be defined in 1-, 2-, or 3-D");
 
-  AXOM_STATIC_ASSERT_MSG(std::is_arithmetic<T>::value,
-                         "A NURBS Curve must be defined using an arithmetic type");
+  static_assert(std::is_arithmetic<T>::value,
+                "A NURBS Curve must be defined using an arithmetic type");
 
 public:
-  /*!
-   * \brief Default constructor for a NURBS Curve
-   *
-   * \note An empty NURBS curve is not valid
-   */
-  explicit NURBSCurve()
-  {
-    m_controlPoints.resize(0);
-    m_knotvec = KnotVectorType();
-    makeNonrational();
-  }
+  //@{
+  //!  @name Constructors for NURBS curves
 
   /*!
-   * \brief Constructor for a simple NURBS Curve that reserves space for
+   * \brief Constructor for a simple NURBS curve that reserves space for
    *  the minimum (sensible) number of points for the given degree
    *
    * \param [in] deg the degree of the resulting curve
    * 
-   * A uniform knot vector is constructed such that the curve is continuous
+   * \note A uniform knot vector is constructed such that the curve is continuous
+   * \note This constructor reserves space for the control points, but does not set them
    * 
-   * \pre degree is greater than or equal to 0.
+   * \pre degree is greater than or equal to -1
+   * \note When the degree is -1, no space is reserved and the NURBS curve is not valid, 
+   *       i.e. in this case, \a curve.isValid() will return false
    */
-  explicit NURBSCurve(int degree)
-  {
-    SLIC_ASSERT(degree >= 0);
-    m_controlPoints.resize(degree + 1);
-    m_knotvec = KnotVectorType(degree + 1, degree);
-
-    makeNonrational();
-  }
+  explicit NURBSCurve(int degree = -1) : NURBSCurve(degree + 1, degree) { }
 
   /*!
    * \brief Constructor for a NURBS curve with given number of control points and degree
@@ -113,36 +100,102 @@ public:
     * \param [in] npts the number of control points
     * \param [in] degree the degree of the curve
     * 
-    * A uniform knot vector is constructed such that the curve is continuous
+    * \note A uniform knot vector is constructed such that the curve is continuous
+    * \note This constructor reserves space for the control points, but does not set them
     * 
-    * \pre npts > degree, degree >= 0
+    * \pre npts > degree, degree >= -1
     */
-  NURBSCurve(int npts, int degree)
+  NURBSCurve(int npts, int degree) : m_knotvec(KnotVectorType(npts, degree))
   {
     SLIC_ASSERT(npts > degree);
-    SLIC_ASSERT(degree >= 0);
+    SLIC_ASSERT(degree >= -1);
 
-    m_controlPoints.resize(npts);
-    m_knotvec = KnotVectorType(npts, degree);
+    if(degree == -1)
+    {
+      SLIC_ASSERT(npts == 0);
+      m_controlPoints.resize(0);
+    }
+    else
+    {
+      m_controlPoints.resize(npts);
+      SLIC_ASSERT(isValidNURBS());
+    }
+  }
 
-    makeNonrational();
+  /*!
+   * \brief Constructor for a NURBS Curve with ArrayViews of control points and weights and a KnotVector
+   *
+   * \param [in] pts ArrayView of control points
+   * \param [in] weights ArrayView of weights
+   * \param [in] knotVector The knot vector object
+   *
+   * For clamped and continuous curves, the control points and knot vector uniquely determine the degree
+   *
+   * \pre The number of control points must be greater than the knot vector degree
+   * \pre If the knotVector degree is -1, pts must be empty
+   * \pre If the knotVector degree is higher, we assume knotVector.isValid()
+   * \pre weights can either be empty (yielding a non-rational spline) or its size must match that of pts
+   */
+  NURBSCurve(axom::ArrayView<const PointType> pts,
+             axom::ArrayView<const T> weights,
+             const KnotVectorType& knotVector)
+    : m_knotvec(knotVector)
+  {
+    SLIC_ASSERT(m_knotvec.getDegree() >= -1);
 
+    if(m_knotvec.getDegree() == -1)
+    {
+      SLIC_ASSERT(pts.empty());
+      SLIC_ASSERT(weights.empty());
+    }
+    else
+    {
+      SLIC_ASSERT(m_knotvec.isValid());
+      SLIC_ASSERT(!pts.empty() && pts.data() != nullptr);
+      SLIC_ASSERT(pts.size() > m_knotvec.getDegree());
+      m_controlPoints = pts;
+
+      if(weights.empty())
+      {
+        makeNonrational();
+      }
+      else
+      {
+        SLIC_ASSERT(weights.size() == pts.size());
+        SLIC_ASSERT(weights.data() != nullptr);
+        m_weights = weights;
+      }
+    }
     SLIC_ASSERT(isValidNURBS());
   }
+
+  /*!
+   * \brief Constructs a NURBSCurve from arrays of control points, weights and knots
+   *
+   * \param[in] pts        ArrayView of control points
+   * \param[in] weights    ArrayView of weights
+   * \param[in] knotVector Knot vector defining the parameterization of the curve.
+   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
+   */
+  NURBSCurve(axom::ArrayView<PointType> pts,
+             axom::ArrayView<T> weights,
+             const KnotVectorType& knotVector)
+    : NURBSCurve(axom::ArrayView<const PointType>(pts.data(), pts.size()),
+                 axom::ArrayView<const T>(weights.data(), weights.size()),
+                 knotVector)
+  { }
 
   /*!
    * \brief Constructor for a NURBS curve from a Bezier curve
    *
    * \param [in] bezierCurve the Bezier curve to convert to a NURBS curve 
+   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   explicit NURBSCurve(const BezierCurve<T, NDIMS>& bezierCurve)
-  {
-    m_controlPoints = bezierCurve.getControlPoints();
-    m_weights = bezierCurve.getWeights();
-
-    int degree = bezierCurve.getOrder();
-    m_knotvec = KnotVectorType(degree + 1, degree);
-  }
+    : NURBSCurve(bezierCurve.getControlPoints(),
+                 bezierCurve.getWeights(),
+                 KnotVectorType(bezierCurve.getOrder() + 1, bezierCurve.getOrder()))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Curve with control points and degree
@@ -151,28 +204,14 @@ public:
    * \param [in] npts the number of control points
    * \param [in] degree the degree of the curve
    * 
-   * A uniform knot vector is constructed such that the curve is continuous
-   * 
    * \pre Requires valid pointers, npts > degree, degree >= 0
+   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const PointType* pts, int npts, int degree)
-  {
-    SLIC_ASSERT(pts != nullptr);
-    SLIC_ASSERT(npts >= degree + 1);
-    SLIC_ASSERT(degree >= 0);
-
-    m_controlPoints.resize(npts);
-    makeNonrational();
-
-    for(int i = 0; i < npts; ++i)
-    {
-      m_controlPoints[i] = pts[i];
-    }
-
-    m_knotvec = KnotVectorType(npts, degree);
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSCurve(axom::ArrayView<const PointType>(pts, npts),
+                 axom::ArrayView<const double>(nullptr, 0),
+                 KnotVectorType(npts, degree))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Curve with control points, weights, and degree
@@ -182,30 +221,14 @@ public:
    * \param [in] npts the number of control points and weights
    * \param [in] degree the degree of the curve
    * 
-   * A uniform knot vector is constructed such that the curve is continuous
-   * 
    * \pre Requires valid pointers, npts > degree, npts == nwts, and degree >= 0
+   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const PointType* pts, const T* weights, int npts, int degree)
-  {
-    SLIC_ASSERT(pts != nullptr && weights != nullptr);
-    SLIC_ASSERT(npts >= degree + 1);
-    SLIC_ASSERT(degree >= 0);
-
-    m_controlPoints.resize(npts);
-    m_weights.resize(npts);
-
-    for(int i = 0; i < npts; ++i)
-    {
-      m_controlPoints[i] = pts[i];
-      m_weights[i] = weights[i];
-    }
-
-    // Knots for the clamped curve
-    m_knotvec = KnotVectorType(npts, degree);
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSCurve(axom::ArrayView<const PointType>(pts, npts),
+                 axom::ArrayView<const T>(weights, npts),
+                 KnotVectorType(npts, degree))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Curve with control points and knots
@@ -215,100 +238,59 @@ public:
    * \param [in] knots the weights of the control points
    * \param [in] nkts the length of the knot vector
    * 
-   * For clamped and continuous curves, npts and nkts 
-   *   uniquely determine the degree
-   * 
    * \pre Requires valid pointers, a valid knot vector and npts > degree
+   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const PointType* pts, int npts, const T* knots, int nkts)
-  {
-    SLIC_ASSERT(nkts >= 0);
-    SLIC_ASSERT(npts >= 0);
-
-    m_controlPoints.resize(npts);
-
-    for(int i = 0; i < npts; ++i)
-    {
-      m_controlPoints[i] = pts[i];
-    }
-    makeNonrational();
-
-    m_knotvec = KnotVectorType(knots, nkts, nkts - npts - 1);
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSCurve(axom::ArrayView<const PointType>(pts, npts),
+                 axom::ArrayView<const T>(nullptr, 0),
+                 KnotVectorType(knots, nkts, nkts - npts - 1))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Curve with control points, weights, and knots
    *
    * \param [in] pts the control points of the curve
-   * \param [in] npts the number of control points and weights
    * \param [in] weights the weights of the control points
+   * \param [in] npts the number of control points and weights
    * \param [in] knots the weights of the control points
    * \param [in] nkts the length of the knot vector
    * 
-   * For clamped and continuous curves, npts and nkts 
-   *   uniquely determine the degree
-   * 
    * \pre Requires valid pointers, a valid knot vector, npts > degree, npts == nwts, wts > 0
+   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const PointType* pts, const T* weights, int npts, const T* knots, int nkts)
-  {
-    SLIC_ASSERT(pts != nullptr && weights != nullptr);
-    SLIC_ASSERT(nkts >= 0);
-    SLIC_ASSERT(npts >= 0);
-
-    m_controlPoints.resize(npts);
-    m_weights.resize(npts);
-
-    for(int i = 0; i < npts; ++i)
-    {
-      m_controlPoints[i] = pts[i];
-      m_weights[i] = weights[i];
-    }
-
-    m_knotvec = KnotVectorType(knots, nkts, nkts - npts - 1);
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSCurve(axom::ArrayView<const PointType>(pts, npts),
+                 axom::ArrayView<const T>(weights, npts),
+                 KnotVectorType(knots, nkts, nkts - npts - 1))
+  { }
 
   /*!
-   * \brief Constructor for a NURBS Curve with axom arrays of data
+   * \brief Constructor for a NURBS Curve of the specified degree from an array of control points
    *
    * \param [in] pts the control points of the curve
    * \param [in] degree the degree of the curve
-   *
-   * A uniform knot vector is constructed such that the curve is continuous
    * 
    * \pre Requires npts > degree and degree >= 0
+   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
-  NURBSCurve(const axom::Array<PointType>& pts, int degree) : m_controlPoints(pts)
-  {
-    makeNonrational();
-    m_knotvec = KnotVectorType(pts.size(), degree);
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+  NURBSCurve(const axom::Array<PointType>& pts, int degree)
+    : NURBSCurve(pts.view(), axom::ArrayView<const T>(nullptr, 0), KnotVectorType(pts.size(), degree))
+  { }
 
   /*!
-   * \brief Constructor for a NURBS Curve with axom arrays of data
+   * \brief Constructor for a NURBS Curve of the specified degree from an array of control points and weights
    *
    * \param [in] pts the control points of the curve
    * \param [in] weights the weights of the control points
    * \param [in] degree the degree of the curve
    *
-   * A uniform knot vector is constructed such that the curve is continuous
-   * 
-   * \pre Requires npts > degree, degree >= 0, and npts == nwts
+   * \pre Requires npts > degree, degree >= 0, and pts.size() == weights.size()
+   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const axom::Array<PointType>& pts, const axom::Array<T>& weights, int degree)
-    : m_controlPoints(pts)
-    , m_weights(weights)
-  {
-    m_knotvec = KnotVectorType(pts.size(), degree);
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSCurve(pts.view(), weights.view(), KnotVectorType(pts.size(), degree))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Curve with axom arrays of nodes and knots
@@ -316,19 +298,14 @@ public:
    * \param [in] pts the control points of the curve
    * \param [in] knots the knot vector of the curve
    *
-   * For clamped and continuous curves, npts and the knot vector 
-   *   uniquely determine the degree
-   * 
    * \pre Requires a valid knot vector and npts > degree
+   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
-  NURBSCurve(const axom::Array<PointType>& pts, const axom::Array<T>& knots) : m_controlPoints(pts)
-  {
-    makeNonrational();
-
-    m_knotvec = KnotVectorType(knots, knots.size() - pts.size() - 1);
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+  NURBSCurve(const axom::Array<PointType>& pts, const axom::Array<T>& knots)
+    : NURBSCurve(pts.view(),
+                 axom::ArrayView<const T>(nullptr, 0),
+                 KnotVectorType(knots, knots.size() - pts.size() - 1))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Curve with axom arrays of nodes, weights, and knots
@@ -337,21 +314,14 @@ public:
    * \param [in] weights the weights of the control points
    * \param [in] knots the knot vector of the curve
    *
-   * For clamped and continuous curves, npts and the knot vector 
-   *   uniquely determine the degree
-   * 
    * \pre Requires a valid knot vector, npts > degree, npts == nwts, wts > 0
+   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const axom::Array<PointType>& pts,
              const axom::Array<T>& weights,
              const axom::Array<T>& knots)
-    : m_controlPoints(pts)
-    , m_weights(weights)
-  {
-    m_knotvec = KnotVectorType(knots, knots.size() - pts.size() - 1);
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSCurve(pts.view(), weights.view(), KnotVectorType(knots, knots.size() - pts.size() - 1))
+  { }
 
   /*!
    * \brief Constructor from axom array of nodes and KnotVector object
@@ -359,19 +329,12 @@ public:
    * \param [in] pts the control points of the curve
    * \param [in] knotVector A KnotVector object
    * 
-   * For clamped and continuous curves, npts and the knot vector 
-   *   uniquely determine the degree
-   *
    * \pre Requires a valid knot vector and npts > degree
+   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const axom::Array<PointType>& pts, const KnotVectorType& knotVector)
-    : m_controlPoints(pts)
-    , m_knotvec(knotVector)
-  {
-    makeNonrational();
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSCurve(pts.view(), axom::ArrayView<const T>(nullptr, 0), knotVector)
+  { }
 
   /*!
    * \brief Constructor from axom array of nodes, weights, and KnotVector object
@@ -379,21 +342,17 @@ public:
    * \param [in] pts the control points of the curve
    * \param [in] weights the weights of the control points
    * \param [in] knotVector A KnotVector object
-   *
-   * For clamped and continuous curves, npts and the knot vector 
-   *   uniquely determine the degree
    * 
    * \pre Requires a valid knot vector, npts > degree, npts == nwts, wts > 0
+   * \see NURBSCurve(axom::ArrayView<const PointType>, axom::ArrayView<const T>, const KnotVectorType&)
    */
   NURBSCurve(const axom::Array<PointType>& pts,
              const axom::Array<T>& weights,
              const KnotVectorType& knotVector)
-    : m_controlPoints(pts)
-    , m_weights(weights)
-    , m_knotvec(knotVector)
-  {
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSCurve(pts.view(), weights.view(), knotVector)
+  { }
+
+  //@}
 
   /*!
    * \brief Construct a multi-span, rational, degree 2 NURBS curve from the angles of a circular arc

--- a/src/axom/primal/geometry/NURBSPatch.hpp
+++ b/src/axom/primal/geometry/NURBSPatch.hpp
@@ -108,6 +108,12 @@ public:
    * - Rationality determined by the presence of weights (patches are rational if weights are provided, nonrational otherwise).
    * - Trimming curves are always empty and the patch is untrimmed by default.
    *
+   * For 1D arrays, the mapping of control points and weights to the patch is lexicographical, i.e.
+   * pts[0]               -> nodes[0, 0],     ..., pts[npts_v]       -> nodes[0, npts_v]
+   * pts[npts_v+1]         -> nodes[1, 0],     ..., pts[2*npts_v]     -> nodes[1, npts_v]
+   *                                          ...
+   * pts[npts_u*(npts_v-1)] -> nodes[npts_u, 0], ..., pts[npts_u*npts_v] -> nodes[npts_u, npts_v]
+   * 
    * All constructors ensure that the patch is internally consistent and valid, provided the input parameters are valid.
    */
 
@@ -122,20 +128,17 @@ public:
    * \brief Constructor for a simple NURBS surface that reserves space for
    *  the minimum (sensible) number of points for the given degrees
    * 
-   * \param [in] deg_u The patch's degree on the first axis
-   * \param [in] deg_v The patch's degree on the second axis
+   * \param [in] deg_u, deg_v The patch's degrees on the first and second axis
    * \pre deg_u, deg_v both greater than or equal to 0, or both -1
    */
   NURBSPatch(int deg_u, int deg_v) : NURBSPatch(deg_u + 1, deg_v + 1, deg_u, deg_v) { }
 
   /*!
-   * \brief Constructor for an empty NURBS surface from its size
+   * \brief Constructor for a simple NURBS surface that reserves space for
+   *   \a npts_u * npts_v control points
    *
-   * \param [in] npts_u The number of control points on the first axis
-   * \param [in] npts_v The number of control points on the second axis
-   * \param [in] deg_u The patch's degree on the first axis
-   * \param [in] deg_v The patch's degree on the second axis
-   * 
+   * \param [in] npts_u, npts_v The number of control points on the first and second axis
+   * \param [in] deg_u, deg_v The patch's degrees on the first and second axis
    * \pre Requires npts_d > deg_d and deg_d >= 0 for d = u, v 
    */
   NURBSPatch(int npts_u, int npts_v, int deg_u, int deg_v)
@@ -166,6 +169,23 @@ public:
                  KnotVectorType(bezierPatch.getOrder_v() + 1, bezierPatch.getOrder_v()))
   { }
 
+  /*!
+   * \brief Constructor for a NURBSPatch from 2D ArrayViews of control points and weights 
+   *        and KnotVectors for the u- and v- directions
+   *
+   * \param [in] controlPoints 2D ArrayView of control points
+   * \param [in] weights 2D ArrayView of weights
+   * \param [in] knotVector_u, knotVector_v The knot vectors in the u- and v- directions
+   *
+   * \pre If controlPoints is not empty, its sizes must match the number of control points 
+   * implied by the knot vectors: knotVector_u.getNumControlPoints() * knotVector_v.getNumberControlPoints()
+   * \pre If weights is not empty, its dimensions must match that of the controlPoints
+   * \pre The KnotVector degrees must be valid: \a knotVector_u.getDegree() >= -1 
+   * and \a knotVector_v.getDegree() >= -1. 
+   * \pre If the degrees are not both -1 (i.e., not empty), then:
+   * They must both be non-negative and the number of control points must be
+   * greature than the degree for both axes.
+   */
   NURBSPatch(ArrayView<const PointType, 2> controlPoints,
              ArrayView<const T, 2> weights,
              const KnotVectorType& knotVector_u,
@@ -173,18 +193,21 @@ public:
     : m_knotvec_u(knotVector_u)
     , m_knotvec_v(knotVector_v)
   {
-    const int deg_u = m_knotvec_u.getDegree();
-    const int deg_v = m_knotvec_v.getDegree();
+    const int knot_deg_u = m_knotvec_u.getDegree();
+    const int knot_deg_v = m_knotvec_v.getDegree();
+    SLIC_ASSERT(knot_deg_u >= -1 && knot_deg_v >= -1);
 
-    SLIC_ASSERT(deg_u >= -1 && deg_v >= -1);
-    if(const bool is_empty = (deg_u == -1 && deg_v == -1); is_empty)
+    if(const bool is_empty = (knot_deg_u == -1 && knot_deg_u == -1); is_empty)
     {
       SLIC_ASSERT(controlPoints.empty());
       SLIC_ASSERT(weights.empty());
     }
     else
     {
-      SLIC_ASSERT(deg_u >= 0 && deg_v >= 0);
+      SLIC_ASSERT(knot_deg_u >= 0 && knot_deg_v >= 0);
+      const int deg_u = utilities::max(0, knot_deg_u);
+      const int deg_v = utilities::max(0, knot_deg_v);
+
       const int npts_u = knotVector_u.getNumControlPoints();
       const int npts_v = knotVector_v.getNumControlPoints();
       SLIC_ASSERT(npts_u > deg_u && npts_v > deg_v);
@@ -213,12 +236,25 @@ public:
     }
   }
 
+  /*!
+   * \brief Constructor for a NURBSPatch from 2D ArrayViews of control points
+   *        and KnotVectors for the u- and v- directions
+   *
+   * \param [in] controlPoints 2D ArrayView of control points
+   * \param [in] weights 2D ArrayView of weights
+   * \param [in] knotVector_u, knotVector_v The knot vectors in the u- and v- directions
+   */
   NURBSPatch(ArrayView<const PointType, 2> controlPoints,
              const KnotVectorType& knotVector_u,
              const KnotVectorType& knotVector_v)
     : NURBSPatch(controlPoints, axom::ArrayView<const T, 2>(nullptr, {{0, 0}}), knotVector_u, knotVector_v)
   { }
 
+  /*!
+   * \brief Constructor for a NURBSPatch from 2D ArrayViews of control points
+   *        and KnotVectors for the u- and v- directions
+   * \overload Overload for non-const PointType
+   */
   NURBSPatch(ArrayView<PointType, 2> controlPoints,
              const KnotVectorType& knotVector_u,
              const KnotVectorType& knotVector_v)
@@ -228,6 +264,11 @@ public:
                  knotVector_v)
   { }
 
+  /*!
+   * \brief Constructor for a NURBSPatch from 2D ArrayViews of control points and weights
+   *        and KnotVectors for the u- and v- directions
+   * \overload Overload for non-const PointType and weights
+   */
   NURBSPatch(ArrayView<PointType, 2> controlPoints,
              ArrayView<T, 2> weights,
              const KnotVectorType& knotVector_u,
@@ -242,16 +283,9 @@ public:
    * \brief Constructor for a NURBS Patch from an array of coordinates and degrees
    *
    * \param [in] pts A 1D C-style array of npts_u*npts_v control points
-   * \param [in] npts_u The number of control points on the first axis
-   * \param [in] npts_v The number of control points on the second axis
-   * \param [in] deg_u The patch's degree on the first axis
-   * \param [in] deg_v The patch's degree on the second axis
+   * \param [in] npts_u, npts_v The number of control points on the first and second axis
+   * \param [in] deg_u, deg_v The patch's degree on the first and second axis
    * \pre Requires that npts_d >= deg_d + 1 and deg_d >= 0 for d = u, v
-   *
-   * The knot vectors are constructed such that the patch is uniform
-   * 
-   * Elements of pts[k] are mapped to control nodes (p, q) lexicographically, i.e.
-   * pts[k] = nodes[ k // (npts_u + 1), k % npts_v ]
    */
   NURBSPatch(const PointType* pts, int npts_u, int npts_v, int deg_u, int deg_v)
     : NURBSPatch(axom::ArrayView<const PointType, 2>(pts, {{npts_u, npts_v}}),
@@ -265,16 +299,9 @@ public:
    *
    * \param [in] pts A 1D C-style array of (ord_u+1)*(ord_v+1) control points
    * \param [in] weights A 1D C-style array of (ord_u+1)*(ord_v+1) positive weights
-   * \param [in] npts_u The number of control points on the first axis
-   * \param [in] npts_v The number of control points on the second axis
-   * \param [in] deg_u The patch's degree on the first axis
-   * \param [in] deg_v The patch's degree on the second axis
+   * \param [in] npts_u, npts_v The number of control points on the first and second axis
+   * \param [in] deg_u, deg_v The patch's degree on the first and second axis
    * \pre Requires that npts_d >= deg_d + 1 and deg_d >= 0 for d = u, v
-   *
-   * The knot vectors are constructed such that the patch is uniform
-   * 
-   * Elements of pts[k] are mapped to control nodes (p, q) lexicographically, i.e.
-   * pts[k] = nodes[ k // (npts_u + 1), k % npts_v ]
    */
   NURBSPatch(const PointType* pts, const T* weights, int npts_u, int npts_v, int deg_u, int deg_v)
     : NURBSPatch(axom::ArrayView<const PointType, 2>(pts, {{npts_u, npts_v}}),
@@ -287,16 +314,9 @@ public:
    * \brief Constructor for a NURBS Patch from 1D arrays of coordinates and degrees
    *
    * \param [in] pts A 1D axom::Array of npts_u*npts_v control points
-   * \param [in] npts_u The number of control points on the first axis
-   * \param [in] npts_v The number of control points on the second axis
-   * \param [in] deg_u The patch's degree on the first axis
-   * \param [in] deg_v The patch's degree on the second axis
+   * \param [in] npts_u, npts_v The number of control points on the first and second axis
+   * \param [in] deg_u, deg_v The patch's degree on the first and second axis
    * \pre Requires that npts_d >= deg_d + 1 and deg_d >= 0 for d = u, v
-   *
-   * The knot vectors are constructed such that the patch is uniform
-   * 
-   * Elements of pts[k] are mapped to control nodes (p, q) lexicographically, i.e.
-   * pts[k] = nodes[ k // (npts_u + 1), k % npts_v ]
    */
   NURBSPatch(const CoordsVec& pts, int npts_u, int npts_v, int deg_u, int deg_v)
     : NURBSPatch(axom::ArrayView<const PointType, 2>(pts.data(), {{npts_u, npts_v}}),
@@ -310,16 +330,9 @@ public:
    *
    * \param [in] pts A 1D axom::Array of (ord_u+1)*(ord_v+1) control points
    * \param [in] weights A 1D axom::Array of (ord_u+1)*(ord_v+1) positive weights
-   * \param [in] npts_u The number of control points on the first axis
-   * \param [in] npts_v The number of control points on the second axis
-   * \param [in] deg_u The patch's degree on the first axis
-   * \param [in] deg_v The patch's degree on the second axis
+   * \param [in] npts_u, npts_v The number of control points on the first and second axis
+   * \param [in] deg_u, deg_v The patch's degree on the first and second axis
    * \pre Requires that npts_d >= deg_d + 1 and deg_d >= 0 for d = u, v
-   *
-   * The knot vectors are constructed such that the patch is uniform
-   * 
-   * Elements of pts[k] are mapped to control nodes (p, q) lexicographically, i.e.
-   * pts[k] = nodes[ k // (npts_u + 1), k % npts_v ]
    */
   NURBSPatch(const CoordsVec& pts, const WeightsVec& weights, int npts_u, int npts_v, int deg_u, int deg_v)
     : NURBSPatch(axom::ArrayView<const PointType, 2>(pts.data(), {{npts_u, npts_v}}),
@@ -332,11 +345,8 @@ public:
    * \brief Constructor for a NURBS Patch from 2D arrays of coordinates and degrees
    *
    * \param [in] pts A 2D axom::Array of (npts_u, npts_v) control points
-   * \param [in] deg_u The patch's degree on the first axis
-   * \param [in] deg_v The patch's degree on the second axis
+   * \param [in] deg_u, deg_v The patch's degree on the first and second axis
    * \pre Requires that npts_d >= deg_d + 1 and deg_d >= 0 for d = u, v
-   *
-   * The knot vectors are constructed such that the patch is uniform
    */
   NURBSPatch(const CoordsMat& pts, int deg_u, int deg_v)
     : NURBSPatch(pts.view(),
@@ -350,11 +360,8 @@ public:
    *
    * \param [in] pts A 2D axom::Array of (ord_u+1, ord_v+1) control points
    * \param [in] weights A 2D axom::Array of (ord_u+1, ord_v+1) positive weights
-   * \param [in] deg_u The patch's degree on the first axis
-   * \param [in] deg_v The patch's degree on the second axis
+   * \param [in] deg_u, deg_v The patch's degree on the first and second axis
    * \pre Requires that npts_d >= deg_d + 1 and deg_d >= 0 for d = u, v
-   *
-   * The knot vectors are constructed such that the patch is uniform
    */
   NURBSPatch(const CoordsMat& pts, const WeightsMat& weights, int deg_u, int deg_v)
     : NURBSPatch(pts.view(),
@@ -367,16 +374,13 @@ public:
    * \brief Constructor for a NURBS Patch from C-style arrays of coordinates and knot vectors
    *
    * \param [in] pts A 1D C-style array of npts_u*npts_v control points
-   * \param [in] npts_u The number of control points on the first axis
-   * \param [in] npts_v The number of control points on the second axis
+   * \param [in] npts_u, npts_v The number of control points on the first and second axis
    * \param [in] knots_u A 1D C-style array of npts_u + deg_u + 1 knots
    * \param [in] nkts_u The number of knots in the u direction
    * \param [in] knots_v A 1D C-style array of npts_v + deg_v + 1 knots
    * \param [in] nkts_v The number of knots in the v direction
    * 
-   * For clamped and continuous curves, npts and the knot vector 
-   *   uniquely determine the degree
-   * 
+   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
    * \pre Requires valid pointers and knot vectors
    */
   NURBSPatch(const PointType* pts,
@@ -397,16 +401,13 @@ public:
    *
    * \param [in] pts A 1D C-style array of npts_u*npts_v control points
    * \param [in] weights A 1D C-style array of npts_u*npts_v positive weights
-   * \param [in] npts_u The number of control points on the first axis
-   * \param [in] npts_v The number of control points on the second axis
+   * \param [in] npts_u, npts_v The number of control points on the first and second axis
    * \param [in] knots_u A 1D C-style array of npts_u + deg_u + 1 knots
    * \param [in] nkts_u The number of knots in the u direction
    * \param [in] knots_v A 1D C-style array of npts_v + deg_v + 1 knots
    * \param [in] nkts_v The number of knots in the v direction
    * 
-   * For clamped and continuous curves, npts and the knot vector 
-   *   uniquely determine the degree
-   * 
+   * For clamped and continuous curves, npts and the knot vector  uniquely determine the degree
    * \pre Requires valid pointers and knot vectors
    */
   NURBSPatch(const PointType* pts,
@@ -427,14 +428,11 @@ public:
    * \brief Constructor for a NURBS Patch from 1D axom::Array arrays of coordinates and knots
    *
    * \param [in] pts A 1D axom::Array of npts_u*npts_v control points
-   * \param [in] npts_u The number of control points on the first axis
-   * \param [in] npts_v The number of control points on the second axis
+   * \param [in] npts_u, npts_v The number of control points on the first and second axis
    * \param [in] knots_u An axom::Array of npts_u + deg_u + 1 knots
    * \param [in] knots_v An axom::Array of npts_v + deg_v + 1 knots
    * 
-   * For clamped and continuous curves, npts and the knot vector 
-   *   uniquely determine the degree
-   * 
+   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsVec& pts,
@@ -453,14 +451,11 @@ public:
    *
    * \param [in] pts A 1D axom::Array of npts_u*npts_v control points
    * \param [in] weights A 1D axom::Array of npts_u*npts_v positive weights
-   * \param [in] npts_u The number of control points on the first axis
-   * \param [in] npts_v The number of control points on the second axis
+   * \param [in] npts_u, npts_v The number of control points on the first and second axis
    * \param [in] knots_u An axom::Array of npts_u + deg_u + 1 knots
    * \param [in] knots_v An axom::Array of npts_v + deg_v + 1 knots
    * 
-   * For clamped and continuous curves, npts and the knot vector 
-   *   uniquely determine the degree
-   * 
+   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsVec& pts,
@@ -479,14 +474,10 @@ public:
    * \brief Constructor for a NURBS Patch from 1D axom::Array arrays of coordinates and KnotVectors
    *
    * \param [in] pts A 1D axom::Array of npts_u*npts_v control points
-   * \param [in] npts_u The number of control points on the first axis
-   * \param [in] npts_v The number of control points on the second axis
-   * \param [in] knotvec_u An KnotVector object for the first axis
-   * \param [in] knotvec_v An KnotVector object for the second axis
+   * \param [in] npts_u, npts_v The number of control points on the first and second axis
+   * \param [in] knotvec_u, knotvec_v  KnotVector objects for the first and second axis
    * 
-   * For clamped and continuous curves, npts and the knot vector 
-   *   uniquely determine the degree
-   * 
+   * For clamped and continuous curves, npts and the knot vectoruniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsVec& pts,
@@ -505,14 +496,10 @@ public:
    *
    * \param [in] pts A 1D axom::Array of npts_u*npts_v control points
    * \param [in] weights A 1D axom::Array of npts_u*npts_v positive weights
-   * \param [in] npts_u The number of control points on the first axis
-   * \param [in] npts_v The number of control points on the second axis
-   * \param [in] knotvec_u An KnotVector object for the first axis
-   * \param [in] knotvec_v An KnotVector object for the second axis
+   * \param [in] npts_u, npts_v The number of control points on the first and second axis
+   * \param [in] knotvec_u, knotvec_v KnotVector objects for the first and second axis
    * 
-   * For clamped and continuous curves, npts and the knot vector 
-   *   uniquely determine the degree
-   * 
+   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsVec& pts,
@@ -534,9 +521,7 @@ public:
    * \param [in] knots_u An axom::Array of npts_u + deg_u + 1 knots
    * \param [in] knots_v An axom::Array of npts_v + deg_v + 1 knots
    * 
-   * For clamped and continuous curves, npts and the knot vector 
-   *   uniquely determine the degree
-   * 
+   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsMat& pts, const axom::Array<T>& knots_u, const axom::Array<T>& knots_v)
@@ -554,9 +539,7 @@ public:
    * \param [in] knots_u An axom::Array of npts_u + deg_u + 1 knots
    * \param [in] knots_v An axom::Array of npts_v + deg_v + 1 knots
    * 
-   * For clamped and continuous curves, npts and the knot vector 
-   *   uniquely determine the degree
-   * 
+   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsMat& pts,
@@ -573,12 +556,9 @@ public:
    * \brief Constructor for a NURBS Patch from 1D axom::Array array of coordinates and KnotVector objects
    *
    * \param [in] pts A 2D axom::Array of (ord_u+1, ord_v+1) control points
-   * \param [in] knotvec_u A KnotVector object for the first axis
-   * \param [in] knotvec_v A KnotVector object for the second axis
+   * \param [in] knotvec_u, knotvec_v KnotVector objects for the first and second axis
    * 
-   * For clamped and continuous curves, npts and the knot vector 
-   *   uniquely determine the degree
-   * 
+   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsMat& pts, const KnotVectorType& knotvec_u, const KnotVectorType& knotvec_v)
@@ -590,12 +570,9 @@ public:
    *
    * \param [in] pts A 2D axom::Array of (ord_u+1, ord_v+1) control points
    * \param [in] weights A 2D axom::Array of (ord_u+1, ord_v+1) positive weights
-   * \param [in] knotvec_u A KnotVector object for the first axis
-   * \param [in] knotvec_v A KnotVector object for the second axis
+   * \param [in] knotvec_u, knotvec_v KnotVector objects for the first and second axis
    * 
-   * For clamped and continuous curves, npts and the knot vector 
-   *   uniquely determine the degree
-   * 
+   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsMat& pts,
@@ -610,10 +587,8 @@ public:
   /*!
    * \brief Reset the degree and resize arrays of points (and weights)
    * 
-   * \param [in] npts_u The target number of control points on the first axis
-   * \param [in] npts_v The target number of control points on the second axis
-   * \param [in] deg_u The target degree on the first axis
-   * \param [in] deg_v The target degree on the second axis
+   * \param [in] npts_u, npts_v The target number of control points on the first and second axis
+   * \param [in] deg_u, deg_v The target degrees on the first and second axis
    * 
    * \warning This method will replace existing knot vectors with a uniform one.
    */

--- a/src/axom/primal/geometry/NURBSPatch.hpp
+++ b/src/axom/primal/geometry/NURBSPatch.hpp
@@ -93,42 +93,40 @@ public:
                          "A NURBS Patch must be defined using an arithmetic type");
 
 public:
+  //@{
+  /**
+   * @name Constructors for NURBSPatch
+   *
+   * The NURBSPatch class provides a variety of constructors to support flexible initialization.
+   * The default constructor creates an empty, invalid patch. Other constructors allow you to specify
+   * degrees, control point counts, knot vectors, and weights, either using C-style arrays or axom::Array
+   * containers, in both 1D and 2D forms. You can also construct a NURBSPatch from a BezierPatch.
+   *
+   * Depending on the constructor used, the resulting instance will have:
+   * - Control points and weights arrays sized according to the provided parameters.
+   * - Knot vectors initialized either as uniform (for degree/size-based constructors) or from provided arrays/objects.
+   * - Rationality determined by the presence of weights (patches are rational if weights are provided, nonrational otherwise).
+   * - Trimming curves are always empty and the patch is untrimmed by default.
+   *
+   * All constructors ensure that the patch is internally consistent and valid, provided the input parameters are valid.
+   */
+
   /*! 
    * \brief Default constructor for an empty (invalid) NURBS patch
    *
    * \note An empty NURBS patch is not valid
    */
-  NURBSPatch()
-  {
-    m_controlPoints.resize(0, 0);
-    m_knotvec_u = KnotVectorType();
-    m_knotvec_v = KnotVectorType();
-
-    makeNonrational();
-    makeUntrimmed();
-  }
+  NURBSPatch() : NURBSPatch(0, 0, -1, -1) { }
 
   /*!
    * \brief Constructor for a simple NURBS surface that reserves space for
    *  the minimum (sensible) number of points for the given degrees
-   *
-   * Constructs an empty patch by default (no nodes/weights on either axis)
    * 
    * \param [in] deg_u The patch's degree on the first axis
    * \param [in] deg_v The patch's degree on the second axis
-   * \pre deg_u, deg_v greater than or equal to 0.
+   * \pre deg_u, deg_v both greater than or equal to 0, or both -1
    */
-  NURBSPatch(int deg_u, int deg_v)
-  {
-    SLIC_ASSERT(deg_u >= 0 && deg_v >= 0);
-
-    m_controlPoints.resize(deg_u + 1, deg_v + 1);
-    m_knotvec_u = KnotVectorType(deg_u + 1, deg_u);
-    m_knotvec_v = KnotVectorType(deg_v + 1, deg_v);
-
-    makeNonrational();
-    makeUntrimmed();
-  }
+  NURBSPatch(int deg_u, int deg_v) : NURBSPatch(deg_u + 1, deg_v + 1, deg_u, deg_v) { }
 
   /*!
    * \brief Constructor for an empty NURBS surface from its size
@@ -141,16 +139,19 @@ public:
    * \pre Requires npts_d > deg_d and deg_d >= 0 for d = u, v 
    */
   NURBSPatch(int npts_u, int npts_v, int deg_u, int deg_v)
+    : m_knotvec_u(npts_u, deg_u)
+    , m_knotvec_v(npts_v, deg_v)
   {
-    SLIC_ASSERT(npts_u > deg_u && npts_v > deg_v);
-    SLIC_ASSERT(deg_u >= 0 && deg_v >= 0);
-
-    m_controlPoints.resize(npts_u, npts_v);
-    m_knotvec_u = KnotVectorType(npts_u, deg_u);
-    m_knotvec_v = KnotVectorType(npts_v, deg_v);
-
-    makeNonrational();
-    makeUntrimmed();
+    if(const bool is_empty = (deg_u == -1 && deg_v == -1); is_empty)
+    {
+      SLIC_ASSERT(npts_u == 0 && npts_v == 0);
+    }
+    else
+    {
+      SLIC_ASSERT(deg_u >= 0 && deg_v >= 0);
+      SLIC_ASSERT(npts_u > deg_u && npts_v > deg_v);
+      m_controlPoints.resize(npts_u, npts_v);
+    }
   }
 
   /*!
@@ -159,18 +160,83 @@ public:
    * \param [in] bezierPatch the Bezier patch to convert to a NURBS patch 
    */
   explicit NURBSPatch(const BezierPatch<T, NDIMS>& bezierPatch)
+    : NURBSPatch(bezierPatch.getControlPoints(),
+                 bezierPatch.getWeights(),
+                 KnotVectorType(bezierPatch.getOrder_u() + 1, bezierPatch.getOrder_u()),
+                 KnotVectorType(bezierPatch.getOrder_v() + 1, bezierPatch.getOrder_v()))
+  { }
+
+  NURBSPatch(ArrayView<const PointType, 2> controlPoints,
+             ArrayView<const T, 2> weights,
+             const KnotVectorType& knotVector_u,
+             const KnotVectorType& knotVector_v)
+    : m_knotvec_u(knotVector_u)
+    , m_knotvec_v(knotVector_v)
   {
-    m_controlPoints = bezierPatch.getControlPoints();
-    m_weights = bezierPatch.getWeights();
+    const int deg_u = m_knotvec_u.getDegree();
+    const int deg_v = m_knotvec_v.getDegree();
 
-    int deg_u = bezierPatch.getOrder_u();
-    int deg_v = bezierPatch.getOrder_v();
+    SLIC_ASSERT(deg_u >= -1 && deg_v >= -1);
+    if(const bool is_empty = (deg_u == -1 && deg_v == -1); is_empty)
+    {
+      SLIC_ASSERT(controlPoints.empty());
+      SLIC_ASSERT(weights.empty());
+    }
+    else
+    {
+      SLIC_ASSERT(deg_u >= 0 && deg_v >= 0);
+      const int npts_u = knotVector_u.getNumControlPoints();
+      const int npts_v = knotVector_v.getNumControlPoints();
+      SLIC_ASSERT(npts_u > deg_u && npts_v > deg_v);
 
-    m_knotvec_u = KnotVectorType(deg_u + 1, deg_u);
-    m_knotvec_v = KnotVectorType(deg_v + 1, deg_v);
+      if(controlPoints.empty())
+      {
+        m_controlPoints.resize(npts_u, npts_v);
+      }
+      else
+      {
+        SLIC_ASSERT(controlPoints.data() != nullptr);
+        SLIC_ASSERT(controlPoints.shape()[0] == npts_u);
+        SLIC_ASSERT(controlPoints.shape()[1] == npts_v);
+        m_controlPoints = controlPoints;
+      }
 
-    makeUntrimmed();
+      if(!weights.empty())
+      {
+        SLIC_ASSERT(weights.data() != nullptr);
+        SLIC_ASSERT(weights.shape()[0] == npts_u);
+        SLIC_ASSERT(weights.shape()[1] == npts_v);
+        m_weights = weights;
+      }
+
+      SLIC_ASSERT(isValidNURBS());
+    }
   }
+
+  NURBSPatch(ArrayView<const PointType, 2> controlPoints,
+             const KnotVectorType& knotVector_u,
+             const KnotVectorType& knotVector_v)
+    : NURBSPatch(controlPoints, axom::ArrayView<const T, 2>(nullptr, {{0, 0}}), knotVector_u, knotVector_v)
+  { }
+
+  NURBSPatch(ArrayView<PointType, 2> controlPoints,
+             const KnotVectorType& knotVector_u,
+             const KnotVectorType& knotVector_v)
+    : NURBSPatch(axom::ArrayView<const PointType, 2>(controlPoints.data(), controlPoints.shape()),
+                 axom::ArrayView<const T, 2>(nullptr, {{0, 0}}),
+                 knotVector_u,
+                 knotVector_v)
+  { }
+
+  NURBSPatch(ArrayView<PointType, 2> controlPoints,
+             ArrayView<T, 2> weights,
+             const KnotVectorType& knotVector_u,
+             const KnotVectorType& knotVector_v)
+    : NURBSPatch(axom::ArrayView<const PointType, 2>(controlPoints.data(), controlPoints.shape()),
+                 axom::ArrayView<const T, 2>(weights.data(), weights.shape()),
+                 knotVector_u,
+                 knotVector_v)
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from an array of coordinates and degrees
@@ -188,25 +254,11 @@ public:
    * pts[k] = nodes[ k // (npts_u + 1), k % npts_v ]
    */
   NURBSPatch(const PointType* pts, int npts_u, int npts_v, int deg_u, int deg_v)
-  {
-    SLIC_ASSERT(pts != nullptr);
-    SLIC_ASSERT(npts_u >= deg_u + 1 && npts_v >= deg_v + 1);
-    SLIC_ASSERT(deg_u >= 0 && deg_v >= 0);
-
-    m_controlPoints.resize(npts_u, npts_v);
-    for(int t = 0; t < npts_u * npts_v; ++t)
-    {
-      m_controlPoints.flatIndex(t) = pts[t];
-    }
-
-    makeNonrational();
-    makeUntrimmed();
-
-    m_knotvec_u = KnotVectorType(npts_u, deg_u);
-    m_knotvec_v = KnotVectorType(npts_v, deg_v);
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSPatch(axom::ArrayView<const PointType, 2>(pts, {{npts_u, npts_v}}),
+                 axom::ArrayView<const T, 2>(nullptr, {{0, 0}}),
+                 KnotVectorType(npts_u, deg_u),
+                 KnotVectorType(npts_v, deg_v))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from arrays of coordinates and weights
@@ -225,31 +277,11 @@ public:
    * pts[k] = nodes[ k // (npts_u + 1), k % npts_v ]
    */
   NURBSPatch(const PointType* pts, const T* weights, int npts_u, int npts_v, int deg_u, int deg_v)
-  {
-    SLIC_ASSERT(pts != nullptr);
-    SLIC_ASSERT(weights != nullptr);
-    SLIC_ASSERT(npts_u >= deg_u + 1 && npts_v >= deg_v + 1);
-    SLIC_ASSERT(deg_u >= 0 && deg_v >= 0);
-
-    m_controlPoints.resize(npts_u, npts_v);
-    for(int t = 0; t < npts_u * npts_v; ++t)
-    {
-      m_controlPoints.flatIndex(t) = pts[t];
-    }
-
-    m_weights.resize(npts_u, npts_v);
-    for(int t = 0; t < npts_u * npts_v; ++t)
-    {
-      m_weights.flatIndex(t) = weights[t];
-    }
-
-    m_knotvec_u = KnotVectorType(npts_u, deg_u);
-    m_knotvec_v = KnotVectorType(npts_v, deg_v);
-
-    makeUntrimmed();
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSPatch(axom::ArrayView<const PointType, 2>(pts, {{npts_u, npts_v}}),
+                 axom::ArrayView<const T, 2>(weights, {{weights ? npts_u : 0, weights ? npts_v : 0}}),
+                 KnotVectorType(npts_u, deg_u),
+                 KnotVectorType(npts_v, deg_v))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from 1D arrays of coordinates and degrees
@@ -267,24 +299,11 @@ public:
    * pts[k] = nodes[ k // (npts_u + 1), k % npts_v ]
    */
   NURBSPatch(const CoordsVec& pts, int npts_u, int npts_v, int deg_u, int deg_v)
-  {
-    SLIC_ASSERT(npts_u >= deg_u + 1 && npts_v >= deg_v + 1);
-    SLIC_ASSERT(deg_u >= 0 && deg_v >= 0);
-
-    m_controlPoints.resize(npts_u, npts_v);
-    for(int t = 0; t < pts.size(); ++t)
-    {
-      m_controlPoints.flatIndex(t) = pts[t];
-    }
-
-    makeNonrational();
-    makeUntrimmed();
-
-    m_knotvec_u = KnotVectorType(npts_u, deg_u);
-    m_knotvec_v = KnotVectorType(npts_v, deg_v);
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSPatch(axom::ArrayView<const PointType, 2>(pts.data(), {{npts_u, npts_v}}),
+                 axom::ArrayView<const T, 2>(nullptr, {{0, 0}}),
+                 KnotVectorType(npts_u, deg_u),
+                 KnotVectorType(npts_v, deg_v))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from 1D arrays of coordinates and weights
@@ -303,29 +322,11 @@ public:
    * pts[k] = nodes[ k // (npts_u + 1), k % npts_v ]
    */
   NURBSPatch(const CoordsVec& pts, const WeightsVec& weights, int npts_u, int npts_v, int deg_u, int deg_v)
-  {
-    SLIC_ASSERT(npts_u > deg_u && npts_v > deg_v);
-    SLIC_ASSERT(deg_u >= 0 && deg_v >= 0);
-
-    m_controlPoints.resize(npts_u, npts_v);
-    for(int t = 0; t < pts.size(); ++t)
-    {
-      m_controlPoints.flatIndex(t) = pts[t];
-    }
-
-    m_weights.resize(npts_u, npts_v);
-    for(int t = 0; t < weights.size(); ++t)
-    {
-      m_weights.flatIndex(t) = weights[t];
-    }
-
-    m_knotvec_u = KnotVectorType(npts_u, deg_u);
-    m_knotvec_v = KnotVectorType(npts_v, deg_v);
-
-    makeUntrimmed();
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSPatch(axom::ArrayView<const PointType, 2>(pts.data(), {{npts_u, npts_v}}),
+                 axom::ArrayView<const T, 2>(weights.data(), {{npts_u, npts_v}}),
+                 KnotVectorType(npts_u, deg_u),
+                 KnotVectorType(npts_v, deg_v))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from 2D arrays of coordinates and degrees
@@ -337,21 +338,12 @@ public:
    *
    * The knot vectors are constructed such that the patch is uniform
    */
-  NURBSPatch(const CoordsMat& pts, int deg_u, int deg_v) : m_controlPoints(pts)
-  {
-    const auto pts_shape = pts.shape();
-
-    SLIC_ASSERT(pts_shape[0] >= deg_u + 1 && pts_shape[1] >= deg_v + 1);
-    SLIC_ASSERT(deg_u >= 0 && deg_v >= 0);
-
-    makeNonrational();
-    makeUntrimmed();
-
-    m_knotvec_u = KnotVectorType(pts_shape[0], deg_u);
-    m_knotvec_v = KnotVectorType(pts_shape[1], deg_v);
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+  NURBSPatch(const CoordsMat& pts, int deg_u, int deg_v)
+    : NURBSPatch(pts.view(),
+                 axom::ArrayView<const T, 2>(nullptr, {{0, 0}}),
+                 KnotVectorType(pts.shape()[0], deg_u),
+                 KnotVectorType(pts.shape()[1], deg_v))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from 2D arrays of coordinates and weights
@@ -365,22 +357,11 @@ public:
    * The knot vectors are constructed such that the patch is uniform
    */
   NURBSPatch(const CoordsMat& pts, const WeightsMat& weights, int deg_u, int deg_v)
-    : m_controlPoints(pts)
-    , m_weights(weights)
-  {
-    const auto pts_shape = pts.shape();
-
-    SLIC_ASSERT(deg_u >= 0 && deg_v >= 0);
-    SLIC_ASSERT(pts_shape[0] >= deg_u + 1 && pts_shape[1] >= deg_v + 1);
-    SLIC_ASSERT(pts_shape == weights.shape());
-
-    m_knotvec_u = KnotVectorType(pts_shape[0], deg_u);
-    m_knotvec_v = KnotVectorType(pts_shape[1], deg_v);
-
-    makeUntrimmed();
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSPatch(pts.view(),
+                 weights.view(),
+                 KnotVectorType(pts.shape()[0], deg_u),
+                 KnotVectorType(pts.shape()[1], deg_v))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from C-style arrays of coordinates and knot vectors
@@ -405,25 +386,11 @@ public:
              int nkts_u,
              const T* knots_v,
              int nkts_v)
-  {
-    SLIC_ASSERT(pts != nullptr && knots_u != nullptr && knots_v != nullptr);
-    SLIC_ASSERT(npts_u >= 0 && npts_v >= 0);
-    SLIC_ASSERT(nkts_u >= 0 && nkts_v >= 0);
-
-    m_controlPoints.resize(npts_u, npts_v);
-    for(int t = 0; t < npts_u * npts_v; ++t)
-    {
-      m_controlPoints.flatIndex(t) = pts[t];
-    }
-
-    makeNonrational();
-    makeUntrimmed();
-
-    m_knotvec_u = KnotVectorType(knots_u, nkts_u, nkts_u - npts_u - 1);
-    m_knotvec_v = KnotVectorType(knots_v, nkts_v, nkts_v - npts_v - 1);
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSPatch(axom::ArrayView<const PointType, 2>(pts, {{npts_u, npts_v}}),
+                 axom::ArrayView<const T, 2>(nullptr, {{0, 0}}),
+                 KnotVectorType(axom::ArrayView(knots_u, nkts_u), nkts_u - npts_u - 1),
+                 KnotVectorType(axom::ArrayView(knots_v, nkts_v), nkts_v - npts_v - 1))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from C-style arrays of coordinates and weights
@@ -450,30 +417,11 @@ public:
              int nkts_u,
              const T* knots_v,
              int nkts_v)
-  {
-    SLIC_ASSERT(pts != nullptr && weights != nullptr && knots_u != nullptr && knots_v != nullptr);
-    SLIC_ASSERT(npts_u >= 0 && npts_v >= 0);
-    SLIC_ASSERT(nkts_u >= 0 && nkts_v >= 0);
-
-    m_controlPoints.resize(npts_u, npts_v);
-    for(int t = 0; t < npts_u * npts_v; ++t)
-    {
-      m_controlPoints.flatIndex(t) = pts[t];
-    }
-
-    m_weights.resize(npts_u, npts_v);
-    for(int t = 0; t < npts_u * npts_v; ++t)
-    {
-      m_weights.flatIndex(t) = weights[t];
-    }
-
-    m_knotvec_u = KnotVectorType(knots_u, nkts_u, nkts_u - npts_u - 1);
-    m_knotvec_v = KnotVectorType(knots_v, nkts_v, nkts_v - npts_v - 1);
-
-    makeUntrimmed();
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSPatch(axom::ArrayView<const PointType, 2>(pts, {{npts_u, npts_v}}),
+                 axom::ArrayView<const T, 2>(weights, {{weights ? npts_u : 0, weights ? npts_v : 0}}),
+                 KnotVectorType(axom::ArrayView(knots_u, nkts_u), nkts_u - npts_u - 1),
+                 KnotVectorType(axom::ArrayView(knots_v, nkts_v), nkts_v - npts_v - 1))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from 1D axom::Array arrays of coordinates and knots
@@ -494,23 +442,11 @@ public:
              int npts_v,
              const axom::Array<T>& knots_u,
              const axom::Array<T>& knots_v)
-  {
-    SLIC_ASSERT(npts_u >= 0 && npts_v >= 0);
-
-    m_controlPoints.resize(npts_u, npts_v);
-    for(int t = 0; t < pts.size(); ++t)
-    {
-      m_controlPoints.flatIndex(t) = pts[t];
-    }
-
-    makeNonrational();
-    makeUntrimmed();
-
-    m_knotvec_u = KnotVectorType(knots_u, knots_u.size() - npts_u - 1);
-    m_knotvec_v = KnotVectorType(knots_v, knots_v.size() - npts_v - 1);
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSPatch(axom::ArrayView<const PointType, 2>(pts.data(), {{npts_u, npts_v}}),
+                 axom::ArrayView<const T, 2>(nullptr, {{0, 0}}),
+                 KnotVectorType(knots_u.view(), knots_u.size() - npts_u - 1),
+                 KnotVectorType(knots_v.view(), knots_v.size() - npts_v - 1))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from 1D axom::Array arrays of coordinates, weights, and knots
@@ -533,28 +469,11 @@ public:
              int npts_v,
              const axom::Array<T>& knots_u,
              const axom::Array<T>& knots_v)
-  {
-    SLIC_ASSERT(npts_u >= 0 && npts_v >= 0);
-
-    m_controlPoints.resize(npts_u, npts_v);
-    for(int t = 0; t < pts.size(); ++t)
-    {
-      m_controlPoints.flatIndex(t) = pts[t];
-    }
-
-    m_weights.resize(npts_u, npts_v);
-    for(int t = 0; t < weights.size(); ++t)
-    {
-      m_weights.flatIndex(t) = weights[t];
-    }
-
-    m_knotvec_u = KnotVectorType(knots_u, knots_u.size() - npts_u - 1);
-    m_knotvec_v = KnotVectorType(knots_v, knots_v.size() - npts_v - 1);
-
-    makeUntrimmed();
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSPatch(axom::ArrayView<const PointType, 2>(pts.data(), {{npts_u, npts_v}}),
+                 axom::ArrayView<const T, 2>(weights.data(), {{npts_u, npts_v}}),
+                 KnotVectorType(knots_u.view(), knots_u.size() - npts_u - 1),
+                 KnotVectorType(knots_v.view(), knots_v.size() - npts_v - 1))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from 1D axom::Array arrays of coordinates and KnotVectors
@@ -575,22 +494,11 @@ public:
              int npts_v,
              const KnotVectorType& knotvec_u,
              const KnotVectorType& knotvec_v)
-    : m_knotvec_u(knotvec_u)
-    , m_knotvec_v(knotvec_v)
-  {
-    SLIC_ASSERT(npts_u >= 0 && npts_v >= 0);
-
-    m_controlPoints.resize(npts_u, npts_v);
-    for(int t = 0; t < pts.size(); ++t)
-    {
-      m_controlPoints.flatIndex(t) = pts[t];
-    }
-
-    makeNonrational();
-    makeUntrimmed();
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSPatch(axom::ArrayView<const PointType, 2>(pts.data(), {{npts_u, npts_v}}),
+                 axom::ArrayView<const T, 2>(nullptr, {{0, 0}}),
+                 knotvec_u,
+                 knotvec_v)
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from 1D axom::Array arrays of coordinates, weights, and KnotVectors
@@ -613,27 +521,11 @@ public:
              int npts_v,
              const KnotVectorType& knotvec_u,
              const KnotVectorType& knotvec_v)
-    : m_knotvec_u(knotvec_u)
-    , m_knotvec_v(knotvec_v)
-  {
-    SLIC_ASSERT(npts_u >= 0 && npts_v >= 0);
-
-    m_controlPoints.resize(npts_u, npts_v);
-    for(int t = 0; t < pts.size(); ++t)
-    {
-      m_controlPoints.flatIndex(t) = pts[t];
-    }
-
-    m_weights.resize(npts_u, npts_v);
-    for(int t = 0; t < weights.size(); ++t)
-    {
-      m_weights.flatIndex(t) = weights[t];
-    }
-
-    makeUntrimmed();
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSPatch(axom::ArrayView<const PointType, 2>(pts.data(), {{npts_u, npts_v}}),
+                 axom::ArrayView<const T, 2>(weights.data(), {{npts_u, npts_v}}),
+                 knotvec_u,
+                 knotvec_v)
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from 2D axom::Array array of coordinates and array of knots
@@ -648,20 +540,11 @@ public:
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsMat& pts, const axom::Array<T>& knots_u, const axom::Array<T>& knots_v)
-    : m_controlPoints(pts)
-  {
-    auto pts_shape = pts.shape();
-
-    SLIC_ASSERT(pts_shape[0] >= 0 && pts_shape[1] >= 0);
-
-    makeNonrational();
-    makeUntrimmed();
-
-    m_knotvec_u = KnotVectorType(knots_u, knots_u.size() - pts_shape[0] - 1);
-    m_knotvec_v = KnotVectorType(knots_v, knots_v.size() - pts_shape[1] - 1);
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSPatch(pts.view(),
+                 axom::ArrayView<const T, 2>(nullptr, {{0, 0}}),
+                 KnotVectorType(knots_u.view(), knots_u.size() - pts.shape()[0] - 1),
+                 KnotVectorType(knots_v.view(), knots_v.size() - pts.shape()[1] - 1))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from 2D axom::Array array of coordinates, weights, and array of knots
@@ -680,20 +563,11 @@ public:
              const WeightsMat& weights,
              const axom::Array<T>& knots_u,
              const axom::Array<T>& knots_v)
-    : m_controlPoints(pts)
-    , m_weights(weights)
-  {
-    auto pts_shape = pts.shape();
-
-    SLIC_ASSERT(pts_shape[0] >= 0 && pts_shape[1] >= 0);
-
-    m_knotvec_u = KnotVectorType(knots_u, knots_u.size() - pts_shape[0] - 1);
-    m_knotvec_v = KnotVectorType(knots_v, knots_v.size() - pts_shape[1] - 1);
-
-    makeUntrimmed();
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSPatch(pts.view(),
+                 weights.view(),
+                 KnotVectorType(knots_u.view(), knots_u.size() - pts.shape()[0] - 1),
+                 KnotVectorType(knots_v.view(), knots_v.size() - pts.shape()[1] - 1))
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from 1D axom::Array array of coordinates and KnotVector objects
@@ -708,15 +582,8 @@ public:
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsMat& pts, const KnotVectorType& knotvec_u, const KnotVectorType& knotvec_v)
-    : m_controlPoints(pts)
-    , m_knotvec_u(knotvec_u)
-    , m_knotvec_v(knotvec_v)
-  {
-    makeNonrational();
-    makeUntrimmed();
-
-    SLIC_ASSERT(isValidNURBS());
-  }
+    : NURBSPatch(pts.view(), axom::ArrayView<const T, 2>(nullptr, {{0, 0}}), knotvec_u, knotvec_v)
+  { }
 
   /*!
    * \brief Constructor for a NURBS Patch from 2D axom::Array array of coordinates, weights, and KnotVector objects
@@ -735,15 +602,10 @@ public:
              const WeightsMat& weights,
              const KnotVectorType& knotvec_u,
              const KnotVectorType& knotvec_v)
-    : m_controlPoints(pts)
-    , m_weights(weights)
-    , m_knotvec_u(knotvec_u)
-    , m_knotvec_v(knotvec_v)
-  {
-    makeUntrimmed();
+    : NURBSPatch(pts.view(), weights.view(), knotvec_u, knotvec_v)
+  { }
 
-    SLIC_ASSERT(isValidNURBS());
-  }
+  //@}
 
   /*!
    * \brief Reset the degree and resize arrays of points (and weights)
@@ -3652,13 +3514,6 @@ public:
   bool isValidInteriorParameter(T t) const { return m_knotvec_u.isValidInteriorParameter(t); }
 
 private:
-  CoordsMat m_controlPoints;
-  WeightsMat m_weights;
-  KnotVectorType m_knotvec_u, m_knotvec_v;
-
-  bool m_isTrimmed;
-  TrimmingCurveVec m_trimmingCurves;
-
   /// \brief Private function to rescale trimming curves from (a, b) to (c, d) in x
   /// \warning Does not check that the resulting curves are valid
   void rescaleTrimmingCurves_u(T a, T b, T c, T d)
@@ -3998,6 +3853,14 @@ private:
       outCurvesSecond.push_back(line);
     }
   }
+
+private:
+  CoordsMat m_controlPoints;
+  WeightsMat m_weights;
+  KnotVectorType m_knotvec_u, m_knotvec_v;
+
+  bool m_isTrimmed {false};
+  TrimmingCurveVec m_trimmingCurves;
 };
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/geometry/NURBSPatch.hpp
+++ b/src/axom/primal/geometry/NURBSPatch.hpp
@@ -93,7 +93,7 @@ public:
                          "A NURBS Patch must be defined using an arithmetic type");
 
 public:
-  //@{
+  ///@{
   /**
    * @name Constructors for NURBSPatch
    *
@@ -582,7 +582,7 @@ public:
     : NURBSPatch(pts.view(), weights.view(), knotvec_u, knotvec_v)
   { }
 
-  //@}
+  ///@}
 
   /*!
    * \brief Reset the degree and resize arrays of points (and weights)
@@ -931,7 +931,7 @@ public:
     return OrientedBoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
   }
 
-  //@{
+  ///@{
   //!  @name Methods for (untrimmed) Patch Parameterization.
   //!
   //! These methods operate on the parameterization of the patch
@@ -1483,9 +1483,9 @@ public:
 
     m_knotvec_v.rescale(a, b);
   }
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Methods for (untrimmed) Patch Geometry.
   //!
   //! These methods operate only on the geometry of the patch
@@ -2476,9 +2476,9 @@ public:
     return ret_vec;
   }
 #endif
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Methods for (trimmed) Surface Geometry.
   //!
   //! These methods operate on the visible geometry of the NURBS surface
@@ -3357,7 +3357,7 @@ public:
     m_knotvec_u = KnotVectorType(newKnotVec_u, deg_u);
     m_knotvec_v = KnotVectorType(newKnotVec_v, deg_v);
   }
-  //@}
+  ///@}
 
   /*!
      * \brief Simple formatted print of a NURBS Patch instance

--- a/src/axom/primal/operators/winding_number.hpp
+++ b/src/axom/primal/operators/winding_number.hpp
@@ -254,7 +254,7 @@ double winding_number(const Point<T, 2>& q,
   return ret_val;
 }
 
-//@{
+///@{
 //! @name Winding number operations between 3D points and primitives
 
 /*!
@@ -648,7 +648,7 @@ axom::Array<double> winding_number(const axom::Array<Point<T, 3>>& query_arr,
   return ret_val;
 }
 #endif
-//@}
+///@}
 
 }  // namespace primal
 }  // namespace axom

--- a/src/axom/primal/tests/primal_bezier_curve.cpp
+++ b/src/axom/primal/tests/primal_bezier_curve.cpp
@@ -18,7 +18,7 @@
 namespace primal = axom::primal;
 
 //------------------------------------------------------------------------------
-TEST(primal_beziercurve, constructor)
+TEST(primal_beziercurve, sizing_constructors)
 {
   constexpr int DIM = 3;
   using CoordType = double;

--- a/src/axom/primal/tests/primal_bezier_curve.cpp
+++ b/src/axom/primal/tests/primal_bezier_curve.cpp
@@ -20,28 +20,132 @@ namespace primal = axom::primal;
 //------------------------------------------------------------------------------
 TEST(primal_beziercurve, constructor)
 {
-  const int DIM = 3;
+  constexpr int DIM = 3;
   using CoordType = double;
   using BezierCurveType = primal::BezierCurve<CoordType, DIM>;
   using CoordsVec = BezierCurveType::CoordsVec;
 
+  // Testing default BezierCurve constructor w/ ord -1
   {
-    SLIC_INFO("Testing default BezierCurve constructor ");
     BezierCurveType bCurve;
 
-    int expOrder = -1;
+    constexpr int expOrder = -1;
     EXPECT_EQ(expOrder, bCurve.getOrder());
     EXPECT_EQ(expOrder + 1, bCurve.getControlPoints().size());
     EXPECT_EQ(CoordsVec(), bCurve.getControlPoints());
+    EXPECT_FALSE(bCurve.isRational());
   }
 
+  // Testing BezierCurve constructor w/ different orders
+  for(int ord = -1; ord < 4; ++ord)
   {
-    SLIC_INFO("Testing BezierCurve order constructor ");
+    BezierCurveType bCurve(ord);
+    EXPECT_EQ(ord, bCurve.getOrder());
+    EXPECT_EQ(ord + 1, static_cast<int>(bCurve.getControlPoints().size()));
+    EXPECT_FALSE(bCurve.isRational());
+  }
+}
 
-    BezierCurveType bCurve(1);
-    int expOrder = 1;
-    EXPECT_EQ(expOrder, bCurve.getOrder());
-    EXPECT_EQ(expOrder + 1, static_cast<int>(bCurve.getControlPoints().size()));
+//----------------------------------------------------------------------------------
+TEST(primal_beziercurve, point_array_constructors_polynomial)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using BezierCurveType = primal::BezierCurve<CoordType, DIM>;
+  using CoordsVec = typename BezierCurveType::CoordsVec;
+
+  constexpr int order = 1;
+  PointType controlPoints[2] = {PointType {0.6, 1.2, 1.0}, PointType {0.0, 1.6, 1.8}};
+  CoordsVec pt_array {controlPoints[0], controlPoints[1]};
+
+  auto checkCurve = [&](const BezierCurveType& bCurve) {
+    EXPECT_EQ(order, bCurve.getOrder());
+    for(int p = 0; p <= bCurve.getOrder(); ++p)
+    {
+      EXPECT_EQ(controlPoints[p], bCurve[p]);
+    }
+    EXPECT_FALSE(bCurve.isRational());
+  };
+
+  // test constructor from C-array
+  {
+    BezierCurveType bCurve(controlPoints, order);
+    checkCurve(bCurve);
+  }
+
+  // test constructor from ArrayView generated from C-array
+  {
+    BezierCurveType bCurve(axom::ArrayView<PointType>(controlPoints, order + 1), order);
+    checkCurve(bCurve);
+  }
+
+  // test constructor from axom Array
+  {
+    BezierCurveType bCurve(pt_array, order);
+    checkCurve(bCurve);
+  }
+
+  // test constructor from ArrayView generated from axom Array
+  {
+    BezierCurveType bCurve(pt_array.view(), order);
+    checkCurve(bCurve);
+  }
+}
+
+//----------------------------------------------------------------------------------
+TEST(primal_beziercurve, point_array_constructors_rational)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using BezierCurveType = primal::BezierCurve<CoordType, DIM>;
+  using CoordsVec = typename BezierCurveType::CoordsVec;
+  using WeightsVec = typename BezierCurveType::WeightsVec;
+
+  constexpr int order = 2;
+  PointType controlPoints[3] = {PointType {0.6, 1.2, 1.0},
+                                PointType {0.0, 1.6, 1.8},
+                                PointType {2.0, 2.6, 2.8}};
+  double weights[3] = {1., .5, 1.};
+
+  CoordsVec pts {controlPoints[0], controlPoints[1], controlPoints[2]};
+  WeightsVec wts {weights[0], weights[1], weights[2]};
+
+  auto checkCurve = [&](const BezierCurveType& bCurve) {
+    EXPECT_EQ(order, bCurve.getOrder());
+    for(int p = 0; p <= bCurve.getOrder(); ++p)
+    {
+      EXPECT_EQ(controlPoints[p], bCurve[p]);
+      EXPECT_EQ(weights[p], bCurve.getWeight(p));
+    }
+    EXPECT_TRUE(bCurve.isRational());
+  };
+
+  // test constructor from C-array
+  {
+    BezierCurveType bCurve(controlPoints, weights, order);
+    checkCurve(bCurve);
+  }
+
+  // test constructor from ArrayViews over the C-arrays
+  {
+    BezierCurveType bCurve(axom::ArrayView<PointType>(controlPoints, order + 1),
+                           axom::ArrayView<double>(weights, order + 1),
+                           order);
+    checkCurve(bCurve);
+  }
+
+  // test constructor from axom Arrays
+  {
+    BezierCurveType bCurve(pts, wts, order);
+    checkCurve(bCurve);
+  }
+
+  // test constructor from ArrayViews over the axom arrays
+  {
+    BezierCurveType bCurve(pts.view(), wts.view(), order);
+    checkCurve(bCurve);
   }
 }
 
@@ -69,41 +173,12 @@ TEST(primal_beziercurve, set_order)
 
   for(int p = 0; p <= bCurve.getOrder(); ++p)
   {
-    auto& pt = bCurve[p];
-    for(int i = 0; i < DIM; ++i)
-    {
-      EXPECT_DOUBLE_EQ(controlPoints[p][i], pt[i]);
-    }
+    EXPECT_EQ(controlPoints[p], bCurve[p]);
   }
 
   bCurve.clear();
   EXPECT_EQ(-1, bCurve.getOrder());
   EXPECT_FALSE(bCurve.isRational());
-}
-
-//----------------------------------------------------------------------------------
-TEST(primal_beziercurve, point_array_constructor)
-{
-  SLIC_INFO("Testing point array constructor");
-
-  const int DIM = 3;
-  using CoordType = double;
-  using PointType = primal::Point<CoordType, DIM>;
-  using BezierCurveType = primal::BezierCurve<CoordType, DIM>;
-
-  PointType controlPoints[2] = {PointType {0.6, 1.2, 1.0}, PointType {0.0, 1.6, 1.8}};
-
-  BezierCurveType bCurve(controlPoints, 1);
-
-  EXPECT_EQ(1, bCurve.getOrder());
-  for(int p = 0; p <= bCurve.getOrder(); ++p)
-  {
-    auto& pt = bCurve[p];
-    for(int i = 0; i < DIM; ++i)
-    {
-      EXPECT_DOUBLE_EQ(controlPoints[p][i], pt[i]);
-    }
-  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_bezier_patch.cpp
+++ b/src/axom/primal/tests/primal_bezier_patch.cpp
@@ -19,38 +19,178 @@
 namespace primal = axom::primal;
 
 //------------------------------------------------------------------------------
-TEST(primal_bezierpatch, constructor)
+TEST(primal_bezierpatch, order_constructor)
 {
   using CoordType = double;
   using BezierPatchType = primal::BezierPatch<CoordType, 3>;
   using CoordsMat = BezierPatchType::CoordsMat;
 
+  // testing default BezierPatch constructor
   {
-    SLIC_INFO("Testing default BezierPatch constructor ");
     BezierPatchType bPatch;
     EXPECT_FALSE(bPatch.isRational());
 
-    int expOrder_u = -1, expOrder_v = -1;
-    EXPECT_EQ(expOrder_u, bPatch.getOrder_u());
-    EXPECT_EQ(expOrder_v, bPatch.getOrder_v());
+    EXPECT_EQ(-1, bPatch.getOrder_u());
+    EXPECT_EQ(-1, bPatch.getOrder_v());
 
-    EXPECT_EQ(expOrder_u + 1, bPatch.getControlPoints().shape()[0]);
-    EXPECT_EQ(expOrder_v + 1, bPatch.getControlPoints().shape()[1]);
+    EXPECT_EQ(0, bPatch.getControlPoints().shape()[0]);
+    EXPECT_EQ(0, bPatch.getControlPoints().shape()[1]);
 
     EXPECT_EQ(CoordsMat(), bPatch.getControlPoints());
   }
 
+  // testing BezierPatch order constructor
+  for(int u = 0; u < 5; ++u)
   {
-    SLIC_INFO("Testing BezierPatch order constructor ");
-    BezierPatchType bPatch(1, 1);
-    EXPECT_FALSE(bPatch.isRational());
+    for(int v = 0; v < 5; ++v)
+    {
+      BezierPatchType bPatch(u, v);
+      EXPECT_FALSE(bPatch.isRational());
 
-    int expOrder_u = 1, expOrder_v = 1;
-    EXPECT_EQ(expOrder_u, bPatch.getOrder_u());
-    EXPECT_EQ(expOrder_v, bPatch.getOrder_v());
+      EXPECT_EQ(u, bPatch.getOrder_u());
+      EXPECT_EQ(v, bPatch.getOrder_v());
 
-    EXPECT_EQ(expOrder_u + 1, bPatch.getControlPoints().shape()[0]);
-    EXPECT_EQ(expOrder_v + 1, bPatch.getControlPoints().shape()[1]);
+      EXPECT_EQ(u + 1, bPatch.getControlPoints().shape()[0]);
+      EXPECT_EQ(v + 1, bPatch.getControlPoints().shape()[1]);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_bezierpatch, array_constructors)
+{
+  const int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
+
+  SLIC_INFO("Testing point array constructor");
+
+  constexpr int order_u = 2;
+  constexpr int order_v = 1;
+
+  PointType controlPoints[6] = {PointType {0.0, 0.0, 1.0},
+                                PointType {0.0, 1.0, 2.0},
+                                PointType {0.0, 2.0, 3.0},
+                                PointType {1.0, 0.0, 4.0},
+                                PointType {1.0, 1.0, 5.0},
+                                PointType {1.0, 2.0, 6.0}};
+
+  CoordType weights[6] = {0.009, 1.109, 2.209, 3.009, 4.019, 5.029};
+
+  auto check_patch = [=](const BezierPatchType& patch, bool expect_rational) {
+    EXPECT_EQ(order_u, patch.getOrder_u());
+    EXPECT_EQ(order_v, patch.getOrder_v());
+
+    EXPECT_EQ(order_u + 1, patch.getControlPoints().shape()[0]);
+    EXPECT_EQ(order_v + 1, patch.getControlPoints().shape()[1]);
+
+    EXPECT_EQ(patch.isRational(), expect_rational);
+    if(expect_rational)
+    {
+      EXPECT_EQ(order_u + 1, patch.getWeights().shape()[0]);
+      EXPECT_EQ(order_v + 1, patch.getWeights().shape()[1]);
+    }
+    else
+    {
+      EXPECT_EQ(0, patch.getWeights().shape()[0]);
+      EXPECT_EQ(0, patch.getWeights().shape()[1]);
+    }
+
+    int idx = 0;
+    for(int u = 0; u <= patch.getOrder_u(); ++u)
+    {
+      for(int v = 0; v <= patch.getOrder_v(); ++v, ++idx)
+      {
+        EXPECT_EQ(patch(u, v), controlPoints[idx]);
+
+        if(expect_rational)
+        {
+          EXPECT_EQ(patch.getWeight(u, v), weights[idx]);
+        }
+      }
+    }
+  };
+
+  // check C-array constructors
+  {
+    SCOPED_TRACE("Testing C-array constructor, polynomial");
+    BezierPatchType nPatch(controlPoints, order_u, order_v);
+    check_patch(nPatch, false);
+
+    SCOPED_TRACE("Testing C-array constructor, polynomial w/ null weight");
+    BezierPatchType nPatch2(controlPoints, nullptr, order_u, order_v);
+    check_patch(nPatch, false);
+
+    SCOPED_TRACE("Testing C-array constructor, rational");
+    BezierPatchType rPatch(controlPoints, weights, order_u, order_v);
+    check_patch(rPatch, true);
+  }
+
+  // check ArrayView constructors (from C-arrays)
+  {
+    axom::ArrayView<PointType, 2> cp(controlPoints, {order_u + 1, order_v + 1});
+    axom::ArrayView<double, 2> w(weights, {order_u + 1, order_v + 1});
+
+    SCOPED_TRACE("Testing ArrayView constructor, polynomial");
+    BezierPatchType nPatch(cp, order_u, order_v);
+    check_patch(nPatch, false);
+
+    SCOPED_TRACE("Testing ArrayView constructor, rational");
+    BezierPatchType rPatch(cp, w, order_u, order_v);
+    check_patch(rPatch, true);
+  }
+
+  // check 1D Array contructors
+  {
+    axom::Array<PointType> cp;
+    cp.assign(std::begin(controlPoints), std::end(controlPoints));
+    axom::Array<double> w;
+    w.assign(std::begin(weights), std::end(weights));
+
+    SCOPED_TRACE("Testing Array constructor, polynomial");
+    BezierPatchType nPatch(cp, order_u, order_v);
+    check_patch(nPatch, false);
+
+    SCOPED_TRACE("Testing Array constructor, rational");
+    BezierPatchType rPatch(cp, w, order_u, order_v);
+    check_patch(rPatch, true);
+  }
+
+  {
+    // check 2D array constructors
+    axom::Array<PointType, 2> controlPoints_2D(order_u + 1, order_v + 1);
+    axom::Array<double, 2> weights_2D(order_u + 1, order_v + 1);
+    int idx = 0;
+    for(int u = 0; u <= order_u; ++u)
+    {
+      for(int v = 0; v <= order_v; ++v, ++idx)
+      {
+        controlPoints_2D(u, v) = controlPoints[idx];
+        weights_2D(u, v) = weights[idx];
+      }
+    }
+
+    {
+      SCOPED_TRACE("Testing 2D Array constructor, polynomial");
+      BezierPatchType nPatch(controlPoints_2D, order_u, order_v);
+      check_patch(nPatch, false);
+    }
+    {
+      SCOPED_TRACE("Testing 2D Array constructor, rational");
+      BezierPatchType rPatch(controlPoints_2D, weights_2D, order_u, order_v);
+      check_patch(rPatch, true);
+    }
+    {
+      SCOPED_TRACE("Testing 2D ArrayView constructor from Array, polynomial");
+      BezierPatchType nPatch(controlPoints_2D.view(), order_u, order_v);
+      check_patch(nPatch, false);
+    }
+    {
+      SCOPED_TRACE("Testing 2D Array constructor, rational");
+      BezierPatchType rPatch(controlPoints_2D.view(), weights_2D.view(), order_u, order_v);
+      check_patch(rPatch, true);
+    }
   }
 }
 
@@ -85,191 +225,12 @@ TEST(primal_bezierpatch, set_order)
   bPatch(1, 0) = controlPoints[2];
   bPatch(1, 1) = controlPoints[3];
 
+  int idx = 0;
   for(int p = 0; p <= bPatch.getOrder_u(); ++p)
   {
-    for(int q = 0; q <= bPatch.getOrder_v(); ++q)
+    for(int q = 0; q <= bPatch.getOrder_v(); ++q, ++idx)
     {
-      auto& pt = bPatch(p, q);
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPoints[p * (order_u + 1) + q][i], pt[i]);
-      }
-    }
-  }
-}
-
-//------------------------------------------------------------------------------
-TEST(primal_bezierpatch, array_constructors)
-{
-  const int DIM = 3;
-  using CoordType = double;
-  using PointType = primal::Point<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
-
-  SLIC_INFO("Testing point array constructor");
-
-  const int order_u = 1;
-  const int order_v = 1;
-
-  PointType controlPoints[4] = {PointType {0.0, 0.0, 1.0},
-                                PointType {0.0, 1.0, 0.0},
-                                PointType {1.0, 0.0, 0.0},
-                                PointType {1.0, 1.0, -1.0}};
-
-  CoordType weights[4] = {1.0, 2.0, 1.0, 0.5};
-
-  BezierPatchType nonrational_patch(controlPoints, order_u, order_v);
-  EXPECT_EQ(nonrational_patch.getOrder_u(), order_u);
-  EXPECT_EQ(nonrational_patch.getOrder_v(), order_v);
-  EXPECT_FALSE(nonrational_patch.isRational());
-
-  for(int p = 0; p <= nonrational_patch.getOrder_u(); ++p)
-  {
-    for(int q = 0; q <= nonrational_patch.getOrder_v(); ++q)
-    {
-      auto& pt = nonrational_patch(p, q);
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPoints[p * (order_u + 1) + q][i], pt[i]);
-      }
-    }
-  }
-
-  BezierPatchType nonrational_patch_again(controlPoints, nullptr, order_u, order_v);
-  EXPECT_EQ(nonrational_patch_again.getOrder_u(), order_u);
-  EXPECT_EQ(nonrational_patch_again.getOrder_v(), order_v);
-  EXPECT_FALSE(nonrational_patch_again.isRational());
-
-  for(int p = 0; p <= nonrational_patch_again.getOrder_u(); ++p)
-  {
-    for(int q = 0; q <= nonrational_patch_again.getOrder_v(); ++q)
-    {
-      auto& pt = nonrational_patch_again(p, q);
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPoints[p * (order_u + 1) + q][i], pt[i]);
-      }
-    }
-  }
-
-  BezierPatchType rational_patch(controlPoints, weights, order_u, order_v);
-  EXPECT_EQ(rational_patch.getOrder_u(), order_u);
-  EXPECT_EQ(rational_patch.getOrder_v(), order_v);
-  EXPECT_TRUE(rational_patch.isRational());
-
-  for(int p = 0; p <= rational_patch.getOrder_u(); ++p)
-  {
-    for(int q = 0; q <= rational_patch.getOrder_v(); ++q)
-    {
-      auto& pt = rational_patch(p, q);
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPoints[p * (order_u + 1) + q][i], pt[i]);
-      }
-      EXPECT_DOUBLE_EQ(weights[p * (order_u + 1) + q], rational_patch.getWeight(p, q));
-    }
-  }
-}
-
-//------------------------------------------------------------------------------
-TEST(primal_bezierpatch, axom_array_constructors)
-{
-  const int DIM = 3;
-  using CoordType = double;
-  using PointType = primal::Point<CoordType, DIM>;
-  using BezierPatchType = primal::BezierPatch<CoordType, DIM>;
-
-  SLIC_INFO("Testing point array constructor");
-
-  const int order_u = 1;
-  const int order_v = 1;
-
-  // Construct with 1D axom arrays
-  axom::Array<PointType> controlPoints({PointType {0.0, 0.0, 1.0},
-                                        PointType {0.0, 1.0, 0.0},
-                                        PointType {1.0, 0.0, 0.0},
-                                        PointType {1.0, 1.0, -1.0}});
-
-  axom::Array<CoordType> weights({1.0, 2.0, 1.0, 0.5});
-
-  BezierPatchType nonrational_patch(controlPoints, order_u, order_v);
-  EXPECT_EQ(nonrational_patch.getOrder_u(), order_u);
-  EXPECT_EQ(nonrational_patch.getOrder_v(), order_v);
-  EXPECT_FALSE(nonrational_patch.isRational());
-
-  for(int p = 0; p <= nonrational_patch.getOrder_u(); ++p)
-  {
-    for(int q = 0; q <= nonrational_patch.getOrder_v(); ++q)
-    {
-      auto& pt = nonrational_patch(p, q);
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPoints[p * (order_u + 1) + q][i], pt[i]);
-      }
-    }
-  }
-
-  BezierPatchType rational_patch(controlPoints, weights, order_u, order_v);
-  EXPECT_EQ(rational_patch.getOrder_u(), order_u);
-  EXPECT_EQ(rational_patch.getOrder_v(), order_v);
-  EXPECT_TRUE(rational_patch.isRational());
-
-  for(int p = 0; p <= rational_patch.getOrder_u(); ++p)
-  {
-    for(int q = 0; q <= rational_patch.getOrder_v(); ++q)
-    {
-      auto& pt = rational_patch(p, q);
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPoints[p * (order_u + 1) + q][i], pt[i]);
-      }
-      EXPECT_DOUBLE_EQ(weights[p * (order_u + 1) + q], rational_patch.getWeight(p, q));
-    }
-  }
-
-  // Construct with 2D axom arrays
-  axom::Array<PointType, 2> controlPoints_2D(2, 2);
-  controlPoints_2D(0, 0) = PointType {0.0, 0.0, 1.0};
-  controlPoints_2D(0, 1) = PointType {0.0, 1.0, 0.0};
-  controlPoints_2D(1, 0) = PointType {1.0, 0.0, 0.0};
-  controlPoints_2D(1, 1) = PointType {1.0, 1.0, -1.0};
-
-  axom::Array<CoordType, 2> weights_2D(2, 2);
-  weights_2D(0, 0) = 1.0;
-  weights_2D(0, 1) = 2.0;
-  weights_2D(1, 0) = 1.0;
-  weights_2D(1, 1) = 0.5;
-
-  BezierPatchType nonrational_patch_2D(controlPoints_2D, order_u, order_v);
-  EXPECT_EQ(nonrational_patch_2D.getOrder_u(), order_u);
-  EXPECT_EQ(nonrational_patch_2D.getOrder_v(), order_v);
-  EXPECT_FALSE(nonrational_patch_2D.isRational());
-
-  for(int p = 0; p <= nonrational_patch_2D.getOrder_u(); ++p)
-  {
-    for(int q = 0; q <= nonrational_patch_2D.getOrder_v(); ++q)
-    {
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPoints_2D(p, q)[i], nonrational_patch_2D(p, q)[i]);
-      }
-    }
-  }
-
-  BezierPatchType rational_patch_2D(controlPoints_2D, weights_2D, order_u, order_v);
-  EXPECT_EQ(rational_patch_2D.getOrder_u(), order_u);
-  EXPECT_EQ(rational_patch_2D.getOrder_v(), order_v);
-  EXPECT_TRUE(rational_patch_2D.isRational());
-
-  for(int p = 0; p <= rational_patch_2D.getOrder_u(); ++p)
-  {
-    for(int q = 0; q <= rational_patch_2D.getOrder_v(); ++q)
-    {
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPoints_2D(p, q)[i], rational_patch_2D(p, q)[i]);
-      }
-      EXPECT_DOUBLE_EQ(weights_2D(p, q), rational_patch_2D.getWeight(p, q));
+      EXPECT_EQ(controlPoints[idx], bPatch(p, q));
     }
   }
 }

--- a/src/axom/primal/tests/primal_bezier_patch.cpp
+++ b/src/axom/primal/tests/primal_bezier_patch.cpp
@@ -19,11 +19,14 @@
 namespace primal = axom::primal;
 
 //------------------------------------------------------------------------------
-TEST(primal_bezierpatch, order_constructor)
+TEST(primal_bezierpatch, sizing_constructors)
 {
   using CoordType = double;
   using BezierPatchType = primal::BezierPatch<CoordType, 3>;
   using CoordsMat = BezierPatchType::CoordsMat;
+  using PointType = BezierPatchType::PointType;
+  using PointArrayView = axom::ArrayView<const PointType, 2>;
+  using WeightsArrayView = axom::ArrayView<const double, 2>;
 
   // testing default BezierPatch constructor
   {
@@ -44,14 +47,19 @@ TEST(primal_bezierpatch, order_constructor)
   {
     for(int v = 0; v < 5; ++v)
     {
-      BezierPatchType bPatch(u, v);
-      EXPECT_FALSE(bPatch.isRational());
+      for(const BezierPatchType& patch :
+          {BezierPatchType(u, v),
+           BezierPatchType(PointArrayView(nullptr, {0, 0}), u, v),
+           BezierPatchType(PointArrayView(nullptr, {0, 0}), WeightsArrayView(nullptr, {0, 0}), u, v)})
+      {
+        EXPECT_FALSE(patch.isRational());
 
-      EXPECT_EQ(u, bPatch.getOrder_u());
-      EXPECT_EQ(v, bPatch.getOrder_v());
+        EXPECT_EQ(u, patch.getOrder_u());
+        EXPECT_EQ(v, patch.getOrder_v());
 
-      EXPECT_EQ(u + 1, bPatch.getControlPoints().shape()[0]);
-      EXPECT_EQ(v + 1, bPatch.getControlPoints().shape()[1]);
+        EXPECT_EQ(u + 1, patch.getControlPoints().shape()[0]);
+        EXPECT_EQ(v + 1, patch.getControlPoints().shape()[1]);
+      }
     }
   }
 }
@@ -69,14 +77,14 @@ TEST(primal_bezierpatch, array_constructors)
   constexpr int order_u = 2;
   constexpr int order_v = 1;
 
-  PointType controlPoints[6] = {PointType {0.0, 0.0, 1.0},
-                                PointType {0.0, 1.0, 2.0},
-                                PointType {0.0, 2.0, 3.0},
-                                PointType {1.0, 0.0, 4.0},
-                                PointType {1.0, 1.0, 5.0},
-                                PointType {1.0, 2.0, 6.0}};
+  // clang-format off
+  PointType controlPoints[6] = {
+    PointType {0.0, 0.0, 1.0}, PointType {0.0, 1.0, 2.0}, PointType {0.0, 2.0, 3.0},
+    PointType {1.0, 0.0, 4.0}, PointType {1.0, 1.0, 5.0}, PointType {1.0, 2.0, 6.0}};
 
-  CoordType weights[6] = {0.009, 1.109, 2.209, 3.009, 4.019, 5.029};
+  CoordType weights[6] = {0.009, 1.019, 2.029, 
+                          3.109, 4.119, 5.129};
+  // clang-format on
 
   auto check_patch = [=](const BezierPatchType& patch, bool expect_rational) {
     EXPECT_EQ(order_u, patch.getOrder_u());

--- a/src/axom/primal/tests/primal_knot_vector.cpp
+++ b/src/axom/primal/tests/primal_knot_vector.cpp
@@ -17,11 +17,26 @@
 namespace primal = axom::primal;
 
 //------------------------------------------------------------------------------
+TEST(primal_knotvector, default_constructor)
+{
+  primal::KnotVector<double> kvector;
+
+  constexpr axom::IndexType zero {0};
+
+  EXPECT_EQ(-1, kvector.getDegree());
+  EXPECT_EQ(zero, kvector.getNumControlPoints());
+  EXPECT_EQ(zero, kvector.getNumKnots());
+  EXPECT_EQ(zero, kvector.getNumKnotSpans());
+  EXPECT_FALSE(kvector.isValid());
+}
+
+//------------------------------------------------------------------------------
 TEST(primal_knotvector, degree_constructor)
 {
-  const int degree = 2;
-  const int npts = 5;
+  constexpr int degree = 2;
+  constexpr int npts = 5;
   primal::KnotVector<double> kvector(npts, degree);
+  EXPECT_TRUE(kvector.isValid());
 
   // Check size of knot vector
   EXPECT_EQ(degree, kvector.getDegree());
@@ -43,56 +58,59 @@ TEST(primal_knotvector, degree_constructor)
 }
 
 //------------------------------------------------------------------------------
-TEST(primal_knotvector, array_constructor)
+TEST(primal_knotvector, array_constructors)
 {
-  const int degree = 2;
+  constexpr int degree = 2;
 
-  const int nkts = 9;
+  constexpr int nkts = 9;
   double knots[] = {0.0, 0.0, 0.0, 0.2, 0.5, 0.8, 1.0, 1.0, 1.0};
+  constexpr int npts = nkts - degree - 1;
+  constexpr int nspans = 4;
 
-  const int npts = nkts - degree - 1;
+  axom::Array<double> knot_arr;
+  knot_arr.assign(std::begin(knots), std::end(knots));
 
-  primal::KnotVector<double> kvector(knots, nkts, degree);
+  // lambda to check validity of KnotVector instances
+  auto check_knot_vector = [=](const primal::KnotVector<double>& kv) {
+    EXPECT_TRUE(kv.isValid());
 
-  // Check size of knot vector
-  EXPECT_EQ(degree, kvector.getDegree());
-  EXPECT_EQ(npts, kvector.getNumControlPoints());
-  EXPECT_EQ(npts + degree + 1, kvector.getNumKnots());
-  EXPECT_EQ(4, kvector.getNumKnotSpans());
+    // Check sizeof knot vector
+    EXPECT_EQ(degree, kv.getDegree());
+    EXPECT_EQ(npts, kv.getNumControlPoints());
+    EXPECT_EQ(npts + degree + 1, kv.getNumKnots());
+    EXPECT_EQ(nspans, kv.getNumKnotSpans());
 
-  EXPECT_TRUE(kvector.isValid());
+    // Check for array access
+    for(int i = 0; i < degree; ++i)
+    {
+      EXPECT_DOUBLE_EQ(kv[i], knots[i]);
+      EXPECT_DOUBLE_EQ(kv.getArray()[i], knots[i]);
+    }
+  };
 
-  // Check for array access
-  for(int i = 0; i < 9; ++i)
+  // test C-array constructor
   {
-    EXPECT_DOUBLE_EQ(kvector[i], knots[i]);
-    EXPECT_DOUBLE_EQ(kvector.getArray()[i], knots[i]);
+    primal::KnotVector<double> kvector(knots, nkts, degree);
+    check_knot_vector(kvector);
   }
-}
 
-//------------------------------------------------------------------------------
-TEST(primal_knotvector, axom_array_constructor)
-{
-  const int degree = 2;
-  axom::Array<double> knots {0.0, 0.0, 0.0, 0.2, 0.5, 0.8, 1.0, 1.0, 1.0};
-
-  const int npts = knots.size() - degree - 1;
-
-  primal::KnotVector<double> kvector(knots, degree);
-
-  // Check size of knot vector
-  EXPECT_EQ(degree, kvector.getDegree());
-  EXPECT_EQ(npts, kvector.getNumControlPoints());
-  EXPECT_EQ(npts + degree + 1, kvector.getNumKnots());
-  EXPECT_EQ(4, kvector.getNumKnotSpans());
-
-  EXPECT_TRUE(kvector.isValid());
-
-  // Check for array access
-  for(int i = 0; i < 9; ++i)
+  // test ArrayView from C-array constructor
   {
-    EXPECT_DOUBLE_EQ(kvector[i], knots[i]);
-    EXPECT_DOUBLE_EQ(kvector.getArray()[i], knots[i]);
+    axom::ArrayView<double> knots_v(knots, nkts);
+    primal::KnotVector<double> kvector(knots_v, degree);
+    check_knot_vector(kvector);
+  }
+
+  // test Array constructor
+  {
+    primal::KnotVector<double> kvector(knot_arr, degree);
+    check_knot_vector(kvector);
+  }
+
+  // test ArrayView from axom::Array
+  {
+    primal::KnotVector<double> kvector(knot_arr.view(), degree);
+    check_knot_vector(kvector);
   }
 }
 

--- a/src/axom/primal/tests/primal_nurbs_curve.cpp
+++ b/src/axom/primal/tests/primal_nurbs_curve.cpp
@@ -121,7 +121,7 @@ TEST(primal_nurbscurve, bezier_constructors)
 }
 
 //------------------------------------------------------------------------------
-TEST(primal_nurbscurve, knotless_constructors)
+TEST(primal_nurbscurve, knotless_array_constructors)
 {
   constexpr int DIM = 3;
   using CoordType = double;
@@ -207,7 +207,7 @@ TEST(primal_nurbscurve, knotless_constructors)
 }
 
 //------------------------------------------------------------------------------
-TEST(primal_nurbscurve, knot_array_constructor)
+TEST(primal_nurbscurve, knotted_array_constructor)
 {
   SLIC_INFO("Testing knot array constructor");
 

--- a/src/axom/primal/tests/primal_nurbs_curve.cpp
+++ b/src/axom/primal/tests/primal_nurbs_curve.cpp
@@ -18,21 +18,298 @@
 namespace primal = axom::primal;
 
 //------------------------------------------------------------------------------
-TEST(primal_nurbscurve, constructor)
+TEST(primal_nurbscurve, default_constructor)
 {
-  const int DIM = 3;
+  constexpr int DIM = 3;
   using CoordType = double;
   using NURBSCurveType = primal::NURBSCurve<CoordType, DIM>;
 
-  SLIC_INFO("Testing default NURBSCurve constructor");
-  NURBSCurveType nCurve;
+  auto check_curve = [](const NURBSCurveType& cur) {
+    constexpr axom::IndexType zero {0};
 
-  int expDegree = -1;
-  EXPECT_EQ(expDegree, nCurve.getDegree());
-  EXPECT_EQ(expDegree + 1, nCurve.getOrder());
-  EXPECT_EQ(expDegree + 1, nCurve.getControlPoints().size());
-  EXPECT_EQ(expDegree + 1, nCurve.getKnotsArray().size());
-  EXPECT_FALSE(nCurve.isRational());
+    EXPECT_EQ(-1, cur.getDegree());
+    EXPECT_EQ(zero, cur.getOrder());
+    EXPECT_EQ(zero, cur.getControlPoints().size());
+    EXPECT_EQ(zero, cur.getKnotsArray().size());
+    EXPECT_FALSE(cur.isValidNURBS());
+  };
+
+  // check default constructor
+  {
+    NURBSCurveType nCurve;
+    check_curve(nCurve);
+  }
+
+  // explicitly specify degree of -1
+  {
+    NURBSCurveType nCurve(-1);
+    check_curve(nCurve);
+  }
+
+  // explicitly specify degree of -1 and 0 points
+  {
+    NURBSCurveType nCurve(0, -1);
+    check_curve(nCurve);
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_nurbscurve, sizing_constructors)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using NURBSCurveType = primal::NURBSCurve<CoordType, DIM>;
+
+  for(int deg = 0; deg < 5; ++deg)
+  {
+    for(int npts = deg + 1; npts < 10; ++npts)
+    {
+      NURBSCurveType nCurve(npts, deg);
+
+      EXPECT_TRUE(nCurve.isValidNURBS());
+
+      EXPECT_EQ(deg, nCurve.getDegree());
+      EXPECT_EQ(deg + 1, nCurve.getOrder());
+      EXPECT_EQ(npts, nCurve.getControlPoints().size());
+      EXPECT_EQ(npts + deg + 1, nCurve.getKnotsArray().size());
+      EXPECT_FALSE(nCurve.isRational());
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_nurbscurve, bezier_constructors)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using NURBSCurveType = primal::NURBSCurve<CoordType, DIM>;
+
+  constexpr int order = 2;
+
+  axom::Array<PointType> controlPoints {PointType {0.6, 1.2, 1.0},
+                                        PointType {0.0, 1.6, 1.8},
+                                        PointType {0.2, 1.4, 2.0}};
+  axom::Array<double> weights {.25, .5, .75};
+
+  primal::BezierCurve<double, DIM> nBez(controlPoints, order);
+  EXPECT_FALSE(nBez.isRational());
+
+  primal::BezierCurve<double, DIM> rBez(controlPoints, weights, order);
+  EXPECT_TRUE(rBez.isRational());
+
+  for(const auto& bez : {nBez, rBez})
+  {
+    NURBSCurveType cur(bez);
+    EXPECT_TRUE(cur.isValidNURBS());
+    EXPECT_EQ(cur.isRational(), bez.isRational());
+
+    EXPECT_EQ(order, cur.getDegree());
+    EXPECT_EQ(order + 1, cur.getOrder());
+    EXPECT_EQ(controlPoints.size(), cur.getControlPoints().size());
+    EXPECT_EQ(controlPoints.size() + order + 1, cur.getKnotsArray().size());
+
+    for(int p = 0; p < controlPoints.size(); ++p)
+    {
+      EXPECT_EQ(controlPoints[p], cur[p]);
+      if(cur.isRational())
+      {
+        EXPECT_EQ(weights[p], cur.getWeight(p));
+      }
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_nurbscurve, knotless_constructors)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using NURBSCurveType = primal::NURBSCurve<CoordType, DIM>;
+
+  constexpr int npts = 3;
+  constexpr int degree = 1;
+
+  // Construct from C-Style arrays
+  PointType controlPoints[npts] = {PointType {0.6, 1.2, 1.0},
+                                   PointType {0.0, 1.6, 1.8},
+                                   PointType {0.2, 1.4, 2.0}};
+
+  double weights[npts] = {1.0, 2.0, 3.0};
+
+  auto check_curve = [&](const NURBSCurveType& cur, bool expect_rational) {
+    EXPECT_TRUE(cur.isValidNURBS());
+
+    EXPECT_EQ(degree, cur.getDegree());
+    EXPECT_EQ(degree + 1, cur.getOrder());
+    EXPECT_EQ(npts, cur.getControlPoints().size());
+    EXPECT_EQ(npts + degree + 1, cur.getKnotsArray().size());
+
+    EXPECT_EQ(cur.isRational(), expect_rational);
+
+    for(int p = 0; p < cur.getNumControlPoints(); ++p)
+    {
+      EXPECT_EQ(controlPoints[p], cur[p]);
+      if(expect_rational)
+      {
+        EXPECT_EQ(weights[p], cur.getWeight(p));
+      }
+    }
+  };
+
+  // test constructors over C-arrays
+  {
+    NURBSCurveType nCurve(controlPoints, npts, degree);
+    check_curve(nCurve, false);
+
+    NURBSCurveType wCurve(controlPoints, weights, npts, degree);
+    check_curve(wCurve, true);
+  }
+
+  // test constructors over ArrayViews over C-arrays
+  {
+    axom::ArrayView<PointType> cp(controlPoints, npts);
+    axom::ArrayView<double> wt(weights, npts);
+
+    NURBSCurveType nCurve(cp, degree);
+    check_curve(nCurve, false);
+
+    NURBSCurveType wCurve(cp, wt, degree);
+    check_curve(wCurve, true);
+  }
+
+  // test over Axom arrays
+  {
+    axom::Array<PointType> cp;
+    cp.assign(std::begin(controlPoints), std::end(controlPoints));
+
+    axom::Array<double> wt;
+    wt.assign(std::begin(weights), std::end(weights));
+
+    // test over axom::Arrays
+    {
+      NURBSCurveType nCurve(cp, degree);
+      check_curve(nCurve, false);
+
+      NURBSCurveType wCurve(cp, wt, degree);
+      check_curve(wCurve, true);
+    }
+
+    // test over ArrayViews from Arrays
+    {
+      NURBSCurveType nCurve(cp.view(), degree);
+      check_curve(nCurve, false);
+      NURBSCurveType wCurve(cp.view(), wt.view(), degree);
+      check_curve(wCurve, true);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_nurbscurve, knot_array_constructor)
+{
+  SLIC_INFO("Testing knot array constructor");
+
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using NURBSCurveType = primal::NURBSCurve<CoordType, DIM>;
+
+  constexpr int npts = 3;
+  constexpr int degree = 1;
+  constexpr int nkts = npts + degree + 1;
+
+  // Construct from C-Style arrays
+  PointType controlPoints[npts] = {PointType {0.6, 1.2, 1.0},
+                                   PointType {0.0, 1.6, 1.8},
+                                   PointType {0.2, 1.4, 2.0}};
+
+  double weights[npts] = {1.0, 2.0, 3.0};
+  double knots[nkts] = {0.0, 0.0, 0.2, 1.0, 1.0};
+
+  auto check_curve = [&](const NURBSCurveType& cur, bool expect_rational) {
+    EXPECT_TRUE(cur.isValidNURBS());
+
+    EXPECT_EQ(degree, cur.getDegree());
+    EXPECT_EQ(degree + 1, cur.getOrder());
+    EXPECT_EQ(npts, cur.getControlPoints().size());
+    EXPECT_EQ(nkts, cur.getKnotsArray().size());
+
+    EXPECT_EQ(cur.isRational(), expect_rational);
+
+    for(int p = 0; p < cur.getNumControlPoints(); ++p)
+    {
+      EXPECT_EQ(controlPoints[p], cur[p]);
+      if(expect_rational)
+      {
+        EXPECT_EQ(weights[p], cur.getWeight(p));
+      }
+    }
+  };
+
+  // test constructors over C-arrays
+  {
+    NURBSCurveType nCurve(controlPoints, npts, knots, nkts);
+    NURBSCurveType wCurve(controlPoints, weights, npts, knots, nkts);
+
+    check_curve(nCurve, false);
+    check_curve(wCurve, true);
+  }
+
+  // test constructors over ArrayViews from C-arrays
+  {
+    axom::ArrayView<PointType> cp(controlPoints, npts);
+    axom::ArrayView<double> wt(weights, npts);
+    axom::ArrayView<double> kv(knots, nkts);
+
+    NURBSCurveType nCurve(cp, degree);
+    check_curve(nCurve, false);
+
+    NURBSCurveType wCurve(cp, wt, degree);
+    check_curve(wCurve, true);
+  }
+
+  // Construct from axom::Array
+  {
+    axom::Array<PointType> cp_arr;
+    cp_arr.assign(std::begin(controlPoints), std::end(controlPoints));
+
+    axom::Array<double> wt_arr;
+    wt_arr.assign(std::begin(weights), std::end(weights));
+
+    axom::Array<double> kt_arr;
+    kt_arr.assign(std::begin(knots), std::end(knots));
+
+    primal::KnotVector<double> knotvec(kt_arr, degree);
+
+    // test using Axom Arrays
+    {
+      NURBSCurveType nCurve(cp_arr, kt_arr);
+      check_curve(nCurve, false);
+
+      NURBSCurveType wCurve(cp_arr, wt_arr, kt_arr);
+      check_curve(wCurve, true);
+    }
+
+    // test using Axom arrays and KnotVectors
+    {
+      NURBSCurveType nCurve(cp_arr, knotvec);
+      check_curve(nCurve, false);
+
+      NURBSCurveType wCurve(cp_arr, wt_arr, knotvec);
+      check_curve(wCurve, true);
+    }
+
+    // test using ArrayViews from Arrays as well as KnotVectors
+    {
+      NURBSCurveType nCurve(cp_arr.view(), knotvec);
+      check_curve(nCurve, false);
+
+      NURBSCurveType wCurve(cp_arr.view(), wt_arr.view(), knotvec);
+      check_curve(wCurve, true);
+    }
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -43,7 +320,7 @@ TEST(primal_nurbscurve, set_degree)
   using PointType = primal::Point<CoordType, DIM>;
   using NURBSCurveType = primal::NURBSCurve<CoordType, DIM>;
 
-  SLIC_INFO("Test adding control points to empty Bezier curve");
+  SLIC_INFO("Test adding control points to empty NURBS curve");
 
   NURBSCurveType nCurve;
   EXPECT_EQ(-1, nCurve.getDegree());
@@ -67,11 +344,7 @@ TEST(primal_nurbscurve, set_degree)
 
   for(int p = 0; p < npts; ++p)
   {
-    auto& pt = nCurve[p];
-    for(int i = 0; i < DIM; ++i)
-    {
-      EXPECT_DOUBLE_EQ(controlPoints[p][i], pt[i]);
-    }
+    EXPECT_EQ(nCurve[p], controlPoints[p]);
   }
 
   nCurve.clear();
@@ -84,134 +357,6 @@ TEST(primal_nurbscurve, set_degree)
 
   nCurve.setWeight(0, 2.0);
   EXPECT_EQ(nCurve.getWeight(0), 2.0);
-}
-
-//------------------------------------------------------------------------------
-TEST(primal_nurbscurve, point_array_constructor)
-{
-  SLIC_INFO("Testing point array constructor");
-
-  const int DIM = 3;
-  using CoordType = double;
-  using PointType = primal::Point<CoordType, DIM>;
-  using NURBSCurveType = primal::NURBSCurve<CoordType, DIM>;
-
-  const int npts = 3;
-  const int degree = 1;
-
-  // Construct from C-Style arrays
-  PointType controlPoints[npts] = {PointType {0.6, 1.2, 1.0},
-                                   PointType {0.0, 1.6, 1.8},
-                                   PointType {0.2, 1.4, 2.0}};
-
-  double weights[npts] = {1.0, 2.0, 3.0};
-
-  NURBSCurveType nCurve(controlPoints, npts, degree);
-  NURBSCurveType wCurve(controlPoints, weights, npts, degree);
-
-  EXPECT_EQ(1, nCurve.getDegree());
-  for(int p = 0; p <= nCurve.getDegree(); ++p)
-  {
-    auto& pt1 = nCurve[p];
-    auto& pt2 = wCurve[p];
-    double w = wCurve.getWeight(p);
-
-    EXPECT_DOUBLE_EQ(weights[p], w);
-    for(int i = 0; i < DIM; ++i)
-    {
-      EXPECT_DOUBLE_EQ(controlPoints[p][i], pt1[i]);
-      EXPECT_DOUBLE_EQ(controlPoints[p][i], pt2[i]);
-    }
-  }
-
-  // Construct from axom::Array
-  axom::Array<PointType> controlPointsArray {PointType {0.6, 1.2, 1.0},
-                                             PointType {0.0, 1.6, 1.8},
-                                             PointType {0.2, 1.4, 2.0}};
-  axom::Array<double> weightsArray {1.0, 2.0, 3.0};
-
-  NURBSCurveType nCurveArray(controlPointsArray, degree);
-  NURBSCurveType wCurveArray(controlPointsArray, weightsArray, degree);
-
-  EXPECT_EQ(1, nCurveArray.getDegree());
-  for(int p = 0; p <= nCurveArray.getDegree(); ++p)
-  {
-    auto& pt1 = nCurveArray[p];
-    auto& pt2 = wCurveArray[p];
-    double w = wCurveArray.getWeight(p);
-
-    EXPECT_DOUBLE_EQ(weightsArray[p], w);
-    for(int i = 0; i < DIM; ++i)
-    {
-      EXPECT_DOUBLE_EQ(controlPointsArray[p][i], pt1[i]);
-      EXPECT_DOUBLE_EQ(controlPointsArray[p][i], pt2[i]);
-    }
-  }
-}
-
-//------------------------------------------------------------------------------
-TEST(primal_nurbscurve, knot_array_constructor)
-{
-  SLIC_INFO("Testing knot array constructor");
-
-  const int DIM = 3;
-  using CoordType = double;
-  using PointType = primal::Point<CoordType, DIM>;
-  using NURBSCurveType = primal::NURBSCurve<CoordType, DIM>;
-
-  const int npts = 3;
-  const int degree = 1;
-
-  // Construct from C-Style arrays
-  PointType controlPoints[npts] = {PointType {0.6, 1.2, 1.0},
-                                   PointType {0.0, 1.6, 1.8},
-                                   PointType {0.2, 1.4, 2.0}};
-
-  double weights[npts] = {1.0, 2.0, 3.0};
-  double knots[npts + degree + 1] = {0.0, 0.0, 0.2, 1.0, 1.0};
-
-  NURBSCurveType nCurve(controlPoints, npts, knots, npts + degree + 1);
-  NURBSCurveType wCurve(controlPoints, weights, npts, knots, npts + degree + 1);
-
-  EXPECT_EQ(1, nCurve.getDegree());
-  for(int p = 0; p <= nCurve.getDegree(); ++p)
-  {
-    auto& pt1 = nCurve[p];
-    auto& pt2 = wCurve[p];
-    double w = wCurve.getWeight(p);
-
-    EXPECT_DOUBLE_EQ(weights[p], w);
-    for(int i = 0; i < DIM; ++i)
-    {
-      EXPECT_DOUBLE_EQ(controlPoints[p][i], pt1[i]);
-      EXPECT_DOUBLE_EQ(controlPoints[p][i], pt2[i]);
-    }
-  }
-
-  // Construct from axom::Array
-  axom::Array<PointType> controlPointsArray {PointType {0.6, 1.2, 1.0},
-                                             PointType {0.0, 1.6, 1.8},
-                                             PointType {0.2, 1.4, 2.0}};
-  axom::Array<double> weightsArray {1.0, 2.0, 3.0};
-  axom::Array<double> knotsArray {0.0, 0.0, 0.2, 1.0, 1.0};
-
-  NURBSCurveType nCurveArray(controlPointsArray, knotsArray);
-  NURBSCurveType wCurveArray(controlPointsArray, weightsArray, knotsArray);
-
-  EXPECT_EQ(1, nCurveArray.getDegree());
-  for(int p = 0; p <= nCurveArray.getDegree(); ++p)
-  {
-    auto& pt1 = nCurveArray[p];
-    auto& pt2 = wCurveArray[p];
-    double w = wCurveArray.getWeight(p);
-
-    EXPECT_DOUBLE_EQ(weightsArray[p], w);
-    for(int i = 0; i < DIM; ++i)
-    {
-      EXPECT_DOUBLE_EQ(controlPointsArray[p][i], pt1[i]);
-      EXPECT_DOUBLE_EQ(controlPointsArray[p][i], pt2[i]);
-    }
-  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_nurbs_patch.cpp
+++ b/src/axom/primal/tests/primal_nurbs_patch.cpp
@@ -68,7 +68,8 @@ TEST(primal_nurbspatch, sizing_constructors)
     for(int deg_v = 0; deg_v < 5; ++deg_v)
     {
       {
-        SCOPED_TRACE(fmt::format("NURBS Patch constructor with deg_u={}, deg_v={}", deg_u, deg_v));
+        SCOPED_TRACE(
+          axom::fmt::format("NURBS Patch constructor with deg_u={}, deg_v={}", deg_u, deg_v));
         NURBSPatchType patch = NURBSPatchType(deg_u, deg_v);
         check_patch(patch, deg_u, deg_v, deg_u + 1, deg_v + 1, false);
       }
@@ -77,12 +78,12 @@ TEST(primal_nurbspatch, sizing_constructors)
       {
         for(int npts_v = deg_v + 1; npts_v < deg_v + 5; ++npts_v)
         {
-          SCOPED_TRACE(
-            fmt::format("NURBS Patch constructor with npts_u={}, npts_v={}, deg_u={}, deg_v={}",
-                        npts_u,
-                        npts_v,
-                        deg_u,
-                        deg_v));
+          SCOPED_TRACE(axom::fmt::format(
+            "NURBS Patch constructor with npts_u={}, npts_v={}, deg_u={}, deg_v={}",
+            npts_u,
+            npts_v,
+            deg_u,
+            deg_v));
           NURBSPatchType nPatch(npts_u, npts_v, deg_u, deg_v);
           check_patch(nPatch, deg_u, deg_v, npts_u, npts_v, false);
         }

--- a/src/axom/primal/tests/primal_nurbs_patch.cpp
+++ b/src/axom/primal/tests/primal_nurbs_patch.cpp
@@ -11,6 +11,7 @@
 #include "gtest/gtest.h"
 
 #include "axom/slic.hpp"
+#include "axom/fmt.hpp"
 
 #include "axom/primal/geometry/BezierCurve.hpp"
 #include "axom/primal/geometry/BezierPatch.hpp"
@@ -22,29 +23,446 @@
 namespace primal = axom::primal;
 
 //------------------------------------------------------------------------------
-TEST(primal_nurbspatch, constructor)
+TEST(primal_nurbspatch, sizing_constructors)
 {
-  const int DIM = 3;
+  constexpr int DIM = 3;
   using CoordType = double;
   using NURBSPatchType = primal::NURBSPatch<CoordType, DIM>;
 
-  SLIC_INFO("Testing default NURBS Patch constructor ");
-  NURBSPatchType nPatch;
+  auto check_patch =
+    [=](const NURBSPatchType& nPatch, int deg_u, int deg_v, int npts_u, int npts_v, bool expect_empty) {
+      EXPECT_EQ(!expect_empty, nPatch.getKnots_u().isValid());
+      EXPECT_EQ(!expect_empty, nPatch.getKnots_v().isValid());
+      EXPECT_EQ(!expect_empty, nPatch.isValidNURBS());
 
-  int expDegree_u = -1, expDegree_v = -1;
-  EXPECT_EQ(expDegree_u, nPatch.getDegree_u());
-  EXPECT_EQ(expDegree_v, nPatch.getDegree_v());
+      EXPECT_EQ(deg_u, nPatch.getDegree_u());
+      EXPECT_EQ(deg_v, nPatch.getDegree_v());
 
-  EXPECT_EQ(expDegree_u + 1, nPatch.getOrder_u());
-  EXPECT_EQ(expDegree_v + 1, nPatch.getOrder_v());
+      EXPECT_EQ(deg_u + 1, nPatch.getOrder_u());
+      EXPECT_EQ(deg_v + 1, nPatch.getOrder_v());
 
-  EXPECT_EQ(expDegree_u + 1, nPatch.getControlPoints().shape()[0]);
-  EXPECT_EQ(expDegree_v + 1, nPatch.getControlPoints().shape()[1]);
+      EXPECT_EQ(npts_u, nPatch.getControlPoints().shape()[0]);
+      EXPECT_EQ(npts_v, nPatch.getControlPoints().shape()[1]);
+      EXPECT_EQ(npts_u * npts_v, nPatch.getControlPoints().size());
 
-  EXPECT_EQ(expDegree_u + 1, nPatch.getKnotsArray_u().size());
-  EXPECT_EQ(expDegree_v + 1, nPatch.getKnotsArray_v().size());
+      EXPECT_EQ(npts_u + deg_u + 1, nPatch.getKnotsArray_u().size());
+      EXPECT_EQ(npts_v + deg_v + 1, nPatch.getKnotsArray_v().size());
 
-  EXPECT_FALSE(nPatch.isRational());
+      EXPECT_FALSE(nPatch.isRational());
+    };
+
+  {
+    SCOPED_TRACE("Default NURBS Patch constructor ");
+    NURBSPatchType nPatch;
+    check_patch(nPatch, -1, -1, 0, 0, true);
+  }
+
+  {
+    SCOPED_TRACE("Empty NURBS Patch constructor ");
+    NURBSPatchType nPatch(-1, -1);
+    check_patch(nPatch, -1, -1, 0, 0, true);
+  }
+
+  for(int deg_u = 0; deg_u < 5; ++deg_u)
+  {
+    for(int deg_v = 0; deg_v < 5; ++deg_v)
+    {
+      {
+        SCOPED_TRACE(fmt::format("NURBS Patch constructor with deg_u={}, deg_v={}", deg_u, deg_v));
+        NURBSPatchType patch = NURBSPatchType(deg_u, deg_v);
+        check_patch(patch, deg_u, deg_v, deg_u + 1, deg_v + 1, false);
+      }
+
+      for(int npts_u = deg_u + 1; npts_u < deg_u + 5; ++npts_u)
+      {
+        for(int npts_v = deg_v + 1; npts_v < deg_v + 5; ++npts_v)
+        {
+          SCOPED_TRACE(
+            fmt::format("NURBS Patch constructor with npts_u={}, npts_v={}, deg_u={}, deg_v={}",
+                        npts_u,
+                        npts_v,
+                        deg_u,
+                        deg_v));
+          NURBSPatchType nPatch(npts_u, npts_v, deg_u, deg_v);
+          check_patch(nPatch, deg_u, deg_v, npts_u, npts_v, false);
+        }
+      }
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_nurbspatch, bezier_constructors)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using NURBSPatchType = primal::NURBSPatch<CoordType, DIM>;
+
+  constexpr int ord_u = 2;
+  constexpr int ord_v = 3;
+
+  // clang-format off
+  axom::Array<PointType> controlPoints {
+    PointType {0.0, 0.0, 0.0}, PointType {0.0, 1.0,  1.0}, PointType {0.0, 2.0,  2.0},
+    PointType {1.0, 0.0, 3.0}, PointType {1.0, 1.0,  4.0}, PointType {1.0, 2.0,  5.0},
+    PointType {2.0, 0.0, 6.0}, PointType {2.0, 1.0,  7.0}, PointType {2.0, 2.0,  8.0},
+    PointType {3.0, 0.0, 9.0}, PointType {3.0, 1.0, 10.0}, PointType {3.0, 2.0, 11.0}};
+
+  axom::Array<double> weights { 0.009,  1.019,  2.029, 
+                                3.109,  4.119,  5.129, 
+                                6.209,  7.219,  8.229, 
+                                9.309, 10.319, 11.329};
+  // clang-format on
+
+  primal::BezierPatch<double, DIM> nBez(controlPoints, ord_u, ord_v);
+  EXPECT_FALSE(nBez.isRational());
+
+  primal::BezierPatch<double, DIM> rBez(controlPoints, weights, ord_u, ord_v);
+  EXPECT_TRUE(rBez.isRational());
+
+  for(const auto& bez : {nBez, rBez})
+  {
+    NURBSPatchType patch(bez);
+    EXPECT_TRUE(patch.isValidNURBS());
+    EXPECT_EQ(patch.isRational(), bez.isRational());
+
+    EXPECT_EQ(ord_u, patch.getDegree_u());
+    EXPECT_EQ(ord_v, patch.getDegree_v());
+    EXPECT_EQ(ord_u + 1, patch.getOrder_u());
+    EXPECT_EQ(ord_v + 1, patch.getOrder_v());
+    EXPECT_EQ(ord_u + 1, patch.getNumControlPoints_u());
+    EXPECT_EQ(ord_v + 1, patch.getNumControlPoints_v());
+    EXPECT_EQ(controlPoints.size(), patch.getControlPoints().size());
+    EXPECT_EQ(bez.getControlPoints().size(), patch.getControlPoints().size());
+
+    for(int p = 0; p < ord_u + 1; ++p)
+    {
+      for(int q = 0; q < ord_v + 1; ++q)
+      {
+        EXPECT_EQ(patch(p, q), bez(p, q));
+        if(patch.isRational())
+        {
+          EXPECT_EQ(patch.getWeight(p, q), bez.getWeight(p, q));
+        }
+      }
+    }
+
+    constexpr int nkts_u = 2 * (ord_u + 1);
+    constexpr int nkts_v = 2 * (ord_v + 1);
+
+    EXPECT_EQ(nkts_u, patch.getNumKnots_u());
+    EXPECT_EQ(nkts_v, patch.getNumKnots_v());
+
+    for(int k_u = 0; k_u < ord_u + 1; ++k_u)
+    {
+      patch.getKnots_u()[k_u] = 0.;
+      patch.getKnots_u()[nkts_u - k_u - 1] = 1.;
+    }
+
+    for(int k_v = 0; k_v < ord_v + 1; ++k_v)
+    {
+      patch.getKnots_v()[k_v] = 0.;
+      patch.getKnots_v()[nkts_v - k_v - 1] = 1.;
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_nurbspatch, knotless_array_constructors)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using NURBSPatchType = primal::NURBSPatch<CoordType, DIM>;
+
+  SLIC_INFO("Testing point array constructor");
+
+  constexpr int degree_u = 2;
+  constexpr int degree_v = 1;
+
+  constexpr int npts_u = 3;
+  constexpr int npts_v = 4;
+
+  // clang-format off
+  // Construct from C-style arrays
+  PointType controlPoints[12] = {
+    PointType {0.0, 0.0, 0.0}, PointType {0.0, 1.0,  1.0}, PointType {0.0, 2.0, 2.0},
+    PointType {1.0, 0.0, 3.0}, PointType {1.0, 1.0,  4.0}, PointType {1.0, 2.0, 5.0},
+    PointType {2.0, 0.0, 6.0}, PointType {2.0, 1.0,  7.0}, PointType {2.0, 2.0, 8.0},
+    PointType {3.0, 0.0, 9.0}, PointType {3.0, 1.0, 10.0}, PointType {3.0, 2.0, 11.0}};
+
+  CoordType weights[12] = { 0.009,  1.019,  2.029, 
+                            3.109,  4.119,  5.129, 
+                            6.209,  7.219,  8.229, 
+                            9.309, 10.319, 11.329};
+  // clang-format on
+
+  auto check_patch =
+    [=](const NURBSPatchType& patch, int deg_u, int deg_v, int npts_u, int npts_v, bool expect_rational) {
+      EXPECT_EQ(deg_u, patch.getDegree_u());
+      EXPECT_EQ(deg_v, patch.getDegree_v());
+
+      EXPECT_EQ(npts_u, patch.getControlPoints().shape()[0]);
+      EXPECT_EQ(npts_v, patch.getControlPoints().shape()[1]);
+      EXPECT_EQ(npts_u * npts_v, patch.getControlPoints().size());
+
+      EXPECT_EQ(npts_u + deg_u + 1, patch.getKnotsArray_u().size());
+      EXPECT_EQ(npts_v + deg_v + 1, patch.getKnotsArray_v().size());
+
+      if(expect_rational)
+      {
+        EXPECT_EQ(npts_u, patch.getWeights().shape()[0]);
+        EXPECT_EQ(npts_v, patch.getWeights().shape()[1]);
+        EXPECT_EQ(npts_u * npts_v, patch.getWeights().size());
+      }
+      else
+      {
+        EXPECT_TRUE(patch.getWeights().empty());
+      }
+
+      int idx = 0;
+      for(int u = 0; u < npts_u; ++u)
+      {
+        for(int v = 0; v < npts_v; ++v, ++idx)
+        {
+          EXPECT_EQ(patch(u, v), controlPoints[idx]);
+          if(expect_rational)
+          {
+            EXPECT_EQ(patch.getWeight(u, v), weights[idx]);
+          }
+        }
+      }
+    };
+
+  // test C-array constructors
+  {
+    NURBSPatchType nPatch(controlPoints, npts_u, npts_v, degree_u, degree_v);
+    check_patch(nPatch, degree_u, degree_v, npts_u, npts_v, false);
+
+    NURBSPatchType wPatch(controlPoints, weights, npts_u, npts_v, degree_u, degree_v);
+    check_patch(wPatch, degree_u, degree_v, npts_u, npts_v, true);
+  }
+
+  // test 1D axom::Array constructors
+  {
+    axom::Array<PointType> cp;
+    cp.assign(std::begin(controlPoints), std::end(controlPoints));
+
+    axom::Array<double> w;
+    w.assign(std::begin(weights), std::end(weights));
+
+    NURBSPatchType nPatch(cp, npts_u, npts_v, degree_u, degree_v);
+    check_patch(nPatch, degree_u, degree_v, npts_u, npts_v, false);
+
+    NURBSPatchType wPatch(cp, w, npts_u, npts_v, degree_u, degree_v);
+    check_patch(wPatch, degree_u, degree_v, npts_u, npts_v, true);
+  }
+
+  // test 2D axom::Array constructors
+  {
+    axom::Array<PointType, 2> controlPointsArray2D(npts_u, npts_v);
+    axom::Array<double, 2> weightsArray2D(npts_u, npts_v);
+
+    int idx = 0;
+    for(int p = 0; p < npts_u; ++p)
+    {
+      for(int q = 0; q < npts_v; ++q, ++idx)
+      {
+        controlPointsArray2D(p, q) = controlPoints[idx];
+        weightsArray2D(p, q) = weights[idx];
+      }
+    }
+
+    NURBSPatchType nPatch(controlPointsArray2D, degree_u, degree_v);
+    check_patch(nPatch, degree_u, degree_v, npts_u, npts_v, false);
+
+    NURBSPatchType wPatch(controlPointsArray2D, weightsArray2D, degree_u, degree_v);
+    check_patch(wPatch, degree_u, degree_v, npts_u, npts_v, true);
+
+    NURBSPatchType nPatch_vw(controlPointsArray2D.view(), degree_u, degree_v);
+    check_patch(nPatch_vw, degree_u, degree_v, npts_u, npts_v, false);
+
+    NURBSPatchType wPatch_vw(controlPointsArray2D.view(), weightsArray2D.view(), degree_u, degree_v);
+    check_patch(wPatch_vw, degree_u, degree_v, npts_u, npts_v, true);
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_nurbspatch, knot_array_constructor)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using NURBSPatchType = primal::NURBSPatch<CoordType, DIM>;
+  using KnotVectorType = primal::KnotVector<CoordType>;
+
+  SLIC_INFO("Testing knot array constructor");
+
+  constexpr int degree_u = 1;
+  constexpr int degree_v = 1;
+
+  constexpr int npts_u = 3;
+  constexpr int npts_v = 3;
+
+  // clang-format off
+  PointType controlPoints[npts_u * npts_v] = {
+    PointType {0.0, 0.0, 1.0}, PointType {0.0, 1.0,  0.0}, PointType {0.0, 2.0, 0.0},
+    PointType {1.0, 0.0, 0.0}, PointType {1.0, 1.0, -1.0}, PointType {1.0, 2.0, 0.0},
+    PointType {2.0, 0.0, 0.0}, PointType {2.0, 1.0,  0.0}, PointType {2.0, 2.0, 1.0}};
+
+  CoordType weights[npts_u * npts_v] = {1.0, 2.0, 3.0, 
+                                        2.0, 3.0, 4.0, 
+                                        3.0, 4.0, 5.0};
+  // clang-format on
+
+  double knots_u[npts_u + degree_u + 1] = {0.0, 0.0, 0.5, 1.0, 1.0};
+  double knots_v[npts_v + degree_v + 1] = {0.0, 0.0, 0.5, 1.0, 1.0};
+
+  auto check_patch =
+    [=](const NURBSPatchType& patch, int deg_u, int deg_v, int npts_u, int npts_v, bool expect_rational) {
+      EXPECT_EQ(deg_u, patch.getDegree_u());
+      EXPECT_EQ(deg_v, patch.getDegree_v());
+
+      EXPECT_EQ(npts_u, patch.getControlPoints().shape()[0]);
+      EXPECT_EQ(npts_v, patch.getControlPoints().shape()[1]);
+      EXPECT_EQ(npts_u * npts_v, patch.getControlPoints().size());
+
+      EXPECT_EQ(npts_u + deg_u + 1, patch.getKnotsArray_u().size());
+      EXPECT_EQ(npts_v + deg_v + 1, patch.getKnotsArray_v().size());
+
+      if(expect_rational)
+      {
+        EXPECT_EQ(npts_u, patch.getWeights().shape()[0]);
+        EXPECT_EQ(npts_v, patch.getWeights().shape()[1]);
+        EXPECT_EQ(npts_u * npts_v, patch.getWeights().size());
+      }
+      else
+      {
+        EXPECT_TRUE(patch.getWeights().empty());
+      }
+
+      int idx = 0;
+      for(int u = 0; u < npts_u; ++u)
+      {
+        for(int v = 0; v < npts_v; ++v, ++idx)
+        {
+          EXPECT_EQ(patch(u, v), controlPoints[idx]);
+          if(expect_rational)
+          {
+            EXPECT_EQ(patch.getWeight(u, v), weights[idx]);
+          }
+        }
+      }
+    };
+
+  // test from C-style arrays
+  {
+    NURBSPatchType nPatch(controlPoints,
+                          npts_u,
+                          npts_v,
+                          knots_u,
+                          npts_u + degree_u + 1,
+                          knots_v,
+                          npts_v + degree_v + 1);
+    check_patch(nPatch, degree_u, degree_v, npts_u, npts_v, false);
+
+    NURBSPatchType wPatch(controlPoints,
+                          weights,
+                          npts_u,
+                          npts_v,
+                          knots_u,
+                          npts_u + degree_u + 1,
+                          knots_v,
+                          npts_v + degree_v + 1);
+    check_patch(wPatch, degree_u, degree_v, npts_u, npts_v, true);
+  }
+
+  // test with 1D axom::Arrays
+  {
+    axom::Array<PointType> cp_arr;
+    cp_arr.assign(std::begin(controlPoints), std::end(controlPoints));
+    axom::Array<double> w_arr;
+    w_arr.assign(std::begin(weights), std::end(weights));
+
+    axom::Array<double> knot_arr_u;
+    knot_arr_u.assign(std::begin(knots_u), std::end(knots_u));
+    axom::Array<double> knot_arr_v;
+    knot_arr_v.assign(std::begin(knots_v), std::end(knots_v));
+
+    KnotVectorType knotvec_u(knot_arr_u, degree_u);
+    KnotVectorType knotvec_v(knot_arr_v, degree_v);
+
+    {
+      SCOPED_TRACE("Testing 1D array constructors with 1D array of knots");
+
+      NURBSPatchType nPatch(cp_arr, npts_u, npts_v, knot_arr_u, knot_arr_v);
+      check_patch(nPatch, degree_u, degree_v, npts_u, npts_v, false);
+
+      NURBSPatchType wPatch(cp_arr, w_arr, npts_u, npts_v, knot_arr_u, knot_arr_v);
+      check_patch(wPatch, degree_u, degree_v, npts_u, npts_v, true);
+    }
+    {
+      SCOPED_TRACE("Testing 1D array constructors with KnotVectors");
+
+      NURBSPatchType nPatch(cp_arr, npts_u, npts_v, knotvec_u, knotvec_v);
+      check_patch(nPatch, degree_u, degree_v, npts_u, npts_v, false);
+
+      NURBSPatchType wPatch(cp_arr, w_arr, npts_u, npts_v, knotvec_u, knotvec_v);
+      check_patch(wPatch, degree_u, degree_v, npts_u, npts_v, true);
+    }
+  }
+
+  // test with 2D axom::Arrays
+  {
+    axom::Array<PointType, 2> cp_arr_2D(npts_u, npts_v);
+    axom::Array<double, 2> w_arr_2D(npts_u, npts_v);
+
+    int idx = 0;
+    for(int p = 0; p < npts_u; ++p)
+    {
+      for(int q = 0; q < npts_v; ++q, ++idx)
+      {
+        cp_arr_2D(p, q) = controlPoints[idx];
+        w_arr_2D(p, q) = weights[idx];
+      }
+    }
+
+    axom::Array<double> knot_arr_u;
+    knot_arr_u.assign(std::begin(knots_u), std::end(knots_u));
+    axom::Array<double> knot_arr_v;
+    knot_arr_v.assign(std::begin(knots_v), std::end(knots_v));
+
+    KnotVectorType knotvec_u(knot_arr_u, degree_u);
+    KnotVectorType knotvec_v(knot_arr_v, degree_v);
+
+    {
+      SCOPED_TRACE("Testing 2D array constructors with 1D array of knots");
+      NURBSPatchType nPatch(cp_arr_2D, knot_arr_u, knot_arr_v);
+      check_patch(nPatch, degree_u, degree_v, npts_u, npts_v, false);
+
+      NURBSPatchType wPatch(cp_arr_2D, w_arr_2D, knot_arr_u, knot_arr_v);
+      check_patch(wPatch, degree_u, degree_v, npts_u, npts_v, true);
+    }
+
+    {
+      SCOPED_TRACE("Testing 2D array constructors with KnotVector");
+      NURBSPatchType nPatch(cp_arr_2D, knotvec_u, knotvec_v);
+      check_patch(nPatch, degree_u, degree_v, npts_u, npts_v, false);
+
+      NURBSPatchType wPatch(cp_arr_2D, w_arr_2D, knotvec_u, knotvec_v);
+      check_patch(wPatch, degree_u, degree_v, npts_u, npts_v, true);
+    }
+
+    {
+      SCOPED_TRACE("Testing 2D ArrayView constructors with KnotVector");
+      NURBSPatchType nPatch(cp_arr_2D.view(), knotvec_u, knotvec_v);
+      check_patch(nPatch, degree_u, degree_v, npts_u, npts_v, false);
+
+      NURBSPatchType wPatch(cp_arr_2D.view(), w_arr_2D.view(), knotvec_u, knotvec_v);
+      check_patch(wPatch, degree_u, degree_v, npts_u, npts_v, true);
+    }
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -79,25 +497,16 @@ TEST(primal_nurbspatch, set_degree)
   EXPECT_EQ(nPatch.getNumKnots_u(), degree_u + npts_u + 1);
   EXPECT_EQ(nPatch.getNumKnots_v(), degree_v + npts_v + 1);
 
-  PointType controlPoints[9] = {PointType {0.0, 0.0, 1.0},
-                                PointType {0.0, 1.0, 0.0},
-                                PointType {0.0, 2.0, 0.0},
-                                PointType {1.0, 0.0, 0.0},
-                                PointType {1.0, 1.0, -1.0},
-                                PointType {1.0, 2.0, 0.0},
-                                PointType {2.0, 0.0, 0.0},
-                                PointType {2.0, 1.0, 0.0},
-                                PointType {2.0, 2.0, 1.0}};
+  // clang-format off
+  PointType controlPoints[9] = {
+    PointType {0.0, 0.0, 1.0}, PointType {0.0, 1.0,  0.0}, PointType {0.0, 2.0, 0.0},
+    PointType {1.0, 0.0, 0.0}, PointType {1.0, 1.0, -1.0}, PointType {1.0, 2.0, 0.0},
+    PointType {2.0, 0.0, 0.0}, PointType {2.0, 1.0,  0.0}, PointType {2.0, 2.0, 1.0}};
 
-  nPatch(0, 0) = controlPoints[0];
-  nPatch(0, 1) = controlPoints[1];
-  nPatch(0, 2) = controlPoints[2];
-  nPatch(1, 0) = controlPoints[3];
-  nPatch(1, 1) = controlPoints[4];
-  nPatch(1, 2) = controlPoints[5];
-  nPatch(2, 0) = controlPoints[6];
-  nPatch(2, 1) = controlPoints[7];
-  nPatch(2, 2) = controlPoints[8];
+  nPatch(0, 0) = controlPoints[0]; nPatch(0, 1) = controlPoints[1]; nPatch(0, 2) = controlPoints[2];
+  nPatch(1, 0) = controlPoints[3]; nPatch(1, 1) = controlPoints[4]; nPatch(1, 2) = controlPoints[5];
+  nPatch(2, 0) = controlPoints[6]; nPatch(2, 1) = controlPoints[7]; nPatch(2, 2) = controlPoints[8];
+  // clang-format on
 
   for(int p = 0; p < npts_u; ++p)
   {
@@ -122,324 +531,6 @@ TEST(primal_nurbspatch, set_degree)
 
   nPatch.setWeight(0, 0, 2.0);
   EXPECT_DOUBLE_EQ(2.0, nPatch.getWeight(0, 0));
-}
-
-//------------------------------------------------------------------------------
-TEST(primal_nurbspatch, point_array_constructors)
-{
-  const int DIM = 3;
-  using CoordType = double;
-  using PointType = primal::Point<CoordType, DIM>;
-  using NURBSPatchType = primal::NURBSPatch<CoordType, DIM>;
-
-  SLIC_INFO("Testing point array constructor");
-
-  const int degree_u = 1;
-  const int degree_v = 1;
-
-  const int npts_u = 3;
-  const int npts_v = 3;
-
-  // Construct from C-style arrays
-  PointType controlPoints[9] = {PointType {0.0, 0.0, 1.0},
-                                PointType {0.0, 1.0, 0.0},
-                                PointType {0.0, 2.0, 0.0},
-                                PointType {1.0, 0.0, 0.0},
-                                PointType {1.0, 1.0, -1.0},
-                                PointType {1.0, 2.0, 0.0},
-                                PointType {2.0, 0.0, 0.0},
-                                PointType {2.0, 1.0, 0.0},
-                                PointType {2.0, 2.0, 1.0}};
-
-  CoordType weights[9] = {1.0, 2.0, 3.0, 2.0, 3.0, 4.0, 3.0, 4.0, 5.0};
-
-  NURBSPatchType nPatch(controlPoints, npts_u, npts_v, degree_u, degree_v);
-  NURBSPatchType wPatch(controlPoints, weights, npts_u, npts_v, degree_u, degree_v);
-
-  EXPECT_EQ(nPatch.getDegree_u(), degree_u);
-  EXPECT_EQ(nPatch.getDegree_v(), degree_v);
-
-  for(int p = 0; p < npts_u; ++p)
-  {
-    for(int q = 0; q < npts_v; ++q)
-    {
-      auto& pt1 = nPatch(p, q);
-      auto& pt2 = wPatch(p, q);
-      double w = wPatch.getWeight(p, q);
-
-      EXPECT_DOUBLE_EQ(weights[p * npts_u + q], w);
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPoints[p * npts_u + q][i], pt1[i]);
-        EXPECT_DOUBLE_EQ(controlPoints[p * npts_u + q][i], pt2[i]);
-      }
-    }
-  }
-
-  // Construct from 1D axom::Array
-  axom::Array<PointType> controlPointsArray({PointType {0.0, 0.0, 1.0},
-                                             PointType {0.0, 1.0, 0.0},
-                                             PointType {0.0, 2.0, 0.0},
-                                             PointType {1.0, 0.0, 0.0},
-                                             PointType {1.0, 1.0, -1.0},
-                                             PointType {1.0, 2.0, 0.0},
-                                             PointType {2.0, 0.0, 0.0},
-                                             PointType {2.0, 1.0, 0.0},
-                                             PointType {2.0, 2.0, 1.0}});
-  axom::Array<CoordType> weightsArray({1.0, 2.0, 3.0, 2.0, 3.0, 4.0, 3.0, 4.0, 5.0});
-
-  NURBSPatchType nPatchArray(controlPointsArray, npts_u, npts_v, degree_u, degree_v);
-  NURBSPatchType wPatchArray(controlPointsArray, weightsArray, npts_u, npts_v, degree_u, degree_v);
-
-  EXPECT_EQ(nPatchArray.getDegree_u(), degree_u);
-  EXPECT_EQ(nPatchArray.getDegree_v(), degree_v);
-
-  for(int p = 0; p < npts_u; ++p)
-  {
-    for(int q = 0; q < npts_v; ++q)
-    {
-      auto& pt1 = nPatchArray(p, q);
-      auto& pt2 = wPatchArray(p, q);
-      double w = wPatchArray.getWeight(p, q);
-
-      EXPECT_DOUBLE_EQ(weightsArray[p * npts_u + q], w);
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPointsArray[p * npts_u + q][i], pt1[i]);
-        EXPECT_DOUBLE_EQ(controlPointsArray[p * npts_u + q][i], pt2[i]);
-      }
-    }
-  }
-
-  // Construct from 2D axom::Array
-  axom::Array<PointType, 2> controlPointsArray2D(3, 3);
-  axom::Array<double, 2> weightsArray2D(3, 3);
-
-  for(int p = 0; p < npts_u; ++p)
-  {
-    for(int q = 0; q < npts_v; ++q)
-    {
-      controlPointsArray2D(p, q) = controlPoints[p * npts_u + q];
-      weightsArray2D(p, q) = weights[p * npts_u + q];
-    }
-  }
-
-  NURBSPatchType nPatchArray2D(controlPointsArray2D, degree_u, degree_v);
-  NURBSPatchType wPatchArray2D(controlPointsArray2D, weightsArray2D, degree_u, degree_v);
-
-  EXPECT_EQ(nPatchArray2D.getDegree_u(), degree_u);
-  EXPECT_EQ(nPatchArray2D.getDegree_v(), degree_v);
-
-  for(int p = 0; p < npts_u; ++p)
-  {
-    for(int q = 0; q < npts_v; ++q)
-    {
-      auto& pt1 = nPatchArray2D(p, q);
-      auto& pt2 = wPatchArray2D(p, q);
-      double w = wPatchArray2D.getWeight(p, q);
-
-      EXPECT_DOUBLE_EQ(weightsArray2D(p, q), w);
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPointsArray2D(p, q)[i], pt1[i]);
-        EXPECT_DOUBLE_EQ(controlPointsArray2D(p, q)[i], pt2[i]);
-      }
-    }
-  }
-}
-
-//------------------------------------------------------------------------------
-TEST(primal_nurbspatch, knot_array_constructor)
-{
-  const int DIM = 3;
-  using CoordType = double;
-  using PointType = primal::Point<CoordType, DIM>;
-  using NURBSPatchType = primal::NURBSPatch<CoordType, DIM>;
-
-  SLIC_INFO("Testing knot array constructor");
-
-  const int degree_u = 1;
-  const int degree_v = 1;
-
-  const int npts_u = 3;
-  const int npts_v = 3;
-
-  // Construct from C-style arrays
-  PointType controlPoints[npts_u * npts_v] = {PointType {0.0, 0.0, 1.0},
-                                              PointType {0.0, 1.0, 0.0},
-                                              PointType {0.0, 2.0, 0.0},
-                                              PointType {1.0, 0.0, 0.0},
-                                              PointType {1.0, 1.0, -1.0},
-                                              PointType {1.0, 2.0, 0.0},
-                                              PointType {2.0, 0.0, 0.0},
-                                              PointType {2.0, 1.0, 0.0},
-                                              PointType {2.0, 2.0, 1.0}};
-
-  CoordType weights[npts_u * npts_v] = {1.0, 2.0, 3.0, 2.0, 3.0, 4.0, 3.0, 4.0, 5.0};
-
-  double knots_u[npts_u + degree_u + 1] = {0.0, 0.0, 0.5, 1.0, 1.0};
-  double knots_v[npts_v + degree_v + 1] = {0.0, 0.0, 0.5, 1.0, 1.0};
-
-  NURBSPatchType nPatch(controlPoints,
-                        npts_u,
-                        npts_v,
-                        knots_u,
-                        npts_u + degree_u + 1,
-                        knots_v,
-                        npts_v + degree_v + 1);
-  NURBSPatchType wPatch(controlPoints,
-                        weights,
-                        npts_u,
-                        npts_v,
-                        knots_u,
-                        npts_u + degree_u + 1,
-                        knots_v,
-                        npts_v + degree_v + 1);
-
-  EXPECT_EQ(nPatch.getDegree_u(), degree_u);
-  EXPECT_EQ(nPatch.getDegree_v(), degree_v);
-  for(int p = 0; p < npts_u; ++p)
-  {
-    for(int q = 0; q < npts_v; ++q)
-    {
-      auto& pt1 = nPatch(p, q);
-      auto& pt2 = wPatch(p, q);
-      double w = wPatch.getWeight(p, q);
-
-      EXPECT_DOUBLE_EQ(weights[p * npts_u + q], w);
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPoints[p * npts_u + q][i], pt1[i]);
-        EXPECT_DOUBLE_EQ(controlPoints[p * npts_u + q][i], pt2[i]);
-      }
-    }
-  }
-
-  // Construct from 1D axom::Array
-  axom::Array<PointType> controlPointsArray({PointType {0.0, 0.0, 1.0},
-                                             PointType {0.0, 1.0, 0.0},
-                                             PointType {0.0, 2.0, 0.0},
-                                             PointType {1.0, 0.0, 0.0},
-                                             PointType {1.0, 1.0, -1.0},
-                                             PointType {1.0, 2.0, 0.0},
-                                             PointType {2.0, 0.0, 0.0},
-                                             PointType {2.0, 1.0, 0.0},
-                                             PointType {2.0, 2.0, 1.0}});
-  axom::Array<CoordType> weightsArray({1.0, 2.0, 3.0, 2.0, 3.0, 4.0, 3.0, 4.0, 5.0});
-
-  axom::Array<double> knots_uArray({0.0, 0.0, 0.5, 1.0, 1.0});
-  axom::Array<double> knots_vArray({0.0, 0.0, 0.5, 1.0, 1.0});
-
-  NURBSPatchType nPatchArray(controlPointsArray, npts_u, npts_v, knots_uArray, knots_vArray);
-  NURBSPatchType wPatchArray(controlPointsArray, weightsArray, npts_u, npts_v, knots_uArray, knots_vArray);
-
-  EXPECT_EQ(nPatchArray.getDegree_u(), degree_u);
-  EXPECT_EQ(nPatchArray.getDegree_v(), degree_v);
-  for(int p = 0; p < npts_u; ++p)
-  {
-    for(int q = 0; q < npts_v; ++q)
-    {
-      auto& pt1 = nPatchArray(p, q);
-      auto& pt2 = wPatchArray(p, q);
-      double w = wPatchArray.getWeight(p, q);
-
-      EXPECT_DOUBLE_EQ(weightsArray[p * npts_u + q], w);
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPointsArray[p * npts_u + q][i], pt1[i]);
-        EXPECT_DOUBLE_EQ(controlPointsArray[p * npts_u + q][i], pt2[i]);
-      }
-    }
-  }
-
-  // Construct from 2D axom::Array
-  axom::Array<PointType, 2> controlPointsArray2D(3, 3);
-  axom::Array<double, 2> weightsArray2D(3, 3);
-
-  for(int p = 0; p < npts_u; ++p)
-  {
-    for(int q = 0; q < npts_v; ++q)
-    {
-      controlPointsArray2D(p, q) = controlPoints[p * npts_u + q];
-      weightsArray2D(p, q) = weights[p * npts_u + q];
-    }
-  }
-
-  NURBSPatchType nPatchArray2D(controlPointsArray2D, knots_uArray, knots_vArray);
-  NURBSPatchType wPatchArray2D(controlPointsArray2D, weightsArray2D, knots_uArray, knots_vArray);
-
-  EXPECT_EQ(nPatchArray2D.getDegree_u(), degree_u);
-  EXPECT_EQ(nPatchArray2D.getDegree_v(), degree_v);
-  for(int p = 0; p < npts_u; ++p)
-  {
-    for(int q = 0; q < npts_v; ++q)
-    {
-      auto& pt1 = nPatchArray2D(p, q);
-      auto& pt2 = wPatchArray2D(p, q);
-      double w = wPatchArray2D.getWeight(p, q);
-
-      EXPECT_DOUBLE_EQ(weightsArray2D(p, q), w);
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPointsArray2D(p, q)[i], pt1[i]);
-        EXPECT_DOUBLE_EQ(controlPointsArray2D(p, q)[i], pt2[i]);
-      }
-    }
-  }
-
-  // Construct from 1D axom::Array and KnotVector object
-  primal::KnotVector<CoordType> knotVector_u(npts_u, degree_u);
-  primal::KnotVector<CoordType> knotVector_v(npts_v, degree_v);
-
-  NURBSPatchType nPatchKnotVector(controlPointsArray, npts_u, npts_v, knotVector_u, knotVector_v);
-  NURBSPatchType wPatchKnotVector(controlPointsArray,
-                                  weightsArray,
-                                  npts_u,
-                                  npts_v,
-                                  knotVector_u,
-                                  knotVector_v);
-
-  EXPECT_EQ(nPatchKnotVector.getDegree_u(), degree_u);
-  EXPECT_EQ(nPatchKnotVector.getDegree_v(), degree_v);
-  for(int p = 0; p < npts_u; ++p)
-  {
-    for(int q = 0; q < npts_v; ++q)
-    {
-      auto& pt1 = nPatchKnotVector(p, q);
-      auto& pt2 = wPatchKnotVector(p, q);
-      double w = wPatchKnotVector.getWeight(p, q);
-
-      EXPECT_DOUBLE_EQ(weightsArray[p * npts_u + q], w);
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPointsArray[p * npts_u + q][i], pt1[i]);
-        EXPECT_DOUBLE_EQ(controlPointsArray[p * npts_u + q][i], pt2[i]);
-      }
-    }
-  }
-
-  // Construct from 2D axom::Array and KnotVector object
-  NURBSPatchType nPatchKnotVector2D(controlPointsArray2D, knotVector_u, knotVector_v);
-  NURBSPatchType wPatchKnotVector2D(controlPointsArray2D, weightsArray2D, knotVector_u, knotVector_v);
-
-  EXPECT_EQ(nPatchKnotVector2D.getDegree_u(), degree_u);
-  EXPECT_EQ(nPatchKnotVector2D.getDegree_v(), degree_v);
-  for(int p = 0; p < npts_u; ++p)
-  {
-    for(int q = 0; q < npts_v; ++q)
-    {
-      auto& pt1 = nPatchKnotVector2D(p, q);
-      auto& pt2 = wPatchKnotVector2D(p, q);
-      double w = wPatchKnotVector2D.getWeight(p, q);
-
-      EXPECT_DOUBLE_EQ(weightsArray2D(p, q), w);
-      for(int i = 0; i < DIM; ++i)
-      {
-        EXPECT_DOUBLE_EQ(controlPointsArray2D(p, q)[i], pt1[i]);
-        EXPECT_DOUBLE_EQ(controlPointsArray2D(p, q)[i], pt2[i]);
-      }
-    }
-  }
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/quest/DiscreteShape.hpp
+++ b/src/axom/quest/DiscreteShape.hpp
@@ -66,7 +66,7 @@ public:
 
   virtual ~DiscreteShape() { clearInternalData(); }
 
-  //@{
+  ///@{
   //! @name Functions to get and set shaping parameters
 
   //! @brief Set prefix for shape files specified as relative path.
@@ -88,7 +88,7 @@ public:
   */
   void setPercentError(double percent);
 
-  //@}
+  ///@}
 
 #if defined(AXOM_USE_MPI)
   /**
@@ -145,14 +145,14 @@ private:
   //!@brief Prefix for disc files with relative path.
   std::string m_prefixPath;
 
-  //@{
+  ///@{
   //!@name Various parameters for discretization of analytical shapes.
   RefinementType m_refinementType;
   double m_percentError {MINIMUM_PERCENT_ERROR};
   int m_samplesPerKnotSpan {DEFAULT_SAMPLES_PER_KNOT_SPAN};
   double m_vertexWeldThreshold {DEFAULT_VERTEX_WELD_THRESHOLD};
   double m_revolvedVolume {0.0};
-  //@}
+  ///@}
 
 #if defined(AXOM_USE_MPI)
   MPI_Comm m_comm {MPI_COMM_WORLD};

--- a/src/axom/quest/IntersectionShaper.hpp
+++ b/src/axom/quest/IntersectionShaper.hpp
@@ -565,7 +565,7 @@ public:
     AXOM_ANNOTATE_END("allocate m_overlap_volumes");
   }
 
-  //@{
+  ///@{
   //!  @name Functions to get and set shaping parameters related to intersection; supplements parameters in base class
 
   void setLevel(int level) { m_level = level; }
@@ -588,7 +588,7 @@ public:
     }
     m_free_mat_name = name;
   }
-  //@}
+  ///@}
 
   /*!
    * \brief Return the revolved volume that was computed during dynamic refinement.
@@ -624,7 +624,7 @@ public:
 private:
 #endif
 
-  //@{
+  ///@{
   //!  @name Private functions related to the stages for a given shape
 
   template <typename ExecSpace>
@@ -1733,7 +1733,7 @@ public:
     m_surfaceMesh.reset();
   }
 
-  //@}
+  ///@}
 
 public:
   /*!

--- a/src/axom/quest/MarchingCubes.hpp
+++ b/src/axom/quest/MarchingCubes.hpp
@@ -4,9 +4,9 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 /*!
- * \file MarchingCubes.hpp
+ * @file MarchingCubes.hpp
  *
- * \brief Consists of classes implementing marching cubes algorithm to
+ * @brief Consists of classes implementing marching cubes algorithm to
  * compute isocontour from a scalar field in a blueprint mesh.
  */
 
@@ -41,14 +41,14 @@ class MarchingCubesSingleDomain;
 }  // namespace detail
 
 /*!
-  @brief Enum for implementation.
-
-  Partial parallel implementation uses a non-parallizable loop and
-  processes less data.  It has been shown to work well on CPUs.
-  Full parallel implementation processes more data, but parallelizes
-  fully and has been shown to work well on GPUs.  byPolicy chooses
-  based on runtime policy.
-*/
+ * @brief Enum for implementation.
+ *
+ * Partial parallel implementation uses a non-parallizable loop and
+ * processes less data.  It has been shown to work well on CPUs.
+ * Full parallel implementation processes more data, but parallelizes
+ * fully and has been shown to work well on GPUs.  byPolicy chooses
+ * based on runtime policy.
+ */
 enum class MarchingCubesDataParallelism
 {
   byPolicy = 0,
@@ -57,7 +57,7 @@ enum class MarchingCubesDataParallelism
 };
 
 /*!
- * \@brief Class implementing marching cubes to compute a contour
+ * @brief Class implementing marching cubes to compute a contour
  * mesh from a scalar function on an input mesh.
  *
  * This implementation is for the original 1987 algorithm:
@@ -65,14 +65,13 @@ enum class MarchingCubesDataParallelism
  * "Marching cubes: A high resolution 3D surface construction algorithm".
  * ACM SIGGRAPH Computer Graphics. 21 (4): 163-169
  *
- * Implementation is for 2D (marching squares) and 3D (marching
- * cubes).
+ * Implementation is for 2D (marching squares) and 3D (marching cubes).
  *
  * The input mesh is a Conduit::Node following the Mesh Blueprint
  * convention.  The mesh must be in multi-domain format.
  *
  * Usage example:
- * @beginverbatim
+ * @verbatim
  *   void foo( conduit::Node &meshNode,
  *             const std::string &topologyName,
  *             const std::string &functionName,
@@ -110,60 +109,59 @@ public:
   using RuntimePolicy = axom::runtime_policy::Policy;
   using DomainIdType = axom::IndexType;
   /*!
-    \brief Constructor sets up runtime preferences for the marching
-    cubes implementation.
-
-    \param [in] runtimePolicy A value from RuntimePolicy.
-                The simplest policy is RuntimePolicy::seq, which specifies
-                running sequentially on the CPU.
-    \param [in] allocatorID Data allocator ID.  Choose something compatible
-                with \c runtimePolicy.  See \c execution_space.
-    \param [in] dataParallelism Data parallel implementation choice.
+   * @brief Constructor sets up runtime preferences for the marching
+   * cubes implementation.
+   *
+   * @param [in] runtimePolicy A value from RuntimePolicy.
+   *             The simplest policy is RuntimePolicy::seq, which specifies
+   *             running sequentially on the CPU.
+   * @param [in] allocatorID Data allocator ID.  Choose something compatible
+   *             with \c runtimePolicy.  See \c execution_space.
+   * @param [in] dataParallelism Data parallel implementation choice.
   */
   MarchingCubes(RuntimePolicy runtimePolicy,
                 int allocatorId,
                 MarchingCubesDataParallelism dataParallelism);
 
   /*!
-    @brief Set the input mesh.
-    \param [in] bpMesh Blueprint multi-domain mesh containing scalar field.
-    \param [in] topologyName Name of Blueprint topology to use in \a bpMesh.
-    \param [in] maskField Cell-based std::int32_t mask field.  If provided,
-                cells where this field evaluates to false are skipped.
-
-    Array data in \a bpMesh must be accessible in the \a runtimePolicy
-    environment specified in the constructor.  It's an error if not,
-    e.g., using CPU memory with a GPU policy.
-
-    Some metadata from \a bpMesh may be cached.  Any change to it
-    after setMesh() leads to undefined behavior.
+   * @brief Set the input mesh.
+   * @param [in] bpMesh Blueprint multi-domain mesh containing scalar field.
+   * @param [in] topologyName Name of Blueprint topology to use in \a bpMesh.
+   * @param [in] maskField Cell-based std::int32_t mask field.  If provided,
+   *             cells where this field evaluates to false are skipped.
+   *
+   * Array data in \a bpMesh must be accessible in the \a runtimePolicy
+   * environment specified in the constructor.  It's an error if not,
+   * e.g., using CPU memory with a GPU policy.
+   * 
+   * Some metadata from \a bpMesh may be cached.  Any change to it
+   * after setMesh() leads to undefined behavior.
   */
   void setMesh(const conduit::Node &bpMesh,
                const std::string &topologyName,
                const std::string &maskField = {});
 
   /*!
-    @brief Set the field containing the nodal function.
-    \param [in] fcnField Name of node-based scalar function values.
+   * @brief Set the field containing the nodal function.
+   * @param [in] fcnField Name of node-based scalar function values.
   */
   void setFunctionField(const std::string &fcnField);
 
   /*!
-    @brief Set the mask value.
-    \param [in] maskVal mask value.  If a mask field is given in
-      setMesh(), compute only for cells whose mask matches this value.
-
-    The default vask value is 1 unless explicitly set by this method.
-    The mask value has no effect if a mask field is not specified.
+   * @brief Set the mask value.
+   * @param [in] maskVal mask value.  If a mask field is given in
+   *   setMesh(), compute only for cells whose mask matches this value.
+   *
+   * The default vask value is 1 unless explicitly set by this method.
+   * The mask value has no effect if a mask field is not specified.
   */
   void setMaskValue(int maskVal) { m_maskVal = maskVal; }
 
   /*!
-   \brief Computes the isocontour.
-   \param [in] contourVal isocontour value
-
-   Each computeIsocontour call adds to previously computed contour
-   mesh.
+   * @brief Computes the isocontour.
+   * @param [in] contourVal isocontour value
+   *
+   * Each computeIsocontour call adds to previously computed contour mesh.
   */
   void computeIsocontour(double contourVal = 0.0);
 
@@ -175,93 +173,90 @@ public:
   //!@brief Get number of nodes in the generated contour mesh.
   axom::IndexType getContourNodeCount() const;
 
-  //@{
+  ///@{
   //!@name Access to output contour mesh
   /*!
-    @brief Put generated contour in a mint::UnstructuredMesh.
-    @param mesh Output contour mesh
-    @param cellIdField Name of field to store the array of
-      parent cells ids, numbered in the row- or column-major
-      ordering of the nodal scalar function.
-      If empty, the data is not provided.
-    @param domainIdField Name of field to store the
-      parent domain ids.  The type of this data is \c DomainIdType.
-      If omitted, the data is not provided.
-
-    If the fields aren't in the mesh, they will be created.
-
-    Important: mint::UnstructuredMesh only supports host memory, so
-    regardless of the allocator ID, this method always deep-copies
-    data to host memory.  To access the data without deep-copying, see
-    the other output methods in this name group.
+   * @brief Put generated contour in a mint::UnstructuredMesh.
+   * @param mesh Output contour mesh
+   * @param cellIdField Name of field to store the array of
+   *   parent cells ids, numbered in the row- or column-major
+   *   ordering of the nodal scalar function.
+   *   If empty, the data is not provided.
+   * @param domainIdField Name of field to store the
+   *   parent domain ids.  The type of this data is \c DomainIdType.
+   *   If omitted, the data is not provided.
+   *
+   *  If the fields aren't in the mesh, they will be created.
+   *
+   *  Important: mint::UnstructuredMesh only supports host memory, so
+   *  regardless of the allocator ID, this method always deep-copies
+   *  data to host memory.  To access the data without deep-copying, see
+   *  the other output methods in this name group.
   */
   void populateContourMesh(axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE> &mesh,
                            const std::string &cellIdField = {},
                            const std::string &domainIdField = {}) const;
 
   /*!
-    @brief Return view of facet corner node indices (connectivity) Array.
-
-    The array shape is (getContourCellCount(), <spatial dimension>), where
-    the second index is index of the facet corner.
-  */
+   * @brief Return view of facet corner node indices (connectivity) Array.
+   *
+   * The array shape is (getContourCellCount(), <spatial dimension>), where
+   * the second index is index of the facet corner.
+   */
   axom::ArrayView<const axom::IndexType, 2> getContourFacetCorners() const
   {
     return m_facetNodeIds.view();
   }
 
   /*!
-    @brief Return view of node coordinates Array.
-
-    The array shape is (getContourNodeCount(), <spatial dimension>), where
-    the second index is the spatial index.
-  */
+   * @brief Return view of node coordinates Array.
+   *
+   * The array shape is (getContourNodeCount(), <spatial dimension>), where
+   * the second index is the spatial index.
+   */
   axom::ArrayView<const double, 2> getContourNodeCoords() const { return m_facetNodeCoords.view(); }
 
   /*!
-    @brief Return view of parent cell indices Array.
-
-    The buffer size is getContourCellCount().  The parent ID is the
-    flat index of the cell in the parent domain (see MDMapping),
-    not counting ghost cells, with row- or major-ordering same as that
-    for the input scalar function array.
-  */
+   *  @brief Return view of parent cell indices Array.
+   *
+   *  The buffer size is getContourCellCount().  The parent ID is the
+   *  flat index of the cell in the parent domain (see MDMapping),
+   *  not counting ghost cells, with row- or major-ordering same as that
+   *  for the input scalar function array.
+   */
   axom::ArrayView<const axom::IndexType> getContourFacetParents() const
   {
     return m_facetParentIds.view();
   }
 
   /*!
-    @brief Return view of parent domain indices Array.
-    @param allocatorID Allocator id for the output data.  If omitted,
-           use the id set in the constructor.
-
-    The buffer size is getContourCellCount().
-  */
+   *   @brief Return view of parent domain indices Array.
+   *   @param allocatorID Allocator id for the output data.  If omitted,
+   *          use the id set in the constructor.
+   *   The buffer size is getContourCellCount().
+   */
   axom::ArrayView<const axom::IndexType> getContourFacetDomainIds() const
   {
     return m_facetDomainIds.view();
   }
 
   /*!
-    @brief Give caller posession of the contour data.
-
-    This efficiently gives the generated contour data to the caller,
-    to stay in scope after the MarchingCubes object is deleted.
-
-    @param [i] facetNodeIds Node ids for the node at the corners of
-      each facet.  @see getContourFacetCorners().
-    @param [i] facetNodeCoords Coordinates of each facet node.
-      @see getContourNodeCoords().
-    @param [i] facetParentIds Parent cell id of each facet.
-      @see getContourFacetParents().
-    @param [i] facetDomainIds Domain id of each facet.
-      @see getContourFacetDomainIds().
-
-    @pre computeIsocontour() must have been called.
-    @post outputs can no longer be accessed from object, as though
-    clearOutput() has been called.
-  */
+   *  @brief Give caller posession of the contour data.
+   *
+   *  This efficiently gives the generated contour data to the caller,
+   *  to stay in scope after the MarchingCubes object is deleted.
+   *  @param [i] facetNodeIds Node ids for the node at the corners of each facet.
+   *  @see getContourFacetCorners().
+   *  @param [i] facetNodeCoords Coordinates of each facet node.
+   *  @see getContourNodeCoords().
+   *  @param [i] facetParentIds Parent cell id of each facet.
+   *  @see getContourFacetParents().
+   *  @param [i] facetDomainIds Domain id of each facet.
+   *  @see getContourFacetDomainIds().
+   * 
+   *  @pre computeIsocontour() must have been called.
+   *  @post outputs can no longer be accessed from object, as though clearOutput() has been called.
+   */
   void relinquishContourData(axom::Array<axom::IndexType, 2> &facetNodeIds,
                              axom::Array<double, 2> &facetNodeCoords,
                              axom::Array<axom::IndexType, 1> &facetParentIds,
@@ -278,11 +273,9 @@ public:
     facetParentIds.swap(m_facetParentIds);
     facetDomainIds.swap(m_facetDomainIds);
   }
-  //@}
+  ///@}
 
-  /*!
-    @brief Clear the computed contour mesh.
-  */
+  //! @brief Clear the computed contour mesh.
   void clearOutput();
 
   // Allow single-domain code to share common scratch space.
@@ -301,16 +294,16 @@ private:
   RuntimePolicy m_runtimePolicy;
   int m_allocatorID = axom::INVALID_ALLOCATOR_ID;
 
-  //@brief Choice of full or partial data-parallelism, or byPolicy.
+  //! @brief Choice of full or partial data-parallelism, or byPolicy.
   MarchingCubesDataParallelism m_dataParallelism = MarchingCubesDataParallelism::byPolicy;
 
-  //!@brief Number of domains.
+  //! @brief Number of domains.
   axom::IndexType m_domainCount;
 
   /*!
-    @brief Single-domain implementations.
-
-    May be longer than m_domainCount (the real count).
+   * @brief Single-domain implementations.
+   *
+   * May be longer than m_domainCount (the real count).
   */
   axom::Array<std::shared_ptr<detail::marching_cubes::MarchingCubesSingleDomain>> m_singles;
   std::string m_topologyName;
@@ -321,49 +314,47 @@ private:
 
   int m_maskVal = 1;
 
-  //!@brief First facet index from each parent domain.
+  //! @brief First facet index from each parent domain.
   axom::Array<axom::IndexType> m_facetIndexOffsets;
 
-  //!@brief Facet count over all parent domains.
+  //! @brief Facet count over all parent domains.
   axom::IndexType m_facetCount = 0;
 
-  //@{
-  //!@name Scratch space from m_allocatorID, shared among singles
+  ///@{
+  //! @name Scratch space from m_allocatorID, shared among singles
   // Memory alloc is slow on CUDA, so this optimizes space AND time.
   axom::Array<std::uint16_t> m_caseIdsFlat;
 
   axom::Array<CrossingFlagType> m_crossingFlags;
   axom::Array<axom::IndexType> m_scannedFlags;
   axom::Array<axom::IndexType> m_facetIncrs;
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!@name Generated contour mesh, shared with singles.
   /*!
-    @brief Corners (index into m_facetNodeCoords) of generated facets.
-    @see allocateOutputBuffers().
+   * @brief Corners (index into m_facetNodeCoords) of generated facets.
+   * @see allocateOutputBuffers().
   */
   axom::Array<axom::IndexType, 2> m_facetNodeIds;
 
   /*!
-    @brief Coordinates of generated surface mesh nodes.
-    @see allocateOutputBuffers().
+   * @brief Coordinates of generated surface mesh nodes.
+   * @see allocateOutputBuffers().
   */
   axom::Array<double, 2> m_facetNodeCoords;
 
   /*!
-    @brief Flat index of parent cell of facets.
-    @see allocateOutputBuffers().
+   * @brief Flat index of parent cell of facets.
+   * @see allocateOutputBuffers().
   */
   axom::Array<IndexType, 1> m_facetParentIds;
 
-  /*!
-    @brief Domain ids of facets.
-  */
+  /// @brief Domain ids of facets
   axom::Array<IndexType, 1> m_facetDomainIds;
-  //@}
+  ///@}
 
-  //!@brief Allocate output buffers corresponding to runtime policy.
+  //! @brief Allocate output buffers corresponding to runtime policy.
   void allocateOutputBuffers();
 };
 

--- a/src/axom/quest/MeshViewUtil.hpp
+++ b/src/axom/quest/MeshViewUtil.hpp
@@ -64,27 +64,24 @@ static inline T product(const axom::StackArray<T, DIM>& a)
   return prod;
 }
 
-//@{
+///@{
 //!@name Conversions between shape specifications and strides-and-offsets.
+
 /*!
-  @brief Convert shape specifications to blueprint-style
-  offsets and strides.
-
-  @tparam IType Index type
-  @tparam DIM Spatial dimension
-
-  @param realShape [i]
-  @param loPads [i] Ghost padding amount on low side.
-  @param hiPads [i] Ghost padding amount ont high side.
-  @param strideOrder [i] Fastest-to-slowest advancing
-    index directions.
-  @param minStride [i] Stride of fastest advancing
-    index direction.
-  @param offsets [o] Blueprint-style index offsets.
-  @param strides [o] Blueprint-style strides.
-  @param valuesCount [o] Number of values in
-    ghost-padded data.
-*/
+ * @brief Convert shape specifications to blueprint-style offsets and strides.
+ *
+ * @tparam IType Index type
+ * @tparam DIM Spatial dimension
+ *
+ * @param realShape [i]
+ * @param loPads [i] Ghost padding amount on low side.
+ * @param hiPads [i] Ghost padding amount ont high side.
+ * @param strideOrder [i] Fastest-to-slowest advancing index directions.
+ * @param minStride [i] Stride of fastest advancing index direction.
+ * @param offsets [o] Blueprint-style index offsets.
+ * @param strides [o] Blueprint-style strides.
+ * @param valuesCount [o] Number of values in ghost-padded data.
+ */
 template <typename IType, int DIM>
 static void shapesToStridesAndOffsets(const axom::StackArray<IType, DIM>& realShape,
                                       const axom::StackArray<IType, DIM>& loPads,
@@ -114,25 +111,21 @@ static void shapesToStridesAndOffsets(const axom::StackArray<IType, DIM>& realSh
 }
 
 /*!
-  @brief Convert blueprint-style offsets and strides to
-  shape specifications.
-
-  @tparam IType Index type
-  @tparam DIM Spatial dimension
-
-  @param realShape [i]
-  @param offsets [i] Blueprint-style index offsets.
-  @param strides [i] Blueprint-style strides.
-  @param valuesCount [i] Number of values in
-    ghost-padded data.
-  @param paddedShape [o] \a realShape + \a loPads + \a hiPads
-  @param loPads [o] Ghost padding amount on low side.
-  @param hiPads [o] Ghost padding amount ont high side.
-  @param minStride [i] Stride of fastest advancing
-    index direction.
-  @param strideOrder [i] Fastest-to-slowest advancing
-    index directions.
-*/
+ * @brief Convert blueprint-style offsets and strides to shape specifications.
+ *
+ * @tparam IType Index type
+ * @tparam DIM Spatial dimension
+ *
+ * @param realShape [i]
+ * @param offsets [i] Blueprint-style index offsets.
+ * @param strides [i] Blueprint-style strides.
+ * @param valuesCount [i] Number of values in ghost-padded data.
+ * @param paddedShape [o] \a realShape + \a loPads + \a hiPads
+ * @param loPads [o] Ghost padding amount on low side.
+ * @param hiPads [o] Ghost padding amount ont high side.
+ * @param minStride [i] Stride of fastest advancing index direction.
+ * @param strideOrder [i] Fastest-to-slowest advancing index directions.
+ */
 template <typename IType, int DIM>
 static void stridesAndOffsetsToShapes(const axom::StackArray<IType, DIM>& realShape,
                                       const axom::StackArray<IType, DIM>& offsets,
@@ -173,35 +166,35 @@ static void stridesAndOffsetsToShapes(const axom::StackArray<IType, DIM>& realSh
     hiPads[d] = paddedShape[d] - realShape[d] - loPads[d];
   }
 }
-//@}
+///@}
 
 }  // namespace internal
 
 /**
-   \brief Utility for high-level access into a blueprint mesh,
-   for structured mesh with explicit coordinates.
-
-   Note: This class was written for a specific use and supports
-   only structured domains with explicit node values.
-
-   Blueprint mesh data is sufficient but sparse, leaving users to
-   compute some intermediate data to get to high-level data of
-   interest, such as views into array data.  This class encapsulates
-   those common functions.
-
-   Views are single-domain-specific.  They don't apply to multi-domain
-   meshes.  They are also topology specific, with the topology name
-   given to the constructor.  They are valid only while their domain
-   exists with no change to its data layout.
-
-   This class recognizes potential ghost (a.k.a. phony, image) data
-   layers around the domain.  Some methods and paramenters names refer
-   to the data with ghosts, while others refer to the data without
-   ghosts (a.k.a. real data).
-
-   TODO: Figure out if there's a better place for this utility.
-   It's only in axom/quest because the initial need was there.
-*/
+ * \brief Utility for high-level access into a blueprint mesh,
+ * for structured mesh with explicit coordinates.
+ *
+ * Note: This class was written for a specific use and supports
+ * only structured domains with explicit node values.
+ *
+ * Blueprint mesh data is sufficient but sparse, leaving users to
+ * compute some intermediate data to get to high-level data of
+ * interest, such as views into array data.  This class encapsulates
+ * those common functions.
+ *
+ * Views are single-domain-specific.  They don't apply to multi-domain
+ * meshes.  They are also topology specific, with the topology name
+ * given to the constructor.  They are valid only while their domain
+ * exists with no change to its data layout.
+ *
+ * This class recognizes potential ghost (a.k.a. phony, image) data
+ * layers around the domain.  Some methods and paramenters names refer
+ * to the data with ghosts, while others refer to the data without
+ * ghosts (a.k.a. real data).
+ *
+ * TODO: Figure out if there's a better place for this utility.
+ * It's only in axom/quest because the initial need was there.
+ */
 template <int DIM, axom::MemorySpace MemSpace = MemorySpace::Dynamic>
 class MeshViewUtil
 {
@@ -210,9 +203,10 @@ public:
   using CoordsViewsType = axom::StackArray<axom::ArrayView<double, DIM, MemSpace>, DIM>;
   using ConstCoordsViewsType = axom::StackArray<axom::ArrayView<const double, DIM, MemSpace>, DIM>;
 
-  //@{
-  //@name Setting up
-  //!@brief Default constructor doesn't set up the view utility.
+  ///@{
+  /// @name Setting up
+
+  //! @brief Default constructor doesn't set up the view utility.
   MeshViewUtil()
     : m_dom(nullptr)
     , m_topology(nullptr)
@@ -221,15 +215,16 @@ public:
     , m_ctopology(nullptr)
     , m_ccoordset(nullptr)
   { }
+
   /*!
-    @brief Construct view of a non-const domain.
-
-    @param [in] bpDomain Blueprint single domain.
-    @param [in] topologyName Name of topology in the domain.
-
-    If \a topologyName is omitted, use the first topology.
-
-    The topology dimension must match DIM.
+   * @brief Construct view of a non-const domain.
+   *
+   * @param [in] bpDomain Blueprint single domain.
+   * @param [in] topologyName Name of topology in the domain.
+   *
+   * If \a topologyName is omitted, use the first topology.
+   *
+   * @pre The topology dimension must match DIM.
   */
   MeshViewUtil(conduit::Node& bpDomain, const std::string& topologyName = "")
     : m_dom(&bpDomain)
@@ -263,13 +258,13 @@ public:
   }
 
   /*!
-    @brief Construct view of a const domain.
-
-    @param [in] bpDomain const Blueprint single domain.
-    @param [in] topologyName Name op topology in the domain.
-
-    If \a topologyName is omitted, use the first topology.
-    The topology dimension must match DIM.
+   * @brief Construct view of a const domain.
+   *
+   * @param [in] bpDomain const Blueprint single domain.
+   * @param [in] topologyName Name op topology in the domain.
+   *
+   * If \a topologyName is omitted, use the first topology.
+   * @pre The topology dimension must match DIM.
   */
   MeshViewUtil(const conduit::Node& bpDomain, const std::string& topologyName)
     : m_cdom(&bpDomain)
@@ -295,11 +290,9 @@ public:
   }
 
   /*!
-    @brief Whether the domain is a valid one for this utility.
-
-    In addition to checking for blueprint validity (unless \a
-    checkBlueprint is false), this method checks against its own
-    requirements.
+  * @brief Whether the domain is a valid one for this utility.
+  * In addition to checking for blueprint validity (unless \a checkBlueprint is false), 
+  * this method checks against its own requirements.
   */
   bool isValid(bool checkBlueprint = false, bool printFailureCause = false) const
   {
@@ -337,14 +330,14 @@ public:
 
     return valA && valB && valC && valD;
   }
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!@name Blueprint data organization
   /*!
-    @brief Get the named topology.
-
-    @return the Conduit node at "topologies/<topologyName>".
+   * @brief Get the named topology.
+   * 
+   * @return the Conduit node at "topologies/<topologyName>".
   */
   const conduit::Node& getTopology() { return *m_topology; }
   const conduit::Node& getTopology() const { return *m_ctopology; }
@@ -355,10 +348,10 @@ public:
 
   //! @brief Get the spatial dimension of the named topology.
   conduit::index_t getTopologyDim() const { return DIM; }
-  //@}
+  ///@}
 
-  //@{
-  //!@name General sizes and shapes of domain
+  ///@{
+  //! @name General sizes and shapes of domain
 
   //! @brief Get the number of cells in each direction of the domain.
   MdIndices getCellShape() const { return m_cellShape; }
@@ -391,21 +384,15 @@ public:
 
     return m_cellShape;
   }
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //! @name Coordinates and field data sizes and shapes.
 
-  /*!
-    @brief Return the array strides for ghost-free nodal
-    coordinates.
-  */
+  /// @brief Return the array strides for ghost-free nodal coordinates.
   MdIndices getCoordsStrides() const { return m_coordsStrides; }
 
-  /*!
-    @brief Return the array index offsets for ghost-free nodal
-    coordinates.
-  */
+  /// @brief Return the array index offsets for ghost-free nodal coordinates.
   MdIndices getCoordsOffsets() const { return m_coordsOffsets; }
 
   //! @brief Return number of points, excluding ghosts.
@@ -418,12 +405,12 @@ public:
     axom::IndexType rval = valuesNode[0].dtype().number_of_elements();
     return rval;
   }
-  //@}
+  ///@}
 
-  //@{
-  //!@name Coords and data views
+  ///@{
+  //! @name Coords and data views
 
-  //!@brief Return the views of the DIM coordinates component data.
+  //! @brief Return the views of the DIM coordinates component data.
   CoordsViewsType getCoordsViews(bool withGhosts = false)
   {
     conduit::Node& valuesNode = getCoordSet().fetch_existing("values");
@@ -450,7 +437,7 @@ public:
     return rval;
   }
 
-  //!@brief Return the views of the DIM coordinates component data.
+  //! @brief Return the views of the DIM coordinates component data.
   ConstCoordsViewsType getConstCoordsViews(bool withGhosts = false) const
   {
     const conduit::Node& valuesNode = getCoordSet().fetch_existing("values");
@@ -482,15 +469,14 @@ public:
   }
 
   /*!
-    @brief Return view to a scalar field variable.
-
-    WARNING: The view returned has an allocator id determined by
-    \a MemSpace, regardless of the memory type.
-
-    WARNING: Assuming, without checking, that the field contains
-    data of type \a T.  User is responsible for using the correct
-    type.
-  */
+   * @brief Return view to a scalar field variable.
+   * 
+   * @warning view returned has an allocator id determined by
+   * \a MemSpace, regardless of the memory type.
+   * 
+   * @warning Assuming, without checking, that the field contains
+   * data of type \a T.  User is responsible for using the correct type.
+   */
   template <typename T>
   axom::ArrayView<T, DIM, MemSpace> getFieldView(const std::string& fieldName, bool withGhosts = false)
   {
@@ -547,15 +533,14 @@ public:
   }
 
   /*!
-    @brief Return view to a scalar field variable.
-
-    WARNING: The view returned has an allocator id determined by
-    \a MemSpace, regardless of the memory type.
-
-    WARNING: Assuming, without checking, that the field contains
-    data of type \a T.  User is responsible for using the correct
-    type.
-  */
+   * @brief Return view to a scalar field variable.
+   * 
+   * @warning The view returned has an allocator id determined by
+   * \a MemSpace, regardless of the memory type.
+   * 
+   * @warning Assuming, without checking, that the field contains
+   * data of type \a T.  User is responsible for using the correct type.
+   */
   template <typename T>
   axom::ArrayView<const T, DIM, MemSpace> getConstFieldView(const std::string& fieldName,
                                                             bool withGhosts = false)
@@ -605,32 +590,32 @@ public:
 
     return rval;
   }
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!@name Creating data
 
   /*!
-    @brief Create a new scalar nodal data field with specified
-    strides and offsets.
-
-    @param [in] fieldName
-    @param [in] association "vertex" or "element"
-    @param [in] dtype Conduit data type to put in the field.  Must be at least
-                big enough for the strides and offsets specified.
-    @param [in] strides Data strides.  Set to zero for no ghosts and default strides.
-    @param [in] offsets Data index offsets.  Set to zero for no ghosts.
-
-    Field data allocation is done by Conduit, so the data lives in
-    host memory.  Conduit currently doesn't provide a means to allocate
-    the array in device memory.
-
-    Creating a field with given strides and offsets may only be useful
-    for matching the strides and offsets of existing data.  It's more
-    natural to create the field based on ghost layer thickness and
-    index advancement order (row-major, column-major or some other).
-    Use createFieldPadded() for this.
-  */
+   * @brief Create a new scalar nodal data field with specified
+   * strides and offsets.
+   *
+   * @param [in] fieldName
+   * @param [in] association "vertex" or "element"
+   * @param [in] dtype Conduit data type to put in the field.  Must be at least
+   *             big enough for the strides and offsets specified.
+   * @param [in] strides Data strides.  Set to zero for no ghosts and default strides.
+   * @param [in] offsets Data index offsets.  Set to zero for no ghosts.
+   *
+   * Field data allocation is done by Conduit, so the data lives in
+   * host memory.  Conduit currently doesn't provide a means to allocate
+   * the array in device memory.
+   *
+   * Creating a field with given strides and offsets may only be useful
+   * for matching the strides and offsets of existing data.  It's more
+   * natural to create the field based on ghost layer thickness and
+   * index advancement order (row-major, column-major or some other).
+   * Use createFieldPadded() for this.
+   */
   void createField(const std::string& fieldName,
                    const std::string& association,
                    const conduit::DataType& dtype,
@@ -690,23 +675,21 @@ public:
   }
 
   /*!
-    @brief Create a new scalar nodal data field with specified
-    ghost paddings.
-
-    @param [in] fieldName
-    @param [in] association "vertex" or "element"
-    @param [in] dtype Conduit data type to put in the field.
-      If dtype has too few elements, the minimum sufficient
-      size will be allocated.
-    @param loPads [i] Ghost padding amount on low side.
-    @param hiPads [i] Ghost padding amount ont high side.
-    @param strideOrder [i] Fastest-to-slowest advancing
-      index directions.
-
-    Field data allocation is done by Conduit, so the data lives in
-    host memory.  Conduit currently doesn't provide a means to allocate
-    the array in device memory.
-  */
+   * @brief Create a new scalar nodal data field with specified ghost paddings.
+   * 
+   * @param [in] fieldName
+   * @param [in] association "vertex" or "element"
+   * @param [in] dtype Conduit data type to put in the field.
+   *   If dtype has too few elements, the minimum sufficient
+   *   size will be allocated.
+   * @param loPads [i] Ghost padding amount on low side.
+   * @param hiPads [i] Ghost padding amount ont high side.
+   * @param strideOrder [i] Fastest-to-slowest advancing index directions.
+   * 
+   * Field data allocation is done by Conduit, so the data lives in
+   * host memory.  Conduit currently doesn't provide a means to allocate
+   * the array in device memory.
+   */
   void createField(const std::string& fieldName,
                    const std::string& association,
                    const conduit::DataType& dtype,
@@ -756,7 +739,7 @@ public:
     }
     fieldNode["values"].set(bumpedDtype);
   }
-  //@}
+  ///@}
 
 private:
   conduit::Node* m_dom = nullptr;

--- a/src/axom/quest/SamplingShaper.hpp
+++ b/src/axom/quest/SamplingShaper.hpp
@@ -70,7 +70,7 @@ public:
     m_inoutArrays.clear();
   }
 
-  //@{
+  ///@{
   //!  @name Functions to get and set shaping parameters related to sampling; supplements parameters in base class
 
   void setSamplingType(shaping::VolFracSampling vfSampling) { m_vfSampling = vfSampling; }
@@ -91,7 +91,7 @@ public:
   /// Registers a function to project from 3D input points to 3D query points
   void setPointProjector33(shaping::PointProjector<3, 3> projector) { m_projector33 = projector; }
 
-  //@}
+  ///@}
 
   /// Returns a pointer to the quadrature function associated with shape \a name if it exists, else nullptr
   mfem::QuadratureFunction* getShapeQFunction(const std::string& name) const
@@ -140,7 +140,7 @@ private:
   }
 
 public:
-  //@{
+  ///@{
   //!  @name Functions related to the stages for a given shape
 
   /// Initializes the spatial index for shaping
@@ -396,7 +396,7 @@ public:
     m_surfaceMesh.reset();
   }
 
-  //@}
+  ///@}
 
 public:
   /**

--- a/src/axom/quest/Shaper.hpp
+++ b/src/axom/quest/Shaper.hpp
@@ -43,8 +43,7 @@ namespace quest
 /**
  * Abstract base class for shaping material volume fractions
  *
- * Shaper requires Axom to be configured with Conduit or MFEM
- * or both.
+ * Shaper requires Axom to be configured with Conduit or MFEM or both.
  */
 class Shaper
 {
@@ -52,9 +51,7 @@ public:
   using RuntimePolicy = axom::runtime_policy::Policy;
 
 #if defined(AXOM_USE_MFEM)
-  /*!
-    @brief Construct Shaper to operate on an MFEM mesh.
-  */
+  /// @brief Construct Shaper to operate on an MFEM mesh.
   Shaper(RuntimePolicy execPolicy,
          int allocatorId,
          const klee::ShapeSet& shapeSet,
@@ -62,9 +59,9 @@ public:
 #endif
 
   /*!
-    @brief Construct Shaper to operate on a blueprint-formatted mesh
-    stored in a sidre Group.
-  */
+   * @brief Construct Shaper to operate on a blueprint-formatted mesh
+   * stored in a sidre Group.
+   */
   Shaper(RuntimePolicy execPolicy,
          int allocatorId,
          const klee::ShapeSet& shapeSet,
@@ -72,13 +69,13 @@ public:
          const std::string& topo = "");
 
   /*!
-    @brief Construct Shaper to operate on a blueprint-formatted mesh
-    stored in a conduit Node.
-
-    Because \c conduit::Node doesn't support application-specified
-    allocator id for (only) arrays, the incoming \c bpNode must have
-    all arrays pre-allocated in a space accessible by the runtime
-    policy.  Any needed-but-missing space would lead to an exception.
+   * @brief Construct Shaper to operate on a blueprint-formatted mesh
+   * stored in a conduit Node.
+   * 
+   * Because \c conduit::Node doesn't support application-specified
+   * allocator id for (only) arrays, the incoming \c bpNode must have
+   * all arrays pre-allocated in a space accessible by the runtime
+   * policy.  Any needed-but-missing space would lead to an exception.
   */
   Shaper(RuntimePolicy execPolicy,
          int allocatorId,
@@ -101,7 +98,7 @@ public:
   //! @brief Verify the input mesh is okay for this class to work with.
   bool verifyInputMesh(std::string& whyBad) const;
 
-  //@{
+  ///@{
   //!  @name Functions to get and set shaping parameters
 
   void setSamplesPerKnotSpan(int nSamples);
@@ -110,13 +107,13 @@ public:
   void setPercentError(double percent);
   void setRefinementType(RefinementType t);
 
-  //@}
+  ///@}
 
   /*!
-    @brief Set path of shape input file.
-
-    The path is used to resolve relative paths that may have been
-    specified in the file.
+   * @brief Set path of shape input file.
+   *
+   * The path is used to resolve relative paths that may have been
+   * specified in the file.
   */
   void setFilePath(const std::string& filePath);
 
@@ -146,8 +143,8 @@ public:
   RuntimePolicy getExecutionPolicy() const { return m_execPolicy; }
 
 public:
-  //@{
-  //!  @name Functions related to the stages for a given shape
+  ///@{
+  ///  @name Functions related to the stages for a given shape
 
   /// Loads the shape from file into m_surfaceMesh
   virtual void loadShape(const klee::Shape& shape);
@@ -160,15 +157,15 @@ public:
 
   virtual void finalizeShapeQuery() = 0;
 
-  //@}
+  ///@}
 
 public:
-  //@{
-  //!  @name Functions to generate/adjust volume fractions after all shapes have been applied
+  ///@{
+  ///  @name Functions to generate/adjust volume fractions after all shapes have been applied
 
   virtual void adjustVolumeFractions() = 0;
 
-  //@}
+  ///@}
 
   /*!
    * \brief Helper to apply a parallel sum reduction to a quantity

--- a/src/axom/quest/detail/MarchingCubesSingleDomain.hpp
+++ b/src/axom/quest/detail/MarchingCubesSingleDomain.hpp
@@ -149,11 +149,11 @@ public:
   struct ImplBase
   {
     /*!
-      @brief Prepare internal data for operating on the given domain.
-
-      Put in here codes that can't be in MarchingCubesSingleDomain
-      due to template use (DIM and ExecSpace).
-    */
+     * @brief Prepare internal data for operating on the given domain.
+     *
+     * Put in here codes that can't be in MarchingCubesSingleDomain
+     * due to template use (DIM and ExecSpace).
+     */
     virtual void setDomain(const conduit::Node &dom,
                            const std::string &topologyName,
                            const std::string &maskPath = {}) = 0;
@@ -164,22 +164,28 @@ public:
 
     virtual void setDataParallelism(MarchingCubesDataParallelism dataPar) = 0;
 
-    //@{
-    //!@name Distinct phases in contour generation.
-    //!@brief Compute the contour mesh.
-    //!@brief Mark parent cells that cross the contour value.
+    ///@{
+    //! @name Distinct phases in contour generation.
+
+    /*!
+     * @brief Compute the contour mesh.
+     * @brief Mark parent cells that cross the contour value.
+     */
     virtual void markCrossings() = 0;
+
     //!@brief Scan operations to determine counts and offsets.
     virtual void scanCrossings() = 0;
+
     //!@brief Compute contour data.
     virtual void computeFacets() = 0;
-    //@}
+    ///@}
 
-    //@{
+    ///@{
     //!@name Output methods
-    //!@brief Return number of contour mesh facets generated.
+
+    //! @brief Return number of contour mesh facets generated.
     virtual axom::IndexType getContourCellCount() const = 0;
-    //@}
+    ///@}
 
     void setOutputBuffers(axom::ArrayView<axom::IndexType, 2> &facetNodeIds,
                           axom::ArrayView<double, 2> &facetNodeCoords,
@@ -209,30 +215,28 @@ public:
   ImplBase &getImpl() { return *m_impl; }
 
 private:
-  //!@brief Multi-domain implementation this object is under.
+  //! @brief Multi-domain implementation this object is under.
   MarchingCubes &m_mc;
 
   RuntimePolicy m_runtimePolicy;
   int m_allocatorID = axom::INVALID_ALLOCATOR_ID;
 
-  //@brief Choice of full or partial data-parallelism, or byPolicy.
+  //! @brief Choice of full or partial data-parallelism, or byPolicy.
   MarchingCubesDataParallelism m_dataParallelism = MarchingCubesDataParallelism::byPolicy;
 
-  /*!
-    \brief Computational mesh as a conduit::Node.
-  */
+  //! \brief Computational mesh as a conduit::Node.
   const conduit::Node *m_dom;
   int m_ndim;
 
-  //!@brief Name of Blueprint topology in m_dom.
+  //! @brief Name of Blueprint topology in m_dom.
   std::string m_topologyName;
 
   std::string m_fcnFieldName;
-  //!@brief Path to nodal scalar function in m_dom.
+  //! @brief Path to nodal scalar function in m_dom.
   std::string m_fcnPath;
 
   std::string m_maskFieldName;
-  //!@brief Path to mask in m_dom.
+  //! @brief Path to mask in m_dom.
   std::string m_maskPath;
 
   double m_contourVal = 0.0;
@@ -247,9 +251,7 @@ private:
    */
   void setDomain(const conduit::Node &dom);
 
-  /*!
-    @brief Allocate MarchingCubesImpl object
-  */
+  /// @brief Allocate MarchingCubesImpl object
   std::unique_ptr<ImplBase> newMarchingCubesImpl();
 
 };  // class MarchingCubesSingleDomain

--- a/src/axom/sidre/core/AttrValues.hpp
+++ b/src/axom/sidre/core/AttrValues.hpp
@@ -219,7 +219,7 @@ private:
    */
   IndexType getNextValidAttrValueIndex(IndexType idx) const;
 
-  //@{
+  ///@{
   //!  @name Private AttrValues ctor and dtor
   //!        (callable only by DataStore methods).
 
@@ -228,20 +228,15 @@ private:
    */
   AttrValues();
 
-  /*!
-   * \brief Private copy ctor.
-   */
+  /// \brief Private copy ctor.
   AttrValues(const AttrValues& source);
 
-  /*!
-   * \brief Private dtor.
-   */
+  /// \brief Private dtor.
   ~AttrValues();
 
-  //@}
+  ///@}
 
   ///////////////////////////////////////////////////////////////////
-  //
   using Values = std::vector<Node>;
   ///////////////////////////////////////////////////////////////////
 

--- a/src/axom/sidre/core/Attribute.hpp
+++ b/src/axom/sidre/core/Attribute.hpp
@@ -126,7 +126,7 @@ private:
   DISABLE_DEFAULT_CTOR(Attribute);
   DISABLE_MOVE_AND_ASSIGNMENT(Attribute);
 
-  //@{
+  ///@{
   //!  @name Private Attribute ctor and dtor
   //!        (callable only by DataStore methods).
 
@@ -146,7 +146,7 @@ private:
    */
   ~Attribute();
 
-  //@}
+  ///@}
 
   /// Name of this Attribute object.
   std::string m_name;

--- a/src/axom/sidre/core/Buffer.hpp
+++ b/src/axom/sidre/core/Buffer.hpp
@@ -67,7 +67,7 @@ public:
   friend class Group;
   friend class View;
 
-  //@{
+  ///@{
   //!  @name Basic query and accessor methods
 
   /*!
@@ -84,9 +84,9 @@ public:
     return static_cast<IndexType>(m_views.size());
   }
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Methods to query and access Buffer data
 
   /*!
@@ -144,9 +144,9 @@ public:
    */
   bool isDescribed() const { return !m_node.dtype().is_empty(); }
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Data description and allocation methods
 
   /*!
@@ -211,7 +211,7 @@ public:
    */
   Buffer* deallocate();
 
-  //@}
+  ///@}
 
   /*!
    * \brief Copy given number of bytes of data from src into Buffer.

--- a/src/axom/sidre/core/DataStore.hpp
+++ b/src/axom/sidre/core/DataStore.hpp
@@ -82,7 +82,7 @@ public:
    */
   const Group* getRoot() const { return m_RootGroup; };
 
-  //@{
+  ///@{
   /*!  @name Methods to query and clear Conduit I/O flags and exception messages.
    *
    * If an error occurs, the load(), save(), and loadExternalData() methods of
@@ -106,10 +106,10 @@ public:
     m_conduit_errors = m_conduit_errors + "\n" + mesg;
   };
 
-  //@}
+  ///@}
 
 public:
-  //@{
+  ///@{
   //!  @name Methods to query, access, create, and destroy Buffers.
 
   /// \brief Return number of Buffers in the DataStore.
@@ -128,16 +128,13 @@ public:
   bool hasBuffer(IndexType idx) const;
 
   /*!
-   * \brief Insert information about DataStore Buffers in fields of given
-   *        Conduit Node.
+   * \brief Insert information about DataStore Buffers in fields of given Conduit Node.
    *
-   *        Fields in Conduit Node will be named:
-   * 
-   *          - "num_buffers" : number of Buffer objects owned by DataStore
-   *          - "num_buffers_referenced" : number of Buffers with View attached
-   *          - "num_buffers_detached" : number of Buffers with no View attached
-   *          - "num_bytes_allocated" : total number of allocated bytes over
-   *                                    all buffers
+   * Fields in Conduit Node will be named:
+   *  - "num_buffers" : number of Buffer objects owned by DataStore
+   *  - "num_buffers_referenced" : number of Buffers with View attached
+   *  - "num_buffers_detached" : number of Buffers with no View attached
+   *  - "num_bytes_allocated" : total number of allocated bytes over all buffers
    *
    * Numeric values associated with these fields may be accessed as type 
    * axom::IndexType, which is defined at compile-time. For example,
@@ -195,31 +192,32 @@ public:
   void destroyBuffer(IndexType idx);
 
   /*!
-   * \brief Remove all Buffers from the DataStore and destroy them
-   *        and their data.
+   * \brief Remove all Buffers from the DataStore and destroy them and their data.
    *
    *        Note that Buffer destruction detaches it from all Views to
    *        which it is attached.
    */
   void destroyAllBuffers();
 
-  //@}
+  ///@}
 
-  //@{
-  //!  @name Methods for iterating over Buffers in the DataStore.
-  //!
-  //! Using these methods, a code can get the first Buffer index and each
-  //! succeeding index.  This allows Buffer iteration using the same
-  //! constructs in C++, C, and Fortran.  Example:
-  //!
-  //!      for (sidre::IndexType idx = ds->getFirstValidBufferIndex();
-  //!           sidre::indexIsValid(idx);
-  //!           idx = ds->getNextValidBufferIndex(idx))
-  //!      {
-  //!          Buffer * buf = ds->getBuffer(idx);
-  //!
-  //!          /// code here using buf
-  //!      }
+  ///@{
+  /**
+   * @name Methods for iterating over Buffers in the DataStore.
+   *
+   * Using these methods, a code can get the first Buffer index and each
+   * succeeding index.  This allows Buffer iteration using the same
+   * constructs in C++, C, and Fortran.  Example:
+   *
+   *      for (sidre::IndexType idx = ds->getFirstValidBufferIndex();
+   *           sidre::indexIsValid(idx);
+   *           idx = ds->getNextValidBufferIndex(idx))
+   *      {
+   *          Buffer * buf = ds->getBuffer(idx);
+   *
+   *          /// code here using buf
+   *      }
+   */
 
   /*!
    * \brief Return first valid Buffer index.
@@ -239,37 +237,33 @@ public:
    */
   IndexType getNextValidBufferIndex(IndexType idx) const;
 
-  //@}
+  ///@}
 
-  //@{
-  //!  @name Accessors for iterating buffer collections.
-  //!
-  //! These methods can be used to iterate over the collection of buffers
-  //! Example:
-  //!      for (auto& buffer : ds->buffers())
-  //!      {
-  //!          /// code here using buffers
-  //!      }
-
-  /*!
-   * \brief Returns an adaptor to support iterating the collection of buffers
+  ///@{
+  /*!  
+   * @name Accessors for iterating buffer collections.
+   *
+   * These methods can be used to iterate over the collection of buffers
+   * Example:
+   *     for (auto& buffer : ds->buffers())
+   *     {
+   *         /// code here using buffers
+   *     }
    */
+
+  /// \brief Returns an adaptor to support iterating the collection of buffers
   typename BufferCollection::iterator_adaptor buffers();
 
-  /*!
-   * \brief Returns a const adaptor to support iterating the collection of buffers
-   */
+  /// \brief Returns a const adaptor to support iterating the collection of buffers
   typename BufferCollection::const_iterator_adaptor buffers() const;
 
-  //@}
+  ///@}
 
 public:
-  //@{
+  ///@{
   //!  @name Methods to query, access, create, and destroy Attributes.
 
-  /*!
-   * \brief Return number of Attributes in the DataStore.
-   */
+  /// \brief Return number of Attributes in the DataStore.
   IndexType getNumAttributes() const;
 
   /*!
@@ -344,9 +338,9 @@ public:
    */
   void destroyAllAttributes();
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Attribute access methods.
 
   /*!
@@ -386,23 +380,25 @@ public:
   /// \brief Create attributes from name/value pairs in node["attribute"].
   void loadAttributeLayout(Node& node);
 
-  //@}
+  ///@}
 
-  //@{
-  //!  @name Methods for iterating over Attributes in the DataStore.
-  //!
-  //! Using these methods, a code can get the first Attribute index and each
-  //! succeeding index.  This allows Attribute iteration using the same
-  //! constructs in C++, C, and Fortran.  Example:
-  //!
-  //!      for (sidre::IndexType idx = ds->getFirstValidAttributeIndex();
-  //!           sidre::indexIsValid(idx);
-  //!           idx = ds->getNextValidAttributeIndex(idx))
-  //!      {
-  //!          Attribute * attr = ds->getAttribute(idx);
-  //!
-  //!          /// code here using attr
-  //!      }
+  ///@{
+  /*!
+   * @name Methods for iterating over Attributes in the DataStore.
+   *
+   * Using these methods, a code can get the first Attribute index and each
+   * succeeding index.  This allows Attribute iteration using the same
+   * constructs in C++, C, and Fortran.  Example:
+   *
+   *      for (sidre::IndexType idx = ds->getFirstValidAttributeIndex();
+   *           sidre::indexIsValid(idx);
+   *           idx = ds->getNextValidAttributeIndex(idx))
+   *      {
+   *          Attribute * attr = ds->getAttribute(idx);
+   *
+   *          /// code here using attr
+   *      }
+   */
 
   /*!
    * \brief Return first valid Attribute index in DataStore object
@@ -425,29 +421,27 @@ public:
    */
   IndexType getNextValidAttributeIndex(IndexType idx) const;
 
-  //@}
+  ///@}
 
-  //@{
-  //!  @name Accessors for iterating attribute collections.
-  //!
-  //! These methods can be used to iterate over the collection of attributes
-  //! Example:
-  //!      for (auto& attr : ds->attributes())
-  //!      {
-  //!          /// code here using attribute
-  //!      }
-
+  ///@{
   /*!
-   * \brief Returns an adaptor to support iterating the collection of attributes
+   *  @name Accessors for iterating attribute collections.
+   *
+   * These methods can be used to iterate over the collection of attributes
+   * Example:
+   *      for (auto& attr : ds->attributes())
+   *      {
+   *          /// code here using attribute
+   *      }
    */
+
+  /// \brief Returns an adaptor to support iterating the collection of attributes
   typename AttributeCollection::iterator_adaptor attributes();
 
-  /*!
-   * \brief Returns a const adaptor to support iterating the collection of attributes
-   */
+  /// \brief Returns a const adaptor to support iterating the collection of attributes
   typename AttributeCollection::const_iterator_adaptor attributes() const;
 
-  //@}
+  ///@}
 
 public:
   /*!
@@ -523,9 +517,8 @@ private:
   DISABLE_COPY_AND_ASSIGNMENT(DataStore);
   DISABLE_MOVE_AND_ASSIGNMENT(DataStore);
 
-  //@{
-  //!  @name Private View declaration methods.
-  //!        (callable only by Group and View methods).
+  ///@{
+  //!  @name Private View declaration methods (callable only by Group and View methods).
 
   /*!
    * \brief Create an Attribute and insert it into the DataStore.
@@ -533,7 +526,7 @@ private:
    */
   Attribute* createAttributeEmpty(const std::string& name);
 
-  //@}
+  ///@}
 
 private:
   /// Root Group, created when DataStore object is created.

--- a/src/axom/sidre/core/Group.hpp
+++ b/src/axom/sidre/core/Group.hpp
@@ -139,7 +139,7 @@ public:
   using ViewCollection = ItemCollection<View>;
   using GroupCollection = ItemCollection<Group>;
 
-  //@{
+  ///@{
   //!  @name Basic query and accessor methods.
 
   /*!
@@ -375,9 +375,9 @@ public:
    */
   void getDataInfo(Node& n, bool recursive = true) const;
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name View query methods.
 
   /*!
@@ -414,9 +414,9 @@ public:
    */
   const std::string& getViewName(IndexType idx) const;
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name View access methods.
 
   /*!
@@ -452,9 +452,9 @@ public:
    */
   const View* getView(IndexType idx) const;
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name View iteration methods.
   //!
   //! Using these methods, a code can get the first View index and each
@@ -494,9 +494,9 @@ public:
    */
   IndexType getNextValidViewIndex(IndexType idx) const;
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Methods to create a View that has no associated data.
   //!
   //! \attention These methods do not allocate data or associate a View
@@ -552,9 +552,9 @@ public:
    */
   View* createView(const std::string& path, const DataType& dtype);
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Methods to create a View with a Buffer attached.
   //!
   //! \attention The Buffer passed to each of these methods may or may not
@@ -645,9 +645,9 @@ public:
    */
   View* createView(const std::string& path, const DataType& dtype, Buffer* buff);
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Methods to create a View with externally-owned data attached.
   //!
   //! \attention To do anything useful with a View created by one of these
@@ -734,9 +734,9 @@ public:
    */
   View* createView(const std::string& path, const DataType& dtype, void* external_ptr);
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Methods to create a View and allocate data for it.
   //!
   //! Each of these methods is a no-op if the given View name is an
@@ -842,9 +842,9 @@ public:
    */
   View* createViewString(const std::string& path, const std::string& value);
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name View destruction methods.
   //!
   //! Each of these methods is a no-op if the specified View does not exist.
@@ -886,9 +886,9 @@ public:
    */
   void destroyViewsAndData();
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name View move and copy methods.
 
   /*!
@@ -941,9 +941,9 @@ public:
    */
   View* deepCopyView(const View* view, int allocID = INVALID_ALLOCATOR_ID);
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Child Group query methods.
 
   /*!
@@ -981,9 +981,9 @@ public:
    */
   const std::string& getGroupName(IndexType idx) const;
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Group access and iteration methods.
 
   /*!
@@ -1018,9 +1018,9 @@ public:
    */
   const Group* getGroup(IndexType idx) const;
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Accessors for iterating the group and view collections.
   //!
   //! These methods can be used to iterate over the collection of groups and views
@@ -1054,7 +1054,7 @@ public:
    */
   typename GroupCollection::const_iterator_adaptor groups() const;
 
-  //@}
+  ///@}
 private:
   /*!
    * \brief Casts the views ItemCollection to a (named) MapCollection
@@ -1107,7 +1107,7 @@ private:
   void getDataInfoHelper(Node& n, std::set<IndexType>& buffer_ids, bool recursive) const;
 
 public:
-  //@{
+  ///@{
   //!  @name Group iteration methods.
   //!
   //! Using these methods, a code can get the first Group index and each
@@ -1144,9 +1144,9 @@ public:
    */
   IndexType getNextValidGroupIndex(IndexType idx) const;
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Child Group creation and destruction methods.
 
   /*!
@@ -1245,9 +1245,9 @@ public:
    */
   void destroyGroups();
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Group move and copy methods.
 
   /*!
@@ -1308,9 +1308,9 @@ public:
    */
   Group* deepCopyGroup(const Group* srcGroup, int allocID = INVALID_ALLOCATOR_ID);
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Group print methods.
 
   /*!
@@ -1335,7 +1335,7 @@ public:
    */
   void printTree(const int nlevels, std::ostream& os = std::cout) const;
 
-  //@}
+  ///@}
 
   /*!
    * \brief Copy description of Group hierarchy rooted at this Group to
@@ -1413,37 +1413,37 @@ public:
    */
   bool isUsingList() const { return m_is_list; }
 
-  //@{
+  ///@{
   /*!
- * @name    Group I/O methods
- *   These methods save and load Group trees to and from files.
- *   This includes the views and buffers used in by groups in the tree.
- *   We provide several "protocol" options:
- *
- *   protocols:
- *    sidre_hdf5 (default when Axom is configured with hdf5)
- *    sidre_conduit_json (default otherwise)
- *    sidre_json
- *
- *    conduit_hdf5
- *    conduit_bin
- *    conduit_json
- *    json
- *
- *   \note The sidre_hdf5 and conduit_hdf5 protocols are only available
- *   when Axom is configured with hdf5.
- *
- *   There are two overloaded versions for each of save, load, and
- *   loadExternalData.  The first of each takes a file path and is intended
- *   for use in a serial context and can be called directly using any
- *   of the supported protocols.  The second takes an hdf5 handle that
- *   has previously been created by the calling code.  These mainly exist
- *   to handle parallel I/O calls from the SPIO component.  They can only
- *   take the sidre_hdf5 or conduit_hdf5 protocols.
- *
- *   \note The hdf5 overloads are only available when Axom is configured
- *   with hdf5.
- */
+   * @name    Group I/O methods
+   *   These methods save and load Group trees to and from files.
+   *   This includes the views and buffers used in by groups in the tree.
+   *   We provide several "protocol" options:
+   *
+   *   protocols:
+   *    sidre_hdf5 (default when Axom is configured with hdf5)
+   *    sidre_conduit_json (default otherwise)
+   *    sidre_json
+   *
+   *    conduit_hdf5
+   *    conduit_bin
+   *    conduit_json
+   *    json
+   *
+   *   \note The sidre_hdf5 and conduit_hdf5 protocols are only available
+   *   when Axom is configured with hdf5.
+   *
+   *   There are two overloaded versions for each of save, load, and
+   *   loadExternalData.  The first of each takes a file path and is intended
+   *   for use in a serial context and can be called directly using any
+   *   of the supported protocols.  The second takes an hdf5 handle that
+   *   has previously been created by the calling code.  These mainly exist
+   *   to handle parallel I/O calls from the SPIO component.  They can only
+   *   take the sidre_hdf5 or conduit_hdf5 protocols.
+   *
+   *   \note The hdf5 overloads are only available when Axom is configured
+   *   with hdf5.
+   */
 
   /*!
    * \brief Save the Group to a file.
@@ -1664,7 +1664,7 @@ public:
 
 #endif /* AXOM_USE_HDF5 */
 
-  //@}
+  ///@}
 
   /*!
    * \brief Change the name of this Group.
@@ -1740,7 +1740,7 @@ private:
   DISABLE_COPY_AND_ASSIGNMENT(Group);
   DISABLE_MOVE_AND_ASSIGNMENT(Group);
 
-  //@{
+  ///@{
   //!  @name Private Group ctors and dtors
   //!        (callable only by DataStore and Group methods).
 
@@ -1763,9 +1763,9 @@ private:
    */
   ~Group();
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name View attach and detach methods.
 
   /*!
@@ -1788,9 +1788,9 @@ private:
    */
   View* detachView(IndexType idx);
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Group attach and detach methods.
 
   /*!
@@ -1810,9 +1810,9 @@ private:
    */
   Group* detachGroup(IndexType idx);
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Private Group View manipulation methods.
 
   /*!
@@ -1826,9 +1826,9 @@ private:
    */
   void destroyViewAndData(View* view);
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Private Group methods for interacting with Conduit Nodes.
 
   /*!
@@ -1880,7 +1880,7 @@ private:
    */
   void importFrom(conduit::Node& node, const std::map<IndexType, IndexType>& buffer_id_map);
 
-  //@}
+  ///@}
 
   /*!
    * \brief Private method that returns the Group that is the next-to-last

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -96,7 +96,7 @@ public:
   friend class Group;
   friend class Buffer;
 
-  //@{
+  ///@{
   //!  @name View query and accessor methods
 
   /*!
@@ -331,9 +331,9 @@ public:
    */
   bool isUpdateableFrom(const View* other) const;
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name View allocation methods
 
   /*!
@@ -421,7 +421,7 @@ public:
    */
   View* deallocate();
 
-  //@}
+  ///@}
 
   /*!
    * \brief Reshape the array without changing its size.
@@ -511,7 +511,7 @@ public:
    */
   void clear();
 
-  //@{
+  ///@{
   //!  @name Methods to apply View description to data.
 
   /*!
@@ -586,9 +586,9 @@ public:
    */
   View* apply(const DataType& dtype);
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Methods to set data in the view (scalar, string, or external data).
 
   /*!
@@ -774,7 +774,7 @@ public:
     return this;
   }
 
-  //@}
+  ///@}
 
   /*!
  * \brief Update the data in this View with the data in other
@@ -784,7 +784,7 @@ public:
  */
   View* updateFrom(const View* other);
 
-  //@{
+  ///@{
   //! @name Methods to retrieve data in a view.
 
   /*!
@@ -903,9 +903,9 @@ public:
    */
   void* getVoidPtr() const;
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name View print methods.
 
   /*!
@@ -918,7 +918,7 @@ public:
    */
   void print(std::ostream& os) const;
 
-  //@}
+  ///@}
 
   /*!
    * \brief Copy data view description to given Conduit node.
@@ -961,7 +961,7 @@ public:
    */
   bool rename(const std::string& new_name);
 
-  //@{
+  ///@{
   //!  @name Attribute Value query and accessor methods
 
   /*!
@@ -1293,13 +1293,13 @@ public:
     return m_attr_values.getNextValidAttrValueIndex(idx);
   }
 
-  //@}
+  ///@}
 
 private:
   DISABLE_DEFAULT_CTOR(View);
   DISABLE_MOVE_AND_ASSIGNMENT(View);
 
-  //@{
+  ///@{
   //!  @name Private View ctor and dtor
   //!        (callable only by Group and View methods).
 
@@ -1319,9 +1319,9 @@ private:
    */
   ~View();
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Private View declaration methods.
   //!        (callable only by Group and View methods).
 
@@ -1462,9 +1462,9 @@ private:
     unapply();
   }
 
-  //@}
+  ///@}
 
-  //@{
+  ///@{
   //!  @name Private methods that indicate when certain view operations are valid.
 
   /*!
@@ -1479,7 +1479,7 @@ private:
    */
   bool isApplyValid() const;
 
-  //@}
+  ///@}
 
   ///
   /// Enum with constants that identify the state of a view.

--- a/src/axom/spin/OctreeBase.hpp
+++ b/src/axom/spin/OctreeBase.hpp
@@ -484,7 +484,7 @@ public:
   int maxInternalLevel() const { return m_levels.size() - 1; }
 
 public:
-  //@{
+  ///@{
 
   /**
    * \brief Utility function to find the number of (possible) grid cells at a given level or resolution
@@ -509,10 +509,10 @@ public:
    */
   static BlockIndex root() { return BlockIndex(); }
 
-  // @}
+  ///@}
 
 public:
-  // @{
+  ///@{
   // KW: The following four functions are probably not necessary any more
   //     Since their functionality is in the BlockIndex inner class.
 
@@ -562,7 +562,7 @@ public:
     return block.child(childIndex);
   }
 
-  // @}
+  ///@}
 
   /// \brief Accessor for a reference to the octree level instance at level lev
   OctreeLevelType& getOctreeLevel(int lev) { return *m_leavesLevelMap[lev]; }

--- a/src/docs/sphinx/coding_guide/sec07_documentation.rst
+++ b/src/docs/sphinx/coding_guide/sec07_documentation.rst
@@ -460,13 +460,13 @@ sufficient.
 
       An example of Doxygen syntax for such a grouping is::
 
-         //@{
+         ///@{
          //! @name Setters for data members
 
          void setMember1(int arg1) { m_member1 = arg1; }
          void setMember2(int arg2) { m_member2 = arg2; }
 
-         //@}
+         ///@}
 
 
 Header file vs. source file documentation
@@ -547,13 +547,13 @@ with a single descriptive comment.
 
       An example of Doxygen syntax for such a grouping is::
 
-         //@{
+         ///@{
          //!  @name Data member description...
 
          int m_member1;
          int m_member2;
          ...
-         //@}
+         ///@}
 
 
 --------------------------------------------------------------------


### PR DESCRIPTION
# Summary

- This PR is a refactoring that consolidates the constructor logic for the `BezierCurve`, `BezierPatch`, `KnotVector`, `NURBSCurve` and `NURBSPatch` classes into one or two delegate constructors
- These classes have flexible constructor with many parameters supporting C-arrays w/ sizes, 1D axom::Arrays and 2D axom::Arrays. Since each constructor implemented its own logic and checks it can be difficult to understand what is being constructed.
- This PR adds constructors from axom::ArrayViews and uses these as delegate constructors for all the other types
- It also improves the tests and doxygen comments for all the various constructors
- Other than the new ArrayView constructors, this PR does not add any API or unexpected behavioral changes (it might fix some bugs though)
- Completes a subtask of #1528 
- ReadTheDocs for this branch: https://axom.readthedocs.io/en/feature-kweiss-bezier-nurbs-constructors/