### PR TITLE
Remove allow_failure for CUDA build job

### DIFF
--- a/.gitlab/build_matrix.yml
+++ b/.gitlab/build_matrix.yml
@@ -42,8 +42,6 @@ matrix-gcc_13_3_1_cuda-src:
     COMPILER: "gcc@13.3.1_cuda"
     HOST_CONFIG: "matrix-toss_4_x86_64_ib-${COMPILER}.cmake"
   extends: .src_build_on_matrix
-  # TODO: Fix unit tests failures
-  allow_failure: true
 
 ####
 # Full Build jobs


### PR DESCRIPTION
Removed allow_failure flag for the gcc build job.