### PR TITLE
Fix macro spelling error.

### DIFF
--- a/src/axom/sidre/core/ConduitMemory.cpp
+++ b/src/axom/sidre/core/ConduitMemory.cpp
@@ -22,7 +22,7 @@ void ConduitMemory::privateRegisterAllocator()
     axom::deallocate<char>(cPtr);
   };
   m_deallocCallback = deallocator;
-#if defined(AXOM_USE_CONDUIT_STD_FUNCTION)
+#if defined(AXOM_CONDUIT_USES_STD_FUNCTION)
   m_allocCallback = [=](size_t itemCount, size_t itemByteSize) -> void* {
     void* ptr = axom::allocate<char>(itemCount * itemByteSize, m_axomId);
     return ptr;


### PR DESCRIPTION
# Summary

- This PR is a bug fix
- It fixes a spelling error and allows Axom to use Conduit's support for `std::function` call-backs.  Without this fix, Axom still avoids usting `std::function` these call-backs.