### PR TITLE
Change to snprintf 

### DIFF
--- a/src/axom/sidre/examples/sidre_shocktube.cpp
+++ b/src/axom/sidre/examples/sidre_shocktube.cpp
@@ -476,21 +476,23 @@ void UpdateElemInfo(Group* const prob)
 void DumpUltra(Group* const prob)
 {
 #if 1
+  constexpr int fname_size = 100;
   FILE* fp;
-  char fname[100];
+  char fname[fname_size];
   char* tail;
 
   //   VHashTraverse_t content ;
 
-  strcpy(fname, "problem");
+  snprintf(fname, fname_size, "problem");
 
+  int fname_rem = fname_size;
   /* Skip past the junk */
   for(tail = fname; isalpha(*tail); ++tail)
   {
-    ;
+    fname_rem--;
   }
 
-  sprintf(tail, "_%04d.ult", prob->getView("cycle")->getData<int>());
+  snprintf(tail, fname_rem, "_%04d.ult", prob->getView("cycle")->getData<int>());
 
   if((fp = fopen(fname, "w")) == nullptr)
   {

--- a/src/axom/slam/examples/lulesh2.0.3/lulesh-util.cpp
+++ b/src/axom/slam/examples/lulesh2.0.3/lulesh-util.cpp
@@ -203,9 +203,10 @@ namespace slamLulesh {
 #endif
         }
         else {
-          char msg[80];
+          constexpr int msg_size = 80;
+          char msg[msg_size];
           PrintCommandLineOptions(argv[0], myRank);
-          sprintf(msg, "ERROR: Unknown command line argument: %s\n", argv[i]);
+          snprintf(msg, msg_size, "ERROR: Unknown command line argument: %s\n", argv[i]);
           ParseError(msg, myRank);
         }
       }

--- a/src/axom/slam/examples/lulesh2.0.3/lulesh-viz.cpp
+++ b/src/axom/slam/examples/lulesh2.0.3/lulesh-viz.cpp
@@ -62,13 +62,14 @@ namespace slamLulesh {
 /**********************************************************************/
   void DumpToVisit(Domain& domain, int numFiles, int myRank, int numRanks)
   {
-    char subdirName[32];
-    char basename[32];
+    constexpr int buff_size = 32;
+ 
+    char subdirName[buff_size];
+    char basename[buff_size];
     DBfile *db;
 
-
-    sprintf(basename,   "lulesh_plot_c%d",  domain.cycle());
-    sprintf(subdirName, "data_%d",          myRank);
+    snprintf(basename, buff_size,  "lulesh_plot_c%d",  domain.cycle());
+    snprintf(subdirName, buff_size, "data_%d",          myRank);
 
 #ifdef AXOM_USE_MPI
 
@@ -83,12 +84,13 @@ namespace slamLulesh {
 
     int myiorank = PMPIO_GroupRank(bat, myRank);
 
-    char fileName[64];
+    constexpr int fileName_size = 64;
+    char fileName[fileName_size];
 
     if (myiorank == 0)
-      strcpy(fileName, basename);
+      snprintf(fileName, fileName_size, basename);
     else
-      sprintf(fileName, "%s.%03d", basename, myiorank);
+      snprintf(fileName, fileName_size, "%s.%03d", basename, myiorank);
 
     db = (DBfile*)PMPIO_WaitForBaton(bat, fileName, subdirName);
 


### PR DESCRIPTION
# Summary

- This PR changes calls to `strcpy` and `sprintf` to `snprintf` in code locations reported to cause compiler warnings.
- Note that we still use `sprintf` inside `axom::fmt`. I did not change those.

Resolves https://github.com/llnl/axom/issues/1612
