### PR TITLE
Adds a BezierTriangle class to `primal`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,6 +26,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Primal: Adds `NURBSPatch::isTriviallyTrimmed()` to check if the trimming curves for a patch lie on the patch boundaries
 - Quest: Adds support for reading mfem files with variable order NURBS curves (requires mfem>4.9).
 - Quest: Adds OMP support for fast GWN methods for STL/Triangulated STEP input and linearized NURBS Curve input.
+- Quest: Adds OMP supported, fast and accurate GWN method for NURBS curves and trimmed NURBS surfaces.
 - Klee: Adds an optional "center" parameter in scale operators that permits scaling relative to a custom center point.
 - Quest: `SamplingShaper` now supports selecting MFEM quadrature families for custom sample-point generation, including
   anisotropic per-direction sampling resolution on quadrilateral and hexahedral meshes. Quadrature type is selected via
@@ -36,6 +37,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   removed in a future version of Axom.
 - Core: Adds Durand-Kerner polynomial solver which returns the complex roots of a univariate polynomial
 - Core: Adds `axom::Array::pop_back` for API compatibility with `std::vector`
+- Primal: Adds a `primal::BezierTriangle` class
 
 ### Removed
 

--- a/src/axom/primal/CMakeLists.txt
+++ b/src/axom/primal/CMakeLists.txt
@@ -23,6 +23,7 @@ set( primal_headers
     ## geometry
     geometry/BezierCurve.hpp
     geometry/BezierPatch.hpp
+    geometry/BezierTriangle.hpp
     geometry/BoundingBox.hpp
     geometry/CoordinateTransformer.hpp
     geometry/Cone.hpp

--- a/src/axom/primal/geometry/BezierCurve.hpp
+++ b/src/axom/primal/geometry/BezierCurve.hpp
@@ -160,7 +160,7 @@ public:
    *
    * \param [in] pts a vector with ord+1 control points
    * \param [in] ord The Curve's polynomial order
-   * \pre order is greater than or equal to zero
+   * \pre order is greater than or equal to -1
    */
   BezierCurve(const PointType* pts, int ord)
     : BezierCurve(axom::ArrayView<const PointType>(pts, ord + 1),
@@ -174,7 +174,7 @@ public:
    * \param [in] pts a vector with ord+1 control points
    * \param [in] weights a vector with ord+1 positive weights
    * \param [in] ord The Curve's polynomial order
-   * \pre order is greater than or equal to zero
+   * \pre order is greater than or equal to -1
    */
   BezierCurve(const PointType* pts, const T* weights, int ord)
     : BezierCurve(axom::ArrayView<const PointType>(pts, ord + 1),
@@ -187,7 +187,7 @@ public:
    *
    * \param [in] pts an array with ord+1 control points
    * \param [in] ord The Curve's polynomial order
-   * \pre order is greater than or equal to zero
+   * \pre order+1 is equal to pts.size()
    */
   BezierCurve(const axom::Array<PointType>& pts, int ord)
     : BezierCurve(pts.view(), axom::ArrayView<const T>(nullptr, 0), ord)
@@ -199,7 +199,8 @@ public:
    * \param [in] pts an array with ord+1 control points
    * \param [in] weights an array with ord+1 positive weights
    * \param [in] ord The Curve's polynomial order
-   * \pre order is greater than or equal to zero
+   * \pre pts.size() is equal to order+1
+   * \pre weights.size() is equal to order+1 or 0
    */
   BezierCurve(const axom::Array<PointType>& pts, const axom::Array<T>& weights, int ord)
     : BezierCurve(pts.view(), weights.view(), ord)

--- a/src/axom/primal/geometry/BezierCurve.hpp
+++ b/src/axom/primal/geometry/BezierCurve.hpp
@@ -52,6 +52,10 @@ std::ostream& operator<<(std::ostream& os, const BezierCurve<T, NDIMS>& bCurve);
  * 
  * Contains an array of positive weights to represent a rational Bezier curve.
  * Nonrational Bezier curves are identified by an empty weights array.
+ * 
+ * A default-constructed curve will have order -1, and is "invalid".
+ * Arrays of nodes and weights will be empty, and most methods are invalid 
+ * 
  * Algorithms for Rational Bezier curves derived from 
  * Gerald Farin, "Algorithms for rational Bezier curves"
  * Computer-Aided Design, Volume 15, Number 2, 1983,
@@ -103,15 +107,14 @@ public:
    * If \a controlPoints is empty, we still allocate space for \a ord+1 control points
    * \pre order \a ord is greater than or equal to -1
    * \pre controlPoints is either empty or has size \a ord+1
-   * \pre weights is either empty or has size \a ord+1
-   * \pre controlPoints cannot be empty if weights are supplied
+   * \pre weights is either empty or has size of controlPoints
    */
   BezierCurve(axom::ArrayView<const PointType> controlPoints, axom::ArrayView<const T> weights, int ord)
   {
     SLIC_ASSERT(ord >= -1);
     const int SZ = utilities::max(0, ord + 1);
 
-    SLIC_ASSERT(controlPoints.size() >= weights.size());
+    SLIC_ASSERT(weights.empty() || controlPoints.size() == weights.size());
 
     // note: always allocates space for the control points
     if(controlPoints.empty())

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -821,19 +821,7 @@ public:
       //  and BezierPatch of weights (w)
       BezierPatch<T, NDIMS> projective(ord_u, ord_v);
       BezierPatch<T, 1> weights(ord_u, ord_v);
-
-      for(int p = 0; p <= ord_u; ++p)
-      {
-        for(int q = 0; q <= ord_v; ++q)
-        {
-          weights(p, q)[0] = m_weights(p, q);
-
-          for(int i = 0; i < NDIMS; ++i)
-          {
-            projective(p, q)[i] = m_controlPoints(p, q)[i] * m_weights(p, q);
-          }
-        }
-      }
+      fill_projective_patches(projective, weights);
 
       BezierCurve<T, NDIMS> P = projective.isocurve_u(u);
       BezierCurve<T, 1> W = weights.isocurve_u(u);
@@ -942,19 +930,7 @@ public:
       //  and BezierPatch of weights (w)
       BezierPatch<T, NDIMS> projective(ord_u, ord_v);
       BezierPatch<T, 1> weights(ord_u, ord_v);
-
-      for(int p = 0; p <= ord_u; ++p)
-      {
-        for(int q = 0; q <= ord_v; ++q)
-        {
-          weights(p, q)[0] = m_weights(p, q);
-
-          for(int i = 0; i < NDIMS; ++i)
-          {
-            projective(p, q)[i] = m_controlPoints(p, q)[i] * m_weights(p, q);
-          }
-        }
-      }
+      fill_projective_patches(projective, weights);
 
       BezierCurve<T, NDIMS> P = projective.isocurve_v(v);
       BezierCurve<T, 1> W = weights.isocurve_v(v);
@@ -1131,19 +1107,7 @@ public:
       //  and BezierPatch of weights (w)
       BezierPatch<T, NDIMS> projective(ord_u, ord_v);
       BezierPatch<T, 1> weights(ord_u, ord_v);
-
-      for(int p = 0; p <= ord_u; ++p)
-      {
-        for(int q = 0; q <= ord_v; ++q)
-        {
-          weights(p, q)[0] = m_weights(p, q);
-
-          for(int i = 0; i < NDIMS; ++i)
-          {
-            projective(p, q)[i] = m_controlPoints(p, q)[i] * m_weights(p, q);
-          }
-        }
-      }
+      fill_projective_patches(projective, weights);
 
       Point<T, NDIMS> P;
       Vector<T, NDIMS> P_u, P_v, P_uu, P_vv, P_uv;
@@ -1175,12 +1139,12 @@ public:
    *
    * \note We typically evaluate the patch at \a u and \a v between 0 and 1
    */
-  void evaluate_linear_derivatives(T u,
-                                   T v,
-                                   Point<T, NDIMS>& eval,
-                                   Vector<T, NDIMS>& Du,
-                                   Vector<T, NDIMS>& Dv,
-                                   Vector<T, NDIMS>& DuDv) const
+  void evaluateLinearDerivatives(T u,
+                                 T v,
+                                 Point<T, NDIMS>& eval,
+                                 Vector<T, NDIMS>& Du,
+                                 Vector<T, NDIMS>& Dv,
+                                 Vector<T, NDIMS>& DuDv) const
   {
     using axom::utilities::lerp;
     const int ord_u = getOrder_u();
@@ -1307,19 +1271,7 @@ public:
       //  and BezierPatch of weights (w)
       BezierPatch<T, NDIMS> projective(ord_u, ord_v);
       BezierPatch<T, 1> weights(ord_u, ord_v);
-
-      for(int p = 0; p <= ord_u; ++p)
-      {
-        for(int q = 0; q <= ord_v; ++q)
-        {
-          weights(p, q)[0] = m_weights(p, q);
-
-          for(int i = 0; i < NDIMS; ++i)
-          {
-            projective(p, q)[i] = m_controlPoints(p, q)[i] * m_weights(p, q);
-          }
-        }
-      }
+      fill_projective_patches(projective, weights);
 
       Point<T, NDIMS> P;
       Vector<T, NDIMS> P_u, P_v, P_uu, P_vv, P_uv;
@@ -1568,19 +1520,7 @@ public:
       //  and BezierPatch of weights (w)
       BezierPatch<T, NDIMS> projective(ord_u, ord_v);
       BezierPatch<T, 1> weights(ord_u, ord_v);
-
-      for(int p = 0; p <= ord_u; ++p)
-      {
-        for(int q = 0; q <= ord_v; ++q)
-        {
-          weights(p, q)[0] = m_weights(p, q);
-
-          for(int i = 0; i < NDIMS; ++i)
-          {
-            projective(p, q)[i] = m_controlPoints(p, q)[i] * m_weights(p, q);
-          }
-        }
-      }
+      fill_projective_patches(projective, weights);
 
       Point<T, NDIMS> P;
       Vector<T, NDIMS> P_u, P_v, P_uu, P_vv, P_uv;
@@ -1770,19 +1710,7 @@ public:
       //  and BezierPatch of weights (w)
       BezierPatch<T, NDIMS> projective(ord_u, ord_v);
       BezierPatch<T, 1> weights(ord_u, ord_v);
-
-      for(int p = 0; p <= ord_u; ++p)
-      {
-        for(int q = 0; q <= ord_v; ++q)
-        {
-          weights(p, q)[0] = m_weights(p, q);
-
-          for(int i = 0; i < NDIMS; ++i)
-          {
-            projective(p, q)[i] = m_controlPoints(p, q)[i] * m_weights(p, q);
-          }
-        }
-      }
+      fill_projective_patches(projective, weights);
 
       Point<T, NDIMS> P;
       Vector<T, NDIMS> P_u, P_v, P_uv;
@@ -1790,8 +1718,8 @@ public:
       Point<T, 1> W;
       Vector<T, 1> W_u, W_v, W_uv;
 
-      projective.evaluate_linear_derivatives(u, v, P, P_u, P_v, P_uv);
-      weights.evaluate_linear_derivatives(u, v, W, W_u, W_v, W_uv);
+      projective.evaluateLinearDerivatives(u, v, P, P_u, P_v, P_uv);
+      weights.evaluateLinearDerivatives(u, v, W, W_u, W_v, W_uv);
 
       // Store values used in each coordinate computation
       double weight_prod = 2 * W_u[0] * W_v[0] - W[0] * W_uv[0];
@@ -2119,6 +2047,25 @@ private:
     }
 
     return true;
+  }
+
+  void fill_projective_patches(BezierPatches<T, NDIMS>& projective, BezierPatches<T, 1>& weights) const
+  {
+    SLIC_ASSERT(isRational());
+    SLIC_ASSERT(is_valid_rational());
+
+    for(int p = 0; p <= ord_u; ++p)
+    {
+      for(int q = 0; q <= ord_v; ++q)
+      {
+        weights(p, q)[0] = m_weights(p, q);
+
+        for(int i = 0; i < NDIMS; ++i)
+        {
+          projective(p, q)[i] = m_controlPoints(p, q)[i] * m_weights(p, q);
+        }
+      }
+    }
   }
 
 private:

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -2049,10 +2049,13 @@ private:
     return true;
   }
 
-  void fill_projective_patches(BezierPatches<T, NDIMS>& projective, BezierPatches<T, 1>& weights) const
+  void fill_projective_patches(BezierPatch<T, NDIMS>& projective, BezierPatch<T, 1>& weights) const
   {
     SLIC_ASSERT(isRational());
-    SLIC_ASSERT(is_valid_rational());
+    SLIC_ASSERT(isValidRational());
+
+    const int ord_u = getOrder_u();
+    const int ord_v = getOrder_v();
 
     for(int p = 0; p <= ord_u; ++p)
     {

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -176,7 +176,7 @@ public:
    *  space for the given order of the surface
    * 
    * \param [in] ord_u, ord_v The patch's polynomial orders
-   * \pre ord_u, ord_v greater than or equal to -1.
+   * \pre ord_u and ord_v must either both be at least 0 for a valid patch, or both must be -1 for an invalid patch
    */
   BezierPatch(int ord_u = -1, int ord_v = -1)
     : BezierPatch(axom::ArrayView<const PointType, 2>(nullptr, {0, 0}),

--- a/src/axom/primal/geometry/BezierPatch.hpp
+++ b/src/axom/primal/geometry/BezierPatch.hpp
@@ -52,6 +52,9 @@ std::ostream& operator<<(std::ostream& os, const BezierPatch<T, NDIMS>& bPatch);
  * Contains a 2D array of positive weights to represent a rational Bezier patch.
  * Polynomial (nonrational) Bezier patches are identified by an empty weights array.
  * 
+ * A default-constructed patch will have order -1 in both directions, and is "invalid".
+ * Arrays of nodes and weights will be empty, and most methods are invalid.
+ * 
  * Algorithms for Rational Bezier curves derived from 
  * Gerald Farin, "Algorithms for rational Bezier curves"
  * Computer-Aided Design, Volume 15, Number 2, 1983,
@@ -114,7 +117,7 @@ public:
    * \param [in] ord_v The patch's polynomial order on the second axis
    * 
    * If \a controlPoints is empty, we still allocate space for (ord_u+1, ord_v+1) control points
-   * \pre ord_u and ord_v must either both be at least 0 for a valid patch, or both must be -1 for an empty patch
+   * \pre ord_u and ord_v must either both be at least 0 for a valid patch, or both must be -1 for an invalid patch
    */
   BezierPatch(axom::ArrayView<const PointType, 2> controlPoints,
               axom::ArrayView<const T, 2> weights,

--- a/src/axom/primal/geometry/BezierTriangle.hpp
+++ b/src/axom/primal/geometry/BezierTriangle.hpp
@@ -1528,10 +1528,7 @@ public:
    *
    * \param [in] ord Triangle order
    */
-  static constexpr int triSize(int ord)
-  {
-    return (ord >= 0) ? ((ord + 1) * (ord + 2) / 2) : 0;
-  }
+  static constexpr int triSize(int ord) { return (ord >= 0) ? ((ord + 1) * (ord + 2) / 2) : 0; }
 
   /*!
    * \brief Maps triangular indices \a (i,j) to the linear storage index

--- a/src/axom/primal/geometry/BezierTriangle.hpp
+++ b/src/axom/primal/geometry/BezierTriangle.hpp
@@ -40,8 +40,7 @@ std::ostream& operator<<(std::ostream& os, const BezierTriangle<T, NDIMS>& bTri)
  *
  * \brief Represents a Bezier triangle defined by a triangular array of control points
  * \tparam T the coordinate type, e.g., double, float, etc.
- * \tparam NDIMS The dimension of each control point, e.g. 4 for homogeneous surfaces 
- *                 or 1 for rational weights.
+ * \tparam NDIMS The dimension of each control point, e.g. 1 for rational weights
  *
  * A Bezier triangle of order \a N has \f$ (N+1)(N+2)/2 \f$ control points.
  * It is parametrized over the domain \f$ u0 \ge 0, v0 \ge 0, u0+v0 \le 1 \f$.
@@ -54,6 +53,9 @@ std::ostream& operator<<(std::ostream& os, const BezierTriangle<T, NDIMS>& bTri)
  * Rational triangles are represented by an additional set of positive weights.
  * Polynomial (nonrational) Bezier triangles are identified by an empty weights array.
  *
+ * A default-constructed triangle will have order -1, and is "invalid".
+ * Arrays of nodes and weights will be empty, and most methods are invalid 
+ * 
  * \note This triangle uses permuted barycentric coordinates (u0, v0) for evaluation such that, when
  * `getOrder()==1`, the parameter values correspond to the triangle vertices:
  * - `evaluate(0,0) == (*this)(0,0)`
@@ -118,10 +120,8 @@ public:
    * All weights must be greater than 0 in a rational triangle.
    *
    * For 1D control point/weight arrays, the expected layout corresponds to the indexing
-   * used by `operator()(i,j)`:
-     \verbatim
-      pts[ triIndex(N,i,j) ]  <->  (*this)(i,j)   for 0<=i<=N and 0<=j<=N-i
-     \endverbatim
+   * used by `operator()(i,j)`: 
+   *    pts[ triIndex(N,i,j) ]  <->  (*this)(i,j)   for 0<=i<=N and 0<=j<=N-i
    */
 
   /**

--- a/src/axom/primal/geometry/BezierTriangle.hpp
+++ b/src/axom/primal/geometry/BezierTriangle.hpp
@@ -27,8 +27,6 @@
 
 #include <vector>
 #include <ostream>
-#include <unordered_map>
-#include <cstdint>
 
 namespace axom
 {
@@ -479,36 +477,41 @@ public:
       const int degPrev = n - (p - 1);
       std::vector<axom::Array<PointType>> currNets(triSize(p));
 
-      for(int a = 0; a <= p; ++a)
+      for(int fixedVcCount = 0; fixedVcCount <= p; ++fixedVcCount)
       {
-        for(int b = 0; b <= p - a; ++b)
+        for(int fixedVbCount = 0; fixedVbCount <= p - fixedVcCount; ++fixedVbCount)
         {
-          const int idx = triIndex(p, a, b);
-          const int c = p - a - b;
+          const int fixedVaCount = p - fixedVcCount - fixedVbCount;
+          const int idx = triIndex(p, fixedVcCount, fixedVbCount);
 
-          // Choose a unique predecessor (and thus a unique evaluation order) to avoid
-          // redundant reductions; the blossom symmetry ensures the final values are
-          // order-independent.
-          const Barycentric* Q = nullptr;
+          // Each net in this "tetrahedral" construction corresponds to a blossom value
+          // b(Vc^fixedVcCount, Vb^fixedVbCount, Va^fixedVaCount) at degree (n-p).
+          //
+          // There are multiple equivalent ways to compute each blossom value (blossom is
+          // symmetric in its arguments). We pick one deterministic predecessor to keep
+          // the recurrence simple and compute each net exactly once.
+          //
+          // Convention: consume Va arguments first, then Vb, then Vc.
           int predIdx = -1;
+          const Barycentric& splitPoint =
+            (fixedVaCount > 0) ? Va : (fixedVbCount > 0) ? Vb : Vc;
 
-          if(c > 0)
+          if(fixedVaCount > 0)
           {
-            predIdx = triIndex(p - 1, a, b);
-            Q = &Va;
+            predIdx = triIndex(p - 1, fixedVcCount, fixedVbCount);
           }
-          else if(b > 0)
+          else if(fixedVbCount > 0)
           {
-            predIdx = triIndex(p - 1, a, b - 1);
-            Q = &Vb;
+            predIdx = triIndex(p - 1, fixedVcCount, fixedVbCount - 1);
           }
           else
           {
-            predIdx = triIndex(p - 1, a - 1, b);
-            Q = &Vc;
+            SLIC_ASSERT(fixedVcCount > 0);
+            predIdx = triIndex(p - 1, fixedVcCount - 1, fixedVbCount);
           }
 
-          currNets[idx] = reduce_once(prevNets[predIdx], degPrev, *Q);
+          SLIC_ASSERT(predIdx >= 0);
+          currNets[idx] = reduce_once(prevNets[predIdx], degPrev, splitPoint);
         }
       }
 
@@ -823,182 +826,6 @@ public:
     restrictToSubtriangle(B, P0, P2, t2);
     restrictToSubtriangle(C, P1, P0, t3);
     restrictToSubtriangle(P1, P0, P2, t4);
-  }
-
-  /*!
-   * \brief Uniform 4-way "triforce" split at edge midpoints
-   *
-   * This is a convenience wrapper for `split(0.5, 0.5, 0.5, ...)`. A future optimized
-   * implementation can exploit the symmetry at \a s=0.5 to share intermediate nets.
-   *
-   * \param [out] t1 Subtriangle near vertex `(0,0)`
-   * \param [out] t2 Subtriangle near vertex `(0,1)`
-   * \param [out] t3 Subtriangle near vertex `(1,0)`
-   * \param [out] t4 Central subtriangle
-   *
-   * \pre getOrder() >= 0
-   * \pre This triangle is polynomial (nonrational)
-   */
-  void uniformSplit(BezierTriangle& t1,
-                    BezierTriangle& t2,
-                    BezierTriangle& t3,
-                    BezierTriangle& t4) const
-  {
-    SLIC_ASSERT(m_ord >= 0);
-    SLIC_ASSERT(!isRational());
-
-    // Optimized uniform subdivision at the edge midpoints (s=0.5) following:
-    // Kenneth I. Joy, "A Uniform Subdivision Method for Triangular Bezier Patches".
-    //
-    // The method constructs a degenerate "Bezier tetrahedron" of intermediate points via
-    // repeated midpoint averaging in the control net, then extracts the four subpatch
-    // control nets from its four faces (three corner triangles + one central triangle).
-    //
-    // Notation: the paper indexes control points as P_{i,j,k} with i+j+k = n and defines
-    // intermediate points P_{i,j,k}^{[n1,n2,n3]} via:
-    //   if n1>0: 1/2( P^{[n1-1,n2,n3]}_{i,j,k} + P^{[n1-1,n2,n3]}_{i-1,j+1,k} )
-    //   if n2>0: 1/2( P^{[n1,n2-1,n3]}_{i,j,k} + P^{[n1,n2-1,n3]}_{i,j-1,k+1} )
-    //   if n3>0: 1/2( P^{[n1,n2,n3-1]}_{i,j,k} + P^{[n1,n2,n3-1]}_{i+1,j,k-1} )
-    //   else:    P_{i,j,k}
-    //
-    // The four output meshes are then:
-    //   Q1 = { P^{[m,0,k]}_{i,0,k} : i+k=n, m=0..i }          (near paper vertex P1)
-    //   Q2 = { P^{[i,m,0]}_{i,j,0} : i+j=n, m=0..j }          (near paper vertex P2)
-    //   Q3 = { P^{[0,j,m]}_{0,j,k} : j+k=n, m=0..k }          (near paper vertex P3)
-    //   Q4 = { P^{[i,j,k]}_{i,j,k} : i+j+k=n }                (central)
-    //
-    // Under this class' (u,v,w) convention, paper (P1,P2,P3) corresponds to (C,B,A),
-    // so Q3->t1 (near A), Q2->t2 (near B), Q1->t3 (near C), Q4->t4 (central).
-
-    const int n = m_ord;
-
-    t1.setOrder(n);
-    t2.setOrder(n);
-    t3.setOrder(n);
-    t4.setOrder(n);
-    t1.getWeights().resize(0);
-    t2.getWeights().resize(0);
-    t3.getWeights().resize(0);
-    t4.getWeights().resize(0);
-
-    // Memoize intermediate values. For a fixed order, all indices are in [0,n], so we can
-    // use a mixed-radix packing with base (n+1) (safe for typical Bezier orders).
-    const std::uint64_t base = static_cast<std::uint64_t>(n + 1);
-    auto make_key = [&](int i, int j, int k, int n1, int n2, int n3) -> std::uint64_t {
-      std::uint64_t key = static_cast<std::uint64_t>(i);
-      key = key * base + static_cast<std::uint64_t>(j);
-      key = key * base + static_cast<std::uint64_t>(k);
-      key = key * base + static_cast<std::uint64_t>(n1);
-      key = key * base + static_cast<std::uint64_t>(n2);
-      key = key * base + static_cast<std::uint64_t>(n3);
-      return key;
-    };
-
-    std::unordered_map<std::uint64_t, PointType> memo;
-    memo.reserve(static_cast<std::size_t>((n + 1) * (n + 1) * (n + 1)));
-
-    // Recursive evaluation of P^{[n1,n2,n3]}_{i,j,k}.
-    std::function<PointType(int, int, int, int, int, int)> eval =
-      [&](int i, int j, int k, int n1, int n2, int n3) -> PointType {
-      SLIC_ASSERT(i >= 0 && j >= 0 && k >= 0);
-      SLIC_ASSERT(i + j + k == n);
-      SLIC_ASSERT(n1 >= 0 && n2 >= 0 && n3 >= 0);
-      SLIC_ASSERT(n1 <= n && n2 <= n && n3 <= n);
-
-      const auto key = make_key(i, j, k, n1, n2, n3);
-      auto it = memo.find(key);
-      if(it != memo.end())
-      {
-        return it->second;
-      }
-
-      PointType out;
-      if(n1 > 0)
-      {
-        SLIC_ASSERT(i > 0);
-        const auto a = eval(i, j, k, n1 - 1, n2, n3);
-        const auto b = eval(i - 1, j + 1, k, n1 - 1, n2, n3);
-        for(int d = 0; d < NDIMS; ++d)
-        {
-          out[d] = T(0.5) * (a[d] + b[d]);
-        }
-      }
-      else if(n2 > 0)
-      {
-        SLIC_ASSERT(j > 0);
-        const auto a = eval(i, j, k, n1, n2 - 1, n3);
-        const auto b = eval(i, j - 1, k + 1, n1, n2 - 1, n3);
-        for(int d = 0; d < NDIMS; ++d)
-        {
-          out[d] = T(0.5) * (a[d] + b[d]);
-        }
-      }
-      else if(n3 > 0)
-      {
-        SLIC_ASSERT(k > 0);
-        const auto a = eval(i, j, k, n1, n2, n3 - 1);
-        const auto b = eval(i + 1, j, k - 1, n1, n2, n3 - 1);
-        for(int d = 0; d < NDIMS; ++d)
-        {
-          out[d] = T(0.5) * (a[d] + b[d]);
-        }
-      }
-      else
-      {
-        // Base: original control point P_{i,j,k} (k implied by n-i-j).
-        SLIC_ASSERT(k == n - i - j);
-        out = (*this)(i, j);
-      }
-
-      memo.emplace(key, out);
-      return out;
-    };
-
-    // Q3 -> t1 : t1(i_local=j, j_local=m) = P^{[0,j,m]}_{0,j,k}, with k = n-j.
-    for(int i_local = 0; i_local <= n; ++i_local)
-    {
-      const int j = i_local;
-      const int k = n - j;
-      for(int j_local = 0; j_local <= n - i_local; ++j_local)
-      {
-        const int m = j_local;
-        t1(i_local, j_local) = eval(0, j, k, 0, j, m);
-      }
-    }
-
-    // Q2 -> t2 : t2(i_local=i, j_local=m) = P^{[i,m,0]}_{i,j,0}, with j = n-i.
-    for(int i_local = 0; i_local <= n; ++i_local)
-    {
-      const int i = i_local;
-      const int j = n - i;
-      for(int j_local = 0; j_local <= n - i_local; ++j_local)
-      {
-        const int m = j_local;
-        t2(i_local, j_local) = eval(i, j, 0, i, m, 0);
-      }
-    }
-
-    // Q1 -> t3 : t3(i_local=k, j_local=m) = P^{[m,0,k]}_{i,0,k}, with i = n-k.
-    for(int i_local = 0; i_local <= n; ++i_local)
-    {
-      const int k = i_local;
-      const int i = n - k;
-      for(int j_local = 0; j_local <= n - i_local; ++j_local)
-      {
-        const int m = j_local;
-        t3(i_local, j_local) = eval(i, 0, k, m, 0, k);
-      }
-    }
-
-    // Q4 -> t4 : t4(i,j) = P^{[i,j,k]}_{i,j,k}, k = n-i-j.
-    for(int i = 0; i <= n; ++i)
-    {
-      for(int j = 0; j <= n - i; ++j)
-      {
-        const int k = n - i - j;
-        t4(i, j) = eval(i, j, k, i, j, k);
-      }
-    }
   }
 
   /*!

--- a/src/axom/primal/geometry/BezierTriangle.hpp
+++ b/src/axom/primal/geometry/BezierTriangle.hpp
@@ -1,0 +1,935 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+// files for dates and other details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ * \file BezierTriangle.hpp
+ *
+ * \brief A BezierTriangle primitive
+ */
+
+#ifndef AXOM_PRIMAL_BEZIERTRIANGLE_HPP_
+#define AXOM_PRIMAL_BEZIERTRIANGLE_HPP_
+
+#include "axom/core.hpp"
+#include "axom/slic.hpp"
+
+#include "axom/primal/geometry/Point.hpp"
+#include "axom/primal/geometry/Vector.hpp"
+#include "axom/primal/geometry/Segment.hpp"
+#include "axom/primal/geometry/BezierCurve.hpp"
+#include "axom/primal/geometry/BoundingBox.hpp"
+#include "axom/primal/geometry/OrientedBoundingBox.hpp"
+
+#include "axom/primal/operators/squared_distance.hpp"
+
+#include <ostream>
+
+namespace axom
+{
+namespace primal
+{
+// Forward declare the templated classes and operator functions
+template <typename T, int NDIMS>
+class BezierTriangle;
+
+/*! \brief Overloaded output operator for Bezier Triangles*/
+template <typename T, int NDIMS>
+std::ostream& operator<<(std::ostream& os, const BezierTriangle<T, NDIMS>& bTri);
+
+/*!
+ * \class BezierTriangle
+ *
+ * \brief Represents a Bezier triangle defined by a triangular array of control points
+ * \tparam T the coordinate type, e.g., double, float, etc.
+ *
+ * A Bezier triangle of order \a N has \f$ (N+1)(N+2)/2 \f$ control points.
+ * It is parametrized over the domain \f$ u \ge 0, v \ge 0, u+v \le 1 \f$.
+ *
+ * Control points are indexed using integer coordinates \f$ (i,j) \f$ with
+ * \f$ 0 \le i \le N \f$ and \f$ 0 \le j \le N-i \f$ and accessed via `operator()(i,j)`.
+ * Internally, the triangular control net is stored in a 1D array and `triIndex(N,i,j)`
+ * maps \f$ (i,j) \f$ to that linear storage index.
+ *
+ * Rational triangles are represented by an additional set of positive weights.
+ * Polynomial (nonrational) Bezier triangles are identified by an empty weights array.
+ *
+ * \note This triangle uses permuted barycentric coordinates for evaluation such that, when
+ * `getOrder()==1`, the parameter values correspond to the triangle vertices:
+ * - `evaluate(0,0) == (*this)(0,0)`
+ * - `evaluate(0,1) == (*this)(0,1)`
+ * - `evaluate(1,0) == (*this)(1,0)`
+ */
+template <typename T, int NDIMS>
+class BezierTriangle
+{
+public:
+  using PointType = Point<T, NDIMS>;
+  using VectorType = Vector<T, NDIMS>;
+
+  using CoordsVec = axom::Array<PointType, 1>;
+  using WeightsVec = axom::Array<T, 1>;
+
+  using BoundingBoxType = BoundingBox<T, NDIMS>;
+  using OrientedBoundingBoxType = OrientedBoundingBox<T, NDIMS>;
+  using BezierCurveType = primal::BezierCurve<T, NDIMS>;
+
+  AXOM_STATIC_ASSERT_MSG((NDIMS == 1) || (NDIMS == 2) || (NDIMS == 3),
+                         "A Bezier Triangle object may be defined in 1-, 2-, or 3-D");
+
+  AXOM_STATIC_ASSERT_MSG(std::is_arithmetic<T>::value,
+                         "A Bezier Triangle must be defined using an arithmetic type");
+
+public:
+  ///@{
+  /**
+   * @name Constructors for BezierTriangle
+   *
+   * The constructors allow for flexible initialization of BezierTriangle objects from:
+   * - 1D Axom arrays/views of control points and weights,
+   * - C-style arrays of control points and weights,
+   * - a specified polynomial order,
+   * - rational or polynomial (nonrational) triangles, depending on the presence of weights.
+   *
+   * The triangle is parametrized over the domain \f$ u \ge 0, v \ge 0, u+v \le 1 \f$.
+   *
+   * Rational triangles are identified by a non-empty weights array,
+   * and nonrational triangles by an empty weights array.
+   * All weights must be greater than 0 in a rational triangle.
+   *
+   * For 1D control point/weight arrays, the expected layout corresponds to the indexing
+   * used by `operator()(i,j)`:
+     \verbatim
+      pts[ triIndex(N,i,j) ]  <->  (*this)(i,j)   for 0<=i<=N and 0<=j<=N-i
+     \endverbatim
+   */
+
+  /**
+   * \brief Constructor from ArrayViews of control points and weights
+   *
+   * \param [in] controlPoints ArrayView of control points (size: (ord+1)(ord+2)/2 or 0)
+   * \param [in] weights ArrayView of weights (size: (ord+1)(ord+2)/2 or 0)
+   * \param [in] ord The triangle's polynomial order
+   *
+   * If \a controlPoints is empty, we still allocate space for the control points.
+   * \pre ord must be greater than or equal to -1
+   */
+  BezierTriangle(axom::ArrayView<const PointType> controlPoints,
+                 axom::ArrayView<const T> weights,
+                 int ord)
+    : m_ord(ord)
+  {
+    SLIC_ASSERT(ord >= -1);
+
+    const int SZ = (m_ord >= 0) ? triSize(m_ord) : 0;
+    SLIC_ASSERT(controlPoints.size() >= weights.size());
+
+    // note: always allocate space for control points
+    if(controlPoints.empty())
+    {
+      m_controlPoints.resize(SZ);
+    }
+    else
+    {
+      SLIC_ASSERT(controlPoints.data() != nullptr);
+      SLIC_ASSERT(controlPoints.size() == SZ);
+      m_controlPoints = controlPoints;
+    }
+
+    // note: only allocate space for weights when they are supplied
+    if(!weights.empty())
+    {
+      SLIC_ASSERT(weights.data() != nullptr);
+      SLIC_ASSERT(weights.size() == SZ);
+      m_weights = weights;
+      SLIC_ASSERT(is_valid_rational());
+    }
+  }
+
+  /// Constructor from ArrayViews of (non-const) control points and weights
+  BezierTriangle(axom::ArrayView<PointType> controlPoints, axom::ArrayView<T> weights, int ord)
+    : BezierTriangle(axom::ArrayView<const PointType>(controlPoints.data(), controlPoints.size()),
+                     axom::ArrayView<const T>(weights.data(), weights.size()),
+                     ord)
+  { }
+
+  /*!
+   * \brief Constructor for a polynomial (nonrational) Bezier Triangle that reserves space
+   *
+   * \param [in] ord The triangle's polynomial order
+   * \pre ord must be greater than or equal to -1
+   */
+  explicit BezierTriangle(int ord = -1)
+    : BezierTriangle(axom::ArrayView<const PointType>(nullptr, 0),
+                     axom::ArrayView<const T>(nullptr, 0),
+                     ord)
+  { }
+
+  /*!
+   * \brief Constructor for a polynomial Bezier Triangle from an array of coordinates
+   *
+   * \param [in] pts A 1D C-style array of (ord+1)(ord+2)/2 control points
+   * \param [in] ord The triangle's polynomial order
+   * \pre ord is greater than or equal to zero
+   */
+  BezierTriangle(const PointType* pts, int ord)
+    : BezierTriangle(axom::ArrayView<const PointType>(pts, triSize(ord)),
+                     axom::ArrayView<const T>(nullptr, 0),
+                     ord)
+  { }
+
+  /*!
+   * \brief Constructor for a rational Bezier Triangle from arrays of coordinates and weights
+   *
+   * \param [in] pts A 1D C-style array of (ord+1)(ord+2)/2 control points
+   * \param [in] weights A 1D C-style array of (ord+1)(ord+2)/2 positive weights
+   * \param [in] ord The triangle's polynomial order
+   * \pre ord is greater than or equal to zero
+   *
+   * If \a weights is the null pointer, creates a nonrational triangle.
+   */
+  BezierTriangle(const PointType* pts, const T* weights, int ord)
+    : BezierTriangle(axom::ArrayView<const PointType>(pts, triSize(ord)),
+                     axom::ArrayView<const T>(weights, weights ? triSize(ord) : 0),
+                     ord)
+  { }
+
+  /*!
+   * \brief Constructor from an Axom array of control points
+   *
+   * \param [in] pts A 1D Axom array of (ord+1)(ord+2)/2 control points
+   * \param [in] ord The triangle's polynomial order (>= 0)
+   */
+  BezierTriangle(const CoordsVec& pts, int ord)
+    : BezierTriangle(pts.view(), axom::ArrayView<const T>(nullptr, 0), ord)
+  { }
+
+  /*!
+   * \brief Constructor from Axom arrays of control points and weights
+   *
+   * \param [in] pts A 1D Axom array of (ord+1)(ord+2)/2 control points
+   * \param [in] weights A 1D Axom array of (ord+1)(ord+2)/2 positive weights
+   * \param [in] ord The triangle's polynomial order (>= 0)
+   */
+  BezierTriangle(const CoordsVec& pts, const WeightsVec& weights, int ord)
+    : BezierTriangle(pts.view(), weights.view(), ord)
+  { }
+
+  ///@}
+
+  /*!
+   * \brief Returns true when this triangle is rational
+   *
+   * A rational triangle has a weight per control point; polynomial (nonrational) triangles
+   * are identified by an empty weight array.
+   */
+  bool isRational() const { return !m_weights.empty(); }
+
+  /*!
+   * \brief Returns a reference to the triangle's control points
+   *
+   * The control net contains `triSize(getOrder())` points (or 0 when `getOrder()<0`).
+   */
+  CoordsVec& getControlPoints() { return m_controlPoints; }
+
+  /// \overload
+  const CoordsVec& getControlPoints() const { return m_controlPoints; }
+
+  /*!
+   * \brief Returns a reference to the triangle's weights
+   *
+   * The weight array is empty for polynomial triangles. For rational triangles it contains
+   * `triSize(getOrder())` positive weights.
+   */
+  WeightsVec& getWeights() { return m_weights; }
+
+  /// \overload
+  const WeightsVec& getWeights() const { return m_weights; }
+
+  /*!
+   * \brief Returns an axis-aligned bounding box containing the Bezier triangle
+   *
+   * \note The returned box is computed from the control points.
+   */
+  BoundingBoxType boundingBox() const
+  {
+    return BoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
+  }
+
+  /*!
+   * \brief Returns an oriented bounding box containing the Bezier triangle
+   *
+   * \note The returned box is computed from the control points.
+   */
+  OrientedBoundingBoxType orientedBoundingBox() const
+  {
+    return OrientedBoundingBoxType(m_controlPoints.data(), static_cast<int>(m_controlPoints.size()));
+  }
+
+  /*!
+   * \brief Sets the order of the Bezier triangle and resizes internal storage
+   *
+   * \param [in] ord The polynomial order 
+   * 
+   * \pre ord must be greater than or equal to -1
+   *
+   * \note This function only resizes the control point and weight arrays and does not
+   * initialize their values. If the triangle is rational (`isRational()==true`), the
+   * weight array is also resized to match the number of control points.
+   */
+  void setOrder(int ord)
+  {
+    SLIC_ASSERT(ord >= -1);
+
+    m_ord = ord;
+
+    const int SZ = (m_ord >= 0) ? triSize(m_ord) : 0;
+    m_controlPoints.resize(SZ);
+    if(isRational())
+    {
+      m_weights.resize(SZ);
+    }
+  }
+
+  /*!
+   * \brief Returns the polynomial order of the triangle
+   *
+   * \note A default constructed triangle has order -1 and no control points.
+   */
+  int getOrder() const { return m_ord; }
+
+  /*!
+   * \brief Access a control point in the triangular control net
+   *
+   * \param [in] i The first index (0 <= i <= getOrder())
+   * \param [in] j The second index (0 <= j <= getOrder()-i)
+   *
+   * \pre \a i and \a j are in range and \a i+\a j <= getOrder()
+   */
+  PointType& operator()(int i, int j)
+  {
+    SLIC_ASSERT(i >= 0);
+    SLIC_ASSERT(j >= 0);
+    SLIC_ASSERT(i + j <= m_ord);
+    return m_controlPoints[triIndex(m_ord, i, j)];
+  }
+
+  const PointType& operator()(int i, int j) const
+  {
+    SLIC_ASSERT(i >= 0);
+    SLIC_ASSERT(j >= 0);
+    SLIC_ASSERT(i + j <= m_ord);
+    return m_controlPoints[triIndex(m_ord, i, j)];
+  }
+
+  /*!
+   * \brief Evaluates the Bezier triangle at \a (u,v)
+   *
+   * \param [in] u Parameter value along the \a u axis
+   * \param [in] v Parameter value along the \a v axis
+   *
+   * \pre getOrder() >= 0
+   * \pre u >= 0, v >= 0, and u+v <= 1
+   *
+   * \return Point value S(u,v)
+   *
+   * \note In the rational case, evaluation is performed in projective space and divided
+   * by the evaluated weight.
+   */
+  PointType evaluate(T u, T v) const
+  {
+    SLIC_ASSERT(m_ord >= 0);
+    SLIC_ASSERT(u >= T(0));
+    SLIC_ASSERT(v >= T(0));
+    SLIC_ASSERT(u + v <= T(1));
+
+    if(!isRational())
+    {
+      PointType ptval;
+
+      const int npts = m_controlPoints.size();
+      axom::Array<T> dCarray(npts);
+
+      // Run de Casteljau algorithm on each dimension
+      for(int N = 0; N < NDIMS; ++N)
+      {
+        for(int n = 0; n < npts; ++n)
+        {
+          dCarray[n] = m_controlPoints[n][N];
+        }
+
+        for(int p = 1; p <= m_ord; ++p)
+        {
+          const int end = m_ord - p + 1;
+          for(int i = 0; i < end; ++i)
+          {
+            for(int j = 0; j < end - i; ++j)
+            {
+              const auto& A = dCarray[triIndex(end, i, j)];
+              const auto& B = dCarray[triIndex(end, i, j + 1)];
+              const auto& C = dCarray[triIndex(end, i + 1, j)];
+              dCarray[triIndex(end - 1, i, j)] = A + u * (C - A) + v * (B - A);
+            }
+          }
+        }
+
+        ptval[N] = dCarray[0];
+      }
+
+      return ptval;
+    }
+    else
+    {
+      // Rational case: evaluate in projective space, then divide by weight
+      BezierTriangle<T, NDIMS> projective(m_ord);
+      BezierTriangle<T, 1> weights(m_ord);
+      fill_projective_triangles(projective, weights);
+
+      const Point<T, NDIMS> P = projective.evaluate(u, v);
+      const Point<T, 1> W = weights.evaluate(u, v);
+
+      PointType eval;
+      for(int N = 0; N < NDIMS; ++N)
+      {
+        eval[N] = P[N] / W[0];
+      }
+      return eval;
+    }
+  }
+
+  /*!
+   * \brief Evaluates first derivatives of the Bezier triangle at \a (u,v)
+   *
+   * \param [in] u Parameter value along the \a u axis
+   * \param [in] v Parameter value along the \a v axis
+   * \param [out] eval Point value S(u,v)
+   * \param [out] Du First derivative S_u(u,v)
+   * \param [out] Dv First derivative S_v(u,v)
+   *
+   * \pre getOrder() >= 0
+   * \pre u >= 0, v >= 0, and u+v <= 1
+   */
+  void evaluateFirstDerivatives(T u,
+                                T v,
+                                Point<T, NDIMS>& eval,
+                                Vector<T, NDIMS>& Du,
+                                Vector<T, NDIMS>& Dv) const
+  {
+    SLIC_ASSERT(m_ord >= 0);
+    SLIC_ASSERT(u >= T(0));
+    SLIC_ASSERT(v >= T(0));
+    SLIC_ASSERT(u + v <= T(1));
+
+    if(m_ord == 0)
+    {
+      eval = m_controlPoints[0];
+      for(int N = 0; N < NDIMS; ++N)
+      {
+        Du[N] = T(0);
+        Dv[N] = T(0);
+      }
+      return;
+    }
+
+    if(!isRational())
+    {
+      const int npts = m_controlPoints.size();
+      axom::Array<T> dCarray(npts);
+
+      // Run de Casteljau algorithm on each dimension
+      for(int N = 0; N < NDIMS; ++N)
+      {
+        for(int n = 0; n < npts; ++n)
+        {
+          dCarray[n] = m_controlPoints[n][N];
+        }
+
+        for(int p = 1; p <= m_ord - 1; ++p)
+        {
+          const int end = m_ord - p + 1;
+          for(int i = 0; i < end; ++i)
+          {
+            for(int j = 0; j < end - i; ++j)
+            {
+              const auto& A = dCarray[triIndex(end, i, j)];
+              const auto& B = dCarray[triIndex(end, i, j + 1)];
+              const auto& C = dCarray[triIndex(end, i + 1, j)];
+              dCarray[triIndex(end - 1, i, j)] = A + u * (C - A) + v * (B - A);
+            }
+          }
+        }
+
+        // The last reduction yields a linear triangle:
+        //   S(u,v) = A + u(C-A) + v(B-A)
+        Du[N] = (dCarray[2] - dCarray[0]);
+        Dv[N] = (dCarray[1] - dCarray[0]);
+        eval[N] = dCarray[0] + u * Du[N] + v * Dv[N];
+
+        Du[N] *= m_ord;
+        Dv[N] *= m_ord;
+      }
+    }
+    else
+    {
+      BezierTriangle<T, NDIMS> projective(m_ord);
+      BezierTriangle<T, 1> weights(m_ord);
+      fill_projective_triangles(projective, weights);
+
+      Point<T, NDIMS> P;
+      Vector<T, NDIMS> P_u, P_v;
+
+      Point<T, 1> W;
+      Vector<T, 1> W_u, W_v;
+
+      projective.evaluateFirstDerivatives(u, v, P, P_u, P_v);
+      weights.evaluateFirstDerivatives(u, v, W, W_u, W_v);
+
+      for(int N = 0; N < NDIMS; ++N)
+      {
+        eval[N] = P[N] / W[0];
+        Du[N] = (P_u[N] - eval[N] * W_u[0]) / W[0];
+        Dv[N] = (P_v[N] - eval[N] * W_v[0]) / W[0];
+      }
+    }
+  }
+
+  /*!
+   * \brief Evaluates all linear derivatives of a Bezier triangle at (\a u, \a v)
+   *
+   * \param [in] u Parameter value at which to evaluate along the u axis
+   * \param [in] v Parameter value at which to evaluate along the v axis
+   * \param [out] eval The point value of the Bezier triangle at (u, v)
+   * \param [out] Du The vector value of S_u(u, v)
+   * \param [out] Dv The vector value of S_v(u, v)
+   * \param [out] DuDv The vector value of S_uv(u, v) == S_vu(u, v)
+   */
+  void evaluateLinearDerivatives(T u,
+                                 T v,
+                                 Point<T, NDIMS>& eval,
+                                 Vector<T, NDIMS>& Du,
+                                 Vector<T, NDIMS>& Dv,
+                                 Vector<T, NDIMS>& DuDv) const
+  {
+    SLIC_ASSERT(m_ord >= 0);
+    SLIC_ASSERT(u >= T(0));
+    SLIC_ASSERT(v >= T(0));
+    SLIC_ASSERT(u + v <= T(1));
+
+    if(!isRational())
+    {
+      if(m_ord < 2)
+      {
+        evaluateFirstDerivatives(u, v, eval, Du, Dv);
+        for(int N = 0; N < NDIMS; ++N)
+        {
+          DuDv[N] = T(0);
+        }
+        return;
+      }
+
+      const int npts = m_controlPoints.size();
+      axom::Array<T> dCarray(npts);
+
+      const T n_ord = static_cast<T>(m_ord);
+      const T n_ord_nm1 = static_cast<T>(m_ord) * static_cast<T>(m_ord - 1);
+
+      for(int N = 0; N < NDIMS; ++N)
+      {
+        for(int n = 0; n < npts; ++n)
+        {
+          dCarray[n] = m_controlPoints[n][N];
+        }
+
+        // Reduce to a quadratic triangle (order 2)
+        for(int p = 1; p <= m_ord - 2; ++p)
+        {
+          const int end = m_ord - p + 1;
+          for(int i = 0; i < end; ++i)
+          {
+            for(int j = 0; j < end - i; ++j)
+            {
+              const auto& A = dCarray[triIndex(end, i, j)];
+              const auto& B = dCarray[triIndex(end, i, j + 1)];
+              const auto& C = dCarray[triIndex(end, i + 1, j)];
+              dCarray[triIndex(end - 1, i, j)] = A + u * (C - A) + v * (B - A);
+            }
+          }
+        }
+
+        // Extract the reduced quadratic triangle values
+        const T Q00 = dCarray[triIndex(2, 0, 0)];
+        const T Q01 = dCarray[triIndex(2, 0, 1)];
+        const T Q02 = dCarray[triIndex(2, 0, 2)];
+        const T Q10 = dCarray[triIndex(2, 1, 0)];
+        const T Q11 = dCarray[triIndex(2, 1, 1)];
+        const T Q20 = dCarray[triIndex(2, 2, 0)];
+
+        // One reduction yields a linear triangle (order 1)
+        const T L00 = Q00 + u * (Q10 - Q00) + v * (Q01 - Q00);
+        const T L01 = Q01 + u * (Q11 - Q01) + v * (Q02 - Q01);
+        const T L10 = Q10 + u * (Q20 - Q10) + v * (Q11 - Q10);
+
+        eval[N] = L00 + u * (L10 - L00) + v * (L01 - L00);
+        Du[N] = n_ord * (L10 - L00);
+        Dv[N] = n_ord * (L01 - L00);
+        DuDv[N] = n_ord_nm1 * (Q11 - Q10 - Q01 + Q00);
+      }
+    }
+    else
+    {
+      BezierTriangle<T, NDIMS> projective(m_ord);
+      BezierTriangle<T, 1> weights(m_ord);
+      fill_projective_triangles(projective, weights);
+
+      Point<T, NDIMS> P;
+      Vector<T, NDIMS> P_u, P_v, P_uv;
+
+      Point<T, 1> W;
+      Vector<T, 1> W_u, W_v, W_uv;
+
+      projective.evaluateLinearDerivatives(u, v, P, P_u, P_v, P_uv);
+      weights.evaluateLinearDerivatives(u, v, W, W_u, W_v, W_uv);
+
+      for(int N = 0; N < NDIMS; ++N)
+      {
+        eval[N] = P[N] / W[0];
+        Du[N] = (P_u[N] - eval[N] * W_u[0]) / W[0];
+        Dv[N] = (P_v[N] - eval[N] * W_v[0]) / W[0];
+        DuDv[N] = (P_uv[N] - Du[N] * W_v[0] - Dv[N] * W_u[0] - eval[N] * W_uv[0]) / W[0];
+      }
+    }
+  }
+
+  /*!
+   * \brief Evaluates all second derivatives of a Bezier triangle at (\a u, \a v)
+   *
+   * \param [in] u Parameter value at which to evaluate along the u axis
+   * \param [in] v Parameter value at which to evaluate along the v axis
+   * \param [out] eval The point value of the Bezier triangle at (u, v)
+   * \param [out] Du The vector value of S_u(u, v)
+   * \param [out] Dv The vector value of S_v(u, v)
+   * \param [out] DuDu The vector value of S_uu(u, v)
+   * \param [out] DvDv The vector value of S_vv(u, v)
+   * \param [out] DuDv The vector value of S_uv(u, v) == S_vu(u, v)
+   */
+  void evaluateSecondDerivatives(T u,
+                                 T v,
+                                 Point<T, NDIMS>& eval,
+                                 Vector<T, NDIMS>& Du,
+                                 Vector<T, NDIMS>& Dv,
+                                 Vector<T, NDIMS>& DuDu,
+                                 Vector<T, NDIMS>& DvDv,
+                                 Vector<T, NDIMS>& DuDv) const
+  {
+    SLIC_ASSERT(m_ord >= 0);
+    SLIC_ASSERT(u >= T(0));
+    SLIC_ASSERT(v >= T(0));
+    SLIC_ASSERT(u + v <= T(1));
+
+    if(m_ord == 0)
+    {
+      eval = m_controlPoints[0];
+      for(int N = 0; N < NDIMS; ++N)
+      {
+        Du[N] = T(0);
+        Dv[N] = T(0);
+        DuDu[N] = T(0);
+        DvDv[N] = T(0);
+        DuDv[N] = T(0);
+      }
+      return;
+    }
+
+    if(m_ord == 1)
+    {
+      evaluateFirstDerivatives(u, v, eval, Du, Dv);
+      for(int N = 0; N < NDIMS; ++N)
+      {
+        DuDu[N] = T(0);
+        DvDv[N] = T(0);
+        DuDv[N] = T(0);
+      }
+      return;
+    }
+
+    if(!isRational())
+    {
+      const int npts = m_controlPoints.size();
+      axom::Array<T> dCarray(npts);
+
+      const T n_ord = static_cast<T>(m_ord);
+      const T n_ord_nm1 = static_cast<T>(m_ord) * static_cast<T>(m_ord - 1);
+
+      for(int N = 0; N < NDIMS; ++N)
+      {
+        for(int n = 0; n < npts; ++n)
+        {
+          dCarray[n] = m_controlPoints[n][N];
+        }
+
+        // Reduce to a quadratic triangle (order 2)
+        for(int p = 1; p <= m_ord - 2; ++p)
+        {
+          const int end = m_ord - p + 1;
+          for(int i = 0; i < end; ++i)
+          {
+            for(int j = 0; j < end - i; ++j)
+            {
+              const auto& A = dCarray[triIndex(end, i, j)];
+              const auto& B = dCarray[triIndex(end, i, j + 1)];
+              const auto& C = dCarray[triIndex(end, i + 1, j)];
+              dCarray[triIndex(end - 1, i, j)] = A + u * (C - A) + v * (B - A);
+            }
+          }
+        }
+
+        // Extract the reduced quadratic triangle values
+        const T Q00 = dCarray[triIndex(2, 0, 0)];
+        const T Q01 = dCarray[triIndex(2, 0, 1)];
+        const T Q02 = dCarray[triIndex(2, 0, 2)];
+        const T Q10 = dCarray[triIndex(2, 1, 0)];
+        const T Q11 = dCarray[triIndex(2, 1, 1)];
+        const T Q20 = dCarray[triIndex(2, 2, 0)];
+
+        // One reduction yields a linear triangle (order 1)
+        const T L00 = Q00 + u * (Q10 - Q00) + v * (Q01 - Q00);
+        const T L01 = Q01 + u * (Q11 - Q01) + v * (Q02 - Q01);
+        const T L10 = Q10 + u * (Q20 - Q10) + v * (Q11 - Q10);
+
+        eval[N] = L00 + u * (L10 - L00) + v * (L01 - L00);
+        Du[N] = n_ord * (L10 - L00);
+        Dv[N] = n_ord * (L01 - L00);
+
+        // Second derivatives from second differences of the reduced quadratic triangle
+        DuDu[N] = n_ord_nm1 * (Q20 - T(2) * Q10 + Q00);
+        DvDv[N] = n_ord_nm1 * (Q02 - T(2) * Q01 + Q00);
+        DuDv[N] = n_ord_nm1 * (Q11 - Q10 - Q01 + Q00);
+      }
+    }
+    else
+    {
+      BezierTriangle<T, NDIMS> projective(m_ord);
+      BezierTriangle<T, 1> weights(m_ord);
+      fill_projective_triangles(projective, weights);
+
+      Point<T, NDIMS> P;
+      Vector<T, NDIMS> P_u, P_v, P_uu, P_vv, P_uv;
+
+      Point<T, 1> W;
+      Vector<T, 1> W_u, W_v, W_uu, W_vv, W_uv;
+
+      projective.evaluateSecondDerivatives(u, v, P, P_u, P_v, P_uu, P_vv, P_uv);
+      weights.evaluateSecondDerivatives(u, v, W, W_u, W_v, W_uu, W_vv, W_uv);
+
+      for(int N = 0; N < NDIMS; ++N)
+      {
+        eval[N] = P[N] / W[0];
+        Du[N] = (P_u[N] - eval[N] * W_u[0]) / W[0];
+        Dv[N] = (P_v[N] - eval[N] * W_v[0]) / W[0];
+        DuDu[N] = (P_uu[N] - T(2) * W_u[0] * Du[N] - eval[N] * W_uu[0]) / W[0];
+        DvDv[N] = (P_vv[N] - T(2) * W_v[0] * Dv[N] - eval[N] * W_vv[0]) / W[0];
+        DuDv[N] = (P_uv[N] - Du[N] * W_v[0] - Dv[N] * W_u[0] - eval[N] * W_uv[0]) / W[0];
+      }
+    }
+  }
+
+  /*!
+   * \brief Computes a tangent of a Bezier triangle at (\a u, \a v) along the u axis
+   */
+  VectorType du(T u, T v) const
+  {
+    PointType eval;
+    VectorType Du, Dv;
+    evaluateFirstDerivatives(u, v, eval, Du, Dv);
+    return Du;
+  }
+
+  /*!
+   * \brief Computes a tangent of a Bezier triangle at (\a u, \a v) along the v axis
+   */
+  VectorType dv(T u, T v) const
+  {
+    PointType eval;
+    VectorType Du, Dv;
+    evaluateFirstDerivatives(u, v, eval, Du, Dv);
+    return Dv;
+  }
+
+  /*!
+   * \brief Computes the second derivative of a Bezier triangle at (\a u, \a v) along the u axis
+   */
+  VectorType dudu(T u, T v) const
+  {
+    PointType eval;
+    VectorType Du, Dv, DuDu, DvDv, DuDv;
+    evaluateSecondDerivatives(u, v, eval, Du, Dv, DuDu, DvDv, DuDv);
+    return DuDu;
+  }
+
+  /*!
+   * \brief Computes the second derivative of a Bezier triangle at (\a u, \a v) along the v axis
+   */
+  VectorType dvdv(T u, T v) const
+  {
+    PointType eval;
+    VectorType Du, Dv, DuDu, DvDv, DuDv;
+    evaluateSecondDerivatives(u, v, eval, Du, Dv, DuDu, DvDv, DuDv);
+    return DvDv;
+  }
+
+  /*!
+   * \brief Computes the mixed second derivative of a Bezier triangle at (\a u, \a v)
+   */
+  VectorType dudv(T u, T v) const
+  {
+    PointType eval;
+    VectorType Du, Dv, DuDu, DvDv, DuDv;
+    evaluateSecondDerivatives(u, v, eval, Du, Dv, DuDu, DvDv, DuDv);
+    return DuDv;
+  }
+
+  /// Convenience alias for S_vu(u,v), which equals S_uv(u,v) for polynomial triangles
+  VectorType dvdu(T u, T v) const { return dudv(u, v); }
+
+  /*!
+   * \brief Computes the normal vector of a Bezier triangle at (\a u, \a v)
+   *
+   * \note Only meaningful for NDIMS==3.
+   */
+  VectorType normal(T u, T v) const
+  {
+    Point<T, NDIMS> eval;
+    Vector<T, NDIMS> Du, Dv;
+    evaluateFirstDerivatives(u, v, eval, Du, Dv);
+    return VectorType::cross_product(Du, Dv);
+  }
+
+  /*!
+   * \brief Simple formatted print of a Bezier Triangle instance
+   *
+   * \param os The output stream to write to
+   * \return A reference to the modified ostream
+   */
+  std::ostream& print(std::ostream& os) const
+  {
+    os << "{ order " << m_ord << " Bezier Triangle ";
+
+    for(int i = 0; i <= m_ord; ++i)
+    {
+      for(int j = 0; j <= m_ord - i; ++j)
+      {
+        os << (*this)(i, j) << ((i < m_ord || j < m_ord - i) ? "," : "");
+      }
+    }
+
+    if(isRational())
+    {
+      os << ", weights [";
+      for(int i = 0; i <= m_ord; ++i)
+      {
+        for(int j = 0; j <= m_ord - i; ++j)
+        {
+          os << m_weights[triIndex(m_ord, i, j)] << ((i < m_ord || j < m_ord - i) ? "," : "");
+        }
+      }
+      os << "]";
+    }
+
+    os << "}";
+    return os;
+  }
+
+  /*!
+   * \brief Returns the number of control points for a triangle of order \a ord
+   *
+   * \param [in] ord Triangle order
+   */
+  static constexpr size_t triSize(int ord)
+  {
+    return (ord >= 0) ? static_cast<size_t>((ord + 1) * (ord + 2) / 2) : size_t {0};
+  }
+
+  /*!
+   * \brief Maps triangular indices \a (i,j) to the linear storage index
+   *
+   * \param [in] ord Triangle order
+   * \param [in] i First control net index
+   * \param [in] j Second control net index
+   *
+   * \pre ord >= 0, i >= 0, j >= 0, and i+j <= ord
+   */
+  static constexpr size_t triIndex(int ord, int i, int j)
+  {
+    return static_cast<size_t>(i * (2 * ord + 3 - i) / 2 + j);
+  }
+
+private:
+  /// Check that the weights used are positive, and
+  ///  that there is one for each control node
+  bool is_valid_rational() const
+  {
+    if(!isRational())
+    {
+      return true;
+    }
+
+    if(m_weights.size() != m_controlPoints.size())
+    {
+      return false;
+    }
+
+    for(int p = 0; p < m_weights.size(); ++p)
+    {
+      if(m_weights[p] <= 0)
+      {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  void fill_projective_triangles(BezierTriangle<T, NDIMS>& projective,
+                                 BezierTriangle<T, 1>& weights) const
+  {
+    SLIC_ASSERT(isRational());
+    SLIC_ASSERT(is_valid_rational());
+
+    for(int i = 0; i <= m_ord; ++i)
+    {
+      for(int j = 0; j <= m_ord - i; ++j)
+      {
+        const T w = m_weights[triIndex(m_ord, i, j)];
+        weights(i, j)[0] = w;
+
+        for(int N = 0; N < NDIMS; ++N)
+        {
+          projective(i, j)[N] = (*this)(i, j)[N] * w;
+        }
+      }
+    }
+  }
+
+private:
+  int m_ord;
+
+  CoordsVec m_controlPoints;
+  WeightsVec m_weights;
+};
+
+//------------------------------------------------------------------------------
+/// Free functions related to BezierTriangle
+//------------------------------------------------------------------------------
+template <typename T, int NDIMS>
+std::ostream& operator<<(std::ostream& os, const BezierTriangle<T, NDIMS>& bTri)
+{
+  bTri.print(os);
+  return os;
+}
+
+}  // namespace primal
+}  // namespace axom
+
+#endif  // AXOM_PRIMAL_BEZIERTRIANGLE_HPP_

--- a/src/axom/primal/geometry/BezierTriangle.hpp
+++ b/src/axom/primal/geometry/BezierTriangle.hpp
@@ -25,7 +25,10 @@
 
 #include "axom/primal/operators/squared_distance.hpp"
 
+#include <vector>
 #include <ostream>
+#include <unordered_map>
+#include <cstdint>
 
 namespace axom
 {
@@ -75,6 +78,7 @@ public:
   using BoundingBoxType = BoundingBox<T, NDIMS>;
   using OrientedBoundingBoxType = OrientedBoundingBox<T, NDIMS>;
   using BezierCurveType = primal::BezierCurve<T, NDIMS>;
+  using EdgesVec = axom::Array<BezierCurveType>;
 
   AXOM_STATIC_ASSERT_MSG((NDIMS == 1) || (NDIMS == 2) || (NDIMS == 3),
                          "A Bezier Triangle object may be defined in 1-, 2-, or 3-D");
@@ -148,7 +152,7 @@ public:
     }
   }
 
-  /// Constructor from ArrayViews of (non-const) control points and weights
+  /// \brief Constructor from ArrayViews of (non-const) control points and weights
   BezierTriangle(axom::ArrayView<PointType> controlPoints, axom::ArrayView<T> weights, int ord)
     : BezierTriangle(axom::ArrayView<const PointType>(controlPoints.data(), controlPoints.size()),
                      axom::ArrayView<const T>(weights.data(), weights.size()),
@@ -234,7 +238,7 @@ public:
    */
   CoordsVec& getControlPoints() { return m_controlPoints; }
 
-  /// \overload
+  /// \brief Returns a reference to the triangle's control points
   const CoordsVec& getControlPoints() const { return m_controlPoints; }
 
   /*!
@@ -245,7 +249,7 @@ public:
    */
   WeightsVec& getWeights() { return m_weights; }
 
-  /// \overload
+  /// \brief Returns a reference to the triangle's weights
   const WeightsVec& getWeights() const { return m_weights; }
 
   /*!
@@ -301,6 +305,703 @@ public:
   int getOrder() const { return m_ord; }
 
   /*!
+   * \brief Returns one of the boundary edges of the Bezier triangle
+   *
+   * \param [in] edgeIdx Index of the requested edge in \a [0,2]
+   *
+   * The edges are returned in counter-clockwise order with respect to the
+   * parameter domain (u,v), with edge 0 across from corner 0 (i.e. evaluate(0,0)):
+   * - \a edgeIdx = 0: u+v = 1 from `evaluate(1,0)` to `evaluate(0,1)`
+   * - \a edgeIdx = 1: u = 0 from `evaluate(0,1)` to `evaluate(0,0)`
+   * - \a edgeIdx = 2: v = 0 from `evaluate(0,0)` to `evaluate(1,0)`
+   *
+   * For rational triangles, the returned curve is rational and uses the subset of
+   * weights corresponding to the boundary control points.
+   * 
+   * \return A Bezier curve representing the requested edge.
+   */
+  BezierCurveType getEdge(int edgeIdx) const
+  {
+    SLIC_ASSERT(m_ord >= 0);
+    SLIC_ASSERT(edgeIdx >= 0 && edgeIdx < 3);
+
+    axom::Array<PointType> pts(m_ord + 1);
+    axom::Array<T> wts;
+    if(isRational())
+    {
+      wts.resize(m_ord + 1);
+    }
+
+    switch(edgeIdx)
+    {
+    case 0:
+      for(int k = 0; k <= m_ord; ++k)
+      {
+        const int i = k;
+        const int j = m_ord - k;
+        pts[k] = (*this)(i, j);
+        if(isRational())
+        {
+          wts[k] = m_weights[triIndex(m_ord, i, j)];
+        }
+      }
+      break;
+    case 1:
+      for(int k = 0; k <= m_ord; ++k)
+      {
+        const int i = m_ord - k;
+        pts[k] = (*this)(i, 0);
+        if(isRational())
+        {
+          wts[k] = m_weights[triIndex(m_ord, i, 0)];
+        }
+      }
+      break;
+    case 2:
+      for(int j = 0; j <= m_ord; ++j)
+      {
+        pts[j] = (*this)(0, j);
+        if(isRational())
+        {
+          wts[j] = m_weights[triIndex(m_ord, 0, j)];
+        }
+      }
+      break;
+    default:
+      break;
+    }
+
+    return isRational() ? BezierCurveType(pts, wts, m_ord) : BezierCurveType(pts, m_ord);
+  }
+
+  /*!
+   * \brief Returns all three boundary edges of the Bezier triangle
+   *
+   * \return An array of three Bezier curves, ordered the same as `getEdge(int)`.
+   */
+  EdgesVec getEdges() const
+  {
+    SLIC_ASSERT(m_ord >= 0);
+    EdgesVec edges;
+    edges.reserve(3);
+    edges.push_back(getEdge(0));
+    edges.push_back(getEdge(1));
+    edges.push_back(getEdge(2));
+    return edges;
+  }
+
+  /*!
+   * \brief Restricts this polynomial Bezier triangle to a subtriangle of the parameter domain
+   *
+   * The subtriangle is defined by three barycentric coordinates \a (u,v,w) (with \a w = 1-u-v)
+   * in the parameter domain of this triangle.
+   *
+   * The returned triangle is parametrized over the reference domain and maps its vertices as:
+   * - local `(0,0)` -> \a Va
+   * - local `(0,1)` -> \a Vb
+   * - local `(1,0)` -> \a Vc
+   *
+   * \param [in] Va Barycentric coordinates of the first subtriangle vertex `(u,v,w)`
+   * \param [in] Vb Barycentric coordinates of the second subtriangle vertex `(u,v,w)`
+   * \param [in] Vc Barycentric coordinates of the third subtriangle vertex `(u,v,w)`
+   *
+   * \pre getOrder() >= 0
+   * \pre This triangle is polynomial (nonrational)
+   */
+  BezierTriangle restrictToSubtriangle(const Point<T, 3>& Va,
+                                       const Point<T, 3>& Vb,
+                                       const Point<T, 3>& Vc) const
+  {
+    BezierTriangle out;
+    restrictToSubtriangle(Va, Vb, Vc, out);
+    return out;
+  }
+
+  /*!
+   * \brief Restricts this polynomial Bezier triangle to a subtriangle of the parameter domain
+   *
+   * See overload returning a `BezierTriangle` for the vertex mapping convention.
+   *
+   * \param [in] Va Barycentric coordinates of the first subtriangle vertex `(u,v,w)`
+   * \param [in] Vb Barycentric coordinates of the second subtriangle vertex `(u,v,w)`
+   * \param [in] Vc Barycentric coordinates of the third subtriangle vertex `(u,v,w)`
+   * \param [out] out Output restricted Bezier triangle
+   *
+   * \pre getOrder() >= 0
+   * \pre This triangle is polynomial (nonrational)
+   */
+  void restrictToSubtriangle(const Point<T, 3>& Va,
+                             const Point<T, 3>& Vb,
+                             const Point<T, 3>& Vc,
+                             BezierTriangle& out) const
+  {
+    using Barycentric = Point<T, 3>;
+    SLIC_ASSERT(m_ord >= 0);
+    SLIC_ASSERT(!isRational());
+
+    const int n = m_ord;
+
+    auto reduce_once = [&](const axom::Array<PointType>& prev, int deg, const Barycentric& Q) {
+      const int newDeg = deg - 1;
+      axom::Array<PointType> next;
+      next.resize(triSize(newDeg));
+
+      for(int ii = 0; ii <= newDeg; ++ii)
+      {
+        for(int jj = 0; jj <= newDeg - ii; ++jj)
+        {
+          const auto& A0 = prev[triIndex(deg, ii, jj)];
+          const auto& B0 = prev[triIndex(deg, ii, jj + 1)];
+          const auto& C0 = prev[triIndex(deg, ii + 1, jj)];
+
+          PointType val;
+          for(int N = 0; N < NDIMS; ++N)
+          {
+            // Barycentric coordinates permuted to match convention in evaluate()
+            val[N] = Q[2] * A0[N] + Q[1] * B0[N] + Q[0] * C0[N];
+          }
+          next[triIndex(newDeg, ii, jj)] = val;
+        }
+      }
+
+      return next;
+    };
+
+    // Tetrahedral family of intermediate nets, indexed by the counts of (Vc, Vb, Va)
+    // fixed in the blossom. For p fixed arguments, there are triSize(p) nets, each of
+    // degree (n-p). At p==n, each net is degree 0 and corresponds to a restricted
+    // control point b(Vc^i, Vb^j, Va^(n-i-j)).
+    std::vector<axom::Array<PointType>> prevNets(1);
+    prevNets[0] = m_controlPoints;
+
+    for(int p = 1; p <= n; ++p)
+    {
+      const int degPrev = n - (p - 1);
+      std::vector<axom::Array<PointType>> currNets(triSize(p));
+
+      for(int a = 0; a <= p; ++a)
+      {
+        for(int b = 0; b <= p - a; ++b)
+        {
+          const int idx = triIndex(p, a, b);
+          const int c = p - a - b;
+
+          // Choose a unique predecessor (and thus a unique evaluation order) to avoid
+          // redundant reductions; the blossom symmetry ensures the final values are
+          // order-independent.
+          const Barycentric* Q = nullptr;
+          int predIdx = -1;
+
+          if(c > 0)
+          {
+            predIdx = triIndex(p - 1, a, b);
+            Q = &Va;
+          }
+          else if(b > 0)
+          {
+            predIdx = triIndex(p - 1, a, b - 1);
+            Q = &Vb;
+          }
+          else
+          {
+            predIdx = triIndex(p - 1, a - 1, b);
+            Q = &Vc;
+          }
+
+          currNets[idx] = reduce_once(prevNets[predIdx], degPrev, *Q);
+        }
+      }
+
+      prevNets.swap(currNets);
+    }
+
+    out.setOrder(n);
+    out.getWeights().resize(0);
+    for(int i = 0; i <= n; ++i)
+    {
+      for(int j = 0; j <= n - i; ++j)
+      {
+        out(i, j) = prevNets[triIndex(n, i, j)][0];
+      }
+    }
+  }
+
+  /*!
+   * \brief Splits a polynomial Bezier triangle into three subtriangles by connecting an
+   * interior parameter point \a (u,v) to the triangle's three vertices
+   *
+   * \param [in] u Parameter value along the \a u axis for the split point
+   * \param [in] v Parameter value along the \a v axis for the split point
+   * \param [out] t0 Subtriangle over the parameter triangle with vertices
+   *  `(0,1)`, `(1,0)`, and `(u,v)` (preserves edge 0)
+   * \param [out] t1 Subtriangle over the parameter triangle with vertices
+   *  `(1,0)`, `(0,0)`, and `(u,v)` (preserves edge 1)
+   * \param [out] t2 Subtriangle over the parameter triangle with vertices
+   *  `(0,0)`, `(0,1)`, and `(u,v)` (preserves edge 2)
+   *
+   * \pre \a u > 0, \a v > 0, and \a u + \a v < 1
+   * 
+   *            A
+   *           /|\
+   *          / | \ 
+   *         /t2|t1\ 
+   *        /  /Q\  \
+   *       / /  t0 \ \ 
+   *      //_________\\
+   *     B             C   
+   * 
+   * \return t0 = Tri(B,C,Q), t1 = Tri(C,A,Q), t2 = Tri(A,B,Q)
+   */
+  void split(T u, T v, BezierTriangle& t0, BezierTriangle& t1, BezierTriangle& t2) const
+  {
+    SLIC_ASSERT(m_ord >= 0);
+    SLIC_ASSERT(!isRational());
+    SLIC_ASSERT(u > T(0));
+    SLIC_ASSERT(v > T(0));
+    SLIC_ASSERT(u + v < T(1));
+
+    // Q is the split point in barycentric coordinates over the reference parameter triangle:
+    using Barycentric = Point<T, 3>;
+    const Barycentric Q {u, v, T(1) - u - v};
+
+    const int n = m_ord;
+    std::vector<axom::Array<PointType>> net(static_cast<std::size_t>(n + 1));
+    net[0] = m_controlPoints;
+
+    for(int p = 1; p <= n; ++p)
+    {
+      const int deg = n - p + 1;
+      const int newDeg = deg - 1;
+
+      net[p].resize(triSize(newDeg));
+      const auto& prev = net[p - 1];
+
+      for(int ii = 0; ii <= newDeg; ++ii)
+      {
+        for(int jj = 0; jj <= newDeg - ii; ++jj)
+        {
+          const auto& A0 = prev[triIndex(deg, ii, jj)];
+          const auto& B0 = prev[triIndex(deg, ii, jj + 1)];
+          const auto& C0 = prev[triIndex(deg, ii + 1, jj)];
+
+          PointType val;
+          for(int N = 0; N < NDIMS; ++N)
+          {
+            val[N] = Q[2] * A0[N] + Q[1] * B0[N] + Q[0] * C0[N];
+          }
+          net[p][triIndex(newDeg, ii, jj)] = val;
+        }
+      }
+    }
+
+    t0.setOrder(n);
+    t1.setOrder(n);
+    t2.setOrder(n);
+    t0.getWeights().resize(0);
+    t1.getWeights().resize(0);
+    t2.getWeights().resize(0);
+
+    // Subtriangle (B,C,Q): (0,1), (1,0), (u,v)
+    for(int i = 0; i <= n; ++i)
+    {
+      const int deg = n - i;
+      for(int j = 0; j <= n - i; ++j)
+      {
+        t0(i, j) = net[i][triIndex(deg, j, deg - j)];
+      }
+    }
+
+    // Subtriangle (C,A,Q): (1,0), (0,0), (u,v)
+    for(int i = 0; i <= n; ++i)
+    {
+      const int deg = n - i;
+      for(int j = 0; j <= n - i; ++j)
+      {
+        t1(i, j) = net[i][triIndex(deg, deg - j, 0)];
+      }
+    }
+
+    // Subtriangle (A,B,Q): (0,0), (0,1), (u,v)
+    for(int i = 0; i <= n; ++i)
+    {
+      const int deg = n - i;
+      for(int j = 0; j <= n - i; ++j)
+      {
+        t2(i, j) = net[i][triIndex(deg, 0, j)];
+      }
+    }
+  }
+
+  /*!
+   * \brief Splits a polynomial Bezier triangle into two subtriangles by connecting a
+   * point on a boundary edge to the opposite vertex
+   *
+   * \param [in] edgeIdx Index of the boundary edge to split (same convention as `getEdge(int)`)
+   * \param [in] s Parameter in \a [0,1] locating the split point along the chosen edge
+   * \param [out] t0 First output subtriangle
+   * \param [out] t1 Second output subtriangle
+   *
+   * \pre edgeIdx is 0, 1, or 2
+   * \pre \a s is in (0,1)
+   *
+   * Taking P0 as the vertex opposite edge `edgeIdx`:
+   * 
+   *            P0
+   *           /|\
+   *          / | \ 
+   *         /  |  \ 
+   *        /   |   \
+   *       / t0 | t1 \ 
+   *      /_____|_____\
+   *   P1       Q      P2   
+   *   s=0      s      s=1
+   * 
+   * \return t0 = Tri( P0, P1, Q ), t1 = Tri( P2, P0, Q )
+   */
+  void split(int edgeIdx, T s, BezierTriangle& t0, BezierTriangle& t1) const
+  {
+    SLIC_ASSERT(m_ord >= 0);
+    SLIC_ASSERT(!isRational());
+    SLIC_ASSERT(edgeIdx >= 0 && edgeIdx < 3);
+    SLIC_ASSERT(s > T(0) && s < T(1));
+
+    using Barycentric = Point<T, 3>;
+
+    Barycentric Q;
+    switch(edgeIdx)
+    {
+    case 0:  // (u=s, v=1-s, w=0)
+      Q = Barycentric {s, T(1) - s, T(0)};
+      break;
+    case 1:  // (u=1-s, v=0, w=s)
+      Q = Barycentric {T(1) - s, T(0), s};
+      break;
+    case 2:  // (u=0, v=s, w=1-s)
+      Q = Barycentric {T(0), s, T(1) - s};
+      break;
+    default:
+      break;
+    }
+
+    const int n = m_ord;
+    std::vector<axom::Array<PointType>> net(static_cast<std::size_t>(n + 1));
+    net[0] = m_controlPoints;
+
+    for(int p = 1; p <= n; ++p)
+    {
+      const int deg = n - p + 1;
+      const int newDeg = deg - 1;
+
+      net[p].resize(triSize(newDeg));
+      const auto& prev = net[p - 1];
+
+      for(int ii = 0; ii <= newDeg; ++ii)
+      {
+        for(int jj = 0; jj <= newDeg - ii; ++jj)
+        {
+          const auto& A0 = prev[triIndex(deg, ii, jj)];
+          const auto& B0 = prev[triIndex(deg, ii, jj + 1)];
+          const auto& C0 = prev[triIndex(deg, ii + 1, jj)];
+
+          PointType val;
+          for(int N = 0; N < NDIMS; ++N)
+          {
+            // Barycentric coordinates permuted to match convention in evaluate
+            val[N] = Q[2] * A0[N] + Q[1] * B0[N] + Q[0] * C0[N];
+          }
+          net[p][triIndex(newDeg, ii, jj)] = val;
+        }
+      }
+    }
+
+    auto fill_from_net = [&](int keptEdge, BezierTriangle& out) {
+      out.setOrder(n);
+      out.getWeights().resize(0);
+      for(int i = 0; i <= n; ++i)
+      {
+        const int deg = n - i;
+        for(int j = 0; j <= n - i; ++j)
+        {
+          switch(keptEdge)
+          {
+          case 0:
+            // Keeps original BC line: (j,deg-j)
+            out(i, j) = net[i][triIndex(deg, j, deg - j)];
+            break;
+          case 1:
+            // Keeps original CA line: (deg-j,0)
+            out(i, j) = net[i][triIndex(deg, deg - j, 0)];
+            break;
+          case 2:
+            // Keeps original AB line: (0,j)
+            out(i, j) = net[i][triIndex(deg, 0, j)];
+            break;
+          default:
+            break;
+          }
+        }
+      }
+    };
+
+    switch(edgeIdx)
+    {
+    case 0:
+      // Q on BC -> keep AB and CA
+      fill_from_net(2, t0);  // (A,B,Q)
+      fill_from_net(1, t1);  // (C,A,Q)
+      break;
+    case 1:
+      // Q on CA -> keep BC and AB
+      fill_from_net(0, t0);  // (B,C,Q)
+      fill_from_net(2, t1);  // (A,B,Q)
+      break;
+    case 2:
+      // Q on AB -> keep CA and BC
+      fill_from_net(1, t0);  // (C,A,Q)
+      fill_from_net(0, t1);  // (B,C,Q)
+      break;
+    default:
+      break;
+    }
+  }
+
+  /*!
+   * \brief Splits a polynomial Bezier triangle into four subtriangles by inserting one
+   * split point on each boundary edge and connecting the split points pairwise
+   *
+   * \param [in] s1 Parameter in \a [0,1] locating the split point on edge 0 (same convention as `getEdge(0)`)
+   * \param [in] s2 Parameter in \a [0,1] locating the split point on edge 1 (same convention as `getEdge(1)`)
+   * \param [in] s3 Parameter in \a [0,1] locating the split point on edge 2 (same convention as `getEdge(2)`)
+   * \param [out] t1 Subtriangle near vertex `(0,0)` with vertices `(0,0)`, point on edge 2, point on edge 1
+   * \param [out] t2 Subtriangle near vertex `(0,1)` with vertices `(0,1)`, point on edge 0, point on edge 2
+   * \param [out] t3 Subtriangle near vertex `(1,0)` with vertices `(1,0)`, point on edge 1, point on edge 0
+   * \param [out] t4 Central subtriangle with vertices point on edge 1, point on edge 0, point on edge 2
+   *
+   * \pre \a s1, \a s2, \a s3 are all in (0,1)
+   *           C
+   *           /\     
+   *          /t3\ 
+   *      P1 /____\ P0 
+   *        /\ t4 /\  
+   *       /t1\  /t2\ 
+   *      /____\/____\
+   *     A     P2      B    
+   * 
+   * \return t1 = Tri( A, P2, P1 ), t2 = Tri( B, P0, P2 ), t3 = Tri( C, P1, P0 ), t4 = Tri( P1, P0, P2 )
+   */
+  void split(T s1,
+             T s2,
+             T s3,
+             BezierTriangle& t1,
+             BezierTriangle& t2,
+             BezierTriangle& t3,
+             BezierTriangle& t4) const
+  {
+    using Barycentric = Point<T, 3>;
+    SLIC_ASSERT(m_ord >= 0);
+    SLIC_ASSERT(!isRational());
+    SLIC_ASSERT(s1 > T(0) && s1 < T(1));
+    SLIC_ASSERT(s2 > T(0) && s2 < T(1));
+    SLIC_ASSERT(s3 > T(0) && s3 < T(1));
+
+    // Barycentric coordinates in (u, v, w) where w = 1-u-v
+    // and the triangle vertices are: A=(0,0,1), B=(0,1,0), C=(1,0,0)
+    const Barycentric A {T(0), T(0), T(1)};
+    const Barycentric B {T(0), T(1), T(0)};
+    const Barycentric C {T(1), T(0), T(0)};
+
+    // Edge points (u, v, w = 1-u-v) following the same orientation as getEdge(0..2)
+    // edge0: B->C  (w == 0)
+    // edge1: C->A  (v == 0)
+    // edge2: A->B  (u == 0)
+    const Barycentric P0 {s1, T(1) - s1, T(0)};
+    const Barycentric P1 {T(1) - s2, T(0), s2};
+    const Barycentric P2 {T(0), s3, T(1) - s3};
+
+    // Corner triangles (ordered to match the diagram and preserve interior-edge orientation)
+    restrictToSubtriangle(A, P2, P1, t1);
+    restrictToSubtriangle(B, P0, P2, t2);
+    restrictToSubtriangle(C, P1, P0, t3);
+    restrictToSubtriangle(P1, P0, P2, t4);
+  }
+
+  /*!
+   * \brief Uniform 4-way "triforce" split at edge midpoints
+   *
+   * This is a convenience wrapper for `split(0.5, 0.5, 0.5, ...)`. A future optimized
+   * implementation can exploit the symmetry at \a s=0.5 to share intermediate nets.
+   *
+   * \param [out] t1 Subtriangle near vertex `(0,0)`
+   * \param [out] t2 Subtriangle near vertex `(0,1)`
+   * \param [out] t3 Subtriangle near vertex `(1,0)`
+   * \param [out] t4 Central subtriangle
+   *
+   * \pre getOrder() >= 0
+   * \pre This triangle is polynomial (nonrational)
+   */
+  void uniformSplit(BezierTriangle& t1,
+                    BezierTriangle& t2,
+                    BezierTriangle& t3,
+                    BezierTriangle& t4) const
+  {
+    SLIC_ASSERT(m_ord >= 0);
+    SLIC_ASSERT(!isRational());
+
+    // Optimized uniform subdivision at the edge midpoints (s=0.5) following:
+    // Kenneth I. Joy, "A Uniform Subdivision Method for Triangular Bezier Patches".
+    //
+    // The method constructs a degenerate "Bezier tetrahedron" of intermediate points via
+    // repeated midpoint averaging in the control net, then extracts the four subpatch
+    // control nets from its four faces (three corner triangles + one central triangle).
+    //
+    // Notation: the paper indexes control points as P_{i,j,k} with i+j+k = n and defines
+    // intermediate points P_{i,j,k}^{[n1,n2,n3]} via:
+    //   if n1>0: 1/2( P^{[n1-1,n2,n3]}_{i,j,k} + P^{[n1-1,n2,n3]}_{i-1,j+1,k} )
+    //   if n2>0: 1/2( P^{[n1,n2-1,n3]}_{i,j,k} + P^{[n1,n2-1,n3]}_{i,j-1,k+1} )
+    //   if n3>0: 1/2( P^{[n1,n2,n3-1]}_{i,j,k} + P^{[n1,n2,n3-1]}_{i+1,j,k-1} )
+    //   else:    P_{i,j,k}
+    //
+    // The four output meshes are then:
+    //   Q1 = { P^{[m,0,k]}_{i,0,k} : i+k=n, m=0..i }          (near paper vertex P1)
+    //   Q2 = { P^{[i,m,0]}_{i,j,0} : i+j=n, m=0..j }          (near paper vertex P2)
+    //   Q3 = { P^{[0,j,m]}_{0,j,k} : j+k=n, m=0..k }          (near paper vertex P3)
+    //   Q4 = { P^{[i,j,k]}_{i,j,k} : i+j+k=n }                (central)
+    //
+    // Under this class' (u,v,w) convention, paper (P1,P2,P3) corresponds to (C,B,A),
+    // so Q3->t1 (near A), Q2->t2 (near B), Q1->t3 (near C), Q4->t4 (central).
+
+    const int n = m_ord;
+
+    t1.setOrder(n);
+    t2.setOrder(n);
+    t3.setOrder(n);
+    t4.setOrder(n);
+    t1.getWeights().resize(0);
+    t2.getWeights().resize(0);
+    t3.getWeights().resize(0);
+    t4.getWeights().resize(0);
+
+    // Memoize intermediate values. For a fixed order, all indices are in [0,n], so we can
+    // use a mixed-radix packing with base (n+1) (safe for typical Bezier orders).
+    const std::uint64_t base = static_cast<std::uint64_t>(n + 1);
+    auto make_key = [&](int i, int j, int k, int n1, int n2, int n3) -> std::uint64_t {
+      std::uint64_t key = static_cast<std::uint64_t>(i);
+      key = key * base + static_cast<std::uint64_t>(j);
+      key = key * base + static_cast<std::uint64_t>(k);
+      key = key * base + static_cast<std::uint64_t>(n1);
+      key = key * base + static_cast<std::uint64_t>(n2);
+      key = key * base + static_cast<std::uint64_t>(n3);
+      return key;
+    };
+
+    std::unordered_map<std::uint64_t, PointType> memo;
+    memo.reserve(static_cast<std::size_t>((n + 1) * (n + 1) * (n + 1)));
+
+    // Recursive evaluation of P^{[n1,n2,n3]}_{i,j,k}.
+    std::function<PointType(int, int, int, int, int, int)> eval =
+      [&](int i, int j, int k, int n1, int n2, int n3) -> PointType {
+      SLIC_ASSERT(i >= 0 && j >= 0 && k >= 0);
+      SLIC_ASSERT(i + j + k == n);
+      SLIC_ASSERT(n1 >= 0 && n2 >= 0 && n3 >= 0);
+      SLIC_ASSERT(n1 <= n && n2 <= n && n3 <= n);
+
+      const auto key = make_key(i, j, k, n1, n2, n3);
+      auto it = memo.find(key);
+      if(it != memo.end())
+      {
+        return it->second;
+      }
+
+      PointType out;
+      if(n1 > 0)
+      {
+        SLIC_ASSERT(i > 0);
+        const auto a = eval(i, j, k, n1 - 1, n2, n3);
+        const auto b = eval(i - 1, j + 1, k, n1 - 1, n2, n3);
+        for(int d = 0; d < NDIMS; ++d)
+        {
+          out[d] = T(0.5) * (a[d] + b[d]);
+        }
+      }
+      else if(n2 > 0)
+      {
+        SLIC_ASSERT(j > 0);
+        const auto a = eval(i, j, k, n1, n2 - 1, n3);
+        const auto b = eval(i, j - 1, k + 1, n1, n2 - 1, n3);
+        for(int d = 0; d < NDIMS; ++d)
+        {
+          out[d] = T(0.5) * (a[d] + b[d]);
+        }
+      }
+      else if(n3 > 0)
+      {
+        SLIC_ASSERT(k > 0);
+        const auto a = eval(i, j, k, n1, n2, n3 - 1);
+        const auto b = eval(i + 1, j, k - 1, n1, n2, n3 - 1);
+        for(int d = 0; d < NDIMS; ++d)
+        {
+          out[d] = T(0.5) * (a[d] + b[d]);
+        }
+      }
+      else
+      {
+        // Base: original control point P_{i,j,k} (k implied by n-i-j).
+        SLIC_ASSERT(k == n - i - j);
+        out = (*this)(i, j);
+      }
+
+      memo.emplace(key, out);
+      return out;
+    };
+
+    // Q3 -> t1 : t1(i_local=j, j_local=m) = P^{[0,j,m]}_{0,j,k}, with k = n-j.
+    for(int i_local = 0; i_local <= n; ++i_local)
+    {
+      const int j = i_local;
+      const int k = n - j;
+      for(int j_local = 0; j_local <= n - i_local; ++j_local)
+      {
+        const int m = j_local;
+        t1(i_local, j_local) = eval(0, j, k, 0, j, m);
+      }
+    }
+
+    // Q2 -> t2 : t2(i_local=i, j_local=m) = P^{[i,m,0]}_{i,j,0}, with j = n-i.
+    for(int i_local = 0; i_local <= n; ++i_local)
+    {
+      const int i = i_local;
+      const int j = n - i;
+      for(int j_local = 0; j_local <= n - i_local; ++j_local)
+      {
+        const int m = j_local;
+        t2(i_local, j_local) = eval(i, j, 0, i, m, 0);
+      }
+    }
+
+    // Q1 -> t3 : t3(i_local=k, j_local=m) = P^{[m,0,k]}_{i,0,k}, with i = n-k.
+    for(int i_local = 0; i_local <= n; ++i_local)
+    {
+      const int k = i_local;
+      const int i = n - k;
+      for(int j_local = 0; j_local <= n - i_local; ++j_local)
+      {
+        const int m = j_local;
+        t3(i_local, j_local) = eval(i, 0, k, m, 0, k);
+      }
+    }
+
+    // Q4 -> t4 : t4(i,j) = P^{[i,j,k]}_{i,j,k}, k = n-i-j.
+    for(int i = 0; i <= n; ++i)
+    {
+      for(int j = 0; j <= n - i; ++j)
+      {
+        const int k = n - i - j;
+        t4(i, j) = eval(i, j, k, i, j, k);
+      }
+    }
+  }
+
+  /*!
    * \brief Access a control point in the triangular control net
    *
    * \param [in] i The first index (0 <= i <= getOrder())
@@ -316,6 +1017,7 @@ public:
     return m_controlPoints[triIndex(m_ord, i, j)];
   }
 
+  /// \brief Access a control point in the triangular control net
   const PointType& operator()(int i, int j) const
   {
     SLIC_ASSERT(i >= 0);
@@ -330,13 +1032,9 @@ public:
    * \param [in] u Parameter value along the \a u axis
    * \param [in] v Parameter value along the \a v axis
    *
-   * \pre getOrder() >= 0
    * \pre u >= 0, v >= 0, and u+v <= 1
-   *
+   * 
    * \return Point value S(u,v)
-   *
-   * \note In the rational case, evaluation is performed in projective space and divided
-   * by the evaluated weight.
    */
   PointType evaluate(T u, T v) const
   {
@@ -408,7 +1106,6 @@ public:
    * \param [out] Du First derivative S_u(u,v)
    * \param [out] Dv First derivative S_v(u,v)
    *
-   * \pre getOrder() >= 0
    * \pre u >= 0, v >= 0, and u+v <= 1
    */
   void evaluateFirstDerivatives(T u,
@@ -735,9 +1432,7 @@ public:
     }
   }
 
-  /*!
-   * \brief Computes a tangent of a Bezier triangle at (\a u, \a v) along the u axis
-   */
+  /// \brief Computes a tangent of a Bezier triangle at (\a u, \a v) along the u axis
   VectorType du(T u, T v) const
   {
     PointType eval;
@@ -746,9 +1441,7 @@ public:
     return Du;
   }
 
-  /*!
-   * \brief Computes a tangent of a Bezier triangle at (\a u, \a v) along the v axis
-   */
+  /// \brief Computes a tangent of a Bezier triangle at (\a u, \a v) along the v axis
   VectorType dv(T u, T v) const
   {
     PointType eval;
@@ -757,9 +1450,7 @@ public:
     return Dv;
   }
 
-  /*!
-   * \brief Computes the second derivative of a Bezier triangle at (\a u, \a v) along the u axis
-   */
+  /// \brief Computes the second derivative of a Bezier triangle at (\a u, \a v) along the u axis
   VectorType dudu(T u, T v) const
   {
     PointType eval;
@@ -768,9 +1459,7 @@ public:
     return DuDu;
   }
 
-  /*!
-   * \brief Computes the second derivative of a Bezier triangle at (\a u, \a v) along the v axis
-   */
+  /// \brief Computes the second derivative of a Bezier triangle at (\a u, \a v) along the v axis
   VectorType dvdv(T u, T v) const
   {
     PointType eval;
@@ -779,9 +1468,7 @@ public:
     return DvDv;
   }
 
-  /*!
-   * \brief Computes the mixed second derivative of a Bezier triangle at (\a u, \a v)
-   */
+  /// \brief Computes the mixed second derivative of a Bezier triangle at (\a u, \a v)
   VectorType dudv(T u, T v) const
   {
     PointType eval;
@@ -790,7 +1477,7 @@ public:
     return DuDv;
   }
 
-  /// Convenience alias for S_vu(u,v), which equals S_uv(u,v) for polynomial triangles
+  /// \brief Convenience alias for S_vu(u,v), which equals S_uv(u,v) for polynomial triangles
   VectorType dvdu(T u, T v) const { return dudv(u, v); }
 
   /*!
@@ -866,8 +1553,7 @@ public:
   }
 
 private:
-  /// Check that the weights used are positive, and
-  ///  that there is one for each control node
+  /// \brief Check that each weight is positive and the size matches control nodes
   bool is_valid_rational() const
   {
     if(!isRational())
@@ -891,6 +1577,7 @@ private:
     return true;
   }
 
+  /// \brief For a rational triangle, fill triangle objects with weighted control points and weights
   void fill_projective_triangles(BezierTriangle<T, NDIMS>& projective,
                                  BezierTriangle<T, 1>& weights) const
   {

--- a/src/axom/primal/geometry/BezierTriangle.hpp
+++ b/src/axom/primal/geometry/BezierTriangle.hpp
@@ -18,14 +18,9 @@
 
 #include "axom/primal/geometry/Point.hpp"
 #include "axom/primal/geometry/Vector.hpp"
-#include "axom/primal/geometry/Segment.hpp"
 #include "axom/primal/geometry/BezierCurve.hpp"
 #include "axom/primal/geometry/BoundingBox.hpp"
 #include "axom/primal/geometry/OrientedBoundingBox.hpp"
-
-#include "axom/primal/operators/squared_distance.hpp"
-
-#include <vector>
 #include <ostream>
 
 namespace axom
@@ -47,7 +42,7 @@ std::ostream& operator<<(std::ostream& os, const BezierTriangle<T, NDIMS>& bTri)
  * \tparam T the coordinate type, e.g., double, float, etc.
  *
  * A Bezier triangle of order \a N has \f$ (N+1)(N+2)/2 \f$ control points.
- * It is parametrized over the domain \f$ u \ge 0, v \ge 0, u+v \le 1 \f$.
+ * It is parametrized over the domain \f$ u0 \ge 0, v0 \ge 0, u0+v0 \le 1 \f$.
  *
  * Control points are indexed using integer coordinates \f$ (i,j) \f$ with
  * \f$ 0 \le i \le N \f$ and \f$ 0 \le j \le N-i \f$ and accessed via `operator()(i,j)`.
@@ -57,11 +52,12 @@ std::ostream& operator<<(std::ostream& os, const BezierTriangle<T, NDIMS>& bTri)
  * Rational triangles are represented by an additional set of positive weights.
  * Polynomial (nonrational) Bezier triangles are identified by an empty weights array.
  *
- * \note This triangle uses permuted barycentric coordinates for evaluation such that, when
+ * \note This triangle uses permuted barycentric coordinates (u0, v0) for evaluation such that, when
  * `getOrder()==1`, the parameter values correspond to the triangle vertices:
  * - `evaluate(0,0) == (*this)(0,0)`
  * - `evaluate(0,1) == (*this)(0,1)`
  * - `evaluate(1,0) == (*this)(1,0)`
+ * These are mapped to standard Barycentric coordinates through (u0, v0) = {1 - u0 - v0, v0, u0}
  */
 template <typename T, int NDIMS>
 class BezierTriangle
@@ -251,6 +247,43 @@ public:
   const WeightsVec& getWeights() const { return m_weights; }
 
   /*!
+   * \brief Get a specific weight from a rational Bezier triangle
+   *
+   * \param [in] i First control net index
+   * \param [in] j Second control net index
+   * \pre Requires that the triangle be rational
+   */
+  const T& getWeight(int i, int j) const
+  {
+    SLIC_ASSERT(isRational());
+    SLIC_ASSERT(m_weights.size() == m_controlPoints.size());
+    SLIC_ASSERT(i >= 0);
+    SLIC_ASSERT(j >= 0);
+    SLIC_ASSERT(i + j <= m_ord);
+    return m_weights[triIndex(m_ord, i, j)];
+  }
+
+  /*!
+   * \brief Set the weight at a specific index for a rational Bezier triangle
+   *
+   * \param [in] i First control net index
+   * \param [in] j Second control net index
+   * \param [in] weight The updated value of the weight
+   * \pre Requires that the triangle be rational
+   * \pre Requires that the weight be positive
+   */
+  void setWeight(int i, int j, T weight)
+  {
+    SLIC_ASSERT(isRational());
+    SLIC_ASSERT(m_weights.size() == m_controlPoints.size());
+    SLIC_ASSERT(weight > T(0));
+    SLIC_ASSERT(i >= 0);
+    SLIC_ASSERT(j >= 0);
+    SLIC_ASSERT(i + j <= m_ord);
+    m_weights[triIndex(m_ord, i, j)] = weight;
+  }
+
+  /*!
    * \brief Returns an axis-aligned bounding box containing the Bezier triangle
    *
    * \note The returned box is computed from the control points.
@@ -273,8 +306,8 @@ public:
   /*!
    * \brief Sets the order of the Bezier triangle and resizes internal storage
    *
-   * \param [in] ord The polynomial order 
-   * 
+   * \param [in] ord The polynomial order
+   *
    * \pre ord must be greater than or equal to -1
    *
    * \note This function only resizes the control point and weight arrays and does not
@@ -303,6 +336,32 @@ public:
   int getOrder() const { return m_ord; }
 
   /*!
+   * \brief Return one vertex from the Bezier triangle
+   *
+   * \param [in] vertIdx Index of the requested vertex
+   *
+   * The vertices are returned in counter-clockwise order with respect to
+   * the first control point (*this)(0, 0) == evaluate(0, 0)
+   *
+   * \return The PointType object at the vertex
+   */
+  PointType getVertex(int vertIdx) const
+  {
+    SLIC_ASSERT(m_ord >= 0);
+    SLIC_ASSERT(vertIdx >= 0 && vertIdx < 3);
+
+    switch(vertIdx)
+    {
+    case 0:
+      return (*this)(0, 0);
+    case 1:
+      return (*this)(0, m_ord);
+    default:
+      return (*this)(m_ord, 0);
+    }
+  }
+
+  /*!
    * \brief Returns one of the boundary edges of the Bezier triangle
    *
    * \param [in] edgeIdx Index of the requested edge in \a [0,2]
@@ -313,9 +372,6 @@ public:
    * - \a edgeIdx = 1: u = 0 from `evaluate(0,1)` to `evaluate(0,0)`
    * - \a edgeIdx = 2: v = 0 from `evaluate(0,0)` to `evaluate(1,0)`
    *
-   * For rational triangles, the returned curve is rational and uses the subset of
-   * weights corresponding to the boundary control points.
-   * 
    * \return A Bezier curve representing the requested edge.
    */
   BezierCurveType getEdge(int edgeIdx) const
@@ -389,34 +445,7 @@ public:
   }
 
   /*!
-   * \brief Restricts this polynomial Bezier triangle to a subtriangle of the parameter domain
-   *
-   * The subtriangle is defined by three barycentric coordinates \a (u,v,w) (with \a w = 1-u-v)
-   * in the parameter domain of this triangle.
-   *
-   * The returned triangle is parametrized over the reference domain and maps its vertices as:
-   * - local `(0,0)` -> \a Va
-   * - local `(0,1)` -> \a Vb
-   * - local `(1,0)` -> \a Vc
-   *
-   * \param [in] Va Barycentric coordinates of the first subtriangle vertex `(u,v,w)`
-   * \param [in] Vb Barycentric coordinates of the second subtriangle vertex `(u,v,w)`
-   * \param [in] Vc Barycentric coordinates of the third subtriangle vertex `(u,v,w)`
-   *
-   * \pre getOrder() >= 0
-   * \pre This triangle is polynomial (nonrational)
-   */
-  BezierTriangle restrictToSubtriangle(const Point<T, 3>& Va,
-                                       const Point<T, 3>& Vb,
-                                       const Point<T, 3>& Vc) const
-  {
-    BezierTriangle out;
-    restrictToSubtriangle(Va, Vb, Vc, out);
-    return out;
-  }
-
-  /*!
-   * \brief Restricts this polynomial Bezier triangle to a subtriangle of the parameter domain
+   * \brief Restricts this Bezier triangle to a subtriangle of the parameter domain
    *
    * See overload returning a `BezierTriangle` for the vertex mapping convention.
    *
@@ -426,98 +455,118 @@ public:
    * \param [out] out Output restricted Bezier triangle
    *
    * \pre getOrder() >= 0
-   * \pre This triangle is polynomial (nonrational)
+   *
+   * \note The barycentric inputs \a Va, \a Vb, \a Vc are \a (u,v,w) triplets in the same
+   *       parameter-coordinate convention used internally by `evaluate(u,v)` (with \a w = 1-u-v).
    */
   void restrictToSubtriangle(const Point<T, 3>& Va,
                              const Point<T, 3>& Vb,
                              const Point<T, 3>& Vc,
                              BezierTriangle& out) const
   {
+    using TriangularArray = axom::Array<PointType>;
     using Barycentric = Point<T, 3>;
+
     SLIC_ASSERT(m_ord >= 0);
-    SLIC_ASSERT(!isRational());
+    if(isRational())
+    {
+      // Rational case: restrict in projective space, then convert back.
+      BezierTriangle<T, NDIMS> projective(m_ord);
+      BezierTriangle<T, 1> weights(m_ord);
+      fill_projective_triangles(projective, weights);
+
+      BezierTriangle<T, NDIMS> proj_out(m_ord);
+      BezierTriangle<T, 1> w_out(m_ord);
+
+      projective.restrictToSubtriangle(Va, Vb, Vc, proj_out);
+      weights.restrictToSubtriangle(Va, Vb, Vc, w_out);
+
+      set_from_projective_triangles(proj_out, w_out, out);
+      return;
+    }
 
     const int n = m_ord;
 
-    auto reduce_once = [&](const axom::Array<PointType>& prev, int deg, const Barycentric& Q) {
-      const int newDeg = deg - 1;
-      axom::Array<PointType> next;
-      next.resize(triSize(newDeg));
+    // Given a degree `deg` control net in `prev`, perform one reduction step so that
+    // `next` becomes the degree `deg-1` control net at barycentric point `Q`.
+    auto reduce_once =
+      [&](const TriangularArray& prev, TriangularArray& next, int deg, const Barycentric& Q) {
+        const int newDeg = deg - 1;
 
-      for(int ii = 0; ii <= newDeg; ++ii)
-      {
-        for(int jj = 0; jj <= newDeg - ii; ++jj)
+        for(int ii = 0; ii <= newDeg; ++ii)
         {
-          const auto& A0 = prev[triIndex(deg, ii, jj)];
-          const auto& B0 = prev[triIndex(deg, ii, jj + 1)];
-          const auto& C0 = prev[triIndex(deg, ii + 1, jj)];
-
-          PointType val;
-          for(int N = 0; N < NDIMS; ++N)
+          for(int jj = 0; jj <= newDeg - ii; ++jj)
           {
-            // Barycentric coordinates permuted to match convention in evaluate()
-            val[N] = Q[2] * A0[N] + Q[1] * B0[N] + Q[0] * C0[N];
+            const auto& A0 = prev[triIndex(deg, ii, jj)];
+            const auto& B0 = prev[triIndex(deg, ii, jj + 1)];
+            const auto& C0 = prev[triIndex(deg, ii + 1, jj)];
+
+            PointType val;
+            for(int N = 0; N < NDIMS; ++N)
+            {
+              // Barycentric coordinates permuted to match convention in evaluate()
+              val[N] = Q[2] * A0[N] + Q[1] * B0[N] + Q[0] * C0[N];
+            }
+            next[triIndex(newDeg, ii, jj)] = val;
           }
-          next[triIndex(newDeg, ii, jj)] = val;
         }
-      }
+      };
 
-      return next;
-    };
-
-    // Tetrahedral family of intermediate nets, indexed by the counts of (Vc, Vb, Va)
-    // fixed in the blossom. For p fixed arguments, there are triSize(p) nets, each of
-    // degree (n-p). At p==n, each net is degree 0 and corresponds to a restricted
-    // control point b(Vc^i, Vb^j, Va^(n-i-j)).
-    std::vector<axom::Array<PointType>> prevNets(1);
+    // The restricted control net over (Va,Vb,Vc) is given by blossom values:
+    //   out(i,j) = b(Vc^i, Vb^j, Va^(n-i-j))  for 0<=i<=n and 0<=j<=n-i
+    //
+    // At layer p, we maintain all intermediate nets with exactly p fixed arguments,
+    //  i.e. b(Vc^i0, Vb^j0, Vc^k0) with i0 + j0 + k0 = p, and use them to compute nets
+    //  for blossom values with one more fixed argument until p == n
+    axom::Array<TriangularArray> prevNets(1);
     prevNets[0] = m_controlPoints;
 
     for(int p = 1; p <= n; ++p)
     {
       const int degPrev = n - (p - 1);
-      std::vector<axom::Array<PointType>> currNets(triSize(p));
+      const int degCurr = degPrev - 1;
 
-      for(int fixedVcCount = 0; fixedVcCount <= p; ++fixedVcCount)
+      // Allocate triangular arrays for each layer-p net.
+      axom::Array<TriangularArray> currNets(triSize(p));
+      for(auto& net : currNets)
       {
-        for(int fixedVbCount = 0; fixedVbCount <= p - fixedVcCount; ++fixedVbCount)
+        net.resize(triSize(degCurr));
+      }
+
+      // Iterate over count triples with i0 + j0 + k0 == p.
+      for(int i0 = 0; i0 <= p; ++i0)
+      {
+        for(int j0 = 0; j0 <= p - i0; ++j0)
         {
-          const int fixedVaCount = p - fixedVcCount - fixedVbCount;
-          const int idx = triIndex(p, fixedVcCount, fixedVbCount);
+          const int k0 = p - i0 - j0;
+          const int idx = triIndex(p, i0, j0);
 
-          // Each net in this "tetrahedral" construction corresponds to a blossom value
-          // b(Vc^fixedVcCount, Vb^fixedVbCount, Va^fixedVaCount) at degree (n-p).
-          //
-          // There are multiple equivalent ways to compute each blossom value (blossom is
-          // symmetric in its arguments). We pick one deterministic predecessor to keep
-          // the recurrence simple and compute each net exactly once.
-          //
-          // Convention: consume Va arguments first, then Vb, then Vc.
-          int predIdx = -1;
-          const Barycentric& splitPoint =
-            (fixedVaCount > 0) ? Va : (fixedVbCount > 0) ? Vb : Vc;
-
-          if(fixedVaCount > 0)
+          // Increase Va, then Vb, then Vc.
+          // The order is arbitrary, since the blossom is symmetric.
+          if(k0 > 0)
           {
-            predIdx = triIndex(p - 1, fixedVcCount, fixedVbCount);
+            const int predIdx = triIndex(p - 1, i0, j0);
+            reduce_once(prevNets[predIdx], currNets[idx], degPrev, Va);
           }
-          else if(fixedVbCount > 0)
+          else if(j0 > 0)
           {
-            predIdx = triIndex(p - 1, fixedVcCount, fixedVbCount - 1);
+            const int predIdx = triIndex(p - 1, i0, j0 - 1);
+            reduce_once(prevNets[predIdx], currNets[idx], degPrev, Vb);
           }
           else
           {
-            SLIC_ASSERT(fixedVcCount > 0);
-            predIdx = triIndex(p - 1, fixedVcCount - 1, fixedVbCount);
+            SLIC_ASSERT(i0 > 0);
+            const int predIdx = triIndex(p - 1, i0 - 1, j0);
+            reduce_once(prevNets[predIdx], currNets[idx], degPrev, Vc);
           }
-
-          SLIC_ASSERT(predIdx >= 0);
-          currNets[idx] = reduce_once(prevNets[predIdx], degPrev, splitPoint);
         }
       }
 
+      // Discard the previous nets, since layer p determines layer p+1
       prevNets.swap(currNets);
     }
 
+    // Each net in the last layer (p==n) has degree 0 and contains a single control point.
     out.setOrder(n);
     out.getWeights().resize(0);
     for(int i = 0; i <= n; ++i)
@@ -530,11 +579,11 @@ public:
   }
 
   /*!
-   * \brief Splits a polynomial Bezier triangle into three subtriangles by connecting an
+   * \brief Splits a Bezier triangle into three subtriangles by connecting an
    * interior parameter point \a (u,v) to the triangle's three vertices
    *
-   * \param [in] u Parameter value along the \a u axis for the split point
-   * \param [in] v Parameter value along the \a v axis for the split point
+   * \param [in] u0 Parameter value along the \a u axis for the split point
+   * \param [in] v0 Parameter value along the \a v axis for the split point
    * \param [out] t0 Subtriangle over the parameter triangle with vertices
    *  `(0,1)`, `(1,0)`, and `(u,v)` (preserves edge 0)
    * \param [out] t1 Subtriangle over the parameter triangle with vertices
@@ -542,33 +591,50 @@ public:
    * \param [out] t2 Subtriangle over the parameter triangle with vertices
    *  `(0,0)`, `(0,1)`, and `(u,v)` (preserves edge 2)
    *
-   * \pre \a u > 0, \a v > 0, and \a u + \a v < 1
-   * 
+   * \pre \a u0 > 0, \a v0 > 0, and \a u0 + \a v0 < 1
+   *
    *            A
    *           /|\
-   *          / | \ 
-   *         /t2|t1\ 
+   *          / | \
+   *         /t2|t1\
    *        /  /Q\  \
-   *       / /  t0 \ \ 
+   *       / /  t0 \ \
    *      //_________\\
-   *     B             C   
-   * 
+   *     B             C
+   *
    * \return t0 = Tri(B,C,Q), t1 = Tri(C,A,Q), t2 = Tri(A,B,Q)
    */
-  void split(T u, T v, BezierTriangle& t0, BezierTriangle& t1, BezierTriangle& t2) const
+  void split(T u0, T v0, BezierTriangle& t0, BezierTriangle& t1, BezierTriangle& t2) const
   {
     SLIC_ASSERT(m_ord >= 0);
-    SLIC_ASSERT(!isRational());
-    SLIC_ASSERT(u > T(0));
-    SLIC_ASSERT(v > T(0));
-    SLIC_ASSERT(u + v < T(1));
+    SLIC_ASSERT(u0 > T(0));
+    SLIC_ASSERT(v0 > T(0));
+    SLIC_ASSERT(u0 + v0 < T(1));
+
+    if(isRational())
+    {
+      // Rational case: split in projective space and for weights, then convert back.
+      BezierTriangle<T, NDIMS> projective(m_ord);
+      BezierTriangle<T, 1> weights(m_ord);
+      fill_projective_triangles(projective, weights);
+
+      BezierTriangle<T, NDIMS> p0, p1, p2;
+      BezierTriangle<T, 1> w0, w1, w2;
+      projective.split(u0, v0, p0, p1, p2);
+      weights.split(u0, v0, w0, w1, w2);
+
+      set_from_projective_triangles(p0, w0, t0);
+      set_from_projective_triangles(p1, w1, t1);
+      set_from_projective_triangles(p2, w2, t2);
+      return;
+    }
 
     // Q is the split point in barycentric coordinates over the reference parameter triangle:
     using Barycentric = Point<T, 3>;
-    const Barycentric Q {u, v, T(1) - u - v};
+    const Barycentric Q {u0, v0, T(1) - u0 - v0};
 
     const int n = m_ord;
-    std::vector<axom::Array<PointType>> net(static_cast<std::size_t>(n + 1));
+    axom::Array<axom::Array<PointType>> net(n + 1);
     net[0] = m_controlPoints;
 
     for(int p = 1; p <= n; ++p)
@@ -604,7 +670,7 @@ public:
     t1.getWeights().resize(0);
     t2.getWeights().resize(0);
 
-    // Subtriangle (B,C,Q): (0,1), (1,0), (u,v)
+    // Subtriangle (B,C,Q): (0,1), (1,0), (u0,v0)
     for(int i = 0; i <= n; ++i)
     {
       const int deg = n - i;
@@ -614,7 +680,7 @@ public:
       }
     }
 
-    // Subtriangle (C,A,Q): (1,0), (0,0), (u,v)
+    // Subtriangle (C,A,Q): (1,0), (0,0), (u0,v0)
     for(int i = 0; i <= n; ++i)
     {
       const int deg = n - i;
@@ -624,7 +690,7 @@ public:
       }
     }
 
-    // Subtriangle (A,B,Q): (0,0), (0,1), (u,v)
+    // Subtriangle (A,B,Q): (0,0), (0,1), (u0,v0)
     for(int i = 0; i <= n; ++i)
     {
       const int deg = n - i;
@@ -636,11 +702,11 @@ public:
   }
 
   /*!
-   * \brief Splits a polynomial Bezier triangle into two subtriangles by connecting a
+   * \brief Splits a Bezier triangle into two subtriangles by connecting a
    * point on a boundary edge to the opposite vertex
    *
    * \param [in] edgeIdx Index of the boundary edge to split (same convention as `getEdge(int)`)
-   * \param [in] s Parameter in \a [0,1] locating the split point along the chosen edge
+   * \param [in] s Parameter in \a (0,1) locating the split point along the chosen edge
    * \param [out] t0 First output subtriangle
    * \param [out] t1 Second output subtriangle
    *
@@ -648,26 +714,43 @@ public:
    * \pre \a s is in (0,1)
    *
    * Taking P0 as the vertex opposite edge `edgeIdx`:
-   * 
+   *
    *            P0
    *           /|\
-   *          / | \ 
-   *         /  |  \ 
+   *          / | \
+   *         /  |  \
    *        /   |   \
-   *       / t0 | t1 \ 
+   *       / t0 | t1 \
    *      /_____|_____\
-   *   P1       Q      P2   
+   *   P1       Q      P2
    *   s=0      s      s=1
-   * 
+   *
    * \return t0 = Tri( P0, P1, Q ), t1 = Tri( P2, P0, Q )
    */
   void split(int edgeIdx, T s, BezierTriangle& t0, BezierTriangle& t1) const
   {
     SLIC_ASSERT(m_ord >= 0);
-    SLIC_ASSERT(!isRational());
     SLIC_ASSERT(edgeIdx >= 0 && edgeIdx < 3);
     SLIC_ASSERT(s > T(0) && s < T(1));
 
+    if(isRational())
+    {
+      // Rational case: split in projective space and for weights, then convert back.
+      BezierTriangle<T, NDIMS> projective(m_ord);
+      BezierTriangle<T, 1> weights(m_ord);
+      fill_projective_triangles(projective, weights);
+
+      BezierTriangle<T, NDIMS> p0, p1;
+      BezierTriangle<T, 1> w0, w1;
+      projective.split(edgeIdx, s, p0, p1);
+      weights.split(edgeIdx, s, w0, w1);
+
+      set_from_projective_triangles(p0, w0, t0);
+      set_from_projective_triangles(p1, w1, t1);
+      return;
+    }
+
+    using TriangularArray = axom::Array<PointType>;
     using Barycentric = Point<T, 3>;
 
     Barycentric Q;
@@ -687,7 +770,7 @@ public:
     }
 
     const int n = m_ord;
-    std::vector<axom::Array<PointType>> net(static_cast<std::size_t>(n + 1));
+    axom::Array<TriangularArray> net(n + 1);
     net[0] = m_controlPoints;
 
     for(int p = 1; p <= n; ++p)
@@ -769,12 +852,92 @@ public:
   }
 
   /*!
-   * \brief Splits a polynomial Bezier triangle into four subtriangles by inserting one
+   * \brief Uniform 4-way split at edge midpoints
+   *
+   * \param [out] t0 Subtriangle near vertex `(0,0)`
+   * \param [out] t1 Subtriangle near vertex `(0,1)`
+   * \param [out] t2 Subtriangle near vertex `(1,0)`
+   * \param [out] t3 Central subtriangle
+   *
+   * This is equivalent to `split(0.5, 0.5, 0.5, ...)`, but with optimizations to reduce
+   *  redundant computations by sharing intermediate control nets.
+   * We also separate the implementation based on triangle rationality to improve performance
+   *
+   *           C
+   *           /\
+   *          /t2\
+   *      P1 /____\ P0
+   *        /\ t3 /\
+   *       /t0\  /t1\
+   *      /____\/____\
+   *     A     P2      B
+   *
+   * \return t0 = Tri( A, P2, P1 ), t1 = Tri( B, P0, P2 ), t2 = Tri( C, P1, P0 ), t3 = Tri( P1, P0, P2 )
+   */
+  void uniformSplit(BezierTriangle& t0, BezierTriangle& t1, BezierTriangle& t2, BezierTriangle& t3) const
+  {
+    SLIC_ASSERT(m_ord >= 0);
+    const int n = m_ord;
+    const int triN = triSize(n);
+
+    t0.setOrder(n);
+    t1.setOrder(n);
+    t2.setOrder(n);
+    t3.setOrder(n);
+
+    if(!isRational())
+    {
+      t0.getWeights().resize(0);
+      t1.getWeights().resize(0);
+      t2.getWeights().resize(0);
+      t3.getWeights().resize(0);
+
+      // For polynomial triangles, these accessors just use the regular control points
+      auto get_point = [&](int i, int j) -> PointType { return (*this)(i, j); };
+      auto set_point = [&](BezierTriangle& out, int i, int j, const PointType& pt) {
+        out(i, j) = pt;
+      };
+      uniform_split_impl<PointType>(get_point, set_point, t0, t1, t2, t3);
+    }
+    else
+    {
+      using HomogeneousPoint = Point<T, NDIMS + 1>;
+      t0.getWeights().resize(triN);
+      t1.getWeights().resize(triN);
+      t2.getWeights().resize(triN);
+      t3.getWeights().resize(triN);
+
+      // For rational triangles, these accessors generate homogeneous control points
+      auto get_hom_point = [&](int i, int j) -> HomogeneousPoint {
+        HomogeneousPoint hp;
+        const T w = m_weights[triIndex(n, i, j)];
+        hp[NDIMS] = w;
+        for(int d = 0; d < NDIMS; ++d)
+        {
+          hp[d] = (*this)(i, j)[d] * w;
+        }
+        return hp;
+      };
+      auto set_hom_point = [&](BezierTriangle& out, int i, int j, const HomogeneousPoint& hp) {
+        const T w = hp[NDIMS];
+        SLIC_ASSERT(w > T(0));
+        out.getWeights()[triIndex(n, i, j)] = w;
+        for(int d = 0; d < NDIMS; ++d)
+        {
+          out(i, j)[d] = hp[d] / w;
+        }
+      };
+      uniform_split_impl<HomogeneousPoint>(get_hom_point, set_hom_point, t0, t1, t2, t3);
+    }
+  }
+
+  /*!
+   * \brief Splits a Bezier triangle into four subtriangles by inserting one
    * split point on each boundary edge and connecting the split points pairwise
    *
-   * \param [in] s1 Parameter in \a [0,1] locating the split point on edge 0 (same convention as `getEdge(0)`)
-   * \param [in] s2 Parameter in \a [0,1] locating the split point on edge 1 (same convention as `getEdge(1)`)
-   * \param [in] s3 Parameter in \a [0,1] locating the split point on edge 2 (same convention as `getEdge(2)`)
+   * \param [in] s1 Parameter in \a (0,1) locating the split point on edge 0 (same convention as `getEdge(0)`)
+   * \param [in] s2 Parameter in \a (0,1) locating the split point on edge 1 (same convention as `getEdge(1)`)
+   * \param [in] s3 Parameter in \a (0,1) locating the split point on edge 2 (same convention as `getEdge(2)`)
    * \param [out] t1 Subtriangle near vertex `(0,0)` with vertices `(0,0)`, point on edge 2, point on edge 1
    * \param [out] t2 Subtriangle near vertex `(0,1)` with vertices `(0,1)`, point on edge 0, point on edge 2
    * \param [out] t3 Subtriangle near vertex `(1,0)` with vertices `(1,0)`, point on edge 1, point on edge 0
@@ -782,14 +945,14 @@ public:
    *
    * \pre \a s1, \a s2, \a s3 are all in (0,1)
    *           C
-   *           /\     
-   *          /t3\ 
-   *      P1 /____\ P0 
-   *        /\ t4 /\  
-   *       /t1\  /t2\ 
+   *           /\
+   *          /t3\
+   *      P1 /____\ P0
+   *        /\ t4 /\
+   *       /t1\  /t2\
    *      /____\/____\
-   *     A     P2      B    
-   * 
+   *     A     P2      B
+   *
    * \return t1 = Tri( A, P2, P1 ), t2 = Tri( B, P0, P2 ), t3 = Tri( C, P1, P0 ), t4 = Tri( P1, P0, P2 )
    */
   void split(T s1,
@@ -802,7 +965,6 @@ public:
   {
     using Barycentric = Point<T, 3>;
     SLIC_ASSERT(m_ord >= 0);
-    SLIC_ASSERT(!isRational());
     SLIC_ASSERT(s1 > T(0) && s1 < T(1));
     SLIC_ASSERT(s2 > T(0) && s2 < T(1));
     SLIC_ASSERT(s3 > T(0) && s3 < T(1));
@@ -854,21 +1016,27 @@ public:
   }
 
   /*!
-   * \brief Evaluates the Bezier triangle at \a (u,v)
+   * \brief Evaluates the Bezier triangle at \a (u0,v0)
    *
-   * \param [in] u Parameter value along the \a u axis
-   * \param [in] v Parameter value along the \a v axis
+   * \param [in] u0 Parameter value along the \a u axis
+   * \param [in] v0 Parameter value along the \a v axis
    *
-   * \pre u >= 0, v >= 0, and u+v <= 1
-   * 
-   * \return Point value S(u,v)
+   * \pre u0 >= 0, v0 >= 0, and u0+v0 <= 1
+   *
+   * \note Evaluation uses permuted barycentric coordinates such that
+   *   parameter values (u0, v0) correspond to the triangle vertices:
+   *     - `evaluate(0,0) == (*this)(0,0)`
+   *     - `evaluate(0,1) == (*this)(0,order)`
+   *     - `evaluate(1,0) == (*this)(order,0)`
+   *
+   * \return Point value S(u0,v0)
    */
-  PointType evaluate(T u, T v) const
+  PointType evaluate(T u0, T v0) const
   {
     SLIC_ASSERT(m_ord >= 0);
-    SLIC_ASSERT(u >= T(0));
-    SLIC_ASSERT(v >= T(0));
-    SLIC_ASSERT(u + v <= T(1));
+    SLIC_ASSERT(u0 >= T(0));
+    SLIC_ASSERT(v0 >= T(0));
+    SLIC_ASSERT(u0 + v0 <= T(1));
 
     if(!isRational())
     {
@@ -895,7 +1063,7 @@ public:
               const auto& A = dCarray[triIndex(end, i, j)];
               const auto& B = dCarray[triIndex(end, i, j + 1)];
               const auto& C = dCarray[triIndex(end, i + 1, j)];
-              dCarray[triIndex(end - 1, i, j)] = A + u * (C - A) + v * (B - A);
+              dCarray[triIndex(end - 1, i, j)] = A + u0 * (C - A) + v0 * (B - A);
             }
           }
         }
@@ -912,8 +1080,8 @@ public:
       BezierTriangle<T, 1> weights(m_ord);
       fill_projective_triangles(projective, weights);
 
-      const Point<T, NDIMS> P = projective.evaluate(u, v);
-      const Point<T, 1> W = weights.evaluate(u, v);
+      const Point<T, NDIMS> P = projective.evaluate(u0, v0);
+      const Point<T, 1> W = weights.evaluate(u0, v0);
 
       PointType eval;
       for(int N = 0; N < NDIMS; ++N)
@@ -925,26 +1093,26 @@ public:
   }
 
   /*!
-   * \brief Evaluates first derivatives of the Bezier triangle at \a (u,v)
+   * \brief Evaluates first derivatives of the Bezier triangle at \a (u0,v0)
    *
-   * \param [in] u Parameter value along the \a u axis
-   * \param [in] v Parameter value along the \a v axis
+   * \param [in] u0 Parameter value along the \a u axis
+   * \param [in] v0 Parameter value along the \a v axis
    * \param [out] eval Point value S(u,v)
    * \param [out] Du First derivative S_u(u,v)
    * \param [out] Dv First derivative S_v(u,v)
    *
-   * \pre u >= 0, v >= 0, and u+v <= 1
+   * \pre u0 >= 0, v0 >= 0, and u0+v0 <= 1
    */
-  void evaluateFirstDerivatives(T u,
-                                T v,
+  void evaluateFirstDerivatives(T u0,
+                                T v0,
                                 Point<T, NDIMS>& eval,
                                 Vector<T, NDIMS>& Du,
                                 Vector<T, NDIMS>& Dv) const
   {
     SLIC_ASSERT(m_ord >= 0);
-    SLIC_ASSERT(u >= T(0));
-    SLIC_ASSERT(v >= T(0));
-    SLIC_ASSERT(u + v <= T(1));
+    SLIC_ASSERT(u0 >= T(0));
+    SLIC_ASSERT(v0 >= T(0));
+    SLIC_ASSERT(u0 + v0 <= T(1));
 
     if(m_ord == 0)
     {
@@ -980,16 +1148,16 @@ public:
               const auto& A = dCarray[triIndex(end, i, j)];
               const auto& B = dCarray[triIndex(end, i, j + 1)];
               const auto& C = dCarray[triIndex(end, i + 1, j)];
-              dCarray[triIndex(end - 1, i, j)] = A + u * (C - A) + v * (B - A);
+              dCarray[triIndex(end - 1, i, j)] = A + u0 * (C - A) + v0 * (B - A);
             }
           }
         }
 
         // The last reduction yields a linear triangle:
-        //   S(u,v) = A + u(C-A) + v(B-A)
+        //   S(u,v) = A + u0(C-A) + v0(B-A)
         Du[N] = (dCarray[2] - dCarray[0]);
         Dv[N] = (dCarray[1] - dCarray[0]);
-        eval[N] = dCarray[0] + u * Du[N] + v * Dv[N];
+        eval[N] = dCarray[0] + u0 * Du[N] + v0 * Dv[N];
 
         Du[N] *= m_ord;
         Dv[N] *= m_ord;
@@ -1007,8 +1175,8 @@ public:
       Point<T, 1> W;
       Vector<T, 1> W_u, W_v;
 
-      projective.evaluateFirstDerivatives(u, v, P, P_u, P_v);
-      weights.evaluateFirstDerivatives(u, v, W, W_u, W_v);
+      projective.evaluateFirstDerivatives(u0, v0, P, P_u, P_v);
+      weights.evaluateFirstDerivatives(u0, v0, W, W_u, W_v);
 
       for(int N = 0; N < NDIMS; ++N)
       {
@@ -1022,30 +1190,30 @@ public:
   /*!
    * \brief Evaluates all linear derivatives of a Bezier triangle at (\a u, \a v)
    *
-   * \param [in] u Parameter value at which to evaluate along the u axis
-   * \param [in] v Parameter value at which to evaluate along the v axis
+   * \param [in] u0 Parameter value at which to evaluate along the u axis
+   * \param [in] v0 Parameter value at which to evaluate along the v axis
    * \param [out] eval The point value of the Bezier triangle at (u, v)
    * \param [out] Du The vector value of S_u(u, v)
    * \param [out] Dv The vector value of S_v(u, v)
    * \param [out] DuDv The vector value of S_uv(u, v) == S_vu(u, v)
    */
-  void evaluateLinearDerivatives(T u,
-                                 T v,
+  void evaluateLinearDerivatives(T u0,
+                                 T v0,
                                  Point<T, NDIMS>& eval,
                                  Vector<T, NDIMS>& Du,
                                  Vector<T, NDIMS>& Dv,
                                  Vector<T, NDIMS>& DuDv) const
   {
     SLIC_ASSERT(m_ord >= 0);
-    SLIC_ASSERT(u >= T(0));
-    SLIC_ASSERT(v >= T(0));
-    SLIC_ASSERT(u + v <= T(1));
+    SLIC_ASSERT(u0 >= T(0));
+    SLIC_ASSERT(v0 >= T(0));
+    SLIC_ASSERT(u0 + v0 <= T(1));
 
     if(!isRational())
     {
       if(m_ord < 2)
       {
-        evaluateFirstDerivatives(u, v, eval, Du, Dv);
+        evaluateFirstDerivatives(u0, v0, eval, Du, Dv);
         for(int N = 0; N < NDIMS; ++N)
         {
           DuDv[N] = T(0);
@@ -1077,7 +1245,7 @@ public:
               const auto& A = dCarray[triIndex(end, i, j)];
               const auto& B = dCarray[triIndex(end, i, j + 1)];
               const auto& C = dCarray[triIndex(end, i + 1, j)];
-              dCarray[triIndex(end - 1, i, j)] = A + u * (C - A) + v * (B - A);
+              dCarray[triIndex(end - 1, i, j)] = A + u0 * (C - A) + v0 * (B - A);
             }
           }
         }
@@ -1091,11 +1259,11 @@ public:
         const T Q20 = dCarray[triIndex(2, 2, 0)];
 
         // One reduction yields a linear triangle (order 1)
-        const T L00 = Q00 + u * (Q10 - Q00) + v * (Q01 - Q00);
-        const T L01 = Q01 + u * (Q11 - Q01) + v * (Q02 - Q01);
-        const T L10 = Q10 + u * (Q20 - Q10) + v * (Q11 - Q10);
+        const T L00 = Q00 + u0 * (Q10 - Q00) + v0 * (Q01 - Q00);
+        const T L01 = Q01 + u0 * (Q11 - Q01) + v0 * (Q02 - Q01);
+        const T L10 = Q10 + u0 * (Q20 - Q10) + v0 * (Q11 - Q10);
 
-        eval[N] = L00 + u * (L10 - L00) + v * (L01 - L00);
+        eval[N] = L00 + u0 * (L10 - L00) + v0 * (L01 - L00);
         Du[N] = n_ord * (L10 - L00);
         Dv[N] = n_ord * (L01 - L00);
         DuDv[N] = n_ord_nm1 * (Q11 - Q10 - Q01 + Q00);
@@ -1113,8 +1281,8 @@ public:
       Point<T, 1> W;
       Vector<T, 1> W_u, W_v, W_uv;
 
-      projective.evaluateLinearDerivatives(u, v, P, P_u, P_v, P_uv);
-      weights.evaluateLinearDerivatives(u, v, W, W_u, W_v, W_uv);
+      projective.evaluateLinearDerivatives(u0, v0, P, P_u, P_v, P_uv);
+      weights.evaluateLinearDerivatives(u0, v0, W, W_u, W_v, W_uv);
 
       for(int N = 0; N < NDIMS; ++N)
       {
@@ -1127,10 +1295,10 @@ public:
   }
 
   /*!
-   * \brief Evaluates all second derivatives of a Bezier triangle at (\a u, \a v)
+   * \brief Evaluates all second derivatives of a Bezier triangle at (\a u0, \a v0)
    *
-   * \param [in] u Parameter value at which to evaluate along the u axis
-   * \param [in] v Parameter value at which to evaluate along the v axis
+   * \param [in] u0 Parameter value at which to evaluate along the u axis
+   * \param [in] v0 Parameter value at which to evaluate along the v axis
    * \param [out] eval The point value of the Bezier triangle at (u, v)
    * \param [out] Du The vector value of S_u(u, v)
    * \param [out] Dv The vector value of S_v(u, v)
@@ -1138,8 +1306,8 @@ public:
    * \param [out] DvDv The vector value of S_vv(u, v)
    * \param [out] DuDv The vector value of S_uv(u, v) == S_vu(u, v)
    */
-  void evaluateSecondDerivatives(T u,
-                                 T v,
+  void evaluateSecondDerivatives(T u0,
+                                 T v0,
                                  Point<T, NDIMS>& eval,
                                  Vector<T, NDIMS>& Du,
                                  Vector<T, NDIMS>& Dv,
@@ -1148,9 +1316,9 @@ public:
                                  Vector<T, NDIMS>& DuDv) const
   {
     SLIC_ASSERT(m_ord >= 0);
-    SLIC_ASSERT(u >= T(0));
-    SLIC_ASSERT(v >= T(0));
-    SLIC_ASSERT(u + v <= T(1));
+    SLIC_ASSERT(u0 >= T(0));
+    SLIC_ASSERT(v0 >= T(0));
+    SLIC_ASSERT(u0 + v0 <= T(1));
 
     if(m_ord == 0)
     {
@@ -1168,7 +1336,7 @@ public:
 
     if(m_ord == 1)
     {
-      evaluateFirstDerivatives(u, v, eval, Du, Dv);
+      evaluateFirstDerivatives(u0, v0, eval, Du, Dv);
       for(int N = 0; N < NDIMS; ++N)
       {
         DuDu[N] = T(0);
@@ -1204,7 +1372,7 @@ public:
               const auto& A = dCarray[triIndex(end, i, j)];
               const auto& B = dCarray[triIndex(end, i, j + 1)];
               const auto& C = dCarray[triIndex(end, i + 1, j)];
-              dCarray[triIndex(end - 1, i, j)] = A + u * (C - A) + v * (B - A);
+              dCarray[triIndex(end - 1, i, j)] = A + u0 * (C - A) + v0 * (B - A);
             }
           }
         }
@@ -1218,11 +1386,11 @@ public:
         const T Q20 = dCarray[triIndex(2, 2, 0)];
 
         // One reduction yields a linear triangle (order 1)
-        const T L00 = Q00 + u * (Q10 - Q00) + v * (Q01 - Q00);
-        const T L01 = Q01 + u * (Q11 - Q01) + v * (Q02 - Q01);
-        const T L10 = Q10 + u * (Q20 - Q10) + v * (Q11 - Q10);
+        const T L00 = Q00 + u0 * (Q10 - Q00) + v0 * (Q01 - Q00);
+        const T L01 = Q01 + u0 * (Q11 - Q01) + v0 * (Q02 - Q01);
+        const T L10 = Q10 + u0 * (Q20 - Q10) + v0 * (Q11 - Q10);
 
-        eval[N] = L00 + u * (L10 - L00) + v * (L01 - L00);
+        eval[N] = L00 + u0 * (L10 - L00) + v0 * (L01 - L00);
         Du[N] = n_ord * (L10 - L00);
         Dv[N] = n_ord * (L01 - L00);
 
@@ -1244,8 +1412,8 @@ public:
       Point<T, 1> W;
       Vector<T, 1> W_u, W_v, W_uu, W_vv, W_uv;
 
-      projective.evaluateSecondDerivatives(u, v, P, P_u, P_v, P_uu, P_vv, P_uv);
-      weights.evaluateSecondDerivatives(u, v, W, W_u, W_v, W_uu, W_vv, W_uv);
+      projective.evaluateSecondDerivatives(u0, v0, P, P_u, P_v, P_uu, P_vv, P_uv);
+      weights.evaluateSecondDerivatives(u0, v0, W, W_u, W_v, W_uu, W_vv, W_uv);
 
       for(int N = 0; N < NDIMS; ++N)
       {
@@ -1259,64 +1427,64 @@ public:
     }
   }
 
-  /// \brief Computes a tangent of a Bezier triangle at (\a u, \a v) along the u axis
-  VectorType du(T u, T v) const
+  /// \brief Computes a tangent of a Bezier triangle at (\a u0, \a v0) along the u axis
+  VectorType du(T u0, T v0) const
   {
     PointType eval;
     VectorType Du, Dv;
-    evaluateFirstDerivatives(u, v, eval, Du, Dv);
+    evaluateFirstDerivatives(u0, v0, eval, Du, Dv);
     return Du;
   }
 
-  /// \brief Computes a tangent of a Bezier triangle at (\a u, \a v) along the v axis
-  VectorType dv(T u, T v) const
+  /// \brief Computes a tangent of a Bezier triangle at (\a u0, \a v0) along the v axis
+  VectorType dv(T u0, T v0) const
   {
     PointType eval;
     VectorType Du, Dv;
-    evaluateFirstDerivatives(u, v, eval, Du, Dv);
+    evaluateFirstDerivatives(u0, v0, eval, Du, Dv);
     return Dv;
   }
 
-  /// \brief Computes the second derivative of a Bezier triangle at (\a u, \a v) along the u axis
-  VectorType dudu(T u, T v) const
+  /// \brief Computes the second derivative of a Bezier triangle at (\a u0, \a v0) along the u axis
+  VectorType dudu(T u0, T v0) const
   {
     PointType eval;
     VectorType Du, Dv, DuDu, DvDv, DuDv;
-    evaluateSecondDerivatives(u, v, eval, Du, Dv, DuDu, DvDv, DuDv);
+    evaluateSecondDerivatives(u0, v0, eval, Du, Dv, DuDu, DvDv, DuDv);
     return DuDu;
   }
 
-  /// \brief Computes the second derivative of a Bezier triangle at (\a u, \a v) along the v axis
-  VectorType dvdv(T u, T v) const
+  /// \brief Computes the second derivative of a Bezier triangle at (\a u0, \a v0) along the v axis
+  VectorType dvdv(T u0, T v0) const
   {
     PointType eval;
     VectorType Du, Dv, DuDu, DvDv, DuDv;
-    evaluateSecondDerivatives(u, v, eval, Du, Dv, DuDu, DvDv, DuDv);
+    evaluateSecondDerivatives(u0, v0, eval, Du, Dv, DuDu, DvDv, DuDv);
     return DvDv;
   }
 
-  /// \brief Computes the mixed second derivative of a Bezier triangle at (\a u, \a v)
-  VectorType dudv(T u, T v) const
+  /// \brief Computes the mixed second derivative of a Bezier triangle at (\a u0, \a v0)
+  VectorType dudv(T u0, T v0) const
   {
     PointType eval;
     VectorType Du, Dv, DuDu, DvDv, DuDv;
-    evaluateSecondDerivatives(u, v, eval, Du, Dv, DuDu, DvDv, DuDv);
+    evaluateSecondDerivatives(u0, v0, eval, Du, Dv, DuDu, DvDv, DuDv);
     return DuDv;
   }
 
-  /// \brief Convenience alias for S_vu(u,v), which equals S_uv(u,v) for polynomial triangles
-  VectorType dvdu(T u, T v) const { return dudv(u, v); }
+  /// \brief Convenience alias for S_vu(u0,v0), which equals S_uv(u0,v0) for polynomial triangles
+  VectorType dvdu(T u0, T v0) const { return dudv(u0, v0); }
 
   /*!
-   * \brief Computes the normal vector of a Bezier triangle at (\a u, \a v)
+   * \brief Computes the normal vector of a Bezier triangle at (\a u0, \a v0)
    *
    * \note Only meaningful for NDIMS==3.
    */
-  VectorType normal(T u, T v) const
+  VectorType normal(T u0, T v0) const
   {
     Point<T, NDIMS> eval;
     Vector<T, NDIMS> Du, Dv;
-    evaluateFirstDerivatives(u, v, eval, Du, Dv);
+    evaluateFirstDerivatives(u0, v0, eval, Du, Dv);
     return VectorType::cross_product(Du, Dv);
   }
 
@@ -1360,9 +1528,9 @@ public:
    *
    * \param [in] ord Triangle order
    */
-  static constexpr size_t triSize(int ord)
+  static constexpr int triSize(int ord)
   {
-    return (ord >= 0) ? static_cast<size_t>((ord + 1) * (ord + 2) / 2) : size_t {0};
+    return (ord >= 0) ? ((ord + 1) * (ord + 2) / 2) : 0;
   }
 
   /*!
@@ -1421,6 +1589,220 @@ private:
         for(int N = 0; N < NDIMS; ++N)
         {
           projective(i, j)[N] = (*this)(i, j)[N] * w;
+        }
+      }
+    }
+  }
+
+  /*!
+   * \brief Private function to evaluate the uniform split algorithm
+   *
+   * \param [in] get_eval_point Lambda that returns an `EvalPointType` for control point `(i,j)`
+   * \param [in] set_eval_point Lambda that assigns an `EvalPointType` to output triangle control point `(i,j)`
+   *              If the triangle is polynomial, these should access the control point as-is.
+   *              If the triangle is rational, these should access the homogeneous control point.
+   *
+   * Implements the algorithm from Kenneth I. Joy, "A Uniform Subdivision Method for Triangular Bezier Patches"
+   *
+   * We construct a degenerate "Bezier tetrahedron" of intermediate points via repeated
+   *  midpoint averaging in the control net, then extract the four subtriangle control nets
+   *  from its four faces (three corner triangles + one central triangle)
+   *
+   * We separate this templated implementation so that we can more efficiently process rational triangles.
+   */
+  template <typename EvalPointType, typename GetEvalPointFn, typename SetEvalPointFn>
+  void uniform_split_impl(GetEvalPointFn get_eval_point,
+                          SetEvalPointFn set_eval_point,
+                          BezierTriangle& t0,
+                          BezierTriangle& t1,
+                          BezierTriangle& t2,
+                          BezierTriangle& t3) const
+  {
+    const int n = m_ord;
+    const int triN = triSize(n);
+    constexpr int evalDims = EvalPointType::dimension();
+
+    axom::Array<int> offsets(n + 2);
+    offsets[0] = 0;
+    for(int p = 0; p <= n; ++p)
+    {
+      offsets[p + 1] = offsets[p] + triSize(p);
+    }
+    const int tetN = offsets[n + 1];
+
+    // tetSize: Number of (n1,n2,n3) triples with n1+n2+n3 <= m_ord.
+    SLIC_ASSERT(tetN == (n + 1) * (n + 2) * (n + 3) / 6);
+
+    // Storage for the degenerate tetrahedron:
+    // - tetIdx indexes a (n1,n2,n3) triple with fixed sum p via:
+    //     tetIdx(p,n1,n2) = offsets[p] + triIndex(p,n1,n2), with n3 = p-n1-n2
+    // - within each state, we store a full triangle mesh at degree n indexed by triIndex(n,i,j)
+    //   (even though only a subset of indices are valid for a given (n1,n2,n3)).
+    axom::Array<axom::Array<EvalPointType>> tet(tetN);
+    for(int s = 0; s < tetN; ++s)
+    {
+      tet[s].resize(triN);
+    }
+
+    auto tetIdx = [&](int p, int n1, int n2) -> int {
+      SLIC_ASSERT(p >= 0 && p <= n);
+      SLIC_ASSERT(n1 >= 0 && n1 <= p);
+      SLIC_ASSERT(n2 >= 0 && n2 <= p - n1);
+      return offsets[p] + triIndex(p, n1, n2);
+    };
+    auto getTetPt = [&](int state, int i, int j) -> const EvalPointType& {
+      return tet[static_cast<std::size_t>(state)][triIndex(n, i, j)];
+    };
+    auto setTetPt = [&](int state, int i, int j, const EvalPointType& value) {
+      tet[static_cast<std::size_t>(state)][triIndex(n, i, j)] = value;
+    };
+
+    const int base = tetIdx(0, 0, 0);
+    for(int i = 0; i <= n; ++i)
+    {
+      for(int j = 0; j <= n - i; ++j)
+      {
+        setTetPt(base, i, j, get_eval_point(i, j));
+      }
+    }
+
+    // Build the tetrahedron states in increasing p = n1+n2+n3.
+    for(int p = 1; p <= n; ++p)
+    {
+      for(int n1 = 0; n1 <= p; ++n1)
+      {
+        for(int n2 = 0; n2 <= p - n1; ++n2)
+        {
+          const int n3 = p - n1 - n2;
+          const int curr = tetIdx(p, n1, n2);
+
+          // Pick the predecessor state and the second point used in the midpoint average.
+          int prev = -1, di = 0, dj = 0;
+          if(n1 > 0)
+          {
+            prev = tetIdx(p - 1, n1 - 1, n2);
+            di = -1;
+            dj = +1;
+          }
+          else if(n2 > 0)
+          {
+            prev = tetIdx(p - 1, n1, n2 - 1);
+            di = 0;
+            dj = -1;
+          }
+          else
+          {
+            // n1==0 && n2==0 so n3>0 here.
+            prev = tetIdx(p - 1, 0, 0);
+            di = +1;
+            dj = 0;
+          }
+
+          // Valid domain: i>=n1, j>=n2, k>=n3.
+          for(int i = n1; i <= n; ++i)
+          {
+            const int jMax = n - n3 - i;
+            if(jMax < n2)
+            {
+              continue;
+            }
+            for(int j = n2; j <= jMax; ++j)
+            {
+              const auto& a = getTetPt(prev, i, j);
+              const auto& b = getTetPt(prev, i + di, j + dj);
+
+              EvalPointType out;
+              for(int d = 0; d < evalDims; ++d)
+              {
+                out[d] = T(0.5) * (a[d] + b[d]);
+              }
+              setTetPt(curr, i, j, out);
+            }
+          }
+        }
+      }
+    }
+
+    // Extract the four faces Q1..Q4, given by
+    //   Q1 = { P^{[m,0,k]}_{i,0,k} : i+k=n, m=0..i }
+    //   Q2 = { P^{[i,m,0]}_{i,j,0} : i+j=n, m=0..j }
+    //   Q3 = { P^{[0,j,m]}_{0,j,k} : j+k=n, m=0..k }
+    //   Q4 = { P^{[i,j,k]}_{i,j,k} : i+j+k=n }
+
+    // Q3 -> t0 : P^{[0,j,m]}_{0,j,k} with j+k=n and m<=k maps to local (m,j)
+    // so that (0,1) is the midpoint on AB and (1,0) is the midpoint on AC.
+    for(int j = 0; j <= n; ++j)
+    {
+      const int i = 0;
+      for(int m = 0; m <= n - j; ++m)
+      {
+        const int p = j + m;
+        const int state = tetIdx(p, 0, j);
+        set_eval_point(t0, m, j, getTetPt(state, i, j));
+      }
+    }
+
+    // Q2 -> t1 : P^{[i,m,0]}_{i,j,0} with i+j=n and m<=j maps to local (m,i)
+    // so that (0,1) is the midpoint on BC and (1,0) is the midpoint on AB.
+    for(int i = 0; i <= n; ++i)
+    {
+      const int j = n - i;
+      for(int m = 0; m <= j; ++m)
+      {
+        const int p = i + m;
+        const int state = tetIdx(p, i, m);
+        set_eval_point(t1, m, i, getTetPt(state, i, j));
+      }
+    }
+
+    // Q1 -> t2 : P^{[m,0,k]}_{i,0,k} with i+k=n and m<=i maps to local (m,k)
+    // so that (0,1) is the midpoint on AC and (1,0) is the midpoint on BC.
+    for(int k = 0; k <= n; ++k)
+    {
+      const int i = n - k;
+      const int j = 0;
+      for(int m = 0; m <= i; ++m)
+      {
+        const int p = m + k;
+        const int state = tetIdx(p, m, 0);
+        set_eval_point(t2, m, k, getTetPt(state, i, j));
+      }
+    }
+
+    // Q4 -> t3 : P^{[i,j,k]}_{i,j,k} with i+j+k=n maps to local (j,i)
+    // so that (0,1) is the midpoint on BC and (1,0) is the midpoint on AB.
+    for(int i = 0; i <= n; ++i)
+    {
+      for(int j = 0; j <= n - i; ++j)
+      {
+        const int state = offsets[n] + triIndex(n, j, i);
+        set_eval_point(t3, i, j, getTetPt(state, j, i));
+      }
+    }
+  }
+
+  /// \brief Fill a (possibly non-rational) triangle from projective control points and weights
+  static void set_from_projective_triangles(const BezierTriangle<T, NDIMS>& projective,
+                                            const BezierTriangle<T, 1>& weights,
+                                            BezierTriangle& out)
+  {
+    const int ord = projective.getOrder();
+    SLIC_ASSERT(ord == weights.getOrder());
+
+    out.setOrder(ord);
+    out.getWeights().resize(triSize(ord));
+
+    for(int i = 0; i <= ord; ++i)
+    {
+      for(int j = 0; j <= ord - i; ++j)
+      {
+        const T w = weights(i, j)[0];
+        SLIC_ASSERT(w > T(0));
+        out.getWeights()[triIndex(ord, i, j)] = w;
+
+        for(int N = 0; N < NDIMS; ++N)
+        {
+          out(i, j)[N] = projective(i, j)[N] / w;
         }
       }
     }

--- a/src/axom/primal/geometry/BezierTriangle.hpp
+++ b/src/axom/primal/geometry/BezierTriangle.hpp
@@ -40,6 +40,8 @@ std::ostream& operator<<(std::ostream& os, const BezierTriangle<T, NDIMS>& bTri)
  *
  * \brief Represents a Bezier triangle defined by a triangular array of control points
  * \tparam T the coordinate type, e.g., double, float, etc.
+ * \tparam NDIMS The dimension of each control point, e.g. 4 for homogeneous surfaces 
+ *                 or 1 for rational weights.
  *
  * A Bezier triangle of order \a N has \f$ (N+1)(N+2)/2 \f$ control points.
  * It is parametrized over the domain \f$ u0 \ge 0, v0 \ge 0, u0+v0 \le 1 \f$.
@@ -57,13 +59,26 @@ std::ostream& operator<<(std::ostream& os, const BezierTriangle<T, NDIMS>& bTri)
  * - `evaluate(0,0) == (*this)(0,0)`
  * - `evaluate(0,1) == (*this)(0,1)`
  * - `evaluate(1,0) == (*this)(1,0)`
- * These are mapped to standard Barycentric coordinates through (u0, v0) = {1 - u0 - v0, v0, u0}
+ * 
+ * These are mapped to standard Barycentric coordinates {u,v,w} through (u0, v0) = {1 - u0 - v0, v0, u0}:
+ *
+ *   Parametric (u0, v0):       Barycentric {u,v,w}:
+ *        (1, 0)                      {0,0,1}
+ *          /\                          /\
+ *         /  \                        /  \
+ *   ^    /    \         <--->        /    \
+ *   |   /      \                    /      \
+ *   |  /        \                  /        \
+ *  v0 /__________\                /__________\
+ * (0, 0) u0 ---> (0, 1)       {1,0,0}        {0,1,0}
+ * 
  */
 template <typename T, int NDIMS>
 class BezierTriangle
 {
 public:
   using PointType = Point<T, NDIMS>;
+  using Barycentric = Point<T, 3>;
   using VectorType = Vector<T, NDIMS>;
 
   using CoordsVec = axom::Array<PointType, 1>;
@@ -76,6 +91,11 @@ public:
 
   AXOM_STATIC_ASSERT_MSG((NDIMS == 1) || (NDIMS == 2) || (NDIMS == 3),
                          "A Bezier Triangle object may be defined in 1-, 2-, or 3-D");
+
+  // Allows template types to access private member data of other allowable templates
+  friend class BezierTriangle<T, 1>;
+  friend class BezierTriangle<T, 2>;
+  friend class BezierTriangle<T, 3>;
 
   AXOM_STATIC_ASSERT_MSG(std::is_arithmetic<T>::value,
                          "A Bezier Triangle must be defined using an arithmetic type");
@@ -225,6 +245,19 @@ public:
    */
   bool isRational() const { return !m_weights.empty(); }
 
+  /// Make trivially rational. If already rational, do nothing
+  void makeRational()
+  {
+    if(!isRational())
+    {
+      m_weights.resize(triSize(m_ord));
+      m_weights.fill(1.0);
+    }
+  }
+
+  /// Make nonrational by shrinking array of weights
+  void makeNonrational() { m_weights.clear(); }
+
   /*!
    * \brief Returns a reference to the triangle's control points
    *
@@ -245,43 +278,6 @@ public:
 
   /// \brief Returns a reference to the triangle's weights
   const WeightsVec& getWeights() const { return m_weights; }
-
-  /*!
-   * \brief Get a specific weight from a rational Bezier triangle
-   *
-   * \param [in] i First control net index
-   * \param [in] j Second control net index
-   * \pre Requires that the triangle be rational
-   */
-  const T& getWeight(int i, int j) const
-  {
-    SLIC_ASSERT(isRational());
-    SLIC_ASSERT(m_weights.size() == m_controlPoints.size());
-    SLIC_ASSERT(i >= 0);
-    SLIC_ASSERT(j >= 0);
-    SLIC_ASSERT(i + j <= m_ord);
-    return m_weights[triIndex(m_ord, i, j)];
-  }
-
-  /*!
-   * \brief Set the weight at a specific index for a rational Bezier triangle
-   *
-   * \param [in] i First control net index
-   * \param [in] j Second control net index
-   * \param [in] weight The updated value of the weight
-   * \pre Requires that the triangle be rational
-   * \pre Requires that the weight be positive
-   */
-  void setWeight(int i, int j, T weight)
-  {
-    SLIC_ASSERT(isRational());
-    SLIC_ASSERT(m_weights.size() == m_controlPoints.size());
-    SLIC_ASSERT(weight > T(0));
-    SLIC_ASSERT(i >= 0);
-    SLIC_ASSERT(j >= 0);
-    SLIC_ASSERT(i + j <= m_ord);
-    m_weights[triIndex(m_ord, i, j)] = weight;
-  }
 
   /*!
    * \brief Returns an axis-aligned bounding box containing the Bezier triangle
@@ -362,7 +358,7 @@ public:
   }
 
   /*!
-   * \brief Returns one of the boundary edges of the Bezier triangle
+   * \brief Returns a copy of one of the boundary edges of the Bezier triangle
    *
    * \param [in] edgeIdx Index of the requested edge in \a [0,2]
    *
@@ -372,7 +368,7 @@ public:
    * - \a edgeIdx = 1: u = 0 from `evaluate(0,1)` to `evaluate(0,0)`
    * - \a edgeIdx = 2: v = 0 from `evaluate(0,0)` to `evaluate(1,0)`
    *
-   * \return A Bezier curve representing the requested edge.
+   * \return A copy of the Bezier curve representing the requested edge.
    */
   BezierCurveType getEdge(int edgeIdx) const
   {
@@ -391,33 +387,33 @@ public:
     case 0:
       for(int k = 0; k <= m_ord; ++k)
       {
-        const int i = k;
-        const int j = m_ord - k;
-        pts[k] = (*this)(i, j);
+        const int idx = triIndex(m_ord, k, m_ord - k);
+        pts[k] = m_controlPoints[idx];
         if(isRational())
         {
-          wts[k] = m_weights[triIndex(m_ord, i, j)];
+          wts[k] = m_weights[idx];
         }
       }
       break;
     case 1:
       for(int k = 0; k <= m_ord; ++k)
       {
-        const int i = m_ord - k;
-        pts[k] = (*this)(i, 0);
+        const int idx = triIndex(m_ord, m_ord - k, 0);
+        pts[k] = m_controlPoints[idx];
         if(isRational())
         {
-          wts[k] = m_weights[triIndex(m_ord, i, 0)];
+          wts[k] = m_weights[idx];
         }
       }
       break;
     case 2:
-      for(int j = 0; j <= m_ord; ++j)
+      for(int k = 0; k <= m_ord; ++k)
       {
-        pts[j] = (*this)(0, j);
+        const int idx = triIndex(m_ord, 0, k);
+        pts[k] = m_controlPoints[idx];
         if(isRational())
         {
-          wts[j] = m_weights[triIndex(m_ord, 0, j)];
+          wts[k] = m_weights[idx];
         }
       }
       break;
@@ -449,23 +445,22 @@ public:
    *
    * See overload returning a `BezierTriangle` for the vertex mapping convention.
    *
-   * \param [in] Va Barycentric coordinates of the first subtriangle vertex `(u,v,w)`
-   * \param [in] Vb Barycentric coordinates of the second subtriangle vertex `(u,v,w)`
-   * \param [in] Vc Barycentric coordinates of the third subtriangle vertex `(u,v,w)`
+   * \param [in] Qa Barycentric coordinates of the first subtriangle vertex `(u,v,w)`
+   * \param [in] Qb Barycentric coordinates of the second subtriangle vertex `(u,v,w)`
+   * \param [in] Qc Barycentric coordinates of the third subtriangle vertex `(u,v,w)`
    * \param [out] out Output restricted Bezier triangle
    *
    * \pre getOrder() >= 0
    *
-   * \note The barycentric inputs \a Va, \a Vb, \a Vc are \a (u,v,w) triplets in the same
-   *       parameter-coordinate convention used internally by `evaluate(u,v)` (with \a w = 1-u-v).
+   * \note The barycentric inputs \a Qa, \a Qb, \a Qc are standard Barycentric coordiantes
+   *       related to parameter convention through (u0 = Qc, v0 = Qb)
    */
-  void restrictToSubtriangle(const Point<T, 3>& Va,
-                             const Point<T, 3>& Vb,
-                             const Point<T, 3>& Vc,
+  void restrictToSubtriangle(const Barycentric& Qa,
+                             const Barycentric& Qb,
+                             const Barycentric& Qc,
                              BezierTriangle& out) const
   {
     using TriangularArray = axom::Array<PointType>;
-    using Barycentric = Point<T, 3>;
 
     SLIC_ASSERT(m_ord >= 0);
     if(isRational())
@@ -478,8 +473,8 @@ public:
       BezierTriangle<T, NDIMS> proj_out(m_ord);
       BezierTriangle<T, 1> w_out(m_ord);
 
-      projective.restrictToSubtriangle(Va, Vb, Vc, proj_out);
-      weights.restrictToSubtriangle(Va, Vb, Vc, w_out);
+      projective.restrictToSubtriangle(Qa, Qb, Qc, proj_out);
+      weights.restrictToSubtriangle(Qa, Qb, Qc, w_out);
 
       set_from_projective_triangles(proj_out, w_out, out);
       return;
@@ -501,22 +496,16 @@ public:
             const auto& B0 = prev[triIndex(deg, ii, jj + 1)];
             const auto& C0 = prev[triIndex(deg, ii + 1, jj)];
 
-            PointType val;
-            for(int N = 0; N < NDIMS; ++N)
-            {
-              // Barycentric coordinates permuted to match convention in evaluate()
-              val[N] = Q[2] * A0[N] + Q[1] * B0[N] + Q[0] * C0[N];
-            }
-            next[triIndex(newDeg, ii, jj)] = val;
+            next[triIndex(newDeg, ii, jj)] = triInterpolate(A0, B0, C0, Q);
           }
         }
       };
 
-    // The restricted control net over (Va,Vb,Vc) is given by blossom values:
-    //   out(i,j) = b(Vc^i, Vb^j, Va^(n-i-j))  for 0<=i<=n and 0<=j<=n-i
+    // The restricted control net over (Qa,Qb,Qc) is given by blossom values:
+    //   out(i,j) = b(Qc^i, Qb^j, Qa^(n-i-j))  for 0<=i<=n and 0<=j<=n-i
     //
     // At layer p, we maintain all intermediate nets with exactly p fixed arguments,
-    //  i.e. b(Vc^i0, Vb^j0, Vc^k0) with i0 + j0 + k0 = p, and use them to compute nets
+    //  i.e. b(Qc^i0, Qb^j0, Qc^k0) with i0 + j0 + k0 = p, and use them to compute nets
     //  for blossom values with one more fixed argument until p == n
     axom::Array<TriangularArray> prevNets(1);
     prevNets[0] = m_controlPoints;
@@ -546,18 +535,18 @@ public:
           if(k0 > 0)
           {
             const int predIdx = triIndex(p - 1, i0, j0);
-            reduce_once(prevNets[predIdx], currNets[idx], degPrev, Va);
+            reduce_once(prevNets[predIdx], currNets[idx], degPrev, Qa);
           }
           else if(j0 > 0)
           {
             const int predIdx = triIndex(p - 1, i0, j0 - 1);
-            reduce_once(prevNets[predIdx], currNets[idx], degPrev, Vb);
+            reduce_once(prevNets[predIdx], currNets[idx], degPrev, Qb);
           }
           else
           {
             SLIC_ASSERT(i0 > 0);
             const int predIdx = triIndex(p - 1, i0 - 1, j0);
-            reduce_once(prevNets[predIdx], currNets[idx], degPrev, Vc);
+            reduce_once(prevNets[predIdx], currNets[idx], degPrev, Qc);
           }
         }
       }
@@ -568,28 +557,29 @@ public:
 
     // Each net in the last layer (p==n) has degree 0 and contains a single control point.
     out.setOrder(n);
-    out.getWeights().resize(0);
+    out.makeNonrational();
     for(int i = 0; i <= n; ++i)
     {
       for(int j = 0; j <= n - i; ++j)
       {
-        out(i, j) = prevNets[triIndex(n, i, j)][0];
+        const int idx = triIndex(n, i, j);
+        out.m_controlPoints[idx] = prevNets[idx][0];
       }
     }
   }
 
   /*!
    * \brief Splits a Bezier triangle into three subtriangles by connecting an
-   * interior parameter point \a (u,v) to the triangle's three vertices
+   * interior parameter point \a (u0,v0) to the triangle's three vertices
    *
    * \param [in] u0 Parameter value along the \a u axis for the split point
    * \param [in] v0 Parameter value along the \a v axis for the split point
    * \param [out] t0 Subtriangle over the parameter triangle with vertices
-   *  `(0,1)`, `(1,0)`, and `(u,v)` (preserves edge 0)
+   *  `(0,1)`, `(1,0)`, and `(u0,v0)` (preserves edge 0)
    * \param [out] t1 Subtriangle over the parameter triangle with vertices
-   *  `(1,0)`, `(0,0)`, and `(u,v)` (preserves edge 1)
+   *  `(1,0)`, `(0,0)`, and `(u0,v0)` (preserves edge 1)
    * \param [out] t2 Subtriangle over the parameter triangle with vertices
-   *  `(0,0)`, `(0,1)`, and `(u,v)` (preserves edge 2)
+   *  `(0,0)`, `(0,1)`, and `(u0,v0)` (preserves edge 2)
    *
    * \pre \a u0 > 0, \a v0 > 0, and \a u0 + \a v0 < 1
    *
@@ -607,9 +597,7 @@ public:
   void split(T u0, T v0, BezierTriangle& t0, BezierTriangle& t1, BezierTriangle& t2) const
   {
     SLIC_ASSERT(m_ord >= 0);
-    SLIC_ASSERT(u0 > T(0));
-    SLIC_ASSERT(v0 > T(0));
-    SLIC_ASSERT(u0 + v0 < T(1));
+    SLIC_ASSERT(is_valid_interior_parameter(u0, v0));
 
     if(isRational())
     {
@@ -630,8 +618,7 @@ public:
     }
 
     // Q is the split point in barycentric coordinates over the reference parameter triangle:
-    using Barycentric = Point<T, 3>;
-    const Barycentric Q {u0, v0, T(1) - u0 - v0};
+    const Barycentric Q {T(1) - u0 - v0, v0, u0};
 
     const int n = m_ord;
     axom::Array<axom::Array<PointType>> net(n + 1);
@@ -653,24 +640,14 @@ public:
           const auto& B0 = prev[triIndex(deg, ii, jj + 1)];
           const auto& C0 = prev[triIndex(deg, ii + 1, jj)];
 
-          PointType val;
-          for(int N = 0; N < NDIMS; ++N)
-          {
-            val[N] = Q[2] * A0[N] + Q[1] * B0[N] + Q[0] * C0[N];
-          }
-          net[p][triIndex(newDeg, ii, jj)] = val;
+          net[p][triIndex(newDeg, ii, jj)] = triInterpolate(A0, B0, C0, Q);
         }
       }
     }
 
-    t0.setOrder(n);
-    t1.setOrder(n);
-    t2.setOrder(n);
-    t0.getWeights().resize(0);
-    t1.getWeights().resize(0);
-    t2.getWeights().resize(0);
-
     // Subtriangle (B,C,Q): (0,1), (1,0), (u0,v0)
+    t0.setOrder(n);
+    t0.makeNonrational();
     for(int i = 0; i <= n; ++i)
     {
       const int deg = n - i;
@@ -681,6 +658,8 @@ public:
     }
 
     // Subtriangle (C,A,Q): (1,0), (0,0), (u0,v0)
+    t1.setOrder(n);
+    t1.makeNonrational();
     for(int i = 0; i <= n; ++i)
     {
       const int deg = n - i;
@@ -691,6 +670,8 @@ public:
     }
 
     // Subtriangle (A,B,Q): (0,0), (0,1), (u0,v0)
+    t2.setOrder(n);
+    t2.makeNonrational();
     for(int i = 0; i <= n; ++i)
     {
       const int deg = n - i;
@@ -751,19 +732,18 @@ public:
     }
 
     using TriangularArray = axom::Array<PointType>;
-    using Barycentric = Point<T, 3>;
 
     Barycentric Q;
     switch(edgeIdx)
     {
-    case 0:  // (u=s, v=1-s, w=0)
-      Q = Barycentric {s, T(1) - s, T(0)};
+    case 0:  // (u=0, v=1-s, w=s)
+      Q = Barycentric {T(0), T(1) - s, s};
       break;
-    case 1:  // (u=1-s, v=0, w=s)
-      Q = Barycentric {T(1) - s, T(0), s};
+    case 1:  // (u=s, v=0, w=1-s)
+      Q = Barycentric {s, T(0), T(1) - s};
       break;
-    case 2:  // (u=0, v=s, w=1-s)
-      Q = Barycentric {T(0), s, T(1) - s};
+    case 2:  // (u=1-s, v=s, w=0)
+      Q = Barycentric {T(1) - s, s, T(0)};
       break;
     default:
       break;
@@ -789,20 +769,14 @@ public:
           const auto& B0 = prev[triIndex(deg, ii, jj + 1)];
           const auto& C0 = prev[triIndex(deg, ii + 1, jj)];
 
-          PointType val;
-          for(int N = 0; N < NDIMS; ++N)
-          {
-            // Barycentric coordinates permuted to match convention in evaluate
-            val[N] = Q[2] * A0[N] + Q[1] * B0[N] + Q[0] * C0[N];
-          }
-          net[p][triIndex(newDeg, ii, jj)] = val;
+          net[p][triIndex(newDeg, ii, jj)] = triInterpolate(A0, B0, C0, Q);
         }
       }
     }
 
     auto fill_from_net = [&](int keptEdge, BezierTriangle& out) {
       out.setOrder(n);
-      out.getWeights().resize(0);
+      out.makeNonrational();
       for(int i = 0; i <= n; ++i)
       {
         const int deg = n - i;
@@ -887,10 +861,10 @@ public:
 
     if(!isRational())
     {
-      t0.getWeights().resize(0);
-      t1.getWeights().resize(0);
-      t2.getWeights().resize(0);
-      t3.getWeights().resize(0);
+      t0.makeNonrational();
+      t1.makeNonrational();
+      t2.makeNonrational();
+      t3.makeNonrational();
 
       // For polynomial triangles, these accessors just use the regular control points
       auto get_point = [&](int i, int j) -> PointType { return (*this)(i, j); };
@@ -902,29 +876,33 @@ public:
     else
     {
       using HomogeneousPoint = Point<T, NDIMS + 1>;
-      t0.getWeights().resize(triN);
-      t1.getWeights().resize(triN);
-      t2.getWeights().resize(triN);
-      t3.getWeights().resize(triN);
+      t0.makeRational();
+      t1.makeRational();
+      t2.makeRational();
+      t3.makeRational();
 
       // For rational triangles, these accessors generate homogeneous control points
       auto get_hom_point = [&](int i, int j) -> HomogeneousPoint {
+        const int idx = triIndex(n, i, j);
+
         HomogeneousPoint hp;
-        const T w = m_weights[triIndex(n, i, j)];
-        hp[NDIMS] = w;
+        hp[NDIMS] = m_weights[idx];
         for(int d = 0; d < NDIMS; ++d)
         {
-          hp[d] = (*this)(i, j)[d] * w;
+          hp[d] = m_controlPoints[idx][d] * m_weights[idx];
         }
         return hp;
       };
       auto set_hom_point = [&](BezierTriangle& out, int i, int j, const HomogeneousPoint& hp) {
+        const int idx = triIndex(n, i, j);
+
         const T w = hp[NDIMS];
         SLIC_ASSERT(w > T(0));
-        out.getWeights()[triIndex(n, i, j)] = w;
+
+        out.m_weights[idx] = w;
         for(int d = 0; d < NDIMS; ++d)
         {
-          out(i, j)[d] = hp[d] / w;
+          out.m_controlPoints[idx][d] = hp[d] / w;
         }
       };
       uniform_split_impl<HomogeneousPoint>(get_hom_point, set_hom_point, t0, t1, t2, t3);
@@ -963,25 +941,24 @@ public:
              BezierTriangle& t3,
              BezierTriangle& t4) const
   {
-    using Barycentric = Point<T, 3>;
     SLIC_ASSERT(m_ord >= 0);
     SLIC_ASSERT(s1 > T(0) && s1 < T(1));
     SLIC_ASSERT(s2 > T(0) && s2 < T(1));
     SLIC_ASSERT(s3 > T(0) && s3 < T(1));
 
-    // Barycentric coordinates in (u, v, w) where w = 1-u-v
-    // and the triangle vertices are: A=(0,0,1), B=(0,1,0), C=(1,0,0)
-    const Barycentric A {T(0), T(0), T(1)};
+    // Standard Barycentric coordinates in {u,v,w} where w = 1-u-v
+    // and the triangle vertices are: A={1,0,0}, B={0,1,0}, C={0,0,1}
+    const Barycentric A {T(1), T(0), T(0)};
     const Barycentric B {T(0), T(1), T(0)};
-    const Barycentric C {T(1), T(0), T(0)};
+    const Barycentric C {T(0), T(0), T(1)};
 
-    // Edge points (u, v, w = 1-u-v) following the same orientation as getEdge(0..2)
+    // Edge points {u,v,w} following the same orientation as getEdge(0..2)
     // edge0: B->C  (w == 0)
     // edge1: C->A  (v == 0)
     // edge2: A->B  (u == 0)
-    const Barycentric P0 {s1, T(1) - s1, T(0)};
-    const Barycentric P1 {T(1) - s2, T(0), s2};
-    const Barycentric P2 {T(0), s3, T(1) - s3};
+    const Barycentric P0 {T(0), T(1) - s1, s1};
+    const Barycentric P1 {s2, T(0), T(1) - s2};
+    const Barycentric P2 {T(1) - s3, s3, T(0)};
 
     // Corner triangles (ordered to match the diagram and preserve interior-edge orientation)
     restrictToSubtriangle(A, P2, P1, t1);
@@ -1000,19 +977,46 @@ public:
    */
   PointType& operator()(int i, int j)
   {
-    SLIC_ASSERT(i >= 0);
-    SLIC_ASSERT(j >= 0);
-    SLIC_ASSERT(i + j <= m_ord);
+    SLIC_ASSERT(isValidIndex(m_ord, i, j));
     return m_controlPoints[triIndex(m_ord, i, j)];
   }
 
   /// \brief Access a control point in the triangular control net
   const PointType& operator()(int i, int j) const
   {
-    SLIC_ASSERT(i >= 0);
-    SLIC_ASSERT(j >= 0);
-    SLIC_ASSERT(i + j <= m_ord);
+    SLIC_ASSERT(isValidIndex(m_ord, i, j));
     return m_controlPoints[triIndex(m_ord, i, j)];
+  }
+
+  /*!
+   * \brief Get a specific weight from a rational Bezier triangle
+   *
+   * \param [in] i First control net index
+   * \param [in] j Second control net index
+   * \pre Requires that the triangle be rational
+   */
+  const T& getWeight(int i, int j) const
+  {
+    SLIC_ASSERT(isRational());
+    SLIC_ASSERT(isValidIndex(m_ord, i, j));
+    return m_weights[triIndex(m_ord, i, j)];
+  }
+
+  /*!
+   * \brief Set the weight at a specific index for a rational Bezier triangle
+   *
+   * \param [in] i First control net index
+   * \param [in] j Second control net index
+   * \param [in] weight The updated value of the weight
+   * \pre Requires that the triangle be rational
+   * \pre Requires that the weight be positive
+   */
+  void setWeight(int i, int j, T weight)
+  {
+    SLIC_ASSERT(isRational());
+    SLIC_ASSERT(weight > T {0});
+    SLIC_ASSERT(isValidIndex(m_ord, i, j));
+    m_weights[triIndex(m_ord, i, j)] = weight;
   }
 
   /*!
@@ -1021,22 +1025,20 @@ public:
    * \param [in] u0 Parameter value along the \a u axis
    * \param [in] v0 Parameter value along the \a v axis
    *
-   * \pre u0 >= 0, v0 >= 0, and u0+v0 <= 1
-   *
    * \note Evaluation uses permuted barycentric coordinates such that
    *   parameter values (u0, v0) correspond to the triangle vertices:
    *     - `evaluate(0,0) == (*this)(0,0)`
    *     - `evaluate(0,1) == (*this)(0,order)`
    *     - `evaluate(1,0) == (*this)(order,0)`
    *
+   * \warning Will automatically extrapolate if (u0, v0) are outside the triangular
+   *            domain (u0 >= 0, v0 >= 0, and u0+v0 <= 1)
+   * 
    * \return Point value S(u0,v0)
    */
   PointType evaluate(T u0, T v0) const
   {
     SLIC_ASSERT(m_ord >= 0);
-    SLIC_ASSERT(u0 >= T(0));
-    SLIC_ASSERT(v0 >= T(0));
-    SLIC_ASSERT(u0 + v0 <= T(1));
 
     if(!isRational())
     {
@@ -1063,7 +1065,8 @@ public:
               const auto& A = dCarray[triIndex(end, i, j)];
               const auto& B = dCarray[triIndex(end, i, j + 1)];
               const auto& C = dCarray[triIndex(end, i + 1, j)];
-              dCarray[triIndex(end - 1, i, j)] = A + u0 * (C - A) + v0 * (B - A);
+              dCarray[triIndex(end - 1, i, j)] =
+                triInterpolate(A, B, C, Barycentric {1.0 - u0 - v0, v0, u0});
             }
           }
         }
@@ -1101,7 +1104,8 @@ public:
    * \param [out] Du First derivative S_u(u,v)
    * \param [out] Dv First derivative S_v(u,v)
    *
-   * \pre u0 >= 0, v0 >= 0, and u0+v0 <= 1
+   * \warning Will automatically extrapolate if (u0, v0) are outside the triangular
+   *            domain (u0 >= 0, v0 >= 0, and u0+v0 <= 1)
    */
   void evaluateFirstDerivatives(T u0,
                                 T v0,
@@ -1110,9 +1114,6 @@ public:
                                 Vector<T, NDIMS>& Dv) const
   {
     SLIC_ASSERT(m_ord >= 0);
-    SLIC_ASSERT(u0 >= T(0));
-    SLIC_ASSERT(v0 >= T(0));
-    SLIC_ASSERT(u0 + v0 <= T(1));
 
     if(m_ord == 0)
     {
@@ -1148,7 +1149,8 @@ public:
               const auto& A = dCarray[triIndex(end, i, j)];
               const auto& B = dCarray[triIndex(end, i, j + 1)];
               const auto& C = dCarray[triIndex(end, i + 1, j)];
-              dCarray[triIndex(end - 1, i, j)] = A + u0 * (C - A) + v0 * (B - A);
+              dCarray[triIndex(end - 1, i, j)] =
+                triInterpolate(A, B, C, Barycentric {1.0 - u0 - v0, v0, u0});
             }
           }
         }
@@ -1196,6 +1198,9 @@ public:
    * \param [out] Du The vector value of S_u(u, v)
    * \param [out] Dv The vector value of S_v(u, v)
    * \param [out] DuDv The vector value of S_uv(u, v) == S_vu(u, v)
+   *
+   * \warning Will automatically extrapolate if (u0, v0) are outside the triangular
+   *            domain (u0 >= 0, v0 >= 0, and u0+v0 <= 1)
    */
   void evaluateLinearDerivatives(T u0,
                                  T v0,
@@ -1205,9 +1210,6 @@ public:
                                  Vector<T, NDIMS>& DuDv) const
   {
     SLIC_ASSERT(m_ord >= 0);
-    SLIC_ASSERT(u0 >= T(0));
-    SLIC_ASSERT(v0 >= T(0));
-    SLIC_ASSERT(u0 + v0 <= T(1));
 
     if(!isRational())
     {
@@ -1245,7 +1247,8 @@ public:
               const auto& A = dCarray[triIndex(end, i, j)];
               const auto& B = dCarray[triIndex(end, i, j + 1)];
               const auto& C = dCarray[triIndex(end, i + 1, j)];
-              dCarray[triIndex(end - 1, i, j)] = A + u0 * (C - A) + v0 * (B - A);
+              dCarray[triIndex(end - 1, i, j)] =
+                triInterpolate(A, B, C, Barycentric {1.0 - u0 - v0, v0, u0});
             }
           }
         }
@@ -1305,6 +1308,9 @@ public:
    * \param [out] DuDu The vector value of S_uu(u, v)
    * \param [out] DvDv The vector value of S_vv(u, v)
    * \param [out] DuDv The vector value of S_uv(u, v) == S_vu(u, v)
+   * 
+   * \warning Will automatically extrapolate if (u0, v0) are outside the triangular
+   *            domain (u0 >= 0, v0 >= 0, and u0+v0 <= 1)
    */
   void evaluateSecondDerivatives(T u0,
                                  T v0,
@@ -1316,9 +1322,6 @@ public:
                                  Vector<T, NDIMS>& DuDv) const
   {
     SLIC_ASSERT(m_ord >= 0);
-    SLIC_ASSERT(u0 >= T(0));
-    SLIC_ASSERT(v0 >= T(0));
-    SLIC_ASSERT(u0 + v0 <= T(1));
 
     if(m_ord == 0)
     {
@@ -1372,7 +1375,8 @@ public:
               const auto& A = dCarray[triIndex(end, i, j)];
               const auto& B = dCarray[triIndex(end, i, j + 1)];
               const auto& C = dCarray[triIndex(end, i + 1, j)];
-              dCarray[triIndex(end - 1, i, j)] = A + u0 * (C - A) + v0 * (B - A);
+              dCarray[triIndex(end - 1, i, j)] =
+                triInterpolate(A, B, C, Barycentric {1.0 - u0 - v0, v0, u0});
             }
           }
         }
@@ -1544,6 +1548,27 @@ public:
     return static_cast<size_t>(i * (2 * ord + 3 - i) / 2 + j);
   }
 
+  /// \brief Check if a given index is valid in the triangular array
+  static constexpr bool isValidIndex(int ord, int i, int j)
+  {
+    return (i >= 0) && (j >= 0) && (i + j <= ord);
+  }
+
+  /// \brief Do a triangular interpolation from three points and a barycentric coordinate
+  static constexpr PointType triInterpolate(const PointType& A,
+                                            const PointType& B,
+                                            const PointType& C,
+                                            const Barycentric& Q)
+  {
+    return PointType {Q[0] * A.array() + Q[1] * B.array() + Q[2] * C.array()};
+  }
+
+  /// \brief Do a triangular interpolation from three coordinates and a barycentric coordinate
+  static constexpr T triInterpolate(const T& A, const T& B, const T& C, const Barycentric& Q)
+  {
+    return Q[0] * A + Q[1] * B + Q[2] * C;
+  }
+
 private:
   /// \brief Check that each weight is positive and the size matches control nodes
   bool is_valid_rational() const
@@ -1569,26 +1594,10 @@ private:
     return true;
   }
 
-  /// \brief For a rational triangle, fill triangle objects with weighted control points and weights
-  void fill_projective_triangles(BezierTriangle<T, NDIMS>& projective,
-                                 BezierTriangle<T, 1>& weights) const
+  /// \brief Check if the given coordinates are interior to the triangle
+  bool is_valid_interior_parameter(T u0, T v0) const
   {
-    SLIC_ASSERT(isRational());
-    SLIC_ASSERT(is_valid_rational());
-
-    for(int i = 0; i <= m_ord; ++i)
-    {
-      for(int j = 0; j <= m_ord - i; ++j)
-      {
-        const T w = m_weights[triIndex(m_ord, i, j)];
-        weights(i, j)[0] = w;
-
-        for(int N = 0; N < NDIMS; ++N)
-        {
-          projective(i, j)[N] = (*this)(i, j)[N] * w;
-        }
-      }
-    }
+    return (u0 > T {0}) && (v0 > T {0}) && (u0 + v0 < T {1});
   }
 
   /*!
@@ -1787,19 +1796,44 @@ private:
     SLIC_ASSERT(ord == weights.getOrder());
 
     out.setOrder(ord);
-    out.getWeights().resize(triSize(ord));
+    out.makeRational();
 
     for(int i = 0; i <= ord; ++i)
     {
       for(int j = 0; j <= ord - i; ++j)
       {
-        const T w = weights(i, j)[0];
+        const int idx = triIndex(ord, i, j);
+        const T w = weights.m_controlPoints[idx][0];
+
         SLIC_ASSERT(w > T(0));
-        out.getWeights()[triIndex(ord, i, j)] = w;
+        out.m_weights[idx] = w;
 
         for(int N = 0; N < NDIMS; ++N)
         {
-          out(i, j)[N] = projective(i, j)[N] / w;
+          out.m_controlPoints[idx][N] = projective.m_controlPoints[idx][N] / w;
+        }
+      }
+    }
+  }
+
+  /// \brief For a rational triangle, fill triangle objects with weighted control points and weights
+  void fill_projective_triangles(BezierTriangle<T, NDIMS>& projective,
+                                 BezierTriangle<T, 1>& weights) const
+  {
+    SLIC_ASSERT(isRational());
+    SLIC_ASSERT(is_valid_rational());
+
+    for(int i = 0; i <= m_ord; ++i)
+    {
+      for(int j = 0; j <= m_ord - i; ++j)
+      {
+        const int idx = triIndex(m_ord, i, j);
+        const T w = m_weights[idx];
+        weights.m_controlPoints[idx][0] = w;
+
+        for(int N = 0; N < NDIMS; ++N)
+        {
+          projective.m_controlPoints[idx][N] = m_controlPoints[idx][N] * w;
         }
       }
     }

--- a/src/axom/primal/geometry/BezierTriangle.hpp
+++ b/src/axom/primal/geometry/BezierTriangle.hpp
@@ -852,7 +852,6 @@ public:
   {
     SLIC_ASSERT(m_ord >= 0);
     const int n = m_ord;
-    const int triN = triSize(n);
 
     t0.setOrder(n);
     t1.setOrder(n);

--- a/src/axom/primal/tests/CMakeLists.txt
+++ b/src/axom/primal/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set( primal_tests
     primal_bezier_curve.cpp
     primal_bezier_intersect.cpp
     primal_bezier_patch.cpp
+    primal_bezier_triangle.cpp
     primal_boundingbox.cpp
     primal_bounding_box_intersect.cpp
     primal_clip.cpp

--- a/src/axom/primal/tests/primal_bezier_patch.cpp
+++ b/src/axom/primal/tests/primal_bezier_patch.cpp
@@ -822,7 +822,7 @@ TEST(primal_bezierpatch, rational_batch_derivatives)
     BezierPatchType patch(controlPoints, weights, order_u, order_v);
 
     patch.evaluateFirstDerivatives(u, v, batch1_val, batch1_du, batch1_dv);
-    patch.evaluate_linear_derivatives(u, v, batch2_val, batch2_du, batch2_dv, batch2_dudv);
+    patch.evaluateLinearDerivatives(u, v, batch2_val, batch2_du, batch2_dv, batch2_dudv);
     patch.evaluateSecondDerivatives(u,
                                     v,
                                     batch3_val,
@@ -855,7 +855,7 @@ TEST(primal_bezierpatch, rational_batch_derivatives)
     patch.swapAxes();
 
     patch.evaluateFirstDerivatives(u, v, batch1_val, batch1_du, batch1_dv);
-    patch.evaluate_linear_derivatives(u, v, batch2_val, batch2_du, batch2_dv, batch2_dudv);
+    patch.evaluateLinearDerivatives(u, v, batch2_val, batch2_du, batch2_dv, batch2_dudv);
     patch.evaluateSecondDerivatives(u,
                                     v,
                                     batch3_val,

--- a/src/axom/primal/tests/primal_bezier_triangle.cpp
+++ b/src/axom/primal/tests/primal_bezier_triangle.cpp
@@ -16,9 +16,44 @@
 #include "axom/primal/geometry/BezierTriangle.hpp"
 
 #include <array>
-#include <iterator>
 
 namespace primal = axom::primal;
+
+namespace
+{
+template <typename BTri>
+void fillControlNet(BTri& tri)
+{
+  // Fills the BezierTriangle with sample data
+  using CoordType = typename BTri::PointType::CoordType;
+  using PointType = typename BTri::PointType;
+
+  const int ord = tri.getOrder();
+  for(int i = 0; i <= ord; ++i)
+  {
+    for(int j = 0; j <= ord - i; ++j)
+    {
+      const auto ii = static_cast<CoordType>(i);
+      const auto jj = static_cast<CoordType>(j);
+      tri(i, j) = PointType {ii, jj, 10.0 * ii - 3.0 * jj};
+    }
+  }
+}
+
+template <typename BTri>
+void makeRational(BTri& tri)
+{
+  using CoordType = typename BTri::PointType::CoordType;
+
+  tri.getWeights().resize(tri.getControlPoints().size());
+  for(int k = 0; k < tri.getWeights().size(); ++k)
+  {
+    // Positive, non-uniform weights
+    tri.getWeights()[k] = static_cast<CoordType>(0.5 + 0.25 * k);
+  }
+  EXPECT_TRUE(tri.isRational());
+}
+}  // namespace
 
 //------------------------------------------------------------------------------
 TEST(primal_beziertriangle, sizing_constructors)
@@ -438,15 +473,7 @@ TEST(primal_beziertriangle, split_interior_polynomial)
   constexpr int ord = 3;
   BTri tri(ord);
 
-  for(int i = 0; i <= ord; ++i)
-  {
-    for(int j = 0; j <= ord - i; ++j)
-    {
-      const auto ii = static_cast<CoordType>(i);
-      const auto jj = static_cast<CoordType>(j);
-      tri(i, j) = PointType {ii, jj, 10.0 * ii - 3.0 * jj};
-    }
-  }
+  fillControlNet(tri);
 
   const CoordType u = 0.2;
   const CoordType v = 0.3;
@@ -527,6 +554,99 @@ TEST(primal_beziertriangle, split_interior_polynomial)
 }
 
 //------------------------------------------------------------------------------
+TEST(primal_beziertriangle, split_interior_rational)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using BTri = primal::BezierTriangle<CoordType, DIM>;
+
+  constexpr int ord = 3;
+  BTri tri(ord);
+  fillControlNet(tri);
+  makeRational(tri);
+
+  const CoordType u = 0.2;
+  const CoordType v = 0.3;
+
+  BTri t0, t1, t2;
+  tri.split(u, v, t0, t1, t2);
+
+  EXPECT_EQ(ord, t0.getOrder());
+  EXPECT_EQ(ord, t1.getOrder());
+  EXPECT_EQ(ord, t2.getOrder());
+  EXPECT_TRUE(t0.isRational());
+  EXPECT_TRUE(t1.isRational());
+  EXPECT_TRUE(t2.isRational());
+  EXPECT_EQ(BTri::triSize(ord), t0.getWeights().size());
+  EXPECT_EQ(BTri::triSize(ord), t1.getWeights().size());
+  EXPECT_EQ(BTri::triSize(ord), t2.getWeights().size());
+
+  // Vertex mapping checks
+  const auto pA = tri.evaluate(0.0, 0.0);
+  const auto pB = tri.evaluate(0.0, 1.0);
+  const auto pC = tri.evaluate(1.0, 0.0);
+  const auto pQ = tri.evaluate(u, v);
+
+  for(int i = 0; i < DIM; ++i)
+  {
+    // t0 -> (B, C, Q)
+    EXPECT_NEAR(pB[i], t0.evaluate(0.0, 0.0)[i], 1e-10);
+    EXPECT_NEAR(pC[i], t0.evaluate(0.0, 1.0)[i], 1e-10);
+    EXPECT_NEAR(pQ[i], t0.evaluate(1.0, 0.0)[i], 1e-10);
+
+    // t1 -> (C, A, Q)
+    EXPECT_NEAR(pC[i], t1.evaluate(0.0, 0.0)[i], 1e-10);
+    EXPECT_NEAR(pA[i], t1.evaluate(0.0, 1.0)[i], 1e-10);
+    EXPECT_NEAR(pQ[i], t1.evaluate(1.0, 0.0)[i], 1e-10);
+
+    // t2 -> (A, B, Q)
+    EXPECT_NEAR(pA[i], t2.evaluate(0.0, 0.0)[i], 1e-10);
+    EXPECT_NEAR(pB[i], t2.evaluate(0.0, 1.0)[i], 1e-10);
+    EXPECT_NEAR(pQ[i], t2.evaluate(1.0, 0.0)[i], 1e-10);
+  }
+
+  // Interior point checks via affine parameter mapping
+  const CoordType s = 0.2;
+  const CoordType t = 0.1;
+
+  // t0 is over vertices (0,1), (1,0), (u,v)
+  {
+    const CoordType u2 = s * u + t;
+    const CoordType v2 = 1.0 + s * (v - 1.0) - t;
+    const auto expected = tri.evaluate(u2, v2);
+    const auto actual = t0.evaluate(s, t);
+    for(int d = 0; d < DIM; ++d)
+    {
+      EXPECT_NEAR(expected[d], actual[d], 1e-12);
+    }
+  }
+
+  // t1 is over vertices (1,0), (0,0), (u,v)
+  {
+    const CoordType u3 = 1.0 + s * (u - 1.0) - t;
+    const CoordType v3 = s * v;
+    const auto expected = tri.evaluate(u3, v3);
+    const auto actual = t1.evaluate(s, t);
+    for(int d = 0; d < DIM; ++d)
+    {
+      EXPECT_NEAR(expected[d], actual[d], 1e-12);
+    }
+  }
+
+  // t2 is over vertices (0,0), (0,1), (u,v)
+  {
+    const CoordType u1 = s * u;
+    const CoordType v1 = t + s * v;
+    const auto expected = tri.evaluate(u1, v1);
+    const auto actual = t2.evaluate(s, t);
+    for(int d = 0; d < DIM; ++d)
+    {
+      EXPECT_NEAR(expected[d], actual[d], 1e-12);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
 TEST(primal_beziertriangle, split_edge_polynomial)
 {
   constexpr int DIM = 3;
@@ -537,15 +657,7 @@ TEST(primal_beziertriangle, split_edge_polynomial)
   constexpr int ord = 3;
   BTri tri(ord);
 
-  for(int i = 0; i <= ord; ++i)
-  {
-    for(int j = 0; j <= ord - i; ++j)
-    {
-      const auto ii = static_cast<CoordType>(i);
-      const auto jj = static_cast<CoordType>(j);
-      tri(i, j) = PointType {ii, jj, 10.0 * ii - 3.0 * jj};
-    }
-  }
+  fillControlNet(tri);
 
   const auto pA = tri.evaluate(0.0, 0.0);
   const auto pB = tri.evaluate(0.0, 1.0);
@@ -585,7 +697,7 @@ TEST(primal_beziertriangle, split_edge_polynomial)
 }
 
 //------------------------------------------------------------------------------
-TEST(primal_beziertriangle, split_triforce_polynomial)
+TEST(primal_beziertriangle, split_edge_rational)
 {
   constexpr int DIM = 3;
   using CoordType = double;
@@ -594,16 +706,59 @@ TEST(primal_beziertriangle, split_triforce_polynomial)
 
   constexpr int ord = 3;
   BTri tri(ord);
+  fillControlNet(tri);
+  makeRational(tri);
 
-  for(int i = 0; i <= ord; ++i)
+  const auto pA = tri.evaluate(0.0, 0.0);
+  const auto pB = tri.evaluate(0.0, 1.0);
+  const auto pC = tri.evaluate(1.0, 0.0);
+
+  axom::Array<PointType> vertices {pA, pB, pC};
+
+  const CoordType s = 0.35;
+
+  BTri t0, t1;
+
+  for(int i = 0; i < 3; ++i)
   {
-    for(int j = 0; j <= ord - i; ++j)
+    tri.split(i, s, t0, t1);
+
+    EXPECT_EQ(ord, t0.getOrder());
+    EXPECT_EQ(ord, t1.getOrder());
+    EXPECT_TRUE(t0.isRational());
+    EXPECT_TRUE(t1.isRational());
+    EXPECT_EQ(BTri::triSize(ord), t0.getWeights().size());
+    EXPECT_EQ(BTri::triSize(ord), t1.getWeights().size());
+
+    // Vertex mapping checks
+    const auto pQ = tri.getEdge(i).evaluate(s);
+
+    for(int N = 0; N < DIM; ++N)
     {
-      const auto ii = static_cast<CoordType>(i);
-      const auto jj = static_cast<CoordType>(j);
-      tri(i, j) = PointType {ii, jj, 10.0 * ii - 3.0 * jj};
+      EXPECT_NEAR(vertices[(i + 0) % 3][N], t0.evaluate(0.0, 0.0)[N], 1e-10);
+      EXPECT_NEAR(vertices[(i + 1) % 3][N], t0.evaluate(0.0, 1.0)[N], 1e-10);
+
+      EXPECT_NEAR(vertices[(i + 2) % 3][N], t1.evaluate(0.0, 0.0)[N], 1e-10);
+      EXPECT_NEAR(vertices[(i + 0) % 3][N], t1.evaluate(0.0, 1.0)[N], 1e-10);
+
+      // Subtriangles agree at the last vertex
+      EXPECT_NEAR(pQ[N], t0.evaluate(1.0, 0.0)[N], 1e-10);
+      EXPECT_NEAR(pQ[N], t1.evaluate(1.0, 0.0)[N], 1e-10);
     }
   }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_beziertriangle, split_fourway_polynomial)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using BTri = primal::BezierTriangle<CoordType, DIM>;
+
+  constexpr int ord = 3;
+  BTri tri(ord);
+
+  fillControlNet(tri);
 
   const CoordType s0 = 0.25;  // edge0: B->C
   const CoordType s1 = 0.6;   // edge1: C->A
@@ -668,6 +823,204 @@ TEST(primal_beziertriangle, split_triforce_polynomial)
     EXPECT_NEAR(eP0P2_from_t2[d], eP0P2_from_t4[d], 1e-12);
     EXPECT_NEAR(eP2P1_from_t1[d], eP2P1_from_t4[d], 1e-12);
     EXPECT_NEAR(eP1P0_from_t3[d], eP1P0_from_t4[d], 1e-12);
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_beziertriangle, split_fourway_rational)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using BTri = primal::BezierTriangle<CoordType, DIM>;
+
+  constexpr int ord = 3;
+  BTri tri(ord);
+  fillControlNet(tri);
+  makeRational(tri);
+
+  const CoordType s0 = 0.25;  // edge0: B->C
+  const CoordType s1 = 0.6;   // edge1: C->A
+  const CoordType s2 = 0.4;   // edge2: A->B
+
+  BTri t1, t2, t3, t4;
+  tri.split(s0, s1, s2, t1, t2, t3, t4);
+
+  EXPECT_EQ(ord, t1.getOrder());
+  EXPECT_EQ(ord, t2.getOrder());
+  EXPECT_EQ(ord, t3.getOrder());
+  EXPECT_EQ(ord, t4.getOrder());
+  EXPECT_TRUE(t1.isRational());
+  EXPECT_TRUE(t2.isRational());
+  EXPECT_TRUE(t3.isRational());
+  EXPECT_TRUE(t4.isRational());
+
+  const auto pA = tri.evaluate(0.0, 0.0);
+  const auto pB = tri.evaluate(0.0, 1.0);
+  const auto pC = tri.evaluate(1.0, 0.0);
+
+  const auto pP0 = tri.getEdge(0).evaluate(s0);
+  const auto pP1 = tri.getEdge(1).evaluate(s1);
+  const auto pP2 = tri.getEdge(2).evaluate(s2);
+
+  for(int d = 0; d < DIM; ++d)
+  {
+    // t1 = Tri(A, P2, P1)
+    EXPECT_NEAR(pA[d], t1.evaluate(0.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pP2[d], t1.evaluate(0.0, 1.0)[d], 1e-10);
+    EXPECT_NEAR(pP1[d], t1.evaluate(1.0, 0.0)[d], 1e-10);
+
+    // t2 = Tri(B, P0, P2)
+    EXPECT_NEAR(pB[d], t2.evaluate(0.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pP0[d], t2.evaluate(0.0, 1.0)[d], 1e-10);
+    EXPECT_NEAR(pP2[d], t2.evaluate(1.0, 0.0)[d], 1e-10);
+
+    // t3 = Tri(C, P1, P0)
+    EXPECT_NEAR(pC[d], t3.evaluate(0.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pP1[d], t3.evaluate(0.0, 1.0)[d], 1e-10);
+    EXPECT_NEAR(pP0[d], t3.evaluate(1.0, 0.0)[d], 1e-10);
+
+    // t4 = Tri(P1, P0, P2)
+    EXPECT_NEAR(pP1[d], t4.evaluate(0.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pP0[d], t4.evaluate(0.0, 1.0)[d], 1e-10);
+    EXPECT_NEAR(pP2[d], t4.evaluate(1.0, 0.0)[d], 1e-10);
+  }
+
+  // Shared interior edges agree
+  const CoordType s = 0.37;
+  const auto eP0P2_from_t2 = t2.getEdge(0).evaluate(s);  // P0 -> P2
+  const auto eP0P2_from_t4 = t4.getEdge(0).evaluate(s);  // P0 -> P2
+
+  const auto eP2P1_from_t1 = t1.getEdge(0).evaluate(s);  // P2 -> P1
+  const auto eP2P1_from_t4 = t4.getEdge(1).evaluate(s);  // P2 -> P1
+
+  const auto eP1P0_from_t3 = t3.getEdge(0).evaluate(s);  // P1 -> P0
+  const auto eP1P0_from_t4 = t4.getEdge(2).evaluate(s);  // P1 -> P0
+
+  for(int d = 0; d < DIM; ++d)
+  {
+    EXPECT_NEAR(eP0P2_from_t2[d], eP0P2_from_t4[d], 1e-12);
+    EXPECT_NEAR(eP2P1_from_t1[d], eP2P1_from_t4[d], 1e-12);
+    EXPECT_NEAR(eP1P0_from_t3[d], eP1P0_from_t4[d], 1e-12);
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_beziertriangle, uniformSplit_fourway_polynomial)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using BTri = primal::BezierTriangle<CoordType, DIM>;
+  using PointType = BTri::PointType;
+
+  constexpr int ord = 3;
+  BTri tri(ord);
+
+  fillControlNet(tri);
+
+  BTri t1, t2, t3, t4;
+  tri.uniformSplit(t1, t2, t3, t4);
+
+  // Compare against the general (non-optimized) split at s=0.5.
+  BTri r1, r2, r3, r4;
+  tri.split(0.5, 0.5, 0.5, r1, r2, r3, r4);
+
+  const auto pP0 = tri.getEdge(0).evaluate(0.5);
+  const auto pP1 = tri.getEdge(1).evaluate(0.5);
+  const auto pP2 = tri.getEdge(2).evaluate(0.5);
+
+  for(int d = 0; d < DIM; ++d)
+  {
+    EXPECT_NEAR(pP1[d], t4.evaluate(0.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pP0[d], t4.evaluate(0.0, 1.0)[d], 1e-10);
+    EXPECT_NEAR(pP2[d], t4.evaluate(1.0, 0.0)[d], 1e-10);
+  }
+
+  const CoordType s = 0.23;
+  const CoordType t = 0.17;
+  const auto p11 = t1.evaluate(s, t);
+  const auto p12 = r1.evaluate(s, t);
+  const auto p21 = t2.evaluate(s, t);
+  const auto p22 = r2.evaluate(s, t);
+  const auto p31 = t3.evaluate(s, t);
+  const auto p32 = r3.evaluate(s, t);
+  const auto p41 = t4.evaluate(s, t);
+  const auto p42 = r4.evaluate(s, t);
+
+  for(int d = 0; d < DIM; ++d)
+  {
+    EXPECT_NEAR(p11[d], p12[d], 1e-12);
+    EXPECT_NEAR(p21[d], p22[d], 1e-12);
+    EXPECT_NEAR(p31[d], p32[d], 1e-12);
+    EXPECT_NEAR(p41[d], p42[d], 1e-12);
+  }
+
+  // Also confirm vertex ordering matches the general split for s=0.5
+  for(int d = 0; d < DIM; ++d)
+  {
+    EXPECT_NEAR(t1.evaluate(0.0, 0.0)[d], r1.evaluate(0.0, 0.0)[d], 1e-12);
+    EXPECT_NEAR(t1.evaluate(0.0, 1.0)[d], r1.evaluate(0.0, 1.0)[d], 1e-12);
+    EXPECT_NEAR(t1.evaluate(1.0, 0.0)[d], r1.evaluate(1.0, 0.0)[d], 1e-12);
+
+    EXPECT_NEAR(t2.evaluate(0.0, 0.0)[d], r2.evaluate(0.0, 0.0)[d], 1e-12);
+    EXPECT_NEAR(t2.evaluate(0.0, 1.0)[d], r2.evaluate(0.0, 1.0)[d], 1e-12);
+    EXPECT_NEAR(t2.evaluate(1.0, 0.0)[d], r2.evaluate(1.0, 0.0)[d], 1e-12);
+
+    EXPECT_NEAR(t3.evaluate(0.0, 0.0)[d], r3.evaluate(0.0, 0.0)[d], 1e-12);
+    EXPECT_NEAR(t3.evaluate(0.0, 1.0)[d], r3.evaluate(0.0, 1.0)[d], 1e-12);
+    EXPECT_NEAR(t3.evaluate(1.0, 0.0)[d], r3.evaluate(1.0, 0.0)[d], 1e-12);
+
+    EXPECT_NEAR(t4.evaluate(0.0, 0.0)[d], r4.evaluate(0.0, 0.0)[d], 1e-12);
+    EXPECT_NEAR(t4.evaluate(0.0, 1.0)[d], r4.evaluate(0.0, 1.0)[d], 1e-12);
+    EXPECT_NEAR(t4.evaluate(1.0, 0.0)[d], r4.evaluate(1.0, 0.0)[d], 1e-12);
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_beziertriangle, uniformSplit_fourway_rational)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using BTri = primal::BezierTriangle<CoordType, DIM>;
+
+  constexpr int ord = 3;
+  BTri tri(ord);
+  fillControlNet(tri);
+  makeRational(tri);
+
+  BTri t1, t2, t3, t4;
+  tri.uniformSplit(t1, t2, t3, t4);
+
+  EXPECT_TRUE(t1.isRational());
+  EXPECT_TRUE(t2.isRational());
+  EXPECT_TRUE(t3.isRational());
+  EXPECT_TRUE(t4.isRational());
+
+  // Compare against the general (non-optimized) split at s=0.5.
+  BTri r1, r2, r3, r4;
+  tri.split(0.5, 0.5, 0.5, r1, r2, r3, r4);
+
+  EXPECT_TRUE(r1.isRational());
+  EXPECT_TRUE(r2.isRational());
+  EXPECT_TRUE(r3.isRational());
+  EXPECT_TRUE(r4.isRational());
+
+  const CoordType s = 0.23;
+  const CoordType t = 0.17;
+  const auto p11 = t1.evaluate(s, t);
+  const auto p12 = r1.evaluate(s, t);
+  const auto p21 = t2.evaluate(s, t);
+  const auto p22 = r2.evaluate(s, t);
+  const auto p31 = t3.evaluate(s, t);
+  const auto p32 = r3.evaluate(s, t);
+  const auto p41 = t4.evaluate(s, t);
+  const auto p42 = r4.evaluate(s, t);
+
+  for(int d = 0; d < DIM; ++d)
+  {
+    EXPECT_NEAR(p11[d], p12[d], 1e-12);
+    EXPECT_NEAR(p21[d], p22[d], 1e-12);
+    EXPECT_NEAR(p31[d], p32[d], 1e-12);
+    EXPECT_NEAR(p41[d], p42[d], 1e-12);
   }
 }
 

--- a/src/axom/primal/tests/primal_bezier_triangle.cpp
+++ b/src/axom/primal/tests/primal_bezier_triangle.cpp
@@ -468,7 +468,6 @@ TEST(primal_beziertriangle, split_interior_polynomial)
   constexpr int DIM = 3;
   using CoordType = double;
   using BTri = primal::BezierTriangle<CoordType, DIM>;
-  using PointType = BTri::PointType;
 
   constexpr int ord = 3;
   BTri tri(ord);
@@ -914,7 +913,6 @@ TEST(primal_beziertriangle, uniformSplit_fourway_polynomial)
   constexpr int DIM = 3;
   using CoordType = double;
   using BTri = primal::BezierTriangle<CoordType, DIM>;
-  using PointType = BTri::PointType;
 
   constexpr int ord = 3;
   BTri tri(ord);

--- a/src/axom/primal/tests/primal_bezier_triangle.cpp
+++ b/src/axom/primal/tests/primal_bezier_triangle.cpp
@@ -351,3 +351,335 @@ TEST(primal_beziertriangle, rational_triangles)
   check_at(0.2, 0.3);
   check_at(0.6, 0.1);
 }
+
+//------------------------------------------------------------------------------
+TEST(primal_beziertriangle, edges)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using BTri = primal::BezierTriangle<CoordType, DIM>;
+  using PointType = BTri::PointType;
+
+  constexpr int ord = 3;
+  BTri poly(ord);
+  BTri rat(ord);
+  rat.getWeights().resize(rat.getControlPoints().size());
+
+  for(int i = 0; i <= ord; ++i)
+  {
+    for(int j = 0; j <= ord - i; ++j)
+    {
+      const int idx = BTri::triIndex(ord, i, j);
+      const auto ii = static_cast<CoordType>(i);
+      const auto jj = static_cast<CoordType>(j);
+      poly(i, j) = PointType {ii, jj, 100. * ii + jj};
+      rat(i, j) = poly(i, j);
+      rat.getWeights()[idx] = 0.25 + idx;
+    }
+  }
+
+  // edge 0: u + v = 1, from (0,1) to (ord,0)
+  {
+    const auto e0 = poly.getEdge(0);
+    EXPECT_EQ(ord, e0.getOrder());
+    EXPECT_FALSE(e0.isRational());
+    EXPECT_EQ(ord + 1, e0.getNumControlPoints());
+    EXPECT_EQ(poly(0, ord), e0.getInitPoint());
+    EXPECT_EQ(poly(ord, 0), e0.getEndPoint());
+  }
+
+  // edge 1: v = 0, from (ord,0) to (0,0)
+  {
+    const auto e1 = poly.getEdge(1);
+    EXPECT_EQ(ord, e1.getOrder());
+    EXPECT_FALSE(e1.isRational());
+    EXPECT_EQ(ord + 1, e1.getNumControlPoints());
+    EXPECT_EQ(poly(ord, 0), e1.getInitPoint());
+    EXPECT_EQ(poly(0, 0), e1.getEndPoint());
+  }
+
+  // edge 2: u = 0, from (0,0) to (0,ord)
+  {
+    const auto e2 = poly.getEdge(2);
+    EXPECT_EQ(ord, e2.getOrder());
+    EXPECT_FALSE(e2.isRational());
+    EXPECT_EQ(ord + 1, e2.getNumControlPoints());
+    EXPECT_EQ(poly(0, 0), e2.getInitPoint());
+    EXPECT_EQ(poly(0, ord), e2.getEndPoint());
+  }
+
+  // weight propagation to rational edge curves
+  {
+    const auto e0 = rat.getEdge(0);
+    EXPECT_TRUE(e0.isRational());
+    EXPECT_EQ(ord, e0.getOrder());
+    ASSERT_EQ(ord + 1, e0.getWeights().size());
+
+    const auto e1 = rat.getEdge(1);
+    EXPECT_TRUE(e1.isRational());
+    EXPECT_EQ(ord, e1.getOrder());
+    ASSERT_EQ(ord + 1, e1.getWeights().size());
+
+    const auto e2 = rat.getEdge(2);
+    EXPECT_TRUE(e2.isRational());
+    EXPECT_EQ(ord, e2.getOrder());
+    ASSERT_EQ(ord + 1, e2.getWeights().size());
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_beziertriangle, split_interior_polynomial)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using BTri = primal::BezierTriangle<CoordType, DIM>;
+  using PointType = BTri::PointType;
+
+  constexpr int ord = 3;
+  BTri tri(ord);
+
+  for(int i = 0; i <= ord; ++i)
+  {
+    for(int j = 0; j <= ord - i; ++j)
+    {
+      const auto ii = static_cast<CoordType>(i);
+      const auto jj = static_cast<CoordType>(j);
+      tri(i, j) = PointType {ii, jj, 10.0 * ii - 3.0 * jj};
+    }
+  }
+
+  const CoordType u = 0.2;
+  const CoordType v = 0.3;
+
+  BTri t0, t1, t2;
+  tri.split(u, v, t0, t1, t2);
+
+  EXPECT_EQ(ord, t0.getOrder());
+  EXPECT_EQ(ord, t1.getOrder());
+  EXPECT_EQ(ord, t2.getOrder());
+  EXPECT_FALSE(t0.isRational());
+  EXPECT_FALSE(t1.isRational());
+  EXPECT_FALSE(t2.isRational());
+
+  // Vertex mapping checks
+  const auto pA = tri.evaluate(0.0, 0.0);
+  const auto pB = tri.evaluate(0.0, 1.0);
+  const auto pC = tri.evaluate(1.0, 0.0);
+  const auto pQ = tri.evaluate(u, v);
+
+  for(int i = 0; i < DIM; ++i)
+  {
+    // t0 -> (B, C, Q)
+    EXPECT_NEAR(pB[i], t0.evaluate(0.0, 0.0)[i], 1e-10);
+    EXPECT_NEAR(pC[i], t0.evaluate(0.0, 1.0)[i], 1e-10);
+    EXPECT_NEAR(pQ[i], t0.evaluate(1.0, 0.0)[i], 1e-10);
+
+    // t1 -> (C, A, Q)
+    EXPECT_NEAR(pC[i], t1.evaluate(0.0, 0.0)[i], 1e-10);
+    EXPECT_NEAR(pA[i], t1.evaluate(0.0, 1.0)[i], 1e-10);
+    EXPECT_NEAR(pQ[i], t1.evaluate(1.0, 0.0)[i], 1e-10);
+
+    // t2 -> (A, B, Q)
+    EXPECT_NEAR(pA[i], t2.evaluate(0.0, 0.0)[i], 1e-10);
+    EXPECT_NEAR(pB[i], t2.evaluate(0.0, 1.0)[i], 1e-10);
+    EXPECT_NEAR(pQ[i], t2.evaluate(1.0, 0.0)[i], 1e-10);
+  }
+
+  // Interior point checks via affine parameter mapping
+  const CoordType s = 0.2;
+  const CoordType t = 0.1;
+
+  // t0 is over vertices (0,1), (1,0), (u,v)
+  {
+    const CoordType u2 = s * u + t;
+    const CoordType v2 = 1.0 + s * (v - 1.0) - t;
+    const auto expected = tri.evaluate(u2, v2);
+    const auto actual = t0.evaluate(s, t);
+    for(int d = 0; d < DIM; ++d)
+    {
+      EXPECT_NEAR(expected[d], actual[d], 1e-12);
+    }
+  }
+
+  // t1 is over vertices (1,0), (0,0), (u,v)
+  {
+    const CoordType u3 = 1.0 + s * (u - 1.0) - t;
+    const CoordType v3 = s * v;
+    const auto expected = tri.evaluate(u3, v3);
+    const auto actual = t1.evaluate(s, t);
+    for(int d = 0; d < DIM; ++d)
+    {
+      EXPECT_NEAR(expected[d], actual[d], 1e-12);
+    }
+  }
+
+  // t2 is over vertices (0,0), (0,1), (u,v)
+  {
+    const CoordType u1 = s * u;
+    const CoordType v1 = t + s * v;
+    const auto expected = tri.evaluate(u1, v1);
+    const auto actual = t2.evaluate(s, t);
+    for(int d = 0; d < DIM; ++d)
+    {
+      EXPECT_NEAR(expected[d], actual[d], 1e-12);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_beziertriangle, split_edge_polynomial)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using BTri = primal::BezierTriangle<CoordType, DIM>;
+  using PointType = BTri::PointType;
+
+  constexpr int ord = 3;
+  BTri tri(ord);
+
+  for(int i = 0; i <= ord; ++i)
+  {
+    for(int j = 0; j <= ord - i; ++j)
+    {
+      const auto ii = static_cast<CoordType>(i);
+      const auto jj = static_cast<CoordType>(j);
+      tri(i, j) = PointType {ii, jj, 10.0 * ii - 3.0 * jj};
+    }
+  }
+
+  const auto pA = tri.evaluate(0.0, 0.0);
+  const auto pB = tri.evaluate(0.0, 1.0);
+  const auto pC = tri.evaluate(1.0, 0.0);
+
+  axom::Array<PointType> vertices {pA, pB, pC};
+
+  const CoordType s = 0.35;
+
+  BTri t0, t1;
+
+  for(int i = 0; i < 3; ++i)
+  {
+    tri.split(i, s, t0, t1);
+
+    EXPECT_EQ(ord, t0.getOrder());
+    EXPECT_EQ(ord, t1.getOrder());
+    EXPECT_FALSE(t0.isRational());
+    EXPECT_FALSE(t1.isRational());
+
+    // Vertex mapping checks
+    const auto pQ = tri.getEdge(i).evaluate(s);
+
+    for(int N = 0; N < DIM; ++N)
+    {
+      EXPECT_NEAR(vertices[(i + 0) % 3][N], t0.evaluate(0.0, 0.0)[N], 1e-10);
+      EXPECT_NEAR(vertices[(i + 1) % 3][N], t0.evaluate(0.0, 1.0)[N], 1e-10);
+
+      EXPECT_NEAR(vertices[(i + 2) % 3][N], t1.evaluate(0.0, 0.0)[N], 1e-10);
+      EXPECT_NEAR(vertices[(i + 0) % 3][N], t1.evaluate(0.0, 1.0)[N], 1e-10);
+
+      // Subtriangles agree at the last vertex
+      EXPECT_NEAR(pQ[N], t0.evaluate(1.0, 0.0)[N], 1e-10);
+      EXPECT_NEAR(pQ[N], t1.evaluate(1.0, 0.0)[N], 1e-10);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_beziertriangle, split_triforce_polynomial)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using BTri = primal::BezierTriangle<CoordType, DIM>;
+  using PointType = BTri::PointType;
+
+  constexpr int ord = 3;
+  BTri tri(ord);
+
+  for(int i = 0; i <= ord; ++i)
+  {
+    for(int j = 0; j <= ord - i; ++j)
+    {
+      const auto ii = static_cast<CoordType>(i);
+      const auto jj = static_cast<CoordType>(j);
+      tri(i, j) = PointType {ii, jj, 10.0 * ii - 3.0 * jj};
+    }
+  }
+
+  const CoordType s0 = 0.25;  // edge0: B->C
+  const CoordType s1 = 0.6;   // edge1: C->A
+  const CoordType s2 = 0.4;   // edge2: A->B
+
+  BTri t1, t2, t3, t4;
+  tri.split(s0, s1, s2, t1, t2, t3, t4);
+
+  EXPECT_EQ(ord, t1.getOrder());
+  EXPECT_EQ(ord, t2.getOrder());
+  EXPECT_EQ(ord, t3.getOrder());
+  EXPECT_EQ(ord, t4.getOrder());
+  EXPECT_FALSE(t1.isRational());
+  EXPECT_FALSE(t2.isRational());
+  EXPECT_FALSE(t3.isRational());
+  EXPECT_FALSE(t4.isRational());
+
+  const auto pA = tri.evaluate(0.0, 0.0);
+  const auto pB = tri.evaluate(0.0, 1.0);
+  const auto pC = tri.evaluate(1.0, 0.0);
+
+  const auto pP0 = tri.getEdge(0).evaluate(s0);
+  const auto pP1 = tri.getEdge(1).evaluate(s1);
+  const auto pP2 = tri.getEdge(2).evaluate(s2);
+
+  for(int d = 0; d < DIM; ++d)
+  {
+    // t1 = Tri(A, P2, P1)
+    EXPECT_NEAR(pA[d], t1.evaluate(0.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pP2[d], t1.evaluate(0.0, 1.0)[d], 1e-10);
+    EXPECT_NEAR(pP1[d], t1.evaluate(1.0, 0.0)[d], 1e-10);
+
+    // t2 = Tri(B, P0, P2)
+    EXPECT_NEAR(pB[d], t2.evaluate(0.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pP0[d], t2.evaluate(0.0, 1.0)[d], 1e-10);
+    EXPECT_NEAR(pP2[d], t2.evaluate(1.0, 0.0)[d], 1e-10);
+
+    // t3 = Tri(C, P1, P0)
+    EXPECT_NEAR(pC[d], t3.evaluate(0.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pP1[d], t3.evaluate(0.0, 1.0)[d], 1e-10);
+    EXPECT_NEAR(pP0[d], t3.evaluate(1.0, 0.0)[d], 1e-10);
+
+    // t4 = Tri(P1, P0, P2)
+    EXPECT_NEAR(pP1[d], t4.evaluate(0.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pP0[d], t4.evaluate(0.0, 1.0)[d], 1e-10);
+    EXPECT_NEAR(pP2[d], t4.evaluate(1.0, 0.0)[d], 1e-10);
+  }
+
+  // Shared interior edges agree (same geometry and orientation for the chosen outputs)
+  const CoordType s = 0.37;
+  const auto eP0P2_from_t2 = t2.getEdge(0).evaluate(s);  // P0 -> P2
+  const auto eP0P2_from_t4 = t4.getEdge(0).evaluate(s);  // P0 -> P2
+
+  const auto eP2P1_from_t1 = t1.getEdge(0).evaluate(s);  // P2 -> P1
+  const auto eP2P1_from_t4 = t4.getEdge(1).evaluate(s);  // P2 -> P1
+
+  const auto eP1P0_from_t3 = t3.getEdge(0).evaluate(s);  // P1 -> P0
+  const auto eP1P0_from_t4 = t4.getEdge(2).evaluate(s);  // P1 -> P0
+
+  for(int d = 0; d < DIM; ++d)
+  {
+    EXPECT_NEAR(eP0P2_from_t2[d], eP0P2_from_t4[d], 1e-12);
+    EXPECT_NEAR(eP2P1_from_t1[d], eP2P1_from_t4[d], 1e-12);
+    EXPECT_NEAR(eP1P0_from_t3[d], eP1P0_from_t4[d], 1e-12);
+  }
+}
+
+int main(int argc, char* argv[])
+{
+  int result = 0;
+
+  ::testing::InitGoogleTest(&argc, argv);
+
+  axom::slic::SimpleLogger logger;
+
+  result = RUN_ALL_TESTS();
+
+  return result;
+}

--- a/src/axom/primal/tests/primal_bezier_triangle.cpp
+++ b/src/axom/primal/tests/primal_bezier_triangle.cpp
@@ -1,0 +1,353 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+// files for dates and other details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ * \file primal_bezier_triangle.cpp
+ * \brief This file tests primal's Bezier triangle functionality
+ */
+
+#include "gtest/gtest.h"
+
+#include "axom/slic.hpp"
+
+#include "axom/primal/geometry/BezierTriangle.hpp"
+
+#include <array>
+#include <iterator>
+
+namespace primal = axom::primal;
+
+//------------------------------------------------------------------------------
+TEST(primal_beziertriangle, sizing_constructors)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using BezierTriangleType = primal::BezierTriangle<CoordType, DIM>;
+  using CoordsVec = BezierTriangleType::CoordsVec;
+
+  // testing default BezierTriangle constructor
+  {
+    BezierTriangleType bTri;
+    EXPECT_FALSE(bTri.isRational());
+
+    EXPECT_EQ(-1, bTri.getOrder());
+    EXPECT_EQ(0, bTri.getControlPoints().size());
+    EXPECT_EQ(CoordsVec(), bTri.getControlPoints());
+  }
+
+  // testing BezierTriangle order constructor
+  for(int ord = -1; ord < 5; ++ord)
+  {
+    BezierTriangleType bTri(ord);
+    EXPECT_FALSE(bTri.isRational());
+
+    EXPECT_EQ(ord, bTri.getOrder());
+    EXPECT_EQ(BezierTriangleType::triSize(ord), bTri.getControlPoints().size());
+    EXPECT_EQ(0, bTri.getWeights().size());
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_beziertriangle, array_constructors)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using PointType = primal::Point<CoordType, DIM>;
+  using BezierTriangleType = primal::BezierTriangle<CoordType, DIM>;
+
+  SLIC_INFO("Testing BezierTriangle array constructors");
+
+  constexpr int ord = 2;
+  constexpr int npts = (ord + 1) * (ord + 2) / 2;
+
+  PointType controlPoints[npts];
+  CoordType weights[npts];
+
+  for(int i = 0; i <= ord; ++i)
+  {
+    for(int j = 0; j <= ord - i; ++j)
+    {
+      const int idx = BezierTriangleType::triIndex(ord, i, j);
+      controlPoints[idx] = PointType {static_cast<CoordType>(i),
+                                      static_cast<CoordType>(j),
+                                      static_cast<CoordType>(i + 2 * j)};
+      weights[idx] = static_cast<CoordType>(0.25 + idx);
+    }
+  }
+
+  auto check_triangle = [&](const BezierTriangleType& tri, bool expect_rational) {
+    EXPECT_EQ(ord, tri.getOrder());
+    EXPECT_EQ(npts, tri.getControlPoints().size());
+    EXPECT_EQ(expect_rational, tri.isRational());
+    EXPECT_EQ(expect_rational ? npts : 0, tri.getWeights().size());
+
+    for(int i = 0; i <= ord; ++i)
+    {
+      for(int j = 0; j <= ord - i; ++j)
+      {
+        const int idx = BezierTriangleType::triIndex(ord, i, j);
+        EXPECT_EQ(tri(i, j), controlPoints[idx]);
+        if(expect_rational)
+        {
+          EXPECT_EQ(tri.getWeights()[idx], weights[idx]);
+        }
+      }
+    }
+  };
+
+  // check C-array constructors
+  {
+    SCOPED_TRACE("Testing C-array constructor, polynomial");
+    BezierTriangleType nTri(controlPoints, ord);
+    check_triangle(nTri, false);
+
+    SCOPED_TRACE("Testing C-array constructor, polynomial w/ null weight");
+    BezierTriangleType nTri2(controlPoints, static_cast<const CoordType*>(nullptr), ord);
+    check_triangle(nTri2, false);
+
+    SCOPED_TRACE("Testing C-array constructor, rational");
+    BezierTriangleType rTri(controlPoints, weights, ord);
+    check_triangle(rTri, true);
+  }
+
+  // check ArrayView constructors (from C-arrays)
+  {
+    axom::ArrayView<PointType> cp(controlPoints, npts);
+    axom::ArrayView<CoordType> w(weights, npts);
+
+    SCOPED_TRACE("Testing ArrayView constructor, polynomial");
+    BezierTriangleType nTri(cp, axom::ArrayView<CoordType>(nullptr, 0), ord);
+    check_triangle(nTri, false);
+
+    SCOPED_TRACE("Testing ArrayView constructor, rational");
+    BezierTriangleType rTri(cp, w, ord);
+    check_triangle(rTri, true);
+  }
+
+  // check 1D Array constructors
+  {
+    axom::Array<PointType> cp;
+    cp.assign(std::begin(controlPoints), std::end(controlPoints));
+
+    axom::Array<CoordType> w;
+    w.assign(std::begin(weights), std::end(weights));
+
+    SCOPED_TRACE("Testing Array constructor, polynomial");
+    BezierTriangleType nTri(cp, ord);
+    check_triangle(nTri, false);
+
+    SCOPED_TRACE("Testing Array constructor, rational");
+    BezierTriangleType rTri(cp, w, ord);
+    check_triangle(rTri, true);
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_beziertriangle, set_order)
+{
+  constexpr int DIM = 3;
+  using CoordType = double;
+  using BezierTriangleType = primal::BezierTriangle<CoordType, DIM>;
+
+  BezierTriangleType bTri;
+  EXPECT_EQ(-1, bTri.getOrder());
+  EXPECT_EQ(0, bTri.getControlPoints().size());
+  EXPECT_FALSE(bTri.isRational());
+
+  constexpr int ord = 2;
+  bTri.setOrder(ord);
+  EXPECT_EQ(ord, bTri.getOrder());
+  EXPECT_EQ(BezierTriangleType::triSize(ord), bTri.getControlPoints().size());
+  EXPECT_FALSE(bTri.isRational());
+
+  // Setting the order should resize weights in rational triangles
+  BezierTriangleType rTri(1);
+  rTri.getWeights().resize(rTri.getControlPoints().size());
+  for(int i = 0; i < rTri.getWeights().size(); ++i)
+  {
+    rTri.getWeights()[i] = 1.0;
+  }
+  EXPECT_TRUE(rTri.isRational());
+
+  constexpr int ord2 = 3;
+  rTri.setOrder(ord2);
+  EXPECT_EQ(ord2, rTri.getOrder());
+  EXPECT_EQ(BezierTriangleType::triSize(ord2), rTri.getControlPoints().size());
+  EXPECT_EQ(BezierTriangleType::triSize(ord2), rTri.getWeights().size());
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_beziertriangle, evaluate_linear)
+{
+  using CoordType = double;
+  using BTri = primal::BezierTriangle<CoordType, 3>;
+  using PointType = BTri::PointType;
+  using VectorType = BTri::VectorType;
+
+  constexpr int ord = 1;
+  constexpr CoordType eps = 1e-14;
+
+  BTri tri(ord);
+
+  const PointType p00 {1.0, 2.0, 3.0};
+  const PointType p01 {2.0, -1.0, 0.5};
+  const PointType p10 {0.25, 1.5, -2.0};
+  tri(0, 0) = p00;
+  tri(0, 1) = p01;
+  tri(1, 0) = p10;
+
+  EXPECT_EQ(tri.evaluate(0.0, 0.0), p00);
+  EXPECT_EQ(tri.evaluate(0.0, 1.0), p01);
+  EXPECT_EQ(tri.evaluate(1.0, 0.0), p10);
+
+  const CoordType u = 0.3;
+  const CoordType v = 0.2;
+  const PointType expected = PointType {p00[0] + u * (p10[0] - p00[0]) + v * (p01[0] - p00[0]),
+                                        p00[1] + u * (p10[1] - p00[1]) + v * (p01[1] - p00[1]),
+                                        p00[2] + u * (p10[2] - p00[2]) + v * (p01[2] - p00[2])};
+
+  const PointType eval = tri.evaluate(u, v);
+  for(int d = 0; d < 3; ++d)
+  {
+    EXPECT_NEAR(eval[d], expected[d], eps);
+  }
+
+  PointType e1;
+  VectorType Du, Dv;
+  tri.evaluateFirstDerivatives(u, v, e1, Du, Dv);
+  for(int d = 0; d < 3; ++d)
+  {
+    EXPECT_NEAR(e1[d], expected[d], eps);
+    EXPECT_NEAR(Du[d], (p10[d] - p00[d]), eps);
+    EXPECT_NEAR(Dv[d], (p01[d] - p00[d]), eps);
+  }
+
+  VectorType DuDu, DvDv, DuDv;
+  tri.evaluateSecondDerivatives(u, v, e1, Du, Dv, DuDu, DvDv, DuDv);
+  for(int d = 0; d < 3; ++d)
+  {
+    EXPECT_NEAR(DuDu[d], 0.0, eps);
+    EXPECT_NEAR(DvDv[d], 0.0, eps);
+    EXPECT_NEAR(DuDv[d], 0.0, eps);
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_beziertriangle, evaluate_quadratic_second_derivatives_constant)
+{
+  using CoordType = double;
+  using BTri = primal::BezierTriangle<CoordType, 3>;
+  using PointType = BTri::PointType;
+  using VectorType = BTri::VectorType;
+
+  constexpr int ord = 2;
+  constexpr CoordType eps = 1e-12;
+
+  BTri tri(ord);
+
+  // Populate control net with deterministic values
+  for(int i = 0; i <= ord; ++i)
+  {
+    for(int j = 0; j <= ord - i; ++j)
+    {
+      tri(i, j) = PointType {static_cast<CoordType>(i),
+                             static_cast<CoordType>(j),
+                             static_cast<CoordType>(i * i + j)};
+    }
+  }
+
+  // Vertex interpolation
+  EXPECT_EQ(tri.evaluate(0.0, 0.0), tri(0, 0));
+  EXPECT_EQ(tri.evaluate(0.0, 1.0), tri(0, ord));
+  EXPECT_EQ(tri.evaluate(1.0, 0.0), tri(ord, 0));
+
+  auto derivs = [&](CoordType u, CoordType v) {
+    PointType e;
+    VectorType Du, Dv, DuDu, DvDv, DuDv;
+    tri.evaluateSecondDerivatives(u, v, e, Du, Dv, DuDu, DvDv, DuDv);
+    return std::array<VectorType, 3> {DuDu, DvDv, DuDv};
+  };
+
+  const auto d0 = derivs(0.2, 0.3);
+  const auto d1 = derivs(0.6, 0.1);
+  for(int d = 0; d < 3; ++d)
+  {
+    EXPECT_NEAR(d0[0][d], d1[0][d], eps);
+    EXPECT_NEAR(d0[1][d], d1[1][d], eps);
+    EXPECT_NEAR(d0[2][d], d1[2][d], eps);
+  }
+}
+
+TEST(primal_beziertriangle, rational_triangles)
+{
+  using CoordType = double;
+  using BTri = primal::BezierTriangle<CoordType, 3>;
+  using PointType = BTri::PointType;
+  using VectorType = BTri::VectorType;
+
+  constexpr int ord = 2;
+  constexpr CoordType eps = 1e-12;
+
+  BTri poly(ord);
+  BTri rat(ord);
+  rat.getWeights().resize(rat.getControlPoints().size());
+  for(int i = 0; i < rat.getWeights().size(); ++i)
+  {
+    rat.getWeights()[i] = 1.0;
+  }
+
+  // Populate a shared control net
+  poly(0, 0) = PointType {0.0, 0.0, 0.0};
+  poly(0, 1) = PointType {1.0, 0.0, 0.0};
+  poly(0, 2) = PointType {2.0, 0.0, 0.0};
+  poly(1, 0) = PointType {0.0, 1.0, 0.0};
+  poly(1, 1) = PointType {1.0, 1.0, 1.0};
+  poly(2, 0) = PointType {0.0, 2.0, 0.0};
+
+  rat(0, 0) = poly(0, 0);
+  rat(0, 1) = poly(0, 1);
+  rat(0, 2) = poly(0, 2);
+  rat(1, 0) = poly(1, 0);
+  rat(1, 1) = poly(1, 1);
+  rat(2, 0) = poly(2, 0);
+
+  auto check_at = [&](CoordType u, CoordType v) {
+    // value
+    const PointType p0 = poly.evaluate(u, v);
+    const PointType p1 = rat.evaluate(u, v);
+    for(int d = 0; d < 3; ++d)
+    {
+      EXPECT_NEAR(p0[d], p1[d], eps);
+    }
+
+    // first derivatives
+    PointType e0, e1;
+    VectorType du0, dv0, du1, dv1;
+    poly.evaluateFirstDerivatives(u, v, e0, du0, dv0);
+    rat.evaluateFirstDerivatives(u, v, e1, du1, dv1);
+    for(int d = 0; d < 3; ++d)
+    {
+      EXPECT_NEAR(e0[d], e1[d], eps);
+      EXPECT_NEAR(du0[d], du1[d], eps);
+      EXPECT_NEAR(dv0[d], dv1[d], eps);
+    }
+
+    // second derivatives
+    VectorType duu0, dvv0, duv0, duu1, dvv1, duv1;
+    poly.evaluateSecondDerivatives(u, v, e0, du0, dv0, duu0, dvv0, duv0);
+    rat.evaluateSecondDerivatives(u, v, e1, du1, dv1, duu1, dvv1, duv1);
+    for(int d = 0; d < 3; ++d)
+    {
+      EXPECT_NEAR(e0[d], e1[d], eps);
+      EXPECT_NEAR(duu0[d], duu1[d], eps);
+      EXPECT_NEAR(dvv0[d], dvv1[d], eps);
+      EXPECT_NEAR(duv0[d], duv1[d], eps);
+    }
+  };
+
+  check_at(0.2, 0.3);
+  check_at(0.6, 0.1);
+}

--- a/src/axom/primal/tests/primal_bezier_triangle.cpp
+++ b/src/axom/primal/tests/primal_bezier_triangle.cpp
@@ -494,22 +494,23 @@ TEST(primal_beziertriangle, split_interior_polynomial)
   const auto pC = tri.evaluate(1.0, 0.0);
   const auto pQ = tri.evaluate(u, v);
 
+  constexpr double tol = 1e-10;
   for(int i = 0; i < DIM; ++i)
   {
     // t0 -> (B, C, Q)
-    EXPECT_NEAR(pB[i], t0.evaluate(0.0, 0.0)[i], 1e-10);
-    EXPECT_NEAR(pC[i], t0.evaluate(0.0, 1.0)[i], 1e-10);
-    EXPECT_NEAR(pQ[i], t0.evaluate(1.0, 0.0)[i], 1e-10);
+    EXPECT_NEAR(pB[i], t0.evaluate(0.0, 0.0)[i], tol);
+    EXPECT_NEAR(pC[i], t0.evaluate(0.0, 1.0)[i], tol);
+    EXPECT_NEAR(pQ[i], t0.evaluate(1.0, 0.0)[i], tol);
 
     // t1 -> (C, A, Q)
-    EXPECT_NEAR(pC[i], t1.evaluate(0.0, 0.0)[i], 1e-10);
-    EXPECT_NEAR(pA[i], t1.evaluate(0.0, 1.0)[i], 1e-10);
-    EXPECT_NEAR(pQ[i], t1.evaluate(1.0, 0.0)[i], 1e-10);
+    EXPECT_NEAR(pC[i], t1.evaluate(0.0, 0.0)[i], tol);
+    EXPECT_NEAR(pA[i], t1.evaluate(0.0, 1.0)[i], tol);
+    EXPECT_NEAR(pQ[i], t1.evaluate(1.0, 0.0)[i], tol);
 
     // t2 -> (A, B, Q)
-    EXPECT_NEAR(pA[i], t2.evaluate(0.0, 0.0)[i], 1e-10);
-    EXPECT_NEAR(pB[i], t2.evaluate(0.0, 1.0)[i], 1e-10);
-    EXPECT_NEAR(pQ[i], t2.evaluate(1.0, 0.0)[i], 1e-10);
+    EXPECT_NEAR(pA[i], t2.evaluate(0.0, 0.0)[i], tol);
+    EXPECT_NEAR(pB[i], t2.evaluate(0.0, 1.0)[i], tol);
+    EXPECT_NEAR(pQ[i], t2.evaluate(1.0, 0.0)[i], tol);
   }
 
   // Interior point checks via affine parameter mapping
@@ -524,7 +525,7 @@ TEST(primal_beziertriangle, split_interior_polynomial)
     const auto actual = t0.evaluate(s, t);
     for(int d = 0; d < DIM; ++d)
     {
-      EXPECT_NEAR(expected[d], actual[d], 1e-12);
+      EXPECT_NEAR(expected[d], actual[d], tol);
     }
   }
 
@@ -536,7 +537,7 @@ TEST(primal_beziertriangle, split_interior_polynomial)
     const auto actual = t1.evaluate(s, t);
     for(int d = 0; d < DIM; ++d)
     {
-      EXPECT_NEAR(expected[d], actual[d], 1e-12);
+      EXPECT_NEAR(expected[d], actual[d], tol);
     }
   }
 
@@ -548,7 +549,7 @@ TEST(primal_beziertriangle, split_interior_polynomial)
     const auto actual = t2.evaluate(s, t);
     for(int d = 0; d < DIM; ++d)
     {
-      EXPECT_NEAR(expected[d], actual[d], 1e-12);
+      EXPECT_NEAR(expected[d], actual[d], tol);
     }
   }
 }
@@ -587,22 +588,23 @@ TEST(primal_beziertriangle, split_interior_rational)
   const auto pC = tri.evaluate(1.0, 0.0);
   const auto pQ = tri.evaluate(u, v);
 
+  constexpr double tol = 1e-10;
   for(int i = 0; i < DIM; ++i)
   {
     // t0 -> (B, C, Q)
-    EXPECT_NEAR(pB[i], t0.evaluate(0.0, 0.0)[i], 1e-10);
-    EXPECT_NEAR(pC[i], t0.evaluate(0.0, 1.0)[i], 1e-10);
-    EXPECT_NEAR(pQ[i], t0.evaluate(1.0, 0.0)[i], 1e-10);
+    EXPECT_NEAR(pB[i], t0.evaluate(0.0, 0.0)[i], tol);
+    EXPECT_NEAR(pC[i], t0.evaluate(0.0, 1.0)[i], tol);
+    EXPECT_NEAR(pQ[i], t0.evaluate(1.0, 0.0)[i], tol);
 
     // t1 -> (C, A, Q)
-    EXPECT_NEAR(pC[i], t1.evaluate(0.0, 0.0)[i], 1e-10);
-    EXPECT_NEAR(pA[i], t1.evaluate(0.0, 1.0)[i], 1e-10);
-    EXPECT_NEAR(pQ[i], t1.evaluate(1.0, 0.0)[i], 1e-10);
+    EXPECT_NEAR(pC[i], t1.evaluate(0.0, 0.0)[i], tol);
+    EXPECT_NEAR(pA[i], t1.evaluate(0.0, 1.0)[i], tol);
+    EXPECT_NEAR(pQ[i], t1.evaluate(1.0, 0.0)[i], tol);
 
     // t2 -> (A, B, Q)
-    EXPECT_NEAR(pA[i], t2.evaluate(0.0, 0.0)[i], 1e-10);
-    EXPECT_NEAR(pB[i], t2.evaluate(0.0, 1.0)[i], 1e-10);
-    EXPECT_NEAR(pQ[i], t2.evaluate(1.0, 0.0)[i], 1e-10);
+    EXPECT_NEAR(pA[i], t2.evaluate(0.0, 0.0)[i], tol);
+    EXPECT_NEAR(pB[i], t2.evaluate(0.0, 1.0)[i], tol);
+    EXPECT_NEAR(pQ[i], t2.evaluate(1.0, 0.0)[i], tol);
   }
 
   // Interior point checks via affine parameter mapping
@@ -617,7 +619,7 @@ TEST(primal_beziertriangle, split_interior_rational)
     const auto actual = t0.evaluate(s, t);
     for(int d = 0; d < DIM; ++d)
     {
-      EXPECT_NEAR(expected[d], actual[d], 1e-12);
+      EXPECT_NEAR(expected[d], actual[d], tol);
     }
   }
 
@@ -629,7 +631,7 @@ TEST(primal_beziertriangle, split_interior_rational)
     const auto actual = t1.evaluate(s, t);
     for(int d = 0; d < DIM; ++d)
     {
-      EXPECT_NEAR(expected[d], actual[d], 1e-12);
+      EXPECT_NEAR(expected[d], actual[d], tol);
     }
   }
 
@@ -641,7 +643,7 @@ TEST(primal_beziertriangle, split_interior_rational)
     const auto actual = t2.evaluate(s, t);
     for(int d = 0; d < DIM; ++d)
     {
-      EXPECT_NEAR(expected[d], actual[d], 1e-12);
+      EXPECT_NEAR(expected[d], actual[d], tol);
     }
   }
 }
@@ -784,27 +786,28 @@ TEST(primal_beziertriangle, split_fourway_polynomial)
   const auto pP1 = tri.getEdge(1).evaluate(s1);
   const auto pP2 = tri.getEdge(2).evaluate(s2);
 
+  constexpr double tol = 1e-10;
   for(int d = 0; d < DIM; ++d)
   {
     // t1 = Tri(A, P2, P1)
-    EXPECT_NEAR(pA[d], t1.evaluate(0.0, 0.0)[d], 1e-10);
-    EXPECT_NEAR(pP2[d], t1.evaluate(0.0, 1.0)[d], 1e-10);
-    EXPECT_NEAR(pP1[d], t1.evaluate(1.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pA[d], t1.evaluate(0.0, 0.0)[d], tol);
+    EXPECT_NEAR(pP2[d], t1.evaluate(0.0, 1.0)[d], tol);
+    EXPECT_NEAR(pP1[d], t1.evaluate(1.0, 0.0)[d], tol);
 
     // t2 = Tri(B, P0, P2)
-    EXPECT_NEAR(pB[d], t2.evaluate(0.0, 0.0)[d], 1e-10);
-    EXPECT_NEAR(pP0[d], t2.evaluate(0.0, 1.0)[d], 1e-10);
-    EXPECT_NEAR(pP2[d], t2.evaluate(1.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pB[d], t2.evaluate(0.0, 0.0)[d], tol);
+    EXPECT_NEAR(pP0[d], t2.evaluate(0.0, 1.0)[d], tol);
+    EXPECT_NEAR(pP2[d], t2.evaluate(1.0, 0.0)[d], tol);
 
     // t3 = Tri(C, P1, P0)
-    EXPECT_NEAR(pC[d], t3.evaluate(0.0, 0.0)[d], 1e-10);
-    EXPECT_NEAR(pP1[d], t3.evaluate(0.0, 1.0)[d], 1e-10);
-    EXPECT_NEAR(pP0[d], t3.evaluate(1.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pC[d], t3.evaluate(0.0, 0.0)[d], tol);
+    EXPECT_NEAR(pP1[d], t3.evaluate(0.0, 1.0)[d], tol);
+    EXPECT_NEAR(pP0[d], t3.evaluate(1.0, 0.0)[d], tol);
 
     // t4 = Tri(P1, P0, P2)
-    EXPECT_NEAR(pP1[d], t4.evaluate(0.0, 0.0)[d], 1e-10);
-    EXPECT_NEAR(pP0[d], t4.evaluate(0.0, 1.0)[d], 1e-10);
-    EXPECT_NEAR(pP2[d], t4.evaluate(1.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pP1[d], t4.evaluate(0.0, 0.0)[d], tol);
+    EXPECT_NEAR(pP0[d], t4.evaluate(0.0, 1.0)[d], tol);
+    EXPECT_NEAR(pP2[d], t4.evaluate(1.0, 0.0)[d], tol);
   }
 
   // Shared interior edges agree (same geometry and orientation for the chosen outputs)
@@ -820,9 +823,9 @@ TEST(primal_beziertriangle, split_fourway_polynomial)
 
   for(int d = 0; d < DIM; ++d)
   {
-    EXPECT_NEAR(eP0P2_from_t2[d], eP0P2_from_t4[d], 1e-12);
-    EXPECT_NEAR(eP2P1_from_t1[d], eP2P1_from_t4[d], 1e-12);
-    EXPECT_NEAR(eP1P0_from_t3[d], eP1P0_from_t4[d], 1e-12);
+    EXPECT_NEAR(eP0P2_from_t2[d], eP0P2_from_t4[d], tol);
+    EXPECT_NEAR(eP2P1_from_t1[d], eP2P1_from_t4[d], tol);
+    EXPECT_NEAR(eP1P0_from_t3[d], eP1P0_from_t4[d], tol);
   }
 }
 
@@ -862,27 +865,28 @@ TEST(primal_beziertriangle, split_fourway_rational)
   const auto pP1 = tri.getEdge(1).evaluate(s1);
   const auto pP2 = tri.getEdge(2).evaluate(s2);
 
+  constexpr double tol = 1e-10;
   for(int d = 0; d < DIM; ++d)
   {
     // t1 = Tri(A, P2, P1)
-    EXPECT_NEAR(pA[d], t1.evaluate(0.0, 0.0)[d], 1e-10);
-    EXPECT_NEAR(pP2[d], t1.evaluate(0.0, 1.0)[d], 1e-10);
-    EXPECT_NEAR(pP1[d], t1.evaluate(1.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pA[d], t1.evaluate(0.0, 0.0)[d], tol);
+    EXPECT_NEAR(pP2[d], t1.evaluate(0.0, 1.0)[d], tol);
+    EXPECT_NEAR(pP1[d], t1.evaluate(1.0, 0.0)[d], tol);
 
     // t2 = Tri(B, P0, P2)
-    EXPECT_NEAR(pB[d], t2.evaluate(0.0, 0.0)[d], 1e-10);
-    EXPECT_NEAR(pP0[d], t2.evaluate(0.0, 1.0)[d], 1e-10);
-    EXPECT_NEAR(pP2[d], t2.evaluate(1.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pB[d], t2.evaluate(0.0, 0.0)[d], tol);
+    EXPECT_NEAR(pP0[d], t2.evaluate(0.0, 1.0)[d], tol);
+    EXPECT_NEAR(pP2[d], t2.evaluate(1.0, 0.0)[d], tol);
 
     // t3 = Tri(C, P1, P0)
-    EXPECT_NEAR(pC[d], t3.evaluate(0.0, 0.0)[d], 1e-10);
-    EXPECT_NEAR(pP1[d], t3.evaluate(0.0, 1.0)[d], 1e-10);
-    EXPECT_NEAR(pP0[d], t3.evaluate(1.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pC[d], t3.evaluate(0.0, 0.0)[d], tol);
+    EXPECT_NEAR(pP1[d], t3.evaluate(0.0, 1.0)[d], tol);
+    EXPECT_NEAR(pP0[d], t3.evaluate(1.0, 0.0)[d], tol);
 
     // t4 = Tri(P1, P0, P2)
-    EXPECT_NEAR(pP1[d], t4.evaluate(0.0, 0.0)[d], 1e-10);
-    EXPECT_NEAR(pP0[d], t4.evaluate(0.0, 1.0)[d], 1e-10);
-    EXPECT_NEAR(pP2[d], t4.evaluate(1.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pP1[d], t4.evaluate(0.0, 0.0)[d], tol);
+    EXPECT_NEAR(pP0[d], t4.evaluate(0.0, 1.0)[d], tol);
+    EXPECT_NEAR(pP2[d], t4.evaluate(1.0, 0.0)[d], tol);
   }
 
   // Shared interior edges agree
@@ -898,9 +902,9 @@ TEST(primal_beziertriangle, split_fourway_rational)
 
   for(int d = 0; d < DIM; ++d)
   {
-    EXPECT_NEAR(eP0P2_from_t2[d], eP0P2_from_t4[d], 1e-12);
-    EXPECT_NEAR(eP2P1_from_t1[d], eP2P1_from_t4[d], 1e-12);
-    EXPECT_NEAR(eP1P0_from_t3[d], eP1P0_from_t4[d], 1e-12);
+    EXPECT_NEAR(eP0P2_from_t2[d], eP0P2_from_t4[d], tol);
+    EXPECT_NEAR(eP2P1_from_t1[d], eP2P1_from_t4[d], tol);
+    EXPECT_NEAR(eP1P0_from_t3[d], eP1P0_from_t4[d], tol);
   }
 }
 
@@ -928,11 +932,12 @@ TEST(primal_beziertriangle, uniformSplit_fourway_polynomial)
   const auto pP1 = tri.getEdge(1).evaluate(0.5);
   const auto pP2 = tri.getEdge(2).evaluate(0.5);
 
+  constexpr double tol = 1e-10;
   for(int d = 0; d < DIM; ++d)
   {
-    EXPECT_NEAR(pP1[d], t4.evaluate(0.0, 0.0)[d], 1e-10);
-    EXPECT_NEAR(pP0[d], t4.evaluate(0.0, 1.0)[d], 1e-10);
-    EXPECT_NEAR(pP2[d], t4.evaluate(1.0, 0.0)[d], 1e-10);
+    EXPECT_NEAR(pP1[d], t4.evaluate(0.0, 0.0)[d], tol);
+    EXPECT_NEAR(pP0[d], t4.evaluate(0.0, 1.0)[d], tol);
+    EXPECT_NEAR(pP2[d], t4.evaluate(1.0, 0.0)[d], tol);
   }
 
   const CoordType s = 0.23;
@@ -957,21 +962,21 @@ TEST(primal_beziertriangle, uniformSplit_fourway_polynomial)
   // Also confirm vertex ordering matches the general split for s=0.5
   for(int d = 0; d < DIM; ++d)
   {
-    EXPECT_NEAR(t1.evaluate(0.0, 0.0)[d], r1.evaluate(0.0, 0.0)[d], 1e-12);
-    EXPECT_NEAR(t1.evaluate(0.0, 1.0)[d], r1.evaluate(0.0, 1.0)[d], 1e-12);
-    EXPECT_NEAR(t1.evaluate(1.0, 0.0)[d], r1.evaluate(1.0, 0.0)[d], 1e-12);
+    EXPECT_NEAR(t1.evaluate(0.0, 0.0)[d], r1.evaluate(0.0, 0.0)[d], tol);
+    EXPECT_NEAR(t1.evaluate(0.0, 1.0)[d], r1.evaluate(0.0, 1.0)[d], tol);
+    EXPECT_NEAR(t1.evaluate(1.0, 0.0)[d], r1.evaluate(1.0, 0.0)[d], tol);
 
-    EXPECT_NEAR(t2.evaluate(0.0, 0.0)[d], r2.evaluate(0.0, 0.0)[d], 1e-12);
-    EXPECT_NEAR(t2.evaluate(0.0, 1.0)[d], r2.evaluate(0.0, 1.0)[d], 1e-12);
-    EXPECT_NEAR(t2.evaluate(1.0, 0.0)[d], r2.evaluate(1.0, 0.0)[d], 1e-12);
+    EXPECT_NEAR(t2.evaluate(0.0, 0.0)[d], r2.evaluate(0.0, 0.0)[d], tol);
+    EXPECT_NEAR(t2.evaluate(0.0, 1.0)[d], r2.evaluate(0.0, 1.0)[d], tol);
+    EXPECT_NEAR(t2.evaluate(1.0, 0.0)[d], r2.evaluate(1.0, 0.0)[d], tol);
 
-    EXPECT_NEAR(t3.evaluate(0.0, 0.0)[d], r3.evaluate(0.0, 0.0)[d], 1e-12);
-    EXPECT_NEAR(t3.evaluate(0.0, 1.0)[d], r3.evaluate(0.0, 1.0)[d], 1e-12);
-    EXPECT_NEAR(t3.evaluate(1.0, 0.0)[d], r3.evaluate(1.0, 0.0)[d], 1e-12);
+    EXPECT_NEAR(t3.evaluate(0.0, 0.0)[d], r3.evaluate(0.0, 0.0)[d], tol);
+    EXPECT_NEAR(t3.evaluate(0.0, 1.0)[d], r3.evaluate(0.0, 1.0)[d], tol);
+    EXPECT_NEAR(t3.evaluate(1.0, 0.0)[d], r3.evaluate(1.0, 0.0)[d], tol);
 
-    EXPECT_NEAR(t4.evaluate(0.0, 0.0)[d], r4.evaluate(0.0, 0.0)[d], 1e-12);
-    EXPECT_NEAR(t4.evaluate(0.0, 1.0)[d], r4.evaluate(0.0, 1.0)[d], 1e-12);
-    EXPECT_NEAR(t4.evaluate(1.0, 0.0)[d], r4.evaluate(1.0, 0.0)[d], 1e-12);
+    EXPECT_NEAR(t4.evaluate(0.0, 0.0)[d], r4.evaluate(0.0, 0.0)[d], tol);
+    EXPECT_NEAR(t4.evaluate(0.0, 1.0)[d], r4.evaluate(0.0, 1.0)[d], tol);
+    EXPECT_NEAR(t4.evaluate(1.0, 0.0)[d], r4.evaluate(1.0, 0.0)[d], tol);
   }
 }
 
@@ -1015,12 +1020,13 @@ TEST(primal_beziertriangle, uniformSplit_fourway_rational)
   const auto p41 = t4.evaluate(s, t);
   const auto p42 = r4.evaluate(s, t);
 
+  constexpr double tol = 1e-12;
   for(int d = 0; d < DIM; ++d)
   {
-    EXPECT_NEAR(p11[d], p12[d], 1e-12);
-    EXPECT_NEAR(p21[d], p22[d], 1e-12);
-    EXPECT_NEAR(p31[d], p32[d], 1e-12);
-    EXPECT_NEAR(p41[d], p42[d], 1e-12);
+    EXPECT_NEAR(p11[d], p12[d], tol);
+    EXPECT_NEAR(p21[d], p22[d], tol);
+    EXPECT_NEAR(p31[d], p32[d], tol);
+    EXPECT_NEAR(p41[d], p42[d], tol);
   }
 }
 


### PR DESCRIPTION
# Summary

This PR is adds the class `primal::BezierTriangle`, which manages the control points and weights for a possibly rational Bezier triangle class. The implementation is meant to mirror `BezierPatch` where possible.
- Control points and weights for an order `m` triangle are stored internally in a linear array, and are accessed through `BezierTriangle::operator()(int i, int j)`, with the restriction that `i + j <= m`.
- Evaluation methods for the surface and derivatives. Evaluation is parameterized by `(u0, v0)`, which are almost (but not quite) the first two elements of Barycentric coordinates. These coordinates are permuted so that `tri.evaluate(0.0, 0.0) == tri(0, 0)`, `tri.evaluate(0.0, 1.0) == tri(0, m)`, and `tri.evaluate(1.0, 0.0) == tri(m, 0)`. If it were real Barycentric coordinates, then `tri.evaluate(0.0, 0.0 \*, 1.0*\)` would be the same as the `(1, 0)` control point, and that seems confusing. 
- Various `BezierTriangle::split` methods, which split a triangle into 2, 3, and 4 patches respectively. There is also a dedicated `uniformSplit` method which uses a faster, more specialized method based on degenerate tetrahedon. Some cursory profiling says that it is about 4x the speed of the generic method.

I've also added some minor readability improvements to `BezierPatch`.