### PR TITLE
Improves error handling/reported for invalid c2c contours

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,6 +36,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   removed in a future version of Axom.
 - Core: Adds Durand-Kerner polynomial solver which returns the complex roots of a univariate polynomial
 - Core: Adds `axom::Array::pop_back` for API compatibility with `std::vector`
+- Primal: Adds KnotVector constructors that skip validity assertion checks, allowing the user to call `isValid()`
+  and handle the error appropriately.
 
 ### Removed
 
@@ -47,6 +49,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ### Fixed
 - Primal: Fixes signs of `compute_moments` to match orientation convention in `primal::evaluate_area_integral`
+- Quest: Improves error handling/reporting when loading an invalid c2c contour
 
 ## [Version 0.14.0] - Release date 2026-03-31
 

--- a/src/axom/primal/geometry/KnotVector.hpp
+++ b/src/axom/primal/geometry/KnotVector.hpp
@@ -271,9 +271,19 @@ public:
     m_knots.clear();
   }
 
-  /// \brief Return if the knot vector is valid
-  ///
-  /// \param [in] verbose When true, emits a warning on the first failing check.
+  /*!
+   *  \brief Return if the knot vector is valid
+   * 
+   *  Checks that the knot vector satisfies all requirements for a valid B-spline/NURBS knot vector:
+   *  degree >= 0, sufficient knots, monotonic sequence, clamped ends, and valid internal multiplicities.
+   * 
+   *  \param [in] verbose When true, emits a warning message describing the first failing check.
+   * 
+   *  \note Only the *first* validation error is reported when \a verbose is true.
+   *        Fix that error and call \a isValid(true) again to discover subsequent errors.
+   * 
+   *  \return true if the knot vector satisfies all validity conditions, false otherwise
+   */
   bool isValid(bool verbose = false) const
   {
     // Check degree

--- a/src/axom/primal/geometry/KnotVector.hpp
+++ b/src/axom/primal/geometry/KnotVector.hpp
@@ -305,14 +305,16 @@ public:
       return false;
     }
 
-    if(m_knots.size() < (m_deg + 1))
+    // For clamped knot vectors, we require at least (p+1) repeated knots at each end
+    const axom::IndexType min_num_knots = static_cast<axom::IndexType>(2 * (m_deg + 1));
+    if(m_knots.size() < min_num_knots)
     {
-      SLIC_WARNING_ROOT_IF(
-        verbose,
-        axom::fmt::format(
-          "Invalid KnotVector: knot array too small for degree (degree={}, num_knots={})",
-          m_deg,
-          m_knots.size()));
+      SLIC_WARNING_ROOT_IF(verbose,
+                           axom::fmt::format("Invalid KnotVector: knot array too small for degree "
+                                             "(degree={}, num_knots={}, min_num_knots={})",
+                                             m_deg,
+                                             m_knots.size(),
+                                             min_num_knots));
       return false;
     }
 

--- a/src/axom/primal/geometry/KnotVector.hpp
+++ b/src/axom/primal/geometry/KnotVector.hpp
@@ -51,6 +51,15 @@ public:
                          "A knot vector must be defined using an arithmetic type");
 
 public:
+  /*!
+   * \brief Tag type to construct a KnotVector without asserting validity in the constructor
+   *
+   * This enables callers to construct a KnotVector from potentially-invalid input,
+   * then explicitly check \a isValid() and handle errors gracefully.
+   */
+  struct SkipValidityChecks
+  { };
+
   ///@{
   /**
    * \name Constructors for KnotVector
@@ -75,18 +84,34 @@ public:
    * \pre The \a knots can be empty when the degree is -1, otherwise knots.data() is not \a nullptr
    * \sa isValid() tests conditions for a valid knot span instance
    */
-  KnotVector(axom::ArrayView<const T> knots, int degree) : m_deg(degree)
+  KnotVector(axom::ArrayView<const T> knots, int degree)
+    : KnotVector(knots, degree, SkipValidityChecks {})
   {
-    SLIC_ASSERT(degree >= -1);
-    SLIC_ASSERT(knots.size() >= (degree + 1));
-    SLIC_ASSERT(knots.empty() || knots.data() != nullptr);
+    SLIC_ASSERT(isValid());
+  }
 
-    if(!knots.empty())
+  /*!
+   * \brief Constructor from a user-supplied knot vector without asserting \a isValid()
+   *
+   * \param [in] knots the knot vector
+   * \param [in] degree the degree of the curve
+   * \param [in] SkipValidityChecks tag to indicate validity is not asserted
+   *
+   * \post The KnotVector degree is at least -1
+   * \post The KnotVector values will be copied when the input \a knots is non-empty and non-null
+   * \note The resulting KnotVector may be invalid; call \a isValid() to verify.
+   */
+  KnotVector(axom::ArrayView<const T> knots, int degree, SkipValidityChecks)
+    : m_deg(axom::utilities::max(degree, -1))
+  {
+    if(knots.empty() || knots.data() == nullptr)
+    {
+      m_deg = -1;
+    }
+    else
     {
       m_knots = knots;
     }
-
-    SLIC_ASSERT(isValid());
   }
 
   /*!
@@ -98,6 +123,15 @@ public:
    */
   KnotVector(axom::ArrayView<T> knots, int degree)
     : KnotVector(axom::ArrayView<const T>(knots.data(), knots.size()), degree)
+  { }
+
+  /*!
+   * \brief Constructor from a user-supplied knot vector (axom::ArrayView<T>) without asserting \a isValid()
+   *
+   * \overload for ArrayView of non-const T
+   */
+  KnotVector(axom::ArrayView<T> knots, int degree, SkipValidityChecks)
+    : KnotVector(axom::ArrayView<const T>(knots.data(), knots.size()), degree, SkipValidityChecks {})
   { }
 
   /// \brief Default constructor for an empty (invalid) knot vector
@@ -127,6 +161,15 @@ public:
   { }
 
   /*!
+   * \brief Constructor from a user-supplied knot vector (C-style array) without asserting \a isValid()
+   *
+   * \see KnotVector(axom::ArrayView<const T> knots, int degree, SkipValidityChecks)
+   */
+  KnotVector(const T* knots, axom::IndexType nkts, int degree, SkipValidityChecks)
+    : KnotVector(axom::ArrayView<const T>(knots, nkts), degree, SkipValidityChecks {})
+  { }
+
+  /*!
    * \brief Constructor from a user-supplied knot vector (axom::Array)
    * 
    * \param [in] knots the knot vector
@@ -135,6 +178,15 @@ public:
    * \see KnotVector(axom::ArrayView<const T> knots, int degree)
    */
   KnotVector(const axom::Array<T>& knots, int degree) : KnotVector(knots.view(), degree) { }
+
+  /*!
+   * \brief Constructor from a user-supplied knot vector (axom::Array) without asserting \a isValid()
+   *
+   * \see KnotVector(axom::ArrayView<const T> knots, int degree, SkipValidityChecks)
+   */
+  KnotVector(const axom::Array<T>& knots, int degree, SkipValidityChecks)
+    : KnotVector(knots.view(), degree, SkipValidityChecks {})
+  { }
 
   ///@}
 
@@ -224,6 +276,12 @@ public:
   {
     // Check degree
     if(m_deg < 0)
+    {
+      return false;
+    }
+
+    // Check knots vector has the correct size and data
+    if(m_knots.size() < (m_deg + 1 || m_knots.data() == nullptr))
     {
       return false;
     }

--- a/src/axom/primal/geometry/KnotVector.hpp
+++ b/src/axom/primal/geometry/KnotVector.hpp
@@ -272,17 +272,37 @@ public:
   }
 
   /// \brief Return if the knot vector is valid
-  bool isValid() const
+  ///
+  /// \param [in] verbose When true, emits a warning on the first failing check.
+  bool isValid(bool verbose = false) const
   {
     // Check degree
     if(m_deg < 0)
     {
+      SLIC_WARNING_ROOT_IF(verbose, "Invalid KnotVector: degree is negative");
       return false;
     }
 
-    // Check knots vector has the correct size and data
-    if(m_knots.size() < (m_deg + 1 || m_knots.data() == nullptr))
+    if(m_knots.empty())
     {
+      SLIC_WARNING_ROOT_IF(verbose, "Invalid KnotVector: knot array is empty");
+      return false;
+    }
+
+    if(m_knots.data() == nullptr)
+    {
+      SLIC_WARNING_ROOT_IF(verbose, "Invalid KnotVector: knot array data pointer is null");
+      return false;
+    }
+
+    if(m_knots.size() < (m_deg + 1))
+    {
+      SLIC_WARNING_ROOT_IF(
+        verbose,
+        axom::fmt::format(
+          "Invalid KnotVector: knot array too small for degree (degree={}, num_knots={})",
+          m_deg,
+          m_knots.size()));
       return false;
     }
 
@@ -291,6 +311,14 @@ public:
     {
       if(m_knots[i] > m_knots[i + 1])
       {
+        SLIC_WARNING_ROOT_IF(
+          verbose,
+          axom::fmt::format(
+            "Invalid KnotVector: knot vector is not monotone (knot[{}]={} > knot[{}]={})",
+            i,
+            m_knots[i],
+            i + 1,
+            m_knots[i + 1]));
         return false;
       }
     }
@@ -303,10 +331,24 @@ public:
     {
       if(m_knots[i] != minKnot)
       {
+        SLIC_WARNING_ROOT_IF(
+          verbose,
+          axom::fmt::format(
+            "Invalid KnotVector: knot vector is not clamped at start (knot[{}]={} != minKnot={})",
+            i,
+            m_knots[i],
+            minKnot));
         return false;
       }
       if(m_knots[nkts - 1 - i] != maxKnot)
       {
+        SLIC_WARNING_ROOT_IF(
+          verbose,
+          axom::fmt::format(
+            "Invalid KnotVector: knot vector is not clamped at end (knot[{}]={} != maxKnot={})",
+            nkts - 1 - i,
+            m_knots[nkts - 1 - i],
+            maxKnot));
         return false;
       }
     }
@@ -326,6 +368,13 @@ public:
         this_multiplicity++;
         if(this_multiplicity > m_deg)
         {
+          SLIC_WARNING_ROOT_IF(
+            verbose,
+            axom::fmt::format("Invalid KnotVector: internal knot multiplicity exceeds degree "
+                              "(knot={}, multiplicity={}, degree={})",
+                              this_knot,
+                              this_multiplicity,
+                              m_deg));
           return false;
         }
       }

--- a/src/axom/primal/geometry/KnotVector.hpp
+++ b/src/axom/primal/geometry/KnotVector.hpp
@@ -87,7 +87,7 @@ public:
   KnotVector(axom::ArrayView<const T> knots, int degree)
     : KnotVector(knots, degree, SkipValidityChecks {})
   {
-    SLIC_ASSERT(isValid());
+    SLIC_ASSERT(isValid(true));
   }
 
   /*!
@@ -97,12 +97,12 @@ public:
    * \param [in] degree the degree of the curve
    * \param [in] SkipValidityChecks tag to indicate validity is not asserted
    *
-   * \post The KnotVector degree is at least -1
+   * \post The KnotVector degree is clamped to be at least -1
    * \post The KnotVector values will be copied when the input \a knots is non-empty and non-null
    * \note The resulting KnotVector may be invalid; call \a isValid() to verify.
    */
   KnotVector(axom::ArrayView<const T> knots, int degree, SkipValidityChecks)
-    : m_deg(axom::utilities::max(degree, -1))
+    : m_deg(axom::utilities::clampLower(degree, -1))
   {
     if(knots.empty() || knots.data() == nullptr)
     {

--- a/src/axom/primal/tests/primal_knot_vector.cpp
+++ b/src/axom/primal/tests/primal_knot_vector.cpp
@@ -439,6 +439,152 @@ TEST(primal_knotvector, split)
   }
 }
 
+//------------------------------------------------------------------------------
+TEST(primal_knotvector, skip_validity_checks_constructors)
+{
+  using SkipTag = primal::KnotVector<double>::SkipValidityChecks;
+
+  constexpr int degree = 2;
+  constexpr int nkts = 9;
+  double valid_knots[] = {0.0, 0.0, 0.0, 0.2, 0.5, 0.8, 1.0, 1.0, 1.0};
+
+  // Test C-array constructor with SkipValidityChecks
+  {
+    primal::KnotVector<double> kvector(valid_knots, nkts, degree, SkipTag {});
+    EXPECT_TRUE(kvector.isValid());
+    EXPECT_EQ(degree, kvector.getDegree());
+    EXPECT_EQ(nkts, kvector.getNumKnots());
+  }
+
+  // Test ArrayView constructor with SkipValidityChecks
+  {
+    axom::ArrayView<double> knots_v(valid_knots, nkts);
+    primal::KnotVector<double> kvector(knots_v, degree, SkipTag {});
+    EXPECT_TRUE(kvector.isValid());
+    EXPECT_EQ(degree, kvector.getDegree());
+  }
+
+  // Test ArrayView<const T> constructor with SkipValidityChecks
+  {
+    axom::ArrayView<const double> knots_v(valid_knots, nkts);
+    primal::KnotVector<double> kvector(knots_v, degree, SkipTag {});
+    EXPECT_TRUE(kvector.isValid());
+    EXPECT_EQ(degree, kvector.getDegree());
+  }
+
+  // Test Array constructor with SkipValidityChecks
+  {
+    axom::Array<double> knot_arr;
+    knot_arr.assign(std::begin(valid_knots), std::end(valid_knots));
+    primal::KnotVector<double> kvector(knot_arr, degree, SkipTag {});
+    EXPECT_TRUE(kvector.isValid());
+    EXPECT_EQ(degree, kvector.getDegree());
+  }
+
+  // Test that invalid input doesn't assert with SkipValidityChecks
+  {
+    double invalid_knots[] = {0.0, 0.0};  // Too few knots
+    primal::KnotVector<double> kvector(invalid_knots, 2, degree, SkipTag {});
+    EXPECT_FALSE(kvector.isValid());
+  }
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_knotvector, validity_checks)
+{
+  using SkipTag = primal::KnotVector<double>::SkipValidityChecks;
+
+  // negative degree is invalid
+  {
+    const int degree = -5;
+    double knots[] = {0.0, 0.0, 1.0, 1.0};
+    primal::KnotVector<double> kvector(knots, 4, degree, SkipTag {});
+
+    EXPECT_FALSE(kvector.isValid());
+    // Degree should be clamped to -1
+    EXPECT_EQ(-1, kvector.getDegree());
+  }
+
+  // empty knot vector is invalid
+  {
+    axom::ArrayView<double> empty_knots(nullptr, 0);
+    primal::KnotVector<double> kvector(empty_knots, 2, SkipTag {});
+
+    EXPECT_FALSE(kvector.isValid());
+    EXPECT_EQ(0, kvector.getNumKnots());
+  }
+
+  // null knot vector is invalid
+  {
+    axom::ArrayView<double> null_knots(nullptr, 5);
+    primal::KnotVector<double> kvector(null_knots, 2, SkipTag {});
+
+    EXPECT_FALSE(kvector.isValid());
+  }
+
+  // knot vector needs to be sufficiently large for the given degree
+  {
+    constexpr int degree = 3;
+    double knots[] = {0.0, 0.0, 1.0};  // Need at least degree+1 = 4 knots
+
+    primal::KnotVector<double> kvector(knots, 3, degree, SkipTag {});
+
+    EXPECT_FALSE(kvector.isValid());
+  }
+
+  // knot vector needs to be monotonic
+  {
+    constexpr int degree = 2;
+    double knots[] = {0.0, 0.0, 0.0, 0.5, 0.3, 1.0, 1.0, 1.0};  // 0.5 > 0.3
+
+    primal::KnotVector<double> kvector(knots, 8, degree, SkipTag {});
+
+    EXPECT_FALSE(kvector.isValid());
+  }
+
+  // knot vector needs to be clamped at start
+  {
+    constexpr int degree = 2;
+    double knots[] = {0.0, 0.0, 0.1, 0.5, 0.8, 1.0, 1.0, 1.0};  // Start not clamped
+
+    primal::KnotVector<double> kvector(knots, 8, degree, SkipTag {});
+
+    EXPECT_FALSE(kvector.isValid());
+  }
+
+  // .. and at end
+  {
+    constexpr int degree = 2;
+    double knots[] = {0.0, 0.0, 0.0, 0.5, 0.8, 0.9, 1.0, 1.0};  // End not clamped
+
+    primal::KnotVector<double> kvector(knots, 8, degree, SkipTag {});
+
+    EXPECT_FALSE(kvector.isValid());
+  }
+
+  // knot vector multiplicities cannot be larger than degree
+  {
+    constexpr int degree = 2;
+    // Internal knot 0.5 has multiplicity 3, which exceeds degree 2
+    double knots[] = {0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0};
+
+    primal::KnotVector<double> kvector(knots, 9, degree, SkipTag {});
+
+    EXPECT_FALSE(kvector.isValid());
+  }
+
+  // .. but can equal degree
+  {
+    constexpr int degree = 3;
+    // Internal knot 0.5 has multiplicity 3, which equals degree - this should be valid
+    double knots[] = {0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0};
+
+    primal::KnotVector<double> kvector(knots, 11, degree, SkipTag {});
+
+    EXPECT_TRUE(kvector.isValid());
+  }
+}
+
 int main(int argc, char* argv[])
 {
   int result = 0;

--- a/src/axom/primal/tests/primal_knot_vector.cpp
+++ b/src/axom/primal/tests/primal_knot_vector.cpp
@@ -532,6 +532,15 @@ TEST(primal_knotvector, validity_checks)
     EXPECT_FALSE(kvector.isValid());
   }
 
+  // knot vector needs enough knots for a clamped vector
+  {
+    constexpr int degree = 2;
+    double knots[] = {0.0, 0.0, 0.0};
+
+    primal::KnotVector<double> kvector(knots, 3, degree, SkipTag {});
+    EXPECT_FALSE(kvector.isValid());
+  }
+
   // knot vector needs to be monotonic
   {
     constexpr int degree = 2;

--- a/src/axom/quest/DiscreteShape.cpp
+++ b/src/axom/quest/DiscreteShape.cpp
@@ -152,18 +152,18 @@ std::shared_ptr<mint::Mesh> DiscreteShape::createMeshRepresentation()
     SLIC_ERROR_ROOT_IF(file_format != "c2c",
                        axom::fmt::format(" '{}' format requires .contour file type", file_format));
 
-    // Get the transforms that are being applied to the mesh. Get them
-    // as a single concatenated matrix.
+    // Get the transforms that are being applied to the mesh as a single concatenated matrix
     auto transform = getTransforms();
 
-    // Pass in the transform so any transformations can figure into computing the revolved volume.
+    // Pass in the transform so any transformations can figure into computing the revolved volume
     axom::mint::Mesh* meshRep = nullptr;
     const bool uniform = !(m_refinementType == DiscreteShape::RefinementDynamic &&
                            m_percentError > MINIMUM_PERCENT_ERROR);
-  #ifdef AXOM_USE_MPI
+
     int rc = quest::internal::READ_FAILED;
     try
     {
+  #ifdef AXOM_USE_MPI
       rc = quest::internal::read_c2c_mesh(shapePath,
                                           uniform,
                                           transform,
@@ -173,25 +173,7 @@ std::shared_ptr<mint::Mesh> DiscreteShape::createMeshRepresentation()
                                           meshRep,
                                           m_revolvedVolume,  // output arg
                                           m_comm);
-    }
-    catch(const std::exception& e)
-    {
-      SLIC_ERROR_ROOT(
-        axom::fmt::format("Failed to read C2C shape '{}' from file '{}'. Exception: {}",
-                          m_shape.getName(),
-                          shapePath,
-                          e.what()));
-    }
-    catch(...)
-    {
-      SLIC_ERROR_ROOT(axom::fmt::format("Failed to read C2C shape '{}' from file '{}'.",
-                                        m_shape.getName(),
-                                        shapePath));
-    }
   #else
-    int rc = quest::internal::READ_FAILED;
-    try
-    {
       rc = quest::internal::read_c2c_mesh(shapePath,
                                           uniform,
                                           transform,
@@ -200,6 +182,7 @@ std::shared_ptr<mint::Mesh> DiscreteShape::createMeshRepresentation()
                                           m_percentError,
                                           meshRep,
                                           m_revolvedVolume);  // output arg
+  #endif
     }
     catch(const std::exception& e)
     {
@@ -215,11 +198,13 @@ std::shared_ptr<mint::Mesh> DiscreteShape::createMeshRepresentation()
                                         m_shape.getName(),
                                         shapePath));
     }
-  #endif
-    SLIC_ERROR_ROOT_IF(rc != quest::internal::READ_SUCCESS,
-                       axom::fmt::format("Failed to read C2C shape '{}' from file '{}'.",
-                                         m_shape.getName(),
-                                         shapePath));
+
+    SLIC_ERROR_ROOT_IF(
+      rc != quest::internal::READ_SUCCESS,
+      axom::fmt::format(
+        "Invalid C2C contour for shape '{}' from file '{}'. See earlier warnings for details.",
+        m_shape.getName(),
+        shapePath));
 
     m_meshRep.reset(meshRep);
 

--- a/src/axom/quest/examples/containment_driver.cpp
+++ b/src/axom/quest/examples/containment_driver.cpp
@@ -69,12 +69,17 @@ public:
   }
 
 #ifdef AXOM_USE_C2C
-  void loadContourMesh(const std::string& inputFile, int segmentsPerKnotSpan)
+  bool loadContourMesh(const std::string& inputFile, int segmentsPerKnotSpan)
   {
     AXOM_ANNOTATE_SCOPE("load c2c");
     quest::C2CReader reader;
     reader.setFileName(inputFile);
-    reader.read();
+    const int rc = reader.read();
+    if(rc != 0)
+    {
+      SLIC_WARNING(axom::fmt::format("Failed to load contour file '{}'", inputFile));
+      return false;
+    }
 
     // Create surface mesh
     m_surfaceMesh.reset(new UMesh(2, mint::SEGMENT));
@@ -82,15 +87,15 @@ public:
     lin.getLinearMeshUniform(reader.getCurvesView(),
                              static_cast<UMesh*>(m_surfaceMesh.get()),
                              segmentsPerKnotSpan);
+    return true;
   }
 #else
-  void loadContourMesh(const std::string& inputFile, int segmentsPerKnotSpan)
+  bool loadContourMesh(const std::string&, int))
   {
-    AXOM_UNUSED_VAR(inputFile);
-    AXOM_UNUSED_VAR(segmentsPerKnotSpan);
-    SLIC_ERROR(
+    SLIC_WARNING(
       "Configuration error: Loading contour files is only supported when Axom "
       "is configured with C2C support.");
+    return false;
   }
 #endif  // AXOM_USE_C2C
 
@@ -608,7 +613,10 @@ int main(int argc, char** argv)
 
   if(is2D)
   {
-    driver2D.loadContourMesh(params.inputFile, params.samplesPerKnotSpan);
+    if(!driver2D.loadContourMesh(params.inputFile, params.samplesPerKnotSpan))
+    {
+      return 1;
+    }
   }
   else
   {

--- a/src/axom/quest/examples/containment_driver.cpp
+++ b/src/axom/quest/examples/containment_driver.cpp
@@ -77,7 +77,9 @@ public:
     const int rc = reader.read();
     if(rc != 0)
     {
-      SLIC_WARNING(axom::fmt::format("Failed to load contour file '{}'", inputFile));
+      SLIC_WARNING(
+        axom::fmt::format("Failed to load contour file '{}'. See earlier warnings for details.",
+                          inputFile));
       return false;
     }
 

--- a/src/axom/quest/examples/containment_driver.cpp
+++ b/src/axom/quest/examples/containment_driver.cpp
@@ -90,7 +90,7 @@ public:
     return true;
   }
 #else
-  bool loadContourMesh(const std::string&, int))
+  bool loadContourMesh(const std::string&, int)
   {
     SLIC_WARNING(
       "Configuration error: Loading contour files is only supported when Axom "

--- a/src/axom/quest/examples/quest_candidates_example.cpp
+++ b/src/axom/quest/examples/quest_candidates_example.cpp
@@ -941,7 +941,7 @@ int main(int argc, char** argv)
 
   // Print total number of pairs across all ranks
   int totalNumCandidates = 0;
-  MPI_Reduce(&numCandidates, &totalNumCandidates, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+  MPI_Reduce(const_cast<int*>(&numCandidates), &totalNumCandidates, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
   if(myRank == 0)
   {
     SLIC_INFO(axom::fmt::format(axom::utilities::locale(),

--- a/src/axom/quest/interface/internal/QuestHelpers.cpp
+++ b/src/axom/quest/interface/internal/QuestHelpers.cpp
@@ -400,7 +400,7 @@ int read_c2c_mesh(const std::string& file,
   }
   else
   {
-    SLIC_WARNING("reading C2C file failed, setting mesh to NULL");
+    SLIC_WARNING_ROOT(axom::fmt::format("reading C2C file '{}' failed, setting mesh to NULL", file));
     m = nullptr;
   }
 

--- a/src/axom/quest/io/C2CReader.cpp
+++ b/src/axom/quest/io/C2CReader.cpp
@@ -17,6 +17,7 @@
 
 #include <fstream>
 #include <string>
+#include <utility>
 
 namespace axom
 {
@@ -30,6 +31,9 @@ int C2CReader::read()
   SLIC_WARNING_IF(m_fileName.empty(), "Missing a filename in C2CReader::read()");
 
   using axom::utilities::string::endsWith;
+
+  // Always clear prior results so callers never observe stale curves after a failed read
+  this->clear();
 
   int ret = 1;
 
@@ -57,8 +61,9 @@ int C2CReader::readContour()
 
   SLIC_INFO(fmt::format("Loading contour with {} pieces", contour.getPieces().size()));
 
-  m_nurbsData.clear();
-  m_nurbsData.reserve(contour.getPieces().size());
+  // Build results transactionally so we don't retain partial curves on error
+  CurveArray nurbs_data;
+  nurbs_data.reserve(contour.getPieces().size());
 
   int piece_index = 0;
   for(auto* piece : contour.getPieces())
@@ -73,6 +78,10 @@ int C2CReader::readContour()
       controlPoints.emplace_back(PointType {pt.getZ().getValue(), pt.getR().getValue()});
     }
     const int npts = static_cast<int>(controlPoints.size());
+    if(npts <= 0)
+    {
+      continue;
+    }
 
     // Load and check knot vector; check degree first then knots
     const auto nkts = static_cast<axom::IndexType>(nurbsData.knots.size());
@@ -84,6 +93,19 @@ int C2CReader::readContour()
                     "{} (npts={}, nkts={})",
                     m_fileName,
                     piece_index,
+                    npts,
+                    nkts));
+      return 1;
+    }
+
+    if(npts <= degree)
+    {
+      SLIC_WARNING(
+        fmt::format("Invalid contour file '{}': piece {} has too few control points for degree "
+                    "(degree={}, npts={}, nkts={})",
+                    m_fileName,
+                    piece_index,
+                    degree,
                     npts,
                     nkts));
       return 1;
@@ -145,16 +167,17 @@ int C2CReader::readContour()
     // Construct NURBSCurve using Array constructors to avoid use-after-free
     if(weights.empty())
     {
-      m_nurbsData.emplace_back(controlPoints, knotvec);
+      nurbs_data.emplace_back(controlPoints, knotvec);
     }
     else
     {
-      m_nurbsData.emplace_back(controlPoints, weights, knotvec);
+      nurbs_data.emplace_back(controlPoints, weights, knotvec);
     }
 
     ++piece_index;
   }
 
+  m_nurbsData = std::move(nurbs_data);
   return 0;
 }
 

--- a/src/axom/quest/io/C2CReader.cpp
+++ b/src/axom/quest/io/C2CReader.cpp
@@ -57,21 +57,93 @@ int C2CReader::readContour()
 
   SLIC_INFO(fmt::format("Loading contour with {} pieces", contour.getPieces().size()));
 
+  m_nurbsData.clear();
+  m_nurbsData.reserve(contour.getPieces().size());
+
+  int piece_index = 0;
   for(auto* piece : contour.getPieces())
   {
     const auto nurbsData = c2c::toNurbs(*piece, m_lengthUnit);
 
+    // Load control points
     axom::Array<PointType> controlPoints;
+    controlPoints.reserve(nurbsData.controlPoints.size());
     for(const auto& pt : nurbsData.controlPoints)
     {
       controlPoints.emplace_back(PointType {pt.getZ().getValue(), pt.getR().getValue()});
     }
+    const auto pts_view = controlPoints.view();
+    const int npts = static_cast<int>(controlPoints.size());
 
-    m_nurbsData.emplace_back(controlPoints.data(),
-                             nurbsData.weights.data(),
-                             controlPoints.size(),
-                             nurbsData.knots.data(),
-                             nurbsData.knots.size());
+    // Load and check knot vector; check degree first then knots
+    const auto nkts = static_cast<axom::IndexType>(nurbsData.knots.size());
+    const int degree = static_cast<int>(nkts - npts - 1);
+    if(degree < 0)
+    {
+      SLIC_WARNING(
+        fmt::format("Invalid contour file '{}': computed negative NURBS degree for piece "
+                    "{} (npts={}, nkts={})",
+                    m_fileName,
+                    piece_index,
+                    npts,
+                    nkts));
+      return 1;
+    }
+
+    const axom::ArrayView<const double> knots_view(nurbsData.knots.data(), nkts);
+    primal::KnotVector<double> knotvec(knots_view,
+                                       degree,
+                                       primal::KnotVector<double>::SkipValidityChecks {});
+
+    if(!knotvec.isValid())
+    {
+      SLIC_WARNING(
+        fmt::format("Invalid contour file '{}': piece {} converted to an invalid NURBS knot vector "
+                    "(degree={}). "
+                    "This can happen for linear splines with duplicate points.",
+                    m_fileName,
+                    piece_index,
+                    degree));
+      m_nurbsData.clear();
+      return 1;
+    }
+
+    // Load and check weights; count must either be 0 or match control points
+    const axom::ArrayView<const double> wts_view(
+      nurbsData.weights.data(),
+      static_cast<axom::IndexType>(nurbsData.weights.size()));
+    if(!wts_view.empty() && wts_view.size() != pts_view.size())
+    {
+      SLIC_WARNING(
+        fmt::format("Invalid contour file '{}': piece {} has {} weights for {} control points",
+                    m_fileName,
+                    piece_index,
+                    wts_view.size(),
+                    npts));
+      m_nurbsData.clear();
+      return 1;
+    }
+
+    // the weights are non-trivial when present and not all equal to 1
+    bool has_non_trivial_weights = false;
+    for(const double& wt : wts_view)
+    {
+      if(wt != 1.0)
+      {
+        has_non_trivial_weights = true;
+      }
+    }
+
+    if(has_non_trivial_weights)
+    {
+      m_nurbsData.emplace_back(pts_view, wts_view, knotvec);
+    }
+    else
+    {
+      m_nurbsData.emplace_back(pts_view, knotvec);
+    }
+
+    ++piece_index;
   }
 
   return 0;

--- a/src/axom/quest/io/C2CReader.cpp
+++ b/src/axom/quest/io/C2CReader.cpp
@@ -106,37 +106,50 @@ int C2CReader::readContour()
     }
 
     // Load and check weights; count must either be 0 or match control points
-    const axom::ArrayView<const double> wts_view(
-      nurbsData.weights.data(),
-      static_cast<axom::IndexType>(nurbsData.weights.size()));
-    if(!wts_view.empty() && wts_view.size() != controlPoints.size())
+    axom::Array<double> weights;
+    if(!nurbsData.weights.empty())
     {
-      SLIC_WARNING(
-        fmt::format("Invalid contour file '{}': piece {} has {} weights for {} control points",
-                    m_fileName,
-                    piece_index,
-                    wts_view.size(),
-                    npts));
-      return 1;
-    }
-
-    // the weights are non-trivial when present and not all equal to 1
-    bool has_non_trivial_weights = false;
-    for(const double& wt : wts_view)
-    {
-      if(wt != 1.0)
+      if(static_cast<axom::IndexType>(nurbsData.weights.size()) != controlPoints.size())
       {
-        has_non_trivial_weights = true;
+        SLIC_WARNING(
+          fmt::format("Invalid contour file '{}': piece {} has {} weights for {} control points",
+                      m_fileName,
+                      piece_index,
+                      nurbsData.weights.size(),
+                      npts));
+        return 1;
+      }
+
+      // Check if weights are non-trivial (present and not all equal to 1)
+      bool has_non_trivial_weights = false;
+      for(const double& wt : nurbsData.weights)
+      {
+        if(wt != 1.0)
+        {
+          has_non_trivial_weights = true;
+          break;
+        }
+      }
+
+      // Only copy weights if they are non-trivial
+      if(has_non_trivial_weights)
+      {
+        weights.reserve(nurbsData.weights.size());
+        for(const double& wt : nurbsData.weights)
+        {
+          weights.push_back(wt);
+        }
       }
     }
 
-    if(has_non_trivial_weights)
+    // Construct NURBSCurve using Array constructors to avoid use-after-free
+    if(weights.empty())
     {
-      m_nurbsData.emplace_back(controlPoints.view(), wts_view, knotvec);
+      m_nurbsData.emplace_back(controlPoints, knotvec);
     }
     else
     {
-      m_nurbsData.emplace_back(controlPoints.view(), knotvec);
+      m_nurbsData.emplace_back(controlPoints, weights, knotvec);
     }
 
     ++piece_index;

--- a/src/axom/quest/io/C2CReader.cpp
+++ b/src/axom/quest/io/C2CReader.cpp
@@ -95,12 +95,12 @@ int C2CReader::readContour()
                                        degree,
                                        primal::KnotVector<double>::SkipValidityChecks {});
 
-    if(!knotvec.isValid())
+    if(!knotvec.isValid(true))
     {
       SLIC_WARNING(
         fmt::format("Invalid contour file '{}': piece {} converted to an invalid NURBS knot vector "
                     "(degree={}). "
-                    "This can happen for linear splines with duplicate points.",
+                    "See previous warning for the first invalidity reason.",
                     m_fileName,
                     piece_index,
                     degree));

--- a/src/axom/quest/io/C2CReader.cpp
+++ b/src/axom/quest/io/C2CReader.cpp
@@ -72,7 +72,6 @@ int C2CReader::readContour()
     {
       controlPoints.emplace_back(PointType {pt.getZ().getValue(), pt.getR().getValue()});
     }
-    const auto pts_view = controlPoints.view();
     const int npts = static_cast<int>(controlPoints.size());
 
     // Load and check knot vector; check degree first then knots
@@ -99,12 +98,10 @@ int C2CReader::readContour()
     {
       SLIC_WARNING(
         fmt::format("Invalid contour file '{}': piece {} converted to an invalid NURBS knot vector "
-                    "(degree={}). "
-                    "See previous warning for the first invalidity reason.",
+                    "(degree={}).",
                     m_fileName,
                     piece_index,
                     degree));
-      m_nurbsData.clear();
       return 1;
     }
 
@@ -112,7 +109,7 @@ int C2CReader::readContour()
     const axom::ArrayView<const double> wts_view(
       nurbsData.weights.data(),
       static_cast<axom::IndexType>(nurbsData.weights.size()));
-    if(!wts_view.empty() && wts_view.size() != pts_view.size())
+    if(!wts_view.empty() && wts_view.size() != controlPoints.size())
     {
       SLIC_WARNING(
         fmt::format("Invalid contour file '{}': piece {} has {} weights for {} control points",
@@ -120,7 +117,6 @@ int C2CReader::readContour()
                     piece_index,
                     wts_view.size(),
                     npts));
-      m_nurbsData.clear();
       return 1;
     }
 
@@ -136,11 +132,11 @@ int C2CReader::readContour()
 
     if(has_non_trivial_weights)
     {
-      m_nurbsData.emplace_back(pts_view, wts_view, knotvec);
+      m_nurbsData.emplace_back(controlPoints.view(), wts_view, knotvec);
     }
     else
     {
-      m_nurbsData.emplace_back(pts_view, knotvec);
+      m_nurbsData.emplace_back(controlPoints.view(), knotvec);
     }
 
     ++piece_index;

--- a/src/axom/quest/tests/quest_c2c_reader.cpp
+++ b/src/axom/quest/tests/quest_c2c_reader.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "axom/config.hpp"
+#include "axom/core/utilities/FileUtilities.hpp"
 
 #ifndef AXOM_USE_C2C
   #error These tests should only be included when Axom is configured with C2C
@@ -226,6 +227,23 @@ TEST(quest_c2c_reader, interpolate_spline)
   mint::write_vtk(mesh, "test_spline.vtk");
 
   delete mesh;
+}
+
+TEST(quest_c2c_reader, duplicate_point_linear_fails_gracefully)
+{
+#ifdef AXOM_DATA_DIR
+  // This file contains an invalid contour -- reading the files should return non-zero
+  const auto fileName =
+    axom::utilities::filesystem::joinPath(AXOM_DATA_DIR, "contours/duplicate_point_linear.contour");
+
+  quest::C2CReader reader;
+  reader.setFileName(fileName);
+
+  EXPECT_NE(0, reader.read());
+  EXPECT_EQ(0, reader.getCurvesView().size());
+#else
+  GTEST_SKIP() << "AXOM_DATA_DIR not defined";
+#endif
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/quest/tests/quest_sampling_shaper.cpp
+++ b/src/axom/quest/tests/quest_sampling_shaper.cpp
@@ -785,6 +785,37 @@ shapes:
   }
 }
 
+TEST_F(SamplingShaperTest2D, duplicate_point_linear_contour_aborts)
+{
+#if defined(AXOM_USE_C2C) && defined(AXOM_DATA_DIR)
+  const auto& testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();
+
+  const auto contour_file = fs::joinPath(AXOM_DATA_DIR, "contours/duplicate_point_linear.contour");
+
+  const std::string shape_template = R"(
+dimensions: 2
+
+shapes:
+- name: dup_linear
+  material: {}
+  geometry:
+    format: c2c
+    path: {}
+)";
+
+  fs::TempFile shape_file(testname, ".yaml");
+  shape_file.write(axom::fmt::format(axom::fmt::runtime(shape_template), "dupMat", contour_file));
+
+  this->validateShapeFile(shape_file.getPath());
+  this->initializeShaping(shape_file.getPath());
+
+  slic::ScopedAbortToThrow abort_guard;
+  EXPECT_THROW(this->runShaping(), slic::SlicAbortException);
+#else
+  GTEST_SKIP() << "Test requires AXOM_USE_C2C and AXOM_DATA_DIR";
+#endif
+}
+
 TEST_F(SamplingShaperTest2D, basic_circle_projector)
 {
   const auto& testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();


### PR DESCRIPTION
# Summary

- This PR improves error handling and reporting when loading invalid c2c contour files
- It adds constructors to `primal::KnotVector` to skip validity assertions during construction.
   - This allows users to call `isValid` and handle invalid inputs appropriately.
   - Previously, the construction would assert, and fail without error messages in Debug configs, and silently chug along in Release configs
 - It also improves our handling/reporting of errors in the shaping application and other examples that load c2c files
- Resolves https://github.com/llnl/axom/issues/1879
- Depends on https://github.com/llnl/axom_data/pull/38