### PR TITLE
Add warnings as errors to Gitlab CI

### DIFF
--- a/.gitlab/build_dane.yml
+++ b/.gitlab/build_dane.yml
@@ -37,10 +37,11 @@
 
 ####
 # PR Build jobs
-dane-llvm_19_1_3-debug-src:
+dane-llvm_19_1_3-werror-debug-src:
   variables:
     COMPILER: "llvm@19.1.3"
     HOST_CONFIG: "dane-toss_4_x86_64_ib-${COMPILER}.cmake"
+    EXTRA_CMAKE_OPTIONS: "-DENABLE_WARNINGS_AS_ERRORS:BOOL=ON"
   extends: .src_build_on_dane
 
 dane-llvm_19_1_3-release-src:
@@ -51,10 +52,11 @@ dane-llvm_19_1_3-release-src:
     EXTRA_CMAKE_OPTIONS: "-DAXOM_QUEST_ENABLE_EXTRA_REGRESSION_TESTS:BOOL=ON"
   extends: .src_build_on_dane
 
-dane-gcc_13_3_1-src:
+dane-gcc_13_3_1-werror-src:
   variables:
     COMPILER: "gcc@13.3.1"
     HOST_CONFIG: "dane-toss_4_x86_64_ib-${COMPILER}.cmake"
+    EXTRA_CMAKE_OPTIONS: "-DENABLE_WARNINGS_AS_ERRORS:BOOL=ON"
   extends: .src_build_on_dane
 
 dane-sanitizers-gcc_13_3_1-src:


### PR DESCRIPTION
This PR:
- Turns on `ENABLE_WARNINGS_AS_ERRORS` (adds `-Werror` on the backend) for debug gcc & clang jobs on dane in Gitlab CI. 
  - You can double-check the flag was added by viewing the raw job logs for `-Werror` 

Closes #1688 