### PR TITLE
Fix compiler error when `MPI_Op` is not `int`

### DIFF
--- a/src/axom/quest/MeshClipper.cpp
+++ b/src/axom/quest/MeshClipper.cpp
@@ -239,7 +239,7 @@ std::unique_ptr<MeshClipper::Impl> MeshClipper::newImpl()
 
 #if defined(AXOM_USE_MPI)
 template <typename T>
-void globalReduce(axom::Array<T>& values, int reduceOp)
+void globalReduce(axom::Array<T>& values, MPI_Op reduceOp)
 {
   axom::Array<T> localValues(values);
   MPI_Allreduce(localValues.data(),


### PR DESCRIPTION
# Summary
Fix a build error that happens when `MPI_Op` is not `int`.
Fixes https://github.com/llnl/axom/issues/1783.  Thanks @dtaller for this fix.