### PR TITLE
More slam modernization, including traits classes and aliases

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -55,6 +55,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Quest: The C2CReader was enhanced to provide assembly support.
 - Core: Adds `utilities::filesystem::getFileExtension(str)`
 - Klee: Adds support for lua-based input decks for shaping
+- Slam: Adds convenience aliases in `axom/slam/Aliases.hpp` for the most common set and relation configurations, 
+  including `ArraySet`, `ArrayViewSet`, `VariableRelation`, `ConstantRelation` and their `View` forms.
 
 ### Removed
 - Bump: Removed `axom::bump::views::MultiBufferMaterialView`, which was a view type for an obsolete flavor of Blueprint matset.
@@ -74,9 +76,19 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Changed to `#pragma once` instead of unique header guard defines
 - Python: Sidre's bindings now install under the `axom` Python package (`import axom.sidre`)
   Code that previously imported `pysidre` needs to be updated to `axom.sidre`.
+- Slam: `slam::Map`, `slam::BivariateMap` and `policies::VariableCardinality` now default to
+  `policies::ArrayIndirection` instead of `policies::STLVectorIndirection`.
+   Code that previously used the default `std::vector`-backed Maps will need to either
+   add a template for the `policies::STLVectorIndirection` or update to `policies::ArrayIndirection`.
+- Slam: `FieldRegistry` fields and buffers that it manages now use `axom::Array`
+  (a `slam::Map` with the default `axom::Array` indirection) rather than `std::vector`.
+  Code that previously registered `std::vector`-backed buffers should use
+  `FieldRegistry::MapType`, `FieldRegistry::BufferType`, `auto`, or `buffer.view()`, as appropriate.
 
 ### Fixed
 - MIR/Bump: `MergeCoordsetPoints` now only emits its node-merge `SLIC_INFO` when MIR `verbose` is enabled on the Conduit options passed through ELVIRA.
+- Slam: View-backed static relations are now trivially copyable and safe to capture by
+  value into device kernels.
 - Primal: Fixes signs of `compute_moments` to match orientation convention in `primal::evaluate_area_integral`
 - Quest: Improves error handling/reporting when loading an invalid c2c contour
 - Primal: Improves reproducibility of 3D GWN methods by removing some sources of randomness

--- a/src/axom/bump/MergeMeshes.hpp
+++ b/src/axom/bump/MergeMeshes.hpp
@@ -23,6 +23,7 @@
 #include <conduit/conduit.hpp>
 
 #include <string>
+#include <type_traits>
 
 namespace axom
 {
@@ -1769,8 +1770,9 @@ private:
         auto *This = this;
         disp.dispatchMatset(n_matset, [&](auto matsetView) {
           // Figure out the types to use for storing the data.
-          using IType = typename decltype(matsetView)::IndexType;
-          using FType = typename decltype(matsetView)::FloatType;
+          using MatsetViewType = std::remove_reference_t<decltype(matsetView)>;
+          using IType = typename MatsetViewType::IndexType;
+          using FType = typename MatsetViewType::FloatType;
           mi.itype = utils::cpp2conduit<IType>::id;
           mi.ftype = utils::cpp2conduit<FType>::id;
 
@@ -2037,7 +2039,8 @@ private:
                         axom::IndexType nzones,
                         axom::IndexType zOffset) const
   {
-    using MatID = typename decltype(matsetView)::IndexType;
+    using MatsetViewType = std::remove_reference_t<decltype(matsetView)>;
+    using MatID = typename MatsetViewType::IndexType;
 
     // Make some maps for renumbering material numbers.
     const auto localMaterialMap = axom::bump::views::materials(n_matset);

--- a/src/axom/bump/views/dispatch_material.hpp
+++ b/src/axom/bump/views/dispatch_material.hpp
@@ -12,6 +12,8 @@
 
 #include <conduit/conduit_blueprint.hpp>
 
+#include <type_traits>
+
 namespace axom
 {
 namespace bump
@@ -54,20 +56,23 @@ bool dispatch_material_unibuffer_with_values(const conduit::Node &matset,
   verify(matset, "matset");
   if(conduit::blueprint::mesh::matset::is_uni_buffer(matset))
   {
-    indexNodeToArrayViewSame(matset["material_ids"],
-                             matset["sizes"],
-                             matset["offsets"],
-                             matset["indices"],
-                             [&](auto material_ids, auto sizes, auto offsets, auto indices) {
-                               floatNodeToArrayView(values, [&](auto typedValues) {
-                                 using IndexType = typename decltype(material_ids)::value_type;
-                                 using FloatType = typename decltype(typedValues)::value_type;
+    indexNodeToArrayViewSame(
+      matset["material_ids"],
+      matset["sizes"],
+      matset["offsets"],
+      matset["indices"],
+      [&](auto material_ids, auto sizes, auto offsets, auto indices) {
+        floatNodeToArrayView(values, [&](auto typedValues) {
+          using MaterialIDsView = std::remove_reference_t<decltype(material_ids)>;
+          using ValuesView = std::remove_reference_t<decltype(typedValues)>;
+          using IndexType = typename MaterialIDsView::value_type;
+          using FloatType = typename ValuesView::value_type;
 
-                                 UnibufferMaterialView<IndexType, FloatType, MAXMATERIALS> matsetView;
-                                 matsetView.set(material_ids, typedValues, sizes, offsets, indices);
-                                 func(matsetView);
-                               });
-                             });
+          UnibufferMaterialView<IndexType, FloatType, MAXMATERIALS> matsetView;
+          matsetView.set(material_ids, typedValues, sizes, offsets, indices);
+          func(matsetView);
+        });
+      });
     retval = true;
   }
   return retval;
@@ -126,8 +131,8 @@ bool dispatch_material_element_dominant_with_values(const conduit::Node &matset,
     {
       const conduit::Node &n_firstValues = values_object[0];
       floatNodeToArrayView(n_firstValues, [&](auto firstValues) {
-        using FloatElement =
-          typename std::remove_const<typename decltype(firstValues)::value_type>::type;
+        using FirstValuesView = std::remove_reference_t<decltype(firstValues)>;
+        using FloatElement = typename std::remove_const<typename FirstValuesView::value_type>::type;
         using FloatView = axom::ArrayView<FloatElement>;
         using IntElement = axom::IndexType;
 
@@ -186,10 +191,10 @@ bool dispatch_material_material_dominant_with_values(const conduit::Node &matset
 
       indexNodeToArrayView(n_firstIndices, [&](auto firstIndices) {
         floatNodeToArrayView(n_firstValues, [&](auto firstValues) {
-          using FloatElement =
-            typename std::remove_const<typename decltype(firstValues)::value_type>::type;
-          using IntElement =
-            typename std::remove_const<typename decltype(firstIndices)::value_type>::type;
+          using FirstValuesView = std::remove_reference_t<decltype(firstValues)>;
+          using FirstIndicesView = std::remove_reference_t<decltype(firstIndices)>;
+          using FloatElement = typename std::remove_const<typename FirstValuesView::value_type>::type;
+          using IntElement = typename std::remove_const<typename FirstIndicesView::value_type>::type;
           using FloatView = axom::ArrayView<FloatElement>;
           using IntView = axom::ArrayView<IntElement>;
 

--- a/src/axom/mint/mesh/UnstructuredMesh.hpp
+++ b/src/axom/mint/mesh/UnstructuredMesh.hpp
@@ -27,7 +27,7 @@
 #include "axom/slic/interface/slic.hpp"
 
 // C/C++ includes
-#include <cstring>  // for std::memcpy
+#include <cstring>
 
 namespace axom
 {
@@ -55,11 +55,8 @@ struct topology_traits<SINGLE_SHAPE>
   using FaceSet = slam::PositionSet<IdxType, IdxType>;
 
   using ZoneNodeRelation = slam::RuntimeConstantRelationView<ZoneSet, NodeSet>;
-
   using ZoneFaceRelation = slam::RuntimeConstantRelationView<ZoneSet, FaceSet>;
-
   using FaceZoneRelation = slam::ConstantRelationView<FaceSet, ZoneSet, 2>;
-
   using FaceNodeRelation = slam::VariableRelationView<FaceSet, NodeSet>;
 };
 
@@ -75,11 +72,8 @@ struct topology_traits<MIXED_SHAPE>
   using FaceSet = slam::PositionSet<IdxType, IdxType>;
 
   using ZoneNodeRelation = slam::VariableRelationView<ZoneSet, NodeSet>;
-
   using ZoneFaceRelation = slam::VariableRelationView<ZoneSet, FaceSet>;
-
   using FaceZoneRelation = slam::ConstantRelationView<FaceSet, ZoneSet, 2>;
-
   using FaceNodeRelation = slam::VariableRelationView<FaceSet, NodeSet>;
 };
 

--- a/src/axom/mint/mesh/UnstructuredMesh.hpp
+++ b/src/axom/mint/mesh/UnstructuredMesh.hpp
@@ -20,8 +20,8 @@
 #include "axom/mint/mesh/internal/MeshHelpers.hpp"
 
 // Slam includes
+#include "axom/slam/Aliases.hpp"
 #include "axom/slam/RangeSet.hpp"
-#include "axom/slam/StaticRelation.hpp"
 
 // Slic includes
 #include "axom/slic/interface/slic.hpp"
@@ -54,26 +54,13 @@ struct topology_traits<SINGLE_SHAPE>
   using NodeSet = slam::PositionSet<IdxType, IdxType>;
   using FaceSet = slam::PositionSet<IdxType, IdxType>;
 
-  using ViewIndirection = slam::policies::ArrayViewIndirection<IdxType, IdxType>;
+  using ZoneNodeRelation = slam::RuntimeConstantRelationView<ZoneSet, NodeSet>;
 
-  using ZNStride = slam::policies::RuntimeStride<IdxType>;
-  using ZNCardinality = slam::policies::ConstantCardinality<IdxType, ZNStride>;
-  using ZoneNodeRelation =
-    slam::StaticRelation<IdxType, IdxType, ZNCardinality, ViewIndirection, ZoneSet, NodeSet>;
+  using ZoneFaceRelation = slam::RuntimeConstantRelationView<ZoneSet, FaceSet>;
 
-  using ZFStride = slam::policies::RuntimeStride<IdxType>;
-  using ZFCardinality = slam::policies::ConstantCardinality<IdxType, ZFStride>;
-  using ZoneFaceRelation =
-    slam::StaticRelation<IdxType, IdxType, ZFCardinality, ViewIndirection, ZoneSet, FaceSet>;
+  using FaceZoneRelation = slam::ConstantRelationView<FaceSet, ZoneSet, 2>;
 
-  using FZStride = slam::policies::CompileTimeStride<IdxType, 2>;
-  using FZCardinality = slam::policies::ConstantCardinality<IdxType, FZStride>;
-  using FaceZoneRelation =
-    slam::StaticRelation<IdxType, IdxType, FZCardinality, ViewIndirection, FaceSet, ZoneSet>;
-
-  using FNCardinality = slam::policies::VariableCardinality<IdxType, ViewIndirection>;
-  using FaceNodeRelation =
-    slam::StaticRelation<IdxType, IdxType, FNCardinality, ViewIndirection, FaceSet, NodeSet>;
+  using FaceNodeRelation = slam::VariableRelationView<FaceSet, NodeSet>;
 };
 
 template <>
@@ -87,24 +74,13 @@ struct topology_traits<MIXED_SHAPE>
   using NodeSet = slam::PositionSet<IdxType, IdxType>;
   using FaceSet = slam::PositionSet<IdxType, IdxType>;
 
-  using ViewIndirection = slam::policies::ArrayViewIndirection<IdxType, IdxType>;
+  using ZoneNodeRelation = slam::VariableRelationView<ZoneSet, NodeSet>;
 
-  using ZNCardinality = slam::policies::VariableCardinality<IdxType, ViewIndirection>;
-  using ZoneNodeRelation =
-    slam::StaticRelation<IdxType, IdxType, ZNCardinality, ViewIndirection, ZoneSet, NodeSet>;
+  using ZoneFaceRelation = slam::VariableRelationView<ZoneSet, FaceSet>;
 
-  using ZFCardinality = slam::policies::VariableCardinality<IdxType, ViewIndirection>;
-  using ZoneFaceRelation =
-    slam::StaticRelation<IdxType, IdxType, ZFCardinality, ViewIndirection, ZoneSet, FaceSet>;
+  using FaceZoneRelation = slam::ConstantRelationView<FaceSet, ZoneSet, 2>;
 
-  using FZStride = slam::policies::CompileTimeStride<IdxType, 2>;
-  using FZCardinality = slam::policies::ConstantCardinality<IdxType, FZStride>;
-  using FaceZoneRelation =
-    slam::StaticRelation<IdxType, IdxType, FZCardinality, ViewIndirection, FaceSet, ZoneSet>;
-
-  using FNCardinality = slam::policies::VariableCardinality<IdxType, ViewIndirection>;
-  using FaceNodeRelation =
-    slam::StaticRelation<IdxType, IdxType, FNCardinality, ViewIndirection, FaceSet, NodeSet>;
+  using FaceNodeRelation = slam::VariableRelationView<FaceSet, NodeSet>;
 };
 
 /*!

--- a/src/axom/mir/reference/MIRMesh.cpp
+++ b/src/axom/mir/reference/MIRMesh.cpp
@@ -221,7 +221,8 @@ void MIRMesh::constructMeshVolumeFractionsVertex(const std::vector<std::vector<a
 
 //--------------------------------------------------------------------------------
 
-void MIRMesh::constructVertexPositionMap(const std::vector<Point2>& data)
+template <typename PointContainer>
+void MIRMesh::constructVertexPositionMap(const PointContainer& data)
 {
   // construct the position map on the vertices
   m_vertexPositions = PointMap(&m_verts);
@@ -233,7 +234,8 @@ void MIRMesh::constructVertexPositionMap(const std::vector<Point2>& data)
 
 //--------------------------------------------------------------------------------
 
-void MIRMesh::constructElementParentMap(const std::vector<int>& elementParents)
+template <typename IntContainer>
+void MIRMesh::constructElementParentMap(const IntContainer& elementParents)
 {
   // Initialize the map for the elements' parent IDs
   m_elementParentIDs = IntMap(&m_elems);
@@ -246,7 +248,8 @@ void MIRMesh::constructElementParentMap(const std::vector<int>& elementParents)
 
 //--------------------------------------------------------------------------------
 
-void MIRMesh::constructElementDominantMaterialMap(const std::vector<int>& dominantMaterials)
+template <typename IntContainer>
+void MIRMesh::constructElementDominantMaterialMap(const IntContainer& dominantMaterials)
 {
   // Initialize the map for the elements' dominant colors
   m_elementDominantMaterials = IntMap(&m_elems);

--- a/src/axom/mir/reference/MIRMesh.cpp
+++ b/src/axom/mir/reference/MIRMesh.cpp
@@ -221,49 +221,6 @@ void MIRMesh::constructMeshVolumeFractionsVertex(const std::vector<std::vector<a
 
 //--------------------------------------------------------------------------------
 
-template <typename PointContainer>
-void MIRMesh::constructVertexPositionMap(const PointContainer& data)
-{
-  // construct the position map on the vertices
-  m_vertexPositions = PointMap(&m_verts);
-
-  for(int vID = 0; vID < m_verts.size(); ++vID) m_vertexPositions[vID] = data[vID];
-
-  SLIC_ASSERT_MSG(m_vertexPositions.isValid(), "Position map is not valid.");
-}
-
-//--------------------------------------------------------------------------------
-
-template <typename IntContainer>
-void MIRMesh::constructElementParentMap(const IntContainer& elementParents)
-{
-  // Initialize the map for the elements' parent IDs
-  m_elementParentIDs = IntMap(&m_elems);
-
-  // Copy the data for the elements
-  for(int eID = 0; eID < m_elems.size(); ++eID) m_elementParentIDs[eID] = elementParents[eID];
-
-  SLIC_ASSERT_MSG(m_elementParentIDs.isValid(), "Element parent map is not valid.");
-}
-
-//--------------------------------------------------------------------------------
-
-template <typename IntContainer>
-void MIRMesh::constructElementDominantMaterialMap(const IntContainer& dominantMaterials)
-{
-  // Initialize the map for the elements' dominant colors
-  m_elementDominantMaterials = IntMap(&m_elems);
-
-  // Copy the dat for the elements
-  for(int eID = 0; eID < m_elems.size(); ++eID)
-    m_elementDominantMaterials[eID] = dominantMaterials[eID];
-
-  SLIC_ASSERT_MSG(m_elementDominantMaterials.isValid(),
-                  "Element dominant materials map is not valid.");
-}
-
-//--------------------------------------------------------------------------------
-
 void MIRMesh::constructElementShapeTypesMap(const std::vector<mir::Shape>& shapeTypes)
 {
   // Initialize the map for the elements' dominant colors

--- a/src/axom/mir/reference/MIRMesh.hpp
+++ b/src/axom/mir/reference/MIRMesh.hpp
@@ -156,21 +156,24 @@ private:
        * 
        * \param data  The vector of position data for each vertex.
        */
-  void constructVertexPositionMap(const std::vector<Point2>& data);
+  template <typename PointContainer>
+  void constructVertexPositionMap(const PointContainer& data);
 
   /**
        * \brief Constructs the map of elements to their original element parent.
        * 
        * \param cellParents  The vector of parent IDs for each element of the mesh.
        */
-  void constructElementParentMap(const std::vector<int>& elementParents);
+  template <typename IntContainer>
+  void constructElementParentMap(const IntContainer& elementParents);
 
   /**
        * \brief Constructs the map of elements to their dominant materials.
        * 
        * \param dominantMaterials  A vector of material ids that are the dominant material of each element.
        */
-  void constructElementDominantMaterialMap(const std::vector<int>& dominantMaterials);
+  template <typename IntContainer>
+  void constructElementDominantMaterialMap(const IntContainer& dominantMaterials);
 
   /**
        * \brief Constructs the map of elements to their shape types.

--- a/src/axom/mir/reference/MIRMesh.hpp
+++ b/src/axom/mir/reference/MIRMesh.hpp
@@ -10,17 +10,16 @@
  * \file MIRMesh.hpp
  * 
  * \brief Contains the specification for the MIRMesh class.
- * 
  */
 
-#include "axom/core.hpp"  // for axom macros
-#include "axom/slam.hpp"  // unified header for slam classes and functions
+#include "axom/core.hpp"
+#include "axom/slam.hpp"
 
 #include "axom/mir/reference/MIRMeshTypes.hpp"
 #include "axom/mir/reference/CellData.hpp"
 
 // C/C++ includes
-#include <cmath>  // for definition of M_PI, exp()
+#include <cmath>
 #include <vector>
 #include <string>
 #include <fstream>
@@ -38,47 +37,46 @@ const int NULL_MAT = -1;
 //--------------------------------------------------------------------------------
 
 /**
-   * \class MIRMesh
-   * 
-   * \brief The MIRMesh class represents a finite element mesh containing element volume fractions.
-   * 
-   * \detail This class is meant to be used in conjunction with the InterfaceReconstructor class
-   *         to process the mesh.
-   * 
-   */
+ * \class MIRMesh
+ * 
+ * \brief The MIRMesh class represents a finite element mesh containing element volume fractions.
+ * 
+ * \detail This class is meant to be used in conjunction with the InterfaceReconstructor class
+ *         to process the mesh.
+ */
 class MIRMesh
 {
 public:
   /**
-       * \brief Default constructor.
-       */
+   * \brief Default constructor.
+   */
   MIRMesh();
 
   /**
-       * \brief Copy constructor.
-       */
+   * \brief Copy constructor.
+   */
   MIRMesh(const MIRMesh& other);
 
   /**
-       * \brief Default destructor.
-       */
+   * \brief Default destructor.
+   */
   ~MIRMesh() = default;
 
   /**
-       * \brief Copy assignment.
-       */
+   * \brief Copy assignment.
+   */
   MIRMesh& operator=(const MIRMesh& other);
 
   /**
-       * \brief Initializes a mesh with the provided data and topology.
-       * 
-       * \param _verts  The set of vertices of the mesh.
-       * \param _elems  The set of elements of the mesh.
-       * \param _numMaterials  The number of materials present in the mesh.
-       * \param _topology  The topology/connectivity of the mesh.
-       * \param _mapData  The data used to initialized the maps associated with the vertex and element sets.
-       * \param _elementVF  The volume fractions of each element. Note that this is an optional parameter.
-       */
+   * \brief Initializes a mesh with the provided data and topology.
+   * 
+   * \param _verts  The set of vertices of the mesh.
+   * \param _elems  The set of elements of the mesh.
+   * \param _numMaterials  The number of materials present in the mesh.
+   * \param _topology  The topology/connectivity of the mesh.
+   * \param _mapData  The data used to initialized the maps associated with the vertex and element sets.
+   * \param _elementVF  The volume fractions of each element. Note that this is an optional parameter.
+   */
   void initializeMesh(const VertSet _verts,
                       const ElemSet _elems,
                       const int _numMaterials,
@@ -87,60 +85,60 @@ public:
                       const std::vector<std::vector<axom::float64>>& _elementVF = {});
 
   /**
-       * \brief Constructs the mesh boundary and coboundary relations.
-       * 
-       * \note The boundary relation is from each element to its vertices.
-       * \note The coboundary relation is from each vertex to its elements.
-       */
+   * \brief Constructs the mesh boundary and coboundary relations.
+   * 
+   * \note The boundary relation is from each element to its vertices.
+   * \note The coboundary relation is from each vertex to its elements.
+   */
   void constructMeshRelations();
 
   /**
-       * \brief Constructs the element and vertex volume fraction maps.
-       * 
-       * \param elementVF  The volume fractions of each element.
-       */
+   * \brief Constructs the element and vertex volume fraction maps.
+   * 
+   * \param elementVF  The volume fractions of each element.
+   */
   void constructMeshVolumeFractionsMaps(const std::vector<std::vector<axom::float64>>& elementVF);
 
   /**
-       * \brief Constructs the vertex volume fraction map.
-       * 
-       * \param vertexVF  The volume fractions of each vertex.
-       */
+   * \brief Constructs the vertex volume fraction map.
+   * 
+   * \param vertexVF  The volume fractions of each vertex.
+   */
   void constructMeshVolumeFractionsVertex(const std::vector<std::vector<axom::float64>>& vertexVF);
 
   /**
-       * \brief Prints out the data contained within this mesh in a nice format.
-       */
+   * \brief Prints out the data contained within this mesh in a nice format.
+   */
   void print();
 
   /**
-       * \brief Reads in a mesh specified by the given file.
-       * 
-       * \param filename  The location where the mesh file will be read from.
-       */
+   * \brief Reads in a mesh specified by the given file.
+   * 
+   * \param filename  The location where the mesh file will be read from.
+   */
   void readMeshFromFile(const std::string filename);
 
   /**
-       * \brief Writes out the mesh to the given file.
-       * 
-       * \param filename  The location where the mesh file will be written.
-       * 
-       * \note Currently reads in an ASCII, UNSTRUCTURED_GRID .vtk file.
-       */
+   * \brief Writes out the mesh to the given file.
+   * 
+   * \param filename  The location where the mesh file will be written.
+   * 
+   * \note Currently reads in an ASCII, UNSTRUCTURED_GRID .vtk file.
+   */
   void writeMeshToFile(const std::string& dirName,
                        const std::string& fileName,
                        const std::string& separator = "/");
 
   /**
-       * \brief  Computes the volume fractions of the elements of the original mesh.
-       */
+   * \brief  Computes the volume fractions of the elements of the original mesh.
+   */
   std::vector<std::vector<axom::float64>> computeOriginalElementVolumeFractions();
 
   /**
-       * \brief Checks that this instance of MIRMesh is valid
-       *
-       * \return True if this instance is valid, false otherwise
-       */
+   * \brief Checks that this instance of MIRMesh is valid
+   *
+   * \return True if this instance is valid, false otherwise
+   */
   bool isValid(bool verbose) const;
 
 private:
@@ -152,60 +150,63 @@ private:
   bool areMapsValid(bool verbose) const;
 
   /**
-       * \brief Constructs the positions map on the vertices.
-       * 
-       * \param data  The vector of position data for each vertex.
-       */
+   * \brief Constructs the positions map on the vertices.
+   * 
+   * \param data  A container of position data for each vertex
+   * (indexable by, e.g., an `axom::Array` or `std::vector`).
+   */
   template <typename PointContainer>
   void constructVertexPositionMap(const PointContainer& data);
 
   /**
-       * \brief Constructs the map of elements to their original element parent.
-       * 
-       * \param cellParents  The vector of parent IDs for each element of the mesh.
-       */
+   * \brief Constructs the map of elements to their original element parent.
+   * 
+   * \param elementParents  A container of parent IDs for each element of the mesh
+   *  (indexable by , e.g., an `axom::Array` or `std::vector`).
+   */
   template <typename IntContainer>
   void constructElementParentMap(const IntContainer& elementParents);
 
   /**
-       * \brief Constructs the map of elements to their dominant materials.
-       * 
-       * \param dominantMaterials  A vector of material ids that are the dominant material of each element.
-       */
+   * \brief Constructs the map of elements to their dominant materials.
+   * 
+   * \param dominantMaterials  A container of material ids that are the dominant
+   *  material of each element (indexable by, e.g., an `axom::Array` or `std::vector`).
+   */
   template <typename IntContainer>
   void constructElementDominantMaterialMap(const IntContainer& dominantMaterials);
 
   /**
-       * \brief Constructs the map of elements to their shape types.
-       * 
-       * \param shapeTypes  A vector of shape enumerators that are the shape type of each element.
-       */
+   * \brief Constructs the map of elements to their shape types.
+   * 
+   * \param shapeTypes  A vector of shape enumerators that are the shape type of each element.
+   */
   void constructElementShapeTypesMap(const std::vector<mir::Shape>& shapeTypes);
 
   /**
-       * \brief Computes the area of the triangle defined by the given three vertex positions using Heron's formula.
-       * 
-       * \param p0  The position of the first vertex.
-       * \param p1  The position of the second vertex.
-       * \param p2  The position of the third vertex.
-       */
+   * \brief Computes the area of the triangle defined by the given three vertex positions using Heron's formula.
+   * 
+   * \param p0  The position of the first vertex.
+   * \param p1  The position of the second vertex.
+   * \param p2  The position of the third vertex.
+   */
   axom::float64 computeTriangleArea(Point2 p0, Point2 p1, Point2 p2);
 
   /**
-       * \brief  Computes the area of the quad defined by the given four vertex positions.
-       * 
-       * \param p0  The position of the first vertex.
-       * \param p1  The position of the second vertex.
-       * \param p2  The position of the third vertex.
-       * \param p3  The position of the fourth vertex.
-       * 
-       * \note It is assumed that the points are given in consecutive, counter-clockwise order.
-       */
+   * \brief  Computes the area of the quad defined by the given four vertex positions.
+   * 
+   * \param p0  The position of the first vertex.
+   * \param p1  The position of the second vertex.
+   * \param p2  The position of the third vertex.
+   * \param p3  The position of the fourth vertex.
+   * 
+   * \note It is assumed that the points are given in consecutive, counter-clockwise order.
+   */
   axom::float64 computeQuadArea(Point2 p0, Point2 p1, Point2 p2, Point2 p3);
 
   /****************************************************************
-     *                        VARIABLES
-     ****************************************************************/
+   *                        VARIABLES
+   ****************************************************************/
 public:
   // Mesh Set Definitions
   VertSet m_verts;  // the set of vertices in the mesh
@@ -228,5 +229,47 @@ public:
 };
 
 //--------------------------------------------------------------------------------
+
+template <typename PointContainer>
+void MIRMesh::constructVertexPositionMap(const PointContainer& data)
+{
+  // construct the position map on the vertices
+  m_vertexPositions = PointMap(&m_verts);
+
+  for(int vID = 0; vID < m_verts.size(); ++vID) m_vertexPositions[vID] = data[vID];
+
+  SLIC_ASSERT_MSG(m_vertexPositions.isValid(), "Position map is not valid.");
+}
+
+//--------------------------------------------------------------------------------
+
+template <typename IntContainer>
+void MIRMesh::constructElementParentMap(const IntContainer& elementParents)
+{
+  // Initialize the map for the elements' parent IDs
+  m_elementParentIDs = IntMap(&m_elems);
+
+  // Copy the data for the elements
+  for(int eID = 0; eID < m_elems.size(); ++eID) m_elementParentIDs[eID] = elementParents[eID];
+
+  SLIC_ASSERT_MSG(m_elementParentIDs.isValid(), "Element parent map is not valid.");
+}
+
+//--------------------------------------------------------------------------------
+
+template <typename IntContainer>
+void MIRMesh::constructElementDominantMaterialMap(const IntContainer& dominantMaterials)
+{
+  // Initialize the map for the elements' dominant colors
+  m_elementDominantMaterials = IntMap(&m_elems);
+
+  // Copy the dat for the elements
+  for(int eID = 0; eID < m_elems.size(); ++eID)
+    m_elementDominantMaterials[eID] = dominantMaterials[eID];
+
+  SLIC_ASSERT_MSG(m_elementDominantMaterials.isValid(),
+                  "Element dominant materials map is not valid.");
+}
+
 }  // namespace mir
 }  // namespace axom

--- a/src/axom/mir/reference/MIRMeshTypes.hpp
+++ b/src/axom/mir/reference/MIRMeshTypes.hpp
@@ -54,8 +54,8 @@ using VertToElemRelation =
 
 // MAP TYPE ALIASES
 using BaseSet = slam::Set<PosType, ElemType>;
-using ScalarMap = slam::ArrayMap<BaseSet, axom::float64>;
-using PointMap = slam::ArrayMap<BaseSet, Point2>;
-using IntMap = slam::ArrayMap<BaseSet, int>;
+using ScalarMap = slam::Map<axom::float64, BaseSet>;
+using PointMap = slam::Map<Point2, BaseSet>;
+using IntMap = slam::Map<int, BaseSet>;
 }  // namespace mir
 }  // namespace axom

--- a/src/axom/mir/reference/MIRMeshTypes.hpp
+++ b/src/axom/mir/reference/MIRMeshTypes.hpp
@@ -12,7 +12,7 @@
  * \brief Contains the specifications for types aliases used throughout the MIR component.
  */
 
-#include "axom/core.hpp"  // for axom macros
+#include "axom/core.hpp"
 #include "axom/slam.hpp"
 #include "axom/primal.hpp"
 
@@ -54,8 +54,8 @@ using VertToElemRelation =
 
 // MAP TYPE ALIASES
 using BaseSet = slam::Set<PosType, ElemType>;
-using ScalarMap = slam::Map<axom::float64, BaseSet>;
-using PointMap = slam::Map<Point2, BaseSet>;
-using IntMap = slam::Map<int, BaseSet>;
+using ScalarMap = slam::ArrayMap<BaseSet, axom::float64>;
+using PointMap = slam::ArrayMap<BaseSet, Point2>;
+using IntMap = slam::ArrayMap<BaseSet, int>;
 }  // namespace mir
 }  // namespace axom

--- a/src/axom/multimat/examples/calculate.cpp
+++ b/src/axom/multimat/examples/calculate.cpp
@@ -7,8 +7,7 @@
 /**
  * \file calculate.cpp
  *
- * \brief Examples using MultiMat to do some calculation common in physics
- * simulation.
+ * \brief Examples using MultiMat to do some calculation common in physics simulation.
  */
 
 #include "axom/multimat/multimat.hpp"
@@ -39,10 +38,8 @@ using Field2DT = MultiMat::Field2D<double, B>;
 template <DataLayout D, typename B>
 using Field2DTempT = MultiMat::Field2DTemplated<double, D, B>;
 
-using ArrayViewIndirection = slam::policies::ArrayViewIndirection<slam::DefaultPositionType, double>;
-
 template <typename B>
-using BiVarMapT = slam::BivariateMap<double, B, ArrayViewIndirection>;
+using BiVarMapT = slam::ArrayViewBivariateMap<B, double>;
 
 enum class MMFieldMethod
 {

--- a/src/axom/multimat/examples/calculate.cpp
+++ b/src/axom/multimat/examples/calculate.cpp
@@ -189,11 +189,7 @@ struct FieldGetter<MMFieldMethod::SlamTmplStrideField, typename MultiMat::Produc
 {
   using VirtualBSet = typename MultiMat::ProductSetType;
   using BSet = ConcreteProdSet;
-  using SlamBMap = BiVarMapT<BSet>;
-  using Stride = slam::policies::StrideOne<int>;
-  using Ind = typename SlamBMap::IndirectionPolicy;
-
-  using SlamBMapStrided = slam::BivariateMap<double, BSet, Ind, Stride>;
+  using SlamBMapStrided = slam::ArrayViewBivariateMap<BSet, double>;
 
   static SlamBMapStrided get(MultiMat& mm, const std::string& fieldName)
   {
@@ -215,11 +211,7 @@ struct FieldGetter<MMFieldMethod::SlamTmplField, typename MultiMat::RelationSetT
 {
   using VirtualBSet = typename MultiMat::RelationSetType;
   using BSet = ConcreteRelationSet;
-  using SlamBMap = BiVarMapT<BSet>;
-  using Stride = slam::policies::StrideOne<int>;
-  using Ind = typename SlamBMap::IndirectionPolicy;
-
-  using SlamBMapStrided = slam::BivariateMap<double, BSet, Ind, Stride>;
+  using SlamBMapStrided = slam::ArrayViewBivariateMap<BSet, double>;
 
   static SlamBMapStrided get(MultiMat& mm, const std::string& fieldName)
   {

--- a/src/axom/multimat/examples/calculate.cpp
+++ b/src/axom/multimat/examples/calculate.cpp
@@ -38,8 +38,11 @@ using Field2DT = MultiMat::Field2D<double, B>;
 template <DataLayout D, typename B>
 using Field2DTempT = MultiMat::Field2DTemplated<double, D, B>;
 
+// ArrayView indirection over the example's position type
+using ArrayViewIndirection = slam::policies::ArrayViewIndirection<slam::DefaultPositionType, double>;
+
 template <typename B>
-using BiVarMapT = slam::ArrayViewBivariateMap<B, double>;
+using BiVarMapT = slam::BivariateMap<double, B, ArrayViewIndirection>;
 
 enum class MMFieldMethod
 {
@@ -189,7 +192,7 @@ struct FieldGetter<MMFieldMethod::SlamTmplStrideField, typename MultiMat::Produc
 {
   using VirtualBSet = typename MultiMat::ProductSetType;
   using BSet = ConcreteProdSet;
-  using SlamBMapStrided = slam::ArrayViewBivariateMap<BSet, double>;
+  using SlamBMapStrided = slam::BivariateMap<double, BSet, ArrayViewIndirection>;
 
   static SlamBMapStrided get(MultiMat& mm, const std::string& fieldName)
   {
@@ -211,7 +214,7 @@ struct FieldGetter<MMFieldMethod::SlamTmplField, typename MultiMat::RelationSetT
 {
   using VirtualBSet = typename MultiMat::RelationSetType;
   using BSet = ConcreteRelationSet;
-  using SlamBMapStrided = slam::ArrayViewBivariateMap<BSet, double>;
+  using SlamBMapStrided = slam::BivariateMap<double, BSet, ArrayViewIndirection>;
 
   static SlamBMapStrided get(MultiMat& mm, const std::string& fieldName)
   {

--- a/src/axom/multimat/multimat.hpp
+++ b/src/axom/multimat/multimat.hpp
@@ -66,22 +66,25 @@ class MMField2DTemplated;
 class MultiMat
 {
 protected:
-  // SLAM Set type definitions
+  // Slam Set type definitions
   using SetPosType = slam::DefaultPositionType;
   using SetElemType = slam::DefaultPositionType;
   using SetType = slam::Set<SetPosType, SetElemType>;
   using RangeSetType = slam::RangeSet<SetPosType, SetElemType>::ConcreteSet;
 
 public:
-  // SLAM Bivariate set type definitions
+  // Slam Bivariate set type definitions
   using BivariateSetType = slam::BivariateSet<RangeSetType, RangeSetType>;
   using ProductSetType = slam::ProductSet<RangeSetType, RangeSetType>;
 
 private:
-  // SLAM Relation typedef
+  // Slam Relation typedef
   using IndBufferType = axom::Array<SetPosType>;
   template <typename T>
   using IndViewPolicy = slam::policies::ArrayViewIndirection<SetPosType, T>;
+
+  // Multi-component fields have a runtime stride
+  using MapStrideType = slam::policies::RuntimeStride<SetPosType>;
 
   using VariableCardinality =
     slam::policies::MappedVariableCardinality<SetPosType, IndViewPolicy<SetElemType>>;
@@ -90,19 +93,22 @@ private:
 
   using DynamicVariableRelationType = slam::DynamicVariableRelation<RangeSetType, RangeSetType>;
 
+  // A field over a single set, viewing an externally-managed buffer, with runtime stride.
   template <typename T>
-  using MapType = slam::RuntimeArrayViewMap<RangeSetType, T>;
+  using MapType = slam::Map<T, RangeSetType, IndViewPolicy<T>, MapStrideType>;
 
+  // A field over a bivariate set, viewing an externally-managed buffer, with runtime stride.
   template <typename T, typename BSet = BivariateSetType>
-  using BivariateMapType = slam::RuntimeArrayViewBivariateMap<BSet, T>;
+  using BivariateMapType = slam::BivariateMap<T, BSet, IndViewPolicy<T>, MapStrideType>;
 
+  // As above, but with compile-time stride 1 (Slam's default stride policy).
   template <typename T, typename BSet = BivariateSetType>
-  using BivariateMapTypeStrideOne = slam::ArrayViewBivariateMap<BSet, T>;
+  using BivariateMapTypeStrideOne = slam::BivariateMap<T, BSet, IndViewPolicy<T>>;
 
 public:
   using SparseRelationType = StaticVariableRelationType;
 
-  // SLAM RelationSet for the set of non-zero cell to mat variables
+  // Slam RelationSet for the set of non-zero cell to mat variables
   using RelationSetType = slam::RelationSet<StaticVariableRelationType>;  //, RangeSetType
   using RelationSetDynType = slam::RelationSet<DynamicVariableRelationType>;
 
@@ -112,9 +118,6 @@ public:
   using Field1D = MapType<T>;
 
   //2D Field
-  //old
-  //template <typename T, typename BSet = BivariateSetType>
-  //using Field2D = BivariateMapType<T,BSet>;
   template <typename T, typename BSet = BivariateSetType>
   using Field2D = MMField2D<T, BSet>;
   //special
@@ -432,7 +435,8 @@ public:
   Field2DTemplated<T, D, B> getTemplated2DField(const std::string& field_name);
 
   template <typename T, typename BSetType>
-  slam::ArrayViewBivariateMap<BSetType, T> get2dFieldAsSlamBivarMap(const std::string& field_name);
+  slam::BivariateMap<T, BSetType, IndViewPolicy<T>> get2dFieldAsSlamBivarMap(
+    const std::string& field_name);
 
   /**
    * \brief Get the volume fraction field
@@ -1231,7 +1235,8 @@ MultiMat::Field2DTemplated<T, D, B> MultiMat::getTemplated2DField(const std::str
 
 // Warning: The return type uses a compile time stride of one!
 template <typename T, typename BSetType>
-slam::ArrayViewBivariateMap<BSetType, T> MultiMat::get2dFieldAsSlamBivarMap(const std::string& field_name)
+slam::BivariateMap<T, BSetType, MultiMat::IndViewPolicy<T>> MultiMat::get2dFieldAsSlamBivarMap(
+  const std::string& field_name)
 {
   // Get a reference to the unspecialized BMap
   auto bmap = get2dField<T>(field_name);
@@ -1241,7 +1246,9 @@ slam::ArrayViewBivariateMap<BSetType, T> MultiMat::get2dFieldAsSlamBivarMap(cons
   BSetType bsetValue = getCompatibleBivarSet<BSetType>(fieldIdx);
 
   // Create instance of templated BivariateMap
-  slam::ArrayViewBivariateMap<BSetType, T> typedBMap(bsetValue, bmap.getMap()->data(), bmap.stride());
+  slam::BivariateMap<T, BSetType, IndViewPolicy<T>> typedBMap(bsetValue,
+                                                              bmap.getMap()->data(),
+                                                              bmap.stride());
 
   return typedBMap;
 }

--- a/src/axom/multimat/multimat.hpp
+++ b/src/axom/multimat/multimat.hpp
@@ -90,19 +90,14 @@ private:
 
   using DynamicVariableRelationType = slam::DynamicVariableRelation<RangeSetType, RangeSetType>;
 
-  // SLAM Map type
-  using MapStrideType = slam::policies::RuntimeStride<SetPosType>;
-
   template <typename T>
-  using MapType = typename slam::Map<T, RangeSetType, IndViewPolicy<T>, MapStrideType>::ConcreteMap;
+  using MapType = slam::RuntimeArrayViewMap<RangeSetType, T>;
 
   template <typename T, typename BSet = BivariateSetType>
-  using BivariateMapType =  //this one has runtime stride
-    typename slam::BivariateMap<T, BSet, IndViewPolicy<T>, MapStrideType>::ConcreteMap;
+  using BivariateMapType = slam::RuntimeArrayViewBivariateMap<BSet, T>;
 
   template <typename T, typename BSet = BivariateSetType>
-  using BivariateMapTypeStrideOne =  //this one has compile time stride 1
-    typename slam::BivariateMap<T, BSet, IndViewPolicy<T>>::ConcreteMap;
+  using BivariateMapTypeStrideOne = slam::ArrayViewBivariateMap<BSet, T>;
 
 public:
   using SparseRelationType = StaticVariableRelationType;
@@ -437,8 +432,7 @@ public:
   Field2DTemplated<T, D, B> getTemplated2DField(const std::string& field_name);
 
   template <typename T, typename BSetType>
-  slam::BivariateMap<T, BSetType, IndViewPolicy<T>> get2dFieldAsSlamBivarMap(
-    const std::string& field_name);
+  slam::ArrayViewBivariateMap<BSetType, T> get2dFieldAsSlamBivarMap(const std::string& field_name);
 
   /**
    * \brief Get the volume fraction field
@@ -1237,8 +1231,7 @@ MultiMat::Field2DTemplated<T, D, B> MultiMat::getTemplated2DField(const std::str
 
 // Warning: The return type uses a compile time stride of one!
 template <typename T, typename BSetType>
-slam::BivariateMap<T, BSetType, MultiMat::IndViewPolicy<T>> MultiMat::get2dFieldAsSlamBivarMap(
-  const std::string& field_name)
+slam::ArrayViewBivariateMap<BSetType, T> MultiMat::get2dFieldAsSlamBivarMap(const std::string& field_name)
 {
   // Get a reference to the unspecialized BMap
   auto bmap = get2dField<T>(field_name);
@@ -1248,9 +1241,7 @@ slam::BivariateMap<T, BSetType, MultiMat::IndViewPolicy<T>> MultiMat::get2dField
   BSetType bsetValue = getCompatibleBivarSet<BSetType>(fieldIdx);
 
   // Create instance of templated BivariateMap
-  slam::BivariateMap<T, BSetType, IndViewPolicy<T>> typedBMap(bsetValue,
-                                                              bmap.getMap()->data(),
-                                                              bmap.stride());
+  slam::ArrayViewBivariateMap<BSetType, T> typedBMap(bsetValue, bmap.getMap()->data(), bmap.stride());
 
   return typedBMap;
 }

--- a/src/axom/quest/InOutOctree.hpp
+++ b/src/axom/quest/InOutOctree.hpp
@@ -87,6 +87,7 @@ private:
 public:
   using OctreeBaseType = spin::OctreeBase<DIM, InOutBlockData>;
   using SpatialOctreeType = spin::SpatialOctree<DIM, InOutBlockData>;
+  using OctreeLevels = typename OctreeBaseType::OctreeLevels;
 
   using GeometricBoundingBox = typename SpatialOctreeType::GeometricBoundingBox;
   using SpacePt = typename SpatialOctreeType::SpacePt;
@@ -124,7 +125,7 @@ public:
 
   // Type aliases for the Relations from Gray leaf blocks to mesh entities
   static const int MAX_VERTS_PER_BLOCK = 1;
-  using VertexBlockMap = slam::Map<BlockIndex>;
+  using VertexBlockMap = slam::ArrayMap<MeshVertexSet, BlockIndex>;
 
   using GrayLeafSet = slam::PositionSet<>;
   using GrayLeafVertexRelation =
@@ -133,9 +134,9 @@ public:
   using GrayLeafElementRelation = slam::VariableRelation<GrayLeafSet, MeshElementSet>;
   using CellIndexSet = typename GrayLeafElementRelation::RelationSubset;
 
-  using GrayLeafsLevelMap = slam::Map<GrayLeafSet>;
-  using GrayLeafVertexRelationLevelMap = slam::Map<GrayLeafVertexRelation>;
-  using GrayLeafElementRelationLevelMap = slam::Map<GrayLeafElementRelation>;
+  using GrayLeafsLevelMap = slam::ArrayMap<OctreeLevels, GrayLeafSet>;
+  using GrayLeafVertexRelationLevelMap = slam::ArrayMap<OctreeLevels, GrayLeafVertexRelation>;
+  using GrayLeafElementRelationLevelMap = slam::ArrayMap<OctreeLevels, GrayLeafElementRelation>;
 
 public:
   /**

--- a/src/axom/quest/InOutOctree.hpp
+++ b/src/axom/quest/InOutOctree.hpp
@@ -125,17 +125,12 @@ public:
   // Type aliases for the Relations from Gray leaf blocks to mesh entities
   static const int MAX_VERTS_PER_BLOCK = 1;
   using VertexBlockMap = slam::Map<BlockIndex>;
-  using ArrayIndirection = slam::policies::ArrayIndirection<VertexIndex, VertexIndex>;
 
   using GrayLeafSet = slam::PositionSet<>;
-  using BVStride = slam::policies::CompileTimeStride<VertexIndex, MAX_VERTS_PER_BLOCK>;
-  using ConstantCardinality = slam::policies::ConstantCardinality<VertexIndex, BVStride>;
   using GrayLeafVertexRelation =
-    slam::StaticRelation<VertexIndex, VertexIndex, ConstantCardinality, ArrayIndirection, GrayLeafSet, MeshVertexSet>;
+    slam::ConstantRelation<GrayLeafSet, MeshVertexSet, MAX_VERTS_PER_BLOCK>;
 
-  using VariableCardinality = slam::policies::VariableCardinality<VertexIndex, ArrayIndirection>;
-  using GrayLeafElementRelation =
-    slam::StaticRelation<VertexIndex, VertexIndex, VariableCardinality, ArrayIndirection, GrayLeafSet, MeshElementSet>;
+  using GrayLeafElementRelation = slam::VariableRelation<GrayLeafSet, MeshElementSet>;
   using CellIndexSet = typename GrayLeafElementRelation::RelationSubset;
 
   using GrayLeafsLevelMap = slam::Map<GrayLeafSet>;

--- a/src/axom/quest/InOutOctree.hpp
+++ b/src/axom/quest/InOutOctree.hpp
@@ -125,7 +125,7 @@ public:
 
   // Type aliases for the Relations from Gray leaf blocks to mesh entities
   static const int MAX_VERTS_PER_BLOCK = 1;
-  using VertexBlockMap = slam::ArrayMap<MeshVertexSet, BlockIndex>;
+  using VertexBlockMap = slam::Map<BlockIndex, MeshVertexSet>;
 
   using GrayLeafSet = slam::PositionSet<>;
   using GrayLeafVertexRelation =
@@ -134,9 +134,9 @@ public:
   using GrayLeafElementRelation = slam::VariableRelation<GrayLeafSet, MeshElementSet>;
   using CellIndexSet = typename GrayLeafElementRelation::RelationSubset;
 
-  using GrayLeafsLevelMap = slam::ArrayMap<OctreeLevels, GrayLeafSet>;
-  using GrayLeafVertexRelationLevelMap = slam::ArrayMap<OctreeLevels, GrayLeafVertexRelation>;
-  using GrayLeafElementRelationLevelMap = slam::ArrayMap<OctreeLevels, GrayLeafElementRelation>;
+  using GrayLeafsLevelMap = slam::Map<GrayLeafSet, OctreeLevels>;
+  using GrayLeafVertexRelationLevelMap = slam::Map<GrayLeafVertexRelation, OctreeLevels>;
+  using GrayLeafElementRelationLevelMap = slam::Map<GrayLeafElementRelation, OctreeLevels>;
 
 public:
   /**

--- a/src/axom/quest/InOutOctree.hpp
+++ b/src/axom/quest/InOutOctree.hpp
@@ -125,17 +125,17 @@ public:
   // Type aliases for the Relations from Gray leaf blocks to mesh entities
   static const int MAX_VERTS_PER_BLOCK = 1;
   using VertexBlockMap = slam::Map<BlockIndex>;
-  using STLIndirection = slam::policies::STLVectorIndirection<VertexIndex, VertexIndex>;
+  using ArrayIndirection = slam::policies::ArrayIndirection<VertexIndex, VertexIndex>;
 
   using GrayLeafSet = slam::PositionSet<>;
   using BVStride = slam::policies::CompileTimeStride<VertexIndex, MAX_VERTS_PER_BLOCK>;
   using ConstantCardinality = slam::policies::ConstantCardinality<VertexIndex, BVStride>;
   using GrayLeafVertexRelation =
-    slam::StaticRelation<VertexIndex, VertexIndex, ConstantCardinality, STLIndirection, GrayLeafSet, MeshVertexSet>;
+    slam::StaticRelation<VertexIndex, VertexIndex, ConstantCardinality, ArrayIndirection, GrayLeafSet, MeshVertexSet>;
 
-  using VariableCardinality = slam::policies::VariableCardinality<VertexIndex, STLIndirection>;
+  using VariableCardinality = slam::policies::VariableCardinality<VertexIndex, ArrayIndirection>;
   using GrayLeafElementRelation =
-    slam::StaticRelation<VertexIndex, VertexIndex, VariableCardinality, STLIndirection, GrayLeafSet, MeshElementSet>;
+    slam::StaticRelation<VertexIndex, VertexIndex, VariableCardinality, ArrayIndirection, GrayLeafSet, MeshElementSet>;
   using CellIndexSet = typename GrayLeafElementRelation::RelationSubset;
 
   using GrayLeafsLevelMap = slam::Map<GrayLeafSet>;

--- a/src/axom/quest/ScatteredInterpolation.hpp
+++ b/src/axom/quest/ScatteredInterpolation.hpp
@@ -271,8 +271,7 @@ private:
   using MortonIndexType = std::uint64_t;
 
   using VertexSet = typename DelaunayTriangulation::IAMeshType::VertexSet;
-  using VertexIndirectionSet =
-    slam::ArrayIndirectionSet<typename VertexSet::PositionType, axom::IndexType>;
+  using VertexIndirectionSet = slam::ArraySet<typename VertexSet::PositionType, axom::IndexType>;
 
 private:
   /**

--- a/src/axom/quest/detail/inout/InOutOctreeMeshDumper.hpp
+++ b/src/axom/quest/detail/inout/InOutOctreeMeshDumper.hpp
@@ -63,10 +63,11 @@ public:
   using CellVertIndices = typename MeshWrapper<DIM>::CellVertIndices;
   using GeometricBoundingBox = typename InOutOctreeType::GeometricBoundingBox;
   using SpaceCell = typename InOutOctreeType::SpaceCell;
+  using LeafSet = slam::PositionSet<>;
 
-  using LeafVertMap = slam::Map<VertexIndex>;
-  using LeafIntMap = slam::Map<axom::IndexType>;
-  using LeafGridPtMap = slam::Map<GridPt>;
+  using LeafVertMap = slam::ArrayMap<LeafSet, VertexIndex>;
+  using LeafIntMap = slam::ArrayMap<LeafSet, axom::IndexType>;
+  using LeafGridPtMap = slam::ArrayMap<LeafSet, GridPt>;
 
   using DebugMesh = mint::UnstructuredMesh<mint::MIXED_SHAPE>;
 
@@ -131,7 +132,7 @@ public:
       return;
     }
 
-    using LevelGridIntMap = slam::Map<GridIntMap>;
+    using LevelGridIntMap = slam::ArrayMap<OctreeLevels, GridIntMap>;
     LevelGridIntMap diffBlocks(&(m_octree.m_levels));
 
     int totalBlocks = 0;
@@ -216,7 +217,7 @@ public:
     const bool hasColors = (m_generationState >= InOutOctreeType::INOUTOCTREE_LEAVES_COLORED);
 
     // Allocate Slam Maps for the field data
-    slam::PositionSet<> leafSet(blocks.size());
+    LeafSet leafSet(blocks.size());
 
     LeafVertMap leafVertID(&leafSet);
     LeafVertMap leafVertID_unique(&leafSet);
@@ -412,7 +413,9 @@ private:
   using Base::CellIndexSet;
   using Base::CellVertIndices;
   using Base::DebugMesh;
+  using Base::GeometricBoundingBox;
   using Base::InOutOctreeType;
+  using Base::SpaceCell;
   using Base::SpacePt;
   using Base::VertexIndex;
 
@@ -620,7 +623,9 @@ private:
   using Base::CellIndexSet;
   using Base::CellVertIndices;
   using Base::DebugMesh;
+  using Base::GeometricBoundingBox;
   using Base::InOutOctreeType;
+  using Base::SpaceCell;
   using Base::SpacePt;
   using Base::VertexIndex;
 

--- a/src/axom/quest/detail/inout/InOutOctreeMeshDumper.hpp
+++ b/src/axom/quest/detail/inout/InOutOctreeMeshDumper.hpp
@@ -65,9 +65,9 @@ public:
   using SpaceCell = typename InOutOctreeType::SpaceCell;
   using LeafSet = slam::PositionSet<>;
 
-  using LeafVertMap = slam::ArrayMap<LeafSet, VertexIndex>;
-  using LeafIntMap = slam::ArrayMap<LeafSet, axom::IndexType>;
-  using LeafGridPtMap = slam::ArrayMap<LeafSet, GridPt>;
+  using LeafVertMap = slam::Map<VertexIndex, LeafSet>;
+  using LeafIntMap = slam::Map<axom::IndexType, LeafSet>;
+  using LeafGridPtMap = slam::Map<GridPt, LeafSet>;
 
   using DebugMesh = mint::UnstructuredMesh<mint::MIXED_SHAPE>;
 
@@ -132,7 +132,7 @@ public:
       return;
     }
 
-    using LevelGridIntMap = slam::ArrayMap<OctreeLevels, GridIntMap>;
+    using LevelGridIntMap = slam::Map<GridIntMap, OctreeLevels>;
     LevelGridIntMap diffBlocks(&(m_octree.m_levels));
 
     int totalBlocks = 0;

--- a/src/axom/quest/detail/inout/InOutOctreeStats.hpp
+++ b/src/axom/quest/detail/inout/InOutOctreeStats.hpp
@@ -42,10 +42,12 @@ public:
   using OctreeBaseType = typename InOutOctreeType::OctreeBaseType;
   using OctreeLevels = typename OctreeBaseType::OctreeLevels;
   using BlockIndex = typename OctreeBaseType::BlockIndex;
+  using MeshVertexSet = typename MeshWrapper<DIM>::MeshVertexSet;
+  using MeshElementSet = typename MeshWrapper<DIM>::MeshElementSet;
 
-  using LeafCountMap = slam::Map<int>;
-  using CellCountMap = slam::Map<int>;
-  using CardinalityVCMap = slam::Map<int>;
+  using LeafCountMap = slam::ArrayMap<OctreeLevels, int>;
+  using CellCountMap = slam::ArrayMap<MeshElementSet, int>;
+  using CardinalityVCMap = slam::ArrayMap<MeshVertexSet, int>;
 
   using LogHistogram = std::map<int, int>;
   using MinMaxRange = primal::BoundingBox<double, 1>;

--- a/src/axom/quest/detail/inout/InOutOctreeStats.hpp
+++ b/src/axom/quest/detail/inout/InOutOctreeStats.hpp
@@ -45,9 +45,9 @@ public:
   using MeshVertexSet = typename MeshWrapper<DIM>::MeshVertexSet;
   using MeshElementSet = typename MeshWrapper<DIM>::MeshElementSet;
 
-  using LeafCountMap = slam::ArrayMap<OctreeLevels, int>;
-  using CellCountMap = slam::ArrayMap<MeshElementSet, int>;
-  using CardinalityVCMap = slam::ArrayMap<MeshVertexSet, int>;
+  using LeafCountMap = slam::Map<int, OctreeLevels>;
+  using CellCountMap = slam::Map<int, MeshElementSet>;
+  using CardinalityVCMap = slam::Map<int, MeshVertexSet>;
 
   using LogHistogram = std::map<int, int>;
   using MinMaxRange = primal::BoundingBox<double, 1>;

--- a/src/axom/quest/detail/inout/MeshWrapper.hpp
+++ b/src/axom/quest/detail/inout/MeshWrapper.hpp
@@ -56,16 +56,12 @@ public:
   using SpaceVector = primal::Vector<double, DIM>;
   using GeometricBoundingBox = primal::BoundingBox<double, DIM>;
 
-  using VertexIndexMap = slam::Map<VertexIndex>;
-  using VertexPositionMap = slam::Map<SpacePt>;
+  using VertexIndexMap = slam::ArrayMap<MeshVertexSet, VertexIndex>;
+  using VertexPositionMap = slam::ArrayMap<MeshVertexSet, SpacePt>;
 
   /// Always DIM verts since we're representing a d-dimensional simplicial mesh in dimension d
   static constexpr int NUM_CELL_VERTS = DIM;
-  using STLIndirection = slam::policies::STLVectorIndirection<VertexIndex, VertexIndex>;
-  using TVStride = slam::policies::CompileTimeStride<VertexIndex, NUM_CELL_VERTS>;
-  using ConstantCardinality = slam::policies::ConstantCardinality<VertexIndex, TVStride>;
-  using CellVertexRelation =
-    slam::StaticRelation<VertexIndex, VertexIndex, ConstantCardinality, STLIndirection, MeshElementSet, MeshVertexSet>;
+  using CellVertexRelation = slam::ConstantRelation<MeshElementSet, MeshVertexSet, NUM_CELL_VERTS>;
   using CellVertIndices = typename CellVertexRelation::RelationSubset;
 
   // \brief A vertex index to indicate that there is no associated vertex
@@ -259,7 +255,7 @@ protected:
 
   VertexPositionMap m_vertexPositions;
 
-  std::vector<VertexIndex> m_cv_data;
+  axom::Array<VertexIndex> m_cv_data;
   CellVertexRelation m_cellToVertexRelation;
 
   bool m_meshWasReindexed {false};

--- a/src/axom/quest/detail/inout/MeshWrapper.hpp
+++ b/src/axom/quest/detail/inout/MeshWrapper.hpp
@@ -56,8 +56,8 @@ public:
   using SpaceVector = primal::Vector<double, DIM>;
   using GeometricBoundingBox = primal::BoundingBox<double, DIM>;
 
-  using VertexIndexMap = slam::ArrayMap<MeshVertexSet, VertexIndex>;
-  using VertexPositionMap = slam::ArrayMap<MeshVertexSet, SpacePt>;
+  using VertexIndexMap = slam::Map<VertexIndex, MeshVertexSet>;
+  using VertexPositionMap = slam::Map<SpacePt, MeshVertexSet>;
 
   /// Always DIM verts since we're representing a d-dimensional simplicial mesh in dimension d
   static constexpr int NUM_CELL_VERTS = DIM;

--- a/src/axom/slam/Aliases.hpp
+++ b/src/axom/slam/Aliases.hpp
@@ -1,0 +1,251 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+// files for dates and other details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ * \file Aliases.hpp
+ *
+ * \brief Blessed, user-facing aliases for Slam's common set/relation/map types.
+ *
+ * Slam's containers are assembled from policy template parameters, which can be verbose.
+ * This header names the combinations that most Axom code actually wants:
+ *
+ *   - \c RangeSet<P,E>                -- a contiguous range of positions (from RangeSet.hpp)
+ *   - \c ArraySet<P,E>                -- a set that binds an external \c axom::Array
+ *   - \c ArrayViewSet<P,E>            -- a set that binds an \c axom::ArrayView by value
+ *   - \c VariableRelation<F,T>        -- an Array-backed static relation with variable cardinality
+ *   - \c VariableRelationView<F,T>    -- an ArrayView-backed static relation with variable cardinality
+ *   - \c ConstantRelation<F,T,N>      -- an Array-backed static relation with compile-time cardinality N
+ *   - \c ConstantRelationView<F,T,N>  -- an ArrayView-backed static relation with compile-time cardinality N
+ *   - \c RuntimeConstantRelation<F,T> -- an Array-backed static relation with runtime constant cardinality
+ *   - \c ArrayMap<S,T,STRIDE>         -- an Array-backed map from set S to T
+ *   - \c ArrayViewMap<S,T,STRIDE>     -- an ArrayView-backed map from set S to T
+ *   - \c RuntimeArrayMap<S,T>         -- an Array-backed map with runtime stride
+ *   - \c RuntimeArrayViewMap<S,T>     -- an ArrayView-backed map with runtime stride
+ *   - \c ArrayBivariateMap<BSet,T>     -- an Array-backed bivariate map
+ *   - \c ArrayViewBivariateMap<BSet,T> -- an ArrayView-backed bivariate map
+ */
+
+#ifndef SLAM_ALIASES_H_
+#define SLAM_ALIASES_H_
+
+#include "axom/slam/RangeSet.hpp"
+#include "axom/slam/IndirectionSet.hpp"
+#include "axom/slam/StaticRelation.hpp"
+#include "axom/slam/Map.hpp"
+#include "axom/slam/BivariateMap.hpp"
+
+#include "axom/slam/policies/CardinalityPolicies.hpp"
+#include "axom/slam/policies/IndirectionPolicies.hpp"
+#include "axom/slam/policies/StridePolicies.hpp"
+
+namespace axom
+{
+namespace slam
+{
+/*!
+ * \brief A set whose \a ElemType elements are stored in an external \c axom::Array.
+ *
+ * This is the canonical Axom indirection set for binding an \c axom::Array buffer.
+ * The array object is managed outside the set and must outlive it.
+ * \sa ArrayViewSet for the non-owning, device-capturable form
+ */
+template <typename PosType = DefaultPositionType, typename ElemType = DefaultElementType>
+using ArraySet = ArrayIndirectionSet<PosType, ElemType>;
+
+/*!
+ * \brief A set whose \a ElemType elements are viewed through an \c axom::ArrayView.
+ *
+ * The view is stored by value, so this is the preferred indirection-set shape
+ * for device-capturable views over storage owned elsewhere.
+ */
+template <typename PosType = DefaultPositionType, typename ElemType = DefaultElementType>
+using ArrayViewSet = ArrayViewIndirectionSet<PosType, ElemType>;
+
+/*!
+ * \brief A static relation from \a FromSet to \a ToSet with per-element (variable) cardinality,
+ *  binding offsets and indices in external \c axom::Array buffers.
+ *
+ * This is the type produced by the \c axom::Array overload of \c make_variable_relation.
+ */
+template <typename FromSet,
+          typename ToSet,
+          typename PosType = typename FromSet::PositionType,
+          typename ElemType = typename ToSet::PositionType>
+using VariableRelation =
+  StaticRelation<PosType,
+                 ElemType,
+                 policies::VariableCardinality<PosType, policies::ArrayIndirection<PosType, PosType>>,
+                 policies::ArrayIndirection<PosType, ElemType>,
+                 FromSet,
+                 ToSet>;
+
+/*!
+ * \brief A static relation view from \a FromSet to \a ToSet with per-element
+ *  (variable) cardinality, binding offsets and indices through \c axom::ArrayView.
+ */
+template <typename FromSet,
+          typename ToSet,
+          typename PosType = typename FromSet::PositionType,
+          typename ElemType = typename ToSet::PositionType>
+using VariableRelationView =
+  StaticRelation<PosType,
+                 ElemType,
+                 policies::VariableCardinality<PosType, policies::ArrayViewIndirection<PosType, PosType>>,
+                 policies::ArrayViewIndirection<PosType, ElemType>,
+                 FromSet,
+                 ToSet>;
+
+/*!
+ * \brief A static relation from \a FromSet to \a ToSet with fixed cardinality \a N
+ *  (each from-element maps to exactly N to-elements), binding indices in an external \c axom::Array buffer.
+ */
+template <typename FromSet,
+          typename ToSet,
+          int N,
+          typename PosType = typename FromSet::PositionType,
+          typename ElemType = typename ToSet::PositionType>
+using ConstantRelation =
+  StaticRelation<PosType,
+                 ElemType,
+                 policies::ConstantCardinality<PosType, policies::CompileTimeStride<PosType, N>>,
+                 policies::ArrayIndirection<PosType, ElemType>,
+                 FromSet,
+                 ToSet>;
+
+/*!
+ * \brief A static relation view from \a FromSet to \a ToSet with fixed cardinality \a N,
+ *  binding indices through \c axom::ArrayView.
+ */
+template <typename FromSet,
+          typename ToSet,
+          int N,
+          typename PosType = typename FromSet::PositionType,
+          typename ElemType = typename ToSet::PositionType>
+using ConstantRelationView =
+  StaticRelation<PosType,
+                 ElemType,
+                 policies::ConstantCardinality<PosType, policies::CompileTimeStride<PosType, N>>,
+                 policies::ArrayViewIndirection<PosType, ElemType>,
+                 FromSet,
+                 ToSet>;
+
+/*!
+ * \brief A static relation from \a FromSet to \a ToSet with runtime constant cardinality,
+ *  binding indices in an external \c axom::Array buffer.
+ */
+template <typename FromSet,
+          typename ToSet,
+          typename PosType = typename FromSet::PositionType,
+          typename ElemType = typename ToSet::PositionType>
+using RuntimeConstantRelation =
+  StaticRelation<PosType,
+                 ElemType,
+                 policies::ConstantCardinality<PosType, policies::RuntimeStride<PosType>>,
+                 policies::ArrayIndirection<PosType, ElemType>,
+                 FromSet,
+                 ToSet>;
+
+/*!
+ * \brief A static relation view from \a FromSet to \a ToSet with runtime constant cardinality,
+ *  binding indices through \c axom::ArrayView.
+ */
+template <typename FromSet,
+          typename ToSet,
+          typename PosType = typename FromSet::PositionType,
+          typename ElemType = typename ToSet::PositionType>
+using RuntimeConstantRelationView =
+  StaticRelation<PosType,
+                 ElemType,
+                 policies::ConstantCardinality<PosType, policies::RuntimeStride<PosType>>,
+                 policies::ArrayViewIndirection<PosType, ElemType>,
+                 FromSet,
+                 ToSet>;
+
+/*!
+ * \brief A map from the set \a S to values of type \a T, with compile-time \a STRIDE
+ *  components per element (default 1), owning its values in an \c axom::Array buffer.
+ */
+template <typename S, typename T = DefaultElementType, int STRIDE = 1>
+using ArrayMap = Map<T,
+                     S,
+                     policies::ArrayIndirection<typename S::PositionType, T>,
+                     policies::CompileTimeStride<typename S::PositionType, STRIDE>>;
+
+/*!
+ * \brief A non-owning map view from the set \a S to values of type \a T, with compile-time
+ *  \a STRIDE components per element (default 1).
+ */
+template <typename S, typename T = DefaultElementType, int STRIDE = 1>
+using ArrayViewMap = Map<T,
+                         S,
+                         policies::ArrayViewIndirection<typename S::PositionType, T>,
+                         policies::CompileTimeStride<typename S::PositionType, STRIDE>>;
+
+/*!
+ * \brief A map from the set \a S to values of type \a T with runtime stride,
+ *  owning its values in an \c axom::Array buffer.
+ */
+template <typename S, typename T = DefaultElementType>
+using RuntimeArrayMap = Map<T,
+                            S,
+                            policies::ArrayIndirection<typename S::PositionType, T>,
+                            policies::RuntimeStride<typename S::PositionType>>;
+
+/*!
+ * \brief A non-owning map view from the set \a S to values of type \a T with runtime stride.
+ */
+template <typename S, typename T = DefaultElementType>
+using RuntimeArrayViewMap = Map<T,
+                                S,
+                                policies::ArrayViewIndirection<typename S::PositionType, T>,
+                                policies::RuntimeStride<typename S::PositionType>>;
+
+/*!
+ * \brief A bivariate map of \a T over the bivariate set \a BSet
+ *  (e.g. a \c ProductSet or \c RelationSet), owning its values in an \c axom::Array buffer.
+ */
+template <typename BSet, typename T = DefaultElementType, int STRIDE = 1>
+using ArrayBivariateMap =
+  BivariateMap<T,
+               BSet,
+               policies::ArrayIndirection<typename BSet::PositionType, T>,
+               policies::CompileTimeStride<typename BSet::PositionType, STRIDE>>;
+
+/*!
+ * \brief A non-owning bivariate map view of \a T over the bivariate set \a BSet.
+ */
+template <typename BSet, typename T = DefaultElementType, int STRIDE = 1>
+using ArrayViewBivariateMap =
+  BivariateMap<T,
+               BSet,
+               policies::ArrayViewIndirection<typename BSet::PositionType, T>,
+               policies::CompileTimeStride<typename BSet::PositionType, STRIDE>>;
+
+/*!
+ * \brief A bivariate map of \a T over the bivariate set \a BSet with runtime stride,
+ *  owning its values in an \c axom::Array buffer.
+ */
+template <typename BSet, typename T = DefaultElementType>
+using RuntimeArrayBivariateMap =
+  BivariateMap<T,
+               BSet,
+               policies::ArrayIndirection<typename BSet::PositionType, T>,
+               policies::RuntimeStride<typename BSet::PositionType>>;
+
+/*!
+ * \brief A non-owning bivariate map view of \a T over the bivariate set \a BSet with runtime stride.
+ */
+template <typename BSet, typename T = DefaultElementType>
+using RuntimeArrayViewBivariateMap =
+  BivariateMap<T,
+               BSet,
+               policies::ArrayViewIndirection<typename BSet::PositionType, T>,
+               policies::RuntimeStride<typename BSet::PositionType>>;
+
+}  // namespace slam
+}  // namespace axom
+
+#endif  // SLAM_ALIASES_H_

--- a/src/axom/slam/Aliases.hpp
+++ b/src/axom/slam/Aliases.hpp
@@ -10,7 +10,7 @@
  * \brief Blessed, user-facing aliases for Slam's common set/relation/map types.
  *
  * Slam's containers are assembled from policy template parameters, which can be verbose.
- * This header names the combinations that most Axom code actually wants:
+ * This header provides aliases for common configurations using Axom-native storage:
  *
  *   - \c RangeSet<P,E>                -- a contiguous range of positions (from RangeSet.hpp)
  *   - \c ArraySet<P,E>                -- a set that binds an external \c axom::Array
@@ -20,12 +20,32 @@
  *   - \c ConstantRelation<F,T,N>      -- an Array-backed static relation with compile-time cardinality N
  *   - \c ConstantRelationView<F,T,N>  -- an ArrayView-backed static relation with compile-time cardinality N
  *   - \c RuntimeConstantRelation<F,T> -- an Array-backed static relation with runtime constant cardinality
+ *   - \c RuntimeConstantRelationView<F,T>
+ *       -- an ArrayView-backed static relation with runtime constant cardinality
  *   - \c ArrayMap<S,T,STRIDE>         -- an Array-backed map from set S to T
  *   - \c ArrayViewMap<S,T,STRIDE>     -- an ArrayView-backed map from set S to T
  *   - \c RuntimeArrayMap<S,T>         -- an Array-backed map with runtime stride
  *   - \c RuntimeArrayViewMap<S,T>     -- an ArrayView-backed map with runtime stride
  *   - \c ArrayBivariateMap<BSet,T>     -- an Array-backed bivariate map
  *   - \c ArrayViewBivariateMap<BSet,T> -- an ArrayView-backed bivariate map
+ *   - \c RuntimeArrayBivariateMap<BSet,T>
+ *       -- an Array-backed bivariate map with runtime stride
+ *   - \c RuntimeArrayViewBivariateMap<BSet,T>
+ *       -- an ArrayView-backed bivariate map with runtime stride
+ *
+ * Prefer these aliases in user-facing and component-facing Axom code.
+ * They keep the set/relation/map concepts visible while hiding the common policy stack.
+ * Use the full policies when adapting legacy storage, such as
+ * \c std::vector via \c policies::STLVectorIndirection, 
+ * raw pointers via \c policies::CArrayIndirection, 
+ * custom third-party buffers, or less common combinations of 
+ * stride, offset, size, subsetting, indirection or interface policies.
+ *
+ * For maps, the ownership distinction follows Axom's container vocabulary:
+ * \c ArrayMap and \c ArrayBivariateMap own an \c axom::Array buffer, 
+ * while \c ArrayViewMap and \c ArrayViewBivariateMap store an \c axom::ArrayView by value
+ * and view storage owned elsewhere. Owning maps are convenient host-side storage objects
+ * while view maps are the preferred lightweight form to pass into kernels and generic algorithms.
  */
 
 #ifndef SLAM_ALIASES_H_

--- a/src/axom/slam/Aliases.hpp
+++ b/src/axom/slam/Aliases.hpp
@@ -7,45 +7,44 @@
 /*!
  * \file Aliases.hpp
  *
- * \brief Blessed, user-facing aliases for Slam's common set/relation/map types.
+ * \brief Convenience aliases for Slam's most common set and relation configurations.
  *
- * Slam's containers are assembled from policy template parameters, which can be verbose.
- * This header provides aliases for common configurations using Axom-native storage:
+ * Slam's sets, relations and maps are assembled from policy template parameters
+ * (cardinality, stride, indirection, offset, size, subsetting, interface).
+ * This lets users customize data structure to their required data model,
+ * avoiding unnecessary computational and memory overhead.
+ * See the Slam user guide for how to choose policies.
+ *
+ * A handful of \e relations are commonly used, warranting named shorthands.
+ * The aliases in this file for the  common relation types, as well as some set types
+ * use `axom::Array` for storage the object manages itself and `axom::ArrayView` for
+ * storage managed elsewhere:
  *
  *   - \c RangeSet<P,E>                -- a contiguous range of positions (from RangeSet.hpp)
- *   - \c ArraySet<P,E>                -- a set that binds an external \c axom::Array
- *   - \c ArrayViewSet<P,E>            -- a set that binds an \c axom::ArrayView by value
- *   - \c VariableRelation<F,T>        -- an Array-backed static relation with variable cardinality
- *   - \c VariableRelationView<F,T>    -- an ArrayView-backed static relation with variable cardinality
- *   - \c ConstantRelation<F,T,N>      -- an Array-backed static relation with compile-time cardinality N
- *   - \c ConstantRelationView<F,T,N>  -- an ArrayView-backed static relation with compile-time cardinality N
- *   - \c RuntimeConstantRelation<F,T> -- an Array-backed static relation with runtime constant cardinality
- *   - \c RuntimeConstantRelationView<F,T>
- *       -- an ArrayView-backed static relation with runtime constant cardinality
- *   - \c ArrayMap<S,T,STRIDE>         -- an Array-backed map from set S to T
- *   - \c ArrayViewMap<S,T,STRIDE>     -- an ArrayView-backed map from set S to T
- *   - \c RuntimeArrayMap<S,T>         -- an Array-backed map with runtime stride
- *   - \c RuntimeArrayViewMap<S,T>     -- an ArrayView-backed map with runtime stride
- *   - \c ArrayBivariateMap<BSet,T>     -- an Array-backed bivariate map
- *   - \c ArrayViewBivariateMap<BSet,T> -- an ArrayView-backed bivariate map
- *   - \c RuntimeArrayBivariateMap<BSet,T>
- *       -- an Array-backed bivariate map with runtime stride
- *   - \c RuntimeArrayViewBivariateMap<BSet,T>
- *       -- an ArrayView-backed bivariate map with runtime stride
+ *   - \c ArraySet<P,E>                -- a set indexed through an \c axom::Array it manages
+ *   - \c ArrayViewSet<P,E>            -- a set indexed through an \c axom::ArrayView managed elsewhere
+ *   - \c VariableRelation<F,T>        -- a static relation with variable cardinality, managing its buffers
+ *   - \c VariableRelationView<F,T>    -- as above, viewing buffers managed elsewhere
+ *   - \c ConstantRelation<F,T,N>      -- a static relation with compile-time cardinality N, managing its buffer
+ *   - \c ConstantRelationView<F,T,N>  -- as above, viewing a buffer managed elsewhere
+ *   - \c RuntimeConstantRelation<F,T> -- a static relation with runtime-constant cardinality, managing its buffer
+ *   - \c RuntimeConstantRelationView<F,T> -- as above, viewing a buffer managed elsewhere
  *
- * Prefer these aliases in user-facing and component-facing Axom code.
- * They keep the set/relation/map concepts visible while hiding the common policy stack.
- * Use the full policies when adapting legacy storage, such as
- * \c std::vector via \c policies::STLVectorIndirection, 
- * raw pointers via \c policies::CArrayIndirection, 
- * custom third-party buffers, or less common combinations of 
- * stride, offset, size, subsetting, indirection or interface policies.
+ * These aliases are a convenience for the commonly used configurations.
+ * Use the underlying policies directly whenever you need other configuration,
+ * e.g. -- a specific stride, offset, size, subsetting or interface, a specialized cardinality such as
+ * \c policies::MappedVariableCardinality, or a different buffer such as \c std::vector
+ * (\c policies::STLVectorIndirection) or a raw pointer (\c policies::CArrayIndirection).
  *
- * For maps, the ownership distinction follows Axom's container vocabulary:
- * \c ArrayMap and \c ArrayBivariateMap own an \c axom::Array buffer, 
- * while \c ArrayViewMap and \c ArrayViewBivariateMap store an \c axom::ArrayView by value
- * and view storage owned elsewhere. Owning maps are convenient host-side storage objects
- * while view maps are the preferred lightweight form to pass into kernels and generic algorithms.
+ * \note This file does not currently alias map types.  A \c Map or \c BivariateMap already
+ *  defaults to the common case of `axom::Array` indirection with stride one,
+ *  while cases that do vary the map (a view into an externally-managed buffer,
+ *  or a runtime stride) also tend to vary in ways a small fixed set of names cannot capture cleanly.
+ *
+ * \note "Manages its buffer" vs. "views a buffer" refers to lifetime, not to whether
+ *  the data is logically owned by the object. An \c axom::Array indirection allocates
+ *  and frees the buffer as part of the Slam object's lifetime, while an \c axom::ArrayView
+ *  indirection refers to a buffer whose lifetime is managed elsewhere and must outlive the Slam object.
  */
 
 #ifndef SLAM_ALIASES_H_
@@ -183,87 +182,6 @@ using RuntimeConstantRelationView =
                  policies::ArrayViewIndirection<PosType, ElemType>,
                  FromSet,
                  ToSet>;
-
-/*!
- * \brief A map from the set \a S to values of type \a T, with compile-time \a STRIDE
- *  components per element (default 1), owning its values in an \c axom::Array buffer.
- */
-template <typename S, typename T = DefaultElementType, int STRIDE = 1>
-using ArrayMap = Map<T,
-                     S,
-                     policies::ArrayIndirection<typename S::PositionType, T>,
-                     policies::CompileTimeStride<typename S::PositionType, STRIDE>>;
-
-/*!
- * \brief A non-owning map view from the set \a S to values of type \a T, with compile-time
- *  \a STRIDE components per element (default 1).
- */
-template <typename S, typename T = DefaultElementType, int STRIDE = 1>
-using ArrayViewMap = Map<T,
-                         S,
-                         policies::ArrayViewIndirection<typename S::PositionType, T>,
-                         policies::CompileTimeStride<typename S::PositionType, STRIDE>>;
-
-/*!
- * \brief A map from the set \a S to values of type \a T with runtime stride,
- *  owning its values in an \c axom::Array buffer.
- */
-template <typename S, typename T = DefaultElementType>
-using RuntimeArrayMap = Map<T,
-                            S,
-                            policies::ArrayIndirection<typename S::PositionType, T>,
-                            policies::RuntimeStride<typename S::PositionType>>;
-
-/*!
- * \brief A non-owning map view from the set \a S to values of type \a T with runtime stride.
- */
-template <typename S, typename T = DefaultElementType>
-using RuntimeArrayViewMap = Map<T,
-                                S,
-                                policies::ArrayViewIndirection<typename S::PositionType, T>,
-                                policies::RuntimeStride<typename S::PositionType>>;
-
-/*!
- * \brief A bivariate map of \a T over the bivariate set \a BSet
- *  (e.g. a \c ProductSet or \c RelationSet), owning its values in an \c axom::Array buffer.
- */
-template <typename BSet, typename T = DefaultElementType, int STRIDE = 1>
-using ArrayBivariateMap =
-  BivariateMap<T,
-               BSet,
-               policies::ArrayIndirection<typename BSet::PositionType, T>,
-               policies::CompileTimeStride<typename BSet::PositionType, STRIDE>>;
-
-/*!
- * \brief A non-owning bivariate map view of \a T over the bivariate set \a BSet.
- */
-template <typename BSet, typename T = DefaultElementType, int STRIDE = 1>
-using ArrayViewBivariateMap =
-  BivariateMap<T,
-               BSet,
-               policies::ArrayViewIndirection<typename BSet::PositionType, T>,
-               policies::CompileTimeStride<typename BSet::PositionType, STRIDE>>;
-
-/*!
- * \brief A bivariate map of \a T over the bivariate set \a BSet with runtime stride,
- *  owning its values in an \c axom::Array buffer.
- */
-template <typename BSet, typename T = DefaultElementType>
-using RuntimeArrayBivariateMap =
-  BivariateMap<T,
-               BSet,
-               policies::ArrayIndirection<typename BSet::PositionType, T>,
-               policies::RuntimeStride<typename BSet::PositionType>>;
-
-/*!
- * \brief A non-owning bivariate map view of \a T over the bivariate set \a BSet with runtime stride.
- */
-template <typename BSet, typename T = DefaultElementType>
-using RuntimeArrayViewBivariateMap =
-  BivariateMap<T,
-               BSet,
-               policies::ArrayViewIndirection<typename BSet::PositionType, T>,
-               policies::RuntimeStride<typename BSet::PositionType>>;
 
 }  // namespace slam
 }  // namespace axom

--- a/src/axom/slam/Aliases.hpp
+++ b/src/axom/slam/Aliases.hpp
@@ -65,27 +65,26 @@ namespace axom
 namespace slam
 {
 /*!
- * \brief A set whose \a ElemType elements are stored in an external \c axom::Array.
+ * \brief A set whose \a ElemType elements are read from an \c axom::Array.
  *
- * This is the canonical Axom indirection set for binding an \c axom::Array buffer.
- * The array object is managed outside the set and must outlive it.
- * \sa ArrayViewSet for the non-owning, device-capturable form
+ * The \c axom::Array is managed outside the set and must outlive it.
+ * \sa ArrayViewSet for the device-capturable form
  */
 template <typename PosType = DefaultPositionType, typename ElemType = DefaultElementType>
 using ArraySet = ArrayIndirectionSet<PosType, ElemType>;
 
 /*!
- * \brief A set whose \a ElemType elements are viewed through an \c axom::ArrayView.
+ * \brief A set whose \a ElemType elements are read through an \c axom::ArrayView.
  *
- * The view is stored by value, so this is the preferred indirection-set shape
- * for device-capturable views over storage owned elsewhere.
+ * The view is held by value and refers to a buffer managed elsewhere (which must outlive the set);
+ * because \c axom::ArrayView is trivially copyable, it can be used for device capture.
  */
 template <typename PosType = DefaultPositionType, typename ElemType = DefaultElementType>
 using ArrayViewSet = ArrayViewIndirectionSet<PosType, ElemType>;
 
 /*!
  * \brief A static relation from \a FromSet to \a ToSet with per-element (variable) cardinality,
- *  binding offsets and indices in external \c axom::Array buffers.
+ *  reading offsets and indices from \c axom::Array buffers managed elsewhere.
  *
  * This is the type produced by the \c axom::Array overload of \c make_variable_relation.
  */
@@ -119,7 +118,7 @@ using VariableRelationView =
 
 /*!
  * \brief A static relation from \a FromSet to \a ToSet with fixed cardinality \a N
- *  (each from-element maps to exactly N to-elements), binding indices in an external \c axom::Array buffer.
+ *  (each from-element maps to exactly N to-elements), reading indices from an \c axom::Array buffer managed elsewhere.
  */
 template <typename FromSet,
           typename ToSet,
@@ -153,7 +152,7 @@ using ConstantRelationView =
 
 /*!
  * \brief A static relation from \a FromSet to \a ToSet with runtime constant cardinality,
- *  binding indices in an external \c axom::Array buffer.
+ *  reading indices from an \c axom::Array buffer managed elsewhere.
  */
 template <typename FromSet,
           typename ToSet,

--- a/src/axom/slam/Aliases.hpp
+++ b/src/axom/slam/Aliases.hpp
@@ -47,8 +47,7 @@
  *  indirection refers to a buffer whose lifetime is managed elsewhere and must outlive the Slam object.
  */
 
-#ifndef SLAM_ALIASES_H_
-#define SLAM_ALIASES_H_
+#pragma once
 
 #include "axom/slam/RangeSet.hpp"
 #include "axom/slam/IndirectionSet.hpp"
@@ -60,9 +59,7 @@
 #include "axom/slam/policies/IndirectionPolicies.hpp"
 #include "axom/slam/policies/StridePolicies.hpp"
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /*!
  * \brief A set whose \a ElemType elements are read from an \c axom::Array.
@@ -182,7 +179,4 @@ using RuntimeConstantRelationView =
                  FromSet,
                  ToSet>;
 
-}  // namespace slam
-}  // namespace axom
-
-#endif  // SLAM_ALIASES_H_
+}  // namespace axom::slam

--- a/src/axom/slam/BitSet.cpp
+++ b/src/axom/slam/BitSet.cpp
@@ -8,9 +8,7 @@
 
 #include "axom/slam/BitSet.hpp"
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 void BitSet::clear()
 {
@@ -246,5 +244,4 @@ bool BitSet::operator==(const BitSet& other) const
   return m_data == other.m_data;
 }
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/BitSet.hpp
+++ b/src/axom/slam/BitSet.hpp
@@ -21,9 +21,7 @@
 
 #include <vector>
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 // Forward declare the BitSet class and some operator functions
 
@@ -413,5 +411,4 @@ private:
   int m_numBits;
 };
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/BivariateMap.hpp
+++ b/src/axom/slam/BivariateMap.hpp
@@ -80,7 +80,7 @@ namespace slam
 
 template <typename T,
           typename BSet = BivariateSet<>,
-          typename IndPol = policies::STLVectorIndirection<typename BSet::PositionType, T>,
+          typename IndPol = policies::ArrayIndirection<typename BSet::PositionType, T>,
           typename StrPol = policies::StrideOne<typename BSet::PositionType>,
           typename IfacePol = policies::ConcreteInterface>
 class BivariateMap : public policies::MapInterface<IfacePol, typename BSet::PositionType>,

--- a/src/axom/slam/BivariateMap.hpp
+++ b/src/axom/slam/BivariateMap.hpp
@@ -44,13 +44,11 @@ namespace slam
  * an index that disregards the individual components. Hence, to access
  * each component, one would need to provide a component index as well.
  *
- * \note When \a IndPol is not specified, \c BivariateMap owns its values in an
- *       \c axom::Array via \c policies::ArrayIndirection. 
- *       This replaced the earlier \c policies::STLVectorIndirection default. 
- *       New Axom code typically uses the common owning/view policy stacks with
- *       \c ArrayBivariateMap, \c ArrayViewBivariateMap or their runtime-stride variants.
- *       Code that intentionally needs \c std::vector backing should
- *       specify \c policies::STLVectorIndirection explicitly.
+ * \note When \a IndPol is not specified, \c BivariateMap stores its values in an
+ *       \c axom::Array via \c policies::ArrayIndirection, and manages that buffer itself.
+ *       This replaced the earlier \c policies::STLVectorIndirection default.
+ *       To refer to a buffer managed elsewhere, use \c policies::ArrayViewIndirection.
+ *       For \c std::vector backing, specify \c policies::STLVectorIndirection explicitly.
  *
  * Example:
  * For a 2 x 2 sparse matrix with 3 components below:

--- a/src/axom/slam/BivariateMap.hpp
+++ b/src/axom/slam/BivariateMap.hpp
@@ -24,9 +24,7 @@
 #include <cassert>
 #include <typeinfo>
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \class BivariateMap
@@ -748,5 +746,4 @@ private:
   typename BivariateSetType::IteratorType m_bsetIterator;
 };
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/BivariateMap.hpp
+++ b/src/axom/slam/BivariateMap.hpp
@@ -44,6 +44,14 @@ namespace slam
  * an index that disregards the individual components. Hence, to access
  * each component, one would need to provide a component index as well.
  *
+ * \note When \a IndPol is not specified, \c BivariateMap owns its values in an
+ *       \c axom::Array via \c policies::ArrayIndirection. 
+ *       This replaced the earlier \c policies::STLVectorIndirection default. 
+ *       New Axom code typically uses the common owning/view policy stacks with
+ *       \c ArrayBivariateMap, \c ArrayViewBivariateMap or their runtime-stride variants.
+ *       Code that intentionally needs \c std::vector backing should
+ *       specify \c policies::STLVectorIndirection explicitly.
+ *
  * Example:
  * For a 2 x 2 sparse matrix with 3 components below:
  *     \code

--- a/src/axom/slam/BivariateSet.hpp
+++ b/src/axom/slam/BivariateSet.hpp
@@ -25,9 +25,7 @@
 #include <optional>
 #include <type_traits>
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 template <typename BivariateSetType>
 struct BivariateSetIterator;
@@ -451,5 +449,4 @@ private:
   }
 };
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/CMakeLists.txt
+++ b/src/axom/slam/CMakeLists.txt
@@ -25,9 +25,10 @@ axom_component_requires(NAME       SLAM
 #------------------------------------------------------------------------------
 set(slam_headers
     # Utility files
-    Utilities.hpp
     FieldRegistry.hpp
     ModularInt.hpp
+    Traits.hpp
+    Utilities.hpp
 
     #SRM policies
     policies/CardinalityPolicies.hpp

--- a/src/axom/slam/CMakeLists.txt
+++ b/src/axom/slam/CMakeLists.txt
@@ -25,6 +25,7 @@ axom_component_requires(NAME       SLAM
 #------------------------------------------------------------------------------
 set(slam_headers
     # Utility files
+    Aliases.hpp
     FieldRegistry.hpp
     ModularInt.hpp
     Traits.hpp

--- a/src/axom/slam/DynamicConstantRelation.hpp
+++ b/src/axom/slam/DynamicConstantRelation.hpp
@@ -31,9 +31,7 @@
 
 #include <vector>
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \class DynamicConstantRelation
@@ -569,5 +567,4 @@ bool DynamicConstantRelation<PosType, ElemType, CardinalityPolicy>::isValid(bool
   return bValid;
 }
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/DynamicMap.hpp
+++ b/src/axom/slam/DynamicMap.hpp
@@ -16,9 +16,7 @@
 #include "axom/slam/DynamicSet.hpp"
 #include "axom/slam/Map.hpp"
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \class DynamicMap
@@ -246,5 +244,4 @@ bool DynamicMap<SetType, DataType>::isValid(bool verboseOutput) const
   return bValid;
 }
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/DynamicSet.hpp
+++ b/src/axom/slam/DynamicSet.hpp
@@ -20,9 +20,7 @@
 
 #include <optional>
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \class DynamicSet
@@ -485,5 +483,4 @@ private:
 template <typename P, typename E, typename S>
 constexpr typename DynamicSet<P, E, S>::ElementType DynamicSet<P, E, S>::INVALID_ENTRY;
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/DynamicVariableRelation.hpp
+++ b/src/axom/slam/DynamicVariableRelation.hpp
@@ -27,9 +27,7 @@
 #include <sstream>
 #include <iterator>
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 template <typename FirstSetType = slam::Set<>, typename SecondSetType = slam::Set<>>
 class DynamicVariableRelation
@@ -307,5 +305,4 @@ bool DynamicVariableRelation<FirstSetType, SecondSetType>::isValid(bool verboseO
   return bValid;
 }
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/FieldRegistry.hpp
+++ b/src/axom/slam/FieldRegistry.hpp
@@ -43,11 +43,11 @@ namespace axom::slam
  *         with an `axom::ArrayView` indirection
  *         (useful when generating Slam objects from externally-managed arrays)
  *
- * \note Owning buffers and owning fields now use `axom::Array` rather than `std::vector`.
- *       Prefer `auto`, `FieldRegistry::BufferType`, and `FieldRegistry::MapType` 
- *       at registry boundaries. Code that needs a non-owning view
- *       should call `buffer.view()` or register storage with `addFieldView()` 
- *       or `addBufferView()` instead of assuming a `std::vector` interface.
+ * \note The registry-managed fields and buffers (the first mode above, and \ref FieldRegistry::BufferType)
+ *       now hold an `axom::Array` rather than a `std::vector`.
+ *       Prefer `auto`, `FieldRegistry::BufferType`, and `FieldRegistry::MapType` at registry boundaries.
+ *       When an `axom::ArrayView` is the right interface, call `buffer.view()`;
+ *       to register a buffer managed elsewhere, use `addFieldView()` or `addBufferView()`.
  */
 template <typename SetType, typename TheDataType>
 class FieldRegistry

--- a/src/axom/slam/FieldRegistry.hpp
+++ b/src/axom/slam/FieldRegistry.hpp
@@ -53,8 +53,13 @@ public:
   /// \brief Key type used for registry entries.
   using KeyType = std::string;
 
-  /// \brief Owning field type (`slam::Map`) stored by this registry.
-  using MapType = slam::Map<DataType, SetType>;
+  /*!
+   * \brief Owning field type (`slam::Map`) stored by this registry.
+   *
+   * Uses the canonical `policies::ArrayIndirection` policy so registry-owned fields
+   * store their values in an `axom::Array` buffer.
+   */
+  using MapType = slam::Map<DataType, SetType, policies::ArrayIndirection<PositionType, DataType>>;
 
   /// \brief Owning buffer type used by `MapType`.
   using BufferType = typename MapType::OrderedMap;
@@ -63,7 +68,8 @@ public:
    * \brief View-backed field type stored by this registry.
    *
    * This is the return type of `slam::make_map(set, axom::ArrayView<DataType>{...})`
-   * and uses `policies::ArrayViewIndirection`.
+   * and uses the canonical non-owning `policies::ArrayViewIndirection` policy.
+   * The view's backing storage must outlive the registered field.
    */
   using ViewMapType = decltype(slam::make_map(std::declval<const SetType*>(),
                                               std::declval<axom::ArrayView<DataType>>()));

--- a/src/axom/slam/FieldRegistry.hpp
+++ b/src/axom/slam/FieldRegistry.hpp
@@ -70,7 +70,7 @@ public:
    */
   using MapType = slam::Map<DataType, SetType>;
 
-  /// \brief Buffer type backing `MapType` (uses the default Map buffer type: `axom::Array<DataType>`
+  /// \brief Buffer type backing `MapType` (uses the default Map buffer type: `axom::Array<DataType>`)
   using BufferType = typename MapType::OrderedMap;
 
   /*!

--- a/src/axom/slam/FieldRegistry.hpp
+++ b/src/axom/slam/FieldRegistry.hpp
@@ -37,9 +37,11 @@ namespace axom::slam
  *       query with a std::string_view without constructing a temporary std::string.
  *
  * \note FieldRegistry supports two field storage modes under a single set of field keys:
- *       - owning fields stored as `slam::ArrayMap`
- *       - view-backed fields stored as `slam::ArrayViewMap`
- *         (useful when generating Slam objects from externally-owned arrays)
+ *       - fields that manage their own buffer, stored as a `slam::Map` with the
+ *         default `axom::Array` indirection
+ *       - fields that refer to an externally-managed buffer, stored as a `slam::Map`
+ *         with an `axom::ArrayView` indirection
+ *         (useful when generating Slam objects from externally-managed arrays)
  *
  * \note Owning buffers and owning fields now use `axom::Array` rather than `std::vector`.
  *       Prefer `auto`, `FieldRegistry::BufferType`, and `FieldRegistry::MapType` 
@@ -61,17 +63,14 @@ public:
   using KeyType = std::string;
 
   /*!
-   * \brief Owning field type (`slam::Map`) stored by this registry.
+   * \brief Field type stored by this registry, a `slam::Map` from \a SetType to \a DataType.
    *
-   * Uses the canonical `ArrayMap` alias so registry-owned fields store their
-   * values in an `axom::Array` buffer.
+   * Uses Slam's default indirection (`axom::Array`), so registry-managed
+   * fields hold their own buffer.  See \ref FieldRegistry::BufferType.
    */
-  using MapType = slam::ArrayMap<SetType, DataType>;
+  using MapType = slam::Map<DataType, SetType>;
 
-  /*! \brief Owning buffer type used by `MapType`.
-   *
-   * This is `axom::Array<DataType>` through the `ArrayMap` policy stack.
-   */
+  /// \brief Buffer type backing `MapType` (uses the default Map buffer type: `axom::Array<DataType>`
   using BufferType = typename MapType::OrderedMap;
 
   /*!

--- a/src/axom/slam/FieldRegistry.hpp
+++ b/src/axom/slam/FieldRegistry.hpp
@@ -11,6 +11,7 @@
 
 #include "axom/slam/Utilities.hpp"
 #include "axom/slam/Set.hpp"
+#include "axom/slam/Aliases.hpp"
 #include "axom/slam/Map.hpp"
 #include "axom/slam/MapBuilders.hpp"
 
@@ -56,10 +57,10 @@ public:
   /*!
    * \brief Owning field type (`slam::Map`) stored by this registry.
    *
-   * Uses the canonical `policies::ArrayIndirection` policy so registry-owned fields
-   * store their values in an `axom::Array` buffer.
+   * Uses the canonical `ArrayMap` alias so registry-owned fields store their
+   * values in an `axom::Array` buffer.
    */
-  using MapType = slam::Map<DataType, SetType, policies::ArrayIndirection<PositionType, DataType>>;
+  using MapType = slam::ArrayMap<SetType, DataType>;
 
   /// \brief Owning buffer type used by `MapType`.
   using BufferType = typename MapType::OrderedMap;

--- a/src/axom/slam/FieldRegistry.hpp
+++ b/src/axom/slam/FieldRegistry.hpp
@@ -36,10 +36,16 @@ namespace axom::slam
  *       lookup tables use transparent comparison (std::less<>) so callers may
  *       query with a std::string_view without constructing a temporary std::string.
  *
- * \note FieldRegistry supports two field storage modes under a single field keyspace:
- *       - owning fields stored as `slam::Map`
- *       - view-backed fields stored as `slam::Map` over `axom::ArrayView`
- *         (useful when generating SLAM objects from externally-owned C arrays)
+ * \note FieldRegistry supports two field storage modes under a single set of field keys:
+ *       - owning fields stored as `slam::ArrayMap`
+ *       - view-backed fields stored as `slam::ArrayViewMap`
+ *         (useful when generating Slam objects from externally-owned arrays)
+ *
+ * \note Owning buffers and owning fields now use `axom::Array` rather than `std::vector`.
+ *       Prefer `auto`, `FieldRegistry::BufferType`, and `FieldRegistry::MapType` 
+ *       at registry boundaries. Code that needs a non-owning view
+ *       should call `buffer.view()` or register storage with `addFieldView()` 
+ *       or `addBufferView()` instead of assuming a `std::vector` interface.
  */
 template <typename SetType, typename TheDataType>
 class FieldRegistry
@@ -62,7 +68,10 @@ public:
    */
   using MapType = slam::ArrayMap<SetType, DataType>;
 
-  /// \brief Owning buffer type used by `MapType`.
+  /*! \brief Owning buffer type used by `MapType`.
+   *
+   * This is `axom::Array<DataType>` through the `ArrayMap` policy stack.
+   */
   using BufferType = typename MapType::OrderedMap;
 
   /*!

--- a/src/axom/slam/IndirectionSet.hpp
+++ b/src/axom/slam/IndirectionSet.hpp
@@ -11,11 +11,10 @@
  *
  * \brief Defines alias templates for OrderedSets with indirection.
  *
- * New Axom code should prefer \c ArrayIndirectionSet when binding an
- * \c axom::Array buffer and \c ArrayViewIndirectionSet when viewing storage
- * owned elsewhere. \c CArrayIndirectionSet and \c VectorIndirectionSet are
- * retained for raw-pointer/std::vector interop and as reference examples for
- * custom indirection policies.
+ * Use \c ArrayIndirectionSet for a set indexed through an \c axom::Array it manages,
+ * and \c ArrayViewIndirectionSet for a set indexed through an \c axom::ArrayView of a buffer managed elsewhere. 
+ * \c CArrayIndirectionSet and \c VectorIndirectionSet index raw-pointer and \c std::vector storage,
+ * for interoperation and as reference examples for custom indirection policies.
  */
 
 #include <cstddef>
@@ -30,8 +29,8 @@ namespace slam
 /**
  * \brief Alias template for an OrderedSet with indirection over a C array.
  *
- * \note This is a low-level compatibility/reference alias. Prefer
- *  \c ArrayViewIndirectionSet for new non-owning buffers when possible.
+ * \note Indexes a raw pointer, for interoperation with C-style array storage.
+ *  For an \c axom::ArrayView of a buffer managed elsewhere, use \c ArrayViewIndirectionSet.
  *
  * \tparam PosType The position type for indexing into the set
  * \tparam ElemType The type for the set's elements
@@ -48,8 +47,8 @@ using CArrayIndirectionSet = OrderedSet<PosType,
 /**
  * \brief Alias template for an OrderedSet with indirection over a std::vector.
  *
- * \note This is a host-only compatibility/reference alias. Prefer
- *  \c ArrayIndirectionSet or \c ArrayViewIndirectionSet for new Axom code.
+ * \note Indexes a (host-only) \c std::vector, for interoperation with existing \c std::vector storage. 
+ *  For \c axom::Array / \c axom::ArrayView storage, use \c ArrayIndirectionSet or \c ArrayViewIndirectionSet.
  *
  * \tparam PosType The position type for indexing into the set
  * \tparam ElemType The type for the set's elements
@@ -66,8 +65,8 @@ using VectorIndirectionSet = OrderedSet<PosType,
 /**
  * \brief Alias template for an OrderedSet with indirection over an axom::Array.
  *
- * This is the canonical Axom alias for binding a set to an \c axom::Array
- * buffer. The array object is managed outside the set and must outlive it.
+ * This is the canonical Axom alias for binding a set to an \c axom::Array buffer.
+ * The array object is managed outside the set and must outlive it.
  *
  * \tparam PosType The position type for indexing into the set
  * \tparam ElemType The type for the set's elements
@@ -84,10 +83,9 @@ using ArrayIndirectionSet = OrderedSet<PosType,
 /**
  * \brief Alias template for an OrderedSet with indirection over an axom::ArrayView.
  *
- * This is the canonical Axom alias for a non-owning, view-backed indirection
- * set. The view's backing allocation must outlive the set. Because
- * \c axom::ArrayView is trivially copyable, this alias is the preferred shape
- * for sets captured by value into device kernels.
+ * A set indexed through an \c axom::ArrayView of a buffer managed elsewhere.
+ * The backing allocation must outlive the set. Because \c axom::ArrayView is
+ * trivially copyable, it can be captured by value into device kernels.
  *
  * \tparam PosType The position type for indexing into the set
  * \tparam ElemType The type for the set's elements

--- a/src/axom/slam/IndirectionSet.hpp
+++ b/src/axom/slam/IndirectionSet.hpp
@@ -9,7 +9,13 @@
 /**
  * \file IndirectionSet.hpp
  *
- * \brief Defines some alias templates for OrderedSets with indirection
+ * \brief Defines alias templates for OrderedSets with indirection.
+ *
+ * New Axom code should prefer \c ArrayIndirectionSet when binding an
+ * \c axom::Array buffer and \c ArrayViewIndirectionSet when viewing storage
+ * owned elsewhere. \c CArrayIndirectionSet and \c VectorIndirectionSet are
+ * retained for raw-pointer/std::vector interop and as reference examples for
+ * custom indirection policies.
  */
 
 #include <cstddef>
@@ -22,7 +28,10 @@ namespace axom
 namespace slam
 {
 /**
- * \brief Alias template for an OrderedSet with indirection over a C array
+ * \brief Alias template for an OrderedSet with indirection over a C array.
+ *
+ * \note This is a low-level compatibility/reference alias. Prefer
+ *  \c ArrayViewIndirectionSet for new non-owning buffers when possible.
  *
  * \tparam PosType The position type for indexing into the set
  * \tparam ElemType The type for the set's elements
@@ -37,7 +46,10 @@ using CArrayIndirectionSet = OrderedSet<PosType,
                                         policies::CArrayIndirection<PosType, ElemType>>;
 
 /**
- * \brief Alias template for an OrderedSet with indirection over an stl vector
+ * \brief Alias template for an OrderedSet with indirection over a std::vector.
+ *
+ * \note This is a host-only compatibility/reference alias. Prefer
+ *  \c ArrayIndirectionSet or \c ArrayViewIndirectionSet for new Axom code.
  *
  * \tparam PosType The position type for indexing into the set
  * \tparam ElemType The type for the set's elements
@@ -52,7 +64,10 @@ using VectorIndirectionSet = OrderedSet<PosType,
                                         policies::STLVectorIndirection<PosType, ElemType>>;
 
 /**
- * \brief Alias template for an OrderedSet with indirection over an axom::Array
+ * \brief Alias template for an OrderedSet with indirection over an axom::Array.
+ *
+ * This is the canonical Axom alias for binding a set to an \c axom::Array
+ * buffer. The array object is managed outside the set and must outlive it.
  *
  * \tparam PosType The position type for indexing into the set
  * \tparam ElemType The type for the set's elements
@@ -67,7 +82,12 @@ using ArrayIndirectionSet = OrderedSet<PosType,
                                        policies::ArrayIndirection<PosType, ElemType>>;
 
 /**
- * \brief Alias template for an OrderedSet with indirection over an axom::ArrayView
+ * \brief Alias template for an OrderedSet with indirection over an axom::ArrayView.
+ *
+ * This is the canonical Axom alias for a non-owning, view-backed indirection
+ * set. The view's backing allocation must outlive the set. Because
+ * \c axom::ArrayView is trivially copyable, this alias is the preferred shape
+ * for sets captured by value into device kernels.
  *
  * \tparam PosType The position type for indexing into the set
  * \tparam ElemType The type for the set's elements

--- a/src/axom/slam/IndirectionSet.hpp
+++ b/src/axom/slam/IndirectionSet.hpp
@@ -22,9 +22,7 @@
 
 #include "axom/slam/OrderedSet.hpp"
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \brief Alias template for an OrderedSet with indirection over a C array.
@@ -99,5 +97,4 @@ using ArrayViewIndirectionSet = OrderedSet<PosType,
                                            policies::StrideOne<PosType>,
                                            policies::ArrayViewIndirection<PosType, ElemType>>;
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/Map.hpp
+++ b/src/axom/slam/Map.hpp
@@ -172,13 +172,15 @@ public:
   }
 
   /**
-   * \brief Constructor for Map using a Set pointer and externally-owned data.
+   * \brief Constructor for Map from a Set pointer and an existing buffer.
    *
-   * This overload is intended for non-owning indirection policies such as
-   * `policies::ArrayViewIndirection`, but also works for owning buffers.
+   * Primarily for indirection policies that refer to a buffer managed elsewhere,
+   * such as `policies::ArrayViewIndirection`, It also accepts a buffer to move in
+   * for policies that hold their buffer by value.
    *
    * \param theSet pointer to the map's set (must outlive the map)
-   * \param data externally-owned (or moved-in) storage for the map's values
+   * \param data the map's value buffer -- viewed (and thus required to outlive the
+   *  map) for a view indirection, or moved in for an owning indirection
    * \param shape (Optional) number of values mapped per set element (stride)
    */
   Map(const SetType* theSet, OrderedMap data, ElementShape shape = StridePolicyType::DefaultSize())
@@ -389,8 +391,7 @@ public:
    * \brief Returns the shape of the component values associated with each element.
    *
    *  For one-dimensional strides, equivalent to stride(); otherwise, returns
-   *  an N-dimensional array with the number of values in each sub-component
-   *  index.
+   *  an N-dimensional array with the number of values in each sub-component index.
    */
   AXOM_HOST_DEVICE ElementShape shape() const { return StridePolicyType::shape(); }
 
@@ -517,7 +518,7 @@ public:
     SetPosition flatIndex() const { return this->m_pos; }
 
   protected:
-    /** Implementation of advance() as required by IteratorBase */
+    /// Implementation of advance() as required by IteratorBase
     AXOM_HOST_DEVICE void advance(PositionType n) { m_pos += n; }
 
   private:

--- a/src/axom/slam/Map.hpp
+++ b/src/axom/slam/Map.hpp
@@ -65,7 +65,7 @@ namespace slam
 
 template <typename T,
           typename S = Set<>,
-          typename IndPol = policies::STLVectorIndirection<typename S::PositionType, T>,
+          typename IndPol = policies::ArrayIndirection<typename S::PositionType, T>,
           typename StrPol = policies::StrideOne<typename S::PositionType>,
           typename IfacePol = policies::ConcreteInterface>
 class Map : public StrPol, public policies::MapInterface<IfacePol, typename S::PositionType>

--- a/src/axom/slam/Map.hpp
+++ b/src/axom/slam/Map.hpp
@@ -32,9 +32,7 @@
 #include "axom/slam/policies/PolicyTraits.hpp"
 #include "axom/slam/policies/MapInterfacePolicies.hpp"
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 // This class is missing some simplifying copy constructors
 // -- or at least ways of interacting with the data store
@@ -858,5 +856,4 @@ void Map<T, S, IndPol, StrPol, IfacePol>::print() const
   std::cout << sstr.str() << std::endl;
 }
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/Map.hpp
+++ b/src/axom/slam/Map.hpp
@@ -61,12 +61,11 @@ namespace slam
  *          ( `map(i,j)` ), or via the square bracket operator
  *          (i.e. `map[k]`, where `k = i * stride() + j` ).
  *
- * \note When \a IndPol is not specified, \c Map owns its values in an
- *       \c axom::Array via \c policies::ArrayIndirection.
+ * \note When \a IndPol is not specified, \c Map stores its values in an \c axom::Array
+ *       via \c policies::ArrayIndirection, and manages that buffer itself.
  *       This replaced the earlier \c policies::STLVectorIndirection default.
- *       Most use-cases utilize this common policy stack as \c ArrayMap<S,T>.
- *       Code that intentionally needs \c std::vector backing should
- *       specify \c policies::STLVectorIndirection explicitly.
+ *       To refer to a buffer managed elsewhere, use \c policies::ArrayViewIndirection.
+ *       For \c std::vector backing, specify \c policies::STLVectorIndirection explicitly.
  */
 
 template <typename T,

--- a/src/axom/slam/Map.hpp
+++ b/src/axom/slam/Map.hpp
@@ -61,6 +61,12 @@ namespace slam
  *          ( `map(i,j)` ), or via the square bracket operator
  *          (i.e. `map[k]`, where `k = i * stride() + j` ).
  *
+ * \note When \a IndPol is not specified, \c Map owns its values in an
+ *       \c axom::Array via \c policies::ArrayIndirection.
+ *       This replaced the earlier \c policies::STLVectorIndirection default.
+ *       Most use-cases utilize this common policy stack as \c ArrayMap<S,T>.
+ *       Code that intentionally needs \c std::vector backing should
+ *       specify \c policies::STLVectorIndirection explicitly.
  */
 
 template <typename T,

--- a/src/axom/slam/MapBase.hpp
+++ b/src/axom/slam/MapBase.hpp
@@ -18,9 +18,7 @@
 
 #include "axom/slam/Set.hpp"
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \class   MapBase
@@ -61,5 +59,4 @@ private:
   virtual void verifyPosition(SetPosition) const = 0;
 };
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/ModularInt.hpp
+++ b/src/axom/slam/ModularInt.hpp
@@ -20,9 +20,7 @@
 #include "axom/slam/policies/SizePolicies.hpp"
 #include "axom/core/Macros.hpp"
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \class ModularInt
@@ -285,5 +283,4 @@ constexpr ModularInt<SizePolicy> operator*(const int n, const ModularInt<SizePol
   return tmp;
 }
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/NullSet.hpp
+++ b/src/axom/slam/NullSet.hpp
@@ -16,9 +16,7 @@
 #include "axom/slic.hpp"
 #include "axom/slam/Set.hpp"
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \class NullSet
@@ -88,5 +86,4 @@ inline bool operator!=(NullSet const&, NullSet const&)
 }
 #endif
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/OrderedSet.hpp
+++ b/src/axom/slam/OrderedSet.hpp
@@ -10,9 +10,9 @@
  * \file OrderedSet.hpp
  *
  * \brief Basic API for an ordered set of entities in a simulation
+ * 
  * \note We are actually storing (ordered) multisets, since elements can be
  *  repeated an arbitrary number of times (e.g. for indirection sets)
- *
  */
 
 #include "axom/config.hpp"
@@ -123,9 +123,7 @@ private:
             typename OtherInterfacePolicy>
   friend struct OrderedSet;
 
-  /*!
-   * \brief Helper tag class to call OrderedSet conversion constructor.
-   */
+  /// \brief Helper tag class to call OrderedSet conversion constructor
   struct ConversionTag
   { };
 

--- a/src/axom/slam/OrderedSet.hpp
+++ b/src/axom/slam/OrderedSet.hpp
@@ -20,6 +20,7 @@
 #include "axom/slic.hpp"
 
 #include "axom/slam/Set.hpp"
+#include "axom/slam/Traits.hpp"
 
 #include "axom/slam/policies/SizePolicies.hpp"
 #include "axom/slam/policies/OffsetPolicies.hpp"
@@ -315,11 +316,11 @@ public:
     using difference_type = PositionType;
 
     using reference =
-      typename std::conditional<Const,
-                                typename OrderedSet::IndirectionPolicyType::ConstIndirectionResult,
-                                typename OrderedSet::IndirectionPolicyType::IndirectionResult>::type;
+      std::conditional_t<Const,
+                         typename OrderedSet::IndirectionPolicyType::ConstIndirectionResult,
+                         typename OrderedSet::IndirectionPolicyType::IndirectionResult>;
 
-    using pointer = typename std::conditional<Const, const T*, T*>::type;
+    using pointer = maybe_const_t<Const, T>*;
 
     using IterBase = IteratorBase<OrderedSetIterator<T, Const>, PositionType>;
 
@@ -340,51 +341,21 @@ public:
     /// \}
 
     /// \name Member and pointer operators
-    /// \note We use the \a enable_if construct to implement both
-    /// const and non-const iterators in the same implementation.
+    /// \note A single const-qualified implementation serves both the const and non-const iterator.
+    /// Element mutability is carried by the \a reference and \a pointer types
+    /// \a m_orderedSet is \c mutable so the non-const iterator can return
+    /// a mutable reference from a const-qualified operator, and the
+    /// iterator is const-dereferenceable (as the standard iterator concepts require).
     /// \{
 
-    /// Indirection operator for non-const iterator
-    template <bool _Const = Const>
-    typename std::enable_if<!_Const, reference>::type operator*()
-    {
-      return m_orderedSet.IndirectionType::indirection(m_pos);
-    }
+    /// Dereference operator
+    reference operator*() const { return m_orderedSet.IndirectionType::indirection(m_pos); }
 
-    /// Indirection operator for const iterator
-    template <bool _Const = Const>
-    typename std::enable_if<_Const, reference>::type operator*() const
-    {
-      return m_orderedSet.IndirectionType::indirection(m_pos);
-    }
+    /// Structure dereference operator
+    pointer operator->() const { return &(m_orderedSet.IndirectionType::indirection(m_pos)); }
 
-    /// Structure dereference operator for non-const iterator
-    template <bool _Const = Const>
-    typename std::enable_if<!_Const, pointer>::type operator->()
-    {
-      return &(m_orderedSet.IndirectionType::indirection(m_pos));
-    }
-
-    /// Structure dereference operator for const iterator
-    template <bool _Const = Const>
-    typename std::enable_if<_Const, pointer>::type operator->() const
-    {
-      return &(m_orderedSet.IndirectionType::indirection(m_pos));
-    }
-
-    /// Subscript operator for non-const iterator
-    template <bool _Const = Const>
-    typename std::enable_if<!_Const, reference>::type operator[](PositionType n)
-    {
-      return *(*this + n);
-    }
-
-    /// Subscript operator for const iterator
-    template <bool _Const = Const>
-    typename std::enable_if<_Const, reference>::type operator[](PositionType n) const
-    {
-      return *(*this + n);
-    }
+    /// Subscript operator
+    reference operator[](PositionType n) const { return *(*this + n); }
 
     /// \}
 
@@ -416,7 +387,7 @@ public:
     inline const PositionType offset() const { return m_orderedSet.OffsetType::offset(); }
 
   private:
-    OrderedSet::ConcreteSet m_orderedSet;
+    mutable OrderedSet::ConcreteSet m_orderedSet;
   };
 
 public:  // Functions related to iteration

--- a/src/axom/slam/OrderedSet.hpp
+++ b/src/axom/slam/OrderedSet.hpp
@@ -37,9 +37,7 @@
 #include <vector>
 #include <iterator>
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \class OrderedSet
@@ -497,5 +495,4 @@ bool OrderedSet<PosType, ElemType, SizePolicy, OffsetPolicy, StridePolicy, Indir
   return bValid;
 }
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/ProductSet.hpp
+++ b/src/axom/slam/ProductSet.hpp
@@ -21,9 +21,7 @@
 #include <cassert>
 #include <optional>
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \class ProductSet
@@ -334,5 +332,4 @@ private:
   RowSet<void, typename BaseType::SubsetType> m_rowSet;
 };
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/RangeSet.hpp
+++ b/src/axom/slam/RangeSet.hpp
@@ -10,10 +10,10 @@
  * \file RangeSet.hpp
  *
  * \brief Basic API for an ordered set of entities in a simulation
- *
  */
 
 #include "axom/slam/OrderedSet.hpp"
+#include "axom/slam/Traits.hpp"
 
 namespace axom
 {
@@ -107,6 +107,10 @@ using PositionSet = GenericRangeSet<P, E, policies::ZeroOffset<P>>;
  */
 template <typename P = slam::DefaultPositionType, typename E = slam::DefaultElementType>
 using RangeSet = GenericRangeSet<P, E>;
+
+// Check that RangeSet and PositionSet are set-like
+static_assert(is_ordered_set_like_v<RangeSet<>>, "RangeSet models the ordered-set contract");
+static_assert(is_set_like_v<PositionSet<>>, "PositionSet models the set contract");
 
 }  // end namespace slam
 }  // end namespace axom

--- a/src/axom/slam/RangeSet.hpp
+++ b/src/axom/slam/RangeSet.hpp
@@ -15,9 +15,7 @@
 #include "axom/slam/OrderedSet.hpp"
 #include "axom/slam/Traits.hpp"
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \class GenericRangeSet
@@ -112,5 +110,4 @@ using RangeSet = GenericRangeSet<P, E>;
 static_assert(is_ordered_set_like_v<RangeSet<>>, "RangeSet models the ordered-set contract");
 static_assert(is_set_like_v<PositionSet<>>, "PositionSet models the set contract");
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/Relation.hpp
+++ b/src/axom/slam/Relation.hpp
@@ -18,9 +18,7 @@
 #include "axom/slam/Set.hpp"
 #include "axom/slam/NullSet.hpp"
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 template <typename PosType, typename ElemType>
 class NullSet;
@@ -83,5 +81,4 @@ public:
 template <typename PosType, typename ElemType>
 NullSet<PosType, ElemType> Relation<PosType, ElemType>::s_nullSet;
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/RelationSet.hpp
+++ b/src/axom/slam/RelationSet.hpp
@@ -12,9 +12,7 @@
 
 #include <optional>
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \class RelationSet
@@ -333,5 +331,4 @@ private:
   RelationType* m_relation;  //the relation that this set is based off of
 };
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/Set.hpp
+++ b/src/axom/slam/Set.hpp
@@ -20,9 +20,7 @@
 #include "axom/core/utilities/Utilities.hpp"
 #include "axom/slam/Utilities.hpp"
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \class Set
@@ -167,5 +165,4 @@ inline bool operator!=(const Set<P1, E1>& set1, const Set<P2, E2>& set2)
   return !(set1 == set2);
 }
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/SetBuilders.hpp
+++ b/src/axom/slam/SetBuilders.hpp
@@ -25,6 +25,11 @@
  *   auto s = slam::make_indirection_set(view);  // -> ArrayViewIndirectionSet<.., double>
  * \endcode
  *
+ * The indirection helpers prefer Slam's canonical Axom view policy for non-owning buffers.
+ * Overloads that receive \c axom::ArrayView or \c axom::Array return \c ArrayViewIndirectionSet.
+ * Construct \c ArrayIndirectionSet directly when the set should bind
+ * an \c axom::Array buffer through the \c ArrayIndirection policy.
+ *
  * \note On CTAD vs. helpers. A class-template-argument deduction guide cannot
  *  recover a set's policy stack from a SetBuilder argument: a guide parameter of
  *  the form `typename OrderedSet<P,...>::SetBuilder` is a non-deduced context
@@ -98,6 +103,9 @@ ArrayViewIndirectionSet<PosType, T> make_indirection_set(axom::ArrayView<T> view
  * \brief Make an indirection set whose elements indirect through an std::vector.
  *
  * The element type is deduced from \a vec. The set's size matches the vector.
+ * This host-only overload is retained for std::vector interop.
+ * Prefer the \c axom::Array/axom::ArrayView overloads for new Axom code.
+ *
  * \param vec the backing vector (must outlive the set)
  * \return a VectorIndirectionSet<PosType, T>
  */
@@ -111,8 +119,9 @@ VectorIndirectionSet<PosType, T> make_indirection_set(std::vector<T>& vec)
 /*!
  * \brief Make an indirection set whose elements indirect through an axom::Array's flat storage.
  *
- * The element type is deduced from \a arr; the set is device-capable because it 
- * stores an ArrayView over the array's flat storage. The set's size matches the array.
+ * The element type is deduced from \a arr.
+ * The returned set uses the canonical non-owning ArrayView indirection policy
+ * over the array's flat storage. The set's size matches the array.
  *
  * The set exposes the array in `flatIndex` order: element \c i resolves to
  * `arr.data()[i * arr.minStride()]`, matching axom::Array's own flat-index contract
@@ -137,6 +146,9 @@ ArrayViewIndirectionSet<PosType, T> make_indirection_set(axom::Array<T, DIM, SPA
 
 /*!
  * \brief Make an indirection set whose elements indirect through a C array.
+ *
+ * This low-level overload is retained for raw-pointer interop.
+ * Prefer passing an \c axom::ArrayView when the buffer can be described as a view.
  *
  * \param data pointer to the backing buffer (must outlive the set)
  * \param size the number of elements

--- a/src/axom/slam/SetBuilders.hpp
+++ b/src/axom/slam/SetBuilders.hpp
@@ -25,10 +25,10 @@
  *   auto s = slam::make_indirection_set(view);  // -> ArrayViewIndirectionSet<.., double>
  * \endcode
  *
- * The indirection helpers prefer Slam's canonical Axom view policy for non-owning buffers.
- * Overloads that receive \c axom::ArrayView or \c axom::Array return \c ArrayViewIndirectionSet.
- * Construct \c ArrayIndirectionSet directly when the set should bind
- * an \c axom::Array buffer through the \c ArrayIndirection policy.
+ * These helpers return sets that view a buffer managed elsewhere: 
+ * overloads that receive an \c axom::ArrayView or \c axom::Array return an
+ * \c ArrayViewIndirectionSet (holding an \c axom::ArrayView by value). 
+ * To make a set that manages its own \c axom::Array, construct \c ArrayIndirectionSet directly.
  *
  * \note On CTAD vs. helpers. A class-template-argument deduction guide cannot
  *  recover a set's policy stack from a SetBuilder argument: a guide parameter of
@@ -120,8 +120,8 @@ VectorIndirectionSet<PosType, T> make_indirection_set(std::vector<T>& vec)
  * \brief Make an indirection set whose elements indirect through an axom::Array's flat storage.
  *
  * The element type is deduced from \a arr.
- * The returned set uses the canonical non-owning ArrayView indirection policy
- * over the array's flat storage. The set's size matches the array.
+ * The returned set holds an \c axom::ArrayView over the array's flat storage
+ * (so \a arr must outlive the set). The set's size matches the array.
  *
  * The set exposes the array in `flatIndex` order: element \c i resolves to
  * `arr.data()[i * arr.minStride()]`, matching axom::Array's own flat-index contract

--- a/src/axom/slam/StaticRelation.hpp
+++ b/src/axom/slam/StaticRelation.hpp
@@ -25,9 +25,7 @@
 #include "axom/slam/OrderedSet.hpp"
 #include "axom/slam/Relation.hpp"
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 template <typename PosType,   // = slam::DefaultPositionType,
           typename ElemType,  // = slam::DefaultElementType,
@@ -350,5 +348,4 @@ bool StaticRelation<PosType,
   return bValid;
 }
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/StaticRelation.hpp
+++ b/src/axom/slam/StaticRelation.hpp
@@ -10,8 +10,7 @@
  * \file StaticRelation.hpp
  *
  * \brief API for a topological relation between two sets where the
- *        relation does not change after it is initialized
- *
+ *        relation does not change after it is initialized.
  */
 
 #include "axom/config.hpp"
@@ -57,12 +56,16 @@ public:
                                              policies::StrideOne<SetPosition>,
                                              IndicesIndirectionPolicy>::ConcreteSet;
 
+  // The stored indices set uses the concrete (non-virtual) interface so that a
+  // relation built on a view indirection is trivially copyable / device-capturable.
   using IndicesSet = OrderedSet<SetPosition,
                                 SetElement,
                                 policies::RuntimeSize<SetPosition>,
                                 policies::ZeroOffset<SetPosition>,
                                 policies::StrideOne<SetPosition>,
-                                IndicesIndirectionPolicy>;
+                                IndicesIndirectionPolicy,
+                                policies::NoSubset,
+                                policies::ConcreteInterface>;
 
   using IndirectionBufferType = typename IndicesIndirectionPolicy::IndirectionBufferType;
   using IndirectionRefType = typename IndicesIndirectionPolicy::IndirectionRefType;

--- a/src/axom/slam/SubMap.hpp
+++ b/src/axom/slam/SubMap.hpp
@@ -23,9 +23,7 @@
 #include <type_traits>
 #include <sstream>
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \class SubMap
@@ -487,5 +485,4 @@ private:
   MapRangeIterator m_mapIter;
 };
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/Traits.hpp
+++ b/src/axom/slam/Traits.hpp
@@ -25,8 +25,7 @@
  * \c is_set_like_v excludes bivariate sets explicitly.
  */
 
-#ifndef SLAM_TRAITS_H_
-#define SLAM_TRAITS_H_
+#pragma once
 
 #include <type_traits>
 #include <utility>
@@ -251,5 +250,3 @@ template <typename T>
 inline constexpr bool is_handle_like_v = std::is_trivially_copyable_v<T>;
 
 }  // namespace axom::slam
-
-#endif  // SLAM_TRAITS_H_

--- a/src/axom/slam/Traits.hpp
+++ b/src/axom/slam/Traits.hpp
@@ -33,6 +33,10 @@
 
 namespace axom::slam
 {
+/// Utility for class or member template that serves both const and non-const forms
+template <bool Const, typename T>
+using maybe_const_t = std::conditional_t<Const, const T, T>;
+
 namespace detail
 {
 

--- a/src/axom/slam/Traits.hpp
+++ b/src/axom/slam/Traits.hpp
@@ -1,0 +1,251 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+// files for dates and other details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ * \file Traits.hpp
+ *
+ * \brief Named, compile-time trait predicates for slam's core concepts.
+ *
+ * These variable templates give slam's implicit, duck-typed policy and container contracts
+ * a name, documentation, and enforcement within C++17, and will be converted to C++20 concepts.
+ *
+ * Everything in this header is compile-time, so the predicates are usable in
+ * host and kernel contexts.
+ * 
+ * The predicates categorize a type by the interface it exposes, using the
+ * distinguishing member typedefs each slam concept carries:
+ *   - a Set exposes \c PositionType and \c ElementType and a zero-argument \c size();
+ *   - a Relation exposes \c FromSetType and \c ToSetType;
+ *   - a BivariateSet exposes \c FirstSetType and \c SecondSetType;
+ *   - a Map exposes \c SetType.
+ * Because a BivariateSet also carries \c PositionType, \c ElementType and \c size(),
+ * \c is_set_like_v excludes bivariate sets explicitly.
+ */
+
+#ifndef SLAM_TRAITS_H_
+#define SLAM_TRAITS_H_
+
+#include <type_traits>
+#include <utility>
+
+namespace axom::slam
+{
+namespace detail
+{
+
+//---------------------------------------------------------------------------
+// Member-typedef detectors (void_t idiom).
+//---------------------------------------------------------------------------
+
+template <typename T, typename = void>
+struct has_position_element : std::false_type
+{ };
+template <typename T>
+struct has_position_element<T, std::void_t<typename T::PositionType, typename T::ElementType>>
+  : std::true_type
+{ };
+
+template <typename T, typename = void>
+struct has_from_to_set : std::false_type
+{ };
+template <typename T>
+struct has_from_to_set<T, std::void_t<typename T::FromSetType, typename T::ToSetType>> : std::true_type
+{ };
+
+template <typename T, typename = void>
+struct has_first_second_set : std::false_type
+{ };
+template <typename T>
+struct has_first_second_set<T, std::void_t<typename T::FirstSetType, typename T::SecondSetType>>
+  : std::true_type
+{ };
+
+template <typename T, typename = void>
+struct has_set_type : std::false_type
+{ };
+template <typename T>
+struct has_set_type<T, std::void_t<typename T::SetType>> : std::true_type
+{ };
+
+template <typename T, typename = void>
+struct has_indirection_result : std::false_type
+{ };
+template <typename T>
+struct has_indirection_result<T, std::void_t<typename T::IndirectionResult>> : std::true_type
+{ };
+
+//---------------------------------------------------------------------------
+// Member-function detectors (const-callable).
+//---------------------------------------------------------------------------
+
+template <typename T, typename = void>
+struct has_size : std::false_type
+{ };
+template <typename T>
+struct has_size<T, std::void_t<decltype(std::declval<const T&>().size())>> : std::true_type
+{ };
+
+template <typename T, typename = void>
+struct has_begin_end : std::false_type
+{ };
+template <typename T>
+struct has_begin_end<
+  T,
+  std::void_t<decltype(std::declval<const T&>().begin()), decltype(std::declval<const T&>().end())>>
+  : std::true_type
+{ };
+
+// The value policies expose a zero argument value(); sets and relations do not.
+template <typename T, typename = void>
+struct has_value : std::false_type
+{ };
+template <typename T>
+struct has_value<T, std::void_t<decltype(std::declval<const T&>().value())>> : std::true_type
+{ };
+
+template <typename T, typename = void>
+struct has_stride_accessor : std::false_type
+{ };
+template <typename T>
+struct has_stride_accessor<T, std::void_t<decltype(std::declval<const T&>().stride())>>
+  : std::true_type
+{ };
+
+template <typename T, typename = void>
+struct has_offset_accessor : std::false_type
+{ };
+template <typename T>
+struct has_offset_accessor<T, std::void_t<decltype(std::declval<const T&>().offset())>>
+  : std::true_type
+{ };
+
+// Checks that M is a Map whose SetType is S
+template <typename M, typename S, bool = has_set_type<M>::value>
+struct map_over : std::false_type
+{ };
+template <typename M, typename S>
+struct map_over<M, S, true> : std::is_same<typename M::SetType, S>
+{ };
+
+}  // namespace detail
+
+//---------------------------------------------------------------------------
+// Structural concepts
+//---------------------------------------------------------------------------
+
+/*!
+ * \brief True if \a T models a bivariate set (i.e. has \c FirstSetType and \c SecondSetType).
+ *  Examples: \c ProductSet and \c RelationSet.
+ */
+template <typename T>
+inline constexpr bool is_bivariate_set_like_v = detail::has_first_second_set<T>::value;
+
+/*!
+ * \brief True if \a T models a (univariate) set (i.e. has \c PositionType and \c ElementType typedefs
+ *  and a zero argument \c size(). Bivariate sets are excluded even though they satisfy those members.
+ */
+template <typename T>
+inline constexpr bool is_set_like_v = detail::has_position_element<T>::value &&
+  detail::has_size<T>::value && !is_bivariate_set_like_v<T>;
+
+/*!
+ * \brief True if \a T is a set that also supports ordered iteration via
+ *  const \c begin() / \c end() (e.g. \c OrderedSet, \c RangeSet).
+ */
+template <typename T>
+inline constexpr bool is_ordered_set_like_v = is_set_like_v<T> && detail::has_begin_end<T>::value;
+
+/*!
+ * \brief True if \a T models a relation between two sets
+ *  (i.e. is has   \c FromSetType and \c ToSetType )
+ *  Examples: \c StaticRelation and the \c VariableRelation / \c ConstantRelation aliases.
+ */
+template <typename T>
+inline constexpr bool is_relation_like_v = detail::has_from_to_set<T>::value;
+
+/*!
+ * \brief True if \a T models a map over a set (i.e. it has a \c SetType typedef).
+ *  Examples: \c Map / \c BivariateMap.
+ */
+template <typename T>
+inline constexpr bool is_map_like_v = detail::has_set_type<T>::value;
+
+/*!
+ * \brief True if \a M is a map whose \c SetType is \a S.
+ *  SFINAE-safe for non-map \a M (evaluates to false rather than erroring).
+ */
+template <typename M, typename S>
+inline constexpr bool is_map_over_v = detail::map_over<M, S>::value;
+
+//---------------------------------------------------------------------------
+// Policy concepts
+//---------------------------------------------------------------------------
+
+/*!
+ * \brief True if \a T is a value policy
+ *
+ *  It exposes a zero argument \c value() accessor 
+ *  ( \c RuntimeValue / \c CompileTimeValue and their leaf policies).
+ *  Sets also expose \c size() but not \c value(), which keeps the two apart.
+ */
+template <typename T>
+inline constexpr bool is_value_policy_v = detail::has_value<T>::value;
+
+/*!
+ * \brief True if \a T is a size policy
+ *
+ *  A value policy that also exposes the named \c size() accessor.
+ */
+template <typename T>
+inline constexpr bool is_size_policy_v = detail::has_value<T>::value && detail::has_size<T>::value;
+
+/*!
+ * \brief True if \a T is a stride policy
+ * 
+ *  A value policy that also exposes the named \c stride() accessor.
+ */
+template <typename T>
+inline constexpr bool is_stride_policy_v =
+  detail::has_value<T>::value && detail::has_stride_accessor<T>::value;
+
+/*!
+ * \brief True if \a T is an offset policy
+ * 
+ *  A value policy that also exposes the named \c offset() accessor.
+ */
+template <typename T>
+inline constexpr bool is_offset_policy_v =
+  detail::has_value<T>::value && detail::has_offset_accessor<T>::value;
+
+/*!
+ * \brief True if \a T is an indirection policy (i.e. has an \c IndirectionResult typedef)
+ * 
+ *  Examples: \c NoIndirection, \c ArrayIndirection, \c ArrayViewIndirection,
+ *  \c STLVectorIndirection, \c CArrayIndirection.
+ */
+template <typename T>
+inline constexpr bool is_indirection_policy_v = detail::has_indirection_result<T>::value;
+
+//---------------------------------------------------------------------------
+// Index-space concepts for handle-like elements
+//---------------------------------------------------------------------------
+
+/// \brief True if \a T can serve as a position in a slam index space
+template <typename T>
+inline constexpr bool is_position_like_v = std::is_integral_v<std::remove_cv_t<T>>;
+
+/*!
+ * \brief True if \a T can serve as a slam element handle
+ *
+ *  It must be trivially copyable so it survives capture-by-value into device kernels.
+ *  A type with a user-provided copy constructor fails this by design.
+ */
+template <typename T>
+inline constexpr bool is_handle_like_v = std::is_trivially_copyable_v<T>;
+
+}  // namespace axom::slam
+
+#endif  // SLAM_TRAITS_H_

--- a/src/axom/slam/docs/sphinx/aliases.rst
+++ b/src/axom/slam/docs/sphinx/aliases.rst
@@ -17,7 +17,7 @@ connectivity is shaped, where its data lives, and what is fixed at compile time.
 This page explains the choices that come up most often, and a small set of
 aliases in ``axom/slam/Aliases.hpp`` that name the most common relation configurations.
 
-The aliases are a convenience for these common types and are preffered when applicable.
+The aliases are a convenience for these common types and are preferred when applicable.
 Use the policies directly when needed, e.g. for compile-time strides, indirection buffers
 backed by ``std::vector`` or C-arrays, or specialized cardinalities.
 
@@ -35,7 +35,7 @@ buffer that a set, relation or map indexes through. Slam's default is
 
    slam::Map<double, Cells> density(&cells);   // axom::Array indirection (the default)
 
-The two most common indirection policies differ in who manages the buffer's lifetime**:
+The two most common indirection policies differ in who manages the buffer's lifetime:
 
 ``policies::ArrayIndirection`` (``axom::Array``)
   The Slam object allocates the buffer and frees it when the object is destroyed.
@@ -83,7 +83,7 @@ The same distinction applies to a set's size (``policies::CompileTimeSize`` vs. 
 The set and relation aliases
 ============================
 
-A handful of relation configurations recur across mesh code and requite spelling out all
+A handful of relation configurations recur across mesh code and require spelling out all
 six ``StaticRelation`` policy parameters, so a named shorthand can be helpful.
 The aliases below cover them, together with the two indirection set types.
 Each has a ``*View`` form that uses an ``axom::ArrayView`` (a buffer managed elsewhere) 
@@ -149,7 +149,7 @@ FieldRegistry
 =============
 
 ``FieldRegistry`` is a host-side convenience that keeps a set of named fields and buffers.
-Its field type (``Registry::MapType``) is a ``slam::Map`` with the default ``axom::Array`` indirection,\
+Its field type (``Registry::MapType``) is a ``slam::Map`` with the default ``axom::Array`` indirection,
 and its buffer type (``Registry::BufferType``) is an ``axom::Array``:
 
 .. code-block:: C++

--- a/src/axom/slam/docs/sphinx/aliases.rst
+++ b/src/axom/slam/docs/sphinx/aliases.rst
@@ -1,0 +1,155 @@
+.. ## Copyright (c) Lawrence Livermore National Security, LLC and other
+.. ## Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+.. ## files for dates and other details.
+.. ##
+.. ## SPDX-License-Identifier: (BSD-3-Clause)
+
+============================
+Common aliases and migration
+============================
+
+Slam's core concepts are **sets**, **relations** and **maps**.
+While these are highly configurable, most concrete Slam types are built
+from a common set of policy template parameters provided as aliases 
+in ``axom/slam/Aliases.hpp``.
+
+Use the aliases when code is meant to communicate Slam intent. 
+Use explicit policies when adapting old storage, third-party storage
+or a less common policy stack.
+
+Choosing an alias
+=================
+
+Sets
+----
+
+``RangeSet<P,E>``
+  A contiguous set without explicit storage. Use this for dense ranges of mesh
+  entities such as cells, nodes, materials or levels.
+
+``ArraySet<P,E>``
+  A set whose element ids are stored in an external ``axom::Array``. 
+  The array object is owned elsewhere and must outlive the set.
+
+``ArrayViewSet<P,E>``
+  A set whose element ids are stored in an ``axom::ArrayView`` held by value.
+  Prefer this for non-owning, lightweight views over storage owned elsewhere.
+
+Relations
+---------
+
+``ConstantRelation<FromSet, ToSet, N>``
+  A static relation where each from-set entity has exactly ``N`` related
+  to-set entities. The relation indices are stored in an ``axom::Array``.
+
+``RuntimeConstantRelation<FromSet, ToSet>``
+  A static relation with constant cardinality known at runtime.
+
+``VariableRelation<FromSet, ToSet>``
+  A static, CSR-shaped relation whose cardinality can vary per from-set entity.
+  It stores begin offsets and relation indices in ``axom::Array`` buffers.
+
+The ``*View`` forms use ``axom::ArrayView`` buffers instead of ``axom::Array`` buffers.
+They are the preferred form for lightweight, non-owning traversal and kernel-capturable data.
+
+The dynamic relation classes, ``DynamicConstantRelation`` and ``DynamicVariableRelation``, 
+keep their existing names because their cardinality or connectivity can be edited 
+after construction.
+
+Maps
+----
+
+``ArrayMap<S,T,STRIDE>``
+  An owning map from set ``S`` to values of type ``T``. Its values are stored in
+  an ``axom::Array``. Use this for registry-owned fields, scratch fields and
+  other host-constructed data owned by the map.
+
+``ArrayViewMap<S,T,STRIDE>``
+  A non-owning map view over an ``axom::ArrayView``. Use this when storage is
+  owned elsewhere, or when passing a map-shaped view to generic algorithms or kernels.
+
+``RuntimeArrayMap<S,T>`` and ``RuntimeArrayViewMap<S,T>``
+  Use these when the number of components per set element is known only at runtime.
+
+``ArrayBivariateMap<BSet,T,STRIDE>`` and ``ArrayViewBivariateMap<BSet,T,STRIDE>``
+  Map values over a bivariate set, such as a product set or relation set. Use these for
+  dense/sparse two-axis data, for example material-by-cell or cell-by-material values.
+
+``RuntimeArrayBivariateMap<BSet,T>`` and ``RuntimeArrayViewBivariateMap<BSet,T>``
+  Runtime-stride forms of the bivariate map aliases.
+
+Default map storage
+===================
+
+``slam::Map`` and ``slam::BivariateMap`` now default to ``policies::ArrayIndirection``. 
+That means a map declared without an explicit indirection policy owns an ``axom::Array`` buffer:
+
+.. code-block:: C++
+
+   using Cells = slam::RangeSet<>;
+   using Mats  = slam::RangeSet<>;
+   using CellMatSet = slam::ProductSet<Cells, Mats>;
+
+   Cells cells(numCells);
+   Mats materials(numMaterials);
+   CellMatSet cm(&cells, &materials);
+   slam::Map<double, Cells> density(&cells);            // axom::Array-backed
+   slam::BivariateMap<double, CellMatSet> volfrac(&cm); // axom::Array-backed
+
+The maps in the last two lines can use the following aliases:
+
+.. code-block:: C++
+
+   using Density = slam::ArrayMap<Cells, double>;
+   using Volfrac = slam::ArrayBivariateMap<CellMatSet, double>;
+
+Code that requires ``std::vector`` backing can still use those explicitly:
+
+.. code-block:: C++
+
+   using VecIndirection =
+     slam::policies::STLVectorIndirection<Cells::PositionType, double>;
+
+   using VectorBackedMap =
+     slam::Map<double, Cells, VecIndirection>;
+
+
+FieldRegistry migration
+=======================
+
+``FieldRegistry`` is still a host-side convenience class, but its owning field
+and buffer types now follow the canonical map aliases:
+
+.. code-block:: C++
+
+   using CellSet = slam::RangeSet<>;
+   using Registry = slam::FieldRegistry<CellSet, double>;
+
+   CellSet cells(numCells);
+   Registry fields;
+   auto& density = fields.addField("density", &cells); // Registry::MapType
+   auto& buffer = fields.addBuffer("tmp", cells.size()); // Registry::BufferType
+
+``Registry::BufferType`` is an ``axom::Array<double>``.
+
+Guidance for migrating from ``std::vector``:
+
+* Use ``auto&`` or ``Registry::BufferType&`` instead of ``std::vector<T>&``.
+* Use ``buffer.data()``, ``buffer.size()`` and ``buffer.resize(n)`` for the
+  common vector-like operations.
+* Use ``buffer.view()`` when an ``axom::ArrayView`` is the right interface.
+* Use ``addFieldView()`` or ``addBufferView()`` for externally owned storage.
+
+
+When explicit policies are still appropriate
+============================================
+
+Use the full policy stack instead of these aliases when code needs to:
+
+* Preserve legacy ``std::vector`` storage with ``STLVectorIndirection``.
+* Bind raw pointer storage with ``CArrayIndirection``.
+* Adapt a third-party container such as an application-specific array type.
+* Combine non-default size, offset, stride, subsetting, indirection or interface
+  policies that are not named by the alias layer.
+* Demonstrate or test the policy contract itself.
+

--- a/src/axom/slam/docs/sphinx/aliases.rst
+++ b/src/axom/slam/docs/sphinx/aliases.rst
@@ -4,121 +4,153 @@
 .. ##
 .. ## SPDX-License-Identifier: (BSD-3-Clause)
 
-============================
-Common aliases and migration
-============================
+.. _aliases-label:
 
-Slam's core concepts are **sets**, **relations** and **maps**.
-While these are highly configurable, most concrete Slam types are built
-from a common set of policy template parameters provided as aliases 
-in ``axom/slam/Aliases.hpp``.
+===============================
+Choosing policies and aliases
+===============================
 
-Use the aliases when code is meant to communicate Slam intent. 
-Use explicit policies when adapting old storage, third-party storage
-or a less common policy stack.
+A Slam set, relation or map is assembled from policy template parameters including:
+cardinality, stride, indirection, offset, size, subsetting and interface.
+Choosing those policies is how you describe the data structure, i.e. how its
+connectivity is shaped, where its data lives, and what is fixed at compile time.
+This page explains the choices that come up most often, and a small set of
+aliases in ``axom/slam/Aliases.hpp`` that name the most common relation configurations.
 
-Choosing an alias
-=================
+The aliases are a convenience for these common types and are preffered when applicable.
+Use the policies directly when needed, e.g. for compile-time strides, indirection buffers
+backed by ``std::vector`` or C-arrays, or specialized cardinalities.
 
-Sets
-----
+Where data lives: managed buffers and views
+===========================================
 
-``RangeSet<P,E>``
-  A contiguous set without explicit storage. Use this for dense ranges of mesh
-  entities such as cells, nodes, materials or levels.
-
-``ArraySet<P,E>``
-  A set whose element ids are stored in an external ``axom::Array``. 
-  The array object is owned elsewhere and must outlive the set.
-
-``ArrayViewSet<P,E>``
-  A set whose element ids are stored in an ``axom::ArrayView`` held by value.
-  Prefer this for non-owning, lightweight views over storage owned elsewhere.
-
-Relations
----------
-
-``ConstantRelation<FromSet, ToSet, N>``
-  A static relation where each from-set entity has exactly ``N`` related
-  to-set entities. The relation indices are stored in an ``axom::Array``.
-
-``RuntimeConstantRelation<FromSet, ToSet>``
-  A static relation with constant cardinality known at runtime.
-
-``VariableRelation<FromSet, ToSet>``
-  A static, CSR-shaped relation whose cardinality can vary per from-set entity.
-  It stores begin offsets and relation indices in ``axom::Array`` buffers.
-
-The ``*View`` forms use ``axom::ArrayView`` buffers instead of ``axom::Array`` buffers.
-They are the preferred form for lightweight, non-owning traversal and kernel-capturable data.
-
-The dynamic relation classes, ``DynamicConstantRelation`` and ``DynamicVariableRelation``, 
-keep their existing names because their cardinality or connectivity can be edited 
-after construction.
-
-Maps
-----
-
-``ArrayMap<S,T,STRIDE>``
-  An owning map from set ``S`` to values of type ``T``. Its values are stored in
-  an ``axom::Array``. Use this for registry-owned fields, scratch fields and
-  other host-constructed data owned by the map.
-
-``ArrayViewMap<S,T,STRIDE>``
-  A non-owning map view over an ``axom::ArrayView``. Use this when storage is
-  owned elsewhere, or when passing a map-shaped view to generic algorithms or kernels.
-
-``RuntimeArrayMap<S,T>`` and ``RuntimeArrayViewMap<S,T>``
-  Use these when the number of components per set element is known only at runtime.
-
-``ArrayBivariateMap<BSet,T,STRIDE>`` and ``ArrayViewBivariateMap<BSet,T,STRIDE>``
-  Map values over a bivariate set, such as a product set or relation set. Use these for
-  dense/sparse two-axis data, for example material-by-cell or cell-by-material values.
-
-``RuntimeArrayBivariateMap<BSet,T>`` and ``RuntimeArrayViewBivariateMap<BSet,T>``
-  Runtime-stride forms of the bivariate map aliases.
-
-Default map storage
-===================
-
-``slam::Map`` and ``slam::BivariateMap`` now default to ``policies::ArrayIndirection``. 
-That means a map declared without an explicit indirection policy owns an ``axom::Array`` buffer:
+The most common choice is the indirection policy, which selects the
+buffer that a set, relation or map indexes through. Slam's default is
+``policies::ArrayIndirection``, backed by an ``axom::Array``:
 
 .. code-block:: C++
 
    using Cells = slam::RangeSet<>;
-   using Mats  = slam::RangeSet<>;
-   using CellMatSet = slam::ProductSet<Cells, Mats>;
-
    Cells cells(numCells);
-   Mats materials(numMaterials);
-   CellMatSet cm(&cells, &materials);
-   slam::Map<double, Cells> density(&cells);            // axom::Array-backed
-   slam::BivariateMap<double, CellMatSet> volfrac(&cm); // axom::Array-backed
 
-The maps in the last two lines can use the following aliases:
+   slam::Map<double, Cells> density(&cells);   // axom::Array indirection (the default)
+
+The two most common indirection policies differ in who manages the buffer's lifetime**:
+
+``policies::ArrayIndirection`` (``axom::Array``)
+  The Slam object allocates the buffer and frees it when the object is destroyed.
+  Lifetime is tied to the Slam object.
+
+``policies::ArrayViewIndirection`` (``axom::ArrayView``)
+  The Slam object refers to a buffer that something else (e.g an application array,
+  a registry, another Slam object) allocated and will free.
+  That buffer must outlive the Slam object. An ``ArrayView`` is small and trivially
+  copyable, so it can be handed to a generic algorithm and can be captured in a device kernel.
+
+.. note:: "Manages the buffer" vs. "views a buffer" is a statement about
+   lifetime, not about which piece of code logically owns the data.
+   A map with an ``axom::Array`` indirection frees its buffer as part of its destruction.
+   A map with an ``axom::ArrayView`` indirection leaves that to whoever created the buffer.
+   When a Slam object merely wraps an ``axom::Array`` that lives elsewhere,
+   an ``ArrayView`` indirection is the accurate description 
+   even though the underlying ``axom::Array`` owns its memory.
+
+Two other indirections are supplied for interoperability and to test the interface:
+``policies::STLVectorIndirection`` indexes an ``std::vector``, 
+and ``policies::CArrayIndirection`` indexes a raw pointer.
+Use them when adapting existing storage of that kind.
+
+
+Fixing parameters at compile time
+==================================
+
+Where a quantity is known at compile time, encoding it in a policy lets the
+compiler specialize the generated code and data structures.
+
+The stride of a relation or map is the common case. A quad mesh's
+element-to-vertex relation has exactly four vertices per element,
+so its stride can be a compile-time constant:
 
 .. code-block:: C++
 
-   using Density = slam::ArrayMap<Cells, double>;
-   using Volfrac = slam::ArrayBivariateMap<CellMatSet, double>;
+   using ElemVertRelation =
+     slam::ConstantRelation<ElemSet, VertSet, /* stride */ 4>;   // CompileTimeStride
 
-Code that requires ``std::vector`` backing can still use those explicitly:
+When the same count is only known at runtime, use the runtime form
+(``RuntimeConstantRelation``, or ``policies::RuntimeStride``) directly.
+The same distinction applies to a set's size (``policies::CompileTimeSize`` vs. a runtime size) and offset.
+
+The set and relation aliases
+============================
+
+A handful of relation configurations recur across mesh code and requite spelling out all
+six ``StaticRelation`` policy parameters, so a named shorthand can be helpful.
+The aliases below cover them, together with the two indirection set types.
+Each has a ``*View`` form that uses an ``axom::ArrayView`` (a buffer managed elsewhere) 
+in place of the ``axom::Array`` (a buffer the object manages).
+
+Sets:
+
+``RangeSet<P,E>``
+  A contiguous range of positions, with no separate storage. Use it for dense
+  ranges of mesh entities such as cells, nodes, materials or levels.
+
+``ArraySet<P,E>`` / ``ArrayViewSet<P,E>``
+  A set whose element ids are read from an ``axom::Array`` it manages (``ArraySet``) 
+  or from an ``axom::ArrayView`` of a buffer managed elsewhere (``ArrayViewSet``).
+
+Relations:
+
+``ConstantRelation<FromSet, ToSet, N>``
+  A static relation with exactly ``N`` to-set entities per from-set entity,
+  with ``N`` fixed at compile time.
+
+``RuntimeConstantRelation<FromSet, ToSet>``
+  As above, but with the (constant) cardinality supplied at runtime.
+
+``VariableRelation<FromSet, ToSet>``
+  A static, CSR-shaped relation whose cardinality varies per from-set entity;
+  it holds begin offsets and relation indices.
+
+The dynamic relation classes, ``DynamicConstantRelation`` and
+``DynamicVariableRelation``, keep their own names because their connectivity can
+be edited after construction.
+
+There are intentionally no map aliases. 
+A ``Map`` or ``BivariateMap`` already defaults to an ``axom::Array`` indirection with stride one, 
+so the common cases read clearly on their own:
 
 .. code-block:: C++
 
-   using VecIndirection =
-     slam::policies::STLVectorIndirection<Cells::PositionType, double>;
+   slam::Map<double, Cells> density(&cells);            // one value per cell
+   slam::BivariateMap<double, CellMatSet> volfrac(&cm); // one value per (cell, material)
 
-   using VectorBackedMap =
-     slam::Map<double, Cells, VecIndirection>;
+The cases that vary a map, e.g. a view into a buffer managed elsewhere, or a runtime stride,
+tend to be the cases where a fixed alias name would not capture the configuration cleanly:
 
+.. code-block:: C++
 
-FieldRegistry migration
-=======================
+   using CellPos = Cells::PositionType;
 
-``FieldRegistry`` is still a host-side convenience class, but its owning field
-and buffer types now follow the canonical map aliases:
+   // A field that views a buffer managed elsewhere, with a runtime component count:
+   using ViewedField =
+     slam::Map<double,
+               Cells,
+               slam::policies::ArrayViewIndirection<CellPos, double>,
+               slam::policies::RuntimeStride<CellPos>>;
+
+   // An std::vector-backed field, for interoperation with existing storage:
+   using VectorField =
+     slam::Map<double,
+               Cells,
+               slam::policies::STLVectorIndirection<CellPos, double>>;
+
+FieldRegistry
+=============
+
+``FieldRegistry`` is a host-side convenience that keeps a set of named fields and buffers.
+Its field type (``Registry::MapType``) is a ``slam::Map`` with the default ``axom::Array`` indirection,\
+and its buffer type (``Registry::BufferType``) is an ``axom::Array``:
 
 .. code-block:: C++
 
@@ -127,29 +159,14 @@ and buffer types now follow the canonical map aliases:
 
    CellSet cells(numCells);
    Registry fields;
-   auto& density = fields.addField("density", &cells); // Registry::MapType
-   auto& buffer = fields.addBuffer("tmp", cells.size()); // Registry::BufferType
+   auto& density = fields.addField("density", &cells);    // Registry::MapType
+   auto& buffer  = fields.addBuffer("tmp", cells.size()); // Registry::BufferType (axom::Array<double>)
 
-``Registry::BufferType`` is an ``axom::Array<double>``.
+Because the registry's buffers are now ``axom::Array`` rather than
+``std::vector``, code that consumes them should:
 
-Guidance for migrating from ``std::vector``:
-
-* Use ``auto&`` or ``Registry::BufferType&`` instead of ``std::vector<T>&``.
-* Use ``buffer.data()``, ``buffer.size()`` and ``buffer.resize(n)`` for the
-  common vector-like operations.
-* Use ``buffer.view()`` when an ``axom::ArrayView`` is the right interface.
-* Use ``addFieldView()`` or ``addBufferView()`` for externally owned storage.
-
-
-When explicit policies are still appropriate
-============================================
-
-Use the full policy stack instead of these aliases when code needs to:
-
-* Preserve legacy ``std::vector`` storage with ``STLVectorIndirection``.
-* Bind raw pointer storage with ``CArrayIndirection``.
-* Adapt a third-party container such as an application-specific array type.
-* Combine non-default size, offset, stride, subsetting, indirection or interface
-  policies that are not named by the alias layer.
-* Demonstrate or test the policy contract itself.
-
+* use ``auto&`` or ``Registry::BufferType&`` rather than ``std::vector<T>&``;
+* use ``buffer.data()``, ``buffer.size()`` and ``buffer.resize(n)`` for the
+  common vector-like operations;
+* call ``buffer.view()`` when an ``axom::ArrayView`` is the right interface;
+* register externally-managed storage with ``addFieldView()`` or ``addBufferView()``.

--- a/src/axom/slam/docs/sphinx/core_concepts.rst
+++ b/src/axom/slam/docs/sphinx/core_concepts.rst
@@ -10,7 +10,7 @@
 Core concepts
 =============
 
-This section desribes Slam concepts: what they mean and how they are used.
+This section describes Slam's concepts: what they mean and how they are used.
 
 .. figure:: figs/set_relation_map.png
    :figwidth: 400px
@@ -67,9 +67,13 @@ Maps attach values to the members of a set. In mesh terms, a map is the Slam
 abstraction for scalar, vector or tensor data associated with vertices, cells,
 materials or other entity sets.
 
-``ArrayMap`` is the canonical alias for maps that own their data 
-and store values in ``axom::Array``. ``ArrayViewMap`` is the canonical alias
-for maps that don't own their data.
-``ArrayBivariateMap`` and ``ArrayViewBivariateMap`` attach values to a
-bivariate set, such as a product set or relation set.
+A ``Map`` stores its values in an ``axom::Array`` by default, allocating and freeing
+that buffer as part of the map's lifetime. To point a map at a buffer whose lifetime is
+managed elsewhere, e.g. storage owned by an application, or data to be captured in a device kernel,
+construct it with an ``axom::ArrayView`` indirection instead.
+``BivariateMap`` attaches values to a bivariate set, such as a product set or relation set,
+with the same choice of storage.
+
+See :ref:`aliases-label` for how the map storage default interacts with
+those of other Slam containers, and for the relation aliases.
 

--- a/src/axom/slam/docs/sphinx/core_concepts.rst
+++ b/src/axom/slam/docs/sphinx/core_concepts.rst
@@ -10,7 +10,7 @@
 Core concepts
 =============
 
-Describe Slam concepts, what they mean, how they are used, etc.
+This section desribes Slam concepts: what they mean and how they are used.
 
 .. figure:: figs/set_relation_map.png
    :figwidth: 400px
@@ -25,9 +25,12 @@ Describe Slam concepts, what they mean, how they are used, etc.
 Set
 ===
 
-* Taxonomy of set types (OrderedSet, IndirectionSet, Subset, static vs. dynamic)
-* Simple API (including semantics of operator[] and iterators )
-* Example to show how we iterate through a set
+Sets model mesh entities such as vertices, zones, materials or refinement levels.
+Ordered sets associate each entity with a position so Slam code can iterate
+and index efficiently.
+
+Use ``RangeSet`` for contiguous ranges. Use ``ArraySet`` or ``ArrayViewSet``
+when set elements are stored in Axom buffers.
 
 .. Future
    Discuss different indexing schemes for ProductSets
@@ -38,16 +41,21 @@ Set
 Relation
 ========
 
-* Relational operator (from element of Set A to set of elements in Set B)
-* Taxonomy:
-    * Cardinality: Fixed vs Variable number of elements per relation
-    * Mutability: Static vs. Dynamic relation
-    * Storage: Implicit vs. Explicit (e.g. product set)
-* Simple API (including semantics of operator[] )
-* Three ways to iterate through a relations
-    * Double subscript
-    * Separate subscripts
-    * Iterators
+A relation connects elements from a `from-set` to those of a `to-set`
+and can be used to encode mesh incidence and adjacency relations, such 
+as those from cells to vertices, from vertices to cells, from zones to materials
+or from elements to neighboring elements.
+
+Slam classifies relations along a few independent axes:
+
+* cardinality: constant per from-set entity or variable per from-set entity
+* mutability: static after construction or dynamically editable
+* storage: implicit, such as a product set, or explicit, such as index buffers
+
+Use ``ConstantRelation`` / ``ConstantRelationView`` for static fixed-cardinality
+relations and ``VariableRelation`` / ``VariableRelationView`` for static
+CSR-shaped relations. Use ``DynamicConstantRelation`` or
+``DynamicVariableRelation`` when the connectivity needs to be edited.
 
 
 .. _map-concept-label:
@@ -55,5 +63,13 @@ Relation
 Map
 ===
 
-* Data associated with all members of a set
-* Simple API (including semantics of operator[] )
+Maps attach values to the members of a set. In mesh terms, a map is the Slam
+abstraction for scalar, vector or tensor data associated with vertices, cells,
+materials or other entity sets.
+
+``ArrayMap`` is the canonical alias for maps that own their data 
+and store values in ``axom::Array``. ``ArrayViewMap`` is the canonical alias
+for maps that don't own their data.
+``ArrayBivariateMap`` and ``ArrayViewBivariateMap`` attach values to a
+bivariate set, such as a product set or relation set.
+

--- a/src/axom/slam/docs/sphinx/first_example.rst
+++ b/src/axom/slam/docs/sphinx/first_example.rst
@@ -45,14 +45,16 @@ Type aliases and variables
 We begin by defining some type aliases for the Sets, Relations and Maps in our mesh.
 These type aliases would typically be found in a configuration file or in class header files.
 
-Each type is assembled from the policies that describe how it behaves,
-for example, the cardinality and stride of a relation, or the storage backing a map.
+Each Slam type is assembled from policies that describe how it behaves, for example the
+cardinality and stride of a relation, or the storage backing a map. 
 
-This follows Slam's central design philosophy: the policies name the design choices for the data structure.
-For the relations below we spell those policies out, and for common relation configurations,
-the aliases in ``axom/slam/Aliases.hpp`` (:ref:`aliases-label`) provide a shorthand.
+This follows Slam's central design philosophy: the policies name the design choices for the data structure. Spelling out every policy is always available when you need fine control, but the common
+configurations have named shorthands in ``axom/slam/Aliases.hpp`` (:ref:`aliases-label`),
+and we use those aliases throughout this example.
 
-We use the following types throughout this example:
+We use the following buffer type for the mesh connectivity data.
+Slam objects index into their data through a buffer; ``axom::Array`` is Slam's canonical
+choice, and it is the default storage for the aliases and helpers used below:
 
 .. literalinclude:: ../../examples/UserDocs.cpp
    :start-after: _quadmesh_example_common_typedefs_start
@@ -89,8 +91,9 @@ We also have relations describing the incidences between the mesh vertices and e
 
 The element-to-vertex *boundary* relation encodes the indices of the vertices in the
 boundary of each element. Since this is a quad mesh and there are always four vertices in
-the boundary of a quadrilateral, we use a ``ConstantCardinality`` policy with a
-``CompileTimeStride`` set to 4 for this ``StaticRelation``.
+the boundary of a quadrilateral, its cardinality is a compile-time constant. We use the
+``slam::ConstantRelation`` alias, which names the common configuration of a ``StaticRelation``
+with a ``ConstantCardinality`` policy, a ``CompileTimeStride`` (here, 4), and ``axom::Array`` storage:
 
 .. literalinclude:: ../../examples/UserDocs.cpp
    :start-after: _quadmesh_example_bdry_relation_typedefs_start
@@ -99,12 +102,18 @@ the boundary of a quadrilateral, we use a ``ConstantCardinality`` policy with a
 
 The vertex-to-element *coboundary* relation encodes the indices of all elements incident
 in each of the vertices. Since the cardinality of this relation changes for different
-vertices, we use a ``VariableCardinality`` policy for this ``StaticRelation``.
+vertices, we use the ``slam::VariableRelation`` alias, which names a ``StaticRelation`` with
+a ``VariableCardinality`` policy and ``axom::Array`` storage:
 
 .. literalinclude:: ../../examples/UserDocs.cpp
    :start-after: _quadmesh_example_cobdry_relation_typedefs_start
    :end-before:  _quadmesh_example_cobdry_relation_typedefs_end
    :language: C++
+
+.. note:: Each alias has a ``*View`` counterpart (``ConstantRelationView``, ``VariableRelationView``)
+   that refers to buffers managed elsewhere through an ``axom::ArrayView``,
+   rather than ``axom::Array`` buffers it manages. When a configuration is not covered by an alias,
+   spell out the ``StaticRelation`` policies directly. See :ref:`aliases-label`.
 
 We declare them as:
 
@@ -169,18 +178,19 @@ The values of the vertex indices range from ``0`` to ``verts.size()-1`` (and sim
 Relations
 ---------
 
-The relations are constructed by binding their associated sets and arrays of data to the
-relation instance. In this example, we use an internal helper class ``RelationBuilder``.
+The relations are constructed by binding their associated sets and buffers of connectivity data.
+We use the ``slam::make_*_relation`` helper functions, which deduce the relation type from their arguments (including the ``axom::Array`` buffers) and return a ready-to-use relation.
 
-We construct the boundary relation by attaching its two sets (``elems`` for its ``fromSet``
-and ``verts`` for its ``toSet``) and an array of indices for the relation's data.
+We construct the boundary relation from its two sets 
+(``elems`` as its ``fromSet`` and ``verts`` as its ``toSet``)
+and the array of vertex indices:
 
 .. literalinclude:: ../../examples/UserDocs.cpp
    :start-after: _quadmesh_example_construct_bdry_relation_start
    :end-before:  _quadmesh_example_construct_bdry_relation_end
    :language: C++
 
-The Coboundary relation requires an additional array of offsets (``begins``) 
+The coboundary relation requires an additional array of offsets (``begins``)
 to indicate the starting index in the relation for each vertex:
 
 .. literalinclude:: ../../examples/UserDocs.cpp
@@ -189,12 +199,14 @@ to indicate the starting index in the relation for each vertex:
    :language: C++
 
 
-Since these are static relations, we used data that was constructed elsewhere.
-Note that these relations are lightweight wrappers over the underlying data, 
-and no data is copied. To iteratively build the relations, 
-we would use the ``DynamicConstantRelation`` and ``DynamicVariableRelation`` classes.
+Since these are static relations, they refer to data that was constructed elsewhere
+(the ``axom::Array`` buffers, which must outlive the relations).
+The relations are lightweight views over that data, and no data is copied. To iteratively
+build relations instead, we would use the ``DynamicConstantRelation`` and
+``DynamicVariableRelation`` classes.
 
-See :ref:`setup-label` for more details about Slam's ``Builder`` classes for sets, relations and maps.
+The ``make_*`` helpers wrap Slam's lower-level ``Builder`` classes; see :ref:`setup-label`
+for more details about constructing sets, relations and maps directly.
 
 Maps
 ----

--- a/src/axom/slam/docs/sphinx/first_example.rst
+++ b/src/axom/slam/docs/sphinx/first_example.rst
@@ -48,6 +48,9 @@ We begin by defining some type aliases for the Sets, Relations and Maps in our m
 These type aliases would typically be found in a configuration file or in class header
 files.
 
+The following example uses some relation policies to explicitly bind fixed raw arrays. 
+For Axom-owned storage, prefer the ``Array*`` aliases.
+
 We use the following types throughout this example:
 
 .. literalinclude:: ../../examples/UserDocs.cpp
@@ -55,6 +58,7 @@ We use the following types throughout this example:
    :end-before:  _quadmesh_example_common_typedefs_end
    :language: C++
 
+Axom code should prefer the common aliases from ``axom/slam/Aliases.hpp`` where they apply. 
 
 Sets
 ----
@@ -124,6 +128,11 @@ It is templated on a point type (``Point2``) that handles simple operations on 2
    :start-after: _quadmesh_example_maps_typedefs_start
    :end-before:  _quadmesh_example_maps_typedefs_end
    :language: C++
+
+``ArrayMap`` is the canonical owning map alias. It stores map values in
+``axom::Array`` and mirrors the default storage used by ``slam::Map`` when no
+indirection policy is specified. Use ``ArrayViewMap`` in cases where Slam only
+has a view to data to external data (which it does not own).
 
 It is declared as:
 

--- a/src/axom/slam/docs/sphinx/first_example.rst
+++ b/src/axom/slam/docs/sphinx/first_example.rst
@@ -8,20 +8,18 @@
 An introductory example
 =======================
 
-This file contains an introductory example to define and traverse a simple quadrilateral
-mesh. The code for this example can be found in
-``axom/src/axom/slam/examples/UserDocs.cpp``.
+This file contains an introductory example to define and traverse a simple quadrilateral mesh.
+The code for this example can be found in ``axom/src/axom/slam/examples/UserDocs.cpp``.
 
 .. figure:: figs/quad_mesh.png
    :figwidth: 400px
    :alt: A quad mesh with five elements
    :align: center
 
-   An unstructured mesh with eleven vertices (red circles) and five elements
-   (quadrilaterals bounded by black lines)
+   An unstructured mesh with eleven vertices (red circles) 
+   and five elements (quadrilaterals bounded by black lines)
 
-We first import the unified Slam header, which includes all necessary files for working
-with slam:
+We first import the unified Slam header, which includes all necessary files for working with Slam:
 
 .. literalinclude:: ../../examples/UserDocs.cpp
    :start-after: _quadmesh_example_import_header_start
@@ -45,11 +43,14 @@ Type aliases and variables
 
 
 We begin by defining some type aliases for the Sets, Relations and Maps in our mesh.
-These type aliases would typically be found in a configuration file or in class header
-files.
+These type aliases would typically be found in a configuration file or in class header files.
 
-The following example uses some relation policies to explicitly bind fixed raw arrays. 
-For Axom-owned storage, prefer the ``Array*`` aliases.
+Each type is assembled from the policies that describe how it behaves,
+for example, the cardinality and stride of a relation, or the storage backing a map.
+
+This follows Slam's central design philosophy: the policies name the design choices for the data structure.
+For the relations below we spell those policies out, and for common relation configurations,
+the aliases in ``axom/slam/Aliases.hpp`` (:ref:`aliases-label`) provide a shorthand.
 
 We use the following types throughout this example:
 
@@ -57,8 +58,6 @@ We use the following types throughout this example:
    :start-after: _quadmesh_example_common_typedefs_start
    :end-before:  _quadmesh_example_common_typedefs_end
    :language: C++
-
-Axom code should prefer the common aliases from ``axom/slam/Aliases.hpp`` where they apply. 
 
 Sets
 ----
@@ -129,10 +128,9 @@ It is templated on a point type (``Point2``) that handles simple operations on 2
    :end-before:  _quadmesh_example_maps_typedefs_end
    :language: C++
 
-``ArrayMap`` is the canonical owning map alias. It stores map values in
-``axom::Array`` and mirrors the default storage used by ``slam::Map`` when no
-indirection policy is specified. Use ``ArrayViewMap`` in cases where Slam only
-has a view to data to external data (which it does not own).
+The map's values are stored in an ``axom::Array`` that the map allocates and frees itself.
+To instead point a map at a buffer whose lifetime is managed elsewhere (for instance, to view data owned by an application or
+to pass a map into a device kernel), give it an ``axom::ArrayView`` indirection via ``policies::ArrayViewIndirection``.
 
 It is declared as:
 
@@ -145,8 +143,7 @@ It is declared as:
 Constructing the mesh
 =====================
 
-This example uses a very simple fixed mesh, which is assumed to not change after it has
-been initialized.
+This example uses a very simple fixed mesh, which is assumed to not change after it has been initialized.
 
 Sets
 ----
@@ -158,8 +155,7 @@ The sets are created using a constructor that takes the number of elements.
    :end-before:  _quadmesh_example_construct_sets_end
    :language: C++
 
-The values of the vertex indices range from ``0`` to ``verts.size()-1`` (and similarly
-for ``elems``).
+The values of the vertex indices range from ``0`` to ``verts.size()-1`` (and similarly for ``elems``).
 
 .. note:: All sets, relations and maps in Slam have internal validity checks using
    the ``isValid()`` function:
@@ -176,17 +172,16 @@ Relations
 The relations are constructed by binding their associated sets and arrays of data to the
 relation instance. In this example, we use an internal helper class ``RelationBuilder``.
 
-We construct the boundary relation by attaching its two sets (``elems`` for its
-``fromSet`` and ``verts`` for its ``toSet``) and an array of indices for the relation's
-data.
+We construct the boundary relation by attaching its two sets (``elems`` for its ``fromSet``
+and ``verts`` for its ``toSet``) and an array of indices for the relation's data.
 
 .. literalinclude:: ../../examples/UserDocs.cpp
    :start-after: _quadmesh_example_construct_bdry_relation_start
    :end-before:  _quadmesh_example_construct_bdry_relation_end
    :language: C++
 
-The Coboundary relation requires an additional array of offsets (``begins``) to indicate
-the starting index in the relation for each vertex:
+The Coboundary relation requires an additional array of offsets (``begins``) 
+to indicate the starting index in the relation for each vertex:
 
 .. literalinclude:: ../../examples/UserDocs.cpp
    :start-after: _quadmesh_example_construct_cobdry_relation_start
@@ -195,19 +190,18 @@ the starting index in the relation for each vertex:
 
 
 Since these are static relations, we used data that was constructed elsewhere.
-Note that these relations are lightweight wrappers over the underlying data -- no data is
-copied. To iteratively build the relations, we would use the ``DynamicConstantRelation``
-and ``DynamicVariableRelation`` classes.
+Note that these relations are lightweight wrappers over the underlying data, 
+and no data is copied. To iteratively build the relations, 
+we would use the ``DynamicConstantRelation`` and ``DynamicVariableRelation`` classes.
 
-See :ref:`setup-label` for more details about Slam's ``Builder`` classes for sets,
-relations and maps.
+See :ref:`setup-label` for more details about Slam's ``Builder`` classes for sets, relations and maps.
 
 Maps
 ----
 
 We define the positions of the mesh vertices as a ``Map`` on the ``verts`` set.
-For this example, we set the first vertex to lie at the origin, and the remaining
-vertices line within an annulus around the unit circle.
+For this example, we set the first vertex to lie at the origin,
+and the remaining vertices line within an annulus around the unit circle.
 
 .. literalinclude:: ../../examples/UserDocs.cpp
    :start-after: _quadmesh_example_vert_positions_start
@@ -218,14 +212,13 @@ vertices line within an annulus around the unit circle.
 Traversing the mesh
 ===================
 
-Now that we've constructed the mesh, we can start traversing the mesh connectivity
-and attaching more fields.
+Now that we've constructed the mesh, we can start traversing the mesh connectivity and attaching more fields.
 
 Computing a derived field
 -------------------------
 
-Our first traversal loops through the vertices and computes a derived field on the
-position map. For each vertex, we compute its distance to the origin.
+Our first traversal loops through the vertices and computes a derived field on the position map.
+For each vertex, we compute its distance to the origin.
 
 .. literalinclude:: ../../examples/UserDocs.cpp
    :start-after: _quadmesh_example_vert_distances_start
@@ -243,21 +236,18 @@ Our next example uses element-to-vertex boundary relation to compute the
    :end-before:  _quadmesh_example_elem_centroids_end
    :language: C++
 
-Perhaps the most interesting line here is when we call the relation's subscript
-operator (``bdry[eID]``).  This function takes an element index
-(``eID``) and returns the *set* of vertices that are incident in this element.
-As such, we can use all functions in the Set API on this return type, e.g. ``size()``
-and the subscript operator.
+Perhaps the most interesting line here is when we call the relation's subscript operator (``bdry[eID]``).
+This function takes an element index (``eID``) and returns the *set* of vertices that are incident in this element.
+As such, we can use all functions in the Set API on this return type, e.g. ``size()`` and the subscript operator.
 
 Outputting mesh to disk
 -----------------------
 
-As a final example, we highlight several different ways to iterate through the
-mesh's Sets, Relations and Maps as we output the mesh to disk (in the ``vtk`` format).
+As a final example, we highlight several different ways to iterate through the mesh's Sets, Relations and Maps
+as we output the mesh to disk (in the ``vtk`` format).
 
-This is a longer example, but the callouts
-(left-aligned comments of the form  ``// <-- message`` ) point to
-different iteration patterns.
+This is a longer example, but the callouts (left-aligned comments 
+of the form  ``// <-- message`` ) point to different iteration patterns.
 
 .. literalinclude:: ../../examples/UserDocs.cpp
    :start-after: _quadmesh_example_output_vtk_start

--- a/src/axom/slam/docs/sphinx/implementation_details.rst
+++ b/src/axom/slam/docs/sphinx/implementation_details.rst
@@ -16,7 +16,11 @@ Policy-based design
 Slam uses policy-based design to combine the storage and indexing behavior a
 type needs without paying for features it does not use.
 
-Common policies include:
+Slam defines several aliases for commonly used configurations (see :doc:`aliases`), 
+and its types are extensible to custom storage, legacy storage 
+and less common combinations that the alias layer does not intentionally name.
+
+Policies include:
 
 * SizePolicy, StridePolicy, OffsetPolicy (compile time vs. runtime)
 * IndirectionPolicy, which chooses how set elements, relation indices and map
@@ -34,14 +38,14 @@ Common policies include:
 * SubsettingPolicy (none, virtual parent, concrete parent)
 * OwnershipPolicy (local, sidre, other repository)
 
+``Map`` and ``BivariateMap`` default to ``ArrayIndirection``.
 
-Feature diagram of OrderedSet policies (subset).
+The following feature diagram of OrderedSet policies shows how these policies
+interact with the subscript operator:
 
 .. figure:: figs/orderedset_feature_diagram.png
    :figwidth: 100%
    :alt: Feature diagram for slam's ordered set
-
-The figure shows how these policies interact with the subscript operator.
 
 
 .. _setup-label:

--- a/src/axom/slam/docs/sphinx/implementation_details.rst
+++ b/src/axom/slam/docs/sphinx/implementation_details.rst
@@ -27,20 +27,19 @@ Policies include:
   values are reached through backing storage:
 
   * ``NoIndirection`` for implicit ``element == position`` storage
-  * ``ArrayIndirection`` for the canonical ``axom::Array``-backed policy used
-    when Slam owns or manages an Axom buffer
-  * ``ArrayViewIndirection`` for the canonical non-owning ``axom::ArrayView``
-    policy used to view externally owned storage and to build lightweight,
-    device-capturable Slam objects
-  * ``CArrayIndirection`` and ``STLVectorIndirection`` as compatibility and
-    reference examples
+  * ``ArrayIndirection`` (the default), backed by an ``axom::Array``
+    whose lifetime the Slam object manages
+  * ``ArrayViewIndirection``, backed by an ``axom::ArrayView`` of a buffer managed elsewhere.
+    These are small and trivially copyable, so it is the form used for lightweight, device-capturable Slam objects
+  * ``CArrayIndirection`` and ``STLVectorIndirection`` for interoperation 
+    with raw-pointer and ``std::vector`` storage
   * custom policies, e.g. ``mfem::Array`` adapters
 * SubsettingPolicy (none, virtual parent, concrete parent)
 * OwnershipPolicy (local, sidre, other repository)
 
 ``Map`` and ``BivariateMap`` default to ``ArrayIndirection``.
 
-The following feature diagram of OrderedSet policies shows how these policies
+The following feature diagram of ``slam::OrderedSet`` policies shows how these policies
 interact with the subscript operator:
 
 .. figure:: figs/orderedset_feature_diagram.png

--- a/src/axom/slam/docs/sphinx/implementation_details.rst
+++ b/src/axom/slam/docs/sphinx/implementation_details.rst
@@ -13,10 +13,24 @@ Implementation details
 Policy-based design
 ===================
 
-Handling the combinatorial explosion of features; avoid paying for what we don't need
+Slam uses policy-based design to combine the storage and indexing behavior a
+type needs without paying for features it does not use.
+
+Common policies include:
 
 * SizePolicy, StridePolicy, OffsetPolicy (compile time vs. runtime)
-* IndirectionPolicy (none, C-array, std::vector, custom, e.g. mfem::Array)
+* IndirectionPolicy, which chooses how set elements, relation indices and map
+  values are reached through backing storage:
+
+  * ``NoIndirection`` for implicit ``element == position`` storage
+  * ``ArrayIndirection`` for the canonical ``axom::Array``-backed policy used
+    when Slam owns or manages an Axom buffer
+  * ``ArrayViewIndirection`` for the canonical non-owning ``axom::ArrayView``
+    policy used to view externally owned storage and to build lightweight,
+    device-capturable Slam objects
+  * ``CArrayIndirection`` and ``STLVectorIndirection`` as compatibility and
+    reference examples
+  * custom policies, e.g. ``mfem::Array`` adapters
 * SubsettingPolicy (none, virtual parent, concrete parent)
 * OwnershipPolicy (local, sidre, other repository)
 
@@ -27,7 +41,7 @@ Feature diagram of OrderedSet policies (subset).
    :figwidth: 100%
    :alt: Feature diagram for slam's ordered set
 
-The figure shows how certain these policies interact with the subscript operator.
+The figure shows how these policies interact with the subscript operator.
 
 
 .. _setup-label:

--- a/src/axom/slam/docs/sphinx/index.rst
+++ b/src/axom/slam/docs/sphinx/index.rst
@@ -83,10 +83,11 @@ Current limitations
 
 * Slam is under active development with many features planned.
 * Support for GPUs in Slam is under development.
-* Slam's policy-based design enable highly configurable classes  which are explicitly
-  defined via type aliases. We are investigating ways to simplify this set up
-  using *Generator* classes where enumerated strings can define related types 
-  within a mesh configuration.
+* Slam's policy-based design yields highly configurable types that are named
+  through type aliases. ``axom/slam/Aliases.hpp`` provides shorthands for the
+  most common set and relation configurations (see :ref:`aliases-label`); we are
+  also investigating *Generator* classes, where enumerated strings could define
+  the related types within a mesh configuration.
 
 
 .. toctree::

--- a/src/axom/slam/docs/sphinx/index.rst
+++ b/src/axom/slam/docs/sphinx/index.rst
@@ -95,5 +95,6 @@ Current limitations
 
    first_example
    core_concepts
+   aliases
    implementation_details
    portability

--- a/src/axom/slam/docs/sphinx/portability.rst
+++ b/src/axom/slam/docs/sphinx/portability.rst
@@ -47,7 +47,6 @@ Slam uses ``std::optional`` for optional-returning APIs.
 The CUDA host-configs enable ``--expt-relaxed-constexpr``,
 and HIP's compiler accepts these standard library calls from host-device paths in the supported builds.
 
-The device-side contract is to check ``has_value()`` before dereferencing with
-``operator*``, or to use ``value_or``. Avoid ``value()`` in kernels because
-standard library implementations can route the disengaged case through a
-throwing host-only helper.
+The device-side contract is to check ``has_value()`` before dereferencing with ``operator*``,
+or to use ``value_or``. Avoid ``value()`` in kernels because standard library implementations
+can route the disengaged case through a throwing host-only helper.

--- a/src/axom/slam/examples/ShockTube.cpp
+++ b/src/axom/slam/examples/ShockTube.cpp
@@ -128,13 +128,13 @@ public:
 
   using EFCard = slam::policies::ConstantCardinality<PositionType, EFStride>;
   using FECard = slam::policies::ConstantCardinality<PositionType, FEStride>;
-  using STLIndirection = slam::policies::STLVectorIndirection<PositionType, ElementType>;
-  using IndexVec = typename STLIndirection::IndirectionBufferType;
+  using ArrayIndirection = slam::policies::ArrayIndirection<PositionType, ElementType>;
+  using IndexVec = typename ArrayIndirection::IndirectionBufferType;
 
   using TubeElemToFaceRelation =
-    slam::StaticRelation<PositionType, ElementType, EFCard, STLIndirection, ElemSubset, FaceSet>;
+    slam::StaticRelation<PositionType, ElementType, EFCard, ArrayIndirection, ElemSubset, FaceSet>;
   using FaceToElemRelation =
-    slam::StaticRelation<PositionType, ElementType, FECard, STLIndirection, FaceSet, ElemSet>;
+    slam::StaticRelation<PositionType, ElementType, FECard, ArrayIndirection, FaceSet, ElemSet>;
 
 public:
   ElemSet elems;            // The entire set of elements
@@ -290,7 +290,7 @@ void CreateShockTubeMesh(ShockTubeMesh* mesh)
   /// Setup the FaceToElem relation
   IndexVec& feRelVec =
     intsRegistry.addBuffer("feRel", ShockTubeMesh::FACES_PER_ELEM * mesh->faces.size());
-  IndexVec::iterator relIt = feRelVec.begin();
+  auto relIt = feRelVec.begin();
   for(ShockTubeMesh::IndexType idx = 0;
       idx < static_cast<ShockTubeMesh::IndexType>(mesh->faces.size());
       ++idx)

--- a/src/axom/slam/examples/ShockTube.cpp
+++ b/src/axom/slam/examples/ShockTube.cpp
@@ -123,18 +123,10 @@ public:
     FACES_PER_ELEM = 2
   };
 
-  using EFStride = slam::policies::CompileTimeStride<PositionType, FACES_PER_ELEM>;
-  using FEStride = slam::policies::CompileTimeStride<PositionType, ELEMS_PER_FACE>;
+  using IndexVec = axom::Array<ElementType>;
 
-  using EFCard = slam::policies::ConstantCardinality<PositionType, EFStride>;
-  using FECard = slam::policies::ConstantCardinality<PositionType, FEStride>;
-  using ArrayIndirection = slam::policies::ArrayIndirection<PositionType, ElementType>;
-  using IndexVec = typename ArrayIndirection::IndirectionBufferType;
-
-  using TubeElemToFaceRelation =
-    slam::StaticRelation<PositionType, ElementType, EFCard, ArrayIndirection, ElemSubset, FaceSet>;
-  using FaceToElemRelation =
-    slam::StaticRelation<PositionType, ElementType, FECard, ArrayIndirection, FaceSet, ElemSet>;
+  using TubeElemToFaceRelation = slam::ConstantRelation<ElemSubset, FaceSet, FACES_PER_ELEM>;
+  using FaceToElemRelation = slam::ConstantRelation<FaceSet, ElemSet, ELEMS_PER_FACE>;
 
 public:
   ElemSet elems;            // The entire set of elements

--- a/src/axom/slam/examples/UnstructMeshField.cpp
+++ b/src/axom/slam/examples/UnstructMeshField.cpp
@@ -65,10 +65,10 @@ public:
 
   /// types for maps
   using BaseSet = axom::slam::Set<PositionType, ElementType>;
-  using NodalPositions = slam::ArrayMap<BaseSet, Point3>;
-  using ZonalPositions = slam::ArrayMap<BaseSet, Point3>;
-  using NodeField = slam::ArrayMap<BaseSet, DataType>;
-  using ZoneField = slam::ArrayMap<BaseSet, DataType>;
+  using NodalPositions = slam::Map<Point3, BaseSet>;
+  using ZonalPositions = slam::Map<Point3, BaseSet>;
+  using NodeField = slam::Map<DataType, BaseSet>;
+  using ZoneField = slam::Map<DataType, BaseSet>;
 
 public:
   /** \brief Simple accessor for the number of nodes in the mesh  */
@@ -101,8 +101,8 @@ struct Repository
   using SetType = axom::slam::Set<>;
   using IntsRegistry = slam::FieldRegistry<SetType, SetType::ElementType>;
   using RealsRegistry = slam::FieldRegistry<SetType, double>;
-  using IntField = slam::ArrayMap<SetType, int>;
-  using RealField = slam::ArrayMap<SetType, double>;
+  using IntField = slam::Map<int, SetType>;
+  using RealField = slam::Map<double, SetType>;
 
   static IntsRegistry intsRegistry;
   static RealsRegistry realsRegistry;

--- a/src/axom/slam/examples/UnstructMeshField.cpp
+++ b/src/axom/slam/examples/UnstructMeshField.cpp
@@ -57,24 +57,18 @@ public:
   using ZoneSet = slam::PositionSet<PositionType, ElementType>;
 
   /// types for relations
-  using ArrayIndirection = slam::policies::ArrayIndirection<PositionType, PositionType>;
-  using VariableCardinality = slam::policies::VariableCardinality<PositionType, ArrayIndirection>;
-  using NodeToZoneRelation =
-    slam::StaticRelation<PositionType, ElementType, VariableCardinality, ArrayIndirection, NodeSet, ZoneSet>;
+  using NodeToZoneRelation = slam::VariableRelation<NodeSet, ZoneSet>;
   using NodeZoneIterator = NodeToZoneRelation::RelationConstIterator;
 
-  using ZNStride = slam::policies::CompileTimeStride<PositionType, NODES_PER_ZONE>;
-  using ConstantCardinality = slam::policies::ConstantCardinality<PositionType, ZNStride>;
-  using ZoneToNodeRelation =
-    slam::StaticRelation<PositionType, ElementType, ConstantCardinality, ArrayIndirection, ZoneSet, NodeSet>;
+  using ZoneToNodeRelation = slam::ConstantRelation<ZoneSet, NodeSet, NODES_PER_ZONE>;
   using ZoneNodeIterator = ZoneToNodeRelation::RelationConstIterator;
 
   /// types for maps
   using BaseSet = axom::slam::Set<PositionType, ElementType>;
-  using NodalPositions = slam::Map<Point3>;
-  using ZonalPositions = slam::Map<Point3>;
-  using NodeField = slam::Map<DataType>;
-  using ZoneField = slam::Map<DataType>;
+  using NodalPositions = slam::ArrayMap<BaseSet, Point3>;
+  using ZonalPositions = slam::ArrayMap<BaseSet, Point3>;
+  using NodeField = slam::ArrayMap<BaseSet, DataType>;
+  using ZoneField = slam::ArrayMap<BaseSet, DataType>;
 
 public:
   /** \brief Simple accessor for the number of nodes in the mesh  */
@@ -107,8 +101,8 @@ struct Repository
   using SetType = axom::slam::Set<>;
   using IntsRegistry = slam::FieldRegistry<SetType, SetType::ElementType>;
   using RealsRegistry = slam::FieldRegistry<SetType, double>;
-  using IntField = slam::Map<int>;
-  using RealField = slam::Map<double>;
+  using IntField = slam::ArrayMap<SetType, int>;
+  using RealField = slam::ArrayMap<SetType, double>;
 
   static IntsRegistry intsRegistry;
   static RealsRegistry realsRegistry;

--- a/src/axom/slam/examples/UnstructMeshField.cpp
+++ b/src/axom/slam/examples/UnstructMeshField.cpp
@@ -57,16 +57,16 @@ public:
   using ZoneSet = slam::PositionSet<PositionType, ElementType>;
 
   /// types for relations
-  using STLIndirection = slam::policies::STLVectorIndirection<PositionType, PositionType>;
-  using VariableCardinality = slam::policies::VariableCardinality<PositionType, STLIndirection>;
+  using ArrayIndirection = slam::policies::ArrayIndirection<PositionType, PositionType>;
+  using VariableCardinality = slam::policies::VariableCardinality<PositionType, ArrayIndirection>;
   using NodeToZoneRelation =
-    slam::StaticRelation<PositionType, ElementType, VariableCardinality, STLIndirection, NodeSet, ZoneSet>;
+    slam::StaticRelation<PositionType, ElementType, VariableCardinality, ArrayIndirection, NodeSet, ZoneSet>;
   using NodeZoneIterator = NodeToZoneRelation::RelationConstIterator;
 
   using ZNStride = slam::policies::CompileTimeStride<PositionType, NODES_PER_ZONE>;
   using ConstantCardinality = slam::policies::ConstantCardinality<PositionType, ZNStride>;
   using ZoneToNodeRelation =
-    slam::StaticRelation<PositionType, ElementType, ConstantCardinality, STLIndirection, ZoneSet, NodeSet>;
+    slam::StaticRelation<PositionType, ElementType, ConstantCardinality, ArrayIndirection, ZoneSet, NodeSet>;
   using ZoneNodeIterator = ZoneToNodeRelation::RelationConstIterator;
 
   /// types for maps
@@ -232,7 +232,7 @@ void readHexMesh(std::string fileName, HexMesh* mesh)
 
   /// Create the nodal position field
   mesh->nodePosition = HexMesh::NodalPositions(&mesh->nodes);
-  RealBuf::iterator ptIt = Repository::realsRegistry.getBuffer("node_positions").begin();
+  auto ptIt = Repository::realsRegistry.getBuffer("node_positions").begin();
   for(PositionType idx = 0; idx < mesh->numNodes(); ++idx)
   {
     mesh->nodePosition[idx] = Point3(*ptIt++, *ptIt++, *ptIt++);

--- a/src/axom/slam/examples/UnstructMeshField.cpp
+++ b/src/axom/slam/examples/UnstructMeshField.cpp
@@ -204,7 +204,6 @@ void readHexMesh(std::string fileName, HexMesh* mesh)
     SimpleVTKHexMeshReader vtkMeshReader(fileName);
     vtkMeshReader.parseMeshFile();
   }
-  using RealBuf = Repository::RealsRegistry::BufferType;
   using IndexBuf = Repository::IntsRegistry::BufferType;
   using PositionType = HexMesh::PositionType;
 

--- a/src/axom/slam/examples/UserDocs.cpp
+++ b/src/axom/slam/examples/UserDocs.cpp
@@ -20,15 +20,13 @@
  */
 
 #include "axom/core.hpp"
+#include "axom/fmt.hpp"
 #include "axom/slic.hpp"
 
 // _quadmesh_example_import_header_start
 #include "axom/slam.hpp"
 // _quadmesh_example_import_header_end
 
-#include "axom/slam/RelationBuilders.hpp"
-
-#include <sstream>
 #include <cmath>
 #include <fstream>
 
@@ -62,7 +60,7 @@ struct Point2
   Point2& operator/=(double val)
   {
     m_x /= val;
-    m_y += val;
+    m_y /= val;
     return *this;
   }
 
@@ -95,35 +93,33 @@ struct SimpleQuadMesh
   // _quadmesh_example_set_typedefs_end
 
   // _quadmesh_example_common_typedefs_start
-  using ArrayIndir = slam::policies::CArrayIndirection<PosType, ElemType>;
+  // Slam objects index into buffers of positions.
+  // We store that connectivity data in axom::Array, Slam's canonical buffer type.
+  using IndexBuffer = axom::Array<PosType>;
   // _quadmesh_example_common_typedefs_end
 
   /// Type aliases for relations
   // _quadmesh_example_bdry_relation_typedefs_start
-  // Type aliases for element-to-vertex boundary relation
+  // Element-to-vertex boundary relation: each quad has exactly four vertices,
+  // so the cardinality is a compile-time constant via ConstantRelation.
   enum
   {
     VertsPerElem = 4
   };
-  using CTStride = slam::policies::CompileTimeStride<PosType, VertsPerElem>;
-  using ConstCard = slam::policies::ConstantCardinality<PosType, CTStride>;
-  using ElemToVertRelation =
-    slam::StaticRelation<PosType, ElemType, ConstCard, ArrayIndir, ElemSet, VertSet>;
+  using ElemToVertRelation = slam::ConstantRelation<ElemSet, VertSet, VertsPerElem>;
   // _quadmesh_example_bdry_relation_typedefs_end
 
   // _quadmesh_example_cobdry_relation_typedefs_start
-  // Type aliases for vertex-to-element coboundary relation
-  using VarCard = slam::policies::VariableCardinality<PosType, ArrayIndir>;
-  using VertToElemRelation =
-    slam::StaticRelation<PosType, ElemType, VarCard, ArrayIndir, VertSet, ElemSet>;
+  // Vertex-to-element coboundary relation: the number of incident elements
+  // varies per vertex, so we use VariableRelation.
+  using VertToElemRelation = slam::VariableRelation<VertSet, ElemSet>;
   // _quadmesh_example_cobdry_relation_typedefs_end
 
   /// Type alias for position map
   // _quadmesh_example_maps_typedefs_start
-  using BaseSet = slam::Set<PosType, ElemType>;
-  using ScalarMap = slam::Map<Point2, BaseSet>;
-  using PointMap = slam::Map<Point2, BaseSet>;
-  using VertPositions = PointMap;
+  // A Map attaches a value to each element of a set. With no indirection policy
+  // specified, a Map stores its values in an axom::Array it manages itself.
+  using VertPositions = slam::Map<Point2, VertSet>;
   // _quadmesh_example_maps_typedefs_end
 
   SimpleQuadMesh()
@@ -178,22 +174,14 @@ struct SimpleQuadMesh
     {
       // _quadmesh_example_construct_bdry_relation_start
       // construct boundary relation from elements to vertices
-      bdry = slam::make_constant_relation_ct<VertsPerElem>(&elems,
-                                                           &verts,
-                                                           evInds.data(),
-                                                           static_cast<PosType>(evInds.size()));
+      bdry = slam::make_constant_relation_ct<VertsPerElem>(&elems, &verts, evInds);
       // _quadmesh_example_construct_bdry_relation_end
     }
 
     {
       // _quadmesh_example_construct_cobdry_relation_start
       // construct coboundary relation from vertices to elements
-      cobdry = slam::make_variable_relation(&verts,
-                                            &elems,
-                                            veBegins.data(),
-                                            static_cast<PosType>(veBegins.size()),
-                                            veInds.data(),
-                                            static_cast<PosType>(veInds.size()));
+      cobdry = slam::make_variable_relation(&verts, &elems, veBegins, veInds);
       // _quadmesh_example_construct_cobdry_relation_end
     }
 
@@ -243,8 +231,9 @@ struct SimpleQuadMesh
   void computeDistances()
   {
     // _quadmesh_example_vert_distances_start
-    // Create a Map of scalars over the vertices
-    ScalarMap distances(&verts);
+    // Create a Map of scalars over the vertices. As with the position map,
+    // this owns its values in an axom::Array (the default indirection).
+    slam::Map<double, VertSet> distances(&verts);
 
     for(int i = 0; i < distances.size(); ++i)  // <-- Map::size()
     {
@@ -269,8 +258,7 @@ struct SimpleQuadMesh
   {
     // _quadmesh_example_elem_centroids_start
     // Create a Map of Point2 over the mesh elements
-    using ElemCentroidMap = PointMap;
-    ElemCentroidMap centroid = ElemCentroidMap(&elems);
+    slam::Map<Point2, ElemSet> centroid(&elems);
 
     // for each element...
     for(int eID = 0; eID < elems.size(); ++eID)  // <-- Set::size()
@@ -300,56 +288,63 @@ struct SimpleQuadMesh
   void outputVTKMesh()
   {
     // _quadmesh_example_output_vtk_start
-    std::ofstream meshfile;
-    meshfile.open("quadMesh.vtk");
-    std::ostream_iterator<PosType> out_it(meshfile, " ");
+    std::ofstream meshfile {"quadMesh.vtk"};
 
     // write header
-    meshfile << "# vtk DataFile Version 3.0\n"
-             << "vtk output\n"
-             << "ASCII\n"
-             << "DATASET UNSTRUCTURED_GRID\n\n"
-             << "POINTS " << verts.size() << " double\n";
+    axom::fmt::print(meshfile,
+                     "# vtk DataFile Version 3.0\n"
+                     "vtk output\n"
+                     "ASCII\n"
+                     "DATASET UNSTRUCTURED_GRID\n\n"
+                     "POINTS {} double\n",
+                     verts.size());
 
     // write positions
     for(auto pos : position)  // <-- Uses range-based for on position map
     {
-      meshfile << pos[0] << " " << pos[1] << " 0\n";
+      axom::fmt::print(meshfile, "{} {} 0\n", pos[0], pos[1]);
     }
 
     // write elem-to-vert boundary relation
-    meshfile << "\nCELLS " << elems.size() << " " << 5 * elems.size();
+    axom::fmt::print(meshfile, "\nCELLS {} {}", elems.size(), 5 * elems.size());
     for(auto e : elems)  // <-- uses range-based for on element set
     {
-      meshfile << "\n4 ";
-      std::copy(bdry.begin(e),  // <-- uses relation's iterators
-                bdry.end(e),
-                out_it);
+      axom::fmt::print(meshfile, "\n4 ");
+      for(auto v : bdry[e])  // <-- uses relation's per-element set
+      {
+        axom::fmt::print(meshfile, "{} ", v);
+      }
     }
 
     // write element types ( 9 == VKT_QUAD )
-    meshfile << "\n\nCELL_TYPES " << elems.size() << "\n";
+    axom::fmt::print(meshfile, "\n\nCELL_TYPES {}\n", elems.size());
     for(int i = 0; i < elems.size(); ++i)
     {
-      meshfile << "9 ";
+      axom::fmt::print(meshfile, "9 ");
     }
 
     // write element ids
-    meshfile << "\n\nCELL_DATA " << elems.size() << "\nSCALARS cellIds int 1"
-             << "\nLOOKUP_TABLE default \n";
+    axom::fmt::print(meshfile,
+                     "\n\nCELL_DATA {}\n"
+                     "SCALARS cellIds int 1\n"
+                     "LOOKUP_TABLE default \n",
+                     elems.size());
     for(int i = 0; i < elems.size(); ++i)
     {
-      meshfile << elems[i] << " ";  // <-- uses size() and operator[] on set
+      axom::fmt::print(meshfile, "{} ", elems[i]);  // <-- uses size() and operator[] on set
     }
 
     // write vertex ids
-    meshfile << "\n\nPOINT_DATA " << verts.size() << "\nSCALARS vertIds int 1"
-             << "\nLOOKUP_TABLE default \n";
+    axom::fmt::print(meshfile,
+                     "\n\nPOINT_DATA {}\n"
+                     "SCALARS vertIds int 1\n"
+                     "LOOKUP_TABLE default \n",
+                     verts.size());
     for(int i = 0; i < verts.size(); ++i)
     {
-      meshfile << verts[i] << " ";
+      axom::fmt::print(meshfile, "{} ", verts[i]);
     }
-    meshfile << "\n";
+    axom::fmt::print(meshfile, "\n");
     // _quadmesh_example_output_vtk_end
   }
 
@@ -368,10 +363,10 @@ private:
   VertPositions position;  // vertex position
   // _quadmesh_example_map_variables_end
 
-  // support data for mesh connectivity
-  std::vector<PosType> evInds;
-  std::vector<PosType> veInds;
-  std::vector<PosType> veBegins;
+  // support data for mesh connectivity, stored in axom::Array buffers
+  IndexBuffer evInds;
+  IndexBuffer veInds;
+  IndexBuffer veBegins;
 };
 
 void quadMeshExample()

--- a/src/axom/slam/examples/UserDocs.cpp
+++ b/src/axom/slam/examples/UserDocs.cpp
@@ -121,8 +121,8 @@ struct SimpleQuadMesh
   /// Type alias for position map
   // _quadmesh_example_maps_typedefs_start
   using BaseSet = slam::Set<PosType, ElemType>;
-  using ScalarMap = slam::Map<Point2, BaseSet>;
-  using PointMap = slam::Map<Point2, BaseSet>;
+  using ScalarMap = slam::ArrayMap<BaseSet, Point2>;
+  using PointMap = slam::ArrayMap<BaseSet, Point2>;
   using VertPositions = PointMap;
   // _quadmesh_example_maps_typedefs_end
 

--- a/src/axom/slam/examples/UserDocs.cpp
+++ b/src/axom/slam/examples/UserDocs.cpp
@@ -121,8 +121,8 @@ struct SimpleQuadMesh
   /// Type alias for position map
   // _quadmesh_example_maps_typedefs_start
   using BaseSet = slam::Set<PosType, ElemType>;
-  using ScalarMap = slam::ArrayMap<BaseSet, Point2>;
-  using PointMap = slam::ArrayMap<BaseSet, Point2>;
+  using ScalarMap = slam::Map<Point2, BaseSet>;
+  using PointMap = slam::Map<Point2, BaseSet>;
   using VertPositions = PointMap;
   // _quadmesh_example_maps_typedefs_end
 

--- a/src/axom/slam/examples/lulesh2.0.3/lulesh.hpp
+++ b/src/axom/slam/examples/lulesh2.0.3/lulesh.hpp
@@ -166,21 +166,21 @@ namespace slamLulesh {
     using NodeToCornerRelation = axom::slam::VariableRelation<NodeSet, CornerSet>;
     using NodeCornerSet = const NodeToCornerRelation::RelationSubset;
 
-    using ElemIndexMap = axom::slam::ArrayMap<SetBase, Index_t>;
-    using ElemIntMap = axom::slam::ArrayMap<SetBase, Int_t>;
-    //using ElemRealMap = axom::slam::ArrayMap<SetBase, Real_t>;
+    using ElemIndexMap = axom::slam::Map<Index_t, SetBase>;
+    using ElemIntMap = axom::slam::Map<Int_t, SetBase>;
+    //using ElemRealMap = axom::slam::Map<Real_t, SetBase>;
 
-    using NodeIndexMap = axom::slam::ArrayMap<SetBase, Index_t>;
-    //using NodeIntMap = axom::slam::ArrayMap<SetBase, Int_t>;
-    //using NodeRealMap = axom::slam::ArrayMap<SetBase, Real_t>;
+    using NodeIndexMap = axom::slam::Map<Index_t, SetBase>;
+    //using NodeIntMap = axom::slam::Map<Int_t, SetBase>;
+    //using NodeRealMap = axom::slam::Map<Real_t, SetBase>;
 
-    //using RegionIndexMap = axom::slam::ArrayMap<SetBase, Index_t>;
-    using RegionIntMap = axom::slam::ArrayMap<SetBase, Int_t>;
-    //using RegionRealMap = axom::slam::ArrayMap<SetBase, Real_t>;
+    //using RegionIndexMap = axom::slam::Map<Index_t, SetBase>;
+    using RegionIntMap = axom::slam::Map<Int_t, SetBase>;
+    //using RegionRealMap = axom::slam::Map<Real_t, SetBase>;
 
-    //using CornerIndexMap = axom::slam::ArrayMap<SetBase, Index_t>;
-    //using CornerIntMap = axom::slam::ArrayMap<SetBase, Int_t>;
-    using CornerRealMap = axom::slam::ArrayMap<SetBase, Real_t>;
+    //using CornerIndexMap = axom::slam::Map<Index_t, SetBase>;
+    //using CornerIntMap = axom::slam::Map<Int_t, SetBase>;
+    using CornerRealMap = axom::slam::Map<Real_t, SetBase>;
 
     using RealsRegistry = axom::slam::FieldRegistry<SetBase, Real_t>;
     using IntsRegistry = axom::slam::FieldRegistry<SetBase, Index_t>;

--- a/src/axom/slam/examples/lulesh2.0.3/lulesh.hpp
+++ b/src/axom/slam/examples/lulesh2.0.3/lulesh.hpp
@@ -132,8 +132,8 @@ namespace slamLulesh {
  *  "Real_t &z(Index_t idx) { return m_coord[idx].z ; }"
  */
 
-  class Domain {
-
+  class Domain
+  {
   public:
     using SetBase = axom::slam::Set<>;
     using NullSet = axom::slam::NullSet<>;
@@ -147,40 +147,24 @@ namespace slamLulesh {
 
     using SymmNodeSet = axom::slam::ArrayIndirectionSet<PositionType, ElementType>;
 
-    using ArrayIndirection = axom::slam::policies::ArrayIndirection<PositionType, ElementType>;
+    enum
+    {
+      NODES_PER_ZONE = 8,
+      FACES_PER_ZONE = 1
+    };
 
-    enum { NODES_PER_ZONE = 8, FACES_PER_ZONE = 1};
-    using ZNStride = axom::slam::policies::CompileTimeStride<PositionType, NODES_PER_ZONE>;
-    using ZFStride = axom::slam::policies::CompileTimeStride<PositionType, FACES_PER_ZONE>;
-
-    using ZNCard = axom::slam::policies::ConstantCardinality<PositionType, ZNStride>;
-    using ElemToNodeRelation =
-        axom::slam::StaticRelation<PositionType, ElementType,ZNCard, ArrayIndirection, ElemSet, NodeSet>;
+    using ElemToNodeRelation = axom::slam::ConstantRelation<ElemSet, NodeSet, NODES_PER_ZONE>;
     using ElemNodeSet = const ElemToNodeRelation::RelationSubset;
 
-    using ZFCard = axom::slam::policies::ConstantCardinality<PositionType, ZFStride>;
     using ElemFaceAdjacencyRelation =
-        axom::slam::StaticRelation<PositionType, ElementType,ZFCard, ArrayIndirection, ElemSet, ExtendedElemSet>;
-
+      axom::slam::ConstantRelation<ElemSet, ExtendedElemSet, FACES_PER_ZONE>;
 
     using RegionSet = axom::slam::RangeSet<>;
-    using VariableCardinality = axom::slam::policies::VariableCardinality<PositionType, ArrayIndirection>;
-    using RegionToElemRelation = axom::slam::StaticRelation<
-                                    PositionType, ElementType,
-                                    VariableCardinality,
-                                    ArrayIndirection,
-                                    RegionSet,
-                                    ElemSet>;
+    using RegionToElemRelation = axom::slam::VariableRelation<RegionSet, ElemSet>;
     using RegionElemSet = const RegionToElemRelation::RelationSubset;
 
-
-    using NodeToCornerRelation = axom::slam::StaticRelation<
-                                    PositionType, ElementType,
-                                    VariableCardinality,
-                                    ArrayIndirection,
-                                    NodeSet,
-                                    CornerSet>;
-    using NodeCornerSet = const NodeToCornerRelation::RelationSubset ;
+    using NodeToCornerRelation = axom::slam::VariableRelation<NodeSet, CornerSet>;
+    using NodeCornerSet = const NodeToCornerRelation::RelationSubset;
 
     using ElemIndexMap = axom::slam::Map<Index_t>;
     using ElemIntMap = axom::slam::Map<Int_t>;
@@ -202,7 +186,6 @@ namespace slamLulesh {
     using IntsRegistry = axom::slam::FieldRegistry<SetBase, Index_t>;
 
   public:
-
     // Constructor
     Domain(Int_t numRanks, Index_t colLoc,
         Index_t rowLoc, Index_t planeLoc,
@@ -211,7 +194,7 @@ namespace slamLulesh {
 
     // Destructor
     ~Domain();
-    
+
     //
     // ALLOCATION
     //

--- a/src/axom/slam/examples/lulesh2.0.3/lulesh.hpp
+++ b/src/axom/slam/examples/lulesh2.0.3/lulesh.hpp
@@ -145,9 +145,9 @@ namespace slamLulesh {
     using CornerSet = axom::slam::RangeSet<>;
     using ExtendedElemSet = axom::slam::RangeSet<>;
 
-    using SymmNodeSet = axom::slam::VectorIndirectionSet<>;
+    using SymmNodeSet = axom::slam::ArrayIndirectionSet<PositionType, ElementType>;
 
-    using STLIndirection = axom::slam::policies::STLVectorIndirection<PositionType, ElementType>;
+    using ArrayIndirection = axom::slam::policies::ArrayIndirection<PositionType, ElementType>;
 
     enum { NODES_PER_ZONE = 8, FACES_PER_ZONE = 1};
     using ZNStride = axom::slam::policies::CompileTimeStride<PositionType, NODES_PER_ZONE>;
@@ -155,20 +155,20 @@ namespace slamLulesh {
 
     using ZNCard = axom::slam::policies::ConstantCardinality<PositionType, ZNStride>;
     using ElemToNodeRelation =
-        axom::slam::StaticRelation<PositionType, ElementType,ZNCard, STLIndirection, ElemSet, NodeSet>;
+        axom::slam::StaticRelation<PositionType, ElementType,ZNCard, ArrayIndirection, ElemSet, NodeSet>;
     using ElemNodeSet = const ElemToNodeRelation::RelationSubset;
 
     using ZFCard = axom::slam::policies::ConstantCardinality<PositionType, ZFStride>;
     using ElemFaceAdjacencyRelation =
-        axom::slam::StaticRelation<PositionType, ElementType,ZFCard, STLIndirection, ElemSet, ExtendedElemSet>;
+        axom::slam::StaticRelation<PositionType, ElementType,ZFCard, ArrayIndirection, ElemSet, ExtendedElemSet>;
 
 
     using RegionSet = axom::slam::RangeSet<>;
-    using VariableCardinality = axom::slam::policies::VariableCardinality<PositionType, STLIndirection>;
+    using VariableCardinality = axom::slam::policies::VariableCardinality<PositionType, ArrayIndirection>;
     using RegionToElemRelation = axom::slam::StaticRelation<
                                     PositionType, ElementType,
                                     VariableCardinality,
-                                    STLIndirection,
+                                    ArrayIndirection,
                                     RegionSet,
                                     ElemSet>;
     using RegionElemSet = const RegionToElemRelation::RelationSubset;
@@ -177,7 +177,7 @@ namespace slamLulesh {
     using NodeToCornerRelation = axom::slam::StaticRelation<
                                     PositionType, ElementType,
                                     VariableCardinality,
-                                    STLIndirection,
+                                    ArrayIndirection,
                                     NodeSet,
                                     CornerSet>;
     using NodeCornerSet = const NodeToCornerRelation::RelationSubset ;

--- a/src/axom/slam/examples/lulesh2.0.3/lulesh.hpp
+++ b/src/axom/slam/examples/lulesh2.0.3/lulesh.hpp
@@ -166,21 +166,21 @@ namespace slamLulesh {
     using NodeToCornerRelation = axom::slam::VariableRelation<NodeSet, CornerSet>;
     using NodeCornerSet = const NodeToCornerRelation::RelationSubset;
 
-    using ElemIndexMap = axom::slam::Map<Index_t>;
-    using ElemIntMap = axom::slam::Map<Int_t>;
-    //using ElemRealMap = axom::slam::Map<Real_t>;
+    using ElemIndexMap = axom::slam::ArrayMap<SetBase, Index_t>;
+    using ElemIntMap = axom::slam::ArrayMap<SetBase, Int_t>;
+    //using ElemRealMap = axom::slam::ArrayMap<SetBase, Real_t>;
 
-    using NodeIndexMap = axom::slam::Map<Index_t>;
-    //using NodeIntMap = axom::slam::Map<Int_t>;
-    //using NodeRealMap = axom::slam::Map<Real_t>;
+    using NodeIndexMap = axom::slam::ArrayMap<SetBase, Index_t>;
+    //using NodeIntMap = axom::slam::ArrayMap<SetBase, Int_t>;
+    //using NodeRealMap = axom::slam::ArrayMap<SetBase, Real_t>;
 
-    //using RegionIndexMap = axom::slam::Map<Index_t>;
-    using RegionIntMap = axom::slam::Map<Int_t>;
-    //using RegionRealMap = axom::slam::Map<Real_t>;
+    //using RegionIndexMap = axom::slam::ArrayMap<SetBase, Index_t>;
+    using RegionIntMap = axom::slam::ArrayMap<SetBase, Int_t>;
+    //using RegionRealMap = axom::slam::ArrayMap<SetBase, Real_t>;
 
-    //using CornerIndexMap = axom::slam::Map<Index_t>;
-    //using CornerIntMap = axom::slam::Map<Int_t>;
-    using CornerRealMap = axom::slam::Map<Real_t>;
+    //using CornerIndexMap = axom::slam::ArrayMap<SetBase, Index_t>;
+    //using CornerIntMap = axom::slam::ArrayMap<SetBase, Int_t>;
+    using CornerRealMap = axom::slam::ArrayMap<SetBase, Real_t>;
 
     using RealsRegistry = axom::slam::FieldRegistry<SetBase, Real_t>;
     using IntsRegistry = axom::slam::FieldRegistry<SetBase, Index_t>;

--- a/src/axom/slam/examples/tinyHydro/TinyHydroTypes.hpp
+++ b/src/axom/slam/examples/tinyHydro/TinyHydroTypes.hpp
@@ -25,13 +25,13 @@ using ElementType = PositionType;
 
 using SetBase = slam::Set<PositionType, ElementType>;
 
-using IndexField = slam::ArrayMap<slam::Set<>, int>;
+using IndexField = slam::Map<int, slam::Set<>>;
 
-using ScalarField = slam::ArrayMap<SetBase, double>;
+using ScalarField = slam::Map<double, SetBase>;
 using NodalScalarField = ScalarField;
 using ZonalScalarField = ScalarField;
 
-using VectorField = slam::ArrayMap<SetBase, VectorXY>;
+using VectorField = slam::Map<VectorXY, SetBase>;
 using NodalVectorField = VectorField;
 using ZonalVectorField = VectorField;
 using FaceVectorField = VectorField;
@@ -66,7 +66,7 @@ using ZFaceSet = ZoneToFaceRelation::RelationSubset;
 using NUM_BD_SZ = slam::policies::CompileTimeSize<ZoneSet::PositionType, NUM_DOMAIN_BOUNDARIES>;
 using BoundaryEdgeSet = slam::OrderedSet<PositionType, ElementType, NUM_BD_SZ>;
 
-using IndexMap = slam::ArrayMap<slam::Set<>, IndexType>;
+using IndexMap = slam::Map<IndexType, slam::Set<>>;
 
 using IndexRegistry = slam::FieldRegistry<SetBase, ZoneSet::PositionType>;
 using IndexBuffer = IndexRegistry::BufferType;

--- a/src/axom/slam/examples/tinyHydro/TinyHydroTypes.hpp
+++ b/src/axom/slam/examples/tinyHydro/TinyHydroTypes.hpp
@@ -16,71 +16,72 @@
 
 namespace slam = axom::slam;
 
-namespace tinyHydro {
+namespace tinyHydro
+{
 
-  using PositionType = int;
-  using IndexType = PositionType;
-  using ElementType = PositionType;
+using PositionType = int;
+using IndexType = PositionType;
+using ElementType = PositionType;
 
-  using SetBase = slam::Set<PositionType, ElementType>;
+using SetBase = slam::Set<PositionType, ElementType>;
 
-  using IndexField = slam::Map<int>;
+using IndexField = slam::Map<int>;
 
-  using ScalarField = slam::Map<double,SetBase>;
-  using NodalScalarField = ScalarField;
-  using ZonalScalarField = ScalarField;
+using ScalarField = slam::Map<double, SetBase>;
+using NodalScalarField = ScalarField;
+using ZonalScalarField = ScalarField;
 
-  using VectorField = slam::Map<VectorXY,SetBase>;
-  using NodalVectorField = VectorField;
-  using ZonalVectorField = VectorField;
-  using FaceVectorField = VectorField;
+using VectorField = slam::Map<VectorXY, SetBase>;
+using NodalVectorField = VectorField;
+using ZonalVectorField = VectorField;
+using FaceVectorField = VectorField;
 
-  using BoundaryEdgeVectorField = VectorField;
+using BoundaryEdgeVectorField = VectorField;
 
-  using ZoneSet = slam::PositionSet<PositionType, ElementType>;
-  using NodeSet = slam::PositionSet<PositionType, ElementType>;
-  using FaceSet = slam::PositionSet<PositionType, ElementType>;
-  using CornerSet = slam::PositionSet<PositionType, ElementType>;
+using ZoneSet = slam::PositionSet<PositionType, ElementType>;
+using NodeSet = slam::PositionSet<PositionType, ElementType>;
+using FaceSet = slam::PositionSet<PositionType, ElementType>;
+using CornerSet = slam::PositionSet<PositionType, ElementType>;
 
-  using ZoneSubset = slam::VectorIndirectionSet<PositionType, ElementType>;
-  using NodeSubset = slam::VectorIndirectionSet<PositionType, ElementType>;
+using ZoneSubset = slam::ArrayIndirectionSet<PositionType, ElementType>;
+using NodeSubset = slam::ArrayIndirectionSet<PositionType, ElementType>;
 
-  enum
-  {
-    NODES_PER_ZONE        = 4,
-    FACES_PER_ZONE        = 4,
-    BD_BOTTOM             = 0,         // lower boundary nodes
-    BD_RIGHT              = 1,         // right boundary nodes
-    BD_TOP                = 2,         // top boundary nodes
-    BD_LEFT               = 3,         // left boundary nodes
-    NUM_DOMAIN_BOUNDARIES = 4
-  };
+enum
+{
+  NODES_PER_ZONE = 4,
+  FACES_PER_ZONE = 4,
+  BD_BOTTOM = 0,            // lower boundary nodes
+  BD_RIGHT = 1,             // right boundary nodes
+  BD_TOP = 2,               // top boundary nodes
+  BD_LEFT = 3,              // left boundary nodes
+  NUM_DOMAIN_BOUNDARIES = 4
+};
 
-  using STLIndirection = slam::policies::STLVectorIndirection<PositionType, PositionType>;
+using ArrayIndirection = slam::policies::ArrayIndirection<PositionType, PositionType>;
 
-  using ZNStride = slam::policies::CompileTimeStride<PositionType, NODES_PER_ZONE>;
-  using ZNCard = slam::policies::ConstantCardinality<PositionType, ZNStride>;
-  using ZoneToNodeRelation = slam::StaticRelation<PositionType, ElementType,
-                                                  ZNCard, STLIndirection, ZoneSet, NodeSet>;
-  using ZNodeSet = ZoneToNodeRelation::RelationSubset;
+using ZNStride = slam::policies::CompileTimeStride<PositionType, NODES_PER_ZONE>;
+using ZNCard = slam::policies::ConstantCardinality<PositionType, ZNStride>;
+using ZoneToNodeRelation =
+  slam::StaticRelation<PositionType, ElementType, ZNCard, ArrayIndirection, ZoneSet, NodeSet>;
+using ZNodeSet = ZoneToNodeRelation::RelationSubset;
 
-  using ZFStride = slam::policies::CompileTimeStride<PositionType, FACES_PER_ZONE>;
-  using ZFCard = slam::policies::ConstantCardinality<PositionType, ZFStride>;
-  using ZoneToFaceRelation = slam::StaticRelation<PositionType, ElementType,
-                                                  ZFCard, STLIndirection, ZoneSet, FaceSet>;
-  using ZFaceSet = ZoneToFaceRelation::RelationSubset;
+using ZFStride = slam::policies::CompileTimeStride<PositionType, FACES_PER_ZONE>;
+using ZFCard = slam::policies::ConstantCardinality<PositionType, ZFStride>;
+using ZoneToFaceRelation =
+  slam::StaticRelation<PositionType, ElementType, ZFCard, ArrayIndirection, ZoneSet, FaceSet>;
+using ZFaceSet = ZoneToFaceRelation::RelationSubset;
 
-  using NUM_BD_SZ = slam::policies::CompileTimeSize<ZoneSet::PositionType, NUM_DOMAIN_BOUNDARIES>;
-  using BoundaryEdgeSet = slam::OrderedSet< PositionType, ElementType, NUM_BD_SZ>;
+using NUM_BD_SZ = slam::policies::CompileTimeSize<ZoneSet::PositionType, NUM_DOMAIN_BOUNDARIES>;
+using BoundaryEdgeSet = slam::OrderedSet<PositionType, ElementType, NUM_BD_SZ>;
 
-  using IndexMap = slam::Map<IndexType>;
+using IndexMap = slam::Map<IndexType>;
 
-  using IndexRegistry = slam::FieldRegistry<SetBase, ZoneSet::PositionType>;
-  using IndexBuffer = IndexRegistry::BufferType;
+using IndexRegistry = slam::FieldRegistry<SetBase, ZoneSet::PositionType>;
+using IndexBuffer = IndexRegistry::BufferType;
 
-  struct DataRegistry
-  {
-    static IndexRegistry setRegistry;
-  };
+struct DataRegistry
+{
+  static IndexRegistry setRegistry;
+};
 
-} // end namespace tinyHydro
+}  // end namespace tinyHydro

--- a/src/axom/slam/examples/tinyHydro/TinyHydroTypes.hpp
+++ b/src/axom/slam/examples/tinyHydro/TinyHydroTypes.hpp
@@ -25,13 +25,13 @@ using ElementType = PositionType;
 
 using SetBase = slam::Set<PositionType, ElementType>;
 
-using IndexField = slam::Map<int>;
+using IndexField = slam::ArrayMap<slam::Set<>, int>;
 
-using ScalarField = slam::Map<double, SetBase>;
+using ScalarField = slam::ArrayMap<SetBase, double>;
 using NodalScalarField = ScalarField;
 using ZonalScalarField = ScalarField;
 
-using VectorField = slam::Map<VectorXY, SetBase>;
+using VectorField = slam::ArrayMap<SetBase, VectorXY>;
 using NodalVectorField = VectorField;
 using ZonalVectorField = VectorField;
 using FaceVectorField = VectorField;
@@ -43,38 +43,30 @@ using NodeSet = slam::PositionSet<PositionType, ElementType>;
 using FaceSet = slam::PositionSet<PositionType, ElementType>;
 using CornerSet = slam::PositionSet<PositionType, ElementType>;
 
-using ZoneSubset = slam::ArrayIndirectionSet<PositionType, ElementType>;
-using NodeSubset = slam::ArrayIndirectionSet<PositionType, ElementType>;
+using ZoneSubset = slam::ArraySet<PositionType, ElementType>;
+using NodeSubset = slam::ArraySet<PositionType, ElementType>;
 
 enum
 {
   NODES_PER_ZONE = 4,
   FACES_PER_ZONE = 4,
-  BD_BOTTOM = 0,            // lower boundary nodes
-  BD_RIGHT = 1,             // right boundary nodes
-  BD_TOP = 2,               // top boundary nodes
-  BD_LEFT = 3,              // left boundary nodes
+  BD_BOTTOM = 0,  // lower boundary nodes
+  BD_RIGHT = 1,   // right boundary nodes
+  BD_TOP = 2,     // top boundary nodes
+  BD_LEFT = 3,    // left boundary nodes
   NUM_DOMAIN_BOUNDARIES = 4
 };
 
-using ArrayIndirection = slam::policies::ArrayIndirection<PositionType, PositionType>;
-
-using ZNStride = slam::policies::CompileTimeStride<PositionType, NODES_PER_ZONE>;
-using ZNCard = slam::policies::ConstantCardinality<PositionType, ZNStride>;
-using ZoneToNodeRelation =
-  slam::StaticRelation<PositionType, ElementType, ZNCard, ArrayIndirection, ZoneSet, NodeSet>;
+using ZoneToNodeRelation = slam::ConstantRelation<ZoneSet, NodeSet, NODES_PER_ZONE>;
 using ZNodeSet = ZoneToNodeRelation::RelationSubset;
 
-using ZFStride = slam::policies::CompileTimeStride<PositionType, FACES_PER_ZONE>;
-using ZFCard = slam::policies::ConstantCardinality<PositionType, ZFStride>;
-using ZoneToFaceRelation =
-  slam::StaticRelation<PositionType, ElementType, ZFCard, ArrayIndirection, ZoneSet, FaceSet>;
+using ZoneToFaceRelation = slam::ConstantRelation<ZoneSet, FaceSet, FACES_PER_ZONE>;
 using ZFaceSet = ZoneToFaceRelation::RelationSubset;
 
 using NUM_BD_SZ = slam::policies::CompileTimeSize<ZoneSet::PositionType, NUM_DOMAIN_BOUNDARIES>;
 using BoundaryEdgeSet = slam::OrderedSet<PositionType, ElementType, NUM_BD_SZ>;
 
-using IndexMap = slam::Map<IndexType>;
+using IndexMap = slam::ArrayMap<slam::Set<>, IndexType>;
 
 using IndexRegistry = slam::FieldRegistry<SetBase, ZoneSet::PositionType>;
 using IndexBuffer = IndexRegistry::BufferType;

--- a/src/axom/slam/mesh_struct/IA.hpp
+++ b/src/axom/slam/mesh_struct/IA.hpp
@@ -34,9 +34,7 @@
 
 #include <array>
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * \class IA
@@ -443,7 +441,6 @@ constexpr int IAMesh<TDIM, SDIM, P>::COORDS_PER_VERT;
 template <int TDIM, int SDIM, typename P>
 constexpr int IAMesh<TDIM, SDIM, P>::VERTS_PER_ELEM;
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam
 
 #include "axom/slam/mesh_struct/IA_impl.hpp"

--- a/src/axom/slam/mesh_struct/IA_impl.hpp
+++ b/src/axom/slam/mesh_struct/IA_impl.hpp
@@ -27,9 +27,7 @@
 #include <memory>
 #include <cstddef>
 
-namespace axom
-{
-namespace slam
+namespace axom::slam
 {
 /**
  * Helper function on std::vectors
@@ -1281,5 +1279,4 @@ bool IAMesh<TDIM, SDIM, P>::isConforming(bool verboseOutput) const
   return valid;
 }
 
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam

--- a/src/axom/slam/mesh_struct/detail/FacetPairingMap.hpp
+++ b/src/axom/slam/mesh_struct/detail/FacetPairingMap.hpp
@@ -103,11 +103,7 @@
 #include <optional>
 #include <vector>
 
-namespace axom
-{
-namespace slam
-{
-namespace detail
+namespace axom::slam::detail
 {
 
 /**
@@ -461,6 +457,4 @@ thread_local std::vector<typename FacetPairingMap<TDIM, IndexType>::Entry>
 template <int TDIM, typename IndexType>
 thread_local unsigned int FacetPairingMap<TDIM, IndexType>::s_generation = 0;
 
-}  // namespace detail
-}  // namespace slam
-}  // namespace axom
+}  // namespace axom::slam::detail

--- a/src/axom/slam/policies/BivariateSetInterfacePolicies.hpp
+++ b/src/axom/slam/policies/BivariateSetInterfacePolicies.hpp
@@ -9,11 +9,7 @@
 #include "axom/slam/BivariateSet.hpp"
 #include "axom/slam/policies/InterfacePolicies.hpp"
 
-namespace axom
-{
-namespace slam
-{
-namespace policies
+namespace axom::slam::policies
 {
 namespace detail
 {
@@ -138,6 +134,4 @@ template <typename InterfacePolicy, typename FromSet, typename ToSet>
 using BivariateSetInterface =
   typename detail::BSetInterfaceSelector<InterfacePolicy, FromSet, ToSet>::Type;
 
-}  // end namespace policies
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam::policies

--- a/src/axom/slam/policies/CardinalityPolicies.hpp
+++ b/src/axom/slam/policies/CardinalityPolicies.hpp
@@ -77,9 +77,16 @@ struct ConstantCardinality
   using BeginsStridePolicy = StridePolicy;
   using BeginsIndirectionPolicy = NoIndirection<ElementType, ElementType>;
 
-  // runtime size (fromSet.size()), striding from template parameter, no offset
-  using BeginsSet =
-    OrderedSet<ElementType, ElementType, BeginsSizePolicy, BeginsOffsetPolicy, BeginsStridePolicy>;
+  // runtime size (fromSet.size()), striding from template parameter, no offset.
+  // Uses the concrete interface to stay trivially copyable / device-capturable.
+  using BeginsSet = OrderedSet<ElementType,
+                               ElementType,
+                               BeginsSizePolicy,
+                               BeginsOffsetPolicy,
+                               BeginsStridePolicy,
+                               BeginsIndirectionPolicy,
+                               NoSubset,
+                               ConcreteInterface>;
 
   // The cardinality of each relational operator is determined by the
   // StridePolicy of the relation
@@ -148,9 +155,16 @@ struct VariableCardinality
   using BeginsStridePolicy = StrideOne<ElementType>;
   using BeginsIndirectionPolicy = IndirectionPolicy;
 
-  // runtime size (fromSet.size()), striding from template parameter, no offset
-  using BeginsSet =
-    OrderedSet<ElementType, ElementType, BeginsSizePolicy, BeginsOffsetPolicy, BeginsStridePolicy, IndirectionPolicy>;
+  // runtime size (fromSet.size()), striding from template parameter, no offset.
+  // Uses the concrete interface to stay trivially copyable / device-capturable.
+  using BeginsSet = OrderedSet<ElementType,
+                               ElementType,
+                               BeginsSizePolicy,
+                               BeginsOffsetPolicy,
+                               BeginsStridePolicy,
+                               IndirectionPolicy,
+                               NoSubset,
+                               ConcreteInterface>;
 
   // The cardinality of each relational operator is determined by the
   // StridePolicy of the relation
@@ -232,9 +246,16 @@ struct MappedVariableCardinality
   using BeginsStridePolicy = StrideOne<ElementType>;
   using BeginsIndirectionPolicy = IndirectionPolicy;
 
-  // runtime size (fromSet.size()), striding from template parameter, no offset
-  using IndexSet =
-    OrderedSet<ElementType, ElementType, BeginsSizePolicy, BeginsOffsetPolicy, BeginsStridePolicy, IndirectionPolicy>;
+  // runtime size (fromSet.size()), striding from template parameter, no offset.
+  // Use concrete interface to remain trivially copyable.
+  using IndexSet = OrderedSet<ElementType,
+                              ElementType,
+                              BeginsSizePolicy,
+                              BeginsOffsetPolicy,
+                              BeginsStridePolicy,
+                              IndirectionPolicy,
+                              NoSubset,
+                              ConcreteInterface>;
   using BeginsSet = IndexSet;
 
   // The cardinality of each relational operator is determined by the

--- a/src/axom/slam/policies/CardinalityPolicies.hpp
+++ b/src/axom/slam/policies/CardinalityPolicies.hpp
@@ -55,11 +55,7 @@
 #include "axom/slam/OrderedSet.hpp"  // Note: Not a circular dependency since
 // CardinalityPolicies are for relations
 
-namespace axom
-{
-namespace slam
-{
-namespace policies
+namespace axom::slam::policies
 {
 /*!
  * \class ConstantCardinality
@@ -333,7 +329,4 @@ struct MappedVariableCardinality
   BeginsSet m_begins;
 };
 
-}  // end namespace policies
-
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam::policies

--- a/src/axom/slam/policies/CardinalityPolicies.hpp
+++ b/src/axom/slam/policies/CardinalityPolicies.hpp
@@ -144,10 +144,13 @@ struct ConstantCardinality
  *  first set maps to an arbitrary number of elements in the second set.
  *
  * \tparam ElementType the index data type
- * \tparam IndirectionPolicy the policy to use for storing offsets and indices
+ * \tparam IndirectionPolicy the policy to use for storing offsets and indices.
+ *  Defaults to \c ArrayIndirection (backed by an \c axom::Array), matching the
+ *  default indirection of \c slam::Map and \c MappedVariableCardinality.
+ *  Use \c ArrayViewIndirection for a buffer managed elsewhere (device-capturable),
+ *  or \c STLVectorIndirection for interoperation with existing \c std::vector storage.
  */
-template <typename ElementType = int,
-          typename IndirectionPolicy = STLVectorIndirection<ElementType, ElementType>>
+template <typename ElementType = int, typename IndirectionPolicy = ArrayIndirection<ElementType, ElementType>>
 struct VariableCardinality
 {
   using BeginsSizePolicy = RuntimeSize<ElementType>;

--- a/src/axom/slam/policies/IndirectionPolicies.hpp
+++ b/src/axom/slam/policies/IndirectionPolicies.hpp
@@ -12,11 +12,11 @@
  * \brief Defines several indirection policies for slam
  *
  * Indirection policies describe the underlying storage for indirection buffers
- * for a Slam set, relation or map. The canonical Axom-backed policies are
- * \c ArrayIndirection for \c axom::Array buffers and \c ArrayViewIndirection
- * for non-owning \c axom::ArrayView buffers. These are preferred for new Axom code.
- * \c CArrayIndirection and \c STLVectorIndirection remain useful for
- * compatibility, interop and as small reference implementations for custom policies.
+ * for a Slam set, relation or map. The two most common are \c ArrayIndirection,
+ * backed by an \c axom::Array, and \c ArrayViewIndirection, backed by an
+ * \c axom::ArrayView. \c CArrayIndirection (raw pointer) and
+ * \c STLVectorIndirection (\c std::vector) are for interoperation with existing
+ * storage, and serve as small reference implementations for custom policies.
  *
  * A valid indirection policy must support the
  * following interface:
@@ -34,11 +34,15 @@
  *     * data() : ElementType* -- allows direct access to the underlying buffer
  *       (when this exists)
  *
- * \note A policy describes storage access, not always storage ownership.
- *  Sets and relations typically bind externally managed buffers.
- *  Maps hold their \c OrderedMap buffer by value, so maps using \c ArrayIndirection
- *  own an \c axom::Array buffer while maps using \c ArrayViewIndirection 
- *  view storage owned elsewhere.
+ * \note An indirection policy describes how storage is reached and, for the
+ *  buffer types a Slam object holds by value, how that buffer's lifetime is handled.
+ *  It does not change which data structure logically owns the data. 
+ *  A \c Map holds its \c OrderedMap buffer by value: 
+ *  with \c ArrayIndirection that buffer is an \c axom::Array the map allocates 
+ *  and frees as part of its own lifetime, while with \c ArrayViewIndirection 
+ *  it is an \c axom::ArrayView referring to a buffer whose lifetime is managed elsewhere
+ *  (and which must outlive the map). 
+ *  Sets and relations, by contrast, typically refer to buffers managed outside the Slam object.
  */
 
 #include "axom/core/Macros.hpp"
@@ -318,9 +322,9 @@ private:
 /**
  * \brief A policy class for sets with C-style array-based indirection
  *
- * \note This is a low-level compatibility/reference policy.
- *  Prefer \c ArrayIndirection for \c axom::Array-backed storage or
- *  \c ArrayViewIndirection for non-owning views in new Axom code.
+ * \note Indexes a raw pointer, for interoperation with C-style array storage.
+ *  For an \c axom::Array buffer the object manages, use \c ArrayIndirection;
+ *  for an \c axom::ArrayView of a buffer managed elsewhere, use \c ArrayViewIndirection.
  */
 template <typename PositionType, typename ElementType>
 using CArrayIndirection =
@@ -371,9 +375,9 @@ private:
 /**
  * \brief A policy class for sets with std::vector-based indirection
  *
- * \note This is a host-only compatibility/reference policy.
- *  Prefer \c ArrayIndirection for \c axom::Array-backed storage or
- *  \c ArrayViewIndirection for non-owning views in new Axom code.
+ * \note Indexes a (host-only) \c std::vector, for interoperation with existing \c std::vector storage.
+ *  For an \c axom::Array buffer the object manages, use \c ArrayIndirection; 
+ *  for an \c axom::ArrayView of a buffer managed elsewhere, use \c ArrayViewIndirection.
  */
 template <typename PositionType, typename ElementType>
 using STLVectorIndirection =
@@ -423,10 +427,10 @@ private:
 /**
  * \brief A policy class for sets with axom::Array-based indirection
  *
- * \note This is the canonical indirection policy for \c axom::Array-backed storage.
- *  It is the owning-buffer counterpart to the non-owning \c ArrayViewIndirection policy.
- *  Maps using this policy store an \c axom::Array by value,
- *  while sets and relations bind an existing array buffer.
+ * \note Indexes an \c axom::Array; the default indirection for a \c Map or \c BivariateMap.
+ *  A map with this policy holds its \c axom::Array by value and frees it as part of the map's lifetime;
+ *  its lifetime-counterpart is \c ArrayViewIndirection, which refers to a buffer managed elsewhere.
+ *  Sets and relations with this policy refer to an existing \c axom::Array buffer.
  */
 template <typename PositionType, typename ElementType>
 using ArrayIndirection = detail::IndexedIndirection<ArrayIndirectionBase<PositionType, ElementType>>;
@@ -476,11 +480,11 @@ private:
 /**
  * \brief A policy class for sets with axom::ArrayView-based indirection
  *
- * \note This is the canonical non-owning indirection policy for new Axom code
- *  and is the view counterpart to \c ArrayIndirection. It stores an
- *  \c axom::ArrayView by value, so the backing allocation must outlive the
- *  set, map or relation that uses it. Because \c axom::ArrayView is trivially
- *  copyable, view-backed Slam objects can be captured by value into device kernels.
+ * \note Indexes an \c axom::ArrayView; the lifetime-counterpart to \c ArrayIndirection.
+ *  It holds an \c axom::ArrayView by value and refers to a buffer whose lifetime is managed elsewhere, 
+ *  so that backing allocation must outlive the set, map or relation that uses it.
+ *  Because \c axom::ArrayView is trivially copyable, Slam objects using this policy 
+ *  can be captured by value into device kernels.
  */
 template <typename PositionType, typename ElementType>
 using ArrayViewIndirection =

--- a/src/axom/slam/policies/IndirectionPolicies.hpp
+++ b/src/axom/slam/policies/IndirectionPolicies.hpp
@@ -11,8 +11,14 @@
  *
  * \brief Defines several indirection policies for slam
  *
- * Indirection policies encompass the underlying storage for indirection buffers
- * for a SLAM set, relation or map. A valid indirection policy must support the
+ * Indirection policies describe the underlying storage for indirection buffers
+ * for a Slam set, relation or map. The canonical Axom-backed policies are
+ * \c ArrayIndirection for \c axom::Array buffers and \c ArrayViewIndirection
+ * for non-owning \c axom::ArrayView buffers. These are preferred for new Axom code.
+ * \c CArrayIndirection and \c STLVectorIndirection remain useful for
+ * compatibility, interop and as small reference implementations for custom policies.
+ *
+ * A valid indirection policy must support the
  * following interface:
  *   * [required]
  *   * type alias IndirectionResult -- the type of the result of an indirection
@@ -28,8 +34,11 @@
  *     * data() : ElementType* -- allows direct access to the underlying buffer
  *       (when this exists)
  *
- * \note Slam's Sets, Relations and Maps are not responsible for
- *  allocating/deallocating their own memory
+ * \note A policy describes storage access, not always storage ownership.
+ *  Sets and relations typically bind externally managed buffers.
+ *  Maps hold their \c OrderedMap buffer by value, so maps using \c ArrayIndirection
+ *  own an \c axom::Array buffer while maps using \c ArrayViewIndirection 
+ *  view storage owned elsewhere.
  */
 
 #include "axom/core/Macros.hpp"
@@ -308,6 +317,10 @@ private:
 
 /**
  * \brief A policy class for sets with C-style array-based indirection
+ *
+ * \note This is a low-level compatibility/reference policy.
+ *  Prefer \c ArrayIndirection for \c axom::Array-backed storage or
+ *  \c ArrayViewIndirection for non-owning views in new Axom code.
  */
 template <typename PositionType, typename ElementType>
 using CArrayIndirection =
@@ -356,7 +369,11 @@ private:
 };
 
 /**
- * \brief A policy class for sets with stl vector-based indirection
+ * \brief A policy class for sets with std::vector-based indirection
+ *
+ * \note This is a host-only compatibility/reference policy.
+ *  Prefer \c ArrayIndirection for \c axom::Array-backed storage or
+ *  \c ArrayViewIndirection for non-owning views in new Axom code.
  */
 template <typename PositionType, typename ElementType>
 using STLVectorIndirection =
@@ -405,6 +422,11 @@ private:
 
 /**
  * \brief A policy class for sets with axom::Array-based indirection
+ *
+ * \note This is the canonical indirection policy for \c axom::Array-backed storage.
+ *  It is the owning-buffer counterpart to the non-owning \c ArrayViewIndirection policy.
+ *  Maps using this policy store an \c axom::Array by value,
+ *  while sets and relations bind an existing array buffer.
  */
 template <typename PositionType, typename ElementType>
 using ArrayIndirection = detail::IndexedIndirection<ArrayIndirectionBase<PositionType, ElementType>>;
@@ -453,6 +475,12 @@ private:
 
 /**
  * \brief A policy class for sets with axom::ArrayView-based indirection
+ *
+ * \note This is the canonical non-owning indirection policy for new Axom code
+ *  and is the view counterpart to \c ArrayIndirection. It stores an
+ *  \c axom::ArrayView by value, so the backing allocation must outlive the
+ *  set, map or relation that uses it. Because \c axom::ArrayView is trivially
+ *  copyable, view-backed Slam objects can be captured by value into device kernels.
  */
 template <typename PositionType, typename ElementType>
 using ArrayViewIndirection =

--- a/src/axom/slam/policies/InterfacePolicies.hpp
+++ b/src/axom/slam/policies/InterfacePolicies.hpp
@@ -47,7 +47,7 @@ struct VirtualInterface
 { };
 
 /**
- * \class VirtualInterface
+ * \class ConcreteInterface
  *
  * \brief Policy to use a concrete, CRTP-based interface with a given Slam type.
  */

--- a/src/axom/slam/policies/InterfacePolicies.hpp
+++ b/src/axom/slam/policies/InterfacePolicies.hpp
@@ -32,11 +32,7 @@
  * \see BivariateSetInterfacePolicies.hpp
  */
 
-namespace axom
-{
-namespace slam
-{
-namespace policies
+namespace axom::slam::policies
 {
 /**
  * \class VirtualInterface
@@ -54,6 +50,4 @@ struct VirtualInterface
 struct ConcreteInterface
 { };
 
-}  // namespace policies
-}  // namespace slam
-}  // namespace axom
+}  // namespace axom::slam::policies

--- a/src/axom/slam/policies/MapInterfacePolicies.hpp
+++ b/src/axom/slam/policies/MapInterfacePolicies.hpp
@@ -12,11 +12,7 @@
 #include "axom/slam/MapBase.hpp"
 #include "axom/slam/policies/InterfacePolicies.hpp"
 
-namespace axom
-{
-namespace slam
-{
-namespace policies
+namespace axom::slam::policies
 {
 namespace detail
 {
@@ -39,6 +35,4 @@ struct MapInterfaceSelector<VirtualInterface, PosType>
 template <typename InterfacePolicy, typename SetPositionType>
 using MapInterface = typename detail::MapInterfaceSelector<InterfacePolicy, SetPositionType>::Type;
 
-}  // end namespace policies
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam::policies

--- a/src/axom/slam/policies/SetInterfacePolicies.hpp
+++ b/src/axom/slam/policies/SetInterfacePolicies.hpp
@@ -11,11 +11,7 @@
 #include "axom/slam/Set.hpp"
 #include "axom/slam/policies/InterfacePolicies.hpp"
 
-namespace axom
-{
-namespace slam
-{
-namespace policies
+namespace axom::slam::policies
 {
 namespace detail
 {
@@ -56,6 +52,4 @@ struct SetInterfaceSelector<VirtualInterface, PosType, ElemType>
 template <typename InterfacePolicy, typename PosType, typename ElemType>
 using SetInterface = typename detail::SetInterfaceSelector<InterfacePolicy, PosType, ElemType>::Type;
 
-}  // end namespace policies
-}  // end namespace slam
-}  // end namespace axom
+}  // end namespace axom::slam::policies

--- a/src/axom/slam/tests/slam_set_BivariateSet.cpp
+++ b/src/axom/slam/tests/slam_set_BivariateSet.cpp
@@ -35,7 +35,12 @@ constexpr int SET_OFFSET_2 = 2;
 // Template aliases to simplify specifying some sets and relations
 template <typename P, typename E, typename FromSet, typename ToSet>
 using RelType =
-  slam::StaticRelation<P, E, policies::VariableCardinality<E>, policies::STLVectorIndirection<P, E>, FromSet, ToSet>;
+  slam::StaticRelation<P,
+                       E,
+                       policies::VariableCardinality<P, policies::ArrayIndirection<P, P>>,
+                       policies::ArrayIndirection<P, E>,
+                       FromSet,
+                       ToSet>;
 
 template <typename SetType>
 using PositionSetType =
@@ -71,6 +76,8 @@ public:
   using ElementType = typename BSet::ElementType;
 
   using Vec = std::vector<PositionType>;
+  using PositionArray = axom::Array<PositionType>;
+  using ElementArray = axom::Array<ElementType>;
   using RelationType = ::RelType<PositionType, ElementType, FirstSetType, SecondSetType>;
 
   using PSet1 = ::PositionSetType<FirstSetType>;
@@ -187,7 +194,7 @@ private:
     for(int i = 0; i < m_set1->size(); ++i)
     {
       auto outer = m_set1->at(i);
-      relationBegins.push_back(relationIndices.size());
+      relationBegins.push_back(static_cast<PositionType>(relationIndices.size()));
 
       for(int j = 0; j < m_set2->size(); ++j)
       {
@@ -198,7 +205,7 @@ private:
         }
       }
     }
-    relationBegins.push_back(relationIndices.size());
+    relationBegins.push_back(static_cast<PositionType>(relationIndices.size()));
 
     // Construct the relation using this data
     using RelationBuilder = typename RelationType::RelationBuilder;
@@ -286,8 +293,8 @@ protected:
   Vec setIndices1;
   Vec setIndices2;
 
-  Vec relationBegins;
-  Vec relationIndices;
+  PositionArray relationBegins;
+  ElementArray relationIndices;
   RelationType modRelation;
 };
 

--- a/src/axom/slam/tests/slam_static_asserts.cpp
+++ b/src/axom/slam/tests/slam_static_asserts.cpp
@@ -21,10 +21,16 @@
 #include "axom/slam/ModularInt.hpp"
 #include "axom/slam/Traits.hpp"
 #include "axom/slam/RangeSet.hpp"
+#include "axom/slam/ProductSet.hpp"
+#include "axom/slam/StaticRelation.hpp"
+#include "axom/slam/BivariateMap.hpp"
+#include "axom/slam/Map.hpp"
 #include "axom/slam/policies/SizePolicies.hpp"
 #include "axom/slam/policies/StridePolicies.hpp"
 #include "axom/slam/policies/OffsetPolicies.hpp"
 #include "axom/slam/policies/ValuePolicies.hpp"
+#include "axom/slam/policies/CardinalityPolicies.hpp"
+#include "axom/slam/policies/IndirectionPolicies.hpp"
 
 #include <optional>
 
@@ -169,6 +175,51 @@ struct UserCopyHandle
 };
 static_assert(!slam::is_handle_like_v<UserCopyHandle>,
               "a user-declared copy ctor breaks the handle contract");
+
+//------------------------------------------------------------------------------
+// Device-capture contract: a slam container survives capture-by-value into a
+// kernel only if it is trivially copyable, which requires the concrete interface.
+//------------------------------------------------------------------------------
+using SetPos = slam::DefaultPositionType;
+using SetElem = slam::DefaultElementType;
+using ViewInd = policies::ArrayViewIndirection<SetPos, SetElem>;
+using ViewPosInd = policies::ArrayViewIndirection<SetPos, SetPos>;
+using ConcreteRangeSet = slam::RangeSet<SetPos, SetElem>::ConcreteSet;
+using ConcreteProductSet = slam::ProductSet<ConcreteRangeSet, ConcreteRangeSet>::ConcreteSet;
+using ViewMap = slam::Map<SetElem, ConcreteRangeSet, ViewInd>;
+using ViewBivariateMap = slam::BivariateMap<SetElem, ConcreteProductSet, ViewInd>;
+using ViewVariableRelation =  //
+  slam::StaticRelation<SetPos,
+                       SetElem,
+                       policies::VariableCardinality<SetPos, ViewPosInd>,
+                       ViewInd,
+                       ConcreteRangeSet,
+                       ConcreteRangeSet>;
+using ViewConstantRelation =
+  slam::StaticRelation<SetPos,
+                       SetElem,
+                       policies::ConstantCardinality<SetPos, policies::CompileTimeStride<SetPos, 3>>,
+                       ViewInd,
+                       ConcreteRangeSet,
+                       ConcreteRangeSet>;
+
+static_assert(std::is_trivially_copyable_v<ViewInd>,
+              "ArrayViewIndirection holds a view by value and must be trivially copyable");
+static_assert(std::is_trivially_copyable_v<ConcreteRangeSet>,
+              "a concrete-interface RangeSet is trivially copyable");
+static_assert(std::is_trivially_copyable_v<ConcreteProductSet>,
+              "a concrete-interface ProductSet is trivially copyable");
+static_assert(std::is_trivially_copyable_v<ViewMap>, "a view-backed Map is trivially copyable");
+static_assert(std::is_trivially_copyable_v<ViewBivariateMap>,
+              "a view-backed BivariateMap is trivially copyable");
+static_assert(std::is_trivially_copyable_v<ViewVariableRelation>,
+              "a view-backed variable relation is trivially copyable");
+static_assert(std::is_trivially_copyable_v<ViewConstantRelation>,
+              "a view-backed constant relation is trivially copyable");
+
+// The default set uses the virtual interface so it is not trivially copyable
+static_assert(!std::is_trivially_copyable_v<slam::RangeSet<>>,
+              "the virtual-interface set is not device-capturable by design");
 
 }  // anonymous namespace
 

--- a/src/axom/slam/tests/slam_static_asserts.cpp
+++ b/src/axom/slam/tests/slam_static_asserts.cpp
@@ -301,6 +301,12 @@ static_assert(sizeof(AliasRuntimeArrayViewBivariateMap) > 0,
               "RuntimeArrayViewBivariateMap instantiates");
 
 // Check that the alias types match expectations
+static_assert(std::is_same_v<typename slam::Map<double>::OrderedMap, axom::Array<double>>,
+              "Map's default indirection owns an axom::Array");
+static_assert(
+  std::is_same_v<typename slam::BivariateMap<double>::MapType::OrderedMap, axom::Array<double>>,
+  "BivariateMap's default indirection owns an axom::Array");
+
 static_assert(std::is_same_v<AliasArrayMap,
                              slam::Map<double,
                                        slam::RangeSet<>,

--- a/src/axom/slam/tests/slam_static_asserts.cpp
+++ b/src/axom/slam/tests/slam_static_asserts.cpp
@@ -19,6 +19,8 @@
 #include "gtest/gtest.h"
 
 #include "axom/slam/ModularInt.hpp"
+#include "axom/slam/Traits.hpp"
+#include "axom/slam/RangeSet.hpp"
 #include "axom/slam/policies/SizePolicies.hpp"
 #include "axom/slam/policies/StridePolicies.hpp"
 #include "axom/slam/policies/OffsetPolicies.hpp"
@@ -126,6 +128,47 @@ static_assert(incTwice(4) == 1, "++ twice from 4 mod 5 == 1");
 // equality across the modulus
 static_assert(Mod5(2) == Mod5(7), "2 and 7 are equal mod 5");
 static_assert(Mod5(2) != Mod5(3), "2 and 3 differ mod 5");
+
+//------------------------------------------------------------------------------
+// Check trait predicates for policies and sets
+//------------------------------------------------------------------------------
+
+// Value policies satisfy their policy concept, and are distinguished from each
+// other and from sets (a set has size() but no value()).
+static_assert(slam::is_value_policy_v<Size5>, "a size policy is a value policy");
+static_assert(slam::is_size_policy_v<Size5>, "CompileTimeSize is a size policy");
+static_assert(slam::is_stride_policy_v<Stride4>, "CompileTimeStride is a stride policy");
+static_assert(slam::is_offset_policy_v<Off3>, "CompileTimeOffset is an offset policy");
+static_assert(!slam::is_stride_policy_v<Size5>, "a size policy is not a stride policy");
+static_assert(!slam::is_size_policy_v<Stride4>, "a stride policy is not a size policy");
+static_assert(!slam::is_set_like_v<Size5>, "a policy is not a set");
+
+// RangeSet models the (ordered) set concept and nothing else.
+static_assert(slam::is_set_like_v<slam::RangeSet<>>, "RangeSet is set-like");
+static_assert(slam::is_ordered_set_like_v<slam::RangeSet<>>, "RangeSet is an ordered set");
+static_assert(!slam::is_relation_like_v<slam::RangeSet<>>, "RangeSet is not a relation");
+static_assert(!slam::is_map_like_v<slam::RangeSet<>>, "RangeSet is not a map");
+static_assert(!slam::is_bivariate_set_like_v<slam::RangeSet<>>, "RangeSet is not bivariate");
+
+// Index-space concepts: raw integrals are positions
+static_assert(slam::is_position_like_v<int>, "int is a position");
+static_assert(slam::is_position_like_v<axom::slam::DefaultPositionType>,
+              "slam's default position type is a position");
+static_assert(!slam::is_position_like_v<double>, "double is not a position");
+
+// An element handle must be trivially copyable so it survives capture-by-value into a device kernel
+struct TrivialHandle
+{
+  int id;
+};
+static_assert(slam::is_handle_like_v<TrivialHandle>, "a trivially-copyable struct is handle-like");
+
+struct UserCopyHandle
+{
+  UserCopyHandle(const UserCopyHandle&) { }
+};
+static_assert(!slam::is_handle_like_v<UserCopyHandle>,
+              "a user-declared copy ctor breaks the handle contract");
 
 }  // anonymous namespace
 

--- a/src/axom/slam/tests/slam_static_asserts.cpp
+++ b/src/axom/slam/tests/slam_static_asserts.cpp
@@ -263,6 +263,7 @@ static_assert(std::is_same_v<slam::maybe_const_t<false, int>, int>, "maybe_const
 using AliasArraySet = slam::ArraySet<>;
 using AliasCustomArraySet = slam::ArraySet<SetPos, double>;
 using AliasArrayViewSet = slam::ArrayViewSet<>;
+
 using AliasVarRelation = slam::VariableRelation<slam::RangeSet<>, slam::RangeSet<>>;
 using AliasVarRelationView = slam::VariableRelationView<slam::RangeSet<>, slam::RangeSet<>>;
 using AliasConstRelation = slam::ConstantRelation<slam::RangeSet<>, slam::RangeSet<>, 3>;
@@ -270,15 +271,24 @@ using AliasConstRelationView = slam::ConstantRelationView<slam::RangeSet<>, slam
 using AliasRuntimeConstRelation = slam::RuntimeConstantRelation<slam::RangeSet<>, slam::RangeSet<>>;
 using AliasRuntimeConstRelationView =
   slam::RuntimeConstantRelationView<slam::RangeSet<>, slam::RangeSet<>>;
-using AliasArrayMap = slam::ArrayMap<slam::RangeSet<>, double, 3>;
-using AliasArrayViewMap = slam::ArrayViewMap<slam::RangeSet<>, double, 3>;
-using AliasRuntimeArrayMap = slam::RuntimeArrayMap<slam::RangeSet<>, double>;
-using AliasRuntimeArrayViewMap = slam::RuntimeArrayViewMap<slam::RangeSet<>, double>;
-using AliasArrayBivariateMap = slam::ArrayBivariateMap<ConcreteProductSet, double, 2>;
-using AliasArrayViewBivariateMap = slam::ArrayViewBivariateMap<ConcreteProductSet, double, 2>;
-using AliasRuntimeArrayBivariateMap = slam::RuntimeArrayBivariateMap<ConcreteProductSet, double>;
-using AliasRuntimeArrayViewBivariateMap =
-  slam::RuntimeArrayViewBivariateMap<ConcreteProductSet, double>;
+
+using MapArrayCT = slam::Map<double,
+                             slam::RangeSet<>,
+                             policies::ArrayIndirection<SetPos, double>,
+                             policies::CompileTimeStride<SetPos, 3>>;
+using MapArrayViewCT = slam::Map<double,
+                                 slam::RangeSet<>,
+                                 policies::ArrayViewIndirection<SetPos, double>,
+                                 policies::CompileTimeStride<SetPos, 3>>;
+using MapArrayViewRT = slam::Map<double,
+                                 slam::RangeSet<>,
+                                 policies::ArrayViewIndirection<SetPos, double>,
+                                 policies::RuntimeStride<SetPos>>;
+using BMapArrayViewCT =
+  slam::BivariateMap<double,
+                     ConcreteProductSet,
+                     policies::ArrayViewIndirection<typename ConcreteProductSet::PositionType, double>,
+                     policies::CompileTimeStride<typename ConcreteProductSet::PositionType, 2>>;
 
 // Force full instantiation (also exercises axom::Array's element requirements).
 static_assert(sizeof(AliasArraySet) > 0, "ArraySet instantiates");
@@ -290,80 +300,17 @@ static_assert(sizeof(AliasConstRelation) > 0, "ConstantRelation instantiates");
 static_assert(sizeof(AliasConstRelationView) > 0, "ConstantRelationView instantiates");
 static_assert(sizeof(AliasRuntimeConstRelation) > 0, "RuntimeConstantRelation instantiates");
 static_assert(sizeof(AliasRuntimeConstRelationView) > 0, "RuntimeConstantRelationView instantiates");
-static_assert(sizeof(AliasArrayMap) > 0, "ArrayMap instantiates");
-static_assert(sizeof(AliasArrayViewMap) > 0, "ArrayViewMap instantiates");
-static_assert(sizeof(AliasRuntimeArrayMap) > 0, "RuntimeArrayMap instantiates");
-static_assert(sizeof(AliasRuntimeArrayViewMap) > 0, "RuntimeArrayViewMap instantiates");
-static_assert(sizeof(AliasArrayBivariateMap) > 0, "ArrayBivariateMap instantiates");
-static_assert(sizeof(AliasArrayViewBivariateMap) > 0, "ArrayViewBivariateMap instantiates");
-static_assert(sizeof(AliasRuntimeArrayBivariateMap) > 0, "RuntimeArrayBivariateMap instantiates");
-static_assert(sizeof(AliasRuntimeArrayViewBivariateMap) > 0,
-              "RuntimeArrayViewBivariateMap instantiates");
+static_assert(sizeof(MapArrayCT) > 0, "Array-backed Map instantiates");
+static_assert(sizeof(MapArrayViewCT) > 0, "ArrayView Map instantiates");
+static_assert(sizeof(MapArrayViewRT) > 0, "runtime-stride ArrayView Map instantiates");
+static_assert(sizeof(BMapArrayViewCT) > 0, "ArrayView BivariateMap instantiates");
 
-// Check that the alias types match expectations
+// Map/BivariateMap default to an axom::Array indirection (managing their own buffer).
 static_assert(std::is_same_v<typename slam::Map<double>::OrderedMap, axom::Array<double>>,
-              "Map's default indirection owns an axom::Array");
+              "Map's default indirection uses an axom::Array");
 static_assert(
   std::is_same_v<typename slam::BivariateMap<double>::MapType::OrderedMap, axom::Array<double>>,
-  "BivariateMap's default indirection owns an axom::Array");
-
-static_assert(std::is_same_v<AliasArrayMap,
-                             slam::Map<double,
-                                       slam::RangeSet<>,
-                                       policies::ArrayIndirection<SetPos, double>,
-                                       policies::CompileTimeStride<SetPos, 3>>>,
-              "ArrayMap names the canonical Array-backed Map policy stack");
-static_assert(std::is_same_v<AliasArrayViewMap,
-                             slam::Map<double,
-                                       slam::RangeSet<>,
-                                       policies::ArrayViewIndirection<SetPos, double>,
-                                       policies::CompileTimeStride<SetPos, 3>>>,
-              "ArrayViewMap names the canonical ArrayView-backed Map policy stack");
-static_assert(
-  std::is_same_v<
-    AliasRuntimeArrayMap,
-    slam::Map<double, slam::RangeSet<>, policies::ArrayIndirection<SetPos, double>, policies::RuntimeStride<SetPos>>>,
-  "RuntimeArrayMap names the canonical Array-backed runtime-stride Map");
-static_assert(std::is_same_v<AliasRuntimeArrayViewMap,
-                             slam::Map<double,
-                                       slam::RangeSet<>,
-                                       policies::ArrayViewIndirection<SetPos, double>,
-                                       policies::RuntimeStride<SetPos>>>,
-              "RuntimeArrayViewMap names the canonical ArrayView-backed runtime-stride Map");
-static_assert(
-  std::is_same_v<
-    AliasArrayBivariateMap,
-    slam::BivariateMap<double,
-                       ConcreteProductSet,
-                       policies::ArrayIndirection<typename ConcreteProductSet::PositionType, double>,
-                       policies::CompileTimeStride<typename ConcreteProductSet::PositionType, 2>>>,
-  "ArrayBivariateMap names the canonical Array-backed BivariateMap policy stack");
-static_assert(
-  std::is_same_v<
-    AliasArrayViewBivariateMap,
-    slam::BivariateMap<double,
-                       ConcreteProductSet,
-                       policies::ArrayViewIndirection<typename ConcreteProductSet::PositionType, double>,
-                       policies::CompileTimeStride<typename ConcreteProductSet::PositionType, 2>>>,
-  "ArrayViewBivariateMap names the canonical ArrayView-backed BivariateMap policy stack");
-static_assert(
-  std::is_same_v<
-    AliasRuntimeArrayBivariateMap,
-    slam::BivariateMap<double,
-                       ConcreteProductSet,
-                       policies::ArrayIndirection<typename ConcreteProductSet::PositionType, double>,
-                       policies::RuntimeStride<typename ConcreteProductSet::PositionType>>>,
-  "RuntimeArrayBivariateMap names the canonical Array-backed "
-  "runtime-stride BivariateMap");
-static_assert(
-  std::is_same_v<
-    AliasRuntimeArrayViewBivariateMap,
-    slam::BivariateMap<double,
-                       ConcreteProductSet,
-                       policies::ArrayViewIndirection<typename ConcreteProductSet::PositionType, double>,
-                       policies::RuntimeStride<typename ConcreteProductSet::PositionType>>>,
-  "RuntimeArrayViewBivariateMap names the canonical ArrayView-backed "
-  "runtime-stride BivariateMap");
+  "BivariateMap's default indirection uses an axom::Array");
 
 // Check that the aliases match the expected concepts
 static_assert(slam::is_set_like_v<AliasArraySet>, "ArraySet is set-like");
@@ -383,24 +330,16 @@ static_assert(slam::is_relation_like_v<AliasRuntimeConstRelationView>,
               "RuntimeConstantRelationView is relation-like");
 static_assert(slam::is_bivariate_set_like_v<ConcreteProductSet>,
               "a ProductSet is bivariate-set-like");
-static_assert(slam::is_map_like_v<AliasArrayMap>, "ArrayMap is map-like");
-static_assert(slam::is_map_like_v<AliasArrayViewMap>, "ArrayViewMap is map-like");
-static_assert(slam::is_map_like_v<AliasRuntimeArrayMap>, "RuntimeArrayMap is map-like");
-static_assert(slam::is_map_like_v<AliasRuntimeArrayViewMap>, "RuntimeArrayViewMap is map-like");
-static_assert(slam::is_map_over_v<AliasArrayMap, slam::RangeSet<>>,
-              "ArrayMap is a map over its set");
-static_assert(slam::is_map_over_v<AliasArrayViewMap, slam::RangeSet<>>,
-              "ArrayViewMap is a map over its set");
-static_assert(slam::is_map_over_v<AliasRuntimeArrayMap, slam::RangeSet<>>,
-              "RuntimeArrayMap is a map over its set");
-static_assert(slam::is_map_over_v<AliasRuntimeArrayViewMap, slam::RangeSet<>>,
-              "RuntimeArrayViewMap is a map over its set");
-static_assert(slam::is_map_like_v<AliasArrayBivariateMap>, "ArrayBivariateMap is map-like");
-static_assert(slam::is_map_like_v<AliasArrayViewBivariateMap>, "ArrayViewBivariateMap is map-like");
-static_assert(slam::is_map_like_v<AliasRuntimeArrayBivariateMap>,
-              "RuntimeArrayBivariateMap is map-like");
-static_assert(slam::is_map_like_v<AliasRuntimeArrayViewBivariateMap>,
-              "RuntimeArrayViewBivariateMap is map-like");
+static_assert(slam::is_map_like_v<MapArrayCT>, "Array-backed Map is map-like");
+static_assert(slam::is_map_like_v<MapArrayViewCT>, "ArrayView Map is map-like");
+static_assert(slam::is_map_like_v<MapArrayViewRT>, "runtime-stride ArrayView Map is map-like");
+static_assert(slam::is_map_over_v<MapArrayCT, slam::RangeSet<>>,
+              "Array-backed Map is a map over its set");
+static_assert(slam::is_map_over_v<MapArrayViewCT, slam::RangeSet<>>,
+              "ArrayView Map is a map over its set");
+static_assert(slam::is_map_over_v<MapArrayViewRT, slam::RangeSet<>>,
+              "runtime-stride ArrayView Map is a map over its set");
+static_assert(slam::is_map_like_v<BMapArrayViewCT>, "ArrayView BivariateMap is map-like");
 
 // Check that the aliases match the Array/ArrayView make_* helpers.
 using RSPos = slam::RangeSet<>::PositionType;
@@ -448,15 +387,16 @@ static_assert(
   std::is_same_v<AliasArrayViewSet,
                  decltype(slam::make_indirection_set(std::declval<axom::ArrayView<RSPos>>()))>,
   "ArrayViewSet matches make_indirection_set's ArrayView overload");
-static_assert(std::is_same_v<AliasArrayViewMap,
+static_assert(std::is_same_v<MapArrayViewCT,
                              decltype(slam::make_map_ct<3>(std::declval<const slam::RangeSet<>*>(),
                                                            std::declval<axom::ArrayView<double>>()))>,
-              "ArrayViewMap matches make_map_ct<N>'s ArrayView overload");
-static_assert(std::is_same_v<AliasRuntimeArrayViewMap,
-                             decltype(slam::make_map(std::declval<const slam::RangeSet<>*>(),
-                                                     std::declval<RSPos>(),
-                                                     std::declval<axom::ArrayView<double>>()))>,
-              "RuntimeArrayViewMap matches make_map's runtime-stride ArrayView overload");
+              "make_map_ct<N>'s ArrayView overload yields the ArrayView Map");
+static_assert(
+  std::is_same_v<MapArrayViewRT,
+                 decltype(slam::make_map(std::declval<const slam::RangeSet<>*>(),
+                                         std::declval<RSPos>(),
+                                         std::declval<axom::ArrayView<double>>()))>,
+  "make_map's runtime-stride ArrayView overload yields the runtime-stride ArrayView Map");
 
 }  // anonymous namespace
 

--- a/src/axom/slam/tests/slam_static_asserts.cpp
+++ b/src/axom/slam/tests/slam_static_asserts.cpp
@@ -32,6 +32,7 @@
 #include "axom/slam/policies/CardinalityPolicies.hpp"
 #include "axom/slam/policies/IndirectionPolicies.hpp"
 
+#include <iterator>
 #include <optional>
 
 namespace
@@ -220,6 +221,35 @@ static_assert(std::is_trivially_copyable_v<ViewConstantRelation>,
 // The default set uses the virtual interface so it is not trivially copyable
 static_assert(!std::is_trivially_copyable_v<slam::RangeSet<>>,
               "the virtual-interface set is not device-capturable by design");
+
+//------------------------------------------------------------------------------
+// OrderedSetIterator models C++17 RandomAccessIterator
+// std::iterator_traits is complete for both the mutable and const iterator
+// and reports the random-access category. The single const-qualified
+// accessor path also makes the iterator const-dereferenceable.
+//------------------------------------------------------------------------------
+using RangeIter = slam::RangeSet<>::iterator;
+using RangeConstIter = slam::RangeSet<>::const_iterator;
+
+static_assert(
+  std::is_same_v<std::iterator_traits<RangeIter>::iterator_category, std::random_access_iterator_tag>,
+  "the mutable ordered-set iterator is random-access");
+static_assert(std::is_same_v<std::iterator_traits<RangeConstIter>::iterator_category,
+                             std::random_access_iterator_tag>,
+              "the const ordered-set iterator is random-access");
+static_assert(
+  std::is_same_v<std::iterator_traits<RangeIter>::difference_type, slam::RangeSet<>::PositionType>,
+  "iterator difference_type is the set's position type");
+static_assert(std::is_integral_v<std::iterator_traits<RangeIter>::difference_type> &&
+                std::is_signed_v<std::iterator_traits<RangeIter>::difference_type>,
+              "a random-access difference_type is a signed integral");
+static_assert(!std::is_void_v<std::iterator_traits<RangeConstIter>::value_type>,
+              "iterator_traits exposes a value_type");
+
+// maybe_const_t adds const exactly when requested.
+static_assert(std::is_same_v<slam::maybe_const_t<true, int>, const int>,
+              "maybe_const_t<true, T> is const T");
+static_assert(std::is_same_v<slam::maybe_const_t<false, int>, int>, "maybe_const_t<false, T> is T");
 
 }  // anonymous namespace
 

--- a/src/axom/slam/tests/slam_static_asserts.cpp
+++ b/src/axom/slam/tests/slam_static_asserts.cpp
@@ -25,6 +25,10 @@
 #include "axom/slam/StaticRelation.hpp"
 #include "axom/slam/BivariateMap.hpp"
 #include "axom/slam/Map.hpp"
+#include "axom/slam/Aliases.hpp"
+#include "axom/slam/MapBuilders.hpp"
+#include "axom/slam/RelationBuilders.hpp"
+#include "axom/slam/SetBuilders.hpp"
 #include "axom/slam/policies/SizePolicies.hpp"
 #include "axom/slam/policies/StridePolicies.hpp"
 #include "axom/slam/policies/OffsetPolicies.hpp"
@@ -34,6 +38,7 @@
 
 #include <iterator>
 #include <optional>
+#include <utility>
 
 namespace
 {
@@ -250,6 +255,202 @@ static_assert(!std::is_void_v<std::iterator_traits<RangeConstIter>::value_type>,
 static_assert(std::is_same_v<slam::maybe_const_t<true, int>, const int>,
               "maybe_const_t<true, T> is const T");
 static_assert(std::is_same_v<slam::maybe_const_t<false, int>, int>, "maybe_const_t<false, T> is T");
+
+//------------------------------------------------------------------------------
+// Checks alias layer (Aliases.hpp): each alias instantiates with Slam's
+// canonical Array/ArrayView indirection and satisfies the matching predicate.
+//------------------------------------------------------------------------------
+using AliasArraySet = slam::ArraySet<>;
+using AliasCustomArraySet = slam::ArraySet<SetPos, double>;
+using AliasArrayViewSet = slam::ArrayViewSet<>;
+using AliasVarRelation = slam::VariableRelation<slam::RangeSet<>, slam::RangeSet<>>;
+using AliasVarRelationView = slam::VariableRelationView<slam::RangeSet<>, slam::RangeSet<>>;
+using AliasConstRelation = slam::ConstantRelation<slam::RangeSet<>, slam::RangeSet<>, 3>;
+using AliasConstRelationView = slam::ConstantRelationView<slam::RangeSet<>, slam::RangeSet<>, 3>;
+using AliasRuntimeConstRelation = slam::RuntimeConstantRelation<slam::RangeSet<>, slam::RangeSet<>>;
+using AliasRuntimeConstRelationView =
+  slam::RuntimeConstantRelationView<slam::RangeSet<>, slam::RangeSet<>>;
+using AliasArrayMap = slam::ArrayMap<slam::RangeSet<>, double, 3>;
+using AliasArrayViewMap = slam::ArrayViewMap<slam::RangeSet<>, double, 3>;
+using AliasRuntimeArrayMap = slam::RuntimeArrayMap<slam::RangeSet<>, double>;
+using AliasRuntimeArrayViewMap = slam::RuntimeArrayViewMap<slam::RangeSet<>, double>;
+using AliasArrayBivariateMap = slam::ArrayBivariateMap<ConcreteProductSet, double, 2>;
+using AliasArrayViewBivariateMap = slam::ArrayViewBivariateMap<ConcreteProductSet, double, 2>;
+using AliasRuntimeArrayBivariateMap = slam::RuntimeArrayBivariateMap<ConcreteProductSet, double>;
+using AliasRuntimeArrayViewBivariateMap =
+  slam::RuntimeArrayViewBivariateMap<ConcreteProductSet, double>;
+
+// Force full instantiation (also exercises axom::Array's element requirements).
+static_assert(sizeof(AliasArraySet) > 0, "ArraySet instantiates");
+static_assert(sizeof(AliasCustomArraySet) > 0, "custom-position ArraySet instantiates");
+static_assert(sizeof(AliasArrayViewSet) > 0, "ArrayViewSet instantiates");
+static_assert(sizeof(AliasVarRelation) > 0, "VariableRelation instantiates");
+static_assert(sizeof(AliasVarRelationView) > 0, "VariableRelationView instantiates");
+static_assert(sizeof(AliasConstRelation) > 0, "ConstantRelation instantiates");
+static_assert(sizeof(AliasConstRelationView) > 0, "ConstantRelationView instantiates");
+static_assert(sizeof(AliasRuntimeConstRelation) > 0, "RuntimeConstantRelation instantiates");
+static_assert(sizeof(AliasRuntimeConstRelationView) > 0, "RuntimeConstantRelationView instantiates");
+static_assert(sizeof(AliasArrayMap) > 0, "ArrayMap instantiates");
+static_assert(sizeof(AliasArrayViewMap) > 0, "ArrayViewMap instantiates");
+static_assert(sizeof(AliasRuntimeArrayMap) > 0, "RuntimeArrayMap instantiates");
+static_assert(sizeof(AliasRuntimeArrayViewMap) > 0, "RuntimeArrayViewMap instantiates");
+static_assert(sizeof(AliasArrayBivariateMap) > 0, "ArrayBivariateMap instantiates");
+static_assert(sizeof(AliasArrayViewBivariateMap) > 0, "ArrayViewBivariateMap instantiates");
+static_assert(sizeof(AliasRuntimeArrayBivariateMap) > 0, "RuntimeArrayBivariateMap instantiates");
+static_assert(sizeof(AliasRuntimeArrayViewBivariateMap) > 0,
+              "RuntimeArrayViewBivariateMap instantiates");
+
+// Check that the alias types match expectations
+static_assert(std::is_same_v<AliasArrayMap,
+                             slam::Map<double,
+                                       slam::RangeSet<>,
+                                       policies::ArrayIndirection<SetPos, double>,
+                                       policies::CompileTimeStride<SetPos, 3>>>,
+              "ArrayMap names the canonical Array-backed Map policy stack");
+static_assert(std::is_same_v<AliasArrayViewMap,
+                             slam::Map<double,
+                                       slam::RangeSet<>,
+                                       policies::ArrayViewIndirection<SetPos, double>,
+                                       policies::CompileTimeStride<SetPos, 3>>>,
+              "ArrayViewMap names the canonical ArrayView-backed Map policy stack");
+static_assert(
+  std::is_same_v<
+    AliasRuntimeArrayMap,
+    slam::Map<double, slam::RangeSet<>, policies::ArrayIndirection<SetPos, double>, policies::RuntimeStride<SetPos>>>,
+  "RuntimeArrayMap names the canonical Array-backed runtime-stride Map");
+static_assert(std::is_same_v<AliasRuntimeArrayViewMap,
+                             slam::Map<double,
+                                       slam::RangeSet<>,
+                                       policies::ArrayViewIndirection<SetPos, double>,
+                                       policies::RuntimeStride<SetPos>>>,
+              "RuntimeArrayViewMap names the canonical ArrayView-backed runtime-stride Map");
+static_assert(
+  std::is_same_v<
+    AliasArrayBivariateMap,
+    slam::BivariateMap<double,
+                       ConcreteProductSet,
+                       policies::ArrayIndirection<typename ConcreteProductSet::PositionType, double>,
+                       policies::CompileTimeStride<typename ConcreteProductSet::PositionType, 2>>>,
+  "ArrayBivariateMap names the canonical Array-backed BivariateMap policy stack");
+static_assert(
+  std::is_same_v<
+    AliasArrayViewBivariateMap,
+    slam::BivariateMap<double,
+                       ConcreteProductSet,
+                       policies::ArrayViewIndirection<typename ConcreteProductSet::PositionType, double>,
+                       policies::CompileTimeStride<typename ConcreteProductSet::PositionType, 2>>>,
+  "ArrayViewBivariateMap names the canonical ArrayView-backed BivariateMap policy stack");
+static_assert(
+  std::is_same_v<
+    AliasRuntimeArrayBivariateMap,
+    slam::BivariateMap<double,
+                       ConcreteProductSet,
+                       policies::ArrayIndirection<typename ConcreteProductSet::PositionType, double>,
+                       policies::RuntimeStride<typename ConcreteProductSet::PositionType>>>,
+  "RuntimeArrayBivariateMap names the canonical Array-backed "
+  "runtime-stride BivariateMap");
+static_assert(
+  std::is_same_v<
+    AliasRuntimeArrayViewBivariateMap,
+    slam::BivariateMap<double,
+                       ConcreteProductSet,
+                       policies::ArrayViewIndirection<typename ConcreteProductSet::PositionType, double>,
+                       policies::RuntimeStride<typename ConcreteProductSet::PositionType>>>,
+  "RuntimeArrayViewBivariateMap names the canonical ArrayView-backed "
+  "runtime-stride BivariateMap");
+
+// Check that the aliases match the expected concepts
+static_assert(slam::is_set_like_v<AliasArraySet>, "ArraySet is set-like");
+static_assert(std::is_same_v<AliasCustomArraySet, slam::ArrayIndirectionSet<SetPos, double>>,
+              "ArraySet preserves the normal <Position, Element> set template order");
+static_assert(slam::is_ordered_set_like_v<AliasArraySet>, "ArraySet is an ordered set");
+static_assert(slam::is_ordered_set_like_v<AliasArrayViewSet>, "ArrayViewSet is an ordered set");
+static_assert(slam::is_relation_like_v<AliasVarRelation>, "VariableRelation is relation-like");
+static_assert(slam::is_relation_like_v<AliasVarRelationView>,
+              "VariableRelationView is relation-like");
+static_assert(slam::is_relation_like_v<AliasConstRelation>, "ConstantRelation is relation-like");
+static_assert(slam::is_relation_like_v<AliasConstRelationView>,
+              "ConstantRelationView is relation-like");
+static_assert(slam::is_relation_like_v<AliasRuntimeConstRelation>,
+              "RuntimeConstantRelation is relation-like");
+static_assert(slam::is_relation_like_v<AliasRuntimeConstRelationView>,
+              "RuntimeConstantRelationView is relation-like");
+static_assert(slam::is_bivariate_set_like_v<ConcreteProductSet>,
+              "a ProductSet is bivariate-set-like");
+static_assert(slam::is_map_like_v<AliasArrayMap>, "ArrayMap is map-like");
+static_assert(slam::is_map_like_v<AliasArrayViewMap>, "ArrayViewMap is map-like");
+static_assert(slam::is_map_like_v<AliasRuntimeArrayMap>, "RuntimeArrayMap is map-like");
+static_assert(slam::is_map_like_v<AliasRuntimeArrayViewMap>, "RuntimeArrayViewMap is map-like");
+static_assert(slam::is_map_over_v<AliasArrayMap, slam::RangeSet<>>,
+              "ArrayMap is a map over its set");
+static_assert(slam::is_map_over_v<AliasArrayViewMap, slam::RangeSet<>>,
+              "ArrayViewMap is a map over its set");
+static_assert(slam::is_map_over_v<AliasRuntimeArrayMap, slam::RangeSet<>>,
+              "RuntimeArrayMap is a map over its set");
+static_assert(slam::is_map_over_v<AliasRuntimeArrayViewMap, slam::RangeSet<>>,
+              "RuntimeArrayViewMap is a map over its set");
+static_assert(slam::is_map_like_v<AliasArrayBivariateMap>, "ArrayBivariateMap is map-like");
+static_assert(slam::is_map_like_v<AliasArrayViewBivariateMap>, "ArrayViewBivariateMap is map-like");
+static_assert(slam::is_map_like_v<AliasRuntimeArrayBivariateMap>,
+              "RuntimeArrayBivariateMap is map-like");
+static_assert(slam::is_map_like_v<AliasRuntimeArrayViewBivariateMap>,
+              "RuntimeArrayViewBivariateMap is map-like");
+
+// Check that the aliases match the Array/ArrayView make_* helpers.
+using RSPos = slam::RangeSet<>::PositionType;
+static_assert(
+  std::is_same_v<AliasVarRelation,
+                 decltype(slam::make_variable_relation(std::declval<slam::RangeSet<>*>(),
+                                                       std::declval<slam::RangeSet<>*>(),
+                                                       std::declval<axom::Array<RSPos>&>(),
+                                                       std::declval<axom::Array<RSPos>&>()))>,
+  "VariableRelation matches make_variable_relation's axom::Array overload");
+static_assert(
+  std::is_same_v<AliasVarRelationView,
+                 decltype(slam::make_variable_relation(std::declval<slam::RangeSet<>*>(),
+                                                       std::declval<slam::RangeSet<>*>(),
+                                                       std::declval<axom::ArrayView<RSPos>>(),
+                                                       std::declval<axom::ArrayView<RSPos>>()))>,
+  "VariableRelationView matches make_variable_relation's ArrayView overload");
+static_assert(
+  std::is_same_v<AliasConstRelation,
+                 decltype(slam::make_constant_relation_ct<3>(std::declval<slam::RangeSet<>*>(),
+                                                             std::declval<slam::RangeSet<>*>(),
+                                                             std::declval<axom::Array<RSPos>&>()))>,
+  "ConstantRelation matches make_constant_relation_ct<N>'s axom::Array overload");
+static_assert(
+  std::is_same_v<AliasConstRelationView,
+                 decltype(slam::make_constant_relation_ct<3>(std::declval<slam::RangeSet<>*>(),
+                                                             std::declval<slam::RangeSet<>*>(),
+                                                             std::declval<axom::ArrayView<RSPos>>()))>,
+  "ConstantRelationView matches make_constant_relation_ct<N>'s ArrayView overload");
+static_assert(
+  std::is_same_v<AliasRuntimeConstRelation,
+                 decltype(slam::make_constant_relation(std::declval<slam::RangeSet<>*>(),
+                                                       std::declval<slam::RangeSet<>*>(),
+                                                       std::declval<RSPos>(),
+                                                       std::declval<axom::Array<RSPos>&>()))>,
+  "RuntimeConstantRelation matches make_constant_relation's axom::Array overload");
+static_assert(
+  std::is_same_v<AliasRuntimeConstRelationView,
+                 decltype(slam::make_constant_relation(std::declval<slam::RangeSet<>*>(),
+                                                       std::declval<slam::RangeSet<>*>(),
+                                                       std::declval<RSPos>(),
+                                                       std::declval<axom::ArrayView<RSPos>>()))>,
+  "RuntimeConstantRelationView matches make_constant_relation's ArrayView overload");
+static_assert(
+  std::is_same_v<AliasArrayViewSet,
+                 decltype(slam::make_indirection_set(std::declval<axom::ArrayView<RSPos>>()))>,
+  "ArrayViewSet matches make_indirection_set's ArrayView overload");
+static_assert(std::is_same_v<AliasArrayViewMap,
+                             decltype(slam::make_map_ct<3>(std::declval<const slam::RangeSet<>*>(),
+                                                           std::declval<axom::ArrayView<double>>()))>,
+              "ArrayViewMap matches make_map_ct<N>'s ArrayView overload");
+static_assert(std::is_same_v<AliasRuntimeArrayViewMap,
+                             decltype(slam::make_map(std::declval<const slam::RangeSet<>*>(),
+                                                     std::declval<RSPos>(),
+                                                     std::declval<axom::ArrayView<double>>()))>,
+              "RuntimeArrayViewMap matches make_map's runtime-stride ArrayView overload");
 
 }  // anonymous namespace
 

--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -68,10 +68,7 @@ public:
   using BinSet = slam::OrderedSet<IndexType, IndexType, SizePolicy>;
 
   using BitsetType = slam::BitSet;
-  using BinBitMap = slam::Map<BitsetType,
-                              slam::Set<IndexType, IndexType>,
-                              slam::policies::ArrayIndirection<IndexType, BitsetType>,
-                              slam::policies::StrideOne<IndexType>>;
+  using BinBitMap = slam::ArrayMap<slam::Set<IndexType, IndexType>, BitsetType>;
 
   struct QueryObject;
 
@@ -611,10 +608,7 @@ public:
   using LatticeType = RectangularLattice<NDIMS, double, IndexType>;
 
   using BitsetType = slam::BitSet;
-  using BinBitMap = slam::Map<BitsetType,
-                              slam::Set<IndexType, IndexType>,
-                              slam::policies::ArrayIndirection<IndexType, BitsetType>,
-                              slam::policies::StrideOne<IndexType>>;
+  using BinBitMap = slam::ArrayMap<slam::Set<IndexType, IndexType>, BitsetType>;
 
   QueryObject(const SpatialBoundingBox& spaceBb,
               const LatticeType& lattice,

--- a/src/axom/spin/ImplicitGrid.hpp
+++ b/src/axom/spin/ImplicitGrid.hpp
@@ -68,7 +68,7 @@ public:
   using BinSet = slam::OrderedSet<IndexType, IndexType, SizePolicy>;
 
   using BitsetType = slam::BitSet;
-  using BinBitMap = slam::ArrayMap<slam::Set<IndexType, IndexType>, BitsetType>;
+  using BinBitMap = slam::Map<BitsetType, slam::Set<IndexType, IndexType>>;
 
   struct QueryObject;
 
@@ -608,7 +608,7 @@ public:
   using LatticeType = RectangularLattice<NDIMS, double, IndexType>;
 
   using BitsetType = slam::BitSet;
-  using BinBitMap = slam::ArrayMap<slam::Set<IndexType, IndexType>, BitsetType>;
+  using BinBitMap = slam::Map<BitsetType, slam::Set<IndexType, IndexType>>;
 
   QueryObject(const SpatialBoundingBox& spaceBb,
               const LatticeType& lattice,

--- a/src/axom/spin/OctreeBase.hpp
+++ b/src/axom/spin/OctreeBase.hpp
@@ -132,7 +132,7 @@ public:
   using OctreeLevels = slam::OrderedSet<CoordType, CoordType, MAX_LEVEL_SIZE>;
 
   using OctreeLevelType = OctreeLevel<DIM, BlockDataType>;
-  using LeafIndicesLevelMap = slam::ArrayMap<OctreeLevels, OctreeLevelType*>;
+  using LeafIndicesLevelMap = slam::Map<OctreeLevelType*, OctreeLevels>;
 
   /**
    * \brief Inner class encapsulating the index of an octree <em>block</em>.

--- a/src/axom/spin/OctreeBase.hpp
+++ b/src/axom/spin/OctreeBase.hpp
@@ -132,7 +132,7 @@ public:
   using OctreeLevels = slam::OrderedSet<CoordType, CoordType, MAX_LEVEL_SIZE>;
 
   using OctreeLevelType = OctreeLevel<DIM, BlockDataType>;
-  using LeafIndicesLevelMap = slam::Map<OctreeLevelType*>;
+  using LeafIndicesLevelMap = slam::ArrayMap<OctreeLevels, OctreeLevelType*>;
 
   /**
    * \brief Inner class encapsulating the index of an octree <em>block</em>.

--- a/src/axom/spin/SpatialOctree.hpp
+++ b/src/axom/spin/SpatialOctree.hpp
@@ -37,7 +37,7 @@ public:
   using BlockIndex = typename BaseOctree::BlockIndex;
   using OctreeLevels = typename BaseOctree::OctreeLevels;
 
-  using SpaceVectorLevelMap = slam::ArrayMap<OctreeLevels, SpaceVector>;
+  using SpaceVectorLevelMap = slam::Map<SpaceVector, OctreeLevels>;
 
 public:
   /**

--- a/src/axom/spin/SpatialOctree.hpp
+++ b/src/axom/spin/SpatialOctree.hpp
@@ -35,8 +35,9 @@ public:
   using CoordType = typename GridPt::CoordType;
 
   using BlockIndex = typename BaseOctree::BlockIndex;
+  using OctreeLevels = typename BaseOctree::OctreeLevels;
 
-  using SpaceVectorLevelMap = slam::Map<SpaceVector>;
+  using SpaceVectorLevelMap = slam::ArrayMap<OctreeLevels, SpaceVector>;
 
 public:
   /**


### PR DESCRIPTION
# Summary

- This PR is a follow-up to #1892 and continues to modernize slam in preparation for C++20
- It adds traits classes to slam -- ``is_set_like``, ``is_relation_like`` and ``is_map_like`` -- which will map to concepts
- It makes `StaticRelation` and `VariableRelation` trivially copyable by inheriting from `ConcreteInterface` instead of `VirtualInterface`
- It makes `axom::Array` and `axom::ArrayView` the default backing buffer type for slam's sets, relations and maps. The default was previously `std::vector`, so this might require some minor changes from users. The `std::vector` backing is still available through an explicit `STLVectorIndirection`  policy
- It adds alias types for common set and relation configurations. This greatly simplifies the setup for common cases. I have updated many examples and usages of slam throughout Axom to this type
- This branch contains lots of documentation updates, and reworks the basic example in the user docs (`UserDocs.cpp`)