### PR TITLE
Klee scaling enhancements

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,6 +26,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Primal: Adds `NURBSPatch::isTriviallyTrimmed()` to check if the trimming curves for a patch lie on the patch boundaries
 - Quest: Adds support for reading mfem files with variable order NURBS curves (requires mfem>4.9).
 - Quest: Adds OMP support for fast GWN methods for STL/Triangulated STEP input and linearized NURBS Curve input.
+- Klee: Adds an optional "center" parameter in scale operators that permits scaling relative to a custom center point.
 
 ### Removed
 

--- a/src/axom/core/numerics/transforms.hpp
+++ b/src/axom/core/numerics/transforms.hpp
@@ -235,7 +235,8 @@ Matrix<T> scale(T sx, T sy, const axom::ArrayView<T> &center)
 {
   assert(center.size() == 2);
   const T zero {0};
-  if(axom::utilities::isNearlyEqual(center[0], zero) && axom::utilities::isNearlyEqual(center[1], zero))
+  if(axom::utilities::isNearlyEqual(center[0], zero) &&
+     axom::utilities::isNearlyEqual(center[1], zero))
   {
     return scale(sx, sy);
   }
@@ -265,9 +266,9 @@ Matrix<T> scale(T sx, T sy, T sz, const axom::ArrayView<T> &center)
 {
   assert(center.size() == 3);
   const T zero {0};
-  if(axom::utilities::isNearlyEqual(center[0], zero)
-     && axom::utilities::isNearlyEqual(center[1], zero)
-     && axom::utilities::isNearlyEqual(center[2], zero))
+  if(axom::utilities::isNearlyEqual(center[0], zero) &&
+     axom::utilities::isNearlyEqual(center[1], zero) &&
+     axom::utilities::isNearlyEqual(center[2], zero))
   {
     return scale(sx, sy, sz, 4);
   }

--- a/src/axom/core/numerics/transforms.hpp
+++ b/src/axom/core/numerics/transforms.hpp
@@ -8,6 +8,7 @@
 
 #include "axom/config.hpp"
 #include "axom/core/numerics/Matrix.hpp"
+#include "axom/core/ArrayView.hpp"
 
 #include <cassert>
 #include <cmath>
@@ -134,6 +135,33 @@ Matrix<T> axisRotation(double angleRad, double x, double y, double z)
 }
 
 /*!
+ * \brief Return translation matrix.
+ *
+ * \param tx The translation in x.
+ * \param ty The translation in y.
+ *
+ * \return A Matrix containing the translation transform.
+ */
+template <typename T = double>
+Matrix<T> translate(T tx, T ty)
+{
+  Matrix<T> M = Matrix<T>::identity(3);
+  M(0, 2) = tx;
+  M(1, 2) = ty;
+  return M;
+}
+
+template <typename T = double>
+Matrix<T> translate(T tx, T ty, T tz)
+{
+  Matrix<T> M = Matrix<T>::identity(4);
+  M(0, 3) = tx;
+  M(1, 3) = ty;
+  M(2, 3) = tz;
+  return M;
+}
+
+/*!
  * \brief Return scaling matrix.
  *
  * \param s The scaling value.
@@ -194,30 +222,51 @@ Matrix<T> scale(T sx, T sy, int ndims = 3)
 }
 
 /*!
- * \brief Return translation matrix.
+ * \brief Return scaling matrix relative to a center point.
  *
- * \param tx The translation in x.
- * \param ty The translation in y.
+ * \param sx The scaling value in x.
+ * \param sy The scaling value in y.
+ * \param center The center point.
  *
- * \return A Matrix containing the translation transform.
+ * \return A 3x3 Matrix containing the scaling transform.
  */
 template <typename T = double>
-Matrix<T> translate(T tx, T ty)
+Matrix<T> scale(T sx, T sy, const axom::ArrayView<T> &center)
 {
-  Matrix<T> M = Matrix<T>::identity(3);
-  M(0, 2) = tx;
-  M(1, 2) = ty;
-  return M;
+  assert(center.size() == 2);
+  const auto T0 = translate(-center[0], -center[1]);
+  const auto S = scale(sx, sy, 3);
+  const auto T1 = translate(center[0], center[1]);
+
+  Matrix<T> TS, result;
+  matrix_multiply(T0, S, TS);
+  matrix_multiply(TS, T1, result);
+
+  return result;
 }
 
+/*!
+ * \brief Return scaling matrix relative to a center point.
+ *
+ * \param sx The scaling value in x.
+ * \param sy The scaling value in y.
+ * \param center The center point.
+ *
+ * \return A 4x4 Matrix containing the scaling transform.
+ */
 template <typename T = double>
-Matrix<T> translate(T tx, T ty, T tz)
+Matrix<T> scale(T sx, T sy, T sz, const axom::ArrayView<T> &center)
 {
-  Matrix<T> M = Matrix<T>::identity(4);
-  M(0, 3) = tx;
-  M(1, 3) = ty;
-  M(2, 3) = tz;
-  return M;
+  assert(center.size() == 3);
+  const auto T0 = translate(-center[0], -center[1], -center[2]);
+  const auto S = scale(sx, sy, sz, 4);
+  const auto T1 = translate(center[0], center[1], center[2]);
+
+  Matrix<T> TS, result;
+  matrix_multiply(T0, S, TS);
+  matrix_multiply(TS, T1, result);
+
+  return result;
 }
 
 }  // end namespace transforms

--- a/src/axom/core/numerics/transforms.hpp
+++ b/src/axom/core/numerics/transforms.hpp
@@ -234,13 +234,19 @@ template <typename T = double>
 Matrix<T> scale(T sx, T sy, const axom::ArrayView<T> &center)
 {
   assert(center.size() == 2);
+  const T zero {0};
+  if(axom::utilities::isNearlyEqual(center[0], zero) && axom::utilities::isNearlyEqual(center[1], zero))
+  {
+    return scale(sx, sy);
+  }
+
   const auto T0 = translate(-center[0], -center[1]);
   const auto S = scale(sx, sy, 3);
   const auto T1 = translate(center[0], center[1]);
 
-  Matrix<T> TS, result;
-  matrix_multiply(T0, S, TS);
-  matrix_multiply(TS, T1, result);
+  Matrix<T> TS(Matrix<T>::identity(3)), result(Matrix<T>::identity(3));
+  matrix_multiply(T1, S, TS);
+  matrix_multiply(TS, T0, result);
 
   return result;
 }
@@ -258,13 +264,21 @@ template <typename T = double>
 Matrix<T> scale(T sx, T sy, T sz, const axom::ArrayView<T> &center)
 {
   assert(center.size() == 3);
+  const T zero {0};
+  if(axom::utilities::isNearlyEqual(center[0], zero)
+     && axom::utilities::isNearlyEqual(center[1], zero)
+     && axom::utilities::isNearlyEqual(center[2], zero))
+  {
+    return scale(sx, sy, sz, 4);
+  }
+
   const auto T0 = translate(-center[0], -center[1], -center[2]);
   const auto S = scale(sx, sy, sz, 4);
   const auto T1 = translate(center[0], center[1], center[2]);
 
-  Matrix<T> TS, result;
-  matrix_multiply(T0, S, TS);
-  matrix_multiply(TS, T1, result);
+  Matrix<T> TS(Matrix<T>::identity(4)), result(Matrix<T>::identity(4));
+  matrix_multiply(T1, S, TS);
+  matrix_multiply(TS, T0, result);
 
   return result;
 }

--- a/src/axom/core/tests/CMakeLists.txt
+++ b/src/axom/core/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ set(core_serial_tests
     numerics_lu.hpp
     numerics_matrix.hpp
     numerics_matvecops.hpp
+    numerics_transforms.hpp
     numerics_polynomial_solvers.hpp
 
     utils_endianness.hpp
@@ -226,4 +227,3 @@ if (ENABLE_BENCHMARKS)
                       COMMAND ${test_name} --benchmark_min_time=0.0001s)
   endforeach()
 endif()
-

--- a/src/axom/core/tests/core_serial_main.cpp
+++ b/src/axom/core/tests/core_serial_main.cpp
@@ -40,6 +40,7 @@
 #include "numerics_lu.hpp"
 #include "numerics_matrix.hpp"
 #include "numerics_matvecops.hpp"
+#include "numerics_transforms.hpp"
 #include "numerics_polynomial_solvers.hpp"
 #include "numerics_quadrature.hpp"
 

--- a/src/axom/core/tests/core_static_array.hpp
+++ b/src/axom/core/tests/core_static_array.hpp
@@ -25,7 +25,7 @@ struct DevicePair
 
   AXOM_HOST_DEVICE explicit DevicePair(int value) : first(value), second(-value) { }
 
-  AXOM_HOST_DEVICE DevicePair(const DevicePair &obj) : first(obj.first), second(obj.second) { }
+  AXOM_HOST_DEVICE DevicePair(const DevicePair& obj) : first(obj.first), second(obj.second) { }
 
   AXOM_HOST_DEVICE DevicePair& operator=(const DevicePair& other)
   {

--- a/src/axom/core/tests/core_static_array.hpp
+++ b/src/axom/core/tests/core_static_array.hpp
@@ -25,6 +25,8 @@ struct DevicePair
 
   AXOM_HOST_DEVICE explicit DevicePair(int value) : first(value), second(-value) { }
 
+  AXOM_HOST_DEVICE DevicePair(const DevicePair &obj) : first(obj.first), second(obj.second) { }
+
   AXOM_HOST_DEVICE DevicePair& operator=(const DevicePair& other)
   {
     first = other.first;

--- a/src/axom/core/tests/numerics_transforms.hpp
+++ b/src/axom/core/tests/numerics_transforms.hpp
@@ -28,10 +28,7 @@ void expect_matrix_near(const axom::numerics::Matrix<double>& actual,
   }
 }
 
-void expect_vector_near(const double* actual,
-                        const double* expected,
-                        int size,
-                        double tolerance = 1e-12)
+void expect_vector_near(const double* actual, const double* expected, int size, double tolerance = 1e-12)
 {
   for(int i = 0; i < size; ++i)
   {

--- a/src/axom/core/tests/numerics_transforms.hpp
+++ b/src/axom/core/tests/numerics_transforms.hpp
@@ -1,0 +1,98 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+// files for dates and other details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "gtest/gtest.h"
+
+#include "axom/core/ArrayView.hpp"
+#include "axom/core/numerics/matvecops.hpp"
+#include "axom/core/numerics/transforms.hpp"
+
+namespace
+{
+void expect_matrix_near(const axom::numerics::Matrix<double>& actual,
+                        const axom::numerics::Matrix<double>& expected,
+                        double tolerance = 1e-12)
+{
+  ASSERT_EQ(actual.getNumRows(), expected.getNumRows());
+  ASSERT_EQ(actual.getNumColumns(), expected.getNumColumns());
+
+  for(axom::IndexType i = 0; i < actual.getNumRows(); ++i)
+  {
+    for(axom::IndexType j = 0; j < actual.getNumColumns(); ++j)
+    {
+      EXPECT_NEAR(actual(i, j), expected(i, j), tolerance);
+    }
+  }
+}
+
+void expect_vector_near(const double* actual,
+                        const double* expected,
+                        int size,
+                        double tolerance = 1e-12)
+{
+  for(int i = 0; i < size; ++i)
+  {
+    EXPECT_NEAR(actual[i], expected[i], tolerance);
+  }
+}
+}  // namespace
+
+TEST(numerics_transforms, scale_2d_about_center)
+{
+  double centerData[2] = {2.0, 3.0};
+  axom::ArrayView<double> center(centerData, 2);
+
+  auto actual = axom::numerics::transforms::scale(4.0, 5.0, center);
+
+  axom::numerics::Matrix<double> expected = axom::numerics::Matrix<double>::identity(3);
+  expected(0, 0) = 4.0;
+  expected(1, 1) = 5.0;
+  expected(0, 2) = -6.0;
+  expected(1, 2) = -12.0;
+  expect_matrix_near(actual, expected);
+
+  double point[3] = {3.0, 4.0, 1.0};
+  double result[3] = {0.0, 0.0, 0.0};
+  double expectedPoint[3] = {6.0, 8.0, 1.0};
+  axom::numerics::matrix_vector_multiply(actual, point, result);
+  expect_vector_near(result, expectedPoint, 3);
+}
+
+TEST(numerics_transforms, scale_3d_about_center)
+{
+  double centerData[3] = {0.5, 0.5, 0.5};
+  axom::ArrayView<double> center(centerData, 3);
+
+  auto actual = axom::numerics::transforms::scale(2.0, 3.0, 4.0, center);
+
+  axom::numerics::Matrix<double> expected = axom::numerics::Matrix<double>::identity(4);
+  expected(0, 0) = 2.0;
+  expected(1, 1) = 3.0;
+  expected(2, 2) = 4.0;
+  expected(0, 3) = -0.5;
+  expected(1, 3) = -1.0;
+  expected(2, 3) = -1.5;
+  expect_matrix_near(actual, expected);
+
+  double point[4] = {1.5, 1.5, 1.5, 1.0};
+  double result[4] = {0.0, 0.0, 0.0, 0.0};
+  double expectedPoint[4] = {2.5, 3.5, 4.5, 1.0};
+  axom::numerics::matrix_vector_multiply(actual, point, result);
+  expect_vector_near(result, expectedPoint, 4);
+}
+
+TEST(numerics_transforms, scale_about_zero_center_matches_origin_scale)
+{
+  double center2dData[2] = {0.0, 0.0};
+  axom::ArrayView<double> center2d(center2dData, 2);
+  expect_matrix_near(axom::numerics::transforms::scale(2.0, 3.0, center2d),
+                     axom::numerics::transforms::scale(2.0, 3.0));
+
+  double center3dData[3] = {0.0, 0.0, 0.0};
+  axom::ArrayView<double> center3d(center3dData, 3);
+  expect_matrix_near(axom::numerics::transforms::scale(2.0, 3.0, 4.0, center3d),
+                     axom::numerics::transforms::scale(2.0, 3.0, 4.0, 4));
+}

--- a/src/axom/klee/AffineMatrixVisitor.cpp
+++ b/src/axom/klee/AffineMatrixVisitor.cpp
@@ -3,13 +3,12 @@
 // files for dates and other details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-#ifndef AXOM_KLEE_AFFINE_MATRIX_VISITOR_HPP_
-#define AXOM_KLEE_AFFINE_MATRIX_VISITOR_HPP_
+#include "axom/klee/AffineMatrixVisitor.hpp"
 
 namespace axom::klee
 {
 
-AffineMatrixVisitor::AffineMatrixVisitor() : klee::GeometryOperatorVisitor(), m_isValid(false), m_matrix(4, 4) { }
+AffineMatrixVisitor::AffineMatrixVisitor() : GeometryOperatorVisitor(), m_isValid(false), m_matrix(4, 4) { }
 
   void AffineMatrixVisitor::visit(const klee::Translation& translation)
   {
@@ -44,5 +43,3 @@ AffineMatrixVisitor::AffineMatrixVisitor() : klee::GeometryOperatorVisitor(), m_
   }
 
 } // end namespace axom::klee
-
-#endif

--- a/src/axom/klee/AffineMatrixVisitor.cpp
+++ b/src/axom/klee/AffineMatrixVisitor.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+// files for dates and other details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+#ifndef AXOM_KLEE_AFFINE_MATRIX_VISITOR_HPP_
+#define AXOM_KLEE_AFFINE_MATRIX_VISITOR_HPP_
+
+namespace axom::klee
+{
+
+AffineMatrixVisitor::AffineMatrixVisitor() : klee::GeometryOperatorVisitor(), m_isValid(false), m_matrix(4, 4) { }
+
+  void AffineMatrixVisitor::visit(const klee::Translation& translation)
+  {
+    m_matrix = translation.toMatrix();
+    m_isValid = true;
+  }
+  void AffineMatrixVisitor::visit(const klee::Rotation& rotation)
+  {
+    m_matrix = rotation.toMatrix();
+    m_isValid = true;
+  }
+  void AffineMatrixVisitor::visit(const klee::Scale& scale)
+  {
+    m_matrix = scale.toMatrix();
+    m_isValid = true;
+  }
+  void AffineMatrixVisitor::visit(const klee::UnitConverter& converter)
+  {
+    m_matrix = converter.toMatrix();
+    m_isValid = true;
+  }
+
+  void AffineMatrixVisitor::visit(const klee::CompositeOperator&)
+  {
+    SLIC_WARNING_ROOT("CompositeOperator not supported for Shaper query");
+    m_isValid = false;
+  }
+  void AffineMatrixVisitor::visit(const klee::SliceOperator&)
+  {
+    SLIC_WARNING_ROOT("SliceOperator not yet supported for Shaper query");
+    m_isValid = false;
+  }
+
+} // end namespace axom::klee
+
+#endif

--- a/src/axom/klee/AffineMatrixVisitor.cpp
+++ b/src/axom/klee/AffineMatrixVisitor.cpp
@@ -8,38 +8,42 @@
 namespace axom::klee
 {
 
-AffineMatrixVisitor::AffineMatrixVisitor() : GeometryOperatorVisitor(), m_isValid(false), m_matrix(4, 4) { }
+AffineMatrixVisitor::AffineMatrixVisitor()
+  : GeometryOperatorVisitor()
+  , m_isValid(false)
+  , m_matrix(4, 4)
+{ }
 
-  void AffineMatrixVisitor::visit(const klee::Translation& translation)
-  {
-    m_matrix = translation.toMatrix();
-    m_isValid = true;
-  }
-  void AffineMatrixVisitor::visit(const klee::Rotation& rotation)
-  {
-    m_matrix = rotation.toMatrix();
-    m_isValid = true;
-  }
-  void AffineMatrixVisitor::visit(const klee::Scale& scale)
-  {
-    m_matrix = scale.toMatrix();
-    m_isValid = true;
-  }
-  void AffineMatrixVisitor::visit(const klee::UnitConverter& converter)
-  {
-    m_matrix = converter.toMatrix();
-    m_isValid = true;
-  }
+void AffineMatrixVisitor::visit(const klee::Translation& translation)
+{
+  m_matrix = translation.toMatrix();
+  m_isValid = true;
+}
+void AffineMatrixVisitor::visit(const klee::Rotation& rotation)
+{
+  m_matrix = rotation.toMatrix();
+  m_isValid = true;
+}
+void AffineMatrixVisitor::visit(const klee::Scale& scale)
+{
+  m_matrix = scale.toMatrix();
+  m_isValid = true;
+}
+void AffineMatrixVisitor::visit(const klee::UnitConverter& converter)
+{
+  m_matrix = converter.toMatrix();
+  m_isValid = true;
+}
 
-  void AffineMatrixVisitor::visit(const klee::CompositeOperator&)
-  {
-    SLIC_WARNING_ROOT("CompositeOperator not supported for Shaper query");
-    m_isValid = false;
-  }
-  void AffineMatrixVisitor::visit(const klee::SliceOperator&)
-  {
-    SLIC_WARNING_ROOT("SliceOperator not yet supported for Shaper query");
-    m_isValid = false;
-  }
+void AffineMatrixVisitor::visit(const klee::CompositeOperator&)
+{
+  SLIC_WARNING_ROOT("CompositeOperator not supported for Shaper query");
+  m_isValid = false;
+}
+void AffineMatrixVisitor::visit(const klee::SliceOperator&)
+{
+  SLIC_WARNING_ROOT("SliceOperator not yet supported for Shaper query");
+  m_isValid = false;
+}
 
-} // end namespace axom::klee
+}  // end namespace axom::klee

--- a/src/axom/klee/AffineMatrixVisitor.hpp
+++ b/src/axom/klee/AffineMatrixVisitor.hpp
@@ -37,6 +37,6 @@ private:
   numerics::Matrix<double> m_matrix;
 };
 
-} // end namespace axom::klee
+}  // end namespace axom::klee
 
 #endif

--- a/src/axom/klee/AffineMatrixVisitor.hpp
+++ b/src/axom/klee/AffineMatrixVisitor.hpp
@@ -1,0 +1,41 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+// files for dates and other details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+#ifndef AXOM_KLEE_AFFINE_MATRIX_VISITOR_HPP_
+#define AXOM_KLEE_AFFINE_MATRIX_VISITOR_HPP_
+
+namespace axom::klee
+{
+
+/*!
+ * \brief Implementation of a GeometryOperatorVisitor for processing klee shape operators
+ *
+ * This class extracts the matrix form of supported operators and marks the operator as unvalid otherwise
+ * To use, check the \a isValid() function after visiting and then call the \a getMatrix() function.
+ */
+class AffineMatrixVisitor : public klee::GeometryOperatorVisitor
+{
+public:
+  AffineMatrixVisitor();
+
+  void visit(const klee::Translation& translation) override;
+  void visit(const klee::Rotation& rotation) override;
+  void visit(const klee::Scale& scale) override;
+  void visit(const klee::UnitConverter& converter) override;
+
+  void visit(const klee::CompositeOperator&) override;
+  void visit(const klee::SliceOperator&) override;
+
+  const numerics::Matrix<double>& getMatrix() const { return m_matrix; }
+  bool isValid() const { return m_isValid; }
+
+private:
+  bool m_isValid;
+  numerics::Matrix<double> m_matrix;
+};
+
+} // end namespace axom::klee
+
+#endif

--- a/src/axom/klee/AffineMatrixVisitor.hpp
+++ b/src/axom/klee/AffineMatrixVisitor.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 #ifndef AXOM_KLEE_AFFINE_MATRIX_VISITOR_HPP_
 #define AXOM_KLEE_AFFINE_MATRIX_VISITOR_HPP_
+#include "axom/klee/GeometryOperators.hpp"
 
 namespace axom::klee
 {
@@ -15,7 +16,7 @@ namespace axom::klee
  * This class extracts the matrix form of supported operators and marks the operator as unvalid otherwise
  * To use, check the \a isValid() function after visiting and then call the \a getMatrix() function.
  */
-class AffineMatrixVisitor : public klee::GeometryOperatorVisitor
+class AffineMatrixVisitor : public GeometryOperatorVisitor
 {
 public:
   AffineMatrixVisitor();

--- a/src/axom/klee/CMakeLists.txt
+++ b/src/axom/klee/CMakeLists.txt
@@ -10,6 +10,7 @@ axom_component_requires(NAME       Klee
 # Specify all headers/sources
 #------------------------------------------------------------------------------
 set(klee_headers
+    AffineMatrixVisitor.hpp
     Dimensions.hpp
     Geometry.hpp
     GeometryOperators.hpp
@@ -26,6 +27,7 @@ set(klee_internal_headers
     )
 
 set(klee_sources
+    AffineMatrixVisitor.cpp
     Geometry.cpp
     GeometryOperators.cpp
     KleeError.cpp

--- a/src/axom/klee/Geometry.cpp
+++ b/src/axom/klee/Geometry.cpp
@@ -228,5 +228,47 @@ const std::string& Geometry::getBlueprintTopology() const
   return m_topology;
 }
 
+numerics::Matrix<double> Geometry::getTransform() const
+{
+  const auto identity4x4 = numerics::Matrix<double>::identity(4);
+  numerics::Matrix<double> transformation(identity4x4);
+  if(m_operator)
+  {
+    auto composite = std::dynamic_pointer_cast<const CompositeOperator>(m_operator);
+    if(composite)
+    {
+      // Concatenate the transformations
+
+      // Why don't we multiply the matrices in CompositeOperator::addOperator()?
+      // Why keep the matrices factored and multiply them here repeatedly?
+      // Combining them would also avoid this if-else logic.  BTNG
+      for(auto op : composite->getOperators())
+      {
+        // Use visitor pattern to extract the affine matrix from supported operators
+        AffineMatrixVisitor visitor;
+        op->accept(visitor);
+        if(!visitor.isValid())
+        {
+          continue;
+        }
+        const auto& matrix = visitor.getMatrix();
+        numerics::Matrix<double> res(identity4x4);
+        numerics::matrix_multiply(matrix, transformation, res);
+        transformation = res;
+      }
+    }
+    else
+    {
+      AffineMatrixVisitor visitor;
+      geometryOperator->accept(visitor);
+      if(visitor.isValid())
+      {
+        transformation = visitor.getMatrix();
+      }
+    }
+  }
+  return transformation;
+}
+
 }  // namespace klee
 }  // namespace axom

--- a/src/axom/klee/Geometry.cpp
+++ b/src/axom/klee/Geometry.cpp
@@ -6,6 +6,7 @@
 
 #include "axom/klee/Geometry.hpp"
 #include "axom/klee/GeometryOperators.hpp"
+#include "axom/klee/AffineMatrixVisitor.hpp"
 
 #include "conduit_blueprint_mesh.hpp"
 
@@ -260,7 +261,7 @@ numerics::Matrix<double> Geometry::getTransform() const
     else
     {
       AffineMatrixVisitor visitor;
-      geometryOperator->accept(visitor);
+      m_operator->accept(visitor);
       if(visitor.isValid())
       {
         transformation = visitor.getMatrix();

--- a/src/axom/klee/Geometry.hpp
+++ b/src/axom/klee/Geometry.hpp
@@ -261,6 +261,14 @@ public:
   std::shared_ptr<GeometryOperator const> const &getGeometryOperator() const { return m_operator; }
 
   /**
+   * Get any operator transforms concatenated into a 4x4 matrix. If there are no
+   * geometry operators then the identity matrix is returned.
+   *
+   * \return A 4x4 matrix that represents the geometry transforms.
+   */
+  numerics::Matrix<double> getTransform() const;
+
+  /**
    * Get the initial transformable properties of this geometry
    *
    * \return the initial transformable properties of this geometry

--- a/src/axom/klee/GeometryOperators.cpp
+++ b/src/axom/klee/GeometryOperators.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "axom/core/numerics/matvecops.hpp"
+#include "axom/core/numerics/transforms.hpp"
 
 #include "axom/klee/GeometryOperators.hpp"
 #include "axom/klee/Units.hpp"
@@ -48,12 +49,7 @@ Translation::Translation(const primal::Vector3D &offset,
 
 numerics::Matrix<double> Translation::toMatrix() const
 {
-  auto transformation = numerics::Matrix<double>::identity(4);
-  for(int i = 0; i < 3; ++i)
-  {
-    transformation(i, 3) = m_offset[i];
-  }
-  return transformation;
+  return axom::numerics::transforms::translate(m_offset[0], m_offset[1], m_offset[2]);
 }
 
 void Translation::accept(GeometryOperatorVisitor &visitor) const { visitor.visit(*this); }
@@ -119,16 +115,25 @@ Scale::Scale(double xFactor,
   , m_xFactor {xFactor}
   , m_yFactor {yFactor}
   , m_zFactor {zFactor}
+  , m_center {0., 0., 0.}
+{ }
+
+Scale::Scale(double xFactor,
+             double yFactor,
+             double zFactor,
+             const primal::Point3D &center,
+             const TransformableGeometryProperties &startProperties)
+  : MatrixOperator {startProperties}
+  , m_xFactor {xFactor}
+  , m_yFactor {yFactor}
+  , m_zFactor {zFactor}
+  , m_center {center}
 { }
 
 numerics::Matrix<double> Scale::toMatrix() const
 {
-  auto transformation = numerics::Matrix<double>::zeros(4, 4);
-  transformation(0, 0) = m_xFactor;
-  transformation(1, 1) = m_yFactor;
-  transformation(2, 2) = m_zFactor;
-  transformation(3, 3) = 1;
-  return transformation;
+  axom::ArrayView<double> centerView(const_cast<double *>(m_center.data()), 3);
+  return axom::numerics::transforms::scale(m_xFactor, m_yFactor, m_zFactor, centerView);
 }
 
 void Scale::accept(GeometryOperatorVisitor &visitor) const { visitor.visit(*this); }

--- a/src/axom/klee/GeometryOperators.cpp
+++ b/src/axom/klee/GeometryOperators.cpp
@@ -107,6 +107,10 @@ numerics::Matrix<double> Rotation::toMatrix() const
 
 void Rotation::accept(GeometryOperatorVisitor &visitor) const { visitor.visit(*this); }
 
+Scale::Scale(double xFactor, double yFactor, const TransformableGeometryProperties &startProperties)
+  : Scale(xFactor, yFactor, 1., startProperties)
+{ }
+
 Scale::Scale(double xFactor,
              double yFactor,
              double zFactor,
@@ -116,6 +120,13 @@ Scale::Scale(double xFactor,
   , m_yFactor {yFactor}
   , m_zFactor {zFactor}
   , m_center {0., 0., 0.}
+{ }
+
+Scale::Scale(double xFactor,
+             double yFactor,
+             const primal::Point2D &center,
+             const TransformableGeometryProperties &startProperties)
+  : Scale(xFactor, yFactor, 1., primal::Point3D({center[0], center[1], 0.}), startProperties)
 { }
 
 Scale::Scale(double xFactor,

--- a/src/axom/klee/GeometryOperators.hpp
+++ b/src/axom/klee/GeometryOperators.hpp
@@ -218,6 +218,22 @@ public:
         const TransformableGeometryProperties &startProperties);
 
   /**
+   * Create a new Scale operator.
+   *
+   * \param xFactor the amount by which to scale in the x direction
+   * \param yFactor the amount by which to scale in the y direction
+   * \param zFactor the amount by which to scale in the z direction
+   * \param center The center relative to which the scaling is performed.
+   * \param startProperties the initial properties, as in the parent class. 
+   * If the number of dimensions is 2, zFactor should be 1.0, but this is not enforced.
+   */
+  Scale(double xFactor,
+        double yFactor,
+        double zFactor,
+        const primal::Point3D &center,
+        const TransformableGeometryProperties &startProperties);
+
+  /**
    * Get the scale factor in the x direction.
    *
    * \return the x scale factor
@@ -238,6 +254,14 @@ public:
    */
   double getZFactor() const { return m_zFactor; }
 
+  /**
+   * Get the scale factor in the z direction.
+   *
+   * \return the z scale factor
+   */
+  primal::Point3D &getCenter() { return m_center; }
+  const primal::Point3D &getCenter() const { return m_center; }
+
   numerics::Matrix<double> toMatrix() const override;
 
   void accept(GeometryOperatorVisitor &visitor) const override;
@@ -246,6 +270,7 @@ private:
   double m_xFactor;
   double m_yFactor;
   double m_zFactor;
+  primal::Point3D m_center;
 };
 
 /// An operator for converting units

--- a/src/axom/klee/GeometryOperators.hpp
+++ b/src/axom/klee/GeometryOperators.hpp
@@ -208,9 +208,21 @@ public:
    *
    * \param xFactor the amount by which to scale in the x direction
    * \param yFactor the amount by which to scale in the y direction
+   * \param startProperties the initial properties, as in the parent class.
+   *
+   * \note The scaling factor used for the 3rd dimension is 1.
+   */
+  Scale(double xFactor, double yFactor, const TransformableGeometryProperties &startProperties);
+
+  /**
+   * Create a new Scale operator.
+   *
+   * \param xFactor the amount by which to scale in the x direction
+   * \param yFactor the amount by which to scale in the y direction
    * \param zFactor the amount by which to scale in the z direction
    * \param startProperties the initial properties, as in the parent class. 
-   * If the number of dimensions is 2, zFactor should be 1.0, but this is not enforced.
+   *
+   * \note If the number of dimensions is 2, zFactor should be 1.0, but this is not enforced.
    */
   Scale(double xFactor,
         double yFactor,
@@ -222,10 +234,26 @@ public:
    *
    * \param xFactor the amount by which to scale in the x direction
    * \param yFactor the amount by which to scale in the y direction
+   * \param center The center relative to which the scaling is performed.
+   * \param startProperties the initial properties, as in the parent class.
+   *
+   * \note The scaling factor used for the 3rd dimension is 1.
+   */
+  Scale(double xFactor,
+        double yFactor,
+        const primal::Point2D &center,
+        const TransformableGeometryProperties &startProperties);
+
+  /**
+   * Create a new Scale operator.
+   *
+   * \param xFactor the amount by which to scale in the x direction
+   * \param yFactor the amount by which to scale in the y direction
    * \param zFactor the amount by which to scale in the z direction
    * \param center The center relative to which the scaling is performed.
-   * \param startProperties the initial properties, as in the parent class. 
-   * If the number of dimensions is 2, zFactor should be 1.0, but this is not enforced.
+   * \param startProperties the initial properties, as in the parent class.
+   *
+   * \note If the number of dimensions is 2, zFactor should be 1.0, but this is not enforced.
    */
   Scale(double xFactor,
         double yFactor,

--- a/src/axom/klee/docs/sphinx/specifying_shapes.rst
+++ b/src/axom/klee/docs/sphinx/specifying_shapes.rst
@@ -268,11 +268,18 @@ Operators may also have additional required or optional parameters.
   :name: :code:`scale`
   :value: a vector specifying the amount by which to scale in each dimension,
     or a single value specifying by which to scale in all dimensions
+  :optional arguments:
+    :center: a point specifying the center relative to which to scale.
+      If omitted, scaling is performed relative to the origin.
   :example:
     ::
 
         # Scale by 2x in the x direction 0.5x in y, and 1.5x in z
         scale: [2.0, 0.5, 1.5]
+
+        # Scale by 2x in every direction relative to the point (1, 2, 3)
+        scale: 2.0
+        center: [1, 2, 3]
 
 * Changing Units
 

--- a/src/axom/klee/io/GeometryOperatorsIO.cpp
+++ b/src/axom/klee/io/GeometryOperatorsIO.cpp
@@ -371,7 +371,7 @@ OpPtr parseScale(const inlet::Container &opContainer,
   {
     factors.emplace_back(1.0);
   }
-  Point3D center{0., 0., 0.};
+  Point3D center {0., 0., 0.};
   if(opContainer.contains("center"))
   {
     center = toPoint(opContainer, "center", startProperties.dimensions, Point3D {0, 0, 0});

--- a/src/axom/klee/io/GeometryOperatorsIO.cpp
+++ b/src/axom/klee/io/GeometryOperatorsIO.cpp
@@ -360,7 +360,7 @@ OpPtr parseSlice(const inlet::Container &opContainer,
 OpPtr parseScale(const inlet::Container &opContainer,
                  const TransformableGeometryProperties &startProperties)
 {
-  verifyObjectFields(opContainer, "scale", FieldSet {}, FieldSet {});
+  verifyObjectFields(opContainer, "scale", FieldSet {}, FieldSet {"center"});
   auto factors = opContainer["scale"].get<std::vector<double>>();
   if(factors.size() == 1)
   {
@@ -371,7 +371,13 @@ OpPtr parseScale(const inlet::Container &opContainer,
   {
     factors.emplace_back(1.0);
   }
-  return std::make_shared<Scale>(factors[0], factors[1], factors[2], startProperties);
+  Point3D center{0., 0., 0.};
+  if(opContainer.contains("center"))
+  {
+    center = toPoint(opContainer, "center", startProperties.dimensions, Point3D {0, 0, 0});
+  }
+
+  return std::make_shared<Scale>(factors[0], factors[1], factors[2], center, startProperties);
 }
 
 /**

--- a/src/axom/klee/tests/klee_geometry_operators.cpp
+++ b/src/axom/klee/tests/klee_geometry_operators.cpp
@@ -45,7 +45,7 @@ using primal::Vector3D;
 template <typename ColumnVector>
 ColumnVector operator*(const numerics::Matrix<double> &matrix, const ColumnVector &rhs)
 {
-  if(matrix.getNumRows() != matrix.getNumRows() || matrix.getNumRows() != rhs.dimension())
+  if(matrix.getNumRows() != matrix.getNumColumns() || matrix.getNumRows() != rhs.dimension())
   {
     throw std::logic_error("Can't multiply entities of this size");
   }
@@ -223,12 +223,48 @@ TEST(Scale, basics)
   EXPECT_DOUBLE_EQ(2, scale.getXFactor());
   EXPECT_DOUBLE_EQ(3, scale.getYFactor());
   EXPECT_DOUBLE_EQ(4, scale.getZFactor());
+  EXPECT_DOUBLE_EQ(0., scale.getCenter()[0]);
+  EXPECT_DOUBLE_EQ(0., scale.getCenter()[1]);
+  EXPECT_DOUBLE_EQ(0., scale.getCenter()[2]);
+
+  Scale scale2 {2, 4, 6, Point3D{0.5, 0.5, 0.5}, {Dimensions::Three, LengthUnit::cm}};
+  EXPECT_DOUBLE_EQ(2, scale2.getXFactor());
+  EXPECT_DOUBLE_EQ(4, scale2.getYFactor());
+  EXPECT_DOUBLE_EQ(6, scale2.getZFactor());
+  EXPECT_DOUBLE_EQ(0.5, scale2.getCenter()[0]);
+  EXPECT_DOUBLE_EQ(0.5, scale2.getCenter()[1]);
+  EXPECT_DOUBLE_EQ(0.5, scale2.getCenter()[2]);
 }
 
 TEST(Scale, toMatrix)
 {
   Scale scale {2, 3, 4, {Dimensions::Three, LengthUnit::cm}};
   EXPECT_THAT(scale.toMatrix(), AlmostEqMatrix(affine({{{2, 0, 0, 0}, {0, 3, 0, 0}, {0, 0, 4, 0}}})));
+
+  Scale scale2 {2, 2, 2, Point3D{0.5, 0.5, 0.5}, {Dimensions::Three, LengthUnit::cm}};
+  EXPECT_THAT(scale2.toMatrix(),
+              AlmostEqMatrix(affine({{{2, 0, 0, -0.5}, {0, 2, 0, -0.5}, {0, 0, 2, -0.5}}})));
+
+  EXPECT_THAT(scale2.toMatrix() * affinePoint({0.5, 0.5, 0.5}),
+              AlmostEqPoint(affinePoint({0.5, 0.5, 0.5})));
+  EXPECT_THAT(scale2.toMatrix() * affinePoint({0., 0., 0.}),
+              AlmostEqPoint(affinePoint({-0.5, -0.5, -0.5})));
+  EXPECT_THAT(scale2.toMatrix() * affinePoint({1., 0., 0.}),
+              AlmostEqPoint(affinePoint({1.5, -0.5, -0.5})));
+  EXPECT_THAT(scale2.toMatrix() * affinePoint({1., 1., 0.}),
+              AlmostEqPoint(affinePoint({1.5, 1.5, -0.5})));
+  EXPECT_THAT(scale2.toMatrix() * affinePoint({0., 1., 0.}),
+              AlmostEqPoint(affinePoint({-0.5, 1.5, -0.5})));
+  EXPECT_THAT(scale2.toMatrix() * affinePoint({0., 0., 1.}),
+              AlmostEqPoint(affinePoint({-0.5, -0.5, 1.5})));
+  EXPECT_THAT(scale2.toMatrix() * affinePoint({1., 0., 1.}),
+              AlmostEqPoint(affinePoint({1.5, -0.5, 1.5})));
+  EXPECT_THAT(scale2.toMatrix() * affinePoint({1., 1., 1.}),
+              AlmostEqPoint(affinePoint({1.5, 1.5, 1.5})));
+  EXPECT_THAT(scale2.toMatrix() * affinePoint({0., 1., 1.}),
+              AlmostEqPoint(affinePoint({-0.5, 1.5, 1.5})));
+  EXPECT_THAT(scale2.toMatrix() * affineVec({1., 1., 1.}),
+              AlmostEqVector(affineVec({2., 2., 2.})));
 }
 
 TEST(Scale, accept)

--- a/src/axom/klee/tests/klee_geometry_operators.cpp
+++ b/src/axom/klee/tests/klee_geometry_operators.cpp
@@ -227,7 +227,7 @@ TEST(Scale, basics)
   EXPECT_DOUBLE_EQ(0., scale.getCenter()[1]);
   EXPECT_DOUBLE_EQ(0., scale.getCenter()[2]);
 
-  Scale scale2 {2, 4, 6, Point3D{0.5, 0.5, 0.5}, {Dimensions::Three, LengthUnit::cm}};
+  Scale scale2 {2, 4, 6, Point3D {0.5, 0.5, 0.5}, {Dimensions::Three, LengthUnit::cm}};
   EXPECT_DOUBLE_EQ(2, scale2.getXFactor());
   EXPECT_DOUBLE_EQ(4, scale2.getYFactor());
   EXPECT_DOUBLE_EQ(6, scale2.getZFactor());
@@ -241,7 +241,7 @@ TEST(Scale, toMatrix)
   Scale scale {2, 3, 4, {Dimensions::Three, LengthUnit::cm}};
   EXPECT_THAT(scale.toMatrix(), AlmostEqMatrix(affine({{{2, 0, 0, 0}, {0, 3, 0, 0}, {0, 0, 4, 0}}})));
 
-  Scale scale2 {2, 2, 2, Point3D{0.5, 0.5, 0.5}, {Dimensions::Three, LengthUnit::cm}};
+  Scale scale2 {2, 2, 2, Point3D {0.5, 0.5, 0.5}, {Dimensions::Three, LengthUnit::cm}};
   EXPECT_THAT(scale2.toMatrix(),
               AlmostEqMatrix(affine({{{2, 0, 0, -0.5}, {0, 2, 0, -0.5}, {0, 0, 2, -0.5}}})));
 
@@ -263,8 +263,7 @@ TEST(Scale, toMatrix)
               AlmostEqPoint(affinePoint({1.5, 1.5, 1.5})));
   EXPECT_THAT(scale2.toMatrix() * affinePoint({0., 1., 1.}),
               AlmostEqPoint(affinePoint({-0.5, 1.5, 1.5})));
-  EXPECT_THAT(scale2.toMatrix() * affineVec({1., 1., 1.}),
-              AlmostEqVector(affineVec({2., 2., 2.})));
+  EXPECT_THAT(scale2.toMatrix() * affineVec({1., 1., 1.}), AlmostEqVector(affineVec({2., 2., 2.})));
 }
 
 TEST(Scale, accept)

--- a/src/axom/klee/tests/klee_geometry_operators.cpp
+++ b/src/axom/klee/tests/klee_geometry_operators.cpp
@@ -48,6 +48,7 @@ using ::testing::Matcher;
 using ::testing::Ref;
 using ::testing::Return;
 
+using primal::Point2D;
 using primal::Point3D;
 using primal::Vector3D;
 
@@ -246,6 +247,22 @@ TEST(Scale, basics)
   EXPECT_DOUBLE_EQ(0.5, scale2.getCenter()[0]);
   EXPECT_DOUBLE_EQ(0.5, scale2.getCenter()[1]);
   EXPECT_DOUBLE_EQ(0.5, scale2.getCenter()[2]);
+
+  Scale scale3 {3, 2, {Dimensions::Two, LengthUnit::cm}};
+  EXPECT_DOUBLE_EQ(3, scale3.getXFactor());
+  EXPECT_DOUBLE_EQ(2, scale3.getYFactor());
+  EXPECT_DOUBLE_EQ(1, scale3.getZFactor());
+  EXPECT_DOUBLE_EQ(0., scale3.getCenter()[0]);
+  EXPECT_DOUBLE_EQ(0., scale3.getCenter()[1]);
+  EXPECT_DOUBLE_EQ(0., scale3.getCenter()[2]);
+
+  Scale scale4 {3, 2, Point2D {0.5, 0.5}, {Dimensions::Two, LengthUnit::cm}};
+  EXPECT_DOUBLE_EQ(3, scale4.getXFactor());
+  EXPECT_DOUBLE_EQ(2, scale4.getYFactor());
+  EXPECT_DOUBLE_EQ(1, scale4.getZFactor());
+  EXPECT_DOUBLE_EQ(0.5, scale4.getCenter()[0]);
+  EXPECT_DOUBLE_EQ(0.5, scale4.getCenter()[1]);
+  EXPECT_DOUBLE_EQ(0., scale4.getCenter()[2]);
 }
 
 TEST(Scale, toMatrix)

--- a/src/axom/klee/tests/klee_geometry_operators_io.cpp
+++ b/src/axom/klee/tests/klee_geometry_operators_io.cpp
@@ -364,6 +364,18 @@ TEST(GeometryOperatorsIO, readScale_2d_array)
   EXPECT_EQ(expectedProperties, scale.getEndProperties());
 }
 
+TEST(GeometryOperatorsIO, readScale_2d_array_withCenter)
+{
+  auto scale = readSingleOperator<Scale>({Dimensions::Two, LengthUnit::cm}, R"(
+      scale: [1.2, 3.4]
+      center: [10, 20]
+    )");
+  EXPECT_DOUBLE_EQ(1.2, scale.getXFactor());
+  EXPECT_DOUBLE_EQ(3.4, scale.getYFactor());
+  EXPECT_DOUBLE_EQ(1.0, scale.getZFactor());
+  EXPECT_THAT(scale.getCenter(), AlmostEqPoint(Point3D {10, 20, 0}));
+}
+
 TEST(GeometryOperatorsIO, readScale_3d_array)
 {
   auto scale = readSingleOperator<Scale>({Dimensions::Three, LengthUnit::cm},
@@ -376,6 +388,19 @@ TEST(GeometryOperatorsIO, readScale_3d_array)
   TransformableGeometryProperties expectedProperties {Dimensions::Three, LengthUnit::cm};
   EXPECT_EQ(expectedProperties, scale.getStartProperties());
   EXPECT_EQ(expectedProperties, scale.getEndProperties());
+}
+
+TEST(GeometryOperatorsIO, readScale_3d_array_withCenter)
+{
+  auto scale = readSingleOperator<Scale>({Dimensions::Three, LengthUnit::cm},
+                                         R"(
+      scale: [1.2, 3.4, 5.6]
+      center: [4, 5, 6]
+  )");
+  EXPECT_DOUBLE_EQ(1.2, scale.getXFactor());
+  EXPECT_DOUBLE_EQ(3.4, scale.getYFactor());
+  EXPECT_DOUBLE_EQ(5.6, scale.getZFactor());
+  EXPECT_THAT(scale.getCenter(), AlmostEqPoint(Point3D {4, 5, 6}));
 }
 
 TEST(GeometryOperatorsIO, readConvertUnits)
@@ -731,6 +756,7 @@ TEST(GeometryOperatorsIO, readNamedOperators_basic)
   EXPECT_EQ(expectedScaleProperties, scale.getEndProperties());
   EXPECT_EQ(1.5, scale.getXFactor());
   EXPECT_EQ(1.5, scale.getYFactor());
+  EXPECT_THAT(scale.getCenter(), AlmostEqPoint(Point3D {0, 0, 0}));
 }
 
 TEST(GeometryOperatorsIO, readNamedOperators_invalidDimensions)
@@ -847,6 +873,7 @@ TEST(GeometryOperatorsIO, readNamedOperators_ref)
   auto scale = copyOperator<Scale>(composite->getOperators()[0]);
   EXPECT_EQ(1.5, scale.getXFactor());
   EXPECT_EQ(1.5, scale.getYFactor());
+  EXPECT_THAT(scale.getCenter(), AlmostEqPoint(Point3D {0, 0, 0}));
 
   auto referencedOperator = copyOperator<CompositeOperator>(composite->getOperators()[1]);
   ASSERT_EQ(1u, referencedOperator.getOperators().size());

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -47,7 +47,7 @@ ShapeSet readShapeSetFromString(const std::string &input)
   std::istringstream istream(input);
   return klee::readShapeSet(istream);
 }
-} // end namespace
+}  // end namespace
 
 TEST(IOTest, readShapeSet_noShapes)
 {

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -23,7 +23,9 @@ namespace klee
 {
 namespace
 {
+using primal::Point3D;
 using primal::Vector3D;
+using test::AlmostEqPoint;
 using test::AlmostEqVector;
 using ::testing::Contains;
 using ::testing::HasSubstr;
@@ -336,6 +338,38 @@ TEST(IOTest, readShapeSet_geometryOperators)
   EXPECT_THAT(translation->getOffset(), AlmostEqVector(Vector3D {10, 20, 0}));
   EXPECT_EQ(LengthUnit::m, translation->getEndProperties().units);
   EXPECT_EQ(shapeSet.getDimensions(), translation->getEndProperties().dimensions);
+}
+
+TEST(IOTest, readShapeSet_geometryOperators_scaleWithCenter)
+{
+  auto shapeSet = readShapeSetFromString(R"(
+      dimensions: 2
+      shapes:
+        - name: wheel
+          material: steel
+          geometry:
+            format: test_format
+            path: path/to/file.format
+            units: m
+            operators:
+              - scale: [1.5, 2.5]
+                center: [10, 20]
+    )");
+  auto &shapes = shapeSet.getShapes();
+  ASSERT_EQ(1u, shapes.size());
+  auto &geometryOperator = shapes[0].getGeometry().getGeometryOperator();
+  ASSERT_TRUE(geometryOperator);
+
+  auto composite = std::dynamic_pointer_cast<const CompositeOperator>(geometryOperator);
+  ASSERT_TRUE(composite);
+  ASSERT_EQ(1u, composite->getOperators().size());
+
+  auto scale = dynamic_cast<const Scale *>(composite->getOperators()[0].get());
+  ASSERT_NE(scale, nullptr);
+  EXPECT_DOUBLE_EQ(1.5, scale->getXFactor());
+  EXPECT_DOUBLE_EQ(2.5, scale->getYFactor());
+  EXPECT_DOUBLE_EQ(1.0, scale->getZFactor());
+  EXPECT_THAT(scale->getCenter(), AlmostEqPoint(Point3D {10, 20, 0}));
 }
 
 TEST(IOTest, readShapeSet_geometryOperatorsWithoutUnits)

--- a/src/axom/quest/DiscreteShape.cpp
+++ b/src/axom/quest/DiscreteShape.cpp
@@ -19,60 +19,6 @@ namespace axom
 {
 namespace quest
 {
-namespace internal
-{
-/*!
- * \brief Implementation of a GeometryOperatorVisitor for processing klee shape operators
- *
- * This class extracts the matrix form of supported operators and marks the operator as unvalid otherwise
- * To use, check the \a isValid() function after visiting and then call the \a getMatrix() function.
- */
-class AffineMatrixVisitor : public klee::GeometryOperatorVisitor
-{
-public:
-  AffineMatrixVisitor() : m_matrix(4, 4) { }
-
-  void visit(const klee::Translation& translation) override
-  {
-    m_matrix = translation.toMatrix();
-    m_isValid = true;
-  }
-  void visit(const klee::Rotation& rotation) override
-  {
-    m_matrix = rotation.toMatrix();
-    m_isValid = true;
-  }
-  void visit(const klee::Scale& scale) override
-  {
-    m_matrix = scale.toMatrix();
-    m_isValid = true;
-  }
-  void visit(const klee::UnitConverter& converter) override
-  {
-    m_matrix = converter.toMatrix();
-    m_isValid = true;
-  }
-
-  void visit(const klee::CompositeOperator&) override
-  {
-    SLIC_WARNING_ROOT("CompositeOperator not supported for Shaper query");
-    m_isValid = false;
-  }
-  void visit(const klee::SliceOperator&) override
-  {
-    SLIC_WARNING_ROOT("SliceOperator not yet supported for Shaper query");
-    m_isValid = false;
-  }
-
-  const numerics::Matrix<double>& getMatrix() const { return m_matrix; }
-  bool isValid() const { return m_isValid; }
-
-private:
-  bool m_isValid {false};
-  numerics::Matrix<double> m_matrix;
-};
-
-}  // end namespace internal
 
 // TODO: These were needed for linking - but why? They are constexpr.
 constexpr int DiscreteShape::DEFAULT_SAMPLES_PER_KNOT_SPAN;
@@ -716,45 +662,7 @@ void DiscreteShape::applyTransforms()
 
 numerics::Matrix<double> DiscreteShape::getTransforms() const
 {
-  const auto identity4x4 = numerics::Matrix<double>::identity(4);
-  numerics::Matrix<double> transformation(identity4x4);
-  auto& geometryOperator = m_shape.getGeometry().getGeometryOperator();
-  if(geometryOperator)
-  {
-    auto composite = std::dynamic_pointer_cast<const klee::CompositeOperator>(geometryOperator);
-    if(composite)
-    {
-      // Concatenate the transformations
-
-      // Why don't we multiply the matrices in CompositeOperator::addOperator()?
-      // Why keep the matrices factored and multiply them here repeatedly?
-      // Combining them would also avoid this if-else logic.  BTNG
-      for(auto op : composite->getOperators())
-      {
-        // Use visitor pattern to extract the affine matrix from supported operators
-        internal::AffineMatrixVisitor visitor;
-        op->accept(visitor);
-        if(!visitor.isValid())
-        {
-          continue;
-        }
-        const auto& matrix = visitor.getMatrix();
-        numerics::Matrix<double> res(identity4x4);
-        numerics::matrix_multiply(matrix, transformation, res);
-        transformation = res;
-      }
-    }
-    else
-    {
-      internal::AffineMatrixVisitor visitor;
-      geometryOperator->accept(visitor);
-      if(visitor.isValid())
-      {
-        transformation = visitor.getMatrix();
-      }
-    }
-  }
-  return transformation;
+  return m_shape.getGeometry().getTransform();
 }
 
 // Return a 3x3 matrix that rotates coordinates from the x-axis to the given direction.

--- a/src/axom/quest/MeshClipperStrategy.cpp
+++ b/src/axom/quest/MeshClipperStrategy.cpp
@@ -73,7 +73,7 @@ private:
 
 MeshClipperStrategy::MeshClipperStrategy(const klee::Geometry& kGeom)
   : m_info(kGeom.asHierarchy())
-  , m_extTrans(computeTransformationMatrix(kGeom.getGeometryOperator()))
+  , m_extTrans(kGeom.getTransform())
 { }
 
 const std::string& MeshClipperStrategy::name() const
@@ -92,49 +92,6 @@ const axom::primal::BoundingBox<double, 3>& MeshClipperStrategy::getBoundingBox3
 {
   static const axom::primal::BoundingBox<double, 3> invalidBb3d;
   return invalidBb3d;
-}
-
-numerics::Matrix<double> MeshClipperStrategy::computeTransformationMatrix(
-  const std::shared_ptr<const axom::klee::GeometryOperator>& op) const
-{
-  const auto identity4x4 = numerics::Matrix<double>::identity(4);
-  numerics::Matrix<double> transformation(identity4x4);
-  if(op)
-  {
-    auto composite = std::dynamic_pointer_cast<const klee::CompositeOperator>(op);
-    if(composite)
-    {
-      // Concatenate the transformations
-
-      // Why don't we multiply the matrices in CompositeOperator::addOperator()?
-      // Why keep the matrices factored and multiply them here repeatedly?
-      // Combining them would also avoid this if-else logic.  BTNG
-      for(auto op : composite->getOperators())
-      {
-        // Use visitor pattern to extract the affine matrix from supported operators
-        internal::AffineMatrixVisitor visitor;
-        op->accept(visitor);
-        if(!visitor.isValid())
-        {
-          continue;
-        }
-        const auto& matrix = visitor.getMatrix();
-        numerics::Matrix<double> res(identity4x4);
-        numerics::matrix_multiply(matrix, transformation, res);
-        transformation = res;
-      }
-    }
-    else
-    {
-      internal::AffineMatrixVisitor visitor;
-      op->accept(visitor);
-      if(visitor.isValid())
-      {
-        transformation = visitor.getMatrix();
-      }
-    }
-  }
-  return transformation;
 }
 
 }  // namespace experimental

--- a/src/axom/quest/MeshClipperStrategy.hpp
+++ b/src/axom/quest/MeshClipperStrategy.hpp
@@ -431,13 +431,6 @@ protected:
    * which apply before m_extTrans.
    */
   numerics::Matrix<double> m_extTrans;
-
-private:
-  /*!
-   * @brief Compute the transformation matrix of a GeometryOperator.
-   */
-  numerics::Matrix<double> computeTransformationMatrix(
-    const std::shared_ptr<const axom::klee::GeometryOperator>& op) const;
 };
 
 }  // namespace experimental

--- a/src/axom/quest/tests/quest_sampling_shaper.cpp
+++ b/src/axom/quest/tests/quest_sampling_shaper.cpp
@@ -432,7 +432,6 @@ protected:
 class SamplingShaperTest2D : public SamplingShaperTest
 {
 public:
-  using Point2D = primal::Point<double, 2>;
   using BBox2D = primal::BoundingBox<double, 2>;
 
 public:
@@ -559,7 +558,6 @@ public:
 class SampleTester2D : public SamplingShaperTest
 {
 public:
-  using Point2D = primal::Point<double, 2>;
   using BBox2D = primal::BoundingBox<double, 2>;
 
 public:
@@ -675,9 +673,6 @@ shapes:
 
 TEST_F(SamplingShaperTest2D, basic_circle_projector)
 {
-  using Point2D = primal::Point<double, 2>;
-  using Point3D = primal::Point<double, 3>;
-
   const auto& testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
   const std::string shape_template = R"(
@@ -725,9 +720,6 @@ shapes:
 
 TEST_F(SamplingShaperTest2D, circle_projector_anisotropic)
 {
-  using Point2D = primal::Point<double, 2>;
-  using Point3D = primal::Point<double, 3>;
-
   const auto& testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
   const std::string shape_template = R"(
@@ -833,8 +825,6 @@ shapes:
 
 TEST_F(SamplingShaperTest2D, disk_via_replacement_with_background)
 {
-  using Point2D = typename SamplingShaperTest2D::Point2D;
-
   const auto& testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
   const std::string shape_template = R"(
@@ -943,8 +933,6 @@ shapes:
 
 TEST_F(SamplingShaperTest2D, preshaped_materials)
 {
-  using Point2D = typename SamplingShaperTest2D::Point2D;
-
   const std::string& testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
   const std::string shape_template = R"(
@@ -1024,8 +1012,6 @@ shapes:
 
 TEST_F(SamplingShaperTest2D, disk_with_multiple_preshaped_materials)
 {
-  using Point2D = typename SamplingShaperTest2D::Point2D;
-
   const std::string& testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
   const std::string shape_template = R"(
@@ -1226,9 +1212,6 @@ shapes:
 
 TEST_F(SamplingShaperTest2D, contour_and_stl_2D)
 {
-  using Point2D = primal::Point<double, 2>;
-  using Point3D = primal::Point<double, 3>;
-
   const auto& testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
   constexpr double radius = 1.5;
@@ -1323,8 +1306,6 @@ shapes:
 
 TEST_F(SamplingShaperTest2D, contour_and_mfem_2D)
 {
-  using Point2D = primal::Point<double, 2>;
-
   const auto& testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
   // Shape file
@@ -1726,9 +1707,6 @@ shapes:
 
 TEST_F(SamplingShaperTest3D, tet_boundary_identity_projector)
 {
-  using Point2D = primal::Point<double, 2>;
-  using Point3D = primal::Point<double, 3>;
-
   const auto& testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
   const std::string shape_template = R"(
@@ -1780,9 +1758,6 @@ shapes:
 
 TEST_F(SamplingShaperTest3D, tet_doubling_projector)
 {
-  using Point2D = primal::Point<double, 2>;
-  using Point3D = primal::Point<double, 3>;
-
   const auto& testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
   const std::string shape_template = R"(
@@ -1832,9 +1807,6 @@ shapes:
 
 TEST_F(SamplingShaperTest3D, circle_2D_projector)
 {
-  using Point2D = primal::Point<double, 2>;
-  using Point3D = primal::Point<double, 3>;
-
   const auto& testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
   constexpr double radius = 1.5;
@@ -1894,9 +1866,6 @@ shapes:
 
 TEST_F(SamplingShaperTest3D, contour_and_stl_3D)
 {
-  using Point2D = primal::Point<double, 2>;
-  using Point3D = primal::Point<double, 3>;
-
   const auto& testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
   constexpr double radius = 1.5;
@@ -1970,9 +1939,6 @@ shapes:
 
 TEST_F(SamplingShaperTest2D, shape_proe_tet_with_2D_projection)
 {
-  using Point2D = primal::Point<double, 2>;
-  using Point3D = primal::Point<double, 3>;
-
   const auto& testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
   const std::string shape_template = R"(


### PR DESCRIPTION
This PR resolves #1628.

* Move repeated `AffineMatrixVisitor` class into its own file in klee component
* Enhance transforms.hpp with `scale()` functions that can take a center point
* Enhance klee Scale operator so it can accept center point, if given
* Move repeated code to determine matrix transform for geometry into new `Geometry::getTransform()` method
* Added new tests
* Updated docs and RELEASE-NOTES