### PR TITLE
Axom with openmp and rocm

### DIFF
--- a/.gitlab/build_tuolumne.yml
+++ b/.gitlab/build_tuolumne.yml
@@ -36,10 +36,12 @@
 
 ####
 # PR Build jobs
+# Disable OpenMP to avoid timeout
 tuolumne-llvm-amdgpu_6_4_3_hip-src:
   variables:
     COMPILER: "llvm-amdgpu@6.4.3_hip"
     HOST_CONFIG: "tuolumne-toss_4_x86_64_ib_cray-${COMPILER}.cmake"
+    EXTRA_CMAKE_OPTIONS: "-DENABLE_OPENMP:BOOL=OFF"
   extends: .src_build_on_tuolumne
 
 ####

--- a/host-configs/rzadams-toss_4_x86_64_ib_cray-cce@20.0.0_hip.cmake
+++ b/host-configs/rzadams-toss_4_x86_64_ib_cray-cce@20.0.0_hip.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/blt-0.7.1-af45hpsxdxploxhqqi4irjmy4vz2omqx;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/c2c-1.8.0-cpdkv2uxkhs3qmzqakt4sht3vuiucdwt;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-wytd46zvuquxg2rqf3zec5ldbmjeaat6;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/conduit-0.9.5-pbrrhvrsmnewby6q3u35ceppt5fxme2p;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/lua-5.4.8-y6z3polqakbuhn6nh6muri3rjxqmiioa;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/mfem-4.9.0-2r7wws3ojiqvv6vk7y3ki443xke656sf;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/py-nanobind-2.7.0-ieb2bzuz435ydpyiq2uj36yyqjbrffml;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/adiak-0.4.0-lzgexbo5qyzepgju2acyy6d2qft443tb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/libunwind-1.8.3-zvteigxlopfo5tkdr2n2pglgosg42bah;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/hdf5-1.8.23-to3lvqwzxrqzad65zbvnbtvyt4k63uxe;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/parmetis-4.0.3-bajtzsmahjg2wvcjzo5gfb2hr5oj2elc;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/py-numpy-2.4.2-xw5ysy75zfqlalmbmtl5phd2qip43hlo;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/hypre-2.27.0-knkmxfbf3xcut2wmamjsmhrqf7u7xmi7;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-y7uevzr5oi5eansgqfm4ppgcdkvnni6t;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/umpire-2025.12.0-ke2uxlxkv74lvrhujuzh3ktf3c6e7lfb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/zlib-1.3.1-f3sdiqmy2whvmdn2fxeol3k7oqwouays;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/metis-5.1.0-v4d34x7btqhotktvu5bgk4iwk6h2lumb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-a755kudv24eiizq4thcs2ca2fj7vy65x;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/fmt-11.0.2-nzzmwf4nofjv46yeugehjo64opvfbbzr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cce-tce/cce-20.0.0;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.32-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/blt-0.7.1-af45hpsxdxploxhqqi4irjmy4vz2omqx;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/c2c-1.8.0-cpdkv2uxkhs3qmzqakt4sht3vuiucdwt;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-wytd46zvuquxg2rqf3zec5ldbmjeaat6;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/conduit-0.9.5-pbrrhvrsmnewby6q3u35ceppt5fxme2p;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/lua-5.4.8-y6z3polqakbuhn6nh6muri3rjxqmiioa;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/mfem-4.9.0-wpbbiugqvdw7bylkmyyf2quazcoptzah;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/py-nanobind-2.7.0-ieb2bzuz435ydpyiq2uj36yyqjbrffml;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/adiak-0.4.0-lzgexbo5qyzepgju2acyy6d2qft443tb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/libunwind-1.8.3-zvteigxlopfo5tkdr2n2pglgosg42bah;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/hdf5-1.8.23-to3lvqwzxrqzad65zbvnbtvyt4k63uxe;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/parmetis-4.0.3-bajtzsmahjg2wvcjzo5gfb2hr5oj2elc;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/py-numpy-2.4.2-xw5ysy75zfqlalmbmtl5phd2qip43hlo;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/hypre-2.27.0-knkmxfbf3xcut2wmamjsmhrqf7u7xmi7;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-z3eibnxgk3jeplydlcizrhurpibzqzqv;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/umpire-2025.12.0-eqokbtuch3pwifb225w2i3rrft5ddcgv;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/zlib-1.3.1-f3sdiqmy2whvmdn2fxeol3k7oqwouays;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/metis-5.1.0-v4d34x7btqhotktvu5bgk4iwk6h2lumb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-eplsxvli6nnrgdl4l3hl7cizytginfhp;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/fmt-11.0.2-nzzmwf4nofjv46yeugehjo64opvfbbzr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cce-tce/cce-20.0.0;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.32-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/axom-develop-csdbligyshk6zb3emr4vn5sjrrnbtobj/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/axom-develop-csdbligyshk6zb3emr4vn5sjrrnbtobj/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/axom-develop-xz7g7s5cdkdr6lixuhs23vyuqqodocrg/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/axom-develop-xz7g7s5cdkdr6lixuhs23vyuqqodocrg/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/axom-develop-csdbligyshk6zb3emr4vn5sjrrnbtobj/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0/axom-develop-csdbligyshk6zb3emr4vn5sjrrnbtobj/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/axom-develop-xz7g7s5cdkdr6lixuhs23vyuqqodocrg/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0/axom-develop-xz7g7s5cdkdr6lixuhs23vyuqqodocrg/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -21,11 +21,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/cce/craycc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/cce/craycc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/cce/case-insensitive/crayCC" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/cce/case-insensitive/crayCC" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/cce/crayftn" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/cce/crayftn" CACHE PATH "")
 
 else()
 
@@ -84,37 +84,41 @@ set(ENABLE_HIP ON CACHE BOOL "")
 
 set(ROCM_ROOT_DIR "/opt/rocm-6.4.3" CACHE PATH "")
 
-set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "unwind" CACHE STRING "")
+set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "unwind;ompstub" CACHE STRING "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.32/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.32/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -lompstub -L/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -Wl,-rpath,/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.32/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.32/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -L/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -Wl,-rpath,/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
 #------------------------------------------------
 
-set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(BLT_OPENMP_COMPILE_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-fopenmp>" CACHE STRING "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)")
+
+set(BLT_OPENMP_LINK_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-fopenmp>" CACHE STRING "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)")
 
 #------------------------------------------------------------------------------
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/cce-20.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/cce-20.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-pbrrhvrsmnewby6q3u35ceppt5fxme2p" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-cpdkv2uxkhs3qmzqakt4sht3vuiucdwt" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-2r7wws3ojiqvv6vk7y3ki443xke656sf" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-wpbbiugqvdw7bylkmyyf2quazcoptzah" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-to3lvqwzxrqzad65zbvnbtvyt4k63uxe" CACHE PATH "")
 
 set(LUA_DIR "${TPL_ROOT}/lua-5.4.8-y6z3polqakbuhn6nh6muri3rjxqmiioa" CACHE PATH "")
 
-set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-y7uevzr5oi5eansgqfm4ppgcdkvnni6t" CACHE PATH "")
+set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-z3eibnxgk3jeplydlcizrhurpibzqzqv" CACHE PATH "")
 
-set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-ke2uxlxkv74lvrhujuzh3ktf3c6e7lfb" CACHE PATH "")
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-eqokbtuch3pwifb225w2i3rrft5ddcgv" CACHE PATH "")
 
 # OPENCASCADE not built
 
@@ -122,7 +126,7 @@ set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-lzgexbo5qyzepgju2acyy6d2qft443tb" CACHE P
 
 set(CALIPER_DIR "${TPL_ROOT}/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-wytd46zvuquxg2rqf3zec5ldbmjeaat6" CACHE PATH "")
 
-set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-a755kudv24eiizq4thcs2ca2fj7vy65x" CACHE PATH "")
+set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-eplsxvli6nnrgdl4l3hl7cizytginfhp" CACHE PATH "")
 
 # scr not built
 
@@ -152,12 +156,12 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/._view/ywmag65dnysd7p4dhlmcoaaqqxfzgz5a
 
 set(PY_NANOBIND_DIR "${TPL_ROOT}/py-nanobind-2.7.0-ieb2bzuz435ydpyiq2uj36yyqjbrffml/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5/lib/python3.13/site-packages" CACHE PATH "")
 
 set(PY_NUMPY_DIR "${TPL_ROOT}/py-numpy-2.4.2-xw5ysy75zfqlalmbmtl5phd2qip43hlo/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/py-pluggy-1.6.0-n4ojmtqyawxz6gipk64pup3ahwz3xqpu/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/py-pluggy-1.6.0-n4ojmtqyawxz6gipk64pup3ahwz3xqpu/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/py-iniconfig-2.1.0-lf3yvch65se22jr7b5unfoxtse4ugkrk/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/py-iniconfig-2.1.0-lf3yvch65se22jr7b5unfoxtse4ugkrk/lib/python3.13/site-packages" CACHE PATH "")
 
 

--- a/host-configs/rzadams-toss_4_x86_64_ib_cray-llvm-amdgpu@6.3.1_hip.cmake
+++ b/host-configs/rzadams-toss_4_x86_64_ib_cray-llvm-amdgpu@6.3.1_hip.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/adiak-0.4.0-c4srnrz5apjetx74dt6xjah63o3a7xcx;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/blt-0.7.1-kzmxfjvxm4drr2qhspckvwee6mrlc3e5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/c2c-1.8.0-lm64gc55hpxilmtsw7geirys3q4wacu5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/conduit-0.9.5-wswspowegvp5byl5inc2cikljzkcqg64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/lua-5.4.8-j7ngytniswhoa536kqfzarcraarkicbm;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/mfem-4.9.0-wetr3wqseqqobjb7be3uzrecpfewq4mr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/py-nanobind-2.7.0-q2kwozph3gwgfyjnx43jp2gkbaghwxoj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/hdf5-1.8.23-rb4cjthx4wz4wnpaizwmm2jycijdthqm;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/parmetis-4.0.3-ng66tt5fmjyfoiuuxyl4rxqv4ompawmd;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/py-numpy-2.4.2-zcxbrxijjc3miotq6s3kq446afrgycuu;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/hypre-2.27.0-6m2jwyzqbksxgmdznvh54ytysxyme7jy;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-okzhosj73rts33dgatxh4daotairh5jn;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/umpire-2025.12.0-of6o5lgmd6jgjqfwat2sbyngieagkeco;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/zlib-1.3.1-5w5muvpvct6uruxrddscblsiyizl3uoc;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/metis-5.1.0-4punmdkye6rovr3u7ph7bgj66qim77du;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-74scmbkik6ye7bunoclw46d6zrcfwgha;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/fmt-11.0.2-opsfnufdiedpfpob5wgbvhcrhyhzfkaq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/opt/rocm-6.3.1" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/adiak-0.4.0-c4srnrz5apjetx74dt6xjah63o3a7xcx;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/blt-0.7.1-kzmxfjvxm4drr2qhspckvwee6mrlc3e5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/c2c-1.8.0-lm64gc55hpxilmtsw7geirys3q4wacu5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/conduit-0.9.5-wswspowegvp5byl5inc2cikljzkcqg64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/lua-5.4.8-j7ngytniswhoa536kqfzarcraarkicbm;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/mfem-4.9.0-xwg5un3mlbeog3j4voeltekra43ix3ga;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/py-nanobind-2.7.0-q2kwozph3gwgfyjnx43jp2gkbaghwxoj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/hdf5-1.8.23-rb4cjthx4wz4wnpaizwmm2jycijdthqm;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/parmetis-4.0.3-ng66tt5fmjyfoiuuxyl4rxqv4ompawmd;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/py-numpy-2.4.2-zcxbrxijjc3miotq6s3kq446afrgycuu;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/hypre-2.27.0-6m2jwyzqbksxgmdznvh54ytysxyme7jy;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-wcyqyggju4u2ornjjnamgdgfbqjrzsir;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/umpire-2025.12.0-5w5v22edixuttxwueaagiobpjzn5mcgr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/zlib-1.3.1-5w5muvpvct6uruxrddscblsiyizl3uoc;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/metis-5.1.0-4punmdkye6rovr3u7ph7bgj66qim77du;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-jnalmgzqx2nn2afq4gwhyjda3u6yub7y;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/fmt-11.0.2-opsfnufdiedpfpob5wgbvhcrhyhzfkaq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/opt/rocm-6.3.1" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/axom-develop-xoswouqk3ppxzuxtgegijd3kdoqlkvfe/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/axom-develop-xoswouqk3ppxzuxtgegijd3kdoqlkvfe/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/axom-develop-qrojk4ujrhd5b734s2yc73n5u3kvcgqa/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/axom-develop-qrojk4ujrhd5b734s2yc73n5u3kvcgqa/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/axom-develop-xoswouqk3ppxzuxtgegijd3kdoqlkvfe/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1/axom-develop-xoswouqk3ppxzuxtgegijd3kdoqlkvfe/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/axom-develop-qrojk4ujrhd5b734s2yc73n5u3kvcgqa/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1/axom-develop-qrojk4ujrhd5b734s2yc73n5u3kvcgqa/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -21,11 +21,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdflang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdflang" CACHE PATH "")
 
 else()
 
@@ -82,13 +82,15 @@ set(ENABLE_HIP ON CACHE BOOL "")
 
 set(ROCM_ROOT_DIR "/opt/rocm-6.3.1" CACHE PATH "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.3.1/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.3.1/lib/llvm/lib -L/opt/rocm-6.3.1/lib -Wl,-rpath,/opt/rocm-6.3.1/lib -lpgmath -lompstub -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "ompstub" CACHE STRING "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.3.1/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.3.1/lib/llvm/lib -L/opt/rocm-6.3.1/lib -Wl,-rpath,/opt/rocm-6.3.1/lib -lpgmath -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
 #------------------------------------------------
 
-set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
@@ -96,21 +98,21 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.3.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-wswspowegvp5byl5inc2cikljzkcqg64" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-lm64gc55hpxilmtsw7geirys3q4wacu5" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-wetr3wqseqqobjb7be3uzrecpfewq4mr" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-xwg5un3mlbeog3j4voeltekra43ix3ga" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-rb4cjthx4wz4wnpaizwmm2jycijdthqm" CACHE PATH "")
 
 set(LUA_DIR "${TPL_ROOT}/lua-5.4.8-j7ngytniswhoa536kqfzarcraarkicbm" CACHE PATH "")
 
-set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-okzhosj73rts33dgatxh4daotairh5jn" CACHE PATH "")
+set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-wcyqyggju4u2ornjjnamgdgfbqjrzsir" CACHE PATH "")
 
-set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-of6o5lgmd6jgjqfwat2sbyngieagkeco" CACHE PATH "")
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-5w5v22edixuttxwueaagiobpjzn5mcgr" CACHE PATH "")
 
 # OPENCASCADE not built
 
@@ -118,7 +120,7 @@ set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-c4srnrz5apjetx74dt6xjah63o3a7xcx" CACHE P
 
 # CALIPER not built
 
-set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-74scmbkik6ye7bunoclw46d6zrcfwgha" CACHE PATH "")
+set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-jnalmgzqx2nn2afq4gwhyjda3u6yub7y" CACHE PATH "")
 
 # scr not built
 
@@ -148,12 +150,12 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/._view/ywmag65dnysd7p4dhlmcoaaqqxfzgz5a
 
 set(PY_NANOBIND_DIR "${TPL_ROOT}/py-nanobind-2.7.0-q2kwozph3gwgfyjnx43jp2gkbaghwxoj/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5/lib/python3.13/site-packages" CACHE PATH "")
 
 set(PY_NUMPY_DIR "${TPL_ROOT}/py-numpy-2.4.2-zcxbrxijjc3miotq6s3kq446afrgycuu/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/py-pluggy-1.6.0-n4ojmtqyawxz6gipk64pup3ahwz3xqpu/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/py-pluggy-1.6.0-n4ojmtqyawxz6gipk64pup3ahwz3xqpu/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/py-iniconfig-2.1.0-lf3yvch65se22jr7b5unfoxtse4ugkrk/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/py-iniconfig-2.1.0-lf3yvch65se22jr7b5unfoxtse4ugkrk/lib/python3.13/site-packages" CACHE PATH "")
 
 

--- a/host-configs/rzadams-toss_4_x86_64_ib_cray-llvm-amdgpu@6.4.3_hip.cmake
+++ b/host-configs/rzadams-toss_4_x86_64_ib_cray-llvm-amdgpu@6.4.3_hip.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/blt-0.7.1-4kxhk7nbuiv5oh2ymh7sdimnmor36hmo;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/c2c-1.8.0-h5kio7nseyazg4pzgvj4kxanb3plhbxm;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-rmlwpdacdtpzf4u72ctyroj72soqzf3f;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/conduit-0.9.5-zqywrasos2vbears5hvdwxhulm3xox6q;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/lua-5.4.8-gp4kdewsy4uiy6flsx342lgogcm7fym2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/mfem-4.9.0-g6vxdlgc7spurcdacgc6e5245iu2hyiw;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/py-nanobind-2.7.0-2kp35jcpb73xuujvcz6kmg4q2npek4gg;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/adiak-0.4.0-cropyu42jr4q6k3zar6mkma6gc2vp6tk;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/libunwind-1.8.3-plszp43gkd75kzjcvge3qxrtb6j2budl;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/hdf5-1.8.23-mgic2kxojd5zeivhaz473zzmzrg3gdqe;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/parmetis-4.0.3-hd2qoczrh3vw3ejm6msitqdgecjk7xwe;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/py-numpy-2.4.2-a3mo27shjtpliwewbm5cci2kf37crrab;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/hypre-2.27.0-4nrl5egspbxmnkpzfym5udby6uruhn3i;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-wavyomm5hzyjf3xuyr33txmnspvxveei;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/umpire-2025.12.0-4oytcvf556ksil4hsthjt4b5y4wdpaxw;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/zlib-1.3.1-slqujeue3l44x3pgqbu7e2pw3lh2mj5i;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/metis-5.1.0-puzeddu6ufhz5vpxnw7i3i2i6slsvuuj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-3gtldngru7bva2reuel5iabyytw5fmdf;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/fmt-11.0.2-lpnox72rqcneew5hucwzq4nmms4at525;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/blt-0.7.1-4kxhk7nbuiv5oh2ymh7sdimnmor36hmo;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/c2c-1.8.0-h5kio7nseyazg4pzgvj4kxanb3plhbxm;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-rmlwpdacdtpzf4u72ctyroj72soqzf3f;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/conduit-0.9.5-zqywrasos2vbears5hvdwxhulm3xox6q;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/lua-5.4.8-gp4kdewsy4uiy6flsx342lgogcm7fym2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/mfem-4.9.0-6cgokeizyrjzsjzwmtf35p5jvhnws7n5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/py-nanobind-2.7.0-2kp35jcpb73xuujvcz6kmg4q2npek4gg;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/adiak-0.4.0-cropyu42jr4q6k3zar6mkma6gc2vp6tk;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/libunwind-1.8.3-plszp43gkd75kzjcvge3qxrtb6j2budl;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/hdf5-1.8.23-mgic2kxojd5zeivhaz473zzmzrg3gdqe;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/parmetis-4.0.3-hd2qoczrh3vw3ejm6msitqdgecjk7xwe;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/py-numpy-2.4.2-a3mo27shjtpliwewbm5cci2kf37crrab;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/hypre-2.27.0-4nrl5egspbxmnkpzfym5udby6uruhn3i;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-v74yskgcb7tsgho6bdush5jdlbigkttf;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/umpire-2025.12.0-jft5rocv5ev4b57f3664b2kagyfjra2e;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/zlib-1.3.1-slqujeue3l44x3pgqbu7e2pw3lh2mj5i;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/metis-5.1.0-puzeddu6ufhz5vpxnw7i3i2i6slsvuuj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-zadbjpethvnlhpqwx6vm6ahphk42a4gq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/fmt-11.0.2-lpnox72rqcneew5hucwzq4nmms4at525;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/axom-develop-cdngjuz7ffr3goroyietece35jivxnkv/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/axom-develop-cdngjuz7ffr3goroyietece35jivxnkv/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/axom-develop-i4n5ay2l5l2hludfn6z5vyvfwk57p6hx/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/axom-develop-i4n5ay2l5l2hludfn6z5vyvfwk57p6hx/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/axom-develop-cdngjuz7ffr3goroyietece35jivxnkv/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3/axom-develop-cdngjuz7ffr3goroyietece35jivxnkv/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/axom-develop-i4n5ay2l5l2hludfn6z5vyvfwk57p6hx/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3/axom-develop-i4n5ay2l5l2hludfn6z5vyvfwk57p6hx/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -21,11 +21,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdflang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdflang" CACHE PATH "")
 
 else()
 
@@ -82,13 +82,15 @@ set(ENABLE_HIP ON CACHE BOOL "")
 
 set(ROCM_ROOT_DIR "/opt/rocm-6.4.3" CACHE PATH "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -lompstub -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "ompstub" CACHE STRING "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
 #------------------------------------------------
 
-set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
@@ -96,21 +98,21 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/llvm-amdgpu-6.4.3" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/llvm-amdgpu-6.4.3" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-zqywrasos2vbears5hvdwxhulm3xox6q" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-h5kio7nseyazg4pzgvj4kxanb3plhbxm" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-g6vxdlgc7spurcdacgc6e5245iu2hyiw" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-6cgokeizyrjzsjzwmtf35p5jvhnws7n5" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-mgic2kxojd5zeivhaz473zzmzrg3gdqe" CACHE PATH "")
 
 set(LUA_DIR "${TPL_ROOT}/lua-5.4.8-gp4kdewsy4uiy6flsx342lgogcm7fym2" CACHE PATH "")
 
-set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-wavyomm5hzyjf3xuyr33txmnspvxveei" CACHE PATH "")
+set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-v74yskgcb7tsgho6bdush5jdlbigkttf" CACHE PATH "")
 
-set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-4oytcvf556ksil4hsthjt4b5y4wdpaxw" CACHE PATH "")
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-jft5rocv5ev4b57f3664b2kagyfjra2e" CACHE PATH "")
 
 # OPENCASCADE not built
 
@@ -118,7 +120,7 @@ set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-cropyu42jr4q6k3zar6mkma6gc2vp6tk" CACHE P
 
 set(CALIPER_DIR "${TPL_ROOT}/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-rmlwpdacdtpzf4u72ctyroj72soqzf3f" CACHE PATH "")
 
-set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-3gtldngru7bva2reuel5iabyytw5fmdf" CACHE PATH "")
+set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-zadbjpethvnlhpqwx6vm6ahphk42a4gq" CACHE PATH "")
 
 # scr not built
 
@@ -148,12 +150,12 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/._view/ywmag65dnysd7p4dhlmcoaaqqxfzgz5a
 
 set(PY_NANOBIND_DIR "${TPL_ROOT}/py-nanobind-2.7.0-2kp35jcpb73xuujvcz6kmg4q2npek4gg/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5/lib/python3.13/site-packages" CACHE PATH "")
 
 set(PY_NUMPY_DIR "${TPL_ROOT}/py-numpy-2.4.2-a3mo27shjtpliwewbm5cci2kf37crrab/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/py-pluggy-1.6.0-n4ojmtqyawxz6gipk64pup3ahwz3xqpu/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/py-pluggy-1.6.0-n4ojmtqyawxz6gipk64pup3ahwz3xqpu/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_37/none-none/py-iniconfig-2.1.0-lf3yvch65se22jr7b5unfoxtse4ugkrk/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_03_30/none-none/py-iniconfig-2.1.0-lf3yvch65se22jr7b5unfoxtse4ugkrk/lib/python3.13/site-packages" CACHE PATH "")
 
 

--- a/host-configs/rzvector-toss_4_x86_64_ib-gcc@13.3.1_cuda.cmake
+++ b/host-configs/rzvector-toss_4_x86_64_ib-gcc@13.3.1_cuda.cmake
@@ -81,7 +81,7 @@ set(ENABLE_CUDA ON CACHE BOOL "")
 
 set(CMAKE_CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "")
 
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -restrict --expt-extended-lambda " CACHE STRING "" FORCE)
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -restrict --expt-extended-lambda --expt-relaxed-constexpr " CACHE STRING "" FORCE)
 
 # nvcc does not like gtest's 'pthreads' flag
 

--- a/host-configs/rzvector-toss_4_x86_64_ib-llvm@19.1.3_cuda.cmake
+++ b/host-configs/rzvector-toss_4_x86_64_ib-llvm@19.1.3_cuda.cmake
@@ -83,7 +83,7 @@ set(ENABLE_CUDA ON CACHE BOOL "")
 
 set(CMAKE_CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "")
 
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -restrict --expt-extended-lambda " CACHE STRING "" FORCE)
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -restrict --expt-extended-lambda --expt-relaxed-constexpr " CACHE STRING "" FORCE)
 
 # nvcc does not like gtest's 'pthreads' flag
 

--- a/host-configs/rzvernal-toss_4_x86_64_ib_cray-cce@20.0.0_hip.cmake
+++ b/host-configs/rzvernal-toss_4_x86_64_ib_cray-cce@20.0.0_hip.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/blt-0.7.1-tj6h3jr6fjdlxux2yd4wvdy7xwxxuh23;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/c2c-1.8.0-xav3pjepsvpzrcqd5dcom4is4rioejzr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-37ef6g3godgxug45i3u3x26awgovbhxa;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/conduit-0.9.5-oyjekm66om6cx7yndhpv3yumtxgaaroi;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/lua-5.4.8-ty6vxrgtb5lsthp7rrcy7vx3x4yknrms;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/mfem-4.9.0-qb5a5xcb5sx6mjeqqsuhxifqeikegol3;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/py-nanobind-2.7.0-h7v5ggotyqa5ul7kpyc2yfojjkah4ium;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/adiak-0.4.0-w7lj246x4whjefszgyhapkebe3cjd7bi;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/libunwind-1.8.3-htd47rshpgaa6w73jemf7tycnnlkn5ws;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/hdf5-1.8.23-vy4rnk6awhcfgte2wuwisgp3t3y4gzwy;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/parmetis-4.0.3-jqlganykrtm62xb3ve2eetb3gltn5nki;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/py-numpy-2.4.2-vdrslpslcsdjba3zyryp27z4tmpn3ayu;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/hypre-2.27.0-gjrhbi2v66y2yfxgq7vegqpcawo2b35r;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-mraqiovyi37bfdy7d3cpssvqibljl3rs;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/umpire-2025.12.0-wvhebyygqkj3vxwm6quu3rxnzjnvwjix;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/zlib-1.3.1-6yddik2qxvkwtfcckdhbdgos7awok5za;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/metis-5.1.0-bryzqxg7sgprevvt3ux5np2uxam4wbvp;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-s7ova7cnq6ibqaoxniya4loizwha2g3p;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/fmt-11.0.2-vjndv6co4e6qonqazcmklw3pamvmos74;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cce-tce/cce-20.0.0;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.32-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/blt-0.7.1-tj6h3jr6fjdlxux2yd4wvdy7xwxxuh23;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/c2c-1.8.0-xav3pjepsvpzrcqd5dcom4is4rioejzr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-37ef6g3godgxug45i3u3x26awgovbhxa;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/conduit-0.9.5-oyjekm66om6cx7yndhpv3yumtxgaaroi;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/lua-5.4.8-ty6vxrgtb5lsthp7rrcy7vx3x4yknrms;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/mfem-4.9.0-iiiowpg2cxn346mv67ycscrcrt5eacdk;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/py-nanobind-2.7.0-h7v5ggotyqa5ul7kpyc2yfojjkah4ium;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/adiak-0.4.0-w7lj246x4whjefszgyhapkebe3cjd7bi;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/libunwind-1.8.3-htd47rshpgaa6w73jemf7tycnnlkn5ws;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/hdf5-1.8.23-vy4rnk6awhcfgte2wuwisgp3t3y4gzwy;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/parmetis-4.0.3-jqlganykrtm62xb3ve2eetb3gltn5nki;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/py-numpy-2.4.2-vdrslpslcsdjba3zyryp27z4tmpn3ayu;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/hypre-2.27.0-gjrhbi2v66y2yfxgq7vegqpcawo2b35r;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-iwmhvbuhywrcyi4ojshrizfpccb53g3u;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/umpire-2025.12.0-qkp2thztbvdojybrli7tpxea5duxagkn;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/zlib-1.3.1-6yddik2qxvkwtfcckdhbdgos7awok5za;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/metis-5.1.0-bryzqxg7sgprevvt3ux5np2uxam4wbvp;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-xdstcq3vkkl6gysd7agincseoncdi5nz;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/fmt-11.0.2-vjndv6co4e6qonqazcmklw3pamvmos74;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cce-tce/cce-20.0.0;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.32-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/axom-develop-qs7aomrdxkidtsbjs23bs7ou7kg37qya/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/axom-develop-qs7aomrdxkidtsbjs23bs7ou7kg37qya/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/axom-develop-2xptn5vzdbqfiuuctci6jdklfwydwete/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/axom-develop-2xptn5vzdbqfiuuctci6jdklfwydwete/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/axom-develop-qs7aomrdxkidtsbjs23bs7ou7kg37qya/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0/axom-develop-qs7aomrdxkidtsbjs23bs7ou7kg37qya/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/axom-develop-2xptn5vzdbqfiuuctci6jdklfwydwete/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0/axom-develop-2xptn5vzdbqfiuuctci6jdklfwydwete/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -21,11 +21,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/cce/craycc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/cce/craycc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/cce/case-insensitive/crayCC" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/cce/case-insensitive/crayCC" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/cce/crayftn" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/cce/crayftn" CACHE PATH "")
 
 else()
 
@@ -84,37 +84,41 @@ set(ENABLE_HIP ON CACHE BOOL "")
 
 set(ROCM_ROOT_DIR "/opt/rocm-6.4.3" CACHE PATH "")
 
-set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "unwind" CACHE STRING "")
+set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "unwind;ompstub" CACHE STRING "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.32/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.32/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -lompstub -L/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -Wl,-rpath,/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.32/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.32/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -L/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -Wl,-rpath,/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
 #------------------------------------------------
 
-set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(BLT_OPENMP_COMPILE_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-fopenmp>" CACHE STRING "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)")
+
+set(BLT_OPENMP_LINK_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-fopenmp>" CACHE STRING "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)")
 
 #------------------------------------------------------------------------------
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/cce-20.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/cce-20.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-oyjekm66om6cx7yndhpv3yumtxgaaroi" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-xav3pjepsvpzrcqd5dcom4is4rioejzr" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-qb5a5xcb5sx6mjeqqsuhxifqeikegol3" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-iiiowpg2cxn346mv67ycscrcrt5eacdk" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-vy4rnk6awhcfgte2wuwisgp3t3y4gzwy" CACHE PATH "")
 
 set(LUA_DIR "${TPL_ROOT}/lua-5.4.8-ty6vxrgtb5lsthp7rrcy7vx3x4yknrms" CACHE PATH "")
 
-set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-mraqiovyi37bfdy7d3cpssvqibljl3rs" CACHE PATH "")
+set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-iwmhvbuhywrcyi4ojshrizfpccb53g3u" CACHE PATH "")
 
-set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-wvhebyygqkj3vxwm6quu3rxnzjnvwjix" CACHE PATH "")
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-qkp2thztbvdojybrli7tpxea5duxagkn" CACHE PATH "")
 
 # OPENCASCADE not built
 
@@ -122,7 +126,7 @@ set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-w7lj246x4whjefszgyhapkebe3cjd7bi" CACHE P
 
 set(CALIPER_DIR "${TPL_ROOT}/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-37ef6g3godgxug45i3u3x26awgovbhxa" CACHE PATH "")
 
-set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-s7ova7cnq6ibqaoxniya4loizwha2g3p" CACHE PATH "")
+set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-xdstcq3vkkl6gysd7agincseoncdi5nz" CACHE PATH "")
 
 # scr not built
 
@@ -152,12 +156,12 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/._view/ywmag65dnysd7p4dhlmcoaaqqxfzgz5a
 
 set(PY_NANOBIND_DIR "${TPL_ROOT}/py-nanobind-2.7.0-h7v5ggotyqa5ul7kpyc2yfojjkah4ium/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj/lib/python3.13/site-packages" CACHE PATH "")
 
 set(PY_NUMPY_DIR "${TPL_ROOT}/py-numpy-2.4.2-vdrslpslcsdjba3zyryp27z4tmpn3ayu/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/py-pluggy-1.6.0-27aoz44dedjxa6j6r6cavpqyqmpknidb/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/py-pluggy-1.6.0-27aoz44dedjxa6j6r6cavpqyqmpknidb/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/py-iniconfig-2.1.0-7rty7n4wq6kxxrzflm7wbxqzhhc6ph7q/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/py-iniconfig-2.1.0-7rty7n4wq6kxxrzflm7wbxqzhhc6ph7q/lib/python3.13/site-packages" CACHE PATH "")
 
 

--- a/host-configs/rzvernal-toss_4_x86_64_ib_cray-llvm-amdgpu@6.3.1_hip.cmake
+++ b/host-configs/rzvernal-toss_4_x86_64_ib_cray-llvm-amdgpu@6.3.1_hip.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/adiak-0.4.0-vlugt2gwkx5wzlwudznxg3p2plq76pjq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/blt-0.7.1-sv74qxlkpkll7mm6dhfjagyfog254w7c;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/c2c-1.8.0-tfrrofjzn3rdvyktevespobwrpjai5j4;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/conduit-0.9.5-vnlbr73jbwhqyvh2q76csdtve3ekpncc;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/lua-5.4.8-e3i2pbc52bfhrnxbaniektzp3x5jvyxr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/mfem-4.9.0-lzyx65dulc7kbahov4m3zy5zsopxpfiz;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/py-nanobind-2.7.0-4sgpkalsntbmuim5oltb7ue4gggt6rv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/hdf5-1.8.23-liive5kzeooveetbjhil4ic7hi3ccsg4;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/parmetis-4.0.3-fiyw3adearn3nmxjifcqtuzwy24fshp5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/py-numpy-2.4.2-ij66enxl4hmrmwua5bsec2yslylneqbw;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/hypre-2.27.0-cnukrpfl32kl5q6ud4wozdqbgtqoo7jx;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-aqopcekt2ikzah5tekoesewfzyexhz4q;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/umpire-2025.12.0-6jmr57w6t5ctmf4jgyrzb3y2j77a2clz;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/zlib-1.3.1-dsduxyfnks4bhrkpbskff35l5y36ofp7;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/metis-5.1.0-6mtxrj6jbrvyd3xpq4pvluywbndjx42w;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-eccm2e7wvkrekpfcvmbu6x3rtnip4oh3;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/fmt-11.0.2-kw3vpg2ajhrgi7kozhcioz3nrgc6fh3o;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/opt/rocm-6.3.1" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/adiak-0.4.0-vlugt2gwkx5wzlwudznxg3p2plq76pjq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/blt-0.7.1-sv74qxlkpkll7mm6dhfjagyfog254w7c;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/c2c-1.8.0-tfrrofjzn3rdvyktevespobwrpjai5j4;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/conduit-0.9.5-vnlbr73jbwhqyvh2q76csdtve3ekpncc;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/lua-5.4.8-e3i2pbc52bfhrnxbaniektzp3x5jvyxr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/mfem-4.9.0-jxeezxksp3c7i53h6dhqf2zz6gnaipub;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/py-nanobind-2.7.0-4sgpkalsntbmuim5oltb7ue4gggt6rv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/hdf5-1.8.23-liive5kzeooveetbjhil4ic7hi3ccsg4;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/parmetis-4.0.3-fiyw3adearn3nmxjifcqtuzwy24fshp5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/py-numpy-2.4.2-ij66enxl4hmrmwua5bsec2yslylneqbw;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/hypre-2.27.0-cnukrpfl32kl5q6ud4wozdqbgtqoo7jx;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-5c3lqbqcjmekrwbfeg6ogptz7ssj3n4y;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/umpire-2025.12.0-i2dwv2l2jra74eazijtvprcx7acsupx4;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/zlib-1.3.1-dsduxyfnks4bhrkpbskff35l5y36ofp7;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/metis-5.1.0-6mtxrj6jbrvyd3xpq4pvluywbndjx42w;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-7nvneljwisxwircaqydhfcl3hl65bmr2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/fmt-11.0.2-kw3vpg2ajhrgi7kozhcioz3nrgc6fh3o;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/opt/rocm-6.3.1" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/axom-develop-te7am32fqfkfq6tx6o5arqikygw5j36c/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/axom-develop-te7am32fqfkfq6tx6o5arqikygw5j36c/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/axom-develop-jx2n4ai2kjdjrg7o6oc6nrugd5kvsk24/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/axom-develop-jx2n4ai2kjdjrg7o6oc6nrugd5kvsk24/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/axom-develop-te7am32fqfkfq6tx6o5arqikygw5j36c/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1/axom-develop-te7am32fqfkfq6tx6o5arqikygw5j36c/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/axom-develop-jx2n4ai2kjdjrg7o6oc6nrugd5kvsk24/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1/axom-develop-jx2n4ai2kjdjrg7o6oc6nrugd5kvsk24/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -21,11 +21,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdflang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdflang" CACHE PATH "")
 
 else()
 
@@ -82,13 +82,15 @@ set(ENABLE_HIP ON CACHE BOOL "")
 
 set(ROCM_ROOT_DIR "/opt/rocm-6.3.1" CACHE PATH "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.3.1/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.3.1/lib/llvm/lib -L/opt/rocm-6.3.1/lib -Wl,-rpath,/opt/rocm-6.3.1/lib -lpgmath -lompstub -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "ompstub" CACHE STRING "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.3.1/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.3.1/lib/llvm/lib -L/opt/rocm-6.3.1/lib -Wl,-rpath,/opt/rocm-6.3.1/lib -lpgmath -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
 #------------------------------------------------
 
-set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
@@ -96,21 +98,21 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.3.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-vnlbr73jbwhqyvh2q76csdtve3ekpncc" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-tfrrofjzn3rdvyktevespobwrpjai5j4" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-lzyx65dulc7kbahov4m3zy5zsopxpfiz" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-jxeezxksp3c7i53h6dhqf2zz6gnaipub" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-liive5kzeooveetbjhil4ic7hi3ccsg4" CACHE PATH "")
 
 set(LUA_DIR "${TPL_ROOT}/lua-5.4.8-e3i2pbc52bfhrnxbaniektzp3x5jvyxr" CACHE PATH "")
 
-set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-aqopcekt2ikzah5tekoesewfzyexhz4q" CACHE PATH "")
+set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-5c3lqbqcjmekrwbfeg6ogptz7ssj3n4y" CACHE PATH "")
 
-set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-6jmr57w6t5ctmf4jgyrzb3y2j77a2clz" CACHE PATH "")
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-i2dwv2l2jra74eazijtvprcx7acsupx4" CACHE PATH "")
 
 # OPENCASCADE not built
 
@@ -118,7 +120,7 @@ set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-vlugt2gwkx5wzlwudznxg3p2plq76pjq" CACHE P
 
 # CALIPER not built
 
-set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-eccm2e7wvkrekpfcvmbu6x3rtnip4oh3" CACHE PATH "")
+set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-7nvneljwisxwircaqydhfcl3hl65bmr2" CACHE PATH "")
 
 # scr not built
 
@@ -148,12 +150,12 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/._view/ywmag65dnysd7p4dhlmcoaaqqxfzgz5a
 
 set(PY_NANOBIND_DIR "${TPL_ROOT}/py-nanobind-2.7.0-4sgpkalsntbmuim5oltb7ue4gggt6rv5/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj/lib/python3.13/site-packages" CACHE PATH "")
 
 set(PY_NUMPY_DIR "${TPL_ROOT}/py-numpy-2.4.2-ij66enxl4hmrmwua5bsec2yslylneqbw/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/py-pluggy-1.6.0-27aoz44dedjxa6j6r6cavpqyqmpknidb/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/py-pluggy-1.6.0-27aoz44dedjxa6j6r6cavpqyqmpknidb/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/py-iniconfig-2.1.0-7rty7n4wq6kxxrzflm7wbxqzhhc6ph7q/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/py-iniconfig-2.1.0-7rty7n4wq6kxxrzflm7wbxqzhhc6ph7q/lib/python3.13/site-packages" CACHE PATH "")
 
 

--- a/host-configs/rzvernal-toss_4_x86_64_ib_cray-llvm-amdgpu@6.4.3_hip.cmake
+++ b/host-configs/rzvernal-toss_4_x86_64_ib_cray-llvm-amdgpu@6.4.3_hip.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/blt-0.7.1-2eahqqwjyauupjq3baxftq7kuv3pvdgp;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/c2c-1.8.0-oxqhr2ybswpnzt74f4iritx263ji3uqy;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-sos5uklbsgaycb776a2ufcyje4y24yls;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/conduit-0.9.5-cxdq4qnoptjq6lry5asb2bqodvm3zjig;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/lua-5.4.8-lsey5vgxvpqf5j3xbrlzswrizuwm65vh;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/mfem-4.9.0-gkcg2u6vl5yur7gvigiut76ckzxo4fry;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/py-nanobind-2.7.0-3nchqpyclgle5w56it23ozl4ttbnrfjd;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/adiak-0.4.0-cbxp6kv6rm4f7oeczuhbplm3yb3zxb6z;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/libunwind-1.8.3-r4b3cptnf27zp34jbrdtlrf6r6dp6n4l;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/hdf5-1.8.23-wb7u6epuww3tretkcto7jhq2i7pffimg;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/parmetis-4.0.3-d6ed2qesb4yprvpetx3fso35rx6amf5b;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/py-numpy-2.4.2-t7cvohiksz7deeldwxrtqfmahcvanapb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/hypre-2.27.0-pxqhlqwksiscco65tsz5somb4ctdq3q2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-5r3ukxt2ewfn2geqge37ea2fxd7kfixh;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/umpire-2025.12.0-n4zr37loo2okonovcswffexwi5mbxnxh;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/zlib-1.3.1-ijxa3tdiibemxtng46hrremmbytl2dqq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/metis-5.1.0-mubwzuka5byhpbzmwaxjhtffhst3oj3q;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-k6gr5qtzupytbr5kq2e73qesltauiqcl;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/fmt-11.0.2-unmvs6vefcyfcfnzlie2eag5i2eib35d;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/blt-0.7.1-2eahqqwjyauupjq3baxftq7kuv3pvdgp;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/c2c-1.8.0-oxqhr2ybswpnzt74f4iritx263ji3uqy;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-sos5uklbsgaycb776a2ufcyje4y24yls;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/conduit-0.9.5-cxdq4qnoptjq6lry5asb2bqodvm3zjig;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/lua-5.4.8-lsey5vgxvpqf5j3xbrlzswrizuwm65vh;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/mfem-4.9.0-xwok5jck2jjg76k4575wkzgyvgopipz2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/py-nanobind-2.7.0-3nchqpyclgle5w56it23ozl4ttbnrfjd;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/adiak-0.4.0-cbxp6kv6rm4f7oeczuhbplm3yb3zxb6z;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/libunwind-1.8.3-r4b3cptnf27zp34jbrdtlrf6r6dp6n4l;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/hdf5-1.8.23-wb7u6epuww3tretkcto7jhq2i7pffimg;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/parmetis-4.0.3-d6ed2qesb4yprvpetx3fso35rx6amf5b;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/py-numpy-2.4.2-t7cvohiksz7deeldwxrtqfmahcvanapb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/hypre-2.27.0-pxqhlqwksiscco65tsz5somb4ctdq3q2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-i5stpeet653njjadpjsekbvxlqkng2zn;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/umpire-2025.12.0-hpevb7stqsg6dltp3t2tcnzzps7tgywb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/zlib-1.3.1-ijxa3tdiibemxtng46hrremmbytl2dqq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/metis-5.1.0-mubwzuka5byhpbzmwaxjhtffhst3oj3q;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-j7my6ilwzwzvbaxzscbvishmj5mgyxnz;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/fmt-11.0.2-unmvs6vefcyfcfnzlie2eag5i2eib35d;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/axom-develop-2ah5imlo6grdjcijxzmnj65v5lolnzam/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/axom-develop-2ah5imlo6grdjcijxzmnj65v5lolnzam/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/axom-develop-j5cg6odzkrlra4lrnhap3qtdbfgnwvlk/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/axom-develop-j5cg6odzkrlra4lrnhap3qtdbfgnwvlk/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/axom-develop-2ah5imlo6grdjcijxzmnj65v5lolnzam/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3/axom-develop-2ah5imlo6grdjcijxzmnj65v5lolnzam/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/axom-develop-j5cg6odzkrlra4lrnhap3qtdbfgnwvlk/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3/axom-develop-j5cg6odzkrlra4lrnhap3qtdbfgnwvlk/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -21,11 +21,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdflang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdflang" CACHE PATH "")
 
 else()
 
@@ -82,13 +82,15 @@ set(ENABLE_HIP ON CACHE BOOL "")
 
 set(ROCM_ROOT_DIR "/opt/rocm-6.4.3" CACHE PATH "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -lompstub -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "ompstub" CACHE STRING "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
 #------------------------------------------------
 
-set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
@@ -96,21 +98,21 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/llvm-amdgpu-6.4.3" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/llvm-amdgpu-6.4.3" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-cxdq4qnoptjq6lry5asb2bqodvm3zjig" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-oxqhr2ybswpnzt74f4iritx263ji3uqy" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-gkcg2u6vl5yur7gvigiut76ckzxo4fry" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-xwok5jck2jjg76k4575wkzgyvgopipz2" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-wb7u6epuww3tretkcto7jhq2i7pffimg" CACHE PATH "")
 
 set(LUA_DIR "${TPL_ROOT}/lua-5.4.8-lsey5vgxvpqf5j3xbrlzswrizuwm65vh" CACHE PATH "")
 
-set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-5r3ukxt2ewfn2geqge37ea2fxd7kfixh" CACHE PATH "")
+set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-i5stpeet653njjadpjsekbvxlqkng2zn" CACHE PATH "")
 
-set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-n4zr37loo2okonovcswffexwi5mbxnxh" CACHE PATH "")
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-hpevb7stqsg6dltp3t2tcnzzps7tgywb" CACHE PATH "")
 
 # OPENCASCADE not built
 
@@ -118,7 +120,7 @@ set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-cbxp6kv6rm4f7oeczuhbplm3yb3zxb6z" CACHE P
 
 set(CALIPER_DIR "${TPL_ROOT}/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-sos5uklbsgaycb776a2ufcyje4y24yls" CACHE PATH "")
 
-set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-k6gr5qtzupytbr5kq2e73qesltauiqcl" CACHE PATH "")
+set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-j7my6ilwzwzvbaxzscbvishmj5mgyxnz" CACHE PATH "")
 
 # scr not built
 
@@ -148,12 +150,12 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/._view/ywmag65dnysd7p4dhlmcoaaqqxfzgz5a
 
 set(PY_NANOBIND_DIR "${TPL_ROOT}/py-nanobind-2.7.0-3nchqpyclgle5w56it23ozl4ttbnrfjd/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj/lib/python3.13/site-packages" CACHE PATH "")
 
 set(PY_NUMPY_DIR "${TPL_ROOT}/py-numpy-2.4.2-t7cvohiksz7deeldwxrtqfmahcvanapb/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/py-pluggy-1.6.0-27aoz44dedjxa6j6r6cavpqyqmpknidb/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/py-pluggy-1.6.0-27aoz44dedjxa6j6r6cavpqyqmpknidb/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_11_12_30/none-none/py-iniconfig-2.1.0-7rty7n4wq6kxxrzflm7wbxqzhhc6ph7q/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_13_07_25/none-none/py-iniconfig-2.1.0-7rty7n4wq6kxxrzflm7wbxqzhhc6ph7q/lib/python3.13/site-packages" CACHE PATH "")
 
 

--- a/host-configs/tioga-toss_4_x86_64_ib_cray-cce@20.0.0_hip.cmake
+++ b/host-configs/tioga-toss_4_x86_64_ib_cray-cce@20.0.0_hip.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/blt-0.7.1-tj6h3jr6fjdlxux2yd4wvdy7xwxxuh23;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/c2c-1.8.0-xav3pjepsvpzrcqd5dcom4is4rioejzr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-37ef6g3godgxug45i3u3x26awgovbhxa;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/conduit-0.9.5-oyjekm66om6cx7yndhpv3yumtxgaaroi;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/lua-5.4.8-ty6vxrgtb5lsthp7rrcy7vx3x4yknrms;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/mfem-4.9.0-qb5a5xcb5sx6mjeqqsuhxifqeikegol3;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/py-nanobind-2.7.0-h7v5ggotyqa5ul7kpyc2yfojjkah4ium;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/adiak-0.4.0-w7lj246x4whjefszgyhapkebe3cjd7bi;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/libunwind-1.8.3-htd47rshpgaa6w73jemf7tycnnlkn5ws;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/hdf5-1.8.23-vy4rnk6awhcfgte2wuwisgp3t3y4gzwy;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/parmetis-4.0.3-jqlganykrtm62xb3ve2eetb3gltn5nki;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/py-numpy-2.4.2-vdrslpslcsdjba3zyryp27z4tmpn3ayu;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/hypre-2.27.0-gjrhbi2v66y2yfxgq7vegqpcawo2b35r;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-mraqiovyi37bfdy7d3cpssvqibljl3rs;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/umpire-2025.12.0-wvhebyygqkj3vxwm6quu3rxnzjnvwjix;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/zlib-1.3.1-6yddik2qxvkwtfcckdhbdgos7awok5za;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/metis-5.1.0-bryzqxg7sgprevvt3ux5np2uxam4wbvp;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-s7ova7cnq6ibqaoxniya4loizwha2g3p;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/fmt-11.0.2-vjndv6co4e6qonqazcmklw3pamvmos74;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cce-tce/cce-20.0.0;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.32-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/blt-0.7.1-tj6h3jr6fjdlxux2yd4wvdy7xwxxuh23;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/c2c-1.8.0-xav3pjepsvpzrcqd5dcom4is4rioejzr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-37ef6g3godgxug45i3u3x26awgovbhxa;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/conduit-0.9.5-oyjekm66om6cx7yndhpv3yumtxgaaroi;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/lua-5.4.8-ty6vxrgtb5lsthp7rrcy7vx3x4yknrms;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/mfem-4.9.0-iiiowpg2cxn346mv67ycscrcrt5eacdk;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/py-nanobind-2.7.0-h7v5ggotyqa5ul7kpyc2yfojjkah4ium;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/adiak-0.4.0-w7lj246x4whjefszgyhapkebe3cjd7bi;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/libunwind-1.8.3-htd47rshpgaa6w73jemf7tycnnlkn5ws;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/hdf5-1.8.23-vy4rnk6awhcfgte2wuwisgp3t3y4gzwy;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/parmetis-4.0.3-jqlganykrtm62xb3ve2eetb3gltn5nki;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/py-numpy-2.4.2-vdrslpslcsdjba3zyryp27z4tmpn3ayu;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/hypre-2.27.0-gjrhbi2v66y2yfxgq7vegqpcawo2b35r;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-iwmhvbuhywrcyi4ojshrizfpccb53g3u;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/umpire-2025.12.0-qkp2thztbvdojybrli7tpxea5duxagkn;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/zlib-1.3.1-6yddik2qxvkwtfcckdhbdgos7awok5za;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/metis-5.1.0-bryzqxg7sgprevvt3ux5np2uxam4wbvp;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-xdstcq3vkkl6gysd7agincseoncdi5nz;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/fmt-11.0.2-vjndv6co4e6qonqazcmklw3pamvmos74;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cce-tce/cce-20.0.0;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.32-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/axom-develop-qs7aomrdxkidtsbjs23bs7ou7kg37qya/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/axom-develop-qs7aomrdxkidtsbjs23bs7ou7kg37qya/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/axom-develop-2xptn5vzdbqfiuuctci6jdklfwydwete/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/axom-develop-2xptn5vzdbqfiuuctci6jdklfwydwete/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/axom-develop-qs7aomrdxkidtsbjs23bs7ou7kg37qya/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0/axom-develop-qs7aomrdxkidtsbjs23bs7ou7kg37qya/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/axom-develop-2xptn5vzdbqfiuuctci6jdklfwydwete/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0/axom-develop-2xptn5vzdbqfiuuctci6jdklfwydwete/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -21,11 +21,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/cce/craycc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/cce/craycc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/cce/case-insensitive/crayCC" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/cce/case-insensitive/crayCC" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/cce/crayftn" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/cce/crayftn" CACHE PATH "")
 
 else()
 
@@ -84,37 +84,41 @@ set(ENABLE_HIP ON CACHE BOOL "")
 
 set(ROCM_ROOT_DIR "/opt/rocm-6.4.3" CACHE PATH "")
 
-set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "unwind" CACHE STRING "")
+set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "unwind;ompstub" CACHE STRING "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.32/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.32/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -lompstub -L/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -Wl,-rpath,/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.32/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.32/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -L/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -Wl,-rpath,/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
 #------------------------------------------------
 
-set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(BLT_OPENMP_COMPILE_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-fopenmp>" CACHE STRING "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)")
+
+set(BLT_OPENMP_LINK_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-fopenmp>" CACHE STRING "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)")
 
 #------------------------------------------------------------------------------
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/cce-20.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/cce-20.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-oyjekm66om6cx7yndhpv3yumtxgaaroi" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-xav3pjepsvpzrcqd5dcom4is4rioejzr" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-qb5a5xcb5sx6mjeqqsuhxifqeikegol3" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-iiiowpg2cxn346mv67ycscrcrt5eacdk" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-vy4rnk6awhcfgte2wuwisgp3t3y4gzwy" CACHE PATH "")
 
 set(LUA_DIR "${TPL_ROOT}/lua-5.4.8-ty6vxrgtb5lsthp7rrcy7vx3x4yknrms" CACHE PATH "")
 
-set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-mraqiovyi37bfdy7d3cpssvqibljl3rs" CACHE PATH "")
+set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-iwmhvbuhywrcyi4ojshrizfpccb53g3u" CACHE PATH "")
 
-set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-wvhebyygqkj3vxwm6quu3rxnzjnvwjix" CACHE PATH "")
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-qkp2thztbvdojybrli7tpxea5duxagkn" CACHE PATH "")
 
 # OPENCASCADE not built
 
@@ -122,7 +126,7 @@ set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-w7lj246x4whjefszgyhapkebe3cjd7bi" CACHE P
 
 set(CALIPER_DIR "${TPL_ROOT}/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-37ef6g3godgxug45i3u3x26awgovbhxa" CACHE PATH "")
 
-set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-s7ova7cnq6ibqaoxniya4loizwha2g3p" CACHE PATH "")
+set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-xdstcq3vkkl6gysd7agincseoncdi5nz" CACHE PATH "")
 
 # scr not built
 
@@ -152,12 +156,12 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/._view/ywmag65dnysd7p4dhlmcoaaqqxfzgz5a
 
 set(PY_NANOBIND_DIR "${TPL_ROOT}/py-nanobind-2.7.0-h7v5ggotyqa5ul7kpyc2yfojjkah4ium/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj/lib/python3.13/site-packages" CACHE PATH "")
 
 set(PY_NUMPY_DIR "${TPL_ROOT}/py-numpy-2.4.2-vdrslpslcsdjba3zyryp27z4tmpn3ayu/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/py-pluggy-1.6.0-27aoz44dedjxa6j6r6cavpqyqmpknidb/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/py-pluggy-1.6.0-27aoz44dedjxa6j6r6cavpqyqmpknidb/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/py-iniconfig-2.1.0-7rty7n4wq6kxxrzflm7wbxqzhhc6ph7q/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/py-iniconfig-2.1.0-7rty7n4wq6kxxrzflm7wbxqzhhc6ph7q/lib/python3.13/site-packages" CACHE PATH "")
 
 

--- a/host-configs/tioga-toss_4_x86_64_ib_cray-llvm-amdgpu@6.3.1_hip.cmake
+++ b/host-configs/tioga-toss_4_x86_64_ib_cray-llvm-amdgpu@6.3.1_hip.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/adiak-0.4.0-vlugt2gwkx5wzlwudznxg3p2plq76pjq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/blt-0.7.1-sv74qxlkpkll7mm6dhfjagyfog254w7c;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/c2c-1.8.0-tfrrofjzn3rdvyktevespobwrpjai5j4;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/conduit-0.9.5-vnlbr73jbwhqyvh2q76csdtve3ekpncc;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/lua-5.4.8-e3i2pbc52bfhrnxbaniektzp3x5jvyxr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/mfem-4.9.0-lzyx65dulc7kbahov4m3zy5zsopxpfiz;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/py-nanobind-2.7.0-4sgpkalsntbmuim5oltb7ue4gggt6rv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/hdf5-1.8.23-liive5kzeooveetbjhil4ic7hi3ccsg4;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/parmetis-4.0.3-fiyw3adearn3nmxjifcqtuzwy24fshp5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/py-numpy-2.4.2-ij66enxl4hmrmwua5bsec2yslylneqbw;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/hypre-2.27.0-cnukrpfl32kl5q6ud4wozdqbgtqoo7jx;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-aqopcekt2ikzah5tekoesewfzyexhz4q;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/umpire-2025.12.0-6jmr57w6t5ctmf4jgyrzb3y2j77a2clz;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/zlib-1.3.1-dsduxyfnks4bhrkpbskff35l5y36ofp7;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/metis-5.1.0-6mtxrj6jbrvyd3xpq4pvluywbndjx42w;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-eccm2e7wvkrekpfcvmbu6x3rtnip4oh3;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/fmt-11.0.2-kw3vpg2ajhrgi7kozhcioz3nrgc6fh3o;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/opt/rocm-6.3.1" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/adiak-0.4.0-vlugt2gwkx5wzlwudznxg3p2plq76pjq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/blt-0.7.1-sv74qxlkpkll7mm6dhfjagyfog254w7c;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/c2c-1.8.0-tfrrofjzn3rdvyktevespobwrpjai5j4;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/conduit-0.9.5-vnlbr73jbwhqyvh2q76csdtve3ekpncc;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/lua-5.4.8-e3i2pbc52bfhrnxbaniektzp3x5jvyxr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/mfem-4.9.0-jxeezxksp3c7i53h6dhqf2zz6gnaipub;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/py-nanobind-2.7.0-4sgpkalsntbmuim5oltb7ue4gggt6rv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/hdf5-1.8.23-liive5kzeooveetbjhil4ic7hi3ccsg4;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/parmetis-4.0.3-fiyw3adearn3nmxjifcqtuzwy24fshp5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/py-numpy-2.4.2-ij66enxl4hmrmwua5bsec2yslylneqbw;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/hypre-2.27.0-cnukrpfl32kl5q6ud4wozdqbgtqoo7jx;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-5c3lqbqcjmekrwbfeg6ogptz7ssj3n4y;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/umpire-2025.12.0-i2dwv2l2jra74eazijtvprcx7acsupx4;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/zlib-1.3.1-dsduxyfnks4bhrkpbskff35l5y36ofp7;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/metis-5.1.0-6mtxrj6jbrvyd3xpq4pvluywbndjx42w;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-7nvneljwisxwircaqydhfcl3hl65bmr2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/fmt-11.0.2-kw3vpg2ajhrgi7kozhcioz3nrgc6fh3o;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/opt/rocm-6.3.1" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/axom-develop-te7am32fqfkfq6tx6o5arqikygw5j36c/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/axom-develop-te7am32fqfkfq6tx6o5arqikygw5j36c/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/axom-develop-jx2n4ai2kjdjrg7o6oc6nrugd5kvsk24/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/axom-develop-jx2n4ai2kjdjrg7o6oc6nrugd5kvsk24/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/axom-develop-te7am32fqfkfq6tx6o5arqikygw5j36c/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1/axom-develop-te7am32fqfkfq6tx6o5arqikygw5j36c/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/axom-develop-jx2n4ai2kjdjrg7o6oc6nrugd5kvsk24/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1/axom-develop-jx2n4ai2kjdjrg7o6oc6nrugd5kvsk24/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -21,11 +21,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdflang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdflang" CACHE PATH "")
 
 else()
 
@@ -82,13 +82,15 @@ set(ENABLE_HIP ON CACHE BOOL "")
 
 set(ROCM_ROOT_DIR "/opt/rocm-6.3.1" CACHE PATH "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.3.1/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.3.1/lib/llvm/lib -L/opt/rocm-6.3.1/lib -Wl,-rpath,/opt/rocm-6.3.1/lib -lpgmath -lompstub -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "ompstub" CACHE STRING "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.3.1/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.3.1/lib/llvm/lib -L/opt/rocm-6.3.1/lib -Wl,-rpath,/opt/rocm-6.3.1/lib -lpgmath -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
 #------------------------------------------------
 
-set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
@@ -96,21 +98,21 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.3.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-vnlbr73jbwhqyvh2q76csdtve3ekpncc" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-tfrrofjzn3rdvyktevespobwrpjai5j4" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-lzyx65dulc7kbahov4m3zy5zsopxpfiz" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-jxeezxksp3c7i53h6dhqf2zz6gnaipub" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-liive5kzeooveetbjhil4ic7hi3ccsg4" CACHE PATH "")
 
 set(LUA_DIR "${TPL_ROOT}/lua-5.4.8-e3i2pbc52bfhrnxbaniektzp3x5jvyxr" CACHE PATH "")
 
-set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-aqopcekt2ikzah5tekoesewfzyexhz4q" CACHE PATH "")
+set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-5c3lqbqcjmekrwbfeg6ogptz7ssj3n4y" CACHE PATH "")
 
-set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-6jmr57w6t5ctmf4jgyrzb3y2j77a2clz" CACHE PATH "")
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-i2dwv2l2jra74eazijtvprcx7acsupx4" CACHE PATH "")
 
 # OPENCASCADE not built
 
@@ -118,7 +120,7 @@ set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-vlugt2gwkx5wzlwudznxg3p2plq76pjq" CACHE P
 
 # CALIPER not built
 
-set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-eccm2e7wvkrekpfcvmbu6x3rtnip4oh3" CACHE PATH "")
+set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-7nvneljwisxwircaqydhfcl3hl65bmr2" CACHE PATH "")
 
 # scr not built
 
@@ -148,12 +150,12 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/._view/ywmag65dnysd7p4dhlmcoaaqqxfzgz5a
 
 set(PY_NANOBIND_DIR "${TPL_ROOT}/py-nanobind-2.7.0-4sgpkalsntbmuim5oltb7ue4gggt6rv5/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj/lib/python3.13/site-packages" CACHE PATH "")
 
 set(PY_NUMPY_DIR "${TPL_ROOT}/py-numpy-2.4.2-ij66enxl4hmrmwua5bsec2yslylneqbw/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/py-pluggy-1.6.0-27aoz44dedjxa6j6r6cavpqyqmpknidb/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/py-pluggy-1.6.0-27aoz44dedjxa6j6r6cavpqyqmpknidb/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/py-iniconfig-2.1.0-7rty7n4wq6kxxrzflm7wbxqzhhc6ph7q/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/py-iniconfig-2.1.0-7rty7n4wq6kxxrzflm7wbxqzhhc6ph7q/lib/python3.13/site-packages" CACHE PATH "")
 
 

--- a/host-configs/tioga-toss_4_x86_64_ib_cray-llvm-amdgpu@6.4.3_hip.cmake
+++ b/host-configs/tioga-toss_4_x86_64_ib_cray-llvm-amdgpu@6.4.3_hip.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/blt-0.7.1-2eahqqwjyauupjq3baxftq7kuv3pvdgp;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/c2c-1.8.0-oxqhr2ybswpnzt74f4iritx263ji3uqy;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-sos5uklbsgaycb776a2ufcyje4y24yls;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/conduit-0.9.5-cxdq4qnoptjq6lry5asb2bqodvm3zjig;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/lua-5.4.8-lsey5vgxvpqf5j3xbrlzswrizuwm65vh;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/mfem-4.9.0-gkcg2u6vl5yur7gvigiut76ckzxo4fry;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/py-nanobind-2.7.0-3nchqpyclgle5w56it23ozl4ttbnrfjd;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/adiak-0.4.0-cbxp6kv6rm4f7oeczuhbplm3yb3zxb6z;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/libunwind-1.8.3-r4b3cptnf27zp34jbrdtlrf6r6dp6n4l;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/hdf5-1.8.23-wb7u6epuww3tretkcto7jhq2i7pffimg;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/parmetis-4.0.3-d6ed2qesb4yprvpetx3fso35rx6amf5b;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/py-numpy-2.4.2-t7cvohiksz7deeldwxrtqfmahcvanapb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/hypre-2.27.0-pxqhlqwksiscco65tsz5somb4ctdq3q2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-5r3ukxt2ewfn2geqge37ea2fxd7kfixh;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/umpire-2025.12.0-n4zr37loo2okonovcswffexwi5mbxnxh;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/zlib-1.3.1-ijxa3tdiibemxtng46hrremmbytl2dqq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/metis-5.1.0-mubwzuka5byhpbzmwaxjhtffhst3oj3q;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-k6gr5qtzupytbr5kq2e73qesltauiqcl;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/fmt-11.0.2-unmvs6vefcyfcfnzlie2eag5i2eib35d;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/blt-0.7.1-2eahqqwjyauupjq3baxftq7kuv3pvdgp;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/c2c-1.8.0-oxqhr2ybswpnzt74f4iritx263ji3uqy;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-sos5uklbsgaycb776a2ufcyje4y24yls;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/conduit-0.9.5-cxdq4qnoptjq6lry5asb2bqodvm3zjig;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/lua-5.4.8-lsey5vgxvpqf5j3xbrlzswrizuwm65vh;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/mfem-4.9.0-xwok5jck2jjg76k4575wkzgyvgopipz2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/py-nanobind-2.7.0-3nchqpyclgle5w56it23ozl4ttbnrfjd;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/adiak-0.4.0-cbxp6kv6rm4f7oeczuhbplm3yb3zxb6z;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/libunwind-1.8.3-r4b3cptnf27zp34jbrdtlrf6r6dp6n4l;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/hdf5-1.8.23-wb7u6epuww3tretkcto7jhq2i7pffimg;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/parmetis-4.0.3-d6ed2qesb4yprvpetx3fso35rx6amf5b;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/py-numpy-2.4.2-t7cvohiksz7deeldwxrtqfmahcvanapb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/hypre-2.27.0-pxqhlqwksiscco65tsz5somb4ctdq3q2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-i5stpeet653njjadpjsekbvxlqkng2zn;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/umpire-2025.12.0-hpevb7stqsg6dltp3t2tcnzzps7tgywb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/zlib-1.3.1-ijxa3tdiibemxtng46hrremmbytl2dqq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/metis-5.1.0-mubwzuka5byhpbzmwaxjhtffhst3oj3q;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-j7my6ilwzwzvbaxzscbvishmj5mgyxnz;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/fmt-11.0.2-unmvs6vefcyfcfnzlie2eag5i2eib35d;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/axom-develop-2ah5imlo6grdjcijxzmnj65v5lolnzam/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/axom-develop-2ah5imlo6grdjcijxzmnj65v5lolnzam/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/axom-develop-j5cg6odzkrlra4lrnhap3qtdbfgnwvlk/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/axom-develop-j5cg6odzkrlra4lrnhap3qtdbfgnwvlk/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/axom-develop-2ah5imlo6grdjcijxzmnj65v5lolnzam/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3/axom-develop-2ah5imlo6grdjcijxzmnj65v5lolnzam/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/axom-develop-j5cg6odzkrlra4lrnhap3qtdbfgnwvlk/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3/axom-develop-j5cg6odzkrlra4lrnhap3qtdbfgnwvlk/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -21,11 +21,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdflang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/compiler-wrapper-1.0-r533h4sr4uzpv32pv2w4ootpawmxmmgf/libexec/spack/rocmcc/amdflang" CACHE PATH "")
 
 else()
 
@@ -82,13 +82,15 @@ set(ENABLE_HIP ON CACHE BOOL "")
 
 set(ROCM_ROOT_DIR "/opt/rocm-6.4.3" CACHE PATH "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -lompstub -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "ompstub" CACHE STRING "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
 #------------------------------------------------
 
-set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
@@ -96,21 +98,21 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/llvm-amdgpu-6.4.3" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/llvm-amdgpu-6.4.3" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-cxdq4qnoptjq6lry5asb2bqodvm3zjig" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-oxqhr2ybswpnzt74f4iritx263ji3uqy" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-gkcg2u6vl5yur7gvigiut76ckzxo4fry" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-xwok5jck2jjg76k4575wkzgyvgopipz2" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-wb7u6epuww3tretkcto7jhq2i7pffimg" CACHE PATH "")
 
 set(LUA_DIR "${TPL_ROOT}/lua-5.4.8-lsey5vgxvpqf5j3xbrlzswrizuwm65vh" CACHE PATH "")
 
-set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-5r3ukxt2ewfn2geqge37ea2fxd7kfixh" CACHE PATH "")
+set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-i5stpeet653njjadpjsekbvxlqkng2zn" CACHE PATH "")
 
-set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-n4zr37loo2okonovcswffexwi5mbxnxh" CACHE PATH "")
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-hpevb7stqsg6dltp3t2tcnzzps7tgywb" CACHE PATH "")
 
 # OPENCASCADE not built
 
@@ -118,7 +120,7 @@ set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-cbxp6kv6rm4f7oeczuhbplm3yb3zxb6z" CACHE P
 
 set(CALIPER_DIR "${TPL_ROOT}/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-sos5uklbsgaycb776a2ufcyje4y24yls" CACHE PATH "")
 
-set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-k6gr5qtzupytbr5kq2e73qesltauiqcl" CACHE PATH "")
+set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-j7my6ilwzwzvbaxzscbvishmj5mgyxnz" CACHE PATH "")
 
 # scr not built
 
@@ -148,12 +150,12 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/._view/ywmag65dnysd7p4dhlmcoaaqqxfzgz5a
 
 set(PY_NANOBIND_DIR "${TPL_ROOT}/py-nanobind-2.7.0-3nchqpyclgle5w56it23ozl4ttbnrfjd/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/py-pytest-9.0.0-dn2hwdtaqec2dkxtx7bnvykyxacfdagj/lib/python3.13/site-packages" CACHE PATH "")
 
 set(PY_NUMPY_DIR "${TPL_ROOT}/py-numpy-2.4.2-t7cvohiksz7deeldwxrtqfmahcvanapb/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/py-pluggy-1.6.0-27aoz44dedjxa6j6r6cavpqyqmpknidb/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/py-pluggy-1.6.0-27aoz44dedjxa6j6r6cavpqyqmpknidb/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_10_15_33_36/none-none/py-iniconfig-2.1.0-7rty7n4wq6kxxrzflm7wbxqzhhc6ph7q/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_13_17/none-none/py-iniconfig-2.1.0-7rty7n4wq6kxxrzflm7wbxqzhhc6ph7q/lib/python3.13/site-packages" CACHE PATH "")
 
 

--- a/host-configs/tuolumne-toss_4_x86_64_ib_cray-cce@20.0.0_hip.cmake
+++ b/host-configs/tuolumne-toss_4_x86_64_ib_cray-cce@20.0.0_hip.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/blt-0.7.1-af45hpsxdxploxhqqi4irjmy4vz2omqx;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/c2c-1.8.0-cpdkv2uxkhs3qmzqakt4sht3vuiucdwt;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-wytd46zvuquxg2rqf3zec5ldbmjeaat6;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/conduit-0.9.5-pbrrhvrsmnewby6q3u35ceppt5fxme2p;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/lua-5.4.8-y6z3polqakbuhn6nh6muri3rjxqmiioa;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/mfem-4.9.0-2r7wws3ojiqvv6vk7y3ki443xke656sf;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/py-nanobind-2.7.0-ieb2bzuz435ydpyiq2uj36yyqjbrffml;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/adiak-0.4.0-lzgexbo5qyzepgju2acyy6d2qft443tb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/libunwind-1.8.3-zvteigxlopfo5tkdr2n2pglgosg42bah;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/hdf5-1.8.23-to3lvqwzxrqzad65zbvnbtvyt4k63uxe;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/parmetis-4.0.3-bajtzsmahjg2wvcjzo5gfb2hr5oj2elc;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/py-numpy-2.4.2-xw5ysy75zfqlalmbmtl5phd2qip43hlo;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/hypre-2.27.0-knkmxfbf3xcut2wmamjsmhrqf7u7xmi7;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-y7uevzr5oi5eansgqfm4ppgcdkvnni6t;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/umpire-2025.12.0-ke2uxlxkv74lvrhujuzh3ktf3c6e7lfb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/zlib-1.3.1-f3sdiqmy2whvmdn2fxeol3k7oqwouays;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/metis-5.1.0-v4d34x7btqhotktvu5bgk4iwk6h2lumb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-a755kudv24eiizq4thcs2ca2fj7vy65x;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/fmt-11.0.2-nzzmwf4nofjv46yeugehjo64opvfbbzr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cce-tce/cce-20.0.0;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.32-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/blt-0.7.1-af45hpsxdxploxhqqi4irjmy4vz2omqx;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/c2c-1.8.0-cpdkv2uxkhs3qmzqakt4sht3vuiucdwt;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-wytd46zvuquxg2rqf3zec5ldbmjeaat6;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/conduit-0.9.5-pbrrhvrsmnewby6q3u35ceppt5fxme2p;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/lua-5.4.8-y6z3polqakbuhn6nh6muri3rjxqmiioa;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/mfem-4.9.0-wpbbiugqvdw7bylkmyyf2quazcoptzah;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/py-nanobind-2.7.0-ieb2bzuz435ydpyiq2uj36yyqjbrffml;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/adiak-0.4.0-lzgexbo5qyzepgju2acyy6d2qft443tb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/libunwind-1.8.3-zvteigxlopfo5tkdr2n2pglgosg42bah;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/hdf5-1.8.23-to3lvqwzxrqzad65zbvnbtvyt4k63uxe;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/parmetis-4.0.3-bajtzsmahjg2wvcjzo5gfb2hr5oj2elc;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/py-numpy-2.4.2-xw5ysy75zfqlalmbmtl5phd2qip43hlo;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/hypre-2.27.0-knkmxfbf3xcut2wmamjsmhrqf7u7xmi7;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-z3eibnxgk3jeplydlcizrhurpibzqzqv;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/umpire-2025.12.0-eqokbtuch3pwifb225w2i3rrft5ddcgv;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/zlib-1.3.1-f3sdiqmy2whvmdn2fxeol3k7oqwouays;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/metis-5.1.0-v4d34x7btqhotktvu5bgk4iwk6h2lumb;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-eplsxvli6nnrgdl4l3hl7cizytginfhp;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/fmt-11.0.2-nzzmwf4nofjv46yeugehjo64opvfbbzr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cce-tce/cce-20.0.0;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.32-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/axom-develop-csdbligyshk6zb3emr4vn5sjrrnbtobj/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/axom-develop-csdbligyshk6zb3emr4vn5sjrrnbtobj/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/axom-develop-xz7g7s5cdkdr6lixuhs23vyuqqodocrg/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/axom-develop-xz7g7s5cdkdr6lixuhs23vyuqqodocrg/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/axom-develop-csdbligyshk6zb3emr4vn5sjrrnbtobj/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0/axom-develop-csdbligyshk6zb3emr4vn5sjrrnbtobj/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/axom-develop-xz7g7s5cdkdr6lixuhs23vyuqqodocrg/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0/axom-develop-xz7g7s5cdkdr6lixuhs23vyuqqodocrg/lib64;;/opt/cray/pe/cce/20.0.0/cce/x86_64/lib;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -21,11 +21,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/cce/craycc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/cce/craycc" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/cce/case-insensitive/crayCC" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/cce/case-insensitive/crayCC" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/cce/crayftn" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/cce/crayftn" CACHE PATH "")
 
 else()
 
@@ -84,37 +84,41 @@ set(ENABLE_HIP ON CACHE BOOL "")
 
 set(ROCM_ROOT_DIR "/opt/rocm-6.4.3" CACHE PATH "")
 
-set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "unwind" CACHE STRING "")
+set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "unwind;ompstub" CACHE STRING "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.32/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.32/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -lompstub -L/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -Wl,-rpath,/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.32/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.32/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -L/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -Wl,-rpath,/opt/cray/pe/cce/20.0.0/cce/x86_64/lib -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
 #------------------------------------------------
 
-set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
+
+set(BLT_OPENMP_COMPILE_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-fopenmp>" CACHE STRING "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)")
+
+set(BLT_OPENMP_LINK_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-fopenmp>" CACHE STRING "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)")
 
 #------------------------------------------------------------------------------
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/cce-20.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/cce-20.0.0" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-pbrrhvrsmnewby6q3u35ceppt5fxme2p" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-cpdkv2uxkhs3qmzqakt4sht3vuiucdwt" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-2r7wws3ojiqvv6vk7y3ki443xke656sf" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-wpbbiugqvdw7bylkmyyf2quazcoptzah" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-to3lvqwzxrqzad65zbvnbtvyt4k63uxe" CACHE PATH "")
 
 set(LUA_DIR "${TPL_ROOT}/lua-5.4.8-y6z3polqakbuhn6nh6muri3rjxqmiioa" CACHE PATH "")
 
-set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-y7uevzr5oi5eansgqfm4ppgcdkvnni6t" CACHE PATH "")
+set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-z3eibnxgk3jeplydlcizrhurpibzqzqv" CACHE PATH "")
 
-set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-ke2uxlxkv74lvrhujuzh3ktf3c6e7lfb" CACHE PATH "")
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-eqokbtuch3pwifb225w2i3rrft5ddcgv" CACHE PATH "")
 
 # OPENCASCADE not built
 
@@ -122,7 +126,7 @@ set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-lzgexbo5qyzepgju2acyy6d2qft443tb" CACHE P
 
 set(CALIPER_DIR "${TPL_ROOT}/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-wytd46zvuquxg2rqf3zec5ldbmjeaat6" CACHE PATH "")
 
-set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-a755kudv24eiizq4thcs2ca2fj7vy65x" CACHE PATH "")
+set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-eplsxvli6nnrgdl4l3hl7cizytginfhp" CACHE PATH "")
 
 # scr not built
 
@@ -152,12 +156,12 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/._view/ywmag65dnysd7p4dhlmcoaaqqxfzgz5a
 
 set(PY_NANOBIND_DIR "${TPL_ROOT}/py-nanobind-2.7.0-ieb2bzuz435ydpyiq2uj36yyqjbrffml/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5/lib/python3.13/site-packages" CACHE PATH "")
 
 set(PY_NUMPY_DIR "${TPL_ROOT}/py-numpy-2.4.2-xw5ysy75zfqlalmbmtl5phd2qip43hlo/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/py-pluggy-1.6.0-n4ojmtqyawxz6gipk64pup3ahwz3xqpu/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/py-pluggy-1.6.0-n4ojmtqyawxz6gipk64pup3ahwz3xqpu/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/py-iniconfig-2.1.0-lf3yvch65se22jr7b5unfoxtse4ugkrk/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/py-iniconfig-2.1.0-lf3yvch65se22jr7b5unfoxtse4ugkrk/lib/python3.13/site-packages" CACHE PATH "")
 
 

--- a/host-configs/tuolumne-toss_4_x86_64_ib_cray-llvm-amdgpu@6.3.1_hip.cmake
+++ b/host-configs/tuolumne-toss_4_x86_64_ib_cray-llvm-amdgpu@6.3.1_hip.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/adiak-0.4.0-c4srnrz5apjetx74dt6xjah63o3a7xcx;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/blt-0.7.1-kzmxfjvxm4drr2qhspckvwee6mrlc3e5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/c2c-1.8.0-lm64gc55hpxilmtsw7geirys3q4wacu5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/conduit-0.9.5-wswspowegvp5byl5inc2cikljzkcqg64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/lua-5.4.8-j7ngytniswhoa536kqfzarcraarkicbm;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/mfem-4.9.0-wetr3wqseqqobjb7be3uzrecpfewq4mr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/py-nanobind-2.7.0-q2kwozph3gwgfyjnx43jp2gkbaghwxoj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/hdf5-1.8.23-rb4cjthx4wz4wnpaizwmm2jycijdthqm;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/parmetis-4.0.3-ng66tt5fmjyfoiuuxyl4rxqv4ompawmd;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/py-numpy-2.4.2-zcxbrxijjc3miotq6s3kq446afrgycuu;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/hypre-2.27.0-6m2jwyzqbksxgmdznvh54ytysxyme7jy;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-okzhosj73rts33dgatxh4daotairh5jn;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/umpire-2025.12.0-of6o5lgmd6jgjqfwat2sbyngieagkeco;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/zlib-1.3.1-5w5muvpvct6uruxrddscblsiyizl3uoc;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/metis-5.1.0-4punmdkye6rovr3u7ph7bgj66qim77du;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-74scmbkik6ye7bunoclw46d6zrcfwgha;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/fmt-11.0.2-opsfnufdiedpfpob5wgbvhcrhyhzfkaq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/opt/rocm-6.3.1" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/adiak-0.4.0-c4srnrz5apjetx74dt6xjah63o3a7xcx;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/blt-0.7.1-kzmxfjvxm4drr2qhspckvwee6mrlc3e5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/c2c-1.8.0-lm64gc55hpxilmtsw7geirys3q4wacu5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/conduit-0.9.5-wswspowegvp5byl5inc2cikljzkcqg64;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/lua-5.4.8-j7ngytniswhoa536kqfzarcraarkicbm;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/mfem-4.9.0-xwg5un3mlbeog3j4voeltekra43ix3ga;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/py-nanobind-2.7.0-q2kwozph3gwgfyjnx43jp2gkbaghwxoj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/hdf5-1.8.23-rb4cjthx4wz4wnpaizwmm2jycijdthqm;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/parmetis-4.0.3-ng66tt5fmjyfoiuuxyl4rxqv4ompawmd;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/py-numpy-2.4.2-zcxbrxijjc3miotq6s3kq446afrgycuu;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/hypre-2.27.0-6m2jwyzqbksxgmdznvh54ytysxyme7jy;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-wcyqyggju4u2ornjjnamgdgfbqjrzsir;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/umpire-2025.12.0-5w5v22edixuttxwueaagiobpjzn5mcgr;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/zlib-1.3.1-5w5muvpvct6uruxrddscblsiyizl3uoc;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/metis-5.1.0-4punmdkye6rovr3u7ph7bgj66qim77du;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-jnalmgzqx2nn2afq4gwhyjda3u6yub7y;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/fmt-11.0.2-opsfnufdiedpfpob5wgbvhcrhyhzfkaq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.3.1;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.3.1;/opt/rocm-6.3.1;/opt/rocm-6.3.1" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/axom-develop-xoswouqk3ppxzuxtgegijd3kdoqlkvfe/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/axom-develop-xoswouqk3ppxzuxtgegijd3kdoqlkvfe/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/axom-develop-qrojk4ujrhd5b734s2yc73n5u3kvcgqa/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/axom-develop-qrojk4ujrhd5b734s2yc73n5u3kvcgqa/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/axom-develop-xoswouqk3ppxzuxtgegijd3kdoqlkvfe/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1/axom-develop-xoswouqk3ppxzuxtgegijd3kdoqlkvfe/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/axom-develop-qrojk4ujrhd5b734s2yc73n5u3kvcgqa/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1/axom-develop-qrojk4ujrhd5b734s2yc73n5u3kvcgqa/lib64;;/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -21,11 +21,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdflang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdflang" CACHE PATH "")
 
 else()
 
@@ -82,13 +82,15 @@ set(ENABLE_HIP ON CACHE BOOL "")
 
 set(ROCM_ROOT_DIR "/opt/rocm-6.3.1" CACHE PATH "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.3.1/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.3.1/lib/llvm/lib -L/opt/rocm-6.3.1/lib -Wl,-rpath,/opt/rocm-6.3.1/lib -lpgmath -lompstub -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "ompstub" CACHE STRING "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.3.1/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.3.1/lib/llvm/lib -L/opt/rocm-6.3.1/lib -Wl,-rpath,/opt/rocm-6.3.1/lib -lpgmath -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
 #------------------------------------------------
 
-set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
@@ -96,21 +98,21 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.3.1" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-wswspowegvp5byl5inc2cikljzkcqg64" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-lm64gc55hpxilmtsw7geirys3q4wacu5" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-wetr3wqseqqobjb7be3uzrecpfewq4mr" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-xwg5un3mlbeog3j4voeltekra43ix3ga" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-rb4cjthx4wz4wnpaizwmm2jycijdthqm" CACHE PATH "")
 
 set(LUA_DIR "${TPL_ROOT}/lua-5.4.8-j7ngytniswhoa536kqfzarcraarkicbm" CACHE PATH "")
 
-set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-okzhosj73rts33dgatxh4daotairh5jn" CACHE PATH "")
+set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-wcyqyggju4u2ornjjnamgdgfbqjrzsir" CACHE PATH "")
 
-set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-of6o5lgmd6jgjqfwat2sbyngieagkeco" CACHE PATH "")
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-5w5v22edixuttxwueaagiobpjzn5mcgr" CACHE PATH "")
 
 # OPENCASCADE not built
 
@@ -118,7 +120,7 @@ set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-c4srnrz5apjetx74dt6xjah63o3a7xcx" CACHE P
 
 # CALIPER not built
 
-set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-74scmbkik6ye7bunoclw46d6zrcfwgha" CACHE PATH "")
+set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-jnalmgzqx2nn2afq4gwhyjda3u6yub7y" CACHE PATH "")
 
 # scr not built
 
@@ -148,12 +150,12 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/._view/ywmag65dnysd7p4dhlmcoaaqqxfzgz5a
 
 set(PY_NANOBIND_DIR "${TPL_ROOT}/py-nanobind-2.7.0-q2kwozph3gwgfyjnx43jp2gkbaghwxoj/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5/lib/python3.13/site-packages" CACHE PATH "")
 
 set(PY_NUMPY_DIR "${TPL_ROOT}/py-numpy-2.4.2-zcxbrxijjc3miotq6s3kq446afrgycuu/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/py-pluggy-1.6.0-n4ojmtqyawxz6gipk64pup3ahwz3xqpu/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/py-pluggy-1.6.0-n4ojmtqyawxz6gipk64pup3ahwz3xqpu/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/py-iniconfig-2.1.0-lf3yvch65se22jr7b5unfoxtse4ugkrk/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/py-iniconfig-2.1.0-lf3yvch65se22jr7b5unfoxtse4ugkrk/lib/python3.13/site-packages" CACHE PATH "")
 
 

--- a/host-configs/tuolumne-toss_4_x86_64_ib_cray-llvm-amdgpu@6.4.3_hip.cmake
+++ b/host-configs/tuolumne-toss_4_x86_64_ib_cray-llvm-amdgpu@6.4.3_hip.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/blt-0.7.1-4kxhk7nbuiv5oh2ymh7sdimnmor36hmo;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/c2c-1.8.0-h5kio7nseyazg4pzgvj4kxanb3plhbxm;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-rmlwpdacdtpzf4u72ctyroj72soqzf3f;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/conduit-0.9.5-zqywrasos2vbears5hvdwxhulm3xox6q;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/lua-5.4.8-gp4kdewsy4uiy6flsx342lgogcm7fym2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/mfem-4.9.0-g6vxdlgc7spurcdacgc6e5245iu2hyiw;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/py-nanobind-2.7.0-2kp35jcpb73xuujvcz6kmg4q2npek4gg;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/adiak-0.4.0-cropyu42jr4q6k3zar6mkma6gc2vp6tk;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/libunwind-1.8.3-plszp43gkd75kzjcvge3qxrtb6j2budl;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/hdf5-1.8.23-mgic2kxojd5zeivhaz473zzmzrg3gdqe;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/parmetis-4.0.3-hd2qoczrh3vw3ejm6msitqdgecjk7xwe;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/py-numpy-2.4.2-a3mo27shjtpliwewbm5cci2kf37crrab;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/hypre-2.27.0-4nrl5egspbxmnkpzfym5udby6uruhn3i;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-wavyomm5hzyjf3xuyr33txmnspvxveei;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/umpire-2025.12.0-4oytcvf556ksil4hsthjt4b5y4wdpaxw;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/zlib-1.3.1-slqujeue3l44x3pgqbu7e2pw3lh2mj5i;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/metis-5.1.0-puzeddu6ufhz5vpxnw7i3i2i6slsvuuj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-3gtldngru7bva2reuel5iabyytw5fmdf;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/fmt-11.0.2-lpnox72rqcneew5hucwzq4nmms4at525;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/blt-0.7.1-4kxhk7nbuiv5oh2ymh7sdimnmor36hmo;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/c2c-1.8.0-h5kio7nseyazg4pzgvj4kxanb3plhbxm;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-rmlwpdacdtpzf4u72ctyroj72soqzf3f;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/conduit-0.9.5-zqywrasos2vbears5hvdwxhulm3xox6q;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/lua-5.4.8-gp4kdewsy4uiy6flsx342lgogcm7fym2;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/mfem-4.9.0-6cgokeizyrjzsjzwmtf35p5jvhnws7n5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/py-nanobind-2.7.0-2kp35jcpb73xuujvcz6kmg4q2npek4gg;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/adiak-0.4.0-cropyu42jr4q6k3zar6mkma6gc2vp6tk;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/libunwind-1.8.3-plszp43gkd75kzjcvge3qxrtb6j2budl;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/hdf5-1.8.23-mgic2kxojd5zeivhaz473zzmzrg3gdqe;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/parmetis-4.0.3-hd2qoczrh3vw3ejm6msitqdgecjk7xwe;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/py-numpy-2.4.2-a3mo27shjtpliwewbm5cci2kf37crrab;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/hypre-2.27.0-4nrl5egspbxmnkpzfym5udby6uruhn3i;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-v74yskgcb7tsgho6bdush5jdlbigkttf;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/umpire-2025.12.0-jft5rocv5ev4b57f3664b2kagyfjra2e;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/zlib-1.3.1-slqujeue3l44x3pgqbu7e2pw3lh2mj5i;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/metis-5.1.0-puzeddu6ufhz5vpxnw7i3i2i6slsvuuj;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-zadbjpethvnlhpqwx6vm6ahphk42a4gq;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/fmt-11.0.2-lpnox72rqcneew5hucwzq4nmms4at525;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/shroud/public/toss_4_x86_64_ib_cray/shroud-0.14.0;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/usr/tce/packages/cmake/cmake-3.29.2;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/gcc-13.3.1/cppcheck-2.18.0-n6kdcwtwlrc3u3t47t7gokpyd4h6mc27;/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.29-rocmcc-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/doxygen-1.15.0;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/usr/tce/packages/rocmcc/rocmcc-6.4.3-magic/llvm;/opt/rocm-6.4.3;/collab/usr/gapps/axom/devtools/toss_4_x86_64_ib_cray/2026_02_17_15_20_25/view/python-3.13.11;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3;/opt/rocm-6.4.3" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/axom-develop-cdngjuz7ffr3goroyietece35jivxnkv/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/axom-develop-cdngjuz7ffr3goroyietece35jivxnkv/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/axom-develop-i4n5ay2l5l2hludfn6z5vyvfwk57p6hx/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/axom-develop-i4n5ay2l5l2hludfn6z5vyvfwk57p6hx/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/axom-develop-cdngjuz7ffr3goroyietece35jivxnkv/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3/axom-develop-cdngjuz7ffr3goroyietece35jivxnkv/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/axom-develop-i4n5ay2l5l2hludfn6z5vyvfwk57p6hx/lib;/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3/axom-develop-i4n5ay2l5l2hludfn6z5vyvfwk57p6hx/lib64;;/opt/rh/gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -21,11 +21,11 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdclang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdflang" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/compiler-wrapper-1.0-pypgv2tridcfdliq3cjhfecu23umxcjd/libexec/spack/rocmcc/amdflang" CACHE PATH "")
 
 else()
 
@@ -82,13 +82,15 @@ set(ENABLE_HIP ON CACHE BOOL "")
 
 set(ROCM_ROOT_DIR "/opt/rocm-6.4.3" CACHE PATH "")
 
-set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -lompstub -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
+set(BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE "ompstub" CACHE STRING "")
+
+set(CMAKE_EXE_LINKER_FLAGS "-lxpmem -L/opt/cray/pe/mpich/8.1.29/gtl/lib -Wl,-rpath,/opt/cray/pe/mpich/8.1.29/gtl/lib -lmpi_gtl_hsa -L/opt/rocm-6.4.3/lib/llvm/lib -Wl,-rpath,/opt/rocm-6.4.3/lib/llvm/lib -L/opt/rocm-6.4.3/lib -Wl,-rpath,/opt/rocm-6.4.3/lib -lpgmath -Wl,--disable-new-dtags -lflang -lflangrti -lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr " CACHE STRING "")
 
 #------------------------------------------------
 # Hardware Specifics
 #------------------------------------------------
 
-set(ENABLE_OPENMP OFF CACHE BOOL "")
+set(ENABLE_OPENMP ON CACHE BOOL "")
 
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
@@ -96,21 +98,21 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/llvm-amdgpu-6.4.3" CACHE PATH "")
+set(TPL_ROOT "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/llvm-amdgpu-6.4.3" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-zqywrasos2vbears5hvdwxhulm3xox6q" CACHE PATH "")
 
 set(C2C_DIR "${TPL_ROOT}/c2c-1.8.0-h5kio7nseyazg4pzgvj4kxanb3plhbxm" CACHE PATH "")
 
-set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-g6vxdlgc7spurcdacgc6e5245iu2hyiw" CACHE PATH "")
+set(MFEM_DIR "${TPL_ROOT}/mfem-4.9.0-6cgokeizyrjzsjzwmtf35p5jvhnws7n5" CACHE PATH "")
 
 set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.23-mgic2kxojd5zeivhaz473zzmzrg3gdqe" CACHE PATH "")
 
 set(LUA_DIR "${TPL_ROOT}/lua-5.4.8-gp4kdewsy4uiy6flsx342lgogcm7fym2" CACHE PATH "")
 
-set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-wavyomm5hzyjf3xuyr33txmnspvxveei" CACHE PATH "")
+set(RAJA_DIR "${TPL_ROOT}/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-v74yskgcb7tsgho6bdush5jdlbigkttf" CACHE PATH "")
 
-set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-4oytcvf556ksil4hsthjt4b5y4wdpaxw" CACHE PATH "")
+set(UMPIRE_DIR "${TPL_ROOT}/umpire-2025.12.0-jft5rocv5ev4b57f3664b2kagyfjra2e" CACHE PATH "")
 
 # OPENCASCADE not built
 
@@ -118,7 +120,7 @@ set(ADIAK_DIR "${TPL_ROOT}/adiak-0.4.0-cropyu42jr4q6k3zar6mkma6gc2vp6tk" CACHE P
 
 set(CALIPER_DIR "${TPL_ROOT}/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-rmlwpdacdtpzf4u72ctyroj72soqzf3f" CACHE PATH "")
 
-set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-3gtldngru7bva2reuel5iabyytw5fmdf" CACHE PATH "")
+set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-zadbjpethvnlhpqwx6vm6ahphk42a4gq" CACHE PATH "")
 
 # scr not built
 
@@ -148,12 +150,12 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/._view/ywmag65dnysd7p4dhlmcoaaqqxfzgz5a
 
 set(PY_NANOBIND_DIR "${TPL_ROOT}/py-nanobind-2.7.0-2kp35jcpb73xuujvcz6kmg4q2npek4gg/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PYTEST_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/py-pytest-9.0.0-jfdwo62b3p36blpm54gvocrcj6afccv5/lib/python3.13/site-packages" CACHE PATH "")
 
 set(PY_NUMPY_DIR "${TPL_ROOT}/py-numpy-2.4.2-a3mo27shjtpliwewbm5cci2kf37crrab/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/py-pluggy-1.6.0-n4ojmtqyawxz6gipk64pup3ahwz3xqpu/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_PLUGGY_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/py-pluggy-1.6.0-n4ojmtqyawxz6gipk64pup3ahwz3xqpu/lib/python3.13/site-packages" CACHE PATH "")
 
-set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_03_11_08_14_36/none-none/py-iniconfig-2.1.0-lf3yvch65se22jr7b5unfoxtse4ugkrk/lib/python3.13/site-packages" CACHE PATH "")
+set(PY_INICONFIG_DIR "/usr/WS1/axom/libs/toss_4_x86_64_ib_cray/2026_04_20_15_15_19/none-none/py-iniconfig-2.1.0-lf3yvch65se22jr7b5unfoxtse4ugkrk/lib/python3.13/site-packages" CACHE PATH "")
 
 

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -335,7 +335,6 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
     # Sidre requires conduit_blueprint_mpi.hpp
     conflicts("^conduit@:0.6.0", when="@0.5.0:")
 
-    conflicts("+openmp", when="+rocm")
     conflicts("+cuda", when="+rocm")
 
     conflicts("~raja", when="+cuda")

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -435,7 +435,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_option("CMAKE_CUDA_SEPARABLE_COMPILATION", True))
 
             # CUDA_FLAGS
-            cudaflags = "${CMAKE_CUDA_FLAGS} -restrict --expt-extended-lambda "
+            cudaflags = "${CMAKE_CUDA_FLAGS} -restrict --expt-extended-lambda --expt-relaxed-constexpr "
 
             # Pass through any cxxflags to the host compiler via nvcc's Xcompiler flag
             host_cxx_flags = spec.compiler_flags["cxxflags"]

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -580,7 +580,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
                 "Fortran>:-fopenmp>"
             )
 
-            description = "Different OpenMP compile & link flags between HIP and CXX compilers"
+            description = "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)"
             entries.append(
                 cmake_cache_string("BLT_OPENMP_COMPILE_FLAGS", openmp_gen_exp, description)
             )

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -479,7 +479,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             # Only amdclang requires this path; cray compiler fails if this is included
             if spec.satisfies("%llvm-amdgpu"):
                 hip_link_flags += "-L{0}/lib -Wl,-rpath,{0}/lib ".format(rocm_root)
-            hip_link_flags += "-lpgmath -lompstub "
+            hip_link_flags += "-lpgmath "
 
             # Fixes for mpi for rocm until wrapper paths are fixed
             # These flags are already part of the wrapped compilers on TOSS4 systems
@@ -493,11 +493,22 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
                                         self.spec.compiler.version
                                     )
 
-            # Remove extra link library for crayftn
-            if spec.satisfies("+fortran") and self.is_fortran_compiler("crayftn"):
-                entries.append(
-                    cmake_cache_string("BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE", "unwind")
-                )
+            if spec.satisfies("+fortran"):
+                link_remove_list = ""
+
+                # Remove extra link library for crayftn
+                if self.is_fortran_compiler("crayftn"):
+                    link_remove_list += "unwind "
+
+                # Remove injected OpenMP stub library
+                if spec.satisfies("+openmp"):
+                    link_remove_list += "ompstub"
+
+                if link_remove_list:
+                    entries.append(
+                        cmake_cache_string("BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE",
+                                           link_remove_list)
+                    )
 
             # Additional libraries for TOSS4
             hip_link_flags += "-lamdhip64 -lhsakmt -lhsa-runtime64 -lamd_comgr "
@@ -553,6 +564,25 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             )
 
             description = "Different OpenMP linker flag between CXX and Fortran"
+            entries.append(
+                cmake_cache_string("BLT_OPENMP_LINK_FLAGS", openmp_gen_exp, description)
+            )
+
+        if (
+            spec.satisfies("+openmp")
+            and spec.satisfies("+rocm")
+            and self.spec.satisfies("%cce")
+        ):
+            openmp_gen_exp = (
+                "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:"
+                "-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:"
+                "Fortran>:-fopenmp>"
+            )
+
+            description = "Different OpenMP compile & link flags between HIP and CXX compilers"
+            entries.append(
+                cmake_cache_string("BLT_OPENMP_COMPILE_FLAGS", openmp_gen_exp, description)
+            )
             entries.append(
                 cmake_cache_string("BLT_OPENMP_LINK_FLAGS", openmp_gen_exp, description)
             )

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -78,6 +78,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     version("main", branch="main")
     version("develop", branch="develop")
+    version("0.14.0", tag="v0.14.0", commit="146c8c15386a810791b7ab5c7fcb288cadea6151")
     version("0.13.0", tag="v0.13.0", commit="d00f6c66ef390ad746ae840f1074d982513611ac")
     version("0.12.0", tag="v0.12.0", commit="297544010a3dfb98145a1a85f09f9c648c00a18c")
     version("0.11.0", tag="v0.11.0", commit="685960486aa55d3a74a821ee02f6d9d9a3e67ab1")

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -494,20 +494,21 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
                                     )
 
             if spec.satisfies("+fortran"):
-                link_remove_list = ""
+                link_remove_list = []
 
                 # Remove extra link library for crayftn
                 if self.is_fortran_compiler("crayftn"):
-                    link_remove_list += "unwind "
+                    link_remove_list += ["unwind"]
 
                 # Remove injected OpenMP stub library
                 if spec.satisfies("+openmp"):
-                    link_remove_list += "ompstub"
+                    link_remove_list += ["ompstub"]
 
                 if link_remove_list:
                     entries.append(
-                        cmake_cache_string("BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE",
-                                           link_remove_list)
+                        cmake_cache_string(
+                            "BLT_CMAKE_IMPLICIT_LINK_LIBRARIES_EXCLUDE", ";".join(link_remove_list)
+                        )
                     )
 
             # Additional libraries for TOSS4

--- a/scripts/spack/specs.json
+++ b/scripts/spack/specs.json
@@ -38,9 +38,9 @@
     "__comment__":"# -Wno-int-conversion flag needed for building HDF5",
     "__comment__":"# caliper disabled for rocm@6.3.1, fails to compile",
     "toss_4_x86_64_ib_cray":
-    [ "+python+devtools~openmp+mfem+c2c+adiak+caliper+rocm amdgpu_target=gfx942,gfx90a %rocm_6_4_3 ^hip@6.4.3 ^hipblas@6.4.3 ^hipsparse@6.4.3 ^hsa-rocr-dev@6.4.3 ^rocprim@6.4.3 ^mfem+raja+umpire ^raja~openmp+rocm ^umpire~openmp+rocm ^hdf5 cflags=-Wno-int-conversion",
-      "+python+devtools~openmp+mfem+c2c+adiak~caliper+rocm amdgpu_target=gfx942,gfx90a %rocm_6_3_1 ^hip@6.3.1 ^hipblas@6.3.1 ^hipsparse@6.3.1 ^hsa-rocr-dev@6.3.1 ^rocprim@6.3.1 ^mfem+raja+umpire ^raja~openmp+rocm ^umpire~openmp+rocm ^hdf5 cflags=-Wno-int-conversion",
-      "+python+devtools~openmp+mfem+c2c+adiak+caliper+rocm amdgpu_target=gfx942,gfx90a %cce_20 ^hip@6.4.3 ^hipblas@6.4.3 ^hipsparse@6.4.3 ^hsa-rocr-dev@6.4.3  ^rocprim@6.4.3 ^caliper~shared ^mfem+raja+umpire ^raja~openmp+rocm ^umpire~openmp+rocm ^hdf5 cflags=-Wno-int-conversion" ],
+    [ "+python+devtools+openmp+mfem+c2c+adiak+caliper+rocm amdgpu_target=gfx942,gfx90a %rocm_6_4_3 ^hip@6.4.3 ^hipblas@6.4.3 ^hipsparse@6.4.3 ^hsa-rocr-dev@6.4.3 ^rocprim@6.4.3 ^mfem+raja+umpire ^raja+openmp+rocm ^umpire+openmp+rocm ^hdf5 cflags=-Wno-int-conversion",
+      "+python+devtools+openmp+mfem+c2c+adiak~caliper+rocm amdgpu_target=gfx942,gfx90a %rocm_6_3_1 ^hip@6.3.1 ^hipblas@6.3.1 ^hipsparse@6.3.1 ^hsa-rocr-dev@6.3.1 ^rocprim@6.3.1 ^mfem+raja+umpire ^raja+openmp+rocm ^umpire+openmp+rocm ^hdf5 cflags=-Wno-int-conversion",
+      "+python+devtools+openmp+mfem+c2c+adiak+caliper+rocm amdgpu_target=gfx942,gfx90a %cce_20 ^hip@6.4.3 ^hipblas@6.4.3 ^hipsparse@6.4.3 ^hsa-rocr-dev@6.4.3  ^rocprim@6.4.3 ^caliper~shared ^mfem+raja+umpire ^raja+openmp+rocm ^umpire+openmp+rocm ^hdf5 cflags=-Wno-int-conversion" ],
 
     "darwin-x86_64":
     [ "+python+devtools+mfem %clang@9.0.0" ]

--- a/src/axom/quest/tests/quest_gwn_methods.cpp
+++ b/src/axom/quest/tests/quest_gwn_methods.cpp
@@ -338,7 +338,7 @@ TEST(quest_gwn_methods, mfem_mesh_linearization)
   check_mfem_mesh_linearization<axom::SEQ_EXEC>();
 }
 
-#if defined AXOM_USE_OPENMP && defined(AXOM_USE_RAJA)
+#if defined(AXOM_USE_OPENMP) && defined(AXOM_USE_RAJA)
 TEST(quest_gwn_methods, mfem_mesh_linearization_omp)
 {
   check_mfem_mesh_linearization<axom::OMP_EXEC>();

--- a/src/cmake/AxomConfig.cmake
+++ b/src/cmake/AxomConfig.cmake
@@ -16,7 +16,9 @@ message(STATUS "Configuring Axom version ${AXOM_VERSION_FULL}")
 ## check for vars of the form <DEP>_FOUND or ENABLE_<DEP>
 set(TPL_DEPS ADIAK C2C CALIPER CAMP CLI11 CONDUIT CUDA FMT HIP HDF5 LUA MFEM MPI OPENMP OPENCASCADE RAJA SCR SOL SPARSEHASH UMPIRE ZLIB)
 foreach(dep ${TPL_DEPS})
-    if( ${dep}_FOUND OR ENABLE_${dep} )
+    if( (DEFINED ENABLE_${dep} AND ENABLE_${dep})
+        OR
+        (NOT DEFINED ENABLE_${dep} AND ${dep}_FOUND))
         set(AXOM_USE_${dep} TRUE  )
     endif()
 endforeach()

--- a/src/cmake/AxomConfig.cmake
+++ b/src/cmake/AxomConfig.cmake
@@ -12,8 +12,25 @@ message(STATUS "Configuring Axom version ${AXOM_VERSION_FULL}")
 
 
 ## Add a definition to the generated config file for each library dependency
-## (optional and built-in) that we might need to know about in the code. We
-## check for vars of the form <DEP>_FOUND or ENABLE_<DEP>
+## (optional and built-in) that we might need to know about in the code.
+##
+## We check for vars of the form <DEP>_FOUND or ENABLE_<DEP>:
+##   ENABLE_<DEP> = ON      && <DEP>_FOUND = TRUE    --> AXOM_USE_<DEP> defined
+##   ENABLE_<DEP> = ON      && <DEP>_FOUND = FALSE   --> AXOM_USE_<DEP> defined
+##   ENABLE_<DEP> = ON      && <DEP>_FOUND undefined --> AXOM_USE_<DEP> defined
+##   ENABLE_<DEP> = OFF     && <DEP>_FOUND = TRUE    --> AXOM_USE_<DEP> undefined
+##   ENABLE_<DEP> = OFF     && <DEP>_FOUND = FALSE   --> AXOM_USE_<DEP> undefined
+##   ENABLE_<DEP> = OFF     && <DEP>_FOUND undefined --> AXOM_USE_<DEP> undefined
+##   ENABLE_<DEP> undefined && <DEP>_FOUND = TRUE    --> AXOM_USE_<DEP> defined
+##   ENABLE_<DEP> undefined && <DEP>_FOUND = FALSE   --> AXOM_USE_<DEP> undefined
+##   ENABLE_<DEP> undefined && <DEP>_FOUND undefined --> AXOM_USE_<DEP> undefined
+##
+## Checks first if ENABLE_<DEP> is defined ON or OFF to determine if Axom
+## will be configured with or without the dependency.
+## Allows Axom to be configured without a dependency, even when <DEP>_FOUND
+## is defined by that dependency's find_package().
+## If ENABLE_<DEP> is undefined, Axom checks if <DEP>_FOUND is a true value.
+##
 set(TPL_DEPS ADIAK C2C CALIPER CAMP CLI11 CONDUIT CUDA FMT HIP HDF5 LUA MFEM MPI OPENMP OPENCASCADE RAJA SCR SOL SPARSEHASH UMPIRE ZLIB)
 foreach(dep ${TPL_DEPS})
     if( (DEFINED ENABLE_${dep} AND ENABLE_${dep})

--- a/src/examples/radiuss_tutorial/host-config.cmake.in
+++ b/src/examples/radiuss_tutorial/host-config.cmake.in
@@ -58,6 +58,13 @@ if(ENABLE_HIP)
   # Add optimization flag workaround for Debug builds with cray compiler
   if(CMAKE_CXX_COMPILER MATCHES "crayCC")
     set(CMAKE_CXX_FLAGS_DEBUG           "-O1 -g -DNDEBUG"           CACHE STRING "")
+
+    if(ENABLE_OPENMP)
+      set(BLT_OPENMP_COMPILE_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-fopenmp>" CACHE STRING "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)")
+
+      set(BLT_OPENMP_LINK_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-fopenmp>" CACHE STRING "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)")
+    endif()
+
   endif()
   set(CMAKE_HIP_COMPILER        "@CMAKE_HIP_COMPILER@"        CACHE PATH "")
   set(ROCM_PATH                 "@ROCM_PATH@"                 CACHE PATH "")

--- a/src/examples/shaping_tutorial/host-config.cmake.in
+++ b/src/examples/shaping_tutorial/host-config.cmake.in
@@ -58,6 +58,12 @@ if(ENABLE_HIP)
   # Add optimization flag workaround for Debug builds with cray compiler
   if(CMAKE_CXX_COMPILER MATCHES "crayCC")
     set(CMAKE_CXX_FLAGS_DEBUG           "-O1 -g -DNDEBUG"           CACHE STRING "")
+
+    if(ENABLE_OPENMP)
+      set(BLT_OPENMP_COMPILE_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-fopenmp>" CACHE STRING "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)")
+
+      set(BLT_OPENMP_LINK_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-fopenmp>" CACHE STRING "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)")
+    endif()
   endif()
   set(CMAKE_HIP_COMPILER        "@CMAKE_HIP_COMPILER@"        CACHE PATH "")
   set(ROCM_PATH                 "@ROCM_PATH@"                 CACHE PATH "")


### PR DESCRIPTION
This PR:
- Fixes spack configuration to allow `+openmp+rocm`
  - Removes problematic flag `-lompstub` , which has executables link against a "stub" OpenMP installation. The observed behavior was raja kernels with an OpenMP `omp_exec` policy became effectively no-ops. No errors were observed during compiling or linking.

EDIT: Added `--expt-relaxed-constexpr` to `CMAKE_CUDA_FLAGS` to reduce constexpr cuda warnings.

Addresses #1843

Related Spack PR: spack/spack-packages#4421