### PR TITLE
FlatMap fixups for CUDA

### DIFF
--- a/src/axom/core/FlatMap.hpp
+++ b/src/axom/core/FlatMap.hpp
@@ -233,6 +233,7 @@ public:
     m_metadata.swap(other.m_metadata);
     m_buckets.swap(other.m_buckets);
     axom::utilities::swap(m_loadCount, other.m_loadCount);
+    axom::utilities::swap(m_allocator, other.m_allocator);
   }
 
   /*!

--- a/src/axom/core/FlatMapUtil.hpp
+++ b/src/axom/core/FlatMapUtil.hpp
@@ -284,28 +284,43 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
   // Assume that all elements will be inserted into an empty slot.
   this->reserve(this->size() + num_elems);
 
+  FlatMap<KeyType, ValueType, Hash> temp;
+  bool allocate_temp_map = false;
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+  if(this->m_allocator.getSpace() == MemorySpace::Pinned)
+  {
+    // Pinned memory is allocated on the CPU, and is not always coherent with respect to the GPU.
+    // Instead of using system-scope atomics, we just construct a temporary map in device memory
+    // and copy it back to the pinned space.
+    axom::Allocator device_allocator {axom::detail::getAllocatorID<MemorySpace::Device>()};
+    temp = FlatMap(*this, device_allocator);
+    allocate_temp_map = true;
+  }
+#endif
+  FlatMap<KeyType, ValueType, Hash>& map = allocate_temp_map ? temp : *this;
+
   // Grab some needed internal fields from the flat map.
   // We're going to be constructing metadata and the K-V pairs directly
   // in-place.
-  const int ngroups_pow_2 = this->m_numGroups2;
-  const auto meta_group = this->m_metadata.view();
-  const auto buckets = this->m_buckets.view();
+  const int ngroups_pow_2 = map.m_numGroups2;
+  const auto meta_group = map.m_metadata.view();
+  const auto buckets = map.m_buckets.view();
 
   // Construct an array of locks per-group. This guards metadata updates for
   // each insertion.
   const IndexType num_groups = 1 << ngroups_pow_2;
-  Array<detail::SpinLock> lock_vec(num_groups, num_groups, this->m_allocator.getID());
+  Array<detail::SpinLock> lock_vec(num_groups, num_groups, map.m_allocator.getID());
   const auto group_locks = lock_vec.view();
 
   // Map bucket slots to k-v pair indices. This is used to deduplicate pairs
   // with the same key value.
-  Array<IndexType> key_index_dedup_vec(0, 0, this->m_allocator.getID());
+  Array<IndexType> key_index_dedup_vec(0, 0, map.m_allocator.getID());
   key_index_dedup_vec.resize(num_groups * GroupBucket::Size, -1);
   const auto key_index_dedup = key_index_dedup_vec.view();
 
   // Map k-v pair indices to bucket slots. This is essentially the inverse of
   // the above mapping.
-  Array<IndexType> key_index_to_bucket_vec(num_elems, num_elems, this->m_allocator.getID());
+  Array<IndexType> key_index_to_bucket_vec(num_elems, num_elems, map.m_allocator.getID());
   const auto key_index_to_bucket = key_index_to_bucket_vec.view();
 
   axom::ReduceSum<ExecSpace, IndexType> total_overwrites(0);
@@ -459,8 +474,19 @@ void FlatMap<KeyType, ValueType, Hash>::insert(InputIt kv_begin, InputIt kv_end)
       }
     });
 
-  this->m_size += total_inserts.get() - total_overwrites.get();
-  this->m_loadCount += total_inserts.get() - total_overwrites.get();
+  map.m_size += total_inserts.get() - total_overwrites.get();
+  map.m_loadCount += total_inserts.get() - total_overwrites.get();
+
+#if defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
+  if(allocate_temp_map)
+  {
+    // Original pinned map is in temp.
+    axom::Allocator pinned_allocator = temp.getAllocator();
+
+    // Move new FlatMap to pinned memory.
+    *this = FlatMap(map, pinned_allocator);
+  }
+#endif
 }
 
 }  // namespace axom

--- a/src/axom/core/memory_management.hpp
+++ b/src/axom/core/memory_management.hpp
@@ -307,6 +307,9 @@ public:
   /// \brief Returns the allocator ID.
   int getID() const { return m_id; }
 
+  /// \brief Returns the MemorySpace type for the given allocator.
+  MemorySpace getSpace() const;
+
 private:
   int m_id;
 };
@@ -647,6 +650,8 @@ inline bool isDeviceAllocator(int allocator_id)
 #else
 inline bool isDeviceAllocator(int AXOM_UNUSED_PARAM(allocator_id)) { return false; }
 #endif
+
+inline MemorySpace Allocator::getSpace() const { return axom::detail::getAllocatorSpace(m_id); }
 
 }  // namespace axom
 

--- a/src/axom/core/tests/core_flatmap.hpp
+++ b/src/axom/core/tests/core_flatmap.hpp
@@ -771,11 +771,16 @@ AXOM_TYPED_TEST(core_flatmap, copy_host_device)
   using DeviceExec = typename TestFixture::DeviceExec;
 
   // CUDA failure - Skip tests if key or value is of type std::string
-  #if defined(AXOM_USE_CUDA)
+  #if defined(AXOM_USE_CUDA) && defined(__GLIBCXX__)
   if constexpr(std::is_same<typename TestFixture::KeyType, std::string>::value ||
                std::is_same<typename TestFixture::ValueType, std::string>::value)
   {
-    return;
+    // Copies of non-trivial types to or from device-only memory on CUDA rely
+    // on the types being "trivially relocatable," just as in axom::Array.
+    //
+    // For libstdc++, std::string is not trivially-relocatable, as it keeps a
+    // pointer to itself in its implementation of small-string optimization.
+    GTEST_SKIP() << "std::string is not supported in device-only memory on GCC's libstdc++";
   }
   #endif
 

--- a/src/axom/core/tests/core_flatmap_for_all.hpp
+++ b/src/axom/core/tests/core_flatmap_for_all.hpp
@@ -85,10 +85,10 @@ using ViewTypes = ::testing::Types<
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_CUDA) && defined(AXOM_USE_UMPIRE)
   FlatMapTestParams<axom::FlatMap<int, double>, axom::CUDA_EXEC<256>, axom::MemorySpace::Device>,
   FlatMapTestParams<axom::FlatMap<int, double>, axom::CUDA_EXEC<256>, axom::MemorySpace::Unified>,
-  // FlatMapTestParams<axom::FlatMap<int, double>, axom::CUDA_EXEC<256>, axom::MemorySpace::Pinned>,
+  FlatMapTestParams<axom::FlatMap<int, double>, axom::CUDA_EXEC<256>, axom::MemorySpace::Pinned>,
   FlatMapTestParams<axom::FlatMap<int, double, ConstantHash<int>>, axom::CUDA_EXEC<256>, axom::MemorySpace::Device>,
   FlatMapTestParams<axom::FlatMap<int, double, ConstantHash<int>>, axom::CUDA_EXEC<256>, axom::MemorySpace::Unified>,
-// FlatMapTestParams<axom::FlatMap<int, double, ConstantHash<int>>, axom::CUDA_EXEC<256>, axom::MemorySpace::Pinned>,
+  FlatMapTestParams<axom::FlatMap<int, double, ConstantHash<int>>, axom::CUDA_EXEC<256>, axom::MemorySpace::Pinned>,
 #endif
 #if defined(AXOM_USE_RAJA) && defined(AXOM_USE_HIP) && defined(AXOM_USE_UMPIRE)
   FlatMapTestParams<axom::FlatMap<int, double>, axom::HIP_EXEC<256>, axom::MemorySpace::Device>,


### PR DESCRIPTION
# Summary

- Works around an issue in batched insertion with a FlatMap allocated in pinned memory. Pinned memory is not coherent with respect to the GPU when using the default device-scoped atomics; to work around this, we allocate a temporary map in the device memory space.
- Clarifies a skipped `core_flatmap` test case with additional comments.