### PR TITLE
FlatMap: add batched insertion interface

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -41,8 +41,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - 2D and 3D implementations for `axom::for_all` were added.
 - Adds `axom::FlatMapView`, a helper class associated with `axom::FlatMap` to support queries from
   within a GPU kernel.
-- Adds an `axom::FlatMap::create()` method to support constructing a hash map over a batch of keys
-  and values on the GPU or with OpenMP.
+- Adds `axom::FlatMap::create<ExecSpace>()` and `axom::FlatMap::insert<ExecSpace>()` to support
+  constructing or inserting a hash map over a batch of keys and values on the GPU or with OpenMP.
 - Adds support for custom allocators to `axom::FlatMap`.
 - Primal: Adds ability to perform sample-based shaping on tetrahedral shapes.
 - Improves efficiency of volume fraction computation from quadrature samples during sample-based shaping.
@@ -75,6 +75,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Klee: Moves source files related to IO into a new `io` subdirectory in the Klee component
 - Primal: Consolidates construction logic for `BezierCurve`, `BezierPatch`, `KnotVector`,
   `NURBSCurve` and `NURBSPatch` classes and add overloads from `axom::ArrayView`
+- Core: Updates behavior of `FlatMap::reserve()` to only trigger a rehash if maximum load factor
+  would be exceeded.
 
 ###  Fixed
 - Core: prevent incorrect instantiations of `axom::Array` from a host-only compile, when Axom is compiled
@@ -86,6 +88,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Spin: Fixes undefined behavior in UniformGrid construction associated with invalid geometry bounding boxes
 - Core: Fixes undefined behavior in MapCollection when searching empty collections
 - Core: Fixes some edge cases in the `joinPath` file utility
+- Core: Fixes `FlatMap::erase()` to update reported size.
+- Core: Fixes `FlatMap::rehash()` when allocated in device-only memory.
 
 ###  Deprecated
 - Primal: Deprecates `Triangle::checkInTriangle(pt)`. Use `Triangle::contains(pt)` instead.

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -605,6 +605,28 @@ public:
     }
     else
     {
+      // TODO: replace this with a device-aware rehash method
+#if defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA)
+      if constexpr(std::is_trivially_copyable_v<KeyValuePair>)
+      {
+        // If the FlatMap is constructed in device-only memory, we need to copy
+        // the FlatMap to the host first.
+        MemorySpace space = detail::getAllocatorSpace(m_allocator.getID());
+        FlatMap host_map;
+        if(space == MemorySpace::Device)
+        {
+          int host_allocator_id = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+          // Rehash on the host.
+          host_map = FlatMap(*this, axom::Allocator {host_allocator_id});
+          host_map.rehash(count);
+
+          // Copy back to original map.
+          FlatMap rehashed_device(host_map, m_allocator);
+          this->swap(rehashed_device);
+          return;
+        }
+      }
+#endif
       FlatMap rehashed(m_size,
                        std::make_move_iterator(begin()),
                        std::make_move_iterator(end()),

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -620,7 +620,13 @@ public:
    *
    * \param count the number of elements to fit without a rehash
    */
-  void reserve(IndexType count) { rehash(count); }
+  void reserve(IndexType count)
+  {
+    if(count >= max_load_factor() * bucket_count())
+    {
+      rehash(count);
+    }
+  }
 
   /*!
    * \brief Returns a read-only view of the FlatMap.

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -428,11 +428,16 @@ public:
   /*!
    * \brief Inserts a range of key-value pairs into the FlatMap.
    *
-   *  If the key already exists in the FlatMap, insertion is skipped.
-   *  Otherwise, the key-value mapping is inserted into the FlatMap.
+   *  If a key in the range already exists, assigns the value to the existing
+   *  key in the FlatMap. Otherwise, a new key-value pair is inserted into the
+   *  FlatMap.
    *
    * \param [in] first the beginning of the range of pairs
    * \param [in] last the end of the range of pairs
+   *
+   * \note If duplicate keys are present in the range, the key which appears
+   *  later in the range is updated or inserted. This is equivalent to a
+   *  sequential for-loop of insertions over the input range.
    */
   template <typename InputIt>
   void insert(InputIt first, InputIt last);
@@ -440,8 +445,9 @@ public:
   /*!
    * \brief Inserts a range of key-value pairs into the FlatMap.
    *
-   *  If the key already exists in the FlatMap, insertion is skipped.
-   *  Otherwise, the key-value mapping is inserted into the FlatMap.
+   *  If a key in the range already exists, assigns the value to the existing
+   *  key in the FlatMap. Otherwise, a new key-value pair is inserted into the
+   *  FlatMap.
    *
    * \param [in] first the beginning of the range of pairs
    * \param [in] last the end of the range of pairs
@@ -451,6 +457,10 @@ public:
    *
    * \pre InputIt is a random-access iterator
    * \pre allocator is accessible from ExecSpace
+   *
+   * \note If duplicate keys are present in the range, the key which appears
+   *  later in the range is updated or inserted. This is equivalent to a
+   *  sequential for-loop of insertions over the input range.
    */
   template <typename ExecSpace, typename InputIt>
   void insert(InputIt first, InputIt last);

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -897,6 +897,7 @@ auto FlatMap<KeyType, ValueType, Hash>::erase(const_iterator pos) -> iterator
   {
     m_loadCount--;
   }
+  m_size--;
   return ++iterator(this, pos.m_internalIdx);
 }
 

--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -438,6 +438,24 @@ public:
   void insert(InputIt first, InputIt last);
 
   /*!
+   * \brief Inserts a range of key-value pairs into the FlatMap.
+   *
+   *  If the key already exists in the FlatMap, insertion is skipped.
+   *  Otherwise, the key-value mapping is inserted into the FlatMap.
+   *
+   * \param [in] first the beginning of the range of pairs
+   * \param [in] last the end of the range of pairs
+   *
+   * \tparam ExecSpace the execution space in which to perform the batched
+   *                   construction
+   *
+   * \pre InputIt is a random-access iterator
+   * \pre allocator is accessible from ExecSpace
+   */
+  template <typename ExecSpace, typename InputIt>
+  void insert(InputIt first, InputIt last);
+
+  /*!
    * \brief Inserts a key-value pair into the FlatMap.
    *
    *  If the key already exists, assigns the value to the existing key in the

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -160,11 +160,16 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
   Array<IndexType> key_index_to_bucket_vec(num_elems, num_elems, this->m_allocator.getID());
   const auto key_index_to_bucket = key_index_to_bucket_vec.view();
 
+  axom::ReduceSum<ExecSpace, IndexType> total_overwrites(0);
+
   for_all<ExecSpace>(
     num_elems,
     AXOM_LAMBDA(IndexType idx) {
+      // Construct pair.
+      KeyValuePair kv_pair {*(kv_begin + idx)};
+
       // Hash keys.
-      auto hash = Hash {}(kv_begin[idx].first);
+      auto hash = Hash {}(kv_pair.first);
 
       // We use the k MSBs of the hash as the initial group probe point,
       // where ngroups = 2^k.
@@ -191,8 +196,15 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
             meta_group[curr_group].visitHashOrEmptyBucket(hash_8, [&](int matching_slot) {
               IndexType bucket_index = curr_group * GroupBucket::Size + matching_slot;
 
-              if(kv_begin[key_index_dedup[bucket_index]].first == kv_begin[idx].first)
+              if(buckets[bucket_index].get().first == kv_pair.first)
               {
+                if(key_index_dedup[bucket_index] == -1)
+                {
+                  // The k-v pair matches an already-existing pair in the map.
+                  // Keep track of the number of overwrites so that we don't
+                  // double-count them when incrementing the size.
+                  total_overwrites += 1;
+                }
                 // Highest-indexed kv pair wins.
                 axom::atomicMax<ExecSpace>(&key_index_dedup[bucket_index], idx);
                 key_index_to_bucket[idx] = bucket_index;
@@ -212,9 +224,13 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
               // Got to end of probe sequence without a duplicate.
               // Update empty bucket index.
               empty_bucket_index = curr_group * GroupBucket::Size + empty_slot_index;
-              meta_group[curr_group].template setBucket<true>(empty_slot_index, hash_8);
               key_index_dedup[empty_bucket_index] = idx;
               key_index_to_bucket[idx] = empty_bucket_index;
+
+              // Insert initial element, this will be updated with the value of
+              // the "winning" key-value pair.
+              meta_group[curr_group].template setBucket<true>(empty_slot_index, hash_8);
+              new(&buckets[empty_bucket_index]) KeyValuePair(kv_pair);
             }
           }
           // Unlock group once we're done.
@@ -259,14 +275,14 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
         new(&key_dst) KeyType {kv_begin[kv_idx].first};
         new(&value_dst) ValueType {kv_begin[kv_idx].second};
 #else
-        new(&buckets[bucket_idx]) KeyValuePair(kv_begin[kv_idx]);
+        new(&buckets[bucket_idx]) KeyValuePair(*(kv_begin + kv_idx));
 #endif
         total_inserts += 1;
       }
     });
 
-  this->m_size += total_inserts.get();
-  this->m_loadCount += total_inserts.get();
+  this->m_size += total_inserts.get() - total_overwrites.get();
+  this->m_loadCount += total_inserts.get() - total_overwrites.get();
 }
 
 }  // namespace axom

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -86,8 +86,6 @@ public:
    */
   AXOM_HOST_DEVICE value_type operator*() const { return {*m_keyIter, *m_valueIter}; }
 
-  AXOM_HOST_DEVICE value_type operator[](IndexType idx) const { return *(*this + idx); }
-
 protected:
   /** Implementation of advance() as required by IteratorBase */
   AXOM_HOST_DEVICE void advance(IndexType n)
@@ -309,8 +307,8 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
         // individually.
         KeyType& key_dst = const_cast<KeyType&>(buckets[bucket_idx].get().first);
         ValueType& value_dst = buckets[bucket_idx].get().second;
-        new(&key_dst) KeyType {kv_begin[kv_idx].first};
-        new(&value_dst) ValueType {kv_begin[kv_idx].second};
+        new(&key_dst) KeyType {(*(kv_begin + kv_idx)).first};
+        new(&value_dst) ValueType {(*(kv_begin + kv_idx)).second};
 #else
         new(&buckets[bucket_idx]) KeyValuePair(*(kv_begin + kv_idx));
 #endif

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -52,6 +52,56 @@ struct SpinLock
   }
 };
 
+/*!
+ * \class KVPairIterator
+ * \brief Implements a zip-iterator concept for a key-value pair.
+ */
+template <typename KeyType, typename ValueType>
+class KVPairIterator : public IteratorBase<KVPairIterator<KeyType, ValueType>, IndexType>
+{
+private:
+  using BaseType = IteratorBase<KVPairIterator<KeyType, ValueType>, IndexType>;
+  using KeyIterator = const KeyType*;
+  using ValueIterator = ValueType*;
+
+public:
+  // Iterator traits required to satisfy LegacyRandomAccessIterator concept
+  // before C++20
+  // See: https://en.cppreference.com/w/cpp/iterator/iterator_traits
+  using difference_type = IndexType;
+  using value_type = std::pair<const KeyType, ValueType>;
+  using reference = ValueType&;
+  using pointer = ValueType*;
+  using iterator_category = std::random_access_iterator_tag;
+
+  KVPairIterator() = default;
+
+  AXOM_HOST_DEVICE KVPairIterator(KeyIterator keyIter, ValueIterator valueIter)
+    : m_keyIter {keyIter}
+    , m_valueIter {valueIter}
+  { }
+
+  /**
+   * \brief Returns the current iterator value
+   */
+  AXOM_HOST_DEVICE value_type operator*() const { return {*m_keyIter, *m_valueIter}; }
+
+  AXOM_HOST_DEVICE value_type operator[](IndexType idx) const { return *(*this + idx); }
+
+protected:
+  /** Implementation of advance() as required by IteratorBase */
+  AXOM_HOST_DEVICE void advance(IndexType n)
+  {
+    BaseType::m_pos += n;
+    m_keyIter += n;
+    m_valueIter += n;
+  }
+
+private:
+  KeyIterator m_keyIter {nullptr};
+  ValueIterator m_valueIter {nullptr};
+};
+
 }  // namespace detail
 
 template <typename KeyType, typename ValueType, typename Hash>
@@ -63,42 +113,58 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
   assert(keys.size() == values.size());
 
   const IndexType num_elems = keys.size();
+  detail::KVPairIterator zip_iterator {keys.data(), values.data()};
 
   FlatMap new_map(allocator);
-  new_map.reserve(num_elems);
+  new_map.insert<ExecSpace>(zip_iterator, zip_iterator + num_elems);
+
+  return new_map;
+}
+
+template <typename KeyType, typename ValueType, typename Hash>
+template <typename ExecSpace, typename InputIt>
+void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
+{
+  static_assert(std::is_base_of<std::random_access_iterator_tag,
+                                typename std::iterator_traits<InputIt>::iterator_category>::value,
+                "InputIt must be a random-access iterator for batched construction");
 
   using HashResult = typename Hash::result_type;
   using GroupBucket = detail::flat_map::GroupBucket;
 
+  // Assume that all elements will be inserted into an empty slot.
+  IndexType num_elems = std::distance(kv_begin, kv_end);
+  this->reserve(this->size() + num_elems);
+
   // Grab some needed internal fields from the flat map.
   // We're going to be constructing metadata and the K-V pairs directly
   // in-place.
-  const int ngroups_pow_2 = new_map.m_numGroups2;
-  const auto meta_group = new_map.m_metadata.view();
-  const auto buckets = new_map.m_buckets.view();
+  const int ngroups_pow_2 = this->m_numGroups2;
+  const auto meta_group = this->m_metadata.view();
+  const auto buckets = this->m_buckets.view();
 
   // Construct an array of locks per-group. This guards metadata updates for
   // each insertion.
   const IndexType num_groups = 1 << ngroups_pow_2;
-  Array<detail::SpinLock> lock_vec(num_groups, num_groups, allocator.getID());
+  Array<detail::SpinLock> lock_vec(num_groups, num_groups, this->m_allocator.getID());
   const auto group_locks = lock_vec.view();
 
   // Map bucket slots to k-v pair indices. This is used to deduplicate pairs
   // with the same key value.
-  Array<IndexType> key_index_dedup_vec(0, 0, allocator.getID());
+  Array<IndexType> key_index_dedup_vec(0, 0, this->m_allocator.getID());
   key_index_dedup_vec.resize(num_groups * GroupBucket::Size, -1);
   const auto key_index_dedup = key_index_dedup_vec.view();
 
   // Map k-v pair indices to bucket slots. This is essentially the inverse of
   // the above mapping.
-  Array<IndexType> key_index_to_bucket_vec(num_elems, num_elems, allocator.getID());
+  Array<IndexType> key_index_to_bucket_vec(num_elems, num_elems, this->m_allocator.getID());
   const auto key_index_to_bucket = key_index_to_bucket_vec.view();
 
   for_all<ExecSpace>(
     num_elems,
     AXOM_LAMBDA(IndexType idx) {
       // Hash keys.
-      auto hash = Hash {}(keys[idx]);
+      auto hash = Hash {}(kv_begin[idx].first);
 
       // We use the k MSBs of the hash as the initial group probe point,
       // where ngroups = 2^k.
@@ -125,7 +191,7 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
             meta_group[curr_group].visitHashOrEmptyBucket(hash_8, [&](int matching_slot) {
               IndexType bucket_index = curr_group * GroupBucket::Size + matching_slot;
 
-              if(keys[key_index_dedup[bucket_index]] == keys[idx])
+              if(kv_begin[key_index_dedup[bucket_index]].first == kv_begin[idx].first)
               {
                 // Highest-indexed kv pair wins.
                 axom::atomicMax<ExecSpace>(&key_index_dedup[bucket_index], idx);
@@ -190,19 +256,17 @@ auto FlatMap<KeyType, ValueType, Hash>::create(ArrayView<KeyType> keys,
         // individually.
         KeyType& key_dst = const_cast<KeyType&>(buckets[bucket_idx].get().first);
         ValueType& value_dst = buckets[bucket_idx].get().second;
-        new(&key_dst) KeyType {keys[kv_idx]};
-        new(&value_dst) ValueType {values[kv_idx]};
+        new(&key_dst) KeyType {kv_begin[kv_idx].first};
+        new(&value_dst) ValueType {kv_begin[kv_idx].second};
 #else
-        new(&buckets[bucket_idx]) KeyValuePair(keys[kv_idx], values[kv_idx]);
+        new(&buckets[bucket_idx]) KeyValuePair(kv_begin[kv_idx]);
 #endif
         total_inserts += 1;
       }
     });
 
-  new_map.m_size = total_inserts.get();
-  new_map.m_loadCount = total_inserts.get();
-
-  return new_map;
+  this->m_size += total_inserts.get();
+  this->m_loadCount += total_inserts.get();
 }
 
 }  // namespace axom

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -132,8 +132,16 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
   using HashResult = typename Hash::result_type;
   using GroupBucket = detail::flat_map::GroupBucket;
 
-  // Assume that all elements will be inserted into an empty slot.
   IndexType num_elems = std::distance(kv_begin, kv_end);
+
+  // Every probing sequence within a flat map is free of gaps if no erasure
+  // operations have taken place.
+  // For now, just assume this to be the case if the map is empty or if a rehash
+  // has to take place to accomodate the new elements.
+  bool is_gap_free =
+    (this->size() == 0 || (num_elems + this->size() >= max_load_factor() * bucket_count()));
+
+  // Assume that all elements will be inserted into an empty slot.
   this->reserve(this->size() + num_elems);
 
   // Grab some needed internal fields from the flat map.
@@ -192,28 +200,22 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
         {
           // Every bucket visit - check prior filled buckets for duplicate
           // keys.
-          int empty_slot_index =
-            meta_group[curr_group].visitHashOrEmptyBucket(hash_8, [&](int matching_slot) {
-              IndexType bucket_index = curr_group * GroupBucket::Size + matching_slot;
+          meta_group[curr_group].visitHashBucket(hash_8, [&](int matching_slot) -> bool {
+            IndexType bucket_index = curr_group * GroupBucket::Size + matching_slot;
 
-              if(buckets[bucket_index].get().first == kv_pair.first)
-              {
-                if(key_index_dedup[bucket_index] == -1)
-                {
-                  // The k-v pair matches an already-existing pair in the map.
-                  // Keep track of the number of overwrites so that we don't
-                  // double-count them when incrementing the size.
-                  total_overwrites += 1;
-                }
-                // Highest-indexed kv pair wins.
-                axom::atomicMax<ExecSpace>(&key_index_dedup[bucket_index], idx);
-                key_index_to_bucket[idx] = bucket_index;
-                duplicate_bucket_index = bucket_index;
-              }
-            });
+            if(buckets[bucket_index].get().first == kv_pair.first)
+            {
+              duplicate_bucket_index = bucket_index;
+              return false;  // Don't need to search other buckets.
+            }
+            return true;
+          });
+          int empty_slot_index = meta_group[curr_group].getEmptyBucket();
 
-          if(duplicate_bucket_index == -1)
+          if(duplicate_bucket_index == -1 && empty_bucket_index == -1)
           {
+            // Default probing behavior: no duplicate found yet, and no empty
+            // bucket found prior.
             if(empty_slot_index == GroupBucket::InvalidSlot)
             {
               // Group is full. Set overflow bit for the group.
@@ -221,8 +223,7 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
             }
             else
             {
-              // Got to end of probe sequence without a duplicate.
-              // Update empty bucket index.
+              // Update empty bucket index with first empty slot we encounter.
               empty_bucket_index = curr_group * GroupBucket::Size + empty_slot_index;
               key_index_dedup[empty_bucket_index] = idx;
               key_index_to_bucket[idx] = empty_bucket_index;
@@ -233,14 +234,50 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
               new(&buckets[empty_bucket_index]) KeyValuePair(kv_pair);
             }
           }
+          else if(duplicate_bucket_index != -1)
+          {
+            // Found a duplicate bucket.
+            if(!is_gap_free && empty_bucket_index != -1)
+            {
+              // We've already encountered an empty bucket earlier to place a
+              // k-v pair. This may occur if a probing sequence contains gaps
+              // (insertions followed by erasures).
+              //
+              // Just erase this element.
+              total_overwrites += 1;
+
+              int slot_index = duplicate_bucket_index - curr_group * GroupBucket::Size;
+              buckets[duplicate_bucket_index].get().~KeyValuePair();
+              meta_group[curr_group].clearBucket(slot_index);
+            }
+            else
+            {
+              if(key_index_dedup[duplicate_bucket_index] == -1)
+              {
+                // The k-v pair matches an already-existing pair in the map.
+                // Keep track of the number of overwrites so that we don't
+                // double-count them when incrementing the size.
+                total_overwrites += 1;
+              }
+              // Highest-indexed kv pair wins.
+              axom::atomicMax<ExecSpace>(&key_index_dedup[duplicate_bucket_index], idx);
+              key_index_to_bucket[idx] = duplicate_bucket_index;
+            }
+          }
           // Unlock group once we're done.
           group_locks[curr_group].unlock();
 
-          if(duplicate_bucket_index != -1 || empty_bucket_index != -1)
+          if(duplicate_bucket_index != -1)
           {
-            // We've found an empty slot or a duplicate key to place the
-            // value at. Empty slots should only occur at the end of the
-            // probe sequence, since we're only inserting.
+            // We've found a duplicate key to overwrite.
+            break;
+          }
+          else if(empty_bucket_index != -1 &&
+                  (is_gap_free || !meta_group[curr_group].getMaybeOverflowed(hash_8)))
+          {
+            // If we're inserting into a gap-free map, empty bucket signals the
+            // end of the probing sequence.
+            // Otherwise, we need to check the overflow mask to continue probing.
             break;
           }
           else

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -52,6 +52,23 @@ struct SpinLock
   }
 };
 
+#if defined(AXOM_USE_CUDA)
+template <typename KeyType, typename ValueType>
+AXOM_DEVICE void constructPairInPlace(std::pair<const KeyType, ValueType>& pair,
+                                      KeyType key,
+                                      ValueType value)
+{
+  // HACK: std::pair constructor is not host-device annotated, but CUDA
+  // requires passing in --expt-relaxed-constexpr for it to work.
+  // Instead of requiring this flag, construct each member of the pair
+  // individually.
+  KeyType& key_dst = const_cast<KeyType&>(pair.first);
+  ValueType& value_dst = pair.second;
+  new(&key_dst) KeyType {key};
+  new(&value_dst) ValueType {value};
+}
+#endif
+
 /*!
  * \class KVPairIterator
  * \brief Implements a zip-iterator concept for a key-value pair.
@@ -84,7 +101,16 @@ public:
   /**
    * \brief Returns the current iterator value
    */
-  AXOM_HOST_DEVICE value_type operator*() const { return {*m_keyIter, *m_valueIter}; }
+  AXOM_HOST_DEVICE value_type operator*() const
+  {
+#if defined(__CUDA_ARCH__)
+    value_type kv_pair;
+    constructPairInPlace(kv_pair, *m_keyIter, *m_valueIter);
+    return kv_pair;
+#else
+    return {*m_keyIter, *m_valueIter};
+#endif
+  }
 
 protected:
   /** Implementation of advance() as required by IteratorBase */
@@ -171,11 +197,11 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
   for_all<ExecSpace>(
     num_elems,
     AXOM_LAMBDA(IndexType idx) {
-      // Construct pair.
-      KeyValuePair kv_pair {*(kv_begin + idx)};
+      // Construct key.
+      KeyType key = (*(kv_begin + idx)).first;
 
       // Hash keys.
-      auto hash = Hash {}(kv_pair.first);
+      auto hash = Hash {}(key);
 
       // We use the k MSBs of the hash as the initial group probe point,
       // where ngroups = 2^k.
@@ -201,7 +227,7 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
           meta_group[curr_group].visitHashBucket(hash_8, [&](int matching_slot) -> bool {
             IndexType bucket_index = curr_group * GroupBucket::Size + matching_slot;
 
-            if(buckets[bucket_index].get().first == kv_pair.first)
+            if(buckets[bucket_index].get().first == key)
             {
               duplicate_bucket_index = bucket_index;
               return false;  // Don't need to search other buckets.
@@ -229,7 +255,13 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
               // Insert initial element, this will be updated with the value of
               // the "winning" key-value pair.
               meta_group[curr_group].template setBucket<true>(empty_slot_index, hash_8);
-              new(&buckets[empty_bucket_index]) KeyValuePair(kv_pair);
+#if defined(__CUDA_ARCH__)
+              detail::constructPairInPlace(buckets[empty_bucket_index].get(),
+                                           key,
+                                           (*(kv_begin + idx)).second);
+#else
+              new(&buckets[empty_bucket_index]) KeyValuePair(*(kv_begin + idx));
+#endif
             }
           }
           else if(duplicate_bucket_index != -1)
@@ -301,14 +333,9 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
       if(kv_idx == winning_idx)
       {
 #if defined(__CUDA_ARCH__)
-        // HACK: std::pair constructor is not host-device annotated, but CUDA
-        // requires passing in --expt-relaxed-constexpr for it to work.
-        // Instead of requiring this flag, construct each member of the pair
-        // individually.
-        KeyType& key_dst = const_cast<KeyType&>(buckets[bucket_idx].get().first);
-        ValueType& value_dst = buckets[bucket_idx].get().second;
-        new(&key_dst) KeyType {(*(kv_begin + kv_idx)).first};
-        new(&value_dst) ValueType {(*(kv_begin + kv_idx)).second};
+        detail::constructPairInPlace(buckets[bucket_idx].get(),
+                                     (*(kv_begin + kv_idx)).first,
+                                     (*(kv_begin + kv_idx)).second);
 #else
         new(&buckets[bucket_idx]) KeyValuePair(*(kv_begin + kv_idx));
 #endif

--- a/src/axom/core/detail/FlatTable.hpp
+++ b/src/axom/core/detail/FlatTable.hpp
@@ -227,7 +227,7 @@ struct GroupBucket
     }
   }
 
-  void clearBucket(int index) { metadata.buckets[index] = Empty; }
+  AXOM_HOST_DEVICE void clearBucket(int index) { metadata.buckets[index] = Empty; }
 
   template <bool Atomic = false>
   AXOM_HOST_DEVICE void setOverflow(std::uint8_t hash)

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -519,6 +519,7 @@ AXOM_TYPED_TEST(core_flatmap, insert_then_delete)
   EXPECT_EQ(test_map.size(), NUM_INSERTS);
   EXPECT_GE(test_map.bucket_count(), NUM_INSERTS);
 
+  int num_deletions = 0;
   for(int i = 0; i < NUM_INSERTS; i += 3)
   {
     auto key = this->getKey(i);
@@ -531,7 +532,10 @@ AXOM_TYPED_TEST(core_flatmap, insert_then_delete)
     auto deleted_iterator = test_map.erase(iterator_to_remove);
 
     EXPECT_EQ(deleted_iterator, one_after_elem);
+    num_deletions++;
   }
+
+  EXPECT_EQ(test_map.size(), NUM_INSERTS - num_deletions);
 
   // Check consistency of values.
   for(int i = 0; i < NUM_INSERTS; i++)

--- a/src/axom/core/tests/core_flatmap_for_all.hpp
+++ b/src/axom/core/tests/core_flatmap_for_all.hpp
@@ -326,6 +326,86 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_with_dups)
   }
 }
 
+AXOM_TYPED_TEST(core_flatmap_forall, insert_multiple_batch_with_dups)
+{
+  using MapType = typename TestFixture::MapType;
+  using ExecSpace = typename TestFixture::ExecSpace;
+
+  const int NUM_ELEMS = 100;
+
+  axom::Array<int> keys_vec(NUM_ELEMS);
+  axom::Array<double> values_vec(NUM_ELEMS);
+  // Create batch of array elements
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 5.0);
+
+    keys_vec[i] = key;
+    values_vec[i] = value;
+  }
+
+  // Copy keys and values to GPU space.
+  axom::Array<int> keys_gpu(keys_vec, this->getKernelAllocatorID());
+  axom::Array<double> values_gpu(values_vec, this->getKernelAllocatorID());
+
+  // Construct a flat map with the key-value pairs.
+  MapType test_map_gpu =
+    MapType::template create<ExecSpace>(keys_gpu,
+                                        values_gpu,
+                                        axom::Allocator {this->getKernelAllocatorID()});
+
+  axom::Array<std::pair<int, double>> second_batch_pairs(NUM_ELEMS);
+  // Add some duplicate key values through the batched interface.
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 7.0);
+
+    second_batch_pairs[i] = {key, value};
+  }
+  // Copy pairs to GPU space.
+  axom::Array<std::pair<int, double>> second_batch_gpu(second_batch_pairs,
+                                                       this->getKernelAllocatorID());
+
+  test_map_gpu.template insert<ExecSpace>(second_batch_gpu.data(),
+                                          second_batch_gpu.data() + NUM_ELEMS);
+
+  // Copy back flat map to host for testing.
+  MapType test_map(test_map_gpu, axom::Allocator {this->getHostAllocatorID()});
+
+  // Check contents on the host. Only one of the duplicate keys should remain.
+  EXPECT_EQ(NUM_ELEMS, test_map.size());
+
+  // Check that every element we inserted is in the map
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto expected_key = this->getKey(i);
+    auto expected_val1 = this->getValue(i * 10.0 + 5.0);
+    auto expected_val2 = this->getValue(i * 10.0 + 7.0);
+    EXPECT_EQ(1, test_map.count(expected_key));
+    // Second key-value pair in batch-order should overwrite first pair with
+    // same key.
+    EXPECT_EQ(expected_val2, test_map.at(expected_key));
+    EXPECT_NE(expected_val1, test_map.at(expected_key));
+  }
+
+  // Check that we only have one instance of every key in the map
+  axom::Array<int> dedup_keys(NUM_ELEMS);
+  for(auto &pair : test_map)
+  {
+    // Check that we haven't seen another K-V pair with the same key.
+    EXPECT_EQ(dedup_keys[pair.first], 0);
+    dedup_keys[pair.first]++;
+
+    // Check that we got the second KV pair, not the first.
+    auto expected_val1 = this->getValue(pair.first * 10.0 + 5.0);
+    auto expected_val2 = this->getValue(pair.first * 10.0 + 7.0);
+    EXPECT_EQ(expected_val2, pair.second);
+    EXPECT_NE(expected_val1, pair.second);
+  }
+}
+
 template <typename KeyType>
 struct ConstantHash
 {

--- a/src/axom/core/tests/core_flatmap_for_all.hpp
+++ b/src/axom/core/tests/core_flatmap_for_all.hpp
@@ -252,6 +252,70 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batched)
   }
 }
 
+AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_with_existing)
+{
+  using MapType = typename TestFixture::MapType;
+  using ExecSpace = typename TestFixture::ExecSpace;
+
+  const int NUM_ELEMS_INIT = 100;
+  const int NUM_ELEMS_INSERT = 100;
+  const int NUM_ELEMS = NUM_ELEMS_INIT + NUM_ELEMS_INSERT;
+
+  axom::Array<int> keys_vec(NUM_ELEMS_INIT);
+  axom::Array<double> values_vec(NUM_ELEMS_INIT);
+  // Create batch of array elements
+  for(int i = 0; i < NUM_ELEMS_INIT; i++)
+  {
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 5.0);
+
+    keys_vec[i] = key;
+    values_vec[i] = value;
+  }
+
+  // Copy keys and values to GPU space.
+  axom::Array<int> keys_gpu(keys_vec, this->getKernelAllocatorID());
+  axom::Array<double> values_gpu(values_vec, this->getKernelAllocatorID());
+
+  // Construct a flat map with the key-value pairs.
+  MapType test_map_gpu =
+    MapType::template create<ExecSpace>(keys_gpu,
+                                        values_gpu,
+                                        axom::Allocator {this->getKernelAllocatorID()});
+
+  // Create batch of pairs.
+  axom::Array<std::pair<int, double>> kv_insert_vec(NUM_ELEMS_INSERT);
+  for(int i = 0; i < NUM_ELEMS_INSERT; i++)
+  {
+    int offset_i = i + NUM_ELEMS_INIT;
+    auto key = this->getKey(offset_i);
+    auto value = this->getValue(offset_i * 10.0 + 5.0);
+
+    kv_insert_vec[i] = {key, value};
+  }
+
+  // Copy pairs to GPU space.
+  axom::Array<std::pair<int, double>> kv_insert_gpu(kv_insert_vec, this->getKernelAllocatorID());
+
+  // Insert pairs into existing flatmap.
+  test_map_gpu.insert(kv_insert_vec.begin(), kv_insert_vec.end());
+
+  // Copy back flat map to host for testing.
+  MapType test_map(test_map_gpu, axom::Allocator {this->getHostAllocatorID()});
+
+  // Check contents on the host
+  EXPECT_EQ(NUM_ELEMS, test_map.size());
+
+  // Check that every element we inserted is in the map
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto expected_key = this->getKey(i);
+    auto expected_val = this->getValue(i * 10.0 + 5.0);
+    EXPECT_EQ(1, test_map.count(expected_key));
+    EXPECT_EQ(expected_val, test_map.at(expected_key));
+  }
+}
+
 AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_with_dups)
 {
   using MapType = typename TestFixture::MapType;

--- a/src/axom/core/tests/core_flatmap_for_all.hpp
+++ b/src/axom/core/tests/core_flatmap_for_all.hpp
@@ -531,6 +531,7 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batch_with_gaps_and_dups)
 
   // Delete every third element.
   // This is intended to creates gaps in probing sequences.
+  int num_erases = 0;
   for(int i = 0; i < NUM_ELEMS / 3; i++)
   {
     int index = i * 3 + 2;
@@ -538,7 +539,10 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batch_with_gaps_and_dups)
 
     auto it = test_map.find(key);
     test_map.erase(it);
+    num_erases++;
   }
+
+  EXPECT_EQ(test_map.size(), NUM_ELEMS - num_erases);
 
   MapType test_map_gpu(test_map, axom::Allocator {this->getKernelAllocatorID()});
 

--- a/src/axom/core/tests/core_flatmap_for_all.hpp
+++ b/src/axom/core/tests/core_flatmap_for_all.hpp
@@ -62,24 +62,47 @@ public:
   }
 };
 
+/**
+ * Hash that returns the same value for all elements.
+ * Even with worst-case hash collision behavior, the FlatMap should
+ * nevertheless be correctly constructible and queryable.
+ */
+template <typename KeyType>
+struct ConstantHash
+{
+  using argument_type = KeyType;
+  using result_type = axom::IndexType;
+
+  AXOM_HOST_DEVICE axom::IndexType operator()(KeyType) const { return 0; }
+};
+
 using ViewTypes = ::testing::Types<
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP)
   FlatMapTestParams<axom::FlatMap<int, double>, axom::OMP_EXEC>,
+  FlatMapTestParams<axom::FlatMap<int, double, ConstantHash<int>>, axom::OMP_EXEC>,
 #endif
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
   FlatMapTestParams<axom::FlatMap<int, double>, axom::CUDA_EXEC<256>, axom::MemorySpace::Device>,
   FlatMapTestParams<axom::FlatMap<int, double>, axom::CUDA_EXEC<256>, axom::MemorySpace::Unified>,
   FlatMapTestParams<axom::FlatMap<int, double>, axom::CUDA_EXEC<256>, axom::MemorySpace::Pinned>,
+  FlatMapTestParams<axom::FlatMap<int, double, ConstantHash<int>>, axom::CUDA_EXEC<256>, axom::MemorySpace::Device>,
+  FlatMapTestParams<axom::FlatMap<int, double, ConstantHash<int>>, axom::CUDA_EXEC<256>, axom::MemorySpace::Unified>,
+  FlatMapTestParams<axom::FlatMap<int, double, ConstantHash<int>>, axom::CUDA_EXEC<256>, axom::MemorySpace::Pinned>,
 #endif
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
   FlatMapTestParams<axom::FlatMap<int, double>, axom::HIP_EXEC<256>, axom::MemorySpace::Device>,
   FlatMapTestParams<axom::FlatMap<int, double>, axom::HIP_EXEC<256>, axom::MemorySpace::Unified>,
   FlatMapTestParams<axom::FlatMap<int, double>, axom::HIP_EXEC<256>, axom::MemorySpace::Pinned>,
+  FlatMapTestParams<axom::FlatMap<int, double, ConstantHash<int>>, axom::HIP_EXEC<256>, axom::MemorySpace::Device>,
+  FlatMapTestParams<axom::FlatMap<int, double, ConstantHash<int>>, axom::HIP_EXEC<256>, axom::MemorySpace::Unified>,
+  FlatMapTestParams<axom::FlatMap<int, double, ConstantHash<int>>, axom::HIP_EXEC<256>, axom::MemorySpace::Pinned>,
 #endif
 #if defined(AXOM_USE_UMPIRE)
   FlatMapTestParams<axom::FlatMap<int, double>, axom::SEQ_EXEC, axom::MemorySpace::Host>,
+  FlatMapTestParams<axom::FlatMap<int, double, ConstantHash<int>>, axom::SEQ_EXEC, axom::MemorySpace::Host>,
 #endif
-  FlatMapTestParams<axom::FlatMap<int, double>, axom::SEQ_EXEC>>;
+  FlatMapTestParams<axom::FlatMap<int, double>, axom::SEQ_EXEC>,
+  FlatMapTestParams<axom::FlatMap<int, double, ConstantHash<int>>, axom::SEQ_EXEC>>;
 
 TYPED_TEST_SUITE(core_flatmap_forall, ViewTypes);
 
@@ -469,68 +492,6 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_multiple_batch_with_dups)
     auto expected_val2 = this->getValue(pair.first * 10.0 + 7.0);
     EXPECT_EQ(expected_val2, pair.second);
     EXPECT_NE(expected_val1, pair.second);
-  }
-}
-
-template <typename KeyType>
-struct ConstantHash
-{
-  using argument_type = KeyType;
-  using result_type = axom::IndexType;
-
-  AXOM_HOST_DEVICE axom::IndexType operator()(KeyType) const { return 0; }
-};
-
-/**
- * Test hash map with a hash that returns the same value for all elements.
- * Even with worst-case hash collision behavior, the FlatMap should
- * nevertheless be correctly constructible and queryable.
- */
-AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_constant_hash)
-{
-  using ExecSpace = typename TestFixture::ExecSpace;
-  using KeyType = typename TestFixture::KeyType;
-  using ValueType = typename TestFixture::ValueType;
-
-  using MapType = axom::FlatMap<KeyType, ValueType, ConstantHash<KeyType>>;
-
-  const int NUM_ELEMS = 100;
-
-  axom::Array<int> keys_vec(NUM_ELEMS);
-  axom::Array<double> values_vec(NUM_ELEMS);
-  // Create batch of array elements
-  for(int i = 0; i < NUM_ELEMS; i++)
-  {
-    auto key = this->getKey(i);
-    auto value = this->getValue(i * 10.0 + 5.0);
-
-    keys_vec[i] = key;
-    values_vec[i] = value;
-  }
-
-  // Copy keys and values to GPU space.
-  axom::Array<int> keys_gpu(keys_vec, this->getKernelAllocatorID());
-  axom::Array<double> values_gpu(values_vec, this->getKernelAllocatorID());
-
-  // Construct a flat map with the key-value pairs.
-  MapType test_map_gpu =
-    MapType::template create<ExecSpace>(keys_gpu,
-                                        values_gpu,
-                                        axom::Allocator {this->getKernelAllocatorID()});
-
-  // Copy back flat map to host for testing.
-  MapType test_map(test_map_gpu, axom::Allocator {this->getHostAllocatorID()});
-
-  // Check contents on the host
-  EXPECT_EQ(NUM_ELEMS, test_map.size());
-
-  // Check that every element we inserted is in the map
-  for(int i = 0; i < NUM_ELEMS; i++)
-  {
-    auto expected_key = this->getKey(i);
-    auto expected_val = this->getValue(i * 10.0 + 5.0);
-    EXPECT_EQ(1, test_map.count(expected_key));
-    EXPECT_EQ(expected_val, test_map.at(expected_key));
   }
 }
 

--- a/src/axom/core/tests/core_flatmap_for_all.hpp
+++ b/src/axom/core/tests/core_flatmap_for_all.hpp
@@ -12,6 +12,8 @@
 // gtest includes
 #include "gtest/gtest.h"
 
+#include <random>
+
 template <typename FlatMapType, typename ExecSpace, axom::MemorySpace SPACE = axom::MemorySpace::Dynamic>
 struct FlatMapTestParams
 {
@@ -529,5 +531,124 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_constant_hash)
     auto expected_val = this->getValue(i * 10.0 + 5.0);
     EXPECT_EQ(1, test_map.count(expected_key));
     EXPECT_EQ(expected_val, test_map.at(expected_key));
+  }
+}
+
+/**
+ * Rigorous test of FlatMap probing insert behavior.
+ * High level steps:
+ *  - Insert elements, along common probing path
+ *  - Delete a few of the elements on the same probing path
+ *  - Perform a batched insert, with duplicates.
+ */
+AXOM_TYPED_TEST(core_flatmap_forall, insert_batch_with_gaps_and_dups)
+{
+  using MapType = typename TestFixture::MapType;
+  using ExecSpace = typename TestFixture::ExecSpace;
+
+  const int NUM_ELEMS = 200;
+
+  // Allocate enough space to ensure rehashes don't eliminate probing sequence gaps.
+  MapType test_map(NUM_ELEMS * 4);
+
+  // Shuffle inserted elements.
+  std::vector<int> shuffled_indexes(NUM_ELEMS);
+  std::iota(shuffled_indexes.begin(), shuffled_indexes.end(), 0);
+  std::shuffle(shuffled_indexes.begin(),
+               shuffled_indexes.end(),
+               std::mt19937 {std::random_device {}()});
+
+  // Insert initial elements, in shuffled order.
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    int shuf_i = shuffled_indexes[i];
+    auto key = this->getKey(shuf_i);
+    auto value = this->getValue(shuf_i * 10.0 + 5.0);
+
+    test_map.emplace(key, value);
+  }
+
+  // Delete every third element.
+  // This is intended to creates gaps in probing sequences.
+  for(int i = 0; i < NUM_ELEMS / 3; i++)
+  {
+    int index = i * 3 + 2;
+    auto key = this->getKey(index);
+
+    auto it = test_map.find(key);
+    test_map.erase(it);
+  }
+
+  MapType test_map_gpu(test_map, axom::Allocator {this->getKernelAllocatorID()});
+
+  axom::Array<std::pair<int, double>> second_batch_pairs(NUM_ELEMS * 2);
+
+  // Add some duplicate key values through the batched interface.
+  std::shuffle(shuffled_indexes.begin(),
+               shuffled_indexes.end(),
+               std::mt19937 {std::random_device {}()});
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    int shuf_i = shuffled_indexes[i];
+    auto key = this->getKey(shuf_i);
+    auto value = this->getValue(shuf_i * 10.0 + 6.0);
+
+    second_batch_pairs[i] = {key, value};
+  }
+
+  // Add a second set of duplicates.
+  // Since these ones are at the end of the sequence, they should be the ones
+  // actually written into the map.
+  std::shuffle(shuffled_indexes.begin(),
+               shuffled_indexes.end(),
+               std::mt19937 {std::random_device {}()});
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    int shuf_i = shuffled_indexes[i];
+    auto key = this->getKey(i);
+    auto value = this->getValue(i * 10.0 + 7.0);
+
+    second_batch_pairs[i + NUM_ELEMS] = {key, value};
+  }
+  // Copy pairs to GPU space.
+  axom::Array<std::pair<int, double>> second_batch_gpu(second_batch_pairs,
+                                                       this->getKernelAllocatorID());
+
+  // Perform batched insert.
+  test_map_gpu.template insert<ExecSpace>(second_batch_gpu.data(),
+                                          second_batch_gpu.data() + NUM_ELEMS * 2);
+
+  // Copy back flat map to host for testing.
+  test_map = MapType(test_map_gpu, axom::Allocator {this->getHostAllocatorID()});
+
+  // Check contents on the host. Only one of the duplicate keys should remain.
+  EXPECT_EQ(NUM_ELEMS, test_map.size());
+
+  // Check that every element we inserted is in the map
+  for(int i = 0; i < NUM_ELEMS; i++)
+  {
+    auto expected_key = this->getKey(i);
+    auto expected_val1 = this->getValue(i * 10.0 + 5.0);
+    auto expected_val2 = this->getValue(i * 10.0 + 7.0);
+    EXPECT_EQ(1, test_map.count(expected_key));
+    // Second key-value pair in batch-order should overwrite first pair with
+    // same key.
+    EXPECT_EQ(expected_val2, test_map.at(expected_key));
+    EXPECT_NE(expected_val1, test_map.at(expected_key));
+  }
+
+  // Check that we only have one instance of every key in the map
+  axom::Array<int> dedup_keys(NUM_ELEMS);
+  for(auto &pair : test_map)
+  {
+    // Check that we haven't seen another K-V pair with the same key.
+    EXPECT_EQ(dedup_keys[pair.first], 0);
+    dedup_keys[pair.first]++;
+
+    // Check that we got the second KV pair, not the first.
+    auto expected_val1 = this->getValue(pair.first * 10.0 + 5.0);
+    auto expected_val2 = this->getValue(pair.first * 10.0 + 7.0);
+    EXPECT_EQ(expected_val2, pair.second);
+    EXPECT_NE(expected_val1, pair.second);
   }
 }

--- a/src/axom/core/tests/core_flatmap_for_all.hpp
+++ b/src/axom/core/tests/core_flatmap_for_all.hpp
@@ -311,28 +311,18 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_with_dups)
   }
 
   // Check that we only have one instance of every key in the map
-  axom::Array<std::pair<int, double>> kv_out(NUM_ELEMS);
-  int index = 0;
+  axom::Array<int> dedup_keys(NUM_ELEMS);
   for(auto &pair : test_map)
   {
-    EXPECT_LT(index, NUM_ELEMS);
-    kv_out[index++] = {pair.first, pair.second};
-  }
+    // Check that we haven't seen another K-V pair with the same key.
+    EXPECT_EQ(dedup_keys[pair.first], 0);
+    dedup_keys[pair.first]++;
 
-  std::sort(kv_out.begin(),
-            kv_out.end(),
-            [](const std::pair<int, double> &first, const std::pair<int, double> &second) -> bool {
-              return first.first < second.first;
-            });
-
-  for(int i = 0; i < NUM_ELEMS; i++)
-  {
-    auto expected_key = this->getKey(i);
-    auto expected_val1 = this->getValue(i * 10.0 + 5.0);
-    auto expected_val2 = this->getValue(i * 10.0 + 7.0);
-    EXPECT_EQ(kv_out[i].first, expected_key);
-    EXPECT_EQ(expected_val2, test_map.at(expected_key));
-    EXPECT_NE(expected_val1, test_map.at(expected_key));
+    // Check that we got the second KV pair, not the first.
+    auto expected_val1 = this->getValue(pair.first * 10.0 + 5.0);
+    auto expected_val2 = this->getValue(pair.first * 10.0 + 7.0);
+    EXPECT_EQ(expected_val2, pair.second);
+    EXPECT_NE(expected_val1, pair.second);
   }
 }
 

--- a/src/axom/core/tests/core_flatmap_for_all.hpp
+++ b/src/axom/core/tests/core_flatmap_for_all.hpp
@@ -323,7 +323,8 @@ AXOM_TYPED_TEST(core_flatmap_forall, insert_batched_with_existing)
   axom::Array<std::pair<int, double>> kv_insert_gpu(kv_insert_vec, this->getKernelAllocatorID());
 
   // Insert pairs into existing flatmap.
-  test_map_gpu.insert(kv_insert_vec.begin(), kv_insert_vec.end());
+  test_map_gpu.template insert<ExecSpace>(kv_insert_gpu.data(),
+                                          kv_insert_gpu.data() + NUM_ELEMS_INSERT);
 
   // Copy back flat map to host for testing.
   MapType test_map(test_map_gpu, axom::Allocator {this->getHostAllocatorID()});


### PR DESCRIPTION
# Summary

- Adds `FlatMap::insert<ExecSpace>(beginIt, endIt)` function for batched insertions into an existing `FlatMap`.
- Updates `FlatMap::reserve()` behavior to trigger a rehash only if the required load factor would exceed the maximum load factor
- Fixes a bug in `FlatMap::erase()` where the number of elements in the map wasn't getting updated
- Fixes `FlatMap::rehash()` when allocated in device-only memory with CUDA

Resolves #1613 