### PR TITLE
Add missing includes to bump/mir CMakeLists

### DIFF
--- a/src/axom/bump/CMakeLists.txt
+++ b/src/axom/bump/CMakeLists.txt
@@ -55,8 +55,8 @@ set(bump_headers
     CoordsetBlender.hpp
     CoordsetExtents.hpp
     CoordsetSlicer.hpp
-    ExtractZonesAndMatsetPolyhedral.hpp
     ExtractZones.hpp
+    ExtractZonesAndMatsetPolyhedral.hpp
     ExtrudeMesh.hpp
     FieldBlender.hpp
     FieldSlicer.hpp

--- a/src/axom/bump/CMakeLists.txt
+++ b/src/axom/bump/CMakeLists.txt
@@ -29,6 +29,7 @@ set(bump_headers
     utilities/conduit_memory.hpp
     utilities/conduit_traits.hpp
     utilities/utilities.hpp
+    views/BasicIndexing.hpp
     views/dispatch_coordset.hpp
     views/dispatch_material.hpp
     views/dispatch_rectilinear_topology.hpp
@@ -59,6 +60,7 @@ set(bump_headers
     ExtrudeMesh.hpp
     FieldBlender.hpp
     FieldSlicer.hpp
+    HashNaming.hpp
     IndexingPolicies.hpp
     MakePointMesh.hpp
     MakePolyhedralTopology.hpp

--- a/src/axom/mir/CMakeLists.txt
+++ b/src/axom/mir/CMakeLists.txt
@@ -19,14 +19,14 @@ axom_component_requires(NAME       MIR
 
 # A serial reference implementation (remove eventually)
 set(mir_reference_headers
+    reference/CellClipper.hpp
+    reference/CellData.hpp
+    reference/CellGenerator.hpp
+    reference/InterfaceReconstructor.hpp
     reference/MIRMesh.hpp
     reference/MIRMeshTypes.hpp
-    reference/ZooClippingTables.hpp
-    reference/InterfaceReconstructor.hpp
-    reference/CellData.hpp
-    reference/CellClipper.hpp
     reference/MIRUtilities.hpp
-    reference/CellGenerator.hpp
+    reference/ZooClippingTables.hpp
     )
 set(mir_reference_sources
     reference/MIRMesh.cpp
@@ -39,8 +39,8 @@ set(mir_reference_sources
 
 # Future classes (evaluate whether to keep them)
 set(mir_future_headers
-    future/ClipFieldFilterDevice.hpp
     future/ClipFieldFilter.hpp
+    future/ClipFieldFilterDevice.hpp
     )
 set(mir_future_sources
     future/ClipFieldFilter.cpp

--- a/src/axom/mir/CMakeLists.txt
+++ b/src/axom/mir/CMakeLists.txt
@@ -48,8 +48,9 @@ set(mir_future_sources
 
 set(mir_headers
     ${mir_reference_headers}
-    detail/elvira_impl.hpp
     detail/elvira_detail.hpp
+    detail/elvira_impl.hpp
+    detail/equiz_detail.hpp
     ElviraAlgorithm.hpp
     EquiZAlgorithm.hpp
     MIRAlgorithm.hpp


### PR DESCRIPTION
# Summary

- This PR is a minimal bugfix which adds a few missing header files to the CMake includes for `bump`/`mir`. Without these, referencing an installed Axom will have issues unless those files are copied over to the install directory directly.
- Reordered some includes to be alphabetical. This made it easier to check there wasn't anything else missing.