### PR TITLE
Adds lua support to Klee

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -53,6 +53,8 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 - Python: Adds the `AXOM_PYTHON_MODULE_INSTALL_PREFIX` CMake variable to control where Axom installs its Python
   package(s), relative to the install prefix.
 - Quest: The C2CReader was enhanced to provide assembly support.
+- Core: Adds `utilities::filesystem::getFileExtension(str)`
+- Klee: Adds support for lua-based input decks for shaping
 
 ### Removed
 - Bump: Removed `axom::bump::views::MultiBufferMaterialView`, which was a view type for an obsolete flavor of Blueprint matset.

--- a/src/axom/core/tests/utils_fileUtilities.hpp
+++ b/src/axom/core/tests/utils_fileUtilities.hpp
@@ -105,9 +105,9 @@ TEST(utils_fileUtilities, getFileExtension)
     {R"(directory.with.dot\file.lua)", ".lua"},
     {R"(C:\directory\FILE.YML)", ".YML"}};
 
-  for(const auto& testCase : testCases)
+  for(const auto& [path, expected_ext] : testCases)
   {
-    EXPECT_EQ(testCase.second, fs::getFileExtension(testCase.first)) << testCase.first;
+    EXPECT_EQ(expected_ext, fs::getFileExtension(path)) << path;
   }
 }
 

--- a/src/axom/core/tests/utils_fileUtilities.hpp
+++ b/src/axom/core/tests/utils_fileUtilities.hpp
@@ -86,6 +86,31 @@ TEST(utils_fileUtilities, joinPath)
   }
 }
 
+TEST(utils_fileUtilities, getFileExtension)
+{
+  const std::pair<const char*, const char*> testCases[] = {
+    {"", ""},
+    {"file", ""},
+    {"file.txt", ".txt"},
+    {"file.tar.gz", ".gz"},
+    {"file.", "."},
+    {".gitignore", ""},
+    {".config.json", ".json"},
+    {".", ""},
+    {"..", ""},
+    {"directory/", ""},
+    {"directory.with.dot/file", ""},
+    {"directory.with.dot/file.yaml", ".yaml"},
+    {R"(directory.with.dot\file)", ""},
+    {R"(directory.with.dot\file.lua)", ".lua"},
+    {R"(C:\directory\FILE.YML)", ".YML"}};
+
+  for(const auto& testCase : testCases)
+  {
+    EXPECT_EQ(testCase.second, fs::getFileExtension(testCase.first)) << testCase.first;
+  }
+}
+
 TEST(utils_fileUtilities, pathExists)
 {
   std::cout << "Testing pathExists() function" << std::endl;

--- a/src/axom/core/utilities/FileUtilities.cpp
+++ b/src/axom/core/utilities/FileUtilities.cpp
@@ -88,6 +88,21 @@ std::string joinPath(const std::string& fileDir,
 }
 
 //-----------------------------------------------------------------------------
+std::string getFileExtension(const std::string& path)
+{
+  const auto separator = path.find_last_of("/\\");
+  const auto filename = path.substr(separator == std::string::npos ? 0 : separator + 1);
+
+  if(filename.empty() || filename == "." || filename == "..")
+  {
+    return "";
+  }
+
+  const auto dot = filename.find_last_of('.');
+  return dot == std::string::npos || dot == 0 ? "" : filename.substr(dot);
+}
+
+//-----------------------------------------------------------------------------
 int makeDirsForPath(const std::string& path)
 {
   char separator = '/';

--- a/src/axom/core/utilities/FileUtilities.cpp
+++ b/src/axom/core/utilities/FileUtilities.cpp
@@ -8,6 +8,7 @@
 #include "axom/core/utilities/StringUtilities.hpp"
 #include "axom/fmt.hpp"
 
+#include <filesystem>
 #include <vector>
 #include <string>
 #include <fstream>
@@ -90,16 +91,13 @@ std::string joinPath(const std::string& fileDir,
 //-----------------------------------------------------------------------------
 std::string getFileExtension(const std::string& path)
 {
-  const auto separator = path.find_last_of("/\\");
-  const auto filename = path.substr(separator == std::string::npos ? 0 : separator + 1);
-
-  if(filename.empty() || filename == "." || filename == "..")
-  {
-    return "";
-  }
-
-  const auto dot = filename.find_last_of('.');
-  return dot == std::string::npos || dot == 0 ? "" : filename.substr(dot);
+#if defined(WIN32)
+  return std::filesystem::path(path).extension().string();
+#else
+  std::string native_path = path;
+  std::replace(native_path.begin(), native_path.end(), '\\', '/');
+  return std::filesystem::path(native_path).extension().string();
+#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/src/axom/core/utilities/FileUtilities.hpp
+++ b/src/axom/core/utilities/FileUtilities.hpp
@@ -58,6 +58,20 @@ std::string joinPath(const std::string& fileDir,
                      const std::string& separator = "/");
 
 /*!
+ * \brief Gets the extension from the final component of a filesystem path.
+ *
+ * \param [in] path an absolute or relative filesystem path
+ *
+ * \return the extension, including its leading period, or an empty string when
+ * the path has no extension
+ *
+ * The returned extension preserves its original case. Dots in directory names
+ * are ignored. An initial dot in the filename is not treated as an extension
+ * separator, so ".gitignore" has no extension.
+ */
+std::string getFileExtension(const std::string& path);
+
+/*!
  * \brief Make directories for a given path string
  *
  * \param [in] path  string representing an absolute or relative directory path

--- a/src/axom/klee/AffineMatrixVisitor.cpp
+++ b/src/axom/klee/AffineMatrixVisitor.cpp
@@ -40,10 +40,10 @@ void AffineMatrixVisitor::visit(const klee::CompositeOperator&)
   SLIC_WARNING_ROOT("CompositeOperator not supported for Shaper query");
   m_isValid = false;
 }
-void AffineMatrixVisitor::visit(const klee::SliceOperator&)
+void AffineMatrixVisitor::visit(const klee::SliceOperator& slice)
 {
-  SLIC_WARNING_ROOT("SliceOperator not yet supported for Shaper query");
-  m_isValid = false;
+  m_matrix = slice.toMatrix();
+  m_isValid = true;
 }
 
 }  // end namespace axom::klee

--- a/src/axom/klee/Geometry.cpp
+++ b/src/axom/klee/Geometry.cpp
@@ -7,6 +7,7 @@
 #include "axom/klee/Geometry.hpp"
 #include "axom/klee/GeometryOperators.hpp"
 #include "axom/klee/AffineMatrixVisitor.hpp"
+#include "axom/klee/KleeError.hpp"
 
 #include "conduit_blueprint_mesh.hpp"
 
@@ -16,6 +17,50 @@ namespace axom
 {
 namespace klee
 {
+namespace
+{
+std::string operatorName(const GeometryOperator& op)
+{
+  if(dynamic_cast<const Translation*>(&op))
+  {
+    return "translate";
+  }
+  if(dynamic_cast<const Rotation*>(&op))
+  {
+    return "rotate";
+  }
+  if(dynamic_cast<const Scale*>(&op))
+  {
+    return "scale";
+  }
+  if(dynamic_cast<const UnitConverter*>(&op))
+  {
+    return "convert_units_to";
+  }
+  if(dynamic_cast<const SliceOperator*>(&op))
+  {
+    return "slice";
+  }
+  return "unknown";
+}
+
+void requireMatrixOperator(const std::shared_ptr<const GeometryOperator>& op, int index)
+{
+  if(std::dynamic_pointer_cast<const MatrixOperator>(op))
+  {
+    return;
+  }
+
+  const auto ordinal =
+    index >= 0 ? axom::fmt::format("operator {}", index) : std::string {"operator"};
+  throw KleeError({Path {"geometry/operators"},
+                   axom::fmt::format("Cannot convert geometry to matrix: {} ({}) is not a "
+                                     "matrix operator.",
+                                     ordinal,
+                                     operatorName(*op))});
+}
+}  // namespace
+
 bool operator==(const TransformableGeometryProperties& lhs, const TransformableGeometryProperties& rhs)
 {
   return lhs.dimensions == rhs.dimensions && lhs.units == rhs.units;
@@ -243,14 +288,21 @@ numerics::Matrix<double> Geometry::getTransform() const
       // Why don't we multiply the matrices in CompositeOperator::addOperator()?
       // Why keep the matrices factored and multiply them here repeatedly?
       // Combining them would also avoid this if-else logic.  BTNG
+      int operatorIndex = 0;
       for(auto op : composite->getOperators())
       {
+        ++operatorIndex;
+        requireMatrixOperator(op, operatorIndex);
         // Use visitor pattern to extract the affine matrix from supported operators
         AffineMatrixVisitor visitor;
         op->accept(visitor);
         if(!visitor.isValid())
         {
-          continue;
+          throw KleeError({Path {"geometry/operators"},
+                           axom::fmt::format("Cannot convert geometry to matrix: operator {} ({}) "
+                                             "is not supported by matrix extraction.",
+                                             operatorIndex,
+                                             operatorName(*op))});
         }
         const auto& matrix = visitor.getMatrix();
         numerics::Matrix<double> res(identity4x4);
@@ -260,11 +312,19 @@ numerics::Matrix<double> Geometry::getTransform() const
     }
     else
     {
+      requireMatrixOperator(m_operator, -1);
       AffineMatrixVisitor visitor;
       m_operator->accept(visitor);
       if(visitor.isValid())
       {
         transformation = visitor.getMatrix();
+      }
+      else
+      {
+        throw KleeError({Path {"geometry/operators"},
+                         axom::fmt::format("Cannot convert geometry to matrix: operator ({}) is "
+                                           "not supported by matrix extraction.",
+                                           operatorName(*m_operator))});
       }
     }
   }

--- a/src/axom/klee/Geometry.cpp
+++ b/src/axom/klee/Geometry.cpp
@@ -19,6 +19,13 @@ namespace klee
 {
 namespace
 {
+/**
+ * Require that an operator can be represented as an affine matrix.
+ *
+ * \param op the operator to check
+ * \param index the one-based operator index, or a negative value for an unnamed single operator
+ * \throws KleeError if \a op is not a MatrixOperator
+ */
 void requireMatrixOperator(const std::shared_ptr<const GeometryOperator>& op, int index)
 {
   if(std::dynamic_pointer_cast<const MatrixOperator>(op))

--- a/src/axom/klee/Geometry.cpp
+++ b/src/axom/klee/Geometry.cpp
@@ -19,31 +19,6 @@ namespace klee
 {
 namespace
 {
-std::string operatorName(const GeometryOperator& op)
-{
-  if(dynamic_cast<const Translation*>(&op))
-  {
-    return "translate";
-  }
-  if(dynamic_cast<const Rotation*>(&op))
-  {
-    return "rotate";
-  }
-  if(dynamic_cast<const Scale*>(&op))
-  {
-    return "scale";
-  }
-  if(dynamic_cast<const UnitConverter*>(&op))
-  {
-    return "convert_units_to";
-  }
-  if(dynamic_cast<const SliceOperator*>(&op))
-  {
-    return "slice";
-  }
-  return "unknown";
-}
-
 void requireMatrixOperator(const std::shared_ptr<const GeometryOperator>& op, int index)
 {
   if(std::dynamic_pointer_cast<const MatrixOperator>(op))
@@ -57,7 +32,7 @@ void requireMatrixOperator(const std::shared_ptr<const GeometryOperator>& op, in
                    axom::fmt::format("Cannot convert geometry to matrix: {} ({}) is not a "
                                      "matrix operator.",
                                      ordinal,
-                                     operatorName(*op))});
+                                     op->getName())});
 }
 }  // namespace
 
@@ -302,7 +277,7 @@ numerics::Matrix<double> Geometry::getTransform() const
                            axom::fmt::format("Cannot convert geometry to matrix: operator {} ({}) "
                                              "is not supported by matrix extraction.",
                                              operatorIndex,
-                                             operatorName(*op))});
+                                             op->getName())});
         }
         const auto& matrix = visitor.getMatrix();
         numerics::Matrix<double> res(identity4x4);
@@ -324,7 +299,7 @@ numerics::Matrix<double> Geometry::getTransform() const
         throw KleeError({Path {"geometry/operators"},
                          axom::fmt::format("Cannot convert geometry to matrix: operator ({}) is "
                                            "not supported by matrix extraction.",
-                                           operatorName(*m_operator))});
+                                           m_operator->getName())});
       }
     }
   }

--- a/src/axom/klee/Geometry.hpp
+++ b/src/axom/klee/Geometry.hpp
@@ -264,6 +264,7 @@ public:
    * geometry operators then the identity matrix is returned.
    *
    * \return A 4x4 matrix that represents the geometry transforms.
+   * \throws KleeError if any geometry operator cannot be represented as a matrix
    */
   numerics::Matrix<double> getTransform() const;
 

--- a/src/axom/klee/GeometryOperators.hpp
+++ b/src/axom/klee/GeometryOperators.hpp
@@ -110,6 +110,7 @@ public:
    * Add the given operator to the end of the list of operators in this composite.
    *
    * \param op the operator to add
+   * \throws std::invalid_argument if \a op cannot start from this composite's current end properties
    */
   void addOperator(const OpPtr &op);
 
@@ -327,6 +328,12 @@ public:
 
   TransformableGeometryProperties getEndProperties() const override;
 
+  /**
+   * Convert this operator to its matrix representation.
+   *
+   * \return a 4x4 affine transformation matrix
+   * \throws std::invalid_argument if the start or end units are unspecified
+   */
   numerics::Matrix<double> toMatrix() const override;
 
   void accept(GeometryOperatorVisitor &visitor) const override;
@@ -334,6 +341,7 @@ public:
   /**
    * Get the conversion factor used to convert from the start units to the end units
    * \return the unit conversion factor
+   * \throws std::invalid_argument if the start or end units are unspecified
    */
   double getConversionFactor() const;
 

--- a/src/axom/klee/GeometryOperators.hpp
+++ b/src/axom/klee/GeometryOperators.hpp
@@ -17,6 +17,7 @@
 #include "axom/primal/geometry/Vector.hpp"
 
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace axom
@@ -42,6 +43,9 @@ public:
   explicit GeometryOperator(const TransformableGeometryProperties &startProperties);
 
   virtual ~GeometryOperator() = default;
+
+  /// Returns the name of this operator
+  virtual std::string getName() const = 0;
 
   /**
    * Get the properties that the operator expects to start in
@@ -98,6 +102,8 @@ public:
 
   using OpPtr = std::shared_ptr<const GeometryOperator>;
 
+  std::string getName() const override { return "composite"; }
+
   void accept(GeometryOperatorVisitor &visitor) const override;
 
   /**
@@ -139,6 +145,8 @@ public:
    * \return a vector by which points should be offset
    */
   const primal::Vector3D &getOffset() const { return m_offset; }
+
+  std::string getName() const override { return "translate"; }
 
   numerics::Matrix<double> toMatrix() const override;
 
@@ -187,6 +195,8 @@ public:
    * \return the vector, which when combined with the center, defines the axis of rotation.
    */
   const primal::Vector3D &getAxis() const { return m_axis; }
+
+  std::string getName() const override { return "rotate"; }
 
   numerics::Matrix<double> toMatrix() const override;
 
@@ -289,6 +299,8 @@ public:
   primal::Point3D &getCenter() { return m_center; }
   const primal::Point3D &getCenter() const { return m_center; }
 
+  std::string getName() const override { return "scale"; }
+
   numerics::Matrix<double> toMatrix() const override;
 
   void accept(GeometryOperatorVisitor &visitor) const override;
@@ -310,6 +322,8 @@ public:
    * \param startProperties the properties before the operation
    */
   UnitConverter(LengthUnit endUnits, const TransformableGeometryProperties &startProperties);
+
+  std::string getName() const override { return "convert_units_to"; }
 
   TransformableGeometryProperties getEndProperties() const override;
 
@@ -368,6 +382,8 @@ public:
    * \return the direction of the positive Y axis
    */
   const primal::Vector3D &getUp() const { return m_up; }
+
+  std::string getName() const override { return "slice"; }
 
   numerics::Matrix<double> toMatrix() const override;
 

--- a/src/axom/klee/KleeError.hpp
+++ b/src/axom/klee/KleeError.hpp
@@ -17,6 +17,9 @@ namespace klee
 {
 /**
  * Describes an error that occurred while parsing a Klee file.
+ *
+ * Klee throws this exception for user input validation failures so callers
+ * can report path-aware feedback from Inlet and Klee semantic checks.
  */
 class KleeError : public std::exception
 {

--- a/src/axom/klee/ShapeSet.hpp
+++ b/src/axom/klee/ShapeSet.hpp
@@ -54,6 +54,7 @@ public:
    *
    * \param dimensions the dimension for all the shapes
    * \note This function must be called before calling \a getDimensions()
+   * \throws std::logic_error if \a dimensions is not Dimensions::Two or Dimensions::Three
    */
   void setDimensions(Dimensions dimensions);
 
@@ -62,6 +63,7 @@ public:
    *
    * \pre Only valid after \a setDimensions() has been called on this instance
    * \sa setDimensions()
+   * \throws std::logic_error if dimensions have not been set
    */
   Dimensions getDimensions() const;
 

--- a/src/axom/klee/Units.cpp
+++ b/src/axom/klee/Units.cpp
@@ -17,6 +17,14 @@ namespace klee
 {
 namespace internal
 {
+/**
+ * Parse length units from a string.
+ *
+ * \param unitsAsString the unit string to parse
+ * \param path the input path to report on failure
+ * \return the parsed length unit
+ * \throws KleeError if the unit string is invalid
+ */
 LengthUnit parseLengthUnits(const std::string &unitsAsString, const std::string &path)
 {
   try

--- a/src/axom/klee/Units.hpp
+++ b/src/axom/klee/Units.hpp
@@ -31,6 +31,7 @@ namespace internal
  * \param unitsAsProxy The Inlet proxy from which to get the unit string.
  *
  * \return A LengthUnit containing the unit type.
+ * \throws KleeError if the unit string is invalid
  */
 LengthUnit parseLengthUnits(const inlet::Proxy &unitsAsProxy);
 

--- a/src/axom/klee/docs/sphinx/specifying_shapes.rst
+++ b/src/axom/klee/docs/sphinx/specifying_shapes.rst
@@ -43,11 +43,11 @@ is specified in :code:`windshield.stl`. Note that Klee does not specify
 what a particular material means. A material is simply a label which can
 be used by a host code to apply properties to part of a mesh.
 
-Lua Input Decks
+Lua Input Files
 ***************
-Klee can also read Lua input decks when Axom is configured with
-:code:`AXOM_ENABLE_LUA=ON` and Sol support. Lua decks use the same Klee schema
-as YAML decks. The Lua is evaluated and then read into Inlet. 
+Klee can also read Lua input files when Axom is configured with :code:`AXOM_ENABLE_LUA=ON`
+and Sol support. Lua files use the same Klee schema as YAML files.
+The Lua is evaluated and then read into Inlet.
 
 File-based reads use an explicit :code:`axom::klee::InputFormat` when provided.
 Otherwise they infer the format from the file extension 
@@ -93,8 +93,8 @@ The following YAML and Lua inputs are equivalent:
       }
     }
 
-Because Lua is evaluated before Klee reads the deck, ordinary table values can
-be generated programmatically:
+Because Lua is evaluated before Klee reads the input file,
+ordinary table values can be generated programmatically:
 
 .. code-block:: lua
 
@@ -127,11 +127,11 @@ For Lua input, a one-value scale is written as a one-entry table, for example
 :code:`{ scale = {2.0} }`.
 
 Common Lua input errors are reported as Klee parsing errors.
-A Lua deck read without Lua support reports:
+A Lua input file read without Lua support reports:
 
 .. code-block:: text
 
-    Lua input decks require Axom configured with AXOM_ENABLE_LUA=ON and Sol library support. Rebuild Axom with Lua enabled or convert deck to YAML.
+    Lua input files require Axom configured with AXOM_ENABLE_LUA=ON and Sol library support. Rebuild Axom with Lua enabled or convert the file to YAML.
 
 Unsupported file extensions are rejected before parsing, and unexpected top-level globals
 or syntax errors are reported during Inlet verification or Lua evaluation.
@@ -139,14 +139,14 @@ Unknown nested fields follow the same Inlet schema strictness rules as YAML inpu
 
 Error Reporting
 ***************
-Klee validates user-provided YAML and Lua input decks while reading them.
+Klee validates user-provided YAML and Lua input files while reading them.
 When validation fails, Klee reports the problem by throwing an exception,
 usually :code:`axom::klee::KleeError`.
 
 Using exceptions lets Klee return detailed feedback at the point where the invalid input is detected, 
 including the input path reported by Inlet.
 
-Callers that read input decks should catch :code:`axom::klee::KleeError` and display :code:`what()`
+Callers that read input files should catch :code:`axom::klee::KleeError` and display :code:`what()`
 or inspect :code:`getErrors()` when multiple verification errors are available.
 Klee may still throw standard exceptions such as :code:`std::logic_error` or :code:`std::invalid_argument`
 for programming errors or inconsistent manually constructed objects.
@@ -156,7 +156,7 @@ Paths
 The paths specified in shapes are specified either as absolute paths
 (begin with a :code:`/`), or as relative paths. Absolute paths are evaluated
 as absolute paths in the file systems. Relative paths are evaluated relative
-to the Klee input deck (not the current working directory). For example, in the
+to the Klee input file (not the current working directory). For example, in the
 file :code:`/path/to/my_shapes.yaml`, the table below illustrates how
 different paths would be specified.
 

--- a/src/axom/klee/docs/sphinx/specifying_shapes.rst
+++ b/src/axom/klee/docs/sphinx/specifying_shapes.rst
@@ -4,14 +4,13 @@ Specifying Shapes
 "Shaping", or "painting", is the process of adding non-conformal material
 regions to a mesh. Traditionally, this has been done in code-specific formats
 by each code that provides such a capability. Axom's Klee library provides
-a way to read shape specifications in YAML files and apply the specified
+a way to read shape specifications in YAML or Lua files and apply the specified
 geometry to a mesh.
 
 Basics
 ------
-Shapes in Klee are specified in YAML. A basic file consists of a list of
-shapes. Each one specifies its :code:`name` and :code:`material`,
-as well as a description of its geometry.
+Shapes in Klee are specified as a list. Each shape specifies its :code:`name`
+and :code:`material`, as well as a description of its geometry.
 
 In addition to the shapes themselves, a file must specify the number of
 dimensions of the shapes (only 2 and 3 are allowed). This will be important
@@ -44,12 +43,104 @@ is specified in :code:`windshield.stl`. Note that Klee does not specify
 what a particular material means. A material is simply a label which can
 be used by a host code to apply properties to part of a mesh.
 
+Lua Input Decks
+***************
+Klee can also read Lua input decks when Axom is configured with
+:code:`AXOM_ENABLE_LUA=ON` and Sol support. Lua decks use the same Klee schema
+as YAML decks in this stage; the difference is that Lua evaluates first and
+then Inlet reads the resulting global tables. File-based reads infer the input
+format from :code:`.yaml`, :code:`.yml`, or :code:`.lua` extensions. Stream-based
+reads are YAML by default unless the caller passes
+:code:`axom::klee::InputFormat::Lua`.
+
+The following YAML and Lua inputs are equivalent:
+
+.. code-block:: yaml
+
+    dimensions: 3
+
+    shapes:
+      - name: windshield
+        material: glass
+        geometry:
+          format: stl
+          path: windshield.stl
+          units: cm
+          operators:
+            - rotate: 90
+              axis: [0, 1, 0]
+              center: [0, 0, -10]
+            - translate: [10, 20, 30]
+
+.. code-block:: lua
+
+    dimensions = 3
+
+    shapes = {
+      {
+        name = "windshield",
+        material = "glass",
+        geometry = {
+          format = "stl",
+          path = "windshield.stl",
+          units = "cm",
+          operators = {
+            { rotate = 90, axis = {0, 1, 0}, center = {0, 0, -10} },
+            { translate = {10, 20, 30} }
+          }
+        }
+      }
+    }
+
+Because Lua is evaluated before Klee reads the deck, ordinary table values can
+be generated programmatically:
+
+.. code-block:: lua
+
+    local dim = 2
+    local r = 4.0
+    local z = 8.0
+    local x = 1.0
+    local y = 2.0
+
+    dimensions = dim
+
+    shapes = {
+      {
+        name = "part",
+        material = "steel",
+        geometry = {
+          format = "stl",
+          path = "part.stl",
+          units = "cm",
+          operators = {
+            { translate = (dim == 2) and {r, z} or {x, y, z} }
+          }
+        }
+      }
+    }
+
+Use :code:`local` helper functions and constants for intermediate values so the
+global namespace contains only the Klee schema fields that Inlet should read.
+For Lua input, a one-value scale is written as a one-entry table, for example
+:code:`{ scale = {2.0} }`.
+
+Common Lua input errors are reported as Klee parsing errors. A Lua deck read
+without Lua support reports:
+
+.. code-block:: text
+
+    Lua input decks require Axom configured with AXOM_ENABLE_LUA=ON and Sol library support. Rebuild Axom with Lua enabled or convert deck to YAML.
+
+Unsupported file extensions are rejected before parsing, and unexpected globals
+or syntax errors are reported during Inlet verification or Lua evaluation.
+
 Paths
 *****
 The paths specified in shapes are specified either as absolute paths
 (begin with a :code:`/`), or as relative paths. Absolute paths are evaluated
 as absolute paths in the file systems. Relative paths are evaluated relative
-to the YAML file (not the current working directory). For example, in the
+to the Klee input deck (not the current working directory). For example, in the
 file :code:`/path/to/my_shapes.yaml`, the table below illustrates how
 different paths would be specified.
 

--- a/src/axom/klee/docs/sphinx/specifying_shapes.rst
+++ b/src/axom/klee/docs/sphinx/specifying_shapes.rst
@@ -125,15 +125,16 @@ global namespace contains only the Klee schema fields that Inlet should read.
 For Lua input, a one-value scale is written as a one-entry table, for example
 :code:`{ scale = {2.0} }`.
 
-Common Lua input errors are reported as Klee parsing errors. A Lua deck read
-without Lua support reports:
+Common Lua input errors are reported as Klee parsing errors.
+A Lua deck read without Lua support reports:
 
 .. code-block:: text
 
     Lua input decks require Axom configured with AXOM_ENABLE_LUA=ON and Sol library support. Rebuild Axom with Lua enabled or convert deck to YAML.
 
-Unsupported file extensions are rejected before parsing, and unexpected globals
+Unsupported file extensions are rejected before parsing, and unexpected top-level globals
 or syntax errors are reported during Inlet verification or Lua evaluation.
+Unknown nested fields follow the same Inlet schema strictness rules as YAML input.
 
 Paths
 *****

--- a/src/axom/klee/docs/sphinx/specifying_shapes.rst
+++ b/src/axom/klee/docs/sphinx/specifying_shapes.rst
@@ -47,7 +47,9 @@ Lua Input Files
 ***************
 Klee can also read Lua input files when Axom is configured with :code:`AXOM_ENABLE_LUA=ON`
 and Sol support. Lua files use the same Klee schema as YAML files.
-The Lua is evaluated and then read into Inlet.
+Klee evaluates the Lua once, when the input file is read, and then passes the
+resulting values to Inlet. It does not re-evaluate the Lua during later loops,
+timesteps, or shape-processing operations.
 
 File-based reads use an explicit :code:`axom::klee::InputFormat` when provided.
 Otherwise they infer the format from the file extension 

--- a/src/axom/klee/docs/sphinx/specifying_shapes.rst
+++ b/src/axom/klee/docs/sphinx/specifying_shapes.rst
@@ -47,11 +47,12 @@ Lua Input Decks
 ***************
 Klee can also read Lua input decks when Axom is configured with
 :code:`AXOM_ENABLE_LUA=ON` and Sol support. Lua decks use the same Klee schema
-as YAML decks in this stage; the difference is that Lua evaluates first and
-then Inlet reads the resulting global tables. File-based reads infer the input
-format from :code:`.yaml`, :code:`.yml`, or :code:`.lua` extensions. Stream-based
-reads are YAML by default unless the caller passes
-:code:`axom::klee::InputFormat::Lua`.
+as YAML decks. The Lua is evaluated and then read into Inlet. 
+
+File-based reads use an explicit :code:`axom::klee::InputFormat` when provided.
+Otherwise they infer the format from the file extension 
+(:code:`.yaml`, :code:`.yml`, or :code:`.lua`) when present, and default to YAML.
+Similarly, stream-based reads are YAML by default unless the caller passes :code:`axom::klee::InputFormat::Lua`.
 
 The following YAML and Lua inputs are equivalent:
 

--- a/src/axom/klee/docs/sphinx/specifying_shapes.rst
+++ b/src/axom/klee/docs/sphinx/specifying_shapes.rst
@@ -137,6 +137,20 @@ Unsupported file extensions are rejected before parsing, and unexpected top-leve
 or syntax errors are reported during Inlet verification or Lua evaluation.
 Unknown nested fields follow the same Inlet schema strictness rules as YAML input.
 
+Error Reporting
+***************
+Klee validates user-provided YAML and Lua input decks while reading them.
+When validation fails, Klee reports the problem by throwing an exception,
+usually :code:`axom::klee::KleeError`.
+
+Using exceptions lets Klee return detailed feedback at the point where the invalid input is detected, 
+including the input path reported by Inlet.
+
+Callers that read input decks should catch :code:`axom::klee::KleeError` and display :code:`what()`
+or inspect :code:`getErrors()` when multiple verification errors are available.
+Klee may still throw standard exceptions such as :code:`std::logic_error` or :code:`std::invalid_argument`
+for programming errors or inconsistent manually constructed objects.
+
 Paths
 *****
 The paths specified in shapes are specified either as absolute paths

--- a/src/axom/klee/io/GeometryOperatorsIO.cpp
+++ b/src/axom/klee/io/GeometryOperatorsIO.cpp
@@ -7,6 +7,7 @@
 #include "GeometryOperatorsIO.hpp"
 #include "IOUtil.hpp"
 
+#include "axom/core/utilities/StringUtilities.hpp"
 #include "axom/klee/Geometry.hpp"
 #include "axom/klee/GeometryOperators.hpp"
 #include "axom/klee/KleeError.hpp"
@@ -35,6 +36,16 @@ using primal::Point3D;
 using primal::Vector3D;
 using FieldSet = std::unordered_set<std::string>;
 
+std::string childName(const inlet::Container &container, const std::string &name)
+{
+  std::string result = axom::utilities::string::removePrefix(container.name(), name);
+  if(axom::utilities::string::startsWith(result, '/'))
+  {
+    result = result.substr(1);
+  }
+  return result;
+}
+
 /**
  * Get the names of all the children in the given container.
  *
@@ -48,14 +59,11 @@ std::unordered_set<std::string> getChildNames(const inlet::Container &container)
   std::vector<std::string> unexpectedNames = container.unexpectedNames();
   allChildren.insert(unexpectedNames.begin(), unexpectedNames.end());
 
-  // Add 1 for the "/" separator
-  auto prefixLength = container.name().size() + 1;
-
   for(auto &child : container.getChildContainers())
   {
     if(child.second->exists())
     {
-      allChildren.insert(child.first.substr(prefixLength));
+      allChildren.insert(childName(container, child.first));
     }
   }
 
@@ -63,7 +71,7 @@ std::unordered_set<std::string> getChildNames(const inlet::Container &container)
   {
     if(child.second->exists())
     {
-      allChildren.insert(child.first.substr(prefixLength));
+      allChildren.insert(childName(container, child.first));
     }
   }
 
@@ -71,7 +79,7 @@ std::unordered_set<std::string> getChildNames(const inlet::Container &container)
   {
     if(*child.second)
     {
-      allChildren.insert(child.first.substr(prefixLength));
+      allChildren.insert(childName(container, child.first));
     }
   }
 

--- a/src/axom/klee/io/GeometryOperatorsIO.cpp
+++ b/src/axom/klee/io/GeometryOperatorsIO.cpp
@@ -90,8 +90,7 @@ std::unordered_set<std::string> getChildNames(const inlet::Container &container)
  * Verify that a Container has the correct fields.
  *
  * While Inlet can do a lot of the verification, there are some situations
- * where we need some extra manual checks. For example, operators can look
- * like this:
+ * where we need some extra manual checks. For example, operators can look like this:
  *
  * \code{.yaml}
  *
@@ -114,6 +113,7 @@ std::unordered_set<std::string> getChildNames(const inlet::Container &container)
  * \param name the name of the container. This must be one of its fields.
  * \param additionalRequiredFields any additional required fields
  * \param optionalFields any additional optional fields
+ * \throws KleeError if a required field is missing or an unexpected field is present
  */
 void verifyObjectFields(const inlet::Container &containerToTest,
                         const std::string &name,
@@ -155,6 +155,7 @@ void verifyObjectFields(const inlet::Container &containerToTest,
  * \param opContainer the Container from which to read the operator
  * \param startProperties the properties prior to this operator
  * \return the created operator
+ * \throws KleeError if the operator fields or vector dimensions are invalid
  */
 OpPtr parseTranslate(const inlet::Container &opContainer,
                      const TransformableGeometryProperties &startProperties)
@@ -170,6 +171,7 @@ OpPtr parseTranslate(const inlet::Container &opContainer,
  * \param opContainer the Container from which to read the operator
  * \param startProperties the properties prior to this operator
  * \return the created operator
+ * \throws KleeError if the rotation is invalid for the start dimensions or operator fields
  */
 OpPtr parseRotate(const inlet::Container &opContainer,
                   const TransformableGeometryProperties &startProperties)
@@ -238,6 +240,7 @@ OpPtr makeCheckedSlice(Point3D origin,
  * \param planeName the name of the plane ("x", "y", or "z")
  * \param defaultNormal the default normal vector
  * \return the point to use as the origin
+ * \throws KleeError if the specified origin is not on the slice plane
  */
 primal::Point3D getPerpendicularSliceOrigin(const inlet::Container &sliceContainer,
                                             char const *planeName,
@@ -275,6 +278,7 @@ primal::Point3D getPerpendicularSliceOrigin(const inlet::Container &sliceContain
  * \param sliceContainer the Container describing the slice
  * \param defaultNormal the default normal vector
  * \return the vector to use as the normal
+ * \throws KleeError if the specified normal is not parallel to the slice plane normal
  */
 primal::Vector3D getPerpendicularSliceNormal(const inlet::Container &sliceContainer,
                                              const primal::Vector3D &defaultNormal)
@@ -303,6 +307,7 @@ primal::Vector3D getPerpendicularSliceNormal(const inlet::Container &sliceContai
  * \param defaultUp the default up vector for the plane being parsed
  * \param startProperties the properties prior to this operator
  * \return the parsed plane
+ * \throws KleeError if the slice fields or values are invalid
  */
 OpPtr readPerpendicularSlice(const inlet::Container &sliceContainer,
                              char const *planeName,
@@ -326,6 +331,7 @@ OpPtr readPerpendicularSlice(const inlet::Container &sliceContainer,
  * \param opContainer the Container from which to read the operator
  * \param startProperties the properties prior to this operator
  * \return the created operator
+ * \throws KleeError if the slice fields or values are invalid
  */
 OpPtr parseSlice(const inlet::Container &opContainer,
                  const TransformableGeometryProperties &startProperties)
@@ -364,6 +370,7 @@ OpPtr parseSlice(const inlet::Container &opContainer,
  * \param opContainer the Container from which to read the operator
  * \param startProperties the properties prior to this operator
  * \return the created operator
+ * \throws KleeError if the scale fields or vector dimensions are invalid
  */
 OpPtr parseScale(const inlet::Container &opContainer,
                  const TransformableGeometryProperties &startProperties)
@@ -394,6 +401,7 @@ OpPtr parseScale(const inlet::Container &opContainer,
  * \param opContainer the Container from which to read the operator
  * \param startProperties the properties prior to this operator
  * \return the created operator
+ * \throws KleeError if the unit string or operator fields are invalid
  */
 OpPtr parseConvertUnits(const inlet::Container &opContainer,
                         const TransformableGeometryProperties &startProperties)
@@ -410,6 +418,7 @@ OpPtr parseConvertUnits(const inlet::Container &opContainer,
  * \param startProperties the properties before the "ref" command
  * \param namedOperators a map of named operators from which to get referenced operators
  * \return the created operator
+ * \throws KleeError if the reference is missing or the operator fields are invalid
  */
 OpPtr parseRef(const inlet::Container &opContainer,
                const TransformableGeometryProperties &startProperties,
@@ -457,6 +466,7 @@ OpPtr parseRef(const inlet::Container &opContainer,
  * \param startProperties the properties before the operator
  * \param namedOperators a map of named operators from which to get referenced operators
  * \return the created operator
+ * \throws KleeError if the operator type or fields are invalid
  */
 OpPtr convertOperator(SingleOperatorData const &data,
                       TransformableGeometryProperties startProperties,

--- a/src/axom/klee/io/GeometryOperatorsIO.hpp
+++ b/src/axom/klee/io/GeometryOperatorsIO.hpp
@@ -69,6 +69,7 @@ public:
    * @param startProperties properties of the geometry before the first operator
    * @param namedOperators a map of any named operators
    * @return the (possibly null) operator
+   * @throws KleeError if the operator data is invalid for the given properties
    */
   std::shared_ptr<GeometryOperator> makeOperator(const TransformableGeometryProperties &startProperties,
                                                  const NamedOperatorMap &namedOperators) const;
@@ -120,6 +121,8 @@ struct NamedOperatorMapData
    *
    * @param fileDimensions the dimensions that shapes should be in in this file.
    * @return the name of converted operators
+   * @throws KleeError if a named operator is invalid or its declared end units
+   *         do not match its actual end units
    */
   NamedOperatorMap makeNamedOperatorMap(Dimensions fileDimensions) const;
 
@@ -142,17 +145,32 @@ private:
 template <>
 struct FromInlet<axom::klee::internal::GeometryOperatorData>
 {
+  /**
+   * Convert an Inlet container to geometry operator data.
+   *
+   * @throws axom::klee::KleeError if nested operator data is invalid
+   */
   axom::klee::internal::GeometryOperatorData operator()(const axom::inlet::Container &base);
 };
 
 template <>
 struct FromInlet<axom::klee::internal::NamedOperatorData>
 {
+  /**
+   * Convert an Inlet container to named operator data.
+   *
+   * @throws axom::klee::KleeError if required unit fields are missing or invalid
+   */
   axom::klee::internal::NamedOperatorData operator()(const axom::inlet::Container &base);
 };
 
 template <>
 struct FromInlet<axom::klee::internal::NamedOperatorMapData>
 {
+  /**
+   * Convert an Inlet container to named operator map data.
+   *
+   * @throws axom::klee::KleeError if nested named operator data is invalid
+   */
   axom::klee::internal::NamedOperatorMapData operator()(const axom::inlet::Container &base);
 };

--- a/src/axom/klee/io/IO.cpp
+++ b/src/axom/klee/io/IO.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <exception>
 #include <functional>
 #include <iterator>
 #include <memory>
@@ -363,6 +364,46 @@ std::unique_ptr<inlet::Reader> createReader(InputFormat format)
   throw KleeError({Path {"<unknown path>"}, "Unsupported Klee input format."});
 }
 
+const char *inputFormatName(InputFormat format)
+{
+  switch(format)
+  {
+  case InputFormat::YAML:
+    return "YAML";
+  case InputFormat::Lua:
+    return "Lua";
+  }
+
+  return "unknown";
+}
+
+template <typename Parse>
+void parseOrThrow(Parse &&parse,
+                  InputFormat format,
+                  const Path &path,
+                  const std::string &sourceDescription)
+{
+  bool parsed = false;
+  std::string details;
+  try
+  {
+    parsed = parse();
+  }
+  catch(const std::exception &error)
+  {
+    details = error.what();
+  }
+
+  if(!parsed)
+  {
+    auto message = axom::fmt::format("Failed to parse {} Klee input {}",
+                                     inputFormatName(format),
+                                     sourceDescription);
+    message += details.empty() ? "." : axom::fmt::format(": {}", details);
+    throw KleeError({path, std::move(message)});
+  }
+}
+
 void appendUnexpectedGlobalErrors(const inlet::Inlet &doc,
                                   std::vector<inlet::VerificationError> &errors)
 {
@@ -421,7 +462,10 @@ ShapeSet readShapeSet(std::istream &stream, InputFormat format)
   std::string contents {std::istreambuf_iterator<char>(stream), {}};
 
   auto reader = createReader(format);
-  reader->parseString(contents);
+  parseOrThrow([&]() { return reader->parseString(contents); },
+               format,
+               Path {"<stream>"},
+               "from stream");
   return readShapeSetFromReader(std::move(reader), format == InputFormat::Lua);
 }
 
@@ -429,7 +473,10 @@ ShapeSet readShapeSet(const std::string &filePath)
 {
   const auto format = inferInputFormat(filePath);
   auto reader = createReader(format);
-  reader->parseFile(filePath);
+  parseOrThrow([&]() { return reader->parseFile(filePath); },
+               format,
+               Path {filePath},
+               axom::fmt::format("from file '{}'", filePath));
   auto shapeSet = readShapeSetFromReader(std::move(reader), format == InputFormat::Lua);
   shapeSet.setPath(filePath);
   return shapeSet;

--- a/src/axom/klee/io/IO.cpp
+++ b/src/axom/klee/io/IO.cpp
@@ -327,6 +327,10 @@ std::string extensionOf(const std::string &filePath)
 InputFormat inferInputFormat(const std::string &filePath)
 {
   const auto extension = extensionOf(filePath);
+  if(extension.empty())
+  {
+    return InputFormat::YAML;
+  }
   if(extension == ".yaml" || extension == ".yml")
   {
     return InputFormat::YAML;
@@ -340,7 +344,7 @@ InputFormat inferInputFormat(const std::string &filePath)
     {Path {filePath},
      axom::fmt::format("Unsupported Klee input file extension '{}'. Supported extensions are "
                        ".yaml, .yml, and .lua.",
-                       extension.empty() ? "<none>" : extension)});
+                       extension)});
 }
 
 std::unique_ptr<inlet::Reader> createReader(InputFormat format)
@@ -466,7 +470,11 @@ ShapeSet readShapeSet(std::istream &stream, InputFormat format)
 
 ShapeSet readShapeSet(const std::string &filePath)
 {
-  const auto format = inferInputFormat(filePath);
+  return readShapeSet(filePath, inferInputFormat(filePath));
+}
+
+ShapeSet readShapeSet(const std::string &filePath, InputFormat format)
+{
   auto reader = createReader(format);
   parseOrThrow([&]() { return reader->parseFile(filePath); },
                format,

--- a/src/axom/klee/io/IO.cpp
+++ b/src/axom/klee/io/IO.cpp
@@ -118,7 +118,7 @@ void defineGeometry(inlet::Container &geometry)
 {
   geometry.addString("format", "The format of the input file").required();
   geometry.addString("path",
-                     "The path of the input file, relative to the Klee input deck."
+                     "The path of the input file, relative to the Klee input file."
                      "Required unless 'format' is 'none'");
   internal::defineDimensionsField(geometry,
                                   "start_dimensions",
@@ -314,7 +314,7 @@ internal::NamedOperatorMap getNamedOperators(const inlet::Inlet &doc, Dimensions
 /**
  * Infer the Klee input format from a file path.
  *
- * \param filePath the input deck path
+ * \param filePath the input file path
  * \return the inferred input format
  * \throws KleeError if the file extension is not a supported Klee input extension
  */
@@ -345,7 +345,7 @@ InputFormat inferInputFormat(const std::string &filePath)
 /**
  * Create an Inlet reader for a Klee input format.
  *
- * \param format the input deck format to read
+ * \param format the input file format to read
  * \return a reader for \a format
  * \throws KleeError if \a format is unsupported or Lua support was not enabled
  */
@@ -361,8 +361,8 @@ std::unique_ptr<inlet::Reader> createReader(InputFormat format)
 #else
     throw KleeError(
       {Path {"<unknown path>"},
-       "Lua input decks require Axom configured with AXOM_ENABLE_LUA=ON and Sol library support. "
-       "Rebuild Axom with Lua enabled or convert deck to YAML."});
+       "Lua input files require Axom configured with AXOM_ENABLE_LUA=ON and Sol library support. "
+       "Rebuild Axom with Lua enabled or convert the file to YAML."});
 #endif
   }
 
@@ -386,7 +386,7 @@ const char *inputFormatName(InputFormat format)
  * Run a reader parse operation and convert parse failures to KleeError.
  *
  * \param parse callable that returns true on successful parse
- * \param format the input deck format being parsed
+ * \param format the input file format being parsed
  * \param path the path to report in any generated error
  * \param sourceDescription a human-readable description of the parsed source
  * \throws KleeError if parsing fails or the reader throws while parsing
@@ -426,7 +426,7 @@ void appendUnexpectedGlobalErrors(const inlet::Inlet &doc,
     if(name.find('/') == std::string::npos)
     {
       errors.push_back({Path {name},
-                        axom::fmt::format("Unexpected global variable '{}' in Lua input deck. "
+                        axom::fmt::format("Unexpected global variable '{}' in Lua input file. "
                                           "Use 'local' for helper values and functions.",
                                           name)});
     }
@@ -434,7 +434,7 @@ void appendUnexpectedGlobalErrors(const inlet::Inlet &doc,
 }
 
 /**
- * Read a ShapeSet from a reader that has already parsed an input deck.
+ * Read a ShapeSet from a reader that has already parsed an input file.
  *
  * \param reader the parsed Inlet reader
  * \param rejectUnexpectedGlobals true if unexpected top-level Lua globals should be rejected

--- a/src/axom/klee/io/IO.cpp
+++ b/src/axom/klee/io/IO.cpp
@@ -25,7 +25,6 @@
 #include <memory>
 #include <string>
 #include <tuple>
-#include <unordered_set>
 
 namespace axom
 {
@@ -407,19 +406,15 @@ void parseOrThrow(Parse &&parse,
 void appendUnexpectedGlobalErrors(const inlet::Inlet &doc,
                                   std::vector<inlet::VerificationError> &errors)
 {
-  std::unordered_set<std::string> unexpectedGlobals;
   for(const auto &name : doc.unexpectedNames())
   {
-    const auto slash = name.find('/');
-    unexpectedGlobals.insert(name.substr(0, slash));
-  }
-
-  for(const auto &name : unexpectedGlobals)
-  {
-    errors.push_back({Path {name},
-                      axom::fmt::format("Unexpected global variable '{}' in Lua input deck. Use "
-                                        "'local' for helper values and functions.",
-                                        name)});
+    if(name.find('/') == std::string::npos)
+    {
+      errors.push_back({Path {name},
+                        axom::fmt::format("Unexpected global variable '{}' in Lua input deck. "
+                                          "Use 'local' for helper values and functions.",
+                                          name)});
+    }
   }
 }
 

--- a/src/axom/klee/io/IO.cpp
+++ b/src/axom/klee/io/IO.cpp
@@ -12,13 +12,13 @@
 #include "axom/klee/KleeError.hpp"
 
 #include "axom/config.hpp"
+#include "axom/core/utilities/FileUtilities.hpp"
+#include "axom/core/utilities/StringUtilities.hpp"
 #include "axom/inlet.hpp"
 #ifdef AXOM_USE_LUA
   #include "axom/inlet/LuaReader.hpp"
 #endif
 
-#include <algorithm>
-#include <cctype>
 #include <exception>
 #include <functional>
 #include <iterator>
@@ -305,28 +305,10 @@ internal::NamedOperatorMap getNamedOperators(const inlet::Inlet &doc, Dimensions
   return internal::NamedOperatorMap {};
 }
 
-std::string lowercase(std::string value)
-{
-  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
-    return static_cast<char>(std::tolower(ch));
-  });
-  return value;
-}
-
-std::string extensionOf(const std::string &filePath)
-{
-  const auto slash = filePath.find_last_of("/\\");
-  const auto dot = filePath.find_last_of('.');
-  if(dot == std::string::npos || (slash != std::string::npos && dot < slash))
-  {
-    return "";
-  }
-  return lowercase(filePath.substr(dot));
-}
-
 InputFormat inferInputFormat(const std::string &filePath)
 {
-  const auto extension = extensionOf(filePath);
+  auto extension = utilities::filesystem::getFileExtension(filePath);
+  utilities::string::toLower(extension);
   if(extension.empty())
   {
     return InputFormat::YAML;

--- a/src/axom/klee/io/IO.cpp
+++ b/src/axom/klee/io/IO.cpp
@@ -11,13 +11,20 @@
 #include "axom/klee/GeometryOperators.hpp"
 #include "axom/klee/KleeError.hpp"
 
+#include "axom/config.hpp"
 #include "axom/inlet.hpp"
+#ifdef AXOM_USE_LUA
+  #include "axom/inlet/LuaReader.hpp"
+#endif
 
-#include <fstream>
+#include <algorithm>
+#include <cctype>
 #include <functional>
 #include <iterator>
+#include <memory>
 #include <string>
 #include <tuple>
+#include <unordered_set>
 
 namespace axom
 {
@@ -111,7 +118,7 @@ void defineGeometry(inlet::Container &geometry)
 {
   geometry.addString("format", "The format of the input file").required();
   geometry.addString("path",
-                     "The path of the input file, relative to the yaml file."
+                     "The path of the input file, relative to the Klee input deck."
                      "Required unless 'format' is 'none'");
   internal::defineDimensionsField(geometry,
                                   "start_dimensions",
@@ -297,20 +304,97 @@ internal::NamedOperatorMap getNamedOperators(const inlet::Inlet &doc, Dimensions
   }
   return internal::NamedOperatorMap {};
 }
-}  // namespace
 
-ShapeSet readShapeSet(std::istream &stream)
+std::string lowercase(std::string value)
 {
-  std::string contents {std::istreambuf_iterator<char>(stream), {}};
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return value;
+}
 
-  auto reader = std::unique_ptr<inlet::YAMLReader>(new inlet::YAMLReader());
-  reader->parseString(contents);
+std::string extensionOf(const std::string &filePath)
+{
+  const auto slash = filePath.find_last_of("/\\");
+  const auto dot = filePath.find_last_of('.');
+  if(dot == std::string::npos || (slash != std::string::npos && dot < slash))
+  {
+    return "";
+  }
+  return lowercase(filePath.substr(dot));
+}
 
+InputFormat inferInputFormat(const std::string &filePath)
+{
+  const auto extension = extensionOf(filePath);
+  if(extension == ".yaml" || extension == ".yml")
+  {
+    return InputFormat::YAML;
+  }
+  if(extension == ".lua")
+  {
+    return InputFormat::Lua;
+  }
+
+  throw KleeError(
+    {Path {filePath},
+     axom::fmt::format("Unsupported Klee input file extension '{}'. Supported extensions are "
+                       ".yaml, .yml, and .lua.",
+                       extension.empty() ? "<none>" : extension)});
+}
+
+std::unique_ptr<inlet::Reader> createReader(InputFormat format)
+{
+  switch(format)
+  {
+  case InputFormat::YAML:
+    return std::make_unique<inlet::YAMLReader>();
+  case InputFormat::Lua:
+#ifdef AXOM_USE_LUA
+    return std::make_unique<inlet::LuaReader>();
+#else
+    throw KleeError(
+      {Path {"<unknown path>"},
+       "Lua input decks require Axom configured with AXOM_ENABLE_LUA=ON and Sol library support. "
+       "Rebuild Axom with Lua enabled or convert deck to YAML."});
+#endif
+  }
+
+  throw KleeError({Path {"<unknown path>"}, "Unsupported Klee input format."});
+}
+
+void appendUnexpectedGlobalErrors(const inlet::Inlet &doc,
+                                  std::vector<inlet::VerificationError> &errors)
+{
+  std::unordered_set<std::string> unexpectedGlobals;
+  for(const auto &name : doc.unexpectedNames())
+  {
+    const auto slash = name.find('/');
+    unexpectedGlobals.insert(name.substr(0, slash));
+  }
+
+  for(const auto &name : unexpectedGlobals)
+  {
+    errors.push_back({Path {name},
+                      axom::fmt::format("Unexpected global variable '{}' in Lua input deck. Use "
+                                        "'local' for helper values and functions.",
+                                        name)});
+  }
+}
+
+ShapeSet readShapeSetFromReader(std::unique_ptr<inlet::Reader> reader, bool rejectUnexpectedGlobals)
+{
   sidre::DataStore dataStore;
   inlet::Inlet doc(std::move(reader), dataStore.getRoot());
   defineKleeSchema(doc);
   std::vector<inlet::VerificationError> errors;
-  if(!doc.verify(&errors))
+  bool verified = doc.verify(&errors);
+  if(rejectUnexpectedGlobals)
+  {
+    appendUnexpectedGlobalErrors(doc, errors);
+    verified = verified && errors.empty();
+  }
+  if(!verified)
   {
     if(errors.empty())
     {
@@ -328,12 +412,25 @@ ShapeSet readShapeSet(std::istream &stream)
   shapeSet.setShapes(convert(shapeData, dimensions, namedOperators));
   return shapeSet;
 }
+}  // namespace
+
+ShapeSet readShapeSet(std::istream &stream) { return readShapeSet(stream, InputFormat::YAML); }
+
+ShapeSet readShapeSet(std::istream &stream, InputFormat format)
+{
+  std::string contents {std::istreambuf_iterator<char>(stream), {}};
+
+  auto reader = createReader(format);
+  reader->parseString(contents);
+  return readShapeSetFromReader(std::move(reader), format == InputFormat::Lua);
+}
 
 ShapeSet readShapeSet(const std::string &filePath)
 {
-  std::ifstream fin {filePath};
-  auto shapeSet = readShapeSet(fin);
-  fin.close();
+  const auto format = inferInputFormat(filePath);
+  auto reader = createReader(format);
+  reader->parseFile(filePath);
+  auto shapeSet = readShapeSetFromReader(std::move(reader), format == InputFormat::Lua);
   shapeSet.setPath(filePath);
   return shapeSet;
 }

--- a/src/axom/klee/io/IO.cpp
+++ b/src/axom/klee/io/IO.cpp
@@ -205,6 +205,7 @@ void defineKleeSchema(inlet::Inlet &document)
  * \param fileDimensions the number of dimensions the file expects shapes to have
  * \param namedOperators any named operators that were parsed from the file
  * \return the geometry description for the shape
+ * \throws KleeError if the converted geometry does not match the expected dimensions
  */
 Geometry convert(GeometryData const &data,
                  Dimensions fileDimensions,
@@ -254,6 +255,8 @@ Geometry convert(GeometryData const &data,
  * \param fileDimensions the number of dimensions the file expects shapes to have
  * \param namedOperators any named operators that were parsed from the file
  * \return the shape as a Shape object
+ * \throws KleeError if the geometry data is invalid
+ * \throws std::logic_error if mutually exclusive material replacement lists are both populated
  */
 Shape convert(ShapeData const &data,
               Dimensions fileDimensions,
@@ -273,6 +276,8 @@ Shape convert(ShapeData const &data,
  * \param fileDimensions the number of dimensions the file expects shapes to have
  * \param namedOperators any named operators that were parsed from the file
  * \return the shape as a Shape object
+ * \throws KleeError if any shape's geometry data is invalid
+ * \throws std::logic_error if mutually exclusive material replacement lists are both populated
  */
 std::vector<Shape> convert(std::vector<ShapeData> const &shapeData,
                            Dimensions const &fileDimensions,
@@ -294,6 +299,7 @@ std::vector<Shape> convert(std::vector<ShapeData> const &shapeData,
  * \param startDimensions the number of dimensions that operators should
  * start at unless otherwise specified
  * \return all named operators read from the document
+ * \throws KleeError if named operator conversion fails
  */
 internal::NamedOperatorMap getNamedOperators(const inlet::Inlet &doc, Dimensions startDimensions)
 {
@@ -305,6 +311,13 @@ internal::NamedOperatorMap getNamedOperators(const inlet::Inlet &doc, Dimensions
   return internal::NamedOperatorMap {};
 }
 
+/**
+ * Infer the Klee input format from a file path.
+ *
+ * \param filePath the input deck path
+ * \return the inferred input format
+ * \throws KleeError if the file extension is not a supported Klee input extension
+ */
 InputFormat inferInputFormat(const std::string &filePath)
 {
   auto extension = utilities::filesystem::getFileExtension(filePath);
@@ -329,6 +342,13 @@ InputFormat inferInputFormat(const std::string &filePath)
                        extension)});
 }
 
+/**
+ * Create an Inlet reader for a Klee input format.
+ *
+ * \param format the input deck format to read
+ * \return a reader for \a format
+ * \throws KleeError if \a format is unsupported or Lua support was not enabled
+ */
 std::unique_ptr<inlet::Reader> createReader(InputFormat format)
 {
   switch(format)
@@ -362,6 +382,15 @@ const char *inputFormatName(InputFormat format)
   return "unknown";
 }
 
+/**
+ * Run a reader parse operation and convert parse failures to KleeError.
+ *
+ * \param parse callable that returns true on successful parse
+ * \param format the input deck format being parsed
+ * \param path the path to report in any generated error
+ * \param sourceDescription a human-readable description of the parsed source
+ * \throws KleeError if parsing fails or the reader throws while parsing
+ */
 template <typename Parse>
 void parseOrThrow(Parse &&parse,
                   InputFormat format,
@@ -404,6 +433,14 @@ void appendUnexpectedGlobalErrors(const inlet::Inlet &doc,
   }
 }
 
+/**
+ * Read a ShapeSet from a reader that has already parsed an input deck.
+ *
+ * \param reader the parsed Inlet reader
+ * \param rejectUnexpectedGlobals true if unexpected top-level Lua globals should be rejected
+ * \return the parsed and verified ShapeSet
+ * \throws KleeError if schema verification or semantic validation fails
+ */
 ShapeSet readShapeSetFromReader(std::unique_ptr<inlet::Reader> reader, bool rejectUnexpectedGlobals)
 {
   sidre::DataStore dataStore;

--- a/src/axom/klee/io/IO.hpp
+++ b/src/axom/klee/io/IO.hpp
@@ -44,11 +44,22 @@ ShapeSet readShapeSet(std::istream &stream, InputFormat format);
  * Read a ShapeSet from a specified file
  *
  * \param filePath the file from which to read the ShapeSet
- * \note The input format is inferred from the file extension.
+ * \note The input format is inferred from the file extension. Files without
+ * an extension are read as YAML for backward compatibility.
  * \return the ShapeSet read from the file
  * \throws runtime_error if the input is invalid
  */
 ShapeSet readShapeSet(const std::string &filePath);
+
+/**
+ * Read a ShapeSet from a specified file using an explicit input format.
+ *
+ * \param filePath the file from which to read the ShapeSet
+ * \param format the input deck format to use, regardless of the file extension
+ * \return the ShapeSet read from the file
+ * \throws runtime_error if the input is invalid
+ */
+ShapeSet readShapeSet(const std::string &filePath, InputFormat format);
 
 }  // namespace klee
 }  // namespace axom

--- a/src/axom/klee/io/IO.hpp
+++ b/src/axom/klee/io/IO.hpp
@@ -15,7 +15,7 @@ namespace axom
 {
 namespace klee
 {
-/// Input deck formats supported by Klee.
+/// Input file formats supported by Klee.
 enum class InputFormat
 {
   YAML,
@@ -35,7 +35,7 @@ ShapeSet readShapeSet(std::istream &stream);
  * Read a ShapeSet from an input stream.
  *
  * \param stream the stream from which to read the ShapeSet
- * \param format the input deck format to use
+ * \param format the input file format to use
  * \throws KleeError if parsing, schema verification, or semantic validation fails,
  *         or if the requested input format is unsupported by this build
  */
@@ -57,7 +57,7 @@ ShapeSet readShapeSet(const std::string &filePath);
  * Read a ShapeSet from a specified file using an explicit input format.
  *
  * \param filePath the file from which to read the ShapeSet
- * \param format the input deck format to use, regardless of the file extension
+ * \param format the input file format to use, regardless of the file extension
  * \return the ShapeSet read from the file
  * \throws KleeError if parsing, schema verification, or semantic validation fails,
  *         or if the requested input format is unsupported by this build

--- a/src/axom/klee/io/IO.hpp
+++ b/src/axom/klee/io/IO.hpp
@@ -27,7 +27,7 @@ enum class InputFormat
  *
  * \param stream the stream from which to read the ShapeSet
  * \note This overload reads YAML for backward compatibility.
- * \throws runtime_error if the input is invalid
+ * \throws KleeError if parsing, schema verification, or semantic validation fails
  */
 ShapeSet readShapeSet(std::istream &stream);
 
@@ -36,7 +36,8 @@ ShapeSet readShapeSet(std::istream &stream);
  *
  * \param stream the stream from which to read the ShapeSet
  * \param format the input deck format to use
- * \throws runtime_error if the input is invalid
+ * \throws KleeError if parsing, schema verification, or semantic validation fails,
+ *         or if the requested input format is unsupported by this build
  */
 ShapeSet readShapeSet(std::istream &stream, InputFormat format);
 
@@ -47,7 +48,8 @@ ShapeSet readShapeSet(std::istream &stream, InputFormat format);
  * \note The input format is inferred from the file extension. Files without
  * an extension are read as YAML for backward compatibility.
  * \return the ShapeSet read from the file
- * \throws runtime_error if the input is invalid
+ * \throws KleeError if the extension is unsupported or if parsing,
+ *         schema verification, or semantic validation fails
  */
 ShapeSet readShapeSet(const std::string &filePath);
 
@@ -57,7 +59,8 @@ ShapeSet readShapeSet(const std::string &filePath);
  * \param filePath the file from which to read the ShapeSet
  * \param format the input deck format to use, regardless of the file extension
  * \return the ShapeSet read from the file
- * \throws runtime_error if the input is invalid
+ * \throws KleeError if parsing, schema verification, or semantic validation fails,
+ *         or if the requested input format is unsupported by this build
  */
 ShapeSet readShapeSet(const std::string &filePath, InputFormat format);
 

--- a/src/axom/klee/io/IO.hpp
+++ b/src/axom/klee/io/IO.hpp
@@ -15,18 +15,36 @@ namespace axom
 {
 namespace klee
 {
+/// Input deck formats supported by Klee.
+enum class InputFormat
+{
+  YAML,
+  Lua
+};
+
 /**
  * Read a ShapeSet from an input stream.
  *
  * \param stream the stream from which to read the ShapeSet
+ * \note This overload reads YAML for backward compatibility.
  * \throws runtime_error if the input is invalid
  */
 ShapeSet readShapeSet(std::istream &stream);
 
 /**
+ * Read a ShapeSet from an input stream.
+ *
+ * \param stream the stream from which to read the ShapeSet
+ * \param format the input deck format to use
+ * \throws runtime_error if the input is invalid
+ */
+ShapeSet readShapeSet(std::istream &stream, InputFormat format);
+
+/**
  * Read a ShapeSet from a specified file
  *
  * \param filePath the file from which to read the ShapeSet
+ * \note The input format is inferred from the file extension.
  * \return the ShapeSet read from the file
  * \throws runtime_error if the input is invalid
  */

--- a/src/axom/klee/io/IOUtil.hpp
+++ b/src/axom/klee/io/IOUtil.hpp
@@ -36,6 +36,7 @@ namespace internal
  * @param expectedDims the expected dimensionality of the array
  * @param fieldName the name of the field (used for error reporting)
  * @return the field as a std::vector<double>
+ * @throws KleeError if the field does not have \a expectedDims entries
  */
 std::vector<double> toDoubleVector(inlet::Proxy const &field,
                                    Dimensions expectedDims,
@@ -49,6 +50,7 @@ std::vector<double> toDoubleVector(inlet::Proxy const &field,
  * @param fieldName the name of the field
  * @param expectedDims the expected dimensionality of the point
  * @return the field as a primal::Point3D
+ * @throws KleeError if the field does not have \a expectedDims entries
  */
 primal::Point3D toPoint(inlet::Container const &parent, char const *fieldName, Dimensions expectedDims);
 
@@ -61,6 +63,7 @@ primal::Point3D toPoint(inlet::Container const &parent, char const *fieldName, D
  * @param expectedDims the expected dimensionality of the point
  * @param defaultValue the default value of the field if it is not present
  * @return the field as a primal::Point3D
+ * @throws KleeError if the field is present and does not have \a expectedDims entries
  */
 primal::Point3D toPoint(inlet::Container const &parent,
                         char const *fieldName,
@@ -75,6 +78,7 @@ primal::Point3D toPoint(inlet::Container const &parent,
  * @param fieldName the name of the field
  * @param expectedDims the expected dimensionality of the vector
  * @return the field as a primal::Vector3D
+ * @throws KleeError if the field does not have \a expectedDims entries
  */
 primal::Vector3D toVector(inlet::Container const &parent,
                           char const *fieldName,
@@ -90,6 +94,7 @@ primal::Vector3D toVector(inlet::Container const &parent,
  * @param expectedDims the expected dimensionality of the vector
  * @param defaultValue the default value of the field if it is not present
  * @return the field as a primal::Vector3D
+ * @throws KleeError if the field is present and does not have \a expectedDims entries
  */
 primal::Vector3D toVector(inlet::Container const &parent,
                           char const *fieldName,

--- a/src/axom/klee/tests/KleeTestUtils.hpp
+++ b/src/axom/klee/tests/KleeTestUtils.hpp
@@ -34,6 +34,7 @@ class MockOperator : public GeometryOperator
 {
 public:
   using GeometryOperator::GeometryOperator;
+  MOCK_METHOD(std::string, getName, (), (const));
   MOCK_METHOD(TransformableGeometryProperties, getEndProperties, (), (const));
   MOCK_METHOD(void, accept, (GeometryOperatorVisitor &), (const));
   TransformableGeometryProperties getBaseEndProperties() const

--- a/src/axom/klee/tests/klee_geometry.cpp
+++ b/src/axom/klee/tests/klee_geometry.cpp
@@ -5,8 +5,11 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "axom/klee/Geometry.hpp"
+#include "axom/klee/GeometryOperators.hpp"
+#include "axom/klee/tests/KleeMatchers.hpp"
 #include "axom/klee/tests/KleeTestUtils.hpp"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 #include <memory>
@@ -15,6 +18,7 @@ namespace axom
 {
 namespace klee
 {
+using test::AlmostEqMatrix;
 using test::MockOperator;
 using ::testing::Return;
 
@@ -51,6 +55,18 @@ TEST(GeometryTest, emptyPath)
   Geometry geometry {startProperties, "none", "", nullptr};
 
   EXPECT_FALSE(geometry.hasGeometry());
+}
+
+TEST(GeometryTest, getTransform_sliceOperator)
+{
+  TransformableGeometryProperties startProperties {Dimensions::Three, LengthUnit::cm};
+  auto slice = std::make_shared<SliceOperator>(primal::Point3D {10, 20, 30},
+                                               primal::Vector3D {1, 4, 8},
+                                               primal::Vector3D {-4, 1, 0},
+                                               startProperties);
+  Geometry geometry {startProperties, "test format", "test path", slice};
+
+  EXPECT_THAT(geometry.getTransform(), AlmostEqMatrix(slice->toMatrix()));
 }
 
 }  // namespace klee

--- a/src/axom/klee/tests/klee_geometry_operators.cpp
+++ b/src/axom/klee/tests/klee_geometry_operators.cpp
@@ -110,6 +110,25 @@ TEST(GeometryOperator, getProperties)
   EXPECT_EQ(constructorProps.units, endProperties.units);
 }
 
+TEST(GeometryOperator, names)
+{
+  TransformableGeometryProperties props {Dimensions::Three, LengthUnit::cm};
+
+  CompositeOperator composite {props};
+  Translation translation {{1, 2, 3}, props};
+  Rotation rotation {45, {0, 0, 0}, {0, 0, 1}, props};
+  Scale scale {1, 2, 3, props};
+  UnitConverter converter {LengthUnit::m, props};
+  SliceOperator slice {{0, 0, 0}, {0, 0, 1}, {0, 1, 0}, props};
+
+  EXPECT_EQ("composite", composite.getName());
+  EXPECT_EQ("translate", translation.getName());
+  EXPECT_EQ("rotate", rotation.getName());
+  EXPECT_EQ("scale", scale.getName());
+  EXPECT_EQ("convert_units_to", converter.getName());
+  EXPECT_EQ("slice", slice.getName());
+}
+
 TEST(Translation, basics)
 {
   Vector3D offset {10, 20, 30};

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -315,6 +315,38 @@ TEST(IOTest, readShapeSet_explicitYamlStreamFormat)
   EXPECT_EQ("wheel", shapeSet.getShapes()[0].getName());
 }
 
+TEST(IOTest, readShapeSet_emptyStreamReportsParseFailure)
+{
+  try
+  {
+    readShapeSetFromString("", InputFormat::YAML);
+    FAIL() << "Should have thrown";
+  }
+  catch(const KleeError &error)
+  {
+    ASSERT_EQ(1u, error.getErrors().size());
+    EXPECT_EQ(axom::Path {"<stream>"}, error.getErrors()[0].path);
+    EXPECT_STREQ("Failed to parse YAML Klee input from stream.", error.what());
+  }
+}
+
+TEST(IOTest, readShapeSet_missingFileReportsParseFailure)
+{
+  const std::string fileName = "missingKleeInput.yaml";
+  try
+  {
+    klee::readShapeSet(fileName);
+    FAIL() << "Should have thrown";
+  }
+  catch(const KleeError &error)
+  {
+    ASSERT_EQ(1u, error.getErrors().size());
+    EXPECT_EQ(axom::Path {fileName}, error.getErrors()[0].path);
+    EXPECT_STREQ("Failed to parse YAML Klee input from file 'missingKleeInput.yaml'.",
+                 error.what());
+  }
+}
+
 TEST(IOTest, readShapeSet_unsupportedFileExtension)
 {
   try
@@ -368,6 +400,21 @@ TEST(IOTest, readShapeSet_luaUnavailableDiagnostic)
 #endif
 
 #ifdef AXOM_USE_LUA
+TEST(IOTest, readShapeSet_malformedLuaReportsParseFailure)
+{
+  try
+  {
+    readShapeSetFromString("dimensions =", InputFormat::Lua);
+    FAIL() << "Should have thrown";
+  }
+  catch(const KleeError &error)
+  {
+    ASSERT_EQ(1u, error.getErrors().size());
+    EXPECT_EQ(axom::Path {"<stream>"}, error.getErrors()[0].path);
+    EXPECT_THAT(error.what(), HasSubstr("Failed to parse Lua Klee input from stream"));
+  }
+}
+
 TEST(IOTest, readShapeSet_luaStreamMinimalShapeList)
 {
   auto shapeSet = readShapeSetFromString(R"(

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -438,8 +438,8 @@ TEST(IOTest, readShapeSet_luaUnavailableDiagnostic)
   catch(const KleeError &err)
   {
     EXPECT_STREQ(
-      "Lua input decks require Axom configured with AXOM_ENABLE_LUA=ON and Sol library "
-      "support. Rebuild Axom with Lua enabled or convert deck to YAML.",
+      "Lua input files require Axom configured with AXOM_ENABLE_LUA=ON and Sol library "
+      "support. Rebuild Axom with Lua enabled or convert the file to YAML.",
       err.what());
   }
 }

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -718,7 +718,9 @@ TEST(IOTest, readShapeSet_luaUnexpectedGlobalDiagnostic)
   {
     readShapeSetFromString(R"(
       dimensions = 2
-      unexpected_global = 42
+      unexpected_global = {
+        nested_value = 42
+      }
       shapes = {}
     )",
                            InputFormat::Lua);
@@ -726,8 +728,35 @@ TEST(IOTest, readShapeSet_luaUnexpectedGlobalDiagnostic)
   }
   catch(const KleeError &err)
   {
+    ASSERT_EQ(1u, err.getErrors().size());
+    EXPECT_EQ(axom::Path {"unexpected_global"}, err.getErrors()[0].path);
     EXPECT_THAT(err.what(), HasSubstr("unexpected_global"));
   }
+}
+
+TEST(IOTest, readShapeSet_luaNestedUnexpectedFieldsMatchYamlValidation)
+{
+  auto shapeSet = readShapeSetFromString(R"(
+    dimensions = 2
+    shapes = {
+      {
+        name = "wheel",
+        material = "steel",
+        extra_shape_value = true,
+        geometry = {
+          format = "stl",
+          path = "wheel.stl",
+          extra_geometry_table = {
+            nested_value = 42
+          }
+        }
+      }
+    }
+  )",
+                                         InputFormat::Lua);
+
+  ASSERT_EQ(1u, shapeSet.getShapes().size());
+  EXPECT_EQ("wheel", shapeSet.getShapes()[0].getName());
 }
 #endif
 

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -389,8 +389,7 @@ TEST(IOTest, readShapeSet_missingFileReportsParseFailure)
   {
     ASSERT_EQ(1u, error.getErrors().size());
     EXPECT_EQ(axom::Path {fileName}, error.getErrors()[0].path);
-    EXPECT_STREQ("Failed to parse YAML Klee input from file 'missingKleeInput.yaml'.",
-                 error.what());
+    EXPECT_STREQ("Failed to parse YAML Klee input from file 'missingKleeInput.yaml'.", error.what());
   }
 }
 

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -9,6 +9,7 @@
 #include "axom/klee/KleeError.hpp"
 
 #include "axom/config.hpp"
+#include "axom/core/utilities/FileUtilities.hpp"
 #include "axom/slic.hpp"
 
 #include "KleeMatchers.hpp"
@@ -315,6 +316,52 @@ TEST(IOTest, readShapeSet_explicitYamlStreamFormat)
   EXPECT_EQ("wheel", shapeSet.getShapes()[0].getName());
 }
 
+TEST(IOTest, readShapeSet_fileWithoutExtensionDefaultsToYaml)
+{
+  const std::string fileName = "missingKleeInputWithoutExtension";
+  ASSERT_FALSE(axom::utilities::filesystem::pathExists(fileName));
+  try
+  {
+    klee::readShapeSet(fileName);
+    FAIL() << "Should have thrown";
+  }
+  catch(const KleeError &error)
+  {
+    ASSERT_EQ(1u, error.getErrors().size());
+    EXPECT_EQ(axom::Path {fileName}, error.getErrors()[0].path);
+    EXPECT_THAT(error.what(), HasSubstr("Failed to parse YAML Klee input"));
+  }
+}
+
+TEST(IOTest, readShapeSet_explicitYamlOverridesFileExtension)
+{
+  axom::utilities::filesystem::TempFile input {"explicitYaml", "lua"};
+  input.write(R"(
+    dimensions: 2
+    shapes: [])");
+
+  auto shapeSet = klee::readShapeSet(input.getPath(), InputFormat::YAML);
+  EXPECT_EQ(Dimensions::Two, shapeSet.getDimensions());
+  EXPECT_EQ(input.getPath(), shapeSet.getPath());
+}
+
+TEST(IOTest, readShapeSet_explicitFormatReportsParseFailure)
+{
+  axom::utilities::filesystem::TempFile input {"invalidExplicitYaml", "lua"};
+  input.write("dimensions: [");
+  try
+  {
+    klee::readShapeSet(input.getPath(), InputFormat::YAML);
+    FAIL() << "Should have thrown";
+  }
+  catch(const KleeError &error)
+  {
+    ASSERT_EQ(1u, error.getErrors().size());
+    EXPECT_EQ(axom::Path {input.getPath()}, error.getErrors()[0].path);
+    EXPECT_THAT(error.what(), HasSubstr("Failed to parse YAML Klee input"));
+  }
+}
+
 TEST(IOTest, readShapeSet_emptyStreamReportsParseFailure)
 {
   try
@@ -400,6 +447,18 @@ TEST(IOTest, readShapeSet_luaUnavailableDiagnostic)
 #endif
 
 #ifdef AXOM_USE_LUA
+TEST(IOTest, readShapeSet_explicitLuaOverridesFileExtension)
+{
+  axom::utilities::filesystem::TempFile input {"explicitLua", "yaml"};
+  input.write(R"(
+    dimensions = 2
+    shapes = {})");
+
+  auto shapeSet = klee::readShapeSet(input.getPath(), InputFormat::Lua);
+  EXPECT_EQ(Dimensions::Two, shapeSet.getDimensions());
+  EXPECT_EQ(input.getPath(), shapeSet.getPath());
+}
+
 TEST(IOTest, readShapeSet_malformedLuaReportsParseFailure)
 {
   try

--- a/src/axom/klee/tests/klee_io.cpp
+++ b/src/axom/klee/tests/klee_io.cpp
@@ -8,6 +8,7 @@
 #include "axom/klee/GeometryOperators.hpp"
 #include "axom/klee/KleeError.hpp"
 
+#include "axom/config.hpp"
 #include "axom/slic.hpp"
 
 #include "KleeMatchers.hpp"
@@ -24,6 +25,7 @@ namespace primal = axom::primal;
 
 using klee::CompositeOperator;
 using klee::Dimensions;
+using klee::InputFormat;
 using klee::KleeError;
 using klee::LengthUnit;
 using klee::Rotation;
@@ -46,6 +48,12 @@ ShapeSet readShapeSetFromString(const std::string &input)
 {
   std::istringstream istream(input);
   return klee::readShapeSet(istream);
+}
+
+ShapeSet readShapeSetFromString(const std::string &input, InputFormat format)
+{
+  std::istringstream istream(input);
+  return klee::readShapeSet(istream, format);
 }
 }  // end namespace
 
@@ -289,6 +297,392 @@ TEST(IOTest, readShapeSet_file)
   EXPECT_EQ(1u, shapeSet.getShapes().size());
   EXPECT_EQ("testFile.yaml", shapeSet.getPath());
 }
+
+TEST(IOTest, readShapeSet_explicitYamlStreamFormat)
+{
+  auto shapeSet = readShapeSetFromString(R"(
+    dimensions: 2
+    shapes:
+      - name: wheel
+        material: steel
+        geometry:
+          format: test_format
+          path: path/to/file.format
+  )",
+                                         InputFormat::YAML);
+
+  ASSERT_EQ(1u, shapeSet.getShapes().size());
+  EXPECT_EQ("wheel", shapeSet.getShapes()[0].getName());
+}
+
+TEST(IOTest, readShapeSet_unsupportedFileExtension)
+{
+  try
+  {
+    klee::readShapeSet("testFile.json");
+    FAIL() << "Should have thrown";
+  }
+  catch(const KleeError &err)
+  {
+    EXPECT_THAT(err.what(), HasSubstr("Unsupported Klee input file extension '.json'"));
+    EXPECT_THAT(err.what(), HasSubstr(".yaml, .yml, and .lua"));
+  }
+}
+
+TEST(IOTest, readShapeSet_streamDefaultsToYaml)
+{
+  try
+  {
+    readShapeSetFromString(R"(
+      dimensions = 2
+      shapes = {}
+    )");
+    FAIL() << "Should have thrown";
+  }
+  catch(const KleeError &err)
+  {
+    EXPECT_THAT(err.what(), HasSubstr("dimensions"));
+  }
+}
+
+#ifndef AXOM_USE_LUA
+TEST(IOTest, readShapeSet_luaUnavailableDiagnostic)
+{
+  try
+  {
+    readShapeSetFromString(R"(
+      dimensions = 2
+      shapes = {}
+    )",
+                           InputFormat::Lua);
+    FAIL() << "Should have thrown";
+  }
+  catch(const KleeError &err)
+  {
+    EXPECT_STREQ(
+      "Lua input decks require Axom configured with AXOM_ENABLE_LUA=ON and Sol library "
+      "support. Rebuild Axom with Lua enabled or convert deck to YAML.",
+      err.what());
+  }
+}
+#endif
+
+#ifdef AXOM_USE_LUA
+TEST(IOTest, readShapeSet_luaStreamMinimalShapeList)
+{
+  auto shapeSet = readShapeSetFromString(R"(
+    dimensions = 2
+    shapes = {
+      {
+        name = "wheel",
+        material = "steel",
+        geometry = {
+          format = "test_format",
+          path = "path/to/file.format"
+        }
+      }
+    }
+  )",
+                                         InputFormat::Lua);
+
+  ASSERT_EQ(1u, shapeSet.getShapes().size());
+  const auto &shape = shapeSet.getShapes()[0];
+  EXPECT_EQ("wheel", shape.getName());
+  EXPECT_EQ("steel", shape.getMaterial());
+  EXPECT_EQ("test_format", shape.getGeometry().getFormat());
+  EXPECT_EQ("path/to/file.format", shape.getGeometry().getPath());
+  EXPECT_EQ(Dimensions::Two, shapeSet.getDimensions());
+}
+
+TEST(IOTest, readShapeSet_luaFileExtension)
+{
+  std::string fileName = "testFile.lua";
+
+  std::string fileContents = R"(
+    dimensions = 2
+    shapes = {
+      {
+        name = "wheel",
+        material = "steel",
+        geometry = {
+          format = "test_format",
+          path = "relative/path.format"
+        }
+      }
+    }
+  )";
+  std::ofstream fout {fileName};
+  fout << fileContents;
+  fout.close();
+
+  auto shapeSet = klee::readShapeSet(fileName);
+  ASSERT_EQ(1u, shapeSet.getShapes().size());
+  EXPECT_EQ("testFile.lua", shapeSet.getPath());
+  EXPECT_EQ("relative/path.format", shapeSet.getShapes()[0].getGeometry().getPath());
+}
+
+TEST(IOTest, readShapeSet_luaReplacementRules)
+{
+  auto replaces = readShapeSetFromString(R"(
+    dimensions = 2
+    shapes = {
+      {
+        name = "wheel",
+        material = "steel",
+        replaces = {"mat1", "mat2"},
+        geometry = {
+          format = "test_format",
+          path = "path/to/file.format"
+        }
+      }
+    }
+  )",
+                                         InputFormat::Lua);
+  ASSERT_EQ(1u, replaces.getShapes().size());
+  EXPECT_TRUE(replaces.getShapes()[0].replaces("mat1"));
+  EXPECT_FALSE(replaces.getShapes()[0].replaces("mat3"));
+
+  auto doesNotReplace = readShapeSetFromString(R"(
+    dimensions = 2
+    shapes = {
+      {
+        name = "wheel",
+        material = "steel",
+        does_not_replace = {"mat1", "mat2"},
+        geometry = {
+          format = "test_format",
+          path = "path/to/file.format"
+        }
+      }
+    }
+  )",
+                                               InputFormat::Lua);
+  ASSERT_EQ(1u, doesNotReplace.getShapes().size());
+  EXPECT_FALSE(doesNotReplace.getShapes()[0].replaces("mat1"));
+  EXPECT_TRUE(doesNotReplace.getShapes()[0].replaces("mat3"));
+}
+
+TEST(IOTest, readShapeSet_luaGeometryOperators)
+{
+  auto shapeSet = readShapeSetFromString(R"(
+    dimensions = 3
+    shapes = {
+      {
+        name = "windshield",
+        material = "glass",
+        geometry = {
+          format = "stl",
+          path = "windshield.stl",
+          start_units = "m",
+          end_units = "cm",
+          operators = {
+            { rotate = 90, axis = {0, 1, 0}, center = {0, 0, -10} },
+            { translate = {10, 20, 30} },
+            { scale = {1.5, 2.5, 3.5}, center = {1, 2, 3} },
+            { convert_units_to = "cm" }
+          }
+        }
+      },
+      {
+        name = "slice",
+        material = "steel",
+        geometry = {
+          format = "stl",
+          path = "slice.stl",
+          start_dimensions = 3,
+          dimensions = 2,
+          units = "cm",
+          operators = {
+            { slice = { x = 10 } }
+          }
+        }
+      }
+    }
+  )",
+                                         InputFormat::Lua);
+
+  ASSERT_EQ(2u, shapeSet.getShapes().size());
+  const auto &geometryOperator = shapeSet.getShapes()[0].getGeometry().getGeometryOperator();
+  ASSERT_TRUE(geometryOperator);
+  auto composite = std::dynamic_pointer_cast<const CompositeOperator>(geometryOperator);
+  ASSERT_TRUE(composite);
+  ASSERT_EQ(4u, composite->getOperators().size());
+
+  auto rotation = dynamic_cast<const Rotation *>(composite->getOperators()[0].get());
+  ASSERT_NE(rotation, nullptr);
+  EXPECT_EQ(rotation->getAngle(), 90);
+
+  auto translation = dynamic_cast<const Translation *>(composite->getOperators()[1].get());
+  ASSERT_NE(translation, nullptr);
+  EXPECT_THAT(translation->getOffset(), AlmostEqVector(Vector3D {10, 20, 30}));
+
+  auto scale = dynamic_cast<const Scale *>(composite->getOperators()[2].get());
+  ASSERT_NE(scale, nullptr);
+  EXPECT_DOUBLE_EQ(1.5, scale->getXFactor());
+  EXPECT_DOUBLE_EQ(2.5, scale->getYFactor());
+  EXPECT_DOUBLE_EQ(3.5, scale->getZFactor());
+  EXPECT_THAT(scale->getCenter(), AlmostEqPoint(Point3D {1, 2, 3}));
+  EXPECT_EQ(LengthUnit::cm, composite->getEndProperties().units);
+
+  auto sliceComposite = std::dynamic_pointer_cast<const CompositeOperator>(
+    shapeSet.getShapes()[1].getGeometry().getGeometryOperator());
+  ASSERT_TRUE(sliceComposite);
+  ASSERT_EQ(1u, sliceComposite->getOperators().size());
+  EXPECT_TRUE(std::dynamic_pointer_cast<const SliceOperator>(sliceComposite->getOperators()[0]));
+}
+
+TEST(IOTest, readShapeSet_luaNamedGeometryOperatorsWithNestedRef)
+{
+  auto shapeSet = readShapeSetFromString(R"(
+    dimensions = 2
+
+    shapes = {
+      {
+        name = "wheel",
+        material = "steel",
+        geometry = {
+          format = "test_format",
+          path = "path/to/file.format",
+          units = "m",
+          operators = {
+            { ref = "outer_operation" }
+          }
+        }
+      }
+    }
+
+    named_operators = {
+      {
+        name = "inner_operation",
+        units = "m",
+        value = {
+          { rotate = 90 }
+        }
+      },
+      {
+        name = "outer_operation",
+        units = "m",
+        value = {
+          { ref = "inner_operation" },
+          { translate = {10, 20} }
+        }
+      }
+    }
+  )",
+                                         InputFormat::Lua);
+
+  ASSERT_EQ(1u, shapeSet.getShapes().size());
+  auto composite = std::dynamic_pointer_cast<const CompositeOperator>(
+    shapeSet.getShapes()[0].getGeometry().getGeometryOperator());
+  ASSERT_TRUE(composite);
+  ASSERT_EQ(1u, composite->getOperators().size());
+  auto referenced = dynamic_cast<const CompositeOperator *>(composite->getOperators()[0].get());
+  ASSERT_NE(referenced, nullptr);
+  ASSERT_EQ(2u, referenced->getOperators().size());
+  auto nested = dynamic_cast<const CompositeOperator *>(referenced->getOperators()[0].get());
+  ASSERT_NE(nested, nullptr);
+  EXPECT_EQ(1u, nested->getOperators().size());
+  auto translation = dynamic_cast<const Translation *>(referenced->getOperators()[1].get());
+  ASSERT_NE(translation, nullptr);
+  EXPECT_THAT(translation->getOffset(), AlmostEqVector(Vector3D {10, 20, 0}));
+}
+
+TEST(IOTest, readShapeSet_luaDifferentDimensions)
+{
+  auto shapeSet = readShapeSetFromString(R"(
+    dimensions = 2
+    shapes = {
+      {
+        name = "flat",
+        material = "steel",
+        geometry = {
+          format = "stl",
+          path = "flat.stl",
+          dimensions = 3,
+          units = "cm"
+        }
+      },
+      {
+        name = "sliced",
+        material = "glass",
+        geometry = {
+          format = "stl",
+          path = "sliced.stl",
+          start_dimensions = 3,
+          dimensions = 2,
+          units = "cm",
+          operators = {
+            { slice = { z = 0 } }
+          }
+        }
+      }
+    }
+  )",
+                                         InputFormat::Lua);
+
+  ASSERT_EQ(2u, shapeSet.getShapes().size());
+  EXPECT_EQ(Dimensions::Three, shapeSet.getShapes()[0].getGeometry().getInputDimensions());
+  EXPECT_EQ(Dimensions::Three, shapeSet.getShapes()[0].getGeometry().getOutputDimensions());
+  EXPECT_EQ(Dimensions::Three, shapeSet.getShapes()[1].getGeometry().getInputDimensions());
+  EXPECT_EQ(Dimensions::Two, shapeSet.getShapes()[1].getGeometry().getOutputDimensions());
+}
+
+TEST(IOTest, readShapeSet_luaGeneratedOrdinaryTableValues)
+{
+  auto shapeSet = readShapeSetFromString(R"(
+    local dim = 2
+    local r = 4.0
+    local z = 8.0
+    local x = 1.0
+    local y = 2.0
+
+    dimensions = dim
+
+    shapes = {
+      {
+        name = "part",
+        material = "steel",
+        geometry = {
+          format = "stl",
+          path = "part.stl",
+          units = "cm",
+          operators = {
+            { translate = (dim == 2) and {r, z} or {x, y, z} }
+          }
+        }
+      }
+    }
+  )",
+                                         InputFormat::Lua);
+
+  ASSERT_EQ(1u, shapeSet.getShapes().size());
+  auto composite = std::dynamic_pointer_cast<const CompositeOperator>(
+    shapeSet.getShapes()[0].getGeometry().getGeometryOperator());
+  ASSERT_TRUE(composite);
+  ASSERT_EQ(1u, composite->getOperators().size());
+  auto translation = dynamic_cast<const Translation *>(composite->getOperators()[0].get());
+  ASSERT_NE(translation, nullptr);
+  EXPECT_THAT(translation->getOffset(), AlmostEqVector(Vector3D {4, 8, 0}));
+}
+
+TEST(IOTest, readShapeSet_luaUnexpectedGlobalDiagnostic)
+{
+  try
+  {
+    readShapeSetFromString(R"(
+      dimensions = 2
+      unexpected_global = 42
+      shapes = {}
+    )",
+                           InputFormat::Lua);
+    FAIL() << "Should have thrown";
+  }
+  catch(const KleeError &err)
+  {
+    EXPECT_THAT(err.what(), HasSubstr("unexpected_global"));
+  }
+}
+#endif
 
 TEST(IOTest, readShapeSet_shapeWithReplacesAndDoesNotReplaceLists)
 {

--- a/src/axom/quest/DiscreteShape.cpp
+++ b/src/axom/quest/DiscreteShape.cpp
@@ -8,7 +8,7 @@
 #include "axom/quest/Discretize.hpp"
 #include "axom/mint/mesh/UnstructuredMesh.hpp"
 #include "axom/klee/GeometryOperators.hpp"
-#include "axom/core/utilities/StringUtilities.hpp"
+#include "axom/core/utilities/FileUtilities.hpp"
 #include "axom/quest/interface/internal/QuestHelpers.hpp"
 #ifdef AXOM_USE_C2C
   #include "axom/quest/io/C2CReader.hpp"
@@ -105,12 +105,13 @@ std::shared_ptr<mint::Mesh> DiscreteShape::createMeshRepresentation()
 
   std::string shapePath =
     axom::utilities::filesystem::prefixRelativePath(m_shape.getGeometry().getPath(), m_prefixPath);
+  const std::string fileExtension = utilities::filesystem::getFileExtension(shapePath);
   SLIC_INFO_ROOT("Reading file: " << shapePath << "...");
 
   // Initialize revolved volume.
   m_revolvedVolume = 0.;
 
-  if(utilities::string::endsWith(shapePath, ".stl"))
+  if(fileExtension == ".stl")
   {
     SLIC_ERROR_ROOT_IF(file_format != "stl",
                        axom::fmt::format(" '{}' format requires .stl file type", file_format));
@@ -130,7 +131,7 @@ std::shared_ptr<mint::Mesh> DiscreteShape::createMeshRepresentation()
     // Transform the coordinates of the linearized mesh.
     applyTransforms();
   }
-  else if(utilities::string::endsWith(shapePath, ".proe"))
+  else if(fileExtension == ".proe")
   {
     SLIC_ERROR_ROOT_IF(file_format != "proe",
                        axom::fmt::format(" '{}' format requires .proe file type", file_format));
@@ -216,7 +217,7 @@ std::shared_ptr<mint::Mesh> DiscreteShape::createMeshRepresentation()
   }
 #endif
 #ifdef AXOM_USE_MFEM
-  else if(utilities::string::endsWith(shapePath, ".mesh"))
+  else if(fileExtension == ".mesh")
   {
     SLIC_ERROR_ROOT_IF(file_format != "mfem",
                        axom::fmt::format(" '{}' format requires .mesh file extension", file_format));

--- a/src/axom/quest/DiscreteShape.cpp
+++ b/src/axom/quest/DiscreteShape.cpp
@@ -15,7 +15,6 @@
 #endif
 
 #include <algorithm>
-#include <stdexcept>
 #include <utility>
 
 namespace axom
@@ -621,17 +620,21 @@ void DiscreteShape::createRepresentationOfSOR()
 
 void DiscreteShape::applyTransforms()
 {
-  numerics::Matrix<double> transformation = getTransforms();
+  if(!m_shape.getGeometry().getGeometryOperator())
+  {
+    return;
+  }
 
-  // Apply transformation to coordinates of each vertex in mesh
+  const int spaceDim = m_meshRep->getDimension();
+  const int numSurfaceVertices = m_meshRep->getNumberOfNodes();
+  double* x = m_meshRep->getCoordinateArray(mint::X_COORDINATE);
+  double* y = m_meshRep->getCoordinateArray(mint::Y_COORDINATE);
+  double* z = spaceDim > 2 ? m_meshRep->getCoordinateArray(mint::Z_COORDINATE) : nullptr;
+
+  numerics::Matrix<double> transformation = getTransforms();
+  // Apply transformation to coordinates of each vertex in mesh.
   if(!transformation.isIdentity())
   {
-    const int spaceDim = m_meshRep->getDimension();
-    const int numSurfaceVertices = m_meshRep->getNumberOfNodes();
-    double* x = m_meshRep->getCoordinateArray(mint::X_COORDINATE);
-    double* y = m_meshRep->getCoordinateArray(mint::Y_COORDINATE);
-    double* z = spaceDim > 2 ? m_meshRep->getCoordinateArray(mint::Z_COORDINATE) : nullptr;
-
     double xformed[4];
     for(int i = 0; i < numSurfaceVertices; ++i)
     {

--- a/src/axom/quest/examples/containment_driver.cpp
+++ b/src/axom/quest/examples/containment_driver.cpp
@@ -519,8 +519,7 @@ public:
 
   bool isInput2D() const
   {
-    using axom::utilities::string::endsWith;
-    return endsWith(inputFile, ".contour");
+    return axom::utilities::filesystem::getFileExtension(inputFile) == ".contour";
   }
 
   bool isVerbose() const { return m_verboseOutput; }

--- a/src/axom/quest/examples/quest_inout_interface.cpp
+++ b/src/axom/quest/examples/quest_inout_interface.cpp
@@ -203,8 +203,8 @@ int main(int argc, char** argv)
   }
 
   // Note: contour files are only supported when Axom is configured with C2C
-  using axom::utilities::string::endsWith;
-  const int dim = endsWith(fileName, ".contour") ? 2 : 3;
+  const int dim =
+    axom::utilities::filesystem::getFileExtension(fileName) == ".contour" ? 2 : 3;
   rc = quest::inout_set_dimension(dim);
   if(rc != quest::QUEST_INOUT_SUCCESS)
   {

--- a/src/axom/quest/examples/quest_inout_interface.cpp
+++ b/src/axom/quest/examples/quest_inout_interface.cpp
@@ -203,8 +203,7 @@ int main(int argc, char** argv)
   }
 
   // Note: contour files are only supported when Axom is configured with C2C
-  const int dim =
-    axom::utilities::filesystem::getFileExtension(fileName) == ".contour" ? 2 : 3;
+  const int dim = axom::utilities::filesystem::getFileExtension(fileName) == ".contour" ? 2 : 3;
   rc = quest::inout_set_dimension(dim);
   if(rc != quest::QUEST_INOUT_SUCCESS)
   {

--- a/src/axom/quest/examples/quest_winding_number_3d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_3d.cpp
@@ -25,7 +25,7 @@
 #include "axom/CLI11.hpp"
 #include "axom/fmt.hpp"
 
-#include "axom/core/utilities/StringUtilities.hpp"
+#include "axom/core/utilities/FileUtilities.hpp"
 
 #include "mfem.hpp"
 
@@ -332,8 +332,10 @@ int main(int argc, char** argv)
   // Declare possible geometry input types
   axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE> tri_mesh(3, axom::mint::TRIANGLE);
   axom::Array<NURBSPatch3D> patches;
+  const std::string fileExtension =
+    axom::utilities::filesystem::getFileExtension(input.inputFile);
 
-  if(axom::utilities::string::endsWith(input.inputFile, ".stl"))
+  if(fileExtension == ".stl")
   {
     AXOM_ANNOTATE_SCOPE("read_stl");
 
@@ -360,7 +362,7 @@ int main(int argc, char** argv)
     SLIC_INFO(
       axom::fmt::format(axom::utilities::locale(), "Loaded {} triangles", stl_reader.getNumFaces()));
   }
-  else if(axom::utilities::string::endsWith(input.inputFile, ".step"))
+  else if(fileExtension == ".step")
   {
     AXOM_ANNOTATE_SCOPE("read_step");
 

--- a/src/axom/quest/examples/quest_winding_number_3d.cpp
+++ b/src/axom/quest/examples/quest_winding_number_3d.cpp
@@ -332,8 +332,7 @@ int main(int argc, char** argv)
   // Declare possible geometry input types
   axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE> tri_mesh(3, axom::mint::TRIANGLE);
   axom::Array<NURBSPatch3D> patches;
-  const std::string fileExtension =
-    axom::utilities::filesystem::getFileExtension(input.inputFile);
+  const std::string fileExtension = axom::utilities::filesystem::getFileExtension(input.inputFile);
 
   if(fileExtension == ".stl")
   {

--- a/src/axom/quest/tests/quest_regression.cpp
+++ b/src/axom/quest/tests/quest_regression.cpp
@@ -101,8 +101,8 @@ int numOpenMPThreads()
 
 std::string withoutExtension(const std::string& filename)
 {
-  const auto extPos = filename.find_last_of('.');
-  return extPos == std::string::npos ? filename : filename.substr(0, extPos);
+  const std::string extension = axom::utilities::filesystem::getFileExtension(filename);
+  return extension.empty() ? filename : filename.substr(0, filename.size() - extension.size());
 }
 
 }  // namespace

--- a/src/axom/sina/core/Document.cpp
+++ b/src/axom/sina/core/Document.cpp
@@ -1116,15 +1116,12 @@ namespace internal
 
 Protocol detectOutputProtocol(const std::string &filepath)
 {
-  size_t dotPos = filepath.find_last_of('.');
-
-  if(dotPos == std::string::npos)
+  std::string ext = axom::utilities::filesystem::getFileExtension(filepath);
+  if(ext.empty())
   {
     throw std::runtime_error("Cannot detect file format: no extension found in '" + filepath + "'");
   }
 
-  // Get extension and convert to lowercase
-  std::string ext = filepath.substr(dotPos);
   axom::utilities::string::toLower(ext);  // Modifies ext in-place
 
   if(ext == ".json" || ext == ".jsn")

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -192,5 +192,17 @@ if(AXOM_ENABLE_TUTORIALS AND AXOM_ENABLE_KLEE AND AXOM_ENABLE_QUEST)
                            OUTPUT_DIR ${PROJECT_BINARY_DIR}/tutorials
                            DEPENDS_ON ${shaping_tutorial_deps})
     endforeach()
+
+    if(AXOM_ENABLE_TESTS)
+        blt_add_test(NAME    shaping_tutorial_lesson_03_klee_operators_and_validation_yaml
+                     COMMAND shaping_tutorial_lesson_03_klee_operators_and_validation
+                             ${CMAKE_CURRENT_SOURCE_DIR}/shaping_tutorial/lesson_03/ice_cream.yaml)
+
+        if(LUA_FOUND)
+            blt_add_test(NAME    shaping_tutorial_lesson_03_klee_operators_and_validation_lua
+                         COMMAND shaping_tutorial_lesson_03_klee_operators_and_validation
+                                 ${CMAKE_CURRENT_SOURCE_DIR}/shaping_tutorial/lesson_03/ice_cream.lua)
+        endif()
+    endif()
     
 endif()

--- a/src/examples/shaping_tutorial/CMakeLists.txt
+++ b/src/examples/shaping_tutorial/CMakeLists.txt
@@ -104,6 +104,11 @@ if(ENABLE_TESTS)
     blt_add_test(NAME   lesson_03_klee_operators_and_validation
                 COMMAND lesson_03_klee_operators_and_validation ../lesson_03/ice_cream.yaml)
 
+    if(AXOM_USE_LUA)
+      blt_add_test(NAME    lesson_03_klee_operators_and_validation_lua
+                   COMMAND lesson_03_klee_operators_and_validation ../lesson_03/ice_cream.lua)
+    endif()
+
     if(AXOM_USE_LUA AND AXOM_USE_MFEM)
       blt_add_test(NAME    lesson_04_quest_sampling_shaper
                    COMMAND lesson_04_quest_sampling_shaper -m ../lesson_04/circle_input.lua 

--- a/src/examples/shaping_tutorial/lesson_02/README.md
+++ b/src/examples/shaping_tutorial/lesson_02/README.md
@@ -325,14 +325,16 @@ We can easily support reading in YAML or LUA inputs with Inlet's built-in `YAMLR
 
 ```cpp
 // Define appropriate reader based on file extension
-if(axom::utilities::string::endsWith(inputFilename, ".yaml") ||
-   axom::utilities::string::endsWith(inputFilename, ".yml"))
+auto extension = axom::utilities::filesystem::getFileExtension(inputFilename);
+axom::utilities::string::toLower(extension);
+
+if(extension == ".yaml" || extension == ".yml")
 {
   reader = std::make_unique<axom::inlet::YAMLReader>();
   SLIC_INFO("Using YAML reader for input file: " + inputFilename);
 }
 #ifdef AXOM_USE_LUA
-else if(axom::utilities::string::endsWith(inputFilename, ".lua"))
+else if(extension == ".lua")
 {
   reader = std::make_unique<axom::inlet::LuaReader>();
   SLIC_INFO("Using Lua reader for input file: " + inputFilename);

--- a/src/examples/shaping_tutorial/lesson_02/improved_inlet_metadata.cpp
+++ b/src/examples/shaping_tutorial/lesson_02/improved_inlet_metadata.cpp
@@ -247,9 +247,11 @@ int main(int argc, char** argv)
     ->required()
     ->check(axom::CLI::ExistingFile)
     ->check([&supported_extensions](const std::string& filename) {
+      auto extension = axom::utilities::filesystem::getFileExtension(filename);
+      axom::utilities::string::toLower(extension);
       for(auto& ext : supported_extensions)
       {
-        if(axom::utilities::string::endsWith(filename, ext))
+        if(extension == ext)
         {
           return std::string();
         }
@@ -263,14 +265,15 @@ int main(int argc, char** argv)
 
   // Create appropriate reader based on file extension
   std::unique_ptr<axom::inlet::Reader> reader;
+  auto extension = axom::utilities::filesystem::getFileExtension(inputFilename);
+  axom::utilities::string::toLower(extension);
 
-  if(axom::utilities::string::endsWith(inputFilename, ".yaml") ||
-     axom::utilities::string::endsWith(inputFilename, ".yml"))
+  if(extension == ".yaml" || extension == ".yml")
   {
     reader = std::make_unique<axom::inlet::YAMLReader>();
   }
 #ifdef AXOM_USE_LUA
-  else if(axom::utilities::string::endsWith(inputFilename, ".lua"))
+  else if(extension == ".lua")
   {
     reader = std::make_unique<axom::inlet::LuaReader>();
   }

--- a/src/examples/shaping_tutorial/lesson_03/README.md
+++ b/src/examples/shaping_tutorial/lesson_03/README.md
@@ -281,6 +281,37 @@ shapes:
   <figcaption style="font-style: italic;">Figure: Example Klee inputs showing `scale`, `translate`, `rotate` and unit conversion operators.</figcaption>
 </div>
 
+#### Lua decks
+
+Klee can also read Lua decks when Axom is configured with Lua support.
+Lua decks use the same shape schema as YAML, but Lua is evaluated before
+Inlet reads the resulting global tables. The lesson's `ice_cream.lua` deck
+mirrors the YAML setup while using local Lua variables for shared values:
+
+```lua
+local dim = 2
+local scoop_radius = 1.1
+local scoop_offset = {0.0, 2.0}
+
+dimensions = dim
+
+shapes = {
+  {
+    name = "vanilla_scoop",
+    material = "ice_cream",
+    geometry = {
+      format = "mfem",
+      path = "ice_cream_scoop.mesh",
+      units = "cm",
+      operators = {
+        { scale = {scoop_radius} },
+        { rotate = 5 },
+        { translate = scoop_offset }
+      }
+    }
+  }
+}
+```
 
 ### Replacement Rules
 Replacement rules give users some extra control in how shapes get overlaid. By default, a new shape of a given material will replace all other shapes.

--- a/src/examples/shaping_tutorial/lesson_03/ice_cream.lua
+++ b/src/examples/shaping_tutorial/lesson_03/ice_cream.lua
@@ -1,0 +1,65 @@
+local dim = 2
+
+local scoop_radius = 1.1
+local scoop_lift = 2.0
+local sprinkle_lift = 3.0
+local cone_lift = -2.0
+
+local scoop_scale = {scoop_radius}
+local scoop_offset = {0.0, scoop_lift}
+local sprinkle_offset = {0.0, sprinkle_lift}
+local cone_offset = {0.0, cone_lift}
+
+dimensions = dim
+
+shapes = {
+  {
+    name = "background",
+    material = "background",
+    geometry = {
+      format = "none"
+    }
+  },
+  {
+    name = "vanilla_scoop",
+    material = "ice_cream",
+    geometry = {
+      format = "mfem",
+      path = "ice_cream_scoop.mesh",
+      units = "cm",
+      operators = {
+        { scale = scoop_scale },
+        { rotate = 5 },
+        { translate = scoop_offset }
+      }
+    }
+  },
+  {
+    name = "colorful_sprinkles",
+    material = "sprinkles",
+    geometry = {
+      format = "mfem",
+      path = "ice_cream_sprinkles.mesh",
+      units = "cm",
+      operators = {
+        { rotate = 15 },
+        { translate = sprinkle_offset }
+      }
+    },
+    replaces = {"ice_cream"}
+  },
+  {
+    name = "cone",
+    material = "batter",
+    geometry = {
+      format = "mfem",
+      path = "ice_cream_cone.mesh",
+      units = "cm",
+      operators = {
+        { rotate = -5 },
+        { translate = cone_offset }
+      }
+    },
+    does_not_replace = {"ice_cream", "sprinkles"}
+  }
+}


### PR DESCRIPTION
# Summary

- This PR is a feature
- It adds Lua support to Klee and to our shaping application
  - This first PR provides feature parity with the YAML reader
  - A follow-up PR will add the ability to pass variables into the deck and to define callbacks, e.g. to have different operators/behavior in 2D vs. 3D
- Misc Klee: 
  - Fixes the slice operator
  - Adds a check that each operator can be converted to a matrix (instead of silently failing)
- Misc Core:
   - Adds a utility function to core to extract the file extension from a string and uses this throughout Axom


### Example
For this YAML input:
```yaml
    dimensions: 3
    shapes:
      - name: windshield
        material: glass
        geometry:
          format: stl
          path: windshield.stl
          units: cm
          operators:
            - rotate: 90
              axis: [0, 1, 0]
              center: [0, 0, -10]
            - translate: [10, 20, 30]
```

... we now support the equivalent Lua:
```lua
    dimensions = 3
    shapes = {
      {
        name = "windshield",
        material = "glass",
        geometry = {
          format = "stl",
          path = "windshield.stl",
          units = "cm",
          operators = {
            { rotate = 90, axis = {0, 1, 0}, center = {0, 0, -10} },
            { translate = {10, 20, 30} }
          }
        }
      }
    }
```