### PR TITLE
Change MIRAlgorithm to make it clearer that it operates on a single domain.

### DIFF
--- a/src/axom/mir/ElviraAlgorithm.hpp
+++ b/src/axom/mir/ElviraAlgorithm.hpp
@@ -176,12 +176,12 @@ protected:
       // Gather the inputs into a single root but replace the fields with
       // a new node to which we can add additional fields.
       conduit::Node n_root;
-      n_root[n_coordset.path()].set_external(n_coordset);
-      n_root[n_topo.path()].set_external(n_topo);
-      n_root[n_matset.path()].set_external(n_matset);
-      conduit::Node &n_root_coordset = n_root[n_coordset.path()];
-      conduit::Node &n_root_topo = n_root[n_topo.path()];
-      conduit::Node &n_root_matset = n_root[n_matset.path()];
+      n_root[localPath(n_coordset)].set_external(n_coordset);
+      n_root[localPath(n_topo)].set_external(n_topo);
+      n_root[localPath(n_matset)].set_external(n_matset);
+      conduit::Node &n_root_coordset = n_root[localPath(n_coordset)];
+      conduit::Node &n_root_topo = n_root[localPath(n_topo)];
+      conduit::Node &n_root_matset = n_root[localPath(n_matset)];
       conduit::Node n_root_fields = n_root["fields"];
 
       // Make the clean mesh.
@@ -208,10 +208,10 @@ protected:
 
       // Gather the MIR output into a single node.
       conduit::Node n_mirOutput;
-      n_mirOutput[n_newTopo.path()].set_external(n_newTopo);
-      n_mirOutput[n_newCoordset.path()].set_external(n_newCoordset);
-      n_mirOutput[n_newFields.path()].set_external(n_newFields);
-      n_mirOutput[n_newMatset.path()].set_external(n_newMatset);
+      n_mirOutput[localPath(n_newTopo)].set_external(n_newTopo);
+      n_mirOutput[localPath(n_newCoordset)].set_external(n_newCoordset);
+      n_mirOutput[localPath(n_newFields)].set_external(n_newFields);
+      n_mirOutput[localPath(n_newMatset)].set_external(n_newMatset);
 #if defined(AXOM_ELVIRA_DEBUG)
       saveMesh(n_mirOutput, "debug_elvira_mir");
       SLIC_DEBUG("--- clean ---");
@@ -232,10 +232,10 @@ protected:
 #endif
 
       // Move the merged output into the output variables.
-      n_newCoordset.move(n_merged[n_newCoordset.path()]);
-      n_newTopo.move(n_merged[n_newTopo.path()]);
-      n_newFields.move(n_merged[n_newFields.path()]);
-      n_newMatset.move(n_merged[n_newMatset.path()]);
+      n_newCoordset.move(n_merged[localPath(n_newCoordset)]);
+      n_newTopo.move(n_merged[localPath(n_newTopo)]);
+      n_newFields.move(n_merged[localPath(n_newFields)]);
+      n_newMatset.move(n_merged[localPath(n_newMatset)]);
     }
     else if(cleanZones.size() == 0 && mixedZones.size() > 0)
     {
@@ -823,10 +823,10 @@ protected:
     {
       AXOM_ANNOTATE_SCOPE("verify");
       conduit::Node n_mesh;
-      n_mesh[n_newCoordset.path()].set_external(n_newCoordset);
-      n_mesh[n_newTopo.path()].set_external(n_newTopo);
-      n_mesh[n_newFields.path()].set_external(n_newFields);
-      n_mesh[n_newMatset.path()].set_external(n_newMatset);
+      n_mesh[localPath(n_newCoordset)].set_external(n_newCoordset);
+      n_mesh[localPath(n_newTopo)].set_external(n_newTopo);
+      n_mesh[localPath(n_newFields)].set_external(n_newFields);
+      n_mesh[localPath(n_newMatset)].set_external(n_newMatset);
 
       // Verify the MIR output.
       conduit::Node info;

--- a/src/axom/mir/EquiZAlgorithm.hpp
+++ b/src/axom/mir/EquiZAlgorithm.hpp
@@ -117,10 +117,10 @@ protected:
 #if defined(AXOM_EQUIZ_DEBUG)
     // Save the MIR input.
     conduit::Node n_tmpInput;
-    n_tmpInput[n_topo.path()].set_external(n_topo);
-    n_tmpInput[n_coordset.path()].set_external(n_coordset);
-    n_tmpInput[n_fields.path()].set_external(n_fields);
-    n_tmpInput[n_matset.path()].set_external(n_matset);
+    n_tmpInput[localPath(n_topo)].set_external(n_topo);
+    n_tmpInput[localPath(n_coordset)].set_external(n_coordset);
+    n_tmpInput[localPath(n_fields)].set_external(n_fields);
+    n_tmpInput[localPath(n_matset)].set_external(n_matset);
     saveMesh(n_tmpInput, "debug_equiz_input");
 #endif
 
@@ -137,12 +137,12 @@ protected:
       // Gather the inputs into a single root but replace the fields with
       // a new node to which we can add additional fields.
       conduit::Node n_root;
-      n_root[n_coordset.path()].set_external(n_coordset);
-      n_root[n_topo.path()].set_external(n_topo);
-      n_root[n_matset.path()].set_external(n_matset);
-      conduit::Node &n_root_coordset = n_root[n_coordset.path()];
-      conduit::Node &n_root_topo = n_root[n_topo.path()];
-      conduit::Node &n_root_matset = n_root[n_matset.path()];
+      n_root[localPath(n_coordset)].set_external(n_coordset);
+      n_root[localPath(n_topo)].set_external(n_topo);
+      n_root[localPath(n_matset)].set_external(n_matset);
+      conduit::Node &n_root_coordset = n_root[localPath(n_coordset)];
+      conduit::Node &n_root_topo = n_root[localPath(n_topo)];
+      conduit::Node &n_root_matset = n_root[localPath(n_matset)];
       conduit::Node &n_root_fields = n_root["fields"];
       for(conduit::index_t i = 0; i < n_fields.number_of_children(); i++)
       {
@@ -179,10 +179,10 @@ protected:
 
       // Gather the MIR output into a single node.
       conduit::Node n_mirOutput;
-      n_mirOutput[n_newTopo.path()].set_external(n_newTopo);
-      n_mirOutput[n_newCoordset.path()].set_external(n_newCoordset);
-      n_mirOutput[n_newFields.path()].set_external(n_newFields);
-      n_mirOutput[n_newMatset.path()].set_external(n_newMatset);
+      n_mirOutput[localPath(n_newTopo)].set_external(n_newTopo);
+      n_mirOutput[localPath(n_newCoordset)].set_external(n_newCoordset);
+      n_mirOutput[localPath(n_newFields)].set_external(n_newFields);
+      n_mirOutput[localPath(n_newMatset)].set_external(n_newMatset);
   #if defined(AXOM_EQUIZ_DEBUG)
       saveMesh(n_mirOutput, "debug_equiz_mir");
       std::cout << "--- clean ---\n";
@@ -203,10 +203,10 @@ protected:
   #endif
 
       // Move the merged output into the output variables.
-      n_newCoordset.move(n_merged[n_newCoordset.path()]);
-      n_newTopo.move(n_merged[n_newTopo.path()]);
-      n_newFields.move(n_merged[n_newFields.path()]);
-      n_newMatset.move(n_merged[n_newMatset.path()]);
+      n_newCoordset.move(n_merged[localPath(n_newCoordset)]);
+      n_newTopo.move(n_merged[localPath(n_newTopo)]);
+      n_newFields.move(n_merged[localPath(n_newFields)]);
+      n_newMatset.move(n_merged[localPath(n_newMatset)]);
     }
     else if(cleanZones.size() == 0 && mixedZones.size() > 0)
     {
@@ -514,9 +514,9 @@ protected:
     // Make some nodes that will contain the inputs to subsequent iterations.
     // Store them under a single node so the nodes will have names.
     conduit::Node n_Input;
-    conduit::Node &n_InputTopo = n_Input[n_topo.path()];
-    conduit::Node &n_InputCoordset = n_Input[n_coordset.path()];
-    conduit::Node &n_InputFields = n_Input[n_fields.path()];
+    conduit::Node &n_InputTopo = n_Input[localPath(n_topo)];
+    conduit::Node &n_InputCoordset = n_Input[localPath(n_coordset)];
+    conduit::Node &n_InputFields = n_Input[localPath(n_fields)];
 
     // Get the materials from the matset and determine which of them are clean/mixed.
     axom::bump::views::MaterialInformation allMats, cleanMats, mixedMats;
@@ -647,10 +647,10 @@ protected:
     //
     //--------------------------------------------------------------------------
     conduit::Node n_output;
-    n_output[n_newTopo.path()].set_external(n_newTopo);
-    n_output[n_newCoordset.path()].set_external(n_newCoordset);
-    n_output[n_newFields.path()].set_external(n_newFields);
-    n_output[n_newMatset.path()].set_external(n_newMatset);
+    n_output[localPath(n_newTopo)].set_external(n_newTopo);
+    n_output[localPath(n_newCoordset)].set_external(n_newCoordset);
+    n_output[localPath(n_newFields)].set_external(n_newFields);
+    n_output[localPath(n_newMatset)].set_external(n_newMatset);
     saveMesh(n_output, "debug_equiz_output");
 #endif
   }
@@ -913,9 +913,9 @@ protected:
     {
       AXOM_ANNOTATE_SCOPE("Saving input");
       conduit::Node n_mesh_input;
-      n_mesh_input[n_topo.path()].set_external(n_topo);
-      n_mesh_input[n_coordset.path()].set_external(n_coordset);
-      n_mesh_input[n_fields.path()].set_external(n_fields);
+      n_mesh_input[localPath(n_topo)].set_external(n_topo);
+      n_mesh_input[localPath(n_coordset)].set_external(n_coordset);
+      n_mesh_input[localPath(n_fields)].set_external(n_fields);
 
       // save
       std::stringstream ss1;
@@ -1059,9 +1059,9 @@ protected:
     {
       AXOM_ANNOTATE_SCOPE("Saving output");
       conduit::Node mesh;
-      mesh[n_newTopo.path()].set_external(n_newTopo);
-      mesh[n_newCoordset.path()].set_external(n_newCoordset);
-      mesh[n_newFields.path()].set_external(n_newFields);
+      mesh[localPath(n_newTopo)].set_external(n_newTopo);
+      mesh[localPath(n_newCoordset)].set_external(n_newCoordset);
+      mesh[localPath(n_newFields)].set_external(n_newFields);
 
       // save
       std::stringstream ss;

--- a/src/axom/mir/MIRAlgorithm.cpp
+++ b/src/axom/mir/MIRAlgorithm.cpp
@@ -137,7 +137,7 @@ std::string MIRAlgorithm::localPath(const conduit::Node &obj) const
   std::string path(obj.path());
   const auto dpos = path.find("domain");
   const auto spos = path.find("/");
-  if(dpos == 0 && spos > dpos && obj.parent() != nullptr)
+  if(dpos == 0 && spos != std::string::npos && spos > dpos && obj.parent() != nullptr)
   {
     path = path.substr(spos + 1, path.size() - spos - 1);
   }

--- a/src/axom/mir/MIRAlgorithm.cpp
+++ b/src/axom/mir/MIRAlgorithm.cpp
@@ -135,7 +135,7 @@ void MIRAlgorithm::saveMesh(const conduit::Node &n_mesh, const std::string &file
 std::string MIRAlgorithm::localPath(const conduit::Node &obj) const
 {
   std::string path(obj.path());
-  const auto dpos = path.find("dom");
+  const auto dpos = path.find("domain");
   const auto spos = path.find("/");
   if(dpos == 0 && spos > dpos && obj.parent() != nullptr)
   {

--- a/src/axom/mir/MIRAlgorithm.cpp
+++ b/src/axom/mir/MIRAlgorithm.cpp
@@ -24,14 +24,7 @@ void MIRAlgorithm::execute(const conduit::Node &n_input,
   const auto domains = conduit::blueprint::mesh::domains(n_input);
   if(domains.size() > 1)
   {
-    // Handle multiple domains
-    for(const auto &dom_ptr : domains)
-    {
-      const conduit::Node &n_domain = *dom_ptr;
-      conduit::Node &n_newDomain = n_output.append();
-
-      executeSetup(n_domain, n_options, n_newDomain);
-    }
+    SLIC_ERROR("The input node contains multiple domains. Pass a single domain at a time instead.");
   }
   else if(domains.size() > 0)
   {
@@ -73,6 +66,7 @@ void MIRAlgorithm::executeSetup(const conduit::Node &n_domain,
   newTopo["coordset"] = newCoordsetName;
   conduit::Node &newMatset = n_newDomain["matsets/" + newMatsetName];
   newMatset["topology"] = newTopoName;
+  conduit::Node &newFields = n_newDomain["fields"];
 
   // Execute the algorithm on the domain.
   if(n_domain.has_path("state"))
@@ -81,7 +75,6 @@ void MIRAlgorithm::executeSetup(const conduit::Node &n_domain,
   }
   if(n_domain.has_path("fields"))
   {
-    conduit::Node &newFields = n_newDomain["fields"];
     executeDomain(*n_topo,
                   *n_coordset,
                   n_domain["fields"],
@@ -97,8 +90,6 @@ void MIRAlgorithm::executeSetup(const conduit::Node &n_domain,
     // There are no input fields, but make sure n_fields has a name.
     conduit::Node tmp;
     conduit::Node &n_fields = tmp["fields"];
-    // MIR is likely to output some created fields.
-    conduit::Node &newFields = n_newDomain["fields"];
     executeDomain(*n_topo,
                   *n_coordset,
                   n_fields,

--- a/src/axom/mir/MIRAlgorithm.cpp
+++ b/src/axom/mir/MIRAlgorithm.cpp
@@ -132,5 +132,17 @@ void MIRAlgorithm::saveMesh(const conduit::Node &n_mesh, const std::string &file
 #endif
 }
 
+std::string MIRAlgorithm::localPath(const conduit::Node &obj) const
+{
+  std::string path(obj.path());
+  const auto dpos = path.find("dom");
+  const auto spos = path.find("/");
+  if(dpos == 0 && spos > dpos && obj.parent() != nullptr)
+  {
+    path = path.substr(spos + 1, path.size() - spos - 1);
+  }
+  return path;
+}
+
 }  // namespace mir
 }  // namespace axom

--- a/src/axom/mir/MIRAlgorithm.hpp
+++ b/src/axom/mir/MIRAlgorithm.hpp
@@ -123,6 +123,15 @@ protected:
    * \param filebase The base filename to use when writing files. Extensions may be added.
    */
   void saveMesh(const conduit::Node &n_mesh, const std::string &filebase) const;
+
+  /*!
+   * \brief Return the local path name, stripping off a domain path prefix.
+   *
+   * \param[in] obj The object whose local path we want.
+   *
+   * \return The path without the domain prefix.
+   */
+  std::string localPath(const conduit::Node &obj) const;
 };
 
 }  // end namespace mir

--- a/src/axom/mir/MIRAlgorithm.hpp
+++ b/src/axom/mir/MIRAlgorithm.hpp
@@ -29,12 +29,10 @@ public:
   virtual ~MIRAlgorithm() = default;
 
   /*!
-    \brief Perform material interface reconstruction on the meshes supplied in the
-           root node. Root can either be a mesh domain or a node that contains multiple
-           domains.
+    \brief Perform material interface reconstruction on the mesh supplied by \a n_input.
 
-    \param[in] n_input The root node that contains either a mesh or list of mesh
-                       domains that contain a topology and matset to be used for MIR.
+    \param[in] n_input The node that contains a mesh domain with the topology and matset
+                       to be used for MIR.
     \param[in] n_options A node that contains options that help govern MIR execution.
 
 \code{.yaml}

--- a/src/axom/mir/MIRAlgorithm.hpp
+++ b/src/axom/mir/MIRAlgorithm.hpp
@@ -125,7 +125,9 @@ protected:
   void saveMesh(const conduit::Node &n_mesh, const std::string &filebase) const;
 
   /*!
-   * \brief Return the local path name, stripping off a domain path prefix.
+   * \brief Return the local path name, stripping off a domain path prefix. Blueprint domains
+   *        are typically written under top level nodes with names like "domain_{:05}" or "domain_{:07}".
+   *        This method will strip off any path prefix beginning with "domain".
    *
    * \param[in] obj The object whose local path we want.
    *

--- a/src/axom/mir/tests/mir_elvira2d.cpp
+++ b/src/axom/mir/tests/mir_elvira2d.cpp
@@ -45,54 +45,68 @@ struct braid2d_mat_test
                    const std::string &mattype,
                    const std::string &name,
                    bool selectedZones = false,
-                   bool pointMesh = false)
+                   bool pointMesh = false,
+                   int nDomains = 1)
   {
-    // Create the data
+    // Create the data (1+ domains)
     conduit::Node hostMesh, deviceMesh;
-    initialize(type, mattype, hostMesh);
-    utils::copy<ExecSpace>(deviceMesh, hostMesh);
-    TestApp.saveVisualization(name + "_orig", hostMesh);
-
-    // _elvira_mir_start
-    namespace views = axom::bump::views;
-    // Make views.
-    auto coordsetView = views::make_uniform_coordset<2>::view(deviceMesh["coordsets/coords"]);
-    auto topologyView = views::make_uniform_topology<2>::view(deviceMesh["topologies/mesh"]);
-    using CoordsetView = decltype(coordsetView);
-    using TopologyView = decltype(topologyView);
-    using IndexingPolicy = typename TopologyView::IndexingPolicy;
-
-    conduit::Node deviceMIRMesh;
-    if(mattype == "unibuffer")
+    for(int dom = 0; dom < nDomains; dom++)
     {
-      auto matsetView =
-        views::make_unibuffer_matset<int, float, 3>::view(deviceMesh["matsets/mat"]);
-      using MatsetView = decltype(matsetView);
+      const std::string domainName = axom::fmt::format("domain_{:07}", dom);
+      conduit::Node &hostDomain = (nDomains > 1) ? hostMesh[domainName] : hostMesh;
 
-      using MIR = axom::mir::ElviraAlgorithm<ExecSpace, IndexingPolicy, CoordsetView, MatsetView>;
-      MIR m(topologyView, coordsetView, matsetView);
-      conduit::Node options;
-      options["matset"] = "mat";
-      options["plane"] = 1;
-      options["pointmesh"] = pointMesh ? 1 : 0;
-
-      if(selectedZones)
-      {
-        selectZones(options);
-      }
-      m.execute(deviceMesh, options, deviceMIRMesh);
+      initialize(type, mattype, hostDomain);
+      TestApp.saveVisualization(name + "_orig", hostDomain);
     }
-    // _elvira_mir_end
+    utils::copy<ExecSpace>(deviceMesh, hostMesh);
 
-    // device->host
-    conduit::Node hostMIRMesh;
-    utils::copy<seq_exec>(hostMIRMesh, deviceMIRMesh);
+    // Do MIR on all domains.
+    for(int dom = 0; dom < nDomains; dom++)
+    {
+      const std::string domainName = axom::fmt::format("domain_{:07}", dom);
+      conduit::Node &deviceDomain = (nDomains > 1) ? deviceMesh[domainName] : deviceMesh;
 
-    TestApp.saveVisualization(name, hostMIRMesh);
+      // _elvira_mir_start
+      namespace views = axom::bump::views;
+      // Make views.
+      auto coordsetView = views::make_uniform_coordset<2>::view(deviceDomain["coordsets/coords"]);
+      auto topologyView = views::make_uniform_topology<2>::view(deviceDomain["topologies/mesh"]);
+      using CoordsetView = decltype(coordsetView);
+      using TopologyView = decltype(topologyView);
+      using IndexingPolicy = typename TopologyView::IndexingPolicy;
 
-    // Handle baseline comparison.
-    constexpr double tolerance = 2.6e-06;
-    EXPECT_TRUE(TestApp.test<ExecSpace>(name, hostMIRMesh, tolerance));
+      conduit::Node deviceMIRMesh;
+      if(mattype == "unibuffer")
+      {
+        auto matsetView =
+          views::make_unibuffer_matset<int, float, 3>::view(deviceDomain["matsets/mat"]);
+        using MatsetView = decltype(matsetView);
+
+        using MIR = axom::mir::ElviraAlgorithm<ExecSpace, IndexingPolicy, CoordsetView, MatsetView>;
+        MIR m(topologyView, coordsetView, matsetView);
+        conduit::Node options;
+        options["matset"] = "mat";
+        options["plane"] = 1;
+        options["pointmesh"] = pointMesh ? 1 : 0;
+
+        if(selectedZones)
+        {
+          selectZones(options);
+        }
+        m.execute(deviceDomain, options, deviceMIRMesh);
+      }
+      // _elvira_mir_end
+
+      // device->host
+      conduit::Node hostMIRMesh;
+      utils::copy<seq_exec>(hostMIRMesh, deviceMIRMesh);
+
+      TestApp.saveVisualization(name, hostMIRMesh);
+
+      // Handle baseline comparison.
+      constexpr double tolerance = 2.6e-06;
+      EXPECT_TRUE(TestApp.test<ExecSpace>(name, hostMIRMesh, tolerance));
+    }
   }
 
   /// Function to run a simple kernel. This is a workaround for HIP tests, which
@@ -135,6 +149,14 @@ TEST(mir_elvira, elvira_uniform_unibuffer_seq)
                                    "elvira_uniform_unibuffer",
                                    selectZones,
                                    pointMesh);
+  // Run 2 domain example
+  const int nDomains = 2;
+  braid2d_mat_test<seq_exec>::test("uniform",
+                                   "unibuffer",
+                                   "elvira_uniform_unibuffer",
+                                   selectZones,
+                                   pointMesh,
+                                   nDomains);
 }
 
 TEST(mir_elvira, elvira_uniform_unibuffer_sel_seq)
@@ -184,6 +206,14 @@ TEST(mir_elvira, elvira_uniform_unibuffer_omp)
                                    "elvira_uniform_unibuffer",
                                    selectZones,
                                    pointMesh);
+  // Run 2 domain example
+  const int nDomains = 2;
+  braid2d_mat_test<omp_exec>::test("uniform",
+                                   "unibuffer",
+                                   "elvira_uniform_unibuffer",
+                                   selectZones,
+                                   pointMesh,
+                                   nDomains);
 }
 
 TEST(mir_elvira, elvira_uniform_unibuffer_sel_omp)
@@ -234,6 +264,14 @@ TEST(mir_elvira, elvira_uniform_unibuffer_cuda)
                                     "elvira_uniform_unibuffer",
                                     selectZones,
                                     pointMesh);
+  // Run 2 domain example
+  const int nDomains = 2;
+  braid2d_mat_test<cuda_exec>::test("uniform",
+                                    "unibuffer",
+                                    "elvira_uniform_unibuffer",
+                                    selectZones,
+                                    pointMesh,
+                                    nDomains);
 }
 
 TEST(mir_elvira, elvira_uniform_unibuffer_sel_cuda)
@@ -284,6 +322,14 @@ TEST(mir_elvira, elvira_uniform_unibuffer_hip)
                                    "elvira_uniform_unibuffer",
                                    selectZones,
                                    pointMesh);
+  // Run 2 domain example
+  const int nDomains = 2;
+  braid2d_mat_test<hip_exec>::test("uniform",
+                                   "unibuffer",
+                                   "elvira_uniform_unibuffer",
+                                   selectZones,
+                                   pointMesh,
+                                   nDomains);
 }
 
 TEST(mir_elvira, elvira_uniform_unibuffer_sel_hip)

--- a/src/axom/mir/tests/mir_equiz2d.cpp
+++ b/src/axom/mir/tests/mir_equiz2d.cpp
@@ -50,53 +50,67 @@ TEST(mir_equiz, materialinformation)
 
 //------------------------------------------------------------------------------
 template <typename ExecSpace>
-void braid2d_mat_test(const std::string &type, const std::string &mattype, const std::string &name)
+void braid2d_mat_test(const std::string &type, const std::string &mattype, const std::string &name, int nDomains = 1)
 {
   axom::StackArray<axom::IndexType, 2> dims {10, 10};
   axom::StackArray<axom::IndexType, 2> zoneDims {dims[0] - 1, dims[1] - 1};
 
-  // Create the data
+  // Create the data (make 1+ domains of the same thing)
   conduit::Node hostMesh, deviceMesh;
-  axom::blueprint::testing::data::braid(type, dims, hostMesh);
-  axom::blueprint::testing::data::make_matset(mattype, "mesh", zoneDims, hostMesh);
-  utils::copy<ExecSpace>(deviceMesh, hostMesh);
-  TestApp.saveVisualization(name + "_orig", hostMesh);
-
-  // Make views.
-  auto coordsetView = views::make_uniform_coordset<2>::view(deviceMesh["coordsets/coords"]);
-  auto topologyView = views::make_uniform_topology<2>::view(deviceMesh["topologies/mesh"]);
-  using CoordsetView = decltype(coordsetView);
-  using TopologyView = decltype(topologyView);
-
-  conduit::Node deviceMIRMesh;
-  if(mattype == "unibuffer")
+  for(int dom = 0; dom < nDomains; dom++)
   {
-    // clang-format off
-    using MatsetView = views::UnibufferMaterialView<int, float, 3>;
-    MatsetView matsetView;
-    matsetView.set(utils::make_array_view<int>(deviceMesh["matsets/mat/material_ids"]),
-                   utils::make_array_view<float>(deviceMesh["matsets/mat/volume_fractions"]),
-                   utils::make_array_view<int>(deviceMesh["matsets/mat/sizes"]),
-                   utils::make_array_view<int>(deviceMesh["matsets/mat/offsets"]),
-                   utils::make_array_view<int>(deviceMesh["matsets/mat/indices"]));
-    // clang-format on
+    const std::string domainName = axom::fmt::format("domain_{:07}", dom);
+    conduit::Node &hostDomain = (nDomains > 1) ? hostMesh[domainName] : hostMesh;
 
-    using MIR = axom::mir::EquiZAlgorithm<ExecSpace, TopologyView, CoordsetView, MatsetView>;
-    MIR m(topologyView, coordsetView, matsetView);
-    conduit::Node options;
-    options["matset"] = "mat";
-    m.execute(deviceMesh, options, deviceMIRMesh);
+    axom::blueprint::testing::data::braid(type, dims, hostDomain);
+    axom::blueprint::testing::data::make_matset(mattype, "mesh", zoneDims, hostDomain);
+    TestApp.saveVisualization(name + "_orig", hostDomain);
   }
 
-  // device->host
-  conduit::Node hostMIRMesh;
-  utils::copy<seq_exec>(hostMIRMesh, deviceMIRMesh);
+  // host->device
+  utils::copy<ExecSpace>(deviceMesh, hostMesh);
 
-  TestApp.saveVisualization(name, hostMIRMesh);
+  for(int dom = 0; dom < nDomains; dom++)
+  {
+    const std::string domainName = axom::fmt::format("domain_{:07}", dom);
+    conduit::Node &deviceDomain = (nDomains > 1) ? deviceMesh[domainName] : deviceMesh;
 
-  // Handle baseline comparison.
-  constexpr double tolerance = 2.6e-06;
-  EXPECT_TRUE(TestApp.test<ExecSpace>(name, hostMIRMesh, tolerance));
+    // Make views.
+    auto coordsetView = views::make_uniform_coordset<2>::view(deviceDomain["coordsets/coords"]);
+    auto topologyView = views::make_uniform_topology<2>::view(deviceDomain["topologies/mesh"]);
+    using CoordsetView = decltype(coordsetView);
+    using TopologyView = decltype(topologyView);
+
+    conduit::Node deviceMIRDomain;
+    if(mattype == "unibuffer")
+    {
+      // clang-format off
+      using MatsetView = views::UnibufferMaterialView<int, float, 3>;
+      MatsetView matsetView;
+      matsetView.set(utils::make_array_view<int>(deviceDomain["matsets/mat/material_ids"]),
+                     utils::make_array_view<float>(deviceDomain["matsets/mat/volume_fractions"]),
+                     utils::make_array_view<int>(deviceDomain["matsets/mat/sizes"]),
+                     utils::make_array_view<int>(deviceDomain["matsets/mat/offsets"]),
+                     utils::make_array_view<int>(deviceDomain["matsets/mat/indices"]));
+      // clang-format on
+
+      using MIR = axom::mir::EquiZAlgorithm<ExecSpace, TopologyView, CoordsetView, MatsetView>;
+      MIR m(topologyView, coordsetView, matsetView);
+      conduit::Node options;
+      options["matset"] = "mat";
+      m.execute(deviceDomain, options, deviceMIRDomain);
+    }
+
+    // device->host for the current domain
+    conduit::Node hostMIRDomain;
+    utils::copy<seq_exec>(hostMIRDomain, deviceMIRDomain);
+
+    TestApp.saveVisualization(name, hostMIRDomain);
+
+    // Handle baseline comparison.
+    constexpr double tolerance = 2.6e-06;
+    EXPECT_TRUE(TestApp.test<ExecSpace>(name, hostMIRDomain, tolerance));
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -104,6 +118,7 @@ TEST(mir_equiz, equiz_uniform_unibuffer_seq)
 {
   AXOM_ANNOTATE_SCOPE("equiz_uniform_unibuffer_seq");
   braid2d_mat_test<seq_exec>("uniform", "unibuffer", "equiz_uniform_unibuffer");
+  braid2d_mat_test<seq_exec>("uniform", "unibuffer", "equiz_uniform_unibuffer", 2);
 }
 
 #if defined(AXOM_USE_OPENMP)
@@ -111,6 +126,7 @@ TEST(mir_equiz, equiz_uniform_unibuffer_omp)
 {
   AXOM_ANNOTATE_SCOPE("equiz_uniform_unibuffer_omp");
   braid2d_mat_test<omp_exec>("uniform", "unibuffer", "equiz_uniform_unibuffer");
+  braid2d_mat_test<omp_exec>("uniform", "unibuffer", "equiz_uniform_unibuffer", 2);
 }
 #endif
 
@@ -119,6 +135,7 @@ TEST(mir_equiz, equiz_uniform_unibuffer_cuda)
 {
   AXOM_ANNOTATE_SCOPE("equiz_uniform_unibuffer_cuda");
   braid2d_mat_test<cuda_exec>("uniform", "unibuffer", "equiz_uniform_unibuffer");
+  braid2d_mat_test<cuda_exec>("uniform", "unibuffer", "equiz_uniform_unibuffer", 2);
 }
 #endif
 
@@ -127,6 +144,7 @@ TEST(mir_equiz, equiz_uniform_unibuffer_hip)
 {
   AXOM_ANNOTATE_SCOPE("equiz_uniform_unibuffer_hip");
   braid2d_mat_test<hip_exec>("uniform", "unibuffer", "equiz_uniform_unibuffer");
+  braid2d_mat_test<hip_exec>("uniform", "unibuffer", "equiz_uniform_unibuffer", 2);
 }
 #endif
 

--- a/src/axom/mir/tests/mir_equiz2d.cpp
+++ b/src/axom/mir/tests/mir_equiz2d.cpp
@@ -50,7 +50,10 @@ TEST(mir_equiz, materialinformation)
 
 //------------------------------------------------------------------------------
 template <typename ExecSpace>
-void braid2d_mat_test(const std::string &type, const std::string &mattype, const std::string &name, int nDomains = 1)
+void braid2d_mat_test(const std::string &type,
+                      const std::string &mattype,
+                      const std::string &name,
+                      int nDomains = 1)
 {
   axom::StackArray<axom::IndexType, 2> dims {10, 10};
   axom::StackArray<axom::IndexType, 2> zoneDims {dims[0] - 1, dims[1] - 1};


### PR DESCRIPTION
Early in MIR development, it was coded to iterate over multiple domains and perform MIR on each domain. The code was then pared back to operate on a single domain, with data provided using various topology, coordset, and matset views. This was done to limit the Blueprint types on which the algorithm needs to operate in order to generate smaller code.

This PR removes a vestige of domain iteration from `MIRAlgorithm` and changes comments to indicate that data are passed one domain at a time.

* Added multidomain testing for MIR
* Fixed an issue arising from domain prefix in Conduit object paths 