### PR TITLE
Adds a Durand-Kerner polynomial solver to core and improves solver API

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -27,10 +27,13 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Quest: Adds support for reading mfem files with variable order NURBS curves (requires mfem>4.9).
 - Quest: Adds OMP support for fast GWN methods for STL/Triangulated STEP input and linearized NURBS Curve input.
 - Klee: Adds an optional "center" parameter in scale operators that permits scaling relative to a custom center point.
+- Core: Adds Durand-Kerner polynomial solver which returns the complex roots of a univariate polynomial
+- Core: Adds `axom::Array::pop_back` for API compatibility with `std::vector`
 
 ### Removed
 
 ### Deprecated
+- Core: Deprecates the pointer-based interface to linear-, quadratic- and cubic- polynomial solvers in favor of an ArrayView-based interface
 
 ### Changed
 - Updates CMake code check targets to only use checked in files (via `git ls-files`, when available)

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -743,6 +743,16 @@ public:
   void emplace_back(Args&&... args);
 
   /*!
+   * \brief Removes the last element from the Array.
+   *
+   * \note The size decreases by 1 and the capacity is unchanged.
+   *
+   * \pre DIM == 1
+   * \pre array.empty() == false
+   */
+  void pop_back();
+
+  /*!
    * \brief Push a value to the back of the array.
    *
    * \param [in] value the value to move to the back.
@@ -1588,6 +1598,17 @@ inline void Array<T, DIM, SPACE, StoragePolicy>::emplace_back(Args&&... args)
   static_assert(DIM == 1, "emplace_back is only supported for 1D arrays");
   IndexType insertIndex = reserveForPushBack();
   m_arrayOps.emplace(m_data, insertIndex, std::forward<Args>(args)...);
+}
+
+//------------------------------------------------------------------------------
+template <typename T, int DIM, MemorySpace SPACE, typename StoragePolicy>
+inline void Array<T, DIM, SPACE, StoragePolicy>::pop_back()
+{
+  static_assert(DIM == 1, "pop_back is only supported for 1D arrays");
+  assert(!empty());
+
+  m_arrayOps.destroy(m_data, m_num_elements - 1, 1);
+  updateNumElements(m_num_elements - 1);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -577,7 +577,7 @@ public:
   AXOM_HOST_DEVICE ArrayBase(const StackArray<IndexType, 1>&, int stride = 1) : m_stride(stride) { }
 
   AXOM_HOST_DEVICE ArrayBase(const StackArray<IndexType, 1>&, const StackArray<IndexType, 1>& stride)
-    : m_stride(stride[0])
+    : m_stride(static_cast<int>(stride[0]))
   { }
 
   AXOM_HOST_DEVICE ArrayBase(const StackArray<IndexType, 1>&, const MDMapping<1>& mapping)

--- a/src/axom/core/examples/core_numerics.cpp
+++ b/src/axom/core/examples/core_numerics.cpp
@@ -90,6 +90,7 @@ void demoVectorOps()
   // Find the real roots of a cubic equation.
   // (x + 2)(x - 1)(2x - 3) = 0 = 2x^3 - x^2 - 7x + 6 has real roots at
   // x = -2, x = 1, x = 1.5.
+  // Coefficients are in ascending power order: [c0, c1, c2, c3] for c0 + c1*x + c2*x^2 + c3*x^3
   axom::Array<double> coeff {6., -7., -1., 2.};
   axom::Array<double> roots {0., 0., 0.};
   int numRoots;

--- a/src/axom/core/examples/core_numerics.cpp
+++ b/src/axom/core/examples/core_numerics.cpp
@@ -9,16 +9,17 @@
  */
 
 /* This example code contains snippets used in the Core Sphinx documentation.
-  * They begin and end with comments such as
-  *
-  * timer_start
-  * timer_end
-  *
-  * each prepended with an underscore.
-  */
+ * They begin and end with comments such as
+ *
+ * timer_start
+ * timer_end
+ *
+ * each prepended with an underscore.
+ */
 
 // Axom includes
 #include "axom/core/Macros.hpp"
+#include "axom/core/Array.hpp"
 #include "axom/core/numerics/eigen_solve.hpp"
 #include "axom/core/numerics/jacobi_eigensolve.hpp"
 #include "axom/core/numerics/linear_solve.hpp"
@@ -89,10 +90,10 @@ void demoVectorOps()
   // Find the real roots of a cubic equation.
   // (x + 2)(x - 1)(2x - 3) = 0 = 2x^3 - x^2 - 7x + 6 has real roots at
   // x = -2, x = 1, x = 1.5.
-  double coeff[] = {6., -7., -1., 2.};
-  double roots[3];
+  axom::Array<double> coeff {6., -7., -1., 2.};
+  axom::Array<double> roots {0., 0., 0.};
   int numRoots;
-  int result = numerics::solve_cubic(coeff, roots, numRoots);
+  int result = numerics::solve_cubic(coeff.view(), roots.view(), numRoots);
 
   std::cout << "Root-finding returned " << result
             << " (should be 0, success)."

--- a/src/axom/core/numerics/polynomial_solvers.cpp
+++ b/src/axom/core/numerics/polynomial_solvers.cpp
@@ -69,7 +69,8 @@ int effective_polynomial_degree(ArrayView<const double> coeffs_ascending, double
 //------------------------------------------------------------------------------
 PolynomialRootResult solve_polynomial_durand_kerner_checked(ArrayView<const double> coeffs_ascending,
                                                             double tol,
-                                                            int max_iters)
+                                                            int max_iters,
+                                                            Complex seed)
 {
   PolynomialRootResult result;
   const int degree = static_cast<int>(coeffs_ascending.size()) - 1;
@@ -103,11 +104,12 @@ PolynomialRootResult solve_polynomial_durand_kerner_checked(ArrayView<const doub
   }
 
   result.roots.resize(effective_degree);
-  // Powers of this non-real base with magnitude around 1 give deterministic, distinct initial guesses.
-  const Complex seed_center {0.4, 0.9};
+  // Powers of a non-real base with magnitude around 1 give deterministic, distinct initial guesses.
+  // The seed should be a complex number on or near the unit circle so that the initial guesses
+  // are neither too large nor too small.
   for(int i = 0; i < effective_degree; ++i)
   {
-    result.roots[i] = std::pow(seed_center, i + 1);
+    result.roots[i] = std::pow(seed, i + 1);
   }
 
   // Each sweep updates every root estimate by subtracting p(z_i) divided by
@@ -172,9 +174,10 @@ PolynomialRootResult solve_polynomial_durand_kerner_checked(ArrayView<const doub
 
 //------------------------------------------------------------------------------
 axom::Array<Complex> solve_polynomial_durand_kerner(ArrayView<const double> coeffs_ascending,
-                                                    double tol)
+                                                    double tol,
+                                                    Complex seed)
 {
-  const auto result = solve_polynomial_durand_kerner_checked(coeffs_ascending, tol);
+  const auto result = solve_polynomial_durand_kerner_checked(coeffs_ascending, tol, 200, seed);
   return result.converged ? result.roots : axom::Array<Complex> {};
 }
 

--- a/src/axom/core/numerics/polynomial_solvers.cpp
+++ b/src/axom/core/numerics/polynomial_solvers.cpp
@@ -4,25 +4,26 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "axom/core/utilities/Utilities.hpp"  // for isNearlyEqual()
-
+#include "axom/core/utilities/Utilities.hpp"
 #include "axom/core/numerics/polynomial_solvers.hpp"
 
-// C/C++ includes
-#include <cassert>  // for assert()
+#include <cassert>
+#include <cmath>
 
 namespace axom
 {
 namespace numerics
 {
-//------------------------------------------------------------------------------
-int solve_linear(const double* coeff, double* roots, int& numRoots)
+int solve_linear(ArrayView<const double> coeff, ArrayView<double> roots, int& numRoots)
 {
+  assert(coeff.size() >= 2);
+  assert(roots.size() >= 1);
+
   int status = -1;
 
   // solve ax + b = 0
-  double a = coeff[1];
-  double b = coeff[0];
+  const double a = coeff[1];
+  const double b = coeff[0];
 
   if(utilities::isNearlyEqual(a, 0.))
   {
@@ -50,14 +51,33 @@ int solve_linear(const double* coeff, double* roots, int& numRoots)
 }
 
 //------------------------------------------------------------------------------
-int solve_quadratic(const double* coeff, double* roots, int& numRoots)
+#ifdef _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4244)
+#endif
+int solve_linear(const double* coeff, double* roots, int& numRoots)
 {
+  return solve_linear(ArrayView<const double>(coeff,
+                                              axom::StackArray<axom::IndexType, 1> {2},
+                                              axom::StackArray<axom::IndexType, 1> {1}),
+                      ArrayView<double>(roots,
+                                        axom::StackArray<axom::IndexType, 1> {1},
+                                        axom::StackArray<axom::IndexType, 1> {1}),
+                      numRoots);
+}
+
+//------------------------------------------------------------------------------
+int solve_quadratic(ArrayView<const double> coeff, ArrayView<double> roots, int& numRoots)
+{
+  assert(coeff.size() >= 3);
+  assert(roots.size() >= 2);
+
   int status = -1;
 
   // solve ax^2 + bx + c = 0
-  double a = coeff[2];
-  double b = coeff[1];
-  double c = coeff[0];
+  const double a = coeff[2];
+  const double b = coeff[1];
+  const double c = coeff[0];
 
   if(utilities::isNearlyEqual(a, 0.))
   {
@@ -65,8 +85,8 @@ int solve_quadratic(const double* coeff, double* roots, int& numRoots)
     return solve_linear(coeff, roots, numRoots);
   }
 
-  double discriminant = b * b - 4 * a * c;
-  double overtwoa = 1. / (2 * a);
+  const double discriminant = b * b - 4 * a * c;
+  const double overtwoa = 1. / (2 * a);
 
   if(utilities::isNearlyEqual(discriminant, 0.))
   {
@@ -85,12 +105,24 @@ int solve_quadratic(const double* coeff, double* roots, int& numRoots)
     // Two real roots
     status = 0;
     numRoots = 2;
-    double sqrtdisc = std::sqrt(discriminant);
+    const double sqrtdisc = std::sqrt(discriminant);
     roots[0] = (-b + sqrtdisc) * overtwoa;
     roots[1] = (-b - sqrtdisc) * overtwoa;
   }
 
   return status;
+}
+
+//------------------------------------------------------------------------------
+int solve_quadratic(const double* coeff, double* roots, int& numRoots)
+{
+  return solve_quadratic(ArrayView<const double>(coeff,
+                                                 axom::StackArray<axom::IndexType, 1> {3},
+                                                 axom::StackArray<axom::IndexType, 1> {1}),
+                         ArrayView<double>(roots,
+                                           axom::StackArray<axom::IndexType, 1> {2},
+                                           axom::StackArray<axom::IndexType, 1> {1}),
+                         numRoots);
 }
 
 inline double cuberoot(double x)
@@ -107,8 +139,11 @@ inline double cuberoot(double x)
 }
 
 //------------------------------------------------------------------------------
-int solve_cubic(const double* coeff, double* roots, int& numRoots)
+int solve_cubic(ArrayView<const double> coeff, ArrayView<double> roots, int& numRoots)
 {
+  assert(coeff.size() >= 4);
+  assert(roots.size() >= 3);
+
   int status = -1;
 
   // Here I use variable names as presented in Korn & Korn:
@@ -125,21 +160,21 @@ int solve_cubic(const double* coeff, double* roots, int& numRoots)
   }
 
   // We normalize by dividing all by the cubic coefficient.
-  double invcubecoeff = 1. / cubecoeff;
+  const double invcubecoeff = 1. / cubecoeff;
   a *= invcubecoeff;
   b *= invcubecoeff;
   c *= invcubecoeff;
 
   // Note that p and q differ by a multiplicative constant from Korn,
   // because they're always used with that multiplication.
-  double p = (-a * a + 3 * b) / 9;                      //  1/3 Korn's p
-  double q = (a * (-2 * a * a + 9 * b) - 27 * c) / 54;  // -1/2 Korn's q
+  const double p = (-a * a + 3 * b) / 9;                      //  1/3 Korn's p
+  const double q = (a * (-2 * a * a + 9 * b) - 27 * c) / 54;  // -1/2 Korn's q
 
-  double Q = p * p * p + q * q;  // actual discriminant == -108Q
+  const double Q = p * p * p + q * q;  // actual discriminant == -108Q
   // the term chVar occurs because we've changed variables
   // (x = y - a/3) and we need to change back to x.
   const double onethird = 1. / 3.;
-  double chVar = -a * onethird;
+  const double chVar = -a * onethird;
 
   if(utilities::isNearlyEqual(Q, 0.))
   {
@@ -154,7 +189,7 @@ int solve_cubic(const double* coeff, double* roots, int& numRoots)
     }
     status = 0;
 
-    double cuberootq = cuberoot(q);
+    const double cuberootq = cuberoot(q);
     roots[0] = chVar + 2 * cuberootq;
     roots[1] = chVar - cuberootq;
     roots[2] = roots[1];
@@ -167,9 +202,9 @@ int solve_cubic(const double* coeff, double* roots, int& numRoots)
     numRoots = 1;
     status = 0;
 
-    double sqrtQ = sqrt(Q);
-    double A = cuberoot(q + sqrtQ);
-    double B = cuberoot(q - sqrtQ);
+    const double sqrtQ = sqrt(Q);
+    const double A = cuberoot(q + sqrtQ);
+    const double B = cuberoot(q - sqrtQ);
 
     roots[0] = chVar + A + B;
     roots[1] = 0;
@@ -193,8 +228,8 @@ int solve_cubic(const double* coeff, double* roots, int& numRoots)
     numRoots = 3;
     status = 0;
 
-    double alpha = acos(q / sqrt(-p * p * p));
-    double m = 2 * sqrt(-p);
+    const double alpha = acos(q / sqrt(-p * p * p));
+    const double m = 2 * sqrt(-p);
 
     roots[0] = chVar + m * cos(alpha * onethird);
     roots[1] = chVar - m * cos((alpha + M_PI) * onethird);
@@ -203,6 +238,22 @@ int solve_cubic(const double* coeff, double* roots, int& numRoots)
 
   return status;
 }
+
+//------------------------------------------------------------------------------
+int solve_cubic(const double* coeff, double* roots, int& numRoots)
+{
+  return solve_cubic(ArrayView<const double>(coeff,
+                                             axom::StackArray<axom::IndexType, 1> {4},
+                                             axom::StackArray<axom::IndexType, 1> {1}),
+                     ArrayView<double>(roots,
+                                       axom::StackArray<axom::IndexType, 1> {3},
+                                       axom::StackArray<axom::IndexType, 1> {1}),
+                     numRoots);
+}
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 } /* end namespace numerics */
 } /* end namespace axom */

--- a/src/axom/core/numerics/polynomial_solvers.cpp
+++ b/src/axom/core/numerics/polynomial_solvers.cpp
@@ -19,7 +19,17 @@ namespace numerics
 namespace
 {
 using Complex = std::complex<double>;
+
+double coefficient_scale(ArrayView<const double> coeffs)
+{
+  double scale = 0.0;
+  for(double coeff : coeffs)
+  {
+    scale = axom::utilities::max(scale, std::abs(coeff));
+  }
+  return scale;
 }
+}  // namespace
 
 //------------------------------------------------------------------------------
 axom::Array<double> bernstein_to_monomial(ArrayView<const double> bernstein_coeffs)
@@ -52,8 +62,9 @@ axom::Array<double> bernstein_to_monomial(ArrayView<const double> bernstein_coef
 //------------------------------------------------------------------------------
 int effective_polynomial_degree(ArrayView<const double> coeffs_ascending, double tol)
 {
+  const double trim_threshold = tol * coefficient_scale(coeffs_ascending);
   int degree = static_cast<int>(coeffs_ascending.size()) - 1;
-  while(degree > 0 && std::abs(coeffs_ascending[degree]) <= tol)
+  while(degree > 0 && std::abs(coeffs_ascending[degree]) <= trim_threshold)
   {
     --degree;
   }
@@ -81,6 +92,8 @@ PolynomialRootResult solve_polynomial_durand_kerner_checked(ArrayView<const doub
     return result;
   }
 
+  // Normalize so the Durand-Kerner iteration works with a monic polynomial in
+  // descending power order, regardless of the input scale.
   axom::Array<double> coeffs_descending(effective_degree + 1, effective_degree + 1);
   for(int i = 0; i <= effective_degree; ++i)
   {
@@ -109,6 +122,8 @@ PolynomialRootResult solve_polynomial_durand_kerner_checked(ArrayView<const doub
         }
       }
 
+      // Repeated or tightly clustered roots can make the product nearly zero,
+      // so guard the update against division by an unstable denominator.
       if(std::abs(denom) <= tol)
       {
         denom = Complex {tol, tol};
@@ -135,7 +150,9 @@ PolynomialRootResult solve_polynomial_durand_kerner_checked(ArrayView<const doub
                            std::abs(evaluate_polynomial(coeffs_descending.view(), root)));
   }
 
-  result.converged = result.converged && result.max_residual <= 100.0 * tol;
+  // Residual-based acceptance lets repeated-root cases succeed even when the
+  // update size stalls above tol near a multiple root.
+  result.converged = result.converged || result.max_residual <= 100.0 * tol;
 
   std::sort(result.roots.begin(), result.roots.end(), [](const Complex& lhs, const Complex& rhs) {
     if(lhs.real() != rhs.real())

--- a/src/axom/core/numerics/polynomial_solvers.cpp
+++ b/src/axom/core/numerics/polynomial_solvers.cpp
@@ -73,6 +73,9 @@ PolynomialRootResult solve_polynomial_durand_kerner_checked(ArrayView<const doub
 {
   PolynomialRootResult result;
   const int degree = static_cast<int>(coeffs_ascending.size()) - 1;
+
+  // Degree 0 or negative indicates a constant polynomial with no finite roots.
+  // Empty root array with converged=true signals successful handling of the degenerate case.
   if(degree <= 0)
   {
     result.converged = true;
@@ -81,6 +84,9 @@ PolynomialRootResult solve_polynomial_durand_kerner_checked(ArrayView<const doub
 
   const int effective_degree = effective_polynomial_degree(coeffs_ascending, tol);
   result.effective_degree = effective_degree;
+
+  // Effective degree 0 means the polynomial has been trimmed to a near-constant
+  // after removing near-zero high-order terms. Same handling as degree 0 above.
   if(effective_degree <= 0)
   {
     result.converged = true;
@@ -148,9 +154,10 @@ PolynomialRootResult solve_polynomial_durand_kerner_checked(ArrayView<const doub
                            std::abs(evaluate_polynomial(coeffs_descending.view(), root)));
   }
 
-  // Residual-based acceptance lets repeated-root cases succeed even when the
-  // update size stalls above tol near a multiple root.
-  result.converged = result.converged || result.max_residual <= 100.0 * tol;
+  // Residual-based acceptance lets repeated-root cases succeed even when the update size stalls
+  // above tol near a multiple root. The 100x multiplier accounts for accumulated roundoff error.
+  constexpr double residual_acceptance_factor = 100.0;
+  result.converged = result.converged || result.max_residual <= residual_acceptance_factor * tol;
 
   std::sort(result.roots.begin(), result.roots.end(), [](const Complex& lhs, const Complex& rhs) {
     if(lhs.real() != rhs.real())

--- a/src/axom/core/numerics/polynomial_solvers.cpp
+++ b/src/axom/core/numerics/polynomial_solvers.cpp
@@ -7,13 +7,156 @@
 #include "axom/core/utilities/Utilities.hpp"
 #include "axom/core/numerics/polynomial_solvers.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <complex>
 
 namespace axom
 {
 namespace numerics
 {
+namespace
+{
+using Complex = std::complex<double>;
+}
+
+//------------------------------------------------------------------------------
+axom::Array<double> bernstein_to_monomial(ArrayView<const double> bernstein_coeffs)
+{
+  const axom::IndexType num_coeffs = bernstein_coeffs.size();
+  axom::Array<double> monomial_coeffs(num_coeffs, num_coeffs);
+  for(axom::IndexType i = 0; i < num_coeffs; ++i)
+  {
+    monomial_coeffs[i] = bernstein_coeffs[i];
+  }
+
+  const int degree = static_cast<int>(bernstein_coeffs.size()) - 1;
+
+  for(int order = degree; order >= 1; --order)
+  {
+    for(int j = order; j <= degree; ++j)
+    {
+      monomial_coeffs[j] -= monomial_coeffs[j - 1];
+    }
+  }
+
+  for(int k = 0; k <= degree; ++k)
+  {
+    monomial_coeffs[k] *= axom::utilities::binomialCoefficient(degree, k);
+  }
+
+  return monomial_coeffs;
+}
+
+//------------------------------------------------------------------------------
+int effective_polynomial_degree(ArrayView<const double> coeffs_ascending, double tol)
+{
+  int degree = static_cast<int>(coeffs_ascending.size()) - 1;
+  while(degree > 0 && std::abs(coeffs_ascending[degree]) <= tol)
+  {
+    --degree;
+  }
+  return degree;
+}
+
+//------------------------------------------------------------------------------
+PolynomialRootResult solve_polynomial_durand_kerner_checked(ArrayView<const double> coeffs_ascending,
+                                                            double tol,
+                                                            int max_iters)
+{
+  PolynomialRootResult result;
+  const int degree = static_cast<int>(coeffs_ascending.size()) - 1;
+  if(degree <= 0)
+  {
+    result.converged = true;
+    return result;
+  }
+
+  const int effective_degree = effective_polynomial_degree(coeffs_ascending, tol);
+  result.effective_degree = effective_degree;
+  if(effective_degree <= 0)
+  {
+    result.converged = true;
+    return result;
+  }
+
+  axom::Array<double> coeffs_descending(effective_degree + 1, effective_degree + 1);
+  for(int i = 0; i <= effective_degree; ++i)
+  {
+    coeffs_descending[i] =
+      coeffs_ascending[effective_degree - i] / coeffs_ascending[effective_degree];
+  }
+
+  result.roots.resize(effective_degree);
+  const Complex seed_center {0.4, 0.9};
+  for(int i = 0; i < effective_degree; ++i)
+  {
+    result.roots[i] = std::pow(seed_center, i + 1);
+  }
+
+  for(int iter = 0; iter < max_iters; ++iter)
+  {
+    double max_update = 0.0;
+    for(int i = 0; i < effective_degree; ++i)
+    {
+      Complex denom {1.0, 0.0};
+      for(int j = 0; j < effective_degree; ++j)
+      {
+        if(i != j)
+        {
+          denom *= result.roots[i] - result.roots[j];
+        }
+      }
+
+      if(std::abs(denom) <= tol)
+      {
+        denom = Complex {tol, tol};
+      }
+
+      const Complex update = evaluate_polynomial(coeffs_descending.view(), result.roots[i]) / denom;
+      result.roots[i] -= update;
+      max_update = axom::utilities::max(max_update, std::abs(update));
+    }
+
+    result.iterations = iter + 1;
+    result.max_update = max_update;
+    if(max_update <= tol)
+    {
+      result.converged = true;
+      break;
+    }
+  }
+
+  for(const auto& root : result.roots)
+  {
+    result.max_residual =
+      axom::utilities::max(result.max_residual,
+                           std::abs(evaluate_polynomial(coeffs_descending.view(), root)));
+  }
+
+  result.converged = result.converged && result.max_residual <= 100.0 * tol;
+
+  std::sort(result.roots.begin(), result.roots.end(), [](const Complex& lhs, const Complex& rhs) {
+    if(lhs.real() != rhs.real())
+    {
+      return lhs.real() < rhs.real();
+    }
+    return lhs.imag() < rhs.imag();
+  });
+
+  return result;
+}
+
+//------------------------------------------------------------------------------
+axom::Array<Complex> solve_polynomial_durand_kerner(ArrayView<const double> coeffs_ascending,
+                                                    double tol)
+{
+  const auto result = solve_polynomial_durand_kerner_checked(coeffs_ascending, tol);
+  return result.converged ? result.roots : axom::Array<Complex> {};
+}
+
+//------------------------------------------------------------------------------
 int solve_linear(ArrayView<const double> coeff, ArrayView<double> roots, int& numRoots)
 {
   assert(coeff.size() >= 2);

--- a/src/axom/core/numerics/polynomial_solvers.cpp
+++ b/src/axom/core/numerics/polynomial_solvers.cpp
@@ -34,12 +34,7 @@ double coefficient_scale(ArrayView<const double> coeffs)
 //------------------------------------------------------------------------------
 axom::Array<double> bernstein_to_monomial(ArrayView<const double> bernstein_coeffs)
 {
-  const axom::IndexType num_coeffs = bernstein_coeffs.size();
-  axom::Array<double> monomial_coeffs(num_coeffs, num_coeffs);
-  for(axom::IndexType i = 0; i < num_coeffs; ++i)
-  {
-    monomial_coeffs[i] = bernstein_coeffs[i];
-  }
+  axom::Array<double> monomial_coeffs(bernstein_coeffs);
 
   const int degree = static_cast<int>(bernstein_coeffs.size()) - 1;
 
@@ -92,8 +87,8 @@ PolynomialRootResult solve_polynomial_durand_kerner_checked(ArrayView<const doub
     return result;
   }
 
-  // Normalize so the Durand-Kerner iteration works with a monic polynomial in
-  // descending power order, regardless of the input scale.
+  // Normalize so the Durand-Kerner iteration works with a monic polynomial (highest coefficient 1)
+  // in descending power order, regardless of the input scale.
   axom::Array<double> coeffs_descending(effective_degree + 1, effective_degree + 1);
   for(int i = 0; i <= effective_degree; ++i)
   {
@@ -102,12 +97,15 @@ PolynomialRootResult solve_polynomial_durand_kerner_checked(ArrayView<const doub
   }
 
   result.roots.resize(effective_degree);
+  // Powers of this non-real base with magnitude around 1 give deterministic, distinct initial guesses.
   const Complex seed_center {0.4, 0.9};
   for(int i = 0; i < effective_degree; ++i)
   {
     result.roots[i] = std::pow(seed_center, i + 1);
   }
 
+  // Each sweep updates every root estimate by subtracting p(z_i) divided by
+  // the product of differences from the current guesses for all other roots.
   for(int iter = 0; iter < max_iters; ++iter)
   {
     double max_update = 0.0;

--- a/src/axom/core/numerics/polynomial_solvers.hpp
+++ b/src/axom/core/numerics/polynomial_solvers.hpp
@@ -7,7 +7,10 @@
 #ifndef AXOM_NUMERICS_POLY_SOLVE_HPP_
 #define AXOM_NUMERICS_POLY_SOLVE_HPP_
 
+#include "axom/core/Array.hpp"
 #include "axom/core/ArrayView.hpp"
+
+#include <complex>
 
 /*!
  * \file polynomial_solve.hpp
@@ -28,6 +31,89 @@ namespace axom
 {
 namespace numerics
 {
+
+/*!
+ * \brief Evaluate a polynomial with coefficients stored in descending power order.
+ *
+ * \tparam ScalarType The scalar type used for evaluation, e.g. `double` or `std::complex<double>`.
+ * \param [in] coeffs_descending Polynomial coefficients in descending power order.
+ * \param [in] x The evaluation point.
+ *
+ * \return The polynomial value at `x`.
+ */
+template <typename ScalarType>
+ScalarType evaluate_polynomial(ArrayView<const double> coeffs_descending, const ScalarType& x)
+{
+  ScalarType value {0.0};
+  for(double coeff : coeffs_descending)
+  {
+    value = value * x + coeff;
+  }
+  return value;
+}
+
+/*!
+ * \brief Convert Bernstein coefficients to monomial coefficients on `[0, 1]`.
+ *
+ * Given Bernstein coefficients \f$ b_i \f$ of degree \f$ n \f$, this returns
+ * monomial coefficients \f$ a_i \f$ such that
+ * \f$ \sum_i b_i B_i^n(t) = \sum_i a_i t^i \f$.
+ *
+ * \param [in] bernstein_coeffs Coefficients in the Bernstein basis.
+ *
+ * \return Coefficients in ascending monomial order.
+ */
+axom::Array<double> bernstein_to_monomial(ArrayView<const double> bernstein_coeffs);
+
+/*!
+ * \brief Return the effective degree of a polynomial after trimming near-zero
+ * leading coefficients.
+ *
+ * \param [in] coeffs_ascending Polynomial coefficients in ascending power order.
+ * \param [in] tol Coefficients with magnitude at or below this threshold are
+ * treated as zero when trimming the highest-degree terms.
+ *
+ * \return The largest exponent whose coefficient exceeds `tol`, or `0` if the
+ * polynomial is constant to within the requested tolerance.
+ */
+int effective_polynomial_degree(ArrayView<const double> coeffs_ascending, double tol = 1e-12);
+
+/// \brief Result metadata for an all-roots polynomial solve.
+struct PolynomialRootResult
+{
+  axom::Array<std::complex<double>> roots;
+  bool converged {false};
+  int iterations {0};
+  int effective_degree {0};
+  double max_update {0.0};
+  double max_residual {0.0};
+};
+
+/*!
+ * \brief Approximate all roots of a polynomial using the Durand-Kerner method.
+ *
+ * \param [in] coeffs_ascending Polynomial coefficients in ascending power order.
+ * \param [in] tol Iteration tolerance and effective-zero threshold.
+ *
+ * \return The polynomial roots, sorted by real part and then imaginary part,
+ * or an empty array if the iteration does not converge.
+ */
+axom::Array<std::complex<double>> solve_polynomial_durand_kerner(ArrayView<const double> coeffs_ascending,
+                                                                 double tol = 1e-12);
+
+/*!
+ * \brief Approximate all roots of a polynomial using the Durand-Kerner method,
+ * including convergence diagnostics.
+ *
+ * \param [in] coeffs_ascending Polynomial coefficients in ascending power order.
+ * \param [in] tol Iteration tolerance and effective-zero threshold.
+ * \param [in] max_iters Maximum number of Durand-Kerner iterations.
+ *
+ * \return The roots and convergence metadata for the solve.
+ */
+PolynomialRootResult solve_polynomial_durand_kerner_checked(ArrayView<const double> coeffs_ascending,
+                                                            double tol = 1e-12,
+                                                            int max_iters = 200);
 
 /*!
  * \brief Find the real root for a linear equation of form \f$ ax + b = 0 \f$.
@@ -52,7 +138,8 @@ int solve_linear(ArrayView<const double> coeff, ArrayView<double> roots, int& nu
  * \brief Deprecated pointer-based overload for \ref solve_linear(ArrayView<const
  * double>, ArrayView<double>, int&).
  */
-[[deprecated("Use solve_linear(axom::ArrayView<const double>, axom::ArrayView<double>, int&) instead.")]]
+[[deprecated(
+  "Use solve_linear(axom::ArrayView<const double>, axom::ArrayView<double>, int&) instead.")]]
 int solve_linear(const double* coeff, double* roots, int& numRoots);
 
 /*!
@@ -79,7 +166,8 @@ int solve_quadratic(ArrayView<const double> coeff, ArrayView<double> roots, int&
  * \brief Deprecated pointer-based overload for \ref
  * solve_quadratic(ArrayView<const double>, ArrayView<double>, int&).
  */
-[[deprecated("Use solve_quadratic(axom::ArrayView<const double>, axom::ArrayView<double>, int&) instead.")]]
+[[deprecated(
+  "Use solve_quadratic(axom::ArrayView<const double>, axom::ArrayView<double>, int&) instead.")]]
 int solve_quadratic(const double* coeff, double* roots, int& numRoots);
 
 /*!
@@ -140,7 +228,8 @@ int solve_cubic(ArrayView<const double> coeff, ArrayView<double> roots, int& num
  * \brief Deprecated pointer-based overload for \ref
  * solve_cubic(ArrayView<const double>, ArrayView<double>, int&).
  */
-[[deprecated("Use solve_cubic(axom::ArrayView<const double>, axom::ArrayView<double>, int&) instead.")]]
+[[deprecated(
+  "Use solve_cubic(axom::ArrayView<const double>, axom::ArrayView<double>, int&) instead.")]]
 int solve_cubic(const double* coeff, double* roots, int& numRoots);
 
 }  // namespace numerics

--- a/src/axom/core/numerics/polynomial_solvers.hpp
+++ b/src/axom/core/numerics/polynomial_solvers.hpp
@@ -7,6 +7,8 @@
 #ifndef AXOM_NUMERICS_POLY_SOLVE_HPP_
 #define AXOM_NUMERICS_POLY_SOLVE_HPP_
 
+#include "axom/core/ArrayView.hpp"
+
 /*!
  * \file polynomial_solve.hpp
  * The functions declared in this header file find real roots of polynomials
@@ -18,7 +20,7 @@
  * output array for roots found, and an output int indicating the number
  * of distinct real roots found.
  *
- * Note that coeff[i] = \f$ a_i \f$.  The constant term goes in coeff[0],
+ * Note that coeff[i] = \f$ a_i \f$. The constant term goes in coeff[0],
  * the linear in coeff[1], quadratic in coeff[2], and so forth.
  */
 
@@ -26,6 +28,7 @@ namespace axom
 {
 namespace numerics
 {
+
 /*!
  * \brief Find the real root for a linear equation of form \f$ ax + b = 0 \f$.
  *
@@ -34,14 +37,22 @@ namespace numerics
  * \param [out] roots The real roots of the equation.
  * \param [out] numRoots The number of distinct, real roots found (max: 1).
  *   If the line lies on the X-axis, numRoots is assigned -1 to indicate
- *   infinitely many solutions.  If the line doesn't intersect the X-axis,
+ *   infinitely many solutions. If the line does not intersect the X-axis,
  *   numRoots is assigned 0.
+ *
  * \return 0 for success, or -1 to indicate an inconsistent equation
  *   (all coefficients 0 except for coeff[0]).
  *
- * \pre coeff points to an array of length at least 2.
- * \pre roots points to an array of length at least 1.
+ * \pre coeff.size() >= 2
+ * \pre roots.size() >= 1
  */
+int solve_linear(ArrayView<const double> coeff, ArrayView<double> roots, int& numRoots);
+
+/*!
+ * \brief Deprecated pointer-based overload for \ref solve_linear(ArrayView<const
+ * double>, ArrayView<double>, int&).
+ */
+[[deprecated("Use solve_linear(axom::ArrayView<const double>, axom::ArrayView<double>, int&) instead.")]]
 int solve_linear(const double* coeff, double* roots, int& numRoots);
 
 /*!
@@ -53,14 +64,22 @@ int solve_linear(const double* coeff, double* roots, int& numRoots);
  * \param [out] roots The real roots of the equation.
  * \param [out] numRoots The number of distinct, real roots found (max: 2).
  *   If the equation degenerates to a line lying on the X-axis, numRoots is
- *   assigned -1 to indicate infinitely many solutions.  If the equation
- *   doesn't intersect the X-axis, numRoots is assigned 0.
+ *   assigned -1 to indicate infinitely many solutions. If the equation does
+ *   not intersect the X-axis, numRoots is assigned 0.
+ *
  * \return 0 for success, or -1 to indicate an inconsistent equation
  *   (all coefficients 0 except for coeff[0]).
  *
- * \pre coeff points to an array of length at least 3.
- * \pre roots points to an array of length at least 2.
+ * \pre coeff.size() >= 3
+ * \pre roots.size() >= 2
  */
+int solve_quadratic(ArrayView<const double> coeff, ArrayView<double> roots, int& numRoots);
+
+/*!
+ * \brief Deprecated pointer-based overload for \ref
+ * solve_quadratic(ArrayView<const double>, ArrayView<double>, int&).
+ */
+[[deprecated("Use solve_quadratic(axom::ArrayView<const double>, axom::ArrayView<double>, int&) instead.")]]
 int solve_quadratic(const double* coeff, double* roots, int& numRoots);
 
 /*!
@@ -68,7 +87,7 @@ int solve_quadratic(const double* coeff, double* roots, int& numRoots);
  * find real roots.
  *
  * A closed-form solution for cubic equations was published in Cardano's
- * *Ars Magna* of 1545.  This can be summarized as follows:
+ * *Ars Magna* of 1545. This can be summarized as follows:
  *
  * Start with the cubic equation
  *
@@ -87,13 +106,13 @@ int solve_quadratic(const double* coeff, double* roots, int& numRoots);
  *   \f[ u = \sqrt[3]{\frac{t}{2} \pm \sqrt{\frac{t^2}{4} - 1}}. \f]
  *
  * Because the cubic is an odd function, there can be either one, two, or
- * three distinct real roots.  If there is one distinct real root, the root
- * can either have multiplicity 3, or have multiplicity 1 with two complex
- * roots.  In the case of two real roots, one root will have multiplicity 2.
- * If the discriminant \f$ d = -27t^2 - 4(-3^3) \f$ is zero, the equation has
- * at least one root with multiplicity greater than 1.  If \f$ d > 0, \f$
- * there are three distinct real roots, and if \f$ d > 0, \f$ there is one
- * real root.
+ * three distinct real roots. If there is one distinct real root, the root can
+ * either have multiplicity 3, or have multiplicity 1 with two complex roots.
+ * In the case of two real roots, one root will have multiplicity 2. If the
+ * discriminant \f$ d = -27t^2 - 4(-3^3) \f$ is zero, the equation has at
+ * least one root with multiplicity greater than 1. If \f$ d > 0, \f$ there
+ * are three distinct real roots, and if \f$ d < 0, \f$ there is one real
+ * root.
  *
  * See J. Kopp, Efficient numerical diagonalization of hermitian 3x3 matrices,
  * Int.J.Mod.Phys. C19:523-548, 2008 (https://arxiv.org/abs/physics/0610206)
@@ -106,17 +125,25 @@ int solve_quadratic(const double* coeff, double* roots, int& numRoots);
  * \param [out] roots The real roots of the equation.
  * \param [out] numRoots The number of distinct, real roots found (max: 3).
  *   If the equation degenerates to a line lying on the X-axis, numRoots is
- *   assigned -1 to indicate infinitely many solutions.  If the equation
- *   doesn't intersect the X-axis, numRoots is assigned 0.
+ *   assigned -1 to indicate infinitely many solutions. If the equation does
+ *   not intersect the X-axis, numRoots is assigned 0.
+ *
  * \return 0 for success, or -1 to indicate an inconsistent equation
  *   (all coefficients 0 except for coeff[0]).
  *
- * \pre coeff points to an array of length at least 4.
- * \pre roots points to an array of length at least 3.
+ * \pre coeff.size() >= 4
+ * \pre roots.size() >= 3
  */
+int solve_cubic(ArrayView<const double> coeff, ArrayView<double> roots, int& numRoots);
+
+/*!
+ * \brief Deprecated pointer-based overload for \ref
+ * solve_cubic(ArrayView<const double>, ArrayView<double>, int&).
+ */
+[[deprecated("Use solve_cubic(axom::ArrayView<const double>, axom::ArrayView<double>, int&) instead.")]]
 int solve_cubic(const double* coeff, double* roots, int& numRoots);
 
-} /* end namespace numerics */
-} /* end namespace axom */
+}  // namespace numerics
+}  // namespace axom
 
 #endif  // AXOM_NUMERICS_POLY_SOLVE_HPP_

--- a/src/axom/core/numerics/polynomial_solvers.hpp
+++ b/src/axom/core/numerics/polynomial_solvers.hpp
@@ -102,12 +102,17 @@ struct PolynomialRootResult
  * \param [in] coeffs_ascending Polynomial coefficients in ascending power order.
  * \param [in] tol Iteration tolerance and relative effective-zero threshold
  * used when trimming leading coefficients.
+ * \param [in] seed Seed used to generate deterministic, distinct initial guesses.
+ * This should be a complex number on or near the unit circle (and not purely real),
+ * so that `seed^(i+1)` spreads the starting points around a reasonable radius.
  *
  * \return The polynomial roots, sorted by real part and then imaginary part,
  * or an empty array if the iteration does not converge.
  */
-axom::Array<std::complex<double>> solve_polynomial_durand_kerner(ArrayView<const double> coeffs_ascending,
-                                                                 double tol = 1e-12);
+axom::Array<std::complex<double>> solve_polynomial_durand_kerner(
+  ArrayView<const double> coeffs_ascending,
+  double tol = 1e-12,
+  std::complex<double> seed = std::complex<double> {0.4, 0.9});
 
 /*!
  * \brief Approximate all roots of a polynomial using the Durand-Kerner method,
@@ -120,12 +125,17 @@ axom::Array<std::complex<double>> solve_polynomial_durand_kerner(ArrayView<const
  * which provides reliable convergence for well-conditioned polynomials up to degree ~15-20. 
  * Higher-degree or ill-conditioned polynomials (repeated roots, clustered roots) 
  * may require more iterations or specialized methods.
+ * \param [in] seed Seed used to generate deterministic, distinct initial guesses.
+ * This should be a complex number on or near the unit circle (and not purely real),
+ * so that `seed^(i+1)` spreads the starting points around a reasonable radius.
  *
  * \return The roots and convergence metadata for the solve.
  */
-PolynomialRootResult solve_polynomial_durand_kerner_checked(ArrayView<const double> coeffs_ascending,
-                                                            double tol = 1e-12,
-                                                            int max_iters = 200);
+PolynomialRootResult solve_polynomial_durand_kerner_checked(
+  ArrayView<const double> coeffs_ascending,
+  double tol = 1e-12,
+  int max_iters = 200,
+  std::complex<double> seed = std::complex<double> {0.4, 0.9});
 
 /*!
  * \brief Find the real root for a linear equation of form \f$ ax + b = 0 \f$.

--- a/src/axom/core/numerics/polynomial_solvers.hpp
+++ b/src/axom/core/numerics/polynomial_solvers.hpp
@@ -11,6 +11,7 @@
 #include "axom/core/ArrayView.hpp"
 
 #include <complex>
+#include <type_traits>
 
 /*!
  * \file polynomial_solve.hpp
@@ -44,6 +45,10 @@ namespace numerics
 template <typename ScalarType>
 ScalarType evaluate_polynomial(ArrayView<const double> coeffs_descending, const ScalarType& x)
 {
+  static_assert(
+    std::is_same_v<ScalarType, double> || std::is_same_v<ScalarType, std::complex<double>>,
+    "evaluate_polynomial requires ScalarType to be double or std::complex<double>.");
+
   ScalarType value {0.0};
   for(double coeff : coeffs_descending)
   {

--- a/src/axom/core/numerics/polynomial_solvers.hpp
+++ b/src/axom/core/numerics/polynomial_solvers.hpp
@@ -111,7 +111,10 @@ axom::Array<std::complex<double>> solve_polynomial_durand_kerner(ArrayView<const
  * \param [in] coeffs_ascending Polynomial coefficients in ascending power order.
  * \param [in] tol Iteration tolerance and relative effective-zero threshold
  * used when trimming leading coefficients.
- * \param [in] max_iters Maximum number of Durand-Kerner iterations.
+ * \param [in] max_iters Maximum number of Durand-Kerner iterations. Default is 200,
+ * which provides reliable convergence for well-conditioned polynomials up to degree ~15-20. 
+ * Higher-degree or ill-conditioned polynomials (repeated roots, clustered roots) 
+ * may require more iterations or specialized methods.
  *
  * \return The roots and convergence metadata for the solve.
  */

--- a/src/axom/core/numerics/polynomial_solvers.hpp
+++ b/src/axom/core/numerics/polynomial_solvers.hpp
@@ -70,11 +70,13 @@ axom::Array<double> bernstein_to_monomial(ArrayView<const double> bernstein_coef
  * leading coefficients.
  *
  * \param [in] coeffs_ascending Polynomial coefficients in ascending power order.
- * \param [in] tol Coefficients with magnitude at or below this threshold are
- * treated as zero when trimming the highest-degree terms.
+ * \param [in] tol Relative trimming tolerance. Coefficients with magnitude at
+ * or below `tol * max(abs(coeffs_ascending))` are treated as zero when
+ * trimming the highest-degree terms.
  *
- * \return The largest exponent whose coefficient exceeds `tol`, or `0` if the
- * polynomial is constant to within the requested tolerance.
+ * \return The largest exponent whose coefficient exceeds the scaled trimming
+ * threshold, or `0` if the polynomial is constant to within the requested
+ * tolerance.
  */
 int effective_polynomial_degree(ArrayView<const double> coeffs_ascending, double tol = 1e-12);
 
@@ -93,7 +95,8 @@ struct PolynomialRootResult
  * \brief Approximate all roots of a polynomial using the Durand-Kerner method.
  *
  * \param [in] coeffs_ascending Polynomial coefficients in ascending power order.
- * \param [in] tol Iteration tolerance and effective-zero threshold.
+ * \param [in] tol Iteration tolerance and relative effective-zero threshold
+ * used when trimming leading coefficients.
  *
  * \return The polynomial roots, sorted by real part and then imaginary part,
  * or an empty array if the iteration does not converge.
@@ -106,7 +109,8 @@ axom::Array<std::complex<double>> solve_polynomial_durand_kerner(ArrayView<const
  * including convergence diagnostics.
  *
  * \param [in] coeffs_ascending Polynomial coefficients in ascending power order.
- * \param [in] tol Iteration tolerance and effective-zero threshold.
+ * \param [in] tol Iteration tolerance and relative effective-zero threshold
+ * used when trimming leading coefficients.
  * \param [in] max_iters Maximum number of Durand-Kerner iterations.
  *
  * \return The roots and convergence metadata for the solve.

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -457,6 +457,51 @@ void check_resize(axom::Array<T>& v)
 }
 
 /*!
+ * \brief Check that pop_back() updates the size while keeping capacity and
+ *  existing elements intact.
+ * \param [in] v the Array to check.
+ */
+template <typename T>
+void check_pop_back(axom::Array<T>& v)
+{
+  v.resize(0);
+  v.reserve(4);
+
+  const axom::IndexType capacity = v.capacity();
+  const T* data_ptr = v.data();
+
+  v.push_back(T {1});
+  v.push_back(T {2});
+  v.push_back(T {3});
+
+  EXPECT_EQ(v.size(), 3);
+  EXPECT_EQ(v.capacity(), capacity);
+  EXPECT_EQ(v.data(), data_ptr);
+  EXPECT_EQ(v.front(), T {1});
+  EXPECT_EQ(v.back(), T {3});
+
+  v.pop_back();
+  EXPECT_EQ(v.size(), 2);
+  EXPECT_EQ(v.capacity(), capacity);
+  EXPECT_EQ(v.data(), data_ptr);
+  EXPECT_EQ(v.front(), T {1});
+  EXPECT_EQ(v.back(), T {2});
+
+  v.pop_back();
+  EXPECT_EQ(v.size(), 1);
+  EXPECT_EQ(v.capacity(), capacity);
+  EXPECT_EQ(v.data(), data_ptr);
+  EXPECT_EQ(v.front(), T {1});
+  EXPECT_EQ(v.back(), T {1});
+
+  v.pop_back();
+  EXPECT_TRUE(v.empty());
+  EXPECT_EQ(v.size(), 0);
+  EXPECT_EQ(v.capacity(), capacity);
+  EXPECT_EQ(v.data(), data_ptr);
+}
+
+/*!
  * \brief Check that the insertion into an Array is working properly.
  * \param [in] v the Array to check.
  */
@@ -1166,6 +1211,31 @@ TEST(core_array_DeathTest, checkResize)
   axom::Array<int> v_int(ZERO, size);
   v_int.setResizeRatio(0.99);
   EXPECT_DEATH_IF_SUPPORTED(::check_resize(v_int), "");
+}
+
+//------------------------------------------------------------------------------
+TEST(core_array, checkPopBack)
+{
+  for(axom::IndexType capacity = 2; capacity <= 512; capacity *= 2)
+  {
+    axom::Array<int> v_int(0, capacity);
+    ::check_pop_back(v_int);
+
+    axom::Array<double> v_double(0, capacity);
+    ::check_pop_back(v_double);
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(core_array_DeathTest, popBackEmpty)
+{
+  axom::Array<int> v_int(0, 2);
+#ifdef NDEBUG
+  GTEST_SKIP()
+    << "pop_back() uses assert on empty arrays, so this death test only applies in debug builds.";
+#else
+  EXPECT_DEATH_IF_SUPPORTED(v_int.pop_back(), "");
+#endif
 }
 
 //------------------------------------------------------------------------------
@@ -2466,6 +2536,47 @@ TEST(core_array, reserve_nontrivial_reloc_um)
   }
 }
 #endif
+
+class PopBackTracked
+{
+public:
+  explicit PopBackTracked(int value = 0) : m_value(value) { }
+
+  PopBackTracked(const PopBackTracked&) = default;
+  PopBackTracked(PopBackTracked&&) = default;
+  PopBackTracked& operator=(const PopBackTracked&) = default;
+  PopBackTracked& operator=(PopBackTracked&&) = default;
+
+  ~PopBackTracked() { ++s_destroyCount; }
+
+  int m_value;
+  static int s_destroyCount;
+};
+
+int PopBackTracked::s_destroyCount = 0;
+
+TEST(core_array, popBackDestroysTrailingElement)
+{
+  PopBackTracked::s_destroyCount = 0;
+
+  {
+    axom::Array<PopBackTracked> array(0, 4);
+    array.emplace_back(1);
+    array.emplace_back(2);
+    array.emplace_back(3);
+
+    EXPECT_EQ(array.size(), 3);
+    EXPECT_EQ(PopBackTracked::s_destroyCount, 0);
+
+    array.pop_back();
+
+    EXPECT_EQ(array.size(), 2);
+    EXPECT_EQ(array.back().m_value, 2);
+    EXPECT_EQ(PopBackTracked::s_destroyCount, 1);
+  }
+
+  EXPECT_EQ(PopBackTracked::s_destroyCount, 3);
+}
 
 class AllocatingDefaultInit
 {

--- a/src/axom/core/tests/numerics_polynomial_solvers.hpp
+++ b/src/axom/core/tests/numerics_polynomial_solvers.hpp
@@ -392,4 +392,42 @@ TEST(numerics_polynomial_solvers, solve_polynomial_durand_kerner)
     const auto roots = axom::numerics::solve_polynomial_durand_kerner(coeffs_ascending.view());
     expect_complex_eq(expected_roots, roots);
   }
+
+  {
+    SCOPED_TRACE("Repeated-root cubic is retained when residual is small");
+    const axom::Array<double> coeffs_ascending {-1.0, 3.0, -3.0, 1.0};
+    const auto result =
+      axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view());
+    const auto roots = axom::numerics::solve_polynomial_durand_kerner(coeffs_ascending.view());
+
+    EXPECT_TRUE(result.converged);
+    EXPECT_EQ(result.effective_degree, 3);
+    EXPECT_LE(result.max_residual, 1e-10);
+    ASSERT_EQ(result.roots.size(), 3);
+    ASSERT_EQ(roots.size(), 3);
+    for(axom::IndexType i = 0; i < roots.size(); ++i)
+    {
+      EXPECT_NEAR(roots[i].real(), 1.0, 1e-4);
+      EXPECT_NEAR(roots[i].imag(), 0.0, 1e-4);
+    }
+  }
+
+  {
+    SCOPED_TRACE("Low-scale polynomial keeps its effective degree");
+    const axom::Array<double> coeffs_ascending {1e-20, -2e-20, 1e-20};
+    const auto result =
+      axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view());
+    const auto roots = axom::numerics::solve_polynomial_durand_kerner(coeffs_ascending.view());
+
+    EXPECT_TRUE(result.converged);
+    EXPECT_EQ(result.effective_degree, 2);
+    EXPECT_LE(result.max_residual, 1e-10);
+    ASSERT_EQ(result.roots.size(), 2);
+    ASSERT_EQ(roots.size(), 2);
+    for(axom::IndexType i = 0; i < roots.size(); ++i)
+    {
+      EXPECT_NEAR(roots[i].real(), 1.0, 1e-4);
+      EXPECT_NEAR(roots[i].imag(), 0.0, 1e-4);
+    }
+  }
 }

--- a/src/axom/core/tests/numerics_polynomial_solvers.hpp
+++ b/src/axom/core/tests/numerics_polynomial_solvers.hpp
@@ -15,7 +15,7 @@
 int count_mismatches(const axom::Array<double>& standard,
                      const axom::Array<double>& test,
                      int n,
-                     double thresh = 1.0e-8);
+                     double thresh = 1e-8);
 
 int count_mismatches(const axom::Array<double>& standard,
                      const axom::Array<double>& test,
@@ -37,20 +37,16 @@ int count_mismatches(const axom::Array<double>& standard,
 
 TEST(numerics_polynomial_solvers, solve_linear)
 {
-  axom::Array<double> coeff {0.0, 0.0};
-  axom::Array<double> roots {0.0};
-  axom::Array<double> expected {0.0};
   int n = 1;
-  int rc;
+  int rc = -1;
 
   // In these tests, we are solving ax + b = 0, so
   // coeff[1] = a, coeff[0] = b.
   {
     SCOPED_TRACE("Line 1 through origin.");
-    coeff[0] = 0;
-    coeff[1] = 1;
-    roots[0] = 0;
-    expected[0] = 0;
+    axom::Array<double> coeff {0., 1.};
+    axom::Array<double> roots {0.};
+    axom::Array<double> expected {0.};
     rc = axom::numerics::solve_linear(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
@@ -59,10 +55,9 @@ TEST(numerics_polynomial_solvers, solve_linear)
 
   {
     SCOPED_TRACE("Line 2 through origin.");
-    coeff[0] = 0;
-    coeff[1] = 18;
-    roots[0] = 0;
-    expected[0] = 0;
+    axom::Array<double> coeff {0., 18.};
+    axom::Array<double> roots {0.};
+    axom::Array<double> expected {0.};
     rc = axom::numerics::solve_linear(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
@@ -71,10 +66,9 @@ TEST(numerics_polynomial_solvers, solve_linear)
 
   {
     SCOPED_TRACE("Off origin 1");
-    coeff[0] = -1;
-    coeff[1] = 0.5;
-    roots[0] = 0;
-    expected[0] = 2;
+    axom::Array<double> coeff {-1., 0.5};
+    axom::Array<double> roots {0.};
+    axom::Array<double> expected {2.};
     rc = axom::numerics::solve_linear(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
@@ -83,10 +77,9 @@ TEST(numerics_polynomial_solvers, solve_linear)
 
   {
     SCOPED_TRACE("Off origin 2");
-    coeff[0] = 0.5;
-    coeff[1] = -1;
-    roots[0] = 0;
-    expected[0] = 0.5;
+    axom::Array<double> coeff {0.5, -1};
+    axom::Array<double> roots {0.};
+    axom::Array<double> expected {.5};
     rc = axom::numerics::solve_linear(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
@@ -95,10 +88,9 @@ TEST(numerics_polynomial_solvers, solve_linear)
 
   {
     SCOPED_TRACE("X-axis");
-    coeff[0] = 0;
-    coeff[1] = 0;
-    roots[0] = 0;
-    expected[0] = 0;
+    axom::Array<double> coeff {0., 0.};
+    axom::Array<double> roots {0.};
+    axom::Array<double> expected {0.};
     rc = axom::numerics::solve_linear(coeff.view(), roots.view(), n);
     // rc == 0 because there are real solutions
     EXPECT_EQ(rc, 0);
@@ -110,24 +102,17 @@ TEST(numerics_polynomial_solvers, solve_linear)
 
 TEST(numerics_polynomial_solvers, solve_quadratic)
 {
-  axom::Array<double> coeff {0.0, 0.0, 0.0};
-  axom::Array<double> roots {0.0, 0.0};
-  axom::Array<double> expected {0.0, 0.0};
   int n = 2;
-  int rc;
+  int rc = -1;
 
   // In these tests, we are solving ax^2 + bx + c = 0, so
   // coeff[2] = a, coeff[1] = b, coeff[0] = c.
   {
     // y = (x + 2.3)(x + 2.3)
     SCOPED_TRACE("Double root at x = -2.3");
-    coeff[0] = 5.29;
-    coeff[1] = 4.6;
-    coeff[2] = 1;
-    roots[0] = 0;
-    roots[1] = 0;
-    expected[0] = -2.3;
-    expected[1] = -2.3;
+    axom::Array<double> coeff {5.29, 4.6, 1.};
+    axom::Array<double> roots {0., 0.};
+    axom::Array<double> expected {-2.3, -2.3};
     rc = axom::numerics::solve_quadratic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
@@ -137,13 +122,9 @@ TEST(numerics_polynomial_solvers, solve_quadratic)
   {
     // y = (-x + 1.5)(x - 1.5)
     SCOPED_TRACE("Double root at x = 1.5 (opening down)");
-    coeff[0] = -2.25;
-    coeff[1] = 3;
-    coeff[2] = -1;
-    roots[0] = 0;
-    roots[1] = 0;
-    expected[0] = 1.5;
-    expected[1] = 1.5;
+    axom::Array<double> coeff {-2.25, 3., -1.};
+    axom::Array<double> roots {0., 0.};
+    axom::Array<double> expected {1.5, 1.5};
     rc = axom::numerics::solve_quadratic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
@@ -153,13 +134,9 @@ TEST(numerics_polynomial_solvers, solve_quadratic)
   {
     // y = 3.2(x + 0.7)(x - 2)
     SCOPED_TRACE("Roots at -0.7 and 2");
-    coeff[0] = -4.48;
-    coeff[1] = -4.16;
-    coeff[2] = 3.2;
-    roots[0] = 0;
-    roots[1] = 0;
-    expected[0] = 2;
-    expected[1] = -0.7;
+    axom::Array<double> coeff {-4.48, -4.16, 3.2};
+    axom::Array<double> roots {0., 0.};
+    axom::Array<double> expected {2, -0.7};
     rc = axom::numerics::solve_quadratic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 2);
@@ -169,13 +146,9 @@ TEST(numerics_polynomial_solvers, solve_quadratic)
   {
     // y = 0.1x^2 + 0.2x + 6
     SCOPED_TRACE("No real roots (opening up)");
-    coeff[0] = 6;
-    coeff[1] = 0.2;
-    coeff[2] = 0.1;
-    roots[0] = 0;
-    roots[1] = 0;
-    expected[0] = 0;
-    expected[1] = 0;
+    axom::Array<double> coeff {6, 0.2, 0.1};
+    axom::Array<double> roots {0., 0.};
+    axom::Array<double> expected {0., 0.};
     rc = axom::numerics::solve_quadratic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, -1);
     EXPECT_EQ(n, 0);
@@ -185,13 +158,9 @@ TEST(numerics_polynomial_solvers, solve_quadratic)
   {
     // y = -5x^2 + 0.2x -20
     SCOPED_TRACE("No real roots (opening up)");
-    coeff[0] = 6;
-    coeff[1] = 0.2;
-    coeff[2] = 0.1;
-    roots[0] = 0;
-    roots[1] = 0;
-    expected[0] = 0;
-    expected[1] = 0;
+    axom::Array<double> coeff {6, 0.2, 0.1};
+    axom::Array<double> roots {0., 0.};
+    axom::Array<double> expected {0., 0.};
     rc = axom::numerics::solve_quadratic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, -1);
     EXPECT_EQ(n, 0);
@@ -201,27 +170,20 @@ TEST(numerics_polynomial_solvers, solve_quadratic)
 
 TEST(numerics_polynomial_solvers, solve_cubic)
 {
-  axom::Array<double> coeff {0.0, 0.0, 0.0, 0.0};
-  axom::Array<double> roots {0.0, 0.0, 0.0};
-  axom::Array<double> expected {0.0, 0.0, 0.0};
   int n = 3;
-  int rc;
+  int rc = -1;
 
   // In these tests, we are solving ax^3 + bx^2 + cx + d = 0, so
   // coeff[3] = a, coeff[2] = b, coeff[1] = c, coeff[0] = d.
   {
     // y = (x - 1.2)^3 = 1.0 x^3 - 3.6 x^2 + 4.32 x - 1.728
-    SCOPED_TRACE("Triple root at x = 1.2 (NOTE: LOOSE TOLERANCE HERE)");
-    coeff[0] = -1.728;
-    coeff[1] = 4.32;
-    coeff[2] = -3.6;
-    coeff[3] = 1;
-    roots[0] = 0;
-    roots[1] = 0;
-    roots[2] = 0;
-    expected[0] = 1.2;
-    expected[1] = 1.2;
-    expected[2] = 1.2;
+    // Repeated roots have inherently poor numerical conditioning in polynomial solvers.
+    // We use a looser tolerance here (5e-5 vs default 1e-8) because the discriminant
+    // is nearly zero and floating-point error accumulates during the triple root calculation.
+    SCOPED_TRACE("Triple root at x = 1.2 (loose tolerance due to repeated root conditioning)");
+    axom::Array<double> coeff {-1.728, 4.32, -3.6, 1};
+    axom::Array<double> roots {0., 0., 0.};
+    axom::Array<double> expected {1.2, 1.2, 1.2};
     rc = axom::numerics::solve_cubic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
@@ -231,16 +193,9 @@ TEST(numerics_polynomial_solvers, solve_cubic)
   {
     // y = -x^3 - x + 10
     SCOPED_TRACE("Single real root at x = 2");
-    coeff[0] = 10;
-    coeff[1] = -1;
-    coeff[2] = 0;
-    coeff[3] = -1;
-    roots[0] = 0;
-    roots[1] = 0;
-    roots[2] = 0;
-    expected[0] = 2;
-    expected[1] = 0;
-    expected[2] = 0;
+    axom::Array<double> coeff {10, -1, 0, -1};
+    axom::Array<double> roots {0., 0., 0.};
+    axom::Array<double> expected {2., 0., 0.};
     rc = axom::numerics::solve_cubic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
@@ -250,16 +205,9 @@ TEST(numerics_polynomial_solvers, solve_cubic)
   {
     // y = x^3 + x^2 - 8*x - 12
     SCOPED_TRACE("Two real roots, at x = 3, twice at x = -2");
-    coeff[0] = -12;
-    coeff[1] = -8;
-    coeff[2] = 1;
-    coeff[3] = 1;
-    roots[0] = 0;
-    roots[1] = 0;
-    roots[2] = 0;
-    expected[0] = 3;
-    expected[1] = -2;
-    expected[2] = -2;
+    axom::Array<double> coeff {-12, -8, 1, 1};
+    axom::Array<double> roots {0., 0., 0.};
+    axom::Array<double> expected {3, -2, -2};
     rc = axom::numerics::solve_cubic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 2);
@@ -269,16 +217,9 @@ TEST(numerics_polynomial_solvers, solve_cubic)
   {
     // y = (x + 0.8)(-x + 1)(x - 8) = -3x^3 + 24.6x^2 - 2.4x - 19.2
     SCOPED_TRACE("Three real roots, at x = -0.8, 1, 8");
-    coeff[0] = -19.2;
-    coeff[1] = -2.4;
-    coeff[2] = 24.6;
-    coeff[3] = -3;
-    roots[0] = 0;
-    roots[1] = 0;
-    roots[2] = 0;
-    expected[0] = 8;
-    expected[1] = 1;
-    expected[2] = -0.8;
+    axom::Array<double> coeff {-19.2, -2.4, 24.6, -3};
+    axom::Array<double> roots {0., 0., 0.};
+    axom::Array<double> expected {8, 1, -0.8};
     rc = axom::numerics::solve_cubic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 3);
@@ -289,16 +230,9 @@ TEST(numerics_polynomial_solvers, solve_cubic)
     // y = 4.3(x + 38)(x + 1)(x - 0.001)
     //   = 4.3x^3 + 167.6957x^2 + 163.2323x - 0.1634
     SCOPED_TRACE("Three real roots, at x = -38, -1, 0.001");
-    coeff[0] = -0.1634;
-    coeff[1] = 163.2323;
-    coeff[2] = 167.6957;
-    coeff[3] = 4.3;
-    roots[0] = 0;
-    roots[1] = 0;
-    roots[2] = 0;
-    expected[0] = 0.001;
-    expected[1] = -1;
-    expected[2] = -38;
+    axom::Array<double> coeff {-0.1634, 163.2323, 167.6957, 4.3};
+    axom::Array<double> roots {0., 0., 0.};
+    axom::Array<double> expected {0.001, -1, -38};
     rc = axom::numerics::solve_cubic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 3);
@@ -310,8 +244,8 @@ TEST(numerics_polynomial_solvers, bernstein_to_monomial)
 {
   {
     SCOPED_TRACE("Quadratic Bernstein conversion");
-    const axom::Array<double> bernstein_coeffs {1.0, 2.0, 4.0};
-    const axom::Array<double> expected_monomial {1.0, 2.0, 1.0};
+    const axom::Array<double> bernstein_coeffs {1., 2., 4.};
+    const axom::Array<double> expected_monomial {1., 2., 1.};
     const auto monomial_coeffs = axom::numerics::bernstein_to_monomial(bernstein_coeffs.view());
 
     ASSERT_EQ(expected_monomial.size(), monomial_coeffs.size());
@@ -323,8 +257,8 @@ TEST(numerics_polynomial_solvers, bernstein_to_monomial)
 
   {
     SCOPED_TRACE("Cubic Bernstein conversion");
-    const axom::Array<double> bernstein_coeffs {2.0, 3.0, 5.0, 8.0};
-    const axom::Array<double> expected_monomial {2.0, 3.0, 3.0, 0.0};
+    const axom::Array<double> bernstein_coeffs {2., 3., 5., 8.};
+    const axom::Array<double> expected_monomial {2., 3., 3., 0.};
     const auto monomial_coeffs = axom::numerics::bernstein_to_monomial(bernstein_coeffs.view());
 
     ASSERT_EQ(expected_monomial.size(), monomial_coeffs.size());
@@ -337,12 +271,12 @@ TEST(numerics_polynomial_solvers, bernstein_to_monomial)
 
 TEST(numerics_polynomial_solvers, evaluate_polynomial)
 {
-  const axom::Array<double> coeffs_descending {1.0, -3.0, 2.0};
-  const std::complex<double> x {1.0, 1.0};
+  const axom::Array<double> coeffs_descending {1., -3., 2.};
+  const std::complex<double> x {1., 1.};
   const std::complex<double> value = axom::numerics::evaluate_polynomial(coeffs_descending.view(), x);
 
-  EXPECT_DOUBLE_EQ(-1.0, value.real());
-  EXPECT_DOUBLE_EQ(-1.0, value.imag());
+  EXPECT_DOUBLE_EQ(-1., value.real());
+  EXPECT_DOUBLE_EQ(-1., value.imag());
 }
 
 TEST(numerics_polynomial_solvers, solve_polynomial_durand_kerner)
@@ -360,9 +294,9 @@ TEST(numerics_polynomial_solvers, solve_polynomial_durand_kerner)
 
   {
     SCOPED_TRACE("Two distinct real roots");
-    const axom::Array<double> coeffs_ascending {6.0, -5.0, 1.0};
-    axom::Array<std::complex<double>> expected_roots {std::complex<double> {2.0, 0.0},
-                                                      std::complex<double> {3.0, 0.0}};
+    const axom::Array<double> coeffs_ascending {6., -5., 1.};
+    axom::Array<std::complex<double>> expected_roots {std::complex<double> {2., 0.},
+                                                      std::complex<double> {3., 0.}};
     const auto result =
       axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view());
     EXPECT_TRUE(result.converged);
@@ -373,9 +307,9 @@ TEST(numerics_polynomial_solvers, solve_polynomial_durand_kerner)
 
   {
     SCOPED_TRACE("Purely imaginary roots");
-    const axom::Array<double> coeffs_ascending {1.0, 0.0, 1.0};
-    axom::Array<std::complex<double>> expected_roots {std::complex<double> {0.0, -1.0},
-                                                      std::complex<double> {0.0, 1.0}};
+    const axom::Array<double> coeffs_ascending {1., 0., 1.};
+    axom::Array<std::complex<double>> expected_roots {std::complex<double> {0., -1.},
+                                                      std::complex<double> {0., 1.}};
     const auto result =
       axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view());
     EXPECT_TRUE(result.converged);
@@ -386,16 +320,19 @@ TEST(numerics_polynomial_solvers, solve_polynomial_durand_kerner)
 
   {
     SCOPED_TRACE("Trailing zero high-order coefficient is ignored");
-    const axom::Array<double> coeffs_ascending {2.0, -3.0, 1.0, 0.0};
-    axom::Array<std::complex<double>> expected_roots {std::complex<double> {1.0, 0.0},
-                                                      std::complex<double> {2.0, 0.0}};
+    const axom::Array<double> coeffs_ascending {2., -3., 1., 0.};
+    axom::Array<std::complex<double>> expected_roots {std::complex<double> {1., 0.},
+                                                      std::complex<double> {2., 0.}};
     const auto roots = axom::numerics::solve_polynomial_durand_kerner(coeffs_ascending.view());
     expect_complex_eq(expected_roots, roots);
   }
 
   {
+    // Durand-Kerner converges slowly near repeated roots due to the denominator
+    // becoming small (product of differences approaches zero). We use 1e-4 tolerance
+    // here because the roots cluster rather than separate to machine precision.
     SCOPED_TRACE("Repeated-root cubic is retained when residual is small");
-    const axom::Array<double> coeffs_ascending {-1.0, 3.0, -3.0, 1.0};
+    const axom::Array<double> coeffs_ascending {-1., 3., -3., 1.};
     const auto result =
       axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view());
     const auto roots = axom::numerics::solve_polynomial_durand_kerner(coeffs_ascending.view());
@@ -407,12 +344,15 @@ TEST(numerics_polynomial_solvers, solve_polynomial_durand_kerner)
     ASSERT_EQ(roots.size(), 3);
     for(axom::IndexType i = 0; i < roots.size(); ++i)
     {
-      EXPECT_NEAR(roots[i].real(), 1.0, 1e-4);
-      EXPECT_NEAR(roots[i].imag(), 0.0, 1e-4);
+      EXPECT_NEAR(roots[i].real(), 1., 1e-4);
+      EXPECT_NEAR(roots[i].imag(), 0., 1e-4);
     }
   }
 
   {
+    // Despite tiny coefficients (1e-20 scale), the polynomial (t-1)^2 has the same
+    // root structure. The repeated root at t=1 still exhibits clustering behavior,
+    // so we use 1e-4 tolerance to account for the slow Durand-Kerner convergence.
     SCOPED_TRACE("Low-scale polynomial keeps its effective degree");
     const axom::Array<double> coeffs_ascending {1e-20, -2e-20, 1e-20};
     const auto result =
@@ -426,8 +366,8 @@ TEST(numerics_polynomial_solvers, solve_polynomial_durand_kerner)
     ASSERT_EQ(roots.size(), 2);
     for(axom::IndexType i = 0; i < roots.size(); ++i)
     {
-      EXPECT_NEAR(roots[i].real(), 1.0, 1e-4);
-      EXPECT_NEAR(roots[i].imag(), 0.0, 1e-4);
+      EXPECT_NEAR(roots[i].real(), 1., 1e-4);
+      EXPECT_NEAR(roots[i].imag(), 0., 1e-4);
     }
   }
 }

--- a/src/axom/core/tests/numerics_polynomial_solvers.hpp
+++ b/src/axom/core/tests/numerics_polynomial_solvers.hpp
@@ -5,15 +5,22 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 // Axom includes
+#include "axom/core/Array.hpp"
 #include "axom/core/numerics/polynomial_solvers.hpp"
 #include "axom/core/utilities/Utilities.hpp"  // for isNearlyEqual()
 
 // Google Test include
 #include "gtest/gtest.h"
 
-int count_mismatches(double* standard, double* test, int n, double thresh = 1.0e-8);
+int count_mismatches(const axom::Array<double>& standard,
+                     const axom::Array<double>& test,
+                     int n,
+                     double thresh = 1.0e-8);
 
-int count_mismatches(double* standard, double* test, int n, double thresh)
+int count_mismatches(const axom::Array<double>& standard,
+                     const axom::Array<double>& test,
+                     int n,
+                     double thresh)
 {
   int mcount = 0;
 
@@ -30,9 +37,9 @@ int count_mismatches(double* standard, double* test, int n, double thresh)
 
 TEST(numerics_polynomial_solvers, solve_linear)
 {
-  double coeff[2];
-  double roots[1];
-  double expected[1];
+  axom::Array<double> coeff {0.0, 0.0};
+  axom::Array<double> roots {0.0};
+  axom::Array<double> expected {0.0};
   int n = 1;
   int rc;
 
@@ -44,7 +51,7 @@ TEST(numerics_polynomial_solvers, solve_linear)
     coeff[1] = 1;
     roots[0] = 0;
     expected[0] = 0;
-    rc = axom::numerics::solve_linear(coeff, roots, n);
+    rc = axom::numerics::solve_linear(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
     EXPECT_EQ(count_mismatches(expected, roots, 1), 0);
@@ -56,7 +63,7 @@ TEST(numerics_polynomial_solvers, solve_linear)
     coeff[1] = 18;
     roots[0] = 0;
     expected[0] = 0;
-    rc = axom::numerics::solve_linear(coeff, roots, n);
+    rc = axom::numerics::solve_linear(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
     EXPECT_EQ(count_mismatches(expected, roots, 1), 0);
@@ -68,7 +75,7 @@ TEST(numerics_polynomial_solvers, solve_linear)
     coeff[1] = 0.5;
     roots[0] = 0;
     expected[0] = 2;
-    rc = axom::numerics::solve_linear(coeff, roots, n);
+    rc = axom::numerics::solve_linear(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
     EXPECT_EQ(count_mismatches(expected, roots, 1), 0);
@@ -80,7 +87,7 @@ TEST(numerics_polynomial_solvers, solve_linear)
     coeff[1] = -1;
     roots[0] = 0;
     expected[0] = 0.5;
-    rc = axom::numerics::solve_linear(coeff, roots, n);
+    rc = axom::numerics::solve_linear(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
     EXPECT_EQ(count_mismatches(expected, roots, 1), 0);
@@ -92,7 +99,7 @@ TEST(numerics_polynomial_solvers, solve_linear)
     coeff[1] = 0;
     roots[0] = 0;
     expected[0] = 0;
-    rc = axom::numerics::solve_linear(coeff, roots, n);
+    rc = axom::numerics::solve_linear(coeff.view(), roots.view(), n);
     // rc == 0 because there are real solutions
     EXPECT_EQ(rc, 0);
     // n == -1 because there are infinitely many solutions
@@ -103,9 +110,9 @@ TEST(numerics_polynomial_solvers, solve_linear)
 
 TEST(numerics_polynomial_solvers, solve_quadratic)
 {
-  double coeff[3];
-  double roots[2];
-  double expected[2];
+  axom::Array<double> coeff {0.0, 0.0, 0.0};
+  axom::Array<double> roots {0.0, 0.0};
+  axom::Array<double> expected {0.0, 0.0};
   int n = 2;
   int rc;
 
@@ -121,7 +128,7 @@ TEST(numerics_polynomial_solvers, solve_quadratic)
     roots[1] = 0;
     expected[0] = -2.3;
     expected[1] = -2.3;
-    rc = axom::numerics::solve_quadratic(coeff, roots, n);
+    rc = axom::numerics::solve_quadratic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
     EXPECT_EQ(count_mismatches(expected, roots, 2), 0);
@@ -137,7 +144,7 @@ TEST(numerics_polynomial_solvers, solve_quadratic)
     roots[1] = 0;
     expected[0] = 1.5;
     expected[1] = 1.5;
-    rc = axom::numerics::solve_quadratic(coeff, roots, n);
+    rc = axom::numerics::solve_quadratic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
     EXPECT_EQ(count_mismatches(expected, roots, 2), 0);
@@ -153,7 +160,7 @@ TEST(numerics_polynomial_solvers, solve_quadratic)
     roots[1] = 0;
     expected[0] = 2;
     expected[1] = -0.7;
-    rc = axom::numerics::solve_quadratic(coeff, roots, n);
+    rc = axom::numerics::solve_quadratic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 2);
     EXPECT_EQ(count_mismatches(expected, roots, 2), 0);
@@ -169,7 +176,7 @@ TEST(numerics_polynomial_solvers, solve_quadratic)
     roots[1] = 0;
     expected[0] = 0;
     expected[1] = 0;
-    rc = axom::numerics::solve_quadratic(coeff, roots, n);
+    rc = axom::numerics::solve_quadratic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, -1);
     EXPECT_EQ(n, 0);
     EXPECT_EQ(count_mismatches(expected, roots, 2), 0);
@@ -185,7 +192,7 @@ TEST(numerics_polynomial_solvers, solve_quadratic)
     roots[1] = 0;
     expected[0] = 0;
     expected[1] = 0;
-    rc = axom::numerics::solve_quadratic(coeff, roots, n);
+    rc = axom::numerics::solve_quadratic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, -1);
     EXPECT_EQ(n, 0);
     EXPECT_EQ(count_mismatches(expected, roots, 2), 0);
@@ -194,9 +201,9 @@ TEST(numerics_polynomial_solvers, solve_quadratic)
 
 TEST(numerics_polynomial_solvers, solve_cubic)
 {
-  double coeff[4];
-  double roots[3];
-  double expected[3];
+  axom::Array<double> coeff {0.0, 0.0, 0.0, 0.0};
+  axom::Array<double> roots {0.0, 0.0, 0.0};
+  axom::Array<double> expected {0.0, 0.0, 0.0};
   int n = 3;
   int rc;
 
@@ -215,7 +222,7 @@ TEST(numerics_polynomial_solvers, solve_cubic)
     expected[0] = 1.2;
     expected[1] = 1.2;
     expected[2] = 1.2;
-    rc = axom::numerics::solve_cubic(coeff, roots, n);
+    rc = axom::numerics::solve_cubic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
     EXPECT_EQ(count_mismatches(expected, roots, 3, 5.0e-5), 0);
@@ -234,7 +241,7 @@ TEST(numerics_polynomial_solvers, solve_cubic)
     expected[0] = 2;
     expected[1] = 0;
     expected[2] = 0;
-    rc = axom::numerics::solve_cubic(coeff, roots, n);
+    rc = axom::numerics::solve_cubic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 1);
     EXPECT_EQ(count_mismatches(expected, roots, 3), 0);
@@ -253,7 +260,7 @@ TEST(numerics_polynomial_solvers, solve_cubic)
     expected[0] = 3;
     expected[1] = -2;
     expected[2] = -2;
-    rc = axom::numerics::solve_cubic(coeff, roots, n);
+    rc = axom::numerics::solve_cubic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 2);
     EXPECT_EQ(count_mismatches(expected, roots, 3), 0);
@@ -272,7 +279,7 @@ TEST(numerics_polynomial_solvers, solve_cubic)
     expected[0] = 8;
     expected[1] = 1;
     expected[2] = -0.8;
-    rc = axom::numerics::solve_cubic(coeff, roots, n);
+    rc = axom::numerics::solve_cubic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 3);
     EXPECT_EQ(count_mismatches(expected, roots, 3), 0);
@@ -292,7 +299,7 @@ TEST(numerics_polynomial_solvers, solve_cubic)
     expected[0] = 0.001;
     expected[1] = -1;
     expected[2] = -38;
-    rc = axom::numerics::solve_cubic(coeff, roots, n);
+    rc = axom::numerics::solve_cubic(coeff.view(), roots.view(), n);
     EXPECT_EQ(rc, 0);
     EXPECT_EQ(n, 3);
     EXPECT_EQ(count_mismatches(expected, roots, 3), 0);

--- a/src/axom/core/tests/numerics_polynomial_solvers.hpp
+++ b/src/axom/core/tests/numerics_polynomial_solvers.hpp
@@ -292,17 +292,35 @@ TEST(numerics_polynomial_solvers, solve_polynomial_durand_kerner)
     }
   };
 
+  const axom::Array<std::complex<double>> seeds {std::complex<double> {0.4, 0.9},
+                                                 std::complex<double> {0.8, 0.6},
+                                                 std::complex<double> {0.99, 0.1}};
+
+  auto seed_trace = [](std::complex<double> seed) {
+    return ::testing::Message() << "Seed=(" << seed.real() << ", " << seed.imag() << ")";
+  };
+
+  constexpr int max_iters = 200;
+  constexpr double tol = 1e-12;
+
   {
     SCOPED_TRACE("Two distinct real roots");
     const axom::Array<double> coeffs_ascending {6., -5., 1.};
     axom::Array<std::complex<double>> expected_roots {std::complex<double> {2., 0.},
                                                       std::complex<double> {3., 0.}};
-    const auto result =
-      axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view());
-    EXPECT_TRUE(result.converged);
-    EXPECT_EQ(result.effective_degree, 2);
-    EXPECT_LE(result.max_residual, 1e-10);
-    expect_complex_eq(expected_roots, result.roots);
+    for(const auto& seed : seeds)
+    {
+      SCOPED_TRACE(seed_trace(seed));
+      const auto result =
+        axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view(),
+                                                               tol,
+                                                               max_iters,
+                                                               seed);
+      EXPECT_TRUE(result.converged);
+      EXPECT_EQ(result.effective_degree, 2);
+      EXPECT_LE(result.max_residual, 1e-10);
+      expect_complex_eq(expected_roots, result.roots);
+    }
   }
 
   {
@@ -310,12 +328,19 @@ TEST(numerics_polynomial_solvers, solve_polynomial_durand_kerner)
     const axom::Array<double> coeffs_ascending {1., 0., 1.};
     axom::Array<std::complex<double>> expected_roots {std::complex<double> {0., -1.},
                                                       std::complex<double> {0., 1.}};
-    const auto result =
-      axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view());
-    EXPECT_TRUE(result.converged);
-    EXPECT_EQ(result.effective_degree, 2);
-    EXPECT_LE(result.max_residual, 1e-10);
-    expect_complex_eq(expected_roots, result.roots);
+    for(const auto& seed : seeds)
+    {
+      SCOPED_TRACE(seed_trace(seed));
+      const auto result =
+        axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view(),
+                                                               tol,
+                                                               max_iters,
+                                                               seed);
+      EXPECT_TRUE(result.converged);
+      EXPECT_EQ(result.effective_degree, 2);
+      EXPECT_LE(result.max_residual, 1e-10);
+      expect_complex_eq(expected_roots, result.roots);
+    }
   }
 
   {
@@ -323,8 +348,13 @@ TEST(numerics_polynomial_solvers, solve_polynomial_durand_kerner)
     const axom::Array<double> coeffs_ascending {2., -3., 1., 0.};
     axom::Array<std::complex<double>> expected_roots {std::complex<double> {1., 0.},
                                                       std::complex<double> {2., 0.}};
-    const auto roots = axom::numerics::solve_polynomial_durand_kerner(coeffs_ascending.view());
-    expect_complex_eq(expected_roots, roots);
+    for(const auto& seed : seeds)
+    {
+      SCOPED_TRACE(seed_trace(seed));
+      const auto roots =
+        axom::numerics::solve_polynomial_durand_kerner(coeffs_ascending.view(), tol, seed);
+      expect_complex_eq(expected_roots, roots);
+    }
   }
 
   {
@@ -333,19 +363,27 @@ TEST(numerics_polynomial_solvers, solve_polynomial_durand_kerner)
     // here because the roots cluster rather than separate to machine precision.
     SCOPED_TRACE("Repeated-root cubic is retained when residual is small");
     const axom::Array<double> coeffs_ascending {-1., 3., -3., 1.};
-    const auto result =
-      axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view());
-    const auto roots = axom::numerics::solve_polynomial_durand_kerner(coeffs_ascending.view());
-
-    EXPECT_TRUE(result.converged);
-    EXPECT_EQ(result.effective_degree, 3);
-    EXPECT_LE(result.max_residual, 1e-10);
-    ASSERT_EQ(result.roots.size(), 3);
-    ASSERT_EQ(roots.size(), 3);
-    for(axom::IndexType i = 0; i < roots.size(); ++i)
+    for(const auto& seed : seeds)
     {
-      EXPECT_NEAR(roots[i].real(), 1., 1e-4);
-      EXPECT_NEAR(roots[i].imag(), 0., 1e-4);
+      SCOPED_TRACE(seed_trace(seed));
+      const auto result =
+        axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view(),
+                                                               tol,
+                                                               max_iters,
+                                                               seed);
+      const auto roots =
+        axom::numerics::solve_polynomial_durand_kerner(coeffs_ascending.view(), tol, seed);
+
+      EXPECT_TRUE(result.converged);
+      EXPECT_EQ(result.effective_degree, 3);
+      EXPECT_LE(result.max_residual, 1e-10);
+      ASSERT_EQ(result.roots.size(), 3);
+      ASSERT_EQ(roots.size(), 3);
+      for(axom::IndexType i = 0; i < roots.size(); ++i)
+      {
+        EXPECT_NEAR(roots[i].real(), 1., 1e-4);
+        EXPECT_NEAR(roots[i].imag(), 0., 1e-4);
+      }
     }
   }
 
@@ -355,19 +393,27 @@ TEST(numerics_polynomial_solvers, solve_polynomial_durand_kerner)
     // so we use 1e-4 tolerance to account for the slow Durand-Kerner convergence.
     SCOPED_TRACE("Low-scale polynomial keeps its effective degree");
     const axom::Array<double> coeffs_ascending {1e-20, -2e-20, 1e-20};
-    const auto result =
-      axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view());
-    const auto roots = axom::numerics::solve_polynomial_durand_kerner(coeffs_ascending.view());
-
-    EXPECT_TRUE(result.converged);
-    EXPECT_EQ(result.effective_degree, 2);
-    EXPECT_LE(result.max_residual, 1e-10);
-    ASSERT_EQ(result.roots.size(), 2);
-    ASSERT_EQ(roots.size(), 2);
-    for(axom::IndexType i = 0; i < roots.size(); ++i)
+    for(const auto& seed : seeds)
     {
-      EXPECT_NEAR(roots[i].real(), 1., 1e-4);
-      EXPECT_NEAR(roots[i].imag(), 0., 1e-4);
+      SCOPED_TRACE(seed_trace(seed));
+      const auto result =
+        axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view(),
+                                                               tol,
+                                                               max_iters,
+                                                               seed);
+      const auto roots =
+        axom::numerics::solve_polynomial_durand_kerner(coeffs_ascending.view(), tol, seed);
+
+      EXPECT_TRUE(result.converged);
+      EXPECT_EQ(result.effective_degree, 2);
+      EXPECT_LE(result.max_residual, 1e-10);
+      ASSERT_EQ(result.roots.size(), 2);
+      ASSERT_EQ(roots.size(), 2);
+      for(axom::IndexType i = 0; i < roots.size(); ++i)
+      {
+        EXPECT_NEAR(roots[i].real(), 1., 1e-4);
+        EXPECT_NEAR(roots[i].imag(), 0., 1e-4);
+      }
     }
   }
 }

--- a/src/axom/core/tests/numerics_polynomial_solvers.hpp
+++ b/src/axom/core/tests/numerics_polynomial_solvers.hpp
@@ -305,3 +305,91 @@ TEST(numerics_polynomial_solvers, solve_cubic)
     EXPECT_EQ(count_mismatches(expected, roots, 3), 0);
   }
 }
+
+TEST(numerics_polynomial_solvers, bernstein_to_monomial)
+{
+  {
+    SCOPED_TRACE("Quadratic Bernstein conversion");
+    const axom::Array<double> bernstein_coeffs {1.0, 2.0, 4.0};
+    const axom::Array<double> expected_monomial {1.0, 2.0, 1.0};
+    const auto monomial_coeffs = axom::numerics::bernstein_to_monomial(bernstein_coeffs.view());
+
+    ASSERT_EQ(expected_monomial.size(), monomial_coeffs.size());
+    for(axom::IndexType i = 0; i < expected_monomial.size(); ++i)
+    {
+      EXPECT_DOUBLE_EQ(expected_monomial[i], monomial_coeffs[i]);
+    }
+  }
+
+  {
+    SCOPED_TRACE("Cubic Bernstein conversion");
+    const axom::Array<double> bernstein_coeffs {2.0, 3.0, 5.0, 8.0};
+    const axom::Array<double> expected_monomial {2.0, 3.0, 3.0, 0.0};
+    const auto monomial_coeffs = axom::numerics::bernstein_to_monomial(bernstein_coeffs.view());
+
+    ASSERT_EQ(expected_monomial.size(), monomial_coeffs.size());
+    for(axom::IndexType i = 0; i < expected_monomial.size(); ++i)
+    {
+      EXPECT_DOUBLE_EQ(expected_monomial[i], monomial_coeffs[i]);
+    }
+  }
+}
+
+TEST(numerics_polynomial_solvers, evaluate_polynomial)
+{
+  const axom::Array<double> coeffs_descending {1.0, -3.0, 2.0};
+  const std::complex<double> x {1.0, 1.0};
+  const std::complex<double> value = axom::numerics::evaluate_polynomial(coeffs_descending.view(), x);
+
+  EXPECT_DOUBLE_EQ(-1.0, value.real());
+  EXPECT_DOUBLE_EQ(-1.0, value.imag());
+}
+
+TEST(numerics_polynomial_solvers, solve_polynomial_durand_kerner)
+{
+  auto expect_complex_eq = [](const axom::Array<std::complex<double>>& expected,
+                              const axom::Array<std::complex<double>>& actual,
+                              double tol = 1e-10) {
+    ASSERT_EQ(expected.size(), actual.size());
+    for(axom::IndexType i = 0; i < expected.size(); ++i)
+    {
+      EXPECT_NEAR(expected[i].real(), actual[i].real(), tol);
+      EXPECT_NEAR(expected[i].imag(), actual[i].imag(), tol);
+    }
+  };
+
+  {
+    SCOPED_TRACE("Two distinct real roots");
+    const axom::Array<double> coeffs_ascending {6.0, -5.0, 1.0};
+    axom::Array<std::complex<double>> expected_roots {std::complex<double> {2.0, 0.0},
+                                                      std::complex<double> {3.0, 0.0}};
+    const auto result =
+      axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view());
+    EXPECT_TRUE(result.converged);
+    EXPECT_EQ(result.effective_degree, 2);
+    EXPECT_LE(result.max_residual, 1e-10);
+    expect_complex_eq(expected_roots, result.roots);
+  }
+
+  {
+    SCOPED_TRACE("Purely imaginary roots");
+    const axom::Array<double> coeffs_ascending {1.0, 0.0, 1.0};
+    axom::Array<std::complex<double>> expected_roots {std::complex<double> {0.0, -1.0},
+                                                      std::complex<double> {0.0, 1.0}};
+    const auto result =
+      axom::numerics::solve_polynomial_durand_kerner_checked(coeffs_ascending.view());
+    EXPECT_TRUE(result.converged);
+    EXPECT_EQ(result.effective_degree, 2);
+    EXPECT_LE(result.max_residual, 1e-10);
+    expect_complex_eq(expected_roots, result.roots);
+  }
+
+  {
+    SCOPED_TRACE("Trailing zero high-order coefficient is ignored");
+    const axom::Array<double> coeffs_ascending {2.0, -3.0, 1.0, 0.0};
+    axom::Array<std::complex<double>> expected_roots {std::complex<double> {1.0, 0.0},
+                                                      std::complex<double> {2.0, 0.0}};
+    const auto roots = axom::numerics::solve_polynomial_durand_kerner(coeffs_ascending.view());
+    expect_complex_eq(expected_roots, roots);
+  }
+}


### PR DESCRIPTION
# Summary

- This PR improves Axom's polynomial solver capabilities
- It adds a [Durand-Kerner polynomial solver](https://en.wikipedia.org/wiki/Durand%E2%80%93Kerner_method), which returns the complex roots for a univariate polynomial
- It also modernizes the API for the linear, quadratic and cubic solvers to use `axom::ArrayView`s instead of pointers to C-style arrays. The latter have been deprecated
- Misc: It also adds `axom::Array::pop_back()` for compatibility with `std::vector`

# Durand-Kerner solver
Here's a visualization (courtesy of claude) of how the solver works for the polynomial: $z^3-1$, initialized with three seed points near the unit circle -- powers of $.4+.9i$

<img width="768" height="600" alt="durand_kerner_z3_minus_1" src="https://github.com/user-attachments/assets/f5d82c62-9f19-45bc-a51a-8abbf8134ab4" />
