### PR TITLE
Inlet: Add ability to have containers that hold variant user defined structs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,6 +39,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Primal: Adds KnotVector constructors that skip validity assertion checks, allowing the user to call `isValid()`
   and handle the error appropriately.
 - Inlet: Added the ability to have collections (array and dictionary) with variant values.
+- Inlet: Added the ability to have collections (array and dictionary) with variant user defined structures.
 
 ### Removed
 

--- a/src/axom/inlet/Container.cpp
+++ b/src/axom/inlet/Container.cpp
@@ -1051,10 +1051,16 @@ Container& Container::registerVerifier(Verifier lambda)
 
 bool Container::verify(std::vector<VerificationError>* errors) const
 {
+  const bool collection_group_provided = isCollectionGroup(m_name) &&
+    m_sidreGroup->hasView(detail::VARIANT_STRUCT_COLLECTION_FLAG) &&
+    m_sidreGroup->hasView("retrieval_status") &&
+    static_cast<ReaderResult>(static_cast<int>(m_sidreGroup->getView("retrieval_status")->getData())) ==
+      ReaderResult::Success;
+
   // Whether the calling container has anything in it
   // If the name is empty then we're the global (root) container, which we always
   // consider to be defined
-  const bool this_container_defined = isUserProvided() || m_name.empty();
+  const bool this_container_defined = isUserProvided() || m_name.empty() || collection_group_provided;
 
   // If this container was required, make sure something was defined in it
   bool verified = verifyRequired(*m_sidreGroup, this_container_defined, "Container", errors);

--- a/src/axom/inlet/Container.hpp
+++ b/src/axom/inlet/Container.hpp
@@ -18,9 +18,12 @@
 #include <memory>
 #include <string>
 #include <functional>
+#include <set>
+#include <typeindex>
 #include <unordered_map>
 #include <tuple>
 #include <type_traits>
+#include <variant>
 
 #include "axom/fmt.hpp"
 
@@ -61,8 +64,28 @@ namespace inlet
 
 class Container;
 
+template <typename Variant>
+class VariantStructCollection;
+
 namespace detail
 {
+struct VariantStructFactoryBase
+{
+  virtual ~VariantStructFactoryBase() = default;
+};
+
+template <typename Variant>
+struct VariantStructFactory : VariantStructFactoryBase
+{
+  explicit VariantStructFactory(const std::string& discriminatorName)
+    : discriminator(discriminatorName)
+  { }
+
+  std::string discriminator;
+  std::set<std::string> labels;
+  std::unordered_map<std::string, std::function<Variant(const Container&)>> constructors;
+};
+
 /*!
  *******************************************************************************
  * \class is_inlet_primitive
@@ -172,6 +195,14 @@ struct is_std_vector : std::false_type
 
 template <typename T>
 struct is_std_vector<std::vector<T>> : std::true_type
+{ };
+
+template <typename T>
+struct is_std_variant : std::false_type
+{ };
+
+template <typename... T>
+struct is_std_variant<std::variant<T...>> : std::true_type
 { };
 
 template <typename T>
@@ -323,6 +354,45 @@ void updateUnexpectedNames(const std::string& accessedName,
 class Proxy;
 /*!
  *******************************************************************************
+ * \class VariantStructCollection
+ *
+ * \brief Helper for defining collections whose entries are selected from a
+ *        finite set of user-defined struct types.
+ *******************************************************************************
+ */
+template <typename Variant>
+class VariantStructCollection
+{
+public:
+  /*!
+   *****************************************************************************
+   * \brief Add a struct alternative to this variant collection.
+   *
+   * \param [in] label Discriminator value selecting this alternative
+   * \param [in] defineSchema Callable accepting a Container& and defining the
+   * schema for the selected alternative
+   * \tparam Alternative One of the types held by the Variant
+   *****************************************************************************
+   */
+  template <typename Alternative, typename SchemaDefiner>
+  VariantStructCollection& addAlternative(const std::string& label, SchemaDefiner&& defineSchema);
+
+  Container& collection() { return *m_collection; }
+
+private:
+  VariantStructCollection(Container& collection, detail::VariantStructFactory<Variant>& factory)
+    : m_collection(&collection)
+    , m_factory(&factory)
+  { }
+
+  Container* m_collection;
+  detail::VariantStructFactory<Variant>* m_factory;
+
+  friend class Container;
+};
+
+/*!
+ *******************************************************************************
  * \class Container
  *
  * \brief Provides functions to help define how individual Container and Field
@@ -469,6 +539,25 @@ public:
 
   /*!
    *****************************************************************************
+   * \brief Add an array of variant user-defined types to the input file schema.
+   *
+   * Each element must contain a string discriminator field whose value selects
+   * one of the registered struct alternatives.
+   *
+   * \param [in] name Name of the array
+   * \param [in] discriminator Name of the field selecting the alternative
+   * \param [in] description Description of the array
+   *
+   * \return Helper used to register struct alternatives
+   *****************************************************************************
+   */
+  template <typename Variant>
+  VariantStructCollection<Variant> addVariantStructArray(const std::string& name,
+                                                         const std::string& discriminator = "type",
+                                                         const std::string& description = "");
+
+  /*!
+   *****************************************************************************
    * \brief Add an array of Fields to the input file schema.
    *
    * \param [in] name Name of the array
@@ -541,6 +630,23 @@ public:
    */
   Verifiable<Container>& addVariantDictionary(const std::string& name,
                                               const std::string& description = "");
+
+  /*!
+   *****************************************************************************
+   * \brief Add a dictionary of variant user-defined types to the input file schema.
+   *
+   * \param [in] name Name of the dictionary
+   * \param [in] discriminator Name of the field selecting the alternative
+   * \param [in] description Description of the dictionary
+   *
+   * \return Helper used to register struct alternatives
+   *****************************************************************************
+   */
+  template <typename Variant>
+  VariantStructCollection<Variant> addVariantStructDictionary(
+    const std::string& name,
+    const std::string& discriminator = "type",
+    const std::string& description = "");
 
   /*!
    *****************************************************************************
@@ -721,9 +827,9 @@ public:
    *******************************************************************************
    */
   template <typename T>
-  typename std::enable_if<!detail::is_inlet_primitive<T>::value &&
-                            !detail::is_inlet_array<T>::value && !detail::is_inlet_dict<T>::value &&
-                            !detail::is_std_vector<T>::value && !detail::is_variant_value<T>::value,
+  typename std::enable_if<!detail::is_inlet_primitive<T>::value && !detail::is_inlet_array<T>::value &&
+                            !detail::is_inlet_dict<T>::value && !detail::is_std_vector<T>::value &&
+                            !detail::is_variant_value<T>::value && !detail::is_std_variant<T>::value,
                           T>::type
   get(const std::string& name = "") const
   {
@@ -1209,12 +1315,40 @@ private:
   template <typename Key, typename Val>
   std::unordered_map<Key, Val> getCollection() const
   {
+    return getCollectionImpl<Key, Val>(
+      std::integral_constant < bool,
+      detail::is_std_variant<Val>::value && !detail::is_variant_value<Val>::value > {});
+  }
+
+  template <typename Key, typename Val>
+  std::unordered_map<Key, Val> getCollectionImpl(std::false_type) const
+  {
     std::unordered_map<Key, Val> map;
     for(const auto& indexLabel : detail::collectionIndices(*this))
     {
       if(detail::matchesKeyType<Key>(indexLabel))
       {
         map[detail::toIndex<Key>(indexLabel)] = get<Val>(detail::indexToString(indexLabel));
+      }
+    }
+    return map;
+  }
+
+  template <typename Key, typename Variant>
+  std::unordered_map<Key, Variant> getCollectionImpl(std::true_type) const
+  {
+    const auto& factory = variantStructFactory<Variant>();
+    std::unordered_map<Key, Variant> map;
+    for(const auto& indexLabel : detail::collectionIndices(*this))
+    {
+      if(detail::matchesKeyType<Key>(indexLabel))
+      {
+        const auto& element = getContainer(detail::indexToString(indexLabel));
+        const auto label = element.get<std::string>(factory.discriminator);
+        const auto constructor = factory.constructors.find(label);
+        SLIC_ERROR_IF(constructor == factory.constructors.end(),
+                      fmt::format("[Inlet] Unknown variant struct discriminator '{0}'", label));
+        map.emplace(detail::toIndex<Key>(indexLabel), constructor->second(element));
       }
     }
     return map;
@@ -1248,6 +1382,17 @@ private:
    */
   template <typename Key>
   Container& addStructCollection(const std::string& name, const std::string& description = "");
+
+  template <typename Key, typename Variant>
+  VariantStructCollection<Variant> addVariantStructCollection(const std::string& name,
+                                                              const std::string& discriminator,
+                                                              const std::string& description = "");
+
+  template <typename Variant>
+  detail::VariantStructFactory<Variant>& variantStructFactory(const std::string& discriminator);
+
+  template <typename Variant>
+  const detail::VariantStructFactory<Variant>& variantStructFactory() const;
 
   /*!
    *****************************************************************************
@@ -1321,11 +1466,135 @@ private:
   std::vector<AggregateField> m_aggregate_fields;
   std::vector<AggregateVerifiable<Function>> m_aggregate_funcs;
 
+  std::unordered_map<std::type_index, std::unique_ptr<detail::VariantStructFactoryBase>>
+    m_variant_struct_factories;
+
   // Used when the calling Container is a struct collection within a struct collection
   // Need to delegate schema-defining calls (add*) to the elements of the nested
   // collection
   std::vector<std::reference_wrapper<Container>> m_nested_aggregates;
+
+  template <typename Variant>
+  friend class VariantStructCollection;
 };
+
+template <typename Variant>
+template <typename Alternative, typename SchemaDefiner>
+VariantStructCollection<Variant>& VariantStructCollection<Variant>::addAlternative(
+  const std::string& label,
+  SchemaDefiner&& defineSchema)
+{
+  static_assert(std::is_constructible<Variant, Alternative>::value,
+                "Alternative must be one of the types held by the variant");
+  static_assert(detail::has_FromInlet_specialization<Alternative>::value,
+                "To read a variant struct alternative, specialize FromInlet<T>");
+
+  m_factory->labels.insert(label);
+  m_factory->constructors[label] = [](const Container& container) {
+    FromInlet<Alternative> from_inlet;
+    return Variant {from_inlet(container)};
+  };
+
+  for(const auto& index : detail::collectionIndices(*m_collection))
+  {
+    Container& element = m_collection->getContainer(detail::indexToString(index));
+    if(element.isUserProvided(m_factory->discriminator) &&
+       element.template get<std::string>(m_factory->discriminator) == label)
+    {
+      defineSchema(element);
+    }
+  }
+
+  return *this;
+}
+
+template <typename Variant>
+VariantStructCollection<Variant> Container::addVariantStructArray(const std::string& name,
+                                                                  const std::string& discriminator,
+                                                                  const std::string& description)
+{
+  return addVariantStructCollection<int, Variant>(name, discriminator, description);
+}
+
+template <typename Variant>
+VariantStructCollection<Variant> Container::addVariantStructDictionary(const std::string& name,
+                                                                       const std::string& discriminator,
+                                                                       const std::string& description)
+{
+  return addVariantStructCollection<VariantKey, Variant>(name, discriminator, description);
+}
+
+template <typename Key, typename Variant>
+VariantStructCollection<Variant> Container::addVariantStructCollection(const std::string& name,
+                                                                       const std::string& discriminator,
+                                                                       const std::string& description)
+{
+  static_assert(detail::is_std_variant<Variant>::value,
+                "Variant struct collections must be retrieved as std::variant alternatives");
+
+  auto& collection = addStructCollection<Key>(name, description);
+  if(!collection.m_sidreGroup->hasView(detail::VARIANT_STRUCT_COLLECTION_FLAG))
+  {
+    collection.m_sidreGroup->createViewScalar(detail::VARIANT_STRUCT_COLLECTION_FLAG, true);
+  }
+  auto& factory = collection.template variantStructFactory<Variant>(discriminator);
+  auto* factory_ptr = &factory;
+  collection.addString(discriminator, "Variant struct discriminator")
+    .required()
+    .registerVerifier([factory_ptr](const Field& field) {
+      const auto label = field.get<std::string>();
+      return factory_ptr->labels.find(label) != factory_ptr->labels.end();
+    });
+  collection.m_verifier = [factory_ptr](const Container& container, std::vector<VerificationError>*) {
+    for(const auto& index : detail::collectionIndices(container))
+    {
+      const auto child_name =
+        utilities::string::appendPrefix(container.name(), detail::indexToString(index));
+      const auto& element = *container.getChildContainers().at(child_name);
+      if(!element.isUserProvided(factory_ptr->discriminator))
+      {
+        return false;
+      }
+
+      const auto label = element.template get<std::string>(factory_ptr->discriminator);
+      if(factory_ptr->labels.find(label) == factory_ptr->labels.end())
+      {
+        return false;
+      }
+    }
+    return true;
+  };
+  return VariantStructCollection<Variant>(collection, factory);
+}
+
+template <typename Variant>
+detail::VariantStructFactory<Variant>& Container::variantStructFactory(const std::string& discriminator)
+{
+  auto& base_factory = m_variant_struct_factories[std::type_index(typeid(Variant))];
+  if(!base_factory)
+  {
+    base_factory = std::make_unique<detail::VariantStructFactory<Variant>>(discriminator);
+  }
+
+  auto* factory = dynamic_cast<detail::VariantStructFactory<Variant>*>(base_factory.get());
+  SLIC_ERROR_IF(factory == nullptr, "[Inlet] Variant struct factory type mismatch");
+  SLIC_ERROR_IF(factory->discriminator != discriminator,
+                fmt::format("[Inlet] Variant struct collection already uses discriminator '{0}'",
+                            factory->discriminator));
+  return *factory;
+}
+
+template <typename Variant>
+const detail::VariantStructFactory<Variant>& Container::variantStructFactory() const
+{
+  const auto factory_iter = m_variant_struct_factories.find(std::type_index(typeid(Variant)));
+  SLIC_ERROR_IF(factory_iter == m_variant_struct_factories.end(),
+                "[Inlet] Variant struct collection schema has not been registered");
+
+  auto* factory = dynamic_cast<detail::VariantStructFactory<Variant>*>(factory_iter->second.get());
+  SLIC_ERROR_IF(factory == nullptr, "[Inlet] Variant struct factory type mismatch");
+  return *factory;
+}
 
 }  // namespace inlet
 }  // namespace axom

--- a/src/axom/inlet/Inlet.hpp
+++ b/src/axom/inlet/Inlet.hpp
@@ -395,6 +395,25 @@ public:
 
   /*!
    *****************************************************************************
+   * \brief Add an array of variant user-defined types to the input file schema.
+   *
+   * \param [in] name Name of the array
+   * \param [in] discriminator Name of the field selecting the alternative
+   * \param [in] description Description of the array
+   *
+   * \return Helper used to register struct alternatives
+   *****************************************************************************
+   */
+  template <typename Variant>
+  VariantStructCollection<Variant> addVariantStructArray(const std::string& name,
+                                                         const std::string& discriminator = "type",
+                                                         const std::string& description = "")
+  {
+    return m_globalContainer.addVariantStructArray<Variant>(name, discriminator, description);
+  }
+
+  /*!
+   *****************************************************************************
    * \brief Get a function from the input deck
    *
    * \param [in] name        Name of the function
@@ -505,6 +524,26 @@ public:
   Container& addStructDictionary(const std::string& name, const std::string& description = "")
   {
     return m_globalContainer.addStructDictionary(name, description);
+  }
+
+  /*!
+   *****************************************************************************
+   * \brief Add a dictionary of variant user-defined types to the input file schema.
+   *
+   * \param [in] name Name of the dictionary
+   * \param [in] discriminator Name of the field selecting the alternative
+   * \param [in] description Description of the dictionary
+   *
+   * \return Helper used to register struct alternatives
+   *****************************************************************************
+   */
+  template <typename Variant>
+  VariantStructCollection<Variant> addVariantStructDictionary(
+    const std::string& name,
+    const std::string& discriminator = "type",
+    const std::string& description = "")
+  {
+    return m_globalContainer.addVariantStructDictionary<Variant>(name, discriminator, description);
   }
 
   /*!

--- a/src/axom/inlet/docs/sphinx/advanced_types.rst
+++ b/src/axom/inlet/docs/sphinx/advanced_types.rst
@@ -194,3 +194,29 @@ as ``std::unordered_map<int, T>``:
 String-keyed dictionaries are implemented as ``std::unordered_map<std::string, T>`` and can be retrieved
 in the same way as the array above.  For dictionaries with a mix of string and integer keys, the
 ``inlet::VariantKey`` type can be used, namely, by retrieving a ``std::unordered_map<inlet::VariantKey, T>``.
+
+Variant Struct Collections
+--------------------------
+
+Collections whose entries can be selected from a finite set of user-defined struct types can be
+defined with ``addVariantStructArray`` or ``addVariantStructDictionary``.  Each entry must contain
+a string discriminator field, and each alternative still uses its normal ``FromInlet`` specialization
+for retrieval:
+
+.. code-block:: C++
+
+  using Shape = std::variant<Circle, Box>;
+
+  auto shapes = inlet.addVariantStructArray<Shape>("shapes", "kind");
+  shapes.addAlternative<Circle>("circle", [](inlet::Container& circle) {
+    circle.addDouble("radius").required();
+  });
+  shapes.addAlternative<Box>("box", [](inlet::Container& box) {
+    box.addDouble("width").required();
+    box.addDouble("height").required();
+  });
+
+  auto values = inlet["shapes"].get<std::vector<Shape>>();
+
+Verification fails if an entry omits the discriminator or uses a discriminator value that was not
+registered as an alternative.

--- a/src/axom/inlet/docs/sphinx/advanced_types.rst
+++ b/src/axom/inlet/docs/sphinx/advanced_types.rst
@@ -198,20 +198,75 @@ in the same way as the array above.  For dictionaries with a mix of string and i
 Variant Struct Collections
 --------------------------
 
-Collections whose entries can be selected from a finite set of user-defined struct types can be
-defined with ``addVariantStructArray`` or ``addVariantStructDictionary``.  Each entry must contain
-a string discriminator field, and each alternative still uses its normal ``FromInlet`` specialization
-for retrieval:
+Variant struct collections store a collection whose entries can be selected from a
+finite set of user-defined struct types.  They are useful when every entry in a
+collection shares the same role, but different entries require different fields.
+For example, a ``shapes`` collection might contain both circles and boxes.
+
+Each entry must contain a string discriminator field.  The discriminator value
+selects which struct schema and ``FromInlet`` specialization Inlet should use for
+that entry.
+
+Defining And Storing
+~~~~~~~~~~~~~~~~~~~~
+
+Represent the possible entry types with a ``std::variant``.  Each alternative in
+the variant is a normal user-defined type, so it still provides its own
+``FromInlet`` specialization:
 
 .. literalinclude:: ../../examples/variant_struct_collections.cpp
    :start-after: _inlet_variant_struct_collections_start
    :end-before: _inlet_variant_struct_collections_end
    :language: C++
 
+Use ``addVariantStructArray`` for array-like input.  The function takes the
+collection name and the discriminator field name.  After creating the collection
+schema, register each allowed discriminator value with ``addAlternative`` and
+define the schema for that alternative:
+
 .. literalinclude:: ../../examples/variant_struct_collections.cpp
-   :start-after: _inlet_variant_struct_collections_usage_start
-   :end-before: _inlet_variant_struct_collections_usage_end
+   :start-after: _inlet_variant_struct_collections_schema_usage_start
+   :end-before: _inlet_variant_struct_collections_schema_usage_end
    :language: C++
 
 Verification fails if an entry omits the discriminator or uses a discriminator value that was not
 registered as an alternative.
+
+Accessing
+~~~~~~~~~
+
+Variant struct collections are retrieved as collections of the same
+``std::variant`` type used when defining the schema.  Call ``verify`` before
+retrieval to check that every entry has a known discriminator:
+
+.. literalinclude:: ../../examples/variant_struct_collections.cpp
+   :start-after: _inlet_variant_struct_collections_verify_start
+   :end-before: _inlet_variant_struct_collections_verify_end
+   :language: C++
+
+Contiguous arrays can be retrieved as ``std::vector<Variant>``:
+
+.. literalinclude:: ../../examples/variant_struct_collections.cpp
+   :start-after: _inlet_variant_struct_collections_access_vector_start
+   :end-before: _inlet_variant_struct_collections_access_vector_end
+   :language: C++
+
+The same array-like collection can also be retrieved as an integer-keyed
+dictionary when the original indices are needed:
+
+.. literalinclude:: ../../examples/variant_struct_collections.cpp
+   :start-after: _inlet_variant_struct_collections_access_dictionary_start
+   :end-before: _inlet_variant_struct_collections_access_dictionary_end
+   :language: C++
+
+For associative input, use ``addVariantStructDictionary`` and retrieve the
+collection as ``std::unordered_map<inlet::VariantKey, Variant>``.
+
+Once retrieved, use normal ``std::variant`` access patterns, such as
+``std::visit``, ``std::get_if``, or ``std::holds_alternative``, to work with the
+concrete struct stored in each entry:
+
+.. literalinclude:: ../../examples/variant_struct_collections.cpp
+   :start-after: _inlet_variant_struct_collections_visit_start
+   :end-before: _inlet_variant_struct_collections_visit_end
+   :language: C++

--- a/src/axom/inlet/docs/sphinx/advanced_types.rst
+++ b/src/axom/inlet/docs/sphinx/advanced_types.rst
@@ -203,20 +203,15 @@ defined with ``addVariantStructArray`` or ``addVariantStructDictionary``.  Each 
 a string discriminator field, and each alternative still uses its normal ``FromInlet`` specialization
 for retrieval:
 
-.. code-block:: C++
+.. literalinclude:: ../../examples/variant_struct_collections.cpp
+   :start-after: _inlet_variant_struct_collections_start
+   :end-before: _inlet_variant_struct_collections_end
+   :language: C++
 
-  using Shape = std::variant<Circle, Box>;
-
-  auto shapes = inlet.addVariantStructArray<Shape>("shapes", "kind");
-  shapes.addAlternative<Circle>("circle", [](inlet::Container& circle) {
-    circle.addDouble("radius").required();
-  });
-  shapes.addAlternative<Box>("box", [](inlet::Container& box) {
-    box.addDouble("width").required();
-    box.addDouble("height").required();
-  });
-
-  auto values = inlet["shapes"].get<std::vector<Shape>>();
+.. literalinclude:: ../../examples/variant_struct_collections.cpp
+   :start-after: _inlet_variant_struct_collections_usage_start
+   :end-before: _inlet_variant_struct_collections_usage_end
+   :language: C++
 
 Verification fails if an entry omits the discriminator or uses a discriminator value that was not
 registered as an alternative.

--- a/src/axom/inlet/docs/sphinx/advanced_types.rst
+++ b/src/axom/inlet/docs/sphinx/advanced_types.rst
@@ -219,14 +219,30 @@ the variant is a normal user-defined type, so it still provides its own
    :end-before: _inlet_variant_struct_collections_end
    :language: C++
 
-Use ``addVariantStructArray`` for array-like input.  The function takes the
-collection name and the discriminator field name.  After creating the collection
-schema, register each allowed discriminator value with ``addAlternative`` and
-define the schema for that alternative:
+For array-like input, use ``addVariantStructArray``.  The function takes the
+collection name and the discriminator field name:
 
 .. literalinclude:: ../../examples/variant_struct_collections.cpp
-   :start-after: _inlet_variant_struct_collections_schema_usage_start
-   :end-before: _inlet_variant_struct_collections_schema_usage_end
+   :start-after: _inlet_variant_struct_collections_array_input_start
+   :end-before: _inlet_variant_struct_collections_array_input_end
+   :language: lua
+
+.. literalinclude:: ../../examples/variant_struct_collections.cpp
+   :start-after: _inlet_variant_struct_collections_array_schema_usage_start
+   :end-before: _inlet_variant_struct_collections_array_schema_usage_end
+   :language: C++
+
+For named dictionary input, use ``addVariantStructDictionary`` with the same
+variant type and discriminator field:
+
+.. literalinclude:: ../../examples/variant_struct_collections.cpp
+   :start-after: _inlet_variant_struct_collections_dictionary_input_start
+   :end-before: _inlet_variant_struct_collections_dictionary_input_end
+   :language: lua
+
+.. literalinclude:: ../../examples/variant_struct_collections.cpp
+   :start-after: _inlet_variant_struct_collections_dictionary_schema_usage_start
+   :end-before: _inlet_variant_struct_collections_dictionary_schema_usage_end
    :language: C++
 
 Verification fails if an entry omits the discriminator or uses a discriminator value that was not
@@ -244,23 +260,20 @@ retrieval to check that every entry has a known discriminator:
    :end-before: _inlet_variant_struct_collections_verify_end
    :language: C++
 
-Contiguous arrays can be retrieved as ``std::vector<Variant>``:
+The array input can be retrieved as ``std::vector<Variant>``:
 
 .. literalinclude:: ../../examples/variant_struct_collections.cpp
    :start-after: _inlet_variant_struct_collections_access_vector_start
    :end-before: _inlet_variant_struct_collections_access_vector_end
    :language: C++
 
-The same array-like collection can also be retrieved as an integer-keyed
-dictionary when the original indices are needed:
+The named dictionary input can be retrieved as
+``std::unordered_map<inlet::VariantKey, Variant>``:
 
 .. literalinclude:: ../../examples/variant_struct_collections.cpp
    :start-after: _inlet_variant_struct_collections_access_dictionary_start
    :end-before: _inlet_variant_struct_collections_access_dictionary_end
    :language: C++
-
-For associative input, use ``addVariantStructDictionary`` and retrieve the
-collection as ``std::unordered_map<inlet::VariantKey, Variant>``.
 
 Once retrieved, use normal ``std::variant`` access patterns, such as
 ``std::visit``, ``std::get_if``, or ``std::holds_alternative``, to work with the

--- a/src/axom/inlet/examples/CMakeLists.txt
+++ b/src/axom/inlet/examples/CMakeLists.txt
@@ -23,6 +23,7 @@ blt_list_append(
     fields.cpp
     homogeneous_collections.cpp
     lua_library.cpp
+    variant_struct_collections.cpp
     variant_collections.cpp
     containers.cpp
     user_defined_type.cpp
@@ -78,6 +79,9 @@ if (SOL_FOUND)
 
     axom_add_test( NAME    inlet_variant_collections_ex
                    COMMAND inlet_variant_collections_ex )
+
+    axom_add_test( NAME    inlet_variant_struct_collections_ex
+                   COMMAND inlet_variant_struct_collections_ex )
 
     axom_add_test( NAME    inlet_containers_ex
                    COMMAND inlet_containers_ex)

--- a/src/axom/inlet/examples/variant_struct_collections.cpp
+++ b/src/axom/inlet/examples/variant_struct_collections.cpp
@@ -60,49 +60,63 @@ void defineShapeSchema(inlet::VariantStructCollection<Shape>& shapes)
 }
 // _inlet_variant_struct_collections_end
 
-const std::string input = R"(
+const std::string array_input = R"(
+  -- _inlet_variant_struct_collections_array_input_start
   shapes = {
     { kind = "circle", radius = 2.5 },
     { kind = "box", width = 3.0, height = 4.0 }
   }
+  -- _inlet_variant_struct_collections_array_input_end
 )";
+
+const std::string dictionary_input = R"(
+  -- _inlet_variant_struct_collections_dictionary_input_start
+  shapes = {
+    ["ball"] = { kind = "circle", radius = 2.5 },
+    ["block"] = { kind = "box", width = 3.0, height = 4.0 }
+  }
+  -- _inlet_variant_struct_collections_dictionary_input_end
+)";
+
+void printShape(const Shape& shape)
+{
+  std::visit(
+    [](const auto& concrete_shape) {
+      using ShapeType = std::decay_t<decltype(concrete_shape)>;
+      if constexpr(std::is_same_v<ShapeType, Circle>)
+      {
+        SLIC_INFO(axom::fmt::format("circle radius = {}", concrete_shape.radius));
+      }
+      else
+      {
+        SLIC_INFO(axom::fmt::format("box width = {}, height = {}",
+                                    concrete_shape.width,
+                                    concrete_shape.height));
+      }
+    },
+    shape);
+}
 
 // _inlet_variant_struct_collections_visit_start
 void printShapes(const std::vector<Shape>& shapes)
 {
   for(const Shape& shape : shapes)
   {
-    std::visit(
-      [](const auto& concrete_shape) {
-        using ShapeType = std::decay_t<decltype(concrete_shape)>;
-        if constexpr(std::is_same_v<ShapeType, Circle>)
-        {
-          SLIC_INFO(axom::fmt::format("circle radius = {}", concrete_shape.radius));
-        }
-        else
-        {
-          SLIC_INFO(axom::fmt::format("box width = {}, height = {}",
-                                      concrete_shape.width,
-                                      concrete_shape.height));
-        }
-      },
-      shape);
+    printShape(shape);
   }
 }
 // _inlet_variant_struct_collections_visit_end
 
-int main()
+void runArrayExample()
 {
-  axom::slic::SimpleLogger logger;
-
   auto lr = std::make_unique<inlet::LuaReader>();
-  lr->parseString(input);
+  lr->parseString(array_input);
   inlet::Inlet inlet(std::move(lr));
 
-  // _inlet_variant_struct_collections_schema_usage_start
+  // _inlet_variant_struct_collections_array_schema_usage_start
   auto shapes_schema = inlet.addVariantStructArray<Shape>("shapes", "kind");
   defineShapeSchema(shapes_schema);
-  // _inlet_variant_struct_collections_schema_usage_end
+  // _inlet_variant_struct_collections_array_schema_usage_end
 
   // _inlet_variant_struct_collections_verify_start
   if(!inlet.verify())
@@ -115,13 +129,39 @@ int main()
   const std::vector<Shape> shapes = inlet["shapes"].get<std::vector<Shape>>();
   // _inlet_variant_struct_collections_access_vector_end
 
+  printShapes(shapes);
+}
+
+void runDictionaryExample()
+{
+  auto lr = std::make_unique<inlet::LuaReader>();
+  lr->parseString(dictionary_input);
+  inlet::Inlet inlet(std::move(lr));
+
+  // _inlet_variant_struct_collections_dictionary_schema_usage_start
+  auto shapes_schema = inlet.addVariantStructDictionary<Shape>("shapes", "kind");
+  defineShapeSchema(shapes_schema);
+  // _inlet_variant_struct_collections_dictionary_schema_usage_end
+
+  if(!inlet.verify())
+  {
+    SLIC_ERROR("Inlet failed to verify against provided schema");
+  }
+
   // _inlet_variant_struct_collections_access_dictionary_start
-  const std::unordered_map<int, Shape> shapes_by_index =
-    inlet["shapes"].get<std::unordered_map<int, Shape>>();
+  const std::unordered_map<inlet::VariantKey, Shape> shapes_by_name =
+    inlet["shapes"].get<std::unordered_map<inlet::VariantKey, Shape>>();
   // _inlet_variant_struct_collections_access_dictionary_end
 
-  printShapes(shapes);
-  SLIC_INFO(axom::fmt::format("Read {} shapes by index", shapes_by_index.size()));
+  SLIC_INFO(axom::fmt::format("Read {} named shapes", shapes_by_name.size()));
+}
+
+int main()
+{
+  axom::slic::SimpleLogger logger;
+
+  runArrayExample();
+  runDictionaryExample();
 
   return 0;
 }

--- a/src/axom/inlet/examples/variant_struct_collections.cpp
+++ b/src/axom/inlet/examples/variant_struct_collections.cpp
@@ -10,6 +10,7 @@
 
 #include <string>
 #include <type_traits>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -66,26 +67,9 @@ const std::string input = R"(
   }
 )";
 
-int main()
+// _inlet_variant_struct_collections_visit_start
+void printShapes(const std::vector<Shape>& shapes)
 {
-  axom::slic::SimpleLogger logger;
-
-  auto lr = std::make_unique<inlet::LuaReader>();
-  lr->parseString(input);
-  inlet::Inlet inlet(std::move(lr));
-
-  // _inlet_variant_struct_collections_usage_start
-  auto shapes_schema = inlet.addVariantStructArray<Shape>("shapes", "kind");
-  defineShapeSchema(shapes_schema);
-
-  if(!inlet.verify())
-  {
-    SLIC_ERROR("Inlet failed to verify against provided schema");
-  }
-
-  const std::vector<Shape> shapes = inlet["shapes"].get<std::vector<Shape>>();
-  // _inlet_variant_struct_collections_usage_end
-
   for(const Shape& shape : shapes)
   {
     std::visit(
@@ -104,6 +88,40 @@ int main()
       },
       shape);
   }
+}
+// _inlet_variant_struct_collections_visit_end
+
+int main()
+{
+  axom::slic::SimpleLogger logger;
+
+  auto lr = std::make_unique<inlet::LuaReader>();
+  lr->parseString(input);
+  inlet::Inlet inlet(std::move(lr));
+
+  // _inlet_variant_struct_collections_schema_usage_start
+  auto shapes_schema = inlet.addVariantStructArray<Shape>("shapes", "kind");
+  defineShapeSchema(shapes_schema);
+  // _inlet_variant_struct_collections_schema_usage_end
+
+  // _inlet_variant_struct_collections_verify_start
+  if(!inlet.verify())
+  {
+    SLIC_ERROR("Inlet failed to verify against provided schema");
+  }
+  // _inlet_variant_struct_collections_verify_end
+
+  // _inlet_variant_struct_collections_access_vector_start
+  const std::vector<Shape> shapes = inlet["shapes"].get<std::vector<Shape>>();
+  // _inlet_variant_struct_collections_access_vector_end
+
+  // _inlet_variant_struct_collections_access_dictionary_start
+  const std::unordered_map<int, Shape> shapes_by_index =
+    inlet["shapes"].get<std::unordered_map<int, Shape>>();
+  // _inlet_variant_struct_collections_access_dictionary_end
+
+  printShapes(shapes);
+  SLIC_INFO(axom::fmt::format("Read {} shapes by index", shapes_by_index.size()));
 
   return 0;
 }

--- a/src/axom/inlet/examples/variant_struct_collections.cpp
+++ b/src/axom/inlet/examples/variant_struct_collections.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+// files for dates and other details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "axom/inlet.hpp"
+#include "axom/slic/core/SimpleLogger.hpp"
+#include "axom/fmt.hpp"
+
+#include <string>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+namespace inlet = axom::inlet;
+
+// _inlet_variant_struct_collections_start
+struct Circle
+{
+  double radius;
+};
+
+struct Box
+{
+  double width;
+  double height;
+};
+
+using Shape = std::variant<Circle, Box>;
+
+template <>
+struct FromInlet<Circle>
+{
+  Circle operator()(const inlet::Container& input_data)
+  {
+    return {input_data["radius"]};
+  }
+};
+
+template <>
+struct FromInlet<Box>
+{
+  Box operator()(const inlet::Container& input_data)
+  {
+    return {input_data["width"], input_data["height"]};
+  }
+};
+
+void defineShapeSchema(inlet::VariantStructCollection<Shape>& shapes)
+{
+  shapes.addAlternative<Circle>("circle", [](inlet::Container& circle) {
+    circle.addDouble("radius").required();
+  });
+  shapes.addAlternative<Box>("box", [](inlet::Container& box) {
+    box.addDouble("width").required();
+    box.addDouble("height").required();
+  });
+}
+// _inlet_variant_struct_collections_end
+
+const std::string input = R"(
+  shapes = {
+    { kind = "circle", radius = 2.5 },
+    { kind = "box", width = 3.0, height = 4.0 }
+  }
+)";
+
+int main()
+{
+  axom::slic::SimpleLogger logger;
+
+  auto lr = std::make_unique<inlet::LuaReader>();
+  lr->parseString(input);
+  inlet::Inlet inlet(std::move(lr));
+
+  // _inlet_variant_struct_collections_usage_start
+  auto shapes_schema = inlet.addVariantStructArray<Shape>("shapes", "kind");
+  defineShapeSchema(shapes_schema);
+
+  if(!inlet.verify())
+  {
+    SLIC_ERROR("Inlet failed to verify against provided schema");
+  }
+
+  const std::vector<Shape> shapes = inlet["shapes"].get<std::vector<Shape>>();
+  // _inlet_variant_struct_collections_usage_end
+
+  for(const Shape& shape : shapes)
+  {
+    std::visit(
+      [](const auto& concrete_shape) {
+        using ShapeType = std::decay_t<decltype(concrete_shape)>;
+        if constexpr(std::is_same_v<ShapeType, Circle>)
+        {
+          SLIC_INFO(axom::fmt::format("circle radius = {}", concrete_shape.radius));
+        }
+        else
+        {
+          SLIC_INFO(axom::fmt::format("box width = {}, height = {}",
+                                      concrete_shape.width,
+                                      concrete_shape.height));
+        }
+      },
+      shape);
+  }
+
+  return 0;
+}

--- a/src/axom/inlet/examples/variant_struct_collections.cpp
+++ b/src/axom/inlet/examples/variant_struct_collections.cpp
@@ -33,10 +33,7 @@ using Shape = std::variant<Circle, Box>;
 template <>
 struct FromInlet<Circle>
 {
-  Circle operator()(const inlet::Container& input_data)
-  {
-    return {input_data["radius"]};
-  }
+  Circle operator()(const inlet::Container& input_data) { return {input_data["radius"]}; }
 };
 
 template <>

--- a/src/axom/inlet/inlet_utils.hpp
+++ b/src/axom/inlet/inlet_utils.hpp
@@ -136,6 +136,7 @@ namespace detail
 const std::string COLLECTION_GROUP_NAME = "_inlet_collection";
 const std::string COLLECTION_INDICES_NAME = "_inlet_collection_indices";
 const std::string STRUCT_COLLECTION_FLAG = "_inlet_struct_collection";
+const std::string VARIANT_STRUCT_COLLECTION_FLAG = "_inlet_variant_struct_collection";
 const std::string REQUIRED_FLAG = "required";
 const std::string STRICT_FLAG = "strict";
 }  // namespace detail

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -57,6 +57,46 @@ struct FromInlet<Foo>
   }
 };
 
+struct Circle
+{
+  double radius;
+
+  bool operator==(const Circle& other) const { return radius == other.radius; }
+};
+
+struct Box
+{
+  double width;
+  double height;
+
+  bool operator==(const Box& other) const { return width == other.width && height == other.height; }
+};
+
+using Shape = std::variant<Circle, Box>;
+
+template <>
+struct FromInlet<Circle>
+{
+  Circle operator()(const axom::inlet::Container& base) { return {base["radius"]}; }
+};
+
+template <>
+struct FromInlet<Box>
+{
+  Box operator()(const axom::inlet::Container& base) { return {base["width"], base["height"]}; }
+};
+
+void defineShapeSchema(axom::inlet::VariantStructCollection<Shape>& shapes)
+{
+  shapes.addAlternative<Circle>("circle", [](axom::inlet::Container& circle) {
+    circle.addDouble("radius").required();
+  });
+  shapes.addAlternative<Box>("box", [](axom::inlet::Container& box) {
+    box.addDouble("width").required();
+    box.addDouble("height").required();
+  });
+}
+
 template <typename InletReader>
 class inlet_object : public ::testing::Test
 { };
@@ -123,6 +163,79 @@ TYPED_TEST(inlet_object, simple_array_of_struct_by_value)
   std::unordered_map<int, Foo> expected_foos = {{0, {true, false}}, {1, {false, true}}};
   auto foos = inlet["foo"].get<std::unordered_map<int, Foo>>();
   EXPECT_EQ(foos, expected_foos);
+}
+
+TYPED_TEST(inlet_object, variant_array_of_struct_by_value)
+{
+  std::string testString =
+    "shapes = { [0] = { kind = \"circle\"; radius = 2.5 }, "
+    "           [1] = { kind = \"box\"; width = 3.0; height = 4.0 } }";
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
+
+  auto shapes = inlet.addVariantStructArray<Shape>("shapes", "kind");
+  defineShapeSchema(shapes);
+
+  EXPECT_TRUE(inlet.verify());
+
+  std::unordered_map<int, Shape> expected_shapes = {{0, Circle {2.5}}, {1, Box {3.0, 4.0}}};
+  auto actual_shapes = inlet["shapes"].get<std::unordered_map<int, Shape>>();
+  EXPECT_EQ(actual_shapes, expected_shapes);
+}
+
+TYPED_TEST(inlet_object, variant_array_of_struct_as_vector)
+{
+  std::string testString =
+    "shapes = { [0] = { kind = \"circle\"; radius = 2.5 }, "
+    "           [1] = { kind = \"box\"; width = 3.0; height = 4.0 } }";
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
+
+  auto shapes = inlet.addVariantStructArray<Shape>("shapes", "kind");
+  defineShapeSchema(shapes);
+
+  auto actual_shapes = inlet["shapes"].get<std::vector<Shape>>();
+  ASSERT_EQ(actual_shapes.size(), 2u);
+  EXPECT_EQ(actual_shapes[0], Shape(Circle {2.5}));
+  EXPECT_EQ(actual_shapes[1], Shape(Box {3.0, 4.0}));
+}
+
+TYPED_TEST(inlet_object, variant_dictionary_of_struct_by_value)
+{
+  std::string testString =
+    "shapes = { ball = { kind = \"circle\"; radius = 2.5 }, "
+    "           block = { kind = \"box\"; width = 3.0; height = 4.0 } }";
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
+
+  auto shapes = inlet.addVariantStructDictionary<Shape>("shapes", "kind");
+  defineShapeSchema(shapes);
+
+  EXPECT_TRUE(inlet.verify());
+
+  std::unordered_map<VariantKey, Shape> expected_shapes = {{VariantKey {"ball"}, Circle {2.5}},
+                                                           {VariantKey {"block"}, Box {3.0, 4.0}}};
+  auto actual_shapes = inlet["shapes"].get<std::unordered_map<VariantKey, Shape>>();
+  EXPECT_EQ(actual_shapes, expected_shapes);
+}
+
+TYPED_TEST(inlet_object, variant_array_of_struct_missing_discriminator_fails)
+{
+  std::string testString = "shapes = { [0] = { radius = 2.5 } }";
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
+
+  auto shapes = inlet.addVariantStructArray<Shape>("shapes", "kind");
+  defineShapeSchema(shapes);
+
+  EXPECT_FALSE(inlet.verify());
+}
+
+TYPED_TEST(inlet_object, variant_array_of_struct_unknown_discriminator_fails)
+{
+  std::string testString = "shapes = { [0] = { kind = \"triangle\"; side = 2.5 } }";
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
+
+  auto shapes = inlet.addVariantStructArray<Shape>("shapes", "kind");
+  defineShapeSchema(shapes);
+
+  EXPECT_FALSE(inlet.verify());
 }
 
 TYPED_TEST(inlet_object, simple_array_of_struct_implicit_idx)


### PR DESCRIPTION
Allows you to have a dictionary or an array that holds multiple different user-defined structs that are differentiated with a discriminator. For example:

```  
shapes = {
    { kind = "circle", radius = 2.5 },
    { kind = "box", width = 3.0, height = 4.0 }
}
```