### PR TITLE
Adds efficient point containment predicate to primal::Sphere

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -47,6 +47,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Sidre: Added `axom::sidre::View::checksum()` and `axom::sidre::Group::checksum()` methods that return checksum values. A `Group::checksum(conduit::Node&)` overload emits diffable checksum metadata for group/view subtrees.
 - Core: Adds `AXOM_CONSTEXPR_ASSERT` macro for assertions that are usable within `constexpr` contexts
 - Slam: Adds `make_*_set`, `make_*_relation` and `make_map` helper functions for building sets, relations and maps
+- Primal: Adds `primal::Sphere::contains(const Point&, bool includeBoundary = true)` to efficiently test whether
+  a point lies within a sphere. Use `getOrientation()` when a tolerance-aware boundary classification is needed.
 
 ### Removed
 - Bump: Removed `axom::bump::views::MultiBufferMaterialView`, which was a view type for an obsolete flavor of Blueprint matset.
@@ -72,6 +74,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Core: Avoids a first-use race in `axom::copy()` when multiple OpenMP threads concurrently trigger Umpire fallback host-copy initialization.
 - Python: Improves lifetime handling for python wrapped sidre entities, including support for external views into numpy arrays.
 - Sidre: Vector-valued MFEM `QuadratureFunction` fields exported through `MFEMSidreDataCollection` now use Blueprint mcarray component storage under `values`, instead of a single scalar array.
+- Primal: Fixes `primal::Sphere<T,2>::getVolume()`, which was previously hard-coded for volume of 3D sphere
 
 ## [Version 0.14.0] - Release date 2026-03-31
 

--- a/src/axom/primal/geometry/NURBSPatch.hpp
+++ b/src/axom/primal/geometry/NURBSPatch.hpp
@@ -4206,10 +4206,8 @@ public:
 
     for(const auto& curve : split_trimming_curves)
     {
-      auto curve_midpoint = curve.evaluate(0.5 * (curve.getMinKnot() + curve.getMaxKnot()));
-      bool isInDisk = circle_obj.computeSignedDistance(curve_midpoint) < 0;
-
-      if(isInDisk)
+      // if (parametric) curve midpoint is in the circle add it to the_disk, otherwise, add it to the_rest
+      if(circle_obj.contains(curve.evaluate(0.5 * (curve.getMinKnot() + curve.getMaxKnot())), false))
       {
         the_disk.addTrimmingCurve(curve);
       }

--- a/src/axom/primal/geometry/Sphere.hpp
+++ b/src/axom/primal/geometry/Sphere.hpp
@@ -113,11 +113,19 @@ public:
   AXOM_HOST_DEVICE
   inline const PointType& getCenter() const { return m_center; };
 
-  /*!
-   * \brief Returns the volume of the Sphere.
-   */
+  /// \brief Returns the n-dimensional volume enclosed by the Sphere.
   AXOM_HOST_DEVICE
-  inline T getVolume() const { return 4.0 / 3 * M_PI * m_radius * m_radius * m_radius; };
+  inline T getVolume() const
+  {
+    if constexpr(NDIMS == 2)
+    {
+      return M_PI * m_radius * m_radius;
+    }
+    else
+    {
+      return 4. / 3. * M_PI * m_radius * m_radius * m_radius;
+    }
+  }
 
   /*!
    * \brief Computes the signed distance of a point to the Sphere's boundary.

--- a/src/axom/primal/geometry/Sphere.hpp
+++ b/src/axom/primal/geometry/Sphere.hpp
@@ -168,6 +168,27 @@ public:
   }
 
   /*!
+   * \brief Tests if a point lies inside this sphere.
+   *
+   * \param [in] q The test point
+   * \param [in] includeBoundary should points on the boundary count as contained? (default true)
+   * \return true if \a q lies inside (and possibly on) the sphere, false otherwise.
+   *
+   * \note This is an exact-arithmetic-free containment test.
+   *  When a tolerance-aware answer is required (for example, to treat points within
+   *  \a EPS of the surface as lying on the boundary), use getOrientation(),
+   *  which returns primal::ON_BOUNDARY within the supplied tolerance, or compare
+   *  the result of computeSignedDistance() against your own scale-aware tolerance.
+   */
+  AXOM_HOST_DEVICE
+  inline bool contains(const PointType& q, bool includeBoundary = true) const
+  {
+    const T dist_sq = (q - m_center).squared_norm();
+    const T radius_sq = m_radius * m_radius;
+    return includeBoundary ? (dist_sq <= radius_sq) : (dist_sq < radius_sq);
+  }
+
+  /*!
    * \brief Tests if this sphere instance intersects with another sphere.
    *
    * \param [in] sphere the sphere object to check for intersection

--- a/src/axom/primal/tests/primal_sphere.cpp
+++ b/src/axom/primal/tests/primal_sphere.cpp
@@ -64,6 +64,26 @@ void check_constructor()
 
 //------------------------------------------------------------------------------
 template <int NDIMS>
+void check_volume()
+{
+  using SphereType = primal::Sphere<double, NDIMS>;
+  using PointType = primal::Point<double, NDIMS>;
+
+  constexpr double radius = 2.5;
+  const SphereType sphere1(PointType::zero(), radius);
+  const SphereType sphere2(PointType {3., 4., 0.}, radius);
+
+  // 2D "volume" is the enclosed area (pi r^2); 3D is (4/3) pi r^3.
+  constexpr double expected =
+    (NDIMS == 2) ? M_PI * radius * radius : 4. / 3. * M_PI * radius * radius * radius;
+
+  EXPECT_DOUBLE_EQ(sphere1.getVolume(), expected);
+  EXPECT_DOUBLE_EQ(sphere2.getVolume(), expected);
+  EXPECT_DOUBLE_EQ(sphere1.getVolume(), sphere2.getVolume());
+}
+
+//------------------------------------------------------------------------------
+template <int NDIMS>
 void check_signed_distance_and_orientation()
 {
   using PointType = primal::Point<double, NDIMS>;
@@ -334,6 +354,13 @@ TEST(primal_sphere, constructor)
 {
   check_constructor<2>();
   check_constructor<3>();
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_sphere, volume)
+{
+  check_volume<2>();
+  check_volume<3>();
 }
 
 //------------------------------------------------------------------------------

--- a/src/axom/primal/tests/primal_sphere.cpp
+++ b/src/axom/primal/tests/primal_sphere.cpp
@@ -7,6 +7,8 @@
 #include "axom/primal/geometry/Sphere.hpp"
 #include "axom/primal/geometry/Point.hpp"
 
+#include "axom/core/utilities/Utilities.hpp"
+
 #include "axom/slic.hpp"
 #include "gtest/gtest.h"
 
@@ -181,6 +183,95 @@ void check_sphere_containment()
 
 //------------------------------------------------------------------------------
 template <int NDIMS>
+void check_point_containment()
+{
+  using PointType = primal::Point<double, NDIMS>;
+  using SphereType = primal::Sphere<double, NDIMS>;
+
+  // An off-origin sphere so the test is not accidentally centered.
+  PointType center {3.0, 4.0, 0.0};
+  const double radius = 5.0;
+  SphereType sphere(center, radius);
+
+  // --- Analytic checks: known inside / boundary / outside points ---------
+
+  // Center is strictly inside.
+  EXPECT_TRUE(sphere.contains(center));
+
+  for(int j = 0; j < NDIMS; ++j)
+  {
+    // Strictly inside (half a radius out along axis j): flag-independent.
+    PointType inside = center;
+    inside[j] = center[j] + 0.5 * radius;
+    EXPECT_TRUE(sphere.contains(inside, true));
+    EXPECT_TRUE(sphere.contains(inside, false));
+
+    // Exactly on the boundary.
+    //  An axis-aligned offset of exactly `radius` is representable exactly in floating point
+    PointType on_pos = center;
+    on_pos[j] = center[j] + radius;
+    EXPECT_TRUE(sphere.contains(on_pos, true));
+    EXPECT_FALSE(sphere.contains(on_pos, false));
+    EXPECT_TRUE(sphere.contains(on_pos));  // default == closed ball
+
+    PointType on_neg = center;
+    on_neg[j] = center[j] - radius;
+    EXPECT_TRUE(sphere.contains(on_neg, true));
+    EXPECT_FALSE(sphere.contains(on_neg, false));
+    EXPECT_TRUE(sphere.contains(on_neg));
+
+    // Strictly outside (two radii out along axis j): flag-independent.
+    PointType outside = center;
+    outside[j] = center[j] + 2. * radius;
+    EXPECT_FALSE(sphere.contains(outside, true));
+    EXPECT_FALSE(sphere.contains(outside, false));
+  }
+
+  // --- Agreement with computeSignedDistance() and getOrientation() -------
+  // contains() must agree with the sign of the (sqrt-based) signed distance
+  // and with getOrientation() everywhere except within the provided boundary tolerance
+  constexpr double tol = 1e-12;
+  constexpr double lo = -4.;
+  constexpr double hi = 12.;
+  constexpr double step = 0.37;  // deliberately not aligned to the radius
+
+  int comparisons = 0;
+  PointType q {};
+  for(double x = lo; x <= hi; x += step)
+  {
+    q[0] = x;
+    for(double y = lo; y <= hi; y += step)
+    {
+      q[1] = y;
+
+      const double signed_distance = sphere.computeSignedDistance(q);
+
+      // skip points within tolerance of boundary due to possible rounding diffs
+      if(axom::utilities::isNearlyEqual(signed_distance, 0.0, tol))
+      {
+        continue;
+      }
+
+      const int orientation = sphere.getOrientation(q, tol);
+
+      const bool contained_closed = sphere.contains(q, true);
+      EXPECT_EQ(contained_closed, (signed_distance <= 0.0));
+      EXPECT_EQ(contained_closed, (orientation != primal::ON_POSITIVE_SIDE));
+
+      const bool contained_open = sphere.contains(q, false);
+      EXPECT_EQ(contained_open, (signed_distance < 0.0));
+      EXPECT_EQ(contained_open, (orientation == primal::ON_NEGATIVE_SIDE));
+
+      ++comparisons;
+    }
+  }
+
+  // Guard against a degenerate loop silently exercising nothing.
+  EXPECT_GT(comparisons, 0);
+}
+
+//------------------------------------------------------------------------------
+template <int NDIMS>
 void check_copy_constructor()
 {
   using PointType = primal::Point<double, NDIMS>;
@@ -278,6 +369,13 @@ TEST(primal_sphere, sphere_sphere_containment)
 {
   check_sphere_containment<2>();
   check_sphere_containment<3>();
+}
+
+//------------------------------------------------------------------------------
+TEST(primal_sphere, sphere_point_containment)
+{
+  check_point_containment<2>();
+  check_point_containment<3>();
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

- This PR is a feature with a bonus bugfix
- It adds an efficient point containment predicate `primal::Sphere::contains(Point, includedBoundary)`, which avoids the unnecessary sqrt call from `Sphere::computeSignedDistance()` and `Sphere::getOrientation()`
  - It uses this function within a function in NURBSPatch that was using the (less efficient) `computeSignedDistance()` to test for containment
- Bonus bugfix: `Sphere<T,DIM>::getVolume()` was hard-coded for the 3D volume.
  - This PR fixes this with the appropriate 2D and 3D volume.

- Resolves https://github.com/llnl/axom/issues/1815
