### PR TITLE
Disables extra quest regression tests in some CI plans

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -49,7 +49,7 @@ jobs:
         - job_name: llvm@19.0.0, shared, benchmarks, quest regression
           host_config: llvm@19.0.0.cmake
           compiler_image: ${{ needs.set_image_vars.outputs.clang_docker_image }}
-          cmake_opts: '-DBUILD_SHARED_LIBS=ON -DAXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS:BOOL=ON -DENABLE_BENCHMARKS:BOOL=ON'
+          cmake_opts: '-DBUILD_SHARED_LIBS=ON -DENABLE_BENCHMARKS:BOOL=ON'
           do_build: 'yes'
           do_benchmarks: 'yes'
         include:
@@ -101,6 +101,7 @@ jobs:
         run: |
           echo "build_type     ${{ matrix.build_type }}"
           echo "cmake_opts     ${{ matrix.config.cmake_opts }}"
+          echo "quest_extra_regression_tests ${{ contains(matrix.config.job_name, 'quest regression') && 'ON' || 'OFF' }}"
           echo "compiler_image ${{ matrix.config.compiler_image }}"
           echo "host_config    ${{ matrix.config.host_config }}"
       - name: Build and Test ${{ matrix.build_type }} - ${{ matrix.config.job_name }}
@@ -109,7 +110,7 @@ jobs:
           DO_BUILD=${{ matrix.config.do_build }} \
           DO_BENCHMARKS=${{ matrix.config.do_benchmarks }} \
           HOST_CONFIG=${{ matrix.config.host_config }} \
-          CMAKE_EXTRA_FLAGS=" ${{ matrix.config.cmake_opts }} " \
+          CMAKE_EXTRA_FLAGS=" ${{ matrix.config.cmake_opts }} -DAXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS:BOOL=${{ contains(matrix.config.job_name, 'quest regression') && 'ON' || 'OFF' }} " \
           BUILD_TYPE=${{ matrix.build_type }} \
           ./scripts/github-actions/linux-build_and_test.sh
       - name: Upload Test Results
@@ -192,4 +193,3 @@ jobs:
         submodules: recursive
     - name: Check ${{ matrix.check_type }}
       run: ./scripts/github-actions/linux-check.sh 
-

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -58,7 +58,7 @@ jobs:
             job_name: llvm@19.0.0, shared, no raja
             host_config: llvm@19.0.0.cmake
             compiler_image: ${{ needs.set_image_vars.outputs.clang_docker_image }}
-            cmake_opts: '-DBUILD_SHARED_LIBS=ON -DAXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS:BOOL=ON -DAXOM_ENABLE_MIR:BOOL=OFF -DAXOM_ENABLE_BUMP:BOOL=OFF -U RAJA_DIR'
+            cmake_opts: '-DBUILD_SHARED_LIBS=ON -DAXOM_ENABLE_MIR:BOOL=OFF -DAXOM_ENABLE_BUMP:BOOL=OFF -U RAJA_DIR'
             do_build: 'yes'
             do_benchmarks: 'no'
         - build_type: Debug
@@ -66,7 +66,7 @@ jobs:
             job_name: llvm@19.0.0, shared, no umpire
             host_config: llvm@19.0.0.cmake
             compiler_image: ${{ needs.set_image_vars.outputs.clang_docker_image }}
-            cmake_opts: '-DBUILD_SHARED_LIBS=ON -DAXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS:BOOL=ON -U UMPIRE_DIR'
+            cmake_opts: '-DBUILD_SHARED_LIBS=ON -U UMPIRE_DIR'
             do_build: 'yes'
             do_benchmarks: 'no'
         - build_type: Debug
@@ -74,7 +74,7 @@ jobs:
             job_name: llvm@19.0.0, shared, no raja and umpire
             host_config: llvm@19.0.0.cmake
             compiler_image: ${{ needs.set_image_vars.outputs.clang_docker_image }}
-            cmake_opts: '-DBUILD_SHARED_LIBS=ON -DAXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS:BOOL=ON -DAXOM_ENABLE_MIR:BOOL=OFF -DAXOM_ENABLE_BUMP:BOOL=OFF -U RAJA_DIR -U UMPIRE_DIR'
+            cmake_opts: '-DBUILD_SHARED_LIBS=ON -DAXOM_ENABLE_MIR:BOOL=OFF -DAXOM_ENABLE_BUMP:BOOL=OFF -U RAJA_DIR -U UMPIRE_DIR'
             do_build: 'yes'
             do_benchmarks: 'no'
         - build_type: Debug
@@ -82,7 +82,7 @@ jobs:
             job_name: llvm@19.0.0, shared, no profiling
             host_config: llvm@19.0.0.cmake
             compiler_image: ${{ needs.set_image_vars.outputs.clang_docker_image }}
-            cmake_opts: '-DBUILD_SHARED_LIBS=ON -DAXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS:BOOL=ON -U CALIPER_DIR -U ADIAK_DIR'
+            cmake_opts: '-DBUILD_SHARED_LIBS=ON -U CALIPER_DIR -U ADIAK_DIR'
             do_build: 'yes'
             do_benchmarks: 'no'
     name: ${{ matrix.build_type }} - ${{ matrix.config.job_name }}


### PR DESCRIPTION
# Summary

- This PR is aimed at reducing timeouts in some of our github actions CI configs
- It disables extra quest regression tests in some Debug CI configs (controlled via `AXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS` CMake config variable) since they were causing the CI to timeout.
- Resolves https://github.com/llnl/axom/issues/1859

