### PR TITLE
Make some MergeCoordsetPoints SLIC_INFO selectable.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -76,6 +76,7 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   Code that previously imported `pysidre` needs to be updated to `axom.sidre`.
 
 ### Fixed
+- MIR/Bump: `MergeCoordsetPoints` now only emits its node-merge `SLIC_INFO` when MIR `verbose` is enabled on the Conduit options passed through ELVIRA.
 - Primal: Fixes signs of `compute_moments` to match orientation convention in `primal::evaluate_area_integral`
 - Quest: Improves error handling/reporting when loading an invalid c2c contour
 - Primal: Improves reproducibility of 3D GWN methods by removing some sources of randomness

--- a/src/axom/bump/MergeCoordsetPoints.hpp
+++ b/src/axom/bump/MergeCoordsetPoints.hpp
@@ -152,6 +152,7 @@ public:
                axom::Array<axom::IndexType> &old2new) const
   {
     namespace utils = axom::bump::utilities;
+    const axom::bump::Options opts(n_options);
     const int allocatorID = getAllocatorID();
 
     // If the coordset is not explicit then there is nothing to do.
@@ -204,7 +205,10 @@ public:
     if(merged)
     {
       // There are fewer nodes in the selectedIds so we are able to combine nodes.
-      SLIC_INFO(axom::fmt::format("Merged {} nodes into {} nodes.", nnodes, selectedIds.size()));
+      SLIC_INFO_IF(opts.verbose(),
+                   axom::fmt::format("Merged {} nodes into {} nodes.",
+                                     nnodes,
+                                     selectedIds.size()));
 
       AXOM_ANNOTATE_BEGIN("old2new");
       // Make a map of nodes in the old coordset to nodes in the new coordset. We

--- a/src/axom/bump/MergeCoordsetPoints.hpp
+++ b/src/axom/bump/MergeCoordsetPoints.hpp
@@ -206,9 +206,7 @@ public:
     {
       // There are fewer nodes in the selectedIds so we are able to combine nodes.
       SLIC_INFO_IF(opts.verbose(),
-                   axom::fmt::format("Merged {} nodes into {} nodes.",
-                                     nnodes,
-                                     selectedIds.size()));
+                   axom::fmt::format("Merged {} nodes into {} nodes.", nnodes, selectedIds.size()));
 
       AXOM_ANNOTATE_BEGIN("old2new");
       // Make a map of nodes in the old coordset to nodes in the new coordset. We

--- a/src/axom/mir/ElviraAlgorithm.hpp
+++ b/src/axom/mir/ElviraAlgorithm.hpp
@@ -905,7 +905,7 @@ protected:
     // Clean up the mesh in 3D so it has merged coordinates and merged faces.
     // This step does nothing in 2D at present.
     axom::Array<axom::IndexType> selectedIds;
-    build.cleanMesh(n_newCoordset, point_tolerance, n_newTopo, selectedIds, n_options);
+    build.cleanMesh(n_newCoordset, n_options, point_tolerance, n_newTopo, selectedIds);
 
     //--------------------------------------------------------------------------
 #if defined(AXOM_ELVIRA_DEBUG)

--- a/src/axom/mir/ElviraAlgorithm.hpp
+++ b/src/axom/mir/ElviraAlgorithm.hpp
@@ -905,7 +905,7 @@ protected:
     // Clean up the mesh in 3D so it has merged coordinates and merged faces.
     // This step does nothing in 2D at present.
     axom::Array<axom::IndexType> selectedIds;
-    build.cleanMesh(n_newCoordset, point_tolerance, n_newTopo, selectedIds);
+    build.cleanMesh(n_newCoordset, point_tolerance, n_newTopo, selectedIds, n_options);
 
     //--------------------------------------------------------------------------
 #if defined(AXOM_ELVIRA_DEBUG)

--- a/src/axom/mir/detail/elvira_detail.hpp
+++ b/src/axom/mir/detail/elvira_detail.hpp
@@ -509,10 +509,10 @@ public:
    * \brief Clean the mesh (no-op for 2D)
    */
   void cleanMesh(conduit::Node &AXOM_UNUSED_PARAM(n_coordset),
+                 const conduit::Node &AXOM_UNUSED_PARAM(n_options),
                  double AXOM_UNUSED_PARAM(point_tolerance),
                  conduit::Node &AXOM_UNUSED_PARAM(n_topology),
-                 axom::Array<axom::IndexType> &AXOM_UNUSED_PARAM(selectedIds),
-                 const conduit::Node &AXOM_UNUSED_PARAM(n_options)) const
+                 axom::Array<axom::IndexType> &AXOM_UNUSED_PARAM(selectedIds)) const
   { }
 
 private:
@@ -925,6 +925,7 @@ public:
    * \brief Clean the mesh, merging coordinates and faces.
    *
    * \param n_coordset The coordset to clean up.
+   * \param n_options A node that may contain options.
    * \param point_tolerance The point tolerance used to merge points.
    * \param n_topology The topology to clean up.
    * \param[out] selectedIds An array that indicates the points that were selected during coordset point merging.
@@ -932,10 +933,10 @@ public:
    * \note This method invalidates the views in m_view by causing some of their backing arrays to be replaced.
    */
   void cleanMesh(conduit::Node &n_coordset,
+                 const conduit::Node &n_options,
                  double point_tolerance,
                  conduit::Node &n_topology,
-                 axom::Array<axom::IndexType> &selectedIds,
-                 const conduit::Node &n_options) const
+                 axom::Array<axom::IndexType> &selectedIds) const
   {
     AXOM_ANNOTATE_SCOPE("cleanMesh");
 

--- a/src/axom/mir/detail/elvira_detail.hpp
+++ b/src/axom/mir/detail/elvira_detail.hpp
@@ -511,7 +511,8 @@ public:
   void cleanMesh(conduit::Node &AXOM_UNUSED_PARAM(n_coordset),
                  double AXOM_UNUSED_PARAM(point_tolerance),
                  conduit::Node &AXOM_UNUSED_PARAM(n_topology),
-                 axom::Array<axom::IndexType> &AXOM_UNUSED_PARAM(selectedIds)) const
+                 axom::Array<axom::IndexType> &AXOM_UNUSED_PARAM(selectedIds),
+                 const conduit::Node &AXOM_UNUSED_PARAM(n_options)) const
   { }
 
 private:
@@ -933,7 +934,8 @@ public:
   void cleanMesh(conduit::Node &n_coordset,
                  double point_tolerance,
                  conduit::Node &n_topology,
-                 axom::Array<axom::IndexType> &selectedIds) const
+                 axom::Array<axom::IndexType> &selectedIds,
+                 const conduit::Node &n_options) const
   {
     AXOM_ANNOTATE_SCOPE("cleanMesh");
 
@@ -954,6 +956,10 @@ public:
     axom::bump::MergeCoordsetPoints<ExecSpace, NewCoordsetView> mcp(newCoordsetView);
     conduit::Node n_mcp_options;
     n_mcp_options["tolerance"] = point_tolerance;
+    if(n_options.has_child("verbose"))
+    {
+      n_mcp_options["verbose"].set(n_options["verbose"]);
+    }
     const bool merged = mcp.execute(n_coordset, n_mcp_options, selectedIds, old2new);
     // _bump_utilities_mergecoordsetpoints_end
 


### PR DESCRIPTION
This PR resolves #1946.

* Adds a "verbose" option to `MergeCoordsetPoints`
* Propagate Elvira MIR "verbose" _(default off)_ option value to `MergeCoordsetPoints`

