### PR TITLE
Squash CUDA build warnings

### DIFF
--- a/src/axom/core/execution/execution_space.hpp
+++ b/src/axom/core/execution/execution_space.hpp
@@ -84,12 +84,12 @@ struct execution_space
 
   static constexpr MemorySpace memory_space = MemorySpace::Dynamic;
 
-  static constexpr bool async() noexcept { return false; }
-  static constexpr bool valid() noexcept { return false; }
-  static constexpr bool onDevice() noexcept { return false; }
-  static constexpr char* name() noexcept { return (char*)"[UNDEFINED]"; }
+  AXOM_HOST_DEVICE static constexpr bool async() noexcept { return false; }
+  AXOM_HOST_DEVICE static constexpr bool valid() noexcept { return false; }
+  AXOM_HOST_DEVICE static constexpr bool onDevice() noexcept { return false; }
+  AXOM_HOST_DEVICE static constexpr char* name() noexcept { return (char*)"[UNDEFINED]"; }
   static int allocatorID() noexcept { return axom::INVALID_ALLOCATOR_ID; }
-  static constexpr runtime_policy::Policy runtimePolicy() noexcept
+  AXOM_HOST_DEVICE static constexpr runtime_policy::Policy runtimePolicy() noexcept
   {
     return runtime_policy::Policy::seq;
   }

--- a/src/axom/core/execution/internal/cuda_exec.hpp
+++ b/src/axom/core/execution/internal/cuda_exec.hpp
@@ -57,15 +57,15 @@ struct execution_space<CUDA_EXEC<BLOCK_SIZE, SYNCHRONOUS>>
 
   static constexpr MemorySpace memory_space = MemorySpace::Device;
 
-  static constexpr bool async() noexcept { return false; }
-  static constexpr bool valid() noexcept { return true; }
-  static constexpr bool onDevice() noexcept { return true; }
-  static constexpr char* name() noexcept { return (char*)"[CUDA_EXEC]"; }
+  AXOM_HOST_DEVICE static constexpr bool async() noexcept { return false; }
+  AXOM_HOST_DEVICE static constexpr bool valid() noexcept { return true; }
+  AXOM_HOST_DEVICE static constexpr bool onDevice() noexcept { return true; }
+  AXOM_HOST_DEVICE static constexpr char* name() noexcept { return (char*)"[CUDA_EXEC]"; }
   static int allocatorID() noexcept
   {
     return axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   }
-  static constexpr runtime_policy::Policy runtimePolicy() noexcept
+  AXOM_HOST_DEVICE static constexpr runtime_policy::Policy runtimePolicy() noexcept
   {
     return runtime_policy::Policy::cuda;
   }
@@ -98,15 +98,15 @@ struct execution_space<CUDA_EXEC<BLOCK_SIZE, ASYNC>>
 
   static constexpr MemorySpace memory_space = MemorySpace::Device;
 
-  static constexpr bool async() noexcept { return true; }
-  static constexpr bool valid() noexcept { return true; }
-  static constexpr bool onDevice() noexcept { return true; }
-  static constexpr char* name() noexcept { return (char*)"[CUDA_EXEC] (async)"; }
+  AXOM_HOST_DEVICE static constexpr bool async() noexcept { return true; }
+  AXOM_HOST_DEVICE static constexpr bool valid() noexcept { return true; }
+  AXOM_HOST_DEVICE static constexpr bool onDevice() noexcept { return true; }
+  AXOM_HOST_DEVICE static constexpr char* name() noexcept { return (char*)"[CUDA_EXEC] (async)"; }
   static int allocatorID() noexcept
   {
     return axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   }
-  static constexpr runtime_policy::Policy runtimePolicy() noexcept
+  AXOM_HOST_DEVICE static constexpr runtime_policy::Policy runtimePolicy() noexcept
   {
     return runtime_policy::Policy::cuda;
   }

--- a/src/axom/core/execution/internal/hip_exec.hpp
+++ b/src/axom/core/execution/internal/hip_exec.hpp
@@ -55,15 +55,15 @@ struct execution_space<HIP_EXEC<BLOCK_SIZE, SYNCHRONOUS>>
 
   static constexpr MemorySpace memory_space = MemorySpace::Device;
 
-  static constexpr bool async() noexcept { return false; }
-  static constexpr bool valid() noexcept { return true; }
-  static constexpr bool onDevice() noexcept { return true; }
-  static constexpr char* name() noexcept { return (char*)"[HIP_EXEC]"; }
+  AXOM_HOST_DEVICE static constexpr bool async() noexcept { return false; }
+  AXOM_HOST_DEVICE static constexpr bool valid() noexcept { return true; }
+  AXOM_HOST_DEVICE static constexpr bool onDevice() noexcept { return true; }
+  AXOM_HOST_DEVICE static constexpr char* name() noexcept { return (char*)"[HIP_EXEC]"; }
   static int allocatorID() noexcept
   {
     return axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   }
-  static constexpr runtime_policy::Policy runtimePolicy() noexcept
+  AXOM_HOST_DEVICE static constexpr runtime_policy::Policy runtimePolicy() noexcept
   {
     return runtime_policy::Policy::hip;
   }
@@ -96,15 +96,15 @@ struct execution_space<HIP_EXEC<BLOCK_SIZE, ASYNC>>
 
   static constexpr MemorySpace memory_space = MemorySpace::Device;
 
-  static constexpr bool async() noexcept { return true; }
-  static constexpr bool valid() noexcept { return true; }
-  static constexpr bool onDevice() noexcept { return true; }
-  static constexpr char* name() noexcept { return (char*)"[HIP_EXEC] (async)"; }
+  AXOM_HOST_DEVICE static constexpr bool async() noexcept { return true; }
+  AXOM_HOST_DEVICE static constexpr bool valid() noexcept { return true; }
+  AXOM_HOST_DEVICE static constexpr bool onDevice() noexcept { return true; }
+  AXOM_HOST_DEVICE static constexpr char* name() noexcept { return (char*)"[HIP_EXEC] (async)"; }
   static int allocatorID() noexcept
   {
     return axom::getUmpireResourceAllocatorID(umpire::resource::Device);
   }
-  static constexpr runtime_policy::Policy runtimePolicy() noexcept
+  AXOM_HOST_DEVICE static constexpr runtime_policy::Policy runtimePolicy() noexcept
   {
     return runtime_policy::Policy::hip;
   }

--- a/src/axom/core/execution/internal/omp_exec.hpp
+++ b/src/axom/core/execution/internal/omp_exec.hpp
@@ -47,10 +47,10 @@ struct execution_space<OMP_EXEC>
   static constexpr MemorySpace memory_space = MemorySpace::Dynamic;
 #endif
 
-  static constexpr bool async() noexcept { return false; }
-  static constexpr bool valid() noexcept { return true; }
-  static constexpr bool onDevice() noexcept { return false; }
-  static constexpr char* name() noexcept { return (char*)"[OMP_EXEC]"; }
+  AXOM_HOST_DEVICE static constexpr bool async() noexcept { return false; }
+  AXOM_HOST_DEVICE static constexpr bool valid() noexcept { return true; }
+  AXOM_HOST_DEVICE static constexpr bool onDevice() noexcept { return false; }
+  AXOM_HOST_DEVICE static constexpr char* name() noexcept { return (char*)"[OMP_EXEC]"; }
 
   static int allocatorID() noexcept
   {
@@ -60,7 +60,7 @@ struct execution_space<OMP_EXEC>
     return axom::getDefaultAllocatorID();
 #endif
   }
-  static constexpr runtime_policy::Policy runtimePolicy() noexcept
+  AXOM_HOST_DEVICE static constexpr runtime_policy::Policy runtimePolicy() noexcept
   {
     return runtime_policy::Policy::omp;
   }

--- a/src/axom/core/execution/internal/seq_exec.hpp
+++ b/src/axom/core/execution/internal/seq_exec.hpp
@@ -57,10 +57,10 @@ struct execution_space<SEQ_EXEC>
   static constexpr MemorySpace memory_space = MemorySpace::Dynamic;
 #endif
 
-  static constexpr bool async() noexcept { return false; }
-  static constexpr bool valid() noexcept { return true; }
-  static constexpr bool onDevice() noexcept { return false; }
-  static constexpr char* name() noexcept { return (char*)"[SEQ_EXEC]"; }
+  AXOM_HOST_DEVICE static constexpr bool async() noexcept { return false; }
+  AXOM_HOST_DEVICE static constexpr bool valid() noexcept { return true; }
+  AXOM_HOST_DEVICE static constexpr bool onDevice() noexcept { return false; }
+  AXOM_HOST_DEVICE static constexpr char* name() noexcept { return (char*)"[SEQ_EXEC]"; }
   static int allocatorID() noexcept
   {
 #ifdef AXOM_USE_UMPIRE
@@ -69,7 +69,7 @@ struct execution_space<SEQ_EXEC>
     return axom::getDefaultAllocatorID();
 #endif
   }
-  static constexpr runtime_policy::Policy runtimePolicy() noexcept
+  AXOM_HOST_DEVICE static constexpr runtime_policy::Policy runtimePolicy() noexcept
   {
     return runtime_policy::Policy::seq;
   }

--- a/src/axom/primal/geometry/Polygon.hpp
+++ b/src/axom/primal/geometry/Polygon.hpp
@@ -96,28 +96,12 @@ public:
   ~Polygon() { m_vertices.clear(); }
 
   /*!
-   * \brief Copy assignment operator for Polygon (static array specialization).
-   *        Specializations are necessary to remove warnings.
-   */
-  template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
-            std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Static, int> = 0>
-  AXOM_HOST_DEVICE Polygon& operator=(const Polygon& other)
-  {
-    if(this == &other)
-    {
-      return *this;
-    }
-
-    m_vertices = other.m_vertices;
-    return *this;
-  }
-
-  /*!
    * \brief Copy assignment operator for Polygon.
-   *        (dynamic array specialization)
+   *
+   * Suppress CUDA warnings for dynamic axom::Array.
    */
-  template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
-            std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Dynamic, int> = 0>
+  AXOM_SUPPRESS_HD_WARN
+  AXOM_HOST_DEVICE
   Polygon& operator=(const Polygon& other)
   {
     if(this == &other)

--- a/src/axom/primal/geometry/Polygon.hpp
+++ b/src/axom/primal/geometry/Polygon.hpp
@@ -113,19 +113,14 @@ public:
     return *this;
   }
 
-  /// Copy constructor for Polygon. Specializations are necessary to
-  /// remove __host__ __device__ warning for axom::Array usage with
-  /// the dynamic array type.
-  template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
-            std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Dynamic, int> = 0>
-  Polygon(const Polygon& other) : m_vertices(other.m_vertices)
-  { }
-
-  /// Copy constructor for Polygon (static array specialization)
-  template <PolygonArray P_ARRAY_TYPE = ARRAY_TYPE,
-            std::enable_if_t<P_ARRAY_TYPE == PolygonArray::Static, int> = 0>
-  AXOM_HOST_DEVICE Polygon(const Polygon& other) : m_vertices(other.m_vertices)
-  { }
+  /*!
+   * \brief Copy constructor for Polygon.
+   *
+   * Suppress CUDA warnings for dynamic axom::Array.
+   */
+  AXOM_SUPPRESS_HD_WARN
+  AXOM_HOST_DEVICE
+  Polygon(const Polygon& other) : m_vertices(other.m_vertices) { }
 
   /*!
    * \brief Constructor for an empty polygon that reserves space for

--- a/src/axom/primal/operators/detail/clip_impl.hpp
+++ b/src/axom/primal/operators/detail/clip_impl.hpp
@@ -1185,6 +1185,7 @@ AXOM_HOST_DEVICE double clipPolygonPolygonArea(
  *
  * \sa axom::primal::clip()
  */
+AXOM_SUPPRESS_HD_WARN
 template <typename T, axom::primal::PolygonArray ARRAY_TYPE, int MAX_VERTS>
 AXOM_HOST_DEVICE Polygon<T, 2, ARRAY_TYPE, MAX_VERTS> clipPolygonPlane(
   const Polygon<T, 2, ARRAY_TYPE, MAX_VERTS>& subjectPolygon,

--- a/src/axom/primal/operators/detail/slice_impl.hpp
+++ b/src/axom/primal/operators/detail/slice_impl.hpp
@@ -49,6 +49,7 @@ AXOM_HOST_DEVICE void add_unique_vertex(PolygonType& poly,
  *
  * \return The polygon obtained from slicing a tetrahedron with a plane.
  */
+AXOM_SUPPRESS_HD_WARN
 template <typename T, PolygonArray ARRAY_TYPE = PolygonArray::Dynamic, int MAX_VERTS = DEFAULT_MAX_NUM_VERTICES>
 AXOM_HOST_DEVICE primal::Polygon<T, 3, ARRAY_TYPE, MAX_VERTS> slice_tet_plane(
   const primal::Tetrahedron<T, 3>& tet,

--- a/src/axom/quest/GWNMethods.hpp
+++ b/src/axom/quest/GWNMethods.hpp
@@ -209,11 +209,22 @@ public:
         axom::Array<BoxType> aabbs(ncurves, ncurves);
         auto aabbs_view = aabbs.view();
 
-        axom::for_all<ExecSpace>(
-          ncurves,
-          AXOM_LAMBDA(axom::IndexType i) {
-            aabbs_view[i] = m_processed_curves_view[i].boundingBox();
-          });
+        if constexpr(axom::execution_space<ExecSpace>::onDevice())
+        {
+          axom::for_all<ExecSpace>(
+            ncurves,
+            AXOM_LAMBDA(axom::IndexType i) {
+              aabbs_view[i] = m_processed_curves_view[i].boundingBox();
+            });
+        }
+        else
+        {
+          axom::for_all<ExecSpace>(
+            ncurves,
+            AXOM_HOST_LAMBDA(axom::IndexType i) {
+              aabbs_view[i] = m_processed_curves_view[i].boundingBox();
+            });
+        }
         m_bvh.initialize(aabbs_view, ncurves);
       }
 
@@ -638,11 +649,22 @@ public:
         axom::Array<BoxType> aabbs(npatches, npatches);
         auto aabbs_view = aabbs.view();
 
-        axom::for_all<ExecSpace>(
-          npatches,
-          AXOM_LAMBDA(axom::IndexType i) {
-            aabbs_view[i] = m_processed_patches_view[i].boundingBox();
-          });
+        if constexpr(axom::execution_space<ExecSpace>::onDevice())
+        {
+          axom::for_all<ExecSpace>(
+            npatches,
+            AXOM_LAMBDA(axom::IndexType i) {
+              aabbs_view[i] = m_processed_patches_view[i].boundingBox();
+            });
+        }
+        else
+        {
+          axom::for_all<ExecSpace>(
+            npatches,
+            AXOM_HOST_LAMBDA(axom::IndexType i) {
+              aabbs_view[i] = m_processed_patches_view[i].boundingBox();
+            });
+        }
         m_bvh.initialize(aabbs_view, npatches);
       }
 


### PR DESCRIPTION
# Summary

- This PR eliminates ~20 warnings in our CUDA builds.
- A significant number of warnings that will require some work to remove and are not addressed here. These fall into two categories:
   - nvlink warnings about the compiler being unable to statically determine stack size
   - calling host function from host-device function where the host function is an axom::Array method. However, axom::Array is not designed to be used in device code. So removing these warnings may require some code re-design.

This PR resolves some of https://github.com/llnl/axom/issues/1848. A new issue was created to capture the remaining warnings.