### PR TITLE
Fix more cuda warnings

### DIFF
--- a/host-configs/matrix-toss_4_x86_64_ib-gcc@13.3.1_cuda.cmake
+++ b/host-configs/matrix-toss_4_x86_64_ib-gcc@13.3.1_cuda.cmake
@@ -81,7 +81,7 @@ set(ENABLE_CUDA ON CACHE BOOL "")
 
 set(CMAKE_CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "")
 
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -restrict --expt-extended-lambda " CACHE STRING "" FORCE)
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -restrict --expt-extended-lambda --expt-relaxed-constexpr " CACHE STRING "" FORCE)
 
 # nvcc does not like gtest's 'pthreads' flag
 

--- a/host-configs/matrix-toss_4_x86_64_ib-llvm@19.1.3_cuda.cmake
+++ b/host-configs/matrix-toss_4_x86_64_ib-llvm@19.1.3_cuda.cmake
@@ -83,7 +83,7 @@ set(ENABLE_CUDA ON CACHE BOOL "")
 
 set(CMAKE_CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "")
 
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -restrict --expt-extended-lambda " CACHE STRING "" FORCE)
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -restrict --expt-extended-lambda --expt-relaxed-constexpr " CACHE STRING "" FORCE)
 
 # nvcc does not like gtest's 'pthreads' flag
 

--- a/src/axom/core/IteratorBase.hpp
+++ b/src/axom/core/IteratorBase.hpp
@@ -54,6 +54,7 @@ class IteratorBase
   static_assert(std::is_integral<PosType>::value, "PosType must be integral");
 
 protected:
+  AXOM_HOST_DEVICE
   IteratorBase() : m_pos(PosType()) { }
 
   AXOM_HOST_DEVICE

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -64,6 +64,28 @@ inline void flatmap_get_value(T key, U& out)
   out = key;
 }
 
+struct FlatMapHostStringHash
+{
+  using argument_type = std::string;
+  using result_type = axom::IndexType;
+
+  AXOM_HOST_DEVICE result_type operator()(const std::string& key) const
+  {
+#if defined(AXOM_DEVICE_CODE)
+    AXOM_UNUSED_VAR(key);
+    return 0;
+#else
+    uint64_t hash = static_cast<uint64_t>(std::hash<std::string> {}(key));
+    hash *= 0xbf58476d1ce4e5b9ULL;
+    hash ^= hash >> 32;
+    hash *= 0x94d049bb133111ebULL;
+    hash ^= hash >> 32;
+    hash *= 0x94d049bb133111ebULL;
+    return static_cast<result_type>(hash);
+#endif
+  }
+};
+
 template <typename FlatMapType>
 class core_flatmap : public ::testing::Test
 {
@@ -102,8 +124,10 @@ public:
 
 using MyTypes = ::testing::Types<axom::FlatMap<int, double>,
                                  axom::FlatMap<int, std::string>,
-                                 axom::FlatMap<std::string, double>,
-                                 axom::FlatMap<std::string, std::string>>;
+                                 axom::FlatMap<std::string, double, FlatMapHostStringHash>,
+                                 axom::FlatMap<std::string,
+                                               std::string,
+                                               FlatMapHostStringHash>>;
 
 TYPED_TEST_SUITE(core_flatmap, MyTypes);
 

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -125,9 +125,7 @@ public:
 using MyTypes = ::testing::Types<axom::FlatMap<int, double>,
                                  axom::FlatMap<int, std::string>,
                                  axom::FlatMap<std::string, double, FlatMapHostStringHash>,
-                                 axom::FlatMap<std::string,
-                                               std::string,
-                                               FlatMapHostStringHash>>;
+                                 axom::FlatMap<std::string, std::string, FlatMapHostStringHash>>;
 
 TYPED_TEST_SUITE(core_flatmap, MyTypes);
 

--- a/src/axom/klee/tests/klee_geometry_operators.cpp
+++ b/src/axom/klee/tests/klee_geometry_operators.cpp
@@ -19,12 +19,21 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
-namespace axom
-{
-namespace klee
-{
-namespace
-{
+namespace klee = axom::klee;
+namespace numerics = axom::numerics;
+namespace primal = axom::primal;
+namespace test = axom::klee::test;
+
+using klee::CompositeOperator;
+using klee::Dimensions;
+using klee::GeometryOperatorVisitor;
+using klee::LengthUnit;
+using klee::Rotation;
+using klee::Scale;
+using klee::SliceOperator;
+using klee::TransformableGeometryProperties;
+using klee::Translation;
+using klee::UnitConverter;
 using test::affine;
 using test::AlmostEqMatrix;
 using test::AlmostEqPoint;
@@ -42,6 +51,8 @@ using ::testing::Return;
 using primal::Point3D;
 using primal::Vector3D;
 
+namespace
+{
 template <typename ColumnVector>
 ColumnVector operator*(const numerics::Matrix<double> &matrix, const ColumnVector &rhs)
 {
@@ -50,7 +61,7 @@ ColumnVector operator*(const numerics::Matrix<double> &matrix, const ColumnVecto
     throw std::logic_error("Can't multiply entities of this size");
   }
   ColumnVector result;
-  matrix_vector_multiply(matrix, rhs.data(), result.data());
+  numerics::matrix_vector_multiply(matrix, rhs.data(), result.data());
   return result;
 }
 
@@ -69,6 +80,7 @@ primal::Point<double, 4> affinePoint(const Point3D &point3d)
 }
 
 Dimensions ALL_DIMS[] = {Dimensions::Two, Dimensions::Three};
+}  // namespace
 
 class MockVisitor : public GeometryOperatorVisitor
 {
@@ -401,6 +413,3 @@ TEST(Slice, accept)
   EXPECT_CALL(visitor, visit(Matcher<const SliceOperator &>(Ref(slice))));
   slice.accept(visitor);
 }
-}  // namespace
-}  // namespace klee
-}  // namespace axom

--- a/src/axom/klee/tests/klee_geometry_operators_io.cpp
+++ b/src/axom/klee/tests/klee_geometry_operators_io.cpp
@@ -19,14 +19,30 @@
 #include <memory>
 #include <unordered_map>
 
-namespace axom
-{
-namespace klee
-{
-namespace internal
-{
 namespace
 {
+namespace inlet = axom::inlet;
+namespace internal = axom::klee::internal;
+namespace klee = axom::klee;
+namespace primal = axom::primal;
+namespace sidre = axom::sidre;
+namespace test = axom::klee::test;
+
+using axom::Path;
+using internal::GeometryOperatorData;
+using internal::NamedOperatorMap;
+using internal::NamedOperatorMapData;
+using klee::CompositeOperator;
+using klee::Dimensions;
+using klee::GeometryOperator;
+using klee::KleeError;
+using klee::LengthUnit;
+using klee::Rotation;
+using klee::Scale;
+using klee::SliceOperator;
+using klee::TransformableGeometryProperties;
+using klee::Translation;
+using klee::UnitConverter;
 using primal::Point3D;
 using primal::Vector3D;
 using test::AlmostEqMatrix;
@@ -189,6 +205,7 @@ SliceOperator make_slice(Point3D origin,
 {
   return SliceOperator {origin, normal, up, startProperties};
 }
+}  // namespace
 
 TEST(GeometryOperatorsIO, readMultipleOperatorsIncluded)
 {
@@ -853,11 +870,6 @@ TEST(GeometryOperatorsIO, readNamedOperators_ref)
   auto referencedTranslation = copyOperator<Translation>(referencedOperator.getOperators()[0]);
   EXPECT_THAT(referencedTranslation.getOffset(), AlmostEqVector(Vector3D {10, 20, 0}));
 }
-
-}  // namespace
-}  // namespace internal
-}  // namespace klee
-}  // namespace axom
 
 int main(int argc, char *argv[])
 {

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -17,23 +17,34 @@
 #include <fstream>
 #include <sstream>
 
-namespace axom
-{
-namespace klee
-{
-namespace
-{
+namespace klee = axom::klee;
+namespace inlet = axom::inlet;
+namespace test = axom::klee::test;
+namespace primal = axom::primal;
+
+using klee::CompositeOperator;
+using klee::Dimensions;
+using klee::KleeError;
+using klee::LengthUnit;
+using klee::Rotation;
+using klee::ShapeSet;
+using klee::SliceOperator;
+using klee::TransformableGeometryProperties;
+using klee::Translation;
 using primal::Vector3D;
 using test::AlmostEqVector;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Truly;
 
+namespace
+{
 ShapeSet readShapeSetFromString(const std::string &input)
 {
   std::istringstream istream(input);
-  return readShapeSet(istream);
+  return klee::readShapeSet(istream);
 }
+}  // namespace
 
 TEST(IOTest, readShapeSet_noShapes)
 {
@@ -271,7 +282,7 @@ TEST(IOTest, readShapeSet_file)
   fout << fileContents;
   fout.close();
 
-  auto shapeSet = readShapeSet(fileName);
+  auto shapeSet = klee::readShapeSet(fileName);
   EXPECT_EQ(1u, shapeSet.getShapes().size());
   EXPECT_EQ("testFile.yaml", shapeSet.getPath());
 }
@@ -652,11 +663,6 @@ TEST(IOTest, readShapeSet_namedGeometryOperators)
   ASSERT_NE(translation, nullptr);
   EXPECT_THAT(translation->getOffset(), AlmostEqVector(Vector3D {10, 20, 0}));
 }
-
-}  // namespace
-}  // namespace klee
-}  // namespace axom
-
 int main(int argc, char *argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/axom/klee/tests/klee_shape.cpp
+++ b/src/axom/klee/tests/klee_shape.cpp
@@ -10,10 +10,14 @@
 
 #include "gtest/gtest.h"
 
-namespace axom
-{
-namespace klee
-{
+namespace klee = axom::klee;
+
+using klee::Dimensions;
+using klee::Geometry;
+using klee::LengthUnit;
+using klee::Shape;
+using klee::TransformableGeometryProperties;
+
 namespace
 {
 Geometry createTestGeometry()
@@ -26,6 +30,7 @@ Geometry createTestGeometry()
                    "test path",
                    nullptr};
 }
+}  // namespace
 
 TEST(ShapeTest, replaces_no_lists_given)
 {
@@ -54,6 +59,3 @@ TEST(ShapeTest, both_replacement_lists_given)
   EXPECT_THROW(Shape("name", "material", {"replaced"}, {"not replaced"}, createTestGeometry()),
                std::logic_error);
 }
-}  // namespace
-}  // namespace klee
-}  // namespace axom

--- a/src/axom/klee/tests/klee_shape_set.cpp
+++ b/src/axom/klee/tests/klee_shape_set.cpp
@@ -10,12 +10,10 @@
 
 #include <stdexcept>
 
-namespace axom
-{
-namespace klee
-{
-namespace
-{
+namespace klee = axom::klee;
+
+using klee::Dimensions;
+using klee::ShapeSet;
 
 TEST(ShapeSetTest, dimensions_getAndSet)
 {
@@ -38,7 +36,3 @@ TEST(ShapeSetTest, dimensions_getAndSet)
     EXPECT_EQ(Dimensions::Three, shapeSet.getDimensions());
   }
 }
-
-}  // namespace
-}  // namespace klee
-}  // namespace axom

--- a/src/axom/primal/tests/primal_cone.cpp
+++ b/src/axom/primal/tests/primal_cone.cpp
@@ -29,6 +29,7 @@ double cone_volume(double baseRad, double topRad, double len)
 {
   return M_PI / 3 * len * (baseRad * baseRad + baseRad * topRad + topRad * topRad);
 }
+} /* end anonymous namespace */
 
 //------------------------------------------------------------------------------
 TEST(primal_cone, default_constructor)
@@ -110,8 +111,6 @@ TEST(primal_cone, assignment_operator)
   EXPECT_EQ(coneA.getBaseCenter(), coneB.getBaseCenter());
   EXPECT_EQ(coneA.volume(), coneB.volume());
 }
-
-} /* end anonymous namespace */
 
 //------------------------------------------------------------------------------
 int main(int argc, char* argv[])

--- a/src/axom/quest/DiscreteShape.cpp
+++ b/src/axom/quest/DiscreteShape.cpp
@@ -576,22 +576,21 @@ void DiscreteShape::createRepresentationOfSphere()
 
   auto nodeCoordsView = nodeCoords.view();
   auto connectivityView = connectivity.view();
-  axom::for_all<axom::SEQ_EXEC>(
-    octCount,
-    AXOM_LAMBDA(axom::IndexType octIdx) {
-      TetType tetsInOct[TETS_PER_OCT];
-      axom::primal::split(octs[octIdx], tetsInOct);
-      for(int iTet = 0; iTet < TETS_PER_OCT; ++iTet)
+  for(axom::IndexType octIdx = 0; octIdx < octCount; ++octIdx)
+  {
+    TetType tetsInOct[TETS_PER_OCT];
+    axom::primal::split(octs[octIdx], tetsInOct);
+    for(int iTet = 0; iTet < TETS_PER_OCT; ++iTet)
+    {
+      axom::IndexType tetIdx = octIdx * TETS_PER_OCT + iTet;
+      for(int iNode = 0; iNode < NODES_PER_TET; ++iNode)
       {
-        axom::IndexType tetIdx = octIdx * TETS_PER_OCT + iTet;
-        for(int iNode = 0; iNode < NODES_PER_TET; ++iNode)
-        {
-          axom::IndexType nodeIdx = tetIdx * NODES_PER_TET + iNode;
-          nodeCoordsView[nodeIdx] = tetsInOct[iTet][iNode];
-          connectivityView[tetIdx][iNode] = nodeIdx;
-        }
+        axom::IndexType nodeIdx = tetIdx * NODES_PER_TET + iNode;
+        nodeCoordsView[nodeIdx] = tetsInOct[iTet][iNode];
+        connectivityView[tetIdx][iNode] = nodeIdx;
       }
-    });
+    }
+  }
 
   TetMesh* tetMesh = nullptr;
   if(m_sidreGroup != nullptr)
@@ -632,18 +631,17 @@ void DiscreteShape::createRepresentationOfSOR()
   numerics::Matrix<double> rotate = sorAxisRotMatrix(sorGeom.getSorDirection());
   const auto& translate = sorGeom.getSorOriginCoords();
   auto octsView = octs.view();
-  axom::for_all<axom::SEQ_EXEC>(
-    octCount,
-    AXOM_LAMBDA(axom::IndexType iOct) {
-      auto& oct = octsView[iOct];
-      for(int iVert = 0; iVert < OctType::NUM_VERTS; ++iVert)
-      {
-        auto& newCoords = oct[iVert];
-        auto oldCoords = newCoords;
-        numerics::matrix_vector_multiply(rotate, oldCoords.data(), newCoords.data());
-        newCoords.array() += translate.array();
-      }
-    });
+  for(axom::IndexType iOct = 0; iOct < octCount; ++iOct)
+  {
+    auto& oct = octsView[iOct];
+    for(int iVert = 0; iVert < OctType::NUM_VERTS; ++iVert)
+    {
+      auto& newCoords = oct[iVert];
+      auto oldCoords = newCoords;
+      numerics::matrix_vector_multiply(rotate, oldCoords.data(), newCoords.data());
+      newCoords.array() += translate.array();
+    }
+  }
 
   // Dump discretized octs as a tet mesh
   //

--- a/src/axom/quest/detail/clipping/SORClipper.hpp
+++ b/src/axom/quest/detail/clipping/SORClipper.hpp
@@ -33,6 +33,8 @@ namespace experimental
 class SORClipper : public MeshClipperStrategy
 {
 public:
+  using MeshClipperStrategy::specializedClipCells;
+
   /*!
    * @brief Constructor.
    *

--- a/src/axom/quest/detail/clipping/TetMeshClipper.cpp
+++ b/src/axom/quest/detail/clipping/TetMeshClipper.cpp
@@ -736,7 +736,7 @@ void TetMeshClipper::checkTetOrientations(conduit::Node& connNode,
       {
         if(fixOrientation)
         {
-          std::swap(connArray(iTet, 2), connArray(iTet, 3));
+          axom::utilities::swap(connArray(iTet, 2), connArray(iTet, 3));
         }
         else
         {

--- a/src/axom/quest/detail/clipping/TetMeshClipper.cpp
+++ b/src/axom/quest/detail/clipping/TetMeshClipper.cpp
@@ -792,12 +792,12 @@ void TetMeshClipper::transformCoordset()
   axom::ArrayView<double> xV(coordset.fetch_existing("values/x").as_double_ptr(), count);
   axom::ArrayView<double> yV(coordset.fetch_existing("values/y").as_double_ptr(), count);
   axom::ArrayView<double> zV(coordset.fetch_existing("values/z").as_double_ptr(), count);
-  axom::for_all<axom::SEQ_EXEC>(
-    count,
-    AXOM_LAMBDA(axom::IndexType i) {
-      transformer.transform(xV[i], yV[i], zV[i]);
-      m_tetMeshBb.addPoint(Point3DType {xV[i], yV[i], zV[i]});
-    });
+  const axom::IndexType numPts = static_cast<axom::IndexType>(count);
+  for(axom::IndexType i = 0; i < numPts; ++i)
+  {
+    transformer.transform(xV[i], yV[i], zV[i]);
+    m_tetMeshBb.addPoint(Point3DType {xV[i], yV[i], zV[i]});
+  }
   m_tetMesh.fetch_existing("topologies")
     .fetch_existing(m_topoName)
     .fetch_existing("coordset")

--- a/src/axom/quest/examples/shaping_driver.cpp
+++ b/src/axom/quest/examples/shaping_driver.cpp
@@ -46,6 +46,28 @@ namespace sidre = axom::sidre;
 using VolFracSampling = quest::shaping::VolFracSampling;
 using SamplingMethod = quest::SamplingShaper::SamplingMethod;
 
+namespace
+{
+using Point2D = primal::Point<double, 2>;
+using Point3D = primal::Point<double, 3>;
+
+struct AxisymmetricProjector32
+{
+  AXOM_HOST_DEVICE Point2D operator()(Point3D pt) const
+  {
+    const double& x = pt[0];
+    const double& y = pt[1];
+    const double& z = pt[2];
+    return Point2D {z, sqrt(x * x + y * y)};
+  }
+};
+
+struct Projector23
+{
+  AXOM_HOST_DEVICE Point3D operator()(Point2D pt) const { return Point3D {pt[0], pt[1], 0.}; }
+};
+}  // namespace
+
 //------------------------------------------------------------------------------
 
 /// Struct to help choose our shaping method: sampling or intersection for now
@@ -574,20 +596,11 @@ int main(int argc, char** argv)
     // register point projectors
     if(shapingDC.GetMesh()->Dimension() == 3)
     {
-      samplingShaper->setPointProjector32([](primal::Point<double, 3> pt) {
-        const double& x = pt[0];
-        const double& y = pt[1];
-        const double& z = pt[2];
-        return primal::Point<double, 2> {z, sqrt(x * x + y * y)};
-      });
+      samplingShaper->setPointProjector32(AxisymmetricProjector32 {});
     }
     else if(shapingDC.GetMesh()->Dimension() == 2)
     {
-      samplingShaper->setPointProjector23([](primal::Point<double, 2> pt) {
-        const double& x = pt[0];
-        const double& y = pt[1];
-        return primal::Point<double, 3> {x, y, 0.};
-      });
+      samplingShaper->setPointProjector23(Projector23 {});
     }
   }
 

--- a/src/axom/quest/io/STLWriter.cpp
+++ b/src/axom/quest/io/STLWriter.cpp
@@ -108,13 +108,10 @@ IndexType STLWriter::getNumberOfTriangles() const
   }
   else if(m_mesh->getDimension() == 3)
   {
-    axom::ReduceSum<axom::SEQ_EXEC, axom::IndexType> ntri_reduce(0);
-    axom::mint::for_all_faces<axom::SEQ_EXEC, axom::mint::xargs::nodeids>(
-      m_mesh,
-      AXOM_LAMBDA(IndexType AXOM_UNUSED_PARAM(faceID),
-                  const IndexType *AXOM_UNUSED_PARAM(nodes),
-                  IndexType N) { ntri_reduce += (N - 2); });
-    ntri = ntri_reduce.get();
+    for(IndexType faceId = 0; faceId < m_mesh->getNumberOfFaces(); faceId++)
+    {
+      ntri += (m_mesh->getNumberOfFaceNodes(faceId) - 2);
+    }
   }
   return ntri;
 }
@@ -195,34 +192,30 @@ int STLWriter::write(const mint::Mesh *mesh)
   }
   else
   {
-    // For value capture.
-    std::ofstream *out_ptr = &out;
-    const bool binary = m_binary;
+    axom::Array<axom::IndexType> nodes;
+    for(IndexType faceId = 0; faceId < mesh->getNumberOfFaces(); faceId++)
+    {
+      nodes.resize(mesh->getNumberOfFaceNodes(faceId));
+      const auto nnodes = mesh->getFaceNodeIDs(faceId, nodes.data());
 
-    axom::mint::for_all_faces<axom::SEQ_EXEC, axom::mint::xargs::nodeids>(
-      m_mesh,
-      AXOM_LAMBDA(IndexType AXOM_UNUSED_PARAM(faceID), const IndexType *nodes, IndexType nnodes) {
-        // NOTE: Here in the lambda, we use "mesh" instead of "m_mesh" so we do
-        //       not capture STLWriter's "this" pointer.
+      // Iterate over the face like a triangle fan.
+      double coords[3][3] = {{0., 0., 0.}, {0., 0., 0.}, {0., 0., 0.}};
+      mesh->getNode(nodes[0], coords[0]);
+      const IndexType ntri = nnodes - 2;
+      for(IndexType ti = 0; ti < ntri; ti++)
+      {
+        mesh->getNode(nodes[ti + 1], coords[1]);
+        mesh->getNode(nodes[ti + 2], coords[2]);
 
-        // Iterate over the face like a triangle fan.
-        double coords[3][3] = {{0., 0., 0.}, {0., 0., 0.}, {0., 0., 0.}};
-        mesh->getNode(nodes[0], coords[0]);
-        const IndexType ntri = nnodes - 2;
-        for(IndexType ti = 0; ti < ntri; ti++)
-        {
-          mesh->getNode(nodes[ti + 1], coords[1]);
-          mesh->getNode(nodes[ti + 2], coords[2]);
+        // Compute facet normal.
+        const VectorType A(coords[0], 3);
+        const VectorType B(coords[1], 3);
+        const VectorType C(coords[2], 3);
+        const VectorType N = VectorType::cross_product(B - A, C - A).unitVector();
 
-          // Compute facet normal.
-          const VectorType A(coords[0], 3);
-          const VectorType B(coords[1], 3);
-          const VectorType C(coords[2], 3);
-          const VectorType N = VectorType::cross_product(B - A, C - A).unitVector();
-
-          internal::writeTriangle(*out_ptr, binary, coords, N);
-        }
-      });
+        internal::writeTriangle(out, m_binary, coords, N);
+      }
+    }
   }
 
   if(!m_binary)

--- a/src/axom/quest/tests/quest_sampling_shaper.cpp
+++ b/src/axom/quest/tests/quest_sampling_shaper.cpp
@@ -45,6 +45,9 @@ namespace fs = axom::utilities::filesystem;
 
 namespace
 {
+using Point2D = primal::Point<double, 2>;
+using Point3D = primal::Point<double, 3>;
+
 const std::string unit_circle_contour =
   "piece = circle(origin=(0cm, 0cm), radius=1cm, start=0deg, end=360deg)";
 
@@ -63,6 +66,81 @@ const std::string proe_tet_fmt_str = R"(
 
 // Set the following to true for verbose output and for saving vis files
 constexpr bool very_verbose_output = false;
+
+struct IdentityProjector22
+{
+  AXOM_HOST_DEVICE Point2D operator()(const Point2D& pt) const { return Point2D {pt[0], pt[1]}; }
+};
+
+struct IdentityProjector33
+{
+  AXOM_HOST_DEVICE Point3D operator()(const Point3D& pt) const
+  {
+    return Point3D {pt[0], pt[1], pt[2]};
+  }
+};
+
+struct Projector32
+{
+  AXOM_HOST_DEVICE Point2D operator()(const Point3D& pt) const { return Point2D {pt[0], pt[1]}; }
+};
+
+struct Projector23
+{
+  AXOM_HOST_DEVICE Point3D operator()(const Point2D& pt) const { return Point3D {pt[0], pt[1], 0.}; }
+};
+
+struct ScaleProjector22
+{
+  double scale_a;
+  double scale_b;
+
+  AXOM_HOST_DEVICE Point2D operator()(const Point2D& pt) const
+  {
+    return Point2D {pt[0] / scale_a, pt[1] / scale_b};
+  }
+};
+
+struct ZeroProjector33
+{
+  AXOM_HOST_DEVICE Point3D operator()(const Point3D&) const { return Point3D {0., 0., 0.}; }
+};
+
+struct HalfScaleProjector33
+{
+  AXOM_HOST_DEVICE Point3D operator()(const Point3D& pt) const
+  {
+    return Point3D {pt[0] / 2., pt[1] / 2., pt[2] / 2.};
+  }
+};
+
+struct ZeroProjector32
+{
+  AXOM_HOST_DEVICE Point2D operator()(const Point3D&) const { return Point2D {0., 0.}; }
+};
+
+struct AxisymmetricProjector32
+{
+  AXOM_HOST_DEVICE Point2D operator()(Point3D pt) const
+  {
+    const double& x = pt[0];
+    const double& y = pt[1];
+    const double& z = pt[2];
+    return Point2D {z, sqrt(x * x + y * y)};
+  }
+};
+
+struct PlaneProjector23
+{
+  double z;
+
+  AXOM_HOST_DEVICE Point3D operator()(Point2D pt) const
+  {
+    const double& x = pt[0];
+    const double& y = pt[1];
+    return Point3D {x, y, z};
+  }
+};
 
 // Utility function to slice a tetrahedron along a plane
 primal::Polygon<double, 3> slice(const primal::Tetrahedron<double, 3>& tet,
@@ -624,10 +702,10 @@ shapes:
 
   // check that we can set several projectors in 2D and 3D
   // uses simplest projectors, e.g. identity in 2D and 3D
-  this->m_shaper->setPointProjector33([](const Point3D& pt) { return Point3D {pt[0], pt[1], pt[2]}; });
-  this->m_shaper->setPointProjector22([](const Point2D& pt) { return Point2D {pt[0], pt[1]}; });
-  this->m_shaper->setPointProjector32([](const Point3D& pt) { return Point2D {pt[0], pt[1]}; });
-  this->m_shaper->setPointProjector23([](const Point2D& pt) { return Point3D {pt[0], pt[1], 0}; });
+  this->m_shaper->setPointProjector33(IdentityProjector33 {});
+  this->m_shaper->setPointProjector22(IdentityProjector22 {});
+  this->m_shaper->setPointProjector32(Projector32 {});
+  this->m_shaper->setPointProjector23(Projector23 {});
 
   this->runShaping();
 
@@ -676,10 +754,9 @@ shapes:
   // creating an ellipse by scaling input x and y by scale_a and scale_b
   constexpr double scale_a = 3. / 2.;
   constexpr double scale_b = 3. / 4.;
-  this->m_shaper->setPointProjector22(
-    [](const Point2D& pt) { return Point2D {pt[0] / scale_a, pt[1] / scale_b}; });
+  this->m_shaper->setPointProjector22(ScaleProjector22 {scale_a, scale_b});
   // check that we can register another projector that's not used
-  this->m_shaper->setPointProjector33([](const Point3D&) { return Point3D {0., 0.}; });
+  this->m_shaper->setPointProjector33(ZeroProjector33 {});
 
   this->runShaping();
 
@@ -1215,7 +1292,7 @@ shapes:
   this->initializeShaping(shape_file.getPath(), initialGridFunctions);
 
   // set projector from 2D mesh points to 3D query points within STL
-  this->m_shaper->setPointProjector23([](Point2D pt) { return Point3D {pt[0], pt[1], 0.}; });
+  this->m_shaper->setPointProjector23(Projector23 {});
 
   this->m_shaper->setQuadratureOrder(8);
 
@@ -1678,10 +1755,10 @@ shapes:
 
   // check that we can set several projectors in 2D and 3D
   // uses simplest projectors, e.g. identity in 2D and 3D
-  this->m_shaper->setPointProjector33([](const Point3D& pt) { return Point3D {pt[0], pt[1], pt[2]}; });
-  this->m_shaper->setPointProjector22([](const Point2D& pt) { return Point2D {pt[0], pt[1]}; });
-  this->m_shaper->setPointProjector32([](const Point3D& pt) { return Point2D {pt[0], pt[1]}; });
-  this->m_shaper->setPointProjector23([](const Point2D& pt) { return Point3D {pt[0], pt[1], 0}; });
+  this->m_shaper->setPointProjector33(IdentityProjector33 {});
+  this->m_shaper->setPointProjector22(IdentityProjector22 {});
+  this->m_shaper->setPointProjector32(Projector32 {});
+  this->m_shaper->setPointProjector23(Projector23 {});
 
   this->runShaping();
 
@@ -1731,11 +1808,10 @@ shapes:
   this->initializeShaping(shape_file.getPath());
 
   // scale input points by a factor of 1/2 in each dimension
-  this->m_shaper->setPointProjector33(
-    [](const Point3D& pt) { return Point3D {pt[0] / 2, pt[1] / 2, pt[2] / 2}; });
+  this->m_shaper->setPointProjector33(HalfScaleProjector33 {});
 
   // for good measure, add a 3D->2D projector that will not be used
-  this->m_shaper->setPointProjector32([](const Point3D&) { return Point2D {0, 0}; });
+  this->m_shaper->setPointProjector32(ZeroProjector32 {});
 
   this->runShaping();
 
@@ -1795,12 +1871,7 @@ shapes:
   this->initializeShaping(shape_file.getPath());
 
   // set projector from 3D points to axisymmetric plane
-  this->m_shaper->setPointProjector32([](Point3D pt) {
-    const double& x = pt[0];
-    const double& y = pt[1];
-    const double& z = pt[2];
-    return Point2D {z, sqrt(x * x + y * y)};
-  });
+  this->m_shaper->setPointProjector32(AxisymmetricProjector32 {});
 
   // we need a higher quadrature order to resolve this shape at the (low) testing resolution
   this->m_shaper->setQuadratureOrder(8);
@@ -1874,12 +1945,7 @@ shapes:
   this->initializeShaping(shape_file.getPath());
 
   // set projector from 3D points to axisymmetric plane
-  this->m_shaper->setPointProjector32([](Point3D pt) {
-    const double& x = pt[0];
-    const double& y = pt[1];
-    const double& z = pt[2];
-    return Point2D {z, sqrt(x * x + y * y)};
-  });
+  this->m_shaper->setPointProjector32(AxisymmetricProjector32 {});
 
   // we need a higher quadrature order to resolve this shape at the (low) testing resolution
   this->m_shaper->setQuadratureOrder(8);
@@ -1968,11 +2034,7 @@ shapes:
     SLIC_INFO(axom::fmt::format("Area of intersection polygon: {}", intersectionArea));
 
     // set projector from 2D points to 3-space, z-coord is lambda captured
-    this->m_shaper->setPointProjector23([z](Point2D pt) -> Point3D {
-      const double& x = pt[0];
-      const double& y = pt[1];
-      return Point3D {x, y, z};
-    });
+    this->m_shaper->setPointProjector23(PlaneProjector23 {z});
 
     // we need a higher quadrature order to resolve this shape at the (low) testing resolution
     this->m_shaper->setQuadratureOrder(8);

--- a/src/axom/quest/tests/quest_sampling_shaper.cpp
+++ b/src/axom/quest/tests/quest_sampling_shaper.cpp
@@ -87,7 +87,10 @@ struct Projector32
 
 struct Projector23
 {
-  AXOM_HOST_DEVICE Point3D operator()(const Point2D& pt) const { return Point3D {pt[0], pt[1], 0.}; }
+  AXOM_HOST_DEVICE Point3D operator()(const Point2D& pt) const
+  {
+    return Point3D {pt[0], pt[1], 0.};
+  }
 };
 
 struct ScaleProjector22

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -613,7 +613,7 @@ public:
 #if defined(AXOM_DEBUG)
     if(m_state == TUPLE)
     {
-      DataTypeId arg_id = detail::SidreTT<ScalarType>::id;
+      [[maybe_unused]] DataTypeId arg_id = detail::SidreTT<ScalarType>::id;
       SLIC_CHECK_MSG(arg_id == m_node.dtype().id(),
                      SIDRE_VIEW_LOG_PREPEND << "You are setting a scalar value which has changed "
                                             << " the underlying data type. "
@@ -657,7 +657,7 @@ public:
 #if defined(AXOM_DEBUG)
     if(m_state == TUPLE)
     {
-      DataTypeId arg_id = detail::SidreTT<ScalarType>::id;
+      [[maybe_unused]] DataTypeId arg_id = detail::SidreTT<ScalarType>::id;
       SLIC_CHECK_MSG(arg_id == m_node.dtype().id(),
                      SIDRE_VIEW_LOG_PREPEND << "You are setting a scalar value which has changed "
                                             << " the underlying data type. "

--- a/src/axom/sidre/spio/IOManager.cpp
+++ b/src/axom/sidre/spio/IOManager.cpp
@@ -64,6 +64,31 @@ std::string broadcastString(const std::string& str, MPI_Comm comm, int rank)
   return res;
 }
 
+#ifdef AXOM_USE_HDF5
+inline void checkHDF5Status(herr_t status)
+{
+#ifdef AXOM_DEBUG
+  SLIC_ASSERT(status >= 0);
+#else
+  AXOM_UNUSED_VAR(status);
+#endif
+}
+
+inline void closeHDF5Group(hid_t group_id)
+{
+  checkHDF5Status(H5Gclose(group_id));
+}
+
+inline void flushHDF5File(hid_t file_id)
+{
+  checkHDF5Status(H5Fflush(file_id, H5F_SCOPE_LOCAL));
+}
+
+inline void closeHDF5File(hid_t file_id)
+{
+  checkHDF5Status(H5Fclose(file_id));
+}
+#endif
 }  // end anonymous namespace
 
 namespace axom
@@ -229,15 +254,9 @@ void IOManager::write(sidre::Group* datagroup,
     SLIC_ASSERT(h5_group_id >= 0);
 
     datagroup->save(h5_group_id);
-    herr_t status;
-    AXOM_UNUSED_VAR(status);
-
-    status = H5Gclose(h5_group_id);
-    SLIC_ASSERT(status >= 0);
-    status = H5Fflush(h5_file_id, H5F_SCOPE_LOCAL);
-    SLIC_ASSERT(status >= 0);
-    status = H5Fclose(h5_file_id);
-    SLIC_ASSERT(status >= 0);
+    closeHDF5Group(h5_group_id);
+    flushHDF5File(h5_file_id);
+    closeHDF5File(h5_file_id);
 #else
     SLIC_WARNING("'sidre_hdf5' protocol only available " << "when axom is configured with hdf5");
 #endif /* AXOM_USE_HDF5 */
@@ -380,9 +399,6 @@ void IOManager::loadExternalData(sidre::Group* datagroup, const std::string& roo
   {
     if(m_my_rank < num_groups)
     {
-      herr_t errv;
-      AXOM_UNUSED_VAR(errv);
-
       std::string hdf5_name = getFileNameForRank(file_pattern, root_file, set_id);
 
       hdf5_name = getSCRPath(hdf5_name);
@@ -401,20 +417,14 @@ void IOManager::loadExternalData(sidre::Group* datagroup, const std::string& roo
 
       datagroup->loadExternalData(h5_group_id);
 
-      errv = H5Gclose(h5_group_id);
-      SLIC_ASSERT(errv >= 0);
-
-      errv = H5Fclose(h5_file_id);
-      SLIC_ASSERT(errv >= 0);
+      closeHDF5Group(h5_group_id);
+      closeHDF5File(h5_file_id);
     }
   }
   else
   {
     for(int input_rank = m_my_rank; input_rank < num_groups; input_rank += m_comm_size)
     {
-      herr_t errv;
-      AXOM_UNUSED_VAR(errv);
-
       std::string hdf5_name = getFileNameForRank(file_pattern, root_file, input_rank);
 
       hdf5_name = getSCRPath(hdf5_name);
@@ -436,11 +446,8 @@ void IOManager::loadExternalData(sidre::Group* datagroup, const std::string& roo
 
       one_rank_input->loadExternalData(h5_group_id);
 
-      errv = H5Gclose(h5_group_id);
-      SLIC_ASSERT(errv >= 0);
-
-      errv = H5Fclose(h5_file_id);
-      SLIC_ASSERT(errv >= 0);
+      closeHDF5Group(h5_group_id);
+      closeHDF5File(h5_file_id);
     }
   }
 
@@ -520,9 +527,6 @@ void IOManager::loadExternalData(sidre::Group* parent_group,
     {
       if(m_my_rank < num_groups)
       {
-        herr_t errv;
-        AXOM_UNUSED_VAR(errv);
-
         std::string hdf5_name = getFileNameForRank(file_pattern, root_file, set_id);
 
         hdf5_name = getSCRPath(hdf5_name);
@@ -541,20 +545,14 @@ void IOManager::loadExternalData(sidre::Group* parent_group,
 
         load_group->loadExternalData(h5_group_id, subpath);
 
-        errv = H5Gclose(h5_group_id);
-        SLIC_ASSERT(errv >= 0);
-
-        errv = H5Fclose(h5_file_id);
-        SLIC_ASSERT(errv >= 0);
+        closeHDF5Group(h5_group_id);
+        closeHDF5File(h5_file_id);
       }
     }
     else
     {
       for(int input_rank = m_my_rank; input_rank < num_groups; input_rank += m_comm_size)
       {
-        herr_t errv;
-        AXOM_UNUSED_VAR(errv);
-
         std::string hdf5_name = getFileNameForRank(file_pattern, root_file, input_rank);
 
         hdf5_name = getSCRPath(hdf5_name);
@@ -579,11 +577,8 @@ void IOManager::loadExternalData(sidre::Group* parent_group,
 
         one_rank_input->loadExternalData(h5_group_id, subpath);
 
-        errv = H5Gclose(h5_group_id);
-        SLIC_ASSERT(errv >= 0);
-
-        errv = H5Fclose(h5_file_id);
-        SLIC_ASSERT(errv >= 0);
+        closeHDF5Group(h5_group_id);
+        closeHDF5File(h5_file_id);
       }
     }
   }
@@ -719,9 +714,7 @@ std::string IOManager::getProtocol(const std::string& root_orig)
     if(file_id > 0)
     {
       relay_protocol = "hdf5";
-      herr_t errv = H5Fclose(file_id);
-      AXOM_UNUSED_VAR(errv);
-      SLIC_ASSERT(errv >= 0);
+      closeHDF5File(file_id);
     }
 
     // Restore error output
@@ -852,9 +845,6 @@ void IOManager::readSidreHDF5(sidre::Group* datagroup,
   {
     if(m_my_rank < num_groups)
     {
-      herr_t errv;
-      AXOM_UNUSED_VAR(errv);
-
       std::string hdf5_name = getFileNameForRank(file_pattern, root_file, set_id);
 
       hdf5_name = getSCRPath(hdf5_name);
@@ -872,11 +862,8 @@ void IOManager::readSidreHDF5(sidre::Group* datagroup,
 
       datagroup->load(h5_group_id, "sidre_hdf5", preserve_contents);
 
-      errv = H5Gclose(h5_group_id);
-      SLIC_ASSERT(errv >= 0);
-
-      errv = H5Fclose(h5_file_id);
-      SLIC_ASSERT(errv >= 0);
+      closeHDF5Group(h5_group_id);
+      closeHDF5File(h5_file_id);
     }
   }
   else
@@ -885,9 +872,6 @@ void IOManager::readSidreHDF5(sidre::Group* datagroup,
 
     for(int input_rank = m_my_rank; input_rank < num_groups; input_rank += m_comm_size)
     {
-      herr_t errv;
-      AXOM_UNUSED_VAR(errv);
-
       std::string hdf5_name = getFileNameForRank(file_pattern, root_file, input_rank);
 
       hdf5_name = getSCRPath(hdf5_name);
@@ -908,11 +892,8 @@ void IOManager::readSidreHDF5(sidre::Group* datagroup,
 
       one_rank_input->load(h5_group_id, "sidre_hdf5", preserve_contents);
 
-      errv = H5Gclose(h5_group_id);
-      SLIC_ASSERT(errv >= 0);
-
-      errv = H5Fclose(h5_file_id);
-      SLIC_ASSERT(errv >= 0);
+      closeHDF5Group(h5_group_id);
+      closeHDF5File(h5_file_id);
     }
   }
   (void)m_baton->pass();
@@ -1060,17 +1041,9 @@ void IOManager::writeGroupToRootFile(sidre::Group* group, const std::string& fil
 
   conduit::relay::io::hdf5_write(data_holder, group_id);
 
-  herr_t errv;
-  AXOM_UNUSED_VAR(errv);
-
-  errv = H5Gclose(group_id);
-  SLIC_ASSERT(errv >= 0);
-
-  errv = H5Fflush(root_file_id, H5F_SCOPE_LOCAL);
-  SLIC_ASSERT(errv >= 0);
-
-  errv = H5Fclose(root_file_id);
-  SLIC_ASSERT(errv >= 0);
+  closeHDF5Group(group_id);
+  flushHDF5File(root_file_id);
+  closeHDF5File(root_file_id);
 #else
   AXOM_UNUSED_VAR(group);
   AXOM_UNUSED_VAR(file_name);
@@ -1114,17 +1087,9 @@ void IOManager::writeGroupToRootFileAtPath(sidre::Group* group,
 
   conduit::relay::io::hdf5_write(data_holder, group_id);
 
-  herr_t errv;
-  AXOM_UNUSED_VAR(errv);
-
-  errv = H5Gclose(group_id);
-  SLIC_ASSERT(errv >= 0);
-
-  errv = H5Fflush(root_file_id, H5F_SCOPE_LOCAL);
-  SLIC_ASSERT(errv >= 0);
-
-  errv = H5Fclose(root_file_id);
-  SLIC_ASSERT(errv >= 0);
+  closeHDF5Group(group_id);
+  flushHDF5File(root_file_id);
+  closeHDF5File(root_file_id);
 #else
   AXOM_UNUSED_VAR(group);
   AXOM_UNUSED_VAR(file_name);
@@ -1164,14 +1129,8 @@ void IOManager::writeViewToRootFileAtPath(sidre::View* view,
 
   conduit::relay::io::hdf5_write(data_holder, path_id);
 
-  herr_t errv;
-  AXOM_UNUSED_VAR(errv);
-
-  errv = H5Fflush(root_file_id, H5F_SCOPE_LOCAL);
-  SLIC_ASSERT(errv >= 0);
-
-  errv = H5Fclose(root_file_id);
-  SLIC_ASSERT(errv >= 0);
+  flushHDF5File(root_file_id);
+  closeHDF5File(root_file_id);
 #else
   AXOM_UNUSED_VAR(view);
   AXOM_UNUSED_VAR(file_name);

--- a/src/axom/sidre/spio/IOManager.cpp
+++ b/src/axom/sidre/spio/IOManager.cpp
@@ -67,27 +67,18 @@ std::string broadcastString(const std::string& str, MPI_Comm comm, int rank)
 #ifdef AXOM_USE_HDF5
 inline void checkHDF5Status(herr_t status)
 {
-#ifdef AXOM_DEBUG
+  #ifdef AXOM_DEBUG
   SLIC_ASSERT(status >= 0);
-#else
+  #else
   AXOM_UNUSED_VAR(status);
-#endif
+  #endif
 }
 
-inline void closeHDF5Group(hid_t group_id)
-{
-  checkHDF5Status(H5Gclose(group_id));
-}
+inline void closeHDF5Group(hid_t group_id) { checkHDF5Status(H5Gclose(group_id)); }
 
-inline void flushHDF5File(hid_t file_id)
-{
-  checkHDF5Status(H5Fflush(file_id, H5F_SCOPE_LOCAL));
-}
+inline void flushHDF5File(hid_t file_id) { checkHDF5Status(H5Fflush(file_id, H5F_SCOPE_LOCAL)); }
 
-inline void closeHDF5File(hid_t file_id)
-{
-  checkHDF5Status(H5Fclose(file_id));
-}
+inline void closeHDF5File(hid_t file_id) { checkHDF5Status(H5Fclose(file_id)); }
 #endif
 }  // end anonymous namespace
 

--- a/src/axom/sina/tests/sina_AdiakWriter.cpp
+++ b/src/axom/sina/tests/sina_AdiakWriter.cpp
@@ -25,14 +25,12 @@ extern "C" {
   #include "axom/sina/core/ID.hpp"
   #include "axom/sina/core/Run.hpp"
 
-namespace axom
-{
-namespace sina
-{
-namespace testing
-{
-namespace
-{
+namespace sina = axom::sina;
+
+using sina::ID;
+using sina::IDType;
+using sina::Record;
+using sina::adiakSinaCallback;
 
 using ::testing::DoubleEq;
 using ::testing::ElementsAre;
@@ -163,10 +161,5 @@ TEST_F(AdiakWriterTest, files_list)
   EXPECT_EQ(1, asNode[EXPECTED_FILES_KEY].child(fileListVal2)["tags"].number_of_children());
   EXPECT_EQ(fileListName, asNode[EXPECTED_FILES_KEY].child(fileListVal2)["tags"][0].as_string());
 }
-
-}  // namespace
-}  // namespace testing
-}  // namespace sina
-}  // namespace axom
 
 #endif  // AXOM_USE_ADIAK

--- a/src/axom/sina/tests/sina_AdiakWriter.cpp
+++ b/src/axom/sina/tests/sina_AdiakWriter.cpp
@@ -27,10 +27,10 @@ extern "C" {
 
 namespace sina = axom::sina;
 
+using sina::adiakSinaCallback;
 using sina::ID;
 using sina::IDType;
 using sina::Record;
-using sina::adiakSinaCallback;
 
 using ::testing::DoubleEq;
 using ::testing::ElementsAre;

--- a/src/axom/sina/tests/sina_ConduitUtil.cpp
+++ b/src/axom/sina/tests/sina_ConduitUtil.cpp
@@ -12,14 +12,15 @@
 #include "axom/sina/core/ConduitUtil.hpp"
 #include "axom/sina/tests/SinaMatchers.hpp"
 
-namespace axom
-{
-namespace sina
-{
-namespace testing
-{
-namespace
-{
+namespace sina = axom::sina;
+
+using sina::getOptionalString;
+using sina::getRequiredDouble;
+using sina::getRequiredField;
+using sina::getRequiredString;
+using sina::toDoubleVector;
+using sina::toStringVector;
+using axom::sina::testing::parseJsonValue;
 
 using ::testing::ContainerEq;
 using ::testing::DoubleEq;
@@ -255,8 +256,3 @@ TEST(ConduitUtil, toStringVector_NotListOfStrings)
     EXPECT_THAT(ex.what(), HasSubstr("someName"));
   }
 }
-
-}  // namespace
-}  // namespace testing
-}  // namespace sina
-}  // namespace axom

--- a/src/axom/sina/tests/sina_ConduitUtil.cpp
+++ b/src/axom/sina/tests/sina_ConduitUtil.cpp
@@ -14,13 +14,13 @@
 
 namespace sina = axom::sina;
 
+using axom::sina::testing::parseJsonValue;
 using sina::getOptionalString;
 using sina::getRequiredDouble;
 using sina::getRequiredField;
 using sina::getRequiredString;
 using sina::toDoubleVector;
 using sina::toStringVector;
-using axom::sina::testing::parseJsonValue;
 
 using ::testing::ContainerEq;
 using ::testing::DoubleEq;

--- a/src/axom/sina/tests/sina_Curve.cpp
+++ b/src/axom/sina/tests/sina_Curve.cpp
@@ -13,10 +13,10 @@
 
 namespace sina = axom::sina;
 
-using sina::Curve;
-using sina::addStringsToNode;
 using axom::sina::testing::MatchesJsonMatcher;
 using axom::sina::testing::parseJsonValue;
+using sina::addStringsToNode;
+using sina::Curve;
 
 using ::testing::ContainerEq;
 using ::testing::ElementsAre;

--- a/src/axom/sina/tests/sina_Curve.cpp
+++ b/src/axom/sina/tests/sina_Curve.cpp
@@ -11,14 +11,12 @@
 #include "axom/sina/core/ConduitUtil.hpp"
 #include "axom/sina/tests/SinaMatchers.hpp"
 
-namespace axom
-{
-namespace sina
-{
-namespace testing
-{
-namespace
-{
+namespace sina = axom::sina;
+
+using sina::Curve;
+using sina::addStringsToNode;
+using axom::sina::testing::MatchesJsonMatcher;
+using axom::sina::testing::parseJsonValue;
 
 using ::testing::ContainerEq;
 using ::testing::ElementsAre;
@@ -119,8 +117,3 @@ TEST(Curve, toNode_optionalFields)
     })";
   EXPECT_THAT(curve.toNode(), MatchesJsonMatcher(expected));
 }
-
-}  // namespace
-}  // namespace testing
-}  // namespace sina
-}  // namespace axom

--- a/src/axom/sina/tests/sina_CurveSet.cpp
+++ b/src/axom/sina/tests/sina_CurveSet.cpp
@@ -42,11 +42,15 @@ bool operator==(Curve const &lhs, Curve const &rhs)
     lhs.getTags() == rhs.getTags() && lhs.getValues() == rhs.getValues();
   return r;
 }
+}  // namespace sina
+}  // namespace axom
 
-namespace testing
-{
-namespace
-{
+namespace sina = axom::sina;
+
+using sina::Curve;
+using sina::CurveSet;
+using axom::sina::testing::MatchesJsonMatcher;
+using axom::sina::testing::parseJsonValue;
 
 using ::testing::ContainerEq;
 using ::testing::ElementsAre;
@@ -375,8 +379,3 @@ TEST(CurveSet, customIndependentSortOrder)
   curveSet.applyCustomIndependentCurveOrder(newOrder);
   EXPECT_THAT(curveSet.getOrderedIndependentCurveNames(), ContainerEq(newOrder));
 }
-
-}  // namespace
-}  // namespace testing
-}  // namespace sina
-}  // namespace axom

--- a/src/axom/sina/tests/sina_CurveSet.cpp
+++ b/src/axom/sina/tests/sina_CurveSet.cpp
@@ -47,10 +47,10 @@ bool operator==(Curve const &lhs, Curve const &rhs)
 
 namespace sina = axom::sina;
 
-using sina::Curve;
-using sina::CurveSet;
 using axom::sina::testing::MatchesJsonMatcher;
 using axom::sina::testing::parseJsonValue;
+using sina::Curve;
+using sina::CurveSet;
 
 using ::testing::ContainerEq;
 using ::testing::ElementsAre;

--- a/src/axom/sina/tests/sina_DataHolder.cpp
+++ b/src/axom/sina/tests/sina_DataHolder.cpp
@@ -15,13 +15,13 @@
 
 namespace sina = axom::sina;
 
+using axom::sina::testing::MatchesJsonMatcher;
+using axom::sina::testing::parseJsonValue;
+using sina::addStringsToNode;
 using sina::Curve;
 using sina::CurveSet;
 using sina::DataHolder;
 using sina::Datum;
-using sina::addStringsToNode;
-using axom::sina::testing::MatchesJsonMatcher;
-using axom::sina::testing::parseJsonValue;
 
 using ::testing::Contains;
 using ::testing::DoubleEq;

--- a/src/axom/sina/tests/sina_DataHolder.cpp
+++ b/src/axom/sina/tests/sina_DataHolder.cpp
@@ -13,14 +13,15 @@
 #include "axom/sina/core/DataHolder.hpp"
 #include "axom/sina/tests/SinaMatchers.hpp"
 
-namespace axom
-{
-namespace sina
-{
-namespace testing
-{
-namespace
-{
+namespace sina = axom::sina;
+
+using sina::Curve;
+using sina::CurveSet;
+using sina::DataHolder;
+using sina::Datum;
+using sina::addStringsToNode;
+using axom::sina::testing::MatchesJsonMatcher;
+using axom::sina::testing::parseJsonValue;
 
 using ::testing::Contains;
 using ::testing::DoubleEq;
@@ -311,8 +312,3 @@ TEST(DataHolder, toNode_userDefined)
                                 int_array + userDefined["k3"].dtype().number_of_elements());
   EXPECT_THAT(udef_ints, ElementsAre(1, 2, 3));
 }
-
-}  // namespace
-}  // namespace testing
-}  // namespace sina
-}  // namespace axom

--- a/src/axom/sina/tests/sina_Datum.cpp
+++ b/src/axom/sina/tests/sina_Datum.cpp
@@ -16,9 +16,9 @@
 
 namespace sina = axom::sina;
 
+using sina::addStringsToNode;
 using sina::Datum;
 using sina::ValueType;
-using sina::addStringsToNode;
 
 using ::testing::DoubleEq;
 using ::testing::ElementsAre;

--- a/src/axom/sina/tests/sina_Datum.cpp
+++ b/src/axom/sina/tests/sina_Datum.cpp
@@ -14,14 +14,11 @@
 #include "axom/sina/core/Datum.hpp"
 #include "axom/sina/core/ConduitUtil.hpp"
 
-namespace axom
-{
-namespace sina
-{
-namespace testing
-{
-namespace
-{
+namespace sina = axom::sina;
+
+using sina::Datum;
+using sina::ValueType;
+using sina::addStringsToNode;
 
 using ::testing::DoubleEq;
 using ::testing::ElementsAre;
@@ -189,8 +186,3 @@ TEST(Datum, toJson)
   EXPECT_EQ(scal_list, scal_child_vals);
   EXPECT_EQ(val_list, str_child_vals);
 }
-
-}  // namespace
-}  // namespace testing
-}  // namespace sina
-}  // namespace axom

--- a/src/axom/sina/tests/sina_Document.cpp
+++ b/src/axom/sina/tests/sina_Document.cpp
@@ -34,26 +34,26 @@
 
 namespace sina = axom::sina;
 
+using axom::sina::testing::parseJsonValue;
+using axom::sina::testing::TEST_RECORD_VALUE_KEY;
+using axom::sina::testing::TestRecord;
+using sina::appendDocumentToHDF5;
+using sina::appendDocumentToJson;
+using sina::createRecordLoaderWithAllKnownTypes;
 using sina::Document;
 using sina::File;
+using sina::getRequiredField;
+using sina::getRequiredString;
 using sina::ID;
 using sina::IDType;
+using sina::loadDocument;
 using sina::Protocol;
 using sina::Record;
 using sina::RecordLoader;
 using sina::Relationship;
-using sina::appendDocumentToHDF5;
-using sina::appendDocumentToJson;
-using sina::createRecordLoaderWithAllKnownTypes;
-using sina::getRequiredField;
-using sina::getRequiredString;
-using sina::loadDocument;
 using sina::restoreSlashes;
 using sina::saveDocument;
 using sina::validateAppendDocument;
-using axom::sina::testing::TEST_RECORD_VALUE_KEY;
-using axom::sina::testing::TestRecord;
-using axom::sina::testing::parseJsonValue;
 
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;

--- a/src/axom/sina/tests/sina_Document.cpp
+++ b/src/axom/sina/tests/sina_Document.cpp
@@ -32,14 +32,28 @@
 #include "axom/sina/core/Record.hpp"
 #include "axom/sina/tests/SinaMatchers.hpp"
 
-namespace axom
-{
-namespace sina
-{
-namespace testing
-{
-namespace
-{
+namespace sina = axom::sina;
+
+using sina::Document;
+using sina::File;
+using sina::ID;
+using sina::IDType;
+using sina::Protocol;
+using sina::Record;
+using sina::RecordLoader;
+using sina::Relationship;
+using sina::appendDocumentToHDF5;
+using sina::appendDocumentToJson;
+using sina::createRecordLoaderWithAllKnownTypes;
+using sina::getRequiredField;
+using sina::getRequiredString;
+using sina::loadDocument;
+using sina::restoreSlashes;
+using sina::saveDocument;
+using sina::validateAppendDocument;
+using axom::sina::testing::TEST_RECORD_VALUE_KEY;
+using axom::sina::testing::TestRecord;
+using axom::sina::testing::parseJsonValue;
 
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
@@ -876,7 +890,3 @@ TEST(Document, saveDocument_hdf5)
 }
 
 #endif
-}  // namespace
-}  // namespace testing
-}  // namespace sina
-}  // namespace axom

--- a/src/axom/sina/tests/sina_File.cpp
+++ b/src/axom/sina/tests/sina_File.cpp
@@ -9,29 +9,22 @@
 #include "axom/sina/core/File.hpp"
 #include "axom/sina/core/ConduitUtil.hpp"
 
-namespace axom
-{
-namespace sina
-{
-namespace testing
-{
-namespace
-{
+namespace sina = axom::sina;
 
 char const EXPECTED_MIMETYPE_KEY[] = "mimetype";
 char const EXPECTED_TAGS_KEY[] = "tags";
 
 TEST(File, construct_differentType)
 {
-  File f1 {"from literal"};
-  File f2 {std::string {"from std::string"}};
+  sina::File f1 {"from literal"};
+  sina::File f2 {std::string {"from std::string"}};
   EXPECT_EQ("from literal", f1.getUri());
   EXPECT_EQ("from std::string", f2.getUri());
 }
 
 TEST(File, setMimeType)
 {
-  File file {"the URI"};
+  sina::File file {"the URI"};
   file.setMimeType("mime");
   EXPECT_EQ("the URI", file.getUri());
   EXPECT_EQ("mime", file.getMimeType());
@@ -40,7 +33,7 @@ TEST(File, setMimeType)
 TEST(File, setTags)
 {
   std::vector<std::string> tags = {"these", "are", "tags"};
-  File file {"the URI"};
+  sina::File file {"the URI"};
   file.setTags(tags);
   EXPECT_EQ("the URI", file.getUri());
   EXPECT_EQ(tags, file.getTags());
@@ -50,7 +43,7 @@ TEST(File, create_fromNode_basic)
 {
   std::string uri = "the URI";
   conduit::Node basic_file(conduit::DataType::object());
-  File file {uri, basic_file};
+  sina::File file {uri, basic_file};
   EXPECT_EQ(uri, file.getUri());
   EXPECT_EQ("", file.getMimeType());
   EXPECT_EQ(0, file.getTags().size());
@@ -62,8 +55,8 @@ TEST(File, create_fromNode_complete)
   std::vector<std::string> tags = {"tags", "are", "fun"};
   conduit::Node full_file(conduit::DataType::object());
   full_file[EXPECTED_MIMETYPE_KEY] = "the mime type";
-  addStringsToNode(full_file, EXPECTED_TAGS_KEY, tags);
-  File file {uri, full_file};
+  sina::addStringsToNode(full_file, EXPECTED_TAGS_KEY, tags);
+  sina::File file {uri, full_file};
   EXPECT_EQ(uri, file.getUri());
   EXPECT_EQ("the mime type", file.getMimeType());
   EXPECT_EQ(tags, file.getTags());
@@ -71,7 +64,7 @@ TEST(File, create_fromNode_complete)
 
 TEST(File, toNode_basic)
 {
-  File file {"the URI"};
+  sina::File file {"the URI"};
   auto asNode = file.toNode();
   EXPECT_FALSE(asNode.has_child(EXPECTED_MIMETYPE_KEY));
   EXPECT_FALSE(asNode.has_child(EXPECTED_TAGS_KEY));
@@ -80,15 +73,10 @@ TEST(File, toNode_basic)
 TEST(File, toNode_complete)
 {
   std::vector<std::string> tags = {"these", "are", "tags"};
-  File file {"the URI"};
+  sina::File file {"the URI"};
   file.setMimeType("the mime type");
   file.setTags(tags);
   auto asNode = file.toNode();
   EXPECT_EQ("the mime type", asNode[EXPECTED_MIMETYPE_KEY].as_string());
   EXPECT_EQ(tags, file.getTags());
 }
-
-}  // namespace
-}  // namespace testing
-}  // namespace sina
-}  // namespace axom

--- a/src/axom/sina/tests/sina_ID.cpp
+++ b/src/axom/sina/tests/sina_ID.cpp
@@ -13,14 +13,11 @@
 
 #include "axom/sina/core/ID.hpp"
 
-namespace axom
-{
-namespace sina
-{
-namespace testing
-{
-namespace
-{
+namespace sina = axom::sina;
+namespace internal = axom::sina::internal;
+
+using sina::ID;
+using sina::IDType;
 
 using ::testing::HasSubstr;
 
@@ -104,8 +101,3 @@ TEST(IDField, toNode_global)
   EXPECT_EQ("the id", value["global name"].as_string());
   EXPECT_FALSE(value.has_child("local name"));
 }
-
-}  // namespace
-}  // namespace testing
-}  // namespace sina
-}  // namespace axom

--- a/src/axom/sina/tests/sina_Record.cpp
+++ b/src/axom/sina/tests/sina_Record.cpp
@@ -18,6 +18,12 @@
 
 namespace sina = axom::sina;
 
+using axom::sina::testing::MatchesJsonMatcher;
+using axom::sina::testing::parseJsonValue;
+using axom::sina::testing::TEST_RECORD_VALUE_KEY;
+using axom::sina::testing::TestRecord;
+using sina::addStringsToNode;
+using sina::createRecordLoaderWithAllKnownTypes;
 using sina::Curve;
 using sina::CurveSet;
 using sina::Datum;
@@ -26,13 +32,7 @@ using sina::ID;
 using sina::IDType;
 using sina::Record;
 using sina::RecordLoader;
-using sina::addStringsToNode;
-using sina::createRecordLoaderWithAllKnownTypes;
 using sina::setDefaultCurveOrder;
-using axom::sina::testing::MatchesJsonMatcher;
-using axom::sina::testing::TEST_RECORD_VALUE_KEY;
-using axom::sina::testing::TestRecord;
-using axom::sina::testing::parseJsonValue;
 
 using ::testing::Contains;
 using ::testing::DoubleEq;

--- a/src/axom/sina/tests/sina_Record.cpp
+++ b/src/axom/sina/tests/sina_Record.cpp
@@ -16,14 +16,23 @@
 #include "axom/sina/tests/SinaMatchers.hpp"
 #include "axom/sina/tests/TestRecord.hpp"
 
-namespace axom
-{
-namespace sina
-{
-namespace testing
-{
-namespace
-{
+namespace sina = axom::sina;
+
+using sina::Curve;
+using sina::CurveSet;
+using sina::Datum;
+using sina::File;
+using sina::ID;
+using sina::IDType;
+using sina::Record;
+using sina::RecordLoader;
+using sina::addStringsToNode;
+using sina::createRecordLoaderWithAllKnownTypes;
+using sina::setDefaultCurveOrder;
+using axom::sina::testing::MatchesJsonMatcher;
+using axom::sina::testing::TEST_RECORD_VALUE_KEY;
+using axom::sina::testing::TestRecord;
+using axom::sina::testing::parseJsonValue;
 
 using ::testing::Contains;
 using ::testing::DoubleEq;
@@ -684,8 +693,3 @@ TEST(RecordLoader, createRecordLoaderWithAllKnownTypes)
   RecordLoader loader = createRecordLoaderWithAllKnownTypes();
   EXPECT_TRUE(loader.canLoad("run"));
 }
-
-}  // namespace
-}  // namespace testing
-}  // namespace sina
-}  // namespace axom

--- a/src/axom/sina/tests/sina_Relationship.cpp
+++ b/src/axom/sina/tests/sina_Relationship.cpp
@@ -11,14 +11,11 @@
 
 #include "axom/sina/core/Relationship.hpp"
 
-namespace axom
-{
-namespace sina
-{
-namespace testing
-{
-namespace
-{
+namespace sina = axom::sina;
+
+using sina::ID;
+using sina::IDType;
+using sina::Relationship;
 
 char const EXPECTED_GLOBAL_OBJECT_ID_KEY[] = "object";
 char const EXPECTED_LOCAL_OBJECT_ID_KEY[] = "local_object";
@@ -169,8 +166,3 @@ TEST(Relationship, toNode_globalIds)
   EXPECT_FALSE(asNode.has_child(EXPECTED_LOCAL_SUBJECT_ID_KEY));
   EXPECT_FALSE(asNode.has_child(EXPECTED_LOCAL_OBJECT_ID_KEY));
 }
-
-}  // namespace
-}  // namespace testing
-}  // namespace sina
-}  // namespace axom

--- a/src/axom/sina/tests/sina_Run.cpp
+++ b/src/axom/sina/tests/sina_Run.cpp
@@ -13,10 +13,10 @@
 
 namespace sina = axom::sina;
 
+using sina::addRunLoader;
 using sina::ID;
 using sina::IDType;
 using sina::RecordLoader;
-using sina::addRunLoader;
 
 using ::testing::HasSubstr;
 

--- a/src/axom/sina/tests/sina_Run.cpp
+++ b/src/axom/sina/tests/sina_Run.cpp
@@ -11,14 +11,12 @@
 
 #include "axom/sina/core/Run.hpp"
 
-namespace axom
-{
-namespace sina
-{
-namespace testing
-{
-namespace
-{
+namespace sina = axom::sina;
+
+using sina::ID;
+using sina::IDType;
+using sina::RecordLoader;
+using sina::addRunLoader;
 
 using ::testing::HasSubstr;
 
@@ -103,8 +101,3 @@ TEST(Run, addRunLoader)
   EXPECT_EQ("1.2.3", run->getVersion());
   EXPECT_EQ("jdoe", run->getUser());
 }
-
-}  // namespace
-}  // namespace testing
-}  // namespace sina
-}  // namespace axom

--- a/src/axom/slam/examples/ShockTube.cpp
+++ b/src/axom/slam/examples/ShockTube.cpp
@@ -73,7 +73,7 @@ const double INIT_P_RATIO = 0.5;
 const double INIT_D_RATIO = 0.5;
 
 #ifdef AXOM_DEBUG
-const bool verboseOutput = false;
+[[maybe_unused]] const bool verboseOutput = false;
 #endif
 
 /**

--- a/src/axom/slam/examples/lulesh2.0.3/lulesh-util.cpp
+++ b/src/axom/slam/examples/lulesh2.0.3/lulesh-util.cpp
@@ -298,15 +298,12 @@ namespace slamLulesh {
         << " actual energy at origin was " << locDom.e(ElemId)
         << ". Difference was " << std::fabs(resultCheckMap[gEdge].second - locDom.e(ElemId) ) );
 
-      double diff = std::fabs(resultCheckMap[gEdge].second - locDom.e(ElemId) );
-      double maxFabs = std::max( std::fabs(resultCheckMap[gEdge].second), std::fabs(locDom.e(ElemId) ) );
-      double relMaxFabs = 1.0e-6 * maxFabs;
-      double relMaxFabsWithAbsolute = relMaxFabs + 1.0e-8;
-
-      AXOM_UNUSED_VAR( diff);
-      AXOM_UNUSED_VAR( maxFabs);
-      AXOM_UNUSED_VAR( relMaxFabs);
-      AXOM_UNUSED_VAR( relMaxFabsWithAbsolute);
+#ifdef AXOM_DEBUG
+      const double diff = std::fabs(resultCheckMap[gEdge].second - locDom.e(ElemId));
+      const double maxFabs =
+        std::max(std::fabs(resultCheckMap[gEdge].second), std::fabs(locDom.e(ElemId)));
+      const double relMaxFabs = 1.0e-6 * maxFabs;
+      const double relMaxFabsWithAbsolute = relMaxFabs + 1.0e-8;
       SLIC_DEBUG("**  comparing "
           << resultCheckMap[gEdge].second << " with " << locDom.e(ElemId)
           << "\n\tfabs difference: " << diff
@@ -316,6 +313,7 @@ namespace slamLulesh {
           << "\n\tdiff of last two: " << relMaxFabsWithAbsolute - diff
           << "\n\tNearly equal: " << ( diff <= relMaxFabsWithAbsolute ? "TRUE" : "FALSE" )
       );
+#endif
     }
 
     return;

--- a/src/axom/slam/examples/tinyHydro/tests/slam_tinyHydro_unitTests.cpp
+++ b/src/axom/slam/examples/tinyHydro/tests/slam_tinyHydro_unitTests.cpp
@@ -69,7 +69,6 @@ TEST(slam_tinyHydro,test_02_density_with_prescribed_velocity)
 
   s.addPart(&p);
   Part* pp = s.getPart(0);
-  AXOM_UNUSED_VAR(pp);
 
   SLIC_INFO("**making hydro");
   Hydro h(&s);
@@ -95,11 +94,10 @@ TEST(slam_tinyHydro,test_02_density_with_prescribed_velocity)
   rhoTheory = rhoTheory * rhoTheory * rho0;
 
   double tol = 1.0e-10;
-  AXOM_UNUSED_VAR(tol);
-  SLIC_ASSERT_MSG(
+  EXPECT_TRUE(
     std::fabs(pp->rho(0) - rhoTheory) < tol
     && std::fabs(pp->rho(n - 1) - rhoTheory) < tol
-    , "FAIL -- densities are not correct\n");
+  ) << "FAIL -- densities are not correct";
 
   SLIC_INFO(" *** PASS *** " );
 }
@@ -180,18 +178,16 @@ TEST(slam_tinyHydro,test_03_gradAndForce)
 
 
   double tol = 1e-12;
-  AXOM_UNUSED_VAR(tol);
   VectorXY f12 = h.getForce(12);
   VectorXY f13 = h.getForce(13);
-  SLIC_ASSERT_MSG( std::fabs(f12.x - f13.x) < tol
-      && std::fabs(f12.y) < tol
-      && std::fabs(f13.y) < tol,
-      "force calculation FAILS --"
-      << "  f12: " << f12
-      << ", f13: " << f13
-      << ", diff in x: " << std::fabs(f12.x - f13.x)
-      << ", tolerance: " << tol
-  );
+  const bool symmetricForce = std::fabs(f12.x - f13.x) < tol
+    && std::fabs(f12.y) < tol
+    && std::fabs(f13.y) < tol;
+  EXPECT_TRUE(symmetricForce) << "force calculation FAILS --"
+    << " f12=(" << f12.x << ", " << f12.y << ")"
+    << ", f13=(" << f13.x << ", " << f13.y << ")"
+    << ", diff in x: " << std::fabs(f12.x - f13.x)
+    << ", tolerance: " << tol;
 
   SLIC_INFO("**Testing acceleration:");
 
@@ -210,20 +206,13 @@ TEST(slam_tinyHydro,test_03_gradAndForce)
   VectorXY u0 = s.u(0);
   VectorXY u11 = s.u(11);
   VectorXY u12 = s.u(12);
-  SLIC_ASSERT_MSG( std::fabs(u0.x - u12.x) < tol
-      && std::fabs(u11.y) < tol
-      && std::fabs(u12.y) < tol,
-      "acceleration/velocity calculation FAILS");
+  const bool symmetricVelocity = std::fabs(u0.x - u12.x) < tol
+    && std::fabs(u11.y) < tol
+    && std::fabs(u12.y) < tol;
+  EXPECT_TRUE(symmetricVelocity) << "acceleration/velocity calculation FAILS";
 
 
   SLIC_INFO(" *** PASS ***");
-
-  // Deal with unused variables
-  AXOM_UNUSED_VAR(f12);
-  AXOM_UNUSED_VAR(f13);
-  AXOM_UNUSED_VAR(u0);
-  AXOM_UNUSED_VAR(u11);
-  AXOM_UNUSED_VAR(u12);
 }
 
 
@@ -301,14 +290,13 @@ TEST(slam_tinyHydro,test_04_BC)
 
 
   double tol = 1e-21;
-  AXOM_UNUSED_VAR(tol);
 
-  SLIC_ASSERT_MSG( std::fabs(u0.y) < tol
+  EXPECT_TRUE( std::fabs(u0.y) < tol
       && std::fabs(u11.x) > tol
       && std::fabs(u21.x + 1.0) < tol
       && std::fabs(u120.x + 1.0) < tol
       && std::fabs(u120.y ) < tol
-      , "BC test FAILS ");
+  ) << "BC test FAILS";
 
   SLIC_INFO(" *** PASS *** " );
 }
@@ -403,13 +391,11 @@ TEST(slam_tinyHydro,test_05_newDT_Noh)
   SLIC_INFO("\tnewDT = " << dt );
 
   double tol = 1.0e-16;
-  AXOM_UNUSED_VAR( tol);
-
   double expDT = 0.1 * h.cfl;
-  AXOM_UNUSED_VAR( expDT);
 
-  SLIC_ASSERT_MSG( std::fabs(dt - expDT) < tol,
-      " newDT calculation FAILS -- expected dt = " << expDT << " but got " << dt << " instead, leaving " << dt - expDT);
+  EXPECT_TRUE( std::fabs(dt - expDT) < tol)
+    << "newDT calculation FAILS -- expected dt = " << expDT
+    << " but got " << dt << " instead, leaving " << dt - expDT;
 
   SLIC_INFO(" *** PASS *** " );
 }
@@ -477,13 +463,11 @@ TEST(slam_tinyHydro,test_05_newDT_Sedov)
   double cfl = 0.7;
   double cs = sqrt(10 * E / (4 * zonemass * 9));
   double theoryDT = cfl * L / cs;
-  AXOM_UNUSED_VAR( theoryDT);
-
   double tol = 1.0e-16;
-  AXOM_UNUSED_VAR( tol);
 
-  SLIC_ASSERT_MSG( std::fabs(dt - theoryDT) < tol,
-      " newDT calculation FAILS -- expected dt = " << theoryDT << " but code got " << dt << ". Diff:" <<  dt - theoryDT);
+  EXPECT_TRUE( std::fabs(dt - theoryDT) < tol)
+    << "newDT calculation FAILS -- expected dt = " << theoryDT
+    << " but code got " << dt << ". Diff:" << dt - theoryDT;
 
   SLIC_INFO(" *** PASS ***");
 }
@@ -559,14 +543,12 @@ TEST(slam_tinyHydro,test_06_PdV_work)
   SLIC_INFO("**done stepping. ");
 
   double tol = 1.0e-6;
-  AXOM_UNUSED_VAR(tol);
-
   double theoryRho = 1.0 / (1.0 + h.time * u0);
   double rhoCode = h.getState()->getPart(0)->rho(0);
-  AXOM_UNUSED_VAR(rhoCode);
 
-  SLIC_ASSERT_MSG( std::fabs(theoryRho - rhoCode) < tol,
-      "density calculation FAILS -- rhoCode = " << rhoCode << " but should be " << theoryRho );
+  EXPECT_TRUE( std::fabs(theoryRho - rhoCode) < tol)
+    << "density calculation FAILS -- rhoCode = " << rhoCode
+    << " but should be " << theoryRho;
 
 
   double theoryE = std::pow(theoryRho / rho0, 2.0 / 3.0); // e = e0*(rho/rho0)**(gamma-1)


### PR DESCRIPTION
This PR resolves #1790 by removing additional CUDA warnings.

* The warning mentioned in the issue was already resolved.
* A number of tests caused warnings by enclosing `TEST()` functions in namespaces so this was changed

NOTE: A few "host function called from host/device function" warnings remain, mainly in primal, that would need more changes in Axom to fix properly.
