### PR TITLE
Use std::invoke_result_t instead of deprecated/removed std::result_of

### DIFF
--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -16,6 +16,7 @@
 #include "axom/primal/geometry/Vector.hpp"
 #include "axom/spin/RectangularLattice.hpp"
 
+#include <type_traits>
 #include <vector>
 
 namespace axom
@@ -708,7 +709,7 @@ private:
   template <typename FuncType>
   AXOM_HOST_DEVICE bool getVisitResult(FuncType&& type, int arg) const
   {
-    using ReturnType = typename std::result_of<FuncType(int)>::type;
+    using ReturnType = std::invoke_result_t<FuncType, int>;
     return VisitDispatch<FuncType, ReturnType>::getResult(type, arg);
   }
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - std::result_of was deprecated in C++17 and removed in C++20
  - Uses std::invoke_result_t instead
  - Handles the first case in issue #1718.