### PR TITLE
Convenience script for nanobind python extensions

### DIFF
--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -708,10 +708,7 @@ public:
     return (lhs.m_map == rhs.m_map && lhs.m_internalIdx == rhs.m_internalIdx);
   }
 
-  friend bool operator!=(const IteratorImpl& lhs, const IteratorImpl& rhs)
-  {
-    return !(lhs == rhs);
-  }
+  friend bool operator!=(const IteratorImpl& lhs, const IteratorImpl& rhs) { return !(lhs == rhs); }
 
   IteratorImpl& operator++()
   {

--- a/src/axom/core/FlatMapView.hpp
+++ b/src/axom/core/FlatMapView.hpp
@@ -251,7 +251,7 @@ private:
    */
   AXOM_HOST_DEVICE bool isViewOfSameMap(const IteratorImpl& other) const
   {
-      return this->m_map.isViewOfSameMap(other.m_map);
+    return this->m_map.isViewOfSameMap(other.m_map);
   }
 
   MapType m_map;

--- a/src/axom/sidre/CMakeLists.txt
+++ b/src/axom/sidre/CMakeLists.txt
@@ -144,6 +144,8 @@ if(NANOBIND_FOUND)
         string (REPLACE " " ";" MODULE_LINK_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
         target_link_options(pysidre PRIVATE ${MODULE_LINK_FLAGS})
     endif()
+
+    install(TARGETS pysidre LIBRARY DESTINATION lib)
 endif()
 
 

--- a/src/axom/sidre/examples/CMakeLists.txt
+++ b/src/axom/sidre/examples/CMakeLists.txt
@@ -157,15 +157,11 @@ if(NANOBIND_FOUND)
     foreach(example_source ${Py_example_sources})
         get_filename_component(exe_name ${example_source} NAME_WE)
 
+        # Use convenience script to run python examples
         if(AXOM_ENABLE_PYTHON_TESTS)
-            add_test (
+            axom_add_test (
                 NAME    ${exe_name}
-                COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${example_source}
-            )
-
-            # Add pysidre to search path
-            set_tests_properties(${exe_name} PROPERTIES
-                ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/lib:$ENV{PYTHONPATH}"
+                COMMAND ${PROJECT_BINARY_DIR}/bin/run_python_with_axom.sh ${CMAKE_CURRENT_SOURCE_DIR}/${example_source}
             )
         endif()
     endforeach()

--- a/src/docs/sphinx/dev_guide/component_org.rst
+++ b/src/docs/sphinx/dev_guide/component_org.rst
@@ -307,6 +307,10 @@ from a *cpp* file that describes C++ functions and their interfaces.
 
 Please refer to the `nanobind documentation <https://nanobind.readthedocs.io/en/latest/>`_ for more information.
 
+The python interpreter can be launched with Axom extension(s) in the PYTHONPATH
+by running the convenience script::
+
+  ./bin/run_python_with_axom.sh <optional .py to run>
 
 .. note:: The Python interface requires Axom to be configured with nanobind
           to build and use the interface. This requirement is different from shroud,

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -192,3 +192,32 @@ if(AXOM_ENABLE_QUEST)
             PROPERTIES PASS_REGULAR_EXPRESSION  "Retained 272 boundary faces")
     endif()
 endif()
+
+#------------------------------------------------------------------------------
+# run_python_with_axom.sh.in is a utility that allows running python with
+# nanobind-generated extensions in the PYTHONPATH.
+# Based on Conduit's run_python_with_conduit.sh.in script.
+#------------------------------------------------------------------------------
+if(NANOBIND_FOUND)
+
+    # gen python helper to build directory
+    set(_PYEXT_DIR ${PROJECT_BINARY_DIR}/lib)
+
+    configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/run_python_with_axom.sh.in"
+                    "${PROJECT_BINARY_DIR}/bin/run_python_with_axom.sh" @ONLY)
+
+    # gen python helper to install directory
+    set(_PYEXT_DIR ${CMAKE_INSTALL_PREFIX}/lib)
+
+    configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/run_python_with_axom.sh.in"
+                    "${CMAKE_INSTALL_PREFIX}/bin/run_python_with_axom.sh" @ONLY)
+
+    unset(_PYEXT_DIR)
+
+    # Add unit test to check script
+    if(AXOM_ENABLE_TESTS AND AXOM_ENABLE_SIDRE)
+        axom_add_test(
+            NAME    run_python_with_axom_build
+            COMMAND ${PROJECT_BINARY_DIR}/bin/run_python_with_axom.sh -c "import pysidre")
+    endif()
+endif()

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -203,14 +203,14 @@ if(NANOBIND_FOUND)
     # gen python helper to build directory
     set(_PYEXT_DIR ${PROJECT_BINARY_DIR}/lib)
 
-    configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/run_python_with_axom.sh.in"
-                    "${PROJECT_BINARY_DIR}/bin/run_python_with_axom.sh" @ONLY)
+    axom_configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/run_python_with_axom.sh.in"
+                         "${PROJECT_BINARY_DIR}/bin/run_python_with_axom.sh" @ONLY)
 
     # gen python helper to install directory
     set(_PYEXT_DIR ${CMAKE_INSTALL_PREFIX}/lib)
 
-    configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/run_python_with_axom.sh.in"
-                    "${CMAKE_INSTALL_PREFIX}/bin/run_python_with_axom.sh" @ONLY)
+    axom_configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/run_python_with_axom.sh.in"
+                         "${CMAKE_INSTALL_PREFIX}/bin/run_python_with_axom.sh" @ONLY)
 
     unset(_PYEXT_DIR)
 

--- a/src/tools/run_python_with_axom.sh.in
+++ b/src/tools/run_python_with_axom.sh.in
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+# Axom Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+
+##-----------------------------------------------------------------------------
+## Convenience script that runs python interpreter with Axom extension(s) in
+## the PYTHONPATH.
+##-----------------------------------------------------------------------------
+env PYTHONPATH=$PYTHONPATH:@_PYEXT_DIR@ @Python_EXECUTABLE@ "$@"


### PR DESCRIPTION
This PR:
- Adds a convenience script (`run_python_with_axom.sh`)that runs python interpreter with path to nanobind-generated extensions in the PYTHONPATH.
  - Script is based on Conduit's `run_python_with_conduit.sh` script and CMake configuration logic: https://github.com/LLNL/conduit/blob/develop/src/libs/conduit/python/run_python_with_conduit.sh.in