### PR TITLE
Improvements to Python setup

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -49,6 +49,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 ### Changed
 - Updates CMake code check targets to only use checked in files (via `git ls-files`, when available)
 - Core: Optimization for axom::Array indirection -- since the stride is always 1, we can remove the runtime multiplication
+- Python: Removes build and test dependencies from `run_python_with_axom.sh` wrapper script
 
 ### Fixed
 - Primal: Fixes signs of `compute_moments` to match orientation convention in `primal::evaluate_area_integral`

--- a/scripts/spack/packages/axom/package.py
+++ b/scripts/spack/packages/axom/package.py
@@ -279,7 +279,7 @@ class Axom(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     # Python
     with when("+python"):
-        depends_on("py-nanobind@2.7.0")
+        depends_on("py-nanobind@2.7.0:")
         depends_on("py-pytest")
         depends_on("py-numpy")
         depends_on("py-mpi4py", when="+mpi")

--- a/src/axom/sidre/CMakeLists.txt
+++ b/src/axom/sidre/CMakeLists.txt
@@ -119,10 +119,6 @@ if(AXOM_ENABLE_MPI)
     blt_list_append(TO sidre_depends ELEMENTS scr IF SCR_FOUND)
 endif()
 
-if(NANOBIND_FOUND)
-    list(APPEND sidre_depends conduit::conduit_python)
-endif()
-
 axom_add_library(NAME       sidre
                  SOURCES    ${sidre_sources}
                  HEADERS    ${sidre_headers}
@@ -143,7 +139,9 @@ endif()
 
 if(NANOBIND_FOUND)
     nanobind_add_module(pysidre nanobind_sidre.cpp)
-    target_link_libraries(pysidre PRIVATE sidre)
+    # conduit::conduit_python provides conduit_python.hpp
+    # and is needed only by the binding translation unit, not by libsidre
+    target_link_libraries(pysidre PRIVATE sidre conduit::conduit_python)
 
     # Use HIP executable linker flags for the python module
     # (CMake treats modules separately from executables,

--- a/src/axom/sidre/nanobind_sidre.cpp
+++ b/src/axom/sidre/nanobind_sidre.cpp
@@ -10,6 +10,7 @@
 #include <nanobind/ndarray.h>
 #include <nanobind/make_iterator.h>
 
+#include "axom/config.hpp"
 #include "axom/core/Types.hpp"
 #include "core/SidreTypes.hpp"
 #include "core/Buffer.hpp"
@@ -243,6 +244,9 @@ conduit::Node& nbObjectToNode(nb::object& o)
 NB_MODULE(pysidre, m_sidre)
 {
   m_sidre.doc() = "A python extension for Axom's Sidre component";
+
+  // Module version mirrors the Axom release
+  m_sidre.attr("__version__") = AXOM_VERSION_FULL;
 
   m_sidre.attr("InvalidIndex") = axom::InvalidIndex;
   m_sidre.attr("InvalidName") = axom::utilities::string::InvalidName;

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -604,6 +604,28 @@ macro(axom_configure_file _source _target)
 endmacro(axom_configure_file)
 
 ##------------------------------------------------------------------------------
+## axom_python_test_environment(<output_var>)
+##
+## Composes the ENVIRONMENT entry ("PYTHONPATH=<dir>:<dir>:...") that provides
+## the pytest paths (pytest and its dependencies) from their respective CMake cache variables.
+##
+## Note: runtime dependencies (e.g. axom, conduit, numpy) are expected to be preprended
+## via the run_python_with_axom.sh script.
+##------------------------------------------------------------------------------
+function(axom_python_test_environment output_var)
+    set(_paths "")
+    foreach(_var PY_PYTEST_DIR PY_PLUGGY_DIR PY_INICONFIG_DIR)
+        blt_list_append(TO _paths ELEMENTS "${${_var}}" IF ${_var})
+    endforeach()
+    if(_paths)
+        list(JOIN _paths ":" _joined)
+        set(${output_var} "PYTHONPATH=${_joined}" PARENT_SCOPE)
+    else()
+        set(${output_var} "" PARENT_SCOPE)
+    endif()
+endfunction()
+
+##------------------------------------------------------------------------------
 ## axom_add_python_test(NAME       [name]
 ##                      SOURCE     [source]
 ##                      OUTPUT_DIR [dir])
@@ -626,12 +648,18 @@ macro(axom_add_python_test)
                          "${arg_OUTPUT_DIR}/${arg_SOURCE}" COPYONLY)
 
     # Run unit test with pytest ("python3 -m pytest").
-    # Use convenience script that has
-    # pytest, pysidre, and conduit added to PYTHONPATH.
+    # The run_python_with_axom.sh wrapper provides the runtime environment
+    # and the testing dependencies are injected via the test's ENVIRONMENT property when provided.
     # "-p no:cacheprovider" disables caching.
     add_test (NAME    ${arg_NAME}
       COMMAND ${PROJECT_BINARY_DIR}/bin/run_python_with_axom.sh -m pytest -s -p no:cacheprovider ${arg_OUTPUT_DIR}/${arg_SOURCE}
     )
+
+    axom_python_test_environment(_py_test_env)
+    if(_py_test_env)
+        set_tests_properties(${arg_NAME} PROPERTIES ENVIRONMENT "${_py_test_env}")
+    endif()
+    unset(_py_test_env)
 
 endmacro(axom_add_python_test)
 

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -364,10 +364,8 @@ endif()
 # If the python environment does not contain the required runtime modules,
 # check if library installation paths were provided instead.
 if((NOT PY_RUNTIME_IMPORT_CODE EQUAL 0)
-   AND
-   nanobind_ROOT
-   AND
-   (NOT CONDUIT_PYTHON_MODULE_DIR OR NOT PY_NUMPY_DIR))
+   AND nanobind_ROOT
+   AND (NOT CONDUIT_PYTHON_MODULE_DIR OR NOT PY_NUMPY_DIR))
     message(FATAL_ERROR
       "Axom's python extensions require conduit and numpy at runtime."
       "\nThe python library installation paths can be specified with CMake variables: "
@@ -378,12 +376,9 @@ endif()
 # It is injected per-test via the ENVIRONMENT property and is only required
 # when Axom's python tests are enabled.
 if(AXOM_ENABLE_PYTHON_TESTS
-   AND
-   (NOT PY_PYTEST_IMPORT_CODE EQUAL 0)
-   AND
-   nanobind_ROOT
-   AND
-   (NOT PY_PYTEST_DIR OR NOT PY_PLUGGY_DIR OR NOT PY_INICONFIG_DIR))
+   AND (NOT PY_PYTEST_IMPORT_CODE EQUAL 0)
+   AND nanobind_ROOT
+   AND (NOT PY_PYTEST_DIR OR NOT PY_PLUGGY_DIR OR NOT PY_INICONFIG_DIR))
     message(FATAL_ERROR
       "Running Axom's python tests requires pytest (and its dependencies pluggy and iniconfig)."
       "\nThe library installation paths can be specified with CMake variables: "
@@ -395,12 +390,9 @@ endif()
 # if python environment does not contain required mpi4py module,
 # check if mpi4py library installation path was provided instead.
 if(AXOM_ENABLE_MPI
-   AND
-   (NOT MPI4PY_ENV_IMPORT_CODE EQUAL 0)
-   AND
-   nanobind_ROOT
-   AND
-   (NOT PY_MPI4PY_DIR))
+   AND (NOT MPI4PY_ENV_IMPORT_CODE EQUAL 0)
+   AND nanobind_ROOT
+   AND (NOT PY_MPI4PY_DIR))
     message(FATAL_ERROR
       "Axom's python extension requires mpi4py when Axom library is configured with MPI."
       "\nThe mpi4py library installation paths "
@@ -415,11 +407,8 @@ if(nanobind_ROOT
    AND NOT AXOM_ENABLE_CUDA
    AND NOT AXOM_ENABLE_ASAN
    AND NOT AXOM_ENABLE_UBSAN
-   AND
-   ((NOT "$ENV{SYS_TYPE}" STREQUAL "blueos_3_ppc64le_ib_p9")
-   OR
-   ("$ENV{SYS_TYPE}" STREQUAL "blueos_3_ppc64le_ib_p9"
-   AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")))
+   AND ((NOT "$ENV{SYS_TYPE}" STREQUAL "blueos_3_ppc64le_ib_p9")
+        OR  ("$ENV{SYS_TYPE}" STREQUAL "blueos_3_ppc64le_ib_p9" AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")))
 
     axom_assert_is_directory(DIR_VARIABLE nanobind_ROOT)
     find_package(nanobind CONFIG REQUIRED)

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -370,13 +370,12 @@ if((NOT PY_RUNTIME_IMPORT_CODE EQUAL 0)
    (NOT CONDUIT_PYTHON_MODULE_DIR OR NOT PY_NUMPY_DIR))
     message(FATAL_ERROR
       "Axom's python extensions require conduit and numpy at runtime."
-      "\nThe python library installation paths  can be specified with CMake variables: "
+      "\nThe python library installation paths can be specified with CMake variables: "
       "CONDUIT_PYTHON_MODULE_DIR, PY_NUMPY_DIR")
 endif()
 
-# The pytest harness (pytest plus its dependencies pluggy and iniconfig) is a
-# test-only requirement; it is injected per-test via the ENVIRONMENT property
-# (see axom_python_test_environment in AxomMacros.cmake) and is only required
+# The pytest harness (pytest and its dependencies) is a test-only requirement.
+# It is injected per-test via the ENVIRONMENT property and is only required
 # when Axom's python tests are enabled.
 if(AXOM_ENABLE_PYTHON_TESTS
    AND

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -331,12 +331,22 @@ if(EXISTS ${Python_EXECUTABLE})
         )
     endif()
 
-    # Check if python environment potentially contains all
-    # required dependencies
+    # Check if the python environment contains the runtime dependencies for Axom's python
+    # conduit (Node interop) and numpy (ndarray returns). 
+    # nanobind is statically linked at build time and is located separately above.
     execute_process(
       COMMAND "${CMAKE_COMMAND}" -E env
-              "${Python_EXECUTABLE}" -c "import nanobind, conduit, numpy, pytest"
-      RESULT_VARIABLE PY_ENV_IMPORT_CODE
+              "${Python_EXECUTABLE}" -c "import conduit, numpy"
+      RESULT_VARIABLE PY_RUNTIME_IMPORT_CODE
+      OUTPUT_QUIET
+      ERROR_QUIET
+    )
+
+    # Check if the python environment contains the pytest test harness,
+    execute_process(
+      COMMAND "${CMAKE_COMMAND}" -E env
+              "${Python_EXECUTABLE}" -c "import pytest"
+      RESULT_VARIABLE PY_PYTEST_IMPORT_CODE
       OUTPUT_QUIET
       ERROR_QUIET
     )
@@ -351,24 +361,35 @@ if(EXISTS ${Python_EXECUTABLE})
     )
 endif()
 
-# If python environment does not contain required modules, check if
-# library installation paths were provided instead.
-if((NOT PY_ENV_IMPORT_CODE EQUAL 0)
+# If the python environment does not contain the required runtime modules,
+# check if library installation paths were provided instead.
+if((NOT PY_RUNTIME_IMPORT_CODE EQUAL 0)
    AND
    nanobind_ROOT
    AND
-   (NOT PY_NANOBIND_DIR
-   OR NOT CONDUIT_PYTHON_MODULE_DIR
-   OR NOT PY_NUMPY_DIR
-   OR NOT PY_PYTEST_DIR
-   OR NOT PY_PLUGGY_DIR
-   OR NOT PY_INICONFIG_DIR))
+   (NOT CONDUIT_PYTHON_MODULE_DIR OR NOT PY_NUMPY_DIR))
     message(FATAL_ERROR
-      "Axom's python extensions require nanobind, numpy, pytest, and conduit."
-      "\nThe python library installation paths "
-      "(and pytest's dependencies pluggy and iniconfig) "
-      "can be specified with CMake variables: "
-      "PY_NANOBIND_DIR, CONDUIT_PYTHON_MODULE_DIR, PY_NUMPY_DIR, PY_PYTEST_DIR, PY_PLUGGY_DIR, PY_INICONFIG_DIR")
+      "Axom's python extensions require conduit and numpy at runtime."
+      "\nThe python library installation paths  can be specified with CMake variables: "
+      "CONDUIT_PYTHON_MODULE_DIR, PY_NUMPY_DIR")
+endif()
+
+# The pytest harness (pytest plus its dependencies pluggy and iniconfig) is a
+# test-only requirement; it is injected per-test via the ENVIRONMENT property
+# (see axom_python_test_environment in AxomMacros.cmake) and is only required
+# when Axom's python tests are enabled.
+if(AXOM_ENABLE_PYTHON_TESTS
+   AND
+   (NOT PY_PYTEST_IMPORT_CODE EQUAL 0)
+   AND
+   nanobind_ROOT
+   AND
+   (NOT PY_PYTEST_DIR OR NOT PY_PLUGGY_DIR OR NOT PY_INICONFIG_DIR))
+    message(FATAL_ERROR
+      "Running Axom's python tests requires pytest (and its dependencies pluggy and iniconfig)."
+      "\nThe library installation paths can be specified with CMake variables: "
+      "PY_PYTEST_DIR, PY_PLUGGY_DIR, PY_INICONFIG_DIR."
+      "\nAlternatively, configure with AXOM_ENABLE_PYTHON_TESTS=OFF.")
 endif()
 
 # When Axom is configured with MPI,

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -209,11 +209,27 @@ if(NANOBIND_FOUND)
 
     unset(_PYEXT_DIR)
 
-    # Add smoke test to check script
+    # Smoke tests for the script.
+    # The wrapper provides the runtime environment only:
+    # Axom extensions, conduit (Node interop), numpy (ndarray returns), plus mpi4py in MPI configurations. 
+    # nanobind is a build-time dependency (statically linked into the extensions).
+    # pytest/pluggy/iniconfig are test-harness dependencies.
     if(AXOM_ENABLE_TESTS AND AXOM_ENABLE_SIDRE)
         axom_add_test(
             NAME    run_python_with_axom_build
-            COMMAND ${PROJECT_BINARY_DIR}/bin/run_python_with_axom.sh -c "import pysidre, nanobind, conduit, numpy, pytest")
+            COMMAND ${PROJECT_BINARY_DIR}/bin/run_python_with_axom.sh -c "import pysidre, conduit, numpy")
+
+        # The pytest harness is provided per-test via the ENVIRONMENT property
+        # verify that the wrapper + injected ENVIRONMENT combination resolves.
+        axom_add_test(
+            NAME    run_python_with_axom_pytest_harness
+            COMMAND ${PROJECT_BINARY_DIR}/bin/run_python_with_axom.sh -c "import pytest")
+        axom_python_test_environment(_py_test_env)
+        if(_py_test_env)
+            set_tests_properties(run_python_with_axom_pytest_harness
+                                 PROPERTIES ENVIRONMENT "${_py_test_env}")
+        endif()
+        unset(_py_test_env)
     endif()
 
     #--------------------------------------------------------------------------

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -219,17 +219,19 @@ if(NANOBIND_FOUND)
             NAME    run_python_with_axom_build
             COMMAND ${PROJECT_BINARY_DIR}/bin/run_python_with_axom.sh -c "import pysidre, conduit, numpy")
 
-        # The pytest harness is provided per-test via the ENVIRONMENT property
-        # verify that the wrapper + injected ENVIRONMENT combination resolves.
-        axom_add_test(
-            NAME    run_python_with_axom_pytest_harness
-            COMMAND ${PROJECT_BINARY_DIR}/bin/run_python_with_axom.sh -c "import pytest")
-        axom_python_test_environment(_py_test_env)
-        if(_py_test_env)
-            set_tests_properties(run_python_with_axom_pytest_harness
-                                 PROPERTIES ENVIRONMENT "${_py_test_env}")
+        if(AXOM_ENABLE_PYTHON_TESTS)
+            # The pytest harness is provided per-test via the ENVIRONMENT property;
+            # verify that the wrapper + injected ENVIRONMENT combination resolves.
+            axom_add_test(
+                NAME    run_python_with_axom_pytest_harness
+                COMMAND ${PROJECT_BINARY_DIR}/bin/run_python_with_axom.sh -c "import pytest")
+            axom_python_test_environment(_py_test_env)
+            if(_py_test_env)
+                set_tests_properties(run_python_with_axom_pytest_harness
+                                     PROPERTIES ENVIRONMENT "${_py_test_env}")
+            endif()
+            unset(_py_test_env)
         endif()
-        unset(_py_test_env)
     endif()
 
     #--------------------------------------------------------------------------

--- a/src/tools/run_python_with_axom.sh.in
+++ b/src/tools/run_python_with_axom.sh.in
@@ -7,7 +7,15 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 
 ##-----------------------------------------------------------------------------
-## Convenience script that runs python interpreter with Axom extension(s) in
-## the PYTHONPATH.
+## Convenience script that runs the python interpreter with Axom's extension(s) 
+## and their runtime dependencies in the PYTHONPATH:
+##   - Axom's extension modules (e.g. pysidre)
+##   - conduit's python module (conduit::Node interop)
+##   - numpy (ndarray returns)
+##   - mpi4py (only populated in MPI-enabled configurations)
+##
+## Build-time (nanobind) and testing dependencies (pytest/pluggy/iniconfig) 
+## are intentionally NOT added here. They are expected to be added to the PYTHONPATH
+## via the test's ENVIRONMENT property
 ##-----------------------------------------------------------------------------
-env PYTHONPATH=@_PYEXT_DIR@:@CONDUIT_PYTHON_MODULE_DIR@:@PY_NANOBIND_DIR@:@PY_NUMPY_DIR@:@PY_PYTEST_DIR@:@PY_PLUGGY_DIR@:@PY_INICONFIG_DIR@:@PY_MPI4PY_DIR@:$PYTHONPATH @Python_EXECUTABLE@ "$@"
+env PYTHONPATH=@_PYEXT_DIR@:@CONDUIT_PYTHON_MODULE_DIR@:@PY_NUMPY_DIR@:@PY_MPI4PY_DIR@:$PYTHONPATH @Python_EXECUTABLE@ "$@"


### PR DESCRIPTION
# Summary

- This PR improves our Python setup
- It separates the runtime vs. test vs. build dependencies.
   - The `nanobind` build dependency is statically linked, so we don't need to add it
   - The testing deps (e.g. `pytest`) and now added as a CTest `ENVIRONMENT` property
   - Only the runtime deps (e.g. `conduit` and `numpy`) are added to the `./run_python_with_axom` script
   - Removes conduit python from the sidre dependencies -- it is only a `pysidre` dependency
- Adds the Axom version to the `pysidre` module
- Allows axom's spack package to be configure against newer `nanobind` versions