### PR TITLE
Inlet: add ability to have collections with variant values

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -38,6 +38,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Core: Adds `axom::Array::pop_back` for API compatibility with `std::vector`
 - Primal: Adds KnotVector constructors that skip validity assertion checks, allowing the user to call `isValid()`
   and handle the error appropriately.
+- Inlet: Added the ability to have collections (array and dictionary) with variant values.
 
 ### Removed
 

--- a/src/axom/inlet/CMakeLists.txt
+++ b/src/axom/inlet/CMakeLists.txt
@@ -25,6 +25,7 @@ set(inlet_headers
     Container.hpp 
     Proxy.hpp
     VariantKey.hpp
+    VariantValue.hpp
     Verifiable.hpp
     VerifiableScalar.hpp
     Writer.hpp

--- a/src/axom/inlet/ConduitReader.cpp
+++ b/src/axom/inlet/ConduitReader.cpp
@@ -176,6 +176,16 @@ void arrayToMap(const conduit::DataArray<ConduitType>& array,
   }
 }
 
+void boolArrayToMap(const conduit::DataArray<conduit::uint8>& array,
+                    std::unordered_map<int, VariantValue>& map)
+{
+  map.clear();
+  for(conduit::index_t i = 0; i < array.number_of_elements(); i++)
+  {
+    map[i] = VariantValue {static_cast<bool>(array[i])};
+  }
+}
+
 /*!
  *******************************************************************************
  * \brief Recursive name retrieval function - adds the names of all descendents
@@ -382,7 +392,7 @@ ReaderResult ConduitReader::getStringMap(const std::string& id,
 ReaderResult ConduitReader::getVariantMap(const std::string& id,
                                           std::unordered_map<int, VariantValue>& values)
 {
-  return getArray(id, values);
+  return getVariantArray(id, values);
 }
 
 ReaderResult ConduitReader::getVariantMap(const std::string& id,
@@ -560,6 +570,85 @@ ReaderResult ConduitReader::getArray(const std::string& id, std::unordered_map<i
     {
       T value;
       // Inlet allows for heterogenous collections, but a failure here must be reported
+      const auto result = getValue(&child, value);
+      if(result == ReaderResult::Success)
+      {
+        values[index] = value;
+      }
+      else
+      {
+        contains_other_type = true;
+      }
+      index++;
+    }
+    return collectionRetrievalResult(contains_other_type, !values.empty());
+  }
+  return ReaderResult::Success;
+}
+
+ReaderResult ConduitReader::getVariantArray(const std::string& id,
+                                            std::unordered_map<int, VariantValue>& values)
+{
+  values.clear();
+  const auto node_ptr = detail::traverseNode(m_root, id);
+  if(!node_ptr)
+  {
+    return ReaderResult::NotFound;
+  }
+  const auto& node = *node_ptr;
+  // If it's empty, then the array must have been empty, which counts as successful
+  if(node.dtype().is_empty())
+  {
+    return ReaderResult::Success;
+  }
+  // Dense primitive arrays can be copied directly. JSON booleans are represented
+  // by Conduit as uint8 arrays, so treat that case as bool instead of int.
+  else if(node.dtype().number_of_elements() > 1 && !node.dtype().is_list() &&
+          !node.dtype().is_object())
+  {
+    if(node.dtype().is_floating_point())
+    {
+      detail::arrayToMap(node.as_double_array(), values);
+    }
+    else if(node.dtype().is_int32())
+    {
+      detail::arrayToMap(node.as_int32_array(), values);
+    }
+    else if(node.dtype().is_int64())
+    {
+      detail::arrayToMap(node.as_int64_array(), values);
+    }
+    else if((m_protocol == "json") && node.dtype().is_uint8())
+    {
+      detail::boolArrayToMap(node.as_uint8_array(), values);
+    }
+    else
+    {
+      return ReaderResult::WrongType;
+    }
+  }
+  else if(!node.dtype().is_list() && !node.dtype().is_object())
+  {
+    // Single-element arrays will be just the element itself
+    // If it's a single element, we know the index is zero
+    VariantValue value;
+    const auto result = getValue(&node, value);
+    if(result == ReaderResult::Success)
+    {
+      values[0] = value;
+    }
+    else
+    {
+      return result;
+    }
+  }
+  else
+  {
+    conduit::index_t index = 0;
+    bool contains_other_type = false;
+    for(const auto& child : node.children())
+    {
+      VariantValue value;
       const auto result = getValue(&child, value);
       if(result == ReaderResult::Success)
       {

--- a/src/axom/inlet/ConduitReader.cpp
+++ b/src/axom/inlet/ConduitReader.cpp
@@ -155,6 +155,27 @@ void arrayToMap(const conduit::DataArray<ConduitType>& array,
   }
 }
 
+template <typename ConduitType>
+void arrayToMap(const conduit::DataArray<ConduitType>& array,
+                std::unordered_map<int, VariantValue>& map)
+{
+  map.clear();
+  for(conduit::index_t i = 0; i < array.number_of_elements(); i++)
+  {
+    if(std::is_floating_point<ConduitType>::value)
+    {
+      const double double_value = array[i];
+      const int int_value = static_cast<int>(double_value);
+      map[i] = (static_cast<double>(int_value) == double_value) ? VariantValue {int_value}
+                                                                : VariantValue {double_value};
+    }
+    else
+    {
+      map[i] = VariantValue {static_cast<int>(array[i])};
+    }
+  }
+}
+
 /*!
  *******************************************************************************
  * \brief Recursive name retrieval function - adds the names of all descendents
@@ -259,6 +280,39 @@ ReaderResult ConduitReader::getValue(const conduit::Node* node, bool& value)
   return node->dtype().is_empty() ? ReaderResult::NotFound : ReaderResult::WrongType;
 }
 
+ReaderResult ConduitReader::getValue(const conduit::Node* node, VariantValue& value)
+{
+  if(!node)
+  {
+    return ReaderResult::NotFound;
+  }
+
+  bool bool_value = false;
+  if(getValue(node, bool_value) == ReaderResult::Success)
+  {
+    value = bool_value;
+    return ReaderResult::Success;
+  }
+
+  if(node->dtype().is_number() && !node->dtype().is_uint8())
+  {
+    const double double_value = node->to_double();
+    const int int_value = node->to_int();
+    value = (static_cast<double>(int_value) == double_value) ? VariantValue {int_value}
+                                                             : VariantValue {double_value};
+    return ReaderResult::Success;
+  }
+
+  std::string string_value;
+  if(getValue(node, string_value) == ReaderResult::Success)
+  {
+    value = string_value;
+    return ReaderResult::Success;
+  }
+
+  return node->dtype().is_empty() ? ReaderResult::NotFound : ReaderResult::WrongType;
+}
+
 ReaderResult ConduitReader::getBool(const std::string& id, bool& value)
 {
   return getValue(detail::traverseNode(m_root, id), value);
@@ -321,6 +375,18 @@ ReaderResult ConduitReader::getBoolMap(const std::string& id,
 
 ReaderResult ConduitReader::getStringMap(const std::string& id,
                                          std::unordered_map<VariantKey, std::string>& values)
+{
+  return getDictionary(id, values);
+}
+
+ReaderResult ConduitReader::getVariantMap(const std::string& id,
+                                          std::unordered_map<int, VariantValue>& values)
+{
+  return getArray(id, values);
+}
+
+ReaderResult ConduitReader::getVariantMap(const std::string& id,
+                                          std::unordered_map<VariantKey, VariantValue>& values)
 {
   return getDictionary(id, values);
 }

--- a/src/axom/inlet/ConduitReader.hpp
+++ b/src/axom/inlet/ConduitReader.hpp
@@ -122,6 +122,8 @@ private:
 
   template <typename T>
   ReaderResult getArray(const std::string& id, std::unordered_map<int, T>& values);
+  ReaderResult getVariantArray(const std::string& id,
+                               std::unordered_map<int, VariantValue>& values);
   conduit::Node m_root;
   const std::string m_protocol;
 };

--- a/src/axom/inlet/ConduitReader.hpp
+++ b/src/axom/inlet/ConduitReader.hpp
@@ -76,6 +76,11 @@ public:
   ReaderResult getStringMap(const std::string& id,
                             std::unordered_map<VariantKey, std::string>& values) override;
 
+  ReaderResult getVariantMap(const std::string& id,
+                             std::unordered_map<int, VariantValue>& values) override;
+  ReaderResult getVariantMap(const std::string& id,
+                             std::unordered_map<VariantKey, VariantValue>& values) override;
+
   ReaderResult getIndices(const std::string& id, std::vector<int>& indices) override;
   ReaderResult getIndices(const std::string& id, std::vector<VariantKey>& indices) override;
 
@@ -110,6 +115,7 @@ private:
   ReaderResult getValue(const conduit::Node* node, std::string& value);
   ReaderResult getValue(const conduit::Node* node, double& value);
   ReaderResult getValue(const conduit::Node* node, bool& value);
+  ReaderResult getValue(const conduit::Node* node, VariantValue& value);
 
   template <typename T>
   ReaderResult getDictionary(const std::string& id, std::unordered_map<VariantKey, T>& values);

--- a/src/axom/inlet/ConduitReader.hpp
+++ b/src/axom/inlet/ConduitReader.hpp
@@ -122,8 +122,7 @@ private:
 
   template <typename T>
   ReaderResult getArray(const std::string& id, std::unordered_map<int, T>& values);
-  ReaderResult getVariantArray(const std::string& id,
-                               std::unordered_map<int, VariantValue>& values);
+  ReaderResult getVariantArray(const std::string& id, std::unordered_map<int, VariantValue>& values);
   conduit::Node m_root;
   const std::string m_protocol;
 };

--- a/src/axom/inlet/Container.cpp
+++ b/src/axom/inlet/Container.cpp
@@ -504,14 +504,13 @@ std::vector<VariantKey> registerCollection(Container& container,
 
 void addVariantValue(Container& container, const std::string& key, const VariantValue& value)
 {
-  std::visit([&container, &key](const auto& concrete_value) {
-    container.addPrimitive(key, "", true, concrete_value);
-  }, value);
+  std::visit([&container, &key](
+               const auto& concrete_value) { container.addPrimitive(key, "", true, concrete_value); },
+             value);
 }
 
-std::vector<VariantKey> registerCollection(
-  Container& container,
-  const std::unordered_map<int, VariantValue>& collection)
+std::vector<VariantKey> registerCollection(Container& container,
+                                           const std::unordered_map<int, VariantValue>& collection)
 {
   std::vector<VariantKey> result;
   for(const auto& entry : collection)
@@ -522,9 +521,8 @@ std::vector<VariantKey> registerCollection(
   return result;
 }
 
-std::vector<VariantKey> registerCollection(
-  Container& container,
-  const std::unordered_map<VariantKey, VariantValue>& collection)
+std::vector<VariantKey> registerCollection(Container& container,
+                                           const std::unordered_map<VariantKey, VariantValue>& collection)
 {
   std::vector<VariantKey> result;
   for(const auto& entry : collection)

--- a/src/axom/inlet/Container.cpp
+++ b/src/axom/inlet/Container.cpp
@@ -188,6 +188,12 @@ Verifiable<Container>& Container::addStringArray(const std::string& name,
   return addPrimitiveArray<std::string>(name, description);
 }
 
+Verifiable<Container>& Container::addVariantArray(const std::string& name,
+                                                  const std::string& description)
+{
+  return addPrimitiveArray<VariantValue>(name, description);
+}
+
 template <typename Key>
 Container& Container::addStructCollection(const std::string& name, const std::string& description)
 {
@@ -249,6 +255,12 @@ Verifiable<Container>& Container::addStringDictionary(const std::string& name,
                                                       const std::string& description)
 {
   return addPrimitiveArray<std::string>(name, description, true);
+}
+
+Verifiable<Container>& Container::addVariantDictionary(const std::string& name,
+                                                       const std::string& description)
+{
+  return addPrimitiveArray<VariantValue>(name, description, true);
 }
 
 Container& Container::addStructDictionary(const std::string& name, const std::string& description)
@@ -490,6 +502,46 @@ std::vector<VariantKey> registerCollection(Container& container,
   return result;
 }
 
+void addVariantValue(Container& container, const std::string& key, const VariantValue& value)
+{
+  std::visit([&container, &key](const auto& concrete_value) {
+    container.addPrimitive(key, "", true, concrete_value);
+  }, value);
+}
+
+std::vector<VariantKey> registerCollection(
+  Container& container,
+  const std::unordered_map<int, VariantValue>& collection)
+{
+  std::vector<VariantKey> result;
+  for(const auto& entry : collection)
+  {
+    result.push_back(entry.first);
+    addVariantValue(container, std::to_string(entry.first), entry.second);
+  }
+  return result;
+}
+
+std::vector<VariantKey> registerCollection(
+  Container& container,
+  const std::unordered_map<VariantKey, VariantValue>& collection)
+{
+  std::vector<VariantKey> result;
+  for(const auto& entry : collection)
+  {
+    result.push_back(entry.first);
+    auto string_key = indexToString(entry.first);
+    const auto illegal_char_loc = string_key.find_first_of("/[]");
+    SLIC_ERROR_IF(illegal_char_loc != std::string::npos,
+                  fmt::format("[Inlet] Dictionary key '{0}' contains illegal character '{1}'",
+                              string_key,
+                              string_key[illegal_char_loc]));
+    SLIC_ERROR_IF(string_key.empty(), "[Inlet] Dictionary key cannot be the empty string");
+    addVariantValue(container, string_key, entry.second);
+  }
+  return result;
+}
+
 /*!
  *****************************************************************************
  * \brief Implementation helper for adding primitive arrays
@@ -555,6 +607,18 @@ struct PrimitiveArrayHelper<Key, std::string>
   {
     std::unordered_map<Key, std::string> map;
     const auto result = reader.getStringMap(lookupPath, map);
+    markRetrievalStatus(*container.sidreGroup(), result);
+    return registerCollection(container, map);
+  }
+};
+
+template <typename Key>
+struct PrimitiveArrayHelper<Key, VariantValue>
+{
+  static std::vector<VariantKey> add(Container& container, Reader& reader, const std::string& lookupPath)
+  {
+    std::unordered_map<Key, VariantValue> map;
+    const auto result = reader.getVariantMap(lookupPath, map);
     markRetrievalStatus(*container.sidreGroup(), result);
     return registerCollection(container, map);
   }

--- a/src/axom/inlet/Container.hpp
+++ b/src/axom/inlet/Container.hpp
@@ -29,6 +29,7 @@
 #include "axom/inlet/Reader.hpp"
 #include "axom/inlet/inlet_utils.hpp"
 #include "axom/inlet/VariantKey.hpp"
+#include "axom/inlet/VariantValue.hpp"
 #include "axom/inlet/Verifiable.hpp"
 
 #include "axom/sidre.hpp"
@@ -80,6 +81,13 @@ struct is_inlet_primitive
   static constexpr bool value = std::is_same<BaseType, bool>::value ||
     std::is_same<BaseType, int>::value || std::is_same<BaseType, double>::value ||
     std::is_same<BaseType, std::string>::value;
+};
+
+template <typename T>
+struct is_variant_value
+{
+  using BaseType = typename std::decay<T>::type;
+  static constexpr bool value = std::is_same<BaseType, VariantValue>::value;
 };
 
 /*!
@@ -448,6 +456,19 @@ public:
 
   /*!
    *****************************************************************************
+   * \brief Add an array of mixed primitive Fields to the input file schema.
+   *
+   * \param [in] name Name of the array
+   * \param [in] description Description of the Field
+   *
+   * \return Reference to the created array
+   *****************************************************************************
+   */
+  Verifiable<Container>& addVariantArray(const std::string& name,
+                                         const std::string& description = "");
+
+  /*!
+   *****************************************************************************
    * \brief Add an array of Fields to the input file schema.
    *
    * \param [in] name Name of the array
@@ -507,6 +528,19 @@ public:
    */
   Verifiable<Container>& addStringDictionary(const std::string& name,
                                              const std::string& description = "");
+
+  /*!
+   *****************************************************************************
+   * \brief Add a dictionary of mixed primitive Fields to the input file schema.
+   *
+   * \param [in] name Name of the dict
+   * \param [in] description Description of the dictionary
+   *
+   * \return Reference to the created dictionary
+   *****************************************************************************
+   */
+  Verifiable<Container>& addVariantDictionary(const std::string& name,
+                                              const std::string& description = "");
 
   /*!
    *****************************************************************************
@@ -635,6 +669,45 @@ public:
 
   /*!
    *******************************************************************************
+   * \brief Returns a stored mixed primitive value.
+   * 
+   * \param [in] name Name of the Field value to be gotten
+   * \return The retrieved value
+   * 
+   * \tparam T The variant value type
+   *******************************************************************************
+   */
+  template <typename T>
+  typename std::enable_if<detail::is_variant_value<T>::value, T>::type get(const std::string& name) const
+  {
+    if(!hasField(name))
+    {
+      const std::string msg = fmt::format(
+        "[Inlet] Field with specified path "
+        "does not exist: {0}",
+        name);
+      SLIC_ERROR(msg);
+    }
+
+    const Field& field = getField(name);
+    switch(field.type())
+    {
+    case InletType::Bool:
+      return field.get<bool>();
+    case InletType::Integer:
+      return field.get<int>();
+    case InletType::Double:
+      return field.get<double>();
+    case InletType::String:
+      return field.get<std::string>();
+    default:
+      SLIC_ERROR(fmt::format("[Inlet] Field with specified path is not a variant value: {0}", name));
+      return {};
+    }
+  }
+
+  /*!
+   *******************************************************************************
    * \brief Returns a stored value of user-defined type.
    * 
    * Retrieves a value of user-defined type.
@@ -649,7 +722,8 @@ public:
    */
   template <typename T>
   typename std::enable_if<!detail::is_inlet_primitive<T>::value && !detail::is_inlet_array<T>::value &&
-                            !detail::is_inlet_dict<T>::value && !detail::is_std_vector<T>::value,
+                            !detail::is_inlet_dict<T>::value && !detail::is_std_vector<T>::value &&
+                            !detail::is_variant_value<T>::value,
                           T>::type
   get(const std::string& name = "") const
   {
@@ -928,7 +1002,8 @@ private:
    *****************************************************************************
    */
   template <typename T,
-            typename SFINAE = typename std::enable_if<detail::is_inlet_primitive<T>::value>::type>
+            typename SFINAE = typename std::enable_if<detail::is_inlet_primitive<T>::value ||
+                                                      detail::is_variant_value<T>::value>::type>
   Verifiable<Container>& addPrimitiveArray(const std::string& name,
                                            const std::string& description = "",
                                            const bool isDict = false,

--- a/src/axom/inlet/Container.hpp
+++ b/src/axom/inlet/Container.hpp
@@ -721,9 +721,9 @@ public:
    *******************************************************************************
    */
   template <typename T>
-  typename std::enable_if<!detail::is_inlet_primitive<T>::value && !detail::is_inlet_array<T>::value &&
-                            !detail::is_inlet_dict<T>::value && !detail::is_std_vector<T>::value &&
-                            !detail::is_variant_value<T>::value,
+  typename std::enable_if<!detail::is_inlet_primitive<T>::value &&
+                            !detail::is_inlet_array<T>::value && !detail::is_inlet_dict<T>::value &&
+                            !detail::is_std_vector<T>::value && !detail::is_variant_value<T>::value,
                           T>::type
   get(const std::string& name = "") const
   {

--- a/src/axom/inlet/Inlet.hpp
+++ b/src/axom/inlet/Inlet.hpp
@@ -372,7 +372,8 @@ public:
    * \return Reference to the created array
    *****************************************************************************
    */
-  Verifiable<Container>& addVariantArray(const std::string& name, const std::string& description = "")
+  Verifiable<Container>& addVariantArray(const std::string& name,
+                                         const std::string& description = "")
   {
     return m_globalContainer.addVariantArray(name, description);
   }

--- a/src/axom/inlet/Inlet.hpp
+++ b/src/axom/inlet/Inlet.hpp
@@ -364,6 +364,21 @@ public:
 
   /*!
    *****************************************************************************
+   * \brief Add an array of mixed primitive Fields to the input file schema.
+   *
+   * \param [in] name Name of the array
+   * \param [in] description Description of the array
+   *
+   * \return Reference to the created array
+   *****************************************************************************
+   */
+  Verifiable<Container>& addVariantArray(const std::string& name, const std::string& description = "")
+  {
+    return m_globalContainer.addVariantArray(name, description);
+  }
+
+  /*!
+   *****************************************************************************
    * \brief Add an array of user-defined type to the input file schema.
    *
    * \param [in] name Name of the array
@@ -458,6 +473,22 @@ public:
                                              const std::string& description = "")
   {
     return m_globalContainer.addStringDictionary(name, description);
+  }
+
+  /*!
+   *****************************************************************************
+   * \brief Add a dictionary of mixed primitive Fields to the input file schema.
+   *
+   * \param [in] name Name of the dict
+   * \param [in] description Description of the dictionary
+   *
+   * \return Reference to the created dictionary
+   *****************************************************************************
+   */
+  Verifiable<Container>& addVariantDictionary(const std::string& name,
+                                              const std::string& description = "")
+  {
+    return m_globalContainer.addVariantDictionary(name, description);
   }
 
   /*!

--- a/src/axom/inlet/LuaReader.cpp
+++ b/src/axom/inlet/LuaReader.cpp
@@ -66,6 +66,29 @@ VariantKey extractAs(const axom::sol::object& obj)
   }
 }
 
+bool extractVariantValue(const axom::sol::object& obj, VariantValue& value)
+{
+  switch(obj.get_type())
+  {
+  case axom::sol::type::boolean:
+    value = obj.as<bool>();
+    return true;
+  case axom::sol::type::number:
+  {
+    const double double_value = obj.as<double>();
+    const int int_value = obj.as<int>();
+    value = (static_cast<double>(int_value) == double_value) ? VariantValue {int_value}
+                                                             : VariantValue {double_value};
+    return true;
+  }
+  case axom::sol::type::string:
+    value = obj.as<std::string>();
+    return true;
+  default:
+    return false;
+  }
+}
+
 /*!
  *******************************************************************************
  * \brief Recursive name retrieval function - adds the names of all descendents
@@ -275,6 +298,18 @@ ReaderResult LuaReader::getStringMap(const std::string& id,
                                      std::unordered_map<VariantKey, std::string>& values)
 {
   return getMap(id, values, axom::sol::type::string);
+}
+
+ReaderResult LuaReader::getVariantMap(const std::string& id,
+                                      std::unordered_map<int, VariantValue>& values)
+{
+  return getVariantMapInternal(id, values);
+}
+
+ReaderResult LuaReader::getVariantMap(const std::string& id,
+                                      std::unordered_map<VariantKey, VariantValue>& values)
+{
+  return getVariantMapInternal(id, values);
 }
 
 template <typename Iter>
@@ -569,6 +604,47 @@ ReaderResult LuaReader::getMap(const std::string& id,
     if(is_correct_key_type(entry.first.get_type()) && entry.second.get_type() == type)
     {
       values[detail::extractAs<Key>(entry.first)] = detail::extractAs<Val>(entry.second);
+    }
+    else
+    {
+      contains_other_type = true;
+    }
+  }
+  return collectionRetrievalResult(contains_other_type, !values.empty());
+}
+
+template <typename Key>
+ReaderResult LuaReader::getVariantMapInternal(const std::string& id,
+                                              std::unordered_map<Key, VariantValue>& values)
+{
+  values.clear();
+  std::vector<std::string> tokens = axom::utilities::string::split(id, SCOPE_DELIMITER);
+
+  axom::sol::table t;
+  if(tokens.empty() || !traverseToTable(tokens.begin(), tokens.end(), t))
+  {
+    return ReaderResult::NotFound;
+  }
+
+  const auto is_correct_key_type = [](const axom::sol::type type) {
+    const bool is_number = type == axom::sol::type::number;
+    if(std::is_same<Key, int>::value)
+    {
+      return is_number;
+    }
+    else
+    {
+      return is_number || (type == axom::sol::type::string);
+    }
+  };
+
+  bool contains_other_type = false;
+  for(const auto& entry : t)
+  {
+    VariantValue value;
+    if(is_correct_key_type(entry.first.get_type()) && detail::extractVariantValue(entry.second, value))
+    {
+      values[detail::extractAs<Key>(entry.first)] = value;
     }
     else
     {

--- a/src/axom/inlet/LuaReader.hpp
+++ b/src/axom/inlet/LuaReader.hpp
@@ -72,6 +72,11 @@ public:
   ReaderResult getStringMap(const std::string& id,
                             std::unordered_map<VariantKey, std::string>& values) override;
 
+  ReaderResult getVariantMap(const std::string& id,
+                             std::unordered_map<int, VariantValue>& values) override;
+  ReaderResult getVariantMap(const std::string& id,
+                             std::unordered_map<VariantKey, VariantValue>& values) override;
+
   ReaderResult getIndices(const std::string& id, std::vector<int>& indices) override;
   ReaderResult getIndices(const std::string& id, std::vector<VariantKey>& indices) override;
 
@@ -116,6 +121,10 @@ private:
   ReaderResult getMap(const std::string& id,
                       std::unordered_map<Key, Val>& values,
                       axom::sol::type type);
+
+  template <typename Key>
+  ReaderResult getVariantMapInternal(const std::string& id,
+                                     std::unordered_map<Key, VariantValue>& values);
 
   template <typename T>
   ReaderResult getIndicesInternal(const std::string& id, std::vector<T>& indices);

--- a/src/axom/inlet/Reader.hpp
+++ b/src/axom/inlet/Reader.hpp
@@ -22,6 +22,7 @@
 
 #include "axom/inlet/Function.hpp"
 #include "axom/inlet/VariantKey.hpp"
+#include "axom/inlet/VariantValue.hpp"
 
 namespace axom
 {
@@ -213,6 +214,24 @@ public:
   /// \overload
   virtual ReaderResult getStringMap(const std::string& id,
                                     std::unordered_map<VariantKey, std::string>& values) = 0;
+
+  /*!
+   *****************************************************************************
+   * \brief Get an index-variant mapping for the given array
+   *
+   * This retrieves arrays/dictionaries with mixed primitive values.
+   *
+   * \param [in]  id    The identifier to the collection that will be retrieved
+   * \param [out] map The mixed primitive values that were retrieved
+   *
+   * \return The status of the retrieval, \see ReaderResult
+   *****************************************************************************
+   */
+  virtual ReaderResult getVariantMap(const std::string& id,
+                                     std::unordered_map<int, VariantValue>& values) = 0;
+  /// \overload
+  virtual ReaderResult getVariantMap(const std::string& id,
+                                     std::unordered_map<VariantKey, VariantValue>& values) = 0;
 
   /*!
    *****************************************************************************

--- a/src/axom/inlet/VariantKey.hpp
+++ b/src/axom/inlet/VariantKey.hpp
@@ -16,6 +16,10 @@
 #ifndef INLET_KEY_HPP
 #define INLET_KEY_HPP
 
+#include <ostream>
+#include <string>
+
+#include "axom/fmt.hpp"
 #include "axom/slic/interface/slic.hpp"
 
 namespace axom
@@ -166,5 +170,10 @@ struct hash<axom::inlet::VariantKey>
   }
 };
 }  // end namespace std
+
+/// Overload to format an inlet::VariantKey using fmt
+template <>
+struct axom::fmt::formatter<axom::inlet::VariantKey> : ostream_formatter
+{ };
 
 #endif  // INLET_KEY_HPP

--- a/src/axom/inlet/VariantValue.hpp
+++ b/src/axom/inlet/VariantValue.hpp
@@ -1,0 +1,32 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+// files for dates and other details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ *******************************************************************************
+ * \file VariantValue.hpp
+ *
+ * \brief This file contains Inlet's variant value type for mixed primitive
+ * collections.
+ *******************************************************************************
+ */
+
+#ifndef INLET_VARIANT_VALUE_HPP
+#define INLET_VARIANT_VALUE_HPP
+
+#include <string>
+#include <variant>
+
+namespace axom
+{
+namespace inlet
+{
+
+using VariantValue = std::variant<bool, int, double, std::string>;
+
+}  // namespace inlet
+}  // namespace axom
+
+#endif

--- a/src/axom/inlet/docs/sphinx/simple_types.rst
+++ b/src/axom/inlet/docs/sphinx/simple_types.rst
@@ -127,30 +127,128 @@ can get the Container instance first, then access it with the relative name.
 Arrays
 ******
 
-Coming soon!
+Primitive arrays store a collection of values under integer keys.  The ``addBoolArray``,
+``addIntArray``, ``addDoubleArray``, and ``addStringArray`` schema methods expect
+all values in the array to have the requested primitive type.
+
+In this example, both arrays contain only integer values.  The first input array
+is contiguous and the second uses explicit integer keys:
+
+.. literalinclude:: ../../examples/homogeneous_collections.cpp
+   :start-after: _inlet_simple_types_homogeneous_arrays_input_start
+   :end-before: _inlet_simple_types_homogeneous_arrays_input_end
+   :language: lua
+
+For arrays whose values can be any supported primitive type, use ``addVariantArray``.
+Variant arrays store values as ``inlet::VariantValue``, which is a
+``std::variant<bool, int, double, std::string>``.
+
+In this example, the arrays contain mixed primitive value types:
+
+.. literalinclude:: ../../examples/variant_collections.cpp
+   :start-after: _inlet_simple_types_variant_arrays_input_start
+   :end-before: _inlet_simple_types_variant_arrays_input_end
+   :language: lua
 
 Defining And Storing
 --------------------
 
-Coming soon!
+Homogeneous primitive arrays are added with the type-specific ``add*Array`` method:
+
+.. literalinclude:: ../../examples/homogeneous_collections.cpp
+   :start-after: _inlet_simple_types_homogeneous_collections_add_start
+   :end-before: _inlet_simple_types_homogeneous_collections_add_end
+   :language: C++
+
+Variant arrays are added with ``addVariantArray``:
+
+.. literalinclude:: ../../examples/variant_collections.cpp
+   :start-after: _inlet_simple_types_variant_collections_add_start
+   :end-before: _inlet_simple_types_variant_collections_add_end
+   :language: C++
 
 Accessing
 ---------
 
-Coming soon!
+Contiguous homogeneous arrays can be retrieved as ``std::vector<T>``.  Integer-keyed
+homogeneous arrays can be retrieved as ``std::unordered_map<int, T>`` when the
+original indices are needed.
+
+.. literalinclude:: ../../examples/homogeneous_collections.cpp
+   :start-after: _inlet_simple_types_homogeneous_arrays_access_start
+   :end-before: _inlet_simple_types_homogeneous_arrays_access_end
+   :language: C++
+
+Contiguous variant arrays can be retrieved as ``std::vector<inlet::VariantValue>``.
+Integer-keyed variant arrays can be retrieved as
+``std::unordered_map<int, inlet::VariantValue>`` when the original indices are
+needed.
+
+.. literalinclude:: ../../examples/variant_collections.cpp
+   :start-after: _inlet_simple_types_variant_arrays_access_start
+   :end-before: _inlet_simple_types_variant_arrays_access_end
+   :language: C++
 
 ************
 Dictionaries
 ************
 
-Coming soon!
+Dictionaries store a collection of values under arbitrary string keys or a mix of
+string and integer keys.  The ``addBoolDictionary``, ``addIntDictionary``,
+``addDoubleDictionary``, and ``addStringDictionary`` schema methods expect all
+values in the dictionary to have the requested primitive type.
+
+In this example, all dictionary values are integers:
+
+.. literalinclude:: ../../examples/homogeneous_collections.cpp
+   :start-after: _inlet_simple_types_homogeneous_dictionary_input_start
+   :end-before: _inlet_simple_types_homogeneous_dictionary_input_end
+   :language: lua
+
+For dictionaries whose values can be any supported primitive type, use
+``addVariantDictionary``.  Mixed string and integer keys are represented with
+``inlet::VariantKey``.
+
+In this example, the dictionary has mixed primitive values and mixed key types:
+
+.. literalinclude:: ../../examples/variant_collections.cpp
+   :start-after: _inlet_simple_types_variant_dictionary_input_start
+   :end-before: _inlet_simple_types_variant_dictionary_input_end
+   :language: lua
 
 Defining And Storing
 --------------------
 
-Coming soon!
+Homogeneous primitive dictionaries are added with the type-specific
+``add*Dictionary`` method:
+
+.. literalinclude:: ../../examples/homogeneous_collections.cpp
+   :start-after: _inlet_simple_types_homogeneous_collections_add_start
+   :end-before: _inlet_simple_types_homogeneous_collections_add_end
+   :language: C++
+
+Variant dictionaries are added with ``addVariantDictionary``:
+
+.. literalinclude:: ../../examples/variant_collections.cpp
+   :start-after: _inlet_simple_types_variant_collections_add_start
+   :end-before: _inlet_simple_types_variant_collections_add_end
+   :language: C++
 
 Accessing
 ---------
 
-Coming soon!
+Mixed-key homogeneous dictionaries can be retrieved as
+``std::unordered_map<inlet::VariantKey, T>``.
+
+.. literalinclude:: ../../examples/homogeneous_collections.cpp
+   :start-after: _inlet_simple_types_homogeneous_dictionary_access_start
+   :end-before: _inlet_simple_types_homogeneous_dictionary_access_end
+   :language: C++
+
+Mixed-key variant dictionaries can be retrieved as
+``std::unordered_map<inlet::VariantKey, inlet::VariantValue>``.
+
+.. literalinclude:: ../../examples/variant_collections.cpp
+   :start-after: _inlet_simple_types_variant_dictionary_access_start
+   :end-before: _inlet_simple_types_variant_dictionary_access_end
+   :language: C++

--- a/src/axom/inlet/docs/sphinx/simple_types.rst
+++ b/src/axom/inlet/docs/sphinx/simple_types.rst
@@ -185,14 +185,21 @@ Integer-keyed homogeneous arrays can be retrieved as
    :end-before: _inlet_simple_types_homogeneous_arrays_access_map_end
    :language: C++
 
-Contiguous variant arrays can be retrieved as ``std::vector<inlet::VariantValue>``.
-Integer-keyed variant arrays can be retrieved as
-``std::unordered_map<int, inlet::VariantValue>`` when the original indices are
-needed.
+Contiguous variant arrays can be retrieved as
+``std::vector<inlet::VariantValue>``:
 
 .. literalinclude:: ../../examples/variant_collections.cpp
-   :start-after: _inlet_simple_types_variant_arrays_access_start
-   :end-before: _inlet_simple_types_variant_arrays_access_end
+   :start-after: _inlet_simple_types_variant_arrays_access_vector_start
+   :end-before: _inlet_simple_types_variant_arrays_access_vector_end
+   :language: C++
+
+Integer-keyed variant arrays can be retrieved as
+``std::unordered_map<int, inlet::VariantValue>`` when the original indices are
+needed:
+
+.. literalinclude:: ../../examples/variant_collections.cpp
+   :start-after: _inlet_simple_types_variant_arrays_access_map_start
+   :end-before: _inlet_simple_types_variant_arrays_access_map_end
    :language: C++
 
 ************

--- a/src/axom/inlet/docs/sphinx/simple_types.rst
+++ b/src/axom/inlet/docs/sphinx/simple_types.rst
@@ -170,13 +170,19 @@ Variant arrays are added with ``addVariantArray``:
 Accessing
 ---------
 
-Contiguous homogeneous arrays can be retrieved as ``std::vector<T>``.  Integer-keyed
-homogeneous arrays can be retrieved as ``std::unordered_map<int, T>`` when the
-original indices are needed.
+Contiguous homogeneous arrays can be retrieved as ``std::vector<T>``:
 
 .. literalinclude:: ../../examples/homogeneous_collections.cpp
-   :start-after: _inlet_simple_types_homogeneous_arrays_access_start
-   :end-before: _inlet_simple_types_homogeneous_arrays_access_end
+   :start-after: _inlet_simple_types_homogeneous_arrays_access_vector_start
+   :end-before: _inlet_simple_types_homogeneous_arrays_access_vector_end
+   :language: C++
+
+Integer-keyed homogeneous arrays can be retrieved as
+``std::unordered_map<int, T>`` when the original indices are needed:
+
+.. literalinclude:: ../../examples/homogeneous_collections.cpp
+   :start-after: _inlet_simple_types_homogeneous_arrays_access_map_start
+   :end-before: _inlet_simple_types_homogeneous_arrays_access_map_end
    :language: C++
 
 Contiguous variant arrays can be retrieved as ``std::vector<inlet::VariantValue>``.

--- a/src/axom/inlet/examples/CMakeLists.txt
+++ b/src/axom/inlet/examples/CMakeLists.txt
@@ -21,7 +21,9 @@ blt_list_append(
     arrays.cpp
     documentation_generation.cpp
     fields.cpp
+    homogeneous_collections.cpp
     lua_library.cpp
+    variant_collections.cpp
     containers.cpp
     user_defined_type.cpp
     verification.cpp
@@ -68,8 +70,14 @@ if (SOL_FOUND)
     axom_add_test( NAME    inlet_fields_ex
                    COMMAND inlet_fields_ex)
 
+    axom_add_test( NAME    inlet_homogeneous_collections_ex
+                   COMMAND inlet_homogeneous_collections_ex )
+
     axom_add_test( NAME    inlet_lua_library_ex
                    COMMAND inlet_lua_library_ex )
+
+    axom_add_test( NAME    inlet_variant_collections_ex
+                   COMMAND inlet_variant_collections_ex )
 
     axom_add_test( NAME    inlet_containers_ex
                    COMMAND inlet_containers_ex)

--- a/src/axom/inlet/examples/homogeneous_collections.cpp
+++ b/src/axom/inlet/examples/homogeneous_collections.cpp
@@ -75,14 +75,16 @@ int main()
     SLIC_ERROR("Inlet failed to verify against provided schema");
   }
 
-  // _inlet_simple_types_homogeneous_arrays_access_start
+  // _inlet_simple_types_homogeneous_arrays_access_vector_start
   SLIC_INFO("Contiguous int array as std::vector<int>:");
   const std::vector<int> contiguous_values = inlet["contiguous"].get<std::vector<int>>();
   for(const int value : contiguous_values)
   {
     SLIC_INFO(axom::fmt::format("{}", value));
   }
+  // _inlet_simple_types_homogeneous_arrays_access_vector_end
 
+  // _inlet_simple_types_homogeneous_arrays_access_map_start
   SLIC_INFO("Integer-keyed int array as std::unordered_map<int, int>:");
   const std::unordered_map<int, int> indexed_values =
     inlet["indexed"].get<std::unordered_map<int, int>>();
@@ -90,7 +92,7 @@ int main()
   {
     SLIC_INFO(axom::fmt::format("{} = {}", entry.first, entry.second));
   }
-  // _inlet_simple_types_homogeneous_arrays_access_end
+  // _inlet_simple_types_homogeneous_arrays_access_map_end
 
   // _inlet_simple_types_homogeneous_dictionary_access_start
   SLIC_INFO("Mixed-key int dictionary as std::unordered_map<VariantKey, int>:");

--- a/src/axom/inlet/examples/homogeneous_collections.cpp
+++ b/src/axom/inlet/examples/homogeneous_collections.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+// files for dates and other details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/inlet.hpp"
+#include "axom/slic/core/SimpleLogger.hpp"
+#include "axom/fmt.hpp"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace inlet = axom::inlet;
+
+/* Input file snippets used for documentation
+// _inlet_simple_types_homogeneous_arrays_input_start
+
+contiguous = { 10, 20, 30 }
+
+indexed = {
+  [10] = 100,
+  [20] = 200,
+  [30] = 300
+}
+
+// _inlet_simple_types_homogeneous_arrays_input_end
+
+// _inlet_simple_types_homogeneous_dictionary_input_start
+
+keyed = {
+  [1] = 100,
+  low = 10,
+  medium = 20,
+  high = 30
+}
+
+// _inlet_simple_types_homogeneous_dictionary_input_end
+*/
+
+const std::string input = R"(
+  contiguous = { 10, 20, 30 }
+
+  indexed = {
+    [10] = 100,
+    [20] = 200,
+    [30] = 300
+  }
+
+  keyed = {
+    [1] = 100,
+    low = 10,
+    medium = 20,
+    high = 30
+  }
+)";
+
+int main()
+{
+  axom::slic::SimpleLogger logger;
+
+  auto lr = std::make_unique<inlet::LuaReader>();
+  lr->parseString(input);
+  inlet::Inlet inlet(std::move(lr));
+
+  // _inlet_simple_types_homogeneous_collections_add_start
+  inlet.addIntArray("contiguous", "Contiguous integer values");
+  inlet.addIntArray("indexed", "Integer-keyed integer values");
+  inlet.addIntDictionary("keyed", "Mixed-key integer values");
+  // _inlet_simple_types_homogeneous_collections_add_end
+
+  if(!inlet.verify())
+  {
+    SLIC_ERROR("Inlet failed to verify against provided schema");
+  }
+
+  // _inlet_simple_types_homogeneous_arrays_access_start
+  SLIC_INFO("Contiguous int array as std::vector<int>:");
+  const std::vector<int> contiguous_values = inlet["contiguous"].get<std::vector<int>>();
+  for(const int value : contiguous_values)
+  {
+    SLIC_INFO(axom::fmt::format("{}", value));
+  }
+
+  SLIC_INFO("Integer-keyed int array as std::unordered_map<int, int>:");
+  const std::unordered_map<int, int> indexed_values =
+    inlet["indexed"].get<std::unordered_map<int, int>>();
+  for(const auto& entry : indexed_values)
+  {
+    SLIC_INFO(axom::fmt::format("{} = {}", entry.first, entry.second));
+  }
+  // _inlet_simple_types_homogeneous_arrays_access_end
+
+  // _inlet_simple_types_homogeneous_dictionary_access_start
+  SLIC_INFO("Mixed-key int dictionary as std::unordered_map<VariantKey, int>:");
+  const std::unordered_map<inlet::VariantKey, int> keyed_values =
+    inlet["keyed"].get<std::unordered_map<inlet::VariantKey, int>>();
+  for(const auto& entry : keyed_values)
+  {
+    SLIC_INFO(axom::fmt::format("{} = {}", entry.first, entry.second));
+  }
+  // _inlet_simple_types_homogeneous_dictionary_access_end
+
+  return 0;
+}

--- a/src/axom/inlet/examples/variant_collections.cpp
+++ b/src/axom/inlet/examples/variant_collections.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+// files for dates and other details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/inlet.hpp"
+#include "axom/slic/core/SimpleLogger.hpp"
+#include "axom/fmt.hpp"
+
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace inlet = axom::inlet;
+
+/* Input file snippets used for documentation
+// _inlet_simple_types_variant_arrays_input_start
+
+contiguous = { 42, "hello", true, 3.14 }
+
+indexed = {
+  [10] = 42,
+  [20] = "hello",
+  [30] = true,
+  [40] = 3.14
+}
+
+// _inlet_simple_types_variant_arrays_input_end
+
+// _inlet_simple_types_variant_dictionary_input_start
+
+keyed = {
+  [1] = 42,
+  message = "hello",
+  enabled = true,
+  pi = 3.14
+}
+
+// _inlet_simple_types_variant_dictionary_input_end
+*/
+
+const std::string input = R"(
+  contiguous = { 42, "hello", true, 3.14 }
+
+  indexed = {
+    [10] = 42,
+    [20] = "hello",
+    [30] = true,
+    [40] = 3.14
+  }
+
+  keyed = {
+    [1] = 42,
+    message = "hello",
+    enabled = true,
+    pi = 3.14
+  }
+)";
+
+int main()
+{
+  axom::slic::SimpleLogger logger;
+
+  auto lr = std::make_unique<inlet::LuaReader>();
+  lr->parseString(input);
+  inlet::Inlet inlet(std::move(lr));
+
+  // _inlet_simple_types_variant_collections_add_start
+  inlet.addVariantArray("contiguous", "Contiguous mixed POD values");
+  inlet.addVariantArray("indexed", "Integer-keyed mixed POD values");
+  inlet.addVariantDictionary("keyed", "Mixed-key mixed POD values");
+  // _inlet_simple_types_variant_collections_add_end
+
+  if(!inlet.verify())
+  {
+    SLIC_ERROR("Inlet failed to verify against provided schema");
+  }
+
+  // _inlet_simple_types_variant_arrays_access_start
+  SLIC_INFO("Contiguous VariantArray as std::vector:");
+  const std::vector<inlet::VariantValue> contiguous_values =
+    inlet["contiguous"].get<std::vector<inlet::VariantValue>>();
+  for(const inlet::VariantValue& value : contiguous_values)
+  {
+    std::visit([](const auto& concrete_value) {
+      SLIC_INFO(axom::fmt::format("{}", concrete_value));
+    }, value);
+  }
+
+  SLIC_INFO("Integer-keyed VariantArray as std::unordered_map<int, VariantValue>:");
+  const std::unordered_map<int, inlet::VariantValue> indexed_values =
+    inlet["indexed"].get<std::unordered_map<int, inlet::VariantValue>>();
+  std::map<int, inlet::VariantValue> sorted_indexed_values(indexed_values.begin(),
+                                                           indexed_values.end());
+  for(const auto& entry : sorted_indexed_values)
+  {
+    std::visit([&entry](const auto& concrete_value) {
+      SLIC_INFO(axom::fmt::format("{} = {}", entry.first, concrete_value));
+    }, entry.second);
+  }
+  // _inlet_simple_types_variant_arrays_access_end
+
+  // _inlet_simple_types_variant_dictionary_access_start
+  SLIC_INFO("Mixed-key VariantDictionary as std::unordered_map<VariantKey, VariantValue>:");
+  const std::unordered_map<inlet::VariantKey, inlet::VariantValue> keyed_values =
+    inlet["keyed"].get<std::unordered_map<inlet::VariantKey, inlet::VariantValue>>();
+  for(const auto& entry : keyed_values)
+  {
+    std::visit([&entry](const auto& concrete_value) {
+      SLIC_INFO(axom::fmt::format("{} = {}", entry.first, concrete_value));
+    }, entry.second);
+  }
+  // _inlet_simple_types_variant_dictionary_access_end
+
+  return 0;
+}

--- a/src/axom/inlet/examples/variant_collections.cpp
+++ b/src/axom/inlet/examples/variant_collections.cpp
@@ -84,9 +84,8 @@ int main()
     inlet["contiguous"].get<std::vector<inlet::VariantValue>>();
   for(const inlet::VariantValue& value : contiguous_values)
   {
-    std::visit([](const auto& concrete_value) {
-      SLIC_INFO(axom::fmt::format("{}", concrete_value));
-    }, value);
+    std::visit([](const auto& concrete_value) { SLIC_INFO(axom::fmt::format("{}", concrete_value)); },
+               value);
   }
   // _inlet_simple_types_variant_arrays_access_vector_end
 
@@ -98,9 +97,11 @@ int main()
                                                            indexed_values.end());
   for(const auto& entry : sorted_indexed_values)
   {
-    std::visit([&entry](const auto& concrete_value) {
-      SLIC_INFO(axom::fmt::format("{} = {}", entry.first, concrete_value));
-    }, entry.second);
+    std::visit(
+      [&entry](const auto& concrete_value) {
+        SLIC_INFO(axom::fmt::format("{} = {}", entry.first, concrete_value));
+      },
+      entry.second);
   }
   // _inlet_simple_types_variant_arrays_access_map_end
 
@@ -110,9 +111,11 @@ int main()
     inlet["keyed"].get<std::unordered_map<inlet::VariantKey, inlet::VariantValue>>();
   for(const auto& entry : keyed_values)
   {
-    std::visit([&entry](const auto& concrete_value) {
-      SLIC_INFO(axom::fmt::format("{} = {}", entry.first, concrete_value));
-    }, entry.second);
+    std::visit(
+      [&entry](const auto& concrete_value) {
+        SLIC_INFO(axom::fmt::format("{} = {}", entry.first, concrete_value));
+      },
+      entry.second);
   }
   // _inlet_simple_types_variant_dictionary_access_end
 

--- a/src/axom/inlet/examples/variant_collections.cpp
+++ b/src/axom/inlet/examples/variant_collections.cpp
@@ -78,7 +78,7 @@ int main()
     SLIC_ERROR("Inlet failed to verify against provided schema");
   }
 
-  // _inlet_simple_types_variant_arrays_access_start
+  // _inlet_simple_types_variant_arrays_access_vector_start
   SLIC_INFO("Contiguous VariantArray as std::vector:");
   const std::vector<inlet::VariantValue> contiguous_values =
     inlet["contiguous"].get<std::vector<inlet::VariantValue>>();
@@ -88,7 +88,9 @@ int main()
       SLIC_INFO(axom::fmt::format("{}", concrete_value));
     }, value);
   }
+  // _inlet_simple_types_variant_arrays_access_vector_end
 
+  // _inlet_simple_types_variant_arrays_access_map_start
   SLIC_INFO("Integer-keyed VariantArray as std::unordered_map<int, VariantValue>:");
   const std::unordered_map<int, inlet::VariantValue> indexed_values =
     inlet["indexed"].get<std::unordered_map<int, inlet::VariantValue>>();
@@ -100,7 +102,7 @@ int main()
       SLIC_INFO(axom::fmt::format("{} = {}", entry.first, concrete_value));
     }, entry.second);
   }
-  // _inlet_simple_types_variant_arrays_access_end
+  // _inlet_simple_types_variant_arrays_access_map_end
 
   // _inlet_simple_types_variant_dictionary_access_start
   SLIC_INFO("Mixed-key VariantDictionary as std::unordered_map<VariantKey, VariantValue>:");

--- a/src/axom/inlet/tests/inlet_Reader.cpp
+++ b/src/axom/inlet/tests/inlet_Reader.cpp
@@ -199,6 +199,40 @@ TYPED_TEST(inlet_Reader, getVariantMap)
   EXPECT_EQ(expected, values);
 }
 
+TEST(inlet_Reader_JSON, getVariantMapBoolArray)
+{
+  axom::inlet::JSONReader reader;
+  bool result = reader.parseString("{\"bools\": [true, false, true]}");
+  EXPECT_TRUE(result);
+
+  std::unordered_map<int, axom::inlet::VariantValue> values;
+  ReaderResult retValue = reader.getVariantMap("bools", values);
+  EXPECT_EQ(retValue, ReaderResult::Success);
+
+  std::unordered_map<int, axom::inlet::VariantValue> expected {
+    {0, axom::inlet::VariantValue {true}},
+    {1, axom::inlet::VariantValue {false}},
+    {2, axom::inlet::VariantValue {true}}};
+  EXPECT_EQ(expected, values);
+}
+
+TEST(inlet_Reader_JSON, getVariantMapStringArray)
+{
+  axom::inlet::JSONReader reader;
+  bool result = reader.parseString("{\"strings\": [\"red\", \"green\", \"blue\"]}");
+  EXPECT_TRUE(result);
+
+  std::unordered_map<int, axom::inlet::VariantValue> values;
+  ReaderResult retValue = reader.getVariantMap("strings", values);
+  EXPECT_EQ(retValue, ReaderResult::Success);
+
+  std::unordered_map<int, axom::inlet::VariantValue> expected {
+    {0, axom::inlet::VariantValue {std::string {"red"}}},
+    {1, axom::inlet::VariantValue {std::string {"green"}}},
+    {2, axom::inlet::VariantValue {std::string {"blue"}}}};
+  EXPECT_EQ(expected, values);
+}
+
 TYPED_TEST(inlet_Reader, emptyCollections)
 {
   TypeParam reader;

--- a/src/axom/inlet/tests/inlet_Reader.cpp
+++ b/src/axom/inlet/tests/inlet_Reader.cpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <variant>
 
 template <typename InletReader>
 class inlet_Reader : public testing::Test
@@ -178,6 +179,24 @@ TYPED_TEST(inlet_Reader, getMap)
   // std::unordered_map<int, std::string> expectedStrs {{6, "hello"},
   //                                                    {7, "bye"}};
   // EXPECT_EQ(expectedStrs, strs);
+}
+
+TYPED_TEST(inlet_Reader, getVariantMap)
+{
+  std::string testString = "luaArray = { [0] = 42, [1] = 'hello', [2] = true, [3] = 3.14 }";
+  TypeParam reader;
+  reader.parseString(fromLuaTo<TypeParam>(testString));
+
+  std::unordered_map<int, axom::inlet::VariantValue> values;
+  ReaderResult retValue = reader.getVariantMap("luaArray", values);
+  EXPECT_EQ(retValue, ReaderResult::Success);
+
+  std::unordered_map<int, axom::inlet::VariantValue> expected {
+    {0, axom::inlet::VariantValue {42}},
+    {1, axom::inlet::VariantValue {std::string {"hello"}}},
+    {2, axom::inlet::VariantValue {true}},
+    {3, axom::inlet::VariantValue {3.14}}};
+  EXPECT_EQ(expected, values);
 }
 
 TYPED_TEST(inlet_Reader, emptyCollections)

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -19,11 +19,13 @@
 #include <vector>
 #include <unordered_map>
 #include <iostream>
+#include <variant>
 
 using axom::Path;
 using axom::inlet::Inlet;
 using axom::inlet::InletType;
 using axom::inlet::VariantKey;
+using axom::inlet::VariantValue;
 using axom::inlet::VerificationError;
 
 using ::testing::Contains;
@@ -829,6 +831,33 @@ TYPED_TEST(inlet_object, primitive_arrays_as_std_vector)
   EXPECT_EQ(arr_w_indices, expected_arr_w_indices);
 }
 
+TYPED_TEST(inlet_object, variant_arrays_as_std_vector)
+{
+  std::string testString = " arr = { [0] = 42, [1] = 'hello', [2] = true, [3] = 3.14 }";
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
+
+  inlet.addVariantArray("arr");
+
+  EXPECT_TRUE(inlet.verify());
+
+  std::vector<VariantValue> expected_arr {
+    VariantValue {42},
+    VariantValue {std::string {"hello"}},
+    VariantValue {true},
+    VariantValue {3.14}};
+  std::vector<VariantValue> arr = inlet["arr"].get<std::vector<VariantValue>>();
+  EXPECT_EQ(arr, expected_arr);
+
+  std::unordered_map<int, VariantValue> expected_arr_w_indices {
+    {0, VariantValue {42}},
+    {1, VariantValue {std::string {"hello"}}},
+    {2, VariantValue {true}},
+    {3, VariantValue {3.14}}};
+  std::unordered_map<int, VariantValue> arr_w_indices =
+    inlet["arr"].get<std::unordered_map<int, VariantValue>>();
+  EXPECT_EQ(arr_w_indices, expected_arr_w_indices);
+}
+
 TYPED_TEST(inlet_object, primitive_arrays_as_std_vector_wrong_type)
 {
   std::string testString = " arr = { [0] = 'a', [1] = 'b', [2] = 'c'}";
@@ -1362,6 +1391,21 @@ TEST(inlet_object_lua_dict, mixed_keys_primitive)
   inlet.addIntDictionary("foo", "foo's description");
   std::unordered_map<VariantKey, int> dict = inlet["foo"];
   std::unordered_map<VariantKey, int> correct_dict = {{"key1", 4}, {1, 6}};
+  EXPECT_EQ(dict, correct_dict);
+}
+
+TEST(inlet_object_lua_dict, mixed_keys_variant)
+{
+  std::string testString = "foo = { ['key1'] = 'hello', [1] = 42, ['flag'] = true }";
+  Inlet inlet = createBasicInlet<axom::inlet::LuaReader>(testString);
+
+  inlet.addVariantDictionary("foo", "foo's description");
+  std::unordered_map<VariantKey, VariantValue> dict =
+    inlet["foo"].get<std::unordered_map<VariantKey, VariantValue>>();
+  std::unordered_map<VariantKey, VariantValue> correct_dict = {
+    {"key1", VariantValue {std::string {"hello"}}},
+    {1, VariantValue {42}},
+    {"flag", VariantValue {true}}};
   EXPECT_EQ(dict, correct_dict);
 }
 

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -840,11 +840,10 @@ TYPED_TEST(inlet_object, variant_arrays_as_std_vector)
 
   EXPECT_TRUE(inlet.verify());
 
-  std::vector<VariantValue> expected_arr {
-    VariantValue {42},
-    VariantValue {std::string {"hello"}},
-    VariantValue {true},
-    VariantValue {3.14}};
+  std::vector<VariantValue> expected_arr {VariantValue {42},
+                                          VariantValue {std::string {"hello"}},
+                                          VariantValue {true},
+                                          VariantValue {3.14}};
   std::vector<VariantValue> arr = inlet["arr"].get<std::vector<VariantValue>>();
   EXPECT_EQ(arr, expected_arr);
 


### PR DESCRIPTION
@adayton1 

Thought we had this ability already but only had dictionaries with variant keys. Also added documentation and examples for both variant and homogeneous collections