### PR TITLE
Introduce concepts for slam

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,6 +18,10 @@ The Axom project release numbers follow [Semantic Versioning](http://semver.org/
 
 ## [Unreleased] - Release date yyyy-mm-dd
 
+### Added
+- Slam: Adds `Concepts.hpp` with semantic concepts for sets, relations, maps, and
+  policy capabilities.
+
 ## [Version 0.15.0] - Release date 2026-08-28
 
 ### Added

--- a/src/axom/slam/CMakeLists.txt
+++ b/src/axom/slam/CMakeLists.txt
@@ -26,6 +26,7 @@ axom_component_requires(NAME       SLAM
 set(slam_headers
     # Utility files
     Aliases.hpp
+    Concepts.hpp
     FieldRegistry.hpp
     ModularInt.hpp
     Traits.hpp

--- a/src/axom/slam/Concepts.hpp
+++ b/src/axom/slam/Concepts.hpp
@@ -1,0 +1,409 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+// files for dates and other details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/*!
+ * \file Concepts.hpp
+ * \brief Semantic concepts for Slam sets, relations, and maps.
+ *
+ * Object concepts describe positional access, related elements and mapped values.
+ * They ignore top-level const and reference qualification, but preserve the
+ * constness of elements and values.
+ */
+
+#pragma once
+
+#include <concepts>
+#include <limits>
+#include <type_traits>
+#include <utility>
+
+namespace axom::slam
+{
+
+// ----------------------------------------------------------------------------
+// Helper type aliases for public concepts
+// ----------------------------------------------------------------------------
+namespace detail
+{
+template <typename T>
+using model_t = std::remove_cvref_t<T>;
+
+template <typename T>
+using position_t = typename model_t<T>::PositionType;
+
+template <typename T>
+using element_t = typename model_t<T>::ElementType;
+
+/// Integer arguments may be unsigned, but cannot be Boolean.
+template <typename T>
+concept PositionValueLike = std::integral<model_t<T>> && !std::same_as<model_t<T>, bool>;
+
+/// The operations needed to traverse values, without prescribing iterator aliases.
+template <typename Iterator, typename Sentinel, typename Value>
+concept IteratesAs = requires(Iterator it, Sentinel end) {
+  { *it } -> std::convertible_to<Value>;
+  ++it;
+  { it != end } -> std::convertible_to<bool>;
+};
+
+template <typename R, typename Value>
+concept IterableValues = requires(const model_t<R>& range) {
+  requires IteratesAs<decltype(range.begin()), decltype(range.end()), Value>;
+};
+
+template <typename R, typename Value>
+concept SizedValues = IterableValues<R, Value> && requires(const model_t<R>& range) {
+  { range.size() } -> PositionValueLike;
+};
+
+/// Scalar references may add constness, but cannot discard element qualification.
+template <typename Reference, typename Data>
+concept MapReferenceFor = std::is_lvalue_reference_v<Reference> &&
+  (std::same_as<std::remove_reference_t<Reference>, Data> ||
+   std::same_as<std::remove_reference_t<Reference>, const Data>);
+}  // namespace detail
+
+// ----------------------------------------------------------------------------
+// Public concepts
+// ----------------------------------------------------------------------------
+
+/// \brief A signed integral type for Slam positions and indexing arithmetic.
+template <typename T>
+concept PositionLike = std::signed_integral<detail::model_t<T>>;
+
+/// \brief A sized collection with positional access to its elements.
+/// size() is nonnegative, and empty() agrees with size() == 0. Access requires a valid position.
+template <typename T>
+concept SetLike = PositionLike<detail::position_t<T>> &&
+  requires(const detail::model_t<T>& set, detail::position_t<T> pos) {
+    typename detail::element_t<T>;
+    { set.size() } -> std::same_as<detail::position_t<T>>;
+    { set.empty() } -> std::convertible_to<bool>;
+    { set.at(pos) } -> std::convertible_to<detail::element_t<T>>;
+  };
+
+/// \brief A SetLike type whose const traversal visits the elements in positional order.
+template <typename T>
+concept IterableSetLike = SetLike<T> && detail::IterableValues<T, detail::element_t<T>>;
+
+/// \brief A container that can check its own internal consistency.
+/// Validation is a separate capability, not a requirement of every set or relation.
+template <typename T>
+concept Validatable = requires(const detail::model_t<T>& container) {
+  { container.isValid(false) } -> std::convertible_to<bool>;
+};
+
+/// \brief A set of coordinate pairs with access to the subset for each first-set position.
+/// getElements(first) provides a sized, iterable collection of second-set positions.
+/// Visiting these subsets in first-set order agrees with at(flat), and their sizes
+/// sum to size(). Search and flat-index conversion are not required.
+template <typename T>
+concept BivariateSetLike = SetLike<T> && SetLike<typename detail::model_t<T>::FirstSetType> &&
+  SetLike<typename detail::model_t<T>::SecondSetType> &&
+  requires(detail::element_t<T> coordinate) {
+    requires std::same_as<std::remove_cvref_t<decltype(coordinate.first)>,
+                          typename detail::model_t<T>::FirstSetType::PositionType>;
+    requires std::same_as<std::remove_cvref_t<decltype(coordinate.second)>,
+                          typename detail::model_t<T>::SecondSetType::PositionType>;
+  } &&
+  requires(const detail::model_t<T>& set,
+           typename detail::model_t<T>::FirstSetType::PositionType first) {
+    { set.getFirstSet() } -> std::same_as<const typename detail::model_t<T>::FirstSetType*>;
+    { set.getSecondSet() } -> std::same_as<const typename detail::model_t<T>::SecondSetType*>;
+    requires detail::SizedValues<decltype(set.getElements(first)),
+                                 typename detail::model_t<T>::SecondSetType::PositionType>;
+  };
+
+/// \brief A relation that provides to-set positions for each from-set position.
+/// relation[from] returns a sized, iterable collection of valid to-set positions.
+/// The sets may contain coordinates or other element types. Flat storage,
+/// validation methods and a named subset type are not required.
+template <typename T>
+concept RelationLike = SetLike<typename detail::model_t<T>::FromSetType> &&
+  SetLike<typename detail::model_t<T>::ToSetType> &&
+  requires(const detail::model_t<T>& relation,
+           typename detail::model_t<T>::FromSetType::PositionType from) {
+    { relation.fromSet() } -> std::same_as<const typename detail::model_t<T>::FromSetType*>;
+    { relation.toSet() } -> std::same_as<const typename detail::model_t<T>::ToSetType*>;
+    requires detail::SizedValues<decltype(relation[from]),
+                                 typename detail::model_t<T>::ToSetType::PositionType>;
+  };
+
+/// \brief Values associated with entries, addressed by entry position and local component.
+/// index(pos) identifies the associated set element. flatValue(pos, component)
+/// accesses one scalar component, including for tensor-valued maps. "flat" here
+/// selects an entry of a bivariate set, not a global component-storage position.
+/// Bound maps have positive numComp(). A default unbound SubMap may be empty with zero components.
+template <typename T>
+concept MapLike = PositionLike<detail::position_t<T>> &&
+  requires(detail::model_t<T>& map,
+           const detail::model_t<T>& constMap,
+           detail::position_t<T> pos,
+           detail::position_t<T> component) {
+    typename detail::model_t<T>::DataType;
+    { constMap.size() } -> std::same_as<detail::position_t<T>>;
+    { constMap.numComp() } -> std::same_as<detail::position_t<T>>;
+    constMap.index(pos);
+    requires std::is_object_v<std::remove_cvref_t<decltype(constMap.index(pos))>>;
+    {
+      map.flatValue(pos, component)
+    } -> detail::MapReferenceFor<typename detail::model_t<T>::DataType>;
+    {
+      constMap.flatValue(pos, component)
+    } -> detail::MapReferenceFor<typename detail::model_t<T>::DataType>;
+  };
+
+/// \brief A MapLike type explicitly bound to all positions of exactly S.
+/// MappedSetType names that binding and set() returns it. size() agrees with
+/// set()->size(), and index(pos) agrees with set()->at(pos). SubMap has no such
+/// binding. Its set() selects parent positions, and index() returns their associated elements.
+template <typename M, typename S>
+concept MapOver = MapLike<M> && SetLike<S> &&
+  std::same_as<typename detail::model_t<M>::MappedSetType, detail::model_t<S>> &&
+  std::same_as<detail::position_t<M>, detail::position_t<S>> &&
+  requires(const detail::model_t<M>& map, detail::position_t<M> pos) {
+    { map.set() } -> std::same_as<const detail::model_t<S>*>;
+    { map.index(pos) } -> std::convertible_to<detail::element_t<S>>;
+  };
+
+/// \brief A non-reference type with a trivially copyable C++ representation.
+/// This does not certify device-callable operations or the accessibility/lifetime
+/// of referenced objects. Check those requirements separately before device use.
+template <typename T>
+concept TriviallyCopyableRepresentation =
+  !std::is_reference_v<T> && std::is_trivially_copyable_v<std::remove_cv_t<T>>;
+
+// ----------------------------------------------------------------------------
+// Helper concepts built from the public concepts
+// ----------------------------------------------------------------------------
+namespace detail
+{
+/// Type-level representability of nonnegative positions and sizes.
+template <typename Position, typename RepresentedPosition>
+concept PositionCanRepresent = PositionLike<Position> && PositionLike<RepresentedPosition> &&
+  (std::numeric_limits<model_t<Position>>::digits >=
+   std::numeric_limits<model_t<RepresentedPosition>>::digits);
+
+template <int Stride, typename Position>
+concept PositiveStaticStrideForPosition = PositionLike<Position> && (Stride > 0) &&
+  (Stride <= std::numeric_limits<model_t<Position>>::max());
+
+template <int Stride, typename Set>
+concept PositiveStaticStrideFor =
+  SetLike<Set> && PositiveStaticStrideForPosition<Stride, position_t<Set>>;
+
+template <typename Set, typename Value>
+concept SetPositionConvertible =
+  SetLike<Set> && PositionValueLike<Value> && std::convertible_to<model_t<Value>, position_t<Set>>;
+
+template <typename Set, typename Position>
+concept SetPositionSame = SetLike<Set> && std::same_as<model_t<Position>, position_t<Set>>;
+
+template <typename Set, typename Position>
+concept OptionalSetPositionSame =
+  SetLike<Set> && (std::same_as<model_t<Position>, void> || SetPositionSame<Set, Position>);
+
+/// Flat storage consumed by RelationSet, not a public relation requirement.
+template <typename T>
+using relation_row_t =
+  std::remove_cvref_t<decltype(std::declval<const model_t<T>&>()
+                                 [std::declval<typename model_t<T>::FromSetType::PositionType>()])>;
+
+template <typename T>
+concept RelationSetSource = RelationLike<model_t<T>> && Validatable<model_t<T>> &&
+  requires { typename model_t<T>::FlatPositionType; } &&
+  PositionLike<typename model_t<T>::FlatPositionType> &&
+  requires(const model_t<T>& relation,
+           typename model_t<T>::FromSetType::PositionType fromPosition,
+           typename model_t<T>::FlatPositionType flatPosition) {
+    { relation.offset(fromPosition) } -> std::convertible_to<typename model_t<T>::FlatPositionType>;
+    {
+      static_cast<typename model_t<T>::FromSetType::PositionType>(relation.firstIndex(flatPosition))
+    } -> std::same_as<typename model_t<T>::FromSetType::PositionType>;
+    {
+      relation.relationData().size()
+    } -> std::convertible_to<typename model_t<T>::FlatPositionType>;
+    requires PositionValueLike<decltype(relation.relationData().size())>;
+    {
+      relation.relationData()[flatPosition]
+    } -> std::convertible_to<typename model_t<T>::ToSetType::PositionType>;
+  };
+
+/// Exact policy arguments used as base classes must be ordinary inheritable types.
+template <typename T>
+concept InheritablePolicy = std::is_class_v<T> && std::same_as<T, std::remove_cvref_t<T>> &&
+  !std::is_final_v<T> && !std::is_abstract_v<T>;
+
+template <typename T>
+using policy_default_t = std::remove_cv_t<decltype(T::DEFAULT_VALUE)>;
+
+/// An indirection result may add constness, but cannot discard element qualification.
+template <typename Result, typename Element>
+concept IndirectionResultFor = std::same_as<std::remove_reference_t<Result>, Element> ||
+  std::same_as<std::remove_reference_t<Result>, const Element>;
+
+}  // namespace detail
+
+/// Reports size, emptiness, and validity, with a default size value.
+template <typename T>
+concept SizePolicy = requires(const detail::model_t<T>& policy) {
+  detail::model_t<T>::DEFAULT_VALUE;
+  { policy.size() } -> std::same_as<detail::policy_default_t<detail::model_t<T>>>;
+  { policy.empty() } -> std::convertible_to<bool>;
+  { policy.isValid(false) } -> std::convertible_to<bool>;
+};
+
+/// Reports the signed stride. Shape is an additional requirement of map owners.
+template <typename T>
+concept StridePolicy = requires(const detail::model_t<T>& policy) {
+  { policy.stride() } -> PositionLike;
+};
+
+/// Reports a scalar offset, its default value, and validity.
+template <typename T>
+concept OffsetPolicy = requires(const detail::model_t<T>& policy) {
+  detail::model_t<T>::DEFAULT_VALUE;
+  { policy.offset() } -> std::same_as<detail::policy_default_t<detail::model_t<T>>>;
+  { policy.isValid(false) } -> std::convertible_to<bool>;
+};
+
+/// Reports whether a set has a parent and provides its pointer.
+/// OrderedSet additionally checks construction and validation with its actual iterators.
+template <typename T>
+concept SubsetPolicy = requires(const detail::model_t<T>& policy) {
+  typename detail::model_t<T>::ParentSetType;
+  { policy.isSubset() } -> std::convertible_to<bool>;
+  { policy.parentSet() } -> std::convertible_to<const typename detail::model_t<T>::ParentSetType*>;
+};
+
+/// Indirection that an OrderedSet can construct, copy, bind and use to access elements.
+/// No buffer-container aliases, map accessors, or device flags are required.
+template <typename T, typename Position, typename Element>
+concept OrderedSetIndirectionPolicyFor = detail::InheritablePolicy<T> && PositionLike<Position> &&
+  std::default_initializable<T> && std::copyable<T> &&
+  requires {
+    typename T::IndirectionPtrType;
+    typename T::IndirectionResult;
+    typename T::ConstIndirectionResult;
+  } && std::constructible_from<T, typename T::IndirectionPtrType> &&
+  detail::IndirectionResultFor<typename T::IndirectionResult, Element> &&
+  detail::IndirectionResultFor<typename T::ConstIndirectionResult, Element> &&
+  requires(T& policy, const T& constPolicy, Position pos) {
+    { policy.indirection(pos) } -> std::convertible_to<typename T::IndirectionResult>;
+    { constPolicy.indirection(pos) } -> std::convertible_to<typename T::ConstIndirectionResult>;
+    requires(!std::is_reference_v<typename T::IndirectionResult> ||
+             std::same_as<decltype(policy.indirection(pos)), typename T::IndirectionResult>);
+    requires(!std::is_reference_v<typename T::ConstIndirectionResult> ||
+             std::same_as<decltype(constPolicy.indirection(pos)), typename T::ConstIndirectionResult>);
+    { constPolicy.isValid(pos, pos, pos, false) } -> std::convertible_to<bool>;
+  };
+
+/// Static buffer access for Map, which does not inherit the descriptor.
+/// Both access paths return stable scalar references. Buffer ownership and
+/// referenced allocation accessibility are separate from this type check.
+template <typename T, typename Position, typename Data>
+concept MapIndirectionPolicyFor =
+  std::is_class_v<T> && std::same_as<T, std::remove_cvref_t<T>> && PositionLike<Position> &&
+  requires {
+    typename T::IndirectionBufferType;
+    typename T::IndirectionResult;
+    typename T::ConstIndirectionResult;
+    typename T::ResultPtr;
+    typename T::ConstResultPtr;
+    std::integral_constant<bool, T::IsMutableBuffer> {};
+  } && detail::MapReferenceFor<typename T::IndirectionResult, Data> &&
+  detail::MapReferenceFor<typename T::ConstIndirectionResult, Data> &&
+  std::same_as<typename T::ResultPtr,
+               std::add_pointer_t<std::remove_reference_t<typename T::IndirectionResult>>> &&
+  std::same_as<typename T::ConstResultPtr,
+               std::add_pointer_t<std::remove_reference_t<typename T::ConstIndirectionResult>>> &&
+  requires(typename T::IndirectionBufferType& buffer,
+           const typename T::IndirectionBufferType& constBuffer,
+           Position pos) {
+    { constBuffer.size() } -> detail::PositionValueLike;
+    { constBuffer.empty() } -> std::convertible_to<bool>;
+    { T::getIndirection(buffer, pos) } -> std::same_as<typename T::ResultPtr>;
+    { T::getConstIndirection(constBuffer, pos) } -> std::same_as<typename T::ConstResultPtr>;
+    { T::getIndirection(buffer) } -> std::same_as<typename T::ResultPtr>;
+    { T::getConstIndirection(constBuffer) } -> std::same_as<typename T::ConstResultPtr>;
+  } &&
+  (!T::IsMutableBuffer ||
+   requires(typename T::IndirectionBufferType& buffer, Position size) { buffer.resize(size); });
+
+/// Map storage that can allocate and initialize its buffer.
+template <typename T, typename Position, typename Data>
+concept AllocatingMapIndirectionPolicyFor = MapIndirectionPolicyFor<T, Position, Data> &&
+  requires(Position size, const std::remove_cvref_t<Data>& value, int allocatorId) {
+    { T::create(size, value, allocatorId) } -> std::same_as<typename T::IndirectionBufferType>;
+  };
+
+namespace detail
+{
+/// Scalar policies are copied into builders, assigned there, and inherited by sets.
+template <typename T, typename Position>
+concept PolicyDefaultedOver = InheritablePolicy<T> && PositionLike<Position> &&
+  std::default_initializable<T> && std::copyable<T> && requires { T::DEFAULT_VALUE; } &&
+  std::same_as<policy_default_t<T>, Position> && std::constructible_from<T, Position>;
+
+template <typename T, typename Position>
+concept SetSizePolicyFor = SizePolicy<T> && PolicyDefaultedOver<T, Position>;
+
+template <typename T, typename Position>
+concept DynamicSetSizePolicyFor = SetSizePolicyFor<T, Position> && requires(T& policy) {
+  { policy.size() } -> std::same_as<Position&>;
+};
+
+template <typename T, typename Position>
+concept OrderedSetOffsetPolicyFor = OffsetPolicy<T> && PolicyDefaultedOver<T, Position>;
+
+template <typename T, typename Position>
+concept OrderedSetStridePolicyFor =
+  StridePolicy<T> && PolicyDefaultedOver<T, Position> && requires(const T& policy) {
+    { policy.stride() } -> std::same_as<Position>;
+    { policy.isValid(false) } -> std::convertible_to<bool>;
+  };
+
+/// Map constructs this base from a shape. It need not be default-constructible.
+template <typename T, typename Position>
+concept MapStridePolicyFor = InheritablePolicy<T> && PositionLike<Position> && StridePolicy<T> &&
+  requires(const T& policy) {
+    typename T::IndexType;
+    typename T::ShapeType;
+    std::integral_constant<int, T::NumDims> {};
+    requires(T::NumDims > 0);
+    requires PositionLike<typename T::IndexType>;
+    requires std::constructible_from<T, typename T::ShapeType>;
+    { T::DefaultSize() } -> std::same_as<typename T::ShapeType>;
+    { policy.stride() } -> std::same_as<typename T::IndexType>;
+    { policy.shape() } -> std::same_as<typename T::ShapeType>;
+  } &&
+  ((T::NumDims == 1 && std::convertible_to<typename T::ShapeType, typename T::IndexType>) ||
+   (T::NumDims > 1 && requires(const T& policy, const typename T::ShapeType& shape, int dim) {
+     { policy.strides() } -> std::same_as<typename T::ShapeType>;
+     { shape[dim] } -> std::convertible_to<typename T::IndexType>;
+   }));
+
+template <typename T>
+concept OrderedSetSubsetPolicy =
+  InheritablePolicy<T> && SubsetPolicy<T> && std::default_initializable<T> && std::copyable<T> &&
+  std::constructible_from<T, typename T::ParentSetType*>;
+
+template <typename T, typename Iterator>
+concept ValidatesSubset = requires(const T& policy, Iterator begin, Iterator end) {
+  { policy.isValid(begin, end, false) } -> std::convertible_to<bool>;
+};
+
+template <typename Position, typename Element, typename Size, typename Offset, typename Stride, typename Indirection, typename Subset>
+concept OrderedSetPoliciesFor = SetSizePolicyFor<Size, Position> &&
+  OrderedSetOffsetPolicyFor<Offset, Position> && OrderedSetStridePolicyFor<Stride, Position> &&
+  OrderedSetIndirectionPolicyFor<Indirection, Position, Element> && OrderedSetSubsetPolicy<Subset>;
+
+template <typename Data, typename Set, typename Indirection, typename Stride>
+concept MapParameters = SetLike<Set> && MapStridePolicyFor<Stride, typename Set::PositionType> &&
+  MapIndirectionPolicyFor<Indirection, typename Set::PositionType, Data>;
+}  // namespace detail
+
+}  // namespace axom::slam

--- a/src/axom/slam/policies/IndirectionPolicies.hpp
+++ b/src/axom/slam/policies/IndirectionPolicies.hpp
@@ -18,31 +18,16 @@
  * \c STLVectorIndirection (\c std::vector) are for interoperation with existing
  * storage, and serve as small reference implementations for custom policies.
  *
- * A valid indirection policy must support the
- * following interface:
- *   * [required]
- *   * type alias IndirectionResult -- the type of the result of an indirection
- *      (const/nonconst and ref/nonref)
- *   * indirection() : IntType  -- returns the value of the element after
- *     indirection
- *   * hasIndirection(): bool -- returns whether there is an indirection
- *     buffer
- *   * isValid() : bool -- indicates whether the Indirection policy of the set
- *      is valid
- *   * [optional]
- *     * operator(): IntType -- alternate accessor for indirection
- *     * data() : ElementType* -- allows direct access to the underlying buffer
- *       (when this exists)
+ * OrderedSet inherits an indirection policy and calls indirection(position).
+ * Map instead stores the policy's buffer type by value and uses its static
+ * access functions. These are separate contracts, defined by
+ * OrderedSetIndirectionPolicyFor and MapIndirectionPolicyFor in Concepts.hpp.
+ * Static relations use ordered-set indirection with additional buffer access.
  *
- * \note An indirection policy describes how storage is reached and, for the
- *  buffer types a Slam object holds by value, how that buffer's lifetime is handled.
- *  It does not change which data structure logically owns the data. 
- *  A \c Map holds its \c OrderedMap buffer by value: 
- *  with \c ArrayIndirection that buffer is an \c axom::Array the map allocates 
- *  and frees as part of its own lifetime, while with \c ArrayViewIndirection 
- *  it is an \c axom::ArrayView referring to a buffer whose lifetime is managed elsewhere
- *  (and which must outlive the map). 
- *  Sets and relations, by contrast, typically refer to buffers managed outside the Slam object.
+ * Ownership depends on the containing type. A Map using ArrayIndirection owns
+ * its axom::Array, while an ordered set or static relation borrows an array
+ * object. ArrayViewIndirection stores a view whose allocation is managed elsewhere.
+ * Borrowed objects and allocations must remain valid for every access.
  */
 
 #include "axom/core/Macros.hpp"
@@ -70,6 +55,7 @@ template <typename BasePolicy>
 struct IndexedIndirection : public BasePolicy
 {
   using PositionType = typename BasePolicy::PosType;
+  using ElementType = typename BasePolicy::ElemType;
 
   using typename BasePolicy::ConstIndirectionResult;
   using typename BasePolicy::IndirectionResult;
@@ -251,9 +237,11 @@ bool IndexedIndirection<BasePolicy>::isValid(PositionType size,
 /**
  * \brief A policy class for sets with no indirection
  */
-template <typename PositionType, typename ElementType>
+template <typename PositionT, typename ElementT>
 struct NoIndirection
 {
+  using PositionType = PositionT;
+  using ElementType = ElementT;
   using IndirectionResult = ElementType;
   using ConstIndirectionResult = const ElementType;
   using IndirectionBufferType = struct
@@ -323,8 +311,8 @@ private:
  * \brief A policy class for sets with C-style array-based indirection
  *
  * \note Indexes a raw pointer, for interoperation with C-style array storage.
- *  For an \c axom::Array buffer the object manages, use \c ArrayIndirection;
- *  for an \c axom::ArrayView of a buffer managed elsewhere, use \c ArrayViewIndirection.
+ *  For an external \c axom::Array buffer, use \c ArrayIndirection.
+ *  For an \c axom::ArrayView of a buffer managed elsewhere, use \c ArrayViewIndirection.
  */
 template <typename PositionType, typename ElementType>
 using CArrayIndirection =
@@ -376,8 +364,8 @@ private:
  * \brief A policy class for sets with std::vector-based indirection
  *
  * \note Indexes a (host-only) \c std::vector, for interoperation with existing \c std::vector storage.
- *  For an \c axom::Array buffer the object manages, use \c ArrayIndirection; 
- *  for an \c axom::ArrayView of a buffer managed elsewhere, use \c ArrayViewIndirection.
+ *  For an external \c axom::Array buffer, use \c ArrayIndirection.
+ *  For an \c axom::ArrayView of a buffer managed elsewhere, use \c ArrayViewIndirection.
  */
 template <typename PositionType, typename ElementType>
 using STLVectorIndirection =
@@ -427,10 +415,9 @@ private:
 /**
  * \brief A policy class for sets with axom::Array-based indirection
  *
- * \note Indexes an \c axom::Array; the default indirection for a \c Map or \c BivariateMap.
- *  A map with this policy holds its \c axom::Array by value and frees it as part of the map's lifetime;
- *  its lifetime-counterpart is \c ArrayViewIndirection, which refers to a buffer managed elsewhere.
- *  Sets and relations with this policy refer to an existing \c axom::Array buffer.
+ * \note The default indirection for Map and BivariateMap. A map with this policy
+ *  owns its axom::Array. Ordered sets and static relations borrow an existing
+ *  array object. Use ArrayViewIndirection to bind an allocation through a view.
  */
 template <typename PositionType, typename ElementType>
 using ArrayIndirection = detail::IndexedIndirection<ArrayIndirectionBase<PositionType, ElementType>>;
@@ -442,6 +429,7 @@ struct ArrayViewIndirectionBase
   using ElemType = ElementType;
 
   using IndirectionResult = ElementType&;
+  // ArrayView has shallow constness: a const view can modify external elements.
   using ConstIndirectionResult = ElementType&;
 
   using IndirectionBufferType = axom::ArrayView<ElementType>;
@@ -480,11 +468,9 @@ private:
 /**
  * \brief A policy class for sets with axom::ArrayView-based indirection
  *
- * \note Indexes an \c axom::ArrayView; the lifetime-counterpart to \c ArrayIndirection.
- *  It holds an \c axom::ArrayView by value and refers to a buffer whose lifetime is managed elsewhere, 
- *  so that backing allocation must outlive the set, map or relation that uses it.
- *  Because \c axom::ArrayView is trivially copyable, Slam objects using this policy 
- *  can be captured by value into device kernels.
+ * \note Holds an \c axom::ArrayView by value. The backing allocation must outlive
+ *  the set, map, or relation that uses it. This policy alone does not certify
+ *  device use: operations and all referenced objects must also be accessible.
  */
 template <typename PositionType, typename ElementType>
 using ArrayViewIndirection =

--- a/src/axom/slam/policies/SubsettingPolicies.hpp
+++ b/src/axom/slam/policies/SubsettingPolicies.hpp
@@ -11,15 +11,16 @@
  *
  * \brief Subsetting policies for SLAM
  *
- * Subsetting policies encompass the type and availability of a set's parent
+ * Subsetting policies describe whether a set has a parent and check its selection.
  * A valid subset policy must support the following interface:
- *   * [required]
- *   * isSubset(): bool -- returns whether the set is a subset of another set
- *   * parentSet() : ParentSetType -- returns a pointer to the parent set.
+ *   * isSubset(): bool, indicating whether the set is a subset of another set
+ *   * ParentSetType: the type of the parent set
+ *   * parentSet(): returns a pointer to the parent set,
  *                                     nullptr when isSubset() is false
- *   * isValid() : bool -- indicates whether the Subsetting policy of the set is valid
- *   * [optional]
- *   * operator(): IntType -- alternate accessor for indirection
+ *   * isValid(begin, end, verbose): validates the selected elements using
+ *     the OrderedSet's const iterators
+ * Policies support default construction, copying, and construction from
+ * ParentSetType*. The parent must outlive the set and its iterators.
  */
 
 #include "axom/config.hpp"

--- a/src/axom/slam/policies/ValuePolicies.hpp
+++ b/src/axom/slam/policies/ValuePolicies.hpp
@@ -7,32 +7,16 @@
 /**
  * \file ValuePolicies.hpp
  *
- * \brief Unified storage core for SLAM's scalar value policies.
+ * \brief Shared scalar storage for size, stride and offset policies.
  *
- * Slam's Size, Stride and Offset policies each historically defined
- * a near-identical `Runtime*` / `CompileTime*` pair, with the same: 
- *  (a) single-integer storage
- *  (b) defaulted/asserting constructors, and 
- *  (c) `operator()` accessors, 
- * and differing only in 
- *  (a) the name of the named accessor (`size()` / `stride()` / `offset()`), 
- *  (b) the validity predicate, and
- *  (c) the default value. 
+ * RuntimeValue stores one integer. CompileTimeValue supplies a constant without
+ * storing a value in each object. Both provide value(), operator() and isValid().
  *
- * This file factors that shared substrate into one `RuntimeValue<Tag>` / `CompileTimeValue<auto, Tag>` family.
+ * A tag defines the default value and validity predicate through defaultValue()
+ * and isValidValue(value). The size, stride and offset policies add their named
+ * accessors in SizePolicies.hpp, StridePolicies.hpp and OffsetPolicies.hpp.
  *
- * A `Tag` type supplies the policy-specific knobs as static members:
- *   - `static constexpr IntType defaultValue();` -- the DEFAULT_VALUE
- *   - `static constexpr bool isValidValue(IntType);` -- validity predicate
- *
- * The named accessors (`size()`, `stride()`, `offset()`) are *not* provided here; 
- * they live in the thin leaf policies in SizePolicies.hpp / StridePolicies.hpp / OffsetPolicies.hpp
- * as one-line forwarders to `value()`, which keeps every existing call site spelling 
- * and signature unchanged while removing the storage/ctor/validity duplication.
- *
- * \note Multi-dimensional and dynamically-resizable policies (MultiDimStride,
- *  DynamicRuntimeSize) and the always-zero policies (ZeroSize) are not part of
- *  this scalar substrate and remain defined alongside their families.
+ * MultiDimStride, DynamicRuntimeSize and ZeroSize use separate implementations.
  */
 
 #pragma once
@@ -42,13 +26,12 @@
 namespace axom::slam::policies
 {
 /// \name Value policy tags
-/// \brief Tag types selecting the named-accessor family and the policy knobs
-///  (default value, validity predicate) for the unified value-policy core.
+/// \brief Default values and validity predicates for scalar policies.
 /// \{
 
 /*!
  * \brief Tag for set-size value policies.
- * \note Sizes may not be negative; the default size is zero.
+ * \note Sizes must be nonnegative. The default is zero.
  */
 template <typename IntType>
 struct SizeTag
@@ -59,7 +42,7 @@ struct SizeTag
 
 /*!
  * \brief Tag for set-stride value policies.
- * \note All non-zero strides are valid; the default stride is one.
+ * \note Strides must be nonzero. The default is one. Maps also require positive strides.
  */
 template <typename IntType>
 struct StrideTag
@@ -70,7 +53,7 @@ struct StrideTag
 
 /*!
  * \brief Tag for set-offset value policies.
- * \note Every offset is valid; the default offset is zero.
+ * \note Every offset is valid. The default is zero.
  */
 template <typename IntType>
 struct OffsetTag
@@ -84,16 +67,15 @@ struct OffsetTag
 /*!
  * \class RuntimeValue
  *
- * \brief Shared storage core for a runtime-settable scalar value policy.
+ * \brief Store a scalar policy value that can change at runtime.
  *
  * Stores a single \a IntType whose default is supplied by \a Tag.
- * Provides the generic `value()` accessors (const and mutable), `operator()`,
+ * Provides const and mutable value() access, operator(),
  * and an `isValid()` delegating to the tag's predicate.
  * 
- * Leaf policies derive from this and add their named accessor (`size()` / `stride()` / `offset()`).
+ * Derived policies add size(), stride() or offset().
  *
- * \tparam Tag a value-policy tag (SizeTag / StrideTag / OffsetTag)
- *  carrying the IntType, default value and validity predicate.
+ * \tparam Tag Supplies defaultValue() and isValidValue(). The default's type is IntType.
  */
 template <typename Tag>
 struct RuntimeValue
@@ -119,14 +101,13 @@ protected:
 /*!
  * \class CompileTimeValue
  *
- * \brief Shared core for a compile-time-known scalar value policy.
+ * \brief Supply a scalar policy value fixed at compile time.
  *
  * The value \a V is fixed at compile time.
- * The (defaulted) constructor argument exists only to satisfy 
- * the uniform policy-construction interface and is asserted to match \a V. 
+ * The constructor accepts an argument so that callers can construct runtime and
+ * compile-time policies the same way. The argument must equal \a V.
  *
- * Provides the generic `value()` accessor, `operator()`, and an `isValid()` delegating to the tag's predicate.
- * Leaf policies derive from this and add their named accessor.
+ * Provides value(), operator() and isValid(). Derived policies add their named accessor.
  *
  * \tparam V the compile-time value (its type is the policy's IntType).
  * \tparam Tag a value-policy tag carrying the default value and validity predicate.

--- a/src/axom/slam/tests/CMakeLists.txt
+++ b/src/axom/slam/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ set(gtest_slam_tests
     slam_FieldRegistry.cpp
     slam_make_helpers.cpp
     slam_ModularInt.cpp
+    slam_concepts.cpp
     slam_static_asserts.cpp
     
     #mesh structure test

--- a/src/axom/slam/tests/slam_concepts.cpp
+++ b/src/axom/slam/tests/slam_concepts.cpp
@@ -1,0 +1,698 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// Axom Project Contributors. See top-level LICENSE and COPYRIGHT
+// files for dates and other details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * \file slam_concepts.cpp
+ *
+ * \brief Positive and negative compile-time tests for Slam's C++20 concepts.
+ */
+
+#include "axom/slam/Concepts.hpp"
+
+#include "axom/config.hpp"
+#include "axom/slam/RangeSet.hpp"
+#include "axom/slam/policies/IndirectionPolicies.hpp"
+#include "axom/slam/policies/OffsetPolicies.hpp"
+#include "axom/slam/policies/SizePolicies.hpp"
+#include "axom/slam/policies/StridePolicies.hpp"
+#include "axom/slam/policies/SubsettingPolicies.hpp"
+
+#include "gtest/gtest.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+#include <vector>
+
+namespace slam_concept_test
+{
+namespace slam = axom::slam;
+namespace policies = axom::slam::policies;
+
+using Position = slam::DefaultPositionType;
+using Element = slam::DefaultElementType;
+using ConcreteRange = slam::RangeSet<Position, Element>::ConcreteSet;
+using NarrowRange = slam::RangeSet<std::int32_t, std::int32_t>;
+using WideRange = slam::RangeSet<std::int64_t, std::int64_t>;
+using ViewIndirection = policies::ArrayViewIndirection<Position, double>;
+using ConstViewIndirection = policies::ArrayViewIndirection<Position, const double>;
+using WrongDataIndirection = policies::ArrayViewIndirection<Position, int>;
+using RawPointerMapIndirection = policies::CArrayIndirection<Position, double>;
+using VectorMapIndirection = policies::STLVectorIndirection<Position, double>;
+
+struct TypedefOnlySet
+{
+  using PositionType = Position;
+  using ElementType = Element;
+};
+
+struct WrongSizeSet
+{
+  using PositionType = Position;
+  using ElementType = Element;
+
+  double size() const;
+  bool empty() const;
+  Element at(Position) const;
+};
+
+struct MutableAccessOnlySet
+{
+  using PositionType = Position;
+  using ElementType = Element;
+
+  Position size() const;
+  bool empty() const;
+  Element at(Position);
+};
+
+struct FloatingPositionSet
+{
+  using PositionType = double;
+  using ElementType = Element;
+
+  double size() const;
+  bool empty() const;
+  Element at(double) const;
+};
+
+struct MinimalCoordinate
+{
+  NarrowRange::PositionType first;
+  WideRange::PositionType second;
+};
+
+struct MinimalBivariateSet
+{
+  using FirstSetType = NarrowRange;
+  using SecondSetType = WideRange;
+  using PositionType = std::int64_t;
+  using ElementType = MinimalCoordinate;
+
+  PositionType size() const { return 3; }
+  bool empty() const { return false; }
+  ElementType at(PositionType pos) const { return {pos == 0 ? 0 : 1, pos}; }
+  const FirstSetType* getFirstSet() const { return &first; }
+  const SecondSetType* getSecondSet() const { return &second; }
+  SecondSetType getElements(FirstSetType::PositionType pos) const
+  {
+    return pos == 0 ? SecondSetType(0, 1) : SecondSetType(1, 3);
+  }
+
+  FirstSetType first {2};
+  SecondSetType second {3};
+};
+
+struct BivariateSetMissingEmpty
+{
+  using FirstSetType = NarrowRange;
+  using SecondSetType = WideRange;
+  using PositionType = std::int64_t;
+  using ElementType = MinimalCoordinate;
+
+  PositionType size() const;
+  typename FirstSetType::PositionType firstSetSize() const;
+  typename SecondSetType::PositionType secondSetSize() const;
+  PositionType size(typename FirstSetType::PositionType) const;
+  ElementType at(PositionType) const;
+  const FirstSetType* getFirstSet() const;
+  const SecondSetType* getSecondSet() const;
+  SecondSetType getElements(FirstSetType::PositionType) const;
+  PositionType findElementIndex(FirstSetType::PositionType, SecondSetType::PositionType) const;
+  PositionType findElementFlatIndex(FirstSetType::PositionType, SecondSetType::PositionType) const;
+  FirstSetType::PositionType flatToFirstIndex(PositionType) const;
+  SecondSetType::PositionType flatToSecondIndex(PositionType) const;
+};
+
+struct TypedefOnlyRelation
+{
+  using FromSetType = ConcreteRange;
+  using ToSetType = ConcreteRange;
+};
+
+struct MinimalRelationRow
+{
+  std::size_t size() const { return count; }
+  const WideRange::PositionType* begin() const { return data; }
+  const WideRange::PositionType* end() const { return data + count; }
+
+  const WideRange::PositionType* data;
+  std::size_t count;
+};
+
+struct MinimalRelation
+{
+  using FromSetType = NarrowRange;
+  using ToSetType = WideRange;
+
+  const FromSetType* fromSet() const { return &from; }
+  const ToSetType* toSet() const { return &to; }
+  MinimalRelationRow operator[](FromSetType::PositionType pos) const
+  {
+    return pos == 0 ? MinimalRelationRow {indices, 1} : MinimalRelationRow {indices + 1, 2};
+  }
+
+  FromSetType from {2};
+  ToSetType to {3};
+  WideRange::PositionType indices[3] {2, 0, 1};
+};
+
+struct NotAPosition
+{ };
+
+struct WrongRelationRow
+{
+  std::size_t size() const;
+  NotAPosition* begin() const;
+  NotAPosition* end() const;
+};
+
+struct WrongRelationEntry
+{
+  using FromSetType = ConcreteRange;
+  using ToSetType = WideRange;
+
+  const FromSetType* fromSet() const;
+  const ToSetType* toSet() const;
+  WrongRelationRow operator[](FromSetType::PositionType) const;
+};
+
+struct TypedefOnlyMap
+{
+  using DataType = double;
+  using SetType = ConcreteRange;
+  using PositionType = Position;
+  using SetElement = Element;
+  using ValueType = double&;
+  using ConstValueType = const double&;
+};
+
+struct MinimalBivariateMap
+{
+  using DataType = double;
+  using PositionType = std::int64_t;
+
+  PositionType size() const { return 2; }
+  PositionType numComp() const { return 3; }
+  MinimalCoordinate index(PositionType pos) const { return {1, 2 * pos}; }
+  double& flatValue(PositionType pos, PositionType component)
+  {
+    return values[3 * pos + component];
+  }
+  const double& flatValue(PositionType pos, PositionType component) const
+  {
+    return values[3 * pos + component];
+  }
+
+  double values[6] {};
+};
+
+struct WrongDomainMap : MinimalBivariateMap
+{
+  using MappedSetType = MinimalBivariateSet;
+  const TypedefOnlySet* set() const;
+};
+
+struct WrongPositionMap : MinimalBivariateMap
+{
+  using PositionType = short;
+};
+
+struct WrongValueTypeMap : MinimalBivariateMap
+{
+  int& flatValue(PositionType, PositionType);
+  const int& flatValue(PositionType, PositionType) const;
+};
+
+struct WrongMutableAccessMap : MinimalBivariateMap
+{
+  double flatValue(PositionType, PositionType);
+  const double& flatValue(PositionType, PositionType) const;
+};
+
+struct DropsDataConstnessMap : MinimalBivariateMap
+{
+  using DataType = const double;
+};
+
+struct MissingComponentCountMap : MinimalBivariateMap
+{
+  void numComp() const = delete;
+};
+
+struct MissingIndexMap : MinimalBivariateMap
+{
+  void index(PositionType) const;
+};
+
+struct MissingConstAccessMap : MinimalBivariateMap
+{
+  using MinimalBivariateMap::flatValue;
+  const double& flatValue(PositionType, PositionType) const = delete;
+};
+
+struct ExtraAliasesMap : MinimalBivariateMap
+{
+  using SetType = TypedefOnlySet;
+  using BivariateSetType = void;
+  using ValueType = int;
+};
+
+struct TypedefOnlyIndirection
+{
+  using IndirectionResult = double&;
+  using ConstIndirectionResult = const double&;
+  using IndirectionBufferType = double*;
+  using IndirectionPtrType = double*;
+
+  static constexpr bool DeviceAccessible = true;
+};
+
+struct PrvalueMapIndirection : ViewIndirection
+{
+  using IndirectionResult = double;
+  using ConstIndirectionResult = const double&;
+  using ResultPtr = double*;
+  using ConstResultPtr = const double*;
+};
+
+struct MismatchedConstPointerIndirection : ViewIndirection
+{
+  using IndirectionResult = double&;
+  using ConstIndirectionResult = double&;
+  using ResultPtr = double*;
+  using ConstResultPtr = const double*;
+};
+
+struct DropsReferentConst : ViewIndirection
+{
+  using ElementType = const double;
+};
+
+struct AccessDropsReferentConst : ConstViewIndirection
+{
+  double& indirection(Position);
+  double& indirection(Position) const;
+};
+
+struct LeanMapIndirection
+{
+  using IndirectionResult = double&;
+  using ConstIndirectionResult = const double&;
+  using IndirectionBufferType = std::vector<double>;
+  using ResultPtr = double*;
+  using ConstResultPtr = const double*;
+
+  static constexpr bool IsMutableBuffer = true;
+
+  static ResultPtr getIndirection(IndirectionBufferType& buffer, Position pos = 0)
+  {
+    return buffer.data() + pos;
+  }
+  static ConstResultPtr getConstIndirection(const IndirectionBufferType& buffer, Position pos = 0)
+  {
+    return buffer.data() + pos;
+  }
+};
+
+struct PositionedAccessOnlyIndirection : LeanMapIndirection
+{
+  static ResultPtr getIndirection(IndirectionBufferType&, Position) { return nullptr; }
+  static ConstResultPtr getConstIndirection(const IndirectionBufferType&, Position)
+  {
+    return nullptr;
+  }
+};
+
+struct StrongPosition
+{
+  std::int64_t value;
+};
+
+struct TrivialCapture
+{
+  int value;
+};
+
+struct NonTrivialCapture
+{
+  NonTrivialCapture(const NonTrivialCapture&) { }
+};
+
+struct ExternalSet
+{
+  using PositionType = Position;
+  using ElementType = int;
+
+  PositionType size() const { return 2; }
+  bool empty() const { return false; }
+  int at(PositionType pos) const { return pos == 0 ? 10 : 40; }
+};
+
+struct NonAdvancingSet : ExternalSet
+{
+  struct Iterator
+  {
+    int operator*() const;
+    bool operator!=(Iterator) const;
+  };
+  Iterator begin() const;
+  Iterator end() const;
+};
+
+struct ExtraSetAliases : ExternalSet
+{
+  using FirstSetType = void;
+  using SecondSetType = void;
+};
+
+struct NonComparingSet : ExternalSet
+{
+  struct Iterator
+  {
+    int operator*() const;
+    Iterator& operator++();
+  };
+  Iterator begin() const;
+  Iterator end() const;
+};
+
+struct WrongCoordinateBivariateSet : MinimalBivariateSet
+{
+  using ElementType = std::pair<std::int64_t, std::int64_t>;
+  ElementType at(PositionType) const;
+};
+
+struct BoundMap : MinimalBivariateMap
+{
+  struct Domain
+  {
+    using PositionType = MinimalBivariateMap::PositionType;
+    using ElementType = MinimalCoordinate;
+
+    PositionType size() const { return 2; }
+    bool empty() const { return false; }
+    ElementType at(PositionType pos) const { return {1, 2 * pos}; }
+  };
+  using MappedSetType = Domain;
+  const Domain* set() const { return &domain; }
+
+  Domain domain;
+};
+
+struct ValidatingSet : ExternalSet
+{
+  bool isValid(bool = false) const { return true; }
+};
+
+struct IterableExternalSet : ExternalSet
+{
+  const int* begin() const { return values; }
+  const int* end() const { return values + 2; }
+
+  int values[2] {10, 40};
+};
+
+struct FinalIndirection final : ViewIndirection
+{ };
+
+struct AbstractIndirection : ViewIndirection
+{
+  virtual void bind() = 0;
+};
+
+// Object queries normalize cv/ref qualification while preserving element qualification.
+static_assert(slam::SetLike<ExternalSet>);
+static_assert(slam::SetLike<const ExternalSet&>);
+static_assert(slam::SetLike<ExtraSetAliases>);
+static_assert(slam::SetLike<MinimalBivariateSet>);
+static_assert(!slam::SetLike<TypedefOnlySet>);
+static_assert(!slam::SetLike<WrongSizeSet>);
+static_assert(!slam::SetLike<MutableAccessOnlySet>);
+static_assert(!slam::SetLike<FloatingPositionSet>);
+static_assert(!slam::SetLike<int>);
+static_assert(!slam::SetLike<BivariateSetMissingEmpty>);
+
+static_assert(slam::IterableSetLike<IterableExternalSet>);
+static_assert(!slam::IterableSetLike<ExternalSet>);
+static_assert(!slam::IterableSetLike<NonAdvancingSet>);
+static_assert(!slam::IterableSetLike<NonComparingSet>);
+static_assert(!slam::IterableSetLike<MinimalBivariateSet>);
+
+static_assert(slam::Validatable<ValidatingSet>);
+static_assert(!slam::Validatable<ExternalSet>);
+static_assert(!slam::Validatable<MinimalRelation>);
+
+static_assert(slam::BivariateSetLike<const MinimalBivariateSet&>);
+static_assert(!slam::BivariateSetLike<ExtraSetAliases>);
+static_assert(!slam::BivariateSetLike<BivariateSetMissingEmpty>);
+static_assert(!slam::BivariateSetLike<WrongCoordinateBivariateSet>);
+
+static_assert(slam::RelationLike<MinimalRelation>);
+static_assert(slam::RelationLike<const MinimalRelation&>);
+static_assert(!slam::RelationLike<TypedefOnlyRelation>);
+static_assert(!slam::RelationLike<WrongRelationEntry>);
+static_assert(!slam::RelationLike<int>);
+
+static_assert(slam::MapLike<MinimalBivariateMap>);
+static_assert(slam::MapLike<const MinimalBivariateMap&>);
+static_assert(slam::MapLike<ExtraAliasesMap>);
+static_assert(slam::MapLike<WrongDomainMap>);
+static_assert(!slam::MapLike<TypedefOnlyMap>);
+static_assert(!slam::MapLike<DropsDataConstnessMap>);
+static_assert(!slam::MapLike<MissingComponentCountMap>);
+static_assert(!slam::MapLike<MissingIndexMap>);
+static_assert(!slam::MapLike<MissingConstAccessMap>);
+static_assert(!slam::MapLike<WrongPositionMap>);
+static_assert(!slam::MapLike<WrongValueTypeMap>);
+static_assert(!slam::MapLike<WrongMutableAccessMap>);
+static_assert(!slam::MapLike<int>);
+
+static_assert(slam::MapOver<BoundMap, BoundMap::Domain>);
+static_assert(slam::MapOver<const BoundMap&, const BoundMap::Domain&>);
+static_assert(!slam::MapOver<WrongDomainMap, MinimalBivariateSet>);
+static_assert(!slam::MapOver<BoundMap, ExternalSet>);
+static_assert(!slam::MapOver<MinimalBivariateMap, BoundMap::Domain>);
+static_assert(!slam::MapOver<int, ExternalSet>);
+
+// Refinement must participate in overload ordering, not merely yield true.
+template <slam::SetLike S>
+std::integral_constant<int, 1> selectByConstraint();
+template <slam::BivariateSetLike S>
+std::integral_constant<int, 2> selectByConstraint();
+
+static_assert(decltype(selectByConstraint<ExternalSet>())::value == 1);
+static_assert(decltype(selectByConstraint<MinimalBivariateSet>())::value == 2);
+
+// Policies
+using Size = policies::CompileTimeSize<int, 5>;
+using EmptySize = policies::ZeroSize<int>;
+using RuntimeSize = policies::RuntimeSize<int>;
+using WrongRuntimeSize = policies::RuntimeSize<double>;
+using WrongCompileTimeSize = policies::CompileTimeSize<std::int64_t, 5>;
+using WrongEmptySize = policies::ZeroSize<std::int64_t>;
+using ScalarStride = policies::CompileTimeStride<int, 3>;
+using MatrixStride = policies::MultiDimStride<int, 2>;
+using Offset = policies::CompileTimeOffset<int, 4>;
+using RuntimeOffset = policies::RuntimeOffset<int>;
+using EmptyOffset = policies::ZeroOffset<int>;
+using WrongRuntimeOffset = policies::RuntimeOffset<std::int64_t>;
+using WrongCompileTimeOffset = policies::CompileTimeOffset<std::int64_t, 4>;
+using WrongEmptyOffset = policies::ZeroOffset<std::int64_t>;
+using NoIndirection = policies::NoIndirection<Position, Element>;
+using OwningIndirection = policies::ArrayIndirection<Position, double>;
+
+static_assert(slam::SizePolicy<Size>);
+static_assert(!slam::StridePolicy<Size>);
+static_assert(!slam::SizePolicy<ScalarStride>);
+static_assert(!slam::SetLike<Size>);
+static_assert(slam::SizePolicy<EmptySize>);
+static_assert(slam::detail::SetSizePolicyFor<RuntimeSize, int>);
+static_assert(slam::detail::SetSizePolicyFor<Size, int>);
+static_assert(slam::detail::SetSizePolicyFor<EmptySize, int>);
+static_assert(slam::SizePolicy<WrongRuntimeSize>);
+static_assert(!slam::detail::SetSizePolicyFor<WrongRuntimeSize, int>);
+static_assert(!slam::detail::SetSizePolicyFor<WrongCompileTimeSize, int>);
+static_assert(!slam::detail::SetSizePolicyFor<WrongEmptySize, int>);
+static_assert(slam::StridePolicy<ScalarStride>);
+static_assert(slam::StridePolicy<MatrixStride>);
+static_assert(slam::detail::OrderedSetStridePolicyFor<ScalarStride, int>);
+static_assert(!slam::detail::OrderedSetStridePolicyFor<MatrixStride, int>);
+static_assert(slam::detail::MapStridePolicyFor<ScalarStride, int>);
+static_assert(slam::detail::MapStridePolicyFor<MatrixStride, int>);
+// Maps support a stride index that converts to their (possibly wider) position type
+// OrderedSet's scalar value policy must use that exact position type.
+#if !defined(AXOM_NO_INT64_T)
+// Use explicit types for wide/narrow pairs so they do not depend on AXOM_USE_64BIT_INDEXTYPE.
+using WidePosition = std::int64_t;
+using NarrowStride = policies::CompileTimeStride<std::int32_t, 3>;
+static_assert(!std::is_same_v<NarrowStride::IndexType, WidePosition>,
+              "the wide and narrow types must actually differ for this to test anything");
+static_assert(slam::detail::MapStridePolicyFor<NarrowStride, WidePosition>);
+static_assert(!slam::detail::OrderedSetStridePolicyFor<NarrowStride, WidePosition>);
+#endif
+
+static_assert(slam::OffsetPolicy<Offset>);
+static_assert(slam::detail::OrderedSetOffsetPolicyFor<RuntimeOffset, int>);
+static_assert(slam::detail::OrderedSetOffsetPolicyFor<Offset, int>);
+static_assert(slam::detail::OrderedSetOffsetPolicyFor<EmptyOffset, int>);
+static_assert(!slam::detail::OrderedSetOffsetPolicyFor<WrongRuntimeOffset, int>);
+static_assert(!slam::detail::OrderedSetOffsetPolicyFor<WrongCompileTimeOffset, int>);
+static_assert(!slam::detail::OrderedSetOffsetPolicyFor<WrongEmptyOffset, int>);
+static_assert(!slam::SizePolicy<int>);
+static_assert(!slam::StridePolicy<int>);
+static_assert(!slam::OffsetPolicy<int>);
+static_assert(!slam::OrderedSetIndirectionPolicyFor<TypedefOnlyIndirection, Position, double>);
+static_assert(!slam::MapIndirectionPolicyFor<TypedefOnlyIndirection, Position, double>);
+static_assert(slam::OrderedSetIndirectionPolicyFor<ViewIndirection, Position, double>);
+// Access may add constness to the requested element type, but cannot remove it.
+static_assert(slam::OrderedSetIndirectionPolicyFor<ConstViewIndirection, Position, const double>);
+static_assert(!slam::OrderedSetIndirectionPolicyFor<ViewIndirection, Position, const double>);
+static_assert(slam::OrderedSetIndirectionPolicyFor<ConstViewIndirection, Position, double>);
+static_assert(slam::MapIndirectionPolicyFor<ViewIndirection, Position, double>);
+static_assert(slam::MapIndirectionPolicyFor<ConstViewIndirection, Position, const double>);
+static_assert(!slam::MapIndirectionPolicyFor<ViewIndirection, Position, const double>);
+static_assert(slam::MapIndirectionPolicyFor<ConstViewIndirection, Position, double>);
+static_assert(!slam::MapIndirectionPolicyFor<DropsReferentConst, Position, const double>);
+static_assert(!slam::OrderedSetIndirectionPolicyFor<DropsReferentConst, Position, const double>);
+static_assert(!slam::OrderedSetIndirectionPolicyFor<AccessDropsReferentConst, Position, const double>);
+static_assert(!slam::AllocatingMapIndirectionPolicyFor<ViewIndirection, Position, double>);
+static_assert(!slam::MapIndirectionPolicyFor<RawPointerMapIndirection, Position, double>);
+static_assert(!slam::MapIndirectionPolicyFor<PrvalueMapIndirection, Position, double>);
+static_assert(!slam::MapIndirectionPolicyFor<MismatchedConstPointerIndirection, Position, double>);
+static_assert(slam::MapIndirectionPolicyFor<VectorMapIndirection, Position, double>);
+static_assert(slam::AllocatingMapIndirectionPolicyFor<VectorMapIndirection, Position, double>);
+static_assert(slam::OrderedSetIndirectionPolicyFor<NoIndirection, Position, Element>);
+static_assert(!slam::MapIndirectionPolicyFor<NoIndirection, Position, Element>);
+static_assert(slam::MapIndirectionPolicyFor<OwningIndirection, Position, double>);
+static_assert(slam::AllocatingMapIndirectionPolicyFor<OwningIndirection, Position, double>);
+static_assert(!slam::MapIndirectionPolicyFor<WrongDataIndirection, Position, double>);
+
+// The Map indirection contract that Map family reads.
+// Indirection[Const]RefType are StaticRelation's aliases
+static_assert(slam::MapIndirectionPolicyFor<LeanMapIndirection, Position, double>);
+// ... but the whole-buffer accessor behind Map::data_ptr() is required.
+static_assert(!slam::MapIndirectionPolicyFor<PositionedAccessOnlyIndirection, Position, double>);
+// Map's data_ptr() (private) is declared in terms of the policy's ResultPtr alias
+static_assert(std::same_as<typename ViewIndirection::ResultPtr, double*>);
+static_assert(std::same_as<typename ViewIndirection::ConstResultPtr, double*>,
+              "ArrayView indirection has shallow constness");
+
+static_assert(slam::SizePolicy<const RuntimeSize&>);
+static_assert(slam::StridePolicy<const ScalarStride&>);
+static_assert(slam::OffsetPolicy<const Offset&>);
+static_assert(slam::SubsetPolicy<policies::NoSubset>);
+static_assert(!slam::SubsetPolicy<int>);
+static_assert(!slam::detail::SetSizePolicyFor<const RuntimeSize, int>);
+static_assert(!slam::OrderedSetIndirectionPolicyFor<const ViewIndirection, Position, double>);
+static_assert(!slam::OrderedSetIndirectionPolicyFor<ViewIndirection&, Position, double>);
+static_assert(!slam::OrderedSetIndirectionPolicyFor<FinalIndirection, Position, double>);
+static_assert(!slam::OrderedSetIndirectionPolicyFor<AbstractIndirection, Position, double>);
+static_assert(!slam::MapIndirectionPolicyFor<const ViewIndirection, Position, double>);
+static_assert(!slam::AllocatingMapIndirectionPolicyFor<LeanMapIndirection, Position, double>);
+
+// Position types and representation properties
+static_assert(slam::PositionLike<int>);
+static_assert(slam::PositionLike<const std::int64_t&>);
+static_assert(!slam::PositionLike<unsigned>);
+static_assert(!slam::PositionLike<bool>);
+static_assert(!slam::PositionLike<double>);
+static_assert(!slam::PositionLike<StrongPosition>);
+static_assert(slam::TriviallyCopyableRepresentation<TrivialCapture>);
+static_assert(slam::TriviallyCopyableRepresentation<const TrivialCapture>);
+static_assert(!slam::TriviallyCopyableRepresentation<NonTrivialCapture>);
+static_assert(!slam::TriviallyCopyableRepresentation<TrivialCapture&>);
+
+// An algorithm over the public core needs only row traversal and coordinate access.
+template <slam::BivariateSetLike S>
+void checkRowCoordinates(const S& set)
+{
+  typename S::PositionType flat = 0;
+  for(typename S::FirstSetType::PositionType first = 0; first < set.getFirstSet()->size(); ++first)
+  {
+    const auto row = set.getElements(first);
+    decltype(row.size()) count = 0;
+    for(const auto second : row)
+    {
+      ASSERT_LT(flat, set.size());
+      const auto coordinate = set.at(flat++);
+      EXPECT_EQ(first, coordinate.first);
+      EXPECT_EQ(second, coordinate.second);
+      EXPECT_GE(second, 0);
+      EXPECT_LT(second, set.getSecondSet()->size());
+      ++count;
+    }
+    EXPECT_EQ(count, row.size());
+  }
+  EXPECT_EQ(flat, set.size());
+}
+
+template <slam::RelationLike R>
+auto relationPositions(const R& relation)
+{
+  using Pair = std::pair<typename R::FromSetType::PositionType, typename R::ToSetType::PositionType>;
+  std::vector<Pair> pairs;
+  for(typename R::FromSetType::PositionType from = 0; from < relation.fromSet()->size(); ++from)
+  {
+    for(const auto to : relation[from])
+    {
+      pairs.emplace_back(from, to);
+    }
+  }
+  return pairs;
+}
+
+// These tests use maps with no invalid entries within their extent.
+// Writable access is constrained separately from MapLike.
+template <slam::MapLike M>
+  requires requires(M& map) { map.flatValue(0, 0) = 0.; }
+void fillComponents(M& map)
+{
+  using P = typename M::PositionType;
+  for(P pos = 0; pos < map.size(); ++pos)
+  {
+    for(P component = 0; component < map.numComp(); ++component)
+    {
+      map.flatValue(pos, component) = 100. * pos + component;
+    }
+  }
+}
+
+TEST(slam_concepts, external_models_use_only_core_operations)
+{
+  MinimalBivariateSet set;
+  checkRowCoordinates(set);
+  EXPECT_EQ(0, set.at(0).first);
+  EXPECT_EQ(1, set.at(2).first);
+  EXPECT_EQ(2, set.at(2).second);
+
+  MinimalRelation relation;
+  using Pair = std::pair<std::int32_t, std::int64_t>;
+  const std::vector<Pair> expected {{0, 2}, {1, 0}, {1, 1}};
+  EXPECT_EQ(expected, relationPositions(relation));
+
+  MinimalBivariateMap map;
+  fillComponents(map);
+  const auto& const_map = map;
+  EXPECT_DOUBLE_EQ(102., const_map.flatValue(1, 2));
+  EXPECT_EQ(1, const_map.index(1).first);
+  EXPECT_EQ(2, const_map.index(1).second);
+  EXPECT_EQ(&map.values[5], &const_map.flatValue(1, 2));
+}
+
+TEST(slam_concepts, whole_set_binding_agrees_with_element_lookup)
+{
+  BoundMap map;
+  fillComponents(map);
+  EXPECT_EQ(map.size(), map.set()->size());
+  for(BoundMap::PositionType pos = 0; pos < map.size(); ++pos)
+  {
+    EXPECT_EQ(map.index(pos).first, map.set()->at(pos).first);
+    EXPECT_EQ(map.index(pos).second, map.set()->at(pos).second);
+  }
+  EXPECT_DOUBLE_EQ(102., map.flatValue(1, 2));
+}
+}  // namespace slam_concept_test

--- a/src/axom/slam/tests/slam_concepts.cpp
+++ b/src/axom/slam/tests/slam_concepts.cpp
@@ -251,7 +251,11 @@ struct MissingIndexMap : MinimalBivariateMap
 struct MissingConstAccessMap : MinimalBivariateMap
 {
   using MinimalBivariateMap::flatValue;
-  const double& flatValue(PositionType, PositionType) const = delete;
+
+private:
+  // HIP compilation currently treats a deleted const overload as satisfying the
+  // MapLike requires-expression, so make the const overload inaccessible.
+  const double& flatValue(PositionType, PositionType) const;
 };
 
 struct ExtraAliasesMap : MinimalBivariateMap


### PR DESCRIPTION
# Summary

- This PR adds several concepts for slam's sets, relations and maps
- It adds static assert tests to check that we are modeling the right constraints for our concepts
- This is the first part of several PRs to incorporate concepts into Slam. 
   - See #1979 for the roadmap 
- Future PRs will incorporate these concepts into slam's sets, relations and maps
   - See https://github.com/llnl/axom/tree/feature/kweiss/slam-concepts-all for a prototype of where this is heading