### PR TITLE
define `CAMP_USE_PLATFORM_DEFAULT_STREAM`, if built with mfem+raja

### DIFF
--- a/src/axom/config.hpp.in
+++ b/src/axom/config.hpp.in
@@ -78,9 +78,8 @@
 #cmakedefine AXOM_USE_UMPIRE
 
 /*
- * MFEM requires CAMP to use the platform default stream when Axom is built
- * with RAJA/CAMP support. Define this before any RAJA or CAMP headers are
- * included through Axom headers.
+ * CAMP is required to use the platform default stream (if MFEM is built
+ * with RAJA). Define this before any RAJA or CAMP headers are included.
  */
 #if defined(AXOM_USE_MFEM)
 #ifndef CAMP_USE_PLATFORM_DEFAULT_STREAM

--- a/src/axom/config.hpp.in
+++ b/src/axom/config.hpp.in
@@ -82,7 +82,7 @@
  * with RAJA/CAMP support. Define this before any RAJA or CAMP headers are
  * included through Axom headers.
  */
-#if defined(AXOM_USE_MFEM) && defined(AXOM_USE_RAJA)
+#if defined(AXOM_USE_MFEM)
 #ifndef CAMP_USE_PLATFORM_DEFAULT_STREAM
 #define CAMP_USE_PLATFORM_DEFAULT_STREAM 1
 #endif

--- a/src/axom/config.hpp.in
+++ b/src/axom/config.hpp.in
@@ -78,6 +78,17 @@
 #cmakedefine AXOM_USE_UMPIRE
 
 /*
+ * MFEM requires CAMP to use the platform default stream when Axom is built
+ * with RAJA/CAMP support. Define this before any RAJA or CAMP headers are
+ * included through Axom headers.
+ */
+#if defined(AXOM_USE_MFEM) && defined(AXOM_USE_RAJA)
+#ifndef CAMP_USE_PLATFORM_DEFAULT_STREAM
+#define CAMP_USE_PLATFORM_DEFAULT_STREAM 1
+#endif
+#endif
+
+/*
  * Compiler defines for library capabilities
  */
 #cmakedefine AXOM_USE_UMPIRE_SHARED_MEMORY


### PR DESCRIPTION
A recent MFEM PR checks if `CAMP_USE_PLATFORM_DEFAULT_STREAM=1`. This is a new restriction essentially forcing camp to use default platform stream, if MFEM is built with RAJA. https://github.com/mfem/mfem/pull/5349/changes

However if camp or RAJA are included first, then `CAMP_USE_PLATFORM_DEFAULT_STREAM` will be set to `0` by default. https://github.com/llnl/camp/blob/3e702a10cbf31877e17e83558d2c4abf47960c8b/include/camp/defines.hpp#L164-L168

So, the solution is to either mass change the order of include headers such that MFEM is always first, or define the camp macro in the axom config header, so its guaranteed to be defined first.

Another detail is it would be more accurate to also check if `MFEM_USE_RAJA`. However, given that would require including MFEM's config header within Axom's, i figured itd be safer to skip the check and always set `CAMP_USE_PLATFORM_DEFAULT_STREAM` if Axom is built with MFEM.