### PR TITLE
Maybe_unused member variable

### DIFF
--- a/src/axom/core/utilities/RAII.hpp
+++ b/src/axom/core/utilities/RAII.hpp
@@ -90,7 +90,7 @@ public:
 private:
   int m_rank {0};
   int m_numranks {1};
-  bool m_should_finalize {false};
+  [[maybe_unused]] bool m_should_finalize {false};
 };
 
 /**


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Marks axom::utilities::raii::MPIWrapper private member m_should_finalize as maybe_unused
  - This quiets a very noisy compiler warning in non-MPI builds in a host code

