### PR TITLE
Bugfix: CI jobs should fail if any unit test fails

### DIFF
--- a/scripts/github-actions/linux-build_and_test.sh
+++ b/scripts/github-actions/linux-build_and_test.sh
@@ -45,7 +45,7 @@ if [[ "$DO_BUILD" == "yes" ]] ; then
     fi
 
     echo "~~~~~~ RUNNING TESTS ~~~~~~~~"
-    make CTEST_OUTPUT_ON_FAILURE=1 test ARGS="-T Test --output-on-failure -j${NUM_BUILD_PROCS}"
+    or_die make CTEST_OUTPUT_ON_FAILURE=1 test ARGS="-T Test --output-on-failure -j${NUM_BUILD_PROCS}"
 
     if [[ "${DO_BENCHMARKS}" == "yes" ]] ; then
         echo "~~~~~~ RUNNING BENCHMARKS ~~~~~~~~"

--- a/src/axom/slic/core/Logger.cpp
+++ b/src/axom/slic/core/Logger.cpp
@@ -16,29 +16,33 @@ namespace axom
 {
 namespace slic
 {
+//------------------------------------------------------------------------------
+// Slic's singleton state, scope-limited to this file.
+//
+// Defined the singleton state at namespace scope so its destructors are registered
+// late and runs early during teardown.
+//------------------------------------------------------------------------------
+
 using Loggermap = std::map<std::string, Logger*>;
 
 //------------------------------------------------------------------------------
-// This is a singleton, scope-limited to this file.
+static Loggermap s_loggers;
 Loggermap& getLoggers()
 {
-  static Loggermap s_loggers;
   return s_loggers;
 }
 
 //------------------------------------------------------------------------------
-// This is a singleton, scope-limited to this file.
+static Logger* s_Logger = nullptr;
 Logger*& getLogger()
 {
-  static Logger* s_Logger = nullptr;
   return s_Logger;
 }
 
 //------------------------------------------------------------------------------
-// This is a singleton, scope-limited to this file.
+static LogStreamStatusMonitor s_logStreamStatusMonitor;
 LogStreamStatusMonitor& getLogStreamStatusMonitor()
 {
-  static LogStreamStatusMonitor s_logStreamStatusMonitor;
   return s_logStreamStatusMonitor;
 }
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- In #1896, I noticed that the CI could be marked as passing regardless of whether the test pass
   - Specifically, `make test` was not run through `or_die`
- Inevitably, some of the tests are failing in develop 
   -- specifically some `quest_inout_interface*` tests are failing in the shared gcc@13.3.1 jobs
   -- these tests have been failing in this config since at least April 2026, and our logs don't go back further
         See: https://github.com/llnl/axom/actions/runs/25020134802/job/73280084010

### Steps:
- [x] Add `or_die` to `make_test`
- [ ] Disable the failing tests
- [ ] Fix and re-enable the tests
- [ ] Add `or_die` to `run_benchmarks`


### Screenshot
<img width="1261" height="720" alt="image" src="https://github.com/user-attachments/assets/c5194743-e382-413f-b9ff-9de14d8b6ae1" />

_from: https://github.com/llnl/axom/actions/runs/27728595865/job/82030406017?pr=1882_