### PR TITLE
 Docker image updates

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
 
 env:
-  CLANG_DOCKER_IMAGE: axom/tpls:clang-19_02-17-26_21h-05m
-  GCC_DOCKER_IMAGE: axom/tpls:gcc-13_02-17-26_21h-05m
+  CLANG_DOCKER_IMAGE: axom/tpls:clang-19_05-19-26_17h-35m
+  GCC_DOCKER_IMAGE: axom/tpls:gcc-13_05-19-26_17h-32m
  
 jobs:
   # Hacky solution to reference env variables outside of `run` steps https://stackoverflow.com/a/74217028

--- a/host-configs/docker/gcc@13.3.1.cmake
+++ b/host-configs/docker/gcc@13.3.1.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/local/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/home/axom/axom_tpls/gcc-13.3.1/blt-0.7.1-tp6erawewp4l2ewllhglzso5fnjudoja;/home/axom/axom_tpls/gcc-13.3.1/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-qollf3jglv6wxat4uffls42u2t2biu43;/home/axom/axom_tpls/gcc-13.3.1/conduit-0.9.5-e72kkuzpsp2ct2warb23dw63rjbwyuy7;/home/axom/axom_tpls/gcc-13.3.1/gmake-4.4.1-jclt3ixkhzk7gh4qz7bph3nqno2d2tan;/home/axom/axom_tpls/gcc-13.3.1/mfem-4.9.0-27y23akm3yqlnmn3y4ujuiif7ch3d42x;/home/axom/axom_tpls/gcc-13.3.1/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-xk3wk7pkfxfmczqsud2zgvoaynygae7x;/home/axom/axom_tpls/gcc-13.3.1/umpire-2025.12.0-eg7ottka4ejtla2sshmo5fbnz6ievmht;/home/axom/axom_tpls/gcc-13.3.1/adiak-0.4.0-7tvwkbkbsrz7pg7cmzjbgpakeqwxiwfn;/home/axom/axom_tpls/gcc-13.3.1/elfutils-0.193-yvyizihf3ovzcrz2xspbo3xqpcsgpciw;/home/axom/axom_tpls/gcc-13.3.1/libunwind-1.8.3-dms6jlqrs6yvgwf454ezco5mszpn4fny;/home/axom/axom_tpls/gcc-13.3.1/hdf5-1.8.23-c5fghc2avhw2ujuhxb32akojoz62ulww;/home/axom/axom_tpls/gcc-13.3.1/parmetis-4.0.3-fwggxdxmzfdyu4zuwzps2iy4ku5nlzbq;/home/axom/axom_tpls/gcc-13.3.1/hypre-2.27.0-yukxydlpq2lrtkdzhpyvnyfxo6u62dqh;/home/axom/axom_tpls/gcc-13.3.1/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-gdtpys6nyl4kfgvwd5d46hh7mrx4c64f;/home/axom/axom_tpls/gcc-13.3.1/fmt-11.0.2-auzpmart4pgyllfizbgbrmi7vo5l7imm;/home/axom/axom_tpls/gcc-13.3.1/zstd-1.5.7-ynwtbrjy4fy7fmg4mnoq7inn6j36z2lo;/home/axom/axom_tpls/gcc-13.3.1/metis-5.1.0-ngjvzo5djlp4rtpsh2rro63istec4tks;/home/axom/axom_tpls/gcc-13.3.1/mpich-4.2.0-oafwifl7wossiwmdg3osevy3h42nehm5;/home/axom/axom_tpls/gcc-13.3.1/hwloc-2.12.2-r6jiv64detpwvvobvcpbxqsgbyz4an7b;/home/axom/axom_tpls/gcc-13.3.1/libfabric-2.4.0-glityu7f5kxxo72mbpnt2h54aowe2o7j;/home/axom/axom_tpls/gcc-13.3.1/yaksa-0.4-2nqzb7ap73wiacj77ktkz5qh33s3h7cj;/home/axom/axom_tpls/gcc-13.3.1/libpciaccess-0.17-e7jficwldulh2dbp7l742wedsof3d6h5;/home/axom/axom_tpls/gcc-13.3.1/libxml2-2.13.5-wj6jpg6gipn4cjol77o5bwppiymtifjj;/home/axom/axom_tpls/gcc-13.3.1/ncurses-6.5-20250705-izsjfkqb573w7lny6vvdbt57lctv2j22;/home/axom/axom_tpls/gcc-13.3.1/libiconv-1.18-nwihe6gonhf3rig4qghahxqrdzcpxzp2;/home/axom/axom_tpls/gcc-13.3.1/xz-5.6.3-t6r2wp2e2kybjuus2yzlqap6khgwvw73;/home/axom/axom_tpls/gcc-13.3.1/zlib-ng-2.3.2-xturc74asm73dunfzuwguafjrucw75ae;/home/axom/axom_tpls/none-none/gcc-runtime-13.3.1-ahhevkdxsqek4foiubajeiisj7ryali4;/home/axom/axom_tpls/none-none/compiler-wrapper-1.0-u5fjo4cce7cqt6425ipfxnafausfog7z" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/home/axom/axom_tpls/gcc-13.3.1/blt-0.7.1-tp6erawewp4l2ewllhglzso5fnjudoja;/home/axom/axom_tpls/gcc-13.3.1/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-qollf3jglv6wxat4uffls42u2t2biu43;/home/axom/axom_tpls/gcc-13.3.1/conduit-0.9.5-tov2czaq7ifefmpwa2gtqaqgelclqwge;/home/axom/axom_tpls/gcc-13.3.1/gmake-4.4.1-jclt3ixkhzk7gh4qz7bph3nqno2d2tan;/home/axom/axom_tpls/gcc-13.3.1/mfem-4.9.0-27y23akm3yqlnmn3y4ujuiif7ch3d42x;/home/axom/axom_tpls/gcc-13.3.1/py-nanobind-2.7.0-haxzzbmxto45ae43fjjdfmtgo4l5qhjx;/home/axom/axom_tpls/none-none/py-pytest-9.0.0-lzujihl4aaovgis2uoemzabjpymsjfuj;/home/axom/axom_tpls/gcc-13.3.1/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-xk3wk7pkfxfmczqsud2zgvoaynygae7x;/home/axom/axom_tpls/gcc-13.3.1/umpire-2025.12.0-eg7ottka4ejtla2sshmo5fbnz6ievmht;/home/axom/axom_tpls/gcc-13.3.1/adiak-0.4.0-7tvwkbkbsrz7pg7cmzjbgpakeqwxiwfn;/home/axom/axom_tpls/gcc-13.3.1/elfutils-0.193-yvyizihf3ovzcrz2xspbo3xqpcsgpciw;/home/axom/axom_tpls/gcc-13.3.1/libunwind-1.8.3-dms6jlqrs6yvgwf454ezco5mszpn4fny;/home/axom/axom_tpls/gcc-13.3.1/hdf5-1.8.23-c5fghc2avhw2ujuhxb32akojoz62ulww;/home/axom/axom_tpls/gcc-13.3.1/parmetis-4.0.3-fwggxdxmzfdyu4zuwzps2iy4ku5nlzbq;/home/axom/axom_tpls/gcc-13.3.1/py-mpi4py-4.1.1-n2ebx2enfluwannhglskxq3j5ntbasbp;/home/axom/axom_tpls/gcc-13.3.1/py-numpy-2.4.2-4z3hsqslzknft2priqptynbsotvbetca;/home/axom/axom_tpls/gcc-13.3.1/hypre-2.27.0-yukxydlpq2lrtkdzhpyvnyfxo6u62dqh;/home/axom/axom_tpls/gcc-13.3.1/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-gdtpys6nyl4kfgvwd5d46hh7mrx4c64f;/home/axom/axom_tpls/gcc-13.3.1/fmt-11.0.2-auzpmart4pgyllfizbgbrmi7vo5l7imm;/home/axom/axom_tpls/gcc-13.3.1/zstd-1.5.7-ynwtbrjy4fy7fmg4mnoq7inn6j36z2lo;/home/axom/axom_tpls/gcc-13.3.1/metis-5.1.0-ngjvzo5djlp4rtpsh2rro63istec4tks;/home/axom/axom_tpls/gcc-13.3.1/mpich-4.2.0-oafwifl7wossiwmdg3osevy3h42nehm5;/home/axom/axom_tpls/gcc-13.3.1/hwloc-2.12.2-r6jiv64detpwvvobvcpbxqsgbyz4an7b;/home/axom/axom_tpls/gcc-13.3.1/libfabric-2.4.0-glityu7f5kxxo72mbpnt2h54aowe2o7j;/home/axom/axom_tpls/gcc-13.3.1/yaksa-0.4-2nqzb7ap73wiacj77ktkz5qh33s3h7cj;/home/axom/axom_tpls/gcc-13.3.1/libpciaccess-0.17-e7jficwldulh2dbp7l742wedsof3d6h5;/home/axom/axom_tpls/gcc-13.3.1/libxml2-2.13.5-wj6jpg6gipn4cjol77o5bwppiymtifjj;/home/axom/axom_tpls/gcc-13.3.1/ncurses-6.5-20250705-izsjfkqb573w7lny6vvdbt57lctv2j22;/home/axom/axom_tpls/gcc-13.3.1/libiconv-1.18-nwihe6gonhf3rig4qghahxqrdzcpxzp2;/home/axom/axom_tpls/gcc-13.3.1/xz-5.6.3-t6r2wp2e2kybjuus2yzlqap6khgwvw73;/home/axom/axom_tpls/gcc-13.3.1/zlib-ng-2.3.2-xturc74asm73dunfzuwguafjrucw75ae;/home/axom/axom_tpls/none-none/gcc-runtime-13.3.1-ahhevkdxsqek4foiubajeiisj7ryali4;/home/axom/axom_tpls/none-none/compiler-wrapper-1.0-u5fjo4cce7cqt6425ipfxnafausfog7z" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/home/axom/axom_tpls/gcc-13.3.1/axom-develop-ofy2ds6xm3ggsfnnn2bzwtfoyqooykov/lib;/home/axom/axom_tpls/gcc-13.3.1/axom-develop-ofy2ds6xm3ggsfnnn2bzwtfoyqooykov/lib64;;" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/home/axom/axom_tpls/gcc-13.3.1/axom-develop-hhm5dhgenh2t6dyv3rykj7vvnpmybt3p/lib;/home/axom/axom_tpls/gcc-13.3.1/axom-develop-hhm5dhgenh2t6dyv3rykj7vvnpmybt3p/lib64;;" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/home/axom/axom_tpls/gcc-13.3.1/axom-develop-ofy2ds6xm3ggsfnnn2bzwtfoyqooykov/lib;/home/axom/axom_tpls/gcc-13.3.1/axom-develop-ofy2ds6xm3ggsfnnn2bzwtfoyqooykov/lib64;;" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/home/axom/axom_tpls/gcc-13.3.1/axom-develop-hhm5dhgenh2t6dyv3rykj7vvnpmybt3p/lib;/home/axom/axom_tpls/gcc-13.3.1/axom-develop-hhm5dhgenh2t6dyv3rykj7vvnpmybt3p/lib64;;" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -77,7 +77,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 set(TPL_ROOT "/home/axom/axom_tpls/gcc-13.3.1" CACHE PATH "")
 
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-e72kkuzpsp2ct2warb23dw63rjbwyuy7" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-tov2czaq7ifefmpwa2gtqaqgelclqwge" CACHE PATH "")
 
 # C2C not built
 
@@ -102,13 +102,27 @@ set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main
 # scr not built
 
 #------------------------------------------------------------------------------
-# Devtools
+# Devtools & Python
 #------------------------------------------------------------------------------
 
 # ClangFormat disabled since llvm@19 and devtools not in spec
 
 set(ENABLE_CLANGFORMAT OFF CACHE BOOL "")
 
+set(Python_EXECUTABLE "/usr/bin/python3" CACHE PATH "")
+
 set(ENABLE_DOCS OFF CACHE BOOL "")
+
+set(PY_NANOBIND_DIR "${TPL_ROOT}/py-nanobind-2.7.0-haxzzbmxto45ae43fjjdfmtgo4l5qhjx/lib/python3.12/site-packages" CACHE PATH "")
+
+set(PY_PYTEST_DIR "/home/axom/axom_tpls/none-none/py-pytest-9.0.0-lzujihl4aaovgis2uoemzabjpymsjfuj/lib/python3.12/site-packages" CACHE PATH "")
+
+set(PY_NUMPY_DIR "${TPL_ROOT}/py-numpy-2.4.2-4z3hsqslzknft2priqptynbsotvbetca/lib/python3.12/site-packages" CACHE PATH "")
+
+set(PY_PLUGGY_DIR "/home/axom/axom_tpls/none-none/py-pluggy-1.6.0-mpbg4tbgwvzfntupp2kdega47dr2vxi6/lib/python3.12/site-packages" CACHE PATH "")
+
+set(PY_INICONFIG_DIR "/home/axom/axom_tpls/none-none/py-iniconfig-2.1.0-yhyncq6joox5xckyjtjnj6tuoc35s72m/lib/python3.12/site-packages" CACHE PATH "")
+
+set(PY_MPI4PY_DIR "${TPL_ROOT}/py-mpi4py-4.1.1-n2ebx2enfluwannhglskxq3j5ntbasbp/lib/python3.12/site-packages" CACHE PATH "")
 
 

--- a/host-configs/docker/llvm@19.0.0.cmake
+++ b/host-configs/docker/llvm@19.0.0.cmake
@@ -4,13 +4,13 @@
 # CMake executable path: /usr/local/bin/cmake
 #------------------------------------------------------------------------------
 
-set(CMAKE_PREFIX_PATH "/home/axom/axom_tpls/llvm-19.0.0/blt-0.7.1-p7mm766jfnjcbcnon7lmbmjk52d7nnfy;/home/axom/axom_tpls/llvm-19.0.0/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-qv2wv4xikow5wxrhdem6c2dvkxt2cptf;/home/axom/axom_tpls/llvm-19.0.0/conduit-0.9.5-23be5eyo7aox2o6tzewawhlnjsci3pau;/home/axom/axom_tpls/llvm-19.0.0/gmake-4.4.1-xsybuyd32plkd6jcojnvdqkbwnt44ij6;/home/axom/axom_tpls/llvm-19.0.0/mfem-4.9.0-g3kaipukjvqu677tqztygnik5kzcxhfj;/home/axom/axom_tpls/llvm-19.0.0/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-dkkk27oc7p2gsrq4cslpdsv5qz7g3sbd;/home/axom/axom_tpls/llvm-19.0.0/umpire-2025.12.0-kulqmeumvx2c36r6rzz7lwndhsv3ot4i;/home/axom/axom_tpls/llvm-19.0.0/adiak-0.4.0-idbd67m2y4b4gnuxxbivm7hvesbbl4q5;/home/axom/axom_tpls/llvm-19.0.0/elfutils-0.193-437imlexpxs7pztuf7vh33f4mrvwh2i2;/home/axom/axom_tpls/llvm-19.0.0/libunwind-1.8.3-3tkxrnad3g5t5zjiodqfqne3sqfq5pzn;/home/axom/axom_tpls/llvm-19.0.0/hdf5-1.8.23-mwa7fanurwtkpebryywcggusn4gd7yg2;/home/axom/axom_tpls/llvm-19.0.0/parmetis-4.0.3-oe7i7ur4mu5sqkoet576wwcezbbodolt;/home/axom/axom_tpls/llvm-19.0.0/hypre-2.27.0-phspcafi6ten26qxkokwwij44ygoctxz;/home/axom/axom_tpls/llvm-19.0.0/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-y2k23nuv2eya2soe3fznpcgsgt2k2dai;/home/axom/axom_tpls/llvm-19.0.0/fmt-11.0.2-eutx47cvctyr7hyulz4rv4q4nfg5apzm;/home/axom/axom_tpls/llvm-19.0.0/zstd-1.5.7-ereaou2vj32kdin5v4z23qtd36yk4euw;/home/axom/axom_tpls/llvm-19.0.0/metis-5.1.0-sq3zbc3dla7ya33x67xr2evinhxbb6ey;/home/axom/axom_tpls/llvm-19.0.0/mpich-4.2.0-wxhfezauopwtrdjmf6hx32l2jh4yyb25;/home/axom/axom_tpls/none-none/gcc-runtime-13.3.1-ahhevkdxsqek4foiubajeiisj7ryali4;/home/axom/axom_tpls/llvm-19.0.0/hwloc-2.12.2-mab72jducih2myearbldanjcfr4epqcz;/home/axom/axom_tpls/llvm-19.0.0/libfabric-2.4.0-n7vbijzh3ebt3lahb5hyk7e4smcfyoxz;/home/axom/axom_tpls/llvm-19.0.0/yaksa-0.4-o3gdzqkwwkch27u7cr4yxzzjuewlg327;/home/axom/axom_tpls/llvm-19.0.0/libpciaccess-0.17-2sndua5wqv2xd2jy3ef52ehian4tpd4i;/home/axom/axom_tpls/llvm-19.0.0/libxml2-2.13.5-j3go7vs6gxvkyl7xdh476o3h3aos6zxk;/home/axom/axom_tpls/llvm-19.0.0/ncurses-6.5-20250705-qjve66dkqppk4z75pct2zhcyso2jsjhl;/home/axom/axom_tpls/llvm-19.0.0/libiconv-1.18-wwggylv5rglt7x7teuq3m7egjl27vbp5;/home/axom/axom_tpls/llvm-19.0.0/xz-5.6.3-55t47rdkjzlx64icqzp5lalnd67nsvnm;/home/axom/axom_tpls/llvm-19.0.0/zlib-ng-2.3.2-h74mdgso4hyns3yjgipxrwh3q5ngbbyt;/home/axom/axom_tpls/none-none/compiler-wrapper-1.0-u5fjo4cce7cqt6425ipfxnafausfog7z;/usr/lib/llvm-19" CACHE STRING "")
+set(CMAKE_PREFIX_PATH "/home/axom/axom_tpls/llvm-19.0.0/blt-0.7.1-p7mm766jfnjcbcnon7lmbmjk52d7nnfy;/home/axom/axom_tpls/llvm-19.0.0/caliper-git.7e5b7a5c0eacc077f9b842abf41c9fc7b996ce0c_master-qv2wv4xikow5wxrhdem6c2dvkxt2cptf;/home/axom/axom_tpls/llvm-19.0.0/conduit-0.9.5-vzh2futlihcbvpypnehpznvnqgijdflr;/home/axom/axom_tpls/llvm-19.0.0/gmake-4.4.1-xsybuyd32plkd6jcojnvdqkbwnt44ij6;/home/axom/axom_tpls/llvm-19.0.0/mfem-4.9.0-g3kaipukjvqu677tqztygnik5kzcxhfj;/home/axom/axom_tpls/llvm-19.0.0/py-nanobind-2.7.0-wvrnl66utfn2pr23wovdcp4eko42usc2;/home/axom/axom_tpls/none-none/py-pytest-9.0.0-rrb5ddzqzb7gvgzm7kpaqkye6bdjwsic;/home/axom/axom_tpls/llvm-19.0.0/raja-git.3b8b59a1e9be2e1066c0d77372b3bf5956e6d6e2_develop-dkkk27oc7p2gsrq4cslpdsv5qz7g3sbd;/home/axom/axom_tpls/llvm-19.0.0/umpire-2025.12.0-kulqmeumvx2c36r6rzz7lwndhsv3ot4i;/home/axom/axom_tpls/llvm-19.0.0/adiak-0.4.0-idbd67m2y4b4gnuxxbivm7hvesbbl4q5;/home/axom/axom_tpls/llvm-19.0.0/elfutils-0.193-437imlexpxs7pztuf7vh33f4mrvwh2i2;/home/axom/axom_tpls/llvm-19.0.0/libunwind-1.8.3-3tkxrnad3g5t5zjiodqfqne3sqfq5pzn;/home/axom/axom_tpls/llvm-19.0.0/hdf5-1.8.23-mwa7fanurwtkpebryywcggusn4gd7yg2;/home/axom/axom_tpls/llvm-19.0.0/parmetis-4.0.3-oe7i7ur4mu5sqkoet576wwcezbbodolt;/home/axom/axom_tpls/llvm-19.0.0/py-mpi4py-4.1.1-vcihkzxcnca4aeslr53dqlijjwhcwuuh;/home/axom/axom_tpls/llvm-19.0.0/py-numpy-2.4.2-3lrivxf4cgsisw7njzzpyihmo7ok2b77;/home/axom/axom_tpls/llvm-19.0.0/hypre-2.27.0-phspcafi6ten26qxkokwwij44ygoctxz;/home/axom/axom_tpls/llvm-19.0.0/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main-y2k23nuv2eya2soe3fznpcgsgt2k2dai;/home/axom/axom_tpls/llvm-19.0.0/fmt-11.0.2-eutx47cvctyr7hyulz4rv4q4nfg5apzm;/home/axom/axom_tpls/llvm-19.0.0/zstd-1.5.7-ereaou2vj32kdin5v4z23qtd36yk4euw;/home/axom/axom_tpls/llvm-19.0.0/metis-5.1.0-sq3zbc3dla7ya33x67xr2evinhxbb6ey;/home/axom/axom_tpls/llvm-19.0.0/mpich-4.2.0-wxhfezauopwtrdjmf6hx32l2jh4yyb25;/home/axom/axom_tpls/none-none/gcc-runtime-13.3.1-ahhevkdxsqek4foiubajeiisj7ryali4;/home/axom/axom_tpls/llvm-19.0.0/hwloc-2.12.2-mab72jducih2myearbldanjcfr4epqcz;/home/axom/axom_tpls/llvm-19.0.0/libfabric-2.4.0-n7vbijzh3ebt3lahb5hyk7e4smcfyoxz;/home/axom/axom_tpls/llvm-19.0.0/yaksa-0.4-o3gdzqkwwkch27u7cr4yxzzjuewlg327;/home/axom/axom_tpls/llvm-19.0.0/libpciaccess-0.17-2sndua5wqv2xd2jy3ef52ehian4tpd4i;/home/axom/axom_tpls/llvm-19.0.0/libxml2-2.13.5-j3go7vs6gxvkyl7xdh476o3h3aos6zxk;/home/axom/axom_tpls/llvm-19.0.0/ncurses-6.5-20250705-qjve66dkqppk4z75pct2zhcyso2jsjhl;/home/axom/axom_tpls/llvm-19.0.0/libiconv-1.18-wwggylv5rglt7x7teuq3m7egjl27vbp5;/home/axom/axom_tpls/llvm-19.0.0/xz-5.6.3-55t47rdkjzlx64icqzp5lalnd67nsvnm;/home/axom/axom_tpls/llvm-19.0.0/zlib-ng-2.3.2-h74mdgso4hyns3yjgipxrwh3q5ngbbyt;/home/axom/axom_tpls/none-none/compiler-wrapper-1.0-u5fjo4cce7cqt6425ipfxnafausfog7z;/usr/lib/llvm-19" CACHE STRING "")
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH "ON" CACHE STRING "")
 
-set(CMAKE_BUILD_RPATH "/home/axom/axom_tpls/llvm-19.0.0/axom-develop-pue4pbqffz5ostcywjjmbqrpva3p7c2o/lib;/home/axom/axom_tpls/llvm-19.0.0/axom-develop-pue4pbqffz5ostcywjjmbqrpva3p7c2o/lib64;;" CACHE STRING "")
+set(CMAKE_BUILD_RPATH "/home/axom/axom_tpls/llvm-19.0.0/axom-develop-qzk4bzyik3p6ybwwp7djapznpldjxhvx/lib;/home/axom/axom_tpls/llvm-19.0.0/axom-develop-qzk4bzyik3p6ybwwp7djapznpldjxhvx/lib64;;" CACHE STRING "")
 
-set(CMAKE_INSTALL_RPATH "/home/axom/axom_tpls/llvm-19.0.0/axom-develop-pue4pbqffz5ostcywjjmbqrpva3p7c2o/lib;/home/axom/axom_tpls/llvm-19.0.0/axom-develop-pue4pbqffz5ostcywjjmbqrpva3p7c2o/lib64;;" CACHE STRING "")
+set(CMAKE_INSTALL_RPATH "/home/axom/axom_tpls/llvm-19.0.0/axom-develop-qzk4bzyik3p6ybwwp7djapznpldjxhvx/lib;/home/axom/axom_tpls/llvm-19.0.0/axom-develop-qzk4bzyik3p6ybwwp7djapznpldjxhvx/lib64;;" CACHE STRING "")
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
@@ -79,7 +79,7 @@ set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")
 
 set(TPL_ROOT "/home/axom/axom_tpls/llvm-19.0.0" CACHE PATH "")
 
-set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-23be5eyo7aox2o6tzewawhlnjsci3pau" CACHE PATH "")
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.9.5-vzh2futlihcbvpypnehpznvnqgijdflr" CACHE PATH "")
 
 # C2C not built
 
@@ -104,13 +104,27 @@ set(CAMP_DIR "${TPL_ROOT}/camp-git.a8caefa9f4c811b1a114b4ed2c9b681d40f12325_main
 # scr not built
 
 #------------------------------------------------------------------------------
-# Devtools
+# Devtools & Python
 #------------------------------------------------------------------------------
 
 # ClangFormat disabled since llvm@19 and devtools not in spec
 
 set(ENABLE_CLANGFORMAT OFF CACHE BOOL "")
 
+set(Python_EXECUTABLE "/usr/bin/python3" CACHE PATH "")
+
 set(ENABLE_DOCS OFF CACHE BOOL "")
+
+set(PY_NANOBIND_DIR "${TPL_ROOT}/py-nanobind-2.7.0-wvrnl66utfn2pr23wovdcp4eko42usc2/lib/python3.12/site-packages" CACHE PATH "")
+
+set(PY_PYTEST_DIR "/home/axom/axom_tpls/none-none/py-pytest-9.0.0-rrb5ddzqzb7gvgzm7kpaqkye6bdjwsic/lib/python3.12/site-packages" CACHE PATH "")
+
+set(PY_NUMPY_DIR "${TPL_ROOT}/py-numpy-2.4.2-3lrivxf4cgsisw7njzzpyihmo7ok2b77/lib/python3.12/site-packages" CACHE PATH "")
+
+set(PY_PLUGGY_DIR "/home/axom/axom_tpls/none-none/py-pluggy-1.6.0-3rhfyqmyucyrezyg67awukgbpmagwkr4/lib/python3.12/site-packages" CACHE PATH "")
+
+set(PY_INICONFIG_DIR "/home/axom/axom_tpls/none-none/py-iniconfig-2.1.0-72fwkqdbtz4ngubc37txds5iujbw7keb/lib/python3.12/site-packages" CACHE PATH "")
+
+set(PY_MPI4PY_DIR "${TPL_ROOT}/py-mpi4py-4.1.1-vcihkzxcnca4aeslr53dqlijjwhcwuuh/lib/python3.12/site-packages" CACHE PATH "")
 
 

--- a/scripts/docker/dockerfile_clang-19
+++ b/scripts/docker/dockerfile_clang-19
@@ -29,7 +29,7 @@ RUN git clone --recursive --branch $branch --single-branch --depth 1 https://git
 # Build/install TPLs via spack and then remove the temporary build directory on success
 RUN cd axom_repo && python3 ./scripts/uberenv/uberenv.py --spack-env-file=./scripts/spack/configs/docker/ubuntu24/spack.yaml \
                                                          --project-json=.uberenv_config.json \
-                                                         --spec="+mfem+raja+umpire+adiak+caliper %clang_19" --prefix=/home/axom/axom_tpls -k \
+                                                         --spec="+python+mfem+raja+umpire+adiak+caliper %clang_19" --prefix=/home/axom/axom_tpls -k \
                  && rm -rf /home/axom/axom_tpls/build_stage /home/axom/axom_tpls/spack
 
 RUN mkdir -p /home/axom/export_hostconfig

--- a/scripts/docker/dockerfile_gcc-12_cuda-12
+++ b/scripts/docker/dockerfile_gcc-12_cuda-12
@@ -36,7 +36,7 @@ RUN git clone --recursive --branch $branch https://github.com/LLNL/axom.git axom
 # Build/install TPLs via spack and then remove the temporary build directory on success
 RUN cd ${HOME}/axom_repo && python3 ./scripts/uberenv/uberenv.py --spack-env-file=./scripts/spack/configs/docker/ubuntu22_cuda/spack.yaml \
                                                                  --project-json=.uberenv_config.json \
-                                                                 --spec="%gcc@12.3.0+mfem+adiak+caliper+cuda cuda_arch=70 ^raja+openmp+cuda ^umpire+openmp+cuda" \
+                                                                 --spec="+mfem+adiak+caliper+cuda cuda_arch=70 %gcc_12 ^raja+openmp+cuda ^umpire+openmp+cuda" \
                                                                  --prefix=${HOME}/axom_tpls -k \
                          && rm -rf ${HOME}/axom_tpls/build_stage ${HOME}/axom_tpls/spack
 

--- a/scripts/docker/dockerfile_gcc-13
+++ b/scripts/docker/dockerfile_gcc-13
@@ -29,7 +29,7 @@ RUN git clone --recursive --branch $branch --single-branch --depth 1 https://git
 # Build/install TPLs via spack and then remove the temporary build directory on success
 RUN cd axom_repo && python3 ./scripts/uberenv/uberenv.py --spack-env-file=./scripts/spack/configs/docker/ubuntu24/spack.yaml \
                                                          --project-json=.uberenv_config.json \
-                                                         --spec="+mfem+raja+umpire+adiak+caliper %gcc_13" --prefix=/home/axom/axom_tpls -k \
+                                                         --spec="+python+mfem+raja+umpire+adiak+caliper %gcc_13" --prefix=/home/axom/axom_tpls -k \
                  && rm -rf /home/axom/axom_tpls/build_stage /home/axom/axom_tpls/spack
 
 RUN mkdir -p /home/axom/export_hostconfig

--- a/scripts/docker/dockerfile_gcc-13_vscode
+++ b/scripts/docker/dockerfile_gcc-13_vscode
@@ -1,0 +1,90 @@
+# Docker image for Axom tutorial.
+# Docker container runs a VS Code server accessible through a web browser.
+# Docker and openvscode setup based on the RAJA suite tutorial:
+# https://github.com/LLNL/raja-suite-tutorial/tree/main/containers/tutorial
+
+# This script can be run with the following command:
+# docker build --build-arg branch=<your branch here, defaults to develop> -t "axom/tpls:gcc-13-vscode" - < dockerfile_gcc-13_vscode
+
+# Command to launch openvscode server with the resulting docker image:
+# docker run --init --restart=always -p 3000:3000 <image id>
+
+FROM ghcr.io/llnl/radiuss:gcc-13-ubuntu-24.04
+ARG branch=develop
+ARG USER=axomdev
+ENV HOME /home/${USER}
+
+SHELL ["/bin/bash", "-c"]
+RUN sudo apt-get update -y
+RUN sudo apt-get install -y supervisor
+RUN sudo useradd --create-home --shell /bin/bash ${USER}
+RUN sudo apt-get install gettext gfortran-$(gcc -dumpversion) graphviz libopenblas-dev \
+                         lsb-release lua5.2 lua5.2-dev python3-sphinx locales ssh -fy
+RUN sudo locale-gen en_US.utf8
+#RUN sudo useradd -m -s /bin/bash -G sudo axom
+
+# Install proper doxygen version (should match version in LC host configs)
+RUN sudo wget https://github.com/doxygen/doxygen/releases/download/Release_1_9_8/doxygen-1.9.8.linux.bin.tar.gz
+RUN sudo tar -xf doxygen-1.9.8.linux.bin.tar.gz
+RUN cd doxygen-1.9.8 && sudo make && sudo make install && doxygen --version
+
+WORKDIR /opt/archives
+RUN sudo curl -L https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v1.69.1/openvscode-server-v1.69.1-linux-x64.tar.gz > \
+    /opt/archives/openvscode-server-v1.69.1-linux-x64.tar.gz
+RUN sudo tar xzf openvscode-server-v1.69.1-linux-x64.tar.gz && sudo chown -R ${USER}:${USER} openvscode-server-v1.69.1-linux-x64
+
+WORKDIR ${HOME}
+USER ${USER}
+
+# Set locale for formatting
+ENV LANG='en_US.utf8' \
+    LANGUAGE='en_US.utf8' \
+    LC_ALL='en_US.utf8'
+
+RUN git clone --recursive --branch $branch --single-branch --depth 1 https://github.com/LLNL/axom.git axom_repo
+
+# Build/install TPLs via spack and then remove the temporary build directory on success
+RUN cd ${HOME}/axom_repo && python3 ./scripts/uberenv/uberenv.py --spack-env-file=./scripts/spack/configs/docker/ubuntu24/spack.yaml \
+                                                         --project-json=.uberenv_config.json \
+                                                         --spec="+python+mfem+raja+umpire+adiak+caliper %gcc_13" --prefix=${HOME}/axom_tpls -k \
+                 && rm -rf ${HOME}/axom_tpls/build_stage ${HOME}/axom_tpls/spack
+
+# Make sure the new hostconfig works with a release build
+# Note: having high job slots causes build log to disappear and job to fail
+# Omit testing step, hangs at slam_lulesh unit test (same behavior for azure pipeline images, as well)
+# Disable link-time optimization from MPI wrapper causing linkage failures
+RUN cd ${HOME}/axom_repo && python3 config-build.py -hc *.cmake \
+                                                    -bp ${HOME}/axom_repo/build-release \
+                                                    -ip ${HOME}/axom_repo/install-release \
+                                                    -bt Release \
+                         && cd ${HOME}/axom_repo/build-release \
+                         && make -j4 install
+
+# Install VisIt binary
+# Download tarball, installer, test script, perform installation and cleanup
+# Note - testing is done with command: ./visit/bin/visit -cli -nowin -s test_visit.py
+# (must be done manually; hangs when ran on Apple Silicon/ARM, x86_64/amd64 is okay)
+RUN wget https://github.com/visit-dav/visit/releases/download/v3.4.2/visit3_4_2.linux-x86_64-ubuntu24.tar.gz \
+    && wget https://github.com/visit-dav/visit/releases/download/v3.4.2/visit-install3_4_2 \
+    && wget https://raw.githubusercontent.com/visit-dav/visit/refs/heads/develop/scripts/docker/test_visit.py \
+    && chmod 777 visit-install3_4_2 \
+    && ./visit-install3_4_2 -c none 3.4.2 linux-x86_64-ubuntu24 ${HOME}/visit \
+    && rm -rf visit-install3_4_2 visit3_4_2.linux-x86_64-ubuntu24.tar.gz
+
+# Larger STL meshes for testing (optional)
+# Note: These meshes are large, copied from local directory instead of
+#        downloaded from Github.
+# COPY boxedSphere.stl car.stl porsche.stl ${HOME}/axom_repo/data/quest
+
+
+# Create symlinks for easy access to tutorial material (optional)
+# RUN ln -s ${HOME}/axom_repo/install-release/examples/axom/radiuss_tutorial/ ${HOME}/radiuss_tutorial \
+# && ln -s ${HOME}/axom_repo/data/quest ${HOME}/radiuss_tutorial/stl_meshes
+
+USER root
+ADD ./scripts/docker/supervisord.conf /etc/supervisord.conf
+RUN sed -i "s/XXX/${USER}/g" /etc/supervisord.conf
+
+RUN touch /var/log/openvscode-server.log && chown -R ${USER}:${USER} /var/log/openvscode-server.log
+
+CMD ["/usr/bin/supervisord"]

--- a/scripts/spack/configs/docker/ubuntu22_cuda/spack.yaml
+++ b/scripts/spack/configs/docker/ubuntu22_cuda/spack.yaml
@@ -126,12 +126,14 @@ spack:
       - spec: "+shared~static"
 
     # Globally lock in version of devtools
-    cmake:
-      version: [3.23.1]
-      buildable: false
-      externals:
-      - spec: cmake@3.23.1
-        prefix: /usr/local
+
+    # RAJA needs cmake 3.24:
+    # cmake:
+    #   version: [3.23.1]
+    #   buildable: false
+    #   externals:
+    #   - spec: cmake@3.23.1
+    #     prefix: /usr/local
     doxygen:
       version: [1.8.17]
       buildable: false

--- a/scripts/spack/configs/docker/ubuntu22_cuda/spack.yaml
+++ b/scripts/spack/configs/docker/ubuntu22_cuda/spack.yaml
@@ -22,48 +22,37 @@ spack:
   - ../defaults.yaml
   - ../versions.yaml
 
-  compilers::
-  - compiler:
-      environment: {}
-      extra_rpaths: []
-      flags:
-        cflags: -pthread
-        cxxflags: -pthread
-      modules: []
-      operating_system: ubuntu22.04
-      paths:
-        cc: /usr/bin/gcc
-        cxx: /usr/bin/g++
-        f77: /usr/bin/gfortran
-        fc: /usr/bin/gfortran
-      spec: gcc@12.3.0
-      target: x86_64
+  toolchains:
+    gcc_12:
+    - spec: '%c=gcc'
+      when: '%c'
+    - spec: '%cxx=gcc'
+      when: '%cxx'
+    - spec: '%fortran=gcc'
+      when: '%fortran'
+    - spec: '%mpich'
+      when: '%mpi'
 
   packages:
     all:
       # This defaults us to machine specific flags of ivybridge which allows
       # us to run on broadwell as well
       target: [x86_64]
-      compiler: [gcc, intel, pgi, clang, xl, nag]
       providers:
-        awk: [gawk]
         blas: [openblas]
         lapack: [openblas]
-        daal: [intel-daal]
-        elf: [elfutils]
-        golang: [gcc]
-        ipp: [intel-ipp]
-        java: [jdk]
-        mkl: [intel-mkl]
-        mpe: [mpe2]
         mpi: [mpich]
-        opencl: [pocl]
-        openfoam: [openfoam-com, openfoam-org, foam-extend]
-        pil: [py-pillow]
-        scalapack: [netlib-scalapack]
-        szip: [libszip, libaec]
-        tbb: [intel-tbb]
-        jpeg: [libjpeg-turbo, libjpeg]
+
+    #Compiler packages
+    gcc:
+      externals:
+      - spec: gcc@12.3.0 languages:=c,c++,fortran
+        prefix: /usr/bin
+        extra_attributes:
+          compilers:
+            cc: /usr/bin/gcc
+            cxx: /usr/bin/g++
+            fortran: /usr/bin/gfortran
 
     # Spack may grab for mpi & we don't want to use them
     mpi:

--- a/scripts/spack/configs/docker/ubuntu22_cuda/spack.yaml
+++ b/scripts/spack/configs/docker/ubuntu22_cuda/spack.yaml
@@ -50,7 +50,7 @@ spack:
         prefix: /usr/bin
         extra_attributes:
           compilers:
-            cc: /usr/bin/gcc
+            c: /usr/bin/gcc
             cxx: /usr/bin/g++
             fortran: /usr/bin/gfortran
 

--- a/scripts/spack/configs/docker/ubuntu22_cuda/spack.yaml
+++ b/scripts/spack/configs/docker/ubuntu22_cuda/spack.yaml
@@ -127,7 +127,7 @@ spack:
 
     # Globally lock in version of devtools
 
-    # RAJA needs cmake 3.24:
+    # RAJA's spack package depends on a newer version of CMake for CUDA than 3.23.1
     # cmake:
     #   version: [3.23.1]
     #   buildable: false

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -15,7 +15,6 @@ from spack_repo.builtin.build_systems.cached_cmake import (
 )
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
-from spack.error import SpackError
 
 # Axom components we expose to Spack.  Core is always built and is not listed here.
 _AXOM_COMPONENTS = (
@@ -420,7 +419,9 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             #   icpx: remark: note that use of '-g' without any optimization-level
             #   option will turn off most compiler optimizations similar to use of
             #   '-O0'; use '-Rno-debug-disables-optimization' to disable this remark
-            entries.append(cmake_cache_string("CMAKE_CXX_FLAGS_DEBUG", "-g -Rno-debug-disables-optimization"))
+            entries.append(
+                cmake_cache_string("CMAKE_CXX_FLAGS_DEBUG", "-g -Rno-debug-disables-optimization")
+            )
 
         return entries
 
@@ -433,7 +434,9 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             entries.append(cmake_cache_option("CMAKE_CUDA_SEPARABLE_COMPILATION", True))
 
             # CUDA_FLAGS
-            cudaflags = "${CMAKE_CUDA_FLAGS} -restrict --expt-extended-lambda --expt-relaxed-constexpr "
+            cudaflags = (
+                "${CMAKE_CUDA_FLAGS} -restrict --expt-extended-lambda --expt-relaxed-constexpr "
+            )
 
             # Pass through any cxxflags to the host compiler via nvcc's Xcompiler flag
             host_cxx_flags = spec.compiler_flags["cxxflags"]
@@ -465,14 +468,18 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             # Recommended MPI flags
             if spec.satisfies("+mpi"):
                 hip_link_flags += "-lxpmem "
-                hip_link_flags += "-L/opt/cray/pe/mpich/{0}/gtl/lib ".format(spec["mpi"].version.up_to(3))
+                hip_link_flags += "-L/opt/cray/pe/mpich/{0}/gtl/lib ".format(
+                    spec["mpi"].version.up_to(3)
+                )
                 hip_link_flags += "-Wl,-rpath,/opt/cray/pe/mpich/{0}/gtl/lib ".format(
                     spec["mpi"].version.up_to(3)
                 )
                 hip_link_flags += "-lmpi_gtl_hsa "
 
             if spec.satisfies("^hip@6.0.0:"):
-                hip_link_flags += "-L{0}/lib/llvm/lib -Wl,-rpath,{0}/lib/llvm/lib ".format(rocm_root)
+                hip_link_flags += "-L{0}/lib/llvm/lib -Wl,-rpath,{0}/lib/llvm/lib ".format(
+                    rocm_root
+                )
             else:
                 hip_link_flags += "-L{0}/llvm/lib -Wl,-rpath,{0}/llvm/lib ".format(rocm_root)
             # Only amdclang requires this path; cray compiler fails if this is included
@@ -489,8 +496,8 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
             # Additional library path for cray compiler
             if self.spec.satisfies("%cce"):
                 hip_link_flags += "-L/opt/cray/pe/cce/{0}/cce/x86_64/lib -Wl,-rpath,/opt/cray/pe/cce/{0}/cce/x86_64/lib ".format(
-                                        self.spec.compiler.version
-                                    )
+                    self.spec.compiler.version
+                )
 
             if spec.satisfies("+fortran"):
                 link_remove_list = []
@@ -568,18 +575,16 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
                 cmake_cache_string("BLT_OPENMP_LINK_FLAGS", openmp_gen_exp, description)
             )
 
-        if (
-            spec.satisfies("+openmp")
-            and spec.satisfies("+rocm")
-            and self.spec.satisfies("%cce")
-        ):
+        if spec.satisfies("+openmp") and spec.satisfies("+rocm") and self.spec.satisfies("%cce"):
             openmp_gen_exp = (
                 "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:"
                 "-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:"
                 "Fortran>:-fopenmp>"
             )
 
-            description = "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)"
+            description = (
+                "Different OpenMP compile & link flags between HIP and CXX compilers (amdclang++)"
+            )
             entries.append(
                 cmake_cache_string("BLT_OPENMP_COMPILE_FLAGS", openmp_gen_exp, description)
             )
@@ -641,13 +646,15 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
         if all_components_enabled:
             print("All axom components enabled")
         else:
-            print(f"The following Axom components are enabled: {spec.variants['components'].value}")
+            print(
+                f"The following Axom components are enabled: {spec.variants['components'].value}"
+            )
 
             entries.append("#------------------{0}".format("-" * 60))
             entries.append("# Axom components")
             entries.append("#------------------{0}\n".format("-" * 60))
             entries.append(cmake_cache_option("AXOM_ENABLE_ALL_COMPONENTS", False))
-            
+
             for comp in spec.variants["components"].value:
                 if comp in _AXOM_COMPONENTS:
                     entries.append(cmake_cache_option(f"AXOM_ENABLE_{comp.upper()}", True))
@@ -659,7 +666,18 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
         # Try to find the common prefix of the TPL directory.
         # If found, we will use this in the TPL paths
-        variant_deps = ["conduit", "c2c", "mfem", "hdf5", "lua", "raja", "umpire", "opencascade", "adiak", "caliper"]
+        variant_deps = [
+            "conduit",
+            "c2c",
+            "mfem",
+            "hdf5",
+            "lua",
+            "raja",
+            "umpire",
+            "opencascade",
+            "adiak",
+            "caliper",
+        ]
 
         for dep in variant_deps:
             if dep in ["lua"]:  # skip entries often outside the common prefix
@@ -751,9 +769,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
         if spec.satisfies("^py-yapf"):
             yapf_bin_dir = get_spec_path(spec, "py-yapf", path_replacements, use_bin=True)
-            entries.append(
-                cmake_cache_path("YAPF_EXECUTABLE", pjoin(yapf_bin_dir, "yapf"))
-            )
+            entries.append(cmake_cache_path("YAPF_EXECUTABLE", pjoin(yapf_bin_dir, "yapf")))
 
         if spec.satisfies("^py-shroud"):
             shroud_bin_dir = get_spec_path(spec, "py-shroud", path_replacements, use_bin=True)
@@ -768,11 +784,22 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
         if spec.satisfies("+python"):
             # pytest requires pluggy and iniconfig
-            for dep in ("py-nanobind", "py-pytest", "py-numpy", "py-pluggy", "py-iniconfig", "py-mpi4py"):
+            for dep in (
+                "py-nanobind",
+                "py-pytest",
+                "py-numpy",
+                "py-pluggy",
+                "py-iniconfig",
+                "py-mpi4py",
+            ):
                 if spec.satisfies("^{0}".format(dep)):
                     dep_dir = get_spec_path(spec, dep, path_replacements, use_lib=True)
-                    py_libdir = join_path(dep_dir, f"python{spec['python'].version.up_to(2)}", "site-packages")
-                    entries.append(cmake_cache_path("%s_DIR" % dep.upper().replace("-", "_"), py_libdir))
+                    py_libdir = join_path(
+                        dep_dir, f"python{spec['python'].version.up_to(2)}", "site-packages"
+                    )
+                    entries.append(
+                        cmake_cache_path("%s_DIR" % dep.upper().replace("-", "_"), py_libdir)
+                    )
 
         return entries
 

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -16,7 +16,7 @@ from spack_repo.builtin.build_systems.cached_cmake import (
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 
-# Axom components we expose to Spack.  Core is always built and is not listed here.
+# Axom components we expose to Spack. Core is always built and is not listed here.
 _AXOM_COMPONENTS = (
     "bump",
     "inlet",
@@ -186,9 +186,10 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
     # Libraries
     # Forward variants to Conduit
     with when("+conduit"):
-        for _var in ["fortran", "hdf5", "mpi", "python"]:
+        for _var in ["hdf5", "mpi"]:
             depends_on("conduit+{0}".format(_var), when="+{0}".format(_var))
             depends_on("conduit~{0}".format(_var), when="~{0}".format(_var))
+        depends_on("conduit+fortran", when="+fortran")
 
     depends_on("hdf5", when="+hdf5")
 

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -495,9 +495,9 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
                 hip_link_flags += "-lflang -lflangrti "
 
             # Additional library path for cray compiler
-            if self.spec.satisfies("%cce"):
+            if spec.satisfies("%cce"):
                 hip_link_flags += "-L/opt/cray/pe/cce/{0}/cce/x86_64/lib -Wl,-rpath,/opt/cray/pe/cce/{0}/cce/x86_64/lib ".format(
-                    self.spec.compiler.version
+                    spec.compiler.version
                 )
 
             if spec.satisfies("+fortran"):
@@ -576,7 +576,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
                 cmake_cache_string("BLT_OPENMP_LINK_FLAGS", openmp_gen_exp, description)
             )
 
-        if spec.satisfies("+openmp") and spec.satisfies("+rocm") and self.spec.satisfies("%cce"):
+        if spec.satisfies("+openmp") and spec.satisfies("+rocm") and spec.satisfies("%cce"):
             openmp_gen_exp = (
                 "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:"
                 "-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:"


### PR DESCRIPTION
This PR:
- Adds `+python` to Github Actions CI Docker images for python unit testing.
- Updates/Fixes `dockerfile_gcc-12_cuda-12` to use Spack 1.1
- Adds Dockerfile `dockerfile_gcc-13_vscode`, which is essentially a non-cuda version of the tutorial `dockerfile_gcc-12_cuda-12` image.
- Updates axom spack recipe with upstream spack-packages changes: spack/spack-packages#4853

Relates to #1609