### PR TITLE
Temper randomness in 3D GWN method 

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -50,6 +50,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ### Fixed
 - Primal: Fixes signs of `compute_moments` to match orientation convention in `primal::evaluate_area_integral`
 - Quest: Improves error handling/reporting when loading an invalid c2c contour
+- Primal: Improves reproducibility of 3D GWN methods by removing some sources of randomness
 
 ## [Version 0.14.0] - Release date 2026-03-31
 

--- a/src/axom/primal/operators/detail/winding_number_3d_impl.hpp
+++ b/src/axom/primal/operators/detail/winding_number_3d_impl.hpp
@@ -577,10 +577,28 @@ double nurbs_winding_number(const Point<T, 3>& query,
    * of the surface at known locations.
    */
 
-  // Lambda to generate an entirely random unit vector
-  auto random_unit = []() -> Vector<T, 3> {
-    double theta = axom::utilities::random_real(0.0, 2 * M_PI);
-    double u = axom::utilities::random_real(-1.0, 1.0);
+  // If a new cast direction is needed, use an (2, 3)-Halton sequence
+  //  projected onto the sphere to pick the next direction
+  auto halton = [](int i, int base) -> T {
+    T f = 1.0;
+    T r = 0.0;
+    while(i > 0)
+    {
+      f /= base;
+      r += f * (i % base);
+      i /= base;
+    }
+    return r;
+  };
+
+  // Shift the entire sequence by the original cast direction
+  const T cast_direction_u = (1.0 - cast_direction[2]) / 2.0 - halton(1, 2);
+  const T cast_direction_v =
+    (0.5 * M_1_PI * std::atan2(cast_direction[1], cast_direction[0]) + 1.0) - halton(1, 3);
+
+  auto recast_direction = [&](int attempt) -> Vector<T, 3> {
+    T theta = 2.0 * M_PI * std::fmod(halton(attempt + 1, 3) + cast_direction_v + 1.0, 1.0);
+    T u = 2.0 * std::fmod(halton(attempt + 1, 2) + cast_direction_u + 1.0, 1.0) - 1.0;
     return Vector<T, 3> {sin(theta) * sqrt(1 - u * u), cos(theta) * sqrt(1 - u * u), u};
   };
 
@@ -594,7 +612,8 @@ double nurbs_winding_number(const Point<T, 3>& query,
     auto request_recast = [&]() -> bool {
       if(can_recast)
       {
-        cast_direction_local = random_unit();
+        cast_direction_local = recast_direction(recast_attempt + 1);
+
         return true;
       }
       return false;
@@ -848,8 +867,8 @@ double nurbs_winding_number(const Point<T, 3>& query,
           //  with a cast ray that is mostly in the direction of the normal (assuming it's non-zero)
           Vector<T, 3> new_cast_direction = the_disk.normal(up[i], vp[i]);
           new_cast_direction = (new_cast_direction.norm() < EPS)
-            ? random_unit()
-            : (new_cast_direction.unitVector() + 0.1 * random_unit()).unitVector();
+            ? recast_direction(recast_attempt + 1)
+            : (new_cast_direction.unitVector() + 0.1 * recast_direction(recast_attempt + 1)).unitVector();
 
           the_gwn += nurbs_winding_number(query,
                                           the_disk,

--- a/src/axom/primal/operators/detail/winding_number_3d_memoization.hpp
+++ b/src/axom/primal/operators/detail/winding_number_3d_memoization.hpp
@@ -268,11 +268,18 @@ public:
     // For symmetric patches (e.g. cylinders), the numerator can be close to 0 due to cancellation.
     constexpr double k_dir_eps = 1e-3;
 
-    // Generate a random direction
-    double theta = axom::utilities::random_real(0.0, 2 * M_PI);
-    double u = axom::utilities::random_real(-1.0, 1.0);
+    // Generate a random direction with simple hashes
+    unsigned int seed1 =
+      std::hash<T> {}(m_bBox.getMin()[0] + m_bBox.getMin()[1] + m_bBox.getMin()[2]);
+    unsigned int seed2 =
+      std::hash<T> {}(m_bBox.getMax()[0] + m_bBox.getMax()[1] + m_bBox.getMax()[2]);
+
+    double theta = axom::utilities::random_real(0.0, 2 * M_PI, seed1);
+    double u = axom::utilities::random_real(-1.0, 1.0, seed2);
     const auto random_unit =
       Vector<T, 3> {sin(theta) * sqrt(1 - u * u), cos(theta) * sqrt(1 - u * u), u};
+
+    m_castDirection = m_normal.unitVector();
 
     // If the average normal is too small, use the random direction as-is
     if((m_surfaceArea <= 0.0) || (m_normal.norm() / m_surfaceArea) < k_dir_eps)

--- a/src/axom/primal/operators/detail/winding_number_3d_memoization.hpp
+++ b/src/axom/primal/operators/detail/winding_number_3d_memoization.hpp
@@ -279,8 +279,6 @@ public:
     const auto random_unit =
       Vector<T, 3> {sin(theta) * sqrt(1 - u * u), cos(theta) * sqrt(1 - u * u), u};
 
-    m_castDirection = m_normal.unitVector();
-
     // If the average normal is too small, use the random direction as-is
     if((m_surfaceArea <= 0.0) || (m_normal.norm() / m_surfaceArea) < k_dir_eps)
     {

--- a/src/axom/primal/tests/primal_solid_angle.cpp
+++ b/src/axom/primal/tests/primal_solid_angle.cpp
@@ -674,6 +674,13 @@ TEST(primal_solid_angle, teardrop_regression_test)
     const bool calc_containment = (std::round(gwn_array[n]) != 0);
     EXPECT_EQ(calc_containment, true_containment_arr[n]);
   }
+
+  // Verify determinism of GWN calculation
+  double gwn_1 = axom::primal::winding_number(query_arr[tot_npts / 2], teardrop_shape[0]);
+  double gwn_2 = axom::primal::winding_number(query_arr[tot_npts / 2], teardrop_shape[0]);
+
+  // Should be equal in double precision
+  EXPECT_EQ(gwn_1, gwn_2);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
I've noticed that the text `primal_solid_angle_test` fails a bit more frequently than I'd like, as the underlying 3D GWN method has a few random components that fail with probability 0 mathematically, but probability >0 in floating point (by my estimate, about 0.1% of the time). 

In particular, this PR addresses:
 - Within the GWN algorithm, a re-cast ray was taken to be a random unit vector. This has been reworked to use a Halton sequence projected onto the unit sphere, which also has the advantage of more reliably distributing the cast attempts over the unit sphere.
 - The per-surface cast-direction is taken to be the surface's average normal, plus a small perturbation. This has been changed so that the perturbation is seeded deterministically based on a (possibly too-simple) hashed function of the surface bounding box.

I've also added a simple test to verify this in `primal_solid_angle.cpp`.
