### PR TITLE
Fix license file

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,6 +1,20 @@
 Intellectual Property Notice
 ------------------------------
 
+Axom is produced at the Lawrence Livermore National Laboratory
+
+Unlimited Open Source - BSD Distribution
+LLNL-CODE-825966
+CP02462
+
+Previous open source releases:
+Unlimited Open Source - BSD Distribution
+LLNL-CODE-741217
+OCEC-17-187
+
+This file is part of Axom
+For details, see https://github.com/llnl/axom
+
 Axom is licensed under the BSD 3-Clause license
 (BSD-3-Clause or https://opensource.org/licenses/BSD-3-Clause).
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,23 +1,7 @@
+BSD 3-Clause License
+
 Copyright (c) 2017-2026, Lawrence Livermore National Security, LLC.
-
-Produced at the Lawrence Livermore National Laboratory
-
-Unlimited Open Source - BSD Distribution
-LLNL-CODE-825966
-CP02462
-
-Previous open source releases:
-Unlimited Open Source - BSD Distribution
-LLNL-CODE-741217
-OCEC-17-187
-
 All rights reserved.
-
-This file is part of Axom
-
-For details, see https://github.com/llnl/axom
-
-Please also read axom/COPYRIGHT
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
# Summary

- This PR moves info around in license and copyright files so GitHub can identify the Axom license type properly.
- The issue was introduced in an earlier PR that reworked how copyright date was propagated through the repo (mea culpa)...

Fixes https://github.com/llnl/axom/issues/1810