### PR TITLE
Adds OMP support for existing GWN examples

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,6 +25,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Primal: Adds `NURBSCurve::isLinear()` to check if a curve is (nearly) flat (corresponding to `BezierCurve::isLinear()`)
 - Primal: Adds `NURBSPatch::isTriviallyTrimmed()` to check if the trimming curves for a patch lie on the patch boundaries
 - Quest: Adds support for reading mfem files with variable order NURBS curves (requires mfem>4.9).
+- Quest: Adds OMP support for fast GWN methods for STL/Triangulated STEP input and linearized NURBS Curve input.
 
 ### Removed
 

--- a/src/axom/core/numerics/quadrature.cpp
+++ b/src/axom/core/numerics/quadrature.cpp
@@ -15,6 +15,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <mutex>
 
 namespace axom
 {
@@ -158,7 +159,7 @@ void compute_gauss_legendre_data(int npts,
  * \note If this method has already been called for a given order, it will reuse the same quadrature points
  *  without needing to recompute them
  *
- * \warning The use of a static variable to store cached nodes makes this method not threadsafe.
+ * \note This implementation uses a process-wide cache protected by a mutex for thread safety.
  * 
  * \return The `QuadratureRule` object which contains axom::ArrayView<double>'s of stored nodes and weights
  */
@@ -166,8 +167,10 @@ QuadratureRule get_gauss_legendre(int npts, int allocatorID)
 {
   assert("Quadrature rules must have >= 1 point" && (npts >= 1));
 
-  // Store cached rules keyed by (npts, allocatorID). This cache is not thread-safe.
+  // Store cached rules keyed by (npts, allocatorID).
   static axom::FlatMap<std::uint64_t, GaussLegendreRuleStorage> rule_library(64);
+  static std::mutex rule_library_mutex;
+  const std::lock_guard<std::mutex> lock(rule_library_mutex);
 
   const std::uint64_t key = make_gauss_legendre_key(npts, allocatorID);
 

--- a/src/axom/primal/geometry/NURBSPatch.hpp
+++ b/src/axom/primal/geometry/NURBSPatch.hpp
@@ -29,7 +29,6 @@
 #include "axom/primal/operators/evaluate_integral_curve.hpp"
 #include "axom/primal/operators/detail/winding_number_2d_impl.hpp"
 #include "axom/primal/operators/detail/intersect_bezier_impl.hpp"
-#include "axom/primal/operators/evaluate_integral.hpp"
 
 #include <ostream>
 #include <math.h>

--- a/src/axom/primal/geometry/NURBSPatch.hpp
+++ b/src/axom/primal/geometry/NURBSPatch.hpp
@@ -29,6 +29,7 @@
 #include "axom/primal/operators/evaluate_integral_curve.hpp"
 #include "axom/primal/operators/detail/winding_number_2d_impl.hpp"
 #include "axom/primal/operators/detail/intersect_bezier_impl.hpp"
+#include "axom/primal/operators/evaluate_integral.hpp"
 
 #include <ostream>
 #include <math.h>

--- a/src/axom/primal/operators/detail/winding_number_2d_memoization.hpp
+++ b/src/axom/primal/operators/detail/winding_number_2d_memoization.hpp
@@ -304,7 +304,7 @@ struct nurbs_cache_2d_traits
   using type = NURBSCurveCacheManager;
 };
 
-#if defined(AXOM_USE_OPENMP)
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP)
 /*!
  * \brief Manage per-thread arrays of NURBSCurveGWNCache<double>
  */

--- a/src/axom/primal/operators/detail/winding_number_2d_memoization.hpp
+++ b/src/axom/primal/operators/detail/winding_number_2d_memoization.hpp
@@ -256,6 +256,117 @@ std::ostream& operator<<(std::ostream& os, const NURBSCurveGWNCache<T>& nCurveCa
 }
 
 }  // namespace detail
+
+/*!
+ * \brief Manage an array of NURBSCurveGWNCache<double>
+ */
+class NURBSCurveCacheManager
+{
+  using NURBSCache = axom::primal::detail::NURBSCurveGWNCache<double>;
+  using NURBSCacheArray = axom::Array<NURBSCache>;
+  using NURBSCacheArrayView = axom::ArrayView<const NURBSCache>;
+
+  using CurveArrayView = axom::ArrayView<const axom::primal::NURBSCurve<double, 2>>;
+
+public:
+  NURBSCurveCacheManager() = default;
+
+  NURBSCurveCacheManager(const CurveArrayView& curves, double bbExpansionAmount = 0.0)
+  {
+    for(const auto& curve : curves)
+    {
+      m_nurbs_caches.push_back(NURBSCache(curve, bbExpansionAmount));
+    }
+  }
+
+  /// A view of the manager object.
+  struct View
+  {
+    NURBSCacheArrayView m_view;
+
+    /// Return the NURBSCacheArrayView.
+    NURBSCacheArrayView caches() const { return m_view; }
+  };
+
+  /// Return a view of this manager to pass into a device function.
+  View view() const { return View {m_nurbs_caches.view()}; }
+
+  /// Return if the underlying array is empty
+  bool empty() const { return m_nurbs_caches.empty(); }
+
+private:
+  NURBSCacheArray m_nurbs_caches;
+};
+
+template <typename ExecSpace>
+struct nurbs_cache_2d_traits
+{
+  using type = NURBSCurveCacheManager;
+};
+
+#if defined(AXOM_USE_OPENMP)
+/*!
+ * \brief Manage per-thread arrays of NURBSCurveGWNCache<double>
+ */
+class NURBSCurveCacheManagerOMP
+{
+  using NURBSCache = axom::primal::detail::NURBSCurveGWNCache<double>;
+  using NURBSCachePerThreadArray = axom::Array<axom::Array<NURBSCache>>;
+  using NURBSCachePerThreadArrayView = axom::ArrayView<const axom::Array<NURBSCache>>;
+  using NURBSCacheArrayView = axom::ArrayView<const NURBSCache>;
+
+  using CurveArrayView = axom::ArrayView<const axom::primal::NURBSCurve<double, 2>>;
+
+public:
+  NURBSCurveCacheManagerOMP() = default;
+
+  NURBSCurveCacheManagerOMP(const CurveArrayView& curves, double bbExpansionAmount = 0.0)
+  {
+    const int nt = omp_get_max_threads();
+    m_nurbs_caches.resize(nt);
+    auto nurbs_caches_view = m_nurbs_caches.view();
+
+    // Make the first one
+    nurbs_caches_view[0].resize(curves.size());
+    axom::for_all<axom::OMP_EXEC>(
+      curves.size(),
+      AXOM_LAMBDA(axom::IndexType i) {
+        nurbs_caches_view[0][i] = NURBSCache(curves[i], bbExpansionAmount);
+      });
+
+    // Copy the constructed cache to the other threads' copies (less work than construction)
+    axom::for_all<axom::OMP_EXEC>(
+      1,
+      nt,
+      AXOM_LAMBDA(axom::IndexType t) { nurbs_caches_view[t] = nurbs_caches_view[0]; });
+  }
+
+  /// A view of the manager object.
+  struct View
+  {
+    NURBSCachePerThreadArrayView m_views;
+
+    /// Return the NURBSCacheArrayView for the current OMP thread.
+    NURBSCacheArrayView caches() const { return m_views[omp_get_thread_num()].view(); }
+  };
+
+  /// Return a view of this manager to pass into a device function.
+  View view() const { return View {m_nurbs_caches.view()}; }
+
+  /// Return if the underlying array is empty
+  bool empty() const { return m_nurbs_caches.empty(); }
+
+private:
+  NURBSCachePerThreadArray m_nurbs_caches;
+};
+
+template <>
+struct nurbs_cache_2d_traits<axom::OMP_EXEC>
+{
+  using type = NURBSCurveCacheManagerOMP;
+};
+#endif
+
 }  // namespace primal
 }  // namespace axom
 

--- a/src/axom/primal/operators/detail/winding_number_3d_memoization.hpp
+++ b/src/axom/primal/operators/detail/winding_number_3d_memoization.hpp
@@ -180,7 +180,7 @@ public:
     }
     else
     {
-      m_castDirection = m_averageNormal;
+      m_castDirection = m_averageNormal.unitVector();
     }
 
     m_pboxDiag = m_alteredPatch.getParameterSpaceDiagonal();
@@ -342,7 +342,7 @@ struct nurbs_cache_3d_traits
   using type = NURBSPatchCacheManager;
 };
 
-#if defined(AXOM_USE_OPENMP)
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP)
 /*!
  * \brief Manage per-thread arrays of NURBSPatchGWNCache<double>
  */

--- a/src/axom/primal/operators/detail/winding_number_3d_memoization.hpp
+++ b/src/axom/primal/operators/detail/winding_number_3d_memoization.hpp
@@ -170,6 +170,19 @@ public:
       m_averageNormal = m_alteredPatch.calculateTrimmedPatchNormal();
     }
 
+    // Cast direction is set to average normal, unless it is near zero
+    if(m_averageNormal.norm() < 1e-10)
+    {
+      // ...unless the average direction is zero
+      double theta = axom::utilities::random_real(0.0, 2 * M_PI);
+      double u = axom::utilities::random_real(-1.0, 1.0);
+      m_castDirection = Vector<T, 3> {sin(theta) * sqrt(1 - u * u), cos(theta) * sqrt(1 - u * u), u};
+    }
+    else
+    {
+      m_castDirection = m_averageNormal;
+    }
+
     m_pboxDiag = m_alteredPatch.getParameterSpaceDiagonal();
 
     // Make a bounding box by doing (trimmed) bezier extraction,
@@ -238,6 +251,7 @@ public:
   ///@{
   //! \name Accessors for precomputed data
   const Vector<T, 3>& getAverageNormal() const { return m_averageNormal; }
+  const Vector<T, 3>& getCastDirection() const { return m_castDirection; }
   const BoundingBox<T, 3>& boundingBox() const { return m_bBox; }
   const OrientedBoundingBox<T, 3>& orientedBoundingBox() const { return m_oBox; }
   //@}
@@ -272,7 +286,7 @@ private:
   // Per patch data
   BoundingBox<T, 3> m_bBox;
   OrientedBoundingBox<T, 3> m_oBox;
-  Vector<T, 3> m_averageNormal;
+  Vector<T, 3> m_averageNormal, m_castDirection;
   double m_pboxDiag;
 
   // Per trimming curve data, keyed by (whichRefinementLevel, whichRefinementIndex)
@@ -280,6 +294,123 @@ private:
 };
 
 }  // namespace detail
+
+/*!
+ * \brief Manage an array of NURBSPatchGWNCache<double>
+ */
+class NURBSPatchCacheManager
+{
+  using NURBSCache = axom::primal::detail::NURBSPatchGWNCache<double>;
+  using NURBSCacheArray = axom::Array<NURBSCache>;
+  using NURBSCacheArrayView = axom::ArrayView<const NURBSCache>;
+
+  using PatchArrayView = axom::ArrayView<const axom::primal::NURBSPatch<double, 3>>;
+
+public:
+  NURBSPatchCacheManager() = default;
+
+  NURBSPatchCacheManager(const PatchArrayView& patchs)
+  {
+    for(const auto& patch : patchs)
+    {
+      m_nurbs_caches.push_back(NURBSCache(patch));
+    }
+  }
+
+  /// A view of the manager object.
+  struct View
+  {
+    NURBSCacheArrayView m_view;
+
+    /// Return the NURBSCacheArrayView.
+    NURBSCacheArrayView caches() const { return m_view; }
+  };
+
+  /// Return a view of this manager to pass into a device function.
+  View view() const { return View {m_nurbs_caches.view()}; }
+
+  /// Return if the underlying array is empty
+  bool empty() const { return m_nurbs_caches.empty(); }
+
+private:
+  NURBSCacheArray m_nurbs_caches;
+};
+
+template <typename ExecSpace>
+struct nurbs_cache_3d_traits
+{
+  using type = NURBSPatchCacheManager;
+};
+
+#if defined(AXOM_USE_OPENMP)
+/*!
+ * \brief Manage per-thread arrays of NURBSPatchGWNCache<double>
+ */
+class NURBSPatchCacheManagerOMP
+{
+  using NURBSCache = axom::primal::detail::NURBSPatchGWNCache<double>;
+  using NURBSCachePerThreadArray = axom::Array<axom::Array<NURBSCache>>;
+  using NURBSCachePerThreadArrayView = axom::ArrayView<const axom::Array<NURBSCache>>;
+  using NURBSCacheArrayView = axom::ArrayView<const NURBSCache>;
+
+  using PatchArrayView = axom::ArrayView<const axom::primal::NURBSPatch<double, 3>>;
+
+public:
+  NURBSPatchCacheManagerOMP() = default;
+
+  NURBSPatchCacheManagerOMP(const PatchArrayView& patches)
+  {
+    const int nt = omp_get_max_threads();
+    m_nurbs_caches.resize(nt);
+    auto nurbs_caches_view = m_nurbs_caches.view();
+
+    // Make the first one
+    nurbs_caches_view[0].resize(patches.size());
+    axom::for_all<axom::OMP_EXEC>(
+      patches.size(),
+      AXOM_LAMBDA(axom::IndexType i) { nurbs_caches_view[0][i] = NURBSCache(patches[i]); });
+    SLIC_INFO("Finished the first construction");
+    // Copy the constructed cache to the other threads' copies (less work than construction)
+    axom::for_all<axom::OMP_EXEC>(
+      1,
+      nt,
+      AXOM_LAMBDA(axom::IndexType t) { nurbs_caches_view[t].resize(nurbs_caches_view[0].size()); });
+    axom::for_all<axom::OMP_EXEC>(
+      patches.size(),
+      AXOM_LAMBDA(axom::IndexType i) {
+        for(int t = 0; t < nt; t++)
+        {
+          nurbs_caches_view[t][i] = nurbs_caches_view[0][i];
+        }
+      });
+  }
+
+  /// A view of the manager object.
+  struct View
+  {
+    NURBSCachePerThreadArrayView m_views;
+
+    /// Return the NURBSCacheArrayView for the current OMP thread.
+    NURBSCacheArrayView caches() const { return m_views[omp_get_thread_num()].view(); }
+  };
+
+  /// Return a view of this manager to pass into a device function.
+  View view() const { return View {m_nurbs_caches.view()}; }
+
+  /// Return if the underlying array is empty
+  bool empty() const { return m_nurbs_caches.empty(); }
+
+private:
+  NURBSCachePerThreadArray m_nurbs_caches;
+};
+
+template <>
+struct nurbs_cache_3d_traits<axom::OMP_EXEC>
+{
+  using type = NURBSPatchCacheManagerOMP;
+};
+#endif
+
 }  // namespace primal
 }  // namespace axom
 

--- a/src/axom/primal/operators/winding_number.hpp
+++ b/src/axom/primal/operators/winding_number.hpp
@@ -759,28 +759,40 @@ double winding_number(const Point<T, 3>& query,
                       const double disk_size = 0.01,
                       const double EPS = 1e-8)
 {
-  // Select the cast direction as an average normal of the untrimmed surface
-  auto cast_direction = nurbs.getAverageNormal();
-  if(cast_direction.norm() < 1e-10)
-  {
-    // ...unless the average direction is zero
-    double theta = axom::utilities::random_real(0.0, 2 * M_PI);
-    double u = axom::utilities::random_real(-1.0, 1.0);
-    cast_direction = Vector<T, 3> {sin(theta) * sqrt(1 - u * u), cos(theta) * sqrt(1 - u * u), u};
-  }
-  else
-  {
-    cast_direction = cast_direction.unitVector();
-  }
-
   return detail::nurbs_winding_number(query,
                                       nurbs,
-                                      cast_direction,
+                                      nurbs.getCastDirection(),
                                       edge_tol,
                                       ls_tol,
                                       quad_tol,
                                       disk_size,
                                       EPS);
+}
+
+/// \brief Overload for a single query and an ArrayView
+template <typename T>
+double winding_number(const Point<T, 3>& query,
+                      const axom::ArrayView<const detail::NURBSPatchGWNCache<T>>& nurbs_arr,
+                      const double edge_tol = 1e-8,
+                      const double ls_tol = 1e-8,
+                      const double quad_tol = 1e-8,
+                      const double disk_size = 0.01,
+                      const double EPS = 1e-8)
+{
+  double ret_val = 0.0;
+  for(int i = 0; i < nurbs_arr.size(); ++i)
+  {
+    ret_val += detail::nurbs_winding_number(query,
+                                            nurbs_arr[i],
+                                            nurbs_arr[i].getCastDirection(),
+                                            edge_tol,
+                                            ls_tol,
+                                            quad_tol,
+                                            disk_size,
+                                            EPS);
+  }
+
+  return ret_val;
 }
 
 /*!
@@ -847,26 +859,6 @@ axom::Array<double> winding_number(const axom::Array<Point<T, 3>>& query_arr,
                                    const double disk_size = 0.01,
                                    const double EPS = 1e-8)
 {
-  // Pull precomputed cast directions for each patch
-  axom::Array<Vector<T, 3>> cast_direction_arr(0, nurbs_arr.size());
-  for(int i = 0; i < nurbs_arr.size(); ++i)
-  {
-    // Select the cast direction as an average normal of the untrimmed surface
-    cast_direction_arr.emplace_back(nurbs_arr[i].getAverageNormal());
-    if(cast_direction_arr[i].norm() < 1e-10)
-    {
-      // ...unless the average direction is zero
-      double theta = axom::utilities::random_real(0.0, 2 * M_PI);
-      double u = axom::utilities::random_real(-1.0, 1.0);
-      cast_direction_arr[i] =
-        Vector<T, 3> {sin(theta) * sqrt(1 - u * u), cos(theta) * sqrt(1 - u * u), u};
-    }
-    else
-    {
-      cast_direction_arr[i] = cast_direction_arr[i].unitVector();
-    }
-  }
-
   axom::Array<double> ret_val(query_arr.size());
   for(int n = 0; n < query_arr.size(); ++n)
   {
@@ -876,7 +868,7 @@ axom::Array<double> winding_number(const axom::Array<Point<T, 3>>& query_arr,
     {
       ret_val[n] += detail::nurbs_winding_number(query_arr[n],
                                                  nurbs_arr[i],
-                                                 cast_direction_arr[i],
+                                                 nurbs_arr[i].castDirection(),
                                                  edge_tol,
                                                  ls_tol,
                                                  quad_tol,

--- a/src/axom/primal/operators/winding_number.hpp
+++ b/src/axom/primal/operators/winding_number.hpp
@@ -347,6 +347,23 @@ double winding_number(const Point<T, 2>& query,
   return gwn;
 }
 
+/// \brief Overload for views
+template <typename T>
+double winding_number(const Point<T, 2>& query,
+                      const axom::ArrayView<const detail::NURBSCurveGWNCache<T>>& nurbs_curve_arr,
+                      double edge_tol = 1e-8,
+                      double EPS = 1e-8)
+{
+  double gwn = 0;
+  bool dummy_isOnCurve = false;
+  for(int i = 0; i < nurbs_curve_arr.size(); ++i)
+  {
+    gwn += winding_number(query, nurbs_curve_arr[i], dummy_isOnCurve, edge_tol, EPS);
+  }
+
+  return gwn;
+}
+
 //! \brief Overload without optional return parameter
 template <typename T>
 double winding_number(const Point<T, 2>& query,

--- a/src/axom/primal/operators/winding_number.hpp
+++ b/src/axom/primal/operators/winding_number.hpp
@@ -868,7 +868,7 @@ axom::Array<double> winding_number(const axom::Array<Point<T, 3>>& query_arr,
     {
       ret_val[n] += detail::nurbs_winding_number(query_arr[n],
                                                  nurbs_arr[i],
-                                                 nurbs_arr[i].castDirection(),
+                                                 nurbs_arr[i].getCastDirection(),
                                                  edge_tol,
                                                  ls_tol,
                                                  quad_tol,

--- a/src/axom/quest/GWNMethods.hpp
+++ b/src/axom/quest/GWNMethods.hpp
@@ -200,7 +200,6 @@ public:
     {
       AXOM_ANNOTATE_SCOPE("query");
       const primal::WindingTolerances tol_copy = tol;
-      const auto input_curves_view = m_input_curves_view;
 
       // Use non-memoized form
       if(m_nurbs_cache_mgr.empty())
@@ -337,7 +336,7 @@ public:
         };
 
         const auto traverser = m_bvh.getTraverser();
-        m_internal_moments = traverser.reduce_tree<ExecSpace, GWNMoments>(compute_moments);
+        m_internal_moments = traverser.template reduce_tree<ExecSpace, GWNMoments>(compute_moments);
       }
       stage_timer.stop();
       SLIC_INFO(
@@ -697,7 +696,7 @@ public:
         };
 
         const auto traverser = m_bvh.getTraverser();
-        m_internal_moments = traverser.reduce_tree<ExecSpace, GWNMoments>(compute_moments);
+        m_internal_moments = traverser.template reduce_tree<ExecSpace, GWNMoments>(compute_moments);
       }
       stage_timer.stop();
       SLIC_INFO(

--- a/src/axom/quest/GWNMethods.hpp
+++ b/src/axom/quest/GWNMethods.hpp
@@ -256,7 +256,7 @@ private:
   NURBSCacheArray m_nurbs_caches;
 };
 
-template <int ORDER>
+template <typename ExecSpace, int ORDER>
 class PolylineGWN2D
 {
 public:
@@ -291,7 +291,7 @@ public:
       m_segments.resize(poly_mesh->getNumberOfCells());
       auto segments_view = m_segments.view();
 
-      axom::mint::for_all_cells<axom::SEQ_EXEC, axom::mint::xargs::coords>(
+      axom::mint::for_all_cells<ExecSpace, axom::mint::xargs::coords>(
         poly_mesh,
         AXOM_LAMBDA(axom::IndexType cellIdx,
                     const axom::numerics::Matrix<double>& coords,
@@ -316,7 +316,7 @@ public:
         auto aabbs_view = aabbs.view();
         const auto segments_view = m_segments.view();
 
-        axom::for_all<axom::SEQ_EXEC>(
+        axom::for_all<ExecSpace>(
           nlines,
           AXOM_LAMBDA(axom::IndexType i) {
             aabbs_view[i] = BoxType {segments_view[i].source(), segments_view[i].target()};
@@ -340,7 +340,7 @@ public:
         };
 
         const auto traverser = m_bvh.getTraverser();
-        m_internal_moments = traverser.reduce_tree<axom::SEQ_EXEC, GWNMoments>(compute_moments);
+        m_internal_moments = traverser.reduce_tree<ExecSpace, GWNMoments>(compute_moments);
       }
       stage_timer.stop();
       SLIC_INFO(
@@ -396,7 +396,7 @@ public:
         const auto traverser = m_bvh.getTraverser();
         const auto internal_moments_view = m_internal_moments.view();
 
-        axom::for_all<axom::SEQ_EXEC>(num_query_points, [=, &winding, &inout](axom::IndexType index) {
+        axom::for_all<ExecSpace>(num_query_points, [=, &winding, &inout](axom::IndexType index) {
           const double wn = axom::quest::fast_approximate_winding_number(query_point(index),
                                                                          traverser,
                                                                          segments_view,
@@ -410,7 +410,7 @@ public:
       // Use direct formula
       else
       {
-        axom::for_all<axom::SEQ_EXEC>(num_query_points, [=, &winding, &inout](axom::IndexType index) {
+        axom::for_all<ExecSpace>(num_query_points, [=, &winding, &inout](axom::IndexType index) {
           const axom::primal::Point<double, 2> q = query_point(static_cast<int>(index));
           double wn {};
           for(const auto& seg : segments_view)
@@ -444,7 +444,7 @@ private:
 
   // Only needed for fast approximation method
   axom::Array<GWNMoments> m_internal_moments;
-  axom::spin::BVH<2, axom::SEQ_EXEC> m_bvh;
+  axom::spin::BVH<2, ExecSpace> m_bvh;
 };
 ///@}
 
@@ -837,8 +837,8 @@ enum class GWNInputType
 template <typename GWNQueryType>
 struct gwn_input_traits;
 
-template <int ORDER>
-struct gwn_input_traits<axom::quest::PolylineGWN2D<ORDER>>
+template <typename ExecSpace, int ORDER>
+struct gwn_input_traits<axom::quest::PolylineGWN2D<ExecSpace, ORDER>>
   : std::integral_constant<GWNInputType, GWNInputType::Polyline>
 { };
 

--- a/src/axom/quest/GWNMethods.hpp
+++ b/src/axom/quest/GWNMethods.hpp
@@ -128,11 +128,12 @@ void generate_gwn_query_mesh(mfem::DataCollection& dc,
 ///@{
 /// \name Query methods for 2D GWN applications
 
+template <typename ExecSpace>
 class DirectGWN2D
 {
 public:
   using CurveArrayType = axom::Array<axom::primal::NURBSCurve<double, 2>>;
-  using NURBSCacheArray = axom::Array<axom::primal::detail::NURBSCurveGWNCache<double>>;
+  using NURBSCacheManager = typename axom::primal::nurbs_cache_2d_traits<ExecSpace>::type;
 
   DirectGWN2D() = default;
 
@@ -152,11 +153,7 @@ public:
       AXOM_ANNOTATE_SCOPE("preprocessing");
       if(use_memoization)
       {
-        m_nurbs_caches.reserve(input_curves.size());
-        for(const auto& curv : input_curves)
-        {
-          m_nurbs_caches.emplace_back(curv);
-        }
+        m_nurbs_cache_mgr = NURBSCacheManager(input_curves);
       }
     }
     timer.stop();
@@ -206,14 +203,14 @@ public:
       const auto input_curves_view = m_input_curves_view;
 
       // Use non-memoized form
-      if(m_nurbs_caches.empty())
+      if(m_nurbs_cache_mgr.empty())
       {
-        axom::for_all<axom::SEQ_EXEC>(num_query_points, [=, &winding, &inout](axom::IndexType nidx) {
+        axom::for_all<ExecSpace>(num_query_points, [=, &winding, &inout](axom::IndexType nidx) {
           const auto q = query_point(static_cast<int>(nidx));
           double wn {};
-          for(const auto& cache : input_curves_view)
+          for(const auto& curve : m_input_curves_view)
           {
-            wn += axom::primal::winding_number(q, cache, tol_copy.edge_tol, tol_copy.EPS);
+            wn += axom::primal::winding_number(q, curve, tol_copy.edge_tol, tol_copy.EPS);
           }
           winding[static_cast<int>(nidx)] = wn;
           inout[static_cast<int>(nidx)] = std::lround(wn);
@@ -221,14 +218,14 @@ public:
       }
       else  // Use memoized form
       {
-        const auto nurbs_caches_view = m_nurbs_caches.view();
-        axom::for_all<axom::SEQ_EXEC>(num_query_points, [=, &winding, &inout](axom::IndexType nidx) {
+        const auto cache_mgr_view = m_nurbs_cache_mgr.view();
+        axom::for_all<ExecSpace>(num_query_points, [=, &winding, &inout](axom::IndexType nidx) {
           const auto q = query_point(static_cast<int>(nidx));
-          double wn {};
-          for(const auto& cache : nurbs_caches_view)
-          {
-            wn += axom::primal::winding_number(q, cache, tol_copy.edge_tol, tol_copy.EPS);
-          }
+          const auto caches_view = cache_mgr_view.caches();
+
+          const double wn =
+            axom::primal::winding_number(q, caches_view, tol_copy.edge_tol, tol_copy.EPS);
+
           winding[static_cast<int>(nidx)] = wn;
           inout[static_cast<int>(nidx)] = std::lround(wn);
         });
@@ -243,7 +240,7 @@ public:
       "Querying {:L} samples in winding number field with{} memoization took {:.3Lf} seconds"
       " (@ {:.0Lf} queries per second; {:.6Lf} ms per query)",
       num_query_points,
-      m_nurbs_caches.empty() ? "out" : "",
+      m_nurbs_cache_mgr.empty() ? "out" : "",
       query_time_s,
       num_query_points / query_time_s,
       ms_per_query));
@@ -253,7 +250,7 @@ public:
 
 private:
   axom::ArrayView<const axom::primal::NURBSCurve<double, 2>> m_input_curves_view;
-  NURBSCacheArray m_nurbs_caches;
+  NURBSCacheManager m_nurbs_cache_mgr;
 };
 
 template <typename ExecSpace, int ORDER>
@@ -842,8 +839,8 @@ struct gwn_input_traits<axom::quest::PolylineGWN2D<ExecSpace, ORDER>>
   : std::integral_constant<GWNInputType, GWNInputType::Polyline>
 { };
 
-template <>
-struct gwn_input_traits<axom::quest::DirectGWN2D>
+template <typename ExecSpace>
+struct gwn_input_traits<axom::quest::DirectGWN2D<ExecSpace>>
   : std::integral_constant<GWNInputType, GWNInputType::Curve>
 { };
 

--- a/src/axom/quest/GWNMethods.hpp
+++ b/src/axom/quest/GWNMethods.hpp
@@ -594,7 +594,7 @@ private:
   NURBSCacheArray m_nurbs_caches;
 };
 
-template <int ORDER>
+template <typename ExecSpace, int ORDER>
 class TriangleGWN3D
 {
 public:
@@ -628,7 +628,7 @@ public:
       // Iterate over mesh nodes and get a bounding box for the shape
       BoxType shape_bbox;
       BoxType* shape_bbox_ptr = &shape_bbox;
-      axom::mint::for_all_nodes<axom::SEQ_EXEC, axom::mint::xargs::xyz>(
+      axom::mint::for_all_nodes<ExecSpace, axom::mint::xargs::xyz>(
         tri_mesh,
         AXOM_LAMBDA(axom::IndexType, double x, double y, double z) {
           shape_bbox_ptr->addPoint(Point3D {x, y, z});
@@ -645,7 +645,7 @@ public:
 
       m_triangles.resize(ntris);
       auto triangles_view = m_triangles.view();
-      axom::mint::for_all_cells<axom::SEQ_EXEC, axom::mint::xargs::coords>(
+      axom::mint::for_all_cells<ExecSpace, axom::mint::xargs::coords>(
         tri_mesh,
         AXOM_LAMBDA(axom::IndexType cellIdx,
                     const axom::numerics::Matrix<double>& coords,
@@ -677,7 +677,7 @@ public:
         auto aabbs_view = aabbs.view();
         const auto triangles_view = m_triangles.view();
 
-        axom::for_all<axom::SEQ_EXEC>(
+        axom::for_all<ExecSpace>(
           ntris,
           AXOM_LAMBDA(axom::IndexType i) {
             aabbs_view[i] =
@@ -702,7 +702,7 @@ public:
         };
 
         const auto traverser = m_bvh.getTraverser();
-        m_internal_moments = traverser.reduce_tree<axom::SEQ_EXEC, GWNMoments>(compute_moments);
+        m_internal_moments = traverser.reduce_tree<ExecSpace, GWNMoments>(compute_moments);
       }
       stage_timer.stop();
       SLIC_INFO(
@@ -766,7 +766,7 @@ public:
         const auto traverser = m_bvh.getTraverser();
         const auto internal_moments_view = m_internal_moments.view();
 
-        axom::for_all<axom::SEQ_EXEC>(num_query_points, [=, &winding, &inout](axom::IndexType index) {
+        axom::for_all<ExecSpace>(num_query_points, [=, &winding, &inout](axom::IndexType index) {
           const double wn = axom::quest::fast_approximate_winding_number(scaled_query_point(index),
                                                                          traverser,
                                                                          triangles_view,
@@ -780,7 +780,7 @@ public:
       // Use direct formula
       else
       {
-        axom::for_all<axom::SEQ_EXEC>(num_query_points, [=, &winding, &inout](axom::IndexType index) {
+        axom::for_all<ExecSpace>(num_query_points, [=, &winding, &inout](axom::IndexType index) {
           const auto q = scaled_query_point(static_cast<int>(index));
           double wn {};
           for(const auto& tri : triangles_view)
@@ -814,7 +814,7 @@ private:
 
   // Only needed for fast approximation method
   axom::Array<GWNMoments> m_internal_moments;
-  axom::spin::BVH<3, axom::SEQ_EXEC> m_bvh;
+  axom::spin::BVH<3, ExecSpace> m_bvh;
 
   // Parameters for normalization
   axom::primal::Point<double, 3> m_shape_center;
@@ -847,8 +847,8 @@ struct gwn_input_traits<axom::quest::DirectGWN2D>
   : std::integral_constant<GWNInputType, GWNInputType::Curve>
 { };
 
-template <int ORDER>
-struct gwn_input_traits<axom::quest::TriangleGWN3D<ORDER>>
+template <typename ExecSpace, int ORDER>
+struct gwn_input_traits<axom::quest::TriangleGWN3D<ExecSpace, ORDER>>
   : std::integral_constant<GWNInputType, GWNInputType::Triangulation>
 { };
 

--- a/src/axom/quest/GWNMethods.hpp
+++ b/src/axom/quest/GWNMethods.hpp
@@ -447,11 +447,14 @@ private:
 
 ///@{
 /// \name Query methods for 3D GWN applications
+
+template <typename ExecSpace>
 class DirectGWN3D
 {
 public:
   using PatchArrayType = axom::Array<axom::primal::NURBSPatch<double, 3>>;
   using NURBSCacheArray = axom::Array<axom::primal::detail::NURBSPatchGWNCache<double>>;
+  using NURBSCacheManager = typename axom::primal::nurbs_cache_3d_traits<ExecSpace>::type;
 
   DirectGWN3D() = default;
 
@@ -471,11 +474,7 @@ public:
       AXOM_ANNOTATE_SCOPE("preprocessing");
       if(use_memoization)
       {
-        m_nurbs_caches.reserve(input_patches.size());
-        for(const auto& patch : input_patches)
-        {
-          m_nurbs_caches.emplace_back(patch);
-        }
+        m_nurbs_cache_mgr = NURBSCacheManager(input_patches);
       }
     }
     timer.stop();
@@ -529,9 +528,9 @@ public:
       const auto input_patches_view = m_input_patches_view;
 
       // Use non-memoized form
-      if(m_nurbs_caches.empty())
+      if(m_nurbs_cache_mgr.empty())
       {
-        axom::for_all<axom::SEQ_EXEC>(num_query_points, [=, &winding, &inout](axom::IndexType nidx) {
+        axom::for_all<ExecSpace>(num_query_points, [=, &winding, &inout](axom::IndexType nidx) {
           const auto q = query_point(static_cast<int>(nidx));
           double wn {};
           for(const auto& patch : input_patches_view)
@@ -550,20 +549,19 @@ public:
       }
       else  // Use memoized form
       {
-        const auto nurbs_patches_view = m_nurbs_caches.view();
-        axom::for_all<axom::SEQ_EXEC>(num_query_points, [=, &winding, &inout](axom::IndexType nidx) {
+        const auto cache_mgr_view = m_nurbs_cache_mgr.view();
+        axom::for_all<ExecSpace>(num_query_points, [=, &winding, &inout](axom::IndexType nidx) {
           const auto q = query_point(static_cast<int>(nidx));
-          double wn {};
-          for(const auto& cache : nurbs_patches_view)
-          {
-            wn += axom::primal::winding_number(q,
-                                               cache,
-                                               tol_copy.edge_tol,
-                                               tol_copy.ls_tol,
-                                               tol_copy.quad_tol,
-                                               tol_copy.disk_size,
-                                               tol_copy.EPS);
-          }
+          const auto caches_view = cache_mgr_view.caches();
+
+          const double wn = axom::primal::winding_number(q,
+                                                         caches_view,
+                                                         tol_copy.edge_tol,
+                                                         tol_copy.ls_tol,
+                                                         tol_copy.quad_tol,
+                                                         tol_copy.disk_size,
+                                                         tol_copy.EPS);
+
           winding[static_cast<int>(nidx)] = wn;
           inout[static_cast<int>(nidx)] = std::lround(wn);
         });
@@ -578,7 +576,7 @@ public:
       "Querying {:L} samples in winding number field with{} memoization took {:.3Lf} seconds"
       " (@ {:.0Lf} queries per second; {:.6Lf} ms per query)",
       num_query_points,
-      m_nurbs_caches.empty() ? "out" : "",
+      m_nurbs_cache_mgr.empty() ? "out" : "",
       query_time_s,
       num_query_points / query_time_s,
       ms_per_query));
@@ -588,7 +586,7 @@ public:
 
 private:
   axom::ArrayView<const axom::primal::NURBSPatch<double, 3>> m_input_patches_view;
-  NURBSCacheArray m_nurbs_caches;
+  NURBSCacheManager m_nurbs_cache_mgr;
 };
 
 template <typename ExecSpace, int ORDER>
@@ -849,8 +847,8 @@ struct gwn_input_traits<axom::quest::TriangleGWN3D<ExecSpace, ORDER>>
   : std::integral_constant<GWNInputType, GWNInputType::Triangulation>
 { };
 
-template <>
-struct gwn_input_traits<axom::quest::DirectGWN3D>
+template <typename ExecSpace>
+struct gwn_input_traits<axom::quest::DirectGWN3D<ExecSpace>>
   : std::integral_constant<GWNInputType, GWNInputType::Surface>
 { };
 

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -719,6 +719,7 @@ if(MFEM_FOUND AND OPENCASCADE_FOUND)
                         --output-prefix wn3d_${_model}_res${_res_i}
                         --no-vis
                         --stats
+                        --policy seq
                         query_mesh --res ${_res_i} ${_res_j} ${_res_k} --order 1)
             set_tests_properties(${_testname} PROPERTIES
                 PASS_REGULAR_EXPRESSION "${_pass_regex}")

--- a/src/axom/quest/examples/quest_winding_number_2d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_2d.cpp
@@ -475,7 +475,7 @@ int main(int argc, char** argv)
   }
 
   axom::utilities::raii::AnnotationsWrapper annotation_raii_wrapper(input.annotationMode);
-  AXOM_ANNOTATE_SCOPE("winding number example");
+  AXOM_ANNOTATE_SCOPE("2D winding number example");
 
   if (!input.elevatedMeshFile.empty())
   {

--- a/src/axom/quest/examples/quest_winding_number_2d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_2d.cpp
@@ -413,8 +413,9 @@ public:
 using GWNQueryType = std::variant<axom::quest::DirectGWN2D<axom::SEQ_EXEC>,
                                   axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 0>,
                                   axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 1>,
-                                  axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 2>,
+                                  axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 2>
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP)
+                                  ,
                                   axom::quest::DirectGWN2D<axom::OMP_EXEC>,
                                   axom::quest::PolylineGWN2D<axom::OMP_EXEC, 0>,
                                   axom::quest::PolylineGWN2D<axom::OMP_EXEC, 1>,

--- a/src/axom/quest/examples/quest_winding_number_2d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_2d.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 /*!
- * \file quest_winding_number2d.cpp
+ * \file quest_winding_number_2d.cpp
  * \brief Example that computes the winding number of a grid of points
  * against a collection of 2D parametric rational curves.
  * Supports MFEM meshes in the cubic positive Bernstein basis or the (rational)
@@ -42,214 +42,216 @@ using BoundingBox2D = primal::BoundingBox<double, 2>;
 
 using NURBSCurve2D = primal::NURBSCurve<double, 2>;
 
+using RuntimePolicy = axom::runtime_policy::Policy;
+
 namespace
 {
-/**
- * This helper class takes in an mfem mesh (potentially with variable order curves from mfem>4.9)
- * and writes out a version that is compatible with mfem@4.9
- * In particular, this allows us to visualize it with current versions of VisIt which do not yet support this feature.
- *
- * We can remove this class once downstream applications (such as VisIt) are updated to a version of mfem
- * that supports the NURBS patches format.
- */
-class MFEM49ElevatedNURBSMeshWriter
-{
-public:
-  explicit MFEM49ElevatedNURBSMeshWriter(double tol = 1e-12) : m_tol(tol) { }
-
-  bool writeElevatedMesh(const std::string& input_file, const std::string& output_file) const
+  /**
+   * This helper class takes in an mfem mesh (potentially with variable order curves from mfem>4.9)
+   * and writes out a version that is compatible with mfem@4.9
+   * In particular, this allows us to visualize it with current versions of VisIt which do not yet support this feature.
+   *
+   * We can remove this class once downstream applications (such as VisIt) are updated to a version of mfem
+   * that supports the NURBS patches format.
+   */
+  class MFEM49ElevatedNURBSMeshWriter
   {
-    mfem::Mesh mesh(input_file, /*generate_edges=*/1, /*refine=*/1);
+  public:
+    explicit MFEM49ElevatedNURBSMeshWriter(double tol = 1e-12) : m_tol(tol) {}
 
-    if(mesh.NURBSext == nullptr)
+    bool writeElevatedMesh(const std::string& input_file, const std::string& output_file) const
     {
-      SLIC_WARNING(
-        axom::fmt::format("Input mesh '{}' has no NURBS extension; skipping degree elevation",
-                          input_file));
-      return false;
+      mfem::Mesh mesh(input_file, /*generate_edges=*/1, /*refine=*/1);
+
+      if (mesh.NURBSext == nullptr)
+      {
+        SLIC_WARNING(
+          axom::fmt::format("Input mesh '{}' has no NURBS extension; skipping degree elevation",
+            input_file));
+        return false;
+      }
+
+      // Note: NURBS curve meshes in mfem@4.9 must all have the same degree, and their knotvectors must have the same length.
+      // MFEM calls this quantity "order"; in Axom terminology this is the polynomial degree.
+      const mfem::Array<int>& orders = mesh.NURBSext->GetOrders();
+      int max_order = 0;
+      for (int i = 0; i < orders.Size(); ++i)
+      {
+        max_order = std::max(max_order, orders[i]);
+      }
+
+      if (max_order <= 0)
+      {
+        SLIC_WARNING(
+          axom::fmt::format("Input mesh '{}' has invalid NURBS orders; skipping degree elevation",
+            input_file));
+        return false;
+      }
+
+      mesh.DegreeElevate(max_order, max_order);
+
+      makeKnotVectorsUniform(mesh);
+
+      // Write the modified mesh to output_file
+      if (!writeMeshPrintFormat(mesh, output_file))
+      {
+        SLIC_WARNING(axom::fmt::format("Failed to write elevated mesh '{}'", output_file));
+        return false;
+      }
+
+      SLIC_INFO(axom::fmt::format("Wrote elevated MFEM 4.9-compatible NURBS mesh '{}' (max order {})",
+        output_file,
+        max_order));
+      return true;
     }
 
-    // Note: NURBS curve meshes in mfem@4.9 must all have the same degree, and their knotvectors must have the same length.
-    // MFEM calls this quantity "order"; in Axom terminology this is the polynomial degree.
-    const mfem::Array<int>& orders = mesh.NURBSext->GetOrders();
-    int max_order = 0;
-    for(int i = 0; i < orders.Size(); ++i)
+  private:
+    struct KnotBin
     {
-      max_order = std::max(max_order, orders[i]);
-    }
-
-    if(max_order <= 0)
-    {
-      SLIC_WARNING(
-        axom::fmt::format("Input mesh '{}' has invalid NURBS orders; skipping degree elevation",
-                          input_file));
-      return false;
-    }
-
-    mesh.DegreeElevate(max_order, max_order);
-
-    makeKnotVectorsUniform(mesh);
-
-    // Write the modified mesh to output_file
-    if(!writeMeshPrintFormat(mesh, output_file))
-    {
-      SLIC_WARNING(axom::fmt::format("Failed to write elevated mesh '{}'", output_file));
-      return false;
-    }
-
-    SLIC_INFO(axom::fmt::format("Wrote elevated MFEM 4.9-compatible NURBS mesh '{}' (max order {})",
-                                output_file,
-                                max_order));
-    return true;
-  }
-
-private:
-  struct KnotBin
-  {
-    std::int64_t key {0};
-    double value {0.0};
-    int max_multiplicity {0};
-  };
-
-  // MFEM 4.9's 1D NURBS reader assumes all knotvectors have the same GetNE/GetNCP
-  // and uses KnotVec(0) when computing offsets. To generate MFEM 4.9/VisIt
-  // compatible files, insert knots so every knotvector matches the maximum
-  // knot multiplicity pattern present in the mesh.
-  void makeKnotVectorsUniform(mfem::Mesh& mesh) const
-  {
-    if(mesh.NURBSext == nullptr)
-    {
-      return;
-    }
-    if(mesh.Dimension() != 1 || mesh.NURBSext->Dimension() != 1)
-    {
-      return;
-    }
-
-    const int nkv = mesh.NURBSext->GetNKV();
-    if(nkv <= 1)
-    {
-      return;
-    }
-
-    const double inv_tol = (m_tol > 0.0) ? (1.0 / m_tol) : 1.0e12;
-    auto key_for = [inv_tol](double t) -> std::int64_t {
-      return static_cast<std::int64_t>(std::llround(t * inv_tol));
+      std::int64_t key{ 0 };
+      double value{ 0.0 };
+      int max_multiplicity{ 0 };
     };
 
-    std::vector<std::unordered_map<std::int64_t, int>> counts(nkv);
-    std::unordered_map<std::int64_t, KnotBin> bins;
-
-    for(int i = 0; i < nkv; ++i)
+    // MFEM 4.9's 1D NURBS reader assumes all knotvectors have the same GetNE/GetNCP
+    // and uses KnotVec(0) when computing offsets. To generate MFEM 4.9/VisIt
+    // compatible files, insert knots so every knotvector matches the maximum
+    // knot multiplicity pattern present in the mesh.
+    void makeKnotVectorsUniform(mfem::Mesh& mesh) const
     {
-      const mfem::KnotVector* kv = mesh.NURBSext->GetKnotVector(i);
-      if(kv == nullptr)
+      if (mesh.NURBSext == nullptr)
       {
-        continue;
+        return;
+      }
+      if (mesh.Dimension() != 1 || mesh.NURBSext->Dimension() != 1)
+      {
+        return;
       }
 
-      auto& local = counts[i];
-      for(int j = 0; j < kv->Size(); ++j)
+      const int nkv = mesh.NURBSext->GetNKV();
+      if (nkv <= 1)
       {
-        const double value = (*kv)[j];
-        const std::int64_t key = key_for(value);
-
-        const int multiplicity = ++local[key];
-        auto& bin = bins[key];
-        bin.key = key;
-        bin.value = value;
-        bin.max_multiplicity = std::max(bin.max_multiplicity, multiplicity);
-      }
-    }
-
-    std::vector<KnotBin> sorted_bins;
-    sorted_bins.reserve(bins.size());
-    for(const auto& it : bins)
-    {
-      sorted_bins.push_back(it.second);
-    }
-    std::sort(sorted_bins.begin(), sorted_bins.end(), [](const KnotBin& a, const KnotBin& b) {
-      if(a.value != b.value)
-      {
-        return a.value < b.value;
-      }
-      return a.key < b.key;
-    });
-
-    int total_to_insert = 0;
-    mfem::Array<mfem::Vector*> insertions(nkv);
-    for(int i = 0; i < nkv; ++i)
-    {
-      int need_total = 0;
-      for(const auto& bin : sorted_bins)
-      {
-        const auto found = counts[i].find(bin.key);
-        const int have = (found == counts[i].end()) ? 0 : found->second;
-        need_total += std::max(0, bin.max_multiplicity - have);
+        return;
       }
 
-      insertions[i] = new mfem::Vector(need_total);
-      int pos = 0;
-      for(const auto& bin : sorted_bins)
+      const double inv_tol = (m_tol > 0.0) ? (1.0 / m_tol) : 1.0e12;
+      auto key_for = [inv_tol](double t) -> std::int64_t {
+        return static_cast<std::int64_t>(std::llround(t * inv_tol));
+        };
+
+      std::vector<std::unordered_map<std::int64_t, int>> counts(nkv);
+      std::unordered_map<std::int64_t, KnotBin> bins;
+
+      for (int i = 0; i < nkv; ++i)
       {
-        const auto found = counts[i].find(bin.key);
-        const int have = (found == counts[i].end()) ? 0 : found->second;
-        const int need = std::max(0, bin.max_multiplicity - have);
-        for(int k = 0; k < need; ++k)
+        const mfem::KnotVector* kv = mesh.NURBSext->GetKnotVector(i);
+        if (kv == nullptr)
         {
-          (*insertions[i])[pos++] = bin.value;
+          continue;
+        }
+
+        auto& local = counts[i];
+        for (int j = 0; j < kv->Size(); ++j)
+        {
+          const double value = (*kv)[j];
+          const std::int64_t key = key_for(value);
+
+          const int multiplicity = ++local[key];
+          auto& bin = bins[key];
+          bin.key = key;
+          bin.value = value;
+          bin.max_multiplicity = std::max(bin.max_multiplicity, multiplicity);
         }
       }
-      total_to_insert += need_total;
-    }
 
-    if(total_to_insert > 0)
-    {
-      mesh.KnotInsert(insertions);
-    }
-
-    for(int i = 0; i < nkv; ++i)
-    {
-      delete insertions[i];
-    }
-  }
-
-  bool writeMeshPrintFormat(const mfem::Mesh& mesh, const std::string& output_file) const
-  {
-    std::ostringstream oss;
-    oss.precision(16);
-    mesh.Print(oss);
-
-    std::istringstream iss(oss.str());
-    std::ofstream ofs(output_file);
-    if(!ofs.is_open())
-    {
-      return false;
-    }
-    ofs.precision(16);
-
-    // Note: mfem@4.9's mesh reader does not support the "NURBS2" finite element collection,
-    // if it occurs, we replace it with the (essentially equivalent) "NURBS"
-    std::string line;
-    while(std::getline(iss, line))
-    {
-      constexpr const char* prefix = "FiniteElementCollection: NURBS";
-      if(line.rfind(prefix, 0) == 0)
+      std::vector<KnotBin> sorted_bins;
+      sorted_bins.reserve(bins.size());
+      for (const auto& it : bins)
       {
-        ofs << prefix << '\n';
+        sorted_bins.push_back(it.second);
       }
-      else
+      std::sort(sorted_bins.begin(), sorted_bins.end(), [](const KnotBin& a, const KnotBin& b) {
+        if (a.value != b.value)
+        {
+          return a.value < b.value;
+        }
+        return a.key < b.key;
+        });
+
+      int total_to_insert = 0;
+      mfem::Array<mfem::Vector*> insertions(nkv);
+      for (int i = 0; i < nkv; ++i)
       {
-        ofs << line << '\n';
+        int need_total = 0;
+        for (const auto& bin : sorted_bins)
+        {
+          const auto found = counts[i].find(bin.key);
+          const int have = (found == counts[i].end()) ? 0 : found->second;
+          need_total += std::max(0, bin.max_multiplicity - have);
+        }
+
+        insertions[i] = new mfem::Vector(need_total);
+        int pos = 0;
+        for (const auto& bin : sorted_bins)
+        {
+          const auto found = counts[i].find(bin.key);
+          const int have = (found == counts[i].end()) ? 0 : found->second;
+          const int need = std::max(0, bin.max_multiplicity - have);
+          for (int k = 0; k < need; ++k)
+          {
+            (*insertions[i])[pos++] = bin.value;
+          }
+        }
+        total_to_insert += need_total;
+      }
+
+      if (total_to_insert > 0)
+      {
+        mesh.KnotInsert(insertions);
+      }
+
+      for (int i = 0; i < nkv; ++i)
+      {
+        delete insertions[i];
       }
     }
 
-    return true;
-  }
+    bool writeMeshPrintFormat(const mfem::Mesh& mesh, const std::string& output_file) const
+    {
+      std::ostringstream oss;
+      oss.precision(16);
+      mesh.Print(oss);
 
-private:
-  double m_tol {1e-12};
-};
+      std::istringstream iss(oss.str());
+      std::ofstream ofs(output_file);
+      if (!ofs.is_open())
+      {
+        return false;
+      }
+      ofs.precision(16);
+
+      // Note: mfem@4.9's mesh reader does not support the "NURBS2" finite element collection,
+      // if it occurs, we replace it with the (essentially equivalent) "NURBS"
+      std::string line;
+      while (std::getline(iss, line))
+      {
+        constexpr const char* prefix = "FiniteElementCollection: NURBS";
+        if (line.rfind(prefix, 0) == 0)
+        {
+          ofs << prefix << '\n';
+        }
+        else
+        {
+          ofs << line << '\n';
+        }
+      }
+
+      return true;
+    }
+
+  private:
+    double m_tol{ 1e-12 };
+  };
 
 }  // namespace
 
@@ -261,30 +263,32 @@ class Input
 {
 public:
   std::string inputFile;
-  std::string outputPrefix = {"winding2d"};
+  std::string outputPrefix = { "winding2d" };
 
-  bool verbose {false};
-  std::string annotationMode {"none"};
-  bool memoized {true};
-  bool vis {true};
-  bool stats {false};
+  bool verbose{ false };
+  std::string annotationMode{ "none" };
+  bool memoized{ true };
+  bool vis{ true };
+  bool stats{ false };
   std::string elevatedMeshFile;
 
-  const std::array<std::string, 2> valid_algorithms {"direct", "fast-approximation"};
-  std::string algorithm {valid_algorithms[1]};  // fast-approximation
+  axom::runtime_policy::Policy policy = RuntimePolicy::seq;
 
-  bool linearize {false};
-  int approximation_order {2};
+  const std::array<std::string, 2> valid_algorithms{ "direct", "fast-approximation" };
+  std::string algorithm{ valid_algorithms[1] };  // fast-approximation
+
+  bool linearize{ false };
+  int approximation_order{ 2 };
 
   bool useUniformLinearization;
-  int segmentsPerKnotSpan {10};
-  double percentError {1.0};
+  int segmentsPerKnotSpan{ 10 };
+  double percentError{ 1.0 };
 
   // Query mesh parameters
   std::vector<double> boxMins;
   std::vector<double> boxMaxs;
   std::vector<int> boxResolution;
-  int queryOrder {1};
+  int queryOrder{ 1 };
 
   primal::WindingTolerances tol;
 
@@ -333,26 +337,36 @@ public:
       ->capture_default_str()
       ->check(axom::utilities::ValidCaliperMode);
 #endif
+    std::stringstream pol_sstr;
+    pol_sstr << "Set MIR runtime policy method.";
+    pol_sstr << "\nSet to 'seq' or 0 to use the RAJA sequential policy.";
+#ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
+    pol_sstr << "\nSet to 'omp' or 1 to use the RAJA OpenMP policy.";
+#endif
+
+    app.add_option("-p, --policy", policy, pol_sstr.str())
+      ->capture_default_str()
+      ->transform(axom::CLI::CheckedTransformer(axom::runtime_policy::s_nameToPolicy));
 
     // Options for triangulation of the input STEP file
     auto* linearize_curves_subcommand =
       app.add_subcommand("linearize_curves")
-        ->description("Options for linearizing NURBS curves. Default is ")
-        ->fallthrough();
+      ->description("Options for linearizing NURBS curves. Default is ")
+      ->fallthrough();
 
     auto* nsegments =
       linearize_curves_subcommand->add_option("--num-segments", segmentsPerKnotSpan)
-        ->description(
-          "Number of segments for each knot span of each input curve for a uniform linearization.")
-        ->check(axom::CLI::PositiveNumber)
-        ->capture_default_str();
+      ->description(
+        "Number of segments for each knot span of each input curve for a uniform linearization.")
+      ->check(axom::CLI::PositiveNumber)
+      ->capture_default_str();
     auto* perror =
       linearize_curves_subcommand->add_option("--percent-error", percentError)
-        ->description(
-          "The percent of error that is acceptable to stop refinement during non-uniform "
-          "linearization.")
-        ->check(axom::CLI::Range(0.0f, 100.0f))
-        ->capture_default_str();
+      ->description(
+        "The percent of error that is acceptable to stop refinement during non-uniform "
+        "linearization.")
+      ->check(axom::CLI::Range(0.0f, 100.0f))
+      ->capture_default_str();
     linearize_curves_subcommand->add_option("--algorithm", algorithm)
       ->description(
         "Use direct evaluation instead of fast, heirarchical approximation? (significantly "
@@ -361,19 +375,19 @@ public:
       ->check(axom::CLI::IsMember(valid_algorithms));
     linearize_curves_subcommand
       ->add_option("--approximation-order",
-                   approximation_order,
-                   "The order of the Taylor expansion (lower is faster, less precise)")
+        approximation_order,
+        "The order of the Taylor expansion (lower is faster, less precise)")
       ->expected(0, 2)
       ->capture_default_str();
 
     auto* query_mesh_subcommand =
       app.add_subcommand("query_mesh")->description("Options for setting up a query mesh")->fallthrough();
     auto* minbb = query_mesh_subcommand->add_option("--min", boxMins)
-                    ->description("Min bounds for box mesh (x,y)")
-                    ->expected(2);
+      ->description("Min bounds for box mesh (x,y)")
+      ->expected(2);
     auto* maxbb = query_mesh_subcommand->add_option("--max", boxMaxs)
-                    ->description("Max bounds for box mesh (x,y)")
-                    ->expected(2);
+      ->description("Max bounds for box mesh (x,y)")
+      ->expected(2);
     query_mesh_subcommand->add_option("--res", boxResolution)
       ->description("Resolution of the box mesh (i,j)")
       ->expected(2)
@@ -397,29 +411,47 @@ public:
 };
 
 using GWNQueryType = std::variant<axom::quest::DirectGWN2D,
-                                  axom::quest::PolylineGWN2D<0>,
-                                  axom::quest::PolylineGWN2D<1>,
-                                  axom::quest::PolylineGWN2D<2>>;
+  axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 0>,
+  axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 1>,
+  axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 2>,
+  axom::quest::PolylineGWN2D<axom::OMP_EXEC, 0>,
+  axom::quest::PolylineGWN2D<axom::OMP_EXEC, 1>,
+  axom::quest::PolylineGWN2D<axom::OMP_EXEC, 2>>;
 
-GWNQueryType make_gwn_query(bool linearize_curves, int approximation_order)
+template <typename ExecSpace>
+GWNQueryType pick_gwn_method(bool linearize_curves, int approximation_order)
 {
-  if(linearize_curves)
+  if (linearize_curves)
   {
-    if(approximation_order == 0)
+    if (approximation_order == 0)
     {
-      return axom::quest::PolylineGWN2D<0> {};
+      return axom::quest::PolylineGWN2D<ExecSpace, 0> {};
     }
-    else if(approximation_order == 1)
+    else if (approximation_order == 1)
     {
-      return axom::quest::PolylineGWN2D<1> {};
+      return axom::quest::PolylineGWN2D<ExecSpace, 1> {};
     }
-    else
+    else  // approximation_order == 2
     {
-      return axom::quest::PolylineGWN2D<2> {};
+      return axom::quest::PolylineGWN2D<ExecSpace, 2> {};
     }
   }
 
-  return axom::quest::DirectGWN2D {};
+  return axom::quest::DirectGWN2D{};
+}
+
+GWNQueryType make_gwn_query(axom::runtime_policy::Policy policy,
+  bool linearize_curves,
+  int approximation_order)
+{
+  if (policy == RuntimePolicy::omp)
+  {
+    SLIC_INFO(axom::fmt::format("Using policy omp with {} threads", omp_get_max_threads()));
+    return pick_gwn_method<axom::OMP_EXEC>(linearize_curves, approximation_order);
+  }
+
+  SLIC_INFO("Using policy seq");
+  return pick_gwn_method<axom::SEQ_EXEC>(linearize_curves, approximation_order);
 }
 
 int main(int argc, char** argv)
@@ -428,15 +460,15 @@ int main(int argc, char** argv)
 
   // Parse command line arguments into input
   Input input;
-  axom::CLI::App app {
+  axom::CLI::App app{
     "Load mesh containing collection of curves"
-    " and optionally generate a query mesh of winding numbers."};
+    " and optionally generate a query mesh of winding numbers." };
 
   try
   {
     input.parse(argc, argv, app);
   }
-  catch(const axom::CLI::ParseError& e)
+  catch (const axom::CLI::ParseError& e)
   {
     return app.exit(e);
   }
@@ -444,7 +476,7 @@ int main(int argc, char** argv)
   axom::utilities::raii::AnnotationsWrapper annotation_raii_wrapper(input.annotationMode);
   AXOM_ANNOTATE_SCOPE("winding number example");
 
-  if(!input.elevatedMeshFile.empty())
+  if (!input.elevatedMeshFile.empty())
   {
     AXOM_ANNOTATE_SCOPE("write_elevated_mesh");
 
@@ -461,7 +493,7 @@ int main(int argc, char** argv)
     mfem_reader.setFileName(input.inputFile);
 
     const int ret = mfem_reader.read(curves);
-    if(ret != axom::quest::MFEMReader::READ_SUCCESS)
+    if (ret != axom::quest::MFEMReader::READ_SUCCESS)
     {
       SLIC_ERROR("Failed to read MFEM file.");
       return 1;
@@ -470,13 +502,13 @@ int main(int argc, char** argv)
 
   // Linearize the input curves if asked for
   axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE> poly_mesh(2, axom::mint::SEGMENT);
-  if(input.linearize)
+  if (input.linearize)
   {
     AXOM_ANNOTATE_SCOPE("linearization");
 
     axom::utilities::Timer timer(true);
     axom::quest::LinearizeCurves lc;
-    if(input.useUniformLinearization)
+    if (input.useUniformLinearization)
     {
       lc.getLinearMeshUniform(curves.view(), &poly_mesh, input.segmentsPerKnotSpan);
     }
@@ -497,14 +529,14 @@ int main(int argc, char** argv)
   }
 
   // Early return if user didn't set up a query mesh
-  if(input.boxResolution.empty())
+  if (input.boxResolution.empty())
   {
     return 0;
   }
 
   // Extract the curves and compute their bounding boxes along the way
   BoundingBox2D shape_bbox;
-  for(const auto& cur : curves)
+  for (const auto& cur : curves)
   {
     shape_bbox.addBox(cur.boundingBox());
   }
@@ -515,25 +547,26 @@ int main(int argc, char** argv)
   mfem::DataCollection dc("winding_query");
   {
     // Create the desired winding number query instance
-    auto wn_query = make_gwn_query(app.got_subcommand("linearize_curves"), input.approximation_order);
+    auto wn_query =
+      make_gwn_query(input.policy, app.got_subcommand("linearize_curves"), input.approximation_order);
 
     // Generate the query grid and fields
     quest::generate_gwn_query_mesh(dc,
-                                   shape_bbox,
-                                   input.boxMins,
-                                   input.boxMaxs,
-                                   input.boxResolution,
-                                   input.queryOrder);
+      shape_bbox,
+      input.boxMins,
+      input.boxMaxs,
+      input.boxResolution,
+      input.queryOrder);
 
     // Run the preprocess
     std::visit(
       [&](auto& wn) {
         using T = std::decay_t<decltype(wn)>;
-        if constexpr(quest::gwn_input_type_v<T> == quest::GWNInputType::Curve)
+        if constexpr (quest::gwn_input_type_v<T> == quest::GWNInputType::Curve)
         {
           wn.preprocess(curves, input.memoized);
         }
-        else if constexpr(quest::gwn_input_type_v<T> == quest::GWNInputType::Polyline)
+        else if constexpr (quest::gwn_input_type_v<T> == quest::GWNInputType::Polyline)
         {
           wn.preprocess(&poly_mesh, input.algorithm == "direct");
         }
@@ -545,7 +578,7 @@ int main(int argc, char** argv)
   }
 
   // Postprocess query results: norms, ranges, and integral statistics
-  if(input.stats)
+  if (input.stats)
   {
     AXOM_ANNOTATE_SCOPE("postprocess");
 
@@ -558,14 +591,14 @@ int main(int argc, char** argv)
 
     std::int64_t pos_inout_dofs = 0;
     std::int64_t neg_inout_dofs = 0;
-    for(int i = 0; i < inout.Size(); ++i)
+    for (int i = 0; i < inout.Size(); ++i)
     {
       const double v = inout[i];
-      if(v > 0.0)
+      if (v > 0.0)
       {
         ++pos_inout_dofs;
       }
-      else if(v < 0.0)
+      else if (v < 0.0)
       {
         ++neg_inout_dofs;
       }
@@ -573,11 +606,11 @@ int main(int argc, char** argv)
 
     SLIC_INFO(
       axom::fmt::format("WN_STATS: dof_l2={:.6e} dof_linf={:.6e} l2={:.6e} min={:.6e} max={:.6e}",
-                        winding_stats.dof_l2,
-                        winding_stats.dof_linf,
-                        winding_stats.l2,
-                        winding_stats.min,
-                        winding_stats.max));
+        winding_stats.dof_l2,
+        winding_stats.dof_linf,
+        winding_stats.l2,
+        winding_stats.min,
+        winding_stats.max));
 
     SLIC_INFO(axom::fmt::format(
       "INOUT_STATS: dof_l2={:.6e} dof_linf={:.6e} l2={:.6e} min={:.6e} max={:.6e} volume={:.6e} "
@@ -590,13 +623,13 @@ int main(int argc, char** argv)
       inout_integrals.integral,
       inout_integrals.domain_volume,
       (inout_integrals.domain_volume > 0.0 ? inout_integrals.integral / inout_integrals.domain_volume
-                                           : 0.0),
+        : 0.0),
       pos_inout_dofs,
       neg_inout_dofs));
   }
 
   // Save the query mesh and fields to disk using a format that can be viewed in VisIt
-  if(input.vis)
+  if (input.vis)
   {
     AXOM_ANNOTATE_SCOPE("dump_mesh");
 
@@ -606,8 +639,8 @@ int main(int argc, char** argv)
     windingDC.Save();
 
     SLIC_INFO(axom::fmt::format("Outputting generated mesh '{}' to '{}'",
-                                windingDC.GetCollectionName(),
-                                axom::utilities::filesystem::getCWD()));
+      windingDC.GetCollectionName(),
+      axom::utilities::filesystem::getCWD()));
   }
 
   return 0;

--- a/src/axom/quest/examples/quest_winding_number_2d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_2d.cpp
@@ -448,11 +448,13 @@ GWNQueryType make_gwn_query(axom::runtime_policy::Policy policy,
   bool linearize_curves,
   int approximation_order)
 {
-  if (policy == RuntimePolicy::omp)
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP)
+  if(policy == RuntimePolicy::omp)
   {
     SLIC_INFO(axom::fmt::format("Using policy omp with {} threads", omp_get_max_threads()));
     return pick_gwn_method<axom::OMP_EXEC>(linearize_curves, approximation_order);
   }
+#endif
 
   SLIC_INFO("Using policy seq");
   return pick_gwn_method<axom::SEQ_EXEC>(linearize_curves, approximation_order);

--- a/src/axom/quest/examples/quest_winding_number_2d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_2d.cpp
@@ -411,13 +411,16 @@ public:
 };
 
 using GWNQueryType = std::variant<axom::quest::DirectGWN2D<axom::SEQ_EXEC>,
-                                  axom::quest::DirectGWN2D<axom::OMP_EXEC>,
                                   axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 0>,
                                   axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 1>,
                                   axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 2>,
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP)
+                                  axom::quest::DirectGWN2D<axom::OMP_EXEC>,
                                   axom::quest::PolylineGWN2D<axom::OMP_EXEC, 0>,
                                   axom::quest::PolylineGWN2D<axom::OMP_EXEC, 1>,
-                                  axom::quest::PolylineGWN2D<axom::OMP_EXEC, 2>>;
+                                  axom::quest::PolylineGWN2D<axom::OMP_EXEC, 2>
+#endif
+                                  >;
 
 template <typename ExecSpace>
 GWNQueryType pick_gwn_method(bool linearize_curves, int approximation_order)

--- a/src/axom/quest/examples/quest_winding_number_2d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_2d.cpp
@@ -338,7 +338,7 @@ public:
       ->check(axom::utilities::ValidCaliperMode);
 #endif
     std::stringstream pol_sstr;
-    pol_sstr << "Set MIR runtime policy method.";
+    pol_sstr << "Set runtime policy method.";
     pol_sstr << "\nSet to 'seq' or 0 to use the RAJA sequential policy.";
 #ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
     pol_sstr << "\nSet to 'omp' or 1 to use the RAJA OpenMP policy.";

--- a/src/axom/quest/examples/quest_winding_number_2d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_2d.cpp
@@ -410,13 +410,14 @@ public:
   }
 };
 
-using GWNQueryType = std::variant<axom::quest::DirectGWN2D,
-  axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 0>,
-  axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 1>,
-  axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 2>,
-  axom::quest::PolylineGWN2D<axom::OMP_EXEC, 0>,
-  axom::quest::PolylineGWN2D<axom::OMP_EXEC, 1>,
-  axom::quest::PolylineGWN2D<axom::OMP_EXEC, 2>>;
+using GWNQueryType = std::variant<axom::quest::DirectGWN2D<axom::SEQ_EXEC>,
+                                  axom::quest::DirectGWN2D<axom::OMP_EXEC>,
+                                  axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 0>,
+                                  axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 1>,
+                                  axom::quest::PolylineGWN2D<axom::SEQ_EXEC, 2>,
+                                  axom::quest::PolylineGWN2D<axom::OMP_EXEC, 0>,
+                                  axom::quest::PolylineGWN2D<axom::OMP_EXEC, 1>,
+                                  axom::quest::PolylineGWN2D<axom::OMP_EXEC, 2>>;
 
 template <typename ExecSpace>
 GWNQueryType pick_gwn_method(bool linearize_curves, int approximation_order)
@@ -437,7 +438,7 @@ GWNQueryType pick_gwn_method(bool linearize_curves, int approximation_order)
     }
   }
 
-  return axom::quest::DirectGWN2D{};
+  return axom::quest::DirectGWN2D<ExecSpace> {};
 }
 
 GWNQueryType make_gwn_query(axom::runtime_policy::Policy policy,

--- a/src/axom/quest/examples/quest_winding_number_2d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_2d.cpp
@@ -46,7 +46,7 @@ using RuntimePolicy = axom::runtime_policy::Policy;
 
 namespace
 {
-  /**
+/**
    * This helper class takes in an mfem mesh (potentially with variable order curves from mfem>4.9)
    * and writes out a version that is compatible with mfem@4.9
    * In particular, this allows us to visualize it with current versions of VisIt which do not yet support this feature.
@@ -54,204 +54,204 @@ namespace
    * We can remove this class once downstream applications (such as VisIt) are updated to a version of mfem
    * that supports the NURBS patches format.
    */
-  class MFEM49ElevatedNURBSMeshWriter
+class MFEM49ElevatedNURBSMeshWriter
+{
+public:
+  explicit MFEM49ElevatedNURBSMeshWriter(double tol = 1e-12) : m_tol(tol) { }
+
+  bool writeElevatedMesh(const std::string& input_file, const std::string& output_file) const
   {
-  public:
-    explicit MFEM49ElevatedNURBSMeshWriter(double tol = 1e-12) : m_tol(tol) {}
+    mfem::Mesh mesh(input_file, /*generate_edges=*/1, /*refine=*/1);
 
-    bool writeElevatedMesh(const std::string& input_file, const std::string& output_file) const
+    if(mesh.NURBSext == nullptr)
     {
-      mfem::Mesh mesh(input_file, /*generate_edges=*/1, /*refine=*/1);
-
-      if (mesh.NURBSext == nullptr)
-      {
-        SLIC_WARNING(
-          axom::fmt::format("Input mesh '{}' has no NURBS extension; skipping degree elevation",
-            input_file));
-        return false;
-      }
-
-      // Note: NURBS curve meshes in mfem@4.9 must all have the same degree, and their knotvectors must have the same length.
-      // MFEM calls this quantity "order"; in Axom terminology this is the polynomial degree.
-      const mfem::Array<int>& orders = mesh.NURBSext->GetOrders();
-      int max_order = 0;
-      for (int i = 0; i < orders.Size(); ++i)
-      {
-        max_order = std::max(max_order, orders[i]);
-      }
-
-      if (max_order <= 0)
-      {
-        SLIC_WARNING(
-          axom::fmt::format("Input mesh '{}' has invalid NURBS orders; skipping degree elevation",
-            input_file));
-        return false;
-      }
-
-      mesh.DegreeElevate(max_order, max_order);
-
-      makeKnotVectorsUniform(mesh);
-
-      // Write the modified mesh to output_file
-      if (!writeMeshPrintFormat(mesh, output_file))
-      {
-        SLIC_WARNING(axom::fmt::format("Failed to write elevated mesh '{}'", output_file));
-        return false;
-      }
-
-      SLIC_INFO(axom::fmt::format("Wrote elevated MFEM 4.9-compatible NURBS mesh '{}' (max order {})",
-        output_file,
-        max_order));
-      return true;
+      SLIC_WARNING(
+        axom::fmt::format("Input mesh '{}' has no NURBS extension; skipping degree elevation",
+                          input_file));
+      return false;
     }
 
-  private:
-    struct KnotBin
+    // Note: NURBS curve meshes in mfem@4.9 must all have the same degree, and their knotvectors must have the same length.
+    // MFEM calls this quantity "order"; in Axom terminology this is the polynomial degree.
+    const mfem::Array<int>& orders = mesh.NURBSext->GetOrders();
+    int max_order = 0;
+    for(int i = 0; i < orders.Size(); ++i)
     {
-      std::int64_t key{ 0 };
-      double value{ 0.0 };
-      int max_multiplicity{ 0 };
+      max_order = std::max(max_order, orders[i]);
+    }
+
+    if(max_order <= 0)
+    {
+      SLIC_WARNING(
+        axom::fmt::format("Input mesh '{}' has invalid NURBS orders; skipping degree elevation",
+                          input_file));
+      return false;
+    }
+
+    mesh.DegreeElevate(max_order, max_order);
+
+    makeKnotVectorsUniform(mesh);
+
+    // Write the modified mesh to output_file
+    if(!writeMeshPrintFormat(mesh, output_file))
+    {
+      SLIC_WARNING(axom::fmt::format("Failed to write elevated mesh '{}'", output_file));
+      return false;
+    }
+
+    SLIC_INFO(axom::fmt::format("Wrote elevated MFEM 4.9-compatible NURBS mesh '{}' (max order {})",
+                                output_file,
+                                max_order));
+    return true;
+  }
+
+private:
+  struct KnotBin
+  {
+    std::int64_t key {0};
+    double value {0.0};
+    int max_multiplicity {0};
+  };
+
+  // MFEM 4.9's 1D NURBS reader assumes all knotvectors have the same GetNE/GetNCP
+  // and uses KnotVec(0) when computing offsets. To generate MFEM 4.9/VisIt
+  // compatible files, insert knots so every knotvector matches the maximum
+  // knot multiplicity pattern present in the mesh.
+  void makeKnotVectorsUniform(mfem::Mesh& mesh) const
+  {
+    if(mesh.NURBSext == nullptr)
+    {
+      return;
+    }
+    if(mesh.Dimension() != 1 || mesh.NURBSext->Dimension() != 1)
+    {
+      return;
+    }
+
+    const int nkv = mesh.NURBSext->GetNKV();
+    if(nkv <= 1)
+    {
+      return;
+    }
+
+    const double inv_tol = (m_tol > 0.0) ? (1.0 / m_tol) : 1.0e12;
+    auto key_for = [inv_tol](double t) -> std::int64_t {
+      return static_cast<std::int64_t>(std::llround(t * inv_tol));
     };
 
-    // MFEM 4.9's 1D NURBS reader assumes all knotvectors have the same GetNE/GetNCP
-    // and uses KnotVec(0) when computing offsets. To generate MFEM 4.9/VisIt
-    // compatible files, insert knots so every knotvector matches the maximum
-    // knot multiplicity pattern present in the mesh.
-    void makeKnotVectorsUniform(mfem::Mesh& mesh) const
+    std::vector<std::unordered_map<std::int64_t, int>> counts(nkv);
+    std::unordered_map<std::int64_t, KnotBin> bins;
+
+    for(int i = 0; i < nkv; ++i)
     {
-      if (mesh.NURBSext == nullptr)
+      const mfem::KnotVector* kv = mesh.NURBSext->GetKnotVector(i);
+      if(kv == nullptr)
       {
-        return;
-      }
-      if (mesh.Dimension() != 1 || mesh.NURBSext->Dimension() != 1)
-      {
-        return;
+        continue;
       }
 
-      const int nkv = mesh.NURBSext->GetNKV();
-      if (nkv <= 1)
+      auto& local = counts[i];
+      for(int j = 0; j < kv->Size(); ++j)
       {
-        return;
-      }
+        const double value = (*kv)[j];
+        const std::int64_t key = key_for(value);
 
-      const double inv_tol = (m_tol > 0.0) ? (1.0 / m_tol) : 1.0e12;
-      auto key_for = [inv_tol](double t) -> std::int64_t {
-        return static_cast<std::int64_t>(std::llround(t * inv_tol));
-        };
-
-      std::vector<std::unordered_map<std::int64_t, int>> counts(nkv);
-      std::unordered_map<std::int64_t, KnotBin> bins;
-
-      for (int i = 0; i < nkv; ++i)
-      {
-        const mfem::KnotVector* kv = mesh.NURBSext->GetKnotVector(i);
-        if (kv == nullptr)
-        {
-          continue;
-        }
-
-        auto& local = counts[i];
-        for (int j = 0; j < kv->Size(); ++j)
-        {
-          const double value = (*kv)[j];
-          const std::int64_t key = key_for(value);
-
-          const int multiplicity = ++local[key];
-          auto& bin = bins[key];
-          bin.key = key;
-          bin.value = value;
-          bin.max_multiplicity = std::max(bin.max_multiplicity, multiplicity);
-        }
-      }
-
-      std::vector<KnotBin> sorted_bins;
-      sorted_bins.reserve(bins.size());
-      for (const auto& it : bins)
-      {
-        sorted_bins.push_back(it.second);
-      }
-      std::sort(sorted_bins.begin(), sorted_bins.end(), [](const KnotBin& a, const KnotBin& b) {
-        if (a.value != b.value)
-        {
-          return a.value < b.value;
-        }
-        return a.key < b.key;
-        });
-
-      int total_to_insert = 0;
-      mfem::Array<mfem::Vector*> insertions(nkv);
-      for (int i = 0; i < nkv; ++i)
-      {
-        int need_total = 0;
-        for (const auto& bin : sorted_bins)
-        {
-          const auto found = counts[i].find(bin.key);
-          const int have = (found == counts[i].end()) ? 0 : found->second;
-          need_total += std::max(0, bin.max_multiplicity - have);
-        }
-
-        insertions[i] = new mfem::Vector(need_total);
-        int pos = 0;
-        for (const auto& bin : sorted_bins)
-        {
-          const auto found = counts[i].find(bin.key);
-          const int have = (found == counts[i].end()) ? 0 : found->second;
-          const int need = std::max(0, bin.max_multiplicity - have);
-          for (int k = 0; k < need; ++k)
-          {
-            (*insertions[i])[pos++] = bin.value;
-          }
-        }
-        total_to_insert += need_total;
-      }
-
-      if (total_to_insert > 0)
-      {
-        mesh.KnotInsert(insertions);
-      }
-
-      for (int i = 0; i < nkv; ++i)
-      {
-        delete insertions[i];
+        const int multiplicity = ++local[key];
+        auto& bin = bins[key];
+        bin.key = key;
+        bin.value = value;
+        bin.max_multiplicity = std::max(bin.max_multiplicity, multiplicity);
       }
     }
 
-    bool writeMeshPrintFormat(const mfem::Mesh& mesh, const std::string& output_file) const
+    std::vector<KnotBin> sorted_bins;
+    sorted_bins.reserve(bins.size());
+    for(const auto& it : bins)
     {
-      std::ostringstream oss;
-      oss.precision(16);
-      mesh.Print(oss);
-
-      std::istringstream iss(oss.str());
-      std::ofstream ofs(output_file);
-      if (!ofs.is_open())
+      sorted_bins.push_back(it.second);
+    }
+    std::sort(sorted_bins.begin(), sorted_bins.end(), [](const KnotBin& a, const KnotBin& b) {
+      if(a.value != b.value)
       {
-        return false;
+        return a.value < b.value;
       }
-      ofs.precision(16);
+      return a.key < b.key;
+    });
 
-      // Note: mfem@4.9's mesh reader does not support the "NURBS2" finite element collection,
-      // if it occurs, we replace it with the (essentially equivalent) "NURBS"
-      std::string line;
-      while (std::getline(iss, line))
+    int total_to_insert = 0;
+    mfem::Array<mfem::Vector*> insertions(nkv);
+    for(int i = 0; i < nkv; ++i)
+    {
+      int need_total = 0;
+      for(const auto& bin : sorted_bins)
       {
-        constexpr const char* prefix = "FiniteElementCollection: NURBS";
-        if (line.rfind(prefix, 0) == 0)
-        {
-          ofs << prefix << '\n';
-        }
-        else
-        {
-          ofs << line << '\n';
-        }
+        const auto found = counts[i].find(bin.key);
+        const int have = (found == counts[i].end()) ? 0 : found->second;
+        need_total += std::max(0, bin.max_multiplicity - have);
       }
 
-      return true;
+      insertions[i] = new mfem::Vector(need_total);
+      int pos = 0;
+      for(const auto& bin : sorted_bins)
+      {
+        const auto found = counts[i].find(bin.key);
+        const int have = (found == counts[i].end()) ? 0 : found->second;
+        const int need = std::max(0, bin.max_multiplicity - have);
+        for(int k = 0; k < need; ++k)
+        {
+          (*insertions[i])[pos++] = bin.value;
+        }
+      }
+      total_to_insert += need_total;
     }
 
-  private:
-    double m_tol{ 1e-12 };
-  };
+    if(total_to_insert > 0)
+    {
+      mesh.KnotInsert(insertions);
+    }
+
+    for(int i = 0; i < nkv; ++i)
+    {
+      delete insertions[i];
+    }
+  }
+
+  bool writeMeshPrintFormat(const mfem::Mesh& mesh, const std::string& output_file) const
+  {
+    std::ostringstream oss;
+    oss.precision(16);
+    mesh.Print(oss);
+
+    std::istringstream iss(oss.str());
+    std::ofstream ofs(output_file);
+    if(!ofs.is_open())
+    {
+      return false;
+    }
+    ofs.precision(16);
+
+    // Note: mfem@4.9's mesh reader does not support the "NURBS2" finite element collection,
+    // if it occurs, we replace it with the (essentially equivalent) "NURBS"
+    std::string line;
+    while(std::getline(iss, line))
+    {
+      constexpr const char* prefix = "FiniteElementCollection: NURBS";
+      if(line.rfind(prefix, 0) == 0)
+      {
+        ofs << prefix << '\n';
+      }
+      else
+      {
+        ofs << line << '\n';
+      }
+    }
+
+    return true;
+  }
+
+private:
+  double m_tol {1e-12};
+};
 
 }  // namespace
 
@@ -263,32 +263,32 @@ class Input
 {
 public:
   std::string inputFile;
-  std::string outputPrefix = { "winding2d" };
+  std::string outputPrefix = {"winding2d"};
 
-  bool verbose{ false };
-  std::string annotationMode{ "none" };
-  bool memoized{ true };
-  bool vis{ true };
-  bool stats{ false };
+  bool verbose {false};
+  std::string annotationMode {"none"};
+  bool memoized {true};
+  bool vis {true};
+  bool stats {false};
   std::string elevatedMeshFile;
 
   axom::runtime_policy::Policy policy = RuntimePolicy::seq;
 
-  const std::array<std::string, 2> valid_algorithms{ "direct", "fast-approximation" };
-  std::string algorithm{ valid_algorithms[1] };  // fast-approximation
+  const std::array<std::string, 2> valid_algorithms {"direct", "fast-approximation"};
+  std::string algorithm {valid_algorithms[1]};  // fast-approximation
 
-  bool linearize{ false };
-  int approximation_order{ 2 };
+  bool linearize {false};
+  int approximation_order {2};
 
   bool useUniformLinearization;
-  int segmentsPerKnotSpan{ 10 };
-  double percentError{ 1.0 };
+  int segmentsPerKnotSpan {10};
+  double percentError {1.0};
 
   // Query mesh parameters
   std::vector<double> boxMins;
   std::vector<double> boxMaxs;
   std::vector<int> boxResolution;
-  int queryOrder{ 1 };
+  int queryOrder {1};
 
   primal::WindingTolerances tol;
 
@@ -351,22 +351,22 @@ public:
     // Options for triangulation of the input STEP file
     auto* linearize_curves_subcommand =
       app.add_subcommand("linearize_curves")
-      ->description("Options for linearizing NURBS curves. Default is ")
-      ->fallthrough();
+        ->description("Options for linearizing NURBS curves. Default is ")
+        ->fallthrough();
 
     auto* nsegments =
       linearize_curves_subcommand->add_option("--num-segments", segmentsPerKnotSpan)
-      ->description(
-        "Number of segments for each knot span of each input curve for a uniform linearization.")
-      ->check(axom::CLI::PositiveNumber)
-      ->capture_default_str();
+        ->description(
+          "Number of segments for each knot span of each input curve for a uniform linearization.")
+        ->check(axom::CLI::PositiveNumber)
+        ->capture_default_str();
     auto* perror =
       linearize_curves_subcommand->add_option("--percent-error", percentError)
-      ->description(
-        "The percent of error that is acceptable to stop refinement during non-uniform "
-        "linearization.")
-      ->check(axom::CLI::Range(0.0f, 100.0f))
-      ->capture_default_str();
+        ->description(
+          "The percent of error that is acceptable to stop refinement during non-uniform "
+          "linearization.")
+        ->check(axom::CLI::Range(0.0f, 100.0f))
+        ->capture_default_str();
     linearize_curves_subcommand->add_option("--algorithm", algorithm)
       ->description(
         "Use direct evaluation instead of fast, heirarchical approximation? (significantly "
@@ -375,19 +375,19 @@ public:
       ->check(axom::CLI::IsMember(valid_algorithms));
     linearize_curves_subcommand
       ->add_option("--approximation-order",
-        approximation_order,
-        "The order of the Taylor expansion (lower is faster, less precise)")
+                   approximation_order,
+                   "The order of the Taylor expansion (lower is faster, less precise)")
       ->expected(0, 2)
       ->capture_default_str();
 
     auto* query_mesh_subcommand =
       app.add_subcommand("query_mesh")->description("Options for setting up a query mesh")->fallthrough();
     auto* minbb = query_mesh_subcommand->add_option("--min", boxMins)
-      ->description("Min bounds for box mesh (x,y)")
-      ->expected(2);
+                    ->description("Min bounds for box mesh (x,y)")
+                    ->expected(2);
     auto* maxbb = query_mesh_subcommand->add_option("--max", boxMaxs)
-      ->description("Max bounds for box mesh (x,y)")
-      ->expected(2);
+                    ->description("Max bounds for box mesh (x,y)")
+                    ->expected(2);
     query_mesh_subcommand->add_option("--res", boxResolution)
       ->description("Resolution of the box mesh (i,j)")
       ->expected(2)
@@ -426,13 +426,13 @@ using GWNQueryType = std::variant<axom::quest::DirectGWN2D<axom::SEQ_EXEC>,
 template <typename ExecSpace>
 GWNQueryType pick_gwn_method(bool linearize_curves, int approximation_order)
 {
-  if (linearize_curves)
+  if(linearize_curves)
   {
-    if (approximation_order == 0)
+    if(approximation_order == 0)
     {
       return axom::quest::PolylineGWN2D<ExecSpace, 0> {};
     }
-    else if (approximation_order == 1)
+    else if(approximation_order == 1)
     {
       return axom::quest::PolylineGWN2D<ExecSpace, 1> {};
     }
@@ -446,8 +446,8 @@ GWNQueryType pick_gwn_method(bool linearize_curves, int approximation_order)
 }
 
 GWNQueryType make_gwn_query(axom::runtime_policy::Policy policy,
-  bool linearize_curves,
-  int approximation_order)
+                            bool linearize_curves,
+                            int approximation_order)
 {
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP)
   if(policy == RuntimePolicy::omp)
@@ -467,15 +467,15 @@ int main(int argc, char** argv)
 
   // Parse command line arguments into input
   Input input;
-  axom::CLI::App app{
+  axom::CLI::App app {
     "Load mesh containing collection of curves"
-    " and optionally generate a query mesh of winding numbers." };
+    " and optionally generate a query mesh of winding numbers."};
 
   try
   {
     input.parse(argc, argv, app);
   }
-  catch (const axom::CLI::ParseError& e)
+  catch(const axom::CLI::ParseError& e)
   {
     return app.exit(e);
   }
@@ -483,7 +483,7 @@ int main(int argc, char** argv)
   axom::utilities::raii::AnnotationsWrapper annotation_raii_wrapper(input.annotationMode);
   AXOM_ANNOTATE_SCOPE("2D winding number example");
 
-  if (!input.elevatedMeshFile.empty())
+  if(!input.elevatedMeshFile.empty())
   {
     AXOM_ANNOTATE_SCOPE("write_elevated_mesh");
 
@@ -500,7 +500,7 @@ int main(int argc, char** argv)
     mfem_reader.setFileName(input.inputFile);
 
     const int ret = mfem_reader.read(curves);
-    if (ret != axom::quest::MFEMReader::READ_SUCCESS)
+    if(ret != axom::quest::MFEMReader::READ_SUCCESS)
     {
       SLIC_ERROR("Failed to read MFEM file.");
       return 1;
@@ -509,13 +509,13 @@ int main(int argc, char** argv)
 
   // Linearize the input curves if asked for
   axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE> poly_mesh(2, axom::mint::SEGMENT);
-  if (input.linearize)
+  if(input.linearize)
   {
     AXOM_ANNOTATE_SCOPE("linearization");
 
     axom::utilities::Timer timer(true);
     axom::quest::LinearizeCurves lc;
-    if (input.useUniformLinearization)
+    if(input.useUniformLinearization)
     {
       lc.getLinearMeshUniform(curves.view(), &poly_mesh, input.segmentsPerKnotSpan);
     }
@@ -536,14 +536,14 @@ int main(int argc, char** argv)
   }
 
   // Early return if user didn't set up a query mesh
-  if (input.boxResolution.empty())
+  if(input.boxResolution.empty())
   {
     return 0;
   }
 
   // Extract the curves and compute their bounding boxes along the way
   BoundingBox2D shape_bbox;
-  for (const auto& cur : curves)
+  for(const auto& cur : curves)
   {
     shape_bbox.addBox(cur.boundingBox());
   }
@@ -559,21 +559,21 @@ int main(int argc, char** argv)
 
     // Generate the query grid and fields
     quest::generate_gwn_query_mesh(dc,
-      shape_bbox,
-      input.boxMins,
-      input.boxMaxs,
-      input.boxResolution,
-      input.queryOrder);
+                                   shape_bbox,
+                                   input.boxMins,
+                                   input.boxMaxs,
+                                   input.boxResolution,
+                                   input.queryOrder);
 
     // Run the preprocess
     std::visit(
       [&](auto& wn) {
         using T = std::decay_t<decltype(wn)>;
-        if constexpr (quest::gwn_input_type_v<T> == quest::GWNInputType::Curve)
+        if constexpr(quest::gwn_input_type_v<T> == quest::GWNInputType::Curve)
         {
           wn.preprocess(curves, input.memoized);
         }
-        else if constexpr (quest::gwn_input_type_v<T> == quest::GWNInputType::Polyline)
+        else if constexpr(quest::gwn_input_type_v<T> == quest::GWNInputType::Polyline)
         {
           wn.preprocess(&poly_mesh, input.algorithm == "direct");
         }
@@ -585,7 +585,7 @@ int main(int argc, char** argv)
   }
 
   // Postprocess query results: norms, ranges, and integral statistics
-  if (input.stats)
+  if(input.stats)
   {
     AXOM_ANNOTATE_SCOPE("postprocess");
 
@@ -598,14 +598,14 @@ int main(int argc, char** argv)
 
     std::int64_t pos_inout_dofs = 0;
     std::int64_t neg_inout_dofs = 0;
-    for (int i = 0; i < inout.Size(); ++i)
+    for(int i = 0; i < inout.Size(); ++i)
     {
       const double v = inout[i];
-      if (v > 0.0)
+      if(v > 0.0)
       {
         ++pos_inout_dofs;
       }
-      else if (v < 0.0)
+      else if(v < 0.0)
       {
         ++neg_inout_dofs;
       }
@@ -613,11 +613,11 @@ int main(int argc, char** argv)
 
     SLIC_INFO(
       axom::fmt::format("WN_STATS: dof_l2={:.6e} dof_linf={:.6e} l2={:.6e} min={:.6e} max={:.6e}",
-        winding_stats.dof_l2,
-        winding_stats.dof_linf,
-        winding_stats.l2,
-        winding_stats.min,
-        winding_stats.max));
+                        winding_stats.dof_l2,
+                        winding_stats.dof_linf,
+                        winding_stats.l2,
+                        winding_stats.min,
+                        winding_stats.max));
 
     SLIC_INFO(axom::fmt::format(
       "INOUT_STATS: dof_l2={:.6e} dof_linf={:.6e} l2={:.6e} min={:.6e} max={:.6e} volume={:.6e} "
@@ -630,13 +630,13 @@ int main(int argc, char** argv)
       inout_integrals.integral,
       inout_integrals.domain_volume,
       (inout_integrals.domain_volume > 0.0 ? inout_integrals.integral / inout_integrals.domain_volume
-        : 0.0),
+                                           : 0.0),
       pos_inout_dofs,
       neg_inout_dofs));
   }
 
   // Save the query mesh and fields to disk using a format that can be viewed in VisIt
-  if (input.vis)
+  if(input.vis)
   {
     AXOM_ANNOTATE_SCOPE("dump_mesh");
 
@@ -646,8 +646,8 @@ int main(int argc, char** argv)
     windingDC.Save();
 
     SLIC_INFO(axom::fmt::format("Outputting generated mesh '{}' to '{}'",
-      windingDC.GetCollectionName(),
-      axom::utilities::filesystem::getCWD()));
+                                windingDC.GetCollectionName(),
+                                axom::utilities::filesystem::getCWD()));
   }
 
   return 0;

--- a/src/axom/quest/examples/quest_winding_number_3d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_3d.cpp
@@ -165,7 +165,7 @@ public:
       ->check(axom::utilities::ValidCaliperMode);
 #endif
     std::stringstream pol_sstr;
-    pol_sstr << "Set MIR runtime policy method.";
+    pol_sstr << "Set runtime policy method.";
     pol_sstr << "\nSet to 'seq' or 0 to use the RAJA sequential policy.";
 #ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
     pol_sstr << "\nSet to 'omp' or 1 to use the RAJA OpenMP policy.";

--- a/src/axom/quest/examples/quest_winding_number_3d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_3d.cpp
@@ -246,13 +246,16 @@ public:
 };
 
 using GWNQueryType = std::variant<axom::quest::DirectGWN3D<axom::SEQ_EXEC>,
-                                  axom::quest::DirectGWN3D<axom::OMP_EXEC>,
                                   axom::quest::TriangleGWN3D<axom::SEQ_EXEC, 0>,
                                   axom::quest::TriangleGWN3D<axom::SEQ_EXEC, 1>,
                                   axom::quest::TriangleGWN3D<axom::SEQ_EXEC, 2>,
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP)
+                                  axom::quest::DirectGWN3D<axom::OMP_EXEC>,
                                   axom::quest::TriangleGWN3D<axom::OMP_EXEC, 0>,
                                   axom::quest::TriangleGWN3D<axom::OMP_EXEC, 1>,
-                                  axom::quest::TriangleGWN3D<axom::OMP_EXEC, 2>>;
+                                  axom::quest::TriangleGWN3D<axom::OMP_EXEC, 2>
+#endif
+                                  >;
 
 template <typename ExecSpace>
 GWNQueryType pick_gwn_method(bool triangulate, int approximation_order)

--- a/src/axom/quest/examples/quest_winding_number_3d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_3d.cpp
@@ -245,7 +245,8 @@ public:
   }
 };
 
-using GWNQueryType = std::variant<axom::quest::DirectGWN3D,
+using GWNQueryType = std::variant<axom::quest::DirectGWN3D<axom::SEQ_EXEC>,
+                                  axom::quest::DirectGWN3D<axom::OMP_EXEC>,
                                   axom::quest::TriangleGWN3D<axom::SEQ_EXEC, 0>,
                                   axom::quest::TriangleGWN3D<axom::SEQ_EXEC, 1>,
                                   axom::quest::TriangleGWN3D<axom::SEQ_EXEC, 2>,
@@ -272,7 +273,7 @@ GWNQueryType pick_gwn_method(bool triangulate, int approximation_order)
     }
   }
 
-  return axom::quest::DirectGWN3D {};
+  return axom::quest::DirectGWN3D<ExecSpace> {};
 }
 
 GWNQueryType make_gwn_query(axom::runtime_policy::Policy policy,
@@ -379,7 +380,7 @@ int main(int argc, char** argv)
     SLIC_INFO(axom::fmt::format(
       axom::utilities::locale(),
       "Loaded {} trimmed NURBS patches (with {} trimming curves) in {:.3Lf} seconds",
-      patches.size(),
+      step_reader.numPatches(),
       num_trimming_curves,
       read_timer.elapsed()));
 

--- a/src/axom/quest/examples/quest_winding_number_3d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_3d.cpp
@@ -40,6 +40,8 @@ using BoundingBox3D = primal::BoundingBox<double, 3>;
 using NURBSPatch3D = quest::STEPReader::NURBSPatch;
 using Triangle3D = primal::Triangle<double, 3>;
 
+using RuntimePolicy = axom::runtime_policy::Policy;
+
 //------------------------------------------------------------------------------
 // CLI input
 //------------------------------------------------------------------------------
@@ -56,6 +58,8 @@ public:
   bool vis {true};
   bool validate {false};
   bool stats {false};
+
+  axom::runtime_policy::Policy policy = RuntimePolicy::seq;
 
   const std::array<std::string, 2> valid_algorithms {"direct", "fast-approximation"};
   std::string algorithm {valid_algorithms[1]};  // fast-approximation
@@ -160,6 +164,16 @@ public:
       ->capture_default_str()
       ->check(axom::utilities::ValidCaliperMode);
 #endif
+    std::stringstream pol_sstr;
+    pol_sstr << "Set MIR runtime policy method.";
+    pol_sstr << "\nSet to 'seq' or 0 to use the RAJA sequential policy.";
+#ifdef AXOM_RUNTIME_POLICY_USE_OPENMP
+    pol_sstr << "\nSet to 'omp' or 1 to use the RAJA OpenMP policy.";
+#endif
+
+    app.add_option("-p, --policy", policy, pol_sstr.str())
+      ->capture_default_str()
+      ->transform(axom::CLI::CheckedTransformer(axom::runtime_policy::s_nameToPolicy));
 
     auto* query_mesh_subcommand =
       app.add_subcommand("query_mesh")->description("Options for setting up a query mesh")->fallthrough();
@@ -232,29 +246,47 @@ public:
 };
 
 using GWNQueryType = std::variant<axom::quest::DirectGWN3D,
-                                  axom::quest::TriangleGWN3D<0>,
-                                  axom::quest::TriangleGWN3D<1>,
-                                  axom::quest::TriangleGWN3D<2>>;
+                                  axom::quest::TriangleGWN3D<axom::SEQ_EXEC, 0>,
+                                  axom::quest::TriangleGWN3D<axom::SEQ_EXEC, 1>,
+                                  axom::quest::TriangleGWN3D<axom::SEQ_EXEC, 2>,
+                                  axom::quest::TriangleGWN3D<axom::OMP_EXEC, 0>,
+                                  axom::quest::TriangleGWN3D<axom::OMP_EXEC, 1>,
+                                  axom::quest::TriangleGWN3D<axom::OMP_EXEC, 2>>;
 
-GWNQueryType make_gwn_query(Input input)
+template <typename ExecSpace>
+GWNQueryType pick_gwn_method(bool triangulate, int approximation_order)
 {
-  if(input.triangulate)
+  if(triangulate)
   {
-    if(input.approximation_order == 0)
+    if(approximation_order == 0)
     {
-      return axom::quest::TriangleGWN3D<0> {};
+      return axom::quest::TriangleGWN3D<ExecSpace, 0> {};
     }
-    else if(input.approximation_order == 1)
+    else if(approximation_order == 1)
     {
-      return axom::quest::TriangleGWN3D<1> {};
+      return axom::quest::TriangleGWN3D<ExecSpace, 1> {};
     }
-    else
+    else  // approximation_order == 2
     {
-      return axom::quest::TriangleGWN3D<2> {};
+      return axom::quest::TriangleGWN3D<ExecSpace, 2> {};
     }
   }
 
   return axom::quest::DirectGWN3D {};
+}
+
+GWNQueryType make_gwn_query(axom::runtime_policy::Policy policy,
+                            bool triangulate,
+                            int approximation_order)
+{
+  if(policy == RuntimePolicy::omp)
+  {
+    SLIC_INFO(axom::fmt::format("Using policy omp with {} threads", omp_get_max_threads()));
+    return pick_gwn_method<axom::OMP_EXEC>(triangulate, approximation_order);
+  }
+
+  SLIC_INFO("Using policy seq");
+  return pick_gwn_method<axom::SEQ_EXEC>(triangulate, approximation_order);
 }
 
 int main(int argc, char** argv)
@@ -398,7 +430,7 @@ int main(int argc, char** argv)
   mfem::DataCollection dc("winding_query");
   {
     // Create the desired winding number query instance
-    auto wn_query = make_gwn_query(input);
+    auto wn_query = make_gwn_query(input.policy, input.triangulate, input.approximation_order);
 
     // Generate the query grid and fields
     quest::generate_gwn_query_mesh(dc,

--- a/src/axom/quest/examples/quest_winding_number_3d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_3d.cpp
@@ -248,8 +248,9 @@ public:
 using GWNQueryType = std::variant<axom::quest::DirectGWN3D<axom::SEQ_EXEC>,
                                   axom::quest::TriangleGWN3D<axom::SEQ_EXEC, 0>,
                                   axom::quest::TriangleGWN3D<axom::SEQ_EXEC, 1>,
-                                  axom::quest::TriangleGWN3D<axom::SEQ_EXEC, 2>,
+                                  axom::quest::TriangleGWN3D<axom::SEQ_EXEC, 2>
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP)
+                                  ,
                                   axom::quest::DirectGWN3D<axom::OMP_EXEC>,
                                   axom::quest::TriangleGWN3D<axom::OMP_EXEC, 0>,
                                   axom::quest::TriangleGWN3D<axom::OMP_EXEC, 1>,

--- a/src/axom/quest/examples/quest_winding_number_3d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_3d.cpp
@@ -283,11 +283,13 @@ GWNQueryType make_gwn_query(axom::runtime_policy::Policy policy,
                             bool triangulate,
                             int approximation_order)
 {
+#if defined(AXOM_USE_RAJA) && defined(AXOM_USE_OPENMP)
   if(policy == RuntimePolicy::omp)
   {
     SLIC_INFO(axom::fmt::format("Using policy omp with {} threads", omp_get_max_threads()));
     return pick_gwn_method<axom::OMP_EXEC>(triangulate, approximation_order);
   }
+#endif
 
   SLIC_INFO("Using policy seq");
   return pick_gwn_method<axom::SEQ_EXEC>(triangulate, approximation_order);

--- a/src/axom/quest/tests/quest_gwn_methods.cpp
+++ b/src/axom/quest/tests/quest_gwn_methods.cpp
@@ -338,12 +338,12 @@ TEST(quest_gwn_methods, mfem_mesh_linearization)
   check_mfem_mesh_linearization<axom::SEQ_EXEC>();
 }
 
-//#ifdef AXOM_USE_OMP
-//TEST(quest_gwn_methods, mfem_mesh_linearization_omp)
-//{
-//  check_mfem_mesh_linearization<axom::OMP_EXEC>();
-//}
-//#endif
+#if defined AXOM_USE_OPENMP && defined(AXOM_USE_RAJA)
+TEST(quest_gwn_methods, mfem_mesh_linearization_omp)
+{
+  check_mfem_mesh_linearization<axom::OMP_EXEC>();
+}
+#endif
 
 #ifdef AXOM_USE_OPENCASCADE
 TEST(quest_gwn_methods, step_file_triangulation)
@@ -352,12 +352,12 @@ TEST(quest_gwn_methods, step_file_triangulation)
 }
 #endif
 
-//#if defined(AXOM_USE_OMP) && defined(AXOM_USE_OPENCASCADE)
-//TEST(quest_gwn_methods, step_file_triangulation_omp)
-//{
-//  check_step_file_triangulation<axom::OMP_EXEC>();
-//}
-//#endif
+#if defined(AXOM_USE_OPENCASCADE) && defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
+TEST(quest_gwn_methods, step_file_triangulation_omp)
+{
+  check_step_file_triangulation<axom::OMP_EXEC>();
+}
+#endif
 
 //------------------------------------------------------------------------------
 int main(int argc, char *argv[])

--- a/src/axom/quest/tests/quest_gwn_methods.cpp
+++ b/src/axom/quest/tests/quest_gwn_methods.cpp
@@ -154,7 +154,8 @@ TEST(quest_gwn_methods, gwn_moment_data_triangle)
 }
 
 //------------------------------------------------------------------------------
-TEST(quest_gwn_methods, mfem_mesh_linearization)
+template <typename ExecSpace>
+void check_mfem_mesh_linearization()
 {
   using NURBSCurve2D = axom::primal::NURBSCurve<double, 2>;
   const std::string fileName = pjoin(AXOM_DATA_DIR, "contours", "svg", "mfem_logo_simp.mesh");
@@ -212,19 +213,19 @@ TEST(quest_gwn_methods, mfem_mesh_linearization)
 
   // Direct
   SLIC_INFO("Testing Direct Evaluation");
-  axom::quest::DirectGWN2D gwn_direct {};
+  axom::quest::DirectGWN2D<ExecSpace> gwn_direct {};
   gwn_direct.preprocess(curves);
   gwn_direct.query(dc[0], tol);
 
   // Linearized
   SLIC_INFO("Testing Direct Evaluation of Triangulation");
-  axom::quest::PolylineGWN2D<0> gwn_polyline {};
+  axom::quest::PolylineGWN2D<ExecSpace, 0> gwn_polyline {};
   gwn_polyline.preprocess(&poly_mesh, useDirectPolyline);
   gwn_polyline.query(dc[1], tol);
 
   // Linearized, fast approximation
   SLIC_INFO("Testing Fast-Approximate Evaluation of Triangulation");
-  axom::quest::PolylineGWN2D<0> gwn_polyline_fast {};
+  axom::quest::PolylineGWN2D<ExecSpace, 0> gwn_polyline_fast {};
   gwn_polyline_fast.preprocess(&poly_mesh, !useDirectPolyline);
   gwn_polyline_fast.query(dc[2], tol);
 
@@ -245,7 +246,8 @@ TEST(quest_gwn_methods, mfem_mesh_linearization)
 
 #ifdef AXOM_USE_OPENCASCADE
 //------------------------------------------------------------------------------
-TEST(quest_gwn_methods, step_file_triangulation)
+template <typename ExecSpace>
+void check_step_file_triangulation()
 {
   const std::string fileName = pjoin(AXOM_DATA_DIR, "quest", "step", "nut.step");
 
@@ -298,19 +300,19 @@ TEST(quest_gwn_methods, step_file_triangulation)
 
   // Direct
   SLIC_INFO("Testing Direct Evaluation");
-  axom::quest::DirectGWN3D gwn_direct {};
+  axom::quest::DirectGWN3D<ExecSpace> gwn_direct {};
   gwn_direct.preprocess(patches);
   gwn_direct.query(dc[0], tol);
 
   // Triangulated
   SLIC_INFO("Testing Direct Evaluation of Polyline");
-  axom::quest::TriangleGWN3D<0> gwn_tri {};
+  axom::quest::TriangleGWN3D<ExecSpace, 0> gwn_tri {};
   gwn_tri.preprocess(&tri_mesh, useDirectTriangle);
   gwn_tri.query(dc[1], tol);
 
   // Triangulated, fast approximation
   SLIC_INFO("Testing Fast-Approximate Evaluation of Polyline");
-  axom::quest::TriangleGWN3D<0> gwn_tri_fast {};
+  axom::quest::TriangleGWN3D<ExecSpace, 0> gwn_tri_fast {};
   gwn_tri_fast.preprocess(&tri_mesh, !useDirectTriangle);
   gwn_tri_fast.query(dc[2], tol);
 
@@ -329,6 +331,33 @@ TEST(quest_gwn_methods, step_file_triangulation)
   }
 }
 #endif
+
+//------------------------------------------------------------------------------
+TEST(quest_gwn_methods, mfem_mesh_linearization)
+{
+  check_mfem_mesh_linearization<axom::SEQ_EXEC>();
+}
+
+//#ifdef AXOM_USE_OMP
+//TEST(quest_gwn_methods, mfem_mesh_linearization_omp)
+//{
+//  check_mfem_mesh_linearization<axom::OMP_EXEC>();
+//}
+//#endif
+
+#ifdef AXOM_USE_OPENCASCADE
+TEST(quest_gwn_methods, step_file_triangulation)
+{
+  check_step_file_triangulation<axom::SEQ_EXEC>();
+}
+#endif
+
+//#if defined(AXOM_USE_OMP) && defined(AXOM_USE_OPENCASCADE)
+//TEST(quest_gwn_methods, step_file_triangulation_omp)
+//{
+//  check_step_file_triangulation<axom::OMP_EXEC>();
+//}
+//#endif
 
 //------------------------------------------------------------------------------
 int main(int argc, char *argv[])


### PR DESCRIPTION
# Summary

This PR adds OMP support for the GWN examples in `quest`, which threading cache creation per surface and GWN evaluation per query. These changes are supported by adding "cache manager" classes to `winding_number_2d/3d_memoization.hpp` which provide a view to GWN caches used in execution, and a mutex in `quadrature.cpp` to ensure thread safety. For OMP examples, a separate cache is allocated for each thread. In the future, it might be worth investigating if there are benefits to collocating/binning the query points used for each thread to improve cache utilization. These changes are tested in `quest_gwn_methods.cpp`.

Many thanks to @BradWhitlock for the initial implementation of these methods, from which this PR is mostly derived. 