### PR TITLE
Fix non-sidre build

### DIFF
--- a/src/axom/quest/CMakeLists.txt
+++ b/src/axom/quest/CMakeLists.txt
@@ -158,7 +158,7 @@ if(AXOM_ENABLE_KLEE AND AXOM_ENABLE_SIDRE)
         endif()
     endif()
 
-    if(MFEM_FOUND AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION)
+    if(MFEM_FOUND AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION)
         list(APPEND quest_headers SamplingShaper.hpp 
                                   detail/shaping/InOutSampler.hpp
                                   detail/shaping/PrimitiveSampler.hpp

--- a/src/axom/quest/interface/internal/QuestHelpers.cpp
+++ b/src/axom/quest/interface/internal/QuestHelpers.cpp
@@ -24,7 +24,7 @@
   #endif
 #endif
 
-#if defined(AXOM_USE_MFEM)
+#if defined(AXOM_USE_MFEM) && defined(AXOM_USE_SIDRE)
   #include "axom/quest/io/MFEMReader.hpp"
   #include <mfem.hpp>
   #include <map>
@@ -434,7 +434,7 @@ int read_pro_e_mesh(const std::string& file, mint::Mesh*& m, MPI_Comm comm)
   return rc;
 }
 
-#if defined(AXOM_USE_MFEM)
+#if defined(AXOM_USE_MFEM) && defined(AXOM_USE_SIDRE)
 /*
  * Reads in the contour mesh from the specified file.
  */

--- a/src/axom/quest/io/MFEMReader.hpp
+++ b/src/axom/quest/io/MFEMReader.hpp
@@ -8,8 +8,8 @@
 
 #include "axom/config.hpp"
 
-#ifndef AXOM_USE_MFEM
-  #error MFEMReader should only be included when Axom is configured with MFEM
+#if !defined(AXOM_USE_MFEM) || !defined(AXOM_USE_SIDRE)
+  #error MFEMReader should only be included when Axom is configured with MFEM, SIDRE (and MFEM_SIDRE_DATACOLLECTION)
 #endif
 
 #include "axom/core/Array.hpp"

--- a/src/axom/quest/tests/CMakeLists.txt
+++ b/src/axom/quest/tests/CMakeLists.txt
@@ -87,7 +87,7 @@ endif()
 # Tests that use MFEM when available
 #------------------------------------------------------------------------------
 
-if(MFEM_FOUND)
+if(MFEM_FOUND AND AXOM_ENABLE_SIDRE AND AXOM_ENABLE_MFEM_SIDRE_DATACOLLECTION)
     function(add_quest_mfem_test test_name)
         axom_add_executable(
             NAME       ${test_name}

--- a/src/axom/quest/tests/quest_mfem_reader.cpp
+++ b/src/axom/quest/tests/quest_mfem_reader.cpp
@@ -5,8 +5,8 @@
 
 #include "axom/config.hpp"
 
-#ifndef AXOM_USE_MFEM
-  #error These tests should only be included when Axom is configured with MFEM
+#if !defined(AXOM_USE_MFEM) || !defined(AXOM_USE_SIDRE)
+  #error These tests should only be included when Axom is configured with MFEM and SIDRE
 #endif
 
 #include "axom/quest/io/MFEMReader.hpp"


### PR DESCRIPTION
# Summary

- This PR is a bug fix
- It does the following:
  - Remove from non-sidre build code that requires sidre.
  - Fixes https://github.com/LLNL/axom/issues/1708 and https://github.com/LLNL/axom/issues/1719
