### PR TITLE
Initial clipping code re-factor

### DIFF
--- a/src/axom/core/NumericArray.hpp
+++ b/src/axom/core/NumericArray.hpp
@@ -201,6 +201,7 @@ public:
    * array. If the size is not the same as the size of this array, this
    * behaves the same way as the constructor which takes a pointer and size.
    */
+  AXOM_HOST_DEVICE
   NumericArray(std::initializer_list<T> values)
     : NumericArray {values.begin(), static_cast<int>(values.size())}
   { }

--- a/src/axom/quest/CMakeLists.txt
+++ b/src/axom/quest/CMakeLists.txt
@@ -140,11 +140,22 @@ if(AXOM_ENABLE_KLEE AND AXOM_ENABLE_SIDRE)
         list(APPEND quest_headers Shaper.hpp
                                   DiscreteShape.hpp
                                   IntersectionShaper.hpp
-                                  detail/shaping/shaping_helpers.hpp)
+                                  detail/shaping/shaping_helpers.hpp
+                                  ShapeMesh.hpp)
         list(APPEND quest_sources Shaper.cpp
-                                DiscreteShape.cpp
-                                detail/shaping/shaping_helpers.cpp)
-        list(APPEND quest_depends_on klee)       
+                                  DiscreteShape.cpp
+                                  detail/shaping/shaping_helpers.cpp
+                                  ShapeMesh.cpp)
+        list(APPEND quest_depends_on klee)
+        if(RAJA_FOUND)
+            list(APPEND quest_headers MeshClipper.hpp
+                                      MeshClipperStrategy.hpp
+                                      detail/clipping/TetClipper.hpp
+                                      detail/clipping/MeshClipperImpl.hpp)
+            list(APPEND quest_sources MeshClipper.cpp
+                                      detail/clipping/TetClipper.cpp
+                                      MeshClipperStrategy.cpp)
+        endif()
     endif()
 
     if(MFEM_FOUND AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION)

--- a/src/axom/quest/MeshClipper.cpp
+++ b/src/axom/quest/MeshClipper.cpp
@@ -1,0 +1,250 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/config.hpp"
+
+#include "axom/quest/MeshClipper.hpp"
+#include "axom/quest/detail/clipping/MeshClipperImpl.hpp"
+#include "axom/core/execution/execution_space.hpp"
+#include "axom/core/execution/runtime_policy.hpp"
+#include "axom/slic/interface/slic_macros.hpp"
+#include "axom/fmt.hpp"
+
+namespace axom
+{
+namespace quest
+{
+namespace experimental
+{
+
+MeshClipper::MeshClipper(quest::experimental::ShapeMesh& shapeMesh,
+                         const std::shared_ptr<quest::experimental::MeshClipperStrategy>& strategy)
+  : m_shapeMesh(shapeMesh)
+  , m_strategy(strategy)
+  , m_impl(newImpl())
+  , m_verbose(false)
+{ }
+
+void MeshClipper::clip(axom::Array<double>& ovlap)
+{
+  const int allocId = m_shapeMesh.getAllocatorID();
+  const axom::IndexType cellCount = m_shapeMesh.getCellCount();
+
+  // Resize output array and use appropriate allocator.
+  if(ovlap.size() < cellCount || ovlap.getAllocatorID() != allocId)
+  {
+    AXOM_ANNOTATE_SCOPE("MeshClipper::clip_alloc");
+    ovlap = axom::Array<double>(ArrayOptions::Uninitialized(), cellCount, cellCount, allocId);
+  }
+  clip(ovlap.view());
+}
+
+/*
+ * Orchestrates the geometry clipping by using the capabilities of the
+ * MeshClipperStrategy implementation.
+ *
+ * If the strategy can label cells as inside/on/outside geometry
+ * boundary, use that to reduce reliance on expensive clipping methods.
+ *
+ * Regardless of labling, try to use specialized clipping first.
+ * If specialized methods aren't implemented, resort to discretizing
+ * geomety into tets or octs for clipping against mesh cells.
+ */
+void MeshClipper::clip(axom::ArrayView<double> ovlap)
+{
+  const int allocId = m_shapeMesh.getAllocatorID();
+  const axom::IndexType cellCount = m_shapeMesh.getCellCount();
+  SLIC_ASSERT(ovlap.size() == cellCount);
+
+  // Try to label cells as inside, outside or on shape boundary
+  axom::Array<char> cellLabels;
+  bool withCellInOut = m_strategy->labelCellsInOut(m_shapeMesh, cellLabels);
+
+  bool done = false;
+
+  if(withCellInOut)
+  {
+    SLIC_ERROR_IF(
+      cellLabels.size() != m_shapeMesh.getCellCount(),
+      axom::fmt::format("MeshClipperStrategy '{}' did not return the correct array size of {}",
+                        m_strategy->name(),
+                        m_shapeMesh.getCellCount()));
+    SLIC_ERROR_IF(cellLabels.getAllocatorID() != allocId,
+                  axom::fmt::format("MeshClipperStrategy '{}' failed to provide cellLabels data "
+                                    "with the required allocator id {}",
+                                    m_strategy->name(),
+                                    allocId));
+
+    if(m_verbose)
+    {
+      logLabelStats(cellLabels, "cells");
+    }
+
+    AXOM_ANNOTATE_BEGIN("MeshClipper::processInOut");
+
+    m_impl->initVolumeOverlaps(cellLabels.view(), ovlap);
+
+    axom::Array<axom::IndexType> cellsOnBdry;
+    m_impl->collectOnIndices(cellLabels.view(), cellsOnBdry);
+
+    axom::Array<char> tetLabels;
+    bool withTetInOut = m_strategy->labelTetsInOut(m_shapeMesh, cellsOnBdry.view(), tetLabels);
+
+    axom::Array<axom::IndexType> tetsOnBdry;
+
+    if(withTetInOut)
+    {
+      if(m_verbose)
+      {
+        logLabelStats(tetLabels, "tets");
+      }
+      m_impl->collectOnIndices(tetLabels.view(), tetsOnBdry);
+      m_impl->remapTetIndices(tetsOnBdry, cellsOnBdry);
+
+      SLIC_ASSERT(tetsOnBdry.getAllocatorID() == m_shapeMesh.getAllocatorID());
+      SLIC_ASSERT(tetsOnBdry.size() <= cellsOnBdry.size() * TETS_PER_HEXAHEDRON);
+
+      m_impl->addVolumesOfInteriorTets(cellsOnBdry.view(), tetLabels.view(), ovlap);
+    }
+
+    AXOM_ANNOTATE_END("MeshClipper::processInOut");
+
+    //
+    // If implementation has a specialized clip, use it.
+    //
+    if(withTetInOut)
+    {
+      done = m_strategy->specializedClipTets(m_shapeMesh, ovlap, tetsOnBdry);
+    }
+    else
+    {
+      done = m_strategy->specializedClipCells(m_shapeMesh, ovlap, cellsOnBdry);
+    }
+
+    if(!done)
+    {
+      AXOM_ANNOTATE_SCOPE("MeshClipper::clip3D_limited");
+      if(withTetInOut)
+      {
+        m_impl->computeClipVolumes3DTets(tetsOnBdry.view(), ovlap);
+      }
+      else
+      {
+        m_impl->computeClipVolumes3D(cellsOnBdry.view(), ovlap);
+      }
+    }
+
+    m_localCellInCount = cellsOnBdry.size();
+  }
+  else  // !withCellInOut
+  {
+    std::string msg =
+      axom::fmt::format("MeshClipper strategy '{}' did not provide in/out cell labels.\n",
+                        m_strategy->name());
+    SLIC_INFO(msg);
+    m_impl->initVolumeOverlaps(ovlap);
+    done = m_strategy->specializedClipCells(m_shapeMesh, ovlap);
+
+    if(!done)
+    {
+      AXOM_ANNOTATE_SCOPE("MeshClipper::clip3D");
+      m_impl->computeClipVolumes3D(ovlap);
+    }
+
+    m_localCellInCount = cellCount;
+  }
+}
+
+/*!
+ * @brief Allocate a Impl for the execution-space computations
+ * of this clipper.
+ */
+std::unique_ptr<MeshClipper::Impl> MeshClipper::newImpl()
+{
+  using RuntimePolicy = axom::runtime_policy::Policy;
+
+  auto runtimePolicy = m_shapeMesh.getRuntimePolicy();
+
+  std::unique_ptr<Impl> impl;
+  if(runtimePolicy == RuntimePolicy::seq)
+  {
+    impl.reset(new detail::MeshClipperImpl<axom::SEQ_EXEC>(*this));
+  }
+#ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
+  else if(runtimePolicy == RuntimePolicy::omp)
+  {
+    impl.reset(new detail::MeshClipperImpl<axom::OMP_EXEC>(*this));
+  }
+#endif
+#ifdef AXOM_RUNTIME_POLICY_USE_CUDA
+  else if(runtimePolicy == RuntimePolicy::cuda)
+  {
+    impl.reset(new detail::MeshClipperImpl<axom::CUDA_EXEC<256>>(*this));
+  }
+#endif
+#ifdef AXOM_RUNTIME_POLICY_USE_HIP
+  else if(runtimePolicy == RuntimePolicy::hip)
+  {
+    impl.reset(new detail::MeshClipperImpl<axom::HIP_EXEC<256>>(*this));
+  }
+#endif
+  else
+  {
+    SLIC_ERROR(axom::fmt::format("MeshClipper has no impl for runtime policy {}", runtimePolicy));
+  }
+  return impl;
+}
+
+void MeshClipper::logLabelStats(axom::ArrayView<const LabelType> labels, const std::string& labelType)
+{
+  axom::IndexType countsa[4];
+  axom::IndexType countsb[4];
+  getLabelCounts(labels, countsa[0], countsa[1], countsa[2]);
+  countsa[3] = m_shapeMesh.getCellCount();
+#ifdef AXOM_USE_MPI
+  MPI_Reduce(countsa, countsb, 4, axom::mpi_traits<axom::IndexType>::type, MPI_SUM, 0, MPI_COMM_WORLD);
+#endif
+  std::string msg = axom::fmt::format(
+    "MeshClipper strategy '{}' globally labeled {} {} inside, {} on and {} outside, for mesh with "
+    "{} cells ({} tets)\n",
+    m_strategy->name(),
+    labelType,
+    countsb[0],
+    countsb[1],
+    countsb[2],
+    countsb[3],
+    countsb[3] * TETS_PER_HEXAHEDRON);
+  SLIC_INFO(msg);
+}
+
+void MeshClipper::getClippingStats(axom::IndexType& localCellInCount,
+                                   axom::IndexType& globalCellInCount,
+                                   axom::IndexType& maxLocalCellInCount) const
+{
+  localCellInCount = m_localCellInCount;
+#ifdef AXOM_USE_MPI
+  MPI_Reduce(&localCellInCount,
+             &globalCellInCount,
+             1,
+             axom::mpi_traits<axom::IndexType>::type,
+             MPI_SUM,
+             0,
+             MPI_COMM_WORLD);
+  MPI_Reduce(&localCellInCount,
+             &maxLocalCellInCount,
+             1,
+             axom::mpi_traits<axom::IndexType>::type,
+             MPI_MAX,
+             0,
+             MPI_COMM_WORLD);
+#else
+  maxLocalCellInCount = localCellInCount;
+  globalCellInCount = localCellInCount;
+#endif
+}
+
+}  // namespace experimental
+}  // end namespace quest
+}  // end namespace axom

--- a/src/axom/quest/MeshClipper.hpp
+++ b/src/axom/quest/MeshClipper.hpp
@@ -1,0 +1,206 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_QUEST_MESHCLIPPER_HPP
+#define AXOM_QUEST_MESHCLIPPER_HPP
+
+#include "axom/config.hpp"
+
+#include "axom/klee/Geometry.hpp"
+#include "axom/quest/MeshClipperStrategy.hpp"
+#include "axom/quest/ShapeMesh.hpp"
+
+namespace axom
+{
+namespace quest
+{
+namespace experimental
+{
+
+/*!
+ * @brief Abstract base class encapsulating the clipping task in
+ * intersection shaping, to be specialized for geometry-specific
+ * implementations.
+ *
+ * Each object operates is associated with a single klee::Geometry object.*
+ *
+ * This class defines the interfaces for specializing computations
+ * that can run fast on specific geometries.  This allows for
+ * geometry-specific optimizations.  If no such specialization
+ * is provided, default methods are used.
+ */
+class MeshClipper
+{
+public:
+  //!@brief Whether an element is in, out or on shape boundary.
+  using LabelType = MeshClipperStrategy::LabelType;
+
+  static constexpr axom::IndexType TETS_PER_HEXAHEDRON = MeshClipperStrategy::TETS_PER_HEXAHEDRON;
+
+  /*!
+   * @brief Construct a shape clipper
+   *
+   * @param [in/out] bpMesh Single-domain Blueprint mesh
+   *   to shape into.
+   * @param [in] strategy Strategy where external
+   *   shape-dependent operations are implemented.
+   *
+   * @c bpMesh must be an unstructured hex mesh.
+   * That is the only type currently supported.
+   */
+  MeshClipper(quest::experimental::ShapeMesh& shapeMesh, const std::shared_ptr<MeshClipperStrategy>& strategy);
+
+  //!@brief The mesh.
+  ShapeMesh& getShapeMesh() { return m_shapeMesh; }
+
+  //!@brief Allocator id to be used for all array data.
+  int getAllocatorID() const { return m_shapeMesh.getAllocatorID(); }
+
+  void setVerbose(bool verbose) { m_verbose = verbose; }
+
+  /*!
+   * @brief Clip
+   *
+   * @param ovlap [out] Shape overlap volume of each cell
+   *   in the shapee mesh.
+   */
+  void clip(axom::Array<double>& ovlap);
+
+  /*!
+   * @brief Clip
+   *
+   * @param ovlap [out] Shape overlap volume of each cell
+   *   in the shapee mesh.
+   */
+  void clip(axom::ArrayView<double> ovlap);
+
+  //!@brief Dimension of the shape (2 or 3)
+  int dimension() const { return m_shapeMesh.dimension(); }
+
+  /*!
+   * @brief Single interface for methods implemented with
+   * execution space templates.
+   *
+   * These methods require messy instantiation of
+   * execution spaces and their runtime selection.
+   *
+   * The implementations are in class detail::MeshClipperImpl,
+   * which is templated on execution space.
+   */
+  struct Impl
+  {
+    Impl(MeshClipper& impl) : m_myClipper(impl) { }
+    virtual ~Impl() = default;
+
+    static constexpr axom::IndexType TETS_PER_HEXAHEDRON = MeshClipperStrategy::TETS_PER_HEXAHEDRON;
+
+    /*!
+     * @brief Initialize overlap volumes to full for cells completely
+     * inside the shape and zero for cells outside or on shape boundary.
+     */
+    virtual void initVolumeOverlaps(const axom::ArrayView<MeshClipperStrategy::LabelType>& labels,
+                                    axom::ArrayView<double> ovlap) = 0;
+
+    //! @brief Initialize overlap volumes to zero.
+    virtual void initVolumeOverlaps(axom::ArrayView<double> ovlap) = 0;
+
+    //!@brief Collect unlabeled LABEL_ON indices into an index list.
+    virtual void collectOnIndices(const axom::ArrayView<LabelType>& labels,
+                                  axom::Array<axom::IndexType>& onIndices) = 0;
+
+    //!@brief Change tet indices from sparse-set values to full-set values.
+    virtual void remapTetIndices(axom::ArrayView<axom::IndexType> tetsOnBdry,
+                                 axom::ArrayView<const axom::IndexType> cellsOnBdry) = 0;
+
+    //!@brief Add volumes of tets inside the geometry to the volume data.
+    virtual void addVolumesOfInteriorTets(axom::ArrayView<const axom::IndexType> cellsOnBdry,
+                                          axom::ArrayView<const LabelType> tetLabels,
+                                          axom::ArrayView<double> ovlap) = 0;
+
+    //!@brief Compute clip volumes for every cell.
+    virtual void computeClipVolumes3D(axom::ArrayView<double> ovlap) = 0;
+
+    //!@brief Compute clip volumes for cell in an index list.
+    virtual void computeClipVolumes3D(const axom::ArrayView<axom::IndexType>& cellIndices,
+                                      axom::ArrayView<double> ovlap) = 0;
+
+    /*!
+     * @brief Compute clip volumes for cell tets in an index list.
+     *
+     * The tets are the results from decomposing each cell hex into
+     * TETS_PER_HEXAHEDRON tets and stored consecutively.
+     */
+    virtual void computeClipVolumes3DTets(const axom::ArrayView<axom::IndexType>& tetIndices,
+                                          axom::ArrayView<double> ovlap) = 0;
+
+    //!@brief Count the number of labels of each type.
+    virtual void getLabelCounts(axom::ArrayView<const LabelType> labels,
+                                axom::IndexType& inCount,
+                                axom::IndexType& onCount,
+                                axom::IndexType& outCount) = 0;
+
+    ShapeMesh& getShapeMesh() { return m_myClipper.m_shapeMesh; }
+
+    MeshClipperStrategy& getStrategy() { return *m_myClipper.m_strategy; }
+
+  private:
+    //!@brief The MeshClipper that owns this Impl.
+    MeshClipper& m_myClipper;
+  };
+
+  //! @brief For assessments, not general use.
+  void getClippingStats(axom::IndexType& localCellInCount,
+                        axom::IndexType& globalCellInCount,
+                        axom::IndexType& maxLocalCellInCount) const;
+
+private:
+  friend Impl;
+
+  quest::experimental::ShapeMesh& m_shapeMesh;
+
+  //! @brief Shape-specific operations in clipping.
+  std::shared_ptr<quest::experimental::MeshClipperStrategy> m_strategy;
+
+  //! @brief Object where execution space code is instantiated.
+  std::unique_ptr<Impl> m_impl;
+
+  /* NOTE: MeshClipperStrategy is for shape-specific functions,
+   * implemented externally.  Impl implements internal algorithms
+   * for multiple execution spaces.
+   */
+
+  ///@{
+  //! @name Statistics
+  axom::IndexType m_localCellInCount {0};
+  ///@}
+
+  bool m_verbose;
+
+#if defined(__CUDACC__)
+public:
+#endif
+  //!@brief Allocate a delegate for m_shapeMesh's runtime policy.
+  std::unique_ptr<Impl> newImpl();
+
+  //@{
+  //!@name Convenience methods
+  //!@brief Count the number of labels of each type.
+  void getLabelCounts(const axom::Array<LabelType>& labels,
+                      axom::IndexType& inCount,
+                      axom::IndexType& onCount,
+                      axom::IndexType& outCount)
+  {
+    m_impl->getLabelCounts(labels, inCount, onCount, outCount);
+  }
+
+  void logLabelStats(axom::ArrayView<const LabelType> labels, const std::string& labelType);
+  //@}
+};
+
+}  // namespace experimental
+}  // namespace quest
+}  // namespace axom
+
+#endif  // AXOM_QUEST_MESHCLIPPER_HPP

--- a/src/axom/quest/MeshClipperStrategy.cpp
+++ b/src/axom/quest/MeshClipperStrategy.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/config.hpp"
+
+#include "axom/quest/MeshClipperStrategy.hpp"
+#include "axom/klee/GeometryOperators.hpp"
+
+namespace axom
+{
+namespace quest
+{
+namespace experimental
+{
+namespace internal
+{
+/*!
+ * \brief Implementation of a GeometryOperatorVisitor for processing klee shape operators
+ *
+ * This class extracts the matrix form of supported operators.
+ * For other operators, it sets the valid flag to false.
+ * To use, check the \a isValid() function after visiting and then call the \a getMatrix() function.
+ */
+class AffineMatrixVisitor : public klee::GeometryOperatorVisitor
+{
+public:
+  AffineMatrixVisitor() : m_matrix(4, 4) { }
+
+  void visit(const klee::Translation& translation) override
+  {
+    m_matrix = translation.toMatrix();
+    m_isValid = true;
+  }
+  void visit(const klee::Rotation& rotation) override
+  {
+    m_matrix = rotation.toMatrix();
+    m_isValid = true;
+  }
+  void visit(const klee::Scale& scale) override
+  {
+    m_matrix = scale.toMatrix();
+    m_isValid = true;
+  }
+  void visit(const klee::UnitConverter& converter) override
+  {
+    m_matrix = converter.toMatrix();
+    m_isValid = true;
+  }
+
+  void visit(const klee::CompositeOperator&) override
+  {
+    SLIC_WARNING("CompositeOperator not supported for Shaper query");
+    m_isValid = false;
+  }
+  void visit(const klee::SliceOperator&) override
+  {
+    SLIC_WARNING("SliceOperator not yet supported for Shaper query");
+    m_isValid = false;
+  }
+
+  const numerics::Matrix<double>& getMatrix() const { return m_matrix; }
+  bool isValid() const { return m_isValid; }
+
+private:
+  bool m_isValid {false};
+  numerics::Matrix<double> m_matrix;
+};
+
+}  // end namespace internal
+
+MeshClipperStrategy::MeshClipperStrategy(const klee::Geometry& kGeom)
+  : m_info(kGeom.asHierarchy())
+  , m_extTrans(computeTransformationMatrix(kGeom.getGeometryOperator()))
+{ }
+
+const std::string& MeshClipperStrategy::name() const
+{
+  static const std::string n = "UNNAMED";
+  return n;
+}
+
+const axom::primal::BoundingBox<double, 2>& MeshClipperStrategy::getBoundingBox2D() const
+{
+  static const axom::primal::BoundingBox<double, 2> invalidBb2d;
+  return invalidBb2d;
+}
+
+const axom::primal::BoundingBox<double, 3>& MeshClipperStrategy::getBoundingBox3D() const
+{
+  static const axom::primal::BoundingBox<double, 3> invalidBb3d;
+  return invalidBb3d;
+}
+
+numerics::Matrix<double> MeshClipperStrategy::computeTransformationMatrix(
+  const std::shared_ptr<const axom::klee::GeometryOperator>& op) const
+{
+  const auto identity4x4 = numerics::Matrix<double>::identity(4);
+  numerics::Matrix<double> transformation(identity4x4);
+  if(op)
+  {
+    auto composite = std::dynamic_pointer_cast<const klee::CompositeOperator>(op);
+    if(composite)
+    {
+      // Concatenate the transformations
+
+      // Why don't we multiply the matrices in CompositeOperator::addOperator()?
+      // Why keep the matrices factored and multiply them here repeatedly?
+      // Combining them would also avoid this if-else logic.  BTNG
+      for(auto op : composite->getOperators())
+      {
+        // Use visitor pattern to extract the affine matrix from supported operators
+        internal::AffineMatrixVisitor visitor;
+        op->accept(visitor);
+        if(!visitor.isValid())
+        {
+          continue;
+        }
+        const auto& matrix = visitor.getMatrix();
+        numerics::Matrix<double> res(identity4x4);
+        numerics::matrix_multiply(matrix, transformation, res);
+        transformation = res;
+      }
+    }
+    else
+    {
+      internal::AffineMatrixVisitor visitor;
+      op->accept(visitor);
+      if(visitor.isValid())
+      {
+        transformation = visitor.getMatrix();
+      }
+    }
+  }
+  return transformation;
+}
+
+}  // namespace experimental
+}  // end namespace quest
+}  // end namespace axom

--- a/src/axom/quest/MeshClipperStrategy.hpp
+++ b/src/axom/quest/MeshClipperStrategy.hpp
@@ -1,0 +1,377 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_QUEST_GEOMETRYCLIPPERSTRATEGY_HPP
+#define AXOM_QUEST_GEOMETRYCLIPPERSTRATEGY_HPP
+
+#include "axom/config.hpp"
+
+#include "axom/core/Array.hpp"
+#include "axom/klee/Geometry.hpp"
+#include "axom/quest/ShapeMesh.hpp"
+#include "axom/primal.hpp"
+
+// Requires Conduit for storing hierarchy-form data.
+#include "conduit_blueprint.hpp"
+
+namespace axom
+{
+namespace quest
+{
+namespace experimental
+{
+
+/*!
+ * @brief Strategy base class for clipping operations for specific
+ * geometry instances.
+
+ * Key methods to implement:  (Some combination of these is required.)
+
+ * -# @c getBoundingBox2D or @c getBoundingBox3D: Axis-alligned
+ *    bounding box for the geometry.
+
+ * -# @c labelCellsInOut: Label whether the cells in a mesh is inside,
+ *    outside or on the shape boundary.  If a cell cannot be
+ *    determined, you can conservatively label it as on the boundary.
+
+ * -# @c getShapesAsTets: Build an array of tetrahedra to approximate
+ *    the shape.
+
+ * -# @c getShapesAsOcts: Build an array of octahedra to approximate
+ *    the shape.
+
+ * -# @c specializedClipCells: Use a fast clipping algorithm (if one is
+ *    available) to clip the cells in a mesh.  Implementation should
+ *    use special knowledge of the geometry.  One version of this
+ *    method clips all cells in the mesh and the other clips only
+ *    cells in a provided index list.  The latter works in
+ *    conjunction with @c labelCellsInOut.
+
+ * Every method should return true if it fulfilled the request, or
+ * false if it was a no-op.
+
+ * Implementations of this strategy must provide either
+ * - a @c specializedClipCells method or
+ * - one of the @c getShapesAs...() methods.
+ * The former is prefered if the use of geometry-specific information
+ * can make it faster.  @c labelCellsInOut is optional but if provided,
+ * it can improve performance by limiting the slower clipping steps
+ * to a subset of cells.  @c getBoundingBox2D or @c getBoundingBox3D
+ * can also improve performance by reducing computation.
+*/
+class MeshClipperStrategy
+{
+public:
+  /*!
+   * @brief A type to denote whether something is inside,
+   * on or outside the boundary of a geometry.
+  */
+  using LabelType = char;
+  //!@brief Denotes something inside a shape boundary.
+  static constexpr LabelType LABEL_IN = 0;
+  //!@brief Denotes something on a shape boundary.
+  static constexpr LabelType LABEL_ON = 1;
+  //!@brief Denotes something outside a shape boundary.
+  static constexpr LabelType LABEL_OUT = 2;
+
+  using BoundingBox3DType = axom::primal::BoundingBox<double, 3>;
+  using Cone3DType = axom::primal::Cone<double, 3>;
+  using HexahedronType = axom::primal::Hexahedron<double, 3>;
+  using OctahedronType = axom::primal::Octahedron<double, 3>;
+  using Plane3DType = axom::primal::Plane<double, 3>;
+  using Point3DType = axom::primal::Point<double, 3>;
+  using Ray3DType = axom::primal::Ray<double, 3>;
+  using Segment3DType = axom::primal::Segment<double, 3>;
+  using SphereType = axom::primal::Sphere<double, 3>;
+  using TetrahedronType = axom::primal::Tetrahedron<double, 3>;
+  using Triangle3DType = axom::primal::Triangle<double, 3>;
+  using Vector3DType = axom::primal::Vector<double, 3>;
+
+  using BoundingBox2DType = axom::primal::BoundingBox<double, 2>;
+  using Point2DType = axom::primal::Point<double, 2>;
+  using CircleType = axom::primal::Sphere<double, 2>;
+  using Plane2DType = axom::primal::Plane<double, 2>;
+  using Ray2DType = axom::primal::Ray<double, 2>;
+  using Segment2DType = axom::primal::Segment<double, 2>;
+
+  //!@brief Number of tetrahedra per hexahedron decomposes into
+  // @internal We could use a more efficient 18-tet decomposition in the future.
+  static constexpr axom::IndexType TETS_PER_HEXAHEDRON = HexahedronType::NUM_TRIANGULATE;
+
+  /*!
+   * @brief Construct a strategy for the given klee::Geometry object.
+   *
+   * @param [in] kGeom Describes the shape to place
+   *   into the mesh.
+  */
+  MeshClipperStrategy(const klee::Geometry& kGeom);
+
+  /*!
+   * @brief Optional name for strategy.
+   *
+   * The base implementation returns "UNNAMED".
+  */
+  virtual const std::string& name() const;
+
+  /*!
+   * @brief Free-form information on the geometry.
+   *
+   * The exact information is provided by the klee::Geometry
+   * and should be sufficient to define the geometry.
+  */
+  const conduit::Node& info() const { return m_info; }
+
+  //@{
+  //!@name Geometry-specialized methods
+
+  /*!
+   * @brief Get the 2D axis-aligned bounding box for the geometry,
+   * if it's applicable and available.
+  */
+  virtual const axom::primal::BoundingBox<double, 2>& getBoundingBox2D() const;
+
+  /*!
+   * @brief Get the 3D axis-alligned bounding box for the geometry,
+   * if it's applicable and available.
+  */
+  virtual const axom::primal::BoundingBox<double, 3>& getBoundingBox3D() const;
+
+  /*!
+   * @brief Label the cells in the mesh as inside, outside or
+   * both/undetermined, if possible.
+   *
+   * @param [in] shapeMesh Mesh to shape into.
+   * @param [out] labels Output
+   *
+   * The cell labels should be set to
+   * - @c labelIn if the cell is completely inside the shape,
+   * - @c labelOut if the cell is completely outside, and
+   * - @c labelOn if the cell is both inside and outside (or
+   *   cannot be easily determined).
+   *
+   * The output labels are used in optimizing the clipping algorithm.
+   * Subclasses should implementation this if it's cost-effective, and
+   * skip if it's not.  It's safe to label cells as on the boundary if
+   * it can't be possitively determined as inside or outside.
+   *
+   * @return Whether the operation was done.  (A false means
+   * not done.)
+   *
+   * If implemenation returns true, it should ensure these
+   * post-conditions hold:
+   * @post labels.size() == shapeMesh.getCellCount()
+   * @post labels.getAllocatorID() == shapeMesh.getAllocatorId()
+  */
+  virtual bool labelCellsInOut(quest::experimental::ShapeMesh& shapeMesh, axom::Array<LabelType>& cellLabels)
+  {
+    AXOM_UNUSED_VAR(shapeMesh);
+    AXOM_UNUSED_VAR(cellLabels);
+    return false;
+  }
+
+  /*!
+   * @brief Label the tetrahedra in certain cells, if possible.
+   *
+   * @param [in] shapeMesh Blueprint mesh to shape into.
+   * @param [in] cellIds Indices of cells whose constituent
+   *   tets should be labeled.
+   * @param [out] tetLabels Output
+   *
+   * Only the cells labeled as ON the boundary are subjected to
+   * this labeling.
+   *
+   * Tet indices refer to the @c shapeMesh.getCellsAsTets() array.
+   *
+   * If implemenation returns true, it should ensure these
+   * post-conditions hold:
+   * @post tetLabels.size() == TETS_PER_HEXAHEDRON * cellIds.size()
+   * @post labels.getAllocatorID() == shapeMesh.getAllocatorId()
+   * @post \c tetLabels should have \c TETS_PER_HEXAHEDRON labels
+   * for each index in \c cellIds.
+  */
+  virtual bool labelTetsInOut(quest::experimental::ShapeMesh& shapeMesh,
+                              axom::ArrayView<const axom::IndexType> cellIds,
+                              axom::Array<LabelType>& tetLabels)
+  {
+    AXOM_UNUSED_VAR(shapeMesh);
+    AXOM_UNUSED_VAR(cellIds);
+    AXOM_UNUSED_VAR(tetLabels);
+    return false;
+  }
+
+  /*!
+   * @brief Clip with a fast geometry-specialized method if
+   * possible.
+   *
+   * @param [in] shapeMesh Blueprint mesh to shape into.
+   * @param ovlap [out] Shape overlap volume of each cell
+   *   in the shapee mesh.  It's initialized to zeros.
+   *
+   * The default implementation has no specialized method,
+   * so it's a no-op and returns false.
+   *
+   * If this method returns false, then exactly one of the
+   * @c getShapesAs...() methods must be provided.
+   *
+   * @return True if clipping was done and false if a no-op.
+   *
+   * This method need not be implemented if labelCellsInOut()
+   * returns true.
+   *
+   * If implemenation returns true, it should ensure these
+   * post-conditions hold:
+   * @post ovlap.size() == shapeMesh.getCellCount()
+   * @post ovlap.getAllocatorID() == shapeMesh.getAllocatorId()
+  */
+  virtual bool specializedClipCells(quest::experimental::ShapeMesh& shapeMesh, axom::ArrayView<double> ovlap)
+  {
+    AXOM_UNUSED_VAR(shapeMesh);
+    AXOM_UNUSED_VAR(ovlap);
+    return false;
+  }
+
+  /*!
+   * @brief Clip with a fast geometry-specialized method if
+   * possible.
+   *
+   * @param [in] shapeMesh Blueprint mesh to shape into.
+   * @param [out] ovlap Shape overlap volume of each cell
+   *   in the shapee mesh, initialized to the cell volumes
+   *   for cell inside the shape and zero for other cells.
+   * @param [in] cellIds Limit computation to these cell ids.
+   *
+   * The default implementation has no specialized method,
+   * so it's a no-op and returns false.
+   *
+   * If this method returns false, then exactly one of the
+   * shape discretization methods must be provided.
+   *
+   * @return True if clipping was done and false if a no-op.
+   *
+   * This method need not be implemented if labelCellsInOut()
+   * returns false.
+   *
+   * @pre @c ovlap is pre-initialized for the implementation
+   * to add or subtract partial volumes to individual cells.
+   *
+   * If implemenation returns true, it should ensure these
+   * post-conditions hold:
+   * @post ovlap.size() == shapeMesh.getCellCount()
+   * @post ovlap.getAllocatorID() == shapeMesh.getAllocatorId()
+  */
+  virtual bool specializedClipCells(quest::experimental::ShapeMesh& shapeMesh,
+                                    axom::ArrayView<double> ovlap,
+                                    const axom::ArrayView<IndexType>& cellIds)
+  {
+    AXOM_UNUSED_VAR(shapeMesh);
+    AXOM_UNUSED_VAR(ovlap);
+    AXOM_UNUSED_VAR(cellIds);
+    return false;
+  }
+
+  /*!
+   * Clip the tets listed in tetIds.
+   * @param [in] shapeMesh Blueprint mesh to shape into.
+   * @param [out] ovlap Shape overlap volume of each cell
+   *   in the shapee mesh, initialized to the cell volumes
+   *   for cell inside the shape and zero for other cells.
+   * @param [in] tetIds Indices of tets to clip, referring to the
+   * shapeMesh.getCellsAsTets() array.  tetIds[i] is the
+   * \c (tetIds[i]%TETS_PER_HEXAHEDRON)-th tetrahedron of cell
+   * \c tetIds[i]/TETS_PER_HEXAHEDRON.  Its overlap volume should be added
+   * to that cell.
+   */
+  virtual bool specializedClipTets(quest::experimental::ShapeMesh& shapeMesh,
+                                   axom::ArrayView<double> ovlap,
+                                   const axom::ArrayView<IndexType>& tetIds)
+  {
+    AXOM_UNUSED_VAR(shapeMesh);
+    AXOM_UNUSED_VAR(ovlap);
+    AXOM_UNUSED_VAR(tetIds);
+    return false;
+  }
+
+  /*!
+   * @brief Get the geometry as discrete tetrahedra, or return false.
+   *
+   * @param [in] shapeMesh Blueprint mesh to shape into.
+   * @param [out] tets Array of tetrahedra filling the space of the shape,
+   * fully transformed.
+   *
+   * All vertex coordinates close to zero should be snapped to zero.
+   *
+   * @return Whether the shape can be represented as tetrahedra.
+   *
+   * If implemenation returns true, it should ensure these
+   * post-conditions hold:
+   * @post tets.getAllocatorID() == shapeMesh.getAllocatorId()
+  */
+  virtual bool getGeometryAsTets(quest::experimental::ShapeMesh& shapeMesh,
+                                 axom::Array<TetrahedronType>& tets)
+
+  {
+    AXOM_UNUSED_VAR(shapeMesh);
+    AXOM_UNUSED_VAR(tets);
+    return false;
+  }
+
+  /*!
+   * @brief Get the geometry as discrete octahedra, or return false.
+   *
+   * @param [in] shapeMesh Blueprint mesh to shape into.
+   * @param [out] octs Array of octahedra filling the space of the shape,
+   * fully transformed.
+   *
+   * All vertex coordinates close to zero should be snapped to zero.
+   *
+   * @return Whether the shape can be represented as octahedra.
+   *
+   * If implemenation returns true, it should ensure these
+   * post-conditions hold:
+   * @post octs.getAllocatorID() == shapeMesh.getAllocatorId()
+   */
+  virtual bool getGeometryAsOcts(quest::experimental::ShapeMesh& shapeMesh,
+                                 axom::Array<OctahedronType>& octs)
+  {
+    AXOM_UNUSED_VAR(shapeMesh);
+    AXOM_UNUSED_VAR(octs);
+    return false;
+  }
+
+  //@}
+
+protected:
+  /*!
+   * @brief Free-form representation of the concrete object.
+   *
+   * The constructor initializes this as a deep copy of the source
+   * klee::Geometry hierarchy data.  Subclasses may use and change this
+   * data as needed.
+   */
+  conduit::Node m_info;
+
+  /*!
+   * @brief External transformation due to the GeometryOperator.
+   *
+   * This is a direct result of the klee::Geometry::getGeometryOperator().
+   * Not to be confused with any geometry's internal transformation
+   * (such as a cylinder's orientation and a sphere's center translation),
+   * which apply before m_extTrans.
+  */
+  numerics::Matrix<double> m_extTrans;
+
+private:
+  /*!
+    @brief Compute the transformation matrix of a GeometryOperator.
+  */
+  numerics::Matrix<double> computeTransformationMatrix(
+    const std::shared_ptr<const axom::klee::GeometryOperator>& op) const;
+};
+
+}  // namespace experimental
+}  // namespace quest
+}  // namespace axom
+
+#endif  // AXOM_QUEST_GEOMETRYCLIPPERSTRATEGY_HPP

--- a/src/axom/quest/ShapeMesh.cpp
+++ b/src/axom/quest/ShapeMesh.cpp
@@ -1,0 +1,918 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/config.hpp"
+
+#include "axom/primal.hpp"
+#include "axom/quest/ShapeMesh.hpp"
+#include "axom/core/execution/execution_space.hpp"
+#include "axom/fmt.hpp"
+
+#include "conduit_blueprint.hpp"
+
+namespace axom
+{
+namespace quest
+{
+namespace experimental
+{
+#if defined(AXOM_USE_64BIT_INDEXTYPE) && !defined(AXOM_NO_INT64_T)
+static constexpr conduit::DataType::TypeID conduitDataIdOfAxomIndexType = conduit::DataType::INT64_ID;
+#else
+static constexpr conduit::DataType::TypeID conduitDataIdOfAxomIndexType = conduit::DataType::INT32_ID;
+#endif
+
+constexpr int NUM_TETS_PER_HEX = 24;
+
+ShapeMesh::ShapeMesh(RuntimePolicy runtimePolicy,
+                     int allocatorId,
+                     conduit::Node& bpMesh,
+                     const std::string& topoName,
+                     const std::string& matsetName)
+  : m_runtimePolicy(runtimePolicy)
+  , m_allocId(allocatorId != axom::INVALID_ALLOCATOR_ID
+                ? allocatorId
+                : axom::policyToDefaultAllocatorID(runtimePolicy))
+  , m_topoName(topoName.empty() && bpMesh["topologies"].number_of_children() > 0
+                 ? bpMesh["topologies"].child(0).name()
+                 : topoName)
+  , m_matsetName(matsetName.empty() && bpMesh["matsets"].number_of_children() > 0
+                   ? bpMesh.fetch("matsets").child(0).name()
+                   : matsetName)
+  , m_bpNodeExt(&bpMesh)
+{
+  SLIC_ERROR_IF(m_topoName.empty(),
+                "Topology name was not provided, and no default topology was found.");
+
+  const int hostAllocId = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+
+  // We want unstructured topo but can accomodate structured.
+  const auto& typeNode =
+    m_bpNodeExt->fetch_existing("topologies").fetch_existing(m_topoName).fetch_existing("type");
+  const std::string topoType = typeNode.as_string();
+  SLIC_ERROR_IF(topoType != "unstructured",
+                "ShapeMesh currently only works with unstructured mesh, not " + topoType + ".");
+
+  const conduit::Node& topoNode =
+    m_bpNodeExt->fetch_existing("topologies").fetch_existing(m_topoName);
+  const std::string coordsetName = topoNode.fetch_existing("coordset").as_string();
+  const conduit::Node& coordsetNode =
+    m_bpNodeExt->fetch_existing("coordsets").fetch_existing(coordsetName);
+
+  if(!m_matsetName.empty())
+  {
+    conduit::Node& matsetNode = m_bpNodeExt->fetch("matsets").fetch(m_matsetName);
+
+    // If matsetName was given, but not data isn't set up yet, set it up.
+    if(!matsetNode.has_child("topology"))
+    {
+      matsetNode.set_allocator(sidre::ConduitMemory::axomAllocIdToConduit(hostAllocId));
+      matsetNode.fetch("topology").set_string(m_topoName);
+    }
+
+    SLIC_ERROR_IF(matsetNode["topology"].as_string() != m_topoName,
+                  "matset's topology doesn't match the specified topology");
+  }
+
+  // Input checks.
+  SLIC_ERROR_IF(topoNode["type"].as_string() != "unstructured",
+                "topology type must be 'unstructured'");
+  SLIC_ERROR_IF(topoNode["elements/shape"].as_string() != "hex", "element shape must be 'hex'");
+
+  m_dim = conduit::blueprint::mesh::topology::dims(topoNode);
+  SLIC_ASSERT(m_dim == 3);  // Will allow 2D when we support it.
+
+  m_cellCount = conduit::blueprint::mesh::topology::length(topoNode);
+
+  m_vertexCount = conduit::blueprint::mesh::coordset::length(coordsetNode);
+
+  const conduit::Node& coordsValues = coordsetNode.fetch_existing("values");
+  const bool isInterleaved = conduit::blueprint::mcarray::is_interleaved(coordsValues);
+  const int stride = isInterleaved ? m_dim : 1;
+  const char* dirNames[] = {"x", "y", "z"};
+  for(int d = 0; d < m_dim; ++d)
+  {
+    m_vertCoordsViews3D[d] = axom::ArrayView<const double>(coordsValues[dirNames[d]].as_double_ptr(),
+                                                           {m_vertexCount},
+                                                           stride);
+  }
+}
+
+#ifdef AXOM_USE_SIDRE
+ShapeMesh::ShapeMesh(RuntimePolicy runtimePolicy,
+                     int allocatorId,
+                     sidre::Group* bpMesh,
+                     const std::string& topoName,
+                     const std::string& matsetName)
+  : m_runtimePolicy(runtimePolicy)
+  , m_allocId(allocatorId != axom::INVALID_ALLOCATOR_ID
+                ? allocatorId
+                : axom::policyToDefaultAllocatorID(runtimePolicy))
+  , m_topoName(topoName.empty() && bpMesh->hasGroup("topologies") &&
+                   bpMesh->getGroup("topologies")->getNumGroups() > 0
+                 ? bpMesh->getGroup("topologies")->getGroup(0)->getName()
+                 : topoName)
+  , m_matsetName(matsetName.empty() && bpMesh->hasGroup("matsets") &&
+                     bpMesh->getGroup("matsets")->getNumGroups() > 0
+                   ? bpMesh->getGroup("matsets")->getGroup(0)->getName()
+                   : matsetName)
+  , m_bpGrpExt(bpMesh)
+  , m_bpNodeInt()
+{
+  SLIC_ASSERT(m_topoName != sidre::InvalidName);
+  SLIC_ERROR_IF(m_topoName.empty(),
+                "Topology name was not provided, and no default topology was found.");
+
+  m_bpGrpExt->createNativeLayout(m_bpNodeInt);
+
+  // We want unstructured topo but can accomodate structured.
+  const std::string topoType =
+    m_bpNodeInt.fetch_existing("topologies").fetch_existing(m_topoName).fetch_existing("type").as_string();
+  SLIC_ERROR_IF(topoType != "unstructured",
+                "ShapeMesh currently only works with unstructured mesh, not " + topoType + ".");
+
+  const conduit::Node& topoNode = m_bpNodeInt.fetch_existing("topologies").fetch_existing(m_topoName);
+  const std::string coordsetName = topoNode.fetch_existing("coordset").as_string();
+  const conduit::Node& coordsetNode =
+    m_bpNodeInt.fetch_existing("coordsets").fetch_existing(coordsetName);
+
+  if(!m_matsetName.empty())
+  {
+    conduit::Node& matsetNode = m_bpNodeInt.fetch("matsets").fetch(m_matsetName);
+
+    // If matsetName was given, but not data isn't set up yet, set it up.
+    if(!matsetNode.has_child("topology"))
+    {
+      matsetNode.fetch("topology").set_string(m_topoName);
+    }
+
+    SLIC_ERROR_IF(matsetNode["topology"].as_string() != m_topoName,
+                  "matset's topology doesn't match the specified topology");
+  }
+
+  // Input checks.
+  SLIC_ERROR_IF(topoNode["type"].as_string() != "unstructured",
+                "topology type must be 'unstructured'");
+  SLIC_ERROR_IF(topoNode["elements/shape"].as_string() != "hex", "element shape must be 'hex'");
+
+  m_dim = conduit::blueprint::mesh::topology::dims(topoNode);
+  SLIC_ASSERT(m_dim == 3);  // Will allow 2D when we support it.
+
+  m_cellCount = conduit::blueprint::mesh::topology::length(topoNode);
+
+  m_vertexCount = conduit::blueprint::mesh::coordset::length(coordsetNode);
+
+  const conduit::Node& coordsValues = coordsetNode.fetch_existing("values");
+  const bool isInterleaved = conduit::blueprint::mcarray::is_interleaved(coordsValues);
+  const int stride = isInterleaved ? m_dim : 1;
+  const char* dirNames[] = {"x", "y", "z"};
+  for(int d = 0; d < m_dim; ++d)
+  {
+    m_vertCoordsViews3D[d] = axom::ArrayView<const double>(coordsValues[dirNames[d]].as_double_ptr(),
+                                                           {m_vertexCount},
+                                                           stride);
+  }
+}
+#endif
+
+void ShapeMesh::precomputeMeshData()
+{
+  AXOM_ANNOTATE_SCOPE("ShapeMesh::precomputeMeshData");
+  getCellsAsHexes();
+  getCellsAsTets();
+  getCellVolumes();
+  getCellBoundingBoxes();
+  getCellLengths();
+  getCellNodeConnectivity();
+  getVertexPoints();
+}
+
+axom::ArrayView<const ShapeMesh::TetrahedronType> ShapeMesh::getCellsAsTets()
+{
+  if(m_cellsAsTets.size() != m_cellCount * NUM_TETS_PER_HEX)
+  {
+    computeCellsAsTets();
+  }
+  return m_cellsAsTets;
+}
+
+axom::ArrayView<const ShapeMesh::HexahedronType> ShapeMesh::getCellsAsHexes()
+{
+  if(m_cellsAsHexes.size() != m_cellCount)
+  {
+    computeCellsAsHexes();
+  }
+  return m_cellsAsHexes;
+}
+
+axom::ArrayView<const double> ShapeMesh::getCellVolumes()
+{
+  if(m_hexVolumes.size() != m_cellCount)
+  {
+    computeHexVolumes();
+  }
+  return m_hexVolumes.view();
+}
+
+axom::ArrayView<const ShapeMesh::BoundingBox3DType> ShapeMesh::getCellBoundingBoxes()
+{
+  if(m_hexBbs.size() != m_cellCount)
+  {
+    computeHexBbs();
+  }
+  return m_hexBbs.view();
+}
+
+axom::ArrayView<const double> ShapeMesh::getCellLengths()
+{
+  if(m_cellLengths.size() != m_cellCount)
+  {
+    computeCellLengths();
+  }
+  return m_cellLengths.view();
+}
+
+axom::ArrayView<const ShapeMesh::Point3DType> ShapeMesh::getVertexPoints()
+{
+  if(m_vertPoints3D.size() != m_vertexCount)
+  {
+    computeVertPoints();
+  }
+  return m_vertPoints3D.view();
+}
+
+axom::ArrayView<const axom::IndexType, 2> ShapeMesh::getCellNodeConnectivity()
+{
+  if(m_connectivity.size() != m_cellCount)
+  {
+    computeConnectivity();
+  }
+  return m_connectivity;
+}
+
+bool ShapeMesh::isValidForShaping(std::string& whyNot) const
+{
+  bool rval = true;
+
+  // We run the check on the Conduit form of the mesh.
+  const conduit::Node& bpMesh = m_bpNodeExt ? *m_bpNodeExt : m_bpNodeInt;
+
+  /*
+   * Check Blueprint-validity.
+   * Conduit's verify should work even if m_bpNodeExt has array data on
+   * devices.  The verification doesn't dereference array data.
+   * If this changes in the future, this code must adapt.
+   */
+  conduit::Node info;
+  rval = conduit::blueprint::mesh::verify(bpMesh, info);
+
+  if(rval)
+  {
+    std::string topoType = bpMesh.fetch("topologies")[m_topoName]["type"].as_string();
+    rval = topoType == "unstructured";
+    info[0].set_string("Topology is not unstructured.");
+  }
+
+  if(rval)
+  {
+    std::string elemShape = bpMesh.fetch("topologies")[m_topoName]["elements/shape"].as_string();
+    rval = elemShape == "hex";
+    info[0].set_string("Topology elements are not hex.");
+  }
+
+  whyNot = info.to_summary_string();
+
+  return rval;
+}
+
+void ShapeMesh::setMatsetFromVolume(const std::string& materialName,
+                                    const axom::ArrayView<double>& volumes,
+                                    bool isFraction)
+{
+  SLIC_ERROR_IF(m_matsetName.empty(),
+                "Cannot use material set in ShapeMesh: Matset name was not provided, and no "
+                "default matset was found.");
+
+  double* vfPtr = nullptr;
+
+  auto dataType = conduit::DataType::float64(m_cellCount);
+
+  if(m_bpNodeExt != nullptr)
+  {
+    conduit::Node& matsetNode = m_bpNodeExt->fetch("matsets")[m_matsetName];
+    if(matsetNode.has_child("topology"))
+    {
+      SLIC_ASSERT(matsetNode.fetch_existing("topology").as_string() == m_topoName);
+    }
+    else
+    {
+      matsetNode["topology"].set_string(m_topoName);
+    }
+    const std::string vfValuesPath = "matsets/" + m_matsetName + "/volume_fractions/" + materialName;
+    conduit::Node& vfValues = getMeshConduitPath(*m_bpNodeExt, vfValuesPath, dataType);
+    vfPtr = vfValues.as_double_ptr();
+  }
+  else
+  {
+    SLIC_ASSERT(m_bpGrpExt != nullptr);
+    std::string viewPath = "matsets/" + m_matsetName + "/volume_fractions/" + materialName;
+    sidre::View* vfValues = m_bpGrpExt->hasView(viewPath)
+      ? m_bpGrpExt->getView(viewPath)
+      : m_bpGrpExt->createView("matsets/" + m_matsetName + "/volume_fractions/" + materialName);
+    if(!vfValues->isAllocated())
+    {
+      vfValues->allocate(dataType, m_allocId);
+    }
+    else
+    {
+      SLIC_ASSERT(vfValues->getSchema().dtype().id() == dataType.id());
+      SLIC_ASSERT(vfValues->getSchema().dtype().number_of_elements() == dataType.number_of_elements());
+    }
+    vfPtr = (double*)(vfValues->getVoidPtr());
+  }
+
+  axom::copy(vfPtr, volumes.data(), m_cellCount * sizeof(double));
+  if(!isFraction)
+  {
+    const double* cellVols = getCellVolumes().data();
+    switch(m_runtimePolicy)
+    {
+    case RuntimePolicy::seq:
+      elementwiseDivideImpl<axom::SEQ_EXEC>(vfPtr, cellVols, vfPtr, m_cellCount);
+      break;
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
+    case RuntimePolicy::omp:
+      elementwiseDivideImpl<axom::OMP_EXEC>(vfPtr, cellVols, vfPtr, m_cellCount);
+      break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
+    case RuntimePolicy::cuda:
+      elementwiseDivideImpl<axom::CUDA_EXEC<256>>(vfPtr, cellVols, vfPtr, m_cellCount);
+      break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
+    case RuntimePolicy::hip:
+      elementwiseDivideImpl<axom::HIP_EXEC<256>>(vfPtr, cellVols, vfPtr, m_cellCount);
+      break;
+#endif
+    default:
+      SLIC_ERROR("ShapeMesh internal error: Unhandled execution policy.");
+    }
+  }
+}
+
+void ShapeMesh::setFreeVolumeFractions(const std::string& freeName)
+{
+  SLIC_ERROR_IF(m_matsetName.empty(),
+                "Cannot use material set in ShapeMesh: Matset name was not provided, and no "
+                "default matset was found.");
+
+  auto dataType = conduit::DataType::float64(m_cellCount);
+
+  double* newVfPtr = nullptr;
+  axom::ArrayView<double> newVfView(newVfPtr, {m_cellCount});
+
+  if(m_bpNodeExt != nullptr)
+  {
+    conduit::Node& matsetNode = m_bpNodeExt->fetch("matsets")[m_matsetName];
+    if(matsetNode.has_child("topology"))
+    {
+      SLIC_ASSERT(matsetNode.fetch_existing("topology").as_string() == m_topoName);
+    }
+    else
+    {
+      matsetNode["topology"].set_string(m_topoName);
+    }
+
+    conduit::Node& vfsNode = matsetNode["volume_fractions"];
+
+    conduit::Node& freeVfNode = getMeshConduitPath(vfsNode, freeName, dataType);
+    newVfPtr = freeVfNode.as_double_ptr();
+    newVfView = axom::ArrayView<double>(newVfPtr, {m_cellCount});
+    fillNImpl(newVfView, 0.0);
+
+    for(auto& vfNode : vfsNode.children())
+    {
+      if(vfNode.name() == freeVfNode.name()) continue;
+      axom::ArrayView<double> vfView(vfNode.as_double_ptr(), {m_cellCount});
+      elementwiseAddImpl(newVfView, vfView, newVfView);
+    }
+  }
+  else
+  {
+    SLIC_ASSERT(m_bpGrpExt != nullptr);
+    sidre::Group* matsetGrp = m_bpGrpExt->createGroup("matsets/" + m_matsetName, false, true);
+    if(matsetGrp->hasView("topology"))
+    {
+      SLIC_ERROR_IF(
+        matsetGrp->getView("topology")->getString() != m_topoName,
+        "Material set '" + m_matsetName + "' doesn't have expected topology '" + m_topoName + "'");
+    }
+    else
+    {
+      matsetGrp->createView("topology")->setString(m_topoName);
+    }
+
+    sidre::Group* vfsGrp = matsetGrp->createGroup("volume_fractions", false, true);
+
+    sidre::View* newVfVu = vfsGrp->createView(freeName);
+    newVfVu->allocate(dataType, m_allocId);
+    newVfPtr = (double*)(newVfVu->getVoidPtr());
+    newVfView = axom::ArrayView<double>(newVfPtr, {m_cellCount});
+    fillNImpl(newVfView, 0.0);
+
+    for(auto& vfVu : vfsGrp->views())
+    {
+      if(vfVu.getName() == freeName) continue;
+      axom::ArrayView<double> vfView((double*)(vfVu.getVoidPtr()), {m_cellCount});
+      elementwiseAddImpl(newVfView, vfView, newVfView);
+    }
+  }
+
+  elementwiseComplementImpl(newVfView, 1.0, newVfView);
+}
+
+template <typename T>
+void ShapeMesh::fillNImpl(axom::ArrayView<T> a, const T& val) const
+{
+  auto kern = AXOM_LAMBDA(axom::IndexType i) { a[i] = val; };
+
+  // Zero the new data for use as VF accumulation space.
+  switch(m_runtimePolicy)
+  {
+  case RuntimePolicy::seq:
+    axom::for_all<axom::SEQ_EXEC>(a.size(), kern);
+    break;
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
+  case RuntimePolicy::omp:
+    axom::for_all<axom::OMP_EXEC>(a.size(), kern);
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
+  case RuntimePolicy::cuda:
+    axom::for_all<axom::CUDA_EXEC<256>>(a.size(), kern);
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
+  case RuntimePolicy::hip:
+    axom::for_all<axom::HIP_EXEC<256>>(a.size(), kern);
+    break;
+#endif
+  default:
+    SLIC_ERROR("ShapeMesh internal error: Unhandled execution policy.");
+  }
+}
+
+template <typename T>
+void ShapeMesh::elementwiseAddImpl(const axom::ArrayView<T> a,
+                                   const axom::ArrayView<T> b,
+                                   axom::ArrayView<T> result) const
+{
+  auto kern = AXOM_LAMBDA(axom::IndexType i) { result[i] = a[i] + b[i]; };
+
+  switch(m_runtimePolicy)
+  {
+  case RuntimePolicy::seq:
+    axom::for_all<axom::SEQ_EXEC>(result.size(), kern);
+    break;
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
+  case RuntimePolicy::omp:
+    axom::for_all<axom::OMP_EXEC>(result.size(), kern);
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
+  case RuntimePolicy::cuda:
+    axom::for_all<axom::CUDA_EXEC<256>>(result.size(), kern);
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
+  case RuntimePolicy::hip:
+    axom::for_all<axom::HIP_EXEC<256>>(result.size(), kern);
+    break;
+#endif
+  default:
+    SLIC_ERROR("ShapeMesh internal error: Unhandled execution policy.");
+  }
+}
+
+template <typename T>
+void ShapeMesh::elementwiseComplementImpl(const axom::ArrayView<T> a,
+                                          const T& val,
+                                          axom::ArrayView<T> results) const
+{
+  auto kern = AXOM_LAMBDA(axom::IndexType i) { results[i] = val >= a[i] ? val - a[i] : 0.0; };
+
+  switch(m_runtimePolicy)
+  {
+  case RuntimePolicy::seq:
+    axom::for_all<axom::SEQ_EXEC>(a.size(), kern);
+    break;
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
+  case RuntimePolicy::omp:
+    axom::for_all<axom::OMP_EXEC>(a.size(), kern);
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
+  case RuntimePolicy::cuda:
+    axom::for_all<axom::CUDA_EXEC<256>>(a.size(), kern);
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
+  case RuntimePolicy::hip:
+    axom::for_all<axom::HIP_EXEC<256>>(a.size(), kern);
+    break;
+#endif
+  default:
+    SLIC_ERROR("ShapeMesh internal error: Unhandled execution policy.");
+  }
+}
+
+void ShapeMesh::computeCellsAsHexes()
+{
+  AXOM_ANNOTATE_SCOPE("ShapeMesh::computeCellsAsHexes");
+  switch(m_runtimePolicy)
+  {
+  case RuntimePolicy::seq:
+    computeCellsAsHexesImpl<axom::SEQ_EXEC>();
+    break;
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
+  case RuntimePolicy::omp:
+    computeCellsAsHexesImpl<axom::OMP_EXEC>();
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
+  case RuntimePolicy::cuda:
+    computeCellsAsHexesImpl<axom::CUDA_EXEC<256>>();
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
+  case RuntimePolicy::hip:
+    computeCellsAsHexesImpl<axom::HIP_EXEC<256>>();
+    break;
+#endif
+  default:
+    SLIC_ERROR("Axom Internal error: Unhandled execution policy.");
+  }
+}
+
+void ShapeMesh::computeCellsAsTets()
+{
+  AXOM_ANNOTATE_SCOPE("ShapeMesh::computeCellsAsTets");
+  switch(m_runtimePolicy)
+  {
+  case RuntimePolicy::seq:
+    computeCellsAsTetsImpl<axom::SEQ_EXEC>();
+    break;
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
+  case RuntimePolicy::omp:
+    computeCellsAsTetsImpl<axom::OMP_EXEC>();
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
+  case RuntimePolicy::cuda:
+    computeCellsAsTetsImpl<axom::CUDA_EXEC<256>>();
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
+  case RuntimePolicy::hip:
+    computeCellsAsTetsImpl<axom::HIP_EXEC<256>>();
+    break;
+#endif
+  default:
+    SLIC_ERROR("Axom Internal error: Unhandled execution policy.");
+  }
+}
+
+void ShapeMesh::computeHexVolumes()
+{
+  AXOM_ANNOTATE_SCOPE("ShapeMesh::computeHexVolumes");
+  switch(m_runtimePolicy)
+  {
+  case RuntimePolicy::seq:
+    computeHexVolumesImpl<axom::SEQ_EXEC>();
+    break;
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
+  case RuntimePolicy::omp:
+    computeHexVolumesImpl<axom::OMP_EXEC>();
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
+  case RuntimePolicy::cuda:
+    computeHexVolumesImpl<axom::CUDA_EXEC<256>>();
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
+  case RuntimePolicy::hip:
+    computeHexVolumesImpl<axom::HIP_EXEC<256>>();
+    break;
+#endif
+  default:
+    SLIC_ERROR("Axom Internal error: Unhandled execution policy.");
+  }
+}
+
+void ShapeMesh::computeHexBbs()
+{
+  AXOM_ANNOTATE_SCOPE("ShapeMesh::computeHexBoundingBoxes");
+  switch(m_runtimePolicy)
+  {
+  case RuntimePolicy::seq:
+    computeHexBbsImpl<axom::SEQ_EXEC>();
+    break;
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
+  case RuntimePolicy::omp:
+    computeHexBbsImpl<axom::OMP_EXEC>();
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
+  case RuntimePolicy::cuda:
+    computeHexBbsImpl<axom::CUDA_EXEC<256>>();
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
+  case RuntimePolicy::hip:
+    computeHexBbsImpl<axom::HIP_EXEC<256>>();
+    break;
+#endif
+  default:
+    SLIC_ERROR("Axom Internal error: Unhandled execution policy.");
+  }
+}
+
+void ShapeMesh::computeVertPoints()
+{
+  AXOM_ANNOTATE_SCOPE("ShapeMesh::computeVertPoints(");
+  switch(m_runtimePolicy)
+  {
+  case RuntimePolicy::seq:
+    computeVertPointsImpl<axom::SEQ_EXEC>();
+    break;
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
+  case RuntimePolicy::omp:
+    computeVertPointsImpl<axom::OMP_EXEC>();
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
+  case RuntimePolicy::cuda:
+    computeVertPointsImpl<axom::CUDA_EXEC<256>>();
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
+  case RuntimePolicy::hip:
+    computeVertPointsImpl<axom::HIP_EXEC<256>>();
+    break;
+#endif
+  default:
+    SLIC_ERROR("Axom Internal error: Unhandled execution policy.");
+  }
+}
+
+void ShapeMesh::computeCellLengths()
+{
+  AXOM_ANNOTATE_SCOPE("ShapeMesh::computeCellLengths");
+  switch(m_runtimePolicy)
+  {
+  case axom::runtime_policy::Policy::seq:
+    computeCellLengthsImpl<axom::SEQ_EXEC>();
+    break;
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
+  case axom::runtime_policy::Policy::omp:
+    computeCellLengthsImpl<axom::OMP_EXEC>();
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
+  case axom::runtime_policy::Policy::cuda:
+    computeCellLengthsImpl<axom::CUDA_EXEC<256>>();
+    break;
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
+  case axom::runtime_policy::Policy::hip:
+    computeCellLengthsImpl<axom::HIP_EXEC<256>>();
+    break;
+#endif
+  default:
+    SLIC_ERROR("Axom Internal error: Unhandled execution policy.");
+  }
+}
+
+void ShapeMesh::computeConnectivity()
+{
+  SLIC_ASSERT(m_dim == 3);  // 2D support not done yet.
+
+  constexpr int NUM_VERTS_PER_HEX = 8;
+
+  conduit::Node& bpMesh = m_bpNodeExt ? *m_bpNodeExt : m_bpNodeInt;
+
+  conduit::Node& topoNode = bpMesh.fetch_existing("topologies").fetch_existing(m_topoName);
+  auto& connNode = topoNode.fetch_existing("elements/connectivity");
+  SLIC_ERROR_IF(connNode.dtype().id() != conduitDataIdOfAxomIndexType,
+                "IntersectionShaper error: connectivity data type must be "
+                "axom::IndexType.");
+  const auto* connPtr = static_cast<const axom::IndexType*>(connNode.data_ptr());
+  m_connectivity =
+    axom::ArrayView<const axom::IndexType, 2> {connPtr, m_cellCount, NUM_VERTS_PER_HEX};
+}
+
+template <typename ExecSpace>
+void ShapeMesh::computeCellsAsHexesImpl()
+{
+  constexpr int NUM_VERTS_PER_HEX = 8;
+  constexpr int NDIM = 3;
+
+  SLIC_ASSERT(m_dim == NDIM);  // or we shouldn't be here.
+
+  auto vertexCoords = getVertexCoords3D();
+  const axom::ArrayView<const double>& vX = vertexCoords[0];
+  const axom::ArrayView<const double>& vY = vertexCoords[1];
+  const axom::ArrayView<const double>& vZ = vertexCoords[2];
+
+  axom::ArrayView<const IndexType, 2> connView = getCellNodeConnectivity();
+
+  m_cellsAsHexes =
+    axom::Array<HexahedronType>(ArrayOptions::Uninitialized(), m_cellCount, m_cellCount, m_allocId);
+  axom::ArrayView<HexahedronType> cellsAsHexesView = m_cellsAsHexes.view();
+
+  constexpr double ZERO_THRESHOLD = 1.e-10;
+
+  axom::for_all<ExecSpace>(
+    m_cellCount,
+    AXOM_LAMBDA(axom::IndexType cellId) {
+      // Set each hexahedral element vertices
+      auto& hex = cellsAsHexesView[cellId];
+
+      for(int vi = 0; vi < NUM_VERTS_PER_HEX; ++vi)
+      {
+        axom::IndexType vertIndex = connView(cellId, vi);
+        primal::Point3D vCoords(
+          axom::NumericArray<double, NDIM> {vX[vertIndex], vY[vertIndex], vZ[vertIndex]});
+
+        // Snap coordinates to zero.
+        for(int d = 0; d < NDIM; ++d)
+        {
+          if(axom::utilities::isNearlyEqual(vCoords[d], 0.0, ZERO_THRESHOLD))
+          {
+            vCoords[d] = 0;
+          }
+        }
+
+        hex[vi] = vCoords;
+      }
+    });  // end of loop to initialize hexahedral elements and bounding boxes
+}
+
+template <typename ExecSpace>
+void ShapeMesh::computeCellsAsTetsImpl()
+{
+  constexpr int NUM_TETS_PER_HEX = primal::Hexahedron<double, 3>::NUM_TRIANGULATE;
+
+  SLIC_ASSERT(m_dim == 3);  // or we shouldn't be here.
+
+  m_cellsAsTets = axom::Array<TetrahedronType>(ArrayOptions::Uninitialized(),
+                                               NUM_TETS_PER_HEX * m_cellCount,
+                                               NUM_TETS_PER_HEX * m_cellCount,
+                                               m_allocId);
+  auto cellsAsTetsView = m_cellsAsTets.view();
+
+  auto cellsAsHexesView = getCellsAsHexes();
+
+  axom::for_all<ExecSpace>(
+    m_cellCount,
+    AXOM_LAMBDA(axom::IndexType cellId) {
+      const auto& hex = cellsAsHexesView[cellId];
+      auto* firstTetPtr = &cellsAsTetsView[cellId * NUM_TETS_PER_HEX];
+      hex.triangulate(firstTetPtr);
+    });
+}
+
+template <typename ExecSpace>
+void ShapeMesh::computeHexVolumesImpl()
+{
+  m_hexVolumes =
+    axom::Array<double>(ArrayOptions::Uninitialized(), m_cellCount, m_cellCount, m_allocId);
+
+  auto cellsAsHexes = getCellsAsHexes();
+
+  auto hexVolumesView = m_hexVolumes.view();
+  axom::for_all<ExecSpace>(
+    m_cellCount,
+    AXOM_LAMBDA(axom::IndexType i) { hexVolumesView[i] = cellsAsHexes[i].volume(); });
+}
+
+template <typename ExecSpace>
+void ShapeMesh::computeHexBbsImpl()
+{
+  m_hexBbs =
+    axom::Array<BoundingBox3DType>(ArrayOptions::Uninitialized(), m_cellCount, m_cellCount, m_allocId);
+
+  auto cellsAsHexes = getCellsAsHexes();
+
+  auto hexBbsView = m_hexBbs.view();
+  axom::for_all<ExecSpace>(
+    m_cellCount,
+    AXOM_LAMBDA(axom::IndexType i) {
+      hexBbsView[i] = primal::compute_bounding_box<double, 3>(cellsAsHexes[i]);
+    });
+}
+
+template <typename ExecSpace>
+void ShapeMesh::computeCellLengthsImpl()
+{
+  m_cellLengths =
+    axom::Array<double>(ArrayOptions::Uninitialized(), m_cellCount, m_cellCount, m_allocId);
+
+  auto cellBbs = getCellBoundingBoxes();
+
+  auto lengthsView = m_cellLengths.view();
+  axom::for_all<ExecSpace>(
+    m_cellCount,
+    AXOM_LAMBDA(axom::IndexType cellId) { lengthsView[cellId] = cellBbs[cellId].range().norm(); });
+}
+
+template <typename ExecSpace>
+void ShapeMesh::computeVertPointsImpl()
+{
+  m_vertPoints3D = axom::Array<Point3DType>(m_vertexCount, m_vertexCount, m_allocId);
+
+  auto& vertCoords = getVertexCoords3D();
+  const auto& vX = vertCoords[0];
+  const auto& vY = vertCoords[1];
+  const auto& vZ = vertCoords[2];
+
+  auto vertPointsView = m_vertPoints3D.view();
+  axom::for_all<ExecSpace>(
+    m_vertexCount,
+    AXOM_LAMBDA(axom::IndexType vi) {
+      vertPointsView[vi] = Point3DType {vX[vi], vY[vi], vZ[vi]};
+    });
+}
+
+template <typename ExecSpace, typename T>
+void ShapeMesh::elementwiseDivideImpl(const T* numerator,
+                                      const T* denominator,
+                                      T* quotient,
+                                      axom::IndexType n)
+{
+  axom::for_all<ExecSpace>(
+    n,
+    AXOM_LAMBDA(axom::IndexType i) { quotient[i] = numerator[i] / denominator[i]; });
+}
+
+conduit::Node& ShapeMesh::getMeshConduitPath(conduit::Node& node,
+                                             const std::string& path,
+                                             const conduit::DataType& dtype)
+{
+  conduit::Node* rval = nullptr;
+
+  if(node.has_path(path))
+  {
+    rval = &node.fetch_existing(path);
+    SLIC_ERROR_IF(
+      rval->dtype().id() != dtype.id() ||
+        rval->dtype().number_of_elements() != dtype.number_of_elements() ||
+        rval->dtype().offset() != dtype.offset() || rval->dtype().stride() != dtype.stride() ||
+        rval->dtype().offset() != dtype.offset() || rval->dtype().endianness() != dtype.endianness(),
+      "Blueprint mesh doesn't have correct type for path '" + path + "'");
+  }
+  else
+  {
+    node.set_allocator(sidre::ConduitMemory::axomAllocIdToConduit(m_allocId));
+    rval = &node.fetch(path);
+    rval->set_allocator(sidre::ConduitMemory::axomAllocIdToConduit(m_allocId));
+    rval->set(dtype);
+  }
+
+  // Verify that data is in memory space usable by m_runtimePolicy.
+  void* dataPtr = rval->data_ptr();
+  int allocId = axom::getAllocatorIDFromPointer(dataPtr);
+
+  bool memoryOkForPolicy =
+#if defined(AXOM_RUNTIME_POLICY_USE_OPENMP)
+    m_runtimePolicy == axom::runtime_policy::Policy::omp
+    ? axom::execution_space<axom::OMP_EXEC>::usesAllocId(allocId)
+    :
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_CUDA)
+    m_runtimePolicy == axom::runtime_policy::Policy::cuda
+    ? axom::execution_space<axom::CUDA_EXEC<256>>::usesAllocId(allocId)
+    :
+#endif
+#if defined(AXOM_RUNTIME_POLICY_USE_HIP)
+    m_runtimePolicy == axom::runtime_policy::Policy::hip
+    ? axom::execution_space<axom::HIP_EXEC<256>>::usesAllocId(allocId)
+    :
+#endif
+    axom::execution_space<axom::SEQ_EXEC>::usesAllocId(allocId);
+
+  SLIC_WARNING_IF(!memoryOkForPolicy,
+                  "Blueprint mesh data at " + axom::fmt::format("{}", dataPtr) + " from path '" +
+                    path + "' is not accessible by execution policy " +
+                    axom::runtime_policy::policyToName(m_runtimePolicy));
+
+  return *rval;
+}
+
+}  // end namespace experimental
+}  // end namespace quest
+}  // end namespace axom

--- a/src/axom/quest/ShapeMesh.hpp
+++ b/src/axom/quest/ShapeMesh.hpp
@@ -1,0 +1,325 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_QUEST_SHAPEEMESH_HPP
+#define AXOM_QUEST_SHAPEEMESH_HPP
+
+#ifndef AXOM_USE_CONDUIT
+  #error "ShapeMesh requires Conduit"
+// TODO: Support MFEM as well.
+#endif
+
+#include "axom/core.hpp"
+#include "axom/primal/geometry/Tetrahedron.hpp"
+#include "axom/primal/geometry/Hexahedron.hpp"
+#include "axom/primal/geometry/BoundingBox.hpp"
+
+#ifdef AXOM_USE_SIDRE
+  #include "axom/sidre.hpp"
+#endif
+
+#include "conduit/conduit_node.hpp"
+#include "conduit_blueprint.hpp"
+
+namespace axom
+{
+namespace quest
+{
+namespace experimental
+{
+
+/*!
+ * @brief Computational mesh and intermediate data typically used in shaping.
+ *
+ * This wrapper class:
+ * - encapsulate mesh-dependent data
+ * - provide a common interface to mesh data regardless of the mesh format
+ * - avoid redundant work
+ * - provides some convenience tools typically used in shaping
+ *
+ * The wrapped mesh must have an unstructured 3D hex topology.  That
+ * is the only topology currently supported.  It can be extended to
+ * support 2D.
+ *
+ * TODO: Support MFEM mesh.  First pass only supports blueprint.
+*/
+class ShapeMesh
+{
+public:
+  using RuntimePolicy = axom::runtime_policy::Policy;
+  using Point3DType = primal::Point<double, 3>;
+  using TetrahedronType = primal::Tetrahedron<double, 3>;
+  using HexahedronType = primal::Hexahedron<double, 3>;
+  using BoundingBox3DType = primal::BoundingBox<double, 3>;
+
+  /*!
+   * @brief Constructor with computational mesh in a conduit::Node.
+   *
+   * @param [in] runtimePolicy The run-time policy used for computations
+   * @param [in] allocatorId Allocator id for internal and scratch space.
+   *   It should be compatible with @c runtimePolicy.
+   *   If axom::INVALID_ALLOCATOR_ID is specified, it will be
+   *   replaced with the default allocator for @c runtimePolicy.
+   *   For good performance, especially on GPUs, fast memory pools
+   *   should be used.
+   * @param [in/out] bpMesh Blueprint mesh to shape into.
+   * @param [in] topoName Name of the Blueprint topology.  If empty,
+   *   use the first topology in @c bpMesh.
+   * @param [in] matsetName Name of the Blueprint material set.
+   *   If empty, use the first material set in @c bpMesh.
+   *
+   * Incoming mesh array data are assumed to be accessible by the
+   * runtime policy, or an error will result.  (However the data need
+   * not correspond to the allocator id.)
+   */
+  ShapeMesh(RuntimePolicy runtimePolicy,
+            int allocatorId,
+            conduit::Node& bpMesh,
+            const std::string& topoName = {},
+            const std::string& matsetName = {});
+
+#ifdef AXOM_USE_SIDRE
+  /*!
+   * @brief Constructor with computational mesh in a sidre::Group.
+
+   * @param [in] runtimePolicy The run-time policy used for computations
+   * @param [in] allocatorId Allocator id for internal and scratch space.
+   *   It should be compatible with @c runtimePolicy.
+   *   If axom::INVALID_ALLOCATOR_ID is specified, it will be
+   *   replaced with the default allocator for @c runtimePolicy.
+   *   For good performance, especially on GPUs, fast memory pools
+   *   should be used.
+   * @param [in/out] bpMesh Blueprint mesh to shape into.
+   * @param [in] topoName Name of the Blueprint topology.  If empty,
+   *   use the first topology in @c bpMesh.
+   * @param [in] matsetName Name of the Blueprint material set.
+   *   If empty, use the first material set in @c bpMesh.
+   *
+   * Incoming mesh array data are assumed to be accessible by the
+   * runtime policy, or an error will result.  (However the data need
+   * not correspond to the allocator id.)
+  */
+  ShapeMesh(RuntimePolicy runtimePolicy,
+            int allocatorId,
+            sidre::Group* bpMesh,
+            const std::string& topoName = {},
+            const std::string& matsetName = {});
+#endif
+
+  /*!
+   * @brief Runtime policy set in constructor.
+   */
+  RuntimePolicy getRuntimePolicy() const { return m_runtimePolicy; }
+
+  /*!
+   * @brief Allocator id set in constructor.
+   */
+  int getAllocatorID() const { return m_allocId; }
+
+  /*
+   * !@brief Return computational mesh as a sidre::Group if it has
+   * that form, or nullptr otherwise.
+  */
+  sidre::Group* getMeshAsSidre() { return m_bpGrpExt; }
+
+  /*!
+   * @brief Return computational mesh as a conduit::Node if it has
+   * that form, or nullptr otherwise.
+  */
+  conduit::Node* getMeshAsConduit() { return m_bpNodeExt; }
+
+  //!@brief Dimension of the mesh (2 or 3)
+  int dimension() const { return m_dim; }
+
+  //!@brief Number of cells in mesh.
+  IndexType getCellCount() const { return m_cellCount; }
+
+  //!@brief Number of vertices in mesh.
+  IndexType getVertexCount() const { return m_vertexCount; }
+
+  //@{
+  //!@name Accessors to mesh data.
+  //@}
+
+  //@{
+  //!@name Accessors to mesh-dependent intermediate data.
+  /*
+   * This data is dynamically generated as needed, and cached for use
+   * by multiple geometry clippers.  The idea is to eliminate redundant
+   * code and computations.
+   */
+  /*!
+   * @brief Tetrahedral version of mesh cells with cell i having tet ids
+   * [i*NUM_TETS_PER_HEX, (i+1)*NUM_TETS_PER_HEX).
+  */
+  axom::ArrayView<const TetrahedronType> getCellsAsTets();
+  axom::ArrayView<const HexahedronType> getCellsAsHexes();
+  //!@brief Get volume of mesh cells.
+  axom::ArrayView<const double> getCellVolumes();
+  //!@brief Get characteristic lengths of mesh cells.
+  axom::ArrayView<const double> getCellLengths();
+  axom::ArrayView<const BoundingBox3DType> getCellBoundingBoxes();
+  axom::ArrayView<const IndexType, 2> getCellNodeConnectivity();
+  axom::ArrayView<const Point3DType> getVertexPoints();
+  const axom::StackArray<axom::ArrayView<const double>, 3>& getVertexCoords3D() const
+  {
+    return m_vertCoordsViews3D;
+  }
+  /*!
+   * @brief Precompute (and cache) mesh-dependent intermediate data
+   * that may be used in clipping.
+   *
+   * Mesh-dependent data are computed as needed and cached, but this
+   * computes them all at once.
+  */
+  void precomputeMeshData();
+  //@}
+
+  /*!
+   * @brief Check whether mesh meets requirements for shaping.
+   * @param whyNot [out] Diagnostic message if mesh is invalid.
+   */
+  bool isValidForShaping(std::string& whyNot) const;
+
+  //@{
+  /*!
+   * @brief Create (Blueprint) matset in the mesh for a material.
+   * @param materialName [in]
+   * @param volumes [in] Cell-centered volumes
+   * @param isFraction [in] Whether @c volumes is actually
+   *   volume fractions.
+   *
+   * @pre volumes.size() == getCellCount()
+   * @pre Mesh's matsets is multi-buffer, material-dominant
+   * form (see https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html#material-sets).
+   * Currently not supporting other matset forms.
+   */
+  void setMatsetFromVolume(const std::string& materialName,
+                           const axom::ArrayView<double>& volumes,
+                           bool isFraction = false);
+
+  void setFreeVolumeFractions(const std::string& freeName);
+  //@}
+
+private:
+  const RuntimePolicy m_runtimePolicy;
+
+  int m_allocId;
+
+  //! @brief Mesh topology name.
+  const std::string m_topoName;
+
+  //! @brief Mesh matset name.
+  const std::string m_matsetName;
+
+#if defined(AXOM_USE_SIDRE)
+  //! @brief External computational mesh, when mesh is provided as a Group.
+  axom::sidre::Group* m_bpGrpExt;
+
+  //! @brief Initial shallow copy of m_bpGrp in an internal Node storage.
+  conduit::Node m_bpNodeInt;
+#endif
+
+  //! @brief External computational mesh, when mesh is provided as a Node.
+  conduit::Node* m_bpNodeExt {nullptr};
+
+  //!@brief Dimension of mesh (2 or 3)
+  int m_dim;
+
+  //!@brief Number of cells in mesh.
+  IndexType m_cellCount;
+
+  //!@brief Number of vertices in mesh.
+  IndexType m_vertexCount;
+
+  //!@brief 3D Vertex coordinates as 1D ArrayViews.
+  axom::StackArray<axom::ArrayView<const double>, 3> m_vertCoordsViews3D;
+
+  //!@brief 3D Vertex coordinates as 1D Points.
+  axom::Array<Point3DType> m_vertPoints3D;
+
+  //!@brief Vertex indices for each cell.
+  axom::ArrayView<const axom::IndexType, 2> m_connectivity;
+
+  //!@brief Mesh cells as an array of hexes.
+  axom::Array<HexahedronType> m_cellsAsHexes;
+
+  //!@brief Volumes of hex cells.
+  axom::Array<double> m_hexVolumes;
+
+  //!@brief Characteristic lengths of cells.
+  axom::Array<double> m_cellLengths;
+
+  //!@brief Bounding boxes for m_cellsAsHexes.
+  axom::Array<BoundingBox3DType> m_hexBbs;
+
+  //!@brief Cells as TETS_PER_HEXAHEDRON*m_cellCount tets.
+  axom::Array<TetrahedronType> m_cellsAsTets;
+
+  void computeCellsAsHexes();
+  void computeCellsAsTets();
+  void computeHexVolumes();
+  void computeHexBbs();
+  void computeCellLengths();
+  void computeVertPoints();
+  void computeConnectivity();
+
+#if defined(__CUDACC__)
+public:
+#endif
+
+  template <typename ExecSpace>
+  void computeCellsAsHexesImpl();
+
+  template <typename ExecSpace>
+  void computeCellsAsTetsImpl();
+
+  template <typename ExecSpace>
+  void computeHexVolumesImpl();
+
+  template <typename ExecSpace>
+  void computeHexBbsImpl();
+
+  template <typename ExecSpace>
+  void computeCellLengthsImpl();
+
+  template <typename ExecSpace>
+  void computeVertPointsImpl();
+
+  template <typename ExecSpace, typename T>
+  void elementwiseDivideImpl(const T* numerator, const T* denominator, T* quotient, axom::IndexType n);
+
+  template <typename T>
+  void fillNImpl(axom::ArrayView<T> a, const T& val) const;
+
+  template <typename T>
+  void elementwiseAddImpl(const axom::ArrayView<T> a,
+                          const axom::ArrayView<T> b,
+                          axom::ArrayView<T> result) const;
+
+  template <typename T>
+  void elementwiseComplementImpl(const axom::ArrayView<T> a,
+                                 const T& val,
+                                 axom::ArrayView<T> results) const;
+
+  /*!
+   * @brief Get a Conduit hierarchy within another Conduit hierarchy.
+   *
+   * If specified path doesn't exist, create it.  If it does, verify
+   * its conduit::DataType.
+   *
+   * If the node holds array data, verify that the data is compatible
+   * with m_runtimePolicy.
+   */
+  conduit::Node& getMeshConduitPath(conduit::Node& node,
+                                    const std::string& path,
+                                    const conduit::DataType& dtype);
+};
+
+}  // namespace experimental
+}  // namespace quest
+}  // namespace axom
+
+#endif  // AXOM_QUEST_SHAPEEMESH_HPP

--- a/src/axom/quest/detail/clipping/MeshClipperImpl.hpp
+++ b/src/axom/quest/detail/clipping/MeshClipperImpl.hpp
@@ -1,0 +1,906 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_MESHCLIPPERIMPL_HPP_
+#define AXOM_MESHCLIPPERIMPL_HPP_
+
+#ifndef AXOM_USE_RAJA
+  #error "quest::MeshClipper requires RAJA."
+#endif
+
+#include "axom/quest/MeshClipperStrategy.hpp"
+#include "axom/quest/MeshClipper.hpp"
+#include "axom/spin/BVH.hpp"
+#include "RAJA/RAJA.hpp"
+
+namespace axom
+{
+namespace quest
+{
+namespace experimental
+{
+namespace detail
+{
+
+template <typename ExecSpace>
+class MeshClipperImpl : public MeshClipper::Impl
+{
+public:
+  using LabelType = MeshClipper::LabelType;
+
+  MeshClipperImpl(MeshClipper& clipper) : MeshClipper::Impl(clipper) { }
+
+  void initVolumeOverlaps(const axom::ArrayView<MeshClipperStrategy::LabelType>& labels,
+                          axom::ArrayView<double> ovlap) override
+  {
+    const axom::IndexType cellCount = getShapeMesh().getCellCount();
+    SLIC_ASSERT(labels.size() == cellCount);
+    SLIC_ASSERT(ovlap.size() == cellCount);
+
+    auto cellVolumes = getShapeMesh().getCellVolumes();
+
+    /*
+     * Overlap volumes is cell volume for cells inside geometry.
+     * and zero for cells outside geometry.
+     * Cells on boundary are zeroed for accumulating by clipping process.
+    */
+    axom::for_all<ExecSpace>(
+      cellCount,
+      AXOM_LAMBDA(axom::IndexType i) {
+        auto& l = labels[i];
+        ovlap[i] = l == MeshClipperStrategy::LABEL_IN ? cellVolumes[i] : 0.0;
+      });
+
+    return;
+  }
+
+  void initVolumeOverlaps(axom::ArrayView<double> ovlap) override
+  {
+    SLIC_ASSERT(ovlap.size() == getShapeMesh().getCellCount());
+    ovlap.fill(0.0);
+    return;
+  }
+
+  void addVolumesOfInteriorTets(axom::ArrayView<const axom::IndexType> cellsOnBdry,
+                                axom::ArrayView<const LabelType> tetLabels,
+                                axom::ArrayView<double> ovlap) override
+  {
+    auto meshTets = getShapeMesh().getCellsAsTets();
+
+    const axom::IndexType hexCount = cellsOnBdry.size();
+
+    SLIC_ASSERT(tetLabels.size() == TETS_PER_HEXAHEDRON * hexCount);
+
+    axom::for_all<ExecSpace>(
+      hexCount,
+      AXOM_LAMBDA(axom::IndexType ih) {
+        const axom::IndexType hexId = cellsOnBdry[ih];
+        const LabelType* tetLabelsForHex = &tetLabels[TETS_PER_HEXAHEDRON * ih];
+        for(int it = 0; it < TETS_PER_HEXAHEDRON; ++it)
+        {
+          if(tetLabelsForHex[it] == MeshClipperStrategy::LABEL_IN)
+          {
+            const axom::IndexType tetId = hexId * TETS_PER_HEXAHEDRON + it;
+            const auto& tet = meshTets[tetId];
+            ovlap[hexId] += tet.volume();
+          }
+        }
+      });
+  }
+
+  //! @brief Make an list of indices where labels have value LABEL_ON.
+  void collectOnIndices(const axom::ArrayView<LabelType>& labels,
+                        axom::Array<axom::IndexType>& onIndices) override
+  {
+    if(labels.empty())
+    {
+      return;
+    };
+
+    AXOM_ANNOTATE_SCOPE("MeshClipper::collect_unlabeleds");
+    /*!
+     * 1. Generate tmpLabels, having a value of 1 where labels is LABEL_ON and zero elsewhere.
+     * 2. Inclusive scan on tmpLabels to generate values that step up at unlabeled cells.
+     * 3. Find unlabeled cells by seeing where tmpLabels changes values.
+     *    (Handle first cell separately, then loop from second cell on.)
+    */
+    using ScanPolicy = typename axom::execution_space<ExecSpace>::loop_policy;
+
+    const axom::IndexType labelCount = labels.size();
+
+    axom::Array<axom::IndexType> tmpLabels(labels.shape(), labels.getAllocatorID());
+    auto tmpLabelsView = tmpLabels.view();
+    axom::for_all<ExecSpace>(
+      labelCount,
+      AXOM_LAMBDA(axom::IndexType ci) {
+        tmpLabelsView[ci] = labels[ci] == MeshClipperStrategy::LABEL_ON;
+      });
+
+    RAJA::inclusive_scan_inplace<ScanPolicy>(RAJA::make_span(tmpLabels.data(), tmpLabels.size()),
+                                             RAJA::operators::plus<axom::IndexType> {});
+
+    axom::IndexType onCount; // Count of tets labeled ON.
+    axom::copy(&onCount, &tmpLabels.back(), sizeof(onCount));
+
+    if(onIndices.size() < onCount || onIndices.getAllocatorID() != labels.getAllocatorID())
+    {
+      onIndices = axom::Array<axom::IndexType> {axom::ArrayOptions::Uninitialized(),
+                                                onCount,
+                                                onCount,
+                                                labels.getAllocatorID()};
+    }
+    auto onIndicesView = onIndices.view();
+
+    LabelType firstLabel = '\0';
+    axom::copy(&firstLabel, &labels[0], sizeof(firstLabel));
+    if(firstLabel == 1)
+    {
+      axom::IndexType zero = 0;
+      axom::copy(&onIndices[0], &zero, sizeof(zero));
+    }
+
+    axom::for_all<ExecSpace>(
+      1,
+      labelCount,
+      AXOM_LAMBDA(axom::IndexType i) {
+        if(tmpLabelsView[i] != tmpLabelsView[i - 1])
+        {
+          onIndicesView[tmpLabelsView[i - 1]] = i;
+        }
+      });
+  }
+
+  void remapTetIndices(axom::ArrayView<axom::IndexType> tetsOnBdry,
+                       axom::ArrayView<const axom::IndexType> cellsOnBdry) override
+  {
+    /*
+     * cellsOnBdry is a list of cell indices.
+     *
+     * Each cell has TETS_PER_HEXAHEDRON.
+     *
+     * tetsOnBdry are a list of indices referring to the tets in those
+     * cells.  N tets for each cell.  So the values in tetsOnBDry are
+     * in [0, cellsOnBdry.size()*24).
+     *
+     * Use the indices in cellsOnBdry to map tetsOnBdry values to the
+     * indices of the full set of tets.
+     */
+    if(tetsOnBdry.empty())
+    {
+      return;
+    }
+
+    axom::for_all<ExecSpace>(
+      tetsOnBdry.size(),
+      AXOM_LAMBDA(axom::IndexType i) {
+        auto tetIdId = tetsOnBdry[i];
+        auto cellIdId = tetIdId / TETS_PER_HEXAHEDRON;
+        auto cellId = cellsOnBdry[cellIdId];
+        auto tetIdInCell = tetIdId % TETS_PER_HEXAHEDRON;
+        auto tetId = cellId * TETS_PER_HEXAHEDRON + tetIdInCell;
+        tetsOnBdry[i] = tetId;
+      });
+  }
+
+  /*
+   * Clip tets of from the mesh with tets or octs from the clipping
+   * geomnetry.  This implemenation was lifted from IntersectionShaper
+   * and modified to work both tet and oct representations of the
+   * geometry.
+   */
+  void computeClipVolumes3D(axom::ArrayView<double> ovlap) override
+  {
+    AXOM_ANNOTATE_SCOPE("MeshClipper::computeClipVolumes3D");
+
+    using BoundingBoxType = primal::BoundingBox<double, 3>;
+
+    ShapeMesh& shapeMesh = getShapeMesh();
+
+    const int allocId = shapeMesh.getAllocatorID();
+
+    const IndexType cellCount = shapeMesh.getCellCount();
+
+    SLIC_INFO(axom::fmt::format(
+      "MeshClipper::computeClipVolumes3D: Getting discrete geometry for shape '{}'",
+      getStrategy().name()));
+
+    //
+    // Get the geometry in discrete pieces, which can be tets or octs.
+    //
+    auto& strategy = getStrategy();
+    axom::Array<axom::primal::Tetrahedron<double, 3>> geomAsTets;
+    axom::Array<axom::primal::Octahedron<double, 3>> geomAsOcts;
+    const bool useOcts = strategy.getGeometryAsOcts(shapeMesh, geomAsOcts);
+    const bool useTets = strategy.getGeometryAsTets(shapeMesh, geomAsTets);
+    SLIC_ASSERT(useOcts || geomAsOcts.empty());
+    SLIC_ASSERT(useTets || geomAsTets.empty());
+    if(useTets == useOcts)
+    {
+      SLIC_ERROR(
+        axom::fmt::format("Problem with MeshClipperStrategy implementation '{}'."
+                          "  Implementations that don't provide a specializedClip function"
+                          " must provide exactly one getGeometryAsOcts() or getGeometryAsTets()."
+                          "  This implementation provides {}.",
+                          strategy.name(),
+                          int(useOcts) + int(useTets)));
+    }
+
+    auto geomTetsView = geomAsTets.view();
+    auto geomOctsView = geomAsOcts.view();
+
+    SLIC_INFO(axom::fmt::format("{:-^80}", " Inserting shapes' bounding boxes into BVH "));
+
+    //
+    // Generate the BVH over the (bounding boxes of the) discretized geometry
+    //
+    const axom::IndexType bbCount = useTets ? geomAsTets.size() : geomAsOcts.size();
+    axom::Array<BoundingBoxType> pieceBbs(bbCount, bbCount, allocId);
+    axom::ArrayView<BoundingBoxType> pieceBbsView = pieceBbs.view();
+
+    // Get the bounding boxes for the shapes
+    if(useTets)
+    {
+      axom::for_all<ExecSpace>(
+        pieceBbsView.size(),
+        AXOM_LAMBDA(axom::IndexType i) {
+          pieceBbsView[i] = primal::compute_bounding_box<double, 3>(geomTetsView[i]);
+        });
+    }
+    else
+    {
+      axom::for_all<ExecSpace>(
+        pieceBbsView.size(),
+        AXOM_LAMBDA(axom::IndexType i) {
+          pieceBbsView[i] = primal::compute_bounding_box<double, 3>(geomOctsView[i]);
+        });
+    }
+
+    spin::BVH<3, ExecSpace, double> bvh;
+    bvh.initialize(pieceBbsView, pieceBbsView.size());
+
+    SLIC_INFO(axom::fmt::format("{:-^80}", " Querying the BVH tree "));
+
+    axom::ArrayView<const BoundingBoxType> cellBbsView = shapeMesh.getCellBoundingBoxes();
+
+    // Find which shape bounding boxes intersect hexahedron bounding boxes
+    SLIC_INFO(
+      axom::fmt::format("{:-^80}", " Finding shape candidates for each hexahedral element "));
+
+    axom::Array<IndexType> offsets(cellCount, cellCount, allocId);
+    axom::Array<IndexType> counts(cellCount, cellCount, allocId);
+    axom::Array<IndexType> candidates;
+    AXOM_ANNOTATE_BEGIN("bvh.findBoundingBoxes");
+    bvh.findBoundingBoxes(offsets, counts, candidates, cellCount, cellBbsView);
+    AXOM_ANNOTATE_END("bvh.findBoundingBoxes");
+
+    // Get the total number of candidates
+    using ATOMIC_POL = typename axom::execution_space<ExecSpace>::atomic_policy;
+
+    const auto countsView = counts.view();
+    const int candidateCount = candidates.size();
+
+    AXOM_ANNOTATE_BEGIN("allocate scratch space");
+    // Initialize hexahedron indices and shape candidates
+    axom::Array<IndexType> hexIndices(candidateCount * TETS_PER_HEXAHEDRON,
+                                      candidateCount * TETS_PER_HEXAHEDRON,
+                                      allocId);
+    auto hexIndicesView = hexIndices.view();
+
+    axom::Array<IndexType> shapeCandidates(candidateCount * TETS_PER_HEXAHEDRON,
+                                           candidateCount * TETS_PER_HEXAHEDRON,
+                                           allocId);
+    auto shapeCandidatesView = shapeCandidates.view();
+
+    // Tetrahedrons from hexes (24 for each hex)
+    auto cellsAsTets = shapeMesh.getCellsAsTets();
+
+    // Index into 'tets'
+    axom::Array<IndexType> tetIndices(candidateCount * TETS_PER_HEXAHEDRON,
+                                      candidateCount * TETS_PER_HEXAHEDRON,
+                                      allocId);
+    auto tetIndicesView = tetIndices.view();
+    AXOM_ANNOTATE_END("allocate scratch space");
+
+    // New total number of candidates after omitting degenerate shapes
+    AXOM_ANNOTATE_BEGIN("newTotalCandidates memory");
+    IndexType tetCandidatesCount = 0;
+    IndexType* tetCandidatesCountPtr = &tetCandidatesCount;
+    if(!axom::execution_space<ExecSpace>::usesMemorySpace(MemorySpace::Dynamic))
+    {
+      // Use temporary space compatible with runtime policy.
+      tetCandidatesCountPtr = axom::allocate<IndexType>(1, allocId);
+      axom::copy(tetCandidatesCountPtr, &tetCandidatesCount, sizeof(tetCandidatesCount));
+    }
+    AXOM_ANNOTATE_END("newTotalCandidates memory");
+
+    const auto offsetsView = offsets.view();
+    const auto candidatesView = candidates.view();
+    {
+      AXOM_ANNOTATE_SCOPE("init_candidates");
+      axom::for_all<ExecSpace>(
+        cellCount,
+        AXOM_LAMBDA(axom::IndexType i) {
+          for(int j = 0; j < countsView[i]; j++)
+          {
+            int shapeIdx = candidatesView[offsetsView[i] + j];
+
+            for(int k = 0; k < TETS_PER_HEXAHEDRON; k++)
+            {
+              IndexType idx = RAJA::atomicAdd<ATOMIC_POL>(tetCandidatesCountPtr, IndexType {1});
+              hexIndicesView[idx] = i;
+              shapeCandidatesView[idx] = shapeIdx;
+              tetIndicesView[idx] = i * TETS_PER_HEXAHEDRON + k;
+            }
+          }
+        });
+    }
+
+    SLIC_INFO(
+      axom::fmt::format("Running clip loop on {} candidate tets for of all {} hexes in the mesh",
+                        tetCandidatesCount,
+                        cellCount));
+
+    constexpr double EPS = 1e-10;
+    constexpr bool tryFixOrientation = false;
+
+    {
+      tetCandidatesCount = TETS_PER_HEXAHEDRON * candidates.size();
+      AXOM_ANNOTATE_SCOPE("MeshClipper::clipLoop");
+#if defined(AXOM_DEBUG)
+      // Verifying: this should always pass.
+      if(tetCandidatesCountPtr != &tetCandidatesCount)
+      {
+        axom::copy(&tetCandidatesCount, tetCandidatesCountPtr, sizeof(IndexType));
+      }
+      SLIC_ASSERT(tetCandidatesCount == candidateCount * TETS_PER_HEXAHEDRON);
+#endif
+
+      if(useTets)
+      {
+        axom::for_all<ExecSpace>(
+          tetCandidatesCount,
+          AXOM_LAMBDA(axom::IndexType i) {
+            const int index = hexIndicesView[i];
+            const int shapeIndex = shapeCandidatesView[i];
+            const int tetIndex = tetIndicesView[i];
+
+            const auto poly =
+              primal::clip<double, MAX_VERTS_FOR_TET_CLIPPING, MAX_NBRS_PER_VERT_FOR_TET_CLIPPING>(
+                geomTetsView[shapeIndex],
+                cellsAsTets[tetIndex],
+                EPS,
+                tryFixOrientation);
+
+            // Poly is valid
+            if(poly.numVertices() >= 4)
+            {
+              // Workaround - intermediate volume variable needed for
+              // CUDA Pro/E test case correctness
+              double volume = poly.volume();
+              SLIC_ASSERT(volume >= 0);
+              RAJA::atomicAdd<ATOMIC_POL>(ovlap.data() + index, volume);
+            }
+          });
+      }
+      else  // useOcts
+      {
+        axom::for_all<ExecSpace>(
+          tetCandidatesCount,
+          AXOM_LAMBDA(axom::IndexType i) {
+            const int index = hexIndicesView[i];
+            const int shapeIndex = shapeCandidatesView[i];
+            const int tetIndex = tetIndicesView[i];
+
+            const auto poly =
+              primal::clip<double, MAX_VERTS_FOR_OCT_CLIPPING, MAX_NBRS_PER_VERT_FOR_OCT_CLIPPING>(
+                geomOctsView[shapeIndex],
+                cellsAsTets[tetIndex],
+                EPS,
+                tryFixOrientation);
+
+            // Poly is valid
+            if(poly.numVertices() >= 4)
+            {
+              // Workaround - intermediate volume variable needed for
+              // CUDA Pro/E test case correctness
+              double volume = poly.volume();
+              SLIC_ASSERT(volume >= 0);
+              RAJA::atomicAdd<ATOMIC_POL>(ovlap.data() + index, volume);
+            }
+          });
+      }
+    }
+
+    if(tetCandidatesCountPtr != &tetCandidatesCount)
+    {
+      axom::deallocate(tetCandidatesCountPtr);
+    }
+  }  // end of computeClipVolumes3D() function
+
+  /*
+   * Clip tets of from the mesh with tets or octs from the clipping
+   * geomnetry.  This implemenation is like the above except that it
+   * limits clipping to a subset of mesh cells labeled as potentially
+   * on the boundary.
+   */
+  void computeClipVolumes3D(const axom::ArrayView<axom::IndexType>& cellIndices,
+                            axom::ArrayView<double> ovlap) override
+
+  {
+    AXOM_ANNOTATE_SCOPE("MeshClipper::computeClipVolumes3D:limited");
+
+    using BoundingBoxType = primal::BoundingBox<double, 3>;
+
+    ShapeMesh& shapeMesh = getShapeMesh();
+
+    const int allocId = shapeMesh.getAllocatorID();
+
+    const IndexType cellCount = shapeMesh.getCellCount();
+
+    SLIC_INFO(axom::fmt::format(
+      "MeshClipper::computeClipVolumes3D: Getting discrete geometry for shape '{}'",
+      getStrategy().name()));
+
+    auto& strategy = getStrategy();
+    axom::Array<axom::primal::Tetrahedron<double, 3>> geomAsTets;
+    axom::Array<axom::primal::Octahedron<double, 3>> geomAsOcts;
+    const bool useOcts = strategy.getGeometryAsOcts(shapeMesh, geomAsOcts);
+    const bool useTets = strategy.getGeometryAsTets(shapeMesh, geomAsTets);
+    SLIC_ASSERT(useOcts || geomAsOcts.empty());
+    SLIC_ASSERT(useTets || geomAsTets.empty());
+    if(useTets == useOcts)
+    {
+      SLIC_ERROR(
+        axom::fmt::format("Problem with MeshClipperStrategy implementation '{}'."
+                          "  Implementations that don't provide a specializedClip function"
+                          " must provide exactly one getGeometryAsOcts() or getGeometryAsTets()."
+                          "  This implementation provides {}.",
+                          strategy.name(),
+                          int(useOcts) + int(useTets)));
+    }
+
+    auto geomTetsView = geomAsTets.view();
+    auto geomOctsView = geomAsOcts.view();
+
+    SLIC_INFO(axom::fmt::format("{:-^80}", " Inserting shapes' bounding boxes into BVH "));
+
+    // Generate the BVH tree over the shape's discretized geometry
+    // axis-aligned bounding boxes.  "pieces" refers to tets or octs.
+    const axom::IndexType bbCount = useTets ? geomAsTets.size() : geomAsOcts.size();
+    axom::Array<BoundingBoxType> pieceBbs(bbCount, bbCount, allocId);
+    axom::ArrayView<BoundingBoxType> pieceBbsView = pieceBbs.view();
+
+    // Get the bounding boxes for the shapes
+    if(useTets)
+    {
+      axom::for_all<ExecSpace>(
+        pieceBbsView.size(),
+        AXOM_LAMBDA(axom::IndexType i) {
+          pieceBbsView[i] = primal::compute_bounding_box<double, 3>(geomTetsView[i]);
+        });
+    }
+    else
+    {
+      axom::for_all<ExecSpace>(
+        pieceBbsView.size(),
+        AXOM_LAMBDA(axom::IndexType i) {
+          pieceBbsView[i] = primal::compute_bounding_box<double, 3>(geomOctsView[i]);
+        });
+    }
+
+    // Insert shapes' Bounding Boxes into BVH.
+    spin::BVH<3, ExecSpace, double> bvh;
+    bvh.initialize(pieceBbsView, pieceBbsView.size());
+
+    SLIC_INFO(axom::fmt::format("{:-^80}", " Querying the BVH tree "));
+
+    // Create a temporary subset of cell bounding boxes,
+    // containing only those listed in cellIndices.
+    const axom::IndexType limitedCellCount = cellIndices.size();
+    axom::ArrayView<const BoundingBoxType> cellBbsView = shapeMesh.getCellBoundingBoxes();
+    axom::Array<BoundingBoxType> limitedCellBbs(limitedCellCount, limitedCellCount, allocId);
+    axom::ArrayView<BoundingBoxType> limitedCellBbsView = limitedCellBbs.view();
+    axom::for_all<ExecSpace>(
+      limitedCellBbsView.size(),
+      AXOM_LAMBDA(axom::IndexType i) { limitedCellBbsView[i] = cellBbsView[cellIndices[i]]; });
+
+    // Find which shape bounding boxes intersect hexahedron bounding boxes
+    SLIC_INFO(
+      axom::fmt::format("{:-^80}", " Finding shape candidates for each hexahedral element "));
+
+    axom::Array<IndexType> offsets(limitedCellCount, limitedCellCount, allocId);
+    axom::Array<IndexType> counts(limitedCellCount, limitedCellCount, allocId);
+    axom::Array<IndexType> candidates;
+    AXOM_ANNOTATE_BEGIN("bvh.findBoundingBoxes");
+    bvh.findBoundingBoxes(offsets, counts, candidates, limitedCellCount, limitedCellBbsView);
+    AXOM_ANNOTATE_END("bvh.findBoundingBoxes");
+
+    // Get the total number of candidates
+    using ATOMIC_POL = typename axom::execution_space<ExecSpace>::atomic_policy;
+
+    const auto countsView = counts.view();
+    const int candidateCount = candidates.size();
+
+    AXOM_ANNOTATE_BEGIN("allocate scratch space");
+    // Initialize hexahedron indices and shape candidates
+    axom::Array<IndexType> hexIndices(candidateCount * TETS_PER_HEXAHEDRON,
+                                      candidateCount * TETS_PER_HEXAHEDRON,
+                                      allocId);
+    auto hexIndicesView = hexIndices.view();
+
+    axom::Array<IndexType> shapeCandidates(candidateCount * TETS_PER_HEXAHEDRON,
+                                           candidateCount * TETS_PER_HEXAHEDRON,
+                                           allocId);
+    auto shapeCandidatesView = shapeCandidates.view();
+
+    // Tetrahedrons from hexes (24 for each hex)
+    auto cellsAsTets = shapeMesh.getCellsAsTets();
+
+    // Index into 'tets'
+    axom::Array<IndexType> tetIndices(candidateCount * TETS_PER_HEXAHEDRON,
+                                      candidateCount * TETS_PER_HEXAHEDRON,
+                                      allocId);
+    auto tetIndicesView = tetIndices.view();
+    AXOM_ANNOTATE_END("allocate scratch space");
+
+    // New total number of candidates after omitting degenerate shapes
+    AXOM_ANNOTATE_BEGIN("newTotalCandidates memory");
+    IndexType tetCandidatesCount = 0;
+    IndexType* tetCandidatesCountPtr = &tetCandidatesCount;
+    if(!axom::execution_space<ExecSpace>::usesMemorySpace(MemorySpace::Dynamic))
+    {
+      // Use temporary space compatible with runtime policy.
+      tetCandidatesCountPtr = axom::allocate<IndexType>(1, allocId);
+      axom::copy(tetCandidatesCountPtr, &tetCandidatesCount, sizeof(IndexType));
+    }
+    AXOM_ANNOTATE_END("newTotalCandidates memory");
+
+    const auto offsetsView = offsets.view();
+    const auto candidatesView = candidates.view();
+    {
+      AXOM_ANNOTATE_SCOPE("init_candidates");
+      axom::for_all<ExecSpace>(
+        limitedCellCount,
+        AXOM_LAMBDA(axom::IndexType i) {
+          for(int j = 0; j < countsView[i]; j++)
+          {
+            int shapeIdx = candidatesView[offsetsView[i] + j];
+
+            for(int k = 0; k < TETS_PER_HEXAHEDRON; k++)
+            {
+              IndexType idx = RAJA::atomicAdd<ATOMIC_POL>(tetCandidatesCountPtr, IndexType {1});
+              hexIndicesView[idx] = i;
+              shapeCandidatesView[idx] = shapeIdx;
+              tetIndicesView[idx] = i * TETS_PER_HEXAHEDRON + k;
+            }
+          }
+        });
+    }
+
+    SLIC_INFO(axom::fmt::format(
+      "Running clip loop on {} candidate tets for the select {} hexes of the full {} cells",
+      tetCandidatesCount,
+      cellIndices.size(),
+      cellCount));
+
+    constexpr double EPS = 1e-10;
+    constexpr bool tryFixOrientation = false;
+
+    {
+      tetCandidatesCount = TETS_PER_HEXAHEDRON * candidates.size();
+      AXOM_ANNOTATE_SCOPE("MeshClipper::clipLoop_limited");
+#if defined(AXOM_DEBUG)
+      // Verifying: this should always pass.
+      if(tetCandidatesCountPtr != &tetCandidatesCount)
+      {
+        axom::copy(&tetCandidatesCount, tetCandidatesCountPtr, sizeof(IndexType));
+      }
+      SLIC_ASSERT(tetCandidatesCount == candidateCount * TETS_PER_HEXAHEDRON);
+#endif
+
+      if(useTets)
+      {
+        axom::for_all<ExecSpace>(
+          tetCandidatesCount,
+          AXOM_LAMBDA(axom::IndexType i) {
+            int index = hexIndicesView[i];  // index into limited mesh hex array
+            index = cellIndices[index];     // Now, it indexes into the full hex array.
+
+            const int shapeIndex = shapeCandidatesView[i];  // index into pieces array
+            int tetIndex =
+              tetIndicesView[i];  // index into BVH results, implicit because BVH results specify hexes, not tets.
+            int tetIndex1 = tetIndex / TETS_PER_HEXAHEDRON;
+            int tetIndex2 = tetIndex % TETS_PER_HEXAHEDRON;
+            tetIndex = cellIndices[tetIndex1] * TETS_PER_HEXAHEDRON +
+              tetIndex2;  // Now it indexes into the full tets-from-hexes array.
+
+            const auto poly =
+              primal::clip<double, MAX_VERTS_FOR_TET_CLIPPING, MAX_NBRS_PER_VERT_FOR_TET_CLIPPING>(
+                geomTetsView[shapeIndex],
+                cellsAsTets[tetIndex],
+                EPS,
+                tryFixOrientation);
+
+            // Poly is valid
+            if(poly.numVertices() >= 4)
+            {
+              // Workaround - intermediate volume variable needed for
+              // CUDA Pro/E test case correctness
+              double volume = poly.volume();
+              SLIC_ASSERT(volume >= 0);
+              RAJA::atomicAdd<ATOMIC_POL>(ovlap.data() + index, volume);
+            }
+          });
+      }
+      else  // useOcts
+      {
+        axom::for_all<ExecSpace>(
+          tetCandidatesCount,
+          AXOM_LAMBDA(axom::IndexType i) {
+            int index = hexIndicesView[i];  // index into limited mesh hex array
+            index = cellIndices[index];     // Now, it indexes into the full hex array.
+
+            const int shapeIndex = shapeCandidatesView[i];  // index into pieces array
+            int tetIndex =
+              tetIndicesView[i];  // index into BVH results, implicit because BVH results specify hexes, not tets.
+            int tetIndex1 = tetIndex / TETS_PER_HEXAHEDRON;
+            int tetIndex2 = tetIndex % TETS_PER_HEXAHEDRON;
+            tetIndex = cellIndices[tetIndex1] * TETS_PER_HEXAHEDRON +
+              tetIndex2;  // Now it indexes into the full tets-from-hexes array.
+
+            const auto poly =
+              primal::clip<double, MAX_VERTS_FOR_OCT_CLIPPING, MAX_NBRS_PER_VERT_FOR_OCT_CLIPPING>(
+                geomOctsView[shapeIndex],
+                cellsAsTets[tetIndex],
+                EPS,
+                tryFixOrientation);
+
+            // Poly is valid
+            if(poly.numVertices() >= 4)
+            {
+              // Workaround - intermediate volume variable needed for
+              // CUDA Pro/E test case correctness
+              double volume = poly.volume();
+              SLIC_ASSERT(volume >= 0);
+              RAJA::atomicAdd<ATOMIC_POL>(ovlap.data() + index, volume);
+            }
+          });
+      }
+    }
+
+    if(tetCandidatesCountPtr != &tetCandidatesCount)
+    {
+      axom::deallocate(tetCandidatesCountPtr);
+    }
+  }  // end of computeClipVolumes3D() function
+
+  /*
+   * Clip tets of from the mesh with tets or octs from the clipping
+   * geomnetry.  This implemenation is like the two above except that
+   * it limits clipping to a subset of mesh tets labeled as
+   * potentially on the boundary.
+   */
+  void computeClipVolumes3DTets(const axom::ArrayView<axom::IndexType>& tetIndices,
+                                axom::ArrayView<double> ovlap) override
+
+  {
+    AXOM_ANNOTATE_SCOPE("MeshClipper::computeClipVolumes3D:limited");
+
+    using BoundingBoxType = primal::BoundingBox<double, 3>;
+    using TetrahedronType = primal::Tetrahedron<double, 3>;
+    using OctahedronType = primal::Octahedron<double, 3>;
+
+    ShapeMesh& shapeMesh = getShapeMesh();
+    auto meshTets = getShapeMesh().getCellsAsTets();
+
+    const int allocId = shapeMesh.getAllocatorID();
+
+    SLIC_INFO(axom::fmt::format(
+      "MeshClipper::computeClipVolumes3D: Getting discrete geometry for shape '{}'",
+      getStrategy().name()));
+
+    auto& strategy = getStrategy();
+    axom::Array<TetrahedronType> geomAsTets;
+    axom::Array<OctahedronType> geomAsOcts;
+    const bool useOcts = strategy.getGeometryAsOcts(shapeMesh, geomAsOcts);
+    const bool useTets = strategy.getGeometryAsTets(shapeMesh, geomAsTets);
+    SLIC_ASSERT(useOcts || geomAsOcts.empty());
+    SLIC_ASSERT(useTets || geomAsTets.empty());
+    if(useTets == useOcts)
+    {
+      SLIC_ERROR(
+        axom::fmt::format("Problem with MeshClipperStrategy implementation '{}'."
+                          "  Implementations that don't provide a specializedClip function"
+                          " must provide exactly one getGeometryAsOcts() or getGeometryAsTets()."
+                          "  This implementation provides {}.",
+                          strategy.name(),
+                          int(useOcts) + int(useTets)));
+    }
+
+    auto geomTetsView = geomAsTets.view();
+    auto geomOctsView = geomAsOcts.view();
+
+    SLIC_INFO(axom::fmt::format("{:-^80}", " Inserting shapes' bounding boxes into BVH "));
+
+    // Generate the BVH tree over the shape's discretized geometry
+    // axis-aligned bounding boxes.  "pieces" refers to tets or octs.
+    const axom::IndexType bbCount = useTets ? geomAsTets.size() : geomAsOcts.size();
+    axom::Array<BoundingBoxType> pieceBbs(bbCount, bbCount, allocId);
+    axom::ArrayView<BoundingBoxType> pieceBbsView = pieceBbs.view();
+
+    // Get the bounding boxes for the shapes
+    if(useTets)
+    {
+      axom::for_all<ExecSpace>(
+        pieceBbsView.size(),
+        AXOM_LAMBDA(axom::IndexType i) {
+          pieceBbsView[i] = primal::compute_bounding_box<double, 3>(geomTetsView[i]);
+        });
+    }
+    else
+    {
+      axom::for_all<ExecSpace>(
+        pieceBbsView.size(),
+        AXOM_LAMBDA(axom::IndexType i) {
+          pieceBbsView[i] = primal::compute_bounding_box<double, 3>(geomOctsView[i]);
+        });
+    }
+
+    // Insert shapes' Bounding Boxes into BVH.
+    spin::BVH<3, ExecSpace, double> bvh;
+    bvh.initialize(pieceBbsView, pieceBbsView.size());
+
+    SLIC_INFO(axom::fmt::format("{:-^80}", " Querying the BVH tree "));
+
+    // Create a temporary subset of tet bounding boxes,
+    // containing only those listed in tetIndices.
+    const axom::IndexType tetCount = tetIndices.size();
+    axom::Array<BoundingBoxType> tetBbs(tetCount, tetCount, allocId);
+    axom::ArrayView<BoundingBoxType> tetBbsView = tetBbs.view();
+    axom::for_all<ExecSpace>(
+      tetCount,
+      AXOM_LAMBDA(axom::IndexType i) {
+        auto& tetBb = tetBbsView[i];
+        axom::IndexType tetId = tetIndices[i];
+        const auto& tet = meshTets[tetId];
+        for(int j = 0; j < 4; ++j) tetBb.addPoint(tet[j]);
+      });
+
+    axom::Array<IndexType> counts(tetCount, tetCount, allocId);
+    axom::Array<IndexType> offsets(tetCount, tetCount, allocId);
+
+    auto countsView = counts.view();
+    auto offsetsView = offsets.view();
+
+    AXOM_ANNOTATE_BEGIN("bvh.findBoundingBoxes");
+    axom::Array<IndexType> candidates;
+    bvh.findBoundingBoxes(offsets, counts, candidates, tetBbsView.size(), tetBbsView);
+    auto candidatesView = candidates.view();
+    AXOM_ANNOTATE_END("bvh.findBoundingBoxes");
+
+    axom::Array<IndexType> candToTetIdId(candidates.size(), candidates.size(), allocId);
+    auto candToTetIdIdView = candToTetIdId.view();
+    axom::for_all<ExecSpace>(
+      tetCount,
+      AXOM_LAMBDA(axom::IndexType i) {
+        auto count = countsView[i];
+        auto offset = offsetsView[i];
+        for(int j = 0; j < count; ++j) candToTetIdIdView[offset + j] = i;
+      });
+
+    // Find which shape bounding boxes intersect hexahedron bounding boxes
+    SLIC_INFO(axom::fmt::format("Finding shape candidates for {} tet elements ", tetIndices.size()));
+
+    using ATOMIC_POL = typename axom::execution_space<ExecSpace>::atomic_policy;
+    constexpr double EPS = 1e-10;
+    constexpr bool tryFixOrientation = false;
+
+    if(useTets)
+    {
+      axom::for_all<ExecSpace>(
+        candidates.size(),
+        AXOM_LAMBDA(axom::IndexType iCand) {
+          auto pieceId = candidatesView[iCand];
+          const axom::primal::Tetrahedron<double, 3>& geomPiece = geomTetsView[pieceId];
+
+          auto tetIdId = candToTetIdIdView[iCand];
+          auto tetId = tetIndices[tetIdId];
+          const auto& tet = meshTets[tetId];
+
+          const auto poly =
+            primal::clip<double, MAX_VERTS_FOR_TET_CLIPPING, MAX_NBRS_PER_VERT_FOR_TET_CLIPPING>(
+              tet,
+              geomPiece,
+              EPS,
+              tryFixOrientation);
+
+          if(poly.numVertices() >= 4)
+          {
+            // Poly is valid
+            double volume = poly.volume();
+            SLIC_ASSERT(volume >= 0);
+            auto cellId = tetId / TETS_PER_HEXAHEDRON;
+            RAJA::atomicAdd<ATOMIC_POL>(ovlap.data() + cellId, volume);
+          }
+        });
+    }
+    else  // useOcts
+    {
+      axom::for_all<ExecSpace>(
+        candidates.size(),
+        AXOM_LAMBDA(axom::IndexType iCand) {
+          auto pieceId = candidatesView[iCand];
+          const axom::primal::Octahedron<double, 3>& geomPiece = geomOctsView[pieceId];
+
+          auto tetIdId = candToTetIdIdView[iCand];
+          auto tetId = tetIndices[tetIdId];
+          const auto& tet = meshTets[tetId];
+
+          const auto poly =
+            primal::clip<double, MAX_VERTS_FOR_TET_CLIPPING, MAX_NBRS_PER_VERT_FOR_TET_CLIPPING>(
+              tet,
+              geomPiece,
+              EPS,
+              tryFixOrientation);
+
+          if(poly.numVertices() >= 4)
+          {
+            // Poly is valid
+            double volume = poly.volume();
+            SLIC_ASSERT(volume >= 0);
+            auto cellId = tetId / TETS_PER_HEXAHEDRON;
+            RAJA::atomicAdd<ATOMIC_POL>(ovlap.data() + cellId, volume);
+          }
+        });
+    }
+
+  }  // end of computeClipVolumes3DTets() function
+
+  void getLabelCounts(axom::ArrayView<const LabelType> labels,
+                      axom::IndexType& inCount,
+                      axom::IndexType& onCount,
+                      axom::IndexType& outCount) override
+  {
+    AXOM_ANNOTATE_SCOPE("MeshClipper::getLabelCounts");
+    using ReducePolicy = typename axom::execution_space<ExecSpace>::reduce_policy;
+    using LoopPolicy = typename execution_space<ExecSpace>::loop_policy;
+    RAJA::ReduceSum<ReducePolicy, axom::IndexType> inSum(0);
+    RAJA::ReduceSum<ReducePolicy, axom::IndexType> onSum(0);
+    RAJA::ReduceSum<ReducePolicy, axom::IndexType> outSum(0);
+    RAJA::forall<LoopPolicy>(
+      RAJA::RangeSegment(0, labels.size()),
+      AXOM_LAMBDA(axom::IndexType cellId) {
+        const auto& label = labels[cellId];
+        if(label == MeshClipperStrategy::LABEL_OUT)
+        {
+          outSum += 1;
+        }
+        else if(label == MeshClipperStrategy::LABEL_IN)
+        {
+          inSum += 1;
+        }
+        else
+        {
+          onSum += 1;
+        }
+      });
+    inCount = static_cast<axom::IndexType>(inSum.get());
+    onCount = static_cast<axom::IndexType>(onSum.get());
+    outCount = static_cast<axom::IndexType>(outSum.get());
+  }
+
+private:
+  static constexpr int MAX_VERTS_FOR_TET_CLIPPING = 32;
+  static constexpr int MAX_NBRS_PER_VERT_FOR_TET_CLIPPING = 8;
+  static constexpr int MAX_VERTS_FOR_OCT_CLIPPING = 32;
+  static constexpr int MAX_NBRS_PER_VERT_FOR_OCT_CLIPPING = 8;
+};
+
+}  // end namespace detail
+}  // namespace experimental
+}  // end namespace quest
+}  // end namespace axom
+
+#endif  // AXOM_MESHCLIPPERIMPL_HPP_

--- a/src/axom/quest/detail/clipping/TetClipper.cpp
+++ b/src/axom/quest/detail/clipping/TetClipper.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/config.hpp"
+
+#include "axom/quest/detail/clipping/TetClipper.hpp"
+
+namespace axom
+{
+namespace quest
+{
+namespace experimental
+{
+
+TetClipper::TetClipper(const klee::Geometry& kGeom, const std::string& name)
+  : MeshClipperStrategy(kGeom)
+  , m_name(name.empty() ? std::string("Tet") : name)
+  , m_transformer(m_extTrans)
+{
+  extractClipperInfo();
+
+  for(int i = 0; i < TetrahedronType::NUM_VERTS; ++i)
+  {
+    m_tet[i] = m_transformer.getTransformed(m_tetBeforeTrans[i]);
+  }
+
+  for(int i = 0; i < TetrahedronType::NUM_VERTS; ++i)
+  {
+    m_bb.addPoint(m_tet[i]);
+  }
+
+  for(int iPlane = 0; iPlane < 4; ++iPlane)
+  {
+    const Point3DType& a = m_tet[iPlane % 4];
+    const Point3DType& b = m_tet[(iPlane + 1) % 4];
+    const Point3DType& c = m_tet[(iPlane + 2) % 4];
+    m_planes[iPlane] = axom::primal::make_plane(a, b, c);
+
+    // For tet points ordered by right hand rule, odd planes
+    // face outside.  Make them face inside.
+    if(iPlane % 2 == 1) m_planes[iPlane].flip();
+
+    const Point3DType& apex = m_tet[(iPlane + 3) % 4];
+    m_heights[iPlane] = m_planes[iPlane].signedDistance(apex);
+    SLIC_ASSERT(m_heights[iPlane] >= 0);
+  }
+}
+
+bool TetClipper::getGeometryAsTets(quest::experimental::ShapeMesh& shapeMesh, axom::Array<TetrahedronType>& tets)
+{
+  AXOM_ANNOTATE_SCOPE("TetClipper::getGeometryAsTets");
+  int allocId = shapeMesh.getAllocatorID();
+  if(tets.getAllocatorID() != allocId || tets.size() != 1)
+  {
+    tets = axom::Array<TetrahedronType>(1, 1, allocId);
+  }
+  axom::copy(tets.data(), &m_tet, sizeof(TetrahedronType));
+  return true;
+}
+
+void TetClipper::extractClipperInfo()
+{
+  const auto v0 = m_info.fetch_existing("v0").as_double_array();
+  const auto v1 = m_info.fetch_existing("v1").as_double_array();
+  const auto v2 = m_info.fetch_existing("v2").as_double_array();
+  const auto v3 = m_info.fetch_existing("v3").as_double_array();
+  for(int d = 0; d < 3; ++d)
+  {
+    m_tetBeforeTrans[0][d] = v0[d];
+    m_tetBeforeTrans[1][d] = v1[d];
+    m_tetBeforeTrans[2][d] = v2[d];
+    m_tetBeforeTrans[3][d] = v3[d];
+  }
+}
+
+}  // namespace experimental
+}  // end namespace quest
+}  // end namespace axom

--- a/src/axom/quest/detail/clipping/TetClipper.hpp
+++ b/src/axom/quest/detail/clipping/TetClipper.hpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef AXOM_QUEST_TETCLIPPER_HPP
+#define AXOM_QUEST_TETCLIPPER_HPP
+
+#include "axom/klee/Geometry.hpp"
+#include "axom/quest/MeshClipperStrategy.hpp"
+#include "axom/primal/geometry/CoordinateTransformer.hpp"
+
+namespace axom
+{
+namespace quest
+{
+namespace experimental
+{
+
+/*!
+ * @brief Geometry clipping operations for sphere geometries.
+*/
+class TetClipper : public MeshClipperStrategy
+{
+public:
+  /*!
+   * @brief Constructor.
+   *
+   * @param [in] kGeom Describes the shape to place
+   *   into the mesh.
+   * @param [in] name To override the default strategy name
+  */
+  TetClipper(const klee::Geometry& kGeom, const std::string& name = "");
+
+  virtual ~TetClipper() = default;
+
+  const std::string& name() const override { return m_name; }
+
+  bool getGeometryAsTets(quest::experimental::ShapeMesh& shappeMesh, axom::Array<TetrahedronType>& tets) override;
+
+#if !defined(__CUDACC__)
+private:
+#endif
+  std::string m_name;
+
+  //!@brief Tetrahedron before transformation.
+  TetrahedronType m_tetBeforeTrans;
+
+  //!@brief Tetrahedron after transformation.
+  TetrahedronType m_tet;
+
+  axom::primal::BoundingBox<double, 3> m_bb;
+
+  //!@brief 4 planes of the Tet, oriented to the interior of the tet.
+  axom::StackArray<Plane3DType, 4> m_planes;
+
+  //!@brief Height of the tet when resting on each facet.
+  axom::StackArray<double, 4> m_heights;
+
+  axom::primal::experimental::CoordinateTransformer<double> m_transformer;
+
+  // Extract clipper info from MeshClipperStrategy::m_info.
+  void extractClipperInfo();
+};
+
+}  // namespace experimental
+}  // namespace quest
+}  // namespace axom
+
+#endif  // AXOM_QUEST_TETCLIPPER_HPP

--- a/src/axom/quest/tests/CMakeLists.txt
+++ b/src/axom/quest/tests/CMakeLists.txt
@@ -235,6 +235,54 @@ if(ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
 endif()
 
 #------------------------------------------------------------------------------
+# Geometry clipping tests require Conduit and RAJA
+#------------------------------------------------------------------------------
+if(CONDUIT_FOUND AND RAJA_FOUND)
+    axom_add_executable(
+        NAME        quest_mesh_clipper_test
+        SOURCES     quest_mesh_clipper.cpp
+        OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
+        DEPENDS_ON  ${quest_tests_depends}
+        FOLDER      axom/quest/tests
+        )
+
+    # 3D shaping tests.  No 2D shaping in this feature, at least for now.
+    set(_nranks 1)
+
+    # Run the geometry clipping test on with each enabled policy
+    set(_policies "seq")
+    if(RAJA_FOUND)
+      blt_list_append(TO _policies ELEMENTS "omp"  IF AXOM_ENABLE_OPENMP)
+      blt_list_append(TO _policies ELEMENTS "cuda" IF AXOM_ENABLE_CUDA)
+      blt_list_append(TO _policies ELEMENTS "hip"  IF AXOM_ENABLE_HIP)
+    endif()
+
+    set(_testgeoms "tet" )
+    set(_meshTypes "bpSidre" "bpConduit")
+    foreach(_meshType ${_meshTypes})
+      foreach(_policy ${_policies})
+        foreach(_testgeom ${_testgeoms})
+          set(_testname "quest_mesh_clipper_${_meshType}_${_policy}_${_testgeom}")
+          axom_add_test(
+            NAME ${_testname}
+            COMMAND quest_mesh_clipper_test
+            --policy ${_policy}
+            --verbose
+            --testGeom ${_testgeom}
+            -o ${_testname}
+            --refinements 5
+            --scale .99 .99 .99
+            --dir 8 4 2
+            --meshType ${_meshType}
+            inline_mesh --min -2 -2 -2 --max 2 2 2 --res 16 16 16
+            NUM_MPI_TASKS ${_nranks})
+        endforeach()
+      endforeach()
+    endforeach()
+
+endif()
+
+#------------------------------------------------------------------------------
 # Regression tests for quest signed distance and inout queries
 #
 # Note: By default we only run a small subset of the quest regression tests.

--- a/src/axom/quest/tests/quest_mesh_clipper.cpp
+++ b/src/axom/quest/tests/quest_mesh_clipper.cpp
@@ -1,0 +1,1001 @@
+// Copyright (c) 2017-2025, Lawrence Livermore National Security, LLC and
+// other Axom Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ * \file quest_mesh_clipper.cpp
+ * \brief Test clipping codes built around MeshClipper class.
+ * 3D only.  Extensible to 2D when we have 2D clipping.
+ */
+
+// Axom includes
+#include "axom/config.hpp"
+#include "axom/core.hpp"
+#include "axom/slic.hpp"
+#include "axom/mint.hpp"
+#include "axom/primal.hpp"
+#include "axom/sidre.hpp"
+#include "axom/klee.hpp"
+#include "axom/quest.hpp"
+#include "axom/quest/detail/clipping/TetClipper.hpp"
+
+#include "axom/fmt.hpp"
+#include "axom/CLI11.hpp"
+
+#if !defined(AXOM_USE_CONDUIT)
+  #error Shaping functionality requires Axom to be configured with Conduit
+#endif
+
+#include "conduit_blueprint.hpp"
+#include "conduit_relay_io_blueprint.hpp"
+#include "conduit_utils.hpp"
+
+#include <math.h>
+
+#ifdef AXOM_USE_MPI
+  #include "mpi.h"
+#endif
+
+// RAJA
+#if !defined(AXOM_USE_RAJA)
+  #error quest_mesh_clipper example require RAJA
+#endif
+#include "RAJA/RAJA.hpp"
+
+// C/C++ includes
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace klee = axom::klee;
+namespace primal = axom::primal;
+namespace quest = axom::quest;
+namespace slic = axom::slic;
+namespace sidre = axom::sidre;
+
+//------------------------------------------------------------------------------
+
+using RuntimePolicy = axom::runtime_policy::Policy;
+
+#if defined(AXOM_USE_64BIT_INDEXTYPE) && !defined(AXOM_NO_INT64_T)
+static constexpr conduit::DataType::TypeID conduitDataIdOfAxomIndexType = conduit::DataType::INT64_ID;
+#else
+static constexpr conduit::DataType::TypeID conduitDataIdOfAxomIndexType = conduit::DataType::INT32_ID;
+#endif
+
+/// Struct to parse and store the input parameters
+// Some parameters are used to override defaults.
+struct Input
+{
+public:
+  std::string outputFile;
+
+  std::vector<double> center;
+  double radius {-1.0};
+  double radius2 {-0.3};
+  double length {-2.0};
+  std::vector<double> direction;
+
+  // Shape transformation parameters
+  std::vector<double> scaleFactors;
+
+  // Inline mesh parameters
+  std::vector<double> boxMins {-2, -2, -2};
+  std::vector<double> boxMaxs {2, 2, 2};
+  std::vector<int> boxResolution {20, 20, 20};
+  int getBoxDim() const
+  {
+    auto d = boxResolution.size();
+    SLIC_ASSERT(boxMins.size() == d);
+    SLIC_ASSERT(boxMaxs.size() == d);
+    return int(d);
+  }
+  int getBoxCellCount() const { return boxResolution[0] * boxResolution[1] * boxResolution[2]; }
+
+  // The shape to run.
+  std::vector<std::string> testGeom;
+  // The shapes this example is set up to run.
+  const std::set<std::string> availableShapes {"tet"};  // More geometries to come.
+
+  RuntimePolicy policy {RuntimePolicy::seq};
+  int refinementLevel {7};
+  double weldThresh {1e-9};
+  std::string annotationMode {"none"};
+
+  std::string backgroundMaterial;
+
+  // clang-format off
+  enum class MeshType { bpSidre = 0, bpConduit = 1 };
+  const std::map<std::string, MeshType> meshTypeChoices
+    { {"bpSidre", MeshType::bpSidre} , {"bpConduit", MeshType::bpConduit} };
+  // clang-format on
+  MeshType meshType {MeshType::bpSidre};
+  bool useBlueprintSidre() { return meshType == MeshType::bpSidre; }
+  bool useBlueprintConduit() { return meshType == MeshType::bpConduit; }
+
+private:
+  bool m_verboseOutput {false};
+
+public:
+  bool isVerbose() const { return m_verboseOutput; }
+
+  /// @brief Return volume of input box mesh
+  double boxMeshVolume() const
+  {
+    primal::Vector<double, 3> x {boxMaxs[0] - boxMins[0], 0, 0};
+    primal::Vector<double, 3> y {0, boxMaxs[1] - boxMins[1], 0};
+    primal::Vector<double, 3> z {0, 0, boxMaxs[2] - boxMins[2]};
+    double volume = primal::Vector<double, 3>::scalar_triple_product(x, y, z);
+    return volume;
+  }
+
+  void parse(int argc, char** argv, axom::CLI::App& app)
+  {
+    app.add_option("-o,--outputFile", outputFile)->description("Path to output file(s)");
+
+    app.add_flag("-v,--verbose,!--no-verbose", m_verboseOutput)
+      ->description("Enable/disable verbose output")
+      ->capture_default_str();
+
+    app.add_option("--meshType", meshType)
+      ->description("Type of computational mesh to shape on")
+      ->capture_default_str()
+      ->transform(axom::CLI::CheckedTransformer(meshTypeChoices));
+
+    app.add_option("-t,--weld-threshold", weldThresh)
+      ->description("Threshold for welding")
+      ->check(axom::CLI::NonNegativeNumber)
+      ->capture_default_str();
+
+    app.add_option("-s,--testGeom", testGeom)
+      ->description(
+        "The geometry(s) to run.  Specifying multiple shapes will override scaling and "
+        "translations to shrink shapes and shift them to individual octants of the mesh.")
+      ->check(axom::CLI::IsMember(availableShapes))
+      ->delimiter(',')
+      ->expected(1, 60);
+
+#ifdef AXOM_USE_CALIPER
+    app.add_option("--caliper", annotationMode)
+      ->description(
+        "caliper annotation mode. Valid options include 'none' and 'report'. "
+        "Use 'help' to see full list.")
+      ->capture_default_str()
+      ->check(axom::utilities::ValidCaliperMode);
+#endif
+
+    app.add_option("--center", center)
+      ->description("Center of sphere or base of cone/cyl/SOR (x,y[,z]) shape")
+      ->expected(2, 3);
+
+    app.add_option("--radius", radius)
+      ->description("Radius of sphere or cylinder shape")
+      ->check(axom::CLI::PositiveNumber);
+
+    app.add_option("--length", length)
+      ->description("Length of cone/cyl/SOR shape, avg length of hex.")
+      ->check(axom::CLI::PositiveNumber);
+
+    app.add_option("--dir", direction)
+      ->description(
+        "Direction of axis of rotation (cone/cyl/SOR (x,y[,z])), or rotated "
+        "x-axis (hex, tet, tetmesh, and sphere), or positive normal direction "
+        "(plane).")
+      ->expected(2, 3);
+
+    app.add_option("--radius2", radius2)
+      ->description("Second radius of cone shape")
+      ->check(axom::CLI::PositiveNumber);
+
+    app.add_option("--scale", scaleFactors)
+      ->description("Scale factor to apply to shape (x,y[,z])")
+      ->expected(2, 3)
+      ->check(axom::CLI::PositiveNumber);
+
+    // use either an input mesh file or a simple inline Cartesian mesh
+    {
+      auto* inline_mesh_subcommand = app.add_subcommand("inline_mesh")
+                                       ->description("Options for setting up a simple inline mesh")
+                                       ->fallthrough();
+
+      inline_mesh_subcommand->add_option("--min", boxMins)
+        ->description("Min bounds for box mesh (x,y[,z])")
+        ->expected(2, 3)
+        ->required();
+      inline_mesh_subcommand->add_option("--max", boxMaxs)
+        ->description("Max bounds for box mesh (x,y[,z])")
+        ->expected(2, 3)
+        ->required();
+
+      inline_mesh_subcommand->add_option("--res", boxResolution)
+        ->description("Resolution of the box mesh (i,j[,k])")
+        ->expected(2, 3)
+        ->required();
+    }
+
+    app.add_option("--background-material", backgroundMaterial)
+      ->description("Sets the name of the background material");
+
+    // parameters that only apply to the intersection method
+    {
+      auto* intersection_options =
+        app.add_option_group("intersection", "Options related to intersection-based queries");
+
+      intersection_options->add_option("-r, --refinements", refinementLevel)
+        ->description("Number of refinements to perform for revolved contour")
+        ->capture_default_str()
+        ->check(axom::CLI::NonNegativeNumber);
+
+      std::stringstream pol_sstr;
+      pol_sstr << "Set runtime policy for intersection-based sampling method.";
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_UMPIRE)
+      pol_sstr << "\nSet to 'seq' or 0 to use the RAJA sequential policy.";
+  #ifdef AXOM_USE_OPENMP
+      pol_sstr << "\nSet to 'omp' or 1 to use the RAJA OpenMP policy.";
+  #endif
+  #ifdef AXOM_USE_CUDA
+      pol_sstr << "\nSet to 'cuda' or 2 to use the RAJA CUDA policy.";
+  #endif
+  #ifdef AXOM_USE_HIP
+      pol_sstr << "\nSet to 'hip' or 3 to use the RAJA HIP policy.";
+  #endif
+#endif
+
+      intersection_options->add_option("-p, --policy", policy, pol_sstr.str())
+        ->capture_default_str()
+        ->transform(axom::CLI::CheckedTransformer(axom::runtime_policy::s_nameToPolicy));
+    }
+    app.get_formatter()->column_width(50);
+
+    // could throw an exception
+    app.parse(argc, argv);
+
+    slic::setLoggingMsgLevel(m_verboseOutput ? slic::message::Debug : slic::message::Info);
+  }
+};  // struct Input
+Input params;
+
+/************************************************************
+ * Shared variables.
+ ************************************************************/
+
+const std::string topoName = "mesh";
+const std::string matsetName = "matset";
+const std::string coordsetName = "coords";
+int cellCount = -1;
+// Translation to individual octants (override) when running multiple shapes.
+// Except that the plane is never moved.
+const double tDist = 0.9; // Bias toward origin to help keep shape inside domain.
+std::vector<axom::NumericArray<double, 3>> translations {{tDist, tDist, -tDist},
+                                                         {-tDist, tDist, -tDist},
+                                                         {-tDist, -tDist, -tDist},
+                                                         {tDist, -tDist, -tDist},
+                                                         {tDist, tDist, tDist},
+                                                         {-tDist, tDist, tDist},
+                                                         {-tDist, -tDist, tDist},
+                                                         {tDist, -tDist, tDist}};
+int translationIdx = 0;  // To track what translations have been used.
+
+std::map<std::string, int> geomReps;  // Repetitions of the geometry.
+std::map<std::string, double> exactGeomVols;
+std::map<std::string, double> errorToleranceRel;  // Relative error tolerance.
+std::map<std::string, double> errorToleranceAbs;  // Absolute error tolerance.
+double vScale = 1.0;                              // Volume scale due to geometry scale.
+
+// Start property for all 3D shapes.
+axom::klee::TransformableGeometryProperties startProp {axom::klee::Dimensions::Three,
+                                                       axom::klee::LengthUnit::unspecified};
+
+// Add scale operator if specified by input parameters.
+void addScaleOperator(axom::klee::CompositeOperator& compositeOp)
+{
+  SLIC_ASSERT(params.scaleFactors.empty() || params.scaleFactors.size() == 3);
+  if(!params.scaleFactors.empty())
+  {
+    std::shared_ptr<axom::klee::Scale> scaleOp =
+      std::make_shared<axom::klee::Scale>(params.scaleFactors[0],
+                                          params.scaleFactors[1],
+                                          params.scaleFactors[2],
+                                          startProp);
+    compositeOp.addOperator(scaleOp);
+  }
+}
+
+// Add translate operator.
+void addTranslateOperator(axom::klee::CompositeOperator& compositeOp)
+{
+  if(params.testGeom.size() > 1)
+  {
+    const axom::NumericArray<double, 3>& shifts =
+      translations[(translationIdx++) % translations.size()];
+    primal::Vector3D shift({shifts[0], shifts[1], shifts[2]});
+    auto translateOp = std::make_shared<axom::klee::Translation>(shift, startProp);
+    compositeOp.addOperator(translateOp);
+  }
+  else
+  {
+    // Use zero shift as a smoke test.
+    primal::Vector3D shift({0, 0, 0});
+    auto translateOp = std::make_shared<axom::klee::Translation>(shift, startProp);
+    compositeOp.addOperator(translateOp);
+  }
+}
+
+// Add operator to rotate x-axis to params.direction, if it is given.
+void addRotateOperator(axom::klee::CompositeOperator& compositeOp)
+{
+  if(!params.direction.empty())
+  {
+    static const primal::Point3D center {0.0, 0.0, 0.0};
+    static const primal::Vector3D x {1.0, 0.0, 0.0};
+    primal::Vector3D rotateTo(params.direction.data());
+    // Note that the rotation matrix is not unique.
+    primal::Vector3D a = rotateTo.unitVector();
+    primal::Vector3D u;  // Rotation vector, the cross product of x and a.
+    axom::numerics::cross_product(x.data(), a.data(), u.data());
+    double angle = asin(u.norm()) * 180 / M_PI;
+
+    auto rotateOp = std::make_shared<axom::klee::Rotation>(angle, center, u, startProp);
+    compositeOp.addOperator(rotateOp);
+  }
+}
+
+// Computational mesh in different forms, initialized in main
+axom::sidre::Group* compMeshGrp = nullptr;
+axom::sidre::Group* compMeshGrpOnHost = nullptr;
+std::shared_ptr<conduit::Node> compMeshNode;
+
+axom::sidre::Group* createBoxMesh(axom::sidre::Group* meshGrp)
+{
+  using BBox3D = primal::BoundingBox<double, 3>;
+  using Pt3D = primal::Point<double, 3>;
+  auto res = axom::NumericArray<int, 3>(params.boxResolution.data());
+  auto bbox = BBox3D(Pt3D(params.boxMins.data()), Pt3D(params.boxMaxs.data()));
+  axom::quest::util::make_unstructured_blueprint_box_mesh_3d(meshGrp,
+                                                             bbox,
+                                                             res,
+                                                             topoName,
+                                                             coordsetName,
+                                                             params.policy);
+#if defined(AXOM_DEBUG)
+  conduit::Node meshNode, info;
+  meshGrp->createNativeLayout(meshNode);
+  SLIC_ASSERT(conduit::blueprint::mesh::verify(meshNode, info));
+#endif
+
+  // State group is optional to blueprint, and we don't use it, but mint checks for it.
+  meshGrp->createGroup("state");
+
+  return meshGrp;
+}
+
+/// \brief Utility function to initialize the logger
+void initializeLogger()
+{
+  // Initialize Logger
+  slic::initialize();
+  slic::setLoggingMsgLevel(slic::message::Info);
+
+  slic::LogStream* logStream {nullptr};
+
+#ifdef AXOM_USE_MPI
+  int num_ranks = 1;
+  MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
+  if(num_ranks > 1)
+  {
+    std::string fmt = "[<RANK>][<LEVEL>]: <MESSAGE>\n";
+  #ifdef AXOM_USE_LUMBERJACK
+    const int RLIMIT = 8;
+    logStream = new slic::LumberjackStream(&std::cout, MPI_COMM_WORLD, RLIMIT, fmt);
+  #else
+    logStream = new slic::SynchronizedStream(&std::cout, MPI_COMM_WORLD, fmt);
+  #endif
+  }
+  else
+#endif  // AXOM_USE_MPI
+  {
+    std::string fmt = "[<LEVEL>]: <MESSAGE>\n";
+    logStream = new slic::GenericOutputStream(&std::cout, fmt);
+  }
+
+  slic::addStreamToAllMsgLevels(logStream);
+}
+
+/// \brief Utility function to finalize the logger
+void finalizeLogger()
+{
+  if(slic::isInitialized())
+  {
+    slic::flushStreams();
+    slic::finalize();
+  }
+}
+
+axom::klee::Geometry createGeom_Tet(const std::string& geomName)
+{
+  axom::klee::TransformableGeometryProperties prop {axom::klee::Dimensions::Three,
+                                                    axom::klee::LengthUnit::unspecified};
+
+  // Tetrahedron at origin.
+  const double len = params.length < 0 ? 1.55 : params.length;
+  const Point3D a {Point3D::NumericArray {.8, 0., -1.} * len};
+  const Point3D b {Point3D::NumericArray {-.8, 1, -1.} * len};
+  const Point3D c {Point3D::NumericArray {-.8, -1, -1.} * len};
+  const Point3D d {Point3D::NumericArray {0., 0., +1.} * len};
+  const primal::Tetrahedron<double, 3> tet {a, b, c, d};
+
+  auto compositeOp = std::make_shared<axom::klee::CompositeOperator>(startProp);
+  addScaleOperator(*compositeOp);
+  addRotateOperator(*compositeOp);
+  addTranslateOperator(*compositeOp);
+  exactGeomVols[geomName] = vScale * tet.volume();
+  errorToleranceRel[geomName] = 1e-12;
+  errorToleranceAbs[geomName] = errorToleranceRel[geomName] * exactGeomVols[geomName];
+
+  axom::klee::Geometry tetGeometry(prop, tet, compositeOp);
+
+  return tetGeometry;
+}
+
+/*!
+  @brief Return the element volumes as a sidre::View containing
+  the volumes in an array.
+
+  If it doesn't exist, allocate and compute it.
+  \post The volume data is in the blueprint field \c volFieldName.
+*/
+template <typename ExecSpace>
+axom::sidre::View* getElementVolumes(
+  sidre::Group* meshGrp,
+  const std::string& volFieldName = std::string("elementVolumes"))
+{
+  using XS = axom::execution_space<ExecSpace>;
+  using HexahedronType = axom::primal::Hexahedron<double, 3>;
+
+  axom::sidre::View* volSidreView = nullptr;
+
+  const auto fieldPath = axom::fmt::format("fields/{}", volFieldName);
+  if(meshGrp->hasGroup(fieldPath))
+  {
+    sidre::Group* fieldGrp = meshGrp->getGroup(fieldPath);
+    volSidreView = fieldGrp->getView("values");
+  }
+  else
+  {
+    axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE> mesh(meshGrp, topoName);
+
+    constexpr int NUM_VERTS_PER_HEX = 8;
+    constexpr int NUM_COMPS_PER_VERT = 3;
+    constexpr double ZERO_THRESHOLD = 1.e-10;
+
+    /*
+      Get vertex coordinates.  We use UnstructuredMesh for this,
+      so get it on host first then transfer to device if needed.
+    */
+    auto* connData = meshGrp->getGroup("topologies")
+                       ->getGroup(topoName)
+                       ->getGroup("elements")
+                       ->getView("connectivity");
+    SLIC_ASSERT(connData->getNode().dtype().id() == conduitDataIdOfAxomIndexType);
+
+    conduit::Node coordNode;
+    meshGrp->getGroup("coordsets")->getGroup(coordsetName)->createNativeLayout(coordNode);
+    const conduit::Node& coordValues = coordNode.fetch_existing("values");
+    axom::IndexType vertexCount = coordValues["x"].dtype().number_of_elements();
+    bool isInterleaved = conduit::blueprint::mcarray::is_interleaved(coordValues);
+    int stride = isInterleaved ? NUM_COMPS_PER_VERT : 1;
+    axom::StackArray<axom::ArrayView<const double>, 3> coordArrays {
+      axom::ArrayView<const double>(coordValues["x"].as_double_ptr(), {vertexCount}, stride),
+      axom::ArrayView<const double>(coordValues["y"].as_double_ptr(), {vertexCount}, stride),
+      axom::ArrayView<const double>(coordValues["z"].as_double_ptr(), {vertexCount}, stride)};
+
+    const axom::IndexType* connPtr = connData->getArray();
+    SLIC_ASSERT(connPtr != nullptr);
+    axom::ArrayView<const axom::IndexType, 2> conn(connPtr, cellCount, NUM_VERTS_PER_HEX);
+    axom::Array<Point3D> vertCoords(cellCount * NUM_VERTS_PER_HEX,
+                                    cellCount * NUM_VERTS_PER_HEX,
+                                    XS::allocatorID());
+    auto vertCoordsView = vertCoords.view();
+
+    axom::for_all<ExecSpace>(
+      cellCount,
+      AXOM_LAMBDA(axom::IndexType cellIdx) {
+        // Get the indices of this element's vertices
+        auto verts = conn[cellIdx];
+
+        // Get the coordinates for the vertices
+        for(int j = 0; j < NUM_VERTS_PER_HEX; ++j)
+        {
+          int vertIdx = cellIdx * NUM_VERTS_PER_HEX + j;
+          for(int k = 0; k < NUM_COMPS_PER_VERT; k++)
+          {
+            vertCoordsView[vertIdx][k] = coordArrays[k][verts[j]];
+            // vertCoordsView[vertIdx][k] = mesh.getNodeCoordinate(verts[j], k);
+          }
+        }
+      });
+
+    // Set vertex coords to zero if within threshold.
+    // (I don't know why we do this.  I'm following examples.)
+    axom::ArrayView<double> flatCoordsView((double*)vertCoords.data(),
+                                           vertCoords.size() * Point3D::dimension());
+    assert(flatCoordsView.size() == cellCount * NUM_VERTS_PER_HEX * 3);
+    axom::for_all<ExecSpace>(
+      cellCount * 3,
+      AXOM_LAMBDA(axom::IndexType i) {
+        if(axom::utilities::isNearlyEqual(flatCoordsView[i], 0.0, ZERO_THRESHOLD))
+        {
+          flatCoordsView[i] = 0.0;
+        }
+      });
+
+    // Initialize hexahedral elements.
+    axom::Array<HexahedronType> hexes(cellCount, cellCount, meshGrp->getDefaultAllocatorID());
+    auto hexesView = hexes.view();
+    axom::for_all<ExecSpace>(
+      cellCount,
+      AXOM_LAMBDA(axom::IndexType cellIdx) {
+        // Set each hexahedral element vertices
+        hexesView[cellIdx] = HexahedronType();
+        for(int j = 0; j < NUM_VERTS_PER_HEX; ++j)
+        {
+          int vertIndex = (cellIdx * NUM_VERTS_PER_HEX) + j;
+          auto& hex = hexesView[cellIdx];
+          hex[j] = vertCoordsView[vertIndex];
+        }
+      });  // end of loop to initialize hexahedral elements and bounding boxes
+
+    // Allocate and populate cell volumes.
+    axom::sidre::Group* fieldGrp = meshGrp->createGroup(fieldPath);
+    fieldGrp->createViewString("topology", topoName);
+    fieldGrp->createViewString("association", "element");
+    fieldGrp->createViewString("volume_dependent", "true");
+    volSidreView =
+      fieldGrp->createViewAndAllocate("values", axom::sidre::detail::SidreTT<double>::id, cellCount);
+    axom::IndexType shape2d[] = {cellCount, 1};
+    volSidreView->reshapeArray(2, shape2d);
+    axom::ArrayView<double> volView(volSidreView->getData(), volSidreView->getNumElements());
+    axom::for_all<ExecSpace>(
+      cellCount,
+      AXOM_LAMBDA(axom::IndexType cellIdx) { volView[cellIdx] = hexesView[cellIdx].volume(); });
+  }
+
+  return volSidreView;
+}
+
+template <typename ExecSpace>
+double sumMaterialVolumesImpl(sidre::Group* meshGrp, const std::string& material)
+{
+  conduit::Node meshNode;
+  meshGrp->createNativeLayout(meshNode);
+#if defined(AXOM_DEBUG)
+  // Conduit can verify Blueprint mesh, but only if data is on host.
+  if(axom::execution_space<axom::SEQ_EXEC>::usesAllocId(meshGrp->getDefaultAllocatorID()))
+  {
+    conduit::Node info;
+    conduit::blueprint::mesh::verify(meshNode, info);
+    SLIC_ASSERT(conduit::blueprint::mesh::verify(meshNode, info));
+  }
+#endif
+  std::string topoPath = "topologies/" + topoName;
+  conduit::Node& topoNode = meshNode.fetch_existing(topoPath);
+  const int cellCount = conduit::blueprint::mesh::topology::length(topoNode);
+
+  // Get cell volumes from meshGrp.
+  const std::string volsName = "vol_" + material;
+  axom::sidre::View* elementVols = getElementVolumes<ExecSpace>(meshGrp, volsName);
+  axom::ArrayView<double> elementVolsView(elementVols->getData(), elementVols->getNumElements());
+
+  // Get material volume fractions
+  const auto vfFieldName = "vol_frac_" + material;
+  const auto vfFieldValuesPath = "fields/" + vfFieldName + "/values";
+  axom::sidre::View* volFrac = meshGrp->getView(vfFieldValuesPath);
+  axom::ArrayView<double> volFracView(volFrac->getArray(), cellCount);
+
+  using ReducePolicy = typename axom::execution_space<ExecSpace>::reduce_policy;
+  RAJA::ReduceSum<ReducePolicy, double> localVol(0);
+  axom::for_all<ExecSpace>(
+    cellCount,
+    AXOM_LAMBDA(axom::IndexType i) { localVol += volFracView[i] * elementVolsView[i]; });
+
+  double globalVol = localVol.get();
+#ifdef AXOM_USE_MPI
+  MPI_Allreduce(MPI_IN_PLACE, &globalVol, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+#endif
+  return globalVol;
+}
+
+double sumMaterialVolumes(sidre::Group* meshGrp, const std::string& material)
+{
+  double rval = 0.0;
+  if(params.policy == RuntimePolicy::seq)
+  {
+    rval = sumMaterialVolumesImpl<axom::SEQ_EXEC>(meshGrp, material);
+  }
+#if defined(AXOM_USE_OPENMP)
+  if(params.policy == RuntimePolicy::omp)
+  {
+    rval = sumMaterialVolumesImpl<axom::OMP_EXEC>(meshGrp, material);
+  }
+#endif
+#if defined(AXOM_USE_CUDA)
+  if(params.policy == RuntimePolicy::cuda)
+  {
+    rval = sumMaterialVolumesImpl<axom::CUDA_EXEC<256>>(meshGrp, material);
+  }
+#endif
+#if defined(AXOM_USE_HIP)
+  if(params.policy == RuntimePolicy::hip)
+  {
+    rval = sumMaterialVolumesImpl<axom::HIP_EXEC<256>>(meshGrp, material);
+  }
+#endif
+  return rval;
+}
+
+/// Write blueprint mesh to disk
+void saveMesh(const conduit::Node& mesh, const std::string& filename)
+{
+  AXOM_ANNOTATE_SCOPE("save mesh (conduit)");
+
+#ifdef AXOM_USE_MPI
+  conduit::relay::mpi::io::blueprint::save_mesh(mesh, filename, "hdf5", MPI_COMM_WORLD);
+#else
+  conduit::relay::io::blueprint::save_mesh(mesh, filename, "hdf5");
+#endif
+}
+
+/// Write blueprint mesh to disk
+void saveMesh(const sidre::Group& mesh, const std::string& filename)
+{
+  AXOM_ANNOTATE_SCOPE("save mesh (sidre)");
+
+  axom::sidre::DataStore ds;
+  const sidre::Group* meshOnHost = &mesh;
+  if(mesh.getDefaultAllocatorID() != axom::execution_space<axom::SEQ_EXEC>::allocatorID())
+  {
+    meshOnHost =
+      ds.getRoot()->deepCopyGroup(&mesh, axom::execution_space<axom::SEQ_EXEC>::allocatorID());
+  }
+  conduit::Node tmpMesh;
+  meshOnHost->createNativeLayout(tmpMesh);
+  {
+    conduit::Node info;
+#ifdef AXOM_USE_MPI
+    if(!conduit::blueprint::mpi::verify("mesh", tmpMesh, info, MPI_COMM_WORLD))
+#else
+    if(!conduit::blueprint::verify("mesh", tmpMesh, info))
+#endif
+    {
+      SLIC_INFO("Invalid blueprint for mesh: \n" << info.to_yaml());
+      slic::flushStreams();
+      assert(false);
+    }
+    // info.print();
+  }
+  saveMesh(tmpMesh, filename);
+}
+
+//!@brief Fill a sidre array View with a value.
+// No error checking.
+template <typename T>
+void fillSidreViewData(axom::sidre::View* view, const T& value)
+{
+  double* valuesPtr = view->getData<T*>();
+  switch(params.policy)
+  {
+#if defined(AXOM_USE_CUDA)
+  case RuntimePolicy::cuda:
+    axom::for_all<axom::CUDA_EXEC<256>>(
+      view->getNumElements(),
+      AXOM_LAMBDA(axom::IndexType i) { valuesPtr[i] = value; });
+    break;
+#endif
+#if defined(AXOM_USE_HIP)
+  case RuntimePolicy::hip:
+    axom::for_all<axom::HIP_EXEC<256>>(
+      view->getNumElements(),
+      AXOM_LAMBDA(axom::IndexType i) { valuesPtr[i] = value; });
+    break;
+#endif
+#if defined(AXOM_USE_OMP)
+  case RuntimePolicy::omp:
+    axom::for_all<axom::OMP_EXEC>(
+      view->getNumElements(),
+      AXOM_LAMBDA(axom::IndexType i) { valuesPtr[i] = value; });
+    break;
+#endif
+  case RuntimePolicy::seq:
+  default:
+    axom::for_all<axom::SEQ_EXEC>(
+      view->getNumElements(),
+      AXOM_LAMBDA(axom::IndexType i) { valuesPtr[i] = value; });
+    break;
+  }
+}
+
+//------------------------------------------------------------------------------
+int main(int argc, char** argv)
+{
+  axom::utilities::raii::MPIWrapper mpi_raii_wrapper(argc, argv);
+  const int my_rank = mpi_raii_wrapper.my_rank();
+
+  initializeLogger();
+
+  //---------------------------------------------------------------------------
+  // Set up and parse command line arguments
+  //---------------------------------------------------------------------------
+  axom::CLI::App app {"Driver for Klee shaping query"};
+
+  try
+  {
+    params.parse(argc, argv, app);
+  }
+  catch(const axom::CLI::ParseError& e)
+  {
+    int retval = -1;
+    if(my_rank == 0)
+    {
+      retval = app.exit(e);
+    }
+    finalizeLogger();
+
+#ifdef AXOM_USE_MPI
+    MPI_Bcast(&retval, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    MPI_Finalize();
+#endif
+    exit(retval);
+  }
+
+  if(params.testGeom.size() > 1)
+  {
+    if(params.scaleFactors.empty())
+    {
+      params.scaleFactors.resize(3, 1.0);
+    }
+    for(auto& f : params.scaleFactors) f *= 0.5;
+    axom::StackArray<double, 3> tmpOutput{params.scaleFactors[0], params.scaleFactors[1], params.scaleFactors[2]};
+    SLIC_WARNING(
+      axom::fmt::format("Multiple test configurations specified.\n"
+      "Adding additional 0.5 scaling to shrink the geometries\n"
+      "and move them to individual octants so they don't overlap\n"
+      "with each other.  Final scaling: {}", tmpOutput));
+  }
+  for(auto sf : params.scaleFactors)
+  {
+    vScale *= sf;
+  }
+
+  axom::utilities::raii::AnnotationsWrapper annotations_raii_wrapper(params.annotationMode);
+
+  /*
+    Host allocator is for metadata and arrays that must be on host.
+    Data allocator uses host or device, depending on the runtime policy.
+  */
+  const int hostAllocId = axom::execution_space<axom::SEQ_EXEC>::allocatorID();
+  int dataAllocId = axom::policyToDefaultAllocatorID(params.policy);
+
+#if defined(AXOM_USE_UMPIRE)
+  if(dataAllocId != axom::MALLOC_ALLOCATOR_ID)
+  {
+    // Use Umpire pool for performance benchmarking.
+    constexpr size_t bytesPerCell = 100 * sizeof(double);
+    size_t poolSize = params.getBoxCellCount() * bytesPerCell;
+    umpire::ResourceManager& rm = umpire::ResourceManager::getInstance();
+    const umpire::Allocator dataAllocator = rm.getAllocator(dataAllocId);
+    const umpire::Allocator dataPoolAllocator =
+      rm.makeAllocator<umpire::strategy::QuickPool>("data_pool", dataAllocator, poolSize);
+    dataAllocId = dataPoolAllocator.getId();
+    const std::string poolName = dataAllocator.getName() + "_pool";
+    SLIC_INFO(axom::fmt::format("Using allocator pool id {}, '{}' with size {}",
+                                dataAllocId,
+                                poolName,
+                                poolSize));
+  }
+#endif
+
+  AXOM_ANNOTATE_BEGIN("quest clipping test");
+  AXOM_ANNOTATE_BEGIN("init");
+
+  // Storage for the some geometry meshes.
+  sidre::DataStore ds;
+
+  //---------------------------------------------------------------------------
+  // Create shapes for the test
+  //---------------------------------------------------------------------------
+  axom::Array<std::shared_ptr<axom::quest::experimental::MeshClipperStrategy>> geomStrategies;
+  geomStrategies.reserve(params.testGeom.size());
+  SLIC_ERROR_IF(params.getBoxDim() != 3, "This example is only in 3D.");
+  for(const auto& tg : params.testGeom)
+  {
+    if(geomReps.count(tg) == 0)
+    {
+      geomReps[tg] = 0;
+    }
+    std::string name = axom::fmt::format("{}.{}", tg, geomReps[tg]++);
+
+    if(tg == "tet")
+    {
+      geomStrategies.push_back(std::make_shared<axom::quest::experimental::TetClipper>(createGeom_Tet(name), name));
+    }
+    // More geometries to come.
+  }
+
+  {
+    SLIC_INFO(axom::fmt::format("{:-^80}", "Generating Blueprint mesh"));
+    compMeshGrp = ds.getRoot()->createGroup("compMesh");
+    compMeshGrp->setDefaultAllocator(dataAllocId);
+
+    createBoxMesh(compMeshGrp);
+
+    cellCount = params.getBoxCellCount();
+  }
+
+  //---------------------------------------------------------------------------
+  // Initialize computational mesh.
+  //---------------------------------------------------------------------------
+  std::shared_ptr<quest::experimental::ShapeMesh> sMeshPtr;
+  AXOM_ANNOTATE_BEGIN("setup shaping problem");
+  if(params.useBlueprintSidre())
+  {
+    sMeshPtr =
+      std::make_shared<quest::experimental::ShapeMesh>(params.policy, dataAllocId, compMeshGrp, topoName, matsetName);
+  }
+  if(params.useBlueprintConduit())
+  {
+    compMeshNode.reset(new conduit::Node);
+    compMeshNode->set_allocator(sidre::ConduitMemory::axomAllocIdToConduit(dataAllocId));
+    compMeshGrp->createNativeLayout(*compMeshNode);
+    compMeshNode->set_allocator(sidre::ConduitMemory::axomAllocIdToConduit(dataAllocId));
+
+    sMeshPtr = std::make_shared<quest::experimental::ShapeMesh>(params.policy,
+                                                   dataAllocId,
+                                                   *compMeshNode,
+                                                   topoName,
+                                                   matsetName);
+  }
+  quest::experimental::ShapeMesh& sMesh = *sMeshPtr;
+
+  AXOM_ANNOTATE_END("setup shaping problem");
+
+  // Compute and cache shared data so they are not associated with the first geometry.
+  SLIC_INFO(axom::fmt::format("{:-^80}", "Precomputing mesh data"));
+  sMesh.precomputeMeshData();
+
+  AXOM_ANNOTATE_END("init");
+
+  //---------------------------------------------------------------------------
+  // Process each of the shapes
+  //---------------------------------------------------------------------------
+
+  int failCounts = 0;
+
+  SLIC_INFO(axom::fmt::format("{:=^80}", "Shaping loop"));
+  AXOM_ANNOTATE_BEGIN("clipping");
+  for(axom::IndexType i = 0; i < geomStrategies.size(); ++i)
+  {
+    const auto geomName = geomStrategies[i]->name();
+    const auto annotationName = "clipping:" + geomName;
+
+    SLIC_INFO(axom::fmt::format("{:-^80}", axom::fmt::format("Processing geometry '{}'", geomName)));
+
+    if(my_rank == 0)
+    {
+      std::cout << "Info for geometry '" << geomName << "':" << std::endl;
+      geomStrategies[i]->info().print();
+    }
+
+    quest::experimental::MeshClipper clipper(sMesh, geomStrategies[i]);
+    clipper.setVerbose(params.isVerbose());
+    axom::Array<double> ovlap;
+    AXOM_ANNOTATE_BEGIN(annotationName);
+    clipper.clip(ovlap);
+    AXOM_ANNOTATE_END(annotationName);
+
+    // Save volume fractions in mesh, for plotting and checking.
+    sMesh.setMatsetFromVolume(geomStrategies[i]->name(), ovlap.view(), false);
+
+    // Correctness check on overlap volume.
+    if(!axom::execution_space<axom::SEQ_EXEC>::usesAllocId(ovlap.getAllocatorID()))
+    {
+      // Move to host for check.
+      ovlap = axom::Array<double>(ovlap, hostAllocId);
+    }
+    auto ovlapView = ovlap.view();
+    using reduce_policy = typename axom::execution_space<axom::SEQ_EXEC>::reduce_policy;
+    RAJA::ReduceSum<reduce_policy, double> ovlapSumReduce(0.0);
+    axom::for_all<axom::SEQ_EXEC>(
+      ovlap.size(),
+      AXOM_LAMBDA(axom::IndexType i) { ovlapSumReduce += ovlapView[i]; });
+    double computedOverlapVol = ovlapSumReduce.get();
+    double exactGeomVol = exactGeomVols[geomName];
+
+    bool err = !axom::utilities::isNearlyEqualRelative(computedOverlapVol,
+                                                       exactGeomVol,
+                                                       errorToleranceRel.at(geomName),
+                                                       errorToleranceAbs.at(geomName));
+    failCounts += err;
+
+    SLIC_INFO(axom::fmt::format("{:-^80}",
+                                axom::fmt::format("Shape '{}' has volume {} vs {}, diff of {}, {}.",
+                                                  geomName,
+                                                  computedOverlapVol,
+                                                  exactGeomVol,
+                                                  computedOverlapVol - exactGeomVol,
+                                                  (err ? "ERROR" : "OK"))));
+  }
+  AXOM_ANNOTATE_END("clipping");
+
+  AXOM_ANNOTATE_BEGIN("setFreeVolumeFractions");
+  sMesh.setFreeVolumeFractions("free");
+  AXOM_ANNOTATE_END("setFreeVolumeFractions");
+
+  /*
+    Copy mesh to host check results and plot.
+  */
+  SLIC_INFO(axom::fmt::format("{:-^80}", "Copying mesh to host and write out"));
+
+  AXOM_ANNOTATE_BEGIN("Copy results to host and write out");
+
+  if(params.useBlueprintConduit())
+  {
+    compMeshGrpOnHost = ds.getRoot()->createGroup("onHost");
+    compMeshGrpOnHost->setDefaultAllocator(hostAllocId);
+    compMeshGrpOnHost->importConduitTree(*sMesh.getMeshAsConduit());
+  }
+  if(params.useBlueprintSidre())
+  {
+    if(sMesh.getMeshAsSidre()->getDefaultAllocatorID() != hostAllocId)
+    {
+      compMeshGrpOnHost = ds.getRoot()->createGroup("onHost");
+      compMeshGrpOnHost->setDefaultAllocator(hostAllocId);
+      compMeshGrpOnHost->deepCopyGroup(sMesh.getMeshAsSidre(), hostAllocId);
+    }
+    else
+    {
+      SLIC_ASSERT(sMesh.getMeshAsSidre() == compMeshGrp);
+      compMeshGrpOnHost = compMeshGrp;
+    }
+  }
+
+  compMeshNode.reset(new conduit::Node);
+  compMeshGrpOnHost->createNativeLayout(*compMeshNode);
+
+  /*
+    Check blueprint validity.
+  */
+
+  conduit::Node whyNotValid;
+  if(!conduit::blueprint::mesh::verify(*compMeshNode, whyNotValid))
+  {
+    SLIC_ERROR("Computational mesh is invalid after shaping:\n" + whyNotValid.to_summary_string());
+  }
+
+  /*
+    Save meshes and fields
+  */
+
+  if(!params.outputFile.empty())
+  {
+    std::string fileName = params.outputFile + ".volfracs";
+    saveMesh(*compMeshNode, fileName);
+    SLIC_INFO(axom::fmt::format("{:-^80}", "Wrote output mesh " + fileName));
+  }
+
+  AXOM_ANNOTATE_END("Copy results to host and write out");
+
+  /*
+    Cleanup and exit
+  */
+  SLIC_INFO(axom::fmt::format("{:-^80}", ""));
+  slic::flushStreams();
+
+  AXOM_ANNOTATE_END("quest clipping test");
+
+  SLIC_INFO(axom::fmt::format("exiting with failure count {}", failCounts));
+
+  finalizeLogger();
+
+  return failCounts;
+}


### PR DESCRIPTION
# Summary

- This PR is an initial refactoring of the clipping code in `IntersectionShaper`.

- `IntersectionShaper` has 4 significant jobs that make it big and a bit unwieldy.
  1. Clip user-specified geometries against the cells of a mesh to compute overlap volumes.    Clipping accounts for more than 95% of the time spent in shaping and is the motivation for the current effort.  The intention is to provide fast clipping functionality for `IntersectionShaper` to use.
  2. Combine overlap volumes using replacement rules.
  3. Support multiple mesh formats (Blueprint and MFEM) stored in multiple hierarchy classes (Sidre and Conduit).
  4. Support multiple execution spaces to be selected by the user at run time.

- This PR
  - Implements the clipping code outside of `IntersectionShaper`.  The idea is to eventually remove the `IntersectionShaper`'s clipping code and use the new clipping code instead.
  - Introduces well-defined interfaces to support shape-specific approaches to improve clipping performance.  Clipping involves some shape-specific operations and some common operations.  Both have been re-factored to support a variety of potentially faster algorithms.
  - Begin implementing shape-specific clipping approaches.  The tetrahedral shape is included as an example.  More will follow in https://github.com/LLNL/axom/pull/1654.
  - Implement computation common to all shapes.  Multiple execution spaces are supported by factoring out those computations into a class templated on the execution space.
  - Provides a mesh wrapper that presents basic and derived mesh data as `ArrayView` objects, regardless of whether the mesh is Blueprint or MFEM, and stored in Sidre or Conduit.  This part is a work-in-progress in that MFEM support has not started.

PR https://github.com/LLNL/axom/pull/1654 depends on this one.