### PR TITLE
Add Dynamic Filtering Option to Distributed Closest Point 

### DIFF
--- a/src/axom/quest/DistributedClosestPoint.cpp
+++ b/src/axom/quest/DistributedClosestPoint.cpp
@@ -130,6 +130,15 @@ void DistributedClosestPoint::setDistanceThreshold(double threshold)
   m_sqDistanceThreshold = threshold * threshold;
 }
 
+void DistributedClosestPoint::setDynamicDistanceFiltering(bool on)
+{
+  m_dynamicDistanceFiltering = on;
+  if(m_impl)
+  {
+    m_impl->setDynamicDistanceFiltering(m_dynamicDistanceFiltering);
+  }
+}
+
 void DistributedClosestPoint::setOutput(const std::string& field, bool on)
 {
   // clang-format off
@@ -211,6 +220,7 @@ void DistributedClosestPoint::computeClosestPoints(conduit::Node& query_node,
   SLIC_ASSERT(this->isValidBlueprint(query_node));
 
   m_impl->setSquaredDistanceThreshold(m_sqDistanceThreshold);
+  m_impl->setDynamicDistanceFiltering(m_dynamicDistanceFiltering);
   m_impl->setMpiCommunicator(m_mpiComm);
   m_impl->setOutputSwitches(m_outputRank,
                             m_outputIndex,

--- a/src/axom/quest/DistributedClosestPoint.hpp
+++ b/src/axom/quest/DistributedClosestPoint.hpp
@@ -103,6 +103,14 @@ public:
    */
   void setDistanceThreshold(double threshold);
 
+  /**
+   * \brief Enables dynamic filtering of object ranks based on current closest distances.
+   *
+   * When enabled, transferred query batches skip object ranks whose partition
+   * bounding box cannot improve any current result. Enabled by default.
+   */
+  void setDynamicDistanceFiltering(bool on);
+
   /*!
     @brief Set what fields to output.
 
@@ -198,6 +206,7 @@ private:
   int m_dimension {-1};
   bool m_isVerbose {false};
   double m_sqDistanceThreshold;
+  bool m_dynamicDistanceFiltering {true};
 
   bool m_outputRank = true;
   bool m_outputIndex = true;

--- a/src/axom/quest/detail/DistributedClosestPointImpl.hpp
+++ b/src/axom/quest/detail/DistributedClosestPointImpl.hpp
@@ -251,6 +251,7 @@ public:
     , m_rank(-1)
     , m_nranks(-1)
     , m_sqDistanceThreshold(axom::numeric_limits<double>::max())
+    , m_dynamicDistanceFiltering(true)
   { }
 
   virtual ~DistributedClosestPointImpl() { }
@@ -300,6 +301,11 @@ public:
     SLIC_ERROR_IF(sqThreshold < 0.0, "Squared distance-threshold must be non-negative.");
     m_sqDistanceThreshold = sqThreshold;
   }
+
+  /*!
+   @brief Enables dynamic filtering of object ranks using current closest distances.
+  */
+  void setDynamicDistanceFiltering(bool on) { m_dynamicDistanceFiltering = on; }
 
   /*!
     @brief Set which output data fields to generate.
@@ -528,6 +534,7 @@ protected:
   int m_nranks;
 
   double m_sqDistanceThreshold;
+  bool m_dynamicDistanceFiltering;
 
   bool m_outputRank = true;
   bool m_outputIndex = true;
@@ -747,6 +754,7 @@ public:
     constexpr int tag = 9873;
 
     int remainingRecvs = 0;
+    int fullXferRecvs = 0;
 
     std::list<conduit::relay::mpi::Request> isendRequests;
 
@@ -762,7 +770,7 @@ public:
       BoxArray allQueryBbs;
       gatherBoundingBoxes(myQueryBb, allQueryBbs);
 
-      computeLocalClosestPoints(xferNode);
+      double currentMaxSqDistance = computeLocalClosestPoints(xferNode);
 
       const auto& myObjectBb = m_objectPartitionBbs[m_rank];
       for(int r = 0; r < m_nranks; ++r)
@@ -770,8 +778,7 @@ public:
         if(r != m_rank)
         {
           const auto& otherQueryBb = allQueryBbs[r];
-          double sqDistance = axom::primal::squared_distance(otherQueryBb, myObjectBb);
-          if(sqDistance <= m_sqDistanceThreshold)
+          if(statically_eligible(otherQueryBb, myObjectBb))
           {
             ++remainingRecvs;
           }
@@ -783,7 +790,7 @@ public:
         partition, if any.  Increase remainingRecvs, because this data
         will come back.
       */
-      int firstRecipForMyQuery = next_recipient(xferNode);
+      int firstRecipForMyQuery = next_recipient(xferNode, currentMaxSqDistance, tag, isendRequests);
       if(m_nranks == 1)
       {
         SLIC_ASSERT(firstRecipForMyQuery == -1);
@@ -803,27 +810,46 @@ public:
       }
     }
 
+    const int totalExpectedRecvs = remainingRecvs;
     while(remainingRecvs > 0)
     {
-      SLIC_INFO_IF(m_isVerbose,
-                   fmt::format("=======  {} receives remaining =======", remainingRecvs));
+      if(m_isVerbose)
+      {
+        if(m_dynamicDistanceFiltering)
+        {
+          const int skipTokenRecvs = totalExpectedRecvs - remainingRecvs - fullXferRecvs;
+          SLIC_INFO(fmt::format("=======  receives: remaining={}, full={}, skip={} =======",
+                                remainingRecvs,
+                                fullXferRecvs,
+                                skipTokenRecvs));
+        }
+        else
+        {
+          SLIC_INFO(fmt::format("=======  {} receives remaining =======", remainingRecvs));
+        }
+      }
 
       // Receive the next xferNode
       conduit::Node recvXferNode;
       conduit::relay::mpi::recv_using_schema(recvXferNode, MPI_ANY_SOURCE, tag, m_mpiComm);
 
-      const int homeRank = recvXferNode.fetch_existing("homeRank").as_int();
       --remainingRecvs;
+      const int homeRank = recvXferNode.fetch_existing("homeRank").as_int();
+      if(homeRank < 0)
+      {
+        continue;
+      }
 
+      ++fullXferRecvs;
       if(homeRank == m_rank)
       {
         node_copy_xfer_to_query(recvXferNode, queryMesh, topologyName);
       }
       else
       {
-        computeLocalClosestPoints(recvXferNode);
+        double currentMaxSqDistance = computeLocalClosestPoints(recvXferNode);
 
-        int nextRecipient = next_recipient(recvXferNode);
+        int nextRecipient = next_recipient(recvXferNode, currentMaxSqDistance, tag, isendRequests);
         SLIC_ASSERT(nextRecipient != -1);
         isendRequests.emplace_back(conduit::relay::mpi::Request());
         auto& isendRequest = isendRequests.back();
@@ -846,16 +872,47 @@ public:
   }
 
 private:
+  bool statically_eligible(const BoxType& queryBb,
+                           const BoxType& objectBb,
+                           double* sqDistance = nullptr) const
+  {
+    if(!queryBb.isValid() || !objectBb.isValid())
+    {
+      return false;
+    }
+
+    const double sqDist = primal::squared_distance(queryBb, objectBb);
+    if(sqDistance != nullptr)
+    {
+      *sqDistance = sqDist;
+    }
+    return sqDist <= m_sqDistanceThreshold;
+  }
+
+  void send_skip_token(int dest, int tag, std::list<conduit::relay::mpi::Request>& isendRequests) const
+  {
+    conduit::Node skipToken;
+    skipToken["homeRank"] = -1;
+
+    isendRequests.emplace_back(conduit::relay::mpi::Request());
+    auto& req = isendRequests.back();
+    relay::mpi::isend_using_schema(skipToken, dest, tag, m_mpiComm, &req);
+  }
+
   /**
     Determine the next rank (in ring order) with an object partition
     close to the query points in xferNode.  The intent is to send
     xferNode there next.
   */
-  int next_recipient(const conduit::Node& xferNode) const
+  int next_recipient(const conduit::Node& xferNode,
+                     double currentMaxSqDistance,
+                     int tag,
+                     std::list<conduit::relay::mpi::Request>& isendRequests) const
   {
     int homeRank = xferNode.fetch_existing("homeRank").value();
     BoxType bb;
     get_bounding_box_from_conduit_node(bb, xferNode.fetch_existing("aabb"));
+
     for(int i = 1; i < m_nranks; ++i)
     {
       int maybeNextRecip = (m_rank + i) % m_nranks;
@@ -863,10 +920,14 @@ private:
       {
         return maybeNextRecip;
       }
-      double sqDistance = primal::squared_distance(bb, m_objectPartitionBbs[maybeNextRecip]);
-      if(sqDistance <= m_sqDistanceThreshold)
+      if(double sqDistance = 0.0;
+         statically_eligible(bb, m_objectPartitionBbs[maybeNextRecip], &sqDistance))
       {
-        return maybeNextRecip;
+        if(sqDistance <= currentMaxSqDistance)
+        {
+          return maybeNextRecip;
+        }
+        send_skip_token(maybeNextRecip, tag, isendRequests);
       }
     }
     return -1;
@@ -897,7 +958,7 @@ public:
     return (result == spin::BVH_BUILD_OK);
   }
 
-  void computeLocalClosestPoints(conduit::Node& xferNode) const
+  double computeLocalClosestPoints(conduit::Node& xferNode) const
   {
     using axom::primal::squared_distance;
 
@@ -907,8 +968,11 @@ public:
     const bool is_first = xferNode.has_path("is_first");
     if(!hasObjectPoints && !is_first)
     {
-      return;
+      return m_sqDistanceThreshold;
     }
+
+    double currentMaxSqDistance = -1.0;
+
     conduit::Node& xferDoms = xferNode["xferDoms"];
     for(conduit::Node& xferDom : xferDoms.children())
     {
@@ -977,7 +1041,81 @@ public:
       PointArray execPoints(queryPts, m_allocatorID);
       auto query_pts = execPoints.view();
 
-      if(hasObjectPoints)
+      if(m_dynamicDistanceFiltering && hasObjectPoints)
+      {
+        axom::Array<double> sqDistThresh_host(1,
+                                              1,
+                                              axom::execution_space<axom::SEQ_EXEC>::allocatorID());
+        sqDistThresh_host[0] = m_sqDistanceThreshold;
+        axom::Array<double> sqDistThresh_device =
+          axom::Array<double>(sqDistThresh_host, m_allocatorID);
+        auto sqDistThresh_device_view = sqDistThresh_device.view();
+
+        axom::ReduceMax<ExecSpace, double> maxSqDistance(currentMaxSqDistance);
+
+        auto it = m_bvh->getTraverser();
+        const int rank = m_rank;
+        auto ptCoordsView = m_objectPtCoords.view();
+        auto ptDomainIdsView = m_objectPtDomainIds.view();
+
+        {
+          AXOM_ANNOTATE_SCOPE("ComputeClosestPointsDynamic");
+          axom::for_all<ExecSpace>(
+            qPtCount,
+            AXOM_LAMBDA(std::int32_t idx) mutable {
+              PointType qpt = query_pts[idx];
+
+              MinCandidate curr_min {};
+              if(query_ranks[idx] >= 0)
+              {
+                curr_min.sqDist = squared_distance(qpt, query_pos[idx]);
+                curr_min.pointIdx = query_inds[idx];
+                curr_min.domainIdx = query_doms[idx];
+                curr_min.rank = query_ranks[idx];
+              }
+
+              auto checkMinDist = [&](std::int32_t current_node, const std::int32_t* leaf_nodes) {
+                const int candidate_point_idx = leaf_nodes[current_node];
+                const int candidate_domain_idx = ptDomainIdsView[candidate_point_idx];
+                const PointType candidate_pt = ptCoordsView[candidate_point_idx];
+                const double sq_dist = squared_distance(qpt, candidate_pt);
+
+                if(sq_dist < curr_min.sqDist)
+                {
+                  curr_min.sqDist = sq_dist;
+                  curr_min.pointIdx = candidate_point_idx;
+                  curr_min.domainIdx = candidate_domain_idx;
+                  curr_min.rank = rank;
+                }
+              };
+
+              auto traversePredicate = [&](const PointType& p, const BoxType& bb) -> bool {
+                auto sqDist = squared_distance(p, bb);
+                return sqDist <= curr_min.sqDist && sqDist <= sqDistThresh_device_view[0];
+              };
+
+              it.traverse_tree(qpt, checkMinDist, traversePredicate);
+
+              if(curr_min.rank == rank)
+              {
+                query_inds[idx] = curr_min.pointIdx;
+                query_doms[idx] = curr_min.domainIdx;
+                query_ranks[idx] = curr_min.rank;
+                query_pos[idx] = ptCoordsView[curr_min.pointIdx];
+
+                if(has_cp_distance)
+                {
+                  query_min_dist[idx] = sqrt(curr_min.sqDist);
+                }
+              }
+
+              maxSqDistance.max(curr_min.rank >= 0 ? curr_min.sqDist : sqDistThresh_device_view[0]);
+            });
+        }
+
+        currentMaxSqDistance = maxSqDistance.get();
+      }
+      else if(hasObjectPoints)
       {
         // Get a device-useable iterator
         auto it = m_bvh->getTraverser();
@@ -1071,6 +1209,9 @@ public:
     {
       xferNode.remove_child("is_first");
     }
+
+    return m_dynamicDistanceFiltering && currentMaxSqDistance >= 0.0 ? currentMaxSqDistance
+                                                                     : m_sqDistanceThreshold;
   }
 
 private:

--- a/src/axom/quest/detail/DistributedClosestPointImpl.hpp
+++ b/src/axom/quest/detail/DistributedClosestPointImpl.hpp
@@ -938,6 +938,10 @@ private:
                                 m_objectPartitionBbs[maybeNextRecip],
                                 sqDistance))
       {
+        /// Use the next recipient if that rank may be able to update one of the
+        /// points in the query, otherwise skip that rank. An update is possible
+        /// if the minimum distance between the bounding boxes is less than
+        /// the current distance of any of the query points.
         if(sqDistance <= currentMaxSqDistance)
         {
           return maybeNextRecip;

--- a/src/axom/quest/detail/DistributedClosestPointImpl.hpp
+++ b/src/axom/quest/detail/DistributedClosestPointImpl.hpp
@@ -28,6 +28,8 @@
 #include <list>
 #include <vector>
 #include <algorithm>
+#include <functional>
+#include <optional>
 
 #ifndef AXOM_USE_MPI
   #error This file requires Axom to be configured with MPI
@@ -778,7 +780,7 @@ public:
         if(r != m_rank)
         {
           const auto& otherQueryBb = allQueryBbs[r];
-          if(statically_eligible(otherQueryBb, myObjectBb))
+          if(is_statically_eligible(otherQueryBb, myObjectBb))
           {
             ++remainingRecvs;
           }
@@ -872,9 +874,16 @@ public:
   }
 
 private:
-  bool statically_eligible(const BoxType& queryBb,
-                           const BoxType& objectBb,
-                           double* sqDistance = nullptr) const
+  /*!
+   * \brief Check whether static rank bounding boxes are close enough to search.
+   *
+   * \param [out] sqDistance Optional reference to receive the squared distance
+   * between the boxes.
+   */
+  bool is_statically_eligible(
+    const BoxType& queryBb,
+    const BoxType& objectBb,
+    std::optional<std::reference_wrapper<double>> sqDistance = std::nullopt) const
   {
     if(!queryBb.isValid() || !objectBb.isValid())
     {
@@ -882,9 +891,9 @@ private:
     }
 
     const double sqDist = primal::squared_distance(queryBb, objectBb);
-    if(sqDistance != nullptr)
+    if(sqDistance)
     {
-      *sqDistance = sqDist;
+      sqDistance->get() = sqDist;
     }
     return sqDist <= m_sqDistanceThreshold;
   }
@@ -921,7 +930,9 @@ private:
         return maybeNextRecip;
       }
       if(double sqDistance = 0.0;
-         statically_eligible(bb, m_objectPartitionBbs[maybeNextRecip], &sqDistance))
+         is_statically_eligible(bb,
+                                m_objectPartitionBbs[maybeNextRecip],
+                                sqDistance))
       {
         if(sqDistance <= currentMaxSqDistance)
         {

--- a/src/axom/quest/detail/DistributedClosestPointImpl.hpp
+++ b/src/axom/quest/detail/DistributedClosestPointImpl.hpp
@@ -898,6 +898,9 @@ private:
     return sqDist <= m_sqDistanceThreshold;
   }
 
+  /*!
+   * \brief Send a minimal message indicating this rank has no query data for the destination rank.
+   */
   void send_skip_token(int dest, int tag, std::list<conduit::relay::mpi::Request>& isendRequests) const
   {
     conduit::Node skipToken;
@@ -908,11 +911,12 @@ private:
     relay::mpi::isend_using_schema(skipToken, dest, tag, m_mpiComm, &req);
   }
 
-  /**
-    Determine the next rank (in ring order) with an object partition
-    close to the query points in xferNode.  The intent is to send
-    xferNode there next.
-  */
+  /*!
+   * \brief Determine the next object rank in ring order to receive the transfer node.
+   *
+   * Sends skip tokens to statically eligible ranks that dynamic distance
+   * filtering can prove will not improve the current closest point results.
+   */
   int next_recipient(const conduit::Node& xferNode,
                      double currentMaxSqDistance,
                      int tag,

--- a/src/axom/quest/detail/DistributedClosestPointImpl.hpp
+++ b/src/axom/quest/detail/DistributedClosestPointImpl.hpp
@@ -1040,17 +1040,10 @@ public:
       /// Create an ArrayView in ExecSpace that is compatible with queryPts
       PointArray execPoints(queryPts, m_allocatorID);
       auto query_pts = execPoints.view();
+      const double sqDistThreshold = m_sqDistanceThreshold;
 
       if(m_dynamicDistanceFiltering && hasObjectPoints)
       {
-        axom::Array<double> sqDistThresh_host(1,
-                                              1,
-                                              axom::execution_space<axom::SEQ_EXEC>::allocatorID());
-        sqDistThresh_host[0] = m_sqDistanceThreshold;
-        axom::Array<double> sqDistThresh_device =
-          axom::Array<double>(sqDistThresh_host, m_allocatorID);
-        auto sqDistThresh_device_view = sqDistThresh_device.view();
-
         axom::ReduceMax<ExecSpace, double> maxSqDistance(currentMaxSqDistance);
 
         auto it = m_bvh->getTraverser();
@@ -1091,7 +1084,7 @@ public:
 
               auto traversePredicate = [&](const PointType& p, const BoxType& bb) -> bool {
                 auto sqDist = squared_distance(p, bb);
-                return sqDist <= curr_min.sqDist && sqDist <= sqDistThresh_device_view[0];
+                return sqDist <= curr_min.sqDist && sqDist <= sqDistThreshold;
               };
 
               it.traverse_tree(qpt, checkMinDist, traversePredicate);
@@ -1109,7 +1102,7 @@ public:
                 }
               }
 
-              maxSqDistance.max(curr_min.rank >= 0 ? curr_min.sqDist : sqDistThresh_device_view[0]);
+              maxSqDistance.max(curr_min.rank >= 0 ? curr_min.sqDist : sqDistThreshold);
             });
         }
 
@@ -1120,14 +1113,6 @@ public:
         // Get a device-useable iterator
         auto it = m_bvh->getTraverser();
         const int rank = m_rank;
-
-        axom::Array<double> sqDistThresh_host(1,
-                                              1,
-                                              axom::execution_space<axom::SEQ_EXEC>::allocatorID());
-        sqDistThresh_host[0] = m_sqDistanceThreshold;
-        axom::Array<double> sqDistThresh_device =
-          axom::Array<double>(sqDistThresh_host, m_allocatorID);
-        auto sqDistThresh_device_view = sqDistThresh_device.view();
 
         auto ptCoordsView = m_objectPtCoords.view();
         auto ptDomainIdsView = m_objectPtDomainIds.view();
@@ -1166,7 +1151,7 @@ public:
 
               auto traversePredicate = [&](const PointType& p, const BoxType& bb) -> bool {
                 auto sqDist = squared_distance(p, bb);
-                return sqDist <= curr_min.sqDist && sqDist <= sqDistThresh_device_view[0];
+                return sqDist <= curr_min.sqDist && sqDist <= sqDistThreshold;
               };
 
               // Traverse the tree, searching for the point with minimum distance.

--- a/src/axom/quest/detail/DistributedClosestPointImpl.hpp
+++ b/src/axom/quest/detail/DistributedClosestPointImpl.hpp
@@ -253,7 +253,6 @@ public:
     , m_rank(-1)
     , m_nranks(-1)
     , m_sqDistanceThreshold(axom::numeric_limits<double>::max())
-    , m_dynamicDistanceFiltering(true)
   { }
 
   virtual ~DistributedClosestPointImpl() { }
@@ -536,7 +535,8 @@ protected:
   int m_nranks;
 
   double m_sqDistanceThreshold;
-  bool m_dynamicDistanceFiltering;
+
+  bool m_dynamicDistanceFiltering = true;
 
   bool m_outputRank = true;
   bool m_outputIndex = true;

--- a/src/axom/quest/detail/DistributedClosestPointImpl.hpp
+++ b/src/axom/quest/detail/DistributedClosestPointImpl.hpp
@@ -880,10 +880,9 @@ private:
    * \param [out] sqDistance Optional reference to receive the squared distance
    * between the boxes.
    */
-  bool is_statically_eligible(
-    const BoxType& queryBb,
-    const BoxType& objectBb,
-    std::optional<std::reference_wrapper<double>> sqDistance = std::nullopt) const
+  bool is_statically_eligible(const BoxType& queryBb,
+                              const BoxType& objectBb,
+                              std::optional<std::reference_wrapper<double>> sqDistance = std::nullopt) const
   {
     if(!queryBb.isValid() || !objectBb.isValid())
     {
@@ -934,9 +933,7 @@ private:
         return maybeNextRecip;
       }
       if(double sqDistance = 0.0;
-         is_statically_eligible(bb,
-                                m_objectPartitionBbs[maybeNextRecip],
-                                sqDistance))
+         is_statically_eligible(bb, m_objectPartitionBbs[maybeNextRecip], sqDistance))
       {
         /// Use the next recipient if that rank may be able to update one of the
         /// points in the query, otherwise skip that rank. An update is possible

--- a/src/axom/quest/detail/DistributedClosestPointImpl.hpp
+++ b/src/axom/quest/detail/DistributedClosestPointImpl.hpp
@@ -1037,22 +1037,21 @@ public:
       auto query_pos = cp_pos.view();
       auto query_min_dist = cp_dist.view();
 
-      /// Create an ArrayView in ExecSpace that is compatible with queryPts
-      PointArray execPoints(queryPts, m_allocatorID);
-      auto query_pts = execPoints.view();
-      const double sqDistThreshold = m_sqDistanceThreshold;
-
-      if(m_dynamicDistanceFiltering && hasObjectPoints)
+      if(hasObjectPoints)
       {
-        axom::ReduceMax<ExecSpace, double> maxSqDistance(currentMaxSqDistance);
-
+        /// Create an ArrayView in ExecSpace that is compatible with queryPts
+        PointArray execPoints(queryPts, m_allocatorID);
+        auto query_pts = execPoints.view();
+        const double sqDistThreshold = m_sqDistanceThreshold;
         auto it = m_bvh->getTraverser();
         const int rank = m_rank;
         auto ptCoordsView = m_objectPtCoords.view();
         auto ptDomainIdsView = m_objectPtDomainIds.view();
 
+        if(m_dynamicDistanceFiltering)
         {
           AXOM_ANNOTATE_SCOPE("ComputeClosestPointsDynamic");
+          axom::ReduceMax<ExecSpace, double> maxSqDistance(currentMaxSqDistance);
           axom::for_all<ExecSpace>(
             qPtCount,
             AXOM_LAMBDA(std::int32_t idx) mutable {
@@ -1104,19 +1103,10 @@ public:
 
               maxSqDistance.max(curr_min.rank >= 0 ? curr_min.sqDist : sqDistThreshold);
             });
+
+          currentMaxSqDistance = maxSqDistance.get();
         }
-
-        currentMaxSqDistance = maxSqDistance.get();
-      }
-      else if(hasObjectPoints)
-      {
-        // Get a device-useable iterator
-        auto it = m_bvh->getTraverser();
-        const int rank = m_rank;
-
-        auto ptCoordsView = m_objectPtCoords.view();
-        auto ptDomainIdsView = m_objectPtDomainIds.view();
-
+        else
         {
           AXOM_ANNOTATE_SCOPE("ComputeClosestPoints");
           axom::for_all<ExecSpace>(

--- a/src/axom/quest/detail/DistributedClosestPointImpl.hpp
+++ b/src/axom/quest/detail/DistributedClosestPointImpl.hpp
@@ -1063,8 +1063,12 @@ public:
         auto ptCoordsView = m_objectPtCoords.view();
         auto ptDomainIdsView = m_objectPtDomainIds.view();
 
+        /// Update the query by finding the closest points in the local mesh
         if(m_dynamicDistanceFiltering)
         {
+          /// Dynamic filtering does the same distance calculation as static but
+          /// additionally calculates the furthest distance of any query point
+          /// after the local update
           AXOM_ANNOTATE_SCOPE("ComputeClosestPointsDynamic");
           axom::ReduceMax<ExecSpace, double> maxSqDistance(currentMaxSqDistance);
           axom::for_all<ExecSpace>(

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -426,12 +426,35 @@ if(AXOM_ENABLE_MPI AND AXOM_ENABLE_SIDRE AND HDF5_FOUND)
                                 --distance-file dcp_closest_point_2d_${_pol}_${_mesh}
                     NUM_MPI_TASKS ${_nranks}
                     NUM_OMP_THREADS ${_num_threads})
+
+                if(_pol STREQUAL "seq" AND (_mesh STREQUAL "mdmesh.2x1" OR _mesh STREQUAL "mdmesh.2x2x1"))
+                    set(_static_test "${_test}_no_dynamic_distance_filtering")
+                    axom_add_test(
+                        NAME    ${_static_test}
+                        COMMAND quest_distributed_distance_query_ex
+                                    --mesh-file ${quest_data_dir}/${_mesh}.root
+                                    --long-point-count 60
+                                    --center ${_center}
+                                    --radius 0.9
+                                    --lat-point-count 30
+                                    --obj-domain-count-range 0 2
+                                    --dist-threshold .3
+                                    --no-random-spacing
+                                    --check-results
+                                    --no-dynamic-distance-filtering
+                                    --policy ${_pol}
+                                    --object-file dcp_object_mesh_${_ndim}d_${_pol}_${_mesh}_no_dynamic
+                                    --distance-file dcp_closest_point_2d_${_pol}_${_mesh}_no_dynamic
+                        NUM_MPI_TASKS ${_nranks}
+                        NUM_OMP_THREADS ${_num_threads})
+                endif()
             endforeach()
         endforeach()
 
         unset(optional_dependency)
         unset(_nranks)
         unset(_test)
+        unset(_static_test)
     endif()
 endif()
 

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -408,6 +408,8 @@ if(AXOM_ENABLE_MPI AND AXOM_ENABLE_SIDRE AND HDF5_FOUND)
                   set(_center 0.7 0.9 0.5)
                 endif()
 
+                # Default dynamic distance filtering is tested across the full
+                # enabled policy/mesh matrix.
                 set(_test "quest_distributed_closest_point_run_${_ndim}D_${_pol}_${_mesh}")
                 axom_add_test(
                     NAME    ${_test}
@@ -427,6 +429,8 @@ if(AXOM_ENABLE_MPI AND AXOM_ENABLE_SIDRE AND HDF5_FOUND)
                     NUM_MPI_TASKS ${_nranks}
                     NUM_OMP_THREADS ${_num_threads})
 
+                # Cover the no-dynamic-filtering fallback path with one 2D and
+                # one 3D seq case without duplicating the full test matrix.
                 if(_pol STREQUAL "seq" AND (_mesh STREQUAL "mdmesh.2x1" OR _mesh STREQUAL "mdmesh.2x2x1"))
                     set(_static_test "${_test}_no_dynamic_distance_filtering")
                     axom_add_test(

--- a/src/axom/quest/examples/CMakeLists.txt
+++ b/src/axom/quest/examples/CMakeLists.txt
@@ -408,8 +408,6 @@ if(AXOM_ENABLE_MPI AND AXOM_ENABLE_SIDRE AND HDF5_FOUND)
                   set(_center 0.7 0.9 0.5)
                 endif()
 
-                # Default dynamic distance filtering is tested across the full
-                # enabled policy/mesh matrix.
                 set(_test "quest_distributed_closest_point_run_${_ndim}D_${_pol}_${_mesh}")
                 axom_add_test(
                     NAME    ${_test}
@@ -423,15 +421,16 @@ if(AXOM_ENABLE_MPI AND AXOM_ENABLE_SIDRE AND HDF5_FOUND)
                                 --dist-threshold .3
                                 --no-random-spacing
                                 --check-results
+                                --dynamic-distance-filtering
                                 --policy ${_pol}
                                 --object-file dcp_object_mesh_${_ndim}d_${_pol}_${_mesh}
                                 --distance-file dcp_closest_point_2d_${_pol}_${_mesh}
                     NUM_MPI_TASKS ${_nranks}
                     NUM_OMP_THREADS ${_num_threads})
 
-                # Cover the no-dynamic-filtering fallback path with one 2D and
-                # one 3D seq case without duplicating the full test matrix.
                 if(_pol STREQUAL "seq" AND (_mesh STREQUAL "mdmesh.2x1" OR _mesh STREQUAL "mdmesh.2x2x1"))
+                    # Keep fallback coverage for the non-dynamic filtering path
+                    # with one 2D and one 3D seq case.
                     set(_static_test "${_test}_no_dynamic_distance_filtering")
                     axom_add_test(
                         NAME    ${_static_test}

--- a/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
+++ b/src/axom/quest/examples/quest_distributed_distance_query_example.cpp
@@ -79,6 +79,8 @@ public:
 
   double distThreshold {axom::numeric_limits<double>::max()};
 
+  bool dynamicDistanceFiltering {true};
+
   bool checkResults {false};
 
   bool randomSpacing {true};
@@ -164,6 +166,12 @@ public:
     app.add_option("-d,--dist-threshold", distThreshold)
       ->check(axom::CLI::NonNegativeNumber)
       ->description("Distance threshold to search")
+      ->capture_default_str();
+
+    app
+      .add_flag("--dynamic-distance-filtering,!--no-dynamic-distance-filtering",
+                dynamicDistanceFiltering)
+      ->description("Enable/disable dynamic distance filtering")
       ->capture_default_str();
 
     app.add_option("-p, --policy", policy)
@@ -1380,6 +1388,7 @@ int main(int argc, char** argv)
   query.setMpiCommunicator(MPI_COMM_WORLD, true);
   query.setVerbosity(params.isVerbose());
   query.setDistanceThreshold(params.distThreshold);
+  query.setDynamicDistanceFiltering(params.dynamicDistanceFiltering);
   // To test support for single-domain format, use single-domain when possible.
   query.setObjectMesh(objectMeshNode.number_of_children() == 1 ? objectMeshNode[0] : objectMeshNode,
                       objectMeshWrapper.getTopologyName());


### PR DESCRIPTION
# Summary

Add dynamic filtering option in the distributed closest points algorithm to avoid sending data to ranks that could not improve any of the closest points already found.

Optionally capture the max of the current closest points while updating the closest points with the local mesh and use that to filter on the bounding boxes of the next ranks. If a rank couldn't contain any points that are closer than the max of the current closest points then skip that rank. Each rank that passed the static filtering still expects to get a message so send a small skip message so to ensure the receive count completion criteria is fulfilled.

- This PR is a feature
- It does the following:
  - Adds dynamic filtering at the request of me

