### PR TITLE
Improves lifetime management for wrapped sidre entities in Python interface

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -61,6 +61,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Core: Array construction from strided ArrayView now correctly copies the strided elements
 - Core: Improved `axom::FlatMap` insertion performance by fusing duplicate-key lookup with empty-slot probing.
 - Core: Updated DeviceHash to use 64-bit hash results and improved coverage for integer and floating-point hashing.
+- Python: Improves lifetime handling for python wrapped sidre entities, including support for external views into numpy arrays.
 
 ## [Version 0.14.0] - Release date 2026-03-31
 

--- a/src/axom/sidre/CMakeLists.txt
+++ b/src/axom/sidre/CMakeLists.txt
@@ -155,6 +155,32 @@ if(NANOBIND_FOUND)
     endif()
 
     install(TARGETS pysidre LIBRARY DESTINATION lib)
+
+    # Type stubs (PEP 561). nanobind_add_stub imports the module to introspect it,
+    # so its runtime dependencies (conduit for Node interop, numpy for ndarray returns)
+    # must be importable during the build. We seed PYTHON_PATH with the module's 
+    # output directory plus the conduit/numpy install dirs from their cache variables when set;
+    # on an interpreter that already has conduit and numpy on its path these extra entries are harmless.
+    set(_pysidre_stub_pythonpath $<TARGET_FILE_DIR:pysidre>)
+    if(CONDUIT_PYTHON_MODULE_DIR)
+        list(APPEND _pysidre_stub_pythonpath ${CONDUIT_PYTHON_MODULE_DIR})
+    endif()
+    if(PY_NUMPY_DIR)
+        list(APPEND _pysidre_stub_pythonpath ${PY_NUMPY_DIR})
+    endif()
+
+    nanobind_add_stub(
+        pysidre_stub
+        MODULE pysidre
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/pysidre.pyi"
+        MARKER_FILE "${CMAKE_CURRENT_BINARY_DIR}/py.typed"
+        PYTHON_PATH ${_pysidre_stub_pythonpath}
+        DEPENDS pysidre)
+
+    # Install the stub and py.typed marker next to the extension module so type checkers (mypy, pyright) can find them
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pysidre.pyi"
+                  "${CMAKE_CURRENT_BINARY_DIR}/py.typed"
+            DESTINATION lib)
 endif()
 
 

--- a/src/axom/sidre/examples/sidre_createdatastore_Py.py
+++ b/src/axom/sidre/examples/sidre_createdatastore_Py.py
@@ -6,13 +6,14 @@
 
 import pysidre
 import numpy as np
+import numpy.typing as npt
 
 # This example file is based on sidre_createdatastore.cpp.
 # The python interface is a work-in-progress, and does not yet support
 # all the features in the C++ source.
 
 
-def create_datastore(region):
+def create_datastore(region: npt.NDArray[np.int_]) -> pysidre.DataStore:
     ds = pysidre.DataStore()
     root = ds.getRoot()
 
@@ -73,7 +74,7 @@ def create_datastore(region):
     return ds
 
 
-def access_datastore(ds):
+def access_datastore(ds: pysidre.DataStore) -> pysidre.DataStore:
     # Retrieve Group pointers
     root = ds.getRoot()
     state = root.getGroup("state")
@@ -107,7 +108,7 @@ def access_datastore(ds):
     return ds
 
 
-def iterate_datastore(ds):
+def iterate_datastore(ds: pysidre.DataStore) -> None:
     fill_line = "=" * 80
     print(fill_line)
 

--- a/src/axom/sidre/nanobind_sidre.cpp
+++ b/src/axom/sidre/nanobind_sidre.cpp
@@ -85,9 +85,19 @@ nb::dlpack::dtype typeIDToDtype(DataTypeId id)
  *
  * \note Max dimensions (DMAX) is currently set to 10.
  * \pre data description must have been applied.
+ *
+ * \warning The returned array is a zero-copy view into the View's storage; it
+ *  does not own the data. The array keeps the Python \a View object (and, via
+ *  the View's owner-chain, its Group and DataStore) alive for as long as the
+ *  array is referenced. One sharp edge remains: \c View::reallocate (and
+ *  \c Buffer::reallocate) can move the underlying storage while a live array
+ *  still points at the old allocation, the same hazard as resizing a container
+ *  under a numpy view. Re-acquire the array after any reallocation.
  */
-nb::ndarray<nb::numpy> viewToNumpyArray(View& self)
+nb::ndarray<nb::numpy> viewToNumpyArray(nb::handle_t<View> h)
 {
+  View& self = nb::cast<View&>(h);
+
   // Manually applying offset
   void* data = self.getVoidPtr();
   char* data_with_offset = static_cast<char*>(data) + (self.getOffset() * self.getBytesPerElement());
@@ -103,13 +113,6 @@ nb::ndarray<nb::numpy> viewToNumpyArray(View& self)
     shape[i] = static_cast<size_t>(shapeOutput[i]);
   }
 
-  // TODO This is tricky and difficult to understand
-  // Delete 'data' when the 'owner' capsule expires
-  // nb::capsule owner(data, [](void* p) noexcept { delete[] static_cast<char*>(p); });
-
-  // For external memory (numpy owns it), no deletion takes place
-  nb::capsule owner(data, [](void*) noexcept { });
-
   // When stride is not default of 1, guaranteed that shape is 1D.
   int64_t* strides = nullptr;
   int64_t stride_array[1];
@@ -121,11 +124,15 @@ nb::ndarray<nb::numpy> viewToNumpyArray(View& self)
 
   DataTypeId id = self.getTypeID();
 
+  // Pass the Python 'self' object as the array owner: nanobind ties the
+  // array's lifetime to it, so the View (and its DataStore) cannot be freed
+  // while the array is alive. This resolves the prior no-op owner capsule that
+  // left the array dangling once the View was collected.
   return nb::ndarray<nb::numpy>(
     /* data = */ data,
     /* ndim = */ ndims,
     /* shape = */ shape,
-    /* owner = */ owner,
+    /* owner = */ h,
     /* strides = */ strides,
     /* dtype = */ typeIDToDtype(id));
 }
@@ -134,27 +141,29 @@ nb::ndarray<nb::numpy> viewToNumpyArray(View& self)
  * \brief Returns a Buffer as a numpy array.
  *
  * \pre data description must have been applied.
+ *
+ * \warning The returned array is a zero-copy view into the Buffer's storage; it
+ *  does not own the data. The array keeps the Python \a Buffer object (and its
+ *  owning DataStore) alive for as long as the array is referenced. As with
+ *  \c viewToNumpyArray, \c Buffer::reallocate can move storage under a live
+ *  array; re-acquire the array after any reallocation.
  */
-nb::ndarray<nb::numpy> bufferToNumpyArray(Buffer& self)
+nb::ndarray<nb::numpy> bufferToNumpyArray(nb::handle_t<Buffer> h)
 {
+  Buffer& self = nb::cast<Buffer&>(h);
+
   void* data = self.getVoidPtr();
 
   size_t shape[1] = {static_cast<size_t>(self.getNumElements())};
 
-  // TODO This is tricky and difficult to understand
-  // Delete 'data' when the 'owner' capsule expires
-  // nb::capsule owner(data, [](void* p) noexcept { delete[] static_cast<char*>(p); });
-
-  // For external memory (numpy owns it), no deletion takes place
-  nb::capsule owner(data, [](void*) noexcept { });
-
   DataTypeId id = self.getTypeID();
 
+  // Pass the Python 'self' object as the array owner (see viewToNumpyArray).
   return nb::ndarray<nb::numpy>(
     /* data = */ data,
     /* ndim = */ 1,
     /* shape = */ shape,
-    /* owner = */ owner,
+    /* owner = */ h,
     /* strides = */ nullptr,
     /* dtype = */ typeIDToDtype(id));
 }
@@ -182,7 +191,13 @@ void bindIterator(nb::module_& m, const char* iterator_name)
           nb::type<IteratorType>(),
           iterator_name,
           self.begin(),
-          self.end());
+          self.end(),
+          // Pin each yielded element to the iterator (applies to __next__).
+          // The iterator is in turn pinned to the collection by the
+          // keep_alive on __iter__ below, and the collection accessor
+          // (e.g. Group::views()) is reference_internal, so a harvested
+          // element transitively keeps its DataStore alive.
+          nb::keep_alive<0, 1>());
       },
       nb::keep_alive<0, 1>());
 }
@@ -304,7 +319,7 @@ NB_MODULE(pysidre, m_sidre)
     .def(nb::init<>())
     .def("getRoot",
          nb::overload_cast<>(&DataStore::getRoot),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Return pointer to the root Group")
     .def("getNumBuffers", &DataStore::getNumBuffers, "Return number of Buffers in the DataStore")
     .def("hasBuffer",
@@ -312,16 +327,16 @@ NB_MODULE(pysidre, m_sidre)
          "Return true if DataStore owns a Buffer with given index; else false")
     .def("getBuffer",
          &DataStore::getBuffer,
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Return pointer to Buffer object with the given index")
 
     .def("createBuffer",
          nb::overload_cast<>(&DataStore::createBuffer),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create an undescribed Buffer object")
     .def("createBuffer",
          nb::overload_cast<TypeID, IndexType>(&DataStore::createBuffer),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create a Buffer object with specified type and number of elements")
     .def("destroyBuffer",
          nb::overload_cast<Buffer*>(&DataStore::destroyBuffer),
@@ -345,7 +360,7 @@ NB_MODULE(pysidre, m_sidre)
          "Generate a Conduit Blueprint index based on a mesh in stored in this DataStore.")
     .def("buffers",
          nb::overload_cast<>(&DataStore::buffers),
-         nb::rv_policy::reference,
+         nb::keep_alive<0, 1>(),
          "Return an iterator over Buffers")
 
     .def("getNumAttributes",
@@ -353,19 +368,19 @@ NB_MODULE(pysidre, m_sidre)
          "Return number of Attributes in the DataStore")
     .def("createAttributeScalar",
          &DataStore::createAttributeScalar<int>,
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create an Attribute object with a default int scalar value",
          nb::arg("name"),
          nb::arg("default_value").noconvert())
     .def("createAttributeScalar",
          &DataStore::createAttributeScalar<double>,
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create an Attribute object with a default float (C++ double) scalar value",
          nb::arg("name"),
          nb::arg("default_value").noconvert())
     .def("createAttributeString",
          &DataStore::createAttributeString,
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create an Attribute object with a default string value")
     .def("hasAttribute",
          nb::overload_cast<const std::string&>(&DataStore::hasAttribute, nb::const_),
@@ -387,11 +402,11 @@ NB_MODULE(pysidre, m_sidre)
          "Remove all Attributes from the DataStore and destroy them and their data")
     .def("getAttribute",
          nb::overload_cast<IndexType>(&DataStore::getAttribute),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Return pointer to non-const Attribute with given index")
     .def("getAttribute",
          nb::overload_cast<const std::string&>(&DataStore::getAttribute),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Return pointer to non-const Attribute with given name")
 
     // Requires conduit::Node information
@@ -412,7 +427,7 @@ NB_MODULE(pysidre, m_sidre)
          "(i.e., smallest index over all Attribute indices larger than given one)")
     .def("attributes",
          nb::overload_cast<>(&DataStore::attributes),
-         nb::rv_policy::reference,
+         nb::keep_alive<0, 1>(),
          "Return an iterator over Attributes")
 
     // Nanobind fails compilation on blueos
@@ -479,12 +494,12 @@ NB_MODULE(pysidre, m_sidre)
          "Return the full path of the View object, including its name.")
     .def("getOwningGroup",
          nb::overload_cast<>(&View::getOwningGroup),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Return the owning Group of the View.")
     .def("hasBuffer", &View::hasBuffer, "Check if the View has an associated Buffer object.")
     .def("getBuffer",
          nb::overload_cast<>(&View::getBuffer),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Return the associated Buffer object (non-const).")
     .def("isExternal", &View::isExternal, "Check if the View holds external data.")
     .def("isAllocated", &View::isAllocated, "Check if the View's data is allocated.")
@@ -666,11 +681,11 @@ NB_MODULE(pysidre, m_sidre)
     // Attribute accessors
     .def("getAttribute",
          nb::overload_cast<IndexType>(&View::getAttribute),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Get Attribute by index")
     .def("getAttribute",
          nb::overload_cast<const std::string&>(&View::getAttribute),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Get Attribute by name")
 
     .def("hasAttributeValue",
@@ -836,13 +851,13 @@ NB_MODULE(pysidre, m_sidre)
     .def("getPathName", &Group::getPathName, "Return full path of Group object, including its name.")
     .def("getParent",
          nb::overload_cast<>(&Group::getParent, nb::const_),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Return pointer to non-const parent Group of a Group.")
     .def("getNumGroups", &Group::getNumGroups, "Return number of child Groups in a Group object.")
     .def("getNumViews", &Group::getNumViews, "Return number of Views owned by a Group object.")
     .def("getDataStore",
          nb::overload_cast<>(&Group::getDataStore, nb::const_),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Return pointer to non-const DataStore object that owns this object.")
 
     .def("hasView",
@@ -863,11 +878,11 @@ NB_MODULE(pysidre, m_sidre)
 
     .def("getView",
          nb::overload_cast<const std::string&>(&Group::getView, nb::const_),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Return pointer to const View with given name or path.")
     .def("getView",
          nb::overload_cast<IndexType>(&Group::getView, nb::const_),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Return pointer to non-const View with given index.")
     .def("getFirstValidViewIndex",
          &Group::getFirstValidViewIndex,
@@ -878,11 +893,11 @@ NB_MODULE(pysidre, m_sidre)
 
     .def("createView",
          nb::overload_cast<const std::string&>(&Group::createView),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create an undescribed (i.e., empty) View object with given name or path in this Group.")
     .def("createView",
          nb::overload_cast<const std::string&, TypeID, IndexType>(&Group::createView),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create View object with given name or path in this Group that has a data description "
          "with data type and number of elements.")
     .def(
@@ -890,17 +905,17 @@ NB_MODULE(pysidre, m_sidre)
       [](Group& self, const std::string& path, TypeID type, int ndims, const nb::ndarray<IndexType>& shape) {
         return self.createViewWithShape(path, type, ndims, shape.data());
       },
-      nb::rv_policy::reference,
+      nb::rv_policy::reference_internal,
       "Create View object with given name or path in this Group that has a data description "
       "with data type and shape.")
     .def("createView",
          nb::overload_cast<const std::string&, Buffer*>(&Group::createView),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create an undescribed View object with given name or path in this Group and attach given "
          "Buffer to it.")
     .def("createView",
          nb::overload_cast<const std::string&, TypeID, IndexType, Buffer*>(&Group::createView),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create View object with given name or path in this Group that has a data description "
          "with data type and number of elements and attach given Buffer to it.")
     .def(
@@ -913,7 +928,7 @@ NB_MODULE(pysidre, m_sidre)
          Buffer* buffer) {
         return self.createViewWithShape(path, type, ndims, shape.data(), buffer);
       },
-      nb::rv_policy::reference,
+      nb::rv_policy::reference_internal,
       "Create View object with given name or path in this Group that has a data description "
       "with data type and shape and attach given Buffer to it.")
 
@@ -922,14 +937,14 @@ NB_MODULE(pysidre, m_sidre)
       [](Group& self, const std::string& path, const nb::ndarray<>& a) {
         return self.createView(path, a.data());
       },
-      nb::rv_policy::reference)
+      nb::rv_policy::reference_internal)
 
     .def(
       "createView",
       [](Group& self, const std::string& path, TypeID id, IndexType num_elems, const nb::ndarray<>& a) {
         return self.createView(path, id, num_elems, a.data());
       },
-      nb::rv_policy::reference,
+      nb::rv_policy::reference_internal,
       "Create View object with given name or path in this Group that has a data description "
       "with data type and number of elements and attach externally-owned data to it.")
 
@@ -943,12 +958,12 @@ NB_MODULE(pysidre, m_sidre)
          const nb::ndarray<>& external_ptr) {
         return self.createViewWithShape(path, type, ndims, shape.data(), external_ptr.data());
       },
-      nb::rv_policy::reference,
+      nb::rv_policy::reference_internal,
       "Create View object with given name or path in this Group that has a data description "
       "with data type and shape and attach externally-owned data (numpy array) to it.")
     .def("createViewAndAllocate",
          nb::overload_cast<const std::string&, TypeID, IndexType, int>(&Group::createViewAndAllocate),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create View object with given name or path in this Group that has a data description "
          "with data type and number of elements and allocate data for it.",
          nb::arg("path"),
@@ -960,13 +975,13 @@ NB_MODULE(pysidre, m_sidre)
       [](Group& self, const std::string& path, TypeID type, int ndims, const std::vector<IndexType>& shape) {
         return self.createViewWithShapeAndAllocate(path, type, ndims, shape.data());
       },
-      nb::rv_policy::reference,
+      nb::rv_policy::reference_internal,
       "Create View object with given name or path in this Group that has a data description "
       "with data type and shape and allocate data for it.")
 
     .def("createViewScalar",
          &Group::createViewScalar<int>,
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create View object with given name or path in this Group set its data to given scalar "
          "value (int).",
          nb::arg("path"),
@@ -974,7 +989,7 @@ NB_MODULE(pysidre, m_sidre)
          nb::arg("allocID") = INVALID_ALLOCATOR_ID)
     .def("createViewScalar",
          &Group::createViewScalar<double>,
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create View object with given name or path in this Group set its data to given scalar "
          "value (C++ double, python float).",
          nb::arg("path"),
@@ -982,7 +997,7 @@ NB_MODULE(pysidre, m_sidre)
          nb::arg("allocID") = INVALID_ALLOCATOR_ID)
     .def("createViewString",
          &Group::createViewString,
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create View object with given name or path in this Group set its data to given string.",
          nb::arg("path"),
          nb::arg("value").noconvert(),
@@ -1005,11 +1020,11 @@ NB_MODULE(pysidre, m_sidre)
 
     .def("moveView",
          &Group::moveView,
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Remove given View object from its owning Group and move it to this Group.")
     .def("copyView",
          &Group::copyView,
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create a (shallow) copy of given View object and add it to this Group.")
 
     .def("hasGroup",
@@ -1029,19 +1044,19 @@ NB_MODULE(pysidre, m_sidre)
          "Return the name of immediate child Group with given index.")
     .def("getGroup",
          nb::overload_cast<const std::string&>(&Group::getGroup),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Return pointer to non-const child Group with given name or path.")
     .def("getGroup",
          nb::overload_cast<IndexType>(&Group::getGroup),
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Return pointer to non-const immediate child Group with given index.")
     .def("views",
          nb::overload_cast<>(&Group::views),
-         nb::rv_policy::reference,
+         nb::keep_alive<0, 1>(),
          "Return an iterator over Views")
     .def("groups",
          nb::overload_cast<>(&Group::groups),
-         nb::rv_policy::reference,
+         nb::keep_alive<0, 1>(),
          "Return an iterator over Groups")
     .def("getFirstValidGroupIndex",
          &Group::getFirstValidGroupIndex,
@@ -1051,14 +1066,14 @@ NB_MODULE(pysidre, m_sidre)
          "Return next valid child Group index after given index.")
     .def("createGroup",
          &Group::createGroup,
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create a child Group within this Group with given name or path.",
          nb::arg("path"),
          nb::arg("is_list") = false,
          nb::arg("accept_existing") = false)
     .def("createUnnamedGroup",
          &Group::createUnnamedGroup,
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create a child Group within this Group with no name.",
          nb::arg("is_list") = false)
     .def("destroyGroup",
@@ -1089,12 +1104,12 @@ NB_MODULE(pysidre, m_sidre)
          "Remove given Group object from its parent Group and make it a child of this Group.")
     .def("copyGroup",
          &Group::copyGroup,
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create a (shallow) copy of Group hierarchy rooted at given "
          "Group and make the copy a child of this Group.")
     .def("deepCopyGroup",
          &Group::deepCopyGroup,
-         nb::rv_policy::reference,
+         nb::rv_policy::reference_internal,
          "Create a deep copy of Group hierarchy rooted at given Group and "
          "make the copy a child of this Group.",
          nb::arg("srcGroup"),

--- a/src/axom/sidre/nanobind_sidre.cpp
+++ b/src/axom/sidre/nanobind_sidre.cpp
@@ -1363,6 +1363,7 @@ NB_MODULE(pysidre, m_sidre)
       "Destroy all child Groups in this Group.")
     .def("moveGroup",
          &Group::moveGroup,
+         nb::rv_policy::reference_internal,
          "Remove given Group object from its parent Group and make it a child of this Group.")
     .def("copyGroup",
          &Group::copyGroup,

--- a/src/axom/sidre/nanobind_sidre.cpp
+++ b/src/axom/sidre/nanobind_sidre.cpp
@@ -290,6 +290,8 @@ void pinExternalDataOwner(View* view, const nb::ndarray<Args...>& owner)
 {
   if(view != nullptr)
   {
+    // Note: Map assignment automatically releases the previous ndarray wrapper if present.
+    // When nb::ndarray<> is destroyed, nanobind decrements the underlying Python object's refcount
     externalDataOwnerRegistry()[view] = nb::ndarray<>(owner);
   }
 }
@@ -325,6 +327,72 @@ void releaseExternalDataOwnersOfViews(Group& group)
   for(auto& v : group.views())
   {
     releaseExternalDataOwner(&v);
+  }
+}
+
+/*!
+ * \brief Copy external data pin from source View to destination View.
+ *
+ * When copyView() creates a shallow copy that shares external data, the new View
+ * needs its own pin to prevent the numpy array from being garbage collected.
+ * This function looks up the source View's pin and copies it to the destination.
+ *
+ * \param src_view Source View (must have an external data pin)
+ * \param dst_view Destination View (will receive a copy of the pin)
+ */
+void copyExternalDataOwner(const View* src_view, View* dst_view)
+{
+  if(src_view == nullptr || dst_view == nullptr)
+  {
+    return;
+  }
+
+  auto& registry = externalDataOwnerRegistry();
+  auto it = registry.find(const_cast<View*>(src_view));
+  if(it != registry.end())
+  {
+    // Copy the ndarray handle to the new View, incrementing its refcount
+    registry[dst_view] = it->second;
+  }
+}
+
+/*!
+ * \brief Recursively copy external data pins from source Group hierarchy to destination.
+ *
+ * When copyGroup() creates a shallow copy of a Group hierarchy, all Views with
+ * external data in the source hierarchy need their pins copied to the destination.
+ *
+ * \param src_group Source Group (root of hierarchy to copy from)
+ * \param dst_group Destination Group (root of copied hierarchy)
+ */
+void copyExternalDataOwners(const Group* src_group, Group* dst_group)
+{
+  if(src_group == nullptr || dst_group == nullptr)
+  {
+    return;
+  }
+
+  // Copy pins for all Views in this Group
+  for(auto& src_view : src_group->views())
+  {
+    if(src_view.isExternal())
+    {
+      View* dst_view = dst_group->getView(src_view.getName());
+      if(dst_view != nullptr)
+      {
+        copyExternalDataOwner(&src_view, dst_view);
+      }
+    }
+  }
+
+  // Recursively copy pins for all child Groups
+  for(auto& src_child : src_group->groups())
+  {
+    Group* dst_child = dst_group->getGroup(src_child.getName());
+    if(dst_child != nullptr)
+    {
+      copyExternalDataOwners(&src_child, dst_child);
+    }
   }
 }
 
@@ -431,7 +499,34 @@ private:
 
 NB_MODULE(pysidre, m_sidre)
 {
-  m_sidre.doc() = "A python extension for Axom's Sidre component";
+  m_sidre.doc() = R"pbdoc(
+    A python extension for Axom's Sidre component.
+
+    **Thread Safety:**
+    This module relies on Python's Global Interpreter Lock (GIL) for thread safety.
+
+    - **Python threads:** Safe. The GIL serializes all operations.
+    - **C++ threads:** Unsafe. Calling Sidre methods from C++ threads without acquiring
+      the GIL will cause data races and undefined behavior.
+    - **GIL release:** The bindings do not release the GIL during operations, so Python
+      threads are always serialized. If future changes add `nb::call_guard<nb::gil_scoped_release>`,
+      explicit synchronization (e.g., mutexes) must be added to the external data registry.
+
+    **External Data Lifetime:**
+    Views can reference external numpy arrays via setExternalData() or createView().
+    The binding automatically pins these arrays to prevent garbage collection while
+    the View exists. Pins are released when:
+    - View.clear() is called
+    - The View is destroyed via destroyView() or destroyViewAndData()
+    - The owning Group hierarchy is destroyed via destroyGroup*() methods
+
+    **Reallocation Hazards:**
+    Arrays obtained via getDataArray() are zero-copy views into Sidre storage.
+    View::reallocate() or Buffer::reallocate() can move the underlying storage,
+    leaving existing numpy arrays pointing to freed memory. Always re-acquire
+    arrays after any reallocation. The binding cannot prevent this hazard without
+    breaking zero-copy semantics.
+  )pbdoc";
 
   // Module version mirrors the Axom release
   m_sidre.attr("__version__") = AXOM_VERSION_FULL;
@@ -1221,6 +1316,13 @@ NB_MODULE(pysidre, m_sidre)
       },
       "Destroy View with given name or path owned by this Group, but leave its data intact.")
     .def(
+      "destroyView",
+      [](Group& self, IndexType idx) {
+        releaseExternalDataOwner(self.getView(idx));
+        self.destroyView(idx);
+      },
+      "Destroy View with given index owned by this Group, but leave its data intact.")
+    .def(
       "destroyViewAndData",
       [](Group& self, const std::string& path) {
         releaseExternalDataOwner(self.getView(path));
@@ -1248,10 +1350,20 @@ NB_MODULE(pysidre, m_sidre)
          &Group::moveView,
          nb::rv_policy::reference_internal,
          "Remove given View object from its owning Group and move it to this Group.")
-    .def("copyView",
-         &Group::copyView,
-         nb::rv_policy::reference_internal,
-         "Create a (shallow) copy of given View object and add it to this Group.")
+    .def(
+      "copyView",
+      [](Group& self, View* view) {
+        View* copy = self.copyView(view);
+        if(copy != nullptr && view != nullptr && view->isExternal())
+        {
+          // Shallow copy shares external data pointer - copy the pin to prevent
+          // the numpy array from being garbage collected
+          copyExternalDataOwner(view, copy);
+        }
+        return copy;
+      },
+      nb::rv_policy::reference_internal,
+      "Create a (shallow) copy of given View object and add it to this Group.")
 
     .def("hasGroup",
          nb::overload_cast<const std::string&>(&Group::hasGroup, nb::const_),
@@ -1365,11 +1477,20 @@ NB_MODULE(pysidre, m_sidre)
          &Group::moveGroup,
          nb::rv_policy::reference_internal,
          "Remove given Group object from its parent Group and make it a child of this Group.")
-    .def("copyGroup",
-         &Group::copyGroup,
-         nb::rv_policy::reference_internal,
-         "Create a (shallow) copy of Group hierarchy rooted at given "
-         "Group and make the copy a child of this Group.")
+    .def(
+      "copyGroup",
+      [](Group& self, Group* group) {
+        Group* copy = self.copyGroup(group);
+        if(copy != nullptr && group != nullptr)
+        {
+          // Shallow copy shares external data pointers - recursively copy all pins
+          copyExternalDataOwners(group, copy);
+        }
+        return copy;
+      },
+      nb::rv_policy::reference_internal,
+      "Create a (shallow) copy of Group hierarchy rooted at given "
+      "Group and make the copy a child of this Group.")
     .def("deepCopyGroup",
          &Group::deepCopyGroup,
          nb::rv_policy::reference_internal,

--- a/src/axom/sidre/nanobind_sidre.cpp
+++ b/src/axom/sidre/nanobind_sidre.cpp
@@ -1154,6 +1154,9 @@ NB_MODULE(pysidre, m_sidre)
     .def("loadExternalData",
          nb::overload_cast<const std::string&>(&Group::loadExternalData),
          "Load data into the Group's external views from a file.")
+    .def_static("getDefaultIOProtocol",
+                &Group::getDefaultIOProtocol,
+                "Return the default I/O protocol for this Axom build.")
     .def("rename", &Group::rename, "Change the name of this Group.");
 
   // Bindings for the Attribute class
@@ -1188,6 +1191,25 @@ NB_MODULE(pysidre, m_sidre)
     .def(
       "__init__",
       [](IOManager* self, bool use_scr) { new(self) IOManager(MPI_COMM_WORLD, use_scr); },
+      "Create an IOManager on MPI_COMM_WORLD.",
+      nb::arg("use_scr") = false)
+    .def(
+      "__init__",
+      [](IOManager* self, nb::object comm, bool use_scr) {
+        // Accept an mpi4py communicator without depending on mpi4py's C headers.
+        // mpi4py Comm objects expose py2f(), which returns the Fortran integer handle.
+        // MPI_Comm_f2c converts that handle back to an MPI_Comm.
+        // Passing None uses MPI_COMM_WORLD, while no-argument calls are handled by the bool/use_scr overload above.
+        MPI_Comm c = MPI_COMM_WORLD;
+        if(!comm.is_none())
+        {
+          MPI_Fint handle = nb::cast<MPI_Fint>(comm.attr("py2f")());
+          c = MPI_Comm_f2c(handle);
+        }
+        new(self) IOManager(c, use_scr);
+      },
+      "Create an IOManager on an mpi4py communicator, or MPI_COMM_WORLD when comm is None.",
+      nb::arg("comm"),
       nb::arg("use_scr") = false)
     .def("write",
          &IOManager::write,

--- a/src/axom/sidre/nanobind_sidre.cpp
+++ b/src/axom/sidre/nanobind_sidre.cpp
@@ -11,6 +11,7 @@
 #include <nanobind/make_iterator.h>
 
 #include <memory>
+#include <unordered_map>
 
 #include "axom/config.hpp"
 #include "axom/core/Types.hpp"
@@ -256,6 +257,109 @@ conduit::Node& nbObjectToNode(nb::object& o)
   SLIC_ERROR_IF(!cpp_node, "Failed to get underlying conduit::Node pointer");
 
   return *cpp_node;
+}
+
+/*!
+ * \brief Binding-side owner pinning for external NumPy-backed Sidre views.
+ *
+ * Sidre external views (View::setExternalDataPtr / Group::createView(..., void*))
+ * borrow a raw pointer and do not own the storage. In Python, it is common to
+ * pass a temporary NumPy array (e.g. createView("x", np.arange(...))) and then
+ * drop it immediately, which can leave Sidre holding a dangling pointer once
+ * the ndarray is garbage collected.
+ *
+ * To keep Sidre's C++ semantics unchanged while making the Python API safe, 
+ * we maintain a binding-only registry that maps a C++ View* to a copied
+ * nanobind::ndarray wrapper. Copying nb::ndarray increments the underlying
+ * ndarray owner's refcount via nanobind's internal handle, so the NumPy storage
+ * remains alive as long as the View exists.
+ *
+ * Pins are released when the external pointer is cleared (e.g. View.clear(),
+ * setExternalData(None)) and when views/groups are destroyed via the bound Group::destroy* APIs.
+ */
+std::unordered_map<View*, nb::ndarray<>>& externalDataOwnerRegistry()
+{
+  // Intentionally heap-allocated so Python-owned references are not destroyed
+  // after interpreter finalization during static shutdown.
+  static auto* registry = new std::unordered_map<View*, nb::ndarray<>>();
+  return *registry;
+}
+
+template <typename... Args>
+void pinExternalDataOwner(View* view, const nb::ndarray<Args...>& owner)
+{
+  if(view != nullptr)
+  {
+    externalDataOwnerRegistry()[view] = nb::ndarray<>(owner);
+  }
+}
+
+void releaseExternalDataOwner(View* view)
+{
+  if(view != nullptr)
+  {
+    externalDataOwnerRegistry().erase(view);
+  }
+}
+
+void releaseExternalDataOwners(Group* group)
+{
+  if(group == nullptr)
+  {
+    return;
+  }
+
+  for(auto& v : group->views())
+  {
+    releaseExternalDataOwner(&v);
+  }
+
+  for(auto& g : group->groups())
+  {
+    releaseExternalDataOwners(&g);
+  }
+}
+
+void releaseExternalDataOwnersOfViews(Group& group)
+{
+  for(auto& v : group.views())
+  {
+    releaseExternalDataOwner(&v);
+  }
+}
+
+View* setExternalDataAndPinOwner(View& view, const nb::ndarray<>& owner)
+{
+  View* result = view.setExternalDataPtr(owner.data());
+  if(result != nullptr && result->isExternal())
+  {
+    pinExternalDataOwner(result, owner);
+  }
+  return result;
+}
+
+View* setExternalDataAndPinOwner(View& view, TypeID type, IndexType num_elems, const nb::ndarray<>& owner)
+{
+  View* result = view.setExternalDataPtr(type, num_elems, owner.data());
+  if(result != nullptr && result->isExternal())
+  {
+    pinExternalDataOwner(result, owner);
+  }
+  return result;
+}
+
+View* setExternalDataAndPinOwner(View& view,
+                                 TypeID type,
+                                 int ndims,
+                                 const nb::ndarray<IndexType>& shape,
+                                 const nb::ndarray<>& owner)
+{
+  View* result = view.setExternalDataPtr(type, ndims, shape.data(), owner.data());
+  if(result != nullptr && result->isExternal())
+  {
+    pinExternalDataOwner(result, owner);
+  }
+  return result;
 }
 
 #if defined(AXOM_USE_MPI)
@@ -671,7 +775,13 @@ NB_MODULE(pysidre, m_sidre)
          nb::arg("shape"),
          nb::arg("buffer").none())
 
-    .def("clear", &View::clear, "Clear data and metadata from the View.")
+    .def(
+      "clear",
+      [](View& self) {
+        self.clear();
+        releaseExternalDataOwner(&self);
+      },
+      "Clear data and metadata from the View.")
     .def("apply", nb::overload_cast<>(&View::apply), "Apply the View's description to its data.")
     .def("apply",
          nb::overload_cast<IndexType, IndexType, IndexType>(&View::apply),
@@ -717,9 +827,12 @@ NB_MODULE(pysidre, m_sidre)
       [](View& self, nb::object external_ptr) {
         if(external_ptr.is_none())
         {
-          return self.setExternalDataPtr(nullptr);
+          View* result = self.setExternalDataPtr(nullptr);
+          releaseExternalDataOwner(&self);
+          return result;
         }
-        return self.setExternalDataPtr(nb::cast<nb::ndarray<>>(external_ptr).data());
+        nb::ndarray<> owner = nb::cast<nb::ndarray<>>(external_ptr);
+        return setExternalDataAndPinOwner(self, owner);
       },
       nb::rv_policy::reference,
       "Set the View to hold undescribed external data (numpy array).",
@@ -727,14 +840,14 @@ NB_MODULE(pysidre, m_sidre)
     .def(
       "setExternalData",
       [](View& self, const nb::ndarray<>& external_ptr) {
-        return self.setExternalDataPtr(external_ptr.data());
+        return setExternalDataAndPinOwner(self, external_ptr);
       },
       nb::rv_policy::reference,
       "Set the View to hold undescribed external data (numpy array).")
     .def(
       "setExternalData",
       [](View& self, TypeID type, IndexType num_elems, const nb::ndarray<>& external_ptr) {
-        return self.setExternalDataPtr(type, num_elems, external_ptr.data());
+        return setExternalDataAndPinOwner(self, type, num_elems, external_ptr);
       },
       nb::rv_policy::reference,
       "Set the View to hold described external data  (numpy array).")
@@ -745,7 +858,7 @@ NB_MODULE(pysidre, m_sidre)
          int ndims,
          const nb::ndarray<IndexType>& shape,
          const nb::ndarray<>& external_ptr) {
-        return self.setExternalDataPtr(type, ndims, shape.data(), external_ptr.data());
+        return setExternalDataAndPinOwner(self, type, ndims, shape, external_ptr);
       },
       nb::rv_policy::reference,
       "Set the View to hold described external data (numpy array).")
@@ -1026,14 +1139,18 @@ NB_MODULE(pysidre, m_sidre)
     .def(
       "createView",
       [](Group& self, const std::string& path, const nb::ndarray<>& a) {
-        return self.createView(path, a.data());
+        View* view = self.createView(path, a.data());
+        pinExternalDataOwner(view, a);
+        return view;
       },
       nb::rv_policy::reference_internal)
 
     .def(
       "createView",
       [](Group& self, const std::string& path, TypeID id, IndexType num_elems, const nb::ndarray<>& a) {
-        return self.createView(path, id, num_elems, a.data());
+        View* view = self.createView(path, id, num_elems, a.data());
+        pinExternalDataOwner(view, a);
+        return view;
       },
       nb::rv_policy::reference_internal,
       "Create View object with given name or path in this Group that has a data description "
@@ -1047,7 +1164,9 @@ NB_MODULE(pysidre, m_sidre)
          int ndims,
          const nb::ndarray<IndexType>& shape,
          const nb::ndarray<>& external_ptr) {
-        return self.createViewWithShape(path, type, ndims, shape.data(), external_ptr.data());
+        View* view = self.createViewWithShape(path, type, ndims, shape.data(), external_ptr.data());
+        pinExternalDataOwner(view, external_ptr);
+        return view;
       },
       nb::rv_policy::reference_internal,
       "Create View object with given name or path in this Group that has a data description "
@@ -1094,20 +1213,36 @@ NB_MODULE(pysidre, m_sidre)
          nb::arg("value").noconvert(),
          nb::arg("allocID") = INVALID_ALLOCATOR_ID)
 
-    .def("destroyView",
-         nb::overload_cast<const std::string&>(&Group::destroyView),
-         "Destroy View with given name or path owned by this Group, but leave its data intact.")
-    .def("destroyViewAndData",
-         nb::overload_cast<const std::string&>(&Group::destroyViewAndData),
-         "Destroy View with given name or path owned by this Group and deallocate")
-    .def("destroyViewAndData",
-         nb::overload_cast<IndexType>(&Group::destroyViewAndData),
-         "Destroy View with given index owned by this Group and deallocate its data if it's the "
-         "only View associated with that data.")
-    .def("destroyViewsAndData",
-         &Group::destroyViewsAndData,
-         "Destroy all Views owned by this Group and deallocate "
-         "data for each View when it's the only View associated with that data.")
+    .def(
+      "destroyView",
+      [](Group& self, const std::string& path) {
+        releaseExternalDataOwner(self.getView(path));
+        self.destroyView(path);
+      },
+      "Destroy View with given name or path owned by this Group, but leave its data intact.")
+    .def(
+      "destroyViewAndData",
+      [](Group& self, const std::string& path) {
+        releaseExternalDataOwner(self.getView(path));
+        self.destroyViewAndData(path);
+      },
+      "Destroy View with given name or path owned by this Group and deallocate")
+    .def(
+      "destroyViewAndData",
+      [](Group& self, IndexType idx) {
+        releaseExternalDataOwner(self.getView(idx));
+        self.destroyViewAndData(idx);
+      },
+      "Destroy View with given index owned by this Group and deallocate its data if it's the "
+      "only View associated with that data.")
+    .def(
+      "destroyViewsAndData",
+      [](Group& self) {
+        releaseExternalDataOwnersOfViews(self);
+        self.destroyViewsAndData();
+      },
+      "Destroy all Views owned by this Group and deallocate "
+      "data for each View when it's the only View associated with that data.")
 
     .def("moveView",
          &Group::moveView,
@@ -1167,29 +1302,65 @@ NB_MODULE(pysidre, m_sidre)
          nb::rv_policy::reference_internal,
          "Create a child Group within this Group with no name.",
          nb::arg("is_list") = false)
-    .def("destroyGroup",
-         nb::overload_cast<const std::string&>(&Group::destroyGroup),
-         "Destroy child Group in this Group with given name or path.")
-    .def("destroyGroup",
-         nb::overload_cast<IndexType>(&Group::destroyGroup),
-         "Destroy child Group within this Group with given index.")
-    .def("destroyGroupAndData",
-         nb::overload_cast<const std::string&>(&Group::destroyGroupAndData),
-         "Destroy child Group at the given path, and destroy data that is "
-         "not shared elsewhere.")
-    .def("destroyGroupAndData",
-         nb::overload_cast<IndexType>(&Group::destroyGroupAndData),
-         "Destroy child Group with the given index, and destroy data that "
-         "is not shared elsewhere.")
-    .def("destroyGroupsAndData",
-         &Group::destroyGroupsAndData,
-         "Destroy all child Groups held by this Group, and destroy data that "
-         "is not shared elsewhere.")
-    .def("destroyGroupSubtreeAndData",
-         &Group::destroyGroupSubtreeAndData,
-         "Destroy the entire subtree of Groups and Views held by this Group, "
-         "and destroy data that is not shared elsewhere.")
-    .def("destroyGroups", &Group::destroyGroups, "Destroy all child Groups in this Group.")
+    .def(
+      "destroyGroup",
+      [](Group& self, const std::string& path) {
+        releaseExternalDataOwners(self.getGroup(path));
+        self.destroyGroup(path);
+      },
+      "Destroy child Group in this Group with given name or path.")
+    .def(
+      "destroyGroup",
+      [](Group& self, IndexType idx) {
+        releaseExternalDataOwners(self.getGroup(idx));
+        self.destroyGroup(idx);
+      },
+      "Destroy child Group within this Group with given index.")
+    .def(
+      "destroyGroupAndData",
+      [](Group& self, const std::string& path) {
+        releaseExternalDataOwners(self.getGroup(path));
+        self.destroyGroupAndData(path);
+      },
+      "Destroy child Group at the given path, and destroy data that is "
+      "not shared elsewhere.")
+    .def(
+      "destroyGroupAndData",
+      [](Group& self, IndexType idx) {
+        releaseExternalDataOwners(self.getGroup(idx));
+        self.destroyGroupAndData(idx);
+      },
+      "Destroy child Group with the given index, and destroy data that "
+      "is not shared elsewhere.")
+    .def(
+      "destroyGroupsAndData",
+      [](Group& self) {
+        for(auto& g : self.groups())
+        {
+          releaseExternalDataOwners(&g);
+        }
+        self.destroyGroupsAndData();
+      },
+      "Destroy all child Groups held by this Group, and destroy data that "
+      "is not shared elsewhere.")
+    .def(
+      "destroyGroupSubtreeAndData",
+      [](Group& self) {
+        releaseExternalDataOwners(&self);
+        self.destroyGroupSubtreeAndData();
+      },
+      "Destroy the entire subtree of Groups and Views held by this Group, "
+      "and destroy data that is not shared elsewhere.")
+    .def(
+      "destroyGroups",
+      [](Group& self) {
+        for(auto& g : self.groups())
+        {
+          releaseExternalDataOwners(&g);
+        }
+        self.destroyGroups();
+      },
+      "Destroy all child Groups in this Group.")
     .def("moveGroup",
          &Group::moveGroup,
          "Remove given Group object from its parent Group and make it a child of this Group.")

--- a/src/axom/sidre/nanobind_sidre.cpp
+++ b/src/axom/sidre/nanobind_sidre.cpp
@@ -10,6 +10,8 @@
 #include <nanobind/ndarray.h>
 #include <nanobind/make_iterator.h>
 
+#include <memory>
+
 #include "axom/config.hpp"
 #include "axom/core/Types.hpp"
 #include "core/SidreTypes.hpp"
@@ -256,6 +258,73 @@ conduit::Node& nbObjectToNode(nb::object& o)
   return *cpp_node;
 }
 
+#if defined(AXOM_USE_MPI)
+MPI_Comm mpiCommFromObject(nb::object comm)
+{
+  MPI_Comm c = MPI_COMM_WORLD;
+  if(!comm.is_none())
+  {
+    MPI_Fint handle = nb::cast<MPI_Fint>(comm.attr("py2f")());
+    c = MPI_Comm_f2c(handle);
+  }
+  return c;
+}
+
+/*!
+ * \brief Python-facing IOManager holder that owns the communicator lifetime.
+ *
+ * sidre::IOManager stores the MPI_Comm passed to its constructor but does not
+ * duplicate or free it. That borrowed-communicator contract works for C++
+ * callers, but it is unsafe for mpi4py objects: py2f() exposes the object's
+ * current communicator handle, and Python code may later drop or explicitly
+ * Free() that object while pysidre.IOManager is still alive.
+ *
+ * PyIOManager keeps the public Python class name as pysidre.IOManager while
+ * giving the binding its own lifetime boundary. It duplicates the input
+ * communicator, constructs sidre::IOManager with that duplicate, destroys the
+ * IOManager first, and then frees the duplicate when MPI is still active.
+ */
+class PyIOManager
+{
+public:
+  PyIOManager(MPI_Comm comm, bool use_scr)
+  {
+    int err = MPI_Comm_dup(comm, &m_comm);
+    SLIC_ERROR_IF(err != MPI_SUCCESS, "Failed to duplicate MPI communicator for pysidre.IOManager");
+    m_manager = std::make_unique<IOManager>(m_comm, use_scr);
+  }
+
+  ~PyIOManager()
+  {
+    // IOManager may still use m_comm during destruction, so release it before
+    // freeing the duplicated communicator.
+    m_manager.reset();
+
+    int initialized = 0;
+    MPI_Initialized(&initialized);
+    if(initialized != 0 && m_comm != MPI_COMM_NULL)
+    {
+      int finalized = 0;
+      MPI_Finalized(&finalized);
+      if(finalized == 0)
+      {
+        MPI_Comm_free(&m_comm);
+      }
+    }
+  }
+
+  PyIOManager(const PyIOManager&) = delete;
+  PyIOManager& operator=(const PyIOManager&) = delete;
+
+  IOManager& manager() { return *m_manager; }
+  const IOManager& manager() const { return *m_manager; }
+
+private:
+  MPI_Comm m_comm {MPI_COMM_NULL};
+  std::unique_ptr<IOManager> m_manager;
+};
+#endif
+
 NB_MODULE(pysidre, m_sidre)
 {
   m_sidre.doc() = "A python extension for Axom's Sidre component";
@@ -448,11 +517,7 @@ NB_MODULE(pysidre, m_sidre)
          const std::string& mesh_name,
          const std::string& index_path) {
         MPI_Comm c = MPI_COMM_WORLD;
-        if(!comm.is_none())
-        {
-          MPI_Fint handle = nb::cast<MPI_Fint>(comm.attr("py2f")());
-          c = MPI_Comm_f2c(handle);
-        }
+        c = mpiCommFromObject(comm);
         return self.generateBlueprintIndex(c, domain_path, mesh_name, index_path);
       },
       "Generate a Conduit Blueprint index from a distributed mesh stored in this "
@@ -1213,70 +1278,97 @@ NB_MODULE(pysidre, m_sidre)
     .def("getTypeID", &Attribute::getTypeID, "Return type of Attribute.");
 
 #if defined(AXOM_USE_MPI)
-  nb::class_<IOManager>(m_sidre, "IOManager")
+  nb::class_<PyIOManager>(m_sidre, "IOManager")
     .def(
       "__init__",
-      [](IOManager* self, bool use_scr) { new(self) IOManager(MPI_COMM_WORLD, use_scr); },
+      [](PyIOManager* self, bool use_scr) { new(self) PyIOManager(MPI_COMM_WORLD, use_scr); },
       "Create an IOManager on MPI_COMM_WORLD.",
       nb::arg("use_scr") = false)
     .def(
       "__init__",
-      [](IOManager* self, nb::object comm, bool use_scr) {
+      [](PyIOManager* self, nb::object comm, bool use_scr) {
         // Accept an mpi4py communicator without depending on mpi4py's C headers.
         // mpi4py Comm objects expose py2f(), which returns the Fortran integer handle.
         // MPI_Comm_f2c converts that handle back to an MPI_Comm.
-        // Passing None uses MPI_COMM_WORLD, while no-argument calls are handled by the bool/use_scr overload above.
-        MPI_Comm c = MPI_COMM_WORLD;
-        if(!comm.is_none())
-        {
-          MPI_Fint handle = nb::cast<MPI_Fint>(comm.attr("py2f")());
-          c = MPI_Comm_f2c(handle);
-        }
-        new(self) IOManager(c, use_scr);
+        // PyIOManager duplicates the communicator, so callers may drop or free
+        // the mpi4py communicator after construction.
+        // Passing None uses MPI_COMM_WORLD, while no-argument calls are
+        // handled by the bool/use_scr overload above.
+        new(self) PyIOManager(mpiCommFromObject(comm), use_scr);
       },
       "Create an IOManager on an mpi4py communicator, or MPI_COMM_WORLD when comm is None.",
       nb::arg("comm"),
       nb::arg("use_scr") = false)
-    .def("write",
-         &IOManager::write,
-         "Write a Group to output files.",
-         nb::arg("group"),
-         nb::arg("num_files"),
-         nb::arg("file_base"),
-         nb::arg("protocol"),
-         nb::arg("tree_pattern") = "datagroup")
-    .def("read",
-         nb::overload_cast<Group*, const std::string&, const std::string&, bool>(&IOManager::read),
-         "Read from input file.",
-         nb::arg("group"),
-         nb::arg("root_file"),
-         nb::arg("protocol"),
-         nb::arg("preserve_contents") = false)
-    .def("read",
-         nb::overload_cast<Group*, const std::string&, bool>(&IOManager::read),
-         "Read from a root file.",
-         nb::arg("group"),
-         nb::arg("root_file"),
-         nb::arg("preserve_contents") = false)
-    .def("loadExternalData",
-         nb::overload_cast<Group*, const std::string&>(&IOManager::loadExternalData),
-         "Load external data into a group.",
-         nb::arg("group"),
-         nb::arg("root_file"))
-    .def("loadExternalData",
-         nb::overload_cast<Group*, Group*, const std::string&>(&IOManager::loadExternalData),
-         "Piecewise load of external data into a group.",
-         nb::arg("parent_group"),
-         nb::arg("load_group"),
-         nb::arg("root_file"))
-    .def("getNumFilesFromRoot",
-         &IOManager::getNumFilesFromRoot,
-         "Gets the number of files in the dataset from the specified root file.",
-         nb::arg("root_file"))
-    .def("getNumGroupsFromRoot",
-         &IOManager::getNumGroupsFromRoot,
-         "Gets the number of groups in the dataset from the specified root file.",
-         nb::arg("root_file"))
+    .def(
+      "write",
+      [](PyIOManager& self,
+         Group* group,
+         int num_files,
+         const std::string& file_base,
+         const std::string& protocol,
+         const std::string& tree_pattern) {
+        self.manager().write(group, num_files, file_base, protocol, tree_pattern);
+      },
+      "Write a Group to output files.",
+      nb::arg("group"),
+      nb::arg("num_files"),
+      nb::arg("file_base"),
+      nb::arg("protocol"),
+      nb::arg("tree_pattern") = "datagroup")
+    .def(
+      "read",
+      [](PyIOManager& self,
+         Group* group,
+         const std::string& root_file,
+         const std::string& protocol,
+         bool preserve_contents) {
+        self.manager().read(group, root_file, protocol, preserve_contents);
+      },
+      "Read from input file.",
+      nb::arg("group"),
+      nb::arg("root_file"),
+      nb::arg("protocol"),
+      nb::arg("preserve_contents") = false)
+    .def(
+      "read",
+      [](PyIOManager& self, Group* group, const std::string& root_file, bool preserve_contents) {
+        self.manager().read(group, root_file, preserve_contents);
+      },
+      "Read from a root file.",
+      nb::arg("group"),
+      nb::arg("root_file"),
+      nb::arg("preserve_contents") = false)
+    .def(
+      "loadExternalData",
+      [](PyIOManager& self, Group* group, const std::string& root_file) {
+        self.manager().loadExternalData(group, root_file);
+      },
+      "Load external data into a group.",
+      nb::arg("group"),
+      nb::arg("root_file"))
+    .def(
+      "loadExternalData",
+      [](PyIOManager& self, Group* parent_group, Group* load_group, const std::string& root_file) {
+        self.manager().loadExternalData(parent_group, load_group, root_file);
+      },
+      "Piecewise load of external data into a group.",
+      nb::arg("parent_group"),
+      nb::arg("load_group"),
+      nb::arg("root_file"))
+    .def(
+      "getNumFilesFromRoot",
+      [](PyIOManager& self, const std::string& root_file) {
+        return self.manager().getNumFilesFromRoot(root_file);
+      },
+      "Gets the number of files in the dataset from the specified root file.",
+      nb::arg("root_file"))
+    .def(
+      "getNumGroupsFromRoot",
+      [](PyIOManager& self, const std::string& root_file) {
+        return self.manager().getNumGroupsFromRoot(root_file);
+      },
+      "Gets the number of groups in the dataset from the specified root file.",
+      nb::arg("root_file"))
     .def_static("correspondingRelayProtocol",
                 &IOManager::correspondingRelayProtocol,
                 "Finds conduit relay protocol corresponding to a sidre protocol.");

--- a/src/axom/sidre/nanobind_sidre.cpp
+++ b/src/axom/sidre/nanobind_sidre.cpp
@@ -281,6 +281,13 @@ NB_MODULE(pysidre, m_sidre)
   m_sidre.attr("AXOM_ENABLE_MPI") = false;
 #endif
 
+#if defined(AXOM_USE_MPI) && \
+  ((NB_VERSION_MAJOR > 2) || (NB_VERSION_MAJOR == 2 && NB_VERSION_MINOR >= 10))
+  m_sidre.attr("AXOM_HAS_DISTRIBUTED_BLUEPRINT_INDEX_BINDING") = true;
+#else
+  m_sidre.attr("AXOM_HAS_DISTRIBUTED_BLUEPRINT_INDEX_BINDING") = false;
+#endif
+
   // Bind the DataTypeId enum (TypeID alias)
   nb::enum_<DataTypeId>(m_sidre, "TypeID")
     .value("NO_TYPE_ID", NO_TYPE_ID)
@@ -430,13 +437,32 @@ NB_MODULE(pysidre, m_sidre)
          nb::keep_alive<0, 1>(),
          "Return an iterator over Attributes")
 
-    // Nanobind fails compilation on blueos
-    // #ifdef AXOM_USE_MPI
-    //     .def("generateBlueprintIndex",
-    //          nb::overload_cast<MPI_Comm, const std::string&, const std::string&, const std::string&>(
-    //            &DataStore::generateBlueprintIndex),
-    //          "Generate a Conduit Blueprint index from a distributed mesh stored in this Datastore")
-    // #endif
+#if defined(AXOM_USE_MPI) && \
+  ((NB_VERSION_MAJOR > 2) || (NB_VERSION_MAJOR == 2 && NB_VERSION_MINOR >= 10))
+    // Distributed Blueprint index generation builds cleanly under nanobind >= 2.10
+    .def(
+      "generateBlueprintIndex",
+      [](DataStore& self,
+         nb::object comm,
+         const std::string& domain_path,
+         const std::string& mesh_name,
+         const std::string& index_path) {
+        MPI_Comm c = MPI_COMM_WORLD;
+        if(!comm.is_none())
+        {
+          MPI_Fint handle = nb::cast<MPI_Fint>(comm.attr("py2f")());
+          c = MPI_Comm_f2c(handle);
+        }
+        return self.generateBlueprintIndex(c, domain_path, mesh_name, index_path);
+      },
+      "Generate a Conduit Blueprint index from a distributed mesh stored in this "
+      "DataStore. Pass None to use MPI_COMM_WORLD.",
+      nb::arg("comm").none(),
+      nb::arg("domain_path"),
+      nb::arg("mesh_name"),
+      nb::arg("index_path"))
+#endif
+
     .def("print",
          nb::overload_cast<>(&DataStore::print, nb::const_),
          "Print JSON description of the DataStore");

--- a/src/axom/sidre/nanobind_sidre.cpp
+++ b/src/axom/sidre/nanobind_sidre.cpp
@@ -110,6 +110,12 @@ nb::ndarray<nb::numpy> viewToNumpyArray(nb::handle_t<View> h)
 
   IndexType shapeOutput[DMAX];
   size_t ndims = self.getShape(DMAX, shapeOutput);
+
+  // Guard against buffer overflow if View has more dimensions than our buffer can hold
+  SLIC_ERROR_IF(ndims > DMAX,
+                "View has " << ndims << " dimensions, exceeds maximum of " << DMAX
+                            << ". Cannot convert to numpy array.");
+
   size_t shape[DMAX];
   for(size_t i = 0; i < ndims; i++)
   {
@@ -268,7 +274,7 @@ conduit::Node& nbObjectToNode(nb::object& o)
  * drop it immediately, which can leave Sidre holding a dangling pointer once
  * the ndarray is garbage collected.
  *
- * To keep Sidre's C++ semantics unchanged while making the Python API safe, 
+ * To keep Sidre's C++ semantics unchanged while making the Python API safe,
  * we maintain a binding-only registry that maps a C++ View* to a copied
  * nanobind::ndarray wrapper. Copying nb::ndarray increments the underlying
  * ndarray owner's refcount via nanobind's internal handle, so the NumPy storage
@@ -276,6 +282,14 @@ conduit::Node& nbObjectToNode(nb::object& o)
  *
  * Pins are released when the external pointer is cleared (e.g. View.clear(),
  * setExternalData(None)) and when views/groups are destroyed via the bound Group::destroy* APIs.
+ *
+ * **Registry Lifetime:** The registry persists for the process lifetime and may accumulate
+ * entries for destroyed Views if those Views are destroyed by the C++ DataStore destructor
+ * rather than through the Python-wrapped destroy methods. This is acceptable because:
+ * (1) Dangling View* keys are never dereferenced (we only erase, never lookup by pointer)
+ * (2) The memory overhead is small (one map entry per external View ever created)
+ * (3) In typical Python usage, Views with external data are explicitly destroyed via
+ *     destroyView()/destroyGroup(), which properly releases pins.
  */
 std::unordered_map<View*, nb::ndarray<>>& externalDataOwnerRegistry()
 {
@@ -1311,6 +1325,7 @@ NB_MODULE(pysidre, m_sidre)
     .def(
       "destroyView",
       [](Group& self, const std::string& path) {
+        // releaseExternalDataOwner is null-safe; destroyView handles invalid paths gracefully
         releaseExternalDataOwner(self.getView(path));
         self.destroyView(path);
       },
@@ -1318,6 +1333,7 @@ NB_MODULE(pysidre, m_sidre)
     .def(
       "destroyView",
       [](Group& self, IndexType idx) {
+        // releaseExternalDataOwner is null-safe; destroyView handles invalid indices gracefully
         releaseExternalDataOwner(self.getView(idx));
         self.destroyView(idx);
       },
@@ -1325,6 +1341,7 @@ NB_MODULE(pysidre, m_sidre)
     .def(
       "destroyViewAndData",
       [](Group& self, const std::string& path) {
+        // releaseExternalDataOwner is null-safe; destroyViewAndData handles invalid paths gracefully
         releaseExternalDataOwner(self.getView(path));
         self.destroyViewAndData(path);
       },
@@ -1417,6 +1434,7 @@ NB_MODULE(pysidre, m_sidre)
     .def(
       "destroyGroup",
       [](Group& self, const std::string& path) {
+        // releaseExternalDataOwners is null-safe; destroyGroup handles invalid paths gracefully
         releaseExternalDataOwners(self.getGroup(path));
         self.destroyGroup(path);
       },
@@ -1424,6 +1442,7 @@ NB_MODULE(pysidre, m_sidre)
     .def(
       "destroyGroup",
       [](Group& self, IndexType idx) {
+        // releaseExternalDataOwners is null-safe; destroyGroup handles invalid indices gracefully
         releaseExternalDataOwners(self.getGroup(idx));
         self.destroyGroup(idx);
       },
@@ -1431,6 +1450,7 @@ NB_MODULE(pysidre, m_sidre)
     .def(
       "destroyGroupAndData",
       [](Group& self, const std::string& path) {
+        // releaseExternalDataOwners is null-safe; destroyGroupAndData handles invalid paths gracefully
         releaseExternalDataOwners(self.getGroup(path));
         self.destroyGroupAndData(path);
       },

--- a/src/axom/sidre/tests/CMakeLists.txt
+++ b/src/axom/sidre/tests/CMakeLists.txt
@@ -127,6 +127,19 @@ if(NANOBIND_FOUND AND AXOM_ENABLE_PYTHON_TESTS)
                               OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                               )
     endforeach()
+
+    if(AXOM_ENABLE_MPI)
+        set(_sidre_spio_py_num_ranks 4)
+    else()
+        set(_sidre_spio_py_num_ranks 1)
+    endif()
+
+    axom_add_python_test( NAME sidre_spio_Py
+                          SOURCE sidre_spio_Py.py
+                          OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                          NUM_MPI_TASKS ${_sidre_spio_py_num_ranks}
+                          )
+    unset(_sidre_spio_py_num_ranks)
 endif()
 
 #------------------------------------------------------------------------------

--- a/src/axom/sidre/tests/CMakeLists.txt
+++ b/src/axom/sidre/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ set(python_sidre_tests
    sidre_view_Py.py
    sidre_external_Py.py
    sidre_attribute_Py.py
+   sidre_lifetime_Py.py
    )
 
 set(sidre_gtests_depends_on sidre fmt gtest)

--- a/src/axom/sidre/tests/sidre_lifetime_Py.py
+++ b/src/axom/sidre/tests/sidre_lifetime_Py.py
@@ -1,0 +1,306 @@
+# Copyright (c) Lawrence Livermore National Security, LLC and other
+# Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+# files for dates and other details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+"""Lifetime-soundness regression tests for the sidre python bindings.
+
+Each test obtains a sidre-owned object (child proxy, ancestor proxy, harvested
+iterator element, or zero-copy numpy array), drops every Python owner, forces a
+garbage collection, and then *uses* the object. Before the lifetime audit these
+patterns dereferenced freed memory and segfaulted; with reference_internal on
+owner-chain accessors, keep_alive on iterator elements, and self-as-owner on
+returned arrays, the keep_alive graph keeps the backing DataStore alive and the
+accesses are safe.
+
+These tests therefore only "pass" against the audited bindings; against the
+prior bindings they crash the interpreter (the failure mode the audit fixes).
+"""
+
+import gc
+
+import numpy as np
+import pytest
+
+import pysidre
+
+
+def _force_gc():
+    # A couple of passes to be robust to reference cycles in the proxies.
+    for _ in range(3):
+        gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# Child proxies must pin their owner chain (parent -> owned child)
+# ---------------------------------------------------------------------------
+def test_root_outlives_datastore():
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    del ds
+    _force_gc()
+    # root must keep its DataStore alive
+    assert root.getNumViews() == 0
+    root.createView("v")
+    assert root.hasView("v")
+
+
+def test_child_group_outlives_datastore():
+    ds = pysidre.DataStore()
+    grp = ds.getRoot().createGroup("a/b/c")
+    del ds
+    _force_gc()
+    # grp pins parent group pins root pins DataStore
+    assert grp.getName() == "c"
+    assert grp.getPathName() == "a/b/c"
+
+
+def test_view_outlives_datastore():
+    ds = pysidre.DataStore()
+    view = ds.getRoot().createViewAndAllocate("field", pysidre.TypeID.INT_ID, 4)
+    del ds
+    _force_gc()
+    assert view.getNumElements() == 4
+    assert view.getName() == "field"
+
+
+def test_buffer_outlives_datastore():
+    ds = pysidre.DataStore()
+    buff = ds.createBuffer(pysidre.TypeID.INT_ID, 8)
+    buff.allocate()
+    del ds
+    _force_gc()
+    assert buff.getNumElements() == 8
+
+
+# ---------------------------------------------------------------------------
+# Ancestor proxies (child -> ancestor) must pin the object they were minted from
+# ---------------------------------------------------------------------------
+def test_owning_group_outlives_datastore():
+    ds = pysidre.DataStore()
+    view = ds.getRoot().createView("v")
+    owner = view.getOwningGroup()
+    del ds
+    del view
+    _force_gc()
+    assert owner.hasView("v")
+
+
+def test_get_datastore_back_reference():
+    ds = pysidre.DataStore()
+    grp = ds.getRoot().createGroup("child")
+    back = grp.getDataStore()
+    del ds
+    del grp
+    _force_gc()
+    # back-reference keeps the store alive; reach a fresh proxy through it
+    assert back.getRoot().hasGroup("child")
+
+
+def test_view_buffer_back_reference():
+    ds = pysidre.DataStore()
+    view = ds.getRoot().createViewAndAllocate("field", pysidre.TypeID.INT_ID, 4)
+    buff = view.getBuffer()
+    del ds
+    del view
+    _force_gc()
+    assert buff.getNumElements() == 4
+
+
+# ---------------------------------------------------------------------------
+# Iterator elements harvested into a list must outlive the collection + store
+# ---------------------------------------------------------------------------
+def test_harvested_views_outlive_datastore():
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    for i in range(4):
+        root.createView(f"v{i}")
+    harvested = list(root.views())
+    del ds
+    del root
+    _force_gc()
+    names = sorted(v.getName() for v in harvested)
+    assert names == ["v0", "v1", "v2", "v3"]
+
+
+def test_harvested_groups_outlive_datastore():
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    for i in range(3):
+        root.createGroup(f"g{i}")
+    harvested = list(root.groups())
+    del ds
+    del root
+    _force_gc()
+    names = sorted(g.getName() for g in harvested)
+    assert names == ["g0", "g1", "g2"]
+
+
+def test_harvested_buffers_outlive_datastore():
+    ds = pysidre.DataStore()
+    for _ in range(3):
+        ds.createBuffer(pysidre.TypeID.INT_ID, 2).allocate()
+    harvested = list(ds.buffers())
+    del ds
+    _force_gc()
+    assert sorted(b.getNumElements() for b in harvested) == [2, 2, 2]
+
+
+def test_harvested_attributes_outlive_datastore():
+    ds = pysidre.DataStore()
+    ds.createAttributeString("a0", "x")
+    ds.createAttributeScalar("a1", 42)
+    harvested = list(ds.attributes())
+    del ds
+    _force_gc()
+    assert sorted(a.getName() for a in harvested) == ["a0", "a1"]
+
+
+# ---------------------------------------------------------------------------
+# Iterator adaptors must outlive the owning Group/DataStore
+# ---------------------------------------------------------------------------
+def test_views_adaptor_outlives_group_and_datastore():
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    for i in range(3):
+        root.createView(f"v{i}")
+    adaptor = root.views()
+    del root
+    del ds
+    _force_gc()
+    assert sorted(v.getName() for v in adaptor) == ["v0", "v1", "v2"]
+
+
+def test_groups_adaptor_outlives_group_and_datastore():
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    for i in range(3):
+        root.createGroup(f"g{i}")
+    adaptor = root.groups()
+    del root
+    del ds
+    _force_gc()
+    assert sorted(g.getName() for g in adaptor) == ["g0", "g1", "g2"]
+
+
+def test_buffers_adaptor_outlives_datastore():
+    ds = pysidre.DataStore()
+    for _ in range(3):
+        ds.createBuffer(pysidre.TypeID.INT_ID, 2).allocate()
+    adaptor = ds.buffers()
+    del ds
+    _force_gc()
+    assert sorted(b.getNumElements() for b in adaptor) == [2, 2, 2]
+
+
+def test_attributes_adaptor_outlives_datastore():
+    ds = pysidre.DataStore()
+    ds.createAttributeString("a0", "x")
+    ds.createAttributeScalar("a1", 42)
+    adaptor = ds.attributes()
+    del ds
+    _force_gc()
+    assert sorted(a.getName() for a in adaptor) == ["a0", "a1"]
+
+
+# ---------------------------------------------------------------------------
+# Lookup accessors should return proxies that pin their owner chain
+# ---------------------------------------------------------------------------
+def test_get_view_outlives_group_and_datastore():
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    root.createView("v")
+    view = root.getView("v")
+    del root
+    del ds
+    _force_gc()
+    assert view.getName() == "v"
+
+
+def test_get_group_outlives_group_and_datastore():
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    root.createGroup("g")
+    grp = root.getGroup("g")
+    del root
+    del ds
+    _force_gc()
+    assert grp.getName() == "g"
+
+
+def test_get_buffer_outlives_datastore():
+    ds = pysidre.DataStore()
+    ds.createBuffer(pysidre.TypeID.INT_ID, 7).allocate()
+    buff = ds.getBuffer(0)
+    del ds
+    _force_gc()
+    assert buff.getNumElements() == 7
+
+
+def test_get_attribute_outlives_datastore():
+    ds = pysidre.DataStore()
+    ds.createAttributeString("a0", "x")
+    attr = ds.getAttribute("a0")
+    del ds
+    _force_gc()
+    assert attr.getName() == "a0"
+
+
+def test_parent_group_outlives_datastore():
+    ds = pysidre.DataStore()
+    child = ds.getRoot().createGroup("a/b")
+    parent = child.getParent()
+    del ds
+    del child
+    _force_gc()
+    assert parent.getName() == "a"
+    assert parent.hasGroup("b")
+
+
+# ---------------------------------------------------------------------------
+# Zero-copy numpy arrays must pin their backing View / Buffer (and DataStore)
+# ---------------------------------------------------------------------------
+def test_view_array_outlives_datastore():
+    ds = pysidre.DataStore()
+    view = ds.getRoot().createViewAndAllocate("field", pysidre.TypeID.INT_ID, 4)
+    arr = view.getDataArray()
+    arr[:] = [10, 20, 30, 40]
+    del ds
+    del view
+    _force_gc()
+    # array still references valid memory: read and write
+    assert list(arr) == [10, 20, 30, 40]
+    arr[0] = 99
+    assert arr[0] == 99
+
+
+def test_buffer_array_outlives_datastore():
+    ds = pysidre.DataStore()
+    buff = ds.createBuffer(pysidre.TypeID.INT_ID, 4)
+    buff.allocate()
+    arr = buff.getDataArray()
+    arr[:] = [1, 2, 3, 4]
+    del ds
+    del buff
+    _force_gc()
+    assert list(arr) == [1, 2, 3, 4]
+
+
+def test_view_array_survives_owner_chain_collection():
+    # Keep only the array; let the entire DataStore/Group/View chain be dropped.
+    def make_array():
+        ds = pysidre.DataStore()
+        view = ds.getRoot().createViewAndAllocate("field", pysidre.TypeID.FLOAT64_ID, 5)
+        a = view.getDataArray()
+        a[:] = np.arange(5, dtype=np.float64)
+        return a
+
+    arr = make_array()
+    _force_gc()
+    np.testing.assert_array_equal(arr, np.arange(5, dtype=np.float64))
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/src/axom/sidre/tests/sidre_lifetime_Py.py
+++ b/src/axom/sidre/tests/sidre_lifetime_Py.py
@@ -562,6 +562,32 @@ def test_pin_overwrite_warning():
     np.testing.assert_array_equal(view.getDataArray(), external2)
 
 
+def test_registry_cleanup_on_explicit_destroy():
+    """Pins are released when Views are explicitly destroyed, preventing registry bloat."""
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+
+    weak_refs = []
+    for i in range(5):
+        external = np.arange(10, dtype=np.int32)
+        weak_refs.append(weakref.ref(external))
+        view = root.createView(f"view_{i}")
+        view.setExternalData(pysidre.TypeID.INT32_ID, 10, external)
+        del external  # Pin keeps it alive
+        del view  # Don't hold view reference
+
+    # Explicitly destroy all views - this releases pins
+    for i in range(5):
+        root.destroyView(f"view_{i}")
+
+    _force_gc()
+
+    # Verify all arrays were collected after explicit destruction
+    collected_count = sum(1 for ref in weak_refs if ref() is None)
+    assert collected_count == len(weak_refs), \
+        f"Only {collected_count}/{len(weak_refs)} arrays collected after explicit destroy"
+
+
 if __name__ == "__main__":
     import sys
 

--- a/src/axom/sidre/tests/sidre_lifetime_Py.py
+++ b/src/axom/sidre/tests/sidre_lifetime_Py.py
@@ -258,6 +258,27 @@ def test_parent_group_outlives_datastore():
     assert parent.hasGroup("b")
 
 
+def test_moved_group_outlives_owner_chain():
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    src = root.createGroup("src")
+    dst = root.createGroup("dst")
+    child = src.createGroup("child")
+
+    moved = dst.moveGroup(child)
+    assert moved.getPathName() == "dst/child"
+
+    del ds
+    del root
+    del src
+    del dst
+    del child
+    _force_gc()
+
+    assert moved.getName() == "child"
+    assert moved.getPathName() == "dst/child"
+
+
 # ---------------------------------------------------------------------------
 # Zero-copy numpy arrays must pin their backing View / Buffer (and DataStore)
 # ---------------------------------------------------------------------------

--- a/src/axom/sidre/tests/sidre_lifetime_Py.py
+++ b/src/axom/sidre/tests/sidre_lifetime_Py.py
@@ -588,6 +588,168 @@ def test_registry_cleanup_on_explicit_destroy():
         f"Only {collected_count}/{len(weak_refs)} arrays collected after explicit destroy"
 
 
+def test_multiple_concurrent_datastores():
+    """Multiple active DataStores with external data should not interfere with each other."""
+    # Create multiple DataStores simultaneously
+    datastores = []
+    views = []
+    arrays = []
+
+    for ds_idx in range(3):
+        ds = pysidre.DataStore()
+        root = ds.getRoot()
+        datastores.append(ds)
+
+        # Each DataStore has multiple Views with external data
+        ds_views = []
+        ds_arrays = []
+        for view_idx in range(3):
+            external = np.arange(view_idx * 10, (view_idx + 1) * 10, dtype=np.int32)
+            ds_arrays.append(external)
+            view = root.createView(f"view_{view_idx}")
+            view.setExternalData(pysidre.TypeID.INT32_ID, 10, external)
+            ds_views.append(view)
+
+        views.append(ds_views)
+        arrays.append(ds_arrays)
+
+    # Verify all views can access their data correctly
+    for ds_idx in range(3):
+        for view_idx in range(3):
+            view = views[ds_idx][view_idx]
+            expected = arrays[ds_idx][view_idx]
+            retrieved = view.getDataArray()
+            np.testing.assert_array_equal(retrieved,
+                                          expected,
+                                          err_msg=f"DS{ds_idx} view{view_idx} data mismatch")
+
+    # Destroy one DataStore while others remain active
+    root0 = datastores[0].getRoot()
+    for view_idx in range(3):
+        root0.destroyView(f"view_{view_idx}")
+
+    # Keep references to DS1 and DS2 before deleting DS0
+    ds1_views = views[1]
+    ds2_views = views[2]
+    ds1_arrays = arrays[1]
+    ds2_arrays = arrays[2]
+
+    del datastores[0], views[0], arrays[0]
+    _force_gc()
+
+    # Verify remaining DataStores still work correctly
+    for local_idx, (ds_views, ds_arrays, ds_label) in enumerate([(ds1_views, ds1_arrays, "DS1"),
+                                                                 (ds2_views, ds2_arrays, "DS2")]):
+        for view_idx in range(3):
+            view = ds_views[view_idx]
+            expected = ds_arrays[view_idx]
+            retrieved = view.getDataArray()
+            np.testing.assert_array_equal(
+                retrieved,
+                expected,
+                err_msg=f"After DS0 destroy: {ds_label} view{view_idx} data mismatch")
+
+    # Create a new DataStore and verify it doesn't conflict
+    ds_new = pysidre.DataStore()
+    root_new = ds_new.getRoot()
+    external_new = np.arange(100, 110, dtype=np.int32)
+    view_new = root_new.createView("new_view")
+    view_new.setExternalData(pysidre.TypeID.INT32_ID, 10, external_new)
+
+    # Verify new DataStore works
+    np.testing.assert_array_equal(view_new.getDataArray(), external_new)
+
+    # Verify old DataStores still work
+    for ds_views, ds_arrays, ds_label in [(ds1_views, ds1_arrays, "DS1"),
+                                          (ds2_views, ds2_arrays, "DS2")]:
+        for view_idx in range(3):
+            view = ds_views[view_idx]
+            expected = ds_arrays[view_idx]
+            retrieved = view.getDataArray()
+            np.testing.assert_array_equal(
+                retrieved,
+                expected,
+                err_msg=f"After new DS: {ds_label} view{view_idx} data mismatch")
+
+
+def test_concurrent_datastores_with_copy_move():
+    """Copy/move operations should work correctly with multiple concurrent DataStores."""
+    ds1 = pysidre.DataStore()
+    ds2 = pysidre.DataStore()
+
+    root1 = ds1.getRoot()
+    root2 = ds2.getRoot()
+
+    # Create view with external data in DS1
+    external1 = np.arange(10, dtype=np.int32)
+    view1 = root1.createView("src")
+    view1.setExternalData(pysidre.TypeID.INT32_ID, 10, external1)
+
+    # Copy view to a group in DS1
+    grp1 = root1.createGroup("grp1")
+    copied = grp1.copyView(view1)
+    np.testing.assert_array_equal(copied.getDataArray(), external1)
+
+    # Create view with different external data in DS2
+    external2 = np.arange(20, 30, dtype=np.int64)
+    view2 = root2.createView("other")
+    view2.setExternalData(pysidre.TypeID.INT64_ID, 10, external2)
+
+    # Verify both DataStores maintain correct data
+    np.testing.assert_array_equal(view1.getDataArray(), external1)
+    np.testing.assert_array_equal(copied.getDataArray(), external1)
+    np.testing.assert_array_equal(view2.getDataArray(), external2)
+
+    # Move view within DS1
+    grp2 = root1.createGroup("grp2")
+    moved = grp2.moveView(copied)
+    np.testing.assert_array_equal(moved.getDataArray(), external1)
+
+    # Verify DS2 unaffected
+    np.testing.assert_array_equal(view2.getDataArray(), external2)
+
+
+def test_concurrent_datastores_registry_isolation():
+    """Registry should correctly isolate pins between different DataStores."""
+    ds1 = pysidre.DataStore()
+    ds2 = pysidre.DataStore()
+
+    external1 = np.arange(5, dtype=np.int32)
+    external2 = np.arange(5, dtype=np.int64)
+
+    ref1 = weakref.ref(external1)
+    ref2 = weakref.ref(external2)
+
+    # Both DataStores use external data
+    view1 = ds1.getRoot().createView("v1")
+    view1.setExternalData(pysidre.TypeID.INT32_ID, 5, external1)
+
+    view2 = ds2.getRoot().createView("v2")
+    view2.setExternalData(pysidre.TypeID.INT64_ID, 5, external2)
+
+    del external1, external2  # Only pins keep them alive
+    _force_gc()
+
+    # Both should still be alive
+    assert ref1() is not None, "DS1 external data collected prematurely"
+    assert ref2() is not None, "DS2 external data collected prematurely"
+
+    # Destroy view in DS1
+    ds1.getRoot().destroyView("v1")
+    _force_gc()
+
+    # DS1's external data should be collected, DS2's should not
+    assert ref1() is None, "DS1 external data not collected after destroyView"
+    assert ref2() is not None, "DS2 external data incorrectly collected"
+
+    # Destroy view in DS2
+    ds2.getRoot().destroyView("v2")
+    _force_gc()
+
+    # Now DS2's external data should be collected too
+    assert ref2() is None, "DS2 external data not collected after destroyView"
+
+
 if __name__ == "__main__":
     import sys
 

--- a/src/axom/sidre/tests/sidre_lifetime_Py.py
+++ b/src/axom/sidre/tests/sidre_lifetime_Py.py
@@ -18,6 +18,7 @@ prior bindings they crash the interpreter (the failure mode the audit fixes).
 """
 
 import gc
+import weakref
 
 import numpy as np
 import pytest
@@ -298,6 +299,92 @@ def test_view_array_survives_owner_chain_collection():
     arr = make_array()
     _force_gc()
     np.testing.assert_array_equal(arr, np.arange(5, dtype=np.float64))
+
+
+# ---------------------------------------------------------------------------
+# External numpy storage borrowed by Sidre must stay alive with the C++ View
+# ---------------------------------------------------------------------------
+def test_create_view_external_array_owner_survives_discarded_proxy():
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+
+    def create_external_view():
+        external = np.arange(6, dtype=np.int64)
+        ref = weakref.ref(external)
+        root.createView("external", external).apply(pysidre.TypeID.INT64_ID, 6)
+        return ref
+
+    ref = create_external_view()
+    _force_gc()
+    assert ref() is not None
+    np.testing.assert_array_equal(root.getView("external").getDataArray(), np.arange(6))
+
+
+def test_create_view_with_shape_external_array_owner_survives_discarded_proxy():
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    shape = np.array([2, 3])
+
+    def create_external_view():
+        external = np.arange(6, dtype=np.int64)
+        ref = weakref.ref(external)
+        root.createViewWithShape("shaped", pysidre.TypeID.INT64_ID, 2, shape, external)
+        return ref
+
+    ref = create_external_view()
+    _force_gc()
+    assert ref() is not None
+    np.testing.assert_array_equal(root.getView("shaped").getDataArray(), np.arange(6).reshape(2, 3))
+
+
+def test_set_external_data_array_owner_survives_discarded_proxy():
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+
+    def set_external_data():
+        view = root.createView("external")
+        external = np.arange(6, dtype=np.int64)
+        ref = weakref.ref(external)
+        view.setExternalData(pysidre.TypeID.INT64_ID, 6, external)
+        return ref
+
+    ref = set_external_data()
+    _force_gc()
+    assert ref() is not None
+    np.testing.assert_array_equal(root.getView("external").getDataArray(), np.arange(6))
+
+
+def test_set_external_data_with_shape_array_owner_survives_discarded_proxy():
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    shape = np.array([2, 3])
+
+    def set_external_data():
+        view = root.createView("shaped")
+        external = np.arange(6, dtype=np.int64)
+        ref = weakref.ref(external)
+        view.setExternalData(pysidre.TypeID.INT64_ID, 2, shape, external)
+        return ref
+
+    ref = set_external_data()
+    _force_gc()
+    assert ref() is not None
+    np.testing.assert_array_equal(root.getView("shaped").getDataArray(), np.arange(6).reshape(2, 3))
+
+
+def test_clear_releases_external_array_owner():
+    ds = pysidre.DataStore()
+    view = ds.getRoot().createView("external")
+    external = np.arange(6, dtype=np.int64)
+    ref = weakref.ref(external)
+    view.setExternalData(pysidre.TypeID.INT64_ID, 6, external)
+    del external
+    _force_gc()
+    assert ref() is not None
+
+    view.clear()
+    _force_gc()
+    assert ref() is None
 
 
 if __name__ == "__main__":

--- a/src/axom/sidre/tests/sidre_lifetime_Py.py
+++ b/src/axom/sidre/tests/sidre_lifetime_Py.py
@@ -408,6 +408,160 @@ def test_clear_releases_external_array_owner():
     assert ref() is None
 
 
+def test_copy_view_with_external_data_preserves_pin():
+    """copyView on an external View should copy the pin to prevent premature collection."""
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    src_group = root.createGroup("src")
+    dst_group = root.createGroup("dst")
+
+    # Create view with external data
+    external = np.arange(10, dtype=np.int64)
+    ref = weakref.ref(external)
+    src_view = src_group.createView("original", external)
+    src_view.apply(pysidre.TypeID.INT64_ID, 10)
+    del external
+    _force_gc()
+    assert ref() is not None  # Pin keeps it alive
+
+    # Copy the view - should copy the pin
+    copied_view = dst_group.copyView(src_view)
+    assert copied_view.isExternal()
+
+    # Delete source view and DS - copied view should keep pin alive
+    del src_view
+    del src_group
+    del ds
+    del root
+    del dst_group
+    _force_gc()
+
+    # Pin should still be valid
+    assert ref() is not None
+    np.testing.assert_array_equal(copied_view.getDataArray(), np.arange(10))
+
+
+def test_copy_group_with_external_data_preserves_pins():
+    """copyGroup should recursively copy pins for all external Views in hierarchy."""
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    src = root.createGroup("source")
+
+    # Create nested groups with external data
+    external1 = np.arange(5, dtype=np.int32)
+    external2 = np.arange(8, dtype=np.int64)
+    ref1 = weakref.ref(external1)
+    ref2 = weakref.ref(external2)
+
+    src.createView("view1", external1).apply(pysidre.TypeID.INT32_ID, 5)
+    child = src.createGroup("child")
+    child.createView("view2", external2).apply(pysidre.TypeID.INT64_ID, 8)
+
+    del external1
+    del external2
+    _force_gc()
+    assert ref1() is not None
+    assert ref2() is not None
+
+    # Copy the entire group hierarchy - copyGroup creates a group with the source name
+    dst_parent = root.createGroup("copies")
+    dst = dst_parent.copyGroup(src)
+    assert dst is not None
+    assert dst.getName() == "source"
+    assert dst.hasView("view1")
+    assert dst.hasGroup("child")
+    assert dst.getGroup("child").hasView("view2")
+
+    # Delete source hierarchy - copied pins should keep arrays alive
+    del src
+    del child
+    del ds
+    del root
+    del dst_parent
+    _force_gc()
+
+    # Both pins should still be valid
+    assert ref1() is not None
+    assert ref2() is not None
+    np.testing.assert_array_equal(dst.getView("view1").getDataArray(), np.arange(5, dtype=np.int32))
+    np.testing.assert_array_equal(
+        dst.getGroup("child").getView("view2").getDataArray(), np.arange(8, dtype=np.int64))
+
+
+def test_move_view_with_external_data_preserves_pin():
+    """moveView should preserve the pin since the View* pointer doesn't change."""
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    src = root.createGroup("src")
+    dst = root.createGroup("dst")
+
+    # Create view with external data
+    external = np.arange(12, dtype=np.int64)
+    ref = weakref.ref(external)
+    view = src.createView("moveable", external)
+    view.apply(pysidre.TypeID.INT64_ID, 12)
+    del external
+    _force_gc()
+    assert ref() is not None  # Pin keeps it alive
+
+    # Move the view to dst - View* stays the same, pin should remain valid
+    moved = dst.moveView(view)
+    assert moved.getPathName() == "dst/moveable"
+    assert moved.isExternal()
+    assert not src.hasView("moveable")
+    assert dst.hasView("moveable")
+
+    # Delete original references - moved view should keep pin alive
+    del view
+    del src
+    del ds
+    del root
+    del dst
+    _force_gc()
+
+    # Pin should still be valid
+    assert ref() is not None
+    np.testing.assert_array_equal(moved.getDataArray(), np.arange(12))
+
+
+def test_destroy_view_by_index_releases_external_pin():
+    """destroyView(IndexType) should release the external data pin."""
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+
+    external = np.arange(7, dtype=np.int32)
+    ref = weakref.ref(external)
+    view = root.createView("indexed", external)
+    view.apply(pysidre.TypeID.INT32_ID, 7)
+    view_idx = view.getIndex()
+    del external
+    del view
+    _force_gc()
+    assert ref() is not None  # Pin keeps it alive
+
+    # Destroy by index - should release the pin
+    root.destroyView(view_idx)
+    _force_gc()
+    assert ref() is None  # Pin released, array collected
+
+
+def test_pin_overwrite_warning():
+    """Setting external data twice on the same View correctly replaces the pin."""
+    ds = pysidre.DataStore()
+    view = ds.getRoot().createView("test")
+
+    # First external data
+    external1 = np.arange(5, dtype=np.int32)
+    view.setExternalData(pysidre.TypeID.INT32_ID, 5, external1)
+
+    # Second external data on same view - old pin released, new pin created
+    external2 = np.arange(10, dtype=np.int64)
+    view.setExternalData(pysidre.TypeID.INT64_ID, 10, external2)
+
+    # The second pin should be active; first pin was automatically released
+    np.testing.assert_array_equal(view.getDataArray(), external2)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/src/axom/sidre/tests/sidre_spio_Py.py
+++ b/src/axom/sidre/tests/sidre_spio_Py.py
@@ -100,6 +100,32 @@ def test_iomanager_split_communicator(tmp_path):
         sub.Free()
 
 
+def test_distributed_generate_blueprint_index(tmp_path):
+    # The distributed generateBlueprintIndex overload is built only under
+    # nanobind >= 2.10; skip cleanly if this build omitted it.
+    if not pysidre.AXOM_HAS_DISTRIBUTED_BLUEPRINT_INDEX_BINDING:
+        pytest.skip("generateBlueprintIndex not bound")
+
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    mesh = root.createGroup("mesh")
+    coords = mesh.createGroup("coordsets/coords")
+    coords.createViewString("type", "explicit")
+    topo = mesh.createGroup("topologies/topo")
+    topo.createViewString("type", "unstructured")
+    topo.createViewString("coordset", "coords")
+
+    base_dir = MPI.COMM_WORLD.bcast(str(tmp_path) if MPI.COMM_WORLD.Get_rank() == 0 else None,
+                                    root=0)
+    out = os.path.join(base_dir, "bp_index")
+
+    # Distributed signature: (comm, domain_path, mesh_name, index_path).
+    # We only assert the call is reachable and returns a bool; full Blueprint
+    # validity is covered by the C++ spio tests.
+    result = ds.generateBlueprintIndex(MPI.COMM_WORLD, "mesh", "mesh", out)
+    assert isinstance(result, bool)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/src/axom/sidre/tests/sidre_spio_Py.py
+++ b/src/axom/sidre/tests/sidre_spio_Py.py
@@ -79,6 +79,21 @@ def test_iomanager_explicit_world_communicator(tmp_path):
     assert list(arr) == [rank, rank + 1, rank + 2, rank + 3]
 
 
+def test_iomanager_owned_duplicate_survives_comm_free(tmp_path):
+    # IOManager duplicates the input communicator, so callers may free their
+    # mpi4py communicator after construction.
+    comm = MPI.COMM_SELF.Dup()
+    iom = pysidre.IOManager(comm)
+    comm.Free()
+
+    ds = _fill_datastore()
+    base = _shared_base(tmp_path, f"freed_comm_rank{MPI.COMM_WORLD.Get_rank()}")
+    iom.write(ds.getRoot(), 1, base, pysidre.Group.getDefaultIOProtocol())
+    assert iom.getNumFilesFromRoot(base + ".root") == 1
+    assert iom.getNumGroupsFromRoot(base + ".root") == 1
+    MPI.COMM_WORLD.Barrier()
+
+
 def test_iomanager_split_communicator(tmp_path):
     # Construct from a split communicator; each writes its own dataset.
     world = MPI.COMM_WORLD
@@ -87,17 +102,21 @@ def test_iomanager_split_communicator(tmp_path):
 
     color = world.Get_rank() % 2
     sub = world.Split(color=color, key=world.Get_rank())
+    sub_freed = False
     try:
+        sub_size = sub.Get_size()
         ds = _fill_datastore()
         iom = pysidre.IOManager(sub)
+        sub.Free()
+        sub_freed = True
         # tmp_path differs per rank; rendezvous on a shared, rank-0-broadcast dir
         base = _shared_base(tmp_path, f"split_color{color}")
         iom.write(ds.getRoot(), 1, base, pysidre.Group.getDefaultIOProtocol())
-        sub.Barrier()
         assert iom.getNumFilesFromRoot(base + ".root") == 1
-        assert iom.getNumGroupsFromRoot(base + ".root") == sub.Get_size()
+        assert iom.getNumGroupsFromRoot(base + ".root") == sub_size
     finally:
-        sub.Free()
+        if not sub_freed:
+            sub.Free()
 
 
 def test_distributed_generate_blueprint_index(tmp_path):

--- a/src/axom/sidre/tests/sidre_spio_Py.py
+++ b/src/axom/sidre/tests/sidre_spio_Py.py
@@ -1,0 +1,106 @@
+# Copyright (c) Lawrence Livermore National Security, LLC and other
+# Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+# files for dates and other details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+"""IOManager communicator-construction tests.
+
+These exercise the IOManager constructor's optional mpi4py communicator argument:
+the default (MPI_COMM_WORLD) path and an explicit split-communicator path.
+They are skipped unless the bindings were built with MPI and mpi4py is importable.
+
+Run multi-rank, e.g.:
+    mpirun -n 2 python -m pytest sidre_spio_Py.py
+"""
+
+import os
+
+import pytest
+
+import pysidre
+
+if not pysidre.AXOM_ENABLE_MPI:
+    pytest.skip("pysidre built without MPI", allow_module_level=True)
+
+mpi4py = pytest.importorskip("mpi4py")
+from mpi4py import MPI  # noqa: E402
+
+
+def _shared_base(tmp_path, name):
+    world = MPI.COMM_WORLD
+    base_dir = world.bcast(str(tmp_path) if world.Get_rank() == 0 else None, root=0)
+    return os.path.join(base_dir, name)
+
+
+def _fill_datastore():
+    ds = pysidre.DataStore()
+    root = ds.getRoot()
+    view = root.createViewAndAllocate("field", pysidre.TypeID.INT_ID, 4)
+    rank = MPI.COMM_WORLD.Get_rank()
+    view.getDataArray()[:] = [rank, rank + 1, rank + 2, rank + 3]
+    return ds
+
+
+def test_iomanager_legacy_use_scr_constructor():
+    # Preserve the previous IOManager(use_scr=False) positional API.
+    pysidre.IOManager(False)
+
+
+def test_iomanager_rejects_non_communicator():
+    with pytest.raises(AttributeError):
+        pysidre.IOManager(object())
+
+
+def test_iomanager_default_communicator(tmp_path):
+    # No communicator argument -> MPI_COMM_WORLD (preserves the prior behavior).
+    world = MPI.COMM_WORLD
+    ds = _fill_datastore()
+    iom = pysidre.IOManager()
+    base = _shared_base(tmp_path, "default_comm")
+    iom.write(ds.getRoot(), 1, base, pysidre.Group.getDefaultIOProtocol())
+    world.Barrier()
+    assert iom.getNumFilesFromRoot(base + ".root") == 1
+    assert iom.getNumGroupsFromRoot(base + ".root") == world.Get_size()
+
+
+def test_iomanager_explicit_world_communicator(tmp_path):
+    # Passing COMM_WORLD explicitly must match the default path.
+    world = MPI.COMM_WORLD
+    ds = _fill_datastore()
+    iom = pysidre.IOManager(MPI.COMM_WORLD)
+    base = _shared_base(tmp_path, "explicit_world")
+    iom.write(ds.getRoot(), 1, base, pysidre.Group.getDefaultIOProtocol())
+    world.Barrier()
+
+    ds_in = pysidre.DataStore()
+    iom.read(ds_in.getRoot(), base + ".root")
+    arr = ds_in.getRoot().getView("field").getDataArray()
+    rank = world.Get_rank()
+    assert list(arr) == [rank, rank + 1, rank + 2, rank + 3]
+
+
+def test_iomanager_split_communicator(tmp_path):
+    # Construct from a split communicator; each writes its own dataset.
+    world = MPI.COMM_WORLD
+    if world.Get_size() < 2:
+        pytest.skip("split-communicator test needs >= 2 ranks")
+
+    color = world.Get_rank() % 2
+    sub = world.Split(color=color, key=world.Get_rank())
+    try:
+        ds = _fill_datastore()
+        iom = pysidre.IOManager(sub)
+        # tmp_path differs per rank; rendezvous on a shared, rank-0-broadcast dir
+        base = _shared_base(tmp_path, f"split_color{color}")
+        iom.write(ds.getRoot(), 1, base, pysidre.Group.getDefaultIOProtocol())
+        sub.Barrier()
+        assert iom.getNumFilesFromRoot(base + ".root") == 1
+        assert iom.getNumGroupsFromRoot(base + ".root") == sub.Get_size()
+    finally:
+        sub.Free()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -664,7 +664,9 @@ macro(axom_add_python_test)
 
     axom_python_test_environment(_py_test_env)
     if(_py_test_env)
-        set_tests_properties(${arg_NAME} PROPERTIES ENVIRONMENT "${_py_test_env}")
+        set_property(TEST ${arg_NAME}
+                     APPEND
+                     PROPERTY ENVIRONMENT "${_py_test_env}")
     endif()
     unset(_py_test_env)
     unset(_test_command)

--- a/src/cmake/AxomMacros.cmake
+++ b/src/cmake/AxomMacros.cmake
@@ -626,9 +626,10 @@ function(axom_python_test_environment output_var)
 endfunction()
 
 ##------------------------------------------------------------------------------
-## axom_add_python_test(NAME       [name]
-##                      SOURCE     [source]
-##                      OUTPUT_DIR [dir])
+## axom_add_python_test(NAME          [name]
+##                      SOURCE        [source]
+##                      OUTPUT_DIR    [dir]
+##                      NUM_MPI_TASKS [n])
 ##
 ## Wrapper around add_test() that handles functionality
 ## that Axom applies to all python tests.
@@ -636,7 +637,7 @@ endfunction()
 macro(axom_add_python_test)
 
     set(options)
-    set(singleValueArgs NAME SOURCE OUTPUT_DIR)
+    set(singleValueArgs NAME SOURCE OUTPUT_DIR NUM_MPI_TASKS)
     set(multiValueArgs)
 
     # Parse the arguments to the macro
@@ -651,15 +652,22 @@ macro(axom_add_python_test)
     # The run_python_with_axom.sh wrapper provides the runtime environment
     # and the testing dependencies are injected via the test's ENVIRONMENT property when provided.
     # "-p no:cacheprovider" disables caching.
-    add_test (NAME    ${arg_NAME}
-      COMMAND ${PROJECT_BINARY_DIR}/bin/run_python_with_axom.sh -m pytest -s -p no:cacheprovider ${arg_OUTPUT_DIR}/${arg_SOURCE}
-    )
+    set(_test_command ${PROJECT_BINARY_DIR}/bin/run_python_with_axom.sh
+                      -m pytest -s -p no:cacheprovider ${arg_OUTPUT_DIR}/${arg_SOURCE})
+    blt_add_test(NAME          ${arg_NAME}
+                 COMMAND       ${_test_command}
+                 NUM_MPI_TASKS ${arg_NUM_MPI_TASKS})
+
+    set_property(TEST ${arg_NAME}
+                 APPEND
+                 PROPERTY ENVIRONMENT  "OMPI_MCA_rmaps_base_oversubscribe=1")
 
     axom_python_test_environment(_py_test_env)
     if(_py_test_env)
         set_tests_properties(${arg_NAME} PROPERTIES ENVIRONMENT "${_py_test_env}")
     endif()
     unset(_py_test_env)
+    unset(_test_command)
 
 endmacro(axom_add_python_test)
 

--- a/src/cmake/thirdparty/SetupAxomThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupAxomThirdParty.cmake
@@ -400,15 +400,14 @@ if(AXOM_ENABLE_MPI
       "PY_MPI4PY_DIR")
 endif()
 
-# "cannot allocate memory in static TLS block" on blueos with cuda and/or clang.
+# nanobind extensions have hit "cannot allocate memory in static TLS block" 
+# when the module is loaded into an interpreter alongside CUDA runtime initialization. 
 # Also disable when sanitizers are enabled, requires environment variable manipulation:
 # https://stackoverflow.com/questions/55692357/address-sanitizer-on-a-python-extension
 if(nanobind_ROOT
    AND NOT AXOM_ENABLE_CUDA
    AND NOT AXOM_ENABLE_ASAN
-   AND NOT AXOM_ENABLE_UBSAN
-   AND ((NOT "$ENV{SYS_TYPE}" STREQUAL "blueos_3_ppc64le_ib_p9")
-        OR  ("$ENV{SYS_TYPE}" STREQUAL "blueos_3_ppc64le_ib_p9" AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")))
+   AND NOT AXOM_ENABLE_UBSAN)
 
     axom_assert_is_directory(DIR_VARIABLE nanobind_ROOT)
     find_package(nanobind CONFIG REQUIRED)


### PR DESCRIPTION
# Summary

- This PR further improves support and interoperability for sidre's Python bindings 
- It improves lifetime management for sidre entities in Python interface. 
  - Specifically, the wrapped sidre entities (views, groups, attributes, datastore, iterators) stay alive as long as their python object
  - This allows, e.g. external sidre views into numpy arrays
- It also allows wrapped IOManager to be initialized with MPI communicators other than `MPI_COMM_WORLD`
- It exports the python interface stubs and types for pysidre, allowing for better tool support and IDE integration
- It updates Axom's python test macro `axom_add_python_test` to support `MPI_NUM_TASKS`