### PR TITLE
Inlet: fix issue created by last PR related to get<>() in container and proxy

### DIFF
--- a/src/axom/inlet/Container.hpp
+++ b/src/axom/inlet/Container.hpp
@@ -827,9 +827,9 @@ public:
    *******************************************************************************
    */
   template <typename T>
-  typename std::enable_if<!detail::is_inlet_primitive<T>::value && !detail::is_inlet_array<T>::value &&
-                            !detail::is_inlet_dict<T>::value && !detail::is_std_vector<T>::value &&
-                            !detail::is_variant_value<T>::value && !detail::is_std_variant<T>::value,
+  typename std::enable_if<!detail::is_inlet_primitive<T>::value &&
+                            !detail::is_inlet_array<T>::value && !detail::is_inlet_dict<T>::value &&
+                            !detail::is_std_vector<T>::value && !detail::is_variant_value<T>::value,
                           T>::type
   get(const std::string& name = "") const
   {

--- a/src/axom/inlet/Proxy.hpp
+++ b/src/axom/inlet/Proxy.hpp
@@ -16,6 +16,7 @@
 #define INLET_PROXY_HPP
 
 #include <type_traits>
+#include <utility>
 
 #include "axom/inlet/Field.hpp"
 #include "axom/inlet/Container.hpp"
@@ -24,6 +25,22 @@ namespace axom
 {
 namespace inlet
 {
+
+namespace detail
+{
+template <typename T, typename SFINAE = void>
+struct has_ProxyFromInlet_specialization : std::false_type
+{ };
+
+template <typename T>
+struct has_ProxyFromInlet_specialization<
+  T,
+  typename std::enable_if<
+    std::is_same<T, decltype(std::declval<FromInlet<T>&>()(std::declval<const Proxy&>()))>::value>::type>
+  : std::true_type
+{ };
+}  // namespace detail
+
 /*!
  *******************************************************************************
  * \class Proxy
@@ -42,7 +59,7 @@ public:
   /*!
    *******************************************************************************
    * \brief Constructs a proxy view onto a container
-   * 
+   *
    * \param [in] container The container to construct a proxy into
    *******************************************************************************
    */
@@ -51,7 +68,7 @@ public:
   /*!
    *******************************************************************************
    * \brief Constructs a proxy view onto a field
-   * 
+   *
    * \param [in] field The field to construct a proxy into
    *******************************************************************************
    */
@@ -142,6 +159,28 @@ public:
   /*!
    *******************************************************************************
    * \brief Returns a user-defined type from the proxy
+   *
+   * \tparam T The type of the object to retrieve
+   * \return The retrieved object
+   * \pre The Proxy must refer to a container object
+   *******************************************************************************
+   */
+  template <typename T>
+  typename std::enable_if<!detail::is_inlet_primitive<T>::value && !detail::is_std_function<T>::value &&
+                            detail::has_ProxyFromInlet_specialization<T>::value,
+                          T>::type
+  get() const
+  {
+    SLIC_ASSERT_MSG(m_container != nullptr,
+                    "[Inlet] Tried to read a user-defined type from a Proxy "
+                    "containing a single field or function");
+    FromInlet<T> from_inlet;
+    return from_inlet(*this);
+  }
+
+  /*!
+   *******************************************************************************
+   * \brief Returns a user-defined type from the proxy
    * 
    * \tparam T The type of the object to retrieve
    * \return The retrieved object
@@ -149,7 +188,9 @@ public:
    *******************************************************************************
    */
   template <typename T>
-  typename std::enable_if<!detail::is_inlet_primitive<T>::value && !detail::is_std_function<T>::value, T>::type
+  typename std::enable_if<!detail::is_inlet_primitive<T>::value && !detail::is_std_function<T>::value &&
+                            !detail::has_ProxyFromInlet_specialization<T>::value,
+                          T>::type
   get() const
   {
     SLIC_ASSERT_MSG(m_container != nullptr,

--- a/src/axom/inlet/tests/inlet_object.cpp
+++ b/src/axom/inlet/tests/inlet_object.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "axom/core/Path.hpp"
+#include "axom/fmt.hpp"
 #include "axom/slic/core/SimpleLogger.hpp"
 #include "axom/sidre.hpp"
 
@@ -85,6 +86,36 @@ struct FromInlet<Box>
 {
   Box operator()(const axom::inlet::Container& base) { return {base["width"], base["height"]}; }
 };
+
+template <>
+struct FromInlet<Shape>
+{
+  Shape operator()(const axom::inlet::Container& base) { return (*this)(axom::inlet::Proxy(base)); }
+
+  Shape operator()(const axom::inlet::Proxy& base)
+  {
+    const std::string kind = base["kind"];
+    if(kind == "circle")
+    {
+      return Circle {base["radius"]};
+    }
+    if(kind == "box")
+    {
+      return Box {base["width"], base["height"]};
+    }
+
+    SLIC_ERROR(axom::fmt::format("Unknown shape discriminator '{}'", kind));
+    return Box {0.0, 0.0};
+  }
+};
+
+void defineShapeSchema(axom::inlet::Container& shape)
+{
+  shape.addString("kind").required().validValues({"circle", "box"});
+  shape.addDouble("radius").required(false);
+  shape.addDouble("width").required(false);
+  shape.addDouble("height").required(false);
+}
 
 void defineShapeSchema(axom::inlet::VariantStructCollection<Shape>& shapes)
 {
@@ -236,6 +267,20 @@ TYPED_TEST(inlet_object, variant_array_of_struct_unknown_discriminator_fails)
   defineShapeSchema(shapes);
 
   EXPECT_FALSE(inlet.verify());
+}
+
+TYPED_TEST(inlet_object, variant_struct_by_value)
+{
+  std::string testString = "shape = { kind = \"box\"; width = 3.0; height = 4.0 }";
+  Inlet inlet = createBasicInlet<TypeParam>(testString);
+
+  auto& shape = inlet.addStruct("shape");
+  defineShapeSchema(shape);
+
+  EXPECT_TRUE(inlet.verify());
+
+  EXPECT_EQ(inlet.get<Shape>("shape"), Shape(Box {3.0, 4.0}));
+  EXPECT_EQ(inlet["shape"].get<Shape>(), Shape(Box {3.0, 4.0}));
 }
 
 TYPED_TEST(inlet_object, simple_array_of_struct_implicit_idx)


### PR DESCRIPTION
Found by @chapman39 

```
In file included from /usr/WS2/meemee/smith/repo/src/smith/physics/materials/solid_material_input.cpp:7:
  In file included from /usr/WS2/meemee/smith/repo/src/smith/infrastructure/../../smith/physics/materials/solid_material_input.hpp:18:
  In file included from /usr/WS2/meemee/smith/repo/src/smith/infrastructure/../../smith/infrastructure/input.hpp:24:
  In file included from /usr/WS2/meemee/smith/smith_tpls/toss_4_x86_64_ib/2026-06-29/llvm-19.1.3/axom-0.14.0.2-webdmbomwunrvalslv653nhs5qn4ftiy/include/axom/
  inlet.hpp:15:
  In file included from /usr/WS2/meemee/smith/smith_tpls/toss_4_x86_64_ib/2026-06-29/llvm-19.1.3/axom-0.14.0.2-webdmbomwunrvalslv653nhs5qn4ftiy/include/axom/inlet/
  Inlet.hpp:26:
  /usr/WS2/meemee/smith/smith_tpls/toss_4_x86_64_ib/2026-06-29/llvm-19.1.3/axom-0.14.0.2-webdmbomwunrvalslv653nhs5qn4ftiy/include/axom/inlet/Proxy.hpp:158:25: error: no
  matching member function for call to 'get'
    158 |     return m_container->get<T>();
        |            ~~~~~~~~~~~~~^~~~~~
  /usr/WS2/meemee/smith/repo/src/smith/physics/materials/solid_material_input.cpp:68:58: note: in instantiation of function template specialization
  'axom::inlet::Proxy::get<std::variant<smith::solid_mechanics::LinearHardening, smith::solid_mechanics::PowerLawHardening, smith::solid_mechanics::VoceHardening>>'
  requested here
     68 |     smith::var_hardening_t hardening = base["hardening"].get<smith::var_hardening_t>();
        |                                                          ^
```