### PR TITLE
Reorganizes the Bezier and NURBS classes for consistency

### DIFF
--- a/src/axom/primal/geometry/BezierCurve.hpp
+++ b/src/axom/primal/geometry/BezierCurve.hpp
@@ -310,7 +310,7 @@ public:
    *
    * \param [in] tol Threshold for sum of squared distances
    * \param [in] useStrictLinear If true, checks that the control points are
-   *   evenly spaced along the line
+   *   evenly spaced along the line and not too far from the line
    * \return True if curve is near-linear
    */
   bool isLinear(double tol = 1e-8, bool useStrictLinear = false) const

--- a/src/axom/primal/geometry/BezierCurve.hpp
+++ b/src/axom/primal/geometry/BezierCurve.hpp
@@ -203,6 +203,9 @@ public:
   ///@}
 
 public:
+  ///@{
+  /// \name Query/modify curve properties (order, rationality, ...)
+
   /// Sets the order of the Bezier Curve
   void setOrder(int ord)
   {
@@ -218,6 +221,16 @@ public:
   /// Returns the order of the Bezier Curve
   int getOrder() const { return static_cast<int>(m_controlPoints.size()) - 1; }
 
+  /// Clears the list of control points, make nonrational
+  void clear()
+  {
+    m_controlPoints.clear();
+    makeNonrational();
+  }
+
+  /// Use array size as flag for rationality
+  bool isRational() const { return !m_weights.empty(); }
+
   /// Make trivially rational. If already rational, do nothing
   void makeRational()
   {
@@ -232,21 +245,19 @@ public:
   /// Make nonrational by shrinking array of weights
   void makeNonrational() { m_weights.resize(0); }
 
-  /// Use array size as flag for rationality
-  bool isRational() const { return !m_weights.empty(); }
+  ///@}
 
-  /// Clears the list of control points, make nonrational
-  void clear()
-  {
-    m_controlPoints.clear();
-    makeNonrational();
-  }
+  ///@{
+  /// \name Query/modify curve's geometry (control points, weights, bounding box, ...)
 
   /// Retrieves the control point at index \a idx
   PointType& operator[](int idx) { return m_controlPoints[idx]; }
 
   /// Retrieves the control point at index \a idx
   const PointType& operator[](int idx) const { return m_controlPoints[idx]; }
+
+  /// Returns a copy of the Bezier curve's control points
+  CoordsVec getControlPoints() const { return m_controlPoints; }
 
   /*!
    * \brief Get a specific weight
@@ -276,22 +287,76 @@ public:
     m_weights[idx] = weight;
   };
 
-  /// Checks equality of two Bezier Curve
-  friend inline bool operator==(const BezierCurve<T, NDIMS>& lhs, const BezierCurve<T, NDIMS>& rhs)
-  {
-    return (lhs.m_controlPoints == rhs.m_controlPoints) && (lhs.m_weights == rhs.m_weights);
-  }
-
-  friend inline bool operator!=(const BezierCurve<T, NDIMS>& lhs, const BezierCurve<T, NDIMS>& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-  /// Returns a copy of the Bezier curve's control points
-  CoordsVec getControlPoints() const { return m_controlPoints; }
-
   /// Returns a copy of the Bezier curve's weights
   WeightsVec getWeights() const { return m_weights; }
+
+  /// Returns an axis-aligned bounding box containing the Bezier curve
+  BoundingBoxType boundingBox() const
+  {
+    return BoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
+  }
+
+  /// Returns an oriented bounding box containing the Bezier curve
+  OrientedBoundingBoxType orientedBoundingBox() const
+  {
+    return OrientedBoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
+  }
+
+  /*!
+   * \brief Predicate to check if the Bezier curve is approximately linear
+   *
+   * This function checks if the internal control points of the BezierCurve
+   * are approximately on the line defined by its two endpoints
+   *
+   * \param [in] tol Threshold for sum of squared distances
+   * \param [in] useStrictLinear If true, checks that the control points are
+   *   evenly spaced along the line
+   * \return True if curve is near-linear
+   */
+  bool isLinear(double tol = 1e-8, bool useStrictLinear = false) const
+  {
+    const int ord = getOrder();
+    if(ord <= 1)
+    {
+      return true;
+    }
+
+    if(useStrictLinear)
+    {
+      // Check that the control points are not too far away from the line,
+      //  AND that they are evenly spaced along the line
+      for(int p = 1; p < ord; ++p)
+      {
+        double t = p / static_cast<T>(ord);
+        PointType the_pt = PointType::lerp(m_controlPoints[0], m_controlPoints[ord], t);
+
+        if(squared_distance(m_controlPoints[p], the_pt) > tol)
+        {
+          return false;
+        }
+      }
+    }
+    else
+    {
+      // Check that the control points are not too far away from the line between control points
+      SegmentType seg(m_controlPoints[0], m_controlPoints[ord]);
+
+      for(int p = 1; p < ord; ++p)  // check interior control points
+      {
+        if(squared_distance(m_controlPoints[p], seg) > tol)
+        {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  ///@}
+
+  ///@{
+  /// \name Query/modify curve parametrization
 
   /// Reverses the order of the Bezier curve's control points and weights
   void reverseOrientation()
@@ -312,17 +377,10 @@ public:
     }
   }
 
-  /// Returns an axis-aligned bounding box containing the Bezier curve
-  BoundingBoxType boundingBox() const
-  {
-    return BoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
-  }
+  ///@}
 
-  /// Returns an oriented bounding box containing the Bezier curve
-  OrientedBoundingBoxType orientedBoundingBox() const
-  {
-    return OrientedBoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
-  }
+  ///@{
+  /// \name Functions to evaluate curve and its derivatives and normals
 
   /*!
    * \brief Evaluates a Bezier curve at a particular parameter value \a t
@@ -743,6 +801,11 @@ public:
     }
   }
 
+  ///@}
+
+  ///@{
+  /// \name Functions dealing with curve subdivision
+
   /*!
    * \brief Splits a Bezier curve into two Bezier curves at a given parameter value
    *
@@ -811,56 +874,7 @@ public:
     return;
   }
 
-  /*!
-   * \brief Predicate to check if the Bezier curve is approximately linear
-   *
-   * This function checks if the internal control points of the BezierCurve
-   * are approximately on the line defined by its two endpoints
-   *
-   * \param [in] tol Threshold for sum of squared distances
-   * \param [in] useStrictLinear If true, checks that the control points are
-   *   evenly spaced along the line
-   * \return True if curve is near-linear
-   */
-  bool isLinear(double tol = 1e-8, bool useStrictLinear = false) const
-  {
-    const int ord = getOrder();
-    if(ord <= 1)
-    {
-      return true;
-    }
-
-    if(useStrictLinear)
-    {
-      // Check that the control points are not too far away from the line,
-      //  AND that they are evenly spaced along the line
-      for(int p = 1; p < ord; ++p)
-      {
-        double t = p / static_cast<T>(ord);
-        PointType the_pt = PointType::lerp(m_controlPoints[0], m_controlPoints[ord], t);
-
-        if(squared_distance(m_controlPoints[p], the_pt) > tol)
-        {
-          return false;
-        }
-      }
-    }
-    else
-    {
-      // Check that the control points are not too far away from the line between control points
-      SegmentType seg(m_controlPoints[0], m_controlPoints[ord]);
-
-      for(int p = 1; p < ord; ++p)  // check interior control points
-      {
-        if(squared_distance(m_controlPoints[p], seg) > tol)
-        {
-          return false;
-        }
-      }
-    }
-
-    return true;
-  }
+  ///@}
 
   /*!
    * \brief Simple formatted print of a Bezier Curve instance
@@ -889,6 +903,17 @@ public:
     os << "}";
 
     return os;
+  }
+
+  /// Checks equality of two Bezier Curve
+  friend inline bool operator==(const BezierCurve<T, NDIMS>& lhs, const BezierCurve<T, NDIMS>& rhs)
+  {
+    return (lhs.m_controlPoints == rhs.m_controlPoints) && (lhs.m_weights == rhs.m_weights);
+  }
+
+  friend inline bool operator!=(const BezierCurve<T, NDIMS>& lhs, const BezierCurve<T, NDIMS>& rhs)
+  {
+    return !(lhs == rhs);
   }
 
 private:

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -450,7 +450,7 @@ public:
    *
    * \param [in] tol Threshold for sum of squared distances
    * \param [in] EPS Threshold for nearness to zero
-   * \return True if c1 is planar-polygonal up to tolerance \a sq_tol
+   * \return True if the patch is a planar polygon, up to the desired tolerances
    */
   bool isPolygonal(double sq_tol = 1e-8, double EPS = 1e-8) const
   {

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -90,10 +90,12 @@ public:
    * - Rational or polynomial (nonrational) patches, depending on the presence of weights.
    *
    * For 1D arrays, the mapping of control points and weights to the patch is lexicographical, i.e.
-   * pts[0]               -> nodes[0, 0],     ..., pts[ord_v]       -> nodes[0, ord_v]
-   * pts[ord_v+1]         -> nodes[1, 0],     ..., pts[2*ord_v]     -> nodes[1, ord_v]
-   *                                          ...
-   * pts[ord_u*(ord_v-1)] -> nodes[ord_u, 0], ..., pts[ord_u*ord_v] -> nodes[ord_u, ord_v]
+     \verbatim
+      pts[0]               -> nodes[0, 0],     ..., pts[ord_v]       -> nodes[0, ord_v]
+      pts[ord_v+1]         -> nodes[1, 0],     ..., pts[2*ord_v]     -> nodes[1, ord_v]
+                                               ...
+      pts[ord_u*(ord_v-1)] -> nodes[ord_u, 0], ..., pts[ord_u*ord_v] -> nodes[ord_u, ord_v]
+     \endverbatim
    * 
    * The patch is parametrized from u=0 to u=1 and v=0 to v=1. 
    * 
@@ -259,6 +261,9 @@ public:
 
   ///@}
 
+  ///@{
+  /// \name Query/modify patch properties (order, rationality, ...)
+
   /*!
    * \brief Sets the order of Bezier patch
    *
@@ -287,6 +292,16 @@ public:
   /// Returns the order of the Bezier Patch on the second axis
   int getOrder_v() const { return static_cast<int>(m_controlPoints.shape()[1]) - 1; }
 
+  /// Clears the list of control points, make nonrational
+  void clear()
+  {
+    m_controlPoints.clear();
+    makeNonrational();
+  }
+
+  /// Use array size as flag for rationality
+  bool isRational() const { return !m_weights.empty(); }
+
   /// Make trivially rational. If already rational, do nothing
   void makeRational()
   {
@@ -303,21 +318,19 @@ public:
   /// Make nonrational by shrinking array of weights
   void makeNonrational() { m_weights.clear(); }
 
-  /// Use array size as flag for rationality
-  bool isRational() const { return !m_weights.empty(); }
+  ///@}
 
-  /// Clears the list of control points, make nonrational
-  void clear()
-  {
-    m_controlPoints.clear();
-    makeNonrational();
-  }
+  ///@{
+  /// \name Query/modify patch's geometry (control points, weights, bounding box, ...)
 
   /// Retrieves the control point at index \a (idx_p, idx_q)
   PointType& operator()(int ui, int vi) { return m_controlPoints(ui, vi); }
 
   /// Retrieves the vector of control points at index \a idx
   const PointType& operator()(int ui, int vi) const { return m_controlPoints(ui, vi); }
+
+  /// Returns a copy of the Bezier patch's control points
+  CoordsMat getControlPoints() const { return m_controlPoints; }
 
   /*!
    * \brief Get a specific weight
@@ -349,22 +362,237 @@ public:
     m_weights(ui, vi) = weight;
   };
 
-  /// Checks equality of two Bezier Patches
-  friend inline bool operator==(const BezierPatch<T, NDIMS>& lhs, const BezierPatch<T, NDIMS>& rhs)
-  {
-    return (lhs.m_controlPoints == rhs.m_controlPoints) && (lhs.m_weights == rhs.m_weights);
-  }
-
-  friend inline bool operator!=(const BezierPatch<T, NDIMS>& lhs, const BezierPatch<T, NDIMS>& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-  /// Returns a copy of the Bezier patch's control points
-  CoordsMat getControlPoints() const { return m_controlPoints; }
-
   /// Returns a copy of the Bezier patch's weights
   WeightsMat getWeights() const { return m_weights; }
+
+  /// Returns an axis-aligned bounding box containing the Bezier patch
+  BoundingBoxType boundingBox() const
+  {
+    return BoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
+  }
+
+  /// Returns an oriented bounding box containing the Bezier patch
+  OrientedBoundingBoxType orientedBoundingBox() const
+  {
+    return OrientedBoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
+  }
+
+  /*!
+   * \brief Predicate to check if the Bezier patch is approximately planar (i.e. flat)
+   *
+   * This function checks if all control points of the BezierPatch
+   * are approximately on the plane defined by its four corners
+   *
+   * \param [in] sq_tol Threshold for sum of squared distances
+   * \param [in] EPS Threshold for nearness to zero
+   * \return True if the object is planar up to tolerance \a sq_tol
+   */
+  bool isPlanar(double sq_tol = 1e-8, double EPS = 1e-8) const
+  {
+    const int ord_u = getOrder_u();
+    const int ord_v = getOrder_v();
+
+    if(ord_u <= 0 && ord_v <= 0)
+    {
+      return true;
+    }
+    if(ord_u == 1 && ord_v == 0)
+    {
+      return true;
+    }
+    if(ord_u == 0 && ord_v == 1)
+    {
+      return true;
+    }
+
+    // Check that the four corners aren't coplanar
+    VectorType v1(m_controlPoints(0, 0), m_controlPoints(0, ord_v));
+    VectorType v2(m_controlPoints(0, 0), m_controlPoints(ord_u, 0));
+    VectorType v3(m_controlPoints(0, 0), m_controlPoints(ord_u, ord_v));
+    if(!axom::utilities::isNearlyEqual(VectorType::scalar_triple_product(v1, v2, v3), 0.0, EPS))
+    {
+      return false;
+    }
+
+    // Find three points that produce a nonzero normal
+    VectorType plane_normal = VectorType::cross_product(v1, v2);
+    if(axom::utilities::isNearlyEqual(plane_normal.norm(), 0.0, EPS))
+    {
+      plane_normal = VectorType::cross_product(v1, v3);
+    }
+    if(axom::utilities::isNearlyEqual(plane_normal.norm(), 0.0, EPS))
+    {
+      plane_normal = VectorType::cross_product(v2, v3);
+    }
+    plane_normal = plane_normal.unitVector();
+
+    // Check all control points for simplicity
+    for(int p = 0; p <= ord_u; ++p)
+    {
+      for(int q = ((p == 0) ? 1 : 0); q <= ord_v; ++q)
+      {
+        const double signedDist = plane_normal.dot(m_controlPoints(p, q) - m_controlPoints(0, 0));
+
+        if(signedDist * signedDist > sq_tol)
+        {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /*!
+   * \brief Predicate to check if the patch can be approximated by a polygon
+   *
+   * This function checks if a BezierPatch lies in a plane
+   *  and that the edges are linear up to tolerance `sq_tol`
+   *
+   * \param [in] tol Threshold for sum of squared distances
+   * \param [in] EPS Threshold for nearness to zero
+   * \return True if c1 is planar-polygonal up to tolerance \a sq_tol
+   */
+  bool isPolygonal(double sq_tol = 1e-8, double EPS = 1e-8) const
+  {
+    const int ord_u = getOrder_u();
+    const int ord_v = getOrder_v();
+
+    if(ord_u <= 0 && ord_v <= 0)
+    {
+      return true;
+    }
+    if(ord_u == 1 && ord_v == 0)
+    {
+      return true;
+    }
+    if(ord_u == 0 && ord_v == 1)
+    {
+      return true;
+    }
+
+    // Check if the patch is planar
+    if(!isPlanar(sq_tol, EPS))
+    {
+      return false;
+    }
+
+    // Check if each bounding curve is linear
+    if(!isocurve_u(0).isLinear(sq_tol))
+    {
+      return false;
+    }
+    if(!isocurve_v(0).isLinear(sq_tol))
+    {
+      return false;
+    }
+    if(!isocurve_u(1).isLinear(sq_tol))
+    {
+      return false;
+    }
+    if(!isocurve_v(1).isLinear(sq_tol))
+    {
+      return false;
+    }
+
+    return true;
+  }
+
+  /*!
+   * \brief Predicate to check if the Bezier patch is approximately bilinear
+   *
+   * This function checks if the patch is (nearly) bilinear.
+   * A necessary condition for a geometrically bilinear patch is that each line of
+   *  control points in the net is approximately linear. 
+   * A necessary condition for a parametrically bilinear patch is that the control
+   *  points are coincident with the surface of the bilinear patch defined by
+   *  its corners evaluated at uniform parameter values, 
+   *  i.e. the control points are also equally spaced on the net.
+   *
+   * \param [in] sq_tol Threshold for absolute squared distances
+   * \param [in] useStrictBilinear If true, require the patch be parametrically bilinear
+   * \return True if patch is bilinear up to tolerance \a sq_tol
+   */
+  bool isBilinear(double sq_tol = 1e-8, bool useStrictBilinear = false) const
+  {
+    const int ord_u = getOrder_u();
+    const int ord_v = getOrder_v();
+
+    if(ord_u <= 1 && ord_v <= 1)
+    {
+      return true;
+    }
+
+    if(useStrictBilinear)
+    {
+      // Anonymous function to evaluate the bilinear patch defined by the corners
+      auto bilinear_patch = [&](T u, T v) -> PointType {
+        PointType val;
+        for(int N = 0; N < NDIMS; ++N)
+        {
+          val[N] = axom::utilities::lerp(
+            axom::utilities::lerp(m_controlPoints(0, 0)[N], m_controlPoints(0, ord_v)[N], v),
+            axom::utilities::lerp(m_controlPoints(ord_u, 0)[N], m_controlPoints(ord_u, ord_v)[N], v),
+            u);
+        }
+        return val;
+      };
+
+      for(int u = 0; u <= ord_u; ++u)
+      {
+        for(int v = 0; v <= ord_v; ++v)
+        {
+          // Don't need to check the corners
+          if((u == 0 && v == 0) || (u == 0 && v == ord_v) || (u == ord_u && v == 0) ||
+             (u == ord_u && v == ord_v))
+          {
+            continue;
+          }
+
+          // Evaluate where the control point would be if the patch *was* bilinear
+          PointType bilinear_point =
+            bilinear_patch(u / static_cast<T>(ord_u), v / static_cast<T>(ord_v));
+
+          if(squared_distance(m_controlPoints(u, v), bilinear_point) > sq_tol)
+          {
+            return false;
+          }
+        }
+      }
+    }
+    else
+    {
+      for(int p = 0; p <= ord_u; ++p)
+      {
+        Segment<T, 3> seg(m_controlPoints(p, 0), m_controlPoints(p, ord_v));
+        for(int q = 1; q < ord_v; ++q)
+        {
+          if(squared_distance(m_controlPoints(p, q), seg) > sq_tol)
+          {
+            return false;
+          }
+        }
+      }
+
+      for(int q = 0; q <= ord_v; ++q)
+      {
+        Segment<T, 3> seg(m_controlPoints(0, q), m_controlPoints(ord_u, q));
+        for(int p = 1; p < ord_u; ++p)
+        {
+          if(squared_distance(m_controlPoints(p, q), seg) > sq_tol)
+          {
+            return false;
+          }
+        }
+      }
+    }
+
+    return true;
+  }
+
+  ///@}
+
+  ///@{
+  /// \name Query/modify patch parametrization
 
   /*!
    * \brief Reverses the order of one direction of the Bezier patch's control points and weights
@@ -466,17 +694,10 @@ public:
     }
   }
 
-  /// Returns an axis-aligned bounding box containing the Bezier patch
-  BoundingBoxType boundingBox() const
-  {
-    return BoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
-  }
+  ///@}
 
-  /// Returns an oriented bounding box containing the Bezier patch
-  OrientedBoundingBoxType orientedBoundingBox() const
-  {
-    return OrientedBoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
-  }
+  ///@{
+  /// \name Functions to evaluate patch and its derivatives and normals along points or lines
 
   /*!
    * \brief Evaluates a slice Bezier patch for a fixed parameter value of \a u or \a v
@@ -1607,6 +1828,11 @@ public:
     return VectorType::cross_product(Du, Dv);
   }
 
+  ///@}
+
+  ///@{
+  /// \name Functions dealing with patch subdivision
+
   /*!
    * \brief Splits a Bezier patch into two Bezier patches
    *
@@ -1806,217 +2032,7 @@ public:
     p0.split_v(v, p2, p4);
   }
 
-  /*!
-   * \brief Predicate to check if the Bezier patch is approximately planar (i.e. flat)
-   *
-   * This function checks if all control points of the BezierPatch
-   * are approximately on the plane defined by its four corners
-   *
-   * \param [in] sq_tol Threshold for sum of squared distances
-   * \param [in] EPS Threshold for nearness to zero
-   * \return True if the object is planar up to tolerance \a sq_tol
-   */
-  bool isPlanar(double sq_tol = 1e-8, double EPS = 1e-8) const
-  {
-    const int ord_u = getOrder_u();
-    const int ord_v = getOrder_v();
-
-    if(ord_u <= 0 && ord_v <= 0)
-    {
-      return true;
-    }
-    if(ord_u == 1 && ord_v == 0)
-    {
-      return true;
-    }
-    if(ord_u == 0 && ord_v == 1)
-    {
-      return true;
-    }
-
-    // Check that the four corners aren't coplanar
-    VectorType v1(m_controlPoints(0, 0), m_controlPoints(0, ord_v));
-    VectorType v2(m_controlPoints(0, 0), m_controlPoints(ord_u, 0));
-    VectorType v3(m_controlPoints(0, 0), m_controlPoints(ord_u, ord_v));
-    if(!axom::utilities::isNearlyEqual(VectorType::scalar_triple_product(v1, v2, v3), 0.0, EPS))
-    {
-      return false;
-    }
-
-    // Find three points that produce a nonzero normal
-    VectorType plane_normal = VectorType::cross_product(v1, v2);
-    if(axom::utilities::isNearlyEqual(plane_normal.norm(), 0.0, EPS))
-    {
-      plane_normal = VectorType::cross_product(v1, v3);
-    }
-    if(axom::utilities::isNearlyEqual(plane_normal.norm(), 0.0, EPS))
-    {
-      plane_normal = VectorType::cross_product(v2, v3);
-    }
-    plane_normal = plane_normal.unitVector();
-
-    // Check all control points for simplicity
-    for(int p = 0; p <= ord_u; ++p)
-    {
-      for(int q = ((p == 0) ? 1 : 0); q <= ord_v; ++q)
-      {
-        const double signedDist = plane_normal.dot(m_controlPoints(p, q) - m_controlPoints(0, 0));
-
-        if(signedDist * signedDist > sq_tol)
-        {
-          return false;
-        }
-      }
-    }
-    return true;
-  }
-
-  /*!
-   * \brief Predicate to check if the patch can be approximated by a polygon
-   *
-   * This function checks if a BezierPatch lies in a plane
-   *  and that the edges are linear up to tolerance `sq_tol`
-   *
-   * \param [in] tol Threshold for sum of squared distances
-   * \param [in] EPS Threshold for nearness to zero
-   * \return True if c1 is planar-polygonal up to tolerance \a sq_tol
-   */
-  bool isPolygonal(double sq_tol = 1e-8, double EPS = 1e-8) const
-  {
-    const int ord_u = getOrder_u();
-    const int ord_v = getOrder_v();
-
-    if(ord_u <= 0 && ord_v <= 0)
-    {
-      return true;
-    }
-    if(ord_u == 1 && ord_v == 0)
-    {
-      return true;
-    }
-    if(ord_u == 0 && ord_v == 1)
-    {
-      return true;
-    }
-
-    // Check if the patch is planar
-    if(!isPlanar(sq_tol, EPS))
-    {
-      return false;
-    }
-
-    // Check if each bounding curve is linear
-    if(!isocurve_u(0).isLinear(sq_tol))
-    {
-      return false;
-    }
-    if(!isocurve_v(0).isLinear(sq_tol))
-    {
-      return false;
-    }
-    if(!isocurve_u(1).isLinear(sq_tol))
-    {
-      return false;
-    }
-    if(!isocurve_v(1).isLinear(sq_tol))
-    {
-      return false;
-    }
-
-    return true;
-  }
-
-  /*!
-   * \brief Predicate to check if the Bezier patch is approximately bilinear
-   *
-   * This function checks if the patch is (nearly) bilinear.
-   * A necessary condition for a geometrically bilinear patch is that each line of
-   *  control points in the net is approximately linear. 
-   * A necessary condition for a parametrically bilinear patch is that the control
-   *  points are coincident with the surface of the bilinear patch defined by
-   *  its corners evaluated at uniform parameter values, 
-   *  i.e. the control points are also equally spaced on the net.
-   *
-   * \param [in] sq_tol Threshold for absolute squared distances
-   * \param [in] useStrictBilinear If true, require the patch be parametrically bilinear
-   * \return True if patch is bilinear up to tolerance \a sq_tol
-   */
-  bool isBilinear(double sq_tol = 1e-8, bool useStrictBilinear = false) const
-  {
-    const int ord_u = getOrder_u();
-    const int ord_v = getOrder_v();
-
-    if(ord_u <= 1 && ord_v <= 1)
-    {
-      return true;
-    }
-
-    if(useStrictBilinear)
-    {
-      // Anonymous function to evaluate the bilinear patch defined by the corners
-      auto bilinear_patch = [&](T u, T v) -> PointType {
-        PointType val;
-        for(int N = 0; N < NDIMS; ++N)
-        {
-          val[N] = axom::utilities::lerp(
-            axom::utilities::lerp(m_controlPoints(0, 0)[N], m_controlPoints(0, ord_v)[N], v),
-            axom::utilities::lerp(m_controlPoints(ord_u, 0)[N], m_controlPoints(ord_u, ord_v)[N], v),
-            u);
-        }
-        return val;
-      };
-
-      for(int u = 0; u <= ord_u; ++u)
-      {
-        for(int v = 0; v <= ord_v; ++v)
-        {
-          // Don't need to check the corners
-          if((u == 0 && v == 0) || (u == 0 && v == ord_v) || (u == ord_u && v == 0) ||
-             (u == ord_u && v == ord_v))
-          {
-            continue;
-          }
-
-          // Evaluate where the control point would be if the patch *was* bilinear
-          PointType bilinear_point =
-            bilinear_patch(u / static_cast<T>(ord_u), v / static_cast<T>(ord_v));
-
-          if(squared_distance(m_controlPoints(u, v), bilinear_point) > sq_tol)
-          {
-            return false;
-          }
-        }
-      }
-    }
-    else
-    {
-      for(int p = 0; p <= ord_u; ++p)
-      {
-        Segment<T, 3> seg(m_controlPoints(p, 0), m_controlPoints(p, ord_v));
-        for(int q = 1; q < ord_v; ++q)
-        {
-          if(squared_distance(m_controlPoints(p, q), seg) > sq_tol)
-          {
-            return false;
-          }
-        }
-      }
-
-      for(int q = 0; q <= ord_v; ++q)
-      {
-        Segment<T, 3> seg(m_controlPoints(0, q), m_controlPoints(ord_u, q));
-        for(int p = 1; p < ord_u; ++p)
-        {
-          if(squared_distance(m_controlPoints(p, q), seg) > sq_tol)
-          {
-            return false;
-          }
-        }
-      }
-    }
-
-    return true;
-  }
+  ///@}
 
   /*!
    * \brief Simple formatted print of a Bezier Patch instance
@@ -2053,6 +2069,17 @@ public:
     os << "}";
 
     return os;
+  }
+
+  /// Checks equality of two Bezier Patches
+  friend inline bool operator==(const BezierPatch<T, NDIMS>& lhs, const BezierPatch<T, NDIMS>& rhs)
+  {
+    return (lhs.m_controlPoints == rhs.m_controlPoints) && (lhs.m_weights == rhs.m_weights);
+  }
+
+  friend inline bool operator!=(const BezierPatch<T, NDIMS>& lhs, const BezierPatch<T, NDIMS>& rhs)
+  {
+    return !(lhs == rhs);
   }
 
 private:

--- a/src/axom/primal/geometry/KnotVector.hpp
+++ b/src/axom/primal/geometry/KnotVector.hpp
@@ -137,6 +137,9 @@ public:
 
   ///@}
 
+  ///@{
+  /// \name Query/modify knot vector properties and sizes
+
   /*!
    * \brief Give the knot vector uniformly spaced internal knots
    *
@@ -170,33 +173,6 @@ public:
     }
   }
 
-  /// \brief Accessor for the knot vector
-  const axom::Array<T>& getArray() const { return m_knots; }
-
-  /*!
-   * \brief Getter for the knot vector
-   * 
-   * \param [in] i The vector index
-   * 
-   * \return A const reference to the knot value at index i
-   */
-  const T& operator[](axom::IndexType i) const { return m_knots[i]; }
-
-  /*!
-   * \brief Setter for the knot vector
-   *
-   * \param [in] i The vector index
-   * 
-   * \pre Assumes that the knot vector will remain valid after the change
-   * 
-   * \return A reference to the knot value at index i
-   */
-  T& operator[](axom::IndexType i)
-  {
-    SLIC_ASSERT(isValid());
-    return m_knots[i];
-  }
-
   /// \brief Return the degree of the knot vector
   int getDegree() const { return m_deg; }
 
@@ -226,6 +202,133 @@ public:
 
   /// \brief Return the number of knots in the knot vector
   axom::IndexType getNumKnots() const { return m_knots.size(); }
+
+  /// \brief Return the number of control points implied by the knot vector
+  axom::IndexType getNumControlPoints() const { return m_knots.size() - m_deg - 1; }
+
+  /// \brief Clear the list of knots
+  void clear()
+  {
+    m_deg = -1;
+    m_knots.clear();
+  }
+
+  /// \brief Return if the knot vector is valid
+  bool isValid() const
+  {
+    // Check degree
+    if(m_deg < 0)
+    {
+      return false;
+    }
+
+    // Check for monotonicity
+    for(int i = 0; i < m_knots.size() - 1; ++i)
+    {
+      if(m_knots[i] > m_knots[i + 1])
+      {
+        return false;
+      }
+    }
+
+    // Check for clamped-ness
+    auto nkts = m_knots.size();
+    for(int i = 0; i < m_deg + 1; ++i)
+    {
+      if(m_knots[i] != m_knots[0])
+      {
+        return false;
+      }
+      if(m_knots[nkts - 1 - i] != m_knots[nkts - 1])
+      {
+        return false;
+      }
+    }
+
+    // Check for continuity
+    T this_knot = m_knots[m_deg];
+    int this_multiplicity = 1;
+    for(int i = m_deg + 1; i < nkts - m_deg - 1; ++i)
+    {
+      if(m_knots[i] != this_knot)
+      {
+        this_knot = m_knots[i];
+        this_multiplicity = 1;
+      }
+      else
+      {
+        this_multiplicity++;
+        if(this_multiplicity > m_deg)
+        {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  /*!
+   * \brief Check if a knot span is valid 
+   *
+   * \param [in] span The span to check
+   * 
+   * A valid span is one that is within the knot vector and has a non-zero length
+   * 
+   * \return True if the span is valid, false otherwise
+   */
+  bool isValidSpan(axom::IndexType span) const
+  {
+    return span >= m_deg && span < m_knots.size() - m_deg - 1 && m_knots[span] != m_knots[span + 1];
+  }
+
+  /*!
+   * \brief Check if a knot span is valid and contains the parameter value t
+   *
+   * \param [in] span The span to check
+   * \param [in] t The parameter value
+   * 
+   * A valid span is one that is within the knot vector, has a non-zero length,
+   * and contains the parameter value t
+   * 
+   * \return True if the span is valid, false otherwise
+   */
+  bool isValidSpan(axom::IndexType span, T t) const
+  {
+    return isValidSpan(span) && t >= m_knots[span] && t <= m_knots[span + 1];
+  }
+
+  ///@}
+
+  ///@{
+  /// \name Query/modify/access knots
+
+  /// \brief Accessor for the knot vector
+  const axom::Array<T>& getArray() const { return m_knots; }
+
+  /*!
+   * \brief Getter for the knot vector
+   * 
+   * \param [in] i The vector index
+   * 
+   * \return A const reference to the knot value at index i
+   */
+  const T& operator[](axom::IndexType i) const { return m_knots[i]; }
+
+  /*!
+   * \brief Setter for the knot vector
+   *
+   * \param [in] i The vector index
+   * 
+   * \pre Assumes that the knot vector will remain valid after the change
+   * 
+   * \return A reference to the knot value at index i
+   */
+  T& operator[](axom::IndexType i)
+  {
+    SLIC_ASSERT(isValid());
+    return m_knots[i];
+  }
 
   /// \brief Return an array of the unique knot values
   axom::Array<T> getUniqueKnots() const
@@ -257,15 +360,128 @@ public:
     return num_spans;
   }
 
-  /// \brief Return the number of control points implied by the knot vector
-  axom::IndexType getNumControlPoints() const { return m_knots.size() - m_deg - 1; }
+  ///@}
 
-  /// \brief Clear the list of knots
-  void clear()
+  ///@{
+  /// \name Query/modify KnotVector parametrization
+
+  /// \brief Normalize the knot vector to the span of [0, 1]
+  void normalize()
   {
-    m_deg = -1;
-    m_knots.clear();
+    T min_knot = m_knots[0];
+    T max_knot = m_knots[m_knots.size() - 1];
+    T span = max_knot - min_knot;
+
+    for(int i = 0; i < m_knots.size(); ++i)
+    {
+      m_knots[i] = (m_knots[i] - min_knot) / span;
+    }
   }
+
+  /*!
+   * \brief Rescale the knot vector to the span of [a, b]
+   * 
+   * \param [in] a The lower bound of the new knot vector
+   * \param [in] b The upper bound of the new knot vector
+   * 
+   * \pre Requires a < b
+   */
+  void rescale(T a, T b)
+  {
+    SLIC_ASSERT(a < b);
+
+    T min_knot = m_knots[0];
+    T max_knot = m_knots[m_knots.size() - 1];
+    T span = max_knot - min_knot;
+
+    for(int i = 0; i < m_knots.size(); ++i)
+    {
+      m_knots[i] = a + (m_knots[i] - min_knot) * (b - a) / span;
+    }
+  }
+
+  /// \brief Reverse the knot vector
+  void reverse()
+  {
+    const axom::IndexType nkts = m_knots.size();
+    const axom::IndexType knot_mid = (nkts + 1) / 2;
+
+    // Flip the vector
+    for(int i = 0; i < knot_mid; ++i)
+    {
+      axom::utilities::swap(m_knots[i], m_knots[nkts - 1 - i]);
+    }
+
+    // Replace each knot with sum - knot_value
+    const T the_sum = m_knots[0] + m_knots[nkts - 1];
+    for(int i = 0; i < nkts; ++i)
+    {
+      m_knots[i] = the_sum - m_knots[i];
+    }
+  }
+
+  /*!
+   * \brief Insert a knot into the vector r times
+   * 
+   * \param [in] span The span into which the knot will be inserted
+   * \param [in] t The value of the knot to insert
+   * \param [in] r The number of times to insert the knot
+   *  
+   * \pre Assumes that the input span is correct for input t, and that
+   *  the knot is not present enough times to exceed the degree 
+   */
+  void insertKnotBySpan(axom::IndexType span, T t, int r)
+  {
+    SLIC_ASSERT(isValidSpan(span, t));
+
+    for(int i = 0; i < r; ++i)
+    {
+      m_knots.insert(m_knots.begin() + span + 1, t);
+    }
+
+    SLIC_ASSERT(isValid());
+  }
+
+  /*!
+   * \brief Insert a knot into the vector to have the given multiplicity
+   * 
+   * \param [in] t The value of the knot to insert
+   * \param [in] target_mutliplicity The number of times the knot will be present
+   *
+   * \pre Assumes that the input t is within the knot vector (up to some tolerance)
+   * 
+   * \note If the knot is already present, it will be inserted
+   *  up to the given multiplicity, or the maximum permitted by the degree
+   */
+  void insertKnot(T t, int target_multiplicity)
+  {
+    SLIC_ASSERT(isValidParameter(t));
+
+    int multiplicity;
+    auto span = findSpan(t, multiplicity);
+
+    // Compute how many knots should be inserted
+    int r = axom::utilities::clampVal(target_multiplicity - multiplicity, 0, m_deg - multiplicity);
+
+    insertKnotBySpan(span, t, r);
+  }
+
+  /// \brief Checks if given parameter is in knot span (to a tolerance)
+  bool isValidParameter(T t, T EPS = 1e-5) const
+  {
+    return t >= m_knots[0] - EPS && t <= m_knots[m_knots.size() - 1] + EPS;
+  }
+
+  /// \brief Checks if given parameter is *interior* to knot span (to a tolerance)
+  bool isValidInteriorParameter(T t) const
+  {
+    return t > m_knots[0] && t < m_knots[m_knots.size() - 1];
+  }
+
+  ///@}
+
+  ///@{
+  /// \name Functions for evaluating knot vector
 
   /*!
    * \brief Returns the index of the knot span containing parameter t
@@ -358,161 +574,6 @@ public:
     }
 
     return span;
-  }
-
-  /// \brief Normalize the knot vector to the span of [0, 1]
-  void normalize()
-  {
-    T min_knot = m_knots[0];
-    T max_knot = m_knots[m_knots.size() - 1];
-    T span = max_knot - min_knot;
-
-    for(int i = 0; i < m_knots.size(); ++i)
-    {
-      m_knots[i] = (m_knots[i] - min_knot) / span;
-    }
-  }
-
-  /*!
-   * \brief Rescale the knot vector to the span of [a, b]
-   * 
-   * \param [in] a The lower bound of the new knot vector
-   * \param [in] b The upper bound of the new knot vector
-   * 
-   * \pre Requires a < b
-   */
-  void rescale(T a, T b)
-  {
-    SLIC_ASSERT(a < b);
-
-    T min_knot = m_knots[0];
-    T max_knot = m_knots[m_knots.size() - 1];
-    T span = max_knot - min_knot;
-
-    for(int i = 0; i < m_knots.size(); ++i)
-    {
-      m_knots[i] = a + (m_knots[i] - min_knot) * (b - a) / span;
-    }
-  }
-
-  /*!
-   * \brief Insert a knot into the vector r times
-   * 
-   * \param [in] span The span into which the knot will be inserted
-   * \param [in] t The value of the knot to insert
-   * \param [in] r The number of times to insert the knot
-   *  
-   * \pre Assumes that the input span is correct for input t, and that
-   *  the knot is not present enough times to exceed the degree 
-   */
-  void insertKnotBySpan(axom::IndexType span, T t, int r)
-  {
-    SLIC_ASSERT(isValidSpan(span, t));
-
-    for(int i = 0; i < r; ++i)
-    {
-      m_knots.insert(m_knots.begin() + span + 1, t);
-    }
-
-    SLIC_ASSERT(isValid());
-  }
-
-  /*!
-   * \brief Insert a knot into the vector to have the given multiplicity
-   * 
-   * \param [in] t The value of the knot to insert
-   * \param [in] target_mutliplicity The number of times the knot will be present
-   *
-   * \pre Assumes that the input t is within the knot vector (up to some tolerance)
-   * 
-   * \note If the knot is already present, it will be inserted
-   *  up to the given multiplicity, or the maximum permitted by the degree
-   */
-  void insertKnot(T t, int target_multiplicity)
-  {
-    SLIC_ASSERT(isValidParameter(t));
-
-    int multiplicity;
-    auto span = findSpan(t, multiplicity);
-
-    // Compute how many knots should be inserted
-    int r = axom::utilities::clampVal(target_multiplicity - multiplicity, 0, m_deg - multiplicity);
-
-    insertKnotBySpan(span, t, r);
-  }
-
-  /*!
-   * \brief Split a knot vector at the value at index `span`
-   * 
-   * \param [in] span The span at which the knot will be split
-   * \param [out] k1 The first knot vector
-   * \param [out] k2 The second knot vector
-   * \param [in] normalize Whether to normalize the output knot vectors
-   * 
-   * \warning Assumes that the multiplicity of the knot at which 
-   *  the vector will be split is equal to the degree, or the
-   *  returned knot vectors will be invalid
-   */
-  void splitBySpan(axom::IndexType span, KnotVector& k1, KnotVector& k2, bool normalize = false) const
-  {
-    SLIC_ASSERT(isValidSpan(span));
-
-    const auto nkts = getNumKnots();
-
-    // Create a copy of the vector in case k1 or k2 is the same as *this
-    KnotVector<T> data(*this);
-
-    // Copy the degree
-    k1.m_deg = m_deg;
-    k2.m_deg = m_deg;
-
-    // Copy the knots
-    k1.m_knots.resize(span + 2);
-    k2.m_knots.resize(nkts - span + m_deg);
-
-    k1.m_knots[span + 1] = data[span];
-    for(int i = 0; i < span + 1; ++i)
-    {
-      k1.m_knots[i] = data[i];
-    }
-
-    k2.m_knots[0] = data[span];
-    for(int i = 0; i < nkts - span + m_deg - 1; ++i)
-    {
-      k2.m_knots[i + 1] = data[span + i - m_deg + 1];
-    }
-
-    if(normalize)
-    {
-      k1.normalize();
-      k2.normalize();
-    }
-
-    SLIC_ASSERT(k1.isValid());
-    SLIC_ASSERT(k2.isValid());
-  }
-
-  /*!
-   * \brief Split a knot vector at the value t
-   * 
-   * \param [in] t The value at which the knot will be split
-   * \param [out] k1 The first knot vector
-   * \param [out] k2 The second knot vector
-   * \param [in] normalize Whether to normalize the output knot vectors
-   * 
-   * \pre Assumes that the input t is *interior* to the knot vector
-   */
-  void split(T t, KnotVector& k1, KnotVector& k2, bool normalize = false) const
-  {
-    SLIC_ASSERT(isValidInteriorParameter(t));
-
-    int multiplicity;
-    axom::IndexType span = findSpan(t, multiplicity);
-
-    k1 = *this;
-    k1.insertKnotBySpan(span, t, m_deg - multiplicity);
-
-    k1.splitBySpan(span + m_deg - multiplicity, k1, k2, normalize);
   }
 
   /*!
@@ -691,110 +752,86 @@ public:
     return derivativeBasisFunctionsBySpan(findSpan(t), t, n);
   }
 
-  /// \brief Reverse the knot vector
-  void reverse()
+  ///@}
+
+  ///@{
+  /// \name Functions dealing with knot vector subdivision
+
+  /*!
+   * \brief Split a knot vector at the value at index `span`
+   * 
+   * \param [in] span The span at which the knot will be split
+   * \param [out] k1 The first knot vector
+   * \param [out] k2 The second knot vector
+   * \param [in] normalize Whether to normalize the output knot vectors
+   * 
+   * \warning Assumes that the multiplicity of the knot at which 
+   *  the vector will be split is equal to the degree, or the
+   *  returned knot vectors will be invalid
+   */
+  void splitBySpan(axom::IndexType span, KnotVector& k1, KnotVector& k2, bool normalize = false) const
   {
-    const axom::IndexType nkts = m_knots.size();
-    const axom::IndexType knot_mid = (nkts + 1) / 2;
+    SLIC_ASSERT(isValidSpan(span));
 
-    // Flip the vector
-    for(int i = 0; i < knot_mid; ++i)
+    const auto nkts = getNumKnots();
+
+    // Create a copy of the vector in case k1 or k2 is the same as *this
+    KnotVector<T> data(*this);
+
+    // Copy the degree
+    k1.m_deg = m_deg;
+    k2.m_deg = m_deg;
+
+    // Copy the knots
+    k1.m_knots.resize(span + 2);
+    k2.m_knots.resize(nkts - span + m_deg);
+
+    k1.m_knots[span + 1] = data[span];
+    for(int i = 0; i < span + 1; ++i)
     {
-      axom::utilities::swap(m_knots[i], m_knots[nkts - 1 - i]);
+      k1.m_knots[i] = data[i];
     }
 
-    // Replace each knot with sum - knot_value
-    const T the_sum = m_knots[0] + m_knots[nkts - 1];
-    for(int i = 0; i < nkts; ++i)
+    k2.m_knots[0] = data[span];
+    for(int i = 0; i < nkts - span + m_deg - 1; ++i)
     {
-      m_knots[i] = the_sum - m_knots[i];
-    }
-  }
-
-  /// \brief Return if the knot vector is valid
-  bool isValid() const
-  {
-    // Check degree
-    if(m_deg < 0)
-    {
-      return false;
+      k2.m_knots[i + 1] = data[span + i - m_deg + 1];
     }
 
-    // Check for monotonicity
-    for(int i = 0; i < m_knots.size() - 1; ++i)
+    if(normalize)
     {
-      if(m_knots[i] > m_knots[i + 1])
-      {
-        return false;
-      }
+      k1.normalize();
+      k2.normalize();
     }
 
-    // Check for clamped-ness
-    auto nkts = m_knots.size();
-    for(int i = 0; i < m_deg + 1; ++i)
-    {
-      if(m_knots[i] != m_knots[0])
-      {
-        return false;
-      }
-      if(m_knots[nkts - 1 - i] != m_knots[nkts - 1])
-      {
-        return false;
-      }
-    }
-
-    // Check for continuity
-    T this_knot = m_knots[m_deg];
-    int this_multiplicity = 1;
-    for(int i = m_deg + 1; i < nkts - m_deg - 1; ++i)
-    {
-      if(m_knots[i] != this_knot)
-      {
-        this_knot = m_knots[i];
-        this_multiplicity = 1;
-      }
-      else
-      {
-        this_multiplicity++;
-        if(this_multiplicity > m_deg)
-        {
-          return false;
-        }
-      }
-    }
-
-    return true;
+    SLIC_ASSERT(k1.isValid());
+    SLIC_ASSERT(k2.isValid());
   }
 
   /*!
-   * \brief Check if a knot span is valid 
-   *
-   * \param [in] span The span to check
+   * \brief Split a knot vector at the value t
    * 
-   * A valid span is one that is within the knot vector and has a non-zero length
+   * \param [in] t The value at which the knot will be split
+   * \param [out] k1 The first knot vector
+   * \param [out] k2 The second knot vector
+   * \param [in] normalize Whether to normalize the output knot vectors
    * 
-   * \return True if the span is valid, false otherwise
+   * \pre Assumes that the input t is *interior* to the knot vector
    */
-  bool isValidSpan(axom::IndexType span) const
+  void split(T t, KnotVector& k1, KnotVector& k2, bool normalize = false) const
   {
-    return span >= m_deg && span < m_knots.size() - m_deg - 1 && m_knots[span] != m_knots[span + 1];
+    SLIC_ASSERT(isValidInteriorParameter(t));
+
+    int multiplicity;
+    axom::IndexType span = findSpan(t, multiplicity);
+
+    k1 = *this;
+    k1.insertKnotBySpan(span, t, m_deg - multiplicity);
+
+    k1.splitBySpan(span + m_deg - multiplicity, k1, k2, normalize);
   }
 
-  /*!
-   * \brief Check if a knot span is valid and contains the parameter value t
-   *
-   * \param [in] span The span to check
-   * \param [in] t The parameter value
-   * 
-   * A valid span is one that is within the knot vector, has a non-zero length,
-   * and contains the parameter value t
-   * 
-   * \return True if the span is valid, false otherwise
-   */
-  bool isValidSpan(axom::IndexType span, T t) const
-  {
-    return isValidSpan(span) && t >= m_knots[span] && t <= m_knots[span + 1];
-  }
+  ///@}
 
   /*!
    * \brief Check equality of two knot vectors
@@ -820,18 +857,6 @@ public:
   friend inline bool operator!=(const KnotVector<T>& lhs, const KnotVector<T>& rhs)
   {
     return !(lhs == rhs);
-  }
-
-  /// \brief Checks if given parameter is in knot span (to a tolerance)
-  bool isValidParameter(T t, T EPS = 1e-5) const
-  {
-    return t >= m_knots[0] - EPS && t <= m_knots[m_knots.size() - 1] + EPS;
-  }
-
-  /// \brief Checks if given parameter is *interior* to knot span (to a tolerance)
-  bool isValidInteriorParameter(T t) const
-  {
-    return t > m_knots[0] && t < m_knots[m_knots.size() - 1];
   }
 
   /*!

--- a/src/axom/primal/geometry/NURBSCurve.hpp
+++ b/src/axom/primal/geometry/NURBSCurve.hpp
@@ -354,8 +354,6 @@ public:
     : NURBSCurve(pts.view(), weights.view(), knotVector)
   { }
 
-  ///@}
-
   /*!
    * \brief Construct a multi-span, rational, degree 2 NURBS curve from the angles of a circular arc
    *
@@ -459,6 +457,447 @@ public:
 
     return line;
   }
+
+  ///@}
+
+  ///@{
+  /// \name Query/modify curve properties (degree, rationality, ...)
+
+  /*!
+   * \brief Reset the degree and resize arrays of points (and weights)
+   *
+   * \param [in] npts The target number of control points
+   * \param [in] degree The target degree
+   * 
+   * \warning This method will replace existing knot vector with a uniform one.
+   */
+  void setParameters(int npts, int degree)
+  {
+    SLIC_ASSERT(npts > degree);
+    SLIC_ASSERT(degree >= 0);
+
+    m_controlPoints.resize(npts);
+
+    if(isRational())
+    {
+      m_weights.resize(npts);
+    }
+
+    m_knotvec.makeUniform(npts, degree);
+  }
+
+  /*!
+   * \brief Reset the knot vector
+   *
+   * \param [in] degree The target degree
+   * 
+   * \warning This method does NOT change the existing control points, 
+   *  i.e. does not perform degree elevation/reduction. 
+   *  Will replace existing knot vector with a uniform one.
+   *  
+   * \pre Requires target degree < npts and degree >= 0
+   */
+  void setDegree(int degree)
+  {
+    SLIC_ASSERT(0 <= degree && degree < getNumControlPoints());
+
+    m_knotvec.makeUniform(getNumControlPoints(), degree);
+  }
+
+  /// \brief Returns the degree of the NURBS Curve
+  int getDegree() const { return static_cast<int>(m_knotvec.getDegree()); }
+
+  /// \brief Returns the order of the NURBS Curve
+  int getOrder() const { return static_cast<int>(m_knotvec.getDegree() + 1); }
+
+  /// \brief Returns the number of control points in the NURBS Curve
+  int getNumControlPoints() const { return static_cast<int>(m_controlPoints.size()); }
+
+  /*!
+   * \brief Set the number control points
+   *
+   * \param [in] npts The target number of control points
+   * 
+   * \warning This method does NOT change the existing control points, 
+   *  i.e. does not perform degree elevation/reduction. 
+   *  Will replace existing knot vector with a uniform one.
+   */
+  void setNumControlPoints(int npts)
+  {
+    const int deg = m_knotvec.getDegree();
+    SLIC_ASSERT(npts > deg);
+
+    m_controlPoints.resize(npts);
+    if(isRational())
+    {
+      m_weights.resize(npts);
+    }
+
+    m_knotvec.makeUniform(npts, deg);
+  }
+
+  /// \brief Clears the list of control points, make nonrational
+  void clear()
+  {
+    m_controlPoints.clear();
+    m_knotvec.clear();
+    makeNonrational();
+  }
+
+  /// \brief Use array size as flag for rationality
+  bool isRational() const { return !m_weights.empty(); }
+
+  /// \brief Make trivially rational. If already rational, do nothing
+  void makeRational()
+  {
+    if(!isRational())
+    {
+      m_weights.resize(m_controlPoints.size());
+      m_weights.fill(1.0);
+    }
+  }
+
+  /// \brief Make nonrational. If already rational, do nothing
+  void makeNonrational() { m_weights.resize(0); }
+
+  /// \brief Function to check if the NURBS curve is valid
+  bool isValidNURBS() const
+  {
+    // Check monotonicity, open-ness, continuity
+    if(!m_knotvec.isValid())
+    {
+      return false;
+    }
+
+    // Number of knots must match the number of control points
+    int p = m_knotvec.getDegree();
+    if(m_knotvec.getNumKnots() != m_controlPoints.size() + p + 1)
+    {
+      return false;
+    }
+
+    if(isRational())
+    {
+      if(m_weights.size() != m_controlPoints.size())
+      {
+        // Weights must match the number of control points
+        return false;
+      }
+
+      for(int i = 0; i < m_weights.size(); ++i)
+      {
+        if(m_weights[i] <= 0)
+        {
+          // Weights must be positive
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  ///@}
+
+  ///@{
+  /// \name Query/modify curve's geometry (control points, weights, bounding box, ...)
+
+  /*!
+   * \brief Retrieve the control point at index \a idx
+   *
+   * \param [in] idx The index of the control point
+   * 
+   * \return A reference to the control point at index \a idx
+   */
+  PointType& operator[](int idx) { return m_controlPoints[idx]; }
+
+  /*!
+   * \brief Retrieve the control point at index \a idx
+   *
+   * \param [in] idx The index of the control point
+   * 
+   * \return A const reference to the control point at index \a idx
+   */
+  const PointType& operator[](int idx) const { return m_controlPoints[idx]; }
+
+  /// \brief Returns a copy of the NURBS curve's control points
+  CoordsVec getControlPoints() const { return m_controlPoints; }
+
+  /*!
+   * \brief Get a specific weight
+   *
+   * \param [in] idx The index of the weight
+   * \pre Requires that the curve be rational
+   * 
+   * \return The weight at index \a idx
+   */
+  const T& getWeight(int idx) const
+  {
+    SLIC_ASSERT(isRational());
+    return m_weights[idx];
+  }
+
+  /*!
+   * \brief Set the weight at a specific index
+   *
+   * \param [in] idx The index of the weight
+   * \param [in] weight The updated value of the weight
+   * 
+   * \pre Requires that the curve be rational, and the weight be rational
+   */
+  void setWeight(int idx, T weight)
+  {
+    SLIC_ASSERT(isRational());
+    SLIC_ASSERT(weight > 0);
+
+    m_weights[idx] = weight;
+  }
+
+  /// \brief Returns a copy of the NURBS curve's control points
+  WeightsVec getWeights() const { return m_weights; }
+
+  /// \brief Returns an axis-aligned bounding box containing the NURBS curve
+  BoundingBoxType boundingBox() const
+  {
+    return BoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
+  }
+
+  /// \brief Returns an oriented bounding box containing the NURBS curve
+  OrientedBoundingBoxType orientedBoundingBox() const
+  {
+    return OrientedBoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
+  }
+
+  ///@}
+
+  ///@{
+  /// \name Query/modify curve parametrization
+
+  /// \brief Returns the number of knots in the NURBS Curve
+  axom::IndexType getNumKnots() const { return m_knotvec.getNumKnots(); }
+
+  /// \brief Normalize the knot vector to the span of [0, 1]
+  void normalize() { m_knotvec.normalize(); }
+
+  /*!
+   * \brief Rescale the knot vector to the span of [a, b]
+   * 
+   * \param [in] a The lower bound of the new knot vector
+   * \param [in] b The upper bound of the new knot vector
+   * 
+   * \pre Requires a < b
+   */
+  void rescale(T a, T b)
+  {
+    SLIC_ASSERT(a < b);
+    m_knotvec.rescale(a, b);
+  }
+
+  /*!
+   * \brief Get a specific knot value
+   *
+   * \param [in] idx The index of the knot
+   * 
+   * \return The knot value at index \a idx
+   */
+  const T& getKnot(int idx) const { return m_knotvec[idx]; }
+
+  /*!
+   * \brief Set the knot value at a specific index
+   *
+   * \param [in] idx The index of the knot
+   * \param [in] knot The updated value of the knot
+   */
+  void setKnot(int idx, T knot) { m_knotvec[idx] = knot; }
+
+  /*! 
+   * \brief Set the knot vector by an axom::Array
+   *
+   * \param [in] knots The new knot vector
+   */
+  void setKnots(const axom::Array<T>& knots, int degree)
+  {
+    m_knotvec = KnotVectorType(knots, degree);
+  }
+
+  /*! 
+   * \brief Set the knot vector by a KnotVector object
+   *
+   * \param [in] knotVector The new knot vector
+   */
+  void setKnots(const KnotVectorType& knotVector) { m_knotvec = knotVector; }
+
+  /// \brief Return a copy of the knot vector
+  KnotVectorType getKnots() const { return m_knotvec; }
+
+  /// \brief Return a copy of the knot vector as an array
+  axom::Array<T> getKnotsArray() const { return m_knotvec.getArray(); }
+
+  /// \brief Get minimum knot
+  T getMinKnot() const { return m_knotvec[0]; }
+
+  /// \brief Get maximum knot
+  T getMaxKnot() const { return m_knotvec[m_knotvec.getNumKnots() - 1]; }
+
+  /// \brief Reverses the order of the NURBS curve's control points and weights
+  void reverseOrientation()
+  {
+    const int npts = getNumControlPoints();
+    const int npts_mid = (npts + 1) / 2;
+    for(int i = 0; i < npts_mid; ++i)
+    {
+      axom::utilities::swap(m_controlPoints[i], m_controlPoints[npts - i - 1]);
+    }
+
+    if(isRational())
+    {
+      for(int i = 0; i < npts_mid; ++i)
+      {
+        axom::utilities::swap(m_weights[i], m_weights[npts - i - 1]);
+      }
+    }
+
+    // Reverse the orientation of the knots
+    m_knotvec.reverse();
+  }
+
+  /*! 
+   * \brief Insert a knot with given multiplicity
+   *
+   * \param [in] t The parameter value of the knot to insert
+   * \param [in] target_multiplicity The multiplicity of the knot to insert
+   * \return The index of the new knot
+   * 
+   * Algorithm A5.1 on p. 151 of "The NURBS Book"
+   * 
+   * \note If the knot is already present, it will be inserted
+   *  up to the given multiplicity, or the maximum permitted by the degree
+   * 
+   * \pre Requires \a t in the span of the knots (up to a small tolerance)
+   * 
+   * \note If t is outside the knot span up to this tolerance, it is clamped to the span
+   * 
+   * \return The (maximum) index of the new knot
+   */
+  axom::IndexType insertKnot(T t, int target_multiplicity = 1)
+  {
+    SLIC_ASSERT(m_knotvec.isValidParameter(t));
+    t = axom::utilities::clampVal(t, getMinKnot(), getMaxKnot());
+
+    SLIC_ASSERT(target_multiplicity > 0);
+
+    const bool isRational = this->isRational();
+
+    const int n = getNumControlPoints() - 1;
+    const int p = m_knotvec.getDegree();
+
+    // Find the span and multiplicity of the knot
+    int s = 0;
+    const auto span = m_knotvec.findSpan(t, s);
+
+    // Fix the maximum multiplicity of the knot
+    int r = std::min(target_multiplicity - s, p - s);
+    if(r <= 0)
+    {
+      return span;  // Early exit if no knots to add
+    }
+
+    // Save unaltered control points
+    CoordsVec newControlPoints(m_controlPoints.size() + r);
+    WeightsVec newWeights(isRational ? m_weights.size() + r : 0);
+    for(int i = 0; i <= span - p; ++i)
+    {
+      newControlPoints[i] = m_controlPoints[i];
+      if(isRational)
+      {
+        newWeights[i] = m_weights[i];
+      }
+    }
+
+    for(auto i = span - s; i <= n; ++i)
+    {
+      newControlPoints[i + r] = m_controlPoints[i];
+      if(isRational)
+      {
+        newWeights[i + r] = m_weights[i];
+      }
+    }
+
+    // Insert the new control points
+    CoordsVec tempControlPoints(p + 1);
+    WeightsVec tempWeights(isRational ? p + 1 : 0);
+    for(int i = 0; i <= p - s; ++i)
+    {
+      for(int N = 0; N < NDIMS; ++N)
+      {
+        tempControlPoints[i][N] =
+          m_controlPoints[span - p + i][N] * (isRational ? m_weights[span - p + i] : 1.0);
+      }
+
+      if(isRational)
+      {
+        tempWeights[i] = m_weights[span - p + i];
+      }
+    }
+
+    // Insert the knot r times
+    axom::IndexType L;
+    for(int j = 1; j <= r; ++j)
+    {
+      L = span - p + j;
+      for(int i = 0; i <= p - j - s; ++i)
+      {
+        T alpha = (t - m_knotvec[L + i]) / (m_knotvec[i + span + 1] - m_knotvec[L + i]);
+
+        tempControlPoints[i].array() =
+          (1.0 - alpha) * tempControlPoints[i].array() + alpha * tempControlPoints[i + 1].array();
+
+        if(isRational)
+        {
+          tempWeights[i] = (1.0 - alpha) * tempWeights[i] + alpha * tempWeights[i + 1];
+        }
+      }
+
+      for(int N = 0; N < NDIMS; ++N)
+      {
+        newControlPoints[L][N] = tempControlPoints[0][N] / (isRational ? tempWeights[0] : 1.0);
+        newControlPoints[span + r - j - s][N] =
+          tempControlPoints[p - j - s][N] / (isRational ? tempWeights[p - j - s] : 1.0);
+      }
+
+      if(isRational)
+      {
+        newWeights[L] = tempWeights[0];
+        newWeights[span + r - j - s] = tempWeights[p - j - s];
+      }
+    }
+
+    for(auto i = L + 1; i < span - s; ++i)
+    {
+      for(int N = 0; N < NDIMS; ++N)
+      {
+        newControlPoints[i][N] =
+          tempControlPoints[i - L][N] / (isRational ? tempWeights[i - L] : 1.0);
+      }
+
+      if(isRational)
+      {
+        newWeights[i] = tempWeights[i - L];
+      }
+    }
+
+    // Update the knot vector and control points
+    m_knotvec.insertKnotBySpan(span, t, r);
+    m_controlPoints = newControlPoints;
+    m_weights = newWeights;
+
+    return span + r;
+  }
+
+  ///@}
+
+  ///@{
+  /// \name Functions to evaluate curve and its derivatives and normals
 
   /*!
    * \brief Evaluate a NURBS Curve at a particular parameter value \a t
@@ -705,138 +1144,10 @@ public:
     }
   }
 
-  /*! 
-   * \brief Insert a knot with given multiplicity
-   *
-   * \param [in] t The parameter value of the knot to insert
-   * \param [in] target_multiplicity The multiplicity of the knot to insert
-   * \return The index of the new knot
-   * 
-   * Algorithm A5.1 on p. 151 of "The NURBS Book"
-   * 
-   * \note If the knot is already present, it will be inserted
-   *  up to the given multiplicity, or the maximum permitted by the degree
-   * 
-   * \pre Requires \a t in the span of the knots (up to a small tolerance)
-   * 
-   * \note If t is outside the knot span up to this tolerance, it is clamped to the span
-   * 
-   * \return The (maximum) index of the new knot
-   */
-  axom::IndexType insertKnot(T t, int target_multiplicity = 1)
-  {
-    SLIC_ASSERT(m_knotvec.isValidParameter(t));
-    t = axom::utilities::clampVal(t, getMinKnot(), getMaxKnot());
+  ///@}
 
-    SLIC_ASSERT(target_multiplicity > 0);
-
-    const bool isRational = this->isRational();
-
-    const int n = getNumControlPoints() - 1;
-    const int p = m_knotvec.getDegree();
-
-    // Find the span and multiplicity of the knot
-    int s = 0;
-    const auto span = m_knotvec.findSpan(t, s);
-
-    // Fix the maximum multiplicity of the knot
-    int r = std::min(target_multiplicity - s, p - s);
-    if(r <= 0)
-    {
-      return span;  // Early exit if no knots to add
-    }
-
-    // Save unaltered control points
-    CoordsVec newControlPoints(m_controlPoints.size() + r);
-    WeightsVec newWeights(isRational ? m_weights.size() + r : 0);
-    for(int i = 0; i <= span - p; ++i)
-    {
-      newControlPoints[i] = m_controlPoints[i];
-      if(isRational)
-      {
-        newWeights[i] = m_weights[i];
-      }
-    }
-
-    for(auto i = span - s; i <= n; ++i)
-    {
-      newControlPoints[i + r] = m_controlPoints[i];
-      if(isRational)
-      {
-        newWeights[i + r] = m_weights[i];
-      }
-    }
-
-    // Insert the new control points
-    CoordsVec tempControlPoints(p + 1);
-    WeightsVec tempWeights(isRational ? p + 1 : 0);
-    for(int i = 0; i <= p - s; ++i)
-    {
-      for(int N = 0; N < NDIMS; ++N)
-      {
-        tempControlPoints[i][N] =
-          m_controlPoints[span - p + i][N] * (isRational ? m_weights[span - p + i] : 1.0);
-      }
-
-      if(isRational)
-      {
-        tempWeights[i] = m_weights[span - p + i];
-      }
-    }
-
-    // Insert the knot r times
-    axom::IndexType L;
-    for(int j = 1; j <= r; ++j)
-    {
-      L = span - p + j;
-      for(int i = 0; i <= p - j - s; ++i)
-      {
-        T alpha = (t - m_knotvec[L + i]) / (m_knotvec[i + span + 1] - m_knotvec[L + i]);
-
-        tempControlPoints[i].array() =
-          (1.0 - alpha) * tempControlPoints[i].array() + alpha * tempControlPoints[i + 1].array();
-
-        if(isRational)
-        {
-          tempWeights[i] = (1.0 - alpha) * tempWeights[i] + alpha * tempWeights[i + 1];
-        }
-      }
-
-      for(int N = 0; N < NDIMS; ++N)
-      {
-        newControlPoints[L][N] = tempControlPoints[0][N] / (isRational ? tempWeights[0] : 1.0);
-        newControlPoints[span + r - j - s][N] =
-          tempControlPoints[p - j - s][N] / (isRational ? tempWeights[p - j - s] : 1.0);
-      }
-
-      if(isRational)
-      {
-        newWeights[L] = tempWeights[0];
-        newWeights[span + r - j - s] = tempWeights[p - j - s];
-      }
-    }
-
-    for(auto i = L + 1; i < span - s; ++i)
-    {
-      for(int N = 0; N < NDIMS; ++N)
-      {
-        newControlPoints[i][N] =
-          tempControlPoints[i - L][N] / (isRational ? tempWeights[i - L] : 1.0);
-      }
-
-      if(isRational)
-      {
-        newWeights[i] = tempWeights[i - L];
-      }
-    }
-
-    // Update the knot vector and control points
-    m_knotvec.insertKnotBySpan(span, t, r);
-    m_controlPoints = newControlPoints;
-    m_weights = newWeights;
-
-    return span + r;
-  }
+  ///@{
+  /// \name Functions dealing with curve subdivision
 
   /*!
    * \brief Splits a NURBS curve into two curves at a given parameter value
@@ -924,23 +1235,6 @@ public:
     }
 
     return true;
-  }
-
-  /// \brief Normalize the knot vector to the span of [0, 1]
-  void normalize() { m_knotvec.normalize(); }
-
-  /*!
-   * \brief Rescale the knot vector to the span of [a, b]
-   * 
-   * \param [in] a The lower bound of the new knot vector
-   * \param [in] b The upper bound of the new knot vector
-   * 
-   * \pre Requires a < b
-   */
-  void rescale(T a, T b)
-  {
-    SLIC_ASSERT(a < b);
-    m_knotvec.rescale(a, b);
   }
 
   /*!
@@ -1076,187 +1370,7 @@ public:
     return beziers;
   }
 
-  /*!
-   * \brief Reset the degree and resize arrays of points (and weights)
-   *
-   * \param [in] npts The target number of control points
-   * \param [in] degree The target degree
-   * 
-   * \warning This method will replace existing knot vector with a uniform one.
-   */
-  void setParameters(int npts, int degree)
-  {
-    SLIC_ASSERT(npts > degree);
-    SLIC_ASSERT(degree >= 0);
-
-    m_controlPoints.resize(npts);
-
-    if(isRational())
-    {
-      m_weights.resize(npts);
-    }
-
-    m_knotvec.makeUniform(npts, degree);
-  }
-
-  /*!
-   * \brief Reset the knot vector
-   *
-   * \param [in] degree The target degree
-   * 
-   * \warning This method does NOT change the existing control points, 
-   *  i.e. does not perform degree elevation/reduction. 
-   *  Will replace existing knot vector with a uniform one.
-   *  
-   * \pre Requires target degree < npts and degree >= 0
-   */
-  void setDegree(int degree)
-  {
-    SLIC_ASSERT(0 <= degree && degree < getNumControlPoints());
-
-    m_knotvec.makeUniform(getNumControlPoints(), degree);
-  }
-
-  /// \brief Returns the degree of the NURBS Curve
-  int getDegree() const { return static_cast<int>(m_knotvec.getDegree()); }
-
-  /// \brief Returns the order of the NURBS Curve
-  int getOrder() const { return static_cast<int>(m_knotvec.getDegree() + 1); }
-
-  /// \brief Returns the number of control poitns in the NURBS Curve
-  int getNumControlPoints() const { return static_cast<int>(m_controlPoints.size()); }
-
-  /*!
-   * \brief Set the number control points
-   *
-   * \param [in] npts The target number of control points
-   * 
-   * \warning This method does NOT change the existing control points, 
-   *  i.e. does not perform degree elevation/reduction. 
-   *  Will replace existing knot vector with a uniform one.
-   */
-  void setNumControlPoints(int npts)
-  {
-    const int deg = m_knotvec.getDegree();
-    SLIC_ASSERT(npts > deg);
-
-    m_controlPoints.resize(npts);
-    if(isRational())
-    {
-      m_weights.resize(npts);
-    }
-
-    m_knotvec.makeUniform(npts, deg);
-  }
-
-  /// \brief Returns the number of knots in the NURBS Curve
-  axom::IndexType getNumKnots() const { return m_knotvec.getNumKnots(); }
-
-  /// \brief Make nonrational. If already rational, do nothing
-  void makeNonrational() { m_weights.resize(0); }
-
-  /// \brief Make trivially rational. If already rational, do nothing
-  void makeRational()
-  {
-    if(!isRational())
-    {
-      m_weights.resize(m_controlPoints.size());
-      m_weights.fill(1.0);
-    }
-  }
-
-  /// \brief Use array size as flag for rationality
-  bool isRational() const { return !m_weights.empty(); }
-
-  /// \brief Clears the list of control points, make nonrational
-  void clear()
-  {
-    m_controlPoints.clear();
-    m_knotvec.clear();
-    makeNonrational();
-  }
-
-  /*!
-   * \brief Retrieve the control point at index \a idx
-   *
-   * \param [in] idx The index of the control point
-   * 
-   * \return A reference to the control point at index \a idx
-   */
-  PointType& operator[](int idx) { return m_controlPoints[idx]; }
-
-  /*!
-   * \brief Retrieve the control point at index \a idx
-   *
-   * \param [in] idx The index of the control point
-   * 
-   * \return A const reference to the control point at index \a idx
-   */
-  const PointType& operator[](int idx) const { return m_controlPoints[idx]; }
-
-  /*!
-   * \brief Get a specific weight
-   *
-   * \param [in] idx The index of the weight
-   * \pre Requires that the curve be rational
-   * 
-   * \return The weight at index \a idx
-   */
-  const T& getWeight(int idx) const
-  {
-    SLIC_ASSERT(isRational());
-    return m_weights[idx];
-  }
-
-  /*!
-   * \brief Set the weight at a specific index
-   *
-   * \param [in] idx The index of the weight
-   * \param [in] weight The updated value of the weight
-   * 
-   * \pre Requires that the curve be rational, and the weight be rational
-   */
-  void setWeight(int idx, T weight)
-  {
-    SLIC_ASSERT(isRational());
-    SLIC_ASSERT(weight > 0);
-
-    m_weights[idx] = weight;
-  }
-
-  /*!
-   * \brief Get a specific knot value
-   *
-   * \param [in] idx The index of the knot
-   * 
-   * \return The knot value at index \a idx
-   */
-  const T& getKnot(int idx) const { return m_knotvec[idx]; }
-
-  /*!
-   * \brief Set the knot value at a specific index
-   *
-   * \param [in] idx The index of the knot
-   * \param [in] knot The updated value of the knot
-   */
-  void setKnot(int idx, T knot) { m_knotvec[idx] = knot; }
-
-  /*! 
-   * \brief Set the knot vector by an axom::Array
-   *
-   * \param [in] knots The new knot vector
-   */
-  void setKnots(const axom::Array<T>& knots, int degree)
-  {
-    m_knotvec = KnotVectorType(knots, degree);
-  }
-
-  /*! 
-   * \brief Set the knot vector by a KnotVector object
-   *
-   * \param [in] knotVector The new knot vector
-   */
-  void setKnots(const KnotVectorType& knotVector) { m_knotvec = knotVector; }
+  ///@}
 
   /*!
    * \brief Equality operator for NURBS Curves
@@ -1283,58 +1397,6 @@ public:
   friend inline bool operator!=(const NURBSCurve<T, NDIMS>& lhs, const NURBSCurve<T, NDIMS>& rhs)
   {
     return !(lhs == rhs);
-  }
-
-  /// \brief Returns a copy of the NURBS curve's control points
-  CoordsVec getControlPoints() const { return m_controlPoints; }
-
-  /// \brief Returns a copy of the NURBS curve's control points
-  WeightsVec getWeights() const { return m_weights; }
-
-  /// \brief Return a copy of the knot vector
-  KnotVectorType getKnots() const { return m_knotvec; }
-
-  /// \brief Return a copy of the knot vector as an array
-  axom::Array<T> getKnotsArray() const { return m_knotvec.getArray(); }
-
-  /// \brief Get minimum knot
-  T getMinKnot() const { return m_knotvec[0]; }
-
-  /// \brief Get maximum knot
-  T getMaxKnot() const { return m_knotvec[m_knotvec.getNumKnots() - 1]; }
-
-  /// \brief Reverses the order of the NURBS curve's control points and weights
-  void reverseOrientation()
-  {
-    const int npts = getNumControlPoints();
-    const int npts_mid = (npts + 1) / 2;
-    for(int i = 0; i < npts_mid; ++i)
-    {
-      axom::utilities::swap(m_controlPoints[i], m_controlPoints[npts - i - 1]);
-    }
-
-    if(isRational())
-    {
-      for(int i = 0; i < npts_mid; ++i)
-      {
-        axom::utilities::swap(m_weights[i], m_weights[npts - i - 1]);
-      }
-    }
-
-    // Reverse the orientation of the knots
-    m_knotvec.reverse();
-  }
-
-  /// \brief Returns an axis-aligned bounding box containing the NURBS curve
-  BoundingBoxType boundingBox() const
-  {
-    return BoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
-  }
-
-  /// \brief Returns an oriented bounding box containing the NURBS curve
-  OrientedBoundingBoxType orientedBoundingBox() const
-  {
-    return OrientedBoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
   }
 
   /*!
@@ -1373,43 +1435,6 @@ public:
     os << "}";
 
     return os;
-  }
-
-  /// \brief Function to check if the NURBS curve is valid
-  bool isValidNURBS() const
-  {
-    // Check monotonicity, open-ness, continuity
-    if(!m_knotvec.isValid())
-    {
-      return false;
-    }
-
-    // Number of knots must match the number of control points
-    int p = m_knotvec.getDegree();
-    if(m_knotvec.getNumKnots() != m_controlPoints.size() + p + 1)
-    {
-      return false;
-    }
-
-    if(isRational())
-    {
-      if(m_weights.size() != m_controlPoints.size())
-      {
-        // Weights must match the number of control points
-        return false;
-      }
-
-      for(int i = 0; i < m_weights.size(); ++i)
-      {
-        if(m_weights[i] <= 0)
-        {
-          // Weights must be positive
-          return false;
-        }
-      }
-    }
-
-    return true;
   }
 
 private:

--- a/src/axom/primal/geometry/NURBSPatch.hpp
+++ b/src/axom/primal/geometry/NURBSPatch.hpp
@@ -2558,7 +2558,7 @@ public:
   /// \brief Get number of trimming curves
   int getNumTrimmingCurves() const { return m_trimmingCurves.size(); }
 
-  /// \brief use array size as flag for trimmed-ness
+  /// \brief use boolean flag for trimmed-ness
   bool isTrimmed() const { return m_isTrimmed; }
 
   /// \brief Mark as trimmed

--- a/src/axom/primal/geometry/NURBSPatch.hpp
+++ b/src/axom/primal/geometry/NURBSPatch.hpp
@@ -382,7 +382,7 @@ public:
    * \param [in] knots_v A 1D C-style array of npts_v + deg_v + 1 knots
    * \param [in] nkts_v The number of knots in the v direction
    * 
-   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
+   * For clamped and continuous patch axes, npts and the knot vector uniquely determine the degree
    * \pre Requires valid pointers and knot vectors
    */
   NURBSPatch(const PointType* pts,
@@ -409,7 +409,7 @@ public:
    * \param [in] knots_v A 1D C-style array of npts_v + deg_v + 1 knots
    * \param [in] nkts_v The number of knots in the v direction
    * 
-   * For clamped and continuous curves, npts and the knot vector  uniquely determine the degree
+   * For clamped and continuous patch axes, npts and the knot vector  uniquely determine the degree
    * \pre Requires valid pointers and knot vectors
    */
   NURBSPatch(const PointType* pts,
@@ -434,7 +434,7 @@ public:
    * \param [in] knots_u An axom::Array of npts_u + deg_u + 1 knots
    * \param [in] knots_v An axom::Array of npts_v + deg_v + 1 knots
    * 
-   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
+   * For clamped and continuous patch axes, npts and the knot vector uniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsVec& pts,
@@ -457,7 +457,7 @@ public:
    * \param [in] knots_u An axom::Array of npts_u + deg_u + 1 knots
    * \param [in] knots_v An axom::Array of npts_v + deg_v + 1 knots
    * 
-   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
+   * For clamped and continuous patch axes, npts and the knot vector uniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsVec& pts,
@@ -479,7 +479,7 @@ public:
    * \param [in] npts_u, npts_v The number of control points on the first and second axis
    * \param [in] knotvec_u, knotvec_v  KnotVector objects for the first and second axis
    * 
-   * For clamped and continuous curves, npts and the knot vectoruniquely determine the degree
+   * For clamped and continuous patch axes, npts and the knot vectoruniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsVec& pts,
@@ -501,7 +501,7 @@ public:
    * \param [in] npts_u, npts_v The number of control points on the first and second axis
    * \param [in] knotvec_u, knotvec_v KnotVector objects for the first and second axis
    * 
-   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
+   * For clamped and continuous patch axes, npts and the knot vector uniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsVec& pts,
@@ -523,7 +523,7 @@ public:
    * \param [in] knots_u An axom::Array of npts_u + deg_u + 1 knots
    * \param [in] knots_v An axom::Array of npts_v + deg_v + 1 knots
    * 
-   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
+   * For clamped and continuous patch axes, npts and the knot vector uniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsMat& pts, const axom::Array<T>& knots_u, const axom::Array<T>& knots_v)
@@ -541,7 +541,7 @@ public:
    * \param [in] knots_u An axom::Array of npts_u + deg_u + 1 knots
    * \param [in] knots_v An axom::Array of npts_v + deg_v + 1 knots
    * 
-   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
+   * For clamped and continuous patch axes, npts and the knot vector uniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsMat& pts,
@@ -560,7 +560,7 @@ public:
    * \param [in] pts A 2D axom::Array of (ord_u+1, ord_v+1) control points
    * \param [in] knotvec_u, knotvec_v KnotVector objects for the first and second axis
    * 
-   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
+   * For clamped and continuous patch axes, npts and the knot vector uniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsMat& pts, const KnotVectorType& knotvec_u, const KnotVectorType& knotvec_v)
@@ -574,7 +574,7 @@ public:
    * \param [in] weights A 2D axom::Array of (ord_u+1, ord_v+1) positive weights
    * \param [in] knotvec_u, knotvec_v KnotVector objects for the first and second axis
    * 
-   * For clamped and continuous curves, npts and the knot vector uniquely determine the degree
+   * For clamped and continuous patch axes, npts and the knot vector uniquely determine the degree
    * \pre Requires a valid knot vector and npts_d > deg_d
    */
   NURBSPatch(const CoordsMat& pts,
@@ -831,7 +831,7 @@ public:
   ///@}
 
   ///@{
-  /// \name Query/modify curve's geometry (control points, weights, bounding box, ...)
+  /// \name Query/modify patch's geometry (control points, weights, bounding box, ...)
 
   /// Retrieves the control point at index \a (idx_p, idx_q)
   PointType& operator()(int ui, int vi) { return m_controlPoints(ui, vi); }

--- a/src/axom/primal/geometry/NURBSPatch.hpp
+++ b/src/axom/primal/geometry/NURBSPatch.hpp
@@ -109,10 +109,12 @@ public:
    * - Trimming curves are always empty and the patch is untrimmed by default.
    *
    * For 1D arrays, the mapping of control points and weights to the patch is lexicographical, i.e.
-   * pts[0]               -> nodes[0, 0],     ..., pts[npts_v]       -> nodes[0, npts_v]
-   * pts[npts_v+1]         -> nodes[1, 0],     ..., pts[2*npts_v]     -> nodes[1, npts_v]
-   *                                          ...
-   * pts[npts_u*(npts_v-1)] -> nodes[npts_u, 0], ..., pts[npts_u*npts_v] -> nodes[npts_u, npts_v]
+     \verbatim
+      pts[0]                 -> nodes[0, 0],      ..., pts[npts_v]        -> nodes[0, npts_v]
+      pts[npts_v+1]          -> nodes[1, 0],      ..., pts[2*npts_v]      -> nodes[1, npts_v]
+                                                  ...
+      pts[npts_u*(npts_v-1)] -> nodes[npts_u, 0], ..., pts[npts_u*npts_v] -> nodes[npts_u, npts_v]
+     \endverbatim
    * 
    * All constructors ensure that the patch is internally consistent and valid, provided the input parameters are valid.
    */
@@ -584,6 +586,9 @@ public:
 
   ///@}
 
+  ///@{
+  /// \name Query/modify patch properties (degree, rationality, ...)
+
   /*!
    * \brief Reset the degree and resize arrays of points (and weights)
    * 
@@ -662,6 +667,18 @@ public:
     setDegree_v(deg_v);
   }
 
+  /// \brief Returns the degree of the NURBS Patch on the first axis
+  int getDegree_u() const { return m_knotvec_u.getDegree(); }
+
+  /// \brief Returns the degree of the NURBS Patch on the second axis
+  int getDegree_v() const { return m_knotvec_v.getDegree(); }
+
+  /// \brief Returns the order (degree + 1) of the NURBS Patch on the first axis
+  int getOrder_u() const { return m_knotvec_u.getDegree() + 1; }
+
+  /// \brief Returns the order of the NURBS Patch on the second axis
+  int getOrder_v() const { return m_knotvec_v.getDegree() + 1; }
+
   /*!
    * \brief Set the number control points in u
    *
@@ -686,6 +703,12 @@ public:
     m_knotvec_u.makeUniform(npts_u, getDegree_u());
     m_knotvec_v.makeUniform(npts_v, getDegree_v());
   }
+
+  /// \brief Returns the number of control points in the NURBS Patch on the first axis
+  int getNumControlPoints_u() const { return static_cast<int>(m_controlPoints.shape()[0]); }
+
+  /// \brief Returns the number of control points in the NURBS Patch on the second axis
+  int getNumControlPoints_v() const { return static_cast<int>(m_controlPoints.shape()[1]); }
 
   /*!
    * \brief Set the number control points in u
@@ -730,6 +753,146 @@ public:
 
     m_knotvec_v.makeUniform(npts, getDegree_v());
   }
+
+  /// Clears the list of control points, make nonrational
+  void clear()
+  {
+    m_controlPoints.clear();
+    m_knotvec_u.clear();
+    m_knotvec_v.clear();
+    m_trimmingCurves.clear();
+    makeNonrational();
+    makeUntrimmed();
+  }
+
+  /// \brief Use array size as flag for rationality
+  bool isRational() const { return !m_weights.empty(); }
+
+  /// \brief Make trivially rational. If already rational, do nothing
+  void makeRational()
+  {
+    if(!isRational())
+    {
+      auto patch_shape = m_controlPoints.shape();
+      m_weights.resize(patch_shape[0], patch_shape[1]);
+      m_weights.fill(1.0);
+    }
+  }
+
+  /// \brief Make nonrational by shrinking array of weights
+  void makeNonrational() { m_weights.clear(); }
+
+  /// \brief Function to check if the NURBS surface is valid
+  bool isValidNURBS() const
+  {
+    // Check monotonicity, open-ness, continuity of each knot vector
+    if(!m_knotvec_u.isValid() || !m_knotvec_v.isValid())
+    {
+      return false;
+    }
+
+    // Number of knots must match the number of control points
+    int deg_u = m_knotvec_u.getDegree();
+    int deg_v = m_knotvec_v.getDegree();
+
+    // Number of knots must match the number of control points
+    auto patch_shape = m_controlPoints.shape();
+    if(m_knotvec_u.getNumKnots() != patch_shape[0] + deg_u + 1 ||
+       m_knotvec_v.getNumKnots() != patch_shape[1] + deg_v + 1)
+    {
+      return false;
+    }
+
+    if(isRational())
+    {
+      // Number of control points must match number of weights
+      auto weights_shape = m_weights.shape();
+      if(weights_shape[0] != patch_shape[0] || weights_shape[1] != patch_shape[1])
+      {
+        return false;
+      }
+
+      // Weights must be positive
+      for(int i = 0; i < weights_shape[0]; ++i)
+      {
+        for(int j = 0; j < weights_shape[1]; ++j)
+        {
+          if(m_weights(i, j) <= 0.0)
+          {
+            return false;
+          }
+        }
+      }
+    }
+
+    return true;
+  }
+
+  ///@}
+
+  ///@{
+  /// \name Query/modify curve's geometry (control points, weights, bounding box, ...)
+
+  /// Retrieves the control point at index \a (idx_p, idx_q)
+  PointType& operator()(int ui, int vi) { return m_controlPoints(ui, vi); }
+
+  /// Retrieves the vector of control points at index \a idx
+  const PointType& operator()(int ui, int vi) const { return m_controlPoints(ui, vi); }
+
+  /// Returns a copy of the NURBS patch's control points
+  CoordsMat getControlPoints() const { return m_controlPoints; }
+
+  /*!
+   * \brief Get a specific weight
+   *
+   * \param [in] ui The index of the weight on the first axis
+   * \param [in] vi The index of the weight on the second axis
+   * \pre Requires that the surface be rational
+   */
+  const T& getWeight(int ui, int vi) const
+  {
+    SLIC_ASSERT(isRational());
+    return m_weights(ui, vi);
+  }
+
+  /*!
+   * \brief Set the weight at a specific index
+   *
+   * \param [in] ui The index of the weight in on the first axis
+   * \param [in] vi The index of the weight in on the second axis
+   * \param [in] weight The updated value of the weight
+   * \pre Requires that the surface be rational
+   * \pre Requires that the weight be positive
+   */
+  void setWeight(int ui, int vi, T weight)
+  {
+    SLIC_ASSERT(isRational());
+    SLIC_ASSERT(weight > 0);
+
+    m_weights(ui, vi) = weight;
+  }
+
+  /// Returns a copy of the NURBS patch's weights
+  WeightsMat getWeights() const { return m_weights; }
+
+  /// \brief Returns an axis-aligned bounding box containing the patch
+  BoundingBoxType boundingBox() const
+  {
+    return BoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
+  }
+
+  /// \brief Returns an oriented bounding box containing the patch
+  OrientedBoundingBoxType orientedBoundingBox() const
+  {
+    return OrientedBoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
+  }
+
+  ///@}
+
+  ///@{
+  //!  @name Methods for (untrimmed) Patch Parameterization.
+  //!
+  //! These methods operate on the parameterization of the patch leaving the geometry unchanged.
 
   /*!
    * \brief Set the knot value in the u vector at a specific index
@@ -781,18 +944,6 @@ public:
    */
   void setKnots_v(const KnotVectorType& knotVector) { m_knotvec_v = knotVector; }
 
-  /// \brief Returns the degree of the NURBS Patch on the first axis
-  int getDegree_u() const { return m_knotvec_u.getDegree(); }
-
-  /// \brief Returns the degree of the NURBS Patch on the second axis
-  int getDegree_v() const { return m_knotvec_v.getDegree(); }
-
-  /// \brief Returns the order (degree + 1) of the NURBS Patch on the first axis
-  int getOrder_u() const { return m_knotvec_u.getDegree() + 1; }
-
-  /// \brief Returns the order of the NURBS Patch on the second axis
-  int getOrder_v() const { return m_knotvec_v.getDegree() + 1; }
-
   /// \brief Return a copy of the KnotVector instance on the first axis
   KnotVectorType getKnots_u() const { return m_knotvec_u; }
 
@@ -826,116 +977,11 @@ public:
   /// \brief Get the maximum knot value in the v-axis
   T getMaxKnot_v() const { return m_knotvec_v[m_knotvec_v.getNumKnots() - 1]; }
 
-  /// \brief Returns the number of control points in the NURBS Patch on the first axis
-  int getNumControlPoints_u() const { return static_cast<int>(m_controlPoints.shape()[0]); }
-
-  /// \brief Returns the number of control points in the NURBS Patch on the second axis
-  int getNumControlPoints_v() const { return static_cast<int>(m_controlPoints.shape()[1]); }
-
   /// \brief Return the length of the knot vector on the first axis
   int getNumKnots_u() const { return m_knotvec_u.getNumKnots(); }
 
   /// \brief Return the length of the knot vector on the second axis
   int getNumKnots_v() const { return m_knotvec_v.getNumKnots(); }
-
-  /// Clears the list of control points, make nonrational
-  void clear()
-  {
-    m_controlPoints.clear();
-    m_knotvec_u.clear();
-    m_knotvec_v.clear();
-    m_trimmingCurves.clear();
-    makeNonrational();
-    makeUntrimmed();
-  }
-
-  /// Retrieves the control point at index \a (idx_p, idx_q)
-  PointType& operator()(int ui, int vi) { return m_controlPoints(ui, vi); }
-
-  /// Retrieves the vector of control points at index \a idx
-  const PointType& operator()(int ui, int vi) const { return m_controlPoints(ui, vi); }
-
-  /*!
-   * \brief Get a specific weight
-   *
-   * \param [in] ui The index of the weight on the first axis
-   * \param [in] vi The index of the weight on the second axis
-   * \pre Requires that the surface be rational
-   */
-  const T& getWeight(int ui, int vi) const
-  {
-    SLIC_ASSERT(isRational());
-    return m_weights(ui, vi);
-  }
-
-  /*!
-   * \brief Set the weight at a specific index
-   *
-   * \param [in] ui The index of the weight in on the first axis
-   * \param [in] vi The index of the weight in on the second axis
-   * \param [in] weight The updated value of the weight
-   * \pre Requires that the surface be rational
-   * \pre Requires that the weight be positive
-   */
-  void setWeight(int ui, int vi, T weight)
-  {
-    SLIC_ASSERT(isRational());
-    SLIC_ASSERT(weight > 0);
-
-    m_weights(ui, vi) = weight;
-  }
-
-  /*!
-   * \brief Equality operator for NURBS patches
-   * 
-   * \param [in] lhs The left-hand side NURBS patch
-   * \param [in] rhs The right-hand side NURBS patch
-   * 
-   * \return True if the two patches are equal, false otherwise
-   */
-  friend inline bool operator==(const NURBSPatch<T, NDIMS>& lhs, const NURBSPatch<T, NDIMS>& rhs)
-  {
-    return (lhs.m_controlPoints == rhs.m_controlPoints) && (lhs.m_weights == rhs.m_weights) &&
-      (lhs.m_knotvec_u == rhs.m_knotvec_u) && (lhs.m_knotvec_v == rhs.m_knotvec_v) &&
-      (lhs.m_isTrimmed == rhs.m_isTrimmed) && (lhs.m_trimmingCurves == rhs.m_trimmingCurves);
-  }
-
-  /*!
-   * \brief Inequality operator for NURBS patches
-   * 
-   * \param [in] lhs The left-hand side NURBS patch
-   * \param [in] rhs The right-hand side NURBS patch
-   * 
-   * \return True if the two patches are not equal, false otherwise
-   */
-  friend inline bool operator!=(const NURBSPatch<T, NDIMS>& lhs, const NURBSPatch<T, NDIMS>& rhs)
-  {
-    return !(lhs == rhs);
-  }
-
-  /// Returns a copy of the NURBS patch's control points
-  CoordsMat getControlPoints() const { return m_controlPoints; }
-
-  /// Returns a copy of the NURBS patch's weights
-  WeightsMat getWeights() const { return m_weights; }
-
-  /// \brief Returns an axis-aligned bounding box containing the patch
-  BoundingBoxType boundingBox() const
-  {
-    return BoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
-  }
-
-  /// \brief Returns an oriented bounding box containing the patch
-  OrientedBoundingBoxType orientedBoundingBox() const
-  {
-    return OrientedBoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
-  }
-
-  ///@{
-  //!  @name Methods for (untrimmed) Patch Parameterization.
-  //!
-  //! These methods operate on the parameterization of the patch
-  //!  via its trimming curves, leaving the geometry unchanged.
 
   /*! 
    * \brief Insert a knot to the u knot vector to have the given multiplicity
@@ -1483,31 +1529,311 @@ public:
 
     m_knotvec_v.rescale(a, b);
   }
+
+  /// \brief Function to check if the u parameter is within the knot span
+  bool isValidParameter_u(T u, T EPS = 1e-8) const
+  {
+    return u >= m_knotvec_u[0] - EPS && u <= m_knotvec_u[m_knotvec_u.getNumKnots() - 1] + EPS;
+  }
+
+  /// \brief Function to check if the v parameter is within the knot span
+  bool isValidParameter_v(T v, T EPS = 1e-8) const
+  {
+    return v >= m_knotvec_v[0] - EPS && v <= m_knotvec_v[m_knotvec_v.getNumKnots() - 1] + EPS;
+  }
+
+  /// \brief Checks if given u parameter is *interior* to the knot span
+  bool isValidInteriorParameter(T t) const { return m_knotvec_u.isValidInteriorParameter(t); }
+
+  /*!
+   * \brief Scale the parameter space of the NURBS patch geometry 
+   *         linearly (by tangents) in all directions
+   *
+   * \param [in] scaleFactor The multiplicative factor to expand each knot vector by
+   * \param [in] removeTrimmingCurves If true, the resulting patch has no trimming curves
+   *
+   * Algorithm from Wolters, Hans J., "Extensions: Extrapolation Methods for CAD", 1999
+   * 
+   * \note This function only affects the geometry of the untrimmed NURBS patch, 
+   *       and does not affect any existing trimming curves (unless explicitly removed)
+   * 
+   * \post If removeTrimmingCurves is false, the resulting patch will be trimmed.
+   * 
+   * \warning Method becomes numerically unstable for large values of scaleFactor,
+   *           or for rational patches with a large range of weights.
+   */
+  void scaleParameterSpace(double scaleFactor, bool removeTrimmingCurves = false)
+  {
+    SLIC_ASSERT(scaleFactor >= 1.0);
+    SLIC_WARNING_IF(scaleFactor > 1.15,
+                    "Expanding patch parameter space is numerically unstable "
+                    "for large values of scaleFactor.");
+
+    if(removeTrimmingCurves)
+    {
+      m_trimmingCurves.clear();
+    }
+    else if(!isTrimmed())
+    {
+      // If the patch is untrimmed, we need to create new trimming curves
+      //  to match the original parameter space
+      makeTriviallyTrimmed();
+    }
+
+    double expansionAmount_u = (getMaxKnot_u() - getMinKnot_u()) * (scaleFactor - 1.0);
+    double expansionAmount_v = (getMaxKnot_v() - getMinKnot_v()) * (scaleFactor - 1.0);
+
+    auto n = getNumControlPoints_u();
+    auto m = getNumControlPoints_v();
+
+    if(n <= 1 || m <= 1)
+    {
+      return;
+    }
+
+    // When the patch is expanded in homogeneous space,
+    //  weights may become negative.
+    // We gurantee no negative weights by restricting this expansion
+    //  to w > min_weight in homogeous space
+    double min_weight = 0.0;
+    if(isRational())
+    {
+      min_weight = m_weights(0, 0);
+
+      for(int i = 0; i < n; ++i)
+      {
+        for(int j = 0; j < m; ++j)
+        {
+          min_weight = std::min(min_weight, m_weights(i, j));
+        }
+      }
+
+      min_weight *= 0.5;
+    }
+
+    auto deg_u = getDegree_u();
+    auto deg_v = getDegree_v();
+
+    CoordsMat newControlPoints(n + 2 * deg_u, m + 2 * deg_v);
+    WeightsMat newWeights(0, 0);
+    if(isRational())
+    {
+      newWeights.resize(n + 2 * deg_u, m + 2 * deg_v);
+      newWeights.fill(1.0);
+    }
+
+    axom::Array<T> newKnotVec_u, newKnotVec_v;
+
+    // Copy the original control points
+    for(int i = 0; i < n; ++i)
+    {
+      for(int j = 0; j < m; ++j)
+      {
+        newControlPoints(i + deg_u, j + deg_v) = m_controlPoints(i, j);
+        if(isRational())
+        {
+          newWeights(i + deg_u, j + deg_v) = m_weights(i, j);
+        }
+      }
+    }
+
+    int nkts_v = m_knotvec_v.getNumKnots();
+    int nkts_u = m_knotvec_u.getNumKnots();
+
+    // Add the control points on the v direction
+    for(int i = 0; i < n; ++i)
+    {
+      if(!isRational())
+      {
+        Vector<T, 3> v(m_controlPoints(i, 1), m_controlPoints(i, 0));
+        double alpha = deg_v * expansionAmount_v / (m_knotvec_v[0] - m_knotvec_v[deg_v + 1]);
+
+        for(int j = 0; j < deg_v; ++j)
+        {
+          newControlPoints(i + deg_u, j).array() =
+            m_controlPoints(i, 0).array() + static_cast<T>(j - deg_v) / (deg_v)*alpha * v.array();
+        }
+
+        v = Vector<T, 3>(m_controlPoints(i, m - 2), m_controlPoints(i, m - 1));
+        alpha =
+          deg_v * expansionAmount_v / (m_knotvec_v[nkts_v - 1] - m_knotvec_v[nkts_v - deg_v - 2]);
+
+        for(int j = 0; j < deg_v; ++j)
+        {
+          newControlPoints(i + deg_u, m + deg_v + j).array() =
+            m_controlPoints(i, m - 1).array() + static_cast<T>(j + 1) / (deg_v)*alpha * v.array();
+        }
+      }
+      else
+      {
+        Vector<T, 3> v(Point<T, 3>(m_controlPoints(i, 1).array() * m_weights(i, 1)),
+                       Point<T, 3>(m_controlPoints(i, 0).array() * m_weights(i, 0)));
+        double d_weight = m_weights(i, 0) - m_weights(i, 1);
+        double alpha = deg_v * expansionAmount_v / (m_knotvec_v[0] - m_knotvec_v[deg_v + 1]);
+
+        // New weights can't be less than min_weight
+        if(d_weight != 0 && (m_weights(i, 0) - alpha * d_weight < min_weight))
+        {
+          alpha = (m_weights(i, 0) - min_weight) / d_weight;
+        }
+
+        for(int j = 0; j < deg_v; ++j)
+        {
+          newWeights(i + deg_u, j) =
+            m_weights(i, 0) + static_cast<T>(j - deg_v) / (deg_v)*alpha * d_weight;
+
+          newControlPoints(i + deg_u, j).array() =
+            (m_controlPoints(i, 0).array() * m_weights(i, 0) +
+             static_cast<T>(j - deg_v) / (deg_v)*alpha * v.array()) /
+            newWeights(i + deg_u, j);
+        }
+
+        v = Vector<T, 3>(Point<T, 3>(m_controlPoints(i, m - 2).array() * m_weights(i, m - 2)),
+                         Point<T, 3>(m_controlPoints(i, m - 1).array() * m_weights(i, m - 1)));
+        d_weight = m_weights(i, m - 1) - m_weights(i, m - 2);
+        alpha =
+          deg_v * expansionAmount_v / (m_knotvec_v[nkts_v - 1] - m_knotvec_v[nkts_v - deg_v - 2]);
+
+        // New weights can't be less than min_weight
+        if(d_weight != 0 && (m_weights(i, m - 1) + alpha * d_weight < min_weight))
+        {
+          alpha = (min_weight - m_weights(i, m - 1)) / d_weight;
+        }
+
+        for(int j = 0; j < deg_v; ++j)
+        {
+          newWeights(i + deg_u, m + deg_v + j) =
+            m_weights(i, m - 1) + static_cast<T>(j + 1) / (deg_v)*alpha * d_weight;
+
+          newControlPoints(i + deg_u, m + deg_v + j).array() =
+            (m_controlPoints(i, m - 1).array() * m_weights(i, m - 1) +
+             static_cast<T>(j + 1) / (deg_v)*alpha * v.array()) /
+            newWeights(i + deg_u, m + deg_v + j);
+        }
+      }
+    }
+
+    // Add the control points on the u direction
+    //  Note that this method uses values added in the v direction,
+    //  making it slightly anisotropic at the corners
+    for(int j = 0; j < m + 2 * deg_v; ++j)
+    {
+      if(!isRational())
+      {
+        Vector<T, 3> v(newControlPoints(deg_u + 1, j), newControlPoints(deg_u, j));
+        double alpha = deg_u * expansionAmount_v / (m_knotvec_u[0] - m_knotvec_u[deg_u + 1]);
+        for(int i = 0; i < deg_u; ++i)
+        {
+          newControlPoints(i, j).array() = newControlPoints(deg_u, j).array() +
+            static_cast<T>(i - deg_u) / (deg_u)*alpha * v.array();
+        }
+
+        v = Vector<T, 3>(newControlPoints(n - 2 + deg_u, j), newControlPoints(n + deg_u - 1, j));
+        alpha =
+          deg_u * expansionAmount_v / (m_knotvec_u[nkts_u - 1] - m_knotvec_u[nkts_u - deg_u - 2]);
+        for(int i = 0; i < deg_u; ++i)
+        {
+          newControlPoints(n + deg_u + i, j).array() = newControlPoints(n + deg_u - 1, j).array() +
+            static_cast<T>(i + 1) / (deg_u)*alpha * v.array();
+        }
+      }
+      else
+      {
+        Vector<T, 3> v(Point<T, 3>(newControlPoints(deg_u + 1, j).array() * newWeights(deg_u + 1, j)),
+                       Point<T, 3>(newControlPoints(deg_u, j).array() * newWeights(deg_u, j)));
+        double d_weight = newWeights(deg_u, j) - newWeights(deg_u + 1, j);
+        double alpha = deg_u * expansionAmount_v / (m_knotvec_u[0] - m_knotvec_u[deg_u + 1]);
+
+        // New weights can't be less than min_weight
+        if(d_weight != 0 && (newWeights(deg_u, j) - alpha * d_weight < min_weight))
+        {
+          alpha = (newWeights(deg_u, j) - min_weight) / d_weight;
+        }
+
+        for(int i = 0; i < deg_u; ++i)
+        {
+          newWeights(i, j) =
+            newWeights(deg_u, j) + static_cast<T>(i - deg_u) / (deg_u)*alpha * d_weight;
+
+          newControlPoints(i, j).array() =
+            (newControlPoints(deg_u, j).array() * newWeights(deg_u, j) +
+             static_cast<T>(i - deg_u) / (deg_u)*alpha * v.array()) /
+            newWeights(i, j);
+        }
+
+        v = Vector<T, 3>(
+          Point<T, 3>(newControlPoints(n - 2 + deg_u, j).array() * newWeights(n - 2 + deg_u, j)),
+          Point<T, 3>(newControlPoints(n + deg_u - 1, j).array() * newWeights(n + deg_u - 1, j)));
+        d_weight = newWeights(n + deg_u - 1, j) - newWeights(n - 2 + deg_u, j);
+        alpha =
+          deg_u * expansionAmount_v / (m_knotvec_u[nkts_u - 1] - m_knotvec_u[nkts_u - deg_u - 2]);
+
+        // New weights can't be less than min_weight
+        if(d_weight != 0 && (newWeights(n + deg_u - 1, j) + alpha * d_weight < min_weight))
+        {
+          alpha = (min_weight - newWeights(n + deg_u - 1, j)) / d_weight;
+        }
+
+        for(int i = 0; i < deg_u; ++i)
+        {
+          newWeights(n + deg_u + i, j) =
+            newWeights(n + deg_u - 1, j) + static_cast<T>(i + 1) / (deg_u)*d_weight * alpha;
+
+          newControlPoints(n + deg_u + i, j).array() =
+            (newControlPoints(n + deg_u - 1, j).array() * newWeights(n + deg_u - 1, j) +
+             static_cast<T>(i + 1) / (deg_u)*alpha * v.array()) /
+            newWeights(n + deg_u + i, j);
+        }
+      }
+    }
+
+    // Fix the u knot vector
+    newKnotVec_u.resize(m_knotvec_u.getNumKnots() + 2 * m_knotvec_u.getDegree());
+    for(int i = 0; i <= deg_u; ++i)
+    {
+      newKnotVec_u[i] = m_knotvec_u[0] - expansionAmount_u;
+    }
+    for(int i = 0; i < m_knotvec_u.getNumKnots() - 2; ++i)
+    {
+      newKnotVec_u[i + deg_u + 1] = m_knotvec_u[i + 1];
+    }
+    for(int i = 0; i <= deg_u; ++i)
+    {
+      newKnotVec_u[i + deg_u + m_knotvec_u.getNumKnots() - 1] =
+        m_knotvec_u[m_knotvec_u.getNumKnots() - 1] + expansionAmount_u;
+    }
+
+    // Fix the v knot vector
+    newKnotVec_v.resize(m_knotvec_v.getNumKnots() + 2 * m_knotvec_v.getDegree());
+    for(int i = 0; i <= deg_v; ++i)
+    {
+      newKnotVec_v[i] = m_knotvec_v[0] - expansionAmount_v;
+    }
+    for(int i = 0; i < m_knotvec_v.getNumKnots() - 2; ++i)
+    {
+      newKnotVec_v[i + deg_v + 1] = m_knotvec_v[i + 1];
+    }
+    for(int i = 0; i <= deg_v; ++i)
+    {
+      newKnotVec_v[i + deg_v + m_knotvec_v.getNumKnots() - 1] =
+        m_knotvec_v[m_knotvec_v.getNumKnots() - 1] + expansionAmount_v;
+    }
+
+    m_controlPoints = newControlPoints;
+    m_weights = newWeights;
+
+    m_knotvec_u = KnotVectorType(newKnotVec_u, deg_u);
+    m_knotvec_v = KnotVectorType(newKnotVec_v, deg_v);
+  }
+
   ///@}
 
   ///@{
-  //!  @name Methods for (untrimmed) Patch Geometry.
+  //! \name Functions to evaluate (untrimmed) patch and its derivatives and normals along points or lines
   //!
   //! These methods operate only on the geometry of the patch
   //!  as defined by the control points and weights.
   //! They do not modify nor interact with the trimming curves.
-
-  /// \brief Make trivially rational. If already rational, do nothing
-  void makeRational()
-  {
-    if(!isRational())
-    {
-      auto patch_shape = m_controlPoints.shape();
-      m_weights.resize(patch_shape[0], patch_shape[1]);
-      m_weights.fill(1.0);
-    }
-  }
-
-  /// \brief Make nonrational by shrinking array of weights
-  void makeNonrational() { m_weights.clear(); }
-
-  /// \brief Use array size as flag for rationality
-  bool isRational() const { return !m_weights.empty(); }
 
   /*!
    * \brief Evaluate the NURBS patch geometry at a particular parameter value \a t
@@ -2088,6 +2414,282 @@ public:
     return VectorType::cross_product(Du, Dv);
   }
 
+#ifdef AXOM_USE_MFEM
+  /*!
+   * \brief Calculate the average normal for the (untrimmed) patch
+   * 
+   * \param [in] npts The number of quadrature nodes used in each component integral
+   *
+   * Algorithm from "Mean normal vector to a surface bounded by Bézier curves"
+   *  by Kenji Ueda, 1996
+   * 
+   * Projects the 4 boundary curves of the patch along each coordinate axis, 
+   *  then computes the 2D area of that projection to get the corresponding
+   *  component of the average surface normal.
+   *  
+   * \note This requires the MFEM third-party library
+   * 
+   * \return The calculated mean surface normal
+   */
+  VectorType calculateUntrimmedPatchNormal(int npts = 20) const
+  {
+    SLIC_ASSERT(NDIMS == 3);
+
+    VectorType ret_vec;
+    auto const_integrand = [](Point2D /*x*/) -> double { return 1.0; };
+
+    // Set up the correct sizes and weights of the bounding curves
+    axom::Array<NURBSCurve<T, 2>> boundingPoly(4);
+
+    const int npts_u = getNumControlPoints_u();
+    const int npts_v = getNumControlPoints_v();
+
+    boundingPoly[0].setParameters(npts_v, getDegree_v());
+    boundingPoly[0].setKnots(getKnots_v());
+
+    boundingPoly[1].setParameters(npts_u, getDegree_u());
+    boundingPoly[1].setKnots(getKnots_u());
+
+    boundingPoly[2].setParameters(npts_v, getDegree_v());
+    boundingPoly[2].setKnots(getKnots_v());
+
+    boundingPoly[3].setParameters(npts_u, getDegree_u());
+    boundingPoly[3].setKnots(getKnots_u());
+
+    if(isRational())
+    {
+      for(int i = 0; i < 4; ++i)
+      {
+        boundingPoly[i].makeRational();
+      }
+
+      for(int m = 0; m < npts_v; ++m)
+      {
+        boundingPoly[0].setWeight(m, m_weights(0, npts_v - 1 - m));
+        boundingPoly[2].setWeight(m, m_weights(npts_u - 1, m));
+      }
+
+      for(int n = 0; n < npts_u; ++n)
+      {
+        boundingPoly[1].setWeight(n, m_weights(npts_u - 1 - n, npts_v - 1));
+        boundingPoly[3].setWeight(n, m_weights(n, 0));
+      }
+    }
+
+    // Get each component by projecting boundaries onto the other coordinate axes
+    for(int N = 0; N < 3; ++N)
+    {
+      int ind_3d = 0;
+      for(int i = 0; i < 2; ++i, ++ind_3d)
+      {
+        // Skip the corresponding coordinate used to access the 3D point
+        if(ind_3d == N)
+        {
+          --i;
+          continue;
+        }
+
+        for(int m = 0; m < npts_v; ++m)
+        {
+          boundingPoly[0][m][i] = m_controlPoints(0, npts_v - 1 - m)[ind_3d];
+          boundingPoly[2][m][i] = m_controlPoints(npts_u - 1, m)[ind_3d];
+        }
+
+        for(int n = 0; n < npts_u; ++n)
+        {
+          boundingPoly[1][n][i] = m_controlPoints(npts_u - 1 - n, npts_v - 1)[ind_3d];
+          boundingPoly[3][n][i] = m_controlPoints(n, 0)[ind_3d];
+        }
+      }
+
+      // Find the area of the resulting projection
+      ret_vec[N] = evaluate_area_integral(boundingPoly, const_integrand, npts);
+    }
+
+    // Need to flip the y-component to account for the flipped projection
+    ret_vec[1] = -ret_vec[1];
+    return ret_vec;
+  }
+#endif
+  ///@}
+
+  ///@{
+  //!  @name Methods for (trimmed) Surface Geometry.
+  //!
+  //! These methods operate on the visible geometry of the NURBS surface
+  //!  as defined by the patch geometry and the trimming curves
+  //!  which define visibility.
+
+  /*!
+   * \brief Get array of trimming curves
+   */
+  const TrimmingCurveVec& getTrimmingCurves() const { return m_trimmingCurves; }
+
+  /// \brief Get mutable array of trimming curves
+  TrimmingCurveVec& getTrimmingCurves() { return m_trimmingCurves; }
+
+  /// \brief Get a trimming curve by index
+  const TrimmingCurveType& getTrimmingCurve(int idx) const
+  {
+    SLIC_ASSERT(idx >= 0 && idx < m_trimmingCurves.size());
+    return m_trimmingCurves[idx];
+  }
+
+  /// \brief Add a trimming curve
+  void addTrimmingCurve(const TrimmingCurveType& curve)
+  {
+    m_isTrimmed = true;
+    m_trimmingCurves.push_back(curve);
+  }
+
+  /// \brief Add array of trimming curves
+  void addTrimmingCurves(const TrimmingCurveVec& curves)
+  {
+    m_isTrimmed = true;
+    for(int i = 0; i < curves.size(); ++i)
+    {
+      m_trimmingCurves.push_back(curves[i]);
+    }
+  }
+
+  /// \brief Clear trimming curves, but DON'T mark as untrimmed
+  void clearTrimmingCurves() { m_trimmingCurves.clear(); }
+
+  /// \brief Get number of trimming curves
+  int getNumTrimmingCurves() const { return m_trimmingCurves.size(); }
+
+  /// \brief use array size as flag for trimmed-ness
+  bool isTrimmed() const { return m_isTrimmed; }
+
+  /// \brief Mark as trimmed
+  void markAsTrimmed() { m_isTrimmed = true; }
+
+  /// \brief Delete all trimming curves
+  void makeUntrimmed()
+  {
+    m_isTrimmed = false;
+    m_trimmingCurves.clear();
+  }
+
+  /// \brief Make trivially trimmed by adding trimming curves at each boundary
+  void makeTriviallyTrimmed()
+  {
+    if(isTrimmed())
+    {
+      m_trimmingCurves.clear();
+    }
+
+    const double min_u = m_knotvec_u[0];
+    const double max_u = m_knotvec_u[m_knotvec_u.getNumKnots() - 1];
+
+    const double min_v = m_knotvec_v[0];
+    const double max_v = m_knotvec_v[m_knotvec_v.getNumKnots() - 1];
+
+    // For each min/max u/v, add a straight trimming curve along the boundary
+
+    // Bottom
+    addTrimmingCurve(TrimmingCurveType::make_linear_segment_nurbs({min_u, min_v}, {max_u, min_v}));
+
+    // Top
+    addTrimmingCurve(TrimmingCurveType::make_linear_segment_nurbs({max_u, max_v}, {min_u, max_v}));
+
+    // Left
+    addTrimmingCurve(TrimmingCurveType::make_linear_segment_nurbs({min_u, max_v}, {min_u, min_v}));
+
+    // Right
+    addTrimmingCurve(TrimmingCurveType::make_linear_segment_nurbs({max_u, min_v}, {max_u, max_v}));
+
+    markAsTrimmed();
+  }
+
+  /*!
+   * \brief Check if a parameter point is visible on the NURBS patch via a trim test
+   *
+   * \param [in] u The parameter value on the first axis
+   * \param [in] v The parameter value on the second axis
+   * 
+   * Checks for containment of the parameter point in 
+   *  the collection of trimming curves via an even-odd rule.
+   * 
+   * If the collection of trimming curves does not form closed loops, 
+   *  then the (now fractional) generalized winding number is rounded to the
+   *  nearest integer before the even-odd rule is applied.
+   */
+  bool isVisible(T u, T v) const
+  {
+    if(!isTrimmed())
+    {
+      return (m_knotvec_u.isValidParameter(u) && m_knotvec_v.isValidParameter(v));
+    }
+
+    ParameterPointType uv = {u, v};
+
+    double gwn = 0.0;
+    for(const auto& curve : m_trimmingCurves)
+    {
+      bool isOnThisCurve = false;
+      gwn += detail::nurbs_winding_number(uv, curve, isOnThisCurve);
+
+      if(isOnThisCurve)
+      {
+        return true;
+      }
+    }
+
+    return std::lround(gwn) % 2 != 0;
+  }
+
+  /*!
+   * \brief Restrict the edges of a NURBS surface to the given parameter values, if necessary
+   *
+   * \param [in] min_u The minimum value of the u parameter
+   * \param [in] max_u The maximum value of the u parameter
+   * \param [in] min_v The minimum value of the v parameter
+   * \param [in] max_v The maximum value of the v parameter
+   * \param [in] normalize If true, normalize the patch to the range [0, 1]^2
+   * 
+   * If a given parameter is less/greater than the minimum/maximum knot value,
+   *  then the patch is not changed along that direction and axis
+   * 
+   * \pre Requires that min_u < max_u and min_v < max_v  
+   * \post A patch whose parameter space is a subset of [min_u, max_u] x [min_v, max_v]
+   * 
+   * \sa NURBSPatch::split()
+   */
+  void clip(T min_u, T max_u, T min_v, T max_v, bool normalizeParameters = false)
+  {
+    SLIC_ASSERT(min_u < max_u);
+    SLIC_ASSERT(min_v < max_v);
+    NURBSPatch dummy_patch;
+
+    if(min_u > getMinKnot_u())
+    {
+      this->split_u(min_u, dummy_patch, *this);
+    }
+    if(min_v > getMinKnot_v())
+    {
+      this->split_v(min_v, dummy_patch, *this);
+    }
+    if(max_u < getMaxKnot_u())
+    {
+      this->split_u(max_u, *this, dummy_patch);
+    }
+    if(max_v < getMaxKnot_v())
+    {
+      this->split_v(max_v, *this, dummy_patch);
+    }
+
+    if(normalizeParameters)
+    {
+      normalize();
+    }
+  }
+
+  ///@}
+
+  ///@{
+  /// \name Functions dealing with (untrimmed) patch subdivision
+
   /*!
    * \brief Splits the NURBS patch geometry (at each internal knot) into several Bezier patches
    * 
@@ -2379,276 +2981,10 @@ public:
     return beziers;
   }
 
-#ifdef AXOM_USE_MFEM
-  /*!
-   * \brief Calculate the average normal for the (untrimmed) patch
-   * 
-   * \param [in] npts The number of quadrature nodes used in each component integral
-   *
-   * Algorithm from "Mean normal vector to a surface bounded by Bézier curves"
-   *  by Kenji Ueda, 1996
-   * 
-   * Projects the 4 boundary curves of the patch along each coordinate axis, 
-   *  then computes the 2D area of that projection to get the corresponding
-   *  component of the average surface normal.
-   *  
-   * \note This requires the MFEM third-party library
-   * 
-   * \return The calculated mean surface normal
-   */
-  VectorType calculateUntrimmedPatchNormal(int npts = 20) const
-  {
-    SLIC_ASSERT(NDIMS == 3);
-
-    VectorType ret_vec;
-    auto const_integrand = [](Point2D /*x*/) -> double { return 1.0; };
-
-    // Set up the correct sizes and weights of the bounding curves
-    axom::Array<NURBSCurve<T, 2>> boundingPoly(4);
-
-    const int npts_u = getNumControlPoints_u();
-    const int npts_v = getNumControlPoints_v();
-
-    boundingPoly[0].setParameters(npts_v, getDegree_v());
-    boundingPoly[0].setKnots(getKnots_v());
-
-    boundingPoly[1].setParameters(npts_u, getDegree_u());
-    boundingPoly[1].setKnots(getKnots_u());
-
-    boundingPoly[2].setParameters(npts_v, getDegree_v());
-    boundingPoly[2].setKnots(getKnots_v());
-
-    boundingPoly[3].setParameters(npts_u, getDegree_u());
-    boundingPoly[3].setKnots(getKnots_u());
-
-    if(isRational())
-    {
-      for(int i = 0; i < 4; ++i)
-      {
-        boundingPoly[i].makeRational();
-      }
-
-      for(int m = 0; m < npts_v; ++m)
-      {
-        boundingPoly[0].setWeight(m, m_weights(0, npts_v - 1 - m));
-        boundingPoly[2].setWeight(m, m_weights(npts_u - 1, m));
-      }
-
-      for(int n = 0; n < npts_u; ++n)
-      {
-        boundingPoly[1].setWeight(n, m_weights(npts_u - 1 - n, npts_v - 1));
-        boundingPoly[3].setWeight(n, m_weights(n, 0));
-      }
-    }
-
-    // Get each component by projecting boundaries onto the other coordinate axes
-    for(int N = 0; N < 3; ++N)
-    {
-      int ind_3d = 0;
-      for(int i = 0; i < 2; ++i, ++ind_3d)
-      {
-        // Skip the corresponding coordinate used to access the 3D point
-        if(ind_3d == N)
-        {
-          --i;
-          continue;
-        }
-
-        for(int m = 0; m < npts_v; ++m)
-        {
-          boundingPoly[0][m][i] = m_controlPoints(0, npts_v - 1 - m)[ind_3d];
-          boundingPoly[2][m][i] = m_controlPoints(npts_u - 1, m)[ind_3d];
-        }
-
-        for(int n = 0; n < npts_u; ++n)
-        {
-          boundingPoly[1][n][i] = m_controlPoints(npts_u - 1 - n, npts_v - 1)[ind_3d];
-          boundingPoly[3][n][i] = m_controlPoints(n, 0)[ind_3d];
-        }
-      }
-
-      // Find the area of the resulting projection
-      ret_vec[N] = evaluate_area_integral(boundingPoly, const_integrand, npts);
-    }
-
-    // Need to flip the y-component to account for the flipped projection
-    ret_vec[1] = -ret_vec[1];
-    return ret_vec;
-  }
-#endif
   ///@}
 
   ///@{
-  //!  @name Methods for (trimmed) Surface Geometry.
-  //!
-  //! These methods operate on the visible geometry of the NURBS surface
-  //!  as defined by the patch geometry and the trimming curves
-  //!  which define visibility.
-
-  /*!
-   * \brief Get array of trimming curves
-   */
-  const TrimmingCurveVec& getTrimmingCurves() const { return m_trimmingCurves; }
-
-  /// \brief Get mutable array of trimming curves
-  TrimmingCurveVec& getTrimmingCurves() { return m_trimmingCurves; }
-
-  /// \brief Get a trimming curve by index
-  const TrimmingCurveType& getTrimmingCurve(int idx) const
-  {
-    SLIC_ASSERT(idx >= 0 && idx < m_trimmingCurves.size());
-    return m_trimmingCurves[idx];
-  }
-
-  /// \brief Add a trimming curve
-  void addTrimmingCurve(const TrimmingCurveType& curve)
-  {
-    m_isTrimmed = true;
-    m_trimmingCurves.push_back(curve);
-  }
-
-  /// \brief Add array of trimming curves
-  void addTrimmingCurves(const TrimmingCurveVec& curves)
-  {
-    m_isTrimmed = true;
-    for(int i = 0; i < curves.size(); ++i)
-    {
-      m_trimmingCurves.push_back(curves[i]);
-    }
-  }
-
-  /// \brief Clear trimming curves, but DON'T mark as untrimmed
-  void clearTrimmingCurves() { m_trimmingCurves.clear(); }
-
-  /// \brief Get number of trimming curves
-  int getNumTrimmingCurves() const { return m_trimmingCurves.size(); }
-
-  /// \brief use array size as flag for trimmed-ness
-  bool isTrimmed() const { return m_isTrimmed; }
-
-  /// \brief Mark as trimmed
-  void markAsTrimmed() { m_isTrimmed = true; }
-
-  /// \brief Delete all trimming curves
-  void makeUntrimmed()
-  {
-    m_isTrimmed = false;
-    m_trimmingCurves.clear();
-  }
-
-  /// \brief Make trivially trimmed by adding trimming curves at each boundary
-  void makeTriviallyTrimmed()
-  {
-    if(isTrimmed())
-    {
-      m_trimmingCurves.clear();
-    }
-
-    const double min_u = m_knotvec_u[0];
-    const double max_u = m_knotvec_u[m_knotvec_u.getNumKnots() - 1];
-
-    const double min_v = m_knotvec_v[0];
-    const double max_v = m_knotvec_v[m_knotvec_v.getNumKnots() - 1];
-
-    // For each min/max u/v, add a straight trimming curve along the boundary
-
-    // Bottom
-    addTrimmingCurve(TrimmingCurveType::make_linear_segment_nurbs({min_u, min_v}, {max_u, min_v}));
-
-    // Top
-    addTrimmingCurve(TrimmingCurveType::make_linear_segment_nurbs({max_u, max_v}, {min_u, max_v}));
-
-    // Left
-    addTrimmingCurve(TrimmingCurveType::make_linear_segment_nurbs({min_u, max_v}, {min_u, min_v}));
-
-    // Right
-    addTrimmingCurve(TrimmingCurveType::make_linear_segment_nurbs({max_u, min_v}, {max_u, max_v}));
-
-    markAsTrimmed();
-  }
-
-  /*!
-   * \brief Check if a parameter point is visible on the NURBS patch via a trim test
-   *
-   * \param [in] u The parameter value on the first axis
-   * \param [in] v The parameter value on the second axis
-   * 
-   * Checks for containment of the parameter point in 
-   *  the collection of trimming curves via an even-odd rule.
-   * 
-   * If the collection of trimming curves does not form closed loops, 
-   *  then the (now fractional) generalized winding number is rounded to the
-   *  nearest integer before the even-odd rule is applied.
-   */
-  bool isVisible(T u, T v) const
-  {
-    if(!isTrimmed())
-    {
-      return (m_knotvec_u.isValidParameter(u) && m_knotvec_v.isValidParameter(v));
-    }
-
-    ParameterPointType uv = {u, v};
-
-    double gwn = 0.0;
-    for(const auto& curve : m_trimmingCurves)
-    {
-      bool isOnThisCurve = false;
-      gwn += detail::nurbs_winding_number(uv, curve, isOnThisCurve);
-
-      if(isOnThisCurve)
-      {
-        return true;
-      }
-    }
-
-    return std::lround(gwn) % 2 != 0;
-  }
-
-  /*!
-   * \brief Restrict the edges of a NURBS surface to the given parameter values, if necessary
-   *
-   * \param [in] min_u The minimum value of the u parameter
-   * \param [in] max_u The maximum value of the u parameter
-   * \param [in] min_v The minimum value of the v parameter
-   * \param [in] max_v The maximum value of the v parameter
-   * \param [in] normalize If true, normalize the patch to the range [0, 1]^2
-   * 
-   * If a given parameter is less/greater than the minimum/maximum knot value,
-   *  then the patch is not changed along that direction and axis
-   * 
-   * \pre Requires that min_u < max_u and min_v < max_v  
-   * \post A patch whose parameter space is a subset of [min_u, max_u] x [min_v, max_v]
-   * 
-   * \sa NURBSPatch::split()
-   */
-  void clip(T min_u, T max_u, T min_v, T max_v, bool normalizeParameters = false)
-  {
-    SLIC_ASSERT(min_u < max_u);
-    SLIC_ASSERT(min_v < max_v);
-    NURBSPatch dummy_patch;
-
-    if(min_u > getMinKnot_u())
-    {
-      this->split_u(min_u, dummy_patch, *this);
-    }
-    if(min_v > getMinKnot_v())
-    {
-      this->split_v(min_v, dummy_patch, *this);
-    }
-    if(max_u < getMaxKnot_u())
-    {
-      this->split_u(max_u, *this, dummy_patch);
-    }
-    if(max_v < getMaxKnot_v())
-    {
-      this->split_v(max_v, *this, dummy_patch);
-    }
-
-    if(normalizeParameters)
-    {
-      normalize();
-    }
-  }
+  /// \name Functions dealing with trimmed patch subdivision
 
   /*!
     * \brief Splits a NURBS surface into four NURBS patches
@@ -3077,286 +3413,6 @@ public:
     }
   }
 
-  /*!
-   * \brief Scale the parameter space of the NURBS patch geometry 
-   *         linearly (by tangents) in all directions
-   *
-   * \param [in] scaleFactor The multiplicative factor to expand each knot vector by
-   * \param [in] removeTrimmingCurves If true, the resulting patch has no trimming curves
-   *
-   * Algorithm from Wolters, Hans J., "Extensions: Extrapolation Methods for CAD", 1999
-   * 
-   * \note This function only affects the geometry of the untrimmed NURBS patch, 
-   *       and does not affect any existing trimming curves (unless explicitly removed)
-   * 
-   * \post If removeTrimmingCurves is false, the resulting patch will be trimmed.
-   * 
-   * \warning Method becomes numerically unstable for large values of scaleFactor,
-   *           or for rational patches with a large range of weights.
-   */
-  void scaleParameterSpace(double scaleFactor, bool removeTrimmingCurves = false)
-  {
-    SLIC_ASSERT(scaleFactor >= 1.0);
-    SLIC_WARNING_IF(scaleFactor > 1.15,
-                    "Expanding patch parameter space is numerically unstable "
-                    "for large values of scaleFactor.");
-
-    if(removeTrimmingCurves)
-    {
-      m_trimmingCurves.clear();
-    }
-    else if(!isTrimmed())
-    {
-      // If the patch is untrimmed, we need to create new trimming curves
-      //  to match the original parameter space
-      makeTriviallyTrimmed();
-    }
-
-    double expansionAmount_u = (getMaxKnot_u() - getMinKnot_u()) * (scaleFactor - 1.0);
-    double expansionAmount_v = (getMaxKnot_v() - getMinKnot_v()) * (scaleFactor - 1.0);
-
-    auto n = getNumControlPoints_u();
-    auto m = getNumControlPoints_v();
-
-    if(n <= 1 || m <= 1)
-    {
-      return;
-    }
-
-    // When the patch is expanded in homogeneous space,
-    //  weights may become negative.
-    // We gurantee no negative weights by restricting this expansion
-    //  to w > min_weight in homogeous space
-    double min_weight = 0.0;
-    if(isRational())
-    {
-      min_weight = m_weights(0, 0);
-
-      for(int i = 0; i < n; ++i)
-      {
-        for(int j = 0; j < m; ++j)
-        {
-          min_weight = std::min(min_weight, m_weights(i, j));
-        }
-      }
-
-      min_weight *= 0.5;
-    }
-
-    auto deg_u = getDegree_u();
-    auto deg_v = getDegree_v();
-
-    CoordsMat newControlPoints(n + 2 * deg_u, m + 2 * deg_v);
-    WeightsMat newWeights(0, 0);
-    if(isRational())
-    {
-      newWeights.resize(n + 2 * deg_u, m + 2 * deg_v);
-      newWeights.fill(1.0);
-    }
-
-    axom::Array<T> newKnotVec_u, newKnotVec_v;
-
-    // Copy the original control points
-    for(int i = 0; i < n; ++i)
-    {
-      for(int j = 0; j < m; ++j)
-      {
-        newControlPoints(i + deg_u, j + deg_v) = m_controlPoints(i, j);
-        if(isRational())
-        {
-          newWeights(i + deg_u, j + deg_v) = m_weights(i, j);
-        }
-      }
-    }
-
-    int nkts_v = m_knotvec_v.getNumKnots();
-    int nkts_u = m_knotvec_u.getNumKnots();
-
-    // Add the control points on the v direction
-    for(int i = 0; i < n; ++i)
-    {
-      if(!isRational())
-      {
-        Vector<T, 3> v(m_controlPoints(i, 1), m_controlPoints(i, 0));
-        double alpha = deg_v * expansionAmount_v / (m_knotvec_v[0] - m_knotvec_v[deg_v + 1]);
-
-        for(int j = 0; j < deg_v; ++j)
-        {
-          newControlPoints(i + deg_u, j).array() =
-            m_controlPoints(i, 0).array() + static_cast<T>(j - deg_v) / (deg_v)*alpha * v.array();
-        }
-
-        v = Vector<T, 3>(m_controlPoints(i, m - 2), m_controlPoints(i, m - 1));
-        alpha =
-          deg_v * expansionAmount_v / (m_knotvec_v[nkts_v - 1] - m_knotvec_v[nkts_v - deg_v - 2]);
-
-        for(int j = 0; j < deg_v; ++j)
-        {
-          newControlPoints(i + deg_u, m + deg_v + j).array() =
-            m_controlPoints(i, m - 1).array() + static_cast<T>(j + 1) / (deg_v)*alpha * v.array();
-        }
-      }
-      else
-      {
-        Vector<T, 3> v(Point<T, 3>(m_controlPoints(i, 1).array() * m_weights(i, 1)),
-                       Point<T, 3>(m_controlPoints(i, 0).array() * m_weights(i, 0)));
-        double d_weight = m_weights(i, 0) - m_weights(i, 1);
-        double alpha = deg_v * expansionAmount_v / (m_knotvec_v[0] - m_knotvec_v[deg_v + 1]);
-
-        // New weights can't be less than min_weight
-        if(d_weight != 0 && (m_weights(i, 0) - alpha * d_weight < min_weight))
-        {
-          alpha = (m_weights(i, 0) - min_weight) / d_weight;
-        }
-
-        for(int j = 0; j < deg_v; ++j)
-        {
-          newWeights(i + deg_u, j) =
-            m_weights(i, 0) + static_cast<T>(j - deg_v) / (deg_v)*alpha * d_weight;
-
-          newControlPoints(i + deg_u, j).array() =
-            (m_controlPoints(i, 0).array() * m_weights(i, 0) +
-             static_cast<T>(j - deg_v) / (deg_v)*alpha * v.array()) /
-            newWeights(i + deg_u, j);
-        }
-
-        v = Vector<T, 3>(Point<T, 3>(m_controlPoints(i, m - 2).array() * m_weights(i, m - 2)),
-                         Point<T, 3>(m_controlPoints(i, m - 1).array() * m_weights(i, m - 1)));
-        d_weight = m_weights(i, m - 1) - m_weights(i, m - 2);
-        alpha =
-          deg_v * expansionAmount_v / (m_knotvec_v[nkts_v - 1] - m_knotvec_v[nkts_v - deg_v - 2]);
-
-        // New weights can't be less than min_weight
-        if(d_weight != 0 && (m_weights(i, m - 1) + alpha * d_weight < min_weight))
-        {
-          alpha = (min_weight - m_weights(i, m - 1)) / d_weight;
-        }
-
-        for(int j = 0; j < deg_v; ++j)
-        {
-          newWeights(i + deg_u, m + deg_v + j) =
-            m_weights(i, m - 1) + static_cast<T>(j + 1) / (deg_v)*alpha * d_weight;
-
-          newControlPoints(i + deg_u, m + deg_v + j).array() =
-            (m_controlPoints(i, m - 1).array() * m_weights(i, m - 1) +
-             static_cast<T>(j + 1) / (deg_v)*alpha * v.array()) /
-            newWeights(i + deg_u, m + deg_v + j);
-        }
-      }
-    }
-
-    // Add the control points on the u direction
-    //  Note that this method uses values added in the v direction,
-    //  making it slightly anisotropic at the corners
-    for(int j = 0; j < m + 2 * deg_v; ++j)
-    {
-      if(!isRational())
-      {
-        Vector<T, 3> v(newControlPoints(deg_u + 1, j), newControlPoints(deg_u, j));
-        double alpha = deg_u * expansionAmount_v / (m_knotvec_u[0] - m_knotvec_u[deg_u + 1]);
-        for(int i = 0; i < deg_u; ++i)
-        {
-          newControlPoints(i, j).array() = newControlPoints(deg_u, j).array() +
-            static_cast<T>(i - deg_u) / (deg_u)*alpha * v.array();
-        }
-
-        v = Vector<T, 3>(newControlPoints(n - 2 + deg_u, j), newControlPoints(n + deg_u - 1, j));
-        alpha =
-          deg_u * expansionAmount_v / (m_knotvec_u[nkts_u - 1] - m_knotvec_u[nkts_u - deg_u - 2]);
-        for(int i = 0; i < deg_u; ++i)
-        {
-          newControlPoints(n + deg_u + i, j).array() = newControlPoints(n + deg_u - 1, j).array() +
-            static_cast<T>(i + 1) / (deg_u)*alpha * v.array();
-        }
-      }
-      else
-      {
-        Vector<T, 3> v(Point<T, 3>(newControlPoints(deg_u + 1, j).array() * newWeights(deg_u + 1, j)),
-                       Point<T, 3>(newControlPoints(deg_u, j).array() * newWeights(deg_u, j)));
-        double d_weight = newWeights(deg_u, j) - newWeights(deg_u + 1, j);
-        double alpha = deg_u * expansionAmount_v / (m_knotvec_u[0] - m_knotvec_u[deg_u + 1]);
-
-        // New weights can't be less than min_weight
-        if(d_weight != 0 && (newWeights(deg_u, j) - alpha * d_weight < min_weight))
-        {
-          alpha = (newWeights(deg_u, j) - min_weight) / d_weight;
-        }
-
-        for(int i = 0; i < deg_u; ++i)
-        {
-          newWeights(i, j) =
-            newWeights(deg_u, j) + static_cast<T>(i - deg_u) / (deg_u)*alpha * d_weight;
-
-          newControlPoints(i, j).array() =
-            (newControlPoints(deg_u, j).array() * newWeights(deg_u, j) +
-             static_cast<T>(i - deg_u) / (deg_u)*alpha * v.array()) /
-            newWeights(i, j);
-        }
-
-        v = Vector<T, 3>(
-          Point<T, 3>(newControlPoints(n - 2 + deg_u, j).array() * newWeights(n - 2 + deg_u, j)),
-          Point<T, 3>(newControlPoints(n + deg_u - 1, j).array() * newWeights(n + deg_u - 1, j)));
-        d_weight = newWeights(n + deg_u - 1, j) - newWeights(n - 2 + deg_u, j);
-        alpha =
-          deg_u * expansionAmount_v / (m_knotvec_u[nkts_u - 1] - m_knotvec_u[nkts_u - deg_u - 2]);
-
-        // New weights can't be less than min_weight
-        if(d_weight != 0 && (newWeights(n + deg_u - 1, j) + alpha * d_weight < min_weight))
-        {
-          alpha = (min_weight - newWeights(n + deg_u - 1, j)) / d_weight;
-        }
-
-        for(int i = 0; i < deg_u; ++i)
-        {
-          newWeights(n + deg_u + i, j) =
-            newWeights(n + deg_u - 1, j) + static_cast<T>(i + 1) / (deg_u)*d_weight * alpha;
-
-          newControlPoints(n + deg_u + i, j).array() =
-            (newControlPoints(n + deg_u - 1, j).array() * newWeights(n + deg_u - 1, j) +
-             static_cast<T>(i + 1) / (deg_u)*alpha * v.array()) /
-            newWeights(n + deg_u + i, j);
-        }
-      }
-    }
-
-    // Fix the u knot vector
-    newKnotVec_u.resize(m_knotvec_u.getNumKnots() + 2 * m_knotvec_u.getDegree());
-    for(int i = 0; i <= deg_u; ++i)
-    {
-      newKnotVec_u[i] = m_knotvec_u[0] - expansionAmount_u;
-    }
-    for(int i = 0; i < m_knotvec_u.getNumKnots() - 2; ++i)
-    {
-      newKnotVec_u[i + deg_u + 1] = m_knotvec_u[i + 1];
-    }
-    for(int i = 0; i <= deg_u; ++i)
-    {
-      newKnotVec_u[i + deg_u + m_knotvec_u.getNumKnots() - 1] =
-        m_knotvec_u[m_knotvec_u.getNumKnots() - 1] + expansionAmount_u;
-    }
-
-    // Fix the v knot vector
-    newKnotVec_v.resize(m_knotvec_v.getNumKnots() + 2 * m_knotvec_v.getDegree());
-    for(int i = 0; i <= deg_v; ++i)
-    {
-      newKnotVec_v[i] = m_knotvec_v[0] - expansionAmount_v;
-    }
-    for(int i = 0; i < m_knotvec_v.getNumKnots() - 2; ++i)
-    {
-      newKnotVec_v[i + deg_v + 1] = m_knotvec_v[i + 1];
-    }
-    for(int i = 0; i <= deg_v; ++i)
-    {
-      newKnotVec_v[i + deg_v + m_knotvec_v.getNumKnots() - 1] =
-        m_knotvec_v[m_knotvec_v.getNumKnots() - 1] + expansionAmount_v;
-    }
-
-    m_controlPoints = newControlPoints;
-    m_weights = newWeights;
-
-    m_knotvec_u = KnotVectorType(newKnotVec_u, deg_u);
-    m_knotvec_v = KnotVectorType(newKnotVec_v, deg_v);
-  }
   ///@}
 
   /*!
@@ -3426,67 +3482,6 @@ public:
 
     return os;
   }
-
-  /// \brief Function to check if the NURBS surface is valid
-  bool isValidNURBS() const
-  {
-    // Check monotonicity, open-ness, continuity of each knot vector
-    if(!m_knotvec_u.isValid() || !m_knotvec_v.isValid())
-    {
-      return false;
-    }
-
-    // Number of knots must match the number of control points
-    int deg_u = m_knotvec_u.getDegree();
-    int deg_v = m_knotvec_v.getDegree();
-
-    // Number of knots must match the number of control points
-    auto patch_shape = m_controlPoints.shape();
-    if(m_knotvec_u.getNumKnots() != patch_shape[0] + deg_u + 1 ||
-       m_knotvec_v.getNumKnots() != patch_shape[1] + deg_v + 1)
-    {
-      return false;
-    }
-
-    if(isRational())
-    {
-      // Number of control points must match number of weights
-      auto weights_shape = m_weights.shape();
-      if(weights_shape[0] != patch_shape[0] || weights_shape[1] != patch_shape[1])
-      {
-        return false;
-      }
-
-      // Weights must be positive
-      for(int i = 0; i < weights_shape[0]; ++i)
-      {
-        for(int j = 0; j < weights_shape[1]; ++j)
-        {
-          if(m_weights(i, j) <= 0.0)
-          {
-            return false;
-          }
-        }
-      }
-    }
-
-    return true;
-  }
-
-  /// \brief Function to check if the u parameter is within the knot span
-  bool isValidParameter_u(T u, T EPS = 1e-8) const
-  {
-    return u >= m_knotvec_u[0] - EPS && u <= m_knotvec_u[m_knotvec_u.getNumKnots() - 1] + EPS;
-  }
-
-  /// \brief Function to check if the v parameter is within the knot span
-  bool isValidParameter_v(T v, T EPS = 1e-8) const
-  {
-    return v >= m_knotvec_v[0] - EPS && v <= m_knotvec_v[m_knotvec_v.getNumKnots() - 1] + EPS;
-  }
-
-  /// \brief Checks if given u parameter is *interior* to the knot span
-  bool isValidInteriorParameter(T t) const { return m_knotvec_u.isValidInteriorParameter(t); }
 
 private:
   /// \brief Private function to rescale trimming curves from (a, b) to (c, d) in x
@@ -3827,6 +3822,34 @@ private:
       line.reverseOrientation();
       outCurvesSecond.push_back(line);
     }
+  }
+
+  /*!
+   * \brief Equality operator for NURBS patches
+   * 
+   * \param [in] lhs The left-hand side NURBS patch
+   * \param [in] rhs The right-hand side NURBS patch
+   * 
+   * \return True if the two patches are equal, false otherwise
+   */
+  friend inline bool operator==(const NURBSPatch<T, NDIMS>& lhs, const NURBSPatch<T, NDIMS>& rhs)
+  {
+    return (lhs.m_controlPoints == rhs.m_controlPoints) && (lhs.m_weights == rhs.m_weights) &&
+      (lhs.m_knotvec_u == rhs.m_knotvec_u) && (lhs.m_knotvec_v == rhs.m_knotvec_v) &&
+      (lhs.m_isTrimmed == rhs.m_isTrimmed) && (lhs.m_trimmingCurves == rhs.m_trimmingCurves);
+  }
+
+  /*!
+   * \brief Inequality operator for NURBS patches
+   * 
+   * \param [in] lhs The left-hand side NURBS patch
+   * \param [in] rhs The right-hand side NURBS patch
+   * 
+   * \return True if the two patches are not equal, false otherwise
+   */
+  friend inline bool operator!=(const NURBSPatch<T, NDIMS>& lhs, const NURBSPatch<T, NDIMS>& rhs)
+  {
+    return !(lhs == rhs);
   }
 
 private:


### PR DESCRIPTION
# Summary

- This PR is a refactoring
- It reorganizes and consistently groups the functions in the `BezierCurve`, `BezierPatch`, `NURBSCurve`, `NURBSPatch` and `KnotVector` classes
- This is a precursor to improving the consistency of the APIs across these classes (https://github.com/LLNL/axom/issues/1528)
- Note: This PR has no changes to API or functionality. It only reorganizes the functions and groups them by functionality
- RTD/doxygen links for this branch: 
    - https://axom.readthedocs.io/en/feature-kweiss-bezier-nurbs-api/
    - [Updated Doxygen for BezierCurve class](https://axom.readthedocs.io/en/feature-kweiss-bezier-nurbs-api/doxygen/html/classaxom_1_1primal_1_1BezierCurve.html)
    - [Updated Doxygen for BezierPatch class](https://axom.readthedocs.io/en/feature-kweiss-bezier-nurbs-api/doxygen/html/classaxom_1_1primal_1_1BezierPatch.html)
    - [Updated Doxygen for NURBSCurve class](https://axom.readthedocs.io/en/feature-kweiss-bezier-nurbs-api/doxygen/html/classaxom_1_1primal_1_1NURBSCurve.html)
    - [Updated Doxygen for NURBSPatch class](https://axom.readthedocs.io/en/feature-kweiss-bezier-nurbs-api/doxygen/html/classaxom_1_1primal_1_1NURBSPatch.html)
    - [Updated Doxygen for KnotVector class](https://axom.readthedocs.io/en/feature-kweiss-bezier-nurbs-api/doxygen/html/classaxom_1_1primal_1_1KnotVector.html)