### PR TITLE
Fix arg parsing conflict with flux

### DIFF
--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -165,7 +165,7 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                 COMMAND  quest_shaping_driver_ex 
                             -i ${shaping_data_dir}/circles.yaml
                             --method sampling
-                            inline_mesh --min -6 -6 --max 6 6 --res 25 25 -d 2
+                            inline_mesh --min -6 -6 --max 6 6 --resolution 25 25 -d 2
                 NUM_MPI_TASKS ${_nranks})
             # Analytic area for annulus w/ outer/inner radii 5 and 2.5 is ~58.905
             set_tests_properties(${_testname} PROPERTIES 
@@ -177,7 +177,7 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                 COMMAND  quest_shaping_driver_ex 
                         -i ${shaping_data_dir}/circles_opposite.yaml
                         --method sampling
-                        inline_mesh --min -6 -6 --max 6 6 --res 25 25 -d 2
+                        inline_mesh --min -6 -6 --max 6 6 --resolution 25 25 -d 2
                 NUM_MPI_TASKS ${_nranks})
             # Analytic area for annulus w/ outer/inner radii 5 and 2.5 is ~65.97
             set_tests_properties(${_testname} PROPERTIES 
@@ -190,7 +190,7 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                         -i ${shaping_data_dir}/balls_and_jacks.yaml
                         --method sampling
                         --background-material air
-                        inline_mesh --min -10 0 --max 60 50 --res 25 25 -d 2
+                        inline_mesh --min -10 0 --max 60 50 --resolution 25 25 -d 2
                 NUM_MPI_TASKS ${_nranks})
             # background: 3500; balls: ~373; jacks: ~230; air ~2897
             set_tests_properties(${_testname} PROPERTIES 
@@ -203,7 +203,7 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                         -i ${shaping_data_dir}/ball_impact.yaml
                         --method sampling
                         --background-material air
-                        inline_mesh --min -10 0 --max 40 30 --res 25 25 -d 2
+                        inline_mesh --min -10 0 --max 40 30 --resolution 25 25 -d 2
                 NUM_MPI_TASKS ${_nranks})
             # steel ball: semi-cirle of radius 5.5 has area ~47.516
             set_tests_properties(${_testname} PROPERTIES 
@@ -217,7 +217,7 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                         -i ${shaping_data_dir}/ball_impact.yaml
                         --method sampling
                         --background-material air
-                        inline_mesh --min -30 -30 -10 --max 30 30 40 --res 16 16 16 -d3
+                        inline_mesh --min -30 -30 -10 --max 30 30 40 --resolution 16 16 16 -d3
                 NUM_MPI_TASKS ${_nranks})
             # steel ball: cirle of radius 5.5 has analytic volume ~696.91
             set_tests_properties(${_testname} PROPERTIES 
@@ -231,7 +231,7 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
             COMMAND  quest_shaping_driver_ex
                     -i ${shaping_data_dir}/flat_star.yaml
                     --method intersection
-                    inline_mesh --min 0 0 --max 1 1 --res 4 4 -d 2
+                    inline_mesh --min 0 0 --max 1 1 --resolution 4 4 -d 2
             NUM_MPI_TASKS ${_nranks})
         # steel triangle: star composed of 16 right triangles with
         # leg length 0.25 has analytic volume 0.5
@@ -265,7 +265,7 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                             --policy ${_policy}
                             --segments-per-knot-span 50
                             --method intersection
-                            inline_mesh --min 0 0 --max 3 3 --res 3 3 -d 2
+                            inline_mesh --min 0 0 --max 3 3 --resolution 3 3 -d 2
                     NUM_MPI_TASKS ${_nranks}
                     NUM_OMP_THREADS ${_num_threads})
                 # steel unit semi-circle with an area of pi/2
@@ -283,7 +283,7 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
             COMMAND  quest_shaping_driver_ex 
                      -i ${shaping_data_dir}/heroic_roses_mfem.yaml
                      --method sampling
-                     inline_mesh --min 0 0 --max 300 400 --res 150 200 -d 2
+                     inline_mesh --min 0 0 --max 300 400 --resolution 150 200 -d 2
             NUM_MPI_TASKS ${_nranks})
         set_tests_properties(${_testname} PROPERTIES
             PASS_REGULAR_EXPRESSION  "Volume of material 'black' is 36,?595.")
@@ -295,7 +295,7 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
             COMMAND  quest_shaping_driver_ex 
                      -i ${shaping_data_dir}/heroic_roses_mfem_cp.yaml
                      --method sampling --sampling windingnumber
-                     inline_mesh --min 0 0 --max 300 400 --res 150 200 -d 2
+                     inline_mesh --min 0 0 --max 300 400 --resolution 150 200 -d 2
             NUM_MPI_TASKS ${_nranks})
         set_tests_properties(${_testname} PROPERTIES
             PASS_REGULAR_EXPRESSION  "Volume of material 'black' is 36,?654.")
@@ -308,7 +308,7 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
             COMMAND  quest_shaping_driver_ex 
                     -i ${shaping_data_dir}/sphere.yaml
                     --method sampling
-                    inline_mesh --min -6 -6 -6 --max 6 6 6 --res 16 16 16 -d 3
+                    inline_mesh --min -6 -6 -6 --max 6 6 6 --resolution 16 16 16 -d 3
             NUM_MPI_TASKS ${_nranks})
         # sphere of radius 5 has volume: 4/3 pi * r^3 ~523.6
         # input sphere is discretized and mesh is coarse; accuracy is within ~1%
@@ -322,7 +322,7 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                     -i ${shaping_data_dir}/spheres.yaml
                     --method sampling
                     --background-material void
-                    inline_mesh --min -6 -6 -6 --max 6 6 6 --res 16 16 16 -d 3
+                    inline_mesh --min -6 -6 -6 --max 6 6 6 --resolution 16 16 16 -d 3
             NUM_MPI_TASKS ${_nranks})
         # bbox volume: 12^3 = 1728; sphere(r=5): ~523.6; sphere(r=2): 33.5
         # expected analytic volume when fully resolved: ~1237.9
@@ -336,7 +336,7 @@ if(AXOM_ENABLE_MPI AND MFEM_FOUND AND MFEM_USE_MPI
                     -i ${shaping_data_dir}/plane.yaml
                     --method sampling
                     --background-material air
-                    inline_mesh --min -430 -45 -35 --max 430 855 210 --res 16 16 16 -d 3
+                    inline_mesh --min -430 -45 -35 --max 430 855 210 --resolution 16 16 16 -d 3
             NUM_MPI_TASKS ${_nranks})
         # background: 860*900*245=189,630,000; airplane volume from meshlab: 7,420,578.5
         # expected volume when fully resolved: 182,209,421.5

--- a/src/axom/quest/examples/shaping_driver.cpp
+++ b/src/axom/quest/examples/shaping_driver.cpp
@@ -283,7 +283,7 @@ public:
         ->expected(2, 3)
         ->required();
 
-      inline_mesh_subcommand->add_option("--res", boxResolution)
+      inline_mesh_subcommand->add_option("--res, --resolution", boxResolution)
         ->description("Resolution of the box mesh (i,j[,k])")
         ->expected(2, 3)
         ->required();

--- a/src/axom/quest/tests/CMakeLists.txt
+++ b/src/axom/quest/tests/CMakeLists.txt
@@ -297,7 +297,7 @@ if(AXOM_ENABLE_KLEE AND AXOM_ENABLE_SIDRE AND CONDUIT_FOUND AND RAJA_FOUND AND A
                         --scale .99 .99 .99
                         --dir 8 4 2
                         --meshType ${_meshType}
-                        inline_mesh --min -2 -2 -2 --max 2 2 2 --res 16 16 16
+                        inline_mesh --min -2 -2 -2 --max 2 2 2 --resolution 16 16 16
             NUM_MPI_TASKS ${_nranks}
             NUM_OMP_THREADS ${_num_threads})
         endforeach()

--- a/src/axom/quest/tests/quest_mesh_clipper.cpp
+++ b/src/axom/quest/tests/quest_mesh_clipper.cpp
@@ -225,7 +225,7 @@ public:
         ->expected(2, 3)
         ->required();
 
-      inline_mesh_subcommand->add_option("--res", boxResolution)
+      inline_mesh_subcommand->add_option("--res, --resolution", boxResolution)
         ->description("Resolution of the box mesh (i,j[,k])")
         ->expected(2, 3)
         ->required();

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -140,12 +140,12 @@ if(AXOM_ENABLE_SIDRE AND AXOM_ENABLE_PRIMAL AND MFEM_FOUND)
         
     axom_add_test(
         NAME    data_collection_util_box2D
-        COMMAND data_collection_util --min -1 -1 --max 1 1 --res 16 16 -p 1
+        COMMAND data_collection_util --min -1 -1 --max 1 1 --resolution 16 16 -p 1
         NUM_MPI_TASKS ${_nranks}
     )
     axom_add_test(
         NAME    data_collection_util_box3D
-        COMMAND data_collection_util --min -1 -1 -1 --max 1 1 1 --res 16 16 16 -p 1
+        COMMAND data_collection_util --min -1 -1 -1 --max 1 1 1 --resolution 16 16 16 -p 1
         NUM_MPI_TASKS ${_nranks}
     )
 

--- a/src/tools/data_collection_util.cpp
+++ b/src/tools/data_collection_util.cpp
@@ -195,7 +195,7 @@ public:
     minbb->needs(maxbb);
     maxbb->needs(minbb);
 
-    box_options->add_option("--res", boxResolution)
+    box_options->add_option("--res, --resolution", boxResolution)
       ->description("Resolution of the box mesh (i,j[,k])")
       ->expected(2, 3);
 


### PR DESCRIPTION
This PR:
- Fixes conflict with `flux` option where `--res` is trying to be matched against new flux options `--resources-shape` and `--resources-json` instead of axom executable's `--res` option. Example of failure:
```
$ ctest -V -R "data_collection_util_box2D"
…
549: Test command: /usr/global/tools/flux_wrappers/bin/srun "-n" "2" "/usr/WS1/han12/axom/build-tioga-toss_4_x86_64_ib_cray-llvm-amdgpu@6.4.3_hip-debug/bin/data_collection_util" "--min" "-1" "-1" "--max" "1" "1" "--res" "16" "16" "-p" "1"
549: Working Directory: /usr/WS1/han12/axom/build-tioga-toss_4_x86_64_ib_cray-llvm-amdgpu@6.4.3_hip-debug/tools
549: Environment variables:
549:  OMPI_MCA_rmaps_base_oversubscribe=1
549:  OMP_NUM_THREADS=1
549: Test timeout computed to be: 1500
549: usage: flux run [OPTIONS...] COMMAND [ARGS...]
549: flux run: error: ambiguous option: --res could match --resources-shape, --resources-json
1/1 Test #549: data_collection_util_box2D .......***Failed    0.54 sec
 
0% tests passed, 1 tests failed out of 1
 
Total Test time (real) =   0.61 sec
 
The following tests FAILED:
549 - data_collection_util_box2D (Failed)

```
- Adds an alias `--resolution` to avoid the conflict.