### PR TITLE
allow sol to compile with C++20

### DIFF
--- a/src/thirdparty/axom/sol.hpp
+++ b/src/thirdparty/axom/sol.hpp
@@ -14425,7 +14425,7 @@ namespace sol {
 	// constexpr is fine for not-clang
 
 	namespace detail {
-		template <typename R, typename... Args, typename F, typename = std::result_of_t<meta::unqualified_t<F>(Args...)>>
+		template <typename R, typename... Args, typename F, typename = std::invoke_result_t<meta::unqualified_t<F>, Args...>>
 		inline constexpr auto resolve_i(types<R(Args...)>, F &&) -> R (meta::unqualified_t<F>::*)(Args...) {
 			using Sig = R(Args...);
 			typedef meta::unqualified_t<F> Fu;
@@ -14449,7 +14449,7 @@ namespace sol {
 			return resolve_f(meta::has_deducible_signature<U>{}, std::forward<F>(f));
 		}
 
-		template <typename... Args, typename F, typename R = std::result_of_t<F&(Args...)>>
+		template <typename... Args, typename F, typename R = std::invoke_result_t<F&, Args...>>
 		inline constexpr auto resolve_i(types<Args...>, F&& f) -> decltype(resolve_i(types<R(Args...)>(), std::forward<F>(f))) {
 			return resolve_i(types<R(Args...)>(), std::forward<F>(f));
 		}
@@ -14495,7 +14495,7 @@ namespace sol {
 	// so don't use the constexpr versions inside of clang.
 
 	namespace detail {
-		template <typename R, typename... Args, typename F, typename = std::result_of_t<meta::unqualified_t<F>(Args...)>>
+		template <typename R, typename... Args, typename F, typename = std::invoke_result_t<meta::unqualified_t<F>, Args...>>
 		inline auto resolve_i(types<R(Args...)>, F &&) -> R (meta::unqualified_t<F>::*)(Args...) {
 			using Sig = R(Args...);
 			typedef meta::unqualified_t<F> Fu;
@@ -14519,7 +14519,7 @@ namespace sol {
 			return resolve_f(meta::has_deducible_signature<U>{}, std::forward<F>(f));
 		}
 
-		template <typename... Args, typename F, typename R = std::result_of_t<F&(Args...)>>
+		template <typename... Args, typename F, typename R = std::invoke_result_t<F&, Args...>>
 		inline auto resolve_i(types<Args...>, F&& f) -> decltype(resolve_i(types<R(Args...)>(), std::forward<F>(f))) {
 			return resolve_i(types<R(Args...)>(), std::forward<F>(f));
 		}
@@ -20652,7 +20652,7 @@ namespace sol {
 		}
 
 	private:
-		template <typename R, typename... Args, typename Fx, typename Key, typename = std::result_of_t<Fx(Args...)>>
+		template <typename R, typename... Args, typename Fx, typename Key, typename = std::invoke_result_t<Fx, Args...>>
 		void set_fx(types<R(Args...)>, Key&& key, Fx&& fx) {
 			set_resolved_function<R(Args...)>(std::forward<Key>(key), std::forward<Fx>(fx));
 		}

--- a/src/thirdparty/axom/sol_invoke_result.patch
+++ b/src/thirdparty/axom/sol_invoke_result.patch
@@ -1,0 +1,49 @@
+diff --git a/src/thirdparty/axom/sol.hpp b/src/thirdparty/axom/sol.hpp
+index 243ed4cf7..df11c0b92 100644
+--- a/src/thirdparty/axom/sol.hpp
++++ b/src/thirdparty/axom/sol.hpp
+@@ -14425,7 +14425,7 @@ namespace sol {
+ 	// constexpr is fine for not-clang
+ 
+ 	namespace detail {
+-		template <typename R, typename... Args, typename F, typename = std::result_of_t<meta::unqualified_t<F>(Args...)>>
++		template <typename R, typename... Args, typename F, typename = std::invoke_result_t<meta::unqualified_t<F>, Args...>>
+ 		inline constexpr auto resolve_i(types<R(Args...)>, F &&) -> R (meta::unqualified_t<F>::*)(Args...) {
+ 			using Sig = R(Args...);
+ 			typedef meta::unqualified_t<F> Fu;
+@@ -14449,7 +14449,7 @@ namespace sol {
+ 			return resolve_f(meta::has_deducible_signature<U>{}, std::forward<F>(f));
+ 		}
+ 
+-		template <typename... Args, typename F, typename R = std::result_of_t<F&(Args...)>>
++		template <typename... Args, typename F, typename R = std::invoke_result_t<F&, Args...>>
+ 		inline constexpr auto resolve_i(types<Args...>, F&& f) -> decltype(resolve_i(types<R(Args...)>(), std::forward<F>(f))) {
+ 			return resolve_i(types<R(Args...)>(), std::forward<F>(f));
+ 		}
+@@ -14495,7 +14495,7 @@ namespace sol {
+ 	// so don't use the constexpr versions inside of clang.
+ 
+ 	namespace detail {
+-		template <typename R, typename... Args, typename F, typename = std::result_of_t<meta::unqualified_t<F>(Args...)>>
++		template <typename R, typename... Args, typename F, typename = std::invoke_result_t<meta::unqualified_t<F>, Args...>>
+ 		inline auto resolve_i(types<R(Args...)>, F &&) -> R (meta::unqualified_t<F>::*)(Args...) {
+ 			using Sig = R(Args...);
+ 			typedef meta::unqualified_t<F> Fu;
+@@ -14519,7 +14519,7 @@ namespace sol {
+ 			return resolve_f(meta::has_deducible_signature<U>{}, std::forward<F>(f));
+ 		}
+ 
+-		template <typename... Args, typename F, typename R = std::result_of_t<F&(Args...)>>
++		template <typename... Args, typename F, typename R = std::invoke_result_t<F&, Args...>>
+ 		inline auto resolve_i(types<Args...>, F&& f) -> decltype(resolve_i(types<R(Args...)>(), std::forward<F>(f))) {
+ 			return resolve_i(types<R(Args...)>(), std::forward<F>(f));
+ 		}
+@@ -20652,7 +20652,7 @@ namespace sol {
+ 		}
+ 
+ 	private:
+-		template <typename R, typename... Args, typename Fx, typename Key, typename = std::result_of_t<Fx(Args...)>>
++		template <typename R, typename... Args, typename Fx, typename Key, typename = std::invoke_result_t<Fx, Args...>>
+ 		void set_fx(types<R(Args...)>, Key&& key, Fx&& fx) {
+ 			set_resolved_function<R(Args...)>(std::forward<Key>(key), std::forward<Fx>(fx));
+ 		}


### PR DESCRIPTION
Fixes a C++20 compilation found in the Smith project on macos.

```
In file included from smith/axom/src/axom/inlet/LuaReader.cpp:25:
smith/axom/src/thirdparty/axom/sol.hpp:14498:71: error: no template named 'result_of_t' in namespace 'std'
 14498 |                 template <typename R, typename... Args, typename F, typename = std::result_of_t<meta::unqualified_t<F>(Args...)>>
       |                                                                                ~~~~~^
smith/axom/src/thirdparty/axom/sol.hpp:14522:61: error: no template named 'result_of_t' in namespace 'std'
 14522 |                 template <typename... Args, typename F, typename R = std::result_of_t<F&(Args...)>>
       |                                                                      ~~~~~^
smith/axom/src/thirdparty/axom/sol.hpp:20655:86: error: no template named 'result_of_t' in namespace 'std'
 20655 |                 template <typename R, typename... Args, typename Fx, typename Key, typename = std::result_of_t<Fx(Args...)>>
       |                                                                                               ~~~~~^
3 errors generated.
```

@btalamini