### PR TITLE
One last Array optimization

### DIFF
--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -1637,19 +1637,18 @@ public:
   template <typename... Args>
   void emplace(T* array, IndexType dst, Args&&... args)
   {
-#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE)
-    if(space == MemorySpace::Device)
+#if defined(AXOM_USE_GPU) && defined(AXOM_USE_UMPIRE) && defined(AXOM_USE_CUDA)
+    // CUDA-only: special logic is needed if calling emplace() from the host on
+    // device-only memory.
+    // This is not needed for HIP builds, as device-allocated memory is
+    // accessible on the host.
+    if AXOM_UNLIKELY(space == MemorySpace::Device)
     {
       BaseDevice::emplace(array, dst, std::forward<Args>(args)...);
       return;
     }
-    else if(space == MemorySpace::Unified || space == MemorySpace::Pinned)
-    {
-      BaseUM::emplace(array, dst, std::forward<Args>(args)...);
-      return;
-    }
 #endif
-    Base::emplace(array, dst, std::forward<Args>(args)...);
+    ::new(array + dst) T(std::forward<Args>(args)...);
   }
 };
 


### PR DESCRIPTION
# Summary

Add `#ifdef` guard for special-case `ArrayOps::emplace()` code. This special case is only needed in CUDA builds, as device memory is inaccessible from the host. For HIP builds and host-only builds, we can just directly construct the object.

# Performance

### `push_back` without reserving memory - rzadams

  | int | pair | string
-- | -- | -- | --
std::vector push_back | 41350 | 302672 | 3363174
Array push-back (after PR #1731) | 63215 | 324007 | 3465678
Guard CUDA insert logic | 48650 | 313843 | 3319703
**Slowdown before** | 1.53x | 1.07x | 1.03x
**Slowdown after** | 1.18x | 1.04x | 0.99x

### `push_back` with pre-reserved memory - rzadams

  | int | pair | string
-- | -- | -- | --
std::vector push_back | 35904 | 36129 | 3240172
Array push-back (after PR #1731) | 54590 | 50444 | 3267889
Guard CUDA insert logic | 38426 | 37988 | 3119902
**Slowdown before** | 1.52x | 1.40x | 1.01x
**Slowdown after** | 1.07x | 1.05x | 0.96x

Before, I'd only been running benchmarks on rzadams, so I'll add rzwhippet numbers as well (although this PR won't affect those numbers):

### `push_back` without reserving memory - rzwhippet

  | int | pair | string
-- | -- | -- | --
std::vector push_back | 261766 | 590405 | 4811581
Array push_back | 175436 | 567879 | 4939035
**Speedup with Array** | 1.49x | 1.04x | 0.97x

### `push_back` with pre-reserved memory - rzwhippet

  | int | pair | string
-- | -- | -- | --
std::vector push_back | 174251 | 363834 | 4580622
Array push_back | 78289 | 331551 | 4623944
**Speedup with Array** | 2.23x | 1.10x | 0.99x

For rzwhippet, we are now sometimes even faster than the `std::vector` implementation, potentially due to the use of an Umpire memory pool instead of the default system allocator.

For rzadams, we are now roughly at parity with `std::vector` when pre-allocating memory - maybe 5-7% slower in the worst case. For insertions into an empty array, our worst case slowdown is 18% with `Array<int>` vs `std::vector<int>`. I think these remaining slowdowns might just be down to how Umpire handles support for GPU platforms.

Resolves #1471 