### PR TITLE
Add environment variable in LC CI builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,7 @@ variables:
   BUILD_ROOT: ${CI_PROJECT_DIR}
   FULL_BUILD_ROOT: ${CI_BUILDS_DIR}/axom/${CI_JOB_NAME}
   SLURM_OVERLAP: 1
+  PSM2_KASSIST_MODE: auto
 
 .src_workflow:
   rules:

--- a/.gitlab/build_matrix.yml
+++ b/.gitlab/build_matrix.yml
@@ -20,6 +20,7 @@
     - when: on_success
   before_script:
     - module load cmake/3.26
+    - export MV2_SMP_USE_CMA=0
 
 ####
 # Template


### PR DESCRIPTION
This PR resolves #1867 by setting `PSM2_KASSIST_MODE: auto` in the LC CI configs to work around recent configuration changes that affect MPI applications.
