### PR TITLE
Fix broken build on CUDA

### DIFF
--- a/src/axom/primal/operators/detail/winding_number_2d_memoization.hpp
+++ b/src/axom/primal/operators/detail/winding_number_2d_memoization.hpp
@@ -322,7 +322,23 @@ public:
 
   NURBSCurveCacheManagerOMP(const CurveArrayView& curves, double bbExpansionAmount = 0.0)
   {
-    initialize(curves, bbExpansionAmount);
+    const int nt = omp_get_max_threads();
+    m_nurbs_caches.resize(nt);
+    auto nurbs_caches_view = m_nurbs_caches.view();
+
+    // Make the first one
+    nurbs_caches_view[0].resize(curves.size());
+    axom::for_all<axom::OMP_EXEC>(
+      curves.size(),
+      AXOM_HOST_LAMBDA(axom::IndexType i) {
+        nurbs_caches_view[0][i] = NURBSCache(curves[i], bbExpansionAmount);
+      });
+
+    // Copy the constructed cache to the other threads' copies (less work than construction)
+    axom::for_all<axom::OMP_EXEC>(
+      1,
+      nt,
+      AXOM_HOST_LAMBDA(axom::IndexType t) { nurbs_caches_view[t] = nurbs_caches_view[0]; });
   }
 
   /// A view of the manager object.
@@ -339,30 +355,6 @@ public:
 
   /// Return if the underlying array is empty
   bool empty() const { return m_nurbs_caches.empty(); }
-
-#if !defined(AXOM_USE_CUDA)
-private:
-#endif
-  void initialize(const CurveArrayView& curves, double bbExpansionAmount = 0.0)
-  {
-    const int nt = omp_get_max_threads();
-    m_nurbs_caches.resize(nt);
-    auto nurbs_caches_view = m_nurbs_caches.view();
-
-    // Make the first one
-    nurbs_caches_view[0].resize(curves.size());
-    axom::for_all<axom::OMP_EXEC>(
-      curves.size(),
-      AXOM_LAMBDA(axom::IndexType i) {
-        nurbs_caches_view[0][i] = NURBSCache(curves[i], bbExpansionAmount);
-      });
-
-    // Copy the constructed cache to the other threads' copies (less work than construction)
-    axom::for_all<axom::OMP_EXEC>(
-      1,
-      nt,
-      AXOM_LAMBDA(axom::IndexType t) { nurbs_caches_view[t] = nurbs_caches_view[0]; });
-  }
 
 private:
   NURBSCachePerThreadArray m_nurbs_caches;

--- a/src/axom/primal/operators/detail/winding_number_2d_memoization.hpp
+++ b/src/axom/primal/operators/detail/winding_number_2d_memoization.hpp
@@ -322,6 +322,29 @@ public:
 
   NURBSCurveCacheManagerOMP(const CurveArrayView& curves, double bbExpansionAmount = 0.0)
   {
+    initialize(curves, bbExpansionAmount);
+  }
+
+  /// A view of the manager object.
+  struct View
+  {
+    NURBSCachePerThreadArrayView m_views;
+
+    /// Return the NURBSCacheArrayView for the current OMP thread.
+    NURBSCacheArrayView caches() const { return m_views[omp_get_thread_num()].view(); }
+  };
+
+  /// Return a view of this manager to pass into a device function.
+  View view() const { return View {m_nurbs_caches.view()}; }
+
+  /// Return if the underlying array is empty
+  bool empty() const { return m_nurbs_caches.empty(); }
+
+#if !defined(AXOM_USE_CUDA)
+private:
+#endif
+  void initialize(const CurveArrayView& curves, double bbExpansionAmount = 0.0)
+  {
     const int nt = omp_get_max_threads();
     m_nurbs_caches.resize(nt);
     auto nurbs_caches_view = m_nurbs_caches.view();
@@ -340,21 +363,6 @@ public:
       nt,
       AXOM_LAMBDA(axom::IndexType t) { nurbs_caches_view[t] = nurbs_caches_view[0]; });
   }
-
-  /// A view of the manager object.
-  struct View
-  {
-    NURBSCachePerThreadArrayView m_views;
-
-    /// Return the NURBSCacheArrayView for the current OMP thread.
-    NURBSCacheArrayView caches() const { return m_views[omp_get_thread_num()].view(); }
-  };
-
-  /// Return a view of this manager to pass into a device function.
-  View view() const { return View {m_nurbs_caches.view()}; }
-
-  /// Return if the underlying array is empty
-  bool empty() const { return m_nurbs_caches.empty(); }
 
 private:
   NURBSCachePerThreadArray m_nurbs_caches;

--- a/src/axom/primal/operators/detail/winding_number_3d_memoization.hpp
+++ b/src/axom/primal/operators/detail/winding_number_3d_memoization.hpp
@@ -360,6 +360,29 @@ public:
 
   NURBSPatchCacheManagerOMP(const PatchArrayView& patches)
   {
+    initialize(patches);
+  }
+
+  /// A view of the manager object.
+  struct View
+  {
+    NURBSCachePerThreadArrayView m_views;
+
+    /// Return the NURBSCacheArrayView for the current OMP thread.
+    NURBSCacheArrayView caches() const { return m_views[omp_get_thread_num()].view(); }
+  };
+
+  /// Return a view of this manager to pass into a device function.
+  View view() const { return View {m_nurbs_caches.view()}; }
+
+  /// Return if the underlying array is empty
+  bool empty() const { return m_nurbs_caches.empty(); }
+
+#if !defined(AXOM_USE_CUDA)
+private:
+#endif
+  void initialize(const PatchArrayView& patches)
+  {
     const int nt = omp_get_max_threads();
     m_nurbs_caches.resize(nt);
     auto nurbs_caches_view = m_nurbs_caches.view();
@@ -384,21 +407,6 @@ public:
         }
       });
   }
-
-  /// A view of the manager object.
-  struct View
-  {
-    NURBSCachePerThreadArrayView m_views;
-
-    /// Return the NURBSCacheArrayView for the current OMP thread.
-    NURBSCacheArrayView caches() const { return m_views[omp_get_thread_num()].view(); }
-  };
-
-  /// Return a view of this manager to pass into a device function.
-  View view() const { return View {m_nurbs_caches.view()}; }
-
-  /// Return if the underlying array is empty
-  bool empty() const { return m_nurbs_caches.empty(); }
 
 private:
   NURBSCachePerThreadArray m_nurbs_caches;

--- a/src/axom/primal/operators/detail/winding_number_3d_memoization.hpp
+++ b/src/axom/primal/operators/detail/winding_number_3d_memoization.hpp
@@ -360,7 +360,29 @@ public:
 
   NURBSPatchCacheManagerOMP(const PatchArrayView& patches)
   {
-    initialize(patches);
+    const int nt = omp_get_max_threads();
+    m_nurbs_caches.resize(nt);
+    auto nurbs_caches_view = m_nurbs_caches.view();
+
+    // Make the first one
+    nurbs_caches_view[0].resize(patches.size());
+    axom::for_all<axom::OMP_EXEC>(
+      patches.size(),
+      AXOM_HOST_LAMBDA(axom::IndexType i) { nurbs_caches_view[0][i] = NURBSCache(patches[i]); });
+    SLIC_INFO("Finished the first construction");
+    // Copy the constructed cache to the other threads' copies (less work than construction)
+    axom::for_all<axom::OMP_EXEC>(
+      1,
+      nt,
+      AXOM_HOST_LAMBDA(axom::IndexType t) { nurbs_caches_view[t].resize(nurbs_caches_view[0].size()); });
+    axom::for_all<axom::OMP_EXEC>(
+      patches.size(),
+      AXOM_HOST_LAMBDA(axom::IndexType i) {
+        for(int t = 0; t < nt; t++)
+        {
+          nurbs_caches_view[t][i] = nurbs_caches_view[0][i];
+        }
+      });
   }
 
   /// A view of the manager object.
@@ -377,36 +399,6 @@ public:
 
   /// Return if the underlying array is empty
   bool empty() const { return m_nurbs_caches.empty(); }
-
-#if !defined(AXOM_USE_CUDA)
-private:
-#endif
-  void initialize(const PatchArrayView& patches)
-  {
-    const int nt = omp_get_max_threads();
-    m_nurbs_caches.resize(nt);
-    auto nurbs_caches_view = m_nurbs_caches.view();
-
-    // Make the first one
-    nurbs_caches_view[0].resize(patches.size());
-    axom::for_all<axom::OMP_EXEC>(
-      patches.size(),
-      AXOM_LAMBDA(axom::IndexType i) { nurbs_caches_view[0][i] = NURBSCache(patches[i]); });
-    SLIC_INFO("Finished the first construction");
-    // Copy the constructed cache to the other threads' copies (less work than construction)
-    axom::for_all<axom::OMP_EXEC>(
-      1,
-      nt,
-      AXOM_LAMBDA(axom::IndexType t) { nurbs_caches_view[t].resize(nurbs_caches_view[0].size()); });
-    axom::for_all<axom::OMP_EXEC>(
-      patches.size(),
-      AXOM_LAMBDA(axom::IndexType i) {
-        for(int t = 0; t < nt; t++)
-        {
-          nurbs_caches_view[t][i] = nurbs_caches_view[0][i];
-        }
-      });
-  }
 
 private:
   NURBSCachePerThreadArray m_nurbs_caches;

--- a/src/axom/primal/operators/detail/winding_number_3d_memoization.hpp
+++ b/src/axom/primal/operators/detail/winding_number_3d_memoization.hpp
@@ -374,7 +374,9 @@ public:
     axom::for_all<axom::OMP_EXEC>(
       1,
       nt,
-      AXOM_HOST_LAMBDA(axom::IndexType t) { nurbs_caches_view[t].resize(nurbs_caches_view[0].size()); });
+      AXOM_HOST_LAMBDA(axom::IndexType t) {
+        nurbs_caches_view[t].resize(nurbs_caches_view[0].size());
+      });
     axom::for_all<axom::OMP_EXEC>(
       patches.size(),
       AXOM_HOST_LAMBDA(axom::IndexType i) {

--- a/src/axom/spin/policy/LinearBVH.hpp
+++ b/src/axom/spin/policy/LinearBVH.hpp
@@ -166,7 +166,7 @@ public:
 
       // Return the precomputed values in the reduction.
       auto returnLeafValue =
-        AXOM_LAMBDA(std::int32_t currentNode, const std::int32_t* leafNodes)->ValueType
+        [&](std::int32_t currentNode, const std::int32_t* leafNodes)
       {
         const auto idx = leafNodes[currentNode];
         return leafFieldView[idx];

--- a/src/axom/spin/policy/LinearBVH.hpp
+++ b/src/axom/spin/policy/LinearBVH.hpp
@@ -165,9 +165,7 @@ public:
       });
 
       // Return the precomputed values in the reduction.
-      auto returnLeafValue =
-        [&](std::int32_t currentNode, const std::int32_t* leafNodes)
-      {
+      auto returnLeafValue = [&](std::int32_t currentNode, const std::int32_t* leafNodes) {
         const auto idx = leafNodes[currentNode];
         return leafFieldView[idx];
       };


### PR DESCRIPTION
This PR addresses a broken Axom build on CUDA from bug report "1846" (not mentioning it so as to prevent closure).

* Fixed CUDA compilation errors in GWN about taking a function's address by using `AXOM_HOST_LAMBDA`. This is ok since these classes use OpenMP for the `axom::for_all`.
* Fixed CUDA compilation error in LinearBVH.
