### PR TITLE
Bugfix and optimization for 1D Array/ArrayView

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -48,11 +48,13 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ### Changed
 - Updates CMake code check targets to only use checked in files (via `git ls-files`, when available)
+- Core: Optimization for axom::Array indirection -- since the stride is always 1, we can remove the runtime multiplication
 
 ### Fixed
 - Primal: Fixes signs of `compute_moments` to match orientation convention in `primal::evaluate_area_integral`
 - Quest: Improves error handling/reporting when loading an invalid c2c contour
 - Primal: Improves reproducibility of 3D GWN methods by removing some sources of randomness
+- Core: ArrayView assigments/copies now copy the stride
 
 ## [Version 0.14.0] - Release date 2026-03-31
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -55,6 +55,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Quest: Improves error handling/reporting when loading an invalid c2c contour
 - Primal: Improves reproducibility of 3D GWN methods by removing some sources of randomness
 - Core: ArrayView assigments/copies now copy the stride
+- Core: Array construction from strided ArrayView now correctly copies the strided elements
 
 ## [Version 0.14.0] - Release date 2026-03-31
 

--- a/src/axom/bump/views/Shapes.hpp
+++ b/src/axom/bump/views/Shapes.hpp
@@ -87,7 +87,7 @@ struct PointTraits
 
   AXOM_HOST_DEVICE constexpr static axom::StackArray<IndexType, 1> getFace(IndexType faceIndex)
   {
-#ifdef NDEBUG
+#if defined(NDEBUG)
     AXOM_UNUSED_VAR(faceIndex);
 #endif
     assert(faceIndex == 0);
@@ -136,7 +136,7 @@ struct LineTraits
 
   AXOM_HOST_DEVICE constexpr static axom::StackArray<IndexType, 2> getFace(IndexType faceIndex)
   {
-#ifdef NDEBUG
+#if defined(NDEBUG)
     AXOM_UNUSED_VAR(faceIndex);
 #endif
     assert(faceIndex == 0);
@@ -190,7 +190,7 @@ struct TriTraits
 
   AXOM_HOST_DEVICE constexpr static axom::StackArray<IndexType, 3> getFace(IndexType faceIndex)
   {
-#ifdef NDEBUG
+#if defined(NDEBUG)
     AXOM_UNUSED_VAR(faceIndex);
 #endif
     assert(faceIndex == 0);
@@ -245,7 +245,7 @@ struct QuadTraits
 
   AXOM_HOST_DEVICE constexpr static axom::StackArray<IndexType, 4> getFace(IndexType faceIndex)
   {
-#ifdef NDEBUG
+#if defined(NDEBUG)
     AXOM_UNUSED_VAR(faceIndex);
 #endif
     assert(faceIndex == 0);

--- a/src/axom/bump/views/Shapes.hpp
+++ b/src/axom/bump/views/Shapes.hpp
@@ -87,7 +87,7 @@ struct PointTraits
 
   AXOM_HOST_DEVICE constexpr static axom::StackArray<IndexType, 1> getFace(IndexType faceIndex)
   {
-#if !defined(AXOM_DEBUG)
+#ifdef NDEBUG
     AXOM_UNUSED_VAR(faceIndex);
 #endif
     assert(faceIndex == 0);
@@ -136,7 +136,7 @@ struct LineTraits
 
   AXOM_HOST_DEVICE constexpr static axom::StackArray<IndexType, 2> getFace(IndexType faceIndex)
   {
-#if !defined(AXOM_DEBUG)
+#ifdef NDEBUG
     AXOM_UNUSED_VAR(faceIndex);
 #endif
     assert(faceIndex == 0);
@@ -190,7 +190,7 @@ struct TriTraits
 
   AXOM_HOST_DEVICE constexpr static axom::StackArray<IndexType, 3> getFace(IndexType faceIndex)
   {
-#if !defined(AXOM_DEBUG)
+#ifdef NDEBUG
     AXOM_UNUSED_VAR(faceIndex);
 #endif
     assert(faceIndex == 0);
@@ -245,7 +245,7 @@ struct QuadTraits
 
   AXOM_HOST_DEVICE constexpr static axom::StackArray<IndexType, 4> getFace(IndexType faceIndex)
   {
-#if !defined(AXOM_DEBUG)
+#ifdef NDEBUG
     AXOM_UNUSED_VAR(faceIndex);
 #endif
     assert(faceIndex == 0);

--- a/src/axom/core/Array.hpp
+++ b/src/axom/core/Array.hpp
@@ -983,17 +983,17 @@ protected:
   void initialize(IndexType num_elements, IndexType capacity, bool should_default_construct = true);
 
   /*!
-   * \brief Helper function for initializing an Array instance with an existing
-   *  range of elements.
+   * \brief Helper function for initializing an Array instance with an existing range of elements.
    *
    * \param [in] data pointer to the existing array of elements
    * \param [in] num_elements the number of elements in the existing array
+   * \param [in] src_stride the inter-element stride between elements of the existing array
    * \param [in] data_space the memory space in which data has been allocated
-   * \param [in] user_provided_allocator true if the Array's allocator ID was
-   *  provided by the user
+   * \param [in] user_provided_allocator true if the Array's allocator ID was provided by the user
    */
   void initialize_from_other(const T* data,
                              IndexType num_elements,
+                             IndexType src_stride,
                              MemorySpace data_space,
                              bool user_provided_allocator);
 
@@ -1202,7 +1202,7 @@ Array<T, DIM, SPACE, StoragePolicy>::Array(std::initializer_list<T> elems, int a
   : m_allocator_id(allocator_id)
   , m_arrayOps(m_allocator_id, m_executeOnGPU)
 {
-  initialize_from_other(elems.begin(), elems.size(), MemorySpace::Dynamic, true);
+  initialize_from_other(elems.begin(), elems.size(), 1 /* stride */, MemorySpace::Dynamic, true);
 }
 
 //------------------------------------------------------------------------------
@@ -1275,6 +1275,7 @@ Array<T, DIM, SPACE, StoragePolicy>::Array(const ArrayBase<T, DIM, OtherArrayTyp
 {
   initialize_from_other(static_cast<const OtherArrayType&>(other).data(),
                         static_cast<const OtherArrayType&>(other).size(),
+                        other.minStride(),
                         axom::detail::getAllocatorSpace(m_allocator_id),
                         false);
 }
@@ -1289,6 +1290,7 @@ Array<T, DIM, SPACE, StoragePolicy>::Array(const ArrayBase<const T, DIM, OtherAr
 {
   initialize_from_other(static_cast<const OtherArrayType&>(other).data(),
                         static_cast<const OtherArrayType&>(other).size(),
+                        other.minStride(),
                         axom::detail::getAllocatorSpace(m_allocator_id),
                         false);
 }
@@ -1306,6 +1308,7 @@ Array<T, DIM, SPACE, StoragePolicy>::Array(const ArrayBase<T, DIM, OtherArrayTyp
 
   initialize_from_other(static_cast<const OtherArrayType&>(other).data(),
                         static_cast<const OtherArrayType&>(other).size(),
+                        other.minStride(),
                         axom::detail::getAllocatorSpace(src_allocator),
                         true);
 }
@@ -1323,6 +1326,7 @@ Array<T, DIM, SPACE, StoragePolicy>::Array(const ArrayBase<const T, DIM, OtherAr
 
   initialize_from_other(static_cast<const OtherArrayType&>(other).data(),
                         static_cast<const OtherArrayType&>(other).size(),
+                        other.minStride(),
                         axom::detail::getAllocatorSpace(src_allocator),
                         true);
 }
@@ -1388,7 +1392,7 @@ inline void Array<T, DIM, SPACE, StoragePolicy>::assign(InputIt first, InputIt l
   {
     tmp.push_back(*it);
   }
-  initialize_from_other(tmp.data(), tmp.size(), MemorySpace::Dynamic, true);
+  initialize_from_other(tmp.data(), tmp.size(), 1 /* stride */, MemorySpace::Dynamic, true);
 }
 
 //------------------------------------------------------------------------------
@@ -1715,6 +1719,7 @@ template <typename T, int DIM, MemorySpace SPACE, typename StoragePolicy>
 inline void Array<T, DIM, SPACE, StoragePolicy>::initialize_from_other(
   const T* other_data,
   IndexType num_elements,
+  IndexType src_stride,
   MemorySpace other_data_space,
   bool AXOM_DEBUG_PARAM(user_provided_allocator))
 {
@@ -1734,9 +1739,15 @@ inline void Array<T, DIM, SPACE, StoragePolicy>::initialize_from_other(
   m_executeOnGPU = axom::isDeviceAllocator(m_allocator_id);
   m_arrayOps = OpHelper {m_allocator_id, m_executeOnGPU};
   this->setCapacity(num_elements);
-  // Use fill_range to ensure that copy constructors are invoked for each
-  // element.
-  m_arrayOps.fill_range(m_data, 0, num_elements, other_data, other_data_space);
+  // Use strided copy when necessary, otherwise use efficient contiguous copy
+  if(src_stride == 1)
+  {
+    m_arrayOps.fill_range(m_data, 0, num_elements, other_data, other_data_space);
+  }
+  else
+  {
+    m_arrayOps.fill_range_strided(m_data, 0, num_elements, other_data, src_stride, other_data_space);
+  }
   this->updateNumElements(num_elements);
 }
 

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -584,15 +584,25 @@ public:
     : m_stride(mapping.strides()[0])
   { }
 
-  // Empty implementation because no member data
-  template <typename OtherArrayType>
-  AXOM_HOST_DEVICE ArrayBase(const ArrayBase<typename std::remove_const<T>::type, 1, OtherArrayType>&)
-  { }
-
-  // Empty implementation because no member data
+  /*!
+   * \brief Copy the stride from another 1D array-like object.
+   *
+   * When this array is a view, the source's spacing must be preserved so the
+   * view continues to address the same elements. When this array is owning,
+   * the stride is the compile-time unit stride regardless of the source
+   * (a deep copy from a strided view compacts into contiguous storage).
+   */
   template <typename OtherArrayType>
   AXOM_HOST_DEVICE ArrayBase(
-    const ArrayBase<const typename std::remove_const<T>::type, 1, OtherArrayType>&)
+    const ArrayBase<typename std::remove_const<T>::type, 1, OtherArrayType>& other)
+    : m_stride(static_cast<int>(other.minStride()))
+  { }
+
+  /// \overload
+  template <typename OtherArrayType>
+  AXOM_HOST_DEVICE ArrayBase(
+    const ArrayBase<const typename std::remove_const<T>::type, 1, OtherArrayType>& other)
+    : m_stride(static_cast<int>(other.minStride()))
   { }
 
   /// \brief Returns the dimensions of the Array
@@ -655,8 +665,8 @@ public:
   /// @}
 
   /// \brief Swaps two ArrayBases
-  /// No member data, so this is a no-op
-  void swap(ArrayBase&) { }
+  /// Swaps the stride; this is a no-op for owning arrays (unit stride).
+  void swap(ArrayBase& other) { std::swap(m_stride, other.m_stride); }
 
   /// \brief Set the shape
   /// No member data, so this is a no-op

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -7,15 +7,15 @@
 #ifndef AXOM_ARRAYBASE_HPP_
 #define AXOM_ARRAYBASE_HPP_
 
-#include "axom/config.hpp"                    // for compile-time defines
-#include "axom/core/Macros.hpp"               // for axom macros
-#include "axom/core/MDMapping.hpp"            // for index conversion
-#include "axom/core/memory_management.hpp"    // for memory allocation functions
-#include "axom/core/utilities/Utilities.hpp"  // for processAbort()
-#include "axom/core/Types.hpp"                // for IndexType definition
+#include "axom/config.hpp"
+#include "axom/core/Macros.hpp"
+#include "axom/core/MDMapping.hpp"
+#include "axom/core/memory_management.hpp"
+#include "axom/core/utilities/Utilities.hpp"
+#include "axom/core/Types.hpp"
 #include "axom/core/StackArray.hpp"
-#include "axom/core/numerics/matvecops.hpp"  // for dot_product
-#include "axom/core/execution/for_all.hpp"   // for for_all, *_EXEC
+#include "axom/core/numerics/matvecops.hpp"
+#include "axom/core/execution/for_all.hpp"
 
 // C/C++ includes
 #include <iostream>  // for std::cerr and std::ostream
@@ -1102,6 +1102,67 @@ public:
       std::uninitialized_copy(src_buf.getStagingBuffer(),
                               src_buf.getStagingBuffer() + nelems,
                               dst_buf.getStagingBuffer());
+    }
+  }
+
+  /*!
+   * \brief Fills an uninitialized array with a strided range of objects of type T.
+   *
+   * Similar to fill_range, but handles source data with non-unit stride. When src_stride == 1,
+   * this behaves identically to fill_range (and uses the same fast path). When src_stride > 1,
+   * elements are copied from positions 0, src_stride, 2*src_stride, etc.
+   *
+   * \param [inout] array the array to fill
+   * \param [in] begin the index at which to begin placing elements
+   * \param [in] nelems the number of elements to copy
+   * \param [in] values pointer to the first element of the source data
+   * \param [in] src_stride spacing between consecutive source elements
+   * \param [in] valueSpace the memory space in which values resides
+   */
+  void fill_range_strided(T* array,
+                          IndexType begin,
+                          IndexType nelems,
+                          const T* values,
+                          IndexType src_stride,
+                          MemorySpace valueSpace)
+  {
+    if constexpr(std::is_trivially_copyable_v<T>)
+    {
+      if(src_stride == 1)
+      {
+        // Contiguous case - use efficient bulk copy
+        axom::copy(array + begin, values, sizeof(T) * nelems);
+      }
+      else
+      {
+        // Strided case - element-by-element copy
+        StagingBuffer dst_buf(space, array, begin, nelems);
+        DeviceStagingBuffer<T> src_buf(valueSpace, const_cast<T*>(values), 0, nelems * src_stride, true);
+
+        T* dst = dst_buf.getStagingBuffer();
+        const T* src = src_buf.getStagingBuffer();
+
+        for(IndexType i = 0; i < nelems; ++i)
+        {
+          dst[i] = src[i * src_stride];
+        }
+        // Staging buffers clean up automatically via destructors
+      }
+    }
+    else
+    {
+      // Non-trivially copyable - use placement new with stride
+      StagingBuffer dst_buf(space, array, begin, nelems);
+      DeviceStagingBuffer<T> src_buf(valueSpace, const_cast<T*>(values), 0, nelems * src_stride, true);
+
+      T* dst = dst_buf.getStagingBuffer();
+      const T* src = src_buf.getStagingBuffer();
+
+      for(IndexType i = 0; i < nelems; ++i)
+      {
+        new(&dst[i]) T(src[i * src_stride]);
+      }
+      // Staging buffers clean up automatically via destructors
     }
   }
 

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -638,7 +638,7 @@ public:
   /*!
    * \brief Returns the stride between adjacent items.
    */
-  AXOM_HOST_DEVICE IndexType minStride() const { return m_stride; }
+  AXOM_HOST_DEVICE constexpr IndexType minStride() const { return m_stride; }
 
   /*!
    * \brief Accessor, returns a reference to the given value.
@@ -698,7 +698,7 @@ protected:
   /*!
    * \brief Returns the minimum "chunk size" that should be allocated
    */
-  IndexType blockSize() const { return m_stride; }
+  constexpr IndexType blockSize() const { return m_stride; }
 
   /*!
    * \brief Updates the internal dimensions and striding based on the insertion

--- a/src/axom/core/ArrayBase.hpp
+++ b/src/axom/core/ArrayBase.hpp
@@ -562,6 +562,21 @@ class ArrayBase<T, 1, ArrayType>
 private:
   constexpr static bool is_array_view = detail::ArrayTraits<ArrayType>::is_view;
 
+  /*!
+   * \brief Empty stand-in for the stride of an owning 1D Array.
+   *
+   * Owning 1D arrays are always contiguous, so their stride is the compile-time constant 1.
+   * Encoding that in the type (rather than storing a runtime int that is invariantly 1)
+   * lets operator[] and flatIndex() compile down to data()[idx], with no runtime multiply on the
+   * address-generation path. ArrayViews support runtime spacing and continue to store their stride as an int.
+   */
+  struct UnitStrideTag
+  {
+    AXOM_HOST_DEVICE constexpr UnitStrideTag(int = 1) { }
+    AXOM_HOST_DEVICE constexpr operator int() const { return 1; }
+  };
+  using StrideStorage = typename std::conditional<is_array_view, int, UnitStrideTag>::type;
+
 public:
   /* If ArrayType is an ArrayView, we use shallow-const semantics, akin to
    * std::span; a const ArrayView will still allow for mutating the underlying
@@ -574,15 +589,22 @@ public:
 
   AXOM_HOST_DEVICE ArrayBase(IndexType = 0) { }
 
-  AXOM_HOST_DEVICE ArrayBase(const StackArray<IndexType, 1>&, int stride = 1) : m_stride(stride) { }
+  AXOM_HOST_DEVICE ArrayBase(const StackArray<IndexType, 1>&, int stride = 1) : m_stride(stride)
+  {
+    assert(is_array_view || stride == 1);
+  }
 
   AXOM_HOST_DEVICE ArrayBase(const StackArray<IndexType, 1>&, const StackArray<IndexType, 1>& stride)
     : m_stride(static_cast<int>(stride[0]))
-  { }
+  {
+    assert(is_array_view || stride[0] == 1);
+  }
 
   AXOM_HOST_DEVICE ArrayBase(const StackArray<IndexType, 1>&, const MDMapping<1>& mapping)
-    : m_stride(mapping.strides()[0])
-  { }
+    : m_stride(static_cast<int>(mapping.strides()[0]))
+  {
+    assert(is_array_view || mapping.strides()[0] == 1);
+  }
 
   /*!
    * \brief Copy the stride from another 1D array-like object.
@@ -710,7 +732,7 @@ private:
   }
   /// @}
 
-  int m_stride {1};
+  StrideStorage m_stride {1};
 };
 
 //------------------------------------------------------------------------------

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -2479,11 +2479,7 @@ TEST(core_array, check_1D_view_spacing_preserved)
 
   // Deep copy from strided view to owning array -- must copy the values, not contiguous indices
   {
-    int source[10];
-    for(int i = 0; i < 10; ++i)
-    {
-      source[i] = i * 10;  // {0, 10, 20, 30, 40, 50, 60, 70, 80, 90}
-    }
+    int source[10] = {0, 10, 20, 30, 40, 50, 60, 70, 80, 90};
 
     // Strided view with stride=2 references elements {0, 20, 40, 60, 80}
     axom::ArrayView<int, 1> strided_view(source, {{5}}, 2);
@@ -2494,15 +2490,15 @@ TEST(core_array, check_1D_view_spacing_preserved)
     EXPECT_EQ(strided_view[3], 60);
     EXPECT_EQ(strided_view[4], 80);
 
-    // Deep copy to owning array - should preserve the VALUES
+    // Deep copy to owning array - should preserve the stride
     axom::Array<int, 1> arr(strided_view);
     EXPECT_EQ(arr.size(), 5);
     EXPECT_EQ(arr.minStride(), 1);  // Owning array is contiguous
-    EXPECT_EQ(arr[0], 0);           // Should copy source[0*2], not source[0]
-    EXPECT_EQ(arr[1], 20);          // Should copy source[1*2], not source[1]
-    EXPECT_EQ(arr[2], 40);          // Should copy source[2*2], not source[2]
-    EXPECT_EQ(arr[3], 60);          // Should copy source[3*2], not source[3]
-    EXPECT_EQ(arr[4], 80);          // Should copy source[4*2], not source[4]
+    EXPECT_EQ(arr[0], 0);           // Each should copy source[i*2], not source[i]
+    EXPECT_EQ(arr[1], 20);
+    EXPECT_EQ(arr[2], 40);
+    EXPECT_EQ(arr[3], 60);
+    EXPECT_EQ(arr[4], 80);
   }
 
   // Test with stride=3

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -2476,6 +2476,51 @@ TEST(core_array, check_1D_view_spacing_preserved)
     EXPECT_EQ(a.minStride(), 1);
     EXPECT_EQ(a.mapping().strides()[0], 1);
   }
+
+  // Deep copy from strided view to owning array -- must copy the values, not contiguous indices
+  {
+    int source[10];
+    for(int i = 0; i < 10; ++i)
+    {
+      source[i] = i * 10;  // {0, 10, 20, 30, 40, 50, 60, 70, 80, 90}
+    }
+
+    // Strided view with stride=2 references elements {0, 20, 40, 60, 80}
+    axom::ArrayView<int, 1> strided_view(source, {{5}}, 2);
+    EXPECT_EQ(strided_view.minStride(), 2);
+    EXPECT_EQ(strided_view[0], 0);
+    EXPECT_EQ(strided_view[1], 20);
+    EXPECT_EQ(strided_view[2], 40);
+    EXPECT_EQ(strided_view[3], 60);
+    EXPECT_EQ(strided_view[4], 80);
+
+    // Deep copy to owning array - should preserve the VALUES
+    axom::Array<int, 1> arr(strided_view);
+    EXPECT_EQ(arr.size(), 5);
+    EXPECT_EQ(arr.minStride(), 1);  // Owning array is contiguous
+    EXPECT_EQ(arr[0], 0);           // Should copy source[0*2], not source[0]
+    EXPECT_EQ(arr[1], 20);          // Should copy source[1*2], not source[1]
+    EXPECT_EQ(arr[2], 40);          // Should copy source[2*2], not source[2]
+    EXPECT_EQ(arr[3], 60);          // Should copy source[3*2], not source[3]
+    EXPECT_EQ(arr[4], 80);          // Should copy source[4*2], not source[4]
+  }
+
+  // Test with stride=3
+  {
+    int source[12];
+    for(int i = 0; i < 12; ++i)
+    {
+      source[i] = i * 100;
+    }
+
+    axom::ArrayView<int, 1> view3(source, {{4}}, 3);  // {0, 300, 600, 900}
+    axom::Array<int, 1> arr3(view3);
+    EXPECT_EQ(arr3.size(), 4);
+    EXPECT_EQ(arr3[0], 0);
+    EXPECT_EQ(arr3[1], 300);
+    EXPECT_EQ(arr3[2], 600);
+    EXPECT_EQ(arr3[3], 900);
+  }
 }
 
 TEST(core_array, resize_stackarray)

--- a/src/axom/core/tests/core_array.hpp
+++ b/src/axom/core/tests/core_array.hpp
@@ -2434,6 +2434,50 @@ void test_resize_with_stackarray(DataType value)
   }
 }
 
+TEST(core_array, check_1D_view_spacing_preserved)
+{
+  int buf[12];
+  for(int i = 0; i < 12; i++)
+  {
+    buf[i] = i;
+  }
+
+  // A strided 1D view referencing elements {0, 3, 6, 9}
+  axom::ArrayView<int, 1> v(buf, {{4}}, axom::StackArray<axom::IndexType, 1> {{3}});
+  EXPECT_EQ(v.minStride(), 3);
+  EXPECT_EQ(v[1], 3);
+
+  // A strided 1D view created through the min_stride constructor
+  {
+    axom::ArrayView<int, 1> vs(buf, {{4}}, 3);
+    EXPECT_EQ(vs.minStride(), 3);
+    EXPECT_EQ(vs[2], 6);
+  }
+
+  // Conversion to a view-of-const must preserve the spacing
+  {
+    axom::ArrayView<const int, 1> cv = v;
+    EXPECT_EQ(cv.minStride(), 3);
+    EXPECT_EQ(cv[1], 3);
+    EXPECT_EQ(cv[3], 9);
+    EXPECT_EQ(cv.mapping().strides()[0], 3);
+  }
+
+  // Copy construction must preserve the spacing
+  {
+    axom::ArrayView<int, 1> v2(v);
+    EXPECT_EQ(v2.minStride(), 3);
+    EXPECT_EQ(v2[2], 6);
+  }
+
+  // Owning 1D arrays are always contiguous (unit stride)
+  {
+    axom::Array<int> a(4);
+    EXPECT_EQ(a.minStride(), 1);
+    EXPECT_EQ(a.mapping().strides()[0], 1);
+  }
+}
+
 TEST(core_array, resize_stackarray)
 {
   test_resize_with_stackarray<bool>(false);

--- a/src/axom/core/tests/core_benchmark_array.cpp
+++ b/src/axom/core/tests/core_benchmark_array.cpp
@@ -26,8 +26,9 @@ enum class ArrayFeatureBenchmarks
   Constructors = 1 << 0,
   Insertion = 1 << 1,
   Iterators = 1 << 2,
+  Access = 1 << 3,
 
-  All = Constructors | Insertion | Iterators
+  All = Constructors | Insertion | Iterators | Access
 };
 
 inline ArrayFeatureBenchmarks operator|(ArrayFeatureBenchmarks lhs, ArrayFeatureBenchmarks rhs)
@@ -68,7 +69,8 @@ struct axom::fmt::formatter<ArrayFeatureBenchmarks>
     static const std::map<ArrayFeatureBenchmarks, std::string> feature_map = {
       {ArrayFeatureBenchmarks::Constructors, "Constructors"},
       {ArrayFeatureBenchmarks::Insertion, "Insertion"},
-      {ArrayFeatureBenchmarks::Iterators, "Iterators"}};
+      {ArrayFeatureBenchmarks::Iterators, "Iterators"},
+      {ArrayFeatureBenchmarks::Access, "Access"}};
 
     if(feature == ArrayFeatureBenchmarks::None)
     {
@@ -370,6 +372,97 @@ void iterate_direct(benchmark::State& state)
 }
 
 //-----------------------------------------------------------------------------
+// Benchmarks for contiguous 1D element access
+//-----------------------------------------------------------------------------
+template <typename Container>
+void access_bracket(benchmark::State& state)
+{
+  using T = typename Container::value_type;
+  const int size = state.range(0);
+
+  Container data(size);
+  for(int i = 0; i < size; ++i)
+  {
+    data[i] = static_cast<T>(i);
+  }
+
+  for(auto _ : state)
+  {
+    T sum {};
+    for(int i = 0; i < size; ++i)
+    {
+      sum += data[i];
+    }
+    benchmark::DoNotOptimize(sum);
+  }
+
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * size);
+}
+
+template <typename Container>
+void address_bracket(benchmark::State& state)
+{
+  using T = typename Container::value_type;
+  const int size = state.range(0);
+
+  Container data(size);
+
+  for(auto _ : state)
+  {
+    for(int i = 0; i < size; ++i)
+    {
+      T* ptr = &data[i];
+      benchmark::DoNotOptimize(ptr);
+    }
+  }
+
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * size);
+}
+
+template <typename T>
+void access_flatIndex(benchmark::State& state)
+{
+  const int size = state.range(0);
+
+  axom::Array<T, 1> data(size);
+  for(int i = 0; i < size; ++i)
+  {
+    data[i] = static_cast<T>(i);
+  }
+
+  for(auto _ : state)
+  {
+    T sum {};
+    for(int i = 0; i < size; ++i)
+    {
+      sum += data.flatIndex(i);
+    }
+    benchmark::DoNotOptimize(sum);
+  }
+
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * size);
+}
+
+template <typename T>
+void address_flatIndex(benchmark::State& state)
+{
+  const int size = state.range(0);
+
+  axom::Array<T, 1> data(size);
+
+  for(auto _ : state)
+  {
+    for(int i = 0; i < size; ++i)
+    {
+      T* ptr = &data.flatIndex(i);
+      benchmark::DoNotOptimize(ptr);
+    }
+  }
+
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * size);
+}
+
+//-----------------------------------------------------------------------------
 // Register all the tests
 //-----------------------------------------------------------------------------
 
@@ -408,6 +501,30 @@ void RegisterBenchmark()
     benchmark::RegisterBenchmark(tname("vector::iterate_direct"), &iterate_direct<std::vector<T>>)->Apply(CustomArgs);
   }
   // clang-format on
+}
+
+void RegisterAccessBenchmarks()
+{
+  if((args_benchmark_features & ArrayFeatureBenchmarks::Access) == ArrayFeatureBenchmarks::None)
+  {
+    return;
+  }
+
+  benchmark::RegisterBenchmark("Array<double>::access_bracket",
+                               &access_bracket<axom::Array<double, 1>>)
+    ->Apply(CustomArgs);
+  benchmark::RegisterBenchmark("Array<double>::access_flatIndex", &access_flatIndex<double>)
+    ->Apply(CustomArgs);
+  benchmark::RegisterBenchmark("Array<double>::address_bracket",
+                               &address_bracket<axom::Array<double, 1>>)
+    ->Apply(CustomArgs);
+  benchmark::RegisterBenchmark("Array<double>::address_flatIndex", &address_flatIndex<double>)
+    ->Apply(CustomArgs);
+  benchmark::RegisterBenchmark("vector<double>::access_bracket", &access_bracket<std::vector<double>>)
+    ->Apply(CustomArgs);
+  benchmark::RegisterBenchmark("vector<double>::address_bracket",
+                               &address_bracket<std::vector<double>>)
+    ->Apply(CustomArgs);
 }
 
 //-----------------------------------------------------------------------------
@@ -470,6 +587,7 @@ int main(int argc, char* argv[])
           {"constructors", ArrayFeatureBenchmarks::Constructors},
           {"insertion", ArrayFeatureBenchmarks::Insertion},
           {"iterators", ArrayFeatureBenchmarks::Iterators},
+          {"access", ArrayFeatureBenchmarks::Access},
           {"all", ArrayFeatureBenchmarks::All}};
 
         std::string lower_feature = feature;
@@ -507,6 +625,7 @@ int main(int argc, char* argv[])
   }
 
   RegisterBenchmarks<Types>();
+  RegisterAccessBenchmarks();
   ::benchmark::RunSpecifiedBenchmarks();
   return 0;
 }

--- a/src/axom/sina/core/Curve.cpp
+++ b/src/axom/sina/core/Curve.cpp
@@ -18,6 +18,7 @@
 #include "axom/sina/core/ConduitUtil.hpp"
 
 #include <memory>
+#include <string>
 
 namespace axom
 {
@@ -52,8 +53,10 @@ Curve::Curve(std::string name_, conduit::Node const &curveAsNode)
   , units {}
   , tags {}
 {
-  auto &valuesAsNode = getRequiredField(VALUES_KEY, curveAsNode, CURVE_TYPE_NAME);
-  values = toDoubleVector(valuesAsNode, VALUES_KEY);
+  std::string const curve_type_name {CURVE_TYPE_NAME};
+  std::string const values_key {VALUES_KEY};
+  conduit::Node const &valuesAsNode = getRequiredField(values_key, curveAsNode, curve_type_name);
+  values = toDoubleVector(valuesAsNode, values_key);
 
   units = getOptionalString(UNITS_KEY, curveAsNode, CURVE_TYPE_NAME);
 

--- a/src/axom/sina/tests/sina_ConduitUtil.cpp
+++ b/src/axom/sina/tests/sina_ConduitUtil.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <stdexcept>
+#include <string>
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
@@ -31,7 +32,9 @@ TEST(ConduitUtil, getRequiredField_present)
 {
   conduit::Node parent;
   parent["fieldName"] = "field value";
-  auto &field = getRequiredField("fieldName", parent, "parent name");
+  std::string const field_name {"fieldName"};
+  std::string const parent_name {"parent name"};
+  conduit::Node const &field = getRequiredField(field_name, parent, parent_name);
   EXPECT_TRUE(field.dtype().is_string());
   EXPECT_EQ("field value", field.as_string());
 }
@@ -41,7 +44,9 @@ TEST(ConduitUtil, getRequiredField_missing)
   conduit::Node parent;
   try
   {
-    auto &field = getRequiredField("fieldName", parent, "parent name");
+    std::string const field_name {"fieldName"};
+    std::string const parent_name {"parent name"};
+    conduit::Node const &field = getRequiredField(field_name, parent, parent_name);
     FAIL() << "Should not have found field, but got " << field.name();
   }
   catch(std::invalid_argument const &expected)

--- a/src/thirdparty/tests/CMakeLists.txt
+++ b/src/thirdparty/tests/CMakeLists.txt
@@ -318,9 +318,10 @@ set_target_properties(compiler_flag_unused_local_typedef_test
     PROPERTIES COMPILE_FLAGS "${ADDL_SMOKE_FLAGS} ${AXOM_DISABLE_UNUSED_LOCAL_TYPEDEF}")
 
 # the aliasing test requires optimization, set this up as custom compiler flag
-# in case we need more flexibility for this flag (e.g. for MSVC)
+# GNU requires a higher warning level to trigger strict-aliasing, before disabling it
 blt_append_custom_compiler_flag(FLAGS_VAR TMP_OPT_FLAG
     DEFAULT "-O2"
+    GNU     "-O2 -Wstrict-aliasing=2"
     MSVC    " "
 )
 

--- a/src/thirdparty/tests/compiler_flag_strict_aliasing.cpp
+++ b/src/thirdparty/tests/compiler_flag_strict_aliasing.cpp
@@ -31,7 +31,8 @@ struct Bar
 int main()
 {
   Foo foo = {1, nullptr};
-  ((Bar*)(&foo))->i++;  // violates strict aliasing
+  auto* bar = reinterpret_cast<Bar*>(&foo);
+  bar->i = foo.i + 1;  // violates strict aliasing
 
   std::cout << " foo.i: " << foo.i << std::endl;
   return 0;


### PR DESCRIPTION
# Summary

- This PR is a bugfix and an optimization
- It fixes a bug in the `ArrayView` copy/assign operator where the stride was not copied
- It fixes a bug when copying strided ArrayViews into (unstrided) 1D Arrays
- It optimizes the access operator for `axom::Arrray<T,1>`. Since this always has a unit stride, we should compile away the stride multiplication.
  - The new benchmarks show the following improvement:
      - `Array<double>::address_bracket/1024`: develop ~385 ns → branch ~283 ns (~26% faster)
      - `Array<double>::address_flatIndex/1024`: develop ~344 ns → branch ~283 ns (~18% faster)
- I found this as a possible speedup for #1882, but it should benefit all `axom::Array` users
