### PR TITLE
Reduce verbosity of quest's file readers

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -101,6 +101,9 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
   internal `quest::internal::read_*_mesh()`/`logger_init()` helpers are now declared only when Axom is
   configured with MPI. Serial code that passed the placeholder `MPI_COMM_SELF` explicitly should drop the argument.
 - We can now configure Axom without MPI when some of its dependencies were configured with MPI.
+- Quest: Status-returning reader/writer operations in `C2CReader`, `MFEMReader`, `ProEReader`,
+  `STEPReader`, `STLReader`, `STLWriter`, and their parallel variants are now marked `[[nodiscard]]`.
+  Callers that previously ignored returned status values must check them to avoid compiler diagnostics.
 
 ### Fixed
 - MIR/Bump: `MergeCoordsetPoints` now only emits its node-merge `SLIC_INFO` when MIR `verbose` is enabled on the Conduit options passed through ELVIRA.

--- a/src/axom/quest/examples/containment_driver.cpp
+++ b/src/axom/quest/examples/containment_driver.cpp
@@ -110,7 +110,8 @@ public:
     AXOM_ANNOTATE_SCOPE("load stl");
     quest::STLReader reader;
     reader.setFileName(inputFile);
-    SLIC_ERROR_IF(reader.read() != 0, "Failed to load STL file '" << inputFile << "'.");
+    const int read_status = reader.read();
+    SLIC_ERROR_IF(read_status != 0, "Failed to load STL file '" << inputFile << "'.");
 
     // Create surface mesh
     m_surfaceMesh.reset(new UMesh(3, mint::TRIANGLE));

--- a/src/axom/quest/examples/containment_driver.cpp
+++ b/src/axom/quest/examples/containment_driver.cpp
@@ -110,7 +110,7 @@ public:
     AXOM_ANNOTATE_SCOPE("load stl");
     quest::STLReader reader;
     reader.setFileName(inputFile);
-    reader.read();
+    SLIC_ERROR_IF(reader.read() != 0, "Failed to load STL file '" << inputFile << "'.");
 
     // Create surface mesh
     m_surfaceMesh.reset(new UMesh(3, mint::TRIANGLE));

--- a/src/axom/quest/examples/quest_bvh_two_pass.cpp
+++ b/src/axom/quest/examples/quest_bvh_two_pass.cpp
@@ -375,7 +375,7 @@ int main(int argc, char** argv)
   {
     axom::quest::STLReader reader;
     reader.setFileName(args.file_name);
-    reader.read();
+    SLIC_ERROR_IF(reader.read() != 0, "Failed to load STL file '" << args.file_name << "'.");
 
     // Get surface mesh
     surface_mesh.reset(new UMesh(3, mint::TRIANGLE));

--- a/src/axom/quest/examples/quest_bvh_two_pass.cpp
+++ b/src/axom/quest/examples/quest_bvh_two_pass.cpp
@@ -375,7 +375,8 @@ int main(int argc, char** argv)
   {
     axom::quest::STLReader reader;
     reader.setFileName(args.file_name);
-    SLIC_ERROR_IF(reader.read() != 0, "Failed to load STL file '" << args.file_name << "'.");
+    const int read_status = reader.read();
+    SLIC_ERROR_IF(read_status != 0, "Failed to load STL file '" << args.file_name << "'.");
 
     // Get surface mesh
     surface_mesh.reset(new UMesh(3, mint::TRIANGLE));

--- a/src/axom/quest/examples/quest_proe_bbox.cpp
+++ b/src/axom/quest/examples/quest_proe_bbox.cpp
@@ -141,7 +141,8 @@ int main(int argc, char** argv)
   // To keep all tets, do not set a TetPred.
 
   // Read in the file.
-  SLIC_ERROR_IF(reader.read() != 0, "Failed to load Pro/E file '" << args.file_name << "'.");
+  const int read_status = reader.read();
+  SLIC_ERROR_IF(read_status != 0, "Failed to load Pro/E file '" << args.file_name << "'.");
 
   // Get surface mesh
   UMesh mesh(3, axom::mint::TET);

--- a/src/axom/quest/examples/quest_proe_bbox.cpp
+++ b/src/axom/quest/examples/quest_proe_bbox.cpp
@@ -141,7 +141,7 @@ int main(int argc, char** argv)
   // To keep all tets, do not set a TetPred.
 
   // Read in the file.
-  reader.read();
+  SLIC_ERROR_IF(reader.read() != 0, "Failed to load Pro/E file '" << args.file_name << "'.");
 
   // Get surface mesh
   UMesh mesh(3, axom::mint::TET);

--- a/src/axom/quest/examples/quest_step_file.cpp
+++ b/src/axom/quest/examples/quest_step_file.cpp
@@ -1103,12 +1103,12 @@ int main(int argc, char** argv)
     constexpr bool extract_trimmed_surface = true;
 
     axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE> mesh(3, axom::mint::TRIANGLE);
-    SLIC_ERROR_IF(stepReader.getTriangleMesh(&mesh,
-                                             deflection,
-                                             angular_deflection,
-                                             relative_deflection,
-                                             extract_trimmed_surface) != 0,
-                  "Failed to triangulate the trimmed STEP model.");
+    const int triangulation_status = stepReader.getTriangleMesh(&mesh,
+                                                                deflection,
+                                                                angular_deflection,
+                                                                relative_deflection,
+                                                                extract_trimmed_surface);
+    SLIC_ERROR_IF(triangulation_status != 0, "Failed to triangulate the trimmed STEP model.");
 
 #ifdef AXOM_USE_MPI
     if(validate_model && !validate_triangle_mesh(mesh))
@@ -1130,7 +1130,8 @@ int main(int argc, char** argv)
       else
       {
         axom::quest::STLWriter writer(output_file, true);
-        SLIC_ERROR_IF(writer.write(&mesh) != 0, "Failed to write STL file '" << output_file << "'.");
+        const int write_status = writer.write(&mesh);
+        SLIC_ERROR_IF(write_status != 0, "Failed to write STL file '" << output_file << "'.");
       }
 
       SLIC_INFO(axom::fmt::format(axom::utilities::locale(),
@@ -1155,12 +1156,12 @@ int main(int argc, char** argv)
     constexpr bool extract_trimmed_surface = false;
 
     axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE> mesh(3, axom::mint::TRIANGLE);
-    SLIC_ERROR_IF(stepReader.getTriangleMesh(&mesh,
-                                             deflection,
-                                             angular_deflection,
-                                             relative_deflection,
-                                             extract_trimmed_surface) != 0,
-                  "Failed to triangulate the untrimmed STEP model.");
+    const int triangulation_status = stepReader.getTriangleMesh(&mesh,
+                                                                deflection,
+                                                                angular_deflection,
+                                                                relative_deflection,
+                                                                extract_trimmed_surface);
+    SLIC_ERROR_IF(triangulation_status != 0, "Failed to triangulate the untrimmed STEP model.");
 
 #ifdef AXOM_USE_MPI
     if(validate_model && !validate_triangle_mesh(mesh))
@@ -1182,7 +1183,8 @@ int main(int argc, char** argv)
       else
       {
         axom::quest::STLWriter writer(output_file, true);
-        SLIC_ERROR_IF(writer.write(&mesh) != 0, "Failed to write STL file '" << output_file << "'.");
+        const int write_status = writer.write(&mesh);
+        SLIC_ERROR_IF(write_status != 0, "Failed to write STL file '" << output_file << "'.");
       }
 
       SLIC_INFO(

--- a/src/axom/quest/examples/quest_step_file.cpp
+++ b/src/axom/quest/examples/quest_step_file.cpp
@@ -1103,11 +1103,12 @@ int main(int argc, char** argv)
     constexpr bool extract_trimmed_surface = true;
 
     axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE> mesh(3, axom::mint::TRIANGLE);
-    stepReader.getTriangleMesh(&mesh,
-                               deflection,
-                               angular_deflection,
-                               relative_deflection,
-                               extract_trimmed_surface);
+    SLIC_ERROR_IF(stepReader.getTriangleMesh(&mesh,
+                                             deflection,
+                                             angular_deflection,
+                                             relative_deflection,
+                                             extract_trimmed_surface) != 0,
+                  "Failed to triangulate the trimmed STEP model.");
 
 #ifdef AXOM_USE_MPI
     if(validate_model && !validate_triangle_mesh(mesh))
@@ -1129,7 +1130,7 @@ int main(int argc, char** argv)
       else
       {
         axom::quest::STLWriter writer(output_file, true);
-        writer.write(&mesh);
+        SLIC_ERROR_IF(writer.write(&mesh) != 0, "Failed to write STL file '" << output_file << "'.");
       }
 
       SLIC_INFO(axom::fmt::format(axom::utilities::locale(),
@@ -1154,11 +1155,12 @@ int main(int argc, char** argv)
     constexpr bool extract_trimmed_surface = false;
 
     axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE> mesh(3, axom::mint::TRIANGLE);
-    stepReader.getTriangleMesh(&mesh,
-                               deflection,
-                               angular_deflection,
-                               relative_deflection,
-                               extract_trimmed_surface);
+    SLIC_ERROR_IF(stepReader.getTriangleMesh(&mesh,
+                                             deflection,
+                                             angular_deflection,
+                                             relative_deflection,
+                                             extract_trimmed_surface) != 0,
+                  "Failed to triangulate the untrimmed STEP model.");
 
 #ifdef AXOM_USE_MPI
     if(validate_model && !validate_triangle_mesh(mesh))
@@ -1180,7 +1182,7 @@ int main(int argc, char** argv)
       else
       {
         axom::quest::STLWriter writer(output_file, true);
-        writer.write(&mesh);
+        SLIC_ERROR_IF(writer.write(&mesh) != 0, "Failed to write STL file '" << output_file << "'.");
       }
 
       SLIC_INFO(

--- a/src/axom/quest/io/C2CReader.cpp
+++ b/src/axom/quest/io/C2CReader.cpp
@@ -22,13 +22,11 @@
 #include <string>
 #include <utility>
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 namespace
 {
-c2c::LengthUnit toC2CLengthUnit(utilities::LengthUnit unit)
+constexpr c2c::LengthUnit toC2CLengthUnit(utilities::LengthUnit unit)
 {
   switch(unit)
   {
@@ -138,9 +136,9 @@ C2CReader::ResultType C2CReader::readAssembly(const std::string& filename, Curve
   SLIC_INFO_ROOT(fmt::format("Loading assembly with {} pieces", assembly.getNumEntries()));
 
   // Make an initial guess at the number of curves we may need.
-  const int contoursPerFileGuess = 6;
+  constexpr int contours_per_file_guess = 6;
   CurveArray assemblyCurves;
-  assemblyCurves.reserve(assembly.getNumEntries() * contoursPerFileGuess);
+  assemblyCurves.reserve(assembly.getNumEntries() * contours_per_file_guess);
 
   ResultType ret = ResultType::Success;
   for(auto it = assembly.begin(); it != assembly.end(); it++)
@@ -307,5 +305,4 @@ void C2CReader::log()
   SLIC_INFO_ROOT(sstr.str());
 }
 
-}  // end namespace quest
-}  // end namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/C2CReader.cpp
+++ b/src/axom/quest/io/C2CReader.cpp
@@ -82,7 +82,7 @@ bool C2CReader::hasValidExtension(const std::string& filename)
 
 int C2CReader::read()
 {
-  SLIC_WARNING_IF(m_fileName.empty(), "Missing a filename in C2CReader::read()");
+  SLIC_WARNING_ROOT_IF(m_fileName.empty(), "Missing a filename in C2CReader::read()");
 
   // Always clear prior results so callers never observe stale curves after a failed read
   this->clear();
@@ -104,7 +104,7 @@ C2CReader::ResultType C2CReader::readInternal(const std::string& filename, Curve
   {
     if(!hasValidExtension(filename))
     {
-      SLIC_WARNING(axom::fmt::format("{} is not a valid c2c file", filename));
+      SLIC_WARNING_ROOT(axom::fmt::format("{} is not a valid c2c file", filename));
       return ResultType::Failure;
     }
 
@@ -119,11 +119,11 @@ C2CReader::ResultType C2CReader::readInternal(const std::string& filename, Curve
   }
   catch(const std::exception& e)
   {
-    SLIC_WARNING(axom::fmt::format("Failed to read c2c file '{}': {}", filename, e.what()));
+    SLIC_WARNING_ROOT(axom::fmt::format("Failed to read c2c file '{}': {}", filename, e.what()));
   }
   catch(...)
   {
-    SLIC_WARNING(axom::fmt::format("Failed to read c2c file '{}'", filename));
+    SLIC_WARNING_ROOT(axom::fmt::format("Failed to read c2c file '{}'", filename));
   }
 
   return ResultType::Failure;
@@ -135,7 +135,7 @@ C2CReader::ResultType C2CReader::readAssembly(const std::string& filename, Curve
   std::string assemblyDir;
   utilities::filesystem::getDirName(assemblyDir, filename);
 
-  SLIC_INFO(fmt::format("Loading assembly with {} pieces", assembly.getNumEntries()));
+  SLIC_INFO_ROOT(fmt::format("Loading assembly with {} pieces", assembly.getNumEntries()));
 
   // Make an initial guess at the number of curves we may need.
   const int contoursPerFileGuess = 6;
@@ -172,7 +172,7 @@ C2CReader::ResultType C2CReader::readContour(const std::string& filename, CurveA
   c2c::Contour contour = c2c::parseContour(filename);
   const c2c::LengthUnit c2cLengthUnit = toC2CLengthUnit(m_lengthUnit);
 
-  SLIC_INFO(fmt::format("Loading contour with {} pieces", contour.getPieces().size()));
+  SLIC_INFO_ROOT(fmt::format("Loading contour with {} pieces", contour.getPieces().size()));
 
   inputCurves.reserve(inputCurves.size() + contour.getPieces().size());
 
@@ -199,7 +199,7 @@ C2CReader::ResultType C2CReader::readContour(const std::string& filename, CurveA
     const int degree = static_cast<int>(nkts - npts - 1);
     if(degree < 0)
     {
-      SLIC_WARNING(
+      SLIC_WARNING_ROOT(
         fmt::format("Invalid contour file '{}': computed negative NURBS degree for piece "
                     "{} (npts={}, nkts={})",
                     filename,
@@ -211,7 +211,7 @@ C2CReader::ResultType C2CReader::readContour(const std::string& filename, CurveA
 
     if(npts <= degree)
     {
-      SLIC_WARNING(
+      SLIC_WARNING_ROOT(
         fmt::format("Invalid contour file '{}': piece {} has too few control points for degree "
                     "(degree={}, npts={}, nkts={})",
                     filename,
@@ -229,7 +229,7 @@ C2CReader::ResultType C2CReader::readContour(const std::string& filename, CurveA
 
     if(!knotvec.isValid(true))
     {
-      SLIC_WARNING(
+      SLIC_WARNING_ROOT(
         fmt::format("Invalid contour file '{}': piece {} converted to an invalid NURBS knot vector "
                     "(degree={}).",
                     filename,
@@ -244,7 +244,7 @@ C2CReader::ResultType C2CReader::readContour(const std::string& filename, CurveA
     {
       if(static_cast<axom::IndexType>(nurbsData.weights.size()) != controlPoints.size())
       {
-        SLIC_WARNING(
+        SLIC_WARNING_ROOT(
           fmt::format("Invalid contour file '{}': piece {} has {} weights for {} control points",
                       filename,
                       piece_index,
@@ -304,7 +304,7 @@ void C2CReader::log()
     ++index;
   }
 
-  SLIC_INFO(sstr.str());
+  SLIC_INFO_ROOT(sstr.str());
 }
 
 }  // end namespace quest

--- a/src/axom/quest/io/C2CReader.cpp
+++ b/src/axom/quest/io/C2CReader.cpp
@@ -136,9 +136,9 @@ C2CReader::ResultType C2CReader::readAssembly(const std::string& filename, Curve
   SLIC_INFO_ROOT(fmt::format("Loading assembly with {} pieces", assembly.getNumEntries()));
 
   // Make an initial guess at the number of curves we may need.
-  constexpr int contours_per_file_guess = 6;
+  constexpr int contoursPerFileGuess = 6;
   CurveArray assemblyCurves;
-  assemblyCurves.reserve(assembly.getNumEntries() * contours_per_file_guess);
+  assemblyCurves.reserve(assembly.getNumEntries() * contoursPerFileGuess);
 
   ResultType ret = ResultType::Success;
   for(auto it = assembly.begin(); it != assembly.end(); it++)

--- a/src/axom/quest/io/C2CReader.hpp
+++ b/src/axom/quest/io/C2CReader.hpp
@@ -59,7 +59,7 @@ public:
   void clear();
 
   /// Returns true if the file has a recognized c2c extension.
-  [[nodiscard]] static bool hasValidExtension(const std::string& filename);
+  static bool hasValidExtension(const std::string& filename);
 
   /*!
    * \brief Read the contour file provided by \a setFileName()
@@ -76,8 +76,8 @@ public:
    * 
    * \return A view that contains the curves.
    */
-  [[nodiscard]] CurveArrayView getCurvesView() { return m_nurbsData.view(); }
-  [[nodiscard]] ConstCurveArrayView getCurvesView() const { return m_nurbsData.view(); }
+  CurveArrayView getCurvesView() { return m_nurbsData.view(); }
+  ConstCurveArrayView getCurvesView() const { return m_nurbsData.view(); }
 
 protected:
   /*!

--- a/src/axom/quest/io/C2CReader.hpp
+++ b/src/axom/quest/io/C2CReader.hpp
@@ -21,9 +21,7 @@
 #include <string>
 #include <vector>
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 /*
  * \class C2CReader
@@ -38,6 +36,7 @@ public:
   using NURBSCurve = axom::primal::NURBSCurve<double, 2>;
   using CurveArray = axom::Array<NURBSCurve>;
   using CurveArrayView = axom::ArrayView<NURBSCurve>;
+  using ConstCurveArrayView = axom::ArrayView<const NURBSCurve>;
 
   enum class ResultType
   {
@@ -60,14 +59,14 @@ public:
   void clear();
 
   /// Returns true if the file has a recognized c2c extension.
-  static bool hasValidExtension(const std::string& filename);
+  [[nodiscard]] static bool hasValidExtension(const std::string& filename);
 
   /*!
    * \brief Read the contour file provided by \a setFileName()
    * 
    * \return 0 for a successful read; non-zero otherwise
    */
-  virtual int read();
+  [[nodiscard]] virtual int read();
 
   /// \brief Utility function to log details about the read in file
   virtual void log();
@@ -77,7 +76,8 @@ public:
    * 
    * \return A view that contains the curves.
    */
-  CurveArrayView getCurvesView() { return m_nurbsData.view(); }
+  [[nodiscard]] CurveArrayView getCurvesView() { return m_nurbsData.view(); }
+  [[nodiscard]] ConstCurveArrayView getCurvesView() const { return m_nurbsData.view(); }
 
 protected:
   /*!
@@ -88,7 +88,7 @@ protected:
    *
    * \return Success on success, Failure otherwise.
    */
-  ResultType readInternal(const std::string& filename, CurveArray& inputCurves);
+  [[nodiscard]] ResultType readInternal(const std::string& filename, CurveArray& inputCurves);
 
   /*!
    * \brief Internal helper for reading a contour file.
@@ -98,7 +98,7 @@ protected:
    *
    * \return Success on success, Failure otherwise.
    */
-  ResultType readContour(const std::string& filename, CurveArray& inputCurves);
+  [[nodiscard]] ResultType readContour(const std::string& filename, CurveArray& inputCurves);
 
   /*!
    * \brief Internal helper for reading an assembly file.
@@ -108,7 +108,7 @@ protected:
    *
    * \return Success on success, Failure otherwise.
    */
-  ResultType readAssembly(const std::string& filename, CurveArray& inputCurves);
+  [[nodiscard]] ResultType readAssembly(const std::string& filename, CurveArray& inputCurves);
 
 protected:
   std::string m_fileName;
@@ -116,5 +116,4 @@ protected:
   CurveArray m_nurbsData;
 };
 
-}  // namespace quest
-}  // namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/MFEMReader.cpp
+++ b/src/axom/quest/io/MFEMReader.cpp
@@ -299,7 +299,7 @@ int read_mfem(const std::string& fileName,
   return MFEMReader::READ_SUCCESS;
 }
 
-}  // end namespace internal
+}  // namespace internal
 
 int MFEMReader::read(CurveArray& curves)
 {
@@ -364,4 +364,4 @@ int MFEMReader::read(CurvedPolygonArray& curvedPolygons, axom::Array<int>& attri
   return ret;
 }
 
-}  // end namespace axom::quest
+}  // namespace axom::quest

--- a/src/axom/quest/io/MFEMReader.cpp
+++ b/src/axom/quest/io/MFEMReader.cpp
@@ -47,7 +47,7 @@ int read_mfem(const std::string& fileName,
 {
   if(!axom::utilities::filesystem::pathExists(fileName))
   {
-    SLIC_WARNING(axom::fmt::format("Cannot open the provided MFEM mesh file '{}'", fileName));
+    SLIC_WARNING_ROOT(axom::fmt::format("Cannot open the provided MFEM mesh file '{}'", fileName));
     return MFEMReader::READ_FAILED;
   }
 
@@ -59,7 +59,7 @@ int read_mfem(const std::string& fileName,
 
   if(mesh->Dimension() != 1 || mesh->SpaceDimension() != 2)
   {
-    SLIC_WARNING(
+    SLIC_WARNING_ROOT(
       axom::fmt::format("Mesh must have dimension 1 and spatial dimension 2. The supplied mesh "
                         "is dimension {} with spatial dimension {}.",
                         mesh->Dimension(),
@@ -72,7 +72,7 @@ int read_mfem(const std::string& fileName,
   const auto* fec = fes != nullptr ? fes->FEColl() : nullptr;
   if(nodes == nullptr || fes == nullptr || fec == nullptr)
   {
-    SLIC_WARNING("Mesh does not have a valid nodes grid function");
+    SLIC_WARNING_ROOT("Mesh does not have a valid nodes grid function");
     return MFEMReader::READ_FAILED;
   }
 
@@ -105,7 +105,7 @@ int read_mfem(const std::string& fileName,
     mesh->NURBSext->GetPatchDofs(patchId, dofs);
     if(dofs.Size() <= 0)
     {
-      SLIC_WARNING(
+      SLIC_WARNING_ROOT(
         axom::fmt::format("MFEM patch {} has no DOFs; cannot extract NURBS curve.", patchId));
       return {};
     }
@@ -205,7 +205,7 @@ int read_mfem(const std::string& fileName,
       mesh->NURBSext->GetPatchKnotVectors(patchId, kvs);
       if(kvs.Size() < 1 || kvs[0] == nullptr)
       {
-        SLIC_WARNING(
+        SLIC_WARNING_ROOT(
           axom::fmt::format("MFEM patch {} has no valid knot vector; cannot extract NURBS curve.",
                             patchId));
         return MFEMReader::READ_FAILED;
@@ -213,7 +213,7 @@ int read_mfem(const std::string& fileName,
       const mfem::KnotVector& kv0 = *kvs[0];
       if(kv0.Size() <= 0)
       {
-        SLIC_WARNING(
+        SLIC_WARNING_ROOT(
           axom::fmt::format("MFEM patch {} has an empty knot vector; cannot extract NURBS curve.",
                             patchId));
         return MFEMReader::READ_FAILED;
@@ -224,7 +224,8 @@ int read_mfem(const std::string& fileName,
       const primal::KnotVector<double> kv(knots_view, kv0.GetOrder(), SkipTag {});
       if(!kv.isValid(true))
       {
-        SLIC_WARNING(axom::fmt::format("MFEM patch {} has an invalid knot vector: {}", patchId, kv));
+        SLIC_WARNING_ROOT(
+          axom::fmt::format("MFEM patch {} has an invalid knot vector: {}", patchId, kv));
         return MFEMReader::READ_FAILED;
       }
 
@@ -262,7 +263,7 @@ int read_mfem(const std::string& fileName,
     const bool is_bernstein = dynamic_cast<const mfem::H1Pos_FECollection*>(fec) != nullptr;
     if(!is_bernstein)
     {
-      SLIC_WARNING(axom::fmt::format(
+      SLIC_WARNING_ROOT(axom::fmt::format(
         "Non-NURBS meshes must define their nodes in the positive Bernstein basis "
         "(mfem::H1Pos_FECollection). Got FECollection '{}'.",
         fec->Name()));
@@ -308,7 +309,7 @@ int MFEMReader::read(CurveArray& curves)
 
 int MFEMReader::read(CurveArray& curves, axom::Array<int>& attributes)
 {
-  SLIC_WARNING_IF(m_fileName.empty(), "Missing a filename in MFEMReader::read()");
+  SLIC_WARNING_ROOT_IF(m_fileName.empty(), "Missing a filename in MFEMReader::read()");
 
   curves.clear();
   attributes.clear();
@@ -337,7 +338,7 @@ int MFEMReader::read(CurvedPolygonArray& curvedPolygons)
 
 int MFEMReader::read(CurvedPolygonArray& curvedPolygons, axom::Array<int>& attributes)
 {
-  SLIC_WARNING_IF(m_fileName.empty(), "Missing a filename in MFEMReader::read()");
+  SLIC_WARNING_ROOT_IF(m_fileName.empty(), "Missing a filename in MFEMReader::read()");
 
   curvedPolygons.clear();
   attributes.clear();

--- a/src/axom/quest/io/MFEMReader.hpp
+++ b/src/axom/quest/io/MFEMReader.hpp
@@ -20,9 +20,7 @@
 #include <string>
 #include <vector>
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 /*
  * \class MFEMReader
@@ -52,7 +50,7 @@ public:
    *
    * \return READ_SUCCESS for a successful read; READ_FAILED (non-zero) otherwise
    */
-  int read(CurveArray& curves);
+  [[nodiscard]] int read(CurveArray& curves);
 
   /*!
    * \brief Read the contour file provided by \a setFileName()
@@ -64,7 +62,7 @@ public:
    *
    * \return READ_SUCCESS for a successful read; READ_FAILED (non-zero) otherwise
    */
-  int read(CurveArray& curves, axom::Array<int>& attributes);
+  [[nodiscard]] int read(CurveArray& curves, axom::Array<int>& attributes);
 
   /*!
    * \brief Read the contour file provided by \a setFileName()
@@ -76,7 +74,7 @@ public:
    *
    * \return READ_SUCCESS for a successful read; READ_FAILED (non-zero) otherwise
    */
-  int read(CurvedPolygonArray& curvedPolygons);
+  [[nodiscard]] int read(CurvedPolygonArray& curvedPolygons);
 
   /*!
    * \brief Read the contour file provided by \a setFileName()
@@ -90,11 +88,10 @@ public:
    *
    * \return READ_SUCCESS for a successful read; READ_FAILED (non-zero) otherwise
    */
-  int read(CurvedPolygonArray& curvedPolygons, axom::Array<int>& attributes);
+  [[nodiscard]] int read(CurvedPolygonArray& curvedPolygons, axom::Array<int>& attributes);
 
 protected:
   std::string m_fileName;
 };
 
-}  // namespace quest
-}  // namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/PC2CReader.cpp
+++ b/src/axom/quest/io/PC2CReader.cpp
@@ -13,9 +13,7 @@
 #include "axom/core.hpp"
 #include "axom/slic.hpp"
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 namespace
 {
@@ -128,5 +126,4 @@ bool PC2CReader::bcast_bool(bool value)
   return static_cast<bool>(intValue);
 }
 
-}  // namespace quest
-}  // namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/PC2CReader.hpp
+++ b/src/axom/quest/io/PC2CReader.hpp
@@ -17,9 +17,7 @@
 
 #include "mpi.h"
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 
 class PC2CReader : public C2CReader
@@ -28,7 +26,7 @@ public:
   PC2CReader() = delete;
   PC2CReader(MPI_Comm comm);
 
-  virtual ~PC2CReader() = default;
+  ~PC2CReader() override = default;
 
   /*!
    * \brief Reads in a C2C file to all ranks in the associated communicator
@@ -36,7 +34,7 @@ public:
    * \note Rank 0 reads in the C2C mesh file and broadcasts to the other ranks
    * \return status set to zero on success; non-zero otherwise
    */
-  int read() final override;
+  [[nodiscard]] int read() final override;
 
 private:
   /// MPI broadcasts an integer from rank 0 and returns the value to all ranks
@@ -78,7 +76,7 @@ private:
     {
       // since the data is contiguous, we can cast the start of the data to a double*
       const int numVals = arr.size() * value_type::DIMENSION;
-      double* dataPtr = (numVals > 0) ? arr[0].data() : nullptr;
+      double* dataPtr = !arr.empty() ? arr[0].data() : nullptr;
       MPI_Bcast(dataPtr, numVals, axom::mpi_traits<double>::type, 0, m_comm);
     }
   }
@@ -92,5 +90,4 @@ private:
   DISABLE_MOVE_AND_ASSIGNMENT(PC2CReader);
 };
 
-}  // namespace quest
-}  // namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/PProEReader.cpp
+++ b/src/axom/quest/io/PProEReader.cpp
@@ -6,9 +6,7 @@
 
 #include "axom/quest/io/PProEReader.hpp"
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 namespace
 {
@@ -20,10 +18,7 @@ constexpr int READER_FAILED = -1;
 PProEReader::PProEReader(MPI_Comm comm) : m_comm(comm) { MPI_Comm_rank(m_comm, &m_my_rank); }
 
 //------------------------------------------------------------------------------
-PProEReader::~PProEReader()
-{
-  // Auto-generated destructor stub
-}
+PProEReader::~PProEReader() = default;
 
 //------------------------------------------------------------------------------
 int PProEReader::read()
@@ -46,11 +41,11 @@ int PProEReader::read()
       MPI_Bcast(&m_num_tets, 1, axom::mpi_traits<axom::IndexType>::type, 0, m_comm);
       MPI_Bcast(&m_nodes[0], m_num_nodes * 3, MPI_DOUBLE, 0, m_comm);
       MPI_Bcast(&m_tets[0], m_num_tets * 4, MPI_INT, 0, m_comm);
-    }  // END if
+    }
     else
     {
       MPI_Bcast(&rc, 1, axom::mpi_traits<axom::IndexType>::type, 0, m_comm);
-    }  // END else
+    }
     break;
 
   default:
@@ -69,11 +64,9 @@ int PProEReader::read()
       MPI_Bcast(&m_nodes[0], m_num_nodes * 3, MPI_DOUBLE, 0, m_comm);
       MPI_Bcast(&m_tets[0], m_num_tets * 4, MPI_INT, 0, m_comm);
     }
-
-  }  // END switch
+  }
 
   return (rc);
 }
 
-}  // end namespace quest
-}  // end namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/PProEReader.hpp
+++ b/src/axom/quest/io/PProEReader.hpp
@@ -12,9 +12,7 @@
 
 #include "mpi.h"
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 class PProEReader : public ProEReader
 {
@@ -22,7 +20,7 @@ public:
   PProEReader() = delete;
   PProEReader(MPI_Comm comm);
 
-  virtual ~PProEReader();
+  ~PProEReader() override;
 
   /*!
    * \brief Reads in a Pro/E file to all ranks in the associated communicator.
@@ -30,7 +28,7 @@ public:
    * \note Rank 0 reads in the Pro/E mesh file and broadcasts to the other ranks.
    * \return status set to zero on success; set to a non-zero value otherwise.
    */
-  int read() final override;
+  [[nodiscard]] int read() final override;
 
 private:
   MPI_Comm m_comm {MPI_COMM_NULL};
@@ -40,5 +38,4 @@ private:
   DISABLE_MOVE_AND_ASSIGNMENT(PProEReader);
 };
 
-}  // namespace quest
-}  // namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/PSTEPReader.cpp
+++ b/src/axom/quest/io/PSTEPReader.cpp
@@ -1,8 +1,6 @@
 #include "axom/quest/io/PSTEPReader.hpp"
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 namespace
 {
@@ -321,5 +319,4 @@ bool PSTEPReader::bcast_bool(bool value)
   return static_cast<bool>(intValue);
 }
 
-}  // end namespace quest
-}  // end namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/PSTEPReader.hpp
+++ b/src/axom/quest/io/PSTEPReader.hpp
@@ -174,7 +174,7 @@ private:
     }
     else
     {
-      SLIC_ERROR("Unsupported ArrayType dimensionality in PSTEPReader::bcast_array");
+      SLIC_ERROR_ROOT("Unsupported ArrayType dimensionality in PSTEPReader::bcast_array");
     }
   }
 

--- a/src/axom/quest/io/PSTEPReader.hpp
+++ b/src/axom/quest/io/PSTEPReader.hpp
@@ -174,7 +174,7 @@ private:
     }
     else
     {
-      SLIC_ERROR_ROOT("Unsupported ArrayType dimensionality in PSTEPReader::bcast_array");
+      SLIC_ERROR("Unsupported ArrayType dimensionality in PSTEPReader::bcast_array");
     }
   }
 

--- a/src/axom/quest/io/PSTEPReader.hpp
+++ b/src/axom/quest/io/PSTEPReader.hpp
@@ -17,9 +17,7 @@
 
 #include "mpi.h"
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 
 /*
@@ -53,7 +51,7 @@ public:
    * \param validate_model When true, runs OpenCascade BRep validation on rank 0
    * \return 0 on success on all ranks, non-zero otherwise
    */
-  int read(bool validate_model) override;
+  [[nodiscard]] int read(bool validate_model) override;
 
   /*!
   * \brief Generates a triangulated representation of the STEP file as a Mint unstructured triangle mesh.
@@ -72,11 +70,11 @@ public:
   *
   * The mesh is constructed on rank 0 and is then broadcast to the other ranks.
   */
-  int getTriangleMesh(axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE>* mesh,
-                      double linear_deflection = 0.1,
-                      double angular_deflection = 0.5,
-                      bool is_relative = false,
-                      bool trimmed = true) override;
+  [[nodiscard]] int getTriangleMesh(axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE>* mesh,
+                                    double linear_deflection = 0.1,
+                                    double angular_deflection = 0.5,
+                                    bool is_relative = false,
+                                    bool trimmed = true) override;
 
 private:
   /// MPI broadcasts an integer from rank 0 and returns the value to all ranks
@@ -158,16 +156,16 @@ private:
     {
       // handles 1D or 2D array of primal::Point
       // since the data is contiguous, we cast the values to a 1D ArrayView<double>
-      constexpr static int POINT_DIM = value_type::DIMENSION;
+      static constexpr int POINT_DIM = value_type::DIMENSION;
       const int numVals = arr.size() * POINT_DIM;
       double* dataPtr = nullptr;
       if constexpr(ARR_DIM == 1)  // 1D array of points
       {
-        dataPtr = (arr.size() > 0) ? arr[0].data() : nullptr;
+        dataPtr = !arr.empty() ? arr[0].data() : nullptr;
       }
       else if constexpr(ARR_DIM == 2)  // 2D array of points
       {
-        dataPtr = (arr.size() > 0) ? &arr(0, 0)[0] : nullptr;
+        dataPtr = !arr.empty() ? &arr(0, 0)[0] : nullptr;
       }
       axom::ArrayView<double> flatView(dataPtr, numVals);
       bcast_data(flatView);
@@ -187,5 +185,4 @@ private:
   DISABLE_MOVE_AND_ASSIGNMENT(PSTEPReader);
 };
 
-}  // namespace quest
-}  // namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/PSTLReader.cpp
+++ b/src/axom/quest/io/PSTLReader.cpp
@@ -6,9 +6,7 @@
 
 #include "axom/quest/io/PSTLReader.hpp"
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 namespace
 {
@@ -20,10 +18,7 @@ constexpr int READER_FAILED = -1;
 PSTLReader::PSTLReader(MPI_Comm comm) : m_comm(comm) { MPI_Comm_rank(m_comm, &m_my_rank); }
 
 //------------------------------------------------------------------------------
-PSTLReader::~PSTLReader()
-{
-  // TODO Auto-generated destructor stub
-}
+PSTLReader::~PSTLReader() = default;
 
 //------------------------------------------------------------------------------
 int PSTLReader::read()
@@ -44,11 +39,11 @@ int PSTLReader::read()
     {
       MPI_Bcast(&m_num_nodes, 1, axom::mpi_traits<axom::IndexType>::type, 0, m_comm);
       MPI_Bcast(&m_nodes[0], m_num_nodes * 3, MPI_DOUBLE, 0, m_comm);
-    }  // END if
+    }
     else
     {
       MPI_Bcast(&rc, 1, MPI_INT, 0, m_comm);
-    }  // END else
+    }
     break;
 
   default:
@@ -65,11 +60,9 @@ int PSTLReader::read()
       m_nodes.resize(m_num_nodes * 3);
       MPI_Bcast(&m_nodes[0], m_num_nodes * 3, MPI_DOUBLE, 0, m_comm);
     }
-
-  }  // END switch
+  }
 
   return (rc);
 }
 
-}  // end namespace quest
-}  // end namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/PSTLReader.hpp
+++ b/src/axom/quest/io/PSTLReader.hpp
@@ -12,9 +12,7 @@
 
 #include "mpi.h"
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 class PSTLReader : public STLReader
 {
@@ -22,7 +20,7 @@ public:
   PSTLReader() = delete;
   PSTLReader(MPI_Comm comm);
 
-  virtual ~PSTLReader();
+  ~PSTLReader() override;
 
   /*!
    * \brief Reads in an STL file to all ranks in the associated communicator.
@@ -30,7 +28,7 @@ public:
    * \note Rank 0 reads in the STL mesh file and broadcasts to the other ranks.
    * \return status set to zero on success; set to a non-zero value otherwise.
    */
-  int read() final override;
+  [[nodiscard]] int read() final override;
 
 private:
   MPI_Comm m_comm {MPI_COMM_NULL};
@@ -40,5 +38,4 @@ private:
   DISABLE_MOVE_AND_ASSIGNMENT(PSTLReader);
 };
 
-}  // namespace quest
-}  // namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/ProEReader.cpp
+++ b/src/axom/quest/io/ProEReader.cpp
@@ -151,13 +151,13 @@ void ProEReader::compact_arrays(int elt_count)
 void ProEReader::getMesh(axom::mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh)
 {
   /* Sanity checks */
-  SLIC_ERROR_ROOT_IF(mesh == nullptr, "supplied mesh is null!");
-  SLIC_ERROR_ROOT_IF(static_cast<axom::IndexType>(m_nodes.size()) != m_num_nodes * 3,
-                     "nodes vector size doesn't match expected size!");
-  SLIC_ERROR_ROOT_IF(static_cast<axom::IndexType>(m_tets.size()) != m_num_tets * 4,
-                     "tets vector size doesn't match expected size!");
-  SLIC_ERROR_ROOT_IF(mesh->getDimension() != 3, "Pro/E reader expects a 3D mesh!");
-  SLIC_ERROR_ROOT_IF(mesh->getCellType() != mint::TET, "Pro/E reader expects a tetrahedra mesh!");
+  SLIC_ERROR_IF(mesh == nullptr, "supplied mesh is null!");
+  SLIC_ERROR_IF(static_cast<axom::IndexType>(m_nodes.size()) != m_num_nodes * 3,
+                "nodes vector size doesn't match expected size!");
+  SLIC_ERROR_IF(static_cast<axom::IndexType>(m_tets.size()) != m_num_tets * 4,
+                "tets vector size doesn't match expected size!");
+  SLIC_ERROR_IF(mesh->getDimension() != 3, "Pro/E reader expects a 3D mesh!");
+  SLIC_ERROR_IF(mesh->getCellType() != mint::TET, "Pro/E reader expects a tetrahedra mesh!");
 
   // pre-allocate space to store the mesh
   if(!mesh->isExternal())
@@ -165,12 +165,12 @@ void ProEReader::getMesh(axom::mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh)
     mesh->resize(m_num_nodes, m_num_tets);
   }
 
-  SLIC_ERROR_ROOT_IF(mesh->getNumberOfNodes() != m_num_nodes,
-                     "mesh number of nodes does not match the number of nodes in "
-                     "the Pro/E file!");
-  SLIC_ERROR_ROOT_IF(mesh->getNumberOfCells() != m_num_tets,
-                     "mesh number of cells does not match number of tetrahedra in "
-                     "the Pro/E file!");
+  SLIC_ERROR_IF(mesh->getNumberOfNodes() != m_num_nodes,
+                "mesh number of nodes does not match the number of nodes in "
+                "the Pro/E file!");
+  SLIC_ERROR_IF(mesh->getNumberOfCells() != m_num_tets,
+                "mesh number of cells does not match number of tetrahedra in "
+                "the Pro/E file!");
 
   double* x = mesh->getCoordinateArray(mint::X_COORDINATE);
   double* y = mesh->getCoordinateArray(mint::Y_COORDINATE);

--- a/src/axom/quest/io/ProEReader.cpp
+++ b/src/axom/quest/io/ProEReader.cpp
@@ -53,7 +53,7 @@ int ProEReader::read()
 
   if(!ifs.is_open())
   {
-    SLIC_WARNING("Cannot open the provided Pro/E file [" << m_fileName << "]");
+    SLIC_WARNING_ROOT("Cannot open the provided Pro/E file [" << m_fileName << "]");
     return (-1);
   }
 
@@ -151,13 +151,13 @@ void ProEReader::compact_arrays(int elt_count)
 void ProEReader::getMesh(axom::mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh)
 {
   /* Sanity checks */
-  SLIC_ERROR_IF(mesh == nullptr, "supplied mesh is null!");
-  SLIC_ERROR_IF(static_cast<axom::IndexType>(m_nodes.size()) != m_num_nodes * 3,
-                "nodes vector size doesn't match expected size!");
-  SLIC_ERROR_IF(static_cast<axom::IndexType>(m_tets.size()) != m_num_tets * 4,
-                "tets vector size doesn't match expected size!");
-  SLIC_ERROR_IF(mesh->getDimension() != 3, "Pro/E reader expects a 3D mesh!");
-  SLIC_ERROR_IF(mesh->getCellType() != mint::TET, "Pro/E reader expects a tetrahedra mesh!");
+  SLIC_ERROR_ROOT_IF(mesh == nullptr, "supplied mesh is null!");
+  SLIC_ERROR_ROOT_IF(static_cast<axom::IndexType>(m_nodes.size()) != m_num_nodes * 3,
+                     "nodes vector size doesn't match expected size!");
+  SLIC_ERROR_ROOT_IF(static_cast<axom::IndexType>(m_tets.size()) != m_num_tets * 4,
+                     "tets vector size doesn't match expected size!");
+  SLIC_ERROR_ROOT_IF(mesh->getDimension() != 3, "Pro/E reader expects a 3D mesh!");
+  SLIC_ERROR_ROOT_IF(mesh->getCellType() != mint::TET, "Pro/E reader expects a tetrahedra mesh!");
 
   // pre-allocate space to store the mesh
   if(!mesh->isExternal())
@@ -165,12 +165,12 @@ void ProEReader::getMesh(axom::mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh)
     mesh->resize(m_num_nodes, m_num_tets);
   }
 
-  SLIC_ERROR_IF(mesh->getNumberOfNodes() != m_num_nodes,
-                "mesh number of nodes does not match the number of nodes in "
-                "the Pro/E file!");
-  SLIC_ERROR_IF(mesh->getNumberOfCells() != m_num_tets,
-                "mesh number of cells does not match number of tetrahedra in "
-                "the Pro/E file!");
+  SLIC_ERROR_ROOT_IF(mesh->getNumberOfNodes() != m_num_nodes,
+                     "mesh number of nodes does not match the number of nodes in "
+                     "the Pro/E file!");
+  SLIC_ERROR_ROOT_IF(mesh->getNumberOfCells() != m_num_tets,
+                     "mesh number of cells does not match number of tetrahedra in "
+                     "the Pro/E file!");
 
   double* x = mesh->getCoordinateArray(mint::X_COORDINATE);
   double* y = mesh->getCoordinateArray(mint::Y_COORDINATE);

--- a/src/axom/quest/io/ProEReader.cpp
+++ b/src/axom/quest/io/ProEReader.cpp
@@ -19,14 +19,12 @@
 //------------------------------------------------------------------------------
 //      ProEReader Implementation
 //------------------------------------------------------------------------------
-namespace axom
+namespace axom::quest
 {
-namespace quest
-{
-ProEReader::ProEReader() : m_fileName(""), m_num_nodes(0), m_num_tets(0) { }
+ProEReader::ProEReader() = default;
 
 //------------------------------------------------------------------------------
-ProEReader::~ProEReader() { this->clear(); }
+ProEReader::~ProEReader() = default;
 
 //------------------------------------------------------------------------------
 void ProEReader::clear()
@@ -197,5 +195,4 @@ void ProEReader::getMesh(axom::mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh)
   }
 }
 
-}  // end namespace quest
-}  // end namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/ProEReader.hpp
+++ b/src/axom/quest/io/ProEReader.hpp
@@ -85,13 +85,13 @@ public:
    * \brief Returns the number of nodes of the mesh.
    * \return numNodes the number of nodes.
    */
-  [[nodiscard]] int getNumNodes() const { return static_cast<int>(m_num_nodes); }
+  int getNumNodes() const { return static_cast<int>(m_num_nodes); }
 
   /*!
    * \brief Returns the number of tetrahedra of the mesh
    * \return numTets the number of tetrahedra.
    */
-  [[nodiscard]] int getNumTets() const { return static_cast<int>(m_num_tets); }
+  int getNumTets() const { return static_cast<int>(m_num_tets); }
 
   /*!
    * \brief Clears all internal data-structures

--- a/src/axom/quest/io/ProEReader.hpp
+++ b/src/axom/quest/io/ProEReader.hpp
@@ -13,12 +13,10 @@
 #include "axom/primal/geometry/BoundingBox.hpp"
 
 // C/C++ includes
-#include <string>  // for std::string
-#include <vector>  // for std::vector
+#include <string>
+#include <vector>
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 /*!
  * \class ProEReader
@@ -53,8 +51,8 @@ namespace quest
 class ProEReader
 {
 public:
-  constexpr static int NUM_NODES_PER_TET = 4;
-  constexpr static int NUM_COMPS_PER_NODE = 3;
+  static constexpr int NUM_NODES_PER_TET = 4;
+  static constexpr int NUM_COMPS_PER_NODE = 3;
   using Point3D = primal::Point<double, NUM_COMPS_PER_NODE>;
   using BBox3D = primal::BoundingBox<double, 3>;
   /*! \brief Specify tets to keep.
@@ -81,19 +79,19 @@ public:
    * \brief Sets the name of the file to read.
    * \param [in] fileName the name of the file to read.
    */
-  void setFileName(const std::string& fileName) { m_fileName = fileName; };
+  void setFileName(const std::string& fileName) { m_fileName = fileName; }
 
   /*!
    * \brief Returns the number of nodes of the mesh.
    * \return numNodes the number of nodes.
    */
-  int getNumNodes() const { return static_cast<int>(m_num_nodes); };
+  [[nodiscard]] int getNumNodes() const { return static_cast<int>(m_num_nodes); }
 
   /*!
    * \brief Returns the number of tetrahedra of the mesh
    * \return numTets the number of tetrahedra.
    */
-  int getNumTets() const { return static_cast<int>(m_num_tets); };
+  [[nodiscard]] int getNumTets() const { return static_cast<int>(m_num_tets); }
 
   /*!
    * \brief Clears all internal data-structures
@@ -105,7 +103,7 @@ public:
    * \pre path to input file has been set by calling `setFileName()`
    * \return status set to zero on success; set to a non-zero value otherwise.
    */
-  virtual int read();
+  [[nodiscard]] virtual int read();
 
   /// \name Set tetrahedron predicate to read mesh subset
   /// @{
@@ -139,8 +137,8 @@ public:
 protected:
   std::string m_fileName;
 
-  axom::IndexType m_num_nodes;
-  axom::IndexType m_num_tets;
+  axom::IndexType m_num_nodes {0};
+  axom::IndexType m_num_tets {0};
 
   std::vector<double> m_nodes;
   std::vector<int> m_tets;
@@ -161,5 +159,4 @@ private:
   DISABLE_MOVE_AND_ASSIGNMENT(ProEReader);
 };
 
-}  // namespace quest
-}  // namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/STEPReader.cpp
+++ b/src/axom/quest/io/STEPReader.cpp
@@ -166,8 +166,8 @@ private:
       // Check if the surface is periodic in u or v
       const bool isUPeriodic = m_surface->IsUPeriodic();
       const bool isVPeriodic = m_surface->IsVPeriodic();
-      SLIC_ERROR_ROOT_IF(isUPeriodic || isVPeriodic,
-                         "Axom's NURBSPatch only supports non-periodic patches");
+      SLIC_ERROR_IF(isUPeriodic || isVPeriodic,
+                    "Axom's NURBSPatch only supports non-periodic patches");
 
       // Extract weights, if the surface is rational
       const bool isRational = m_surface->IsURational() || m_surface->IsVRational();
@@ -486,7 +486,7 @@ private:
     NCurve nurbsCurve() const
     {
       const bool isPeriodic = m_curve->IsPeriodic();
-      SLIC_ERROR_ROOT_IF(isPeriodic, "Axom's NURBSCurve only supports non-periodic curves");
+      SLIC_ERROR_IF(isPeriodic, "Axom's NURBSCurve only supports non-periodic curves");
 
       return m_curve->IsRational()
         ? NCurve(extractControlPoints(), extractWeights(), extractCombinedKnots())

--- a/src/axom/quest/io/STEPReader.cpp
+++ b/src/axom/quest/io/STEPReader.cpp
@@ -719,8 +719,8 @@ public:
 
           const bool withinThreshold = patchProcessor.compareToSurface(origSurface, 25);
           SLIC_WARNING_ROOT_IF(!withinThreshold,
-                               axom::fmt::format("[Patch {}] Patch geometry was not "
-                                                 "within threshold after clamping.",
+                               axom::fmt::format("[Patch {}] Patch geometry was not within "
+                                                 "threshold after clamping.\n Patch data: {}.",
                                                  patchIndex,
                                                  patches[patchIndex]));
         }

--- a/src/axom/quest/io/STEPReader.cpp
+++ b/src/axom/quest/io/STEPReader.cpp
@@ -166,8 +166,8 @@ private:
       // Check if the surface is periodic in u or v
       const bool isUPeriodic = m_surface->IsUPeriodic();
       const bool isVPeriodic = m_surface->IsVPeriodic();
-      SLIC_ERROR_IF(isUPeriodic || isVPeriodic,
-                    "Axom's NURBSPatch only supports non-periodic patches");
+      SLIC_ERROR_ROOT_IF(isUPeriodic || isVPeriodic,
+                         "Axom's NURBSPatch only supports non-periodic patches");
 
       // Extract weights, if the surface is rational
       const bool isRational = m_surface->IsURational() || m_surface->IsVRational();
@@ -222,18 +222,18 @@ private:
 
           const double sq_dist = axom::primal::squared_distance(my_val, other_val);
           squared_sum += sq_dist;
-          SLIC_WARNING_IF(m_verbose && sq_dist > sq_tol,
-                          axom::fmt::format("Distance between surfaces at evaluated param "
-                                            "({},{}) exceeded tolerance {}.\n"
-                                            "Point on my surface {}; Point on other surface "
-                                            "{}; Squared distance {}  (running sum {})",
-                                            u,
-                                            v,
-                                            sq_tol,
-                                            my_val,
-                                            other_val,
-                                            sq_dist,
-                                            squared_sum));
+          SLIC_WARNING_ROOT_IF(m_verbose && sq_dist > sq_tol,
+                               axom::fmt::format("Distance between surfaces at evaluated param "
+                                                 "({},{}) exceeded tolerance {}.\n"
+                                                 "Point on my surface {}; Point on other surface "
+                                                 "{}; Squared distance {}  (running sum {})",
+                                                 u,
+                                                 v,
+                                                 sq_tol,
+                                                 my_val,
+                                                 other_val,
+                                                 sq_dist,
+                                                 squared_sum));
         }
       }
 
@@ -243,30 +243,30 @@ private:
     /// Logs some information about the patch
     void printSurfaceInfo() const
     {
-      SLIC_INFO(axom::fmt::format("Patch is periodic in u: {}", m_surface->IsUPeriodic()));
-      SLIC_INFO(axom::fmt::format("Patch is periodic in v: {}", m_surface->IsVPeriodic()));
+      SLIC_INFO_ROOT(axom::fmt::format("Patch is periodic in u: {}", m_surface->IsUPeriodic()));
+      SLIC_INFO_ROOT(axom::fmt::format("Patch is periodic in v: {}", m_surface->IsVPeriodic()));
 
       // Print control points
       {
         const auto patch_control_points = extractControlPoints();
-        SLIC_INFO(axom::fmt::format("Patch control points ({} x {}): {}",
-                                    patch_control_points.shape()[0],
-                                    patch_control_points.shape()[1],
-                                    patch_control_points));
+        SLIC_INFO_ROOT(axom::fmt::format("Patch control points ({} x {}): {}",
+                                         patch_control_points.shape()[0],
+                                         patch_control_points.shape()[1],
+                                         patch_control_points));
       }
 
       // Print weights (if the surface is rational)
       if(const bool isRational = m_surface->IsURational() || m_surface->IsVRational(); isRational)
       {
         const auto patch_weights = extractWeights();
-        SLIC_INFO(axom::fmt::format("Patch weights ({} x {}): {}",
-                                    patch_weights.shape()[0],
-                                    patch_weights.shape()[1],
-                                    patch_weights));
+        SLIC_INFO_ROOT(axom::fmt::format("Patch weights ({} x {}): {}",
+                                         patch_weights.shape()[0],
+                                         patch_weights.shape()[1],
+                                         patch_weights));
       }
       else
       {
-        SLIC_INFO("Patch is polynomial (uniform weights)");
+        SLIC_INFO_ROOT("Patch is polynomial (uniform weights)");
       }
     }
 
@@ -486,7 +486,7 @@ private:
     NCurve nurbsCurve() const
     {
       const bool isPeriodic = m_curve->IsPeriodic();
-      SLIC_ERROR_IF(isPeriodic, "Axom's NURBSCurve only supports non-periodic curves");
+      SLIC_ERROR_ROOT_IF(isPeriodic, "Axom's NURBSCurve only supports non-periodic curves");
 
       return m_curve->IsRational()
         ? NCurve(extractControlPoints(), extractWeights(), extractCombinedKnots())
@@ -527,17 +527,17 @@ private:
 
         const double sq_dist = axom::primal::squared_distance(my_val, other_val);
         squared_sum += sq_dist;
-        SLIC_WARNING_IF(m_verbose && sq_dist > sq_tol,
-                        axom::fmt::format("Distance between curves at evaluated param {} "
-                                          "exceeded tolerance {}.\n"
-                                          "Point on my curve {}; Point on other curve {}; "
-                                          "Squared distance {}  (running sum {})",
-                                          val,
-                                          sq_tol,
-                                          my_val,
-                                          other_val,
-                                          sq_dist,
-                                          squared_sum));
+        SLIC_WARNING_ROOT_IF(
+          m_verbose && sq_dist > sq_tol,
+          axom::fmt::format(
+            "Distance between curves at evaluated param {} exceeded tolerance {}.\n"
+            "Point on my curve {}; Point on other curve {}; Squared distance {}  (running sum {})",
+            val,
+            sq_tol,
+            my_val,
+            other_val,
+            sq_dist,
+            squared_sum));
       }
 
       return squared_sum <= sq_tol;
@@ -686,7 +686,7 @@ public:
     int patchIndex = 0;
     for(TopExp_Explorer ex(m_shape, TopAbs_FACE); ex.More(); ex.Next(), ++patchIndex)
     {
-      SLIC_DEBUG_IF(m_verbose, "*** Processing patch " << patchIndex);
+      SLIC_DEBUG_ROOT_IF(m_verbose, "*** Processing patch " << patchIndex);
       const TopoDS_Face& face = TopoDS::Face(ex.Current());
 
       opencascade::handle<Geom_Surface> surface = BRep_Tool::Surface(face);
@@ -720,19 +720,19 @@ public:
             opencascade::handle<Geom_BSplineSurface>::DownCast(surface);
 
           const bool withinThreshold = patchProcessor.compareToSurface(origSurface, 25);
-          SLIC_WARNING_IF(!withinThreshold,
-                          axom::fmt::format("[Patch {}] Patch geometry was not "
-                                            "within threshold after clamping.",
-                                            patchIndex,
-                                            patches[patchIndex]));
+          SLIC_WARNING_ROOT_IF(!withinThreshold,
+                               axom::fmt::format("[Patch {}] Patch geometry was not "
+                                                 "within threshold after clamping.",
+                                                 patchIndex,
+                                                 patches[patchIndex]));
         }
       }
       else
       {
         const std::string surfaceType = surface->DynamicType()->Name();
-        SLIC_WARNING(fmt::format("Skipping patch {} with non-BSpline surface type: '{}'",
-                                 patchIndex,
-                                 surfaceType));
+        SLIC_WARNING_ROOT(fmt::format("Skipping patch {} with non-BSpline surface type: '{}'",
+                                      patchIndex,
+                                      surfaceType));
       }
     }
   }
@@ -797,7 +797,7 @@ public:
       }
       if(!sstr.str().empty())
       {
-        SLIC_INFO(prefix << "\n" << sstr.str());
+        SLIC_INFO_ROOT(prefix << "\n" << sstr.str());
       }
     };
 
@@ -875,11 +875,12 @@ public:
       auto expandedPatchBbox = patchBbox;
       expandedPatchBbox.scale(1. + 1e-3);
 
-      SLIC_INFO_IF(m_verbose,
-                   axom::fmt::format("[Patch {}]: BBox in parametric space: {}; expanded BBox {}",
-                                     patchIndex,
-                                     patchBbox,
-                                     expandedPatchBbox));
+      SLIC_INFO_ROOT_IF(
+        m_verbose,
+        axom::fmt::format("[Patch {}]: BBox in parametric space: {}; expanded BBox {}",
+                          patchIndex,
+                          patchBbox,
+                          expandedPatchBbox));
 
       int wireIndex = 0;
       for(TopExp_Explorer wireExp(faceExp.Current(), TopAbs_WIRE); wireExp.More();
@@ -896,11 +897,11 @@ public:
           if(m_verbose)
           {
             BRepAdaptor_Curve curveAdaptor(edge);
-            SLIC_INFO(axom::fmt::format("[Patch {} Wire {} Edge {}] Curve type: '{}'",
-                                        patchIndex,
-                                        wireIndex,
-                                        edgeIndex,
-                                        curveTypeMap[curveAdaptor.GetType()]));
+            SLIC_INFO_ROOT(axom::fmt::format("[Patch {} Wire {} Edge {}] Curve type: '{}'",
+                                             patchIndex,
+                                             wireIndex,
+                                             edgeIndex,
+                                             curveTypeMap[curveAdaptor.GetType()]));
           }
 
           Standard_Real first, last;
@@ -934,12 +935,12 @@ public:
 
             patch.addTrimmingCurve(curve);
 
-            SLIC_INFO_IF(m_verbose,
-                         axom::fmt::format("[Patch {} Wire {} Edge {}] Added curve: {}",
-                                           patchIndex,
-                                           wireIndex,
-                                           edgeIndex,
-                                           curve));
+            SLIC_INFO_ROOT_IF(m_verbose,
+                              axom::fmt::format("[Patch {} Wire {} Edge {}] Added curve: {}",
+                                                patchIndex,
+                                                wireIndex,
+                                                edgeIndex,
+                                                curve));
 
             // Check to ensure that curve did not change geometrically after making non-periodic
             if(originalCurvePeriodic)
@@ -947,12 +948,13 @@ public:
               opencascade::handle<Geom2d_BSplineCurve> origCurve =
                 Geom2dConvert::CurveToBSplineCurve(parametricCurve);
               const bool withinThreshold = curveProcessor.compareToCurve(origCurve, 25);
-              SLIC_WARNING_IF(!withinThreshold,
-                              axom::fmt::format("[Patch {} Wire {} Edge {}] Trimming curve was not "
-                                                "within threshold after clamping.",
-                                                patchIndex,
-                                                wireIndex,
-                                                edgeIndex));
+              SLIC_WARNING_ROOT_IF(
+                !withinThreshold,
+                axom::fmt::format("[Patch {} Wire {} Edge {}] Trimming curve was not "
+                                  "within threshold after clamping.",
+                                  patchIndex,
+                                  wireIndex,
+                                  edgeIndex));
             }
 
             // TODO: Check that curve control points are within UV patch after adjusting periodicity
@@ -1018,8 +1020,8 @@ private:
     }
 
     m_loadStatus = LoadStatus::SUCCESS;
-    SLIC_INFO_IF(m_verbose,
-                 axom::fmt::format("Successfully read the STEP file with {} roots", numRoots));
+    SLIC_INFO_ROOT_IF(m_verbose,
+                      axom::fmt::format("Successfully read the STEP file with {} roots", numRoots));
 
     return nurbsShape;
   }
@@ -1084,8 +1086,8 @@ public:
 
       if(triangulation.IsNull())
       {
-        SLIC_WARNING(axom::fmt::format("Error: Triangulation could not be generated for patch {}",
-                                       patchIndex));
+        SLIC_WARNING_ROOT(
+          axom::fmt::format("Error: Triangulation could not be generated for patch {}", patchIndex));
         continue;
       }
 
@@ -1161,7 +1163,7 @@ public:
 
       if(triangulation.IsNull())
       {
-        SLIC_WARNING(
+        SLIC_WARNING_ROOT(
           axom::fmt::format("Error: Triangulation could not be generated for untrimmed patch {}",
                             patchIndex));
         break;
@@ -1470,7 +1472,7 @@ axom::primal::BoundingBox<double, 3> STEPReader::getBRepBoundingBox(bool useTria
 {
   if(!m_stepProcessor->isLoaded())
   {
-    SLIC_WARNING("Cannot compute bounding box until calling STEPReader::read()");
+    SLIC_WARNING_ROOT("Cannot compute bounding box until calling STEPReader::read()");
     return axom::primal::BoundingBox<double, 3> {};
   }
 
@@ -1566,13 +1568,13 @@ int STEPReader::getTriangleMesh(axom::mint::UnstructuredMesh<axom::mint::SINGLE_
 {
   if(!m_stepProcessor || !m_stepProcessor->isLoaded())
   {
-    SLIC_WARNING("Cannot triangulate model until calling STEPReader::read()");
+    SLIC_WARNING_ROOT("Cannot triangulate model until calling STEPReader::read()");
     return 1;
   }
 
   if(!mesh)
   {
-    SLIC_WARNING("Passed in mesh instance was null. Skipping triangulation");
+    SLIC_WARNING_ROOT("Passed in mesh instance was null. Skipping triangulation");
     return 1;
   }
 

--- a/src/axom/quest/io/STEPReader.cpp
+++ b/src/axom/quest/io/STEPReader.cpp
@@ -58,9 +58,7 @@
 
 #include <iostream>
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 namespace internal
 {
@@ -1213,7 +1211,7 @@ private:
   bool m_deflectionIsRelative;
 };
 
-}  // end namespace internal
+}  // namespace internal
 
 std::string STEPReader::getFileUnits() const { return m_stepProcessor->getFileUnits(); }
 
@@ -1595,5 +1593,4 @@ int STEPReader::getTriangleMesh(axom::mint::UnstructuredMesh<axom::mint::SINGLE_
   return 0;
 }
 
-}  // end namespace quest
-}  // end namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/STEPReader.hpp
+++ b/src/axom/quest/io/STEPReader.hpp
@@ -20,9 +20,7 @@
 #include <memory>
 #include <map>
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 namespace internal
 {
@@ -59,15 +57,15 @@ public:
    * \param[in] validate Adds validation tests on the model, when true
    * \return 0 for a successful read; non-zero otherwise
    */
-  virtual int read(bool validate);
+  [[nodiscard]] virtual int read(bool validate);
 
-  std::string getFileUnits() const;
+  [[nodiscard]] std::string getFileUnits() const;
 
-  PatchArray& getPatchArray() { return m_patches; }
-  const PatchArray& getPatchArray() const { return m_patches; }
+  [[nodiscard]] PatchArray& getPatchArray() { return m_patches; }
+  [[nodiscard]] const PatchArray& getPatchArray() const { return m_patches; }
 
   /// Get the number of patches in the read file
-  int numPatches() { return m_patches.size(); }
+  [[nodiscard]] int numPatches() const { return m_patches.size(); }
 
   /*!
    * \brief Returns a 0-based patch id per entry in \a getPatchArray()
@@ -75,7 +73,7 @@ public:
    * This id corresponds to the face index in the input STEP file enumeration.
    * If consumers skip patches, these ids will be non-contiguous.
    */
-  axom::ArrayView<const int> getPatchIds() const { return m_patchIds.view(); }
+  [[nodiscard]] axom::ArrayView<const int> getPatchIds() const { return m_patchIds.view(); }
 
   /*!
    * \brief Returns the 0-based wire index for each extracted trimming curve
@@ -83,19 +81,20 @@ public:
    * The i-th entry corresponds to `getPatchArray()[patchArrayIndex].getTrimmingCurves()[i]`
    * and stores the 0-based wire index from the input face enumeration.
    */
-  axom::ArrayView<const int> getTrimmingCurveWireIds(int patchArrayIndex) const;
+  [[nodiscard]] axom::ArrayView<const int> getTrimmingCurveWireIds(int patchArrayIndex) const;
 
   /// \brief Returns whether the input STEP surface was originally periodic in u for this patch
-  bool patchWasOriginallyPeriodic_u(int patchArrayIndex) const;
+  [[nodiscard]] bool patchWasOriginallyPeriodic_u(int patchArrayIndex) const;
 
   /// \brief Returns whether the input STEP surface was originally periodic in v for this patch
-  bool patchWasOriginallyPeriodic_v(int patchArrayIndex) const;
+  [[nodiscard]] bool patchWasOriginallyPeriodic_v(int patchArrayIndex) const;
 
   /// Returns some information about the loaded BRep
-  std::string getBRepStats() const;
+  [[nodiscard]] std::string getBRepStats() const;
 
   /// Returns an AABB for the loaded BRep as evaluated by OpenCascade
-  axom::primal::BoundingBox<double, 3> getBRepBoundingBox(bool useTriangulation = false) const;
+  [[nodiscard]] axom::primal::BoundingBox<double, 3> getBRepBoundingBox(
+    bool useTriangulation = false) const;
 
   /*!
    * \brief Generates a triangulated representation of the STEP file as a Mint unstructured triangle mesh.
@@ -112,15 +111,15 @@ public:
    *            otherwise, we triangulate the untrimmed patches. The latter is mostly to aid 
    *            in understanding the model's patches and is not generally useful.
    */
-  virtual int getTriangleMesh(axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE>* mesh,
-                              double linear_deflection = 0.1,
-                              double angular_deflection = 0.5,
-                              bool is_relative = false,
-                              bool trimmed = true);
+  [[nodiscard]] virtual int getTriangleMesh(axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE>* mesh,
+                                            double linear_deflection = 0.1,
+                                            double angular_deflection = 0.5,
+                                            bool is_relative = false,
+                                            bool trimmed = true);
 
 protected:
   // open cascade does not appear to offer a direct way to get the number of patches
-  int numPatchesInFile() const;
+  [[nodiscard]] int numPatchesInFile() const;
 
 protected:
   std::string m_fileName;
@@ -133,5 +132,4 @@ protected:
   IndexArray m_patchOriginallyPeriodic_v;
 };
 
-}  // namespace quest
-}  // namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/STEPReader.hpp
+++ b/src/axom/quest/io/STEPReader.hpp
@@ -59,13 +59,13 @@ public:
    */
   [[nodiscard]] virtual int read(bool validate);
 
-  [[nodiscard]] std::string getFileUnits() const;
+  std::string getFileUnits() const;
 
-  [[nodiscard]] PatchArray& getPatchArray() { return m_patches; }
-  [[nodiscard]] const PatchArray& getPatchArray() const { return m_patches; }
+  PatchArray& getPatchArray() { return m_patches; }
+  const PatchArray& getPatchArray() const { return m_patches; }
 
   /// Get the number of patches in the read file
-  [[nodiscard]] int numPatches() const { return m_patches.size(); }
+  int numPatches() const { return m_patches.size(); }
 
   /*!
    * \brief Returns a 0-based patch id per entry in \a getPatchArray()
@@ -73,7 +73,7 @@ public:
    * This id corresponds to the face index in the input STEP file enumeration.
    * If consumers skip patches, these ids will be non-contiguous.
    */
-  [[nodiscard]] axom::ArrayView<const int> getPatchIds() const { return m_patchIds.view(); }
+  axom::ArrayView<const int> getPatchIds() const { return m_patchIds.view(); }
 
   /*!
    * \brief Returns the 0-based wire index for each extracted trimming curve
@@ -81,20 +81,19 @@ public:
    * The i-th entry corresponds to `getPatchArray()[patchArrayIndex].getTrimmingCurves()[i]`
    * and stores the 0-based wire index from the input face enumeration.
    */
-  [[nodiscard]] axom::ArrayView<const int> getTrimmingCurveWireIds(int patchArrayIndex) const;
+  axom::ArrayView<const int> getTrimmingCurveWireIds(int patchArrayIndex) const;
 
   /// \brief Returns whether the input STEP surface was originally periodic in u for this patch
-  [[nodiscard]] bool patchWasOriginallyPeriodic_u(int patchArrayIndex) const;
+  bool patchWasOriginallyPeriodic_u(int patchArrayIndex) const;
 
   /// \brief Returns whether the input STEP surface was originally periodic in v for this patch
-  [[nodiscard]] bool patchWasOriginallyPeriodic_v(int patchArrayIndex) const;
+  bool patchWasOriginallyPeriodic_v(int patchArrayIndex) const;
 
   /// Returns some information about the loaded BRep
-  [[nodiscard]] std::string getBRepStats() const;
+  std::string getBRepStats() const;
 
   /// Returns an AABB for the loaded BRep as evaluated by OpenCascade
-  [[nodiscard]] axom::primal::BoundingBox<double, 3> getBRepBoundingBox(
-    bool useTriangulation = false) const;
+  axom::primal::BoundingBox<double, 3> getBRepBoundingBox(bool useTriangulation = false) const;
 
   /*!
    * \brief Generates a triangulated representation of the STEP file as a Mint unstructured triangle mesh.
@@ -119,7 +118,7 @@ public:
 
 protected:
   // open cascade does not appear to offer a direct way to get the number of patches
-  [[nodiscard]] int numPatchesInFile() const;
+  int numPatchesInFile() const;
 
 protected:
   std::string m_fileName;

--- a/src/axom/quest/io/STLReader.cpp
+++ b/src/axom/quest/io/STLReader.cpp
@@ -16,21 +16,19 @@
 
 namespace
 {
-const std::size_t BINARY_HEADER_SIZE = 80;  // bytes
-const std::size_t BINARY_TRI_SIZE = 50;     // bytes
+constexpr std::size_t binary_header_size = 80;  // bytes
+constexpr std::size_t binary_tri_size = 50;     // bytes
 }  // namespace
 
 //------------------------------------------------------------------------------
 //      STLReader Implementation
 //------------------------------------------------------------------------------
-namespace axom
+namespace axom::quest
 {
-namespace quest
-{
-STLReader::STLReader() : m_fileName(""), m_num_nodes(0), m_num_faces(0) { }
+STLReader::STLReader() = default;
 
 //------------------------------------------------------------------------------
-STLReader::~STLReader() { this->clear(); }
+STLReader::~STLReader() = default;
 
 //------------------------------------------------------------------------------
 void STLReader::clear()
@@ -44,9 +42,9 @@ void STLReader::clear()
 bool STLReader::isAsciiFormat() const
 {
   // The binary format consists of
-  //    a header of size BINARY_HEADER_SIZE==80 bytes
+  //    a header of size binary_header_size==80 bytes
   //    followed by a four byte int encoding the number of triangles
-  //    followed by the triangle data (BINARY_TRI_SIZE == 50 bytes per triangle)
+  //    followed by the triangle data (binary_tri_size == 50 bytes per triangle)
 
   // Open the file
   std::ifstream ifs(m_fileName.c_str(), std::ios::in | std::ios::binary);
@@ -62,15 +60,15 @@ bool STLReader::isAsciiFormat() const
   ifs.seekg(0, ifs.end);
   std::int32_t fileSize = static_cast<std::int32_t>(ifs.tellg());
 
-  const int totalHeaderSize = (BINARY_HEADER_SIZE + sizeof(std::int32_t));
-  if(fileSize < totalHeaderSize)
+  constexpr int total_header_size = binary_header_size + sizeof(std::int32_t);
+  if(fileSize < total_header_size)
   {
     return true;
   }
 
   // Find the number of triangles (if the file were binary)
   int numTris = 0;
-  ifs.seekg(BINARY_HEADER_SIZE, ifs.beg);
+  ifs.seekg(binary_header_size, ifs.beg);
   ifs.read((char*)&numTris, sizeof(std::int32_t));
 
   if(!utilities::isLittleEndian())
@@ -79,11 +77,11 @@ bool STLReader::isAsciiFormat() const
   }
 
   // Check if the size matches our expectation
-  int expectedBinarySize = totalHeaderSize + (numTris * BINARY_TRI_SIZE);
+  const int expected_binary_size = total_header_size + (numTris * binary_tri_size);
 
   ifs.close();
 
-  return (fileSize != expectedBinarySize);
+  return (fileSize != expected_binary_size);
 }
 
 //------------------------------------------------------------------------------
@@ -132,14 +130,14 @@ int STLReader::readAsciiSTL()
 int STLReader::readBinarySTL()
 {
   // Binary STL format consists of
-  //    an 80 byte header (BINARY_HEADER_SIZE)
+  //    an 80 byte header (binary_header_size)
   //    followed by a 32 bit int encoding the number of faces
-  //    followed by the triangles, each of which is 50 bytes (BINARY_TRI_SIZE)
+  //    followed by the triangles, each of which is 50 bytes (binary_tri_size)
 
   // A local union data structure for triangles in a binary STL
   union BinarySTLTri
   {
-    std::int8_t raw[BINARY_TRI_SIZE];
+    std::int8_t raw[binary_tri_size];
 
     struct
     {
@@ -160,7 +158,7 @@ int STLReader::readBinarySTL()
     return (-1);
   }
 
-  ifs.seekg(BINARY_HEADER_SIZE);
+  ifs.seekg(binary_header_size);
 
   // read the num faces and reserve room for the vertex positions
   ifs.read((char*)&m_num_faces, sizeof(std::int32_t));
@@ -176,7 +174,7 @@ int STLReader::readBinarySTL()
   // Read the triangles. Cast to doubles and ignore normals and attributes
   for(axom::IndexType i = 0; i < m_num_faces; ++i)
   {
-    ifs.read((char*)tri.raw, BINARY_TRI_SIZE);
+    ifs.read((char*)tri.raw, binary_tri_size);
 
     for(int j = 0; j < 9; ++j)
     {
@@ -251,5 +249,4 @@ void STLReader::getMesh(axom::mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh)
   }
 }
 
-}  // end namespace quest
-}  // end namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/STLReader.cpp
+++ b/src/axom/quest/io/STLReader.cpp
@@ -210,11 +210,11 @@ int STLReader::read()
 void STLReader::getMesh(axom::mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh)
 {
   /* Sanity checks */
-  SLIC_ERROR_ROOT_IF(mesh == nullptr, "supplied mesh is null!");
-  SLIC_ERROR_ROOT_IF(static_cast<axom::IndexType>(m_nodes.size()) != 3 * m_num_nodes,
-                     "nodes vector size doesn't match expected size!");
-  SLIC_ERROR_ROOT_IF(mesh->getDimension() != 3, "STL reader expects a 3D mesh!");
-  SLIC_ERROR_ROOT_IF(mesh->getCellType() != mint::TRIANGLE, "STL reader expects a triangle mesh!");
+  SLIC_ERROR_IF(mesh == nullptr, "supplied mesh is null!");
+  SLIC_ERROR_IF(static_cast<axom::IndexType>(m_nodes.size()) != 3 * m_num_nodes,
+                "nodes vector size doesn't match expected size!");
+  SLIC_ERROR_IF(mesh->getDimension() != 3, "STL reader expects a 3D mesh!");
+  SLIC_ERROR_IF(mesh->getCellType() != mint::TRIANGLE, "STL reader expects a triangle mesh!");
 
   // pre-allocate space to store the mesh
   if(!mesh->isExternal())
@@ -222,10 +222,10 @@ void STLReader::getMesh(axom::mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh)
     mesh->resize(m_num_nodes, m_num_faces);
   }
 
-  SLIC_ERROR_ROOT_IF(mesh->getNumberOfNodes() != m_num_nodes,
-                     "mesh number of nodes does not match the number of nodes in the STL file!");
-  SLIC_ERROR_ROOT_IF(mesh->getNumberOfCells() != m_num_faces,
-                     "mesh number of cells does not match number of triangles in the STL file!");
+  SLIC_ERROR_IF(mesh->getNumberOfNodes() != m_num_nodes,
+                "mesh number of nodes does not match the number of nodes in the STL file!");
+  SLIC_ERROR_IF(mesh->getNumberOfCells() != m_num_faces,
+                "mesh number of cells does not match number of triangles in the STL file!");
 
   double* x = mesh->getCoordinateArray(mint::X_COORDINATE);
   double* y = mesh->getCoordinateArray(mint::Y_COORDINATE);

--- a/src/axom/quest/io/STLReader.cpp
+++ b/src/axom/quest/io/STLReader.cpp
@@ -16,8 +16,8 @@
 
 namespace
 {
-constexpr std::size_t binary_header_size = 80;  // bytes
-constexpr std::size_t binary_tri_size = 50;     // bytes
+constexpr std::size_t BINARY_HEADER_SIZE = 80;  // bytes
+constexpr std::size_t BINARY_TRI_SIZE = 50;     // bytes
 }  // namespace
 
 //------------------------------------------------------------------------------
@@ -42,9 +42,9 @@ void STLReader::clear()
 bool STLReader::isAsciiFormat() const
 {
   // The binary format consists of
-  //    a header of size binary_header_size==80 bytes
+  //    a header of size BINARY_HEADER_SIZE==80 bytes
   //    followed by a four byte int encoding the number of triangles
-  //    followed by the triangle data (binary_tri_size == 50 bytes per triangle)
+  //    followed by the triangle data (BINARY_TRI_SIZE == 50 bytes per triangle)
 
   // Open the file
   std::ifstream ifs(m_fileName.c_str(), std::ios::in | std::ios::binary);
@@ -60,15 +60,15 @@ bool STLReader::isAsciiFormat() const
   ifs.seekg(0, ifs.end);
   std::int32_t fileSize = static_cast<std::int32_t>(ifs.tellg());
 
-  constexpr int total_header_size = binary_header_size + sizeof(std::int32_t);
-  if(fileSize < total_header_size)
+  constexpr int TOTAL_HEADER_SIZE = BINARY_HEADER_SIZE + sizeof(std::int32_t);
+  if(fileSize < TOTAL_HEADER_SIZE)
   {
     return true;
   }
 
   // Find the number of triangles (if the file were binary)
   int numTris = 0;
-  ifs.seekg(binary_header_size, ifs.beg);
+  ifs.seekg(BINARY_HEADER_SIZE, ifs.beg);
   ifs.read((char*)&numTris, sizeof(std::int32_t));
 
   if(!utilities::isLittleEndian())
@@ -77,11 +77,11 @@ bool STLReader::isAsciiFormat() const
   }
 
   // Check if the size matches our expectation
-  const int expected_binary_size = total_header_size + (numTris * binary_tri_size);
+  const int EXPECTED_BINARY_SIZE = TOTAL_HEADER_SIZE + (numTris * BINARY_TRI_SIZE);
 
   ifs.close();
 
-  return (fileSize != expected_binary_size);
+  return (fileSize != EXPECTED_BINARY_SIZE);
 }
 
 //------------------------------------------------------------------------------
@@ -130,14 +130,14 @@ int STLReader::readAsciiSTL()
 int STLReader::readBinarySTL()
 {
   // Binary STL format consists of
-  //    an 80 byte header (binary_header_size)
+  //    an 80 byte header (BINARY_HEADER_SIZE)
   //    followed by a 32 bit int encoding the number of faces
-  //    followed by the triangles, each of which is 50 bytes (binary_tri_size)
+  //    followed by the triangles, each of which is 50 bytes (BINARY_TRI_SIZE)
 
   // A local union data structure for triangles in a binary STL
   union BinarySTLTri
   {
-    std::int8_t raw[binary_tri_size];
+    std::int8_t raw[BINARY_TRI_SIZE];
 
     struct
     {
@@ -158,7 +158,7 @@ int STLReader::readBinarySTL()
     return (-1);
   }
 
-  ifs.seekg(binary_header_size);
+  ifs.seekg(BINARY_HEADER_SIZE);
 
   // read the num faces and reserve room for the vertex positions
   ifs.read((char*)&m_num_faces, sizeof(std::int32_t));
@@ -174,7 +174,7 @@ int STLReader::readBinarySTL()
   // Read the triangles. Cast to doubles and ignore normals and attributes
   for(axom::IndexType i = 0; i < m_num_faces; ++i)
   {
-    ifs.read((char*)tri.raw, binary_tri_size);
+    ifs.read((char*)tri.raw, BINARY_TRI_SIZE);
 
     for(int j = 0; j < 9; ++j)
     {

--- a/src/axom/quest/io/STLReader.cpp
+++ b/src/axom/quest/io/STLReader.cpp
@@ -54,7 +54,7 @@ bool STLReader::isAsciiFormat() const
   if(!ifs.is_open())
   {
     /* short-circuit */
-    SLIC_WARNING("Cannot open the provided STL file [" << m_fileName << "]");
+    SLIC_WARNING_ROOT("Cannot open the provided STL file [" << m_fileName << "]");
     return false;
   }
 
@@ -93,7 +93,7 @@ int STLReader::readAsciiSTL()
 
   if(!ifs.is_open())
   {
-    SLIC_WARNING("Cannot open the provided STL file [" << m_fileName << "]");
+    SLIC_WARNING_ROOT("Cannot open the provided STL file [" << m_fileName << "]");
     return (-1);
   }
 
@@ -156,7 +156,7 @@ int STLReader::readBinarySTL()
   std::ifstream ifs(m_fileName.c_str(), std::ios::in | std::ios::binary);
   if(!ifs.is_open())
   {
-    SLIC_WARNING("Cannot open the provided STL file [" << m_fileName << "]");
+    SLIC_WARNING_ROOT("Cannot open the provided STL file [" << m_fileName << "]");
     return (-1);
   }
 
@@ -210,11 +210,11 @@ int STLReader::read()
 void STLReader::getMesh(axom::mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh)
 {
   /* Sanity checks */
-  SLIC_ERROR_IF(mesh == nullptr, "supplied mesh is null!");
-  SLIC_ERROR_IF(static_cast<axom::IndexType>(m_nodes.size()) != 3 * m_num_nodes,
-                "nodes vector size doesn't match expected size!");
-  SLIC_ERROR_IF(mesh->getDimension() != 3, "STL reader expects a 3D mesh!");
-  SLIC_ERROR_IF(mesh->getCellType() != mint::TRIANGLE, "STL reader expects a triangle mesh!");
+  SLIC_ERROR_ROOT_IF(mesh == nullptr, "supplied mesh is null!");
+  SLIC_ERROR_ROOT_IF(static_cast<axom::IndexType>(m_nodes.size()) != 3 * m_num_nodes,
+                     "nodes vector size doesn't match expected size!");
+  SLIC_ERROR_ROOT_IF(mesh->getDimension() != 3, "STL reader expects a 3D mesh!");
+  SLIC_ERROR_ROOT_IF(mesh->getCellType() != mint::TRIANGLE, "STL reader expects a triangle mesh!");
 
   // pre-allocate space to store the mesh
   if(!mesh->isExternal())
@@ -222,10 +222,10 @@ void STLReader::getMesh(axom::mint::UnstructuredMesh<mint::SINGLE_SHAPE>* mesh)
     mesh->resize(m_num_nodes, m_num_faces);
   }
 
-  SLIC_ERROR_IF(mesh->getNumberOfNodes() != m_num_nodes,
-                "mesh number of nodes does not match the number of nodes in the STL file!");
-  SLIC_ERROR_IF(mesh->getNumberOfCells() != m_num_faces,
-                "mesh number of cells does not match number of triangles in the STL file!");
+  SLIC_ERROR_ROOT_IF(mesh->getNumberOfNodes() != m_num_nodes,
+                     "mesh number of nodes does not match the number of nodes in the STL file!");
+  SLIC_ERROR_ROOT_IF(mesh->getNumberOfCells() != m_num_faces,
+                     "mesh number of cells does not match number of triangles in the STL file!");
 
   double* x = mesh->getCoordinateArray(mint::X_COORDINATE);
   double* y = mesh->getCoordinateArray(mint::Y_COORDINATE);

--- a/src/axom/quest/io/STLReader.hpp
+++ b/src/axom/quest/io/STLReader.hpp
@@ -45,13 +45,13 @@ public:
    * \brief Returns the number of nodes of the surface mesh.
    * \return numNodes the number of nodes.
    */
-  [[nodiscard]] int getNumNodes() const { return static_cast<int>(m_num_nodes); }
+  int getNumNodes() const { return static_cast<int>(m_num_nodes); }
 
   /*!
    * \brief Returns the number of faces of the surface mesh.
    * \return numFaces the number of faces.
    */
-  [[nodiscard]] int getNumFaces() const { return static_cast<int>(m_num_faces); }
+  int getNumFaces() const { return static_cast<int>(m_num_faces); }
 
   /// \brief Clears all internal data-structures
   void clear();
@@ -82,7 +82,7 @@ private:
    *
    * \return True, if the file is ascii encoded, False if it is binary
    */
-  [[nodiscard]] bool isAsciiFormat() const;
+  bool isAsciiFormat() const;
 
   /*!
    * \brief Reads an ascii-encoded STL file into memory

--- a/src/axom/quest/io/STLReader.hpp
+++ b/src/axom/quest/io/STLReader.hpp
@@ -15,9 +15,7 @@
 #include <string>  // for std::string
 #include <vector>  // for std::vector
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 /*!
  * \class STLReader
@@ -41,19 +39,19 @@ public:
    * \brief Sets the name of the file to read.
    * \param [in] fileName the name of the file to read.
    */
-  void setFileName(const std::string& fileName) { m_fileName = fileName; };
+  void setFileName(const std::string& fileName) { m_fileName = fileName; }
 
   /*!
    * \brief Returns the number of nodes of the surface mesh.
    * \return numNodes the number of nodes.
    */
-  int getNumNodes() const { return static_cast<int>(m_num_nodes); };
+  [[nodiscard]] int getNumNodes() const { return static_cast<int>(m_num_nodes); }
 
   /*!
    * \brief Returns the number of faces of the surface mesh.
    * \return numFaces the number of faces.
    */
-  int getNumFaces() const { return static_cast<int>(m_num_faces); };
+  [[nodiscard]] int getNumFaces() const { return static_cast<int>(m_num_faces); }
 
   /// \brief Clears all internal data-structures
   void clear();
@@ -63,7 +61,7 @@ public:
    * \pre path to input file has been set by calling `setFileName()`
    * \return status set to zero on success; set to a non-zero value otherwise.
    */
-  virtual int read();
+  [[nodiscard]] virtual int read();
 
   /*!
    * \brief Stores the STL data in the supplied unstructured mesh object.
@@ -84,25 +82,25 @@ private:
    *
    * \return True, if the file is ascii encoded, False if it is binary
    */
-  bool isAsciiFormat() const;
+  [[nodiscard]] bool isAsciiFormat() const;
 
   /*!
    * \brief Reads an ascii-encoded STL file into memory
    * \note The filename should be set with STLReader::setFileName()
    */
-  int readAsciiSTL();
+  [[nodiscard]] int readAsciiSTL();
 
   /*!
    * \brief Reads a binary-encoded STL file into memory
    * \note The filename should be set with STLReader::setFileName()
    */
-  int readBinarySTL();
+  [[nodiscard]] int readBinarySTL();
 
 protected:
   std::string m_fileName;
 
-  axom::IndexType m_num_nodes;
-  axom::IndexType m_num_faces;
+  axom::IndexType m_num_nodes {0};
+  axom::IndexType m_num_faces {0};
 
   std::vector<double> m_nodes;
 
@@ -111,5 +109,4 @@ private:
   DISABLE_MOVE_AND_ASSIGNMENT(STLReader);
 };
 
-}  // namespace quest
-}  // namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/STLReader.hpp
+++ b/src/axom/quest/io/STLReader.hpp
@@ -31,14 +31,10 @@ namespace quest
 class STLReader
 {
 public:
-  /*!
-   * \brief Constructor.
-   */
+  /// \brief Constructor
   STLReader();
 
-  /*!
-   * \brief Destructor.
-   */
+  /// \brief Destructor
   virtual ~STLReader();
 
   /*!
@@ -59,9 +55,7 @@ public:
    */
   int getNumFaces() const { return static_cast<int>(m_num_faces); };
 
-  /*!
-   * \brief Clears all internal data-structures
-   */
+  /// \brief Clears all internal data-structures
   void clear();
 
   /*!

--- a/src/axom/quest/io/STLWriter.cpp
+++ b/src/axom/quest/io/STLWriter.cpp
@@ -13,9 +13,7 @@
 #include <cstring>
 #include <fstream>
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 namespace internal
 {
@@ -45,7 +43,7 @@ void writeTriangle(std::ofstream& out, bool binary, double coords[3][3], const N
     }
     // The attribute is sometimes used as colors. Set bits to white.
     // See https://en.wikipedia.org/wiki/STL_(file_format).
-    const std::uint16_t attr = 0x7fff;
+    constexpr std::uint16_t attr = 0x7fff;
     out.write(reinterpret_cast<const char*>(n32), 3 * sizeof(float32));
     out.write(reinterpret_cast<const char*>(coords32[0]), 3 * sizeof(float32));
     out.write(reinterpret_cast<const char*>(coords32[1]), 3 * sizeof(float32));
@@ -64,11 +62,10 @@ void writeTriangle(std::ofstream& out, bool binary, double coords[3][3], const N
   }
 }
 
-}  // end namespace internal
+}  // namespace internal
 
 STLWriter::STLWriter(const std::string& filename, bool binary)
-  : m_mesh(nullptr)
-  , m_fileName(filename)
+  : m_fileName(filename)
   , m_binary(binary)
 { }
 
@@ -121,7 +118,7 @@ int STLWriter::write(const mint::Mesh* mesh)
   using VectorType = axom::primal::Vector<double, 3>;
 
   SLIC_ERROR_IF(mesh == nullptr, "mesh pointer is null!");
-  SLIC_ERROR_IF(m_fileName.length() <= 0, "STL filename is empty!");
+  SLIC_ERROR_IF(m_fileName.empty(), "STL filename is empty!");
   SLIC_ERROR_IF(mesh->getDimension() < 2 || mesh->getDimension() > 3, "Input mesh is not 2D/3D.");
 
   // Save mesh pointer
@@ -138,14 +135,14 @@ int STLWriter::write(const mint::Mesh* mesh)
   // Write header
   if(m_binary)
   {
-    constexpr int STL_HEADER_SIZE = 80;
-    std::uint8_t header[STL_HEADER_SIZE];
+    constexpr int stl_header_size = 80;
+    std::uint8_t header[stl_header_size];
     // Fill with spaces
-    memset(header, ' ', sizeof(std::uint8_t) * STL_HEADER_SIZE);
+    memset(header, ' ', sizeof(std::uint8_t) * stl_header_size);
     // Copy in string (without terminator)
-    const char* msg = "STL Binary File Written By Axom";
-    memcpy(header, msg, strlen(msg));
-    out.write(reinterpret_cast<const char*>(header), STL_HEADER_SIZE);
+    constexpr char message[] = "STL Binary File Written By Axom";
+    memcpy(header, message, strlen(message));
+    out.write(reinterpret_cast<const char*>(header), stl_header_size);
 
     // Write number of triangles
     std::uint32_t ntri = static_cast<std::uint32_t>(getNumberOfTriangles());
@@ -233,5 +230,4 @@ int write_stl(const mint::Mesh* mesh, const std::string& filename, bool binary)
   return w.write(mesh);
 }
 
-}  // namespace quest
-}  // namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/io/STLWriter.cpp
+++ b/src/axom/quest/io/STLWriter.cpp
@@ -135,14 +135,14 @@ int STLWriter::write(const mint::Mesh* mesh)
   // Write header
   if(m_binary)
   {
-    constexpr int stl_header_size = 80;
-    std::uint8_t header[stl_header_size];
+    constexpr int STL_HEADER_SIZE = 80;
+    std::uint8_t header[STL_HEADER_SIZE];
     // Fill with spaces
-    memset(header, ' ', sizeof(std::uint8_t) * stl_header_size);
+    memset(header, ' ', sizeof(std::uint8_t) * STL_HEADER_SIZE);
     // Copy in string (without terminator)
-    constexpr char message[] = "STL Binary File Written By Axom";
-    memcpy(header, message, strlen(message));
-    out.write(reinterpret_cast<const char*>(header), stl_header_size);
+    constexpr char msg[] = "STL Binary File Written By Axom";
+    memcpy(header, msg, strlen(msg));
+    out.write(reinterpret_cast<const char*>(header), STL_HEADER_SIZE);
 
     // Write number of triangles
     std::uint32_t ntri = static_cast<std::uint32_t>(getNumberOfTriangles());

--- a/src/axom/quest/io/STLWriter.hpp
+++ b/src/axom/quest/io/STLWriter.hpp
@@ -80,14 +80,14 @@ protected:
    *
    * \return The number of triangles.
    */
-  [[nodiscard]] IndexType getNumberOfTriangles() const;
+  IndexType getNumberOfTriangles() const;
 
   /*!
    * \brief Determines whether the input mesh is topologically 2D.
    *
    * \return True if the mesh is topologically 2D, false otherwise.
    */
-  [[nodiscard]] bool isTopologically2D() const;
+  bool isTopologically2D() const;
 
   const mint::Mesh* m_mesh {nullptr};
   std::string m_fileName {"output.stl"};

--- a/src/axom/quest/io/STLWriter.hpp
+++ b/src/axom/quest/io/STLWriter.hpp
@@ -13,9 +13,7 @@
 
 #include <string>
 
-namespace axom
-{
-namespace quest
+namespace axom::quest
 {
 /*!
  * \class STLWriter
@@ -70,7 +68,7 @@ public:
    * \pre path to input file has been set by calling `setFileName()`
    * \return status set to zero on success; set to a non-zero value otherwise.
    */
-  int write(const mint::Mesh* mesh);
+  [[nodiscard]] int write(const mint::Mesh* mesh);
 
 // The following members are protected (unless using CUDA)
 #if !defined(__CUDACC__)
@@ -82,14 +80,14 @@ protected:
    *
    * \return The number of triangles.
    */
-  IndexType getNumberOfTriangles() const;
+  [[nodiscard]] IndexType getNumberOfTriangles() const;
 
   /*!
    * \brief Determines whether the input mesh is topologically 2D.
    *
    * \return True if the mesh is topologically 2D, false otherwise.
    */
-  bool isTopologically2D() const;
+  [[nodiscard]] bool isTopologically2D() const;
 
   const mint::Mesh* m_mesh {nullptr};
   std::string m_fileName {"output.stl"};
@@ -105,7 +103,6 @@ protected:
  *
  * \return 0 on success; non-zero otherwise.
  */
-int write_stl(const mint::Mesh* mesh, const std::string& filename, bool binary = false);
+[[nodiscard]] int write_stl(const mint::Mesh* mesh, const std::string& filename, bool binary = false);
 
-}  // namespace quest
-}  // namespace axom
+}  // namespace axom::quest

--- a/src/axom/quest/tests/quest_c2c_reader.cpp
+++ b/src/axom/quest/tests/quest_c2c_reader.cpp
@@ -135,7 +135,7 @@ TEST(quest_c2c_reader, basic_read)
   quest::C2CReader reader;
   reader.setFileName(fileName);
 
-  reader.read();
+  ASSERT_EQ(0, reader.read());
   reader.log();
 }
 
@@ -147,7 +147,7 @@ TEST(quest_c2c_reader, interpolate_circle)
   quest::C2CReader reader;
   reader.setFileName(fileName);
 
-  reader.read();
+  ASSERT_EQ(0, reader.read());
   reader.log();
 
   constexpr int DIM = 2;
@@ -224,7 +224,7 @@ TEST(quest_c2c_reader, interpolate_square)
   quest::C2CReader reader;
   reader.setFileName(fileName);
 
-  reader.read();
+  ASSERT_EQ(0, reader.read());
   reader.log();
 
   constexpr int DIM = 2;
@@ -261,7 +261,7 @@ TEST(quest_c2c_reader, interpolate_spline)
   quest::C2CReader reader;
   reader.setFileName(fileName);
 
-  reader.read();
+  ASSERT_EQ(0, reader.read());
   reader.log();
 
   constexpr int DIM = 2;

--- a/src/axom/quest/tests/quest_gwn_methods.cpp
+++ b/src/axom/quest/tests/quest_gwn_methods.cpp
@@ -277,7 +277,7 @@ void check_step_file_evaluation()
 
   // Get a triangulation of the shape
   axom::mint::UnstructuredMesh<axom::mint::SINGLE_SHAPE> tri_mesh(3, axom::mint::TRIANGLE);
-  step_reader.getTriangleMesh(&tri_mesh, 0.01, 0.5);
+  ASSERT_EQ(step_reader.getTriangleMesh(&tri_mesh, 0.01, 0.5), 0);
 
   // Get bounding box of the shape
   axom::primal::BoundingBox<double, 3> shape_bbox = step_reader.getBRepBoundingBox();

--- a/src/axom/quest/tests/quest_meshtester.cpp
+++ b/src/axom/quest/tests/quest_meshtester.cpp
@@ -339,7 +339,7 @@ TEST(quest_mesh_tester, surfacemesh_self_intersection_ondisk)
       // read in the test file into a Mesh
       quest::STLReader reader;
       reader.setFileName(tfname);
-      reader.read();
+      ASSERT_EQ(reader.read(), 0);
 
       // Get surface mesh
       UMesh* surface_mesh = new UMesh(3, mint::TRIANGLE);
@@ -463,7 +463,7 @@ TEST(quest_mesh_tester, surfacemesh_watertight_ondisk)
         // Read in the test file into a Mesh
         quest::STLReader reader;
         reader.setFileName(tfname);
-        reader.read();
+        ASSERT_EQ(reader.read(), 0);
 
         // Get surface mesh
         UMesh* surface_mesh = new UMesh(3, mint::TRIANGLE);

--- a/src/axom/quest/tests/quest_step_reader.cpp
+++ b/src/axom/quest/tests/quest_step_reader.cpp
@@ -204,7 +204,7 @@ void runStepFileTest(const std::string& stepFile, double deflection = 0.1)
   }
 
   mint::UnstructuredMesh<mint::SINGLE_SHAPE> triMesh(3, mint::TRIANGLE);
-  stepReader.getTriangleMesh(&triMesh, deflection);
+  ASSERT_EQ(0, stepReader.getTriangleMesh(&triMesh, deflection));
 
   MiniTriangleGWN3D triEval;
   triEval.preprocess(triMesh);

--- a/src/examples/radiuss_tutorial/lesson_01/README.md
+++ b/src/examples/radiuss_tutorial/lesson_01/README.md
@@ -195,7 +195,8 @@ TriangleMesh makeTriangleMesh(const std::string& stl_mesh_path)
   {
     auto reader = std::make_unique<axom::quest::STLReader>();
     reader->setFileName(stl_mesh_path);
-    reader->read();
+    SLIC_ERROR_IF(reader->read() != 0,
+                  "Failed to load STL file '" << stl_mesh_path << "'.");
     reader->getMesh(surface_mesh.get());
   }
 

--- a/src/examples/radiuss_tutorial/lesson_01/README.md
+++ b/src/examples/radiuss_tutorial/lesson_01/README.md
@@ -195,8 +195,8 @@ TriangleMesh makeTriangleMesh(const std::string& stl_mesh_path)
   {
     auto reader = std::make_unique<axom::quest::STLReader>();
     reader->setFileName(stl_mesh_path);
-    SLIC_ERROR_IF(reader->read() != 0,
-                  "Failed to load STL file '" << stl_mesh_path << "'.");
+    const int read_status = reader->read();
+    SLIC_ERROR_IF(read_status != 0, "Failed to load STL file '" << stl_mesh_path << "'.");
     reader->getMesh(surface_mesh.get());
   }
 

--- a/src/examples/radiuss_tutorial/lesson_01/load_stl_mesh.cpp
+++ b/src/examples/radiuss_tutorial/lesson_01/load_stl_mesh.cpp
@@ -117,7 +117,8 @@ TriangleMesh makeTriangleMesh(const std::string& stl_mesh_path)
   {
     auto reader = std::make_unique<axom::quest::STLReader>();
     reader->setFileName(stl_mesh_path);
-    SLIC_ERROR_IF(reader->read() != 0, "Failed to load STL file '" << stl_mesh_path << "'.");
+    const int read_status = reader->read();
+    SLIC_ERROR_IF(read_status != 0, "Failed to load STL file '" << stl_mesh_path << "'.");
     reader->getMesh(surface_mesh.get());
   }
 

--- a/src/examples/radiuss_tutorial/lesson_01/load_stl_mesh.cpp
+++ b/src/examples/radiuss_tutorial/lesson_01/load_stl_mesh.cpp
@@ -117,7 +117,7 @@ TriangleMesh makeTriangleMesh(const std::string& stl_mesh_path)
   {
     auto reader = std::make_unique<axom::quest::STLReader>();
     reader->setFileName(stl_mesh_path);
-    reader->read();
+    SLIC_ERROR_IF(reader->read() != 0, "Failed to load STL file '" << stl_mesh_path << "'.");
     reader->getMesh(surface_mesh.get());
   }
 

--- a/src/examples/radiuss_tutorial/lesson_02/naive_self_intersections.cpp
+++ b/src/examples/radiuss_tutorial/lesson_02/naive_self_intersections.cpp
@@ -161,7 +161,8 @@ TriangleMesh makeTriangleMesh(const std::string& stl_mesh_path, double weldThres
 
     auto reader = std::make_unique<axom::quest::STLReader>();
     reader->setFileName(stl_mesh_path);
-    SLIC_ERROR_IF(reader->read() != 0, "Failed to load STL file '" << stl_mesh_path << "'.");
+    const int read_status = reader->read();
+    SLIC_ERROR_IF(read_status != 0, "Failed to load STL file '" << stl_mesh_path << "'.");
     reader->getMesh(surface_mesh);
 
     timer.stop();

--- a/src/examples/radiuss_tutorial/lesson_02/naive_self_intersections.cpp
+++ b/src/examples/radiuss_tutorial/lesson_02/naive_self_intersections.cpp
@@ -161,7 +161,7 @@ TriangleMesh makeTriangleMesh(const std::string& stl_mesh_path, double weldThres
 
     auto reader = std::make_unique<axom::quest::STLReader>();
     reader->setFileName(stl_mesh_path);
-    reader->read();
+    SLIC_ERROR_IF(reader->read() != 0, "Failed to load STL file '" << stl_mesh_path << "'.");
     reader->getMesh(surface_mesh);
 
     timer.stop();

--- a/src/examples/radiuss_tutorial/lesson_03/device_self_intersections.cpp
+++ b/src/examples/radiuss_tutorial/lesson_03/device_self_intersections.cpp
@@ -202,7 +202,7 @@ TriangleMesh makeTriangleMesh(const std::string& stl_mesh_path, double weldThres
 
     auto reader = std::make_unique<axom::quest::STLReader>();
     reader->setFileName(stl_mesh_path);
-    reader->read();
+    SLIC_ERROR_IF(reader->read() != 0, "Failed to load STL file '" << stl_mesh_path << "'.");
     reader->getMesh(surface_mesh);
 
     timer.stop();

--- a/src/examples/radiuss_tutorial/lesson_03/device_self_intersections.cpp
+++ b/src/examples/radiuss_tutorial/lesson_03/device_self_intersections.cpp
@@ -202,7 +202,8 @@ TriangleMesh makeTriangleMesh(const std::string& stl_mesh_path, double weldThres
 
     auto reader = std::make_unique<axom::quest::STLReader>();
     reader->setFileName(stl_mesh_path);
-    SLIC_ERROR_IF(reader->read() != 0, "Failed to load STL file '" << stl_mesh_path << "'.");
+    const int read_status = reader->read();
+    SLIC_ERROR_IF(read_status != 0, "Failed to load STL file '" << stl_mesh_path << "'.");
     reader->getMesh(surface_mesh);
 
     timer.stop();

--- a/src/examples/radiuss_tutorial/lesson_04/device_spatial_indexes.cpp
+++ b/src/examples/radiuss_tutorial/lesson_04/device_spatial_indexes.cpp
@@ -188,7 +188,8 @@ TriangleMesh makeTriangleMesh(const std::string& stl_mesh_path, double weldThres
 
     auto reader = std::make_unique<axom::quest::STLReader>();
     reader->setFileName(stl_mesh_path);
-    SLIC_ERROR_IF(reader->read() != 0, "Failed to load STL file '" << stl_mesh_path << "'.");
+    const int read_status = reader->read();
+    SLIC_ERROR_IF(read_status != 0, "Failed to load STL file '" << stl_mesh_path << "'.");
     reader->getMesh(surface_mesh);
 
     timer.stop();

--- a/src/examples/radiuss_tutorial/lesson_04/device_spatial_indexes.cpp
+++ b/src/examples/radiuss_tutorial/lesson_04/device_spatial_indexes.cpp
@@ -188,7 +188,7 @@ TriangleMesh makeTriangleMesh(const std::string& stl_mesh_path, double weldThres
 
     auto reader = std::make_unique<axom::quest::STLReader>();
     reader->setFileName(stl_mesh_path);
-    reader->read();
+    SLIC_ERROR_IF(reader->read() != 0, "Failed to load STL file '" << stl_mesh_path << "'.");
     reader->getMesh(surface_mesh);
 
     timer.stop();

--- a/src/tools/mesh_converter.cpp
+++ b/src/tools/mesh_converter.cpp
@@ -248,7 +248,10 @@ bool loadProe(const std::string& filename, TetMesh& slam_mesh, bool dump_debug_m
     axom::quest::ProEReader reader;
     reader.setFileName(filename);
 
-    reader.read();
+    if(reader.read() != 0)
+    {
+      return false;
+    }
     SLIC_INFO(axom::fmt::format(axom::utilities::locale(),
                                 "Input mesh has {:L} vertices and {:L} tets",
                                 reader.getNumNodes(),

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -651,7 +651,8 @@ int main(int argc, char** argv)
     AXOM_ANNOTATE_SCOPE("load stl mesh");
     auto reader = std::make_unique<quest::STLReader>();
     reader->setFileName(params.stlInput);
-    SLIC_ERROR_IF(reader->read() != 0, "Failed to load STL file '" << params.stlInput << "'.");
+    const int read_status = reader->read();
+    SLIC_ERROR_IF(read_status != 0, "Failed to load STL file '" << params.stlInput << "'.");
 
     reader->getMesh(surface_mesh);
   }

--- a/src/tools/mesh_tester.cpp
+++ b/src/tools/mesh_tester.cpp
@@ -651,7 +651,7 @@ int main(int argc, char** argv)
     AXOM_ANNOTATE_SCOPE("load stl mesh");
     auto reader = std::make_unique<quest::STLReader>();
     reader->setFileName(params.stlInput);
-    reader->read();
+    SLIC_ERROR_IF(reader->read() != 0, "Failed to load STL file '" << params.stlInput << "'.");
 
     reader->getMesh(surface_mesh);
   }


### PR DESCRIPTION
# Summary

- This PR reduces the verbosity of the quest readers and writers
- It also modernizes them via nested namespaces, `constexpr`, `[[nodiscard]]`
- The `[[nodiscard]]` changes the contract and requires callers to check the return values.