### PR TITLE
Fixes sign convention for primal's compute_moments

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,6 +39,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Updates CMake code check targets to only use checked in files (via `git ls-files`, when available)
 
 ### Fixed
+- Primal: Fixes signs of `compute_moments` to match orientation convention in `primal::evaluate_area_integral`
 
 ## [Version 0.14.0] - Release date 2026-03-31
 

--- a/src/axom/primal/operators/compute_moments.hpp
+++ b/src/axom/primal/operators/compute_moments.hpp
@@ -10,7 +10,7 @@
 /*!
  * \file compute_moments.hpp
  *
- * \brief Consists of a set of methods to compute areas/volumes and centroids 
+ * \brief Consists of a set of methods to compute areas/volumes and centroids
  * for Polygon and CurvedPolygon objects composed of nonrational BezierCurve objects
  */
 
@@ -29,13 +29,13 @@ namespace axom
 namespace primal
 {
 /*!
-   * \brief Calculates the sector area of a planar, nonrational Bezier Curve
-   *
-   * The sector area is the area between the curve and the origin.
-   * The equation and derivation is described in:
-   *  Ueda, K. "Signed area of sectors between spline curves and the origin"
-   *  IEEE International Conference on Information Visualization, 1999.
-   */
+ * \brief Calculates the signed sector area of a planar, nonrational Bezier curve.
+ *
+ * The sector area is the signed area between the curve and the origin.
+ * The equation and derivation are described in:
+ *  Ueda, K. "Signed area of sectors between spline curves and the origin"
+ *  IEEE International Conference on Information Visualization, 1999.
+ */
 template <typename T>
 T sector_area(const primal::BezierCurve<T, 2>& curve)
 {
@@ -53,20 +53,22 @@ T sector_area(const primal::BezierCurve<T, 2>& curve)
   {
     for(int q = 0; q <= ord; ++q)
     {
-      A += weights(p, q) * curve[p][1] * curve[q][0];
+      A += weights(p, q) * curve[p][0] * curve[q][1];
     }
   }
   return A;
 }
 
 /*!
-   * \brief Calculates the sector centroid of a planar, nonrational Bezier Curve
-   *
-   * This is the centroid of the region between the curve and the origin.
-   * The equation and derivation are generalizations of:
-   *  Ueda, K. "Signed area of sectors between spline curves and the origin"
-   *  IEEE International Conference on Information Visualization, 1999.
-   */
+ * \brief Calculates the area-weighted centroid numerator of a planar,
+ * nonrational Bezier curve.
+ *
+ * This is the first raw moment of the region between the curve and the origin.
+ * Divide by sector_area() to recover the centroid.
+ * The equation and derivation are generalizations of:
+ *  Ueda, K. "Signed area of sectors between spline curves and the origin"
+ *  IEEE International Conference on Information Visualization, 1999.
+ */
 template <typename T>
 primal::Point<T, 2> sector_centroid(const primal::BezierCurve<T, 2>& curve)
 {
@@ -86,8 +88,8 @@ primal::Point<T, 2> sector_centroid(const primal::BezierCurve<T, 2>& curve)
     {
       for(int q = 0; q <= ord; ++q)
       {
-        Mx += weights_r(p, q) * curve[p][1] * curve[q][0] * curve[r][0];
-        My += weights_r(p, q) * curve[p][1] * curve[q][0] * curve[r][1];
+        Mx += weights_r(p, q) * curve[p][0] * curve[q][1] * curve[r][0];
+        My += weights_r(p, q) * curve[p][0] * curve[q][1] * curve[r][1];
       }
     }
   }

--- a/src/axom/primal/tests/primal_compute_moments.cpp
+++ b/src/axom/primal/tests/primal_compute_moments.cpp
@@ -18,11 +18,92 @@
 #include "axom/primal/geometry/BezierCurve.hpp"
 #include "axom/primal/geometry/CurvedPolygon.hpp"
 #include "axom/primal/operators/compute_moments.hpp"
+#include "axom/primal/operators/evaluate_integral_curve.hpp"
 #include "axom/primal/operators/detail/compute_moments_impl.hpp"
+
+#include <utility>
 
 namespace primal = axom::primal;
 
-const double EPS = 2e-15;
+constexpr double EPS = 2e-15;
+
+namespace
+{
+using Point2D = primal::Point<double, 2>;
+using BezierCurve2D = primal::BezierCurve<double, 2>;
+using CurvedPolygon2D = primal::CurvedPolygon<BezierCurve2D>;
+
+struct RawPlanarMoments
+{
+  double m00 {};
+  double m10 {};
+  double m01 {};
+};
+
+CurvedPolygon2D make_quadratic_curve_loop()
+{
+  return CurvedPolygon2D(axom::Array<BezierCurve2D> {
+    BezierCurve2D(axom::Array<Point2D> {Point2D {2., 0.}, Point2D {1., 2.}, Point2D {0., 0.}}, 2),
+    BezierCurve2D(axom::Array<Point2D> {Point2D {0., 0.}, Point2D {1., -2.}, Point2D {2., 0.}}, 2)});
+}
+
+CurvedPolygon2D make_cubic_curve_loop()
+{
+  return CurvedPolygon2D(axom::Array<BezierCurve2D> {
+    BezierCurve2D(axom::Array<Point2D> {Point2D {0.6, 1.2},
+                                        Point2D {1.3, 1.6},
+                                        Point2D {2.9, 2.4},
+                                        Point2D {3.2, 3.5}},
+                  3),
+    BezierCurve2D(axom::Array<Point2D> {Point2D {3.2, 3.5}, Point2D {0.6, 1.2}}, 1)});
+}
+
+RawPlanarMoments compute_ueda_raw_moments(const CurvedPolygon2D& polygon)
+{
+  const double area = primal::area(polygon);
+  const Point2D centroid = primal::centroid(polygon);
+
+  RawPlanarMoments moments;
+  moments.m00 = area;
+  moments.m10 = area * centroid[0];
+  moments.m01 = area * centroid[1];
+  return moments;
+}
+
+RawPlanarMoments compute_spectral_raw_moments(const CurvedPolygon2D& polygon, int gauss_points)
+{
+  auto integrate_spectral = [&polygon, gauss_points](auto&& integrand) {
+    return primal::evaluate_area_integral(polygon,
+                                          std::forward<decltype(integrand)>(integrand),
+                                          gauss_points,
+                                          gauss_points);
+  };
+
+  RawPlanarMoments moments;
+  moments.m00 = integrate_spectral([](Point2D) { return 1.; });
+  moments.m10 = integrate_spectral([](const Point2D& x) { return x[0]; });
+  moments.m01 = integrate_spectral([](const Point2D& x) { return x[1]; });
+  return moments;
+}
+
+void expect_raw_moments_near(const RawPlanarMoments& actual,
+                             const RawPlanarMoments& expected,
+                             double tol)
+{
+  EXPECT_NEAR(actual.m00, expected.m00, tol);
+  EXPECT_NEAR(actual.m10, expected.m10, tol);
+  EXPECT_NEAR(actual.m01, expected.m01, tol);
+}
+
+void expect_raw_moments_negated(const RawPlanarMoments& actual,
+                                const RawPlanarMoments& expected,
+                                double tol)
+{
+  EXPECT_NEAR(actual.m00, -expected.m00, tol);
+  EXPECT_NEAR(actual.m10, -expected.m10, tol);
+  EXPECT_NEAR(actual.m01, -expected.m01, tol);
+}
+}  // namespace
 
 //------------------------------------------------------------------------------
 TEST(primal_compute_moments, sector_area_cubic)
@@ -44,7 +125,7 @@ TEST(primal_compute_moments, sector_area_cubic)
     BezierCurveType bCurve(data, order);
     const T area = primal::sector_area(bCurve);
 
-    EXPECT_NEAR(.1455, area, EPS);
+    EXPECT_NEAR(-.1455, area, EPS);
   }
 }
 
@@ -66,8 +147,8 @@ TEST(primal_compute_moments, sector_moment_cubic)
 
     BezierCurveType bCurve(data, order);
     PointType M = primal::sector_centroid(bCurve);
-    EXPECT_NEAR(-.429321428571429, M[0], EPS);
-    EXPECT_NEAR(-.354010714285715, M[1], EPS);
+    EXPECT_NEAR(.429321428571429, M[0], EPS);
+    EXPECT_NEAR(.354010714285715, M[1], EPS);
   }
 }
 
@@ -107,6 +188,39 @@ TEST(primal_compute_moments, sector_moment_point)
     EXPECT_DOUBLE_EQ(M[0], 0.0);
     EXPECT_DOUBLE_EQ(M[1], 0.0);
   }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_compute_moments, spectral_matches_ueda_for_polynomial_bezier_regions)
+{
+  // Cross-check the closed-form moments against our quadrature on polynomial Bezier regions
+  const CurvedPolygon2D quadratic_region = make_quadratic_curve_loop();
+  const CurvedPolygon2D cubic_region = make_cubic_curve_loop();
+
+  expect_raw_moments_near(compute_spectral_raw_moments(quadratic_region, 8),
+                          compute_ueda_raw_moments(quadratic_region),
+                          1e-12);
+  expect_raw_moments_near(compute_spectral_raw_moments(cubic_region, 20),
+                          compute_ueda_raw_moments(cubic_region),
+                          1e-10);
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_compute_moments, reversed_orientation_negates_raw_moments)
+{
+  // Reversing a closed boundary changes the signed measure but not the centroid
+  const CurvedPolygon2D region = make_cubic_curve_loop();
+  CurvedPolygon2D reversed_region = region;
+  reversed_region.reverseOrientation();
+
+  const RawPlanarMoments moments = compute_ueda_raw_moments(region);
+  const RawPlanarMoments reversed_moments = compute_ueda_raw_moments(reversed_region);
+  expect_raw_moments_negated(reversed_moments, moments, 1e-14);
+
+  const Point2D centroid = primal::centroid(region);
+  const Point2D reversed_centroid = primal::centroid(reversed_region);
+  EXPECT_NEAR(reversed_centroid[0], centroid[0], 1e-14);
+  EXPECT_NEAR(reversed_centroid[1], centroid[1], 1e-14);
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_curved_polygon.cpp
+++ b/src/axom/primal/tests/primal_curved_polygon.cpp
@@ -12,6 +12,7 @@
 #include "gtest/gtest.h"
 
 #include "axom/config.hpp"
+#include "axom/core.hpp"
 #include "axom/slic.hpp"
 #include "axom/primal.hpp"
 
@@ -367,7 +368,7 @@ TEST(primal_curvedpolygon, moments_triangle_linear)
   axom::Array<int> orders = {1, 1, 1};
   CurvedPolygonType bPolygon = createBezierPolygon(CP, orders);
 
-  CoordType trueA = -.18;
+  CoordType trueA = .18;
   PointType trueC = PointType::make_point(0.3, 1.6);
 
   checkMoments(bPolygon, trueA, trueC, 1e-14, 1e-15);
@@ -395,7 +396,7 @@ TEST(primal_curvedpolygon, moments_triangle_quadratic)
   axom::Array<int> orders = {2, 2, 2};
   CurvedPolygonType bPolygon = createBezierPolygon(CP, orders);
 
-  CoordType trueA = -0.097333333333333;
+  CoordType trueA = 0.097333333333333;
   PointType trueC {.294479452054794, 1.548219178082190};
 
   checkMoments(bPolygon, trueA, trueC, 1e-15, 1e-14);
@@ -422,7 +423,7 @@ TEST(primal_curvedpolygon, moments_triangle_mixed_order)
   axom::Array<int> orders = {2, 2, 1};
   CurvedPolygonType bPolygon = createBezierPolygon(CP, orders);
 
-  CoordType trueA = -.0906666666666666666666;
+  CoordType trueA = .0906666666666666666666;
   PointType trueC {.2970147058823527, 1.55764705882353};
 
   checkMoments(bPolygon, trueA, trueC, 1e-14, 1e-14);
@@ -447,7 +448,7 @@ TEST(primal_curvedpolygon, moments_quad_all_orders)
   axom::Array<int> orders = {1, 1, 1, 1};
   CurvedPolygonType bPolygon = createBezierPolygon(CPorig, orders);
 
-  CoordType trueA = 1.0;
+  CoordType trueA = -1.0;
   PointType trueC = PointType::make_point(0.5, 0.5);
 
   checkMoments(bPolygon, trueA, trueC, 1e-14, 1e-15);


### PR DESCRIPTION
# Summary

- This PR fixes the sign convention for `primal::sector_area()` and `primal::sector_centroid()` to match the convention for our quadrature scheme in `primal::evaluate_area_integral()` as well as the sign convention from the original approach that our implementation is based on.
- It also adds some new tests