### PR TITLE
64-bit Windows RAJA unsigned atomics test

### DIFF
--- a/scripts/vcpkg_ports/camp/portfile.cmake
+++ b/scripts/vcpkg_ports/camp/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO llnl/camp
     REF main
-    SHA512 0
+    SHA512 25dc2220cf9f5aeb4f1703353c5eb7e00778e09057df14f13eb5636ad6dc276562f6675773ad586b3f6ba40b2b970c1550e1ed1fa8d0a3891f97600c22636fea
 )
 
 set(_is_shared TRUE)

--- a/scripts/vcpkg_ports/camp/portfile.cmake
+++ b/scripts/vcpkg_ports/camp/portfile.cmake
@@ -1,9 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO llnl/camp
-    REF v2025.03.0
-    SHA512 8d1b0f89a4ca95d418a6bf0b9df7e417b9130b5daba274dc83f5ede4e2acb67e2572693e564b3899bb2d69a60ee6d921c1af51f6834b792951808dfcba5f8841
-    HEAD_REF develop
+    REF main
+    SHA512 0
 )
 
 set(_is_shared TRUE)

--- a/scripts/vcpkg_ports/raja/portfile.cmake
+++ b/scripts/vcpkg_ports/raja/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO llnl/raja
     REF task/rhornung67/atomics-shortints
-    SHA512 aae8286479a3b70cc31e4135bc29b599361678ed8bd8f467d042bb5a9fa734ea
+    SHA512 0
 )
 
 set(_is_shared TRUE)

--- a/scripts/vcpkg_ports/raja/portfile.cmake
+++ b/scripts/vcpkg_ports/raja/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO llnl/raja
     REF task/rhornung67/atomics-shortints
-    SHA512 0
+    SHA512 debee645bc2b47bc77a068bea7e74ef81f8dbf5eaed9862fefcb2c55485332834e869f801e8adf4ba1740b0d110a7af4eacd269d742d1076f27ca82288dc4d3f
 )
 
 set(_is_shared TRUE)

--- a/scripts/vcpkg_ports/raja/portfile.cmake
+++ b/scripts/vcpkg_ports/raja/portfile.cmake
@@ -1,7 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO llnl/raja
-    HEAD_REF task/rhornung67/atomics-shortints
+    REF task/rhornung67/atomics-shortints
+    SHA512 aae8286479a3b70cc31e4135bc29b599361678ed8bd8f467d042bb5a9fa734ea
 )
 
 set(_is_shared TRUE)

--- a/scripts/vcpkg_ports/raja/portfile.cmake
+++ b/scripts/vcpkg_ports/raja/portfile.cmake
@@ -1,9 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO llnl/raja
-    REF v2025.03.0
-    SHA512 82a5db484562dcd9404f428bab60dbf9e7b91dfedce9ba6a12c4f590f5a79a0a640a1fd40cbfd805b9ec974947a58deb3eb4b4b1bee1d143c717fb359a805e2e
-    HEAD_REF develop
+    HEAD_REF task/rhornung67/atomics-shortints
 )
 
 set(_is_shared TRUE)

--- a/scripts/vcpkg_ports/raja/vcpkg.json
+++ b/scripts/vcpkg_ports/raja/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "raja",
-  "version-string": "2025.03.0",
+  "version-string": "testing-branch",
   "homepage": "https://github.com/llnl/raja",
   "description": "RAJA Performance Portability Layer (C++)",
   "dependencies": [

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -326,8 +326,12 @@ if((CONDUIT_FOUND OR
         )
 
     if(AXOM_ENABLE_TESTS AND AXOM_DATA_DIR)
-        # 3D shaping tests.  No 2D shaping in this feature, at least for now.
-        set(_nranks 1)
+
+        if(AXOM_ENABLE_MPI)     # this test requires MPI when available
+            set(_nranks 1)      # (but only 1 rank)
+        else()                  # but can otherwise be run without MPI
+            unset(_nranks)
+        endif()
 
         # Run the in-memory shaping example on with each enabled policy
         set(_policies "seq")

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -336,7 +336,10 @@ if((CONDUIT_FOUND OR
         # Run the in-memory shaping example on with each enabled policy
         set(_policies "seq")
         if(RAJA_FOUND)
-            blt_list_append(TO _policies ELEMENTS "omp"  IF AXOM_ENABLE_OPENMP)
+            # Hanging issue on Windows
+            if(NOT WIN32)
+                blt_list_append(TO _policies ELEMENTS "omp"  IF AXOM_ENABLE_OPENMP)
+            endif()
             blt_list_append(TO _policies ELEMENTS "cuda" IF AXOM_ENABLE_CUDA)
             blt_list_append(TO _policies ELEMENTS "hip"  IF AXOM_ENABLE_HIP)
         endif()

--- a/src/axom/quest/examples/quest_shape_in_memory.cpp
+++ b/src/axom/quest/examples/quest_shape_in_memory.cpp
@@ -194,7 +194,9 @@ public:
 
     auto dc = std::unique_ptr<sidre::MFEMSidreDataCollection>(
       new sidre::MFEMSidreDataCollection(name, mesh, dc_owns_data));
+  #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
     dc->SetComm(MPI_COMM_WORLD);
+  #endif
 
     return dc;
   }
@@ -1651,10 +1653,14 @@ int main(int argc, char** argv)
     {
       shapingDC->SetMeshNodesName("positions");
 
-      // With MPI, loadComputationalMesh returns a parallel mesh.
+  // With MPI, loadComputationalMesh returns a parallel mesh.
+  #if defined(AXOM_USE_MPI) && defined(MFEM_USE_MPI)
       mfem::ParMesh* parallelMesh = dynamic_cast<mfem::ParMesh*>(originalMeshDC->GetMesh());
       shapingMesh = (parallelMesh != nullptr) ? new mfem::ParMesh(*parallelMesh)
                                               : new mfem::Mesh(*originalMeshDC->GetMesh());
+  #else
+      shapingMesh = new mfem::Mesh(*originalMeshDC->GetMesh());
+  #endif
       shapingDC->SetMesh(shapingMesh);
     }
     AXOM_ANNOTATE_END("load mesh");


### PR DESCRIPTION
This draft PR:
- Tests RAJA branch LLNL/RAJA#1870 to see if it fixes issue #1615
  - Confirms that the branch does fix the 64-bit Window builds. 
- Windows GHA build for this PR can be found at : https://github.com/LLNL/axom/actions/runs/16816563826
  - Note: The 32-bit x86 Window builds are failing due to #1580, which is a separate issue from the RAJA fix.
- Some Axom code changes were necessary to address MPI guards/OpenMP usage in `quest_shape_in_memory_ex` tests.