### PR TITLE
Add back +mfem to intel spec

### DIFF
--- a/host-configs/dane-toss_4_x86_64_ib-intel-oneapi-compilers@2025.2.0.cmake
+++ b/host-configs/dane-toss_4_x86_64_ib-intel-oneapi-compilers@2025.2.0.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.26.3/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/blt-0.7.1-2n76efajatydczwltuk6plxpgoyvu6jj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/c2c-1.8.0-rl42nhoa33aux3tluna3bftevqokiiqc;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-ti2c3tm4pc6rma2cedok5hy5vnpxmsj7;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/conduit-0.9.5-z4aapemtohmue4rikzbgjhmfyexwuym4;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-jz235wsh3nhxjuzqxse57hcojia7x4mj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/umpire-2025.12.0-2eti2r3wjt4qs772djlcgf6axs44qmko;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/adiak-0.4.0-rgjvxwzjod55ialozetvkjyi3hjczviy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/libunwind-1.8.3-h42c2h7kzkiaeq63dzvt32wlhcqbcrra;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/hdf5-1.8.23-74fr7atqhw4jlzxt22xi5szeqpoxcwkh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/parmetis-4.0.3-g7bp5ds3u3laspneww3scyujjwebgdzh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-2gq3ddrhfxqlgzr6zxbvmwpzvtqxqj25;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/fmt-11.0.2-orofhwltz3p5ckiw2t7gzhkgiifetwjt;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/metis-5.1.0-zschch2gorb5k7t4rmrtc3aubm663i6u;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/none-none/intel-oneapi-runtime-2025.2.0-mfk4ezunnyprzpfps5pncx2nhttsa4z3;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/none-none/gcc-runtime-13.3.1-zsobnkwck2glzcbukupgvgbiwwhdonys;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.26.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/gcc-13.3.1/cppcheck-2.18.0-i3p56kpf66xzj4wm5kfqxyc4vgox7gb3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/doxygen-1.15.0;/usr/tce/backend/installations/linux-rhel8-x86_64/gcc-13.3.1/intel-oneapi-compilers-2025.2.0-ngszoacyp2i5d5nawitlyuh37jswjtie/compiler/2025.2;/usr/tce/packages/intel/intel-2025.2.0;/usr/tce/packages/clang/clang-19.1.3;/usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2025.2.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/blt-0.7.1-2n76efajatydczwltuk6plxpgoyvu6jj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/c2c-1.8.0-rl42nhoa33aux3tluna3bftevqokiiqc;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-ti2c3tm4pc6rma2cedok5hy5vnpxmsj7;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/conduit-0.9.5-x6snw6rzqee7bhmsc6rezi3oobsb6tba;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/mfem-4.9.0-exbr44mwmmbii764bvxrgct2ivffacjh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/gcc-13.3.1/py-nanobind-2.7.0-zg2fpeevizaaykxxnp4butsrujlb54px;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/none-none/py-pytest-9.0.0-vozuj6nkk42nhxeo5mawnux3w7bj3awe;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-jz235wsh3nhxjuzqxse57hcojia7x4mj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/umpire-2025.12.0-2eti2r3wjt4qs772djlcgf6axs44qmko;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/adiak-0.4.0-rgjvxwzjod55ialozetvkjyi3hjczviy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/libunwind-1.8.3-h42c2h7kzkiaeq63dzvt32wlhcqbcrra;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/hdf5-1.8.23-74fr7atqhw4jlzxt22xi5szeqpoxcwkh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/parmetis-4.0.3-g7bp5ds3u3laspneww3scyujjwebgdzh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/gcc-13.3.1/py-numpy-2.4.2-z4yapdkn22w6adfrl7ibucqiokgrwb7f;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/hypre-2.27.0-hgyyzv6j2qosdblkfnupzwgwmujcrtse;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-2gq3ddrhfxqlgzr6zxbvmwpzvtqxqj25;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/fmt-11.0.2-orofhwltz3p5ckiw2t7gzhkgiifetwjt;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/metis-5.1.0-zschch2gorb5k7t4rmrtc3aubm663i6u;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/none-none/intel-oneapi-runtime-2025.2.0-mfk4ezunnyprzpfps5pncx2nhttsa4z3;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/none-none/gcc-runtime-13.3.1-zsobnkwck2glzcbukupgvgbiwwhdonys;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.26.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/gcc-13.3.1/cppcheck-2.18.0-i3p56kpf66xzj4wm5kfqxyc4vgox7gb3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/doxygen-1.15.0;/usr/tce/backend/installations/linux-rhel8-x86_64/gcc-13.3.1/intel-oneapi-compilers-2025.2.0-ngszoacyp2i5d5nawitlyuh37jswjtie/compiler/2025.2;/usr/tce/packages/intel/intel-2025.2.0;/usr/tce/packages/clang/clang-19.1.3;/usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2025.2.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/axom-develop-5onyrt7zct4lirem7z34t2uqdtngl45l/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/axom-develop-5onyrt7zct4lirem7z34t2uqdtngl45l/lib64;;/usr/tce/packages/intel/intel-2025.2.0/compiler/2025.2/lib;/usr/tce/backend/installations/linux-rhel8-x86_64/gcc-13.3.1/intel-oneapi-compilers-2025.2.0-ngszoacyp2i5d5nawitlyuh37jswjtie/compiler/2025.2/lib;/usr/tce/packages/gcc/gcc-13.3.1/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/axom-develop-3l4k45i3jli4otfuyze65smrd7vj43iz/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/axom-develop-3l4k45i3jli4otfuyze65smrd7vj43iz/lib64;;/usr/tce/packages/intel/intel-2025.2.0/compiler/2025.2/lib;/usr/tce/backend/installations/linux-rhel8-x86_64/gcc-13.3.1/intel-oneapi-compilers-2025.2.0-ngszoacyp2i5d5nawitlyuh37jswjtie/compiler/2025.2/lib;/usr/tce/packages/gcc/gcc-13.3.1/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/axom-develop-5onyrt7zct4lirem7z34t2uqdtngl45l/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0/axom-develop-5onyrt7zct4lirem7z34t2uqdtngl45l/lib64;;/usr/tce/packages/intel/intel-2025.2.0/compiler/2025.2/lib;/usr/tce/backend/installations/linux-rhel8-x86_64/gcc-13.3.1/intel-oneapi-compilers-2025.2.0-ngszoacyp2i5d5nawitlyuh37jswjtie/compiler/2025.2/lib;/usr/tce/packages/gcc/gcc-13.3.1/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/axom-develop-3l4k45i3jli4otfuyze65smrd7vj43iz/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0/axom-develop-3l4k45i3jli4otfuyze65smrd7vj43iz/lib64;;/usr/tce/packages/intel/intel-2025.2.0/compiler/2025.2/lib;/usr/tce/backend/installations/linux-rhel8-x86_64/gcc-13.3.1/intel-oneapi-compilers-2025.2.0-ngszoacyp2i5d5nawitlyuh37jswjtie/compiler/2025.2/lib;/usr/tce/packages/gcc/gcc-13.3.1/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -21,11 +21,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q/libexec/spack/oneapi/icx" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q/libexec/spack/oneapi/icx" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q/libexec/spack/oneapi/icpx" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q/libexec/spack/oneapi/icpx" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q/libexec/spack/oneapi/ifx" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q/libexec/spack/oneapi/ifx" CACHE PATH "")
 
 else()
 
@@ -40,6 +40,8 @@ endif()
 set(CMAKE_Fortran_FLAGS "-fPIC" CACHE STRING "")
 
 set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_CXX_FLAGS "-fp-model=precise" CACHE STRING "")
 
 set(CMAKE_CXX_FLAGS_DEBUG "-g -Rno-debug-disables-optimization" CACHE STRING "")
 
@@ -75,13 +77,13 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_11_11_33_13/intel-oneapi-compilers-2025.2.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/intel-oneapi-compilers-2025.2.0" CACHE PATH "")
 
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-z4aapemtohmue4rikzbgjhmfyexwuym4" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-x6snw6rzqee7bhmsc6rezi3oobsb6tba" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-rl42nhoa33aux3tluna3bftevqokiiqc" CACHE PATH "")
 
-# MFEM not built
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-exbr44mwmmbii764bvxrgct2ivffacjh" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-74fr7atqhw4jlzxt22xi5szeqpoxcwkh" CACHE PATH "")
 
@@ -124,5 +126,15 @@ set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/gcc-13.3.1/cppcheck-2.18.0-i3p56kpf66xzj4wm5kfqxyc4vgox7gb3/bin/cppcheck" CACHE PATH "")
 
 set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/._view/kky5oskfhacihjb5gpy7qkeh6edlrtcb/doxygen-1.15.0/bin/doxygen" CACHE PATH "")
+
+set(PY_NANOBIND_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/gcc-13.3.1/py-nanobind-2.7.0-zg2fpeevizaaykxxnp4butsrujlb54px/lib/python3.13/site-packages" CACHE PATH "")
+
+set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/none-none/py-pytest-9.0.0-vozuj6nkk42nhxeo5mawnux3w7bj3awe/lib/python3.13/site-packages" CACHE PATH "")
+
+set(PY_NUMPY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/gcc-13.3.1/py-numpy-2.4.2-z4yapdkn22w6adfrl7ibucqiokgrwb7f/lib/python3.13/site-packages" CACHE PATH "")
+
+set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/none-none/py-pluggy-1.6.0-6zab4pck6v7johubbhalr2waowbwpjei/lib/python3.13/site-packages" CACHE PATH "")
+
+set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_09_14_38/none-none/py-iniconfig-2.1.0-xwmbxuhk2oo3dcuizdp3z4hqbpqykkom/lib/python3.13/site-packages" CACHE PATH "")
 
 

--- a/host-configs/rzwhippet-toss_4_x86_64_ib-intel-oneapi-compilers@2025.2.0.cmake
+++ b/host-configs/rzwhippet-toss_4_x86_64_ib-intel-oneapi-compilers@2025.2.0.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.26.3/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/blt-0.7.1-2n76efajatydczwltuk6plxpgoyvu6jj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/c2c-1.8.0-rl42nhoa33aux3tluna3bftevqokiiqc;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-ti2c3tm4pc6rma2cedok5hy5vnpxmsj7;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/conduit-0.9.5-z4aapemtohmue4rikzbgjhmfyexwuym4;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-jz235wsh3nhxjuzqxse57hcojia7x4mj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/umpire-2025.12.0-2eti2r3wjt4qs772djlcgf6axs44qmko;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/adiak-0.4.0-rgjvxwzjod55ialozetvkjyi3hjczviy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/libunwind-1.8.3-h42c2h7kzkiaeq63dzvt32wlhcqbcrra;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/hdf5-1.8.23-74fr7atqhw4jlzxt22xi5szeqpoxcwkh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/parmetis-4.0.3-g7bp5ds3u3laspneww3scyujjwebgdzh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-2gq3ddrhfxqlgzr6zxbvmwpzvtqxqj25;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/fmt-11.0.2-orofhwltz3p5ckiw2t7gzhkgiifetwjt;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/metis-5.1.0-zschch2gorb5k7t4rmrtc3aubm663i6u;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/none-none/intel-oneapi-runtime-2025.2.0-mfk4ezunnyprzpfps5pncx2nhttsa4z3;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/none-none/gcc-runtime-13.3.1-zsobnkwck2glzcbukupgvgbiwwhdonys;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.26.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/gcc-13.3.1/cppcheck-2.18.0-i3p56kpf66xzj4wm5kfqxyc4vgox7gb3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/doxygen-1.15.0;/usr/tce/backend/installations/linux-rhel8-x86_64/gcc-13.3.1/intel-oneapi-compilers-2025.2.0-ngszoacyp2i5d5nawitlyuh37jswjtie/compiler/2025.2;/usr/tce/packages/intel/intel-2025.2.0;/usr/tce/packages/clang/clang-19.1.3;/usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2025.2.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/blt-0.7.1-2n76efajatydczwltuk6plxpgoyvu6jj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/c2c-1.8.0-rl42nhoa33aux3tluna3bftevqokiiqc;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-ti2c3tm4pc6rma2cedok5hy5vnpxmsj7;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/conduit-0.9.5-x6snw6rzqee7bhmsc6rezi3oobsb6tba;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/mfem-4.9.0-exbr44mwmmbii764bvxrgct2ivffacjh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/gcc-13.3.1/py-nanobind-2.7.0-zg2fpeevizaaykxxnp4butsrujlb54px;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/none-none/py-pytest-9.0.0-vozuj6nkk42nhxeo5mawnux3w7bj3awe;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-jz235wsh3nhxjuzqxse57hcojia7x4mj;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/umpire-2025.12.0-2eti2r3wjt4qs772djlcgf6axs44qmko;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/adiak-0.4.0-rgjvxwzjod55ialozetvkjyi3hjczviy;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/libunwind-1.8.3-h42c2h7kzkiaeq63dzvt32wlhcqbcrra;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/hdf5-1.8.23-74fr7atqhw4jlzxt22xi5szeqpoxcwkh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/parmetis-4.0.3-g7bp5ds3u3laspneww3scyujjwebgdzh;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/gcc-13.3.1/py-numpy-2.4.2-z4yapdkn22w6adfrl7ibucqiokgrwb7f;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/hypre-2.27.0-hgyyzv6j2qosdblkfnupzwgwmujcrtse;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-2gq3ddrhfxqlgzr6zxbvmwpzvtqxqj25;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/fmt-11.0.2-orofhwltz3p5ckiw2t7gzhkgiifetwjt;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/metis-5.1.0-zschch2gorb5k7t4rmrtc3aubm663i6u;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/none-none/intel-oneapi-runtime-2025.2.0-mfk4ezunnyprzpfps5pncx2nhttsa4z3;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/none-none/gcc-runtime-13.3.1-zsobnkwck2glzcbukupgvgbiwwhdonys;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.26.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/gcc-13.3.1/cppcheck-2.18.0-i3p56kpf66xzj4wm5kfqxyc4vgox7gb3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/doxygen-1.15.0;/usr/tce/backend/installations/linux-rhel8-x86_64/gcc-13.3.1/intel-oneapi-compilers-2025.2.0-ngszoacyp2i5d5nawitlyuh37jswjtie/compiler/2025.2;/usr/tce/packages/intel/intel-2025.2.0;/usr/tce/packages/clang/clang-19.1.3;/usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-2025.2.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib/2026_02_17_14_42_14/view/python-3.13.11" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/axom-develop-bj7hmyynlaetqadetbi7owutac5umw3p/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/axom-develop-bj7hmyynlaetqadetbi7owutac5umw3p/lib64;;/usr/tce/packages/intel/intel-2025.2.0/compiler/2025.2/lib;/usr/tce/backend/installations/linux-rhel8-x86_64/gcc-13.3.1/intel-oneapi-compilers-2025.2.0-ngszoacyp2i5d5nawitlyuh37jswjtie/compiler/2025.2/lib;/usr/tce/packages/gcc/gcc-13.3.1/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/axom-develop-3l4k45i3jli4otfuyze65smrd7vj43iz/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/axom-develop-3l4k45i3jli4otfuyze65smrd7vj43iz/lib64;;/usr/tce/packages/intel/intel-2025.2.0/compiler/2025.2/lib;/usr/tce/backend/installations/linux-rhel8-x86_64/gcc-13.3.1/intel-oneapi-compilers-2025.2.0-ngszoacyp2i5d5nawitlyuh37jswjtie/compiler/2025.2/lib;/usr/tce/packages/gcc/gcc-13.3.1/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/axom-develop-bj7hmyynlaetqadetbi7owutac5umw3p/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0/axom-develop-bj7hmyynlaetqadetbi7owutac5umw3p/lib64;;/usr/tce/packages/intel/intel-2025.2.0/compiler/2025.2/lib;/usr/tce/backend/installations/linux-rhel8-x86_64/gcc-13.3.1/intel-oneapi-compilers-2025.2.0-ngszoacyp2i5d5nawitlyuh37jswjtie/compiler/2025.2/lib;/usr/tce/packages/gcc/gcc-13.3.1/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/axom-develop-3l4k45i3jli4otfuyze65smrd7vj43iz/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0/axom-develop-3l4k45i3jli4otfuyze65smrd7vj43iz/lib64;;/usr/tce/packages/intel/intel-2025.2.0/compiler/2025.2/lib;/usr/tce/backend/installations/linux-rhel8-x86_64/gcc-13.3.1/intel-oneapi-compilers-2025.2.0-ngszoacyp2i5d5nawitlyuh37jswjtie/compiler/2025.2/lib;/usr/tce/packages/gcc/gcc-13.3.1/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -21,11 +21,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q/libexec/spack/oneapi/icx" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q/libexec/spack/oneapi/icx" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q/libexec/spack/oneapi/icpx" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q/libexec/spack/oneapi/icpx" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q/libexec/spack/oneapi/ifx" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/none-none/compiler-wrapper-1.0-uesxbqunebynqp5g2i6r3corj4oval5q/libexec/spack/oneapi/ifx" CACHE PATH "")
 
 else()
 
@@ -40,6 +40,8 @@ endif()
 set(CMAKE_Fortran_FLAGS "-fPIC" CACHE STRING "")
 
 set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+set(CMAKE_CXX_FLAGS "-fp-model=precise" CACHE STRING "")
 
 set(CMAKE_CXX_FLAGS_DEBUG "-g -Rno-debug-disables-optimization" CACHE STRING "")
 
@@ -75,13 +77,13 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_03_10_09_31_34/intel-oneapi-compilers-2025.2.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/intel-oneapi-compilers-2025.2.0" CACHE PATH "")
 
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-z4aapemtohmue4rikzbgjhmfyexwuym4" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-x6snw6rzqee7bhmsc6rezi3oobsb6tba" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-rl42nhoa33aux3tluna3bftevqokiiqc" CACHE PATH "")
 
-# MFEM not built
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-exbr44mwmmbii764bvxrgct2ivffacjh" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-74fr7atqhw4jlzxt22xi5szeqpoxcwkh" CACHE PATH "")
 
@@ -124,5 +126,15 @@ set(SHROUD_EXECUTABLE "/collab/usr/gapps/shroud/public/toss_4_x86_64_ib/shroud-0
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/gcc-13.3.1/cppcheck-2.18.0-i3p56kpf66xzj4wm5kfqxyc4vgox7gb3/bin/cppcheck" CACHE PATH "")
 
 set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/._view/kky5oskfhacihjb5gpy7qkeh6edlrtcb/doxygen-1.15.0/bin/doxygen" CACHE PATH "")
+
+set(PY_NANOBIND_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/gcc-13.3.1/py-nanobind-2.7.0-zg2fpeevizaaykxxnp4butsrujlb54px/lib/python3.13/site-packages" CACHE PATH "")
+
+set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/none-none/py-pytest-9.0.0-vozuj6nkk42nhxeo5mawnux3w7bj3awe/lib/python3.13/site-packages" CACHE PATH "")
+
+set(PY_NUMPY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/gcc-13.3.1/py-numpy-2.4.2-z4yapdkn22w6adfrl7ibucqiokgrwb7f/lib/python3.13/site-packages" CACHE PATH "")
+
+set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/none-none/py-pluggy-1.6.0-6zab4pck6v7johubbhalr2waowbwpjei/lib/python3.13/site-packages" CACHE PATH "")
+
+set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib/2026_04_03_07_34_43/none-none/py-iniconfig-2.1.0-xwmbxuhk2oo3dcuizdp3z4hqbpqykkom/lib/python3.13/site-packages" CACHE PATH "")
 
 

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -414,11 +414,14 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
         if spec.satisfies("%cce"):
             entries.append(cmake_cache_string("CMAKE_CXX_FLAGS_DEBUG", "-O1 -g"))
 
-        # Disable intrusive warning:
-        #   icpx: remark: note that use of '-g' without any optimization-level
-        #   option will turn off most compiler optimizations similar to use of
-        #   '-O0'; use '-Rno-debug-disables-optimization' to disable this remark
         if spec.satisfies("%oneapi"):
+            # Addresses floating point issues (default is fast)
+            entries.append(cmake_cache_string("CMAKE_CXX_FLAGS", "-fp-model=precise"))
+
+            # Disable intrusive warning:
+            #   icpx: remark: note that use of '-g' without any optimization-level
+            #   option will turn off most compiler optimizations similar to use of
+            #   '-O0'; use '-Rno-debug-disables-optimization' to disable this remark
             entries.append(cmake_cache_string("CMAKE_CXX_FLAGS_DEBUG", "-g -Rno-debug-disables-optimization"))
 
         return entries

--- a/scripts/spack/specs.json
+++ b/scripts/spack/specs.json
@@ -14,12 +14,11 @@
     "__comment__":"#                                                                             ",
     "__comment__":"##############################################################################",
 
-    "__comment__":"# mfem disabled for intel (icpx compiler error)",
-    "__comment__":"# python disabled for intel (mixed compiler conduit/caliper MPI spack compiler error)",
+    "__comment__":"# For intel compiler, mfem requires given compiler flag and ",
+    "__comment__":"# compiler preferences to prevent compiler mixing",
     "__comment__":"# Configs are for dane/rzwhippet",
-    "__comment__":"# Order matters - if ~python spec is built last this removes view of python",
     "toss_4_x86_64_ib":
-    [ "~python+devtools+hdf5~mfem+c2c+adiak+caliper %intel_25",
+    [ "+python+devtools+hdf5+mfem+c2c+adiak+caliper %%intel_25 ^mfem cxxflags=-fp-speculation=safe %intel_25",
       "+python+devtools+hdf5+mfem+c2c+scr+adiak+caliper %gcc_13",
       "+python+devtools+hdf5+mfem+c2c+scr+adiak+caliper+opencascade %clang_19"],
 

--- a/src/axom/primal/tests/primal_integral.cpp
+++ b/src/axom/primal/tests/primal_integral.cpp
@@ -640,9 +640,11 @@ TEST(primal_integral, check_axom_mfem_quadrature_values)
     for(int j = 0; j < npts; ++j)
     {
       EXPECT_NEAR(axom_rule.node(j), mfem_rule.IntPoint(j).x, axom::numeric_limits<double>::epsilon());
+
+      // Relax tolerance slightly for intel-oneapi
       EXPECT_NEAR(axom_rule.weight(j),
                   mfem_rule.IntPoint(j).weight,
-                  axom::numeric_limits<double>::epsilon());
+                  10 * axom::numeric_limits<double>::epsilon());
     }
   }
 }


### PR DESCRIPTION
This PR:
- Adds mfem back to intel spec, applying fix suggestion from: mfem/mfem#5250
  - Closes #1677 
- Adds `-fp-model=precise` flag to address correctness issue (notably this unit test): https://github.com/llnl/axom/blob/be2a0b41f8d62afe36a37651dccb1f0b7ff7d3e1/src/axom/core/tests/numerics_determinants.hpp#L200

