### PR TITLE
Adds const overloads to data access functions in sidre::View and sidre::Buffer

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -75,6 +75,10 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Python: Improves lifetime handling for python wrapped sidre entities, including support for external views into numpy arrays.
 - Sidre: Vector-valued MFEM `QuadratureFunction` fields exported through `MFEMSidreDataCollection` now use Blueprint mcarray component storage under `values`, instead of a single scalar array.
 - Primal: Fixes `primal::Sphere<T,2>::getVolume()`, which was previously hard-coded for volume of 3D sphere
+- Sidre: Adds a `const` overload of the templated `axom::sidre::View::getData<T>()`,
+and marked the templated `axom::sidre::View::getAttributeScalar<T>()` overloads `const`
+so they can be called on a `const View`. Also added  `const` overloads for `axom::sidre::Buffer::getData()`
+and `axom::sidre::Buffer::getVoidPtr()` so they can be called on a `const Buffer`.
 
 ## [Version 0.14.0] - Release date 2026-03-31
 

--- a/src/axom/sidre/core/Buffer.hpp
+++ b/src/axom/sidre/core/Buffer.hpp
@@ -93,7 +93,18 @@ public:
   /*!
    * \brief Return void-pointer to data held by Buffer.
    */
+  /// @{
   void* getVoidPtr() { return m_node.data_ptr(); }
+
+  /*!
+   * \overload
+   *
+   * \note A const Buffer still exposes its data as a mutable pointer:
+   *  const-ness refers to the Buffer's description, not to the data it holds.
+   * \sa View::getVoidPtr()
+   */
+  void* getVoidPtr() const { return const_cast<Node&>(m_node).data_ptr(); }
+  /// @}
 
   /*!
    * \brief Return data held by Buffer (return type is type caller assigns
@@ -102,6 +113,7 @@ public:
    *        Note that if Buffer is not allocated, an empty Conduit
    *        Node::Value is returned.
    */
+  /// @{
   Node::Value getData()
   {
     if(!isAllocated())
@@ -112,6 +124,25 @@ public:
 
     return m_node.value();
   }
+
+  /*!
+   * \overload
+   *
+   * \note A const Buffer exposes its data as a mutable Node::Value
+   *  const-ness refers to the Buffer's description, not its data.
+   * \sa View::getdata() const
+   */
+  Node::Value getData() const
+  {
+    if(!isAllocated())
+    {
+      SLIC_CHECK_MSG(isAllocated(), "Buffer data is not allocated.");
+      return Node().value();
+    }
+
+    return const_cast<Node&>(m_node).value();
+  }
+  /// @}
 
   /*!
    * \brief Return type of data owned by this Buffer object.

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -921,7 +921,7 @@ public:
     SLIC_CHECK_MSG(
       isAllocated(),
       SIDRE_VIEW_LOG_PREPEND << "No view data present, memory has not been allocated.");
-    SLIC_CHECK_MSG(isDescribed(), SIDRE_VIEW_LOG_PREPEND "View data description not present.");
+    SLIC_CHECK_MSG(isDescribed(), SIDRE_VIEW_LOG_PREPEND << "View data description not present.");
 
     // this will return a default value
     return m_node.value();

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -1251,14 +1251,13 @@ public:
   }
 
   /*!
-   * \brief Lightweight templated wrapper around getAttributeScalar()
-   *  that can be used when you are calling getAttributeScalar(), but not
-   *  assigning the return type.
+   * \brief Lightweight templated wrapper around getAttributeScalar() that can be used
+   *  when you are calling getAttributeScalar(), but not assigning the return type.
    *
    * \sa getAttributeScalar()
    */
   template <typename DataType>
-  DataType getAttributeScalar(IndexType idx)
+  DataType getAttributeScalar(IndexType idx) const
   {
     const Attribute* attr = getAttribute(idx);
     const Node& node = m_attr_values.getValueNodeRef(attr);
@@ -1267,14 +1266,13 @@ public:
   }
 
   /*!
-   * \brief Lightweight templated wrapper around getAttributeScalar()
-   *  that can be used when you are calling getAttributeScalar(), but not
-   *  assigning the return type.
+   * \brief Lightweight templated wrapper around getAttributeScalar() that can be used
+   *  when you are calling getAttributeScalar(), but not assigning the return type.
    *
    * \sa getAttributeScalar()
    */
   template <typename DataType>
-  DataType getAttributeScalar(const std::string& name)
+  DataType getAttributeScalar(const std::string& name) const
   {
     const Attribute* attr = getAttribute(name);
     const Node& node = m_attr_values.getValueNodeRef(attr);
@@ -1283,14 +1281,13 @@ public:
   }
 
   /*!
-   * \brief Lightweight templated wrapper around getAttributeScalar()
-   *  that can be used when you are calling getAttributeScalar(), but not
-   *  assigning the return type.
+   * \brief Lightweight templated wrapper around getAttributeScalar() that can be used
+   *  when you are calling getAttributeScalar(), but not assigning the return type.
    *
    * \sa getAttributeScalar()
    */
   template <typename DataType>
-  DataType getAttributeScalar(const Attribute* attr)
+  DataType getAttributeScalar(const Attribute* attr) const
   {
     SLIC_CHECK_MSG(attr != nullptr,
                    SIDRE_VIEW_LOG_PREPEND << "getAttributeScalar: called with a null Attribute");

--- a/src/axom/sidre/core/View.hpp
+++ b/src/axom/sidre/core/View.hpp
@@ -934,12 +934,26 @@ public:
    *
    * \sa getData()
    */
+  /// @{
   template <typename DataType>
   DataType getData()
   {
     DataType data = m_node.value();
     return data;
   }
+
+  /*!
+   * \overload
+   */
+  template <typename DataType>
+  DataType getData() const
+  {
+    // Mirror getVoidPtr() const: the View is logically const
+    // (its description is not modified) but the data it references remains mutable.
+    DataType data = const_cast<Node&>(m_node).value();
+    return data;
+  }
+  /// @}
 
   /*!
    * \brief Returns a void pointer to the view's data

--- a/src/axom/sidre/nanobind_sidre.cpp
+++ b/src/axom/sidre/nanobind_sidre.cpp
@@ -982,14 +982,16 @@ NB_MODULE(pysidre, m_sidre)
          "Return the string contained in the View.")
     .def("getDataArray", &viewToNumpyArray, "Return the data held by the View as a numpy array.")
 
-    .def("getDataInt",
-         &View::getData<int>,
-         nb::rv_policy::reference,
-         "Return the scalar data held by the View as an python int type.")
-    .def("getDataFloat",
-         &View::getData<double>,
-         nb::rv_policy::reference,
-         "Return the data held by the View as a python float type (C++ double).")
+    .def(
+      "getDataInt",
+      [](View& self) { return self.getData<int>(); },
+      nb::rv_policy::reference,
+      "Return the scalar data held by the View as an python int type.")
+    .def(
+      "getDataFloat",
+      [](View& self) { return self.getData<double>(); },
+      nb::rv_policy::reference,
+      "Return the data held by the View as a python float type (C++ double).")
     .def("print",
          nb::overload_cast<>(&View::print, nb::const_),
          "Print JSON description of the View.")

--- a/src/axom/sidre/tests/sidre_attribute.cpp
+++ b/src/axom/sidre/tests/sidre_attribute.cpp
@@ -553,6 +553,14 @@ TEST(sidre_attribute, overloads)
   EXPECT_EQ(g_dump_yes, view->getAttributeScalar<int>(idump));
   EXPECT_EQ(g_dump_yes, view->getAttributeScalar<int>(g_name_dump));
 
+  // The templated getAttributeScalar<T>() must also be callable on a const View
+  {
+    const View& constView = *view;
+    EXPECT_EQ(g_dump_yes, constView.getAttributeScalar<int>(attr_dump));
+    EXPECT_EQ(g_dump_yes, constView.getAttributeScalar<int>(idump));
+    EXPECT_EQ(g_dump_yes, constView.getAttributeScalar<int>(g_name_dump));
+  }
+
   const Node& node1 = view->getAttributeNodeRef(attr_dump);
   EXPECT_EQ(g_dump_yes, node1.as_int());
   const Node& node2 = view->getAttributeNodeRef(idump);

--- a/src/axom/sidre/tests/sidre_buffer.cpp
+++ b/src/axom/sidre/tests/sidre_buffer.cpp
@@ -119,6 +119,39 @@ TEST(sidre_buffer, alloc_buffer_for_int_array)
 }
 
 //------------------------------------------------------------------------------
+// Regression test (companion to https://github.com/LLNL/axom/issues/1695):
+// Buffer::getData() and Buffer::getVoidPtr() must be callable on a const Buffer,
+// e.g. one obtained through View::getBuffer() const.
+TEST(sidre_buffer, const_get_data)
+{
+  DataStore ds;
+
+  Buffer* dbuff = ds.createBuffer();
+  dbuff->allocate(INT_ID, 10);
+
+  int* data_ptr = dbuff->getData();
+  for(int i = 0; i < 10; i++)
+  {
+    data_ptr[i] = i * i;
+  }
+
+  // Access through a const reference
+  const Buffer& constBuff = *dbuff;
+
+  void* vptr = constBuff.getVoidPtr();
+  EXPECT_EQ(data_ptr, static_cast<int*>(vptr));
+
+  int* const_access = constBuff.getData();
+  ASSERT_NE(nullptr, const_access);
+  for(int i = 0; i < 10; i++)
+  {
+    EXPECT_EQ(i * i, const_access[i]);
+  }
+
+  dbuff->deallocate();
+}
+
+//------------------------------------------------------------------------------
 
 TEST(sidre_buffer, init_buffer_for_int_array)
 {

--- a/src/axom/sidre/tests/sidre_view.cpp
+++ b/src/axom/sidre/tests/sidre_view.cpp
@@ -374,6 +374,43 @@ TEST(sidre_view, scalar_view)
 }
 
 //------------------------------------------------------------------------------
+// Regression test for https://github.com/LLNL/axom/issues/1695
+// The templated View::getData<T>() must be callable through a const View.
+TEST(sidre_view, const_get_data)
+{
+  constexpr int num_elts = 4;
+
+  DataStore ds;
+  Group* root = ds.getRoot();
+
+  // A scalar view and an array view to cover both value and pointer DataTypes.
+  {
+    root->createViewScalar("i0", 42);
+
+    View* arrView = root->createViewAndAllocate("arr", INT_ID, num_elts);
+    int* arrData = arrView->getData<int*>();
+    for(int i = 0; i < num_elts; ++i)
+    {
+      arrData[i] = 10 * i;
+    }
+  }
+
+  // Access the same views through a const reference
+  {
+    const View& constScalarView = *root->getView("i0");
+    EXPECT_EQ(42, constScalarView.getData<int>());
+
+    const View& constArrView = *root->getView("arr");
+    int* constAccessData = constArrView.getData<int*>();
+    ASSERT_NE(nullptr, constAccessData);
+    for(int i = 0; i < num_elts; ++i)
+    {
+      EXPECT_EQ(10 * i, constAccessData[i]);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
 
 TEST(sidre_view, io_state_string_compatibility)
 {


### PR DESCRIPTION
# Summary

- This PR addresses const-correctness issues in `sidre::View` and `sidre::Buffer` allowing usage from a `const View` or `const Buffer`
  - It adds `const` overloads to `sidre::View::getData()`  (and fixes Python bindings)
  - It marks `sidre::View::getAttributeScalar()` as const
  - It adds `const` overloads to `sidre::Buffer::getData()` and `sidre::Buffer::getVoidPtr()`
  - The const overloads all use `const_cast` (as did `View::getVoidPtr()`) since the const is on the container (`View` or `Buffer`) not on the wrapped data.
- Resolves #1695 